### PR TITLE
feat(renderer): highlight matched ⌘F query text in the jumped-to message (BET-806)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -563,12 +563,12 @@ export function ChatPanel({
   // it (a frame or two later for the smooth scroll) instead of flashing on a
   // single immediate lookup.
   const scrollFlashMessage = useCallback(
-    (messageId: string): boolean => {
+    (messageId: string, query?: string): boolean => {
       scrollToMessage(messageId);
       // Cancel any pending wait from a previous jump so it can't flash against
       // a row the user has already scrolled past or a transcript they've left.
       messageFlashCancelRef.current?.();
-      messageFlashCancelRef.current = flashMessageRow(messageId);
+      messageFlashCancelRef.current = flashMessageRow(messageId, document, query);
       return (messagesRef.current ?? []).some((m) => m.info.id === messageId);
     },
     [scrollToMessage],
@@ -579,10 +579,10 @@ export function ChatPanel({
   useEffect(() => {
     const onScrollToMessage = (e: Event) => {
       const detail = (e as CustomEvent).detail as
-        | { sessionId?: string; messageId?: string }
+        | { sessionId?: string; messageId?: string; query?: string }
         | undefined;
       if (detail?.sessionId !== sessionId || !detail?.messageId) return;
-      scrollFlashMessage(detail.messageId);
+      scrollFlashMessage(detail.messageId, detail.query);
     };
     window.addEventListener("manta-scroll-to-message", onScrollToMessage);
     return () => window.removeEventListener("manta-scroll-to-message", onScrollToMessage);
@@ -597,7 +597,7 @@ export function ChatPanel({
     const w = window as PendingScrollWin;
     const pending = w.__mantaPendingMessageScroll;
     if (!pending || pending.sessionId !== sessionId || messages == null) return;
-    if (scrollFlashMessage(pending.messageId)) {
+    if (scrollFlashMessage(pending.messageId, pending.query)) {
       w.__mantaPendingMessageScroll = null;
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/src/renderer/SearchPalette.tsx
+++ b/src/renderer/SearchPalette.tsx
@@ -140,7 +140,7 @@ export function SearchPalette({
     if (row.sessionId === sessionId) {
       window.dispatchEvent(
         new CustomEvent("manta-scroll-to-message", {
-          detail: { sessionId, messageId: row.hit.messageId },
+          detail: { sessionId, messageId: row.hit.messageId, query: q },
         }),
       );
       return;
@@ -150,6 +150,7 @@ export function SearchPalette({
     (window as PendingScrollWin).__mantaPendingMessageScroll = {
       sessionId: row.sessionId,
       messageId: row.hit.messageId,
+      query: q,
     };
     onJumpToWindow(owner.tmuxSession, owner.windowIndex);
   };

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -95,6 +95,7 @@ import {
   zeroStateMode,
   initialRepoSelection,
   describeRepoRow,
+  planHighlightRanges,
   type StatusItem,
   type RepoRow,
 } from "./chatUtils";
@@ -3620,5 +3621,52 @@ describe("describeRepoRow", () => {
         repoRow({ branch: "main", originUrl: null, path: "/home/u/scratch", repoKey: null, forge: null }),
       ),
     ).toBe("⎇ main · /home/u/scratch · no remote");
+  });
+});
+
+describe("planHighlightRanges", () => {
+  it("returns one range for a single match inside one text node", () => {
+    expect(planHighlightRanges([15], "the quick brown fox", "brown")).toEqual([
+      { startNode: 0, startOffset: 10, endNode: 0, endOffset: 15 },
+    ]);
+  });
+
+  it("returns ONE range spanning two text nodes when a match straddles them", () => {
+    const lengths = [6, 6]; // "Hello " + "worldX"
+    const text = "Hello worldX";
+    expect(planHighlightRanges(lengths, text, " world")).toEqual([
+      { startNode: 0, startOffset: 5, endNode: 1, endOffset: 5 },
+    ]);
+  });
+
+  it("is case-insensitive", () => {
+    expect(planHighlightRanges([3], "foo", "Foo")).toEqual([
+      { startNode: 0, startOffset: 0, endNode: 0, endOffset: 3 },
+    ]);
+  });
+
+  it("returns one range per non-overlapping match, in document order", () => {
+    expect(planHighlightRanges([13], "cat dog cat", "cat")).toEqual([
+      { startNode: 0, startOffset: 0, endNode: 0, endOffset: 3 },
+      { startNode: 0, startOffset: 8, endNode: 0, endOffset: 11 },
+    ]);
+  });
+
+  it("resumes after each match so 'aa' in 'aaaa' yields 2 ranges, not 3", () => {
+    expect(planHighlightRanges([4], "aaaa", "aa")).toEqual([
+      { startNode: 0, startOffset: 0, endNode: 0, endOffset: 2 },
+      { startNode: 0, startOffset: 2, endNode: 0, endOffset: 4 },
+    ]);
+    expect(planHighlightRanges([4], "aaaa", "aa")).toHaveLength(2);
+  });
+
+  it("returns [] for an empty query, a whitespace-only query, or no match", () => {
+    expect(planHighlightRanges([5], "abcde", "")).toEqual([]);
+    expect(planHighlightRanges([5], "abcde", "   ")).toEqual([]);
+    expect(planHighlightRanges([5], "abcde", "zzz")).toEqual([]);
+  });
+
+  it("returns [] for an empty lengths array (a row with no text nodes)", () => {
+    expect(planHighlightRanges([], "", "cat")).toEqual([]);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2384,10 +2384,77 @@ export function computeLiveTurn(messages: OpencodeMessage[] | null): LiveTurn | 
 // Cross-file contract for the ⌘F cross-conversation jump: SearchPalette sets
 // this global, ChatPanel consumes it once the target session's transcript has
 // rendered. Same pre-mount-bridge pattern as __mantaScrollQuestionSession.
-export type PendingMessageScroll = { sessionId: string; messageId: string };
+// `query` is the trimmed search term; when present ChatPanel also highlights
+// the matched text in the destination row (BET-806). Absent ⇒ flash only, as
+// with the artifacts-panel jump.
+export type PendingMessageScroll = {
+  sessionId: string;
+  messageId: string;
+  query?: string;
+};
 export type PendingScrollWin = Window & {
   __mantaPendingMessageScroll?: PendingMessageScroll | null;
 };
+
+/**
+ * Plan case-insensitive highlight ranges for `query` across a row's text nodes.
+ *
+ * `lengths` is the character length of each text node, in document order. The
+ * function works on the CONCATENATION of those nodes, so a match that straddles
+ * a node boundary (e.g. bold in the middle of a sentence) still produces one
+ * range. Returns the ranges as node-index + offset pairs, which the DOM caller
+ * turns into `Range` objects.
+ *
+ * Returns [] for an empty query, a query of only whitespace, or no match.
+ * Matches do not overlap: scanning continues after the end of each match.
+ */
+export type HighlightRange = {
+  startNode: number;
+  startOffset: number;
+  endNode: number;
+  endOffset: number;
+};
+
+export function planHighlightRanges(
+  lengths: number[],
+  text: string,
+  query: string,
+): HighlightRange[] {
+  const q = query.toLowerCase();
+  if (q.length === 0 || q.trim().length === 0 || text.length === 0) return [];
+  const lower = text.toLowerCase();
+  const ranges: HighlightRange[] = [];
+  let searchFrom = 0;
+  while (true) {
+    const idx = lower.indexOf(q, searchFrom);
+    if (idx === -1) break;
+    const start = idx;
+    const end = idx + q.length;
+    ranges.push({
+      startNode: nodeForOffset(lengths, start),
+      startOffset: start - offsetAtNode(lengths, nodeForOffset(lengths, start)),
+      endNode: nodeForOffset(lengths, end),
+      endOffset: end - offsetAtNode(lengths, nodeForOffset(lengths, end)),
+    });
+    searchFrom = end;
+  }
+  return ranges;
+}
+
+function offsetAtNode(lengths: number[], node: number): number {
+  let sum = 0;
+  for (let i = 0; i < node; i++) sum += lengths[i];
+  return sum;
+}
+
+function nodeForOffset(lengths: number[], offset: number): number {
+  let sum = 0;
+  for (let i = 0; i < lengths.length; i++) {
+    sum += lengths[i];
+    if (offset < sum) return i;
+  }
+  return lengths.length > 0 ? lengths.length - 1 : 0;
+}
 
 // ===== Subscription plan usage (BET-738: composer dial + popover) =====
 //

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -172,6 +172,14 @@ html, body, #root {
   .manta-message-flash { animation: none; }
 }
 
+/* ⌘F jump: the matched query inside the destination message, painted via the
+   CSS Custom Highlight API so react-markdown's output is never mutated. Same
+   accent-on-accent pairing as the <mark> in the search palette's result rows. */
+::highlight(manta-search-hit) {
+  background-color: var(--accent-bg);
+  color: var(--accent-tx);
+}
+
 /* PaletteShell enter/exit (⌘K switcher, ⌘F search). 140ms in / 100ms out —
    the 100ms must match CLOSE_MS in PaletteShell.tsx. */
 .manta-palette-overlay { animation: manta-palette-fade-in 140ms ease-out; }

--- a/src/renderer/messageFlash.test.ts
+++ b/src/renderer/messageFlash.test.ts
@@ -5,6 +5,7 @@ import {
   FLASH_POLL_MS,
   FLASH_WAIT_MS,
   flashMessageRow,
+  highlightMatchesIn,
 } from "./messageFlash";
 
 const CLASS = "manta-message-flash";
@@ -76,6 +77,88 @@ describe("flashMessageRow", () => {
     document.body.appendChild(el);
     const cancel = flashMessageRow("m1");
     expect(el.classList.contains(CLASS)).toBe(true);
+    cancel();
+    expect(el.classList.contains(CLASS)).toBe(false);
+  });
+});
+
+describe("highlightMatchesIn / flashMessageRow with query", () => {
+  beforeEach(() => {
+    document.body.innerHTML = "";
+    vi.useFakeTimers();
+    (globalThis as { CSS?: unknown }).CSS = { highlights: new Map() };
+    class FakeHighlight {
+      ranges: Range[];
+      constructor(ranges: Range[] = []) {
+        this.ranges = ranges;
+      }
+    }
+    (globalThis as { Highlight?: unknown }).Highlight = FakeHighlight;
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    document.body.innerHTML = "";
+    delete (globalThis as { CSS?: unknown }).CSS;
+    delete (globalThis as { Highlight?: unknown }).Highlight;
+  });
+
+  function textRow(messageId: string, text: string): HTMLDivElement {
+    const el = document.createElement("div");
+    el.setAttribute("data-message-id", messageId);
+    el.textContent = text;
+    return el;
+  }
+
+  it("registers one highlight whose range count matches the number of matches", () => {
+    const el = textRow("m1", "cat and a cat");
+    document.body.appendChild(el);
+    const clear = highlightMatchesIn(el, "cat");
+    const registry = ((globalThis as { CSS?: { highlights: Map<string, unknown> } }).CSS!.highlights);
+    expect(registry.has("manta-search-hit")).toBe(true);
+    const hl = registry.get("manta-search-hit") as { ranges: Range[] };
+    expect(hl.ranges).toHaveLength(2);
+    clear();
+  });
+
+  it("the returned cleaner deletes the registry entry", () => {
+    const el = textRow("m1", "cat");
+    document.body.appendChild(el);
+    const registry = ((globalThis as { CSS?: { highlights: Map<string, unknown> } }).CSS!.highlights);
+    const clear = highlightMatchesIn(el, "cat");
+    expect(registry.has("manta-search-hit")).toBe(true);
+    clear();
+    expect(registry.has("manta-search-hit")).toBe(false);
+  });
+
+  it("returns a callable cleaner and does not throw when CSS.highlights is absent", () => {
+    delete (globalThis as { CSS?: { highlights?: unknown } }).CSS!.highlights;
+    const el = textRow("m1", "cat");
+    document.body.appendChild(el);
+    const clear = highlightMatchesIn(el, "cat");
+    expect(typeof clear).toBe("function");
+    expect(() => clear()).not.toThrow();
+  });
+
+  it("with a query, flashes AND highlights; the canceller clears both", () => {
+    const el = textRow("m1", "hello world");
+    document.body.appendChild(el);
+    const registry = ((globalThis as { CSS?: { highlights: Map<string, unknown> } }).CSS!.highlights);
+    const cancel = flashMessageRow("m1", document, "world");
+    expect(el.classList.contains(CLASS)).toBe(true);
+    expect(registry.has("manta-search-hit")).toBe(true);
+    cancel();
+    expect(el.classList.contains(CLASS)).toBe(false);
+    expect(registry.has("manta-search-hit")).toBe(false);
+  });
+
+  it("without a query, flashes and registers no highlight", () => {
+    const el = textRow("m1", "hello world");
+    document.body.appendChild(el);
+    const registry = ((globalThis as { CSS?: { highlights: Map<string, unknown> } }).CSS!.highlights);
+    const cancel = flashMessageRow("m1", document);
+    expect(el.classList.contains(CLASS)).toBe(true);
+    expect(registry.size).toBe(0);
     cancel();
     expect(el.classList.contains(CLASS)).toBe(false);
   });

--- a/src/renderer/messageFlash.ts
+++ b/src/renderer/messageFlash.ts
@@ -1,6 +1,50 @@
+import { planHighlightRanges } from "./chatUtils";
+
 export const FLASH_MS = 1200;
 export const FLASH_WAIT_MS = 2000;
 export const FLASH_POLL_MS = 50;
+
+export const SEARCH_HIGHLIGHT_NAME = "manta-search-hit";
+
+/**
+ * Paint `query` inside `el` using the CSS Custom Highlight API, and return a
+ * function that clears it. No-ops (returning a no-op cleaner) when the browser
+ * has no Custom Highlight API, or when there is nothing to match.
+ */
+export function highlightMatchesIn(el: Element, query: string): () => void {
+  const noop = () => {};
+  if (typeof CSS === "undefined" || !("highlights" in CSS)) return noop;
+  if (!query || query.trim().length === 0) return noop;
+  const walker = document.createTreeWalker(el, NodeFilter.SHOW_TEXT);
+  const nodes: Text[] = [];
+  const lengths: number[] = [];
+  let text = "";
+  let n: Node | null;
+  while ((n = walker.nextNode())) {
+    const t = n as Text;
+    nodes.push(t);
+    lengths.push(t.data.length);
+    text += t.data;
+  }
+  const planned = planHighlightRanges(lengths, text, query);
+  if (planned.length === 0) return noop;
+  const ranges = planned.map((r) => {
+    const range = document.createRange();
+    range.setStart(nodes[r.startNode], r.startOffset);
+    range.setEnd(nodes[r.endNode], r.endOffset);
+    return range;
+  });
+  // `Highlight` is non-standard-ish (Chromium). Match the runtime we feature-
+  // detect for: only register when the constructor is present too.
+  const Hl = (globalThis as { Highlight?: unknown }).Highlight as
+    | (new (ranges?: Range[]) => Highlight)
+    | undefined;
+  if (typeof Hl !== "function") return noop;
+  CSS.highlights.set(SEARCH_HIGHLIGHT_NAME, new Hl(ranges));
+  return () => {
+    CSS.highlights.delete(SEARCH_HIGHLIGHT_NAME);
+  };
+}
 
 /**
  * Flash the transcript row for `messageId` once it exists in the DOM.
@@ -19,10 +63,12 @@ export const FLASH_POLL_MS = 50;
 export function flashMessageRow(
   messageId: string,
   root: ParentNode = document,
+  query?: string,
 ): () => void {
   let cancelled = false;
   let removeTimer: number | null = null;
   let pollTimer: number | null = null;
+  let clearHighlight: (() => void) | null = null;
   const deadline = Date.now() + FLASH_WAIT_MS;
   // Escape with CSS.escape where available (Chromium); jsdom ships no CSS.escape,
   // so fall back to the raw id there. Message ids are opaque strings from
@@ -35,8 +81,11 @@ export function flashMessageRow(
 
   const applyFlash = (el: Element) => {
     el.classList.add("manta-message-flash");
+    if (query) clearHighlight = highlightMatchesIn(el, query);
     removeTimer = window.setTimeout(() => {
       el.classList.remove("manta-message-flash");
+      clearHighlight?.();
+      clearHighlight = null;
       removeTimer = null;
     }, FLASH_MS);
   };
@@ -60,5 +109,7 @@ export function flashMessageRow(
     if (pollTimer !== null) clearTimeout(pollTimer);
     if (removeTimer !== null) clearTimeout(removeTimer);
     root.querySelector(selector)?.classList.remove("manta-message-flash");
+    clearHighlight?.();
+    clearHighlight = null;
   };
 }


### PR DESCRIPTION
Implements BET-806: after a ⌘F jump, the destination message's matched query text is picked out in the same accent as the search palette, clearing with the row flash.

Base: origin/main @ 06fec0ce

## What changed
- `src/renderer/chatUtils.ts`: pure `planHighlightRanges` (+ `HighlightRange` type) — case-insensitive match ranges across a row's text nodes, computed on the node concatenation so a match straddling bold works; resumes after each match (no overlap). `PendingMessageScroll` gains optional `query`.
- `src/renderer/messageFlash.ts`: `highlightMatchesIn` paints via the CSS Custom Highlight API (`CSS.highlights` + `::highlight`), no DOM mutation; bails to no-op on missing API. `flashMessageRow` takes optional `query`; highlight shares the flash's lifetime/canceller.
- `src/renderer/index.css`: `::highlight(manta-search-hit)` using `var(--accent-bg)` / `var(--accent-tx)`.
- `src/renderer/ChatPanel.tsx` + `SearchPalette.tsx`: plumb optional `query` through the jump event and pending-scroll bridge. Artifacts-panel jump (no query) unchanged.

Explicit non-goals honored: no `<mark>`/DOM mutation, no `dangerouslySetInnerHTML`, no props threaded into `MessageRow`/transcript components, no find-next/counter UI, no server-side search changes.

## Verification results
- `npm run typecheck`: pass, no errors.
- `npm test`: 1705 pass / 0 fail / 0 skip (renderer vitest + server node:test).
- Feature-detection guard verified red-then-green: removing it fails exactly the no-API test, restoring passes (11/11 in messageFlash.test.ts).

## Acceptance criteria
- typecheck + tests: pass.
- No transcript-rendering component gained a prop: none touched.
- Test 10 (no CSS.highlights) fails if feature detection removed: verified.
- Manual ⌘F check: not runnable here (needs the built Electron app); the highlight+flash lifecycle is covered by unit tests 8-11.