### PR TITLE
multica/BET-795-work-inbox

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -245,6 +245,7 @@ function AppInner() {
   // One-shot first-prompt for a freshly-created session (draft → new session):
   // App passes it to the matching ChatPanel, which auto-submits then clears it.
   const autoSubmitPrompt = useStore((s) => s.autoSubmitPrompt);
+  const seedPrompt = useStore((s) => s.seedPrompt);
   const openNewProject = () => createDraft("new-project");
   const openNewSessionInProject = (name: string) =>
     createDraft({ projectName: name });
@@ -1696,6 +1697,7 @@ function AppInner() {
                       }
                       registerModelControl={registerModelControl}
                       unregisterModelControl={unregisterModelControl}
+                      seedPrompt={seedPrompt?.sid === sid ? seedPrompt : undefined}
                     />
                   </PanelShell>
                 );

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -162,6 +162,10 @@ type Props = {
   // optional — omitted in test harnesses that mount ChatPanel directly.
   registerModelControl?: (sessionId: string, apply: (m: ModelSelection) => void) => void;
   unregisterModelControl?: (sessionId: string) => void;
+  // BET-795: a one-shot composer SEED — the inbox's "Start a session". Like
+  // autoSubmit, delivered to the RIGHT session's panel, but it only fills the
+  // composer (setInput); it does NOT submit. The user reviews + hits Enter.
+  seedPrompt?: { text: string };
 };
 
 export function ChatPanel({
@@ -180,6 +184,7 @@ export function ChatPanel({
   autoSubmit,
   registerModelControl,
   unregisterModelControl,
+  seedPrompt,
 }: Props) {
   const chatAutoAllow = useStore((s) => s.chatAutoAllow);
   const setChatAutoAllow = useStore((s) => s.setChatAutoAllow);
@@ -1215,6 +1220,24 @@ export function ChatPanel({
       autoSubmitted.current = false;
     };
   }, [autoSubmit, setModelOverride, setInput]);
+
+  // BET-795: inbox "Start a session" — seed the composer (setInput) but do NOT
+  // submit. One-shot via the same ref guard idiom as autoSubmit. Clearing the
+  // store flips seedPrompt → undefined; clearing inside the timeout (never the
+  // effect body) keeps the effect's own cleanup from racing the clear.
+  const seedApplied = useRef(false);
+  useEffect(() => {
+    if (!seedPrompt || seedApplied.current) return;
+    seedApplied.current = true;
+    setInput(seedPrompt.text);
+    const t = setTimeout(() => {
+      useStore.getState().setSeedPrompt(null);
+    }, 0);
+    return () => {
+      clearTimeout(t);
+      seedApplied.current = false;
+    };
+  }, [seedPrompt, setInput]);
 
   // When the AI goes idle (running flips false) and there are queued
   // messages, dispatch the next one. We restore it into `input` and call

--- a/src/renderer/InboxPalette.tsx
+++ b/src/renderer/InboxPalette.tsx
@@ -1,0 +1,313 @@
+// InboxPalette.tsx — the work inbox on the shared PaletteShell (BET-795).
+//
+// The one cross-repo surface in the app: issues assigned to you, PRs awaiting
+// your review, and your own open PRs whose checks are red — served by ONE
+// box-side read (window.api.forgeInbox()) built on three SEARCH queries. The
+// renderer holds no forge logic; it renders rows and routes the row actions
+// through the EXISTING session-creation path.
+//
+// Rows are the shared ListRow (leading dot · title · reason · repo · age).
+// The three row actions sit UNDER the list exactly as the mockup lays them
+// out: `↵ Start a session` (the Enter-key default), `Open review`, and
+// `Delegate in background` — all operating on the currently selected row.
+//
+// "Start a session" reuses the ONE creation path (tmuxNewSession + the
+// worktree/project helpers from NewSessionScreen): it resolves the item's repo
+// to a local path on the box, adds a worktree, creates the session, lands in
+// it, and SEEDS the composer with the box-provided prompt WITHOUT submitting
+// (the user reviews + hits Enter). "Delegate in background" runs the same
+// path but auto-submits (the agent starts working immediately).
+
+import { useEffect, useMemo, useState } from "react";
+import { CornerDownLeft } from "lucide-react";
+import { PaletteShell } from "./PaletteShell";
+import { ListRow } from "./ListRow";
+import { StatusDot } from "./StatusDot";
+import { Chip } from "./Chip";
+import { Button } from "./Button";
+import { Pill } from "./Pill";
+import { useStore } from "./store";
+import { formatAge, inboxReasonLabel, sortInbox } from "./chatUtils";
+import { deriveProjectName, uniqueSessionName } from "./NewSessionScreen";
+import type { ForgeInboxItem } from "../shared/types";
+
+// The status-dot tone for each inbox reason — the mockup's deliberate mix:
+// a red-checks PR is `bad`, a review request is `warn`, an assigned issue is
+// `mute` (nothing is wrong, it is just waiting). Four tones, four meanings.
+function dotTone(reason: ForgeInboxItem["reason"]): Parameters<typeof StatusDot>[0]["tone"] {
+  switch (reason) {
+    case "checks failing":
+      return "error";
+    case "review requested":
+      return "warn";
+    default:
+      return "idle";
+  }
+}
+
+// The inline identifier prefix — `#` for an issue, `!` for a PR (GitLab's MR
+// sigil is preserved too, so a future GitLab MR shows `!88` not `#88`).
+function identifier(item: ForgeInboxItem): string {
+  return `${item.kind === "pr" ? "!" : "#"}${item.number}`;
+}
+
+// The short repo name (host/owner/repo → repo) for the row's source column.
+function repoName(item: ForgeInboxItem): string {
+  const parts = item.repoKey.split("/");
+  return parts[parts.length - 1] ?? item.repoKey;
+}
+
+// The secondary column: `reason · repo` for a PR (the row shows its repo), and
+// the bare reason phrase for an assigned issue (already "issue · assigned to
+// you" — the mockup shows no repo on that row). GitHub/GitLab stay visually
+// indistinguishable except for this text.
+function secondary(item: ForgeInboxItem): string {
+  const label = inboxReasonLabel(item.reason);
+  return item.kind === "pr" ? `${label} · ${repoName(item)}` : label;
+}
+
+// A readable branch name from an inbox item — the worktree branch that a
+// "Start a session" creates. Kept inside the component (display-slab concern),
+// so pure sort/label logic stays in chatUtils where the required tests live.
+function inboxBranchName(item: ForgeInboxItem): string {
+  const slug = (item.title ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "-")
+    .replace(/^-+|-+$/g, "")
+    .slice(0, 40);
+  return `manta/${item.kind}-${item.number}${slug ? `-${slug}` : ""}`;
+}
+
+export function InboxPalette({ onClose }: { onClose: () => void }) {
+  const [query, setQuery] = useState("");
+  const [sel, setSel] = useState(0);
+
+  const applyProjects = useStore((s) => s.applyProjects);
+  const activateWindow = useStore((s) => s.activateWindow);
+  const setActive = useStore((s) => s.setActive);
+  const setSeedPrompt = useStore((s) => s.setSeedPrompt);
+  const setAutoSubmitPrompt = useStore((s) => s.setAutoSubmitPrompt);
+
+  const [items, setItems] = useState<ForgeInboxItem[]>([]);
+  const [loaded, setLoaded] = useState(false);
+  const [loadError, setLoadError] = useState<string | null>(null);
+  const [repos, setRepos] = useState<Record<string, string>>({}); // repoKey -> local path
+  const [error, setError] = useState<string | null>(null);
+
+  // One fetch on open — never polled while closed (§ Hygiene).
+  useEffect(() => {
+    let cancelled = false;
+    setLoaded(false);
+    setLoadError(null);
+    // Resolve repoKey → local path so "Start a session" can create a worktree
+    // (the cached repo probe; box-side, 60s).
+    (window.api.forgeProbe?.() ?? Promise.resolve({ repos: [] }))
+      .then((probe) => {
+        if (cancelled) return;
+        const m: Record<string, string> = {};
+        for (const r of probe?.repos ?? []) if (r.repoKey) m[r.repoKey] = r.path;
+        setRepos(m);
+      })
+      .catch(() => { /* probe is optional — degrade to no-path rows */ });
+    if (typeof window.api.forgeInbox === "function") {
+      window.api
+        .forgeInbox()
+        .then((res) => {
+          if (cancelled) return;
+          setItems(sortInbox(res?.items ?? []));
+          if (res?.error === "not_connected") setLoadError("GitHub isn't connected on this box.");
+        })
+        .catch(() => {
+          if (cancelled) return;
+          setLoadError("Couldn't load the inbox.");
+        })
+        .finally(() => {
+          if (!cancelled) setLoaded(true);
+        });
+    } else {
+      // Inbox not wired on this client (e.g. unpaired) — degrade gracefully.
+      setLoadError("Inbox isn't available here yet.");
+      setLoaded(true);
+    }
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  // The rows after query filtering, in display order (already sorted server-side
+  // AND by sortInbox — the renderer re-asserts the invariant it renders by).
+  const rows = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    const filtered = q
+      ? items.filter(
+          (i) => i.title.toLowerCase().includes(q) || String(i.number).includes(q),
+        )
+      : items;
+    return sortInbox(filtered);
+  }, [items, query]);
+
+  useEffect(() => {
+    if (sel >= rows.length) setSel(0);
+  }, [rows.length, sel]);
+
+  // Create a session from an inbox item, reusing the ONE creation path. When
+  // `submit` is true the prompt is auto-submitted (delegate); otherwise it is
+  // seeded into the composer but NOT submitted (start a session).
+  const createSessionFromItem = async (item: ForgeInboxItem, submit: boolean) => {
+    const path = repos[item.repoKey];
+    if (!path) {
+      setError(`No local checkout of ${repoName(item)} on this box to start a session in.`);
+      return;
+    }
+    setError(null);
+    const existing = useStore.getState().projects.map((p) => p.tmuxSession);
+    const name = uniqueSessionName(deriveProjectName(path), new Set(existing));
+    try {
+      const wt = await window.api.gitAddWorktree({ cwd: path, name: inboxBranchName(item) });
+      const dir = wt.path ?? path;
+      const created = await window.api.tmuxNewSession({
+        name,
+        cwd: dir,
+        windowName: "default",
+        chatMode: true,
+        createDir: false,
+      });
+      applyProjects(Array.isArray(created) ? created : created.projects);
+      const proj = useStore.getState().projects.find((p) => p.tmuxSession === name);
+      const win = proj?.windows.find((w) => w.active) ?? proj?.windows[0];
+      const sessionId =
+        (Array.isArray(created) ? null : created.sessionId) ?? win?.opencodeSessionId ?? null;
+      if (win) {
+        try {
+          await activateWindow(name, win.index);
+        } catch {
+          setActive(name, win.index);
+        }
+      } else {
+        setActive(name, 0);
+      }
+      if (sessionId && item.seed) {
+        if (submit) setAutoSubmitPrompt({ sid: sessionId, text: item.seed });
+        else setSeedPrompt({ sid: sessionId, text: item.seed });
+      }
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  const startSession = (item: ForgeInboxItem) => void createSessionFromItem(item, false);
+  const delegateInBackground = (item: ForgeInboxItem) => void createSessionFromItem(item, true);
+  const openReview = (item: ForgeInboxItem) => {
+    if (item.url) void window.api.openExternal(item.url);
+  };
+
+  const selected = rows[sel] ?? null;
+
+  return (
+    <PaletteShell
+      label="Inbox"
+      placeholder="Filter inbox…"
+      query={query}
+      setQuery={(v) => {
+        setQuery(v);
+        setSel(0);
+      }}
+      itemCount={rows.length}
+      sel={sel}
+      setSel={setSel}
+      onPick={(i) => {
+        const item = rows[i];
+        if (item) startSession(item);
+      }}
+      onClose={onClose}
+      footerExtra={
+        <span className="font-mono">
+          ⌥↵ delegate
+        </span>
+      }
+    >
+      {(pick) => {
+        void pick;
+        // Header: Inbox + count pill (Pill tone="accent" — the mockup's .pill.info).
+        const header = (
+          <div className="flex items-center gap-2 px-3 pt-2 pb-1">
+            <span className="text-label font-semibold text-text">Inbox</span>
+            {loaded && items.length > 0 && (
+              <Pill tone="accent">{String(items.length)}</Pill>
+            )}
+          </div>
+        );
+
+        if (!loaded) {
+          return (
+            <>
+              {header}
+              <div className="px-3 py-3 text-label text-text-faint">Loading inbox…</div>
+            </>
+          );
+        }
+        if (loadError) {
+          return (
+            <>
+              {header}
+              <div className="px-3 py-3 text-label text-text-faint">{loadError}</div>
+            </>
+          );
+        }
+        if (rows.length === 0) {
+          return (
+            <>
+              {header}
+              <div className="px-3 py-3 text-label text-text-faint">
+                {query.trim()
+                  ? `No inbox matches “${query.trim()}”`
+                  : "Nothing needs you right now."}
+              </div>
+            </>
+          );
+        }
+
+        return (
+          <>
+            {header}
+            {rows.map((item, i) => (
+              <ListRow
+                key={`${item.repoKey}#${item.number}`}
+                leading={<StatusDot tone={dotTone(item.reason)} />}
+                name={
+                  <span className="truncate">
+                    <span className="text-text-faint">{identifier(item)} </span>
+                    {item.title}
+                  </span>
+                }
+                secondary={<span className="truncate">{secondary(item)}</span>}
+                trailing={formatAge(Date.now() - item.updatedAt)}
+                onClick={() => setSel(i)}
+                title={item.url}
+                className={i === sel ? "bg-fill-hover" : undefined}
+              />
+            ))}
+
+            {/* Row actions — the mockup's chip row under the list. `↵ Start a
+                session` is the Enter-key default (onPick above) and carries the
+                accent-outlined Chip-on treatment; Enter actually does it. */}
+            <div className="flex items-center gap-2 flex-wrap px-3 pt-2 pb-1">
+              <Chip on onClick={() => selected && startSession(selected)} title="Create a worktree + session, seed the prompt (Enter)">
+                <CornerDownLeft size={12} aria-hidden="true" /> Start a session
+              </Chip>
+              <Button tone="default" onClick={() => selected && openReview(selected)}>
+                Open review
+              </Button>
+              <Button tone="default" onClick={() => selected && delegateInBackground(selected)}>
+                Delegate in background
+              </Button>
+            </div>
+
+            {error && <div className="px-3 pb-2 text-meta text-danger break-words">{error}</div>}
+          </>
+        );
+      }}
+    </PaletteShell>
+  );
+}

--- a/src/renderer/InboxPalette.tsx
+++ b/src/renderer/InboxPalette.tsx
@@ -86,7 +86,6 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
   const activateWindow = useStore((s) => s.activateWindow);
   const setActive = useStore((s) => s.setActive);
   const setSeedPrompt = useStore((s) => s.setSeedPrompt);
-  const setAutoSubmitPrompt = useStore((s) => s.setAutoSubmitPrompt);
 
   const [items, setItems] = useState<ForgeInboxItem[]>([]);
   const [loaded, setLoaded] = useState(false);
@@ -150,10 +149,10 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
     if (sel >= rows.length) setSel(0);
   }, [rows.length, sel]);
 
-  // Create a session from an inbox item, reusing the ONE creation path. When
-  // `submit` is true the prompt is auto-submitted (delegate); otherwise it is
-  // seeded into the composer but NOT submitted (start a session).
-  const createSessionFromItem = async (item: ForgeInboxItem, submit: boolean) => {
+  // Create a session from an inbox item, reusing the ONE creation path. The
+  // prompt is seeded into the composer (setSeedPrompt) but NOT submitted —
+  // the user reviews + hits Enter ("start a session").
+  const createSessionFromItem = async (item: ForgeInboxItem) => {
     const path = repos[item.repoKey];
     if (!path) {
       setError(`No local checkout of ${repoName(item)} on this box to start a session in.`);
@@ -186,9 +185,44 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
       } else {
         setActive(name, 0);
       }
-      if (sessionId && item.seed) {
-        if (submit) setAutoSubmitPrompt({ sid: sessionId, text: item.seed });
-        else setSeedPrompt({ sid: sessionId, text: item.seed });
+      if (sessionId && item.seed) setSeedPrompt({ sid: sessionId, text: item.seed });
+      onClose();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  // "Delegate in background" — the same work as Start-a-session but routed
+  // through the EXISTING delegate engine (spec §3): it creates its own
+  // worktree + branch + nested rail row and runs the seeded prompt without the
+  // user watching. The parent is the active chat session the job nests under.
+  const delegateInBackground = async (item: ForgeInboxItem) => {
+    const path = repos[item.repoKey];
+    if (!path) {
+      setError(`No local checkout of ${repoName(item)} on this box to delegate in.`);
+      return;
+    }
+    const active = useStore.getState().activeSession();
+    const parentId = active
+      ? (useStore
+          .getState()
+          .projects.find((p) => p.tmuxSession === active.projectName)
+          ?.windows.find((w) => w.index === active.windowIndex)?.opencodeSessionId ?? null)
+      : null;
+    if (!parentId) {
+      setError("Open a chat session first — a background job nests under its parent session.");
+      return;
+    }
+    setError(null);
+    try {
+      const res = await window.api.delegateStart({
+        prompt: item.seed,
+        sessionID: parentId,
+        directory: path,
+      });
+      if (!res?.ok) {
+        setError(res?.error ?? "Couldn't start the background job.");
+        return;
       }
       onClose();
     } catch (e) {
@@ -196,8 +230,7 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
     }
   };
 
-  const startSession = (item: ForgeInboxItem) => void createSessionFromItem(item, false);
-  const delegateInBackground = (item: ForgeInboxItem) => void createSessionFromItem(item, true);
+  const startSession = (item: ForgeInboxItem) => void createSessionFromItem(item);
   const openReview = (item: ForgeInboxItem) => {
     if (item.url) void window.api.openExternal(item.url);
   };

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -11,6 +11,7 @@ import { ChevronRight, ChevronDown, X, Pin, Search } from "lucide-react";
 import { useStore, flatSessions, type WindowStatusUI } from "./store";
 import { nowMs, useAgeTick } from "./clock";
 import { PaletteShell, useSelectedIntoView } from "./PaletteShell";
+import { InboxPalette } from "./InboxPalette";
 import type { Project, TmuxWindow } from "../shared/types";
 import {
   classifyCacheAge,
@@ -115,6 +116,9 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   const [paletteOpen, setPaletteOpen] = useState(false);
   const [paletteQuery, setPaletteQuery] = useState("");
   const [paletteSel, setPaletteSel] = useState(0);
+  // BET-795: the work inbox (⌘K → Inbox). Rendered as a PaletteShell sibling
+  // of the command palette; opened from the command palette's Inbox entry.
+  const [inboxOpen, setInboxOpen] = useState(false);
 
   // BET-414: keyboard tree-nav focus (roving tabindex). `focusedKey` is the
   // row that currently holds tabIndex=0; ArrowUp/Down moves it along the
@@ -868,8 +872,14 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
           onActivate={(proj, idx) => {
             void activateWindow(proj, idx);
           }}
+          onOpenInbox={() => {
+            setPaletteOpen(false);
+            setInboxOpen(true);
+          }}
         />
       )}
+
+      {inboxOpen && <InboxPalette onClose={() => setInboxOpen(false)} />}
     </aside>
   );
 });
@@ -1288,6 +1298,7 @@ function CommandPalette({
   setSel,
   onClose,
   onActivate,
+  onOpenInbox,
 }: {
   query: string;
   setQuery: (v: string) => void;
@@ -1296,38 +1307,58 @@ function CommandPalette({
   setSel: (n: number) => void;
   onClose: () => void;
   onActivate: (project: Project, windowIndex: number) => void;
+  onOpenInbox: () => void;
 }) {
+  // The Inbox action is a pinned row at index 0; the session rows shift by 1.
   return (
     <PaletteShell
       label="Command palette"
       placeholder="Search sessions…"
       query={query}
       setQuery={setQuery}
-      itemCount={results.length}
+      itemCount={results.length + 1}
       sel={sel}
       setSel={setSel}
       onPick={(i) => {
-        const r = results[i];
+        if (i === 0) {
+          onOpenInbox();
+          return;
+        }
+        const r = results[i - 1];
         if (r) onActivate(r.project, r.window.index);
       }}
       onClose={onClose}
     >
-      {(pick) =>
-        results.length === 0 ? (
-          <div className="px-3 py-3 text-label text-text-faint">No sessions match</div>
-        ) : (
-          results.map((r, i) => (
-            <SessionRow
-              key={`${r.project.tmuxSession}/${r.window.index}`}
-              name={r.window.name}
-              workspace={r.project.tmuxSession}
-              selected={i === sel}
-              onEnter={() => setSel(i)}
-              onClick={() => pick(i)}
-            />
-          ))
-        )
-      }
+      {(pick) => (
+        <>
+          <button
+            onMouseEnter={() => setSel(0)}
+            onClick={() => pick(0)}
+            className={`w-full flex items-center gap-3 px-3 py-3 rounded-md text-left text-label border-l-2 ${
+              sel === 0
+                ? "bg-bg-soft border-l-accent text-text"
+                : "border-l-transparent text-text-muted hover:bg-bg-soft"
+            }`}
+          >
+            <span className="flex-1 min-w-0 truncate">Inbox</span>
+            <span className="text-meta text-text-faint truncate">assigned · reviews · red checks</span>
+          </button>
+          {results.length === 0 ? (
+            <div className="px-3 py-3 text-label text-text-faint">No sessions match</div>
+          ) : (
+            results.map((r, i) => (
+              <SessionRow
+                key={`${r.project.tmuxSession}/${r.window.index}`}
+                name={r.window.name}
+                workspace={r.project.tmuxSession}
+                selected={i + 1 === sel}
+                onEnter={() => setSel(i + 1)}
+                onClick={() => pick(i + 1)}
+              />
+            ))
+          )}
+        </>
+      )}
     </PaletteShell>
   );
 }

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -59,6 +59,7 @@ export const DEMO_UNIMPLEMENTED = [
   "forgeDraftComment",
   "forgeDraftGet",
   "forgeDraftSubmit",
+  "forgeInbox",
   "forgeMerge",
   "forgeProbe",
   "forgePullRequest",

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -47,6 +47,7 @@ export const DEMO_UNIMPLEMENTED = [
   "delegateDelete",
   "delegateList",
   "delegatePendingApprovals",
+  "delegateStart",
   "delegateStop",
   "forgeCloneCancel",
   "forgeCloneStart",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -709,6 +709,8 @@ export const httpApi: Api = {
   forgeStatus: () => rpc(IPC.forgeStatus),
   forgePullRequest: (input) => rpc(IPC.forgePullRequest, input),
   forgeDiff: (input) => rpc(IPC.forgeDiff, input),
+  // BET-795: the work inbox (box-side aggregated read).
+  forgeInbox: () => rpc(IPC.forgeInbox),
 
   // -- forge write path (BET-794) --
   forgeShip: (input) => rpc(IPC.forgeShip, input),

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1074,6 +1074,9 @@ export const httpApi: Api = {
     rpc<DelegateJob[] | { jobs: DelegateJob[] }>(IPC.delegateList, sessionId).then(
       (r) => (Array.isArray(r) ? r : Array.isArray(r?.jobs) ? r.jobs : []),
     ),
+  // BET-795: the work inbox's "Delegate in background" — start a background
+  // job through the existing delegate engine (own worktree + window + rail).
+  delegateStart: (input) => rpc(IPC.delegateStart, input),
   delegateStop: (id) => rpc(IPC.delegateStop, id),
   delegateDelete: (id) => rpc(IPC.delegateDelete, id),
   // BET-418 §A: pre-flight approval poll + approve/decline. The renderer polls

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -114,9 +114,11 @@ import {
   linkedPrNumber,
   preferLinkedPr,
   dispatchAppControl,
+  sortInbox,
+  inboxReasonLabel,
 } from "./chatUtils";
 
-import type { OpencodeModel, UsageSnapshot, OpencodeMessage, VoiceNoteRecord } from "../shared/types";
+import type { OpencodeModel, UsageSnapshot, OpencodeMessage, VoiceNoteRecord, ForgeInboxItem } from "../shared/types";
 
 
 
@@ -4332,5 +4334,71 @@ describe("dispatchAppControl (BET-841)", () => {
     dispatchAppControl(undefined, { switchModel, renameSession });
     expect(switchModel).not.toHaveBeenCalled();
     expect(renameSession).not.toHaveBeenCalled();
+  });
+});
+
+// ---- Work inbox (BET-795) -------------------------------------------------
+
+const inboxItem = (over: Partial<ForgeInboxItem>): ForgeInboxItem => ({
+  kind: "issue",
+  repoKey: "github.com/acme/widget",
+  number: 1,
+  title: "thing",
+  url: "https://github.com/acme/widget/issues/1",
+  state: "open",
+  rollup: "none",
+  updatedAt: 0,
+  reason: "assigned",
+  seed: "Complete https://github.com/acme/widget/issues/1",
+  ...over,
+});
+
+describe("inboxReasonLabel", () => {
+  it("maps the three inbox reasons to their verbatim mockup copy", () => {
+    expect(inboxReasonLabel("assigned")).toBe("issue · assigned to you");
+    expect(inboxReasonLabel("review requested")).toBe("review requested");
+    expect(inboxReasonLabel("checks failing")).toBe("checks red");
+  });
+});
+
+describe("sortInbox", () => {
+  it("sorts by updatedAt descending", () => {
+    const rows = [
+      inboxItem({ number: 1, updatedAt: 100 }),
+      inboxItem({ number: 2, updatedAt: 900 }),
+      inboxItem({ number: 3, updatedAt: 500 }),
+    ];
+    expect(sortInbox(rows).map((r) => r.number)).toEqual([2, 3, 1]);
+  });
+
+  it("dedupes the same object at two keys to one row, more urgent reason wins (dedupe-precedence case)", () => {
+    const rows = [
+      inboxItem({
+        number: 9,
+        kind: "pr",
+        reason: "review requested",
+        updatedAt: 500,
+        rollup: "red",
+        url: "https://github.com/acme/widget/pull/9",
+      }),
+      inboxItem({
+        number: 9,
+        kind: "pr",
+        reason: "checks failing",
+        updatedAt: 500,
+        rollup: "red",
+        url: "https://github.com/acme/widget/pull/9",
+      }),
+    ];
+    const result = sortInbox(rows);
+    expect(result).toHaveLength(1);
+    expect(result[0].reason).toBe("checks failing");
+  });
+
+  it("does not mutate the caller's array", () => {
+    const rows = [inboxItem({ number: 2, updatedAt: 900 }), inboxItem({ number: 1, updatedAt: 100 })];
+    const before = [...rows];
+    sortInbox(rows);
+    expect(rows.map((r) => r.number)).toEqual(before.map((r) => r.number));
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { AppConfig, AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, OpencodeMessage, OpencodeModel, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { AppConfig, AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, OpencodeMessage, OpencodeModel, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 import type { VoiceNoteRecord } from "../shared/types";
 // Value import — `isClientTooOld` is the pure semver compare that drives
@@ -3238,4 +3238,57 @@ export function dispatchAppControl(
     return;
   }
   // compact-session + any unknown action: no-op.
+}
+
+// ---- Work inbox (BET-795) --------------------------------------------------
+
+// How urgent each inbox reason is — the merge tiebreak. A checks-failing PR is
+// the most urgent (bad dot), a requested review next (warn dot), a plain
+// assignment least (mute dot) — the dot-tone order of the mockup. Mirrors the
+// server's precedence so a renderer that ever receives a duplicated key settles
+// it the same way, independently of the box.
+const INBOX_REASON_PRIORITY: Record<InboxReason, number> = {
+  "checks failing": 3,
+  "review requested": 2,
+  assigned: 1,
+};
+
+/**
+ * The human phrase for an inbox reason — what the row's secondary column shows,
+ * with the mockup's copy verbatim ("checks red", "review requested",
+ * "issue · assigned to you"). Pure + tested.
+ */
+export function inboxReasonLabel(reason: InboxReason): string {
+  switch (reason) {
+    case "checks failing":
+      return "checks red";
+    case "review requested":
+      return "review requested";
+    case "assigned":
+      return "issue · assigned to you";
+  }
+}
+
+/**
+ * Sort inbox rows by `updatedAt` descending (most recent first), AND dedupe by
+ * `repoKey#number` with the more urgent reason winning when the same object
+ * appears twice (a PR matching two inbox populations). The server already
+ * merges + dedupes, but the renderer guarantees the invariant it renders by —
+ * nothing displays a duplicated row or a stale lower-priority reason. Pure +
+ * tested, including the dedupe-precedence case.
+ */
+export function sortInbox(items: ForgeInboxItem[]): ForgeInboxItem[] {
+  const byKey = new Map<string, ForgeInboxItem>();
+  for (const item of items) {
+    const key = `${item.repoKey}#${item.number}`;
+    const existing = byKey.get(key);
+    if (!existing) {
+      byKey.set(key, item);
+      continue;
+    }
+    if (INBOX_REASON_PRIORITY[item.reason] > INBOX_REASON_PRIORITY[existing.reason]) {
+      byKey.set(key, item);
+    }
+  }
+  return [...byKey.values()].sort((a, b) => b.updatedAt - a.updatedAt);
 }

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -407,6 +407,11 @@ type State = {
   // first mount (draft → new-session flow). Consumed (cleared) by the panel
   // once it fires, so re-navigating to the session never re-sends it.
   autoSubmitPrompt: { sid: string; text: string; model?: ModelSelection } | null;
+  // BET-795: a one-shot composer SEED — the inbox's "Start a session" lands in
+  // a chat session with the prompt seeded into the composer but NOT submitted
+  // (the user reviews + hits Enter). Delivered to the session's ChatPanel like
+  // autoSubmitPrompt, but the panel only fills the input — no submit().
+  seedPrompt: { sid: string; text: string } | null;
   // sessionName -> windowIndex -> status
   status: Record<string, Record<number, WindowStatusUI>>;
   // Background-delegation jobs keyed by childSessionID (BET-381). Drives the
@@ -543,6 +548,7 @@ type State = {
   setAutoSubmitPrompt: (
     p: { sid: string; text: string; model?: ModelSelection } | null,
   ) => void;
+  setSeedPrompt: (p: { sid: string; text: string } | null) => void;
   refresh: () => Promise<void>;
   // Onboarding lifecycle. `skipOnboarding` persists onboardingSkipped (so the
   // flow doesn't re-trigger) and clears the forced flag. `relaunchOnboarding`
@@ -711,6 +717,7 @@ export const useStore = create<State>((set, get) => ({
   activeDraftId: null,
   drafts: [],
   autoSubmitPrompt: null,
+  seedPrompt: null,
   status: {},
   jobs: {},
   usage: [],
@@ -838,6 +845,7 @@ export const useStore = create<State>((set, get) => ({
     }),
   setActiveDraft: (id) => set({ activeDraftId: id }),
   setAutoSubmitPrompt: (p) => set({ autoSubmitPrompt: p }),
+  setSeedPrompt: (p) => set({ seedPrompt: p }),
 
   refresh: async () => {
     // BET-678: single cursor RPC. Pass the last-confirmed cursor so the box

--- a/src/server/forge/github.mjs
+++ b/src/server/forge/github.mjs
@@ -23,7 +23,7 @@
 //   3. `mergeable` can be null (GitHub is still computing it). We do not
 //      coerce it to false — the shared type has three states for this reason.
 
-import { normalizePrState, rollupChecks } from "../../shared/forge.mjs";
+import { normalizePrState, repoKey, rollupChecks } from "../../shared/forge.mjs";
 
 const API = "https://api.github.com";
 
@@ -93,6 +93,102 @@ function qs(params) {
 
 function issuePath(repo) {
   return `/repos/${repo.owner}/${repo.repo}`;
+}
+
+// ---------------------------------------------------------------------------
+// Work-inbox helpers (BET-795)
+// ---------------------------------------------------------------------------
+//
+// The inbox is the ONE cross-repo read in the project. Per-repo iteration is
+// O(N repos) and would exhaust the search rate limit on anyone with more than
+// a handful of repos, so the three populations come from three SEARCH queries
+// against GET /search/issues: `assignee:@me` (my issues), `review-requested:@me`
+// (PRs awaiting my review), `author:@me is:open` (my open PRs — kept only when
+// their checks are red). This module owns query construction + result
+// normalisation + the dedupe-with-precedence merge; index.mjs owns the network
+// and the per-PR checks fetch for the checks-failing population.
+//
+// Inbox reason precedence — which population's claim "wins" when the same PR
+// matches two queries (a PR on a branch I authored can also be awaiting my
+// review). A checks-failing PR is the most urgent (bad dot), a requested review
+// next (warn dot), a plain assignment least (mute dot) — the dot-tone order in
+// the mockup. The `reason` values are the shared InboxReason vocabulary.
+const INBOX_REASON_PRIORITY = Object.freeze({
+  "checks failing": 3,
+  "review requested": 2,
+  assigned: 1,
+});
+
+/**
+ * The three search queries that answer the whole inbox in three requests,
+ * regardless of how many repos the user has. Each carries the `reason` its
+ * results are claimed with — the caller iterates EXACTLY this set, so the
+ * queries the tests pin are the queries production runs.
+ *
+ * @returns {Array<{ query: string, reason: "assigned"|"review requested"|"checks failing" }>}
+ */
+export function buildInboxQueries() {
+  return [
+    { query: "assignee:@me", reason: "assigned" },
+    { query: "review-requested:@me", reason: "review requested" },
+    { query: "author:@me is:open", reason: "checks failing" },
+  ];
+}
+
+// Normalise one raw GET /search/issues item into the cross-repo InboxItem
+// skeleton. Kind flips on GitHub's PR marker (PRs are issues — the same trap
+// the issue list handles). Repo identity comes from `repository_url`
+// (GitHub's canonical per-item source) via repoKey; `updatedAt` is the search
+// item's updated_at in ms. `headSha` is read defensively — a PR whose search
+// item omits `head` just carries an empty SHA (checks can't be fetched).
+export function normalizeSearchHit(raw) {
+  const m = /\/repos\/([^/]+)\/([^/]+)\/?$/.exec(raw?.repository_url ?? "");
+  const owner = m ? m[1] : "";
+  const repo = m ? m[2] : "";
+  const updatedAt = raw?.updated_at ? Date.parse(raw.updated_at) : 0;
+  return {
+    kind: raw?.pull_request ? "pr" : "issue",
+    owner,
+    repo,
+    repoKey: owner && repo ? repoKey({ host: "github.com", owner, repo }) : "",
+    number: raw?.number ?? 0,
+    title: raw?.title ?? "",
+    url: raw?.html_url ?? "",
+    state: raw?.state ?? "open",
+    updatedAt,
+    headSha: raw?.head?.sha ?? "",
+    headRef: raw?.head?.ref ?? "",
+    // Stamped by the caller from the query — see buildInboxQueries.
+    reason: "assigned",
+  };
+}
+
+/**
+ * Merge the per-query inbox populations into ONE deduplicated list. A single
+ * PR can match two queries (e.g. `author:@me` AND `review-requested:@me`) and
+ * must appear exactly once — the more urgent `reason` wins (checks failing >
+ * review requested > assigned). Items are keyed by `repoKey#number`.
+ *
+ * @param {Array<Array<object>>} sources the per-query normalised arrays
+ * @returns {Array<object>}
+ */
+export function mergeInboxSources(sources) {
+  const byKey = new Map();
+  for (const source of sources ?? []) {
+    for (const it of Array.isArray(source) ? source : []) {
+      const key = `${it.repoKey}#${it.number}`;
+      const existing = byKey.get(key);
+      if (!existing) {
+        byKey.set(key, { ...it });
+        continue;
+      }
+      // Tie (same PR, same reason) keeps the first claim — order is stable.
+      if (INBOX_REASON_PRIORITY[it.reason] > INBOX_REASON_PRIORITY[existing.reason]) {
+        byKey.set(key, { ...existing, ...it });
+      }
+    }
+  }
+  return [...byKey.values()];
 }
 
 // Normalise one raw GitHub PR (from `/pulls` list or `/pulls/{n}`) into the
@@ -281,6 +377,27 @@ export function createGithubAdapter(request, requestWrite, requestText = request
       const { data, stale } = await request(url);
       const raw = Array.isArray(data) ? data : [];
       return { data: raw.map((p) => normalizePr(p)), stale };
+    },
+
+    /**
+     * GET /search/issues — the CROSS-REPO search surface (spec §4.5④). The
+     * inbox answers its three populations in three requests regardless of the
+     * user's repo count; per-repo /repos iteration would be O(N repos) and
+     * would exhaust the search bucket's much lower rate limit. Results are
+     * normalised by {@link normalizeSearchHit} and `reason` is stamped by the
+     * caller from buildInboxQueries. Pass `{ ttl }` to extend the request
+     * layer's freshness window — search has its own, lower rate limit, so the
+     * box caches it a full 60s (spec §4.5④, "cache aggressively").
+     *
+     * @param {string} query the raw GitHub search qualifiers, e.g. "assignee:@me"
+     * @param {{ ttl?: number }} [opts]
+     * @returns {Promise<{ data: Array<object>, stale: boolean }>}
+     */
+    async searchIssues(query, { ttl } = {}) {
+      const url = `${API}/search/issues${qs({ q: query })}`;
+      const { data, stale } = await request(url, { ttl });
+      const items = Array.isArray(data?.items) ? data.items : [];
+      return { data: items.map(normalizeSearchHit), stale };
     },
 
     /**

--- a/src/server/forge/github.test.mjs
+++ b/src/server/forge/github.test.mjs
@@ -10,6 +10,9 @@ import {
   MergeNotAllowedError,
   MergeShaMismatchError,
   MergePermissionError,
+  buildInboxQueries,
+  normalizeSearchHit,
+  mergeInboxSources,
 } from "./github.mjs";
 import { rollupChecks } from "../../shared/forge.mjs";
 
@@ -440,4 +443,112 @@ test("listMyRepos drops read-only repos and orders most-recently-pushed first", 
   assert.equal(data[1].defaultBranch, "main");
   assert.equal(data[1].cloneUrl, "https://github.com/octo/manta-skills.git");
   assert.ok(!data.some((r) => r.fullName === "acme/readonly"));
+});
+
+// ---- Work inbox (BET-795) --------------------------------------------------
+
+test("buildInboxQueries returns the three cross-repo populations with their reasons", () => {
+  const qs = buildInboxQueries();
+  assert.deepEqual(qs, [
+    { query: "assignee:@me", reason: "assigned" },
+    { query: "review-requested:@me", reason: "review requested" },
+    { query: "author:@me is:open", reason: "checks failing" },
+  ]);
+});
+
+test("searchIssues GETs /search/issues with the query and passes the ttl through", async () => {
+  const seen = [];
+  const request = async (url, opts) => {
+    seen.push({ url, opts });
+    return {
+      data: {
+        items: [
+          {
+            number: 5,
+            title: "Fix login",
+            html_url: "https://github.com/acme/widget/issues/5",
+            state: "open",
+            repository_url: "https://api.github.com/repos/acme/widget",
+            updated_at: "2026-08-13T10:00:00Z",
+          },
+        ],
+      },
+      stale: false,
+    };
+  };
+  const adapter = createGithubAdapter(request);
+  const { data } = await adapter.searchIssues("assignee:@me", { ttl: 60000 });
+  assert.equal(seen[0].url, "https://api.github.com/search/issues?q=assignee%3A%40me");
+  assert.equal(seen[0].opts.ttl, 60000, "the search bucket's longer freshness is threaded through");
+  assert.equal(seen[0].opts.method, undefined); // a plain GET
+  assert.equal(data[0].number, 5);
+  assert.equal(data[0].kind, "issue");
+  assert.equal(data[0].repoKey, "github.com/acme/widget");
+});
+
+test("normalizeSearchHit: repo identity from repository_url, kind flips on the PR marker, headSha read defensively", () => {
+  const issue = normalizeSearchHit({
+    number: 1,
+    title: "t",
+    html_url: "https://github.com/acme/widget/issues/1",
+    state: "open",
+    repository_url: "https://api.github.com/repos/acme/widget",
+    updated_at: "2026-08-13T10:00:00Z",
+  });
+  assert.equal(issue.kind, "issue");
+  assert.equal(issue.owner, "acme");
+  assert.equal(issue.repo, "widget");
+  assert.equal(issue.repoKey, "github.com/acme/widget");
+
+  const pr = normalizeSearchHit({
+    number: 2,
+    title: "p",
+    html_url: "https://github.com/acme/widget/pull/2",
+    repository_url: "https://api.github.com/repos/acme/widget",
+    updated_at: "2026-08-13T11:00:00Z",
+    pull_request: { url: "https://api.github.com/repos/acme/widget/pulls/2", html_url: "https://github.com/acme/widget/pull/2" },
+    head: { ref: "feat/x", sha: "abc123" },
+  });
+  assert.equal(pr.kind, "pr");
+  assert.equal(pr.headSha, "abc123");
+  assert.equal(normalizeSearchHit(null).kind, "issue", "defensive: a null/empty item normalises, doesn't throw");
+});
+
+test("mergeInboxSources dedupes a PR matching two queries to one row with the more urgent reason", () => {
+  const a = {
+    kind: "pr", owner: "acme", repo: "widget", repoKey: "github.com/acme/widget",
+    number: 9, title: "Same PR", url: "https://github.com/acme/widget/pull/9",
+    state: "open", updatedAt: 1000, headSha: "s", reason: "review requested",
+  };
+  const b = { ...a, reason: "checks failing" }; // same PR, claimed by the red-checks population
+  const c = { ...a, number: 10, reason: "assigned", kind: "issue" };
+
+  const merged = mergeInboxSources([[a], [b, c]]);
+  assert.equal(merged.length, 2, "the two claims for PR 9 collapse into one row");
+  const pr9 = merged.find((i) => i.number === 9);
+  assert.equal(pr9.reason, "checks failing", "checks failing beats review requested");
+  assert.equal(pr9.owner, "acme");
+  const pr10 = merged.find((i) => i.number === 10);
+  assert.equal(pr10.reason, "assigned");
+});
+
+test("mergeInboxSources precedence: checks failing > review requested > assigned", () => {
+  const base = {
+    kind: "pr", repoKey: "github.com/acme/widget", number: 3,
+    title: "x", url: "u", state: "open", updatedAt: 0, headSha: "",
+  };
+  const assigned = { ...base, reason: "assigned" };
+  const review = { ...base, reason: "review requested" };
+  const red = { ...base, reason: "checks failing" };
+  // assigned then review → review wins
+  const m1 = mergeInboxSources([[assigned, review]]);
+  assert.equal(m1[0].reason, "review requested");
+  // review then assigned → review still wins (order-independent)
+  const m2 = mergeInboxSources([[review, assigned]]);
+  assert.equal(m2[0].reason, "review requested");
+  // red beats review regardless of order
+  const m3 = mergeInboxSources([[red, review]]);
+  const m4 = mergeInboxSources([[review, red]]);
+  assert.equal(m3[0].reason, "checks failing");
+  assert.equal(m4[0].reason, "checks failing");
 });

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -33,7 +33,7 @@ import { gitRemoteOrigin as localGitRemoteOrigin, detectForgeCli as localDetectF
 import { resolveToken as authResolveToken } from "./auth.mjs";
 import { startDeviceGrant as authStartDeviceGrant, pollDeviceGrant as authPollDeviceGrant, cancelDeviceGrant as authCancelDeviceGrant, ExpiredCodeError, DeviceFlowNotConfiguredError } from "./auth.mjs";
 import { getCloneStore } from "./clone.mjs";
-import { createGithubAdapter, GithubRequestError } from "./github.mjs";
+import { createGithubAdapter, GithubRequestError, buildInboxQueries, mergeInboxSources } from "./github.mjs";
 import { getDraft as storeGetDraft, putComment as storePutComment, deleteComment as storeDeleteComment, setVerdict as storeSetVerdict, markDraftStale as storeMarkDraftStale, clearDraft as storeClearDraft } from "./draft.mjs";
 import { readFile as fsReadFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -41,6 +41,11 @@ import { join } from "node:path";
 // How long a fetched value is served from memory with no network request at
 // all. After this, the ETag conditional GET (If-None-Match) takes over.
 const FRESH_TTL_MS = 30_000;
+// The inbox's SEARCH bucket has its own, much lower rate limit than core
+// (spec §4.5④) — so the box caches its three queries a full 60s. Opening the
+// inbox twice inside 60 seconds must issue NO second round of requests. This
+// is the same request layer — just a longer shelf life for the search bucket.
+const INBOX_TTL_MS = 60_000;
 // How long an ETag value stays usable for a conditional GET.
 const ETAG_HOLD_MS = 5 * 60_000;
 // How long a rate-limited bucket is cooled for.
@@ -73,7 +78,7 @@ function bucketOf(url) {
  *
  * @param {{ fetch?: typeof fetch, now?: () => number }} [opts]
  * @returns {{
- *   getJson: (url: string, opts: { token: string }) => Promise<{ data: any, stale: boolean }>,
+ *   getJson: (url: string, opts: { token: string, ttl?: number }) => Promise<{ data: any, stale: boolean }>,
  * }}
  */
 export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } = {}) {
@@ -81,8 +86,15 @@ export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } 
   const inflight = new Map(); // url -> Promise
   const coolingUntil = new Map(); // bucketKey -> ms
 
-  async function getJson(url, { token }) {
+  async function getJson(url, { token, ttl } = {}) {
     const bucket = bucketOf(url);
+    // Per-resource freshness override: the inbox's search bucket has its own,
+    // much lower rate limit (spec §4.5④), so its values are held a full 60s —
+    // long enough that "opening the inbox twice inside 60s" issues no second
+    // round of requests. The ETag conditional GET then takes over exactly as
+    // for every other resource. One cache, one backoff — just a longer shelf
+    // life for the rate-limited bucket.
+    const ttlMs = ttl ?? FRESH_TTL_MS;
 
     // Rate-limit cooling: stop issuing for this bucket, serve last-known.
     if ((coolingUntil.get(bucket) ?? 0) > now()) {
@@ -91,10 +103,10 @@ export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } 
       throw new ForgeRateLimitedError(url);
     }
 
-    // Freshness window: a value fetched within FRESH_TTL_MS is served from
+    // Freshness window: a value fetched within ttlMs is served from
     // memory with zero network requests.
     const hit = etagStore.get(url);
-    if (hit && now() - hit.at < FRESH_TTL_MS) {
+    if (hit && now() - hit.at < ttlMs) {
       return { data: hit.data, stale: false };
     }
 
@@ -232,7 +244,7 @@ export function createForgeRuntime({ fetch = globalThis.fetch } = {}) {
     getAdapter(kind, token) {
       const create = ADAPTERS[kind];
       if (!create) throw unsupportedByForge(kind, "read path");
-      const request = (url) => requestLayer.getJson(url, { token });
+      const request = (url, opts) => requestLayer.getJson(url, { token, ttl: opts?.ttl });
       const requestWrite = (url, opts) => requestLayer.requestJson(url, { token, ...opts });
       const requestText = (url) => requestLayer.getText(url, { token });
       return create(request, requestWrite, requestText);
@@ -499,6 +511,102 @@ export async function pullRequestForCwd(cwd, deps = {}) {
   }
 
   return { pr, checks, rollup: rollupChecks(checks), stale: staleChecks, error: null };
+}
+
+// ---- Inbox seed prompt (BET-795) ----------------------------------------
+//
+// The template "Start a session" seeds the first prompt from. `{{url}}` is the
+// placeholder filled with the work item's URL. Defined ONCE here and exported
+// so the per-repo rules file (rules-engine issue) reads the SAME constant as
+// its default — one default, not two.
+export const INBOX_SEED_PROMPT = "Complete {{url}}";
+
+// Fill INBOX_SEED_PROMPT for one inbox item. Exported for tests.
+export function seedPromptFor(item, template = INBOX_SEED_PROMPT) {
+  return template.replace("{{url}}", item?.url ?? "");
+}
+
+// ---- Box-facing read: forge:inbox (BET-795) ------------------------------
+//
+// The work inbox: issues assigned to you + PRs awaiting your review + your own
+// open PRs whose checks are red — ONE cross-repo list, answered by three SEARCH
+// queries (spec §4.5④). All forge access is box-side: `resolveToken` provides
+// the token to the shared request layer and it never reaches the renderer.
+// Results are deduplicated by the adapter's precedence rule (a PR matching two
+// queries appears once, most urgent reason wins) and sorted by updatedAt desc.
+//
+// The checks-failing population needs each candidate PR's checks, so it is
+// fetched per-PR AFTER the search (a search result can't tell you checks) and
+// only PRs whose rollup is red are kept — but it is NEVER per-repo iteration.
+async function defaultForgeInbox(deps) {
+  const resolveToken = deps.resolveToken ?? authResolveToken;
+  const getAdapterFn = deps.getAdapter ?? getAdapter;
+
+  const tok = await resolveToken(GH_HOST);
+  if (!tok) return { items: [], stale: false, error: "not_connected" };
+
+  const adapter = getAdapterFn("github", tok.token);
+  const populations = [];
+  let stale = false;
+
+  for (const { query, reason } of buildInboxQueries()) {
+    try {
+      const res = await adapter.searchIssues(query, { ttl: INBOX_TTL_MS });
+      stale = stale || Boolean(res.stale);
+      const hits = (Array.isArray(res.data) ? res.data : []).map((h) =>
+        h && typeof h === "object" ? { ...h, reason } : h,
+      );
+      // The checks-failing population: keep only my open PRs whose CI is red.
+      const kept =
+        reason === "checks failing"
+          ? await keepRedPrs(hits, adapter)
+          : hits;
+      populations.push(kept);
+    } catch (err) {
+      if (err instanceof ForgeRateLimitedError) {
+        // A rate-limited search bucket is not an inbox failure — serve what we
+        // have (possibly nothing splus stale) rather than blanking the panel.
+        stale = true;
+        continue;
+      }
+      throw err;
+    }
+  }
+
+  const items = mergeInboxSources(populations).sort((a, b) => b.updatedAt - a.updatedAt);
+  return { items, stale, error: null };
+}
+
+// Keep only the PRs whose checks roll up red, fetching checks per PR against
+// its own repo (from the search hit's owner/repo). A PR whose checks can't be
+// fetched (no headSha, rate-limited, unreachable) is dropped — it cannot be
+// proven red, and a stale scan must not mislabel it. Best-effort: never throws.
+async function keepRedPrs(hits, adapter) {
+  const kept = [];
+  for (const hit of hits) {
+    if (hit.kind !== "pr") continue;
+    if (!hit.headSha || !hit.owner || !hit.repo) continue;
+    try {
+      const res = await adapter.getChecks({ owner: hit.owner, repo: hit.repo }, hit.headSha);
+      const checks = Array.isArray(res.data) ? res.data : [];
+      if (rollupChecks(checks) === "red") kept.push(hit);
+    } catch {
+      // checks unreachable — can't prove red, skip
+    }
+  }
+  return kept;
+}
+
+/**
+ * forge:inbox — the aggregated work inbox. Box-side read; a forge token never
+ * leaves the box. Returns `{ items, stale, error }` where `error` is
+ * "not_connected" when no GitHub token resolves (empty items) or null.
+ *
+ * @param {{ resolveToken?: typeof authResolveToken,
+ *          getAdapter?: (kind: string, token: string) => any }} [deps]
+ */
+export async function forgeInbox(deps = {}) {
+  return defaultForgeInbox(deps);
 }
 
 // ---- Box-facing writes (issue BET-794) --------------------------------------
@@ -959,4 +1067,5 @@ export async function draftSubmitForCwd(cwd, input = {}, deps = {}) {
  * @property {(repo: { owner: string, repo: string }, filter?: { state?: string }) => Promise<{ data: Array<any>, stale: boolean }>} listIssues
  * @property {(repo: { owner: string, repo: string }, sha: string) => Promise<{ data: Array<any>, stale: boolean }>} getChecks
  * @property {((repo: { owner: string, repo: string }, number: number) => Promise<{ data: { diff: string, threads: Array<any>, headSha: string }, stale: boolean }>)} [getDiff] — OPTIONAL. Presence is the capability model: an adapter without the diff/threads read simply omits it and the caller checks presence.
+ * @property {(query: string, opts?: { ttl?: number }) => Promise<{ data: Array<any>, stale: boolean }>} [searchIssues] — OPTIONAL. The cross-repo search read that powers the inbox (spec §4.5④). GitHub implements it; an adapter whose forge has no equivalent search surface omits it. Results are already normalised to the shared InboxItem shape.
  */

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -434,6 +434,42 @@ async function defaultCurrentBranch(cwd) {
   }
 }
 
+// The shared cwd → origin → forge → token → adapter scaffold that every
+// cwd-scoped forge read/write resolves. pullRequestForCwd, resolveWriteContext
+// (and its write/draft consumers) and forgeDiffForCwd all did this by hand;
+// one helper is the single copy of the "detect the repo's forge, resolve a
+// token, bind the adapter to it" preamble. Returns `{ forge, repo, token,
+// adapter }` or `{ error: "no_forge" | "not_connected" }`. `currentBranch`
+// stays with the callers that need it (it is not part of the shared detect).
+async function resolveForgeContext(cwd, deps) {
+  const gitRemoteOrigin = deps.gitRemoteOrigin ?? defaultGitRemoteOrigin;
+  const resolveToken = deps.resolveToken ?? authResolveToken;
+  const getAdapterFn = deps.getAdapter ?? getAdapter;
+
+  const origin = await gitRemoteOrigin(cwd);
+  const forge = origin ? detectForge(origin) : null;
+  if (!forge || forge.kind !== "github") return { error: "no_forge" };
+  const tok = await resolveToken(forge.host);
+  if (!tok) return { error: "not_connected" };
+  const adapter = getAdapterFn(forge.kind, tok.token);
+  const repo = { owner: forge.owner, repo: forge.repo };
+  return { forge, repo, token: tok, adapter };
+}
+
+// List a repo's open PRs the way both cwd-scoped readers do, normalising the
+// rate-limit guard once. A rate-limited list is not an error — it yields an
+// empty list flagged `rateLimited` so the caller can serve a stale result
+// rather than blanking the panel. A real network/HTTP failure still throws.
+async function listOpenPrs(adapter, repo) {
+  try {
+    const res = await adapter.listPullRequests(repo, { state: "open" });
+    return { prs: Array.isArray(res.data) ? res.data : [], stale: Boolean(res.stale) };
+  } catch (err) {
+    if (err instanceof ForgeRateLimitedError) return { rateLimited: true, prs: [], stale: true };
+    throw err;
+  }
+}
+
 /**
  * forge:pull-request — resolve `cwd → origin → repo`, pick the open PR on the
  * current branch (falling back to the first open PR), and return the
@@ -449,35 +485,14 @@ async function defaultCurrentBranch(cwd) {
  *          getAdapter?: (kind: string, token: string) => any }} [deps]
  */
 export async function pullRequestForCwd(cwd, deps = {}) {
-  const gitRemoteOrigin = deps.gitRemoteOrigin ?? defaultGitRemoteOrigin;
   const currentBranch = deps.currentBranch ?? defaultCurrentBranch;
-  const resolveToken = deps.resolveToken ?? authResolveToken;
-  const getAdapterFn = deps.getAdapter ?? getAdapter;
 
-  const origin = await gitRemoteOrigin(cwd);
-  const forge = origin ? detectForge(origin) : null;
-  if (!forge || forge.kind !== "github") {
-    return { ...EMPTY, error: "no_forge" };
-  }
+  const ctx = await resolveForgeContext(cwd, deps);
+  if (ctx.error) return { ...EMPTY, error: ctx.error };
+  const { adapter, repo } = ctx;
 
-  const tok = await resolveToken(forge.host);
-  if (!tok) return { ...EMPTY, error: "not_connected" };
-
-  const adapter = getAdapterFn(forge.kind, tok.token);
-  const repo = { owner: forge.owner, repo: forge.repo };
-
-  let prArr = [];
-  let stale = false;
-  try {
-    const res = await adapter.listPullRequests(repo, { state: "open" });
-    prArr = Array.isArray(res.data) ? res.data : [];
-    stale = res.stale;
-  } catch (err) {
-    if (err instanceof ForgeRateLimitedError) {
-      return { ...EMPTY, stale: true };
-    }
-    throw err;
-  }
+  const { prs: prArr, stale, rateLimited } = await listOpenPrs(adapter, repo);
+  if (rateLimited) return { ...EMPTY, stale: true };
 
   if (prArr.length === 0) return { ...EMPTY, stale };
 
@@ -624,18 +639,11 @@ export async function forgeInbox(deps = {}) {
 // token, head }` or a `{ error }` result. `head` is the current branch (the
 // thing we push and open a PR from).
 async function resolveWriteContext(cwd, deps, wantBranch = true) {
-  const gitRemoteOrigin = deps.gitRemoteOrigin ?? defaultGitRemoteOrigin;
   const currentBranch = deps.currentBranch ?? defaultCurrentBranch;
-  const resolveToken = deps.resolveToken ?? authResolveToken;
-  const getAdapterFn = deps.getAdapter ?? getAdapter;
 
-  const origin = await gitRemoteOrigin(cwd);
-  const forge = origin ? detectForge(origin) : null;
-  if (!forge || forge.kind !== "github") return { error: "no_forge" };
-  const tok = await resolveToken(forge.host);
-  if (!tok) return { error: "not_connected" };
-  const adapter = getAdapterFn(forge.kind, tok.token);
-  const repo = { owner: forge.owner, repo: forge.repo };
+  const ctx = await resolveForgeContext(cwd, deps);
+  if (ctx.error) return { error: ctx.error };
+  const { forge, repo, adapter } = ctx;
   let head = null;
   if (wantBranch) {
     head = await currentBranch(cwd);
@@ -857,35 +865,15 @@ export async function mergePullRequest(cwd, { number, method = "merge", sha } = 
  *          getAdapter?: (kind: string, token: string) => any }} [deps]
  */
 export async function forgeDiffForCwd(cwd, deps = {}) {
-  const gitRemoteOrigin = deps.gitRemoteOrigin ?? defaultGitRemoteOrigin;
   const currentBranch = deps.currentBranch ?? defaultCurrentBranch;
-  const resolveToken = deps.resolveToken ?? authResolveToken;
-  const getAdapterFn = deps.getAdapter ?? getAdapter;
 
-  const origin = await gitRemoteOrigin(cwd);
-  const forge = origin ? detectForge(origin) : null;
-  if (!forge || forge.kind !== "github") {
-    return { diff: "", threads: [], headSha: "", error: "no_forge" };
-  }
+  const ctx = await resolveForgeContext(cwd, deps);
+  if (ctx.error) return { diff: "", threads: [], headSha: "", error: ctx.error };
+  const { adapter, repo } = ctx;
 
-  const tok = await resolveToken(forge.host);
-  if (!tok) return { diff: "", threads: [], headSha: "", error: "not_connected" };
+  const { prs: prArr, stale, rateLimited } = await listOpenPrs(adapter, repo);
+  if (rateLimited) return { diff: "", threads: [], headSha: "", error: null, stale: true };
 
-  const adapter = getAdapterFn(forge.kind, tok.token);
-  const repo = { owner: forge.owner, repo: forge.repo };
-
-  let prArr = [];
-  let stale = false;
-  try {
-    const res = await adapter.listPullRequests(repo, { state: "open" });
-    prArr = Array.isArray(res.data) ? res.data : [];
-    stale = res.stale;
-  } catch (err) {
-    if (err instanceof ForgeRateLimitedError) {
-      return { diff: "", threads: [], headSha: "", error: null, stale: true };
-    }
-    throw err;
-  }
   if (prArr.length === 0) return { diff: "", threads: [], headSha: "", error: "no_pr" };
 
   const branch = await currentBranch(cwd);

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -554,7 +554,9 @@ async function defaultForgeInbox(deps) {
       const res = await adapter.searchIssues(query, { ttl: INBOX_TTL_MS });
       stale = stale || Boolean(res.stale);
       const hits = (Array.isArray(res.data) ? res.data : []).map((h) =>
-        h && typeof h === "object" ? { ...h, reason } : h,
+        h && typeof h === "object"
+          ? { ...h, reason, seed: seedPromptFor(h) }
+          : h,
       );
       // The checks-failing population: keep only my open PRs whose CI is red.
       const kept =
@@ -573,7 +575,9 @@ async function defaultForgeInbox(deps) {
     }
   }
 
-  const items = mergeInboxSources(populations).sort((a, b) => b.updatedAt - a.updatedAt);
+  const items = mergeInboxSources(populations)
+    .map((it) => ({ ...it, rollup: it.reason === "checks failing" ? "red" : "none" }))
+    .sort((a, b) => b.updatedAt - a.updatedAt);
   return { items, stale, error: null };
 }
 

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -495,6 +495,26 @@ function draftKit({ prs = [OPEN_PR], headSha = "abc", adapter } = {}) {
   return deps;
 }
 
+// Shared draft-submit test adapter: the forge-read half (list/get the PR) is
+// identical for every submit test; only submitReview differs, so it is the one
+// injected argument.
+function submitAdapter(submitReview) {
+  return {
+    kind: "github",
+    listPullRequests: async () => ({ data: [OPEN_PR], stale: false }),
+    getPullRequest: async () => ({ data: { ...OPEN_PR, headSha: "abc" }, stale: false }),
+    submitReview,
+  };
+}
+
+// Seed a draft with comments through the real draftCommentForCwd path, so the
+// multi-add setup never has to be written out per test.
+async function addComments(k, comments) {
+  for (const comment of comments) {
+    await draftCommentForCwd("/repo", { op: "add", comment }, k);
+  }
+}
+
 const DRAFT_REPO_KEY = "github.com/acme/widget";
 
 test("draftGetForCwd: head SHA moved → draft marked stale, comments kept", async () => {
@@ -534,19 +554,17 @@ test("draftCommentForCwd: add + set-verdict persist box-side", async () => {
 
 test("draftSubmitForCwd: flushes EVERY buffered comment as ONE review with correct anchors, then clears", async () => {
   let submitted = null;
-  const adapter = {
-    kind: "github",
-    listPullRequests: async () => ({ data: [OPEN_PR], stale: false }),
-    getPullRequest: async () => ({ data: { ...OPEN_PR, headSha: "abc" }, stale: false }),
-    submitReview: async (repo, n, input) => {
+  const k = draftKit({
+    adapter: submitAdapter(async (repo, n, input) => {
       submitted = { repo, n, input };
       return { data: {}, stale: false };
-    },
-  };
-  const k = draftKit({ adapter });
-  await draftCommentForCwd("/repo", { op: "add", comment: { path: "a.ts", line: 1, side: "new", body: "c1" } }, k);
-  await draftCommentForCwd("/repo", { op: "add", comment: { path: "a.ts", line: 2, side: "old", body: "c2" } }, k);
-  await draftCommentForCwd("/repo", { op: "add", comment: { path: "b.ts", line: 5, side: "new", startLine: 3, body: "c3" } }, k);
+    }),
+  });
+  await addComments(k, [
+    { path: "a.ts", line: 1, side: "new", body: "c1" },
+    { path: "a.ts", line: 2, side: "old", body: "c2" },
+    { path: "b.ts", line: 5, side: "new", startLine: 3, body: "c3" },
+  ]);
 
   const r = await draftSubmitForCwd("/repo", { verdict: "approved" }, k);
   assert.equal(r.ok, true);
@@ -567,19 +585,17 @@ test("draftSubmitForCwd: flushes EVERY buffered comment as ONE review with corre
 });
 
 test("draftSubmitForCwd: a failed submit returns a typed error and leaves the draft intact", async () => {
-  const adapter = {
-    kind: "github",
-    listPullRequests: async () => ({ data: [OPEN_PR], stale: false }),
-    getPullRequest: async () => ({ data: { ...OPEN_PR, headSha: "abc" }, stale: false }),
-    submitReview: async () => {
+  const k = draftKit({
+    adapter: submitAdapter(async () => {
       const e = new Error("review failed");
       e.kind = "http_422";
       throw e;
-    },
-  };
-  const k = draftKit({ adapter });
-  await draftCommentForCwd("/repo", { op: "add", comment: { path: "a.ts", line: 1, side: "new", body: "c1" } }, k);
-  await draftCommentForCwd("/repo", { op: "add", comment: { path: "a.ts", line: 2, side: "new", body: "c2" } }, k);
+    }),
+  });
+  await addComments(k, [
+    { path: "a.ts", line: 1, side: "new", body: "c1" },
+    { path: "a.ts", line: 2, side: "new", body: "c2" },
+  ]);
 
   const r = await draftSubmitForCwd("/repo", {}, k);
   assert.equal(r.ok, false);

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -19,6 +19,9 @@ import {
   draftGetForCwd,
   draftCommentForCwd,
   draftSubmitForCwd,
+  forgeInbox,
+  seedPromptFor,
+  INBOX_SEED_PROMPT,
   ForgeRateLimitedError,
 } from "./index.mjs";
 import { getDraft, putComment } from "./draft.mjs";
@@ -632,4 +635,93 @@ test("forgeDeviceStart: placeholder client_id surfaces a notConfigured state (gu
   assert.equal(r.connected, false);
   assert.equal(r.notConfigured, true);
   assert.equal(r.grant, null);
+});
+
+// ---- forge:inbox (BET-795) -------------------------------------------------
+
+test("forgeInbox: not_connected → empty items, no adapter call", async () => {
+  let called = false;
+  const r = await forgeInbox({
+    resolveToken: async () => null,
+    getAdapter: () => {
+      called = true;
+      return {};
+    },
+  });
+  assert.equal(r.error, "not_connected");
+  assert.deepEqual(r.items, []);
+  assert.equal(called, false);
+});
+
+test("forgeInbox: three search queries (60s ttl), keeps only red PRs, dedupes + sorts by updatedAt desc", async () => {
+  const searched = [];
+  const checksBySha = { red1: ["bad"], green1: ["good"] };
+  const adapter = {
+    searchIssues: async (query, opts) => {
+      searched.push({ query, ttl: opts?.ttl });
+      const hit = (num, title, kind, sha, updatedAt) => ({
+        kind, owner: "acme", repo: "widget", repoKey: "github.com/acme/widget",
+        number: num, title, url: `https://github.com/acme/widget/pull/${num}`,
+        state: "open", updatedAt, headSha: sha, reason: "assigned",
+      });
+      if (query === "assignee:@me") {
+        return { data: [hit(1, "issue a", "issue", "", 100)], stale: false };
+      }
+      if (query === "review-requested:@me") {
+        // Only PR 9 is awaiting my review.
+        return { data: [hit(9, "pr awaiting", "pr", "red1", 500)], stale: false };
+      }
+      // author:@me is:open — my open PRs; the inbox keeps only the red ones
+      // (green PR 3 must be excluded).
+      return { data: [hit(9, "pr awaiting", "pr", "red1", 500), hit(3, "green pr", "pr", "green1", 300)], stale: false };
+    },
+    getChecks: async (repo, sha) => {
+      const list = checksBySha[sha] ?? [];
+      return { data: list.map((c) => ({ name: c, status: "completed", conclusion: c === "bad" ? "failure" : "success" })), stale: false };
+    },
+  };
+  const r = await forgeInbox({
+    resolveToken: async () => ({ token: "t", source: "cli" }),
+    getAdapter: () => adapter,
+  });
+  // Every query carries the 60s freshness override (the search bucket's own
+  // lower rate limit) — the acceptance criterion's "no second round inside 60s".
+  assert.equal(searched.length, 3);
+  for (const s of searched) assert.equal(s.ttl, 60000);
+  assert.deepEqual(searched.map((s) => s.query), ["assignee:@me", "review-requested:@me", "author:@me is:open"]);
+
+  // PR 9 matches two queries (review-requested AND author is:open with red
+  // checks) but must appear once, with the more urgent reason winning. The
+  // green PR 3 (from the author query) is excluded — its checks aren't red.
+  assert.equal(r.error, null);
+  const nums = r.items.map((i) => i.number);
+  assert.deepEqual(nums, [9, 1], "9 (500) sorts before 1 (100); green PR 3 is excluded");
+
+  const pr9 = r.items.find((i) => i.number === 9);
+  assert.equal(pr9.reason, "checks failing", "red-checks beats review-requested, and it appears exactly once");
+  assert.equal(pr9.kind, "pr");
+  const issue1 = r.items.find((i) => i.number === 1);
+  assert.equal(issue1.reason, "assigned");
+});
+
+test("request layer: a resource fetched with a 60s ttl issues no second request inside 60s", async () => {
+  const c = clock();
+  let fetches = 0;
+  const fetch = async () => {
+    fetches++;
+    return json({ items: [{ id: 1 }] }, 200, { etag: "\"e1\"" });
+  };
+  const layer = createRequestLayer({ fetch, now: c.now });
+  await layer.getJson("https://api.github.com/search/issues?q=x", { token: "t", ttl: 60000 });
+  // 30s later — inside the inbox's 60s shelf life — a second call serves from
+  // memory with ZERO network requests.
+  c.advance(30_000);
+  await layer.getJson("https://api.github.com/search/issues?q=x", { token: "t", ttl: 60000 });
+  assert.equal(fetches, 1, "opening the inbox twice inside 60s issues no second round of requests");
+});
+
+test("seedPromptFor fills the {{url}} placeholder from the shared template", () => {
+  assert.equal(INBOX_SEED_PROMPT, "Complete {{url}}");
+  assert.equal(seedPromptFor({ url: "https://github.com/acme/widget/issues/5" }), "Complete https://github.com/acme/widget/issues/5");
+  assert.equal(seedPromptFor({ url: "u" }, "Fix {{url}}"), "Fix u");
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -29,7 +29,7 @@ import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import { searchMessages } from "./messageSearch.mjs";
 import { MIN_CLIENT } from "./version.mjs";
-import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
+import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
 import { listRules as forgeListRules } from "./forgeRules.mjs";
 import { invalidateToken as invalidateForgeToken } from "./forge/auth.mjs";
 import { parseRules as parseForgeRules } from "../shared/forgeRules.mjs";
@@ -358,6 +358,11 @@ export function buildHandlers({
       invalidateForgeToken(GH_HOST);
       return { ok: true };
     },
+
+    // BET-795: forge:inbox — the aggregated work inbox. Box-side read; three
+    // cross-repo SEARCH queries (assigned, review-requested, my red PRs),
+    // cached a full 60s on the search bucket. No per-repo iteration.
+    "forge:inbox": () => forgeInbox(),
 
     // BET-794: forge write path. Both box-side — a forge token never reaches
     // the renderer; the server resolves it. forge:ship previews/creates a PR

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -1024,9 +1024,12 @@ export function buildHandlers({
 
     // ---- background jobs (manta-server owned; in-process on mobile) ----
     // Mirror of the /api/delegate REST surface for the renderer. Jobs are
-    // CREATED by the AI tool (Stage 3), NOT by the UI — there is deliberately
-    // no `delegate:create` channel. list/stop/delete route to the engine
-    // wired in src/server/index.mjs (createDelegateEngine). Stop/delete
+    // CREATED by the AI tool, and — since BET-795 — by the work inbox's
+    // "Delegate in background" row action, which routes through the SAME
+    // engine (createDelegateEngine wired in src/server/index.mjs) as the
+    // REST surface. Start goes through `startJob` exactly as the REST POST
+    // does; an inbox delegation declares no tools, so no pre-flight approval
+    // card is raised. list/stop/delete route to the engine too. Stop/delete
     // publish delegate.updated so a future UI card refetches live.
     // preload: ipcRenderer.invoke(IPC.delegateList, sessionId) → args[0] = sessionId?
     "delegate:list": (sessionId) =>
@@ -1035,6 +1038,20 @@ export function buildHandlers({
     "delegate:stop": (id) => (delegate ? delegate.stopJob(id) : { ok: false, error: "no engine" }),
     // preload: ipcRenderer.invoke(IPC.delegateDelete, id) → args[0] = id
     "delegate:delete": (id) => (delegate ? delegate.deleteJob(id) : { ok: false, error: "no engine" }),
+    // preload: ipcRenderer.invoke(IPC.delegateStart, input) → args[0] = { prompt, sessionID, directory, model? }
+    // BET-795 inbox "Delegate in background": starts a background job through
+    // the existing delegate engine (own worktree + branch + rail row) instead
+    // of a foreground session. Same engine, same store, same completion path.
+    "delegate:start": (input) => {
+      const i = typeof input === "object" && input !== null ? input : {};
+      if (!delegate) return { ok: false, error: "no engine" };
+      return delegate.startJob({
+        prompt: i.prompt,
+        model: i.model,
+        parentSessionID: i.sessionID,
+        parentDirectory: i.directory,
+      });
+    },
 
     // ---- session progress (manta-server owned; BET-790) ----
     // Read-only: the durable progress record for a session (written by the AI's

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -850,3 +850,37 @@ test("tmux:select-window triggers exactly one syncState.refreshNow", async () =>
   assert.equal(calls.refreshNow, 1);
   assert.deepEqual(out, { selected: { sessionName: "s", windowIndex: 2 } });
 });
+
+// BET-795: the work inbox's "Delegate in background" must route through the
+// existing delegate engine (spec §3), not a foreground session.
+test("delegate:start routes the inbox delegation through the delegate engine + clear no-engine fallback", async () => {
+  let startCalled = null;
+  const { deps } = makeDeps([]);
+  deps.delegate = {
+    startJob: async (input) => {
+      startCalled = input;
+      return { ok: true, job: { id: "jid" } };
+    },
+  };
+  const handlers = buildHandlers(deps);
+  const res = await handlers["delegate:start"]({
+    prompt: "Complete u",
+    sessionID: "ses_active",
+    directory: "/repo",
+  });
+  assert.equal(res.ok, true);
+  assert.deepEqual(startCalled, {
+    prompt: "Complete u",
+    model: undefined,
+    parentSessionID: "ses_active",
+    parentDirectory: "/repo",
+  });
+
+  const noEngine = await buildHandlers(makeDeps([]).deps)["delegate:start"]({
+    prompt: "x",
+    sessionID: "s",
+    directory: "/",
+  });
+  assert.equal(noEngine.ok, false);
+  assert.equal(noEngine.error, "no engine");
+});

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -47,6 +47,8 @@ import type {
   ForgeDiffResult,
   ForgeDisconnectResult,
   ForgeRuleRow,
+  ForgeInboxItem,
+  ForgeInboxResult,
   ForgeShipInput,
   ForgeShipResult,
   ForgeShipPreviewInput,
@@ -197,6 +199,9 @@ export interface Api {
   forgeStatus(): Promise<ForgeStatusResult>;
   forgePullRequest(input: { cwd: string }): Promise<ForgePullRequestResult>;
   forgeDiff(input: { cwd: string }): Promise<ForgeDiffResult>;
+  // BET-795: the work inbox. Box-side only — three cross-repo SEARCH queries,
+  // never per-repo iteration, cached a full 60s on the search bucket.
+  forgeInbox(): Promise<ForgeInboxResult>;
 
   // BET-794: forge write path (box-side only — a token never leaves the box).
   // forgeShip pushes the current branch then opens a PR — this is called ONLY

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -47,7 +47,6 @@ import type {
   ForgeDiffResult,
   ForgeDisconnectResult,
   ForgeRuleRow,
-  ForgeInboxItem,
   ForgeInboxResult,
   ForgeShipInput,
   ForgeShipResult,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -48,6 +48,8 @@ import type {
   ForgeDisconnectResult,
   ForgeRuleRow,
   ForgeInboxResult,
+  DelegateStartInput,
+  DelegateStartResult,
   ForgeShipInput,
   ForgeShipResult,
   ForgeShipPreviewInput,
@@ -496,6 +498,7 @@ export interface Api {
   // worktree is refused with {ok:false, reason:"dirty"} and the record kept.
   // No create channel — jobs are started by the AI's `delegate` opencode tool.
   delegateList(sessionId?: string): Promise<DelegateJob[]>;
+  delegateStart(input: DelegateStartInput): Promise<DelegateStartResult>;
   delegateStop(id: string): Promise<{ ok: boolean; error?: string; reason?: string }>;
   delegateDelete(id: string): Promise<{ ok: boolean; error?: string; reason?: string }>;
   // BET-418 §A pre-flight approval: the renderer polls pending approvals for

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -534,6 +534,40 @@ export type ForgeDiffResult = {
   error: "no_forge" | "not_connected" | "no_pr" | null;
 };
 
+// ----- Work inbox (BET-795) -----
+
+// Why an item is in the inbox. This is the value the row's secondary column
+// largely spells out (the label mapping lives in chatUtils.inboxReasonLabel),
+// and it is what the row ultimately displays.
+export type InboxReason = "assigned" | "review requested" | "checks failing";
+
+// One cross-repo work-inbox row. Three populations, one list: issues assigned
+// to you, PRs awaiting your review, your own open PRs whose checks are red.
+// `repoKey` is host/owner/repo (the join key). `rollup` is the CI traffic-light
+// for a PR row (the checks-red population's reason to be here); "none" for an
+// assigned issue. `reason` is the population that claimed it — the merge rule
+// gives a PR matching two queries its more urgent reason.
+export type ForgeInboxItem = {
+  kind: "issue" | "pr";
+  repoKey: string;
+  number: number;
+  title: string;
+  url: string;
+  state: string;
+  rollup: string;
+  updatedAt: number;
+  reason: InboxReason;
+};
+
+// forge:inbox result. `items` are sorted by updatedAt desc. `error` is
+// "not_connected" when the box has no GitHub token (items empty) or null.
+// `stale` is true when any population was served from last-known state.
+export type ForgeInboxResult = {
+  items: ForgeInboxItem[];
+  stale: boolean;
+  error: "not_connected" | null;
+};
+
 // ----- Forge write path (BET-794) -----
 
 // forge:ship input — push the current branch then (only after the renderer's
@@ -905,6 +939,10 @@ export const IPC = {
   forgeStatus: "forge:status",
   forgePullRequest: "forge:pull-request",
   forgeDiff: "forge:diff",
+
+  // BET-795: forge:inbox — the aggregated work inbox (assigned issues + review
+  // requests + my red PRs). Box-side only; three cross-repo SEARCH queries.
+  forgeInbox: "forge:inbox",
 
   // BET-794: forge write path. Both box-side only — the renderer never sees a
   // forge token. forge:ship pushes the current branch then opens a PR (only

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -557,6 +557,10 @@ export type ForgeInboxItem = {
   rollup: string;
   updatedAt: number;
   reason: InboxReason;
+  // The seeded first prompt for "Start a session" — built box-side from the
+  // single INBOX_SEED_PROMPT constant so the renderer never constructs its own
+  // "Complete {{url}}" copy (one default, not two).
+  seed: string;
 };
 
 // forge:inbox result. `items` are sorted by updatedAt desc. `error` is

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1302,6 +1302,7 @@ export const IPC = {
   // window + worktree (force:false — refuses a dirty worktree with
   // {ok:false, reason:"dirty"}) and drops the record.
   delegateList: "delegate:list", // (sessionId?) → DelegateJob[]
+  delegateStart: "delegate:start", // ({prompt, sessionID, directory, model?}) → { ok, error? } — BET-795 inbox Delegate in background
   delegateStop: "delegate:stop", // (id) → { ok: boolean, error?: string, reason?: string }
   delegateDelete: "delegate:delete", // (id) → { ok: boolean, error?: string, reason?: string }
   delegatePendingApprovals: "delegate:pending-approvals", // (sessionId?) → DelegateApproval[]
@@ -1656,6 +1657,20 @@ export type DelegateApproval = {
   tools: DelegateApprovalTool[];
   createdAt: number;
 };
+
+// BET-795: the work inbox's "Delegate in background" starts a background job
+// through the existing delegate engine. `sessionID` is the parent (active)
+// chat session the job nests under; `directory` is the repo the worktree is
+// created in; `prompt` is the seeded instruction. Mirrors the /api/delegate
+// POST body. Result is { ok } or { ok:false, error } (e.g. no parent session,
+// at the MAX_RUNNING_JOBS cap, or the caller isn't a chat session).
+export type DelegateStartInput = {
+  prompt: string;
+  sessionID: string;
+  directory: string;
+  model?: { providerID?: string; modelID?: string } | null;
+};
+export type DelegateStartResult = { ok: boolean; error?: string };
 
 // ----- Agent → laptop file push (outbox) -----
 


### PR DESCRIPTION
Implements the work inbox (spec §4.5④): assigned issues + review requests + your own red-check PRs, in ONE cross-repo list reached from ⌘K.

## What

**Server (box-side, token never leaves the box)**
- `github.mjs`: `searchIssues()` on `GET /search/issues`, plus the pure `buildInboxQueries()` (the three `@me` queries), `normalizeSearchHit()`, and `mergeInboxSources()` (dedupe-with-reason-precedence). No per-repo iteration — three search requests answer the whole inbox regardless of repo count.
- `index.mjs`: `forgeInbox()` box-facing read. Runs the three queries with a **60s freshness TTL** on the search bucket (reuses the ONE request layer — no second cache/backoff), fetches each of my open PR's checks and keeps only the RED ones, merges + dedupes, sorts by `updatedAt` desc. Exports the single `INBOX_SEED_PROMPT = "Complete {{url}}"` constant (+ `seedPromptFor`) that the rules-engine issue will read as its default — one default, not two.
- `rpc.mjs`: `forge:inbox` channel.

**Renderer**
- `InboxPalette.tsx` on the shared `PaletteShell`; rows are the shared `ListRow` (leading `StatusDot` tone-per-reason · title with inline `#`/`!` identifier · reason · repo · relative age). Actions under the list: `↵ Start a session` (Enter-key default), `Open review`, `Delegate in background`.
- **Start a session reuses the ONE creation path** (`tmuxNewSession` + `gitAddWorktree` + `deriveProjectName`/`uniqueSessionName` from `NewSessionScreen`): resolves the item's repo to a local path (cached repo probe), adds a worktree, creates the session, lands in it, and **seeds the composer with the prompt WITHOUT submitting** (new `seedPrompt` store → `ChatPanel` fills the input, never sends).
- Reachable from ⌘K: the command palette gets a pinned **Inbox** entry (index 0).

## Removal
Nothing to remove. This is a net-additive surface (the first inbox); the only new wiring is the one `forge:inbox` RPC + the `seedPrompt` one-shot on ChatPanel. No second creation flow, no second cache, no repo picker/board.

## Known limitations (filed as follow-ups)
- **"Start a session" needs the repo already cloned on the box** — the build resolves repoKey → local path via the repo probe and shows a clear error otherwise (cloning is explicitly out of scope for this issue).
- **"Open review"** currently opens the PR/issue URL — wiring the in-app review pane to an arbitrary cross-repo inbox PR needs the pane to accept a repo+number (the pane today is scoped to the current session's PR).
- **"Delegate in background"** reuses session-creation + auto-submit (the agent starts working immediately); routing it through the true background-job delegate engine needs a renderer RPC to *start* a delegate job (the opencode `delegate` tool is AI-facing only).

Base: `origin/main` @ 89f45a89
