### PR TITLE
BET-802: fix(chat): scroll transcript to bottom on submit

### DIFF
--- a/docs/chat-animation.md
+++ b/docs/chat-animation.md
@@ -12,7 +12,6 @@ keyframe animations**:
 
 - `manta-bubble-in` — the user prompt bubble "pop".
 - `manta-part-in` — tool cards sliding in.
-- `.manta-streaming > *` — per-markdown-block slide for the live streaming text.
 
 Each surface had its own bespoke motion (a different distance/easing), so a
 turn didn't assemble in one visual language, and the code was hand-maintained
@@ -31,7 +30,7 @@ rise" rather than several different effects.
 | `src/renderer/MessageBubble.tsx` | User prompt bubble — a `motion.div` using `MESSAGE_IN_ENTER`/`IDLE` based on `entering`. |
 | `src/renderer/ToolCall.tsx` | Assistant parts (tool cards **and** streaming text) — wrapped in a `motion.div`; every live part uses the same motion as the prompt. |
 | `src/renderer/Transcript.tsx` | Wraps the transcript in `MotionConfig reducedMotion="user"` so framer-motion honours `prefers-reduced-motion`. |
-| `src/renderer/index.css` | The hand-rolled keyframes were removed; only the **streaming caret** remains. |
+| `src/renderer/index.css` | The hand-rolled keyframes and the streaming caret were removed; chat entry animation is entirely framer-motion. |
 | `src/renderer/ChatPanel.tsx` | The working indicator's constant-height slot (jitter fix #2). |
 
 ## The motion (`MESSAGE_IN_ENTER`)
@@ -60,15 +59,6 @@ Regression tests assert this through a `data-motion` attribute (`"bubble"` /
 `Transcript.test.tsx`. Do not swap this for a real CSS class or a whole-list
 animation; the gate + per-message flag is what keeps loaded history still while
 live adds still animate.
-
-## Streaming caret
-
-The only remaining chat CSS is the trailing **caret** (the blinking marker on
-the currently-writing message), `.manta-streaming > *:last-child::after`. It is
-a typing indicator, not an entry animation, so it was kept. The entry animation
-is delivered by framer-motion; reduced-motion handling for it is via
-`MotionConfig`, so no `prefers-reduced-motion` CSS blocks are needed for the
-entry.
 
 ## Jitter fix #1 — the underdamped spring overshoot
 

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -8,7 +8,7 @@
 // (Transcript / Composer / hook extraction) verifiable rather than blind —
 // if any extraction breaks the mount or the event wiring, a test here fails.
 
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act } from "react";
 import { ChatPanel } from "./ChatPanel";
 import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
@@ -31,6 +31,57 @@ const PROPS = {
   cwd: "/home/dev/projects/x",
   isActive: true,
 };
