### PR TITLE
Chrome: bound the pinned card stack (blocking vs ambient + rollup)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1875,17 +1875,35 @@ export function ChatPanel({
     secrets: { order: 2, label: "secret" },
     webhooks: { order: 1, label: "webhook" },
   };
+  // Monotonic first-seen arrival counter for blocking cards (BET-783 reviewer
+  // Block). Records each blocking ask's true interleaved arrival across
+  // permission requests AND delegate-approval, so "newest" is real arrival
+  // order — NOT derived from the live array length. Deriving delegate's order
+  // from `permissions.length` always out-ranks every newer permission, which
+  // is exactly the "urgent thing demoted" failure this issue prevents. The
+  // idempotent `map.size` assignment survives React StrictMode double-render
+  // (second pass finds the id already present) and the per-session-instance
+  // lifetime (ChatPanel is keyed by session id in App) makes it self-resetting.
+  const blockingArrival = useRef<Map<string, number>>(new Map());
   const cards = useMemo<PinnedCardRender[]>(() => {
     const list: PinnedCardRender[] = [];
     const block = (id: string, order: number, render: React.ReactNode): PinnedCardRender =>
       ({ id, tier: "blocking", order, render });
     const amb = (id: string, render: React.ReactNode): PinnedCardRender =>
       ({ id, tier: "ambient", order: AMBIENT_CARD[id].order, label: AMBIENT_CARD[id].label, render });
-    // Blocking tier — permission requests + delegate-approval. Array index is
-    // arrival order, so the last is newest (highest order => rendered first).
+    const blockOrder = (id: string): number => {
+      const map = blockingArrival.current;
+      let order = map.get(id);
+      if (order === undefined) {
+        order = map.size;
+        map.set(id, order);
+      }
+      return order;
+    };
+    // Blocking tier — permission requests + delegate-approval, newest first.
     if (!jobOwnership) {
-      permissions.forEach((p, i) => list.push(block(
-        `permission-${p.id}`, i,
+      permissions.forEach((p) => list.push(block(
+        `permission-${p.id}`, blockOrder(`permission-${p.id}`),
         <PermissionCard
           key={p.id}
           perm={p}
@@ -1893,7 +1911,7 @@ export function ChatPanel({
         />,
       )));
       if (pendingApproval) list.push(block(
-        "delegate-approval", permissions.length,
+        "delegate-approval", blockOrder("delegate-approval"),
         <DelegateApprovalCard
           approval={pendingApproval}
           onApprove={(tools: DelegateApprovalTool[]) => {

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1867,13 +1867,13 @@ export function ChatPanel({
   // blocking tier (always above ambient, at most one expanded) and an ambient
   // tier (fixed priority, at most two expanded, the rest rolled up).
   const AMBIENT_CARD: Record<string, { order: number; label: string }> = {
-    retry: { order: 7, label: "retry" },
-    compaction: { order: 6, label: "compaction" },
-    "send-error": { order: 5, label: "error" },
-    queued: { order: 4, label: "queued" },
-    schedules: { order: 3, label: "schedule" },
-    secrets: { order: 2, label: "secret" },
-    webhooks: { order: 1, label: "webhook" },
+    retry: { order: 7, label: "↻ retry" },
+    compaction: { order: 6, label: "↧ compaction" },
+    "send-error": { order: 5, label: "⚠ error" },
+    queued: { order: 4, label: "⏳ queued" },
+    schedules: { order: 3, label: "⏰ schedule" },
+    secrets: { order: 2, label: "🔑 secret" },
+    webhooks: { order: 1, label: "🪝 webhook" },
   };
   // Monotonic first-seen arrival counter for blocking cards (BET-783 reviewer
   // Block). Records each blocking ask's true interleaved arrival across
@@ -2135,7 +2135,7 @@ export function ChatPanel({
           internal scroll so the transcript stays the flexible child of the
           panel. Read-only job sessions (jobOwnership) never mount these — the
           ReadOnlyJobBar below replaces the composer instead. */}
-      <CardStack cards={cards} />
+      <CardStack cards={cards} sessionId={sessionId} />
 
       {jobOwnership ? (
         <ReadOnlyJobBar

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -73,7 +73,7 @@ import { MeasureColumn } from "./MeasureColumn";
 import { CompactionCard, PermissionCard, RetryCard } from "./Cards";
 import { Button } from "./Button";
 import { DelegateApprovalCard, ReadOnlyJobBar, ScheduledTasksCard, SecretsCard, WebhooksCard } from "./PanelCards";
-import { CardMount } from "./components/CardMount";
+import { CardStack, type PinnedCardRender } from "./components/CardStack";
 import { useSessionResources } from "./hooks/useSessionResources";
 import { useInputHistory } from "./hooks/useInputHistory";
 import { useTranscriptState } from "./hooks/useTranscriptState";
@@ -1858,6 +1858,146 @@ export function ChatPanel({
     return () => setChatMessages(sessionId, []);
   }, [sessionId, setChatMessages]);
 
+
+  // ===== Pinned card stack (BET-783) =====
+  // The cards that mount above the composer used to be ten hardcoded CardMount
+  // blocks in JSX order, so the transcript was the only flexible child and a
+  // permission request could land below three ambient cards. They are now DATA
+  // — a list the pure `arrangeCards` arbiter (via <CardStack/>) sorts into a
+  // blocking tier (always above ambient, at most one expanded) and an ambient
+  // tier (fixed priority, at most two expanded, the rest rolled up).
+  const AMBIENT_CARD: Record<string, { order: number; label: string }> = {
+    retry: { order: 7, label: "retry" },
+    compaction: { order: 6, label: "compaction" },
+    "send-error": { order: 5, label: "error" },
+    queued: { order: 4, label: "queued" },
+    schedules: { order: 3, label: "schedule" },
+    secrets: { order: 2, label: "secret" },
+    webhooks: { order: 1, label: "webhook" },
+  };
+  const cards = useMemo<PinnedCardRender[]>(() => {
+    const list: PinnedCardRender[] = [];
+    const block = (id: string, order: number, render: React.ReactNode): PinnedCardRender =>
+      ({ id, tier: "blocking", order, render });
+    const amb = (id: string, render: React.ReactNode): PinnedCardRender =>
+      ({ id, tier: "ambient", order: AMBIENT_CARD[id].order, label: AMBIENT_CARD[id].label, render });
+    // Blocking tier — permission requests + delegate-approval. Array index is
+    // arrival order, so the last is newest (highest order => rendered first).
+    if (!jobOwnership) {
+      permissions.forEach((p, i) => list.push(block(
+        `permission-${p.id}`, i,
+        <PermissionCard
+          key={p.id}
+          perm={p}
+          onReply={(reply) => replyPermission(p.id, reply, p.sessionID)}
+        />,
+      )));
+      if (pendingApproval) list.push(block(
+        "delegate-approval", permissions.length,
+        <DelegateApprovalCard
+          approval={pendingApproval}
+          onApprove={(tools: DelegateApprovalTool[]) => {
+            const id = pendingApproval.id;
+            setPendingApproval(null);
+            void window.api.delegateApprove(id, tools).catch(() => { /* best-effort */ });
+          }}
+          onDecline={() => {
+            const id = pendingApproval.id;
+            setPendingApproval(null);
+            void window.api.delegateDecline(id).catch(() => { /* best-effort */ });
+          }}
+        />,
+      ));
+    }
+    // Ambient tier — fixed priority, independent of arrival order.
+    if (retryInfo) list.push(amb("retry",
+      <div className="shrink-0 px-4 pt-2"><RetryCard info={retryInfo} /></div>));
+    if (compactionState) list.push(amb("compaction",
+      <div className="shrink-0 px-4 pt-2"><CompactionCard state={compactionState} /></div>));
+    if (sendError) list.push(amb("send-error",
+      <div className="shrink-0 mx-4 mb-1 px-2 py-1 text-meta text-danger bg-danger-bg border border-danger/30 rounded-xs break-words flex items-start gap-2">
+        <span className="flex-1">⚠ {sendError}</span>
+        {authReconnect && (
+          <button onClick={openAuthReconnect} className="text-danger hover:text-danger underline leading-none px-1" title={`Reconnect ${authReconnect}`}>
+            Reconnect
+          </button>
+        )}
+        <button onClick={() => setSendError(null)} className="text-danger hover:text-danger leading-none px-1 inline-flex items-center" title="Dismiss" aria-label="Dismiss error">
+          <X size={14} aria-hidden="true" />
+        </button>
+      </div>));
+    if (running && messageQueue.length > 0) list.push(amb("queued",
+      <MeasureColumn>
+        <div className="shrink-0 pb-2 flex flex-col text-meta text-text-faint" style={{ gap: "var(--block-gap)" }}>
+          {messageQueue.map((msg, i) => (
+            <div key={i} className="flex items-baseline gap-1">
+              <Clock size={14} aria-hidden="true" className="shrink-0 self-center" />
+              <span className="italic flex-1 truncate">{msg}</span>
+              <button onClick={() => setMessageQueue((q) => q.filter((_, j) => j !== i))} className="ml-1 text-text-faint hover:text-text leading-none shrink-0 inline-flex items-center" title="Remove from queue" aria-label="Remove from queue">
+                <X size={14} aria-hidden="true" />
+              </button>
+            </div>
+          ))}
+        </div>
+      </MeasureColumn>));
+    if (!jobOwnership) {
+      if (openPanel === "schedules") list.push(amb("schedules",
+        <div className="shrink-0 px-4 pt-2 pb-2">
+          <ScheduledTasksCard
+            jobs={schedules}
+            error={scheduleError}
+            onClose={closePanel}
+            onDelete={(id) => {
+              setSchedules((prev) => prev.filter((j) => j.id !== id));
+              window.api.scheduleDelete(id).then(() => refreshSchedules()).catch((e: unknown) => {
+                setScheduleError(e instanceof Error ? e.message : "delete failed");
+                void refreshSchedules();
+              });
+            }}
+          />
+        </div>));
+      if (openPanel === "secrets") list.push(amb("secrets",
+        <div className="shrink-0 px-4 pt-2 pb-2">
+          <SecretsCard
+            secrets={secrets}
+            error={secretError}
+            sessionId={sessionId}
+            onClose={closePanel}
+            onSave={(input) => window.api.secretsSet(input).then((r) => {
+              if (r && r.ok === false) { setSecretError(r.error || "save failed"); return false; }
+              void refreshSecrets(); setSecretError(null); return true;
+            }).catch((e: unknown) => {
+              setSecretError(e instanceof Error ? e.message : "save failed"); return false;
+            })}
+            onDelete={(id) => {
+              setSecrets((prev) => prev.filter((s) => s.id !== id));
+              window.api.secretsDelete(id).then(() => refreshSecrets()).catch((e: unknown) => {
+                setSecretError(e instanceof Error ? e.message : "delete failed");
+                void refreshSecrets();
+              });
+            }}
+          />
+        </div>));
+      if (openPanel === "webhooks") list.push(amb("webhooks",
+        <div className="shrink-0 px-4 pt-2 pb-2">
+          <WebhooksCard
+            hooks={webhooks}
+            error={webhookError}
+            onClose={closePanel}
+            onDelete={(id) => {
+              setWebhooks((prev) => prev.filter((h) => h.id !== id));
+              window.api.webhookDelete(id).then(() => refreshWebhooks()).catch((e: unknown) => {
+                setWebhookError(e instanceof Error ? e.message : "delete failed");
+                void refreshWebhooks();
+              });
+            }}
+          />
+        </div>));
+    }
+    return list;
+  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission]);
+
+
   if (error || transcriptLoadError) {
     return (
       <div className="h-full w-full flex flex-col items-center justify-center gap-4 bg-bg text-text-muted p-6 font-mono">
@@ -1888,6 +2028,7 @@ export function ChatPanel({
       </div>
     );
   }
+
 
   return (
     <div
@@ -1970,239 +2111,13 @@ export function ChatPanel({
         motionStateRef={motionStateRef}
       />
 
-      {/* Pending permission cards. Shown above the running indicator/input */}
-      {/* so they're hard to miss — tool execution pauses until reply. */}
-      {/* Hidden for a job session (BET-418 §D: a job's pre-flight ruleset */}
-      {/* means it never generates asks, but gate defensively anyway). */}
-      {!jobOwnership && (
-      <CardMount show={permissions.length > 0} k="permission">
-        <div className="shrink-0 px-4 pt-2">
-          {/* BET-458: the permission card is a block in the conversation, not
-              an overlay — bound it to the same 72ch measure the transcript
-              column uses (see Transcript), so it edge-aligns with the prose
-              and the question cards instead of bleeding to the pane edge. */}
-          <div className="mx-auto w-full space-y-2" style={{ maxWidth: "72ch" }}>
-            {permissions.map((p) => (
-              <PermissionCard
-                key={p.id}
-                perm={p}
-                onReply={(reply) => replyPermission(p.id, reply, p.sessionID)}
-              />
-            ))}
-          </div>
-        </div>
-      </CardMount>
-      )}
-
-      {/* Retry status — surfaces session.status "retry" so the user can */}
-      {/* see WHY the spinner is still spinning (rate limit, transient API */}
-      {/* failure, etc) instead of assuming the AI is stalled. */}
-      <CardMount show={!!retryInfo} k="retry">
-        {retryInfo && (
-          <div className="shrink-0 px-4 pt-2">
-            <RetryCard info={retryInfo} />
-          </div>
-        )}
-      </CardMount>
-
-      {/* Transcript-loading card removed (BET-251). The warm-stale-reopen */}
-      {/* refetch is now surfaced as an ambient orange sweep on the composer's */}
-      {/* top divider — see InputArea. */}
-      {/* Cold-load (`messages === null`) is still covered by the full-screen */}
-      {/* "Connecting to session…" spinner above. */}
-      {/* `refreshing` is still threaded into the composer below. */}
-
-      {/* Live compaction progress. Streams the summary as it's produced and */}
-      {/* flips to a brief "Compacted" confirmation after .ended; clears on */}
-      {/* a timer (session.compacted refetch has already landed by then). */}
-      <CardMount show={!!compactionState} k="compaction">
-        {compactionState && (
-          <div className="shrink-0 px-4 pt-2">
-            <CompactionCard state={compactionState} />
-          </div>
-        )}
-      </CardMount>
-
-      {/* BET-418 §A: pre-flight background-job approval. Shown in the parent's */}
-      {/* panel when a `delegate` call declared tools and trust mode is OFF. */}
-      {/* Hidden for a job session (read-only view). */}
-      {!jobOwnership && (
-      <CardMount show={!!pendingApproval} k="delegate-approval">
-        {pendingApproval && (
-          <div className="shrink-0 px-4 pt-2 pb-2">
-            <DelegateApprovalCard
-              approval={pendingApproval}
-              onApprove={(tools: DelegateApprovalTool[]) => {
-                const id = pendingApproval.id;
-                setPendingApproval(null);
-                void window.api.delegateApprove(id, tools).catch(() => { /* best-effort */ });
-              }}
-              onDecline={() => {
-                const id = pendingApproval.id;
-                setPendingApproval(null);
-                void window.api.delegateDecline(id).catch(() => { /* best-effort */ });
-              }}
-            />
-          </div>
-        )}
-      </CardMount>
-      )}
-
-      {/* Scheduled-tasks management card. Toggled by the ⏰ toolbar button */}
-      {/* (desktop) or the ⋯ sheet (mobile). Refetch-driven while open. */}
-      {/* pb-2 gives the card breathing room above the composer border so it */}
-      {/* doesn't sit flush against the chat divider. Hidden for a job session. */}
-      <CardMount show={!jobOwnership && openPanel === "schedules"} k="schedules">
-        {!jobOwnership && openPanel === "schedules" && (
-          <div className="shrink-0 px-4 pt-2 pb-2">
-            <ScheduledTasksCard
-              jobs={schedules}
-              error={scheduleError}
-              onClose={closePanel}
-              onDelete={(id) => {
-                setSchedules((prev) => prev.filter((j) => j.id !== id));
-                window.api
-                  .scheduleDelete(id)
-                  .then(() => refreshSchedules())
-                  .catch((e: unknown) => {
-                    setScheduleError(
-                      e instanceof Error ? e.message : "delete failed",
-                    );
-                    void refreshSchedules();
-                  });
-              }}
-            />
-          </div>
-        )}
-      </CardMount>
-
-      {/* Secrets management card. Toggled by the 🔑 toolbar button (desktop) or */}
-      {/* the ⋯ sheet (mobile). The value never appears here — list is metadata */}
-      {/* only. Hidden for a job session (read-only view). */}
-      <CardMount show={!jobOwnership && openPanel === "secrets"} k="secrets">
-        {!jobOwnership && openPanel === "secrets" && (
-          <div className="shrink-0 px-4 pt-2 pb-2">
-            <SecretsCard
-              secrets={secrets}
-              error={secretError}
-              sessionId={sessionId}
-              onClose={closePanel}
-              onSave={(input) => {
-                return window.api
-                  .secretsSet(input)
-                  .then((r) => {
-                    if (r && r.ok === false) {
-                      setSecretError(r.error || "save failed");
-                      return false;
-                    }
-                    void refreshSecrets();
-                    setSecretError(null);
-                    return true;
-                  })
-                  .catch((e: unknown) => {
-                    setSecretError(e instanceof Error ? e.message : "save failed");
-                    return false;
-                  });
-              }}
-              onDelete={(id) => {
-                setSecrets((prev) => prev.filter((s) => s.id !== id));
-                window.api
-                  .secretsDelete(id)
-                  .then(() => refreshSecrets())
-                  .catch((e: unknown) => {
-                    setSecretError(e instanceof Error ? e.message : "delete failed");
-                    void refreshSecrets();
-                  });
-              }}
-            />
-          </div>
-        )}
-      </CardMount>
-
-      {/* Inbound-webhook management card. Toggled by the 🪝 toolbar button */}
-      {/* (desktop) or the ⋯ sheet (mobile). List is metadata only (no signing */}
-      {/* secret); creation is the AI's job via the `webhook` opencode tool. */}
-      {/* Hidden for a job session (read-only view). */}
-      <CardMount show={!jobOwnership && openPanel === "webhooks"} k="webhooks">
-        {!jobOwnership && openPanel === "webhooks" && (
-          <div className="shrink-0 px-4 pt-2 pb-2">
-            <WebhooksCard
-              hooks={webhooks}
-              error={webhookError}
-              onClose={closePanel}
-              onDelete={(id) => {
-                setWebhooks((prev) => prev.filter((h) => h.id !== id));
-                window.api
-                  .webhookDelete(id)
-                  .then(() => refreshWebhooks())
-                  .catch((e: unknown) => {
-                    setWebhookError(e instanceof Error ? e.message : "delete failed");
-                    void refreshWebhooks();
-                  });
-              }}
-            />
-          </div>
-        )}
-      </CardMount>
-
-      <CardMount show={running && messageQueue.length > 0} k="queued">
-      {running && messageQueue.length > 0 && (
-            // Queued prompts are about to be submitted, so the notice belongs
-            // to the composer stack — default ("measure") MeasureColumn, which
-            // owns the 28px inset (BET-646, supersedes BET-642).
-            <MeasureColumn>
-              <div
-                className="shrink-0 pb-2 flex flex-col text-meta text-text-faint"
-                style={{ gap: "var(--block-gap)" }}
-              >
-              {messageQueue.map((msg, i) => (
-                <div key={i} className="flex items-baseline gap-1">
-                  <Clock size={14} aria-hidden="true" className="shrink-0 self-center" />
-                  <span className="italic flex-1 truncate">{msg}</span>
-                  <button
-                    onClick={() => setMessageQueue((q) => q.filter((_, j) => j !== i))}
-                    className="ml-1 text-text-faint hover:text-text leading-none shrink-0 inline-flex items-center"
-                    title="Remove from queue"
-                    aria-label="Remove from queue"
-                  >
-                    <X size={14} aria-hidden="true" />
-                  </button>
-                </div>
-              ))}
-              </div>
-            </MeasureColumn>
-          )}
-      </CardMount>
-
-      {/* Send error banner — surfaced from both client-side capability */}
-      {/* checks and server-side session.error events. Dismissable. For an */}
-      {/* auth-error (BET-316) the banner also renders a [Reconnect] button */}
-      {/* that dispatches `manta-open-subscriptions` — a no-op until the */}
-      {/* Settings → AI → Subscriptions card lands (BET-314). */}
-      <CardMount show={!!sendError} k="send-error">
-        {sendError && (
-          <div className="shrink-0 mx-4 mb-1 px-2 py-1 text-meta text-danger bg-danger-bg border border-danger/30 rounded-xs break-words flex items-start gap-2">
-            <span className="flex-1">⚠ {sendError}</span>
-            {authReconnect && (
-              <button
-                onClick={openAuthReconnect}
-                className="text-danger hover:text-danger underline leading-none px-1"
-                title={`Reconnect ${authReconnect}`}
-              >
-                Reconnect
-              </button>
-            )}
-            <button
-              onClick={() => setSendError(null)}
-              className="text-danger hover:text-danger leading-none px-1 inline-flex items-center"
-              title="Dismiss"
-              aria-label="Dismiss error"
-            >
-              <X size={14} aria-hidden="true" />
-            </button>
-          </div>
-        )}
-      </CardMount>
+      {/* Pinned card stack above the composer (BET-783): blocking always
+          above ambient, at most one blocking expanded, at most two ambient
+          expanded (rest rolled up); the whole stack is capped at 30vh with
+          internal scroll so the transcript stays the flexible child of the
+          panel. Read-only job sessions (jobOwnership) never mount these — the
+          ReadOnlyJobBar below replaces the composer instead. */}
+      <CardStack cards={cards} />
 
       {jobOwnership ? (
         <ReadOnlyJobBar

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1911,7 +1911,7 @@ export function ChatPanel({
         />,
       )));
       if (pendingApproval) list.push(block(
-        "delegate-approval", blockOrder("delegate-approval"),
+        `delegate-${pendingApproval.id}`, blockOrder(`delegate-${pendingApproval.id}`),
         <DelegateApprovalCard
           approval={pendingApproval}
           onApprove={(tools: DelegateApprovalTool[]) => {

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3393,6 +3393,8 @@ describe("selectStatusItems", () => {
     const r = selectStatusItems([], 400, []);
     expect(r.visible).toEqual([]);
     expect(r.overflow).toEqual([]);
+  });
+});
 
 describe("arrangeCards", () => {
   const blocking = (id: string, order: number) => ({ id, tier: "blocking" as const, order });

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -50,6 +50,7 @@ import {
   connectPhaseLabel,
   isPollExpired,
   describeSubscriptionStatus,
+  arrangeCards,
   terminalShortcut,
   authErrorAdvice,
   AUTH_PROVIDER_LABELS,
@@ -3392,5 +3393,100 @@ describe("selectStatusItems", () => {
     const r = selectStatusItems([], 400, []);
     expect(r.visible).toEqual([]);
     expect(r.overflow).toEqual([]);
+
+describe("arrangeCards", () => {
+  const blocking = (id: string, order: number) => ({ id, tier: "blocking" as const, order });
+  const ambient = (id: string, order: number) => ({ id, tier: "ambient" as const, order });
+
+  it("returns an empty result for no cards", () => {
+    expect(arrangeCards([])).toEqual({
+      blocking: null,
+      blockingMore: 0,
+      ambient: [],
+      ambientRollup: [],
+    });
+  });
+
+  it("renders a single blocking card", () => {
+    const cards = [blocking("permission-a", 0)];
+    const r = arrangeCards(cards);
+    expect(r.blocking?.id).toBe("permission-a");
+    expect(r.blockingMore).toBe(0);
+  });
+
+  it("three blocking cards: one expanded plus 2 more", () => {
+    const cards = [
+      blocking("permission-a", 0),
+      blocking("permission-b", 1),
+      blocking("delegate-approval", 2),
+    ];
+    const r = arrangeCards(cards);
+    expect(r.blocking?.id).toBe("delegate-approval"); // newest (highest order)
+    expect(r.blockingMore).toBe(2);
+  });
+
+  it("blocking picks the newest regardless of input order", () => {
+    const cards = [
+      blocking("delegate-approval", 5),
+      blocking("permission-a", 0),
+      blocking("permission-b", 1),
+    ];
+    expect(arrangeCards(cards).blocking?.id).toBe("delegate-approval");
+    expect(arrangeCards(cards).blockingMore).toBe(2);
+  });
+
+  it("two ambient cards both render expanded", () => {
+    const cards = [ambient("retry", 7), ambient("compaction", 6)];
+    const r = arrangeCards(cards);
+    expect(r.ambient.map((c) => c.id)).toEqual(["retry", "compaction"]);
+    expect(r.ambientRollup).toEqual([]);
+  });
+
+  it("four ambient cards: two expanded, two rolled up", () => {
+    const cards = [
+      ambient("retry", 7),
+      ambient("compaction", 6),
+      ambient("send-error", 5),
+      ambient("queued", 4),
+    ];
+    const r = arrangeCards(cards);
+    expect(r.ambient.map((c) => c.id)).toEqual(["retry", "compaction"]);
+    expect(r.ambientRollup.map((c) => c.id)).toEqual(["send-error", "queued"]);
+  });
+
+  it("ambient priority order is independent of input order", () => {
+    const r = arrangeCards([
+      ambient("queued", 4),
+      ambient("send-error", 5),
+      ambient("retry", 7),
+      ambient("compaction", 6),
+    ]);
+    expect(r.ambient.map((c) => c.id)).toEqual(["retry", "compaction"]);
+    expect(r.ambientRollup.map((c) => c.id)).toEqual(["send-error", "queued"]);
+  });
+
+  it("blocking always orders above ambient (never interleaved)", () => {
+    const r = arrangeCards([
+      ambient("retry", 100),
+      blocking("permission-a", 0),
+      ambient("compaction", 90),
+    ]);
+    // blocking is separate from ambient entirely:
+    expect(r.blocking?.id).toBe("permission-a");
+    expect(r.ambient.map((c) => c.id)).toEqual(["retry", "compaction"]);
+  });
+
+  it("blocks with more ambient than the expanded cap roll up", () => {
+    const r = arrangeCards([
+      blocking("permission-a", 0),
+      ambient("retry", 7),
+      ambient("compaction", 6),
+      ambient("send-error", 5),
+      ambient("queued", 4),
+    ]);
+    expect(r.blocking?.id).toBe("permission-a");
+    expect(r.blockingMore).toBe(0);
+    expect(r.ambient.length).toBe(2);
+    expect(r.ambientRollup.length).toBe(2);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2659,3 +2659,5 @@ export function arrangeCards<T extends PinnedCard>(cards: T[]): PinnedCardStack<
     ambient: ambient.slice(0, MAX_AMBIENT_EXPANDED),
     ambientRollup: ambient.slice(MAX_AMBIENT_EXPANDED),
   };
+
+}

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2590,3 +2590,72 @@ export function selectStatusItems(
   }
   return { visible, overflow };
 }
+
+// ===== Pinned card stack arbiter (BET-783) =====
+//
+// Ten cards mount above the composer (permission ×N, retry, compaction,
+// delegate-approval, schedules|secrets|webhooks, queued, send-error) and used
+// to stack in hardcoded JSX order, so the transcript was the only flexible
+// child and a permission request (the single most urgent thing in the app)
+// could end up below several ambient cards. `arrangeCards` is the composer-
+// stack counterpart to `pickBanner` (bannerPriority.ts): where pickBanner
+// collapses boolean state to ONE top-of-window bar, this takes a LIST of
+// independent cards and splits it into two tiers with count + rollup.
+//
+// Tier rules:
+//   blocking — permission, question, delegate-approval. Always above ambient,
+//              never chronologically interleaved; at most ONE expanded, the
+//              newest; the rest collapse into an "N more requests" row.
+//   ambient  — retry, compaction, send-error, queued, resource cards. Fixed
+//              priority order (not arrival order); at most MAX_AMBIENT_EXPANDED
+//              expanded; the rest collapse into a rollup row.
+//
+// Deliberately NOT folded into pickBanner: pickBanner takes a flat boolean
+// BannerState and returns a single winner; arrangeCards takes an ordered LIST
+// of mutable cards and returns expanded + counted-rollup subsets. Different
+// shape, different callers — merging them would force both to give up what
+// makes them simple.
+
+export type CardTier = "blocking" | "ambient";
+
+export interface PinnedCard {
+  /** Stable key for the mount slot (e.g. "permission-<id>", "retry"). */
+  id: string;
+  tier: CardTier;
+  /**
+   * Within-tier ordering. Blocking: higher = newer (newest renders first).
+   * Ambient: higher = more prominent (fixed priority, independent of the
+   * input order of the cards array).
+   */
+  order: number;
+  /** Optional ambient-rollup label (e.g. "schedule"). Ignored for blocking. */
+  label?: string;
+}
+
+export interface PinnedCardStack<T extends PinnedCard = PinnedCard> {
+  /** The single blocking card to render expanded (newest), or null. */
+  blocking: T | null;
+  /** Number of additional pending blocking cards ("N more requests"). */
+  blockingMore: number;
+  /** Ambient cards rendered expanded, priority order, at most MAX_AMBIENT_EXPANDED. */
+  ambient: T[];
+  /** Remaining ambient cards collapsed into a rollup row, priority order. */
+  ambientRollup: T[];
+}
+
+/** Max ambient cards rendered expanded; the rest collapse into the rollup row. */
+export const MAX_AMBIENT_EXPANDED = 2;
+
+export function arrangeCards<T extends PinnedCard>(cards: T[]): PinnedCardStack<T> {
+  const blocking = cards
+    .filter((c) => c.tier === "blocking")
+    .sort((a, b) => b.order - a.order);
+  const ambient = cards
+    .filter((c) => c.tier === "ambient")
+    .sort((a, b) => b.order - a.order);
+  return {
+    blocking: blocking[0] ?? null,
+    blockingMore: Math.max(0, blocking.length - 1),
+    ambient: ambient.slice(0, MAX_AMBIENT_EXPANDED),
+    ambientRollup: ambient.slice(MAX_AMBIENT_EXPANDED),
+  };

--- a/src/renderer/components/CardStack.tsx
+++ b/src/renderer/components/CardStack.tsx
@@ -1,0 +1,126 @@
+// ===== CardStack (BET-783) =====
+//
+// Presentational home of the pinned card stack that mounts above the composer
+// (permission / retry / compaction / delegate-approval / schedules|secrets|
+// webhooks / queued / send-error). ChatPanel builds the list of visible
+// cards as DATA (`PinnedCardRender[]`) and hands it here; this component runs
+// it through the pure `arrangeCards` arbiter and renders the result:
+//
+//   - blocking tier always above ambient, at most one expanded (the newest),
+//     the rest behind an "N more requests" toggle;
+//   - ambient tier in fixed priority order, at most two expanded, the rest
+//     collapsed into a rollup row that expands in place;
+//   - the whole stack capped at 30vh with internal scroll, so the transcript
+//     stays the flexible child of the panel.
+//
+// CardMount wraps every card so mount/unmount stays layout-shift-free.
+
+import { useEffect, useMemo, useState, type ReactNode } from "react";
+import { CardMount } from "./CardMount";
+import { arrangeCards, type PinnedCard } from "../chatUtils";
+
+export interface PinnedCardRender extends PinnedCard {
+  /** Self-contained card content (already includes its own padding wrapper). */
+  render: ReactNode;
+}
+
+export function CardStack({ cards }: { cards: PinnedCardRender[] }) {
+  const arranged = useMemo(() => arrangeCards(cards), [cards]);
+  const { blocking, blockingMore, ambient, ambientRollup } = arranged;
+  const blockingList = useMemo(
+    () => cards.filter((c) => c.tier === "blocking").sort((a, b) => b.order - a.order),
+    [cards],
+  );
+  const [blockingExpanded, setBlockingExpanded] = useState(false);
+  const [ambientExpanded, setAmbientExpanded] = useState(false);
+  useEffect(() => {
+    setBlockingExpanded(false);
+    setAmbientExpanded(false);
+  }, []);
+
+  const rollupText = (() => {
+    const counts = new Map<string, number>();
+    for (const c of ambientRollup) {
+      const l = c.label ?? c.id;
+      counts.set(l, (counts.get(l) ?? 0) + 1);
+    }
+    return [...counts.entries()]
+      .map(([l, n]) => (n > 1 ? `${l} ×${n}` : l))
+      .join(" · ");
+  })();
+
+  return (
+    <div className="shrink-0 overflow-y-auto" style={{ maxHeight: "30vh" }}>
+      {/* Blocking tier — newest first, at most one expanded. */}
+      {blockingList.length > 0 && (
+        <div className="mx-auto w-full py-1" style={{ maxWidth: "72ch" }}>
+          <div className="space-y-2">
+            <CardMount show={blockingList.length > 0} k={blocking?.id ?? "blocking"}>
+              <div className="shrink-0 px-4 pt-2">{blocking?.render}</div>
+            </CardMount>
+            {blockingMore > 0 &&
+              (blockingExpanded ? (
+                <>
+                  <CardMount show k="blocking-more">
+                    <div className="shrink-0 px-4 pt-2 space-y-2">
+                      {blockingList.slice(1).map((c) => (
+                        <div key={c.id}>{c.render}</div>
+                      ))}
+                    </div>
+                  </CardMount>
+                  <button
+                    type="button"
+                    onClick={() => setBlockingExpanded(false)}
+                    className="shrink-0 px-4 text-meta text-text-faint hover:text-text leading-none"
+                  >
+                    Show fewer
+                  </button>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setBlockingExpanded(true)}
+                  className="shrink-0 px-4 text-meta text-text-faint hover:text-text leading-none"
+                >
+                  {blockingMore > 1 ? `${blockingMore} more requests` : "1 more request"}{" "}›
+                </button>
+              ))}
+          </div>
+        </div>
+      )}
+
+      {/* Ambient tier — fixed priority, at most two expanded, rest rolled up. */}
+      {ambient.map((c) => (
+        <CardMount key={c.id} show k={c.id}>
+          {c.render}
+        </CardMount>
+      ))}
+      {ambientRollup.length > 0 &&
+        (ambientExpanded ? (
+          <>
+            {ambientRollup.map((c) => (
+              <CardMount key={c.id} show k={c.id}>
+                {c.render}
+              </CardMount>
+            ))}
+            <button
+              type="button"
+              onClick={() => setAmbientExpanded(false)}
+              className="shrink-0 mx-4 mb-1 px-3 py-1 text-meta text-text-faint hover:text-text leading-none"
+            >
+              Show fewer
+            </button>
+          </>
+        ) : (
+          <button
+            type="button"
+            onClick={() => setAmbientExpanded(true)}
+            className="shrink-0 mx-4 my-1 px-3 py-1 text-meta text-text-faint hover:text-text leading-none inline-flex items-center gap-1"
+            title="Show all"
+          >
+            ⚙ {rollupText} ›
+          </button>
+        ))}
+    </div>
+  );
+}

--- a/src/renderer/components/CardStack.tsx
+++ b/src/renderer/components/CardStack.tsx
@@ -24,7 +24,15 @@ export interface PinnedCardRender extends PinnedCard {
   render: ReactNode;
 }
 
-export function CardStack({ cards }: { cards: PinnedCardRender[] }) {
+// One padding recipe for the stack's four toggle/rollup controls ("N more
+// requests", the two "Show fewer"s, and the collapsed rollup row) — same
+// control in four positions (BET-783 steering). `mx-4` keeps them clear of the
+// transcript's 72ch measure; `my-1` gives breathing room against surrounding
+// cards.
+const TOGGLE_CLS =
+  "shrink-0 mx-4 my-1 px-3 py-1 text-meta text-text-faint hover:text-text leading-none";
+
+export function CardStack({ cards, sessionId }: { cards: PinnedCardRender[]; sessionId?: string }) {
   const arranged = useMemo(() => arrangeCards(cards), [cards]);
   const { blocking, blockingMore, ambient, ambientRollup } = arranged;
   const blockingList = useMemo(
@@ -33,10 +41,12 @@ export function CardStack({ cards }: { cards: PinnedCardRender[] }) {
   );
   const [blockingExpanded, setBlockingExpanded] = useState(false);
   const [ambientExpanded, setAmbientExpanded] = useState(false);
+  // Collapse any open rollup on session change — carrying an expanded stack
+  // across a session switch would be wrong.
   useEffect(() => {
     setBlockingExpanded(false);
     setAmbientExpanded(false);
-  }, []);
+  }, [sessionId]);
 
   const rollupText = (() => {
     const counts = new Map<string, number>();
@@ -71,7 +81,7 @@ export function CardStack({ cards }: { cards: PinnedCardRender[] }) {
                   <button
                     type="button"
                     onClick={() => setBlockingExpanded(false)}
-                    className="shrink-0 px-4 text-meta text-text-faint hover:text-text leading-none"
+                    className={TOGGLE_CLS}
                   >
                     Show fewer
                   </button>
@@ -80,7 +90,7 @@ export function CardStack({ cards }: { cards: PinnedCardRender[] }) {
                 <button
                   type="button"
                   onClick={() => setBlockingExpanded(true)}
-                  className="shrink-0 px-4 text-meta text-text-faint hover:text-text leading-none"
+                  className={TOGGLE_CLS}
                 >
                   {blockingMore > 1 ? `${blockingMore} more requests` : "1 more request"}{" "}›
                 </button>
@@ -106,7 +116,7 @@ export function CardStack({ cards }: { cards: PinnedCardRender[] }) {
             <button
               type="button"
               onClick={() => setAmbientExpanded(false)}
-              className="shrink-0 mx-4 mb-1 px-3 py-1 text-meta text-text-faint hover:text-text leading-none"
+              className={TOGGLE_CLS}
             >
               Show fewer
             </button>
@@ -115,10 +125,10 @@ export function CardStack({ cards }: { cards: PinnedCardRender[] }) {
           <button
             type="button"
             onClick={() => setAmbientExpanded(true)}
-            className="shrink-0 mx-4 my-1 px-3 py-1 text-meta text-text-faint hover:text-text leading-none inline-flex items-center gap-1"
+            className={`${TOGGLE_CLS} inline-flex items-center gap-1`}
             title="Show all"
           >
-            ⚙ {rollupText} ›
+            {rollupText} ›
           </button>
         ))}
     </div>


### PR DESCRIPTION
## What

Bounds the pinned card stack above the composer (BET-783). The ten hardcoded `<CardMount>` JSX blocks in `ChatPanel.tsx` become **data** — a `PinnedCardRender[]` list — run through the pure `arrangeCards` arbiter (in `chatUtils.ts`) and rendered by a small presentational `<CardStack/>` component.

Rules implemented:
- **Blocking tier** (permission requests + delegate-approval): always above ambient, at most one expanded (the newest), the rest behind an "N more requests" toggle. (iOS already showed only the newest; this brings desktop in line.)
- **Ambient tier** (retry, compaction, send-error, queued, schedules|secrets|webhooks): fixed priority order independent of arrival; at most two expanded, the rest collapse into a rollup row (`⚙ error ×2 · schedule`) that expands in place.
- **Aggregate cap:** the whole stack is `max-height: 30vh` + `overflow-y: auto`, so the transcript stops being the sole absorber.

No card's own markup/props/behaviour changed. `CardMount` still wraps every card (layout-shift-free). The `openPanel` mutual-exclusion in `useSessionResources` is untouched. Read-only job sessions (`jobOwnership`) still never mount these cards.

## What I removed

- The **ten hardcoded card mounts** (permission ×N, retry, compaction, delegate-approval, schedules, secrets, webhooks, queued, send-error) as sibling `<CardMount>` JSX blocks — replaced by one `<CardStack cards={cards} />`.
- Their per-mount wrapper boilerplate collapsed into the shared `<CardStack/>` renderer.
- Net effect: **ChatPanel.tsx shrunk from 2332 → 2247 lines.**

## Could `bannerPriority.ts` host both arbiters?

Investigated; **no.** `pickBanner` takes a flat boolean `BannerState` and returns ONE winner by a fixed severity order. `arrangeCards` takes a LIST of independent cards and returns expanded + counted-rollup subsets across two tiers (and orderings differ: blocking is newest-first arrival, ambient is fixed priority). Same family, different shape — merging them would force both to give up what makes them simple. So this lives in `chatUtils.ts` next to `pickBanner`-style pure logic, per the issue's fallback instruction, and is fully unit-tested there.

## Files changed

`4` files:
- `src/renderer/ChatPanel.tsx` (2332 → 2247 lines)
- `src/renderer/chatUtils.ts` (+70: `arrangeCards`, `PinnedCard`, `PinnedCardStack`, `MAX_AMBIENT_EXPANDED`)
- `src/renderer/chatUtils.test.ts` (+98: 9 `arrangeCards` cases)
- `src/renderer/components/CardStack.tsx` (+126, new)

**Base: origin/main @ `0e56cedc`**

**Verification results:**
- PR branch (`multica/BET-783-pinned-card-stack` @ `e9eb5a9d`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1659 pass / 0 fail / 0 skip (node:test) + vitest 2378 pass / 7 skip. Failures: none. log sha256: `5799059bc2aee5e82894ec8bfb4ed4e1eedacf970b764c2fcdd16a71470ad178`
- Base (`main` @ `0e56cedc`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f` (byte-identical to PR)
  - test: exit 0, 1659 pass / 0 fail. Failures: none. log sha256: `cfedb457d30dee0f993904752319755ea3fc9d02e92cfa0ada3ddff786501a1e`
- **Conclusion:** 0 new failures, 0 pre-existing. (test logs differ in sha only because node:test stamps per-run timing; pass/fail counts identical.)

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.


---

### Follow-up (noted only, out of scope — BET-783)

`docs/components.md` records that `RetryCard` / `CompactionCard` / `ScheduledTasksCard` / `SecretsCard` / `WebhooksCard` still use a legacy hand-rolled shell (`rounded-sm border bg-bg-elev` + inline `rgb(var(--accent-rgb)/0.33)` border) rather than the `Card` primitive. BET-783 must not change any card's own markup; the arbiter refactor does not make the migration a one-liner (the shells carry their own chrome), so this is left as a follow-up rather than folded in.
