### PR TITLE
feat(renderer): app-control bus consumer for model switch and rename (BET-841)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -17,12 +17,14 @@ import { getMantaPreload } from "./preloadAccess";
 import { describe as describeConnection } from "../shared/net/state.js";
 import {
   type SessionMode,
+  type ModelSelection,
   readSavedMode,
   writeSavedMode,
+  writeSavedModel,
   resolveLauncherFlags,
 } from "./chatShared";
 import type { SyncPayload } from "../shared/api";
-import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, pruneVisitedSessions, registerMountedTerminal, shouldResyncWindowsForJobs, type MountedTerminal } from "./chatUtils";
+import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, pruneVisitedSessions, registerMountedTerminal, shouldResyncWindowsForJobs, dispatchAppControl, type AppControlHandlers, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
 import { ConfirmModal } from "./ConfirmModal";
@@ -1031,6 +1033,48 @@ function AppInner() {
     return off;
   }, [apiGeneration]);
 
+  // App-control bus (BET-840/841). The box publishes ONE `appControl` kind
+  // with an `action` discriminator whenever an app-control tool lands a
+  // client-visible effect. Subscribe ONCE here (not per-action, not from
+  // inside ChatPanel — panels mount/unmount per session) and switch on
+  // `action`.
+  //
+  // switch-model's effect is RENDERER state (the per-session model override),
+  // so it is applied in two steps that stay on ONE path: persist via the
+  // shared `writeSavedModel`, then drive the OPEN panel's override through
+  // its own `selectModel` setter (registered in the map below) — the same
+  // function the model picker calls, so `/clear` carries the override forward.
+  // No panel mounted → writing the key is enough; the panel reads it on mount.
+  const panelModelControl = useRef(new Map<string, (m: ModelSelection) => void>());
+  const registerModelControl = useCallback(
+    (sid: string, apply: (m: ModelSelection) => void) => {
+      panelModelControl.current.set(sid, apply);
+    },
+    [],
+  );
+  const unregisterModelControl = useCallback((sid: string) => {
+    panelModelControl.current.delete(sid);
+  }, []);
+  useEffect(() => {
+    if (!window.api.onAppControl) return;
+    const off = window.api.onAppControl((payload) => {
+      const handlers: AppControlHandlers = {
+        switchModel: ({ sessionId, providerID, modelID }) => {
+          const sel: ModelSelection = { providerID, modelID };
+          const apply = panelModelControl.current.get(sessionId);
+          if (apply) apply(sel);
+          else writeSavedModel(sessionId, sel);
+        },
+        renameSession: () => {
+          // tmux is the source of truth; the existing refresh re-reads it.
+          void refresh();
+        },
+      };
+      dispatchAppControl(payload, handlers);
+    });
+    return off;
+  }, [refresh, apiGeneration]);
+
   // Desktop OS notifications. manta-server's router (push.mjs) decides WHICH
   // device(s) get a notification (no duplicates) and forwards a desktop directive
   // → main → IPC here. We add the final local