+
+// react-virtuoso mock (BET-802) — one test needs to OBSERVE every
+// `scrollToIndex` call the panel makes, but Virtuoso recreates its imperative
+// handle object on every render, so a handle spied after mount goes stale the
+// moment the submit re-render lands. Instead of reaching into internals, we
+// wrap the REAL `<Virtuoso>` (delegating all rendering so the other harness
+// tests are untouched) and, in a layout effect that runs after Virtuoso sets
+// ref.current but before passiv ive effects (where ChatPanel's post-commit
+// force-tail scroll lives), route every `scrollToIndex` on the current handle
+// through a module-scope observer the test installs. Layout effects flush
+// bottom-up, so the child Virtuoso's handle exists before this wrapper runs.
+vi.mock("react-virtuoso", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("react-virtuoso")>();
+  const React = await import("react");
+  const { forwardRef: fwd, useLayoutEffect: layout, useRef: ref } = React;
+
+  // Registry the BET-802 test reads/writes. `observer` receives every
+  // scrollToIndex call; `container` is where the panel is mounted, so the
+  // observer can capture the transcript text at the moment of the call.
+  (globalThis as { __virtuosoScrollObserver?: unknown }).__virtuosoScrollObserver = null;
+  (globalThis as { __virtuosoContainer?: unknown }).__virtuosoContainer = null;
+
+  const Virtuoso = fwd(function Virtuoso(props: Record<string, unknown>, forwarded: unknown) {
+    const mountedRef = ref<boolean>(false);
+    layout(() => {
+      // `forwarded` is the panel's virtuosoRef; Virtuoso (child, rendered
+      // below) sets forwarded.current to a fresh handle during its own layout
+      // effect, which flushes before this one.
+      const handle = (forwarded as { current?: { scrollToIndex?: unknown } } | null)?.current;
+      if (handle && typeof handle.scrollToIndex === "function") {
+        const base = (handle.scrollToIndex as (...a: unknown[]) => unknown).bind(handle);
+        (handle as { scrollToIndex: (...a: unknown[]) => unknown }).scrollToIndex =
+          (...args: unknown[]) => {
+            const container = (globalThis as any).__virtuosoContainer as HTMLElement | null;
+            const observer = (globalThis as any).__virtuosoScrollObserver as
+              | ((args: unknown[], text: string) => void)
+              | null;
+            if (observer) observer(args, container?.textContent ?? "");
+            return base(...args);
+          };
+      }
+      mountedRef.current = true;
+    });
+    return React.createElement(
+      actual.Virtuoso,
+      { ...(props as Record<string, unknown>), ref: forwarded } as never,
+    );
+  });
+
+  return { ...actual, Virtuoso };
+});
 
 describe("ChatPanel render harness", () => {
   let bus: MockEventBus;
@@ -652,6 +703,81 @@ describe("ChatPanel composer submit", () => {
     await h.flush();
     // useInputHistory swapped the empty draft for the last user prompt.
     expect(textarea.value).toBe("previous prompt");
+  });
+
+  it("scrolls the transcript to the tail only after the optimistic message is committed (BET-802)", async () => {
+    // Capture every scrollToIndex the panel fires, together with the
+    // transcript text at the instant of the call, via the react-virtuoso mock
+    // defined at the top of this file (Virtuoso recreates its handle on every
+    // render, so an instance-level spy goes stale the moment submit commits).
+    const calls: Array<{ args: unknown[]; text: string }> = [];
+    (globalThis as any).__virtuosoScrollObserver = (args: unknown[], text: string) => {
+      calls.push({ args, text });
+    };
+    (globalThis as any).__virtuosoContainer = null;
+
+    // Seed one transcript row so the message-list branch (and thus the
+    // Virtuoso handle) is mounted before we submit; an empty initial fetch
+    // would render only the welcome state and no Virtuoso at all.
+    const transcript = [
+      {
+        info: {
+          id: "msg_a1",
+          sessionID: "ses_test",
+          role: "assistant" as const,
+          time: { created: 1, completed: 2 },
+        },
+        parts: [
+          { type: "text", id: "prt_a1", messageID: "msg_a1", text: "ready" },
+        ],
+      },
+    ];
+    ({ api } = installMockApi({
+      opencodeMessages: () => Promise.resolve(transcript),
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    (globalThis as any).__virtuosoContainer = h.container;
+    const before = calls.length;
+
+    const textarea = h.container.querySelector("textarea") as HTMLTextAreaElement;
+    await act(async () => {
+      typeInto(textarea, "please scroll to me");
+    });
+    await act(async () => {
+      textarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await h.flush();
+
+    // The optimistic user message committed into the DOM…
+    expect(h.text()).toContain("please scroll to me");
+    // …and at least one force-pin to "LAST" fired for it (the submit
+    // force-pin), at a moment when that very message was already rendered.
+    // If submit scrolled inline against the stale list, the "LAST" call would
+    // capture a transcript without the new message — the exact BET-802 bug.
+    const scrollsAfterSubmit = calls.slice(before);
+    const lastScrolled = scrollsAfterSubmit.some(
+      (c) => (c.args[0] as { index?: unknown } | undefined)?.index === "LAST",
+    );
+    const lastEndScrolled = scrollsAfterSubmit.some(
+      (c) => (c.args[0] as { index?: unknown; align?: unknown } | undefined)?.index === "LAST"
+        && (c.args[0] as { index?: unknown; align?: unknown } | undefined)?.align === "end",
+    );
+    const hadMessageWhenLastScrolled = scrollsAfterSubmit.some(
+      (c) =>
+        (c.args[0] as { index?: unknown } | undefined)?.index === "LAST"
+        && c.text.includes("please scroll to me"),
+    );
+    expect(lastScrolled).toBe(true);
+    expect(lastEndScrolled).toBe(true);
+    expect(hadMessageWhenLastScrolled).toBe(true);
+
+    (globalThis as any).__virtuosoScrollObserver = null;
+    (globalThis as any).__virtuosoContainer = null;
   });
 });
 

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -286,8 +286,22 @@ export function ChatPanel({
   // the deleted `pinnedToBottom` ref) fed by Virtuoso's atBottomStateChange.
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const atBottomRef = useRef(true);
+  // Set by submit(), consumed by the force-tail effect below. Submit cannot
+  // scroll inline: the optimistic row it just queued is not committed yet, so
+  // `index: "LAST"` would resolve to the PREVIOUS last message.
+  const forceTailRef = useRef(false);
   const onAtBottomChange = useCallback((atBottom: boolean) => {
     atBottomRef.current = atBottom;
+  }, []);
+  // The ONE way this panel scrolls the transcript to its tail. Every caller
+  // goes through here: submit's force-pin, the question-card reveal, the
+  // composer-resize rescue and the re-activation re-pin. `atBottomRef` is set
+  // eagerly rather than waiting for Virtuoso's async atBottomStateChange, so
+  // the followOutput gate and resizeInput's rescue agree with the scroll we
+  // just asked for.
+  const scrollToTail = useCallback((behavior: "auto" | "smooth" = "auto") => {
+    atBottomRef.current = true;
+    virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior });
   }, []);
   // Mirror of `messages` for event listeners (deep-link jumps) that need the
   // current list without re-registering on every message update.
@@ -517,7 +531,7 @@ export function ChatPanel({
         if (questions.length > 0) {
           // The question cards live in the transcript's footer; scroll the last
           // row into view so the footer (with the cards) is revealed.
-          virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior: "smooth" });
+          scrollToTail("smooth");
           wantQuestionScroll.current = false;
         }
       }
@@ -607,10 +621,10 @@ export function ChatPanel({
   // start: questions arrive via the async fetch after this panel mounts).
   useEffect(() => {
     if (wantQuestionScroll.current && questions.length > 0) {
-      virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior: "smooth" });
+      scrollToTail("smooth");
       wantQuestionScroll.current = false;
     }
-  }, [questions]);
+  }, [questions, scrollToTail]);
 
   // Textarea auto-resize up to a 6-line cap. After resizing, if the scroll
   // container is at the bottom we re-scroll so the input growing pushes the
@@ -624,9 +638,9 @@ export function ChatPanel({
     const cap = 6 * 20;
     el.style.height = `${Math.min(el.scrollHeight, cap)}px`;
     if (atBottomRef.current) {
-      virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end" });
+      scrollToTail();
     }
-  }, []);
+  }, [scrollToTail]);
   useEffect(() => {
     resizeInput();
   }, [input, resizeInput]);
