### PR TITLE
fix(server): single-flight ensureAuth mint + atomic revoke (BET-771)

### DIFF
--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -31,10 +31,9 @@
 // the mobile QR scanner (M3) are separate issues; they consume /auth/pair +
 // /auth/claim built here.
 
-import { unlink } from "node:fs/promises";
 import { randomBytes, randomInt, timingSafeEqual } from "node:crypto";
 import { statePath } from "../shared/paths.mjs";
-import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { readJsonSync, writeJsonAtomic, createMutex } from "./jsonStore.mjs";
 import { createDeviceRegistry, DEVICES_STORE_PATH, DEVICE_IDLE_TTL_MS, saveDevicesRaw } from "./devices.mjs";
 
 const STORE_PATH = statePath("auth.json");
@@ -281,21 +280,13 @@ export async function saveAuth(auth, path = STORE_PATH) {
   await writeJsonAtomic(path, JSON.stringify(auth, null, 2), { mode: 0o600 });
 }
 
-// Delete the persisted auth file. Idempotent — a missing file is not an error
-// (the caller is racing for "delete a box" semantics where concurrent revokes
-// are fine, and a not-yet-created store on a fresh install is irrelevant).
-// Used by revoke() to satisfy the BET-357 §2 contract: "the old box_token no
-// longer works" is enforced by regenerating a fresh identity (see revoke),
-// but the on-disk file is rewritten by the regenerate step so the store shape
-// stays consistent across revocation.
-export async function deleteAuth(path = STORE_PATH) {
-  try {
-    await unlink(path);
-  } catch (e) {
-    if (e && e.code === "ENOENT") return;
-    throw e;
-  }
-}
+// Serializes FIRST-RUN identity minting so it is single-flight (BET-771 P3-2).
+// ensureAuth is a check-then-act: without serialization, two concurrent first
+// calls both load a missing store, mint two different identities, and the last
+// write wins — silently swapping the box's identity. Wrapping the
+// load-check-mint-save in a mutex means the second caller re-loads only after
+// the first has persisted, so both observe the SAME identity.
+const ensureAuthLock = createMutex();
 
 // Load the box identity, generating + persisting a fresh one on first run.
 // Returns { box_id, box_token, created_at }. I/O injectable for tests.
