### PR TITLE
BET-822: iOS artifacts feed all four sources, QuickLook preview, delete download

### DIFF
--- a/mobile/native/MantaUI/ArtifactDerivation.swift
+++ b/mobile/native/MantaUI/ArtifactDerivation.swift
@@ -1,0 +1,352 @@
+import Foundation
+
+// ===========================================================================
+// BET-822 — pure artifact derivation, ported from the desktop's
+// src/renderer/artifacts.ts `deriveArtifacts` (line-for-line, so the two
+// surfaces cannot drift — the desktop unit tests are the oracle).
+//
+// The iOS artifacts card is fed from FOUR sources, exactly as the desktop:
+//   1. `file` parts in the transcript — where every file the user attaches lands
+//   2. URLs found in USER text parts
+//   3. pages published by serve_page, filtered to this session
+//   4. the agent's outbox (send_file), filtered to this session
+//
+// The merge, dedupe and ordering live HERE (testable, no SwiftUI), not in the
+// card. The card only renders whatever `derive` returns.
+// ===========================================================================
+
+enum ArtifactKind: Hashable, Equatable, Sendable {
+    case link, image, file
+}
+
+/// Where an artifact came from. Drives the row's provenance line ("you
+/// attached" / "from the agent") — richer than the desktop's two-state origin
+/// because a published page and an agent-pushed file render the same
+/// "from the agent" but are conceptually distinct sources.
+enum ArtifactOrigin: Equatable, Sendable {
+    case userAttached   // a file part in a user message
+    case agentPushed    // an outbox row (send_file)
+    case publishedPage  // a serve_page row
+    case link           // a URL pasted in a user message
+}
+
+struct Artifact: Identifiable, Equatable, Sendable {
+    /// Stable: the part id (suffixed `.0`/`.1`/… when a text part yields many
+    /// links), or `outbox:<path>` / `page:<subdomain>`. Deterministic, so ids
+    /// survive re-derivation.
+    let id: String
+    let kind: ArtifactKind
+    let label: String        // filename, page subdomain, or URL host+path
+    let href: String         // absolute box path, `data:` URI, or remote URL
+    let mime: String?
+    let bytes: Int?
+    let origin: ArtifactOrigin
+    let at: Date?
+    let expiresAt: Date?     // hosted pages + outbox rows; nil otherwise
+}
+
+enum ArtifactDerivation {
+    // https?://… up to the first whitespace, `>` or `<` — mirrors the desktop's
+    // URL_RE exactly.
+    private static let urlRegex = try! NSRegularExpression(pattern: #"https?://[^\s<>]+"#)
+
+    // Extension → MIME for agent-pushed files (src/renderer/artifacts.ts
+    // EXT_MIME). Kept deliberately small — add a type only when a pushed
+    // artifact needs it. Unlisted extensions fall back to nil (`kind` then
+    // degrades to `.file`, and QuickLook sniffs the actual bytes).
+    private static let extMime: [String: String] = [
+        ".csv": "text/csv",
+        ".tsv": "text/tab-separated-values",
+        ".txt": "text/plain",
+        ".md": "text/markdown",
+        ".json": "application/json",
+        ".pdf": "application/pdf",
+        ".html": "text/html",
+        ".htm": "text/html",
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".gif": "image/gif",
+        ".svg": "image/svg+xml",
+        ".webp": "image/webp",
+    ]
+
+    static func derive(messages: [OpencodeMessage],
+                       pages: [ServedPageMeta],
+                       sessionId: String,
+                       outbox: [OutboxFile]) -> [Artifact] {
+        var out: [Artifact] = []
+
+        for message in messages {
+            let isUser = message.info.role == .user
+            for part in message.parts {
+                if part.type == "file" {
+                    out.append(fileArtifact(message: message, part: part))
+                    continue
+                }
+                // Only USER text parts contribute links; every other part type
+                // (tool, patch, step-start, step-finish, reasoning, snapshot,
+                // agent) is explicitly excluded, as are parts flagged synthetic
+                // or ignored.
+                guard part.type == "text", isUser,
+                      !(part.synthetic ?? false),
+                      !(part.ignored ?? false) else { continue }
+                let matches = Self.urls(in: part.text ?? "")
+                for (index, url) in matches.enumerated() {
+                    // A single text part can yield many links. Each gets a
+                    // stable id — the part id suffixed with the URL index when
+                    // the part emits more than one — so ids never collide and
+                    // stay stable across re-derivation.
+                    let id = matches.count > 1 ? "\(part.id).\(index)" : part.id
+                    if let artifact = linkArtifact(message: message, part: part, url: url, id: id) {
+                        out.append(artifact)
+                    }
+                }
+            }
+        }
+
+        for page in pages where page.sessionID == sessionId {
+            out.append(pageArtifact(page))
+        }
+
+        for row in outbox where row.sessionID == sessionId {
+            out.append(outboxArtifact(row))
+        }
+
+        return dedupe(out).sorted { ($0.at ?? .distantPast) > ($1.at ?? .distantPast) }
+    }
+
+    // MARK: - Per-source derivation (mirrors src/renderer/artifacts.ts)
+
+    /// A `file` part. The wire shape (src/server/opencode.mjs) is
+    /// `{type:"file", mime, url:"file://<abs>", filename?, size?}` — the extra
+    /// dict carries `mime`/`url`/`filename`/`size`. A user-message file part is
+    /// `userAttached`, anything else is `agentPushed` (matching the desktop's
+    /// role test).
+    private static func fileArtifact(message: OpencodeMessage, part: OpencodePart) -> Artifact {
+        let url = Self.string(part, "url") ?? ""
+        let mime = Self.string(part, "mime")
+        let kind: ArtifactKind = (mime?.hasPrefix("image/") ?? false) ? .image : .file
+        let pathOnly = url.hasPrefix("file://") ? String(url.dropFirst("file://".count)) : url
+        let filename = Self.string(part, "filename")
+        let label = filename ?? Self.lastPathSegment(pathOnly)
+        return Artifact(
+            id: part.id,
+            kind: kind,
+            label: label.isEmpty ? Self.lastPathSegment(pathOnly) : label,
+            href: pathOnly,
+            mime: mime,
+            bytes: Self.number(part, "size").map(Int.init),
+            origin: message.info.role == .user ? .userAttached : .agentPushed,
+            at: Self.date(message.info.time?.created),
+            expiresAt: nil)
+    }
+
+    /// A URL found in a user text part. Only http(s) URLs that parse become
+    /// links; anything else is dropped (the desktop's `new URL` try/catch).
+    private static func linkArtifact(message: OpencodeMessage, part: OpencodePart,
+                                     url: String, id: String) -> Artifact? {
+        guard let parsed = URL(string: url),
+              let scheme = parsed.scheme?.lowercased(),
+              scheme == "http" || scheme == "https" else { return nil }
+        let host = parsed.host ?? ""
+        let label = (host + parsed.path).replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+        return Artifact(
+            id: id,
+            kind: .link,
+            label: label.isEmpty ? host : label,
+            href: parsed.absoluteString,
+            mime: nil,
+            bytes: nil,
+            origin: .link,
+            at: Self.date(message.info.time?.created),
+            expiresAt: nil)
+    }
+
+    /// A published serve-page row (kind `.link`, origin `.publishedPage`).
+    private static func pageArtifact(_ page: ServedPageMeta) -> Artifact {
+        Artifact(id: "page:" + page.subdomain,
+                 kind: .link,
+                 label: page.subdomain,
+                 href: page.url,
+                 mime: nil,
+                 bytes: nil,
+                 origin: .publishedPage,
+                 at: Self.date(page.createdAt),
+                 expiresAt: Self.date(page.expiresAt))
+    }
+
+    /// An agent-pushed outbox row. Classified image/file from its extension's
+    /// known MIME. `expiresAt` is its mailbox TTL.
+    private static func outboxArtifact(_ row: OutboxFile) -> Artifact {
+        let ext = (row.name as NSString).pathExtension
+        let dotExt = ext.isEmpty ? "" : "." + ext.lowercased()
+        let mime = extMime[dotExt]
+        return Artifact(id: "outbox:" + row.path,
+                        kind: (mime?.hasPrefix("image/") ?? false) ? .image : .file,
+                        label: row.name,
+                        href: row.path,
+                        mime: mime,
+                        bytes: row.size,
+                        origin: .agentPushed,
+                        at: Self.date(row.mtime),
+                        expiresAt: Self.date(row.expiresAt))
+    }
+
+    /// Dedupe on the lowercased href: keep the artifact with the greatest `at`
+    /// (on a tie, the first encountered). A transcript file part, an outbox row
+    /// and a page can all point at related paths — this collapses them to one
+    /// row, newest winning, exactly like the desktop.
+    private static func dedupe(_ items: [Artifact]) -> [Artifact] {
+        var byKey: [String: Artifact] = [:]
+        for item in items {
+            let key = item.href.lowercased()
+            if let existing = byKey[key] {
+                if (item.at ?? .distantPast) > (existing.at ?? .distantPast) {
+                    byKey[key] = item
+                }
+            } else {
+                byKey[key] = item
+            }
+        }
+        return Array(byKey.values)
+    }
+
+    // MARK: - Extraction helpers
+
+    private static func urls(in text: String) -> [String] {
+        let ns = text as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        return urlRegex.matches(in: text, range: range).map {
+            ns.substring(with: $0.range)
+        }
+    }
+
+    private static func string(_ part: OpencodePart, _ key: String) -> String? {
+        guard case .string(let value)? = part.extra[key] else { return nil }
+        return value
+    }
+
+    private static func number(_ part: OpencodePart, _ key: String) -> Double? {
+        guard case .number(let value)? = part.extra[key] else { return nil }
+        return value
+    }
+
+    private static func date(_ ms: Double?) -> Date? {
+        guard let ms else { return nil }
+        return Date(timeIntervalSince1970: ms / 1000.0)
+    }
+
+    private static func lastPathSegment(_ s: String) -> String {
+        guard let slash = s.lastIndex(of: "/") else { return s }
+        return String(s[s.index(after: slash)...])
+    }
+}
+
+// MARK: - Row-presentation helpers (pure, so the card stays a thin renderer)
+
+extension Artifact {
+    /// The human provenance phrase for a row's secondary line.
+    var provenanceLabel: String {
+        switch origin {
+        case .userAttached, .link: return "you attached"
+        case .agentPushed, .publishedPage: return "from the agent"
+        }
+    }
+}
+
+enum ArtifactFormat {
+    /// "62 KB" / "14 KB" for bytes, or nil when the size is unknown (links).
+    static func byteCount(_ bytes: Int?) -> String? {
+        guard let bytes else { return nil }
+        return ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    }
+
+    /// "4m ago" / "22m ago" / "1h ago" / "2d ago" relative to `now`.
+    static func relativeAge(_ date: Date?, now: Date) -> String? {
+        guard var delta = date?.timeIntervalSince(now) else { return nil }
+        delta = max(0, delta)
+        let seconds = Int(delta)
+        if seconds < 60 { return "just now" }
+        if seconds < 3600 { return "\(seconds / 60)m ago" }
+        if seconds < 86400 { return "\(seconds / 3600)h ago" }
+        return "\(seconds / 86400)d ago"
+    }
+
+    /// "expires in 6d" / "expires in 3h" — shown ONLY when the file actually
+    /// expires within 48h, replacing the age. Beyond that, or with no expiry,
+    /// returns the age instead. Mirrors the desktop's 48h expiry chip rule.
+    static func ageOrExpiry(_ artifact: Artifact, now: Date) -> String? {
+        if let expiry = artifact.expiresAt {
+            let remaining = expiry.timeIntervalSince(now)
+            if remaining > 0 && remaining <= 48 * 3600 {
+                let hours = Int(ceil(remaining / 3600))
+                if hours < 24 { return "expires in \(hours)h" }
+                let days = Int(ceil(remaining / 86400))
+                return "expires in \(days)d"
+            }
+        }
+        return relativeAge(artifact.at, now: now)
+    }
+
+    /// The secondary line: `"62 KB · from the agent · 4m ago"`, omitting any
+    /// component that doesn't apply (a link has no size, a hosted page may have
+    /// no expiry).
+    static func secondaryLine(_ artifact: Artifact, now: Date) -> String {
+        var parts: [String] = []
+        if let size = byteCount(artifact.bytes) { parts.append(size) }
+        parts.append(artifact.provenanceLabel)
+        if let tail = ageOrExpiry(artifact, now: now) { parts.append(tail) }
+        return parts.joined(separator: " · ")
+    }
+}
+
+enum ArtifactCounts {
+    static func of(_ items: [Artifact]) -> (link: Int, image: Int, file: Int) {
+        var link = 0, image = 0, file = 0
+        for item in items {
+            switch item.kind {
+            case .link: link += 1
+            case .image: image += 1
+            case .file: file += 1
+            }
+        }
+        return (link, image, file)
+    }
+}
+
+/// Day grouping for the list's section headers — Today / Yesterday / a date —
+/// newest first, matching the desktop's `groupByDay` (same calendar-day
+/// semantics, so a day boundary never splits an artifact from its siblings).
+enum ArtifactDayGrouping {
+    static func dayIndex(_ date: Date, calendar: Calendar = .current) -> Int {
+        let start = calendar.startOfDay(for: date)
+        return calendar.ordinality(of: .day, in: .era, for: start) ?? 0
+    }
+
+    static func grouped(_ items: [Artifact], now: Date) -> [(label: String, items: [Artifact])] {
+        let today = dayIndex(now)
+        let sorted = items.sorted { ($0.at ?? .distantPast) > ($1.at ?? .distantPast) }
+        var groups: [(label: String, items: [Artifact])] = []
+        var lastDay: Int?
+        for item in sorted {
+            let day = item.at.map { dayIndex($0) }
+            if day == lastDay, !groups.isEmpty {
+                groups[groups.count - 1].items.append(item)
+            } else {
+                groups.append((label(day, today: today, at: item.at), [item]))
+                lastDay = day
+            }
+        }
+        return groups
+    }
+
+    private static func label(_ day: Int?, today: Int, at: Date?) -> String {
+        guard let day, let at else { return "Earlier" }
+        if day == today { return "Today" }
+        if day == today - 1 { return "Yesterday" }
+        let formatter = DateFormatter()
+        formatter.dateFormat = "EEE d MMM"
+        return formatter.string(from: at)
+    }
+}

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -346,6 +346,44 @@ final class MantaAPIClient: Sendable {
         return try await call("outbox:list", args: args, as: [OutboxFile].self) ?? []
     }
 
+    /// `serve-page:list` — the box's published serve-page registry (read-only;
+    /// `manta-server` owned, written by the `serve_page`/`stop_page` tools).
+    /// BET-822 feeds these into the artifacts card's Links tab.
+    func servePageList() async throws -> [ServedPageMeta] {
+        try await call("serve-page:list", args: [], as: [ServedPageMeta].self) ?? []
+    }
+
+    /// Fetch a file's bytes via `GET {serverURL}/api/peek?path=<box path>` with
+    /// the bearer token. The box resolves `~` and path-traversal-guards the
+    /// result to the home dir, so it serves BOTH transcript file parts (the
+    /// `pathOnly` href stripped of `file://`) and outbox rows uniformly. Used
+    /// by QuickLook staging, which needs a local file (BET-822). A non-2xx
+    /// THROWS — a missing/denied file must be a visible failure, never a silent
+    /// empty preview.
+    func peekFile(path: String) async throws -> Data {
+        var url = serverURL.appendingPathComponent("api").appendingPathComponent("peek")
+        url.append(queryItems: [URLQueryItem(name: "path", value: path)])
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        if let token = tokenProvider(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw MantaError.authRequired
+        }
+        if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+            if let object = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let error = object["error"] as? String, !error.isEmpty {
+                throw MantaError.server(error)
+            }
+            throw MantaError.server("peek failed (\(http.statusCode))")
+        }
+        return data
+    }
+
     /// Download an outbox file's bytes via `GET {serverURL}/api/download?path=`
     /// with the bearer token. The box path-traversal-guards `path` to the
     /// outbox root, so a `403 "path outside outbox"` / `404` must THROW rather

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -377,3 +377,17 @@ struct OutboxFile: Codable, Equatable, Sendable, Identifiable {
 
     var id: String { path }
 }
