### PR TITLE
feat(ios): artifacts/agent-file outbox receive panel + downloads (BET-750)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,7 @@ report/
 
 # Native iOS derived-data + capture scratch — build/capture output, not source.
 mobile/native/.build/
+mobile/native/build/
 mobile/native/.capture-out/
 playwright-report/
 test-results/

--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -49,10 +49,12 @@
 		7E8C2A70A3D5C0F949D79FF5 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28250B8DDAB996449F7AE3AD /* SessionModels.swift */; };
 		863035B4DE4C873A0BD9D0F5 /* MantaAuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */; };
 		8A6656EBBD6AEC1B5CE7D0D6 /* MantaSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFB984A951D5C7BD8D02F9 /* MantaSettingsTests.swift */; };
+		8C67D893A425A3B5495CB882 /* ComposerTypeahead.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6ABAA46F1CBD2093D4AC87 /* ComposerTypeahead.swift */; };
 		8C965541FA4ABDFB2A2A319E /* terminal in Resources */ = {isa = PBXBuildFile; fileRef = 0C1EE3F998CADE8487D2555E /* terminal */; };
 		8F61F901888B9FE16EA093B0 /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471BF240012879FDED5689C1 /* ChatSessionStore.swift */; };
 		9055A7DECF435A0A430D6FAB /* MantaSettingsStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABF1AB00CC95EA99A4EF537B /* MantaSettingsStore.swift */; };
 		9068396FC592D6010419D13D /* MantaDynamicType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0FCC705A51D162CE3E7E3B00 /* MantaDynamicType.swift */; };
+		9203A22473582BAD597CFABC /* ComposerTypeaheadTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E94945B8AA543436D5A6202 /* ComposerTypeaheadTests.swift */; };
 		94493F871005DA7F4DA19ED7 /* SessionListView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */; };
 		95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */ = {isa = PBXBuildFile; fileRef = A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */; };
 		959894A87F301CC717772BD3 /* ChatLoadingSkeleton.swift in Sources */ = {isa = PBXBuildFile; fileRef = E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */; };
@@ -153,6 +155,7 @@
 		772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaReconnectController.swift; sourceTree = "<group>"; };
 		799EED7CC4F10C6684A5662C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
 		7D7BC8920829E8847057C8DA /* TerminalKeyRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyRow.swift; sourceTree = "<group>"; };
+		7E94945B8AA543436D5A6202 /* ComposerTypeaheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTypeaheadTests.swift; sourceTree = "<group>"; };
 		7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaStreamModels.swift; sourceTree = "<group>"; };
 		81FE763828641B50BF496F4D /* TerminalSessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionState.swift; sourceTree = "<group>"; };
 		82EEBB3B72D8F63CF4D8CB7B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -192,6 +195,7 @@
 		DD646A4951E292E750890CCB /* MantaAppRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppRoot.swift; sourceTree = "<group>"; };
 		E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLoadingSkeleton.swift; sourceTree = "<group>"; };
 		EBC7D0BF807861DCCABC5A26 /* MantaResourceCardModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaResourceCardModelsTests.swift; sourceTree = "<group>"; };
+		ED6ABAA46F1CBD2093D4AC87 /* ComposerTypeahead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTypeahead.swift; sourceTree = "<group>"; };
 		EE0504A23AC9360042B3D51B /* ChatStreamMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamMergeTests.swift; sourceTree = "<group>"; };
 		EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStreamTests.swift; sourceTree = "<group>"; };
 		F88D3B9B782BF819EEBEBF1D /* TerminalSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSocket.swift; sourceTree = "<group>"; };
@@ -245,6 +249,7 @@
 				EE0504A23AC9360042B3D51B /* ChatStreamMergeTests.swift */,
 				C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */,
 				938AB4A14437119280E1B53A /* ComposerTests.swift */,
+				7E94945B8AA543436D5A6202 /* ComposerTypeaheadTests.swift */,
 				9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */,
 				989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */,
 				EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */,
