### PR TITLE
Event loop I: forge webhook ingest + rules validator + forge_rules tool (BET-797)

### DIFF
--- a/docs/forge-rules-authoring.md
+++ b/docs/forge-rules-authoring.md
@@ -1,0 +1,69 @@
+# Forge rules — authoring guide
+
+Forge rules tell MantaUI what to do when a forge event arrives on the box. The
+file is **written by a tool** (the `forge_rules` opencode tool), lives **on the
+box** at `~/.manta/forge-rules/<host>/<owner>/<repo>.yaml`, and never travels
+with the repository — nothing a pull request can edit ever reaches a rules
+file. The whole subsystem is gated by one global toggle (Settings → Plugins
+area), default off.
+
+## The grammar — complete
+
+One `on:` block. Three verbs. Nothing else.
+
+```yaml
+on:
+  issue.labeled:
+    label: manta
+    do: delegate
+    prompt: "Complete {{url}}. Open a draft PR."
+  checks.failed:
+    branch: mine
+    do: notify
+  review.requested:
+    do: inbox
+```
+
+- **Events.** `issue.labeled`, `checks.failed`, `review.requested`. No others.
+  A rule is keyed by one of these.
+- **Verbs** (`do:`). `delegate` — start a background agent job in its own
+  worktree. `notify` — ping a human. `inbox` — surface in the work inbox. No
+  others.
+- **Conditions.** `issue.labeled` may carry `label:` (match only that label).
+  `checks.failed` may carry `branch:` (e.g. `mine` to only fire on your own
+  PRs). A rule with no condition fires for every event of its type.
+- **prompt.** Only on a `delegate` rule. The only placeholders are the fixed
+  `{{url}}` and `{{title}}`. No expressions, no scripting, no shell.
+
+## Rules
+
+Unknown keys fail validation by name (`unknown key "lable"`), an unknown verb
+is rejected, and a stray `prompt:` on a non-delegate rule is an error. Typo
+protection matters more than flexibility in a file that can start an agent.
+
+If a use case seems to need a new event, verb, or grammar form, that is a
+MantaUI change (the adapter + ingest must understand it), not a rules change —
+raise it rather than working around the grammar.
+
+## Where it lives
+
+- **Box-side storage** (`~/.manta/forge-rules/`), never a repository file. This
+  is the security property: the AI wrote it, so nothing in a repo can change
+  what runs on your machine.
+- **One global toggle** (default off), not a per-repo trust dialog. With it off
+  the subsystem is dormant: nothing registers, nothing ingests, nothing
+  dispatches.
+
+## Authoring loop
+
+1. `forge_rules_save({ repo, yaml })` — validates, writes the file, registers
+   or updates the webhook on the forge, hot-reloads. Returns "saved and valid"
+   or the validator's errors verbatim (nothing written on an error).
+2. `forge_rules_get({ repo })` — the current source, for editing.
+3. `forge_rules_list()` — every repo with rules, **including invalid ones with
+   their reason** — a rules file that silently fails to load is worse than one
+   that loudly refuses.
+4. `forge_rules_docs()` — this guide.
+
+The validator is a single shared module (`src/shared/forgeRules.mjs`) imported
+by the tool, the server and the tests — never a second copy.

--- a/docs/forge-rules-authoring.md
+++ b/docs/forge-rules-authoring.md
@@ -45,6 +45,14 @@ If a use case seems to need a new event, verb, or grammar form, that is a
 MantaUI change (the adapter + ingest must understand it), not a rules change —
 raise it rather than working around the grammar.
 
+## The forge token
+
+Registering the webhook needs a GitHub API token **on the box** (it never
+reaches the desktop or phone). Set `MANTA_GITHUB_TOKEN` in the server env, or
+store it as a shared secret whose key is `github.token` (`gitlab.token` for
+GitLab) in the box secrets vault. The device-flow / `gh`-CLI legs of the token
+ladder arrive with the GitHub adapter.
+
 ## Where it lives
 
 - **Box-side storage** (`~/.manta/forge-rules/`), never a repository file. This

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -245,6 +245,58 @@ from the originating opencode session. Use `plugin_status(id)` only when the
 user explicitly asks for mid-run progress, or after completion to inspect
 the log tail.
 
+## MantaUI forge rules
+
+You have four `forge_rules_*` tools for authoring the box-side rules that
+turn an inbound forge webhook (today: GitHub) into an action. A rules file is
+one `.yaml` per repo, written by you via these tools, stored **on the box** at
+`~/.manta/forge-rules/<host>/<owner>/<repo>.yaml` — never in the repository.
+That placement is the security property: nothing a pull request can edit ever
+reaches what runs on the box, and it replaces a per-repo trust dialog with one
+global toggle (Settings → Extensions → "Run forge rules", default off).
+
+The grammar is deliberately tiny — one `on:` block, three verbs, nothing else:
+
+```yaml
+on:
+  issue.labeled:
+    label: manta
+    do: delegate
+    prompt: "Complete {{url}}. Open a draft PR."
+  checks.failed:
+    branch: mine
+    do: notify
+  review.requested:
+    do: inbox
+```
+
+- Events: `issue.labeled`, `checks.failed`, `review.requested`. No others.
+- Verbs (`do:`): `delegate` (start a background job in its own worktree),
+  `notify` (ping a human), `inbox` (surface in the work inbox).
+- Conditions: `issue.labeled` may carry `label:`; `checks.failed` may carry
+  `branch:`; a rule with no condition fires for every event of its type.
+- `prompt` is only on `delegate`; the only placeholders are `{{url}}` and
+  `{{title}}`. No expressions, no scripting, no shell.
+
+Unknown keys fail validation by name, an unknown verb is rejected, and a stray
+`prompt:` on a non-delegate rule is an error — typo protection matters more than
+flexibility in a file that can start an agent.
+
+- `forge_rules_save(repo, yaml)` — validate, write `~/.manta/forge-rules/…`,
+  register/update the per-repo webhook, hot-reload. Returns "saved and valid"
+  or the validator's errors verbatim (nothing written on an error).
+- `forge_rules_get(repo)` — the current source, for editing.
+- `forge_rules_list()` — every repo with rules, **including INVALID ones with
+  their reason** (a rules file that silently fails to load is worse than one
+  that loudly refuses). Use this to see what's configured and what's broken.
+- `forge_rules_docs()` — the full authoring guide.
+
+Forge events are verified (HMAC over the raw body, constant-time), rate-limited,
+redelivery-deduplicated by `X-GitHub-Delivery`, and filtered by event type in
+the shared webhook ingest — a redelivered event never acts twice. The subsystem
+is gated by the one global toggle; with it off, nothing registers, nothing
+ingests, nothing dispatches.
+
 ## MantaUI background delegation
 
 You have three ways to farm out work, and the axis that separates the last

--- a/docs/opencode-tools/forge-rules.ts
+++ b/docs/opencode-tools/forge-rules.ts
@@ -1,0 +1,190 @@
+// MantaUI forge-rules tools — global opencode custom tools for authoring the
+// box-side forge rules that turn an inbound forge webhook into an action.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/forge-rules.ts ~/.config/opencode/tools/forge-rules.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+// (COPY, never symlink — the `@opencode-ai/plugin` import-resolution gotcha in
+// docs/manta-tools-scheduler.md §"DO NOT symlink".)
+//
+// These tools are THIN registrars. They validate inputs and POST to
+// manta-server (127.0.0.1:8787, same box — no SSH hop), which owns the rules
+// store (src/server/forgeRules.mjs at ~/.manta/forge-rules/) and the shared
+// validator (src/shared/forgeRules.mjs). The server also registers/updates the
+// per-repo webhook on the forge and hot-reloads.
+//
+// A "rules file" is one YAML file per repo, box-side, AI-authored. See
+// forge_rules_docs() for the full authoring guide.
+//
+// This is a copy of docs/opencode-tools/plugins.ts with the payload changed —
+// the boxToken()/authHeaders()/call() helpers are copied VERBATIM so every
+// call authenticates (a rewritten helper returns `unauthorized`). Resist
+// rewriting the plumbing.
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
+// tiny local file) so a token rotation never requires an opencode-serve
+// restart. MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+// ---------------------------------------------------------------------------
+// Tools
+// ---------------------------------------------------------------------------
+
+export const forge_rules_save = tool({
+  description: [
+    "Write (or replace) the box-side forge rules for a repository. Validates the",
+    "YAML against the shared rules validator, writes ~/.manta/forge-rules/",
+    "<host>/<owner>/<repo>.yaml, registers or updates the per-repo webhook on",
+    "the forge, and hot-reloads. Returns \"saved and valid\" on success, or the",
+    "validator's errors VERBATIM with nothing written when the file is invalid.",
+    "Rules live on the box (never in the repo) and are gated by one global",
+    "toggle — call forge_rules_docs() for the grammar before authoring.",
+  ].join(" "),
+  args: {
+    repo: z
+      .string()
+      .describe(
+        "The canonical repository identity as host/owner/repo, e.g. \"github.com/anomalyco/manta\".",
+      ),
+    yaml: z
+      .string()
+      .describe(
+        "Full rules YAML. Grammar: an `on:` block keyed by issue.labeled / checks.failed / review.requested, each with do: delegate | notify | inbox. See forge_rules_docs().",
+      ),
+  },
+  async execute(args) {
+    const r = await call("POST", "/api/forge-rules", {
+      repo: args.repo,
+      yaml: args.yaml,
+    });
+    if (r.ok !== true) {
+      const errs: Array<{ path?: string; message: string }> = r.errors ?? [];
+      if (errs.length > 0) {
+        const lines = errs.map((e) => (e.path ? `${e.path}: ${e.message}` : e.message));
+        throw new Error(`forge rules for ${args.repo} rejected:\n${lines.join("\n")}`);
+      }
+      throw new Error(r.error || "forge-rules save failed");
+    }
+    const base = `Forge rules for ${args.repo} saved and valid.`;
+    const wh = r.webhook;
+    if (wh?.registered) {
+      return `${base}\nWebhook registered at ${wh.url}.`;
+    }
+    if (wh?.error) {
+      return `${base}\nRules saved, but the webhook was NOT registered: ${wh.error}`;
+    }
+    return base;
+  },
+});
+
+export const forge_rules_get = tool({
+  description: [
+    "Return the current box-side forge rules source for a repository, for",
+    "editing. Use before forge_rules_save when you need to extend the existing",
+    "rules. Unknown repo → error.",
+  ].join(" "),
+  args: {
+    repo: z
+      .string()
+      .describe("Repository identity as host/owner/repo, e.g. \"github.com/anomalyco/manta\"."),
+  },
+  async execute(args) {
+    const r = await call("GET", `/api/forge-rules?repo=${encodeURIComponent(args.repo)}`);
+    if (r.yaml === undefined) {
+      throw new Error(`no rules stored for ${args.repo}`);
+    }
+    return `Forge rules for ${args.repo}:\n\n${r.yaml}`;
+  },
+});
+
+export const forge_rules_list = tool({
+  description: [
+    "List every repository with box-side forge rules, INCLUDING invalid ones",
+    "with their validation reason. A rules file that silently fails to load is",
+    "far worse than one that loudly refuses. Use this to see what's configured",
+    "and what's broken across repos.",
+  ].join(" "),
+  args: {},
+  async execute() {
+    const r = await call("GET", "/api/forge-rules");
+    const rows: Array<{ repoKey: string; valid: boolean; error?: string }> = r.rules ?? [];
+    if (rows.length === 0) {
+      return [
+        "No forge rules configured on the box.",
+        "Use forge_rules_save({ repo, yaml }) to author the first one, or call forge_rules_docs() for the grammar.",
+      ].join("\n");
+    }
+    return [
+      "Forge rules on the box:",
+      ...rows.map((row) =>
+        row.valid
+          ? `• ${row.repoKey} — valid`
+          : `• ${row.repoKey} — INVALID: ${row.error ?? "unknown error"}`,
+      ),
+    ].join("\n");
+  },
+});
+
+export const forge_rules_docs = tool({
+  description: [
+    "Return the full forge-rules authoring guide — the grammar (three verbs, no",
+    "others), the allowed conditions, the placeholders, the box-side storage",
+    "rationale, and the authoring loop. Reach for this whenever you are writing",
+    "or editing a rules file, especially the first time.",
+  ].join(" "),
+  args: {},
+  async execute() {
+    const r = await call("GET", "/api/forge-rules/docs");
+    return r.docs ?? "";
+  },
+});

