### PR TITLE
feat(renderer): wire Review changes button to the in-app review pane (BET-869)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1268,6 +1268,15 @@ function AppInner() {
       window.removeEventListener("manta-open-settings", handler as EventListener);
   }, []);
 
+  // BET-869: the "Review changes" button in the branch popover opens the
+  // artifacts panel (ArtifactsPanel separately switches itself to its Review
+  // tab). Same window-CustomEvent convention as manta-open-settings above.
+  useEffect(() => {
+    const handler = () => setArtifactsOpen(true);
+    window.addEventListener("manta-open-review", handler);
+    return () => window.removeEventListener("manta-open-review", handler);
+  }, []);
+
   const activeWinName = activeProject?.windows.find(
     (w) => w.index === activeWindowByProject[activeProjectName!],
   )?.name ?? null;

--- a/src/renderer/ArtifactsPanel.review.test.tsx
+++ b/src/renderer/ArtifactsPanel.review.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+//
+// BET-869: the "Review changes" button in the branch popover opens the
+// artifacts panel on its Review tab. App.tsx flips the panel open via
+// `manta-open-review`; ArtifactsPanel independently listens for the same event
+// and selects the Review tab. This pins the panel's half of that bridge.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { act } from "react";
+import { installMockApi, resetStore, mount } from "./testHarness";
+import { ArtifactsPanel } from "./ArtifactsPanel";
+
+function reviewTab(h: { container: Element }) {
+  const btn = Array.from(
+    h.container.querySelectorAll<HTMLButtonElement>('button[role="tab"]'),
+  ).find((b) => b.textContent?.trim() === "Review");
+  expect(btn, 'expected a "Review" tab').not.toBeUndefined();
+  return btn!;
+}
+
+describe("ArtifactsPanel Review bridge (BET-869)", () => {
+  beforeEach(() => {
+    installMockApi();
+    resetStore();
+  });
+
+  it("manta-open-review selects the Review tab", async () => {
+    const h = mount(
+      <ArtifactsPanel sessionId="ses_test" cwd="/work" open={false} />,
+    );
+    await h.flush();
+
+    // Default is the Links tab.
+    expect(reviewTab(h).getAttribute("aria-selected")).toBe("false");
+
+    act(() => {
+      window.dispatchEvent(new CustomEvent("manta-open-review"));
+    });
+    await h.flush();
+
+    expect(reviewTab(h).getAttribute("aria-selected")).toBe("true");
+
+    h.unmount();
+  });
+});

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -536,6 +536,15 @@ export function ArtifactsPanel({
     setPreviewIndex(null);
   }, [sessionId]);
 
