### PR TITLE
feat(server): wire saveRules to the §3.3 forge token ladder (BET-810)

### DIFF
--- a/docs/forge-rules-authoring.md
+++ b/docs/forge-rules-authoring.md
@@ -48,16 +48,18 @@ raise it rather than working around the grammar.
 ## The forge token
 
 Registering the webhook needs a GitHub API token **on the box** (it never
-reaches the desktop or phone). It is resolved by the single box-side forge
-token ladder (§3.3), CLI first:
+reaches the desktop or phone). The token is resolved through the forge auth
+ladder (`src/server/forge/auth.mjs`), tried in order:
 
-1. **`gh auth token`** (run through a login shell) when the box is already a
-   GitHub dev machine — the common case.
-2. Otherwise a **shared secret named `GITHUB_TOKEN`** in the box secrets vault.
+1. The `MANTA_GITHUB_TOKEN` env var (`MANTA_GITLAB_TOKEN` for GitLab) — an
+   explicit operator override.
+2. The `gh` CLI's own credential — `gh auth token` (`gh auth login` on the
+   box). This is the default for a box that is already a dev machine.
+3. A stored secret in the box secrets vault under the key `GITHUB_TOKEN`
+   (`gitlab.token` for GitLab; the legacy `github.token` key still works).
 
-If neither is present the webhook registration reports "not connected" — run
-`gh auth login`, or store the `GITHUB_TOKEN` shared secret, on the box. The
-GitLab leg of the ladder arrives with the GitLab adapter.
+All three are box-side only; the value never reaches the desktop or phone.
+`forge_rules_save` will not register a webhook until one of these resolves.
 
 ## Where it lives
 

--- a/src/server/forge/auth.mjs
+++ b/src/server/forge/auth.mjs
@@ -1,17 +1,27 @@
 // auth.mjs — box-side forge-credential resolution: the §3.3 ladder (BET-788).
 //
 // Priority for a resolved token:
-//   1. The forge CLI's own token — `gh auth token` for github.com, run through
+//   1. A per-host env var (`MANTA_GITHUB_TOKEN` / `MANTA_GITLAB_TOKEN`) — the
+//      dev/test override and a legitimate self-host affordance. Highest
+//      because an explicit operator override must win over ambient state.
+//   2. The forge CLI's own token — `gh auth token` for github.com, run through
 //      a login shell. gh lives under ~/.local/bin or a Homebrew prefix that a
 //      bare execFile PATH cannot see, so this reuses runLoginShell
 //      (src/server/launchers.mjs) — the same helper the repo probe's
 //      detectForgeCli() uses. This is the default and covers the overwhelmingly
 //      common case of a box that is already a dev machine.
-//   2. A stored secret — GITHUB_TOKEN in the box secrets vault
-//      (~/.manta-secrets, 0600), read via resolveSecret. Reading the value
-//      in-process is fine: the secrets-store invariant is that a value never
-//      enters an AGENT's transcript, not that it never enters the server's
-//      memory.
+//   3. A stored secret in the box secrets vault (~/.manta-secrets, 0600), read
+//      via resolveSecret. Both the BET-788 canonical key (`GITHUB_TOKEN` /
+//      `GITLAB_TOKEN`) and the BET-797 legacy key (`github.token` /
+//      `gitlab.token`) are accepted so a secret stored through either
+//      documentation path resolves. Reading the value in-process is fine: the
+//      secrets-store invariant is that a value never enters an AGENT's
+//      transcript, not that it never enters the server's memory.
+//
+// This is the ONE forge token resolver on the box. The rules
+// (forge_rules_save in forgeRules.mjs) and the adapter (forge/index.mjs)
+// both resolve through it, so a gh-authenticated or secret-stored box
+// registers webhooks and reads the forge with the same credential.
 //
 // A resolved token is cached in memory for a short TTL (so a poll loop doesn't
 // re-spawn `gh auth token` every couple of seconds) and invalidateToken()
@@ -29,18 +39,33 @@ import { resolveSecret, loadSecrets } from "../secrets.mjs";
 const TTL_MS = 60_000;
 
 // The CLI leg only exists for github.com (`gh auth token`). GitLab has its own
-// CLI but it arrives with the GitLab adapter; this issue is the GitHub read
-// path.
+// CLI but it arrives with the GitLab adapter.
 const CLI_HOST = "github.com";
 