@@ -301,6 +306,7 @@
 				436675A65BF149932C1EADE0 /* ChatScreen.swift */,
 				471BF240012879FDED5689C1 /* ChatSessionStore.swift */,
 				0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */,
+				ED6ABAA46F1CBD2093D4AC87 /* ComposerTypeahead.swift */,
 				C42691C89906181C99929354 /* ComposerView.swift */,
 				72E2CCAF6C565AEE489E1618 /* EdgeSwipeRestorer.swift */,
 				5D71EC917661085ED10E0867 /* FolderPickerView.swift */,
@@ -549,6 +555,7 @@
 				3CE79341ACF08E7F836522FD /* ChatStreamMergeTests.swift in Sources */,
 				650862947C7F0D6C393C94BB /* ChatTranscriptTests.swift in Sources */,
 				96F128D3EBC0D1432F603FDB /* ComposerTests.swift in Sources */,
+				9203A22473582BAD597CFABC /* ComposerTypeaheadTests.swift in Sources */,
 				5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */,
 				0129D15936E52427A46702E7 /* MantaAuthClientTests.swift in Sources */,
 				9BF6855A825F539665FF1563 /* MantaEventStreamTests.swift in Sources */,
@@ -576,6 +583,7 @@
 				E12FC0E7284E2760AD3A6C4C /* ChatScreen.swift in Sources */,
 				8F61F901888B9FE16EA093B0 /* ChatSessionStore.swift in Sources */,
 				C96C7F34F91F06214FD25523 /* ChatVoice.swift in Sources */,
+				8C67D893A425A3B5495CB882 /* ComposerTypeahead.swift in Sources */,
 				D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */,
 				4F6D25AA2FFF73A8FE1321D3 /* EdgeSwipeRestorer.swift in Sources */,
 				95A9EDE98E7304030E438CEF /* FolderPickerView.swift in Sources */,

