### PR TITLE
feat(renderer): empty-state suggestion chips in the composer (BET-815)

### DIFF
--- a/src/renderer/InputArea.test.tsx
+++ b/src/renderer/InputArea.test.tsx
@@ -12,8 +12,113 @@
 // that keeps the real controls clickable — the half that is easy to get
 // wrong, since a too-broad rule would swallow the Send button's click.
 
-import { describe, it, expect } from "vitest";
-import { isComposerControlTarget } from "./InputArea";
+import { describe, it, expect, vi } from "vitest";
+import { act } from "react";
+import { isComposerControlTarget, InputArea } from "./InputArea";
+import { mount } from "./testHarness";
+
+// A full InputArea has ~40 props, nearly all inert scaffolding for any given
+// assertion. `makeProps` supplies the quiet default (empty input, no running
+// turn, no voice, no typeahead); a test overrides only what its assertion is
+// about. Mirrors the SessionHeader mount helper's overrides pattern.
+function makeProps(over: Partial<Parameters<typeof InputArea>[0]> = {}) {
+  const setInput = vi.fn();
+  const submit = vi.fn();
+  const props = {
+    input: "",
+    setInput,
+    inputRef: { current: null as HTMLTextAreaElement | null },
+    submit,
+    abort: vi.fn(),
+    running: false,
+    refreshing: false,
+    attachments: [],
+    onRemoveAttachment: vi.fn(),
+    onAttachFiles: vi.fn(),
+    pendingScreenshots: [],
+    onAcceptScreenshots: vi.fn(),
+    onDiscardScreenshot: vi.fn(),
+    modelLabel: null,
+    chatAutoAllow: false,
+    setChatAutoAllow: vi.fn(),
+    voice: {
+      voiceEnabled: false,
+      voiceRecording: false,
+      voiceProcessing: false,
+      voiceAnnouncement: "",
+      voiceRecorder: {
+        phase: "idle" as const,
+        elapsedMs: 0,
+        nearLimit: false,
+        lastError: null,
+        liveWindowRef: { current: null as Float32Array | null },
+        start: vi.fn(),
+        pause: vi.fn(),
+        resume: vi.fn(),
+        send: vi.fn(),
+        stop: vi.fn(),
+        requestDiscard: vi.fn(),
+        cancel: vi.fn(),
+        discardArmed: false,
+      },
+    },
+    models: null,
+    modelOverride: null,
+    defaultModel: null,
+    activeProviderID: null,
+    deactivatedMainModels: [],
+    onOpenModels: vi.fn(),
+    onSelectModel: vi.fn(),
+    scheduleCount: 0,
+    onSchedules: vi.fn(),
+    onSecrets: vi.fn(),
+    onWebhooks: vi.fn(),
+    typeaheadOpen: false,
+    typeaheadExactMatch: false,
+    onTypeaheadConfirm: vi.fn(),
+    onTypeaheadMove: vi.fn(),
+    onTypeaheadCancel: vi.fn(),
+    onHistoryUp: vi.fn(),
+    onHistoryDown: vi.fn(),
+    onQueuePop: vi.fn(),
+    onPaste: vi.fn(),
+    ...over,
+  };
+  return props;
+}
+
+// Empty-state suggestion chips (manta-forge S9): shown while the composer is
+// empty, and each chip FILLS the input (setInput) without submitting.
+describe("InputArea suggestion chips", () => {
+  it("renders the suggestion chips while the composer is empty", () => {
+    const h = mount(<InputArea {...makeProps()} />);
+    expect(h.text()).toContain("Explain this codebase");
+    expect(h.text()).toContain("What's the test setup?");
+    h.unmount();
+  });
+
+  it("hides the suggestion chips once the composer has text", () => {
+    const h = mount(<InputArea {...makeProps({ input: "hello" })} />);
+    expect(h.text()).not.toContain("Explain this codebase");
+    expect(h.text()).not.toContain("What's the test setup?");
+    h.unmount();
+  });
+
+  it("fills the input on click without submitting (chips never auto-send)", () => {
+    const setInput = vi.fn();
+    const submit = vi.fn();
+    const h = mount(<InputArea {...makeProps({ setInput, submit })} />);
+    const buttons = h.container.querySelectorAll("button");
+    const chip = Array.from(buttons).find((b) =>
+      b.textContent?.includes("Explain this codebase"),
+    );
+    expect(chip).toBeTruthy();
+    act(() => chip!.click());
+    expect(setInput).toHaveBeenCalledWith("Explain this codebase");
+    expect(submit).not.toHaveBeenCalled();
+    h.unmount();
+  });
+});
 
 /** Build a detached composer-box-shaped tree and hand back its parts. */
 function box() {

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -51,6 +51,13 @@ export { TypeaheadPopup } from "./ComposerParts";
 // AttachmentStrip is no longer re-exported — it is now rendered INSIDE the
 // composer box (BET-416 §B), so Composer no longer imports it.
 
+// Empty-state suggestion chips (manta-forge S9). Shown only while the composer
+// is empty; each chip FILLS the input (setInput) — it never auto-submits, so a
+// stray click can't spend a turn without consent. The spec's fresh-box variant
+// seeds "Set up this box for development — install dependencies and check the
+// tests run." as well; the default set below matches the landed mockup.
+const SUGGESTION_CHIPS = ["Explain this codebase", "What's the test setup?"] as const;
+
 // Measure the caret's VISUAL row within a textarea, accounting for soft wrap.
 // Render a hidden mirror <div> that copies the textarea's box + text styling,
 // place a marker span at the caret offset, and compare the marker's top against
@@ -486,6 +493,32 @@ export function InputArea({
           )}
         </button>
         </div>
+        )}
+        {/* Empty-state suggestion chips (manta-forge S9). A chip only FILLS the
+            input (setInput) — it never sends — so clicking one is always
+            recoverable. Hidden the moment the field has any text, a take is
+            recording, or a turn is running (the running state already shows
+            "Queue a message…"). */}
+        {!input.trim() && !takeActive && !running && (
+          <div className="flex flex-wrap items-center gap-2">
+            {SUGGESTION_CHIPS.map((label) => (
+              <button
+                key={label}
+                type="button"
+                onClick={() => {
+                  setInput(label);
+                  inputRef.current?.focus();
+                }}
+                className={
+                  "inline-flex items-center rounded-md border border-border-subtle " +
+                  "bg-bg-soft px-3 py-[5px] text-[12px] leading-none text-text-muted " +
+                  "transition-colors hover:border-border-strong hover:text-text"
+                }
+              >
+                {label}
+              </button>
+            ))}
+          </div>
         )}
       </div>
       {/* Meta footer — model ▸ effort split on the left, resource toolbar +


### PR DESCRIPTION
## BET-815 — Chat composer: empty-state suggestion chips (fill, don't send)

### What

Implements manta-forge [S9]'s suggestion chips in the **real composer**'s empty
state. When the composer has no text, two chips render below the input row
inside the composer box: **"Explain this codebase"** and **"What's the test
setup?"** (the S9 landed-mockup defaults). Clicking a chip **fills the input**
(`setInput`) and focuses the field — it never submits, so a stray click can't
spend a turn without consent.

Hidden the moment the composer has any text, a voice take is active, or a turn
is running (the running state already shows "Queue a message…").

### Scope guard

Placeholder only as scoped in the issue — the chips are wired into the
**ChatPanel composer** (`InputArea`, which the `Composer` already assembles and
ChatPanel already drives with `input`/`setInput`). **Not** part of
`NewSessionScreen`; that screen is untouched. No new props were added — the
composer already receives `input`, `setInput`, `inputRef`, `running`, so the
change is local to `InputArea.tsx`.

### Files changed

- `src/renderer/InputArea.tsx` — `SUGGESTION_CHIPS` constant + the empty-state
  chip row (33 insertions)
- `src/renderer/InputArea.test.tsx` — 3 new render tests: chips show when
  empty, hide when there's text, and clicking fills input without calling
  `submit` (a `makeProps` harness mirroring the SessionHeader overrides
  pattern)

### Verification results

**Files changed:** `2` files.

- **PR branch** (`multica/BET-815-suggestion-chips` @ `a4da2d06`):
  - typecheck: exit 0, errors none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0. Renderer 2605 pass / 0 fail / 7 skip (Test Files 136). Server node:test 0 fail. log sha256: `18f9415f530ecbffa02f5d42ba492542f9bc11b77dbb2591090e82e7d016a8b1`
- **Base** (`main` @ `bc94be7e`):
  - typecheck: exit 0, errors none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, 0 failures. log sha256: `3793a02056bc5ffcd105523940a9a7709db80bcd625e98b5a86b4324aa3ebc19`
- **Conclusion:** 0 new failures; all tests green on both branches.

**Base: `origin/main` @ `bc94be7e`** (rebased onto current main; three-dot diff
is exactly the two files above).

### Self-check (acceptance criteria)

- **Chips appear in the ChatPanel composer's empty input** → 10/10. Rendered
  inside the composer box; verified by render test + full suite.
- **Chips only FILL the input, never send** → 10/10. `onClick` calls
  `setInput(label)` and focuses; `submit` is never invoked from a chip (pinned
  by test).
- **Placeholder only — NOT part of NewSessionScreen** → 10/10. Only
  `InputArea.tsx`/`InputArea.test.tsx` touched; NewSessionScreen untouched.

No actionable follow-ups surfaced.
