### PR TITLE
fix(renderer): open demo on the transcript-bearing session (BET-663)

### DIFF
--- a/scripts/visual/screens.mjs
+++ b/scripts/visual/screens.mjs
@@ -108,8 +108,8 @@ export const SCREENS = [
     id: "session",
     title: "Session view — rail, header, transcript, ask card, composer",
     // The product's main screen, and the one the marketing hero shows. The
-    // fixture's `Deploy new billing service` session is the state the mockup
-    // is drawn against: a permission card open, a tool call above it.
+    // fixture's transcript-bearing session is the state the mockup is drawn
+    // against: a permission card open, a tool call above it.
     url: "/app/index.html?demo&desktop",
     // The shell root exists from first paint, and it is also the structure
     // contract — the mockup covers rail + header + transcript + composer.
@@ -117,9 +117,6 @@ export const SCREENS = [
     // The permission card's heading proves the transcript rendered AND the
     // blocking ask is on screen — the state the design is specified for.
     final: "text=Run a shell command?",
-    actions: async (page) => {
-      await page.locator('.truncate:has-text("Deploy new billing service")').first().click();
-    },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/session/mockup.html",
     surfacesClosed: [
@@ -232,13 +229,10 @@ export const SCREENS = [
     title: "Session view — mid-stream transcript, early/mid/late phases",
     url: "/app/index.html?demo&desktop&state=stream",
     ready: '[data-screen="session"]',
-    // Same navigation as the `session` row — the default demo view opens an
-    // empty welcome session, so we click into the transcript-bearing one.
+    // Same default view as the `session` row — the demo opens straight on the
+    // transcript-bearing session.
     final: "text=Run a shell command?",
     phases: ["early", "mid", "late"],
-    actions: async (page) => {
-      await page.locator('.truncate:has-text("Deploy new billing service")').first().click();
-    },
     viewport: DESKTOP_VIEWPORT,
     // No design exists for a mid-stream frame — `null` is the registry's
     // documented way to say so; the row still gets structure + pixels.
@@ -271,9 +265,6 @@ export const SCREENS = [
     // so scope to the visible pane's header — only the active one is shown.
     region: ".manta-session-header:visible",
     mockupRegion: ".topb",
-    actions: async (page) => {
-      await page.locator('.truncate:has-text("Deploy new billing service")').first().click();
-    },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/session/mockup.html",
     surfacesClosed: [
@@ -295,9 +286,6 @@ export const SCREENS = [
     // See session-header: only the active chat pane's composer is visible.
     region: ".manta-composer:visible",
     mockupRegion: ".composer",
-    actions: async (page) => {
-      await page.locator('.truncate:has-text("Deploy new billing service")').first().click();
-    },
     viewport: DESKTOP_VIEWPORT,
     mockup: "docs/screens/session/mockup.html",
     surfacesClosed: [
@@ -438,7 +426,6 @@ export const SCREENS = [
     final: '[role="menu"]',
     region: ".manta-session-menu-dropdown",
     actions: async (page) => {
-      await page.locator('.truncate:has-text("Deploy new billing service")').first().click();
       await page.getByRole("button", { name: "Session actions" }).click();
     },
     viewport: DESKTOP_VIEWPORT,
@@ -470,7 +457,6 @@ export const SCREENS = [
     final: ".manta-model-dropdown",
     region: ".manta-model-dropdown",
     actions: async (page) => {
-      await page.locator('.truncate:has-text("Deploy new billing service")').first().click();
       await page.locator(".manta-model-picker-btn:visible").first().click();
     },
     viewport: DESKTOP_VIEWPORT,
@@ -500,7 +486,6 @@ export const SCREENS = [
     final: ".manta-effort-dropdown",
     region: ".manta-effort-dropdown",
     actions: async (page) => {
-      await page.locator('.truncate:has-text("Deploy new billing service")').first().click();
       await page.locator(".manta-model-picker-btn:visible").first().click();
       // Model rows render as listbox options now (MenuOption, BET-644) — the
       // row that enables the effort segment is an option, not a button.
@@ -531,7 +516,6 @@ export const SCREENS = [
     final: ".manta-ctx-popover",
     region: ".manta-ctx-popover",
     actions: async (page) => {
-      await page.locator('.truncate:has-text("Deploy new billing service")').first().click();
       await page.locator(".manta-ctx-pill:visible").first().click();
     },
     viewport: DESKTOP_VIEWPORT,
@@ -594,13 +578,6 @@ export const SCREENS = [
     mockup: "docs/screens/artifacts/mockup.html",
     viewport: DESKTOP_VIEWPORT,
     actions: async (page) => {
-      // The demo only mounts the chat panel (and therefore its transcript)
-      // once the fixture's active session is selected in the rail — the same
-      // first action the `session` row uses.
-      await page
-        .locator('.truncate:has-text("Deploy new billing service")')
-        .first()
-        .click();
       await page
         .locator('[aria-label="Show artifacts"]')
         .filter({ visible: true })
@@ -633,10 +610,6 @@ export const SCREENS = [
     mockup: "docs/screens/artifacts/mockup.html",
     viewport: DESKTOP_VIEWPORT,
     actions: async (page) => {
-      // The fixture's artifact content lives on the infra session; open it
-      // (a real user opening that session), then the artifacts panel. Links is
-      // the default tab, so no further gesture.
-      await page.getByText("Deploy new billing service").first().click();
       await page
         .locator('[aria-label="Show artifacts"]')
         .filter({ visible: true })
@@ -664,7 +637,6 @@ export const SCREENS = [
     mockup: "docs/screens/artifacts/mockup.html",
     viewport: DESKTOP_VIEWPORT,
     actions: async (page) => {
-      await page.getByText("Deploy new billing service").first().click();
       await page
         .locator('[aria-label="Show artifacts"]')
         .filter({ visible: true })
@@ -693,7 +665,6 @@ export const SCREENS = [
     mockup: "docs/screens/artifacts/mockup.html",
     viewport: DESKTOP_VIEWPORT,
     actions: async (page) => {
-      await page.getByText("Deploy new billing service").first().click();
       await page
         .locator('[aria-label="Show artifacts"]')
         .filter({ visible: true })

--- a/src/renderer/api/demoApi.test.ts
+++ b/src/renderer/api/demoApi.test.ts
@@ -31,13 +31,26 @@ import {
 
 // The three fictional project names. Mirrors the shot list in
 // `docs/specs/website-readme-revamp.md` section 6 — every screenshot /
-// video frame renders the same brand.
-const PROJECT_NAMES = ["ethernal", "marketing", "infra"] as const;
+// video frame renders the same brand. Order IS load-bearing here: the store
+// defaults the active project to projects[0], and the demo must open on the
+// transcript-bearing infra session (BET-663). Changing the order without
+// updating this test (and the visual screens that rely on the default view)
+// silently makes the demo land on an empty session again.
+const PROJECT_NAMES = ["infra", "ethernal", "marketing"] as const;
 
 describe("demo fixture — project + session structure", () => {
   it("contains exactly the three agreed fictional project names", () => {
     const names = demoState.projects.map((p) => p.tmuxSession);
     expect(names).toEqual([...PROJECT_NAMES]);
+  });
+
+  it("defaults the active project to the transcript-bearing infra session", () => {
+    // The store's default-active rule is `activeProjectName = projects[0]`.
+    // The demo relies on infra being first so `?demo&desktop` lands on the
+    // rich transcript, not the empty "Add CSV export" welcome (BET-663).
+    const first = demoState.projects[0];
+    expect(first.tmuxSession).toBe("infra");
+    expect(first.windows.some((w) => w.active === true)).toBe(true);
   });
 
   it("has six or seven sessions total across the three projects", () => {

--- a/src/renderer/api/demoFixture.ts
+++ b/src/renderer/api/demoFixture.ts
@@ -108,6 +108,28 @@ export const demoAppConfig: AppConfig = {
 // amber steady / pulsing red ? / pulsing red ! / subagent count).
 // =============================================================================
 export const demoProjects: Project[] = [
+  // Ordering is load-bearing: the store defaults the active project to
+  // projects[0], and the demo opens there. The infra session is the one that
+  // owns SES_INFRA — the transcript-bearing session — so it must be first for
+  // `?demo&desktop` to land on the real content instead of an empty Welcome.
+  {
+    tmuxSession: "infra",
+    defaultCwd: "/home/dev/projects/infra",
+    attached: true,
+    windows: [
+      // Active session — chat-mode. Holds the rendered transcript + the
+      // visible permission card + visible question card. Both blocks at once
+      // satisfies "permission card and question card are both visible without
+      // interaction" without forcing a navigation.
+      {
+        index: 0,
+        name: "Deploy new billing service",
+        active: true,
+        paneCurrentPath: "/home/dev/projects/infra/terraform/billing",
+        opencodeSessionId: SES_INFRA,
+      },
+    ],
+  },
   {
     tmuxSession: "ethernal",
     defaultCwd: "/home/dev/projects/ethernal",
@@ -163,24 +185,6 @@ export const demoProjects: Project[] = [
         active: false,
         paneCurrentPath: "/home/dev/projects/marketing-site",
         opencodeSessionId: null,
-      },
-    ],
-  },
-  {
-    tmuxSession: "infra",
-    defaultCwd: "/home/dev/projects/infra",
-    attached: true,
-    windows: [
-      // Active session — chat-mode. Holds the rendered transcript + the
-      // visible permission card + visible question card. Both blocks at once
-      // satisfies "permission card and question card are both visible without
-      // interaction" without forcing a navigation.
-      {
-        index: 0,
-        name: "Deploy new billing service",
-        active: true,
-        paneCurrentPath: "/home/dev/projects/infra/terraform/billing",
-        opencodeSessionId: SES_INFRA,
       },
     ],
   },


### PR DESCRIPTION
## BET-663 — Demo: default-active session now matches the transcript-bearing session

**Files changed:** 3.

- `src/renderer/api/demoFixture.ts` — reorder `demoProjects` so the `infra` project (owner of `SES_INFRA`) is `projects[0]`. The store defaults the active project to `projects[0]`, so `?demo&desktop` now opens directly on the rich infra transcript instead of the empty "Add CSV export" welcome.
- `scripts/visual/screens.mjs` — delete the twelve now-redundant clicks that previously navigated to the infra session (`'.truncate:has-text("Deploy new billing service")'` and the `getByText(...)` variants), plus the stale comments. Where an `actions` block did something else, only the click was removed; where the click was the sole action, the now-empty `actions` key was deleted.
- `src/renderer/api/demoApi.test.ts` — reflect the new load-bearing order in `PROJECT_NAMES` and add a regression guard that the first project is the transcript-bearing infra session with an active window.

`demoActiveSessionId` was kept: it still has consumers inside `demoFixture.ts` (the demo-state initializers and the `activeSessionId === demoActiveSessionId` comparison), so per the issue it is retained, not deleted.

**Base: `origin/main` @ `445e111b`**

**Verification results:**
- PR branch (`multica/BET-663-demo-active-session` @ `619025b4`):
  - typecheck: exit 0, errors none
  - test: exit 0 — vitest 2366 pass / 0 fail, node:test 1631 pass / 0 fail
- Conclusion: 0 new failures.

**Baseline re-record — intentionally deferred to BET-662.** This issue is sequenced after BET-662 (`test(visual): regenerate stale baselines from current main`), whose PR (#738) is still open and is the designated owner of regenerating the visual baselines against current main. Visual/pixel-baseline verification was also retired from agent instructions (2026-08-07), so re-recording baselines here would collide with BET-662 and contradict the retirement. The code change itself is complete and green; the `session` baseline will reflect the transcript once BET-662 regenerates from current main.
