### PR TITLE
ConfirmModal: widen body to ReactNode + confirmTone; migrate confirm shells (BET-754)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -25,8 +25,7 @@ import type { SyncPayload } from "../shared/api";
 import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, pruneVisitedSessions, registerMountedTerminal, shouldResyncWindowsForJobs, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
-import { Modal } from "./Modal";
-import { Button } from "./Button";
+import { ConfirmModal } from "./ConfirmModal";
 import { Callout } from "./Callout";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
@@ -1721,72 +1720,45 @@ function AppInner() {
       {/* Box self-update confirm: restarting opencode ends every in-flight
           agent turn, so the destructive restart needs explicit consent before
           the update starts. */}
-      <Modal
-          open={confirmServerUpdate}
-          size="md"
-          label="Update the box?"
-          onDismiss={() => setConfirmServerUpdate(false)}
-        >
-          <div className="space-y-4">
-            <h3 className="text-title font-semibold">Update the box?</h3>
-            <div className="text-body text-text-faint">
-              This restarts opencode, which will end every agent turn currently
-              running in any session. Any unsaved work in a running turn is lost.
-            </div>
-            <div className="flex justify-end gap-2">
-              <Button
-                tone="ghost"
-                onClick={() => setConfirmServerUpdate(false)}
-              >
-                Cancel
-              </Button>
-              <Button
-                tone="primary"
-                onClick={() => {
-                  setConfirmServerUpdate(false);
-                  void applyServerUpdate();
-                }}
-              >
-                Update &amp; restart
-              </Button>
-            </div>
-          </div>
-        </Modal>
+      <ConfirmModal
+        open={confirmServerUpdate}
+        title="Update the box?"
+        body="This restarts opencode, which will end every agent turn currently running in any session. Any unsaved work in a running turn is lost."
+        confirmLabel="Update & restart"
+        confirmTone="primary"
+        onConfirm={() => {
+          setConfirmServerUpdate(false);
+          void applyServerUpdate();
+        }}
+        onCancel={() => setConfirmServerUpdate(false)}
+      />
 
       {/* Keep going at reset — BET-739 usage escalation confirm. Rendered at
           App level (like the toasts) so it works over any pane. */}
       {keepGoing && (
-        <Modal
+        <ConfirmModal
           open
-          size="sm"
-          label="Send an automatic message at reset?"
-          onDismiss={() => setKeepGoing(null)}
-        >
-          <div className="space-y-4">
-            <h3 className="text-title font-semibold">Send an automatic message at reset?</h3>
-            <div className="text-body text-text-faint">
+          title="Send an automatic message at reset?"
+          confirmLabel="Schedule it"
+          confirmTone="primary"
+          body={
+            <>
               At {formatResetClock(keepGoing.fireAt, true)} MantaUI will send “Keep going” to this
               session on your behalf and the agent will resume unattended. You can cancel it any
               time from ⏰ scheduled tasks.
-            </div>
-            {shouldWarnStaleCache(keepGoing.fireAt, Date.now(), cacheTtl) && (
-              <Callout tone="warn">
-                The reset is {describeResetDistance(keepGoing.fireAt - Date.now())} away — well past
-                your {cacheTtl === "5m" ? "5 minute" : "1 hour"} prompt-cache window. The whole
-                conversation will be re-sent and re-billed as fresh input, which costs significantly
-                more than a reply now.
-              </Callout>
-            )}
-            <div className="flex justify-end gap-2">
-              <Button tone="ghost" onClick={() => setKeepGoing(null)}>
-                Cancel
-              </Button>
-              <Button tone="primary" onClick={() => void confirmKeepGoing()}>
-                Schedule it
-              </Button>
-            </div>
-          </div>
-        </Modal>
+              {shouldWarnStaleCache(keepGoing.fireAt, Date.now(), cacheTtl) && (
+                <Callout tone="warn">
+                  The reset is {describeResetDistance(keepGoing.fireAt - Date.now())} away — well past
+                  your {cacheTtl === "5m" ? "5 minute" : "1 hour"} prompt-cache window. The whole
+                  conversation will be re-sent and re-billed as fresh input, which costs significantly
+                  more than a reply now.
+                </Callout>
+              )}
+            </>
+          }
+          onConfirm={() => void confirmKeepGoing()}
+          onCancel={() => setKeepGoing(null)}
+        />
       )}
     </div>
   );

