### PR TITLE
test(renderer): Settings nested-modal Escape + focus-trap regression (BET-736)

### DIFF
--- a/src/renderer/Settings.test.tsx
+++ b/src/renderer/Settings.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment jsdom
+//
+// Regression tests for nested-modal Escape ownership inside Settings (BET-724,
+// requested by BET-736). BET-724 made the Modal primitive own Escape / focus
+// trap / restore, and Settings' own dialog is built on `useDialog` (not on
+// Modal), so a confirm opened INSIDE Settings (a nested Modal rendered as a
+// child of Settings' dialog) must own Escape and Tab — closing only the
+// confirm, never the Settings dialog around it.
+//
+// Test-only file. Settings is not mounted anywhere else in the suite; this
+// file mounts it for the first time via the shared testHarness `mount()` and
+// stubs `window.api` with the installMockApi pattern, stubbing only the calls
+// Settings makes on mount (getClientVersion / getServerVersion / configGet).
+//
+// Test 1 uses the "Reset all settings?" confirm (confirmReset): it sits on the
+// default General tab, so no tab navigation is needed to reach its trigger.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { act } from "react";
+import { mount, installMockApi, type Harness } from "./testHarness";
+import { Settings } from "./Settings";
+
+// The confirm used for test 1. "Reset all settings?" (confirmReset) opens from
+// the default General tab's Danger zone.
+const CONFIRM_LABEL = "Reset all settings?";
+
+describe("Settings — Escape + nested-confirm ownership (BET-724 regression)", () => {
+  let h: Harness | null = null;
+
+  const stubApi = () =>
+    installMockApi({
+      configGet: () => Promise.resolve({}),
+      getClientVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      getServerVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+    });
+
+  const dialogs = (): HTMLElement[] =>
+    [...h!.container.querySelectorAll<HTMLElement>('[role="dialog"]')];
+
+  const confirmDialog = (): HTMLElement | null =>
+    h!.container.querySelector<HTMLElement>(
+      `[role="dialog"][aria-label="${CONFIRM_LABEL}"]`,
+    );
+
+  const clickResetConfirm = () => {
+    const btn = [...h!.container.querySelectorAll("button")].find(
+      (b) => (b.textContent ?? "").trim() === "Reset all settings…",
+    );
+    expect(btn, "Reset all settings… trigger button").toBeTruthy();
+    act(() => (btn as HTMLButtonElement).click());
+  };
+
+  // Let a Modal's exit animation (0.18s) run to completion and drain the
+  // mock-api promise microtasks.
+  const settle = async () => {
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 400));
+    });
+    await h!.flush();
+  };
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("Escape with the confirm open closes only the confirm — Settings stays mounted, onClose not called", async () => {
+    const closeCalls: number[] = [];
+    stubApi();
+    h = mount(<Settings onClose={() => closeCalls.push(1)} />);
+    await h.flush();
+
+    expect(dialogs().length).toBe(1);
+
+    clickResetConfirm();
+    await h.flush();
+
+    // Confirm is now open: Settings dialog + nested confirm dialog.
+    expect(dialogs().length).toBe(2);
+    const confirm = confirmDialog();
+    expect(confirm, "confirm dialog should be open").toBeTruthy();
+
+    // Focus is trapped inside the confirm; press Escape on its first focusable
+    // (Cancel) — the innermost open Modal owns Escape, so only it closes.
+    const confirmBtn = confirm!.querySelector<HTMLElement>("button");
+    expect(confirmBtn, "confirm has a focusable control").toBeTruthy();
+    act(() => {
+      confirmBtn!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+    await settle();
+
+    // Confirm gone, Settings dialog still mounted, and onClose was NOT called.
+    expect(confirmDialog()).toBeNull();
+    expect(dialogs().length).toBe(1);
+    expect(closeCalls.length).toBe(0);
+  });
+
+  it("Escape with no confirm open closes Settings (onClose called exactly once)", async () => {
+    const closeCalls: number[] = [];
+    stubApi();
+    h = mount(<Settings onClose={() => closeCalls.push(1)} />);
+    await h.flush();
+
+    const search = h.container.querySelector<HTMLElement>(
+      'input[placeholder="Find a setting…"]',
+    );
+    expect(search, "settings search field").toBeTruthy();
+
+    act(() => {
+      search!.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Escape", bubbles: true }),
+      );
+    });
+    await h.flush();
+
+    expect(closeCalls.length).toBe(1);
+  });
+
+  it("with the confirm open, Tab stays within the confirm (Settings' trap does not fight the nested Modal's)", async () => {
+    stubApi();
+    h = mount(<Settings onClose={() => {}} />);
+    await h.flush();
+
+    clickResetConfirm();
+    await h.flush();
+
+    const confirm = confirmDialog();
+    expect(confirm, "confirm dialog should be open").toBeTruthy();
+    const focusables = [
+      ...confirm!.querySelectorAll<HTMLElement>("button"),
+    ];
+    expect(focusables.length).toBe(2); // Cancel + Reset
+
+    // Tab off the LAST focusable in the confirm: the nested Modal's trap wraps
+    // within the confirm, rather than Settings' outer trap claiming the Tab.
+    const last = focusables[focusables.length - 1];
+    last.focus();
+    expect(document.activeElement).toBe(last);
+
+    act(() => {
+      last.dispatchEvent(
+        new KeyboardEvent("keydown", {
+          key: "Tab",
+          bubbles: true,
+          cancelable: true,
+        }),
+      );
+    });
+
+    // Wrapped to the confirm's first control (Cancel) — still inside it.
+    expect(document.activeElement).toBe(focusables[0]);
+    expect(confirm!.contains(document.activeElement)).toBe(true);
+  });
+});


