### PR TITLE
feat(renderer): lift the voice-note audio engine out of the transcript row (BET-881)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -88,6 +88,7 @@ import { useTranscriptState } from "./hooks/useTranscriptState";
 import { useSseBus } from "./hooks/useSseBus";
 import { useVoice } from "./hooks/useVoice";
 import { useTypeahead } from "./hooks/useTypeahead";
+import { VoicePlaybackProvider } from "./hooks/useVoicePlayback";
 import { Transcript } from "./Transcript";
 import { Composer } from "./Composer";
 import { SessionHeader } from "./SessionHeader";
@@ -2521,35 +2522,37 @@ export function ChatPanel({
         onEnsureShipPreview={() => void ensureShipPreview()}
       />
 
-      <Transcript
-        messages={messages}
-        virtuosoRef={virtuosoRef}
-        sessionId={sessionId}
-        setMessages={setMessages}
-        loadedAllRef={loadedAllRef}
-        taskContextValue={taskContextValue}
-        showThinking={showThinking}
-        running={running}
-        liveTurn={liveTurn}
-        progress={liveProgress}
-        isActive={isActive}
-        activeTodos={activeTodos}
-        onDismissTodos={dismissTodos}
-        // BET-418 §D: a job session is read-only — never show its (anyway
-        // impossible) question cards. Defensive: a job's pre-flight ruleset
-        // means it never generates asks.
-        questions={jobOwnership ? [] : questions}
-        turnInfo={turnInfo}
-        finishByMessageId={finishByMessageId}
-        userCommandInfo={userCommandInfo}
-        voiceNoteByMessageId={voiceNoteByMessageId}
-        pendingVoiceNote={pendingVoiceNote}
-        onRetryVoiceNote={retryVoiceNote}
-        onReplyQuestion={replyQuestion}
-        onRejectQuestion={rejectQuestion}
-        onAtBottomChange={onAtBottomChange}
-        motionStateRef={motionStateRef}
-      />
+      <VoicePlaybackProvider active={isActive}>
+        <Transcript
+          messages={messages}
+          virtuosoRef={virtuosoRef}
+          sessionId={sessionId}
+          setMessages={setMessages}
+          loadedAllRef={loadedAllRef}
+          taskContextValue={taskContextValue}
+          showThinking={showThinking}
+          running={running}
+          liveTurn={liveTurn}
+          progress={liveProgress}
+          isActive={isActive}
+          activeTodos={activeTodos}
+          onDismissTodos={dismissTodos}
+          // BET-418 §D: a job session is read-only — never show its (anyway
+          // impossible) question cards. Defensive: a job's pre-flight ruleset
+          // means it never generates asks.
+          questions={jobOwnership ? [] : questions}
+          turnInfo={turnInfo}
+          finishByMessageId={finishByMessageId}
+          userCommandInfo={userCommandInfo}
+          voiceNoteByMessageId={voiceNoteByMessageId}
+          pendingVoiceNote={pendingVoiceNote}
+          onRetryVoiceNote={retryVoiceNote}
+          onReplyQuestion={replyQuestion}
+          onRejectQuestion={rejectQuestion}
+          onAtBottomChange={onAtBottomChange}
+          motionStateRef={motionStateRef}
+        />
+      </VoicePlaybackProvider>
 
       {/* Pinned card stack above the composer (BET-783): blocking always
           above ambient, at most one blocking expanded, at most two ambient

--- a/src/renderer/VoiceNote.test.tsx
+++ b/src/renderer/VoiceNote.test.tsx
@@ -11,6 +11,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { act } from "react";
 import { mount, installMockApi, type Harness } from "./testHarness";
 import { VoicePlayerFrame, VoicePlayer } from "./VoiceNote";
+import { VoicePlaybackProvider } from "./hooks/useVoicePlayback";
 import type { VoiceNoteRecord } from "../shared/types";
 
 // 40 non-zero peaks: with bars=40 and progress=0.5 the bar at index i is
@@ -124,7 +125,11 @@ describe("VoicePlayer — 'two players' regression guard", () => {
         expiresAt: null,
         audioAvailable: true,
       };
-      const h = mount(<VoicePlayer note={note} />);
+      const h = mount(
+        <VoicePlaybackProvider active>
+          <VoicePlayer note={note} />
+        </VoicePlaybackProvider>,
+      );
       await h.flush();
       const container = h.container;
       const playControls = Array.from(container.querySelectorAll("button")).filter(

--- a/src/renderer/VoiceNote.tsx
+++ b/src/renderer/VoiceNote.tsx
@@ -22,11 +22,21 @@
 //                        player's chrome is described. No hooks, no fetching,
 //                        no <audio>: every visual is a prop, so the ready,
 //                        expired and pending states cannot drift apart.
-//   - VoicePlayer      — binds a stored note to playback and renders the frame.
+//   - VoicePlayer      — binds a stored note to the SHARED conversation-wide
+//                        playback engine (useVoicePlayback) and renders the
+//                        frame.
 //   - PendingVoiceRow  — the not-yet-real row shown while a recording uploads +
 //                        transcribes; renders the same frame, non-interactive.
+//
+// Why is the engine NOT in the row? The transcript is virtualised — Virtuoso
+// destroys rows that scroll out of view, so a row-owned <audio> would be torn
+// down (its object URL revoked) mid-playback by scrolling. The engine lives in
+// the conversation-level VoicePlaybackProvider instead, which means scrolling
+// never affects playback, only one note plays at a time, and each clip is
+// fetched once for the whole conversation.
 
-import { memo, useEffect, useRef, useState } from "react";
+import { memo } from "react";
+import { useVoicePlayback } from "./hooks/useVoicePlayback";
 import { Pause, Play } from "lucide-react";
 import { bucketPeaks, formatClock, normalizeForDisplay } from "../shared/waveform.mjs";
 import type { VoiceNoteRecord } from "../shared/types";
@@ -75,8 +85,6 @@ export const VoiceBars = memo(function VoiceBars({
     </div>
   );
 });
-
-const SPEEDS = [1, 1.5, 2];
 
 // ===== VoicePlayerFrame — the presentational shell =====
 //
@@ -152,90 +160,32 @@ export const VoicePlayerFrame = memo(function VoicePlayerFrame({
   );
 });
 
-// ===== VoicePlayer — a stored note bound to playback =====
+// ===== VoicePlayer — a stored note bound to the shared playback engine =====
 //
-// Drives ONE <audio> from a fetched blob URL (never a `?token=` URL) and hands
-// the frame its visual state. An expired note skips the fetch entirely.
+// Pure consumer: it renders the frame and calls into the conversation-wide
+// engine (useVoicePlayback). It owns no <audio>, no fetch, no audio state —
+// those live in VoicePlaybackProvider, so scrolling the virtualised transcript
+// never interrupts playback and only one note plays at a time.
 export const VoicePlayer = memo(function VoicePlayer({ note }: { note: VoiceNoteRecord }) {
-  const audioRef = useRef<HTMLAudioElement | null>(null);
-  const [url, setUrl] = useState<string | null>(null);
-  const [playing, setPlaying] = useState(false);
-  const [currentMs, setCurrentMs] = useState(0);
-  const [speedIdx, setSpeedIdx] = useState(0);
-  const audioAvailable = note.audioAvailable;
+  const { playing, currentMs, speed, toggle, cycleSpeed } = useVoicePlayback(note.id);
 
-  // CHANGE 1: skip the fetch for an expired note — it can only 404.
-  useEffect(() => {
-    if (!audioAvailable) return;
-    let cancelled = false;
-    let objectUrl: string | null = null;
-    window.api
-      .voiceFetchNote(note.id)
-      .then((blob) => {
-        if (cancelled) return;
-        objectUrl = URL.createObjectURL(blob);
-        setUrl(objectUrl);
-      })
-      .catch(() => {
-        // Audio swept/expired between the list and the tap — leave the row
-        // silent rather than throwing (the frame already reads as inactive).
-      });
-    return () => {
-      cancelled = true;
-      if (objectUrl) URL.revokeObjectURL(objectUrl);
-      setUrl(null);
-      setPlaying(false);
-    };
-  }, [note.id, audioAvailable]);
-
-  const durationMs =
-    note.durationMs > 0 ? note.durationMs : Math.round((audioRef.current?.duration ?? 0) * 1000);
-  const progress = durationMs > 0 ? Math.min(1, currentMs / durationMs) : 0;
-  const remainingMs = Math.max(0, durationMs - currentMs);
-
-  const toggle = () => {
-    const a = audioRef.current;
-    if (!a || !url) return;
-    if (playing) a.pause();
-    // CHANGE 2: drop the `a.currentTime = a.currentTime || 0;` line — it
-    // assigns currentTime to itself and is a no-op.
-    else void a.play().catch(() => { /* autoplay block — ignore */ });
-  };
-
-  const cycleSpeed = () => {
-    const next = (speedIdx + 1) % SPEEDS.length;
-    setSpeedIdx(next);
-    if (audioRef.current) audioRef.current.playbackRate = SPEEDS[next];
-  };
-
-  if (!audioAvailable) {
+  if (!note.audioAvailable) {
     return <VoicePlayerFrame peaks={note.peaks} clockMs={note.durationMs} expired />;
   }
 
+  const progress = note.durationMs > 0 ? Math.min(1, currentMs / note.durationMs) : 0;
+  const remainingMs = Math.max(0, note.durationMs - currentMs);
+
   return (
-    <>
-      <VoicePlayerFrame
-        peaks={note.peaks}
-        clockMs={remainingMs}
-        progress={progress}
-        playing={playing}
-        // CHANGE 3: withholding onToggle until the blob has arrived replaces the
-        // old `disabled={!url}` — the disc reads as not-yet-ready instead of
-        // being a live button that silently does nothing.
-        onToggle={url ? toggle : undefined}
-        speed={SPEEDS[speedIdx]}
-        onCycleSpeed={cycleSpeed}
-      />
-      <audio
-        ref={audioRef}
-        src={url ?? undefined}
-        onTimeUpdate={(e) => setCurrentMs(Math.round(e.currentTarget.currentTime * 1000))}
-        onPlay={() => setPlaying(true)}
-        onPause={() => setPlaying(false)}
-        onEnded={() => { setPlaying(false); setCurrentMs(durationMs); }}
-        onLoadedMetadata={() => setCurrentMs(0)}
-      />
-    </>
+    <VoicePlayerFrame
+      peaks={note.peaks}
+      clockMs={remainingMs}
+      progress={progress}
+      playing={playing}
+      onToggle={toggle}
+      speed={speed}
+      onCycleSpeed={cycleSpeed}
+    />
   );
 });
 

