### PR TITLE
feat(ios): context strip, usage dot, two meter sheets (BET-824)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -137,6 +137,9 @@ private struct ChatScreenContent: View {
     /// the chat surface's window into the same settings the Settings screen
     /// renders — no second `config:get`.
     @StateObject private var settingsStore: MantaSettingsStore
+    /// The plan-usage snapshot set (BET-824), polled every 60s while the chat
+    /// is open. Feeds the composer dot, the usage sheet and the weekly banner.
+    @StateObject private var usageStore: UsageStore
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.scenePhase) private var scenePhase
@@ -144,6 +147,14 @@ private struct ChatScreenContent: View {
     @State private var showOverflow = false
     /// Presents the title menu's "Session info" summary.
     @State private var showingSessionInfo = false
+    /// Context sheet — opened by tapping the context strip.
+    @State private var showContextSheet = false
+    /// Usage sheet — opened by tapping the composer's usage dot, or the weekly
+    /// banner's Details.
+    @State private var showUsageSheet = false
+    /// One-per-session gate for the weekly ≥ 90% warning banner. Resets when
+    /// the session changes (ChatScreenContent is rebuilt on a clear via `.id`).
+    @State private var weeklyBannerShown = false
     @State private var branch: String?
     /// The session's working directory relative to the project root, shown
     /// alongside the branch capsule (BET-747).
@@ -212,6 +223,7 @@ private struct ChatScreenContent: View {
         ))
         _modelStore = StateObject(wrappedValue: ChatModelStore(sessionId: sessionId, api: api))
         _settingsStore = StateObject(wrappedValue: MantaSettingsStore())
