### PR TITLE
feat(composer): solid send/stop glyphs + a real loading state for the model chip

### DIFF
--- a/src/renderer/Chip.test.tsx
+++ b/src/renderer/Chip.test.tsx
@@ -194,6 +194,34 @@ describe("SplitChip", () => {
     expect(pr.hasAttribute("aria-expanded")).toBe(false);
   });
 
+  it("loading drops every segment's hover affordance together and marks the shell aria-busy", () => {
+    const shell = mountSplit({ loading: true, rightAccent: true });
+    expect(shell.getAttribute("aria-busy")).toBe("true");
+    const [l, r] = buttons();
+    // No segment offers a hover it can't honour, and the accent is withheld:
+    // the right segment's colour asserts a resolved value it doesn't have yet.
+    expect(l.className).not.toContain("hover:");
+    expect(r.className).not.toContain("hover:");
+    expect(r.className).not.toContain("text-accent-tx");
+    expect(l.className).toContain("cursor-default");
+    expect(r.className).toContain("cursor-default");
+
+    // Absent the prop nothing leaks — aria-busy is omitted, not "false".
+    const rest = mountSplit();
+    expect(rest.hasAttribute("aria-busy")).toBe(false);
+  });
+
+  it("loading is presentational: it must NOT disable the segments (a failed fetch would strand the user)", () => {
+    let l = 0;
+    mountSplit({ loading: true, onLeftClick: () => l++ });
+    const [bl, br] = buttons();
+    expect(bl.disabled).toBe(false);
+    expect(br.disabled).toBe(false);
+    bl.click();
+    // The left segment still opens its (self-describing) menu while loading.
+    expect(l).toBe(1);
+  });
+
   it("does NOT assume popup semantics: aria-haspopup is absent unless popup is opted in", () => {
     mountSplit();
     const [l, r] = buttons();

--- a/src/renderer/Chip.tsx
+++ b/src/renderer/Chip.tsx
@@ -97,6 +97,7 @@ export function SplitChip({
   extraHook,
   extraPressed,
   extraDisabled = false,
+  loading = false,
 }: {
   /** Left-segment content (e.g. model name + an icon). */
   left: ReactNode;
@@ -165,15 +166,33 @@ export function SplitChip({
   extraPressed?: boolean;
   /** Render the extra segment non-interactive (dimmed, `disabled`). */
   extraDisabled?: boolean;
+  /**
+   * The control is still resolving what it describes. All segments drop their
+   * hover affordance together and the shell reports `aria-busy` — they describe
+   * ONE subject (in the composer: the model, its effort and its fast twin), so
+   * a chip that looked half-live would imply the other half is known.
+   *
+   * Deliberately PRESENTATIONAL: it does not `disabled` the segments. A caller
+   * whose segments are already inert while loading (ModelPicker's effort/toggle
+   * early-return on an empty variant/fast resolution) gets that for free, and
+   * one whose left segment opens a self-describing menu keeps it reachable —
+   * which matters because a catalog fetch that fails leaves this state up until
+   * the next remount, and a hard-disabled chip would be the user's only
+   * affordance taken away.
+   */
+  loading?: boolean;
 }) {
   const listbox = popup ? { "aria-haspopup": "listbox" as const } : {};
   const leftAria = leftExpanded !== undefined ? { "aria-expanded": leftExpanded } : {};
   const rightAria = rightExpanded !== undefined ? { "aria-expanded": rightExpanded } : {};
-  const leftClass = `${leftHook ? `${leftHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full hover:bg-fill-hover hover:text-text`;
+  const idle = loading ? " cursor-default" : " hover:bg-fill-hover hover:text-text";
+  const leftClass = `${leftHook ? `${leftHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full${idle}`;
   // `rightAccent` is a COLOUR accent only. It used to add `font-semibold` too,
   // which made the effort label the heaviest text in the composer — the accent
   // already carries the emphasis, and the extra weight only shouted.
-  const rightClass = `${rightHook ? `${rightHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full border-l border-border hover:bg-fill-hover${rightAccent ? " text-accent-tx" : ""}`;
+  const rightClass =
+    `${rightHook ? `${rightHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full border-l border-border` +
+    `${loading ? " cursor-default" : " hover:bg-fill-hover"}${rightAccent && !loading ? " text-accent-tx" : ""}`;
   // The toggle segment shares the divider + padding of the right segment, so
   // the three read as one control. Only its TONE differs, across three states
   // that must be told apart at a glance:
@@ -194,16 +213,21 @@ export function SplitChip({
     : extraDisabled
       ? "text-text-quiet"
       : "text-text-faint";
-  const extraInteraction = extraDisabled
-    ? "opacity-50 cursor-not-allowed"
-    : extraPressed
-      ? "hover:bg-fill-hover"
-      : "hover:bg-fill-hover hover:text-text";
+  const extraInteraction = loading
+    ? "cursor-default"
+    : extraDisabled
+      ? "opacity-50 cursor-not-allowed"
+      : extraPressed
+        ? "hover:bg-fill-hover"
+        : "hover:bg-fill-hover hover:text-text";
   const extraClass =
     `${extraHook ? `${extraHook} ` : ""}inline-flex items-center ${CHIP_PAD} h-full border-l border-border ` +
     `${extraTone} ${extraInteraction}`;
   return (
-    <div className={`${hook ? `${hook} ` : ""}${SPLIT_SHELL} p-0 overflow-hidden ${CHIP_REST}`}>
+    <div
+      className={`${hook ? `${hook} ` : ""}${SPLIT_SHELL} p-0 overflow-hidden ${CHIP_REST}`}
+      aria-busy={loading || undefined}
+    >
       <button type="button" onClick={onLeftClick} title={leftTitle} className={leftClass} {...listbox} {...leftAria}>
         {left}
       </button>
@@ -216,8 +240,11 @@ export function SplitChip({
           onClick={onExtraClick}
           title={extraTitle}
           aria-label={extraLabel}
+          // `aria-pressed` is dropped while loading: the toggle's state is a
+          // property of a model we haven't resolved, so reporting `false` would
+          // assert "off" rather than "unknown".
           disabled={extraDisabled}
-          aria-pressed={extraPressed}
+          aria-pressed={loading ? undefined : extraPressed}
           className={extraClass}
         >
           {extra}

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -17,7 +17,7 @@
 // a focus state instead of hairline dividers around a naked textarea.
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Mic, Send, Shield, Square } from "lucide-react";
+import { Mic, Shield, Square } from "lucide-react";
 import type { OpencodeModel } from "../shared/types";
 import type { VoiceMode, VoicePhase } from "./voice";
 import {
@@ -41,6 +41,37 @@ import { UsageDial } from "./UsageDial";
 export { TypeaheadPopup } from "./ComposerParts";
 // AttachmentStrip is no longer re-exported — it is now rendered INSIDE the
 // composer box (BET-416 §B), so Composer no longer imports it.
+
+/**
+ * The send glyph: lucide's paper plane as a SOLID shape.
+ *
+ * Not `<Send fill="currentColor"/>` — lucide's Send is two paths, the plane
+ * body plus a separate diagonal line for the fold. Filling the component fills
+ * the body but leaves that second path a stroke, so a hairline crease cuts
+ * across the solid plane. Dropping it is what "filled send" means, and the
+ * component API gives no way to render one path of two, so the body is inlined
+ * here (the same inline-SVG escape hatch CopyButton uses).
+ *
+ * The path is lucide-react v1.28.0's `send` body, verbatim; the light stroke on
+ * top of the fill is what keeps a 14px solid shape from looking eroded at its
+ * points.
+ */
+function SendFilled({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z" />
+    </svg>
+  );
+}
 
 // Measure the caret's VISUAL row within a textarea, accounting for soft wrap.
 // Render a hidden mirror <div> that copies the textarea's box + text styling,
@@ -430,7 +461,15 @@ export function InputArea({
               : "bg-fill text-text-faint")
           }
         >
-          {running ? <Square size={12} aria-hidden="true" /> : <Send size={14} aria-hidden="true" />}
+          {/* Both glyphs are SOLID (BET icon pass): against the accent fill an
+              outline reads as a faint sketch, and the hollow square in
+              particular did not say "stop". Square keeps its stroke on top of
+              the fill so it stays optically the same size as before. */}
+          {running ? (
+            <Square size={12} fill="currentColor" aria-hidden="true" />
+          ) : (
+            <SendFilled size={14} />
+          )}
         </button>
         </div>
       </div>

--- a/src/renderer/ModelPicker.test.tsx
+++ b/src/renderer/ModelPicker.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+//
+// ModelPicker loading state — the three segments (model ▸ effort ▸ ⚡ fast)
+// describe ONE subject, so they enter placeholder together while the shared
+// catalog is in flight (`models === null`, the only loading signal
+// `useModelCatalog` exposes).
+//
+// The reason this is pinned rather than left to review: the non-loading
+// fallbacks are not neutral, they are confident and WRONG before the catalog
+// lands — the model button settles on the "opencode" stub, the effort label
+// hard-codes "High", and `resolveFastToggle` reports the model as having no
+// fast twin. Those read as resolved facts about a model nobody has resolved,
+// which is exactly the state a user is most likely to act on. Each assertion
+// below is one of those three lies.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { ModelPicker } from "./ModelPicker";
+import type { OpencodeModel } from "../shared/types";
+
+const MODELS: OpencodeModel[] = [
+  {
+    id: "claude-opus-4-7",
+    providerID: "anthropic",
+    name: "Claude Opus 4.7",
+    variants: [{ id: "high" }, { id: "low" }],
+  } as OpencodeModel,
+];
+
+describe("ModelPicker — loading state (models === null)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  // The server default is supplied in both cases: it is what the composer
+  // actually has in hand, and it isolates the variable under test to `models`.
+  // (With no default AND no override the loaded chip legitimately shows the
+  // "opencode" stub — a different, already-resolved state.)
+  function render(models: OpencodeModel[] | null): HTMLElement {
+    h?.unmount();
+    h = mount(
+      <ModelPicker
+        modelLabel={null}
+        models={models}
+        modelOverride={null}
+        defaultModel={{ providerID: "anthropic", modelID: "claude-opus-4-7" }}
+        onOpen={() => {}}
+        onSelect={() => {}}
+      />,
+    );
+    return h.container;
+  }
+
+  it("states no model, effort or fast-mode value while the catalog is in flight", () => {
+    const c = render(null);
+    const text = c.textContent ?? "";
+    // The three fabricated values, none of which may appear.
+    expect(text).not.toContain("opencode");
+    expect(text).not.toContain("High");
+    expect(text).not.toContain("Default");
+
+    // …and the toggle reports "unknown", not "off": an aria-pressed="false"
+    // here would assert the model has fast mode available and switched off.
+    const fastBtn = c.querySelector<HTMLElement>(".manta-fast-toggle-btn");
+    expect(fastBtn).toBeTruthy();
+    expect(fastBtn?.hasAttribute("aria-pressed")).toBe(false);
+  });
+
+  it("marks the whole split control busy, not one segment", () => {
+    const c = render(null);
+    const shell = c.firstElementChild?.firstElementChild as HTMLElement;
+    expect(shell.getAttribute("aria-busy")).toBe("true");
+    // All three segments are present and identity-stable, so the chip does not
+    // change shape when the catalog lands — only its content.
+    expect(c.querySelector(".manta-model-picker-btn")).toBeTruthy();
+    expect(c.querySelector(".manta-effort-picker-btn")).toBeTruthy();
+    expect(c.querySelector(".manta-fast-toggle-btn")).toBeTruthy();
+  });
+
+  it("resolves to real values once the catalog lands", () => {
+    const c = render(MODELS);
+    const shell = c.firstElementChild?.firstElementChild as HTMLElement;
+    expect(shell.hasAttribute("aria-busy")).toBe(false);
+    const text = c.textContent ?? "";
+    expect(text).toContain("Claude Opus 4.7");
+  });
+});

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -22,6 +22,24 @@ import { SplitChip } from "./Chip";
 import { EffortMenu } from "./EffortMenu";
 import { ModelMenu } from "./ModelMenu";
 
+const LOADING_TITLE = "Loading models…";
+
+/**
+ * A placeholder bar sized to the label it stands in for, so the chip doesn't
+ * jump when the real text arrives. `bg-border` is the one neutral token with an
+ * alpha channel; `animate-pulse` is already covered by the global
+ * prefers-reduced-motion guard in index.css.
+ */
+function SkeletonBar({ width }: { width: number }) {
+  return (
+    <span
+      className="inline-block h-[9px] rounded-full bg-border animate-pulse"
+      style={{ width }}
+      aria-hidden="true"
+    />
+  );
+}
+
 export function ModelPicker({
   modelLabel,
   models,
@@ -144,25 +162,53 @@ export function ModelPicker({
     [selectableModels, activeModel, activeVariantId],
   );
 
+  // The catalog hasn't landed yet. `models === null` is the ONLY loading signal
+  // (useModelCatalog keeps no separate flag), and all three segments describe
+  // the same unresolved subject, so they go into placeholder together.
+  //
+  // This branch exists because the fallbacks below are not neutral — they are
+  // confident and WRONG while the list is in flight: the left segment settles
+  // on the "opencode" stub, `effortLabel` hard-codes "High", and
+  // `resolveFastToggle` returns unavailable, i.e. the chip claims this model has
+  // no fast twin. A user reading that gets three facts about a model nobody has
+  // resolved. Placeholder bars say "not yet" instead.
+  const loading = models === null;
+
   return (
     <div ref={rootRef} className="overflow-visible min-w-0 relative">
       <SplitChip
+        loading={loading}
         left={
-          <span className="flex items-center gap-1 truncate">
-            <Sparkles size={13} aria-hidden="true" className="shrink-0 text-accent" />
-            <span className="truncate max-w-[140px]">{modelDisplayName}</span>
-            <ChevronDown size={13} aria-hidden="true" className="shrink-0 text-text-faint" />
-          </span>
+          loading ? (
+            <span className="flex items-center gap-1">
+              <Sparkles size={13} aria-hidden="true" className="shrink-0 text-text-quiet" />
+              <SkeletonBar width={76} />
+              <ChevronDown size={13} aria-hidden="true" className="shrink-0 text-text-quiet" />
+            </span>
+          ) : (
+            <span className="flex items-center gap-1 truncate">
+              <Sparkles size={13} aria-hidden="true" className="shrink-0 text-accent" />
+              <span className="truncate max-w-[140px]">{modelDisplayName}</span>
+              <ChevronDown size={13} aria-hidden="true" className="shrink-0 text-text-faint" />
+            </span>
+          )
         }
         right={
-          <span className="flex items-center gap-1 truncate">
-            <span className="truncate max-w-[80px]">{effortLabel}</span>
-            <ChevronDown
-              size={13}
-              aria-hidden="true"
-              className={`shrink-0 ${effortDisabled ? "text-text-quiet" : "text-text-faint"}`}
-            />
-          </span>
+          loading ? (
+            <span className="flex items-center gap-1">
+              <SkeletonBar width={30} />
+              <ChevronDown size={13} aria-hidden="true" className="shrink-0 text-text-quiet" />
+            </span>
+          ) : (
+            <span className="flex items-center gap-1 truncate">
+              <span className="truncate max-w-[80px]">{effortLabel}</span>
+              <ChevronDown
+                size={13}
+                aria-hidden="true"
+                className={`shrink-0 ${effortDisabled ? "text-text-quiet" : "text-text-faint"}`}
+              />
+            </span>
+          )
         }
         onLeftClick={() => {
           if (!modelOpen) onOpen();
@@ -182,7 +228,15 @@ export function ModelPicker({
         // hollow Zap says available-but-off; filled Zap says on. (`fast.on`
         // wins over availability so an on-but-frozen toggle still shows as on.)
         extra={
-          fast.on ? (
+          loading ? (
+            // A neutral 13px block, not a dimmed Zap/ZapOff: either glyph would
+            // state an availability we don't know yet, which is the whole point
+            // of the loading branch.
+            <span
+              className="w-[13px] h-[13px] rounded-sm bg-border animate-pulse"
+              aria-hidden="true"
+            />
+          ) : fast.on ? (
             <Zap size={13} aria-hidden="true" fill="currentColor" />
           ) : fast.available ? (
             <Zap size={13} aria-hidden="true" fill="none" />
@@ -196,7 +250,7 @@ export function ModelPicker({
           setVariantOpen(false);
           onSelect(fast.target);
         }}
-        extraTitle={fast.title}
+        extraTitle={loading ? LOADING_TITLE : fast.title}
         extraLabel="Fast mode"
         extraHook="manta-fast-toggle-btn"
         extraPressed={fast.on}
@@ -207,11 +261,13 @@ export function ModelPicker({
         rightHook="manta-effort-picker-btn"
         leftExpanded={modelOpen}
         rightExpanded={variantOpen}
-        leftTitle="Pick model for next prompt"
+        leftTitle={loading ? LOADING_TITLE : "Pick model for next prompt"}
         rightTitle={
-          effortDisabled
-            ? "This model has no effort / variant setting"
-            : "Pick effort / variant"
+          loading
+            ? LOADING_TITLE
+            : effortDisabled
+              ? "This model has no effort / variant setting"
+              : "Pick effort / variant"
         }
       />
 


### PR DESCRIPTION
Two unrelated composer fixes, both cases of a control stating something it shouldn't.

## Icons

The send and stop glyphs were lucide outlines sitting on the accent fill, where a 2px stroke reads as a faint sketch — and a hollow square in particular does not say "stop". Both are solid now.

`Square` keeps its stroke on top of the fill so it stays optically the size it was.

`Send` could **not** be fixed by passing `fill` to the component: lucide's `Send` is two paths — the plane body plus a separate diagonal for the fold — so filling it leaves that second path a stroke and a hairline crease cuts across the solid plane. The body path is inlined as `SendFilled` (the same inline-SVG escape hatch `CopyButton` already uses) with the fold dropped, which is what a filled send means. The dropped path's endpoints lie entirely inside the body's bounding box, so the glyph's size and optical centre are unchanged.

## Model chip loading state

While the shared catalog is in flight the three segments did not render a neutral state — they rendered three confident and wrong ones:

| Segment | Before, while loading | Reality |
|---|---|---|
| Model | the `"opencode"` stub | unknown |
| Effort | hard-coded `"High"` | unknown |
| ⚡ Fast | `ZapOff`, "No fast mode for this model" | unknown |

All three describe one subject, so they now enter placeholder together behind a new presentational `loading` prop on `SplitChip`: hover affordances drop, the shell reports `aria-busy`, the right segment's accent is withheld, and the toggle omits `aria-pressed` rather than claiming "off".

`loading` deliberately does **not** disable the segments. A catalog fetch that fails leaves this state up until the next remount, and hard-disabling would take away the one affordance a stuck user has left — the model menu, which describes its own state. The effort and toggle segments are already inert in that state via their existing guards.

Placeholder bars are sized to the labels they stand in for, so the chip does not change shape when the real values land. `animate-pulse` is already covered by the global `prefers-reduced-motion` guard in `index.css`.

## Verification

- `npm run typecheck` clean
- Full suite green: 1682 server + 1290 renderer
- `scripts/check-duplication-gate.sh` PASS
- 5 new tests: 2 on `SplitChip`'s `loading` (hover/aria-busy grouping; presentational-not-disabled), 3 on `ModelPicker` (no fabricated values while loading; whole control busy; resolves on arrival)
- Non-loading `className` output is byte-identical — `Chip.test.tsx` asserts the exact strings and still passes
- Visual gate unaffected: the popup-coverage registry keys on `aria-haspopup` + `manta-*` on the segment buttons, both of which are unchanged in the loading state, and the demo catalog resolves before capture