### PR TITLE
feat(server): resolve forge sink target + delegate parent through the session link (BET-844)

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -248,6 +248,31 @@ export function resolveOwner(projects, sessionID) {
   return null;
 }
 
+// Resolve the real parent for a forge-triggered delegate job (BET-844, spec
+// §3.4⑥). A forge event has no user session to inherit from, so the job's
+// window must land in the tmux project on this box that OWNS the repo checkout
+// being branched off. Returns { parentSessionID, tmuxSession } — the opencode
+// session id to place the job window under, plus the owning project — or null
+// when no tracked project wraps that directory. Pure.
+export function resolveForgeOwner(projects, parentDirectory) {
+  if (!Array.isArray(projects) || typeof parentDirectory !== "string" || !parentDirectory) return null;
+  for (const p of projects) {
+    const windows = p.windows || [];
+    const ownsDir =
+      (typeof p.defaultCwd === "string" && p.defaultCwd === parentDirectory) ||
+      windows.some(
+        (w) =>
+          typeof w?.paneCurrentPath === "string" &&
+          (w.paneCurrentPath === parentDirectory || w.paneCurrentPath.startsWith(parentDirectory + "/")),
+      );
+    if (!ownsDir) continue;
+    const win = windows.find((w) => w?.opencodeSessionId) ?? windows[0];
+    if (!win?.opencodeSessionId) return null;
+    return { parentSessionID: win.opencodeSessionId, tmuxSession: p.tmuxSession };
+  }
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // List / get
 // ---------------------------------------------------------------------------

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -307,6 +307,7 @@ async function registerJob(
     existingSessionId,
     origin,
     permission,
+    link,
   },
   deps = {},
 ) {
@@ -374,6 +375,13 @@ async function registerJob(
     branch,
     baseSha,
     origin,
+    // Session-link primitive (§3.4⑥, BET-847/844): the at-most-one issue + one
+    // pull request this job's session is about. Stored on the job's own session
+    // record in the shared `{ issue?, pr? }` shape so the forge progress sink
+    // (and future notification/inbox readers) address the linked issue or PR —
+    // the triggering issue — with no per-feature plumbing. A forge-triggered
+    // delegate sets this at dispatch; a user delegate leaves it null.
+    link: link ?? null,
     status: "running",
     activity: null,
     createdAt: now(),
@@ -394,7 +402,11 @@ async function registerJob(
 }
 
 /**
- * @param {{prompt:string, model?:string, parentSessionID:string, parentDirectory:string}} input
+ * @param {{prompt:string, model?:string, parentSessionID:string, parentDirectory:string,
+ *          link?: {issue?:{repoKey:string,number:number}, pr?:{repoKey:string,number:number}}|null}} input
+ *        `link` (BET-844) — the optional session link (at most one issue + one
+ *        PR, `{issue?, pr?}` shape) a forge-triggered delegate carries so the
+ *        progress sink addresses the linked issue/PR. Stored on the job record.
  * @param {object} deps injected I/O (load/save/publish/deliver/listProjects/
  *        newWindow/gitAddWorktree/gitRun/oc listMessages/now)
  */
@@ -486,6 +498,7 @@ export async function startJob(input, deps = {}) {
         existingSessionId: undefined,
         origin: "delegate",
         permission: input?.permission,
+        link: input?.link,
       },
       deps,
     );

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -368,6 +368,46 @@ test("sweep leaves a running job whose parent session is alive", async () => {
 // 4. Nesting: a start whose parentSessionID is a live job's childSessionID
 // ----------------------------------------------------------------------------
 
+test("startJob persists the session link on the job record (BET-844)", async () => {
+  const h = harness([]);
+  h.deps.gitAddWorktree = async ({ name }) => ({ path: `/repo/wt-${name}`, branch: name });
+  const parentWin = { index: 1, name: "p", opencodeSessionId: "parent", paneCurrentPath: "/repo" };
+  h.deps.listProjects = async () => [{ tmuxSession: "forge-work", windows: [parentWin] }];
+  h.deps.newWindow = async (input) => ({
+    sessionId: "child_link",
+    windowIndex: 5,
+    projects: [{ tmuxSession: input.sessionName, windows: [parentWin] }],
+  });
+  const res = await startJob(
+    {
+      prompt: "complete the issue",
+      parentSessionID: "parent",
+      parentDirectory: "/repo",
+      link: { issue: { repoKey: "github.com/owner/repo", number: 42 } },
+    },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  const job = h.jobs.find((j) => j.childSessionID === "child_link");
+  assert.ok(job, "job persisted");
+  assert.deepEqual(job.link, { issue: { repoKey: "github.com/owner/repo", number: 42 } });
+});
+
+test("startJob leaves the link null when none is provided", async () => {
+  const h = harness([]);
+  h.deps.gitAddWorktree = async () => { throw new Error("not a git repository"); };
+  const parentWin = { index: 1, name: "p", opencodeSessionId: "parent", paneCurrentPath: "/repo" };
+  h.deps.listProjects = async () => [{ tmuxSession: "s", windows: [parentWin] }];
+  h.deps.newWindow = async () => ({ sessionId: "child_nolink", windowIndex: 1 });
+  const res = await startJob(
+    { prompt: "plain delegate", parentSessionID: "parent", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  const job = h.jobs.find((j) => j.childSessionID === "child_nolink");
+  assert.equal(job.link, null);
+});
+
 test("startJob refuses nesting when parentSessionID is a live job's childSessionID", async () => {
   const live = { ...runningJob(0), childSessionID: "child_live", status: "running" };
   const h = harness([live]);

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -5,6 +5,7 @@ import {
   buildCompletionText,
   deriveName,
   resolveOwner,
+  resolveForgeOwner,
   startJob,
   observeEvent,
   finishJob,
@@ -170,6 +171,39 @@ test("deriveName falls back to a slug for symbol-heavy prompts", () => {
 // ----------------------------------------------------------------------------
 // resolveOwner helper
 // ----------------------------------------------------------------------------
+
+test("resolveForgeOwner finds the project that owns the repo checkout (BET-844)", () => {
+  const projects = [
+    { tmuxSession: "other", defaultCwd: "/other" },
+    {
+      tmuxSession: "forge-work",
+      defaultCwd: "/repo",
+      windows: [{ index: 1, name: "p", opencodeSessionId: "ses_parent", paneCurrentPath: "/repo" }],
+    },
+  ];
+  assert.deepEqual(resolveForgeOwner(projects, "/repo"), {
+    parentSessionID: "ses_parent",
+    tmuxSession: "forge-work",
+  });
+});
+
+test("resolveForgeOwner matches a window whose cwd is nested inside the checkout", () => {
+  const projects = [
+    {
+      tmuxSession: "repo-project",
+      defaultCwd: "/",
+      windows: [{ index: 2, name: "w", opencodeSessionId: "ses_par", paneCurrentPath: "/repo/sub" }],
+    },
+  ];
+  const owner = resolveForgeOwner(projects, "/repo");
+  assert.equal(owner.parentSessionID, "ses_par");
+  assert.equal(owner.tmuxSession, "repo-project");
+});
+
+test("resolveForgeOwner returns null when no project wraps the directory", () => {
+  assert.equal(resolveForgeOwner([{ tmuxSession: "a", defaultCwd: "/x", windows: [] }], "/repo"), null);
+  assert.equal(resolveForgeOwner([], "/repo"), null);
+});
 
 test("resolveOwner finds the tmux session owning a session id", () => {
   const projects = [

--- a/src/server/forge/rules.mjs
+++ b/src/server/forge/rules.mjs
@@ -60,6 +60,26 @@ export function substitutePrompt(prompt, { url, title } = {}) {
     .replace(/\{\{title\}\}/g, title ?? "");
 }
 
+// Map a normalised forge event to a session-link ref (spec §3.4⑥, BET-844).
+// A delegate verb carries this on the job's session record so the progress
+// sink addresses the TRIGGERING issue or pull request instead of the stopgap's
+// "the job's own PR" guess. Pure:
+//   - issue.labeled → the linked issue ({ issue: { repoKey, number } })
+//   - review.requested → the linked PR ({ pr: { repoKey, number } })
+//   - checks.failed has no issue/PR number in its payload → null (the sink
+//     then no-ops: there is no distinct target, which is correct).
+// `repoKey` is the forged `host/owner/repo` identity already resolved by the
+// caller; the number is parsed from the event's canonical html_url.
+export function eventLinkRef(repoKey, event) {
+  const url = event?.url;
+  if (typeof url !== "string" || typeof repoKey !== "string") return null;
+  const issue = url.match(/\/issues\/(\d+)/);
+  if (issue) return { issue: { repoKey, number: Number(issue[1]) } };
+  const pr = url.match(/\/pull\/(\d+)/) ?? url.match(/\/merge_requests\/(\d+)/);
+  if (pr) return { pr: { repoKey, number: Number(pr[1]) } };
+  return null;
+}
+
 // ---------------------------------------------------------------------------
 // Guard + normalisation (pure) — raw GitHub delivery → forge event
 // ---------------------------------------------------------------------------

--- a/src/server/forge/rules.test.mjs
+++ b/src/server/forge/rules.test.mjs
@@ -8,6 +8,7 @@ import {
   createRulesEngine,
   normalizeEvent,
   substitutePrompt,
+  eventLinkRef,
   DEFAULT_DELEGATE_PROMPT,
   AUTONOMOUS_JOB_CONTRACT,
 } from "./rules.mjs";
@@ -162,6 +163,34 @@ test("substitutePrompt tolerates an absent placeholder", () => {
     substitutePrompt("Complete {{url}}.", { title: "T" }),
     "Complete .",
   );
+});
+
+// eventLinkRef — session-link from a normalised event (BET-844)
+test("eventLinkRef: issue.labeled url links the ISSUE", () => {
+  assert.deepEqual(eventLinkRef("github.com/owner/repo", { url: "https://github.com/owner/repo/issues/42" }), {
+    issue: { repoKey: "github.com/owner/repo", number: 42 },
+  });
+});
+
+test("eventLinkRef: review.requested url links the PR", () => {
+  assert.deepEqual(eventLinkRef("github.com/owner/repo", { url: "https://github.com/owner/repo/pull/7" }), {
+    pr: { repoKey: "github.com/owner/repo", number: 7 },
+  });
+});
+
+test("eventLinkRef: GitLab merge_request url links the PR", () => {
+  assert.deepEqual(eventLinkRef("gitlab.com/owner/repo", { url: "https://gitlab.com/owner/repo/-/merge_requests/88" }), {
+    pr: { repoKey: "gitlab.com/owner/repo", number: 88 },
+  });
+});
+
+test("eventLinkRef: checks.failed has no issue/PR number → null", () => {
+  assert.equal(eventLinkRef("github.com/owner/repo", { url: "https://github.com/owner/repo" }), null);
+});
+
+test("eventLinkRef: missing url or repoKey → null", () => {
+  assert.equal(eventLinkRef("github.com/owner/repo", {}), null);
+  assert.equal(eventLinkRef(null, { url: "https://github.com/o/r/issues/1" }), null);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -101,7 +101,7 @@ import {
   saveRules as forgeSaveRules,
   forgeIngest,
 } from "./forgeRules.mjs";
-import { createRulesEngine } from "./forge/rules.mjs";
+import { createRulesEngine, eventLinkRef } from "./forge/rules.mjs";
 import {
   createForgePoller,
   pollChecksFailed,
@@ -114,6 +114,7 @@ import { getAdapter } from "./forge/index.mjs";
 import { resolveToken as forgeResolveToken } from "./forge/auth.mjs";
 import { parseRules as parseForgeRules } from "../shared/forgeRules.mjs";
 import { detectForge as detectForgeUrl } from "../shared/forge.mjs";
+import { sessionLink as readSessionLink } from "../shared/sessionLink.mjs";
 import {
   ensureAuth,
   createAuthEngine,
@@ -406,19 +407,22 @@ const forgePollSeen = new Map(); // repoKey -> { issues, checks, reviews } seen-
 forgeRulesEngine = createRulesEngine({
   enabled: async () => (await local.configGet())?.forgeRulesEnabled === true,
   startDelegate: async ({ prompt, repoKey, event, rule }) => {
-    // Resolve a parent directory to branch the worktree off. The session-link
-    // primitive (spec §3.4⑥) is not yet shipped, so the parent is sourced from
-    // a documented box-side forge checkout when one exists; otherwise the job
-    // is refused (recorded below) rather than guessed at. This keeps a real
-    // rule storm bounded to the delegate engine's five-job cap with clean
-    // refusals — never queued.
+    // Resolve a parent directory to branch the worktree off: the box's own
+    // local checkout of the linked repo (found via the same repo scan the
+    // forge probe uses, matched by repoKey). This replaces the BET-798 stopgap
+    // that required a hand-made directory at ~/.manta/forge-checkouts/<repo>.
     const cwd = await resolveForgeParentDirectory(repoKey);
     if (!cwd) {
       return {
         ok: false,
-        error: "no local forge checkout to branch the job worktree off (session-link primitive not yet shipped)",
+        error: "no local checkout of this repo to branch the job worktree off",
       };
     }
+    // Session-link primitive (§3.4⑥, BET-844): carry the triggering issue / PR
+    // on the job's session record so the forge progress sink comments on the
+    // ISSUE, not a job-own-PR guess. checks.failed has no issue/PR number →
+    // no link → the sink no-ops (no distinct target), which is correct.
+    const link = eventLinkRef(repoKey, event);
     const permission = delegateBuildPermissionRuleset([
       { permission: "bash", pattern: "**" },
       { permission: "write", pattern: "**" },
@@ -430,6 +434,7 @@ forgeRulesEngine = createRulesEngine({
       parentSessionID: "forge", // synthetic parent channel; real parent arrives with the link primitive
       parentDirectory: cwd,
       permission,
+      link,
     });
   },
   notify: async ({ message, event }) =>
@@ -514,59 +519,46 @@ const { stop: stopForgePoller } = createForgePoller({
 });
 
 // Resolve a parent directory to branch a forge-triggered job's worktree off.
-// A documented box-side convention: a directory at ~/.manta/forge-checkouts/<repo>
-// when it exists (otherwise the job is refused). This is the concrete seam the
-// session-link primitive will replace.
+// The parent-directory the session-link primitive names (spec §3.4⑥, BET-844):
+// the box's own local checkout of the linked repo — found via the same repo
+// scan the forge probe uses, matched by repoKey — rather than the BET-798
+// stopgap convention of a hand-made ~/.manta/forge-checkouts/<repo> directory.
+// Returns the checkout path, or null when the repo isn't checked out on this
+// box (the job is then refused: you cannot branch a worktree off a clone you
+// don't have).
 async function resolveForgeParentDirectory(repoKey) {
-  const parts = forgeParseRepoKey(repoKey);
-  if (!parts) return null;
+  if (typeof repoKey !== "string" || !forgeParseRepoKey(repoKey)) return null;
   try {
-    const { stat } = await import("node:fs/promises");
-    const dir = join(
-      homedir(),
-      ".manta",
-      "forge-checkouts",
-      `${parts.host}-${parts.owner}-${parts.repo}`.replace(/\//g, "_"),
-    );
-    await stat(dir);
-    return dir;
+    const { repos } = await local.scanRepos({ roots: local.buildRoots() });
+    const hit = (repos ?? []).find((r) => r.repoKey === repoKey);
+    return hit?.path ?? null;
   } catch {
     return null;
   }
 }
 
-// Resolve the PR a forge progress sink should comment on, for a job's child
-// session. Walks job worktree → origin → open PR on the branch, and returns
-// the adapter + repo + number when one exists. The session-link primitive
-// (spec §3.4⑥) that names the target outright is a later issue; until then the
-// sink targets a job's OWN PR, and returns null (no-op) for everything else.
+// Resolve the forge progress sink target from the session-link primitive
+// (spec §3.4⑥, BET-844): the LINKED pull request or issue on the job's own
+// session record — the triggering issue. Replaces the BET-798 stopgap that
+// walked worktree → origin → open PR (which could only ever reach a job's own
+// PR, never the issue that started it). Returns { adapter, repo, number } or
+// null (the sink no-ops) when the job has no link — e.g. checks.failed, which
+// carries no issue/PR number in its event.
 async function resolveForgeSinkTarget(childSessionID) {
   try {
     const { jobs } = await delegateEngine.listJobs();
-    const job = jobs?.find((j) => j.childSessionID === childSessionID && j.worktree);
-    if (!job?.worktree) return null;
-    const origin = await local.gitRemoteOrigin(job.worktree);
-    const forge = origin ? detectForgeUrl(origin) : null;
-    if (!forge || forge.kind !== "github") return null;
+    const job = jobs?.find((j) => j.childSessionID === childSessionID);
+    const link = readSessionLink(job ?? null);
+    const ref = link?.pr ?? link?.issue;
+    if (!ref) return null;
+    const parts = forgeParseRepoKey(ref.repoKey);
+    if (!parts) return null;
+    const forge = detectForgeUrl(`https://${parts.host}/${parts.owner}/${parts.repo}`);
+    if (!forge) return null;
     const tok = await forgeResolveToken(forge.host).catch(() => null);
     if (!tok) return null;
     const adapter = getAdapter(forge.kind, tok.token);
-    const repo = { owner: forge.owner, repo: forge.repo };
-    const { data } = await adapter.listPullRequests(repo, { state: "open" });
-    const prs = Array.isArray(data) ? data : [];
-    const branch = await gitBranchFor(job.worktree);
-    const pr = branch ? prs.find((p) => p.headRef === branch) : undefined;
-    if (!pr?.number) return null;
-    return { adapter, repo, number: pr.number };
-  } catch {
-    return null;
-  }
-}
-
-async function gitBranchFor(cwd) {
-  try {
-    const { stdout } = await run("git", ["-C", cwd, "branch", "--show-current"]);
-    return (stdout ?? "").trim() || null;
+    return { adapter, repo: { owner: forge.owner, repo: forge.repo }, number: ref.number };
   } catch {
     return null;
   }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -65,7 +65,7 @@ import {
   startCapSweeper,
 } from "./capabilities.mjs";
 import { notifyCapSession } from "./capNotifier.mjs";
-import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset } from "./delegate.mjs";
+import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset, resolveForgeOwner } from "./delegate.mjs";
 import {
   reportProgress,
   readProgressRecord,
@@ -423,6 +423,17 @@ forgeRulesEngine = createRulesEngine({
     // ISSUE, not a job-own-PR guess. checks.failed has no issue/PR number →
     // no link → the sink no-ops (no distinct target), which is correct.
     const link = eventLinkRef(repoKey, event);
+    // Resolve the real parent: the tmux project that owns this repo's checkout,
+    // so the job's window has a home (the stopgap's synthetic "forge" parent
+    // could never resolve an owner, so a forge delegate could not actually
+    // launch). Refused when no local project wraps the checkout.
+    const owner = resolveForgeOwner(await tmux.listProjects(), cwd);
+    if (!owner) {
+      return {
+        ok: false,
+        error: "no local project wraps this repo checkout to host the job window",
+      };
+    }
     const permission = delegateBuildPermissionRuleset([
       { permission: "bash", pattern: "**" },
       { permission: "write", pattern: "**" },
@@ -431,7 +442,7 @@ forgeRulesEngine = createRulesEngine({
     ]);
     return delegateEngine.startJob({
       prompt,
-      parentSessionID: "forge", // synthetic parent channel; real parent arrives with the link primitive
+      parentSessionID: owner.parentSessionID,
       parentDirectory: cwd,
       permission,
       link,


### PR DESCRIPTION
BET-844 — Forge sink target + delegate parent resolve through the session-link primitive (spec §3.4⑥)

Remove the BET-798 stopgaps now that the session-link primitive (BET-847) is merged:

1. **Forge progress sink now targets the LINKED issue/PR, not the job's own PR.**
   `resolveForgeSinkTarget` reads the job's session-link record (`sessionLink(job)`
   → `pr ?? issue`) and resolves `{adapter, repo, number}` from the linked
   `repoKey` + number. A forge-triggered delegate now carries the *triggering*
   issue/PR (via `eventLinkRef`) on its job record, so the progress comment
   lands on the issue that started the job — the wrong-surface gap is gone.

2. **Delegate parent directory no longer needs a hand-made checkout.**
   `resolveForgeParentDirectory` finds the box's own local checkout of the
   linked repo via the same repo scan the forge probe uses (`local.scanRepos` +
   `buildRoots`, matched by `repoKey`), replacing the
   `~/.manta/forge-checkouts/<repo>` convention.

3. **The delegate actually launches into a real parent.** The stopgap passed a
   synthetic `"forge"` parent that could never resolve an owner, so a forge
   delegate could not start a job. `resolveForgeOwner` now resolves the tmux
   project on this box that owns the repo checkout, placing the job's window
   there; refused cleanly when no local project wraps it. This is the "real
   parent arrives with the link primitive" the stopgap promised.

4. **The delegate job carries the link.** `startJob` accepts an optional `link`
   (`{issue?, pr?}`) and persists it on the job's own session record in the
   shared sessionLink shape — one field, the vocabulary BET-847 defined.

Notes:
- `checks.failed` events carry no issue/PR number → `eventLinkRef` returns null →
  the sink no-ops (no distinct target), which is correct. `issue.labeled` →
  linked issue; `review.requested` → linked PR (GitHub `/pull/N` + GitLab
  `/merge_requests/N`).
- The two index.mjs helpers are thin glue over the delegate engine + repo scan
  (not unit-testable as `index.mjs` is the server entry); the testable core is
  `eventLinkRef` (rules.test.mjs), `resolveForgeOwner` + the `startJob` link
  persistence (delegate.test.mjs). All covered.
- Pre-existing, not touched here: `package.json`'s `test` glob is unquoted, so
  top-level `src/server/*.test.mjs` (incl. `delegate.test.mjs`) are not picked
  up by `npm test` in a non-globstar shell — BET-845 covers this. My new
  `delegate.test.mjs` tests verify green via a direct module run (72/72);
  `eventLinkRef` tests run inside `npm test`.

**Files changed:** `5`. `src/server/index.mjs`, `src/server/delegate.mjs`,
`src/server/forge/rules.mjs`, plus tests in `delegate.test.mjs` /
`rules.test.mjs`.

**Verification results:**
- PR branch (`multica/BET-844-forge-link-target` @ `7d7e662e`):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, 727 pass / 0 fail / 0 skip. Failures: none. log sha256: `1a4b92fbd32bc5ab4e1c5b2a508663bc72f6899e83b1224b303c6c0af453ad8e`
  - delegate.test.mjs direct run (top-level module not in `npm test` glob): 72/72 pass, incl. the new link + owner tests.
- Base (`main` @ `10f00de3`):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, 722 pass / 0 fail / 0 skip. Failures: none. log sha256: `896c1519c43b8ad538f990d78cad91d373b14f598608ad1e79582723019bea3f`
- **Conclusion:** 0 new failures; PR adds tests that all pass (the 727-vs-722 delta is the new `eventLinkRef` tests inside `npm test`; the remaining new delegate tests are verified by direct run).

**Base: origin/main @ `10f00de3`**

The live end-to-end acceptance (BET-798 criteria 1/2/6 — real label → real job →
comment on the triggering issue) needs a configured rule + a running job against
a real forge and is a post-merge verification step, as the issue notes.
