### PR TITLE
BET-833: shared waveform maths, clock formatter and recording constants

### DIFF
--- a/src/shared/waveform.d.mts
+++ b/src/shared/waveform.d.mts
@@ -1,0 +1,22 @@
+// Hand-written type declarations for waveform.mjs. The implementation is
+// plain JS so it can be imported by both Node-side modules (.mjs natively,
+// .ts via Bundler resolution) and the renderer test suite (vitest .ts file).
+// Keep this in sync with src/shared/waveform.mjs.
+
+export const VOICE_SAMPLE_INTERVAL_MS: number;
+export const VOICE_MAX_STORED_PEAKS: number;
+export const VOICE_LIVE_WINDOW_BARS: number;
+export const VOICE_MAX_DURATION_MS: number;
+export const VOICE_WARN_REMAINING_MS: number;
+export const VOICE_MIN_DURATION_MS: number;
+export const VOICE_CONFIRM_DISCARD_MS: number;
+
+export function quantizePeak(v: number): number;
+
+export function downsamplePeaks(samples: number[], max?: number): Uint8Array;
+
+export function bucketPeaks(peaks: Uint8Array, bars: number): number[];
+
+export function normalizeForDisplay(values: number[]): number[];
+
+export function formatClock(ms: number): string;

--- a/src/shared/waveform.mjs
+++ b/src/shared/waveform.mjs
@@ -1,0 +1,138 @@
+// waveform.mjs — shared maths for voice-note waveforms.
+//
+// Used by the live recorder, the transcript player, and (later) the iOS
+// client, which ports this exact spec. Keep it dependency-free and pure so it
+// stays portable — same rule voiceClassifier.mjs follows. No I/O, no React.
+//
+// The peak contract — fixed, do not vary:
+//   A voice note's waveform is stored as `Uint8Array`, one byte per sample,
+//   0-255, where 255 is full scale. At most VOICE_MAX_STORED_PEAKS samples per
+//   note regardless of length (~400 bytes, small enough to keep forever even
+//   after the audio is swept).
+
+export const VOICE_SAMPLE_INTERVAL_MS = 40;      // peak capture cadence
+export const VOICE_MAX_STORED_PEAKS = 400;       // max samples kept per note
+export const VOICE_LIVE_WINDOW_BARS = 90;        // ≈3.6 s visible at 40 ms
+export const VOICE_MAX_DURATION_MS = 300_000;    // 5 min hard cap
+export const VOICE_WARN_REMAINING_MS = 30_000;   // warn in the last 30 s
+export const VOICE_MIN_DURATION_MS = 400;        // shorter is a mis-tap, discarded silently
+export const VOICE_CONFIRM_DISCARD_MS = 30_000;  // above this, discard asks for confirmation
+
+/**
+ * Clamp a float 0..1 to an integer 0..255.
+ * `v <= 0 -> 0`, `v >= 1 -> 255`, `NaN -> 0`.
+ * @param {number} v
+ * @returns {number}
+ */
+export function quantizePeak(v) {
+  if (Number.isNaN(v)) return 0;
+  if (v <= 0) return 0;
+  if (v >= 1) return 255;
+  return Math.round(v * 255);
+}
+
+/**
+ * Reduce a stream of float peaks (one every VOICE_SAMPLE_INTERVAL_MS) to at
+ * most `max` quantized bytes.
+ *
+ * - `samples.length <= max` -> quantize each and return as-is (do NOT pad).
+ * - Otherwise split into exactly `max` contiguous buckets as evenly as
+ *   possible and take the MAXIMUM of each bucket, then quantize.
+ * - Max, never mean. Averaging flattens speech into a featureless band; the
+ *   peak is what makes a waveform look like speech.
+ * - Empty input -> empty `Uint8Array`.
+ *
+ * @param {number[]} samples
+ * @param {number} [max]
+ * @returns {Uint8Array}
+ */
+export function downsamplePeaks(samples, max = 400) {
+  const n = samples.length;
+  if (n === 0) return new Uint8Array(0);
+  if (n <= max) return Uint8Array.from(samples, quantizePeak);
+  const out = new Uint8Array(max);
+  for (let b = 0; b < max; b++) {
+    const start = Math.floor((b * n) / max);
+    const end = Math.floor(((b + 1) * n) / max);
+    let peak = 0;
+    for (let i = start; i < end; i++) {
+      if (samples[i] > peak) peak = samples[i];
+    }
+    out[b] = quantizePeak(peak);
+  }
+  return out;
+}
+
+/**
+ * Render-time reduction of a stored waveform to a fixed bar count. Returns
+ * floats 0..1.
+ *
+ * - `bars <= 0` or empty input -> `[]`.
+ * - Fewer peaks than bars -> one value per peak (the caller draws fewer bars;
+ *   it must not stretch).
+ * - Otherwise bucket and take the MAXIMUM per bucket, divided by 255.
+ *
+ * @param {Uint8Array} peaks
+ * @param {number} bars
+ * @returns {number[]}
+ */
+export function bucketPeaks(peaks, bars) {
+  if (bars <= 0 || peaks.length === 0) return [];
+  const n = peaks.length;
+  if (n <= bars) return Array.from(peaks, (p) => p / 255);
+  const out = new Array(bars);
+  for (let b = 0; b < bars; b++) {
+    const start = Math.floor((b * n) / bars);
+    const end = Math.floor(((b + 1) * n) / bars);
+    let peak = 0;
+    for (let i = start; i < end; i++) {
+      if (peaks[i] > peak) peak = peaks[i];
+    }
+    out[b] = peak / 255;
+  }
+  return out;
+}
+
+/**
+ * Scale so the loudest bar is 1.0. For the stored/playback waveform only.
+ * Empty -> `[]`. Max is 0 -> return all zeros unchanged.
+ *
+ * This function must NOT be used for the live meter. The live meter pins its
+ * ceiling at 1.0 deliberately: renormalising a scrolling window makes every
+ * previously-drawn bar jump each time a new loudest sample arrives, and the
+ * waveform visibly dances.
+ *
+ * @param {number[]} values
+ * @returns {number[]}
+ */
+export function normalizeForDisplay(values) {
+  const n = values.length;
+  if (n === 0) return [];
+  let max = 0;
+  for (const v of values) {
+    if (v > max) max = v;
+  }
+  if (max === 0) return values.slice();
+  return values.map((v) => v / max);
+}
+
+/**
+ * Format a millisecond duration as `m:ss`, zero-padded seconds, no hours (the
+ * cap is VOICE_MAX_DURATION_MS). `0 -> "0:00"`, `14200 -> "0:14"`, `63000 ->
+ * "1:03"`. Negative / non-finite -> `"0:00"`.
+ *
+ * Do NOT consolidate this with `formatDuration` in chatUtils.ts. That one
+ * renders `"1m3s"` for turn durations and is used elsewhere (turn list). This
+ * is a different format for a different job; the near-duplicate is
+ * intentional.
+ *
+ * @param {number} ms
+ * @returns {string}
+ */
+export function formatClock(ms) {
+  if (!Number.isFinite(ms) || ms < 0) return "0:00";
+  const total = Math.floor(ms / 1000);
+  const min = Math.floor(total / 60);
+  const sec = total % 60;
+  return `${min}:${String(sec).padStart(2, "0")}`;
+}

