### PR TITLE
feat(forge): open inbox PR in the in-app review pane (BET-850)

### DIFF
--- a/src/renderer/InboxPalette.tsx
+++ b/src/renderer/InboxPalette.tsx
@@ -19,13 +19,14 @@
 // path but auto-submits (the agent starts working immediately).
 
 import { useEffect, useMemo, useState } from "react";
-import { CornerDownLeft } from "lucide-react";
+import { CornerDownLeft, X } from "lucide-react";
 import { PaletteShell } from "./PaletteShell";
 import { ListRow } from "./ListRow";
 import { StatusDot } from "./StatusDot";
 import { Chip } from "./Chip";
 import { Button } from "./Button";
 import { Pill } from "./Pill";
+import { ReviewPane } from "./ReviewPane";
 import { useStore } from "./store";
 import { formatAge, inboxReasonLabel, sortInbox } from "./chatUtils";
 import { deriveProjectName, uniqueSessionName } from "./NewSessionScreen";
@@ -92,6 +93,11 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [repos, setRepos] = useState<Record<string, string>>({}); // repoKey -> local path
   const [error, setError] = useState<string | null>(null);
+
+  // BET-850: the inbox PR currently open in the in-app review pane (null =
+  // no review open, showing the inbox list). Addressed by { repoKey, number }
+  // — a cross-repo PR the box may not have cloned — NOT the session's cwd.
+  const [reviewItem, setReviewItem] = useState<ForgeInboxItem | null>(null);
 
   // One fetch on open — never polled while closed (§ Hygiene).
   useEffect(() => {
@@ -231,13 +237,67 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
   };
 
   const startSession = (item: ForgeInboxItem) => void createSessionFromItem(item);
+  // BET-850: "Open review" opens the in-app review pane (ReviewPane) for the
+  // inbox PR — addressed explicitly by { repoKey, number }, so a cross-repo PR
+  // from outside the session (possibly a repo the box has not cloned) renders
+  // its diff + comment gutter + box-buffered draft review, not the browser.
   const openReview = (item: ForgeInboxItem) => {
-    if (item.url) void window.api.openExternal(item.url);
+    if (item.kind !== "pr") {
+      setError("Open review is for pull requests.");
+      return;
+    }
+    setError(null);
+    setReviewItem(item);
   };
 
   const selected = rows[sel] ?? null;
 
+  // The stable { repoKey, number } the review pane addresses. Memoized on the
+  // item so the pane's fetch effect keyed on `target` does not re-run on every
+  // InboxPalette re-render (the inline object would otherwise be new each time).
+  const reviewTarget = useMemo(
+    () => (reviewItem ? { repoKey: reviewItem.repoKey, number: reviewItem.number } : null),
+    [reviewItem],
+  );
+
+  // The in-app review overlay that "Open review" mounts on top of the inbox.
+  // A full-surface sheet (above the z-50 palette) hosting the shared
+  // ReviewPane, addressed by the inbox PR's { repoKey, number }. No session —
+  // "Send to agent" is hidden; the box-buffered draft review + comment gutter
+  // still work against the cross-repo forge read.
+  const reviewOverlay = reviewItem ? (
+    <div
+      className="fixed inset-0 z-[60] flex flex-col bg-bg"
+      onKeyDown={(e) => {
+        if (e.key === "Escape") {
+          e.stopPropagation();
+          setReviewItem(null);
+        }
+      }}
+    >
+      <div className="flex items-center gap-3 border-b border-border-subtle px-4 py-3">
+        <span className="font-mono text-meta text-text-faint">{`!${reviewItem.number}`}</span>
+        <span className="min-w-0 flex-1 truncate text-label font-semibold text-text">
+          {reviewItem.title}
+        </span>
+        <button
+          type="button"
+          onClick={() => setReviewItem(null)}
+          title="Back to inbox (Esc)"
+          aria-label="Back to inbox"
+          className="inline-flex items-center gap-1 rounded-sm border border-border-subtle px-2 py-1 text-meta text-text-faint hover:text-text"
+        >
+          <X size={13} aria-hidden="true" /> Back to inbox
+        </button>
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        <ReviewPane target={reviewTarget ?? undefined} />
+      </div>
+    </div>
+  ) : null;
+
   return (
+    <>
     <PaletteShell
       label="Inbox"
       placeholder="Filter inbox…"
@@ -342,5 +402,7 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
         );
       }}
     </PaletteShell>
+    {reviewOverlay}
+    </>
   );
 }

--- a/src/renderer/ReviewPane.tsx
+++ b/src/renderer/ReviewPane.tsx
@@ -88,7 +88,23 @@ function NoteInline({
   );
 }
 
