### PR TITLE
feat(forge): seed ship PR body from the session-linked issue (BET-827)

### DIFF
--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -799,7 +799,11 @@ export async function shipPreview(cwd, deps = {}) {
   }
 
   const title = await draftTitle(cwd, ctx.head, deps);
-  const body = await draftBody(cwd, ctx.head, base, files, deps);
+  const body = await draftBody(cwd, ctx.head, base, files, {
+    ...deps,
+    linkedIssue: deps.linkedIssue ?? null,
+    prRepoKey: forgeRepoKey(ctx.forge),
+  });
   return { ok: true, head: ctx.head, base, fileCount: files.length, title, body };
 }
 
@@ -844,19 +848,39 @@ export function humanizeBranch(branch) {
   return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
 }
 
+// `repoKey` is "host/owner/repo" (e.g. "github.com/antoinedc/MantaUI"); a forge
+// close-reference is "owner/repo#N", or bare "#N" when the issue lives in the
+// same repo as the pull request. Pure + exported for tests.
+export function issueCloseRef(issue, prRepoKey) {
+  if (!issue?.repoKey || !Number.isInteger(issue.number)) return "";
+  if (issue.repoKey === prRepoKey) return `#${issue.number}`;
+  const [, owner, repo] = String(issue.repoKey).split("/");
+  return owner && repo ? `${owner}/${repo}#${issue.number}` : "";
+}
+
 // Body draft: the repo's PR template when one exists (honouring step-1's
 // "honouring the repo's PR template"), else a short changed-files summary.