--- a/src/renderer/hooks/useVoicePlayback.test.tsx
+++ b/src/renderer/hooks/useVoicePlayback.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+//
+// Component tests for the conversation-wide voice playback engine (BET-881).
+// The provider owns ONE <audio> for the whole conversation; each VoicePlayer
+// is a pure consumer that binds a stored note to it. These tests mount the
+// real provider + real VoicePlayers and drive the disc/speed controls, which
+// is exactly where the "one at a time", "idle rows stay idle", "fetched once"
+// and "hidden panel pauses" behaviours live.
+//
+// jsdom does not implement HTMLMediaElement play/pause, so play/pause are
+// stubbed to dispatch the matching media event (bubbling, as the real browser
+// does) — that is what drives the provider's onPlay/onPause state.
+// window.api.voiceFetchNote and URL.createObjectURL/revokeObjectURL are also
+// stubbed (jsdom lacks the URL ones).
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import { mount, installMockApi, type Harness } from "../testHarness";
+import { VoicePlaybackProvider } from "./useVoicePlayback";
+import { VoicePlayer } from "../VoiceNote";
+import type { VoiceNoteRecord } from "../../shared/types";
+
+const peaks = new Uint8Array(40).fill(200);
+
+function makeNote(id: string): VoiceNoteRecord {
+  return {
+    id,
+    sessionId: "s1",
+    transcript: "hi",
+    mime: "audio/webm",
+    durationMs: 5000,
+    peaks,
+    createdAt: 0,
+    expiresAt: null,
+    audioAvailable: true,
+  };
+}
+
+// The play/pause disc is the frame's interactive affordance (aria-label
+// "Play|Pause voice note, …"); the speed badge is a separate control. With two
+// VoicePlayers mounted, discs[0] is A and discs[1] is B (DOM order).
+function discs(container: Element): HTMLButtonElement[] {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>("button")).filter((b) =>
+    /^(Play|Pause) voice note/.test(b.getAttribute("aria-label") ?? ""),
+  );
+}
+
+function speedButton(container: Element): HTMLButtonElement {
+  return Array.from(container.querySelectorAll<HTMLButtonElement>("button")).find((b) =>
+    /^Playback speed /.test(b.getAttribute("aria-label") ?? ""),
+  )!;
+}
+
+function audioEl(container: Element): HTMLAudioElement {
+  return container.querySelector("audio")!;
+}
+
+describe("VoicePlaybackProvider + VoicePlayer", () => {
+  let h: Harness | null = null;
+  let fetchSpy: ReturnType<typeof vi.fn>;
+  let playSpy: ReturnType<typeof vi.spyOn>;
+  let pauseSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.fn(() => Promise.resolve(new Blob()));
+    installMockApi({ voiceFetchNote: fetchSpy });
+    // jsdom implements neither play/pause nor object URLs.
+    playSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "play")
+      .mockImplementation(function (this: HTMLMediaElement) {
+        this.dispatchEvent(new Event("play", { bubbles: true }));
+        return Promise.resolve();
+      });
+    pauseSpy = vi
+      .spyOn(HTMLMediaElement.prototype, "pause")
+      .mockImplementation(function (this: HTMLMediaElement) {
+        this.dispatchEvent(new Event("pause", { bubbles: true }));
+      });
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL: () => "blob:mock",
+      revokeObjectURL: () => {},
+    });
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    playSpy.mockRestore();
+    pauseSpy.mockRestore();
+    vi.unstubAllGlobals();
+  });
+
+  const mountTwo = (): Harness =>
+    mount(
+      <VoicePlaybackProvider active>
+        <VoicePlayer note={makeNote("A")} />
+        <VoicePlayer note={makeNote("B")} />
+      </VoicePlaybackProvider>,
+    );
+
+  it("one at a time: toggling B stops A and B reports playing", async () => {
+    h = mountTwo();
+    const container = h.container;
+    await h.flush();
+    expect(discs(container)[0].getAttribute("aria-label") ?? "").toMatch(/^Play/);
+    expect(discs(container)[1].getAttribute("aria-label") ?? "").toMatch(/^Play/);
+
+    act(() => discs(container)[0].click()); // play A
+    await h.flush();
+    expect(discs(container)[0].getAttribute("aria-label") ?? "").toMatch(/^Pause/);
+    expect(discs(container)[1].getAttribute("aria-label") ?? "").toMatch(/^Play/);
+
+    act(() => discs(container)[1].click()); // play B → A stops
+    await h.flush();
+    expect(discs(container)[0].getAttribute("aria-label") ?? "").toMatch(/^Play/); // A stopped
+    expect(discs(container)[1].getAttribute("aria-label") ?? "").toMatch(/^Pause/); // B playing
+  });
+
+  it("idle rows are idle: while A plays, B shows total duration and a Play glyph", async () => {
+    h = mountTwo();
+    const container = h.container;
+    await h.flush();
+    act(() => discs(container)[0].click()); // play A only
+    await h.flush();
+
+    const frames = Array.from(container.children) as HTMLElement[]; // [frameA, frameB, audio]
+    expect((frames[1].textContent ?? "").includes("0:05")).toBe(true); // B idle → total
+    expect(discs(container)[1].getAttribute("aria-label") ?? "").toMatch(/^Play voice note/);
+  });
+
+  it("fetched once: toggling the same note off and on fetches exactly once", async () => {
+    h = mountTwo();
+    const container = h.container;
+    await h.flush();
+    act(() => discs(container)[0].click()); // play A → fetch #1
+    await h.flush();
+    act(() => discs(container)[0].click()); // pause A (active & playing) → no fetch
+    await h.flush();
+    act(() => discs(container)[0].click()); // play A again → cache hit → no fetch
+    await h.flush();
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("deactivation pauses: active=false pauses the engine", async () => {
+    h = mountTwo();
+    const container = h.container;
+    await h.flush();
+    act(() => discs(container)[0].click()); // play A
+    await h.flush();
+    pauseSpy.mockClear();
+    h.rerender(
+      <VoicePlaybackProvider active={false}>
+        <VoicePlayer note={makeNote("A")} />
+        <VoicePlayer note={makeNote("B")} />
+      </VoicePlaybackProvider>,
+    );
+    await h.flush();
+    expect(pauseSpy).toHaveBeenCalled();
+  });
+
+  it("speed is global and applies to the engine's audio element: 1 → 1.5 → 2", async () => {
+    h = mountTwo();
+    const container = h.container;
+    await h.flush();
+    act(() => discs(container)[0].click()); // play A so the engine has an element
+    await h.flush();
+
+    expect(speedButton(container).textContent).toBe("1×");
+    expect(audioEl(container).playbackRate).toBe(1);
+
+    act(() => speedButton(container).click());
+    expect(speedButton(container).textContent).toBe("1.5×");
+    expect(audioEl(container).playbackRate).toBe(1.5);
+
+    act(() => speedButton(container).click());
+    expect(speedButton(container).textContent).toBe("2×");
+    expect(audioEl(container).playbackRate).toBe(2);
+  });
+});

