### PR TITLE
feat(shared): forge seam L0 — pure vocabulary, remote parsing, normalisers (BET-785)

### DIFF
--- a/src/shared/forge.d.mts
+++ b/src/shared/forge.d.mts
@@ -1,0 +1,99 @@
+// Hand-written type declarations for forge.mjs. The implementation is plain
+// JS so any server code imports it natively; the renderer imports through
+// bundler resolution. Keep in sync with src/shared/forge.mjs.
+
+// The forges we model. Deliberately only these two — adding a kind is a
+// design decision that ships with that forge's adapter (spec §3.5).
+export type ForgeKind = "github" | "gitlab";
+
+// A normalised pull-request / merge-request state. Four values only; the
+// forge raw values ("opened", "locked", merged-as-closed) are reconciled by
+// `normalizePrState`, never surfaced here.
+export type PullRequestState = "draft" | "open" | "merged" | "closed";
+
+// The normalised CI rollup — a traffic-light for logic. The raw per-check
+// array is kept separately for display (spec §3.4②).
+export type CheckRollup = "green" | "yellow" | "red" | "none";
+
+// A normalised review verdict. GitLab has no review object at all; this is
+// what the box-buffered draft review produces.
+export type ReviewVerdict =
+  | "approved"
+  | "changes_requested"
+  | "commented"
+  | "pending";
+
+// The shared PR/MR type. Always normalised, never a raw forge payload.
+// `number` is GitHub `number` and GitLab `iid` — never GitLab's global `id`.
+// `mergeable` is `null` while the forge is still computing it. `mergeBlockedReason`
+// is human readable (e.g. "checks failing", "not approved").
+export type PullRequest = {
+  number: number;
+  title: string;
+  body: string;
+  url: string;
+  state: PullRequestState;
+  draft: boolean;
+  headRef: string;
+  baseRef: string;
+  headSha: string;
+  author: string;
+  reviewers: string[];
+  mergeable: true | false | null;
+  mergeBlockedReason: string | null;
+  unresolvedThreads: number;
+};
+
+// A normalised per-check row, as fed to `rollupChecks`. Already normalised at
+// the adapter boundary — its `status`/`conclusion` are the adapter's words,
+// not a raw forge enum.
+export type ForgeCheck = {
+  name: string;
+  status?: string;
+  conclusion?: string;
+  url?: string;
+};
+
+// Parse a git remote URL into its forge identity. Returns
+// `{ kind, host, owner, repo }` (lowercased; `owner` is the full
+// `group/subgroup` path for GitLab) or `null` for a local path, a non-URL
+// string, an empty string, `undefined`, or a non-github/gitlab host.
+// Credentials in the URL are always stripped.
+export function detectForge(
+  remoteUrl: unknown,
+): { kind: ForgeKind; host: string; owner: string; repo: string } | null;
+
+// Canonical stable join key `host/owner/repo`, lowercased, no `.git`, no
+// trailing slash. Identical for the HTTPS and SSH forms of the same repo.
+export function repoKey(repo: {
+  host: string;
+  owner: string;
+  repo: string;
+}): string;
+
+// Normalise a forge's raw PR/MR state into the shared `PullRequestState`.
+// Handles GitLab `opened`/`locked` and GitHub merged-as-closed. Throws on an
+// unknown raw state.
+export function normalizePrState(
+  raw: { state: string; merged?: boolean; draft?: boolean },
+  kind: ForgeKind,
+): PullRequestState;
+
+// Roll the already-normalised per-check array up to a single traffic-light.
+// Returns ONLY the tri-state; never mutates the input array.
+export function rollupChecks(checks: ForgeCheck[]): CheckRollup;
+
+// A typed error for a capability a forge does not have. Carries `.kind` and
+// `.capability` so a capability gap is a value to pattern-match, not a thrown
+// string.
+export class UnsupportedByForgeError extends Error {
+  readonly kind: ForgeKind;
+  readonly capability: string;
+  constructor(kind: ForgeKind, capability: string);
+}
+
+// Construct an {@link UnsupportedByForgeError}.
+export function unsupportedByForge(
+  kind: ForgeKind,
+  capability: string,
+): UnsupportedByForgeError;

