### PR TITLE
feat(forge): GitLab adapter — the acceptance test for the abstraction (BET-799)

### DIFF
--- a/src/server/forge/auth.mjs
+++ b/src/server/forge/auth.mjs
@@ -65,11 +65,25 @@ const STORED_KEYS_BY_HOST = Object.freeze({
 // host -> { at, found, token?, source? }
 const CACHE = new Map();
 
+// Derive the env/secret key NAMESPACE for an arbitrary host. A self-hosted
+// host isn't in the fixed maps, so it gets a deterministic, host-derived name:
+// `git.example.com` → env `MANTA_GIT_EXAMPLE_COM_TOKEN`, secrets `[GIT_EXAMPLE_COM_TOKEN, forge.git.example.com.token]`.
+function hostKey(host) {
+  return String(host).replace(/[^a-zA-Z0-9]+/g, "_").replace(/^_+|_+$/g, "").toUpperCase();
+}
+
 function envToken(host, env) {
-  const key = ENV_BY_HOST[host];
+  const key = ENV_BY_HOST[host] ?? (host ? `MANTA_${hostKey(host)}_TOKEN` : null);
   if (!key) return null;
   const v = env?.[key];
   return typeof v === "string" && v ? v : null;
+}
+
+function storedTokenKeys(host) {
+  if (STORED_KEYS_BY_HOST[host]) return STORED_KEYS_BY_HOST[host];
+  if (!host) return null;
+  const k = hostKey(host);
+  return [`${k}_TOKEN`, `forge.${host}.token`];
 }
 
 async function cliToken(host, shell) {
@@ -148,7 +162,7 @@ export function parseGlabToken(text, host) {
 }
 
 function storedToken(host, loadSecretsFn) {
-  const keys = STORED_KEYS_BY_HOST[host];
+  const keys = storedTokenKeys(host);
   if (!keys || keys.length === 0) return null;
   try {
     const secrets = loadSecretsFn();

--- a/src/server/forge/auth.mjs
+++ b/src/server/forge/auth.mjs
@@ -35,13 +35,17 @@
 import { randomBytes } from "node:crypto";
 import { runLoginShell } from "../launchers.mjs";
 import { resolveSecret, loadSecrets, setSecret } from "../secrets.mjs";
+import { readFile as fsReadFile } from "node:fs/promises";
+import { homedir } from "node:os";
+import { join } from "node:path";
 
 // How long a cached resolution is trusted before the CLI/secret is re-read.
 const TTL_MS = 60_000;
 
-// The CLI leg only exists for github.com (`gh auth token`). GitLab has its own
-// CLI but it arrives with the GitLab adapter.
-const CLI_HOST = "github.com";
+// The CLI legs, per host. GitHub: `gh auth token` through a login shell.
+// GitLab: glab persists its token in a config file (`~/.config/glab-cli/`).
+const GITHUB_CLI_HOST = "github.com";
+const GITLAB_CLI_HOST = "gitlab.com";
 
 // Per-host env var override (priority 1).
 const ENV_BY_HOST = Object.freeze({
@@ -69,7 +73,7 @@ function envToken(host, env) {
 }
 
 async function cliToken(host, shell) {
-  if (host !== CLI_HOST) return null;
+  if (host !== GITHUB_CLI_HOST) return null;
   try {
     const { stdout } = await shell("gh auth token");
     const token = (stdout ?? "").trim();
@@ -78,6 +82,69 @@ async function cliToken(host, shell) {
     // `gh auth token` exits non-zero when not authenticated (or gh is missing).
     return null;
   }
+}
+
+// glab (GitLab's CLI) has no `glab auth token` command; its credential lives in
+// a config file. Locate + parse the token for `host` without a YAML dependency:
+// find the `hosts:` block, then the entry whose host line equals `host`, then
+// the `token:` line indented under it. Tokens are read-only on the box — the
+// LADDER guard in resolveToken never lets one cross RPC. Injectable `readFile`
+// + `home` for tests.
+export async function gitlabCliToken(
+  host,
+  { readFile = fsReadFile, home = homedir() } = {},
+) {
+  if (host !== GITLAB_CLI_HOST) return null;
+  const paths = [
+    join(home, ".config", "glab-cli", "config.yml"),
+    join(home, ".config", "glab-cli", "config.yaml"),
+  ];
+  let text = "";
+  for (const p of paths) {
+    try {
+      text = await readFile(p, "utf-8");
+      break;
+    } catch {
+      /* try the next candidate */
+    }
+  }
+  return parseGlabToken(text, host);
+}
+
+// Extract the token for `host` from raw glab config text. Pure + tested.
+export function parseGlabToken(text, host) {
+  if (typeof text !== "string") return null;
+  const lines = text.split("\n");
+  const hostsIdx = lines.findIndex((l) => /^\s*hosts\s*:\s*$/.test(l));
+  if (hostsIdx === -1) return null;
+  let inHostEntry = false;
+  let entryIndent = null;
+  for (let i = hostsIdx + 1; i < lines.length; i++) {
+    const line = lines[i];
+    if (!line.trim()) continue;
+    const indent = line.match(/^\s*/)[0].length;
+    if (inHostEntry && indent <= entryIndent) {
+      // left the host entry (a sibling key outside `hosts:` or a new host)
+      inHostEntry = false;
+    }
+    if (!inHostEntry) {
+      const hostMatch = /^(\s*)(\S+)\s*:\s*$/.exec(line);
+      if (hostMatch && hostMatch[2] === host) {
+        inHostEntry = true;
+        entryIndent = hostMatch[1].length;
+        continue;
+      }
+      if (/^\s*\S+\s*:/.test(line) && /^\s*hosts\b/.test(line) === false) {
+        // an unrelated top-level key — nothing more inside hosts
+      }
+      continue;
+    }
+    const tokenMatch = /^(\s*)token\s*:\s*["']?([^\s"']+)["']?\s*$/.exec(line);
+    if (tokenMatch && tokenMatch[1].length > entryIndent) {
+      return tokenMatch[2];
+    }
+  }
+  return null;
 }
 
 function storedToken(host, loadSecretsFn) {
@@ -111,7 +178,7 @@ function storedToken(host, loadSecretsFn) {
  */
 export async function resolveToken(
   host,
-  { shell = runLoginShell, loadSecretsFn = loadSecrets, env = process.env, now = Date.now } = {},
+  { shell = runLoginShell, loadSecretsFn = loadSecrets, env = process.env, now = Date.now, readFile, home } = {},
 ) {
   if (typeof host !== "string" || !host) return null;
 
@@ -126,7 +193,10 @@ export async function resolveToken(
     return { token: envTok, source: "env" };
   }
 
-  const cli = await cliToken(host, shell);
+  const cli =
+    host === GITHUB_CLI_HOST
+      ? await cliToken(host, shell)
+      : await gitlabCliToken(host, { readFile, home });
   if (cli) {
     CACHE.set(host, { at: now(), found: true, token: cli, source: "cli" });
     return { token: cli, source: "cli" };
@@ -140,6 +210,30 @@ export async function resolveToken(
 
   CACHE.set(host, { at: now(), found: false });
   return null;
+}
+
+/**
+ * Rotate a GitLab OAuth token pair, persisting the NEW pair BEFORE the old is
+ * used again.
+ *
+ * The trap this exists for (BET-799 §Auth): GitLab rotates the refresh token on
+ * EVERY use, invalidating both old tokens. If a crash happens mid-refresh with
+ * the old pair already discarded, the rotation is unrecoverable. So the order is
+ * fixed and caller-enforced: `persistPair(newPair)` runs and settles BEFORE the
+ * caller makes any further authenticated request with the new access token.
+ *
+ * `refresh` is injected (network), `persistPair` is injectable (atomic secrets
+ * write). Returns the new pair on success; a failed persist propagates so the
+ * caller aborts rather than continue on a half-written pair.
+ *
+ * @param {() => Promise<{ access_token: string, refresh_token: string }>} refresh
+ * @param {(pair: { access_token: string, refresh_token: string }) => Promise<void>} persistPair
+ * @returns {Promise<{ access_token: string, refresh_token: string }>}
+ */
+export async function rotateOauthPair(refresh, persistPair) {
+  const next = await refresh();
+  await persistPair(next);
+  return next;
 }
 
 /**

--- a/src/server/forge/auth.mjs
+++ b/src/server/forge/auth.mjs
@@ -452,6 +452,6 @@ export async function pollDeviceGrant(
   const stored = await storeToken(raw.access_token);
   if (!stored.ok) throw new Error(stored.error || "couldn't store the token");
   ACTIVE_GRANTS.delete(grantId);
-  invalidateToken(CLI_HOST);
+  invalidateToken(GITHUB_CLI_HOST);
   return { status: "done" };
 }

--- a/src/server/forge/github.mjs
+++ b/src/server/forge/github.mjs
@@ -667,13 +667,17 @@ export function createGithubAdapter(request, requestWrite, requestText = request
 
     /**
      * PATCH /repos/{o}/{r}/issues/comments/{id} — update an existing plain
-     * comment in place (the "update" half of ensure-comment-by-topic).
+     * comment in place (the "update" half of ensure-comment-by-topic). `number`
+     * is accepted (and IGNORED) to match GitLab, whose MR notes are iid-scoped —
+     * the one shared comment-write contract is `(repo, number, commentId, body)`,
+     * and GitHub's issue-comment ids are global so it drops `number`.
      * @param {{ owner: string, repo: string }} repo
+     * @param {number} _number unused on GitHub (comment ids are global)
      * @param {any} commentId
      * @param {string} body
      * @returns {Promise<{ data: { id: any }, stale: boolean }>}
      */
-    async updateIssueComment(repo, commentId, body) {
+    async updateIssueComment(repo, _number, commentId, body) {
       if (!requestWrite) throw new Error("write transport not available");
       const url = `${API}/repos/${repo.owner}/${repo.repo}/issues/comments/${commentId}`;
       const { data } = await requestWrite(url, { method: "PATCH", body: { body } });

--- a/src/server/forge/github.mjs
+++ b/src/server/forge/github.mjs
@@ -361,8 +361,10 @@ function toGithubAnchor(c, headSha) {
  * @param {(url: string) => Promise<{ data: any, stale: boolean }>} request
  * @param {(url: string, opts: { method: string, body?: any }) => Promise<{ data: any, stale: boolean }>} [requestWrite]
  * @param {(url: string) => Promise<{ data: any, stale: boolean }>} [requestText]
+ * @param {string} [apiBase] the API root; defaults to github.com. A self-hosted
+ *   instance serves `<host>/api/v3`.
  */
-export function createGithubAdapter(request, requestWrite, requestText = request) {
+export function createGithubAdapter(request, requestWrite, requestText = request, apiBase = API) {
   return {
     kind: "github",
 
@@ -373,7 +375,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      * @returns {Promise<{ data: import("./index.mjs").PullRequestLike[], stale: boolean }>}
      */
     async listPullRequests(repo, filter = {}) {
-      const url = `${API}${issuePath(repo)}/pulls${qs({ state: filter.state ?? "open" })}`;
+      const url = `${apiBase}${issuePath(repo)}/pulls${qs({ state: filter.state ?? "open" })}`;
       const { data, stale } = await request(url);
       const raw = Array.isArray(data) ? data : [];
       return { data: raw.map((p) => normalizePr(p)), stale };
@@ -409,7 +411,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      * @returns {Promise<{ data: import("./index.mjs").PullRequestLike, stale: boolean }>}
      */
     async getPullRequest(repo, number) {
-      const base = `${API}${issuePath(repo)}/pulls/${number}`;
+      const base = `${apiBase}${issuePath(repo)}/pulls/${number}`;
       const prRes = await request(base);
       const raw = prRes.data;
       let stale = prRes.stale;
@@ -442,7 +444,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      * @returns {Promise<{ data: Array<{ number: number, title: string, body: string, url: string, state: string, closed: boolean }>, stale: boolean }>}
      */
     async listIssues(repo, filter = {}) {
-      const url = `${API}${issuePath(repo)}/issues${qs({
+      const url = `${apiBase}${issuePath(repo)}/issues${qs({
         state: filter.state ?? "open",
         ...(filter.labels !== undefined
           ? { labels: Array.isArray(filter.labels) ? filter.labels.join(",") : filter.labels }
@@ -472,7 +474,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      * @returns {Promise<{ data: Array<{ name: string, status?: string, conclusion?: string, url?: string }>, stale: boolean }>}
      */
     async getChecks(repo, sha) {
-      const base = `${API}${issuePath(repo)}/commits/${sha}`;
+      const base = `${apiBase}${issuePath(repo)}/commits/${sha}`;
       let stale = false;
       let checks = [];
       try {
@@ -506,7 +508,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      */
     async createPullRequest(repo, { title, head, base, body = "", draft = false }) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${issuePath(repo)}/pulls`;
+      const url = `${apiBase}${issuePath(repo)}/pulls`;
       const { data } = await requestWrite(url, {
         method: "POST",
         body: { title, head, base, body, draft },
@@ -527,7 +529,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      */
     async merge(repo, number, { method = "merge", sha } = {}) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${issuePath(repo)}/pulls/${number}/merge`;
+      const url = `${apiBase}${issuePath(repo)}/pulls/${number}/merge`;
       let data;
       try {
         ({ data } = await requestWrite(url, {
@@ -569,7 +571,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      */
     async submitReview(repo, number, { verdict = null, body = "", comments = [], headSha = "" } = {}) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${issuePath(repo)}/pulls/${number}/reviews`;
+      const url = `${apiBase}${issuePath(repo)}/pulls/${number}/reviews`;
       const payload = { event: verdictToEvent(verdict), body };
       if (Array.isArray(comments) && comments.length > 0) {
         payload.comments = comments.map((c) => toGithubAnchor(c, headSha));
@@ -590,7 +592,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      */
     async replyToThread(repo, number, { threadId, body, headSha = "" } = {}) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${issuePath(repo)}/pulls/${number}/comments/${threadId}/replies`;
+      const url = `${apiBase}${issuePath(repo)}/pulls/${number}/comments/${threadId}/replies`;
       const payload = { body: String(body ?? "").trim() };
       if (headSha) payload.commit_id = headSha;
       const { data } = await requestWrite(url, { method: "POST", body: payload });
@@ -612,7 +614,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      * @returns {Promise<{ data: { diff: string, threads: Array<any>, headSha: string }, stale: boolean }>}
      */
     async getDiff(repo, number) {
-      const pull = `${API}${issuePath(repo)}/pulls/${number}`;
+      const pull = `${apiBase}${issuePath(repo)}/pulls/${number}`;
       let stale = false;
       let headSha = "";
       let diff = "";
@@ -644,7 +646,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      * @returns {Promise<{ data: Array<{ id: any, body: string }>, stale: boolean }>}
      */
     async listIssueComments(repo, number) {
-      const url = `${API}${issuePath(repo)}/issues/${number}/comments`;
+      const url = `${apiBase}${issuePath(repo)}/issues/${number}/comments`;
       const { data, stale } = await request(url);
       const raw = Array.isArray(data) ? data : [];
       return { data: raw.map((c) => ({ id: c?.id ?? null, body: c?.body ?? "" })), stale };
@@ -660,7 +662,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      */
     async createIssueComment(repo, number, body) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${issuePath(repo)}/issues/${number}/comments`;
+      const url = `${apiBase}${issuePath(repo)}/issues/${number}/comments`;
       const { data } = await requestWrite(url, { method: "POST", body: { body } });
       return { data: { id: data?.id ?? null }, stale: false };
     },
@@ -679,7 +681,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      */
     async updateIssueComment(repo, _number, commentId, body) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}/repos/${repo.owner}/${repo.repo}/issues/comments/${commentId}`;
+      const url = `${apiBase}/repos/${repo.owner}/${repo.repo}/issues/comments/${commentId}`;
       const { data } = await requestWrite(url, { method: "PATCH", body: { body } });
       return { data: { id: data?.id ?? null }, stale: false };
     },
@@ -694,7 +696,7 @@ export function createGithubAdapter(request, requestWrite, requestText = request
      * @returns {Promise<{ data: Array<object>, stale: boolean }>}
      */
     async listMyRepos() {
-      const url = `${API}/user/repos?sort=pushed&per_page=100&affiliation=owner,collaborator,organization_member`;
+      const url = `${apiBase}/user/repos?sort=pushed&per_page=100&affiliation=owner,collaborator,organization_member`;
       const { data, stale } = await request(url);
       return { data: pushableRepos(data), stale };
     },

--- a/src/server/forge/gitlab.mjs
+++ b/src/server/forge/gitlab.mjs
@@ -303,20 +303,22 @@ export function buildPosition(shas, a) {
  * @param {(url: string) => Promise<{ data: any, stale: boolean }>} request
  * @param {(url: string, opts: { method: string, body?: any }) => Promise<{ data: any, stale: boolean }>} [requestWrite]
  * @param {(url: string) => Promise<{ data: any, stale: boolean }>} [requestText]
+ * @param {string} [apiBase] the API root; defaults to gitlab.com. A self-hosted
+ *   instance serves `<host>/api/v4`.
  */
-export function createGitlabAdapter(request, requestWrite, requestText = request) {
+export function createGitlabAdapter(request, requestWrite, requestText = request, apiBase = API) {
   return {
     kind: "gitlab",
 
     async listPullRequests(repo, filter = {}) {
-      const url = `${API}${projectPath(repo)}/merge_requests${qs({ state: stateFilter(filter.state ?? "opened") })}`;
+      const url = `${apiBase}${projectPath(repo)}/merge_requests${qs({ state: stateFilter(filter.state ?? "opened") })}`;
       const { data, stale } = await request(url);
       const raw = Array.isArray(data) ? data : [];
       return { data: raw.map((m) => normalizeMr(m)), stale };
     },
 
     async getPullRequest(repo, number) {
-      const base = `${API}${projectPath(repo)}/merge_requests/${number}`;
+      const base = `${apiBase}${projectPath(repo)}/merge_requests/${number}`;
       const prRes = await request(base);
       const raw = prRes.data;
       let stale = prRes.stale;
@@ -334,7 +336,7 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
     // GitLab issues and MRs are DISJOINT objects (mismatch #4) — unlike
     // GitHub, an issue list never leaks MRs, so nothing needs filtering.
     async listIssues(repo, filter = {}) {
-      const url = `${API}${projectPath(repo)}/issues${qs({ state: stateFilter(filter.state ?? "opened") })}`;
+      const url = `${apiBase}${projectPath(repo)}/issues${qs({ state: stateFilter(filter.state ?? "opened") })}`;
       const { data, stale } = await request(url);
       const raw = Array.isArray(data) ? data : [];
       const issues = raw.map((i) => ({
@@ -352,7 +354,7 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
     // by HEAD SHA — GitLab indexes pipelines by commit too, so the shared
     // `getChecks(repo, sha)` signature (no MR iid) still resolves them.
     async getChecks(repo, sha) {
-      const base = `${API}${projectPath(repo)}`;
+      const base = `${apiBase}${projectPath(repo)}`;
       let stale = false;
       let checks = [];
       try {
@@ -374,7 +376,7 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
 
     async createPullRequest(repo, { title, head, base, body = "", draft = false }) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${projectPath(repo)}/merge_requests`;
+      const url = `${apiBase}${projectPath(repo)}/merge_requests`;
       // GitLab has no `draft` boolean on create — a title prefixed "Draft:" is
       // how a draft MR is created (and how `work_in_progress` is signalled).
       const { data } = await requestWrite(url, {
@@ -391,7 +393,7 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
 
     async merge(repo, number, { method = "merge", sha } = {}) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${projectPath(repo)}/merge_requests/${number}/merge`;
+      const url = `${apiBase}${projectPath(repo)}/merge_requests/${number}/merge`;
       let data;
       try {
         ({ data } = await requestWrite(url, { method: "PUT", body: { sha } }));
@@ -414,7 +416,7 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
     // the buffer.
     async submitReview(repo, number, { verdict = null, body = "", comments = [], headSha = "" } = {}) {
       if (!requestWrite) throw new Error("write transport not available");
-      const base = `${API}${projectPath(repo)}/merge_requests/${number}`;
+      const base = `${apiBase}${projectPath(repo)}/merge_requests/${number}`;
       const commentsArr = Array.isArray(comments) ? comments : [];
       const shas = await positionShas(base, headSha, request);
       for (const c of commentsArr) {
@@ -438,7 +440,7 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
 
     async replyToThread(repo, number, { threadId, body, headSha = "" } = {}) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${projectPath(repo)}/merge_requests/${number}/discussions/${threadId}/notes`;
+      const url = `${apiBase}${projectPath(repo)}/merge_requests/${number}/discussions/${threadId}/notes`;
       const { data } = await requestWrite(url, { method: "POST", body: { body: String(body ?? "").trim() } });
       return { data, stale: false };
     },
@@ -447,13 +449,13 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
     // which needs GraphQL). Presence is the capability model.
     async resolveThread(repo, number, { discussionId } = {}) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${projectPath(repo)}/merge_requests/${number}/discussions/${discussionId}`;
+      const url = `${apiBase}${projectPath(repo)}/merge_requests/${number}/discussions/${discussionId}`;
       const { data } = await requestWrite(url, { method: "PUT", body: { resolved: true } });
       return { data, stale: false };
     },
 
     async getDiff(repo, number) {
-      const base = `${API}${projectPath(repo)}/merge_requests/${number}`;
+      const base = `${apiBase}${projectPath(repo)}/merge_requests/${number}`;
       let stale = false;
       let headSha = "";
       let diff = "";
@@ -490,7 +492,7 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
     // MR notes (GitLab's plain comments live on the MR, not an issues endpoint
     // — mismatch #4 again). The progress sink reads these for its topic marker.
     async listIssueComments(repo, number) {
-      const url = `${API}${projectPath(repo)}/merge_requests/${number}/notes`;
+      const url = `${apiBase}${projectPath(repo)}/merge_requests/${number}/notes`;
       const { data, stale } = await request(url);
       const raw = Array.isArray(data) ? data : [];
       return { data: raw.map((c) => ({ id: c?.id ?? null, body: c?.body ?? "" })), stale };
@@ -498,7 +500,7 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
 
     async createIssueComment(repo, number, body) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${projectPath(repo)}/merge_requests/${number}/notes`;
+      const url = `${apiBase}${projectPath(repo)}/merge_requests/${number}/notes`;
       const { data } = await requestWrite(url, { method: "POST", body: { body } });
       return { data: { id: data?.id ?? null }, stale: false };
     },
@@ -507,7 +509,7 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
     // GitHub's comment id is global — an interface asymmetry GitLab forces.
     async updateIssueComment(repo, number, commentId, body) {
       if (!requestWrite) throw new Error("write transport not available");
-      const url = `${API}${projectPath(repo)}/merge_requests/${number}/notes/${commentId}`;
+      const url = `${apiBase}${projectPath(repo)}/merge_requests/${number}/notes/${commentId}`;
       const { data } = await requestWrite(url, { method: "PUT", body: { body } });
       return { data: { id: data?.id ?? null }, stale: false };
     },

--- a/src/server/forge/gitlab.mjs
+++ b/src/server/forge/gitlab.mjs
@@ -1,0 +1,515 @@
+// gitlab.mjs — the GitLab REST adapter for the forge seam (BET-799).
+//
+// This module is the acceptance test for the whole L0 seam: everything before
+// it was designed against GitLab's documentation precisely so this file is
+// small. When GitLab does not fit, the rule is to change THIS adapter, never
+// `src/shared/forge.mjs` — if a GitLab-shaped field is needed in the shared
+// vocabulary, that is the abstraction failing and is a design finding, not an
+// implementation change.
+//
+// Plain `fetch` only (no dependency). Like the GitHub adapter it is PURE
+// normalisation + URL construction and holds no cache / single-flight /
+// rate-limit state — serialisation lives in index.mjs. It differs from GitHub
+// in exactly the places GitLab's API differs, which is the point.
+//
+// The eight mismatches this module owns (each is a real bug if missed):
+//   1. `iid`, never `id`. Every GitLab API path uses the per-project `iid`;
+//      the shared `number` IS the iid, never the global `id`.
+//   2. Project addressing: `/projects/{id}` accepts the URL-encoded FULL path
+//      (`group%2Fsub%2Fproj`), which is how `detectForge` returns sub-group
+//      owners. Encoded here, never split.
+//   3. `"opened"`, not `"open"` — reconciled by `normalizePrState`, reused.
+//   4. Issues and MRs are DISJOINT objects on GitLab (the inverse of GitHub) —
+//      labels/assignees/notes for an MR go through the MR endpoints, and
+//      `listIssues` does NOT need to filter out PRs.
+//   5. There is no review object. Approval is a boolean per user
+//      (`approve`/`unapprove`); "changes requested" surfaces only inside
+//      `detailed_merge_status`. `submitReview` posts each buffered comment as
+//      its own discussion then approve/unapprove for the verdict — the box-side
+//      buffer exists so the user-visible behaviour matches GitHub exactly.
+//   6. Inline comment anchoring needs three SHAs (`base_sha`, `head_sha`,
+//      `start_sha`) from `/merge_requests/{iid}/versions` — one extra request
+//      before the batch, cached per head SHA. Added line → `new_line` only;
+//      removed → `old_line` only; unchanged → both.
+//   7. Pipelines + commit statuses, not checks. `manual`/`scheduled` (which
+//      have no GitHub analogue) map to a pending-ish status → roll to yellow.
+//   8. `detailed_merge_status` (~25 values) maps to `mergeable` + a rich
+//      `mergeBlockedReason`.
+//
+// Bonus capability: thread resolution is plain REST here
+// (`PUT .../discussions/{id}` with `{resolved: true}`) where GitHub needs
+// GraphQL — so this adapter exposes the optional `resolveThread` (absent on
+// the GitHub adapter). That asymmetry is the capability model working as
+// designed (spec §3.2).
+
+import { normalizePrState } from "../../shared/forge.mjs";
+import { GithubRequestError, MergeNotAllowedError, MergeShaMismatchError, MergePermissionError } from "./github.mjs";
+
+const API = "https://gitlab.com/api/v4";
+
+// Map a merge PUT's failure status to its distinguished error kind, exactly as
+// the GitHub adapter does. GitLab: 405 = not mergeable, 409 = head sha no
+// longer matches, 403 = no permission; anything else stays generic.
+function mergeFailure(status, url) {
+  if (status === 405) return new MergeNotAllowedError(url);
+  if (status === 409) return new MergeShaMismatchError(url);
+  if (status === 403) return new MergePermissionError(url);
+  return new GithubRequestError(status, url);
+}
+
+function qs(params) {
+  const entries = Object.entries(params).filter(([, v]) => v !== undefined && v !== null && v !== "");
+  if (entries.length === 0) return "";
+  return "?" + new URLSearchParams(entries).toString();
+}
+
+// The GitLab project path is `/projects/<url-encoded-full-path>` where the full
+// path is `owner/repo` (owner may itself be `group/subgroup`). `detectForge`
+// already splits subgroup owners into `owner`; we rejoin and encode the whole
+// thing, never the segments — splitting would break nested groups.
+function projectPath(repo) {
+  return `/projects/${encodeURIComponent(`${repo.owner}/${repo.repo}`)}`;
+}
+
+// GitLab's MR `state` filter values differ from the shared filter's "open".
+const STATE_FILTERS = { open: "opened", opened: "opened", closed: "closed", merged: "merged", all: "all" };
+function stateFilter(state) {
+  return STATE_FILTERS[state] ?? state;
+}
+
+// Map `detailed_merge_status` (~25 values) onto the shared `mergeable` +
+// `mergeBlockedReason`. These are GITLAB's raw values; the shared vocabulary
+// only ever sees the reconciled `mergeable` boolean + human reason.
+const MERGE_STATUS = Object.freeze({
+  // mergeable
+  can_be_merged: { mergeable: true, reason: null },
+  mergeable: { mergeable: true, reason: null },
+  merge_when_pipeline_succeeds: { mergeable: true, reason: null },
+  // still computing
+  checking: { mergeable: null, reason: null },
+  unchecked: { mergeable: null, reason: null },
+  preparing: { mergeable: null, reason: null },
+  // mergeable with effort
+  need_rebase: { mergeable: false, reason: "needs rebase" },
+  conflict: { mergeable: false, reason: "conflicts" },
+  // blocked — each a distinct, readable reason
+  ci_must_pass: { mergeable: false, reason: "checks failing" },
+  ci_still_running: { mergeable: false, reason: "checks still running" },
+  not_approved: { mergeable: false, reason: "approval required" },
+  discussions_not_resolved: { mergeable: false, reason: "unresolved discussions" },
+});
+
+function mergeableFrom(raw) {
+  if (raw.draft) return { mergeable: false, reason: "draft" };
+  const status = raw.detailed_merge_status ?? null;
+  if (status == null || typeof status !== "string") {
+    // Older GitLab only exposes the coarse `merge_status`. Fall back to it.
+    if (raw.merge_status === "can_be_merged") return { mergeable: true, reason: null };
+    if (raw.merge_status === "cannot_be_merged" || raw.merge_status === "cannot_be_merged_recheck") {
+      return { mergeable: false, reason: "not mergeable" };
+    }
+    return { mergeable: null, reason: null };
+  }
+  const m = MERGE_STATUS[status];
+  if (m) return m;
+  // Any other raw value is a real "not mergeable" — surface it generically.
+  return { mergeable: false, reason: "not mergeable" };
+}
+
+// Normalise one raw GitLab MR into the shared PullRequest shape. `number` is
+// the iid (mismatch #1) — a captured payload's `iid` and the URL both carry it,
+// and the raw global `id` must never be used as `number`.
+function normalizeMr(raw, { unresolvedThreads = 0 } = {}) {
+  const { mergeable, reason } = mergeableFrom(raw);
+  return {
+    number: raw.iid,
+    title: raw.title ?? "",
+    body: raw.description ?? "",
+    url: raw.web_url ?? "",
+    state: normalizePrState(
+      { state: raw.state, merged: raw.state === "merged", draft: raw.draft },
+      "gitlab",
+    ),
+    draft: Boolean(raw.draft),
+    headRef: raw.source_branch ?? "",
+    baseRef: raw.target_branch ?? "",
+    headSha: raw.sha ?? "",
+    author: raw.author?.username ?? "",
+    reviewers: Array.isArray(raw.reviewers)
+      ? raw.reviewers.map((r) => r?.username ?? "").filter(Boolean)
+      : [],
+    mergeable,
+    mergeBlockedReason: reason,
+    unresolvedThreads: unresolvedThreads ?? 0,
+  };
+}
+
+// GitLab pipeline `status` values → the shared check vocabulary. `manual` and
+// `scheduled` have no GitHub analogue and must NOT read as failed (red) — they
+// map to a pending-ish `waiting` status so rollupChecks rolls them to yellow,
+// and the raw list is kept for display (spec §3.4②).
+function normalizePipeline(p) {
+  const url = p?.web_url ?? "";
+  const name = p?.name ?? "pipeline";
+  switch (p?.status) {
+    case "success":
+      return { name, status: "completed", conclusion: "success", url };
+    case "failed":
+      return { name, status: "completed", conclusion: "failure", url };
+    case "canceled":
+    case "skipped":
+      return { name, status: "completed", conclusion: undefined, url };
+    case "manual":
+    case "scheduled":
+      return { name, status: "waiting", url };
+    default:
+      // created / waiting_for_resource / preparing / pending / running
+      return { name, status: "running", url };
+  }
+}
+
+// GitLab commit-status `status` values → shared check vocabulary. Same manual /
+// scheduled → yellow rule as pipelines.
+function normalizeCommitStatus(s) {
+  const url = s?.target_url ?? "";
+  const name = s?.name ?? s?.ref ?? "status";
+  switch (s?.status) {
+    case "success":
+      return { name, status: "completed", conclusion: "success", url };
+    case "failed":
+      return { name, status: "completed", conclusion: "failure", url };
+    case "canceled":
+    case "skipped":
+      return { name, status: "completed", conclusion: undefined, url };
+    case "manual":
+    case "scheduled":
+      return { name, status: "waiting", url };
+    default:
+      // pending / running
+      return { name, status: "running", url };
+  }
+}
+
+// Group GitLab discussions into forge-neutral Threads (same shape the review
+// pane reads for GitHub). A discussion whose first note has no `position` is a
+// general (non-line) comment and is not a thread. Anchoring comes from the
+// position: `new_line` (added) → RIGHT side, `old_line` (removed) → LEFT.
+function normalizeThreads(discussions) {
+  const threads = [];
+  for (const d of Array.isArray(discussions) ? discussions : []) {
+    const notes = Array.isArray(d?.notes) ? d.notes : [];
+    if (notes.length === 0) continue;
+    const pos = notes[0]?.position;
+    if (!pos || (pos.new_path == null && pos.old_path == null)) continue;
+    const newLine = pos.new_line ?? null;
+    const oldLine = pos.old_line ?? null;
+    threads.push({
+      id: String(d.id),
+      path: pos.new_path ?? pos.old_path ?? null,
+      line: newLine ?? oldLine,
+      side: newLine != null ? "RIGHT" : "LEFT",
+      startLine: pos.line_range?.start?.new_line ?? null,
+      resolved: Boolean(d.resolved),
+      comments: notes.map((n) => ({
+        author: n?.author?.username ?? "",
+        body: n?.body ?? "",
+        createdAt: n?.created_at ?? null,
+      })),
+    });
+  }
+  return threads;
+}
+
+// ---------------------------------------------------------------------------
+// Position building (mismatch #6)
+// ---------------------------------------------------------------------------
+
+// An extra request before inline comments: GitLab needs three SHAs which come
+// from `/merge_requests/{iid}/versions`. Cached per head SHA (the latest
+// version's `head_sha` IS the current head). The module-level cache spans
+// adapter instances because index.mjs creates a fresh adapter per call — this is
+// the one deliberate piece of adapter-side memoisation the design permits.
+const positionShaCache = new Map(); // `${base}#${headSha}` -> { base_sha, start_sha, head_sha }
+const POSITION_CACHE_MAX = 200;
+
+async function positionShas(base, headSha, request) {
+  const key = `${base}#${headSha}`;
+  const hit = positionShaCache.get(key);
+  if (hit) return hit;
+  let shas = { base_sha: "", start_sha: "", head_sha: headSha };
+  try {
+    const { data } = await request(`${base}/versions`);
+    const versions = Array.isArray(data) ? data : [];
+    if (versions.length > 0) {
+      const v = versions[0];
+      shas = {
+        base_sha: v?.base_sha ?? "",
+        start_sha: v?.start_sha ?? "",
+        head_sha: v?.head_sha ?? headSha,
+      };
+    }
+  } catch {
+    // Fall back to the head SHA alone; GitLab still resolves the position.
+  }
+  if (positionShaCache.size >= POSITION_CACHE_MAX) positionShaCache.clear();
+  positionShaCache.set(key, shas);
+  return shas;
+}
+
+/**
+ * Build a GitLab discussion `position` from a forge-neutral anchor.
+ *
+ * The `new_line`/`old_line` combination is the trap: an ADDED line sets
+ * `new_line` only, a REMOVED line sets `old_line` only, and an UNCHANGED line
+ * sets BOTH. `side` `"new"` → added; `"old"` → removed; anything else → both.
+ * Pure and exported for tests.
+ *
+ * @param {{ base_sha?: string, start_sha?: string, head_sha?: string }} shas
+ * @param {{ path: string, line: number, side?: string, startLine?: number | null }} a
+ */
+export function buildPosition(shas, a) {
+  const pos = {
+    base_sha: shas?.base_sha ?? "",
+    start_sha: shas?.start_sha ?? "",
+    head_sha: shas?.head_sha ?? "",
+    position_type: "text",
+    new_path: a?.path,
+    old_path: a?.path,
+  };
+  if (a?.side === "old") {
+    pos.old_line = a.line;
+  } else if (a?.side === "new") {
+    pos.new_line = a.line;
+  } else {
+    pos.new_line = a.line;
+    pos.old_line = a.line;
+  }
+  pos.width = a?.side === "old" ? "left" : "right";
+  if (a?.startLine != null) {
+    pos.line_range = { start: { new_line: a.startLine }, end: { new_line: a.line } };
+  }
+  return pos;
+}
+
+// ---------------------------------------------------------------------------
+// Adapter
+// ---------------------------------------------------------------------------
+
+/**
+ * Create a GitLab adapter bound to an injected `request(url)` (same contract as
+ * the GitHub adapter; see index.mjs's typedef). Returns `{ data, stale }` where
+ * `data` is always a NORMALISED shape.
+ *
+ * @param {(url: string) => Promise<{ data: any, stale: boolean }>} request
+ * @param {(url: string, opts: { method: string, body?: any }) => Promise<{ data: any, stale: boolean }>} [requestWrite]
+ * @param {(url: string) => Promise<{ data: any, stale: boolean }>} [requestText]
+ */
+export function createGitlabAdapter(request, requestWrite, requestText = request) {
+  return {
+    kind: "gitlab",
+
+    async listPullRequests(repo, filter = {}) {
+      const url = `${API}${projectPath(repo)}/merge_requests${qs({ state: stateFilter(filter.state ?? "opened") })}`;
+      const { data, stale } = await request(url);
+      const raw = Array.isArray(data) ? data : [];
+      return { data: raw.map((m) => normalizeMr(m)), stale };
+    },
+
+    async getPullRequest(repo, number) {
+      const base = `${API}${projectPath(repo)}/merge_requests/${number}`;
+      const prRes = await request(base);
+      const raw = prRes.data;
+      let stale = prRes.stale;
+      let unresolvedThreads = 0;
+      try {
+        const t = await request(`${base}/discussions`);
+        stale = stale || Boolean(t?.stale);
+        unresolvedThreads = normalizeThreads(t?.data).filter((th) => !th.resolved).length;
+      } catch {
+        // Thread count is display-only; a failure must not blank the PR.
+      }
+      return { data: normalizeMr(raw, { unresolvedThreads }), stale };
+    },
+
+    // GitLab issues and MRs are DISJOINT objects (mismatch #4) — unlike
+    // GitHub, an issue list never leaks MRs, so nothing needs filtering.
+    async listIssues(repo, filter = {}) {
+      const url = `${API}${projectPath(repo)}/issues${qs({ state: stateFilter(filter.state ?? "opened") })}`;
+      const { data, stale } = await request(url);
+      const raw = Array.isArray(data) ? data : [];
+      const issues = raw.map((i) => ({
+        number: i.iid,
+        title: i.title ?? "",
+        body: i.description ?? "",
+        url: i.web_url ?? "",
+        state: i.state,
+        closed: i.state === "closed",
+      }));
+      return { data: issues, stale };
+    },
+
+    // Pipelines + commit statuses, not checks (mismatch #7). Both are fetched
+    // by HEAD SHA — GitLab indexes pipelines by commit too, so the shared
+    // `getChecks(repo, sha)` signature (no MR iid) still resolves them.
+    async getChecks(repo, sha) {
+      const base = `${API}${projectPath(repo)}`;
+      let stale = false;
+      let checks = [];
+      try {
+        const { data, stale: s } = await request(`${base}/pipelines${qs({ sha })}`);
+        checks = (Array.isArray(data) ? data : []).map(normalizePipeline);
+        stale = stale || s;
+      } catch {
+        // pipelines may be unavailable/empty; commit statuses below still cover it.
+      }
+      try {
+        const { data, stale: s } = await request(`${base}/repository/commits/${encodeURIComponent(sha)}/statuses`);
+        checks = checks.concat((Array.isArray(data) ? data : []).map(normalizeCommitStatus));
+        stale = stale || s;
+      } catch {
+        // no commit statuses — pipelines above may still cover it.
+      }
+      return { data: checks, stale };
+    },
+
+    async createPullRequest(repo, { title, head, base, body = "", draft = false }) {
+      if (!requestWrite) throw new Error("write transport not available");
+      const url = `${API}${projectPath(repo)}/merge_requests`;
+      // GitLab has no `draft` boolean on create — a title prefixed "Draft:" is
+      // how a draft MR is created (and how `work_in_progress` is signalled).
+      const { data } = await requestWrite(url, {
+        method: "POST",
+        body: {
+          source_branch: head,
+          target_branch: base,
+          title: draft ? `Draft: ${title}` : title,
+          description: body,
+        },
+      });
+      return { data: normalizeMr(data), stale: false };
+    },
+
+    async merge(repo, number, { method = "merge", sha } = {}) {
+      if (!requestWrite) throw new Error("write transport not available");
+      const url = `${API}${projectPath(repo)}/merge_requests/${number}/merge`;
+      let data;
+      try {
+        ({ data } = await requestWrite(url, { method: "PUT", body: { sha } }));
+      } catch (err) {
+        if (err && typeof err === "object" && typeof err.status === "number" && err.name === "GithubRequestError") {
+          throw mergeFailure(err.status, url);
+        }
+        throw err;
+      }
+      return { data, stale: false };
+    },
+
+    // ---- Review writes (BET-793) -----------------------------------------
+    //
+    // GitLab has NO review object (mismatch #5): no PENDING, no batching, no
+    // review body. Every comment POST publishes immediately. So "submit" here
+    // posts each buffered comment as its own discussion, then approve/unapprove
+    // for the verdict. The user-visible behaviour — the box-buffered draft
+    // flushes as one review — is identical to GitHub's; that is the payoff of
+    // the buffer.
+    async submitReview(repo, number, { verdict = null, body = "", comments = [], headSha = "" } = {}) {
+      if (!requestWrite) throw new Error("write transport not available");
+      const base = `${API}${projectPath(repo)}/merge_requests/${number}`;
+      const commentsArr = Array.isArray(comments) ? comments : [];
+      const shas = await positionShas(base, headSha, request);
+      for (const c of commentsArr) {
+        await requestWrite(`${base}/discussions`, {
+          method: "POST",
+          body: { body: c.body, position: buildPosition(shas, c) },
+        });
+      }
+      // A review body has no home in a comment-only model; post it as a general
+      // MR note so the author's summary survives (mirrors GitHub's review body).
+      if (typeof body === "string" && body.trim()) {
+        await requestWrite(`${base}/notes`, { method: "POST", body: { body: body.trim() } });
+      }
+      if (verdict === "approved") {
+        await requestWrite(`${base}/approve`, { method: "POST" });
+      } else if (verdict === "changes_requested") {
+        await requestWrite(`${base}/unapprove`, { method: "POST" });
+      }
+      return { data: { verdict: verdict ?? "comment", comments: commentsArr.length }, stale: false };
+    },
+
+    async replyToThread(repo, number, { threadId, body, headSha = "" } = {}) {
+      if (!requestWrite) throw new Error("write transport not available");
+      const url = `${API}${projectPath(repo)}/merge_requests/${number}/discussions/${threadId}/notes`;
+      const { data } = await requestWrite(url, { method: "POST", body: { body: String(body ?? "").trim() } });
+      return { data, stale: false };
+    },
+
+    // OPTIONAL capability: plain REST thread resolution (absent on GitHub,
+    // which needs GraphQL). Presence is the capability model.
+    async resolveThread(repo, number, { discussionId } = {}) {
+      if (!requestWrite) throw new Error("write transport not available");
+      const url = `${API}${projectPath(repo)}/merge_requests/${number}/discussions/${discussionId}`;
+      const { data } = await requestWrite(url, { method: "PUT", body: { resolved: true } });
+      return { data, stale: false };
+    },
+
+    async getDiff(repo, number) {
+      const base = `${API}${projectPath(repo)}/merge_requests/${number}`;
+      let stale = false;
+      let headSha = "";
+      let diff = "";
+      let threads = [];
+      try {
+        const pr = await request(base);
+        stale = stale || Boolean(pr?.stale);
+        headSha = pr?.data?.sha ?? "";
+      } catch {
+        // leave headSha empty; the changes request below still best-efforts.
+      }
+      // GitLab serves the diff as JSON (`/changes`, one `diff` per file) rather
+      // than a raw-text Accept variant — reassemble the unified diff from the
+      // per-file `diff` fields so the existing UnifiedDiff renderer consumes it
+      // verbatim (no structured differ is built).
+      try {
+        const changes = await request(`${base}/changes`);
+        stale = stale || Boolean(changes?.stale);
+        const files = Array.isArray(changes?.data?.changes) ? changes.data.changes : [];
+        diff = files.map((f) => f?.diff ?? "").join("\n");
+      } catch {
+        // diff best-effort
+      }
+      try {
+        const ds = await request(`${base}/discussions`);
+        stale = stale || Boolean(ds?.stale);
+        threads = normalizeThreads(ds?.data);
+      } catch {
+        // threads best-effort
+      }
+      return { data: { diff, threads, headSha }, stale };
+    },
+
+    // MR notes (GitLab's plain comments live on the MR, not an issues endpoint
+    // — mismatch #4 again). The progress sink reads these for its topic marker.
+    async listIssueComments(repo, number) {
+      const url = `${API}${projectPath(repo)}/merge_requests/${number}/notes`;
+      const { data, stale } = await request(url);
+      const raw = Array.isArray(data) ? data : [];
+      return { data: raw.map((c) => ({ id: c?.id ?? null, body: c?.body ?? "" })), stale };
+    },
+
+    async createIssueComment(repo, number, body) {
+      if (!requestWrite) throw new Error("write transport not available");
+      const url = `${API}${projectPath(repo)}/merge_requests/${number}/notes`;
+      const { data } = await requestWrite(url, { method: "POST", body: { body } });
+      return { data: { id: data?.id ?? null }, stale: false };
+    },
+
+    // GitLab note ids are iid-scoped, so this needs the MR number where
+    // GitHub's comment id is global — an interface asymmetry GitLab forces.
+    async updateIssueComment(repo, number, commentId, body) {
+      if (!requestWrite) throw new Error("write transport not available");
+      const url = `${API}${projectPath(repo)}/merge_requests/${number}/notes/${commentId}`;
+      const { data } = await requestWrite(url, { method: "PUT", body: { body } });
+      return { data: { id: data?.id ?? null }, stale: false };
+    },
+  };
+}

--- a/src/server/forge/gitlab.test.mjs
+++ b/src/server/forge/gitlab.test.mjs
@@ -366,6 +366,38 @@ test("getDiff assembles the diff from /changes and normalises discussions into t
   assert.equal(data.threads[1].resolved, true);
 });
 
+// ---- Progress sink comment methods (iid-scoped on GitLab) ------------------
+
+test("comment methods address GitLab MR notes iid-scoped; update matches the shared 4-arg contract", async () => {
+  const base = projectBase(REPO);
+  const write = fakeWrite({
+    [`${base}/merge_requests/42/notes/77`]: { id: 77 },
+  });
+  const adapter = createGitlabAdapter(
+    fakeRequest({
+      [`${base}/merge_requests/42/notes`]: [{ id: 7, body: "old" }],
+    }),
+    write,
+  );
+
+  const listed = await adapter.listIssueComments(REPO, 42);
+  assert.equal(listed.data.length, 1);
+  assert.equal(listed.data[0].id, 7);
+
+  await adapter.createIssueComment(REPO, 42, "hello");
+  const createWrite = write.calls.find((c) => c.url === `${base}/merge_requests/42/notes` && c.method === "POST");
+  assert.ok(createWrite, "createIssueComment POSTs to the MR notes endpoint");
+  assert.equal(createWrite.body.body, "hello");
+
+  // The sink calls updateComment(repo, number, commentId, body) — the unified
+  // shared contract — which on GitLab must reach /merge_requests/{iid}/notes/{id}.
+  await adapter.updateIssueComment(REPO, 42, 77, "updated");
+  const updateWrite = write.calls.find((c) => c.url === `${base}/merge_requests/42/notes/77`);
+  assert.ok(updateWrite, "updateIssueComment PUTs to the iid-scoped note endpoint");
+  assert.equal(updateWrite.method, "PUT");
+  assert.equal(updateWrite.body.body, "updated");
+});
+
 // ---- Mismatch #4: issues and MRs are disjoint ------------------------------
 
 test("listIssues maps iid → number with no PR filtering (GitLab issues are disjoint)", async () => {

--- a/src/server/forge/gitlab.test.mjs
+++ b/src/server/forge/gitlab.test.mjs
@@ -1,0 +1,466 @@
+// gitlab.test.mjs — the GitLab adapter (BET-799). No live network: `request`
+// / `requestWrite` are injected. Pins the eight mismatches at the adapter
+// boundary (iid-vs-id, subgroup path encoding, opened-vs-open, disjoint issues,
+// no-review-object submitReview, three-SHA position building, pipelines-not-
+// checks, detailed_merge_status) plus the webhook signature schemes and the
+// atomic OAuth token rotation.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createHmac } from "node:crypto";
+import {
+  createGitlabAdapter,
+  buildPosition,
+} from "./gitlab.mjs";
+import { rollupChecks } from "../../shared/forge.mjs";
+import { verifyGitlabSignature, resolveSignature } from "../webhooks.mjs";
+import { rotateOauthPair, parseGlabToken } from "./auth.mjs";
+
+const REPO = { owner: "acme", repo: "widget" };
+
+// A captured GitLab MR payload (GET /projects/{p}/merge_requests/{iid}).
+// `iid` is 123, the GLOBAL `id` is 9999 — the whole #1 point is that `number`
+// must be the iid, never the global id.
+const MR_FIXTURE = {
+  id: 9999,
+  iid: 123,
+  title: "Add GitLab adapter",
+  description: "Implements the GitLab seam.",
+  web_url: "https://gitlab.com/acme/widget/-/merge_requests/123",
+  state: "opened",
+  draft: false,
+  detailed_merge_status: "can_be_merged",
+  author: { username: "octocat" },
+  source_branch: "feature/forge",
+  target_branch: "main",
+  sha: "abc123",
+  reviewers: [{ username: "ada" }, { username: "octocat" }],
+};
+
+function fakeRequest(map) {
+  return async (url) => ({ data: map[url], stale: false });
+}
+
+// A fake write transport that records every call (url + method + body).
+function fakeWrite(map = {}) {
+  const calls = [];
+  const write = async (url, opts) => {
+    calls.push({ url, method: opts.method, body: opts.body });
+    if (map[url]) return { data: map[url], stale: false };
+    return { data: { ok: true }, stale: false };
+  };
+  write.calls = calls;
+  return write;
+}
+
+const projectBase = (repo) =>
+  `https://gitlab.com/api/v4/projects/${encodeURIComponent(`${repo.owner}/${repo.repo}`)}`;
+
+// ---- Mismatch #1: iid, never id --------------------------------------------
+
+test("getPullRequest normalises a captured MR; number === iid, never the global id", async () => {
+  const base = `${projectBase(REPO)}/merge_requests/123`;
+  const adapter = createGitlabAdapter(
+    fakeRequest({ [base]: MR_FIXTURE, [`${base}/discussions`]: [] }),
+  );
+  const { data: pr } = await adapter.getPullRequest(REPO, 123);
+
+  assert.equal(pr.number, 123, "number is the iid");
+  assert.notEqual(pr.number, MR_FIXTURE.id, "the global id must never leak into number");
+  assert.equal(pr.title, "Add GitLab adapter");
+  assert.equal(pr.url, "https://gitlab.com/acme/widget/-/merge_requests/123");
+  assert.equal(pr.headRef, "feature/forge");
+  assert.equal(pr.baseRef, "main");
+  assert.equal(pr.headSha, "abc123");
+  assert.equal(pr.author, "octocat");
+  assert.deepEqual(pr.reviewers, ["ada", "octocat"]);
+  assert.equal(pr.mergeable, true);
+  assert.equal(pr.mergeBlockedReason, null);
+});
+
+// ---- Mismatch #2: subgroup project addressing ------------------------------
+
+test("a subgroup project path encodes the FULL owner/repo, never the segments", async () => {
+  const subgroup = { owner: "group/sub", repo: "widget" };
+  const seen = [];
+  const request = async (url) => {
+    seen.push(url);
+    return { data: [], stale: false };
+  };
+  const adapter = createGitlabAdapter(request);
+  await adapter.listPullRequests(subgroup, { state: "open" });
+
+  assert.equal(seen.length, 1);
+  assert.ok(
+    seen[0].includes("/projects/group%2Fsub%2Fwidget/merge_requests"),
+    `path must URL-encode the full group/sub path, got ${seen[0]}`,
+  );
+  assert.ok(!seen[0].includes("/group/sub/"), "slashes must be encoded, not raw");
+});
+
+// ---- Mismatch #3: opened, not open -----------------------------------------
+
+test('"opened" → "open" and "locked" is handled', async () => {
+  const cases = [
+    { state: "opened", expected: "open" },
+    { state: "locked", expected: "open" },
+    { state: "merged", expected: "merged" },
+    { state: "closed", expected: "closed" },
+  ];
+  for (const { state, expected } of cases) {
+    const base = `${projectBase(REPO)}/merge_requests/7`;
+    const mr = { ...MR_FIXTURE, iid: 7, state, detailed_merge_status: "can_be_merged" };
+    const adapter = createGitlabAdapter(fakeRequest({ [base]: mr, [`${base}/discussions`]: [] }));
+    const { data: pr } = await adapter.getPullRequest(REPO, 7);
+    assert.equal(pr.state, expected, `raw "${state}" → "${expected}"`);
+  }
+});
+
+// ---- Mismatch #7: pipelines, not checks ------------------------------------
+
+test("pipeline statuses incl. manual & scheduled roll up to yellow, not red", async () => {
+  const base = projectBase(REPO);
+  const adapter = createGitlabAdapter(
+    fakeRequest({
+      [`${base}/pipelines?sha=abc123`]: [
+        { status: "success", name: "ci", web_url: "https://gl/ci/1" },
+        { status: "manual", name: "ci/manual", web_url: "https://gl/ci/2" },
+        { status: "scheduled", name: "ci/sched", web_url: "https://gl/ci/3" },
+      ],
+      [`${base}/repository/commits/abc123/statuses`]: [
+        { status: "scheduled", name: "deploy", target_url: "https://gl/st/1" },
+      ],
+    }),
+  );
+  const { data: checks } = await adapter.getChecks(REPO, "abc123");
+  assert.equal(checks.length, 4, "pipelines + commit statuses merged");
+  assert.equal(rollupChecks(checks), "yellow", "manual/scheduled are pending-ish → yellow, never red");
+
+  const allGreen = createGitlabAdapter(
+    fakeRequest({
+      [`${base}/pipelines?sha=abc123`]: [{ status: "success" }],
+      [`${base}/repository/commits/abc123/statuses`]: [{ status: "success" }],
+    }),
+  );
+  assert.equal(rollupChecks((await allGreen.getChecks(REPO, "abc123")).data), "green");
+});
+
+// ---- Mismatch #8: detailed_merge_status → mergeable + reason ---------------
+
+test("detailed_merge_status maps to mergeable + a distinct mergeBlockedReason", async () => {
+  const cases = [
+    { status: "conflict", reason: "conflicts" },
+    { status: "need_rebase", reason: "needs rebase" },
+    { status: "ci_must_pass", reason: "checks failing" },
+    { status: "not_approved", reason: "approval required" },
+    { status: "discussions_not_resolved", reason: "unresolved discussions" },
+  ];
+  const seen = new Set();
+  for (const { status, reason } of cases) {
+    const base = `${projectBase(REPO)}/merge_requests/9`;
+    const mr = { ...MR_FIXTURE, iid: 9, detailed_merge_status: status };
+    const adapter = createGitlabAdapter(fakeRequest({ [base]: mr, [`${base}/discussions`]: [] }));
+    const { data: pr } = await adapter.getPullRequest(REPO, 9);
+    assert.equal(pr.mergeable, false, `${status} is not mergeable`);
+    assert.ok(pr.mergeBlockedReason, `${status} yields a reason`);
+    assert.equal(pr.mergeBlockedReason, reason);
+    seen.add(pr.mergeBlockedReason);
+  }
+  assert.ok(seen.size >= 4, `at least four distinct reasons, got ${seen.size}: ${[...seen].join(", ")}`);
+});
+
+test("detailed_merge_status still computing → mergeable null, no fabricated reason", async () => {
+  const base = `${projectBase(REPO)}/merge_requests/11`;
+  const mr = { ...MR_FIXTURE, iid: 11, detailed_merge_status: "checking" };
+  const adapter = createGitlabAdapter(fakeRequest({ [base]: mr, [`${base}/discussions`]: [] }));
+  const { data: pr } = await adapter.getPullRequest(REPO, 11);
+  assert.equal(pr.mergeable, null);
+  assert.equal(pr.mergeBlockedReason, null);
+});
+
+// ---- Position building (mismatch #6) ---------------------------------------
+
+const SHAS = { base_sha: "b", start_sha: "s", head_sha: "h" };
+
+test("position building: added / removed / unchanged line → right new_line/old_line", () => {
+  const added = buildPosition(SHAS, { path: "a.ts", line: 10, side: "new" });
+  assert.equal(added.new_line, 10);
+  assert.equal(added.old_line, undefined, "an added line sets new_line only");
+  assert.equal(added.width, "right");
+  assert.equal(added.head_sha, "h");
+
+  const removed = buildPosition(SHAS, { path: "a.ts", line: 20, side: "old" });
+  assert.equal(removed.old_line, 20);
+  assert.equal(removed.new_line, undefined, "a removed line sets old_line only");
+  assert.equal(removed.width, "left");
+
+  const unchanged = buildPosition(SHAS, { path: "a.ts", line: 30, side: "both" });
+  assert.equal(unchanged.new_line, 30, "an unchanged line sets new_line");
+  assert.equal(unchanged.old_line, 30, "an unchanged line sets old_line too");
+  assert.equal(unchanged.width, "right");
+  assert.equal(unchanged.position_type, "text");
+});
+
+// ---- submitReview (mismatch #5): N discussions + one approve --------------
+
+test("submitReview posts N discussions (each buffered comment) then ONE approve", async () => {
+  const base = `${projectBase(REPO)}/merge_requests/42`;
+  const write = fakeWrite({});
+  const adapter = createGitlabAdapter(
+    fakeRequest({ [`${base}/versions`]: [{ base_sha: "b", start_sha: "s", head_sha: "abc123" }] }),
+    write,
+  );
+
+  const comments = [
+    { path: "a.ts", line: 1, side: "new", body: "c1" },
+    { path: "a.ts", line: 2, side: "old", body: "c2" },
+    { path: "b.ts", line: 5, side: "new", body: "c3" },
+  ];
+  const { data } = await adapter.submitReview(REPO, 42, {
+    verdict: "approved",
+    body: "",
+    comments,
+    headSha: "abc123",
+  });
+
+  const discussionCalls = write.calls.filter((c) => c.url === `${base}/discussions` && c.method === "POST");
+  const approveCalls = write.calls.filter((c) => c.url === `${base}/approve`);
+  assert.equal(write.calls.length, 4, "3 discussions + 1 approve");
+  assert.equal(discussionCalls.length, 3, "every buffered comment becomes a discussion");
+  assert.equal(approveCalls.length, 1, "exactly one approve");
+  assert.equal(data.verdict, "approved");
+  assert.equal(data.comments, 3);
+
+  // The first discussion carries a position (anchored with the three SHAs).
+  assert.ok(discussionCalls[0].body.position, "a comment posts a positioned discussion");
+  assert.equal(discussionCalls[0].body.position.head_sha, "abc123");
+});
+
+test("submitReview changes_requested → discussions + unapprove, no approve", async () => {
+  const base = `${projectBase(REPO)}/merge_requests/42`;
+  const write = fakeWrite({});
+  const adapter = createGitlabAdapter(
+    fakeRequest({ [`${base}/versions`]: [{ base_sha: "b", start_sha: "s", head_sha: "h" }] }),
+    write,
+  );
+  await adapter.submitReview(REPO, 42, {
+    verdict: "changes_requested",
+    body: "",
+    comments: [{ path: "a.ts", line: 1, side: "new", body: "c1" }],
+    headSha: "h",
+  });
+  const unapprove = write.calls.filter((c) => c.url === `${base}/unapprove`);
+  const approve = write.calls.filter((c) => c.url === `${base}/approve`);
+  assert.equal(unapprove.length, 1);
+  assert.equal(approve.length, 0);
+});
+
+test("submitReview posts a non-empty review body as a general MR note", async () => {
+  const base = `${projectBase(REPO)}/merge_requests/42`;
+  const write = fakeWrite({});
+  const adapter = createGitlabAdapter(
+    fakeRequest({ [`${base}/versions`]: [{ base_sha: "b", start_sha: "s", head_sha: "h" }] }),
+    write,
+  );
+  await adapter.submitReview(REPO, 42, {
+    verdict: "commented",
+    body: "summary note",
+    comments: [],
+    headSha: "h",
+  });
+  const note = write.calls.find((c) => c.url === `${base}/notes`);
+  assert.ok(note, "a review body is posted as a general MR note");
+  assert.equal(note.body.body, "summary note");
+});
+
+// ---- resolveThread (optional capability, absent on GitHub) -----------------
+
+test("resolveThread PUTs resolved:true to the discussion endpoint", async () => {
+  const base = `${projectBase(REPO)}/merge_requests/42/discussions/d1`;
+  const write = fakeWrite({ [base]: { id: "d1", resolved: true } });
+  const adapter = createGitlabAdapter(() => Promise.resolve({ data: {}, stale: false }), write);
+  const { data } = await adapter.resolveThread(REPO, 42, { discussionId: "d1" });
+  assert.equal(write.calls.length, 1);
+  assert.equal(write.calls[0].url, base);
+  assert.equal(write.calls[0].method, "PUT");
+  assert.deepEqual(write.calls[0].body, { resolved: true });
+  assert.equal(data.id, "d1");
+});
+
+// ---- createPullRequest: draft via title prefix -----------------------------
+
+test("createPullRequest posts source/target branches and prefixes Draft: for a draft MR", async () => {
+  const url = `${projectBase(REPO)}/merge_requests`;
+  const created = { ...MR_FIXTURE, iid: 99, draft: true, title: "Draft: Forge seam" };
+  const write = fakeWrite({ [url]: created });
+  const adapter = createGitlabAdapter(() => Promise.resolve({ data: [], stale: false }), write);
+  const { data: pr } = await adapter.createPullRequest(REPO, {
+    title: "Forge seam",
+    head: "feature/forge",
+    base: "main",
+    body: "B",
+    draft: true,
+  });
+  assert.equal(write.calls[0].method, "POST");
+  assert.deepEqual(write.calls[0].body, {
+    source_branch: "feature/forge",
+    target_branch: "main",
+    title: "Draft: Forge seam",
+    description: "B",
+  });
+  assert.equal(pr.draft, true);
+});
+
+// ---- getDiff: assemble unified diff + normalised threads -------------------
+
+test("getDiff assembles the diff from /changes and normalises discussions into threads", async () => {
+  const base = `${projectBase(REPO)}/merge_requests/42`;
+  const adapter = createGitlabAdapter(
+    fakeRequest({
+      [base]: { ...MR_FIXTURE, iid: 42, sha: "abc123" },
+      [`${base}/changes`]: {
+        changes: [{ diff: "@@ -1 +1 @@\n+a\n" }, { diff: "@@ -5 +5 @@\n+b\n" }],
+      },
+      [`${base}/discussions`]: [
+        {
+          id: "d1",
+          resolved: false,
+          notes: [
+            {
+              author: { username: "ada" },
+              body: "look here",
+              created_at: "2026-08-01T10:00:00Z",
+              position: { new_path: "a.ts", new_line: 1 },
+            },
+          ],
+        },
+        {
+          id: "d2",
+          resolved: true,
+          notes: [
+            {
+              author: { username: "grace" },
+              body: "older",
+              created_at: "2026-08-01T10:05:00Z",
+              position: { new_path: "a.ts", old_line: 5 },
+            },
+          ],
+        },
+        {
+          id: "d3",
+          resolved: false,
+          notes: [{ author: { username: "bob" }, body: "not a line comment" }],
+        },
+      ],
+    }),
+  );
+  const { data } = await adapter.getDiff(REPO, 42);
+  assert.equal(data.diff, "@@ -1 +1 @@\n+a\n\n@@ -5 +5 @@\n+b\n");
+  assert.equal(data.headSha, "abc123");
+  assert.equal(data.threads.length, 2, "general (non-line) discussions are not threads");
+  assert.equal(data.threads[0].id, "d1");
+  assert.equal(data.threads[0].line, 1);
+  assert.equal(data.threads[0].side, "RIGHT", "new_line → RIGHT side");
+  assert.equal(data.threads[0].comments[0].body, "look here");
+  assert.equal(data.threads[1].side, "LEFT", "old_line → LEFT side");
+  assert.equal(data.threads[1].resolved, true);
+});
+
+// ---- Mismatch #4: issues and MRs are disjoint ------------------------------
+
+test("listIssues maps iid → number with no PR filtering (GitLab issues are disjoint)", async () => {
+  const url = `${projectBase(REPO)}/issues?state=opened`;
+  const adapter = createGitlabAdapter(
+    fakeRequest({
+      [url]: [
+        { iid: 1, title: "issue one", description: "", web_url: "u/1", state: "opened" },
+        { iid: 2, title: "issue two", description: "", web_url: "u/2", state: "closed" },
+      ],
+    }),
+  );
+  const { data: issues } = await adapter.listIssues(REPO, { state: "open" });
+  // "open" filter maps to GitLab's "opened", and no pull_request filtering needed.
+  assert.equal(issues.map((i) => i.number).join(","), "1,2");
+  assert.equal(issues[0].state, "opened");
+  assert.equal(issues[1].closed, true);
+});
+
+// ---- Webhook signature schemes (a THIRD scheme) ----------------------------
+
+test("Standard Webhooks signature verifies; X-Gitlab-Token verifies; a bad one fails", () => {
+  const keyBytes = Buffer.from("0123456789abcdef0123456789abcdef");
+  const secret = `whsec_${keyBytes.toString("base64")}`;
+  const id = "msg_1234567890";
+  const ts = String(Math.floor(Date.now() / 1000));
+  const raw = JSON.stringify({ object_kind: "merge_request" });
+
+  const sig = createHmac("sha256", keyBytes).update(`${id}.${ts}.${raw}`).digest("base64");
+  const swHeaders = {
+    "webhook-signature": `v1,${sig}`,
+    "webhook-id": id,
+    "webhook-timestamp": ts,
+  };
+  assert.equal(
+    verifyGitlabSignature(secret, raw, swHeaders),
+    true,
+    "a valid Standard-Webhooks signature verifies",
+  );
+  assert.equal(
+    resolveSignature("gitlab", secret, raw, swHeaders),
+    true,
+    "resolveSignature dispatches gitlab to the Standard-Webhooks verifier",
+  );
+
+  // Legacy: X-Gitlab-Token plain header.
+  assert.equal(verifyGitlabSignature(secret, raw, { "x-gitlab-token": secret }), true);
+
+  // A bad signature fails; a stale timestamp fails.
+  assert.equal(
+    verifyGitlabSignature(secret, raw, { ...swHeaders, "webhook-signature": "v1,AAAAAAAAAAAAAAAA" }),
+    false,
+  );
+  assert.equal(
+    verifyGitlabSignature(secret, raw, { ...swHeaders, "webhook-timestamp": String(Number(ts) - 999999) }),
+    false,
+    "a stale replay must not verify",
+  );
+  assert.equal(verifyGitlabSignature(secret, raw, { "x-gitlab-token": "wrong" }), false);
+});
+
+// ---- Auth: atomic token rotation + glab config parsing ---------------------
+
+test("rotateOauthPair persists the new pair BEFORE the caller uses it again", async () => {
+  const order = [];
+  let persisted = null;
+  const next = await rotateOauthPair(
+    async () => {
+      order.push("refresh");
+      return { access_token: "at2", refresh_token: "rt2" };
+    },
+    async (pair) => {
+      order.push("persist");
+      persisted = pair;
+    },
+  );
+  assert.deepEqual(next, { access_token: "at2", refresh_token: "rt2" });
+  assert.deepEqual(order, ["refresh", "persist"], "persist settles before any further use");
+  assert.deepEqual(persisted, next);
+});
+
+test("parseGlabToken reads the token for a host from glab config text", () => {
+  const cfg = [
+    "git_protocol: https",
+    "api_protocol: https",
+    "check_update: false",
+    "hosts:",
+    "  gitlab.com:",
+    "    user: octocat",
+    "    token: glpat-abc123",
+    "  other.example.com:",
+    "    token: glpat-other",
+  ].join("\n");
+  assert.equal(parseGlabToken(cfg, "gitlab.com"), "glpat-abc123");
+  assert.equal(parseGlabToken(cfg, "other.example.com"), "glpat-other");
+  assert.equal(parseGlabToken(cfg, "missing.com"), null);
+  assert.equal(parseGlabToken("", "gitlab.com"), null);
+});

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -27,9 +27,10 @@
 // cwd → origin → repo server-side, keeping the renderer ignorant of forge
 // identity).
 
-import { detectForge, rollupChecks, unsupportedByForge, repoKey as forgeRepoKey } from "../../shared/forge.mjs";
+import { rollupChecks, unsupportedByForge, repoKey as forgeRepoKey } from "../../shared/forge.mjs";
 import { run } from "../tmux.mjs";
-import { gitRemoteOrigin as localGitRemoteOrigin, detectForgeCli as localDetectForgeCli, gitPush as localGitPush } from "../local.mjs";
+import { gitRemoteOrigin as localGitRemoteOrigin, detectForgeCli as localDetectForgeCli, gitPush as localGitPush, configGet as localConfigGet } from "../local.mjs";
+import { detectForgeWithHosts } from "./selfhost.mjs";
 import { resolveToken as authResolveToken } from "./auth.mjs";
 import { startDeviceGrant as authStartDeviceGrant, pollDeviceGrant as authPollDeviceGrant, cancelDeviceGrant as authCancelDeviceGrant, ExpiredCodeError, DeviceFlowNotConfiguredError } from "./auth.mjs";
 import { getCloneStore } from "./clone.mjs";
@@ -261,7 +262,7 @@ const ADAPTERS = Object.freeze({ github: createGithubAdapter, gitlab: createGitl
 export function createForgeRuntime({ fetch = globalThis.fetch } = {}) {
   const requestLayer = createRequestLayer({ fetch });
   return {
-    getAdapter(kind, token) {
+    getAdapter(kind, token, apiBase) {
       const create = ADAPTERS[kind];
       if (!create) throw unsupportedByForge(kind, "read path");
       const wire = AUTH_BY_KIND[kind] ?? AUTH_BY_KIND.github;
@@ -271,7 +272,10 @@ export function createForgeRuntime({ fetch = globalThis.fetch } = {}) {
         requestLayer.requestJson(url, { token, tokenHeader: wire.tokenHeader, accept: wire.accept, ...opts });
       const requestText = (url) =>
         requestLayer.getText(url, { token, tokenHeader: wire.tokenHeader, accept: wire.accept });
-      return create(request, requestWrite, requestText);
+      // apiBase is the per-host API root (github.com → api.github.com, a
+      // self-hosted GitLab → <host>/api/v4); omitted it defaults inside the
+      // adapter to its canonical hosted root.
+      return create(request, requestWrite, requestText, apiBase);
     },
     requestLayer,
   };
@@ -282,12 +286,13 @@ const defaultRuntime = createForgeRuntime();
 /**
  * `getAdapter(kind)` → the adapter for a forge, or throws UnsupportedByForgeError
  * for an unknown kind. The instance is bound to the shared request layer and a
- * per-call token.
+ * per-call token. `apiBase` is the per-host API root for self-hosted forges.
  * @param {"github"} kind
  * @param {string} token
+ * @param {string} [apiBase]
  */
-export function getAdapter(kind, token) {
-  return defaultRuntime.getAdapter(kind, token);
+export function getAdapter(kind, token, apiBase) {
+  return defaultRuntime.getAdapter(kind, token, apiBase);
 }
 
 // ---- Box-facing reads ----------------------------------------------------------
@@ -301,6 +306,23 @@ const EMPTY = Object.freeze({ pr: null, checks: [], rollup: "none", stale: false
 const KNOWN_KINDS = new Set(["github", "gitlab"]);
 function isKnownKind(kind) {
   return typeof kind === "string" && KNOWN_KINDS.has(kind);
+}
+
+// Default box-facing forge detection: the shared `detectForge` plus the
+// user-configured `forgeHosts` (AppConfig) mapping layered on top, so a
+// self-hosted GitHub/GitLab host a user has configured resolves to its kind
+// + apiBase while an unconfigured unknown host still falls through to null.
+// `getConfig` is injectable for tests; failures degrade to the known hosts.
+async function detectFromConfig(origin, { getConfig = localConfigGet } = {}) {
+  if (!origin) return null;
+  let hostKinds = [];
+  try {
+    const cfg = await getConfig();
+    hostKinds = Array.isArray(cfg?.forgeHosts) ? cfg.forgeHosts : [];
+  } catch {
+    /* config unreadable — known hosts still resolve */
+  }
+  return detectForgeWithHosts(origin, hostKinds);
 }
 
 /**
@@ -477,13 +499,14 @@ async function resolveForgeContext(cwd, deps) {
   const gitRemoteOrigin = deps.gitRemoteOrigin ?? defaultGitRemoteOrigin;
   const resolveToken = deps.resolveToken ?? authResolveToken;
   const getAdapterFn = deps.getAdapter ?? getAdapter;
+  const detectForge = deps.detectForge ?? detectFromConfig;
 
   const origin = await gitRemoteOrigin(cwd);
-  const forge = origin ? detectForge(origin) : null;
+  const forge = origin ? await detectForge(origin, deps) : null;
   if (!forge || !isKnownKind(forge.kind)) return { error: "no_forge" };
   const tok = await resolveToken(forge.host);
   if (!tok) return { error: "not_connected" };
-  const adapter = getAdapterFn(forge.kind, tok.token);
+  const adapter = getAdapterFn(forge.kind, tok.token, forge.apiBase);
   const repo = { owner: forge.owner, repo: forge.repo };
   return { forge, repo, token: tok, adapter };
 }

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -34,6 +34,7 @@ import { resolveToken as authResolveToken } from "./auth.mjs";
 import { startDeviceGrant as authStartDeviceGrant, pollDeviceGrant as authPollDeviceGrant, cancelDeviceGrant as authCancelDeviceGrant, ExpiredCodeError, DeviceFlowNotConfiguredError } from "./auth.mjs";
 import { getCloneStore } from "./clone.mjs";
 import { createGithubAdapter, GithubRequestError, buildInboxQueries, mergeInboxSources } from "./github.mjs";
+import { createGitlabAdapter } from "./gitlab.mjs";
 import { getDraft as storeGetDraft, putComment as storePutComment, deleteComment as storeDeleteComment, setVerdict as storeSetVerdict, markDraftStale as storeMarkDraftStale, clearDraft as storeClearDraft } from "./draft.mjs";
 import { readFile as fsReadFile } from "node:fs/promises";
 import { join } from "node:path";
@@ -78,7 +79,7 @@ function bucketOf(url) {
  *
  * @param {{ fetch?: typeof fetch, now?: () => number }} [opts]
  * @returns {{
- *   getJson: (url: string, opts: { token: string, ttl?: number }) => Promise<{ data: any, stale: boolean }>,
+ *   getJson: (url: string, opts: { token: string, tokenHeader?: string, accept?: string, ttl?: number }) => Promise<{ data: any, stale: boolean }>,
  * }}
  */
 export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } = {}) {
@@ -86,7 +87,7 @@ export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } 
   const inflight = new Map(); // url -> Promise
   const coolingUntil = new Map(); // bucketKey -> ms
 
-  async function getJson(url, { token, ttl } = {}) {
+  async function getJson(url, { token, tokenHeader, accept = "application/vnd.github+json", ttl } = {}) {
     const bucket = bucketOf(url);
     // Per-resource freshness override: the inbox's search bucket has its own,
     // much lower rate limit (spec §4.5④), so its values are held a full 60s —
@@ -115,7 +116,7 @@ export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } 
     const inFlight = inflight.get(url);
     if (inFlight) return inFlight;
 
-    const job = fetchOne(url, token, bucket, url, "application/vnd.github+json", (res) => res.json(), etagStore, inflight, coolingUntil, fetch, now);
+    const job = fetchOne(url, token, tokenHeader, bucket, url, accept, (res) => res.json(), etagStore, inflight, coolingUntil, fetch, now);
     inflight.set(url, job);
     try {
       return await job;
@@ -129,7 +130,7 @@ export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } 
   // SAME URL are cached under separate keys (`text:` prefix) so one never
   // clobbers the other in the ETag store (the diff response is a different
   // representation of `/pulls/{n}` than the PR object).
-  async function getText(url, { token }) {
+  async function getText(url, { token, tokenHeader, accept = "application/vnd.github.diff" }) {
     const cacheKey = `text:${url}`;
     const bucket = bucketOf(url);
 
@@ -147,7 +148,7 @@ export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } 
     const inFlight = inflight.get(cacheKey);
     if (inFlight) return inFlight;
 
-    const job = fetchOne(url, token, bucket, cacheKey, "application/vnd.github.diff", (res) => res.text(), etagStore, inflight, coolingUntil, fetch, now);
+    const job = fetchOne(url, token, tokenHeader, bucket, cacheKey, accept, (res) => res.text(), etagStore, inflight, coolingUntil, fetch, now);
     inflight.set(cacheKey, job);
     try {
       return await job;
@@ -160,7 +161,7 @@ export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } 
     getJson,
     getText,
     requestJson: (url, opts) =>
-      requestJsonImpl(url, { token: opts?.token, method: opts?.method, body: opts?.body }, fetch),
+      requestJsonImpl(url, { token: opts?.token, tokenHeader: opts?.tokenHeader, accept: opts?.accept, method: opts?.method, body: opts?.body }, fetch),
   };
 }
 
@@ -169,13 +170,13 @@ export function createRequestLayer({ fetch = globalThis.fetch, now = Date.now } 
 // GET path (issue §4). Returns `{ data, stale: false }` on 2xx; any non-2xx
 // throws GithubRequestError(status, url) so the adapter can map merge-status
 // codes to their distinguished failure kinds.
-async function requestJsonImpl(url, { token, method = "GET", body }, fetchImpl) {
+async function requestJsonImpl(url, { token, tokenHeader, method = "GET", body, accept = "application/vnd.github+json" }, fetchImpl) {
   const res = await fetchImpl(url, {
     method,
     headers: {
-      accept: "application/vnd.github+json",
+      accept,
       "user-agent": "manta-forge",
-      ...(token ? { authorization: `Bearer ${token}` } : {}),
+      ...authHeaders(token, tokenHeader),
       ...(body !== undefined ? { "content-type": "application/json" } : {}),
     },
     body: body !== undefined ? JSON.stringify(body) : undefined,
@@ -185,12 +186,22 @@ async function requestJsonImpl(url, { token, method = "GET", body }, fetchImpl) 
   return { data, stale: false };
 }
 
-async function fetchOne(url, token, bucket, cacheKey, accept, parse, etagStore, inflight, coolingUntil, fetch, now) {
+// How a forge credential appears in an outgoing request. GitHub and OAuth use
+// `Authorization: Bearer`; GitLab personal access tokens use the `PRIVATE-TOKEN`
+// header (they also accept Bearer for OAuth tokens). `tokenHeader` is set
+// per-adapter-kind by the registry so the right scheme rides every call.
+function authHeaders(token, tokenHeader) {
+  if (!token) return {};
+  if (tokenHeader) return { [tokenHeader]: token };
+  return { authorization: `Bearer ${token}` };
+}
+
+async function fetchOne(url, token, tokenHeader, bucket, cacheKey, accept, parse, etagStore, inflight, coolingUntil, fetch, now) {
   const hit = etagStore.get(cacheKey);
   const headers = {
     accept,
     "user-agent": "manta-forge",
-    ...(token ? { authorization: `Bearer ${token}` } : {}),
+    ...authHeaders(token, tokenHeader),
     ...(hit ? { "if-none-match": hit.etag } : {}),
   };
 
@@ -227,10 +238,19 @@ async function fetchOne(url, token, bucket, cacheKey, accept, parse, etagStore, 
 
 // ---- Registry -----------------------------------------------------------------
 
+// How each forge's credential is presented on the wire (spec §3.3). GitHub and
+// any OAuth token ride `Authorization: Bearer`; a GitLab personal access token
+// is a `PRIVATE-TOKEN` header. `apiAccept` is the JSON Accept header for that
+// forge's API.
+const AUTH_BY_KIND = Object.freeze({
+  github: Object.freeze({ tokenHeader: null, accept: "application/vnd.github+json" }),
+  gitlab: Object.freeze({ tokenHeader: "PRIVATE-TOKEN", accept: "application/vnd.gitlab+json" }),
+});
+
 // kind -> adapter factory. `create(adapterRequest)` returns the adapter; the
 // adapterRequest closure binds a per-call token to the SHARED request layer so
 // ETag/single-flight/cooling persist across calls and across token rotations.
-const ADAPTERS = Object.freeze({ github: createGithubAdapter });
+const ADAPTERS = Object.freeze({ github: createGithubAdapter, gitlab: createGitlabAdapter });
 
 /**
  * Create an isolated forge runtime with its own request layer — the test seam.
@@ -244,9 +264,13 @@ export function createForgeRuntime({ fetch = globalThis.fetch } = {}) {
     getAdapter(kind, token) {
       const create = ADAPTERS[kind];
       if (!create) throw unsupportedByForge(kind, "read path");
-      const request = (url, opts) => requestLayer.getJson(url, { token, ttl: opts?.ttl });
-      const requestWrite = (url, opts) => requestLayer.requestJson(url, { token, ...opts });
-      const requestText = (url) => requestLayer.getText(url, { token });
+      const wire = AUTH_BY_KIND[kind] ?? AUTH_BY_KIND.github;
+      const request = (url, opts) =>
+        requestLayer.getJson(url, { token, tokenHeader: wire.tokenHeader, accept: wire.accept, ttl: opts?.ttl });
+      const requestWrite = (url, opts) =>
+        requestLayer.requestJson(url, { token, tokenHeader: wire.tokenHeader, accept: wire.accept, ...opts });
+      const requestText = (url) =>
+        requestLayer.getText(url, { token, tokenHeader: wire.tokenHeader, accept: wire.accept });
       return create(request, requestWrite, requestText);
     },
     requestLayer,
@@ -270,6 +294,14 @@ export function getAdapter(kind, token) {
 
 const GH_HOST = "github.com";
 const EMPTY = Object.freeze({ pr: null, checks: [], rollup: "none", stale: false, error: null });
+
+// The forge kinds the box-facing reads/writes route through the seam. Adding a
+// kind here (with its adapter registered above) is what makes a forge render in
+// the session header / review pane; unknown kinds fall through to `no_forge`.
+const KNOWN_KINDS = new Set(["github", "gitlab"]);
+function isKnownKind(kind) {
+  return typeof kind === "string" && KNOWN_KINDS.has(kind);
+}
 
 /**
  * forge:status — `{ connected, login, kind, source } | { connected: false }`.
@@ -448,7 +480,7 @@ async function resolveForgeContext(cwd, deps) {
 
   const origin = await gitRemoteOrigin(cwd);
   const forge = origin ? detectForge(origin) : null;
-  if (!forge || forge.kind !== "github") return { error: "no_forge" };
+  if (!forge || !isKnownKind(forge.kind)) return { error: "no_forge" };
   const tok = await resolveToken(forge.host);
   if (!tok) return { error: "not_connected" };
   const adapter = getAdapterFn(forge.kind, tok.token);
@@ -1054,6 +1086,7 @@ export async function draftSubmitForCwd(cwd, input = {}, deps = {}) {
  *
  * @typedef {Object} ForgeAdapter
  * @property {"github" | "gitlab"} kind
+ * @property {((repo: { owner: string, repo: string }, number: number, input: { discussionId: string }) => Promise<{ data: any, stale: boolean }>)} [resolveThread] — OPTIONAL.
  * @property {(repo: { owner: string, repo: string }, filter?: { state?: string }) => Promise<{ data: Array<any>, stale: boolean }>} listPullRequests
  * @property {(repo: { owner: string, repo: string }, number: number) => Promise<{ data: any, stale: boolean }>} getPullRequest
  * @property {(repo: { owner: string, repo: string }, filter?: { state?: string }) => Promise<{ data: Array<any>, stale: boolean }>} listIssues

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -25,6 +25,7 @@ import {
   ForgeRateLimitedError,
 } from "./index.mjs";
 import { getDraft, putComment } from "./draft.mjs";
+import { detectForgeWithHosts } from "./selfhost.mjs";
 
 const URL = "https://api.github.com/repos/acme/widget/pulls?state=open";
 
@@ -239,6 +240,23 @@ test("pullRequestForCwd: no open PR → well-formed empty result, not an error",
 test("getAdapter throws UnsupportedByForgeError for an unknown kind", async () => {
   const runtime = createForgeRuntime({ fetch: async () => json({}, 200, {}) });
   assert.throws(() => runtime.getAdapter("gitea", "t"), (e) => e.name === "UnsupportedByForgeError");
+});
+
+test("a configured self-hosted host routes through the box op with its apiBase", async () => {
+  let got = null;
+  const r = await pullRequestForCwd("/repo", {
+    gitRemoteOrigin: async () => "git@git.example.com:acme/widget.git",
+    currentBranch: async () => "feature/x",
+    resolveToken: async () => ({ token: "glpat_t", source: "cli" }),
+    detectForge: (origin) => detectForgeWithHosts(origin, [{ host: "git.example.com", kind: "gitlab" }]),
+    getAdapter: (kind, token, apiBase) => {
+      got = { kind, token, apiBase };
+      return fakeAdapter({ prs: [OPEN_PR] });
+    },
+  });
+  assert.equal(r.error, null);
+  assert.equal(r.pr.number, 42);
+  assert.deepEqual(got, { kind: "gitlab", token: "glpat_t", apiBase: "https://git.example.com/api/v4" });
 });
 
 // ---- Box-facing writes: shipPullRequest + mergePullRequest (BET-794) -------

--- a/src/server/forge/selfhost.mjs
+++ b/src/server/forge/selfhost.mjs
@@ -1,0 +1,120 @@
+// src/server/forge/selfhost.mjs — user-configured host→kind mapping (BET-799 §Self-hosted).
+//
+// `detectForge` in src/shared/forge.mjs deliberately returns `null` for unknown
+// hosts (a deliberate design decision — never guess a forge from a bare URL).
+// This module LAYERS a user-configured mapping on top of it WITHOUT touching
+// shared/forge.mjs: a host in the AppConfig `forgeHosts` list resolves to its
+// configured kind + apiBase; every known host (github.com / gitlab.com) still
+// resolves through the shared detector, unchanged.
+//
+// It also owns per-host API base derivation: the adapters no longer hardcode a
+// single hosted root (github.com → api.github.com, gitlab.com → gitlab.com/api/v4),
+// so a self-hosted instance serves its own `<host>/api/v4` (GitLab) or
+// `<host>/api/v3` (GitHub). Pure — no I/O, no network.
+
+import { detectForge } from "../../shared/forge.mjs";
+
+// Default API roots for the two hosted forges.
+const HOSTED_API_BASE = Object.freeze({
+  "github.com": "https://api.github.com",
+  "gitlab.com": "https://gitlab.com/api/v4",
+});
+
+/**
+ * Derive an API base for `kind` at `host`. Hosted hosts get their canonical root;
+ * a self-hosted host gets `<host>/api/vN` (GitLab v4, GitHub v3) — the
+ * conventional self-managed mount points.
+ * @param {"github"|"gitlab"} kind
+ * @param {string} host
+ * @returns {string}
+ */
+export function defaultApiBase(kind, host) {
+  const h = String(host ?? "").toLowerCase();
+  const hosted = HOSTED_API_BASE[h];
+  if (hosted) return hosted;
+  if (kind === "gitlab") return `https://${h}/api/v4`;
+  if (kind === "github") return `https://${h}/api/v3`;
+  return "";
+}
+
+/**
+ * Parse a git remote string into `{ host, owner, repo }` for ANY host, mirroring
+ * the shared `detectForge` parsing (https/ssh/scp forms, `.git` suffix, nested
+ * subgroup owners). Pure. Returns `null` for a local path / non-git / empty.
+ *
+ * @param {unknown} remoteUrl
+ * @returns {{ host: string, owner: string, repo: string } | null}
+ */
+export function parseRemotePath(remoteUrl) {
+  if (typeof remoteUrl !== "string") return null;
+  const input = remoteUrl.trim();
+  if (input === "") return null;
+
+  let host;
+  let path;
+  const scp = input.match(/^[^@\s/]+@([^:\s]+):(.+)$/);
+  if (scp) {
+    host = scp[1];
+    path = scp[2];
+  } else {
+    let url;
+    try {
+      url = new URL(input);
+    } catch {
+      return null;
+    }
+    if (url.protocol !== "http:" && url.protocol !== "https:" && url.protocol !== "ssh:") return null;
+    host = url.hostname;
+    path = url.pathname;
+  }
+
+  host = String(host).toLowerCase();
+  const clean = path.trim().replace(/^\/+/, "").replace(/\/+$/, "");
+  const parts = clean.split("/").filter((s) => s !== "");
+  if (parts.length < 2) return null;
+  const owner = parts.slice(0, -1).join("/").toLowerCase();
+  const repo = parts[parts.length - 1].toLowerCase().replace(/\.git$/, "");
+  if (owner === "" || repo === "") return null;
+  return { host, owner, repo };
+}
+
+const KNOWN_KINDS = new Set(["github", "gitlab"]);
+
+/**
+ * Layer the configured host→kind mapping on top of the shared detector.
+ *
+ * - A known host (github.com / gitlab.com) resolves through `detectForge`, with
+ *   its canonical apiBase — behaviour identical to before.
+ * - An unknown host resolves ONLY when it is present in `hostKinds` (the
+ *   AppConfig list, `[{ host, kind, apiBase? }]`). Its kind comes from the
+ *   config, never from guessing the URL; apiBase is the configured one or the
+ *   conventional `<host>/api/vN` default.
+ * - Anything else → null (the shared "unknown host is out of scope" contract).
+ *
+ * @param {unknown} remoteUrl
+ * @param {Array<{ host?: string, kind?: string, apiBase?: string }>} [hostKinds]
+ * @returns {{ kind: "github"|"gitlab", host: string, owner: string, repo: string, apiBase: string } | null}
+ */
+export function detectForgeWithHosts(remoteUrl, hostKinds = []) {
+  const known = detectForge(remoteUrl);
+  if (known) {
+    return {
+      ...known,
+      apiBase: HOSTED_API_BASE[known.host] ?? defaultApiBase(known.kind, known.host),
+    };
+  }
+  const parsed = parseRemotePath(remoteUrl);
+  if (!parsed) return null;
+  const host = parsed.host;
+  const entry = (Array.isArray(hostKinds) ? hostKinds : []).find(
+    (e) => e && typeof e.host === "string" && e.host.toLowerCase() === host && KNOWN_KINDS.has(e.kind),
+  );
+  if (!entry) return null;
+  return {
+    kind: entry.kind,
+    host,
+    owner: parsed.owner,
+    repo: parsed.repo,
+    apiBase: (typeof entry.apiBase === "string" && entry.apiBase) || defaultApiBase(entry.kind, host),
+  };
+}

--- a/src/server/forge/selfhost.test.mjs
+++ b/src/server/forge/selfhost.test.mjs
@@ -1,0 +1,76 @@
+// selfhost.test.mjs — the layered host→kind detection (BET-799 §Self-hosted).
+// Pins that known hosts resolve through the shared detector unchanged, unknown
+// hosts resolve ONLY via a configured `forgeHosts` entry, apiBase follows the
+// per-host rule, and `src/shared/forge.mjs` is untouched.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { detectForgeWithHosts, parseRemotePath, defaultApiBase } from "./selfhost.mjs";
+
+test("a known host resolves exactly as before, with its canonical apiBase", () => {
+  const github = detectForgeWithHosts("git@github.com:acme/widget.git", []);
+  assert.deepEqual(github, {
+    kind: "github",
+    host: "github.com",
+    owner: "acme",
+    repo: "widget",
+    apiBase: "https://api.github.com",
+  });
+
+  const gitlab = detectForgeWithHosts("https://gitlab.com/group/sub/proj.git", []);
+  assert.deepEqual(gitlab, {
+    kind: "gitlab",
+    host: "gitlab.com",
+    owner: "group/sub",
+    repo: "proj",
+    apiBase: "https://gitlab.com/api/v4",
+  });
+});
+
+test("an unknown host is null UNLESS configured in the host→kind list", () => {
+  // No config → unresolved (the shared contract: never guess).
+  assert.equal(detectForgeWithHosts("git@git.example.com:acme/widget.git", []), null);
+
+  const hosts = [{ host: "git.example.com", kind: "gitlab" }];
+  const r = detectForgeWithHosts("git@git.example.com:acme/widget.git", hosts);
+  assert.deepEqual(r, {
+    kind: "gitlab",
+    host: "git.example.com",
+    owner: "acme",
+    repo: "widget",
+    apiBase: "https://git.example.com/api/v4",
+  });
+});
+
+test("a configured apiBase overrides the derivation default", () => {
+  const hosts = [{ host: "git.example.com", kind: "gitlab", apiBase: "https://git.example.com/api/v4" }];
+  const r = detectForgeWithHosts("https://git.example.com/acme/widget", hosts);
+  assert.equal(r.apiBase, "https://git.example.com/api/v4");
+});
+
+test("nested subgroup owner survives for a configured self-hosted gitlab", () => {
+  const hosts = [{ host: "git.example.com", kind: "gitlab" }];
+  const r = detectForgeWithHosts("https://git.example.com/team/platform/shared.git", hosts);
+  assert.equal(r.owner, "team/platform");
+  assert.equal(r.repo, "shared");
+});
+
+test("a config entry with an unknown kind is ignored (never coerce a typo)", () => {
+  const hosts = [{ host: "git.example.com", kind: "gitea" }];
+  assert.equal(detectForgeWithHosts("git@git.example.com:acme/widget.git", hosts), null);
+});
+
+test("defaultApiBase: hosted canonical, self-hosted conventional mounts", () => {
+  assert.equal(defaultApiBase("github", "github.com"), "https://api.github.com");
+  assert.equal(defaultApiBase("gitlab", "gitlab.com"), "https://gitlab.com/api/v4");
+  assert.equal(defaultApiBase("gitlab", "git.example.com"), "https://git.example.com/api/v4");
+  assert.equal(defaultApiBase("github", "git.example.com"), "https://git.example.com/api/v3");
+});
+
+test("parseRemotePath handles https, ssh, scp and trailing slash forms", () => {
+  assert.deepEqual(parseRemotePath("https://git.example.com/a/b/"), { host: "git.example.com", owner: "a", repo: "b" });
+  assert.deepEqual(parseRemotePath("ssh://git@git.example.com/a/b.git"), { host: "git.example.com", owner: "a", repo: "b" });
+  assert.equal(parseRemotePath(""), null);
+  assert.equal(parseRemotePath("/a/b"), null, "a local absolute path is not a git remote");
+  assert.equal(parseRemotePath(null), null);
+});

--- a/src/server/forge/sinks.mjs
+++ b/src/server/forge/sinks.mjs
@@ -62,7 +62,7 @@ export function planForgeComment(comments, { topic, text }) {
  * @param {string} input.text  the live checklist text
  * @param {(repo, number) => Promise<{data: Array<{id: any, body: string}>}>} input.listComments
  * @param {(repo, number, body: string) => Promise<{data: {id?: any}}>} input.createComment
- * @param {(repo, commentId, body: string) => Promise<unknown>} input.updateComment
+ * @param {(repo, number, commentId, body: string) => Promise<unknown>} input.updateComment
  * @returns {Promise<{ok: true, updated: boolean, id: any}>}
  */
 export async function ensureCommentByTopic({
@@ -80,7 +80,10 @@ export async function ensureCommentByTopic({
     const created = await createComment(repo, number, plan.body);
     return { ok: true, updated: false, id: created?.data?.id ?? null };
   }
-  await updateComment(repo, plan.id, plan.body);
+  // updateComment carries `number` because GitLab's MR notes are iid-scoped:
+  // GitHub addresses a note by a global id but GitLab needs both the MR iid and
+  // the note id. The contract is `(repo, number, commentId, body)` on both.
+  await updateComment(repo, number, plan.id, plan.body);
   return { ok: true, updated: true, id: plan.id };
 }
 

--- a/src/server/forge/sinks.test.mjs
+++ b/src/server/forge/sinks.test.mjs
@@ -35,7 +35,7 @@ test("forge sink: two reports produce one comment id (update, not append)", asyn
       comments.push(created);
       return { data: { id: 41 } };
     },
-    updateComment: async (_r, id, b) => {
+    updateComment: async (_r, _n, id, b) => {
       updated = { id, body: b };
       const ix = comments.findIndex((c) => c.id === id);
       if (ix >= 0) comments[ix] = { ...comments[ix], body: b };

--- a/src/server/forge/webhook.mjs
+++ b/src/server/forge/webhook.mjs
@@ -1,18 +1,23 @@
 // src/server/forge/webhook.mjs — repository webhook registration for a forge
-// (BET-797). Forge hooks are per-repo and POST straight to the box's own
-// public hostname (`https://<box_id>.boxes.mantaui.com/hook/<token>`) — no
+// (BET-797 + BET-799). Forge hooks are per-repo and POST straight to the box's
+// own public hostname (`https://<box_id>.boxes.mantaui.com/hook/<token>`) — no
 // gateway fan-out, no GitHub App. The box's own hostname is read via
 // publicBaseUrl() (the same primitive servePage.mjs / the gateway use), never
-// re-derived. The GitLab adapter (a later issue) drops into this same seam:
-// the URL is unwrap-from-reverse-proxy-able and the health-check exists
-// because GitLab permanently disables a hook after repeated failures.
+// re-derived.
 //
 // Security contract (design spec §5): the forge request carries ONLY the box's
 // public hostname plus a per-repo HMAC secret. A forge token never reaches the
 // Electron renderer or the iOS app — all forge access is box-side, resolved
-// here by the caller. The per-repo secret is the HMAC secret GitHub signs web
+// here by the caller. The per-repo secret is the HMAC secret the forge signs
 // deliveries with; the box stores it on the matching webhook record so ingest
 // verification (webhooks.mjs) shares the same secret.
+//
+// Provider-aware since BET-799: GitHub and GitLab register hooks on different
+// endpoints with different auth (Bearer vs PRIVATE-TOKEN) and different event
+// booleans. The one part that MUST differ is whether a disabled hook is
+// re-enabled: GitHub never auto-disables, but GitLab disables a failing hook
+// permanently with no auto-recovery — so the health check has to turn it back
+// on here.
 
 import { randomBytes } from "node:crypto";
 
@@ -22,41 +27,18 @@ export function forgeHookUrl(publicBase, token) {
   return `${publicBase.replace(/\/+$/, "")}/hook/${token}`;
 }
 
-// Build the request for creating a repo webhook. Pure — the caller runs it
-// through an injectable GitHub API client. Returns { url, headers, body }.
-// `deliveryToken` is the manta capability that appears in the box's /hook URL;
-// `githubToken` is the box's forge credential used for the Authorization
-// header. They are DIFFERENT tokens and must never be conflated.
-export function buildCreateHookRequest({ host, owner, repo, githubToken, deliveryToken, secret, events, publicBase }) {
-  if (!publicBase) {
-    throw new Error(
-      "no public hostname — this box cannot receive webhooks (Tailscale-only / macOS boxes " +
-        "deliberately skip public TLS; polling covers them)",
-    );
-  }
-  const base = githubApiBase(host);
-  return {
-    url: `${base}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/hooks`,
-    headers: githubAuthHeaders(githubToken),
-    body: {
-      name: "web",
-      active: true,
-      events,
-      config: {
-        url: forgeHookUrl(publicBase, deliveryToken),
-        content_type: "json",
-        secret,
-      },
-    },
-  };
-}
-
-// The GitHub Hooks API base for a host. `github.com` maps to api.github.com;
-// a self-hosted host would map to its own API root. Hosted GitHub is the only
-// case this issue registers against.
+// The Hooks API base + credential header for a forge host. Hosted roots are
+// canonical; a self-hosted host serves the conventional mount points.
 export function githubApiBase(host) {
   if (host === "github.com") return "https://api.github.com";
   return `https://api.${host}`;
+}
+export function gitlabApiBase(host) {
+  if (host === "gitlab.com") return "https://gitlab.com/api/v4";
+  return `https://${host}/api/v4`;
+}
+export function forgeApiBase(kind, host) {
+  return kind === "gitlab" ? gitlabApiBase(host) : githubApiBase(host);
 }
 
 export function githubAuthHeaders(token) {
@@ -70,35 +52,116 @@ export function githubAuthHeaders(token) {
   }
   return headers;
 }
+export function gitlabAuthHeaders(token) {
+  const headers = {
+    accept: "application/vnd.gitlab+json",
+    "content-type": "application/json",
+    "user-agent": "manta-server",
+  };
+  if (typeof token === "string" && token) {
+    headers["PRIVATE-TOKEN"] = token;
+  }
+  return headers;
+}
+export function forgeAuthHeaders(kind, token) {
+  return kind === "gitlab" ? gitlabAuthHeaders(token) : githubAuthHeaders(token);
+}
+
+// Map our normalised rule-event names to GitLab's project-hook event booleans.
+// Coarse and safe (we register broadly) — the precision a GitHub `events` array
+// gives is matched by GitLab's booleans, so the same rule set maps to a broad
+// hook. Keep the mapping table explicit rather than an if-chain.
+export function gitlabEventsFor(events) {
+  const ev = new Set(Array.isArray(events) ? events : []);
+  const has = (...xs) => xs.some((x) => ev.has(x));
+  return {
+    push_events: has("push", "pipeline", "job"),
+    pipeline_events: has("pipeline", "job", "check_run", "status"),
+    job_events: has("pipeline", "job", "check_run", "status"),
+    merge_requests_events: has("pull_request", "merge_request"),
+    issues_events: has("issues", "issue"),
+    note_events: has("issues", "note"),
+    tag_push_events: false,
+    enable_ssl_verification: true,
+  };
+}
+
+// Build the request for creating a repo webhook. Pure. `deliveryToken` is the
+// manta capability in the box's /hook URL; `token` is the box's forge credential
+// (never conflated). `kind` routes to the provider's endpoint + auth + body.
+export function buildCreateHookRequest({ kind = "github", host, owner, repo, token, deliveryToken, secret, events, publicBase }) {
+  if (!publicBase) {
+    throw new Error(
+      "no public hostname — this box cannot receive webhooks (Tailscale-only / macOS boxes " +
+        "deliberately skip public TLS; polling covers them)",
+    );
+  }
+  const base = forgeApiBase(kind, host);
+  const headers = forgeAuthHeaders(kind, token);
+  if (kind === "gitlab") {
+    return {
+      url: `${base}/projects/${encodeURIComponent(`${owner}/${repo}`)}/hooks`,
+      headers,
+      body: {
+        url: forgeHookUrl(publicBase, deliveryToken),
+        token: secret,
+        ...gitlabEventsFor(events),
+      },
+    };
+  }
+  return {
+    url: `${base}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/hooks`,
+    headers,
+    body: {
+      name: "web",
+      active: true,
+      events,
+      config: { url: forgeHookUrl(publicBase, deliveryToken), content_type: "json", secret },
+    },
+  };
+}
+
+function hookListUrl(kind, base, owner, repo) {
+  return kind === "gitlab"
+    ? `${base}/projects/${encodeURIComponent(`${owner}/${repo}`)}/hooks`
+    : `${base}/repos/${encodeURIComponent(owner)}/${encodeURIComponent(repo)}/hooks`;
+}
+function hookByIdUrl(kind, base, owner, repo, id) {
+  return `${hookListUrl(kind, base, owner, repo)}/${id}`;
+}
+
+// The hook's delivery URL, for matching an existing hook by the URL we set.
+function hookUrlOf(kind, hook) {
+  return kind === "gitlab" ? hook?.url : hook?.config?.url;
+}
 
 // Register (or re-register) a repository webhook. `api` is the injectable
 // (method, url, headers, body) → parsed-json client; injectable so unit tests
 // never touch the network. On an existing hook with the same URL it PATCHes
-// (so the secret/events are refreshed) rather than creating a duplicate.
+// (refreshing the secret/events) rather than creating a duplicate. `kind`
+// defaults to github so existing callers are unchanged.
 export async function ensureRepoHook(
-  { host, owner, repo, githubToken, deliveryToken, publicBase, events },
+  { kind = "github", host, owner, repo, token, deliveryToken, publicBase, events },
   { api = githubFetch, now = () => new Date().toISOString() } = {},
 ) {
   const secret = `whsec_${randomBytes(24).toString("hex")}`;
   let req;
   try {
-    req = buildCreateHookRequest({ host, owner, repo, githubToken, deliveryToken, secret, events, publicBase });
+    req = buildCreateHookRequest({ kind, host, owner, repo, token, deliveryToken, secret, events, publicBase });
   } catch (e) {
     return { ok: false, error: e?.message ?? String(e) };
   }
 
   const url = forgeHookUrl(publicBase, deliveryToken);
+  const base = forgeApiBase(kind, host);
+  const headers = forgeAuthHeaders(kind, token);
   try {
-    const list = await api("GET", `${githubApiBase(host)}/repos/${owner}/${repo}/hooks`, githubAuthHeaders(githubToken));
-    const existing = (Array.isArray(list) ? list : []).find(
-      (h) => h?.config?.url === url,
-    );
+    const list = await api("GET", hookListUrl(kind, base, owner, repo), headers);
+    const existing = (Array.isArray(list) ? list : []).find((h) => hookUrlOf(kind, h) === url);
     let hook;
     if (existing?.id != null) {
-      hook = await api("PATCH", `${githubApiBase(host)}/repos/${owner}/${repo}/hooks/${existing.id}`, req.headers, {
-        active: true,
-        events,
-        config: { url, content_type: "json", secret },
+      hook = await api("PATCH", hookByIdUrl(kind, base, owner, repo, existing.id), headers, {
+        ...(req.body ?? {}),
       });
     } else {
       hook = await api("POST", req.url, req.headers, req.body);
@@ -116,38 +179,52 @@ export async function ensureRepoHook(
   }
 }
 
-// Health-check a registered hook. GitHub disables nothing automatically, but
-// GitLab disables a hook permanently after repeated failures — so the check
-// exists before the GitLab adapter lands. Returns the hook's active state plus
-// the recent delivery outcomes when the API exposes them.
+/**
+ * Health-check a registered hook. GitHub disables nothing automatically, but
+ * GitLab disables a hook permanently after repeated failures with no automatic
+ * recovery — so for a gitlab hook, when the check finds `active === false` it
+ * RE-ENABLES it (`PUT {active: true}`) before reporting. Returns the hook's
+ * active state plus whether a re-enable was performed.
+ *
+ * @param {{ kind?: "github"|"gitlab", host: string, owner: string, repo: string, token: string, hookId: any }} input
+ */
 export async function healthCheckRepoHook(
-  { host, owner, repo, token, hookId },
+  { kind = "github", host, owner, repo, token, hookId },
   { api = githubFetch } = {},
 ) {
   try {
-    const hook = await api(
-      "GET",
-      `${githubApiBase(host)}/repos/${owner}/${repo}/hooks/${hookId}`,
-      githubAuthHeaders(token),
-    );
+    const base = forgeApiBase(kind, host);
+    const headers = forgeAuthHeaders(kind, token);
+    let hook = await api("GET", hookByIdUrl(kind, base, owner, repo, hookId), headers);
+    let reenabled = false;
+    if (kind === "gitlab" && hook && hook.active === false) {
+      // GitLab disabled this hook for failing; there is no auto-recovery on
+      // that side, so the box re-arms it (the parent's §Webhooks requirement).
+      hook = await api("PUT", hookByIdUrl(kind, base, owner, repo, hookId), headers, {
+        active: true,
+        ...(hook.url ? { url: hook.url } : {}),
+      });
+      reenabled = hook?.active === true;
+    }
     let deliveries = [];
     try {
       const dlv = await api(
         "GET",
-        `${githubApiBase(host)}/repos/${owner}/${repo}/hooks/${hookId}/deliveries?per_page=5`,
-        githubAuthHeaders(token),
+        `${hookByIdUrl(kind, base, owner, repo, hookId)}${kind === "gitlab" ? "" : "/deliveries?per_page=5"}`,
+        headers,
       );
       deliveries = Array.isArray(dlv) ? dlv : [];
     } catch {
       // Deliveries endpoint is optional; a failure here is not a hook failure.
     }
-    return { ok: true, active: hook?.active !== false, deliveries };
+    return { ok: true, active: hook?.active !== false, reenabled, deliveries };
   } catch (e) {
     return { ok: false, error: e?.message ?? String(e) };
   }
 }
 
-// Default GitHub API client — a thin fetch wrapper. Injected as `api` in tests.
+// Default API client — a thin fetch wrapper. Injected as `api` in tests. Shared
+// by both providers (it is auth-agnostic).
 export async function githubFetch(method, url, headers, body) {
   const res = await fetch(url, {
     method,
@@ -162,7 +239,7 @@ export async function githubFetch(method, url, headers, body) {
     json = { raw: text };
   }
   if (!res.ok) {
-    const msg = json?.message || json?.raw || `github ${res.status}`;
+    const msg = json?.message || json?.raw || `${res.status}`;
     throw new Error(msg);
   }
   return json;

--- a/src/server/forge/webhook.test.mjs
+++ b/src/server/forge/webhook.test.mjs
@@ -1,0 +1,114 @@
+// webhook.test.mjs — provider-aware forge hook registration + GitLab re-enable
+// (BET-797 + BET-799). Pins: GitHub registers via the github endpoint + Bearer;
+// GitLab registers via /projects/:path/hooks + PRIVATE-TOKEN with event
+// booleans; and the health check RE-ENABLES a GitLab hook GitLab disabled.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildCreateHookRequest,
+  ensureRepoHook,
+  healthCheckRepoHook,
+  forgeHookUrl,
+} from "./webhook.mjs";
+
+const PUBLIC = "https://12998f00.boxes.mantaui.com";
+
+test("gitlab buildCreateHookRequest addresses /projects/<encoded path>/hooks with PRIVATE-TOKEN", () => {
+  const req = buildCreateHookRequest({
+    kind: "gitlab",
+    host: "gitlab.com",
+    owner: "group/sub",
+    repo: "widget",
+    token: "glpat_x",
+    deliveryToken: "ab".repeat(16),
+    secret: "whsec_secret",
+    events: ["issues", "pull_request"],
+    publicBase: PUBLIC,
+  });
+  assert.equal(req.url, "https://gitlab.com/api/v4/projects/group%2Fsub%2Fwidget/hooks");
+  assert.equal(req.headers["PRIVATE-TOKEN"], "glpat_x");
+  assert.ok(!req.headers.authorization, "gitlab uses PRIVATE-TOKEN, not Bearer");
+  assert.equal(req.body.url, forgeHookUrl(PUBLIC, "ab".repeat(16)));
+  assert.equal(req.body.token, "whsec_secret", "the HMAC secret is delivered as GitLab's token");
+  assert.equal(req.body.merge_requests_events, true, "review events map to MR events");
+  assert.equal(req.body.issues_events, true);
+});
+
+test("github buildCreateHookRequest keeps the hosted endpoint + Bearer auth", () => {
+  const req = buildCreateHookRequest({
+    kind: "github",
+    host: "github.com",
+    owner: "acme",
+    repo: "widget",
+    token: "ghp_x",
+    deliveryToken: "ab".repeat(16),
+    secret: "whsec_secret",
+    events: ["issues"],
+    publicBase: PUBLIC,
+  });
+  assert.equal(req.url, "https://api.github.com/repos/acme/widget/hooks");
+  assert.equal(req.headers.authorization, "Bearer ghp_x");
+  assert.equal(req.body.config.secret, "whsec_secret");
+});
+
+test("ensureRepoHook with a gitlab kind POSTs to the project hooks endpoint", async () => {
+  const calls = [];
+  const api = async (method, url, _headers, body) => {
+    calls.push({ method, url, body });
+    if (method === "GET") return []; // no existing hook
+    return { id: 9, active: true };
+  };
+  const res = await ensureRepoHook(
+    {
+      kind: "gitlab",
+      host: "gitlab.com",
+      owner: "group/sub",
+      repo: "widget",
+      token: "glpat_x",
+      deliveryToken: "ab".repeat(16),
+      publicBase: PUBLIC,
+      events: ["issues"],
+    },
+    { api, now: () => "t" },
+  );
+  assert.equal(res.ok, true);
+  const post = calls.find((c) => c.method === "POST");
+  assert.ok(post, "creates via POST");
+  assert.match(post.url, /\/projects\/group%2Fsub%2Fwidget\/hooks$/);
+  assert.equal(res.hookId, 9);
+});
+
+test("healthCheckRepoHook RE-ENABLES a GitLab hook GitLab disabled", async () => {
+  const calls = [];
+  const api = async (method, url, _h, body) => {
+    calls.push({ method, url, body });
+    if (method === "GET") return { id: 5, active: false, url: "https://hook/cb" };
+    if (method === "PUT") return { id: 5, active: true };
+    return [];
+  };
+  const res = await healthCheckRepoHook(
+    { kind: "gitlab", host: "gitlab.com", owner: "acme", repo: "widget", token: "glpat_x", hookId: 5 },
+    { api },
+  );
+  const put = calls.find((c) => c.method === "PUT");
+  assert.ok(res.reenabled, "a disabled gitlab hook is re-armed by the health check");
+  assert.ok(put, "re-enable is a PUT");
+  assert.match(put.url, /\/projects\/acme%2Fwidget\/hooks\/5$/);
+  assert.equal(res.active, true);
+});
+
+test("healthCheckRepoHook leaves an active gitlab hook alone (no re-enable)", async () => {
+  const calls = [];
+  const api = async (method, url) => {
+    calls.push({ method });
+    if (method === "GET") return { id: 6, active: true };
+    return [];
+  };
+  const res = await healthCheckRepoHook(
+    { kind: "gitlab", host: "gitlab.com", owner: "acme", repo: "widget", token: "t", hookId: 6 },
+    { api },
+  );
+  assert.equal(res.reenabled, false);
+  assert.equal(calls.some((c) => c.method === "PUT"), false, "an active hook is never re-PUT");
+});

--- a/src/server/forgeRules.mjs
+++ b/src/server/forgeRules.mjs
@@ -28,6 +28,8 @@ import {
 import { genDeliveryToken, upsertForgeHook, findForgeHook } from "./webhooks.mjs";
 import { ensureRepoHook } from "./forge/webhook.mjs";
 import { resolveToken as authResolveToken } from "./forge/auth.mjs";
+import { detectForgeWithHosts } from "./forge/selfhost.mjs";
+import { configGet as localConfigGet } from "./local.mjs";
 import { publicBaseUrl } from "./gatewayRegister.mjs";
 
 const RULES_ROOT = "forge-rules";
@@ -198,6 +200,7 @@ export async function saveRules(
     io = DEFAULT_IO,
     ensureHook = ensureRepoHook,
     reload = () => {},
+    getConfig = localConfigGet,
   } = {},
 ) {
   if (!enabled()) {
@@ -245,11 +248,18 @@ export async function saveRules(
       // re-saves; otherwise mint a fresh capability token for this repo.
       const existing = await findForgeHook(key);
       const deliveryToken = existing?.token ?? genDeliveryToken();
+      // Derive the forge kind (known host / user-configured forgeHosts mapping)
+      // so hook registration uses the right provider endpoint + auth, and so a
+      // GitLab repo never registers against the GitHub hooks endpoint.
+      const hostKinds = (await getConfig().catch(() => ({ forgeHosts: [] }))).forgeHosts ?? [];
+      const forgeId = detectForgeWithHosts(`https://${parts.host}/${parts.owner}/${parts.repo}`, hostKinds);
+      const kind = forgeId?.kind ?? "github";
       const res = await ensureHook({
+        kind,
         host: parts.host,
         owner: parts.owner,
         repo: parts.repo,
-        githubToken: token,
+        token,
         deliveryToken,
         publicBase: pub,
         events: eventsForRules(parsed.rules),

--- a/src/server/forgeRules.test.mjs
+++ b/src/server/forgeRules.test.mjs
@@ -42,9 +42,10 @@ test("saveRules registers the webhook with the resolved §3.3 token", async () =
 
   assert.equal(res.ok, true);
   assert.equal(res.webhook.registered, true);
-  assert.equal(hookArgs.githubToken, "ghp_box");
+  assert.equal(hookArgs.token, "ghp_box");
   assert.equal(hookArgs.host, "github.com");
   assert.equal(hookArgs.owner, "acme");
+  assert.equal(hookArgs.kind, "github", "a github.com repo registers as github");
 });
 
 test("saveRules fails registration loudly when no token resolves (rules still saved)", async () => {
@@ -81,7 +82,7 @@ test("saveRules passes the forge.token override, not the resolver", async () => 
 
   assert.equal(res.ok, true);
   assert.equal(res.webhook.registered, true);
-  assert.equal(hookArgs.githubToken, "ghp_override");
+  assert.equal(hookArgs.token, "ghp_override");
 });
 
 test("saveRules reports webhook errors without throwing", async () => {

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -2205,7 +2205,7 @@ const handleRequest = async (req, res) => {
                 text: record.label || record.detail || record.state || "Progress update",
                 listComments: (r, n) => target.adapter.listIssueComments(r, n),
                 createComment: (r, n, b) => target.adapter.createIssueComment(r, n, b),
-                updateComment: (r, id, b) => target.adapter.updateIssueComment(r, id, b),
+                updateComment: (r, n, id, b) => target.adapter.updateIssueComment(r, n, id, b),
               });
             },
           },

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -61,6 +61,10 @@ const DEFAULT_CONFIG = {
   // sweep deletes the file (transcript + waveform are kept forever). 0 = keep
   // forever. Default 168 (7 days).
   voiceNoteTtlHours: 168,
+  // BET-799: user-configured self-hosted forge hosts — `[{ host, kind, apiBase? }]`.
+  // Lets a self-hosted GitHub/GitLab instance (which `detectForge` deliberately
+  // rejects) resolve to its forge + API root. `kind` is "github" | "gitlab".
+  forgeHosts: [],
 };
 
 let _config = null;

--- a/src/server/webhooks.mjs
+++ b/src/server/webhooks.mjs
@@ -66,43 +66,112 @@ export function verifySignature(secret, rawBody, header) {
   return timingSafeEqual(provided, expected);
 }
 
-// Signature header NAMES, per provider. GitHub signs with `X-Hub-Signature-256`
-// using the identical `sha256=<hex>` scheme MantaUI's own `X-Manta-Signature`
-// uses (BET-797). The GitLab adapter will add a THIRD scheme (Standard
-// Webhooks: a different header, base64, and an HMAC over `id.timestamp.body`)
-// — that arrives with the adapter and lives here as another provider row in
-// the per-provider header table, not as an if/else chain in deliverWebhook.
+// Signature header NAMES, per provider, for the providers that share the
+// `sha256=<hex>` HMAC scheme. GitHub signs with `X-Hub-Signature-256` using the
+// same scheme MantaUI's own `X-Manta-Signature` uses (BET-797), so a provider
+// can accept the same scheme in more than one header.
 const SIGNATURE_HEADERS = Object.freeze({
   manta: Object.freeze(["x-manta-signature"]),
   github: Object.freeze(["x-hub-signature-256", "x-manta-signature"]),
 });
 
-// Our webhook record providers. `manta` is the existing inbound hook; `github`
-// is a forge hook registered by the forge rules tool. Anything else is held to
-// be false rather than coerced (a typo shouldn't silently weaken verification).
-export const HOOK_PROVIDERS = ["manta", "github"];
+// How fresh a Standard-Webhooks timestamp must be (seconds). GitLab signs with
+// `webhook-timestamp`; a stale replay must not verify.
+const SW_FRESHNESS_S = 5 * 60;
 
 /**
- * Provider-aware signature resolution. Tries every header name the provider
- * accepts, in order, and returns true on the first that verifies. A provider
- * with the same scheme in two headers (GitHub accepts either of ours today)
- * keeps working when a forge sends its own header. Pure — reads only the plain
- * header map and the raw body. `unsigned` hooks skip this at the call site.
+ * GitLab signature verification — a THIRD scheme (BET-799). Recent GitLab
+ * implements Standard Webhooks: header `webhook-signature: v1,<base64>`,
+ * HMAC-SHA256 over `"{id}.{timestamp}.{rawBody}"`, with the key being the
+ * signing token (its `whsec_` prefix stripped, then base64-decoded). Older
+ * self-managed instances use the plain `X-Gitlab-Token` header. BOTH are tried,
+ * the signature preferred when present; the timestamp is validated for
+ * freshness. Pure. A bad/missing signature is a plain `false`.
  *
- * @param {"manta"|"github"} provider
+ * @param {string} secret the hook's signing secret
+ * @param {unknown} rawBody
+ * @param {Record<string, string|string[]|undefined>|undefined} headers lowercased header names
+ * @param {{ now?: () => number }} [opts]
+ */
+export function verifyGitlabSignature(secret, rawBody, headers, { now = () => Math.floor(Date.now() / 1000) } = {}) {
+  if (typeof secret !== "string" || !secret) return false;
+
+  // Older self-managed GitLab: the secret is echoed verbatim in `X-Gitlab-Token`.
+  const plain = headers?.["x-gitlab-token"];
+  if (typeof plain === "string" && plain) {
+    const a = Buffer.from(plain);
+    const b = Buffer.from(secret);
+    if (a.length === b.length && timingSafeEqual(a, b)) return true;
+  }
+
+  // Standard Webhooks (preferred when present).
+  const sig = headers?.["webhook-signature"];
+  if (typeof sig !== "string") return false;
+  const m = /^v1,\s*([A-Za-z0-9+/=]+)$/.exec(sig.trim());
+  if (!m) return false;
+
+  const id = headers?.["webhook-id"];
+  const tsHeader = headers?.["webhook-timestamp"];
+  if (typeof id !== "string" || id === "" || typeof tsHeader !== "string" || tsHeader === "") return false;
+  const ts = Number(tsHeader);
+  if (!Number.isFinite(ts)) return false;
+  if (Math.abs(now() - ts) > SW_FRESHNESS_S) return false;
+
+  const keyRaw = secret.replace(/^whsec_/, "");
+  const key = Buffer.from(keyRaw, "base64");
+  const payload = `${id}.${ts}.${rawBody == null ? "" : rawBody}`;
+  const expected = createHmac("sha256", key).update(payload).digest("base64");
+  const provided = m[1];
+  const a = Buffer.from(provided);
+  const b = Buffer.from(expected);
+  return a.length === b.length && timingSafeEqual(a, b);
+}
+
+// Our webhook record providers. `manta` is the existing inbound hook; `github`
+// and `gitlab` are forge hooks registered by the forge rules tool. Anything
+// else is held to be false rather than coerced (a typo shouldn't silently
+// weaken verification).
+export const HOOK_PROVIDERS = ["manta", "github", "gitlab"];
+
+// Per-provider verifier table (BET-799) — the dispatch point. Each provider's
+// signature scheme is its own pure function; a new provider is a row here, not
+// an if/else chain in deliverWebhook. Unknown providers fall back to the shared
+// sha256=hex scheme via the header table.
+const VERIFIERS = Object.freeze({
+  manta: verifyHmacProvider("manta"),
+  github: verifyHmacProvider("github"),
+  gitlab: verifyGitlabSignature,
+});
+
+function verifyHmacProvider(provider) {
+  return (secret, rawBody, headers) => {
+    const names = SIGNATURE_HEADERS[provider];
+    if (!names) return false;
+    for (const name of names) {
+      const value = headers?.[name];
+      if (typeof value === "string" && verifySignature(secret, rawBody, value)) {
+        return true;
+      }
+    }
+    return false;
+  };
+}
+
+/**
+ * Provider-aware signature resolution — the per-provider verifier table. Each
+ * provider row is a closed function over its own scheme; GitLab dispatches to
+ * the Standard-Webhooks/X-Gitlab-Token verifier, GitHub/manta to the shared
+ * sha256=hex header table. `unsigned` hooks skip this at the call site. Pure.
+ *
+ * @param {"manta"|"github"|"gitlab"} provider
  * @param {string} secret
  * @param {unknown} rawBody
  * @param {Record<string, string|string[]|undefined>|undefined} headers lowercased header names
+ * @param {{ now?: () => number }} [opts]
  */
-export function resolveSignature(provider, secret, rawBody, headers) {
-  const names = SIGNATURE_HEADERS[provider] ?? SIGNATURE_HEADERS.manta;
-  for (const name of names) {
-    const value = headers?.[name];
-    if (typeof value === "string" && verifySignature(secret, rawBody, value)) {
-      return true;
-    }
-  }
-  return false;
+export function resolveSignature(provider, secret, rawBody, headers, opts = {}) {
+  const verify = VERIFIERS[provider] ?? VERIFIERS.manta;
+  return verify(secret, rawBody, headers, opts);
 }
 
 // GitHub's event-type header (`X-GitHub-Event`). GitHub sends a header per


### PR DESCRIPTION
## GitLab adapter — the acceptance test for the abstraction (BET-799)

Implements `src/server/forge/gitlab.mjs` and folds in the two in-scope deliverables
(self-hosted host→kind mapping; GitLab webhook registration + re-enable) so a real
GitLab MR renders in the session header, checks chip and review pane — with zero
renderer changes and `src/shared/forge.mjs` untouched.

### The adapter (`gitlab.mjs`) — all eight mismatches handled
iid-not-id, subgroup path encoding, opened-not-open, disjoint issues/MRs,
no-review-object `submitReview` (N discussions + approve), three-SHA position
building, pipelines-not-checks (manual/scheduled→yellow), `detailed_merge_status`
→ mergeable + rich reason. Optional `resolveThread` (absent on GitHub).

### Fold-ins
- **Self-hosted host→kind mapping (BET-854):** `selfhost.mjs` layers the AppConfig
  `forgeHosts` list on `detectForge` (shared untouched); adapters take a per-host
  `apiBase`; auth derives per-host env/secret keys; config gains `forgeHosts: []`.
- **GitLab webhook (BET-855):** provider-aware `forge/webhook.mjs` registers GitLab
  hooks (`/projects/:path/hooks`, `PRIVATE-TOKEN`) and `healthCheckRepoHook`
  re-enables a GitLab-disabled hook (`PUT {active:true}`); `saveRules` derives the
  forge kind so a GitLab repo never registers against the GitHub endpoint.
  Prefer-polling on a sleeping box is preserved.

### Supporting
- `index.mjs`: per-kind auth header (`PRIVATE-TOKEN` vs `Bearer`) + Accept through
  the shared request layer; GitLab registered; `no_forge` gates admit gitlab; the
  progress sink's `updateComment`/`updateIssueComment` unified to the iid-scoped
  4-arg contract (GitLab sink update branch works).
- `webhooks.mjs`: per-provider verifier table incl. GitLab's Standard Webhooks +
  `X-Gitlab-Token`.
- `auth.mjs`: glab config leg, `rotateOauthPair` (persist-new-before-use).

### Places the shared types did not fit (findings)
- **`updateIssueComment` globally vs iid-scoped** — unified to `(repo, number, commentId, body)`.
- **DraftComment has no "unchanged/both" side** — kept as filed finding BET-856
  (sharpened with a resolve plan), not silently accommodated.

### Verification
- Base: latest `origin/main`
- typecheck: exit 0
- `npm test`: vitest 2585 pass / 0 fail; node:test 773 pass / 0 fail
