### PR TITLE
feat(renderer): one always-visible voice player, delete the collapsed chip (BET-880)

### DIFF
--- a/src/renderer/MessageRow.tsx
+++ b/src/renderer/MessageRow.tsx
@@ -32,7 +32,7 @@ import { pastVerbFor } from "./chatShared";
 import { AssistantPart } from "./ToolCall";
 import { MantaMark } from "./MantaLoader";
 import { MessageBubble } from "./MessageBubble";
-import { VoiceNoteChip, VoicePlayer } from "./VoiceNote";
+import { VoicePlayer } from "./VoiceNote";
 
 // ===== Active todos =====
 //
@@ -278,10 +278,11 @@ export const MessageRow = memo(function MessageRow({
   // chevron instead of the full expanded template body.
   commandInfo: { name: string; arguments: string } | null;
   // BET-837: the voice note claimed by this user message (via
-  // buildVoiceNoteMap). When set, the row renders a VoiceNoteChip below the
-  // text — the transcript stays fully visible (text-first); the chip marks it
-  // as spoken and expands a VoicePlayer. null/undefined = a normal typed
-  // message (and the subagent transcripts in TaskCard, which have no notes).
+  // buildVoiceNoteMap). When set, the row renders a VoicePlayer below the
+  // text — the transcript stays fully visible (text-first); the player is
+  // immediately operable, no collapsed chip and no expand state. null /
+  // undefined = a normal typed message (and the subagent transcripts in
+  // TaskCard, which have no notes).
   voiceNote?: VoiceNoteRecord | null;
   // True when this message ARRIVED while the user was watching, as opposed to
   // being part of the transcript they loaded (transcript-motion). Decided once
@@ -297,10 +298,6 @@ export const MessageRow = memo(function MessageRow({
   entering?: boolean;
 }) {
   const isUser = msg.info.role === "user";
-  // BET-837: whether the note's player (VoicePlayer) is expanded below the
-  // chip for THIS row. Local state is fine — the memo chain passes `voiceNote`
-  // (a stable Map value) not this, so keystrokes don't touch it.
-  const [voiceExpanded, setVoiceExpanded] = useState(false);
 
   // Subtle wall-clock timestamp for each message/action. Sourced from the
   // message's own time.created — no new prop, so the MessageRow memo chain is
@@ -393,18 +390,12 @@ export const MessageRow = memo(function MessageRow({
             <MessageBubble entering={entering}>{text}</MessageBubble>
           )
         )}
-        {/* Text-first voice note: the transcript stays visible at all times;
-            the chip marks the message as spoken and expands a player below. */}
+        {/* Text-first voice note: the transcript stays fully visible; the player
+            sits below it and is immediately operable — no collapsed chip and no
+            expand state (see VoiceNote.tsx). */}
         {voiceNote && (
           <div className="flex justify-end">
-            <div className="flex flex-col items-end">
-              <VoiceNoteChip
-                audioAvailable={voiceNote.audioAvailable}
-                durationMs={voiceNote.durationMs}
-                onToggle={() => setVoiceExpanded((v) => !v)}
-              />
-              {voiceExpanded && <VoicePlayer note={voiceNote} />}
-            </div>
+            <VoicePlayer note={voiceNote} />
           </div>
         )}
       </div>,

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -66,7 +66,7 @@ export type TranscriptContext = {
   onRejectQuestion: (q: QuestionRequest) => void;
   // BET-837: the pending voice-note row (upload/transcribe in flight) renders
   // here — after the message list, before the working indicator. When it
-  // resolves into a real note it lands as a VoiceNoteChip on its message row.
+  // resolves into a real note it lands as a VoicePlayer on its message row.
   pendingVoiceNote?: PendingVoiceNote | null;
   onRetryVoiceNote?: (noteId: string) => void;
 };

--- a/src/renderer/VoiceNote.test.tsx
+++ b/src/renderer/VoiceNote.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment jsdom
+//
+// Component tests for the voice-note player (BET-880). Following the shape of
+// MessageBubble.test.tsx: VoicePlayerFrame is a PURE presentational component
+// (every visual is a prop — no api, no fetch), so it is tested directly with
+// no mocking. The one integration-style test (the "two players" regression
+// guard) mounts the real VoicePlayer, which fetches a blob via window.api, so
+// it installs the mock api and stubs URL.createObjectURL for jsdom.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { act } from "react";
+import { mount, installMockApi, type Harness } from "./testHarness";
+import { VoicePlayerFrame, VoicePlayer } from "./VoiceNote";
+import type { VoiceNoteRecord } from "../shared/types";
+
+// 40 non-zero peaks: with bars=40 and progress=0.5 the bar at index i is
+// "played" when i/40 < 0.5, i.e. exactly the first half tints accent.
+const peaks = new Uint8Array(40).fill(200);
+
+// The play/pause disc — the frame's interactive affordance. The speed control
+// is a SEPARATE button, so filtering by the disc's aria-label is how a test
+// counts play/pause controls without catching the speed badge.
+function discButton(container: Element): HTMLButtonElement | null {
+  return (
+    Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find((b) =>
+      /^(Play|Pause) voice note/.test(b.getAttribute("aria-label") ?? ""),
+    ) ?? null
+  );
+}
+
+function speedButton(container: Element): HTMLButtonElement | null {
+  return (
+    Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find((b) =>
+      /^Playback speed /.test(b.getAttribute("aria-label") ?? ""),
+    ) ?? null
+  );
+}
+
+describe("VoicePlayerFrame", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("ready state: enabled disc + a speed control that both fire on click", () => {
+    const onToggle = vi.fn();
+    const onCycleSpeed = vi.fn();
+    h = mount(
+      <VoicePlayerFrame
+        peaks={peaks}
+        clockMs={5000}
+        onToggle={onToggle}
+        speed={1}
+        onCycleSpeed={onCycleSpeed}
+      />,
+    );
+    const disc = discButton(h.container);
+    expect(disc).not.toBeNull();
+    expect(disc!.disabled).toBe(false);
+    expect(speedButton(h.container)?.textContent).toBe("1×");
+
+    act(() => disc!.click());
+    expect(onToggle).toHaveBeenCalledTimes(1);
+
+    act(() => speedButton(h.container)!.click());
+    expect(onCycleSpeed).toHaveBeenCalledTimes(1);
+  });
+
+  it("expired state: dashed + dimmed, clock suffixed, disc disabled, no speed control", () => {
+    h = mount(<VoicePlayerFrame peaks={peaks} clockMs={11000} expired />);
+    const frame = h.container.firstElementChild as HTMLElement;
+    expect(frame.className).toContain("border-dashed");
+    expect(frame.className).toContain("opacity-50");
+    expect(frame.textContent ?? "").toMatch(/0:11 · expired$/);
+    expect(discButton(h.container)?.disabled).toBe(true);
+    expect(speedButton(h.container)).toBeNull();
+  });
+
+  it("pending state: muted disc + no speed control + bare clock (no expired suffix)", () => {
+    h = mount(<VoicePlayerFrame peaks={peaks} clockMs={7000} />);
+    const frame = h.container.firstElementChild as HTMLElement;
+    expect(discButton(h.container)?.disabled).toBe(true);
+    expect(speedButton(h.container)).toBeNull();
+    expect(frame.textContent ?? "").toContain("0:07");
+    expect(frame.textContent ?? "").not.toContain("expired");
+  });
+
+  it("progress tints roughly half the bars accent, the rest neutral", () => {
+    h = mount(
+      <VoicePlayerFrame
+        peaks={peaks}
+        clockMs={5000}
+        progress={0.5}
+        onToggle={() => {}}
+        speed={1}
+        onCycleSpeed={() => {}}
+      />,
+    );
+    expect(h.container.querySelectorAll("div.bg-accent").length).toBe(20);
+    expect(h.container.querySelectorAll("div.bg-border-strong").length).toBe(20);
+  });
+});
+
+describe("VoicePlayer — 'two players' regression guard", () => {
+  it("renders EXACTLY one play/pause control for an available note", async () => {
+    installMockApi(); // window.api.voiceFetchNote — must exist or the fetch throws
+    // jsdom has no createObjectURL/revokeObjectURL; stub so the blob fetch
+    // resolves quietly instead of rejecting unhandled.
+    const originalCreate = URL.createObjectURL;
+    const originalRevoke = URL.revokeObjectURL;
+    URL.createObjectURL = () => "blob:mock";
+    URL.revokeObjectURL = () => {};
+    try {
+      const note: VoiceNoteRecord = {
+        id: "n1",
+        sessionId: "s1",
+        transcript: "hi",
+        mime: "audio/webm",
+        durationMs: 5000,
+        peaks,
+        createdAt: 0,
+        expiresAt: null,
+        audioAvailable: true,
+      };
+      const h = mount(<VoicePlayer note={note} />);
+      await h.flush();
+      const playControls = Array.from(h.container.querySelectorAll("button")).filter(
+        (b) => /^(Play|Pause) voice note/.test(b.getAttribute("aria-label") ?? ""),
+      );
+      // The old shape stacked a collapsed chip (its own disc) ABOVE a player
+      // disc — two play controls. This must be exactly one. This test fails if
+      // a collapsed chip is ever reintroduced.
+      expect(playControls.length).toBe(1);
+      h.unmount();
+    } finally {
+      URL.createObjectURL = originalCreate;
+      URL.revokeObjectURL = originalRevoke;
+    }
+  });
+});

--- a/src/renderer/VoiceNote.test.tsx
+++ b/src/renderer/VoiceNote.test.tsx
@@ -55,15 +55,16 @@ describe("VoicePlayerFrame", () => {
         onCycleSpeed={onCycleSpeed}
       />,
     );
-    const disc = discButton(h.container);
+    const container = h.container;
+    const disc = discButton(container);
     expect(disc).not.toBeNull();
     expect(disc!.disabled).toBe(false);
-    expect(speedButton(h.container)?.textContent).toBe("1×");
+    expect(speedButton(container)?.textContent).toBe("1×");
 
     act(() => disc!.click());
     expect(onToggle).toHaveBeenCalledTimes(1);
 
-    act(() => speedButton(h.container)!.click());
+    act(() => speedButton(container)!.click());
     expect(onCycleSpeed).toHaveBeenCalledTimes(1);
   });
 
@@ -125,7 +126,8 @@ describe("VoicePlayer — 'two players' regression guard", () => {
       };
       const h = mount(<VoicePlayer note={note} />);
       await h.flush();
-      const playControls = Array.from(h.container.querySelectorAll("button")).filter(
+      const container = h.container;
+      const playControls = Array.from(container.querySelectorAll("button")).filter(
         (b) => /^(Play|Pause) voice note/.test(b.getAttribute("aria-label") ?? ""),
       );
       // The old shape stacked a collapsed chip (its own disc) ABOVE a player

--- a/src/renderer/VoiceNote.tsx
+++ b/src/renderer/VoiceNote.tsx
@@ -1,25 +1,30 @@
-// ===== VoiceNote — the text-first voice-note bubble (BET-837) =====
+// ===== VoiceNote — the text-first voice-note bubble (BET-880) =====
 //
 // The rendered side of a stored voice note. A dictated message keeps its
-// transcript fully visible as normal text (text-first); below it a collapsed
-// `VoiceNoteChip` marks the row as spoken, and clicking it expands a
-// `VoicePlayer` with a DOM waveform (`VoiceBars`) + playback.
+// transcript fully visible as normal text (text-first); below it a single
+// always-visible player renders the waveform + playback.
+//
+// There is deliberately NO collapsed chip and NO expand/collapse state. The
+// earlier shape kept a chip AND appended a player below it on click, so two
+// controls both reading as "the player" stacked in the same column and the
+// first click cost the user a turn without playing anything. The player is now
+// the affordance: always visible, first click plays. Do not reintroduce a
+// collapsed variant.
 //
 // Component split:
-//   - VoiceBars   — static waveform, DOM not canvas. 40 bars is cheap, the
-//                   played/unplayed split and future seeking are trivial in
-//                   DOM, and it themes itself. The LIVE meter stays canvas
-//                   (VoiceWaveform) because it redraws 60×/s — do NOT unify
-//                   them; the two genuinely differ in rate and purpose.
-//   - VoiceNoteChip — the collapsed affordance (disc + duration, "expired"
-//                   when the audio has been swept). Optional `peaks` renders a
-//                   mini waveform, used by the pending row where the waveform
-//                   is fully formed instantly.
-//   - VoicePlayer — expanded: play/pause disc, VoiceBars, remaining time, and
-//                   a 1× → 1.5× → 2× speed cycle. Drives a single <audio> from
-//                   a fetched blob URL (never a `?token=` URL).
-//   - PendingVoiceRow — the not-yet-real row shown while a recording uploads +
-//                   transcribes; resolves into a normal user message on success.
+//   - VoiceBars        — static waveform, DOM not canvas. 40 bars is cheap,
+//                        the played/unplayed split and future seeking are
+//                        trivial in DOM, and it themes itself. The LIVE meter
+//                        stays canvas (VoiceWaveform) because it redraws
+//                        60×/s — do NOT unify them; the two genuinely differ
+//                        in rate and purpose.
+//   - VoicePlayerFrame — the presentational shell and the ONLY place the
+//                        player's chrome is described. No hooks, no fetching,
+//                        no <audio>: every visual is a prop, so the ready,
+//                        expired and pending states cannot drift apart.
+//   - VoicePlayer      — binds a stored note to playback and renders the frame.
+//   - PendingVoiceRow  — the not-yet-real row shown while a recording uploads +
+//                        transcribes; renders the same frame, non-interactive.
 
 import { memo, useEffect, useRef, useState } from "react";
 import { Pause, Play } from "lucide-react";
@@ -71,85 +76,97 @@ export const VoiceBars = memo(function VoiceBars({
   );
 });
 
-// ===== VoiceNoteChip — the collapsed affordance =====
+const SPEEDS = [1, 1.5, 2];
+
+// ===== VoicePlayerFrame — the presentational shell =====
 //
-// A pill marking a message as spoken: a filled disc holding a tiny
-// Play glyph, then the clock. Expired notes (audio swept, transcript kept)
-// render dimmed + dashed with a "· expired" suffix and are disabled — the chip
-// stays visible so the message keeps its identity as something spoken.
-export const VoiceNoteChip = memo(function VoiceNoteChip({
-  audioAvailable,
-  durationMs,
+// Fixed left-to-right order: disc, waveform, clock, speed. The three states are
+// expressed purely through props so there is exactly one set of chrome classes
+// and they cannot drift apart:
+//   ready   — onToggle + speed supplied.
+//   expired — `expired` set. Dashed + dimmed, muted disc, "· expired" suffix,
+//             no speed control, not interactive.
+//   pending — neither onToggle nor speed. Muted disc, not interactive.
+// The frame owns NO outer margin — vertical spacing belongs to the parent.
+export const VoicePlayerFrame = memo(function VoicePlayerFrame({
   peaks,
+  clockMs,
+  progress,
+  playing = false,
   onToggle,
+  speed,
+  onCycleSpeed,
+  expired = false,
 }: {
-  audioAvailable: boolean;
-  durationMs: number;
-  peaks?: Uint8Array;
+  peaks: Uint8Array;
+  /** Milliseconds on the clock: REMAINING while a clip is loaded, total otherwise. */
+  clockMs: number;
+  /** 0..1 played fraction; undefined = every bar neutral. */
+  progress?: number;
+  playing?: boolean;
+  /** Absent => non-interactive (pending / not-yet-fetched / expired). */
   onToggle?: () => void;
+  /** Both present => the speed control renders. */
+  speed?: number;
+  onCycleSpeed?: () => void;
+  expired?: boolean;
 }) {
-  const expired = !audioAvailable;
-  // Interactive only when the row is playable AND the caller wired a toggle.
-  // The pending row passes no onToggle → a non-interactive pill. Use <span>
-  // for that (not a disabled <button>) so nothing about it invites a click.
-  const inner = (
-    <>
-      <span
-        className={`w-5 h-5 rounded-full grid place-items-center shrink-0 ${
-          expired ? "bg-border-strong" : "bg-accent-solid text-on-accent"
-        }`}
-      >
-        <Play size={9} aria-hidden />
-      </span>
-      {peaks && peaks.length > 0 && <VoiceBars peaks={peaks} bars={14} />}
-      <span>{expired ? `${formatClock(durationMs)} · expired` : formatClock(durationMs)}</span>
-    </>
-  );
-  const base =
-    "inline-flex items-center gap-2 rounded-full border border-border bg-fill pl-1 pr-3 py-px mt-2 text-meta font-mono text-text-faint " +
-    (expired ? "opacity-50 border-dashed" : "hover:border-border-strong hover:text-text hover:bg-fill-hover transition-colors");
-  if (expired || !onToggle) {
-    return (
-      <span className={base} title={expired ? "Audio expired — transcript kept" : undefined}>
-        {inner}
-      </span>
-    );
-  }
+  const interactive = !expired && !!onToggle;
   return (
-    <button
-      type="button"
-      onClick={onToggle}
-      title="Replay voice note"
-      aria-label={`Play voice note, ${formatClock(durationMs)}`}
-      className={`${base} cursor-pointer`}
+    <div
+      className={
+        "flex items-center gap-3 rounded-md border border-border-subtle bg-bg-soft px-3 py-2 w-full max-w-[420px] " +
+        (expired ? "border-dashed opacity-50" : "")
+      }
+      title={expired ? "Audio expired — transcript kept" : undefined}
     >
-      {inner}
-    </button>
+      <button
+        type="button"
+        onClick={onToggle}
+        disabled={!interactive}
+        aria-label={playing ? "Pause voice note" : `Play voice note, ${formatClock(clockMs)}`}
+        className={
+          "w-7 h-7 shrink-0 rounded-full grid place-items-center transition-opacity " +
+          (interactive
+            ? "bg-accent-solid text-on-accent hover:opacity-90 cursor-pointer"
+            : "bg-border-strong text-on-accent")
+        }
+      >
+        {playing ? <Pause size={12} aria-hidden /> : <Play size={12} aria-hidden />}
+      </button>
+      <VoiceBars peaks={peaks} progress={progress} />
+      <span className="text-meta font-mono text-text-quiet tabular-nums shrink-0">
+        {expired ? `${formatClock(clockMs)} · expired` : formatClock(clockMs)}
+      </span>
+      {speed != null && onCycleSpeed && (
+        <button
+          type="button"
+          onClick={onCycleSpeed}
+          aria-label={`Playback speed ${speed}×`}
+          className="text-micro font-mono text-text-faint border border-border rounded-full px-2 py-px shrink-0 hover:text-text hover:border-border-strong transition-colors cursor-pointer"
+        >
+          {speed}×
+        </button>
+      )}
+    </div>
   );
 });
 
-const SPEEDS = [1, 1.5, 2];
-
-// ===== VoicePlayer — expanded playback =====
+// ===== VoicePlayer — a stored note bound to playback =====
 //
-// Play/pause disc, the VoiceBars filling the row (played portion tinted by
-// `progress`), the remaining clock, and a speed control cycling 1× → 1.5× →
-// 2×. Drives ONE <audio> element from a fetched blob URL; `timeupdate` feeds
-// progress. Pauses and revokes the object URL on unmount or note change.
-export const VoicePlayer = memo(function VoicePlayer({
-  note,
-}: {
-  note: VoiceNoteRecord;
-}) {
+// Drives ONE <audio> from a fetched blob URL (never a `?token=` URL) and hands
+// the frame its visual state. An expired note skips the fetch entirely.
+export const VoicePlayer = memo(function VoicePlayer({ note }: { note: VoiceNoteRecord }) {
   const audioRef = useRef<HTMLAudioElement | null>(null);
   const [url, setUrl] = useState<string | null>(null);
   const [playing, setPlaying] = useState(false);
   const [currentMs, setCurrentMs] = useState(0);
   const [speedIdx, setSpeedIdx] = useState(0);
+  const audioAvailable = note.audioAvailable;
 
-  // Fetch audio → blob URL. Never a `?token=` URL (box token must not leak
-  // into a URL); the bearer header rides the fetch. Revoke on unmount/id change.
+  // CHANGE 1: skip the fetch for an expired note — it can only 404.
   useEffect(() => {
+    if (!audioAvailable) return;
     let cancelled = false;
     let objectUrl: string | null = null;
     window.api
@@ -161,7 +178,7 @@ export const VoicePlayer = memo(function VoicePlayer({
       })
       .catch(() => {
         // Audio swept/expired between the list and the tap — leave the row
-        // silent rather than throwing (the chip already reads as inactive).
+        // silent rather than throwing (the frame already reads as inactive).
       });
     return () => {
       cancelled = true;
@@ -169,21 +186,20 @@ export const VoicePlayer = memo(function VoicePlayer({
       setUrl(null);
       setPlaying(false);
     };
-  }, [note.id]);
+  }, [note.id, audioAvailable]);
 
-  const durationMs = note.durationMs > 0 ? note.durationMs : Math.round((audioRef.current?.duration ?? 0) * 1000);
+  const durationMs =
+    note.durationMs > 0 ? note.durationMs : Math.round((audioRef.current?.duration ?? 0) * 1000);
   const progress = durationMs > 0 ? Math.min(1, currentMs / durationMs) : 0;
   const remainingMs = Math.max(0, durationMs - currentMs);
 
   const toggle = () => {
     const a = audioRef.current;
     if (!a || !url) return;
-    if (playing) {
-      a.pause();
-    } else {
-      a.currentTime = a.currentTime || 0;
-      void a.play().catch(() => { /* autoplay block — ignore */ });
-    }
+    if (playing) a.pause();
+    // CHANGE 2: drop the `a.currentTime = a.currentTime || 0;` line — it
+    // assigns currentTime to itself and is a no-op.
+    else void a.play().catch(() => { /* autoplay block — ignore */ });
   };
 
   const cycleSpeed = () => {
@@ -192,29 +208,24 @@ export const VoicePlayer = memo(function VoicePlayer({
     if (audioRef.current) audioRef.current.playbackRate = SPEEDS[next];
   };
 
+  if (!audioAvailable) {
+    return <VoicePlayerFrame peaks={note.peaks} clockMs={note.durationMs} expired />;
+  }
+
   return (
-    <div className="flex items-center gap-3 rounded-md border border-border-subtle bg-bg-soft px-3 py-2 mt-2 min-w-0">
-      <button
-        type="button"
-        onClick={toggle}
-        disabled={!url}
-        aria-label={playing ? "Pause" : "Play"}
-        className="w-7 h-7 shrink-0 rounded-full bg-accent-solid text-on-accent grid place-items-center hover:opacity-90 disabled:opacity-40 transition-opacity"
-      >
-        {playing ? <Pause size={12} aria-hidden /> : <Play size={12} aria-hidden />}
-      </button>
-      <VoiceBars peaks={note.peaks} progress={progress} />
-      <span className="text-meta font-mono text-text-quiet tabular-nums shrink-0">
-        {formatClock(remainingMs)}
-      </span>
-      <button
-        type="button"
-        onClick={cycleSpeed}
-        className="text-micro font-mono text-text-faint border border-border rounded-full px-2 py-px shrink-0 hover:text-text hover:border-border-strong transition-colors"
-        aria-label={`Playback speed ${SPEEDS[speedIdx]}×`}
-      >
-        {SPEEDS[speedIdx]}×
-      </button>
+    <>
+      <VoicePlayerFrame
+        peaks={note.peaks}
+        clockMs={remainingMs}
+        progress={progress}
+        playing={playing}
+        // CHANGE 3: withholding onToggle until the blob has arrived replaces the
+        // old `disabled={!url}` — the disc reads as not-yet-ready instead of
+        // being a live button that silently does nothing.
+        onToggle={url ? toggle : undefined}
+        speed={SPEEDS[speedIdx]}
+        onCycleSpeed={cycleSpeed}
+      />
       <audio
         ref={audioRef}
         src={url ?? undefined}
@@ -224,7 +235,7 @@ export const VoicePlayer = memo(function VoicePlayer({
         onEnded={() => { setPlaying(false); setCurrentMs(durationMs); }}
         onLoadedMetadata={() => setCurrentMs(0)}
       />
-    </div>
+    </>
   );
 });
 
@@ -234,9 +245,9 @@ export const VoicePlayer = memo(function VoicePlayer({
 // uploads + transcribes. Right-aligned like a normal user message, but its
 // left rule is neutral (`border-border-strong`) instead of the accent so it
 // reads as pending, not-yet-real. Two shimmer bars stand in for the transcript
-// text, a non-interactive chip draws the already-captured waveform (which is
-// what makes the wait read as "almost done"), and a status line reports
-// progress — or the failure + a Retry against the returned note id.
+// text, a non-interactive player frame draws the already-captured waveform
+// (which is what makes the wait read as "almost done"), and a status line
+// reports progress — or the failure + a Retry against the returned note id.
 export const PendingVoiceRow = memo(function PendingVoiceRow({
   pending,
   onRetry,
@@ -253,11 +264,7 @@ export const PendingVoiceRow = memo(function PendingVoiceRow({
             <div className="manta-shimmer h-3 rounded-xs" style={{ width: "88%" }} />
             <div className="manta-shimmer h-3 rounded-xs" style={{ width: "54%" }} />
           </div>
-          <VoiceNoteChip
-            audioAvailable
-            durationMs={pending.durationMs}
-            peaks={pending.peaks}
-          />
+          <VoicePlayerFrame peaks={pending.peaks} clockMs={pending.durationMs} />
         </div>
         {pending.error && pending.noteId ? (
           <div className="flex items-center gap-2 text-label">

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -121,6 +121,7 @@ function defaultApiImpl(): Record<string, unknown> {
     getPathForFile: () => "",
     clipboardReadImage: () => Promise.resolve(null),
     voiceListNotes: () => Promise.resolve([]),
+    voiceFetchNote: () => Promise.resolve(new Blob()),
   };
 }
 


### PR DESCRIPTION
Implements BET-880: delete the collapsed voice-note chip and the expand/collapse state entirely, leaving ONE always-visible player.

## What changed
- `src/renderer/VoiceNote.tsx`: deleted `VoiceNoteChip` (and all expand/collapse state). Added `VoicePlayerFrame` — a pure presentational shell where ready / expired / pending are expressed purely through props, so the chrome classes live in exactly one place and cannot drift. `VoicePlayer` now renders the frame; expired notes skip the audio fetch (can only 404), the no-op `a.currentTime = a.currentTime || 0` line is gone, and the disc's `onToggle` is withheld until the blob arrives (reads as not-yet-ready instead of a live button that silently does nothing).
- `src/renderer/MessageRow.tsx`: drops the `voiceExpanded` state and the chip-above-player stack; the player renders directly below the transcript text (text-first), right-aligned.
- `src/renderer/Transcript.tsx`: comment-only (pending note resolves to a player, not a chip).
- `src/renderer/testHarness.tsx`: stubbed `voiceFetchNote` so the regression test can mount a live player.
- `src/renderer/VoiceNote.test.tsx`: new tests covering ready / expired / pending / progress-tint for the frame, plus the explicit "two players" regression guard (exactly one play/pause control).

`VoiceBars`, `src/shared/waveform.mjs`, server-side code, and `demoCoverage.test.ts` are untouched, per scope.

## Anti-spaghetti
This is a net deletion as specified: one presentational frame is the single source of truth for the player's chrome (DRY), and the old chip is fully removed, not left behind.

**Base: origin/main @ 62c911f**

**Verification results:**
- PR branch (`multica/BET-880-voice-player` @ `193ae13`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0; vitest 2629 passed / 7 skipped; node 1980 pass / 0 fail. Failures: none. log sha256: `6fad2455b3724d2f0ea710abdeff6ea5d710b95b57489bd31c083f8ff1a30cce`
- Base (`main` @ `62c911f`):
  - typecheck: exit 0. Errors: none. log sha256: `ada2758fb1286e0aae5cba9202fcdcf309ac473ffa5237226950617c6dd84d3e`
  - test: exit 0; vitest 2624 passed / 7 skipped; node 1980 pass / 0 fail. Failures: none. log sha256: `9dfd202e528d736747b43a8472f48ec3aea31df3578b35fd99be6fe91a6e24e5`
- **Conclusion:** 0 new failures. This PR adds 5 new passing tests; no pre-existing failures on either branch.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
