### PR TITLE
feat(renderer): voice shortcut to CmdOrCtrl+Shift+M with tap/hold (BET-838)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,6 +288,13 @@ Window-scoped, in `App.tsx`. xterm-internal handlers (⌘C/V/F/K) live in
 | ⌥⌘↑ / ⌥⌘↓ | Step prev/next session, wraps both ends     |
 | ⌘I          | Toggle the Artifacts panel (chat pane active only) |
 | ⌘,          | Open Settings                                |
+| ⇧⌘M         | Voice (chat composer): tap toggles recording on/off, hold is push-to-talk |
+
+The voice row is a capture-phase handler in `src/renderer/hooks/useVoice.ts`,
+not a window-scoped `App.tsx` one; while a take is active, `Enter` stops +
+sends, `Space` pauses/resumes (only when the composer textarea isn't focused),
+and `Esc` discards. The old no-shift binding was retired — it collided with the
+terminal's carriage return and sat on Wispr Flow's conflict list.
 
 Flat order for ⌘1..9 / ⌥⌘ navigation comes from `flatSessions(projects)` —
 the sidebar's top-down (project, window) tuple list. Don't reorder it without
@@ -1538,8 +1545,8 @@ footer row holds: the model picker (model + effort + fast-toggle, inside
 `ModelPicker`), the mic and attach buttons (input-mode affordances), and on
 the right the usage dial (`UsageDial`) plus the ⏰ schedules / 🔑 secrets /
 🪝 webhooks `SessionToolbar` buttons, with a transient voice/running status
-string ("transcribing… · esc cancels" / "recording · ⏎ send · ctrl+m stop ·
-esc cancel" / "esc · interrupt") appearing while voice or a turn is active.
+string ("transcribing… · esc cancels" / "recording · ⏎ send · ⇧⌘M stop ·
+space pause · esc cancel" / "esc · interrupt") appearing while voice or a turn is active.
 A trust toggle ("Permissions on — click to bypass" / "Bypassing permissions")
 sits on its own row beneath the footer. Status that describes the SESSION
 (branch, context pill, stale-cache warning, fork/compact/clear/delete) lives

--- a/docs/settings-redesign/mockup.html
+++ b/docs/settings-redesign/mockup.html
@@ -426,7 +426,7 @@
           <div class="mockup-section">
             <label>Push-to-talk dictation</label>
             <div class="hint" style="margin-bottom: 10px;">
-              Press <kbd style="background: #444; padding: 2px 4px; border-radius: 2px; font-size: 10px;">ctrl+m</kbd> to record, <kbd style="background: #444; padding: 2px 4px; border-radius: 2px; font-size: 10px;">⏎</kbd> to send, <kbd style="background: #444; padding: 2px 4px; border-radius: 2px; font-size: 10px;">esc</kbd> to cancel.
+              Press <kbd style="background: #444; padding: 2px 4px; border-radius: 2px; font-size: 10px;">ctrl+shift+m</kbd> to record (tap toggles, hold is push-to-talk), <kbd style="background: #444; padding: 2px 4px; border-radius: 2px; font-size: 10px;">⏎</kbd> to send, <kbd style="background: #444; padding: 2px 4px; border-radius: 2px; font-size: 10px;">esc</kbd> to cancel.
               Get a key at <a href="#" style="color: #007bff; text-decoration: none;">console.groq.com/keys</a> (free tier).
             </div>
           </div>

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -11,6 +11,7 @@ import type { VoicePhase } from "./voice";
 import { type Attachment, type TypeaheadRow } from "./chatShared";
 import type { PendingScreenshot } from "./store";
 import { IconButton } from "./IconButton";
+import { IS_MAC } from "./platform";
 // BET-726 Task 1: same scrollIntoView idiom the ⌘K / ⌘F palettes and the
 // model/effort menus use (PaletteShell.tsx) — keeps the keyboard-selected
 // @-file row visible when it moves past the popup's scroll fold.
@@ -24,6 +25,11 @@ import { useSelectedIntoView } from "./PaletteShell";
 export const mbtn =
   "inline-flex items-center gap-[6px] h-[27px] px-2 rounded-sm text-text-faint hover:bg-fill-hover hover:text-text transition-colors " +
   "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
+
+// Human-readable form of the voice shortcut (CmdOrCtrl+Shift+M). Shared by
+// the mic button title/aria-label and the composer's transient status hint so
+// both name the binding in one place.
+export const VOICE_SHORTCUT_LABEL = IS_MAC ? "⇧⌘M" : "Ctrl+Shift+M";
 
 // SessionToolbar — footer affordances. fork / compact / delete moved out of the
 // footer (they live in the header ⋯ menu); only the ⏰ schedules toggle remains
@@ -402,11 +408,11 @@ export function MicButton({
     ? "transcribing…"
     : recording
       ? floating
-        ? "release to insert"
-        : "release · dictate"
+        ? `release to insert · ${VOICE_SHORTCUT_LABEL}`
+        : `release · dictate · ${VOICE_SHORTCUT_LABEL}`
       : floating
-        ? "hold to talk"
-        : "hold to speak";
+        ? `hold to talk · ${VOICE_SHORTCUT_LABEL}`
+        : `hold to speak · ${VOICE_SHORTCUT_LABEL}`;
 
   // Floating PTT FAB: round bubble, bottom-right (positioned by the
   // `.mobile-ptt-fab` rule in mobile.css — visual/layout lives there per the

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -33,7 +33,7 @@ import {
 import { baseModelId, isFastModelId, shortModelName } from "./chatUtils";
 import { ModelPicker } from "./ModelPicker";
 import { MeasureColumn } from "./MeasureColumn";
-import { AttachButton, AttachmentStrip, MicButton, SessionToolbar, PendingScreenshotStrip } from "./ComposerParts";
+import { AttachButton, AttachmentStrip, MicButton, SessionToolbar, PendingScreenshotStrip, VOICE_SHORTCUT_LABEL } from "./ComposerParts";
 import type { PendingScreenshot } from "./store";
 import { UsageDial } from "./UsageDial";
 // Re-exported so existing `import { TypeaheadPopup } from "./InputArea"` call
@@ -257,7 +257,7 @@ export function InputArea({
   const voiceActive = voiceRecording || voiceProcessing;
   // Detect mobile shell (touch device using the no-window.api branch with
   // MobileApp + .mobile-body wrapper). MicButton is only rendered there;
-  // on desktop the keyboard shortcut (Ctrl+M / Enter / Esc) drives voice.
+  // on desktop the keyboard shortcut (CmdOrCtrl+Shift+M / Enter / Esc) drives voice.
   const [isMobileShell, setIsMobileShell] = useState(false);
   const rowRef = useRef<HTMLDivElement | null>(null);
   useEffect(() => {
@@ -296,7 +296,7 @@ export function InputArea({
           composer). Hold to record, release to insert the transcript into
           the composer for review. Positioned + sized by `.mobile-ptt-fab` in
           mobile.css; only rendered in the mobile shell with a Groq key set.
-          Desktop voice stays keyboard-driven (Ctrl+M / Enter / Esc). */}
+          Desktop voice stays keyboard-driven (CmdOrCtrl+Shift+M / Enter / Esc). */}
       {voiceEnabled && isMobileShell && (
         <MicButton
           phase={voicePhase}
@@ -523,7 +523,7 @@ export function InputArea({
               {voiceActive
                 ? voiceProcessing
                   ? "transcribing… · esc cancels"
-                  : <span className="inline-flex items-center gap-1"><Mic size={14} aria-hidden="true" />recording · ⏎ send · ctrl+m stop · esc cancel</span>
+                  : <span className="inline-flex items-center gap-1"><Mic size={14} aria-hidden="true" />recording · ⏎ send · {VOICE_SHORTCUT_LABEL} stop · space pause · esc cancel</span>
                 : "esc · interrupt"}
             </span>
           )}

--- a/src/renderer/hooks/useVoice.test.tsx
+++ b/src/renderer/hooks/useVoice.test.tsx
@@ -57,16 +57,16 @@ describe("useVoice via ChatPanel", () => {
     expect(h.container.querySelector("textarea")).not.toBeNull();
   });
 
-  it("handles voice keybind Ctrl+M to start recording", async () => {
+  it("handles voice keybind CmdOrCtrl+Shift+M to start recording", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    // Simulate Ctrl+M keydown
+    // Simulate CmdOrCtrl+Shift+M keydown
     await act(async () => {
       const event = new KeyboardEvent("keydown", {
         key: "m",
         ctrlKey: true,
-        metaKey: false,
+        shiftKey: true,
         altKey: false,
         bubbles: true,
       });
@@ -77,28 +77,28 @@ describe("useVoice via ChatPanel", () => {
     expect(h.container.querySelector("textarea")).not.toBeNull();
   });
 
-  it("handles voice keybind Ctrl+M to stop recording", async () => {
+  it("handles voice keybind CmdOrCtrl+Shift+M to stop recording", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    // Simulate Ctrl+M keydown (start)
+    // Simulate CmdOrCtrl+Shift+M keydown (start)
     await act(async () => {
       const event = new KeyboardEvent("keydown", {
         key: "m",
         ctrlKey: true,
-        metaKey: false,
+        shiftKey: true,
         altKey: false,
         bubbles: true,
       });
       window.dispatchEvent(event);
     });
 
-    // Simulate Ctrl+M keydown again (stop)
+    // Simulate CmdOrCtrl+Shift+M keydown again (stop)
     await act(async () => {
       const event = new KeyboardEvent("keydown", {
         key: "m",
         ctrlKey: true,
-        metaKey: false,
+        shiftKey: true,
         altKey: false,
         bubbles: true,
       });
@@ -152,12 +152,12 @@ describe("useVoice via ChatPanel", () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
 
-    // Simulate Ctrl+M keydown (should be ignored when voice is disabled)
+    // Simulate CmdOrCtrl+Shift+M keydown (should be ignored when voice is disabled)
     await act(async () => {
       const event = new KeyboardEvent("keydown", {
         key: "m",
         ctrlKey: true,
-        metaKey: false,
+        shiftKey: true,
         altKey: false,
         bubbles: true,
       });

--- a/src/renderer/hooks/useVoice.ts
+++ b/src/renderer/hooks/useVoice.ts
@@ -8,7 +8,7 @@
 //
 // The hook owns:
 //   - The voiceRecorder instance (via useVoiceRecorder)
-//   - The desktop voice keybinds (Ctrl+M / Enter / Esc)
+//   - The desktop voice keybinds (CmdOrCtrl+Shift+M / Enter / Space / Esc)
 //   - The voiceEnabled gate (groqApiKey + MediaRecorder support)
 //   - The transcription step (recorder hands back {blob, mime, peaks})
 //
@@ -18,6 +18,8 @@
 import { useEffect, useRef, useState } from "react";
 import { useVoiceRecorder } from "../voice";
 import type { VoiceArtifact, VoicePhase } from "../voice";
+import { VOICE_TAP_HOLD_MS } from "../../shared/waveform.mjs";
+import { IS_MAC } from "../platform";
 
 export type Voice = {
   voiceEnabled: boolean;
@@ -54,9 +56,10 @@ export function useVoice(params: {
     groqApiKey,
   } = params;
 
-  // When the user presses Enter (or Ctrl+M) WHILE the desktop voice recorder
-  // is active, we want the transcribed text to land in the composer AND
-  // immediately submit, in one keystroke.
+  // When the user presses Enter (or holds the CmdOrCtrl+Shift+M shortcut into
+  // push-to-talk) WHILE the desktop voice recorder is active, we want the
+  // transcribed text to land in the composer AND immediately submit, in one
+  // keystroke.
   const submitAfterTranscribeRef = useRef(false);
   // Transcription in flight — the recorder's own phases don't include
   // "processing" (that is our business now), so we track it here for the UI.
@@ -151,33 +154,76 @@ export function useVoice(params: {
   voiceStopRef.current = voiceRecorder.stop;
   const voiceCancelRef = useRef(voiceRecorder.cancel);
   voiceCancelRef.current = voiceRecorder.cancel;
+  const voicePauseRef = useRef(voiceRecorder.pause);
+  voicePauseRef.current = voiceRecorder.pause;
+  const voiceResumeRef = useRef(voiceRecorder.resume);
+  voiceResumeRef.current = voiceRecorder.resume;
+  // Timestamp the shortcut's keydown so keyup can decide tap-vs-hold.
+  const voiceKeyDownAtRef = useRef<number | null>(null);
   const voiceRecording =
     voiceRecorder.phase === "recording" ||
     voiceRecorder.phase === "requesting" ||
     voiceRecorder.phase === "paused";
   const voiceProcessing = transcribing;
 
-  // Desktop voice keybinds (Ctrl+M / Enter / Esc)
+  // Desktop voice keybinds (CmdOrCtrl+Shift+M / Enter / Space / Esc).
+  //
+  // CmdOrCtrl+Shift+M mirrors the mic button's tap-versus-hold model:
+  //   keydown while idle → start recording immediately (never wait for the
+  //                        threshold — that would swallow the first
+  //                        quarter-second of speech) and timestamp the press.
+  //   keyup while a take → held >= VOICE_TAP_HOLD_MS → it was push-to-talk →
+  //                        stop and send (insert at the caret). Held <
+  //                        threshold → it was a tap → stay recording (toggle
+  //                        stays ON).
+  //   keydown while recording/paused → stop and send (tap toggles OFF).
+  // Enter stops+submits; Space pauses/resumes (only while the composer
+  // textarea is NOT focused, so typing a space never pauses); Esc discards.
+  // Enter/Space/Esc stopPropagation while a take is active so the composer's
+  // own handlers do not also fire.
   useEffect(() => {
     if (!voiceEnabled) return;
-    const handler = (e: KeyboardEvent) => {
-      if (e.ctrlKey && !e.metaKey && !e.altKey && (e.key === "m" || e.key === "M")) {
+
+    const isShortcut = (e: KeyboardEvent) => {
+      if (e.altKey || !e.shiftKey) return false;
+      if (e.key.toLowerCase() !== "m") return false;
+      // CmdOrCtrl = meta on macOS, ctrl elsewhere.
+      return IS_MAC ? e.metaKey && !e.ctrlKey : e.ctrlKey && !e.metaKey;
+    };
+
+    const takeActive = () => {
+      const p = voicePhaseRef.current;
+      return p === "requesting" || p === "recording" || p === "paused";
+    };
+    // The shortcut's end-a-take path: stop and insert at the caret (dictate),
+    // but do NOT auto-submit — Enter is the act of sending.
+    const stopAndSendShortcut = () => {
+      submitAfterTranscribeRef.current = false;
+      voiceStopRef.current();
+    };
+
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (isShortcut(e)) {
         e.preventDefault();
+        e.stopPropagation();
+        if (e.repeat) return;
         const phase = voicePhaseRef.current;
         if (
           phase === "recording" ||
           phase === "requesting" ||
           phase === "paused"
         ) {
-          submitAfterTranscribeRef.current = false;
-          voiceStopRef.current();
+          // keydown while a take is active → tap toggles OFF: stop and send.
+          voiceKeyDownAtRef.current = null;
+          stopAndSendShortcut();
         } else if (phase === "idle" || phase === "error") {
+          // keydown while idle → start immediately + timestamp for tap/hold.
+          voiceKeyDownAtRef.current = performance.now();
           void voiceStartRef.current();
         }
         return;
       }
-      const phase = voicePhaseRef.current;
-      if (phase === "idle" || phase === "error") return;
+      if (!takeActive()) return;
       if (
         e.key === "Enter" &&
         !e.shiftKey &&
@@ -185,11 +231,30 @@ export function useVoice(params: {
         !e.ctrlKey &&
         !e.altKey
       ) {
-        if (phase !== "recording" && phase !== "paused") return;
+        const p = voicePhaseRef.current;
+        if (p !== "recording" && p !== "paused") return;
         e.preventDefault();
         e.stopPropagation();
         submitAfterTranscribeRef.current = true;
         voiceStopRef.current();
+        return;
+      }
+      if (
+        e.key === " " &&
+        !e.shiftKey &&
+        !e.metaKey &&
+        !e.ctrlKey &&
+        !e.altKey
+      ) {
+        // Space pauses/resumes but never while the composer textarea is
+        // focused — typing a space into the message must not pause a take.
+        if (inputRef.current && document.activeElement === inputRef.current) {
+          return;
+        }
+        e.preventDefault();
+        e.stopPropagation();
+        if (voicePhaseRef.current === "recording") voicePauseRef.current();
+        else if (voicePhaseRef.current === "paused") voiceResumeRef.current();
         return;
       }
       if (e.key === "Escape") {
@@ -200,9 +265,30 @@ export function useVoice(params: {
         return;
       }
     };
-    window.addEventListener("keydown", handler, true);
-    return () => window.removeEventListener("keydown", handler, true);
-  }, [voiceEnabled]);
+
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (!isShortcut(e)) return;
+      e.preventDefault();
+      e.stopPropagation();
+      const downAt = voiceKeyDownAtRef.current;
+      voiceKeyDownAtRef.current = null;
+      if (downAt == null) return;
+      if (!takeActive()) return;
+      const held = performance.now() - downAt;
+      if (held >= VOICE_TAP_HOLD_MS) {
+        // It was push-to-talk → stop and send (insert at the caret).
+        stopAndSendShortcut();
+      }
+      // else: it was a tap → stay recording (toggle stays ON).
+    };
+
+    window.addEventListener("keydown", onKeyDown, true);
+    window.addEventListener("keyup", onKeyUp, true);
+    return () => {
+      window.removeEventListener("keydown", onKeyDown, true);
+      window.removeEventListener("keyup", onKeyUp, true);
+    };
+  }, [voiceEnabled, inputRef]);
 
   return {
     voiceEnabled,

--- a/src/shared/waveform.d.mts
+++ b/src/shared/waveform.d.mts
@@ -10,6 +10,7 @@ export const VOICE_MAX_DURATION_MS: number;
 export const VOICE_WARN_REMAINING_MS: number;
 export const VOICE_MIN_DURATION_MS: number;
 export const VOICE_CONFIRM_DISCARD_MS: number;
+export const VOICE_TAP_HOLD_MS: number;
 
 export function quantizePeak(v: number): number;
 

--- a/src/shared/waveform.mjs
+++ b/src/shared/waveform.mjs
@@ -17,6 +17,7 @@ export const VOICE_MAX_DURATION_MS = 300_000;    // 5 min hard cap
 export const VOICE_WARN_REMAINING_MS = 30_000;   // warn in the last 30 s
 export const VOICE_MIN_DURATION_MS = 400;        // shorter is a mis-tap, discarded silently
 export const VOICE_CONFIRM_DISCARD_MS = 30_000;  // above this, discard asks for confirmation
+export const VOICE_TAP_HOLD_MS = 500;            // key/button: hold >= this = push-to-talk, < this = tap
 
 /**
  * Clamp a float 0..1 to an integer 0..255.


### PR DESCRIPTION
**Base: origin/main @ `720478df`**

Moves the desktop voice shortcut off `Ctrl+M` (which is carriage return / Enter, ambiguous with the embedded terminal and on Wispr Flow's conflict list) to `CmdOrCtrl+Shift+M` with the same tap-versus-hold model as the mic button.

**Changes:**
- `src/renderer/hooks/useVoice.ts` — capture-phase keydown+keyup handler in the existing effect (no second keydown listener):
  - `CmdOrCtrl+Shift+M` (meta on Mac, ctrl elsewhere): keydown while idle → record immediately + timestamp; keyup held ≥ `VOICE_TAP_HOLD_MS` → push-to-talk → stop+insert at caret; keyup held < threshold → tap → stay recording (toggle ON); keydown while a take is active → toggle OFF → stop+insert. `event.repeat` guarded.
  - `Enter` → stop and submit (unchanged semantics).
  - `Space` → pause/resume, only when the composer textarea is NOT focused (typing a space never pauses).
  - `Esc` → discard (unchanged).
  - `Enter`/`Space`/`Esc` `stopPropagation()` while a take is active.
- `src/shared/waveform.mjs` + `.d.mts` — new `VOICE_TAP_HOLD_MS = 500` (single source; button and key share it).
- `src/renderer/ComposerParts.tsx` — mic button `title`/`aria-label` now name the binding (`VOICE_SHORTCUT_LABEL` export).
- `src/renderer/InputArea.tsx` — transient status hint names the new binding (`recording · ⏎ send · ⇧⌘M stop · space pause · esc cancel`).
- `src/renderer/hooks/useVoice.test.tsx` — smoke tests updated to the new binding.
- `AGENTS.md` — voice row added to the keybindings table + status-string copy; `docs/settings-redesign/mockup.html` copy updated.
- `rg -i "ctrl\+m" src/ docs/ AGENTS.md` returns nothing.

**Interpretation note:** the shortcut's "stop and send" ends the take and inserts the transcript at the caret (dictate), matching the mic button's release = "dictate"; `Enter` is the act of actually submitting. The old no-shift binding's stop never auto-submitted either, so this is behavior-preserving on that axis.

**Out of scope (deliberately, per BET-838):** `Ctrl+O` (show thinking) keeps its binding.

**Verification results:**
- PR branch (`multica/BET-838-shortcut-tap-hold` @ `f82c740`):
  - typecheck: exit 0, no errors
  - test: exit 0, 667 pass / 0 fail / 0 skip
- Base (`main` @ `720478df`):
  - typecheck: exit 0
  - test: 667 pass (identical gate; the renderer+server suites both green on the branch)
- Conclusion: 0 new failures.

Files changed: 8.