-// Secrets-vault key per host for the stored leg. GITHUB_TOKEN is the issue's
-// canonical key for GitHub.
-const STORED_KEY_BY_HOST = Object.freeze({
-  "github.com": "GITHUB_TOKEN",
+// Per-host env var override (priority 1).
+const ENV_BY_HOST = Object.freeze({
+  "github.com": "MANTA_GITHUB_TOKEN",
+  "gitlab.com": "MANTA_GITLAB_TOKEN",
+});
+
+// Secrets-vault keys per host, checked in order. The first is the BET-788
+// canonical key; the second is the BET-797 legacy key still documented in
+// docs/forge-rules-authoring.md and accepted so an existing secret keeps
+// working.
+const STORED_KEYS_BY_HOST = Object.freeze({
+  "github.com": ["GITHUB_TOKEN", "github.token"],
+  "gitlab.com": ["GITLAB_TOKEN", "gitlab.token"],
 });
 
 // host -> { at, found, token?, source? }
 const CACHE = new Map();
+
+function envToken(host, env) {
+  const key = ENV_BY_HOST[host];
+  if (!key) return null;
+  const v = env?.[key];
+  return typeof v === "string" && v ? v : null;
+}
 
 async function cliToken(host, shell) {
   if (host !== CLI_HOST) return null;
@@ -55,11 +80,15 @@ async function cliToken(host, shell) {
 }
 
 function storedToken(host, loadSecretsFn) {
-  const key = STORED_KEY_BY_HOST[host];
-  if (!key) return null;
+  const keys = STORED_KEYS_BY_HOST[host];
+  if (!keys || keys.length === 0) return null;
   try {
-    const entry = resolveSecret(loadSecretsFn(), key, null, null);
-    return typeof entry?.value === "string" && entry.value ? entry.value : null;
+    const secrets = loadSecretsFn();
+    for (const key of keys) {
+      const entry = resolveSecret(secrets, key, null, null);
+      if (typeof entry?.value === "string" && entry.value) return entry.value;
+    }
+    return null;
   } catch {
     return null;
   }
@@ -67,26 +96,33 @@ function storedToken(host, loadSecretsFn) {
 
 /**
  * Resolve the box-side token for a forge host per §3.3's ladder, or null when
- * neither leg yields one (callers surface "not connected").
+ * no leg yields one (callers surface "not connected").
  *
- * Priority: CLI (`gh auth token`) wins over the stored secret. A resolved
- * value is cached for TTL_MS; a miss is cached briefly too so a not-connected
- * box doesn't re-spawn the CLI on every poll. Pass `now` to control the clock
- * in tests; `invalidateToken` clears a host's entry for the rotation case.
+ * Priority: env var → CLI (`gh auth token`) → stored secret. A resolved value
+ * is cached for TTL_MS; a miss is cached briefly too so a not-connected box
+ * doesn't re-spawn the CLI on every poll. Pass `now` / `env` / `shell` /
+ * `loadSecretsFn` to control the clock and I/O in tests;
+ * `invalidateToken` clears a host's entry for the rotation case.
  *
  * @param {string} host
- * @param {{ shell?: (cmd: string) => Promise<{stdout: string}>, loadSecretsFn?: () => unknown, now?: () => number }} [opts]
- * @returns {Promise<{ token: string, source: "cli" | "stored" } | null>}
+ * @param {{ shell?: (cmd: string) => Promise<{stdout: string}>, loadSecretsFn?: () => unknown, env?: NodeJS.ProcessEnv, now?: () => number }} [opts]
+ * @returns {Promise<{ token: string, source: "env" | "cli" | "stored" } | null>}
  */
 export async function resolveToken(
   host,
-  { shell = runLoginShell, loadSecretsFn = loadSecrets, now = Date.now } = {},
+  { shell = runLoginShell, loadSecretsFn = loadSecrets, env = process.env, now = Date.now } = {},
 ) {
   if (typeof host !== "string" || !host) return null;
 
   const hit = CACHE.get(host);
   if (hit && now() - hit.at < TTL_MS) {
     return hit.found ? { token: hit.token, source: hit.source } : null;
+  }
+
+  const envTok = envToken(host, env);
+  if (envTok) {
+    CACHE.set(host, { at: now(), found: true, token: envTok, source: "env" });
+    return { token: envTok, source: "env" };
   }
 
   const cli = await cliToken(host, shell);

--- a/src/server/forge/auth.test.mjs
+++ b/src/server/forge/auth.test.mjs
@@ -29,10 +29,12 @@ function loadWith(secrets) {
   return () => secrets;
 }
 
+const NO_ENV = {};
 const STORED = [{ id: "s1", key: "GITHUB_TOKEN", value: "ghp_stored", scope: "shared", sessionID: null, project: null }];
 
 test("resolveToken: CLI wins over stored", async () => {
   const r = await resolveToken("github.com", {
+    env: NO_ENV,
     shell: shellReturning("ghp_cli\n"),
     loadSecretsFn: loadWith(STORED),
   });
@@ -41,14 +43,65 @@ test("resolveToken: CLI wins over stored", async () => {
 
 test("resolveToken: stored secret used when no CLI token", async () => {
   const r = await resolveToken("github.com", {
+    env: NO_ENV,
     shell: shellReturning(""),
     loadSecretsFn: loadWith(STORED),
   });
   assert.deepEqual(r, { token: "ghp_stored", source: "stored" });
 });
 
+test("resolveToken: env var wins over CLI and stored", async () => {
+  const r = await resolveToken("github.com", {
+    env: { MANTA_GITHUB_TOKEN: "ghp_env" },
+    shell: shellReturning("ghp_cli\n"),
+    loadSecretsFn: loadWith(STORED),
+  });
+  assert.deepEqual(r, { token: "ghp_env", source: "env" });
+});
+
+test("resolveToken: legacy github.token secret still resolves", async () => {
+  const legacy = [{ id: "s1", key: "github.token", value: "ghp_legacy", scope: "shared", sessionID: null, project: null }];
+  const r = await resolveToken("github.com", {
+    env: NO_ENV,
+    shell: shellReturning(""),
+    loadSecretsFn: loadWith(legacy),
+  });
+  assert.deepEqual(r, { token: "ghp_legacy", source: "stored" });
+});
+
+test("resolveToken: canonical GITHUB_TOKEN wins over legacy github.token", async () => {
+  const both = [
+    { id: "s1", key: "github.token", value: "ghp_legacy", scope: "shared", sessionID: null, project: null },
+    { id: "s2", key: "GITHUB_TOKEN", value: "ghp_canonical", scope: "shared", sessionID: null, project: null },
+  ];
+  const r = await resolveToken("github.com", {
+    env: NO_ENV,
+    shell: shellReturning(""),
+    loadSecretsFn: loadWith(both),
+  });
+  assert.deepEqual(r, { token: "ghp_canonical", source: "stored" });
+});
+
+test("resolveToken: gitlab env var + legacy secret resolve", async () => {
+  const legacy = [{ id: "s1", key: "gitlab.token", value: "glpat_legacy", scope: "shared", sessionID: null, project: null }];
+  const r = await resolveToken("gitlab.com", {
+    env: NO_ENV,
+    shell: shellReturning(""),
+    loadSecretsFn: loadWith(legacy),
+  });
+  assert.deepEqual(r, { token: "glpat_legacy", source: "stored" });
+  invalidateToken("gitlab.com"); // drop the cached legacy resolution so the env leg is re-tried
+  const envR = await resolveToken("gitlab.com", {
+    env: { MANTA_GITLAB_TOKEN: "glpat_env" },
+    shell: shellReturning(""),
+    loadSecretsFn: loadWith([]),
+  });
+  assert.deepEqual(envR, { token: "glpat_env", source: "env" });
+});
+
 test("resolveToken: neither → null", async () => {
   const r = await resolveToken("github.com", {
+    env: NO_ENV,
     shell: shellReturning(""),
     loadSecretsFn: loadWith([]),
   });
@@ -58,6 +111,7 @@ test("resolveToken: neither → null", async () => {
 test("resolveToken: unknown/empty host → null without touching anything", async () => {
   let shellCalls = 0;
   const r = await resolveToken("", {
+    env: NO_ENV,
     shell: async () => (shellCalls++, { stdout: "x" }),
     loadSecretsFn: loadWith([]),
   });
@@ -67,6 +121,7 @@ test("resolveToken: unknown/empty host → null without touching anything", asyn
 
 test("resolveToken: CLI failure (gh missing) falls through to stored", async () => {
   const r = await resolveToken("github.com", {
+    env: NO_ENV,
     shell: async () => {
       throw new Error("gh not found");
     },
@@ -79,8 +134,8 @@ test("resolveToken: cached hit within TTL does not re-invoke the shell", async (
   const clock = makeClock();
   const seen = [];
   const shell = async () => (seen.push(1), { stdout: "ghp_cached" });
-  await resolveToken("github.com", { shell, loadSecretsFn: loadWith([]), now: clock.now });
-  await resolveToken("github.com", { shell, loadSecretsFn: loadWith([]), now: clock.now });
+  await resolveToken("github.com", { env: NO_ENV, shell, loadSecretsFn: loadWith([]), now: clock.now });
+  await resolveToken("github.com", { env: NO_ENV, shell, loadSecretsFn: loadWith([]), now: clock.now });
   assert.equal(seen.length, 1, "second resolve within TTL is served from cache");
 });
 
@@ -88,11 +143,11 @@ test("resolveToken: cache expires after TTL and re-reads", async () => {
   const clock = makeClock();
   let token = "ghp_v1";
   const shell = async () => ({ stdout: token });
-  const a = await resolveToken("github.com", { shell, loadSecretsFn: loadWith([]), now: clock.now });
+  const a = await resolveToken("github.com", { env: NO_ENV, shell, loadSecretsFn: loadWith([]), now: clock.now });
   assert.equal(a.token, "ghp_v1");
   token = "ghp_v2"; // rotated out-of-band while the box stayed up
   clock.advance(61_000);
-  const b = await resolveToken("github.com", { shell, loadSecretsFn: loadWith([]), now: clock.now });
+  const b = await resolveToken("github.com", { env: NO_ENV, shell, loadSecretsFn: loadWith([]), now: clock.now });
   assert.equal(b.token, "ghp_v2", "rotation picked up after TTL");
 });
 
@@ -100,9 +155,9 @@ test("invalidateToken clears the cache immediately", async () => {
   const clock = makeClock();
   let token = "ghp_a";
   const shell = async () => ({ stdout: token });
-  await resolveToken("github.com", { shell, loadSecretsFn: loadWith([]), now: clock.now });
+  await resolveToken("github.com", { env: NO_ENV, shell, loadSecretsFn: loadWith([]), now: clock.now });
   token = "ghp_b";
   invalidateToken("github.com");
-  const r = await resolveToken("github.com", { shell, loadSecretsFn: loadWith([]), now: clock.now });
+  const r = await resolveToken("github.com", { env: NO_ENV, shell, loadSecretsFn: loadWith([]), now: clock.now });
   assert.equal(r.token, "ghp_b", "invalidate forces a re-read before TTL");
 });

--- a/src/server/forgeRules.mjs
+++ b/src/server/forgeRules.mjs
@@ -182,7 +182,8 @@ function formatErrors(errors) {
  * @param {object} [deps]
  * @param {() => boolean} [deps.enabled]
  * @param {{host?:string, token?:string}} [deps.forge] forge identity + token override for registration
- * @param {(host: string) => Promise<{ token?: string, source?: string } | null>} [deps.resolveToken] box-side token resolver (default authResolveToken)
+ * @param {(host: string) => Promise<{ token: string, source?: string } | null> | string | null} [deps.resolveToken] box-side token resolver (default the §3.3 ladder in forge/auth.mjs)
+ * @param {() => string|null} [deps.publicBase] box public hostname resolver (default publicBaseUrl)
  * @param {object} [deps.io]
  * @param {typeof ensureRepoHook} [deps.ensureHook]
  * @param {() => void} [deps.reload]
@@ -193,6 +194,7 @@ export async function saveRules(
     enabled = () => true,
     forge = {},
     resolveToken = authResolveToken,
+    publicBase = publicBaseUrl,
     io = DEFAULT_IO,
     ensureHook = ensureRepoHook,
     reload = () => {},
@@ -212,16 +214,16 @@ export async function saveRules(
 
   await io.write(p.path, yaml);
 
-  // The forge API token for the repo's host, resolved box-side via the §3.3
-  // ladder (gh auth token → shared secret named GITHUB_TOKEN in the secrets
-  // vault). Never reaches the renderer/iOS. An explicit `forge.token` override
-  // wins (tests/dev). `resolveToken` is async and yields `{ token } | null`.
+  // The forge API token for the repo's host, resolved box-side through the §3.3
+  // ladder (forge/auth.mjs): env var → `gh auth token` → stored secret. Never
+  // reaches the renderer/iOS. An explicit `forge.token` override wins
+  // (tests/dev). `resolveToken` is async and yields `{ token } | null`.
   const resolved = forge.token ? { token: forge.token } : await resolveToken(parts.host).catch(() => null);
   const token = resolved?.token || null;
 
   let webhook = { registered: false };
   try {
-    const pub = publicBaseUrl();
+    const pub = publicBase();
     if (!pub) {
       webhook = {
         registered: false,
@@ -233,8 +235,9 @@ export async function saveRules(
       webhook = {
         registered: false,
         error:
-          `no ${parts.host} token configured — run \`gh auth login\` on the box, ` +
-          "or store a shared secret named GITHUB_TOKEN",
+          `no ${parts.host} token configured — authenticate the forge CLI (gh auth login) ` +
+          "on the box, set MANTA_GITHUB_TOKEN (or MANTA_GITLAB_TOKEN), or store the PAT as a " +
+          "shared secret named GITHUB_TOKEN (github.token for the legacy key; gitlab.token for GitLab)",
       };
     } else {
       const key = repoKey(parts);

--- a/src/server/forgeRules.test.mjs
+++ b/src/server/forgeRules.test.mjs
@@ -1,0 +1,119 @@
+// forgeRules.test.mjs — saveRules' token resolution wiring (BET-810).
+//
+// saveRules is pure of the network path: io, publicBase, the token resolver
+// and the hook registrar are all injected. These tests pin that the §3.3
+// ladder result actually drives webhook registration — a gh-authenticated or
+// secret-stored box must reach `ensureHook` with its token, a box with no
+// token must fail registration loudly (not silently no-op), and the `forge.token`
+// override must beat the resolver.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { saveRules } from "./forgeRules.mjs";
+
+const VALID_YAML = "on:\n  issue.labeled:\n    do: notify\n";
+const PUBLIC_BASE = "https://00000000000000000000000000000000.boxes.mantaui.com";
+
+// Minimal in-memory io — saveRules only writes the rules file, then delegates
+// registration to the injected ensureHook.
+const io = { write: async () => {} };
+
+function hookOk() {
+  return async (args) => ({
+    ok: true,
+    secret: "whsec_x",
+    hookId: 1,
+    events: args.events,
+    url: `${PUBLIC_BASE}/hook/deliverytoken`,
+  });
+}
+
+test("saveRules registers the webhook with the resolved §3.3 token", async () => {
+  let hookArgs = null;
+  const res = await saveRules(
+    { repo: "github.com/acme/widgets", yaml: VALID_YAML },
+    {
+      io,
+      publicBase: () => PUBLIC_BASE,
+      resolveToken: async () => ({ token: "ghp_box", source: "cli" }),
+      ensureHook: (args) => (hookArgs = args, hookOk()(args)),
+    },
+  );
+
+  assert.equal(res.ok, true);
+  assert.equal(res.webhook.registered, true);
+  assert.equal(hookArgs.githubToken, "ghp_box");
+  assert.equal(hookArgs.host, "github.com");
+  assert.equal(hookArgs.owner, "acme");
+});
+
+test("saveRules fails registration loudly when no token resolves (rules still saved)", async () => {
+  let ensureCalled = false;
+  const res = await saveRules(
+    { repo: "github.com/acme/widgets", yaml: VALID_YAML },
+    {
+      io,
+      publicBase: () => PUBLIC_BASE,
+      resolveToken: async () => null,
+      ensureHook: () => (ensureCalled = true, hookOk()()),
+    },
+  );
+
+  assert.equal(res.ok, true, "the rules file is still saved — the rules are the point");
+  assert.equal(res.webhook.registered, false);
+  assert.match(res.webhook.error, /no github\.com token configured/);
+  assert.equal(ensureCalled, false, "a missing token must never reach the hook registrar");
+});
+
+test("saveRules passes the forge.token override, not the resolver", async () => {
+  let hookArgs = null;
+  const res = await saveRules(
+    { repo: "github.com/acme/widgets", yaml: VALID_YAML },
+    {
+      forge: { token: "ghp_override" },
+      io,
+      publicBase: () => PUBLIC_BASE,
+      // The resolver would win if the override didn't; it must not even be used.
+      resolveToken: async () => ({ token: "ghp_resolver", source: "cli" }),
+      ensureHook: (args) => (hookArgs = args, hookOk()(args)),
+    },
+  );
+
+  assert.equal(res.ok, true);
+  assert.equal(res.webhook.registered, true);
+  assert.equal(hookArgs.githubToken, "ghp_override");
+});
+
+test("saveRules reports webhook errors without throwing", async () => {
+  const res = await saveRules(
+    { repo: "github.com/acme/widgets", yaml: VALID_YAML },
+    {
+      io,
+      publicBase: () => PUBLIC_BASE,
+      resolveToken: async () => ({ token: "ghp_box", source: "cli" }),
+      ensureHook: async () => ({ ok: false, error: "github 401" }),
+    },
+  );
+
+  assert.equal(res.ok, true);
+  assert.equal(res.webhook.registered, false);
+  assert.equal(res.webhook.error, "github 401");
+});
+
+test("saveRules requires a public hostname before registration", async () => {
+  let ensureCalled = false;
+  const res = await saveRules(
+    { repo: "github.com/acme/widgets", yaml: VALID_YAML },
+    {
+      io,
+      publicBase: () => null,
+      resolveToken: async () => ({ token: "ghp_box", source: "cli" }),
+      ensureHook: () => (ensureCalled = true, hookOk()()),
+    },
+  );
+
+  assert.equal(res.ok, true);
+  assert.equal(res.webhook.registered, false);
+  assert.match(res.webhook.error, /no public hostname/);
+  assert.equal(ensureCalled, false);
+});


### PR DESCRIPTION
**Closes BET-810.**

## What changed

`forge_rules_save` could not register a webhook unless a `MANTA_GITHUB_TOKEN`/`github.token` secret happened to exist — BET-797 had wired it to a placeholder resolver that never consulted the §3.3 ladder, silently no-opping on registration for a normal gh-authenticated box. This wires it to the ladder.

**Note on overlap with BET-814:** `main` has since converged the forge token onto the §3.3 ladder (BET-814, PR #817) — it wired `saveRules` to `forge/auth.mjs` and deleted `forge/token.mjs`. This PR has been rebased onto that; what it **adds** on top of BET-814 is the delta BET-814 dropped:

- **Env-var leg restored** (`MANTA_GITHUB_TOKEN` / `MANTA_GITLAB_TOKEN`, highest priority) and the **legacy secret keys** (`github.token` / `gitlab.token`) folded back into `forge/auth.mjs` alongside the canonical `GITHUB_TOKEN`/`GITLAB_TOKEN` — so no documented BET-797 path regresses. Priority: env → `gh auth token` → stored secret.
- **`saveRules` token-wiring tests** (`forgeRules.test.mjs`) — BET-814 shipped none: resolved token reaches the hook registrar; missing token fails loudly without touching it; `forge.token` override wins; public-hostname guard.
- **`publicBase` made injectable** in `saveRules` (the module already injects `io`/`ensureHook`/`resolveToken`/`reload`) so the tests never touch the real gateway host.
- Error message + `docs/forge-rules-authoring.md` updated for the ladder's three sources.

Box-side only; the value never reaches the renderer/iOS. The §3.3 device-flow leg is tracked by BET-796; the GitLab CLI leg arrives with BET-799.

**Files changed:** 5 files. `[docs/forge-rules-authoring.md, src/server/forge/auth.mjs, src/server/forge/auth.test.mjs, src/server/forgeRules.mjs, src/server/forgeRules.test.mjs]`

**Verification results (rebased head `f05c3976`):**
- typecheck: exit 0. Errors: none. log sha256: `75342603966d11824516b89baa97128413853820f43086df3254737d95622e1f`
- `npm test`: exit 0. node:test 640/640 pass, 0 fail; vitest 135 files / 2509 passed / 7 skipped. One flaky first-run of the `e2e-smoke` Playwright-installed check timed out on a cold cache and passed immediately on re-run (file untouched by this PR). log sha256: `see /tmp/test-pr2.log`
- `gh pr checks 818` at hand-off: mergeable==true, `typecheck-test`/`duplication-gate` pending (CI queued on the new head).
- **Base: `origin/main` @ `77ab55c5`** (rebase point after BET-814 landed).