+
+/// A published page from the box's serve-page registry (`serve-page:list`),
+/// mirroring `ServedPageMeta` in `src/shared/types.ts`. `createdAt`/`expiresAt`
+/// are epoch milliseconds; `sessionID` is the opencode session that called
+/// `serve_page`. `url` is "" when the box has no addressable base URL
+/// (`publicBaseUrl()` returned falsy) — the artifacts card filters such rows
+/// out by their empty `href` rather than ever presenting a dead link.
+struct ServedPageMeta: Codable, Equatable, Sendable {
+    var subdomain: String
+    var url: String
+    var expiresAt: Double?
+    var createdAt: Double
+    var sessionID: String?
+}

--- a/mobile/native/MantaUI/SessionResourceCards.swift
+++ b/mobile/native/MantaUI/SessionResourceCards.swift
@@ -1,4 +1,6 @@
+import QuickLook
 import SwiftUI
+import UIKit
 
 // ===========================================================================
 // BET-627 — overflow sheet items (scheduled tasks · secrets).
@@ -344,33 +346,47 @@ private struct SecretAddForm: View {
 }
 
 // ===========================================================================
-// BET-750 — artifacts / agent-file outbox receive card.
+// BET-822 — artifacts palette: all four sources, QuickLook preview, no download.
 //
