### PR TITLE
feat(renderer): branch chip prefers stored session-link PR number (BET-852)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -54,6 +54,8 @@ import {
   type StaleCacheResult,
   type PendingScrollWin,
   isApprovalCoveredByAlways,
+  linkedPrNumber,
+  preferLinkedPr,
   MANTA_BUILTIN_COMMANDS,
   MANTA_BUILTIN_NAMES,
   parseModelRef,
@@ -236,6 +238,20 @@ export function ChatPanel({
   const [shipError, setShipError] = useState<string | null>(null);
   const [mergeBusy, setMergeBusy] = useState(false);
   const [mergeError, setMergeError] = useState<string | null>(null);
+  // BET-852: the stored session-link PR number (`projects[].link.pr`), read off
+  // the box config. The branch chip prefers it over the (15s) live forge lookup
+  // when present — so a freshly-shipped PR's number appears immediately and
+  // independently of the poll resolving. Refreshed on session change and after
+  // a ship/merge writes the link.
+  const [linkedPr, setLinkedPr] = useState<number | null>(null);
+  const refreshLinkedPr = useCallback(async () => {
+    try {
+      const cfg = await window.api.configGet();
+      setLinkedPr(linkedPrNumber(cfg, tmuxSession));
+    } catch {
+      /* non-fatal — fall back to the live lookup */
+    }
+  }, [tmuxSession]);
 
   // BET-418 §D: detect whether THIS session is a background job's child. A
   // job session is read-only (no composer, no cards, no model picker/fork/
@@ -536,6 +552,7 @@ export function ChatPanel({
       if (res.ok) {
         setShipOpen(false);
         setShipProposal(null);
+        void refreshLinkedPr();
         void window.api.forgePullRequest({ cwd }).then((r) => setForgeResult(r)).catch(() => {});
       } else {
         setShipError(res.error);
@@ -545,7 +562,7 @@ export function ChatPanel({
     } finally {
       setShipBusy(false);
     }
-  }, [cwd]);
+  }, [cwd, refreshLinkedPr]);
 
   // Merge the shown PR, ALWAYS with the head SHA the user approved.
   const doMerge = useCallback(async () => {
@@ -556,6 +573,7 @@ export function ChatPanel({
     try {
       const res = await window.api.forgeMerge({ cwd, number: pr.number, method: "merge", sha: pr.headSha });
       if (res.ok) {
+        void refreshLinkedPr();
         void window.api.forgePullRequest({ cwd }).then((r) => setForgeResult(r)).catch(() => {});
       } else {
         setMergeError(describeMergeFailure(res.kind));
@@ -565,7 +583,7 @@ export function ChatPanel({
     } finally {
       setMergeBusy(false);
     }
-  }, [cwd, forgeResult]);
+  }, [cwd, forgeResult, refreshLinkedPr]);
 
 
   // ===== ChatPanel-own state (not extracted to hooks) =====
@@ -667,6 +685,12 @@ export function ChatPanel({
       // non-fatal — the forge read path is best-effort; keep last-known.
     }
   }, []);
+  // Resolve which PR the branch chip renders: the stored link's number when
+  // present, else today's live `forgePullRequest` result (the 15s poll).
+  const displayPr = useMemo(
+    () => preferLinkedPr(forge.pr, linkedPr),
+    [forge.pr, linkedPr],
+  );
 
   // BET-789: dismiss the "Connect GitHub…" offer permanently, per-box. Mirror
   // of AppConfig.forgeConnectOfferDismissed, written through the generic
@@ -694,6 +718,14 @@ export function ChatPanel({
     }, 5000);
     return () => clearInterval(branchPoll);
   }, [cwd, refreshBranch, isActive, refreshForge]);
+
+  // BET-852: refresh the stored session-link PR number on entry (and when the
+  // session changes). Gated on isActive like the other session reads — a
+  // hidden panel doesn't re-read config. Written again by ship/merge below.
+  useEffect(() => {
+    if (!isActive || !tmuxSession) return;
+    void refreshLinkedPr();
+  }, [refreshLinkedPr, isActive, tmuxSession]);
 
   // Ctrl+O toggles reasoning visibility. Matches Claude Code's TUI keybind.
   useEffect(() => {
@@ -2482,7 +2514,7 @@ export function ChatPanel({
         artifactsOpen={artifactsOpen}
         onToggleArtifacts={onToggleArtifacts}
         hiddenStatusItems={hiddenStatusItems}
-        pr={forge.pr}
+        pr={displayPr}
         checks={forge.checks}
         checksRollup={forge.rollup}
         forgeConnected={forge.connected}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -2168,7 +2168,7 @@ describe("isBackgroundJobCompletionTurn", () => {
 
 // ===== BET-414 sidebar helpers =====
 
-import type { Project, PermissionRequest } from "../shared/types";
+import type { Project, PermissionRequest, SessionLink } from "../shared/types";
 
 function mkProject(
   tmuxSession: string,
@@ -4177,7 +4177,7 @@ describe("buildVoiceNoteMap (BET-837)", () => {
 });
 
 describe("linkedPrNumber (BET-852)", () => {
-  const cfg = (link?: unknown) => ({
+  const cfg = (link?: SessionLink | null) => ({
     projects: [{ tmuxSession: "ethernal", defaultCwd: "/p", link }],
   });
 

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -110,6 +110,8 @@ import {
   progressAttentionKind,
   concatUserMessageText,
   buildVoiceNoteMap,
+  linkedPrNumber,
+  preferLinkedPr,
 } from "./chatUtils";
 
 import type { OpencodeModel, UsageSnapshot, OpencodeMessage, VoiceNoteRecord } from "../shared/types";
@@ -4171,5 +4173,76 @@ describe("buildVoiceNoteMap (BET-837)", () => {
     expect(concatUserMessageText(msg)).toBe("line one\nline two");
     const map = buildVoiceNoteMap([msg], [vnote("n1", "line one\nline two")]);
     expect(map.get("m1")?.id).toBe("n1");
+  });
+});
+
+describe("linkedPrNumber (BET-852)", () => {
+  const cfg = (link?: unknown) => ({
+    projects: [{ tmuxSession: "ethernal", defaultCwd: "/p", link }],
+  });
+
+  it("returns the stored PR number when the session has a link.pr slot", () => {
+    expect(linkedPrNumber(cfg({ pr: { repoKey: "x/y", number: 412 } }), "ethernal")).toBe(412);
+  });
+
+  it("returns null when there is no link or no pr slot", () => {
+    expect(linkedPrNumber(cfg({ issue: { repoKey: "x/y", number: 9 } }), "ethernal")).toBe(null);
+    expect(linkedPrNumber(cfg(undefined), "ethernal")).toBe(null);
+    expect(linkedPrNumber(cfg(null), "ethernal")).toBe(null);
+    expect(linkedPrNumber(undefined, "ethernal")).toBe(null);
+    expect(linkedPrNumber(cfg({ pr: { repoKey: "x/y", number: 412 } }), null)).toBe(null);
+  });
+
+  it("only matches the session's own project (by tmuxSession)", () => {
+    expect(linkedPrNumber(cfg({ pr: { repoKey: "x/y", number: 412 } }), "marketing")).toBe(null);
+  });
+
+  it("rejects a non-positive / non-integer stored number defensively", () => {
+    const bad = { pr: { repoKey: "x/y", number: 0 } };
+    expect(linkedPrNumber(cfg(bad), "ethernal")).toBe(null);
+  });
+});
+
+describe("preferLinkedPr (BET-852)", () => {
+  const live = (number: number) => ({
+    number,
+    title: "T",
+    body: "",
+    url: "https://github.com/x/y/pull/" + number,
+    state: "open" as const,
+    draft: false,
+    headRef: "h",
+    baseRef: "b",
+    headSha: "s",
+    author: "a",
+    reviewers: [],
+    mergeable: null,
+    mergeBlockedReason: null,
+    unresolvedThreads: 0,
+  });
+
+  it("preserves the live lookup unchanged when there is no stored link", () => {
+    const l = live(412);
+    expect(preferLinkedPr(l, null)).toBe(l);
+    expect(preferLinkedPr(null, null)).toBe(null);
+  });
+
+  it("keeps full live details when the live PR is the stored PR", () => {
+    const l = live(412);
+    expect(preferLinkedPr(l, 412)).toBe(l);
+  });
+
+  it("prefers the stored link number over a differing live PR number", () => {
+    const out = preferLinkedPr(live(410), 412);
+    expect(out?.number).toBe(412);
+    expect(out?.title).toBe("T");
+  });
+
+  it("renders a minimal card from the stored number when the poll has not resolved", () => {
+    const out = preferLinkedPr(null, 412);
+    expect(out).not.toBeNull();
+    expect(out!.number).toBe(412);
+    expect(out!.url).toBe("");
+    expect(out!.reviewers).toEqual([]);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { CheckRollup, DelegateApprovalTool, ForgeCheckRun, OpencodeMessage, OpencodeModel, PermissionRequest, ProgressRecord, ProgressState, Project, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { AppConfig, CheckRollup, DelegateApprovalTool, ForgeCheckRun, OpencodeMessage, OpencodeModel, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 import type { VoiceNoteRecord } from "../shared/types";
 // Value import — `isClientTooOld` is the pure semver compare that drives
@@ -3105,4 +3105,54 @@ export function buildVoiceNoteMap(
     }
   }
   return map;
+}
+
+// BET-852: the stored session-link PR ref (`projects[].link.pr`) is the source
+// of truth for "what PR is this session shipping" — recorded the moment
+// `shipPullRequest` opens a PR (onPrOpened → linkPullRequest). Reading it off
+// the AppConfig the box serves lets the branch chip show the linked PR number
+// immediately (and even when the 15s forge poll has not resolved), instead of
+// depending on the live `forgePullRequest` lookup alone. Returns the stored
+// PR number when the session has a saved link slot; null otherwise (a PR
+// opened outside the app, or before the first ship), which is the fall-back
+// to live-lookup territory.
+export function linkedPrNumber(
+  config: Pick<AppConfig, "projects"> | null | undefined,
+  tmuxSession: string | null,
+): number | null {
+  if (!config || !tmuxSession) return null;
+  const proj = (config.projects ?? []).find((p) => p.tmuxSession === tmuxSession);
+  const pr = proj?.link?.pr;
+  return pr && Number.isInteger(pr.number) && pr.number > 0 ? pr.number : null;
+}
+
+// BET-852: resolve the PR object the branch chip should render. Prefers the
+// stored link's number when the session has one (per the issue, the stored
+// link wins); otherwise preserves today's live-lookup behavior unchanged.
+// When the live poll has already resolved the SAME PR we keep its full
+// details (title/state/checks panel); when it has not resolved yet we render
+// a minimal card so `#N` appears immediately from the stored link rather than
+// waiting for the poll.
+export function preferLinkedPr(
+  live: PullRequest | null,
+  linkedNumber: number | null,
+): PullRequest | null {
+  if (linkedNumber == null) return live;
+  if (live) return live.number === linkedNumber ? live : { ...live, number: linkedNumber };
+  return {
+    number: linkedNumber,
+    title: "",
+    body: "",
+    url: "",
+    state: "open",
+    draft: false,
+    headRef: "",
+    baseRef: "",
+    headSha: "",
+    author: "",
+    reviewers: [],
+    mergeable: null,
+    mergeBlockedReason: null,
+    unresolvedThreads: 0,
+  };
 }


### PR DESCRIPTION
**Files changed:** `3` files. `src/renderer/ChatPanel.tsx`, `src/renderer/chatUtils.ts`, `src/renderer/chatUtils.test.ts`

**What changed (BET-852):** The branch chip now reads the session's stored link PR number (`projects[].link.pr`) when present, falling back to the live `forgePullRequest` lookup when the session has no stored link (PR opened outside the app, or before the first ship).

- `chatUtils.ts`: two pure helpers — `linkedPrNumber(config, tmuxSession)` (extract the stored PR number for a project) and `preferLinkedPr(live, linkedNumber)` (prefer the stored number, keep full live details when the poll has the same PR, else a minimal card so `#N` shows immediately).
- `ChatPanel.tsx`: reads the link via `window.api.configGet()` on session entry (gated on `isActive`) and re-reads after ship/merge; threads `displayPr = preferLinkedPr(forge.pr, linkedPr)` to `SessionHeader` instead of `forge.pr` directly.

**Verification results:**
- PR branch (`multica/BET-852-branch-chip-session-link` @ `dd366c03`):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, 722 pass / 0 fail / 0 skip. Failures: none. log sha256: `b39bf4e706edad4b34585190444ec15b0053eb2b4f2eda0ede10bdb75dc60baf`
- Base (`main` @ `7bfb1aea`): renderer-only change with added pure functions + tests; no behavior change to shared/server paths. Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.
- **Conclusion:** `0` new failures; `0` pre-existing. New tests: 10 (`linkedPrNumber`, `preferLinkedPr`).

**Base: origin/main @ 7bfb1aea**
