### PR TITLE
fix(server): add 'both' unchanged-line anchor side for precise GitLab positions (BET-856)

### DIFF
--- a/src/renderer/ToolBodies.tsx
+++ b/src/renderer/ToolBodies.tsx
@@ -433,7 +433,10 @@ export function UnifiedDiff({
       sign = " ";
       body = line.slice(1);
       ln = newLine;
-      anchor = { path, line: newLine, side: "new" };
+      // An unchanged context line exists in BOTH versions — GitLab positions it
+      // with both `new_line` and `old_line`, so the anchor is "both" (BET-856),
+      // not "new" (which would misplace it as a pure addition on GitLab).
+      anchor = { path, line: newLine, side: "both" };
       newLine++;
       oldLine++;
     }

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3918,20 +3918,20 @@ describe("commentableLines", () => {
       "+ new",
       "  c",
     ].join("\n");
-    // a=10 (context), old=11 (removed), new=11 (added), c=12 (context)
+    // a=10 (context→both), old=11 (removed), new=11 (added), c=12 (context→both)
     expect(commentableLines(diff)).toEqual([
-      { path: "file.ts", line: 10, side: "new" },
+      { path: "file.ts", line: 10, side: "both" },
       { path: "file.ts", line: 11, side: "old" },
       { path: "file.ts", line: 11, side: "new" },
-      { path: "file.ts", line: 12, side: "new" },
+      { path: "file.ts", line: 12, side: "both" },
     ]);
   });
 
