### PR TITLE
feat(forge): provider+hookId forge-hook store and GitLab health-check loop (BET-855)

### DIFF
--- a/src/server/forge/poller.mjs
+++ b/src/server/forge/poller.mjs
@@ -28,6 +28,9 @@
 
 import { rollupChecks } from "../../shared/forge.mjs";
 import { startPoller } from "../startPoller.mjs";
+import { parseRepoKey } from "../forgeRules.mjs";
+import { parseRules as parseForgeRules } from "../../shared/forgeRules.mjs";
+import { detectForgeWithHosts } from "./selfhost.mjs";
 
 /**
  * Build the polling loop. `pollRepo` is the injected per-repo unit (the shape
@@ -82,6 +85,50 @@ export function createForgePoller({
   }
 
   return startPoller(tick, { intervalMs, label: "forge-poller" });
+}
+
+/**
+ * Resolve the poll plan for one rules row: which poll units it subscribes to,
+ * the repo's forge kind, and whether it ALREADY has a working webhook. Pure of
+ * I/O (the store lookup is injected). This is the "never both" gate made
+ * provider-aware (BET-855): a GitLab hook is stored under `provider: "gitlab"`,
+ * so the github-scoped default find would miss it and the poller would wrongly
+ * poll a repo that has a working webhook. `findHook(repoKey, {provider})` is
+ * how the caller (index.mjs) reaches the forge-hook store.
+ *
+ * @param {object} input
+ * @param {string} input.repoKey   canonical "host/owner/repo"
+ * @param {string} [input.yaml]    the raw rules source (for the `on:` blocks)
+ * @param {Array<{host: string, kind: string}>} [input.hostKinds] user-configured forgeHosts mapping
+ * @param {(repoKey: string, opts: {provider: string}) => Promise<object|null>} input.findHook
+ * @param {object} [deps]
+ * @param {typeof parseForgeRules} [deps.parse]
+ * @param {typeof detectForgeWithHosts} [deps.detect]
+ * @returns {Promise<object|null>} the repo poll plan, or null for an invalid key
+ */
+export async function repoPollPlan(
+  { repoKey, yaml, hostKinds = [], findHook },
+  { parse = parseForgeRules, detect = detectForgeWithHosts } = {},
+) {
+  const parts = parseRepoKey(repoKey);
+  if (!parts) return null;
+  // Same kind derivation as saveRules (BET-855): known host OR the user's
+  // forgeHosts mapping. A GitLab repo is keyed under provider "gitlab" so its
+  // registered hook is never missed by the github-scoped default.
+  const forgeId = detect(`https://${parts.host}/${parts.owner}/${parts.repo}`, hostKinds);
+  const kind = forgeId?.kind ?? "github";
+  const hook = await findHook(repoKey, { provider: kind });
+  const rulesOn = parse(yaml ?? "").rules?.on ?? {};
+  const labeled = rulesOn["issue.labeled"];
+  return {
+    repoKey,
+    parts,
+    kind,
+    label: typeof labeled?.label === "string" ? labeled.label : null,
+    pollChecksFailed: !!rulesOn["checks.failed"],
+    pollReviewRequested: !!rulesOn["review.requested"],
+    webhookRegistered: !!hook,
+  };
 }
 
 // The identity used to de-duplicate a polled issue event, so a 304 / an

--- a/src/server/forge/poller.test.mjs
+++ b/src/server/forge/poller.test.mjs
@@ -4,7 +4,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
-import { createForgePoller, pollChecksFailed, pollIssueLabels, pollReviewRequested } from "./poller.mjs";
+import { createForgePoller, repoPollPlan, pollChecksFailed, pollIssueLabels, pollReviewRequested } from "./poller.mjs";
 
 const repo = { owner: "anomalyco", repo: "manta" };
 
@@ -185,4 +185,64 @@ test("poller feeds pollRepo events to handleEvent", async () => {
     setTimeout(() => resolve(false), 500);
   });
   assert.equal(done, true);