### PR DESCRIPTION
## BET-736 — Settings.tsx test harness + nested-modal Escape regression tests

Test-only. Adds `src/renderer/Settings.test.tsx` mounting `Settings` for the
first time in the suite (previously only imported by `App.tsx`). No production
code touched — `git diff --stat` on the base shows one new test file only.

Uses the two existing harness patterns (D1): `mount()` from
`src/renderer/testHarness.tsx` + `installMockApi` (the ChatPanel.harness.test
pattern). Stubs only what `Settings` calls on mount: `configGet`,
`getClientVersion`, `getServerVersion` (D3). No new shared helper exported (D1)
— no second test file needed it in this diff.

Exactly the three tests in the ticket (D4):

1. **Escape with the confirm open closes only the confirm.** Uses the
   **"Reset all settings?"** confirm (`confirmReset`): it sits on the default
   General tab, so the trigger is mounted without tab navigation. Opens it,
   presses Escape on the confirm's focusable, asserts the confirm's dialog is
   removed, the Settings dialog is still mounted, and `onClose` was NOT called.
2. **Escape with no confirm open closes Settings** — `onClose` called exactly once.
3. **Tab does not double-trap** — with the confirm open, focusing the confirm's
   last control and Tabbing wraps within the confirm (Cancel), never leaking to
   Settings' outer trap (each `useFocusTrap` bails when focus is inside a
   nested `[role="dialog"]` that isn't its own container).

**Which confirm for test 1:** `Reset all settings?` (`confirmReset`), per the
ticket's "pick one and say which".

### Anti-spaghetti / contract notes
- No production code changed: not `Settings.tsx`, `Modal.tsx`, `ConfirmModal.tsx`, `useFocusTrap.ts`, or `testHarness.tsx`.
- No snapshot / visual baselines. No neighbouring test files touched.

**Base: origin/main @ `ef520093`**

**Files changed:** 1.
- `src/renderer/Settings.test.tsx`

**Verification results:**
- PR branch (`multica/BET-736-settings-test-harness` @ `HEAD`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0. vitest 2369 passed / 7 skipped (130 files), node:test 1637 pass / 0 fail. Failures: none. log sha256: `32db37a0b2ee15c67505a9e7e83840fadf373b04e6eabf8494a40d57278e4301`
- Base (`main` @ `ef520093`): not re-run separately — the PR branch differs from base by exactly one additive test file and both gates were run on the PR branch; the added tests are the only delta.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`.
