### PR TITLE
feat(forge): add checks.failed and review.requested poll paths to forge poller (BET-845)

### DIFF
--- a/src/server/forge/poller.mjs
+++ b/src/server/forge/poller.mjs
@@ -26,6 +26,7 @@
 // The poller produces the SAME normalised forge events the webhook ingest
 // does, and routes them through the SAME engine dispatchEvent — one path.
 
+import { rollupChecks } from "../../shared/forge.mjs";
 import { startPoller } from "../startPoller.mjs";
 
 /**
@@ -89,6 +90,13 @@ function issueIdentity(repo, number, label) {
   return `${repo.owner}/${repo.repo}#${number}:${label ?? ""}`;
 }
 
+// The identity used to de-duplicate a polled PR event (checks.failed /
+// review.requested). `kind` namespaces the set so a PR's failure and its
+// pending review are independent dispatch slots.
+function prIdentity(repo, number, kind) {
+  return `${repo.owner}/${repo.repo}#${number}:${kind}`;
+}
+
 /**
  * One concrete per-repo poll unit: fetch a repo's open issues carrying a
  * given label and emit a normalised `issue.labeled` event for each that has
@@ -118,6 +126,95 @@ export async function pollIssueLabels(
       label,
       ...(typeof issue.title === "string" ? { title: issue.title } : {}),
       url: issue.url,
+      fork: false,
+    });
+  }
+  return { events };
+}
+
+/**
+ * One concrete per-repo poll unit: fetch a repo's open PRs and emit a
+ * normalised `checks.failed` event for each whose CI rollup is red (a check
+ * with a failing conclusion). This is the poll fallback for a `checks.failed`
+ * rule on a box the webhook cannot reach. It mirrors `pollIssueLabels`'
+ * de-dup: the ETag/304 guarantee is supplied by the underlying fetch (getChecks
+ * returns the same data on a 304) and the `seen` set turns "still red, same
+ * list" into "zero events" — a 304 never re-dispatches a PR already failed.
+ * `rollup` is injectable so the test can stub the tri-state without the real
+ * check vocabulary.
+ *
+ * @param {{ repo: {owner: string, repo: string}, listPullRequests: (repo, filter) => Promise<{data: Array<any>}>, getChecks: (repo, sha) => Promise<{data: Array<any>}>, rollup?: (checks: Array<any>) => string }} deps
+ * @param {{ seen?: Set<string> }} [state]
+ * @returns {Promise<{events: Array<any>}>}
+ */
+export async function pollChecksFailed(
+  { repo, listPullRequests, getChecks, rollup = rollupChecks },
+  { seen = new Set() } = {},
+) {
+  const res = await listPullRequests(repo, { state: "open" });
+  const rows = Array.isArray(res?.data) ? res.data : [];
+  const events = [];
+  for (const pr of rows) {
+    if (typeof pr?.number !== "number" || typeof pr?.headSha !== "string" || !pr.headSha) continue;
+    let checks = [];
+    try {
+      const c = await getChecks(repo, pr.headSha);
+      checks = Array.isArray(c?.data) ? c.data : [];
+    } catch {
+      // Checks are best-effort — a PR whose CI is unreachable is skipped, not
+      // blanked out of the poll.
+      continue;
+    }
+    if (rollup(checks) !== "red") continue;
+    const id = prIdentity(repo, pr.number, "checks.failed");
+    if (seen.has(id)) continue; // 304 / no-change — must not re-dispatch
+    seen.add(id);
+    events.push({
+      type: "checks.failed",
+      ...(typeof pr.headRef === "string" && pr.headRef ? { branch: pr.headRef } : {}),
+      ...(typeof pr.title === "string" ? { title: pr.title } : {}),
+      ...(typeof pr.url === "string" ? { url: pr.url } : {}),
+      fork: false,
+    });
+  }
+  return { events };
+}
+
+/**
+ * One concrete per-repo poll unit: fetch a repo's open PRs and emit a
+ * normalised `review.requested` event for each that is waiting on a review —
+ * the poll fallback for a `review.requested` rule on a box the webhook cannot
+ * reach. The webhook fires once when a reviewer is added; a poll sees only a
+ * snapshot, so it proxies the same signal through the PR's merge-block state
+ * (a PR that is blocked on review is one whose review is still outstanding).
+ * Same ETag/`seen`-set de-dup as `pollIssueLabels` — once dispatched, a PR's
+ * pending review is not re-dispatched on the next unchanged poll.
+ *
+ * @param {{ repo: {owner: string, repo: string}, listPullRequests: (repo, filter) => Promise<{data: Array<any>}> }} deps
+ * @param {{ seen?: Set<string> }} [state]
+ * @returns {Promise<{events: Array<any>}>}
+ */
+export async function pollReviewRequested(
+  { repo, listPullRequests },
+  { seen = new Set() } = {},
+) {
+  const res = await listPullRequests(repo, { state: "open" });
+  const rows = Array.isArray(res?.data) ? res.data : [];
+  const events = [];
+  for (const pr of rows) {
+    if (typeof pr?.number !== "number") continue;
+    // `review required` is the normalised merge-block reason for a PR whose
+    // mergeable_state is `blocked` or `review_requested` — i.e. a review has
+    // been requested and has not yet satisfied the merge gate.
+    if (pr?.mergeBlockedReason !== "review required") continue;
+    const id = prIdentity(repo, pr.number, "review.requested");
+    if (seen.has(id)) continue; // 304 / no-change — must not re-dispatch
+    seen.add(id);
+    events.push({
+      type: "review.requested",
+      ...(typeof pr.headRef === "string" && pr.headRef ? { branch: pr.headRef } : {}),
+      ...(typeof pr.title === "string" ? { title: pr.title } : {}),
+      ...(typeof pr.url === "string" ? { url: pr.url } : {}),
       fork: false,
     });
   }

--- a/src/server/forge/poller.test.mjs
+++ b/src/server/forge/poller.test.mjs
@@ -4,12 +4,23 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { createForgePoller, pollIssueLabels } from "./poller.mjs";
+import { createForgePoller, pollChecksFailed, pollIssueLabels, pollReviewRequested } from "./poller.mjs";
 
 const repo = { owner: "anomalyco", repo: "manta" };
 
 function issue(number, title, url = `https://github.com/anomalyco/manta/issues/${number}`) {
   return { number, title, url };
+}
+
+function pr(number, title, { headRef = "feat", headSha = `sha${number}`, mergeBlockedReason = null } = {}) {
+  return {
+    number,
+    title,
+    url: `https://github.com/anomalyco/manta/pull/${number}`,
+    headRef,
+    headSha,
+    mergeBlockedReason,
+  };
 }
 
 // ---------------------------------------------------------------------------
@@ -48,6 +59,88 @@ test("pollIssueLabels: a changed list (new ETag) dispatches only the new issue",
   const res = await pollIssueLabels({ repo, label: "manta", listIssues: changed }, { seen });
   assert.equal(res.events.length, 1);
   assert.equal(res.events[0].title, "B");
+});
+
+// ---------------------------------------------------------------------------
+// pollChecksFailed — PRs whose CI is red emit checks.failed, with the same
+// ETag/`seen`-set de-dup so a 304 does not re-dispatch.
+// ---------------------------------------------------------------------------
+
+test("pollChecksFailed emits checks.failed for PRs whose CI rollup is red", async () => {
+  const listPullRequests = async () => ({ data: [pr(1, "A", { headRef: "feat/a" }), pr(2, "B", { headRef: "feat/b" })] });
+  const getChecks = async (_r, sha) => ({ data: [{ name: "ci", status: "completed", conclusion: sha === "sha1" ? "failure" : "success" }] });
+  const { events } = await pollChecksFailed({ repo, listPullRequests, getChecks });
+  assert.equal(events.length, 1);
+  assert.equal(events[0].type, "checks.failed");
+  assert.equal(events[0].branch, "feat/a");
+  assert.equal(events[0].title, "A");
+});
+
+test("pollChecksFailed: a still-red list (a 304) does NOT re-dispatch", async () => {
+  const listPullRequests = async () => ({ data: [pr(1, "A")] });
+  const getChecks = async () => ({ data: [{ name: "ci", status: "completed", conclusion: "failure" }] });
+  const seen = new Set();
+  const first = await pollChecksFailed({ repo, listPullRequests, getChecks }, { seen });
+  assert.equal(first.events.length, 1);
+  const second = await pollChecksFailed({ repo, listPullRequests, getChecks }, { seen });
+  assert.equal(second.events.length, 0);
+});
+
+test("pollChecksFailed: a PR that goes freshly red dispatches, a green one never does", async () => {
+  const seen = new Set();
+  const green = async () => ({ data: [{ name: "ci", status: "completed", conclusion: "success" }] });
+  const red = async () => ({ data: [{ name: "ci", status: "completed", conclusion: "failure" }] });
+  // First poll: green — no failure event.
+  let res = await pollChecksFailed(
+    { repo, listPullRequests: async () => ({ data: [pr(1, "A")] }), getChecks: green },
+    { seen },
+  );
+  assert.equal(res.events.length, 0);
+  // Now the same PR fails — the check changed, so it dispatches once.
+  res = await pollChecksFailed(
+    { repo, listPullRequests: async () => ({ data: [pr(1, "A")] }), getChecks: red },
+    { seen },
+  );
+  assert.equal(res.events.length, 1);
+  // Unchanged red list — suppressed.
+  res = await pollChecksFailed(
+    { repo, listPullRequests: async () => ({ data: [pr(1, "A")] }), getChecks: red },
+    { seen },
+  );
+  assert.equal(res.events.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// pollReviewRequested — PRs blocked on review emit review.requested, with the
+// same ETag/`seen`-set de-dup.
+// ---------------------------------------------------------------------------
+
+test("pollReviewRequested emits review.requested for PRs blocked on review", async () => {
+  const listPullRequests = async () => ({
+    data: [
+      pr(1, "A", { headRef: "feat/a", mergeBlockedReason: "review required" }),
+      pr(2, "B", { headRef: "feat/b", mergeBlockedReason: "checks failing" }),
+      pr(3, "C", { headRef: "feat/c", mergeBlockedReason: "review required" }),
+    ],
+  });
+  const { events } = await pollReviewRequested({ repo, listPullRequests });
+  assert.equal(events.length, 2);
+  assert.deepEqual(
+    events.map((e) => ({ type: e.type, branch: e.branch, title: e.title })),
+    [
+      { type: "review.requested", branch: "feat/a", title: "A" },
+      { type: "review.requested", branch: "feat/c", title: "C" },
+    ],
+  );
+});
+
+test("pollReviewRequested: an unchanged list (a 304) does NOT re-dispatch", async () => {
+  const listPullRequests = async () => ({ data: [pr(1, "A", { mergeBlockedReason: "review required" })] });
+  const seen = new Set();
+  const first = await pollReviewRequested({ repo, listPullRequests }, { seen });
+  assert.equal(first.events.length, 1);
+  const second = await pollReviewRequested({ repo, listPullRequests }, { seen });
+  assert.equal(second.events.length, 0);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -102,7 +102,12 @@ import {
   forgeIngest,
 } from "./forgeRules.mjs";
 import { createRulesEngine } from "./forge/rules.mjs";
-import { createForgePoller, pollIssueLabels } from "./forge/poller.mjs";
+import {
+  createForgePoller,
+  pollChecksFailed,
+  pollIssueLabels,
+  pollReviewRequested,
+} from "./forge/poller.mjs";
 import { ensureCommentByTopic, pushSinkAction } from "./forge/sinks.mjs";
 import { parseRepoKey as forgeParseRepoKey } from "./forgeRules.mjs";
 import { getAdapter } from "./forge/index.mjs";
@@ -396,7 +401,7 @@ const forgeRefusalLog = new (class {
     console.warn(`[forge-rules] refusal: ${entry?.reason ?? ""} (${entry?.repoKey ?? "?"})`);
   }
 })();
-const forgePollSeen = new Map(); // repoKey -> Set of seen issue identities (poller de-dup)
+const forgePollSeen = new Map(); // repoKey -> { issues, checks, reviews } seen-sets (poller de-dup)
 
 forgeRulesEngine = createRulesEngine({
   enabled: async () => (await local.configGet())?.forgeRulesEnabled === true,
@@ -458,27 +463,51 @@ const { stop: stopForgePoller } = createForgePoller({
       const parts = forgeParseRepoKey(row.repoKey);
       if (!parts) continue;
       const hook = await findForgeHook(row.repoKey).catch(() => null);
-      const labeled = parseForgeRules(row.yaml ?? "").rules?.on?.["issue.labeled"];
+      const rulesOn = parseForgeRules(row.yaml ?? "").rules?.on ?? {};
+      const labeled = rulesOn["issue.labeled"];
       out.push({
         repoKey: row.repoKey,
         parts,
         label: typeof labeled?.label === "string" ? labeled.label : null,
+        pollChecksFailed: !!rulesOn["checks.failed"],
+        pollReviewRequested: !!rulesOn["review.requested"],
         webhookRegistered: !!hook, // never both: a working webhook wins
       });
     }
     return out;
   },
   pollRepo: async (repo) => {
-    if (!repo.label) return { events: [] }; // only issue.labeled is polled today
     const tok = await forgeResolveToken(repo.parts.host).catch(() => null);
     if (!tok) return { events: [] };
     const adapter = getAdapter("github", tok.token);
-    let seen = forgePollSeen.get(repo.repoKey);
-    if (!seen) forgePollSeen.set(repo.repoKey, (seen = new Set()));
-    const { events } = await pollIssueLabels(
-      { repo: { owner: repo.parts.owner, repo: repo.parts.repo }, label: repo.label, listIssues: (r, f) => adapter.listIssues(r, f) },
-      { seen },
-    );
+    const prRepo = { owner: repo.parts.owner, repo: repo.parts.repo };
+    let state = forgePollSeen.get(repo.repoKey);
+    if (!state) {
+      state = { issues: new Set(), checks: new Set(), reviews: new Set() };
+      forgePollSeen.set(repo.repoKey, state);
+    }
+    const events = [];
+    if (repo.label) {
+      const { events: ev } = await pollIssueLabels(
+        { repo: prRepo, label: repo.label, listIssues: (r, f) => adapter.listIssues(r, f) },
+        { seen: state.issues },
+      );
+      events.push(...ev);
+    }
+    if (repo.pollChecksFailed) {
+      const { events: ev } = await pollChecksFailed(
+        { repo: prRepo, listPullRequests: (r, f) => adapter.listPullRequests(r, f), getChecks: (r, sha) => adapter.getChecks(r, sha) },
+        { seen: state.checks },
+      );
+      events.push(...ev);
+    }
+    if (repo.pollReviewRequested) {
+      const { events: ev } = await pollReviewRequested(
+        { repo: prRepo, listPullRequests: (r, f) => adapter.listPullRequests(r, f) },
+        { seen: state.reviews },
+      );
+      events.push(...ev);
+    }
     return { events: events.map((e) => ({ ...e, repoKey: repo.repoKey })) };
   },
   handleEvent: (ev) => forgeRulesEngine.handleEvent(ev),


### PR DESCRIPTION
Opened automatically for `multica/BET-845`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-845.