+});
+
+// ----------------------------------------------------------------------------
+// repoPollPlan — provider-aware webhook detection (BET-855 review fix)
+// ----------------------------------------------------------------------------
+
+// A hook-store stub keyed by (repoKey, provider).
+function storeHook(map) {
+  return async (repoKey, { provider }) => map[`${provider}:${repoKey}`] ?? null;
+}
+
+test("repoPollPlan: a gitlab rule with a gitlab-provider hook is webhookRegistered", async () => {
+  const plan = await repoPollPlan(
+    {
+      repoKey: "gitlab.com/group/sub/widget",
+      yaml: `on:\n  issue.labeled:\n    label: manta\n    do: notify\n`,
+      hostKinds: [],
+      findHook: storeHook({ "gitlab:gitlab.com/group/sub/widget": { id: "h1" } }),
+    },
+  );
+  assert.equal(plan.kind, "gitlab", "kind is derived for a gitlab host");
+  assert.equal(plan.webhookRegistered, true, "the gitlab hook is seen even though it is not stored under provider github");
+  assert.equal(plan.label, "manta");
+});
+
+test("repoPollPlan: a gitlab rule with NO hook is not webhookRegistered (should poll)", async () => {
+  const plan = await repoPollPlan(
+    {
+      repoKey: "gitlab.com/acme/widget",
+      yaml: `on:\n  checks.failed:\n    do: notify\n`,
+      hostKinds: [],
+      findHook: storeHook({}),
+    },
+  );
+  assert.equal(plan.kind, "gitlab");
+  assert.equal(plan.webhookRegistered, false);
+  assert.equal(plan.pollChecksFailed, true);
+  assert.equal(plan.label, null);
+});
+
+test("repoPollPlan: a github rule stays unaffected and a github hook registers it", async () => {
+  const plan = await repoPollPlan(
+    {
+      repoKey: "github.com/acme/widget",
+      yaml: `on:\n  review.requested:\n    do: inbox\n`,
+      hostKinds: [],
+      findHook: storeHook({ "github:github.com/acme/widget": { id: "g1" } }),
+    },
+  );
+  assert.equal(plan.kind, "github");
+  assert.equal(plan.webhookRegistered, true);
+  assert.equal(plan.pollReviewRequested, true);
+});
+
+test("repoPollPlan: an invalid repo key returns null", async () => {
+  const plan = await repoPollPlan({
+    repoKey: "not-a-valid-key",
+    findHook: storeHook({}),
+  });
+  assert.equal(plan, null);
 });

--- a/src/server/forge/webhook.mjs
+++ b/src/server/forge/webhook.mjs
@@ -20,6 +20,7 @@
 // on here.
 
 import { randomBytes } from "node:crypto";
+import { startPoller } from "../startPoller.mjs";
 
 // The Manta webhook URL under a box's public hostname. `<token>` is the
 // 128-bit capability that resolves to the hook record at ingest.
@@ -221,6 +222,82 @@ export async function healthCheckRepoHook(
   } catch (e) {
     return { ok: false, error: e?.message ?? String(e) };
   }
