### PR TITLE
BET-840: feat(server): app-control tools — server module, REST surface, tool registrar

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -984,6 +984,58 @@ and worktree all belong to it.
   assembly, buildJobPrompt/buildCompletionText, sweep retention, stop/delete
   — pure/IO-injected logic only, no live HTTP/tmux).
 
+## App control — MantaUI-native AI tool (`src/server/appControl.mjs`)
+
+The seventh **MantaUI-native opencode tool**: an opencode session can drive
+the app the user is looking at — switch the model for its chat session, rename
+the session in the sidebar, compact it, or list the sessions in its workspace.
+Same "MantaUI tools" pattern as the other six (`docs/manta-tools-scheduler.md`).
+This ticket is the server half + tool registrar; the sibling ticket (BET-841)
+consumes the bus envelopes in the renderer.
+
+- **Global opencode tool**, `docs/opencode-tools/manta-app.ts`, **COPIED** (not
+  symlinked — same `@opencode-ai/plugin` gotcha) to
+  `~/.config/opencode/tools/manta-app.ts`. Four exports → `manta_compact_session`,
+  `manta_switch_model`, `manta_rename_session`, `manta_list_sessions`. Guidance
+  appended to `~/.config/opencode/AGENTS.md`. **Install/update =
+  `systemctl --user restart opencode-serve`.**
+- **Thin registrar** — each `execute` POSTs `/api/app-control {action,
+  sessionID, directory, ...args}` (same box, no SSH hop) and returns promptly.
+  The `boxToken()` / `authHeaders()` helpers are copied verbatim (every `/api/*`
+  route is behind the bearer gate). Dispatch on `action`; unknown actions are
+  rejected by name with a message the model can act on, never a bare 500.
+- **Session resolution** — every action resolves the caller's window the way
+  `peers.mjs` does, via the shared `resolveWorkspace` (sessionID first, then a
+  `paneCurrentPath === directory` fallback). No second resolver. Pure logic,
+  injected I/O, no durable store — a live claim, computed per call.
+- **The four actions:**
+  - `compactSession` — calls the existing `oc.compactSession`. `{ok:true}`;
+    no bus event (opencode already emits `session.compacted` and the renderer
+    reacts).
+  - `switchModel({query})` — resolves the query against `oc.listModels()`
+    with the shared fuzzy matcher `fuzzyMatchModel` (moved to
+    `src/shared/modelGuide.mjs`; `suggestModels` powers the no-match error that
+    names the closest candidates for a retry). On a hit publishes `{action:
+    "switch-model", sessionId, providerID, modelID}`. **The model override is
+    renderer state** (per-session `localStorage`), so the server can't apply it
+    directly — the bus event is how it lands on the open ChatPanel.
+  - `renameSession({name})` — validates (1–40 chars, no `:` or control chars),
+    calls `tmux.renameWindow` (never shells out directly), publishes `{action:
+    "rename-session", sessionId, name}` so sidebars refresh without a poll.
+  - `listSessions` — read-only windows in the caller's workspace: name, index,
+    chat-mode flag, branch (best-effort), and whether it's the caller. No event.
+- **Bus** — ONE kind, `appControl`, with an `action` discriminator (not one
+  kind per action). Published through the existing bus in `index.mjs` as
+  `{kind:"appControl", payload}`; the renderer needs exactly one listener + one
+  switch. Payload is client-agnostic so the native client can adopt it later.
+- **Out of scope by design**: interrupt/abort of the current turn and
+  permission/question approval are NOT available through these tools — the
+  tool descriptions and guidance say so explicitly.
+- Tests: `src/server/appControl.test.mjs` (session resolution by id and
+  directory fallback, model fuzzy match + no-match candidate error, rename
+  validation accept/reject, unknown-action rejection, bus payload shape for
+  both publishing actions — pure/injected only, no live HTTP/tmux).
+
 ## Mouse mode — design decision, do not re-litigate
 
 **Mouse is ON through the whole pipeline (tmux + claude).** This matches what

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -350,6 +350,38 @@ checkout.
 and run `systemctl --user restart opencode-serve`. A symlinked tool fails
 to resolve `@opencode-ai/plugin` and silently never registers.
 
+## MantaUI app control
+
+You have four `manta_*` tools to drive the app the user is looking at from
+THIS chat session:
+
+- `manta_compact_session()` — compact this session to free context (the same
+  as `/compact`). Immediate and visible in the transcript.
+- `manta_switch_model(query)` — switch this session to the model the user
+  asked for (e.g. "opus", "sonnet 4"), resolved with a fuzzy matcher. The
+  change is immediate and visible in the composer's model pill, but applies
+  to **subsequent** turns — the current reply has already started on the old
+  model, so never claim the current response is on the new one.
+- `manta_rename_session(name)` — rename this session/window in the sidebar.
+  Immediate; the sidebar refreshes on its own.
+- `manta_list_sessions()` — list the sessions (windows) in this workspace with
+  their name, index, type (chat/terminal), branch, and which one you are.
+
+Use them to **act rather than ask** when the user's intent is clear — just do
+it and confirm tersely; each reports the effect as immediate and visible.
+`manta_list_sessions` is the cheap read for orienting within the workspace.
+
+**What is NOT available, and must not be attempted:** there is no tool to
+interrupt or abort the current turn, and no way to approve a pending
+permission or answer a question from these tools. Interruption and permission
+approval are out of scope for app control — do not claim you performed them or
+try to route around them with the other tools.
+
+Install/update is a COPY, never a symlink: copy
+`docs/opencode-tools/manta-app.ts` to `~/.config/opencode/tools/manta-app.ts`
+then `systemctl --user restart opencode-serve`. A symlink fails to resolve
+`@opencode-ai/plugin` and the tool silently never registers.
+
 ## manta send-file
 
 You have a `send_file` tool to hand a file to the user and record it as a

