### PR TITLE
fix(server/forge): diff/draft panes resolve no_pr when branch has no open PR (BET-875)

### DIFF
--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -552,9 +552,10 @@ async function resolveRefContext(ref, deps) {
 
 // Pick the PR number a diff/draft read targets. An explicit `{ repoKey, number }`
 // ref wins outright (a cross-repo inbox PR — never derived from a branch). A
-// cwd ref picks the open PR on the current branch, falling back to the first
-// open PR, exactly as before. Returns `{ number, stale }` or `{ error: "no_pr" }`
-// / `{ rateLimited: true }`.
+// cwd ref picks the open PR on the current branch; a branch with no open PR —
+// or no branch at all (detached HEAD) — resolves to `"no_pr"`, never someone
+// else's PR. Returns `{ number, stale }` or `{ error: "no_pr" }` /
+// `{ rateLimited: true }`.
 async function resolveRefNumber(ref, ctx, deps) {
   if (typeof ref === "object" && ref !== null && ref.repoKey) {
     const number = Number(ref.number);
@@ -566,8 +567,8 @@ async function resolveRefNumber(ref, ctx, deps) {
   if (prs.length === 0) return { error: "no_pr" };
   const currentBranch = deps.currentBranch ?? defaultCurrentBranch;
   const branch = await currentBranch(ctx.cwd);
-  let candidate = branch ? prs.find((p) => p.headRef === branch) : undefined;
-  if (!candidate) candidate = prs[0];
+  const candidate = branch ? prs.find((p) => p.headRef === branch) : undefined;
+  if (!candidate) return { error: "no_pr" };
   return { number: candidate.number, stale };
 }
 
@@ -995,13 +996,13 @@ export async function mergePullRequest(cwd, { number, method = "merge", sha } = 
 
 /**
  * forge:diff — the review pane's read. A `ref` is either a session `cwd`
- * (resolve cwd → origin → repo, then pick the open PR on the current branch,
- * falling back to the first open PR) OR an explicit cross-repo target
- * `{ repoKey, number }` for an inbox PR row (no git — the read addresses the
- * forge over the API directly, BET-850). Fetches the PR's raw unified diff +
- * normalised incoming threads + head SHA. Returns `{ diff, threads, headSha,
- * error }` — never throws for a repo with no forge ("no_forge"), no token
- * ("not_connected") or no PR ("no_pr").
+ * (resolve cwd → origin → repo, then pick the open PR on the current branch;
+ * a branch with none — or detached HEAD — yields "no_pr") OR an explicit
+ * cross-repo target `{ repoKey, number }` for an inbox PR row (no git — the
+ * read addresses the forge over the API directly, BET-850). Fetches the PR's
+ * raw unified diff + normalised incoming threads + head SHA. Returns `{ diff,
+ * threads, headSha, error }` — never throws for a repo with no forge
+ * ("no_forge"), no token ("not_connected") or no PR ("no_pr").
  *
  * @param {string | { cwd?: string } | { repoKey: string, number: number }} ref
  * @param {{ gitRemoteOrigin?: (cwd: string) => Promise<string|null>,

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -603,7 +603,10 @@ test("forgeDiffForCwd: open PRs exist but none on this branch → no_pr, not the
     resolveToken: async () => ({ token: "t", source: "cli" }),
     getAdapter: () =>
       diffAdapter({
-        prs: [OPEN_PR, { ...OPEN_PR, number: 43, headRef: "other" }],
+        prs: [
+          { ...OPEN_PR, headRef: "topic/a" },
+          { ...OPEN_PR, number: 43, headRef: "other" },
+        ],
         diff: "@@ -1 +1 @@\n+someone elses PR\n",
       }),
   });

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -596,6 +596,53 @@ test("forgeDiffForCwd: no open PR → no_pr (not an error)", async () => {
   assert.deepEqual(r.threads, []);
 });
 
+test("forgeDiffForCwd: open PRs exist but none on this branch → no_pr, not the first PR", async () => {
+  const r = await forgeDiffForCwd("/repo", {
+    gitRemoteOrigin: async () => "git@github.com:acme/widget.git",
+    currentBranch: async () => "feature/x",
+    resolveToken: async () => ({ token: "t", source: "cli" }),
+    getAdapter: () =>
+      diffAdapter({
+        prs: [OPEN_PR, { ...OPEN_PR, number: 43, headRef: "other" }],
+        diff: "@@ -1 +1 @@\n+someone elses PR\n",
+      }),
+  });
+  assert.deepEqual(r.error, "no_pr");
+  assert.equal(r.diff, "");
+  assert.deepEqual(r.threads, []);
+});
+
+test("forgeDiffForCwd: detached HEAD / unknown branch → no_pr, not the first PR", async () => {
+  const r = await forgeDiffForCwd("/repo", {
+    gitRemoteOrigin: async () => "git@github.com:acme/widget.git",
+    currentBranch: async () => null,
+    resolveToken: async () => ({ token: "t", source: "cli" }),
+    getAdapter: () =>
+      diffAdapter({
+        prs: [OPEN_PR],
+        diff: "@@ -1 +1 @@\n+someone elses PR\n",
+      }),
+  });
+  assert.deepEqual(r.error, "no_pr");
+  assert.equal(r.diff, "");
+  assert.deepEqual(r.threads, []);
+});
+
+test("forgeDiffForCwd: match is exact, not positional — picks the branch's PR", async () => {
+  const r = await forgeDiffForCwd("/repo", {
+    gitRemoteOrigin: async () => "git@github.com:acme/widget.git",
+    currentBranch: async () => "feature/x",
+    resolveToken: async () => ({ token: "t", source: "cli" }),
+    getAdapter: () =>
+      diffAdapter({
+        prs: [{ ...OPEN_PR, number: 1, headRef: "topic/a" }, OPEN_PR],
+        diff: "@@ -1 +1 @@\n+mine\n",
+      }),
+  });
+  assert.equal(r.error, null);
+  assert.equal(r.diff, "@@ -1 +1 @@\n+mine\n");
+});
+
 test("forgeDiffForCwd: explicit { repoKey, number } addresses the PR directly (BET-850)", async () => {
   // No git deps at all — the explicit inbox target must not touch cwd/git.
   const getAdapter = (kind, token) => {
@@ -646,12 +693,12 @@ test("forgeDiffForCwd: explicit target with an invalid number → no_pr", async 
 // A draft-op test kit: injectable git/forge deps plus an in-memory stand-in
 // for the durable draft store (deep-copy load/save). `headSha` is what the
 // adapter's getPullRequest reports as the PR's CURRENT head.
-function draftKit({ prs = [OPEN_PR], headSha = "abc", adapter } = {}) {
+function draftKit({ prs = [OPEN_PR], headSha = "abc", adapter, currentBranch = async () => "feature/x" } = {}) {
   let store = [];
   const events = [];
   const deps = {
     gitRemoteOrigin: async () => "https://github.com/acme/widget.git",
-    currentBranch: async () => "feature/x",
+    currentBranch,
     resolveToken: async () => ({ token: "ghp_t", source: "cli" }),
     getAdapter: () =>
       adapter ?? {
@@ -883,6 +930,21 @@ test("draft ops resolve no_forge / not_connected like the other write ops", asyn
     getAdapter: () => ({}),
   });
   assert.equal(rTok.error, "not_connected");
+});
+
+test("draft ops resolve no_pr when the branch has no open PR, not the first PR (BET-875)", async () => {
+  const k1 = draftKit({ prs: [{ ...OPEN_PR, headRef: "other" }] });
+  const rNone = await draftGetForCwd("/repo", k1);
+  assert.equal(rNone.draft, null);
+  assert.deepEqual(rNone.error, "no_pr");
+  const cNone = await draftCommentForCwd("/repo", { op: "add", comment: {} }, k1);
+  assert.equal(cNone.ok, false);
+  assert.deepEqual(cNone.error, "no_pr");
+
+  const k2 = draftKit({ currentBranch: async () => null });
+  const rDetached = await draftGetForCwd("/repo", k2);
+  assert.equal(rDetached.draft, null);
+  assert.deepEqual(rDetached.error, "no_pr");
 });
 
 test("forgeDeviceStart: an existing credential skips straight to the picker", async () => {


### PR DESCRIPTION
Duplicate of BET-866, one level down in the diff/review + draft panes.

**Base: `origin/main` @ `b24b866d`**

## Problem
`resolveRefNumber` resolved the diff/threads/draft-review target to the current branch's open PR, then **fell back to the first open PR in the repo** when the branch had none:

```js
let candidate = branch ? prs.find((p) => p.headRef === branch) : undefined;
if (!candidate) candidate = prs[0];   // ← wrong answer, not "no PR"
```

A session on `main`, an unshipped feature branch, or detached HEAD showed the diff of an **unrelated** open PR in the review/draft panes — the same wrong answer BET-866 fixed in the session header.

## Change
- `resolveRefNumber` (src/server/forge/index.mjs): no branch match (or no branch — detached HEAD) now returns `{ error: "no_pr" }`, never `prs[0]`. Reuses the existing `no_pr` value the zero-open-PR path already returns — no new error/empty literal.
- The explicit `{ repoKey, number }` cross-repo inbox branch is untouched (that ref never derives from a branch) — per scope guard.
- JSDoc on `resolveRefNumber` and `forgeDiffForCwd` updated to drop the "falling back to the first open PR" wording.

**Removed:** the first-open-PR fallback (2 lines).

## Tests (src/server/forge/index.test.mjs)
- `forgeDiffForCwd`: open PRs exist but none on branch → `no_pr`; detached HEAD → `no_pr`; match is exact, not positional.
- Draft ops: branch with no open PR → `no_pr` on both get and comment paths; detached → `no_pr`. (draftKit extended to accept a `currentBranch` override.)

## Verification results
- PR branch (`multica/BET-875-no-fallback-in-diff-draft-ref` @ `291f569a`):
  - typecheck: exit 0, clean. log sha256 `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0, **1980 pass / 0 fail / 0 skip**. log sha256 `fad9d72c66061536c87e4e0fce642324e97b0fa545806eb6b6df6fcd8e3a61c9`
- Base (`main` @ `b24b866d`):
  - typecheck: exit 0, clean. log sha256 `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0, **1976 pass / 0 fail / 0 skip**. log sha256 `cf902a0605756aa1a74fe96957ed5182368db3be520bbf039cc809e872ef69d8`
- **Conclusion:** 0 new failures; +4 tests added by this PR. Typecheck identical across branches.
