### PR TITLE
BET-829: fix(box): stop self-update bricking the box at the dependency step

### DIFF
--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -95,6 +95,10 @@ verify_sha256() {
 # dependency on the caller's variable names.
 replace_release_payload() {
   local pkg="$1" dest="$2" node_bin="$3" rel includes
+  # Tells install_prod_deps whether this run already installed a prebuilt,
+  # build-time-verified node_modules from the payload. Reset per call so a
+  # caller can never inherit a stale "yes" from an earlier invocation.
+  REPLACED_NODE_MODULES=0
   includes="$("$node_bin" -e 'const i=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).includes||[]; process.stdout.write(i.join("\n"))' "$pkg/RELEASE.json")" \
     || die "release payload: cannot read includes from $pkg/RELEASE.json"
   [ -n "$includes" ] || die "release payload: $pkg/RELEASE.json has an empty includes list"
@@ -106,6 +110,7 @@ replace_release_payload() {
     cp -R "$pkg/$rel" "$dest/$rel.new" || die "release payload: copy failed for $rel"
     rm -rf "$dest/$rel"
     mv "$dest/$rel.new" "$dest/$rel" || die "release payload: swap failed for $rel"
+    [ "$rel" = "node_modules" ] && REPLACED_NODE_MODULES=1
   done
   cp "$pkg/RELEASE.json" "$dest/RELEASE.json"
 }
@@ -170,4 +175,80 @@ sync_opencode_guidance() {
     rm -f "$tmp"
     ok "opencode AGENTS.md already current."
   fi
+}
+
+# install_prod_deps <dest-dir>
+#
+# Make <dest-dir>/node_modules correct for the box, NON-DESTRUCTIVELY (BET-829).
+#
+# WHY THIS IS NOT JUST `npm ci` ANY MORE
+# --------------------------------------
+# The old update step was a bare `npm ci --omit=dev --prefix <dest>`. `npm ci`
+# DELETES node_modules before it installs, so every way it could fail left the
+# box with no loadable `node-pty` — i.e. a manta-server that cannot start. It
+# failed routinely:
+#
+#   * no `npm` on a service PATH (fixed by the PATH pin in self-update.sh);
+#   * no C toolchain — a clean VPS has no `make`/`g++`, and install.sh never
+#     installs one because the release tarball ships node_modules PREBUILT;
+#   * a system npm bound to a different Node than the vendored runtime, which
+#     "succeeds" while producing a binding for the wrong ABI;
+#   * npm does not preserve the executable bit on node-pty's `spawn-helper`,
+#     which pack.mjs explicitly repairs at build time and an on-box install
+#     silently would not.
+#
+# So the release payload is the PREFERRED source: pack.mjs materializes an
+# --omit=dev tree, repairs spawn-helper, and PROVES it by requiring node-pty
+# through the vendored node for that exact arch. If the incoming release owns
+# node_modules, replace_release_payload has already swapped that verified tree
+# in and there is nothing to do here.
+#
+# `npm ci` remains the fallback for the cases with no payload to take deps
+# from — a git-kind checkout, or a packaged box updating to a release built
+# before node_modules joined `includes`. It is now wrapped so a failure is
+# survivable: the existing tree is moved aside (a rename, so it is cheap and
+# on the same filesystem) and restored if the install fails, leaving the box
+# exactly as bootable as it was before the attempt.
+install_prod_deps() {
+  local dest="$1" backup="$1/node_modules.prev"
+
+  # Set by replace_release_payload in THIS run when the incoming release owned
+  # node_modules. Deliberately a run-scoped variable rather than a marker file
+  # on disk: a marker would go stale the moment a box updated to a release that
+  # did NOT ship node_modules, and we would then skip the install that release
+  # actually needed.
+  if [ "${REPLACED_NODE_MODULES:-0}" = "1" ]; then
+    ok "self-update: prod deps came from the release payload (prebuilt, arch- and ABI-verified at build time)"
+    return 0
+  fi
+
+  if ! command -v npm >/dev/null 2>&1; then
+    die "self-update: npm not found on PATH.
+      The box vendors its own npm at \$MANTA_HOME/runtime/node/bin; if that
+      directory is missing, the install is incomplete — re-run install.sh."
+  fi
+
+  log "self-update: reinstalling prod-only deps with npm ci"
+  rm -rf "$backup"
+  if [ -d "$dest/node_modules" ]; then
+    mv "$dest/node_modules" "$backup" || die "self-update: could not set aside node_modules"
+  fi
+
+  if npm ci --omit=dev --prefix "$dest"; then
+    rm -rf "$backup"
+    ok "self-update: prod deps installed"
+    return 0
+  fi
+
+  # Restore, so a box whose deps cannot be rebuilt here still starts. This is
+  # the difference between "the update failed" and "the box is bricked".
+  warn "self-update: npm ci failed — restoring the previous node_modules"
+  rm -rf "$dest/node_modules"
+  if [ -d "$backup" ]; then
+    mv "$backup" "$dest/node_modules" || die "self-update: could not restore node_modules — box may not start; re-run install.sh"
+    die "self-update: dependency install failed; previous node_modules restored.
+      The box still runs, but it is now on new source with older deps — re-run
+      install.sh to get a matching prebuilt tree."
+  fi
+  die "self-update: dependency install failed and there was no previous node_modules to restore — re-run install.sh"
 }

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -21,6 +21,7 @@ import {
   existsSync,
   readdirSync,
   rmSync,
+  symlinkSync,
   statSync,
   mkdirSync,
 } from "node:fs";
@@ -237,4 +238,148 @@ test("no *.new staging directories survive a successful run", () => {
     rmSync(pkg, { recursive: true, force: true });
     rmSync(dest, { recursive: true, force: true });
   }
+});
+
+// --- install_prod_deps (BET-829) --------------------------------------------
+//
+// The old update step was a bare `npm ci --omit=dev`, which DELETES
+// node_modules before installing. Every failure mode therefore left the box
+// without a loadable node-pty — a manta-server that cannot start. These cases
+// pin the two properties that make it survivable: prefer the prebuilt tree the
+// release payload already carries, and never destroy a working tree on failure.
+
+/**
+ * Source release.sh and call `install_prod_deps <dest>` with a stubbed `npm`
+ * on PATH whose exit status the test chooses, so no real install ever runs.
+ * `replaced` seeds REPLACED_NODE_MODULES the way replace_release_payload would.
+ */
+function runInstallDeps(dest, { npmExit = 0, replaced = 0, npmOnPath = true } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "manta-deps-"));
+  const binDir = join(dir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  // Hermetic PATH: the ONLY entry is binDir, so `npmOnPath:false` really means
+  // npm is unreachable (this box has a system /usr/bin/npm that would
+  // otherwise satisfy the lookup and void the test). The coreutils the
+  // function genuinely needs are symlinked in explicitly.
+  for (const cmd of ["rm", "mv", "mkdir"]) {
+    const src = ["/bin/", "/usr/bin/"].map((p) => p + cmd).find((p) => existsSync(p));
+    if (src) symlinkSync(src, join(binDir, cmd));
+  }
+  if (npmOnPath) {
+    // A fake npm that mimics the destructive part of `npm ci`: it wipes the
+    // target node_modules FIRST, then exits with the status under test. If the
+    // function did not set the tree aside beforehand, a non-zero exit leaves
+    // nothing behind — which is exactly the brick we are testing against.
+    writeFileSync(
+      join(binDir, "npm"),
+      `#!/bin/sh\nrm -rf '${dest}/node_modules'\nmkdir -p '${dest}/node_modules'\necho fresh > '${dest}/node_modules/INSTALLED'\nexit ${npmExit}\n`,
+      { mode: 0o755 },
+    );
+  }
+  const script = join(dir, "run.sh");
+  writeFileSync(
+    script,
+    `#!/usr/bin/env bash
+set +e
+log()  { printf 'log: %s\\n' "$*"; }
+ok()   { printf 'ok: %s\\n' "$*"; }
+warn() { printf 'warn: %s\\n' "$*"; }
+die()  { printf 'die: %s\\n' "$*"; exit 1; }
+export PATH='${binDir}'
+REPLACED_NODE_MODULES=${replaced}
+source '${RELEASE_LIB}'
+install_prod_deps '${dest}'
+exit $?
+`,
+    { mode: 0o755 },
+  );
+  try {
+    const stdout = execFileSync("bash", [script], { encoding: "utf8" });
+    return { status: 0, stdout };
+  } catch (e) {
+    return { status: e.status ?? 1, stdout: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("install_prod_deps: skips npm entirely when the payload already supplied node_modules", () => {
+  const dest = mkdtempSync(join(tmpdir(), "manta-dest-"));
+  writeTree(dest, { "node_modules/from-payload.txt": "prebuilt" });
+  // npm is absent from PATH: if the function tried to run it, this would fail.
+  const r = runInstallDeps(dest, { replaced: 1, npmOnPath: false });
+  assert.equal(r.status, 0, r.stdout);
+  assert.match(r.stdout, /came from the release payload/);
+  assert.equal(
+    readFileSync(join(dest, "node_modules/from-payload.txt"), "utf8"),
+    "prebuilt",
+    "the payload tree must be left exactly as swapped in",
+  );
+  rmSync(dest, { recursive: true, force: true });
+});
+
+test("install_prod_deps: runs npm ci when there is no payload tree (git checkout)", () => {
+  const dest = mkdtempSync(join(tmpdir(), "manta-dest-"));
+  writeTree(dest, { "node_modules/old.txt": "stale" });
+  const r = runInstallDeps(dest, { replaced: 0, npmExit: 0 });
+  assert.equal(r.status, 0, r.stdout);
+  assert.ok(existsSync(join(dest, "node_modules/INSTALLED")), "npm ci should have installed");
+  assert.ok(
+    !existsSync(join(dest, "node_modules.prev")),
+    "the set-aside copy must be cleaned up on success",
+  );
+  rmSync(dest, { recursive: true, force: true });
+});
+
+test("install_prod_deps: RESTORES the previous node_modules when npm ci fails (the brick case)", () => {
+  const dest = mkdtempSync(join(tmpdir(), "manta-dest-"));
+  writeTree(dest, { "node_modules/node-pty/pty.node": "working-binding" });
+  const r = runInstallDeps(dest, { replaced: 0, npmExit: 1 });
+  assert.equal(r.status, 1, "a failed dependency install must still fail the update");
+  assert.equal(
+    readFileSync(join(dest, "node_modules/node-pty/pty.node"), "utf8"),
+    "working-binding",
+    "the working tree must be restored so the box still starts — this is the whole point",
+  );
+  assert.ok(!existsSync(join(dest, "node_modules.prev")), "no leftover set-aside directory");
+  assert.match(r.stdout, /restoring the previous node_modules/);
+  rmSync(dest, { recursive: true, force: true });
+});
+
+test("install_prod_deps: fails with actionable guidance when npm is not on PATH", () => {
+  const dest = mkdtempSync(join(tmpdir(), "manta-dest-"));
+  writeTree(dest, { "node_modules/keep.txt": "keep" });
+  const r = runInstallDeps(dest, { replaced: 0, npmOnPath: false });
+  assert.equal(r.status, 1);
+  assert.match(r.stdout, /npm not found on PATH/);
+  assert.equal(
+    readFileSync(join(dest, "node_modules/keep.txt"), "utf8"),
+    "keep",
+    "bailing early must not have touched the existing tree",
+  );
+  rmSync(dest, { recursive: true, force: true });
+});
+
+test("replace_release_payload: signals when it swapped node_modules from the payload", () => {
+  const pkg = mkdtempSync(join(tmpdir(), "manta-pkg-"));
+  const dest = mkdtempSync(join(tmpdir(), "manta-dest-"));
+  writeTree(pkg, {
+    "RELEASE.json": JSON.stringify({ version: "9.9.9", includes: ["src", "node_modules"] }),
+    "src/server/index.mjs": "new",
+    "node_modules/node-pty/pty.node": "prebuilt-verified",
+  });
+  writeTree(dest, {
+    "RELEASE.json": JSON.stringify({ version: "0.0.1", includes: ["src"] }),
+    "src/server/index.mjs": "old",
+    "node_modules/node-pty/pty.node": "stale",
+  });
+  const r = runReplace(pkg, dest);
+  assert.equal(r.status, 0, r.stdout);
+  assert.equal(
+    readFileSync(join(dest, "node_modules/node-pty/pty.node"), "utf8"),
+    "prebuilt-verified",
+    "node_modules must be swapped from the payload when the release owns it",
+  );
+  rmSync(pkg, { recursive: true, force: true });
+  rmSync(dest, { recursive: true, force: true });
 });

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -80,6 +80,17 @@ function allPaths(root) {
  * bash subprocess. Returns { status, stdout }.
  */
 function runReplace(pkg, dest) {
+  return sourceAndRun(`replace_release_payload '${pkg}' '${dest}' '${NODE_CMD}'`);
+}
+
+/**
+ * The one place a bash subprocess is built for these tests: define the
+ * `log`/`ok`/`warn`/`die` helpers release.sh expects its CALLER to own, source
+ * the library, then run `body`. `preamble` injects anything that must be set
+ * before sourcing (PATH, seed variables). Returns { status, stdout } with
+ * stderr folded in, so assertions can match on `die` output.
+ */
+function sourceAndRun(body, { preamble = "" } = {}) {
   const dir = mkdtempSync(join(tmpdir(), "manta-release-"));
   const script = join(dir, "run.sh");
   writeFileSync(
@@ -90,8 +101,9 @@ log()  { printf 'log: %s\\n' "$*"; }
 ok()   { printf 'ok: %s\\n' "$*"; }
 warn() { printf 'warn: %s\\n' "$*" >&2; }
 die()  { printf 'die: %s\\n' "$*" >&2; exit 1; }
+${preamble}
 source '${RELEASE_LIB}'
-replace_release_payload '${pkg}' '${dest}' '${NODE_CMD}'
+${body}
 exit $?
 `,
     { mode: 0o755 },
@@ -276,28 +288,10 @@ function runInstallDeps(dest, { npmExit = 0, replaced = 0, npmOnPath = true } = 
       { mode: 0o755 },
     );
   }
-  const script = join(dir, "run.sh");
-  writeFileSync(
-    script,
-    `#!/usr/bin/env bash
-set +e
-log()  { printf 'log: %s\\n' "$*"; }
-ok()   { printf 'ok: %s\\n' "$*"; }
-warn() { printf 'warn: %s\\n' "$*"; }
-die()  { printf 'die: %s\\n' "$*"; exit 1; }
-export PATH='${binDir}'
-REPLACED_NODE_MODULES=${replaced}
-source '${RELEASE_LIB}'
-install_prod_deps '${dest}'
-exit $?
-`,
-    { mode: 0o755 },
-  );
   try {
-    const stdout = execFileSync("bash", [script], { encoding: "utf8" });
-    return { status: 0, stdout };
-  } catch (e) {
-    return { status: e.status ?? 1, stdout: `${e.stdout ?? ""}${e.stderr ?? ""}` };
+    return sourceAndRun(`install_prod_deps '${dest}'`, {
+      preamble: `export PATH='${binDir}'\nREPLACED_NODE_MODULES=${replaced}`,
+    });
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }

--- a/scripts/release/pack.mjs
+++ b/scripts/release/pack.mjs
@@ -127,9 +127,23 @@ const INCLUDE = [
 // plus `runtime`: the vendored Node is produced by ensureNodeRuntime() during
 // staging rather than copied from the repo, so it cannot be in the staging
 // allowlist above, but it must be replaced on update or a runtime version bump
-// can never reach an installed box. node_modules is deliberately NOT here — it
-// is materialized on the box by `npm ci --omit=dev` after the swap.
-const OWNED_ON_BOX = [...INCLUDE, "runtime"];
+// can never reach an installed box.
+//
+// `node_modules` is here too, as of BET-829. It used to be excluded on the
+// grounds that the box would materialize it with `npm ci --omit=dev` after the
+// swap — but doing that ON the box was the single worst step in the update
+// path. It needs a C toolchain a clean VPS does not have (install.sh never
+// installs one, precisely because this tarball ships deps prebuilt); it builds
+// against whatever Node the SYSTEM has rather than the vendored runtime, so a
+// box with a mismatched system npm gets a wrong-ABI binding and a "successful"
+// update that will not start; and it silently loses the node-pty
+// `spawn-helper` executable bit that this script repairs below.
+//
+// The tree staged here is strictly better than anything the box could build:
+// it is --omit=dev, spawn-helper is repaired, and it is PROVEN by requiring
+// node-pty through the vendored node for this exact arch before we tar it.
+// Tarballs are per-arch, so the copy a box downloads always matches it.
+const OWNED_ON_BOX = [...INCLUDE, "runtime", "node_modules"];
 
 // Parse the nodejs.org SHASUMS256.txt into {filename: sha256}. Tolerates the
 // `*` prefix some lines carry for binary-mode sha.

--- a/scripts/release/pack.test.mjs
+++ b/scripts/release/pack.test.mjs
@@ -108,17 +108,11 @@ test("pack.mjs --arch bogus fails the parseArgs validation with the right messag
 // pack.mjs. INCLUDE is which repo paths get COPIED into the tarball;
 // OWNED_ON_BOX is which paths self-update replaces on an installed box.
 //
-// They differ by exactly two entries, and for the same underlying reason: both
-// are PRODUCED during staging rather than copied from the repo, so neither can
-// be in INCLUDE — but both must reach an installed box on update.
-//   * `runtime` — the vendored Node, produced by ensureNodeRuntime(). Without
-//     it in the owned list a runtime version bump can never reach a box.
-//   * `node_modules` — the --omit=dev tree, whose node-pty binding is repaired
-//     (spawn-helper exec bit) and then PROVEN loadable by the vendored node for
-//     this arch. Added in BET-829: the box used to rebuild it locally with
-//     `npm ci`, which needs a toolchain a clean VPS lacks and links against the
-//     system Node rather than the vendored one, producing a wrong-ABI binding
-//     and a box that will not start.
+// They differ by exactly two entries — `runtime` and `node_modules` — and for
+// the same underlying reason: both are PRODUCED during staging rather than
+// copied from the repo, so neither can be in INCLUDE, yet both must reach an
+// installed box on update. The full rationale for each lives on OWNED_ON_BOX
+// in pack.mjs and is deliberately not restated here.
 //
 // pack.mjs can't be imported (main() runs on import and hits the network), so
 // we read its SOURCE and evaluate the two array literals — the same way the

--- a/scripts/release/pack.test.mjs
+++ b/scripts/release/pack.test.mjs
@@ -104,12 +104,21 @@ test("pack.mjs --arch bogus fails the parseArgs validation with the right messag
 });
 
 // The staging allowlist (INCLUDE) and the owned-on-box list (OWNED_ON_BOX =
-// [...INCLUDE, "runtime"]) are two distinct concepts in pack.mjs. INCLUDE is
-// which repo paths get COPIED into the tarball; OWNED_ON_BOX is which paths
-// self-update replaces on an installed box. They must differ by exactly
-// `runtime`: the vendored Node is produced by ensureNodeRuntime() during
-// staging (so it can't be in INCLUDE), but it must be replaced on update (so
-// it has to be in OWNED_ON_BOX).
+// [...INCLUDE, "runtime", "node_modules"]) are two distinct concepts in
+// pack.mjs. INCLUDE is which repo paths get COPIED into the tarball;
+// OWNED_ON_BOX is which paths self-update replaces on an installed box.
+//
+// They differ by exactly two entries, and for the same underlying reason: both
+// are PRODUCED during staging rather than copied from the repo, so neither can
+// be in INCLUDE — but both must reach an installed box on update.
+//   * `runtime` — the vendored Node, produced by ensureNodeRuntime(). Without
+//     it in the owned list a runtime version bump can never reach a box.
+//   * `node_modules` — the --omit=dev tree, whose node-pty binding is repaired
+//     (spawn-helper exec bit) and then PROVEN loadable by the vendored node for
+//     this arch. Added in BET-829: the box used to rebuild it locally with
+//     `npm ci`, which needs a toolchain a clean VPS lacks and links against the
+//     system Node rather than the vendored one, producing a wrong-ABI binding
+//     and a box that will not start.
 //
 // pack.mjs can't be imported (main() runs on import and hits the network), so
 // we read its SOURCE and evaluate the two array literals — the same way the
@@ -122,17 +131,32 @@ function evalArrayLiteral(declName, scope = {}) {
   return Function(...Object.keys(scope), `return ${m[1]}`)(...Object.values(scope));
 }
 
-test("OWNED_ON_BOX = INCLUDE + runtime: owned list has runtime, staging allowlist does not, otherwise equal", () => {
+test("OWNED_ON_BOX = INCLUDE + runtime + node_modules: staged-not-copied paths are owned, otherwise equal", () => {
   const include = evalArrayLiteral("INCLUDE");
   const owned = evalArrayLiteral("OWNED_ON_BOX", { INCLUDE: include });
 
-  assert.ok(owned.includes("runtime"), "owned-on-box list must include runtime");
-  assert.ok(!include.includes("runtime"), "staging allowlist must NOT include runtime");
+  for (const staged of ["runtime", "node_modules"]) {
+    assert.ok(owned.includes(staged), `owned-on-box list must include ${staged}`);
+    assert.ok(!include.includes(staged), `staging allowlist must NOT include ${staged}`);
+  }
   assert.deepEqual(
-    owned.filter((p) => p !== "runtime"),
+    owned.filter((p) => p !== "runtime" && p !== "node_modules"),
     include,
     "owned list must otherwise equal the staging allowlist",
   );
   // guard against the two lists silently collapsing back into one
   assert.notDeepEqual(owned, include);
+});
+
+// BET-829 regression. Dropping node_modules from the owned list would silently
+// restore the old behaviour: the box would fall back to `npm ci` on a machine
+// with no compiler and a mismatched system Node, and the failure only surfaces
+// as a manta-server that will not start after the next restart.
+test("BET-829: node_modules stays release-owned so the box never rebuilds deps locally", () => {
+  const include = evalArrayLiteral("INCLUDE");
+  const owned = evalArrayLiteral("OWNED_ON_BOX", { INCLUDE: include });
+  assert.ok(
+    owned.includes("node_modules"),
+    "node_modules must be release-owned — the tarball ships a prebuilt, arch- and ABI-verified tree",
+  );
 });

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -91,6 +91,28 @@ else
   NODE_CMD="node"
 fi
 
+# Put the box's OWN vendored runtime FIRST on PATH (BET-829). install.sh does
+# exactly this; this script never did, and every consequence was a silent brick:
+#
+#   * `npm` is not on the PATH a service gets at all. manta-server's systemd
+#     unit / LaunchAgent carries a minimal PATH that excludes
+#     runtime/node/bin, and an install.sh box has NO system npm (it vendors
+#     Node precisely so it needs none) — so the `npm ci` below died with
+#     "npm: command not found" AFTER the payload swap had already happened.
+#   * Worse, on a box that DOES have a system npm, that npm belongs to a
+#     DIFFERENT Node (e.g. system v22 while the box runs vendored v24). It
+#     rebuilds node-pty's native binding for the wrong ABI, the update reports
+#     success, and manta-server then fails to start at the next restart. A
+#     silent-success brick is worse than a loud failure.
+#
+# Pinning PATH here makes `npm`/`node`/`node-gyp` resolve to the SAME runtime
+# that will load the result. Guarded because a git-kind checkout may have no
+# vendored runtime (it runs whatever Node is on PATH, by design).
+if [ -d "$MANTA_HOME/runtime/node/bin" ]; then
+  PATH="$MANTA_HOME/runtime/node/bin:$PATH"
+  export PATH
+fi
+
 echo "MANTA_PROGRESS 2/6 Downloading update"
 if [ "$INSTALL_KIND" = "git" ]; then
   # A git checkout has no vendored runtime under version control — the box runs
@@ -182,8 +204,7 @@ else
 fi
 
 echo "MANTA_PROGRESS 3/6 Installing dependencies"
-log "self-update: reinstalling prod-only deps"
-npm ci --omit=dev --prefix "$MANTA_HOME"
+install_prod_deps "$MANTA_HOME"
 
 # --- Refresh the manta-native opencode tools --------------------------------
 # The AI-facing tool sources (docs/opencode-tools/*.ts) are COPIED into


### PR DESCRIPTION
Closes BET-829.

## The bug

`scripts/self-update.sh` ran a bare `npm ci --omit=dev --prefix "$MANTA_HOME"`. `npm ci` **deletes `node_modules` before installing**, so every way that step could fail left the box with no loadable `node-pty` — a `manta-server` that cannot start. And the step is ordered *after* the payload swap, so the source tree is already replaced when it dies.

Three distinct failure modes, all observed on real boxes:

| Box shape | What happens | Result |
|---|---|---|
| clean VPS (staging) | no system npm → `npm: command not found`, exit 127 | `node_modules` destroyed, box unbootable |
| clean VPS, PATH fixed | no `make`/`g++` → node-gyp fails | same |
| has system npm (dev box) | system Node **v22** builds the binding; server runs vendored Node **v24** | **update reports success**, box dies at next restart |

The third is the dangerous one: a toolchain doesn't save you, it just makes the wrong-ABI build *succeed*.

## Root cause

The dependency step ran under whatever Node the **system** happened to have, instead of the vendored runtime the server actually uses. A box was only safe by coincidence — if its system Node happened to match the vendored major.

## The fix

**1. Pin the vendored runtime on PATH** (`self-update.sh`) — `install.sh` already does exactly this; the updater never did. `npm`/`node`/`node-gyp` now resolve to the runtime that must load the result.

**2. Make `node_modules` release-owned** (`pack.mjs` `OWNED_ON_BOX`) — the tarball *already ships* a prebuilt tree: `--omit=dev`, node-pty's `spawn-helper` exec bit repaired, and **proven loadable by requiring node-pty through the vendored node for that exact arch** before tarring. `install.sh` uses it; the updater threw it away and rebuilt. Now the packaged update swaps in that verified tree, and needs no toolchain at all.

**3. Keep `npm ci` as a non-destructive fallback** — still needed where there is no payload (a git checkout, or a packaged box updating to a pre-BET-829 release). It now moves the existing tree aside and **restores it if the install fails**, so a failed update leaves the box as bootable as it was.

`node_modules` is now owned, so the tree is swapped by the existing `replace_release_payload` (stage as `.new`, swap with `mv`) — already atomic, no new mechanism.

## Note on the previous rationale

`pack.mjs` documented excluding `node_modules` as deliberate ("materialized on the box by `npm ci`"). That is the decision being reversed — pack.mjs itself works around npm dropping node-pty's exec bit, which an on-box install would silently lose. Comments updated to record why.

## Tests

- 5 new cases in `scripts/lib/release.test.mjs` driving the **real shell functions** in a bash subprocess with a stubbed npm, including the brick case (`npm ci` fails → previous tree restored) and a hermetic PATH so "npm not on PATH" genuinely means unreachable.
- `pack.test.mjs` updated for the new owned list + a regression test pinning `node_modules` as owned.
- **Red/green verified:** reverting `install_prod_deps` to the old destructive body fails 3 of the new tests; the fix passes 10/10.
- Full suite green: 2504 renderer, 642 server, typecheck clean.

## Manual verification

The dev box's 0.0.19 → 0.0.23 hop was run by hand with the PATH pin and `node_modules` backed up: exit 0, `pty.node` present and loading under vendored Node 24, server healthy on 0.0.23. Run the way the button does, the same box would have built against system Node 22.

## Two-hop caveat

A box applies this update with the updater it already has, so the *first* update after this lands still uses the old destructive step; the fixed logic applies from the one after. Inherent to a self-replacing updater and already documented in the script's header.