### PR TITLE
refactor(renderer): one git surface — delete ForgeCard, move Merge + Ship into the branch popover (BET-867)

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -343,7 +343,10 @@ everything it needs in the prompt: the goal, the relevant files/paths,
 constraints, and what "done" looks like. It commits to its own branch in its
 isolated worktree, and it **may open a draft pull request** for that branch —
 but it must **never merge**, never force-push, and must not touch any other
-checkout.
+checkout. (BET-867: a human clicking `Create PR` in the app is an explicit
+confirm — a *non-draft* pull request is allowed that way. The **never merge**
+prohibition is absolute and unweakened; nothing here gives an agent a path to
+create a PR, only the human-facing app is confirmed by the human's click.)
 
 **Install/update is a COPY, never a symlink.** Copy
 `docs/opencode-tools/delegate.ts` to `~/.config/opencode/tools/delegate.ts`

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -595,7 +595,9 @@ export function ChatPanel({
   // Base / Changes). Click-only surface ⇒ fetched on popover open, never
   // polled, and not re-fetched if already loaded for this cwd.
   const ensureShipPreview = useCallback(async () => {
-    if (!cwd || shipProposal) return;
+    if (!cwd) return;
+    setShipError(null);
+    if (shipProposal) return;
     try {
       const prev = await window.api.forgeShipPreview({ cwd });
       if (prev.ok) {

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -23,7 +23,6 @@ import type {
   DelegateApproval,
   DelegateApprovalTool,
   ForgeCheckRun,
-  ForgePullRequestResult,
   OpencodeModel,
   ProgressRecord,
   PullRequest,
@@ -54,8 +53,6 @@ import {
   type StaleCacheResult,
   type PendingScrollWin,
   isApprovalCoveredByAlways,
-  linkedPrNumber,
-  preferLinkedPr,
   MANTA_BUILTIN_COMMANDS,
   MANTA_BUILTIN_NAMES,
   parseModelRef,
@@ -83,7 +80,7 @@ import { MantaLoader } from "./MantaLoader";
 import { MeasureColumn } from "./MeasureColumn";
 import { BlockedProgressCard, CompactionCard, PermissionCard, RetryCard } from "./Cards";
 import { Button } from "./Button";
-import { DelegateApprovalCard, ForgeCard, ReadOnlyJobBar, ScheduledTasksCard, SecretsCard, ShipConfirmCard, WebhooksCard } from "./PanelCards";
+import { DelegateApprovalCard, ReadOnlyJobBar, ScheduledTasksCard, SecretsCard, ShipConfirmCard, WebhooksCard } from "./PanelCards";
 import { CardStack, type PinnedCardRender } from "./components/CardStack";
 import { useSessionResources } from "./hooks/useSessionResources";
 import { useInputHistory } from "./hooks/useInputHistory";
@@ -238,34 +235,17 @@ export function ChatPanel({
   const [pendingApproval, setPendingApproval] = useState<DelegateApproval | null>(null);
   const chatAutoAllowApproval = useStore((s) => s.chatAutoAllow);
 
-  // BET-794: forge ship + merge for this session. The server resolves cwd →
+  // BET-794/867: forge ship + merge for this session. The server resolves cwd →
   // repo → token box-side (a forge token never reaches the renderer). The
-  // ForgeCard shows the current PR + merge gate, or a Ship entry; the
-  // ShipConfirmCard is the mandatory human gate before anything is pushed or
-  // opened. Never auto-submitted.
-  const [forgeResult, setForgeResult] = useState<ForgePullRequestResult | null>(null);
-  const [forgeLoading, setForgeLoading] = useState(false);
-  const [forgeConnected, setForgeConnected] = useState(false);
+  // branch chip's popover is the merge surface (BET-867); the ShipConfirmCard
+  // is the mandatory human gate before a Draft PR is pushed/opened, and Create
+  // PR ships inline (BET-867 owner-approved departure) — never auto-submitted.
   const [shipOpen, setShipOpen] = useState(false);
   const [shipProposal, setShipProposal] = useState<{ head: string; base: string; fileCount: number; title: string; body: string } | null>(null);
   const [shipBusy, setShipBusy] = useState(false);
   const [shipError, setShipError] = useState<string | null>(null);
   const [mergeBusy, setMergeBusy] = useState(false);
   const [mergeError, setMergeError] = useState<string | null>(null);
-  // BET-852: the stored session-link PR number (`projects[].link.pr`), read off
-  // the box config. The branch chip prefers it over the (15s) live forge lookup
-  // when present — so a freshly-shipped PR's number appears immediately and
-  // independently of the poll resolving. Refreshed on session change and after
-  // a ship/merge writes the link.
-  const [linkedPr, setLinkedPr] = useState<number | null>(null);
-  const refreshLinkedPr = useCallback(async () => {
-    try {
-      const cfg = await window.api.configGet();
-      setLinkedPr(linkedPrNumber(cfg, tmuxSession));
-    } catch {
-      /* non-fatal — fall back to the live lookup */
-    }
-  }, [tmuxSession]);
 
   // BET-418 §D: detect whether THIS session is a background job's child. A
   // job session is read-only (no composer, no cards, no model picker/fork/
@@ -510,95 +490,6 @@ export function ChatPanel({
     return () => { cancelled = true; clearInterval(t); };
   }, [sessionId, chatAutoAllowApproval, isActive]);
 
-  // BET-794: poll the forge read path for this session's cwd (the PR + its CI
-  // rollup) while the panel is active. 15s cadence keeps the merge gate fresh
-  // without hammering the forge; a per-session poll mirrors the approval poll.
-  useEffect(() => {
-    if (!isActive || !cwd) return;
-    setForgeLoading(true);
-    let cancelled = false;
-    const load = async () => {
-      try {
-        const res = await window.api.forgePullRequest({ cwd });
-        if (cancelled) return;
-        setForgeResult(res);
-        // connected = the box resolved the repo AND a token (error null).
-        setForgeConnected(res.error === null);
-      } catch {
-        /* non-fatal — the card just stays on its last known state */
-      } finally {
-        if (!cancelled) setForgeLoading(false);
-      }
-    };
-    void load();
-    const t = setInterval(load, 15000);
-    return () => { cancelled = true; clearInterval(t); };
-  }, [cwd, isActive]);
-
-  // Open the ship confirm card — the always-on human gate. Loads the preview
-  // (head/base/fileCount) first so the card shows real facts before anything
-  // is pushed. Nothing is pushed or opened until the user confirms (confirmShip).
-  const openShip = useCallback(async () => {
-    setShipError(null);
-    setShipOpen(true);
-    if (!cwd) return;
-    try {
-      const prev = await window.api.forgeShipPreview({ cwd });
-      if (prev.ok) {
-        setShipProposal({ head: prev.head, base: prev.base, fileCount: prev.fileCount, title: prev.title ?? "", body: prev.body ?? "" });
-      } else {
-        setShipProposal(null);
-        setShipError(prev.error);
-      }
-    } catch (e) {
-      setShipProposal(null);
-      setShipError(e instanceof Error ? e.message : "could not prepare the pull request");
-    }
-  }, [cwd]);
-
-  // Confirm → push + create. Only ever called from the ShipConfirmCard.
-  const confirmShip = useCallback(async (input: { title: string; body: string; draft: boolean }) => {
-    if (!cwd) return;
-    setShipBusy(true);
-    setShipError(null);
-    try {
-      const res = await window.api.forgeShip({ cwd, ...input });
-      if (res.ok) {
-        setShipOpen(false);
-        setShipProposal(null);
-        void refreshLinkedPr();
-        void window.api.forgePullRequest({ cwd }).then((r) => setForgeResult(r)).catch(() => {});
-      } else {
-        setShipError(res.error);
-      }
-    } catch (e) {
-      setShipError(e instanceof Error ? e.message : "ship failed");
-    } finally {
-      setShipBusy(false);
-    }
-  }, [cwd, refreshLinkedPr]);
-
-  // Merge the shown PR, ALWAYS with the head SHA the user approved.
-  const doMerge = useCallback(async () => {
-    const pr = forgeResult?.pr;
-    if (!pr || !cwd) return;
-    setMergeBusy(true);
-    setMergeError(null);
-    try {
-      const res = await window.api.forgeMerge({ cwd, number: pr.number, method: "merge", sha: pr.headSha });
-      if (res.ok) {
-        void refreshLinkedPr();
-        void window.api.forgePullRequest({ cwd }).then((r) => setForgeResult(r)).catch(() => {});
-      } else {
-        setMergeError(describeMergeFailure(res.kind));
-      }
-    } catch (e) {
-      setMergeError(e instanceof Error ? e.message : "merge failed");
-    } finally {
-      setMergeBusy(false);
-    }
-  }, [cwd, forgeResult, refreshLinkedPr]);
-
 
   // ===== ChatPanel-own state (not extracted to hooks) =====
   const [error, setError] = useState<string | null>(null);
@@ -699,12 +590,88 @@ export function ChatPanel({
       // non-fatal — the forge read path is best-effort; keep last-known.
     }
   }, []);
-  // Resolve which PR the branch chip renders: the stored link's number when
-  // present, else today's live `forgePullRequest` result (the 15s poll).
-  const displayPr = useMemo(
-    () => preferLinkedPr(forge.pr, linkedPr),
-    [forge.pr, linkedPr],
-  );
+
+  // Fetch the ship preview once (the branch popover's no-PR state shows
+  // Base / Changes). Click-only surface ⇒ fetched on popover open, never
+  // polled, and not re-fetched if already loaded for this cwd.
+  const ensureShipPreview = useCallback(async () => {
+    if (!cwd || shipProposal) return;
+    try {
+      const prev = await window.api.forgeShipPreview({ cwd });
+      if (prev.ok) {
+        setShipProposal({ head: prev.head, base: prev.base, fileCount: prev.fileCount, title: prev.title ?? "", body: prev.body ?? "" });
+      } else {
+        setShipProposal(null);
+        setShipError(prev.error);
+      }
+    } catch (e) {
+      setShipProposal(null);
+      setShipError(e instanceof Error ? e.message : "could not prepare the pull request");
+    }
+  }, [cwd, shipProposal]);
+
+  // Confirm → push + create. Only ever called from the ShipConfirmCard or the
+  // inline Create PR handler. On success it refreshes the PR (the branch
+  // popover swaps in place to the PR state).
+  const confirmShip = useCallback(async (input: { title: string; body: string; draft: boolean }) => {
+    if (!cwd) return;
+    setShipBusy(true);
+    setShipError(null);
+    try {
+      const res = await window.api.forgeShip({ cwd, ...input });
+      if (res.ok) {
+        setShipOpen(false);
+        setShipProposal(null);
+        void refreshForge(cwd);
+      } else {
+        setShipError(res.error);
+      }
+    } catch (e) {
+      setShipError(e instanceof Error ? e.message : "ship failed");
+    } finally {
+      setShipBusy(false);
+    }
+  }, [cwd, refreshForge]);
+
+  // Create PR — the inline, no-form path (BET-867 owner-approved departure
+  // from BET-794's mandatory-confirm rule). A human clicking a button labelled
+  // `Create PR` is the explicit confirm. Ships the same title/body the Draft
+  // card would have shown, as a real (non-draft) PR. One code path: both this
+  // and Draft PR… end in confirmShip.
+  const createPr = useCallback(() => {
+    if (!shipProposal) return;
+    void confirmShip({ title: shipProposal.title, body: shipProposal.body, draft: false });
+  }, [shipProposal, confirmShip]);
+
+  // Open the ship confirm card — the always-on human gate for Draft PR….
+  // Loads the preview (head/base/fileCount) so the card shows real facts; if
+  // the preview is already loaded it must not re-fetch. Nothing is pushed or
+  // opened until the user confirms (confirmShip).
+  const openShip = useCallback(() => {
+    setShipError(null);
+    setShipOpen(true);
+    void ensureShipPreview();
+  }, [ensureShipPreview]);
+
+  // Merge the shown PR, ALWAYS with the head SHA the user approved.
+  const doMerge = useCallback(async () => {
+    const pr = forge.pr;
+    if (!pr || !cwd) return;
+    setMergeBusy(true);
+    setMergeError(null);
+    try {
+      const res = await window.api.forgeMerge({ cwd, number: pr.number, method: "merge", sha: pr.headSha });
+      if (res.ok) {
+        void refreshForge(cwd);
+      } else {
+        setMergeError(describeMergeFailure(res.kind));
+      }
+    } catch (e) {
+      setMergeError(e instanceof Error ? e.message : "merge failed");
+    } finally {
+      setMergeBusy(false);
+    }
+  }, [cwd, forge.pr, refreshForge]);
 
   // BET-789: dismiss the "Connect GitHub…" offer permanently, per-box. Mirror
   // of AppConfig.forgeConnectOfferDismissed, written through the generic
@@ -732,14 +699,6 @@ export function ChatPanel({
     }, 5000);
     return () => clearInterval(branchPoll);
   }, [cwd, refreshBranch, isActive, refreshForge]);
-
-  // BET-852: refresh the stored session-link PR number on entry (and when the
-  // session changes). Gated on isActive like the other session reads — a
-  // hidden panel doesn't re-read config. Written again by ship/merge below.
-  useEffect(() => {
-    if (!isActive || !tmuxSession) return;
-    void refreshLinkedPr();
-  }, [refreshLinkedPr, isActive, tmuxSession]);
 
   // Ctrl+O toggles reasoning visibility. Matches Claude Code's TUI keybind.
   useEffect(() => {
@@ -2283,7 +2242,6 @@ export function ChatPanel({
     schedules: { order: 3, label: "⏰ schedule" },
     secrets: { order: 2, label: "🔑 secret" },
     webhooks: { order: 1, label: "🪝 webhook" },
-    forge: { order: 0, label: "⛨ git" },
   };
   // Monotonic first-seen arrival counter for blocking cards (BET-783 reviewer
   // Block). Records each blocking ask's true interleaved arrival across
@@ -2397,22 +2355,6 @@ export function ChatPanel({
           ))}
         </div>
       </MeasureColumn>));
-    // BET-794: the forge surface — the current PR + merge gate, or the Ship
-    // entry that opens the [SH1] confirm card. Shown while a forge is
-    // resolved for this cwd (connected) or still being checked; hidden for a
-    // scratch dir with no forge.
-    if (forgeConnected || forgeLoading) list.push(amb("forge",
-      <div className="shrink-0 px-4 pt-2 pb-2">
-        <ForgeCard
-          result={forgeResult}
-          loading={forgeLoading}
-          shipOpen={shipOpen}
-          busy={shipBusy || mergeBusy}
-          mergeError={mergeError}
-          onShip={() => void openShip()}
-          onMerge={() => void doMerge()}
-        />
-      </div>));
     if (!jobOwnership) {
       if (openPanel === "schedules") list.push(amb("schedules",
         <div className="shrink-0 px-4 pt-2 pb-2">
@@ -2468,7 +2410,7 @@ export function ChatPanel({
         </div>));
     }
     return list;
-  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipOpen, shipProposal, shipBusy, shipError, confirmShip, forgeConnected, forgeLoading, forgeResult, mergeError, openShip, doMerge, liveProgress]);
+  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipOpen, shipProposal, shipBusy, shipError, confirmShip, liveProgress]);
 
 
   if (error || transcriptLoadError) {
@@ -2556,7 +2498,7 @@ export function ChatPanel({
         artifactsOpen={artifactsOpen}
         onToggleArtifacts={onToggleArtifacts}
         hiddenStatusItems={hiddenStatusItems}
-        pr={displayPr}
+        pr={forge.pr}
         checks={forge.checks}
         checksRollup={forge.rollup}
         forgeConnected={forge.connected}
@@ -2565,6 +2507,16 @@ export function ChatPanel({
         onOpenExternal={(url) => void window.api.openExternal(url)}
         onFillComposer={updateInputWithHistoryReset}
         onDismissForgeConnect={dismissForgeConnect}
+        onMerge={() => void doMerge()}
+        mergeBusy={mergeBusy}
+        mergeError={mergeError}
+        shipBusy={shipBusy}
+        shipError={shipError}
+        shipBase={shipProposal?.base ?? null}
+        shipFileCount={shipProposal?.fileCount ?? null}
+        onDraftPr={() => void openShip()}
+        onCreatePr={() => void createPr()}
+        onEnsureShipPreview={() => void ensureShipPreview()}
       />
 
       <Transcript

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -16,7 +16,6 @@ import type {
   DelegateApproval,
   DelegateApprovalTool,
   DelegateJob,
-  ForgePullRequestResult,
   ScheduledJob,
   SecretMeta,
   SecretScope,
@@ -25,7 +24,7 @@ import type {
 import { Button } from "./Button";
 import { Chip } from "./Chip";
 import { Field } from "./Field";
-import { canMerge, describeCron, describeNextRun, formatJobSummary } from "./chatUtils";
+import { describeCron, describeNextRun, formatJobSummary } from "./chatUtils";
 import { MetaBadge } from "./chatShared";
 
 // ScheduledTasksCard — pinned card above the composer showing this session's
@@ -694,113 +693,6 @@ export const ShipConfirmCard = memo(function ShipConfirmCard({
       <div className="text-text-faint text-label mt-1">
         Never auto-submitted — nothing is pushed or opened until you confirm here.
       </div>
-    </div>
-  );
-});
-
-// ForgeCard — the session's forge surface. When the repo has a pull request it
-// shows its state + a Merge control gated by canMerge (with a visible reason),
-// and surfaces the distinguished merge-failure kind. When there is none and the
-// box is connected, it offers the Ship action that opens the ShipConfirmCard.
-export const ForgeCard = memo(function ForgeCard({
-  result,
-  loading,
-  shipOpen,
-  busy,
-  mergeError,
-  onShip,
-  onMerge,
-}: {
-  result?: ForgePullRequestResult | null;
-  loading: boolean;
-  shipOpen: boolean;
-  busy: boolean;
-  mergeError: string | null;
-  onShip: () => void;
-  onMerge: () => void;
-}) {
-  const pr = result?.pr ?? null;
-  const rollup = result?.rollup ?? "none";
-  const merge = canMerge({
-    rollup,
-    unresolvedThreads: pr?.unresolvedThreads ?? 0,
-    mergeable: pr?.mergeable ?? null,
-  });
-  const rollupColor =
-    rollup === "green" ? "var(--ok)" : rollup === "red" ? "var(--danger)" : rollup === "yellow" ? "var(--warn)" : "var(--tx3)";
-  return (
-    <div
-      className="rounded-sm border bg-bg-elev px-3 py-2 text-meta"
-      style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
-    >
-      <div className="flex items-center gap-2 mb-1">
-        <span style={{ color: "var(--accent)" }} className="inline-flex items-center">
-          <GitPullRequest size={16} aria-hidden="true" />
-        </span>
-        {loading ? (
-          <span className="text-text-faint">Checking GitHub…</span>
-        ) : pr ? (
-          <>
-            <span className="text-text truncate" title={pr.title}>
-              #{pr.number} {pr.title}
-            </span>
-            <MetaBadge title="The normalised PR state">{pr.state}</MetaBadge>
-            {/* Traffic-light for checks; null = not mergeable (reason below). */}
-            <span
-              className="inline-flex items-center gap-1 text-text-faint"
-              title={`Checks: ${rollup}`}
-            >
-              <span className="inline-block w-2 h-2 rounded-full" style={{ backgroundColor: rollupColor }} />
-              <span className="font-mono text-label">{result?.checks?.length ?? 0}</span>
-            </span>
-          </>
-        ) : (
-          <span className="text-text-faint">No open pull request on this branch</span>
-        )}
-      </div>
-
-      {pr ? (
-        <>
-          {/* Can I merge? Disabled with a visible reason; green rollup + no
-              threads + mergeable true are ALL required. */}
-          <div className="text-text-faint text-label mb-1">
-            {merge.can
-              ? "Ready to merge — checks green, threads resolved."
-              : `Can't merge yet — ${merge.reason}.`}
-          </div>
-          {!merge.can && pr.mergeBlockedReason && (
-            <div className="text-text-faint text-label mb-1">
-              GitHub: {pr.mergeBlockedReason}
-            </div>
-          )}
-          {mergeError && (
-            <div className="text-danger break-words mb-1">
-              {mergeError}
-            </div>
-          )}
-          <div className="flex items-center gap-2">
-            <Button
-              tone="primary"
-              disabled={!merge.can || busy}
-              onClick={onMerge}
-              title={merge.can ? "Merge this pull request" : merge.reason ?? "not mergeable"}
-            >
-              {busy ? "Merging…" : "Merge"}
-            </Button>
-            <span className="text-text-faint text-label">
-              {pr.headRef} → {pr.baseRef}
-            </span>
-          </div>
-        </>
-      ) : (
-        shipOpen === false && !loading && (
-          <div className="flex items-center gap-2">
-            <Button tone="ghost" onClick={onShip} title="Push the current branch and open a pull request">
-              Ship as pull request
-            </Button>
-          </div>
-        )
-      )}
     </div>
   );
 });

--- a/src/renderer/SessionHeader.branch.test.tsx
+++ b/src/renderer/SessionHeader.branch.test.tsx
@@ -1,0 +1,182 @@
+// @vitest-environment jsdom
+//
+// BET-867: the branch chip is the ONE git surface. It opens a popover in BOTH
+// the has-PR (merge surface) and the no-PR (Draft PR… / Create PR) states; the
+// plain non-interactive Tag survives only for a scratch dir with no forge.
+// These mount the real <SessionHeader> via the render harness, open the branch
+// popover (portalled to <body>), and assert on the action rows + props.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import {
+  installMockApi,
+  resetStore,
+  mountSessionHeader,
+  type Harness,
+} from "./testHarness";
+import type { PullRequest } from "../shared/types";
+
+const PR: PullRequest = {
+  number: 412,
+  title: "forge seam + github adapter",
+  body: "",
+  url: "https://github.com/x/y/pull/412",
+  state: "open",
+  draft: false,
+  headRef: "feat/forge-seam",
+  baseRef: "main",
+  headSha: "abc",
+  author: "octocat",
+  reviewers: ["octocat"],
+  mergeable: true,
+  mergeBlockedReason: null,
+  unresolvedThreads: 3,
+};
+
+// The popover is portalled to <body> by Popover, so assertions on its content
+// read the whole body (harness container ⊂ body).
+const bodyText = () => document.body.textContent ?? "";
+
+function buttonWithText(text: string): HTMLButtonElement {
+  const btn = [...document.body.querySelectorAll<HTMLButtonElement>("button")].find(
+    (b) => b.textContent?.trim() === text,
+  );
+  expect(btn, `expected a "${text}" button`).not.toBeUndefined();
+  return btn!;
+}
+
+function openBranchChip(h: Harness) {
+  // The trigger is the branch chip button (stable `manta-branch-chip` hook).
+  // Interacting by class avoids the jsdom selector quirk around `+` in the
+  // PR-derived aria-label attribute value.
+  const trigger = h.container.querySelector<HTMLButtonElement>(
+    "button.manta-branch-chip",
+  );
+  expect(trigger, "expected branch chip trigger").not.toBeNull();
+  act(() => trigger!.click());
+}
+
+describe("SessionHeader branch popover (BET-867)", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    installMockApi();
+    resetStore();
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("no PR + forge connected → Draft PR… / Create PR, and NOT Merge", async () => {
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: null,
+      onDraftPr: vi.fn(),
+      onCreatePr: vi.fn(),
+      onEnsureShipPreview: () => {},
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const text = bodyText();
+    expect(text).toContain("No pull request on this branch");
+    expect(text).toContain("Draft PR…");
+    expect(text).toContain("Create PR");
+    expect(text).not.toContain("Merge");
+    // No PR → no merge surface / no reviewers rows.
+    expect(text).not.toContain("Review changes");
+  });
+
+  it("PR present → Merge, Review changes and the Open-on-GitHub tooltip button, and NOT Create PR", async () => {
+    const onOpenExternal = vi.fn();
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: PR,
+      checksRollup: "green",
+      onMerge: vi.fn(),
+      onOpenExternal,
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const text = bodyText();
+    expect(text).toContain("Reviewers");
+    expect(text).toContain("Unresolved threads");
+    expect(text).toContain("Review changes");
+    expect(text).not.toContain("Create PR");
+    expect(buttonWithText("Merge")).toBeTruthy();
+
+    // Icon-only open-on-forge: the label lives in `title`, not button text.
+    const openGithub = document.body.querySelector<HTMLButtonElement>(
+      `button[title="Open on GitHub"]`,
+    );
+    expect(openGithub).not.toBeNull();
+    act(() => openGithub!.click());
+    expect(onOpenExternal).toHaveBeenCalledWith(PR.url);
+  });
+
+  it("Merge is disabled with the reason as title when canMerge is false", async () => {
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: PR,
+      checksRollup: "red",
+      onMerge: vi.fn(),
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const mergeBtn = buttonWithText("Merge");
+    expect(mergeBtn.disabled).toBe(true);
+    expect(mergeBtn.title).toBe("checks failing");
+  });
+
+  it("Create PR click calls the injected create handler exactly once", async () => {
+    const onCreatePr = vi.fn();
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: null,
+      shipBase: "main",
+      shipFileCount: 18,
+      onCreatePr,
+      onDraftPr: vi.fn(),
+      onEnsureShipPreview: () => {},
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const createBtn = buttonWithText("Create PR");
+    act(() => createBtn.click());
+    expect(onCreatePr).toHaveBeenCalledTimes(1);
+
+    // Preview rows come from the ship preview (Base / Changes).
+    const text = bodyText();
+    expect(text).toContain("Base");
+    expect(text).toContain("18 files");
+  });
+
+  it("while a ship is in flight both buttons disable and Create PR labels Creating…", async () => {
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: null,
+      shipBusy: true,
+      shipError: null,
+      onDraftPr: vi.fn(),
+      onCreatePr: vi.fn(),
+      onEnsureShipPreview: () => {},
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const text = bodyText();
+    expect(text).toContain("Opening pull request…");
+    expect(buttonWithText("Draft PR…").disabled).toBe(true);
+    expect(buttonWithText("Creating…").disabled).toBe(true);
+  });
+});

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -17,7 +17,7 @@ import {
   useState,
   type CSSProperties,
 } from "react";
-import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal, Bot, MessageSquare, Clock, PanelRight } from "lucide-react";
+import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal, Bot, MessageSquare, Clock, PanelRight, ExternalLink } from "lucide-react";
 import {
   ctxStageColor,
   cssVar,
@@ -27,6 +27,8 @@ import {
   countsForChecks,
   shouldOfferForgeConnect,
   failuresToAgentPrompt,
+  branchPanelState,
+  canMerge,
   type ChecksChipTone,
   type ContextBreakdown,
   type StaleCacheResult,
@@ -93,6 +95,16 @@ export function SessionHeader({
   onOpenExternal,
   onFillComposer,
   onDismissForgeConnect,
+  onMerge,
+  mergeBusy,
+  mergeError,
+  shipBusy,
+  shipError,
+  shipBase,
+  shipFileCount,
+  onDraftPr,
+  onCreatePr,
+  onEnsureShipPreview,
 }: {
   branch: string | null;
   ctxBreakdown: ContextBreakdown;
@@ -149,6 +161,22 @@ export function SessionHeader({
   onOpenExternal?: (url: string) => void;
   onFillComposer?: (text: string) => void;
   onDismissForgeConnect?: () => void;
+  // BET-867: the branch chip's popover is the ONE git surface. Merge + ship
+  // live here now (ForgeCard deleted), so ChatPanel threads the ship/merge
+  // state + handlers down. All optional so non-forge callers / tests stay
+  // byte-identical.
+  onMerge?: () => void;
+  mergeBusy?: boolean;
+  mergeError?: string | null;
+  shipBusy?: boolean;
+  shipError?: string | null;
+  // The ship preview's base branch + file count (fetched once when the no-PR
+  // popover opens). null while the preview is still loading → rows render "—".
+  shipBase?: string | null;
+  shipFileCount?: number | null;
+  onDraftPr?: () => void;
+  onCreatePr?: () => void;
+  onEnsureShipPreview?: () => void;
 }) {
   const { pct, segments, freshInput, cacheRead, cacheWrite, totalInput } =
     ctxBreakdown;
@@ -182,6 +210,15 @@ export function SessionHeader({
     connected: forgeConnected ?? false,
     forgeKind: forgeKind ?? null,
     dismissed: forgeConnectOfferDismissed ?? false,
+  });
+
+  // BET-867: the one decision driving the branch chip — plain non-interactive
+  // Tag (no branch / no forge) vs. the interactive branch popover in its
+  // no-PR or PR state.
+  const branchState = branchPanelState({
+    pr: pr ?? null,
+    forgeConnected: forgeConnected ?? false,
+    branch,
   });
 
   // ===== Status-item registry (BET-782) =====
@@ -325,22 +362,37 @@ export function SessionHeader({
       )}
 
       {/* Branch chip — session state, at the `sm` tag density so it reads as
-            metadata beside the breadcrumb rather than as a control. When an
-            open PR rides the branch, the chip becomes interactive and opens the
-            PR popover [C7] (the PR is an ATRIBUTE of the branch, not a peer of
-            it — no second PR chip, §4.3). No PR → byte-identical to today [C2]. */}
-      {branch &&
-        (pr ? (
-          <BranchChip branch={branch} pr={pr} onOpenExternal={onOpenExternal} />
-        ) : (
-          <Tag
-            size="sm"
-            icon={<GitBranch size={11} aria-hidden="true" className="shrink-0" />}
-            title={`Current branch: ${branch}`}
-          >
+            metadata beside the breadcrumb rather than as a control. When the
+            forge is connected the chip opens the ONE git surface — the branch
+            popover [BET-867] — carrying either the PR (merge surface) or the
+            Draft PR / Create PR offer; a scratch dir with no forge keeps the
+            plain non-interactive Tag (byte-identical to today). */}
+      {branchState !== "none" ? (
+        <BranchChip
+          branch={branch ?? ""}
+          pr={pr ?? null}
+          checksRollup={checksRollup ?? "none"}
+          mergeBusy={mergeBusy ?? false}
+          mergeError={mergeError ?? null}
+          onMerge={onMerge}
+          shipBusy={shipBusy ?? false}
+          shipError={shipError ?? null}
+          shipBase={shipBase ?? null}
+          shipFileCount={shipFileCount ?? null}
+          onDraftPr={onDraftPr}
+          onCreatePr={onCreatePr}
+          onEnsureShipPreview={onEnsureShipPreview}
+          onOpenExternal={onOpenExternal}
+        />
+      ) : branch ? (
+        <Tag
+          size="sm"
+          icon={<GitBranch size={11} aria-hidden="true" className="shrink-0" />}
+          title={`Current branch: ${branch}`}
+        >
             <span className="shrink-0 truncate max-w-[200px]">{branch}</span>
           </Tag>
-        ))}
+        ) : null}
 
       {/* Right group — the registry's visible items + the overflow trigger.
             Order preserves today's wide-width visual (context, artifacts,
@@ -925,26 +977,58 @@ function SessionMenu({
 // (BET-865) — Popover owns all of that. Each chip keeps its own trigger button
 // chrome; the portalled panel exists only while open.
 
-// ===== Branch + PR popover chip (BET-789 [C3] [C7]) =====
+// ===== Branch + PR popover chip (BET-789 [C3] [C7] → BET-867) =====
 //
-// The PR rides the branch chip — it is an attribute of the branch, not a peer
-// of it. `⎇ feat/forge-seam` becomes `⎇ feat/forge-seam · #412` and, with a PR
-// present, opens a popover carrying the PR's title, state, head→base refs,
-// reviewers, unresolved-thread count and — the payload of this feature — the
-// mergeability REASON (never "can't merge" alone, §4.3). Without a PR the
-// branch renders as the plain non-interactive Tag (byte-identical to today).
+// The branch chip is the ONE git surface: the PR rides the branch (an
+// attribute, not a peer — no second PR chip). With the forge connected it
+// opens the branch popover in two states — the branch has a PR ([F1]: title,
+// state, refs, reviewers, threads, mergeability + Merge / Review changes /
+// open-on-forge), or it does not ([F2]: Base / Changes from the ship preview
+// + Draft PR… / Create PR). BET-867 is an owner-approved departure from
+// BET-789's [C2]: the no-PR branch now opens a popover where it previously
+// stayed a plain non-interactive Tag; a scratch dir with no forge keeps the
+// Tag unchanged (branchPanelState == "none").
 function BranchChip({
   branch,
   pr,
+  checksRollup,
+  mergeBusy,
+  mergeError,
+  onMerge,
+  shipBusy,
+  shipError,
+  shipBase,
+  shipFileCount,
+  onDraftPr,
+  onCreatePr,
+  onEnsureShipPreview,
   onOpenExternal,
 }: {
   branch: string;
-  pr: PullRequest;
+  pr: PullRequest | null;
+  checksRollup: CheckRollup;
+  mergeBusy: boolean;
+  mergeError: string | null;
+  onMerge?: () => void;
+  shipBusy: boolean;
+  shipError: string | null;
+  shipBase: string | null;
+  shipFileCount: number | null;
+  onDraftPr?: () => void;
+  onCreatePr?: () => void;
+  onEnsureShipPreview?: () => void;
   onOpenExternal?: (url: string) => void;
 }) {
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
-  const label = `Pull request #${pr.number}: ${pr.title}`;
+  const label = pr
+    ? `Pull request #${pr.number}: ${pr.title}`
+    : `Current branch: ${branch}`;
+  // The no-PR state shows the ship preview (Base / Changes); fetch it once
+  // when the popover opens — click-only surface, never polled.
+  useEffect(() => {
+    if (open && !pr) onEnsureShipPreview?.();
+  }, [open, pr, onEnsureShipPreview]);
   return (
     <>
       {/* The chip sits in the header's drag region (the left group), so the
@@ -963,10 +1047,11 @@ function BranchChip({
         <Tag
           size="sm"
           icon={<GitBranch size={11} aria-hidden="true" className="shrink-0" />}
-          title={`Current branch: ${branch} — pull request #${pr.number}`}
+          title={label}
         >
           <span className="shrink-0 truncate max-w-[200px]">
-            {branch} · #{pr.number}
+            {branch}
+            {pr ? ` · #${pr.number}` : ""}
           </span>
         </Tag>
       </button>
@@ -979,7 +1064,21 @@ function BranchChip({
         hook="manta-branch-popover"
         surfaceClassName="w-[360px]"
       >
-        <BranchPanel pr={pr} onOpenExternal={onOpenExternal} />
+        <BranchPanel
+          branch={branch}
+          pr={pr}
+          checksRollup={checksRollup}
+          mergeBusy={mergeBusy}
+          mergeError={mergeError}
+          onMerge={onMerge}
+          shipBusy={shipBusy}
+          shipError={shipError}
+          shipBase={shipBase}
+          shipFileCount={shipFileCount}
+          onDraftPr={onDraftPr}
+          onCreatePr={onCreatePr}
+          onOpenExternal={onOpenExternal}
+        />
       </Popover>
     </>
   );
@@ -1011,13 +1110,82 @@ function PanelRow({
   );
 }
 
+// The branch popover's single surface, branching on `pr` presence (BET-867).
+// PR present → the merge surface [F1]; no PR → the Draft PR… / Create PR
+// offer [F2][F3][F4]. PanelRow is reused verbatim for both states' rows.
 function BranchPanel({
+  branch,
   pr,
+  checksRollup,
+  mergeBusy,
+  mergeError,
+  onMerge,
+  shipBusy,
+  shipError,
+  shipBase,
+  shipFileCount,
+  onDraftPr,
+  onCreatePr,
   onOpenExternal,
 }: {
-  pr: PullRequest;
+  branch: string;
+  pr: PullRequest | null;
+  checksRollup: CheckRollup;
+  mergeBusy: boolean;
+  mergeError: string | null;
+  onMerge?: () => void;
+  shipBusy: boolean;
+  shipError: string | null;
+  shipBase: string | null;
+  shipFileCount: number | null;
+  onDraftPr?: () => void;
+  onCreatePr?: () => void;
   onOpenExternal?: (url: string) => void;
 }) {
+  if (!pr) {
+    // No pull request on this branch [F2] — the Draft PR… / Create PR offer.
+    return (
+      <div className="p-3">
+        <div className="mb-[3px] truncate text-[13.5px] font-semibold leading-snug text-text">
+          {branch}
+        </div>
+        {shipError ? (
+          <div className="mb-2 break-words text-xs text-danger">{shipError}</div>
+        ) : (
+          <div className="mb-2 text-xs text-text-faint">
+            {shipBusy ? "Opening pull request…" : "No pull request on this branch"}
+          </div>
+        )}
+        <div className="flex flex-col">
+          <PanelRow label="Base" value={shipBase ?? "—"} />
+          <PanelRow
+            label="Changes"
+            value={
+              shipFileCount != null
+                ? `${shipFileCount} file${shipFileCount === 1 ? "" : "s"}`
+                : "—"
+            }
+          />
+        </div>
+        <div className="mt-3 flex flex-nowrap items-center gap-2">
+          <Button tone="primary" disabled={shipBusy} onClick={onDraftPr}>
+            Draft PR…
+          </Button>
+          <Button tone="default" disabled={shipBusy} onClick={onCreatePr}>
+            {shipBusy ? "Creating…" : "Create PR"}
+          </Button>
+        </div>
+      </div>
+    );
+  }
+  // PR present — the merge surface [F1]. The merge gate is the existing
+  // canMerge: green rollup + no unresolved threads + mergeable true are ALL
+  // required (BET-867, do not re-derive).
+  const merge = canMerge({
+    rollup: checksRollup,
+    unresolvedThreads: pr.unresolvedThreads,
+    mergeable: pr.mergeable,
+  });
   // mergeBlockedReason is the payload — "checks failing", "conflicts",
   // "review required", "draft" — displayed in danger. Only when there is no
   // reason does it fall back to a status the forge itself reports.
@@ -1042,12 +1210,23 @@ function BranchPanel({
         <PanelRow label="Unresolved threads" value={String(pr.unresolvedThreads)} />
         <PanelRow label="Mergeable" value={mergeable.text} valueClass={mergeable.className} />
       </div>
-      <div className="mt-3 flex flex-wrap items-center gap-2">
-        {/* "Review changes" is inert in BET-789 — a later issue wires it. */}
+      {mergeError && (
+        <div className="mt-1 break-words text-xs text-danger">{mergeError}</div>
+      )}
+      <div className="mt-3 flex flex-nowrap items-center gap-2">
+        <Button
+          tone="primary"
+          disabled={!merge.can || mergeBusy}
+          onClick={onMerge}
+          title={merge.can ? "Merge this pull request" : merge.reason ?? "not mergeable"}
+        >
+          {mergeBusy ? "Merging…" : "Merge"}
+        </Button>
+        {/* "Review changes" is inert in BET-867 — BET-869 wires it. */}
         <Button tone="default">Review changes</Button>
         {onOpenExternal && (
-          <Button tone="default" onClick={() => onOpenExternal(pr.url)}>
-            Open on GitHub ↗
+          <Button tone="ghost" title="Open on GitHub" onClick={() => onOpenExternal(pr.url)}>
+            <ExternalLink size={14} aria-hidden="true" />
           </Button>
         )}
       </div>

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -162,9 +162,9 @@ export function SessionHeader({
   onFillComposer?: (text: string) => void;
   onDismissForgeConnect?: () => void;
   // BET-867: the branch chip's popover is the ONE git surface. Merge + ship
-  // live here now (ForgeCard deleted), so ChatPanel threads the ship/merge
-  // state + handlers down. All optional so non-forge callers / tests stay
-  // byte-identical.
+  // live here now (the pinned forge card is deleted), so ChatPanel threads the
+  // ship/merge state + handlers down. All optional so non-forge callers / tests
+  // stay byte-identical.
   onMerge?: () => void;
   mergeBusy?: boolean;
   mergeError?: string | null;

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -988,22 +988,10 @@ function SessionMenu({
 // BET-789's [C2]: the no-PR branch now opens a popover where it previously
 // stayed a plain non-interactive Tag; a scratch dir with no forge keeps the
 // Tag unchanged (branchPanelState == "none").
-function BranchChip({
-  branch,
-  pr,
-  checksRollup,
-  mergeBusy,
-  mergeError,
-  onMerge,
-  shipBusy,
-  shipError,
-  shipBase,
-  shipFileCount,
-  onDraftPr,
-  onCreatePr,
-  onEnsureShipPreview,
-  onOpenExternal,
-}: {
+//
+// The panel props are shared by BranchChip and BranchPanel (the chip passes
+// them straight through) — one type, no parallel re-declaration.
+type BranchPanelProps = {
   branch: string;
   pr: PullRequest | null;
   checksRollup: CheckRollup;
@@ -1016,9 +1004,14 @@ function BranchChip({
   shipFileCount: number | null;
   onDraftPr?: () => void;
   onCreatePr?: () => void;
-  onEnsureShipPreview?: () => void;
   onOpenExternal?: (url: string) => void;
-}) {
+};
+
+function BranchChip({
+  onEnsureShipPreview,
+  ...panelProps
+}: BranchPanelProps & { onEnsureShipPreview?: () => void }) {
+  const { branch, pr } = panelProps;
   const [open, setOpen] = useState(false);
   const triggerRef = useRef<HTMLButtonElement>(null);
   const label = pr
@@ -1064,21 +1057,7 @@ function BranchChip({
         hook="manta-branch-popover"
         surfaceClassName="w-[360px]"
       >
-        <BranchPanel
-          branch={branch}
-          pr={pr}
-          checksRollup={checksRollup}
-          mergeBusy={mergeBusy}
-          mergeError={mergeError}
-          onMerge={onMerge}
-          shipBusy={shipBusy}
-          shipError={shipError}
-          shipBase={shipBase}
-          shipFileCount={shipFileCount}
-          onDraftPr={onDraftPr}
-          onCreatePr={onCreatePr}
-          onOpenExternal={onOpenExternal}
-        />
+        <BranchPanel {...panelProps} />
       </Popover>
     </>
   );
@@ -1127,21 +1106,7 @@ function BranchPanel({
   onDraftPr,
   onCreatePr,
   onOpenExternal,
-}: {
-  branch: string;
-  pr: PullRequest | null;
-  checksRollup: CheckRollup;
-  mergeBusy: boolean;
-  mergeError: string | null;
-  onMerge?: () => void;
-  shipBusy: boolean;
-  shipError: string | null;
-  shipBase: string | null;
-  shipFileCount: number | null;
-  onDraftPr?: () => void;
-  onCreatePr?: () => void;
-  onOpenExternal?: (url: string) => void;
-}) {
+}: BranchPanelProps) {
   if (!pr) {
     // No pull request on this branch [F2] — the Draft PR… / Create PR offer.
     return (

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -112,8 +112,7 @@ import {
   progressAttentionKind,
   concatUserMessageText,
   buildVoiceNoteMap,
-  linkedPrNumber,
-  preferLinkedPr,
+  branchPanelState,
   dispatchAppControl,
   sortInbox,
   inboxReasonLabel,
@@ -2173,7 +2172,7 @@ describe("isBackgroundJobCompletionTurn", () => {
 
 // ===== BET-414 sidebar helpers =====
 
-import type { Project, PermissionRequest, SessionLink } from "../shared/types";
+import type { Project, PermissionRequest } from "../shared/types";
 
 function mkProject(
   tmuxSession: string,
@@ -4234,39 +4233,12 @@ describe("cloneErrorKind", () => {
   });
 });
 
-describe("linkedPrNumber (BET-852)", () => {
-  const cfg = (link?: SessionLink | null) => ({
-    projects: [{ tmuxSession: "ethernal", defaultCwd: "/p", link }],
-  });
-
-  it("returns the stored PR number when the session has a link.pr slot", () => {
-    expect(linkedPrNumber(cfg({ pr: { repoKey: "x/y", number: 412 } }), "ethernal")).toBe(412);
-  });
-
-  it("returns null when there is no link or no pr slot", () => {
-    expect(linkedPrNumber(cfg({ issue: { repoKey: "x/y", number: 9 } }), "ethernal")).toBe(null);
-    expect(linkedPrNumber(cfg(undefined), "ethernal")).toBe(null);
-    expect(linkedPrNumber(cfg(null), "ethernal")).toBe(null);
-    expect(linkedPrNumber(undefined, "ethernal")).toBe(null);
-    expect(linkedPrNumber(cfg({ pr: { repoKey: "x/y", number: 412 } }), null)).toBe(null);
-  });
-
-  it("only matches the session's own project (by tmuxSession)", () => {
-    expect(linkedPrNumber(cfg({ pr: { repoKey: "x/y", number: 412 } }), "marketing")).toBe(null);
-  });
-
-  it("rejects a non-positive / non-integer stored number defensively", () => {
-    const bad = { pr: { repoKey: "x/y", number: 0 } };
-    expect(linkedPrNumber(cfg(bad), "ethernal")).toBe(null);
-  });
-});
-
-describe("preferLinkedPr (BET-852)", () => {
-  const live = (number: number) => ({
-    number,
+describe("branchPanelState (BET-867)", () => {
+  const pr = {
+    number: 412,
     title: "T",
     body: "",
-    url: "https://github.com/x/y/pull/" + number,
+    url: "",
     state: "open" as const,
     draft: false,
     headRef: "h",
@@ -4277,31 +4249,23 @@ describe("preferLinkedPr (BET-852)", () => {
     mergeable: null,
     mergeBlockedReason: null,
     unresolvedThreads: 0,
+  };
+
+  it("no branch → none (plain non-interactive Tag)", () => {
+    expect(branchPanelState({ pr, forgeConnected: true, branch: null })).toBe("none");
+    expect(branchPanelState({ pr, forgeConnected: true, branch: "" })).toBe("none");
   });
 
-  it("preserves the live lookup unchanged when there is no stored link", () => {
-    const l = live(412);
-    expect(preferLinkedPr(l, null)).toBe(l);
-    expect(preferLinkedPr(null, null)).toBe(null);
+  it("branch but forge not connected → none", () => {
+    expect(branchPanelState({ pr, forgeConnected: false, branch: "feat/x" })).toBe("none");
   });
 
-  it("keeps full live details when the live PR is the stored PR", () => {
-    const l = live(412);
-    expect(preferLinkedPr(l, 412)).toBe(l);
+  it("branch + connected + no PR → no-pr", () => {
+    expect(branchPanelState({ pr: null, forgeConnected: true, branch: "feat/x" })).toBe("no-pr");
   });
 
-  it("prefers the stored link number over a differing live PR number", () => {
-    const out = preferLinkedPr(live(410), 412);
-    expect(out?.number).toBe(412);
-    expect(out?.title).toBe("T");
-  });
-
-  it("renders a minimal card from the stored number when the poll has not resolved", () => {
-    const out = preferLinkedPr(null, 412);
-    expect(out).not.toBeNull();
-    expect(out!.number).toBe(412);
-    expect(out!.url).toBe("");
-    expect(out!.reviewers).toEqual([]);
+  it("branch + connected + PR → pr", () => {
+    expect(branchPanelState({ pr, forgeConnected: true, branch: "feat/x" })).toBe("pr");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { AppConfig, AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, OpencodeMessage, OpencodeModel, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, OpencodeMessage, OpencodeModel, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 import type { VoiceNoteRecord } from "../shared/types";
 // Value import — `isClientTooOld` is the pure semver compare that drives
@@ -3042,6 +3042,27 @@ export function describeMergeFailure(kind: string | null | undefined): string {
   }
 }
 
+/**
+ * The single decision for how the session-header branch chip renders and
+ * whether it opens a popover (the ONE git surface, BET-867). `"none"` means the
+ * plain, non-interactive `Tag` — either there is no branch, or the forge is not
+ * connected for this cwd (a scratch dir with no forge must stay byte-identical
+ * to a non-forge session). `"no-pr"` opens the popover in its Draft PR / Create
+ * PR state; `"pr"` opens it in the merge surface state.
+ */
+export function branchPanelState({
+  pr,
+  forgeConnected,
+  branch,
+}: {
+  pr: PullRequest | null;
+  forgeConnected: boolean;
+  branch: string | null;
+}): "none" | "no-pr" | "pr" {
+  if (!branch || !forgeConnected) return "none";
+  return pr ? "pr" : "no-pr";
+}
+
 // ---- Forge review pane (BET-792) -------------------------------------------
 
 // The line anchor a comment may attach to, in the forge-neutral shape the spec
@@ -3160,56 +3181,6 @@ export function buildVoiceNoteMap(
   }
   return map;
 }
-
-// BET-852: the stored session-link PR ref (`projects[].link.pr`) is the source
-// of truth for "what PR is this session shipping" — recorded the moment
-// `shipPullRequest` opens a PR (onPrOpened → linkPullRequest). Reading it off
-// the AppConfig the box serves lets the branch chip show the linked PR number
-// immediately (and even when the 15s forge poll has not resolved), instead of
-// depending on the live `forgePullRequest` lookup alone. Returns the stored
-// PR number when the session has a saved link slot; null otherwise (a PR
-// opened outside the app, or before the first ship), which is the fall-back
-// to live-lookup territory.
-export function linkedPrNumber(
-  config: Pick<AppConfig, "projects"> | null | undefined,
-  tmuxSession: string | null,
-): number | null {
-  if (!config || !tmuxSession) return null;
-  const proj = (config.projects ?? []).find((p) => p.tmuxSession === tmuxSession);
-  const pr = proj?.link?.pr;
-  return pr && Number.isInteger(pr.number) && pr.number > 0 ? pr.number : null;
-}
-
-// BET-852: resolve the PR object the branch chip should render. Prefers the
-// stored link's number when the session has one (per the issue, the stored
-// link wins); otherwise preserves today's live-lookup behavior unchanged.
-// When the live poll has already resolved the SAME PR we keep its full
-// details (title/state/checks panel); when it has not resolved yet we render
-// a minimal card so `#N` appears immediately from the stored link rather than
-// waiting for the poll.
-export function preferLinkedPr(
-  live: PullRequest | null,
-  linkedNumber: number | null,
-): PullRequest | null {
-  if (linkedNumber == null) return live;
-  if (live) return live.number === linkedNumber ? live : { ...live, number: linkedNumber };
-  return {
-    number: linkedNumber,
-    title: "",
-    body: "",
-    url: "",
-    state: "open",
-    draft: false,
-    headRef: "",
-    baseRef: "",
-    headSha: "",
-    author: "",
-    reviewers: [],
-    mergeable: null,
-    mergeBlockedReason: null,
-    unresolvedThreads: 0,
-  };
-};
 
 // ---------------------------------------------------------------------------
 // App-control bus dispatcher (BET-840/841).


### PR DESCRIPTION
## One git surface — delete the pinned `ForgeCard`, move Merge + Ship into the branch popover

The branch chip's popover is now the **only** place a pull request is shown or acted on, in both states (the branch has a PR, or it does not). `ForgeCard` is deleted; the pinned card above the composer is gone.

### Delivered
- **Deleted `ForgeCard`** (component + export + import), its `forge` ambient-card mount, and the `⛨ git` `AMBIENT_CARD` entry. Nothing is pinned above the composer for a session that merely has a forge connected.
- **Deleted the 15s `forgePullRequest` poll** and the `forgeResult`/`forgeLoading`/`forgeConnected` state. The 5s branch poll (`refreshForge`) is the only timer; `forge` is the single source of PR state and `SessionHeader`'s `pr` prop is fed `forge.pr` directly.
- **Deleted `linkedPr`/`refreshLinkedPr`** and the `preferLinkedPr`/`linkedPrNumber` helpers + tests. `preferLinkedPr` was actively wrong (it built a chimera PR carrying A's title/state under B's number); the renderer no longer reads the stored link — box-side deletion is BET-870's.
- **`BranchPanel` now takes `pr: PullRequest | null`** and branches:
  - **PR present** — `Merge` (gated by the existing `canMerge`, reason in the tooltip, `Merging…` while busy), `Review changes` (inert — BET-869 wires it), and an icon-only `Open on GitHub` (`ExternalLink`), on one non-wrapping row.
  - **No PR** — `Base`/`Changes` from the ship preview, `Draft PR…` opens the unchanged `ShipConfirmCard`, `Create PR` ships inline (`Creating…` while busy), one row.
- **`Create PR`** ships inline via the existing `confirmShip({title, body, draft:false})` — the popover stays open and swaps in place to the PR state (chip becomes `⎇ branch · #N`), no navigation, no toast. Ship preview fetched once on popover open (click-only, never polled, not re-fetched if loaded).
- **Added `branchPanelState({pr, forgeConnected, branch})`** (pure, tested) — `none` keeps the plain non-interactive `Tag` for a scratch dir with no forge.

### Departures (recorded deliberately, do not "fix" back)
- **Owner-approved departure from `[C2]`/BET-789:** the branch chip now opens a popover in the no-PR state (it used to be a plain non-interactive `Tag`). Same chip, same size, same text; it gains a hover state + a disclosure.
- **Departure from BET-794 (Create PR skips the mandatory confirm card):** a human clicking a button labelled `Create PR` *is* the explicit confirm; a PR is reversible in a way merge is not. Merge keeps its full gate and is untouched. Recorded in `docs/opencode-tools/AGENTS.md` next to the "may never merge" rule — the merge prohibition is intact and unweakened; nothing gives an agent a path to Create PR.

### Coordination with BET-865 / 866
- Built on the portalled `Popover` primitive (BET-865) with the existing `manta-branch-popover` hook class. The chip becoming interactive in the no-PR state is the **eighth** anchored surface; none re-introduces `PopoverChip`, a `relative` wrapper, `absolute` panel, or a second `useClickAway`. Reuses BET-866's "branch's PR or nothing" server contract.
- `manta-branch-chip` / `manta-branch-popover` classes unchanged (visual gate coverage intact).

### What was removed / diffstat
- **Removed:** `ForgeCard`, the 15s poll, `forgeResult`/`forgeLoading`/`forgeConnected`, `preferLinkedPr`/`linkedPrNumber` (+ their tests), the forge ambient card, the `displayPr` memo.
- **Net line count (src/renderer):** production (non-test) **net −39** — the duplicated forge chrome removed outweighs the two-state popover addition. The issue-mandated new tests (`branchPanelState` in `chatUtils.test.ts` + `SessionHeader.branch.test.tsx`) add net +146. (Full diff: `ChatPanel.tsx −248/…`, `PanelCards.tsx −110`, `SessionHeader.tsx +226`, `chatUtils.ts −73`, `chatUtils.test.ts −68`, `SessionHeader.branch.test.tsx +182`, `docs/opencode-tools/AGENTS.md +5`.)
- Production net-negative is the point of the issue ("Removal beats addition" / "must be net-negative"); the tests are the coverage the issue explicitly requires.

**Base:** origin/main @ `62c911fe`

### Verification results
- PR branch (`multica/BET-867-one-git-surface` @ `59e47e04`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b`
  - test: exit 0 — 138 files, 2625 passed / 7 skipped (2632); node:test 1980 pass / 0 fail. Failures: none. log sha256: `0f6743de476c`
- Base (`main` @ `62c911fe`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b`
  - test: exit 0 — 137 files, 2624 passed / 7 skipped (2631); node:test 1980 pass / 0 fail. Failures: none. log sha256: `157a3935426a`
- **Conclusion:** 0 new failures. PR adds 1 net vitest test (new `branchPanelState` + component coverage); node:test identical between branches.

Note: `npm run visual` is retired as a verification gate per repo policy (2026-08-07) — verification is typecheck + unit tests.
