### PR TITLE
BET-809: chore(release): 0.0.23 — publish BET-804's self-update runtime fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.22",
+      "version": "0.0.23",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.22",
+  "version": "0.0.23",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.22",
+ "version": "0.0.23",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Closes BET-809.

## What

Bumps `package.json` (and the lockfile's self-reference) 0.0.22 → 0.0.23 so a `server-v*` tag can publish a box tarball that installed boxes will actually apply.

## Why the issue's premise needed correcting

BET-809 says the published release is 0.0.19 shipping EOL Node 20. It isn't — the published release is **0.0.22**, and it already vendors **Node 24.19.0** (the runtime bump `9c01cb6` is an ancestor of `server-v16`). So *fresh installs* are already correct.

What is genuinely unpublished is **BET-804 itself** (`9ce9896`, merged after `server-v16`): the self-update change that lets a vendored-runtime bump reach an **already-installed** box.

## Why the bump is mandatory, not cosmetic

`scripts/self-update.sh` exits early when `INSTALLED_VERSION == TARBALL_VERSION`. Re-tagging at 0.0.22 would be skipped by every installed box and deliver nothing.

## Two-hop caveat (expected, documented in BET-804)

A box runs the copy of `self-update.sh` already on its disk, so this publish only **delivers** the new updater — existing boxes' `runtime/` swaps on the release *after* this one. That is inherent to a self-replacing updater and is called out in BET-804's own header comment. A follow-up issue tracks the second publish.

## Verification

- `npm run typecheck` — clean
- `npm test` — 2503 passed. One unrelated flake: `tests/unit/e2e-smoke.test.ts` timed out at 5s shelling to `npx playwright --version` under full-suite load; passes standalone in 3.5s and is untouched by a version-string change.