--- a/mobile/native/MantaUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/native/MantaUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,87 @@
 {
-  "originHash" : "9c2909e906f5bef7060e17b2f43ac069f48f76bb62f7cc6653b107d419af48f0",
+  "originHash" : "eaf0fa840220cd8a89d4eba79b18d45cade2e66bd7897cfb95b7906d0e0f6d06",
   "pins" : [
+    {
+      "identity" : "abseil-cpp-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/abseil-cpp-binary.git",
+      "state" : {
+        "revision" : "bbe8b69694d7873315fd3a4ad41efe043e1c07c5",
+        "version" : "1.2024072200.0"
+      }
+    },
+    {
+      "identity" : "app-check",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/app-check.git",
+      "state" : {
+        "revision" : "3e33dd27dd4c69bd81c7c81fe61d8ccf58846902",
+        "version" : "11.3.1"
+      }
+    },
+    {
+      "identity" : "firebase-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/firebase-ios-sdk",
+      "state" : {
+        "revision" : "33a468adfdb75b53f05a37e7c886ca7c962b5c17",
+        "version" : "12.17.0"
+      }
+    },
+    {
+      "identity" : "google-ads-on-device-conversion-ios-sdk",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/googleads/google-ads-on-device-conversion-ios-sdk",
+      "state" : {
+        "revision" : "dc39082d8881109d35b94b1c122164c0e8d08a55",
+        "version" : "3.6.1"
+      }
+    },
+    {
+      "identity" : "googleappmeasurement",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleAppMeasurement.git",
+      "state" : {
+        "revision" : "fceaffa07d22dcd5624d3639fd970351a4a5ad8c",
+        "version" : "12.17.0"
+      }
+    },
+    {
+      "identity" : "googledatatransport",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleDataTransport.git",
+      "state" : {
+        "revision" : "ba3358d3c3dbae8ef230b58a46b97ad65e84e974",
+        "version" : "10.1.1"
+      }
+    },
+    {
+      "identity" : "googleutilities",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/GoogleUtilities.git",
+      "state" : {
+        "revision" : "9f183ae842be978784f2963a343682e0c46d8fb3",
+        "version" : "8.1.2"
+      }
+    },
+    {
+      "identity" : "grpc-binary",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/grpc-binary.git",
+      "state" : {
+        "revision" : "75b31c842f664a0f46a2e590a570e370249fd8f6",
+        "version" : "1.69.1"
+      }
+    },
+    {
+      "identity" : "gtm-session-fetcher",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/gtm-session-fetcher.git",
+      "state" : {
+        "revision" : "724a52eea6329b7e12d3ad8300d76ca9f3895fcc",
+        "version" : "5.3.1"
+      }
+    },
     {
       "identity" : "highlightr",
       "kind" : "remoteSourceControl",
@@ -8,6 +89,24 @@
       "state" : {
         "revision" : "05e7fcc63b33925cd0c1faaa205cdd5681e7bbef",
         "version" : "2.3.0"
+      }
+    },
+    {
+      "identity" : "interop-ios-for-google-sdks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/interop-ios-for-google-sdks.git",
+      "state" : {
+        "revision" : "040d087ac2267d2ddd4cca36c757d1c6a05fdbfe",
+        "version" : "101.0.0"
+      }
+    },
+    {
+      "identity" : "leveldb",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/firebase/leveldb.git",
+      "state" : {
+        "revision" : "a0bc79961d7be727d258d33d5a6b2f1023270ba1",
+        "version" : "1.22.5"
       }
     },
     {
@@ -20,12 +119,21 @@
       }
     },
     {
-      "identity" : "plcrashreporter",
+      "identity" : "nanopb",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/plcrashreporter",
+      "location" : "https://github.com/firebase/nanopb.git",
       "state" : {
-        "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
-        "version" : "1.12.2"
+        "revision" : "3851d94a41890dea16dc3db34caf60e585cb4163",
+        "version" : "2.30910.1"
+      }
+    },
+    {
+      "identity" : "promises",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/google/promises.git",
+      "state" : {
+        "revision" : "f4a19a3c313dc2616c70bb49d29a799fb16be837",
+        "version" : "2.4.1"
       }
     },
     {

--- a/mobile/native/MantaUI/ChatOverflowCaptureScene.swift
+++ b/mobile/native/MantaUI/ChatOverflowCaptureScene.swift
@@ -31,6 +31,7 @@ struct ChatOverflowCaptureScene: View {
                     projectName: "manta",
                     onSchedules: {},
                     onSecrets: {},
+                    onArtifacts: {},
                     onCompact: {},
                     onClear: {},
                     onFork: {},

--- a/mobile/native/MantaUI/ChatOverflowSheet.swift
+++ b/mobile/native/MantaUI/ChatOverflowSheet.swift
@@ -37,6 +37,7 @@ struct ChatOverflowSheet: View {
 
     var onSchedules: () -> Void
     var onSecrets: () -> Void
+    var onArtifacts: () -> Void
     var onCompact: () -> Void
     var onClear: () -> Void
     var onFork: () -> Void
@@ -74,6 +75,7 @@ struct ChatOverflowSheet: View {
                 Section {
                     row("Scheduled tasks", systemImage: "clock", badge: scheduleCount, action: onSchedules)
                     row("Secrets", systemImage: "key", action: onSecrets)
+                    row("Artifacts", systemImage: "doc", action: onArtifacts)
                 }
                 Section {
                     Button {

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -71,6 +71,7 @@ enum BranchFreshnessPolicy {
 private enum OverflowDestination: String, Identifiable {
     case schedules
     case secrets
+    case artifacts
 
     var id: String { rawValue }
 }
@@ -433,6 +434,7 @@ private struct ChatScreenContent: View {
             projectName: projectName,
             onSchedules: { overflowDestination = .schedules },
             onSecrets: { overflowDestination = .secrets },
+            onArtifacts: { overflowDestination = .artifacts },
             onCompact: { store.compact() },
             onClear: { Task { await clearSession() } },
             onFork: { Task { await forkSession() } },
@@ -478,6 +480,11 @@ private struct ChatScreenContent: View {
             )
         case .secrets:
             SecretsCard(
+                sessionId: store.sessionId,
+                onClose: { overflowDestination = nil }
+            )
+        case .artifacts:
+            ArtifactsCard(
                 sessionId: store.sessionId,
                 onClose: { overflowDestination = nil }
             )

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -338,6 +338,45 @@ final class MantaAPIClient: Sendable {
         _ = try await call("secrets:delete", args: [id], as: VoidResult.self)
     }
 
+    /// `outbox:list` — agent-pushed artifacts scoped to the session (the box's
+    /// `~/.manta-outbox/` row shape from `src/server/outbox.mjs`). Non-
+    /// destructive: entries expire via the box's TTL sweep, not on download.
+    func listOutbox(sessionId: String? = nil) async throws -> [OutboxFile] {
+        let args: [Any] = sessionId.map { [$0] } ?? []
+        return try await call("outbox:list", args: args, as: [OutboxFile].self) ?? []
+    }
+
+    /// Download an outbox file's bytes via `GET {serverURL}/api/download?path=`
+    /// with the bearer token. The box path-traversal-guards `path` to the
+    /// outbox root, so a `403 "path outside outbox"` / `404` must THROW rather
+    /// than surface as a successful empty `Data` (BET-750). Non-destructive:
+    /// the source stays on the box until the TTL sweep.
+    func downloadOutboxFile(path: String) async throws -> Data {
+        var url = serverURL.appendingPathComponent("api").appendingPathComponent("download")
+        url.append(queryItems: [URLQueryItem(name: "path", value: path)])
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        if let token = tokenProvider(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw MantaError.authRequired
+        }
+        if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+            // Non-2xx: the box replies `{error: "…"}` (e.g. "path outside
+            // outbox") — surface that text rather than an empty `Data`.
+            if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let error = object["error"] as? String, !error.isEmpty {
+                throw MantaError.server(error)
+            }
+            throw MantaError.server("download failed (\(http.statusCode))")
+        }
+        return data
+    }
+
     /// `voice:transcribe` — ship recorded audio (base64 over the JSON RPC
     /// wire, as the desktop shim does) to the box's Groq transcription.
     /// Returns the transcribed text, or nil when the clip was empty.

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -357,3 +357,23 @@ struct SecretSetResult: Decodable, Equatable, Sendable {
     var meta: SecretMeta?
     var error: String?
 }
+
+// MARK: - Artifacts / agent-file outbox (BET-750)
+
+/// A row from the box's artifact mailbox (`~/.manta-outbox/`), as served by
+/// the `outbox:list` RPC and `src/server/outbox.mjs` `statRow`. Non-destructive:
+/// files expire via the box's TTL sweep, never on download. `size` is bytes,
+/// `mtime`/`expiresAt` are epoch milliseconds (nullable — a loose root file or
+/// a file stat that failed can carry nulls). `path` is the absolute box path
+/// and doubles as the stable identity for `GET /api/download?path=<path>`
+/// (BET-750).
+struct OutboxFile: Codable, Equatable, Sendable, Identifiable {
+    var path: String
+    var name: String
+    var size: Int
+    var sessionID: String?
+    var mtime: Double?
+    var expiresAt: Double?
+
+    var id: String { path }
+}

--- a/mobile/native/MantaUI/SessionResourceCards.swift
+++ b/mobile/native/MantaUI/SessionResourceCards.swift
@@ -342,3 +342,150 @@ private struct SecretAddForm: View {
         }
     }
 }
+
+// ===========================================================================
+// BET-750 — artifacts / agent-file outbox receive card.
+//
+// The reverse of the composer's paperclip: files the AI pushes to the box's
+// `~/.manta-outbox/<sessionID>/` are listed here, scoped to this session, and
+// each row's download button pulls the bytes over `GET /api/download` and hands
+// them to the system share sheet ("Save to Files"). Receive-only — this is not
+// an upload path. Same stock-SwiftUI treatment as SchedulesCard/SecretsCard:
+// the list refetches on `.task` (and lightly while presented, so a file the AI
+// drops mid-chat appears) with an honest empty state and a `failed` flag.
+// ===========================================================================
+
+/// List of agent-pushed files for this session (`outbox:list`), each with a
+/// system download action. Once a row's bytes are fetched it is written to the
+/// app's temp directory and that row swaps its download button for a
+/// `ShareLink`, so saving to Files goes through the platform share sheet.
+struct ArtifactsCard: View {
+    let sessionId: String
+    let onClose: () -> Void
+
+    @State private var files: [OutboxFile] = []
+    @State private var loaded = false
+    @State private var failed = false
+    /// Per-path temp URL where a successfully-downloaded file lives. A row
+    /// whose path is present here shows a ShareLink instead of a download tap.
+    @State private var downloaded: [String: URL] = [:]
+    /// Paths currently being fetched (row spinner).
+    @State private var downloading: Set<String> = []
+    private let api = MantaAPIClient.live()
+    /// Poll cadence while the card is presented, so a file the AI drops mid-chat
+    /// appears without needing to dismiss and reopen the card.
+    private static let refreshIntervalNanoseconds: UInt64 = 3_000_000_000
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if failed {
+                    Text("Couldn't load artifacts.")
+                        .foregroundStyle(.secondary)
+                } else if loaded {
+                    if files.isEmpty {
+                        emptyState
+                    } else {
+                        List(files) { file in
+                            row(file)
+                        }
+                        .listStyle(.insetGrouped)
+                    }
+                } else {
+                    ProgressView()
+                }
+            }
+            .navigationTitle("Artifacts")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done", action: onClose)
+                }
+            }
+        }
+        // Live update: refetch while presented (matches the other cards' `.task`
+        // load, extended to a light poll). Cancels when the card dismisses.
+        .task {
+            while !Task.isCancelled {
+                await load()
+                try? await Task.sleep(nanoseconds: Self.refreshIntervalNanoseconds)
+            }
+        }
+    }
+
+    private func load() async {
+        if let result = try? await api.listOutbox(sessionId: sessionId) {
+            files = result
+            failed = false
+        } else {
+            failed = true
+        }
+        loaded = true
+    }
+
+    /// Fetch the file's bytes and stage them in the app's temp directory so the
+    /// row can offer a system Save-to-Files share. A failed download leaves the
+    /// row's download control in place — nothing is reported as saved.
+    private func download(_ file: OutboxFile) async {
+        guard !downloading.contains(file.path) else { return }
+        downloading.insert(file.path)
+        defer { downloading.remove(file.path) }
+        do {
+            let data = try await api.downloadOutboxFile(path: file.path)
+            let url = Self.tempURL(for: file.name)
+            try data.write(to: url)
+            downloaded[file.path] = url
+        } catch {
+            // Failure: leave the control in place; no fabricated success.
+        }
+    }
+
+    /// A writable temp URL the share sheet can hand to the OS. Derives from the
+    /// file name and is overwritten on each (re)download of the same row.
+    private static func tempURL(for name: String) -> URL {
+        let dir = FileManager.default.temporaryDirectory
+        let safe = name.replacingOccurrences(of: "/", with: "_")
+        return dir.appendingPathComponent(safe)
+    }
+
+    private var emptyState: some View {
+        ContentUnavailableView(
+            "No artifacts",
+            systemImage: "doc",
+            description: Text("Files the AI sends during this conversation will appear here.")
+        )
+    }
+
+    private func row(_ file: OutboxFile) -> some View {
+        HStack(alignment: .center) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(file.name)
+                    .font(.body)
+                    .lineLimit(1)
+                Text(Self.formatSize(file.size))
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
+            Spacer(minLength: 8)
+            if let url = downloaded[file.path] {
+                ShareLink(item: url)
+                    .accessibilityLabel("Save \(file.name)")
+            } else if downloading.contains(file.path) {
+                ProgressView()
+            } else {
+                Button {
+                    Task { await download(file) }
+                } label: {
+                    Image(systemName: "arrow.down.circle")
+                }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("Download \(file.name)")
+            }
+        }
+        .padding(.vertical, 2)
+    }
+
+    private static func formatSize(_ bytes: Int) -> String {
+        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    }
+}

