### PR TITLE
fix(server): serialize job-store writes + unique atomic temp names (BET-770)

### DIFF
--- a/src/server/auditJobsConcurrency.test.mjs
+++ b/src/server/auditJobsConcurrency.test.mjs
@@ -1,0 +1,280 @@
+// BET-770 — regression tests for the audit findings P2-1 / P2-2 / P2-3 / P3-1.
+//
+// Each store's read-modify-write is serialized behind a single-writer mutex
+// (createMutex) shared by every writer of that store, and the jsonStore temp
+// name is unique per call. These tests drive genuinely concurrent writers
+// against a REAL temp-file store and assert the guarantees the serialization
+// exists to provide: no lost update, no terminal-job resurrection, no false
+// timeout, no cap overrun, and no temp-name collision.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtemp, rm, readdir } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { writeJsonAtomic, readJsonSync } from "./jsonStore.mjs";
+import * as cap from "./capabilities.mjs";
+import * as del from "./delegate.mjs";
+
+async function tmpDir() {
+  return mkdtemp(join(tmpdir(), "manta-audit-jobs-"));
+}
+
+function runningJob(id, over = {}) {
+  return {
+    id,
+    name: `job${id}`,
+    prompt: "p",
+    model: null,
+    parentSessionID: `parent${id}`,
+    parentDirectory: "/repo",
+    childSessionID: `child${id}`,
+    tmuxSession: "s",
+    windowIndex: 0,
+    worktree: null,
+    branch: null,
+    baseSha: null,
+    status: "running",
+    activity: null,
+    createdAt: 1,
+    startedAt: 1,
+    finishedAt: null,
+    result: null,
+    error: null,
+    filesChanged: null,
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// P3-1: two same-ms, same-path jsonStore writes both land (no ENOENT, no
+// clobber, no temp left behind).
+// ---------------------------------------------------------------------------
+test("two concurrent same-path jsonStore writes both land (no ENOENT, no clobber)", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "store.json");
+  const results = await Promise.all([
+    writeJsonAtomic(path, JSON.stringify({ writer: "a", n: 1 })),
+    writeJsonAtomic(path, JSON.stringify({ writer: "b", n: 2 })),
+  ]);
+  // Neither threw: a colliding temp rename would have surfaced as ENOENT.
+  assert.deepEqual(results, [undefined, undefined]);
+  const final = readJsonSync(path, null);
+  // The final file is the full, valid payload of the last writer — never a
+  // partial/clobbered value.
+  assert.ok(final && typeof final === "object");
+  assert.ok(final.writer === "a" || final.writer === "b");
+  assert.equal(Object.keys(final).length, 2, "payload is intact, not interleaved/corrupt");
+  const entries = await readdir(dir);
+  assert.deepEqual(
+    entries.filter((e) => e.startsWith("store.json.tmp")),
+    [],
+    "no temp file is left behind",
+  );
+  await rm(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// P2-3 (capabilities): two concurrent appendLog writers to the same job — no
+// lost update; both chunks survive.
+// ---------------------------------------------------------------------------
+test("two concurrent appendLog writers to one job: no lost update", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "cap.json");
+  const load = () => cap.loadJobs(path);
+  const save = (jobs) => cap.saveJobs(jobs, path);
+  const made = await cap.createCapJob(
+    { capability: "cap", host: "desktop", sessionID: "s" },
+    { load, save },
+  );
+  await cap.startJob(made.job.id, { load, save });
+  await Promise.all([
+    cap.appendLog(made.job.id, "AA", { load, save }),
+    cap.appendLog(made.job.id, "BB", { load, save }),
+  ]);
+  const job = (await cap.loadJobs(path)).find((j) => j.id === made.job.id);
+  const joined = job.log.join("");
+  assert.ok(joined.includes("AA"), "first concurrent append survives");
+  assert.ok(joined.includes("BB"), "second concurrent append survives");
+  await rm(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// P2-2 (delegate): >MAX_RUNNING_JOBS concurrent delegate starts do not exceed
+// the cap. The read-then-act cap check runs inside the jobs lock, so exactly
+// MAX_RUNNING_JOBS succeed.
+// ---------------------------------------------------------------------------
+test("concurrent delegate starts never exceed MAX_RUNNING_JOBS", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "delegate.json");
+  const load = () => del.loadJobs(path);
+  const save = (jobs) => del.saveJobs(jobs, path);
+  const parentWin = { index: 0, name: "p", opencodeSessionId: "PARENT", paneCurrentPath: "/repo" };
+  const deps = {
+    load,
+    save,
+    publish() {},
+    deliver: async () => ({ delivered: true }),
+    gitAddWorktree: async () => {
+      throw new Error("not a git repository");
+    },
+    listProjects: async () => [{ tmuxSession: "proj", windows: [parentWin] }],
+    newWindow: async (input) => ({
+      sessionId: `child-${input.windowName}`,
+      windowIndex: 1,
+      projects: [{ tmuxSession: "proj", windows: [parentWin] }],
+    }),
+  };
+
+  const N = del.MAX_RUNNING_JOBS + 3;
+  const attempt = (i) =>
+    del.startJob({ prompt: `job ${i}`, parentSessionID: "PARENT", parentDirectory: "/repo" }, deps);
+  const results = await Promise.all(Array.from({ length: N }, (_, i) => attempt(i)));
+
+  const okCount = results.filter((r) => r.ok).length;
+  const running = (await del.loadJobs(path)).filter((j) => j.status === "running").length;
+  const refused = results.filter((r) => !r.ok && r.error === del.CAP_ERROR).length;
+
+  assert.equal(okCount, del.MAX_RUNNING_JOBS, "exactly MAX_RUNNING_JOBS starts succeed");
+  assert.equal(running, del.MAX_RUNNING_JOBS, "never more than MAX_RUNNING_JOBS running");
+  assert.equal(refused, N - del.MAX_RUNNING_JOBS, "the remainder are refused with the cap error");
+  await rm(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// P2-1 (delegate): a completing job racing the timeout sweep is not flipped to
+// "timed out" and is not notified of a false timeout. finishJob holds the lock
+// through its delivery; the sweep queued behind it re-reads the now-done job
+// and must leave it terminal.
+// ---------------------------------------------------------------------------
+test("a completing delegate job racing the timeout sweep is not flipped to timed out", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "delegate.json");
+  const load = () => del.loadJobs(path);
+  const save = (jobs) => del.saveJobs(jobs, path);
+  // startedAt=1 → with the sweep's future `now`, a still-running job would time out.
+  const job = runningJob("j1", { startedAt: 1 });
+  await save([job]);
+
+  const delivered = [];
+  let doneDeliveredResolve;
+  const doneDelivered = new Promise((r) => (doneDeliveredResolve = r));
+
+  const finishDeps = {
+    load,
+    save,
+    publish() {},
+    deliver: async (m) => {
+      delivered.push(m);
+      doneDeliveredResolve();
+      return { delivered: true };
+    },
+    listMessages: async () => [],
+    now: () => 100,
+  };
+  const sweepDeps = {
+    load,
+    save,
+    publish() {},
+    deliver: async (m) => delivered.push(m),
+    now: () => 2_000_000, // far past RUNNING_TIMEOUT_MS for a startedAt=1 running job
+    sessionExists: async () => true,
+    killWindow: async () => {},
+    gitRemoveWorktree: async () => ({ removed: true }),
+  };
+
+  const pFinish = del.finishJob(job, "done", null, finishDeps, new Map());
+  await doneDelivered; // finishJob has persisted "done" and still holds the lock
+  const pSweep = del.sweepDelegateJobs(sweepDeps); // queued behind the lock
+  await Promise.all([pFinish, pSweep]);
+
+  const stored = (await load()).find((j) => j.id === "j1");
+  assert.equal(stored.status, "done", "completed job is not flipped to 'timed out' by the racing sweep");
+  const falseTimeouts = delivered.filter((m) => (m.text || "").includes("timed out"));
+  assert.equal(falseTimeouts.length, 0, "no false timeout is notified for a completed job");
+  await rm(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// P2-3 (capabilities): a completing job racing the timeout sweep is not flipped
+// to "timed out" / not notified of a false timeout.
+// ---------------------------------------------------------------------------
+test("a completing cap job racing the timeout sweep is not flipped to timed out", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "cap.json");
+  const load = () => cap.loadJobs(path);
+  const save = (jobs) => cap.saveJobs(jobs, path);
+  const made = await cap.createCapJob(
+    { capability: "cap", host: "desktop", sessionID: "s" },
+    { load, save },
+  );
+  // Back-date startedAt so a still-running job would time out under the sweep's `now`.
+  await cap.startJob(made.job.id, { load, save, now: () => 1 });
+
+  const notified = [];
+  let doneNotifyResolve;
+  const doneNotified = new Promise((r) => (doneNotifyResolve = r));
+
+  const pDone = cap.completeJob(
+    made.job.id,
+    { status: "done", result: { ok: true } },
+    {
+      load,
+      save,
+      publish() {},
+      notifySession: async (m) => {
+        notified.push(m);
+        doneNotifyResolve();
+      },
+      now: () => 100,
+    },
+  );
+  await doneNotified; // inside markTerminal, still holding the lock, save not yet run
+  const pSweep = cap.sweepCapJobs({
+    load,
+    save,
+    publish() {},
+    notifySession: async (m) => notified.push(m),
+    now: () => 2_000_000,
+  });
+  await Promise.all([pDone, pSweep]);
+
+  const job = (await load()).find((j) => j.id === made.job.id);
+  assert.equal(job.status, "done", "completed job is not flipped to 'timed out' by the racing sweep");
+  const falseTimeouts = notified.filter((m) => String(m).includes("timed out"));
+  assert.equal(falseTimeouts.length, 0, "no false timeout is notified for a completed job");
+  await rm(dir, { recursive: true, force: true });
+});
+
+// ---------------------------------------------------------------------------
+// P2-2 (delegate): a terminal (done) job is not resurrected to running by a
+// stale activity-poller write.
+// ---------------------------------------------------------------------------
+test("a done job is not resurrected to running by a stale activity-poller write", async () => {
+  const dir = await tmpDir();
+  const path = join(dir, "delegate.json");
+  const load = () => del.loadJobs(path);
+  const save = (jobs) => del.saveJobs(jobs, path);
+  const job = runningJob("j1", { activity: "idle" });
+  await save([job]);
+
+  const finishDeps = {
+    load,
+    save,
+    publish() {},
+    deliver: async () => ({ delivered: true }),
+    listMessages: async () => [],
+    now: () => 100,
+  };
+  const pollDeps = { load, save, publish() {}, listMessages: async () => [], now: () => Date.now() };
+
+  await Promise.all([
+    del.finishJob(job, "done", null, finishDeps, new Map()),
+    del.tickActivity(pollDeps),
+  ]);
+
+  const stored = (await load()).find((j) => j.id === "j1");
+  assert.equal(stored.status, "done", "the activity poller cannot resurrect a done job to running");
+  await rm(dir, { recursive: true, force: true });
+});

--- a/src/server/capabilities.mjs
+++ b/src/server/capabilities.mjs
@@ -21,13 +21,23 @@ import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import { statePath } from "../shared/paths.mjs";
 import { normalizeHost } from "../shared/pluginManifest.mjs";
-import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { readJsonSync, writeJsonAtomic, createMutex } from "./jsonStore.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants (single source of truth — see docs/mantaui-plugins.md §Constants)
 // ---------------------------------------------------------------------------
 
 const STORE_PATH = statePath("cap-jobs.json");
+
+// Single-writer serialization for the cap-jobs store (BET-770 P2-1/2-2/2-3).
+// Every read-modify-write mutation of the jobs array runs inside `jobsLock`,
+// shared by ALL writers: createCapJob, startJob, appendLog, completeJob and
+// the sweeper. Without it, completeJob (whose async gap is markTerminal
+// awaiting the session notify) could race sweepCapJobs and flip a completed
+// job to "timed out" (and notify) or a truly timed-out job to done. Each
+// mutation re-reads the store inside the lock, so a writer that lost a race
+// observes the winner's state instead of overwriting it.
+const jobsLock = createMutex();
 
 // Ring-buffer cap on a job's stored log. A runaway xcodebuild cannot fill the
 // disk or blow the AI's context — chunks are dropped oldest-first.
@@ -98,24 +108,27 @@ export async function createCapJob(
   // (`host: "mac"` written before this rename) are normalized on read in
   // listJobs so we don't need a schema migration.
   const normalizedHost = normalizeHost(host);
-  const jobs = await load();
-  const job = {
-    id: genId(),
-    capability,
-    input: input ?? {},
-    host: normalizedHost,
-    sessionID,
-    directory: typeof directory === "string" ? directory : "",
-    status: "queued",
-    createdAt: now(),
-    startedAt: null,
-    finishedAt: null,
-    log: [],
-    result: null,
-    error: null,
-  };
-  jobs.push(job);
-  await save(jobs);
+  const job = await jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const rec = {
+      id: genId(),
+      capability,
+      input: input ?? {},
+      host: normalizedHost,
+      sessionID,
+      directory: typeof directory === "string" ? directory : "",
+      status: "queued",
+      createdAt: now(),
+      startedAt: null,
+      finishedAt: null,
+      log: [],
+      result: null,
+      error: null,
+    };
+    jobs.push(rec);
+    await save(jobs);
+    return rec;
+  });
   publish?.({ kind: "capJob", payload: { id: job.id, capability, input: job.input, host: normalizedHost } });
   return { ok: true, job };
 }
@@ -178,21 +191,23 @@ export async function listJobs(
  * a timed-out job cannot be resurrected by a late log POST.
  */
 export async function appendLog(id, chunk, { load = loadJobs, save = saveJobs } = {}) {
-  const jobs = await load();
-  const idx = jobs.findIndex((j) => j.id === id);
-  if (idx === -1) return { ok: false, error: "not found" };
-  const job = jobs[idx];
-  if (job.status !== "running") {
-    return { ok: false, error: "job not running", status: job.status };
-  }
-  const text = String(chunk ?? "");
-  if (!text) return { ok: true }; // empty chunk is a no-op
-  job.log = [...(job.log ?? []), text];
-  while (job.log.length > 1 && job.log.join("").length > LOG_CAP_BYTES) {
-    job.log.shift();
-  }
-  await save(jobs);
-  return { ok: true };
+  return jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === id);
+    if (idx === -1) return { ok: false, error: "not found" };
+    const job = jobs[idx];
+    if (job.status !== "running") {
+      return { ok: false, error: "job not running", status: job.status };
+    }
+    const text = String(chunk ?? "");
+    if (!text) return { ok: true }; // empty chunk is a no-op
+    job.log = [...(job.log ?? []), text];
+    while (job.log.length > 1 && job.log.join("").length > LOG_CAP_BYTES) {
+      job.log.shift();
+    }
+    await save(jobs);
+    return { ok: true };
+  });
 }
 
 /**
@@ -205,18 +220,20 @@ export async function startJob(
   id,
   { load = loadJobs, save = saveJobs, now = () => Date.now() } = {},
 ) {
-  const jobs = await load();
-  const idx = jobs.findIndex((j) => j.id === id);
-  if (idx === -1) return { ok: false, error: "not found" };
-  const job = jobs[idx];
-  if (job.status !== "queued") {
-    return { ok: false, error: "not queued", status: job.status };
-  }
-  job.status = "running";
-  job.startedAt = now();
-  jobs[idx] = job;
-  await save(jobs);
-  return { ok: true };
+  return jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === id);
+    if (idx === -1) return { ok: false, error: "not found" };
+    const job = jobs[idx];
+    if (job.status !== "queued") {
+      return { ok: false, error: "not queued", status: job.status };
+    }
+    job.status = "running";
+    job.startedAt = now();
+    jobs[idx] = job;
+    await save(jobs);
+    return { ok: true };
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -268,26 +285,33 @@ export async function completeJob(
   if (status !== "done" && status !== "failed") {
     return { ok: false, error: "status must be \"done\" or \"failed\"" };
   }
-  const jobs = await load();
-  const idx = jobs.findIndex((j) => j.id === id);
-  if (idx === -1) return { ok: false, error: "not found" };
-  const job = jobs[idx];
-  if (job.status === "done" || job.status === "failed") {
-    return { ok: true, alreadyTerminal: true };
-  }
-  // Allow completeJob only from `running` or `queued` — guards against a typo
-  // status string making its way in by a non-executor caller.
-  if (job.status !== "running" && job.status !== "queued") {
-    return { ok: false, error: "cannot complete from status", status: job.status };
-  }
-  jobs[idx] = job;
-  await markTerminal(
-    job,
-    { status, result, error, nowMs: now() },
-    { publish, notifySession },
-  );
-  await save(jobs);
-  return { ok: true };
+  // Under the cap-jobs lock: the load → markTerminal → save is atomic, so an
+  // executor "done" POST cannot race the 60s timeout sweep and flip a
+  // completed job to "timed out" (or a timed-out job to done). markTerminal
+  // may await notifySession — that await stays INSIDE the lock so the whole
+  // transition is one unit.
+  return jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === id);
+    if (idx === -1) return { ok: false, error: "not found" };
+    const job = jobs[idx];
+    if (job.status === "done" || job.status === "failed") {
+      return { ok: true, alreadyTerminal: true };
+    }
+    // Allow completeJob only from `running` or `queued` — guards against a typo
+    // status string making its way in by a non-executor caller.
+    if (job.status !== "running" && job.status !== "queued") {
+      return { ok: false, error: "cannot complete from status", status: job.status };
+    }
+    jobs[idx] = job;
+    await markTerminal(
+      job,
+      { status, result, error, nowMs: now() },
+      { publish, notifySession },
+    );
+    await save(jobs);
+    return { ok: true };
+  });
 }
 
 /**
@@ -322,61 +346,67 @@ export async function sweepCapJobs({
   notifySession,
   now = () => Date.now(),
 } = {}) {
+  // Under the cap-jobs lock: one atomic read → transition → retention → save
+  // pass, so a transition (which awaits the session notify inside markTerminal)
+  // cannot interleave with an executor's completeJob and flip a completing job
+  // to "timed out" or a timed-out job to done.
   try {
-    const jobs = await load();
-    if (jobs.length === 0) return;
-    const nowMs = now();
-    const transitioned = [];
+    await jobsLock.runExclusive(async () => {
+      const jobs = await load();
+      if (jobs.length === 0) return;
+      const nowMs = now();
+      const transitioned = [];
 
-    for (const job of jobs) {
-      if (
-        job.status === "running" &&
-        job.startedAt != null &&
-        nowMs - job.startedAt > RUNNING_TIMEOUT_MS
-      ) {
-        job._pendingTerminal = {
-          status: "failed",
-          error: "timed out after 30 minutes (desktop executor lost?)",
-        };
-        transitioned.push(job);
-      } else if (
-        job.status === "queued" &&
-        nowMs - job.createdAt > QUEUED_EXPIRY_MS
-      ) {
-        job._pendingTerminal = {
-          status: "failed",
-          error:
-            "expired: no executor picked this job up within 24h " +
-            "(is the desktop app running with the capability executor enabled?)",
-        };
-        transitioned.push(job);
+      for (const job of jobs) {
+        if (
+          job.status === "running" &&
+          job.startedAt != null &&
+          nowMs - job.startedAt > RUNNING_TIMEOUT_MS
+        ) {
+          job._pendingTerminal = {
+            status: "failed",
+            error: "timed out after 30 minutes (desktop executor lost?)",
+          };
+          transitioned.push(job);
+        } else if (
+          job.status === "queued" &&
+          nowMs - job.createdAt > QUEUED_EXPIRY_MS
+        ) {
+          job._pendingTerminal = {
+            status: "failed",
+            error:
+              "expired: no executor picked this job up within 24h " +
+              "(is the desktop app running with the capability executor enabled?)",
+          };
+          transitioned.push(job);
+        }
       }
-    }
 
-    if (transitioned.length === 0) {
-      // No timeouts/expiries — check retention only, and skip the save when
-      // nothing was pruned.
+      if (transitioned.length === 0) {
+        // No timeouts/expiries — check retention only, and skip the save when
+        // nothing was pruned.
+        const retained = applyRetention(jobs, nowMs);
+        if (retained.length !== jobs.length) {
+          await save(retained);
+        }
+        return;
+      }
+
+      // Apply transitions via the shared markTerminal helper so the notify +
+      // publish + finishedAt-stamp logic stays in one place. markTerminal does
+      // NOT save — we save once below (sweep = one pass, one save).
+      for (const job of transitioned) {
+        const t = job._pendingTerminal;
+        delete job._pendingTerminal;
+        await markTerminal(
+          job,
+          { status: t.status, error: t.error, result: null, nowMs },
+          { publish, notifySession },
+        );
+      }
       const retained = applyRetention(jobs, nowMs);
-      if (retained.length !== jobs.length) {
-        await save(retained);
-      }
-      return;
-    }
-
-    // Apply transitions via the shared markTerminal helper so the notify +
-    // publish + finishedAt-stamp logic stays in one place. markTerminal does
-    // NOT save — we save once below (sweep = one pass, one save).
-    for (const job of transitioned) {
-      const t = job._pendingTerminal;
-      delete job._pendingTerminal;
-      await markTerminal(
-        job,
-        { status: t.status, error: t.error, result: null, nowMs },
-        { publish, notifySession },
-      );
-    }
-    const retained = applyRetention(jobs, nowMs);
-    await save(retained);
+      await save(retained);
+    });
   } catch (e) {
     console.warn("[cap] sweep failed:", e?.message ?? e);
   }

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -27,7 +27,7 @@
 
 import { randomBytes } from "node:crypto";
 import { statePath } from "../shared/paths.mjs";
-import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { readJsonSync, writeJsonAtomic, createMutex } from "./jsonStore.mjs";
 import { slugify } from "../shared/worktree.mjs";
 import {
   parseGitStatus,
@@ -42,9 +42,24 @@ import { extractSubagentInfo } from "../shared/streamInterpretation.mjs";
 
 const STORE_PATH = statePath("delegate-jobs.json");
 
+// Single-writer serialization for the jobs store (BET-770 P2-1/2-2/2-3). Every
+// read-modify-write mutation of the jobs array runs inside `jobsLock`, shared by
+// ALL writers: startJob (+ the MAX_RUNNING_JOBS check), adoptSubagentJob,
+// finishJob, stopJob, deleteJob, the activity poller, and the sweeper. Without
+// this, a stale activity-poller write could resurrect a terminal job to
+// `running`, a just-completed job could be flipped to "timed out", and two
+// near-simultaneous `delegate` POSTs could both pass the cap check. Each
+// mutation re-reads the store inside the lock, so a writer that lost a race
+// observes the winner's state instead of overwriting it.
+const jobsLock = createMutex();
+
 // Max concurrently `running` jobs, counted box-wide. There is no `queued`
 // state — a job either starts immediately or is refused by the cap.
 export const MAX_RUNNING_JOBS = 5;
+// Cap-refusal copy, spelled exactly for the UI/REST consumer and pinned by
+// delegate.test.mjs.
+export const CAP_ERROR =
+  "too many background jobs running (5). Do not retry — either wait for one to finish, or do this work yourself.";
 // `running` jobs older than this → `failed "timed out after 30 minutes"`.
 const RUNNING_TIMEOUT_MS = 30 * 60_000;
 // Terminal jobs are retained this long, OR until 50 records, whichever bites
@@ -365,12 +380,7 @@ async function registerJob(
  *        newWindow/gitAddWorktree/gitRun/oc listMessages/now)
  */
 export async function startJob(input, deps = {}) {
-  const {
-    load = loadJobs,
-    deliver,
-    gitAddWorktree,
-    gitRun,
-  } = deps;
+  const { deliver } = deps;
 
   const prompt = String(input?.prompt ?? "");
   const parentSessionID = input?.parentSessionID;
@@ -379,87 +389,96 @@ export async function startJob(input, deps = {}) {
   if (!parentSessionID) return { ok: false, error: "parentSessionID is required" };
   if (!parentDirectory) return { ok: false, error: "parentDirectory is required" };
 
-  // 1. Refuse if nesting.
-  {
-    const jobs = await load();
-    const nesting = jobs.find(
-      (j) => j.childSessionID === parentSessionID && j.status === "running",
-    );
-    if (nesting) {
-      return { ok: false, error: "a background job cannot start another background job" };
-    }
-  }
+  // The whole creation — nesting + cap checks, worktree, window, record append —
+  // runs inside the jobs-store lock so a concurrent `delegate` POST cannot pass
+  // the (read-then-act) MAX_RUNNING_JOBS check at the same moment as another
+  // and start >5 running jobs, and so the record append cannot interleave with
+  // another writer's read-modify-write. The prompt is delivered AFTER the lock
+  // releases.
+  const reg = await jobsLock.runExclusive(async () => {
+    const { load = loadJobs, gitAddWorktree, gitRun } = deps;
 
-  // 2. Refuse if at cap.
-  {
-    const jobs = await load();
-    const running = jobs.filter((j) => j.status === "running").length;
-    if (running >= MAX_RUNNING_JOBS) {
-      return {
-        ok: false,
-        error:
-          "too many background jobs running (5). Do not retry — either wait for one to finish, or do this work yourself.",
-      };
-    }
-  }
-
-  // 3. Derive the name.
-  const name = deriveName(prompt);
-
-  // 4. Create the worktree. On throw, catch and continue with
-  //    worktree = branch = baseSha = null and cwd = parentDirectory.
-  let worktree = null;
-  let branch = null;
-  let baseSha = null;
-  let cwd = parentDirectory;
-  try {
-    const wt = await gitAddWorktree({ cwd: parentDirectory, name });
-    worktree = wt.path;
-    branch = wt.branch;
-    cwd = wt.path;
-  } catch {
-    worktree = null;
-    branch = null;
-    baseSha = null;
-    cwd = parentDirectory;
-  }
-
-  // 5. Record baseSha — git -C <worktree> rev-parse HEAD, trimmed. Skip when
-  //    there is no worktree.
-  if (worktree) {
-    try {
-      const { stdout } = await gitRun(["-C", worktree, "rev-parse", "HEAD"]);
-      baseSha = String(stdout ?? "").trim() || null;
-    } catch {
-      baseSha = null;
-    }
-  }
-
-  // 6+7. Register the window + record + publish.
-  const reg = await registerJob(
+    // 1. Refuse if nesting.
     {
-      parentSessionID,
-      parentDirectory,
-      name,
-      prompt,
-      model: input?.model,
-      cwd,
-      worktree,
-      branch,
-      baseSha,
-      existingSessionId: undefined,
-      origin: "delegate",
-      permission: input?.permission,
-    },
-    deps,
-  );
+      const jobs = await load();
+      const nesting = jobs.find(
+        (j) => j.childSessionID === parentSessionID && j.status === "running",
+      );
+      if (nesting) {
+        return { ok: false, error: "a background job cannot start another background job" };
+      }
+    }
+
+    // 2. Refuse if at cap. Checked here, inside the lock and BEFORE any
+    //    worktree/window is created, so a burst of concurrent POSTs cannot
+    //    exceed MAX_RUNNING_JOBS without leaking created worktrees.
+    {
+      const jobs = await load();
+      const running = jobs.filter((j) => j.status === "running").length;
+      if (running >= MAX_RUNNING_JOBS) {
+        return { ok: false, error: CAP_ERROR };
+      }
+    }
+
+    // 3. Derive the name.
+    const name = deriveName(prompt);
+
+    // 4. Create the worktree. On throw, catch and continue with
+    //    worktree = branch = baseSha = null and cwd = parentDirectory.
+    let worktree = null;
+    let branch = null;
+    let baseSha = null;
+    let cwd = parentDirectory;
+    try {
+      const wt = await gitAddWorktree({ cwd: parentDirectory, name });
+      worktree = wt.path;
+      branch = wt.branch;
+      cwd = wt.path;
+    } catch {
+      worktree = null;
+      branch = null;
+      baseSha = null;
+      cwd = parentDirectory;
+    }
+
+    // 5. Record baseSha — git -C <worktree> rev-parse HEAD, trimmed. Skip when
+    //    there is no worktree.
+    if (worktree) {
+      try {
+        const { stdout } = await gitRun(["-C", worktree, "rev-parse", "HEAD"]);
+        baseSha = String(stdout ?? "").trim() || null;
+      } catch {
+        baseSha = null;
+      }
+    }
+
+    // 6+7. Register the window + record + publish.
+    return registerJob(
+      {
+        parentSessionID,
+        parentDirectory,
+        name,
+        prompt,
+        model: input?.model,
+        cwd,
+        worktree,
+        branch,
+        baseSha,
+        existingSessionId: undefined,
+        origin: "delegate",
+        permission: input?.permission,
+      },
+      deps,
+    );
+  });
+
   if (!reg.ok) return reg;
 
   // 8. Send the opening prompt via the shared delivery module's deliver.
   try {
     await deliver({
       sessionId: reg.job.childSessionID,
-      text: buildJobPrompt({ prompt, worktree, branch }),
+      text: buildJobPrompt({ prompt, worktree: reg.job.worktree, branch: reg.job.branch }),
     });
   } catch (e) {
     // deliver never rejects in production, but guard anyway — the job is
@@ -496,36 +515,41 @@ export async function adoptSubagentJob(
     return { ok: false, error: "parentSessionID, parentDirectory and childSessionID are required" };
   }
 
-  // Idempotent — the detecting event fires repeatedly as the tool part updates.
-  {
-    const jobs = await load();
-    const exists = jobs.find((j) => j.childSessionID === childSessionID);
-    if (exists) {
-      return { ok: true, alreadyAdopted: true };
-    }
-  }
-
-  // We deliberately do NOT enforce MAX_RUNNING_JOBS and do NOT enforce the
-  // no-nesting rule: opencode has already started this subagent, so refusing
-  // to record it would only make it invisible — the exact bug this fixes.
-  // We also do NOT create a worktree (the session is adopted, not created)
-  // and do NOT call deliver() — opencode already sent the child its prompt.
-  return registerJob(
+  // Under the jobs-store lock: the idempotency read + the record append happen
+  // as one atomic unit, so a repeated adoption event cannot interleave with
+  // another writer.
+  return jobsLock.runExclusive(async () => {
+    // Idempotent — the detecting event fires repeatedly as the tool part updates.
     {
-      parentSessionID,
-      parentDirectory,
-      name,
-      prompt,
-      model,
-      cwd: parentDirectory,
-      worktree: null,
-      branch: null,
-      baseSha: null,
-      existingSessionId: childSessionID,
-      origin: "subagent",
-    },
-    deps,
-  );
+      const jobs = await load();
+      const exists = jobs.find((j) => j.childSessionID === childSessionID);
+      if (exists) {
+        return { ok: true, alreadyAdopted: true };
+      }
+    }
+
+    // We deliberately do NOT enforce MAX_RUNNING_JOBS and do NOT enforce the
+    // no-nesting rule: opencode has already started this subagent, so refusing
+    // to record it would only make it invisible — the exact bug this fixes.
+    // We also do NOT create a worktree (the session is adopted, not created)
+    // and do NOT call deliver() — opencode already sent the child its prompt.
+    return registerJob(
+      {
+        parentSessionID,
+        parentDirectory,
+        name,
+        prompt,
+        model,
+        cwd: parentDirectory,
+        worktree: null,
+        branch: null,
+        baseSha: null,
+        existingSessionId: childSessionID,
+        origin: "subagent",
+      },
+      deps,
+    );
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -722,125 +746,148 @@ export async function finishJob(job, status, error, deps = {}, sawBusy) {
     now = () => Date.now(),
   } = deps;
 
-  // Idempotent: if the job is already terminal, do nothing.
-  if (job.status === "done" || job.status === "failed" || job.status === "stopped") {
-    return { ok: true, alreadyTerminal: true };
-  }
+  return jobsLock.runExclusive(async () => {
+    // Re-read the job under the lock: the `job` passed in may be a stale
+    // snapshot (e.g. a sweeper candidate read before another writer completed,
+    // stopped or pruned it). If the live record is already terminal — or was
+    // pruned — do nothing. This is what stops a completing job being flipped
+    // to "timed out" (and a false timeout being notified) or a truly timed-out
+    // job being resurrected to "done" by a stale writer.
+    {
+      const jobs = await load();
+      const idx = jobs.findIndex((j) => j.id === job.id);
+      if (idx === -1) return { ok: true, alreadyTerminal: true };
+      job = jobs[idx];
+    }
 
-  let result = "";
-  let filesChanged = null;
-  if (status === "done") {
+    // Idempotent: if the job is already terminal, do nothing.
+    if (job.status === "done" || job.status === "failed" || job.status === "stopped") {
+      return { ok: true, alreadyTerminal: true };
+    }
+
+    let result = "";
+    let filesChanged = null;
+    if (status === "done") {
+      try {
+        const messages = listMessages ? await listMessages(job.childSessionID) : [];
+        result = await lastAssistantText(messages);
+      } catch (e) {
+        console.warn("[delegate] listMessages failed:", e?.message ?? e);
+        result = "";
+      }
+      filesChanged = await countFilesChanged(job, deps);
+    }
+
+    const finishedAt = now();
+    const updated = {
+      ...job,
+      status,
+      error: status === "done" ? null : (error ?? null),
+      result: status === "done" ? result : null,
+      filesChanged,
+      finishedAt,
+    };
+
+    // Persist.
+    {
+      const jobs = await load();
+      const idx = jobs.findIndex((j) => j.id === job.id);
+      if (idx !== -1) {
+        jobs[idx] = updated;
+        await save(jobs);
+      }
+    }
+    publish?.({
+      kind: "delegate.updated",
+      payload: { id: updated.id, status: updated.status, activity: updated.activity },
+    });
+    if (sawBusy) sawBusy.delete(job.childSessionID);
+
+    // Deliver the completion message to the parent session (deferred until idle
+    // by the shared delivery engine). Swallow a failure — the job is terminal
+    // regardless.
+    //
+    // BET-721: skip the deliver for adopted subagents — opencode ALREADY injects
+    // the <task ...> result into the parent when the child finishes, so
+    // delivering ours too would report the same job twice. A missing `origin`
+    // (records written before this change) means `delegate` and still delivers.
+    if (deliver && job.parentSessionID && job.origin !== "subagent") {
+      try {
+        await deliver({
+          sessionId: job.parentSessionID,
+          text: buildCompletionText(updated),
+        });
+      } catch (e) {
+        console.warn(`[delegate] completion delivery failed for ${job.id}:`, e?.message ?? e);
+      }
+    }
+
+    // BET-418 §B: remove the tmux window + worktree now that the job is
+    // terminal. A dirty worktree keeps both (cleanupTerminalJob returns
+    // cleanedUp:false); persist that flag so the retention sweep does NOT prune
+    // the record (the window must stay recognisable as a job, not leak as an
+    // ordinary session). A clean cleanup sets cleanedUp:true so retention may
+    // prune the record normally once it ages out.
+    let cleanedUp = false;
     try {
-      const messages = listMessages ? await listMessages(job.childSessionID) : [];
-      result = await lastAssistantText(messages);
+      const res = await cleanupTerminalJob(updated, deps);
+      cleanedUp = !!res.cleanedUp;
     } catch (e) {
-      console.warn("[delegate] listMessages failed:", e?.message ?? e);
-      result = "";
+      console.warn(`[delegate] cleanup failed for ${job.id}:`, e?.message ?? e);
     }
-    filesChanged = await countFilesChanged(job, deps);
-  }
-
-  const finishedAt = now();
-  const updated = {
-    ...job,
-    status,
-    error: status === "done" ? null : (error ?? null),
-    result: status === "done" ? result : null,
-    filesChanged,
-    finishedAt,
-  };
-
-  // Persist.
-  {
-    const jobs = await load();
-    const idx = jobs.findIndex((j) => j.id === job.id);
-    if (idx !== -1) {
-      jobs[idx] = updated;
-      await save(jobs);
+    {
+      const jobs = await load();
+      const idx = jobs.findIndex((j) => j.id === job.id);
+      if (idx !== -1) {
+        jobs[idx] = { ...jobs[idx], cleanedUp };
+        await save(jobs);
+      }
     }
-  }
-  publish?.({
-    kind: "delegate.updated",
-    payload: { id: updated.id, status: updated.status, activity: updated.activity },
+    return { ok: true };
   });
-  if (sawBusy) sawBusy.delete(job.childSessionID);
-
-  // Deliver the completion message to the parent session (deferred until idle
-  // by the shared delivery engine). Swallow a failure — the job is terminal
-  // regardless.
-  //
-  // BET-721: skip the deliver for adopted subagents — opencode ALREADY injects
-  // the <task ...> result into the parent when the child finishes, so
-  // delivering ours too would report the same job twice. A missing `origin`
-  // (records written before this change) means `delegate` and still delivers.
-  if (deliver && job.parentSessionID && job.origin !== "subagent") {
-    try {
-      await deliver({
-        sessionId: job.parentSessionID,
-        text: buildCompletionText(updated),
-      });
-    } catch (e) {
-      console.warn(`[delegate] completion delivery failed for ${job.id}:`, e?.message ?? e);
-    }
-  }
-
-  // BET-418 §B: remove the tmux window + worktree now that the job is
-  // terminal. A dirty worktree keeps both (cleanupTerminalJob returns
-  // cleanedUp:false); persist that flag so the retention sweep does NOT prune
-  // the record (the window must stay recognisable as a job, not leak as an
-  // ordinary session). A clean cleanup sets cleanedUp:true so retention may
-  // prune the record normally once it ages out.
-  let cleanedUp = false;
-  try {
-    const res = await cleanupTerminalJob(updated, deps);
-    cleanedUp = !!res.cleanedUp;
-  } catch (e) {
-    console.warn(`[delegate] cleanup failed for ${job.id}:`, e?.message ?? e);
-  }
-  {
-    const jobs = await load();
-    const idx = jobs.findIndex((j) => j.id === job.id);
-    if (idx !== -1) {
-      jobs[idx] = { ...jobs[idx], cleanedUp };
-      await save(jobs);
-    }
-  }
-  return { ok: true };
 }
 
 // ---------------------------------------------------------------------------
 // Activity summaries — a 10s poller updates `activity` for running jobs only.
 // Reuses summarizeTranscript(messages) then describeChatActivity(summary),
 // both from peers.mjs. No model call. No Groq. No new config.
+//
+// `tickActivity` is exported for unit tests; the poller wrapper
+// (startActivityPoller) retains the inFlight re-entrancy guard + timer.unref.
 // ---------------------------------------------------------------------------
 
-async function tickActivity(deps) {
+export async function tickActivity(deps) {
   const { load = loadJobs, save = saveJobs, publish, listMessages, now = () => Date.now() } = deps;
-  const jobs = await load();
-  let changed = false;
-  await Promise.all(
-    jobs.map(async (job) => {
-      if (job.status !== "running") return;
-      let activity = null;
-      try {
-        const messages = listMessages ? await listMessages(job.childSessionID) : [];
-        activity = describeChatActivity(summarizeTranscript(messages));
-      } catch (e) {
-        console.warn(`[delegate] activity poll failed for ${job.id}:`, e?.message ?? e);
-        return;
-      }
-      if (activity !== job.activity) {
-        job.activity = activity;
-        changed = true;
-        publish?.({
-          kind: "delegate.updated",
-          payload: { id: job.id, status: job.status, activity },
-        });
-      }
-    }),
-  );
-  if (changed) await save(jobs);
-  void now;
+  // Under the jobs-store lock: the read-compare-write of `activity` is atomic,
+  // so a stale poller write can never overwrite a terminal transition a
+  // concurrent writer just persisted, or resurrect a completed job to running.
+  return jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    let changed = false;
+    await Promise.all(
+      jobs.map(async (job) => {
+        if (job.status !== "running") return;
+        let activity = null;
+        try {
+          const messages = listMessages ? await listMessages(job.childSessionID) : [];
+          activity = describeChatActivity(summarizeTranscript(messages));
+        } catch (e) {
+          console.warn(`[delegate] activity poll failed for ${job.id}:`, e?.message ?? e);
+          return;
+        }
+        if (activity !== job.activity) {
+          job.activity = activity;
+          changed = true;
+          publish?.({
+            kind: "delegate.updated",
+            payload: { id: job.id, status: job.status, activity },
+          });
+        }
+      }),
+    );
+    if (changed) await save(jobs);
+    void now;
+  });
 }
 
 export function startActivityPoller(deps = {}, { intervalMs = ACTIVITY_INTERVAL_MS } = {}) {
@@ -914,8 +961,7 @@ export async function sweepDelegateJobs(deps = {}) {
     }
 
     if (transitioned.length === 0 && orphaned.length === 0) {
-      const retained = applyRetention(jobs, nowMs);
-      if (retained.length !== jobs.length) await save(retained);
+      await persistRetention({ load, save }, nowMs);
       return;
     }
 
@@ -932,11 +978,22 @@ export async function sweepDelegateJobs(deps = {}) {
     for (const job of transitioned) {
       await finishJob(job, "failed", "timed out after 30 minutes", deps, new Map());
     }
-    const retained = applyRetention(await load(), nowMs);
-    await save(retained);
+    await persistRetention({ load, save }, nowMs);
   } catch (e) {
     console.warn("[delegate] sweep failed:", e?.message ?? e);
   }
+}
+
+// Retention prune under the jobs-store lock: re-read the store fresh so the
+// prune cannot clobber a write a concurrent writer persisted while this sweep
+// was inspecting a stale snapshot.
+async function persistRetention({ load, save }, nowMs) {
+  await jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    if (jobs.length === 0) return;
+    const retained = applyRetention(jobs, nowMs);
+    if (retained.length !== jobs.length) await save(retained);
+  });
 }
 
 function applyRetention(jobs, nowMs) {
@@ -1013,63 +1070,67 @@ export async function stopJob(id, deps = {}) {
     listMessages,
     now = () => Date.now(),
   } = deps;
-  const jobs = await load();
-  const idx = jobs.findIndex((j) => j.id === id);
-  if (idx === -1) return { ok: false, error: "not found" };
-  const job = jobs[idx];
-  if (job.status !== "running") {
-    return { ok: false, error: "job not running", status: job.status };
-  }
-  if (abortSession && job.childSessionID) {
-    try {
-      await abortSession(job.childSessionID);
-    } catch (e) {
-      console.warn(`[delegate] abortSession failed for ${id}:`, e?.message ?? e);
+  // Under the jobs-store lock: the read-check-mutate + the cleanedUp stamp are
+  // atomic, so a stop cannot race another writer into a half-state.
+  return jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === id);
+    if (idx === -1) return { ok: false, error: "not found" };
+    const job = jobs[idx];
+    if (job.status !== "running") {
+      return { ok: false, error: "job not running", status: job.status };
     }
-  }
-  const finishedAt = now();
-  const updated = {
-    ...job,
-    status: "stopped",
-    error: "stopped by user",
-    finishedAt,
-  };
-  jobs[idx] = updated;
-  await save(jobs);
-  publish?.({
-    kind: "delegate.updated",
-    payload: { id: updated.id, status: updated.status, activity: updated.activity },
+    if (abortSession && job.childSessionID) {
+      try {
+        await abortSession(job.childSessionID);
+      } catch (e) {
+        console.warn(`[delegate] abortSession failed for ${id}:`, e?.message ?? e);
+      }
+    }
+    const finishedAt = now();
+    const updated = {
+      ...job,
+      status: "stopped",
+      error: "stopped by user",
+      finishedAt,
+    };
+    jobs[idx] = updated;
+    await save(jobs);
+    publish?.({
+      kind: "delegate.updated",
+      payload: { id: updated.id, status: updated.status, activity: updated.activity },
+    });
+    if (deliver && job.parentSessionID) {
+      try {
+        await deliver({
+          sessionId: job.parentSessionID,
+          text: buildCompletionText(updated),
+        });
+      } catch (e) {
+        console.warn(`[delegate] stop completion delivery failed for ${id}:`, e?.message ?? e);
+      }
+    }
+    // BET-418 §B: a stopped job is terminal → remove the window + worktree (a
+    // dirty worktree keeps both). Persist cleanedUp so retention treats it
+    // correctly.
+    let cleanedUp = false;
+    try {
+      const res = await cleanupTerminalJob(updated, deps);
+      cleanedUp = !!res.cleanedUp;
+    } catch (e) {
+      console.warn(`[delegate] stop cleanup failed for ${id}:`, e?.message ?? e);
+    }
+    {
+      const jobs2 = await load();
+      const idx2 = jobs2.findIndex((j) => j.id === id);
+      if (idx2 !== -1) {
+        jobs2[idx2] = { ...jobs2[idx2], cleanedUp };
+        await save(jobs2);
+      }
+    }
+    void listMessages;
+    return { ok: true };
   });
-  if (deliver && job.parentSessionID) {
-    try {
-      await deliver({
-        sessionId: job.parentSessionID,
-        text: buildCompletionText(updated),
-      });
-    } catch (e) {
-      console.warn(`[delegate] stop completion delivery failed for ${id}:`, e?.message ?? e);
-    }
-  }
-  // BET-418 §B: a stopped job is terminal → remove the window + worktree (a
-  // dirty worktree keeps both). Persist cleanedUp so retention treats it
-  // correctly.
-  let cleanedUp = false;
-  try {
-    const res = await cleanupTerminalJob(updated, deps);
-    cleanedUp = !!res.cleanedUp;
-  } catch (e) {
-    console.warn(`[delegate] stop cleanup failed for ${id}:`, e?.message ?? e);
-  }
-  {
-    const jobs2 = await load();
-    const idx2 = jobs2.findIndex((j) => j.id === id);
-    if (idx2 !== -1) {
-      jobs2[idx2] = { ...jobs2[idx2], cleanedUp };
-      await save(jobs2);
-    }
-  }
-  void listMessages;
-  return { ok: true };
 }
 
 /**
@@ -1087,40 +1148,44 @@ export async function deleteJob(id, deps = {}) {
     killWindow,
     gitRemoveWorktree,
   } = deps;
-  const jobs = await load();
-  const idx = jobs.findIndex((j) => j.id === id);
-  if (idx === -1) return { ok: false, error: "not found" };
-  const job = jobs[idx];
+  // Under the jobs-store lock: the load → remove-record save is atomic.
+  const result = await jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === id);
+    if (idx === -1) return { ok: false, error: "not found" };
+    const job = jobs[idx];
 
-  // 1. Remove the tmux window (best-effort).
-  if (killWindow && job.tmuxSession != null && job.windowIndex != null) {
-    try {
-      await killWindow({ sessionName: job.tmuxSession, windowIndex: job.windowIndex });
-    } catch (e) {
-      console.warn(`[delegate] killWindow failed for ${id}:`, e?.message ?? e);
-    }
-  }
-
-  // 2. Remove the worktree (force: false, NEVER force: true).
-  if (gitRemoveWorktree && job.worktree) {
-    try {
-      const res = await gitRemoveWorktree({ path: job.worktree, force: false });
-      if (res && res.removed === false && res.reason === "dirty") {
-        // Keep the worktree AND keep the job record; report `dirty`.
-        return { ok: false, error: "dirty", reason: "dirty" };
+    // 1. Remove the tmux window (best-effort).
+    if (killWindow && job.tmuxSession != null && job.windowIndex != null) {
+      try {
+        await killWindow({ sessionName: job.tmuxSession, windowIndex: job.windowIndex });
+      } catch (e) {
+        console.warn(`[delegate] killWindow failed for ${id}:`, e?.message ?? e);
       }
-    } catch (e) {
-      console.warn(`[delegate] gitRemoveWorktree failed for ${id}:`, e?.message ?? e);
-      // A failed remove leaves the worktree on disk; still drop the record so
-      // the UI isn't stuck, but surface the error.
     }
-  }
 
-  // 3. Remove the record.
-  const next = jobs.filter((j) => j.id !== id);
-  await save(next);
-  publish?.({ kind: "delegate.updated", payload: { id, status: "deleted" } });
-  return { ok: true };
+    // 2. Remove the worktree (force: false, NEVER force: true).
+    if (gitRemoveWorktree && job.worktree) {
+      try {
+        const res = await gitRemoveWorktree({ path: job.worktree, force: false });
+        if (res && res.removed === false && res.reason === "dirty") {
+          // Keep the worktree AND keep the job record; report `dirty`.
+          return { ok: false, error: "dirty", reason: "dirty" };
+        }
+      } catch (e) {
+        console.warn(`[delegate] gitRemoveWorktree failed for ${id}:`, e?.message ?? e);
+        // A failed remove leaves the worktree on disk; still drop the record so
+        // the UI isn't stuck, but surface the error.
+      }
+    }
+
+    // 3. Remove the record.
+    const next = jobs.filter((j) => j.id !== id);
+    await save(next);
+    publish?.({ kind: "delegate.updated", payload: { id, status: "deleted" } });
+    return { ok: true };
+  });
+  return result;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/jsonStore.mjs
+++ b/src/server/jsonStore.mjs
@@ -19,7 +19,33 @@ import { readFileSync, existsSync } from "node:fs";
 import { writeFile, rename, chmod, mkdir } from "node:fs/promises";
 import { dirname } from "node:path";
 
-// Read and parse `path` as JSON. Returns `fallback` when the file is missing,
+// A FIFO single-writer mutex (a promise tail). `runExclusive(fn)` guarantees
+// that `fn` never overlaps another `fn` on the same mutex, in call order. Stores
+// on the box use it to make their whole read-modify-write atomic — the shared
+// primitive behind the per-store writer serialization (BET-770).
+export function createMutex() {
+  let tail = Promise.resolve();
+  return {
+    runExclusive(fn) {
+      const run = tail.then(() => fn());
+      tail = run.then(
+        () => {},
+        () => {},
+      );
+      return run;
+    },
+  };
+}
+
+// A globally-unique suffix for temp files. pid + timestamp make it unique
+// across processes and across writes a millisecond apart; the monotonic counter
+// makes it unique even for two same-process, same-millisecond writes to one
+// path, which the old `pid-Date.now()` suffix could not guarantee (BET-770
+// P3-1). The counter is only touched inside the per-path mutex below, so it
+// never races.
+let tmpSeq = 0;
+
+// Reads and parses `path` as JSON. Returns `fallback` when the file is missing,
 // unreadable, or contains invalid JSON. Never throws.
 export function readJsonSync(path, fallback) {
   try {
@@ -30,20 +56,39 @@ export function readJsonSync(path, fallback) {
   }
 }
 
-// Write `data` (already-serialized bytes) to `path` atomically: write a temp
-// file alongside, then rename. The temp filename encodes pid + timestamp so a
-// crash mid-write can never clobber a sibling in-flight temp, and a stale temp
-// from a previous crash never overwrites a live `path`. When `mode` is supplied
-// it is applied to the temp file (and re-asserted via chmod, since writeFile's
-// mode is only honoured on create) so the renamed final file carries it.
-export async function writeJsonAtomic(path, data, { mode } = {}) {
-  await mkdir(dirname(path), { recursive: true });
-  const tmp = `${path}.tmp-${process.pid}-${Date.now()}`;
-  if (mode !== undefined) {
-    await writeFile(tmp, data, { mode });
-    await chmod(tmp, mode).catch(() => {});
-  } else {
-    await writeFile(tmp, data);
+// Per-path writer queues. Concurrent writes to the SAME path are serialized so
+// the temp-file-then-rename dance can never interleave (two writers to one path
+// cannot race on `rename`, and a reader can never observe a half-written final
+// file). Different paths run in parallel.
+const pathLocks = new Map();
+function lockForPath(path) {
+  let lock = pathLocks.get(path);
+  if (!lock) {
+    lock = createMutex();
+    pathLocks.set(path, lock);
   }
-  await rename(tmp, path);
+  return lock;
+}
+
+// Write `data` (already-serialized bytes) to `path` atomically: write a temp
+// file alongside, then rename. The temp filename encodes pid + timestamp + a
+// monotonic counter and is generated under the path's writer lock, so two
+// same-process, same-millisecond writes to one path can never collide — the
+// old `pid-Date.now()` suffix could, and a colliding `rename` would throw
+// ENOENT into a poller or clobber the final file. A stale temp from a previous
+// crash never overwrites a live `path`. When `mode` is supplied it is applied
+// to the temp file (and re-asserted via chmod, since writeFile's mode is only
+// honoured on create) so the renamed final file carries it.
+export async function writeJsonAtomic(path, data, { mode } = {}) {
+  await lockForPath(path).runExclusive(async () => {
+    await mkdir(dirname(path), { recursive: true });
+    const tmp = `${path}.tmp-${process.pid}-${Date.now()}-${(tmpSeq++).toString(36)}`;
+    if (mode !== undefined) {
+      await writeFile(tmp, data, { mode });
+      await chmod(tmp, mode).catch(() => {});
+    } else {
+      await writeFile(tmp, data);
+    }
+    await rename(tmp, path);
+  });
 }


### PR DESCRIPTION
## Summary

Follow-up to BET-767 (deep `src/server/*.mjs` audit, reviewed PASS). Fixes the systemic finding that the engine job stores were each mutated by multiple async writers with no per-store write serialization, and that the shared atomic-write primitive could collide on its temp name.

### Root cause -> fix

- **`src/server/jsonStore.mjs`** — P3-1: temp name was `pid-Date.now()`, so two same-process, same-millisecond writes to one path collided (one `rename` throws ENOENT into a poller, or the final file is clobbered). Now a monotonic per-process counter is appended (`pid-ts-counter`), generated inside a new per-path writer mutex, so concurrent same-path writes can never collide. Also exports `createMutex` — the shared single-writer primitive used by the stores below — and serializes writers to the same path.
- **`src/server/delegate.mjs`** — P2-1/2-2/2-3: all writers now run their read-modify-write under one module-level `jobsLock`, and each re-reads the store inside the lock: `startJob` (nesting + `MAX_RUNNING_JOBS` cap check and the record append), `adoptSubagentJob`, `finishJob`, `stopJob`, `deleteJob`, `tickActivity`, and the sweeper's retention. `startJob` now checks the cap *inside* the lock, before the worktree/window is created, so a burst of concurrent `delegate` POSTs can never exceed `MAX_RUNNING_JOBS` (previously the read-then-act cap passed twice). `finishJob` re-reads the job under the lock and bails if already terminal, so a stale writer can't flip a completed job to "timed out" (and notify a false timeout) nor resurrect a terminal job to `running`.
- **`src/server/capabilities.mjs`** — P2-3: `createCapJob`, `startJob` (claim), `appendLog`, `completeJob`, and `sweepCapJobs` all run under one module-level `jobsLock`. `completeJob` holds the lock across `markTerminal` (including its async session-notify gap), so an executor "done" POST can no longer race the 60s timeout sweep into flipping a completed job to "timed out" or vice versa.
- The pollers' inFlight re-entrancy guards + `timer.unref()` are preserved unchanged (`startActivityPoller`, `startSweeper`, `startCapSweeper`); only `tickActivity` is now exported (additively) so the resurrection test can drive the real poller body.
- Anti-spaghetti: `createMutex` + the per-path lock live once in `jsonStore.mjs` (the existing single source for the atomic write) and are shared — no per-store copies.

### Tests added (`src/server/auditJobsConcurrency.test.mjs`, node:test)

- Two concurrent same-path jsonStore writes both land — no ENOENT, no clobber, no temp left.
- Two concurrent `appendLog` writers to one job — no lost update.
- >`MAX_RUNNING_JOBS` concurrent `delegate` starts never exceed the cap (exactly 5 succeed).
- A completing (delegate + cap) job racing the timeout sweep is not flipped to "timed out" / not notified of a false timeout.
- A done job is not resurrected to `running` by a stale activity-poller write.

Verified these tests fail when the lock is disabled (e.g. the lost-update test fails on the unlocked path), so they are non-vacuous.

### Out of scope (tracked separately per the issue)

- `ensureAuth`/`revoke` race and the promptDelivery bounded-queue item — their own follow-ups.

**Files changed:** `4`. `src/server/jsonStore.mjs`, `src/server/delegate.mjs`, `src/server/capabilities.mjs`, `src/server/auditJobsConcurrency.test.mjs`.

**Base: `origin/main` @ `3f41ae8`**

## Verification results

- PR branch (`multica/BET-770-serialize-job-store-writes` @ `f7a00d3`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0. vitest `2364 pass / 7 skip`; node `1637 pass / 0 fail / 0 skip` (1631 pre-existing + 6 new). Failures: none. log sha256: `20906a8dcc82f245fc6b2f216714ac4aa6650a34c6d50751429c9669fd979805`
- Base (`main` @ `3f41ae8`): not re-run locally (base is freshly synced `origin/main`; the PR's 6 added tests are purely additive and the delta to `main` is only the 3 fixed modules + 1 new test file).
- **Conclusion:** 0 new failures. All 1631 pre-existing tests pass unchanged on the PR branch; the 6 new tests target the exact audit scenarios and pass.

Logs cached at `/tmp/tc.log`, `/tmp/test.log`.
