### PR TITLE
chore(box): replace stale (BET-XXX) placeholder with BET-764

### DIFF
--- a/scripts/systemd/opencode-serve.service
+++ b/scripts/systemd/opencode-serve.service
@@ -39,7 +39,7 @@ ExecStart=@@OPENCODE_BIN@@ serve --port 4096 --hostname 127.0.0.1
 # dirs (tmux). install.sh substitutes the resolved list (see
 # launchd_agent_path()).
 Environment=PATH=@@AGENT_PATH@@
-# Background subagents (BET-XXX). Unlocks `task(background: true)` — the tool
+# Background subagents (BET-764). Unlocks `task(background: true)` — the tool
 # returns immediately and opencode injects the child's result back into the
 # parent session when it finishes — plus the
 # POST /experimental/session/:id/background detach endpoint. Without this env


### PR DESCRIPTION
Replaces the literal `(BET-XXX)` placeholder in the "Background subagents" comment in `scripts/systemd/opencode-serve.service` with the real tracking issue, BET-764 (shipped via PR #726). Comment-only change, no behaviour impact.

**Files changed:** `1` file. `scripts/systemd/opencode-serve.service`

**Verification results:**
- typecheck: exit 0, errors: none
- test: exit 1, 1630 pass / 1 fail / 0 skip. The single failure (`duplication-gate`) is pre-existing — reproduced identically on the stashed base (also 1630/1).
- Base: `origin/main @ 445e111b`
- **Conclusion:** 1 pre-existing failure, 0 new. Comment-only change; no code touched.