### PR TITLE
fix(server): supply real GitHub device-grant client_id (BET-849)

### DIFF
--- a/src/server/forge/auth.mjs
+++ b/src/server/forge/auth.mjs
@@ -290,9 +290,10 @@ export function invalidateToken(host) {
 //      this on receipt) so the user pastes rather than retypes on a phone.
 
 // The public OAuth client_id for the device grant. The device flow needs NO
-// secret — a client_id is public. Supply the real product id at deploy (BET-849);
-// the mechanics below are client-id-agnostic and fully injectable.
-export const DEVICE_CLIENT_ID = "Iv1.0000000000000000";
+// secret — a client_id is public; the mechanics below are client-id-agnostic
+// and fully injectable. This is the real Manta product id (BET-849) — verified
+// accepted by `github.com/login/device/code` — so the flow runs for real users.
+export const DEVICE_CLIENT_ID = "Ov23liJP5kpodIqrcc3F";
 
 // A placeholder id has NEVER been registered with GitHub, so a start against it
 // would categorically dead-end at /login/device/code. The flow is GUARDED: a

--- a/src/server/forge/auth.test.mjs
+++ b/src/server/forge/auth.test.mjs
@@ -3,7 +3,7 @@
 
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { resolveToken, invalidateToken, normalizeUserCode, startDeviceGrant, pollDeviceGrant, ExpiredCodeError, DeviceFlowNotConfiguredError, DEVICE_CLIENT_ID_PLACEHOLDER } from "./auth.mjs";
+import { resolveToken, invalidateToken, normalizeUserCode, startDeviceGrant, pollDeviceGrant, ExpiredCodeError, DeviceFlowNotConfiguredError, DEVICE_CLIENT_ID, DEVICE_CLIENT_ID_PLACEHOLDER } from "./auth.mjs";
 
 // The module-level auth cache persists across test cases in this file — clear
 // it before each so a cached github.com resolution from one test can't leak
@@ -294,4 +294,13 @@ test("device grant: placeholder client_id refuses to start (guard, BET-849)", as
     DeviceFlowNotConfiguredError,
   );
   assert.equal(fetched, false, "no GitHub call is made for a placeholder id");
+});
+
+test("device grant: the production default client_id is real, not the placeholder (BET-849)", async () => {
+  assert.notEqual(DEVICE_CLIENT_ID, DEVICE_CLIENT_ID_PLACEHOLDER);
+  assert.notEqual(DEVICE_CLIENT_ID, "");
+  const clock = makeClock();
+  const fetchFn = makeFetch(async () => ({ error: "authorization_pending" }));
+  const started = await startDeviceGrant({ fetch: fetchFn, now: clock.now });
+  assert.equal(started.pollInterval, 5, "the default id is unguarded — the device flow actually runs");
 });


### PR DESCRIPTION
## Summary

Supplies the real public GitHub OAuth `client_id` for the Manta product's device-grant flow (BET-849). The device flow itself was implemented, guarded and tested in BET-796; the only missing piece was a production `client_id`, which Antoine registered and posted on the issue (`Ov23liJP5kpodIqrcc3F`).

**Change:** `src/server/forge/auth.mjs` — set `DEVICE_CLIENT_ID` to the real id. The guard (`DEVICE_CLIENT_ID_PLACEHOLDER`) and the injectable `clientId` seam in `startDeviceGrant`/`pollDeviceGrant` are untouched: an explicit placeholder/empty id still raises `DeviceFlowNotConfiguredError` → `notConfigured` renderer state, but the production default now runs the flow for real.

**Added test** pinned the invariant so the default never silently falls back to a placeholder.

## Verification

Verified against real GitHub (non-interactively): `POST github.com/login/device/code` with the new `client_id` returns HTTP 200 with a valid `device_code`/`user_code`/`verification_uri`, confirming the app is registered and accepted. Typecheck and the full suite are green.

**Files changed:** 2 files.

**Verification results:**
- PR branch (`multica/BET-849-device-client-id`): typecheck exit 0, no errors. `npm test`: 1961 pass / 0 fail / 0 skip.
- Base: `origin/main @ 74b9da9`.
- Conclusion: 0 new failures; no pre-existing failures.

The final interactive step of the acceptance criterion — a human entering the `user_code` at `github.com/login/device` on a box with no `gh`/no token — cannot be exercised by an agent and remains an explicit manual hand-off (as flagged during dispatch); the client-id prerequisite this issue was blocked on is now proven.

**Base: origin/main @ 74b9da9**
