### PR TITLE
feat(server+renderer): job footer names its model (BET-801)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -50,6 +50,7 @@ import {
   isApprovalCoveredByAlways,
   MANTA_BUILTIN_COMMANDS,
   MANTA_BUILTIN_NAMES,
+  parseModelRef,
 } from "./chatUtils";
 import {
   appendPromptHistory,
@@ -2205,6 +2206,9 @@ export function ChatPanel({
       {jobOwnership ? (
         <ReadOnlyJobBar
           job={jobOwnership}
+          modelName={
+            resolveActiveModel(models, parseModelRef(jobOwnership.model), null)?.name ?? null
+          }
           parentName={(() => {
             const pid = jobOwnership.parentSessionID;
             for (const p of projects) {

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -553,11 +553,13 @@ export const ReadOnlyJobBar = memo(function ReadOnlyJobBar({
   parentName,
   onGoToParent,
   onStop,
+  modelName,
 }: {
   job: DelegateJob;
   parentName: string | null;
   onGoToParent: () => void;
   onStop: () => void;
+  modelName: string | null;
 }) {
   const terminal = job.status !== "running";
   return (
@@ -566,7 +568,11 @@ export const ReadOnlyJobBar = memo(function ReadOnlyJobBar({
         <span style={{ color: "var(--accent)" }} className="inline-flex items-center">
           <Bot size={14} aria-hidden="true" />
         </span>
-        <span className="text-text">Read-only — this is a background job.</span>
+        <span className="text-text">
+          {modelName
+            ? <>Read-only — this is a background job running <strong>{modelName}</strong>.</>
+            : "Read-only — this is a background job."}
+        </span>
         {parentName && (
           <span className="text-text-faint">It reports to {parentName}.</span>
         )}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -68,6 +68,7 @@ import {
   isApprovalCoveredByAlways,
   shortModelName,
   isFastModelId,
+  parseModelRef,
   baseModelId,
   fastModelId,
   hideFastSiblingGroups,
@@ -2044,6 +2045,43 @@ describe("formatJobSummary", () => {
     expect(
       formatJobSummary({ branch: "fix-login", filesChanged: null, worktree: "/tmp/wt" }),
     ).toBe("fix-login · 0 files changed");
+  });
+});
+
+// ===== parseModelRef (BET-801) =====
+
+describe("parseModelRef", () => {
+  it("splits a canonical providerID/modelID ref", () => {
+    expect(parseModelRef("anthropic/claude-sonnet-4-6")).toEqual({
+      providerID: "anthropic",
+      modelID: "claude-sonnet-4-6",
+    });
+  });
+
+  it("splits on the FIRST slash only when the modelID contains a slash", () => {
+    expect(parseModelRef("openai/gpt-4o/mini")).toEqual({
+      providerID: "openai",
+      modelID: "gpt-4o/mini",
+    });
+  });
+
+  it("returns null for absent or empty refs", () => {
+    expect(parseModelRef(null)).toBeNull();
+    expect(parseModelRef(undefined)).toBeNull();
+    expect(parseModelRef("")).toBeNull();
+  });
+
+  it("returns null for a ref with no slash", () => {
+    expect(parseModelRef("anthropic")).toBeNull();
+  });
+
+  it("returns null when either side is empty", () => {
+    expect(parseModelRef("/claude")).toBeNull();
+    expect(parseModelRef("anthropic/")).toBeNull();
+  });
+
+  it("returns null for a non-string (the legacy object shape on disk)", () => {
+    expect(parseModelRef({ providerID: "anthropic", modelID: "claude" } as unknown as string)).toBeNull();
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1540,6 +1540,20 @@ export function isJobRow(
 // Used by the jobs management card for terminal (done/failed/stopped) rows.
 // The no-worktree case (job ran in the parent cwd, worktree null) renders
 // without a branch. `filesChanged` null/undefined → "0 files".
+// A job record's `model` is the canonical "providerID/modelID" ref. This
+// splits it on the FIRST "/" only — model ids contain slashes, provider ids
+// do not. Returns null for absent/malformed input and for any non-string
+// (defends against a legacy object shape persisted on disk, so the job footer
+// renders plain rather than crashing).
+export function parseModelRef(
+  ref: string | null | undefined,
+): { providerID: string; modelID: string } | null {
+  if (typeof ref !== "string" || ref.length === 0) return null;
+  const idx = ref.indexOf("/");
+  if (idx < 1 || idx === ref.length - 1) return null;
+  return { providerID: ref.slice(0, idx), modelID: ref.slice(idx + 1) };
+}
+
 export function formatJobSummary(job: {
   branch?: string | null;
   filesChanged?: number | null;

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -623,7 +623,7 @@ export async function observeEvent(evt, deps = {}, sawBusy = new Map()) {
             childSessionID: info.childSessionId,
             name: info.description || info.agent,
             prompt: info.prompt,
-            model: info.model,
+            model: info.model ? `${info.model.providerID}/${info.model.modelID}` : null,
           },
           deps,
         );
@@ -891,6 +891,28 @@ export async function finishJob(job, status, error, deps = {}, sawBusy) {
 // (startActivityPoller) retains the inFlight re-entrancy guard + timer.unref.
 // ---------------------------------------------------------------------------
 
+/**
+ * Last message that names a model → "providerID/modelID", else null. The
+ * messages are opencode transcript entries whose `info` carries optional
+ * providerID/modelID. Guarded for a non-array argument and for messages
+ * with no `info`. Used by tickActivity to stamp the effective model on a job
+ * record (the model the child actually used, observed from its own messages).
+ */
+export function effectiveModelFromMessages(messages) {
+  if (!Array.isArray(messages)) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const info = messages[i]?.info;
+    if (
+      info &&
+      typeof info.providerID === "string" &&
+      typeof info.modelID === "string"
+    ) {
+      return `${info.providerID}/${info.modelID}`;
+    }
+  }
+  return null;
+}
+
 export async function tickActivity(deps) {
   const { load = loadJobs, save = saveJobs, publish, listMessages, now = () => Date.now() } = deps;
   // Under the jobs-store lock: the read-compare-write of `activity` is atomic,
@@ -903,15 +925,25 @@ export async function tickActivity(deps) {
       jobs.map(async (job) => {
         if (job.status !== "running") return;
         let activity = null;
+        let activityChanged = false;
+        let modelChanged = false;
         try {
           const messages = listMessages ? await listMessages(job.childSessionID) : [];
           activity = describeChatActivity(summarizeTranscript(messages));
+          const model = effectiveModelFromMessages(messages);
+          if (model !== null && model !== job.model) {
+            job.model = model;
+            modelChanged = true;
+          }
         } catch (e) {
           console.warn(`[delegate] activity poll failed for ${job.id}:`, e?.message ?? e);
           return;
         }
         if (activity !== job.activity) {
           job.activity = activity;
+          activityChanged = true;
+        }
+        if (activityChanged || modelChanged) {
           changed = true;
           publish?.({
             kind: "delegate.updated",

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -18,6 +18,8 @@ import {
   MAX_RUNNING_JOBS,
   createDelegateEngine,
   adoptSubagentJob,
+  effectiveModelFromMessages,
+  tickActivity,
 } from "./delegate.mjs";
 
 // ----------------------------------------------------------------------------
@@ -629,13 +631,28 @@ function backgroundPart(overrides = {}) {
 
 test("observeEvent adopts a running background:true subagent from a message.part.updated", async () => {
   const a = adoptHarness();
-  const evt = { type: "message.part.updated", properties: { sessionID: "ses_parent", part: backgroundPart() } };
+  const part = backgroundPart({
+    state: {
+      ...backgroundPart().state,
+      metadata: {
+        sessionId: "ses_child",
+        background: true,
+        model: { providerID: "anthropic", modelID: "claude-haiku-4-5" },
+      },
+    },
+  });
+  const evt = { type: "message.part.updated", properties: { sessionID: "ses_parent", part } };
   await observeEvent(evt, a.deps, new Map());
   assert.equal(a.jobs.length, 1);
   assert.equal(a.jobs[0].childSessionID, "ses_child");
   assert.equal(a.jobs[0].origin, "subagent");
   assert.equal(a.jobs[0].status, "running");
   assert.equal(a.newWindowCalls[0].existingSessionId, "ses_child");
+  assert.equal(
+    a.jobs[0].model,
+    "anthropic/claude-haiku-4-5",
+    "adoption persists model as the canonical string, never an object",
+  );
 });
 
 test("observeEvent adopts nothing when background is absent from the part", async () => {
@@ -657,7 +674,68 @@ test("observeEvent adopts nothing for a completed background task", async () => 
 });
 
 // ----------------------------------------------------------------------------
-// BET-773: the engine serialises observeEvent per session. opencode emits
+// effectiveModelFromMessages + tickActivity model stamping (BET-801)
+// ----------------------------------------------------------------------------
+
+function modelMessage(providerID, modelID) {
+  return { info: { providerID, modelID }, parts: [] };
+}
+
+test("effectiveModelFromMessages returns the LAST model-bearing message's providerID/modelID", () => {
+  const messages = [
+    modelMessage("anthropic", "claude-opus-5"),
+    { info: {}, parts: [] },
+    modelMessage("anthropic", "claude-sonnet-4-6"),
+    modelMessage("deepseek", "deepseek-chat"),
+  ];
+  assert.equal(effectiveModelFromMessages(messages), "deepseek/deepseek-chat");
+});
+
+test("effectiveModelFromMessages returns null for [], non-array, and messages without a model", () => {
+  assert.equal(effectiveModelFromMessages([]), null);
+  assert.equal(effectiveModelFromMessages(undefined), null);
+  assert.equal(effectiveModelFromMessages("nope"), null);
+  assert.equal(effectiveModelFromMessages(null), null);
+  const noModel = [
+    { info: { role: "user" }, parts: [] },
+    { info: { providerID: "anthropic" }, parts: [] }, // only providerID
+  ];
+  assert.equal(effectiveModelFromMessages(noModel), null);
+});
+
+test("tickActivity stamps job.model from the transcript and publishes delegate.updated exactly once", async () => {
+  const running = runningJob(0);
+  running.model = null;
+  running.activity = null;
+  const h = harness([running]);
+  h.deps.listMessages = async () => [
+    modelMessage("anthropic", "claude-opus-5"),
+    modelMessage("anthropic", "claude-sonnet-4-6"), // last → stripes model
+  ];
+  await tickActivity(h.deps);
+  assert.equal(h.jobs[0].model, "anthropic/claude-sonnet-4-6");
+  const modelPublishes = h.published.filter((p) => p.kind === "delegate.updated");
+  assert.equal(modelPublishes.length, 1, "single delegate.updated for a both-changed tick");
+  assert.equal(modelPublishes[0].payload.id, running.id);
+  assert.equal(modelPublishes[0].payload.status, "running");
+  assert.notEqual(h.jobs[0].activity, null, "activity changed too in this tick");
+});
+
+test("tickActivity does NOT publish when neither activity nor model changed", async () => {
+  const running = runningJob(0);
+  running.model = null;
+  running.activity = null;
+  const h = harness([running]);
+  h.deps.listMessages = async () => [modelMessage("anthropic", "claude-sonnet-4-6")];
+  await tickActivity(h.deps);
+  assert.equal(h.published.length, 1, "first tick stamps model + activity");
+  h.published.length = 0;
+  await tickActivity(h.deps);
+  assert.equal(h.published.length, 0, "second tick with nothing changed does not publish");
+  assert.equal(h.jobs[0].model, "anthropic/claude-sonnet-4-6");
+});
+
+
 // several events per turn boundary and the pump calls observeEvent without
 // awaiting it, so two invocations are in flight at once. Without per-session
 // serialisation each read-store -> decide -> write-store sequence interleaves


### PR DESCRIPTION
## BET-801 — Job footer names its model

Fixes the background-job footer to name the model the job is actually running
on, and makes `DelegateJob.model` stop lying about its shape.

### Approach (as specified — no re-derivation)

1. **One shape at the single writer.** The subagent-adoption block in
   `observeEvent` now passes the canonical `"providerID/modelID"` string
   (`info.model ? `${info.model.providerID}/${info.model.modelID}` : null`)
   instead of the raw `{providerID, modelID}` object from
   `extractSubagentInfo`. `registerJob`, `adoptSubagentJob`, and
   `extractSubagentInfo` are unchanged — the conversion happens at the call
   site only.
2. **Effective model stamped from the child transcript.** The existing
   activity poller (`tickActivity`) already fetches the child's messages, so
   it now also derives the effective model from the LAST message that names
   both `providerID` and `modelID` and stamps it onto `job.model` when it
   differs. No new fetch, poller, or field. It publishes `delegate.updated`
   once for a tick where activity and/or model changed (payload shape
   unchanged).
3. **Small pure helpers, reused.** `effectiveModelFromMessages` (server) and
   `parseModelRef` (renderer) split `"providerID/modelID"` on the FIRST slash
   only; `parseModelRef` returns null for non-strings (the legacy object shape
   on disk renders the plain sentence, never crashes).
4. **Renderer reuses existing lookups.** ChatPanel computes
   `resolveActiveModel(models, parseModelRef(jobOwnership.model), null)?.name`
   inline at the `<ReadOnlyJobBar>` call site (no `useMemo`). ReadOnlyJobBar
   adds a `modelName: string | null` prop and renders `Read-only — this is a
   background job running **<name>**.` when set, byte-identical
   `Read-only — this is a background job.` when null.

### Explicitly NOT done (per the ticket)

- `DelegateJob` type/fields unchanged (`model: string | null`).
- No second field, no union, no migration, no new API route / RPC / `window.api`
  method / bus event, no `useMemo`, no CSS class.
- `registerJob`, `startJob`, `finishJob`, `adoptSubagentJob`, `stopJob`,
  `cleanupTerminalJob`, `extractSubagentInfo` signatures and behaviours untouched.

### Diffstat

```
 src/renderer/ChatPanel.tsx     |  4 +++
 src/renderer/PanelCards.tsx    |  8 ++++-
 src/renderer/chatUtils.test.ts | 38 ++++++++++++++++++++
 src/renderer/chatUtils.ts      | 14 ++++++++
 src/server/delegate.mjs        | 34 +++++++++++++++++-
 src/server/delegate.test.mjs   | 82 ++++++++++++++++++++++++++++++++++++++++--
 6 files changed, 176 insertions(+), 4 deletions(-)
```

Production code accounts for ~60 lines; the rest is the requested test cases.

### Verification results

- PR branch (`multica/BET-801-job-model-footer` @ `50536373`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, vitest 2420 pass / 7 skip / 0 fail, node 1683 pass / 0 fail. log sha256: `52e103ce88f65f85ef304bb84181f001a5bb8916b09a02725168824597798b4a`
- Base (`main` @ `3e1bdc18`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, vitest 2414 pass / 7 skip / 0 fail, node 1679 pass / 0 fail. log sha256: `f0baf0d493d7d4061f72e041ea0d5cdf840ddc0ac01d58fbefdf4afafa492fcc`
- **Conclusion:** 0 new failures. PR adds exactly the new tests (6 renderer `parseModelRef` + 4 server `effectiveModelFromMessages`/`tickActivity`/adoption). Pre-existing suites remain green on both branches.

**Base: origin/main @ `3e1bdc18`**

### Manual check (to be run on the box)

1. run a background subagent and a `delegate` job **without** passing a model
2. open each job's session from the sidebar rail
3. within one activity tick the footer reads
   `Read-only — this is a background job running **<name>**.` with a real
   friendly model name in bold, for BOTH kinds
4. `~/.manta/delegate-jobs.json` shows `"model": "provider/model"` strings for
   both new records