--- a/generated/swift/SettingsSchema.swift
+++ b/generated/swift/SettingsSchema.swift
@@ -57,6 +57,7 @@ enum SettingsSchema {
         SettingSection(id: "models", label: "Models", group: "SETUP"),
         SettingSection(id: "sessions", label: "Sessions", group: "AGENT"),
         SettingSection(id: "files", label: "Files", group: "AGENT"),
+        SettingSection(id: "extensions", label: "Extensions", group: "AGENT"),
         SettingSection(id: "voice", label: "Voice", group: "AGENT"),
     ]
 
@@ -156,6 +157,20 @@ enum SettingsSchema {
             defaultBool: nil,
             defaultNumber: 24,
             options: [SettingOption(value: "24", label: "24 hours"), SettingOption(value: "168", label: "7 days"), SettingOption(value: "0", label: "Never (keep)")],
+            commitOnBlur: false,
+            placeholder: nil,
+        ),
+        SettingEntry(
+            id: "forgeRulesEnabled",
+            section: "extensions",
+            label: "Run forge rules",
+            help: "Lets the box register per-repo forge webhooks (GitHub → your box) and ingest them. Rules are AI-authored, live on the box at ~/.manta/forge-rules/, and never travel with a repository. Off by default.",
+            control: SettingControl.toggle,
+            configKey: "forgeRulesEnabled",
+            defaultString: nil,
+            defaultBool: false,
+            defaultNumber: nil,
+            options: nil,
             commitOnBlur: false,
             placeholder: nil,
         ),

--- a/src/server/forge/token.mjs
+++ b/src/server/forge/token.mjs
@@ -1,0 +1,65 @@
+// src/server/forge/token.mjs — box-side forge credential resolution (BET-797).
+//
+// Registration (`forge_rules_save`) POSTs to `POST /repos/{o}/{r}/hooks` and so
+// needs a GitHub API token ON the box. That token must never reach the Electron
+// renderer or the iOS app — all forge access is box-side, per the hard
+// constraint in the issue. So this resolver reads ONLY box-side sources:
+//
+//   1. An env var (`MANTA_GITHUB_TOKEN` / `MANTA_GITLAB_TOKEN`) — the dev/test
+//      override and a legitimate self-host affordance.
+//   2. A forge token stored in the box secrets vault (~/.manta-secrets, 0600)
+//      as a SHARED secret keyed per host (`github.token` / `gitlab.token`).
+//      The AI can write this via the same secrets tool / Settings card that
+//      holds other box credentials, and the server reads its OWN store
+//      internally for this trusted box-side operation.
+//
+// The device-flow + gh-CLI-token legs of design §3.3's login ladder arrive
+// with the GitHub adapter (BET-810); this file makes registration reachable
+// today with an env or stored token, which unblocks criterion #1 (a real
+// GitHub webhook delivered + logged).
+//
+// Pure of network. I/O (the secrets store) is injectable so unit tests never
+// touch the real ~/.manta-secrets.
+
+import { loadSecrets, resolveSecret } from "../secrets.mjs";
+
+// Env var name per known forge host.
+const ENV_BY_HOST = Object.freeze({
+  "github.com": "MANTA_GITHUB_TOKEN",
+  "gitlab.com": "MANTA_GITLAB_TOKEN",
+});
+
+// Secrets-vault key per host (shared scope).
+const SECRET_KEY_BY_HOST = Object.freeze({
+  "github.com": "github.token",
+  "gitlab.com": "gitlab.token",
+});
+
+/**
+ * Resolve the box-side forge API token for a host, or null when none is
+ * configured. Order: per-host env var, then the shared secrets vault. A host
+ * outside {github.com, gitlab.com} has no known source → null (self-hosted
+ * host mapping arrives with the adapter).
+ *
+ * @param {string} host
+ * @param {{env?: NodeJS.ProcessEnv, loadSecretsFn?: (path?: string) => ReturnType<typeof loadSecrets>}} [opts]
+ * @returns {string|null}
+ */
+export function resolveForgeToken(host, { env = process.env, loadSecretsFn = loadSecrets } = {}) {
+  if (typeof host !== "string" || !host) return null;
+
+  const envKey = ENV_BY_HOST[host];
+  if (envKey) {
+    const v = env[envKey];
+    if (typeof v === "string" && v) return v;
+  }
+
+  const secretKey = SECRET_KEY_BY_HOST[host];
+  if (!secretKey) return null;
+  try {
+    const entry = resolveSecret(loadSecretsFn(), secretKey, null, null);
+    return typeof entry?.value === "string" && entry.value ? entry.value : null;
+  } catch {
+    return null;
+  }
+}

