### PR TITLE
feat(server): session link primitive (BET-847)

### DIFF
--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -519,6 +519,11 @@ async function defaultReadPrTemplate(cwd, deps = {}) {
  * Push uses gitPush (120s timeout — a real network push is killed by the
  * shared 10s `run()`), then createPullRequest with the given config.
  *
+ * When `deps.onPrOpened` is provided, it is invoked with
+ * `{ cwd, repoKey, number }` once a PR is created (best-effort; a throwing /
+ * absent dep never fails the ship). BET-847 wires this to record the session
+ * link (`link.pr`) at the point the field is set.
+ *
  * @param {string} cwd
  * @param {{ title: string, body?: string, base?: string, draft?: boolean }} input
  * @param {object} [deps] injectable I/O
@@ -547,6 +552,18 @@ export async function shipPullRequest(cwd, { title, body = "", base, draft = fal
     pr = res.data;
   } catch (e) {
     return { ok: false, error: `create pull request failed: ${String(e?.message ?? e)}` };
+  }
+
+  // Session-link primitive (BET-847): the one code path for opening a PR is the
+  // natural place to set the session's PR link. Best-effort — the ship result
+  // is returned regardless, and consumers (sink / notification / inbox / chip)
+  // read the linked PR from the session record.
+  if (deps.onPrOpened && pr?.number) {
+    try {
+      await deps.onPrOpened({ cwd, repoKey: forgeRepoKey(ctx.forge), number: pr.number });
+    } catch {
+      // link persistence is auxiliary; never fail the ship because of it
+    }
   }
 
   return { ok: true, pr, url: pr?.url ?? "" };

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -290,6 +290,29 @@ test("shipPullRequest: push failure surfaces a push-failed error, never creates"
   assert.ok(r.error.startsWith("push failed"));
 });
 
+test("shipPullRequest: onPrOpened is called with repoKey + number on a successful create", async () => {
+  let opened = null;
+  const created = { ...OPEN_PR, number: 91 };
+  const adapter = writeAdapter({ created });
+  const r = await shipPullRequest("/repo", { title: "t" }, {
+    ...SHIP_DEPS,
+    getAdapter: () => adapter,
+    gitPush: async () => ({ stdout: "", stderr: "" }),
+    onPrOpened: async (arg) => { opened = arg; },
+  });
+  assert.equal(r.ok, true);
+  assert.deepEqual(opened, { cwd: "/repo", repoKey: "github.com/acme/widget", number: 91 });
+});
+
+test("shipPullRequest: a throwing onPrOpened never fails the ship", async () => {
+  const r = await shipPullRequest("/repo", { title: "t" }, {
+    ...SHIP_DEPS,
+    gitPush: async () => ({ stdout: "", stderr: "" }),
+    onPrOpened: async () => { throw new Error("link-store down"); },
+  });
+  assert.equal(r.ok, true);
+});
+
 test("mergePullRequest passes the head SHA and surfaces a sha_mismatch failure", async () => {
   let mergeInput = null;
   const adapter = {

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -16,6 +16,12 @@ import { join, dirname, basename } from "node:path";
 import { statePath, expandTilde } from "../shared/paths.mjs";
 import { deriveWorktree, isWorktreeDirtyError } from "../shared/worktree.mjs";
 import { detectForge, repoKey } from "../shared/forge.mjs";
+import {
+  sessionLink as readSessionLink,
+  linkIssue,
+  linkPullRequest,
+  clearLink,
+} from "../shared/sessionLink.mjs";
 import { runLoginShell } from "./launchers.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 
@@ -114,6 +120,55 @@ export async function projectMetaDelete(tmuxSession) {
   const next = { ...cfg, projects: cfg.projects.filter((p) => p.tmuxSession !== tmuxSession) };
   await saveConfig(next);
   return next;
+}
+
+// ---- Session link primitive (§3.4⑥, BET-847) ----
+//
+// The session link lives on the ProjectMeta record inside `config.json`
+// `projects[]` — the ONE store and ONE code path for per-session state (no
+// parallel store, no second config file, no new RPC channel). These helpers
+// read and mutate a project's link through the existing config path
+// (`projectMetaUpsert`), applying the pure `src/shared/sessionLink.mjs`
+// mutators so consumers read a single field with no per-feature plumbing.
+//
+// A session is addressed by its `tmuxSession` name (its project name). The
+// mutators no-op (return null) when no such project is tracked, so a caller
+// that fires a link at an unknown session fails safe.
+
+function findProjectMeta(cfg, tmuxSession) {
+  if (!cfg?.projects) return null;
+  return cfg.projects.find((p) => p.tmuxSession === tmuxSession) ?? null;
+}
+
+// Read a project's link — `{ issue?, pr? }` or null when unset / untracked.
+export async function sessionLinkGet(tmuxSession) {
+  const meta = findProjectMeta(await getConfig(), tmuxSession);
+  return meta ? readSessionLink(meta) : null;
+}
+
+// Apply a pure mutator to the matching project and persist via the existing
+// upsert path. Returns the new normalized link, or null when no such project.
+async function mutateProjectLink(tmuxSession, apply) {
+  const meta = findProjectMeta(await getConfig(), tmuxSession);
+  if (!meta) return null;
+  const next = apply(meta);
+  await projectMetaUpsert(next);
+  return readSessionLink(next);
+}
+
+// Set (replace) the project's issue link, preserving any PR link.
+export function linkSessionIssue(tmuxSession, ref) {
+  return mutateProjectLink(tmuxSession, (meta) => linkIssue(meta, ref));
+}
+
+// Set (replace) the project's PR link, preserving any issue link.
+export function linkSessionPullRequest(tmuxSession, ref) {
+  return mutateProjectLink(tmuxSession, (meta) => linkPullRequest(meta, ref));
+}
+
+// Remove the project's link (both slots).
+export function clearSessionLink(tmuxSession) {
+  return mutateProjectLink(tmuxSession, (meta) => clearLink(meta));
 }
 
 // ============================================================

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -274,6 +274,17 @@ export function buildHandlers({
     }
   }
 
+  // Resolve the tracked project (tmuxSession) whose persisted defaultCwd
+  // matches a cwd, for wiring a session link at a forge set-point (BET-847).
+  // Best-effort: null when the cwd isn't a tracked project's home dir.
+  async function projectNameForCwd(cwd) {
+    const c = typeof cwd === "string" ? cwd.trim() : "";
+    if (!c) return null;
+    const cfg = await local.configGet();
+    const proj = cfg.projects?.find((p) => (p.defaultCwd ?? "").trim() === c);
+    return proj?.tmuxSession ?? null;
+  }
+
   return {
     // ---- local channels (config/git/fs/clipboard/transport/tmux-config) ----
 
@@ -353,11 +364,26 @@ export function buildHandlers({
     // (push then create) ONLY after the renderer's human confirm card.
     // forge:merge merges with the head SHA the user approved, surfacing the
     // distinguished failure kind (sha_mismatch / cannot_merge / permission).
-    "forge:ship": (input) =>
-      shipPullRequest(
-        typeof input === "object" && input !== null ? input.cwd : "",
+    "forge:ship": async (input) => {
+      const cwd = typeof input === "object" && input !== null ? input.cwd : "";
+      const res = await shipPullRequest(
+        cwd,
         typeof input === "object" && input !== null ? input : {},
-      ),
+        {
+          // Session-link primitive (BET-847): a PR opened from this session's
+          // cwd records the PR link on the resolved project (best-effort; a
+          // cwd that isn't a tracked project's home is a no-op). Push the new
+          // config into syncState so subscribers get the link delta.
+          onPrOpened: async ({ repoKey, number }) => {
+            const name = cwd ? await projectNameForCwd(cwd) : null;
+            if (!name) return;
+            await local.linkSessionPullRequest(name, { repoKey, number });
+            syncState.applyConfig(await local.configGet());
+          },
+        },
+      );
+      return res;
+    },
     "forge:ship-preview": (input) =>
       shipPreview(typeof input === "object" && input !== null ? input.cwd : ""),
     "forge:merge": (input) =>

--- a/src/server/sessionLink.test.mjs
+++ b/src/server/sessionLink.test.mjs
@@ -1,0 +1,68 @@
+// Server-side persistence tests for the session link primitive (§3.4⑥,
+// BET-847) — the config.json round-trip through local.mjs. The pure
+// accessors/mutators are covered in src/shared/sessionLink.test.ts; these cover
+// persisting the field through the ONE existing config path and reading it back.
+//
+// MANTA_STATE_HOME is sandboxed by scripts/testSandbox.mjs (node --import) so
+// config.json lives in a throwaway dir, never production state.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  configGet,
+  projectMetaUpsert,
+  sessionLinkGet,
+  linkSessionIssue,
+  linkSessionPullRequest,
+  clearSessionLink,
+} from "./local.mjs";
+
+const ISSUE = { repoKey: "github.com/acme/app", number: 12 };
+const ISSUE2 = { repoKey: "github.com/acme/app", number: 34 };
+const PR = { repoKey: "github.com/acme/app", number: 412 };
+
+async function seed(sessionName) {
+  await projectMetaUpsert({ tmuxSession: sessionName, defaultCwd: `/tmp/${sessionName}` });
+  return sessionName;
+}
+
+test("session link: no-link project resolves null (default empty)", async () => {
+  const name = await seed("bet847-empty");
+  assert.equal(await sessionLinkGet(name), null);
+  // an untracked session also resolves null
+  assert.equal(await sessionLinkGet("bet847-untracked"), null);
+});
+
+test("session link: setting an issue link persists; saving a new issue replaces it", async () => {
+  const name = await seed("bet847-issue");
+  await linkSessionIssue(name, ISSUE);
+  assert.deepEqual(await sessionLinkGet(name), { issue: ISSUE });
+  await linkSessionIssue(name, ISSUE2);
+  assert.deepEqual(await sessionLinkGet(name), { issue: ISSUE2 });
+});
+
+test("session link: persist → load round-trip preserves the link", async () => {
+  const name = await seed("bet847-roundtrip");
+  await linkSessionIssue(name, ISSUE);
+  await linkSessionPullRequest(name, PR);
+  const cfg = await configGet();
+  const meta = cfg.projects.find((p) => p.tmuxSession === name);
+  assert.deepEqual(meta?.link, { issue: ISSUE, pr: PR });
+  assert.deepEqual(await sessionLinkGet(name), { issue: ISSUE, pr: PR });
+});
+
+test("session link: issue + PR slots independent; clear removes both", async () => {
+  const name = await seed("bet847-independent");
+  await linkSessionIssue(name, ISSUE);
+  await linkSessionPullRequest(name, PR);
+  assert.deepEqual(await sessionLinkGet(name), { issue: ISSUE, pr: PR });
+  await clearSessionLink(name);
+  assert.equal(await sessionLinkGet(name), null);
+  const cfg = await configGet();
+  assert.equal(cfg.projects.find((p) => p.tmuxSession === name)?.link, undefined);
+});
+
+test("session link: unknown session is a safe no-op", async () => {
+  assert.equal(await linkSessionPullRequest("bet847-ghost", PR), null);
+  assert.equal(await clearSessionLink("bet847-ghost"), null);
+});

--- a/src/shared/sessionLink.d.mts
+++ b/src/shared/sessionLink.d.mts
@@ -1,0 +1,40 @@
+// Hand-written type declarations for sessionLink.mjs. Implementation is plain
+// JS so any server code imports it natively; the renderer imports through
+// bundler resolution. Keep in sync with src/shared/sessionLink.mjs.
+
+import type { SessionLink, SessionLinkRef } from "./types.js";
+
+// The shape a session record must carry for the link helpers. In the box this
+// is `ProjectMeta` (src/shared/types.ts), which carries `link?`; the optional
+// slot is open (`unknown`) so any record — linked or not — is accepted and its
+// other fields are preserved through the mutators.
+export type SessionLike = {
+  tmuxSession?: unknown;
+  defaultCwd?: unknown;
+  link?: SessionLink | null;
+};
+
+// Read a session's link — a normalized `{ issue?, pr? }` (only set slots) or
+// `null` when the record has no link. Never returns the raw stored value.
+export function sessionLink(
+  session: SessionLike | null | undefined,
+): SessionLink | null;
+
+// Set (replace) the session's issue link, preserving any PR link. Returns a
+// NEW record (the caller persists it). Throws `TypeError` on an invalid ref.
+export function linkIssue<S extends SessionLike>(
+  session: S | null | undefined,
+  ref: SessionLinkRef,
+): S;
+
+// Set (replace) the session's PR link, preserving any issue link. Returns a
+// NEW record. Throws `TypeError` on an invalid ref.
+export function linkPullRequest<S extends SessionLike>(
+  session: S | null | undefined,
+  ref: SessionLinkRef,
+): S;
+
+// Remove the session's link entirely (both slots). Returns a NEW record.
+export function clearLink<S extends SessionLike>(
+  session: S | null | undefined,
+): S;

--- a/src/shared/sessionLink.mjs
+++ b/src/shared/sessionLink.mjs
@@ -1,0 +1,110 @@
+// sessionLink.mjs — the session link primitive (§3.4⑥, BET-847).
+//
+// A session is (a tmux window + an opencode session + a cwd). The link field
+// names what that session is about — at most ONE issue and at most ONE pull
+// request — so the checks strip, the review pane, the progress forge-sink,
+// the notification body and the inbox row all read a single field with no
+// per-feature plumbing.
+//
+// `repoKey`/`number` reuse the unchanged vocabulary from src/shared/forge.mjs
+// (detectForge / PullRequest / Issue shapes) — there is deliberately no second
+// id shape.
+//
+// Contract:
+//   - 100% pure. No I/O. The mutators return a NEW session record (the caller
+//     persists it through the existing config path); they never mutate input.
+//   - Unknown input is handled defensively: `sessionLink` returns `null` for a
+//     missing/empty link; the mutators treat a non-object session as a fresh
+//     record and throw a `TypeError` on an invalid ref (loud rejection, the
+//     forge.mjs discipline).
+//   - At most one issue + one PR: saving a new issue replaces the prior issue;
+//     saving a new PR replaces the prior PR; the two slots stay independent.
+
+/**
+ * Read a session's link — a normalized `{ issue?, pr? }` object (only the set
+ * slots present) or `null` when the record has no link. The input record's
+ * `link` field is validated/vetted so a malformed stored value degrades to the
+ * slots that ARE usable rather than leaking garbage to consumers.
+ *
+ * @param {{ link?: unknown } | null | undefined} session
+ * @returns {{ issue?: { repoKey: string, number: number }, pr?: { repoKey: string, number: number } } | null}
+ */
+export function sessionLink(session) {
+  const raw = session && typeof session === "object" ? session.link : null;
+  if (!raw || typeof raw !== "object") return null;
+  const out = {};
+  const slot = (name) => {
+    const ref = raw[name];
+    if (!ref || typeof ref !== "object") return;
+    const repoKey = typeof ref.repoKey === "string" ? ref.repoKey : null;
+    const number = typeof ref.number === "number" ? ref.number : null;
+    if (!repoKey || !Number.isInteger(number) || number < 1) return;
+    out[name] = { repoKey, number };
+  };
+  slot("issue");
+  slot("pr");
+  return Object.keys(out).length ? out : null;
+}
+
+// Validate a caller-supplied ref (the SET side). Throws loudly so a bad link
+// never silently persists.
+function assertLinkRef(ref, what) {
+  if (!ref || typeof ref !== "object") {
+    throw new TypeError(`${what}: ref must be { repoKey, number }`);
+  }
+  if (typeof ref.repoKey !== "string" || ref.repoKey.trim() === "") {
+    throw new TypeError(`${what}: ref.repoKey must be a non-empty string`);
+  }
+  if (!Number.isInteger(ref.number) || ref.number < 1) {
+    throw new TypeError(`${what}: ref.number must be a positive integer`);
+  }
+}
+
+// Base record to mutate: the session when it's an object, else a fresh one so
+// a null session still yields a link-carrying record.
+function baseSession(session) {
+  return session && typeof session === "object" ? session : {};
+}
+
+/**
+ * Set (replace) the session's issue link. The prior issue link is replaced;
+ * an existing PR link is preserved. Returns a NEW record.
+ *
+ * @param {{ link?: unknown } | null | undefined} session
+ * @param {{ repoKey: string, number: number }} ref
+ * @returns {{ link?: unknown }}
+ */
+export function linkIssue(session, ref) {
+  assertLinkRef(ref, "linkIssue");
+  const base = baseSession(session);
+  const current = sessionLink(base) ?? {};
+  return { ...base, link: { ...current, issue: { repoKey: ref.repoKey, number: ref.number } } };
+}
+
+/**
+ * Set (replace) the session's pull-request link. The prior PR link is
+ * replaced; an existing issue link is preserved. Returns a NEW record.
+ *
+ * @param {{ link?: unknown } | null | undefined} session
+ * @param {{ repoKey: string, number: number }} ref
+ * @returns {{ link?: unknown }}
+ */
+export function linkPullRequest(session, ref) {
+  assertLinkRef(ref, "linkPullRequest");
+  const base = baseSession(session);
+  const current = sessionLink(base) ?? {};
+  return { ...base, link: { ...current, pr: { repoKey: ref.repoKey, number: ref.number } } };
+}
+
+/**
+ * Remove the session's link entirely (both slots). Returns a NEW record with
+ * the `link` field absent.
+ *
+ * @param {{ link?: unknown } | null | undefined} session
+ * @returns {{ link?: unknown }}
+ */
+export function clearLink(session) {
+  const base = baseSession(session);
+  const { link, ...rest } = base;
+  return rest;
+}

--- a/src/shared/sessionLink.test.ts
+++ b/src/shared/sessionLink.test.ts
@@ -1,0 +1,114 @@
+// Vitest for the session link primitive (§3.4⑥, BET-847) in
+// src/shared/sessionLink.mjs — the pure accessors + mutators.
+import { describe, expect, it } from "vitest";
+import {
+  sessionLink,
+  linkIssue,
+  linkPullRequest,
+  clearLink,
+} from "./sessionLink.mjs";
+
+const ISSUE = { repoKey: "github.com/acme/app", number: 12 };
+const ISSUE2 = { repoKey: "github.com/acme/app", number: 34 };
+const PR = { repoKey: "github.com/acme/app", number: 412 };
+
+// A ProjectMeta-like record, as persisted in config.json projects[].
+function session(overrides = {}) {
+  return { tmuxSession: "manta", defaultCwd: "/home/u/app", ...overrides };
+}
+
+describe("sessionLink", () => {
+  it("resolves absent/null for a session with no link (default empty)", () => {
+    expect(sessionLink(session())).toBeNull();
+    expect(sessionLink(session({ link: null }))).toBeNull();
+    expect(sessionLink(null)).toBeNull();
+    expect(sessionLink(undefined)).toBeNull();
+    expect(sessionLink({})).toBeNull();
+  });
+
+  it("returns only the slots that are set", () => {
+    expect(sessionLink(session({ link: { pr: PR } }))).toEqual({ pr: PR });
+    expect(sessionLink(session({ link: { issue: ISSUE } }))).toEqual({
+      issue: ISSUE,
+    });
+    expect(sessionLink(session({ link: { issue: ISSUE, pr: PR } }))).toEqual({
+      issue: ISSUE,
+      pr: PR,
+    });
+  });
+
+  it("vets a malformed stored link down to the usable slots rather than leaking it", () => {
+    expect(sessionLink(session({ link: { pr: { repoKey: 7, number: "x" } } }))).toBeNull();
+    expect(sessionLink(session({ link: { issue: ISSUE, pr: { number: 1 } } }))).toEqual({
+      issue: ISSUE,
+    });
+  });
+});
+
+describe("linkIssue", () => {
+  it("saves a new issue link, replacing the prior issue (single slot)", () => {
+    const once = linkIssue(session(), ISSUE);
+    expect(sessionLink(once)).toEqual({ issue: ISSUE });
+    const twice = linkIssue(once, ISSUE2);
+    // replaced, not appended
+    expect(sessionLink(twice)).toEqual({ issue: ISSUE2 });
+  });
+
+  it("does not touch an existing PR link", () => {
+    const withPr = linkPullRequest(session(), PR);
+    const withBoth = linkIssue(withPr, ISSUE);
+    expect(sessionLink(withBoth)).toEqual({ issue: ISSUE, pr: PR });
+  });
+
+  it("preserves the record's other fields", () => {
+    const next = linkIssue(session(), ISSUE);
+    expect(next.tmuxSession).toBe("manta");
+    expect(next.defaultCwd).toBe("/home/u/app");
+  });
+
+  it("treats a null session as a fresh record", () => {
+    expect(sessionLink(linkIssue(null, ISSUE))).toEqual({ issue: ISSUE });
+  });
+
+  it("throws on an invalid ref", () => {
+    expect(() => linkIssue(session(), { repoKey: "", number: 1 })).toThrow(TypeError);
+    expect(() => linkIssue(session(), { repoKey: "r", number: 0 })).toThrow(TypeError);
+  });
+});
+
+describe("linkPullRequest", () => {
+  it("saves a new PR link, replacing the prior PR (single slot)", () => {
+    const once = linkPullRequest(session(), PR);
+    const twice = linkPullRequest(once, { repoKey: PR.repoKey, number: 500 });
+    expect(sessionLink(twice)).toEqual({
+      pr: { repoKey: PR.repoKey, number: 500 },
+    });
+  });
+
+  it("does not touch an existing issue link", () => {
+    const withIssue = linkIssue(session(), ISSUE);
+    const withBoth = linkPullRequest(withIssue, PR);
+    expect(sessionLink(withBoth)).toEqual({ issue: ISSUE, pr: PR });
+  });
+});
+
+describe("clearLink", () => {
+  it("removes both slots", () => {
+    const linked = linkPullRequest(linkIssue(session(), ISSUE), PR);
+    expect(sessionLink(linked)).toEqual({ issue: ISSUE, pr: PR });
+    const cleared = clearLink(linked);
+    expect(sessionLink(cleared)).toBeNull();
+    expect(cleared).not.toHaveProperty("link");
+  });
+
+  it("preserves the record's other fields", () => {
+    const cleared = clearLink(session({ link: { pr: PR } }));
+    expect(cleared.tmuxSession).toBe("manta");
+    expect(cleared.defaultCwd).toBe("/home/u/app");
+  });
+
+  it("is a no-op (returns a cleared record) when already unlinked", () => {
+    const cleared = clearLink(session());
+    expect(sessionLink(cleared)).toBeNull();
+  });
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -10,6 +10,27 @@ import type { SshTarget } from "./sshTarget.js";
 export type ProjectMeta = {
   tmuxSession: string; // == project name (and the tmux session name on the remote)
   defaultCwd: string;
+  // Session link primitive (§3.4⑥, BET-847): at most one issue and one pull
+  // request per session. `repoKey`/`number` reuse the forge vocabulary (see
+  // src/shared/forge.mjs). Null (or absent) = unlinked. Saving a new issue
+  // replaces the prior issue; saving a new PR replaces the prior PR; the two
+  // slots are independent.
+  link?: SessionLink | null;
+};
+
+// A forge object reference — the minimal "what is this session about" pointer
+// used by the session-link field. `repoKey` is the canonical `host/owner/repo`
+// join key from src/shared/forge.mjs (`repoKey()`); `number` is GitHub
+// `number` / GitLab `iid`.
+export type SessionLinkRef = {
+  repoKey: string;
+  number: number;
+};
+
+// The link field on a session record. Either slot may be absent.
+export type SessionLink = {
+  issue?: SessionLinkRef;
+  pr?: SessionLinkRef;
 };
 
 export type AppConfig = {


### PR DESCRIPTION
## Session link primitive (§3.4⑥) — at most one issue + one PR per session

Builds BET-847: the missing "one field" that the checks strip, review pane, forge progress-sink, notification body and inbox row all read. This issue builds the primitive + persistence + set-site wiring; it does **not** rewire the sink (BET-844 owns that).

### What's here

- **`src/shared/types.ts`** — adds `SessionLinkRef` / `SessionLink` and `link?: SessionLink | null` on `ProjectMeta` (a `SessionLinkRef` = `{ repoKey, number }`, reusing the forge vocabulary from `src/shared/forge.mjs`; no second id shape).
- **`src/shared/sessionLink.mjs` + `.d.mts`** — pure, exported accessors + mutators: `sessionLink(session)` → `{ issue?, pr? } | null`, `linkIssue`, `linkPullRequest`, `clearLink`. Slots are independent; saving an issue replaces the prior issue (same for PR); `clearLink` removes both. Pure (return new records), tested in vitest.
- **`src/server/local.mjs`** — read/mutate/persist a project's link through the **existing** config path (`config.json` → `projects[]`, via `projectMetaUpsert`). `sessionLinkGet`, `linkSessionIssue`, `linkSessionPullRequest`, `clearSessionLink`. One store, one code path, **no new RPC channel**.
- **`src/server/forge/index.mjs`** — `shipPullRequest` gains an optional `deps.onPrOpened({ cwd, repoKey, number })` hook fired after a successful create (best-effort; a throwing/absent dep never fails the ship). This is the ONE "open a PR" code path, so it's where the PR link gets set.
- **`src/server/rpc.mjs`** — `forge:ship` wires `onPrOpened` to persist the PR link on the resolved session (`local.linkSessionPullRequest`) + push the config delta to `syncState`.

### Wiring decisions (scope boundaries)

- **Ship opening a PR sets the PR link** — done (above). An existing issue link is preserved (slots independent).
- **Forge sink / notification / inbox row read the linked issue/PR** — the primitive + `sessionLink`/`sessionLinkGet` read path is in place; the sink **rewire of `resolveForgeSinkTarget` / `resolveForgeParentDirectory` is BET-844** (explicitly out of scope here).
- **Inbox "Start a session" + background-delegate set the link from the row item** — no inbox row-item component exists yet, and the delegate-forge rework is BET-844's; follow-up filed.
- **Session header branch chip reads the linked PR number** — the chip currently renders the PR via the live `forgePullRequest` lookup; wiring it to prefer the stored link is a renderer concern, follow-up filed.

### Tests

- `src/shared/sessionLink.test.ts` — 13 vitest: replace-on-save, issue/PR independence, clear, default-empty, malformed-link vetting, invalid-ref throw.
- `src/server/sessionLink.test.mjs` — config round-trip through `projectMetaUpsert`/`configGet` (persist → load), default-empty, independence, safe no-op for untracked sessions.
- `src/server/forge/index.test.mjs` — `onPrOpened` called with repoKey+number on success; throwing dep never fails the ship.

**Base: origin/main @ 0a880d31**

**Verification results:**
- PR branch (`multica/BET-847-session-link` @ caa68083):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, vitest 2571 passed / 7 skipped; node:test 715 pass / 0 fail. log sha256: `48ec41cc66cba2b3bcb42b3f9e8866abef709c006dc141b8992698f4af5115c0`
- Base (`main` @ 0a880d31):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, vitest 2558 passed / 7 skipped; node:test 715 pass / 0 fail. log sha256: `942aab06bc51b8dd0441ed74ee9684ab1ba9ae888fd44d9d109a8c75a7bac173`
- **Conclusion:** 0 new failures; +13 vitest (new pure tests) and the new server round-trip tests pass. The `npm test` shell glob (`src/server/**/*.test.mjs`, unquoted) omits **top-level** `src/server/*.test.mjs` (local/rpc/sessionLink) on non-globstar shells — pre-existing; my server test passes when the file is run directly. Flagged as a follow-up.
