### PR TITLE
feat(ios): fill the plan-usage ring to the percentage (BET-877)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -805,12 +805,13 @@ private struct ChatScreenContent: View {
 
     // MARK: - Context meter (BET-824)
 
-    /// The context reading from the live stream payload: `.known` with a real
-    /// percentage, `.unknown` when the box has none (nil early in a session,
-    /// and again after a compaction). Never renders 0% for "don't know".
-    private var contextMeterReading: MeterReading {
-        guard let ctx = store.context, ctx.pct.isFinite else { return .unknown }
-        return .known(pct: ctx.pct)
+    /// The context percentage from the live stream payload: a real percentage
+    /// when the box reports one, nil when it has none (nil early in a session,
+    /// and again after a compaction). A missing value renders nothing — never
+    /// a confident 0%.
+    private var contextPct: Double? {
+        guard let ctx = store.context, ctx.pct.isFinite else { return nil }
+        return ctx.pct
     }
 
     /// The active model's own context window — the meter's denominator. Opus
@@ -829,7 +830,7 @@ private struct ChatScreenContent: View {
 
     /// The band colour for the current context reading (strip + sheet).
     private var contextBandColor: Color {
-        if case .known(let pct) = contextMeterReading {
+        if let pct = contextPct {
             return MeterRing.tint(UsageMeters.band(pct), tokens)
         }
         return tokens.tx4
@@ -847,7 +848,7 @@ private struct ChatScreenContent: View {
     /// and VoiceOver announces it so.
     @ViewBuilder
     private var contextStrip: some View {
-        if case .known(let pct) = contextMeterReading {
+        if let pct = contextPct {
             Button { showContextSheet = true } label: {
                 HStack(spacing: Metrics.spacing.sp2) {
                     Text("Context")
@@ -915,7 +916,7 @@ private struct ChatScreenContent: View {
     private var weeklyBanner: some View {
         let weekly = UsageMeters.weeklyWindow(usageStore.snapshots)
         return HStack(spacing: Metrics.spacing.sp2) {
-            MeterRing(color: tokens.danger, diameter: 14, lineWidth: 2.5)
+            MeterRing(pct: weekly?.pct ?? 0, color: tokens.danger, diameter: 14, lineWidth: 2.5, track: tokens.borderSubtle)
             VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
                 Text("Weekly limit \(Int((weekly?.pct ?? 0).rounded()))%")
                     .font(.manta(size: Metrics.type.xs, weight: .semibold))

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -304,22 +304,24 @@ struct ComposerView: View {
 
     // MARK: - Plan-usage dot (BET-824)
 
-    /// The bare band-coloured ring beside the model name. Colour only — no
-    /// number, no label, ever. It tracks the 5-hour `session` window, always
-    /// (a dot that silently switched windows would force a tap to know what
-    /// the colour meant). Absent when there is no session window (`.absent`);
-    /// a hollow muted ring when the value is unknown.
+    /// The band-coloured ring beside the model name, filled clockwise from
+    /// 12 o'clock to the session window's percentage (a solid disc at/over
+    /// 100). Colour + fraction only — no number, no label, ever. It tracks
+    /// the 5-hour `session` window, always (a dot that silently switched
+    /// windows would force a tap to know what the colour meant). Hidden when
+    /// there is no session window.
     @ViewBuilder
     private var usageDot: some View {
-        switch meterReading {
-        case .absent:
-            EmptyView()
-        case .known, .unknown:
+        if let window = UsageMeters.sessionWindow(usageStore.snapshots) {
             Button { onShowUsage?() } label: {
-                MeterRing(color: dotColor, diameter: 13, lineWidth: 2.5)
+                MeterRing(pct: window.pct,
+                          color: MeterRing.tint(UsageMeters.band(window.pct), tokens),
+                          diameter: 13,
+                          lineWidth: 2.5,
+                          track: tokens.borderSubtle)
             }
             .buttonStyle(.plain)
-            // 44pt tap target around the 13pt ring — colour-only costs no
+            // 44pt tap target around the 13pt ring — colour+fill costs no
             // width and survives accessibility type sizes.
             .frame(width: 44, height: 44)
             .contentShape(Rectangle())
@@ -327,22 +329,6 @@ struct ComposerView: View {
             .accessibilityIdentifier("usage-dot")
         }
     }
-
-    /// The dot's severity: the band of the session window when known, a muted
-    /// hollow ring when unknown. Never a confident green for "don't know".
-    private var meterReading: MeterReading {
-        guard let session = UsageMeters.sessionWindow(usageStore.snapshots) else { return .absent }
-        return .known(pct: session.pct)
-    }
-
-    private var dotColor: Color {
-        switch meterReading {
-        case .known(let pct): return MeterRing.tint(UsageMeters.band(pct), tokens)
-        case .unknown, .absent: return tokens.tx4
-        }
-    }
-
-
 
     /// Accent while a background refetch is in flight, and never while a turn
     /// runs — the two states must not share an indicator (BET-630 D1).

--- a/mobile/native/MantaUI/UsageMeters.swift
+++ b/mobile/native/MantaUI/UsageMeters.swift
@@ -11,38 +11,25 @@ import Foundation
 // This file holds ONLY the decisions (band, which window, banner gate, reset
 // format) so they are unit-testable with plain values and
 // no SwiftUI hierarchy, mirroring `BranchFreshnessPolicy` in ChatScreen.swift.
-// The three non-numeric states matter here:
-//   .known   — a definitive percentage
-//   .unknown — the upstream value is nil early in a session and again after a
-//              compaction. Renders as a hollow ring / hidden strip; never a
-//              confident 0%.
-//   .absent  — no usage object at all (not a subscriber, or pre-first-
-//              response). Hides the dot entirely.
+// Missing values are expressed with Swift optionals rather than a bespoke
+// enum: a nil session window hides the dot; a nil context percentage hides
+// the context strip. A missing value renders nothing — never a confident 0%.
 // ===========================================================================
 
 /// The severity band of a meter reading, from a percentage at the 70/90
-/// breakpoints. `unknown`/`absent` never band to `ok` — a missing value is
-/// not a confident green.
+/// breakpoints. A gate must never band a missing value — see `band` below.
 enum MeterBand: Equatable {
     case ok
     case warn
     case danger
 }
 
-/// A meter's non-numeric source of truth.
-enum MeterReading: Equatable {
-    case known(pct: Double)
-    case unknown
-    case absent
-}
-
 /// Pure decisions behind the two meters.
 enum UsageMeters {
 
     /// Band a 0-100 percentage at Anthropic's published breakpoints: < 70
-    /// green, 70–89 amber, ≥ 90 red. Callers pass an already-`known` value;
-    /// a gate must never feed `.unknown`/`.absent` here (they would read as
-    /// `ok` and lie).
+    /// green, 70–89 amber, ≥ 90 red. Callers pass only a real percentage; a
+    /// missing value must render nothing upstream, never a confident `ok`.
     static func band(_ pct: Double) -> MeterBand {
         if pct >= 90 { return .danger }
         if pct >= 70 { return .warn }
@@ -50,7 +37,7 @@ enum UsageMeters {
     }
 
     /// The 5-hour session window across all snapshots, or nil. `nil` is the
-    /// signal that hides the usage dot (`.absent`) — e.g. a snapshot set
+    /// signal that hides the usage dot — e.g. a snapshot set
     /// holding only a weekly window.
     static func sessionWindow(_ snapshots: [UsageSnapshot]) -> UsageWindow? {
         first(whereKind: "session", in: snapshots)

--- a/mobile/native/MantaUI/UsageSheets.swift
+++ b/mobile/native/MantaUI/UsageSheets.swift
@@ -11,18 +11,38 @@ import SwiftUI
 // no action).
 // ===========================================================================
 
-/// The bare band-coloured ring used by the composer dot, the usage-sheet rows
-/// and the weekly banner. 13pt / 2.5pt stroke by default; colour only — no
-/// percentage, no label, ever.
+/// The partially-filled band-coloured ring used by the composer dot, the
+/// usage-sheet rows and the weekly banner. 13pt / 2.5pt stroke by default;
+/// the filled fraction matches the meter's percentage drawn over a muted
+/// track. Colour + fraction only — no number, no label, ever.
 struct MeterRing: View {
+    /// 0-100. Clamped: a provider can report over 100.
+    let pct: Double
     let color: Color
     var diameter: CGFloat = 13
     var lineWidth: CGFloat = 2.5
+    /// The muted full-circle track drawn underneath the filled fraction.
+    let track: Color
 
     var body: some View {
-        Circle()
-            .stroke(color, lineWidth: lineWidth)
+        let clamped = Self.clamp(pct)
+        // At/over 100 the fraction would be a full ring identical to 99% —
+        // so it becomes a solid disc instead. That state must be unmistakable.
+        if Self.isFull(clamped) {
+            Circle()
+                .fill(color)
+                .frame(width: diameter, height: diameter)
+        } else {
+            ZStack {
+                Circle()
+                    .stroke(track, lineWidth: lineWidth)
+                Circle()
+                    .trim(from: 0, to: clamped / 100)
+                    .stroke(color, lineWidth: lineWidth)
+                    .rotationEffect(.degrees(-90))
+            }
             .frame(width: diameter, height: diameter)
+        }
     }
 
     static func tint(_ band: MeterBand, _ tokens: Tokens) -> Color {
@@ -31,6 +51,17 @@ struct MeterRing: View {
         case .warn: return tokens.warn
         case .danger: return tokens.danger
         }
+    }
+
+    /// Clamp a 0-100 percentage (providers can report over 100).
+    static func clamp(_ pct: Double) -> Double {
+        min(max(pct, 0), 100)
+    }
+
+    /// Whether the (already-clamped) percentage is at/over 100 — the
+    /// solid-disc state. Pure so the ≥100 boundary is unit-testable.
+    static func isFull(_ pct: Double) -> Bool {
+        pct >= 100
     }
 }
 
@@ -253,7 +284,7 @@ private struct UsageWindowRow: View {
         let tint = MeterRing.tint(band, tokens)
         VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
             HStack(spacing: Metrics.spacing.sp1) {
-                MeterRing(color: tint, diameter: 11, lineWidth: 2.5)
+                MeterRing(pct: window.pct, color: tint, diameter: 11, lineWidth: 2.5, track: tokens.borderSubtle)
                 Text(name)
                     .font(.manta(size: Metrics.type.small, weight: .semibold))
                     .foregroundColor(tokens.tx1)

--- a/mobile/native/MantaUITests/UsageMetersTests.swift
+++ b/mobile/native/MantaUITests/UsageMetersTests.swift
@@ -3,10 +3,9 @@ import XCTest
 
 // ===========================================================================
 // BET-824 — pure decisions of the plan + context meters (UsageMeters). No view,
-// no HTTP, no box. Tests every boundary exactly: 69.9/70/89.9/90, `unknown`
-// never banding to `ok` (band never fed unknown), `absent` hiding the dot
-// (sessionWindow nil), a snapshot holding only a weekly window, and
-// `formatReset` under and over 24h.
+// no HTTP, no box. Tests every boundary exactly: 69.9/70/89.9/90, a missing
+// value rendering nothing (sessionWindow nil), a snapshot holding only a
+// weekly window, and `formatReset` under and over 24h.
 // ===========================================================================
 
 final class UsageMetersTests: XCTestCase {
@@ -126,5 +125,26 @@ final class UsageMetersTests: XCTestCase {
         XCTAssertEqual(UsageMeters.formatTokens(1_000_000), "1M")
         XCTAssertEqual(UsageMeters.formatTokens(500), "500")
         XCTAssertEqual(UsageMeters.formatTokens(nil), "0")
+    }
+
+    // MARK: - MeterRing clamp / isFull (BET-877)
+
+    /// `pct` is clamped to 0...100 before drawing — a provider can report
+    /// over 100, and a negative never wraps around into a full ring.
+    func testMeterRingClampBounds() {
+        XCTAssertEqual(MeterRing.clamp(-5), 0)
+        XCTAssertEqual(MeterRing.clamp(0), 0)
+        XCTAssertEqual(MeterRing.clamp(140), 100)
+        XCTAssertEqual(MeterRing.clamp(100), 100)
+    }
+
+    /// The ≥100 boundary: 99.9 is still a ring (not full); 100 (and anything
+    /// over, once clamped) is a solid disc — a "full" ring would be
+    /// indistinguishable from 99%.
+    func testMeterRingIsFullBoundary() {
+        XCTAssertFalse(MeterRing.isFull(99.9))
+        XCTAssertFalse(MeterRing.isFull(0))
+        XCTAssertTrue(MeterRing.isFull(100))
+        XCTAssertTrue(MeterRing.isFull(120))
     }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-877-ios-usage-ring`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-877.