### PR TITLE
fix(ios): composer model menu + searchable catalogue sheet (BET-825)

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -169,6 +169,39 @@ enum ChatModel {
         return nil
     }
 
+    // MARK: - Catalogue row badges (BET-825)
+
+    /// Compact context-window display, ported from the desktop
+    /// `formatModelContextSize` (src/renderer/chatUtils.ts): 200_000 → "200k",
+    /// 1_000_000 → "1M", 1_500_000 → "1.5M". Returns nil for a missing /
+    /// non-positive limit so callers omit the badge entirely rather than
+    /// rendering "0k". At 1M+ it switches to millions and strips a trailing
+    /// ".0"; below it keeps the k form.
+    static func contextSize(_ context: Double?) -> String? {
+        guard let context, context.isFinite, context > 0 else { return nil }
+        if context >= 1_000_000 {
+            let m = context / 1_000_000
+            let rounded = (m * 10).rounded() / 10
+            let text = String(format: "%.1f", rounded)
+            let trimmed = text.hasSuffix(".0") ? String(text.dropLast(2)) : text
+            return "\(trimmed)M"
+        }
+        return "\(Int((context / 1000).rounded()))k"
+    }
+
+    /// Capability glyphs for a catalogue row, in display order:
+    /// "reasoning" when the model exposes reasoning effort (has variants),
+    /// "vision" when it accepts image input. The differentiator at scale is
+    /// capability, not a name — the list is drawn from the model's own data.
+    static func capabilityGlyphs(_ model: OpencodeModel) -> [String] {
+        var glyphs: [String] = []
+        if !(model.variants ?? []).isEmpty { glyphs.append("reasoning") }
+        if (model.capabilities?.input ?? []).contains(where: { $0.lowercased() == "image" }) {
+            glyphs.append("vision")
+        }
+        return glyphs
+    }
+
     /// Encode a selection as the persisted `providerID/modelID` string.
     static func encode(_ id: OpencodeModelID) -> String {
         "\(id.providerID)/\(id.modelID)"

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -32,6 +32,10 @@ final class ChatModelStore: ObservableObject {
     /// model "variants"). Model-specific, so it is cleared whenever the model
     /// changes rather than carried onto a model that has no such setting.
     @Published private(set) var variant: String?
+    /// The last 3–5 (model, effort, fast) triples actually used, most recent
+    /// first. Persisted PER BOX (a habit, not a conversation), unlike the
+    /// override/variant above which are per-session.
+    @Published private(set) var recents: [ModelChoice] = []
 
     let sessionId: String
     private let catalog: ChatModelCatalog
@@ -51,6 +55,7 @@ final class ChatModelStore: ObservableObject {
         self.defaultModel = catalog.defaultModel
         self.loadFailed = catalog.loadFailed
         self.loaded = catalog.loaded
+        self.recents = ModelRecents.load()
         catalog.objectWillChange
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.mirrorCatalog() }
@@ -129,6 +134,68 @@ final class ChatModelStore: ObservableObject {
     /// The effort variants the ACTIVE model offers (empty when it has none).
     var activeVariants: [OpencodeModel.Variant] {
         ChatModel.activeModel(models, override: override, default: defaultModel)?.variants ?? []
+    }
+
+    // MARK: - Recents (BET-825)
+
+    /// The currently-active (model, effort, fast) triple, or nil when there is
+    /// no per-session override (the "Server default" state — the checkmark
+    /// lands on Server default, not on a recent). `modelID` is always the
+    /// base id; fast is expressed as the `fast` flag.
+    var activeChoice: ModelChoice? {
+        guard let override, let active = ChatModel.activeModel(models, override: override, default: defaultModel) else {
+            return nil
+        }
+        return ModelChoice(
+            providerID: override.providerID,
+            modelID: ChatModel.baseModelID(active.id),
+            variant: variant,
+            fast: ChatModel.isFastModelID(active.id)
+        )
+    }
+
+    /// Apply a stored recent choice (base model id + effort + fast) to the
+    /// override + variant, then move it to the front of recents. Selecting a
+    /// recent IS the act of using it, so it is recorded on apply.
+    func apply(_ choice: ModelChoice) {
+        let targetID = choice.fast ? ChatModel.fastModelID(choice.modelID) : choice.modelID
+        setOverride(OpencodeModelID(providerID: choice.providerID, modelID: targetID))
+        setVariant(choice.variant)
+        recents = ModelRecents.record(choice, into: recents)
+        ModelRecents.save(recents)
+    }
+
+    /// Record the current effective (model, effort, fast) as a recent — called
+    /// when the user changes effort or fast, or picks a model from the
+    /// catalogue sheet. Only records when the user has an explicit model
+    /// override (the "Server default" state is not a recent — it is the
+    /// always-present escape hatch, so it must not crowd recents with one
+    /// entry per effort dial).
+    func recordCurrentChoice() {
+        guard
+            let override,
+            let active = ChatModel.activeModel(models, override: override, default: defaultModel)
+        else { return }
+        let choice = ModelChoice(
+            providerID: override.providerID,
+            modelID: ChatModel.baseModelID(active.id),
+            variant: variant,
+            fast: ChatModel.isFastModelID(active.id)
+        )
+        recents = ModelRecents.record(choice, into: recents)
+        ModelRecents.save(recents)
+    }
+
+    /// Flip fast mode on the active model, carrying the current effort across
+    /// (the fast twin keeps the chosen effort, or fast is unavailable). Moved
+    /// here from the sheet so the menu and the sheet share one implementation.
+    func setFast(_ on: Bool) {
+        guard let active = ChatModel.activeModel(models, override: override, default: defaultModel) else { return }
+        let f = ChatModel.fastToggle(models: models, active: active, variantId: variant)
+        guard let target = f.target else { return }
+        let currentVariant = variant
+        setOverride(OpencodeModelID(providerID: target.providerID, modelID: target.modelID))
+        if let currentVariant { setVariant(currentVariant) }
     }
 
     static func loadOverride(for sessionId: String) -> OpencodeModelID? {

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -459,44 +459,188 @@ struct ComposerView: View {
         .presentationDetents([.large])
     }
 
-    // MARK: - Model pill
+    // MARK: - Model pill → menu (BET-825)
 
+    /// The composer chip: a real control (a `Menu`) anchored on a filled
+    /// capsule. The capsule is ONE token — "✦ Opus 4.7 · High" plus a bolt when
+    /// fast — with a fill, so the resolved (model · effort · fast) triple reads
+    /// at a glance and the model name can never wrap. The menu holds the common
+    /// case (recents + inline effort + fast); the catalogue sheet is reached
+    /// only from "More Models…".
     private var modelPill: some View {
-        Button {
-            showModelPicker = true
+        Menu {
+            modelMenuContent
         } label: {
-            HStack(spacing: Metrics.spacing.sp1) {
+            chipLabel
+        }
+        .accessibilityLabel("Model")
+        .accessibilityIdentifier("model-picker")
+    }
+
+    /// The chip's single-line label: "✦ Opus 4.7 · High" + bolt when fast.
+    /// `.lineLimit(1)` + `.fixedSize(horizontal:)` is load-bearing — the model
+    /// name must never wrap at any Dynamic Type size.
+    private var chipLabel: some View {
+        HStack(spacing: Metrics.spacing.sp1) {
+            if modelStore.loaded {
                 Image(systemName: "sparkles")
                     .font(.system(size: Metrics.type.xs, weight: .medium))
-                if modelStore.loaded {
-                    Text(ChatModel.label(modelStore.models, override: modelStore.override, default: modelStore.defaultModel))
-                        .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
-                        .lineLimit(1)
-                    if let variant = modelStore.variant, !variant.isEmpty {
-                        Text("·")
-                            .font(.manta(size: Metrics.type.small))
-                        Text(variant.capitalized)
-                            .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
-                            .lineLimit(1)
-                    }
-                } else {
-                    // Box-wide model list still arriving — show an explicit
-                    // loading state rather than a misleading "Default".
-                    ProgressView()
-                        .controlSize(.mini)
-                        .accessibilityLabel("Loading models")
+                Text(resolvedChipText)
+                    .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                    .lineLimit(1)
+                    .fixedSize(horizontal: true, vertical: false)
+                if isFastActive {
+                    Image(systemName: "bolt.fill")
+                        .font(.system(size: Metrics.type.xs, weight: .semibold))
+                }
+            } else {
+                // Box-wide model list still arriving — show an explicit
+                // loading state rather than a misleading "Default".
+                ProgressView()
+                    .controlSize(.mini)
+                    .accessibilityLabel("Loading models")
+            }
+        }
+        .foregroundColor(tokens.accentTx)
+        .padding(.vertical, Metrics.spacing.sp1)
+        .padding(.horizontal, Metrics.spacing.sp2)
+        .background(tokens.accentSoft, in: Capsule())
+        .lineLimit(1)
+    }
+
+    private var activeModel: OpencodeModel? {
+        ChatModel.activeModel(modelStore.models, override: modelStore.override, default: modelStore.defaultModel)
+    }
+
+    private var isFastActive: Bool {
+        guard let active = activeModel else { return false }
+        return ChatModel.isFastModelID(active.id)
+    }
+
+    /// The chip's resolved triple as a single run: "Opus 4.7 · High" (the ⚡
+    /// is a separate bolt glyph). One run, never two — three axes with only
+    /// one visible is how a quota gets burned on max effort unnoticed.
+    private var resolvedChipText: String {
+        guard let model = activeModel else { return "Default" }
+        var parts = [model.name]
+        if let variant = modelStore.variant, !variant.isEmpty {
+            parts.append(variant.capitalized)
+        }
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Tier 1 menu content
+
+    /// The menu: recents + Server default, inline effort + fast, then the
+    /// catalogue sheet. Order is HIG-driven (most-frequent first).
+    @ViewBuilder
+    private var modelMenuContent: some View {
+        // 1. Recents (most recent first) + the ever-present Server-default
+        //    escape. Each recent is a (model, effort, fast) triple.
+        if !modelStore.recents.isEmpty {
+            ForEach(modelStore.recents, id: \.self) { choice in
+                recentButton(choice)
+            }
+        }
+        Button(action: { modelStore.setOverride(nil) }) {
+            HStack {
+                Text("Server default")
+                Spacer()
+                if modelStore.override == nil { Image(systemName: "checkmark") }
+            }
+        }
+
+        // 3 + 4. Effort (inline segmented) and Fast mode. Omitted when the
+        //    active model offers neither — a model with no variants shows no
+        //    effort control anywhere.
+        if showEffortPicker || showFastToggle {
+            Divider()
+            if showEffortPicker {
+                effortPicker
+            }
+            if showFastToggle {
+                fastToggle
+            }
+            Divider()
+        } else {
+            Divider()
+        }
+
+        // 6. The catalogue sheet — the ellipsis (per HIG, it opens another view).
+        Button { showModelPicker = true } label: {
+            Label("More Models…", systemImage: "ellipsis")
+        }
+    }
+
+    private func recentButton(_ choice: ModelChoice) -> some View {
+        Button(action: { modelStore.apply(choice) }) {
+            HStack {
+                Text(ModelRecents.label(for: choice, models: modelStore.models))
+                    .lineLimit(1)
+                Spacer()
+                if modelStore.activeChoice == choice {
+                    Image(systemName: "checkmark")
                 }
             }
-            .foregroundColor(tokens.accentTx)
-            // Bare accent label, no pill fill: only Send carries a background
-            // in this row. No horizontal padding so the label sits flush at the
-            // box's left edge — the same distance from the border as Send is on
-            // the right. Vertical padding keeps a comfortable tap target.
-            .padding(.vertical, Metrics.spacing.sp1)
         }
-        .buttonStyle(.plain)
-        .accessibilityLabel("Model picker")
-        .accessibilityIdentifier("model-picker")
+    }
+
+    private var showEffortPicker: Bool {
+        !modelStore.activeVariants.isEmpty
+    }
+
+    private var fastToggleState: ChatModel.FastToggle {
+        ChatModel.fastToggle(models: modelStore.models, active: activeModel, variantId: modelStore.variant)
+    }
+
+    private var showFastToggle: Bool {
+        let fast = fastToggleState
+        return fast.available || fast.on
+    }
+
+    /// Inline segmented effort control — a segmented control shows the CURRENT
+    /// value without a second tap, which an effort submenu cannot. The "Default"
+    /// segment is the model's recommended level (no explicit variant).
+    private var effortPicker: some View {
+        let selection = Binding<String>(
+            get: { modelStore.variant ?? "" },
+            set: { newValue in
+                if newValue.isEmpty {
+                    modelStore.setVariant(nil)
+                } else {
+                    modelStore.setVariant(newValue)
+                }
+                modelStore.recordCurrentChoice()
+            }
+        )
+        return VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+            Text("Effort")
+                .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))
+                .foregroundColor(tokens.tx3)
+            Picker("Effort", selection: selection) {
+                Text("Default").tag("")
+                ForEach(modelStore.activeVariants, id: \.id) { variant in
+                    Text(variant.id.capitalized).tag(variant.id)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    /// Fast-mode toggle — a session-level flag, so it sits at the same level
+    /// as effort, never nested under it. Omitted when the model has no fast twin.
+    private var fastToggle: some View {
+        let fast = fastToggleState
+        return Toggle(isOn: Binding(
+            get: { fast.on },
+            set: { on in
+                modelStore.setFast(on)
+                modelStore.recordCurrentChoice()
+            }
+        )) {
+            Label("Fast mode", systemImage: fast.on ? "bolt.fill" : "bolt")
+        }
+        .disabled(!fast.available)
     }
 
     // MARK: - Scroll to bottom

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -278,6 +278,18 @@ struct OpencodeModel: Codable, Equatable, Sendable {
     /// context window (Opus 4.7 reports 1M, Sonnet 200k) — the denominator the
     /// context meter must use, never a hardcoded 200k.
     var limit: ModelLimit? = nil
+    /// The model's declared input/output capabilities (`{tools, input, output}`
+    /// from the box's `getProviders()`/`listModels()`). `input` is the list of
+    /// accepted input modalities ("text", "image", ...) — whether the row shows
+    /// a "vision" glyph. Absent for providers that don't annotate it.
+    var capabilities: ModelCapabilities? = nil
+}
+
+/// The model's advertised capabilities from `opencode:models` (`capabilities`).
+struct ModelCapabilities: Codable, Equatable, Sendable {
+    var tools: Bool?
+    var input: [String]?
+    var output: [String]?
 }
 
 /// The model's advertised limits from `opencode:models` (`limit: { context }`).

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -1,46 +1,34 @@
 import SwiftUI
 
 // ===========================================================================
-// Model + effort selection.
+// Tier 2 — the model CATALOGUE (BET-825).
 //
-// These are TWO independent choices and are presented as such: which model
-// answers, and how much reasoning effort it spends. Effort is model-specific
-// (opencode exposes it as a model's "variants"), so the effort list is derived
-// from the chosen model and is simply absent for a model that offers none —
-// rather than being a fixed set of levels that silently do nothing.
+// Reached ONLY from the composer chip's menu → "More Models…". This is the
+// escape hatch for the long tail (searchable grouped list), not the front door
+// — the common case lives in the menu (recents + inline effort + fast).
 //
-// Native iOS surface (HIG-aligned): a grouped Form/List in a sheet, ordered
-//                                ...
-//   - "Server default" row pinned first — the effective model when no per-
-//     session override is set.
-//   - A "Fast mode" Toggle, shown only when the active model has a fast twin
-//     available (desktop ⚡ logic). Fast flavours (`<id>-fast`) are a MODE of
-//     the base model, not a separate row, so they are hidden from the groups
-//     and reached through this toggle.
-//   - An "Effort" section listing the active model's variants (Default + each).
-//   - The model list grouped into Section per provider (the desktop menu's
-//     shape), with a search strip and a checkmark on the selected row.
+// The sheet opens at medium (recents + search visible) and drags to large to
+// reveal the full grouped catalogue. Effort and Fast mode are GONE from here:
+// they moved to the menu (Tier 1), so a decision is never set in two places.
+// The effort/fast sections this sheet used to own were the duplicate code
+// path this work exists to remove.
 //
-// Tapping a model sets the per-session override; toggling Fast swaps the
-// override to the model's `-fast` twin (or back), carrying the chosen effort.
+// Each row carries its context size + capability glyphs ("1M · reasoning ·
+// vision") — at this scale the differentiator is capability, not name. The k/M
+// badge comes from the shared `ChatModel.contextSize` (a port of the desktop's
+// `formatModelContextSize`), never re-derived inline.
 // ===========================================================================
 
 struct ModelPickerSheet: View {
     @ObservedObject var modelStore: ChatModelStore
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
     @State private var query = ""
+
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
     private var groups: [(provider: String, models: [OpencodeModel])] {
         ChatModel.filteredGroups(ChatModel.groups(modelStore.models), query: query)
-    }
-
-    private var activeModel: OpencodeModel? {
-        ChatModel.activeModel(modelStore.models, override: modelStore.override, default: modelStore.defaultModel)
-    }
-
-    /// The fast-mode toggle state for the active model (desktop `resolveFastToggle`).
-    private var fast: ChatModel.FastToggle {
-        ChatModel.fastToggle(models: modelStore.models, active: activeModel, variantId: modelStore.variant)
     }
 
     private func isSelected(_ m: OpencodeModel) -> Bool {
@@ -48,17 +36,20 @@ struct ModelPickerSheet: View {
         return override.providerID == m.providerID && override.modelID == m.id
     }
 
+    /// Pick a model from the catalogue and record it as a recently-used triple.
     private func select(_ m: OpencodeModel) {
         modelStore.setOverride(OpencodeModelID(providerID: m.providerID, modelID: m.id))
+        modelStore.recordCurrentChoice()
     }
 
-    /// Apply the fast-mode toggle: switch the override to the model's `-fast`
-    /// twin (or its base), carrying the currently-chosen effort across.
-    private func applyFastToggle(_ on: Bool) {
-        guard let target = fast.target else { return }
-        let currentVariant = modelStore.variant
-        modelStore.setOverride(OpencodeModelID(providerID: target.providerID, modelID: target.modelID))
-        if let currentVariant { modelStore.setVariant(currentVariant) }
+    /// The row's badge line: context size, then capability glyphs.
+    private func badgeText(_ m: OpencodeModel) -> String {
+        var parts: [String] = []
+        if let ctx = ChatModel.contextSize(m.limit?.context) {
+            parts.append(ctx)
+        }
+        parts.append(contentsOf: ChatModel.capabilityGlyphs(m))
+        return parts.joined(separator: " · ")
     }
 
     var body: some View {
@@ -67,11 +58,8 @@ struct ModelPickerSheet: View {
                 if modelStore.loaded {
                     List {
                         serverDefaultSection
-                        if fast.available || fast.on {
-                            fastSection
-                        }
-                        if !modelStore.activeVariants.isEmpty {
-                            effortSection
+                        if !modelStore.recents.isEmpty {
+                            recentsSection
                         }
                         providerSections
                     }
@@ -87,7 +75,7 @@ struct ModelPickerSheet: View {
                         .frame(maxWidth: .infinity, maxHeight: .infinity)
                 }
             }
-            .navigationTitle("Model")
+            .navigationTitle("All models")
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
@@ -95,15 +83,19 @@ struct ModelPickerSheet: View {
                 }
             }
         }
-        .presentationDetents([.large])
+        // Medium shows the recents + search; dragging up reveals the full
+        // grouped catalogue. Not `.large`-only — that is the old full-height
+        // sheet this replaces.
+        .presentationDetents([.medium, .large])
         .presentationDragIndicator(.visible)
         .onAppear { modelStore.load() }
     }
 
-    /// The "Server default" row — the effective model when no override is set.
+    /// The "Server default" row — pinned first, the effective model when no
+    /// override is set.
     private var serverDefaultSection: some View {
         Section {
-            Button { modelStore.setOverride(nil) } label: {
+            Button { setOverrideAndDismiss(nil) } label: {
                 HStack {
                     Text("Server default")
                     Spacer()
@@ -120,58 +112,47 @@ struct ModelPickerSheet: View {
         }
     }
 
-    /// Fast-mode toggle, present only when it can do something.
-    private var fastSection: some View {
-        Section {
-            Toggle(isOn: Binding(get: { fast.on }, set: { applyFastToggle($0) })) {
-                Label("Fast mode", systemImage: fast.on ? "bolt.fill" : "bolt")
-            }
-            .disabled(!fast.available)
-            .accessibilityIdentifier("model-fast-toggle")
-        } footer: {
-            Text(fast.title)
-        }
-    }
-
-    /// Effort/variant list for the ACTIVE model. Absent when it offers none.
-    private var effortSection: some View {
-        Section("Effort") {
-            Button { modelStore.setVariant(nil) } label: {
-                HStack {
-                    Text("Default")
-                    Spacer()
-                    if modelStore.variant == nil { checkmark }
-                }
-            }
-            ForEach(modelStore.activeVariants, id: \.id) { variant in
-                Button { modelStore.setVariant(variant.id) } label: {
+    /// The recently-used triples, most recent first — the habitual models the
+    /// menu already surfaces, kept here so the medium detent of this sheet
+    /// reads like the same habit.
+    private var recentsSection: some View {
+        Section("Recents") {
+            ForEach(modelStore.recents, id: \.self) { choice in
+                Button { applyAndDismiss(choice) } label: {
                     HStack {
-                        Text(variant.id.capitalized)
+                        Text(ModelRecents.label(for: choice, models: modelStore.models))
+                            .lineLimit(1)
                         Spacer()
-                        if modelStore.variant == variant.id { checkmark }
+                        if modelStore.activeChoice == choice { checkmark }
                     }
                 }
             }
         }
     }
 
-    /// The model list, grouped into a Section per provider.
+    /// The model list, grouped into a Section per provider. Empty-query misses
+    /// render the platform search empty state rather than ad-hoc text.
     @ViewBuilder
     private var providerSections: some View {
         if groups.isEmpty {
             if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                Section {
-                    Text("No models match")
-                        .foregroundStyle(.secondary)
-                }
+                ContentUnavailableView.search(text: "No models match")
             }
         } else {
             ForEach(groups, id: \.provider) { group in
                 Section {
                     ForEach(group.models, id: \.id) { m in
-                        Button { select(m) } label: {
-                            HStack {
-                                Text(m.name)
+                        Button { select(m); dismiss() } label: {
+                            HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
+                                VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
+                                    Text(m.name)
+                                        .lineLimit(1)
+                                    if !badgeText(m).isEmpty {
+                                        Text(badgeText(m))
+                                            .font(.manta(size: Metrics.type.xs))
+                                            .foregroundColor(tokens.tx3)
+                                    }
+                                }
                                 Spacer()
                                 if isSelected(m) { checkmark }
                             }
@@ -182,6 +163,16 @@ struct ModelPickerSheet: View {
                 }
             }
         }
+    }
+
+    private func setOverrideAndDismiss(_ id: OpencodeModelID?) {
+        modelStore.setOverride(id)
+        dismiss()
+    }
+
+    private func applyAndDismiss(_ choice: ModelChoice) {
+        modelStore.apply(choice)
+        dismiss()
     }
 
     private var checkmark: some View {

--- a/mobile/native/MantaUI/ModelRecents.swift
+++ b/mobile/native/MantaUI/ModelRecents.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+// ===========================================================================
+// BET-825 — the composer model menu's recents: the last 3–5 (model, effort,
+// fast) triples actually used, most recent first.
+//
+// Recents are a HABIT, not a conversation, so they persist PER BOX under a
+// single UserDefaults key — deliberately NOT per session, unlike the model
+// override/variant (which live in ChatModelStore under per-session keys). The
+// store loads them once at init and writes them on every change.
+//
+// `modelID` in a choice is ALWAYS the base (non-`-fast`) id: fast is an
+// orthogonal mode bit, not a separate model, so the same model at the same
+// effort with fast off/on is a distinct entry. Dedup/ordering/cap logic is
+// pure (mirrors `BranchFreshnessPolicy` in ChatScreen.swift); persistence is a
+// thin pair of helpers beside it.
+// ===========================================================================
+
+/// One remembered (model, effort, fast) selection, most recent first.
+struct ModelChoice: Codable, Hashable, Sendable {
+    let providerID: String
+    /// The BASE model id — never a `-fast` flavour (fast is the `fast` flag).
+    let modelID: String
+    /// The reasoning-effort variant id, or nil (the model's recommended default).
+    let variant: String?
+    /// Whether the fast twin of `modelID` is used.
+    let fast: Bool
+}
+
+enum ModelRecents {
+    /// The recents list is capped at this many entries.
+    static let capacity = 5
+    /// Per-box storage key (recents are a habit, not tied to one session).
+    static let storageKey = "manta:model-recents"
+
+    /// Insert a choice at the front, de-duplicating on the WHOLE triple. A
+    /// choice already in the list is moved to the front without duplicating;
+    /// the same model at a different effort (or fast state) is distinct. The
+    /// list never grows past `capacity` — the oldest entry drops off.
+    static func record(_ choice: ModelChoice, into list: [ModelChoice]) -> [ModelChoice] {
+        var out = list.filter { $0 != choice }
+        out.insert(choice, at: 0)
+        return Array(out.prefix(capacity))
+    }
+
+    /// The display label for a stored choice: "Opus 4.7 · High" with a bolt
+    /// appended when fast is on. Resolves the friendly name from the model
+    /// list, falling back to the model id when the list doesn't name it.
+    static func label(for choice: ModelChoice, models: [OpencodeModel]) -> String {
+        let name = models.first {
+            $0.providerID == choice.providerID && ChatModel.baseModelID($0.id) == choice.modelID
+        }?.name ?? choice.modelID
+        var parts = [name]
+        if let variant = choice.variant, !variant.isEmpty {
+            parts.append(variant.capitalized)
+        }
+        if choice.fast { parts.append("⚡") }
+        return parts.joined(separator: " · ")
+    }
+
+    // MARK: - Persistence (per box)
+
+    static func load(_ defaults: UserDefaults = .standard) -> [ModelChoice] {
+        guard let data = defaults.data(forKey: storageKey),
+              let list = try? JSONDecoder().decode([ModelChoice].self, from: data)
+        else { return [] }
+        return list
+    }
+
+    static func save(_ list: [ModelChoice], _ defaults: UserDefaults = .standard) {
+        if let data = try? JSONEncoder().encode(list) {
+            defaults.set(data, forKey: storageKey)
+        }
+    }
+}

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -46,7 +46,7 @@ final class ModelRecentsTests: XCTestCase {
         let list = ModelRecents.record(low, into: [])
         let list2 = ModelRecents.record(high, into: list)
         XCTAssertEqual(list2.count, 2)
-        XCTAssertEqual(list2.map(\.variant).sorted(), ["high", "low"])
+        XCTAssertEqual(list2.map { $0.variant ?? "" }.sorted(), ["high", "low"])
     }
 
     func testSameModelDifferentFastIsDistinct() {
@@ -66,7 +66,7 @@ final class ModelRecentsTests: XCTestCase {
         list = ModelRecents.record(b, into: list)
         // Re-picking A brings it back to front, keeping B.
         list = ModelRecents.record(a, into: list)
-        XCTAssertEqual(list.map(\.variant), ["high", "max"])
+        XCTAssertEqual(list.map { $0.variant ?? "" }, ["high", "max"])
     }
 
     // MARK: - label

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -1,0 +1,142 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// BET-825 — the composer model menu's pure logic: ModelRecents (ordered,
+// capped, de-duplicated on the whole triple) and the catalogue row badges
+// (ChatModel.contextSize port of the desktop formatModelContextSize, and
+// ChatModel.capabilityGlyphs). No view, no HTTP, no box.
+// ===========================================================================
+
+final class ModelRecentsTests: XCTestCase {
+
+    private func choice(_ model: String = "opus", variant: String? = nil, fast: Bool = false) -> ModelChoice {
+        ModelChoice(providerID: "anthropic", modelID: model, variant: variant, fast: fast)
+    }
+
+    // MARK: - record (ordering, dedup, cap)
+
+    func testNewChoiceGoesToFront() {
+        let list = ModelRecents.record(choice("sonnet"), into: [])
+        let list2 = ModelRecents.record(choice("haiku"), into: list)
+        XCTAssertEqual(list2.map(\.modelID), ["haiku", "sonnet"])
+    }
+
+    func testReSelectingExistingMovesToFrontWithoutDuplicate() {
+        let list = ModelRecents.record(choice("haiku"), into: [])
+        let list2 = ModelRecents.record(choice("opus"), into: list)
+        let list3 = ModelRecents.record(choice("haiku"), into: list2)
+        XCTAssertEqual(list3.map(\.modelID), ["haiku", "opus"])
+        XCTAssertEqual(list3.count, 2)
+    }
+
+    func testCapsAtFiveAndDropsOldest() {
+        var list: [ModelChoice] = []
+        for i in 0..<7 {
+            list = ModelRecents.record(choice("m\(i)"), into: list)
+        }
+        XCTAssertEqual(list.count, 5)
+        // Most recent first; the two oldest (m0, m1) dropped.
+        XCTAssertEqual(list.map(\.modelID), ["m6", "m5", "m4", "m3", "m2"])
+    }
+
+    func testSameModelDifferentEffortIsDistinct() {
+        let low = choice("opus", variant: "low")
+        let high = choice("opus", variant: "high")
+        let list = ModelRecents.record(low, into: [])
+        let list2 = ModelRecents.record(high, into: list)
+        XCTAssertEqual(list2.count, 2)
+        XCTAssertEqual(list2.map(\.variant).sorted(), ["high", "low"])
+    }
+
+    func testSameModelDifferentFastIsDistinct() {
+        let normal = choice("haiku")
+        let fast = choice("haiku", fast: true)
+        let list = ModelRecents.record(normal, into: [])
+        let list2 = ModelRecents.record(fast, into: list)
+        XCTAssertEqual(list2.count, 2)
+    }
+
+    func testRecordIsMostRecentFirstAfterRefill() {
+        // De-duplication happens on the whole triple each time.
+        let a = choice("opus", variant: "high")
+        let b = choice("opus", variant: "max")
+        var list: [ModelChoice] = []
+        list = ModelRecents.record(a, into: list)
+        list = ModelRecents.record(b, into: list)
+        // Re-picking A brings it back to front, keeping B.
+        list = ModelRecents.record(a, into: list)
+        XCTAssertEqual(list.map(\.variant), ["high", "max"])
+    }
+
+    // MARK: - label
+
+    func testLabelResolvesFriendlyNameAndEffort() {
+        let models = [OpencodeModel(id: "opus", providerID: "anthropic", name: "Claude Opus 4.7")]
+        let c = ModelChoice(providerID: "anthropic", modelID: "opus", variant: "high", fast: false)
+        XCTAssertEqual(ModelRecents.label(for: c, models: models), "Claude Opus 4.7 · High")
+    }
+
+    func testLabelAppendsBoltWhenFast() {
+        let models = [OpencodeModel(id: "haiku", providerID: "anthropic", name: "Claude Haiku 4")]
+        let c = ModelChoice(providerID: "anthropic", modelID: "haiku", variant: nil, fast: true)
+        XCTAssertEqual(ModelRecents.label(for: c, models: models), "Claude Haiku 4 · ⚡")
+    }
+
+    func testLabelFallsBackToModelIDWhenUnknown() {
+        let c = ModelChoice(providerID: "deepseek", modelID: "deepseek-chat", variant: nil, fast: false)
+        XCTAssertEqual(ModelRecents.label(for: c, models: []), "deepseek-chat")
+    }
+
+    // MARK: - ChatModel.contextSize (desktop formatModelContextSize port)
+
+    func testContextSizeKForm() {
+        XCTAssertEqual(ChatModel.contextSize(200_000), "200k")
+        XCTAssertEqual(ChatModel.contextSize(250_000), "250k")
+    }
+
+    func testContextSizeMForm() {
+        XCTAssertEqual(ChatModel.contextSize(1_000_000), "1M")
+        XCTAssertEqual(ChatModel.contextSize(1_500_000), "1.5M")
+    }
+
+    func testContextSizeNilAndInvalid() {
+        XCTAssertNil(ChatModel.contextSize(nil))
+        XCTAssertNil(ChatModel.contextSize(0))
+        XCTAssertNil(ChatModel.contextSize(-5))
+        XCTAssertNil(ChatModel.contextSize(.infinity))
+    }
+
+    // MARK: - ChatModel.capabilityGlyphs
+
+    private func gylphModel(variants: Int = 0, input: [String] = []) -> OpencodeModel {
+        OpencodeModel(
+            id: "m",
+            providerID: "p",
+            name: "m",
+            variants: (0..<variants).map { OpencodeModel.Variant(id: "v\($0)") },
+            capabilities: ModelCapabilities(input: input)
+        )
+    }
+
+    func testReasoningFromVariants() {
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(variants: 3)), ["reasoning"])
+    }
+
+    func testVisionFromImageInput() {
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(input: ["text", "image"])), ["vision"])
+    }
+
+    func testBothInOrderReasoningThenVision() {
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(variants: 5, input: ["text", "image"])), ["reasoning", "vision"])
+    }
+
+    func testEmptyWhenNeither() {
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel()), [])
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(input: ["text"])), [])
+    }
+
+    func testVisionCaseInsensitive() {
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(input: ["Image"])), ["vision"])
+    }
+}


### PR DESCRIPTION
## BET-825 — iOS model picker: composer menu for the common case, searchable sheet for the long tail

Three independent axes (model · effort · fast) previously stacked as three list sections in one full-height sheet. Now: a **menu** on the composer chip for the 95% case (recents + inline effort + fast) and a **searchable catalogue sheet** (`[.medium, .large]`) reached only from *More Models…* as the escape hatch. Deletes more than it adds.

### Deleted symbols
- `ModelPickerSheet.fastSection` — fast moved to the menu (one code path, never two)
- `ModelPickerSheet.effortSection` — effort moved to the menu (one code path, never two)
- `ModelPickerSheet.applyFastToggle` — moved into `ChatModelStore.setFast(_:)` (single implementation)
- `ModelPickerSheet` `.presentationDetents([.large])` — now `[.medium, .large]` with drag indicator
- The "No models match" ad-hoc `Text` — now `ContentUnavailableView.search`
- `ComposerView.modelPill` as a bare-accent `Button` — now a `Menu` anchored on a filled capsule (`Tokens.accentSoft`, capsule, `sp1`/`sp2` padding, `lineLimit(1)` + `fixedSize(horizontal:)` so the name never wraps)
- The two-run model/variant pill text — now a single `"Opus 4.7 · High"` run (+ `bolt.fill` when fast)

**New view structs: none.** The menu lives inline in `ComposerView`; `ModelPickerSheet` was reworked in place.

### What was added
- `mobile/native/MantaUI/ModelRecents.swift` — `ModelChoice` + `ModelRecents` (pure `record`, capped at 5, de-duped on the whole triple, per-box `UserDefaults`)
- `ChatModel.contextSize(_:)` — port of the desktop `formatModelContextSize` (no inline `Math.round`-style re-derive)
- `ChatModel.capabilityGlyphs(_:)` — "reasoning" (has variants) / "vision" (accepts image input) from the model's own `capabilities`
- `OpencodeModel.capabilities` + `ModelCapabilities` DTO (from `opencode:models`)
- `ChatModelStore`: `recents`, `activeChoice`, `apply(_:)`, `recordCurrentChoice()`, `setFast(_:)`
- `mobile/native/MantaUITests/ModelRecentsTests.swift` — recents ordering/dedup/cap, label, `contextSize`, `capabilityGlyphs`

### Verification
- `ios-mantaui` `compile-only` @ 721dec34 → **COMPILE: PASS** (app target, xcodegen PASS)
- `ios-mantaui` `test-unit` @ `multica/BET-825-ios-model-picker-menu` HEAD (55484f61) → **UNIT: PASS — Executed 362 tests, 0 failures**

This change is Swift-only (native iOS); no `src/` TS/JS or `src/server/` code was touched.

**Base: origin/main @ e827852a**
