### PR TITLE
fix(server): drop expired one-shot schedules so yearless crons can't re-fire (BET-778)

### DIFF
--- a/src/server/schedule.mjs
+++ b/src/server/schedule.mjs
@@ -149,6 +149,39 @@ export function cronMatches(expr, date) {
   return true; // both wildcard
 }
 
+// The first instant at or after `from` (minute resolution) at which `cron`
+// fires, or null if there is none within `maxDays`. Pure.
+//
+// The day-level pre-test reuses cronMatches with the minute+hour fields
+// replaced by "*", so a non-matching day costs ONE call instead of 1440.
+// That keeps the worst case (a cron whose date never occurs, e.g. 31 Feb)
+// at ~400 calls rather than ~576,000 — and this runs once per job creation,
+// never in the tick.
+export function firstCronMatchAtOrAfter(cron, from, { maxDays = 400 } = {}) {
+  const fields = String(cron).trim().split(/\s+/);
+  if (fields.length !== 5) return null;
+  const dayExpr = `* * ${fields[2]} ${fields[3]} ${fields[4]}`;
+
+  const cursor = new Date(from.getTime());
+  cursor.setSeconds(0, 0);
+
+  for (let day = 0; day <= maxDays; day++) {
+    const dayStart = new Date(cursor.getFullYear(), cursor.getMonth(), cursor.getDate());
+    if (cronMatches(dayExpr, dayStart)) {
+      // Walk the minutes of this day, starting at `cursor` on the first day.
+      const probe = new Date(cursor.getTime());
+      while (probe.getDate() === dayStart.getDate() && probe.getMonth() === dayStart.getMonth()) {
+        if (cronMatches(cron, probe)) return probe;
+        probe.setMinutes(probe.getMinutes() + 1);
+      }
+    }
+    // Advance to the start of the next day.
+    cursor.setFullYear(dayStart.getFullYear(), dayStart.getMonth(), dayStart.getDate() + 1);
+    cursor.setHours(0, 0, 0, 0);
+  }
+  return null;
+}
+
 // Stable minute key in LOCAL time: "YYYY-MM-DDTHH:mm". Used as the dedup guard
 // so a job fires at most once per minute even though the poller ticks twice.
 export function minuteKey(date) {
@@ -241,6 +274,13 @@ export async function createJob(
     return { ok: false, error: `invalid kind "${kind}"` };
 
   const jobs = await load();
+  const createdAt = now().getTime();
+  // A one-shot has exactly one due instant. Stamping it at creation is what
+  // lets the tick drop a job whose moment has passed instead of leaving a
+  // yearless cron to re-match next year. Recurring jobs have no due instant.
+  const dueAt = recurring
+    ? null
+    : (firstCronMatchAtOrAfter(cron.trim(), new Date(createdAt))?.getTime() ?? null);
   const job = {
     id: genId(),
     cron: cron.trim(),
@@ -250,7 +290,8 @@ export async function createJob(
     kind,
     sessionID,
     directory: directory || "",
-    createdAt: now().getTime(),
+    createdAt,
+    dueAt,
     lastFiredMinute: null,
   };
   jobs.push(job);
@@ -321,7 +362,7 @@ export function createScheduler({
       const survivors = [];
       const firedSessions = new Set();
 
-      for (const job of jobs) {
+      for (let job of jobs) {
         // Disabled jobs never fire — they were auto-disabled (dead cwd) or
         // manually disabled by the user. Just persist them as-is.
         if (job.disabled) {
@@ -351,6 +392,24 @@ export function createScheduler({
 
         const due = job.lastFiredMinute !== key && cronMatches(job.cron, when);
         if (!due) {
+          // A one-shot whose due instant has passed never fires (there is no
+          // catch-up). Dropping it here is what stops a yearless cron re-matching
+          // 12 months later, and is what keeps the store from accumulating
+          // never-fired jobs. `dueAt == null` covers jobs created before this
+          // field existed AND crons with no match in range — those keep the old
+          // behaviour rather than being silently deleted.
+          if (!job.recurring && job.dueAt === undefined) {
+            // Legacy job created before `dueAt` existed: derive it once from the
+            // fields every job already has, stamp it, and let the rule below apply
+            // on this same tick. This is why no migration script is needed.
+            job = { ...job, dueAt: firstCronMatchAtOrAfter(job.cron, new Date(job.createdAt))?.getTime() ?? null };
+            mutated = true;
+          }
+          if (!job.recurring && typeof job.dueAt === "number" && when.getTime() > job.dueAt) {
+            console.warn(`[schedule] drop one-shot ${job.id}: due instant passed without firing`);
+            mutated = true;
+            continue; // not pushed to survivors
+          }
           survivors.push(job);
           continue;
         }

--- a/src/server/schedule.test.mjs
+++ b/src/server/schedule.test.mjs
@@ -6,6 +6,7 @@ import {
   minuteKey,
   cronForInstant,
   isJobFireable,
+  firstCronMatchAtOrAfter,
   createJob,
   createScheduler,
 } from "./schedule.mjs";
@@ -550,4 +551,145 @@ test("tick does not re-evaluate already-disabled jobs", async () => {
   assert.equal(h.sent.length, 0);
   assert.equal(h.jobs.length, 1);
   assert.equal(h.jobs[0].disabled, true);
+});
+
+// ----------------------------------------------------------------------------
+// firstCronMatchAtOrAfter — BET-778 one-shot expiry
+// ----------------------------------------------------------------------------
+
+test("firstCronMatchAtOrAfter returns the exact instant when from is before it", () => {
+  const res = firstCronMatchAtOrAfter("30 14 15 3 *", localDate(2026, 3, 10, 0, 0));
+  assert.equal(res?.getTime(), localDate(2026, 3, 15, 14, 30).getTime());
+});
+
+test("firstCronMatchAtOrAfter at-or-after returns the same minute when from is exactly on it", () => {
+  const res = firstCronMatchAtOrAfter("30 14 15 3 *", localDate(2026, 3, 15, 14, 30));
+  assert.equal(res?.getTime(), localDate(2026, 3, 15, 14, 30).getTime());
+});
+
+test("firstCronMatchAtOrAfter for a daily cron with from at 10:00 returns next day 09:00", () => {
+  const res = firstCronMatchAtOrAfter("0 9 * * *", localDate(2026, 6, 20, 10, 0));
+  assert.equal(res?.getTime(), localDate(2026, 6, 21, 9, 0).getTime());
+});
+
+test("firstCronMatchAtOrAfter for an impossible date returns null without hanging", () => {
+  // 30 February never occurs.
+  const res = firstCronMatchAtOrAfter("0 0 30 2 *", localDate(2026, 1, 1, 0, 0));
+  assert.equal(res, null);
+});
+
+// ----------------------------------------------------------------------------
+// createJob — dueAt stamping (BET-778)
+// ----------------------------------------------------------------------------
+
+test("createJob stores a dueAt equal to the matching instant for a one-shot", async () => {
+  const { ok, job } = await createJob(
+    {
+      cron: "0 9 18 8 *",
+      prompt: "reset",
+      recurring: false,
+      sessionID: "ses_x",
+      now: () => localDate(2026, 8, 13, 9, 0),
+    },
+    { load: async () => [], save: async () => {} },
+  );
+  assert.equal(ok, true);
+  assert.equal(job.dueAt, localDate(2026, 8, 18, 9, 0).getTime());
+});
+
+test("createJob stores dueAt null for a recurring job", async () => {
+  const { ok, job } = await createJob(
+    {
+      cron: "0 9 * * *",
+      prompt: "check",
+      recurring: true,
+      sessionID: "ses_x",
+      now: () => localDate(2026, 8, 13, 9, 0),
+    },
+    { load: async () => [], save: async () => {} },
+  );
+  assert.equal(ok, true);
+  assert.equal(job.dueAt, null);
+});
+
+// ----------------------------------------------------------------------------
+// createScheduler.tick — drop an expired one-shot (BET-778)
+// ----------------------------------------------------------------------------
+
+test("tick drops a one-shot whose dueAt is in the past without firing", async () => {
+  const now = localDate(2026, 8, 19, 9, 0);
+  const expired = {
+    ...baseJob,
+    id: "expired1",
+    cron: "0 9 18 8 *",
+    recurring: false,
+    dueAt: localDate(2026, 8, 18, 9, 0).getTime(),
+  };
+  const h = harness([expired], now);
+  const { tick } = createScheduler(h.deps);
+  await tick();
+  assert.equal(h.sent.length, 0, "expired one-shot must not fire");
+  assert.equal(h.jobs.length, 0, "expired one-shot is not in survivors");
+});
+
+test("tick FIRES a one-shot at its due minute (tie goes to firing, not expiry)", async () => {
+  const now = localDate(2026, 8, 18, 9, 0);
+  const due = {
+    ...baseJob,
+    id: "due1",
+    cron: "0 9 18 8 *",
+    recurring: false,
+    dueAt: localDate(2026, 8, 18, 9, 0).getTime(),
+  };
+  const h = harness([due], now);
+  const { tick } = createScheduler(h.deps);
+  await tick();
+  assert.equal(h.sent.length, 1, "one-shot at its due minute fires");
+  assert.equal(h.jobs.length, 0, "fired one-shot is removed as before");
+});
+
+test("tick does NOT drop a recurring job with a past dueAt present", async () => {
+  const now = localDate(2026, 6, 20, 15, 3); // not a */5 minute → not due
+  const recurring = { ...baseJob, id: "rec1", dueAt: 0 };
+  const h = harness([recurring], now);
+  const { tick } = createScheduler(h.deps);
+  await tick();
+  assert.equal(h.sent.length, 0);
+  assert.equal(h.jobs.length, 1, "recurring job survives despite past dueAt");
+  assert.equal(h.jobs[0].id, "rec1");
+});
+
+test("tick stamps and drops a legacy one-shot with no dueAt and a PAST cron date on the same tick", async () => {
+  const now = localDate(2026, 8, 19, 9, 0);
+  const legacy = {
+    ...baseJob,
+    id: "legacy1",
+    cron: "0 9 18 8 *",
+    recurring: false,
+    createdAt: localDate(2026, 8, 1, 0, 0).getTime(),
+  };
+  delete legacy.dueAt;
+  const h = harness([legacy], now);
+  const { tick } = createScheduler(h.deps);
+  await tick();
+  assert.equal(h.sent.length, 0, "stale legacy one-shot must not fire");
+  assert.equal(h.jobs.length, 0, "stale legacy one-shot is dropped this tick");
+});
+
+test("tick stamps a legacy one-shot with a FUTURE cron date and lets it survive", async () => {
+  const now = localDate(2026, 8, 13, 9, 0);
+  const legacy = {
+    ...baseJob,
+    id: "legacy2",
+    cron: "0 9 18 8 *",
+    recurring: false,
+    createdAt: localDate(2026, 8, 1, 0, 0).getTime(),
+  };
+  delete legacy.dueAt;
+  const h = harness([legacy], now);
+  const { tick } = createScheduler(h.deps);
+  await tick();
+  assert.equal(h.sent.length, 0, "not due yet, must not fire");
+  assert.equal(h.jobs.length, 1, "future legacy one-shot survives");
+  assert.equal(h.jobs[0].dueAt, localDate(2026, 8, 18, 9, 0).getTime());
 });


### PR DESCRIPTION
## What

A one-shot scheduled job carries a 5-field cron with no year. A job that never
fires (box off, restart, tick missed the minute) was never dropped — deliberately
no catch-up — so it lingered in `~/.manta/schedule.json` and could re-match the
same date+time a year later, firing a stale prompt/push ~12 months late.

This makes the documented "no catch-up — fire-once-when-due" contract actually
hold in the code:

1. **`firstCronMatchAtOrAfter`** — a bounded pure helper (reuses `cronMatches`,
   day-level pre-test so impossible dates terminate in ~400 calls not ~576k).
2. **`createJob` stamps `dueAt`** on non-recurring jobs at creation (recurring ⇒
   `null`). Enabled for both the renderer `fireAt` path and the AI `cron` path
   since `fireAt` is rendered into `cron` first — one code path.
3. **Tick drops an expired one-shot** in the `!due` branch when
   `when > dueAt` (strict `>`, so a job is never dropped during its own due
   minute — the fire branch wins ties). Legacy jobs with no `dueAt` are lazily
   stamped once on the same tick and then dropped/survive by the same rule —
   the nine stale jobs on the live store clear on the first tick after deploy,
   no migration script.

Out of scope, per the issue decision: no catch-up, no missed-job notification,
no recurring-behaviour change, no cron parser, no migration/backfill.

## Scope

- `src/server/schedule.mjs` — 3 changes (helper + createJob `dueAt` + tick drop)
- `src/server/schedule.test.mjs` — 11 new tests (helper: 4, createJob: 2, tick: 5)

No new bus event kinds, no new config, no new API surface.
No `mobile/www/`, no renderer/IPC changes.

**Files changed:** `2` files.

**Verification results:**
- PR branch (`multica/BET-778-oneshot-cron-year` @ `455f6210`):
  - typecheck: exit `0`. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit `0`, `1658` pass / `0` fail / `0` skip. Failures: none. log sha256: `ee1656e19c0dd01213f36915339d8bff1f6b84002a39587000ced0606f7642e6`
- Base (`main` @ `9940cf8b`): not re-run locally — this PR touches only
  `src/server/schedule.mjs` + its test file; full suite on the PR branch is
  0 failures, so no base re-run is warranted (per workflow, reviewer may
  spot-check).
- **Conclusion:** `0` failures on the PR branch. No new failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.
Base: origin/main @ `9940cf8b`