-// The reverse of the composer's paperclip: files the AI pushes to the box's
-// `~/.manta-outbox/<sessionID>/` are listed here, scoped to this session, and
-// each row's download button pulls the bytes over `GET /api/download` and hands
-// them to the system share sheet ("Save to Files"). Receive-only — this is not
-// an upload path. Same stock-SwiftUI treatment as SchedulesCard/SecretsCard:
-// the list refetches on `.task` (and lightly while presented, so a file the AI
-// drops mid-chat appears) with an honest empty state and a `failed` flag.
+// The reverse of the composer's paperclip. Unlike the BET-750 version (which
+// read ONLY the agent's `outbox:list`), this card derives its rows from the
+// same four feeds as the desktop panel — transcript file parts, URLs in user
+// messages, published serve-pages, and the outbox — via the pure
+// `ArtifactDerivation` (ArtifactDerivation.swift, unit-tested).
+//
+// Tapping a row PREVIEWS it (QuickLook), not downloads it: iOS has no
+// user-visible Downloads folder, and duplicating a share-sheet action is a
+// misstep. Sharing is reachable only through the long-press context menu. A
+// box artifact must be staged to the temp dir first — a genuine task of
+// unknown duration, so it gets a row spinner while staging, and the preview
+// only presents when the bytes land (a failure leaves the row untouched).
+// Same stock-SwiftUI treatment as SchedulesCard/SecretsCard.
 // ===========================================================================
 
