### PR TITLE
BET-805: fix(renderer): wait for virtualised row before flashing on jump

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -26,6 +26,7 @@ import type {
 } from "../shared/types";
 import { useStore } from "./store";
 import type { PendingScreenshot } from "./store";
+import { flashMessageRow } from "./messageFlash";
 import {
   allTodosTerminal,
   selectActiveTodos,
@@ -291,6 +292,11 @@ export function ChatPanel({
   // scroll inline: the optimistic row it just queued is not committed yet, so
   // `index: "LAST"` would resolve to the PREVIOUS last message.
   const forceTailRef = useRef(false);
+  // Canceller for the in-flight message-flash wait (BET-805). Held across
+  // `flashMessageRow` calls so a pending wait from a previous jump can be
+  // cancelled before starting a new one, and cleared in the session-change
+  // cleanup so a wait can't fire against a transcript the user has left.
+  const messageFlashCancelRef = useRef<(() => void) | null>(null);
   const onAtBottomChange = useCallback((atBottom: boolean) => {
     atBottomRef.current = atBottom;
   }, []);
@@ -487,6 +493,12 @@ export function ChatPanel({
     // away and back would re-run the reset and wipe staged attachments, @agent
     // mentions and the /help notice out of the composer. The poll lives in its
     // own visibility-gated effect below.
+    return () => {
+      // Cancel a pending message-flash wait on session change/unmount so it
+      // can't fire against a transcript the user has since left.
+      messageFlashCancelRef.current?.();
+      messageFlashCancelRef.current = null;
+    };
   }, [sessionId, cwd]);
 
   // Branch indicator: poll every 5s while this session is visible. Gated on
@@ -547,18 +559,16 @@ export function ChatPanel({
   // callers can retry later (e.g. the ⌘F cross-conversation jump, where the
   // window has just been activated and its transcript is still streaming in).
   // scrollToMessage scrolls via Virtuoso's scrollToIndex; the target row may
-  // not be in the DOM until Virtuoso renders it, so we flash once it exists
-  // (a frame or two later for the smooth scroll).
+  // not be in the DOM until Virtuoso renders it, so flashMessageRow polls for
+  // it (a frame or two later for the smooth scroll) instead of flashing on a
+  // single immediate lookup.
   const scrollFlashMessage = useCallback(
     (messageId: string): boolean => {
       scrollToMessage(messageId);
-      requestAnimationFrame(() => {
-        const el = document.querySelector<HTMLElement>(
-          `[data-message-id="${messageId}"]`,
-        );
-        el?.classList.add("manta-message-flash");
-        window.setTimeout(() => el?.classList.remove("manta-message-flash"), 1200);
-      });
+      // Cancel any pending wait from a previous jump so it can't flash against
+      // a row the user has already scrolled past or a transcript they've left.
+      messageFlashCancelRef.current?.();
+      messageFlashCancelRef.current = flashMessageRow(messageId);
       return (messagesRef.current ?? []).some((m) => m.info.id === messageId);
     },
     [scrollToMessage],

--- a/src/renderer/messageFlash.test.ts
+++ b/src/renderer/messageFlash.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import {
+  FLASH_MS,
+  FLASH_POLL_MS,
+  FLASH_WAIT_MS,
+  flashMessageRow,
+} from "./messageFlash";
+
+const CLASS = "manta-message-flash";
+
+function row(messageId: string): HTMLDivElement {
+  const el = document.createElement("div");
+  el.setAttribute("data-message-id", messageId);
+  return el;
+}
+
+describe("flashMessageRow", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+  });
+
+  it("flashes synchronously when the row is already in the DOM", () => {
+    const el = row("m1");
+    document.body.appendChild(el);
+    flashMessageRow("m1");
+    expect(el.classList.contains(CLASS)).toBe(true);
+  });
+
+  it("flashes a LATE-appearing row once it is mounted", () => {
+    flashMessageRow("m1");
+    expect(document.querySelector(`[data-message-id="m1"]`)).toBeNull();
+    const el = row("m1");
+    document.body.appendChild(el);
+    vi.advanceTimersByTime(FLASH_POLL_MS);
+    expect(el.classList.contains(CLASS)).toBe(true);
+  });
+
+  it("removes the class FLASH_MS after it was applied (not after the call)", () => {
+    const el = row("m1");
+    document.body.appendChild(el);
+    flashMessageRow("m1");
+    expect(el.classList.contains(CLASS)).toBe(true);
+    vi.advanceTimersByTime(FLASH_MS - 1);
+    expect(el.classList.contains(CLASS)).toBe(true);
+    vi.advanceTimersByTime(1);
+    expect(el.classList.contains(CLASS)).toBe(false);
+  });
+
+  it("gives up after FLASH_WAIT_MS when the row never appears, leaving no timers", () => {
+    flashMessageRow("m1");
+    expect(document.querySelector(`[data-message-id="m1"]`)).toBeNull();
+    vi.advanceTimersByTime(FLASH_WAIT_MS);
+    expect(vi.getTimerCount()).toBe(0);
+    expect(document.querySelector(`[data-message-id="m1"]`)).toBeNull();
+  });
+
+  it("cancelling stops a pending wait (a late row is never flashed)", () => {
+    const cancel = flashMessageRow("m1");
+    cancel();
+    document.body.appendChild(row("m1"));
+    vi.advanceTimersByTime(FLASH_WAIT_MS);
+    const el = document.querySelector<HTMLElement>(`[data-message-id="m1"]`);
+    expect(el).not.toBeNull();
+    expect(el!.classList.contains(CLASS)).toBe(false);
+  });
+
+  it("cancelling removes an already-applied class", () => {
+    const el = row("m1");
+    document.body.appendChild(el);
+    const cancel = flashMessageRow("m1");
+    expect(el.classList.contains(CLASS)).toBe(true);
+    cancel();
+    expect(el.classList.contains(CLASS)).toBe(false);
+  });
+});

--- a/src/renderer/messageFlash.ts
+++ b/src/renderer/messageFlash.ts
@@ -1,0 +1,64 @@
+export const FLASH_MS = 1200;
+export const FLASH_WAIT_MS = 2000;
+export const FLASH_POLL_MS = 50;
+
+/**
+ * Flash the transcript row for `messageId` once it exists in the DOM.
+ *
+ * The transcript is virtualised and scrolled smoothly, so the target row is
+ * typically NOT mounted when the jump is requested — it appears some frames
+ * later as the scroll arrives. We therefore poll for it (immediately, then
+ * every FLASH_POLL_MS) and give up after FLASH_WAIT_MS so a messageId that
+ * never renders cannot leave a timer running forever.
+ *
+ * Returns a cancel function; calling it stops any pending wait and removes the
+ * class if it was already applied. Calling flashMessageRow again for a
+ * different row does NOT cancel a previous one — callers that need that must
+ * hold the returned canceller (ChatPanel does).
+ */
+export function flashMessageRow(
+  messageId: string,
+  root: ParentNode = document,
+): () => void {
+  let cancelled = false;
+  let removeTimer: number | null = null;
+  let pollTimer: number | null = null;
+  const deadline = Date.now() + FLASH_WAIT_MS;
+  // Escape with CSS.escape where available (Chromium); jsdom ships no CSS.escape,
+  // so fall back to the raw id there. Message ids are opaque strings from
+  // opencode; today they are selector-safe either way.
+  const escapedId =
+    typeof CSS !== "undefined" && typeof CSS.escape === "function"
+      ? CSS.escape(messageId)
+      : messageId;
+  const selector = `[data-message-id="${escapedId}"]`;
+
+  const applyFlash = (el: Element) => {
+    el.classList.add("manta-message-flash");
+    removeTimer = window.setTimeout(() => {
+      el.classList.remove("manta-message-flash");
+      removeTimer = null;
+    }, FLASH_MS);
+  };
+
+  const check = () => {
+    pollTimer = null;
+    if (cancelled) return;
+    const el = root.querySelector(selector);
+    if (el) {
+      applyFlash(el);
+      return;
+    }
+    if (Date.now() >= deadline) return;
+    pollTimer = window.setTimeout(check, FLASH_POLL_MS);
+  };
+
+  check();
+
+  return () => {
+    cancelled = true;
+    if (pollTimer !== null) clearTimeout(pollTimer);
+    if (removeTimer !== null) clearTimeout(removeTimer);
+    root.querySelector(selector)?.classList.remove("manta-message-flash");
+  };
+}


### PR DESCRIPTION
## Summary

BET-805. The jump-to-result flash (added in BET-660 for the artifacts panel) rarely fired on the ⌘F search path because `scrollFlashMessage` looked the target row up **one animation frame** after requesting a smooth scroll — but the transcript is virtualised (Virtuoso) and the target row isn't mounted until the scroll arrives, so `querySelector` returned `null` and the `?.` silently swallowed the flash.

The fix moves the flash into a testable module that **waits for the row to exist** rather than attempting a single immediate lookup.

**`src/renderer/messageFlash.ts`** (new): `flashMessageRow(messageId, root = document)` polls for the row every `FLASH_POLL_MS` (50 ms), flashes it once found, removes the class after `FLASH_MS` (1200), and gives up after `FLASH_WAIT_MS` (2000) so a never-rendering id can't leave a timer running. Returns a canceller: it stops a pending wait and removes an already-applied class. Polling uses `window.setTimeout` (deterministic under fake timers) rather than `requestAnimationFrame`. Ids are escaped with `CSS.escape` where available.

**`src/renderer/ChatPanel.tsx`**: `scrollFlashMessage` now just scrolls, cancels any prior in-flight wait, and calls `flashMessageRow`, holding the returned canceller in a ref. The ref is cleared in the existing session-change/unmount cleanup so a pending wait can't fire against a transcript the user has left. The inline `requestAnimationFrame` block and the inline `1200` literal are gone from the jump path; the return value (whether the message is in the loaded transcript) is unchanged, so the cross-conversation jump effect still works.

**`src/renderer/messageFlash.test.ts`** (new): 6 jsdom tests driven with `vi.useFakeTimers()` covering synchronous flash, the late-appearing-row regression, FLASH_MS-after-application removal, give-up-after-FLASH_WAIT_MS with zero pending timers, cancelling a pending wait, and cancelling an already-applied class.

### Cross-cutting
ArtifactsPanel.tsx shares `scrollFlashMessage` and is repaired by this change with no edits — confirmed in the issue as out of scope. SearchPalette / the `manta-scroll-to-message` event shape are untouched (a separate ticket adds a `query` field). CSS class, colour and 1.2 s duration are unchanged per the non-goals.

**Base: origin/main @ 95cc297**

## Verification results

**Files changed:** `3` files. `src/renderer/ChatPanel.tsx`, `src/renderer/messageFlash.ts` (new), `src/renderer/messageFlash.test.ts` (new).

- PR branch (`multica/BET-805-message-flash` @ `029c220`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0. vitest 2481 pass / 7 skip / 0 fail; node:test 1475 pass / 0 fail. log sha256: `0a015628fa3853bdefe5f25c788adfd4d8ab133b9a04a951069913fc2532cbad`
- Base (`main @ 95cc297`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0. vitest 2475 pass / 7 skip / 0 fail; node:test 1475 pass / 0 fail. log sha256: `60fc652ba3f940394b34f4beb181ab9fad66963d5182c5ea05f47117192092ae`
- **Conclusion:** 0 new failures; 6 new passing tests (the new messageFlash suite). The regression test ("flashes a LATE-appearing row") goes red when `flashMessageRow` is reduced to a single immediate lookup, verified.
