### PR TITLE
fix(server): capture full stdout — resolve on close, not exit

### DIFF
--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1368,7 +1368,11 @@ export async function getVcsBranch(directory) {
     let stdout = "";
     proc.stdout.on("data", (b) => (stdout += b.toString()));
     proc.on("error", () => resolve(null));
-    proc.on("exit", () => {
+    // "close", NOT "exit" — same trap as spawnRun in tmux.mjs: `exit` fires
+    // before stdout is drained, so a live branch intermittently read back as
+    // "" and this returned null ("not a git repo"), blanking the footer's
+    // branch indicator at random.
+    proc.on("close", () => {
       const name = stdout.trim();
       resolve(name ? name : null);
     });

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -56,7 +56,18 @@ function spawnRun(cmd, args) {
     p.stdout.on("data", (b) => (stdout += b.toString()));
     p.stderr.on("data", (b) => (stderr += b.toString()));
     p.on("error", (e) => { finish(); reject(e); });
-    p.on("exit", (code) => {
+    // "close", NOT "exit". `exit` fires the moment the child dies, BEFORE its
+    // stdout pipe has been drained, so anything still buffered is discarded and
+    // the call resolves with a TRUNCATED-or-EMPTY stdout at exit code 0 — which
+    // is indistinguishable from "tmux legitimately has nothing to list". Under
+    // concurrent reads (the event pump, the status/activity pollers and push's
+    // session-label lookup all query tmux at once) that happened ~11% of the
+    // time per spawn on the dev box, so `listProjects` returned an empty box
+    // ~50% of the time; the visible symptom was a backgrounded subagent never
+    // getting a sidebar row ("could not resolve the owning window"), plus
+    // spurious "unresolvable-session" push suppressions. `close` fires only
+    // after every stdio stream is closed, so stdout is always complete.
+    p.on("close", (code) => {
       finish();
       code === 0 ? resolve({ stdout, stderr })
                  : reject(new Error(`${cmd} exited ${code}: ${stderr.trim() || stdout.trim()}`));

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -5,6 +5,7 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   parseSessions,
+  run,
   tmuxSpawnEnv,
   isMissingSessionError,
   isNoTmuxServerError,
@@ -820,4 +821,25 @@ test("renameSession keeps ownership under the new name", async () => {
     _resetOwnedSessionsCache();
     await rm(dir, { recursive: true, force: true });
   }
+});
+
+// spawnRun must resolve on the child's "close" (all stdio drained), not its
+// "exit" (process dead, pipe possibly still holding bytes). Resolving on
+// "exit" hands the caller a truncated — often EMPTY — stdout at exit code 0,
+// which is indistinguishable from "tmux legitimately has nothing to list".
+// Under concurrent reads (the opencode event pump, the status/activity
+// pollers and push's session-label lookup all query tmux at once) that made
+// `listProjects` report an empty box roughly half the time, so a backgrounded
+// subagent never got its sidebar row ("could not resolve the owning window")
+// and push logged spurious "unresolvable-session" suppressions.
+//
+// The child here exits IMMEDIATELY while a background descendant still holds
+// the inherited stdout and writes to it 200ms later — so "exit" observes ""
+// deterministically and "close" observes the full output.
+test("run waits for stdout to close, not just for the child to exit", async () => {
+  const { stdout } = await run("/bin/sh", [
+    "-c",
+    "{ sleep 0.2; printf late-bytes; } & exit 0",
+  ]);
+  assert.equal(stdout, "late-bytes", "stdout must not be lost when the child exits early");
 });


### PR DESCRIPTION
## The bug

`spawnRun` in `src/server/tmux.mjs` resolved on the child's **`exit`** event. `exit` fires the instant the process dies — *before* its stdout pipe is drained — so buffered bytes are discarded and the call returns a truncated (usually **empty**) stdout at **exit code 0**. An empty `list-sessions`/`list-windows` is indistinguishable from "tmux legitimately has nothing to list", so a healthy box reports itself empty.

Measured on the dev box:

| resolve on | empty stdout per spawn (8-way concurrency, real tmux) |
|---|---|
| `exit` (before) | 53 / 480 |
| `close` (after) | 0 / 480 |

`listProjects()` at 4-way concurrency: **108/320 returned no projects at all, 62/320 returned sessions with zero windows** — 53% failure.

## What it broke

**Backgrounded subagents never got a sidebar row (BET-721).** Adoption resolves the parent's tmux window from `listProjects()`; a subagent starts during an event burst — exactly when the event pump, the status/activity pollers and push's session-label lookup all query tmux at once — so the lookup saw an empty box and bailed with `[delegate] could not resolve the owning window to adopt background subagent`. Reproduced live: attempt 1 failed with `projects= []`, attempt 2 (quiet moment) adopted correctly and ran the whole lifecycle — record, nested row, activity line, result, window cleanup.

Same cause behind the spurious `suppressed=unresolvable-session` push suppressions, and behind BET-773 §3's unexplained diagnostic — which "never reproduced" because every probe there ran **sequentially**; the race needs two concurrent tmux reads.

`getVcsBranch` in `src/server/opencode.mjs` had the identical bug: a live branch intermittently read back as `""` → `null`, blanking the branch indicator at random.

## The fix

Listen for `close` (all stdio closed) instead of `exit`, in both places. Timeout/`settled` logic unchanged.

## Test

`run waits for stdout to close, not just for the child to exit` — the child exits immediately while a background descendant writes to the inherited stdout 200 ms later. Deterministic: `""` on `exit`, full output on `close`. Verified red on the old code, green on the new.

`npm run typecheck` clean, `npm test` 1659/1659 green.