### PR TITLE
feat(ios): stream tool callID so live and canonical step rows share one identity (BET-823)

### DIFF
--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -271,7 +271,7 @@ enum ChatTranscriptMapper {
     /// Append the still-running LIVE tools (streamed mid-turn by the box) to the
     /// transcript, in the turn that spawned them.
     ///
-    /// This is the replacement for the deleted pinned `RunningToolRow` overlay:
+    /// This is the replacement for the deleted pinned running-tool overlay:
     /// a tool call renders inside the transcript (tailing its output as a live
     /// step) instead of floating above the composer. Each live tool becomes a
     /// `.running` step keyed by the SAME `callID` the canonical `stepIdentity`

--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -306,7 +306,12 @@ enum ChatTranscriptMapper {
                 return step.id
             }
         })
-        let toAppend = liveSteps.filter { !existingIDs.contains($0.id) }
+        // A live tool becomes a `.step` row — the `.rows` case holds
+        // `[StepGroupRow]`, and a step row is the step payload wrapped in
+        // `.step`. Deduping uses the ToolStep id before wrapping.
+        let toAppend: [StepGroupRow] = liveSteps
+            .filter { !existingIDs.contains($0.id) }
+            .map { .step($0) }
         guard !toAppend.isEmpty else { return blocks }
 
         var result = blocks

--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -119,12 +119,37 @@ enum ChatClock {
     }
 }
 
-/// Map a tool part's `state.status` string onto the StepStatus dot.
+/// Map a tool part's `state.status` string onto the StepStatus taxonomy.
 enum StepStatusFromTool {
     static func status(_ raw: String?) -> StepStatus {
-        // Only an explicit terminal "completed" is `done`; everything else
-        // (pending / running / error) is a live `running` row.
-        raw?.lowercased() == "completed" ? .done : .running
+        switch (raw ?? "").lowercased() {
+        case "completed": return .completed
+        case "error": return .error
+        case "denied": return .denied
+        case "awaitingapproval", "awaiting_approval": return .awaitingApproval
+        case "pending": return .pending
+        default: return .running
+        }
+    }
+}
+
+/// Whether a step row renders expanded, given its state and the user's manual
+/// override. Pure so it is unit-testable with no view dependencies (mirrors the
+/// `BranchFreshnessPolicy` shape in ChatScreen.swift).
+enum StepDisclosure {
+    /// User intent always wins: a row someone opened must never close under
+    /// them, and a row they closed must stay closed. Only when the user has
+    /// not touched the row does the state-driven default apply.
+    static func expanded(status: StepStatus, userToggled: Bool?) -> Bool {
+        if let userToggled { return userToggled }
+        switch status {
+        case .running, .awaitingApproval, .error, .denied:
+            // Live output tails; a failure must never auto-collapse.
+            return true
+        case .completed, .pending:
+            // Keeps a many-step turn readable by default.
+            return false
+        }
     }
 }
 
@@ -241,6 +266,56 @@ enum ChatTranscriptMapper {
         }
         flush(&pending, into: &blocks)
         return blocks
