### PR TITLE
test(server): dedupe busy-session defer clone in webhooks.test.mjs (BET-812)

### DIFF
--- a/src/server/webhooks.test.mjs
+++ b/src/server/webhooks.test.mjs
@@ -487,18 +487,9 @@ test("isRedelivery / isEventFiltered pure semantics", () => {
 });
 
 test("deliverWebhook returns 429 when rate-limited, never sends", async () => {
-  let sent = 0;
-  const res = await deliverWebhook(
-    { token: "a".repeat(32), rawBody: "{}", signatureHeader: "" },
-    {
-      load: async () => [fakeHook({ unsigned: true })],
-      save: async () => {},
-      sendPrompt: async () => { sent++; },
-      take: () => false,
-    },
-  );
+  const { res, sent } = await deliverToBusySession({ take: () => false });
   assert.equal(res.status, 429);
-  assert.equal(sent, 0);
+  assert.equal(sent(), 0);
 });
 
 test("deliverWebhook happy path sends the formatted turn and stamps metadata", async () => {
@@ -538,9 +529,9 @@ test("deliverWebhook on an unsigned hook skips signature verification", async ()
   assert.equal(sent, 1);
 });
 
-// Both defer cases share everything but `enqueue` — the busy-session envelope
-// is the fixture, the enqueue outcome is the axis under test.
-async function deliverToBusySession(enqueue) {
+// The busy session is the fixture for every defer/rate-limit case — the
+// envelope is identical, only the session deps under test differ.
+async function deliverToBusySession(deps) {
   let sent = 0;
   const res = await deliverWebhook(
     { token: "a".repeat(32), rawBody: "{}", signatureHeader: "" },
@@ -548,8 +539,7 @@ async function deliverToBusySession(enqueue) {
       load: async () => [fakeHook({ unsigned: true })],
       save: async () => {},
       sendPrompt: async () => { sent++; },
-      isBusy: () => true,
-      enqueue,
+      ...deps,
     },
   );
   return { res, sent: () => sent };
@@ -557,7 +547,10 @@ async function deliverToBusySession(enqueue) {
 
 test("deliverWebhook defers (202) on a busy session instead of draining", async () => {
   let queued = null;
-  const { res, sent } = await deliverToBusySession((sid, text) => { queued = { sid, text }; });
+  const { res, sent } = await deliverToBusySession({
+    isBusy: () => true,
+    enqueue: (sid, text) => { queued = { sid, text }; },
+  });
   assert.equal(res.status, 202);
   assert.equal(res.queued, true);
   assert.equal(sent(), 0); // did NOT send / abort the in-flight turn
@@ -567,10 +560,13 @@ test("deliverWebhook defers (202) on a busy session instead of draining", async 
 
 test("deliverWebhook surfaces a defer-queue-full rejection as 429, not 202 (BET-772)", async () => {
   let enqueueCalls = 0;
-  const { res, sent } = await deliverToBusySession(async () => {
-    enqueueCalls++;
-    // The shared engine rejects when the session's pending queue is full.
-    return { delivered: false, queued: false, rejected: true };
+  const { res, sent } = await deliverToBusySession({
+    isBusy: () => true,
+    enqueue: async () => {
+      enqueueCalls++;
+      // The shared engine rejects when the session's pending queue is full.
+      return { delivered: false, queued: false, rejected: true };
+    },
   });
   // The sender must NOT be told "queued, will be delivered" for a dropped
   // prompt — surface it as a non-202 so the sender knows the delivery failed.

--- a/src/server/webhooks.test.mjs
+++ b/src/server/webhooks.test.mjs
@@ -538,9 +538,10 @@ test("deliverWebhook on an unsigned hook skips signature verification", async ()
   assert.equal(sent, 1);
 });
 
-test("deliverWebhook defers (202) on a busy session instead of draining", async () => {
+// Both defer cases share everything but `enqueue` — the busy-session envelope
+// is the fixture, the enqueue outcome is the axis under test.
+async function deliverToBusySession(enqueue) {
   let sent = 0;
-  let queued = null;
   const res = await deliverWebhook(
     { token: "a".repeat(32), rawBody: "{}", signatureHeader: "" },
     {
@@ -548,39 +549,35 @@ test("deliverWebhook defers (202) on a busy session instead of draining", async 
       save: async () => {},
       sendPrompt: async () => { sent++; },
       isBusy: () => true,
-      enqueue: (sid, text) => { queued = { sid, text }; },
+      enqueue,
     },
   );
+  return { res, sent: () => sent };
+}
+
+test("deliverWebhook defers (202) on a busy session instead of draining", async () => {
+  let queued = null;
+  const { res, sent } = await deliverToBusySession((sid, text) => { queued = { sid, text }; });
   assert.equal(res.status, 202);
   assert.equal(res.queued, true);
-  assert.equal(sent, 0); // did NOT send / abort the in-flight turn
+  assert.equal(sent(), 0); // did NOT send / abort the in-flight turn
   assert.equal(queued.sid, "ses_1");
   assert.match(queued.text, /Inbound webhook/);
 });
 
 test("deliverWebhook surfaces a defer-queue-full rejection as 429, not 202 (BET-772)", async () => {
-  let sent = 0;
   let enqueueCalls = 0;
-  const res = await deliverWebhook(
-    { token: "a".repeat(32), rawBody: "{}", signatureHeader: "" },
-    {
-      load: async () => [fakeHook({ unsigned: true })],
-      save: async () => {},
-      sendPrompt: async () => { sent++; },
-      isBusy: () => true,
-      enqueue: async () => {
-        enqueueCalls++;
-        // The shared engine rejects when the session's pending queue is full.
-        return { delivered: false, queued: false, rejected: true };
-      },
-    },
-  );
+  const { res, sent } = await deliverToBusySession(async () => {
+    enqueueCalls++;
+    // The shared engine rejects when the session's pending queue is full.
+    return { delivered: false, queued: false, rejected: true };
+  });
   // The sender must NOT be told "queued, will be delivered" for a dropped
   // prompt — surface it as a non-202 so the sender knows the delivery failed.
   assert.equal(res.status, 429);
   assert.equal(res.queued, undefined);
   assert.equal(res.ok, false);
   assert.equal(res.error, "queue full");
-  assert.equal(sent, 0); // it was deferred-and-rejected, never sent now
+  assert.equal(sent(), 0); // it was deferred-and-rejected, never sent now
   assert.equal(enqueueCalls, 1);
 });


### PR DESCRIPTION
## BET-812 — Dedupe the 9-line self-clone in `webhooks.test.mjs`

Test-only change. No production code touched (`src/server/webhooks.mjs` and all
others are unchanged).

### What changed

Added one file-local helper, `deliverToBusySession(deps)`, in
`src/server/webhooks.test.mjs` that carries the shared busy-session
`deliverWebhook` envelope. Both defer tests now call it.

### Deviation from the issue body (important)

The issue prescribed the helper for **exactly** the two defer tests. Doing only
that **does not reach the "0 clones" done-when**: the pre-existing
`"deliverWebhook returns 429 when rate-limited, never sends"` test shares the
*identical* 8-line envelope (`rawBody: "{}"`, `load`/`save`/`sendPrompt` with
`sent++`) with the busy tests, so after deduping the two busy tests a residual
clone of that envelope remains between the rate-limited test and the helper.

I verified this empirically (`scripts/check-duplication-gate.sh` reported 1
clone with the helper scoped to two tests). To satisfy the blocking gate's hard
"0 clones" acceptance I extended the **same single file-local helper** to also
serve the rate-limited test (the third case sharing the envelope). The helper
takes the per-case session deps and spreads them.

- Both busy tests keep their exact names and every original assertion
  (`202`/`queued===true`/`queued.sid`/`/Inbound webhook/`; `429`/`queued===undefined`/`ok===false`/`error==="queue full"`/`enqueueCalls===1`).
- The rate-limited test keeps its name and both assertions (`429`, `sent===0`).

### Done-when

- `node scripts/duplication-gate` → **PASS — no clones** for `webhooks.test.mjs`
- `npm run typecheck` → clean
- `npm test` → 1960 pass, 0 fail
- **Net line delta: −7** (24 insertions, 31 deletions) — negative, as required.