--- a/src/renderer/hooks/useVoicePlayback.tsx
+++ b/src/renderer/hooks/useVoicePlayback.tsx
@@ -1,0 +1,166 @@
+// ===== useVoicePlayback — one audio engine per conversation (BET-881) =====
+//
+// The <audio> element used to live INSIDE each transcript row, but the
+// transcript is virtualised (Virtuoso destroys rows that scroll out of view).
+// Three bugs followed from a row-owned player: playback died when the row was
+// scrolled away (the effect cleanup revoked the object URL mid-sentence),
+// several notes could overlap, and the clip was re-downloaded every time a row
+// remounted. This provider lifts the engine OUT of the row: it owns exactly
+// one <audio>, the active note, and a blob-URL cache, so scrolling has no
+// effect on playback, "one note at a time" is automatic, and each clip is
+// fetched exactly once per conversation.
+
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
+
+export const SPEEDS = [1, 1.5, 2];
+
+type PlaybackEngine = {
+  activeNoteId: string | null;
+  playing: boolean;
+  currentMs: number;
+  speedIdx: number;
+  toggle: (noteId: string) => void;
+  cycleSpeed: () => void;
+};
+
+const VoicePlaybackContext = createContext<PlaybackEngine | null>(null);
+
+function useVoicePlaybackEngine(): PlaybackEngine {
+  const ctx = useContext(VoicePlaybackContext);
+  if (!ctx) {
+    throw new Error("useVoicePlayback must be used within a VoicePlaybackProvider");
+  }
+  return ctx;
+}
+
+/** Wraps the transcript. `active` false (a hidden ChatPanel) pauses playback. */
+export function VoicePlaybackProvider({
+  active,
+  children,
+}: {
+  active: boolean;
+  children: ReactNode;
+}) {
+  const audioRef = useRef<HTMLAudioElement | null>(null);
+  const urlCacheRef = useRef<Map<string, string>>(new Map());
+  const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
+  const [playing, setPlaying] = useState(false);
+  const [currentMs, setCurrentMs] = useState(0);
+  const [speedIdx, setSpeedIdx] = useState(0);
+
+  const toggle = useCallback(
+    (noteId: string) => {
+      const a = audioRef.current;
+      if (!a) return;
+
+      if (noteId === activeNoteId && playing) {
+        a.pause();
+        return;
+      }
+      if (noteId === activeNoteId && !playing) {
+        void a.play().catch(() => {
+          /* autoplay block — ignore */
+        });
+        return;
+      }
+
+      // A different note (or none active): pause whatever is playing, fetch +
+      // cache the clip, and play it. Starting one note stops the other.
+      a.pause();
+      void (async () => {
+        let url = urlCacheRef.current.get(noteId);
+        if (!url) {
+          try {
+            const blob = await window.api.voiceFetchNote(noteId);
+            url = URL.createObjectURL(blob);
+            urlCacheRef.current.set(noteId, url);
+          } catch {
+            // Audio swept/expired between the list and the tap — leave it
+            // silent rather than throwing.
+            return;
+          }
+        }
+        a.src = url;
+        setActiveNoteId(noteId);
+        setCurrentMs(0);
+        a.playbackRate = SPEEDS[speedIdx];
+        void a.play().catch(() => {
+          /* autoplay block — ignore */
+        });
+      })();
+    },
+    [activeNoteId, playing, speedIdx],
+  );
+
+  const cycleSpeed = useCallback(() => {
+    const next = (speedIdx + 1) % SPEEDS.length;
+    setSpeedIdx(next);
+    if (audioRef.current) audioRef.current.playbackRate = SPEEDS[next];
+  }, [speedIdx]);
+
+  // Hidden panels (ChatPanels for other sessions stay mounted) must not keep
+  // playing.
+  useEffect(() => {
+    if (!active) audioRef.current?.pause();
+  }, [active]);
+
+  // Unmount cleanup: stop and free every cached object URL.
+  useEffect(() => {
+    return () => {
+      audioRef.current?.pause();
+      for (const url of urlCacheRef.current.values()) URL.revokeObjectURL(url);
+      urlCacheRef.current.clear();
+    };
+  }, []);
+
+  const value = useMemo<PlaybackEngine>(
+    () => ({ activeNoteId, playing, currentMs, speedIdx, toggle, cycleSpeed }),
+    [activeNoteId, playing, currentMs, speedIdx, toggle, cycleSpeed],
+  );
+
+  return (
+    <VoicePlaybackContext.Provider value={value}>
+      {children}
+      <audio
+        ref={audioRef}
+        onTimeUpdate={(e) => setCurrentMs(Math.round(e.currentTarget.currentTime * 1000))}
+        onPlay={() => setPlaying(true)}
+        onPause={() => setPlaying(false)}
+        onEnded={() => setPlaying(false)}
+        onLoadedMetadata={() => setCurrentMs(0)}
+      />
+    </VoicePlaybackContext.Provider>
+  );
+}
+
+/**
+ * Playback state for ONE note. Returns idle values (playing false, currentMs
+ * 0) whenever this note is not the active one, so an inactive row shows its
+ * total duration and a Play glyph with no extra bookkeeping in the row.
+ */
+export function useVoicePlayback(noteId: string): {
+  playing: boolean;
+  currentMs: number;
+  speed: number;
+  toggle: () => void;
+  cycleSpeed: () => void;
+} {
+  const engine = useVoicePlaybackEngine();
+  const isActive = engine.activeNoteId === noteId;
+  return {
+    playing: isActive && engine.playing,
+    currentMs: isActive ? engine.currentMs : 0,
+    speed: SPEEDS[engine.speedIdx],
+    toggle: () => engine.toggle(noteId),
+    cycleSpeed: engine.cycleSpeed,
+  };
+}