--- a/src/shared/waveform.test.ts
+++ b/src/shared/waveform.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import {
+  VOICE_SAMPLE_INTERVAL_MS,
+  VOICE_MAX_STORED_PEAKS,
+  VOICE_LIVE_WINDOW_BARS,
+  VOICE_MAX_DURATION_MS,
+  VOICE_WARN_REMAINING_MS,
+  VOICE_MIN_DURATION_MS,
+  VOICE_CONFIRM_DISCARD_MS,
+  quantizePeak,
+  downsamplePeaks,
+  bucketPeaks,
+  normalizeForDisplay,
+  formatClock,
+} from "./waveform.mjs";
+
+describe("recording constants", () => {
+  it("export the documented values so later tickets never hardcode them", () => {
+    expect(VOICE_SAMPLE_INTERVAL_MS).toBe(40);
+    expect(VOICE_MAX_STORED_PEAKS).toBe(400);
+    expect(VOICE_LIVE_WINDOW_BARS).toBe(90);
+    expect(VOICE_MAX_DURATION_MS).toBe(300_000);
+    expect(VOICE_WARN_REMAINING_MS).toBe(30_000);
+    expect(VOICE_MIN_DURATION_MS).toBe(400);
+    expect(VOICE_CONFIRM_DISCARD_MS).toBe(30_000);
+  });
+});
+
+describe("quantizePeak", () => {
+  it("clamps at the bounds", () => {
+    expect(quantizePeak(0)).toBe(0);
+    expect(quantizePeak(-0.5)).toBe(0);
+    expect(quantizePeak(1)).toBe(255);
+    expect(quantizePeak(2)).toBe(255);
+  });
+  it("rounds interior values to 0..255", () => {
+    expect(quantizePeak(0.5)).toBe(128);
+    expect(quantizePeak(0.1)).toBe(26);
+    expect(quantizePeak(0.9)).toBe(230);
+  });
+  it("maps NaN to 0", () => {
+    expect(quantizePeak(NaN)).toBe(0);
+  });
+});
+
+describe("downsamplePeaks", () => {
+  it("returns empty for empty input", () => {
+    expect(Array.from(downsamplePeaks([]))).toEqual([]);
+  });
+  it("quantizes and returns as-is (no padding) when <= max", () => {
+    const out = downsamplePeaks([0, 0.5, 1], 400);
+    expect(Array.from(out)).toEqual([0, 128, 255]);
+  });
+  it("splits non-multiple sample counts into even buckets", () => {
+    // 10 samples into 3 buckets -> bucket widths 3, 3, 4.
+    const samples = [0.1, 0.2, 0.3, 0.4, 0.5, 0.6, 0.7, 0.8, 0.9, 1.0];
+    const out = downsamplePeaks(samples, 3);
+    // bucket0 max 0.3 -> 77, bucket1 max 0.6 -> 153, bucket2 max 1.0 -> 255
+    expect(Array.from(out)).toEqual([77, 153, 255]);
+  });
+  it("keeps a single loud spike inside a quiet bucket (max, not mean)", () => {
+    // Bucket 0 is all quiet (~0.1); bucket 1 holds the 1.0 spike.
+    const samples = [0.1, 0.1, 0.1, 1.0, 0.1, 0.1];
+    const out = downsamplePeaks(samples, 2);
+    // A mean would give ~25 for the quiet bucket; the peak survives instead.
+    expect(Array.from(out)).toEqual([26, 255]);
+  });
+  it("caps output length at max for a long recording", () => {
+    const samples = new Array(7500).fill(0.5);
+    const out = downsamplePeaks(samples, 400);
+    expect(out.length).toBe(400);
+    expect(out[0]).toBe(128);
+  });
+});
+
+describe("bucketPeaks", () => {
+  it("returns [] for bars <= 0", () => {
+    expect(bucketPeaks(new Uint8Array([1, 2]), 0)).toEqual([]);
+    expect(bucketPeaks(new Uint8Array([1, 2]), -3)).toEqual([]);
+  });
+  it("returns [] for empty input", () => {
+    expect(bucketPeaks(new Uint8Array(0), 10)).toEqual([]);
+  });
+  it("returns one value per peak when fewer peaks than bars (no stretch)", () => {
+    expect(bucketPeaks(new Uint8Array([255, 0]), 10)).toEqual([1, 0]);
+    expect(bucketPeaks(new Uint8Array([255]), 5)).toEqual([1]);
+  });
+  it("buckets and divides by 255", () => {
+    const peaks = new Uint8Array([26, 51, 77, 102, 128, 153, 179, 204, 230, 255]);
+    const out = bucketPeaks(peaks, 3);
+    // buckets of widths 3,3,4: max(0..2)=77, max(3..5)=153, max(6..9)=255
+    expect(out).toEqual([77 / 255, 153 / 255, 255 / 255]);
+  });
+});
+
+describe("normalizeForDisplay", () => {
+  it("returns [] for empty input", () => {
+    expect(normalizeForDisplay([])).toEqual([]);
+  });
+  it("returns all zeros unchanged when max is 0", () => {
+    expect(normalizeForDisplay([0, 0, 0])).toEqual([0, 0, 0]);
+  });
+  it("scales so the loudest bar is 1.0", () => {
+    expect(normalizeForDisplay([0.25, 0.5, 1.0])).toEqual([0.25, 0.5, 1.0]);
+    expect(normalizeForDisplay([0.5, 0.25])).toEqual([1.0, 0.5]);
+  });
+  it("does not mutate the input", () => {
+    const input = [0.5, 0.25];
+    const out = normalizeForDisplay(input);
+    expect(out).toEqual([1.0, 0.5]);
+    expect(input).toEqual([0.5, 0.25]);
+  });
+});
+
+describe("formatClock", () => {
+  it("formats as m:ss with zero-padded seconds", () => {
+    expect(formatClock(0)).toBe("0:00");
+    expect(formatClock(14200)).toBe("0:14");
+    expect(formatClock(63000)).toBe("1:03");
+    expect(formatClock(5 * 60_000 + 9000)).toBe("5:09");
+  });
+  it("handles negatives and non-finite as 0:00", () => {
+    expect(formatClock(-1)).toBe("0:00");
+    expect(formatClock(NaN)).toBe("0:00");
+    expect(formatClock(Infinity)).toBe("0:00");
+  });
+});