+}
+
+/**
+ * The scheduled health-check loop — the PRODUCTION CALLER that gives
+ * `healthCheckRepoHook`'s re-enable capability a reason to exist (the BET-855
+ * deferral: the capability shipped but nothing called it). GitLab disables a
+ * failing webhook permanently with no auto-recovery, so a box that sleeps / a
+ * hook that hiccups goes silently deaf unless something re-arms it on a
+ * cadence.
+ *
+ * Reuses the shared `startPoller` shape (immediate first tick, inFlight guard,
+ * timer.unref()) exactly as forge/poller.mjs does — this is NOT a hand-rolled
+ * loop. Each tick iterates the injected `listHooks()` records, resolves a forge
+ * credential per host, and runs `checkHook` (the concrete implementer is
+ * `healthCheckRepoHook`). Only GitLab records are checked — GitHub never
+ * auto-disables, so a github hook would be a no-op round-trip.
+ *
+ * `resolveToken(host, hook) -> Promise<string|null>` supplies the box-side forge
+ * credential; `listHooks() -> Array<{kind, host, owner, repo, hookId}>` is the
+ * box's forge hook store. All I/O is injected, so a test never touches the
+ * network or the live store.
+ *
+ * @param {object} deps
+ * @param {() => Promise<Array<{kind: string, host: string, owner: string, repo: string, hookId: any}>>} [deps.listHooks]
+ * @param {(host: string, hook: object) => Promise<string|null>} [deps.resolveToken]
+ * @param {typeof healthCheckRepoHook} [deps.checkHook]
+ * @param {number} [deps.intervalMs]
+ * @param {(msg: string, ...rest: any[]) => void} [deps.log]
+ * @returns {{ stop: () => void }}
+ */
+export function startForgeHealthCheck({
+  listHooks = async () => [],
+  resolveToken = async () => null,
+  checkHook = healthCheckRepoHook,
+  intervalMs = 15 * 60_000,
+  log = console.warn,
+} = {}) {
+  async function tick() {
+    let hooks = [];
+    try {
+      hooks = await listHooks();
+    } catch (e) {
+      log("[forge-health] listHooks failed:", e?.message ?? e);
+      return;
+    }
+    for (const hook of hooks) {
+      if (hook?.kind !== "gitlab") continue; // GitHub never auto-disables; skip.
+      const label = `${hook?.host ?? "?"}/${hook?.owner ?? "?"}/${hook?.repo ?? "?"}`;
+      const token = await resolveToken(hook.host, hook).catch(() => null);
+      if (!token) {
+        log(`[forge-health] no token for ${label} — skipping re-enable check`);
+        continue;
+      }
+      try {
+        const res = await checkHook({
+          kind: "gitlab",
+          host: hook.host,
+          owner: hook.owner,
+          repo: hook.repo,
+          token,
+          hookId: hook.hookId,
+        });
+        if (!res.ok) {
+          log(`[forge-health] hook ${label} check failed:`, res?.error ?? "");
+          continue;
+        }
+        if (res.reenabled) {
+          log(`[forge-health] re-enabled disabled GitLab hook ${label} (${hook.hookId})`);
+        }
+      } catch (e) {
+        log(`[forge-health] hook ${label} check threw:`, e?.message ?? e);
+      }
+    }
+  }
+
+  return startPoller(tick, { intervalMs, label: "forge-health" });
 }
 
 // Default API client — a thin fetch wrapper. Injected as `api` in tests. Shared

--- a/src/server/forge/webhook.test.mjs
+++ b/src/server/forge/webhook.test.mjs
@@ -10,6 +10,7 @@ import {
   ensureRepoHook,
   healthCheckRepoHook,
   forgeHookUrl,
+  startForgeHealthCheck,
 } from "./webhook.mjs";
 
 const PUBLIC = "https://12998f00.boxes.mantaui.com";
@@ -112,3 +113,116 @@ test("healthCheckRepoHook leaves an active gitlab hook alone (no re-enable)", as
   assert.equal(res.reenabled, false);
   assert.equal(calls.some((c) => c.method === "PUT"), false, "an active hook is never re-PUT");
 });