--- a/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
+++ b/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
@@ -18,6 +18,7 @@ final class MantaActionRPCWireTests: XCTestCase {
         super.setUp()
         CapturingURLProtocol.cache = []
         CapturingURLProtocol.result = #"{"result": null}"#
+        CapturingURLProtocol.statusCode = 200
     }
 
     private func makeClient() -> MantaAPIClient {
@@ -260,6 +261,87 @@ final class MantaActionRPCWireTests: XCTestCase {
         XCTAssertEqual(source?["start"] as? Int, 4)
         XCTAssertEqual(source?["end"] as? Int, 18)
     }
+
+    // MARK: - artifacts / agent-file outbox (BET-750)
+
+    /// `outbox:list` is dispatched as `fn(sessionId)` — scoped to the session —
+    /// and decodes the box's `[OutboxFile]` rows.
+    func testListOutboxSendsSessionIdAndDecodesFiles() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": [{"path": "/home/dev/.manta-outbox/ses_1/report.pdf", "name": "report.pdf", "size": 1234, "sessionID": "ses_1", "mtime": 1750000000000, "expiresAt": 1750604800000}]}"#
+        let files = try await client.listOutbox(sessionId: "ses_1")
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/outbox:list")
+        let args = CapturingURLProtocol.bodyJSON(CapturingURLProtocol.cache.last!)?["args"] as? [Any]
+        XCTAssertEqual(args?.count, 1)
+        XCTAssertEqual(args?.first as? String, "ses_1")
+        let file = try XCTUnwrap(files.first)
+        XCTAssertEqual(file.path, "/home/dev/.manta-outbox/ses_1/report.pdf")
+        XCTAssertEqual(file.name, "report.pdf")
+        XCTAssertEqual(file.size, 1234)
+        XCTAssertEqual(file.sessionID, "ses_1")
+        XCTAssertEqual(file.mtime, 1750000000000)
+        XCTAssertEqual(file.expiresAt, 1750604800000)
+    }
+
+    /// `outbox:list` with a nil sessionId sends no args — the box then lists
+    /// every artifact across sessions.
+    func testListOutboxOmitsSessionIdWhenNil() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": []}"#
+        let files = try await client.listOutbox()
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/outbox:list")
+        let args = CapturingURLProtocol.bodyJSON(CapturingURLProtocol.cache.last!)?["args"] as? [Any]
+        XCTAssertEqual(args?.count, 0)
+        XCTAssertTrue(files.isEmpty)
+    }
+
+    /// `downloadOutboxFile` GETs `/api/download?path=<abs>` with a bearer token
+    /// and returns the file bytes on 200.
+    func testDownloadOutboxFileReturnsBytesOn200() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"PDFBYTES"#
+        let data = try await client.downloadOutboxFile(path: "/home/dev/.manta-outbox/ses_1/report.pdf")
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/api/download")
+        // Assert the `path` query item carries the absolute box path, decoding
+        // the percent-encoding rather than pinning a specific escape form.
+        let components = try XCTUnwrap(URLComponents(url: try XCTUnwrap(CapturingURLProtocol.cache.last?.url), resolvingAgainstBaseURL: false))
+        let pathValue = components.queryItems?.first { $0.name == "path" }?.value
+        XCTAssertEqual(pathValue, "/home/dev/.manta-outbox/ses_1/report.pdf")
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.value(forHTTPHeaderField: "Authorization"), "Bearer tok")
+        XCTAssertEqual(data, Data("PDFBYTES".utf8))
+    }
+
+    /// A `403 "path outside outbox"` must throw — never surface as empty bytes.
+    func testDownloadOutboxFileThrowsOn403() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.statusCode = 403
+        CapturingURLProtocol.result = #"{"error": "path outside outbox"}"#
+        do {
+            _ = try await client.downloadOutboxFile(path: "/etc/passwd")
+            XCTFail("expected a throw for a path outside the outbox")
+        } catch let error as MantaError {
+            guard case .server(let message) = error else {
+                return XCTFail("expected MantaError.server, got \(error)")
+            }
+            XCTAssertEqual(message, "path outside outbox")
+        }
+    }
+
+    /// A `404` for a missing file must throw rather than return empty `Data`.
+    func testDownloadOutboxFileThrowsOn404() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.statusCode = 404
+        CapturingURLProtocol.result = #"{"error": "not found"}"#
+        do {
+            _ = try await client.downloadOutboxFile(path: "/home/dev/.manta-outbox/ses_1/gone.txt")
+            XCTFail("expected a throw for a missing file")
+        } catch let error as MantaError {
+            guard case .server(let message) = error else {
+                return XCTFail("expected MantaError.server, got \(error)")
+            }
+            XCTAssertEqual(message, "not found")
+        }
+    }
 }
 
 // MARK: - Capturing URLProtocol
