### PR TITLE
BET-848: reply to an incoming forge thread (wire replyToThread)

### DIFF
--- a/src/renderer/ReviewPane.tsx
+++ b/src/renderer/ReviewPane.tsx
@@ -117,6 +117,11 @@ export function ReviewPane({
   const [draftText, setDraftText] = useState<string>("");
   const [submitting, setSubmitting] = useState(false);
 
+  // Reply-to-an-incoming-thread composer (for a colleague's thread on the diff).
+  // `replyingTo` is the target thread id; `replyText` is the draft reply body.
+  const [replyingTo, setReplyingTo] = useState<string | null>(null);
+  const [replyText, setReplyText] = useState<string>("");
+
   // Renderer-local "routed to agent" flags keyed by buffered comment id. The
   // forge never sees this — it only lands in the chat composer. Not a draft
   // field, so the box store stays forge-shaped.
@@ -185,6 +190,19 @@ export function ReviewPane({
     setComposing(null);
     setDraftText("");
   }, [target, cwd, composing, draftText]);
+
+  // Reply to ONE existing incoming thread — posts immediately (never buffered
+  // in the draft), then refetches threads so the reply lands with the canonical
+  // read. The composer stays open on failure.
+  const postReply = useCallback(async (threadId: string, body: string) => {
+    if (!body.trim()) return;
+    const res = await window.api.forgeThreadReply({ ...ref, threadId, body });
+    if (!res.ok) return;
+    setReplyingTo(null);
+    setReplyText("");
+    const fresh = await window.api.forgeDiff(ref);
+    setThreads(Array.isArray(fresh.threads) ? fresh.threads : []);
+  }, [ref]);
 
   const sendToAgent = useCallback(
     (text: string, commentId?: string) => {
@@ -270,7 +288,56 @@ export function ReviewPane({
                     {c.body}
                   </div>
                 ))}
+                {replyingTo === t.id && (
+                  <div className="mt-2 rounded-r-[var(--r-sm)] border-l-2 border-accent bg-bg-elev px-[11px] py-2">
+                    <textarea
+                      autoFocus
+                      value={replyText}
+                      onChange={(e) => setReplyText(e.target.value)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter" && !e.shiftKey) {
+                          e.preventDefault();
+                          postReply(t.id, replyText);
+                        } else if (e.key === "Escape") {
+                          e.preventDefault();
+                          setReplyingTo(null);
+                          setReplyText("");
+                        }
+                      }}
+                      placeholder="Reply…"
+                      rows={2}
+                      className="w-full resize-none rounded-xs border border-border-strong bg-bg px-2 py-1 font-mono text-meta text-text outline-none placeholder:text-text-faint focus:border-accent"
+                    />
+                    <div className="mt-2 flex items-center gap-[6px]">
+                      <Button tone="default" onClick={() => postReply(t.id, replyText)}>
+                        Reply
+                      </Button>
+                      <Button
+                        tone="ghost"
+                        onClick={() => {
+                          setReplyingTo(null);
+                          setReplyText("");
+                        }}
+                      >
+                        Cancel
+                      </Button>
+                    </div>
+                  </div>
+                )}
               </div>
+            }
+            action={
+              replyingTo !== t.id ? (
+                <Button
+                  tone="ghost"
+                  onClick={() => {
+                    setReplyingTo(t.id);
+                    setReplyText("");
+                  }}
+                >
+                  Reply
+                </Button>
+              ) : undefined
             }
           />
         ),