--- a/src/shared/forge.mjs
+++ b/src/shared/forge.mjs
@@ -1,0 +1,328 @@
+// forge.mjs — the L0 forge seam: pure vocabulary for the MantaUI forge
+// integration (BET-785).
+//
+// This is the layer EVERYTHING else in the forge project imports from — the
+// repo probe (which normalises a git remote URL) and the GitHub / GitLab
+// adapters (which normalise raw forge payloads). It is designed against
+// GitLab's documentation as well as GitHub's, BEFORE either adapter exists,
+// exactly so the shared types are not GitHub-shaped with GitLab filed off.
+//
+// Contract (design spec §3.1 / §3.2 L0):
+//   - 100% pure. No `fetch`, no `node:fs`, no `node:child_process`, no
+//     network, no filesystem, no spawn. The only global used is `URL`, which
+//     is a pure string parser, not I/O. If this module ever needs I/O the
+//     design is wrong.
+//   - Named exports only. No default export, matching the rest of src/shared/.
+//   - Unknown input is rejected loudly (returned `null` or a thrown typed
+//     error) rather than coerced.
+//
+// Vocabulary discipline (spec §3.1):
+//   - The shared PR/MR type is named `PullRequest`, deliberately (the term
+//     users already know on both forges) — but its fields are NORMALISED
+//     shapes, never a raw forge payload. GitLab's per-project `iid` maps to
+//     `number`; GitLab's disjoint Issues and absent review object are
+//     reconciled at the adapter boundary, not here.
+//   - No `gitea` / `bitbucket` kind. Out of scope and a settled design
+//     decision (spec §3.5 sketches gitea as ~a day once the seam exists).
+
+/**
+ * The forges we model. Deliberately only these two — adding a kind is a
+ * design decision that ships with that forge's adapter, not a guess here.
+ * @typedef {"github" | "gitlab"} ForgeKind
+ */
+
+/**
+ * A normalised pull-request / merge-request state. Four values only. GitLab
+ * emits `"opened"` (not `"open"`) and also has `"locked"`; GitHub reports a
+ * merged PR as `closed` + a separate `merged` flag. Those forge raw values
+ * are reconciled by `normalizePrState`, never surfaced here.
+ * @typedef {"draft" | "open" | "merged" | "closed"} PullRequestState
+ */
+
+/**
+ * The normalised CI rollup — a traffic-light. Drives logic (can I merge,
+ * should I nudge). The raw per-check array is kept separately for display.
+ * This tri-state / raw-list split is spec §3.4②.
+ * @typedef {"green" | "yellow" | "red" | "none"} CheckRollup
+ */
+
+/**
+ * A normalised review verdict. GitLab has no review object at all (it has
+ * approve/unapprove booleans and a merge-status enum); this shared verdict is
+ * what the box-buffered draft review produces. Spec §3.1.
+ * @typedef {"approved" | "changes_requested" | "commented" | "pending"} ReviewVerdict
+ */
+
+/**
+ * The shared PR/MR type. Always normalised, never a raw forge payload.
+ * `number` is GitHub `number` and GitLab `iid` — never GitLab's global `id`.
+ * `mergeable` is `null` while the forge is still computing it (caller retries).
+ * `mergeBlockedReason` is human readable (e.g. "checks failing", "not
+ * approved') so "cannot merge" means something to a user. Spec §3.1 / §3.4②.
+ * @typedef {{
+ *   number: number,
+ *   title: string,
+ *   body: string,
+ *   url: string,
+ *   state: PullRequestState,
+ *   draft: boolean,
+ *   headRef: string,
+ *   baseRef: string,
+ *   headSha: string,
+ *   author: string,
+ *   reviewers: string[],
+ *   mergeable: true | false | null,
+ *   mergeBlockedReason: string | null,
+ *   unresolvedThreads: number,
+ * }} PullRequest
+ */
+
+// ---------------------------------------------------------------------------
+// Forge detection
+// ---------------------------------------------------------------------------
+
+// Remote hosts we recognise, and the kind each maps to. Anything else is out
+// of scope (self-hosted host mapping is a deliberate design decision that
+// arrives with the GitLab adapter) and rejected.
+const HOST_KIND = Object.freeze({
+  "github.com": "github",
+  "gitlab.com": "gitlab",
+});
+
+/**
+ * Parse a git remote URL into its forge identity.
+ *
+ * Handles the HTTPS, `ssh://` and scp-like (`git@host:owner/repo.git`) forms,
+ * GitHub's flat `owner/repo`, GitLab's nested `group/subgroup/project`,
+ * trailing slashes, an optional `.git` suffix, and strips any credentials
+ * that appear in the URL.
+ *
+ * Returns `{ kind, host, owner, repo }` — all lowercased, owner is the full
+ * `group/subgroup` path for GitLab. `host` is "github.com" | "gitlab.com".
+ *
+ * Returns `null` for a local path, a non-URL string, an empty string,
+ * `undefined`, and any host that is not github.com or gitlab.com.
+ *
+ * A credential appearing anywhere in the return value is a security bug —
+ * there is an explicit test pinning that.
+ *
+ * @param {unknown} remoteUrl
+ * @returns {{ kind: ForgeKind, host: string, owner: string, repo: string } | null}
+ */
+export function detectForge(remoteUrl) {
+  if (typeof remoteUrl !== "string") return null;
+  const input = remoteUrl.trim();
+  if (input === "") return null;
+
+  let host;
+  let path;
+  const scp = input.match(/^[^@\s/]+@([^:\s]+):(.+)$/);
+  if (scp) {
+    // scp-like form: `git@github.com:owner/repo.git` — not a URL, no scheme.
+    host = scp[1];
+    path = scp[2];
+  } else {
+    let url;
+    try {
+      url = new URL(input);
+    } catch {
+      return null;
+    }
+    // Only http(s)/ssh remote URLs are git remotes. Anything else (ftp,
+    // file, a bare host with no scheme that somehow parsed) is not one.
+    if (url.protocol !== "http:" && url.protocol !== "https:" && url.protocol !== "ssh:") {
+      return null;
+    }
+    // We use hostname + pathname only, so credentials (user:pass@host) are
+    // structurally excluded from the result.
+    host = url.hostname;
+    path = url.pathname;
+  }
+
+  host = host.toLowerCase();
+  const kind = HOST_KIND[host];
+  if (kind === undefined) return null;
+
+  const parsed = parseOwnerRepo(path);
+  if (parsed === null) return null;
+  return { kind, host, owner: parsed.owner, repo: parsed.repo };
+}
+
+// Split `/owner/repo/` (or `owner/repo.git`) into { owner, repo }. `owner` is
+// every path segment before the repo, joined with `/`, so GitLab subgroups
+// fall out naturally (`group/subgroup/project` → owner "group/subgroup"). The
+// `.git` suffix is optional on the repo segment. Strips leading/trailing
+// slashes and rejects anything without both an owner and a repo.
+function parseOwnerRepo(rawPath) {
+  const path = rawPath.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  if (path === "") return null;
+  const parts = path.split("/").filter((segment) => segment !== "");
+  if (parts.length < 2) return null;
+  const owner = parts.slice(0, -1).join("/").toLowerCase();
+  const repo = parts[parts.length - 1].toLowerCase().replace(/\.git$/, "");
+  if (owner === "" || repo === "") return null;
+  return { owner, repo };
+}
+
+// ---------------------------------------------------------------------------
+// Canonical join key
+// ---------------------------------------------------------------------------
+
+/**
+ * A canonical, stable join key for a repository: `host/owner/repo`, all
+ * lowercased, no `.git` suffix, no trailing slash. Used as the join key by
+ * the repo probe, the rules store and project metadata, so it must be
+ * identical for the HTTPS and SSH forms of the same repository (both forms
+ * parse to the same host/owner/repo via `detectForge`).
+ *
+ * @param {{ host: string, owner: string, repo: string }} repo
+ * @returns {string}
+ */
+export function repoKey({ host, owner, repo }) {
+  const h = String(host).toLowerCase().replace(/\/+$/, "");
+  const o = String(owner).toLowerCase().replace(/^\/+|\/+$/g, "");
+  const r = String(repo).toLowerCase().replace(/\.git$/, "").replace(/^\/+|\/+$/g, "");
+  return `${h}/${o}/${r}`;
+}
+
+// ---------------------------------------------------------------------------
+// PR/MR state normalisation
+// ---------------------------------------------------------------------------
+
+// What each forge's raw `state` string means, after the merged/draft flags
+// (which live outside `state` on both forges) have been considered. GitLab
+// emits `opened` (not `open`) and its own `locked`; GitHub emits `closed` for
+// both a closed and a merged PR (the `merged` flag disambiguates).
+const STATE_BY_KIND = Object.freeze({
+  github: Object.freeze({
+    open: "open",
+    closed: "closed",
+  }),
+  gitlab: Object.freeze({
+    opened: "open",
+    closed: "closed",
+    // A locked GitLab MR is an *open* MR whose discussion has been locked
+    // (admin action, or a bot); it is not merged, not closed, not draft, so
+    // it normalises to "open". The spec has no sixth state — the shared enum
+    // is four values and locked must land on one of them.
+    locked: "open",
+    merged: "merged",
+  }),
+});
+
+/**
+ * Normalise a forge's raw PR/MR state into the shared `PullRequestState`.
+ *
+ * Both forges carry `merged` and `draft` as booleans OUTSIDE `state`, so the
+ * raw `state` string alone is ambiguous in exactly two places, which is the
+ * whole reason this function exists:
+ *   - GitHub reports a merged PR as `state: "closed"` + `merged: true` — so
+ *     `closed` alone cannot mean "merged".
+ *   - GitLab reports `state: "opened"`, not `"open"`, and also emits
+ *     `"locked"`.
+ *
+ * Order is: a merged PR wins over everything; a draft PR wins over the
+ * open/closed classification; then the per-forge `state` table maps the rest.
+ * Graceful handling: merged is checked before draft so a merged-but-shown-as-
+ * draft PR is still "merged".
+ *
+ * @param {{ state: string, merged?: boolean, draft?: boolean }} raw the forge PR/MR payload fields
+ * @param {ForgeKind} kind
+ * @returns {PullRequestState}
+ * @throws {Error} if the raw state is not one the forge emits (unknown input
+ *   is rejected loudly rather than coerced — module invariant).
+ */
+export function normalizePrState({ state, merged, draft }, kind) {
+  if (merged === true) return "merged";
+  if (draft === true) return "draft";
+
+  const table = STATE_BY_KIND[kind];
+  const normalized = table ? table[state] : undefined;
+  if (normalized === undefined) {
+    throw new Error(
+      `normalizePrState: unknown ${kind} state ${JSON.stringify(state)}`,
+    );
+  }
+  return normalized;
+}
+
+// ---------------------------------------------------------------------------
+// Checks rollup
+// ---------------------------------------------------------------------------
+
+// Conclusion values that make a check read as RED (the run did not pass).
+const RED_CONCLUSIONS = new Set(["failure", "failed", "timed_out", "timeout", "action_required"]);
+
+// Status values that mean the check is still PENDING/RUNNING (not finished).
+const PENDING_STATUSES = new Set([
+  "queued",
+  "pending",
+  "in_progress",
+  "running",
+  "waiting",
+  "started",
+]);
+
+/**
+ * Roll the already-normalised per-check array up to a single traffic-light.
+ *
+ * Rules, in order: any red → `"red"`; else any pending/running → `"yellow"`;
+ * else any green → `"green"`; else `"none"` (including empty input).
+ *
+ * This returns ONLY the tri-state. It must not mutate, filter or discard the
+ * input array — callers keep the raw list for display. That split (tri-state
+ * for logic, raw list for display) is spec §3.4② and the single most-copied
+ * lesson from Renovate's eleven-platform abstraction.
+ *
+ * @param {Array<{ name: string, status?: string, conclusion?: string, url?: string }>} checks
+ * @returns {CheckRollup}
+ */
+export function rollupChecks(checks) {
+  let sawPending = false;
+  let sawGreen = false;
+  for (const check of checks) {
+    if (RED_CONCLUSIONS.has(check.conclusion)) return "red";
+    if (PENDING_STATUSES.has(check.status)) sawPending = true;
+    if (check.conclusion === "success") sawGreen = true;
+  }
+  if (sawPending) return "yellow";
+  if (sawGreen) return "green";
+  return "none";
+}
+
+// ---------------------------------------------------------------------------
+// Typed capability-gap error
+// ---------------------------------------------------------------------------
+
+/**
+ * A typed error for a capability a forge simply does not have (e.g. "GitLab
+ * has no pending-review concept"). Carries `.kind` and `.capability` so a
+ * capability gap is a value a caller can pattern-match, not a thrown string
+ * to regex. The optional capability methods on a forge adapter are the
+ * feature flag (spec §3.2), and this error is what an adapter throws when
+ * one is invoked anyway.
+ *
+ * @extends {Error}
+ */
+export class UnsupportedByForgeError extends Error {
+  /**
+   * @param {ForgeKind} kind
+   * @param {string} capability
+   */
+  constructor(kind, capability) {
+    super(`${capability} is not supported by ${kind}`);
+    this.name = "UnsupportedByForgeError";
+    this.kind = kind;
+    this.capability = capability;
+  }
+}
+
+/**
+ * Construct an {@link UnsupportedByForgeError}.
+ * @param {ForgeKind} kind
+ * @param {string} capability
+ * @returns {UnsupportedByForgeError}
+ */
+export function unsupportedByForge(kind, capability) {
+  return new UnsupportedByForgeError(kind, capability);
+}