+
+// ----------------------------------------------------------------------------
+// startForgeHealthCheck — the scheduled loop that drives healthCheckRepoHook
+// ----------------------------------------------------------------------------
+
+// startPoller fires its first tick immediately, then on intervalMs. These tests
+// use a long interval (so the only tick is the immediate one) and drain enough
+// microtask turns for that tick's awaits to resolve.
+const flush = () => new Promise((r) => setTimeout(r, 20));
+
+test("health-check loop re-enables a disabled gitlab hook (BET-855)", async () => {
+  const checked = [];
+  const poller = startForgeHealthCheck({
+    intervalMs: 60_000,
+    listHooks: async () => [
+      { kind: "gitlab", host: "gitlab.com", owner: "acme", repo: "widget", hookId: 5 },
+    ],
+    resolveToken: async (host) => (host === "gitlab.com" ? "glpat_x" : null),
+    checkHook: async (input) => {
+      checked.push(input);
+      assert.equal(input.kind, "gitlab");
+      assert.equal(input.host, "gitlab.com");
+      assert.equal(input.hookId, 5);
+      assert.equal(input.token, "glpat_x");
+      return { ok: true, active: true, reenabled: true };
+    },
+    log: () => {},
+  });
+  try {
+    await flush();
+    assert.equal(checked.length, 1, "the disabled gitlab hook is health-checked");
+  } finally {
+    poller.stop();
+  }
+});
+
+test("health-check loop skips non-gitlab hooks and hook-less / token-less records (BET-855)", async () => {
+  const checked = [];
+  const poller = startForgeHealthCheck({
+    intervalMs: 60_000,
+    listHooks: async () => [
+      { kind: "github", host: "github.com", owner: "acme", repo: "other", hookId: 1 },
+      { kind: "gitlab", host: "gitlab.com", owner: "acme", repo: "notokened", hookId: 2 },
+      { kind: "gitlab", host: "gitlab.com", owner: "acme", repo: "ok", hookId: 3 },
+    ],
+    // No token for gitlab.com → the "notokened" and "ok" records are skipped.
+    resolveToken: async () => null,
+    checkHook: async (input) => {
+      checked.push(input);
+      return { ok: true, active: true, reenabled: false };
+    },
+    log: () => {},
+  });
+  try {
+    await flush();
+    assert.equal(checked.length, 0, "no hook is health-checked without a forge token");
+  } finally {
+    poller.stop();
+  }
+});
+
+test("health-check loop checks every gitlab record for a host it has a token for (BET-855)", async () => {
+  const checked = [];
+  const poller = startForgeHealthCheck({
+    intervalMs: 60_000,
+    listHooks: async () => [
+      { kind: "github", host: "github.com", owner: "a", repo: "d", hookId: 3 },
+      { kind: "gitlab", host: "gitlab.com", owner: "a", repo: "b", hookId: 1 },
+      { kind: "gitlab", host: "gitlab.com", owner: "a", repo: "c", hookId: 2 },
+    ],
+    resolveToken: async (host) => (host === "gitlab.com" ? "t1" : null),
+    checkHook: async (input) => {
+      checked.push(input);
+      assert.equal(input.kind, "gitlab");
+      return { ok: true, active: true, reenabled: input.hookId === 2 };
+    },
+    log: () => {},
+  });
+  try {
+    await flush();
+    assert.deepEqual(
+      checked.map((c) => c.repo),
+      ["b", "c"],
+      "only gitlab records are checked; the github record is skipped",
+    );
+  } finally {
+    poller.stop();
+  }
+});
+
+test("health-check loop logs a per-hook failure and keeps going (BET-855)", async () => {
+  const checked = [];
+  const poller = startForgeHealthCheck({
+    intervalMs: 60_000,
+    listHooks: async () => [
+      { kind: "gitlab", host: "gitlab.com", owner: "a", repo: "bad", hookId: 1 },
+      { kind: "gitlab", host: "gitlab.com", owner: "a", repo: "good", hookId: 2 },
+    ],
+    resolveToken: async () => "t",
+    checkHook: async ({ repo }) => {
+      checked.push(repo);
+      return repo === "bad" ? { ok: false, error: "boom" } : { ok: true, active: true, reenabled: true };
+    },
+    log: () => {},
+  });
+  try {
+    await flush();
+    assert.deepEqual(checked, ["bad", "good"], "a failing hook does not stop the pass");
+  } finally {
+    poller.stop();
+  }
+});
+