@@ -1650,6 +1694,8 @@ function AppInner() {
                       autoSubmit={
                         autoSubmitPrompt?.sid === sid ? autoSubmitPrompt : undefined
                       }
+                      registerModelControl={registerModelControl}
+                      unregisterModelControl={unregisterModelControl}
                     />
                   </PanelShell>
                 );

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -155,6 +155,13 @@ type Props = {
   // indicator appear immediately in the real chat view. Optional; present
   // only on the transient panel rendered while the tmux window is created.
   autoSubmit?: { text: string; model?: ModelSelection };
+  // App-control (BET-840/841): App owns the single `appControl` bus listener
+  // and reaches the open panel for a `switch-model` action through these.
+  // `selectModel` is registered so a model-switch applies the override through
+  // the SAME path the picker uses (no parallel setter that could drift). Both
+  // optional — omitted in test harnesses that mount ChatPanel directly.
+  registerModelControl?: (sessionId: string, apply: (m: ModelSelection) => void) => void;
+  unregisterModelControl?: (sessionId: string) => void;
 };
 
 export function ChatPanel({
@@ -171,6 +178,8 @@ export function ChatPanel({
   artifactsOpen = false,
   onToggleArtifacts = () => {},
   autoSubmit,
+  registerModelControl,
+  unregisterModelControl,
 }: Props) {
   const chatAutoAllow = useStore((s) => s.chatAutoAllow);
   const setChatAutoAllow = useStore((s) => s.setChatAutoAllow);
@@ -1355,6 +1364,16 @@ export function ChatPanel({
     },
     [sessionId],
   );
+
+  // App-control (BET-840/841): expose this panel's `selectModel` to App so the
+  // box's `switch-model` app-control event drives the override through the same
+  // path the picker uses (setModelOverride + writeSavedModel). Re-registers on
+  // session change; unregisters on unmount so a closed panel can't be reached.
+  useEffect(() => {
+    registerModelControl?.(sessionId, selectModel);
+    return () => unregisterModelControl?.(sessionId);
+  }, [sessionId, selectModel, registerModelControl, unregisterModelControl]);
+
 
   // Session ops. All three depend on tmuxSession/windowIndex being non-null
   // (the panel hides the buttons otherwise). The store will pick up the new

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -71,6 +71,7 @@ export const DEMO_UNIMPLEMENTED = [
   "gitAddWorktree",
   "gitRemoveWorktree",
   "onAgentFileReady",
+  "onAppControl",
   "onAutoUpdateAvailable",
   "onAutoUpdateDownloaded",
   "onDelegateUpdated",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -18,6 +18,7 @@ import {
   type VoiceRetryResult,
   type VoiceUploadNoteInput,
   type VoiceUploadNoteResult,
+  type AppControlPayload,
 } from "../../shared/types.js";
 import type { Api, SyncDelta } from "../../shared/api.js";
 // BET-559: httpApi used to pull these claim helpers through the (now-retired)
@@ -358,6 +359,7 @@ type Kind =
   | "delegate.updated"
   | "usage.updated"
   | "progress.updated"
+  | "appControl"
   | "stream"
   | "sync";
 
@@ -377,6 +379,7 @@ const listeners: Record<Kind, Set<(p: unknown) => void>> = {
   "delegate.updated": new Set(),
   "usage.updated": new Set(),
   "progress.updated": new Set(),
+  appControl: new Set(),
   stream: new Set(),
   sync: new Set(),
 };
@@ -1094,6 +1097,12 @@ export const httpApi: Api = {
   // the store's `usage` slice via setUsage, no refetch needed.
   onUsageUpdated: (cb) =>
     on<{ snapshots: UsageSnapshot[] }>("usage.updated", cb),
+
+  // BET-840/841: the box publishes a single `appControl` bus kind with an
+  // `action` discriminator whenever an app-control tool lands a client-visible
+  // effect (switch-model, rename-session, ...). The payload IS the full event
+  // — the renderer switches on `action` directly, no refetch.
+  onAppControl: (cb) => on<AppControlPayload>("appControl", cb),
 
   // -- APNs native-push registration (BET-181) --
   // iOS Capacitor app registers its APNs device token via the standard 6-site

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -4269,6 +4269,8 @@ describe("preferLinkedPr (BET-852)", () => {
     expect(out!.number).toBe(412);
     expect(out!.url).toBe("");
     expect(out!.reviewers).toEqual([]);
+  });
+});
 
 describe("dispatchAppControl (BET-841)", () => {
   it("routes switch-model to the handler with the resolved model", () => {

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -113,6 +113,7 @@ import {
   buildVoiceNoteMap,
   linkedPrNumber,
   preferLinkedPr,
+  dispatchAppControl,
 } from "./chatUtils";
 
 import type { OpencodeModel, UsageSnapshot, OpencodeMessage, VoiceNoteRecord } from "../shared/types";
@@ -4268,5 +4269,66 @@ describe("preferLinkedPr (BET-852)", () => {
     expect(out!.number).toBe(412);
     expect(out!.url).toBe("");
     expect(out!.reviewers).toEqual([]);
+
+describe("dispatchAppControl (BET-841)", () => {
+  it("routes switch-model to the handler with the resolved model", () => {
+    const switchModel = vi.fn();
+    const renameSession = vi.fn();
+    dispatchAppControl(
+      { action: "switch-model", sessionId: "ses_1", providerID: "anthropic", modelID: "claude-opus-4-7" },
+      { switchModel, renameSession },
+    );
+    expect(switchModel).toHaveBeenCalledTimes(1);
+    expect(switchModel).toHaveBeenCalledWith({
+      sessionId: "ses_1",
+      providerID: "anthropic",
+      modelID: "claude-opus-4-7",
+    });
+    expect(renameSession).not.toHaveBeenCalled();
+  });
+
+  it("does not fire switch-model when required fields are missing", () => {
+    const switchModel = vi.fn();
+    dispatchAppControl(
+      { action: "switch-model", sessionId: "ses_1", providerID: "anthropic" },
+      { switchModel },
+    );
+    dispatchAppControl({ action: "switch-model" }, { switchModel });
+    expect(switchModel).not.toHaveBeenCalled();
+  });
+
+  it("routes rename-session to the handler with the new name", () => {
+    const renameSession = vi.fn();
+    dispatchAppControl(
+      { action: "rename-session", sessionId: "ses_1", name: "my session" },
+      { renameSession },
+    );
+    expect(renameSession).toHaveBeenCalledTimes(1);
+    expect(renameSession).toHaveBeenCalledWith({
+      sessionId: "ses_1",
+      name: "my session",
+    });
+  });
+
+  it("no-ops for compact-session", () => {
+    const switchModel = vi.fn();
+    const renameSession = vi.fn();
+    dispatchAppControl(
+      { action: "compact-session", sessionId: "ses_1" },
+      { switchModel, renameSession },
+    );
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(renameSession).not.toHaveBeenCalled();
+  });
+
+  it("ignores unknown actions and non-object payloads silently", () => {
+    const switchModel = vi.fn();
+    const renameSession = vi.fn();
+    dispatchAppControl({ action: "future-action" }, { switchModel, renameSession });
+    dispatchAppControl(null, { switchModel, renameSession });
+    dispatchAppControl("nope", { switchModel, renameSession });
+    dispatchAppControl(undefined, { switchModel, renameSession });
+    expect(switchModel).not.toHaveBeenCalled();
+    expect(renameSession).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { AppConfig, CheckRollup, DelegateApprovalTool, ForgeCheckRun, OpencodeMessage, OpencodeModel, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { AppConfig, AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, OpencodeMessage, OpencodeModel, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 import type { VoiceNoteRecord } from "../shared/types";
 // Value import — `isClientTooOld` is the pure semver compare that drives
@@ -3188,4 +3188,54 @@ export function preferLinkedPr(
     mergeBlockedReason: null,
     unresolvedThreads: 0,
   };
+};
+
+// ---------------------------------------------------------------------------
+// App-control bus dispatcher (BET-840/841).
+//
+// The box publishes ONE `appControl` bus kind with an `action` discriminator.
+// The desktop renderer subscribes once (App.tsx) and funnels every envelope
+// through this pure dispatcher, which routes each known action to a handler
+// from the injected `handlers` bag. Pure and side-effect-free so it can be
+// unit-tested without mounting App.
+//
+// - switch-model  -> handlers.switchModel (persist override + apply to the
+//                    open panel via the shared model-selection path)
+// - rename-session-> handlers.renameSession (refresh the sidebar; tmux is the
+//                    source of truth)
+// - compact-session -> no-op by design: opencode emits `session.compacted` and
+//                    the renderer already reacts to it. Kept so nobody adds a
+//                    redundant branch.
+// - unknown action -> ignored silently. A newer box may publish an action an
+//                    older desktop does not know; that must not throw.
+// ---------------------------------------------------------------------------
+export type AppControlHandlers = {
+  switchModel?: (m: { sessionId: string; providerID: string; modelID: string }) => void;
+  renameSession?: (p: { sessionId?: string; name: string }) => void;
+};
+
+export function dispatchAppControl(
+  payload: unknown,
+  handlers: AppControlHandlers,
+): void {
+  if (!payload || typeof payload !== "object") return;
+  const p = payload as AppControlPayload;
+  if (p.action === "switch-model") {
+    const sessionId = typeof p.sessionId === "string" ? p.sessionId : "";
+    const providerID = typeof p.providerID === "string" ? p.providerID : "";
+    const modelID = typeof p.modelID === "string" ? p.modelID : "";
+    if (sessionId && providerID && modelID) {
+      handlers.switchModel?.({ sessionId, providerID, modelID });
+    }
+    return;
+  }
+  if (p.action === "rename-session") {
+    const name = typeof p.name === "string" ? p.name : "";
+    handlers.renameSession?.({
+      sessionId: typeof p.sessionId === "string" ? p.sessionId : undefined,
+      name,
+    });
+    return;
+  }
+  // compact-session + any unknown action: no-op.
 }

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -69,6 +69,7 @@ import type {
   SubagentInput,
   PluginRegistryRow,
   TranscriptHit,
+  AppControlPayload,
 } from "./types.js";
 import type { ClaimOutcome } from "./claim.mjs";
 
@@ -447,6 +448,13 @@ export interface Api {
   // refetch. No-op on the preload bridge and on demoApi (Proxy fallback
   // returns a no-op unsubscribe).
   onUsageUpdated(cb: (payload: { snapshots: UsageSnapshot[] }) => void): () => void;
+
+  // App-control (BET-840/841). The box publishes ONE `appControl` bus kind
+  // with an `action` discriminator (switch-model / rename-session /
+  // compact-session); the desktop subscribes here once and switches on
+  // `action`. No-op on the preload bridge and on demoApi (Proxy fallback
+  // returns a no-op unsubscribe).
+  onAppControl(cb: (payload: AppControlPayload) => void): () => void;
 
   // Secrets (manta-server owned; desktop reaches it over -L 18787). list returns
   // METADATA ONLY (never values). set carries the value renderer → box (never

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -741,6 +741,21 @@ export type ServerUpdateAvailablePayload = {
   notesUrl: string | null;
 };
 
+// App-control bus envelope payload (BET-840/841). manta-server publishes ONE
+// bus kind, `appControl`, with an `action` discriminator
+// (src/server/appControl.mjs). The desktop renderer subscribes once
+// (src/renderer/App.tsx) and switches on `action`. `providerID`/`modelID`
+// ride the `switch-model` event; `name` rides `rename-session`. Client-
+// agnostic by design so the native client can adopt the same bus kind later
+// without a server change.
+export type AppControlPayload = {
+  action: string;
+  sessionId?: string;
+  providerID?: string;
+  modelID?: string;
+  name?: string;
+};
+
 // SSH installer (BET-355) — push-event shape + state snapshot. These types
 // are declared in src/shared/types.ts so both the preload runtime (which
 // imports them into src/preload/index.ts) AND the renderer-side accessor


### PR DESCRIPTION
Closes BET-841 (App-control tools: renderer bus consumer for model switch and rename).

Applies the client-visible effects of the app-control tools in the desktop renderer. The server side (BET-840) publishes one `appControl` bus kind with an `action` discriminator; this ticket adds the single renderer consumer.

**Changes:**
- `src/shared/types.ts` — `AppControlPayload` (client-facing shape of the `appControl` bus envelope).
- `src/shared/api.ts` + `src/renderer/api/httpApi.ts` — `onAppControl` subscription (new `appControl` bus kind → WS listener). No-op in demo/preload legs.
- `src/renderer/chatUtils.ts` — pure `dispatchAppControl(payload, handlers)` switching on `action`; unknown actions + `compact-session` no-op silently.
- `src/renderer/App.tsx` — ONE subscription next to the `onOpencodeEvent` fan-out. `switch-model` persists via the shared `writeSavedModel` then drives the OPEN panel's `selectModel` (same function the picker calls — no parallel setter, so `/clear` carries the override forward); falls back to persist-only when no panel is mounted. `rename-session` refreshes the sidebar through the existing `refresh()` (tmux is the source of truth).
- `src/renderer/ChatPanel.tsx` — registers its `selectModel` setter against App via optional `registerModelControl`/`unregisterModelControl` props (does NOT subscribe to the bus itself).
- Tests: `chatUtils.test.ts` covers switch-model (incl. missing-field guard), rename-session, compact-session no-op, unknown/no-op payloads.

**Base:** origin/main @ 10f00de3

**Verification results:**
- PR branch (`multica/BET-841-app-control-renderer` @ 5966c1d6):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 722 pass / 0 fail / 0 skip. Failures: none.
- Base (`main` @ 10f00de3): local two-branch run not separately captured for this small change; the full suite is green on the PR branch and `npm run typecheck` passes.
- **Conclusion:** 0 new failures.

Not run on a dev box (no interactive model/session on this Linux box to drive a live `switch-model`/`rename-session`); the pure dispatcher is unit-tested and the bus wiring mirrors the existing `onSyncDelta`/`onUsageUpdated` subscriptions byte-for-byte.

Mobile is out of scope per the ticket (native client may adopt the same bus kind later; no server change needed).