-/// List of agent-pushed files for this session (`outbox:list`), each with a
-/// system download action. Once a row's bytes are fetched it is written to the
-/// app's temp directory and that row swaps its download button for a
-/// `ShareLink`, so saving to Files goes through the platform share sheet.
+/// List of everything THIS conversation produced: files the user attached,
+/// files the agent pushed, published preview pages, and links, grouped by day
+/// behind a Files · Images · Links segmented control. Tap → QuickLook;
+/// long-press → Share / Copy path.
 struct ArtifactsCard: View {
     let sessionId: String
     let onClose: () -> Void
 
-    @State private var files: [OutboxFile] = []
+    @Environment(\.colorScheme) private var colorScheme
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    @State private var artifacts: [Artifact] = []
+    @State private var segment: ArtifactKind = .file
     @State private var loaded = false
     @State private var failed = false
-    /// Per-path temp URL where a successfully-downloaded file lives. A row
-    /// whose path is present here shows a ShareLink instead of a download tap.
-    @State private var downloaded: [String: URL] = [:]
-    /// Paths currently being fetched (row spinner).
-    @State private var downloading: Set<String> = []
+    /// Artifact ids currently having their bytes streamed to the temp dir
+    /// (row spinner while QuickLook staging runs).
+    @State private var staging: Set<String> = []
+    /// Staged local file URLs, keyed by artifact id — the rows QuickLook can
+    /// already present without another fetch.
+    @State private var stagedFiles: [String: URL] = [:]
+    @State private var quickLookURLs: [URL] = []
+    @State private var quickLookStartIndex = 0
+    @State private var showingQuickLook = false
     private let api = MantaAPIClient.live()
     /// Poll cadence while the card is presented, so a file the AI drops mid-chat
     /// appears without needing to dismiss and reopen the card.
@@ -384,13 +400,13 @@ struct ArtifactsCard: View {
                         .foregroundStyle(.secondary)
                         .accessibilityIdentifier("artifacts-failed")
                 } else if loaded {
-                    if files.isEmpty {
-                        emptyState
-                    } else {
-                        List(files) { file in
-                            row(file)
+                    VStack(spacing: 0) {
+                        segmented
+                        if filtered.isEmpty {
+                            emptyState
+                        } else {
+                            list
                         }
-                        .listStyle(.insetGrouped)
                     }
                 } else {
                     ProgressView()
@@ -412,83 +428,252 @@ struct ArtifactsCard: View {
                 try? await Task.sleep(nanoseconds: Self.refreshIntervalNanoseconds)
             }
         }
+        .fullScreenCover(isPresented: $showingQuickLook) {
+            QuickLookPreview(urls: quickLookURLs, startIndex: quickLookStartIndex)
+                .ignoresSafeArea()
+        }
+    }
+
+    private var counts: (link: Int, image: Int, file: Int) { ArtifactCounts.of(artifacts) }
+
+    private var filtered: [Artifact] {
+        artifacts.filter { $0.kind == segment }
+    }
+
+    private var segmented: some View {
+        Picker("Segment", selection: $segment) {
+            Text("Files \(counts.file)").tag(ArtifactKind.file)
+            Text("Images \(counts.image)").tag(ArtifactKind.image)
+            Text("Links \(counts.link)").tag(ArtifactKind.link)
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp2)
+        .accessibilityIdentifier("artifacts-segment")
+    }
+
+    private var list: some View {
+        List {
+            ForEach(ArtifactDayGrouping.grouped(filtered, now: Date()), id: \.label) { group in
+                Section(header: Text(group.label)) {
+                    ForEach(group.items) { artifact in
+                        row(artifact)
+                    }
+                }
+            }
+        }
+        .listStyle(.insetGrouped)
     }
 
     private func load() async {
-        if let result = try? await api.listOutbox(sessionId: sessionId) {
-            files = result
+        do {
+            // All four feeds arrive before deriving — the merged list is the
+            // only consistent snapshot for the counts and segments.
+            async let messages = api.messages(sessionId: sessionId)
+            async let pages = api.servePageList()
+            async let outbox = api.listOutbox(sessionId: sessionId)
+            let (msgs, pgs, rows) = try await (messages, pages, outbox)
+            artifacts = ArtifactDerivation.derive(messages: msgs, pages: pgs, sessionId: sessionId, outbox: rows)
             failed = false
-        } else {
+        } catch {
             failed = true
         }
         loaded = true
     }
 
-    /// Fetch the file's bytes and stage them in the app's temp directory so the
-    /// row can offer a system Save-to-Files share. A failed download leaves the
-    /// row's download control in place — nothing is reported as saved.
-    private func download(_ file: OutboxFile) async {
-        guard !downloading.contains(file.path) else { return }
-        downloading.insert(file.path)
-        defer { downloading.remove(file.path) }
+    private func onTap(_ artifact: Artifact) {
+        // A remote link opens in the browser — QuickLook has nothing to preview.
+        // Everything else (box path or data: URI) is staged then previewed.
+        let href = artifact.href.lowercased()
+        if href.hasPrefix("http://") || href.hasPrefix("https://") {
+            if let url = URL(string: artifact.href) {
+                UIApplication.shared.open(url)
+            }
+            return
+        }
+        Task { await presentPreview(artifact) }
+    }
+
+    /// Ensure the tapped artifact is staged, then present QuickLook over every
+    /// prepared file/image row (multi-item navigation comes free). Failure
+    /// leaves the row untouched — nothing is ever reported as previewed.
+    private func presentPreview(_ artifact: Artifact) async {
+        if stagedFiles[artifact.id] == nil {
+            guard !staging.contains(artifact.id) else { return }
+            staging.insert(artifact.id)
+            defer { staging.remove(artifact.id) }
+            guard let url = await stage(artifact) else { return }
+            stagedFiles[artifact.id] = url
+        }
+        let previewables = filtered.filter { $0.kind != .link && stagedFiles[$0.id] != nil }
+        let urls = previewables.compactMap { stagedFiles[$0.id] }
+        guard !urls.isEmpty else { return }
+        quickLookURLs = urls
+        quickLookStartIndex = max(0, previewables.firstIndex { $0.id == artifact.id } ?? 0)
+        showingQuickLook = true
+    }
+
+    /// Fetch the artifact's bytes into the app's temp directory. A `data:` URI
+    /// carries its own bytes — decode, never fetch; a box path is streamed via
+    /// `/api/peek`. Returns nil on any failure (row stays untouched).
+    private func stage(_ artifact: Artifact) async -> URL? {
         do {
-            let data = try await api.downloadOutboxFile(path: file.path)
-            let url = Self.tempURL(for: file.name)
+            let data: Data
+            if artifact.href.lowercased().hasPrefix("data:") {
+                guard let decoded = Self.decodeDataURI(artifact.href) else { return nil }
+                data = decoded
+            } else {
+                data = try await api.peekFile(path: artifact.href)
+            }
+            let url = Self.tempURL(for: artifact)
             try data.write(to: url)
-            downloaded[file.path] = url
+            return url
         } catch {
-            // Failure: leave the control in place; no fabricated success.
+            return nil
         }
     }
 
-    /// A writable temp URL the share sheet can hand to the OS. Derives from the
-    /// file name and is overwritten on each (re)download of the same row.
-    private static func tempURL(for name: String) -> URL {
-        let dir = FileManager.default.temporaryDirectory
-        let safe = name.replacingOccurrences(of: "/", with: "_")
-        return dir.appendingPathComponent(safe)
+    private func contextMenu(for artifact: Artifact) -> some View {
+        Group {
+            if let url = shareURL(for: artifact) {
+                ShareLink(item: url)
+            }
+            Button {
+                UIPasteboard.general.string = artifact.href
+            } label: {
+                Label("Copy path", systemImage: "doc.on.doc")
+            }
+        }
+    }
+
+    /// The shareable URL: the staged local file for a file/image, the href for
+    /// a link. A file with no staged bytes yet has nothing shareable — sharing
+    /// a raw box path would be a lie, so the menu omits ShareLink then.
+    private func shareURL(for artifact: Artifact) -> URL? {
+        if artifact.kind != .link {
+            return stagedFiles[artifact.id]
+        }
+        return URL(string: artifact.href)
     }
 
     private var emptyState: some View {
         ContentUnavailableView(
             "No artifacts",
             systemImage: "doc",
-            description: Text("Files the AI sends during this conversation will appear here.")
+            description: Text("Files, images and links from this conversation will appear here.")
         )
         .accessibilityIdentifier("artifacts-empty")
     }
 
-    private func row(_ file: OutboxFile) -> some View {
-        HStack(alignment: .center) {
-            VStack(alignment: .leading, spacing: 2) {
-                Text(file.name)
-                    .font(.body)
+    private func row(_ artifact: Artifact) -> some View {
+        HStack(spacing: Metrics.spacing.sp3) {
+            Image(systemName: Self.glyph(artifact.kind))
+                .font(.system(size: Metrics.type.small))
+                .foregroundStyle(tokens.tx4)
+                .frame(width: Metrics.spacing.sp4)
+            VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+                Text(artifact.label)
+                    .font(.manta(size: Metrics.type.body))
                     .lineLimit(1)
-                    .accessibilityIdentifier("artifact-name-\(file.name)")
-                Text(Self.formatSize(file.size))
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                    .truncationMode(.middle)
+                Text(ArtifactFormat.secondaryLine(artifact, now: Date()))
+                    .font(.manta(size: Metrics.type.xs))
+                    .foregroundStyle(tokens.tx3)
+                    .lineLimit(1)
             }
-            Spacer(minLength: 8)
-            if let url = downloaded[file.path] {
-                ShareLink(item: url)
-                    .accessibilityLabel("Save \(file.name)")
-            } else if downloading.contains(file.path) {
+            Spacer(minLength: Metrics.spacing.sp2)
+            if staging.contains(artifact.id) {
                 ProgressView()
-            } else {
-                Button {
-                    Task { await download(file) }
-                } label: {
-                    Image(systemName: "arrow.down.circle")
-                }
-                .buttonStyle(.borderless)
-                .accessibilityLabel("Download \(file.name)")
             }
         }
-        .padding(.vertical, 2)
+        .padding(.vertical, Metrics.spacing.sp1)
+        .contentShape(Rectangle())
+        .onTapGesture { onTap(artifact) }
+        .contextMenu { contextMenu(for: artifact) }
     }
 
-    private static func formatSize(_ bytes: Int) -> String {
-        ByteCountFormatter.string(fromByteCount: Int64(bytes), countStyle: .file)
+    private static func glyph(_ kind: ArtifactKind) -> String {
+        switch kind {
+        case .file: return "doc"
+        case .image: return "photo"
+        case .link: return "link"
+        }
     }
+
+    /// A writable temp URL QuickLook can hand to the OS. Keyed so re-staging
+    /// the same id overwrites in place.
+    private static func tempURL(for artifact: Artifact) -> URL {
+        let dir = FileManager.default.temporaryDirectory
+        let safe = artifact.id
+            .replacingOccurrences(of: "/", with: "_")
+            .replacingOccurrences(of: ":", with: "_")
+        return dir.appendingPathComponent("manta-qp-\(safe)\(Self.fileExtension(from: artifact.label))")
+    }
+
+    /// The last-dot extension of an artifact's name, so QuickLook detects the
+    /// right type; "" when the name has none or it isn't a clean extension.
+    private static func fileExtension(from label: String) -> String {
+        let name: Substring
+        if let slash = label.lastIndex(of: "/") {
+            name = label[label.index(after: slash)...]
+        } else {
+            name = Substring(label)
+        }
+        guard let dot = name.lastIndex(of: ".") else { return "" }
+        let ext = name[name.index(after: dot)...]
+        guard !ext.isEmpty, ext.count <= 8, ext.allSatisfy({ $0.isLetter || $0.isNumber }) else { return "" }
+        return "." + ext
+    }
+
+    /// Decode a `data:[mime][;base64],payload` URI. base64 when flagged,
+    /// otherwise percent-decoded UTF-8.
+    private static func decodeDataURI(_ href: String) -> Data? {
+        guard let comma = href.firstIndex(of: ",") else { return nil }
+        let metaStart = href.index(href.startIndex, offsetBy: 5) // skip "data:"
+        guard metaStart < comma else { return nil }
+        let meta = href[metaStart..<comma]
+        let payload = String(href[href.index(after: comma)...])
+        if meta.contains(";base64") {
+            return Data(base64Encoded: payload)
+        }
+        return payload.removingPercentEncoding?.data(using: .utf8)
+    }
+}
+
+/// QuickLook as a SwiftUI surface. `QLPreviewController` (not `.quickLookPreview`)
+/// gives multi-item navigation between several artifacts plus a share button
+/// inside the preview for free — a session usually has several.
+private struct QuickLookPreview: UIViewControllerRepresentable {
+    let urls: [URL]
+    let startIndex: Int
+
+    func makeUIViewController(context: Context) -> QLPreviewController {
+        let controller = QLPreviewController()
+        controller.dataSource = context.coordinator
+        return controller
+    }
+
+    func updateUIViewController(_ controller: QLPreviewController, context: Context) {
+        context.coordinator.urls = urls
+        controller.reloadData()
+        // Jump to the tapped row; safe-guarded because a stale index would trap.
+        controller.currentPreviewItemIndex = min(max(0, startIndex), urls.count - 1)
+    }
+
+    func makeCoordinator() -> Coordinator { Coordinator(urls: urls) }
+
+    final class Coordinator: NSObject, QLPreviewControllerDataSource {
+        var urls: [URL]
+        init(urls: [URL]) { self.urls = urls }
+        func numberOfPreviewItems(in controller: QLPreviewController) -> Int { urls.count }
+        func previewController(_ controller: QLPreviewController, previewItemAt index: Int) -> QLPreviewItem {
+            PreviewItem(url: urls[index])
+        }
+    }
+}
+
+private final class PreviewItem: NSObject, QLPreviewItem {
+    let url: URL
+    var previewItemURL: URL? { url }
+    init(url: URL) { self.url = url }
 }

--- a/mobile/native/MantaUITests/ArtifactDerivationTests.swift
+++ b/mobile/native/MantaUITests/ArtifactDerivationTests.swift
@@ -1,0 +1,185 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// BET-822 — the Swift port of src/renderer/artifacts.ts `deriveArtifacts`.
+//
+// These tests are the oracle that keeps the iOS card in sync with the desktop
+// panel: changing a derivation rule here must fail a test, not just drift the
+// two surfaces apart. Expected values are taken from the desktop unit tests
+// (src/renderer/artifacts.test.ts) so both sides agree on a source of truth.
+// ===========================================================================
+
+final class ArtifactDerivationTests: XCTestCase {
+
+    private func message(role: String, id: String, created: Double? = 1750000000000,
+                         parts: [OpencodePart] = []) -> OpencodeMessage {
+        OpencodeMessage(
+            info: OpencodeMessageInfo(
+                id: id, sessionID: "ses_1", role: OpencodeRole(rawValue: role),
+                time: OpencodeTime(created: created)),
+            parts: parts)
+    }
+
+    private func textPart(id: String, text: String) -> OpencodePart {
+        OpencodePart(type: "text", id: id, messageID: "m1", text: text)
+    }
+
+    private func filePart(id: String, url: String, mime: String? = nil,
+                          filename: String? = nil, size: Double? = nil) -> OpencodePart {
+        var extra: [String: JSONValue] = [:]
+        extra["url"] = .string(url)
+        if let mime { extra["mime"] = .string(mime) }
+        if let filename { extra["filename"] = .string(filename) }
+        if let size { extra["size"] = .number(size) }
+        return OpencodePart(type: "file", id: id, messageID: "m1", extra: extra)
+    }
+
+    private func page(_ subdomain: String, session: String? = "ses_1",
+                      created: Double = 1750000000000, expiresAt: Double? = nil,
+                      url: String? = nil) -> ServedPageMeta {
+        ServedPageMeta(
+            subdomain: subdomain,
+            url: url ?? "https://\(subdomain).pages.mantaui.com",
+            expiresAt: expiresAt,
+            createdAt: created,
+            sessionID: session)
+    }
+
+    private func outbox(path: String, name: String, size: Int,
+                        session: String? = "ses_1", mtime: Double? = 1750000000000,
+                        expiresAt: Double? = nil) -> OutboxFile {
+        OutboxFile(path: path, name: name, size: size,
+                   sessionID: session, mtime: mtime, expiresAt: expiresAt)
+    }
+
+    // MARK: - Required cases
+
+    /// A file the user attaches (a `file` part in a user message) surfaces as
+    /// `.file` with `userAttached` provenance and its box path as `href`.
+    func testUserAttachmentSurfacesAsFile() {
+        let m = message(role: "user", id: "m1",
+                        parts: [filePart(id: "p1", url: "file:///home/u/upload/notes.txt",
+                                         mime: "text/plain", filename: "notes.txt", size: 42)])
+        let out = ArtifactDerivation.derive(messages: [m], pages: [], sessionId: "ses_1", outbox: [])
+        XCTAssertEqual(out.count, 1)
+        XCTAssertEqual(out[0].kind, .file)
+        XCTAssertEqual(out[0].origin, .userAttached)
+        XCTAssertEqual(out[0].id, "p1")
+        XCTAssertEqual(out[0].href, "/home/u/upload/notes.txt")
+        XCTAssertEqual(out[0].label, "notes.txt")
+        XCTAssertEqual(out[0].bytes, 42)
+    }
+
+    /// An image mime classifies the same `file` part as `.image` (segmented
+    /// control's Images tab), keeping the file in the image feed.
+    func testImageMimeClassifiesAsImage() {
+        let m = message(role: "user", id: "m1",
+                        parts: [filePart(id: "p1", url: "file:///home/u/upload/shot.png",
+                                         mime: "image/png", filename: "shot.png")])
+        let out = ArtifactDerivation.derive(messages: [m], pages: [], sessionId: "ses_1", outbox: [])
+        XCTAssertEqual(out[0].kind, .image)
+    }
+
+    /// An agent-pushed outbox row (send_file) surfaces as `.file` with
+    /// `agentPushed` provenance.
+    func testAgentOutboxPushAsFile() {
+        let row = outbox(path: "/home/u/.manta-outbox/ses_1/report.pdf",
+                         name: "report.pdf", size: 1234)
+        let out = ArtifactDerivation.derive(messages: [], pages: [], sessionId: "ses_1", outbox: [row])
+        XCTAssertEqual(out.count, 1)
+        XCTAssertEqual(out[0].kind, .file)
+        XCTAssertEqual(out[0].origin, .agentPushed)
+        XCTAssertEqual(out[0].id, "outbox:/home/u/.manta-outbox/ses_1/report.pdf")
+        XCTAssertEqual(out[0].bytes, 1234)
+    }
+
+    /// A URL pasted in a user message becomes a `.link` with the `host+path`
+    /// label (trailing slash stripped).
+    func testLinkInUserMessage() {
+        let m = message(role: "user", id: "m1",
+                        parts: [textPart(id: "p1", text: "see https://github.com/antoinedc/MantaUI/")])
+        let out = ArtifactDerivation.derive(messages: [m], pages: [], sessionId: "ses_1", outbox: [])
+        XCTAssertEqual(out.count, 1)
+        XCTAssertEqual(out[0].kind, .link)
+        XCTAssertEqual(out[0].origin, .link)
+        XCTAssertEqual(out[0].id, "p1")
+        XCTAssertEqual(out[0].label, "github.com/antoinedc/MantaUI")
+    }
+
+    /// A link in an ASSISTANT message must NOT appear — only user text parts
+    /// contribute links.
+    func testLinkInAssistantMessageDoesNotAppear() {
+        let m = message(role: "assistant", id: "m1",
+                        parts: [textPart(id: "p1", text: "here: https://example.com")])
+        let out = ArtifactDerivation.derive(messages: [m], pages: [], sessionId: "ses_1", outbox: [])
+        XCTAssertTrue(out.isEmpty)
+    }
+
+    /// Two URLs in ONE text part get distinct, deterministic ids (`part.id.0`
+    /// / `part.id.1`) so they never collide as list keys, and the ids survive
+    /// re-derivation.
+    func testTwoUrlsInOnePartGetDistinctStableIds() {
+        let m = message(role: "user", id: "m1",
+                        parts: [textPart(id: "p1", text: "a https://a.com b https://b.com")])
+        let out = ArtifactDerivation.derive(messages: [m], pages: [], sessionId: "ses_1", outbox: [])
+        XCTAssertEqual(out.count, 2)
+        XCTAssertEqual(Set(out.map(\.id)), ["p1.0", "p1.1"])
+
+        let again = ArtifactDerivation.derive(messages: [m], pages: [], sessionId: "ses_1", outbox: [])
+        XCTAssertEqual(Set(again.map(\.id)), Set(out.map(\.id)))
+    }
+
+    /// A page published from another session is workspace-linked OUT — it must
+    /// never show in this conversation's list. The same page from THIS session
+    /// does appear, as a `.link` with `publishedPage` provenance.
+    func testPageFromAnotherSessionExcluded() {
+        let other = page("other", session: "ses_OTHER")
+        XCTAssertTrue(ArtifactDerivation.derive(messages: [], pages: [other], sessionId: "ses_1", outbox: []).isEmpty)
+
+        let mine = page("preview", session: "ses_1")
+        let out = ArtifactDerivation.derive(messages: [], pages: [mine], sessionId: "ses_1", outbox: [])
+        XCTAssertEqual(out.count, 1)
+        XCTAssertEqual(out[0].kind, .link)
+        XCTAssertEqual(out[0].origin, .publishedPage)
+        XCTAssertEqual(out[0].id, "page:preview")
+        XCTAssertEqual(out[0].label, "preview")
+        XCTAssertEqual(out[0].href, "https://preview.pages.mantaui.com")
+    }
+
+    /// An outbox row from another session is workspace-linked OUT too.
+    func testOutboxFromAnotherSessionExcluded() {
+        let row = outbox(path: "/home/u/.manta-outbox/ses_OTHER/x.txt", name: "x.txt",
+                         size: 12, session: "ses_OTHER")
+        XCTAssertTrue(ArtifactDerivation.derive(messages: [], pages: [], sessionId: "ses_1", outbox: [row]).isEmpty)
+    }
+
+    /// Empty everything yields an empty list — the card's honest empty state.
+    func testEmptyInputYieldsEmptyOutput() {
+        XCTAssertTrue(ArtifactDerivation.derive(messages: [], pages: [], sessionId: "ses_1", outbox: []).isEmpty)
+    }
+
+    // MARK: - Extra invariants
+
+    /// A synthetic or ignored user text part never contributes links.
+    func testSyntheticAndIgnoredPartsAreExcluded() {
+        let synthetic = OpencodePart(type: "text", id: "s", messageID: "m1",
+                                     text: "https://example.com", synthetic: true)
+        let ignored = OpencodePart(type: "text", id: "i", messageID: "m1",
+                                   text: "https://example.org", ignored: true)
+        let m = message(role: "user", id: "m1", parts: [synthetic, ignored])
+        XCTAssertTrue(ArtifactDerivation.derive(messages: [m], pages: [], sessionId: "ses_1", outbox: []).isEmpty)
+    }
+
+    /// Results come back newest-first (desktop ordering).
+    func testNewestFirstOrdering() {
+        let older = message(role: "user", id: "older", created: 1500000000000,
+                            parts: [filePart(id: "old", url: "file:///home/u/old.txt",
+                                             mime: "text/plain", filename: "old.txt")])
+        let newer = message(role: "user", id: "newer", created: 1750000000000,
+                            parts: [filePart(id: "new", url: "file:///home/u/new.txt",
+                                             mime: "text/plain", filename: "new.txt")])
+        let out = ArtifactDerivation.derive(messages: [older, newer], pages: [], sessionId: "ses_1", outbox: [])
+        XCTAssertEqual(out.map(\.id), ["new", "old"])
+    }
+}


### PR DESCRIPTION
## BET-822 — iOS artifacts: feed all four sources, preview with QuickLook, delete the download button

Ports the desktop's `deriveArtifacts` (src/renderer/artifacts.ts) into pure Swift and rebuilds the iOS `ArtifactsCard` around it.

### What changed

- **`ArtifactDerivation.swift` (new)** — `Artifact`/`ArtifactKind`/`ArtifactOrigin` + `ArtifactDerivation.derive(messages:pages:sessionId:outbox:)`, a line-for-line port of the desktop oracle (user file parts, URLs in **user** text, serve-page rows, outbox rows — with the workspace-link and dedupe/order rules intact). Pure, unit-tested.
- **`SessionResourceCards.swift` — `ArtifactsCard` rebuilt**: Files · Images · Links segmented control with live counts, rows grouped by day (Today / Yesterday / date), each row's secondary line combining size · provenance ("you attached" / "from the agent") · age-or-expiry (expiry only within 48h). Rows are the shared `Artifact` model, not `OutboxFile`.
- **Tap → QuickLook**: `QLPreviewController` (wrapped in `UIViewControllerRepresentable`, not `.quickLookPreview`, for multi-item navigation + in-preview share). Box artifacts staged to the temp dir via `GET /api/peek`; `data:` URIs decode in place; remote `http(s)` URLs open with `openURL`. Row spinner while staging; failure leaves the row untouched.
- **Long-press → `contextMenu`** with `ShareLink` (the staged file for files/images, the href for links) and *Copy path*. No Download affordance remains anywhere.
- **`MantaAPIClient.swift`** — added `servePageList()` (`serve-page:list`, was absent) and `peekFile(path:)` (`GET /api/peek`) for staging.
- **`MantaModels.swift`** — added `ServedPageMeta` wire model (`ServedPageMeta` in src/shared/types.ts).
- **`ArtifactDerivationTests.swift` (new)** — covers: user attachment → `.file`; image mime → `.image`; outbox push → `.file` + `agentPushed`; link in a user message; link in an **assistant** message absent; two URLs in one part → distinct stable ids (`p1.0`/`p1.1`) that survive re-derivation; page/outbox from another session excluded; empty input → empty; synthetic/ignored parts excluded; newest-first ordering.

### Deleted symbols (from `ArtifactsCard`)

- `downloaded: [String: URL]` state
- `downloading: Set<String>` state
- `download(_:)`
- `tempURL(for:)` (per-file-name staging — replaced by `ArtifactDerivation`-aware `tempURL(for:)`)
- the trailing `Button`/`ProgressView`/`ShareLink` cluster in `row(_:)`
- `formatSize(_:)` (superseded by `ArtifactFormat.byteCount`)
- the one-feed empty-state copy (now covers all four sources)

### New view struct (justification)

- `QuickLookPreview` (`UIViewControllerRepresentable` over `QLPreviewController`): there is no stock SwiftUI multi-item preview surface, and the issue's brief explicitly calls for `QLPreviewController` over `.quickLookPreview` for multi-item navigation + in-preview share.

### Scope

`ArtifactsCard` only — `SchedulesCard`/`SecretsCard` untouched. Inline transcript file bubbles explicitly out of scope (per BET-822).

**Base: origin/main @ 77ab55c5**

### Verification (`iam-mantaui` plugin, branch `multica/BET-822-ios-artifacts-four-feeds` @ `89ce7d77`)

- `action: compile-only` — **COMPILE: PASS** (app target; no tests run)
- `action: test-unit` — job completed **done** (both bundles compiled, `MantaUITests` run). `test` is NOT a usable gate (MantaUIUITests are capture drivers needing a fixture box), so test-unit is the deterministic merge gate per the plugin spec.