-// Template `${head}` / `${base}` placeholders, if present, are filled.
+// Template `${head}` / `${base}` placeholders, if present, are filled. When
+// `deps.linkedIssue` (an async fn returning `{ repoKey, number } | null`)
+// resolves a ref, ONE "Closes <ref>" line plus a blank line is prepended to
+// whichever body branch runs — `deps.prRepoKey` decides the bare/suffixed ref.
+// With no ref (or no dep) the output is byte-identical to today.
 async function draftBody(cwd, head, base, files, deps) {
   const readPrTemplate = deps.readPrTemplate ?? defaultReadPrTemplate;
+  let issueRef = "";
+  if (deps.linkedIssue) {
+    const issue = await deps.linkedIssue();
+    issueRef = issueCloseRef(issue, deps.prRepoKey);
+  }
+  const preamble = issueRef ? `Closes ${issueRef}\n\n` : "";
   const template = await readPrTemplate(cwd, deps);
   if (template && template.trim()) {
-    return template
+    return preamble + template
       .replace(/\$\{head\}/g, head || "")
       .replace(/\$\{base\}/g, base || "");
   }
-  if (files.length === 0) return "";
-  return `## What\n\nOpens ${head} → ${base}.\n\n## Changed files\n\n${files.map((f) => `- ${f}`).join("\n")}`;
+  if (files.length === 0) return preamble;
+  return preamble + `## What\n\nOpens ${head} → ${base}.\n\n## Changed files\n\n${files.map((f) => `- ${f}`).join("\n")}`;
 }
 
 // Find + read the repo's PR template, best-first from the candidates list.

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -14,6 +14,7 @@ import {
   forgeDiffForCwd,
   shipPullRequest,
   shipPreview,
+  issueCloseRef,
   humanizeBranch,
   mergePullRequest,
   draftGetForCwd,
@@ -419,6 +420,68 @@ test("shipPreview: repo with no forge → no_forge", async () => {
     gitRemoteOrigin: async () => null,
   });
   assert.deepEqual(r, { ok: false, error: "no_forge" });
+});
+
+// ---- issueCloseRef + the linked-issue PR body seed (BET-827) ----------------
+
+test("issueCloseRef: bare #N when the issue lives in the PR's own repo", () => {
+  assert.equal(issueCloseRef({ repoKey: "github.com/acme/widget", number: 12 }, "github.com/acme/widget"), "#12");
+});
+
+test("issueCloseRef: owner/repo#N for a cross-repo issue", () => {
+  assert.equal(issueCloseRef({ repoKey: "github.com/acme/something", number: 12 }, "github.com/acme/widget"), "acme/something#12");
+});
+
+test("issueCloseRef: \"\" for malformed or missing refs", () => {
+  assert.equal(issueCloseRef(null, "github.com/acme/widget"), "");
+  assert.equal(issueCloseRef(undefined, "github.com/acme/widget"), "");
+  assert.equal(issueCloseRef({}, "github.com/acme/widget"), "");
+  assert.equal(issueCloseRef({ repoKey: "x", number: 12 }, "github.com/acme/widget"), "");
+  assert.equal(issueCloseRef({ repoKey: "github.com/acme/widget" }, "github.com/acme/widget"), "");
+});
+
+test("shipPreview prepends Closes #N before the template when the session has a linked issue", async () => {
+  const r = await shipPreview("/repo", {
+    ...SHIP_DEPS,
+    currentBranch: async () => "feat/forge-seam",
+    readPrTemplate: async () => "## Summary\n\n${head} → ${base}\n\n## Checklist\n- [x] tests",
+    linkedIssue: async () => ({ repoKey: "github.com/acme/widget", number: 12 }),
+  });
+  assert.equal(r.ok, true);
+  assert.match(r.body, /^Closes #12\n\n## Summary/, "close line + blank line precede the template");
+});
+
+test("shipPreview uses a cross-repo owner/repo#N close ref", async () => {
+  const r = await shipPreview("/repo", {
+    ...SHIP_DEPS,
+    currentBranch: async () => "feat/forge-seam",
+    readPrTemplate: async () => "## Summary\n\nbody",
+    linkedIssue: async () => ({ repoKey: "github.com/acme/something", number: 12 }),
+  });
+  assert.equal(r.ok, true);
+  assert.match(r.body, /^Closes acme\/something#12\n\n## Summary/);
+});
+
+test("shipPreview with a linked issue and no template still emits the close line", async () => {
+  const r = await shipPreview("/repo", {
+    ...SHIP_DEPS,
+    currentBranch: async () => "feat/forge-seam",
+    readPrTemplate: async () => null,
+    linkedIssue: async () => ({ repoKey: "github.com/acme/widget", number: 7 }),
+  });
+  assert.equal(r.ok, true);
+  assert.match(r.body, /^Closes #7\n\n/);
+});
+
+test("shipPreview with no linkedIssue dep leaves the body unchanged from today", async () => {
+  const r = await shipPreview("/repo", {
+    ...SHIP_DEPS,
+    currentBranch: async () => "feat/forge-seam",
+    readPrTemplate: async () => "## Summary\n\nbody without a close line",
+  });
+  assert.equal(r.ok, true);
+  assert.match(r.body, /^## Summary/);
+  assert.ok(!r.body.includes("Closes"), "no linkedIssue dep ⇒ no Closes line");
 });
 
 

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -279,6 +279,17 @@ const SHIP_DEPS = {
   gitPush: async (input) => ({ input }),
 };
 
+// ShipPreview deps for the BET-827 linked-issue cases — the common base (a fixed
+// branch) plus per-case overrides. Shared so the cases don't each re-type the
+// SHIP_DEPS + currentBranch preamble.
+function linkedShipDeps(overrides = {}) {
+  return {
+    ...SHIP_DEPS,
+    currentBranch: async () => "feat/forge-seam",
+    ...overrides,
+  };
+}
+
 test("shipPullRequest: no forge → no_forge, never pushes", async () => {
   const pushed = [];
   const r = await shipPullRequest("/repo", { title: "t" }, {
@@ -441,44 +452,36 @@ test("issueCloseRef: \"\" for malformed or missing refs", () => {
 });
 
 test("shipPreview prepends Closes #N before the template when the session has a linked issue", async () => {
-  const r = await shipPreview("/repo", {
-    ...SHIP_DEPS,
-    currentBranch: async () => "feat/forge-seam",
+  const r = await shipPreview("/repo", linkedShipDeps({
     readPrTemplate: async () => "## Summary\n\n${head} → ${base}\n\n## Checklist\n- [x] tests",
     linkedIssue: async () => ({ repoKey: "github.com/acme/widget", number: 12 }),
-  });
+  }));
   assert.equal(r.ok, true);
   assert.match(r.body, /^Closes #12\n\n## Summary/, "close line + blank line precede the template");
 });
 
 test("shipPreview uses a cross-repo owner/repo#N close ref", async () => {
-  const r = await shipPreview("/repo", {
-    ...SHIP_DEPS,
-    currentBranch: async () => "feat/forge-seam",
+  const r = await shipPreview("/repo", linkedShipDeps({
     readPrTemplate: async () => "## Summary\n\nbody",
     linkedIssue: async () => ({ repoKey: "github.com/acme/something", number: 12 }),
-  });
+  }));
   assert.equal(r.ok, true);
   assert.match(r.body, /^Closes acme\/something#12\n\n## Summary/);
 });
 
 test("shipPreview with a linked issue and no template still emits the close line", async () => {
-  const r = await shipPreview("/repo", {
-    ...SHIP_DEPS,
-    currentBranch: async () => "feat/forge-seam",
+  const r = await shipPreview("/repo", linkedShipDeps({
     readPrTemplate: async () => null,
     linkedIssue: async () => ({ repoKey: "github.com/acme/widget", number: 7 }),
-  });
+  }));
   assert.equal(r.ok, true);
   assert.match(r.body, /^Closes #7\n\n/);
 });
 
 test("shipPreview with no linkedIssue dep leaves the body unchanged from today", async () => {
-  const r = await shipPreview("/repo", {
-    ...SHIP_DEPS,
-    currentBranch: async () => "feat/forge-seam",
+  const r = await shipPreview("/repo", linkedShipDeps({
     readPrTemplate: async () => "## Summary\n\nbody without a close line",
-  });
+  }));
   assert.equal(r.ok, true);
   assert.match(r.body, /^## Summary/);
   assert.ok(!r.body.includes("Closes"), "no linkedIssue dep ⇒ no Closes line");
@@ -642,6 +645,24 @@ async function addComments(k, comments) {
   }
 }
 
+// A draftKit whose adapter reports whether replyToThread was ever invoked —
+// shared by the replyThreadForCwd no-call cases so the two don't repeat the
+// adapter fixture. `called()` is queried AFTER the call under test.
+function replyKit() {
+  let called = false;
+  const k = draftKit({
+    adapter: {
+      kind: "github",
+      listPullRequests: async () => ({ data: [OPEN_PR], stale: false }),
+      getPullRequest: async () => ({ data: { ...OPEN_PR, headSha: "abc" }, stale: false }),
+      replyToThread: async () => {
+        called = true;
+      },
+    },
+  });
+  return { k, called: () => called };
+}
+
 const DRAFT_REPO_KEY = "github.com/acme/widget";
 
 test("draftGetForCwd: head SHA moved → draft marked stale, comments kept", async () => {
@@ -702,39 +723,19 @@ test("replyThreadForCwd: posts immediately with the resolved repo, PR number and
 });
 
 test("replyThreadForCwd: empty threadId → error without calling the adapter", async () => {
-  let called = false;
-  const k = draftKit({
-    adapter: {
-      kind: "github",
-      listPullRequests: async () => ({ data: [OPEN_PR], stale: false }),
-      getPullRequest: async () => ({ data: { ...OPEN_PR, headSha: "abc" }, stale: false }),
-      replyToThread: async () => {
-        called = true;
-      },
-    },
-  });
+  const { k, called } = replyKit();
   const r = await replyThreadForCwd("/repo", { threadId: "", body: "hi" }, k);
   assert.equal(r.ok, false);
   assert.equal(r.error, "missing threadId");
-  assert.equal(called, false);
+  assert.equal(called(), false);
 });
 
 test("replyThreadForCwd: empty body → error without calling the adapter", async () => {
-  let called = false;
-  const k = draftKit({
-    adapter: {
-      kind: "github",
-      listPullRequests: async () => ({ data: [OPEN_PR], stale: false }),
-      getPullRequest: async () => ({ data: { ...OPEN_PR, headSha: "abc" }, stale: false }),
-      replyToThread: async () => {
-        called = true;
-      },
-    },
-  });
+  const { k, called } = replyKit();
   const r = await replyThreadForCwd("/repo", { threadId: "t1", body: "   " }, k);
   assert.equal(r.ok, false);
   assert.equal(r.error, "empty reply");
-  assert.equal(called, false);
+  assert.equal(called(), false);
 });
 
 test("draftSubmitForCwd: flushes EVERY buffered comment as ONE review with correct anchors, then clears", async () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -392,8 +392,20 @@ export function buildHandlers({
       );
       return res;
     },
-    "forge:ship-preview": (input) =>
-      shipPreview(typeof input === "object" && input !== null ? input.cwd : ""),
+    "forge:ship-preview": (input) => {
+      const cwd = typeof input === "object" && input !== null ? input.cwd : "";
+      // Seed the PR body with a "Closes #N" line from the session-linked issue
+      // (BET-827): reuse the same projectNameForCwd + sessionLinkGet pair the
+      // forge:ship onPrOpened handler uses — no second session-link reader.
+      return shipPreview(cwd, {
+        linkedIssue: async () => {
+          const name = cwd ? await projectNameForCwd(cwd) : null;
+          if (!name) return null;
+          const link = await local.sessionLinkGet(name);
+          return link?.issue ?? null;
+        },
+      });
+    },
     "forge:merge": (input) =>
       mergePullRequest(
         typeof input === "object" && input !== null ? input.cwd : "",


### PR DESCRIPTION
Seeds the ship preview PR body with a "Closes #N" line from the session-linked issue.

**Scope (BET-827).** Two files plus tests — the only unmet half of the ship body
draft was the linked issue (title + template drafting already shipped in
`shipPreview`). No new tool, no pending-ship store, no renderer change.

- `src/server/forge/index.mjs`: new pure exported `issueCloseRef` (`#N` for a
  same-repo issue, `owner/repo#N` cross-repo, `""` for malformed). `draftBody`
  accepts an optional `deps.linkedIssue` async fn; when it resolves a ref, ONE
  `Closes <ref>` line + blank line is prepended to whichever body branch runs.
  `shipPreview` forwards the dep and passes the PR's own repo key
  (`forgeRepoKey(ctx.forge)`) as `prRepoKey`. With no link / no dep the output
  is byte-identical to today.
- `src/server/rpc.mjs`: `forge:ship-preview` wires `linkedIssue` via the SAME
  `projectNameForCwd` + `sessionLinkGet` pair the `forge:ship` onPrOpened handler
  uses — no second session-link reader.

**Tests** (`src/server/forge/index.test.mjs`): `issueCloseRef` unit cases
(same/cross-repo/malformed); `shipPreview` with a `linkedIssue` dep prepends the
close line before the template and in the no-template case; no-dep case leaves
the body unchanged. Existing ship tests untouched.

**Files changed:** 3. `src/server/forge/index.mjs`, `src/server/forge/index.test.mjs`, `src/server/rpc.mjs`.

**Verification results:**
- PR branch (`multica/BET-827-ship-preview-linked-issue` @ `b933dc81`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1971 pass / 0 fail / 0 skip (unchanged count vs main — no regressions).
- **Conclusion:** 0 new test failures; no pre-existing failures.
- `Base: origin/main @ 7c33ee73`
