### PR TITLE
BET-828: chore(release): 0.0.24 — ship the BET-829 self-update fix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.23",
+      "version": "0.0.24",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.23",
+  "version": "0.0.24",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.23",
+ "version": "0.0.24",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Cuts the release that carries **BET-829** (PR #826) to boxes.

## Why now

`server-v17`/0.0.23 was tagged at `23:43`; BET-829 merged at `00:46` — an hour later. So 0.0.23 does **not** contain the updater fix, and every box in the field (including a box freshly installed today) carries an updater that can brick itself at the dependency step. Verified on a live 0.0.23 box: `replace_release_payload` present, PATH pin and `install_prod_deps` absent.

## What ships

- BET-829: vendored runtime pinned on PATH, `node_modules` release-owned so the box stops rebuilding deps locally, and `npm ci` demoted to a non-destructive fallback.
- Version bumped in lockstep across `package.json`, the lockfile, and `website/updates/server.json` (the latter deploys on `web-v*`, not `server-v*`).

## Tags (pushed separately — >3 in one push silently fires nothing)

- `server-v18` → publishes the tarballs
- `web-v23` → publishes `updates/server.json`

## Announcement caveat — please do not skip

A box applies an update using the updater **already on its disk**, so the hop that delivers this fix still runs the OLD destructive step. Publishing this does not make the Update button safe for the hop that carries it.

Users should **re-run `install.sh`** for this one release rather than clicking "Update & restart". The installer replaces the tree wholesale, never rebuilds dependencies, preserves pairing/identity, and skips the two-hop entirely. The button is safe again from the following release onward.

This is not a regression introduced here: the hazard exists on every field box today regardless of this change.