### PR TITLE
fix(ios): move transcript ListDataSource ownership into TiledView (BET-807)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -144,6 +144,14 @@ private struct ChatScreenContent: View {
         autoScrollsToBottomOnAppend: true,
         scrollsToBottomOnReplace: true
     )
+    /// Owned by the VIEW, never by the store: `ListDataSource` keeps an
+    /// append-only change log that `TiledView` replays from index 0 whenever
+    /// it meets a data source it has not seen. A store-owned one is mutated
+    /// long before (and across more than one) view creation, so the replay
+    /// runs against an already-final snapshot and desyncs the collection
+    /// view — the invalid-batch-updates crash. View-owned, the log and the
+    /// replay cursor are born together and the replay is always coherent.
+    @State private var dataSource = ListDataSource<TranscriptRow>()
     /// Whether the transcript has been scrolled up far enough that the round
     /// "scroll to bottom" control (rendered in ComposerView's model-selection
     /// row) should be shown. Driven purely by scroll geometry; it does not
@@ -776,7 +784,7 @@ private struct ChatScreenContent: View {
         // replaces the hand-rolled ScrollView + LazyVStack + geometry/keyboard/
         // landing machinery that was the source of the device-only blank-on-
         // open, snap, and disappear-on-scroll bugs.
-        TiledView(dataSource: store.dataSource, scrollPosition: $scrollPosition) { row in
+        TiledView(dataSource: dataSource, scrollPosition: $scrollPosition) { row in
             TranscriptBlockCell(item: row, tokens: tokens)
         }
         // Reserves the floating header's height. The header is an overlay and
@@ -840,6 +848,9 @@ private struct ChatScreenContent: View {
         // erases the type to `some View`, the compiler no longer sees it.
         .onTiledScrollGeometryChange { geometry in
             showScrollToBottom = geometry.pointsFromBottom > Self.scrollToBottomThreshold
+        }
+        .onChange(of: store.rows, initial: true) { _, rows in
+            dataSource.apply(rows)
         }
         // A tap on the transcript lowers the keyboard. (TiledView handles the
         // scroll-driven interactive keyboard dismiss itself.)
@@ -967,6 +978,14 @@ struct ChatSubagentScreen: View {
         autoScrollsToBottomOnAppend: true,
         scrollsToBottomOnReplace: true
     )
+    /// Owned by the VIEW, never by the store: `ListDataSource` keeps an
+    /// append-only change log that `TiledView` replays from index 0 whenever
+    /// it meets a data source it has not seen. A store-owned one is mutated
+    /// long before (and across more than one) view creation, so the replay
+    /// runs against an already-final snapshot and desyncs the collection
+    /// view — the invalid-batch-updates crash. View-owned, the log and the
+    /// replay cursor are born together and the replay is always coherent.
+    @State private var dataSource = ListDataSource<TranscriptRow>()
 
     /// Measured height of the subagent's own header, so the conversation rests
     /// below it. The header floats as an overlay (reserving nothing itself), so
@@ -974,7 +993,7 @@ struct ChatSubagentScreen: View {
     @State private var headerHeight: CGFloat = 0
 
     var body: some View {
-        TiledView(dataSource: store.dataSource, scrollPosition: $scrollPosition) { row in
+        TiledView(dataSource: dataSource, scrollPosition: $scrollPosition) { row in
             TranscriptBlockCell(item: row, tokens: tokens)
         }
         .headerContent(.header {
@@ -989,6 +1008,9 @@ struct ChatSubagentScreen: View {
         .typingIndicator(.indicator(isVisible: store.running) {
             RunningIndicator(store: store)
         })
+        .onChange(of: store.rows, initial: true) { _, rows in
+            dataSource.apply(rows)
+        }
         .overlay(alignment: .top) {
             SubagentHeader(
                 title: title,

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -1,6 +1,5 @@
 import Foundation
 import Combine
-import MessagingUI
 
 // ===========================================================================
 // S4 — chat session store (BET-596).
@@ -151,14 +150,14 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var inProgressText = ""
     @Published private(set) var blocks: [TranscriptBlock] = []
     /// The same transcript as `blocks`, but wrapped in `TranscriptRow` with a
-    /// STABLE id (see `TranscriptRow`). Kept so the subagent screen (and
-    /// anything else) can keep using `blocks` unchanged.
+    /// STABLE id (see `TranscriptRow`). This is the actual input the transcript
+    /// surfaces (parent chat and subagent drill-in) feed to `TiledView`.
+    /// It is intentionally NOT a `ListDataSource`: the data source is owned by
+    /// each `TiledView` so its change log and the view's replay cursor share a
+    /// lifetime. A store-owned one gets replayed from the beginning against a
+    /// final snapshot every time a new view is created, which is the
+    /// invalid-batch-updates / deque-out-of-bounds crash pair.
     @Published private(set) var rows: [TranscriptRow] = []
-    /// MessagingUI's incremental data source over `blocks`. Mutated IN PLACE
-    /// via `apply` so its `id` stays stable and TiledView coalesces each turn's
-    /// change as a prepend (loadEarlier) / append (streaming tail) / update
-    /// rather than a full reload — which is what preserves scroll position.
-    @Published private(set) var dataSource: ListDataSource<TranscriptRow> = ListDataSource()
     @Published private(set) var running = false
     @Published private(set) var turnComplete = false
     @Published private(set) var context: StreamContextPayload?
@@ -620,9 +619,6 @@ final class ChatSessionStore: ObservableObject {
                 + [TranscriptRow(id: liveTailRowID, block: .prose(inProgressText, at: nil))]
         }
         rows = newRows
-        // Mutate the data source in place (not `= ...`) so its identity — and
-        // therefore TiledView's scroll position and cell state — survives.
-        dataSource.apply(newRows)
         // Cap the subagent stores at the children the CURRENT transcript can
         // actually drill into; stores left over from a previous transcript no
         // longer show a row the user could open (BET-672).


### PR DESCRIPTION
## What

Fixes two FATAL iOS crashes (Crashlytics `c57c298d…` invalid-batch-updates + `6f231bbc…` deque out-of-bounds) that share one root cause: the transcript `ListDataSource` was owned by `ChatSessionStore` and mutated on every rebuild, so each new `TiledView` replayed the whole historical change log against an already-final snapshot.

**The invariant this restores:** no `ListDataSource` instance outlives, or is shared between, the `TiledView` instances that replay it.

## Changes

- `ChatSessionStore.swift` — deleted the store-owned `dataSource` (`@Published` + `dataSource.apply(newRows)` in `rebuildBlocks`) and the now-unused `import MessagingUI`. Updated the `rows` doc comment to say it is now the transcript surface's actual input and why it is not a `ListDataSource`. Net deletion.
- `ChatScreen.swift` — both `TiledView` surfaces (parent chat + `ChatSubagentScreen`) now own their data source as `@State private var dataSource = ListDataSource<TranscriptRow>()`, pass it to `TiledView(dataSource: dataSource, …)`, and feed it from `store.rows` via an identical `.onChange(of: store.rows, initial: true) { _, rows in dataSource.apply(rows) }` modifier placed after the MessagingUI `Self`-returning modifiers. The two call sites are identical and did not diverge.

No package bump/fork, no `pendingChanges` manipulation, no transcript-view unification, no test edits. `MantaUITests`/`ChatTranscriptTests` are untouched; the invariant is now enforced by the compiler (the store has no data source to leak).

## Verification

- Confirmed by inspection per the issue's manual-verification guidance (device-only, timing-dependent crash).
- `git diff` confirms: store no longer references `ListDataSource`; `store.rows` is read by both transcript surfaces; both `TiledView` call sites own their data source identically.
- **iOS build + `MantaUITests` NOT run here** — this box has no Apple toolchain (Xcode/simulator). Requires a Mac (macos) verification: build `mobile/native` for iOS, confirm no new warnings, run `MantaUITests` unchanged. Core repos root suite (untouched by this change, which is Swift-only) is green:
  - typecheck: exit 0
  - test: 1679 pass / 0 fail

**Base: `origin/main` @ `9b9a37a2`**
