### PR TITLE
fix(app-control): whole-word model matching, provider/model form, rename sidebar refresh (BET-862)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -2330,6 +2330,13 @@ const handleRequest = async (req, res) => {
         const body = await readJsonBody(req);
         const deps = { publish: (payload) => bus.publish({ kind: "appControl", payload }) };
         const result = await appControl.dispatch(body?.action, body || {}, deps);
+        // Rename mutates the tmux window list; re-materialize sync state so the
+        // `sync` delta publishes now (parity with the tmux:rename-window RPC,
+        // which already refreshes). Without this the sidebar lags until the 2s
+        // poller. Only on success, only for the mutating action.
+        if (result?.ok && body?.action === "rename-session") {
+          await syncState.refreshNow();
+        }
         respondJson(res, result.ok ? 200 : 400, result);
         return;
       }

--- a/src/shared/modelGuide.mjs
+++ b/src/shared/modelGuide.mjs
@@ -252,17 +252,46 @@ export function familyKey(modelID) {
 /**
  * Match a fuzzy model query against a list of models. Exact id wins, then
  * every token present in the id, then every token present in the name, then a
- * providerID prefix.
- *
- * @param {string|null|undefined} query
- * @param {Array<{id?: string, name?: string, providerID?: string}>} models
- * @returns {object|null} the resolved model, or null when nothing matches.
- */
+  * providerID prefix.
+  *
+  * @param {string|null|undefined} query
+  * @param {Array<{id?: string, name?: string, providerID?: string}>} models
+  * @returns {object|null} the resolved model, or null when nothing matches.
+  */
+
+// Split an id/name into lowercase alphanumeric tokens on any non-alphanumeric
+// boundary. "claude-opus-4-5" -> ["claude","opus","4","5"];
+// "claude-opus-5" -> ["claude","opus","5"]. Used so a query token like "5"
+// matches a standalone "5" segment, not the "5" inside "4-5".
+function idWords(s) {
+  return String(s ?? "")
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter(Boolean);
+}
+
 export function fuzzyMatchModel(query, models) {
   const list = Array.isArray(models) ? models : [];
   if (!query || !list.length) return null;
   const q = String(query).toLowerCase().trim();
   if (!q) return null;
+
+  // Accept an explicit "providerID/modelID" form by matching the model part
+  // scoped to that provider, then reuse the normal matcher for the rest.
+  const slash = q.indexOf("/");
+  if (slash > 0 && slash < q.length - 1) {
+    const prov = q.slice(0, slash);
+    const rest = q.slice(slash + 1);
+    const scoped = list.filter(
+      (m) => String(m?.providerID ?? "").toLowerCase() === prov,
+    );
+    // Recurse on the provider-scoped list with the model part only.
+    const hit = fuzzyMatchModel(rest, scoped);
+    if (hit) return hit;
+    // Fall through: if the provider/model didn't resolve, try the whole
+    // string against the normal path (handles ids that legitimately
+    // contain a slash, if any ever exist).
+  }
 
   const direct = list.find((m) => String(m?.id ?? "").toLowerCase() === q);
   if (direct) return direct;
@@ -270,14 +299,27 @@ export function fuzzyMatchModel(query, models) {
   const tokens = q.split(/\s+/).filter(Boolean);
   if (tokens.length === 0) return null;
 
-  for (const m of list) {
-    const id = String(m?.id ?? "").toLowerCase();
-    if (tokens.every((t) => id.includes(t))) return m;
-  }
-  for (const m of list) {
-    const name = String(m?.name ?? "").toLowerCase();
-    if (tokens.every((t) => name.includes(t))) return m;
-  }
+  const pickFewestWords = (candidates) => {
+    if (candidates.length === 0) return null;
+    return candidates.reduce((best, m) =>
+      idWords(m?.id).length < idWords(best?.id).length ? m : best,
+    );
+  };
+
+  const byId = list.filter((m) => {
+    const words = new Set(idWords(m?.id));
+    return tokens.every((t) => words.has(t));
+  });
+  const idHit = pickFewestWords(byId);
+  if (idHit) return idHit;
+
+  const byName = list.filter((m) => {
+    const words = new Set(idWords(m?.name));
+    return tokens.every((t) => words.has(t));
+  });
+  const nameHit = pickFewestWords(byName);
+  if (nameHit) return nameHit;
+
   for (const m of list) {
     if (tokens[0] === String(m?.providerID ?? "").toLowerCase()) return m;
   }

--- a/src/shared/modelGuide.test.ts
+++ b/src/shared/modelGuide.test.ts
@@ -205,8 +205,11 @@ const MODELS = [
   { providerID: "anthropic", id: "claude-haiku-4", name: "Claude Haiku 4" },
   { providerID: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
   { providerID: "anthropic", id: "claude-opus-4-7", name: "Claude Opus 4.7" },
+  { providerID: "anthropic", id: "claude-opus-4-5", name: "Claude Opus 4.5" },
+  { providerID: "anthropic", id: "claude-opus-5", name: "Claude Opus 5" },
   { providerID: "openai", id: "gpt-4o", name: "GPT-4o" },
   { providerID: "openai", id: "gpt-4o-mini", name: "GPT-4o mini" },
+  { providerID: "voska", id: "default", name: "Voska Default" },
 ];
 
 describe("fuzzyMatchModel", () => {
@@ -214,8 +217,17 @@ describe("fuzzyMatchModel", () => {
     expect(fuzzyMatchModel("claude-opus-4-7", MODELS)?.id).toBe("claude-opus-4-7");
   });
 
-  it("matches every token against a model id (queries like \"opus\")", () => {
-    expect(fuzzyMatchModel("opus", MODELS)?.id).toBe("claude-opus-4-7");
+  it("matches the fewest-word id for a single-token family query (\"opus\")", () => {
+    expect(fuzzyMatchModel("opus", MODELS)?.id).toBe("claude-opus-5");
+  });
+
+  it("prefers the exact-word model over a longer id (\"opus 5\")", () => {
+    expect(fuzzyMatchModel("opus 5", MODELS)?.id).toBe("claude-opus-5");
+  });
+
+  it("still matches a single-token family query to the fewest-word id", () => {
+    // "opus" appears in several ids; fewest-word wins deterministically.
+    expect(fuzzyMatchModel("opus", MODELS)?.id).toBeDefined();
   });
 
   it("matches a multi-word query against a model name (\"gpt 4o mini\")", () => {
@@ -228,6 +240,15 @@ describe("fuzzyMatchModel", () => {
 
   it("falls back to a providerID match for a bare provider name", () => {
     expect(fuzzyMatchModel("openai", MODELS)?.providerID).toBe("openai");
+  });
+
+  it("resolves an explicit providerID/modelID form", () => {
+    expect(fuzzyMatchModel("voska/default", MODELS)?.id).toBe("default");
+    expect(fuzzyMatchModel("voska/default", MODELS)?.providerID).toBe("voska");
+  });
+
+  it("resolves providerID/family form via the reused matcher", () => {
+    expect(fuzzyMatchModel("anthropic/opus 5", MODELS)?.id).toBe("claude-opus-5");
   });
 
   it("returns null for no match or empty input", () => {


### PR DESCRIPTION
**Files changed:** 3 files (`src/shared/modelGuide.mjs`, `src/shared/modelGuide.test.ts`, `src/server/index.mjs`).

**Base:** origin/main @ `4c8b7c17`

Implements exactly the three specified BET-862 fixes; no design decisions, no scope creep.

## Bug 1 — `manta_switch_model` picked the wrong model for "opus 5"
`src/shared/modelGuide.mjs`: added the `idWords` helper and switched the id/name token loops in `fuzzyMatchModel` from substring (`.includes`) to whole-word matching with fewest-words tie-breaking. "opus 5" now resolves to `claude-opus-5` (3 words) over `claude-opus-4-5` (4 words). Kept the exact-id short-circuit and providerID fallback exactly as-is. Verified "gpt 4o mini" still matches `gpt-4o-mini`.

## Bug 2 — provider/model form rejected
`fuzzyMatchModel`: added the `providerID/modelID` slash split at the top of the function that scopes to the provider and recurses through the same matcher. `voska/default` and `anthropic/opus 5` now resolve.

## Bug 3 — rename didn't refresh the sidebar
`src/server/index.mjs` (`/api/app-control` handler): after a successful `rename-session` dispatch, call the module-level `syncState.refreshNow()` so the `sync` delta publishes immediately (parity with the `tmux:rename-window` RPC). `appControl.mjs` and `App.tsx` untouched, exactly per the issue's guardrails. The appControl rename test already asserts `{ok:true,name}` + bus publish — left as-is.

## Verification results
- PR branch (`multica/BET-862-app-control-fixes` @ `3544bc98`):
  - typecheck: exit 0. Errors: none. log sha256: `d1915bed49d879f4563af2d7695447aac9be4047d1c0927326f7bce49a3822e8`
  - test: exit 0, vitest 2619 pass / 0 fail / 7 skip, node 1971 pass / 0 fail / 0 skip. Failures: none. log sha256: `f15f2805e308823c6a1182a0b663857e389737202175e068a33a1fb3d69b51cb`
- Base (`main` @ `4c8b7c17`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0, vitest 2615 pass / 0 fail / 7 skip, node 1971 pass / 0 fail / 0 skip. Failures: none. log sha256: `ed7842350bf5840ff70b16410f3e30de62a68aca868f35ef4ad6ac056d84a5a1`
- **Conclusion:** 0 new failures, 0 pre-existing failures. PR adds 4 new tests (the new modelGuide regression cases). All existing tests pass unchanged except the single `"opus"` expectation, which was intentionally updated per the issue's specified behavior change (fewest-words winner is now `claude-opus-5`).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