@@ -304,15 +295,17 @@ export async function ensureAuth({
   save = saveAuth,
   now = () => Date.now(),
 } = {}) {
-  const existing = await load();
-  if (existing) return existing;
-  const auth = {
-    box_id: genToken(),
-    box_token: genToken(),
-    created_at: now(),
-  };
-  await save(auth);
-  return auth;
+  return ensureAuthLock.runExclusive(async () => {
+    const existing = await load();
+    if (existing) return existing;
+    const auth = {
+      box_id: genToken(),
+      box_token: genToken(),
+      created_at: now(),
+    };
+    await save(auth);
+    return auth;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -404,14 +397,12 @@ export function createPairingRegistry({ ttlMs = PAIRING_TTL_MS, now = () => Date
  *                 Passed through to the device registry; see devices.mjs.
  *   saveAuth    — injectable writer (default saveAuth) for the post-revoke
  *                 regenerate step
- *   deleteAuth  — injectable unlink (default deleteAuth) for the post-revoke
- *                 "wipe + regenerate" path.
  *   devices     — injectable device registry (createDeviceRegistry instance).
  *                 Tests MUST inject their own (with no-op load/save); the
  *                 DEFAULT targets ~/.manta/devices.json (0600) and is owned by
  *                 index.mjs.
  *
- * DANGER — the saveAuth/deleteAuth DEFAULTS target the real box store
+ * DANGER — the saveAuth DEFAULT targets the real box store
  * (~/.manta/auth.json). Only index.mjs, which owns that store, may rely on
  * them. Any other caller (tests above all) MUST inject its own writers: a
  * revoke() with a matching token silently rotates the identity of the machine
@@ -426,7 +417,6 @@ export function createAuthEngine({
   now = () => Date.now(),
   idleTtlMs = DEVICE_IDLE_TTL_MS,
   saveAuth: saveAuthFn = saveAuth,
-  deleteAuth: deleteAuthFn = deleteAuth,
   devices: devicesFn,
 } = {}) {
   if (!auth || !isValidToken(auth.box_id) || !isValidToken(auth.box_token)) {
@@ -614,11 +604,12 @@ export function createAuthEngine({
     // Clear any active pairing: the code minted under the old identity is
     // moot now (it would authorize the old token, which nothing holds).
     pairing.clear();
-    // Wipe the on-disk file first so a power-fail between writes can't leave
-    // a stale token behind, then write the fresh identity atomically. Best-
-    // effort on the unlink (an absent file is fine — the write below re-
-    // creates it).
-    await deleteAuthFn();
+    // Replace the on-disk store with the fresh identity in ONE atomic write.
+    // writeJsonAtomic writes a temp file then renames over `path`, so the file
+    // transitions directly from the old token to the new one — there is no
+    // delete-then-save gap in which a power-fail could leave NO store (and a
+    // reboot re-mint a whole new identity). The stale token is gone the instant
+    // the rename lands (BET-771 P3-2).
     await saveAuthFn(fresh);
     // Reset the device registry to the fresh primary token (drops every
     // per-device credential).

--- a/src/server/auth.test.mjs
+++ b/src/server/auth.test.mjs
@@ -2,7 +2,7 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { rm, readFile, stat, writeFile } from "node:fs/promises";
+import { rm, readFile, stat } from "node:fs/promises";
 import {
   isValidToken,
   isValidPairingCode,
@@ -12,7 +12,6 @@ import {
   isPublicAssetPath,
   loadAuth,
   saveAuth,
-  deleteAuth,
   ensureAuth,
   createPairingRegistry,
   createAuthEngine,
@@ -263,6 +262,32 @@ test("ensureAuth generates + persists a fresh identity on first run, then is sta
   }
 });
 
+test("ensureAuth is single-flight under concurrent first-run calls (BET-771)", async () => {
+  // Regression for the check-then-act race: two concurrent first-run calls
+  // must mint ONE shared identity, not two (where last-write-wins silently
+  // swaps the box). Serialized by the internal mutex, the second call reloads
+  // the store the first just wrote, so both observe the SAME box.
+  const path = tmpPath("ensure-concurrent");
+  const load = () => loadAuth(path);
+  let saves = 0;
+  const save = async (a) => {
+    saves++;
+    await saveAuth(a, path);
+  };
+  try {
+    const [a, b] = await Promise.all([
+      ensureAuth({ load, save }),
+      ensureAuth({ load, save }),
+    ]);
+    assert.equal(isValidToken(a.box_id), true);
+    assert.equal(isValidToken(a.box_token), true);
+    assert.deepEqual(b, a); // both observe the SAME identity
+    assert.equal(saves, 1); // minted + persisted exactly once
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
 // ----------------------------------------------------------------------------
 // pairing registry
 // ----------------------------------------------------------------------------
@@ -316,10 +341,10 @@ const AUTH = { box_id: HEX32, box_token: HEX32B, created_at: 0 };
 
 // SAFETY — build engines through this helper, never `createAuthEngine` directly.
 //
-// createAuthEngine's saveAuth/deleteAuth default to the REAL box store
-// (~/.manta/auth.json). revoke() with a MATCHING token therefore unlinks that
-// file and mints a fresh identity in it — so a revoke test written without
-// injection rotates the box_id/box_token of whatever machine runs the suite.
+// createAuthEngine's saveAuth DEFAULT targets the real box store
+// (~/.manta/auth.json). revoke() with a MATCHING token therefore mints and
+// persists a fresh identity there — so a revoke test written without injection
+// rotates the box_id/box_token of whatever machine runs the suite.
 // That is not hypothetical: on the dev box (which also hosts the self-hosted CI
 // runner) every `npm test` regenerated the identity on disk while the running
 // manta-server kept the old token in memory, so each manta-native AI tool —
@@ -331,7 +356,6 @@ const AUTH = { box_id: HEX32, box_token: HEX32B, created_at: 0 };
 function engine(opts = {}) {
   return createAuthEngine({
     saveAuth: async () => {},
-    deleteAuth: async () => {},
     // Fresh in-memory device registry with no-op persistence: keeps the
     // device store (devices.json) OFF the real/sandboxed filesystem and
     // isolates each engine so a claim/revoke in one test can't leak into
@@ -582,7 +606,6 @@ test("revoke: valid token deletes box_token from auth.json (BET-357 §2)", async
   const eng = engine({
     auth: initial,
     saveAuth: (a) => saveAuth(a, path),
-    deleteAuth: () => deleteAuth(path),
   });
 
   const r = await eng.revoke({ token: HEX32B });
@@ -618,6 +641,39 @@ test("revoke: valid token deletes box_token from auth.json (BET-357 §2)", async
   await rm(path, { force: true });
 });
 
+test("revoke: whole-box reset is a single atomic store write (BET-771)", async () => {
+  // Regression for the old delete-then-save pair. The on-disk store must
+  // transition old → fresh in ONE write (writeJsonAtomic's temp-then-rename),
+  // never pass through a window where the file is absent — a power-fail there
+  // would leave no store and a reboot would mint a whole new identity.
+  const path = tmpPath("revoke-atomic");
+  const initial = { box_id: HEX32, box_token: HEX32B, created_at: 1000 };
+  await saveAuth(initial, path);
+  let writes = 0;
+  const eng = engine({
+    auth: initial,
+    saveAuth: (a) => {
+      writes++;
+      return saveAuth(a, path);
+    },
+  });
+
+  const r = await eng.revoke({ token: HEX32B });
+  assert.equal(r.ok, true);
+  assert.equal(writes, 1); // exactly one store write — no separate delete step
+  assert.equal(isValidToken(r.box_id), true);
+  assert.notEqual(r.box_id, HEX32);
+  // The store still exists (atomically replaced, never removed) and holds the
+  // fresh identity — no "missing store → reboot re-mints a new box" gap.
+  const onDisk = loadAuth(path);
+  assert.notEqual(onDisk, null);
+  assert.equal(onDisk.box_id, r.box_id);
+  assert.notEqual(onDisk.box_token, HEX32B);
+  assert.equal(isValidToken(onDisk.box_token), true);
+
+  await rm(path, { force: true });
+});
+
 test("revoke: pair + claim after revoke returns the NEW identity, not the old one", async () => {
   // End-to-end: a real revoke is followed by a fresh pair+claim. The claim
   // must surface the new identity (so any device that re-pairs next gets a
@@ -629,7 +685,6 @@ test("revoke: pair + claim after revoke returns the NEW identity, not the old on
   const eng = engine({
     auth: initial,
     saveAuth: (a) => saveAuth(a, path),
-    deleteAuth: () => deleteAuth(path),
   });
 
   await eng.revoke({ token: HEX32B });
@@ -658,25 +713,6 @@ test("revoke: clears any active pairing code (the old identity's code is moot)",
   assert.equal(eng.hasActivePairing(), false);
   const staleClaim = eng.claim({ pairing_code: stale });
   assert.equal(staleClaim.ok, false);
-});
-
-test("deleteAuth: idempotent — missing file is not an error", async () => {
-  const path = tmpPath("delete-missing");
-  // Should not throw, even though the file doesn't exist.
-  await deleteAuth(path);
-  await deleteAuth(path); // twice for good measure
-});
-
-test("deleteAuth: removes the file and the next loadAuth returns null", async () => {
-  const path = tmpPath("delete-roundtrip");
-  try {
-    await writeFile(path, JSON.stringify({ box_id: HEX32, box_token: HEX32B }), "utf-8");
-    assert.equal(loadAuth(path)?.box_token, HEX32B);
-    await deleteAuth(path);
-    assert.equal(loadAuth(path), null);
-  } finally {
-    await rm(path, { force: true });
-  }
 });
 
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
Fixes **BET-771** (audit P3-2) — two low-severity atomicity concerns in `src/server/auth.mjs`.

## 1. `ensureAuth` first-run mint was a check-then-act race
Two concurrent first calls both load a missing store, mint **two different identities**, and last-write-wins — silently swapping the box's identity. Now serialized behind the shared `createMutex` primitive (the same atomicity primitive BET-770 established), so the second caller re-loads after the first has persisted and both observe the **same** box.

## 2. `revoke` whole-box reset was delete-then-save (non-atomic)
The reset unlinked the store, then wrote the fresh identity — a power-fail in between left **no store**, so a reboot re-minted a whole new identity. Now a single atomic write (`writeJsonAtomic` temp-then-rename): the file transitions old → fresh with no window in which it is missing.

Removed the now-orphaned `deleteAuth` export (its only caller was the deleted delete-then-save path) and the `createAuthEngine` `deleteAuth` injectable.

## Tests
- `ensureAuth is single-flight under concurrent first-run calls (BET-771)` — two `Promise.all` first calls return the same identity and persist exactly once.
- `revoke: whole-box reset is a single atomic store write (BET-771)` — exactly one store write, store never absent, holds the fresh identity.

## Verification
- `npm run typecheck` ✅
- `npm test` ✅ (1637 pass, 0 fail)

Base: `origin/main` @ `ef520093`, rebased clean.