### PR TITLE
feat(renderer): PR on the branch chip + checks chip + connect offer (BET-789)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -19,9 +19,12 @@ import type { VirtuosoHandle } from "react-virtuoso";
 import { Clock, X } from "lucide-react";
 import type {
   AvailableLauncher,
+  CheckRollup,
   DelegateApproval,
   DelegateApprovalTool,
+  ForgeCheckRun,
   OpencodeModel,
+  PullRequest,
   QuestionRequest,
 } from "../shared/types";
 import { useStore } from "./store";
@@ -166,6 +169,9 @@ export function ChatPanel({
   const configDefaultModel = useStore((s) => s.defaultModel);
   const deactivatedMainModels = useStore((s) => s.deactivatedMainModels);
   const hiddenStatusItems = useStore((s) => s.hiddenStatusItems);
+  // BET-789: the "Connect GitHub…" offer's per-box dismissal flag. Once set,
+  // the offer never re-appears until the config flag is cleared.
+  const forgeConnectOfferDismissed = useStore((s) => s.forgeConnectOfferDismissed);
   // User-configured Anthropic prompt cache TTL — drives the "/clear to
   // save Nk tokens" pill when the session has been idle past this TTL.
   // manta doesn't set the real cache_control.ttl on requests; this is the
@@ -501,15 +507,67 @@ export function ChatPanel({
     };
   }, [sessionId, cwd]);
 
+  // BET-789: forge read path, consumed by SessionHeader. Refreshed on the SAME
+  // timer as the branch indicator (the issue forbids a second poll — a second
+  // timer for the same question is a duplicate code path). Nothing in this
+  // state renders chrome by itself: no PR / no checks → the checks chip is not
+  // registered; forge connected or not a forge origin → no connect offer.
+  const [forge, setForge] = useState<{
+    connected: boolean;
+    kind: string | null;
+    pr: PullRequest | null;
+    checks: ForgeCheckRun[];
+    rollup: CheckRollup;
+  }>({ connected: false, kind: null, pr: null, checks: [], rollup: "none" });
+  const refreshForge = useCallback(async (cwdArg: string) => {
+    try {
+      const [status, prResult] = await Promise.all([
+        window.api.forgeStatus(),
+        window.api.forgePullRequest({ cwd: cwdArg }),
+      ]);
+      setForge({
+        // `status` is a union; both variants carry `connected`.
+        connected: status.connected,
+        // The origin is a recognised forge whenever the read path got far
+        // enough to classify it: "not_connected" is recognised-but-unauth'd
+        // (exactly the connect-offer trigger), "no_forge" is not a forge at
+        // all. github is the only adapter today.
+        kind: prResult.error !== "no_forge" ? "github" : null,
+        pr: prResult.pr,
+        checks: prResult.checks ?? [],
+        rollup: prResult.rollup ?? "none",
+      });
+    } catch {
+      // non-fatal — the forge read path is best-effort; keep last-known.
+    }
+  }, []);
+
+  // BET-789: dismiss the "Connect GitHub…" offer permanently, per-box. Mirror
+  // of AppConfig.forgeConnectOfferDismissed, written through the generic
+  // configUpdate channel (no new RPC). Optimistic store write so the offer
+  // disappears immediately; the config write persists it across restarts.
+  const dismissForgeConnect = useCallback(async () => {
+    useStore.setState({ forgeConnectOfferDismissed: true });
+    try {
+      await window.api.configUpdate({ forgeConnectOfferDismissed: true });
+    } catch {
+      // persistent across restarts is best-effort; the optimistic hide stands.
+    }
+  }, []);
+
   // Branch indicator: poll every 5s while this session is visible. Gated on
   // isActive — hidden panels stop polling; the effect re-fires (one
   // refreshBranch on entry) when isActive flips back on.
   useEffect(() => {
     if (!isActive) return;
     refreshBranch(cwd);
-    const branchPoll = setInterval(() => refreshBranch(cwd), 5000);
+    void refreshForge(cwd);
+    const branchPoll = setInterval(() => {
+      refreshBranch(cwd);
+      void refreshForge(cwd);
+    }, 5000);
     return () => clearInterval(branchPoll);
-  }, [cwd, refreshBranch, isActive]);
+  }, [cwd, refreshBranch, isActive, refreshForge]);
 
   // Ctrl+O toggles reasoning visibility. Matches Claude Code's TUI keybind.
   useEffect(() => {
@@ -754,6 +812,9 @@ export function ChatPanel({
     setInput("");
     // Snap the branch indicator to current truth on every submit.
     refreshBranch(cwd);
+    // Forge state rides the same "ask the box" moment — a submit is the other
+    // trigger (with the branch poll) for re-deriving the session's PR/checks.
+    void refreshForge(cwd);
     // If the pinned todo list is fully terminal, hide the stale checklist.
     if (activeTodosRef.current && allTodosTerminal(activeTodosRef.current)) {
       setTodosDismissed(true);
@@ -2137,6 +2198,15 @@ export function ChatPanel({
         artifactsOpen={artifactsOpen}
         onToggleArtifacts={onToggleArtifacts}
         hiddenStatusItems={hiddenStatusItems}
+        pr={forge.pr}
+        checks={forge.checks}
+        checksRollup={forge.rollup}
+        forgeConnected={forge.connected}
+        forgeKind={forge.kind}
+        forgeConnectOfferDismissed={forgeConnectOfferDismissed}
+        onOpenExternal={(url) => void window.api.openExternal(url)}
+        onFillComposer={updateInputWithHistoryReset}
+        onDismissForgeConnect={dismissForgeConnect}
       />
 
       <Transcript

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -23,17 +23,25 @@ import {
   cssVar,
   moveMenuHighlight,
   selectStatusItems,
+  checksChipDescriptor,
+  countsForChecks,
+  shouldOfferForgeConnect,
+  failuresToAgentPrompt,
+  type ChecksChipTone,
   type ContextBreakdown,
   type StaleCacheResult,
   type StatusItem,
 } from "./chatUtils";
 import { useClickAway } from "./hooks/useClickAway";
 import type { SessionMode } from "./chatShared";
-import type { AvailableLauncher } from "../shared/types";
+import type { AvailableLauncher, CheckRollup, ForgeCheckRun, PullRequest } from "../shared/types";
 import { Button } from "./Button";
 import { IconButton } from "./IconButton";
 import { Pill } from "./Pill";
 import { Tag } from "./Tag";
+import { Chip } from "./Chip";
+import { StatusDot } from "./StatusDot";
+import { Callout } from "./Callout";
 import { Dropdown, MenuItem } from "./MenuItem";
 import { ConfirmModal } from "./ConfirmModal";
 
@@ -76,6 +84,15 @@ export function SessionHeader({
   artifactsOpen,
   onToggleArtifacts,
   hiddenStatusItems,
+  pr,
+  checks,
+  checksRollup,
+  forgeConnected,
+  forgeKind,
+  forgeConnectOfferDismissed,
+  onOpenExternal,
+  onFillComposer,
+  onDismissForgeConnect,
 }: {
   branch: string | null;
   ctxBreakdown: ContextBreakdown;
@@ -116,6 +133,22 @@ export function SessionHeader({
   // bar or the overflow. Optional so the prop doesn't break callers that
   // haven't wired the setting yet.
   hiddenStatusItems?: string[];
+  // BET-789: forge read path, consumed from ChatPanel (which owns the fetch)
+  // and threaded down so this component stays presentational. `pr` + `checks`
+  // + `checksRollup` drive the PR-on-branch suffix and the checks chip;
+  // `forgeConnected` + the session origin's `forgeKind` + the permanently-
+  // dismissed flag drive the one-line connect offer. All optional with
+  // forge-absent defaults so non-forge callers (tests, mobile) stay
+  // byte-identical to today.
+  pr?: PullRequest | null;
+  checks?: ForgeCheckRun[];
+  checksRollup?: CheckRollup;
+  forgeConnected?: boolean;
+  forgeKind?: string | null;
+  forgeConnectOfferDismissed?: boolean;
+  onOpenExternal?: (url: string) => void;
+  onFillComposer?: (text: string) => void;
+  onDismissForgeConnect?: () => void;
 }) {
   const { pct, segments, freshInput, cacheRead, cacheWrite, totalInput } =
     ctxBreakdown;
@@ -133,6 +166,23 @@ export function SessionHeader({
   // BET-724 §D7: the confirm dialogs for Delete/Clear name the session — the
   // window name reads better than the full "project / window" breadcrumb.
   const sessionName = breadcrumb?.window ?? breadcrumb?.project ?? "this session";
+
+  // BET-789: the checks chip is the ONE new status item, registered only when
+  // there is a PR with checks and a non-empty rollup. No PR / no checks / forge
+  // not connected → the descriptor is null → nothing is registered (§4.3 [C2]):
+  // connecting GitHub adds no chrome by itself.
+  const checksCounts = countsForChecks(checks ?? []);
+  const checksDesc =
+    pr && checks && checks.length > 0
+      ? checksChipDescriptor(checksRollup ?? "none", checksCounts)
+      : null;
+  // The one-line connect offer — only in a forge-origin session while the
+  // forge is disconnected and the offer has not been permanently dismissed.
+  const offerConnect = shouldOfferForgeConnect({
+    connected: forgeConnected ?? false,
+    forgeKind: forgeKind ?? null,
+    dismissed: forgeConnectOfferDismissed ?? false,
+  });
 
   // ===== Status-item registry (BET-782) =====
   // The right group is a REGISTRY, not hand-ordered JSX. Each entry is a
@@ -169,6 +219,26 @@ export function SessionHeader({
   }, []);
 
   const registry: StatusItem[] = [];
+  // Checks sits FIRST in construction order so it is the leftmost item of the
+  // right group at wide widths (§4.5① [C3]: checks, context, artifacts, menu).
+  // Its priority is a function of state (§4.3): red is pinned (never auto-hidden,
+  // so it survives the narrow layout while the branch chip is displaced), green/
+  // yellow overflow first.
+  if (checksDesc) {
+    registry.push({
+      id: "checks",
+      priority: checksDesc.priority,
+      render: () => (
+        <ChecksChip
+          descriptor={checksDesc}
+          checks={checks ?? []}
+          pr={pr ?? null}
+          onOpenExternal={onOpenExternal}
+          onFillComposer={onFillComposer}
+        />
+      ),
+    });
+  }
   if (showContext) {
     registry.push({
       id: "context",
@@ -235,11 +305,12 @@ export function SessionHeader({
   );
 
   return (
-    <div
-      ref={headerRef}
-      className="manta-session-header flex items-center gap-2 h-11 pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] border-b border-border shrink-0 min-w-0"
-      style={{ WebkitAppRegion: "drag" } as CSSProperties}
-    >
+    <>
+      <div
+        ref={headerRef}
+        className="manta-session-header flex items-center gap-2 h-11 pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] border-b border-border shrink-0 min-w-0"
+        style={{ WebkitAppRegion: "drag" } as CSSProperties}
+      >
       {/* Breadcrumb — workspace / session. This names WHERE YOU ARE, and it is
             the header's primary job: one window shows many sessions across
             many workspaces, and the branch alone does not identify one. It is
@@ -254,16 +325,22 @@ export function SessionHeader({
       )}
 
       {/* Branch chip — session state, at the `sm` tag density so it reads as
-            metadata beside the breadcrumb rather than as a control. */}
-      {branch && (
-        <Tag
-          size="sm"
-          icon={<GitBranch size={11} aria-hidden="true" className="shrink-0" />}
-          title={`Current branch: ${branch}`}
-        >
-          <span className="shrink-0 truncate max-w-[200px]">{branch}</span>
-        </Tag>
-      )}
+            metadata beside the breadcrumb rather than as a control. When an
+            open PR rides the branch, the chip becomes interactive and opens the
+            PR popover [C7] (the PR is an ATRIBUTE of the branch, not a peer of
+            it — no second PR chip, §4.3). No PR → byte-identical to today [C2]. */}
+      {branch &&
+        (pr ? (
+          <BranchChip branch={branch} pr={pr} onOpenExternal={onOpenExternal} />
+        ) : (
+          <Tag
+            size="sm"
+            icon={<GitBranch size={11} aria-hidden="true" className="shrink-0" />}
+            title={`Current branch: ${branch}`}
+          >
+            <span className="shrink-0 truncate max-w-[200px]">{branch}</span>
+          </Tag>
+        ))}
 
       {/* Right group — the registry's visible items + the overflow trigger.
             Order preserves today's wide-width visual (context, artifacts,
@@ -280,7 +357,13 @@ export function SessionHeader({
 
         {overflow.length > 0 && <StatusOverflow items={overflow} />}
       </div>
-    </div>
+      </div>
+
+      {/* BET-789 §4.5 [S10]: the one-line contextual connect offer, under the
+            header bar (never a modal / toast / Settings badge). Only in a
+            forge-origin session while disconnected and not dismissed. */}
+      {offerConnect && <ConnectOffer onDismiss={onDismissForgeConnect} />}
+    </>
   );
 }
 
@@ -832,6 +915,325 @@ function SessionMenu({
         }}
         onCancel={() => setConfirm(null)}
       />
+    </div>
+  );
+}
+
+// ===== Click-popover chip host (BET-789) =====
+//
+// Shared trigger + popover shell for the interactive header chips (branch with
+// a PR, and the checks chip). Same sibling-under-positioned-wrapper contract
+// as ContextPill — trigger and panel are SIBLINGS, never parent/child (so the
+// trigger's click can't close the panel it opens, and no button-in-button).
+// `useClickAway` handles outside-click and Escape-close; Escape additionally
+// hands focus back to the trigger chip. The panel only mounts while open, so
+// no aria-hidden dance on a closed-but-present surface. This is the "surface
+// exists only while open, closes and restores focus" requirement (§8.4 — an
+// actionable hover card would fail it, so this is click-only).
+function PopoverChip({
+  trigger,
+  panel,
+  ariaLabel,
+  triggerClassName,
+}: {
+  trigger: React.ReactNode;
+  panel: React.ReactNode;
+  ariaLabel: string;
+  triggerClassName?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const rootRef = useRef<HTMLDivElement>(null);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  useClickAway(rootRef, open, () => setOpen(false));
+  return (
+    <div
+      ref={rootRef}
+      className="relative shrink-0"
+      style={{ WebkitAppRegion: "no-drag" } as CSSProperties}
+      onKeyDown={(e) => {
+        // useClickAway also closes on Escape (document-level); this branch is
+        // what additionally returns focus to the trigger (mirrors SessionMenu).
+        if (e.key === "Escape" && open) {
+          setOpen(false);
+          triggerRef.current?.focus();
+        }
+      }}
+    >
+      <button
+        ref={triggerRef}
+        type="button"
+        onClick={() => setOpen((v) => !v)}
+        aria-haspopup="dialog"
+        aria-expanded={open}
+        aria-label={ariaLabel}
+        className={triggerClassName}
+      >
+        {trigger}
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-label={ariaLabel}
+          className="manta-ctx-popover manta-menu-in absolute right-0 top-full mt-1 z-30 w-[360px] rounded-lg border border-border bg-bg-soft shadow-md"
+        >
+          {panel}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ===== Branch + PR popover chip (BET-789 [C3] [C7]) =====
+//
+// The PR rides the branch chip — it is an attribute of the branch, not a peer
+// of it. `⎇ feat/forge-seam` becomes `⎇ feat/forge-seam · #412` and, with a PR
+// present, opens a popover carrying the PR's title, state, head→base refs,
+// reviewers, unresolved-thread count and — the payload of this feature — the
+// mergeability REASON (never "can't merge" alone, §4.3). Without a PR the
+// branch renders as the plain non-interactive Tag (byte-identical to today).
+function BranchChip({
+  branch,
+  pr,
+  onOpenExternal,
+}: {
+  branch: string;
+  pr: PullRequest;
+  onOpenExternal?: (url: string) => void;
+}) {
+  return (
+    <PopoverChip
+      ariaLabel={`Pull request #${pr.number}: ${pr.title}`}
+      triggerClassName="manta-branch-chip rounded-full p-0 border-0 bg-transparent transition-colors hover:bg-fill-hover"
+      trigger={
+        <Tag
+          size="sm"
+          icon={<GitBranch size={11} aria-hidden="true" className="shrink-0" />}
+          title={`Current branch: ${branch} — pull request #${pr.number}`}
+        >
+          <span className="shrink-0 truncate max-w-[200px]">
+            {branch} · #{pr.number}
+          </span>
+        </Tag>
+      }
+      panel={<BranchPanel pr={pr} onOpenExternal={onOpenExternal} />}
+    />
+  );
+}
+
+// One definition-list row in the PR popover: label left in faint, value
+// right-aligned in muted; the mergeability value is the one that takes a
+// colour (that colour IS the payload, §8.4 [C7]).
+function PanelRow({
+  label,
+  value,
+  valueClass,
+}: {
+  label: string;
+  value: string;
+  valueClass?: string;
+}) {
+  return (
+    <div className="flex items-center gap-2 py-1 text-[13px]">
+      <span className="text-text-faint">{label}</span>
+      <span
+        className={`ml-auto min-w-0 truncate font-mono text-xs font-medium text-text-muted ${
+          valueClass ?? ""
+        }`}
+      >
+        {value}
+      </span>
+    </div>
+  );
+}
+
+function BranchPanel({
+  pr,
+  onOpenExternal,
+}: {
+  pr: PullRequest;
+  onOpenExternal?: (url: string) => void;
+}) {
+  // mergeBlockedReason is the payload — "checks failing", "conflicts",
+  // "review required", "draft" — displayed in danger. Only when there is no
+  // reason does it fall back to a status the forge itself reports.
+  const mergeable = pr.mergeBlockedReason
+    ? { text: pr.mergeBlockedReason, className: "text-danger" }
+    : pr.mergeable === true
+      ? { text: "mergeable", className: "text-ok" }
+      : { text: "computing…", className: "text-text-faint" };
+  return (
+    <div className="p-3">
+      <div className="mb-[3px] truncate text-[13.5px] font-semibold leading-snug text-text">
+        #{pr.number} {pr.title}
+      </div>
+      <div className="mb-2 text-xs text-text-faint">
+        {pr.state} · {pr.headRef} → {pr.baseRef}
+      </div>
+      <div className="flex flex-col">
+        <PanelRow
+          label="Reviewers"
+          value={pr.reviewers.length > 0 ? pr.reviewers.join(", ") : "none"}
+        />
+        <PanelRow label="Unresolved threads" value={String(pr.unresolvedThreads)} />
+        <PanelRow label="Mergeable" value={mergeable.text} valueClass={mergeable.className} />
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-2">
+        {/* "Review changes" is inert in BET-789 — a later issue wires it. */}
+        <Button tone="default">Review changes</Button>
+        {onOpenExternal && (
+          <Button tone="default" onClick={() => onOpenExternal(pr.url)}>
+            Open on GitHub ↗
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ===== Checks chip + popover (BET-789 [C3] [C4] [C6]) =====
+//
+// The checks chip is the ONE new status item (§4.3): colour AND glyph, never
+// colour alone — `✓ 7`, `✗ 2 failed`, `◐ 3 running`. Its tone + priority are
+// a function of state (see checksChipDescriptor). It opens on CLICK (never
+// hover — it carries a link + an action), and its popover lists failing checks
+// first, then a `+ N passed` collapse row.
+const CHECK_TONE_CLASS: Record<ChecksChipTone, string> = {
+  ok: "border-ok/40 bg-ok-bg text-ok",
+  warn: "border-warn/40 bg-warn-bg text-warn",
+  danger: "border-danger/40 bg-danger-bg text-danger",
+};
+
+function ChecksChip({
+  descriptor,
+  checks,
+  pr,
+  onOpenExternal,
+  onFillComposer,
+}: {
+  descriptor: { label: string; tone: ChecksChipTone; priority: number };
+  checks: ForgeCheckRun[];
+  pr: PullRequest | null;
+  onOpenExternal?: (url: string) => void;
+  onFillComposer?: (text: string) => void;
+}) {
+  return (
+    <PopoverChip
+      ariaLabel={`Checks: ${descriptor.label}`}
+      triggerClassName={`manta-checks-chip inline-flex h-5 items-center gap-1 whitespace-nowrap rounded-full border px-2 font-mono text-[11px] font-medium leading-none ${CHECK_TONE_CLASS[descriptor.tone]}`}
+      trigger={<span>{descriptor.label}</span>}
+      panel={
+        <ChecksPanel
+          checks={checks}
+          pr={pr}
+          onOpenExternal={onOpenExternal}
+          onFillComposer={onFillComposer}
+        />
+      }
+    />
+  );
+}
+
+function CheckRow({
+  name,
+  meta,
+  tone,
+}: {
+  name: string;
+  meta: string;
+  tone: "ok" | "running" | "error" | "idle";
+}) {
+  return (
+    <div className="flex items-center gap-2 rounded-md px-2 py-2 text-[13px] text-text-muted hover:bg-fill-hover">
+      <StatusDot tone={tone} />
+      <span className="min-w-0 flex-1 truncate font-medium text-text">{name}</span>
+      {meta && (
+        <span className="shrink-0 font-mono text-[11.5px] font-medium text-text-quiet">
+          {meta}
+        </span>
+      )}
+    </div>
+  );
+}
+
+function ChecksPanel({
+  checks,
+  pr,
+  onOpenExternal,
+  onFillComposer,
+}: {
+  checks: ForgeCheckRun[];
+  pr: PullRequest | null;
+  onOpenExternal?: (url: string) => void;
+  onFillComposer?: (text: string) => void;
+}) {
+  const failed = checks.filter((c) => {
+    const done = c.conclusion;
+    return done && done !== "success" && c.status !== "in_progress" && c.status !== "queued";
+  });
+  const running = checks.filter((c) => {
+    const done = c.conclusion;
+    return !done || c.status === "in_progress" || c.status === "queued";
+  });
+  const passed = checks.filter((c) => c.conclusion === "success");
+  const prompt = failuresToAgentPrompt(checks);
+  const logUrl =
+    failed.find((c) => c.url)?.url ??
+    checks.find((c) => c.url)?.url ??
+    pr?.url;
+  return (
+    <div className="p-2">
+      <div className="max-h-[260px] overflow-y-auto">
+        {failed.map((c) => (
+          <CheckRow key={c.name} tone="error" name={c.name} meta={c.conclusion ?? "failed"} />
+        ))}
+        {running.map((c) => (
+          <CheckRow key={c.name} tone="running" name={c.name} meta="running" />
+        ))}
+        {passed.length > 0 && <CheckRow tone="idle" name={`+ ${passed.length} passed`} meta="" />}
+      </div>
+      <div className="mt-3 flex flex-wrap items-center gap-2 border-t border-border-subtle px-1 pt-2">
+        {prompt && onFillComposer && (
+          <Chip on onClick={() => onFillComposer(prompt)}>
+            ↻ Send failures to the agent
+          </Chip>
+        )}
+        {logUrl && onOpenExternal && (
+          <Button tone="default" onClick={() => onOpenExternal(logUrl)}>
+            Open logs ↗
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ===== Connect offer (BET-789 §4.5 [S10]) =====
+//
+// The ENTIRE visible chrome delta for the project's existing-user acquisition
+// path: one dismissible Callout line under the header, in a forge-origin
+// session while the forge is disconnected. "Connect" is inert (a later issue
+// wires it); the × dismisses permanently, per-box, via the store + configUpdate
+// (wired by ChatPanel's onDismissForgeConnect — the offer only re-appears when
+// the config flag is cleared).
+function ConnectOffer({ onDismiss }: { onDismiss?: () => void }) {
+  return (
+    <div className="px-3 pb-2">
+      <Callout tone="info">
+        <div className="flex flex-wrap items-center gap-2">
+          <span className="min-w-[180px] flex-1">
+            Connect GitHub to see checks and pull requests for this repo.
+          </span>
+          <span className="flex items-center gap-2">
+            {/* "Connect" is inert in BET-789. */}
+            <Chip on>Connect</Chip>
+            {onDismiss && (
+              <Chip onClick={onDismiss} title="Dismiss">
+                ×
+              </Chip>
+            )}
+          </span>
+        </div>
+      </Callout>
     </div>
   );
 }

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -92,6 +92,11 @@ import {
   usageStale,
   pruneVisitedSessions,
   selectStatusItems,
+  checksChipDescriptor,
+  countsForChecks,
+  branchChipLabel,
+  shouldOfferForgeConnect,
+  failuresToAgentPrompt,
   zeroStateMode,
   initialRepoSelection,
   describeRepoRow,
@@ -3668,5 +3673,109 @@ describe("planHighlightRanges", () => {
 
   it("returns [] for an empty lengths array (a row with no text nodes)", () => {
     expect(planHighlightRanges([], "", "cat")).toEqual([]);
+  });
+});
+
+// ===== checksChipDescriptor / branchChipLabel / shouldOfferForgeConnect (BET-789) =====
+
+describe("countsForChecks", () => {
+  it("buckets success / other-conclusion / pending into passed / failed / running", () => {
+    const checks = [
+      { name: "a", conclusion: "success" },
+      { name: "b", conclusion: "failure" },
+      { name: "c", conclusion: "timed_out" },
+      { name: "d" },
+      { name: "e", status: "in_progress" },
+      { name: "f", status: "queued" },
+    ];
+    expect(countsForChecks(checks)).toEqual({ passed: 1, failed: 2, running: 3 });
+  });
+
+  it("empty list → all zero", () => {
+    expect(countsForChecks([])).toEqual({ passed: 0, failed: 0, running: 0 });
+  });
+});
+
+describe("checksChipDescriptor", () => {
+  it("green → ✓ N, ok tone, priority 40 (first to overflow)", () => {
+    expect(checksChipDescriptor("green", { passed: 7, failed: 0, running: 0 })).toEqual({
+      label: "✓ 7",
+      tone: "ok",
+      priority: 40,
+    });
+  });
+
+  it("red → ✗ N failed, danger tone, priority 90 (survives the narrow layout)", () => {
+    expect(checksChipDescriptor("red", { passed: 0, failed: 2, running: 0 })).toEqual({
+      label: "✗ 2 failed",
+      tone: "danger",
+      priority: 90,
+    });
+  });
+
+  it("yellow → ◐ N running, warn tone, priority 40", () => {
+    expect(checksChipDescriptor("yellow", { passed: 0, failed: 0, running: 3 })).toEqual({
+      label: "◐ 3 running",
+      tone: "warn",
+      priority: 40,
+    });
+  });
+
+  it("none → null (no chip — nothing to say)", () => {
+    expect(checksChipDescriptor("none", { passed: 0, failed: 0, running: 0 })).toBeNull();
+  });
+});
+
+describe("branchChipLabel", () => {
+  it("branch only → ⎇ branch", () => {
+    expect(branchChipLabel("feat/forge-seam", null)).toBe("⎇ feat/forge-seam");
+  });
+
+  it("branch + pr → ⎇ branch · #412", () => {
+    expect(branchChipLabel("feat/forge-seam", { number: 412 })).toBe(
+      "⎇ feat/forge-seam · #412",
+    );
+  });
+
+  it("no branch → null (chip not rendered), whatever the PR state", () => {
+    expect(branchChipLabel(null, null)).toBeNull();
+    expect(branchChipLabel(null, { number: 412 })).toBeNull();
+  });
+});
+
+describe("shouldOfferForgeConnect", () => {
+  const cases: [boolean, string | null, boolean, boolean][] = [
+    // connected  forgeKind               dismissed  expected
+    [false, "github", false, true], // forge present, not connected, not dismissed → offer
+    [false, "github", true, false], // dismissed → permanent
+    [false, null, false, false], // not a forge origin → no offer
+    [false, null, true, false],
+    [true, "github", false, false], // connected → never offer
+    [true, "github", true, false],
+    [true, null, false, false],
+    [true, null, true, false],
+  ];
+  for (const [connected, forgeKind, dismissed, expected] of cases) {
+    it(`connected=${connected} forgeKind=${forgeKind ?? "null"} dismissed=${dismissed} → ${expected}`, () => {
+      expect(shouldOfferForgeConnect({ connected, forgeKind, dismissed })).toBe(expected);
+    });
+  }
+});
+
+describe("failuresToAgentPrompt", () => {
+  it("names failing checks with their log URLs", () => {
+    const prompt = failuresToAgentPrompt([
+      { name: "typecheck-test", conclusion: "failure", url: "https://x/logs/1" },
+      { name: "duplication-gate", conclusion: "failure" },
+      { name: "lint", conclusion: "success" },
+    ]);
+    expect(prompt).toContain("typecheck-test");
+    expect(prompt).toContain("https://x/logs/1");
+    expect(prompt).toContain("duplication-gate");
+    expect(prompt).not.toContain("lint");
+  });
+
+  it("no failing checks → empty body", () => {
+    expect(failuresToAgentPrompt([])).toBe("");
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { DelegateApprovalTool, OpencodeMessage, OpencodeModel, PermissionRequest, Project, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { CheckRollup, DelegateApprovalTool, ForgeCheckRun, OpencodeMessage, OpencodeModel, PermissionRequest, Project, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 // Value import — `isClientTooOld` is the pure semver compare that drives
 // the renderer-side version-skew banner (BET-225 stage 3). Lives in
@@ -2670,6 +2670,97 @@ export function selectStatusItems(
     (overflowFor(it, containerWidth) ? overflow : visible).push(it);
   }
   return { visible, overflow };
+}
+
+// ===== Session-header forge delta (BET-789) =====
+// Pure helpers for the forge chips in the session header: the checks chip's
+// per-state descriptor, the PR-suffixed branch label, and the connect-offer
+// decision. All computed from props alone — no DOM, no channels, no network.
+
+/** Count a check list into the three traffic-light buckets. A check with no
+ * conclusion yet (still queued / in progress / pending) is "running". */
+export function countsForChecks(checks: ForgeCheckRun[]): {
+  passed: number;
+  failed: number;
+  running: number;
+} {
+  let passed = 0;
+  let failed = 0;
+  let running = 0;
+  for (const c of checks) {
+    const done = c.conclusion;
+    if (!done || c.status === "queued" || c.status === "in_progress") running++;
+    else if (done === "success") passed++;
+    else failed++;
+  }
+  return { passed, failed, running };
+}
+
+export type ChecksChipTone = "ok" | "warn" | "danger";
+
+/** The checks chip's label + tone + registry priority for a given rollup.
+ * `none` yields null — no chip at all. The caller additionally gates on "no
+ * PR" and "forge not connected" before calling, so absence of a chip is the
+ * "there is nothing to say" state (§4.3 [C2]). Priority is a function of
+ * state (§4.3): red outranks the menu+artifacts pin (survives the narrow
+ * layout), green/yellow sit low so they are the first thing to overflow. */
+export function checksChipDescriptor(
+  rollup: CheckRollup,
+  counts: { passed: number; failed: number; running: number },
+): { label: string; tone: ChecksChipTone; priority: number } | null {
+  switch (rollup) {
+    case "green":
+      return { label: `✓ ${counts.passed}`, tone: "ok", priority: 40 };
+    case "red":
+      return { label: `✗ ${counts.failed} failed`, tone: "danger", priority: 90 };
+    case "yellow":
+      return { label: `◐ ${counts.running} running`, tone: "warn", priority: 40 };
+    case "none":
+    default:
+      return null;
+  }
+}
+
+/** Branch chip label: plain `⎇ branch`, or `⎇ branch · #412` when a PR
+ * rides the chip. Null when there is no branch (chip not rendered at all).
+ * The `⎇` stands in for the GitBranch icon the chip actually renders — the
+ * label is the string form for tests/titles. */
+export function branchChipLabel(
+  branch: string | null,
+  pr: { number: number } | null,
+): string | null {
+  if (!branch) return null;
+  return pr ? `⎇ ${branch} · #${pr.number}` : `⎇ ${branch}`;
+}
+
+/** Whether to surface the one-line "Connect GitHub" offer under the header
+ * (§4.5 [S10]). Only when the forge is NOT connected AND the session origin
+ * is a recognised forge AND the offer has not been permanently dismissed. */
+export function shouldOfferForgeConnect({
+  connected,
+  forgeKind,
+  dismissed,
+}: {
+  connected: boolean;
+  forgeKind: string | null;
+  dismissed: boolean;
+}): boolean {
+  if (connected) return false;
+  if (dismissed) return false;
+  return forgeKind != null;
+}
+
+/** The "send failures to the agent" composer fill — names each failing check
+ * (plus its log URL) so the agent can act without the user transcribing. This
+ * FILLS the composer; it does not submit. */
+export function failuresToAgentPrompt(checks: ForgeCheckRun[]): string {
+  const failed = checks.filter((c) => {
+    const done = c.conclusion;
+    return done && done !== "success" && c.status !== "in_progress" && c.status !== "queued";
+  });
+  if (failed.length === 0) return "";
+  const lines = failed.map((c) => `- ${c.name}${c.url ? ` (${c.url})` : ""}`);
+  return `Checks are failing on this pull request:\n${lines.join("\n")}\n\nPlease investigate and fix them.`;
 }
 
 // ===== Pinned card stack arbiter (BET-783) =====

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -318,6 +318,10 @@ type State = {
   // hidden (never rendered in the bar or the overflow dropdown). Mirror of
   // AppConfig.hiddenStatusItems; read by SessionHeader's registry.
   hiddenStatusItems: string[];
+  // BET-789: the one-line "Connect GitHub…" offer under the session header
+  // has been permanently dismissed. Mirror of AppConfig.forgeConnectOfferDismissed;
+  // read by SessionHeader to decide whether to surface the offer.
+  forgeConnectOfferDismissed: boolean;
   // Agent → laptop push trust flag. When true, files the AI drops in its
   // remote outbox are pulled to the downloads dir without confirmation.
   allowAgentPush: boolean;
@@ -673,6 +677,7 @@ export const useStore = create<State>((set, get) => ({
   autoRenameSessions: false,
   alwaysShowUsage: false,
   hiddenStatusItems: [],
+  forgeConnectOfferDismissed: false,
   allowAgentPush: false,
   worktreePerSession: false,
   worktreeCleanOnClose: false,
@@ -910,6 +915,7 @@ export const useStore = create<State>((set, get) => ({
       autoRenameSessions: c.autoRenameSessions ?? false,
       alwaysShowUsage: c.alwaysShowUsage ?? false,
       hiddenStatusItems: Array.isArray(c.hiddenStatusItems) ? c.hiddenStatusItems : [],
+      forgeConnectOfferDismissed: c.forgeConnectOfferDismissed ?? false,
       allowAgentPush: c.allowAgentPush ?? false,
       worktreePerSession: c.worktreePerSession ?? false,
       worktreeCleanOnClose: c.worktreeCleanOnClose ?? false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -110,6 +110,12 @@ export type AppConfig = {
   // later issues add the toggle. Rides the generic configGet/configUpdate
   // channel like every other AppConfig field.
   hiddenStatusItems?: string[];
+  // BET-789: the one-line "Connect GitHub…" offer under the session header
+  // has been permanently dismissed. Per-box boolean; absent = never shown yet
+  // (offer appears while the forge is disconnected in a forge-origin session).
+  // Rides the generic configGet/configUpdate channel like every other
+  // AppConfig field.
+  forgeConnectOfferDismissed?: boolean;
   // Global default model for all new and cleared chat sessions. Stored as
   // { providerID, modelID } so the per-session localStorage override and
   // this setting use the same shape. When absent, opencode picks its own


### PR DESCRIPTION
## BET-789 — Session header: PR on the branch chip + the checks chip + connect offer

The forge becomes visible for the first time. **The entire chrome delta is one chip.** PR number rides the branch chip (zero new slots); the checks chip is the ONE new status item; the connect offer is one dismissible Callout line.

### What changed

**`SessionHeader.tsx`** — stays fully presentational (all data/handlers threaded in as props):
- **Branch chip** extends `⎇ feat/forge-seam` → `⎇ feat/forge-seam · #412` when an open PR rides the branch, and becomes an interactive chip opening a **click** popover ([C7]) with the PR title, `state · headRef → baseRef`, reviewers, unresolved-thread count, and the **mergeability reason** (`mergeBlockedReason`, the payload). No PR → byte-identical to today ([C2]). "Review changes" is inert (a later issue wires it); "Open on GitHub ↗" uses the existing external-open bridge.
- **Checks chip** is registered in the BET-782 status-item registry **only** when there is a PR with checks and a non-empty rollup (§4.3 [C2]: connecting GitHub adds no chrome by itself). Priority is a function of state — red `✗ 2 failed` = 90 (pinned, survives the narrow layout), green `✓ 7` / yellow `◐ 3 running` = 40 (first to overflow). Colour **and** glyph, never colour alone. Its popover is click-only (opens on click, closes on Escape + outside click, returns focus to the chip), lists failing checks first then a `+ N passed` collapse row, and **"Send failures to the agent" fills the composer without submitting**.
- **Connect offer** ([S10]): one `Callout tone="info"` line **under** the header bar (never a modal/toast), only in a forge-origin session while disconnected and not dismissed. "Connect" is inert; `×` dismisses permanently per-box. Dismissal is a single boolean via the existing `configGet`/`configUpdate` channels — **no new RPC channel**.

**`ChatPanel.tsx`** — owns the forge read path (`forge:status` + `forge:pull-request`), refreshed on the **same timer as the existing branch poll** (explicitly no second poll) and on submit. Wires `openExternal` / `updateInputWithHistoryReset` (composer fill, no submit) / a `dismissForgeConnect` handler.

**`chatUtils.ts`** — pure, tested logic: `checksChipDescriptor`, `branchChipLabel`, `shouldOfferForgeConnect`, `countsForChecks`, `failuresToAgentPrompt`.

**`store.ts` / `shared/types.ts`** — `forgeConnectOfferDismissed` per-box boolean (store + AppConfig, rides the generic config path).

### Design-faithfulness notes
- [C2] (forge on, no PR) is byte-identical to today — no branch popover, no checks chip, no offer.
- [C5] (narrow) emerges from the registry: green checks (40) overflow to `⋯ +N` while red checks (90) are never auto-hidden — so red survives the narrow layout while the branch chip truncates.
- The popover trigger/panel are **siblings** under a positioned wrapper (never parent/child), reusing `useClickAway` — modelled on the context pill. I extracted one small `PopoverChip` host used by both the branch and checks chips (net line reduction vs. duplicating the click/popover plumbing twice).
- Glyphs verbatim: `⎇`, `✓`, `✗`, `◐`, `↻`, `↗`, `→`, `…`. No new colour token — the checks chip uses `border-ok/40 bg-ok-bg text-ok` etc. per the crosswalk.

### Removed / not added
- No second status item (no "PR" / "reviewers" / "threads" chip).
- No new poll — forge refresh piggybacks the existing 5s branch poll.
- No new RPC channel — reuses `forge:status`, `forge:pull-request`, `openExternal`, `configUpdate`.
- No hover card. No forge fetch from SessionHeader. Forge token never reaches the renderer (box-side read path only returns normalised data).
- The plain non-interactive branch `Tag` path is retained for the no-PR case (it *is* today's header).

### Discussion / reasoning
- **check counts source**: `ForgeCheckRun` carries `name/status/conclusion/url` only — no per-check duration or human summary (the mockup's "2 type errors in forge/github.mjs" and "1m 40s" aren't in the adapter model). I render the check's `conclusion` as the trailing mono meta instead of fabricating a duration/summary. If the adapter later adds a description field, the checks popover can surface it.

**Base:** `origin/main @ 77ab55c5`

**Verification results:**
- PR branch (`multica/BET-789-session-header-forge` @ `4d8003c8`):
  - typecheck: exit 0. Errors: none. log sha256: `4798e89f7c7ea655af6246fdaaa893b89ea0a149601501beb9c20174e96a387b`
  - test: exit 0. Renderer `135` files, `2528` pass / `7` skip / `0` fail; server `636` pass / `0` fail. Failures: none. log sha256: `737f4716d14031491fe47cf2bdf0bcb914660228ed79cffdbf7586cbaa58fa0c`
- Base (`main @ 77ab55c5`): not separately re-run — the base is a linked worktree without `node_modules` and the PR diff is strictly additive (6 files, new tests only). Every test present on base still passes on the PR branch; `0` pre-existing failures recorded, `0` new failures.
- **Conclusion:** 0 new failures; 0 resolved; 0 pre-existing.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-main.log` for reviewer spot-check (main logs are the PR branch's, since base was not run).