--- a/docs/opencode-tools/manta-app.ts
+++ b/docs/opencode-tools/manta-app.ts
@@ -1,0 +1,165 @@
+// manta-native `app-control` tools — global opencode custom tools.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/manta-app.ts ~/.config/opencode/tools/manta-app.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+// A copy, never a symlink — opencode resolves a tool's imports relative to the
+// file's REAL path, so a symlink back into the repo (no node_modules) fails
+// with `Cannot find module '@opencode-ai/plugin'` and the tool silently never
+// registers.
+//
+// These tools let THIS session drive the app the user is looking at: switch
+// the model for this chat session, rename the session in the sidebar, compact
+// it, or list the sessions in this workspace. They are THIN registrars: each
+// `fetch`es manta-server (127.0.0.1:8787/api/app-control, same box, no SSH
+// hop) and returns promptly — no long-running work, no sleeping. Effects are
+// immediate and visible to the user (or — for switch-model — apply from the
+// next turn on). See src/server/appControl.mjs.
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
+// tiny local file) so a token rotation never requires an opencode-serve
+// restart. MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+async function appControl<T>(action: string, args: Record<string, unknown>, context: any): Promise<T> {
+  const res = await fetch(`${MANTA_SERVER}/api/app-control`, {
+    method: "POST",
+    headers: authHeaders(args),
+    body: JSON.stringify({
+      action,
+      sessionID: context?.sessionID,
+      directory: context?.directory,
+      ...args,
+    }),
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json as T;
+}
+
+export const manta_compact_session = tool({
+  description: [
+    "Compact THIS chat session now to free context (the same as the /compact command).",
+    "The effect is immediate and visible in the transcript.",
+    "Act rather than ask when the user's intent is clear — just do it and confirm",
+    "tersely; you do not need the user to approve the mechanical act.",
+  ].join(" "),
+  args: {},
+  async execute(_args, context) {
+    const result = await appControl<{ ok: boolean }>("compact-session", {}, context);
+    if (!result.ok) throw new Error("compact failed");
+    return "Compacted this session. It now has a shorter context to continue from.";
+  },
+});
+
+export const manta_switch_model = tool({
+  description: [
+    "Switch THIS chat session to the model the user asked for, matched on a spoken",
+    "or typed name (e.g. \"opus\", \"sonnet 4\"). The change is immediate and",
+    "visible in the composer's model pill, but it applies to SUBSEQUENT turns —",
+    "the current reply has already started on the old model and does not switch.",
+    "So do not claim the current response is on the new model.",
+    "Act rather than ask when the user's intent is clear — just switch and confirm",
+    "which model it picked.",
+  ].join(" "),
+  args: {
+    query: tool.schema
+      .string()
+      .describe("The model name to switch to, as the user said it, e.g. \"opus\" or \"sonnet 4\"."),
+  },
+  async execute(args, context) {
+    const result = await appControl<{
+      ok: boolean;
+      model?: { modelID: string; name?: string | null };
+      error?: string;
+    }>("switch-model", { query: args.query }, context);
+    if (!result.ok) throw new Error(result.error || "switch failed");
+    const m = result.model;
+    return `Switched this session to ${m?.modelID}. It will apply from the next turn onward.`;
+  },
+});
+
+export const manta_rename_session = tool({
+  description: [
+    "Rename THIS chat session / window to the name the user asked for (visible in",
+    "the sidebar). The effect is immediate and visible to the user — the sidebar",
+    "refreshes on its own, no manual refresh needed.",
+    "Act rather than ask when the user's intent is clear — just rename and confirm.",
+  ].join(" "),
+  args: {
+    name: tool.schema
+      .string()
+      .describe("The new session name (1–40 characters; no ':' or control characters)."),
+  },
+  async execute(args, context) {
+    const result = await appControl<{ ok: boolean; name?: string; error?: string }>(
+      "rename-session",
+      { name: args.name },
+      context,
+    );
+    if (!result.ok) throw new Error(result.error || "rename failed");
+    return `Renamed this session to "${result.name}".`;
+  },
+});
+
+export const manta_list_sessions = tool({
+  description: [
+    "List the sessions (tmux windows) in THIS workspace, with each one's name,",
+    "index, whether it's a chat window, its git branch, and whether it is the",
+    "current session. Read-only and cheap — use it to understand the workspace",
+    "(e.g. before switching windows) or to report what is open.",
+  ].join(" "),
+  args: {},
+  async execute(_args, context) {
+    const result = await appControl<{
+      ok: boolean;
+      workspace?: string;
+      self?: string;
+      sessions?: Array<{ name: string; index: number; chat: boolean; branch: string | null; caller: boolean }>;
+      error?: string;
+    }>("list-sessions", {}, context);
+    if (!result.ok) throw new Error(result.error || "list failed");
+    const rows = (result.sessions ?? []).map(
+      (s) =>
+        `• window ${s.index} [${s.name}] (${s.chat ? "chat" : "terminal"})${s.branch ? ` ⎇${s.branch}` : ""}${s.caller ? " ← you" : ""}`,
+    );
+    return `Workspace "${result.workspace}" — ${rows.length} session(s):\n${rows.join("\n")}`;
+  },
+});

--- a/src/server/appControl.mjs
+++ b/src/server/appControl.mjs
@@ -1,0 +1,193 @@
+// appControl.mjs — app-control tools for the mobile server.
+//
+// Lets an opencode session drive the app the user is looking at: switch the
+// model for its chat session, rename the session in the sidebar, compact it,
+// or list the sessions in the caller's workspace. The remote AI calls the
+// global opencode `manta_*` tools (docs/opencode-tools/manta-app.ts), which
+// POST to manta-server's /api/app-control; this module is the dispatch target.
+//
+// Mirrors src/server/peers.mjs: pure logic with injected I/O, live reads, no
+// durable store. Every action resolves the caller's session the way peers.mjs
+// does — by sessionID first, falling back to matching `directory` against a
+// window's pane path — via the shared resolveWorkspace.
+//
+// Client-visible effects are published on the bus as ONE kind, `appControl`,
+// with an `action` discriminator. The bus envelope ({ kind:"appControl",
+// payload }) is added by index.mjs; each function here calls its injected
+// `publish` with the bare payload ({ action, ... }). The desktop renderer
+// subscribes once (the sibling ticket) and switches on `payload.action`.
+
+import * as tmux from "./tmux.mjs";
+import * as oc from "./opencode.mjs";
+import { resolveWorkspace } from "./peers.mjs";
+import { fuzzyMatchModel, suggestModels } from "../shared/modelGuide.mjs";
+
+// Window names tmux tolerates: anything except the `:` target separator and
+// control characters (a newline in a window name would corrupt the tab- and
+// newline-delimited -F listing). We reject rather than sanitise — the caller
+// (the model) gets a clear message and can retry with a different name.
+export function validateSessionName(name) {
+  if (typeof name !== "string") return { ok: false, error: "A session name is required." };
+  const trimmed = name.trim();
+  if (trimmed.length < 1 || trimmed.length > 40) {
+    return { ok: false, error: "Session name must be 1–40 characters." };
+  }
+  if (/[:]/.test(trimmed) || /[\x00-\x1f\x7f]/.test(trimmed)) {
+    return {
+      ok: false,
+      error: "Session name cannot contain ':' or control characters.",
+    };
+  }
+  return { ok: true, name: trimmed };
+}
+
+// Compact the caller's session. opencode already emits `session.compacted`
+// and the renderer already reacts to it, so no bus event is needed here.
+export async function compactSession({ sessionID, directory }, deps = {}) {
+  const listProjects = deps.listProjects || tmux.listProjects;
+  const compact = deps.compactSession || oc.compactSession;
+  const projects = await listProjects();
+  const loc = resolveWorkspace(projects, sessionID, directory);
+  if (!loc) {
+    return { ok: false, error: "Could not locate your session in any tmux workspace." };
+  }
+  await compact(loc.self.opencodeSessionId);
+  return { ok: true };
+}
+
+// Switch the caller's chat session to the model matching `query` (e.g.
+// "opus", "sonnet 4"). Resolves against oc.listModels() via the shared fuzzy
+// matcher; on a hit, publishes an `appControl` bus event.
+//
+// The model override is RENDERER state (localStorage, keyed per session), so
+// the server cannot apply it directly — the bus event is how it lands on the
+// open ChatPanel. That is the whole point of publishing here.
+export async function switchModel({ sessionID, directory, query }, deps = {}) {
+  const listProjects = deps.listProjects || tmux.listProjects;
+  const listModels = deps.listModels || oc.listModels;
+  const publish = deps.publish || (() => {});
+  const projects = await listProjects();
+  const loc = resolveWorkspace(projects, sessionID, directory);
+  if (!loc) {
+    return { ok: false, error: "Could not locate your session in any tmux workspace." };
+  }
+  if (!query || !String(query).trim()) {
+    return {
+      ok: false,
+      error: 'query is required — say which model, e.g. "opus" or "sonnet 4".',
+    };
+  }
+  const models = await listModels();
+  const resolved = fuzzyMatchModel(query, models);
+  if (!resolved) {
+    const suggestions = suggestModels(query, models, 3);
+    const hint = suggestions.length
+      ? ` Closest models: ${suggestions.map((s) => `${s.providerID}/${s.id}`).join(", ")}.`
+      : " No models are currently available on this box.";
+    return { ok: false, error: `No model matched "${query}".${hint}` };
+  }
+  publish({
+    action: "switch-model",
+    sessionId: loc.self.opencodeSessionId,
+    providerID: resolved.providerID,
+    modelID: resolved.id,
+  });
+  return {
+    ok: true,
+    model: {
+      providerID: resolved.providerID,
+      modelID: resolved.id,
+      name: resolved.name ?? null,
+    },
+  };
+}
+
+// Rename the caller's own window (session). Validates the name, calls the
+// tmux rename-window path through src/server/tmux.mjs (which owns every tmux
+// invocation, including its locale-safe spawn environment), and publishes an
+// `appControl` event so sidebars refresh without waiting for a poll.
+export async function renameSession({ sessionID, directory, name }, deps = {}) {
+  const listProjects = deps.listProjects || tmux.listProjects;
+  const renameWindow = deps.renameWindow || tmux.renameWindow;
+  const publish = deps.publish || (() => {});
+  const projects = await listProjects();
+  const loc = resolveWorkspace(projects, sessionID, directory);
+  if (!loc) {
+    return { ok: false, error: "Could not locate your session in any tmux workspace." };
+  }
+  const valid = validateSessionName(name);
+  if (!valid.ok) return valid;
+  await renameWindow({
+    sessionName: loc.project.tmuxSession,
+    windowIndex: loc.self.index,
+    newName: valid.name,
+  });
+  publish({
+    action: "rename-session",
+    sessionId: loc.self.opencodeSessionId,
+    name: valid.name,
+  });
+  return { ok: true, name: valid.name };
+}
+
+// List the windows (sessions) in the caller's workspace: name, index, whether
+// it is a chat-mode window, its current branch, and whether it is the caller.
+// Read-only — no bus event. Branch is best-effort (non-git cwd → null).
+export async function listSessions({ sessionID, directory }, deps = {}) {
+  const listProjects = deps.listProjects || tmux.listProjects;
+  const getVcsBranch = deps.getVcsBranch || oc.getVcsBranch;
+  const projects = await listProjects();
+  const loc = resolveWorkspace(projects, sessionID, directory);
+  if (!loc) {
+    return { ok: false, error: "Could not locate your session in any tmux workspace." };
+  }
+  const wins = loc.project.windows || [];
+  const sessions = await Promise.all(
+    wins.map(async (w) => {
+      const branch = await getVcsBranch(w.paneCurrentPath).catch(() => null);
+      const caller =
+        w === loc.self ||
+        (!!loc.self?.opencodeSessionId &&
+          !!w.opencodeSessionId &&
+          w.opencodeSessionId === loc.self.opencodeSessionId);
+      return {
+        name: w.name,
+        index: w.index,
+        chat: !!w.opencodeSessionId,
+        branch: branch || null,
+        caller,
+      };
+    }),
+  );
+  return {
+    ok: true,
+    workspace: loc.project.tmuxSession,
+    self: loc.self.name,
+    sessions,
+  };
+}
+
+// Dispatch an /api/app-control request on its `action`. Rejects unknown
+// actions by name so the caller can reply with a message the model can act on.
+// `args` carries { action, sessionID, directory, ...action-specific }. `deps`
+// is the injected-I/O bag passed through to each handler (listProjects,
+// listModels, publish, ...). Returns `{ ok: true, ... }` or `{ ok: false,
+// error }`.
+export async function dispatch(action, args = {}, deps = {}) {
+  const base = { sessionID: args.sessionID, directory: args.directory };
+  switch (action) {
+    case "compact-session":
+      return compactSession(base, deps);
+    case "switch-model":
+      return switchModel({ ...base, query: args.query }, deps);
+    case "rename-session":
+      return renameSession({ ...base, name: args.name }, deps);
+    case "list-sessions":
+      return listSessions(base, deps);
+    default:
+      return {
+        ok: false,
+        error: `unknown action "${action}". Supported actions: compact-session, switch-model, rename-session, list-sessions.`,
+      };
+  }
+}

--- a/src/server/appControl.test.mjs
+++ b/src/server/appControl.test.mjs
@@ -1,0 +1,235 @@
+// Tests for appControl.mjs pure logic — no live tmux/opencode/git.
+// Run via `npm run test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  validateSessionName,
+  compactSession,
+  switchModel,
+  renameSession,
+  listSessions,
+  dispatch,
+} from "./appControl.mjs";
+
+const PROJECTS = [
+  {
+    tmuxSession: "alpha",
+    windows: [
+      { index: 0, name: "main", opencodeSessionId: "ses_a0", paneCurrentPath: "/work/alpha" },
+      { index: 1, name: "tui", opencodeSessionId: null, paneCurrentPath: "/work/alpha" },
+      { index: 2, name: "helper", opencodeSessionId: "ses_a2", paneCurrentPath: "/work/alpha" },
+    ],
+  },
+  {
+    tmuxSession: "beta",
+    windows: [
+      { index: 0, name: "b0", opencodeSessionId: "ses_b0", paneCurrentPath: "/work/beta" },
+    ],
+  },
+];
+
+const MODELS = [
+  { providerID: "anthropic", id: "claude-haiku-4", name: "Claude Haiku 4" },
+  { providerID: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+  { providerID: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
+  { providerID: "openai", id: "gpt-4o", name: "GPT-4o" },
+];
+
+function harness(extra = {}) {
+  const published = [];
+  const calls = { compact: [], rename: [], branch: 0 };
+  const deps = {
+    listProjects: async () => PROJECTS,
+    listModels: async () => MODELS,
+    publish: (payload) => published.push(payload),
+    compactSession: async (sid) => calls.compact.push(sid),
+    renameWindow: async (args) => calls.rename.push(args),
+    getVcsBranch: async () => {
+      calls.branch += 1;
+      return "main";
+    },
+    ...extra,
+  };
+  return { published, calls, deps };
+}
+
+// ---------------------------------------------------------------------------
+// validateSessionName
+// ---------------------------------------------------------------------------
+
+test("validateSessionName accepts a normal 1–40 char name", () => {
+  const r = validateSessionName("My Session");
+  assert.equal(r.ok, true);
+  assert.equal(r.name, "My Session");
+});
+
+test("validateSessionName trims surrounding whitespace", () => {
+  assert.equal(validateSessionName("  clear  ").name, "clear");
+});
+
+test("validateSessionName rejects empty, too-short, and over-40-char names", () => {
+  assert.equal(validateSessionName("").ok, false);
+  assert.equal(validateSessionName("   ").ok, false);
+  assert.equal(validateSessionName("a".repeat(41)).ok, false);
+  assert.equal(validateSessionName(null).ok, false);
+  assert.equal(validateSessionName(undefined).ok, false);
+});
+
+test("validateSessionName rejects ':' and control characters", () => {
+  assert.equal(validateSessionName("a:b").ok, false);
+  assert.equal(validateSessionName("line\nbreak").ok, false);
+  assert.equal(validateSessionName("bad\u0000").ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// compactSession — session resolution by id and by directory fallback
+// ---------------------------------------------------------------------------
+
+test("compactSession resolves by sessionID and compacts that session", async () => {
+  const { calls, deps } = harness();
+  const r = await compactSession({ sessionID: "ses_a2" }, deps);
+  assert.equal(r.ok, true);
+  assert.deepEqual(calls.compact, ["ses_a2"]);
+});
+
+test("compactSession falls back to resolving by directory", async () => {
+  const { calls, deps } = harness();
+  const r = await compactSession({ sessionID: "ses_unknown", directory: "/work/beta" }, deps);
+  assert.equal(r.ok, true);
+  assert.deepEqual(calls.compact, ["ses_b0"]);
+});
+
+test("compactSession errors when the caller's workspace can't be resolved", async () => {
+  const { calls, deps } = harness();
+  const r = await compactSession({ sessionID: "ses_x", directory: "/nope" }, deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /Could not locate your session/);
+  assert.equal(calls.compact.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// switchModel — fuzzy match + no-match error listing candidates + bus payload
+// ---------------------------------------------------------------------------
+
+test("switchModel matches a fuzzy query and publishes the switch-model payload", async () => {
+  const { published, deps } = harness();
+  const r = await switchModel({ sessionID: "ses_a0", query: "opus" }, deps);
+  assert.equal(r.ok, true);
+  assert.deepEqual(r.model, { providerID: "anthropic", modelID: "claude-opus-4-7", name: "Claude Opus 4.7" });
+  assert.deepEqual(published, [
+    { action: "switch-model", sessionId: "ses_a0", providerID: "anthropic", modelID: "claude-opus-4-7" },
+  ]);
+});
+
+test("switchModel resolves a multi-token query against a model name", async () => {
+  const { deps } = harness();
+  const r = await switchModel({ sessionID: "ses_a0", query: "gpt 4o" }, deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.model.modelID, "gpt-4o");
+});
+
+test("switchModel no-match error names the closest candidate(s)", async () => {
+  const { published, deps } = harness();
+  // "claude 32b": the token "claude" hits every id, so suggestModels lists
+  // candidates, but no single model contains every token → no match.
+  const miss = await switchModel({ sessionID: "ses_a0", query: "claude 32b" }, deps);
+  assert.equal(miss.ok, false);
+  assert.match(miss.error, /No model matched "claude 32b"/);
+  assert.match(miss.error, /Closest models:/);
+  assert.equal(published.length, 0);
+});
+
+test("switchModel errors without a query and when unresolvable", async () => {
+  const { published, deps } = harness();
+  const noQ = await switchModel({ sessionID: "ses_a0", query: "  " }, deps);
+  assert.equal(noQ.ok, false);
+  assert.match(noQ.error, /query is required/);
+  const unresolvable = await switchModel({ sessionID: "ses_x", directory: "/nope", query: "opus" }, deps);
+  assert.equal(unresolvable.ok, false);
+  assert.match(unresolvable.error, /Could not locate your session/);
+  assert.equal(published.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// renameSession — validation + tmux call + bus payload
+// ---------------------------------------------------------------------------
+
+test("renameSession renames the caller's window and publishes the rename payload", async () => {
+  const { published, calls, deps } = harness();
+  const r = await renameSession({ sessionID: "ses_a0", name: "Fresh Name" }, deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.name, "Fresh Name");
+  assert.deepEqual(calls.rename, [{ sessionName: "alpha", windowIndex: 0, newName: "Fresh Name" }]);
+  assert.deepEqual(published, [{ action: "rename-session", sessionId: "ses_a0", name: "Fresh Name" }]);
+});
+
+test("renameSession rejects an invalid name without calling tmux", async () => {
+  const { calls, deps } = harness();
+  const r = await renameSession({ sessionID: "ses_a0", name: "has:colon" }, deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /cannot contain ':'/);
+  assert.equal(calls.rename.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// listSessions
+// ---------------------------------------------------------------------------
+
+test("listSessions returns the caller's workspace windows with flags", async () => {
+  const { deps } = harness();
+  const r = await listSessions({ sessionID: "ses_a0" }, deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.workspace, "alpha");
+  assert.equal(r.self, "main");
+  assert.equal(r.sessions.length, 3);
+  assert.deepEqual(r.sessions[0], { name: "main", index: 0, chat: true, branch: "main", caller: true });
+  assert.deepEqual(r.sessions[1], { name: "tui", index: 1, chat: false, branch: "main", caller: false });
+  assert.deepEqual(r.sessions[2], { name: "helper", index: 2, chat: true, branch: "main", caller: false });
+});
+
+test("listSessions falls back to resolving by directory", async () => {
+  const { deps } = harness();
+  const r = await listSessions({ sessionID: "ses_x", directory: "/work/beta" }, deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.workspace, "beta");
+  assert.equal(r.self, "b0");
+});
+
+test("listSessions errors when unresolvable", async () => {
+  const { deps } = harness();
+  const r = await listSessions({ sessionID: "ses_x", directory: "/nope" }, deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /Could not locate your session/);
+});
+
+// ---------------------------------------------------------------------------
+// dispatch — unknown action rejected by name, known actions routed
+// ---------------------------------------------------------------------------
+
+test("dispatch rejects an unknown action by name", async () => {
+  const { deps } = harness();
+  const r = await dispatch("explode-everything", {}, deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /unknown action "explode-everything"/);
+  assert.match(r.error, /Supported actions:/);
+});
+
+test("dispatch routes known actions to their handlers", async () => {
+  const { deps } = harness();
+  const switchR = await dispatch("switch-model", { sessionID: "ses_a0", query: "haiku" }, deps);
+  assert.equal(switchR.ok, true);
+  const renameR = await dispatch("rename-session", { sessionID: "ses_a0", name: "Renamed" }, deps);
+  assert.equal(renameR.ok, true);
+  const compactR = await dispatch("compact-session", { sessionID: "ses_b0" }, deps);
+  assert.equal(compactR.ok, true);
+  const listR = await dispatch("list-sessions", { sessionID: "ses_a0" }, deps);
+  assert.equal(listR.ok, true);
+});
+
+test("dispatch with no action reports an unknown action", async () => {
+  const { deps } = harness();
+  const r = await dispatch(undefined, {}, deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /unknown action "undefined"/);
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -83,6 +83,7 @@ import {
   isValidSubdomain,
 } from "./servePage.mjs";
 import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./peers.mjs";
+import * as appControl from "./appControl.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
 import { createPromptDelivery } from "./promptDelivery.mjs";
 import {
@@ -2017,6 +2018,34 @@ const handleRequest = async (req, res) => {
       }
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- App control ----------
+  // POST /api/app-control  body {action, sessionID, directory, ...args}
+  //   → {ok, ...} on success, or {ok:false, error} (400) on a bad request.
+  // Lets an opencode session drive the app the user is looking at: switch its
+  // model, rename the session, compact it, or list the caller's workspace
+  // sessions. Called by the remote AI's global opencode `manta_*` tools. See
+  // src/server/appControl.mjs.
+  //
+  // The client-visible effects are published on the bus as ONE kind,
+  // `appControl`, with an `action` discriminator — the renderer subscribes
+  // once (the sibling ticket) and switches on payload.action.
+  if (path === "/api/app-control") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const deps = { publish: (payload) => bus.publish({ kind: "appControl", payload }) };
+        const result = await appControl.dispatch(body?.action, body || {}, deps);
+        respondJson(res, result.ok ? 200 : 400, result);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      // Errors return a message the model can act on, never a bare 500.
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;

--- a/src/shared/modelGuide.d.mts
+++ b/src/shared/modelGuide.d.mts
@@ -12,3 +12,20 @@ export function describeModel(
 ): ModelInfo | null;
 
 export function familyKey(modelID: string): string | null;
+
+export interface ResolvedModel {
+  id?: string;
+  name?: string;
+  providerID?: string;
+}
+
+export function fuzzyMatchModel(
+  query: string | null | undefined,
+  models: ResolvedModel[]
+): ResolvedModel | null;
+
+export function suggestModels(
+  query: string | null | undefined,
+  models: ResolvedModel[],
+  limit?: number
+): ResolvedModel[];

--- a/src/shared/modelGuide.mjs
+++ b/src/shared/modelGuide.mjs
@@ -241,3 +241,74 @@ export function familyKey(modelID) {
   const entry = matchFamily(modelID);
   return entry ? entry.key : null;
 }
+
+// --- Model matching for app-control (the manta_switch_model tool) -----------
+//
+// Resolves a spoken/typed model query ("opus", "sonnet 4", "claude-haiku")
+// against a list of normalized opencode models (oc.listModels()). This is the
+// canonical fuzzy matcher — src/server/appControl.mjs uses it for the
+// switch-model action. Do not write a second match implementation anywhere.
+
+/**
+ * Match a fuzzy model query against a list of models. Exact id wins, then
+ * every token present in the id, then every token present in the name, then a
+ * providerID prefix.
+ *
+ * @param {string|null|undefined} query
+ * @param {Array<{id?: string, name?: string, providerID?: string}>} models
+ * @returns {object|null} the resolved model, or null when nothing matches.
+ */
+export function fuzzyMatchModel(query, models) {
+  const list = Array.isArray(models) ? models : [];
+  if (!query || !list.length) return null;
+  const q = String(query).toLowerCase().trim();
+  if (!q) return null;
+
+  const direct = list.find((m) => String(m?.id ?? "").toLowerCase() === q);
+  if (direct) return direct;
+
+  const tokens = q.split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return null;
+
+  for (const m of list) {
+    const id = String(m?.id ?? "").toLowerCase();
+    if (tokens.every((t) => id.includes(t))) return m;
+  }
+  for (const m of list) {
+    const name = String(m?.name ?? "").toLowerCase();
+    if (tokens.every((t) => name.includes(t))) return m;
+  }
+  for (const m of list) {
+    if (tokens[0] === String(m?.providerID ?? "").toLowerCase()) return m;
+  }
+  return null;
+}
+
+/**
+ * The closest candidates for an unmatched query, for a retry hint. Ranks
+ * models by how many query tokens appear in their id/name; returns the top
+ * `limit`. Exported so the switch-model no-match error can name candidates
+ * the model can retry with.
+ *
+ * @param {string|null|undefined} query
+ * @param {Array<{id?: string, name?: string, providerID?: string}>} models
+ * @param {number} [limit]
+ * @returns {Array<{providerID?: string, id?: string, name?: string}>}
+ */
+export function suggestModels(query, models, limit = 3) {
+  const list = Array.isArray(models) ? models : [];
+  if (!query || !list.length) return [];
+  const tokens = String(query).toLowerCase().split(/\s+/).filter(Boolean);
+  if (tokens.length === 0) return [];
+  const scored = [];
+  for (const m of list) {
+    const haystack = `${String(m?.id ?? "")} ${String(m?.name ?? "")}`.toLowerCase();
+    let hits = 0;
+    for (const t of tokens) if (haystack.includes(t)) hits++;
+    if (hits > 0) scored.push({ m, hits });
+  }
+  return scored
+    .sort((a, b) => b.hits - a.hits)
+    .slice(0, limit)
+    .map(({ m }) => ({ providerID: m?.providerID, id: m?.id, name: m?.name }));
+}

--- a/src/shared/modelGuide.test.ts
+++ b/src/shared/modelGuide.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { describeModel, familyKey } from "./modelGuide.mjs";
+import { describeModel, familyKey, fuzzyMatchModel, suggestModels } from "./modelGuide.mjs";
 
 describe("describeModel", () => {
   it("matches haiku family", () => {
@@ -198,5 +198,61 @@ describe("familyKey", () => {
   it("returns a non-null key for newly cataloged models so subagent naming stops falling back to slugs", () => {
     expect(familyKey("gpt-5.2-codex")).toBe("codex");
     expect(familyKey("k3")).toBe("k3");
+  });
+});
+
+const MODELS = [
+  { providerID: "anthropic", id: "claude-haiku-4", name: "Claude Haiku 4" },
+  { providerID: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+  { providerID: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
+  { providerID: "openai", id: "gpt-4o", name: "GPT-4o" },
+  { providerID: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" },
+];
+
+describe("fuzzyMatchModel", () => {
+  it("matches an exact model id", () => {
+    expect(fuzzyMatchModel("claude-opus-4-7", MODELS)?.id).toBe("claude-opus-4-7");
+  });
+
+  it("matches every token against a model id (queries like \"opus\")", () => {
+    expect(fuzzyMatchModel("opus", MODELS)?.id).toBe("claude-opus-4-7");
+  });
+
+  it("matches a multi-word query against a model name (\"gpt 4o mini\")", () => {
+    expect(fuzzyMatchModel("gpt 4o mini", MODELS)?.id).toBe("gpt-4o-mini");
+  });
+
+  it("is case-insensitive", () => {
+    expect(fuzzyMatchModel("SONNET", MODELS)?.id).toBe("claude-sonnet-4-6");
+  });
+
+  it("falls back to a providerID match for a bare provider name", () => {
+    expect(fuzzyMatchModel("openai", MODELS)?.providerID).toBe("openai");
+  });
+
+  it("returns null for no match or empty input", () => {
+    expect(fuzzyMatchModel("gpt-5", MODELS)).toBeNull();
+    expect(fuzzyMatchModel("", MODELS)).toBeNull();
+    expect(fuzzyMatchModel("opus", [])).toBeNull();
+    expect(fuzzyMatchModel(null as unknown as string, MODELS)).toBeNull();
+  });
+});
+
+describe("suggestModels", () => {
+  it("rates candidates whose id/name contain a query token", () => {
+    const s = suggestModels("4o", MODELS, 3);
+    expect(s.map((m) => m.id).sort()).toEqual(["gpt-4o", "gpt-4o-mini"]);
+    expect(s[0].providerID).toBe("openai");
+  });
+
+  it("respects the limit", () => {
+    // every model contains the "claude" token; limit 2 caps the result.
+    expect(suggestModels("claude", MODELS, 2).length).toBe(2);
+  });
+
+  it("returns empty for no overlap", () => {
+    expect(suggestModels("zzzz", MODELS)).toEqual([]);
+    expect(suggestModels("", MODELS)).toEqual([]);
+    expect(suggestModels(null as unknown as string, MODELS)).toEqual([]);
   });
 });


### PR DESCRIPTION
# BET-840 — App-control tools: server module, REST surface and opencode tool registrar

Stage 1 of the app-control epic: the server half + the opencode tool registrar. Nothing in the renderer changes here — client-visible effects are published on the bus as one `appControl` kind and consumed by the sibling ticket (BET-841).

## What shipped

- **`src/server/appControl.mjs`** — the four actions (`compactSession`, `switchModel`, `renameSession`, `listSessions`), pure logic with injected I/O mirroring `peers.mjs`, reusing the shared `resolveWorkspace` (sessionID first, directory fallback) for every action. No durable store — all live reads.
- **`POST /api/app-control`** — behind the existing bearer gate (not added to `isExemptPath`). Dispatches on `action` (via `appControl.dispatch`); unknown actions rejected by name; every error returns a message the model can act on, never a bare 500.
- **Bus** — one kind, `appControl`, with an `action` discriminator, published through the existing bus (`{kind:"appControl", payload}`). `switch-model` and `rename-session` publish; `compact` deliberately does not (opencode already emits `session.compacted`).
- **`src/shared/modelGuide.mjs`** — the fuzzy matcher now lives here. It was previously in `src/renderer/voice.ts`, but **BET-831 deleted it along with voice command mode** (verified via `git log -S fuzzyMatchModel`), so there is no renderer import left to update — it's a clean move-to-canonical-home. `suggestModels` powers the no-match error that names the closest candidates for a retry.
- **`switchModel`** — the model override is renderer state (per-session `localStorage`), so the server cannot apply it directly; the bus event is how it lands on the open ChatPanel (documented in a comment).
- **`renameSession`** — validates (1–40 chars, no `:` or control chars, reject-not-sanitise) and calls `tmux.renameWindow` (never shells out directly).
- **`docs/opencode-tools/manta-app.ts`** — four thin `manta_*` registrar tools with the `boxToken()`/`authHeaders()` helpers copied verbatim (the bearer-gate gotcha). Descriptions instruct act-don't-ask + immediate effect; `manta_switch_model` states the change applies to **subsequent** turns.
- **Docs** — `## MantaUI app control` appended to `docs/opencode-tools/AGENTS.md` and a section added to the repo `AGENTS.md` alongside the other six tools; both state the copy-not-symlink + `systemctl --user restart opencode-serve` install step and that interrupt / permission approval are NOT available.
- **Tests** — `src/server/appControl.test.mjs` (19) + `fuzzyMatchModel`/`suggestModels` in `src/shared/modelGuide.test.ts`.

## Files changed (9)

`AGENTS.md`, `docs/opencode-tools/AGENTS.md`, `docs/opencode-tools/manta-app.ts`, `src/server/appControl.mjs`, `src/server/appControl.test.mjs`, `src/server/index.mjs`, `src/shared/modelGuide.d.mts`, `src/shared/modelGuide.mjs`, `src/shared/modelGuide.test.ts` (+851/−1).

## Verification results

**PR branch:** `multica/BET-840-app-control-tools` @ `e1200f54`

- typecheck: exit `0`. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
- test (vitest): exit `0`, `2558` pass / `7` skip / `0` fail. (in `npm test`)
- test (node:test): exit `0`, `667` pass / `0` fail / `0` skip. log sha256 (full `npm test`): `eb64686683d5f96a4c04695578537405b4d8a8bdbc142b1f7d18ad32b22b0a9b`

**Base:** `origin/main` @ `bf01c8b6` — unchanged since this branch was cut from it (verified `git merge-base` = `bf01c8b6` = current `origin/main`). The branch diff is 9 additive files; the pre-existing suite is fully green, so **0 new failures**.

**Conclusion:** 0 new failures, 0 pre-existing failures. (All runs: `npm run typecheck && npm test`, plus `npm run test:server`.)

**Not verified here:** invoking the four tools live from an opencode session on a dev box — that requires copying `manta-app.ts` to `~/.config/opencode/tools/` and `systemctl --user restart opencode-serve` on a running box, outside this run's scope. The file is a straight registrar mirroring the shipped `peers.ts` pattern.

Base: `origin/main @ bf01c8b6`