@@ -361,7 +428,7 @@ export function ReviewPane({
     }
 
     return out;
-  }, [threads, draft, composing, draftText, addToReview, sendToAgent, removeComment, canSend]);
+  }, [threads, draft, composing, draftText, addToReview, sendToAgent, removeComment, canSend, replyingTo, replyText, postReply]);
 
   const draftCount = draft?.comments.length ?? 0;
 

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -69,6 +69,7 @@ export const DEMO_UNIMPLEMENTED = [
   "forgeShip",
   "forgeShipPreview",
   "forgeStatus",
+  "forgeThreadReply",
   "getPathForFile",
   "gitAddWorktree",
   "gitRemoveWorktree",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -725,6 +725,7 @@ export const httpApi: Api = {
   forgeDraftGet: (input) => rpc(IPC.forgeDraftGet, input),
   forgeDraftComment: (input) => rpc(IPC.forgeDraftComment, input),
   forgeDraftSubmit: (input) => rpc(IPC.forgeDraftSubmit, input),
+  forgeThreadReply: (input) => rpc(IPC.forgeThreadReply, input),
 
   // -- forge clone flow (BET-796), box-side only --
   forgeDeviceStart: () => rpc(IPC.forgeDeviceStart),

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -1109,6 +1109,35 @@ export async function draftCommentForCwd(ref, input = {}, deps = {}) {
 }
 
 /**
+ * forge:thread-reply — post a reply to ONE existing incoming thread. Unlike a
+ * draft comment this is not buffered: a reply is per-thread and publishes
+ * immediately. Box-side only; the token never reaches the renderer.
+ *
+ * @param {string|object} ref
+ * @param {{ threadId: string, body: string }} input
+ * @param {object} [deps] injectable I/O
+ * @returns {Promise<{ ok: true } | { ok: false, error: string }>}
+ */
+export async function replyThreadForCwd(ref, input = {}, deps = {}) {
+  const ctx = await resolveDraftContext(ref, deps);
+  if (ctx.error) return { ok: false, error: ctx.error };
+  const threadId = String(input.threadId ?? "").trim();
+  const body = String(input.body ?? "").trim();
+  if (!threadId) return { ok: false, error: "missing threadId" };
+  if (!body) return { ok: false, error: "empty reply" };
+  try {
+    await ctx.adapter.replyToThread(ctx.repo, ctx.number, {
+      threadId,
+      body,
+      headSha: ctx.headSha,
+    });
+  } catch (e) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+  return { ok: true };
+}
+
+/**
  * forge:draft-submit — flush the box-buffered draft as ONE review. The draft
  * is cleared ONLY on success; a failed submit leaves it intact and recoverable.
  * Returns a typed error (`kind`) for the distinguishable failure modes.

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -19,6 +19,7 @@ import {
   draftGetForCwd,
   draftCommentForCwd,
   draftSubmitForCwd,
+  replyThreadForCwd,
   forgeInbox,
   seedPromptFor,
   INBOX_SEED_PROMPT,
@@ -613,6 +614,64 @@ test("draftCommentForCwd: add + set-verdict persist box-side", async () => {
   const bad = await draftCommentForCwd("/repo", { op: "frobnicate" }, k);
   assert.equal(bad.ok, false);
   assert.equal(bad.error.includes("unknown op"), true);
+});
+
+test("replyThreadForCwd: posts immediately with the resolved repo, PR number and headSha", async () => {
+  let called = null;
+  const k = draftKit({
+    headSha: "abc",
+    adapter: {
+      kind: "github",
+      listPullRequests: async () => ({ data: [OPEN_PR], stale: false }),
+      getPullRequest: async () => ({ data: { ...OPEN_PR, headSha: "abc" }, stale: false }),
+      replyToThread: async (repo, n, input) => {
+        called = { repo, n, input };
+      },
+    },
+  });
+  const r = await replyThreadForCwd("/repo", { threadId: "t1", body: "thanks!" }, k);
+  assert.equal(r.ok, true);
+  assert.equal(called.repo.owner, "acme");
+  assert.equal(called.n, 42);
+  assert.equal(called.input.threadId, "t1");
+  assert.equal(called.input.body, "thanks!");
+  assert.equal(called.input.headSha, "abc");
+});
+
+test("replyThreadForCwd: empty threadId → error without calling the adapter", async () => {
+  let called = false;
+  const k = draftKit({
+    adapter: {
+      kind: "github",
+      listPullRequests: async () => ({ data: [OPEN_PR], stale: false }),
+      getPullRequest: async () => ({ data: { ...OPEN_PR, headSha: "abc" }, stale: false }),
+      replyToThread: async () => {
+        called = true;
+      },
+    },
+  });
+  const r = await replyThreadForCwd("/repo", { threadId: "", body: "hi" }, k);
+  assert.equal(r.ok, false);
+  assert.equal(r.error, "missing threadId");
+  assert.equal(called, false);
+});
+
+test("replyThreadForCwd: empty body → error without calling the adapter", async () => {
+  let called = false;
+  const k = draftKit({
+    adapter: {
+      kind: "github",
+      listPullRequests: async () => ({ data: [OPEN_PR], stale: false }),
+      getPullRequest: async () => ({ data: { ...OPEN_PR, headSha: "abc" }, stale: false }),
+      replyToThread: async () => {
+        called = true;
+      },
+    },
+  });
+  const r = await replyThreadForCwd("/repo", { threadId: "t1", body: "   " }, k);
+  assert.equal(r.ok, false);
+  assert.equal(r.error, "empty reply");
+  assert.equal(called, false);
 });
 
 test("draftSubmitForCwd: flushes EVERY buffered comment as ONE review with correct anchors, then clears", async () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -29,7 +29,7 @@ import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import { searchMessages } from "./messageSearch.mjs";
 import { MIN_CLIENT } from "./version.mjs";
-import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
+import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, replyThreadForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
 import { listRules as forgeListRules } from "./forgeRules.mjs";
 import { invalidateToken as invalidateForgeToken } from "./forge/auth.mjs";
 import { parseRules as parseForgeRules } from "../shared/forgeRules.mjs";
@@ -414,6 +414,11 @@ export function buildHandlers({
       ),
     "forge:draft-submit": (input) =>
       draftSubmitForCwd(
+        typeof input === "object" && input !== null ? input : "",
+        typeof input === "object" && input !== null ? input : {},
+      ),
+    "forge:thread-reply": (input) =>
+      replyThreadForCwd(
         typeof input === "object" && input !== null ? input : "",
         typeof input === "object" && input !== null ? input : {},
       ),

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -62,6 +62,8 @@ import type {
   ForgeDraftCommentResult,
   ForgeDraftSubmitInput,
   ForgeDraftSubmitResult,
+  ForgeThreadReplyInput,
+  ForgeThreadReplyResult,
   ForgeDeviceStartResult,
   ForgeDevicePollResult,
   ForgeRepoListResult,
@@ -228,6 +230,7 @@ export interface Api {
   forgeDraftGet(input: ForgeRefTarget): Promise<ForgeDraftGetResult>;
   forgeDraftComment(input: ForgeDraftCommentInput): Promise<ForgeDraftCommentResult>;
   forgeDraftSubmit(input: ForgeDraftSubmitInput): Promise<ForgeDraftSubmitResult>;
+  forgeThreadReply(input: ForgeThreadReplyInput): Promise<ForgeThreadReplyResult>;
 
   // BET-796: fresh-box clone flow (box-side only — a forge token never leaves
   // the box). deviceStart mints the GitHub device grant (RENDERER-SAFE: no

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -709,6 +709,18 @@ export type ForgeDraftSubmitResult =
   | { ok: true }
   | { ok: false; error: string; kind?: string | null };
 
+// forge:thread-reply input + result. A reply targets ONE existing incoming
+// thread and posts immediately — it is never buffered in the draft, which
+// batches new line comments only.
+export type ForgeThreadReplyInput = {
+  threadId: string;
+  body: string;
+} & ForgeRefTarget;
+
+export type ForgeThreadReplyResult =
+  | { ok: true }
+  | { ok: false; error: string };
+
 
 // ----- IPC inputs -----
 
@@ -982,6 +994,7 @@ export const IPC = {
   forgeDraftGet: "forge:draft-get",
   forgeDraftComment: "forge:draft-comment",
   forgeDraftSubmit: "forge:draft-submit",
+  forgeThreadReply: "forge:thread-reply",
 
   // BET-796: fresh-box clone flow, all box-side (a forge token never reaches
   // the renderer). forge:device-start mints the GitHub device grant (returns a


### PR DESCRIPTION
Wire the dead `replyToThread` — a colleague's review thread in the diff pane can now be answered. Closes BET-848.

**Files changed:** 8 files.
```
src/shared/types.ts                     forge:thread-reply types + channel constant
src/shared/api.ts                       forgeThreadReply in the Api contract
src/renderer/api/httpApi.ts             forgeThreadReply → /rpc
src/renderer/api/demoCoverage.test.ts   record the new unstubbed Api method
src/server/forge/index.mjs              replyThreadForCwd box handler
src/server/forge/index.test.mjs         3 replyThreadForCwd tests
src/server/rpc.mjs                      forge:thread-reply dispatch
src/renderer/ReviewPane.tsx             Reply affordance + inline reply composer
```

**Design notes (per spec, not re-litigated):**
- A reply posts immediately and is never buffered in the draft (`replyThreadForCwd` reuses `resolveDraftContext`, same as the draft channels).
- No optimistic UI: on success the pane re-fetches via the existing `forgeDiff` path so the reply arrives with the canonical read.
- Reply composer reuses the exact inline textarea markup the pane already renders for `composing` (Enter submits / Shift+Enter newline / Escape cancels; `placeholder="Reply…"`). No "Send to agent" on a reply.
- No adpater / `github.test.mjs` / `forge:diff` / draft-store changes.

**Base:** `origin/main @ 74b9da97`

**Verification results:**
- PR branch (`multica/BET-848-wire-replyToThread` @ `63509e5d`):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, 136 files passed (vitest 2615 passed / 7 skipped; server 1963 pass / 0 fail). Failures: none. log sha256: `0be090668fd311d4092a30e1445548655db185c4bdd5c6819a64203ca658eb74`
- **Conclusion:** 0 new failures. `grep -rn "replyToThread" src/` confirms a production caller (`src/server/forge/index.mjs`).

Acceptance: clicking `Reply` posts to the forge and the reply appears after the refetch (via the same `forgeDiff` reload path the pane already uses).
