### PR TITLE
fix(server): parse modern gh auth status login (BET-818)

### DIFF
--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -473,7 +473,10 @@ export function sortRepoHits(hits) {
 // that looks like a token (never return a secret). Pure.
 export function parseGhAuthStatus(text) {
   if (typeof text !== "string") return null;
-  const m = /as ([^()\n]+?)\s*\(/.exec(text);
+  // Legacy gh: "Logged in to github.com as octocat (…)". Modern gh no longer
+  // emits the "as …" phrasing — it prints "account octocat (…)" instead
+  // ("Logged in to github.com account octocat"). Accept both forms.
+  const m = /(?:as |account )([^()\n]+?)\s*\(/.exec(text);
   if (!m) return null;
   const login = m[1].trim();
   if (!login) return null;

--- a/src/server/local.test.mjs
+++ b/src/server/local.test.mjs
@@ -164,6 +164,19 @@ test("parseGhAuthStatus: extracts the login from `gh auth status` output", () =>
   );
 });
 
+test("parseGhAuthStatus: modern gh `account <login> (` form is accepted", () => {
+  assert.equal(
+    parseGhAuthStatus("github.com\n  ✓ Logged in to github.com account octocat (oauth)\n  ✓ Active account: true\n"),
+    "octocat",
+  );
+});
+
+test("parseGhAuthStatus: modern token-like account value is still rejected", () => {
+  const ghoPrefix = "gh" + "o_";
+  const shortToken = ghoPrefix + "AbC12xYz89QwEr00";
+  assert.equal(parseGhAuthStatus(`github.com\n  ✓ Logged in to github.com account ${shortToken} (oauth)\n`), null);
+});
+
 test("parseGhAuthStatus: multi-host output returns the logged-in account", () => {
   assert.equal(
     parseGhAuthStatus(


### PR DESCRIPTION
## What

Fixes `parseGhAuthStatus` so `forge:status` reports the correct `login` on modern `gh` (BET-788 criterion 1).

Modern `gh auth status` no longer emits the legacy `as octocat (` phrasing — it prints `account octocat (`. The BET-786 parser only matched the legacy form, so `parseGhAuthStatus` returned null and `forge:status` showed `connected: true` but `login: null`.

## Change

- `src/server/local.mjs`: extended the extraction regex to accept both forms — `(?:as |account )([^()\n]+?)\s*\(`. Kept the existing guards (token-like capture rejected via `isTokenLike`).
- `src/server/local.test.mjs`: added cases pinning the legacy `as X (`, the modern `account X (`, and that a token-like modern capture is still rejected.

Root cause fixed in the single canonical parser (BET-786's merged `local.mjs`, the one BET-788 consumes) — no second copy introduced.

## Verification results

**Files changed:** `2` files. `src/server/local.mjs`, `src/server/local.test.mjs` (17 insertions, 1 deletion).

**Verification results:**
- PR branch (`multica/BET-818-gh-auth-status-login` @ `4ddae76f`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1707 pass / 0 fail / 0 skip. Failures: none. log sha256: `84e25724ec99a32327bf4140748b4d09549db7f08c337f7f9372d5c49b5400ca`
- Base (`main` @ `06fec0ce`):
  - typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
  - test: exit 0, 1705 pass / 0 fail / 0 skip. Failures: none. log sha256: `2847866e7d3a175c1864c1c430ac480e616f5dc4d3313600de27a64dcd86d432`
- **Conclusion:** 0 test failures are new and caused by this PR. 2 tests were added (both pass); 1705 pre-existing tests pass identically on both branches.

**Base: origin/main @ `06fec0ce`**
