### PR TITLE
fix(server/forge): a session's PR is its branch's PR or nothing (BET-866)

### DIFF
--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -586,10 +586,12 @@ async function listOpenPrs(adapter, repo) {
 }
 
 /**
- * forge:pull-request — resolve `cwd → origin → repo`, pick the open PR on the
- * current branch (falling back to the first open PR), and return the
- * normalised PR + merged checks + rollup. Never throws for "no PR" or "not
- * connected" — those are well-formed `{ error }` / `{ pr: null }` results.
+ * forge:pull-request — resolve `cwd → origin → repo`, pick the open PR whose
+ * head is the current branch, and return the normalised PR + merged checks +
+ * rollup. A branch with no open PR — or no branch at all (detached HEAD) —
+ * returns the well-formed empty result `{ pr: null }`, never someone else's
+ * PR. Never throws for "no PR" or "not connected" — those are well-formed
+ * `{ error }` / `{ pr: null }` results.
  *
  * All git/forge deps are injectable for tests.
  *
@@ -612,8 +614,10 @@ export async function pullRequestForCwd(cwd, deps = {}) {
   if (prArr.length === 0) return { ...EMPTY, stale };
 
   const branch = await currentBranch(cwd);
-  let candidate = branch ? prArr.find((p) => p.headRef === branch) : undefined;
-  if (!candidate) candidate = prArr[0];
+  if (!branch) return { ...EMPTY, stale };
+
+  const candidate = prArr.find((p) => p.headRef === branch);
+  if (!candidate) return { ...EMPTY, stale };
 
   // Full normalised representation — getPullRequest populates reviewers + the
   // unresolved-thread count that the list endpoint cannot. Falls back to the

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -239,6 +239,56 @@ test("pullRequestForCwd: no open PR → well-formed empty result, not an error",
   assert.deepEqual(r.checks, []);
 });
 
+test("pullRequestForCwd: open PRs exist but none on this branch → no PR", async () => {
+  const r = await pullRequestForCwd("/repo", {
+    gitRemoteOrigin: async () => "https://github.com/acme/widget.git",
+    currentBranch: async () => "feature/x",
+    resolveToken: async () => ({ token: "ghp_t", source: "cli" }),
+    getAdapter: () =>
+      fakeAdapter({
+        prs: [
+          { ...OPEN_PR, number: 1, headRef: "topic/a" },
+          { ...OPEN_PR, number: 2, headRef: "topic/b" },
+        ],
+      }),
+  });
+  assert.equal(r.pr, null);
+  assert.equal(r.error, null);
+  assert.equal(r.rollup, "none");
+  assert.deepEqual(r.checks, []);
+});
+
+test("pullRequestForCwd: detached HEAD / unknown branch → no PR", async () => {
+  const r = await pullRequestForCwd("/repo", {
+    gitRemoteOrigin: async () => "https://github.com/acme/widget.git",
+    currentBranch: async () => null,
+    resolveToken: async () => ({ token: "ghp_t", source: "cli" }),
+    getAdapter: () => fakeAdapter({ prs: [OPEN_PR] }),
+  });
+  assert.equal(r.pr, null);
+  assert.equal(r.error, null);
+  assert.equal(r.rollup, "none");
+  assert.deepEqual(r.checks, []);
+});
+
+test("pullRequestForCwd: the match is exact, not positional", async () => {
+  const r = await pullRequestForCwd("/repo", {
+    gitRemoteOrigin: async () => "https://github.com/acme/widget.git",
+    currentBranch: async () => "feature/x",
+    resolveToken: async () => ({ token: "ghp_t", source: "cli" }),
+    getAdapter: () =>
+      fakeAdapter({
+        prs: [
+          { ...OPEN_PR, number: 1, headRef: "other" },
+          { ...OPEN_PR, number: 42, headRef: "feature/x" },
+        ],
+      }),
+  });
+  assert.equal(r.error, null);
+  assert.equal(r.pr.number, 42, "returns the branch-matching PR, not the first open PR");
+  assert.equal(r.pr.headRef, "feature/x");
+});
+
 test("getAdapter throws UnsupportedByForgeError for an unknown kind", async () => {
   const runtime = createForgeRuntime({ fetch: async () => json({}, 200, {}) });
   assert.throws(() => runtime.getAdapter("gitea", "t"), (e) => e.name === "UnsupportedByForgeError");


### PR DESCRIPTION
Fixes the session PR chip showing the wrong PR: a session's PR is now its branch's PR or nothing.

## What was removed

The first-open-PR fallback in `pullRequestForCwd` (`src/server/forge/index.mjs`):

```js
let candidate = branch ? prArr.find((p) => p.headRef === branch) : undefined;
if (!candidate) candidate = prArr[0];  // ← deleted
```

A branch with no matching open PR — or no branch at all (detached HEAD) — now returns the existing `EMPTY` result (`{ pr: null, checks: [], rollup: "none" }`) instead of an unrelated PR. The exact `EMPTY` constant already used by the zero-PR path is reused; no new empty-literal, no new error value. JSDoc updated to match.

## Verification

- typecheck: exit 0, no errors
- `npm test`: 1975 pass / 0 fail / 0 skip
- Forge suite: 60 pass / 0 fail — including 3 new negative tests:
  - open PRs exist but none on this branch → no PR
  - detached HEAD / unknown branch → no PR
  - match is exact, not positional (returns the branch PR, not the first open PR)

Base: `origin/main` @ `e827852a`