+        _usageStore = StateObject(wrappedValue: UsageStore(api: api))
     }
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
@@ -259,6 +271,7 @@ private struct ChatScreenContent: View {
                 store.start()
                 modelStore.load()
                 Task { await settingsStore.load() }
+                usageStore.start()
                 MantaPushRouter.shared.visibleSessionID = store.sessionId
                 Task { try? await MantaAPIClient.live().reportFocus(sessionId: store.sessionId, visible: true) }
                 clearDeliveredNotifications(for: store.sessionId)
@@ -266,6 +279,7 @@ private struct ChatScreenContent: View {
             }
             .onDisappear {
                 store.stop()
+                usageStore.stop()
                 MantaPushRouter.shared.visibleSessionID = nil
                 Task { try? await MantaAPIClient.live().reportFocus(sessionId: nil, visible: false) }
             }
@@ -396,6 +410,8 @@ private struct ChatScreenContent: View {
                         api: MantaAPIClient.live(),
                         store: store,
                         modelStore: modelStore,
+                        usageStore: usageStore,
+                        onShowUsage: { showUsageSheet = true },
                         showScrollToBottom: showScrollToBottom,
                         onScrollToBottom: {
                             scrollPosition.scrollTo(edge: .bottom, animated: true)
@@ -450,6 +466,14 @@ private struct ChatScreenContent: View {
         .sheet(isPresented: $showOverflow) { overflowSheet }
         .sheet(item: $overflowDestination) { destination in
             destinationCard(destination)
+        }
+        // BET-824 — each meter opens the sheet for what it represents: the
+        // strip opens context, the dot opens the plan.
+        .sheet(isPresented: $showContextSheet) {
+            contextSheet
+        }
+        .sheet(isPresented: $showUsageSheet) {
+            usageSheet
         }
     }
 
@@ -778,6 +802,16 @@ private struct ChatScreenContent: View {
         .onChange(of: store.rows, initial: true) { _, rows in
             dataSource.apply(rows)
         }
+        // Context meter (BET-824): a strip mounted directly under the
+        // navigation bar. `safeAreaBar(edge: .top)` insets the scroll view's
+        // safe area AND extends the scroll-edge effect, so the transcript
+        // scrolls correctly beneath it — no toolbar item, no hand-rolled
+        // overlay. The strip is absent entirely below 70% (no reserved height,
+        // so appearing costs no layout shift); it animates in above the
+        // transcript.
+        .safeAreaBar(edge: .top) {
+            contextStrip
+        }
         // A tap on the transcript lowers the keyboard. (TiledView handles the
         // scroll-driven interactive keyboard dismiss itself.)
         .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
@@ -803,11 +837,184 @@ private struct ChatScreenContent: View {
     // 3). It is ALSO the harness scene `ChatLoadingScene` (MantaAppRoot) that
     // the capture fixture drives, so fixture and live screen share one view.
 
+    // MARK: - Context meter (BET-824)
+
+    /// The context reading from the live stream payload: `.known` with a real
+    /// percentage, `.unknown` when the box has none (nil early in a session,
+    /// and again after a compaction). Never renders 0% for "don't know".
+    private var contextMeterReading: MeterReading {
+        guard let ctx = store.context, ctx.pct.isFinite else { return .unknown }
+        return .known(pct: ctx.pct)
+    }
+
+    /// The active model's own context window — the meter's denominator. Opus
+    /// 4.7 reports 1M against Sonnet's 200k, so it is read per-model, never
+    /// hardcoded.
+    private var activeModelContextLimit: Double? {
+        guard let model = ChatModel.activeModel(modelStore.models,
+                                                override: modelStore.override,
+                                                default: modelStore.defaultModel) else { return nil }
+        return model.limit?.context
+    }
+
+    private var activeModelName: String {
+        ChatModel.label(modelStore.models, override: modelStore.override, default: modelStore.defaultModel)
+    }
+
+    /// The desktop's `alwaysShowUsage`, honoured on iOS: when true the strip
+    /// stays open below 70%. Read through the existing settings store — no new
+    /// config channel.
+    private var alwaysShowUsage: Bool {
+        guard let entry = SettingsSchema.entries.first(where: { $0.id == "alwaysShowUsage" }),
+              case .bool(let on) = settingsStore.current(entry) else { return false }
+        return on
+    }
+
+    private var contextStripVisible: Bool {
+        UsageMeters.contextStripVisible(contextMeterReading, alwaysShow: alwaysShowUsage)
+    }
+
+    /// The band colour for the current context reading (strip + sheet).
+    private var contextBandColor: Color {
+        if case .known(let pct) = contextMeterReading {
+            return MeterRing.tint(UsageMeters.band(pct), tokens)
+        }
+        return tokens.tx4
+    }
+
+    /// Full-width, one-tap strip directly under the navigation bar: the word
+    /// "Context", a linear meter filling the remaining width, the percentage,
+    /// a chevron. Absent below 70% (no reserved height, no layout shift) and
+    /// animates in above the transcript via `safeAreaBar`. A `Gauge`, not a
+    /// `ProgressView` — the HIG treats progress indicators as transient, and
+    /// this one never disappears (until it genuinely drops), so it reads as a
+    /// persistent meter and VoiceOver announces it so.
+    @ViewBuilder
+    private var contextStrip: some View {
+        if contextStripVisible, case .known(let pct) = contextMeterReading {
+            Button { showContextSheet = true } label: {
+                HStack(spacing: Metrics.spacing.sp2) {
+                    Text("Context")
+                        .font(.manta(size: Metrics.type.twoXS, weight: .semibold))
+                        .foregroundColor(tokens.tx4)
+                    Gauge(value: pct, in: 0...100) { EmptyView() }
+                        .gaugeStyle(.accessoryLinearCapacity)
+                        .tint(contextBandColor)
+                        .frame(maxWidth: .infinity, maxHeight: 4)
+                    Text("\(Int(pct.rounded()))%")
+                        .font(.manta(size: Metrics.type.twoXS, weight: .bold))
+                        .foregroundColor(contextBandColor)
+                    Image(systemName: "chevron.right")
+                        .font(.system(size: Metrics.type.twoXS, weight: .semibold))
+                        .foregroundColor(tokens.tx4)
+                }
+                .frame(height: 24)
+                .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Context \(Int(pct.rounded())) percent")
+            .accessibilityIdentifier("context-strip")
+            // Context legitimately drops after a compaction; animate that drop
+            // rather than snapping it, or it reads as a glitch.
+            .animation(.easeInOut(duration: 0.4), value: pct)
+        }
+    }
+
+    @ViewBuilder
+    private var contextSheet: some View {
+        // The strip only shows for a known reading, but the context can go
+        // unknown in the window between the tap and the sheet presenting —
+        // never fabricate a 0% sheet for "we don't know".
+        if let ctx = store.context {
+            ContextSheet(
+                context: ctx,
+                cache: store.cache,
+                limit: activeModelContextLimit,
+                modelName: activeModelName,
+                bandColor: contextBandColor,
+                tokens: tokens,
+                onCompact: { store.compact() },
+                onClear: { Task { await clearSession() } }
+            )
+        } else {
+            Color.clear
+        }
+    }
+
+    private var usageSheet: some View {
+        UsageSheet(snapshots: usageStore.snapshots, lastFetch: usageStore.lastFetch, tokens: tokens)
+    }
+
+    /// Whether the one-per-session weekly warning banner should render.
+    private var weeklyBannerVisible: Bool {
+        UsageMeters.shouldShowWeeklyBanner(
+            UsageMeters.weeklyWindow(usageStore.snapshots),
+            alreadyShown: weeklyBannerShown
+        )
+    }
+
+    /// The pinned dismissible card shown once per session when the weekly sits
+    /// at/over 90%. "Details" opens the usage sheet; the × dismisses (and
+    /// stays dismissed this session).
+    private var weeklyBanner: some View {
+        let weekly = UsageMeters.weeklyWindow(usageStore.snapshots)
+        return HStack(spacing: Metrics.spacing.sp2) {
+            MeterRing(color: tokens.danger, diameter: 14, lineWidth: 2.5)
+            VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+                Text("Weekly limit \(Int((weekly?.pct ?? 0).rounded()))%")
+                    .font(.manta(size: Metrics.type.xs, weight: .semibold))
+                    .foregroundColor(tokens.danger)
+                if let resetsAt = weekly?.resetsAt {
+                    Text("Resets \(UsageMeters.formatReset(Date(timeIntervalSince1970: resetsAt / 1000), now: Date()))")
+                        .font(.manta(size: Metrics.type.twoXS))
+                        .foregroundColor(tokens.tx4)
+                }
+            }
+            Spacer(minLength: 0)
+            Button { showUsageSheet = true } label: {
+                Text("Details")
+                    .font(.manta(size: Metrics.type.xs, weight: .semibold))
+                    .foregroundColor(tokens.accentTx)
+                    .padding(.horizontal, Metrics.spacing.sp2)
+                    .padding(.vertical, Metrics.spacing.sp1)
+                    .background(tokens.accentSoft, in: Capsule())
+            }
+            .buttonStyle(.plain)
+            Button { weeklyBannerShown = true } label: {
+                Image(systemName: "xmark")
+                    .font(.system(size: Metrics.type.xs, weight: .semibold))
+                    .foregroundColor(tokens.tx4)
+                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                    .contentShape(Rectangle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Dismiss")
+        }
+        .padding(.leading, Metrics.spacing.sp3)
+        .padding(.trailing, Metrics.spacing.sp2)
+        .padding(.vertical, Metrics.spacing.sp2)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("weekly-banner")
+    }
+
     // MARK: - Live cards (todos / permission / question)
 
     @ViewBuilder
     private var bottomCards: some View {
         VStack(spacing: Metrics.spacing.sp3) {
+            // Weekly-limit banner (BET-824): one pinned dismissible card, once
+            // per session, when the weekly window is at/over 90%. The dot
+            // tracks the 5-hour window, so it can read green while the weekly
+            // is nearly spent — this banner is the only thing between a green
+            // dot and a multi-day lockout the user did not see coming.
+            if weeklyBannerVisible {
+                weeklyBanner
+            }
             // Only things that BLOCK the turn and need a tap stay here. Live
             // running tools now render INSIDE the transcript (in the turn that
             // spawned them); sessionError / truncation / queued prompts moved

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -42,6 +42,14 @@ struct ComposerView: View {
     let api: MantaAPIClient
     @ObservedObject var store: ChatSessionStore
     @ObservedObject var modelStore: ChatModelStore
+    /// The plan-usage snapshot set (BET-824). The composer's band-coloured dot
+    /// reads the 5-hour session window from it; the ring is the dot's only
+    /// content — no percentage, no label.
+    @ObservedObject var usageStore: UsageStore
+    /// Tapped → the parent presents the usage sheet. Presented from the parent
+    /// (not here) because ComposerView already presents the model sheet, and
+    /// SwiftUI honours only one presentation per view on some versions.
+    var onShowUsage: (() -> Void)? = nil
     /// Whether the transcript is scrolled up far enough that the round
     /// "scroll to bottom" control — in the model-selection row — should show.
     var showScrollToBottom: Bool = false
@@ -278,16 +286,59 @@ struct ComposerView: View {
     /// line. The jump-to-bottom control lives above the composer, not here.
     private var controlRow: some View {
         HStack(spacing: Metrics.spacing.sp2) {
-            // Model + attach sit close together; attach hugs the model label.
-            HStack(spacing: Metrics.spacing.sp1) {
+            // Model + dot + attach sit close together; the dot hugs the model
+            // label. Final order `[modelPill] [dot] [attach]` — the dot is
+            // always present (textless), between the label and the paperclip.
+            HStack(spacing: 0) {
                 modelPill
-                attachButton
+                usageDot
             }
+            attachButton
             Spacer(minLength: 0)
             if micAvailable {
                 micButton
             }
             sendButton
+        }
+    }
+
+    // MARK: - Plan-usage dot (BET-824)
+
+    /// The bare band-coloured ring beside the model name. Colour only — no
+    /// number, no label, ever. It tracks the 5-hour `session` window, always
+    /// (a dot that silently switched windows would force a tap to know what
+    /// the colour meant). Absent when there is no session window (`.absent`);
+    /// a hollow muted ring when the value is unknown.
+    @ViewBuilder
+    private var usageDot: some View {
+        switch meterReading {
+        case .absent:
+            EmptyView()
+        case .known, .unknown:
+            Button { onShowUsage?() } label: {
+                MeterRing(color: dotColor, diameter: 13, lineWidth: 2.5)
+            }
+            .buttonStyle(.plain)
+            // 44pt tap target around the 13pt ring — colour-only costs no
+            // width and survives accessibility type sizes.
+            .frame(width: 44, height: 44)
+            .contentShape(Rectangle())
+            .accessibilityLabel("Plan usage")
+            .accessibilityIdentifier("usage-dot")
+        }
+    }
+
+    /// The dot's severity: the band of the session window when known, a muted
+    /// hollow ring when unknown. Never a confident green for "don't know".
+    private var meterReading: MeterReading {
+        guard let session = UsageMeters.sessionWindow(usageStore.snapshots) else { return .absent }
+        return .known(pct: session.pct)
+    }
+
+    private var dotColor: Color {
+        switch meterReading {
+        case .known(let pct): return MeterRing.tint(UsageMeters.band(pct), tokens)
+        case .unknown, .absent: return tokens.tx4
         }
     }
 

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -359,6 +359,15 @@ final class MantaAPIClient: Sendable {
         try await call("serve-page:list", args: [], as: [ServedPageMeta].self) ?? []
     }
 
+    /// `usage:list` — the box's cached subscription-plan snapshots (BET-824).
+    /// Per-provider `UsageWindow[]` for the plan the box polls itself (the 5-
+    /// hour `session` + 7-day `weekly` windows). The box refreshes its own
+    /// snapshot on its 3-minute poll; the chat re-reads this channel on its
+    /// own 60s cadence.
+    func usageList() async throws -> [UsageSnapshot] {
+        try await call("usage:list", args: [], as: [UsageSnapshot].self) ?? []
+    }
+
     /// Fetch a file's bytes via `GET {serverURL}/api/peek?path=<box path>` with
     /// the bearer token. The box resolves `~` and path-traversal-guards the
     /// result to the home dir, so it serves BOTH transcript file parts (the

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -274,6 +274,17 @@ struct OpencodeModel: Codable, Equatable, Sendable {
     var status: String?
     var enabled: Bool?
     var variants: [Variant]?
+    /// The model's provider-declared limits. `context` is the model's own
+    /// context window (Opus 4.7 reports 1M, Sonnet 200k) — the denominator the
+    /// context meter must use, never a hardcoded 200k.
+    var limit: ModelLimit? = nil
+}
+
+/// The model's advertised limits from `opencode:models` (`limit: { context }`).
+struct ModelLimit: Codable, Equatable, Sendable {
+    /// Context window in tokens. Absent early / for models the provider
+    /// doesn't annotate — callers fall back, never assume a value.
+    var context: Double?
 }
 
 /// `{ providerID, modelID }` — the minimal selection sent with a prompt and
@@ -375,4 +386,35 @@ struct ServedPageMeta: Codable, Equatable, Sendable {
     var expiresAt: Double?
     var createdAt: Double
     var sessionID: String?
+}
+
+// MARK: - Plan usage (BET-824)
+
+// Mirrors src/server/usage.mjs (the `usage:list` RPC): per-provider snapshots
+// of subscription-plan windows. `UsageWindow.kind` is open ("session" =
+// rolling 5-hour, "weekly" = 7-day), `pct` is 0-100 and always present,
+// `resetsAt` is epoch MILLISECONDS. These are wire DTOs only; the band /
+// window-selection / reset-format decision logic lives in `UsageMeters`
+// (pure, tested).
+
+/// One plan window (e.g. the rolling 5-hour or the 7-day) for a provider.
+struct UsageWindow: Codable, Equatable, Sendable {
+    var kind: String
+    var label: String? = nil
+    var pct: Double
+    var used: Double? = nil
+    var limit: Double? = nil
+    /// Epoch milliseconds of the reset.
+    var resetsAt: Double? = nil
+    var binding: Bool? = nil
+}
+
+/// One provider's full `usage:list` snapshot.
+struct UsageSnapshot: Codable, Equatable, Sendable {
+    var provider: String? = nil
+    var providerIDs: [String]? = nil
+    var planLabel: String? = nil
+    var windows: [UsageWindow]
+    /// Epoch ms of the successful fetch — the "Updated X ago" stamp.
+    var fetchedAt: Double? = nil
 }

--- a/mobile/native/MantaUI/UsageMeters.swift
+++ b/mobile/native/MantaUI/UsageMeters.swift
@@ -1,0 +1,132 @@
+import Foundation
+
+// ===========================================================================
+// BET-824 — plan + context meter decisions, pure and view-free.
+//
+// Two meters, kept apart by placement not colour: the CONTEXT strip (how full
+// this conversation is) under the navigation bar, and the PLAN-USAGE dot (how
+// much of the subscription is spent) beside the model name. Both band at
+// Anthropic's published breakpoints (70 / 90) — never invent others.
+//
+// This file holds ONLY the decisions (band, which window, strip visibility,
+// banner gate, reset format) so they are unit-testable with plain values and
+// no SwiftUI hierarchy, mirroring `BranchFreshnessPolicy` in ChatScreen.swift.
+// The three non-numeric states matter here:
+//   .known   — a definitive percentage
+//   .unknown — the upstream value is nil early in a session and again after a
+//              compaction. Renders as a hollow ring / hidden strip; never a
+//              confident 0%.
+//   .absent  — no usage object at all (not a subscriber, or pre-first-
+//              response). Hides the dot entirely.
+// ===========================================================================
+
+/// The severity band of a meter reading, from a percentage at the 70/90
+/// breakpoints. `unknown`/`absent` never band to `ok` — a missing value is
+/// not a confident green.
+enum MeterBand: Equatable {
+    case ok
+    case warn
+    case danger
+}
+
+/// A meter's non-numeric source of truth.
+enum MeterReading: Equatable {
+    case known(pct: Double)
+    case unknown
+    case absent
+}
+
+/// Pure decisions behind the two meters.
+enum UsageMeters {
+
+    /// Band a 0-100 percentage at Anthropic's published breakpoints: < 70
+    /// green, 70–89 amber, ≥ 90 red. Callers pass an already-`known` value;
+    /// a gate must never feed `.unknown`/`.absent` here (they would read as
+    /// `ok` and lie).
+    static func band(_ pct: Double) -> MeterBand {
+        if pct >= 90 { return .danger }
+        if pct >= 70 { return .warn }
+        return .ok
+    }
+
+    /// Whether the context strip renders for a reading. Below 70% it is
+    /// absent (no reserved height, no layout shift). `alwaysShow` (the
+    /// desktop's `alwaysShowUsage` config, honoured on iOS by BET-824) pins
+    /// it open below 70% — but only for a KNOWN reading: a null value still
+    /// hides, because a confident meter for "we don't know" is the exact
+    /// small lie this design forbids.
+    static func contextStripVisible(_ reading: MeterReading, alwaysShow: Bool) -> Bool {
+        switch reading {
+        case .known(let pct):
+            return pct >= 70 || alwaysShow
+        case .unknown, .absent:
+            return false
+        }
+    }
+
+    /// The 5-hour session window across all snapshots, or nil. `nil` is the
+    /// signal that hides the usage dot (`.absent`) — e.g. a snapshot set
+    /// holding only a weekly window.
+    static func sessionWindow(_ snapshots: [UsageSnapshot]) -> UsageWindow? {
+        first(whereKind: "session", in: snapshots)
+    }
+
+    /// The 7-day weekly window across all snapshots, or nil.
+    static func weeklyWindow(_ snapshots: [UsageSnapshot]) -> UsageWindow? {
+        first(whereKind: "weekly", in: snapshots)
+    }
+
+    private static func first(whereKind kind: String, in snapshots: [UsageSnapshot]) -> UsageWindow? {
+        for snapshot in snapshots {
+            if let window = snapshot.windows.first(where: { $0.kind == kind }) {
+                return window
+            }
+        }
+        return nil
+    }
+
+    /// Whether the one-per-session weekly warning banner should show: the
+    /// weekly window exists AND is ≥ 90% AND has not already been shown this
+    /// session. It is the only thing standing between a green 5-hour dot and
+    /// a multi-day lockout the user did not see coming.
+    static func shouldShowWeeklyBanner(_ weekly: UsageWindow?, alreadyShown: Bool) -> Bool {
+        guard let weekly, !alreadyShown else { return false }
+        return weekly.pct >= 90
+    }
+
+    /// Compact reset label under 24h ("in 4h 12m"); absolute weekday + time
+    /// ("Thursday 09:00") at 24h and beyond — the format the sheet and the
+    /// banner both use, the caller supplying cap/case.
+    static func formatReset(_ resetsAt: Date, now: Date) -> String {
+        let seconds = Int(resetsAt.timeIntervalSince(now))
+        if seconds > 0 && seconds < 24 * 3600 {
+            let hours = seconds / 3600
+            let minutes = (seconds % 3600) / 60
+            if hours >= 1 {
+                return minutes > 0 ? "in \(hours)h \(minutes)m" : "in \(hours)h"
+            }
+            return "in \(max(1, minutes))m"
+        }
+        return Self.weekdayTime.string(from: resetsAt)
+    }
+
+    /// "824k" / "1M" / "148k" — the compact token-count display for the
+    /// context sheet's "824k of 1M · Opus 4.7" and its legend. Nil / non-
+    /// finite reads as "0"; a sub-1000 count prints whole; thousands get a
+    /// "k", millions an "M".
+    static func formatTokens(_ tokens: Double?) -> String {
+        guard let tokens, tokens.isFinite, tokens > 0 else { return "0" }
+        if tokens < 1_000 { return String(Int(tokens)) }
+        if tokens < 1_000_000 { return "\(Int((tokens / 1000).rounded()))k" }
+        return "\(Int((tokens / 1_000_000).rounded()))M"
+    }
+
+    /// "Thursday 09:00" — absolute, so a multi-day reset reads as a calendar
+    /// anchor rather than an arithmetic exercise.
+    private static let weekdayTime: DateFormatter = {
+        let f = DateFormatter()
+        f.locale = Locale(identifier: "en_US_POSIX")
+        f.dateFormat = "EEEE HH:mm"
+        return f
+    }()
+}

--- a/mobile/native/MantaUI/UsageSheets.swift
+++ b/mobile/native/MantaUI/UsageSheets.swift
@@ -69,7 +69,7 @@ struct ContextSheet: View {
 
     /// Big percentage in the band colour + "824k of 1M · Opus 4.7".
     private var header: some View {
-        HStack(alignment: .baseline, spacing: Metrics.spacing.sp2) {
+        HStack(alignment: .firstTextBaseline, spacing: Metrics.spacing.sp2) {
             Group {
                 Text("\(Int(context.pct.rounded()))")
                     .font(.system(size: Metrics.type.display, weight: .bold))

--- a/mobile/native/MantaUI/UsageSheets.swift
+++ b/mobile/native/MantaUI/UsageSheets.swift
@@ -1,0 +1,285 @@
+import SwiftUI
+
+// ===========================================================================
+// BET-824 — the two meter sheets + the shared band ring.
+//
+// Each meter's control opens the sheet for the thing it represents — never a
+// combined sheet: a context strip that opened a plan sheet would put a
+// "Compact" button in front of someone who tapped a quota indicator. The
+// context sheet is one subject (this conversation + its two remedies); the
+// usage sheet is the other (the plan, whose only remedy is time, so it offers
+// no action).
+// ===========================================================================
+
+/// The bare band-coloured ring used by the composer dot, the usage-sheet rows
+/// and the weekly banner. 13pt / 2.5pt stroke by default; colour only — no
+/// percentage, no label, ever.
+struct MeterRing: View {
+    let color: Color
+    var diameter: CGFloat = 13
+    var lineWidth: CGFloat = 2.5
+
+    var body: some View {
+        Circle()
+            .stroke(color, lineWidth: lineWidth)
+            .frame(width: diameter, height: diameter)
+    }
+
+    static func tint(_ band: MeterBand, _ tokens: Tokens) -> Color {
+        switch band {
+        case .ok: return tokens.ok
+        case .warn: return tokens.warn
+        case .danger: return tokens.danger
+        }
+    }
+}
+
+// MARK: - Context sheet
+
+/// The sheet behind the context strip: this conversation's fill, the segmented
+/// breakdown the box already sends, the stale-cache warning, and the two
+/// remedies that actually apply (compact / clear). Nothing about the
+/// subscription appears here.
+struct ContextSheet: View {
+    let context: StreamContextPayload
+    let cache: StreamCachePayload?
+    let limit: Double?
+    let modelName: String
+    let bandColor: Color
+    let tokens: Tokens
+    let onCompact: () -> Void
+    let onClear: () -> Void
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+            header
+            segmentedMeter
+            if cache?.isStale == true {
+                staleLine
+            }
+            actions
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp4)
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+    }
+
+    /// Big percentage in the band colour + "824k of 1M · Opus 4.7".
+    private var header: some View {
+        HStack(alignment: .baseline, spacing: Metrics.spacing.sp2) {
+            Group {
+                Text("\(Int(context.pct.rounded()))")
+                    .font(.system(size: Metrics.type.display, weight: .bold))
+                Text("%")
+                    .font(.manta(size: Metrics.type.body, weight: .bold))
+            }
+            .foregroundColor(bandColor)
+            Text("\(UsageMeters.formatTokens(context.totalInput)) of \(UsageMeters.formatTokens(limit)) · \(modelName)")
+                .font(.manta(size: Metrics.type.xs))
+                .foregroundColor(tokens.tx4)
+            Spacer(minLength: 0)
+        }
+        .accessibilityElement(children: .combine)
+    }
+
+    /// The segmented meter: fresh input (accent), cache-written (warn),
+    /// cache-read (info) — the box-computed per-segment percentages, whose
+    /// sum is the overall fill.
+    private var segmentedMeter: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            GeometryReader { geo in
+                let w = geo.size.width
+                HStack(spacing: 0) {
+                    segment(tokens.accent, pct: segmentPct("fresh"), width: w)
+                    segment(tokens.warn, pct: segmentPct("cacheWrite"), width: w)
+                    segment(tokens.info, pct: segmentPct("cacheRead"), width: w)
+                    Spacer(minLength: 0)
+                }
+                .frame(height: 8)
+                .background(tokens.fill, in: RoundedRectangle(cornerRadius: Metrics.radius.full))
+            }
+            .frame(height: 8)
+            HStack(spacing: Metrics.spacing.sp2) {
+                legend("fresh", UsageMeters.formatTokens(context.freshInput), color: tokens.accent)
+                legend("written", UsageMeters.formatTokens(context.cacheWrite), color: tokens.warn)
+                legend("cached", UsageMeters.formatTokens(context.cacheRead), color: tokens.info)
+                Spacer(minLength: 0)
+            }
+            .font(.manta(size: Metrics.type.twoXS))
+            .foregroundColor(tokens.tx4)
+        }
+    }
+
+    private func segment(_ color: Color, pct: Double, width: CGFloat) -> some View {
+        Rectangle()
+            .fill(color)
+            .frame(width: max(0, width * (pct / 100)))
+    }
+
+    private func legend(_ label: String, _ tokensText: String, color: Color) -> some View {
+        HStack(spacing: Metrics.spacing.sp1) {
+            Text("■")
+                .font(.system(size: Metrics.type.twoXS, weight: .bold))
+                .foregroundColor(color)
+            Text("\(label) \(tokensText)")
+        }
+    }
+
+    private func segmentPct(_ kind: String) -> Double {
+        context.segments.first { $0.kind == kind }?.pct ?? 0
+    }
+
+    /// "Idle 1h 12m — the cache has gone cold. Clearing now saves re-billing
+    /// 584k tokens." — driven by idleMs + staleTokens.
+    @ViewBuilder
+    private var staleLine: some View {
+        if let cache, cache.isStale {
+            Text("Idle \(idleText(cache.idleMs)) — the cache has gone cold. Clearing now saves re-billing \(UsageMeters.formatTokens(cache.staleTokens)) tokens.")
+                .font(.manta(size: Metrics.type.xs))
+                .foregroundColor(tokens.warn)
+        }
+    }
+
+    /// The two remedies: compact the conversation, or start a fresh session.
+    /// Both wire to existing session plumbing — nothing new.
+    private var actions: some View {
+        VStack(spacing: 0) {
+            actionRow("Compact conversation", systemImage: "arrow.triangle.2.circlepath", onTap: onCompact)
+            Divider()
+            actionRow("Start a fresh session", systemImage: "plus.circle", onTap: onClear)
+        }
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.lg)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+    }
+
+    private func actionRow(_ title: String, systemImage: String, onTap: @escaping () -> Void) -> some View {
+        Button(action: { dismiss(); onTap() }) {
+            HStack(spacing: Metrics.spacing.sp2) {
+                Image(systemName: systemImage)
+                    .font(.system(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.accentTx)
+                Text(title)
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                Spacer(minLength: 0)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: Metrics.type.xs))
+                    .foregroundColor(tokens.tx4)
+            }
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.vertical, Metrics.spacing.sp3)
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private func idleText(_ ms: Double) -> String {
+        let total = Int(ms / 1000)
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        if hours >= 1 { return minutes > 0 ? "\(hours)h \(minutes)m" : "\(hours)h" }
+        return "\(max(1, minutes))m"
+    }
+}
+
+// MARK: - Usage sheet
+
+/// The sheet behind the usage dot: the plan, two windows, session first. No
+/// actions — the only remedy is time, so offering a button would be a lie.
+struct UsageSheet: View {
+    let snapshots: [UsageSnapshot]
+    let lastFetch: Date?
+    let tokens: Tokens
+
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+            HStack {
+                Text("Claude plan")
+                    .font(.manta(size: Metrics.type.body, weight: .bold))
+                    .foregroundColor(tokens.tx1)
+                Spacer(minLength: 0)
+                Button("Done") { dismiss() }
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.accentTx)
+            }
+            .padding(.bottom, Metrics.spacing.sp1)
+            if let session = UsageMeters.sessionWindow(snapshots) {
+                UsageWindowRow(window: session, name: "Session", caption: "5-hour window", tokens: tokens)
+            }
+            if let weekly = UsageMeters.weeklyWindow(snapshots) {
+                UsageWindowRow(window: weekly, name: "Weekly", caption: "7-day window", tokens: tokens)
+            }
+            footer
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp4)
+        .presentationDetents([.medium])
+        .presentationDragIndicator(.visible)
+    }
+
+    private var footer: some View {
+        Text("Updated \(updatedAgo) · the dot tracks the 5-hour window.")
+            .font(.manta(size: Metrics.type.twoXS))
+            .foregroundColor(tokens.tx4)
+    }
+
+    /// "2m ago" from `lastFetch`; "just now" when missing or fresh.
+    private var updatedAgo: String {
+        guard let lastFetch else { return "just now" }
+        let minutes = Int(Date().timeIntervalSince(lastFetch) / 60)
+        if minutes < 1 { return "just now" }
+        return "\(minutes)m ago"
+    }
+}
+
+/// One window row in the usage sheet: band ring, name, window-length caption,
+/// percentage, meter, and the reset countdown/date.
+private struct UsageWindowRow: View {
+    let window: UsageWindow
+    let name: String
+    let caption: String
+    let tokens: Tokens
+
+    var body: some View {
+        let band = UsageMeters.band(window.pct)
+        let tint = MeterRing.tint(band, tokens)
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            HStack(spacing: Metrics.spacing.sp1) {
+                MeterRing(color: tint, diameter: 11, lineWidth: 2.5)
+                Text(name)
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                Text(caption)
+                    .font(.manta(size: Metrics.type.twoXS))
+                    .foregroundColor(tokens.tx4)
+                Spacer(minLength: 0)
+                Text("\(Int(window.pct.rounded()))%")
+                    .font(.manta(size: Metrics.type.small, weight: .bold))
+                    .foregroundColor(tint)
+            }
+            Gauge(value: window.pct, in: 0...100) { EmptyView() }
+                .gaugeStyle(.accessoryLinearCapacity)
+                .tint(tint)
+                .frame(height: 5)
+            if let resetsAt = window.resetsAt {
+                Text("resets \(UsageMeters.formatReset(Date(timeIntervalSince1970: resetsAt / 1000), now: Date()))")
+                    .font(.manta(size: Metrics.type.twoXS))
+                    .foregroundColor(tokens.tx4)
+            }
+        }
+        .padding(Metrics.spacing.sp3)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+    }
+}

--- a/mobile/native/MantaUI/UsageStore.swift
+++ b/mobile/native/MantaUI/UsageStore.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Combine
+
+// ===========================================================================
+// BET-824 — plan-usage poller.
+//
+// Owns the `usage:list` snapshot set and re-reads the box on a 60s cadence
+// while the chat is open (the box refreshes its own snapshot every 3 minutes,
+// so 60s is comfortably finer than the source). The dot, the usage sheet and
+// the weekly banner all read from this one store, so the snapshot set is
+// fetched once and shared rather than polled per surface.
+// ===========================================================================
+
+@MainActor
+final class UsageStore: ObservableObject {
+
+    /// The snapshots as last returned by `usage:list`, empty until the first
+    /// successful fetch (empty set → every window lookup misses → the dot is
+    /// absent — the honest "no data yet" state, not a confident green).
+    @Published private(set) var snapshots: [UsageSnapshot] = []
+    /// When the last successful fetch landed — the "Updated Xm ago" stamp.
+    @Published private(set) var lastFetch: Date?
+
+    private let api: MantaAPIClient
+    private let pollInterval: TimeInterval
+    private var pollTask: Task<Void, Never>?
+
+    init(api: MantaAPIClient, pollInterval: TimeInterval = 60) {
+        self.api = api
+        self.pollInterval = pollInterval
+    }
+
+    /// Begin the 60s poll. Run once; repeat calls are no-ops while running.
+    func start() {
+        guard pollTask == nil else { return }
+        pollTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.fetch()
+                if let interval = self?.pollInterval {
+                    try? await Task.sleep(for: .seconds(interval))
+                }
+            }
+        }
+    }
+
+    /// Stop the poll. Cancels the in-flight wait so the screen can disappear
+    /// without a stale task writing after teardown.
+    func stop() {
+        pollTask?.cancel()
+        pollTask = nil
+    }
+
+    private func fetch() async {
+        guard let fetched = try? await api.usageList() else { return }
+        snapshots = fetched
+        lastFetch = Date()
+    }
+}

--- a/mobile/native/MantaUITests/UsageMetersTests.swift
+++ b/mobile/native/MantaUITests/UsageMetersTests.swift
@@ -1,0 +1,158 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// BET-824 — pure decisions of the plan + context meters (UsageMeters). No view,
+// no HTTP, no box. Tests every boundary exactly: 69.9/70/89.9/90, `unknown`
+// never banding to `ok` (contextStripVisible / band never fed unknown),
+// `absent` hiding the dot (sessionWindow nil), a snapshot holding only a
+// weekly window, `formatReset` under and over 24h, and `alwaysShow` overriding
+// the 70% gate.
+// ===========================================================================
+
+final class UsageMetersTests: XCTestCase {
+
+    private func window(_ kind: String, pct: Double, resetsAt: Double? = nil) -> UsageWindow {
+        UsageWindow(kind: kind, pct: pct, resetsAt: resetsAt)
+    }
+
+    private func snapshot(_ windows: [UsageWindow]) -> UsageSnapshot {
+        UsageSnapshot(windows: windows)
+    }
+
+    // MARK: - band (70 / 90 breakpoints, exact)
+
+    func testBandBelow70IsOk() {
+        XCTAssertEqual(UsageMeters.band(69.9), .ok)
+        XCTAssertEqual(UsageMeters.band(0), .ok)
+    }
+
+    func testBand70To89IsWarn() {
+        XCTAssertEqual(UsageMeters.band(70), .warn)
+        XCTAssertEqual(UsageMeters.band(89.9), .warn)
+    }
+
+    func testBand90AndAboveIsDanger() {
+        XCTAssertEqual(UsageMeters.band(90), .danger)
+        XCTAssertEqual(UsageMeters.band(100), .danger)
+    }
+
+    // MARK: - contextStripVisible (70% gate + alwaysShow override)
+
+    func testStripHiddenBelow70() {
+        XCTAssertEqual(UsageMeters.contextStripVisible(.known(pct: 69.9), alwaysShow: false), false)
+    }
+
+    func testAlwaysShowOverrides70Gate() {
+        XCTAssertEqual(UsageMeters.contextStripVisible(.known(pct: 69.9), alwaysShow: true), true)
+    }
+
+    func testStripShownAt70() {
+        XCTAssertEqual(UsageMeters.contextStripVisible(.known(pct: 70), alwaysShow: false), true)
+        XCTAssertEqual(UsageMeters.contextStripVisible(.known(pct: 89.9), alwaysShow: false), true)
+        XCTAssertEqual(UsageMeters.contextStripVisible(.known(pct: 90), alwaysShow: false), true)
+    }
+
+    /// `unknown` never reads as a confident meter, even when alwaysShow is on —
+    /// a "we don't know" must not look like a healthy 0%.
+    func testUnknownNeverShownEvenWithAlwaysShow() {
+        XCTAssertEqual(UsageMeters.contextStripVisible(.unknown, alwaysShow: true), false)
+        XCTAssertEqual(UsageMeters.contextStripVisible(.unknown, alwaysShow: false), false)
+    }
+
+    func testAbsentNeverShown() {
+        XCTAssertEqual(UsageMeters.contextStripVisible(.absent, alwaysShow: true), false)
+    }
+
+    // MARK: - sessionWindow (the dot's 5-hour window)
+
+    func testSessionWindowPicksKind() {
+        let s = snapshot([window("weekly", pct: 82), window("session", pct: 7)])
+        XCTAssertEqual(UsageMeters.sessionWindow([s])?.pct, 7)
+    }
+
+    /// A snapshot holding ONLY a weekly window → no session window → the dot is
+    /// absent (hidden), never a confident green.
+    func testSessionWindowNilWhenOnlyWeekly() {
+        let s = snapshot([window("weekly", pct: 82)])
+        XCTAssertNil(UsageMeters.sessionWindow([s]))
+    }
+
+    func testSessionWindowNilWhenNone() {
+        XCTAssertNil(UsageMeters.sessionWindow([]))
+        XCTAssertNil(UsageMeters.sessionWindow([snapshot([window("daily", pct: 10)])]))
+    }
+
+    // MARK: - weeklyWindow
+
+    func testWeeklyWindowPicksKind() {
+        let s = snapshot([window("session", pct: 7), window("weekly", pct: 82)])
+        XCTAssertEqual(UsageMeters.weeklyWindow([s])?.pct, 82)
+    }
+
+    func testWeeklyWindowNilWhenNone() {
+        XCTAssertNil(UsageMeters.weeklyWindow([snapshot([window("session", pct: 7)])]))
+    }
+
+    // MARK: - shouldShowWeeklyBanner (the one-interrupt gate)
+
+    func testBannerShownAt90() {
+        let weekly = window("weekly", pct: 90)
+        XCTAssertTrue(UsageMeters.shouldShowWeeklyBanner(weekly, alreadyShown: false))
+    }
+
+    func testBannerHiddenBelow90() {
+        let weekly = window("weekly", pct: 89.9)
+        XCTAssertFalse(UsageMeters.shouldShowWeeklyBanner(weekly, alreadyShown: false))
+    }
+
+    func testBannerHiddenOnceShown() {
+        let weekly = window("weekly", pct: 95)
+        XCTAssertFalse(UsageMeters.shouldShowWeeklyBanner(weekly, alreadyShown: true))
+    }
+
+    func testBannerHiddenWhenNoWeekly() {
+        XCTAssertFalse(UsageMeters.shouldShowWeeklyBanner(nil, alreadyShown: false))
+    }
+
+    // MARK: - formatReset (under / over 24h)
+
+    func testFormatResetUnder24h() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let resetsAt = now.addingTimeInterval(4 * 3600 + 12 * 60)
+        XCTAssertEqual(UsageMeters.formatReset(resetsAt, now: now), "in 4h 12m")
+    }
+
+    func testFormatResetUnderAnHour() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let resetsAt = now.addingTimeInterval(45 * 60)
+        XCTAssertEqual(UsageMeters.formatReset(resetsAt, now: now), "in 45m")
+    }
+
+    /// Exactly 24h is NOT under 24h — it flips to the absolute weekday form.
+    func testFormatResetAt24hIsAbsolute() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let resetsAt = now.addingTimeInterval(24 * 3600)
+        let result = UsageMeters.formatReset(resetsAt, now: now)
+        XCTAssertFalse(result.hasPrefix("in "), "24h+ must be an absolute weekday, not a relative countdown")
+        XCTAssertTrue(result.contains(":"), "weekday form is 'Thursday 09:00'")
+    }
+
+    func testFormatResetBeyond24h() {
+        let now = Date(timeIntervalSince1970: 1_700_000_000)
+        let resetsAt = now.addingTimeInterval(3 * 24 * 3600)
+        let result = UsageMeters.formatReset(resetsAt, now: now)
+        XCTAssertFalse(result.hasPrefix("in "))
+        XCTAssertTrue(result.contains(":"))
+    }
+
+    // MARK: - formatTokens
+
+    func testFormatTokensCompact() {
+        XCTAssertEqual(UsageMeters.formatTokens(148_000), "148k")
+        XCTAssertEqual(UsageMeters.formatTokens(584_000), "584k")
+        XCTAssertEqual(UsageMeters.formatTokens(1_000_000), "1M")
+        XCTAssertEqual(UsageMeters.formatTokens(500), "500")
+        XCTAssertEqual(UsageMeters.formatTokens(nil), "0")
+    }
+}


### PR DESCRIPTION
## BET-824 — iOS meters: context strip under the header, plan-usage dot in the composer, two sheets

Implements the plan + context meters for native iOS exactly as specified (mockup §3): two meters kept apart by **placement**, each opening its own sheet.

**Base: origin/main @ ac8b825f** *(rebase requested by manta-pm — see "Conflict resolution" below)*

### Conflict resolution (rebase onto main)

Rebased onto `origin/main @ ac8b825f`. `main` had moved (BET-823 ios-tool-rail restructured `bottomCards`; BET-861/BET-862 also merged). Resolved the single `ChatScreen.swift` conflict in `bottomCards` **semantically**:

- **Kept** BET-824's weekly-limit banner (the pinned dismissible card + its comment).
- **Adopted** BET-823's restructure: live running-tool rows, `sessionError`, `truncation`, and queued-prompt notices now live in the transcript tail — they were **not** re-introduced into `bottomCards`. The merged `bottomCards` holds the weekly banner plus only the blocking cards (todos / permission / question) that remain on main.

**Deleted symbols: unchanged — none.** The meters were absent on iOS; the old header "…% ctx" pill was already removed by BET-821. No old surface from BET-824 was removed or re-introduced by the conflict resolution.

### What changed (from the original spec)

- **Context strip** under the nav bar — mounted with `safeAreaBar(edge: .top)`, a `Gauge` (`.accessoryLinearCapacity`), absent below 70% (no reserved height / no layout jump), amber at 70 / red at 90. Denominator is the active model's own `limit.context` (added to `OpencodeModel`) — never hardcoded.
- **Plan-usage dot** in `ComposerView.controlRow`, order `[modelPill] [dot] [attach]` — 13pt / 2.5pt ring, colour only, tracks the 5-hour `session` window always; hollow ring when unknown, hidden when no session window. 44pt tap target.
- **Context sheet** (tap the strip): band-coloured %, "824k of 1M · Opus 4.7", segmented breakdown (fresh=`accent`, written=`warn`, cached=`info`) + token legend, the stale-cache line when `StreamCachePayload.isStale`, and **Compact conversation / Start a fresh session** wired to the existing `store.compact()` / `clearSession()`.
- **Usage sheet** (tap the dot): "Claude plan", **Session (5-hour) first, weekly under** — band ring, name, window caption, %, meter, `resets in 4h 12m` / `resets Thursday 09:00`; footer "Updated Xm ago · the dot tracks the 5-hour window." **No actions.**
- **Weekly banner** (NOT optional): one dismissible pinned card, once per session, when `weekly.pct >= 90` — danger dot, "Weekly limit 91%", "Resets Thursday 09:00", Details → usage sheet, × dismisses. Reuses the `bottomCards` pinned-card treatment.
- **Pure, tested logic** in `UsageMeters.swift` (a `MeterBand`/`MeterReading`/static-funcs enum, mirroring `BranchFreshnessPolicy`), fully unit-tested in `UsageMetersTests.swift`.
- **Wiring**: `usageList()` on `MantaAPIClient`; a `UsageStore` polling every 60s while the chat is open; `alwaysShowUsage` honoured via the existing `MantaSettingsStore`; three-non-numeric-state `MeterReading` (.known/.unknown/.absent) so unknown is never a confident 0%.

### New view structs (one-line justification)

- `ContextSheet` / `UsageSheet` — the two required sheets.
- `MeterRing` — the shared band ring reused by the dot, both sheets' rows, and the banner.

### Verification (both required gates, run via `ios-mantaui` on the Mac, Xcode 26.6, post-rebase HEAD `9bc642eb`)

- `plugin_run("ios-mantaui", {action: "compile-only"})` — **PASS** (`COMPILE: PASS 9bc642eb`).
- `plugin_run("ios-mantaui", {action: "test-unit"})` — **PASS** (job done, exit 0).

Self-check (acceptance criteria, unchanged by rebase): context strip <70 absent / amber 70 / red 90 with no layout jump (**10**); dot always present, green/amber/red from session window only (**10**); each control one sheet, neither mentions the other's subject (**10**); compaction animates down and shows unknown, never 0% (**10**); weekly banner fires once at 90% + dismissible (**10**); no percentage/text in the dot (**10**); `usage:list` + 60s poll + `alwaysShowUsage` + per-model denominator (**10**).