-  it("anchors a removed line on the old side and a context line on the new side", () => {
+  it("anchors a removed line on the old side and an unchanged context line on both sides", () => {
     const diff = ["--- a/x.ts", "+++ b/x.ts", "@@ -5 +5 @@", "- gone", "  kept"].join("\n");
     expect(commentableLines(diff)).toEqual([
       { path: "x.ts", line: 5, side: "old" },
-      { path: "x.ts", line: 5, side: "new" },
+      { path: "x.ts", line: 5, side: "both" },
     ]);
   });
 
@@ -3948,12 +3948,12 @@ describe("commentableLines", () => {
       "+ w",
     ].join("\n");
     expect(commentableLines(diff)).toEqual([
-      // first hunk: a=1 (context), b=2 (removed), c=2 (added)
-      { path: "file.ts", line: 1, side: "new" },
+      // first hunk: a=1 (context→both), b=2 (removed), c=2 (added)
+      { path: "file.ts", line: 1, side: "both" },
       { path: "file.ts", line: 2, side: "old" },
       { path: "file.ts", line: 2, side: "new" },
-      // second hunk: z=20 (context), w=21 (added)
-      { path: "file.ts", line: 20, side: "new" },
+      // second hunk: z=20 (context→both), w=21 (added)
+      { path: "file.ts", line: 20, side: "both" },
       { path: "file.ts", line: 21, side: "new" },
     ]);
   });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3045,21 +3045,24 @@ export function describeMergeFailure(kind: string | null | undefined): string {
 // ---- Forge review pane (BET-792) -------------------------------------------
 
 // The line anchor a comment may attach to, in the forge-neutral shape the spec
-// (§3.4③) normalises on: `path` names the FILE, `side` is "new" (added/context
-// lines — GitHub's RIGHT) or "old" (removed lines — GitHub's LEFT), and `line`
-// is the corresponding line number. `path` is load-bearing — a PR diff is a
-// single merged stream of many files, so an anchor that drops it misplaces a
-// thread whenever two files share a line number. The renderer maps these onto
-// the rows UnifiedDiff draws, keyed per-file.
-export type CommentableLine = { path: string; line: number; side: "new" | "old" };
+// (§3.4③) normalises on: `path` names the FILE, `side` is "new" (added lines —
+// GitHub's RIGHT), "old" (removed lines — GitHub's LEFT) or "both" (unchanged
+// context lines, present in both versions — GitLab positions them with both
+// `new_line` and `old_line`, BET-856), and `line` is the corresponding line
+// number. `path` is load-bearing — a PR diff is a single merged stream of many
+// files, so an anchor that drops it misplaces a thread whenever two files share
+// a line number. The renderer maps these onto the rows UnifiedDiff draws, keyed
+// per-file.
+export type CommentableLine = { path: string; line: number; side: "new" | "old" | "both" };
 
 // Derive the set of commentable line anchors from a unified-diff text, walking
-// the `@@ -A,B +C,D @@` hunk headers so numbers are exact per hunk. Added and
-// context lines anchor on the NEW side (new line number); removed lines on the
-// OLD side (old line number). The active file path is tracked from the `+++ b/`
-// marker (falling back to `--- a/` when a file is deleted to `/dev/null`), so
-// every anchor is keyed to its file. File markers / hunk headers are not
-// commentable. An empty diff yields `[]`.
+// the `@@ -A,B +C,D @@` hunk headers so numbers are exact per hunk. Added lines
+// anchor on the NEW side (new line number); removed lines on the OLD side (old
+// line number); unchanged context lines on BOTH (present in both versions, so
+// GitLab positions them with both `new_line` and `old_line` — BET-856). The
+// active file path is tracked from the `+++ b/` marker (falling back to `--- a/`
+// when a file is deleted to `/dev/null`), so every anchor is keyed to its file.
+// File markers / hunk headers are not commentable. An empty diff yields `[]`.
 export function commentableLines(diffText: string): CommentableLine[] {
   const result: CommentableLine[] = [];
   let oldLine = 0;
@@ -3093,7 +3096,7 @@ export function commentableLines(diffText: string): CommentableLine[] {
       if (path) result.push({ path, line: oldLine, side: "old" });
       oldLine++;
     } else if (line.startsWith(" ")) {
-      if (path) result.push({ path, line: newLine, side: "new" });
+      if (path) result.push({ path, line: newLine, side: "both" });
       oldLine++;
       newLine++;
     }

--- a/src/server/forge/draft.mjs
+++ b/src/server/forge/draft.mjs
@@ -41,12 +41,17 @@ const STORE_PATH = statePath("forge-drafts.json");
 // verdict yet). No second enum is defined anywhere (issue §Hygiene).
 const VERDICTS = new Set(["approved", "changes_requested", "commented"]);
 
-// A forge-neutral review-comment anchor. `side` is the renderer's "new"|"old"
-// (the adapter maps it onto the forge's word — GitHub "RIGHT"/"LEFT"). `line`
-// is required; `startLine` is the multi-line highlight start (optional). The
-// old GitHub `position` field (offset from the hunk header) is retired — never
-// built on.
-const SIDES = new Set(["new", "old"]);
+// A forge-neutral review-comment anchor. `side` is the renderer's
+// "new"|"old"|"both" (the adapter maps it onto the forge's word — GitHub
+// "RIGHT"/"LEFT"; GitLab's position uses `new_line`/`old_line`/both).
+// `"both"` is an UNCHANGED line (present in both versions): GitLab positions
+// it with BOTH `new_line` and `old_line`, so a draft anchored `"both"` must be
+// able to say so rather than being coerced to `"new"` (which would misplace it
+// as a pure addition). Adapted lines → `"new"`, removed → `"old"`, unchanged
+// context lines → `"both"` (BET-856). `line` is required; `startLine` is the
+// multi-line highlight start (optional). The old GitHub `position` field
+// (offset from the hunk header) is retired — never built on.
+const SIDES = new Set(["new", "old", "both"]);
 
 export async function loadDrafts(path = STORE_PATH) {
   const parsed = readJsonSync(path, {});

--- a/src/server/forge/draft.test.mjs
+++ b/src/server/forge/draft.test.mjs
@@ -83,6 +83,19 @@ test("normalizeAnchor rejects an invalid or missing anchor", () => {
   assert.equal(normalizeAnchor(null), null);
 });
 
+test("normalizeAnchor accepts and preserves the 'both' (unchanged line) side (BET-856)", async () => {
+  assert.deepEqual(normalizeAnchor({ path: "a", line: 3, side: "both" }), { path: "a", line: 3, side: "both" });
+  assert.deepEqual(normalizeAnchor({ path: "a", line: 3, side: "both", startLine: 1 }), {
+    path: "a", line: 3, side: "both", startLine: 1,
+  });
+  // A draft comment anchored on an unchanged line is stored with its side intact —
+  // never coerced to "new", which would misplace it as a pure addition on GitLab.
+  const m = memStore();
+  const r = await putComment(REPO, 1, "sha", { path: "a.ts", line: 7, side: "both", body: "unchanged line" }, m);
+  assert.equal(r.ok, true);
+  assert.equal(r.draft.comments[0].side, "both");
+});
+
 test("two drafts for different PRs do not collide", async () => {
   const m = memStore();
   await putComment(REPO, 1, "sha", { path: "a.ts", line: 1, side: "new", body: "one" }, m);

--- a/src/server/forge/gitlab.mjs
+++ b/src/server/forge/gitlab.mjs
@@ -261,8 +261,9 @@ async function positionShas(base, headSha, request) {
  *
  * The `new_line`/`old_line` combination is the trap: an ADDED line sets
  * `new_line` only, a REMOVED line sets `old_line` only, and an UNCHANGED line
- * sets BOTH. `side` `"new"` → added; `"old"` → removed; anything else → both.
- * Pure and exported for tests.
+ * sets BOTH. `side` maps exactly: `"new"` → added; `"old"` → removed;
+ * `"both"` (an unchanged context line, emitted by the renderer's diff gutter —
+ * BET-856) → both. Pure and exported for tests.
  *
  * @param {{ base_sha?: string, start_sha?: string, head_sha?: string }} shas
  * @param {{ path: string, line: number, side?: string, startLine?: number | null }} a

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -628,14 +628,17 @@ export type ForgeMergeResult =
 
 // A box-buffered draft review comment. The anchor is forge-neutral — the same
 // `{ path, line, side }` the review pane's diff gutter uses, plus `startLine`
-// for a multi-line highlight. `side` is the renderer's "new"|"old"; the adapter
-// maps it onto the forge's word ("RIGHT"/"LEFT" on GitHub). `body` is the typed
+// for a multi-line highlight. `side` is the renderer's "new"|"old"|"both":
+// adapted → new, removed → old, unchanged context line → both (the renderer's
+// gutter emits "both" for a line present in both versions, so GitLab can
+// position it with both `new_line` and `old_line` — BET-856). The adapter maps
+// it onto the forge's word ("RIGHT"/"LEFT" on GitHub). `body` is the typed
 // comment text. The old GitHub `position` field is deliberately never used.
 export type ForgeDraftComment = {
   id: string;
   path: string;
   line: number;
-  side: "new" | "old";
+  side: "new" | "old" | "both";
   startLine?: number | null;
   body: string;
 };
@@ -674,7 +677,7 @@ export type ForgeDraftCommentInput = {
     id?: string;
     path?: string;
     line?: number;
-    side?: "new" | "old";
+    side?: "new" | "old" | "both";
     startLine?: number | null;
     body?: string;
   };


### PR DESCRIPTION
## What & why (BET-856)

The shared `DraftComment` anchor only had two sides — `"new"` (added) and `"old"` (removed). A comment on an **unchanged context line** was therefore coerced to `"new"`, which GitLab places as a **pure addition** (`new_line` only). GitLab positions an unchanged line with **BOTH** `new_line` and `old_line`, so the anchor must be able to say `"both"`.

This threads the third `"both"` side end-to-end:

1. **`src/server/forge/draft.mjs`** — `SIDES` now `{ "new", "old", "both" }`; `normalizeAnchor` validates + persists it (never coerces `"both"` back to `"new"`).
2. **`src/shared/types.ts`** — `ForgeDraftComment.side` and the `ForgeDraftCommentInput` comment `side` accept `"both"`.
3. **`src/renderer/chatUtils.ts`** — `CommentableLine.side` is now `"new" | "old" | "both"`; `commentableLines` emits `side: "both"` for unchanged context lines.
4. **`src/renderer/ToolBodies.tsx` (UnifiedDiff)** — the diff-gutter anchor producer emits `side: "both"` for context lines (this is what actually reaches the draft when a user comments on an unchanged line).
5. **`src/server/forge/gitlab.mjs`** — `buildPosition` already mapped `"both"` to both `new_line` + `old_line` (the else branch); doc comment updated to name `"both"` explicitly. No behavior change.

**GitHub is unchanged:** `github.mjs` maps `side !== "old"` → `"RIGHT"`, so a `"both"` anchor on GitHub still posts to `RIGHT` with the new line — identical behavior to before. Only GitLab positions correctly now.

## What was removed / why net-additive

No code was removed — this is a type-widening + one line-constant change across an existing path, plus the anchor producer corrected from `"new"` to `"both"` for context lines. There was nothing to delete or collapse.

## Files changed (7)

```
 src/renderer/ToolBodies.tsx     |  5 ++++-
 src/renderer/chatUtils.test.ts  | 18 +++++++++---------
 src/renderer/chatUtils.ts       | 31 +++++++++++++++++--------------
 src/server/forge/draft.mjs      | 17 +++++++++++------
 src/server/forge/draft.test.mjs | 13 +++++++++++++
 src/server/forge/gitlab.mjs     |  5 +++--
 src/shared/types.ts             | 11 +++++++----
 7 files changed, 64 insertions(+), 36 deletions(-)
```

## Tests

- `draft.test.mjs`: `normalizeAnchor` accepts/validates `"both"`; a draft comment anchored `side: "both"` is stored with its side intact.
- `chatUtils.test.ts`: `commentableLines` now emits `side: "both"` for unchanged context lines.
- `gitlab.test.mjs`: the existing "position building" test already covered `side: "both"` → both `new_line` + `old_line`.

Base: `origin/main @ deec7141`

## Verification results

**Files changed:** 7 files.

- PR branch (`multica/BET-856-both-anchor-side` @ `b0be08f0`):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, 1942 pass / 0 fail / 0 skip. Failures: none. log sha256: `1330c909d9be1f2f6ab80eb0d805a453ad3faf57023bdc7bdb18c24a02dddadd`
- Base (`main` @ `deec7141`):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, 1941 pass / 0 fail / 0 skip. Failures: none. log sha256: `1ac0326e46382154b245892ecc2b726313212111b9e50ca5e9e036b0b4faca59`
- **Conclusion:** 0 new failures; this PR adds 1 net new test (1941 → 1942). No pre-existing failures on either branch.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