+    }
+
+    /// Append the still-running LIVE tools (streamed mid-turn by the box) to the
+    /// transcript, in the turn that spawned them.
+    ///
+    /// This is the replacement for the deleted pinned `RunningToolRow` overlay:
+    /// a tool call renders inside the transcript (tailing its output as a live
+    /// step) instead of floating above the composer. Each live tool becomes a
+    /// `.running` step keyed by the SAME `callID` the canonical `stepIdentity`
+    /// uses, so a live row and its completed canonical sibling share one
+    /// identity and the turn-boundary refetch replaces the row IN PLACE — no
+    /// remove-and-reinsert flash (the whole point of this issue).
+    ///
+    /// A live tool whose `callID` the transcript already owns is skipped: the
+    /// canonical step has taken over, so appending again would duplicate it.
+    /// Live tools append to the LAST unrolled `.steps` group (continuing the
+    /// turn's rail); if the last step block is a rolled-up summary — completed
+    /// content a running tool does not belong to — or there is none, a fresh
+    /// group is opened at the end.
+    static func appendingLiveTools(_ liveTools: [LiveTool], to blocks: [TranscriptBlock]) -> [TranscriptBlock] {
+        guard !liveTools.isEmpty else { return blocks }
+
+        let liveSteps: [ToolStep] = liveTools.map { tool in
+            ToolStep(
+                id: tool.callID.isEmpty ? tool.idx : tool.callID,
+                verb: StepVerb.text(for: tool.name ?? "tool"),
+                target: tool.presentationHint.flatMap { $0.isEmpty ? nil : $0 } ?? tool.name ?? "tool",
+                duration: "",
+                status: .running,
+                output: tool.tail.isEmpty ? nil : tool.tail
+            )
+        }
+
+        let existingIDs = Set(blocks.flatMap { block -> [String] in
+            guard case .steps(let content) = block else { return [] }
+            return content.rows.compactMap { row -> String? in
+                guard case .step(let step) = row else { return nil }
+                return step.id
+            }
+        })
+        let toAppend = liveSteps.filter { !existingIDs.contains($0.id) }
+        guard !toAppend.isEmpty else { return blocks }
+
+        var result = blocks
+        if let last = result.indices.last, case .steps(.rows(let rows)) = result[last] {
+            result[last] = .steps(.rows(rows + toAppend))
+        } else {
+            result.append(.steps(.rows(toAppend)))
+        }
+        return result
     }
 
     private static func flush(_ pending: inout [StepGroupRow], into blocks: inout [TranscriptBlock]) {

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -809,32 +809,13 @@ private struct ChatScreenContent: View {
     @ViewBuilder
     private var bottomCards: some View {
         VStack(spacing: Metrics.spacing.sp3) {
-            // LIVE running-tool rows (BET-753): what the box is doing mid-turn,
-            // pinned above the composer. Each vanishes when its `toolEnded`
-            // frame lands and the canonical refetch renders it as a step row.
-            if !store.runningTools.isEmpty {
-                ForEach(Array(store.runningTools.enumerated()), id: \.element.idx) { _, tool in
-                    RunningToolRow(tool: tool, tokens: tokens)
-                        .transition(.opacity)
-                }
-            }
-            if let err = store.sessionError {
-                ChatNoticeRow(text: err.message, color: tokens.danger, tokens: tokens)
-            }
-            if let trunc = store.truncation, !store.running {
-                ChatNoticeRow(text: trunc.label ?? "Response truncated", color: tokens.warn, tokens: tokens)
-            }
-            if !store.queuedPrompts.isEmpty {
-                ChatNoticeRow(
-                    text: store.queuedPrompts.count == 1
-                        ? "1 message queued — sends when this turn finishes"
-                        : "\(store.queuedPrompts.count) messages queued — send when this turn finishes",
-                    color: tokens.tx2,
-                    tokens: tokens
-                )
-            }
+            // Only things that BLOCK the turn and need a tap stay here. Live
+            // running tools now render INSIDE the transcript (in the turn that
+            // spawned them); sessionError / truncation / queued prompts moved
+            // into the transcript tail too. Todos stay, collapsed to a single
+            // line while a turn runs.
             if let todos = store.todos, !(todos.visible?.visible ?? todos.active ?? []).isEmpty {
-                TodosCard(payload: todos, tokens: tokens)
+                TodosCard(payload: todos, tokens: tokens, compact: store.running)
             }
             if let permission = newestPermission {
                 PermissionCard(permission: permission, tokens: tokens) { reply in
@@ -952,6 +933,9 @@ struct ChatSubagentScreen: View {
 private struct TodosCard: View {
     let payload: StreamTodosPayload
     let tokens: Tokens
+    /// True while a turn runs: the card collapses to a single summary line so
+    /// the pinned area reads quiet during work (BET-823).
+    let compact: Bool
 
     /// The rows to draw: the box already computes the "top 5 + hidden counts"
     /// window (`visible`), so prefer it and fall back to the raw active list.
@@ -974,18 +958,22 @@ private struct TodosCard: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
-            // The box's todo items carry NO id field, ever, so every item's
-            // `id` is nil and keying on it gives every row the SAME identity —
-            // SwiftUI then renders one row's content repeated N times. Key on
-            // array POSITION instead: position IS the identity here, exactly as
-            // the desktop card does (src/renderer/MessageRow.tsx, ActiveTodos).
-            ForEach(Array(rows.enumerated()), id: \.offset) { pair in
-                todoRow(pair.element)
-            }
-            if let overflowSummary {
-                Text(overflowSummary)
-                    .font(.manta(size: Metrics.type.xs))
-                    .foregroundColor(tokens.tx4)
+            if compact {
+                compactRow
+            } else {
+                // The box's todo items carry NO id field, ever, so every item's
+                // `id` is nil and keying on it gives every row the SAME identity —
+                // SwiftUI then renders one row's content repeated N times. Key on
+                // array POSITION instead: position IS the identity here, exactly as
+                // the desktop card does (src/renderer/MessageRow.tsx, ActiveTodos).
+                ForEach(Array(rows.enumerated()), id: \.offset) { pair in
+                    todoRow(pair.element)
+                }
+                if let overflowSummary {
+                    Text(overflowSummary)
+                        .font(.manta(size: Metrics.type.xs))
+                        .foregroundColor(tokens.tx4)
+                }
             }
         }
         .padding(.horizontal, Metrics.spacing.sp3)
@@ -997,6 +985,30 @@ private struct TodosCard: View {
         )
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("todos-card")
+    }
+
+    /// The single-line collapse shown during a running turn — a count summary
+    /// with the in-progress figure, so the user still knows work is pending
+    /// without a full checklist pinning the composer.
+    private var compactRow: some View {
+        HStack(spacing: Metrics.spacing.sp2) {
+            Image(systemName: "checklist")
+                .font(.system(size: Metrics.type.xs))
+                .foregroundColor(tokens.tx4)
+            Text(compactSummary)
+                .font(.manta(size: Metrics.type.small))
+                .foregroundColor(tokens.tx2)
+                .lineLimit(1)
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var compactSummary: String {
+        let total = rows.count
+        let inProgress = rows.filter { ($0.status ?? "").lowercased() == "in_progress" }.count
+        if total <= 1 { return "1 todo" }
+        if inProgress == 0 { return "\(total) todos" }
+        return "\(total) todos · \(inProgress) in progress"
     }
 
     /// One todo row. Status styling matches the desktop; `status` is compared
@@ -1232,27 +1244,5 @@ private struct QuestionCard: View {
                 customText: customText
             )
         )
-    }
-}
-
-// MARK: - Shared notice row (session errors / truncation)
-
-private struct ChatNoticeRow: View {
-    let text: String
-    let color: Color
-    let tokens: Tokens
-    var body: some View {
-        HStack(spacing: 8) {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .font(.system(size: Metrics.type.xs, weight: .semibold))
-                .foregroundColor(color)
-            Text(text)
-                .font(.manta(size: Metrics.type.xs))
-                .foregroundColor(color)
-                .lineLimit(3)
-            Spacer(minLength: 0)
-        }
-        .padding(10)
-        .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: 10))
     }
 }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -168,11 +168,6 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var questions: [QuestionRequest] = []
     @Published private(set) var permissions: [PermissionRequest] = []
     @Published private(set) var subagents: [StreamSubagentPayload] = []
-    /// Live tools currently running on the box, in start order (BET-753). The
-    /// chat renders each as a running-tool row with its live bash tail; a tool
-    /// leaves the set the moment its `toolEnded` frame lands, and the canonical
-    /// turn-boundary refetch renders it as a step row.
-    @Published private(set) var runningTools: [LiveTool] = []
     @Published private(set) var childStores: [String: ChatSessionStore] = [:]
     /// Prompts accepted mid-turn, FIFO. Drained one per idle edge — never
     /// POSTed while `running`, which is what used to implicitly abort the
@@ -418,7 +413,6 @@ final class ChatSessionStore: ObservableObject {
         sessionError = s.sessionError
         todos = s.todos
         subagents = s.subagents
-        runningTools = s.runningTools
 
         // Which frame (if any) just changed this session's stream state. The
         // `$sessionStates` sink fires on every republish, so the stamp only
@@ -582,10 +576,29 @@ final class ChatSessionStore: ObservableObject {
     /// visible duplicate, not a harmless overlap. The tail is emptied by the
     /// retirement step in `fetchTranscript`; nothing else may append to it.
     private func rebuildBlocks() {
-        // `uniqueTranscriptRows` (not a bare `stableScrollID` map) is
-        // load-bearing: content-derived ids can collide across a long history,
-        // and a duplicate id traps inside MessagingUI's diff the moment
-        // `loadEarlier()` widens the window over the colliding pair.
+        // LIVE running tools, appended into THIS turn's step rail. They are not
+        // canonical content, so they merge here (on every stream frame) rather
+        // than in the mapper that feeds `transcript` — that keeps `transcript`
+        // pristine while the live rows tail their output and vanish on
+        // turnComplete (when the canonical refetch takes them over as steps).
+        let liveTools = eventStore.sessionStates[sessionId]?.runningTools ?? []
+        let liveTranscript = ChatTranscriptMapper.appendingLiveTools(liveTools, to: transcript)
+
+        // Terminal state of the current turn, MOVED out of the pinned area into
+        // the transcript, at the end of the turn it belongs to: session errors
+        // and truncations scroll WITH their turn rather than hovering over the
+        // composer.
+        var trailing: [TranscriptBlock] = []
+        if let err = sessionError {
+            trailing.append(.notice(err.message, .error))
+        }
+        if let trunc = truncation, !running {
+            trailing.append(.notice(trunc.label ?? "Response truncated", .warn))
+        }
+        // Prompts accepted mid-turn render as dim ghost bubbles at the very
+        // tail — where they will actually land once the current turn finishes.
+        trailing.append(contentsOf: queuedPrompts.map { .queuedPrompt($0.text) })
+
         let newRows: [TranscriptRow]
         if inProgressText.isEmpty {
             // No live tail: the whole transcript is canonical. If the turn
@@ -597,7 +610,7 @@ final class ChatSessionStore: ObservableObject {
             // Guarded on `wasRenderingTail`: `send()` mints `liveTailRowID`
             // before any text exists, and that optimistic no-tail state must
             // not rebadge the previous turn's last prose.
-            var rows = uniqueTranscriptRows(transcript)
+            var rows = uniqueTranscriptRows(liveTranscript)
             if wasRenderingTail,
                !liveTailRowID.isEmpty,
                let lastProse = rows.lastIndex(where: {
@@ -607,16 +620,17 @@ final class ChatSessionStore: ObservableObject {
                 liveTailRowID = ""
             }
             wasRenderingTail = false
-            blocks = transcript
-            newRows = rows
+            blocks = liveTranscript + trailing
+            newRows = rows + uniqueTranscriptRows(trailing)
         } else {
             // The live tail has no completion time yet — it gets one when the
             // turn ends and the canonical refetch replaces this block. The row
             // keeps `liveTailRowID` across the settle so it never blinks.
             wasRenderingTail = true
-            blocks = transcript + [.prose(inProgressText, at: nil)]
-            newRows = uniqueTranscriptRows(transcript)
+            blocks = liveTranscript + [.prose(inProgressText, at: nil)] + trailing
+            newRows = uniqueTranscriptRows(liveTranscript)
                 + [TranscriptRow(id: liveTailRowID, block: .prose(inProgressText, at: nil))]
+                + uniqueTranscriptRows(trailing)
         }
         rows = newRows
         // Cap the subagent stores at the children the CURRENT transcript can

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -40,6 +40,11 @@ struct StreamTextChunk: Equatable, Sendable {
 /// turn-boundary refetch lands. Mirror of the server's `st.tools` record.
 struct LiveTool: Equatable, Sendable {
     var idx: String
+    /// The tool's stable call id — the SAME identity the canonical `ToolStep`
+    /// row carries (see `ChatTranscriptMapper.stepIdentity`), so the live row
+    /// and its completed canonical sibling share an id and replace in place.
+    /// Falls back to `idx` when the box gave no callID.
+    var callID: String
     var name: String?
     var presentationHint: String?
     var status: String?
@@ -172,8 +177,10 @@ enum MantaStreamRouter {
             s.toolStartOrder.removeAll()
         case "toolStarted":
             if let p = try? frame.decodedPayload(StreamToolStartedPayload.self) {
+                let callID = (p.callID?.isEmpty ?? true) ? p.idx : p.callID!
                 s.tools[p.idx] = LiveTool(
                     idx: p.idx,
+                    callID: callID,
                     name: p.toolName,
                     presentationHint: p.toolPresentationHint,
                     status: p.status

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -289,6 +289,9 @@ struct StreamSubagentChildPayload: Codable, Equatable, Sendable {
 struct StreamToolStartedPayload: Codable, Equatable, Sendable {
     var sessionId: String
     var idx: String
+    /// The tool's stable call id. Optional so a frame from an older box (or a
+    /// fixture that omits it) still decodes; callers fall back to `idx`.
+    var callID: String?
     var toolName: String?
     var toolPresentationHint: String?
     var status: String?

--- a/mobile/native/MantaUI/RootView.swift
+++ b/mobile/native/MantaUI/RootView.swift
@@ -92,7 +92,7 @@ struct RootView: View {
             .user("check bet-520 and see if it's blocked correctly", at: nil),
             .prose("Checking its metadata and the blocker chain.", at: nil),
             .steps(.rows([
-                .step(ToolStep(id: "fixture-ran-1", verb: "Ran", target: "multica issue get BET-520", duration: "0.4s", status: .done, output: nil)),
+                .step(ToolStep(id: "fixture-ran-1", verb: "Ran", target: "multica issue get BET-520", duration: "0.4s", status: .completed, output: nil)),
             ])),
             .prose("Blocked correctly — waiting_on names both PoC issues. Now fanning out to audit the three sweeps.", at: nil),
             .steps(.rows([
@@ -104,9 +104,9 @@ struct RootView: View {
             .steps(.rollup(
                 summary: "▸ 4 steps · read 3 files, 1 search",
                 rows: [
-                    .step(ToolStep(id: "fixture-read-1", verb: "Read", target: "pr-body.md", duration: "0.2s", status: .done, output: nil)),
-                    .step(ToolStep(id: "fixture-read-2", verb: "Read", target: "src/main/auth.ts", duration: "0.2s", status: .done, output: nil)),
-                    .step(ToolStep(id: "fixture-read-3", verb: "Read", target: "src/renderer/mobile/setupLogic.ts", duration: "0.2s", status: .done, output: nil)),
+                    .step(ToolStep(id: "fixture-read-1", verb: "Read", target: "pr-body.md", duration: "0.2s", status: .completed, output: nil)),
+                    .step(ToolStep(id: "fixture-read-2", verb: "Read", target: "src/main/auth.ts", duration: "0.2s", status: .completed, output: nil)),
+                    .step(ToolStep(id: "fixture-read-3", verb: "Read", target: "src/renderer/mobile/setupLogic.ts", duration: "0.2s", status: .completed, output: nil)),
                     .step(ToolStep(id: "fixture-search-1", verb: "Search", target: "gh pr view 429 --json files", duration: "0.9s", status: .running, output: nil)),
                 ]
             )),
@@ -119,7 +119,7 @@ struct RootView: View {
         [
             .prose("Reading the close-on-merge workflow and its CI posture.", at: nil),
             .steps(.rows([
-                .step(ToolStep(id: "fixture-read-clm", verb: "Read", target: "multica-close-on-merge.yml", duration: "0.3s", status: .done, output: nil)),
+                .step(ToolStep(id: "fixture-read-clm", verb: "Read", target: "multica-close-on-merge.yml", duration: "0.3s", status: .completed, output: nil)),
                 .step(ToolStep(id: "fixture-ran-sweep", verb: "Ran", target: "node scripts/multica-unblock.mjs --dry-run", duration: "1.8s", status: .running, output: nil)),
             ])),
             .prose("The sweep flips a blocked issue to todo the moment its blockers clear.", at: nil),

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -211,9 +211,18 @@ struct MantaProseCaptureScene: View {
 // Verb is 600 weight `tx2`; target is 12px mono `tx4`. Output is collapsed by
 // default, revealed inline on `inset` in 12px mono when the row is tapped.
 
+/// The Vercel AI Elements tool-step taxonomy, ported verbatim. `awaitingApproval`
+/// (a tool blocked on a permission gate) and `denied` (permission refused) are
+/// FIRST-CLASS states, not error variants — a coding agent with a permission
+/// gate needs to tell "waiting for the user" from "failed", and folding either
+/// into `.error` would lose that.
 enum StepStatus: Hashable {
+    case pending           // queued, not started
+    case awaitingApproval  // blocked on a permission request
     case running
-    case done
+    case completed
+    case error
+    case denied            // permission refused
 }
 
 struct ToolStep: Identifiable, Hashable {
@@ -243,15 +252,22 @@ struct ToolStep: Identifiable, Hashable {
 struct StepRowView: View {
     let step: ToolStep
     let tokens: Tokens
-    @State private var revealed = false
+    /// The user's own expand/collapse intent, nil until they tap. User intent
+    /// always beats the state-driven default: a row they opened must never
+    /// close under them, and one they closed must stay closed (StepDisclosure).
+    @State private var userToggled: Bool?
+
+    /// The expanded state is DECIDED in the pure `StepDisclosure` function, not
+    /// inline here — so expansion-by-state is unit-testable without a view.
+    private var expanded: Bool {
+        StepDisclosure.expanded(status: step.status, userToggled: userToggled)
+    }
 
     var body: some View {
         VStack(spacing: 0) {
-            Button(action: { revealed.toggle() }) {
+            Button(action: { userToggled = !expanded }) {
                 HStack(spacing: Metrics.spacing.sp2) {
-                    Circle()
-                        .fill(dotColor)
-                        .frame(width: Metrics.type.stepDot, height: Metrics.type.stepDot)
+                    statusGlyph
                     // §8: a step row is ONE line. The verb is normally a word
                     // ("Ran", "Read"), but a tool name can be long enough to
                     // wrap, which broke the row's fixed height and made the
@@ -274,33 +290,73 @@ struct StepRowView: View {
                         .foregroundColor(tokens.tx4)
                 }
                 .padding(.vertical, Metrics.type.stepRowY)
-                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.leading, glyphLeading)
+                .padding(.trailing, Metrics.spacing.sp3)
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
 
-            if revealed, let output = step.output {
+            if expanded, let output = step.output {
                 Text(output)
                     .font(.manta(size: Metrics.type.xs, design: .monospaced))
                     .foregroundColor(tokens.tx3)
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: .infinity, alignment: .leading)
                     .padding(.vertical, Metrics.spacing.sp2)
-                    .padding(.horizontal, Metrics.spacing.sp3)
+                    .padding(.leading, contentLeading)
+                    .padding(.trailing, Metrics.spacing.sp3)
+                    // Only an EXPANDED row's output well keeps a material of its
+                    // own — Liquid Glass belongs to the navigation layer, never
+                    // the content layer, so a tool step gets no background of its
+                    // own (see StepGroupView; a rail replaces the old panel).
                     .background(tokens.inset)
                     .accessibilityIdentifier("step-output")
             }
         }
         // Expand/collapse is animated, matching the file's animation convention
         // (BET-752 task 6).
-        .animation(.smooth(duration: 0.22), value: revealed)
+        .animation(.smooth(duration: 0.22), value: expanded)
     }
 
-    private var dotColor: Color {
+    /// The rail line (StepGroupView) sits at `sp4` from the group's leading
+    /// edge, and each status glyph sits ON that line, breaking it. Parking the
+    /// glyph's leading at `sp4 - stepDot/2` centres it on the line.
+    private var glyphLeading: CGFloat {
+        Metrics.spacing.sp4 - Metrics.type.stepDot / 2
+    }
+
+    /// Text and output align after the glyph + its inter-glyph spacing, so an
+    /// expanded output well reads as continuing the row it belongs to.
+    private var contentLeading: CGFloat {
+        glyphLeading + Metrics.type.stepDot + Metrics.spacing.sp2
+    }
+
+    /// One SF Symbol + one Tokens colour per state, in a SINGLE switch — the
+    /// colour logic is not scattered across the view. `running` pulses.
+    @ViewBuilder
+    private var statusGlyph: some View {
         switch step.status {
-        case .running: return tokens.accent
-        case .done: return tokens.ok
+        case .pending:
+            glyph(systemName: "circle.dotted", color: tokens.tx4)
+        case .awaitingApproval:
+            glyph(systemName: "hand.raised.fill", color: tokens.warn)
+        case .running:
+            glyph(systemName: "circle.fill", color: tokens.accent)
+                .symbolEffect(.pulse)
+        case .completed:
+            glyph(systemName: "checkmark.circle.fill", color: tokens.ok)
+        case .error:
+            glyph(systemName: "exclamationmark.circle.fill", color: tokens.danger)
+        case .denied:
+            glyph(systemName: "slash.circle.fill", color: tokens.tx4)
         }
+    }
+
+    private func glyph(systemName: String, color: Color) -> some View {
+        Image(systemName: systemName)
+            .font(.system(size: Metrics.type.stepDot))
+            .foregroundColor(color)
+            .frame(width: Metrics.type.stepDot, height: Metrics.type.stepDot)
     }
 }
 
@@ -348,7 +404,8 @@ struct StepGroupView: View {
                             .foregroundColor(tokens.tx4)
                             .frame(maxWidth: .infinity, alignment: .leading)
                             .padding(.vertical, Metrics.type.stepRowY)
-                            .padding(.horizontal, Metrics.spacing.sp3)
+                            .padding(.leading, Metrics.spacing.sp4)
+                            .padding(.trailing, Metrics.spacing.sp3)
                             .contentShape(Rectangle())
                     }
                     .buttonStyle(.plain)
@@ -361,11 +418,19 @@ struct StepGroupView: View {
                 .animation(.smooth(duration: 0.22), value: rollupExpanded)
             }
         }
-        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: Metrics.radius.md)
-                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
-        )
+        // The step group is a TIMELINE RAIL, not a panel: a 1pt vertical
+        // connector inset `sp4` from the leading edge, running the height of the
+        // group, with each row's status glyph sitting on it and breaking it.
+        // Liquid Glass belongs to the navigation layer, never the content layer,
+        // so a tool step gets no material of its own — the old panel, its
+        // border stroke, and the hairline separators between rows are all gone;
+        // only an expanded row's output well keeps a fill (see StepRowView).
+        .background(alignment: .leading) {
+            Rectangle()
+                .fill(tokens.borderSubtle)
+                .frame(width: Metrics.spacing.spPx)
+                .padding(.leading, Metrics.spacing.sp4)
+        }
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("step-rows")
     }
@@ -373,11 +438,8 @@ struct StepGroupView: View {
     @ViewBuilder
     private func rowsView(_ rows: [StepGroupRow]) -> some View {
         VStack(spacing: 0) {
-            ForEach(Array(rows.enumerated()), id: \.element.id) { index, row in
+            ForEach(Array(rows.enumerated()), id: \.element.id) { _, row in
                 rowView(row)
-                if index < rows.count - 1 {
-                    tokens.borderSubtle.frame(height: Metrics.spacing.spPx)
-                }
             }
         }
     }
@@ -389,85 +451,6 @@ struct StepGroupView: View {
             StepRowView(step: step, tokens: tokens)
         case .subagent(let agent):
             SubagentRowView(agent: agent, tokens: tokens)
-        }
-    }
-}
-
-// MARK: - Live running tool row (BET-753)
-//
-// The LIVE counterpart to a canonical step row. While a tool call is still in
-// flight the box streams `toolStarted`/`toolOutput`/`toolEnded` frames, and
-// this row renders what the box is doing mid-turn (tool name + status + the
-// accumulated bash tail) pinned above the composer, so the phone shows
-// something instead of nothing until the turn-boundary refetch lands.
-//
-// It mirrors the canonical `StepRowView` treatment (status dot + tool name +
-// mono tail on a `panel` group) so the live→canonical swap at the refetch
-// boundary doesn't pop. It is an OVERLAY — never part of the canonical
-// transcript (that remains `ChatSessionStore.swift`'s source of truth).
-struct RunningToolRow: View {
-    let tool: LiveTool
-    let tokens: Tokens
-
-    var body: some View {
-        VStack(alignment: .leading, spacing: 0) {
-            HStack(spacing: Metrics.spacing.sp2) {
-                Circle()
-                    .fill(tokens.accent)
-                    .frame(width: Metrics.type.stepDot, height: Metrics.type.stepDot)
-                Text(tool.name ?? "tool")
-                    .font(.system(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.semibold)))
-                    .foregroundColor(tokens.tx2)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
-                    .layoutPriority(1)
-                // The box's human title for the part (e.g. "Run: npm test"),
-                // when it differs from the bare tool name.
-                if let hint = tool.presentationHint, !hint.isEmpty, hint != tool.name {
-                    Text(hint)
-                        .font(.system(size: Metrics.type.xs, design: .monospaced))
-                        .foregroundColor(tokens.tx4)
-                        .lineLimit(1)
-                        .truncationMode(.tail)
-                }
-                Spacer(minLength: 0)
-                Text(statusText)
-                    .font(.system(size: Metrics.type.twoXS))
-                    .foregroundColor(tokens.tx4)
-            }
-            .padding(.vertical, Metrics.type.stepRowY)
-            .padding(.horizontal, Metrics.spacing.sp3)
-
-            if !tool.tail.isEmpty {
-                Text(tool.tail)
-                    .font(.system(size: Metrics.type.xs, design: .monospaced))
-                    .foregroundColor(tokens.tx3)
-                    .fixedSize(horizontal: false, vertical: true)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .padding(.vertical, Metrics.spacing.sp2)
-                    .padding(.horizontal, Metrics.spacing.sp3)
-                    .background(tokens.inset)
-                    .accessibilityIdentifier("running-tool-tail")
-            }
-        }
-        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
-        .overlay(
-            RoundedRectangle(cornerRadius: Metrics.radius.md)
-                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
-        )
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("running-tool-row")
-    }
-
-    /// The row's live status label. The wire `status` is one of
-    /// pending/running/completed/error; while the row renders the tool is
-    /// still in flight, so this stays truthful to the incoming value.
-    private var statusText: String {
-        switch (tool.status ?? "").lowercased() {
-        case "error": return "error"
-        case "pending": return "queued"
-        case "completed": return "done"
-        default: return "running"
         }
     }
 }
@@ -637,6 +620,14 @@ struct TimestampGutterLabel: View {
     }
 }
 
+/// A system notice (session error / truncation) rendered inline in the
+/// transcript at the end of the turn it belongs to — NOT pinned above the
+/// composer. `error` is a failed turn; `warn` is a truncation.
+enum SystemNotice: Equatable {
+    case error
+    case warn
+}
+
 enum TranscriptBlock: Equatable {
     // The date is the block's wall-clock time, shown only in the swipe-to-reveal
     // gutter. Machinery (`.steps`) carries none: a step row already states how
@@ -644,12 +635,18 @@ enum TranscriptBlock: Equatable {
     case user(String, at: Date?)
     case prose(String, at: Date?)
     case steps(StepGroupContent)
+    /// A terminal system notice (session error / truncation) at the end of the
+    /// turn it belongs to.
+    case notice(String, SystemNotice)
+    /// A prompt accepted mid-turn, waiting for the session to go idle. Rendered
+    /// as a DIM ghost user bubble where the message will actually land.
+    case queuedPrompt(String)
 
     /// The time shown in the gutter; nil for blocks that have none.
     var timestamp: Date? {
         switch self {
         case .user(_, let at), .prose(_, let at): return at
-        case .steps: return nil
+        case .steps, .notice, .queuedPrompt: return nil
         }
     }
 }

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -44,6 +44,8 @@ extension TranscriptBlock {
         case .prose(let text, let at):
             return "p\(text.hashValue)@\(at?.timeIntervalSince1970 ?? 0)"
         case .steps(let content): return "s" + content.rows.map(\.id).joined(separator: "|")
+        case .notice(let text, let kind): return "n\(kind)\(text.hashValue)"
+        case .queuedPrompt(let text): return "q\(text.hashValue)"
         }
     }
 }
@@ -149,6 +151,43 @@ func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens) -> some View 
         StepGroupView(content: content, tokens: tokens)
             .padding(.horizontal, Metrics.spacing.sp3)
             .padding(.bottom, Metrics.spacing.sp3)
+    case .notice(let text, let kind):
+        SystemNoticeView(text: text, kind: kind, tokens: tokens)
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.bottom, Metrics.spacing.sp3)
+    case .queuedPrompt(let text):
+        // A ghost, dimmed user bubble — the message will land here once the
+        // current turn ends, so it renders a preview of where that will be.
+        UserBand(text: text, tokens: tokens)
+            .opacity(0.45)
+            .padding(.bottom, Metrics.spacing.sp4)
+    }
+}
+
+/// A system notice (session error / truncation) inline at the end of the turn
+/// it belongs to. It scrolls WITH that turn — replacing the pinned notice row
+/// that used to float above the composer and detach from the turn.
+struct SystemNoticeView: View {
+    let text: String
+    let kind: SystemNotice
+    let tokens: Tokens
+
+    var body: some View {
+        let color = kind == .error ? tokens.danger : tokens.warn
+        HStack(spacing: Metrics.spacing.sp2) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: Metrics.type.xs, weight: .semibold))
+                .foregroundColor(color)
+            Text(text)
+                .font(.manta(size: Metrics.type.xs))
+                .foregroundColor(color)
+                .lineLimit(3)
+            Spacer(minLength: 0)
+        }
+        .padding(Metrics.spacing.sp2)
+        .background(color.opacity(0.12), in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("system-notice")
     }
 }
 

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -493,12 +493,25 @@ final class ChatStreamMergeTests: XCTestCase {
 
     // MARK: - Live tools (BET-753)
 
-    /// A `toolStarted` frame surfaces a running-tool row on the store, even
-    /// before any canonical transcript rows exist.
-    func testToolStartedPopulatesRunningTools() async {
+    /// The step rows across all blocks in order, for asserting the live-tool
+    /// merge (BET-823).
+    private static func stepRows(in blocks: [TranscriptBlock]) -> [ToolStep] {
+        blocks.flatMap { block -> [ToolStep] in
+            guard case .steps(let content) = block else { return [] }
+            return content.rows.compactMap { row in
+                guard case .step(let step) = row else { return nil }
+                return step
+            }
+        }
+    }
+
+    /// A `toolStarted` frame surfaces the live tool as a step row INSIDE the
+    /// transcript (merged into a step group keyed by its callID), not as a
+    /// pinned overlay above the composer.
+    func testToolStartedMergesLiveToolIntoTranscript() async {
         let stream = TestStreamControl()
         let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
-        stream.inject(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","toolName":"bash","toolPresentationHint":"Run: npm test","status":"running"}}"#)
+        stream.inject(#"{"kind":"stream","sub":"toolStarted","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","callID":"toolu_1","toolName":"bash","toolPresentationHint":"Run: npm test","status":"running"}}"#)
 
         let store = ChatSessionStore(
             sessionId: "ses",
@@ -507,15 +520,17 @@ final class ChatStreamMergeTests: XCTestCase {
         )
         await Task.yield()
 
-        XCTAssertEqual(store.runningTools.count, 1)
-        XCTAssertEqual(store.runningTools[0].idx, "toolu_1")
-        XCTAssertEqual(store.runningTools[0].name, "bash")
-        XCTAssertEqual(store.runningTools[0].presentationHint, "Run: npm test")
+        let steps = Self.stepRows(in: store.blocks)
+        XCTAssertEqual(steps.count, 1, "the live tool renders as a step row in the transcript")
+        XCTAssertEqual(steps[0].id, "toolu_1", "the live step is keyed by the callID so it replaces in place on completion")
+        XCTAssertEqual(steps[0].verb, "Ran")
+        XCTAssertEqual(steps[0].target, "Run: npm test")
+        XCTAssertEqual(steps[0].status, .running)
     }
 
-    /// Appended `toolOutput` deltas for the same `idx` concatenate in order; a
-    /// new `idx` starts a fresh tail.
-    func testToolOutputConcatenatesByIndexInOrder() async {
+    /// Appended `toolOutput` deltas for the same `idx` concatenate onto the live
+    /// step's tail in order; a new `idx` starts a fresh tail.
+    func testToolOutputTailConcatenatesOnLiveStep() async {
         let stream = TestStreamControl()
         let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
         let store = ChatSessionStore(
@@ -532,15 +547,15 @@ final class ChatStreamMergeTests: XCTestCase {
         stream.inject(#"{"kind":"stream","sub":"toolOutput","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_2","text":"file.txt"}}"#)
         await Task.yield()
 
-        XCTAssertEqual(store.runningTools.map(\.idx), ["toolu_1", "toolu_2"])
-        XCTAssertEqual(store.runningTools[0].tail, "one\ntwo\n", "deltas for the same idx concatenate in order")
-        XCTAssertEqual(store.runningTools[1].tail, "file.txt", "a new idx starts a fresh tail")
+        let steps = Self.stepRows(in: store.blocks)
+        XCTAssertEqual(steps.map(\.id), ["toolu_1", "toolu_2"], "live tools render in start order")
+        XCTAssertEqual(steps[0].output, "one\ntwo\n", "deltas for the same idx concatenate in order")
+        XCTAssertEqual(steps[1].output, "file.txt", "a new idx starts a fresh tail")
     }
 
-    /// `toolEnded` removes the running tool; the store surfaces the outcome
-    /// (`ok:false`/`truncated`) on the retained record until the canonical
-    /// refetch takes over.
-    func testToolEndedRemovesRunningToolAndReflectsOutcome() async {
+    /// `toolEnded` removes the live step from the transcript; the event store
+    /// retains the outcome (`ok:false`/`truncated`) for the canonical refetch.
+    func testToolEndedRemovesLiveStepAndRetainsOutcome() async {
         let stream = TestStreamControl()
         let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
         let store = ChatSessionStore(
@@ -555,7 +570,7 @@ final class ChatStreamMergeTests: XCTestCase {
         stream.inject(#"{"kind":"stream","sub":"toolEnded","sessionId":"ses","payload":{"sessionId":"ses","idx":"toolu_1","ok":false,"truncated":true}}"#)
         await Task.yield()
 
-        XCTAssertEqual(store.runningTools.count, 0, "an ended tool leaves the running set")
+        XCTAssertEqual(Self.stepRows(in: store.blocks).count, 0, "an ended tool leaves the transcript's live steps")
         let reflected = eventStore.sessionStates["ses"]?.tools["toolu_1"]
         XCTAssertEqual(reflected?.ended, true, "the outcome is reflected on the retained record")
         XCTAssertEqual(reflected?.ok, false)

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -161,7 +161,7 @@ final class ChatTranscriptTests: XCTestCase {
         XCTAssertEqual(step.verb, "Ran")
         XCTAssertEqual(step.target, "multica issue get BET-520")
         XCTAssertEqual(step.duration, "0.4s")
-        XCTAssertEqual(step.status, .done)
+        XCTAssertEqual(step.status, .completed)
         XCTAssertEqual(step.output, "Blocked")
     }
 
@@ -437,5 +437,78 @@ final class ChatTranscriptTests: XCTestCase {
         let rows = uniqueTranscriptRows(blocks)
         XCTAssertEqual(rows.map(\.id), blocks.map(\.stableScrollID),
                        "non-colliding blocks must keep their content-stable ids unchanged")
+    }
+
+    // MARK: - Step disclosure (BET-823)
+
+    func testStepDisclosureStateDefaults() {
+        // A running tool tails its output; a live approval/failure past the
+        // turn never auto-collapses; a completed or pending step reads collapsed.
+        XCTAssertTrue(StepDisclosure.expanded(status: .running, userToggled: nil))
+        XCTAssertTrue(StepDisclosure.expanded(status: .awaitingApproval, userToggled: nil))
+        XCTAssertTrue(StepDisclosure.expanded(status: .error, userToggled: nil))
+        XCTAssertTrue(StepDisclosure.expanded(status: .denied, userToggled: nil))
+        XCTAssertFalse(StepDisclosure.expanded(status: .completed, userToggled: nil))
+        XCTAssertFalse(StepDisclosure.expanded(status: .pending, userToggled: nil))
+    }
+
+    func testStepDisclosureUserIntentWins() {
+        // A row the user opened stays open even when its state would collapse it.
+        XCTAssertTrue(StepDisclosure.expanded(status: .completed, userToggled: true))
+        XCTAssertTrue(StepDisclosure.expanded(status: .pending, userToggled: true))
+        // A row the user closed stays closed even when its state would expand it.
+        XCTAssertFalse(StepDisclosure.expanded(status: .running, userToggled: false))
+        XCTAssertFalse(StepDisclosure.expanded(status: .error, userToggled: false))
+        XCTAssertFalse(StepDisclosure.expanded(status: .awaitingApproval, userToggled: false))
+    }
+
+    // MARK: - Live tools merged into the transcript (BET-823)
+
+    func testLiveToolAppendsToLastStepsGroup() {
+        let canonical = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "bash", status: "completed", input: ["command": str("ls")]),
+        ])]
+        let blocks = ChatTranscriptMapper.blocks(from: canonical)
+        let live = [LiveTool(idx: "t2", callID: "toolu_2", name: "read", presentationHint: "Read a.ts", status: "running")]
+        let merged = ChatTranscriptMapper.appendingLiveTools(live, to: blocks)
+        guard case .steps(.rows(let rows)) = merged[0], rows.count == 2,
+              case .step(let step) = rows[0], case .step(let liveStep) = rows[1] else {
+            return XCTFail("expected both steps in one group")
+        }
+        XCTAssertEqual(step.status, .completed)
+        XCTAssertEqual(liveStep.id, "toolu_2", "the live step is keyed by its callID")
+        XCTAssertEqual(liveStep.status, .running)
+        XCTAssertEqual(liveStep.verb, "Read")
+        XCTAssertEqual(liveStep.target, "Read a.ts")
+    }
+
+    func testLiveToolSkipsWhenCanonicalCounterpartExists() {
+        // A live tool whose callID the transcript already owns must not be
+        // appended a second time — the canonical step takes over in place.
+        let canonical = [message(id: "m1", role: "assistant", parts: [
+            toolPart("t1", "m1", tool: "bash", status: "completed", input: ["command": str("ls")]),
+        ])]
+        let blocks = ChatTranscriptMapper.blocks(from: canonical)
+        let live = [LiveTool(idx: "t1", callID: "t1", name: "bash", presentationHint: nil, status: "running")]
+        let merged = ChatTranscriptMapper.appendingLiveTools(live, to: blocks)
+        guard case .steps(.rows(let rows)) = merged[0] else {
+            return XCTFail("expected a steps group")
+        }
+        XCTAssertEqual(rows.count, 1, "the canonical step owns the row; no duplicate live row")
+    }
+
+    func testLiveToolCreatesGroupWhenNoStepsExist() {
+        let blocks = ChatTranscriptMapper.blocks(from: [])
+        let live = [LiveTool(idx: "t1", callID: "toolu_1", name: "bash", presentationHint: nil, status: "running")]
+        let merged = ChatTranscriptMapper.appendingLiveTools(live, to: blocks)
+        guard case .steps(.rows(let rows)) = merged.last else {
+            return XCTFail("expected a steps group to be created at the tail")
+        }
+        XCTAssertEqual(rows.count, 1)
+    }
+
+    func testAppendingLiveToolsIsANoOpWhenEmpty() {
+        let blocks = ChatTranscriptMapper.blocks(from: [])
+        XCTAssertTrue(ChatTranscriptMapper.appendingLiveTools([], to: blocks).isEmpty)
     }
 }

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -108,7 +108,7 @@ function newSessionState() {
 //
 // App contract (the iOS rendering half, sequenced BET, must read exactly these
 // frame + field names so the two halves cannot drift):
-//   toolStarted { sessionId, idx, toolName, toolPresentationHint?, status }
+//   toolStarted { sessionId, idx, callID, toolName, toolPresentationHint?, status }
 //   toolOutput  { sessionId, idx, text }
 //   toolEnded   { sessionId, idx, ok, truncated? }
 //
@@ -116,6 +116,11 @@ function newSessionState() {
 //   sessionId            string   — the opencode session the tool belongs to
 //   idx                  string   — the tool PART ID; stable per tool across the
 //                                   whole run (identical on started/output/ended)
+//   callID               string   — the tool's stable call id (opencode's
+//                                   `callID`, falling back to `idx`); shared with
+//                                   the canonical step row's id so a live row is
+//                                   replaced IN PLACE by its completed sibling
+//                                   instead of removing one and inserting another
 //   toolName             string   — e.g. "bash", "read", "write", "task"
 //   toolPresentationHint string?  — opencode's human title for the part (e.g.
 //                                   "Run: npm test"); null when the box gave none
@@ -141,15 +146,23 @@ function updateToolFrames(st, sid, part, emit) {
   const status = typeof state?.status === "string" ? state.status : null;
   if (!status) return;
 
+  // The canonical step row is keyed by the tool's callID (see the Swift
+  // `ChatTranscriptMapper.stepIdentity`). Stream that same id here so the live
+  // row and its completed canonical sibling carry the same identity — the only
+  // thing that lets the turn-boundary refetch REPLACE the row in place instead
+  // of removing + inserting (a visible flash/reorder).
+  const callID = typeof part.callID === "string" && part.callID.length > 0 ? part.callID : idx;
+
   let tool = st.tools.get(idx);
 
   // A tool the device hasn't been told about yet -> toolStarted.
   if (!tool) {
-    tool = { idx, name: part.tool ?? null, status, sent: 0, truncated: false, ended: false };
+    tool = { idx, callID, name: part.tool ?? null, status, sent: 0, truncated: false, ended: false };
     st.tools.set(idx, tool);
     emit(sid, "toolStarted", {
       sessionId: sid,
       idx,
+      callID,
       toolName: tool.name,
       toolPresentationHint: typeof state?.title === "string" ? state.title : null,
       status,

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -442,7 +442,7 @@ test("interpret ignores events with no session id", () => {
 // ---------------------------------------------------------------------------
 
 // Build a tool `message.part.updated` payload in the shape opencode sends.
-function toolPartUpdated({ id, tool = "bash", status, title, metaOutput, output, messageID = "msg1" }) {
+function toolPartUpdated({ id, tool = "bash", status, title, metaOutput, output, callID, messageID = "msg1" }) {
   return {
     type: "message.part.updated",
     properties: {
@@ -452,6 +452,7 @@ function toolPartUpdated({ id, tool = "bash", status, title, metaOutput, output,
         id,
         type: "tool",
         tool,
+        ...(callID !== undefined ? { callID } : {}),
         state: {
           status,
           ...(title !== undefined ? { title } : {}),
@@ -471,9 +472,21 @@ test("toolStarted is emitted once when a tool part first appears", () => {
   assert.equal(started.length, 1, "re-emit for the same idx emits toolStarted exactly once");
   assert.equal(started[0].payload.sessionId, SID);
   assert.equal(started[0].payload.idx, "t1");
+  // callID falls back to the part id when opencode gave none, so the live row
+  // always shares the canonical step row's identity.
+  assert.equal(started[0].payload.callID, "t1");
   assert.equal(started[0].payload.toolName, "bash");
   assert.equal(started[0].payload.toolPresentationHint, "Run: npm test");
   assert.equal(started[0].payload.status, "running");
+});
+
+test("toolStarted carries the tool's callID when opencode provides one", () => {
+  const { interp, events } = make();
+  interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", callID: "toolu_123" }));
+  const started = events.filter((e) => e.sub === "toolStarted");
+  assert.equal(started.length, 1);
+  assert.equal(started[0].payload.idx, "t1");
+  assert.equal(started[0].payload.callID, "toolu_123");
 });
 
 test("toolOutput carries only the delta since the last chunk, never the full output", () => {


### PR DESCRIPTION
## BET-823 — iOS transcript: live tool rows render as a rail inside the transcript

Moves live running tools OUT of the pinned overlay above the composer and INTO
the transcript, in the turn that spawned them, rendered through the SAME
`StepRowView` as completed steps — the two implementations of one row are now
one.

### Deleted symbols (removal beats addition)

- `RunningToolRow` (TranscriptComponents.swift) — the pinned live-tool overlay; gone entirely.
- `ChatSessionStore.runningTools` `@Published` property + its assignment — gone; live tools now merge into the transcript.
- `ChatNoticeRow` (ChatScreen.swift) — the pinned session-error/truncation/queued notice row; notice rendering moved inline.
- `StepStatus.done` — renamed `completed` and expanded to the 6-state Vercel AI Elements taxonomy.
- `StepGroupView` panel background, border stroke, and inter-row separators — replaced by the timeline rail.

### Behaviour

- **One row type**, `StepRowView`, keyed by the tool's `callID`. The box now
  streams `callID` on `toolStarted` (additive) so a live row and its completed
  canonical sibling share one identity — the turn-boundary refetch replaces the
  row IN PLACE instead of removing + inserting (no flash / reorder).
- **Six first-class states** (`pending`, `awaitingApproval`, `running`,
  `completed`, `error`, `denied`), one SF Symbol + one token colour each, in a
  single switch. `awaitingApproval`/`denied` are not error variants.
- **Expansion** is decided by the pure, unit-tested `StepDisclosure.expanded(status:userToggled:)` — running/awaitingApproval/error/denied expand (a failure never auto-collapses), completed/pending collapse, and the user's manual toggle always wins.
- **The group is a rail**: a 1pt vertical connector inset `sp4` from the leading
  edge with each status glyph sitting on it (no material — Liquid Glass stays in
  the navigation layer; only an expanded output well keeps a `Tokens.inset` fill).
- **Pinned area** now keeps only permission + question cards, with todos
  collapsed to a single summary line while a turn runs. `sessionError` /
  `truncation` moved into the transcript tail as inline notices; `queuedPrompts`
  move to the transcript tail as a dimmed ghost user bubble where the message
  will land.

### Tests

- `StepDisclosure` (one case per state + both override directions).
- `appendingLiveTools` (append to last steps group, skip canonical counterpart, create group, no-op on empty).
- Store live-tool merge (moved from the deleted `runningTools` property to
  transcript `blocks` assertions).
- Server: `streamInterp` `toolStarted` now carries/falls-back `callID` (2 cases).

### Verification

- Server-side (`streamInterp`) tests: **28 pass** (run on box).
- Native on-Mac gates (both green on branch head `f7b2037b`):
  - `ios-mantaui {action: compile-only}` → **COMPILE: PASS** (app target only, no tests).
  - `ios-mantaui {action: test-unit}` → **UNIT: PASS** — 325 tests, 0 failures.
- Acceptance grep: `grep -r RunningToolRow mobile/native` returns nothing.