-export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string }) {
+export function ReviewPane({
+  sessionId,
+  cwd,
+  target,
+}: {
+  sessionId?: string;
+  cwd?: string;
+  // BET-850: an explicit cross-repo inbox PR. When present, the pane addresses
+  // the forge by { repoKey, number } instead of resolving the session's cwd →
+  // origin → open PR (the inbox row may live in a repo the box has not cloned).
+  target?: { repoKey: string; number: number };
+}) {
+  // The forge read/write ref: the explicit inbox target wins; otherwise the
+  // session's cwd (resolved box-side). "Send to agent" needs a live session,
+  // so it is gated on a non-empty sessionId (hidden for a standalone review).
+  const ref = target ?? { cwd: cwd ?? "" };
+  const canSend = Boolean(sessionId);
   const [diff, setDiff] = useState<string>("");
   const [threads, setThreads] = useState<ForgeThread[]>([]);
   const [error, setError] = useState<"no_forge" | "not_connected" | "no_pr" | null>(null);
@@ -107,10 +123,12 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
   const sentRef = useRef<Set<string>>(new Set());
   const [, forceRender] = useState(0);
 
-  // Fetch the PR diff + the box-owned draft for the session's cwd. Re-runs
-  // when the cwd changes (session switch). No interval — refetch on reopen.
+  // Fetch the PR diff + the box-owned draft for the forge ref (the session's
+  // cwd, or an explicit inbox target). Re-runs when the ref changes. No
+  // interval — refetch on reopen.
   useEffect(() => {
-    if (!cwd) {
+    const refKey = target ? `${target.repoKey}#${target.number}` : cwd;
+    if (!refKey) {
       setLoading(false);
       setError("no_forge");
       return;
@@ -123,7 +141,7 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
     sentRef.current = new Set();
 
     window.api
-      .forgeDiff({ cwd })
+      .forgeDiff(ref)
       .then((res) => {
         if (cancelled) return;
         setDiff(res.diff ?? "");
@@ -138,7 +156,7 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
       });
 
     window.api
-      .forgeDraftGet({ cwd })
+      .forgeDraftGet(ref)
       .then((res) => {
         if (cancelled) return;
         if (res.draft) setDraft(res.draft);
@@ -150,7 +168,7 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
     return () => {
       cancelled = true;
     };
-  }, [cwd, sessionId]);
+  }, [cwd, target, sessionId]);
 
   // ---- Composer / draft mutations (all box-side) --------------------------
 
@@ -159,14 +177,14 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
     const body = draftText.trim();
     if (!body) return;
     const res = await window.api.forgeDraftComment({
-      cwd,
+      ...ref,
       op: "add",
       comment: { path: composing.path, line: composing.line, side: composing.side, body },
     });
     if (res.ok) setDraft(res.draft);
     setComposing(null);
     setDraftText("");
-  }, [cwd, composing, draftText]);
+  }, [target, cwd, composing, draftText]);
 
   const sendToAgent = useCallback(
     (text: string, commentId?: string) => {
@@ -185,25 +203,25 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
 
   const removeComment = useCallback(
     async (commentId: string) => {
-      const res = await window.api.forgeDraftComment({ cwd, op: "delete", comment: { id: commentId } });
+      const res = await window.api.forgeDraftComment({ ...ref, op: "delete", comment: { id: commentId } });
       if (res.ok) setDraft(res.draft);
     },
-    [cwd],
+    [target, cwd],
   );
 
   const setVerdict = useCallback(
     async (verdict: ForgeDraft["verdict"]) => {
-      const res = await window.api.forgeDraftComment({ cwd, op: "set-verdict", verdict });
+      const res = await window.api.forgeDraftComment({ ...ref, op: "set-verdict", verdict });
       if (res.ok) setDraft(res.draft);
     },
-    [cwd],
+    [target, cwd],
   );
 
   const submit = useCallback(async () => {
     if (!draft || draft.comments.length === 0 || submitting) return;
     setSubmitting(true);
     try {
-      const res = await window.api.forgeDraftSubmit({ cwd, verdict: draft.verdict ?? undefined });
+      const res = await window.api.forgeDraftSubmit({ ...ref, verdict: draft.verdict ?? undefined });
       if (res.ok) {
         setDraft(null);
         sentRef.current = new Set();
@@ -213,7 +231,7 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
     } finally {
       setSubmitting(false);
     }
-  }, [cwd, draft, submitting]);
+  }, [target, cwd, draft, submitting]);
 
   const { label, plus, minus } = useMemo(() => diffHeader(diff), [diff]);
 
@@ -274,7 +292,7 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
             body={c.body}
             action={
               <>
-                {sent ? null : (
+                {sent ? null : canSend && (
                   <Chip on onClick={() => sendToAgent(c.body, c.id)}>
                     Send to agent
                   </Chip>
@@ -319,9 +337,11 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
               className="w-full resize-none rounded-xs border border-border-strong bg-bg px-2 py-1 font-mono text-meta text-text outline-none placeholder:text-text-faint focus:border-accent"
             />
             <div className="mt-2 flex items-center gap-[6px]">
-              <Chip on onClick={() => sendToAgent(draftText)}>
-                Send to agent
-              </Chip>
+              {canSend && (
+                <Chip on onClick={() => sendToAgent(draftText)}>
+                  Send to agent
+                </Chip>
+              )}
               <Button tone="default" onClick={addToReview}>
                 Add to review
               </Button>
@@ -341,7 +361,7 @@ export function ReviewPane({ sessionId, cwd }: { sessionId: string; cwd: string 
     }
 
     return out;
-  }, [threads, draft, composing, draftText, addToReview, sendToAgent, removeComment]);
+  }, [threads, draft, composing, draftText, addToReview, sendToAgent, removeComment, canSend]);
 
   const draftCount = draft?.comments.length ?? 0;
 

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -27,7 +27,7 @@
 // cwd → origin → repo server-side, keeping the renderer ignorant of forge
 // identity).
 
-import { rollupChecks, unsupportedByForge, repoKey as forgeRepoKey } from "../../shared/forge.mjs";
+import { rollupChecks, unsupportedByForge, repoKey as forgeRepoKey, repoKeyParts } from "../../shared/forge.mjs";
 import { run } from "../tmux.mjs";
 import { gitRemoteOrigin as localGitRemoteOrigin, detectForgeCli as localDetectForgeCli, gitPush as localGitPush, configGet as localConfigGet } from "../local.mjs";
 import { detectForgeWithHosts } from "./selfhost.mjs";
@@ -511,6 +511,66 @@ async function resolveForgeContext(cwd, deps) {
   return { forge, repo, token: tok, adapter };
 }
 
+// Resolve the forge identity a diff/draft read addresses. A `ref` is either
+// the session's `cwd` (resolve cwd → origin → repo, as before) OR an explicit
+// cross-repo inbox target `{ repoKey, number }` (no cwd to resolve — the row
+// carries only host/owner/repo + the PR number, BET-850). Returns the same
+// `{ forge, repo, adapter }` context as resolveForgeContext plus a canonical
+// `repoKey`, or `{ error: "no_forge" | "not_connected" }`.
+//
+// The explicit branch does NOT call git at all — a cross-repo PR may live in a
+// repo the box has not cloned, so the read must get to the forge over the API
+// alone, keyed by the inbox row's host/owner/repo + number.
+async function resolveRefContext(ref, deps) {
+  const resolveToken = deps.resolveToken ?? authResolveToken;
+  const getAdapterFn = deps.getAdapter ?? getAdapter;
+
+  if (typeof ref === "object" && ref !== null && ref.repoKey) {
+    const target = repoKeyParts(ref.repoKey);
+    if (!target) return { error: "no_forge" };
+    const tok = await resolveToken(target.host);
+    if (!tok) return { error: "not_connected" };
+    return {
+      forge: { kind: target.kind, host: target.host, owner: target.owner, repo: target.repo },
+      repo: { owner: target.owner, repo: target.repo },
+      adapter: getAdapterFn(target.kind, tok.token),
+      repoKey: forgeRepoKey({ host: target.host, owner: target.owner, repo: target.repo }),
+      cwd: null,
+      error: null,
+    };
+  }
+
+  const cwd = typeof ref === "string" ? ref : ref?.cwd;
+  const ctx = await resolveForgeContext(cwd, deps);
+  if (ctx.error) return { error: ctx.error };
+  return {
+    ...ctx,
+    cwd,
+    repoKey: forgeRepoKey({ host: ctx.forge.host, owner: ctx.forge.owner, repo: ctx.forge.repo }),
+  };
+}
+
+// Pick the PR number a diff/draft read targets. An explicit `{ repoKey, number }`
+// ref wins outright (a cross-repo inbox PR — never derived from a branch). A
+// cwd ref picks the open PR on the current branch, falling back to the first
+// open PR, exactly as before. Returns `{ number, stale }` or `{ error: "no_pr" }`
+// / `{ rateLimited: true }`.
+async function resolveRefNumber(ref, ctx, deps) {
+  if (typeof ref === "object" && ref !== null && ref.repoKey) {
+    const number = Number(ref.number);
+    if (!Number.isInteger(number) || number <= 0) return { error: "no_pr" };
+    return { number, stale: false };
+  }
+  const { prs, stale, rateLimited } = await listOpenPrs(ctx.adapter, ctx.repo);
+  if (rateLimited) return { rateLimited: true };
+  if (prs.length === 0) return { error: "no_pr" };
+  const currentBranch = deps.currentBranch ?? defaultCurrentBranch;
+  const branch = await currentBranch(ctx.cwd);
+  let candidate = branch ? prs.find((p) => p.headRef === branch) : undefined;
+  if (!candidate) candidate = prs[0];
+  return { number: candidate.number, stale };
+}
+
 // List a repo's open PRs the way both cwd-scoped readers do, normalising the
 // rate-limit guard once. A rate-limited list is not an error — it yields an
 // empty list flagged `rateLimited` so the caller can serve a stale result
@@ -906,42 +966,37 @@ export async function mergePullRequest(cwd, { number, method = "merge", sha } = 
 // ---- Adapter interface (the seam a second adapter implements) ------------------
 
 /**
- * forge:diff — the review pane's read. Resolve `cwd → origin → repo`, pick the
- * open PR on the current branch (falling back to the first open PR) exactly as
- * `pullRequestForCwd` does, then fetch its raw unified diff + normalised
- * incoming threads + head SHA. Returns `{ diff, threads, headSha, error }` —
- * never throws for a repo with no forge ("no_forge"), no token
- * ("not_connected") or no open PR ("no_pr").
+ * forge:diff — the review pane's read. A `ref` is either a session `cwd`
+ * (resolve cwd → origin → repo, then pick the open PR on the current branch,
+ * falling back to the first open PR) OR an explicit cross-repo target
+ * `{ repoKey, number }` for an inbox PR row (no git — the read addresses the
+ * forge over the API directly, BET-850). Fetches the PR's raw unified diff +
+ * normalised incoming threads + head SHA. Returns `{ diff, threads, headSha,
+ * error }` — never throws for a repo with no forge ("no_forge"), no token
+ * ("not_connected") or no PR ("no_pr").
  *
- * @param {string} cwd
+ * @param {string | { cwd?: string } | { repoKey: string, number: number }} ref
  * @param {{ gitRemoteOrigin?: (cwd: string) => Promise<string|null>,
  *          currentBranch?: (cwd: string) => Promise<string|null>,
  *          resolveToken?: typeof authResolveToken,
  *          getAdapter?: (kind: string, token: string) => any }} [deps]
  */
-export async function forgeDiffForCwd(cwd, deps = {}) {
-  const currentBranch = deps.currentBranch ?? defaultCurrentBranch;
-
-  const ctx = await resolveForgeContext(cwd, deps);
+export async function forgeDiffForCwd(ref, deps = {}) {
+  const ctx = await resolveRefContext(ref, deps);
   if (ctx.error) return { diff: "", threads: [], headSha: "", error: ctx.error };
   const { adapter, repo } = ctx;
 
-  const { prs: prArr, stale, rateLimited } = await listOpenPrs(adapter, repo);
-  if (rateLimited) return { diff: "", threads: [], headSha: "", error: null, stale: true };
-
-  if (prArr.length === 0) return { diff: "", threads: [], headSha: "", error: "no_pr" };
-
-  const branch = await currentBranch(cwd);
-  let candidate = branch ? prArr.find((p) => p.headRef === branch) : undefined;
-  if (!candidate) candidate = prArr[0];
+  const target = await resolveRefNumber(ref, ctx, deps);
+  if (target.rateLimited) return { diff: "", threads: [], headSha: "", error: null, stale: true };
+  if (target.error) return { diff: "", threads: [], headSha: "", error: target.error };
 
   try {
-    const res = await adapter.getDiff(repo, candidate.number);
+    const res = await adapter.getDiff(repo, target.number);
     return {
       diff: res.data.diff ?? "",
       threads: Array.isArray(res.data.threads) ? res.data.threads : [],
       headSha: res.data.headSha ?? "",
-      stale: stale || Boolean(res.stale),
+      stale: target.stale || Boolean(res.stale),
       error: null,
     };
   } catch (err) {
@@ -964,47 +1019,40 @@ export async function forgeDiffForCwd(cwd, deps = {}) {
 
 // Resolve the box-side context a draft op needs: the forge identity, the
 // adapter, the target PR number and its current head SHA, plus the canonical
-// repoKey the draft store uses. Returns `{ error }` for no_forge /
+// repoKey the draft store uses. `ref` is either a session `cwd` (the
+// cwd → origin → forge → token → adapter preamble) or an explicit cross-repo
+// `{ repoKey, number }` inbox target (BET-850 — the draft ops must hit the
+// SAME PR the diff pane shows when it is opened from the inbox, which may be a
+// repo the box has not cloned). Returns `{ error }` for no_forge /
 // not_connected / no_pr; otherwise the full context.
-//
-// Built on the SHARED resolveWriteContext (the cwd → origin → forge → token →
-// adapter preamble) rather than a parallel copy — the draft variant only adds
-// the PR-number + head-SHA resolution on top of what that resolver already
-// returns. One code path (issue §Hygiene).
-async function resolveDraftContext(cwd, deps) {
-  const base = await resolveWriteContext(cwd, deps, false);
-  if (base.error) return { error: base.error };
+async function resolveDraftContext(ref, deps) {
+  const ctx = await resolveRefContext(ref, deps);
+  if (ctx.error) return { error: ctx.error };
+  const { adapter, repo } = ctx;
 
-  const currentBranch = deps.currentBranch ?? defaultCurrentBranch;
-  const adapter = base.adapter;
-  const repo = base.repo;
-
-  const res = await adapter.listPullRequests(repo, { state: "open" });
-  const prArr = Array.isArray(res.data) ? res.data : [];
-  if (prArr.length === 0) return { error: "no_pr" };
-
-  const branch = await currentBranch(cwd);
-  const branchPr = branch ? prArr.find((p) => p.headRef === branch) : undefined;
-  const number = branchPr?.number ?? prArr[0].number;
+  const target = await resolveRefNumber(ref, ctx, deps);
+  if (target.rateLimited) return { error: "no_pr" };
+  if (target.error) return { error: target.error };
+  const number = target.number;
 
   // The head SHA the diff was anchored at. getPullRequest is the authoritative
-  // source; a failure (stale/counting) falls back to the list entry's SHA so
-  // the context still resolves and the reconciler degrades gracefully.
-  let headSha = prArr.find((p) => p.number === number)?.headSha ?? "";
+  // source; a failure (stale/counting) degrades to "" so the context still
+  // resolves and the reconciler degrades gracefully.
+  let headSha = "";
   try {
     const full = await adapter.getPullRequest(repo, number);
     if (full?.data?.headSha) headSha = full.data.headSha;
   } catch {
-    /* fall back to the list's headSha */
+    /* fall back to "" */
   }
 
   return {
-    forge: base.forge,
+    forge: ctx.forge,
     repo,
     adapter,
     number,
     headSha,
-    repoKey: forgeRepoKey({ host: base.forge.host, owner: base.forge.owner, repo: base.forge.repo }),
+    repoKey: ctx.repoKey,
   };
 }
 
@@ -1017,8 +1065,8 @@ async function resolveDraftContext(cwd, deps) {
  * @param {object} [deps] injectable I/O
  * @returns {Promise<{ draft: object | null, error: "no_forge"|"not_connected"|"no_pr"|null }>}
  */
-export async function draftGetForCwd(cwd, deps = {}) {
-  const ctx = await resolveDraftContext(cwd, deps);
+export async function draftGetForCwd(ref, deps = {}) {
+  const ctx = await resolveDraftContext(ref, deps);
   if (ctx.error) return { draft: null, error: ctx.error };
   let draft = await storeGetDraft(ctx.repoKey, ctx.number, deps);
   if (draft && draft.headSha && ctx.headSha && draft.headSha !== ctx.headSha) {
@@ -1037,8 +1085,8 @@ export async function draftGetForCwd(cwd, deps = {}) {
  * @param {object} [deps] injectable I/O
  * @returns {Promise<{ ok: true, draft: object } | { ok: false, error: string }>}
  */
-export async function draftCommentForCwd(cwd, input = {}, deps = {}) {
-  const ctx = await resolveDraftContext(cwd, deps);
+export async function draftCommentForCwd(ref, input = {}, deps = {}) {
+  const ctx = await resolveDraftContext(ref, deps);
   if (ctx.error) return { ok: false, error: ctx.error };
   const { op, comment, verdict, body } = input;
   switch (op) {
@@ -1070,8 +1118,8 @@ export async function draftCommentForCwd(cwd, input = {}, deps = {}) {
  * @param {object} [deps] injectable I/O
  * @returns {Promise<{ ok: true } | { ok: false, error: string, kind?: string }>}
  */
-export async function draftSubmitForCwd(cwd, input = {}, deps = {}) {
-  const ctx = await resolveDraftContext(cwd, deps);
+export async function draftSubmitForCwd(ref, input = {}, deps = {}) {
+  const ctx = await resolveDraftContext(ref, deps);
   if (ctx.error) return { ok: false, error: ctx.error };
   const draft = await storeGetDraft(ctx.repoKey, ctx.number, deps);
   if (!draft || draft.comments.length === 0) return { ok: false, error: "nothing to submit" };

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -479,6 +479,51 @@ test("forgeDiffForCwd: no open PR → no_pr (not an error)", async () => {
   assert.deepEqual(r.threads, []);
 });
 
+test("forgeDiffForCwd: explicit { repoKey, number } addresses the PR directly (BET-850)", async () => {
+  // No git deps at all — the explicit inbox target must not touch cwd/git.
+  const getAdapter = (kind, token) => {
+    assert.equal(kind, "github");
+    assert.equal(token, "t");
+    return diffAdapter({
+      diff: "@@ -1 +1 @@\n+cross repo\n",
+      threads: [{ id: "9", path: "z.ts", line: 2, side: "RIGHT", resolved: false, comments: [] }],
+      headSha: "def",
+    });
+  };
+  const r = await forgeDiffForCwd(
+    { repoKey: "github.com/acme/widget", number: 42 },
+    { resolveToken: async (host) => ({ token: "t", source: "cli" }), getAdapter },
+  );
+  assert.equal(r.error, null);
+  assert.equal(r.diff, "@@ -1 +1 @@\n+cross repo\n");
+  assert.equal(r.threads.length, 1);
+  assert.equal(r.headSha, "def");
+});
+
+test("forgeDiffForCwd: explicit target with no token → not_connected", async () => {
+  const r = await forgeDiffForCwd(
+    { repoKey: "github.com/acme/widget", number: 42 },
+    { resolveToken: async () => null, getAdapter: () => diffAdapter() },
+  );
+  assert.deepEqual(r.error, "not_connected");
+});
+
+test("forgeDiffForCwd: explicit target with an unknown host → no_forge", async () => {
+  const r = await forgeDiffForCwd(
+    { repoKey: "example.com/acme/widget", number: 42 },
+    { resolveToken: async () => ({ token: "t", source: "cli" }), getAdapter: () => diffAdapter() },
+  );
+  assert.deepEqual(r.error, "no_forge");
+});
+
+test("forgeDiffForCwd: explicit target with an invalid number → no_pr", async () => {
+  const r = await forgeDiffForCwd(
+    { repoKey: "github.com/acme/widget", number: 0 },
+    { resolveToken: async () => ({ token: "t", source: "cli" }), getAdapter: () => diffAdapter() },
+  );
+  assert.deepEqual(r.error, "no_pr");
+});
+
 // ---- Box-buffered draft review (BET-793) ------------------------------------
 
 // A draft-op test kit: injectable git/forge deps plus an in-memory stand-in
@@ -629,6 +674,26 @@ test("draftSubmitForCwd: no buffered comments → nothing to submit", async () =
   const r = await draftSubmitForCwd("/repo", {}, k);
   assert.equal(r.ok, false);
   assert.equal(r.error, "nothing to submit");
+});
+
+test("draft ops: explicit { repoKey, number } builds/serves the draft for that PR (BET-850)", async () => {
+  const k = draftKit({ headSha: "abc" });
+  const add = await draftCommentForCwd(
+    { repoKey: "github.com/acme/widget", number: 42 },
+    { op: "add", comment: { path: "a.ts", line: 1, side: "new", body: "cross-repo note" } },
+    k,
+  );
+  assert.equal(add.ok, true);
+  assert.equal(add.draft.comments.length, 1);
+
+  const get = await draftGetForCwd({ repoKey: "github.com/acme/widget", number: 42 }, k);
+  assert.equal(get.error, null);
+  assert.equal(get.draft.comments[0].body, "cross-repo note");
+  assert.equal(get.draft.repoKey, "github.com/acme/widget");
+
+  // The draft is stored under the target repoKey + number, not a session cwd.
+  const stored = await getDraft("github.com/acme/widget", 42, k);
+  assert.equal(stored.comments.length, 1);
 });
 
 test("draft ops resolve no_forge / not_connected like the other write ops", async () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -337,8 +337,11 @@ export function buildHandlers({
     "forge:status": () => forgeStatus(),
     "forge:pull-request": (input) =>
       pullRequestForCwd(typeof input === "object" && input !== null ? input.cwd : input),
-    "forge:diff": (input) =>
-      forgeDiffForCwd(typeof input === "object" && input !== null ? input.cwd : input),
+    // A forge ref is either the session cwd ({ cwd }) — resolved box-side to
+    // the open PR — or an explicit cross-repo inbox target ({ repoKey, number },
+    // BET-850). Pass the whole input so the server reads whichever addressing
+    // mode the caller supplied.
+    "forge:diff": (input) => forgeDiffForCwd(input),
 
     // BET-798: box-side rules registry reads + disconnect (the Settings [G1]
     // surface). A forge token never reaches the renderer — list returns rule
@@ -403,16 +406,15 @@ export function buildHandlers({
     // the renderer). forge:draft-get reads the current draft (reconciling head
     // movement → stale); forge:draft-comment mutates a comment or sets the
     // verdict; forge:draft-submit flushes and clears only on success.
-    "forge:draft-get": (input) =>
-      draftGetForCwd(typeof input === "object" && input !== null ? input.cwd : ""),
+    "forge:draft-get": (input) => draftGetForCwd(input),
     "forge:draft-comment": (input) =>
       draftCommentForCwd(
-        typeof input === "object" && input !== null ? input.cwd : "",
+        typeof input === "object" && input !== null ? input : "",
         typeof input === "object" && input !== null ? input : {},
       ),
     "forge:draft-submit": (input) =>
       draftSubmitForCwd(
-        typeof input === "object" && input !== null ? input.cwd : "",
+        typeof input === "object" && input !== null ? input : "",
         typeof input === "object" && input !== null ? input : {},
       ),
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -44,6 +44,7 @@ import type {
   ForgeProbeResult,
   ForgeStatusResult,
   ForgePullRequestResult,
+  ForgeRefTarget,
   ForgeDiffResult,
   ForgeDisconnectResult,
   ForgeRuleRow,
@@ -199,7 +200,7 @@ export interface Api {
   // and the server resolves cwd → origin → repo.
   forgeStatus(): Promise<ForgeStatusResult>;
   forgePullRequest(input: { cwd: string }): Promise<ForgePullRequestResult>;
-  forgeDiff(input: { cwd: string }): Promise<ForgeDiffResult>;
+  forgeDiff(input: ForgeRefTarget): Promise<ForgeDiffResult>;
   // BET-795: the work inbox. Box-side only — three cross-repo SEARCH queries,
   // never per-repo iteration, cached a full 60s on the search bucket.
   forgeInbox(): Promise<ForgeInboxResult>;
@@ -224,7 +225,7 @@ export interface Api {
   // the current draft; draftComment mutates a comment (add/edit/delete) or sets
   // the verdict; draftSubmit flushes the whole draft as ONE review, clearing it
   // only on success.
-  forgeDraftGet(input: { cwd: string }): Promise<ForgeDraftGetResult>;
+  forgeDraftGet(input: ForgeRefTarget): Promise<ForgeDraftGetResult>;
   forgeDraftComment(input: ForgeDraftCommentInput): Promise<ForgeDraftCommentResult>;
   forgeDraftSubmit(input: ForgeDraftSubmitInput): Promise<ForgeDraftSubmitResult>;
 

--- a/src/shared/forge.d.mts
+++ b/src/shared/forge.d.mts
@@ -71,6 +71,15 @@ export function repoKey(repo: {
   repo: string;
 }): string;
 
+// The inverse of `repoKey`: split a `host/owner/repo` key back into its forge
+// identity. Returns `{ kind, host, owner, repo }` (owner is the full
+// `group/subgroup` path for GitLab) or `null` for a non-string, a key with
+// fewer than three segments, or a host that is not a known forge. Used by the
+// forge reads to address an explicit cross-repo inbox PR (BET-850).
+export function repoKeyParts(
+  key: unknown,
+): { kind: ForgeKind; host: string; owner: string; repo: string } | null;
+
 // Normalise a forge's raw PR/MR state into the shared `PullRequestState`.
 // Handles GitLab `opened`/`locked` and GitHub merged-as-closed. Throws on an
 // unknown raw state.

--- a/src/shared/forge.mjs
+++ b/src/shared/forge.mjs
@@ -185,6 +185,40 @@ export function repoKey({ host, owner, repo }) {
   return `${h}/${o}/${r}`;
 }
 
+/**
+ * The inverse of `repoKey`: split a `host/owner/repo` key back into its forge
+ * identity. `host` is the first segment and must map to a known forge kind
+ * (github.com / gitlab.com); `owner` is every middle segment joined with `/`
+ * (so GitLab subgroups fall out unchanged); `repo` is the last segment.
+ *
+ * Cross-repo inbox rows carry only this join key (host/owner/repo) plus a PR
+ * number — there is no cwd to resolve from. This is what lets the diff/draft
+ * reads address an explicit inbox PR instead of the session's cwd (BET-850).
+ *
+ * Returns `null` for a non-string, a key with fewer than three segments, or a
+ * host that is not a known forge (mirrors `detectForge`'s loud rejection of
+ * unknown hosts).
+ *
+ * @param {unknown} key `host/owner/repo`
+ * @returns {{ kind: ForgeKind, host: string, owner: string, repo: string } | null}
+ */
+export function repoKeyParts(key) {
+  if (typeof key !== "string") return null;
+  const parts = key
+    .trim()
+    .replace(/^\/+|\/+$/g, "")
+    .split("/")
+    .filter((s) => s !== "");
+  if (parts.length < 3) return null;
+  const host = parts[0].toLowerCase();
+  const kind = HOST_KIND[host];
+  if (kind === undefined) return null;
+  const owner = parts.slice(1, -1).map((s) => s.toLowerCase()).join("/");
+  const repo = parts[parts.length - 1].toLowerCase().replace(/\.git$/, "");
+  if (owner === "" || repo === "") return null;
+  return { kind, host, owner, repo };
+}
+
 // ---------------------------------------------------------------------------
 // PR/MR state normalisation
 // ---------------------------------------------------------------------------

--- a/src/shared/forge.test.ts
+++ b/src/shared/forge.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   detectForge,
   repoKey,
+  repoKeyParts,
   normalizePrState,
   rollupChecks,
   UnsupportedByForgeError,
@@ -118,6 +119,42 @@ describe("repoKey", () => {
     expect(repoKey({ host: "Github.Com", owner: "Owner", repo: "Repo.git" })).toBe(
       "github.com/owner/repo",
     );
+  });
+});
+
+describe("repoKeyParts", () => {
+  it("round-trips a flat github key back into forge identity", () => {
+    expect(repoKeyParts("github.com/acme/widget")).toEqual({
+      kind: "github",
+      host: "github.com",
+      owner: "acme",
+      repo: "widget",
+    });
+  });
+  it("round-trips a gitlab subgroup key, preserving the owners path", () => {
+    expect(repoKeyParts("gitlab.com/group/sub/proj")).toEqual({
+      kind: "gitlab",
+      host: "gitlab.com",
+      owner: "group/sub",
+      repo: "proj",
+    });
+  });
+  it("normalises case and strips a trailing .git", () => {
+    expect(repoKeyParts("GITHUB.com/Acme/Widget.git")).toEqual({
+      kind: "github",
+      host: "github.com",
+      owner: "acme",
+      repo: "widget",
+    });
+  });
+  it("is the inverse of repoKey(detectForge(...))", () => {
+    const identity = detectForge("https://gitlab.com/Group/Sub/Proj.git")!;
+    expect(repoKeyParts(repoKey(identity))).toEqual(identity);
+  });
+  it("returns null for a non-string, a short key, or an unknown host", () => {
+    expect(repoKeyParts(undefined)).toBeNull();
+    expect(repoKeyParts("github.com/acme")).toBeNull();
+    expect(repoKeyParts("example.com/acme/widget")).toBeNull();
   });
 });
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -524,6 +524,15 @@ export type ForgeThread = {
   comments: { author: string; body: string; createdAt: string | null }[];
 };
 
+// The target of a forge read/write. Either the session's `cwd` (resolved
+// box-side to the open PR on the current branch) or an explicit cross-repo
+// inbox PR — `repoKey` (host/owner/repo) + `number` (BET-850). The inbox
+// "Open review" row action addresses the review pane this way when the PR is
+// not the current session's (it may live in a repo the box has not cloned).
+export type ForgeRefTarget =
+  | { cwd: string }
+  | { repoKey: string; number: number };
+
 // forge:diff result — the review pane's read for a session cwd. `diff` is the
 // RAW unified diff text consumed verbatim by UnifiedDiff; `threads` are the
 // incoming forge threads; `headSha` is the PR head the diff was fetched at (so
@@ -668,7 +677,6 @@ export type ForgeDraftGetResult = {
 // (optional) — which subset is required depends on `op`, and the box validates
 // the payload per op rather than encoding it in the transport type.
 export type ForgeDraftCommentInput = {
-  cwd: string;
   op: "add" | "edit" | "delete" | "set-verdict";
   comment?: {
     id?: string;
@@ -680,7 +688,7 @@ export type ForgeDraftCommentInput = {
   };
   verdict?: "approved" | "changes_requested" | "commented" | null;
   body?: string;
-};
+} & ForgeRefTarget;
 
 export type ForgeDraftCommentResult =
   | { ok: true; draft: ForgeDraft }
@@ -690,10 +698,9 @@ export type ForgeDraftCommentResult =
 // review; the draft is cleared only on success. A failed submit returns a typed
 // `kind` (e.g. "http_422") and leaves the draft intact.
 export type ForgeDraftSubmitInput = {
-  cwd: string;
   verdict?: "approved" | "changes_requested" | "commented" | null;
   body?: string;
-};
+} & ForgeRefTarget;
 
 export type ForgeDraftSubmitResult =
   | { ok: true }


### PR DESCRIPTION
## Summary
BET-795 had "Open review" on an inbox row open the PR/issue URL in the browser. The design (§4.5④) calls for the in-app review pane (ReviewPane, BET-792). The review pane was scoped to the current session's PR (resolved via `forgeDiffForCwd` → cwd → origin → open PR), so opening it for an arbitrary **cross-repo** inbox PR — possibly one in a repo the box has not cloned — required the read to accept an explicit `{ repoKey, number }`.

## What changed
- **`forge:diff` + `forge:draft-{get,comment,submit}`** accept either the session `cwd` (as before) or an explicit `{ repoKey, number }` inbox target. The explicit path resolves over the forge API alone (no git call) — it never touches cwd/origin.
- **`repoKeyParts(key)`** — pure inverse of `repoKey` in `src/shared/forge.mjs` (splits `host/owner/repo` back into `{kind, host, owner, repo}`), with matching `forge.d.mts` declaration.
- **`ReviewPane`** accepts an optional explicit `target`; when present it addresses all four reads by `{repoKey, number}`. "Send to agent" is gated on a live `sessionId` (hidden for a standalone cross-repo review — there's no session to route to). The box-buffered draft review + comment gutter still work.
- **`InboxPalette`** "Open review" mounts the ReviewPane in a full-surface sheet over the inbox for the selected PR (issues show a "reviews are for PRs" message instead of opening the browser).

## Verification results (PR branch `multica/BET-850-inbox-open-review-pane` @ `9b70df80`)
- typecheck: exit 0, no errors
- test: exit 0, 1915 pass / 0 fail / 0 skip

Base: `origin/main` @ `8f29a4e5`

New tests cover the explicit target path: `forgeDiffForCwd` with `{ repoKey, number }` (diff + threads + no git), unknown host → `no_forge`, no token → `not_connected`, invalid number → `no_pr`, and the draft write/read round-trip keyed to `repoKey + number`. Pure `repoKeyParts` unit tests in `src/shared/forge.test.ts`.