--- a/src/server/forgeRules.mjs
+++ b/src/server/forgeRules.mjs
@@ -244,16 +244,19 @@ export async function saveRules(
       };
     } else {
       const key = repoKey(parts);
-      // Reuse the existing hook's delivery token so the URL stays stable across
-      // re-saves; otherwise mint a fresh capability token for this repo.
-      const existing = await findForgeHook(key);
-      const deliveryToken = existing?.token ?? genDeliveryToken();
       // Derive the forge kind (known host / user-configured forgeHosts mapping)
-      // so hook registration uses the right provider endpoint + auth, and so a
-      // GitLab repo never registers against the GitHub hooks endpoint.
+      // FIRST so hook registration uses the right provider endpoint + auth, and
+      // so a GitLab repo never registers against the GitHub hooks endpoint (nor
+      // reuses a GitHub hook's record in the store).
       const hostKinds = (await getConfig().catch(() => ({ forgeHosts: [] }))).forgeHosts ?? [];
       const forgeId = detectForgeWithHosts(`https://${parts.host}/${parts.owner}/${parts.repo}`, hostKinds);
       const kind = forgeId?.kind ?? "github";
+      // Reuse the existing hook's delivery token so the URL stays stable across
+      // re-saves; otherwise mint a fresh capability token for this repo. The
+      // lookup is provider-scoped so a GitLab repo read is distinct from a
+      // GitHub repo of the same owner/name.
+      const existing = await findForgeHook(key, { provider: kind });
+      const deliveryToken = existing?.token ?? genDeliveryToken();
       const res = await ensureHook({
         kind,
         host: parts.host,
@@ -267,11 +270,16 @@ export async function saveRules(
       if (!res.ok) {
         webhook = { registered: false, error: res.error };
       } else {
+        // Persist provider + the remote hookId the forge assigned, so the
+        // scheduled health check can target this exact hook to re-enable it
+        // (GitLab disables failing hooks; BET-855).
         await upsertForgeHook({
           repoKey: key,
+          provider: kind,
           label: key,
           token: deliveryToken,
           secret: res.secret,
+          hookId: res.hookId ?? null,
           events: eventsForRules(parsed.rules),
         });
         webhook = { registered: true, url: res.url };

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -93,6 +93,7 @@ import {
   deleteHook,
   createRateLimiter,
   findForgeHook,
+  listForgeHooks,
 } from "./webhooks.mjs";
 import { putRegistry as pluginsPutRegistry, getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import {
@@ -112,6 +113,7 @@ import { ensureCommentByTopic, pushSinkAction } from "./forge/sinks.mjs";
 import { parseRepoKey as forgeParseRepoKey } from "./forgeRules.mjs";
 import { getAdapter } from "./forge/index.mjs";
 import { resolveToken as forgeResolveToken } from "./forge/auth.mjs";
+import { startForgeHealthCheck, healthCheckRepoHook } from "./forge/webhook.mjs";
 import { parseRules as parseForgeRules } from "../shared/forgeRules.mjs";
 import { detectForge as detectForgeUrl } from "../shared/forge.mjs";
 import { sessionLink as readSessionLink } from "../shared/sessionLink.mjs";
@@ -528,6 +530,41 @@ const { stop: stopForgePoller } = createForgePoller({
   },
   handleEvent: (ev) => forgeRulesEngine.handleEvent(ev),
 });
+
+// The forge hook health check (BET-855) — the production caller for the
+// re-enable capability in forge/webhook.mjs. GitLab permanently disables a
+// failing webhook with no automatic recovery, so a periodic pass iterates the
+// persisted forge-hook store, resolves each GitLab host's token, and re-enables
+// (`PUT {active:true}`) any hook GitLab disabled. Same startPoller cadence as
+// the forge poller above; does nothing while the forge-rules toggle is off (no
+// gitlab hooks exist then anyway). Github hooks are skipped — GitHub never
+// auto-disables. 15 min: a box that sleeps at night falls a few checks behind
+// but re-arms promptly on wake, far below GitLab's permanent-disable threshold.
+const FORGE_HEALTH_INTERVAL_MS = 15 * 60_000;
+const { stop: stopForgeHealthCheck } = startForgeHealthCheck({
+  intervalMs: FORGE_HEALTH_INTERVAL_MS,
+  listHooks: async () => {
+    const cfg = await local.configGet();
+    if (cfg?.forgeRulesEnabled !== true) return [];
+    return (await listForgeHooks().catch(() => []))
+      .map((h) => {
+        const parts = forgeParseRepoKey(h.repoKey);
+        if (!parts) return null;
+        return {
+          kind: h.provider ?? "github",
+          host: parts.host,
+          owner: parts.owner,
+          repo: parts.repo,
+          hookId: h.hookId,
+        };
+      })
+      .filter(Boolean);
+  },
+  resolveToken: async (host) => ((await forgeResolveToken(host).catch(() => null))?.token) ?? null,
+  checkHook: healthCheckRepoHook,
+});
+// eslint-disable-next-line no-unused-vars
+void stopForgeHealthCheck;
 
 // Resolve a parent directory to branch a forge-triggered job's worktree off.
 // The parent-directory the session-link primitive names (spec §3.4⑥, BET-844):

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -541,6 +541,7 @@ const { stop: stopForgePoller } = createForgePoller({
 // auto-disables. 15 min: a box that sleeps at night falls a few checks behind
 // but re-arms promptly on wake, far below GitLab's permanent-disable threshold.
 const FORGE_HEALTH_INTERVAL_MS = 15 * 60_000;
+// eslint-disable-next-line no-unused-vars
 const { stop: stopForgeHealthCheck } = startForgeHealthCheck({
   intervalMs: FORGE_HEALTH_INTERVAL_MS,
   listHooks: async () => {
@@ -563,8 +564,6 @@ const { stop: stopForgeHealthCheck } = startForgeHealthCheck({
   resolveToken: async (host) => ((await forgeResolveToken(host).catch(() => null))?.token) ?? null,
   checkHook: healthCheckRepoHook,
 });
-// eslint-disable-next-line no-unused-vars
-void stopForgeHealthCheck;
 
 // Resolve a parent directory to branch a forge-triggered job's worktree off.
 // The parent-directory the session-link primitive names (spec §3.4⑥, BET-844):

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -105,6 +105,7 @@ import {
 import { createRulesEngine, eventLinkRef } from "./forge/rules.mjs";
 import {
   createForgePoller,
+  repoPollPlan,
   pollChecksFailed,
   pollIssueLabels,
   pollReviewRequested,
@@ -113,6 +114,7 @@ import { ensureCommentByTopic, pushSinkAction } from "./forge/sinks.mjs";
 import { parseRepoKey as forgeParseRepoKey } from "./forgeRules.mjs";
 import { getAdapter } from "./forge/index.mjs";
 import { resolveToken as forgeResolveToken } from "./forge/auth.mjs";
+import { detectForgeWithHosts } from "./forge/selfhost.mjs";
 import { startForgeHealthCheck, healthCheckRepoHook } from "./forge/webhook.mjs";
 import { parseRules as parseForgeRules } from "../shared/forgeRules.mjs";
 import { detectForge as detectForgeUrl } from "../shared/forge.mjs";
@@ -475,29 +477,29 @@ const { stop: stopForgePoller } = createForgePoller({
     const cfg = await local.configGet();
     if (cfg?.forgeRulesEnabled !== true) return [];
     const rows = await forgeListRules();
+    const hostKinds = cfg?.forgeHosts ?? [];
     const out = [];
     for (const row of rows) {
       if (!row.valid) continue; // invalid rules never dispatch (listed in Settings)
-      const parts = forgeParseRepoKey(row.repoKey);
-      if (!parts) continue;
-      const hook = await findForgeHook(row.repoKey).catch(() => null);
-      const rulesOn = parseForgeRules(row.yaml ?? "").rules?.on ?? {};
-      const labeled = rulesOn["issue.labeled"];
-      out.push({
-        repoKey: row.repoKey,
-        parts,
-        label: typeof labeled?.label === "string" ? labeled.label : null,
-        pollChecksFailed: !!rulesOn["checks.failed"],
-        pollReviewRequested: !!rulesOn["review.requested"],
-        webhookRegistered: !!hook, // never both: a working webhook wins
-      });
+      // Provider-aware poll plan (BET-855): a GitLab hook is stored under
+      // `provider: "gitlab"`, so webhookRegistered must be resolved with the
+      // repo's forge kind or the poller would poll a repo that has a working
+      // webhook — violating "never both: a working webhook wins".
+      const plan = await repoPollPlan(
+        { repoKey: row.repoKey, yaml: row.yaml ?? "", hostKinds, findHook: findForgeHook },
+        { parse: parseForgeRules },
+      );
+      if (!plan) continue;
+      out.push(plan);
     }
     return out;
   },
   pollRepo: async (repo) => {
     const tok = await forgeResolveToken(repo.parts.host).catch(() => null);
     if (!tok) return { events: [] };
-    const adapter = getAdapter("github", tok.token);
+    // Use the repo's forge kind, not a hardcoded github adapter — a GitLab repo
+    // on a box that cannot register webhooks is polled against the GitLab API.
+    const adapter = getAdapter(repo.kind ?? "github", tok.token);
     const prRepo = { owner: repo.parts.owner, repo: repo.parts.repo };
     let state = forgePollSeen.get(repo.repoKey);
     if (!state) {

--- a/src/server/webhooks.mjs
+++ b/src/server/webhooks.mjs
@@ -382,25 +382,30 @@ export function genDeliveryToken() {
 }
 
 // Create or refresh a forge (provider !== "manta") webhook record keyed by
-// repoKey. The token + secret are SUPPLIED here (unlike createHook, which mints
-// its own) because the GitHub hook URL and its HMAC secret are fixed up front
-// by the registration flow and MUST match the stored record. Reuses an
-// existing record for the same repo so re-save refreshes secret/events rather
-// than accumulating duplicate hooks. Returns the stored hook.
+// repoKey + provider. The token + secret are SUPPLIED here (unlike createHook,
+// which mints its own) because the forge hook URL and its HMAC secret are fixed
+// up front by the registration flow and MUST match the stored record. Reuses
+// an existing record for the same provider+repo so re-save refreshes
+// secret/events rather than accumulating duplicate hooks. `provider` defaults
+// to github (so pre-BET-855 callers are unchanged); `hookId` persists the
+// remote id the forge assigned — the handle the health check needs to target a
+// specific hook to re-enable it (GitLab disables failing hooks). Returns the
+// stored hook.
 export async function upsertForgeHook(
-  { repoKey, label, token, secret, events, now = () => Date.now() },
+  { repoKey, provider = "github", label, token, secret, hookId = null, events, now = () => Date.now() },
   { load = loadHooks, save = saveHooks } = {},
 ) {
   const hooks = await load();
-  const idx = hooks.findIndex((h) => h.provider === "github" && h.repoKey === repoKey);
+  const idx = hooks.findIndex((h) => h.provider === provider && h.repoKey === repoKey);
   const existing = idx >= 0 ? hooks[idx] : null;
   const url = deliveryUrl(token);
   const hook = {
     id: existing?.id ?? genId(),
     token,
     secret,
-    provider: "github",
+    provider,
     repoKey,
+    hookId: hookId ?? existing?.hookId ?? null,
     unsigned: false,
     label,
     instructions: "",
@@ -419,13 +424,23 @@ export async function upsertForgeHook(
   return hook;
 }
 
-// Read the full forge hook record (INCLUDING its secret) for a repoKey, or
-// null. Used by the registration flow to reuse an existing hook's token/secret
-// when re-saving rules for the same repo. `toMeta` never returns the secret;
+// Read the full forge hook record (INCLUDING its secret) for a repoKey +
+// provider, or null. Used by the registration flow to reuse an existing hook's
+// token/secret when re-saving rules for the same repo. `provider` defaults to
+// github so existing callers are unchanged. `toMeta` never returns the secret;
 // this is the box-side forge path only.
-export async function findForgeHook(repoKey, { load = loadHooks } = {}) {
+export async function findForgeHook(repoKey, { provider = "github", load = loadHooks } = {}) {
   const hooks = await load();
-  return hooks.find((h) => h.provider === "github" && h.repoKey === repoKey) ?? null;
+  return hooks.find((h) => h.provider === provider && h.repoKey === repoKey) ?? null;
+}
+
+// List the box's forge hook records (INCLUDING their remote hookId + secret).
+// The health-check pass (forge/webhook.mjs startForgeHealthCheck) iterates
+// these to re-enable disabled GitLab hooks. Box-side forge path only — never
+// the renderer (which gets metadata via listHooks/toMeta instead).
+export async function listForgeHooks({ providers = ["github", "gitlab"], load = loadHooks } = {}) {
+  const hooks = await load();
+  return hooks.filter((h) => providers.includes(h.provider));
 }
 
 export async function deleteHook(id, { load = loadHooks, save = saveHooks, publish } = {}) {

--- a/src/server/webhooks.test.mjs
+++ b/src/server/webhooks.test.mjs
@@ -16,6 +16,8 @@ import {
   deliveryUrl,
   createHook,
   upsertForgeHook,
+  findForgeHook,
+  listForgeHooks,
   listHooks,
   deleteHook,
   deliverWebhook,
@@ -239,6 +241,102 @@ test("upsertForgeHook persists a github hook and refreshes it on re-save", async
     assert.equal(second.events.length, 2);
     const all = await loadHooks(path);
     assert.equal(all.filter((h) => h.repoKey === "github.com/o/r").length, 1);
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
+test("upsertForgeHook persists a gitlab provider + the remote hookId (BET-855)", async () => {
+  const path = tmpStore();
+  const load = () => loadHooks(path);
+  const save = (h) => saveHooks(h, path);
+  try {
+    const hook = await upsertForgeHook(
+      {
+        repoKey: "gitlab.com/grp/r",
+        provider: "gitlab",
+        label: "gitlab.com/grp/r",
+        token: "b".repeat(32),
+        secret: "s1",
+        hookId: 42,
+        events: ["issues"],
+      },
+      { load, save },
+    );
+    assert.equal(hook.provider, "gitlab");
+    assert.equal(hook.hookId, 42, "the remote hookId is persisted for the health check");
+
+    // Same provider+repo refresh keeps the hookId even when not re-supplied.
+    const refreshed = await upsertForgeHook(
+      {
+        repoKey: "gitlab.com/grp/r",
+        provider: "gitlab",
+        label: "gitlab.com/grp/r",
+        token: "c".repeat(32),
+        secret: "s2",
+        events: ["issues"],
+      },
+      { load, save },
+    );
+    assert.equal(refreshed.hookId, 42, "re-save preserves the previously stored hookId");
+    const all = await loadHooks(path);
+    assert.equal(all.filter((h) => h.provider === "gitlab" && h.repoKey === "gitlab.com/grp/r").length, 1);
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
+test("findForgeHook is provider-scoped — a gitlab repo does not collide with a github one (BET-855)", async () => {
+  const path = tmpStore();
+  const load = () => loadHooks(path);
+  const save = (h) => saveHooks(h, path);
+  try {
+    // Same owner/repo under different providers — distinct records.
+    await upsertForgeHook(
+      { repoKey: "x.com/o/r", provider: "github", label: "g", token: "a".repeat(32), secret: "s", events: [] },
+      { load, save },
+    );
+    await upsertForgeHook(
+      { repoKey: "x.com/o/r", provider: "gitlab", label: "l", token: "b".repeat(32), secret: "t", hookId: 7, events: [] },
+      { load, save },
+    );
+    const githubHook = await findForgeHook("x.com/o/r", { provider: "github", load });
+    const gitlabHook = await findForgeHook("x.com/o/r", { provider: "gitlab", load });
+    assert.notEqual(githubHook, null);
+    assert.notEqual(gitlabHook, null);
+    assert.equal(githubHook.secret, "s");
+    assert.equal(gitlabHook.secret, "t");
+    assert.equal(gitlabHook.hookId, 7);
+    assert.equal(githubHook.hookId, null);
+    // Legacy callers (no provider arg) default to github — unchanged.
+    assert.equal((await findForgeHook("x.com/o/r", { load })).secret, "s");
+  } finally {
+    await rm(path, { force: true });
+  }
+});
+
+test("listForgeHooks returns only forge records with their hookId (BET-855)", async () => {
+  const path = tmpStore();
+  const load = () => loadHooks(path);
+  const save = (h) => saveHooks(h, path);
+  try {
+    await createHook(
+      { label: "manta hook", sessionID: "ses_1" },
+      { load, save },
+    );
+    await upsertForgeHook(
+      { repoKey: "g.com/o/r", provider: "github", label: "g", token: "a".repeat(32), secret: "s", events: [] },
+      { load, save },
+    );
+    await upsertForgeHook(
+      { repoKey: "gitlab.com/o/r", provider: "gitlab", label: "l", token: "b".repeat(32), secret: "t", hookId: 3, events: [] },
+      { load, save },
+    );
+    const all = await listForgeHooks({ load });
+    assert.equal(all.length, 2);
+    assert.ok(all.every((h) => h.provider !== "manta"), "manta hooks are excluded");
+    const gl = all.find((h) => h.provider === "gitlab");
+    assert.equal(gl.hookId, 3);
   } finally {
     await rm(path, { force: true });
   }


### PR DESCRIPTION
## BET-855 — provider+hookId forge-hook store and the GitLab health-check loop

The GitLab disabled-hook re-enable capability (`healthCheckRepoHook`) now has a **production caller**, and the box-side forge-hook store can drive it (the BET-799 Reviewer Question, deferred to this issue).

**Rebased onto `main`** (BET-799 / #843 is merged) — this PR is the clean, conflict-free BET-855 delta. Supersedes (now-closed) #852.

### What changed
1. **`webhooks.mjs`** — `upsertForgeHook` keys on `provider + repoKey` (default `github`, existing callers unchanged) and persists the remote `hookId`; `findForgeHook` is provider-scoped; new `listForgeHooks()` feeds the health check.
2. **`forgeRules.mjs`** — derives the forge kind before the store lookup and persists `provider` + `hookId` on registration.
3. **`forge/webhook.mjs`** — `startForgeHealthCheck`, a `startPoller` loop (same shape as `forge/poller.mjs`) that iterates GitLab hook records, resolves the host token, and re-arms any hook GitLab disabled. All I/O injected; a failing hook is logged and skipped.
4. **`index.mjs`** — loop wired on boot (15-min cadence, gated on `forgeRulesEnabled`).
5. **`forge/poller.mjs`** — `repoPollPlan` (pure, tested): the poller's `webhookRegistered` detection and poll adapter are now provider-aware (review Block fix).

### Verification
- `npm run typecheck` ✅
- `npm test` ✅ — 1952 pass, 0 fail
- Required check `typecheck-test` running green on this head.

Reviewer passed the BET-855 content (0 Blocks, 0 Questions). Ready for merge by `manta-pm`.