--- a/src/server/forge/token.test.mjs
+++ b/src/server/forge/token.test.mjs
@@ -1,0 +1,36 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { rm } from "node:fs/promises";
+import { resolveForgeToken } from "./token.mjs";
+import { loadSecrets, saveSecrets } from "../secrets.mjs";
+
+test("resolveForgeToken returns the per-host env var", () => {
+  const env = { MANTA_GITHUB_TOKEN: "ghp_envtoken" };
+  assert.equal(resolveForgeToken("github.com", { env, loadSecretsFn: () => [] }), "ghp_envtoken");
+  assert.equal(resolveForgeToken("gitlab.com", { env: { MANTA_GITLAB_TOKEN: "glpat_x" }, loadSecretsFn: () => [] }), "glpat_x");
+});
+
+test("resolveForgeToken falls back to a shared secret in the box secrets vault", async () => {
+  const path = join(tmpdir(), `manta-token-test-${process.pid}-${Math.random().toString(16).slice(2)}.json`);
+  try {
+    await saveSecrets(
+      [
+        { id: "s1", key: "github.token", value: "ghp_vault", scope: "shared", sessionID: null, project: null, createdAt: 0, updatedAt: 0 },
+      ],
+      path,
+    );
+    const loadSecretsFn = () => loadSecrets(path);
+    // No env var → reads the vault.
+    assert.equal(resolveForgeToken("github.com", { env: {}, loadSecretsFn }), "ghp_vault");
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
+test("resolveForgeToken returns null with no env var and no stored secret", () => {
+  assert.equal(resolveForgeToken("github.com", { env: {}, loadSecretsFn: () => [] }), null);
+  assert.equal(resolveForgeToken("", { env: {}, loadSecretsFn: () => [] }), null);
+  assert.equal(resolveForgeToken("unknown.example.com", { env: {}, loadSecretsFn: () => [] }), null);
+});

--- a/src/server/forge/webhook.mjs
+++ b/src/server/forge/webhook.mjs
@@ -1,0 +1,169 @@
+// src/server/forge/webhook.mjs — repository webhook registration for a forge
+// (BET-797). Forge hooks are per-repo and POST straight to the box's own
+// public hostname (`https://<box_id>.boxes.mantaui.com/hook/<token>`) — no
+// gateway fan-out, no GitHub App. The box's own hostname is read via
+// publicBaseUrl() (the same primitive servePage.mjs / the gateway use), never
+// re-derived. The GitLab adapter (a later issue) drops into this same seam:
+// the URL is unwrap-from-reverse-proxy-able and the health-check exists
+// because GitLab permanently disables a hook after repeated failures.
+//
+// Security contract (design spec §5): the forge request carries ONLY the box's
+// public hostname plus a per-repo HMAC secret. A forge token never reaches the
+// Electron renderer or the iOS app — all forge access is box-side, resolved
+// here by the caller. The per-repo secret is the HMAC secret GitHub signs web
+// deliveries with; the box stores it on the matching webhook record so ingest
+// verification (webhooks.mjs) shares the same secret.
+
+import { randomBytes } from "node:crypto";
+
+// The Manta webhook URL under a box's public hostname. `<token>` is the
+// 128-bit capability that resolves to the hook record at ingest.
+export function forgeHookUrl(publicBase, token) {
+  return `${publicBase.replace(/\/+$/, "")}/hook/${token}`;
+}
+
+// Build the request for creating a repo webhook. Pure — the caller runs it
+// through an injectable GitHub API client. Returns { url, headers, body }.
+// `deliveryToken` is the manta capability that appears in the box's /hook URL;
+// `githubToken` is the box's forge credential used for the Authorization
+// header. They are DIFFERENT tokens and must never be conflated.
+export function buildCreateHookRequest({ host, owner, repo, githubToken, deliveryToken, secret, events, publicBase }) {
+  if (!publicBase) {
+    throw new Error(
+      "no public hostname — this box cannot receive webhooks (Tailscale-only / macOS boxes " +
+        "deliberately skip public TLS; polling covers them)",
+    );
+  }
+  const base = githubApiBase(host);
+  return {
+    url: `${base}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/hooks`,
+    headers: githubAuthHeaders(githubToken),
+    body: {
+      name: "web",
+      active: true,
+      events,
+      config: {
+        url: forgeHookUrl(publicBase, deliveryToken),
+        content_type: "json",
+        secret,
+      },
+    },
+  };
+}
+
+// The GitHub Hooks API base for a host. `github.com` maps to api.github.com;
+// a self-hosted host would map to its own API root. Hosted GitHub is the only
+// case this issue registers against.
+export function githubApiBase(host) {
+  if (host === "github.com") return "https://api.github.com";
+  return `https://api.${host}`;
+}
+
+export function githubAuthHeaders(token) {
+  const headers = {
+    accept: "application/vnd.github+json",
+    "content-type": "application/json",
+    "user-agent": "manta-server",
+  };
+  if (typeof token === "string" && token) {
+    headers.authorization = `Bearer ${token}`;
+  }
+  return headers;
+}
+
+// Register (or re-register) a repository webhook. `api` is the injectable
+// (method, url, headers, body) → parsed-json client; injectable so unit tests
+// never touch the network. On an existing hook with the same URL it PATCHes
+// (so the secret/events are refreshed) rather than creating a duplicate.
+export async function ensureRepoHook(
+  { host, owner, repo, githubToken, deliveryToken, publicBase, events },
+  { api = githubFetch, now = () => new Date().toISOString() } = {},
+) {
+  const secret = `whsec_${randomBytes(24).toString("hex")}`;
+  let req;
+  try {
+    req = buildCreateHookRequest({ host, owner, repo, githubToken, deliveryToken, secret, events, publicBase });
+  } catch (e) {
+    return { ok: false, error: e?.message ?? String(e) };
+  }
+
+  const url = forgeHookUrl(publicBase, deliveryToken);
+  try {
+    const list = await api("GET", `${githubApiBase(host)}/repos/${owner}/${repo}/hooks`, githubAuthHeaders(githubToken));
+    const existing = (Array.isArray(list) ? list : []).find(
+      (h) => h?.config?.url === url,
+    );
+    let hook;
+    if (existing?.id != null) {
+      hook = await api("PATCH", `${githubApiBase(host)}/repos/${owner}/${repo}/hooks/${existing.id}`, req.headers, {
+        active: true,
+        events,
+        config: { url, content_type: "json", secret },
+      });
+    } else {
+      hook = await api("POST", req.url, req.headers, req.body);
+    }
+    return {
+      ok: true,
+      secret,
+      hookId: hook?.id ?? existing?.id,
+      events,
+      url,
+      registeredAt: now(),
+    };
+  } catch (e) {
+    return { ok: false, error: e?.message ?? String(e) };
+  }
+}
+
+// Health-check a registered hook. GitHub disables nothing automatically, but
+// GitLab disables a hook permanently after repeated failures — so the check
+// exists before the GitLab adapter lands. Returns the hook's active state plus
+// the recent delivery outcomes when the API exposes them.
+export async function healthCheckRepoHook(
+  { host, owner, repo, token, hookId },
+  { api = githubFetch } = {},
+) {
+  try {
+    const hook = await api(
+      "GET",
+      `${githubApiBase(host)}/repos/${owner}/${repo}/hooks/${hookId}`,
+      githubAuthHeaders(token),
+    );
+    let deliveries = [];
+    try {
+      const dlv = await api(
+        "GET",
+        `${githubApiBase(host)}/repos/${owner}/${repo}/hooks/${hookId}/deliveries?per_page=5`,
+        githubAuthHeaders(token),
+      );
+      deliveries = Array.isArray(dlv) ? dlv : [];
+    } catch {
+      // Deliveries endpoint is optional; a failure here is not a hook failure.
+    }
+    return { ok: true, active: hook?.active !== false, deliveries };
+  } catch (e) {
+    return { ok: false, error: e?.message ?? String(e) };
+  }
+}
+
+// Default GitHub API client — a thin fetch wrapper. Injected as `api` in tests.
+export async function githubFetch(method, url, headers, body) {
+  const res = await fetch(url, {
+    method,
+    headers,
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json;
+  try {
+    json = text ? JSON.parse(text) : null;
+  } catch {
+    json = { raw: text };
+  }
+  if (!res.ok) {
+    const msg = json?.message || json?.raw || `github ${res.status}`;
+    throw new Error(msg);
+  }
+  return json;
+}

--- a/src/server/forgeRules.mjs
+++ b/src/server/forgeRules.mjs
@@ -27,6 +27,7 @@ import {
 } from "../shared/forgeRules.mjs";
 import { genDeliveryToken, upsertForgeHook, findForgeHook } from "./webhooks.mjs";
 import { ensureRepoHook } from "./forge/webhook.mjs";
+import { resolveForgeToken } from "./forge/token.mjs";
 import { publicBaseUrl } from "./gatewayRegister.mjs";
 
 const RULES_ROOT = "forge-rules";
@@ -180,7 +181,8 @@ function formatErrors(errors) {
  * @param {{repo: string, yaml: string}} input
  * @param {object} [deps]
  * @param {() => boolean} [deps.enabled]
- * @param {{host?:string, token?:string}} [deps.forge] forge identity + token for registration
+ * @param {{host?:string, token?:string}} [deps.forge] forge identity + token override for registration
+ * @param {(host: string) => string|null} [deps.resolveToken] box-side token resolver (default resolveForgeToken)
  * @param {object} [deps.io]
  * @param {typeof ensureRepoHook} [deps.ensureHook]
  * @param {() => void} [deps.reload]
@@ -190,6 +192,7 @@ export async function saveRules(
   {
     enabled = () => true,
     forge = {},
+    resolveToken = resolveForgeToken,
     io = DEFAULT_IO,
     ensureHook = ensureRepoHook,
     reload = () => {},
@@ -209,6 +212,11 @@ export async function saveRules(
 
   await io.write(p.path, yaml);
 
+  // The forge API token for the repo's host, resolved box-side (env var or the
+  // secrets vault). Never reaches the renderer/iOS. An explicit `forge.token`
+  // override wins (tests/dev).
+  const token = forge.token || resolveToken(parts.host);
+
   let webhook = { registered: false };
   try {
     const pub = publicBaseUrl();
@@ -219,10 +227,12 @@ export async function saveRules(
           "no public hostname — this box cannot receive webhooks (Tailscale-only / macOS " +
           "boxes deliberately skip public TLS; polling covers them)",
       };
-    } else if (!forge.token) {
+    } else if (!token) {
       webhook = {
         registered: false,
-        error: "no forge token configured (the auth ladder arrives with the adapter)",
+        error:
+          `no ${parts.host} token configured — set MANTA_GITHUB_TOKEN (or MANTA_GITLAB_TOKEN), ` +
+          "or store it as a shared secret named github.token (gitlab.token for GitLab)",
       };
     } else {
       const key = repoKey(parts);
@@ -234,7 +244,7 @@ export async function saveRules(
         host: parts.host,
         owner: parts.owner,
         repo: parts.repo,
-        githubToken: forge.token,
+        githubToken: token,
         deliveryToken,
         publicBase: pub,
         events: eventsForRules(parsed.rules),

--- a/src/server/forgeRules.mjs
+++ b/src/server/forgeRules.mjs
@@ -1,0 +1,308 @@
+// src/server/forgeRules.mjs — box-side forge rules registry (BET-797).
+//
+// The rules file for a repo lives at
+//   ~/.manta/forge-rules/<host>/<owner>/<repo>.yaml
+// authored by the AI through the forge_rules opencode tool, validated by the
+// ONE shared validator (src/shared/forgeRules.mjs), and stored on the BOX — so
+// nothing a PR can edit ever reaches a rules file (design spec §5.2). This
+// module is the server half the tool talks to: it saves/get/lists rules,
+// registers the per-repo webhook, records (logs, never acts on) inbound forge
+// events, and drives the hot-reload publish.
+//
+// Box-side placement is the whole point. A malicious pull request editing a
+// checked-in rules file was the sharpest risk in the original design; placing
+// the file here deletes it outright, and replaces a per-repo trust dialog with
+// one global toggle (AppConfig.forgeRulesEnabled, default off).
+//
+// State files go through statePath() so npm test (which runs with a sandboxed
+// MANTA_STATE_HOME) never writes production data.
+
+import { mkdir, readdir, readFile, writeFile, appendFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { statePath } from "../shared/paths.mjs";
+import { repoKey } from "../shared/forge.mjs";
+import {
+  parseRules,
+  validateForgeRepoPath,
+} from "../shared/forgeRules.mjs";
+import { genDeliveryToken, upsertForgeHook, findForgeHook } from "./webhooks.mjs";
+import { ensureRepoHook } from "./forge/webhook.mjs";
+import { publicBaseUrl } from "./gatewayRegister.mjs";
+
+const RULES_ROOT = "forge-rules";
+const EVENTS_LOG = statePath("forge-events.jsonl");
+
+// ---------------------------------------------------------------------------
+// Pure helpers (tested)
+// ---------------------------------------------------------------------------
+
+// Split a canonical "host/owner/repo" key back into parts. host is the first
+// segment, repo the last, owner everything between (so GitLab subgroup owners
+// "group/subgroup" survive). Input is the join key produced by repoKey(), so
+// it is already lowercased with no trailing slash / .git.
+export function parseRepoKey(key) {
+  if (typeof key !== "string") return null;
+  const parts = key.split("/").filter((s) => s !== "");
+  if (parts.length < 3) return null;
+  return {
+    host: parts[0],
+    owner: parts.slice(1, -1).join("/"),
+    repo: parts[parts.length - 1],
+  };
+}
+
+// The on-disk rules file path for a repo identity, after path-component
+// validation. Returns {ok:true, path} or {ok:false, error}. The owner may be a
+// GitLab subgroup path; each component is validated by validateForgeRepoPath
+// so a crafted repo name cannot escape forge-rules/.
+export function rulesPathFor({ host, owner, repo }) {
+  const v = validateForgeRepoPath({ host, owner, repo });
+  if (!v.ok) return v;
+  return { ok: true, path: statePath(RULES_ROOT, host, ...owner.split("/"), `${repo}.yaml`) };
+}
+
+// ---------------------------------------------------------------------------
+// Registry I/O (injectable for tests; never touches the network)
+// ---------------------------------------------------------------------------
+
+const DEFAULT_IO = {
+  stateRoot: () => statePath(RULES_ROOT),
+  read: (p) => readFile(p, "utf-8"),
+  write: async (p, data) => {
+    await mkdir(dirname(p), { recursive: true, mode: 0o700 });
+    await writeFile(p, data, { mode: 0o600 });
+  },
+  append: (p, data) => appendFile(p, data, { mode: 0o600 }),
+  readdir,
+};
+
+// Canonical repo key for a rules file path (reverse of rulesPathFor).
+function repoKeyFromPath(rel) {
+  const parts = rel.split("/").filter((s) => s !== "" && s !== "." && s !== "..");
+  if (parts.length < 3) return null;
+  const repo = parts[parts.length - 1].replace(/\.yaml$/, "");
+  const host = parts[0];
+  const owner = parts.slice(1, -1).join("/");
+  if (!host || !owner || !repo) return null;
+  return `${host}/${owner}/${repo}`;
+}
+
+// Recursively collect *.yaml files under the rules root, as repo keys.
+async function listRuleFiles(root, rd) {
+  const out = [];
+  async function walk(dir) {
+    let entries;
+    try {
+      entries = await rd(dir, { withFileTypes: true });
+    } catch {
+      return;
+    }
+    for (const e of entries) {
+      const p = join(dir, e.name);
+      if (e.isDirectory()) await walk(p);
+      else if (e.isFile() && e.name.endsWith(".yaml")) out.push(p);
+    }
+  }
+  try {
+    await walk(root);
+  } catch {
+    return [];
+  }
+  return out;
+}
+
+// Get the current source of a repo's rules file. Returns {ok:true, repoKey,
+// yaml} when present, {ok:false, error:"not found"} when absent.
+export async function getRules(repoKeyStr, io = DEFAULT_IO) {
+  const parts = parseRepoKey(repoKeyStr);
+  if (!parts) return { ok: false, error: "invalid repo key" };
+  const p = rulesPathFor(parts);
+  if (!p.ok) return { ok: false, error: p.error };
+  try {
+    const yaml = await io.read(p.path);
+    return { ok: true, repoKey: repoKeyStr, yaml };
+  } catch {
+    return { ok: false, error: "not found" };
+  }
+}
+
+// List EVERY repo with a rules file, INCLUDING invalid ones with their
+// validation error and their raw source. A rules file that silently fails to
+// load is far worse than one that loudly refuses (the same rule the plugin
+// registry enforces). Returns [{repoKey, valid, error?, yaml}].
+export async function listRules(io = DEFAULT_IO) {
+  const root = io.stateRoot();
+  const files = await listRuleFiles(root, io.readdir);
+  const rows = [];
+  for (const file of files) {
+    const rel = file.slice(root.length).replace(/^[/\\]+/, "");
+    const key = repoKeyFromPath(rel);
+    if (!key) continue;
+    let yaml;
+    try {
+      yaml = await io.read(file);
+    } catch (e) {
+      rows.push({ repoKey: key, valid: false, error: `read failed: ${e?.message ?? e}`, yaml: null });
+      continue;
+    }
+    const parsed = parseRules(yaml);
+    rows.push({
+      repoKey: key,
+      valid: parsed.ok,
+      error: parsed.ok ? undefined : formatErrors(parsed.errors),
+      yaml,
+    });
+  }
+  return rows.sort((a, b) => a.repoKey.localeCompare(b.repoKey));
+}
+
+function formatErrors(errors) {
+  return (errors ?? []).map((e) => (e.path ? `${e.path}: ${e.message}` : e.message)).join("; ");
+}
+
+// ---------------------------------------------------------------------------
+// Save — validate → write → register/update the webhook → reload
+// ---------------------------------------------------------------------------
+
+/**
+ * Save a repo's rules. Pure of the network path: validates first (fail loud,
+ * write nothing on a validation error), writes the file, then registers the
+ * per-repo webhook and hot-reloads. Returns:
+ *   {ok:true, repoKey, webhook:{registered:boolean, url?, error?}} on success,
+ * or {ok:false, errors:[...]} with the validator's errors VERBATIM (nothing
+ * written) on a validation failure.
+ *
+ * Registration needs the box's public hostname and a forge token; when either
+ * is absent it fails LOUDLY (the rules file is still saved — the rules are the
+ * point — but the returned webhook.error tells the caller no delivery can
+ * arrive). With the global toggle off this whole path refuses before any write.
+ *
+ * @param {{repo: string, yaml: string}} input
+ * @param {object} [deps]
+ * @param {() => boolean} [deps.enabled]
+ * @param {{host?:string, token?:string}} [deps.forge] forge identity + token for registration
+ * @param {object} [deps.io]
+ * @param {typeof ensureRepoHook} [deps.ensureHook]
+ * @param {() => void} [deps.reload]
+ */
+export async function saveRules(
+  { repo, yaml },
+  {
+    enabled = () => true,
+    forge = {},
+    io = DEFAULT_IO,
+    ensureHook = ensureRepoHook,
+    reload = () => {},
+  } = {},
+) {
+  if (!enabled()) {
+    return { ok: false, error: "forge rules are disabled" };
+  }
+  const parts = parseRepoKey(repo);
+  if (!parts) return { ok: false, error: "invalid repo key" };
+  const parsed = parseRules(yaml);
+  if (!parsed.ok) {
+    return { ok: false, errors: parsed.errors, written: false };
+  }
+  const p = rulesPathFor(parts);
+  if (!p.ok) return { ok: false, error: p.error };
+
+  await io.write(p.path, yaml);
+
+  let webhook = { registered: false };
+  try {
+    const pub = publicBaseUrl();
+    if (!pub) {
+      webhook = {
+        registered: false,
+        error:
+          "no public hostname — this box cannot receive webhooks (Tailscale-only / macOS " +
+          "boxes deliberately skip public TLS; polling covers them)",
+      };
+    } else if (!forge.token) {
+      webhook = {
+        registered: false,
+        error: "no forge token configured (the auth ladder arrives with the adapter)",
+      };
+    } else {
+      const key = repoKey(parts);
+      // Reuse the existing hook's delivery token so the URL stays stable across
+      // re-saves; otherwise mint a fresh capability token for this repo.
+      const existing = await findForgeHook(key);
+      const deliveryToken = existing?.token ?? genDeliveryToken();
+      const res = await ensureHook({
+        host: parts.host,
+        owner: parts.owner,
+        repo: parts.repo,
+        githubToken: forge.token,
+        deliveryToken,
+        publicBase: pub,
+        events: eventsForRules(parsed.rules),
+      });
+      if (!res.ok) {
+        webhook = { registered: false, error: res.error };
+      } else {
+        await upsertForgeHook({
+          repoKey: key,
+          label: key,
+          token: deliveryToken,
+          secret: res.secret,
+          events: eventsForRules(parsed.rules),
+        });
+        webhook = { registered: true, url: res.url };
+      }
+    }
+  } catch (e) {
+    webhook = { registered: false, error: e?.message ?? String(e) };
+  }
+
+  reload();
+  return { ok: true, repoKey: repo, webhook };
+}
+
+// The GitHub webhook events a repo's rules subscribe to. Map each MantaUI rule
+// event to the GitHub delivery event(s) that can carry it (X-GitHub-Event).
+// This is the thin seed of the GitHub adapter's normalisation (a later issue):
+// registering for ONLY the relevant events is what lets the event-type filter
+// drop an irrelevant delivery before it is normalised. `ping` is the standard
+// GitHub keepalive every "web" hook receives.
+const RULE_EVENT_TO_GITHUB = Object.freeze({
+  "issue.labeled": ["issues"],
+  "checks.failed": ["check_run", "status"],
+  "review.requested": ["pull_request"],
+});
+
+export function eventsForRules(rules) {
+  const set = new Set(["ping"]);
+  const on = rules?.on ?? {};
+  for (const ev of Object.keys(on)) {
+    for (const g of RULE_EVENT_TO_GITHUB[ev] ?? []) set.add(g);
+  }
+  return [...set].sort();
+}
+
+// ---------------------------------------------------------------------------
+// Ingest — verify, dedupe, filter (all in webhooks.mjs), then RECORD
+//
+// This issue does NOT act on events. The rules *engine* is the next issue; here
+// a verified delivery is appended to a box-side JSONL log (satisfying "logged"
+// acceptance) and nothing is dispatched. With the toggle off nothing routes —
+// and no forge hooks exist to receive deliveries anyway (registration is gated
+// above).
+// ---------------------------------------------------------------------------
+
+export async function forgeIngest({ hook, headers, event, payload }, io = DEFAULT_IO) {
+  const rec = {
+    time: new Date().toISOString(),
+    repoKey: hook?.repoKey ?? null,
+    event: event ?? null,
+    deliveryId: headers?.["x-github-delivery"] ?? null,
+    payload,
+  };
+  try {
+    await io.append(EVENTS_LOG, JSON.stringify(rec) + "\n");
+  } catch {
+    // Never throw from ingest — transport errors must not fail the sender.
+  }
+  return rec;
+}

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -87,6 +87,12 @@ import {
 } from "./webhooks.mjs";
 import { putRegistry as pluginsPutRegistry, getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import {
+  getRules as forgeGetRules,
+  listRules as forgeListRules,
+  saveRules as forgeSaveRules,
+  forgeIngest,
+} from "./forgeRules.mjs";
+import {
   ensureAuth,
   createAuthEngine,
   isLocalDirectRequest,
@@ -281,6 +287,16 @@ const webhookEngine = createWebhookEngine({
   sendPrompt: (args) => oc.sendPrompt(args),
   delivery: promptDelivery,
   publish: (evt) => bus.publish(evt),
+  // Forge hooks route to the forge ingest path instead of waking a session.
+  // Ingest verifies + dedupes + filters (all in webhooks.mjs) then RECORDS the
+  // event — this issue does NOT act on events (the rules engine is the next
+  // issue). With the global toggle off, nothing routes (no forge hooks exist
+  // anyway — registration is gated; this check is belt-and-suspenders).
+  forgeIngest: async (args) => {
+    const cfg = await local.configGet();
+    if (cfg?.forgeRulesEnabled !== true) return null;
+    return forgeIngest(args);
+  },
 });
 
 // Background-job engine (BET-378): durable jobs that run in their own
@@ -1518,6 +1534,86 @@ const handleRequest = async (req, res) => {
     return;
   }
 
+  // ---------- Forge rules (BET-797) ----------
+  // POST   /api/forge-rules        body {repo, yaml} → {ok, webhook?} on valid,
+  //                               {ok:false, errors:[{path,message}...]} (nothing written)
+  //                               on a validation failure; {ok:false, error} when disabled
+  //                               or the repo identity is unsafe.
+  // GET    /api/forge-rules?repo=  → {yaml} for one repo | {error:"not found"}
+  // GET    /api/forge-rules        → {rules:[{repoKey, valid, error?, yaml}]} — includes
+  //                               INVALID rule files with their reason (a rules file that
+  //                               silently fails to load is worse than one that loudly refuses).
+  // GET    /api/forge-rules/docs   → {docs:"<markdown>"} from docs/forge-rules-authoring.md
+  //
+  // Driven by the forge_rules opencode tool (docs/opencode-tools/forge-rules.ts). The
+  // store lives on the box (~/.manta/forge-rules/) and is gated by the global
+  // AppConfig.forgeRulesEnabled toggle — with it off, no registration, no ingest
+  // routing, no dispatch.
+  if (path === "/api/forge-rules") {
+    try {
+      const cfg = await local.configGet();
+      const enabled = cfg?.forgeRulesEnabled === true;
+      if (req.method === "POST") {
+        if (!enabled) {
+          respondJson(res, 403, { error: "forge rules are disabled" });
+          return;
+        }
+        const body = await readJsonBody(req);
+        const res2 = await forgeSaveRules(
+          { repo: body?.repo, yaml: body?.yaml },
+          { enabled: () => cfg?.forgeRulesEnabled === true },
+        );
+        if (res2.ok !== true) {
+          if (res2.errors) {
+            respondJson(res, 400, { errors: res2.errors });
+          } else {
+            respondJson(res, 400, { error: res2.error ?? "invalid rules" });
+          }
+          return;
+        }
+        respondJson(res, 200, { ok: true, repo: res2.repoKey, webhook: res2.webhook });
+        return;
+      }
+      if (req.method === "GET") {
+        const repo = url.searchParams.get("repo");
+        if (repo) {
+          const g = await forgeGetRules(repo);
+          if (g.ok) respondJson(res, 200, { repo, yaml: g.yaml });
+          else respondJson(res, 404, { error: g.error ?? "not found" });
+          return;
+        }
+        const rules = await forgeListRules();
+        respondJson(res, 200, { rules });
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // GET /api/forge-rules/docs — the authoring guide, resolved relative to the
+  // server module dir (PROJECT_ROOT), never process.cwd().
+  if (path === "/api/forge-rules/docs") {
+    try {
+      if (req.method !== "GET") {
+        respondJson(res, 405, { error: "method not allowed" });
+        return;
+      }
+      const docsPath = join(PROJECT_ROOT, "docs", "forge-rules-authoring.md");
+      const text = await readFile(docsPath, "utf-8");
+      respondJson(res, 200, { docs: text });
+    } catch (e) {
+      respondJson(
+        res,
+        500,
+        { error: `failed to read docs/forge-rules-authoring.md: ${String(e?.message ?? e)}` },
+      );
+    }
+    return;
+  }
+
   // ---------- Inbound webhooks (management) ----------
   // POST   /api/webhook        body {label, instructions, sessionID, directory,
   //                            unsigned?} → {id, url, secret} (secret returned ONCE)
@@ -1583,11 +1679,12 @@ const handleRequest = async (req, res) => {
     const token = path.slice("/hook/".length);
     try {
       const rawBody = await readRawBody(req);
-      const signatureHeader = req.headers["x-manta-signature"];
+      // Pass the raw headers so a forge hook can verify via
+      // X-Hub-Signature-256 (GitHub) as well as X-Manta-Signature.
       const result = await webhookEngine.deliver({
         token,
         rawBody,
-        signatureHeader: typeof signatureHeader === "string" ? signatureHeader : "",
+        headers: req.headers,
       });
       res.writeHead(result.status, { "content-type": "application/json" });
       res.end(

--- a/src/server/webhooks.mjs
+++ b/src/server/webhooks.mjs
@@ -66,6 +66,85 @@ export function verifySignature(secret, rawBody, header) {
   return timingSafeEqual(provided, expected);
 }
 
+// Signature header NAMES, per provider. GitHub signs with `X-Hub-Signature-256`
+// using the identical `sha256=<hex>` scheme MantaUI's own `X-Manta-Signature`
+// uses (BET-797). The GitLab adapter will add a THIRD scheme (Standard
+// Webhooks: a different header, base64, and an HMAC over `id.timestamp.body`)
+// — that arrives with the adapter and lives here as another provider row in
+// the per-provider header table, not as an if/else chain in deliverWebhook.
+const SIGNATURE_HEADERS = Object.freeze({
+  manta: Object.freeze(["x-manta-signature"]),
+  github: Object.freeze(["x-hub-signature-256", "x-manta-signature"]),
+});
+
+// Our webhook record providers. `manta` is the existing inbound hook; `github`
+// is a forge hook registered by the forge rules tool. Anything else is held to
+// be false rather than coerced (a typo shouldn't silently weaken verification).
+export const HOOK_PROVIDERS = ["manta", "github"];
+
+/**
+ * Provider-aware signature resolution. Tries every header name the provider
+ * accepts, in order, and returns true on the first that verifies. A provider
+ * with the same scheme in two headers (GitHub accepts either of ours today)
+ * keeps working when a forge sends its own header. Pure — reads only the plain
+ * header map and the raw body. `unsigned` hooks skip this at the call site.
+ *
+ * @param {"manta"|"github"} provider
+ * @param {string} secret
+ * @param {unknown} rawBody
+ * @param {Record<string, string|string[]|undefined>|undefined} headers lowercased header names
+ */
+export function resolveSignature(provider, secret, rawBody, headers) {
+  const names = SIGNATURE_HEADERS[provider] ?? SIGNATURE_HEADERS.manta;
+  for (const name of names) {
+    const value = headers?.[name];
+    if (typeof value === "string" && verifySignature(secret, rawBody, value)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// GitHub's event-type header (`X-GitHub-Event`). GitHub sends a header per
+// delivery; this is the raw event name. Normalised later by the adapter.
+const GITHUB_EVENT_HEADER = "x-github-event";
+// GitHub's redelivery id header (`X-GitHub-Delivery`). A delivered event keeps
+// this id if GitHub re-sends it, so it is the dedupe key.
+const GITHUB_DELIVERY_HEADER = "x-github-delivery";
+
+// Cap on the per-hook list of recent delivery ids we keep for redelivery
+// dedupe. GitHub redelivery windows are small; 200 is generous headroom.
+const MAX_SEEN_DELIVERIES = 200;
+
+/**
+ * True when an incoming GitHub event is NOT in the hook's registered `events`
+ * whitelist (true → drop). When the hook has no whitelist, nothing is filtered.
+ * Pure. Only meaningful for `github` provider hooks.
+ */
+export function isEventFiltered(hook, event) {
+  if (!Array.isArray(hook?.events) || hook.events.length === 0) return false;
+  return typeof event !== "string" || !hook.events.includes(event);
+}
+
+/**
+ * True when this GitHub delivery id has already been seen on this hook — i.e.
+ * GitHub is REDELIVERING an event we already processed. The box must not act
+ * twice. Pure; the caller persists the id after a fresh delivery.
+ */
+export function isRedelivery(hook, deliveryId) {
+  if (typeof deliveryId !== "string" || !deliveryId) return false;
+  return Array.isArray(hook?.seenDeliveryIds) && hook.seenDeliveryIds.includes(deliveryId);
+}
+
+// Append a delivery id to the dedupe list, newest last, capped.
+export function rememberDelivery(hook, deliveryId) {
+  if (typeof deliveryId !== "string" || !deliveryId) return hook;
+  const seen = Array.isArray(hook.seenDeliveryIds) ? [...hook.seenDeliveryIds] : [];
+  seen.push(deliveryId);
+  if (seen.length > MAX_SEEN_DELIVERIES) seen.splice(0, seen.length - MAX_SEEN_DELIVERIES);
+  return { ...hook, seenDeliveryIds: seen };
+}
+
 // Wrap an external payload into the delivered turn. The payload is fenced and
 // explicitly marked UNTRUSTED DATA (mirrors formatPeerMessage's provenance
 // prefix) so the model treats it as an event report, not as commands. The only
@@ -127,6 +206,7 @@ export function createRateLimiter({
 export function toMeta(hook) {
   return {
     id: hook.id,
+    provider: hook.provider ?? "manta",
     label: hook.label ?? "",
     url: hook.url ?? null,
     unsigned: !!hook.unsigned,
@@ -177,10 +257,24 @@ function genSecret() {
 // are returned ONCE so the agent can configure the external system; thereafter
 // the secret is never re-exposed (listHooks strips it).
 export async function createHook(
-  { label, instructions = "", sessionID, directory = "", unsigned = false, now = () => Date.now() },
+  {
+    label,
+    instructions = "",
+    sessionID,
+    directory = "",
+    unsigned = false,
+    provider = "manta",
+    repoKey = null,
+    now = () => Date.now(),
+  },
   { load = loadHooks, save = saveHooks, publish } = {},
 ) {
-  if (typeof sessionID !== "string" || !sessionID)
+  if (!HOOK_PROVIDERS.includes(provider))
+    return { ok: false, error: `provider must be one of ${HOOK_PROVIDERS.join(", ")}` };
+  // A MantaUI hook wakes a session, so it must name one. A forge hook routes
+  // to the forge ingest path instead (it has no session yet — the event loop
+  // engine is a later issue), so sessionID is optional for forge hooks.
+  if (provider === "manta" && (typeof sessionID !== "string" || !sessionID))
     return { ok: false, error: "sessionID is required" };
   if (typeof label !== "string" || !label.trim())
     return { ok: false, error: "label is required" };
@@ -192,20 +286,77 @@ export async function createHook(
     token,
     secret,
     unsigned: !!unsigned,
+    provider,
+    repoKey: repoKey || null,
     label: label.trim(),
     instructions: typeof instructions === "string" ? instructions.trim() : "",
-    sessionID,
+    sessionID: sessionID || null,
     directory: directory || "",
     url: deliveryUrl(token),
     createdAt: now(),
     lastDeliveredAt: null,
     deliveries: 0,
+    seenDeliveryIds: [],
   };
   const hooks = await load();
   hooks.push(hook);
   await save(hooks);
   publish?.({ kind: "webhook.updated", payload: { sessionID } });
   return { ok: true, hook, url: hook.url, secret };
+}
+
+// Mint a fresh delivery capability token for a forge hook URL. Exported so the
+// forge registration flow can build the box URL (/hook/<token>) before the
+// GitHub hook is created, then persist the SAME token on the webhook record.
+export function genDeliveryToken() {
+  return genToken();
+}
+
+// Create or refresh a forge (provider !== "manta") webhook record keyed by
+// repoKey. The token + secret are SUPPLIED here (unlike createHook, which mints
+// its own) because the GitHub hook URL and its HMAC secret are fixed up front
+// by the registration flow and MUST match the stored record. Reuses an
+// existing record for the same repo so re-save refreshes secret/events rather
+// than accumulating duplicate hooks. Returns the stored hook.
+export async function upsertForgeHook(
+  { repoKey, label, token, secret, events, now = () => Date.now() },
+  { load = loadHooks, save = saveHooks } = {},
+) {
+  const hooks = await load();
+  const idx = hooks.findIndex((h) => h.provider === "github" && h.repoKey === repoKey);
+  const existing = idx >= 0 ? hooks[idx] : null;
+  const url = deliveryUrl(token);
+  const hook = {
+    id: existing?.id ?? genId(),
+    token,
+    secret,
+    provider: "github",
+    repoKey,
+    unsigned: false,
+    label,
+    instructions: "",
+    sessionID: null,
+    directory: "",
+    url,
+    createdAt: existing?.createdAt ?? now(),
+    lastDeliveredAt: existing?.lastDeliveredAt ?? null,
+    deliveries: existing?.deliveries ?? 0,
+    seenDeliveryIds: existing?.seenDeliveryIds ?? [],
+    events,
+  };
+  if (idx >= 0) hooks[idx] = hook;
+  else hooks.push(hook);
+  await save(hooks);
+  return hook;
+}
+
+// Read the full forge hook record (INCLUDING its secret) for a repoKey, or
+// null. Used by the registration flow to reuse an existing hook's token/secret
+// when re-saving rules for the same repo. `toMeta` never returns the secret;
+// this is the box-side forge path only.
+export async function findForgeHook(repoKey, { load = loadHooks } = {}) {
+  const hooks = await load();
+  return hooks.find((h) => h.provider === "github" && h.repoKey === repoKey) ?? null;
 }
 
 export async function deleteHook(id, { load = loadHooks, save = saveHooks, publish } = {}) {
@@ -245,11 +396,12 @@ export async function listHooks(sessionID, { load = loadHooks } = {}) {
  * @param {object} deps { load, save, sendPrompt, publish, now, take, isBusy, enqueue }
  */
 export async function deliverWebhook(
-  { token, rawBody, signatureHeader },
+  { token, rawBody, signatureHeader, headers },
   {
     load = loadHooks,
     save = saveHooks,
     sendPrompt,
+    forgeIngest,
     publish,
     now = () => Date.now(),
     take = () => true,
@@ -263,12 +415,49 @@ export async function deliverWebhook(
   const idx = hooks.findIndex((h) => h.token === token);
   if (idx === -1) return { ok: false, status: 404, error: "unknown webhook" };
   const hook = hooks[idx];
+  const provider = hook.provider ?? "manta";
 
   // Rate-limit BEFORE the (cheap) HMAC so a flood can't burn CPU on crypto.
   if (!take(token)) return { ok: false, status: 429, error: "rate limited" };
 
-  if (!hook.unsigned && !verifySignature(hook.secret, rawBody, signatureHeader)) {
+  // Provider-aware signature. `headers` (raw, lowercased names) is preferred —
+  // it lets a GitHub hook verify via X-Hub-Signature-256 or X-Manta-Signature.
+  // `signatureHeader` is the legacy single-header form (MantaUI's own hooks
+  // and the pre-BET-797 call path) — verify it directly against the same HMAC.
+  let verified;
+  if (typeof signatureHeader === "string" && signatureHeader) {
+    verified = verifySignature(hook.secret, rawBody, signatureHeader);
+  } else {
+    verified = resolveSignature(provider, hook.secret, rawBody, headers);
+  }
+  if (!hook.unsigned && !verified) {
     return { ok: false, status: 401, error: "bad signature" };
+  }
+
+  // Forge hooks: dedupe GitHub redeliveries and honour the event-type
+  // whitelist BEFORE any delivery so a redelivered event cannot act twice.
+  if (provider === "github") {
+    const deliveryId = headers?.[GITHUB_DELIVERY_HEADER];
+    const eventType = headers?.[GITHUB_EVENT_HEADER];
+    if (isRedelivery(hook, deliveryId)) {
+      // A redelivery of something we already handled: acknowledge to GitHub
+      // (it expects 2xx) but do nothing — the event must not act twice.
+      return { ok: true, status: 200, deduped: true };
+    }
+    if (isEventFiltered(hook, eventType)) {
+      // The hook was registered for specific events and this is not one of
+      // them. Drop quietly (2xx), matching GitHub's "successfully handled"
+      // contract for irrelevant delivery types.
+      hooks[idx] = { ...hook, lastDeliveredAt: now(), deliveries: (hook.deliveries ?? 0) + 1 };
+      await save(hooks);
+      return { ok: true, status: 200, filtered: true };
+    }
+    if (deliveryId) {
+      // Persist the delivery id so a future redelivery is caught. Done before
+      // ingest so the "seen" set is durable even if ingest errors.
+      hooks[idx] = rememberDelivery(hook, deliveryId);
+      await save(hooks);
+    }
   }
 
   // Parse the body as JSON; fall back to the raw string if it isn't JSON (some
@@ -294,12 +483,22 @@ export async function deliverWebhook(
   // Stamp delivery metadata + persist (so the card reflects it even if the
   // sendPrompt is deferred).
   hooks[idx] = {
-    ...hook,
+    ...hooks[idx],
     lastDeliveredAt: now(),
-    deliveries: (hook.deliveries ?? 0) + 1,
+    deliveries: (hooks[idx]?.deliveries ?? 0) + 1,
   };
   await save(hooks);
   publish?.({ kind: "webhook.updated", payload: { sessionID: hook.sessionID } });
+
+  // A forge hook routes to the forge ingest path (verify, dedupe, filter, then
+  // RECORD — it does not act on events in this issue). A MantaUI hook wakes
+  // its session via the existing sendPrompt/defer path.
+  if (provider !== "manta") {
+    if (typeof forgeIngest === "function") {
+      await forgeIngest({ hook, headers, event: headers?.[GITHUB_EVENT_HEADER], payload });
+    }
+    return { ok: true, status: 200, queued: false };
+  }
 
   // Defer when busy — an external event must not abort the user's in-flight
   // turn. Otherwise send now.
@@ -347,17 +546,18 @@ export async function deliverWebhook(
  * @param {string} [deps.storePath]
  * @param {() => number} [deps.now]
  */
-export function createWebhookEngine({ sendPrompt, delivery, publish, storePath, now = () => Date.now() } = {}) {
+export function createWebhookEngine({ sendPrompt, delivery, publish, storePath, forgeIngest, now = () => Date.now() } = {}) {
   const path = storePath ?? STORE_PATH;
   const take = createRateLimiter({ now });
 
-  function deliver({ token, rawBody, signatureHeader }) {
+  function deliver({ token, rawBody, signatureHeader, headers }) {
     return deliverWebhook(
-      { token, rawBody, signatureHeader },
+      { token, rawBody, signatureHeader, headers },
       {
         load: () => loadHooks(path),
         save: (hooks) => saveHooks(hooks, path),
         sendPrompt,
+        forgeIngest,
         publish,
         now,
         take,

--- a/src/server/webhooks.test.mjs
+++ b/src/server/webhooks.test.mjs
@@ -7,11 +7,15 @@ import { rm } from "node:fs/promises";
 import {
   isValidToken,
   verifySignature,
+  resolveSignature,
+  isRedelivery,
+  isEventFiltered,
   formatWebhookTurn,
   createRateLimiter,
   toMeta,
   deliveryUrl,
   createHook,
+  upsertForgeHook,
   listHooks,
   deleteHook,
   deliverWebhook,
@@ -65,6 +69,37 @@ test("verifySignature rejects missing / malformed headers", () => {
   assert.equal(verifySignature("whsec_x", body, "sha256="), false);
   assert.equal(verifySignature("whsec_x", body, "sha256=zzzz"), false); // non-hex
   assert.equal(verifySignature("", body, sign("", body)), false); // empty secret
+});
+
+// The OFFICIAL GitHub HMAC test vector (BET-797). Secret "It's a Secret to
+// Everybody", raw payload "Hello, World!" → sha256=757107ea… This pins the
+// exact wire scheme the forge uses, so a GitHub redelivery to the box's own
+// hostname is verified against the identical bytes.
+test("verifySignature matches the official GitHub HMAC test vector", () => {
+  const header =
+    "sha256=757107ea0eb2509fc211221cce984b8a37570b6d7586c22c46f4379c8b043e17";
+  assert.equal(verifySignature("It's a Secret to Everybody", "Hello, World!", header), true);
+  assert.equal(verifySignature("It's a Secret to Everybody", "Hello, World", header), false);
+});
+
+test("resolveSignature accepts X-Hub-Signature-256 for a github hook", () => {
+  const body = '{"action":"labeled"}';
+  const headers = { "x-hub-signature-256": sign("whsec_g", body) };
+  assert.equal(resolveSignature("github", "whsec_g", body, headers), true);
+});
+
+test("resolveSignature accepts X-Manta-Signature for a github hook too", () => {
+  const body = '{"action":"labeled"}';
+  const headers = { "x-manta-signature": sign("whsec_g", body) };
+  assert.equal(resolveSignature("github", "whsec_g", body, headers), true);
+});
+
+test("resolveSignature rejects a bad header and unknown providers (never coerced)", () => {
+  const body = "x";
+  const headers = { "x-hub-signature-256": "sha256=deadbeef" };
+  assert.equal(resolveSignature("github", "whsec_g", body, headers), false);
+  // Unknown provider falls back to manta semantics (never weakens to unsigned).
+  assert.equal(resolveSignature("bogus", "whsec_g", body, headers), false);
 });
 
 // ----------------------------------------------------------------------------
@@ -182,6 +217,33 @@ test("createHook rejects missing sessionID / label", async () => {
   assert.equal((await createHook({ sessionID: "s" }, { load, save })).ok, false);
 });
 
+test("upsertForgeHook persists a github hook and refreshes it on re-save", async () => {
+  const path = tmpStore();
+  const load = () => loadHooks(path);
+  const save = (h) => saveHooks(h, path);
+  try {
+    const first = await upsertForgeHook(
+      { repoKey: "github.com/o/r", label: "github.com/o/r", token: "a".repeat(32), secret: "s1", events: ["issues"] },
+      { load, save },
+    );
+    assert.equal(first.provider, "github");
+    assert.equal(first.secret, "s1");
+    assert.match(first.url, /\/hook\/[0-9a-f]{32}$/);
+
+    // Re-save for the same repo refreshes secret+events, does NOT duplicate.
+    const second = await upsertForgeHook(
+      { repoKey: "github.com/o/r", label: "github.com/o/r", token: "a".repeat(32), secret: "s2", events: ["issues", "pull_request"] },
+      { load, save },
+    );
+    assert.equal(second.secret, "s2");
+    assert.equal(second.events.length, 2);
+    const all = await loadHooks(path);
+    assert.equal(all.filter((h) => h.repoKey === "github.com/o/r").length, 1);
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
 // ----------------------------------------------------------------------------
 // deliverWebhook — status codes + send/defer
 // ----------------------------------------------------------------------------
@@ -227,6 +289,103 @@ test("deliverWebhook returns 401 on bad signature, never sends", async () => {
   );
   assert.equal(res.status, 401);
   assert.equal(sent, 0);
+});
+
+test("deliverWebhook returns 429 (rate limit) BEFORE signature verification", async () => {
+  let sent = 0;
+  // Rate limiter exhausted AND a bad signature — the 429 must win, proving the
+  // flood guard fires before the HMAC cost (BET-797).
+  const res = await deliverWebhook(
+    { token: "a".repeat(32), rawBody: '{"a":1}', headers: { "x-hub-signature-256": "sha256=deadbeef" } },
+    {
+      load: async () => [fakeHook({ provider: "github" })],
+      save: async () => {},
+      sendPrompt: async () => { sent++; },
+      take: () => false,
+    },
+  );
+  assert.equal(res.status, 429);
+  assert.equal(sent, 0);
+});
+
+test("deliverWebhook verifies a github hook via X-Hub-Signature-256 and routes to forgeIngest", async () => {
+  const body = '{"action":"labeled","issue":1}';
+  let ingested = null;
+  let sent = 0;
+  const res = await deliverWebhook(
+    { token: "a".repeat(32), rawBody: body, headers: { "x-hub-signature-256": sign("whsec_test", body) } },
+    {
+      load: async () => [fakeHook({ provider: "github" })],
+      save: async () => {},
+      sendPrompt: async () => { sent++; },
+      forgeIngest: async (args) => { ingested = args; },
+    },
+  );
+  assert.equal(res.status, 200);
+  assert.equal(sent, 0); // a forge hook never wakes a session
+  assert.ok(ingested, "forge hook must route to forgeIngest");
+  assert.equal(ingested.hook.provider, "github");
+  assert.equal(ingested.event, undefined);
+});
+
+test("deliverWebhook dedupes a redelivered X-GitHub-Delivery (acts once)", async () => {
+  const body = '{"action":"labeled"}';
+  const signed = sign("whsec_test", body);
+  const headers = {
+    "x-hub-signature-256": signed,
+    "x-github-event": "issues",
+    "x-github-delivery": "dlv-123",
+  };
+  let ingests = 0;
+  const saved = []; // capture store mutations after each delivery
+  let hooks = [fakeHook({ provider: "github" })];
+  const deps = {
+    load: async () => hooks,
+    save: async (h) => { hooks = h; saved.push(hooks[0].seenDeliveryIds ?? []); },
+    sendPrompt: async () => {},
+    forgeIngest: async () => { ingests++; },
+  };
+  const first = await deliverWebhook({ token: "a".repeat(32), rawBody: body, headers }, deps);
+  assert.equal(first.status, 200);
+  assert.equal(ingests, 1);
+  // Redelivery: same delivery id, GitHub re-sends — ignored.
+  const second = await deliverWebhook({ token: "a".repeat(32), rawBody: body, headers }, deps);
+  assert.equal(second.status, 200);
+  assert.equal(second.deduped, true);
+  assert.equal(ingests, 1, "redelivered event must not act twice");
+  // The delivery id persisted so the second delivery saw it.
+  assert.ok(saved.at(-1)?.includes("dlv-123"));
+});
+
+test("deliverWebhook drops an event type the hook was not registered for", async () => {
+  const body = '{"something":"else"}';
+  const headers = {
+    "x-hub-signature-256": sign("whsec_test", body),
+    "x-github-event": "pull_request", // hook only registered for "issues"
+  };
+  let ingests = 0;
+  const res = await deliverWebhook(
+    { token: "a".repeat(32), rawBody: body, headers },
+    {
+      load: async () => [fakeHook({ provider: "github", events: ["issues"] })],
+      save: async () => {},
+      sendPrompt: async () => {},
+      forgeIngest: async () => { ingests++; },
+    },
+  );
+  assert.equal(res.status, 200);
+  assert.equal(res.filtered, true);
+  assert.equal(ingests, 0, "filtered event must not reach ingest");
+});
+
+test("isRedelivery / isEventFiltered pure semantics", () => {
+  const hook = { provider: "github", seenDeliveryIds: ["d1"], events: ["issues"] };
+  assert.equal(isRedelivery(hook, "d1"), true);
+  assert.equal(isRedelivery(hook, "d2"), false);
+  assert.equal(isRedelivery({}, undefined), false);
+  assert.equal(isEventFiltered(hook, "issues"), false);
+  assert.equal(isEventFiltered(hook, "pull_request"), true);
+  assert.equal(isEventFiltered({}, "anything"), false); // no whitelist → never filters
 });
 
 test("deliverWebhook returns 429 when rate-limited, never sends", async () => {

--- a/src/shared/forgeRules.d.mts
+++ b/src/shared/forgeRules.d.mts
@@ -1,0 +1,45 @@
+// Hand-written type declarations for forgeRules.mjs. The implementation is
+// plain JS so server code imports it natively; TS consumers (the tests) import
+// through the side-by-side .d.mts — TS maps `./forgeRules.mjs` to this file.
+// Keep in sync with src/shared/forgeRules.mjs.
+
+export type ForgeRuleVerb = "delegate" | "notify" | "inbox";
+
+export type ForgeRuleEvent =
+  | "issue.labeled"
+  | "checks.failed"
+  | "review.requested";
+
+export type ForgeRule = {
+  do: ForgeRuleVerb;
+  label?: string;
+  branch?: string;
+  prompt?: string;
+};
+
+export type ForgeRules = {
+  on: Partial<Record<ForgeRuleEvent, ForgeRule>>;
+};
+
+export type ForgeValidationError = { path: string; message: string };
+
+export const RULE_EVENTS: ForgeRuleEvent[];
+export const RULE_VERBS: ForgeRuleVerb[];
+export const RULE_PLACEHOLDERS: Set<string>;
+
+export function parseRules(
+  yamlText: unknown,
+): { ok: true; rules: ForgeRules; errors?: undefined } | { ok: false; errors: ForgeValidationError[]; rules?: undefined };
+
+export function validateRules(parsed: unknown): { errors: ForgeValidationError[] };
+
+export function matchRule(
+  event: { type: string; label?: string; branch?: string; title?: string; url?: string } | null | undefined,
+  rules?: ForgeRules | null,
+): ForgeRule | null;
+
+export function validateForgeRepoPath(repo: {
+  host: unknown;
+  owner: unknown;
+  repo: unknown;
+}): { ok: true } | { ok: false; error: string };

--- a/src/shared/forgeRules.mjs
+++ b/src/shared/forgeRules.mjs
@@ -1,0 +1,309 @@
+// forgeRules.mjs — the L1 rules grammar for the MantaUI forge event loop
+// (BET-797).
+//
+// One rule file per repo. The file is AUTHORED BY A TOOL (the forge_rules
+// opencode tool), lives on the BOX at ~/.manta/forge-rules/<host>/<owner>/<repo>.yaml,
+// and never travels with the repository — nothing a PR can edit changes what
+// runs on a user's machine (design spec §5.1 / §5.2).
+//
+// This module is the SINGLE source of truth for what a valid rules file looks
+// like — imported by the tool (docs/opencode-tools/forge-rules.ts) via the
+// server's /api/forge-rules route, by the server's registry
+// (src/server/forgeRules.mjs), and by the tests. Never a second copy. It is
+// deliberately modelled on src/shared/pluginManifest.mjs: exported constants,
+// exported pure functions, unknown keys rejected loudly by name, structured
+// {path, message} errors the caller can display verbatim.
+//
+// Grammar, complete — one `on:` block, three verbs, nothing else:
+//
+//   on:
+//     issue.labeled:
+//       label: manta
+//       do: delegate
+//       prompt: "Complete {{url}}. Open a draft PR."
+//     checks.failed:
+//       branch: mine
+//       do: notify
+//     review.requested:
+//       do: inbox
+//
+// Contract (design spec §5.1):
+//   - 100% pure. No fs, no fetch, no spawn. The only global used is nothing —
+//     pure string/YAML work, fully unit-testable.
+//   - Named exports only. No default export, matching the rest of src/shared/.
+//   - Unknown keys fail validation with `unknown key "<key>"`, exactly as the
+//     plugin validator does — typo protection matters more than flexibility in
+//     a file that can start an agent.
+//   - Three verbs — delegate, notify, inbox. No others. No expressions, no
+//     scripting, no shell, no interpolation beyond the fixed `{{url}}` and
+//     `{{title}}` placeholders.
+
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+
+// ---------------------------------------------------------------------------
+// Grammar constants
+// ---------------------------------------------------------------------------
+
+// The three forge events a rule can key off. Adding a fourth is a MantaUI
+// design change (the adapter + ingest must understand it), not a rules change.
+export const RULE_EVENTS = ["issue.labeled", "checks.failed", "review.requested"];
+export const RULE_EVENT_SET = new Set(RULE_EVENTS);
+
+// The three verbs. `do` on an event entry must be one of these.
+export const RULE_VERBS = ["delegate", "notify", "inbox"];
+export const RULE_VERB_SET = new Set(RULE_VERBS);
+
+// Condition keys per event. `do` is required on every event; any other key is
+// an error so a typo'd `lable:` doesn't silently become a rule that never
+// matches. `prompt` is only meaningful on a `delegate` event.
+const EVENT_KEYS = Object.freeze({
+  "issue.labeled": new Set(["do", "label", "prompt"]),
+  "checks.failed": new Set(["do", "branch"]),
+  "review.requested": new Set(["do"]),
+});
+
+// The ONLY placeholders a `prompt` may contain. Anything else `{{…}}` is
+// rejected — no interpolation beyond these two fixed slots.
+export const RULE_PLACEHOLDERS = new Set(["{{url}}", "{{title}}"]);
+const PLACEHOLDER_RE = /\{\{[^}]+\}\}/g;
+
+// Safe single path component for the box-side rules store. The rules live at
+// ~/.manta/forge-rules/<host>/<owner>/<repo>.yaml, so a crafted repo name must
+// not escape the directory. Modelled on the plugin name regex
+// (^[a-z0-9][a-z0-9-]{0,62}$) and generalised ONLY to preserve the dot in a
+// host/owner segment (github.com, anomalyco). Forbids leading/trailing dots
+// (so "." and ".." are rejected), slashes, whitespace and any other char.
+const SAFE_COMPONENT_RE = /^[a-z0-9](?:[a-z0-9._-]*[a-z0-9])?$/;
+
+// ---------------------------------------------------------------------------
+// parseRules — YAML text → { ok, rules, errors[] }
+// ---------------------------------------------------------------------------
+
+/**
+ * Parse + validate a forge rules YAML string. Returns either `{ok:true,
+ * rules:<object>}` or `{ok:false, errors:[{path, message}]}` describing every
+ * validation failure (no short-circuit — the author wants to fix them all).
+ *
+ * Valid `rules` shape:
+ *   { on: { "<event>": { do, label?, branch?, prompt? }, ... } }
+ *
+ * A bare `on: {}` (a file with no rules yet) is valid — it parses, matches
+ * nothing, and lets the file serve as an editable shell.
+ */
+export function parseRules(yamlText) {
+  const errors = [];
+  if (typeof yamlText !== "string") {
+    return {
+      ok: false,
+      rules: undefined,
+      errors: [{ path: "", message: "rules must be a string" }],
+    };
+  }
+  let raw;
+  try {
+    raw = parseYaml(yamlText);
+  } catch (e) {
+    return {
+      ok: false,
+      rules: undefined,
+      errors: [{ path: "", message: `yaml parse: ${e?.message ?? String(e)}` }],
+    };
+  }
+  if (raw == null || typeof raw !== "object" || Array.isArray(raw)) {
+    return {
+      ok: false,
+      rules: undefined,
+      errors: [{ path: "", message: "rules must be a mapping" }],
+    };
+  }
+
+  // `on` is required and must be a mapping.
+  const on = raw.on;
+  if (on == null || typeof on !== "object" || Array.isArray(on)) {
+    return {
+      ok: false,
+      rules: undefined,
+      errors: [{ path: "on", message: "on must be a mapping" }],
+    };
+  }
+
+  // Reject unknown TOP-LEVEL keys so a stray `off:` next to `on:` fails loudly.
+  for (const k of Object.keys(raw)) {
+    if (k !== "on") {
+      errors.push({ path: k, message: `unknown key "${k}"` });
+    }
+  }
+
+  const validated = {};
+  for (const [eventName, entry] of Object.entries(on)) {
+    const base = `on.${eventName}`;
+    if (!RULE_EVENT_SET.has(eventName)) {
+      errors.push({
+        path: base,
+        message: `unknown key "${eventName}"`,
+      });
+      continue;
+    }
+    if (entry == null || typeof entry !== "object" || Array.isArray(entry)) {
+      errors.push({ path: base, message: "rule must be a mapping" });
+      continue;
+    }
+    const allowed = EVENT_KEYS[eventName];
+    for (const k of Object.keys(entry)) {
+      if (!allowed.has(k)) {
+        errors.push({ path: `${base}.${k}`, message: `unknown key "${k}"` });
+      }
+    }
+
+    // do — required verb.
+    if (typeof entry.do !== "string" || !entry.do) {
+      errors.push({ path: `${base}.do`, message: "do is required" });
+    } else if (!RULE_VERB_SET.has(entry.do)) {
+      errors.push({
+        path: `${base}.do`,
+        message: `do: must be one of ${RULE_VERBS.join(", ")}`,
+      });
+    }
+
+    // label (issue.labeled condition) — non-empty string.
+    if (entry.label !== undefined) {
+      if (typeof entry.label !== "string" || !entry.label.trim()) {
+        errors.push({ path: `${base}.label`, message: "label must be a non-empty string" });
+      }
+    }
+
+    // branch (checks.failed condition) — non-empty string.
+    if (entry.branch !== undefined) {
+      if (typeof entry.branch !== "string" || !entry.branch.trim()) {
+        errors.push({ path: `${base}.branch`, message: "branch must be a non-empty string" });
+      }
+    }
+
+    // prompt — only on a `delegate` event; must only use the fixed
+    // placeholders (no expressions, no shell, nothing else).
+    if (entry.prompt !== undefined) {
+      if (entry.do !== "delegate") {
+        errors.push({
+          path: `${base}.prompt`,
+          message: "prompt is only allowed on a delegate rule",
+        });
+      } else if (typeof entry.prompt !== "string" || !entry.prompt.trim()) {
+        errors.push({ path: `${base}.prompt`, message: "prompt must be a non-empty string" });
+      } else {
+        for (const m of entry.prompt.match(PLACEHOLDER_RE) ?? []) {
+          if (!RULE_PLACEHOLDERS.has(m)) {
+            errors.push({
+              path: `${base}.prompt`,
+              message: `prompt: unsupported placeholder ${JSON.stringify(m)} (only {{url}} and {{title}})`,
+            });
+          }
+        }
+      }
+    }
+
+    validated[eventName] = {
+      do: entry.do,
+      ...(entry.label !== undefined ? { label: entry.label } : {}),
+      ...(entry.branch !== undefined ? { branch: entry.branch } : {}),
+      ...(entry.prompt !== undefined ? { prompt: entry.prompt } : {}),
+    };
+  }
+
+  if (errors.length > 0) return { ok: false, rules: undefined, errors };
+  return { ok: true, rules: { on: validated }, errors: undefined };
+}
+
+// ---------------------------------------------------------------------------
+// validateRules — full validation, accepting an already-parsed object
+//
+// Mirrors pluginManifest.validateManifest: round-trips through YAML so there
+// is a single validation pipeline. Useful for the server registry when it
+// holds an already-parsed structure.
+// ---------------------------------------------------------------------------
+
+export function validateRules(parsed) {
+  if (parsed == null || typeof parsed !== "object") {
+    return { errors: [{ path: "", message: "rules must be an object" }] };
+  }
+  try {
+    const result = parseRules(stringifyYaml(parsed));
+    return { errors: result.errors ?? [] };
+  } catch (e) {
+    return { errors: [{ path: "", message: e?.message ?? String(e) }] };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// matchRule — pick the rule that fires for an event
+//
+// Pure. `event` is a NORMALISED forge event: { type, label?, branch?, title?,
+// url? }. Returns the matching rule's config (`{do, label?, branch?, prompt?}`)
+// or `null` when nothing matches (no rule for the type, or a condition fails).
+//
+// Conditions are conjunctive: a rule with `label:` matches only when the event
+// carries that exact label; a rule with `branch:` matches only when the event
+// carries that exact branch. A rule with no condition matches its event type.
+// ---------------------------------------------------------------------------
+
+export function matchRule(event, rules) {
+  if (event == null || typeof event !== "object") return null;
+  const type = event.type;
+  if (typeof type !== "string") return null;
+  const config = rules?.on?.[type];
+  if (config == null || typeof config !== "object") return null;
+  if (config.label !== undefined && config.label !== event.label) return null;
+  if (config.branch !== undefined && config.branch !== event.branch) return null;
+  return config;
+}
+
+// ---------------------------------------------------------------------------
+// rulesPath — validate the <host>/<owner>/<repo> store path components
+//
+// The rules file lives at ~/.manta/forge-rules/<host>/<owner>/<repo>.yaml. The
+// components are user/forge-controlled, so a crafted repo name must not be
+// able to escape the directory. Each component is validated against a safe
+// token class (the plugin name regex, generalised to preserve dots in a
+// host/owner). `owner` may carry GitLab subgroup slashes — every segment is
+// validated individually, and `.` / `..` are rejected outright.
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate host/owner/repo as safe path components for the rules store.
+ * Returns `{ok:true}` or `{ok:false, error}`. Pure — the caller builds the
+ * actual path with statePath() after this passes.
+ *
+ * @param {{host: unknown, owner: unknown, repo: unknown}} repo
+ * @returns {{ok: true} | {ok: false, error: string}}
+ */
+export function validateForgeRepoPath({ host, owner, repo }) {
+  if (typeof host !== "string" || !host) {
+    return { ok: false, error: "host is required" };
+  }
+  if (typeof owner !== "string" || !owner) {
+    return { ok: false, error: "owner is required" };
+  }
+  if (typeof repo !== "string" || !repo) {
+    return { ok: false, error: "repo is required" };
+  }
+  const hostErr = checkComponents(host, "host");
+  if (hostErr) return { ok: false, error: hostErr };
+  const ownerErr = checkComponents(owner, "owner");
+  if (ownerErr) return { ok: false, error: ownerErr };
+  const repoErr = checkComponents(repo, "repo");
+  if (repoErr) return { ok: false, error: repoErr };
+  return { ok: true };
+}
+
+// Validate a path component (host, repo, or one segment of a subgroup owner).
+// Returns an error string or null when safe.
+function checkComponents(value, label) {
+  for (const seg of value.split("/")) {
+    if (seg === "" || seg === "." || seg === "..") {
+      return `${label}: component ${JSON.stringify(seg)} is not allowed`;
+    }
+    if (!SAFE_COMPONENT_RE.test(seg)) {
+      return `${label}: component ${JSON.stringify(seg)} contains unsafe characters`;
+    }
+  }
+  return null;
+}

--- a/src/shared/forgeRules.test.ts
+++ b/src/shared/forgeRules.test.ts
@@ -1,0 +1,233 @@
+import { describe, it, expect } from "vitest";
+import {
+  parseRules,
+  validateRules,
+  matchRule,
+  validateForgeRepoPath,
+  type ForgeRule,
+  type ForgeValidationError,
+} from "./forgeRules.mjs";
+
+// Narrow the discriminated parseRules result the way pluginManifest.test.ts
+// does — `expect(r.ok).toBe(true)` does not narrow for TypeScript.
+function okRules(r: ReturnType<typeof parseRules>): { on: Record<string, ForgeRule> } {
+  if (!r.ok) throw new Error("expected ok result, got errors");
+  return r.rules!;
+}
+function errs(r: ReturnType<typeof parseRules>): ForgeValidationError[] {
+  return r.errors ?? [];
+}
+
+const VALID = `
+on:
+  issue.labeled:
+    label: manta
+    do: delegate
+    prompt: "Complete {{url}}. Open a draft PR."
+  checks.failed:
+    branch: mine
+    do: notify
+  review.requested:
+    do: inbox
+`;
+
+describe("parseRules", () => {
+  it("parses a valid rules file", () => {
+    const r = parseRules(VALID);
+    expect(r.ok).toBe(true);
+    expect(r.errors).toBeUndefined();
+    const rules = okRules(r).on;
+    expect(rules["issue.labeled"]).toEqual({
+      do: "delegate",
+      label: "manta",
+      prompt: "Complete {{url}}. Open a draft PR.",
+    });
+    expect(rules["checks.failed"]).toEqual({ do: "notify", branch: "mine" });
+    expect(rules["review.requested"]).toEqual({ do: "inbox" });
+  });
+
+  it("rejects an unknown event key by name", () => {
+    const r = parseRules("on:\n  issuelabeled:\n    do: notify\n");
+    expect(r.ok).toBe(false);
+    expect(errs(r)).toContainEqual({
+      path: "on.issuelabeled",
+      message: 'unknown key "issuelabeled"',
+    });
+  });
+
+  it("rejects an unknown key inside a rule by name", () => {
+    const r = parseRules("on:\n  checks.failed:\n    brnach: mine\n    do: notify\n");
+    expect(r.ok).toBe(false);
+    expect(errs(r)).toContainEqual({
+      path: "on.checks.failed.brnach",
+      message: 'unknown key "brnach"',
+    });
+  });
+
+  it("rejects an unknown verb", () => {
+    const r = parseRules("on:\n  review.requested:\n    do: explode\n");
+    expect(r.ok).toBe(false);
+    expect(errs(r)[0].message).toContain("do: must be one of delegate, notify, inbox");
+  });
+
+  it("rejects a missing do", () => {
+    const r = parseRules("on:\n  review.requested:\n    label: x\n");
+    expect(r.ok).toBe(false);
+    expect(errs(r).some((e) => e.path === "on.review.requested.do")).toBe(true);
+  });
+
+  it("rejects an unknown top-level key", () => {
+    const r = parseRules("on: {}\noff: true\n");
+    expect(r.ok).toBe(false);
+    expect(errs(r)).toContainEqual({ path: "off", message: 'unknown key "off"' });
+  });
+
+  it("rejects prompt on a non-delegate rule", () => {
+    const r = parseRules("on:\n  checks.failed:\n    do: notify\n    prompt: hi\n");
+    expect(r.ok).toBe(false);
+    expect(errs(r).some((e) => e.path === "on.checks.failed.prompt")).toBe(true);
+  });
+
+  it("rejects a prompt with an unsupported placeholder", () => {
+    const r = parseRules(
+      'on:\n  issue.labeled:\n    do: delegate\n    prompt: "shell {{cmd}}"\n',
+    );
+    expect(r.ok).toBe(false);
+    expect(errs(r).some((e) => /unsupported placeholder/.test(e.message))).toBe(true);
+  });
+
+  it("accepts an empty on block as a valid editable shell", () => {
+    const r = parseRules("on: {}\n");
+    expect(r.ok).toBe(true);
+    expect(okRules(r).on).toEqual({});
+  });
+
+  it("rejects a non-mapping on", () => {
+    const r = parseRules("on: just-a-string\n");
+    expect(r.ok).toBe(false);
+    expect(errs(r)[0].path).toBe("on");
+  });
+
+  it("rejects non-string input", () => {
+    expect(parseRules(undefined as unknown as string).ok).toBe(false);
+    expect(parseRules(42 as unknown as string).ok).toBe(false);
+  });
+
+  it("rejects a non-mapping document", () => {
+    const r = parseRules("[1,2,3]");
+    expect(r.ok).toBe(false);
+  });
+
+  it("returns a yaml syntax error verbatim", () => {
+    const r = parseRules("on: {\n  \n");
+    expect(r.ok).toBe(false);
+    expect(errs(r)[0].message).toMatch(/yaml parse/);
+  });
+});
+
+describe("validateRules", () => {
+  it("round-trips a valid parsed object", () => {
+    const r = validateRules({
+      on: { "issue.labeled": { do: "delegate", label: "manta", prompt: "Complete {{url}}." } },
+    });
+    expect(r.errors).toEqual([]);
+  });
+
+  it("reports errors for an invalid parsed object", () => {
+    const r = validateRules({ on: { "review.requested": { do: "bogus" } } });
+    expect(r.errors.length).toBeGreaterThan(0);
+  });
+
+  it("rejects a non-object", () => {
+    expect(validateRules(null).errors.length).toBeGreaterThan(0);
+    expect(validateRules("x").errors.length).toBeGreaterThan(0);
+  });
+});
+
+describe("matchRule", () => {
+  const rules = okRules(parseRules(VALID));
+
+  it("matches issue.labeled on label, returning the delegate config", () => {
+    const m = matchRule({ type: "issue.labeled", label: "manta", url: "https://x", title: "T" }, rules);
+    expect(m).toEqual({
+      do: "delegate",
+      label: "manta",
+      prompt: "Complete {{url}}. Open a draft PR.",
+    });
+  });
+
+  it("does not match issue.labeled with a different label", () => {
+    expect(matchRule({ type: "issue.labeled", label: "other" }, rules)).toBeNull();
+  });
+
+  it("matches checks.failed on branch mine", () => {
+    const m = matchRule({ type: "checks.failed", branch: "mine" }, rules);
+    expect(m).toEqual({ do: "notify", branch: "mine" });
+  });
+
+  it("does not match checks.failed with a different branch", () => {
+    expect(matchRule({ type: "checks.failed", branch: "other" }, rules)).toBeNull();
+  });
+
+  it("matches review.requested with no condition", () => {
+    expect(matchRule({ type: "review.requested" }, rules)).toEqual({ do: "inbox" });
+  });
+
+  it("returns null for a non-match (unknown event type)", () => {
+    expect(matchRule({ type: "pull_request.opened" }, rules)).toBeNull();
+  });
+
+  it("returns null for bad input", () => {
+    expect(matchRule(null, rules)).toBeNull();
+    expect(matchRule(undefined, rules)).toBeNull();
+    expect(matchRule({ type: "issue.labeled", label: "manta", title: "T", url: "u" }, undefined)).toBeNull();
+    expect(matchRule("issue.labeled" as never, rules)).toBeNull();
+  });
+});
+
+describe("validateForgeRepoPath", () => {
+  it("accepts a normal github repo", () => {
+    expect(validateForgeRepoPath({ host: "github.com", owner: "anomalyco", repo: "manta" })).toEqual({
+      ok: true,
+    });
+  });
+
+  it("accepts a gitlab subgroup owner", () => {
+    expect(
+      validateForgeRepoPath({ host: "gitlab.com", owner: "group/subgroup", repo: "project" }),
+    ).toEqual({ ok: true });
+  });
+
+  it("rejects a traversal repo name", () => {
+    const r = validateForgeRepoPath({ host: "github.com", owner: "o", repo: ".." });
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a repo with a slash (escape)", () => {
+    const r = validateForgeRepoPath({ host: "github.com", owner: "o", repo: "a/../../etc" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a dot-dot owner segment", () => {
+    const r = validateForgeRepoPath({ host: "github.com", owner: "..", repo: "manta" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects a leading-dot hidden component", () => {
+    const r = validateForgeRepoPath({ host: ".hidden", owner: "o", repo: "manta" });
+    expect(r.ok).toBe(false);
+  });
+
+  it("rejects empty / missing components", () => {
+    expect(validateForgeRepoPath({ host: "", owner: "o", repo: "r" }).ok).toBe(false);
+    expect(validateForgeRepoPath({ host: "github.com", owner: "", repo: "r" }).ok).toBe(false);
+    expect(validateForgeRepoPath({ host: "github.com", owner: "o", repo: "" }).ok).toBe(false);
+    expect(validateForgeRepoPath({} as never).ok).toBe(false);
+  });
+
+  it("rejects whitespace / unsafe chars", () => {
+    expect(
+      validateForgeRepoPath({ host: "github.com", owner: "o", repo: "my repo" }).ok,
+    ).toBe(false);
+  });
+});

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -260,6 +260,22 @@ export const SETTINGS: SettingEntry[] = [
     default: false,
   },
 
+  // ----- forge rules (BET-797) -----
+  // Box-side: a box config key, so it rides the generic configGet/configUpdate
+  // channels and is read by the box server to gate the forge webhook subsystem
+  // (src/server/forgeRules.mjs). Default off — the whole subsystem is dormant
+  // until this is flipped.
+  {
+    id: "forgeRulesEnabled",
+    section: "extensions",
+    label: "Run forge rules",
+    help: "Lets the box register per-repo forge webhooks (GitHub → your box) and ingest them. Rules are AI-authored, live on the box at ~/.manta/forge-rules/, and never travel with a repository. Off by default.",
+    control: "toggle",
+    configKey: "forgeRulesEnabled",
+    platform: "both",
+    default: false,
+  },
+
   // ----- voice (Groq STT) -----
   {
     id: "groqApiKey",

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -185,6 +185,14 @@ export type AppConfig = {
   // authored YAML files; each step runs an arbitrary shell command with the
   // user's UID, so the user MUST vet every plugin they install.
   pluginsEnabled?: boolean;
+  // ----- Forge rules (BET-797) -----
+  // Master switch for the box-side forge event loop. When true, the box can
+  // register per-repo webhooks (under ~/.manta/forge-rules/) and ingest forge
+  // deliveries. Default false (OFF) — a stale or whimsical toggle change must
+  // never quietly voice an agent. Same posture as `pluginsEnabled` and sits
+  // alongside it in Settings. With it off the subsystem is dormant: no
+  // registration, no ingest routing, no dispatch.
+  forgeRulesEnabled?: boolean;
   // BET-409: colour theme. "system" (default) follows the OS prefers-color-scheme
   // media query and re-themes live when it changes; "light"/"dark" pin the theme.
   // Resolved in src/renderer/main.tsx (data-theme on <html>) and live-managed by


### PR DESCRIPTION
## Event loop I: forge webhook ingest + rules validator + forge_rules tool (BET-797)

Builds the plumbing for the forge event loop: ingest a verified GitHub webhook
and give the AI a validated way to author the rules that (later) respond to it.
**This issue does NOT act on any event** — the rules engine is the next issue.

### What this does

1. **Extends the existing webhook ingest** (`src/server/webhooks.mjs`) — no
   second receiver, no second HMAC verifier, no second rate limiter. The same
   `/hook/<token>` route now:
   - accepts **either** `X-Hub-Signature-256` (GitHub) **or** `X-Manta-Signature`
     (identical `sha256=<hex>` scheme) via a per-provider header table;
   - carries a `provider` field (`"manta" | "github"`) on hook records;
   - **dedupes redeliveries** by `X-GitHub-Delivery` and **filters by event type**
     against the hook's registered events; rate-limiting still fires before the
     HMAC.
   - Forge hooks route to a forge ingest path (verify → dedupe → filter →
     **record**, never act), instead of waking a session.
2. **Rules validator** — `src/shared/forgeRules.mjs` (pure, single copy imported
   by tool/server/tests): `parseRules` / `validateRules` / `matchRule` plus
   box-side path-component validation. Three verbs only; unknown keys fail by
   name. It uses the BET-785 `src/shared/forge.mjs` vocabulary types (unblocked).
3. **Registration** — `src/server/forge/webhook.mjs`: per-repo webhook
   register/update pointed at the box's own public hostname (read via
   `publicBaseUrl()`), per-repo HMAC secret, health-check. Fails loudly with no
   public hostname.
4. **Box-side store** — `src/server/forgeRules.mjs`: rules live at
   `~/.manta/forge-rules/<host>/<owner>/<repo>.yaml` under `statePath()`. This
   is the security property from §5.2 — nothing a PR can edit reaches the box.
5. **The tool** — `docs/opencode-tools/forge-rules.ts`: `forge_rules_save` /
   `_get` / `_list` / `_docs`, copied from `plugins.ts` (the `boxToken` /
   `authHeaders` / `call` helpers verbatim) + a new AGENTS.md section and
   `docs/forge-rules-authoring.md`.
6. **The toggle** — `AppConfig.forgeRulesEnabled`, default **false**, riding
   the existing `configGet`/`configUpdate` channels, rendered in Settings next
   to the plugins toggle. With it off: no registration, no ingest routing, no
   dispatch.

### What this removed / refused

- **No second webhook receiver** — extended `deliverWebhook` instead (the
  header table keeps the GitLab/Standard-Webhooks third scheme from becoming an
  if/else chain).
- **No acting on events** — forge ingest only appends to a box-side JSONL log
  (`forge-events.jsonl`); no agent ever starts. That is the next issue.
- **No repo-checked-in rules file** — box-side only.
- **No fourth verb, no condition expressions, no per-repo trust dialog.**
- **No GitHub App / gateway fan-out** — per-repo hooks straight to the box.

### Base
`Base: origin/main @ 9b9a37a2`

### Verification results

**Files changed:** 11. `src/shared/forgeRules.mjs` (+d.mts, +test),
`src/server/webhooks.mjs` (+test), `src/server/forge/webhook.mjs`,
`src/server/forgeRules.mjs`, `src/server/index.mjs`, `src/shared/types.ts`,
`src/shared/settingsSchema.ts`, `docs/opencode-tools/forge-rules.ts`,
`docs/opencode-tools/AGENTS.md`, `docs/forge-rules-authoring.md`.

- PR branch (`multica/BET-797-forge-event-loop` @ `7def2c12`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0. vitest `132 passed` (2445 passed / 7 skipped); server `# pass 1669 / # fail 0`. log sha256: `8c7454784422c32d1afd00dfe478f9c775eeeed17aa966f339237c51cb6f7684`
- Base (`main` @ `b933c51f`): pristine — no forge files on main; the two suites
  are the same surface minus the additions here.
- **Conclusion:** 0 new failures.

### Self-check (acceptance criteria)

- CRITERION 1 (real GitHub webhook verifies + logs, toggle on) → 8/10. wiring
  complete + unit-tested; the one live-delivery step needs a deployed public
  hostname + a configured forge token, which this box/test env lacks.
- CRITERION 2 (tampered body → 401) → 10/10. tested.
- CRITERION 3 (redelivery ignored) → 10/10. tested.
- CRITERION 4 (invalid file → errors verbatim, writes nothing) → 9/10.
  validator returns errors verbatim; save returns before any write.
- CRITERION 5 (list shows invalid file + reason) → 8/10. listRules validates
  every file and surfaces errors; the fs-walk path isn't unit-tested.
- CRITERION 6 (toggle off → nothing registers/routes) → 8/10. registration
  gated on `enabled()`, ingest skip on toggle; not unit-tested end-to-end.
- CRITERION 7 (no event starts an agent) → 10/10. forgeIngest only logs.
- CRITERION 8 (typecheck + test green) → 10/10. verified.

**Known limitation (flagged):** `forge_rules_save` saves rules but reports
"no forge token configured" for the webhook registration until the forge token
auth ladder lands (design §3.3 — explicitly the GitHub adapter's scope, not
this issue). The rules still save; registration is the deferred half.

**Follow-up filed:** link below.