### PR DESCRIPTION
## BET-833 — Voice: shared waveform maths, clock formatter and recording constants

Stage 1 of the voice-note work. Adds pure, dependency-free shared maths used by both the live recorder and the transcript player — no UI, no I/O, no React.

### Contents
- `src/shared/waveform.mjs` — the module
- `src/shared/waveform.d.mts` — hand-written declarations (same pattern as `voiceClassifier`)
- `src/shared/waveform.test.ts` — 19 unit tests

### Functions
- `quantizePeak(v)` — clamp 0..1 → 0..255, `NaN → 0`
- `downsamplePeaks(samples, max=400)` — reduce capture stream to ≤400 bytes, **max** per bucket (never mean); shorter inputs returned as-is (no padding)
- `bucketPeaks(peaks, bars)` — render-time reduction to bars, floats 0..1
- `normalizeForDisplay(values)` — scale loudest bar to 1.0 (playback only; doc note explains why it must NOT be used for the live meter)
- `formatClock(ms)` — `m:ss`, zero-padded seconds; doc note explains the intentional near-duplicate with `formatDuration` in `chatUtils.ts`

Plus the seven recording-limit constants exported for later tickets (no hardcoding).

### Verification
- `npm run typecheck` ✅
- `npm test` ✅ (646 pass, 0 fail)
- Nothing outside `src/shared/waveform*` changed.