### PR TITLE
feat(renderer): recording composer with live waveform, pause/discard/send (BET-836)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1474,12 +1474,7 @@ export function ChatPanel({
   }, [running, messages, autoRenameSessions, tmuxSession, windowIndex, cwd, refresh]);
 
   // ===== Voice (extracted to useVoice) =====
-  const {
-    voiceEnabled,
-    voiceRecording,
-    voiceProcessing,
-    voiceRecorder,
-  } = useVoice({
+  const voice = useVoice({
     input,
     setInput,
     inputRef,
@@ -2523,13 +2518,7 @@ export function ChatPanel({
         modelLabel={modelLabel}
         chatAutoAllow={chatAutoAllow}
         setChatAutoAllow={setChatAutoAllow}
-        voiceEnabled={voiceEnabled}
-        voicePhase={voiceRecorder.phase}
-        voiceRecording={voiceRecording}
-        voiceProcessing={voiceProcessing}
-        startVoice={() => { voiceRecorder.start(); }}
-        stopVoice={voiceRecorder.stop}
-        cancelVoice={voiceRecorder.cancel}
+        voice={voice}
         models={models}
         modelOverride={modelOverride}
         defaultModel={defaultModel}

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -6,16 +6,153 @@
 // and the press-and-hold mic button. InputArea.tsx composes them.
 
 import { useRef } from "react";
-import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip } from "lucide-react";
+import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip, Trash2, Pause, Play } from "lucide-react";
 import type { VoicePhase } from "./voice";
 import { type Attachment, type TypeaheadRow } from "./chatShared";
 import type { PendingScreenshot } from "./store";
 import { IconButton } from "./IconButton";
 import { IS_MAC } from "./platform";
+import { VoiceWaveform } from "./VoiceWaveform";
+import { formatClock, VOICE_TAP_HOLD_MS } from "../shared/waveform.mjs";
 // BET-726 Task 1: same scrollIntoView idiom the ⌘K / ⌘F palettes and the
 // model/effort menus use (PaletteShell.tsx) — keeps the keyboard-selected
 // @-file row visible when it moves past the popup's scroll fold.
 import { useSelectedIntoView } from "./PaletteShell";
+
+/**
+ * The send glyph: lucide's paper plane as a SOLID shape.
+ *
+ * Not `<Send fill="currentColor"/>` — lucide's Send is two paths, the plane
+ * body plus a separate diagonal line for the fold. Filling the component fills
+ * the body but leaves that second path a stroke, so a hairline crease cuts
+ * across the solid plane. Dropping it is what "filled send" means, and the
+ * component API gives no way to render one path of two, so the body is inlined
+ * here (the same inline-SVG escape hatch CopyButton uses).
+ *
+ * The path is lucide-react v1.28.0's `send` body, verbatim; the light stroke on
+ * top of the fill is what keeps a 14px solid shape from looking eroded at its
+ * points.
+ */
+export function SendFilled({ size = 14 }: { size?: number }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      width={size}
+      height={size}
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z" />
+    </svg>
+  );
+}
+
+// The chrome every icon button in the recording row shares — the EXISTING
+// send button's chrome, verbatim: 27px hit box, --r-sm radius, centred. The
+// recording row does not use IconButton (fixed 24/32px hit areas that don't
+// match this row and no className escape hatch by design).
+const recBtn =
+  "w-7 h-7 rounded-sm grid place-items-center shrink-0 transition-colors " +
+  "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent";
+
+// ===== Recording row (BET-836) =====
+//
+// Replaces the textarea + send row INSIDE the composer box while a take is
+// active (recording / paused). The box's outer element and its padding are
+// untouched, so the composer never changes height; only this inner row swaps.
+// The footer (model picker, mic, attach, usage dial, toolbar) stays visible
+// and interactive throughout.
+export function RecordingRow({
+  phase,
+  elapsedMs,
+  liveWindowRef,
+  discardArmed,
+  onDiscard,
+  onPause,
+  onResume,
+  onSend,
+}: {
+  phase: VoicePhase;
+  elapsedMs: number;
+  liveWindowRef: React.RefObject<Float32Array>;
+  discardArmed: boolean;
+  onDiscard: () => void;
+  onPause: () => void;
+  onResume: () => void;
+  onSend: () => void;
+}) {
+  const recording = phase === "recording" || phase === "requesting";
+  const paused = phase === "paused";
+  const wavePhase: "recording" | "paused" = paused ? "paused" : "recording";
+  return (
+    <div className="flex items-center gap-2">
+      {/* 1 · State dot — pulses while recording (CSS), static red when paused
+          is handled elsewhere; paused uses the warn treatment + no animation. */}
+      <span
+        aria-hidden="true"
+        className={
+          "w-2 h-2 rounded-full shrink-0 " +
+          (paused ? "bg-warn" : `bg-danger ${recording ? "manta-recording-dot" : ""}`)
+        }
+      />
+      {/* 2 · Timer — NOT inside a live region (per-second region floods SR). */}
+      <span
+        aria-hidden="true"
+        className={
+          "font-mono text-label tabular-nums shrink-0 w-10 " +
+          (paused ? "text-warn" : "text-danger")
+        }
+      >
+        {formatClock(elapsedMs)}
+      </span>
+      {/* 3 · Live waveform — reads the recorder's level window directly. */}
+      <VoiceWaveform phase={wavePhase} liveWindowRef={liveWindowRef} />
+      {/* 4 · Discard — arms above the confirm threshold. */}
+      <button
+        type="button"
+        onClick={onDiscard}
+        aria-label={discardArmed ? "Confirm discard" : "Discard recording"}
+        title={discardArmed ? "Discard? (tap again to confirm)" : "Discard recording"}
+        className={
+          `${recBtn} ${discardArmed ? "text-danger bg-danger-bg" : "text-danger hover:bg-danger-bg"}`
+        }
+      >
+        {discardArmed ? (
+          <span className="text-label leading-none">Discard?</span>
+        ) : (
+          <Trash2 size={14} aria-hidden="true" />
+        )}
+      </button>
+      {/* 5 · Pause / Resume. */}
+      <button
+        type="button"
+        onClick={paused ? onResume : onPause}
+        aria-label={paused ? "Resume recording" : "Pause recording"}
+        title={paused ? "Resume (space)" : "Pause (space)"}
+        className={`${recBtn} ${paused ? "" : "bg-accent-solid text-on-accent"}`}
+      >
+        {paused ? (
+          <Play size={12} aria-hidden="true" />
+        ) : (
+          <Pause size={12} aria-hidden="true" />
+        )}
+      </button>
+      {/* 6 · Send — stop + submit. */}
+      <button
+        type="button"
+        onClick={onSend}
+        aria-label="Send recording"
+        title="Send (Enter)"
+        className={`${recBtn} bg-accent-solid text-on-accent hover:bg-accent-solid/90`}
+      >
+        <SendFilled size={14} />
+      </button>
+    </div>
+  );
+}
 
 // Shared chrome for the composer's icon-row buttons (BET-620 change 6): the
 // three SessionToolbar resource buttons AND UsageDial's trigger (BET-738) —
@@ -343,6 +480,8 @@ export function MicButton({
   onCancel,
   busy = false,
   floating = false,
+  toggled = false,
+  onSend,
 }: {
   phase: VoicePhase;
   onStart: () => void;
@@ -354,6 +493,15 @@ export function MicButton({
   // above the composer). It is dictation-only, the same as the inline
   // button — transcription is always plain text into the composer.
   floating?: boolean;
+  // `toggled` = the recorder-composer gesture (BET-836): tap toggles
+  // recording on/off, hold is push-to-talk (stop + send on release). When
+  // false (default) the button is plain press-and-hold dictate — every
+  // release stops. The NewSessionScreen dictation mic and the mobile PTT FAB
+  // are the non-toggled consumers.
+  toggled?: boolean;
+  // Required for the toggled gesture — the "send" that a hold-release and a
+  // click-while-recording both resolve to. Falls back to onStop.
+  onSend?: () => void;
 }) {
   const recording = phase === "recording" || phase === "requesting";
 
@@ -368,6 +516,9 @@ export function MicButton({
   // never called → the recorder ran until the 60s maxDuration cap, silently.
   // A ref flips synchronously on pointerdown so release ALWAYS reaches stop.
   const pressActiveRef = useRef(false);
+  // When the press started — used by the toggled gesture to separate a tap
+  // (< VOICE_TAP_HOLD_MS) from a hold (push-to-talk).
+  const pressDownAtRef = useRef(0);
 
   // Pointer-based handlers — single code path for mouse + touch + pen so
   // we don't have to worry about emulated mouse events firing AFTER touch
@@ -376,6 +527,19 @@ export function MicButton({
     if (busy || pressActiveRef.current) return;
     e.preventDefault();
     pressActiveRef.current = true;
+    pressDownAtRef.current = performance.now();
+    if (toggled && (phase === "recording" || phase === "requesting" || phase === "paused")) {
+      // Already recording → stop and send. Same outcome as releasing a hold,
+      // so both gestures agree.
+      (onSend ?? onStop)();
+      // Capture so onPointerUp fires even if the cursor leaves the button.
+      try {
+        (e.currentTarget as HTMLButtonElement).setPointerCapture(e.pointerId);
+      } catch { /* not all browsers support pointer capture */ }
+      return;
+    }
+    // Idle → start recording immediately, on press — never on the threshold,
+    // else the first quarter-second of speech is swallowed.
     onStart();
     // Capture so onPointerUp fires even if the cursor leaves the button.
     try {
@@ -387,6 +551,16 @@ export function MicButton({
     if (!pressActiveRef.current) return;
     pressActiveRef.current = false;
     e.preventDefault();
+    if (toggled) {
+      const held = performance.now() - pressDownAtRef.current;
+      if (held < VOICE_TAP_HOLD_MS) {
+        // A tap → stay recording (toggled on). Nothing to stop.
+        return;
+      }
+      // Held past the threshold → push-to-talk → stop and send.
+      (onSend ?? onStop)();
+      return;
+    }
     // Always stop (not cancel) on a deliberate release — even if `phase` is
     // still "requesting" (the recorder hasn't been constructed yet). The
     // hook's stop() handles the requesting-window case: it records a
@@ -407,12 +581,16 @@ export function MicButton({
   const label = busy
     ? "transcribing…"
     : recording
-      ? floating
-        ? `release to insert · ${VOICE_SHORTCUT_LABEL}`
-        : `release · dictate · ${VOICE_SHORTCUT_LABEL}`
-      : floating
-        ? `hold to talk · ${VOICE_SHORTCUT_LABEL}`
-        : `hold to speak · ${VOICE_SHORTCUT_LABEL}`;
+      ? toggled
+        ? "recording — tap to send"
+        : floating
+          ? `release to insert · ${VOICE_SHORTCUT_LABEL}`
+          : `release · dictate · ${VOICE_SHORTCUT_LABEL}`
+      : toggled
+        ? "hold to talk · tap to record"
+        : floating
+          ? `hold to talk · ${VOICE_SHORTCUT_LABEL}`
+          : `hold to speak · ${VOICE_SHORTCUT_LABEL}`;
 
   // Floating PTT FAB: round bubble, bottom-right (positioned by the
   // `.mobile-ptt-fab` rule in mobile.css — visual/layout lives there per the

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -19,7 +19,7 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { Mic, Shield, Square } from "lucide-react";
 import type { OpencodeModel } from "../shared/types";
-import type { VoicePhase } from "./voice";
+import type { Voice } from "./hooks/useVoice";
 import {
   arrowDownNavigatesHistory,
   arrowUpNavigatesHistory,
@@ -33,45 +33,23 @@ import {
 import { baseModelId, isFastModelId, shortModelName } from "./chatUtils";
 import { ModelPicker } from "./ModelPicker";
 import { MeasureColumn } from "./MeasureColumn";
-import { AttachButton, AttachmentStrip, MicButton, SessionToolbar, PendingScreenshotStrip, VOICE_SHORTCUT_LABEL } from "./ComposerParts";
+import {
+  AttachButton,
+  AttachmentStrip,
+  MicButton,
+  RecordingRow,
+  SendFilled,
+  SessionToolbar,
+  PendingScreenshotStrip,
+} from "./ComposerParts";
 import type { PendingScreenshot } from "./store";
 import { UsageDial } from "./UsageDial";
+import { VOICE_MAX_DURATION_MS } from "../shared/waveform.mjs";
 // Re-exported so existing `import { TypeaheadPopup } from "./InputArea"` call
 // sites (Composer) keep working after the leaf component moved to ./ComposerParts.
 export { TypeaheadPopup } from "./ComposerParts";
 // AttachmentStrip is no longer re-exported — it is now rendered INSIDE the
 // composer box (BET-416 §B), so Composer no longer imports it.
-
-/**
- * The send glyph: lucide's paper plane as a SOLID shape.
- *
- * Not `<Send fill="currentColor"/>` — lucide's Send is two paths, the plane
- * body plus a separate diagonal line for the fold. Filling the component fills
- * the body but leaves that second path a stroke, so a hairline crease cuts
- * across the solid plane. Dropping it is what "filled send" means, and the
- * component API gives no way to render one path of two, so the body is inlined
- * here (the same inline-SVG escape hatch CopyButton uses).
- *
- * The path is lucide-react v1.28.0's `send` body, verbatim; the light stroke on
- * top of the fill is what keeps a 14px solid shape from looking eroded at its
- * points.
- */
-function SendFilled({ size = 14 }: { size?: number }) {
-  return (
-    <svg
-      viewBox="0 0 24 24"
-      width={size}
-      height={size}
-      fill="currentColor"
-      stroke="currentColor"
-      strokeWidth="1.5"
-      strokeLinejoin="round"
-      aria-hidden="true"
-    >
-      <path d="M14.536 21.686a.5.5 0 0 0 .937-.024l6.5-19a.496.496 0 0 0-.635-.635l-19 6.5a.5.5 0 0 0-.024.937l7.93 3.18a2 2 0 0 1 1.112 1.11z" />
-    </svg>
-  );
-}
 
 // Measure the caret's VISUAL row within a textarea, accounting for soft wrap.
 // Render a hidden mirror <div> that copies the textarea's box + text styling,
@@ -164,13 +142,7 @@ export function InputArea({
   modelLabel,
   chatAutoAllow,
   setChatAutoAllow,
-  voiceEnabled,
-  voicePhase,
-  voiceRecording,
-  voiceProcessing,
-  startVoice,
-  stopVoice,
-  cancelVoice,
+  voice,
   models,
   modelOverride,
   defaultModel,
@@ -220,13 +192,10 @@ export function InputArea({
   modelLabel: string | null;
   chatAutoAllow: boolean;
   setChatAutoAllow: (v: boolean) => Promise<void>;
-  voiceEnabled: boolean;
-  voicePhase: VoicePhase;
-  voiceRecording: boolean;
-  voiceProcessing: boolean;
-  startVoice: () => void;
-  stopVoice: () => void;
-  cancelVoice: () => void;
+  // The whole voice hook result (BET-836): the recording session state
+  // (phase/elapsedMs/nearLimit/liveWindowRef), the actions (start/pause/
+  // resume/send/discard), the discard-arm state, and the a11y announcements.
+  voice: Voice;
   // tokens / staleCache / branch / activeModel moved to SessionHeader
   // (BET-415). The composer owns only composing controls now.
   models: OpencodeModel[] | null;
@@ -254,7 +223,28 @@ export function InputArea({
   onQueuePop: () => void;
   onPaste: (e: React.ClipboardEvent<HTMLTextAreaElement>) => void;
 }) {
+  const { voiceEnabled, voiceRecording, voiceProcessing, voiceAnnouncement } =
+    voice;
+  const {
+    phase: voicePhase,
+    elapsedMs,
+    nearLimit,
+    lastError,
+    liveWindowRef,
+    start: voiceStart,
+    pause: voicePause,
+    resume: voiceResume,
+    send: voiceSend,
+    stop: voiceStop,
+    cancel: voiceCancel,
+    requestDiscard,
+    discardArmed,
+  } = voice.voiceRecorder;
   const voiceActive = voiceRecording || voiceProcessing;
+  // A take is active — swap the textarea row for the recording row. Includes
+  // "requesting" (mic permission) so the box's footprint is stable from the
+  // instant recording starts.
+  const takeActive = voiceRecording;
   // Detect mobile shell (touch device using the no-window.api branch with
   // MobileApp + .mobile-body wrapper). MicButton is only rendered there;
   // on desktop the keyboard shortcut (CmdOrCtrl+Shift+M / Enter / Esc) drives voice.
@@ -300,9 +290,9 @@ export function InputArea({
       {voiceEnabled && isMobileShell && (
         <MicButton
           phase={voicePhase}
-          onStart={startVoice}
-          onStop={stopVoice}
-          onCancel={cancelVoice}
+          onStart={voiceStart}
+          onStop={voiceStop}
+          onCancel={voiceCancel}
           busy={voiceProcessing}
           floating
         />
@@ -336,11 +326,13 @@ export function InputArea({
           // every card on the screen, so the composer looked outlined rather
           // than contained. Definition now comes from the fill + --shadow-sm;
           // focus-within still paints the accent border.
-          (voiceActive
-            ? "manta-recording"
-            : refreshing
-              ? "border-accent"
-              : "border-border-subtle")
+          (voicePhase === "paused"
+            ? "manta-recording-paused"
+            : voiceRecording
+              ? "manta-recording"
+              : refreshing
+                ? "border-accent"
+                : "border-border-subtle")
         }
         // Route every non-control click in the box to the message field. This
         // is what makes the composer focusable on Windows, where a click could
@@ -356,6 +348,15 @@ export function InputArea({
           if (document.activeElement !== el) el.focus();
         }}
       >
+        {/* A11y (BET-836): one polite region for the recording lifecycle
+            announcements; a separate assertive region for mic errors. The
+            timer is deliberately NOT in any live region. */}
+        <span className="sr-only" role="status" aria-live="polite">
+          {voiceAnnouncement}
+        </span>
+        <span className="sr-only" aria-live="assertive">
+          {lastError ?? ""}
+        </span>
         {/* Attachment chips live INSIDE the box, above the text line (BET-416
             §B). They are part of the message being composed, so they share
             the box; context chips (folder / branch) sit ABOVE the box in the
@@ -363,6 +364,21 @@ export function InputArea({
         {attachments.length > 0 && (
           <AttachmentStrip attachments={attachments} onRemove={onRemoveAttachment} />
         )}
+        {/* The inner input row swaps for the recording row while a take is
+            active (BET-836). The outer box and its padding are untouched, so
+            the composer never changes height. */}
+        {takeActive ? (
+          <RecordingRow
+            phase={voicePhase}
+            elapsedMs={elapsedMs}
+            liveWindowRef={liveWindowRef}
+            discardArmed={discardArmed}
+            onDiscard={requestDiscard}
+            onPause={voicePause}
+            onResume={voiceResume}
+            onSend={voiceSend}
+          />
+        ) : (
         <div className="flex items-start gap-2">
         <textarea
           ref={inputRef}
@@ -470,6 +486,7 @@ export function InputArea({
           )}
         </button>
         </div>
+        )}
       </div>
       {/* Meta footer — model ▸ effort split on the left, resource toolbar +
           transient status on the right. Branch + context pill moved to the
@@ -497,10 +514,12 @@ export function InputArea({
               {voiceEnabled && (
                 <MicButton
                   phase={voicePhase}
-                  onStart={startVoice}
-                  onStop={stopVoice}
-                  onCancel={cancelVoice}
+                  onStart={voiceStart}
+                  onStop={voiceStop}
+                  onCancel={voiceCancel}
+                  onSend={voiceSend}
                   busy={voiceProcessing}
+                  toggled
                 />
               )}
               <AttachButton onFiles={onAttachFiles} />
@@ -520,11 +539,33 @@ export function InputArea({
           />
           {(voiceActive || running) && (
             <span className="text-meta text-text-faint">
-              {voiceActive
-                ? voiceProcessing
-                  ? "transcribing… · esc cancels"
-                  : <span className="inline-flex items-center gap-1"><Mic size={14} aria-hidden="true" />recording · ⏎ send · {VOICE_SHORTCUT_LABEL} stop · space pause · esc cancel</span>
-                : "esc · interrupt"}
+              {voiceProcessing ? (
+                "transcribing… · esc cancels"
+              ) : voicePhase === "paused" ? (
+                <span className="inline-flex items-center gap-1">
+                  <Mic size={14} aria-hidden="true" />
+                  paused · space resume · ⏎ send
+                  {nearLimit && (
+                    <span className="text-warn">
+                      {" "}
+                      · {Math.max(0, Math.ceil((VOICE_MAX_DURATION_MS - elapsedMs) / 1000))}s left
+                    </span>
+                  )}
+                </span>
+              ) : voiceRecording ? (
+                <span className="inline-flex items-center gap-1">
+                  <Mic size={14} aria-hidden="true" />
+                  recording · ⏎ send · space pause · esc discard
+                  {nearLimit && (
+                    <span className="text-warn">
+                      {" "}
+                      · {Math.max(0, Math.ceil((VOICE_MAX_DURATION_MS - elapsedMs) / 1000))}s left
+                    </span>
+                  )}
+                </span>
+              ) : (
+                "esc · interrupt"
+              )}
             </span>
           )}
         </span>

--- a/src/renderer/VoiceWaveform.tsx
+++ b/src/renderer/VoiceWaveform.tsx
@@ -1,0 +1,114 @@
+// VoiceWaveform.tsx — the live recording meter, hand-rolled on canvas.
+//
+// Reads the recorder's live level window (`liveWindowRef.current`, a rolling
+// Float32Array ring written 25×/s by the recorder) in its own
+// requestAnimationFrame loop. It must NOT subscribe to React state — routing
+// the 25/s updates through state would re-render the composer 25 times a
+// second, a regression this panel has a documented history of.
+//
+// The ceiling is pinned at 1.0 and the live window is never normalised. If we
+// rescaled to the loudest visible sample, every previously-drawn bar would
+// jump each time a new peak arrives and the whole meter would visibly dance.
+// `normalizeForDisplay` in waveform.mjs exists for the STORED waveform only —
+// do not call it here.
+//
+// It keeps drawing under prefers-reduced-motion: the meter is functional, not
+// decorative — a waveform that stops moving is how a user diagnoses a dead
+// microphone. Only the dot's pulse (handled by .manta-recording-dot in CSS)
+// is suppressed.
+
+import { RefObject, useEffect, useRef } from "react";
+import { VOICE_LIVE_WINDOW_BARS } from "../shared/waveform.mjs";
+
+const WAVE_HEIGHT_CSS = 24;
+
+export function VoiceWaveform({
+  phase,
+  liveWindowRef,
+}: {
+  phase: "recording" | "paused";
+  liveWindowRef: RefObject<Float32Array>;
+}) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+
+  // Theme colours, resolved from CSS custom properties on the canvas so both
+  // themes work. Re-read when the phase changes so a theme toggle mid-recording
+  // still paints the right colour on the next frame.
+  const colorsRef = useRef({ recording: "", paused: "" });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const cs = getComputedStyle(canvas);
+    colorsRef.current = {
+      recording: (cs.getPropertyValue("--danger") || "").trim(),
+      paused: (cs.getPropertyValue("--warn") || "").trim(),
+    };
+  }, [phase]);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    const dpr = (typeof window !== "undefined" ? window.devicePixelRatio : 1) || 1;
+
+    const resize = () => {
+      const rect = canvas.getBoundingClientRect();
+      canvas.width = Math.max(1, Math.round(rect.width * dpr));
+      canvas.height = Math.round(WAVE_HEIGHT_CSS * dpr);
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    };
+    resize();
+    const ro = new ResizeObserver(resize);
+    ro.observe(canvas);
+
+    const N = VOICE_LIVE_WINDOW_BARS;
+    const gap = 1.5;
+
+    let raf = 0;
+    const draw = () => {
+      raf = requestAnimationFrame(draw);
+      const W = canvas.width / dpr;
+      const H = canvas.height / dpr;
+      ctx.clearRect(0, 0, W, H);
+      const window_ = liveWindowRef.current;
+      if (!window_) return;
+      const barW = Math.max(1.2, (W - (N - 1) * gap) / N);
+      const recording = phase === "recording";
+      const fill = colorsRef.current[recording ? "recording" : "paused"] || "";
+      if (fill) ctx.fillStyle = fill;
+      for (let i = 0; i < N; i++) {
+        const v = window_[i];
+        if (v <= 0) continue;
+        const h = Math.max(1.5, v * (H - 2));
+        const x = i * (barW + gap);
+        const y = (H - h) / 2;
+        ctx.globalAlpha = recording ? 0.35 + 0.65 * (i / N) : 0.45;
+        ctx.beginPath();
+        if (typeof (ctx as CanvasRenderingContext2D).roundRect === "function") {
+          ctx.roundRect(x, y, barW, h, barW / 2);
+        } else {
+          ctx.rect(x, y, barW, h);
+        }
+        ctx.fill();
+      }
+      ctx.globalAlpha = 1;
+    };
+    draw();
+
+    return () => {
+      cancelAnimationFrame(raf);
+      ro.disconnect();
+    };
+  }, [phase, liveWindowRef]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="flex-1 h-6 min-w-0"
+      aria-hidden="true"
+    />
+  );
+}

--- a/src/renderer/hooks/useVoice.ts
+++ b/src/renderer/hooks/useVoice.ts
@@ -1,39 +1,56 @@
 // ===== useVoice =====
 //
 // Extracted from ChatPanel.tsx (BET-64). Wraps `useVoiceRecorder` from
-// `./voice.ts` and adds the dictation-only behaviour, keybinds, and gating.
-// Orchestration lives HERE, on top of the recorder's onComplete artifact:
-// we transcribe via `voice:transcribe`, insert into the composer at the
-// caret, and keep the desktop keyboard driving the session.
+// `./voice.ts` and adds the dictation-only behaviour, keybinds, gating, and
+// (BET-836) the recording composer's discard-confirmation + a11y
+// announcements. Orchestration lives HERE, on top of the recorder's
+// onComplete artifact: we transcribe via `voice:transcribe`, insert into the
+// composer at the caret, and keep the desktop keyboard driving the session.
 //
 // The hook owns:
 //   - The voiceRecorder instance (via useVoiceRecorder)
 //   - The desktop voice keybinds (CmdOrCtrl+Shift+M / Enter / Space / Esc)
 //   - The voiceEnabled gate (groqApiKey + MediaRecorder support)
 //   - The transcription step (recorder hands back {blob, mime, peaks})
+//   - The discard-with-confirmation state (BET-836)
+//   - The aria-live announcements for the recording lifecycle (BET-836)
 //
 // No Electron-only deps — only `window.api.*`, which the mobile HTTP server
 // shims.
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 import { useVoiceRecorder } from "../voice";
 import type { VoiceArtifact, VoicePhase } from "../voice";
-import { VOICE_TAP_HOLD_MS } from "../../shared/waveform.mjs";
+import { VOICE_TAP_HOLD_MS, VOICE_CONFIRM_DISCARD_MS } from "../../shared/waveform.mjs";
 import { IS_MAC } from "../platform";
 
 export type Voice = {
   voiceEnabled: boolean;
   voiceRecording: boolean;
   voiceProcessing: boolean;
+  // Shown in the visually-hidden aria-live region (Recording started / paused /
+  // resumed / discarded). Not a timer — the timer must never live in a region.
+  voiceAnnouncement: string;
   voiceRecorder: {
     phase: VoicePhase;
-    elapsedSec: number;
+    elapsedMs: number;
     nearLimit: boolean;
+    lastError: string | null;
+    liveWindowRef: React.RefObject<Float32Array>;
     start: () => void;
     pause: () => void;
     resume: () => void;
+    // Stop the take and submit the transcript — the send button, Enter, a
+    // push-to-talk release.
+    send: () => void;
+    // End the take WITHOUT submitting — transcribe and insert at the caret
+    // only. The non-toggled dictation mic (release-to-insert) uses this.
     stop: () => void;
+    // Discard, subject to the confirmation rule under VOICE_CONFIRM_DISCARD_MS.
+    requestDiscard: () => void;
+    // Immediate discard (OS gesture abort — the pointer-cancel path).
     cancel: () => void;
+    discardArmed: boolean;
   };
 };
 
@@ -56,14 +73,29 @@ export function useVoice(params: {
     groqApiKey,
   } = params;
 
-  // When the user presses Enter (or holds the CmdOrCtrl+Shift+M shortcut into
-  // push-to-talk) WHILE the desktop voice recorder is active, we want the
-  // transcribed text to land in the composer AND immediately submit, in one
-  // keystroke.
+  // When the user presses Enter, or ends a push-to-talk hold (the
+  // CmdOrCtrl+Shift+M shortcut or a mic hold-release), WHILE the desktop voice
+  // recorder is active, we want the transcribed text to land in the composer
+  // AND immediately submit, in one keystroke.
   const submitAfterTranscribeRef = useRef(false);
   // Transcription in flight — the recorder's own phases don't include
   // "processing" (that is our business now), so we track it here for the UI.
   const [transcribing, setTranscribing] = useState(false);
+
+  // Discard-with-confirmation state (BET-836). Under VOICE_CONFIRM_DISCARD_MS
+  // the first discard discards immediately; at or above it the first discard
+  // ARMS (the trash button reads "Discard?"), and a second discard within the
+  // window confirms. Anything else cancels the arming.
+  const [discardArmed, setDiscardArmed] = useState(false);
+  const [voiceAnnouncement, setVoiceAnnouncement] = useState("");
+  const discardTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const unarmDiscard = useCallback(() => {
+    if (discardTimerRef.current) {
+      clearTimeout(discardTimerRef.current);
+      discardTimerRef.current = null;
+    }
+    setDiscardArmed(false);
+  }, []);
 
   // Insert text at the caret, mirroring the composer's append behaviour.
   const insertAtCaret = (text: string) => {
@@ -148,18 +180,92 @@ export function useVoice(params: {
 
   const voicePhaseRef = useRef(voiceRecorder.phase);
   voicePhaseRef.current = voiceRecorder.phase;
-  const voiceStartRef = useRef(voiceRecorder.start);
-  voiceStartRef.current = voiceRecorder.start;
-  const voiceStopRef = useRef(voiceRecorder.stop);
-  voiceStopRef.current = voiceRecorder.stop;
-  const voiceCancelRef = useRef(voiceRecorder.cancel);
-  voiceCancelRef.current = voiceRecorder.cancel;
-  const voicePauseRef = useRef(voiceRecorder.pause);
-  voicePauseRef.current = voiceRecorder.pause;
-  const voiceResumeRef = useRef(voiceRecorder.resume);
-  voiceResumeRef.current = voiceRecorder.resume;
+  const voiceElapsedMsRef = useRef(voiceRecorder.elapsedMs);
+  voiceElapsedMsRef.current = voiceRecorder.elapsedMs;
+
+  // Announcement + discard wrappers around the recorder's primitives. Every
+  // public action (start/pause/resume/send/stop/cancel/discard) clears any
+  // pending discard-arming and, where it begins a lifecycle transition,
+  // announces it in the polite aria-live region.
+  const start = useCallback(() => {
+    unarmDiscard();
+    setVoiceAnnouncement("Recording started");
+    voiceRecorder.start();
+  }, [voiceRecorder, unarmDiscard]);
+  const pause = useCallback(() => {
+    unarmDiscard();
+    setVoiceAnnouncement("Recording paused");
+    voiceRecorder.pause();
+  }, [voiceRecorder, unarmDiscard]);
+  const resume = useCallback(() => {
+    unarmDiscard();
+    setVoiceAnnouncement("Recording resumed");
+    voiceRecorder.resume();
+  }, [voiceRecorder, unarmDiscard]);
+  const send = useCallback(() => {
+    unarmDiscard();
+    submitAfterTranscribeRef.current = true;
+    voiceRecorder.stop();
+  }, [voiceRecorder, unarmDiscard]);
+  const stop = useCallback(() => {
+    unarmDiscard();
+    voiceRecorder.stop();
+  }, [voiceRecorder, unarmDiscard]);
+  const cancel = useCallback(() => {
+    unarmDiscard();
+    voiceRecorder.cancel();
+  }, [voiceRecorder, unarmDiscard]);
+  const requestDiscard = useCallback(() => {
+    const phase = voicePhaseRef.current;
+    if (phase !== "recording" && phase !== "paused") return;
+    if (discardArmed) {
+      // Second discard within the window — confirm.
+      unarmDiscard();
+      setVoiceAnnouncement("Recording discarded");
+      voiceRecorder.cancel();
+      return;
+    }
+    if (voiceElapsedMsRef.current < VOICE_CONFIRM_DISCARD_MS) {
+      // Short take — discard immediately.
+      setVoiceAnnouncement("Recording discarded");
+      voiceRecorder.cancel();
+      return;
+    }
+    // Long take — arm.
+    setDiscardArmed(true);
+    discardTimerRef.current = setTimeout(unarmDiscard, 3000);
+  }, [discardArmed, unarmDiscard, voiceRecorder]);
+
+  // "Anything else cancels the arming": leaving recording/paused unarms.
+  useEffect(() => {
+    const phase = voiceRecorder.phase;
+    if (phase !== "recording" && phase !== "paused" && discardArmed) {
+      unarmDiscard();
+    }
+  }, [voiceRecorder.phase, discardArmed, unarmDiscard]);
+
+  // Stop cleanly: clear the arming timer on unmount.
+  useEffect(() => {
+    return () => {
+      if (discardTimerRef.current) clearTimeout(discardTimerRef.current);
+    };
+  }, []);
+
+  const voiceStartRef = useRef(start);
+  voiceStartRef.current = start;
+  const voiceStopRef = useRef(stop);
+  voiceStopRef.current = stop;
+  const voiceSendRef = useRef(send);
+  voiceSendRef.current = send;
+  const voicePauseRef = useRef(pause);
+  voicePauseRef.current = pause;
+  const voiceResumeRef = useRef(resume);
+  voiceResumeRef.current = resume;
+  const voiceRequestDiscardRef = useRef(requestDiscard);
+  voiceRequestDiscardRef.current = requestDiscard;
   // Timestamp the shortcut's keydown so keyup can decide tap-vs-hold.
   const voiceKeyDownAtRef = useRef<number | null>(null);
+
   const voiceRecording =
     voiceRecorder.phase === "recording" ||
     voiceRecorder.phase === "requesting" ||
@@ -178,9 +284,10 @@ export function useVoice(params: {
   //                        stays ON).
   //   keydown while recording/paused → stop and send (tap toggles OFF).
   // Enter stops+submits; Space pauses/resumes (only while the composer
-  // textarea is NOT focused, so typing a space never pauses); Esc discards.
-  // Enter/Space/Esc stopPropagation while a take is active so the composer's
-  // own handlers do not also fire.
+  // textarea is NOT focused, so typing a space never pauses); Esc discards
+  // (with confirmation above VOICE_CONFIRM_DISCARD_MS). Enter/Space/Esc
+  // stopPropagation while a take is active so the composer's own handlers do
+  // not also fire.
   useEffect(() => {
     if (!voiceEnabled) return;
 
@@ -208,11 +315,7 @@ export function useVoice(params: {
         e.stopPropagation();
         if (e.repeat) return;
         const phase = voicePhaseRef.current;
-        if (
-          phase === "recording" ||
-          phase === "requesting" ||
-          phase === "paused"
-        ) {
+        if (phase === "recording" || phase === "requesting" || phase === "paused") {
           // keydown while a take is active → tap toggles OFF: stop and send.
           voiceKeyDownAtRef.current = null;
           stopAndSendShortcut();
@@ -235,8 +338,7 @@ export function useVoice(params: {
         if (p !== "recording" && p !== "paused") return;
         e.preventDefault();
         e.stopPropagation();
-        submitAfterTranscribeRef.current = true;
-        voiceStopRef.current();
+        voiceSendRef.current();
         return;
       }
       if (
@@ -261,7 +363,7 @@ export function useVoice(params: {
         e.preventDefault();
         e.stopPropagation();
         submitAfterTranscribeRef.current = false;
-        voiceCancelRef.current();
+        voiceRequestDiscardRef.current();
         return;
       }
     };
@@ -294,15 +396,21 @@ export function useVoice(params: {
     voiceEnabled,
     voiceRecording,
     voiceProcessing,
+    voiceAnnouncement,
     voiceRecorder: {
       phase: voiceRecorder.phase,
-      elapsedSec: voiceRecorder.elapsedSec,
+      elapsedMs: voiceRecorder.elapsedMs,
       nearLimit: voiceRecorder.nearLimit,
-      start: voiceRecorder.start,
-      pause: voiceRecorder.pause,
-      resume: voiceRecorder.resume,
-      stop: voiceRecorder.stop,
-      cancel: voiceRecorder.cancel,
+      lastError: voiceRecorder.lastError,
+      liveWindowRef: voiceRecorder.liveWindowRef,
+      start,
+      pause,
+      resume,
+      send,
+      stop,
+      requestDiscard,
+      cancel,
+      discardArmed,
     },
   };
 }

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -107,6 +107,27 @@ html, body, #root {
   .manta-recording { animation: none; border-color: var(--danger); }
 }
 
+/* Paused take — same rule as .manta-recording: border colour only, never the
+   fill, but solid --warn and NO animation. */
+.manta-recording-paused {
+  border-color: var(--warn);
+}
+
+/* The recording state dot's own pulse (BET-836): opacity 1 -> 0.25 -> 1,
+   1.4 s ease-in-out, infinite. Suppressed under reduced-motion — the dot is
+   decorative (the waveform + timer carry the live signal). Paused applies no
+   animation. */
+@keyframes manta-recording-dot-pulse {
+  0%, 100% { opacity: 1; }
+  50%      { opacity: 0.25; }
+}
+.manta-recording-dot {
+  animation: manta-recording-dot-pulse 1.4s ease-in-out infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .manta-recording-dot { animation: none; }
+}
+
 /* MantaLoader — the two counter-rotating arcs (src/renderer/MantaLoader.tsx).
    Speeds are the native client's, verbatim: 0.9s clockwise outer, 1.4s
    anticlockwise inner. The mismatched periods are what stop the pair reading

--- a/src/renderer/voice.ts
+++ b/src/renderer/voice.ts
@@ -158,7 +158,7 @@ export function useVoiceRecorder({
   onWarning,
 }: UseVoiceRecorderOptions) {
   const [phase, setPhase] = useState<VoicePhase>("idle");
-  const [elapsedSec, setElapsedSec] = useState(0);
+  const [elapsedMs, setElapsedMs] = useState(0);
   const [nearLimit, setNearLimit] = useState(false);
   const [lastError, setLastError] = useState<string | null>(null);
 
@@ -306,7 +306,7 @@ export function useVoiceRecorder({
       }
       setLastError(null);
       setNearLimit(false);
-      setElapsedSec(0);
+      setElapsedMs(0);
       cancelledRef.current = false;
       stopRequestedRef.current = false;
       endedRef.current = false;
@@ -518,7 +518,7 @@ export function useVoiceRecorder({
       // (or the near-limit flag) actually changes — floor() + useState bail-out.
       elapsedTimerRef.current = setInterval(() => {
         const ms = elapsedCurrent(elapsedRef.current, performance.now());
-        setElapsedSec(Math.floor(ms / 1000));
+        setElapsedMs(Math.round(ms));
         setNearLimit(nearLimitAt(ms));
         // Hard cap: behaves exactly as if the user hit send — the take is
         // kept, never dropped (recorder.stop() -> onstop -> onComplete).
@@ -561,7 +561,7 @@ export function useVoiceRecorder({
       elapsedRef.current,
       performance.now(),
     );
-    setElapsedSec(Math.floor(elapsedRef.current.accumMs / 1000));
+    setElapsedMs(Math.round(elapsedRef.current.accumMs));
     // Stop the sampling interval so the waveform freezes rather than filling
     // with silence.
     if (sampleTimerRef.current) {
@@ -627,7 +627,7 @@ export function useVoiceRecorder({
 
   return {
     phase,
-    elapsedSec,
+    elapsedMs,
     nearLimit,
     lastError,
     liveWindowRef,

--- a/src/shared/waveform.mjs
+++ b/src/shared/waveform.mjs
@@ -17,7 +17,7 @@ export const VOICE_MAX_DURATION_MS = 300_000;    // 5 min hard cap
 export const VOICE_WARN_REMAINING_MS = 30_000;   // warn in the last 30 s
 export const VOICE_MIN_DURATION_MS = 400;        // shorter is a mis-tap, discarded silently
 export const VOICE_CONFIRM_DISCARD_MS = 30_000;  // above this, discard asks for confirmation
-export const VOICE_TAP_HOLD_MS = 500;            // key/button: hold >= this = push-to-talk, < this = tap
+export const VOICE_TAP_HOLD_MS = 250;            // press held this long = push-to-talk (stop+send), shorter = a tap (toggle). Shared by the mic button and the CmdOrCtrl+Shift+M keyboard shortcut.
 
 /**
  * Clamp a float 0..1 to an integer 0..255.


### PR DESCRIPTION
**BET-836 — Voice: recording composer with live waveform, pause/discard/send**

Stage 4 of BET-830. Builds on BET-835 (recorder session: toggle/pause/level capture), BET-834 (voice-note store), and **BET-838 (shortcut tap/hold, already merged into main)**. Implements the inline-morph recording composer: the composer box keeps its exact outer footprint while the inner input row swaps for the recording row while a take is active.

## What's here
- `src/renderer/VoiceWaveform.tsx` — hand-rolled canvas meter (no library), reads `liveWindowRef` directly in a rAF loop (no React state), ceiling pinned at 1.0, never normalised, `roundRect` with `rect` fallback, theme colours from `--danger`/`--warn` via `getComputedStyle` (no hex literals). Keeps drawing under `prefers-reduced-motion`.
- `src/renderer/ComposerParts.tsx` — `RecordingRow` (state dot / timer / waveform / discard / pause·resume / send) reusing the existing send-button chrome (`w-7 h-7 rounded-sm grid place-items-center shrink-0` + focus ring); `SendFilled` moved from `InputArea`; `MicButton` gained a `toggled` gesture (tap toggles, hold = push-to-talk) sharing `VOICE_TAP_HOLD_MS`.
- `src/renderer/InputArea.tsx` — inner row swaps for `RecordingRow` while a take is active; footer (model/mic/attach/usage/toolbar) stays visible + interactive; footer hint + near-limit `{n}s left` in `text-warn`; polite + assertive a11y regions (timer not in a live region).
- `src/renderer/hooks/useVoice.ts` — Enter = send, Space = pause/resume (textarea-unfocused), Esc = discard-with-confirmation; lifecycle aria announcements; discard arm state.
- `src/renderer/index.css` — `.manta-recording-paused` (solid `--warn` border, no animation) + `.manta-recording-dot` pulse (1.4s, reduced-motion disabled). No background tint — pulse animates border only.
- `src/shared/waveform.mjs` — `VOICE_TAP_HOLD_MS` (single value shared by the mic button and the CmdOrCtrl+Shift+M shortcut).

## Rebase reconciliation (manta-pm block)
Rebased onto current `origin/main` (`0a880d31`). BET-838 (shortcut tap/hold) had landed after this branch's original base, so `src/renderer/{ComposerParts,InputArea,hooks/useVoice}.tsx/.ts` and `src/shared/waveform.mjs` conflicted. Integrated BET-836's recording composer ON TOP of BET-838's merged shortcut/tap-hold work — one code path, nothing duplicated, Ctrl+Shift+M shortcut preserved.

**Semantic collision resolved:** BET-838 added `VOICE_TAP_HOLD_MS = 500`; this ticket's spec wants `250`. Kept a SINGLE constant (`250`, per BET-836 spec) and a SINGLE interaction model shared by both the mic button pointerdown/pointerup tap-vs-toggle and the keyboard shortcut keydown/keyup tap-vs-hold. No two values, no two models. Keyboard handler kept BET-838's CmdOrCtrl+Shift+M tap/hold + Enter-submit + Space pause/resume, routed through BET-836's wrapper actions so Esc triggers the discard-with-confirmation. If the reviewer prefers the 500 ms threshold, it is a one-line change.

Sending/transcription/pending-row/bubble out of scope — `send()` calls the existing useVoice completion path unchanged.

**Base: origin/main @ `0a880d31`**

**Files changed:** 8 files (578 insertions, 127 deletions).

**Verification results:**
- PR branch (`multica/BET-836-recording-composer` @ `6a702cb3`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 715 pass / 0 fail / 0 skip. Failures: none.
- Base (`main` @ `0a880d31`): branch is exactly main + this commit (merge-base == main HEAD); reviewer may spot-check.
- **Conclusion:** 0 new failures; all 715 tests pass on the PR branch.

Relates to BET-836.
