### PR TITLE
fix(server): launchers:list RPC 500 — default deps object (BET-872)

### DIFF
--- a/src/server/launchers.mjs
+++ b/src/server/launchers.mjs
@@ -32,9 +32,11 @@ export async function binExists(bin) {
   }
 }
 
+// The deps object is OPTIONAL: the rpc `launchers:list` channel calls with no
+// arguments, and only the unit tests inject a probe.
 export async function listAvailableLaunchers({
   binExists: probe = binExists,
-}) {
+} = {}) {
   const out = [];
   for (const l of LAUNCHERS) {
     // Hidden launchers (BET-354 `claude-auth-login`) are programmatic

--- a/src/server/launchers.test.mjs
+++ b/src/server/launchers.test.mjs
@@ -32,6 +32,15 @@ describe("binExists", () => {
 // ---------------------------------------------------------------------------
 
 describe("listAvailableLaunchers", () => {
+  // BET-872: the rpc `launchers:list` channel calls with NO arguments. The deps
+  // object must default, or this throws on a zero-arg caller. Only assert it
+  // resolves to an array — which binaries resolve depends on the box running
+  // the suite.
+  it("resolves to an array when called with no arguments (BET-872)", async () => {
+    const out = await listAvailableLaunchers();
+    assert.ok(Array.isArray(out));
+  });
+
   it("includes a launcher when its bin exists", async () => {
     const out = await listAvailableLaunchers({
       binExists: async (bin) => bin === "claude",


### PR DESCRIPTION
## What

`src/server/launchers.mjs` — `listAvailableLaunchers({ binExists: probe = binExists } = {})`. The deps object now defaults.

## Why

The `launchers:list` RPC channel calls `listAvailableLaunchers()` with **no arguments** (`src/server/rpc.mjs`), but the deps object had no `= {}` default. Destructuring `undefined` threw `TypeError: Cannot read properties of undefined (reading 'binExists')` → every renderer call returned HTTP 500, so the session-mode dropdown never populated.

## Audit (BET-872 scope)

Ran `^export (async )?function \w+\(\{` across `src/server/*.mjs` and checked every zero-arg call site:

| Function | Zero-arg caller? | Status |
|---|---|---|
| `listAvailableLaunchers` | **yes** (rpc `launchers:list`) | **fixed** |
| `ensureAuth` | yes (index.mjs) | already `= {}` — untouched |
| `createArtifactSweep` | yes (index.mjs) | already `= {}` — untouched |
| `createCleanupSweep` | yes (startCleanupPoller) | already `= {}` — untouched |
| all other candidates (`createScheduler`, `createAuthEngine`, `createDeviceRegistry`, `gitAddWorktree`, `newWindow`, `searchMessages`, `runCommand`, …) | no — every call site passes an object | left alone |

No wrappers, no new exports, no try/catch added — one-token fix + comment, as specified.

## Test

- Added regression case in `src/server/launchers.test.mjs`: `listAvailableLaunchers()` with no args resolves to an array (no content assertion, per spec).
- Zero-arg reproduce command now prints a JSON array (len 1) instead of throwing.
- `npm run test:server` — launchers suite 14/14 pass; pre-existing 8 unrelated failures in pty/rpc/capabilities/forge/pairPage/auditJobsConcurrency (also present on clean `main`, 8 failures / 1314 tests).
- `npm run typecheck` — clean.