@@ -673,8 +687,8 @@ export function ChatPanel({
   useEffect(() => {
     if (!isActive) return;
     if (!atBottomRef.current) return;
-    virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end" });
-  }, [isActive]);
+    scrollToTail();
+  }, [isActive, scrollToTail]);
 
   // Catch-up refetch on reactivation. While inactive, scheduleRefetch and the
   // delta buffer are suppressed (see the gating refs near refetchTimer) so we
@@ -757,10 +771,10 @@ export function ChatPanel({
         ],
       },
     ]);
-    // Force-pin to the tail after the optimistic append (replaces the deleted
-    // `pinnedToBottom.current = true; prevScrollHeight.current = 0` force-pin —
-    // Virtuoso owns the scroll, so the force-pin is one scrollToIndex).
-    virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior: "auto" });
+    // Force-pin to the tail. The scroll is deferred to the force-tail effect
+    // because the optimistic row above has not been committed yet — scrolling
+    // here would land on the previous last message.
+    forceTailRef.current = true;
 
     // Slash-command path: manta-local builtins → opencode commands → normal prompt.
     const slashMatch = text.match(/^\/(\S+)(?:\s+([\s\S]*))?$/);
@@ -896,6 +910,17 @@ export function ChatPanel({
   // latest version without adding submit to the effect's dependency array
   // (which would re-arm the effect on every keystroke).
   submitRef.current = submit;
+
+  // Post-commit half of submit()'s force-pin. Runs once per submit (the ref
+  // gate), after React has committed the optimistic user row and after the
+  // composer has resized, which is what makes `index: "LAST"` resolve to the
+  // message the user just sent. Ordinary streaming stickiness is still
+  // Virtuoso's followOutput — this effect does nothing when the ref is unset.
+  useEffect(() => {
+    if (!forceTailRef.current) return;
+    forceTailRef.current = false;
+    scrollToTail();
+  }, [messages, scrollToTail]);
 
   // Optimistic "new session" auto-submit: seed the composer with the draft's
   // prompt and fire the panel's OWN submit once, on mount. Going through submit

--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -248,7 +248,6 @@ export const MessageRow = memo(function MessageRow({
   verbSeedId,
   truncation,
   commandInfo,
-  streaming = false,
   entering = false,
 }: {
   msg: OpencodeMessage;
@@ -275,11 +274,6 @@ export const MessageRow = memo(function MessageRow({
   // message, the row shows a collapsed `/name args` pill with an expand
   // chevron instead of the full expanded template body.
   commandInfo: { name: string; arguments: string } | null;
-  // True ONLY for the last assistant message while the turn is running — the
-  // message currently being written. Drives the per-block fade-in and the
-  // trailing caret on its final text part (BET-649). Primitive prop, so the
-  // MessageRow memo chain is untouched.
-  streaming?: boolean;
   // True when this message ARRIVED while the user was watching, as opposed to
   // being part of the transcript they loaded (transcript-motion). Decided once
   // in Transcript by `updateEntryMotion` and sticky for the row's whole life —
@@ -413,14 +407,11 @@ export const MessageRow = memo(function MessageRow({
 
   return stampedRow(
     <div className="flex flex-col" style={{ gap: "var(--block-gap)" }}>
-      {visibleParts.map((p, i) => (
+      {visibleParts.map((p) => (
         <AssistantPart
           key={p.id}
           part={p}
           showThinking={showThinking}
-          // Only the LAST part of the message being written streams — an
-          // earlier part is finished even while the turn continues.
-          streaming={streaming && i === visibleParts.length - 1}
           // Slide this part in only when the whole message is new to the user.
           // A loaded transcript passes `entering=false`, so history is still.
           entering={entering}

--- a/src/renderer/ToolCall.tsx
+++ b/src/renderer/ToolCall.tsx
@@ -55,15 +55,10 @@ export function formatFileDiff(additions: number, deletions: number): React.Reac
 export const AssistantPart = memo(function AssistantPart({
   part,
   showThinking,
-  streaming = false,
   entering = false,
 }: {
   part: OpencodePart;
   showThinking: boolean;
-  // True ONLY for the text part currently being written (last part of the last
-  // assistant message while the turn runs). Carries the trailing caret; a
-  // settled transcript never shows one.
-  streaming?: boolean;
   // True when the parent message ARRIVED while the user was watching, so this
   // part pops in as it appears. Every part of a live message does the SAME
   // animation (MESSAGE_IN) — a streaming text reply pops like the prompt,
@@ -72,7 +67,7 @@ export const AssistantPart = memo(function AssistantPart({
   // still (`initial={false}` → nothing moves).
   entering?: boolean;
 }) {
-  const body = renderAssistantPart(part, showThinking, streaming);
+  const body = renderAssistantPart(part, showThinking);
   if (body == null) return null;
   // The motion goes on an ALWAYS-PRESENT wrapper rather than the part's own
   // root because the roots are shared primitives (ToolCard, OutputWell) that
@@ -97,7 +92,6 @@ export const AssistantPart = memo(function AssistantPart({
 function renderAssistantPart(
   part: OpencodePart,
   showThinking: boolean,
-  streaming: boolean,
 ): React.ReactElement | null {
   if (part.type === "text") {
     const text = (part.text ?? "").replace(/^\n+|\n+$/g, "");
@@ -105,11 +99,7 @@ function renderAssistantPart(
     // Per the spec (.amsg) the assistant text is plain paragraphs at the
     // reading size with no leading gutter — the old `●` bullet column is gone
     // (BET-637), so the markdown body sits flush with the reading column.
-    return (
-      <div className={`break-words text-text${streaming ? " manta-streaming" : ""}`}>
-        {renderMarkdown(text)}
-      </div>
-    );
+    return <div className="break-words text-text">{renderMarkdown(text)}</div>;
   }
 
   if (part.type === "reasoning") {

--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -173,15 +173,13 @@ describe("Transcript entry motion", () => {
     // Prose is NOT exempt from the motion anymore — every part of a live
     // message (streaming text included) pops with the same framer-motion
     // entry, so the AI reply reads like the prompt. The container plays once
-    // on mount; the `.manta-streaming` class still supplies the trailing
-    // caret. Settling the turn must not retro-add a second pop.
+    // on mount. Settling the turn must not retro-add a second pop.
     h = open();
     render(h, [...HISTORY, OPTIMISTIC], true);
 
     const streaming = [...HISTORY, OPTIMISTIC, msg("a_new", "assistant", "writing")];
     render(h, streaming, true);
     expect(partsIn(h)).toBe(1);
-    expect(h.container.querySelectorAll(".manta-streaming").length).toBe(1);
 
     // Frozen at mount: settling the turn must not replay the pop.
     render(h, streaming, false);

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -396,8 +396,6 @@ export function Transcript({
     onRejectQuestion,
   };
 
-  const lastId = messages.length > 0 ? messages[messages.length - 1].info.id : null;
-
   // Anchor the initial view to the newest turn. A chat transcript opens at the
   // tail. `initialTopMostItemIndex: "LAST"` would do this declaratively, but
   // that prop renders zero rows under react-virtuoso's VirtuosoMockContext
@@ -488,8 +486,6 @@ export function Transcript({
                 // but the user must not — skip rendering the row entirely so it
                 // never appears as a right-aligned user bubble.
                 if (isBackgroundJobCompletionTurn(m)) return null;
-                const isLastInTranscript =
-                  m.info.id === lastId && m.info.role === "assistant";
                 // cmdInfo comes from `userCommandInfo` (memoized at panel
                 // scope on [messages, commandByMessageId, commands]).
                 // O(1) Map lookup here means MessageRow can be React.memo'd
@@ -507,9 +503,6 @@ export function Transcript({
                     verbSeedId={turnInfo.get(m.info.id)?.verbSeedId ?? null}
                     truncation={finishByMessageId.get(m.info.id) ?? null}
                     commandInfo={cmdInfo}
-                    // The message being written right now: last in the
-                    // transcript, assistant, and the turn still running.
-                    streaming={isLastInTranscript && running}
                     entering={entryMotion.entering.has(m.info.id)}
                   />
                 );

--- a/src/renderer/chatMotion.ts
+++ b/src/renderer/chatMotion.ts
@@ -1,8 +1,8 @@
 // M527.chatMotion — the single entry animation for chat message appearance.
 //
-// There used to be three separate hand-rolled CSS keyframe animations
-// (manta-bubble-in for the prompt, manta-part-in for cards, manta-streaming
-// for per-block streamed text) plus a data-* gate. They were consolidated into
+// There used to be separate hand-rolled CSS keyframe animations
+// (manta-bubble-in for the prompt, manta-part-in for cards) plus a data-*
+// gate. They were consolidated into
 // ONE framer-motion animation, "variant A": every assistant reply, tool card
 // and user prompt that arrives while the user is watching performs the same
 // short rise with a slight scale overshoot (spring physics), so message

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -80,16 +80,6 @@ html, body, #root {
 }
 .xterm-cursor-layer { outline: none; }
 
-/* Terminal-style blinking cursor for the chat running indicator. Hard on/off
-   (step-start), not a smooth fade — matches a real tty cursor. */
-@keyframes blink-cursor {
-  0%, 49% { opacity: 1; }
-  50%, 100% { opacity: 0; }
-}
-.blink-cursor {
-  animation: blink-cursor 1s step-start infinite;
-}
-
 /* Onboarding step transition — fade + slide up, keyed remount per step
    (Onboarding.tsx). Mirrors the mockup's fadeSlideIn. */
 @keyframes onboardingFadeSlideIn {
@@ -135,31 +125,6 @@ html, body, #root {
 @media (prefers-reduced-motion: reduce) {
   .manta-loader-ring-out,
   .manta-loader-ring-in { animation: none; }
-}
-
-/* Streaming assistant text — trailing caret only (BET-649, M527).
-   Entry motion for chat messages now lives in framer-motion
-   (`src/renderer/chatMotion.ts`, applied by MessageBubble / AssistantPart), so
-   the per-block and per-card CSS slide-ins are gone. What remains here is the
-   trailing caret that marks the ONE message currently being written: a thin
-   accent block after the last block's last line, drawn with ::after on the
-   last child so it sits INLINE at the end of the text — a sibling element
-   would break onto its own line after a block-level <p>. Nothing in the
-   settled transcript carries a caret, and the entry animation itself is
-   reduced-motion-handled by the app-root MotionConfig reducedMotion="user". */
-.manta-streaming > *:last-child::after {
-  content: "";
-  display: inline-block;
-  width: 0.45em;
-  height: 1em;
-  margin-left: 2px;
-  vertical-align: -0.15em;
-  border-radius: 1px;
-  background: var(--accent);
-  animation: blink-cursor 1s step-start infinite;
-}
-@media (prefers-reduced-motion: reduce) {
-  .manta-streaming > *:last-child::after { animation: none; }
 }
 
 /* Artifacts tab switch (links/images/files). The SELECTED highlight is a


### PR DESCRIPTION
Two independent desktop chat changes, two commits:

1. **`fix(chat): scroll transcript to bottom on submit`** (BET-802 Part 1)
   - Submit no longer scrolls inline against the yet-uncommitted message list. It
     sets a `forceTailRef` flag; a post-commit effect (after the composer has
     resized) scrolls the transcript to "LAST". Previously `index: "LAST"`
     resolved to the previous last message because the optimistic row wasn't
     committed yet.
   - Consolidated the four duplicate `scrollToIndex({ index: "LAST", ... })`
     literals (question-reveal, resize rescue, re-activation, submit) into one
     shared `scrollToTail` helper.
   - New harness test asserts the ordering: `scrollToIndex({ index: "LAST",
     align: "end" })` fires only at a point where the optimistic user message is
     already in the rendered transcript.
   - No change to `Transcript.tsx`, `useSseBus.ts`, `useTranscriptState.ts`.

2. **`refactor(chat): remove streaming caret animation`** (BET-802 Part 2)
   - Pure deletion of the blinking accent caret at the end of streaming text and
     the entire `streaming` prop chain that drove it
     (`Transcript → MessageRow → ToolCall → index.css`).
   - Removed the now-unused `blink-cursor` keyframes/utility and
     `.manta-streaming` rule from `index.css`; dropped `lastId` /
     `isLastInTranscript` from `Transcript.tsx`.
   - Updated the `chatMotion.ts` header and `docs/chat-animation.md` to match
     reality.
   - `running` on `Transcript` is kept (still drives `WorkingIndicator`).

Repo-wide search: `manta-streaming` and `blink-cursor` are absent from
`src/renderer/**` and `docs/` (the only remaining hit is the gitignored
`mobile/www/` build artifact, which CI rebuilds).

Base: `origin/main @ 9e103b9` (branch cut point). Current `origin/main` is
`035e15b`; it landed commits only to other files — no overlap with the 9 files
touched here, so the branch is clean to merge.

**Files changed:** 9 files, +171 / −93.

**Verification results:**
- PR branch (`multica/BET-802-scroll-submit-caret` @ `acaa8be`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0 — vitest 2426 pass / 7 skip / 0 fail; node 1679 pass / 0 fail. log sha256: `11b72c10b286304dbf54f7d4711116ef0871595b4ebc367513d7ec166ac1acfe`
- Base (`035e15b`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0. log sha256: `7972ba3004e9b3325fa2c45ed1f618e4eaf7200ae7066dbf45fbd96524af5fe0`
- **Conclusion:** 0 failures on both branches — no new failures, no pre-existing.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`,
`/tmp/test-pr.log`, `/tmp/test-main.log`.