@@ -267,6 +349,7 @@ final class MantaActionRPCWireTests: XCTestCase {
 private final class CapturingURLProtocol: URLProtocol {
     nonisolated(unsafe) static var cache: [URLRequest] = []
     nonisolated(unsafe) static var result: String = #"{"result": null}"#
+    nonisolated(unsafe) static var statusCode: Int = 200
 
     override class func canInit(with request: URLRequest) -> Bool { true }
     override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
@@ -274,7 +357,7 @@ private final class CapturingURLProtocol: URLProtocol {
     override func startLoading() {
         Self.cache.append(request)
         let data = Data(Self.result.utf8)
-        let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+        let response = HTTPURLResponse(url: request.url!, statusCode: Self.statusCode, httpVersion: nil, headerFields: nil)!
         client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
         client?.urlProtocol(self, didLoad: data)
         client?.urlProtocolDidFinishLoading(self)

--- a/mobile/native/MantaUITests/MantaResourceCardModelsTests.swift
+++ b/mobile/native/MantaUITests/MantaResourceCardModelsTests.swift
@@ -82,4 +82,49 @@ final class MantaResourceCardModelsTests: XCTestCase {
         let args = try XCTUnwrap(object["args"] as? [String])
         XCTAssertEqual(args, ["ses_1"])
     }
+
+    // MARK: - artifacts / agent-file outbox (BET-750)
+
+    /// `outbox:list` rows (src/server/outbox.mjs `statRow`) decode 1:1 —
+    /// `{path, name, size, sessionID, mtime, expiresAt}`.
+    func testDecodesOutboxFilePayload() throws {
+        let payload = """
+        {"result": [{
+          "path": "/home/dev/.manta-outbox/ses_1/report.pdf",
+          "name": "report.pdf",
+          "size": 1234,
+          "sessionID": "ses_1",
+          "mtime": 1750000000000,
+          "expiresAt": 1750604800000
+        }]}
+        """
+        let files = try MantaAPIClient.decode(json(payload), as: [OutboxFile].self)
+        let file = try XCTUnwrap(files?.first)
+        XCTAssertEqual(file.path, "/home/dev/.manta-outbox/ses_1/report.pdf")
+        XCTAssertEqual(file.name, "report.pdf")
+        XCTAssertEqual(file.size, 1234)
+        XCTAssertEqual(file.sessionID, "ses_1")
+        XCTAssertEqual(file.mtime, 1750000000000)
+        XCTAssertEqual(file.expiresAt, 1750604800000)
+    }
+
+    /// Outbox rows tolerate null `sessionID`/`expiresAt` (a loose root file, or
+    /// a stat that failed) without failing to decode.
+    func testDecodesOutboxFilePayloadWithNulls() throws {
+        let payload = """
+        {"result": [{
+          "path": "/home/dev/.manta-outbox/loose.txt",
+          "name": "loose.txt",
+          "size": 12,
+          "sessionID": null,
+          "mtime": 1750000000000,
+          "expiresAt": null
+        }]}
+        """
+        let files = try MantaAPIClient.decode(json(payload), as: [OutboxFile].self)
+        let file = try XCTUnwrap(files?.first)
+        XCTAssertNil(file.sessionID)
+        XCTAssertNil(file.expiresAt)
+        XCTAssertEqual(file.size, 12)
+    }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-750-ios-artifacts-outbox`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-750.