--- a/src/shared/forge.test.ts
+++ b/src/shared/forge.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect } from "vitest";
+import {
+  detectForge,
+  repoKey,
+  normalizePrState,
+  rollupChecks,
+  UnsupportedByForgeError,
+  unsupportedByForge,
+} from "./forge.mjs";
+
+const OWNER_REPO = { kind: "github", host: "github.com", owner: "owner", repo: "repo" };
+
+describe("detectForge", () => {
+  it("https with .git suffix", () => {
+    expect(detectForge("https://github.com/owner/repo.git")).toEqual(OWNER_REPO);
+  });
+  it("https without .git", () => {
+    expect(detectForge("https://github.com/owner/repo")).toEqual(OWNER_REPO);
+  });
+  it("scp-like form (git@host:owner/repo.git)", () => {
+    expect(detectForge("git@github.com:owner/repo.git")).toEqual(OWNER_REPO);
+  });
+  it("ssh:// scheme", () => {
+    expect(detectForge("ssh://git@github.com/owner/repo.git")).toEqual(OWNER_REPO);
+  });
+  it("GitLab subgroup -> owner is the full group/subgroup path", () => {
+    expect(detectForge("https://gitlab.com/group/subgroup/project.git")).toEqual({
+      kind: "gitlab",
+      host: "gitlab.com",
+      owner: "group/subgroup",
+      repo: "project",
+    });
+  });
+  it("trailing slash is normalised", () => {
+    expect(detectForge("https://github.com/owner/repo/")).toEqual(OWNER_REPO);
+  });
+  it("GitLab with trailing slash + subgroup", () => {
+    expect(detectForge("https://gitlab.com/group/sub/proj/")).toEqual({
+      kind: "gitlab",
+      host: "gitlab.com",
+      owner: "group/sub",
+      repo: "proj",
+    });
+  });
+  it("normalises case in host and path", () => {
+    expect(detectForge("https://GITHUB.com/OWNER/Repo.git")).toEqual(OWNER_REPO);
+    expect(detectForge("GIT@Github.COM:Owner/Repo.GIT")).toEqual(OWNER_REPO);
+  });
+  it("strips credentials from the URL — no credential substring survives", () => {
+    const got = detectForge("https://x-access-token:SECRET@github.com/o/r.git");
+    expect(got).toEqual({ kind: "github", host: "github.com", owner: "o", repo: "r" });
+    const serialized = JSON.stringify(got);
+    expect(serialized).not.toContain("SECRET");
+    expect(serialized).not.toContain("x-access-token");
+    expect(serialized).not.toContain("@");
+  });
+
+  describe("returns null for non-remotes", () => {
+    it("a local path", () => {
+      expect(detectForge("/home/user/repo")).toBeNull();
+      expect(detectForge("./relative/repo")).toBeNull();
+    });
+    it("an empty string", () => {
+      expect(detectForge("")).toBeNull();
+      expect(detectForge("   ")).toBeNull();
+    });
+    it("undefined and non-string input", () => {
+      expect(detectForge(undefined)).toBeNull();
+      expect(detectForge(null)).toBeNull();
+      expect(detectForge(42 as never)).toBeNull();
+      expect(detectForge({} as never)).toBeNull();
+      expect(detectForge([] as never)).toBeNull();
+    });
+    it("a non-URL string", () => {
+      expect(detectForge("not a url")).toBeNull();
+    });
+    it("an unsupported host (github/gitlab only — self-hosted is out of scope)", () => {
+      expect(detectForge("https://bitbucket.org/owner/repo.git")).toBeNull();
+      expect(detectForge("git@bitbucket.org:owner/repo.git")).toBeNull();
+      expect(detectForge("https://github.example.com/owner/repo.git")).toBeNull();
+      expect(detectForge("ssh://git@gitlab.example.org/a/b.git")).toBeNull();
+    });
+    it("a non-git URL scheme", () => {
+      expect(detectForge("ftp://github.com/owner/repo.git")).toBeNull();
+      expect(detectForge("file:///tmp/repo")).toBeNull();
+    });
+    it("a URL with no owner/repo path", () => {
+      expect(detectForge("https://github.com/")).toBeNull();
+      expect(detectForge("ssh://git@github.com/")).toBeNull();
+      expect(detectForge("git@github.com:")).toBeNull();
+    });
+  });
+});
+
+describe("repoKey", () => {
+  it("HTTPS and SSH forms of the same repo produce an identical key", () => {
+    const https = repoKey(detectForge("https://github.com/anomalyco/manta.git")!);
+    const ssh = repoKey(detectForge("git@github.com:anomalyco/manta.git")!);
+    const sshUrl = repoKey(detectForge("ssh://git@github.com/anomalyco/manta.git")!);
+    expect(https).toBe("github.com/anomalyco/manta");
+    expect(ssh).toBe(https);
+    expect(sshUrl).toBe(https);
+  });
+  it("normalises .git suffix, trailing slash and mixed case", () => {
+    expect(repoKey(detectForge("https://github.com/A/Manta.git")!)).toBe(
+      "github.com/a/manta",
+    );
+    expect(repoKey(detectForge("https://github.com/a/manta/")!)).toBe(
+      "github.com/a/manta",
+    );
+  });
+  it("keeps GitLab subgroups in the key", () => {
+    expect(repoKey(detectForge("https://gitlab.com/Group/Sub/Proj.git")!)).toBe(
+      "gitlab.com/group/sub/proj",
+    );
+  });
+  it("is robust to direct input (normalises regardless of source)", () => {
+    expect(repoKey({ host: "Github.Com", owner: "Owner", repo: "Repo.git" })).toBe(
+      "github.com/owner/repo",
+    );
+  });
+});
+
+describe("normalizePrState", () => {
+  describe("GitHub", () => {
+    it("open", () => {
+      expect(normalizePrState({ state: "open" }, "github")).toBe("open");
+    });
+    it("closed, not merged", () => {
+      expect(normalizePrState({ state: "closed", merged: false }, "github")).toBe("closed");
+    });
+    it("merged-as-closed -> merged (closed alone is ambiguous)", () => {
+      expect(normalizePrState({ state: "closed", merged: true }, "github")).toBe("merged");
+      expect(normalizePrState({ state: "closed", merged: true, draft: true }, "github")).toBe(
+        "merged",
+      );
+    });
+    it("draft open PR -> draft", () => {
+      expect(normalizePrState({ state: "open", draft: true }, "github")).toBe("draft");
+    });
+    it("rejects an unknown raw state loudly", () => {
+      expect(() => normalizePrState({ state: "opened" }, "github")).toThrow(/unknown github state/);
+      expect(() => normalizePrState({ state: "merged" }, "github")).toThrow(/unknown github state/);
+    });
+  });
+
+  describe("GitLab", () => {
+    it("opened -> open (GitLab says 'opened', not 'open')", () => {
+      expect(normalizePrState({ state: "opened" }, "gitlab")).toBe("open");
+    });
+    it("closed", () => {
+      expect(normalizePrState({ state: "closed" }, "gitlab")).toBe("closed");
+    });
+    it("merged", () => {
+      expect(normalizePrState({ state: "merged" }, "gitlab")).toBe("merged");
+    });
+    it("locked -> open (a locked MR is still open, its discussion is locked)", () => {
+      expect(normalizePrState({ state: "locked" }, "gitlab")).toBe("open");
+    });
+    it("draft opened MR -> draft", () => {
+      expect(normalizePrState({ state: "opened", draft: true }, "gitlab")).toBe("draft");
+    });
+    it("rejects an unknown raw state loudly", () => {
+      expect(() => normalizePrState({ state: "open" }, "gitlab")).toThrow(/unknown gitlab state/);
+    });
+  });
+
+  it("rejects an unknown kind", () => {
+    expect(() => normalizePrState({ state: "open" }, "bitbucket" as never)).toThrow(
+      /unknown bitbucket state/,
+    );
+  });
+});
+
+describe("rollupChecks", () => {
+  const green = { name: "a", status: "completed", conclusion: "success" };
+  const red = { name: "b", status: "completed", conclusion: "failure" };
+  const pending = { name: "c", status: "in_progress" };
+
+  it("none for empty input", () => {
+    expect(rollupChecks([])).toBe("none");
+  });
+  it("any red wins, regardless of order", () => {
+    expect(rollupChecks([green, red])).toBe("red");
+    expect(rollupChecks([red, green])).toBe("red");
+    expect(rollupChecks([red, pending])).toBe("red");
+  });
+  it("yellow when pending/running and no red (takes precedence over green)", () => {
+    expect(rollupChecks([pending])).toBe("yellow");
+    expect(rollupChecks([green, pending])).toBe("yellow");
+    expect(rollupChecks([pending, green])).toBe("yellow");
+  });
+  it("green when all completed and succeeding", () => {
+    expect(rollupChecks([green])).toBe("green");
+    expect(rollupChecks([green, green])).toBe("green");
+  });
+  it("none when no check is red/pending/green (e.g. neutral/skipped)", () => {
+    expect(rollupChecks([{ name: "n", status: "completed", conclusion: "neutral" }])).toBe(
+      "none",
+    );
+    expect(rollupChecks([{ name: "s", status: "completed", conclusion: "skipped" }])).toBe(
+      "none",
+    );
+    expect(rollupChecks([green, { name: "x", conclusion: "neutral" }])).toBe("green");
+  });
+
+  describe("recognised red conclusions and pending statuses", () => {
+    it("red on failure/timeout/action_required conclusions", () => {
+      for (const c of ["failure", "failed", "timed_out", "timeout", "action_required"]) {
+        expect(rollupChecks([{ name: "c", conclusion: c }])).toBe("red");
+      }
+    });
+    it("yellow on queued/pending/running/started statuses", () => {
+      for (const s of ["queued", "pending", "in_progress", "running", "waiting", "started"]) {
+        expect(rollupChecks([{ name: "c", status: s }])).toBe("yellow");
+      }
+    });
+  });
+
+  it("does not mutate, filter or discard the input array", () => {
+    const checks = [green, red, pending];
+    const copy = checks.map((c) => ({ ...c }));
+    const result = rollupChecks(checks);
+    expect(result).toBe("red");
+    expect(checks).toEqual(copy);
+    expect(checks).toHaveLength(copy.length);
+    // The rollup is a string; the caller keeps the raw list — the array must
+    // come back unchanged including the red entry it short-circuited on.
+    expect(checks[1]).toEqual(red);
+  });
+
+  it("recognises the success conclusion as green", () => {
+    expect(
+      rollupChecks([{ name: "c", status: "completed", conclusion: "success" }]),
+    ).toBe("green");
+  });
+});
+
+describe("UnsupportedByForgeError", () => {
+  it("is an instanceof Error", () => {
+    expect(new UnsupportedByForgeError("gitlab", "pending_review")).toBeInstanceOf(Error);
+  });
+  it("carries both fields", () => {
+    const err = unsupportedByForge("gitlab", "pending_review");
+    expect(err.kind).toBe("gitlab");
+    expect(err.capability).toBe("pending_review");
+    expect(err.name).toBe("UnsupportedByForgeError");
+  });
+  it("builds a readable message and carries kind through unsupportedByForge", () => {
+    const err = unsupportedByForge("github", "resolve_thread");
+    expect(err.message).toContain("resolve_thread");
+    expect(err.message).toContain("github");
+    expect(err).toBeInstanceOf(UnsupportedByForgeError);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.kind).toBe("github");
+  });
+  it("is throwable and catchable as Error", () => {
+    try {
+      throw unsupportedByForge("gitlab", "pending_review");
+    } catch (e) {
+      expect(e).toBeInstanceOf(Error);
+      expect(e).toBeInstanceOf(UnsupportedByForgeError);
+      expect((e as UnsupportedByForgeError).capability).toBe("pending_review");
+    }
+  });
+});


