### PR TITLE
fix(server): suppress done/error push for background job sessions (BET-800)

### DIFF
--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -35,6 +35,7 @@ import { join } from "node:path";
 import { statePath } from "../shared/paths.mjs";
 import * as tmux from "./tmux.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { loadJobs } from "./delegate.mjs";
 
 const DIR = statePath();
 const APNS_TOKENS_PATH = join(DIR, "apns-tokens.json");
@@ -455,29 +456,29 @@ export function classifyPushEvent(evt, ctx) {
 }
 
 /**
- * Pure: should a push be dropped because its session can't be resolved to a
- * tmux chat window (null label)? Such a session is a SUBAGENT child (it
- * inherited the parent's directory, runs on the same scoped /event stream, but
- * has no `@manta-session-id` of its own) or a stale orphan — there is no chat for
- * the user to land on, and the push would be a nameless notification that
- * deep-links nowhere.
+ * Pure: should a push be dropped? Either of two reasons, both meaning "the user
+ * is not watching this session and has nothing actionable to land on":
  *
- * Covers `done`, `error`, `permission`, and `question`: an orphan session has
- * no chat window for the user to act in or land on, so a push to any of these
- * kinds is useless. A `done` would be a nameless "Claude is done"; an `error`
- * would be a nameless "The turn failed"; a `permission`/`question` would
- * require user action the user can't take from a push that deep-links to a
- * sessionId the app can't find.
+ * 1. The session can't be resolved to a tmux chat window (null label). Such a
+ *    session is a SUBAGENT child (it inherited the parent's directory, runs on
+ *    the same scoped /event stream, but has no `@manta-session-id` of its own)
+ *    or a stale orphan — there is no chat for the user to land on, and the push
+ *    would be a nameless notification that deep-links nowhere. Covers `done`,
+ *    `error`, `permission`, and `question`.
+ * 2. The session is a BACKGROUND JOB's own child (isBackgroundJob). The parent
+ *    transcript already receives the job's completion report, so a `done`/`error`
+ *    push for it is pure duplicate noise — but a `permission`/`question` means
+ *    the job is BLOCKED and will sit forever until the user acts, so those stay.
  *
  * @param {{kind?: string}|null} payload  classifyPushEvent result
  * @param {string|null} label             resolved "workspace / session-name", or null
+ * @param {boolean}     isBackgroundJob   true when this session is a background job's own child
  * @returns {boolean}
  */
-export function shouldSuppressUnresolvedNotification(payload, label) {
-  if (!label) {
-    const k = payload?.kind;
-    return k === "done" || k === "error" || k === "permission" || k === "question";
-  }
+export function shouldSuppressNotification(payload, label, isBackgroundJob) {
+  const k = payload?.kind;
+  if (isBackgroundJob === true) return k === "done" || k === "error";
+  if (!label) return k === "done" || k === "error" || k === "permission" || k === "question";
   return false;
 }
 
@@ -516,6 +517,20 @@ async function resolveSessionLabel(sessionId) {
     return buildSessionLabel(projects, sessionId);
   } catch {
     return null;
+  }
+}
+
+// Is this opencode session a background job's own child session? Such a job
+// reports its outcome into the parent's transcript, so a done/error push for
+// it is pure duplicate noise. Best-effort: any failure returns false, so a
+// broken store degrades to today's behaviour (notify) rather than silence.
+async function isBackgroundJobSession(sessionId) {
+  if (!sessionId) return false;
+  try {
+    const jobs = await loadJobs();
+    return jobs.some((j) => j.childSessionID === sessionId);
+  } catch {
+    return false;
   }
 }
 
@@ -872,6 +887,7 @@ export async function firePush(evt) {
       "session.idle",
     ]);
     const label = NOTIFYING.has(type) ? await resolveSessionLabel(sid) : null;
