### PR TITLE
chore(release): 0.0.25 — ship app-control tools to boxes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.24",
+      "version": "0.0.25",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.24",
+  "version": "0.0.25",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.24",
+ "version": "0.0.25",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Bumps 0.0.24 → 0.0.25 to publish the app-control tools (`manta_switch_model`, `manta_rename_session`, `manta_compact_session`, `manta_list_sessions`) to installed boxes.

## Why
0.0.24 was built before app-control landed on main, so no released box carries the AI-facing tool *or* its server endpoint. Verified: the live 0.0.24 tarball (server-v18) contains neither `docs/opencode-tools/manta-app.ts` nor `src/server/appControl.mjs`.

## Changes
Standard release bump — three files, four lines (mirrors the 0.0.24 release commit 8600643):
- `package.json` / `package-lock.json`: 0.0.24 → 0.0.25
- `website/updates/server.json`: 0.0.24 → 0.0.25 (the update pointer a running box polls every 6h)

## After merge
Two tags, one at a time:
1. `server-v19` → builds + publishes the 0.0.25 tarballs (x64/arm64/darwin-arm64)
2. `web-v<n>` → deploys the updated `server.json` so boxes are actually offered the update

Then install.sh / self-update copy the tool into `~/.config/opencode/tools/` and append the AGENTS.md guidance automatically.