### PR TITLE
BET-832 Voice: remove command mode from the iOS client (Swift)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -402,7 +402,6 @@ private struct ChatScreenContent: View {
                             showScrollToBottom = false
                         },
                         onGlassBoxHeightChange: { composerGlassHeight = $0 },
-                        onToggleTrust: { flipTrustMode() },
                         sessionDirectory: sessionWindow?.cwd,
                         onSlashClear: { Task { await clearSession() } },
                         onSlashFork: { Task { await forkSession() } }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -935,41 +935,6 @@ final class ChatSessionStore: ObservableObject {
         }
     }
 
-    /// Dispatch a store-level voice action. Returns a human hint string when
-    /// the action was NOT handled here (the caller should surface it), or nil
-    /// when it was handled. Actions that insert/modify composer text
-    /// (`submit`/`append`/`unknown`) and the app-level ones (`newSession`,
-    /// `openSettings`, `switchWindow`, `fork`, `clear`, `help`,
-    /// `toggleTrust`) are NOT this store's job — the composer routes those.
-    @discardableResult
-    func dispatchVoice(_ action: VoiceAction) -> String? {
-        switch action {
-        case .allowOnce:
-            replyToLatestPermission(.once)
-            return nil
-        case .allowAlways:
-            replyToLatestPermission(.always)
-            return nil
-        case .reject:
-            if newestPermission != nil {
-                replyToLatestPermission(.reject)
-            } else if newestQuestion != nil {
-                rejectQuestion(newestQuestion!)
-            }
-            return nil
-        case .answer(let choice):
-            return answerLatestQuestion(choice: choice)
-        case .abort:
-            abort()
-            return nil
-        case .compact:
-            compact()
-            return nil
-        default:
-            return ChatVoiceHint.text(for: action)
-        }
-    }
-
     private func replyToLatestPermission(_ reply: PermissionReply) {
         guard let permission = newestPermission else { return }
         replyPermission(permission, reply: reply)

--- a/mobile/native/MantaUI/ChatVoice.swift
+++ b/mobile/native/MantaUI/ChatVoice.swift
@@ -2,103 +2,15 @@ import Foundation
 import UniformTypeIdentifiers
 
 // ===========================================================================
-// S5 — voice pure logic (BET-597).
-//
-// Two jobs, both device-side PRESENTATION of box-produced results (§17):
-//   1. Interpret the box's `voice:classify-command` reply into a typed
-//      `VoiceAction` the composer/router can dispatch. The classifier runs on
-//      the box; this is only a faithful mapping of its wire reply.
-//   2. Attachment MIME detection (which extension → which `mime` tag to send
-//      to `POST /api/upload` + `opencode:prompt`), so the box can decide
-//      FilePart-vs-path the way the desktop does.
-// All pure; unit-tested in MantaUITests.
+// S5 — voice pure logic (BET-597). The iOS client is dictation-only: hold the
+// mic, release, the transcript is inserted at the caret. The only remaining
+// device-side presentation job is attachment MIME detection (which extension →
+// which `mime` tag to send to `POST /api/upload` + `opencode:prompt`), so the
+// box can decide FilePart-vs-path the way the desktop does. All pure;
+// unit-tested in MantaUITests.
 // ===========================================================================
 
-/// The recorder's capture mode: dictate inserts transcribed text at the caret;
-/// command routes it through the box classifier to perform an action.
-enum VoiceMode: Equatable {
-    case dictate
-    case command
-}
-
-/// A typed voice command (the classifier's kinds, mapped to Swift). Undecided
-/// / LLM-degraded input becomes `unknown`.
-enum VoiceAction: Equatable {
-    case submit(text: String)
-    case append(text: String)
-    case clear
-    case compact
-    case fork
-    case abort
-    case help
-    case toggleTrust
-    case allowOnce
-    case allowAlways
-    case reject
-    case answer(choice: String)
-    case model(query: String)
-    case switchWindow(index: Int)
-    case newSession
-    case openSettings
-    case unknown(transcript: String)
-}
-
-/// A human hint for a voice action the composer/store chose not to perform
-/// (app-level or navigation actions out of the chat surface). Honest wording —
-/// never a fabricated success.
-enum ChatVoiceHint {
-    static func text(for action: VoiceAction) -> String {
-        switch action {
-        case .clear: return "“Clear” isn't available in this chat yet"
-        case .compact: return "Compacted to free context"
-        case .fork: return "Forking isn't available in this chat yet"
-        case .help: return "Try “submit…”, “abort”, or “answer…”"
-        case .toggleTrust: return "Trust mode can't be toggled right now"
-        case .newSession: return "New-session isn't available in this chat"
-        case .openSettings: return "Settings isn't available in this chat"
-        case .switchWindow: return "Switch-window isn't available in this chat"
-        default: return "Done"
-        }
-    }
-}
-
 enum ChatVoice {
-
-    /// Map the box's `voice:classify-command` reply onto a typed action.
-    /// Kind is lowercased for the match; the current synonym for "submit on a
-    /// relayed {kind,text}" is also tolerated.
-    static func parse(_ r: VoiceClassifyResult) -> VoiceAction {
-        switch r.kind?.lowercased() {
-        case "submit": return .submit(text: r.text ?? "")
-        case "append": return .append(text: r.text ?? "")
-        case "clear": return .clear
-        case "compact": return .compact
-        case "fork": return .fork
-        case "abort": return .abort
-        case "help": return .help
-        case "toggle-trust", "toggle_trust": return .toggleTrust
-        case "allow-once", "allow_once": return .allowOnce
-        case "allow-always", "allow_always": return .allowAlways
-        case "reject": return .reject
-        case "answer": return .answer(choice: r.choice ?? "")
-        case "model": return .model(query: r.query ?? "")
-        case "switch-window", "switch_window": return .switchWindow(index: r.index ?? 1)
-        case "new-session", "new_session": return .newSession
-        case "open-settings", "open_settings": return .openSettings
-        default:
-            return .unknown(transcript: r.transcript ?? r.text ?? "")
-        }
-    }
-
-    /// The `answer` choice as a bare lowercase word (for "yes"/"no" cores);
-    /// otherwise `nil` so the caller treats it as an option label / free text.
-    static func choiceToken(_ choice: String) -> String? {
-        switch choice.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() {
-        case "yes", "yep", "ok", "okay", "sure": return "yes"
-        case "no", "nope", "nay": return "no"
-        default: return nil
-        }
-    }
 
     // MARK: - Attachment MIME detection
 

--- a/mobile/native/MantaUI/ComposerTypeahead.swift
+++ b/mobile/native/MantaUI/ComposerTypeahead.swift
@@ -13,9 +13,9 @@ import Foundation
 //    line up with `NSString` ranges and the `Mention.source` start/end the
 //    box expects.
 //  * `slashCommands` / `filterSlashCommands` — the compact `/` palette, listing
-//    exactly the actions the composer/store already implement (the voice
-//    `VoiceAction` set and the overflow sheet). Nothing new is invented here;
-//    a typed token that matches nothing is honestly absent from the palette.
+//    exactly the actions the composer/store already implement and the overflow
+//    sheet. Nothing new is invented here; a typed token that matches nothing is
+//    honestly absent from the palette.
 // ===========================================================================
 
 enum ComposerTypeahead {
@@ -135,9 +135,9 @@ enum ComposerTypeahead {
         return SlashAnchor(query: query)
     }
 
-    /// The actions the composer/store already implement — the voice
-    /// `VoiceAction` set and the overflow sheet, nothing more. Abort appears
-    /// only while a turn is running (that is the only time it is meaningful).
+    /// The actions the composer/store already implement and the overflow sheet,
+    /// nothing more. Abort appears only while a turn is running (that is the
+    /// only time it is meaningful).
     static func slashCommands(running: Bool) -> [SlashCommand] {
         var commands = [
             SlashCommand(id: "submit", title: "Submit", subtitle: "Send this message", kind: .submit),

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -54,9 +54,6 @@ struct ComposerView: View {
     /// not at the top of the whole bottom stack (chip / cards / anchors
     /// excluded).
     var onGlassBoxHeightChange: (CGFloat) -> Void = { _ in }
-    /// Flip the `chatAutoAllow` trust setting (voice `toggleTrust`, BET-748).
-    /// The chat screen owns the flip + revert; the composer just triggers it.
-    var onToggleTrust: (() -> Void)? = nil
     /// The session's working directory, threaded from the chat screen so the
     /// `@`-file typeahead searches within the session (BET-749). `findFiles`
     /// takes it directly, the same way `vcsBranch` does; nil when the session
@@ -80,7 +77,6 @@ struct ComposerView: View {
     @State private var showHint = false
     @FocusState private var inputFocused: Bool
     @StateObject private var recorder = VoiceRecorder()
-    @State private var micMode: VoiceMode = .dictate
     /// High-water flag for a press whose permission prompt is still resolving —
     /// lets `micPress` re-check the finger is still down after the await.
     @State private var micPressActive = false
@@ -680,19 +676,14 @@ struct ComposerView: View {
                 .onChanged { _ in micPress() }
                 .onEnded { _ in micRelease() }
         )
-        .simultaneousGesture(
-            LongPressGesture(minimumDuration: 0.5)
-                .onEnded { _ in promoteToCommand() }
-        )
-        .accessibilityLabel("Hold to dictate, long press for command")
+        .accessibilityLabel("Hold to dictate")
         .accessibilityIdentifier("mic-button")
         .disabled(!micAvailable)
     }
 
     private var micIcon: String {
         switch recorder.phase {
-        case .recording: return micMode == .command ? "waveform.badge.mic" : "mic.fill"
-        case .processing: return "hourglass"
+        case .recording: return "mic.fill"
         case .error: return "exclamationmark.triangle"
         default: return "mic"
         }
@@ -700,21 +691,21 @@ struct ComposerView: View {
 
     private var micIconFill: Color {
         switch recorder.phase {
-        case .recording: return micMode == .command ? tokens.danger.opacity(0.2) : tokens.accentSolid
+        case .recording: return tokens.accentSolid
         default: return tokens.inset
         }
     }
 
     private var micIconColor: Color {
         switch recorder.phase {
-        case .recording: return micMode == .command ? tokens.danger : tokens.onAccent
+        case .recording: return tokens.onAccent
         case .error: return tokens.danger
         default: return tokens.tx2
         }
     }
 
     private func micPress() {
-        guard micAvailable, recorder.phase != .recording, recorder.phase != .processing else { return }
+        guard micAvailable, recorder.phase != .recording else { return }
         // onChanged fires repeatedly during the permission await — one Task only.
         guard !micPressActive else { return }
         micPressActive = true
@@ -730,42 +721,30 @@ struct ComposerView: View {
             // starting now would record with no press and wedge the phase guard
             // (desktop parity: "cancel checked AFTER getUserMedia resolves").
             guard micPressActive else { return }
-            micMode = .dictate
             recorder.start()
         }
     }
 
-    private func promoteToCommand() {
-        guard recorder.phase == .recording else { return }
-        micMode = .command
-    }
-
     private func micRelease() {
         micPressActive = false
-        guard recorder.phase != .processing else { return }
         guard let data = recorder.stop() else {
             // Too short — treat as an accidental tap, not an error (§ desktop
             // too-short guard). Quiet.
             return
         }
-        let mode = micMode
         Task {
-            await transcribe(data: data, mode: mode)
+            await transcribe(data: data)
         }
     }
 
-    private func transcribe(data: Data, mode: VoiceMode) async {
+    private func transcribe(data: Data) async {
         let result = try? await api.voiceTranscribe(data: data, mime: "audio/mp4")
         let transcript = result?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
         guard !transcript.isEmpty else {
             hintState("No speech detected")
             return
         }
-        if mode == .command {
-            await classify(transcript)
-        } else {
-            await MainActor.run { insertAtCaret(transcript) }
-        }
+        await MainActor.run { insertAtCaret(transcript) }
     }
 
     /// Insert text at the caret (dictate). If the composer's text field is the
@@ -811,55 +790,6 @@ struct ComposerView: View {
             if let found = firstResponderTextView(in: sub) { return found }
         }
         return nil
-    }
-
-    private func classify(_ transcript: String) async {
-        guard let classify = try? await api.voiceClassifyCommand(transcript: transcript) else {
-            hintState("Couldn't understand that command")
-            return
-        }
-        let action = ChatVoice.parse(classify)
-        let hint = handleVoiceAction(action)
-        if let hint { hintState(hint) }
-    }
-
-    /// Route a typed voice action. Returns a hint string when the composer was
-    /// responsible for surfacing it (text-inserting / not-handled-here), nil
-    /// when the store handled it.
-    private func handleVoiceAction(_ action: VoiceAction) -> String? {
-        switch action {
-        case .submit(let text):
-            submitVoice(text)
-            return nil
-        case .append(let text):
-            if !text.isEmpty { insertAtCaret(text) }
-            return nil
-        case .model(let query):
-            if let model = ChatModel.findByQuery(modelStore.models, query: query) {
-                modelStore.setOverride(OpencodeModelID(providerID: model.providerID, modelID: model.id))
-                return nil
-            }
-            return "No model found for “\(query)”"
-        case .toggleTrust:
-            // Real toggle (BET-748): the chat screen flips `chatAutoAllow` and
-            // surfaces a failure through the store's `actionHint` bus. No hint
-            // is returned here — a successful flip needs no local answer, and
-            // a failure already reaches the user through that bus.
-            onToggleTrust?()
-            return nil
-        case .unknown(let transcript):
-            if !transcript.isEmpty { insertAtCaret(transcript) }
-            return nil
-        default:
-            return store.dispatchVoice(action)
-        }
-    }
-
-    private func submitVoice(_ voiceText: String) {
-        let trimmed = voiceText.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return }
-        insertAtCaret(trimmed)
-        submit()
     }
 
     // MARK: - Send

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -434,15 +434,6 @@ final class MantaAPIClient: Sendable {
         return ChatJSON.string(result?["text"])
     }
 
-    /// `voice:classify-command` — route a transcript through the box's rules +
-    /// (fallback) LLM classifier. Returns the structured action.
-    func voiceClassifyCommand(transcript: String, useLlmFallback: Bool? = nil) async throws -> VoiceClassifyResult? {
-        var input: [String: Any] = ["transcript": transcript]
-        if let useLlmFallback { input["useLlmFallback"] = useLlmFallback }
-        let envelope: VoiceClassifyEnvelope? = try await call("voice:classify-command", args: [input], as: VoiceClassifyEnvelope.self)
-        return envelope?.action
-    }
-
     /// `git:list-worktrees` — git worktree fan-out detection for a folder.
     func listWorktrees(_ cwd: String) async throws -> [MantaWorktree] {
         try await call("git:list-worktrees", args: [cwd], as: [MantaWorktree].self) ?? []
@@ -584,11 +575,4 @@ private struct ForkSessionResult: Decodable {
 
 private struct ClearSessionResult: Decodable {
     let newSessionId: String?
-}
-
-/// The `voice:classify-command` reply is `{ action, source }` — the action is
-/// the structured `VoiceAction`; `source` ("rules" | "llm" | "none") is
-/// diagnostic only and discarded here (the device never interprets).
-private struct VoiceClassifyEnvelope: Decodable {
-    var action: VoiceClassifyResult?
 }

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -254,13 +254,12 @@ enum PermissionReply: String, Sendable {
     case reject
 }
 
-// MARK: - S5 composer: model picker + voice (BET-597)
+// MARK: - S5 composer: model picker (BET-597)
 //
 // Models for the composer extras. `OpencodeModel` mirrors the box's
-// `opencode:models` payload (from `getProviders()` → `listModels()`); the
-// `VoiceClassifyResult` mirrors `voice:classify-command`'s reply. These are
-// wire DTOs only — resolution/selection logic lives in ChatModel / ChatVoice
-// (pure, tested).
+// `opencode:models` payload (from `getProviders()` → `listModels()`). These
+// are wire DTOs only — resolution/selection logic lives in ChatModel (pure,
+// tested).
 
 /// A model from a connected provider, as served by `opencode:models`.
 struct OpencodeModel: Codable, Equatable, Sendable {
@@ -287,20 +286,6 @@ struct OpencodeModelID: Codable, Equatable, Hashable, Sendable {
         case providerID
         case modelID
     }
-}
-
-/// The box-side voice classifier's reply (voice:classify-command). Standard
-/// actions carry `kind` (+ optional payload); the LLM fallback degrades to
-/// `unknown` carrying the verbatim transcript. Never interpreted device-side —
-/// the classifier IS the box.
-struct VoiceClassifyResult: Codable, Equatable, Sendable {
-    var kind: String?
-    var text: String?
-    var index: Int?
-    var query: String?
-    var choice: String?
-    var transcript: String?
-    var actions: [VoiceClassifyResult]?
 }
 // MARK: - Overflow sheet resources (BET-627: attach, scheduled tasks, secrets)
 //

--- a/mobile/native/MantaUI/VoiceRecorder.swift
+++ b/mobile/native/MantaUI/VoiceRecorder.swift
@@ -4,11 +4,10 @@ import Foundation
 // ===========================================================================
 // S5 — iOS voice capture (BET-597).
 //
-// A thin AVFoundation recorder. The recording, transcription AND command
-// classification all live on the box (Groq via `voice:transcribe` /
-// `voice:classify-command`) — the device's only job here is to capture the
-// audio and hand the bytes over, exactly as the desktop does. This file owns
-// the capture + the mic permission gate; it does NOT transcribe or classify.
+// A thin AVFoundation recorder. The recording AND transcription live on the
+// box (Groq via `voice:transcribe`) — the device's only job here is to capture
+// the audio and hand the bytes over, exactly as the desktop does. This file
+// owns the capture + the mic permission gate; it does NOT transcribe.
 //
 // The mime is `audio/mp4`: iOS records AAC-in-.m4a via AVAudioRecorder, the
 // only sane container on Apple platforms (matches the retired web client's
@@ -20,9 +19,7 @@ final class VoiceRecorder: ObservableObject {
 
     enum Phase: Equatable {
         case idle
-        case requesting       // waiting on mic permission / session start
         case recording
-        case processing       // stop requested, bytes being handed to the box
         case error(String)
     }
 
@@ -105,14 +102,6 @@ final class VoiceRecorder: ObservableObject {
         discard()
         phase = .idle
         return data
-    }
-
-    /// Cancel a capture (e.g. the user drags away before release).
-    func cancel() {
-        recorder?.stop()
-        discard()
-        deactivateSession()
-        phase = .idle
     }
 
     /// Surface a transient error phase to the UI (caller supplies the reason).

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -3,8 +3,8 @@ import XCTest
 
 // ===========================================================================
 // S5 — composer pure logic (BET-597). Covers ChatModel (model resolution for
-// the picker) and ChatVoice (classifier-reply mapping + attachment MIME). No
-// HTTP / view / Keychain / AVAudioRecorder involved.
+// the picker) and ChatVoice (attachment MIME). No HTTP / view / Keychain /
+// AVAudioRecorder involved.
 // ===========================================================================
 
 final class ComposerTests: XCTestCase {
@@ -171,49 +171,6 @@ final class ComposerTests: XCTestCase {
         XCTAssertEqual(ChatModel.filteredGroups(g, query: "  ").first?.models.count, 2)
     }
 
-    // MARK: - ChatVoice.parse
-
-    private func classify(_ kind: String, text: String? = nil, choice: String? = nil, query: String? = nil, index: Int? = nil, transcript: String? = nil) -> VoiceClassifyResult {
-        VoiceClassifyResult(kind: kind, text: text, index: index, query: query, choice: choice, transcript: transcript, actions: nil)
-    }
-
-    func testParseStandardActions() {
-        XCTAssertEqual(ChatVoice.parse(classify("abort")), .abort)
-        XCTAssertEqual(ChatVoice.parse(classify("compact")), .compact)
-        XCTAssertEqual(ChatVoice.parse(classify("allow-once")), .allowOnce)
-        XCTAssertEqual(ChatVoice.parse(classify("reject")), .reject)
-        XCTAssertEqual(ChatVoice.parse(classify("submit", text: "look at this")), .submit(text: "look at this"))
-        XCTAssertEqual(ChatVoice.parse(classify("append", text: "remember")), .append(text: "remember"))
-        XCTAssertEqual(ChatVoice.parse(classify("answer", choice: "3")), .answer(choice: "3"))
-        XCTAssertEqual(ChatVoice.parse(classify("model", query: "haiku")), .model(query: "haiku"))
-        XCTAssertEqual(ChatVoice.parse(classify("switch-window", index: 2)), .switchWindow(index: 2))
-    }
-
-    func testParseToggleTrustMapsToTupleHead() {
-        // Both wire spellings of the toggle-trust kind map to `.toggleTrust`,
-        // the action the composer now routes to the real `chatAutoAllow` toggle
-        // (BET-748) rather than the old "isn't available in this chat" answer.
-        XCTAssertEqual(ChatVoice.parse(classify("toggle-trust")), .toggleTrust)
-        XCTAssertEqual(ChatVoice.parse(classify("toggle_trust")), .toggleTrust)
-        // The fallback hint no longer describes trust mode as unavailable.
-        XCTAssertNotEqual(ChatVoiceHint.text(for: .toggleTrust), "Trust mode isn't available in this chat")
-    }
-
-    func testParseUnknownDegrades() {
-        XCTAssertEqual(ChatVoice.parse(classify("unknown", transcript: "do the thing")), .unknown(transcript: "do the thing"))
-        // A nil/empty kind is treated as unknown.
-        XCTAssertEqual(ChatVoice.parse(classify("", transcript: "hi")), .unknown(transcript: "hi"))
-    }
-
-    // MARK: - ChatVoice.choiceToken
-
-    func testChoiceTokenCores() {
-        XCTAssertEqual(ChatVoice.choiceToken("yes"), "yes")
-        XCTAssertEqual(ChatVoice.choiceToken("NOPE"), "no")
-        XCTAssertEqual(ChatVoice.choiceToken("okay"), "yes")
-        XCTAssertNil(ChatVoice.choiceToken("the third one"))
-    }
-
     // MARK: - ChatVoice.mime
 
     func testMimeFromFilenameExtension() {
@@ -228,15 +185,5 @@ final class ComposerTests: XCTestCase {
         XCTAssertEqual(ChatVoice.mime(forImageData: Data(jpeg)), "image/jpeg")
         XCTAssertEqual(ChatVoice.mime(forImageData: Data(png)), "image/png")
         XCTAssertEqual(ChatVoice.mime(forImageData: Data([0x00, 0x01, 0x02])), "image/jpeg")
-    }
-
-    // MARK: - Voice action store routing (permission/question)
-
-    @MainActor
-    func testDispatchVoiceAnswerFallsBackWhenNoQuestion() {
-        // No question pending → a hint (non-nil), and it must not crash.
-        let store = ChatSessionStore(sessionId: "ses", eventStore: MantaEventStore(), api: MantaAPIClient(serverURL: URL(string: "https://box.example")!))
-        let hint = store.dispatchVoice(.answer(choice: "yes"))
-        XCTAssertNotNil(hint)
     }
 }


### PR DESCRIPTION
## What

Stage 1 pure deletion for the iOS client (`mobile/native/`), sibling of BET-831 (TypeScript deletion). Removes the `voice:classify-command` command mode from the native Swift client — after this, iOS voice is **dictation only** (hold mic, release, transcript inserted at caret). No TypeScript touched.

## Changes (net **-289** lines)

- `ComposerView.swift` — drop `micMode`, `promoteToCommand()`, the `LongPressGesture` long-press promotion (kept the `DragGesture` recording interaction), `classify(...)`, `handleVoiceAction(...)`, `submitVoice(...)`, and the now-dead `onToggleTrust` property + its `ChatScreen` call site. `transcribe(data:mode:)` → `transcribe(data:)` (transcribe then insert at caret). Collapsed the mic glyph/fill/color helpers to the single dictate case. Removed the unreachable `.processing` branches.
- `ChatVoice.swift` — removed `VoiceMode`, `VoiceAction`, `ChatVoiceHint`, `ChatVoice.parse`, `ChatVoice.choiceToken`. **Kept** the MIME helpers (`mime(forFilename:)`, `chipLabel(forFilename:)`, `mime(forImageData:)`).
- `MantaAPIClient.swift` — removed `voiceClassifyCommand(...)` + `VoiceClassifyEnvelope`. **Kept `voiceTranscribe`** unchanged.
- `MantaModels.swift` — removed the `VoiceClassifyResult` wire DTO.
- `ChatSessionStore.swift` — removed `dispatchVoice(...)` (nothing calls it after the above). **Left `answerLatestQuestion` alone** (unrelated, as scoped).
- `VoiceRecorder.swift` — removed `cancel()` (never called) and `Phase.requesting`/`.processing` (never assigned). No other recorder changes.
- `ComposerTests.swift` — removed the voice-command test cases (parse, choiceToken, store routing); kept the attachment-MIME tests.
- `ComposerTypeahead.swift` — doc-comment cleanup only.

## Verification

- `rg -i "voiceclassify|VoiceAction|promoteToCommand|micMode|choiceToken" mobile/native/` → **nothing** (verified).
- iOS target build + on-device dictate verification are **Apple-side steps** — handed to the `macos` agent to run against this branch.
- TypeScript side untouched (sibling BET-831 covers the TS/RPC `voice:classify-command` channel deletion).

Base: origin/main @ e7ad3fde