### PR TITLE
BET-766: drop stale screenshotToast cross-reference in agentFileToast doc comment

### DIFF
--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -415,10 +415,10 @@ type State = {
   // expires on its own.
   pendingScreenshots: PendingScreenshot[];
   // Single global agent-file toast: a file the remote AI pushed to its outbox.
-  // Same single-instance pattern as screenshotToast — App.tsx owns the one
-  // ipcRenderer listener, the active ChatPanel renders the toast, accept /
-  // dismiss clear it globally. In auto-pull (trust) mode it's informational
-  // (autoPulled:true, localPath set); otherwise it's a Save/dismiss prompt.
+  // Single-instance pattern — App.tsx owns the one ipcRenderer listener, the
+  // active ChatPanel renders the toast, accept / dismiss clear it globally. In
+  // auto-pull (trust) mode it's informational (autoPulled:true, localPath set);
+  // otherwise it's a Save/dismiss prompt.
   agentFileToast: AgentFileReady | null;
   // Transient app-level notices (errors + info) shown by the global ToastStack
   // (BET-723). Replaces every native alert() in the renderer. Capped at 5;


### PR DESCRIPTION
Opened automatically for `multica/BET-766-screenshotToast-doccomment`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-766.