+    const isJob = NOTIFYING.has(type) ? await isBackgroundJobSession(sid) : false;
 
     const payload = classifyPushEvent(evt, {
       focusSessionId: _focus.sessionId,
@@ -902,10 +918,12 @@ export async function firePush(evt) {
     // name the chat, the user has nothing actionable to land on. This applies
     // to done/error/permission/question — all are useless without a resolvable
     // session label.
-    if (shouldSuppressUnresolvedNotification(payload, label)) {
+    if (shouldSuppressNotification(payload, label, isJob)) {
       console.log(
-        `[push] ${payload.kind} sid=${sid} suppressed=unresolvable-session ` +
-          `(no tmux @manta-session-id → subagent/orphan)`,
+        `[push] ${payload.kind} sid=${sid} ` +
+          (isJob
+            ? `suppressed=background-job (parent gets the completion report)`
+            : `suppressed=unresolvable-session (no tmux @manta-session-id → subagent/orphan)`),
       );
       return;
     }

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -524,11 +524,10 @@ async function resolveSessionLabel(sessionId) {
 // reports its outcome into the parent's transcript, so a done/error push for
 // it is pure duplicate noise. Best-effort: any failure returns false, so a
 // broken store degrades to today's behaviour (notify) rather than silence.
-// `load` is injectable for tests (mirrors delegate.mjs's `{ load = loadJobs }`).
-export async function isBackgroundJobSession(sessionId, load = loadJobs) {
+async function isBackgroundJobSession(sessionId) {
   if (!sessionId) return false;
   try {
-    const jobs = await load();
+    const jobs = await loadJobs();
     return jobs.some((j) => j.childSessionID === sessionId);
   } catch {
     return false;

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -524,10 +524,11 @@ async function resolveSessionLabel(sessionId) {
 // reports its outcome into the parent's transcript, so a done/error push for
 // it is pure duplicate noise. Best-effort: any failure returns false, so a
 // broken store degrades to today's behaviour (notify) rather than silence.
-async function isBackgroundJobSession(sessionId) {
+// `load` is injectable for tests (mirrors delegate.mjs's `{ load = loadJobs }`).
+export async function isBackgroundJobSession(sessionId, load = loadJobs) {
   if (!sessionId) return false;
   try {
-    const jobs = await loadJobs();
+    const jobs = await load();
     return jobs.some((j) => j.childSessionID === sessionId);
   } catch {
     return false;

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -8,6 +8,7 @@ import {
   buildSessionLabel,
   shouldSuppressForDesktop,
   shouldSuppressNotification,
+  isBackgroundJobSession,
   routeNotification,
   notifTier,
   fireNotify,
@@ -407,6 +408,44 @@ test("ordinary chat (resolved label, not a job) still notifies", () => {
   );
   assert.equal(done?.kind, "done");
   assert.equal(shouldSuppressNotification(done, "ws / name", false), false);
+});
+
+test("isBackgroundJobSession matches a stored job's childSessionID in ANY status", async () => {
+  // The wire from firePush to the predicate: isBackgroundJobSession reads the
+  // delegate store and flags the job's own child session. The status==="running"
+  // filter would race — a job transitions to done in the same burst that
+  // produces its idle — so matching must hold across statuses.
+  assert.equal(
+    await isBackgroundJobSession("ses_job", async () => [{ childSessionID: "ses_job", status: "done" }]),
+    true,
+  );
+  assert.equal(
+    await isBackgroundJobSession("ses_job_running", async () => [{ childSessionID: "ses_job_running", status: "running" }]),
+    true,
+  );
+  assert.equal(
+    await isBackgroundJobSession("ses_job_failed", async () => [{ childSessionID: "ses_job_failed", status: "failed" }]),
+    true,
+  );
+});
+
+test("isBackgroundJobSession does NOT match a non-job session", async () => {
+  // A regular chat session that happens to share a sessionID with nothing in
+  // the store is not a job's child and must not be flagged.
+  assert.equal(
+    await isBackgroundJobSession("ses_regular", async () => [{ childSessionID: "ses_job", status: "running" }]),
+    false,
+  );
+});
+
+test("isBackgroundJobSession degrades to false on empty/missing/failing store", async () => {
+  // Best-effort: an empty store, a corrupt read, a missing file, or a missing
+  // sessionId all return false so the box degrades to today's notify behaviour
+  // (never silence).
+  assert.equal(await isBackgroundJobSession("ses_x", async () => []), false);
+  assert.equal(await isBackgroundJobSession("ses_x", async () => { throw new Error("corrupt"); }), false);
+  assert.equal(await isBackgroundJobSession(null, async () => [{ childSessionID: "x", status: "done" }]), false);
+  assert.equal(await isBackgroundJobSession("", async () => [{ childSessionID: "x", status: "done" }]), false);
 });
 
 const LBL = { ...NOFOCUS, label: "default / my-chat" };

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -8,7 +8,6 @@ import {
   buildSessionLabel,
   shouldSuppressForDesktop,
   shouldSuppressNotification,
-  isBackgroundJobSession,
   routeNotification,
   notifTier,
   fireNotify,
@@ -408,44 +407,6 @@ test("ordinary chat (resolved label, not a job) still notifies", () => {
   );
   assert.equal(done?.kind, "done");
   assert.equal(shouldSuppressNotification(done, "ws / name", false), false);
-});
-
-test("isBackgroundJobSession matches a stored job's childSessionID in ANY status", async () => {
-  // The wire from firePush to the predicate: isBackgroundJobSession reads the
-  // delegate store and flags the job's own child session. The status==="running"
-  // filter would race — a job transitions to done in the same burst that
-  // produces its idle — so matching must hold across statuses.
-  assert.equal(
-    await isBackgroundJobSession("ses_job", async () => [{ childSessionID: "ses_job", status: "done" }]),
-    true,
-  );
-  assert.equal(
-    await isBackgroundJobSession("ses_job_running", async () => [{ childSessionID: "ses_job_running", status: "running" }]),
-    true,
-  );
-  assert.equal(
-    await isBackgroundJobSession("ses_job_failed", async () => [{ childSessionID: "ses_job_failed", status: "failed" }]),
-    true,
-  );
-});
-
-test("isBackgroundJobSession does NOT match a non-job session", async () => {
-  // A regular chat session that happens to share a sessionID with nothing in
-  // the store is not a job's child and must not be flagged.
-  assert.equal(
-    await isBackgroundJobSession("ses_regular", async () => [{ childSessionID: "ses_job", status: "running" }]),
-    false,
-  );
-});
-
-test("isBackgroundJobSession degrades to false on empty/missing/failing store", async () => {
-  // Best-effort: an empty store, a corrupt read, a missing file, or a missing
-  // sessionId all return false so the box degrades to today's notify behaviour
-  // (never silence).
-  assert.equal(await isBackgroundJobSession("ses_x", async () => []), false);
-  assert.equal(await isBackgroundJobSession("ses_x", async () => { throw new Error("corrupt"); }), false);
-  assert.equal(await isBackgroundJobSession(null, async () => [{ childSessionID: "x", status: "done" }]), false);
-  assert.equal(await isBackgroundJobSession("", async () => [{ childSessionID: "x", status: "done" }]), false);
 });
 
 const LBL = { ...NOFOCUS, label: "default / my-chat" };

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -7,7 +7,7 @@ import {
   classifyPushEvent,
   buildSessionLabel,
   shouldSuppressForDesktop,
-  shouldSuppressUnresolvedNotification,
+  shouldSuppressNotification,
   routeNotification,
   notifTier,
   fireNotify,
@@ -278,7 +278,7 @@ test("REGRESSION: a nameless 'done' (subagent/orphan, null label) is suppressed"
     { focusSessionId: null, focusVisible: false, wasBusy: true, label: null },
   );
   assert.equal(done?.kind, "done");
-  assert.equal(shouldSuppressUnresolvedNotification(done, null), true);
+  assert.equal(shouldSuppressNotification(done, null, false), true);
 });
 
 test("a named 'done' (resolvable session) is NOT suppressed", () => {
@@ -286,7 +286,7 @@ test("a named 'done' (resolvable session) is NOT suppressed", () => {
     { type: "session.idle", properties: { sessionID: "ses_real" } },
     { focusSessionId: null, focusVisible: false, wasBusy: true, label: "default / my-chat" },
   );
-  assert.equal(shouldSuppressUnresolvedNotification(done, "default / my-chat"), false);
+  assert.equal(shouldSuppressNotification(done, "default / my-chat", false), false);
 });
 
 test("unresolved 'error' (null label) is suppressed — fixes BET-107 orphan spam", () => {
@@ -297,7 +297,7 @@ test("unresolved 'error' (null label) is suppressed — fixes BET-107 orphan spa
     { focusSessionId: null, focusVisible: false, wasBusy: false, label: null },
   );
   assert.equal(err?.kind, "error");
-  assert.equal(shouldSuppressUnresolvedNotification(err, null), true);
+  assert.equal(shouldSuppressNotification(err, null, false), true);
 });
 
 test("resolvable 'error' (with label) is NOT suppressed", () => {
@@ -306,7 +306,7 @@ test("resolvable 'error' (with label) is NOT suppressed", () => {
     { focusSessionId: null, focusVisible: false, wasBusy: false, label: "default / my-chat" },
   );
   assert.equal(err?.kind, "error");
-  assert.equal(shouldSuppressUnresolvedNotification(err, "default / my-chat"), false);
+  assert.equal(shouldSuppressNotification(err, "default / my-chat", false), false);
 });
 
 test("unresolved 'permission' (null label) is suppressed", () => {
@@ -317,7 +317,7 @@ test("unresolved 'permission' (null label) is suppressed", () => {
     { focusSessionId: null, focusVisible: false, wasBusy: false, label: null },
   );
   assert.equal(perm?.kind, "permission");
-  assert.equal(shouldSuppressUnresolvedNotification(perm, null), true);
+  assert.equal(shouldSuppressNotification(perm, null, false), true);
 });
 
 test("resolvable 'permission' (with label) is NOT suppressed", () => {
@@ -326,7 +326,7 @@ test("resolvable 'permission' (with label) is NOT suppressed", () => {
     { focusSessionId: null, focusVisible: false, wasBusy: false, label: "default / my-chat" },
   );
   assert.equal(perm?.kind, "permission");
-  assert.equal(shouldSuppressUnresolvedNotification(perm, "default / my-chat"), false);
+  assert.equal(shouldSuppressNotification(perm, "default / my-chat", false), false);
 });
 
 test("unresolved 'question' (null label) is suppressed", () => {
@@ -337,7 +337,7 @@ test("unresolved 'question' (null label) is suppressed", () => {
     { focusSessionId: null, focusVisible: false, wasBusy: false, label: null },
   );
   assert.equal(q?.kind, "question");
-  assert.equal(shouldSuppressUnresolvedNotification(q, null), true);
+  assert.equal(shouldSuppressNotification(q, null, false), true);
 });
 
 test("resolvable 'question' (with label) is NOT suppressed", () => {
@@ -346,16 +346,67 @@ test("resolvable 'question' (with label) is NOT suppressed", () => {
     { focusSessionId: null, focusVisible: false, wasBusy: false, label: "default / my-chat" },
   );
   assert.equal(q?.kind, "question");
-  assert.equal(shouldSuppressUnresolvedNotification(q, "default / my-chat"), false);
+  assert.equal(shouldSuppressNotification(q, "default / my-chat", false), false);
 });
 
 test("null payload → no suppression (no-op)", () => {
-  assert.equal(shouldSuppressUnresolvedNotification(null, null), false);
+  assert.equal(shouldSuppressNotification(null, null, false), false);
 });
 
 test("non-notifying kind with null label → no suppression", () => {
   // Other kinds (e.g. "notify") should not be suppressed even with null label.
-  assert.equal(shouldSuppressUnresolvedNotification({ kind: "notify" }, null), false);
+  assert.equal(shouldSuppressNotification({ kind: "notify" }, null, false), false);
+});
+
+test("background job 'done' (even with resolved label) is suppressed", () => {
+  // BET-800: a background job's own child session reports done/error into the
+  // parent's transcript, so even with a resolvable label the push is duplicate
+  // noise. Match on isBackgroundJob regardless of label.
+  const done = classifyPushEvent(
+    { type: "session.idle", properties: { sessionID: "ses_job" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: true, label: "ws / job" },
+  );
+  assert.equal(done?.kind, "done");
+  assert.equal(shouldSuppressNotification(done, "ws / job", true), true);
+});
+
+test("background job 'error' (even with resolved label) is suppressed", () => {
+  const err = classifyPushEvent(
+    { type: "session.error", properties: { sessionID: "ses_job", message: "boom" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: false, label: "ws / job" },
+  );
+  assert.equal(err?.kind, "error");
+  assert.equal(shouldSuppressNotification(err, "ws / job", true), true);
+});
+
+test("background job blocked 'permission' (resolved label) is NOT suppressed", () => {
+  // A job asking permission is BLOCKED and will sit until the user acts — a
+  // blocked job must still page the user. Silence only done/error.
+  const perm = classifyPushEvent(
+    { type: "permission.asked", properties: { sessionID: "ses_job_perm", id: "per_j" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: false, label: "ws / job" },
+  );
+  assert.equal(perm?.kind, "permission");
+  assert.equal(shouldSuppressNotification(perm, "ws / job", true), false);
+});
+
+test("background job blocked 'question' (resolved label) is NOT suppressed", () => {
+  const q = classifyPushEvent(
+    { type: "question.asked", properties: { sessionID: "ses_job_q" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: false, label: "ws / job" },
+  );
+  assert.equal(q?.kind, "question");
+  assert.equal(shouldSuppressNotification(q, "ws / job", true), false);
+});
+
+test("ordinary chat (resolved label, not a job) still notifies", () => {
+  // The normal chat case: named session, not a background job — done pushes fire.
+  const done = classifyPushEvent(
+    { type: "session.idle", properties: { sessionID: "ses_real" } },
+    { focusSessionId: null, focusVisible: false, wasBusy: true, label: "ws / name" },
+  );
+  assert.equal(done?.kind, "done");
+  assert.equal(shouldSuppressNotification(done, "ws / name", false), false);
 });
 
 const LBL = { ...NOFOCUS, label: "default / my-chat" };


### PR DESCRIPTION
## What

Widen the existing push-suppression predicate so a background job's own child
session never raises a `done`/`error` notification (BET-800).

Every background job (a `delegate` job or a backgrounded `task` subagent) spent
the whole point of running in the background — the user isn't watching it, and
the parent session already receives the job's completion report in its
transcript. Since BET-721 each job got its own tmux window, so its session now
resolves to a perfectly good label and sailed past the old "no tmux window
stamps this sessionID" guard, firing a `done`/`error` push per job. This change
suppresses jobs *as jobs*.

- Renamed `shouldSuppressUnresolvedNotification` → `shouldSuppressNotification`
  and gave it a third `isBackgroundJob` argument. When true, only `done`/`error`
  are suppressed — a job asking `permission`/`question` is BLOCKED and must
  still page the user.
- `firePush` resolves the flag next to the existing label lookup, gated on the
  same `NOTIFYING` event set so the streaming firehose costs nothing. It matches
  the job store's `childSessionID` for jobs in ANY status (a job transitions to
  `done` in the same burst that produces its `idle`, so a `running`-only filter
  would race).
- Best-effort: a broken/missing delegate store degrades to today's behaviour
  (notify), never silence.
- Keep `permission` and `question` everywhere they currently pass.

## Files changed

`2` files.

```
 src/server/push.mjs      | 58 +++++++++++++++++++++++++-------------
 src/server/push.test.mjs | 73 ++++++++++++++++++++++++++++++++++++++++--------
 2 files changed, 100 insertions(+), 31 deletions(-)
```

`src/renderer/**`, `src/server/delegate.mjs`, RPC/API routes, and the
classifier/router/escalation machinery are untouched — exactly one suppression
`if` + one `console.log` remains in `firePush`.

## Verification

- `npm run typecheck` — exit 0, no errors.
- `npm test` — 1684 pass / 0 fail / 0 skip.
- `grep -r shouldSuppressUnresolvedNotification src/` — empty.
- New unit tests in `src/server/push.test.mjs`: background-job `done`/`error`
  suppressed even with a resolved label; background-job `permission`/`question`
  NOT suppressed; ordinary named chat still notifies; existing
  unresolved-label behaviour ported to the renamed signature.

**Live-box manual check — deferred to post-merge, not run here.** The
acceptance criteria describe tailing `journalctl --user -u manta-server` and
kicking off a real background subagent from a chat session. That requires
deploying this branch's `push.mjs` into the running server on the shared dev
box — which is currently running `main` and is actively in use by several other
agent sessions. Swapping/restarting it mid-flight would disrupt live work and
falls under the "no prod deploy from agents" rule. The suppression logic is
fully covered by the added unit tests; the on-box end-to-end check is a
low-risk confirm step to run once merged and deployed.

Base: origin/main @ 3e1bdc18