+  // BET-869: the "Review changes" button in the branch popover opens this panel
+  // on its Review tab (App.tsx separately flips the panel open). Same
+  // window-CustomEvent convention as the manta-open-* bridges.
+  useEffect(() => {
+    const handler = () => setTab("review");
+    window.addEventListener("manta-open-review", handler);
+    return () => window.removeEventListener("manta-open-review", handler);
+  }, []);
+
   const now = useMemo(() => Date.now(), []);
   const artifacts = useMemo(
     () => deriveArtifacts(messages, pages, sessionId ?? "", outbox),

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -2507,6 +2507,9 @@ export function ChatPanel({
         forgeKind={forge.kind}
         forgeConnectOfferDismissed={forgeConnectOfferDismissed}
         onOpenExternal={(url) => void window.api.openExternal(url)}
+        onReviewChanges={() =>
+          void window.dispatchEvent(new CustomEvent("manta-open-review"))
+        }
         onFillComposer={updateInputWithHistoryReset}
         onDismissForgeConnect={dismissForgeConnect}
         onMerge={() => void doMerge()}

--- a/src/renderer/SessionHeader.branch.test.tsx
+++ b/src/renderer/SessionHeader.branch.test.tsx
@@ -119,6 +119,23 @@ describe("SessionHeader branch popover (BET-867)", () => {
     expect(onOpenExternal).toHaveBeenCalledWith(PR.url);
   });
 
+  it("PR present → clicking Review changes calls onReviewChanges exactly once", async () => {
+    const onReviewChanges = vi.fn();
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: PR,
+      checksRollup: "green",
+      onReviewChanges,
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const reviewBtn = buttonWithText("Review changes");
+    act(() => reviewBtn.click());
+    expect(onReviewChanges).toHaveBeenCalledTimes(1);
+  });
+
   it("Merge is disabled with the reason as title when canMerge is false", async () => {
     h = mountSessionHeader({
       branch: "feat/forge-seam",

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -93,6 +93,7 @@ export function SessionHeader({
   forgeKind,
   forgeConnectOfferDismissed,
   onOpenExternal,
+  onReviewChanges,
   onFillComposer,
   onDismissForgeConnect,
   onMerge,
@@ -159,6 +160,10 @@ export function SessionHeader({
   forgeKind?: string | null;
   forgeConnectOfferDismissed?: boolean;
   onOpenExternal?: (url: string) => void;
+  // BET-869: from the PR-present branch popover, "Review changes" opens the
+  // artifacts panel on its Review tab. ChatPanel wires this to the
+  // `manta-open-review` window event.
+  onReviewChanges?: () => void;
   onFillComposer?: (text: string) => void;
   onDismissForgeConnect?: () => void;
   // BET-867: the branch chip's popover is the ONE git surface. Merge + ship
@@ -383,6 +388,7 @@ export function SessionHeader({
           onCreatePr={onCreatePr}
           onEnsureShipPreview={onEnsureShipPreview}
           onOpenExternal={onOpenExternal}
+          onReviewChanges={onReviewChanges}
         />
       ) : branch ? (
         <Tag
@@ -1005,6 +1011,7 @@ type BranchPanelProps = {
   onDraftPr?: () => void;
   onCreatePr?: () => void;
   onOpenExternal?: (url: string) => void;
+  onReviewChanges?: () => void;
 };
 
 function BranchChip({
@@ -1106,6 +1113,7 @@ function BranchPanel({
   onDraftPr,
   onCreatePr,
   onOpenExternal,
+  onReviewChanges,
 }: BranchPanelProps) {
   if (!pr) {
     // No pull request on this branch [F2] — the Draft PR… / Create PR offer.
@@ -1187,8 +1195,7 @@ function BranchPanel({
         >
           {mergeBusy ? "Merging…" : "Merge"}
         </Button>
-        {/* "Review changes" is inert in BET-867 — BET-869 wires it. */}
-        <Button tone="default">Review changes</Button>
+        <Button tone="default" onClick={onReviewChanges}>Review changes</Button>
         {onOpenExternal && (
           <Button tone="ghost" title="Open on GitHub" onClick={() => onOpenExternal(pr.url)}>
             <ExternalLink size={14} aria-hidden="true" />


### PR DESCRIPTION
## BET-869 — Wire the inert "Review changes" button to the in-app review pane

`Review changes` now opens the artifacts panel on its **Review** tab for the current session, via the repo's existing window-`CustomEvent` bridge — exactly the design in the issue.

### Mechanism (one event, two listeners)

- **`ChatPanel`** passes a new optional `onReviewChanges` prop to `SessionHeader`, wired to the `Review changes` button; the handler dispatches `window` `CustomEvent("manta-open-review")`.
- **`App.tsx`** listens for `manta-open-review` → `setArtifactsOpen(true)` (next to the existing `manta-open-settings` listener, same shape).
- **`ArtifactsPanel.tsx`** listens for `manta-open-review` → `setTab("review")`.

No prop chain through `App → ChatPanel → SessionHeader`; no modal, route, second entry point, RPC channel, `window.api` method, or store slice. `ReviewPane`, its props, data fetching, and the `forge:diff` channel are untouched.

### What was removed

- The `{/* "Review changes" is inert in BET-867 — BET-869 wires it. */}` placeholder comment on the button (the button was a no-op). Nothing else could be removed — this was a wiring job on a button that already rendered in the PR-present state.

### Tests

- `SessionHeader.branch.test.tsx`: clicking `Review changes` calls the injected `onReviewChanges` exactly once.
- `ArtifactsPanel.review.test.tsx` (new): dispatching `manta-open-review` on `window` selects the Review tab.

**Files changed:** 6. `src/renderer/App.tsx`, `src/renderer/ArtifactsPanel.tsx`, `src/renderer/ChatPanel.tsx`, `src/renderer/SessionHeader.tsx`, `src/renderer/SessionHeader.branch.test.tsx`, `src/renderer/ArtifactsPanel.review.test.tsx` (new).

**Verification results:**
- PR branch (`multica/BET-869-review-changes-button`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0, all pass / 0 fail / 0 new. log sha256: `4c9389a80e6d2e6613cbccacd06f04d9728f2b7cf7d240c981d80fa8bc05b319`
- Base (`main` @ `05eca658`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0, all pass / 0 fail. log sha256: `008091ec825a78fd6c824a8e8af26e659309573fd6498e5cc73816ded8131357`
- **Conclusion:** 0 new failures; 0 pre-existing failures on either branch. Note: the suite's total test count is flaky run-to-run (138 vs 139 files / ~2615–2630 cases on identical code) — a pre-existing test-collection nondeterminism, unrelated to this change; every run reports 0 failures.

**Base: origin/main @ `05eca658`**

Follow-ups filed: none.