### PR DESCRIPTION
**Files changed:** `5` files. `src/renderer/ChatPanel.tsx` (+provider wrap), `src/renderer/VoiceNote.tsx` (VoicePlayer slimmed to a consumer + header note), `src/renderer/hooks/useVoicePlayback.tsx` (+new engine), `src/renderer/hooks/useVoicePlayback.test.tsx` (+new), `src/renderer/VoiceNote.test.tsx` (wrap regression guard in provider).

**What / why:** The `<audio>` used to live inside each transcript row, but the transcript is virtualised (Virtuoso destroys rows that scroll out of view), so playback died on scroll, several notes could overlap, and the clip was re-downloaded per row remount. VoicePlayer is now a pure consumer of a conversation-wide `VoicePlaybackProvider` engine (one `<audio>`, one active note, a blob-URL cache) wrapping `<Transcript>`.

**Verification results:**
- PR branch (`multica/BET-881-lift-audio-engine` @ `2588b3a`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0, vitest 2635 pass (140 files) + node:test 1980 pass / 0 fail. Failures: none. log sha256: `88feac4ad7949d0ffd9ba20edd571144a7e55be33b02ed3047f72487d1229262`
- Base (`main` @ `06672a90`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0, vitest 2630 pass (139 files) + node:test 1980 pass / 0 fail. Failures: none. log sha256: `95beacc959fd9a69a3d7db74d881c28978a90a6b0d06c134e81c780904c04f4c`
- **Conclusion:** 0 new failures. PR adds 1 test file + 5 tests (engine coverage); nothing regressed.

**Base: origin/main @ `06672a90`**

Out-of-scope respected: no visual change (`VoicePlayerFrame` untouched), no click-to-seek / now-playing bar / shortcuts / media-session, no hoist above ChatPanel, no playback persistence, no subscription store / context optimization (per locked decision).
