### PR TITLE
feat(renderer): render no-remote repo rows home-relative (~/) in zero-state list (BET-816)

### DIFF
--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -174,6 +174,9 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   const [probeFailed, setProbeFailed] = useState(false);
   const [probeRepos, setProbeRepos] = useState<RepoHit[]>([]);
   const [cliStatus, setCliStatus] = useState<ForgeCliStatus | null>(null);
+  // The box's $HOME from the probe, used to render a no-remote repo under the
+  // home dir as `~/…` instead of the absolute path (describeRepoRow).
+  const [homeDir, setHomeDir] = useState<string | null>(null);
   const [checked, setChecked] = useState<ReadonlySet<string>>(new Set());
   // The user chose "Browse for a folder…" (or the picker returned a worktree
   // fan-out) → render today's full composer for that folder. This is how the
@@ -209,6 +212,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
     setProbeFailed(false);
     setProbeRepos([]);
     setCliStatus(null);
+    setHomeDir(null);
     setBrowseChosen(false);
     setChecked(new Set());
     setRowPhase({});
@@ -224,6 +228,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
           setProbePending(false);
           setProbeRepos(res?.repos ?? []);
           setCliStatus(res?.cli ?? null);
+          setHomeDir(res?.homeDir ?? null);
         })
         .catch(() => {
           if (cancelled) return;
@@ -995,7 +1000,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
                           />
                         }
                         name={<span className="truncate">{r.name}</span>}
-                        secondary={<span className="truncate">{describeRepoRow(r)}</span>}
+                        secondary={<span className="truncate">{describeRepoRow(r, homeDir)}</span>}
                         trailing={
                           <span>
                             {r.lastCommitAt ? formatAge(Date.now() - r.lastCommitAt) : "—"}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -100,6 +100,7 @@ import {
   zeroStateMode,
   initialRepoSelection,
   describeRepoRow,
+  homeRelativePath,
   planHighlightRanges,
   canMerge,
   describeMergeFailure,
@@ -3639,6 +3640,36 @@ describe("describeRepoRow", () => {
         repoRow({ branch: "main", originUrl: null, path: "/home/u/scratch", repoKey: null, forge: null }),
       ),
     ).toBe("⎇ main · /home/u/scratch · no remote");
+  });
+
+  it("renders a no-remote repo under the home dir as ~/… per the mockup", () => {
+    expect(
+      describeRepoRow(
+        repoRow({ branch: "main", originUrl: null, path: "/home/u/scratch", repoKey: null, forge: null }),
+        "/home/u",
+      ),
+    ).toBe("⎇ main · ~/scratch · no remote");
+  });
+
+  it("leaves a path outside the home dir absolute even when homeDir is given", () => {
+    expect(
+      describeRepoRow(
+        repoRow({ branch: "main", originUrl: null, path: "/opt/other/scratch", repoKey: null, forge: null }),
+        "/home/u",
+      ),
+    ).toBe("⎇ main · /opt/other/scratch · no remote");
+  });
+
+  it("renders the home dir itself as ~", () => {
+    expect(homeRelativePath("/home/u", "/home/u")).toBe("~");
+  });
+
+  it("returns the raw path when no homeDir is available", () => {
+    expect(homeRelativePath("/home/u/scratch", null)).toBe("/home/u/scratch");
+  });
+
+  it("handles a trailing-slash homeDir", () => {
+    expect(homeRelativePath("/home/u/scratch", "/home/u/")).toBe("~/scratch");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2929,12 +2929,27 @@ export function initialRepoSelection(repos: RepoRow[], cap: number): RepoRow[] {
   return selected;
 }
 
+// Substitute a leading home-dir prefix with `~` for display, matching the
+// manta-forge zero-state mockup (`~/scratch`). Given no homeDir (unavailable),
+// the absolute path is shown unchanged. Pure.
+export function homeRelativePath(path: string, homeDir?: string | null): string {
+  if (!homeDir || !path) return path;
+  if (path === homeDir) return "~";
+  const prefix = homeDir.endsWith("/") ? homeDir : `${homeDir}/`;
+  return path.startsWith(prefix) ? `~/${path.slice(prefix.length)}` : path;
+}
+
 // The secondary line under a repo row. With an origin, the branch alone
 // identifies the row; without one the bare basename does not, so the path and
-// "no remote" are added so the user can tell the row apart.
-export function describeRepoRow(repo: RepoHit): string {
+// "no remote" are added so the user can tell the row apart. `homeDir` (the
+// box's $HOME, from the forge probe) lets a repo under the home dir render
+// as `~/scratch` instead of the absolute path, per the manta-forge mockup.
+export function describeRepoRow(repo: RepoHit, homeDir?: string | null): string {
   const branch = repo.branch ? `⎇ ${repo.branch}` : "no branch";
-  if (!repo.originUrl) return `${branch} · ${repo.path} · no remote`;
+  if (!repo.originUrl) {
+    const path = homeRelativePath(repo.path, homeDir);
+    return `${branch} · ${path} · no remote`;
+  }
   return branch;
 }
 

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -892,7 +892,7 @@ export async function forgeProbe() {
   const projectCwds = (cfg.projects ?? []).map((p) => p.defaultCwd).filter(Boolean);
   const { repos, partial } = await scanRepos({ roots: buildRoots(projectCwds) });
   const cli = await detectForgeCli();
-  const result = { repos, cli, partial };
+  const result = { repos, cli, partial, homeDir: homedir() };
   _forgeCache = { at: now, result };
   return result;
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -355,6 +355,10 @@ export type ForgeProbeResult = {
   repos: RepoHit[];
   cli: ForgeCliStatus;
   partial: boolean;
+  // The box's $HOME, so the renderer can render a repo under it as `~/...`
+  // instead of the absolute path. null when not provided (renderer degrades
+  // to the absolute path).
+  homeDir: string | null;
 };
 
 // ----- Forge clone flow (BET-796) -----


### PR DESCRIPTION
Renders a no-remote repo row home-relative (`~/scratch`) in the zero-state list, matching the manta-forge [S2] mockup, instead of the absolute box path.

**What changed**
- `describeRepoRow(repo, homeDir?)` — substitutes a leading home-dir prefix with `~` for display; absolute paths outside the home dir are unchanged.
- New pure `homeRelativePath(path, homeDir?)` helper (tested).
- `ForgeProbeResult` now carries the box `homeDir`; `forgeProbe()` returns it via `homedir()`.
- `NewSessionScreen` threads the probe's `homeDir` into `describeRepoRow`.

No box-path convention won over the mockup — the mockup is the spec and the tilde form is the more scannable display, so the substitution is added behind a `homeDir` the server now supplies.

**Files changed:** 5 files. `src/renderer/chatUtils.ts`, `src/renderer/chatUtils.test.ts`, `src/shared/types.ts`, `src/server/local.mjs`, `src/renderer/NewSessionScreen.tsx`

**Verification results:**
- PR branch (`multica/BET-816-home-relative-repo-path` @ `b63fa0a2`):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, 2603 pass / 0 fail / 7 skip (vitest) + 1900/0 (server). Failures: none. log sha256: `22e66433b39fe54511962fa30c0bbe27b782e4e03c4b60a3310433da67341c8f`
- Base (`main` @ `b88860c1`):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, 2598 pass / 0 fail / 7 skip (vitest) + 1900/0 (server). Failures: none. log sha256: `b7e1270abb76dc9baaa23a3568d34014a074d3b55e028ea38e1313d35c3d739e`
- **Conclusion:** 0 failures are pre-existing; 0 new failures; 5 new tests added and passing.

Base: origin/main @ `b88860c1`
