### PR TITLE
BET-808: Converge hand-rolled poller wrappers onto startPoller

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -997,22 +997,7 @@ export async function tickActivity(deps) {
 }
 
 export function startActivityPoller(deps = {}, { intervalMs = ACTIVITY_INTERVAL_MS } = {}) {
-  let inFlight = false;
-  const tick = async () => {
-    if (inFlight) return;
-    inFlight = true;
-    try {
-      await tickActivity(deps);
-    } catch (e) {
-      console.warn("[delegate] activity tick failed:", e?.message ?? e);
-    } finally {
-      inFlight = false;
-    }
-  };
-  void tick();
-  const timer = setInterval(() => void tick(), intervalMs);
-  timer.unref();
-  return { stop() { clearInterval(timer); } };
+  return startPoller(() => tickActivity(deps), { intervalMs, label: "delegate-activity" });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -13,6 +13,7 @@ import { readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import http from "node:http";
 import { expandTilde, patchPath } from "../shared/paths.mjs";
+import { startPoller } from "./startPoller.mjs";
 import {
   CREDENTIALS_PATH,
   parseCredentials,
@@ -1651,12 +1652,7 @@ export function createCredentialRefreshSweep({
 
 export function startCredentialRefreshPoller({ intervalMs = CREDENTIAL_REFRESH_MS } = {}) {
   const { sweep } = createCredentialRefreshSweep();
-  // Run once immediately so a fresh server boot doesn't have to wait
-  // intervalMs to discover an already-near-expiry credential.
-  sweep();
-  const timer = setInterval(sweep, intervalMs);
-  timer.unref();
-  return { stop: () => clearInterval(timer) };
+  return startPoller(sweep, { intervalMs, label: "opencode-credentials" });
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/outbox.mjs
+++ b/src/server/outbox.mjs
@@ -19,6 +19,7 @@
 import { readdir, stat, copyFile, mkdir, rm } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { outboxRoot as defaultOutboxRoot } from "../shared/paths.mjs";
+import { startPoller } from "./startPoller.mjs";
 
 const POLL_MS = 3000;
 // Default tenure of a pushed artifact (7 days). Overridable per push via
@@ -252,13 +253,5 @@ export function startOutboxPoller(bus, { intervalMs = POLL_MS, root } = {}) {
   const outboxRoot = root ?? defaultOutboxRoot();
   const { tick } = createOutboxScanner(bus, outboxRoot);
 
-  void tick();
-  const timer = setInterval(() => void tick(), intervalMs);
-  timer.unref();
-
-  return {
-    stop() {
-      clearInterval(timer);
-    },
-  };
+  return startPoller(tick, { intervalMs, label: "outbox" });
 }

--- a/src/server/schedule.mjs
+++ b/src/server/schedule.mjs
@@ -25,6 +25,7 @@ import { randomBytes } from "node:crypto";
 import { join } from "node:path";
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { startPoller } from "./startPoller.mjs";
 
 const STORE_PATH = statePath("schedule.json");
 
@@ -479,13 +480,5 @@ export function startSchedulePoller({ sendPrompt, fireNotify, publish } = {}, { 
     publish,
   });
 
-  void tick();
-  const timer = setInterval(() => void tick(), intervalMs);
-  timer.unref();
-
-  return {
-    stop() {
-      clearInterval(timer);
-    },
-  };
+  return startPoller(tick, { intervalMs, label: "schedule" });
 }

--- a/src/server/servePage.mjs
+++ b/src/server/servePage.mjs
@@ -18,6 +18,7 @@ import { randomBytes } from "node:crypto";
 import { join, dirname } from "node:path";
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { startPoller } from "./startPoller.mjs";
 
 const STORE_PATH = statePath("serve-page.json");
 const PAGES_DIR = statePath("pages");
@@ -300,9 +301,5 @@ export function createCleanupSweep({
 
 export function startCleanupPoller({ intervalMs = CLEANUP_MS } = {}) {
   const { sweep } = createCleanupSweep();
-  // Run once immediately to clean up any leftover expired pages.
-  sweep();
-  const timer = setInterval(sweep, intervalMs);
-  timer.unref();
-  return { stop: () => clearInterval(timer) };
+  return startPoller(sweep, { intervalMs, label: "serve-page" });
 }

--- a/src/server/serverUpdate.mjs
+++ b/src/server/serverUpdate.mjs
@@ -18,6 +18,7 @@
 
 import { isUpdateAvailable } from "../shared/versionCompare.mjs";
 import { resolveBoxChannel } from "../shared/channel.mjs";
+import { startPoller } from "./startPoller.mjs";
 
 const POLL_MS = 6 * 60 * 60 * 1000; // 6h, per the stage-2 spec.
 
@@ -180,13 +181,5 @@ export function startServerUpdatePoller(
     }
   }
 
-  void runTick();
-  const timer = setInterval(() => void runTick(), POLL_MS);
-  timer.unref();
-
-  return {
-    stop() {
-      clearInterval(timer);
-    },
-  };
+  return startPoller(runTick, { intervalMs: POLL_MS, label: "server-update" });
 }

--- a/src/server/status.mjs
+++ b/src/server/status.mjs
@@ -10,6 +10,7 @@
 // countSubagents looks for Task(…) followed by ⎿  Running… within 3 lines.
 
 import { run } from "./tmux.mjs";
+import { startPoller } from "./startPoller.mjs";
 
 const POLL_MS = 2000;
 const CAPTURE_LINES = 40;
@@ -158,34 +159,10 @@ export async function collectPanes(runFn = run) {
  * @returns {{ stop: () => void }}
  */
 export function startStatusPoller(bus, { intervalMs = POLL_MS } = {}) {
-  let inFlight = false;
-
   async function tick() {
-    if (inFlight) return;
-    inFlight = true;
-    try {
-      const stdout = await collectPanes();
-      const batch = parseStatus(stdout);
-      bus.publish({ kind: "status", payload: batch });
-    } catch (e) {
-      // Defensive: collectPanes already absorbs tmux errors; this catches
-      // anything else (e.g. bus.publish throwing) without crashing the process.
-      console.warn("[status] tick failed:", e?.message ?? e);
-    } finally {
-      inFlight = false;
-    }
+    const stdout = await collectPanes();
+    const batch = parseStatus(stdout);
+    bus.publish({ kind: "status", payload: batch });
   }
-
-  // Fire one tick immediately so the sidebar fills in without waiting intervalMs.
-  void tick();
-
-  const timer = setInterval(() => void tick(), intervalMs);
-  // Don't hold the process open for the poller alone (mirrors events.mjs keep-alive).
-  timer.unref();
-
-  return {
-    stop() {
-      clearInterval(timer);
-    },
-  };
+  return startPoller(tick, { intervalMs, label: "status" });
 }

--- a/src/server/uploads.mjs
+++ b/src/server/uploads.mjs
@@ -21,6 +21,7 @@
 import { readdir, stat, rm, rmdir } from "node:fs/promises";
 import { join } from "node:path";
 import { uploadRoot as defaultUploadRoot } from "../shared/paths.mjs";
+import { startPoller } from "./startPoller.mjs";
 
 const POLL_MS = 60 * 60 * 1000; // hourly
 const HOUR_MS = 3600_000;
@@ -144,23 +145,11 @@ export function startUploadCleanupPoller({ configGet, uploadRoot, intervalMs = P
   const root = uploadRoot ?? defaultUploadRoot();
 
   async function tick() {
-    try {
-      const cfg = await configGet();
-      const hours = Number(cfg?.uploadCleanupHours ?? 24);
-      const thresholdMs = hours > 0 ? hours * HOUR_MS : 0;
-      await sweepUploads({ root, thresholdMs });
-    } catch (e) {
-      console.warn("[uploads] cleanup tick failed:", e?.message ?? e);
-    }
+    const cfg = await configGet();
+    const hours = Number(cfg?.uploadCleanupHours ?? 24);
+    const thresholdMs = hours > 0 ? hours * HOUR_MS : 0;
+    await sweepUploads({ root, thresholdMs });
   }
 
-  void tick();
-  const timer = setInterval(() => void tick(), intervalMs);
-  timer.unref();
-
-  return {
-    stop() {
-      clearInterval(timer);
-    },
-  };
+  return startPoller(tick, { intervalMs, label: "uploads" });
 }

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -66,6 +66,7 @@
  */
 
 import { normalizeWindow } from "./usageAdapters/normalizeWindow.mjs";
+import { startPoller } from "./startPoller.mjs";
 import { claudeAdapter } from "./usageAdapters/claude.mjs";
 import { codexAdapter } from "./usageAdapters/codex.mjs";
 import { kimiAdapter } from "./usageAdapters/kimi.mjs";
@@ -239,12 +240,10 @@ let activePoller = null;
 export function startUsagePoller(bus, { intervalMs = POLL_MS } = {}) {
   const poller = createUsagePoller({ publish: (evt) => bus.publish(evt) });
   activePoller = poller;
-  void poller.tick();
-  const timer = setInterval(() => void poller.tick(), intervalMs);
-  timer.unref();
+  const p = startPoller(() => poller.tick(), { intervalMs, label: "usage" });
   return {
     stop() {
-      clearInterval(timer);
+      p.stop();
       poller.stop();
       if (activePoller === poller) activePoller = null;
     },

--- a/src/server/voiceNotes.mjs
+++ b/src/server/voiceNotes.mjs
@@ -26,6 +26,7 @@ import { join, dirname } from "node:path";
 import { mkdir, writeFile, rm, readFile } from "node:fs/promises";
 import { statePath, voiceRoot } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { startPoller } from "./startPoller.mjs";
 import { transcribeAudio, filenameFor } from "../shared/groq.mjs";
 
 const STORE_PATH = statePath("voice-notes.json");
@@ -309,9 +310,6 @@ export function createVoiceSweep({
 
 export function startVoiceSweep({ intervalMs = CLEANUP_MS } = {}) {
   const { sweep } = createVoiceSweep();
-  // Run once immediately to clean up any leftover expired notes.
-  sweep();
-  const timer = setInterval(sweep, intervalMs);
-  timer.unref();
-  return { stop: () => clearInterval(timer), sweep };
+  const p = startPoller(sweep, { intervalMs, label: "voice-notes" });
+  return { stop: p.stop, sweep };
 }


### PR DESCRIPTION
Converge every hand-rolled poller wrapper onto the shared `startPoller`.

Pure code hygiene — no new behaviour, no new files, no new tests. Net **-80 lines** (28 insertions, 108 deletions across 10 files), confirming the negative-delta constraint.

Converted the ten wrappers from the ticket table:
- schedule.mjs → `startPoller(tick, {intervalMs, label:"schedule"})`
- delegate.mjs → `startPoller(() => tickActivity(deps), {intervalMs, label:"delegate-activity"})` (dropped its inline inFlight/try/catch/finally)
- outbox.mjs → `startPoller(tick, {intervalMs, label:"outbox"})`
- servePage.mjs → `startPoller(sweep, {intervalMs, label:"serve-page"})`
- status.mjs → kept `async function tick()` body, stripped inFlight/try/catch/finally
- uploads.mjs → kept `tick` body, stripped try/catch
- opencode.mjs → `startPoller(sweep, {intervalMs, label:"opencode-credentials"})`
- serverUpdate.mjs → `startPoller(runTick, {intervalMs: POLL_MS, label:"server-update"})` (runTick body untouched, incl. its notify/single-publish logic)
- usage.mjs → delegates timer to `startPoller` but keeps the extra `stop()` that also stops the inner poller + clears the `activePoller` singleton
- voiceNotes.mjs → `startPoller(sweep, {intervalMs, label:"voice-notes"})`, keeps the extra `sweep` return field

Constraints honored:
- Pure factories (`createScheduler`, `createOutboxScanner`, `createCleanupSweep`, `createCredentialRefreshSweep`, `createVoiceSweep`, `createUsagePoller`) untouched — their own inFlight guards remain (intentional double-guard per ticket).
- `src/server/index.mjs`: zero diff lines.
- `startPoller.mjs` itself: untouched.
- No tests added.
- Non-table sites left alone: `events.mjs` keep-alives, opencode.mjs SSE watchdog + `_sweep`, index.mjs `syncTimer`, the `local.mjs` git-timeout `setTimeout`, and the `outbox.mjs` socket timer.

`grep -rn "timer.unref()" src/server/*.mjs` now shows no remaining code-level site in any of the 10 converted modules (only comments, plus the unrelated non-poller sites noted above).

**Verification results:**
- typecheck: exit 0. Errors: none.
- test: exit 0, **1961 pass / 0 fail / 0 skip** (includes `serverUpdate.test.mjs`, the only suite constructing these wrappers — still green).

Base: origin/main @ 3b983268
