### PR TITLE
ios: remove production-dead MantaAuthClient.persist(onSuccess:) (BET-719)

### DIFF
--- a/mobile/native/MantaUI/MantaAuthClient.swift
+++ b/mobile/native/MantaUI/MantaAuthClient.swift
@@ -53,12 +53,4 @@ struct MantaAuthClient: Sendable {
             return .network
         }
     }
-
-    /// Persist a successful claim to the Keychain (S1a). Returns true on
-    /// success (or when the outcome was not a claim success).
-    func persist(onSuccess outcome: MantaPairing.ClaimOutcome, serverURL: URL) throws {
-        guard case .success(let boxToken, let boxId, _) = outcome else { return }
-        let credentials = MantaCredentials(serverUrl: serverURL.absoluteString, boxId: boxId, boxToken: boxToken)
-        try KeychainCredentialStore.shared.save(credentials)
-    }
 }

--- a/mobile/native/MantaUI/MantaOnboarding.swift
+++ b/mobile/native/MantaUI/MantaOnboarding.swift
@@ -216,10 +216,11 @@ final class MantaOnboardingFlow: ObservableObject {
         // Progress stages are informational; the volunteer device-registry name
         // is surfaced server-side so a linked device is identifiable (§6.3).
         let name = UIDevice.current.name
-        // A resolvable claim target is a precondition — without one the response
-        // could never have been a success, so surface the same failure class the
-        // unreachable code path used to.
-        guard let serverURL = claimTarget(payload) else {
+        // claimBaseURL is the same resolution MantaAuthClient.claim performs; a
+        // nil base can never produce a .success outcome, so failing here is the
+        // same classification arriving one step earlier — and it removes the
+        // need for a placeholder URL that could never be a real claim target.
+        guard let serverURL = MantaPairing.claimBaseURL(payload) else {
             phase = .failure(.serverError)
             return
         }
@@ -260,10 +261,6 @@ final class MantaOnboardingFlow: ObservableObject {
         case .serverError, .invalidResponse:
             phase = .failure(.serverError)
         }
-    }
-
-    private func claimTarget(_ payload: MantaPairing.PairPayload) -> URL? {
-        MantaPairing.claimBaseURL(payload)
     }
 
     private func requestNotificationAuthorization() async {

--- a/mobile/native/MantaUI/MantaOnboarding.swift
+++ b/mobile/native/MantaUI/MantaOnboarding.swift
@@ -216,7 +216,13 @@ final class MantaOnboardingFlow: ObservableObject {
         // Progress stages are informational; the volunteer device-registry name
         // is surfaced server-side so a linked device is identifiable (§6.3).
         let name = UIDevice.current.name
-        let serverURL = claimTarget(payload)
+        // A resolvable claim target is a precondition — without one the response
+        // could never have been a success, so surface the same failure class the
+        // unreachable code path used to.
+        guard let serverURL = claimTarget(payload) else {
+            phase = .failure(.serverError)
+            return
+        }
         // Stage 1: the claim request starts.
         activeLinkingStage = 0
         let outcome = await auth.claim(payload, deviceName: name)
@@ -256,9 +262,8 @@ final class MantaOnboardingFlow: ObservableObject {
         }
     }
 
-    private func claimTarget(_ payload: MantaPairing.PairPayload) -> URL {
+    private func claimTarget(_ payload: MantaPairing.PairPayload) -> URL? {
         MantaPairing.claimBaseURL(payload)
-            ?? URL(string: "https://")!
     }
 
     private func requestNotificationAuthorization() async {

--- a/mobile/native/MantaUITests/MantaAuthClientTests.swift
+++ b/mobile/native/MantaUITests/MantaAuthClientTests.swift
@@ -90,37 +90,6 @@ final class MantaAuthClientTests: XCTestCase {
         XCTAssertEqual(capturedBody?["name"] as? String, "My iPhone")
     }
 
-    func testClaimSuccessPersistsCredentialsToKeychain() async throws {
-        MockURLProtocol.handler = { request in
-            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
-            let body = ["box_token": self.box, "box_id": self.box, "device_id": "dev_1"]
-            let data = try! JSONSerialization.data(withJSONObject: body)
-            return (response, data)
-        }
-        let client = makeClient()
-        let outcome = await client.claim(serverURL: URL(string: "https://\(box).boxes.mantaui.com")!, code: "123456")
-        XCTAssertEqual(MantaPairing.classifyClaim(status: 200, body: ["box_token": box, "box_id": box, "device_id": "dev_1"]), outcome)
-
-        try client.persist(onSuccess: outcome, serverURL: URL(string: "https://\(box).boxes.mantaui.com")!)
-        let stored = try KeychainCredentialStore.shared.load()
-        XCTAssertEqual(stored?.boxToken, box)
-        XCTAssertEqual(stored?.boxId, box)
-        XCTAssertEqual(stored?.serverUrl, "https://\(box).boxes.mantaui.com")
-    }
-
-    func testClaimWrongCodeDoesNotPersist() async throws {
-        MockURLProtocol.handler = { request in
-            let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
-            return (response, Data("{\"error\":\"no\"}".utf8))
-        }
-        let client = makeClient()
-        let outcome = await client.claim(serverURL: URL(string: "https://\(box).boxes.mantaui.com")!, code: "111111")
-        XCTAssertEqual(outcome, .wrongCode)
-
-        try client.persist(onSuccess: outcome, serverURL: URL(string: "https://\(box).boxes.mantaui.com")!)
-        XCTAssertNil(try KeychainCredentialStore.shared.load())
-    }
-
     func testClaimNetworkFailureClassifiesUnreachable() async throws {
         MockURLProtocol.handler = { _ in
             throw URLError(.notConnectedToInternet)

--- a/mobile/native/MantaUITests/MantaAuthClientTests.swift
+++ b/mobile/native/MantaUITests/MantaAuthClientTests.swift
@@ -90,6 +90,28 @@ final class MantaAuthClientTests: XCTestCase {
         XCTAssertEqual(capturedBody?["name"] as? String, "My iPhone")
     }
 
+    func testClaimSuccessClassifiesSuccess() async throws {
+        MockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            let body = ["box_token": self.box, "box_id": self.box, "device_id": "dev_1"]
+            let data = try! JSONSerialization.data(withJSONObject: body)
+            return (response, data)
+        }
+        let client = makeClient()
+        let outcome = await client.claim(serverURL: URL(string: "https://\(box).boxes.mantaui.com")!, code: "123456")
+        XCTAssertEqual(MantaPairing.classifyClaim(status: 200, body: ["box_token": box, "box_id": box, "device_id": "dev_1"]), outcome)
+    }
+
+    func testClaimWrongCodeClassifiesWrongCode() async throws {
+        MockURLProtocol.handler = { request in
+            let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
+            return (response, Data("{\"error\":\"no\"}".utf8))
+        }
+        let client = makeClient()
+        let outcome = await client.claim(serverURL: URL(string: "https://\(box).boxes.mantaui.com")!, code: "111111")
+        XCTAssertEqual(outcome, .wrongCode)
+    }
+
     func testClaimNetworkFailureClassifiesUnreachable() async throws {
         MockURLProtocol.handler = { _ in
             throw URLError(.notConnectedToInternet)


### PR DESCRIPTION
Opened automatically for `multica/BET-719-remove-persist-onsuccess`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-719.