### PR TITLE
feat(renderer): zero-state workspace list from the repo probe (BET-787)

### DIFF
--- a/src/renderer/ListRow.tsx
+++ b/src/renderer/ListRow.tsx
@@ -1,0 +1,78 @@
+// ListRow — the shared list-row primitive (BET-787 [S2]/[S8]).
+//
+// The mockup's `.row` (manta-forge §8.2): a single flex row with the slots
+// `leading (dot|checkbox) · name · secondary · trailing meta`. It recurs in
+// [S2] [S3] [S6] [S8] [C6] [C7] [G1] and the work inbox — seven surfaces —
+// so it is built here once and shared rather than per-call-site flex stacks.
+//
+// Chrome contract (`rounded-md`, `hover:bg-fill-hover`): the row is a
+// 13px-slot row with a `text-text` truncated name, an optional `text-text-faint`
+// secondary line, and an `ml-auto` mono trailing column. `onClick` promotes it
+// from a plain row to a keyboard-activatable button so a checkbox/dot row and
+// a clickable row share one component (docs/components.md decision 2).
+//
+// Note the deliberate asymmetry with the chrome primitives (Button, Checkbox,
+// StatusDot): this is a *composable container*, not a single chrome element,
+// so it takes `className` (e.g. a `manta-*` identity hook). The slots stay the
+// one way to vary content.
+
+import type { ReactNode } from "react";
+
+export function ListRow({
+  leading,
+  name,
+  secondary,
+  trailing,
+  onClick,
+  title,
+  className,
+}: {
+  /** The row's leading slot: a checkbox, a status dot, or nothing. */
+  leading?: ReactNode;
+  /** The primary name — rendered `text-text font-medium`, truncated. */
+  name: ReactNode;
+  /** Optional secondary line under/after the name — `text-text-faint`. */
+  secondary?: ReactNode;
+  /** Optional trailing meta (e.g. an age) — `ml-auto`, mono, quiet. */
+  trailing?: ReactNode;
+  /** When set the row becomes a clickable button (tilts it to the onClick role). */
+  onClick?: () => void;
+  title?: string;
+  className?: string;
+}) {
+  return (
+    <div
+      role={onClick ? "button" : undefined}
+      tabIndex={onClick ? 0 : undefined}
+      onClick={onClick}
+      onKeyDown={
+        onClick
+          ? (e) => {
+              if (e.key === "Enter" || e.key === " ") {
+                e.preventDefault();
+                onClick();
+              }
+            }
+          : undefined
+      }
+      title={title}
+      className={
+        "flex items-center gap-[9px] px-[10px] py-2 rounded-md text-[13px] " +
+        (onClick ? "cursor-pointer " : "") +
+        "hover:bg-fill-hover " +
+        (className ?? "")
+      }
+    >
+      {leading}
+      <span className="text-text font-medium truncate min-w-0">{name}</span>
+      {secondary != null && (
+        <span className="text-text-faint truncate min-w-0">{secondary}</span>
+      )}
+      {trailing != null && (
+        <span className="ml-auto shrink-0 font-mono tabular-nums text-text-quiet">
+          {trailing}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/src/renderer/NewSessionScreen.harness.test.tsx
+++ b/src/renderer/NewSessionScreen.harness.test.tsx
@@ -77,26 +77,25 @@ describe("NewSessionScreen mount against an unpaired window.api", () => {
     expect(h.container.childElementCount).toBeGreaterThan(0);
   });
 
-  it("empty state: worktree chip is unchecked + enabled even when config defaults it on", async () => {
-    // BET-445: on a fresh box the demo/real config defaults worktreePerSession
-    // to true, but the empty-state cwd is "~" (not a git repo) — pre-arming
-    // wantWorktree from config shipped a "checked but can't be honored" chip.
-    // The new-project (empty) state must render it unchecked and tappable so
-    // the user can choose a folder first.
+  it("new-project zero state is the repo-probe screen, not the folder-chip composer", async () => {
+    // BET-787: the new-project (zero-project) zero state is now the repo-probe
+    // screen. On a box with no repos it is the "fresh" state, not today's
+    // folder-chip composer. In particular there is no worktree chip to pre-arm
+    // (the old BET-445 concern) — the folder/composer path is reached via
+    // "Browse for a folder…" instead.
     installMockApi();
     resetStore({ projects: [], worktreePerSession: true });
 
     h = mountDraft();
     await h.flush();
 
-    // The worktree toggle is now the Checkbox primitive (BET-589); its input
-    // carries the same accessible name it always did, so select it that way.
+    // Fresh-box heading (probe succeeded, zero repos found).
+    expect(h.container.textContent).toContain("Let's get some code on this box");
+    // No worktree chip in the repo-probe zero state.
     const checkbox = h.container.querySelector(
       'input[aria-label="Create in a fresh git worktree"]',
-    ) as HTMLInputElement;
-    expect(checkbox).not.toBeNull();
-    expect(checkbox.checked).toBe(false);
-    expect(checkbox.disabled).toBe(false);
+    );
+    expect(checkbox).toBeNull();
   });
 
   it("still fetches models when window.api IS the paired httpApi", async () => {

--- a/src/renderer/NewSessionScreen.harness.test.tsx
+++ b/src/renderer/NewSessionScreen.harness.test.tsx
@@ -21,7 +21,7 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { installMockApi, resetStore, mount, type Harness } from "./testHarness";
-import { NewSessionScreen } from "./NewSessionScreen";
+import { NewSessionScreen, uniqueSessionName } from "./NewSessionScreen";
 import type { NewSessionDraft } from "./store";
 
 // The two methods that live ONLY on httpApi and are therefore absent from
@@ -107,5 +107,20 @@ describe("NewSessionScreen mount against an unpaired window.api", () => {
     // The guard must not have silently disabled the happy path.
     expect(api.calls.opencodeModels?.length ?? 0).toBe(1);
     expect(api.calls.opencodeDefaultModel?.length ?? 0).toBe(1);
+  });
+});
+
+// BET-787: the numeric session-name de-dup is ONE shared helper — every path
+// that creates a project (repo-probe batch, composer submit, worktree fan-out)
+// must go through it, or two projects can land with the same tmux session
+// name. Pin it here so the duplication can't silently re-split.
+describe("uniqueSessionName", () => {
+  it("returns the base name when it is free", () => {
+    expect(uniqueSessionName("repo", new Set(["server", "other"]))).toBe("repo");
+  });
+
+  it("appends -2, -3, … until a free name is found", () => {
+    expect(uniqueSessionName("repo", new Set(["repo"]))).toBe("repo-2");
+    expect(uniqueSessionName("repo", new Set(["repo", "repo-2", "repo-3"]))).toBe("repo-4");
   });
 });

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -44,12 +44,24 @@ import { Button } from "./Button";
 import { Card } from "./Card";
 import { Checkbox } from "./Checkbox";
 import { FolderPickerModal } from "./FolderPickerModal";
+import { ListRow } from "./ListRow";
+import { Skeleton } from "./Skeleton";
+import { StatusDot } from "./StatusDot";
 import { worktreeName } from "./folderPicker";
 import { useVoiceRecorder, type VoiceResult } from "./voice";
+import {
+  describeRepoRow,
+  formatAge,
+  initialRepoSelection,
+  zeroStateMode,
+  type RepoRow,
+} from "./chatUtils";
 import type { VoiceMode, VoicePhase } from "./voice";
 import type {
+  ForgeCliStatus,
   OpencodeModel,
   Project,
+  RepoHit,
   TmuxCreateResult,
   WorktreeInfo,
 } from "../shared/types";
@@ -104,6 +116,10 @@ export function promptWindowName(input: string): string {
 }
 
 export function NewSessionScreen({ draftId, onDone }: Props) {
+  // Per-row lifecycle for the repo-probe batch setup (BET-787 [S8]).
+  type RowPhase = "idle" | "queued" | "creating" | "ready" | "error";
+  type CreatedSession = { name: string; windowIndex: number | undefined };
+
   // The draft this composer edits. The App only ever renders this screen for a
   // draft that exists (activeDraftId always points at a live draft), so a
   // missing draft is unreachable in practice; the guard keeps TypeScript's
@@ -134,6 +150,220 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  // ---- repo probe (BET-787): the new-project zero state ----
+  // Probe the box for git repos + the gh CLI. The scan is purely additive: if
+  // it fails or is unavailable we degrade to exactly today's behaviour (the
+  // folder picker), never a state worse than the one the screen used to have.
+  const PROBE_PRE_CHECK_CAP = 8;
+  const [probePending, setProbePending] = useState(false);
+  const [probeFailed, setProbeFailed] = useState(false);
+  const [probeRepos, setProbeRepos] = useState<RepoHit[]>([]);
+  const [cliStatus, setCliStatus] = useState<ForgeCliStatus | null>(null);
+  const [checked, setChecked] = useState<ReadonlySet<string>>(new Set());
+  // The user chose "Browse for a folder…" (or the picker returned a worktree
+  // fan-out) → render today's full composer for that folder. This is how the
+  // Browse escape path keeps working exactly as it did before the list.
+  const [browseChosen, setBrowseChosen] = useState(false);
+  // Per-row batch progress (BET-787 [S8]): "queued" / "creating…" / "ready" /
+  // "error". Partial failure is legible and does not abort the batch.
+  const [rowPhase, setRowPhase] = useState<Record<string, RowPhase>>({});
+  const [rowError, setRowError] = useState<Record<string, string>>({});
+  const createdRef = useRef<CreatedSession[]>([]);
+  const errorPathsRef = useRef<Set<string>>(new Set());
+  // True once a batch has run and we're showing the per-row results view (with
+  // errors + retry) instead of the pre-setup list. On all-success we navigate
+  // away immediately, so this view only lingers when at least one row failed.
+  const [batchDone, setBatchDone] = useState(false);
+
+  // All probe rows are local (they already exist on disk); a later forge issue
+  // adds clone rows and those must land `local: false` via the same shape.
+  const rows = useMemo<RepoRow[]>(
+    () => probeRepos.map((r) => ({ ...r, local: true })),
+    [probeRepos],
+  );
+  const hasFailed = rows.some((r) => rowPhase[r.path] === "error");
+
+  useEffect(() => {
+    if (!isNewProject) return;
+    let cancelled = false;
+    setProbePending(true);
+    setProbeFailed(false);
+    setProbeRepos([]);
+    setCliStatus(null);
+    setBrowseChosen(false);
+    setChecked(new Set());
+    setRowPhase({});
+    setRowError({});
+    setBatchDone(false);
+    createdRef.current = [];
+    errorPathsRef.current = new Set();
+    if (typeof window.api.forgeProbe === "function") {
+      window.api
+        .forgeProbe()
+        .then((res) => {
+          if (cancelled) return;
+          setProbePending(false);
+          setProbeRepos(res?.repos ?? []);
+          setCliStatus(res?.cli ?? null);
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setProbePending(false);
+          setProbeFailed(true);
+        });
+    } else {
+      // Probe not wired on this client (e.g. unpaired) — degrade gracefully.
+      setProbePending(false);
+      setProbeFailed(true);
+    }
+    return () => { cancelled = true; };
+  }, [isNewProject, draftId]);
+
+  const zeroState = zeroStateMode({
+    probePending,
+    probeFailed,
+    repos: probeRepos,
+  });
+
+  // Pre-check rule: check what already exists on disk, capped at 8, most
+  // recent first. Never check anything that would require a clone.
+  useEffect(() => {
+    if (probePending || probeFailed) {
+      setChecked(new Set());
+      return;
+    }
+    setChecked(
+      new Set(initialRepoSelection(rows, PROBE_PRE_CHECK_CAP).map((r) => r.path)),
+    );
+  }, [probePending, probeFailed, rows]);
+
+  const toggleRow = (path: string, on: boolean) => {
+    setChecked((prev) => {
+      const next = new Set(prev);
+      if (on) next.add(path);
+      else next.delete(path);
+      return next;
+    });
+  };
+
+  // Numeric de-dup on top of deriveProjectName — the same scheme the fan-out
+  // submit already uses. Extracted so the new zero-state batch and the fan-out
+  // share one naming rule.
+  const uniqueSessionName = (base: string, taken: Set<string>) => {
+    if (!taken.has(base)) return base;
+    let i = 2;
+    while (taken.has(`${base}-${i}`)) i++;
+    return `${base}-${i}`;
+  };
+
+  // Land on the given created session: setActive + box-side select-window +
+  // dismiss the draft, leaving the composer empty (never auto-submit a prompt).
+  const landIn = async (entry: CreatedSession) => {
+    const proj = useStore.getState().projects.find((p) => p.tmuxSession === entry.name);
+    const win =
+      entry.windowIndex != null
+        ? proj?.windows.find((w) => w.index === entry.windowIndex)
+        : proj?.windows.find((w) => w.active) ?? proj?.windows[0];
+    const idx = win?.index ?? entry.windowIndex ?? 0;
+    try {
+      await activateWindow(entry.name, idx);
+    } catch {
+      setActive(entry.name, idx);
+    }
+    dismissDraft(draftId);
+    onDone?.();
+  };
+
+  // Create one repo's workspace, tracking per-row progress. Partial failure
+  // surfaces but never aborts the batch (submitFanOut's rule).
+  const createRow = async (
+    row: RepoRow,
+    taken: Set<string>,
+    createdOut: CreatedSession[],
+  ) => {
+    const name = uniqueSessionName(deriveProjectName(row.path), taken);
+    taken.add(name);
+    setRowPhase((p) => ({ ...p, [row.path]: "creating" }));
+    setRowError((e) => {
+      const n = { ...e };
+      delete n[row.path];
+      return n;
+    });
+    try {
+      const res = await window.api.tmuxNewSession({
+        name,
+        cwd: row.path,
+        windowName: "default",
+        chatMode: true,
+        createDir: false,
+      });
+      const norm = normalizeCreate(res);
+      applyProjects(norm.projects);
+      const entry: CreatedSession = { name, windowIndex: norm.windowIndex };
+      createdOut.push(entry);
+      errorPathsRef.current.delete(row.path);
+      setRowPhase((p) => ({ ...p, [row.path]: "ready" }));
+    } catch (e) {
+      errorPathsRef.current.add(row.path);
+      setRowPhase((p) => ({ ...p, [row.path]: "error" }));
+      setRowError((err) => ({
+        ...err,
+        [row.path]: e instanceof Error ? e.message : String(e),
+      }));
+    }
+  };
+
+  // "Set up N workspaces": create one session per checked repo, in order
+  // (most-recent-first). When every checked repo lands, navigate to the most
+  // recently touched success and dismiss. Partial failure stays on the screen
+  // with the errored row visible + retryable (done via "Done").
+  const setupWorkspaces = async () => {
+    if (sending) return;
+    const chosen = rows.filter((r) => checked.has(r.path));
+    if (chosen.length === 0) return;
+    setSending(true);
+    setBatchDone(true);
+    setError(null);
+    createdRef.current = [];
+    errorPathsRef.current = new Set();
+    setRowPhase(Object.fromEntries(chosen.map((r) => [r.path, "queued"])));
+    setRowError({});
+    const taken = new Set(existingProjects.map((p) => p.tmuxSession));
+    for (const r of chosen) {
+      await createRow(r, taken, createdRef.current);
+    }
+    const created = createdRef.current;
+    setSending(false);
+    if (created.length > 0 && errorPathsRef.current.size === 0) {
+      // All succeeded → land in the most recently touched success.
+      await landIn(created[0]);
+    }
+  };
+
+  // Retry a single failed row (same partial-failure path). When the retry
+  // clears the last error and something was created, proceed as normal.
+  const retryRow = async (row: RepoRow) => {
+    const taken = new Set(existingProjects.map((p) => p.tmuxSession));
+    for (const c of createdRef.current) taken.add(c.name);
+    await createRow(row, taken, createdRef.current);
+    if (errorPathsRef.current.size === 0 && createdRef.current.length > 0) {
+      await landIn(createdRef.current[0]);
+    }
+  };
+
+  // Leave the partial-failure results view: land in the most recent success,
+  // or just dismiss the draft (the App re-creates the zero-state draft) when
+  // nothing was created.
+  const finishSetup = async () => {
+    if (createdRef.current.length > 0) {
+      await landIn(createdRef.current[0]);
+    } else {
+      dismissDraft(draftId);
+      onDone?.();
+    }
+  };
+
 
   // Model state — fetched on mount (same pattern as ChatPanel).
   const [models, setModels] = useState<OpencodeModel[] | null>(null);
@@ -425,12 +655,21 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   const emptyWorktree = isNewProject && !isGitRepo;
   const worktreeChipEnabled = emptyWorktree || isGitRepo;
 
+  // The repo-probe zero state is the NEW-project zero state only. The
+  // new-session-in-an-existing-project variant keeps today's composer
+  // untouched, and the "Browse for a folder…" escape from the zero state lands
+  // back on today's composer once a folder is picked (degrades to exactly
+  // today's behaviour, never a state worse than before the probe existed).
+  const showComposer = !isNewProject || browseChosen;
+
   return (
     // data-screen is the visual harness's handle on this screen (see
     // scripts/visual/screens.mjs). One stable attribute per screen root, so
     // the harness never depends on a class name or DOM position.
     <div data-screen="welcome" className="h-full flex flex-col items-center justify-center px-8">
       <div className="w-full max-w-[720px] rounded-xl border border-border-subtle bg-bg-elev px-6 py-10 flex flex-col gap-2">
+        {showComposer ? (
+        <>
         <div className="text-center space-y-1 mb-4">
           <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
           <p className="text-body text-text-faint">
@@ -554,15 +793,196 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
               onCancel={voiceRecorder.cancel}
             />
           ) : (
-            <IconButton
-              icon={<Mic />}
-              label="Dictate"
-              title="Dictation needs a Groq API key in Settings"
-              size="xl"
-              disabled
-            />
-          )}
+              <IconButton
+                icon={<Mic />}
+                label="Dictate"
+                title="Dictation needs a Groq API key in Settings"
+                size="xl"
+                disabled
+              />
+            )}
         </div>
+        </>
+        ) : (
+        <>
+            {zeroState === "scanning" ? (
+              <>
+                <div className="text-center space-y-1 mb-4">
+                  <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
+                  <p className="text-body text-text-faint">Looking for repositories on your box…</p>
+                </div>
+                <div className="space-y-2" aria-hidden="true">
+                  <Skeleton width={38} />
+                  <Skeleton width={52} />
+                  <Skeleton width={44} />
+                </div>
+                <div className="flex items-center gap-2 mt-4">
+                  <Button tone="default" onClick={() => setPickerOpen(true)}>
+                    Browse for a folder…
+                  </Button>
+                </div>
+              </>
+            ) : zeroState === "degraded" ? (
+              <>
+                <div className="text-center space-y-1 mb-4">
+                  <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
+                  <p className="text-body text-text-faint">
+                    Couldn't scan for repositories. Point Manta at a folder instead.
+                  </p>
+                </div>
+                <div className="flex justify-center mt-2">
+                  <Button tone="primary" onClick={() => setPickerOpen(true)}>
+                    Browse for a folder…
+                  </Button>
+                </div>
+              </>
+            ) : zeroState === "fresh" ? (
+              <>
+                <div className="text-center space-y-1 mb-4">
+                  <h1 className="text-display font-bold tracking-tight text-text">
+                    Let's get some code on this box
+                  </h1>
+                  <p className="text-body text-text-faint">
+                    No repositories found. Clone one from GitHub, or point Manta at a folder.
+                  </p>
+                </div>
+                <div className="flex justify-center gap-2 mt-4">
+                  <Button
+                    tone="primary"
+                    disabled
+                    title="Cloning from GitHub isn't available yet"
+                    onClick={() => {}}
+                  >
+                    Clone from GitHub…
+                  </Button>
+                  <Button tone="ghost" onClick={() => setPickerOpen(true)}>
+                    Browse for a folder…
+                  </Button>
+                </div>
+              </>
+            ) : (
+              <>
+                <div className="text-center space-y-1 mb-4">
+                  <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
+                  <p className="text-body text-text-faint">
+                    Found {probeRepos.length} {probeRepos.length === 1 ? "repository" : "repositories"} on your box.
+                  </p>
+                </div>
+
+                {cliStatus?.authenticated && (
+                  <div className="flex items-center justify-center gap-[7px] -mt-[6px] mb-3 text-[12px] text-text-faint">
+                    <StatusDot tone="ok" />
+                    <span>
+                      GitHub connected as{" "}
+                      <b className="text-text-muted font-semibold">@{cliStatus.login}</b>
+                    </span>
+                    <span
+                      className="text-[11.5px] text-text-faint underline decoration-dotted cursor-default"
+                      title="Not available yet"
+                    >
+                      use a different account
+                    </span>
+                  </div>
+                )}
+
+                <div className="space-y-0.5">
+                  {rows.map((r) =>
+                    batchDone ? (
+                      <ListRow
+                        key={r.path}
+                        leading={
+                          <StatusDot
+                            tone={
+                              rowPhase[r.path] === "ready"
+                                ? "ok"
+                                : rowPhase[r.path] === "creating"
+                                  ? "running"
+                                  : rowPhase[r.path] === "error"
+                                    ? "error"
+                                    : "idle"
+                            }
+                          />
+                        }
+                        name={<span className="truncate">{r.name}</span>}
+                        secondary={
+                          rowPhase[r.path] === "error" ? (
+                            <span className="truncate text-danger">{rowError[r.path]}</span>
+                          ) : (
+                            <span className="truncate">
+                              {rowPhase[r.path] === "ready"
+                                ? "ready"
+                                : rowPhase[r.path] === "creating"
+                                  ? "creating…"
+                                  : "queued"}
+                            </span>
+                          )
+                        }
+                        trailing={
+                          rowPhase[r.path] === "error" ? (
+                            <Button tone="default" onClick={() => void retryRow(r)}>
+                              Retry
+                            </Button>
+                          ) : undefined
+                        }
+                      />
+                    ) : (
+                      <ListRow
+                        key={r.path}
+                        leading={
+                          <Checkbox
+                            checked={checked.has(r.path)}
+                            onChange={(v) => toggleRow(r.path, v)}
+                            ariaLabel={`Set up ${r.name}`}
+                          />
+                        }
+                        name={<span className="truncate">{r.name}</span>}
+                        secondary={<span className="truncate">{describeRepoRow(r)}</span>}
+                        trailing={
+                          <span>
+                            {r.lastCommitAt ? formatAge(Date.now() - r.lastCommitAt) : "—"}
+                          </span>
+                        }
+                        onClick={() => toggleRow(r.path, !checked.has(r.path))}
+                        title={r.originUrl ? undefined : r.path}
+                      />
+                    ),
+                  )}
+                </div>
+
+                <div className="flex items-center flex-wrap gap-2 mt-3">
+                  {batchDone && !sending && hasFailed ? (
+                    <Button tone="primary" onClick={() => void finishSetup()}>
+                      Done
+                    </Button>
+                  ) : batchDone ? (
+                    <span className="text-meta text-text-faint">Setting up workspaces…</span>
+                  ) : (
+                    <>
+                      <Button
+                        tone="primary"
+                        onClick={() => void setupWorkspaces()}
+                        disabled={checked.size === 0}
+                      >
+                        Set up {checked.size} workspace{checked.size === 1 ? "" : "s"}
+                      </Button>
+                      <Button tone="default" onClick={() => setPickerOpen(true)}>
+                        Browse for a folder…
+                      </Button>
+                      <Button
+                        tone="default"
+                        disabled
+                        title="Cloning from GitHub isn't available yet"
+                        onClick={() => {}}
+                      >
+                        Clone from GitHub…
+                      </Button>
+                    </>
+                  )}
+                </div>
+              </>
+            )}
+        </>
+        )}
 
         {error && (
           <Card danger>
@@ -576,11 +996,13 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
           initialPath={draft.cwd || "~"}
           onSelect={(path) => {
             updateDraft(draftId, { cwd: path });
+            if (isNewProject) setBrowseChosen(true);
             setPickerOpen(false);
           }}
           onFanOut={(baseCwd, wts) => {
             setFanOutWorktrees(wts);
             updateDraft(draftId, { cwd: baseCwd });
+            if (isNewProject) setBrowseChosen(true);
             setPickerOpen(false);
           }}
           onCancel={() => setPickerOpen(false)}

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -885,7 +885,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
                   </div>
                 )}
 
-                <div className="space-y-0.5">
+                <div className="space-y-1">
                   {rows.map((r) =>
                     batchDone ? (
                       <ListRow

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -104,6 +104,19 @@ export function deriveProjectName(cwd: string): string {
   return parts[parts.length - 1] || "project";
 }
 
+// Numeric de-dup on top of deriveProjectName: returns the base name if free,
+// else the first free `base-2`, `base-3`, … against the `taken` set (the
+// existing project session names). THE one naming helper for a session name —
+// shared by every path that creates a project (the repo-probe batch, the
+// draft composer submit, and the worktree fan-out), so a twin never lands with
+// the same tmux session name. Exported for testing (pure).
+export function uniqueSessionName(base: string, taken: Set<string>): string {
+  if (!taken.has(base)) return base;
+  let i = 2;
+  while (taken.has(`${base}-${i}`)) i++;
+  return `${base}-${i}`;
+}
+
 // A readable, largely-unique window name derived from the first word of the
 // typed prompt (e.g. "Deploy the billing service" → "deploy"). This avoids the
 // old constant "worktree"/"session" that produced a sidebar full of identical
@@ -245,16 +258,6 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
       else next.delete(path);
       return next;
     });
-  };
-
-  // Numeric de-dup on top of deriveProjectName — the same scheme the fan-out
-  // submit already uses. Extracted so the new zero-state batch and the fan-out
-  // share one naming rule.
-  const uniqueSessionName = (base: string, taken: Set<string>) => {
-    if (!taken.has(base)) return base;
-    let i = 2;
-    while (taken.has(`${base}-${i}`)) i++;
-    return `${base}-${i}`;
   };
 
   // Land on the given created session: setActive + box-side select-window +
@@ -491,14 +494,10 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
       const dir = worktreePath ?? draft.cwd;
       const newProject = isNewProject;
       const sessionName = newProject
-        ? (() => {
-            const base = deriveProjectName(draft.cwd);
-            const taken = new Set(existingProjects.map((p) => p.tmuxSession));
-            if (!taken.has(base)) return base;
-            let i = 2;
-            while (taken.has(`${base}-${i}`)) i++;
-            return `${base}-${i}`;
-          })()
+        ? uniqueSessionName(
+            deriveProjectName(draft.cwd),
+            new Set(existingProjects.map((p) => p.tmuxSession)),
+          )
         : projectName!;
 
       const created = newProject
@@ -561,14 +560,10 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
     setSending(true);
     setError(null);
     try {
-      const sessionName = (() => {
-        const base = deriveProjectName(baseCwd);
-        const taken = new Set(existingProjects.map((p) => p.tmuxSession));
-        if (!taken.has(base)) return base;
-        let i = 2;
-        while (taken.has(`${base}-${i}`)) i++;
-        return `${base}-${i}`;
-      })();
+      const sessionName = uniqueSessionName(
+        deriveProjectName(baseCwd),
+        new Set(existingProjects.map((p) => p.tmuxSession)),
+      );
 
       const [first, ...rest] = wts;
       const created = await window.api.tmuxNewSession({

--- a/src/renderer/Skeleton.tsx
+++ b/src/renderer/Skeleton.tsx
@@ -1,0 +1,18 @@
+// Skeleton — the shared loading-bar primitive (BET-787 [S1]).
+//
+// The mockup's `.sk` (manta-forge §8.2): a `rounded-full bg-fill-active` bar
+// whose only variation is its width. Uneven widths are the whole point — a
+// loading gif of three identical bars reads as a spinner; uneven ones read as
+// content. Callers pass an explicit `width` (percent) and compose their own
+// spacing, so a row of skeletons looks like real rows rather than a loading
+// indicator.
+
+export function Skeleton({ width }: { width: number }) {
+  return (
+    <span
+      aria-hidden="true"
+      className="block h-[9px] rounded-full bg-fill-active"
+      style={{ width: `${width}%` }}
+    />
+  );
+}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -92,7 +92,11 @@ import {
   usageStale,
   pruneVisitedSessions,
   selectStatusItems,
+  zeroStateMode,
+  initialRepoSelection,
+  describeRepoRow,
   type StatusItem,
+  type RepoRow,
 } from "./chatUtils";
 
 import type { OpencodeModel, UsageSnapshot } from "../shared/types";
@@ -3528,5 +3532,91 @@ describe("arrangeCards", () => {
     expect(r.blockingMore).toBe(0);
     expect(r.ambient.length).toBe(2);
     expect(r.ambientRollup.length).toBe(2);
+
+// ===== BET-787: repo-probe zero state =====
+
+function repoRow(over: Partial<RepoRow>): RepoRow {
+  return {
+    path: "/home/u/proj",
+    name: "proj",
+    branch: "main",
+    originUrl: "https://github.com/owner/proj.git",
+    forge: "github",
+    repoKey: "owner/proj",
+    lastCommitAt: 0,
+    local: true,
+    ...over,
+  };
+}
+
+describe("zeroStateMode", () => {
+  it("returns scanning while the probe is pending, whatever the repos", () => {
+    expect(zeroStateMode({ probePending: true, probeFailed: false, repos: [] })).toBe("scanning");
+    expect(
+      zeroStateMode({ probePending: true, probeFailed: false, repos: [repoRow({})] }),
+    ).toBe("scanning");
+  });
+
+  it("returns degraded when the probe failed", () => {
+    expect(zeroStateMode({ probePending: false, probeFailed: true, repos: [] })).toBe("degraded");
+    expect(
+      zeroStateMode({ probePending: false, probeFailed: true, repos: [repoRow({})] }),
+    ).toBe("degraded");
+  });
+
+  it("returns list when the probe succeeded with repos", () => {
+    expect(
+      zeroStateMode({ probePending: false, probeFailed: false, repos: [repoRow({})] }),
+    ).toBe("list");
+  });
+
+  it("returns fresh (not degraded) when the probe succeeded with zero repos", () => {
+    expect(zeroStateMode({ probePending: false, probeFailed: false, repos: [] })).toBe("fresh");
+  });
+});
+
+describe("initialRepoSelection", () => {
+  it("checks every local row when they fit under the cap", () => {
+    const repos = [
+      repoRow({ path: "/a", lastCommitAt: 3 }),
+      repoRow({ path: "/b", lastCommitAt: 2 }),
+      repoRow({ path: "/c", lastCommitAt: 1 }),
+    ];
+    const sel = initialRepoSelection(repos, 8);
+    expect(sel.map((r) => r.path)).toEqual(["/a", "/b", "/c"]);
+  });
+
+  it("caps the checked set at the cap, most-recent first (12 repos -> 8)", () => {
+    const repos = Array.from({ length: 12 }, (_, i) =>
+      repoRow({ path: `/r${i}`, lastCommitAt: 12 - i }),
+    );
+    const sel = initialRepoSelection(repos, 8);
+    expect(sel).toHaveLength(8);
+    expect(sel[0].path).toBe("/r0");
+    expect(sel[1].path).toBe("/r1");
+    expect(sel[7].path).toBe("/r7");
+  });
+
+  it("never pre-checks a non-local row, even a recent one", () => {
+    const repos = [
+      repoRow({ path: "/local-repo", lastCommitAt: 2 }),
+      repoRow({ path: "/clone-repo", lastCommitAt: 99, local: false }),
+    ];
+    const sel = initialRepoSelection(repos, 8);
+    expect(sel.map((r) => r.path)).toEqual(["/local-repo"]);
+  });
+});
+
+describe("describeRepoRow", () => {
+  it("shows only the branch when the repo has an origin", () => {
+    expect(describeRepoRow(repoRow({ branch: "feat/forge-seam" }))).toBe("⎇ feat/forge-seam");
+  });
+
+  it("shows branch + path + no remote without an origin", () => {
+    expect(
+      describeRepoRow(
+        repoRow({ branch: "main", originUrl: null, path: "/home/u/scratch", repoKey: null, forge: null }),
+      ),
+    ).toBe("⎇ main · /home/u/scratch · no remote");
   });
 });

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3532,6 +3532,8 @@ describe("arrangeCards", () => {
     expect(r.blockingMore).toBe(0);
     expect(r.ambient.length).toBe(2);
     expect(r.ambientRollup.length).toBe(2);
+  });
+});
 
 // ===== BET-787: repo-probe zero state =====
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { DelegateApprovalTool, OpencodeMessage, OpencodeModel, PermissionRequest, Project, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { DelegateApprovalTool, OpencodeMessage, OpencodeModel, PermissionRequest, Project, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 // Value import — `isClientTooOld` is the pure semver compare that drives
 // the renderer-side version-skew banner (BET-225 stage 3). Lives in
@@ -2673,5 +2673,54 @@ export function arrangeCards<T extends PinnedCard>(cards: T[]): PinnedCardStack<
     ambient: ambient.slice(0, MAX_AMBIENT_EXPANDED),
     ambientRollup: ambient.slice(MAX_AMBIENT_EXPANDED),
   };
+}
 
+// ===== BET-787: repo-probe zero state =====
+
+// A probe result row augmented with `local` — true when the repo already
+// exists on disk and can therefore be pre-checked without a clone. Clone rows,
+// added by a later forge issue, land here with `local: false` and must never be
+// pre-checked. The pre-check rule is a property of the row's data, not a
+// "default all true", so the clone rows arrive unchecked without a rewrite.
+export type RepoRow = RepoHit & { local: boolean };
+
+// The zero-state mode for the new-project screen, derived from the probe
+// lifecycle. The one rule to get exactly right: "probe succeeded but returned
+// zero repos" is `"fresh"`, never `"degraded"` — a successful scan with nothing
+// found is real information (an empty box invites a clone), a failed scan is a
+// different, worse-off state that degrades to the folder picker.
+export function zeroStateMode(input: {
+  probePending: boolean;
+  probeFailed: boolean;
+  repos: RepoHit[];
+}): "scanning" | "list" | "fresh" | "degraded" {
+  if (input.probePending) return "scanning";
+  if (input.probeFailed) return "degraded";
+  return input.repos.length > 0 ? "list" : "fresh";
+}
+
+// The pre-checked set of repos, capped at `cap`. Rows are considered
+// most-recent-first and only *local* rows can be pre-checked (anything that
+// would require a clone must land unchecked). The cap stops a box with many
+// repos from silently creating that many tmux sessions.
+export function initialRepoSelection(repos: RepoRow[], cap: number): RepoRow[] {
+  const sorted = [...repos].sort(
+    (a, b) => (b.lastCommitAt ?? 0) - (a.lastCommitAt ?? 0),
+  );
+  const selected: RepoRow[] = [];
+  for (const repo of sorted) {
+    if (!repo.local) continue;
+    if (selected.length >= cap) break;
+    selected.push(repo);
+  }
+  return selected;
+}
+
+// The secondary line under a repo row. With an origin, the branch alone
+// identifies the row; without one the bare basename does not, so the path and
+// "no remote" are added so the user can tell the row apart.
+export function describeRepoRow(repo: RepoHit): string {
+  const branch = repo.branch ? `⎇ ${repo.branch}` : "no branch";
+  if (!repo.originUrl) return `${branch} · ${repo.path} · no remote`;
+  return branch;
 }


### PR DESCRIPTION
## BET-787 — Zero state: workspace list from the repo probe

Replaces the bare-folder-chip new-project zero state with the repo-probe workspace list, per manta-forge §7.3/§7.4/§7.5 and mockups [S1]–[S4], [E1], [S8]. Consumes the `forge:probe` channel delivered by BET-786 (merged to main).

### What changed

- **`src/renderer/NewSessionScreen.tsx`** — the new-project zero state is now probe-driven:
  - **[S1] scanning** — skeleton rows (uneven widths), `Browse for a folder…` live from the first frame. Never an empty state while scanning.
  - **[S2]/[S3] repos found** — heading + "Found N repositories on your box.", one `ListRow` per repo (checkbox · name · branch+remote · age), pre-checked most-recent-first capped at 8. "Set up N workspaces" primary. All rows identical whether or not GitHub is connected (§7.3 — no check status). [S3] adds the mandatory "GitHub connected as @login" line (with a quiet inert "use a different account" link) when `cli.authenticated`.
  - **[S4] fresh box** — "Let's get some code on this box", Clone (primary, inert/disabled with a title) + Browse (ghost) as peers.
  - **[E1] probe failed** — degrades to "Couldn't scan for repositories. Point Manta at a folder instead." with Browse as the single primary action — exactly today's behaviour, no error code, no retry button.
  - **[S8] creating** — per-row progress (`queued` / `creating…` / `ready` / error), one `tmuxNewSession` per checked repo in order. Partial failure surfaces with a per-row **Retry** and a `Done` action, never aborts the batch. On all-success it lands in the most recently touched success (`setActive` + `tmuxSelectWindow` + `dismissDraft`) with the composer empty — **no prompt is auto-submitted**.
  - The `Browse for a folder…` escape, and a picker worktree fan-out, land back on today's full composer (so the Browse path keeps working end to end); the new-session-in-an-existing-project variant is untouched.
- **`src/renderer/ListRow.tsx`** (new) + **`src/renderer/Skeleton.tsx`** (new) — the two shared primitives this issue was slated to build (docs/components.md decision 2): `ListRow` (`leading · name · secondary · trailing meta`, `rounded-md`, `hover:bg-fill-hover`) and `Skeleton` (uneven-width skeleton bars).
- **`src/renderer/chatUtils.ts`** — pure, tested helpers: `zeroStateMode`, `initialRepoSelection`, `describeRepoRow`, plus the `RepoRow = RepoHit & { local }` type carrying the pre-check rule as row data (clone rows land `local:false` unchecked without a rewrite).
- **`src/renderer/chatUtils.test.ts`**, **`src/renderer/NewSessionScreen.harness.test.tsx`** — new tests + updated harness to the new zero-state.

### What I removed

- The bare-folder-chip new-project zero state as the default. It survives solely as the post-Browse composer (degrade path) and for new-session mode — not rendered alongside the list behind a condition.

### Judgment calls (design-fidelity notes)

- **Browse is present in [S2]/[S3]** even though the [S3] mockup omits it — [S1]/[S2] carry it and it's the universal escape ([S1]: "The Browse escape is live from the first frame"); the S3 omission reads as a miniature simplification, not a removal. Kept consistent across list states.
- **"Set up N workspaces" pluralizes** to `workspace` for 1, to avoid the grammatically broken "1 workspaces".
- **"Clone from GitHub…"** is rendered disabled with a `title` explaining it (an explicit allowed option) — never half-wired.
- **[S9] landed-state suggestion chips** ("Explain this codebase" / "What's the test setup?") were **not added**: they live in the real ChatPanel composer, a separate concern from this zero-state screen, and the issue marks them optional ("fine and desirable"). This screen satisfies the non-negotiable part of [S9] — land with the composer empty, no auto-submit.

### Files & verification

**Files changed:** 6. `src/renderer/{NewSessionScreen.tsx, chatUtils.ts, chatUtils.test.ts, NewSessionScreen.harness.test.tsx}` + new `ListRow.tsx`, `Skeleton.tsx`.

**Verification results:**
- PR branch (`multica/BET-787-zero-state-repo-probe` @ `774195bb`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 2484 pass (vitest, includes BET-783/787 additions) / 1705 pass (server, node:test). Failures: none. log sha256: `0633db704fd11d986fe7de7194e3b521001d663a3be7a1c6044a748fe7aaf7c5`
- **Base: `origin/main @ 95cc2975`** (rebased onto latest main — includes BET-783/811 which landed after the branch was cut).

**Conclusion:** 0 failures. This is an additive/renderer-only change; the only shared files main also touched after cut (`chatUtils.ts`, `chatUtils.test.ts`) were rebased cleanly (arrangeCards + BET-787 blocks both preserved).
