### PR TITLE
BET-879: fix(renderer): allow blob: media in CSP so voice-note playback works

### DIFF
--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -13,7 +13,12 @@
          that threshold, so they ship as `data:font/woff2;base64,…` inside
          the CSS and were refused under the `default-src 'self'` fallback.
          Still no remote origin — data: here is our own bundled bytes. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: blob:; font-src 'self' data:; connect-src 'self' ws: http: https:;" />
+    <!-- media-src allows blob: because an <audio> element cannot send an
+         Authorization header. Voice-note audio is fetched over the authenticated
+         channel (httpApi `voiceFetchNote`) and handed to the player as an
+         object URL, so blob: here is our own already-authorised bytes — never a
+         remote origin, and never a `?token=` URL. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' data:; connect-src 'self' ws: http: https:;" />
     <!-- BET-559: the PWA (manifest, apple-touch-icon, install meta, home-screen
          decoration) was the web-mobile-client surface and is retired with it.
          The renderer is the desktop Electron app — none of these PWA bits apply. -->


### PR DESCRIPTION
Adds `media-src 'self' blob:` to the renderer's single `<meta>` CSP, so the `blob:` object URL that `VoicePlayer` builds for a voice note's already-fetched audio bytes is allowed to play.

Voice-note audio can't travel via `<audio src>` with an `Authorization` header and a `?token=` URL is forbidden, so the clip is fetched over the authenticated channel and handed to the player as a `blob:` object URL — which the CSP previously refused via the `default-src 'self'` fallback (there was no `media-src`). This adds `media-src` right after `img-src`, on its own with no other directives widened and no `data:` added.

- **Files changed:** `1` — `src/renderer/index.html`
- **Verification (PR branch @ `1478f518`):**
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, `1980` pass / `0` fail / `0` skip. Failures: none.
- **Base: origin/main @ `62c911fe`**
- **Scope respected (per issue):** no other directive widened, no `data:` in `media-src`, no CSP response header added in the Electron main process, `src/server/servePage.mjs` untouched, `VoiceNote.tsx` not refactored (two follow-up issues own that work).