--- a/src/renderer/ConfirmModal.tsx
+++ b/src/renderer/ConfirmModal.tsx
@@ -7,6 +7,7 @@
 // (App.tsx's "Update the box?", Settings.tsx's "Remove box?" / "Reset all
 // settings?") rather than inventing a new type scale.
 
+import type { ReactNode } from "react";
 import { Modal } from "./Modal";
 import { Button } from "./Button";
 
@@ -15,13 +16,15 @@ export function ConfirmModal({
   title,
   body,
   confirmLabel,
+  confirmTone = "danger",
   onConfirm,
   onCancel,
 }: {
   open: boolean;
   title: string;
-  body: string;
+  body: ReactNode;
   confirmLabel: string;
+  confirmTone?: "danger" | "primary";
   onConfirm: () => void;
   onCancel: () => void;
 }) {
@@ -34,7 +37,7 @@ export function ConfirmModal({
           <Button tone="default" onClick={onCancel}>
             Cancel
           </Button>
-          <Button tone="danger" onClick={onConfirm}>
+          <Button tone={confirmTone} onClick={onConfirm}>
             {confirmLabel}
           </Button>
         </div>

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -12,7 +12,7 @@ import {
   Mic,
 } from "lucide-react";
 import { useStore } from "./store";
-import { Modal } from "./Modal";
+import { ConfirmModal } from "./ConfirmModal";
 import { useFocusTrap } from "./useFocusTrap";
 import { Checkbox } from "./Checkbox";
 import { Toggle } from "./Toggle";
@@ -937,28 +937,24 @@ export function Settings({
       </div>
 
       {/* In-app confirm: Remove box (replaces window.confirm — BET-419 §D). */}
-      <Modal open={confirmRemove} size="md" label="Remove this box?" onDismiss={() => setConfirmRemove(false)}>
-          <div className="space-y-4">
-            <h3 className="text-title font-semibold">Remove this box?</h3>
-            <div className="text-body text-text-faint">The desktop will forget its pairing and saved projects. If the box is reachable, its current token is also revoked. If the box is offline, the local credentials are cleared and the box's token will be rotated the next time it starts.</div>
-            <div className="flex justify-end gap-2">
-              <Button onClick={() => setConfirmRemove(false)} tone="ghost">Cancel</Button>
-              <Button onClick={removeBox} tone="danger">Remove</Button>
-            </div>
-          </div>
-        </Modal>
+      <ConfirmModal
+        open={confirmRemove}
+        title="Remove this box?"
+        body="The desktop will forget its pairing and saved projects. If the box is reachable, its current token is also revoked. If the box is offline, the local credentials are cleared and the box's token will be rotated the next time it starts."
+        confirmLabel="Remove"
+        onConfirm={() => void removeBox()}
+        onCancel={() => setConfirmRemove(false)}
+      />
 
       {/* In-app confirm: Reset all settings (BET-419 §B.3). */}
-      <Modal open={confirmReset} size="md" label="Reset all settings?" onDismiss={() => setConfirmReset(false)}>
-          <div className="space-y-4">
-            <h3 className="text-title font-semibold">Reset all settings?</h3>
-            <div className="text-body text-text-faint">Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after.</div>
-            <div className="flex justify-end gap-2">
-              <Button onClick={() => setConfirmReset(false)} tone="ghost">Cancel</Button>
-              <Button onClick={resetAll} tone="danger">Reset</Button>
-            </div>
-          </div>
-        </Modal>
+      <ConfirmModal
+        open={confirmReset}
+        title="Reset all settings?"
+        body="Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after."
+        confirmLabel="Reset"
+        onConfirm={() => void resetAll()}
+        onCancel={() => setConfirmReset(false)}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## BET-754 — ConfirmModal: widen body to ReactNode + optional confirmTone; delete hand-rolled confirm shells

### What changed

Widened the shared `ConfirmModal` primitive by exactly two things and migrated every hand-rolled confirm shell onto it, so only one confirm implementation remains:

1. **`ConfirmModal.tsx`** — `body: string` → `body: ReactNode`; added one optional prop `confirmTone?: "danger" | "primary"` (default `"danger"`), threaded to the confirm `Button`. Nothing else in the file changed (same `Modal size="sm"`, same Cancel button, same Cancel-then-Confirm order).

2. **`Settings.tsx`** — replaced the hand-rolled "Remove this box?" and "Reset all settings?" `Modal` blocks with `<ConfirmModal …>`. Both destructive → default danger tone, no `confirmTone` passed. Title, body copy, confirm labels ("Remove" / "Reset"), cancel affordance, and the `confirmRemove`/`confirmReset` state flags preserved verbatim.

3. **`App.tsx`** —
   - "Keep going at reset" → `<ConfirmModal confirmTone="primary" …>` with the existing `Callout tone="warn"` passed as part of the `body` fragment. (the non-destructive confirm).
   - **"Update the box?"** → also migrated to `<ConfirmModal confirmTone="primary">`. This one is **not** among the three shells enumerated in the issue body, but the acceptance criterion is unconditional: *"No `<Modal` in `Settings.tsx` or `App.tsx` is being used to build a confirm dialog any more."* "Update the box?" is a confirm dialog built with `<Modal>` in `App.tsx`, so leaving it would defeat the ticket's whole point (only one confirm implementation afterwards). It takes `confirmTone="primary"`, matching its existing `tone="primary"` confirm button. This is the only deviation from the literal three-shell list, and it is required by the stated acceptance criteria.

### Rendered content — unchanged per confirm

For each migrated confirm, the rendered title text, body copy, and button labels are byte-identical to before (the diff shows 54 insertions / 83 deletions — net −29 in `src/renderer`):

- **Remove this box?** — title "Remove this box?", body copy identical, buttons Cancel / **Remove**.
- **Reset all settings?** — title "Reset all settings?", body copy identical, buttons Cancel / **Reset**.
- **Keep going at reset** — title "Send an automatic message at reset?", body copy identical, warn Callout preserved, buttons Cancel / **Schedule it**.
- **Update the box?** — title "Update the box?", body copy identical, buttons Cancel / **Update & restart**.

### What must NOT change — preserved

- No visual redesign beyond the primitive's own look; Escape/backdrop still mean Cancel (Modal's `onDismiss` = Cancel) for every migrated dialog.
- `Modal.tsx`, `Button.tsx`, `Callout.tsx` untouched.
- No new confirm added, no confirm removed — four shells became four `ConfirmModal`s.
- `ConfirmModal.test.tsx` unchanged and passing.

### Files changed

- `src/renderer/ConfirmModal.tsx`
- `src/renderer/Settings.tsx`
- `src/renderer/App.tsx`

**Base: origin/main @ `445e111b`**

**Verification results:**
- PR branch (`multica/BET-754-confirmmodal-migrate` @ `f7a36acb`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1631 pass / 0 fail / 0 skip. Failures: none. log sha256: `8fa41497786cbf272e4f9c8fd46f4360962d76b9bd9066e3886537aeded28392`
- Base (`origin/main` @ `445e111b`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 0 fail. Failures: none. log sha256: `c980b06a39e8e8e03b5060811f7f514b642b25a64eea6201460e4aac95544bfa`
- **Conclusion:** 0 new failures; PR branch and base are both green.