### PR DESCRIPTION
## Forge seam L0 — `src/shared/forge.mjs`

Pure forge vocabulary + remote parsing + normalisers (BET-785, spec §3.1 / §3.2 L0 / §3.4). The layer every downstream forge module imports from. Designed against GitLab's docs as well as GitHub's, before either adapter exists.

**Files changed:** 3 (all added). `src/shared/forge.mjs`, `src/shared/forge.d.mts`, `src/shared/forge.test.ts` — 693 insertions, 0 deletions.

- `detectForge(remoteUrl)` — HTTPS, `ssh://`, and scp-like (`git@host:owner/repo.git`) forms; GitHub `owner/repo` and GitLab `group/subgroup/project`; trailing slash; optional `.git`; **credentials structurally stripped** (uses `URL.hostname`/`pathname` only, and lowercases owner/repo first so an uppercased `.GIT` can't survive). Returns `null` for local paths, non-URLs, empty/undefined, and any non-`github.com`/`gitlab.com` host.
- `repoKey({host, owner, repo})` — canonical `host/owner/repo`, lowercase, no `.git`, no trailing slash; identical for HTTPS/SSH forms of the same repo.
- `normalizePrState({state, merged, draft}, kind)` — reconciles GitLab `opened`→`open`, merged-as-`closed` (GitHub), and `locked`; throws loudly on unknown raw states.
- `rollupChecks(checks)` — tri-state rollup (red→yellow→green→none); returns only the tri-state, never mutates the input (raw list kept for display — spec §3.4②).
- `UnsupportedByForgeError` (+ `unsupportedByForge`) — typed capability-gap error carrying `.kind`/`.capability`.

**Design notes**
- `normalizePrState` maps GitLab `locked` → `open`. The spec has no sixth state (the shared enum is the four values) and gives no explicit value table for `locked`; a locked GitLab MR is still an *open* MR whose discussion is locked (not merged / closed / draft), so `open` is the semantics-preserving normalization. Flagging for review — happy to adjust if the intended mapping differs. Commented in the module too.
- No `gitea`/`bitbucket` kind; no host allowlist; no I/O of any kind (`URL` is a pure string parser). No adapter interfaces here — vocabulary only.

**What I removed / why this is net-additive:** nothing to remove — this is greenfield (the box has no forge code today; grep confirmed no existing remote-URL parsing to reuse in `paths.mjs`/`worktree.mjs`). All 693 lines are the requested vocabulary + its exhaustive tests.

**Verification results**
- PR branch (`multica/BET-785-forge-seam` @ `c0a9b56`): typecheck exit 0, no errors; `npm test` exit 0, **1659 pass / 0 fail / 0 skip**.
- `forge.test.ts`: 45/45 pass (all 7 URL shapes, 3+ null cases, explicit credential-strip test, repoKey HTTPS==SSH, every raw state both forges emit, rollup all four outcomes + no-mutation, error instanceof+fields).
- Base: `origin/main @ e572f8b`. This PR is **additive-only** (3 new files, no modifications/deletions to any pre-existing file), so base-branch re-run is redundant by construction — 0 new failures.
- **Conclusion:** 0 new failures.
