### PR TITLE
feat(renderer): status-item registry + overflow for the session header (BET-782)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -163,6 +163,7 @@ export function ChatPanel({
   const autoRenameSessions = useStore((s) => s.autoRenameSessions);
   const configDefaultModel = useStore((s) => s.defaultModel);
   const deactivatedMainModels = useStore((s) => s.deactivatedMainModels);
+  const hiddenStatusItems = useStore((s) => s.hiddenStatusItems);
   // User-configured Anthropic prompt cache TTL — drives the "/clear to
   // save Nk tokens" pill when the session has been idle past this TTL.
   // manta doesn't set the real cache_control.ttl on requests; this is the
@@ -1940,6 +1941,7 @@ export function ChatPanel({
         availableLaunchers={availableLaunchers}
         artifactsOpen={artifactsOpen}
         onToggleArtifacts={onToggleArtifacts}
+        hiddenStatusItems={hiddenStatusItems}
       />
 
       <Transcript

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -255,7 +255,8 @@ export function SessionHeader({
       )}
 
       {/* Right group — the registry's visible items + the overflow trigger.
-            Descending priority = left-to-right: menu, artifacts, context.
+            Order preserves today's wide-width visual (context, artifacts,
+            menu — acceptance #1); priority drives only the overflow cut.
             Opts out of the header's drag region so the controls stay
             clickable. */}
       <div

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -10,14 +10,23 @@
 // result) and handlers (fork / compact / clear / delete) are passed in as
 // props by ChatPanel, which owns the session lifecycle.
 
-import { useEffect, useRef, useState, type CSSProperties } from "react";
+import {
+  Fragment,
+  useEffect,
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+} from "react";
 import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal, Bot, MessageSquare, Clock, PanelRight } from "lucide-react";
 import {
   ctxStageColor,
   cssVar,
   moveMenuHighlight,
+  selectStatusItems,
   type ContextBreakdown,
   type StaleCacheResult,
+  type StatusItem,
 } from "./chatUtils";
 import { useClickAway } from "./hooks/useClickAway";
 import type { SessionMode } from "./chatShared";
@@ -67,6 +76,7 @@ export function SessionHeader({
   availableLaunchers,
   artifactsOpen,
   onToggleArtifacts,
+  hiddenStatusItems,
 }: {
   branch: string | null;
   ctxBreakdown: ContextBreakdown;
@@ -102,6 +112,11 @@ export function SessionHeader({
   // harnesses / non-desktop callers that don't own the panel omit them.
   artifactsOpen?: boolean;
   onToggleArtifacts?: () => void;
+  // BET-782: ids of registry items the user has permanently hidden (see
+  // AppConfig.hiddenStatusItems). An id in this list is never rendered, in the
+  // bar or the overflow. Optional so the prop doesn't break callers that
+  // haven't wired the setting yet.
+  hiddenStatusItems?: string[];
 }) {
   const { pct, segments, freshInput, cacheRead, cacheWrite, totalInput } =
     ctxBreakdown;
@@ -120,8 +135,97 @@ export function SessionHeader({
   // window name reads better than the full "project / window" breadcrumb.
   const sessionName = breadcrumb?.window ?? breadcrumb?.project ?? "this session";
 
+  // ===== Status-item registry (BET-782) =====
+  // The right group is a REGISTRY, not hand-ordered JSX. Each entry is a
+  // stable id + priority + render function; `selectStatusItems` (chatUtils)
+  // sorts descending by priority and decides, for the measured pane width +
+  // the user's hide list, what renders in the bar vs the `⋯ +N` overflow.
+  // `branch` and `breadcrumb` stay in the LEFT group and are NOT registered.
+  const headerRef = useRef<HTMLDivElement>(null);
+  // The cut container width, re-measured each render. Re-renders are driven by
+  // the very state that resizes the pane (sidebar / artifacts panel — BET-782
+  // §3 says the pane width is a function of those, NOT the viewport), so a
+  // plain layout-effect re-measure keeps the overflow current without a
+  // ResizeObserver or window.innerWidth listener (both forbidden). A
+  // zero/unknown width (jsdom, pre-layout) is treated as "everything fits" to
+  // preserve today's wide-width render.
+  const [paneWidth, setPaneWidth] = useState<number>(Infinity);
+  useLayoutEffect(() => {
+    const el = headerRef.current;
+    const w = el ? el.getBoundingClientRect().width : Infinity;
+    const effective = w > 0 ? w : Infinity;
+    setPaneWidth((prev) => (prev === effective ? prev : effective));
+  });
+
+  const registry: StatusItem[] = [];
+  if (showContext) {
+    registry.push({
+      id: "context",
+      priority: 60,
+      render: () => (
+        <ContextPill
+          pct={pct}
+          segments={segments}
+          fill={fill}
+          stale={stale}
+          totalInput={totalInput}
+          ctxLimit={ctxLimit}
+          freshInput={freshInput}
+          cacheRead={cacheRead}
+          cacheWrite={cacheWrite}
+          modelName={modelName}
+          staleCache={staleCache}
+          onClear={onClear}
+        />
+      ),
+    });
+  }
+  if (artifactsToggle) {
+    registry.push({
+      id: "artifacts",
+      priority: 80,
+      render: () => (
+        <IconButton
+          icon={
+            <PanelRight
+              className={artifactsToggle.isOpen ? "text-[var(--accent-tx)]" : undefined}
+            />
+          }
+          label={artifactsToggle.isOpen ? "Hide artifacts" : "Show artifacts"}
+          title={artifactsToggle.isOpen ? "Hide artifacts" : "Show artifacts"}
+          onClick={artifactsToggle.toggle}
+        />
+      ),
+    });
+  }
+  if (hasSession && !readOnly) {
+    registry.push({
+      id: "menu",
+      priority: 100,
+      render: () => (
+        <SessionMenu
+          mode={mode}
+          onModeChange={onModeChange}
+          availableLaunchers={availableLaunchers}
+          onFork={onFork}
+          onCompact={onCompact}
+          onClear={onClear}
+          onDelete={onDelete}
+          sessionName={sessionName}
+        />
+      ),
+    });
+  }
+
+  const { visible, overflow } = selectStatusItems(
+    registry,
+    paneWidth,
+    hiddenStatusItems ?? [],
+  );
+
   return (
     <div
+      ref={headerRef}
       className="manta-session-header flex items-center gap-2 h-11 pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] border-b border-border shrink-0 min-w-0"
       style={{ WebkitAppRegion: "drag" } as CSSProperties}
     >
@@ -150,59 +254,57 @@ export function SessionHeader({
         </Tag>
       )}
 
-      {/* Right group — context pill, session menu. Opts out of the header's
-            drag region so the controls stay clickable. */}
+      {/* Right group — the registry's visible items + the overflow trigger.
+            Descending priority = left-to-right: menu, artifacts, context.
+            Opts out of the header's drag region so the controls stay
+            clickable. */}
       <div
         className="ml-auto flex items-center gap-2"
         style={{ WebkitAppRegion: "no-drag" } as CSSProperties}
       >
-        {showContext && (
-          <ContextPill
-            pct={pct}
-            segments={segments}
-            fill={fill}
-            stale={stale}
-            totalInput={totalInput}
-            ctxLimit={ctxLimit}
-            freshInput={freshInput}
-            cacheRead={cacheRead}
-            cacheWrite={cacheWrite}
-            modelName={modelName}
-            staleCache={staleCache}
-            onClear={onClear}
-          />
-        )}
+        {visible.map((it) => (
+          <Fragment key={it.id}>{it.render()}</Fragment>
+        ))}
 
-        {/* Artifacts toggle (BET-659): toggles a panel, not a popup — so no
-            aria-haspopup (the visual gate scans for it) and no manta hook.
-            Tinted when open. Sits in the no-drag right group so macOS gets the
-            click. Omitted when the caller doesn't own the panel. */}
-        {artifactsToggle && (
-          <IconButton
-            icon={
-              <PanelRight
-                className={artifactsToggle.isOpen ? "text-[var(--accent-tx)]" : undefined}
-              />
-            }
-            label={artifactsToggle.isOpen ? "Hide artifacts" : "Show artifacts"}
-            title={artifactsToggle.isOpen ? "Hide artifacts" : "Show artifacts"}
-            onClick={artifactsToggle.toggle}
-          />
-        )}
-
-        {hasSession && !readOnly && (
-          <SessionMenu
-            mode={mode}
-            onModeChange={onModeChange}
-            availableLaunchers={availableLaunchers}
-            onFork={onFork}
-            onCompact={onCompact}
-            onClear={onClear}
-            onDelete={onDelete}
-            sessionName={sessionName}
-          />
-        )}
+        {overflow.length > 0 && <StatusOverflow items={overflow} />}
       </div>
+    </div>
+  );
+}
+
+// ===== Right-group overflow (BET-782) =====
+//
+// The `⋯ +N` trigger + Dropdown that holds registry items the pane is too
+// narrow to show in the bar. It is a SEPARATE control from the session `⋯`
+// menu — they are never merged. N is the hidden count, which the spec insists
+// on ("a bare ⋯ is explicitly wrong — the count is the point").
+function StatusOverflow({ items }: { items: StatusItem[] }) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  useClickAway(rootRef, open, () => setOpen(false));
+  return (
+    <div ref={rootRef} className="relative shrink-0">
+      <button
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        aria-label={`${items.length} more status item${items.length === 1 ? "" : "s"}`}
+        title={`${items.length} more status item${items.length === 1 ? "" : "s"}`}
+        className="manta-status-overflow-trigger inline-flex items-center gap-1 rounded-md p-1 text-text-faint hover:bg-fill-hover hover:text-text focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
+      >
+        <MoreHorizontal size={16} aria-hidden="true" />
+        <span className="text-micro font-semibold tabular-nums">+{items.length}</span>
+      </button>
+      {open && (
+        <Dropdown hook="manta-status-overflow-dropdown">
+          {items.map((it) => (
+            <div key={it.id} className="px-1 py-1">
+              {it.render()}
+            </div>
+          ))}
+        </Dropdown>
+      )}
     </div>
   );
 }

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3298,74 +3298,77 @@ describe("selectStatusItems", () => {
     render: () => null,
   });
 
-  // The real registry today: artifacts (80), menu (100), context (60).
+  // The real registry today, in construction order: context, artifacts, menu.
+  // selectStatusItems preserves that order (acceptance #1: pixel-identical at
+  // wide width); priority governs ONLY the overflow sacrifice order.
   const registry: StatusItem[] = [
     s("context", 60),
     s("artifacts", 80),
     s("menu", 100),
   ];
 
-  it("renders everything left-to-right by descending priority at wide width", () => {
+  it("renders everything in today's order at wide width, no overflow", () => {
     const { visible, overflow } = selectStatusItems(registry, 900, []);
-    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts", "context"]);
+    expect(visible.map((i) => i.id)).toEqual(["context", "artifacts", "menu"]);
     expect(overflow).toEqual([]);
   });
 
   it("keeps context at 560px (between the two cuts) — 560 cut is a seam only", () => {
     const { visible, overflow } = selectStatusItems(registry, 560, []);
-    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts", "context"]);
+    expect(visible.map((i) => i.id)).toEqual(["context", "artifacts", "menu"]);
     expect(overflow).toEqual([]);
   });
 
   it("moves context into overflow below 420px, keeping artifacts + menu", () => {
     const { visible, overflow } = selectStatusItems(registry, 419, []);
-    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts"]);
+    expect(visible.map((i) => i.id)).toEqual(["artifacts", "menu"]);
     expect(overflow.map((i) => i.id)).toEqual(["context"]);
   });
 
   it("never auto-hides priority ≥ 80 at any width", () => {
     const { visible, overflow } = selectStatusItems(registry, 200, []);
-    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts"]);
+    expect(visible.map((i) => i.id)).toEqual(["artifacts", "menu"]);
     expect(overflow.map((i) => i.id)).toEqual(["context"]);
   });
 
-  it("both cuts: a <60 item is hidden at 560 only, and joins at 420", () => {
+  it("both cuts: a <60 item is hidden at 560 only, and `context` joins at 420", () => {
     const items = [...registry, s("checks", 40)];
-    // 900px — everything fits.
+    // 900px — everything fits, today's order preserved, checks appended last.
     let r = selectStatusItems(items, 900, []);
     expect(r.visible.map((i) => i.id)).toEqual([
-      "menu",
-      "artifacts",
       "context",
+      "artifacts",
+      "menu",
       "checks",
     ]);
     expect(r.overflow).toEqual([]);
-    // 500px (≥420, <560): hide priority < 60 → checks, keep context.
+    // 500px (≥420, <560): hide priority < 60 → checks, keep the rest.
     r = selectStatusItems(items, 500, []);
-    expect(r.visible.map((i) => i.id)).toEqual(["menu", "artifacts", "context"]);
+    expect(r.visible.map((i) => i.id)).toEqual(["context", "artifacts", "menu"]);
     expect(r.overflow.map((i) => i.id)).toEqual(["checks"]);
     // 400px: also hide context.
     r = selectStatusItems(items, 400, []);
-    expect(r.visible.map((i) => i.id)).toEqual(["menu", "artifacts"]);
+    expect(r.visible.map((i) => i.id)).toEqual(["artifacts", "menu"]);
     expect(r.overflow.map((i) => i.id)).toEqual(["context", "checks"]);
   });
 
   it("a hidden id is absent from both arrays (bar and overflow)", () => {
     const { visible, overflow } = selectStatusItems(registry, 300, ["context"]);
-    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts"]);
+    expect(visible.map((i) => i.id)).toEqual(["artifacts", "menu"]);
     expect(overflow.map((i) => i.id)).toEqual([]);
   });
 
   it("hidden ids can remove a ≥80 item entirely, distinct from the auto cut", () => {
     const { visible, overflow } = selectStatusItems(registry, 900, ["artifacts"]);
-    expect(visible.map((i) => i.id)).toEqual(["menu", "context"]);
+    expect(visible.map((i) => i.id)).toEqual(["context", "menu"]);
     expect(overflow).toEqual([]);
   });
 
-  it("breaks priority ties by stable id sort", () => {
-    const tied = [s("z", 60), s("a", 60), s("b", 60)];
-    const r = selectStatusItems(tied, 900, []);
-    expect(r.visible.map((i) => i.id)).toEqual(["a", "b", "z"]);
+  it("keeps the registry construction order stable (no priority re-sort of the bar)", () => {
+    const items = [s("menu", 100), s("context", 60), s("artifacts", 80)];
+    const r = selectStatusItems(items, 900, []);
+    expect(r.visible.map((i) => i.id)).toEqual(["menu", "context", "artifacts"]);
+    expect(r.overflow).toEqual([]);
   });
 
   it("handles an empty registry", () => {

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -89,6 +89,8 @@ import {
   formatUpdatedAgo,
   usageStale,
   pruneVisitedSessions,
+  selectStatusItems,
+  type StatusItem,
 } from "./chatUtils";
 
 import type { OpencodeModel, UsageSnapshot } from "../shared/types";
@@ -3284,5 +3286,91 @@ describe("pruneVisitedSessions", () => {
 
   it("returns an empty array for an empty visited set", () => {
     expect(pruneVisitedSessions(new Set<string>(), new Set(["a"]), null)).toEqual([]);
+  });
+});
+
+// ===== selectStatusItems (BET-782 status-item registry cut) =====
+
+describe("selectStatusItems", () => {
+  const s = (id: string, priority: number) => ({
+    id,
+    priority,
+    render: () => null,
+  });
+
+  // The real registry today: artifacts (80), menu (100), context (60).
+  const registry: StatusItem[] = [
+    s("context", 60),
+    s("artifacts", 80),
+    s("menu", 100),
+  ];
+
+  it("renders everything left-to-right by descending priority at wide width", () => {
+    const { visible, overflow } = selectStatusItems(registry, 900, []);
+    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts", "context"]);
+    expect(overflow).toEqual([]);
+  });
+
+  it("keeps context at 560px (between the two cuts) — 560 cut is a seam only", () => {
+    const { visible, overflow } = selectStatusItems(registry, 560, []);
+    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts", "context"]);
+    expect(overflow).toEqual([]);
+  });
+
+  it("moves context into overflow below 420px, keeping artifacts + menu", () => {
+    const { visible, overflow } = selectStatusItems(registry, 419, []);
+    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts"]);
+    expect(overflow.map((i) => i.id)).toEqual(["context"]);
+  });
+
+  it("never auto-hides priority ≥ 80 at any width", () => {
+    const { visible, overflow } = selectStatusItems(registry, 200, []);
+    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts"]);
+    expect(overflow.map((i) => i.id)).toEqual(["context"]);
+  });
+
+  it("both cuts: a <60 item is hidden at 560 only, and joins at 420", () => {
+    const items = [...registry, s("checks", 40)];
+    // 900px — everything fits.
+    let r = selectStatusItems(items, 900, []);
+    expect(r.visible.map((i) => i.id)).toEqual([
+      "menu",
+      "artifacts",
+      "context",
+      "checks",
+    ]);
+    expect(r.overflow).toEqual([]);
+    // 500px (≥420, <560): hide priority < 60 → checks, keep context.
+    r = selectStatusItems(items, 500, []);
+    expect(r.visible.map((i) => i.id)).toEqual(["menu", "artifacts", "context"]);
+    expect(r.overflow.map((i) => i.id)).toEqual(["checks"]);
+    // 400px: also hide context.
+    r = selectStatusItems(items, 400, []);
+    expect(r.visible.map((i) => i.id)).toEqual(["menu", "artifacts"]);
+    expect(r.overflow.map((i) => i.id)).toEqual(["context", "checks"]);
+  });
+
+  it("a hidden id is absent from both arrays (bar and overflow)", () => {
+    const { visible, overflow } = selectStatusItems(registry, 300, ["context"]);
+    expect(visible.map((i) => i.id)).toEqual(["menu", "artifacts"]);
+    expect(overflow.map((i) => i.id)).toEqual([]);
+  });
+
+  it("hidden ids can remove a ≥80 item entirely, distinct from the auto cut", () => {
+    const { visible, overflow } = selectStatusItems(registry, 900, ["artifacts"]);
+    expect(visible.map((i) => i.id)).toEqual(["menu", "context"]);
+    expect(overflow).toEqual([]);
+  });
+
+  it("breaks priority ties by stable id sort", () => {
+    const tied = [s("z", 60), s("a", 60), s("b", 60)];
+    const r = selectStatusItems(tied, 900, []);
+    expect(r.visible.map((i) => i.id)).toEqual(["a", "b", "z"]);
+  });
+
+  it("handles an empty registry", () => {
+    const r = selectStatusItems([], 400, []);
+    expect(r.visible).toEqual([]);
+    expect(r.overflow).toEqual([]);
   });
 });

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3371,6 +3371,23 @@ describe("selectStatusItems", () => {
     expect(r.overflow).toEqual([]);
   });
 
+  it("breaks equal-priority ties by stable id sort", () => {
+    // Same priority, deliberately out of id order — must come back id-sorted,
+    // regardless of the order they were pushed into the registry.
+    const tied = [s("z", 60), s("b", 60), s("a", 60)];
+    const r = selectStatusItems(tied, 900, []);
+    expect(r.visible.map((i) => i.id)).toEqual(["a", "b", "z"]);
+    expect(r.overflow).toEqual([]);
+  });
+
+  it("id-sorts tied items within the overflow too", () => {
+    // Two equal-priority (60) items both cut at 400px — id-ordered in overflow.
+    const tied = [s("z", 60), s("a", 60)];
+    const r = selectStatusItems(tied, 400, []);
+    expect(r.visible).toEqual([]);
+    expect(r.overflow.map((i) => i.id)).toEqual(["a", "z"]);
+  });
+
   it("handles an empty registry", () => {
     const r = selectStatusItems([], 400, []);
     expect(r.visible).toEqual([]);

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2556,24 +2556,27 @@ function overflowFor(it: StatusItem, containerWidth: number): boolean {
 
 // Select which registry items render in the header bar vs the overflow
 // dropdown for a container width + the user's hide list. Hidden ids are never
-// present in either array (removed entirely). Sort is descending priority with
-// a stable id tiebreak.
+// present in either array (removed entirely).
+//
+// ORDERING NOTE (BET-782): acceptance criterion #1 requires the wide-width
+// header to render EXACTLY as it does today, and the spec's §2 "sort
+// descending by priority; render left-to-right" would put the ⋯ menu (100)
+// left of the context pill (60) — a visual change, and a direct conflict
+// between the two requirements. Criterion #1 is the DoD, so this preserves the
+// registry's construction order (today: context, artifacts, menu). Priority is
+// therefore ONLY the overflow-sacrifice order (which items the cut drops as the
+// pane narrows), not a reordering of the bar. If the descending-order rule is
+// ever made authoritative, flip the loop below to sort by priority descending.
 export function selectStatusItems(
   items: StatusItem[],
   containerWidth: number,
   hiddenIds: string[],
 ): { visible: StatusItem[]; overflow: StatusItem[] } {
   const hidden = new Set(hiddenIds);
-  const considered = items
-    .filter((it) => !hidden.has(it.id))
-    .sort(
-      (a, b) =>
-        b.priority - a.priority || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
-    );
-
   const visible: StatusItem[] = [];
   const overflow: StatusItem[] = [];
-  for (const it of considered) {
+  for (const it of items) {
+    if (hidden.has(it.id)) continue;
     (overflowFor(it, containerWidth) ? overflow : visible).push(it);
   }
   return { visible, overflow };

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3,6 +3,7 @@
 // Type-only import — erased at compile time, keeps this module dependency-
 // free at runtime (the whole point of chatUtils.ts: pure functions testable
 // without DOM/Electron/network).
+import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
 import type { DelegateApprovalTool, OpencodeMessage, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
@@ -2510,4 +2511,70 @@ export function pruneVisitedSessions(
     if (!liveSessionIds.has(sid) && sid !== activeId) toRemove.push(sid);
   }
   return toRemove;
+}
+
+// ===== Session header status-item registry (BET-782) =====
+//
+// The right group of the session header is a REGISTRY of status items, each
+// carrying a stable id, a priority and a render function. Higher priority =
+// further LEFT in the right group = kept longer as the pane narrows. A pure
+// selection function decides, for a given container width + the user's hide
+// list, which items render in the bar vs the overflow dropdown. Purely
+// presentational — no DOM, no React state.
+export type StatusItem = {
+  /** Stable id — the key for the user-hide setting (AppConfig.hiddenStatusItems). */
+  id: string;
+  /** Higher = further LEFT in the right group = kept longer. */
+  priority: number;
+  /** The chip itself. */
+  render: () => ReactNode;
+};
+
+// The two container breakpoints the spec mandates (BET-782 §3). The header is
+// a CSS container query (`container: sessionheader / inline-size`); the width
+// passed in here is that container's inline size — NOT the viewport, which
+// measures the wrong thing when the sidebar / artifacts panel resize the pane.
+const STATUS_CUT_560 = 560;
+const STATUS_CUT_420 = 420;
+// The overflow cut refuses to auto-hide anything at ≥ 80 (artifacts / menu are
+// always present at every width). Priority is the ONLY "pinned" mechanism —
+// there is deliberately no separate flag.
+const STATUS_NEVER_AUTO_HIDE = 80;
+// The 560px seam hides priority < 60 (the band future forge items occupy);
+// the 420px cut additionally hides `context` (priority 60).
+const STATUS_CUT_HIDE_BELOW_560 = 60;
+
+// Whether the overflow cut sends `it` to overflow at the given container
+// width. Never hides priority ≥ 80 (artifacts / menu) via this cut — the user
+// hide list is the only thing that can remove those.
+function overflowFor(it: StatusItem, containerWidth: number): boolean {
+  if (it.priority >= STATUS_NEVER_AUTO_HIDE) return false;
+  if (containerWidth < STATUS_CUT_420) return it.priority <= STATUS_CUT_HIDE_BELOW_560;
+  if (containerWidth < STATUS_CUT_560) return it.priority < STATUS_CUT_HIDE_BELOW_560;
+  return false;
+}
+
+// Select which registry items render in the header bar vs the overflow
+// dropdown for a container width + the user's hide list. Hidden ids are never
+// present in either array (removed entirely). Sort is descending priority with
+// a stable id tiebreak.
+export function selectStatusItems(
+  items: StatusItem[],
+  containerWidth: number,
+  hiddenIds: string[],
+): { visible: StatusItem[]; overflow: StatusItem[] } {
+  const hidden = new Set(hiddenIds);
+  const considered = items
+    .filter((it) => !hidden.has(it.id))
+    .sort(
+      (a, b) =>
+        b.priority - a.priority || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0),
+    );
+
+  const visible: StatusItem[] = [];
+  const overflow: StatusItem[] = [];
+  for (const it of considered) {
+    (overflowFor(it, containerWidth) ? overflow : visible).push(it);
+  }
+  return { visible, overflow };
 }

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2563,19 +2563,28 @@ function overflowFor(it: StatusItem, containerWidth: number): boolean {
 // descending by priority; render left-to-right" would put the ⋯ menu (100)
 // left of the context pill (60) — a visual change, and a direct conflict
 // between the two requirements. Criterion #1 is the DoD, so this preserves the
-// registry's construction order (today: context, artifacts, menu). Priority is
-// therefore ONLY the overflow-sacrifice order (which items the cut drops as the
-// pane narrows), not a reordering of the bar. If the descending-order rule is
-// ever made authoritative, flip the loop below to sort by priority descending.
+// registry's construction order (today: context, artifacts, menu) rather than
+// re-sorting by priority. Priority is therefore ONLY the overflow-sacrifice
+// order (which items the cut drops as the pane narrows), not a reordering of
+// the bar. Equal-priority ties are still broken deterministically by stable id
+// sort (the spec's Tests section requires it); Array.prototype.sort is stable,
+// so leaving differing-priority pairs in construction order while id-sorting
+// only the tied runs is safe. If the descending-order rule is ever made
+// authoritative instead, swap the tie comparator below for a full priority
+// sort.
 export function selectStatusItems(
   items: StatusItem[],
   containerWidth: number,
   hiddenIds: string[],
 ): { visible: StatusItem[]; overflow: StatusItem[] } {
   const hidden = new Set(hiddenIds);
+  const ordered = [...items].sort((a, b) => {
+    if (a.priority === b.priority) return a.id < b.id ? -1 : a.id > b.id ? 1 : 0;
+    return 0; // different priorities keep their construction (today's) order
+  });
   const visible: StatusItem[] = [];
   const overflow: StatusItem[] = [];
-  for (const it of items) {
+  for (const it of ordered) {
     if (hidden.has(it.id)) continue;
     (overflowFor(it, containerWidth) ? overflow : visible).push(it);
   }

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -55,6 +55,16 @@ html, body, #root {
   box-shadow: var(--shadow-sm), 0 0 0 3px var(--accent-bg);
 }
 
+/* BET-782: the session header is a container query. The pane's width is a
+   function of the sidebar + artifacts panel, NOT the viewport, so a viewport
+   breakpoint measures the wrong thing — the cut is driven by the container's
+   inline size. selectStatusItems (chatUtils) mirrors this with the same two
+   breakpoint constants (560 / 420); the container context here is what makes
+   the header a container-query surface rather than a media-query one. */
+.manta-session-header {
+  container: sessionheader / inline-size;
+}
+
 /* Trailing spacer inside any header row that reaches the top-right of the
    window. Zero-width off Windows. */
 .titlebar-inset-right {

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -314,6 +314,10 @@ type State = {
   // 70% (the dial's normal "quiet unless it matters" threshold). Settings-
   // only — rides the generic configUpdate path. See AppConfig.alwaysShowUsage.
   alwaysShowUsage: boolean;
+  // BET-782: ids of session-header status items the user has permanently
+  // hidden (never rendered in the bar or the overflow dropdown). Mirror of
+  // AppConfig.hiddenStatusItems; read by SessionHeader's registry.
+  hiddenStatusItems: string[];
   // Agent → laptop push trust flag. When true, files the AI drops in its
   // remote outbox are pulled to the downloads dir without confirmation.
   allowAgentPush: boolean;
@@ -668,6 +672,7 @@ export const useStore = create<State>((set, get) => ({
   chatAutoAllow: false,
   autoRenameSessions: false,
   alwaysShowUsage: false,
+  hiddenStatusItems: [],
   allowAgentPush: false,
   worktreePerSession: false,
   worktreeCleanOnClose: false,
@@ -904,6 +909,7 @@ export const useStore = create<State>((set, get) => ({
       chatAutoAllow: c.chatAutoAllow ?? false,
       autoRenameSessions: c.autoRenameSessions ?? false,
       alwaysShowUsage: c.alwaysShowUsage ?? false,
+      hiddenStatusItems: Array.isArray(c.hiddenStatusItems) ? c.hiddenStatusItems : [],
       allowAgentPush: c.allowAgentPush ?? false,
       worktreePerSession: c.worktreePerSession ?? false,
       worktreeCleanOnClose: c.worktreeCleanOnClose ?? false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -103,6 +103,13 @@ export type AppConfig = {
   // is to be absent unless it matters; this is the opt-out for someone who
   // wants the ambient meter anyway. Settings-only, rides configUpdate.
   alwaysShowUsage?: boolean;
+  // BET-782: ids of session-header status items the user has permanently
+  // hidden. An id in this array is never rendered, in the header bar or its
+  // overflow dropdown. Absent/empty = every registry item is shown. No
+  // Settings UI in BET-782 — the field being respected is the deliverable;
+  // later issues add the toggle. Rides the generic configGet/configUpdate
+  // channel like every other AppConfig field.
+  hiddenStatusItems?: string[];
   // Global default model for all new and cleared chat sessions. Stored as
   // { providerID, modelID } so the per-session localStorage override and
   // this setting use the same shape. When absent, opencode picks its own


### PR DESCRIPTION
Closes the "status-item registry + overflow" chrome prerequisite so future forge items drop into the registry instead of hand-editing JSX. Adds **no new status items**; it refactors the existing right group (context pill, artifacts toggle, ⋯ menu) into a priority registry and adds an overflow.

## What changed

- **Registry** (`SessionHeader.tsx`): the right group is now a `StatusItem[]` registry (id / priority / render). Entries: `context` (60), `artifacts` (80), `menu` (100). `branch`/`breadcrumb` stay in the left group, unregistered.
- **Cut logic** (`chatUtils.ts`): `selectStatusItems(items, containerWidth, hiddenIds)` — pure, tested. Applies the two container-breakpoint cut (`<560px` hides priority < 60; `<420px` also hides `context`), never auto-hides priority ≥ 80, and drops hidden ids entirely.
- **Overflow**: hidden items go behind a **separate** `⋯ +N` dropdown (N = hidden count) — distinct from the session ⋯ menu.
- **Container query**: `.manta-session-header { container: sessionheader / inline-size }` in `index.css`; the pane width is measured from the container (not the viewport) each render.
- **User-hide**: `AppConfig.hiddenStatusItems?: string[]` added, wired through the existing `configGet`/`configUpdate` channel + store (`store.ts`, `ChatPanel` → `SessionHeader`). No Settings UI (out of scope; the field being respected is the deliverable).
- **Deleted**: the old hand-ordered right-group JSX, replaced by the registry render.

## ⚠️ Ordering: §2 vs acceptance #1 (resolved in favour of acceptance #1)

The spec's §2 says **"sort descending by priority; render left-to-right"** (→ menu, artifacts, context) — but acceptance criterion #1 requires the header to render **"exactly as it does today (same items, same order)"** (→ context, artifacts, menu). For these three items the two cannot both hold.

I resolved in favour of **acceptance #1 (the DoD)**: the bar preserves today's wide-width order (context → artifacts → menu), and **priority drives only the overflow-sacrifice order** (which items the cut drops as the pane narrows). So `selectStatusItems` preserves the registry's construction order rather than re-sorting by priority. If the descending-order rule is made authoritative, it's a one-line flip. Flagging so it isn't a silent decision.

## Removal beats addition

Removed: the ~40-line hand-ordered right-group JSX block. Added only the registry + overflow + the one pure selector (`selectStatusItems`).

## Verification results

- PR branch (`multica/BET-782-session-header-status-registry` @ `8509326`, base `origin/main` @ `0e56ced`):
  - typecheck: exit 0, errors: none. log sha256 `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test (`npm test`): `1659` server node:test pass / `0` fail; `2378` renderer vitest pass / `7` skip / `0` fail. Failures: none.
- Base `main` was clean before branching.
- **Conclusion:** 0 new failures.

Logs: `/tmp/typecheck-pr2.log`.
