### PR TITLE
BET-868: fix(server,gateway): replace hand-maintained CORS allow-list with wildcard

### DIFF
--- a/src/gateway/http.mjs
+++ b/src/gateway/http.mjs
@@ -23,7 +23,7 @@ export function corsHeaders() {
   return {
     "Access-Control-Allow-Origin": "*",
     "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-    "Access-Control-Allow-Headers": "content-type, authorization, x-box-id",
+    "Access-Control-Allow-Headers": "*, Authorization",
     "Access-Control-Max-Age": "600",
   };
 }

--- a/src/gateway/http.test.mjs
+++ b/src/gateway/http.test.mjs
@@ -85,7 +85,7 @@ test("corsHeaders: shape used by both sendJson and sendText", () => {
   const h = corsHeaders();
   assert.equal(h["Access-Control-Allow-Origin"], "*");
   assert.match(h["Access-Control-Allow-Methods"], /POST/);
-  assert.match(h["Access-Control-Allow-Headers"], /authorization/);
+  assert.equal(h["Access-Control-Allow-Headers"], "*, Authorization");
 });
 
 test("sendJson: writes a JSON response with CORS + content-type", () => {

--- a/src/gateway/index.mjs
+++ b/src/gateway/index.mjs
@@ -24,7 +24,7 @@
 
 import { createServer } from "node:http";
 import { randomBytes } from "node:crypto";
-import { readBody, sendJson, sendText } from "./http.mjs";
+import { readBody, sendJson, sendText, corsHeaders } from "./http.mjs";
 import {
   isValidBoxId,
   loadStore,
@@ -351,12 +351,7 @@ export function createGatewayServer({
 
     // CORS preflight — short-circuit before any other handling.
     if (req.method === "OPTIONS") {
-      res.writeHead(204, {
-        "Access-Control-Allow-Origin": "*",
-        "Access-Control-Allow-Methods": "GET, POST, OPTIONS",
-        "Access-Control-Allow-Headers": "content-type, authorization, x-box-id",
-        "Access-Control-Max-Age": "600",
-      });
+      res.writeHead(204, corsHeaders());
       return res.end();
     }
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1191,10 +1191,14 @@ const handleRequest = async (req, res) => {
   // answer CORS preflight so the mobile WebView's fetch() isn't blocked.
   res.setHeader("Access-Control-Allow-Origin", "*");
   res.setHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, OPTIONS");
-  res.setHeader(
-    "Access-Control-Allow-Headers",
-    "Content-Type, X-Filename, Authorization",
-  );
+  // `*` covers every custom header a client sends (x-filename on uploads;
+  // x-mime / x-duration-ms / x-peaks on voice notes) so this can never drift
+  // behind a new route again. `Authorization` is NOT covered by the wildcard
+  // per the Fetch spec and must stay listed by name. The wildcard is only
+  // honoured for non-credentialed requests — every client here sends the box
+  // token in an Authorization header, never a cookie.
+  res.setHeader("Access-Control-Allow-Headers", "*, Authorization");
+  res.setHeader("Access-Control-Max-Age", "600");
   if (req.method === "OPTIONS") {
     res.writeHead(204).end();
     return;


### PR DESCRIPTION
Fixes voice notes failing cross-origin: the `/api/voice` preflight rejected `x-mime` because the server's hand-maintained `Access-Control-Allow-Headers` literal list (`Content-Type, X-Filename, Authorization`) never covered the three custom headers the voice-upload route sends (`x-mime`, `x-duration-ms`, `x-peaks`). Affects every browser-context client (Vite dev + packaged desktop `file://` with its opaque origin), not just local dev.

## Fix
Replaced the hand-maintained allow-list with the wildcard, exactly as specced:
- `src/server/index.mjs` — `Access-Control-Allow-Headers` → `"*, Authorization"` + adds `Access-Control-Max-Age: 600`. The `*` covers every custom header a client sends so this can never drift behind a new route again; `Authorization` stays listed by name (not covered by the wildcard per the Fetch spec). Non-credentialed-only wildcard — all clients send the box token in `Authorization`, never cookies.
- `src/gateway/http.mjs` — same drift, same `"*, Authorization"` value.
- `src/gateway/index.mjs` — deleted the byte-duplicate inline OPTIONS header object; calls `corsHeaders()`.
- `src/gateway/http.test.mjs` — pinned the assertion to the exact value `"*, Authorization"`.

Per the issue's explicit non-goals: no header names added to the list, no new shared CORS module/file, no client changes, `Access-Control-Allow-Origin` unchanged (`*`), no `Allow-Credentials`, no `handleRequest` refactor.

**Base: origin/main @ `acd7edb5`**

**Files changed:** 4 files, +12 −13.

**Verification results:**
- PR branch (`multica/BET-868-cors-wildcard` @ `83561b6c`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1972 pass / 0 fail / 0 skip. Failures: none.
- Base (`main` @ `acd7edb5`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 1972 pass / 0 fail / 0 skip. Failures: none.
- Conclusion: 0 pre-existing, 0 new, 0 resolved — identical pass counts on both branches, with the updated gateway assertion exercising the new `"*, Authorization"` value on the PR branch.

Operational verify (steps 2–4 of the issue) is a live-box step I can't perform from CI: the running `manta-server` on `127.0.0.1:8787` currently still serves the old headers, so the box needs `systemctl --user restart manta-server` to pick up the fix, then a re-curl of the preflight (expects 204 + `Access-Control-Allow-Headers: *, Authorization`), then an in-app voice-note record. Flagging these as the handoff.
