### PR TITLE
Voice: rework the recorder into a toggled session with pause and level capture (BET-835)

### DIFF
--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -325,26 +325,31 @@ function TypeaheadRowButton({
 //   - idle       → microphone glyph in text-muted
 //   - requesting → spinner in text-faint (waiting on mic permission)
 //   - recording  → filled circle pulsing in red, hint text "release to send"
-//   - processing → spinner in accent (Groq round-trip in flight)
 //   - error      → muted-red mic; click to retry by pressing again
+//
+// Transcription is tracked by the orchestration layer (useVoice), not the
+// recorder hook's phases, so the "transcribing" spinner is driven by the
+// `busy` prop rather than a hook phase.
 export function MicButton({
   phase,
   onStart,
   onStop,
   onCancel,
+  busy = false,
   floating = false,
 }: {
   phase: VoicePhase;
   onStart: () => void;
   onStop: () => void;
   onCancel: () => void;
+  // Transcription in flight — blocks a new press and shows "transcribing…".
+  busy?: boolean;
   // `floating` = the mobile WhatsApp-style push-to-talk FAB (bottom-right,
   // above the composer). It is dictation-only, the same as the inline
   // button — transcription is always plain text into the composer.
   floating?: boolean;
 }) {
   const recording = phase === "recording" || phase === "requesting";
-  const busy = phase === "processing";
 
   // Track press state with a REF, not the rendered `recording` prop. This is
   // THE fix for "hold → red → release → nothing happens": the pointerup

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -319,7 +319,7 @@ function TypeaheadRowButton({
 // ===== Input area =====
 
 // Press-and-hold mic button. Dictation-only: the transcript is inserted at
-// the caret (via the hook's onResult).
+// the caret (the orchestration hook inserts it after transcription).
 //
 // Visual states (phase):
 //   - idle       → microphone glyph in text-muted

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -303,6 +303,7 @@ export function InputArea({
           onStart={startVoice}
           onStop={stopVoice}
           onCancel={cancelVoice}
+          busy={voiceProcessing}
           floating
         />
       )}
@@ -499,6 +500,7 @@ export function InputArea({
                   onStart={startVoice}
                   onStop={stopVoice}
                   onCancel={cancelVoice}
+                  busy={voiceProcessing}
                 />
               )}
               <AttachButton onFiles={onAttachFiles} />

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -444,19 +444,26 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
 
   // ---- voice (simplified: just insert transcribed text) ----
   const voiceRecorder = useVoiceRecorder({
-    onResult: (text) => {
-      if (!text) return;
-      const prev = useStore.getState().drafts.find((d) => d.id === draftId)?.input ?? "";
-      const sep = prev && !prev.endsWith(" ") ? " " : "";
-      updateDraft(draftId, { input: prev + sep + text });
-      requestAnimationFrame(() => {
-        const el = inputRef.current;
-        if (el) {
-          el.focus();
-          const end = el.value.length;
-          el.setSelectionRange(end, end);
-        }
-      });
+    onComplete: async ({ blob, mime }) => {
+      try {
+        const buffer = await blob.arrayBuffer();
+        const res = await window.api.voiceTranscribe({ buffer, mime });
+        const text = res.text.trim();
+        if (!text) return;
+        const prev = useStore.getState().drafts.find((d) => d.id === draftId)?.input ?? "";
+        const sep = prev && !prev.endsWith(" ") ? " " : "";
+        updateDraft(draftId, { input: prev + sep + text });
+        requestAnimationFrame(() => {
+          const el = inputRef.current;
+          if (el) {
+            el.focus();
+            const end = el.value.length;
+            el.setSelectionRange(end, end);
+          }
+        });
+      } catch (err) {
+        setError(err instanceof Error ? err.message : String(err));
+      }
     },
     onError: (err: Error) => setError(err.message),
     onEmpty: () => {},

--- a/src/renderer/hooks/useVoice.ts
+++ b/src/renderer/hooks/useVoice.ts
@@ -2,19 +2,22 @@
 //
 // Extracted from ChatPanel.tsx (BET-64). Wraps `useVoiceRecorder` from
 // `./voice.ts` and adds the dictation-only behaviour, keybinds, and gating.
-// The transcribed text is inserted at the caret.
+// Orchestration lives HERE, on top of the recorder's onComplete artifact:
+// we transcribe via `voice:transcribe`, insert into the composer at the
+// caret, and keep the desktop keyboard driving the session.
 //
 // The hook owns:
 //   - The voiceRecorder instance (via useVoiceRecorder)
 //   - The desktop voice keybinds (Ctrl+M / Enter / Esc)
 //   - The voiceEnabled gate (groqApiKey + MediaRecorder support)
+//   - The transcription step (recorder hands back {blob, mime, peaks})
 //
 // No Electron-only deps — only `window.api.*`, which the mobile HTTP server
 // shims.
 
-import { useEffect, useRef } from "react";
+import { useEffect, useRef, useState } from "react";
 import { useVoiceRecorder } from "../voice";
-import type { VoicePhase } from "../voice";
+import type { VoiceArtifact, VoicePhase } from "../voice";
 
 export type Voice = {
   voiceEnabled: boolean;
@@ -22,7 +25,11 @@ export type Voice = {
   voiceProcessing: boolean;
   voiceRecorder: {
     phase: VoicePhase;
+    elapsedSec: number;
+    nearLimit: boolean;
     start: () => void;
+    pause: () => void;
+    resume: () => void;
     stop: () => void;
     cancel: () => void;
   };
@@ -47,10 +54,13 @@ export function useVoice(params: {
     groqApiKey,
   } = params;
 
-  // When the user presses Enter (or Ctrl+M) WHILE the desktop voice
-  // recorder is active, we want the transcribed text to land in the
-  // composer AND immediately submit, in one keystroke.
+  // When the user presses Enter (or Ctrl+M) WHILE the desktop voice recorder
+  // is active, we want the transcribed text to land in the composer AND
+  // immediately submit, in one keystroke.
   const submitAfterTranscribeRef = useRef(false);
+  // Transcription in flight — the recorder's own phases don't include
+  // "processing" (that is our business now), so we track it here for the UI.
+  const [transcribing, setTranscribing] = useState(false);
 
   // Insert text at the caret, mirroring the composer's append behaviour.
   const insertAtCaret = (text: string) => {
@@ -78,11 +88,36 @@ export function useVoice(params: {
   };
 
   const voiceRecorder = useVoiceRecorder({
-    onResult: (text) => {
-      insertAtCaret(text);
-      if (submitAfterTranscribeRef.current) {
+    onComplete: async (artifact: VoiceArtifact) => {
+      // Transcribe the artifact the recorder handed back. The new upload
+      // route is NOT used yet — that lands with the transcript ticket.
+      setTranscribing(true);
+      try {
+        const buffer = await artifact.blob.arrayBuffer();
+        const res = await window.api.voiceTranscribe({
+          buffer,
+          mime: artifact.mime,
+        });
+        const text = res.text.trim();
+        if (!text) {
+          // Pipeline worked but Groq heard no speech (silence / too quiet /
+          // unintelligible). Surface it so the release isn't a silent no-op.
+          submitAfterTranscribeRef.current = false;
+          setSystemNotice(
+            "Didn't catch any speech. Try again, a little louder or closer to the mic.",
+          );
+          return;
+        }
+        insertAtCaret(text);
+        if (submitAfterTranscribeRef.current) {
+          submitAfterTranscribeRef.current = false;
+          setTimeout(() => submitRef.current?.(), 0);
+        }
+      } catch (e) {
         submitAfterTranscribeRef.current = false;
-        setTimeout(() => submitRef.current?.(), 0);
+        setSendError(e instanceof Error ? e.message : String(e));
+      } finally {
+        setTranscribing(false);
       }
     },
     onError: (e) => {
@@ -96,6 +131,9 @@ export function useVoice(params: {
           ? "Didn't catch that — the recording was too short. Hold a bit longer."
           : "Didn't catch any speech. Try again, a little louder or closer to the mic.",
       );
+    },
+    onWarning: (msg) => {
+      setSystemNotice(msg);
     },
   });
 
@@ -115,8 +153,9 @@ export function useVoice(params: {
   voiceCancelRef.current = voiceRecorder.cancel;
   const voiceRecording =
     voiceRecorder.phase === "recording" ||
-    voiceRecorder.phase === "requesting";
-  const voiceProcessing = voiceRecorder.phase === "processing";
+    voiceRecorder.phase === "requesting" ||
+    voiceRecorder.phase === "paused";
+  const voiceProcessing = transcribing;
 
   // Desktop voice keybinds (Ctrl+M / Enter / Esc)
   useEffect(() => {
@@ -125,7 +164,11 @@ export function useVoice(params: {
       if (e.ctrlKey && !e.metaKey && !e.altKey && (e.key === "m" || e.key === "M")) {
         e.preventDefault();
         const phase = voicePhaseRef.current;
-        if (phase === "recording" || phase === "requesting") {
+        if (
+          phase === "recording" ||
+          phase === "requesting" ||
+          phase === "paused"
+        ) {
           submitAfterTranscribeRef.current = false;
           voiceStopRef.current();
         } else if (phase === "idle" || phase === "error") {
@@ -142,7 +185,7 @@ export function useVoice(params: {
         !e.ctrlKey &&
         !e.altKey
       ) {
-        if (phase !== "recording") return;
+        if (phase !== "recording" && phase !== "paused") return;
         e.preventDefault();
         e.stopPropagation();
         submitAfterTranscribeRef.current = true;
@@ -167,7 +210,11 @@ export function useVoice(params: {
     voiceProcessing,
     voiceRecorder: {
       phase: voiceRecorder.phase,
+      elapsedSec: voiceRecorder.elapsedSec,
+      nearLimit: voiceRecorder.nearLimit,
       start: voiceRecorder.start,
+      pause: voiceRecorder.pause,
+      resume: voiceRecorder.resume,
       stop: voiceRecorder.stop,
       cancel: voiceRecorder.cancel,
     },

--- a/src/renderer/voice.test.ts
+++ b/src/renderer/voice.test.ts
@@ -8,8 +8,8 @@ import { describe, expect, it } from "vitest";
 import {
   elapsedCurrent,
   elapsedPause,
+  elapsedReset,
   elapsedResume,
-  elapsedStart,
   isTooShort,
   nearLimitAt,
 } from "./voice";
@@ -55,14 +55,14 @@ describe("peak reduction over a synthetic buffer", () => {
 
 describe("elapsed maths across a pause/resume cycle", () => {
   it("tracks a linear recording with no pauses", () => {
-    const s = elapsedStart();
+    const s = elapsedResume(elapsedReset(), 0); // take begins at t=0
     expect(elapsedCurrent(s, 0)).toBe(0);
     expect(elapsedCurrent(s, 1000)).toBe(1000);
     expect(elapsedCurrent(s, 3500)).toBe(3500);
   });
 
   it("freezes while paused and excludes the paused span after resume", () => {
-    let s = elapsedStart(); // t=0 take starts
+    let s = elapsedResume(elapsedReset(), 0); // t=0 take starts
     expect(elapsedCurrent(s, 2000)).toBe(2000); // 2s live
 
     s = elapsedPause(s, 2000); // pause at t=2s
@@ -74,10 +74,10 @@ describe("elapsed maths across a pause/resume cycle", () => {
   });
 
   it("supports multiple pause/resume cycles summing only live segments", () => {
-    let s = elapsedStart();
-    s = elapsedPause(s, 1000); // ran 1s
+    let s = elapsedResume(elapsedReset(), 0);
+    s = elapsedPause(s, 1000); // ran 1s -> accum 1000
     s = elapsedResume(s, 2000); // paused 1s
-    s = elapsedPause(s, 2500); // ran 0.5s -> accum 1.5s
+    s = elapsedPause(s, 2500); // ran 0.5s -> accum 1500
     expect(elapsedCurrent(s, 9000)).toBe(1500); // paused: frozen
     s = elapsedResume(s, 9000);
     expect(elapsedCurrent(s, 9500)).toBe(2000); // resumed 0.5s

--- a/src/renderer/voice.test.ts
+++ b/src/renderer/voice.test.ts
@@ -1,0 +1,118 @@
+// Pure-part tests for the reworked voice recorder (BET-835). The recorder
+// hook itself wires MediaRecorder + AnalyserNode (not unit-testable here);
+// everything pure — peak reduction, elapsed maths across a pause/resume
+// cycle, the near-limit threshold, and the too-short discard — lives in the
+// extracted functions below and is what we pin.
+
+import { describe, expect, it } from "vitest";
+import {
+  elapsedCurrent,
+  elapsedPause,
+  elapsedResume,
+  elapsedStart,
+  isTooShort,
+  nearLimitAt,
+} from "./voice";
+import {
+  VOICE_MAX_DURATION_MS,
+  VOICE_MIN_DURATION_MS,
+  VOICE_WARN_REMAINING_MS,
+  downsamplePeaks,
+} from "../shared/waveform.mjs";
+
+describe("peak reduction over a synthetic buffer", () => {
+  it("keeps a short buffer as-is (quantized, unpadded)", () => {
+    const out = downsamplePeaks([0.1, 0.5, 1.0, 0.0]);
+    expect(out.length).toBe(4);
+    expect(Array.from(out)).toEqual([26, 128, 255, 0]);
+  });
+
+  it("reduces a long buffer to at most the stored-peak cap", () => {
+    const long = Array.from({ length: 5000 }, (_, i) => (i % 2 ? 0.9 : 0.1));
+    const out = downsamplePeaks(long);
+    expect(out.length).toBeLessThanOrEqual(400);
+    for (const v of out) {
+      expect(v).toBeGreaterThanOrEqual(0);
+      expect(v).toBeLessThanOrEqual(255);
+    }
+  });
+
+  it("uses the max per bucket, never the mean, and never flattens a spike", () => {
+    const samples = new Array(400).fill(0);
+    samples[120] = 1.0; // one loud spike somewhere mid-buffer
+    const out = downsamplePeaks(samples);
+    // A single full-scale sample must survive reduction as at least one 255.
+    expect(Math.max(...out)).toBe(255);
+  });
+
+  it("maps silence to all zeros and empty input to empty output", () => {
+    expect(Array.from(downsamplePeaks(new Array(1000).fill(0)))).toEqual(
+      new Array(400).fill(0),
+    );
+    expect(downsamplePeaks([]).length).toBe(0);
+  });
+});
+
+describe("elapsed maths across a pause/resume cycle", () => {
+  it("tracks a linear recording with no pauses", () => {
+    const s = elapsedStart();
+    expect(elapsedCurrent(s, 0)).toBe(0);
+    expect(elapsedCurrent(s, 1000)).toBe(1000);
+    expect(elapsedCurrent(s, 3500)).toBe(3500);
+  });
+
+  it("freezes while paused and excludes the paused span after resume", () => {
+    let s = elapsedStart(); // t=0 take starts
+    expect(elapsedCurrent(s, 2000)).toBe(2000); // 2s live
+
+    s = elapsedPause(s, 2000); // pause at t=2s
+    expect(elapsedCurrent(s, 3000)).toBe(2000); // paused: frozen at 2s
+
+    s = elapsedResume(s, 3000); // resume at t=3s
+    expect(elapsedCurrent(s, 3500)).toBe(2500); // 2s + 0.5s, paused 1s excluded
+    expect(elapsedCurrent(s, 4000)).toBe(3000);
+  });
+
+  it("supports multiple pause/resume cycles summing only live segments", () => {
+    let s = elapsedStart();
+    s = elapsedPause(s, 1000); // ran 1s
+    s = elapsedResume(s, 2000); // paused 1s
+    s = elapsedPause(s, 2500); // ran 0.5s -> accum 1.5s
+    expect(elapsedCurrent(s, 9000)).toBe(1500); // paused: frozen
+    s = elapsedResume(s, 9000);
+    expect(elapsedCurrent(s, 9500)).toBe(2000); // resumed 0.5s
+  });
+});
+
+describe("near-limit threshold", () => {
+  it("is false fresh and well under the cap", () => {
+    expect(nearLimitAt(0)).toBe(false);
+    expect(nearLimitAt(VOICE_MAX_DURATION_MS / 2)).toBe(false);
+  });
+
+  it("flips true only once remaining time is under the warn window", () => {
+    // remaining == warn is NOT under it
+    expect(
+      nearLimitAt(VOICE_MAX_DURATION_MS - VOICE_WARN_REMAINING_MS),
+    ).toBe(false);
+    // remaining < warn
+    expect(
+      nearLimitAt(VOICE_MAX_DURATION_MS - VOICE_WARN_REMAINING_MS + 1),
+    ).toBe(true);
+    // at/over the cap
+    expect(nearLimitAt(VOICE_MAX_DURATION_MS)).toBe(true);
+  });
+});
+
+describe("too-short discard", () => {
+  it("accepts a take at or above the minimum with a real blob", () => {
+    expect(isTooShort(VOICE_MIN_DURATION_MS, 1024)).toBe(false);
+    expect(isTooShort(VOICE_MIN_DURATION_MS + 1000, 4096)).toBe(false);
+  });
+
+  it("discards a sub-minimum take or a sub-1KB blob", () => {
+    expect(isTooShort(VOICE_MIN_DURATION_MS - 1, 4096)).toBe(true);
+    expect(isTooShort(5000, 1023)).toBe(true);
+    expect(isTooShort(VOICE_MIN_DURATION_MS, 1023)).toBe(true);
+  });
+});

--- a/src/renderer/voice.ts
+++ b/src/renderer/voice.ts
@@ -75,7 +75,7 @@ const RECORDER_TIMESLICE_MS = 250;
 // accumMs + live segment.
 export type ElapsedState = { accumMs: number; segStartAt: number | null };
 
-export function elapsedStart(): ElapsedState {
+export function elapsedReset(): ElapsedState {
   return { accumMs: 0, segStartAt: null };
 }
 
@@ -183,7 +183,7 @@ export function useVoiceRecorder({
   const storedPeaksRef = useRef<number[]>([]);
 
   // Elapsed bookkeeping (excludes paused time).
-  const elapsedRef = useRef<ElapsedState>(elapsedStart());
+  const elapsedRef = useRef<ElapsedState>(elapsedReset());
 
   const recorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
@@ -312,7 +312,7 @@ export function useVoiceRecorder({
       endedRef.current = false;
       storedPeaksRef.current = [];
       liveWindowRef.current = new Float32Array(VOICE_LIVE_WINDOW_BARS);
-      elapsedRef.current = elapsedStart();
+      elapsedRef.current = elapsedReset();
 
       const mime = pickRecorderMime();
       mimeRef.current = mime;

--- a/src/renderer/voice.ts
+++ b/src/renderer/voice.ts
@@ -1,40 +1,62 @@
-// voice.ts — renderer-side voice recording + transcribe helpers.
+// voice.ts — renderer-side voice recording.
 //
-// Push-to-talk MediaRecorder wrapper with a sticky `lastError` so the UI can
-// surface mic-permission denials without subscribing to every state change.
-// Recording is started on press, stopped on release; on stop we transcribe
-// via window.api.voiceTranscribe and hand the raw text to `onResult`.
+// A toggled recording SESSION, not a press-and-hold one-shot: start/pause/
+// resume/stop/cancel, with live level capture for the waveform UI. The hook
+// CAPTURES audio + levels and hands back an artifact; it does not upload,
+// transcribe, or touch the composer. Orchestration (transcription, insertion,
+// keybinds) lives in useVoice.ts. Keeping this line is what lets iOS mirror
+// the hook later without inheriting web concerns.
 //
-// The hook itself is component-coupled (refs/state).
+//     onComplete({ blob, mime, durationMs, peaks })
+//
+// `peaks` is already downsampled (downsamplePeaks) at stop time.
+//
+// The hook itself is component-coupled (refs/state) but all the pure maths
+// (elapsed bookkeeping across pause/resume, the near-limit threshold, the
+// too-short discard) is extracted below so it can be unit-tested without a
+// MediaRecorder.
 
 import { useCallback, useEffect, useRef, useState } from "react";
+import {
+  downsamplePeaks,
+  VOICE_LIVE_WINDOW_BARS,
+  VOICE_MAX_DURATION_MS,
+  VOICE_MIN_DURATION_MS,
+  VOICE_SAMPLE_INTERVAL_MS,
+  VOICE_WARN_REMAINING_MS,
+} from "../shared/waveform.mjs";
 
+// The state machine the hook actually enters. `processing` is deliberately
+// gone — transcription is the orchestration layer's (useVoice's) business,
+// never the recorder's. Do not add a phase this hook never enters; that is
+// exactly the dead-state problem the iOS recorder has.
 export type VoicePhase =
   | "idle"
   | "requesting"  // browser is asking for mic permission / opening device
   | "recording"   // MediaRecorder is collecting chunks
-  | "processing"  // recorder stopped, transcribe in flight
+  | "paused"      // take held open, sampler + recorder paused
   | "error";
 
+export type VoiceArtifact = {
+  blob: Blob;
+  mime: string;
+  durationMs: number;
+  peaks: Uint8Array;
+};
+
 export type UseVoiceRecorderOptions = {
-  // Called when a press-and-hold cycle yields a transcribed result. The
-  // caller inserts the text into the composer (dictation-only).
-  onResult: (text: string) => void;
+  // Called when a take ends (stop, hard cap, or mic loss) with the captured
+  // audio + downsampled waveform. The caller (useVoice) transcribes/uploads.
+  onComplete: (artifact: VoiceArtifact) => void;
   // Optional error sink — defaults to logging. Use it to surface mic
-  // permission denied / no key / network errors in the chat error banner.
+  // permission denied / device loss in the chat error banner.
   onError?: (err: Error) => void;
-  // Optional sink for the "recorded but nothing usable came back" case:
-  // the clip was too short (< ~1KB) OR Groq returned an empty transcript
-  // (silence / unintelligible). This is NOT an error — the pipeline worked,
-  // there was just nothing to insert. Without this the hook silently returns
-  // to idle and the user sees zero feedback after releasing the mic ("I
-  // pressed it, it went red, released, and nothing happened"). `reason`
-  // distinguishes the two so the UI can word the hint appropriately.
-  onEmpty?: (reason: "too-short" | "no-speech") => void;
-  // Hard cap on a single press so a stuck press doesn't burn quota. Default
-  // 60s — Groq's whisper-large-v3-turbo handles ~25MB / ~half hour per call,
-  // but most conversational use is well under a minute.
-  maxDurationMs?: number;
+  // The take was a mis-tap — under the minimum duration or a sub-1KB blob.
+  // Discarded silently; the UI shows "held too short" instead of silence.
+  onEmpty?: (reason: "too-short") => void;
+  // A non-fatal warning (e.g. the underlying source muted temporarily).
+  // Recording continues; the caller decides whether/how to surface it.
+  onWarning?: (msg: string) => void;
 };
 
 // MediaRecorder timeslice. Without a timeslice argument, MediaRecorder is
@@ -44,6 +66,44 @@ export type UseVoiceRecorderOptions = {
 // the time onstop runs. The chunks just concatenate downstream — no logic
 // change. See PR #4 review (W1).
 const RECORDER_TIMESLICE_MS = 250;
+
+// ===== Pure elapsed / limit maths (unit-testable) =====
+
+// Elapsed-time tracker that excludes paused spans from the running total.
+// `accumMs` is the frozen total from finished segments; `segStartAt` marks
+// the start of the current live segment (null while paused). current =
+// accumMs + live segment.
+export type ElapsedState = { accumMs: number; segStartAt: number | null };
+
+export function elapsedStart(): ElapsedState {
+  return { accumMs: 0, segStartAt: null };
+}
+
+export function elapsedCurrent(s: ElapsedState, now: number): number {
+  return s.accumMs + (s.segStartAt == null ? 0 : now - s.segStartAt);
+}
+
+export function elapsedPause(s: ElapsedState, now: number): ElapsedState {
+  return {
+    accumMs: elapsedCurrent(s, now),
+    segStartAt: null,
+  };
+}
+
+export function elapsedResume(s: ElapsedState, now: number): ElapsedState {
+  return { ...s, segStartAt: now };
+}
+
+// True once remaining time is under the warn threshold.
+export function nearLimitAt(elapsedMs: number): boolean {
+  return VOICE_MAX_DURATION_MS - elapsedMs < VOICE_WARN_REMAINING_MS;
+}
+
+// A take under the minimum duration, or a blob under 1 KB, is a mis-tap and
+// is discarded silently (onEmpty("too-short")) — keep today's behaviour.
+export function isTooShort(durationMs: number, blobSize: number): boolean {
+  return durationMs < VOICE_MIN_DURATION_MS || blobSize < 1024;
+}
 
 /**
  * Pick the best mimeType MediaRecorder supports on this platform. Order is
@@ -77,80 +137,96 @@ export function pickRecorderMime(): string {
 }
 
 /**
- * Internal: stop and tear down the recorder + mic stream. Safe to call
- * repeatedly. Used both by release-press and by error/unmount paths.
- */
-function stopRecorder(
-  recorder: MediaRecorder | null,
-  stream: MediaStream | null,
-): void {
-  try {
-    if (recorder && recorder.state !== "inactive") recorder.stop();
-  } catch {
-    /* already stopped or never started */
-  }
-  if (stream) {
-    for (const track of stream.getTracks()) {
-      try {
-        track.stop();
-      } catch {
-        /* track already ended */
-      }
-    }
-  }
-}
-
-/**
- * Push-to-talk hook. `start()` opens the mic + begins recording.
- * `stop()` ends recording and dispatches the transcript through
- * `onResult`. `cancel()` discards the current recording without
- * transcribing (escape hatch for "user changed their mind mid-press").
+ * Toggled recording-session hook. `start()` opens the mic + begins recording;
+ * `pause()`/`resume()` pause and continue the same take; `stop()` ends the
+ * take and fires `onComplete({blob, mime, durationMs, peaks})`; `cancel()`
+ * discards the current take with no callback.
  *
- * Re-entrancy: a second start() while already recording is a no-op.
- * Unmount stops cleanly so the mic LED doesn't stick on.
+ * Also captures live input levels into `liveWindowRef` (a rolling Float32Array
+ * ring, one value per sample) so the composer can render a live meter without
+ * re-rendering through React state — the canvas reads the ref in its own
+ * requestAnimationFrame loop. A flat copy of every sample is kept and
+ * downsampled into `peaks` at stop time.
+ *
+ * Re-entrancy: start() while requesting/recording/paused is a no-op. Unmount
+ * stops cleanly so the mic LED doesn't stick on.
  */
 export function useVoiceRecorder({
-  onResult,
+  onComplete,
   onError,
   onEmpty,
-  maxDurationMs = 60_000,
+  onWarning,
 }: UseVoiceRecorderOptions) {
   const [phase, setPhase] = useState<VoicePhase>("idle");
+  const [elapsedSec, setElapsedSec] = useState(0);
+  const [nearLimit, setNearLimit] = useState(false);
   const [lastError, setLastError] = useState<string | null>(null);
-  // phaseRef shadows `phase` for synchronous re-entrancy guards. React
-  // state lags behind event handlers within the same commit (W4 from
-  // review: two pointerdowns could both pass the state-based guard).
+
+  // phaseRef shadows `phase` for synchronous re-entrancy guards. React state
+  // lags behind event handlers within the same commit (W4 from review: two
+  // pointerdowns could both pass the state-based guard).
   const phaseRef = useRef<VoicePhase>("idle");
   const setPhaseSync = useCallback((p: VoicePhase) => {
     phaseRef.current = p;
     setPhase(p);
   }, []);
-  // Refs so concurrent start/stop don't race against React render cycles —
-  // we need to know IMMEDIATELY whether we're already mid-press.
+
+  // Live level window — a REF, never state. At 40 ms that is 25 updates a
+  // second; routing it through useState would re-render the whole composer
+  // 25 times a second. This is not a micro-optimisation — this panel has a
+  // documented history of keystroke-lag regressions from far less.
+  const liveWindowRef = useRef<Float32Array>(
+    new Float32Array(VOICE_LIVE_WINDOW_BARS),
+  );
+
+  // Every sampled peak (the whole take), downsampled at stop time.
+  const storedPeaksRef = useRef<number[]>([]);
+
+  // Elapsed bookkeeping (excludes paused time).
+  const elapsedRef = useRef<ElapsedState>(elapsedStart());
+
   const recorderRef = useRef<MediaRecorder | null>(null);
   const streamRef = useRef<MediaStream | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const analyserRef = useRef<AnalyserNode | null>(null);
   const chunksRef = useRef<Blob[]>([]);
   const mimeRef = useRef<string>("");
+
   const cancelledRef = useRef<boolean>(false);
   // Set when stop() is called during the "requesting" window (mic permission /
   // getUserMedia still pending, recorder not yet constructed). The start path
   // checks this right after getUserMedia resolves and immediately stops the
-  // freshly-started recorder so a quick press doesn't record to the 60s cap.
-  // Distinct from cancelledRef: a stop is a deliberate "send what I said",
-  // whereas cancel discards. (For a too-quick press there's no audio yet, so
-  // both behave the same in practice, but keeping them separate means a
-  // slightly-slow getUserMedia still captures the tail of speech.)
+  // freshly-started recorder so a quick press doesn't record to the cap.
   const stopRequestedRef = useRef<boolean>(false);
-  const maxTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // Set when the underlying audio track reports `ended` (device lost). The
+  // stop path then surfaces an error even though it keeps a valid take.
+  const endedRef = useRef<boolean>(false);
+
+  const sampleTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const elapsedTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  // Latest-callback refs so the sampling/elapsed intervals (created once per
+  // start) never read a stale callback if the caller's closure identity
+  // changes mid-take.
+  const onCompleteRef = useRef(onComplete);
+  onCompleteRef.current = onComplete;
+  const onErrorRef = useRef(onError);
+  onErrorRef.current = onError;
+  const onEmptyRef = useRef(onEmpty);
+  onEmptyRef.current = onEmpty;
+  const onWarningRef = useRef(onWarning);
+  onWarningRef.current = onWarning;
+  const setPhaseSyncRef = useRef(setPhaseSync);
+  setPhaseSyncRef.current = setPhaseSync;
 
   const reportError = useCallback(
     (err: unknown) => {
       const msg = err instanceof Error ? err.message : String(err);
       setLastError(msg);
       setPhaseSync("error");
-      if (onError) {
+      if (onErrorRef.current) {
         try {
-          onError(err instanceof Error ? err : new Error(msg));
+          onErrorRef.current(err instanceof Error ? err : new Error(msg));
         } catch {
           /* user-supplied callback threw — ignore */
         }
@@ -159,63 +235,187 @@ export function useVoiceRecorder({
         console.warn("[voice]", msg);
       }
     },
-    [onError, setPhaseSync],
+    [setPhaseSync],
   );
+
+  // Stop every track (so the OS recording indicator clears), close the
+  // AudioContext, and drop the recorder/stream references. Safe to call
+  // repeatedly. Used by stop/cancel/unmount/error paths.
+  const teardownMedia = useCallback(() => {
+    if (streamRef.current) {
+      for (const track of streamRef.current.getTracks()) {
+        try {
+          track.stop();
+        } catch {
+          /* track already ended */
+        }
+      }
+    }
+    if (audioCtxRef.current && audioCtxRef.current.state !== "closed") {
+      // Closing is async; fire-and-forget — we only hold the context to
+      // release the OS recording indicator, not to read anything after.
+      audioCtxRef.current.close().catch(() => {});
+    }
+    streamRef.current = null;
+    audioCtxRef.current = null;
+    analyserRef.current = null;
+    recorderRef.current = null;
+  }, []);
+
+  const clearIntervals = useCallback(() => {
+    if (sampleTimerRef.current) {
+      clearInterval(sampleTimerRef.current);
+      sampleTimerRef.current = null;
+    }
+    if (elapsedTimerRef.current) {
+      clearInterval(elapsedTimerRef.current);
+      elapsedTimerRef.current = null;
+    }
+  }, []);
+
+  // One sampling callback shared by start() and resume(). Reads the analyser
+  // and pushes each peak to BOTH the rolling live window (liveWindowRef) and
+  // the flat stored array (downsampled into `peaks` at stop).
+  const sampleTick = useCallback(() => {
+    const analyser = analyserRef.current;
+    if (!analyser) return;
+    const buf = new Float32Array(analyser.fftSize);
+    analyser.getFloatTimeDomainData(buf);
+    let peak = 0;
+    for (let i = 0; i < buf.length; i++) {
+      const a = Math.abs(buf[i]);
+      if (a > peak) peak = a;
+    }
+    // clamp to 0..1
+    peak = peak > 1 ? 1 : peak;
+    const win = liveWindowRef.current;
+    win.copyWithin(0, 1);
+    win[win.length - 1] = peak;
+    storedPeaksRef.current.push(peak);
+  }, []);
 
   const start = useCallback(
     async () => {
-      // W4: ref-based guard. The state-based phase check used to leak
-      // double-presses inside the same React commit; phaseRef is updated
-      // synchronously via setPhaseSync so it can't lie.
+      // ref-based re-entrancy guard (W4).
       if (
-        phaseRef.current === "recording" ||
         phaseRef.current === "requesting" ||
-        phaseRef.current === "processing"
+        phaseRef.current === "recording" ||
+        phaseRef.current === "paused"
       ) {
         return;
       }
       setLastError(null);
+      setNearLimit(false);
+      setElapsedSec(0);
       cancelledRef.current = false;
       stopRequestedRef.current = false;
+      endedRef.current = false;
+      storedPeaksRef.current = [];
+      liveWindowRef.current = new Float32Array(VOICE_LIVE_WINDOW_BARS);
+      elapsedRef.current = elapsedStart();
+
       const mime = pickRecorderMime();
       mimeRef.current = mime;
-      if (typeof navigator === "undefined" || !navigator.mediaDevices?.getUserMedia) {
+      if (
+        typeof navigator === "undefined" ||
+        !navigator.mediaDevices?.getUserMedia
+      ) {
         reportError(new Error("Microphone not available in this environment."));
         return;
       }
       setPhaseSync("requesting");
+
       let stream: MediaStream;
       try {
         stream = await navigator.mediaDevices.getUserMedia({ audio: true });
       } catch (e) {
         reportError(
           e instanceof Error && e.name === "NotAllowedError"
-            ? new Error("Microphone permission denied. Allow it in your browser/OS settings.")
+            ? new Error(
+                "Microphone permission denied. Allow it in your browser/OS settings.",
+              )
             : (e as Error) ?? new Error("Could not access microphone."),
         );
         return;
       }
-      // W3: if the user already released (cancel() flipped cancelledRef
-      // while we were awaiting getUserMedia), abandon NOW — tear the mic
-      // down, don't construct a recorder that nothing will stop. Without
-      // this the maxDurationMs timer would record for the full 60s after
-      // a too-quick press.
+      // W3: if the user already released / cancelled while we awaited
+      // getUserMedia, abandon NOW — tear the mic down, don't construct a
+      // recorder that nothing will stop.
       if (cancelledRef.current) {
         for (const t of stream.getTracks()) {
-          try { t.stop(); } catch { /* ignore */ }
+          try {
+            t.stop();
+          } catch {
+            /* ignore */
+          }
         }
         setPhaseSync("idle");
         return;
       }
       streamRef.current = stream;
+
+      // ===== Level capture — the part that is easy to get wrong =====
+      // Wire an AnalyserNode off the SAME MediaStream driving the recorder:
+      //   AudioContext -> createMediaStreamSource(stream) -> analyser.
+      // fftSize = 32 is NOT about frequency resolution — it is a short buffer
+      // for responsive peak detection. We read with getFloatTimeDomainData
+      // (time-domain), never getByteFrequencyData (that is a spectrum
+      // analyser — a different picture entirely).
+      try {
+        const AC =
+          window.AudioContext ||
+          (window as unknown as { webkitAudioContext?: typeof AudioContext })
+            .webkitAudioContext;
+        const ctx = new AC();
+        const source = ctx.createMediaStreamSource(stream);
+        const analyser = ctx.createAnalyser();
+        analyser.fftSize = 32;
+        source.connect(analyser);
+        // Note: NOT connected to ctx.destination — we only measure, we do not
+        // monitor the mic through the speakers.
+        audioCtxRef.current = ctx;
+        analyserRef.current = analyser;
+      } catch (e) {
+        teardownMedia();
+        reportError(e);
+        return;
+      }
+
+      // ===== Microphone loss =====
+      // The audio track fires `ended` when the device (or its permission) is
+      // gone, and `mute` when the source briefly stops supplying data. A user
+      // muting via hardware or the OS sets `track.enabled`, which fires NO
+      // events at all and cannot be observed — build no UI promising to
+      // detect it.
+      const track = stream.getAudioTracks()[0];
+      if (track) {
+        track.onended = () => {
+          endedRef.current = true;
+          const rec = recorderRef.current;
+          if (rec && rec.state !== "inactive") {
+            try {
+              rec.stop();
+            } catch {
+              /* already inactive */
+            }
+          }
+        };
+        track.onmute = () => {
+          // Source temporarily silent but may unmute — keep recording, just
+          // warn so the user isn't confused by a flat waveform.
+          onWarningRef.current?.(
+            "Microphone muted — recording may come out silent.",
+          );
+        };
+      }
+
       let recorder: MediaRecorder;
       try {
         recorder = mime
           ? new MediaRecorder(stream, { mimeType: mime })
           : new MediaRecorder(stream);
       } catch (e) {
-        stopRecorder(null, stream);
-        streamRef.current = null;
+        teardownMedia();
         reportError(e);
         return;
       }
@@ -233,84 +433,68 @@ export function useVoiceRecorder({
           new Error("MediaRecorder error");
         reportError(err);
       };
-      recorder.onstop = async () => {
-        // Tear down the mic immediately so the OS-level recording indicator
-        // disappears even before the transcribe call returns.
-        if (streamRef.current) {
-          for (const t of streamRef.current.getTracks()) {
-            try {
-              t.stop();
-            } catch {
-              /* ignore */
-            }
-          }
-        }
-        if (maxTimerRef.current) {
-          clearTimeout(maxTimerRef.current);
-          maxTimerRef.current = null;
-        }
-        if (cancelledRef.current) {
-          chunksRef.current = [];
-          recorderRef.current = null;
-          streamRef.current = null;
-          setPhaseSync("idle");
-          return;
-        }
+      recorder.onstop = () => {
+        clearIntervals();
         const chunks = chunksRef.current;
+        const stored = storedPeaksRef.current;
+        const wasCancelled = cancelledRef.current;
+        const wasEnded = endedRef.current;
         chunksRef.current = [];
-        recorderRef.current = null;
-        streamRef.current = null;
-        if (chunks.length === 0) {
-          setPhaseSync("idle");
+        storedPeaksRef.current = [];
+        teardownMedia();
+        if (wasCancelled) {
+          setPhaseSyncRef.current("idle");
           return;
         }
         const blob = new Blob(chunks, { type: mimeRef.current || "audio/webm" });
-        if (blob.size < 1024) {
-          // Too short — Groq returns "audio_too_short". Don't bother. Tell the
-          // UI so the user gets feedback instead of a silent no-op.
-          setPhaseSync("idle");
-          onEmpty?.("too-short");
+        const mime = mimeRef.current || blob.type || "audio/webm";
+        const durationMs = Math.round(
+          elapsedCurrent(elapsedRef.current, performance.now()),
+        );
+        const tooShort = isTooShort(durationMs, blob.size);
+        if (wasEnded) {
+          // Device gone mid-take. Keep whatever we captured (over the
+          // minimum), but surface an error so the user isn't left wondering.
+          if (!tooShort) {
+            onCompleteRef.current({
+              blob,
+              mime,
+              durationMs,
+              peaks: downsamplePeaks(stored),
+            });
+          }
+          reportError(new Error("Microphone disconnected during recording."));
           return;
         }
-        setPhaseSync("processing");
-        try {
-          const buffer = await blob.arrayBuffer();
-          const res = await window.api.voiceTranscribe({
-            buffer,
-            mime: mimeRef.current || blob.type || "audio/webm",
-          });
-          const text = res.text.trim();
-          if (!text) {
-            // Pipeline worked but Groq heard no speech (silence / too quiet /
-            // unintelligible). Surface it so the release isn't a silent no-op.
-            setPhaseSync("idle");
-            onEmpty?.("no-speech");
-            return;
-          }
-          onResult(text);
-          setPhaseSync("idle");
-        } catch (e) {
-          reportError(e);
+        if (tooShort) {
+          // Mis-tap — discard silently, keep today's behaviour.
+          setPhaseSyncRef.current("idle");
+          onEmptyRef.current?.("too-short");
+          return;
         }
+        setPhaseSyncRef.current("idle");
+        onCompleteRef.current({
+          blob,
+          mime,
+          durationMs,
+          peaks: downsamplePeaks(stored),
+        });
       };
+
       try {
-        // W1: 250ms timeslice so ondataavailable fires periodically.
-        // Without it, iOS WKWebView occasionally drops the final chunk
-        // when it arrives after onstop, leaving an empty Blob.
+        // W1: 250ms timeslice so ondataavailable fires periodically. Without
+        // it, iOS WKWebView occasionally drops the final chunk when it
+        // arrives after onstop, leaving an empty Blob.
         recorder.start(RECORDER_TIMESLICE_MS);
       } catch (e) {
-        stopRecorder(recorder, stream);
-        recorderRef.current = null;
-        streamRef.current = null;
+        teardownMedia();
         reportError(e);
         return;
       }
-      setPhaseSync("recording");
       // The user may have already released DURING the getUserMedia await
       // (stop() set stopRequestedRef before the recorder existed). Honor it
-      // now: stop the just-started recorder so onstop fires and transcribes
-      // the brief tail instead of running to maxDuration. A genuinely empty
-      // clip falls through to the onEmpty("too-short") notice in onstop.
+      // now: stop the just-started recorder so onstop fires and completes the
+      // brief tail instead of running to the cap.
       if (stopRequestedRef.current) {
         stopRequestedRef.current = false;
         try {
@@ -320,23 +504,95 @@ export function useVoiceRecorder({
         }
         return;
       }
-      // Auto-stop after maxDurationMs so a stuck press doesn't burn quota.
-      maxTimerRef.current = setTimeout(() => {
-        if (recorderRef.current && recorderRef.current.state === "recording") {
-          try {
-            recorderRef.current.stop();
-          } catch {
-            /* already stopped */
+
+      elapsedRef.current = { accumMs: 0, segStartAt: performance.now() };
+      setPhaseSync("recording");
+
+      // Peak sampling cadence. deliberately setInterval, NOT
+      // requestAnimationFrame: rAF is throttled/stopped when the window is
+      // hidden, and recording deliberately continues through blur — sampling
+      // on rAF would silently drop level data whenever the user switched away.
+      sampleTimerRef.current = setInterval(sampleTick, VOICE_SAMPLE_INTERVAL_MS);
+
+      // Elapsed display tick. React re-renders only when the displayed second
+      // (or the near-limit flag) actually changes — floor() + useState bail-out.
+      elapsedTimerRef.current = setInterval(() => {
+        const ms = elapsedCurrent(elapsedRef.current, performance.now());
+        setElapsedSec(Math.floor(ms / 1000));
+        setNearLimit(nearLimitAt(ms));
+        // Hard cap: behaves exactly as if the user hit send — the take is
+        // kept, never dropped (recorder.stop() -> onstop -> onComplete).
+        if (ms >= VOICE_MAX_DURATION_MS) {
+          const rec = recorderRef.current;
+          if (rec && (rec.state === "recording" || rec.state === "paused")) {
+            try {
+              rec.stop();
+            } catch {
+              /* already stopped */
+            }
           }
         }
-      }, maxDurationMs);
+      }, 250);
     },
-    [onResult, onEmpty, reportError, maxDurationMs, setPhaseSync],
+    [reportError, teardownMedia, clearIntervals, setPhaseSync, sampleTick],
   );
+
+  const pause = useCallback(() => {
+    if (phaseRef.current !== "recording") return;
+    const rec = recorderRef.current;
+    if (rec && rec.state === "recording") {
+      try {
+        // requestData() BEFORE pause() flushes the buffered data so the chunk
+        // boundary is well-defined. Without the flush the paused segment can
+        // be lost — this is a real MediaRecorder trap, not a theoretical one.
+        rec.requestData();
+      } catch {
+        /* ignore */
+      }
+      try {
+        rec.pause();
+      } catch {
+        /* ignore */
+      }
+    }
+    // Freeze elapsed at the pause moment so paused time never counts toward
+    // the duration cap.
+    elapsedRef.current = elapsedPause(
+      elapsedRef.current,
+      performance.now(),
+    );
+    setElapsedSec(Math.floor(elapsedRef.current.accumMs / 1000));
+    // Stop the sampling interval so the waveform freezes rather than filling
+    // with silence.
+    if (sampleTimerRef.current) {
+      clearInterval(sampleTimerRef.current);
+      sampleTimerRef.current = null;
+    }
+    setPhaseSync("paused");
+  }, [setPhaseSync]);
+
+  const resume = useCallback(() => {
+    if (phaseRef.current !== "paused") return;
+    const rec = recorderRef.current;
+    if (rec && rec.state === "paused") {
+      try {
+        rec.resume();
+      } catch {
+        /* ignore */
+      }
+    }
+    // Re-base the time origin so elapsed excludes the paused span.
+    elapsedRef.current = elapsedResume(
+      elapsedRef.current,
+      performance.now(),
+    );
+    sampleTimerRef.current = setInterval(sampleTick, VOICE_SAMPLE_INTERVAL_MS);
+    setPhaseSync("recording");
+  }, [setPhaseSync, sampleTick]);
 
   const stop = useCallback(() => {
     const rec = recorderRef.current;
-    if (rec && rec.state !== "inactive") {
+    if (rec && (rec.state === "recording" || rec.state === "paused")) {
       try {
         rec.stop();
       } catch {
@@ -345,37 +601,40 @@ export function useVoiceRecorder({
     } else if (phaseRef.current === "requesting") {
       // Released before getUserMedia resolved — the recorder doesn't exist
       // yet. Record the intent; the start path stops the recorder the instant
-      // it's constructed (see stopRequestedRef check after recorder.start()).
-      // Without this the recording would run unstoppable to the 60s cap and
-      // the release would appear to do nothing.
+      // it's constructed (see stopRequestedRef after outstanding start).
       stopRequestedRef.current = true;
     }
   }, []);
 
   const cancel = useCallback(() => {
     cancelledRef.current = true;
-    const rec = recorderRef.current;
-    const stream = streamRef.current;
-    stopRecorder(rec, stream);
-    if (maxTimerRef.current) {
-      clearTimeout(maxTimerRef.current);
-      maxTimerRef.current = null;
-    }
-    recorderRef.current = null;
-    streamRef.current = null;
+    teardownMedia();
+    clearIntervals();
     chunksRef.current = [];
+    storedPeaksRef.current = [];
     setPhaseSync("idle");
-  }, [setPhaseSync]);
+  }, [teardownMedia, clearIntervals, setPhaseSync]);
 
   // Stop cleanly on unmount so the mic LED doesn't stick on if the user
-  // navigates away mid-press.
+  // navigates away mid-take.
   useEffect(() => {
     return () => {
       cancelledRef.current = true;
-      stopRecorder(recorderRef.current, streamRef.current);
-      if (maxTimerRef.current) clearTimeout(maxTimerRef.current);
+      teardownMedia();
+      clearIntervals();
     };
-  }, []);
+  }, [teardownMedia, clearIntervals]);
 
-  return { phase, lastError, start, stop, cancel };
+  return {
+    phase,
+    elapsedSec,
+    nearLimit,
+    lastError,
+    liveWindowRef,
+    start,
+    pause,
+    resume,
+    stop,
+    cancel,
+  };
 }


### PR DESCRIPTION
## BET-835 — Voice: rework the recorder into a toggled session with pause and level capture

Reworks `src/renderer/voice.ts` from a press-and-hold one-shot into a toggled recording **session** with pause/resume and waveform level capture. No new UI — the composer renders as before; the mic button keeps working through it.

### What changed
- **Phases**: `idle | requesting | recording | paused | error`. `processing` is removed from the recorder (transcription is the orchestration layer's business now).
- **API**: `{ phase, elapsedSec, nearLimit, lastError, liveWindowRef, start, pause, resume, stop, cancel }`.
- **Artifact**: `onComplete({ blob, mime, durationMs, peaks })` — `peaks` downsampled via `downsamplePeaks` at stop time. The hook captures audio + levels only; orchestration (upload/transcribe/composer) stays in `useVoice.ts`.
- **Level capture**: `AnalyserNode` (fftSize=32) off the same `MediaStream`, read with `getFloatTimeDomainData`, sampled on `setInterval(VOICE_SAMPLE_INTERVAL_MS)` (not rAF — recording continues through blur). `peak = max(|sample|)` clamped 0..1 pushed to both `liveWindowRef` (Float32Array ref, never state) and a flat stored array.
- **Pause/resume**: `requestData()` before `pause()` (flush boundary, documented), sampling interval stopped while paused, time origin re-based on resume so paused time never counts toward the duration cap (checked against `VOICE_MAX_DURATION_MS` in the elapsed tick, keeping the take — never dropped).
- **Limits**: `nearLimit` under `VOICE_WARN_REMAINING_MS`; sub-minimum / sub-1KB blob → `onEmpty("too-short")` discarded silently (today's behaviour).
- **Mic loss**: track `ended` → stop, keep a valid take, surface error; `mute` → warning, keep recording; a comment documents that `enabled` fires no events and can't be observed.
- **Wiring** (`useVoice.ts`): keeps `Ctrl+M` toggle, `Esc` cancel, `Enter` stop-and-submit; transcribes the artifact via the existing `voice:transcribe` channel and inserts at the caret. New upload route not used yet (lands with the transcript ticket). `pause`/`resume` are reachable from the hook.
- **Tests**: `src/renderer/voice.test.ts` covers the pure parts — peak reduction over synthetic buffers, elapsed maths across pause/resume cycles, near-limit threshold, and too-short discard. MediaRecorder is not tested.

### Cross-cutting note
MicButton's `busy` (the "transcribing…" spinner + press guard) was previously derived from the now-removed `processing` phase. It is now an **optional `busy?` prop** supplied by `useVoice` via `InputArea`, keeping MicButton's press/release semantics, `pressActiveRef` guard, and pointer capture unchanged.

### Verification results
- `npm run typecheck` — ✅ pass
- `npm test` — ✅ vitest 2541 passed / 7 skipped; node 660 passed / 0 fail

**Base: origin/main @ `bd303951`**
