### PR TITLE
feat(forge): record originating issue on session so Closes #N works (BET-871)

### DIFF
--- a/src/renderer/InboxPalette.tsx
+++ b/src/renderer/InboxPalette.tsx
@@ -176,6 +176,10 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
         windowName: "default",
         chatMode: true,
         createDir: false,
+        // BET-871: only ISSUE items carry the originating issue onto the
+        // session's `@manta-forge-issue` stamp — a PR is not something a PR
+        // closes. Omitted entirely (not null) so the box skips the stamp.
+        ...(item.kind !== "pr" ? { forgeIssue: { repoKey: item.repoKey, number: item.number } } : {}),
       });
       applyProjects(Array.isArray(created) ? created : created.projects);
       const proj = useStore.getState().projects.find((p) => p.tmuxSession === name);

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -804,7 +804,11 @@ export async function shipPreview(cwd, deps = {}) {
   }
 
   const title = await draftTitle(cwd, ctx.head, deps);
-  const body = await draftBody(cwd, ctx.head, base, files, deps);
+  const body = await draftBody(cwd, ctx.head, base, files, {
+    ...deps,
+    linkedIssue: deps.linkedIssue ?? null,
+    prRepoKey: forgeRepoKey(ctx.forge),
+  });
   return { ok: true, head: ctx.head, base, fileCount: files.length, title, body };
 }
 
@@ -849,19 +853,39 @@ export function humanizeBranch(branch) {
   return cleaned.charAt(0).toUpperCase() + cleaned.slice(1);
 }
 
+// `repoKey` is "host/owner/repo" (e.g. "github.com/antoinedc/MantaUI"); a forge
+// close-reference is "owner/repo#N", or bare "#N" when the issue lives in the
+// same repo as the pull request. Pure + exported for tests.
+export function issueCloseRef(issue, prRepoKey) {
+  if (!issue?.repoKey || !Number.isInteger(issue.number)) return "";
+  if (issue.repoKey === prRepoKey) return `#${issue.number}`;
+  const [, owner, repo] = String(issue.repoKey).split("/");
+  return owner && repo ? `${owner}/${repo}#${issue.number}` : "";
+}
+
 // Body draft: the repo's PR template when one exists (honouring step-1's
 // "honouring the repo's PR template"), else a short changed-files summary.
-// Template `${head}` / `${base}` placeholders, if present, are filled.
+// Template `${head}` / `${base}` placeholders, if present, are filled. When
+// `deps.linkedIssue` (an async fn returning `{ repoKey, number } | null`)
+// resolves a ref, ONE "Closes <ref>" line plus a blank line is prepended to
+// whichever body branch runs — `deps.prRepoKey` decides the bare/suffixed ref.
+// With no ref (or no dep) the output is byte-identical to today.
 async function draftBody(cwd, head, base, files, deps) {
   const readPrTemplate = deps.readPrTemplate ?? defaultReadPrTemplate;
+  let issueRef = "";
+  if (deps.linkedIssue) {
+    const issue = await deps.linkedIssue();
+    issueRef = issueCloseRef(issue, deps.prRepoKey);
+  }
+  const preamble = issueRef ? `Closes ${issueRef}\n\n` : "";
   const template = await readPrTemplate(cwd, deps);
   if (template && template.trim()) {
-    return template
+    return preamble + template
       .replace(/\$\{head\}/g, head || "")
       .replace(/\$\{base\}/g, base || "");
   }
-  if (files.length === 0) return "";
-  return `## What\n\nOpens ${head} → ${base}.\n\n## Changed files\n\n${files.map((f) => `- ${f}`).join("\n")}`;
+  if (files.length === 0) return preamble;
+  return preamble + `## What\n\nOpens ${head} → ${base}.\n\n## Changed files\n\n${files.map((f) => `- ${f}`).join("\n")}`;
 }
 
 // Find + read the repo's PR template, best-first from the candidates list.

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -14,6 +14,7 @@ import {
   forgeDiffForCwd,
   shipPullRequest,
   shipPreview,
+  issueCloseRef,
   humanizeBranch,
   mergePullRequest,
   draftGetForCwd,
@@ -466,6 +467,51 @@ test("shipPreview with no linkedIssue dep leaves the body unchanged from today",
   assert.equal(r.ok, true);
   assert.match(r.body, /^## Summary/);
   assert.ok(!r.body.includes("Closes"), "no linkedIssue dep ⇒ no Closes line");
+});
+
+// ---- issueCloseRef + the linked-issue PR body seed (BET-871) ----------------
+
+test("issueCloseRef: bare #N when the issue lives in the PR's own repo", () => {
+  assert.equal(issueCloseRef({ repoKey: "github.com/acme/widget", number: 12 }, "github.com/acme/widget"), "#12");
+});
+
+test("issueCloseRef: owner/repo#N for a cross-repo issue", () => {
+  assert.equal(issueCloseRef({ repoKey: "github.com/acme/something", number: 12 }, "github.com/acme/widget"), "acme/something#12");
+});
+
+test("issueCloseRef: \"\" for malformed or missing refs", () => {
+  assert.equal(issueCloseRef(null, "github.com/acme/widget"), "");
+  assert.equal(issueCloseRef(undefined, "github.com/acme/widget"), "");
+  assert.equal(issueCloseRef({}, "github.com/acme/widget"), "");
+  assert.equal(issueCloseRef({ repoKey: "x", number: 12 }, "github.com/acme/widget"), "");
+  assert.equal(issueCloseRef({ repoKey: "github.com/acme/widget" }, "github.com/acme/widget"), "");
+});
+
+test("shipPreview prepends Closes #N before the template when the session has a linked issue", async () => {
+  const r = await shipPreview("/repo", linkedShipDeps({
+    readPrTemplate: async () => "## Summary\n\n${head} → ${base}\n\n## Checklist\n- [x] tests",
+    linkedIssue: async () => ({ repoKey: "github.com/acme/widget", number: 12 }),
+  }));
+  assert.equal(r.ok, true);
+  assert.match(r.body, /^Closes #12\n\n## Summary/, "close line + blank line precede the template");
+});
+
+test("shipPreview uses a cross-repo owner/repo#N close ref", async () => {
+  const r = await shipPreview("/repo", linkedShipDeps({
+    readPrTemplate: async () => "## Summary\n\nbody",
+    linkedIssue: async () => ({ repoKey: "github.com/acme/something", number: 12 }),
+  }));
+  assert.equal(r.ok, true);
+  assert.match(r.body, /^Closes acme\/something#12\n\n## Summary/);
+});
+
+test("shipPreview with a linked issue and no template still emits the close line", async () => {
+  const r = await shipPreview("/repo", linkedShipDeps({
+    readPrTemplate: async () => null,
+    linkedIssue: async () => ({ repoKey: "github.com/acme/widget", number: 7 }),
+  }));
+  assert.equal(r.ok, true);
+  assert.match(r.body, /^Closes #7\n\n/);
 });
 
 

--- a/src/server/forgeRules.mjs
+++ b/src/server/forgeRules.mjs
@@ -54,6 +54,36 @@ export function parseRepoKey(key) {
   };
 }
 
+// BET-871: canonical issue reference for the session-scoped "originating
+// issue" carrier — `repoKey#number` (e.g. "github.com/acme/widget#412"),
+// stored as the `@manta-forge-issue` tmux window user-option. The number is
+// the only digits-after-# token; a repoKey contains no "#". `repoKey` is
+// validated with parseRepoKey (so a malformed key is never written), and the
+// number must be a positive integer. Both directions are pure + exported for
+// tests; format returns null for invalid input, so a bad ref never reaches
+// storage (the caller simply skips the stamp). Inverse of formatIssueRef.
+export function formatIssueRef({ repoKey, number }) {
+  if (!parseRepoKey(repoKey)) return null;
+  if (!Number.isInteger(number) || number <= 0) return null;
+  return `${repoKey}#${number}`;
+}
+
+// Split a canonical "repoKey#number" ref back into its parts, or null when it
+// is malformed — a missing/empty repo key, a repoKey parseRepoKey rejects, or
+// a non-integer / non-positive number. Round-trips with formatIssueRef.
+export function parseIssueRef(ref) {
+  if (typeof ref !== "string") return null;
+  const idx = ref.lastIndexOf("#");
+  if (idx < 1) return null;
+  const repoKey = ref.slice(0, idx);
+  const numberStr = ref.slice(idx + 1);
+  if (!parseRepoKey(repoKey)) return null;
+  if (!/^[0-9]+$/.test(numberStr)) return null;
+  const number = Number(numberStr);
+  if (!Number.isInteger(number) || number <= 0) return null;
+  return { repoKey, number };
+}
+
 // The on-disk rules file path for a repo identity, after path-component
 // validation. Returns {ok:true, path} or {ok:false, error}. The owner may be a
 // GitLab subgroup path; each component is validated by validateForgeRepoPath

--- a/src/server/forgeRules.test.mjs
+++ b/src/server/forgeRules.test.mjs
@@ -9,7 +9,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { saveRules } from "./forgeRules.mjs";
+import { saveRules, formatIssueRef, parseIssueRef } from "./forgeRules.mjs";
 
 const VALID_YAML = "on:\n  issue.labeled:\n    do: notify\n";
 const PUBLIC_BASE = "https://00000000000000000000000000000000.boxes.mantaui.com";
@@ -117,4 +117,60 @@ test("saveRules requires a public hostname before registration", async () => {
   assert.equal(res.webhook.registered, false);
   assert.match(res.webhook.error, /no public hostname/);
   assert.equal(ensureCalled, false);
+});
+
+// ---- formatIssueRef / parseIssueRef (BET-871) -------------------------------
+
+test("formatIssueRef / parseIssueRef round-trip a canonical ref", () => {
+  const ref = formatIssueRef({ repoKey: "github.com/acme/widget", number: 412 });
+  assert.equal(ref, "github.com/acme/widget#412");
+  assert.deepEqual(parseIssueRef(ref), { repoKey: "github.com/acme/widget", number: 412 });
+});
+
+test("formatIssueRef/parseIssueRef round-trip a GitLab subgroup owner", () => {
+  const ref = formatIssueRef({ repoKey: "gitlab.com/group/subgroup/widget", number: 7 });
+  assert.equal(ref, "gitlab.com/group/subgroup/widget#7");
+  assert.deepEqual(parseIssueRef(ref), {
+    repoKey: "gitlab.com/group/subgroup/widget",
+    number: 7,
+  });
+});
+
+test("formatIssueRef returns null for a repoKey parseRepoKey rejects", () => {
+  assert.equal(formatIssueRef({ repoKey: "acme/widget", number: 1 }), null); // 2 parts
+  assert.equal(formatIssueRef({ repoKey: "not a key", number: 1 }), null);
+  assert.equal(formatIssueRef({ repoKey: "", number: 1 }), null);
+  assert.equal(formatIssueRef({ repoKey: null, number: 1 }), null);
+});
+
+test("formatIssueRef returns null for a non-integer or non-positive number", () => {
+  assert.equal(formatIssueRef({ repoKey: "github.com/acme/widget", number: 0 }), null);
+  assert.equal(formatIssueRef({ repoKey: "github.com/acme/widget", number: -3 }), null);
+  assert.equal(formatIssueRef({ repoKey: "github.com/acme/widget", number: 1.5 }), null);
+  assert.equal(formatIssueRef({ repoKey: "github.com/acme/widget", number: "12" }), null);
+  assert.equal(formatIssueRef({ repoKey: "github.com/acme/widget", number: NaN }), null);
+});
+
+test("parseIssueRef returns null for a malformed string", () => {
+  assert.equal(parseIssueRef(null), null);
+  assert.equal(parseIssueRef(undefined), null);
+  assert.equal(parseIssueRef(42), null);
+  assert.equal(parseIssueRef(""), null);
+  assert.equal(parseIssueRef("github.com/acme/widget"), null); // no #
+  assert.equal(parseIssueRef("#12"), null); // empty repoKey
+  assert.equal(parseIssueRef("github.com/acme/widget#"), null); // empty number
+});
+
+test("parseIssueRef rejects a non-integer or non-positive number", () => {
+  assert.equal(parseIssueRef("github.com/acme/widget#0"), null);
+  assert.equal(parseIssueRef("github.com/acme/widget#-1"), null);
+  assert.equal(parseIssueRef("github.com/acme/widget#1.5"), null);
+  assert.equal(parseIssueRef("github.com/acme/widget#abc"), null);
+  assert.equal(parseIssueRef("github.com/acme/widget#1_2"), null);
+});
+
+test("parseIssueRef rejects a repoKey parseRepoKey does not accept", () => {
+  assert.equal(parseIssueRef("acme/widget#12"), null); // 2 parts
+  assert.equal(parseIssueRef("github.com/acme#12"), null); // 2 parts
+  assert.equal(parseIssueRef("/acme/widget#12"), null); // empty leading segment
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -30,7 +30,7 @@ import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import { searchMessages } from "./messageSearch.mjs";
 import { MIN_CLIENT } from "./version.mjs";
 import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, replyThreadForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
-import { listRules as forgeListRules } from "./forgeRules.mjs";
+import { listRules as forgeListRules, formatIssueRef, parseIssueRef } from "./forgeRules.mjs";
 import { invalidateToken as invalidateForgeToken } from "./forge/auth.mjs";
 import { parseRules as parseForgeRules } from "../shared/forgeRules.mjs";
 
@@ -369,8 +369,25 @@ export function buildHandlers({
       );
       return res;
     },
-    "forge:ship-preview": (input) =>
-      shipPreview(typeof input === "object" && input !== null ? input.cwd : ""),
+    "forge:ship-preview": async (input) => {
+      const cwd = typeof input === "object" && input !== null ? input.cwd : "";
+      // Seed the PR body with a "Closes #N" line from the originating issue
+      // (BET-871): resolve the session's window from the shipping cwd and read
+      // the `@manta-forge-issue` user-option the inbox's Start-a-session flow
+      // stamped. parseIssueRef returns null for a missing/malformed option, so
+      // a session started any other way (or from an inbox PR) keeps today's
+      // byte-identical body. No second session-link store — the tmux window IS
+      // the app session.
+      return shipPreview(cwd, {
+        linkedIssue: async () => {
+          if (!cwd) return null;
+          const win = await tmux.findWindowForCwd(cwd);
+          if (!win) return null;
+          const raw = await tmux.getWindowOption(win.sessionName, win.windowIndex, "@manta-forge-issue");
+          return raw ? parseIssueRef(raw) : null;
+        },
+      });
+    },
     "forge:merge": (input) =>
       mergePullRequest(
         typeof input === "object" && input !== null ? input.cwd : "",
@@ -516,7 +533,14 @@ export function buildHandlers({
     // issue is about.
     "tmux:new-session": async (i) => {
       const cwd = await resolveProjectCwd(i.name, i.cwd);
-      const result = await tmux.newSession({ ...i, cwd, oc });
+      // BET-871: the inbox's "Start a session" flow passes the originating
+      // issue ({ repoKey, number }) for issue-kind items. Format it to the
+      // canonical "repoKey#number" ref the newSession stamp carries — done
+      // server-side so the format logic lives in one tested place, never in
+      // the renderer. formatIssueRef returns null for invalid input, which
+      // simply skips the stamp.
+      const forgeIssueRef = i?.forgeIssue ? formatIssueRef(i.forgeIssue) : null;
+      const result = await tmux.newSession({ ...i, cwd, oc, forgeIssueRef });
       await local
         .projectMetaUpsert({
           tmuxSession: i.name,

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -443,7 +443,7 @@ export async function newWindowGetIndex(sessionName, windowName, cwd, chatMode =
 // @param {boolean} [input.chatMode]    create an opencode chat-mode window
 // @param {object} [input.oc]           opencode client (required when chatMode)
 // @param {Array} [input.permission]    opencode permission ruleset (chatMode jobs)
-export async function newSession({ name, cwd, windowName, createDir, chatMode, existingSessionId, oc, permission }) {
+export async function newSession({ name, cwd, windowName, createDir, chatMode, existingSessionId, oc, permission, forgeIssueRef }) {
   // Onboarding's first-project step opts into auto-creation via createDir: a
   // missing ~/projects/<name> should be created, not silently swallowed. tmux
   // new-session -c falls back to $HOME for a non-existent dir, so the mkdir -p
@@ -469,6 +469,12 @@ export async function newSession({ name, cwd, windowName, createDir, chatMode, e
   const idx = await newSessionGetIndex(name, dir, windowName, !!chatMode);
   await applySessionSurvivability(name);
   if (sid) await restampSessionId(name, idx, sid);
+  // BET-871: stamp the originating inbox issue on `@manta-forge-issue` right
+  // after `@manta-session-id`, when the session was started from an inbox
+  // issue. `forgeIssueRef` is the canonical "repoKey#number" string, already
+  // formatted by the caller (formatIssueRef in forgeRules.mjs); null skips the
+  // stamp. Issue-only by construction — the inbox never sets it for PR items.
+  if (forgeIssueRef) await setWindowOption(name, idx, "@manta-forge-issue", forgeIssueRef);
   // BET-348: record ownership AFTER tmux accepted the new-session. If
   // anything above threw, we never get here — and we'd rather fail loud
   // than stamp a phantom entry. The next listProjects() will reconcile
@@ -551,6 +557,49 @@ export async function selectWindow({ sessionName, windowIndex }) {
 }
 
 /**
+ * Set a user-option on a tmux window. The ONE write path every manta
+ * window-option stamp goes through — `@manta-session-id`,
+ * `@manta-worktree-path`, `@manta-forge-issue`. Do not add a second
+ * `tmux set-window-option` wrapper; extend this.
+ *
+ * @param {string} sessionName
+ * @param {number} windowIndex
+ * @param {string} name   option name (e.g. "@manta-session-id")
+ * @param {string} value  stored as-is
+ */
+export async function setWindowOption(sessionName, windowIndex, name, value) {
+  await run("tmux", [
+    "set-window-option",
+    "-t", `${sessionName}:${windowIndex}`,
+    name, value,
+  ]);
+}
+
+/**
+ * Read a window user-option value, or null when the window has none set. The
+ * ONE read path that pairs with setWindowOption — a single option is queried
+ * with `show-window-options -v`, which prints only the value and errors when
+ * the option is unset (→ null).
+ *
+ * @param {string} sessionName
+ * @param {number} windowIndex
+ * @param {string} name   option name (e.g. "@manta-forge-issue")
+ * @returns {Promise<string|null>}
+ */
+export async function getWindowOption(sessionName, windowIndex, name) {
+  try {
+    const { stdout } = await run("tmux", [
+      "show-window-options",
+      "-t", `${sessionName}:${windowIndex}`,
+      "-v", name,
+    ]);
+    return String(stdout ?? "").trim() || null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Stamp (or update) the @manta-session-id user-option on a tmux window.
  * This is how the renderer knows a window is a chat-mode window and which
  * opencode session it belongs to.
@@ -560,28 +609,45 @@ export async function selectWindow({ sessionName, windowIndex }) {
  * @param {string} sessionId   opencode session id (e.g. "ses_...")
  */
 export async function restampSessionId(sessionName, windowIndex, sessionId) {
-  await run("tmux", [
-    "set-window-option",
-    "-t", `${sessionName}:${windowIndex}`,
-    "@manta-session-id", sessionId,
-  ]);
+  await setWindowOption(sessionName, windowIndex, "@manta-session-id", sessionId);
 }
 
 /**
  * Stamp (or update) the @manta-worktree-path user-option on a tmux window.
  * Used by BET-246's clean-on-close to know which windows own a worktree
  * that manta created (vs. pre-existing worktrees, which must NEVER be
- * removed). Mirrors restampSessionId verbatim — separate option name so
- * the two stamps never collide.
+ * removed). Separate option name so the two stamps never collide.
  *
  * @param {string} sessionName
  * @param {number} windowIndex
  * @param {string} path   absolute worktree path
  */
 export async function stampWorktreePath(sessionName, windowIndex, path) {
-  await run("tmux", [
-    "set-window-option",
-    "-t", `${sessionName}:${windowIndex}`,
-    "@manta-worktree-path", path,
+  await setWindowOption(sessionName, windowIndex, "@manta-worktree-path", path);
+}
+
+/**
+ * Find the (sessionName, windowIndex) whose pane is rooted at `cwd`, or null
+ * when no window matches. BET-871's read-point: forge:ship-preview resolves
+ * the session's window from the shipping cwd so it can read the originating
+ * issue off `@manta-forge-issue`. `cwd` is expanded (`~`) and matched against
+ * `pane_current_path` exactly — the session was created in that same resolved
+ * dir.
+ *
+ * @param {string} cwd
+ * @returns {Promise<{ sessionName: string, windowIndex: number } | null>}
+ */
+export async function findWindowForCwd(cwd) {
+  const dir = expandTilde(cwd ?? "");
+  if (!dir) return null;
+  const stdout = await tmuxListOutput([
+    "list-windows", "-a",
+    "-F", `#{session_name}${FS}#{window_index}${FS}#{pane_current_path}`,
   ]);
+  for (const line of String(stdout ?? "").split("\n").filter(Boolean)) {
+    const [sessionName, windowIndex, pane] = line.split(FS);
+    if (!sessionName || !windowIndex) continue;
+    if (pane === dir) return { sessionName, windowIndex: Number(windowIndex) };
+  }
+  return null;
 }

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -20,6 +20,9 @@ import {
   addOwnedSession,
   removeOwnedSession,
   listProjects,
+  setWindowOption,
+  getWindowOption,
+  findWindowForCwd,
   killSession,
   renameSession,
   _resetOwnedSessionsCache,
@@ -842,4 +845,130 @@ test("run waits for stdout to close, not just for the child to exit", async () =
     "{ sleep 0.2; printf late-bytes; } & exit 0",
   ]);
   assert.equal(stdout, "late-bytes", "stdout must not be lost when the child exits early");
+});
+
+// ---- setWindowOption / getWindowOption (BET-871) ---------------------------
+// The ONE write path for every manta window-option stamp and its paired read.
+// A fake tmux holds options in a map so set-then-get round-trips.
+
+test("setWindowOption issues the single set-window-option command", async () => {
+  const cmds = installFakeTmux();
+  try {
+    await setWindowOption("proj", 2, "@manta-forge-issue", "github.com/acme/widget#412");
+  } finally {
+    _setRun(null);
+  }
+  const cmd = cmds.find((c) => c.args.includes("set-window-option"));
+  assert.ok(cmd, "set-window-option issued");
+  assert.deepEqual(cmd.args, [
+    "set-window-option", "-t", "proj:2", "@manta-forge-issue", "github.com/acme/widget#412",
+  ]);
+});
+
+test("getWindowOption returns the stored value via show-window-options -v", async () => {
+  let queried = null;
+  _setRun(async (_cmd, args) => {
+    if (args.includes("show-window-options")) {
+      queried = args;
+      return { stdout: "github.com/acme/widget#412", stderr: "" };
+    }
+    return { stdout: "", stderr: "" };
+  });
+  try {
+    const v = await getWindowOption("proj", 2, "@manta-forge-issue");
+    assert.equal(v, "github.com/acme/widget#412", "value is the raw -v output, trimmed");
+  } finally {
+    _setRun(null);
+  }
+  assert.ok(queried, "show-window-options issued");
+});
+
+test("getWindowOption returns null when the option is unset (tmux errors)", async () => {
+  _setRun(async () => { throw new Error("unknown option: @manta-forge-issue"); });
+  try {
+    assert.equal(await getWindowOption("proj", 2, "@manta-forge-issue"), null);
+  } finally {
+    _setRun(null);
+  }
+});
+
+test("getWindowOption returns null for empty output", async () => {
+  _setRun(async () => ({ stdout: "", stderr: "" }));
+  try {
+    assert.equal(await getWindowOption("proj", 2, "@manta-forge-issue"), null);
+  } finally {
+    _setRun(null);
+  }
+});
+
+// ---- findWindowForCwd (BET-871) --------------------------------------------
+test("findWindowForCwd resolves a window by its pane_current_path", async () => {
+  _setRun(async (_cmd, args) => {
+    if (args.includes("list-windows")) {
+      return {
+        stdout:
+          "alpha\t1\t/home/u/other\n" +
+          "beta\t3\t/home/u/worktree",
+        stderr: "",
+      };
+    }
+    return { stdout: "", stderr: "" };
+  });
+  try {
+    assert.deepEqual(await findWindowForCwd("/home/u/worktree"), { sessionName: "beta", windowIndex: 3 });
+    assert.deepEqual(await findWindowForCwd("/home/u/missing"), null);
+    assert.deepEqual(await findWindowForCwd(""), null);
+  } finally {
+    _setRun(null);
+  }
+});
+
+// ---- newSession + forgeIssueRef (BET-871) ----------------------------------
+test("newSession stamps @manta-forge-issue after @manta-session-id when given a ref", async () => {
+  const cmds = installFakeTmux();
+  const oc = fakeOc("ses_sess1");
+  const cwd = await mkdtemp(join(tmpdir(), "tmux-ns-forge-"));
+  try {
+    await newSession({
+      name: "newproj",
+      cwd,
+      windowName: "default",
+      chatMode: true,
+      oc,
+      forgeIssueRef: "github.com/acme/widget#412",
+    });
+  } finally {
+    _setRun(null);
+    await rm(cwd, { recursive: true, force: true });
+  }
+  const stamps = cmds.filter((c) => c.args.includes("set-window-option"));
+  assert.equal(stamps.length, 2, "session-id + forge-issue stamps issued");
+  const sid = stamps.find((c) => c.args.includes("@manta-session-id"));
+  const forge = stamps.find((c) => c.args.includes("@manta-forge-issue"));
+  assert.ok(sid, "@manta-session-id stamped");
+  assert.ok(sid.args.includes("ses_sess1"), "session-id stamp carries the opencode id");
+  assert.ok(forge, "@manta-forge-issue stamped");
+  assert.ok(forge.args.includes("github.com/acme/widget#412"), "forge stamp carries the issue ref");
+});
+
+test("newSession without forgeIssueRef stamps only @manta-session-id", async () => {
+  const cmds = installFakeTmux();
+  const oc = fakeOc("ses_sess1");
+  const cwd = await mkdtemp(join(tmpdir(), "tmux-ns-noforge-"));
+  try {
+    await newSession({
+      name: "newproj",
+      cwd,
+      windowName: "default",
+      chatMode: true,
+      oc,
+    });
+  } finally {
+    _setRun(null);
+    await rm(cwd, { recursive: true, force: true });
+  }
+  const stamps = cmds.filter((c) => c.args.includes("set-window-option"));
+  assert.equal(stamps.length, 1, "only the session-id stamp is issued");
+  assert.ok(stamps[0].args.includes("@manta-session-id"));
+  assert.ok(!stamps.some((c) => c.args.includes("@manta-forge-issue")), "no forge-issue stamp");
 });

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -156,6 +156,11 @@ export interface Api {
     // by the draft flow) instead of creating a new one, and stamp it on the
     // new tmux window.
     existingSessionId?: string;
+    // BET-871: when the session is started from an inbox ISSUE, the box stamps
+    // the originating issue on the `@manta-forge-issue` window option so
+    // shipping a PR from it carries a "Closes #N" line. Omitted for PR-kind
+    // items and any other session start — no stamp.
+    forgeIssue?: { repoKey: string; number: number };
   }): Promise<TmuxCreateResult>;
   tmuxNewWindow(input: {
     sessionName: string;


### PR DESCRIPTION
Fixes the never-once-fired `Closes #N` seeding (BET-827). The originating inbox issue is now recorded on a genuinely **session-scoped** carrier — the `@manta-forge-issue` tmux window user-option — replacing the deleted workspace-scoped `ProjectMeta.link` (BET-870). No new store, no new RPC channel.

## What changed
- `src/server/forgeRules.mjs`: `formatIssueRef` / `parseIssueRef` — canonical `repoKey#N` pair, colocated with `parseRepoKey`, pure + tested.
- `src/server/tmux.mjs`: generalized the window-option write path into `setWindowOption` (the ONE `set-window-option` wrapper) and migrated `@manta-session-id` + `@manta-worktree-path` to it; added `getWindowOption` (paired read) and `findWindowForCwd`; `newSession` stamps `@manta-forge-issue` after `@manta-session-id` when a ref is supplied.
- `src/server/rpc.mjs`: `tmux:new-session` formats `forgeIssue` → ref (server-side, no renderer format copy); `forge:ship-preview` resolves the session's window from the cwd, reads the option, and seeds `linkedIssue`.
- `src/server/forge/index.mjs`: restored BET-827's `issueCloseRef` + `draftBody` `Closes` preamble from git history (the read-point's seeding branch).
- `src/renderer/InboxPalette.tsx`: passes `forgeIssue` for `item.kind !== "pr"` (issue-only) via the existing `tmuxNewSession` path.
- `src/shared/api.ts`: `tmuxNewSession` input gains optional `forgeIssue`.

## What I removed
- The duplicate window-option `set-window-option` wrappers: `restampSessionId` and `stampWorktreePath` were both hand-rolled `run("tmux", ["set-window-option", ...])` calls; both now call the single generalized `setWindowOption`. Clean net: one write path instead of three. No second `set-window-option` wrapper was added (explicitly required by the issue).

## Design notes
- Session-scoped by construction: a tmux window IS an app session — the option dies with the window, so the link is never stale. Loss on reboot is expected; no persistence added.
- Issue-only: PR-kind inbox items never set `forgeIssue` (a PR is not something a PR closes). Background/delegate jobs are untouched (their job record carries its own link).
- No UI, no INBOX_SEED_PROMPT change, no `mobile/native` (Swift).

**Base:** `origin/main` @ `13c1ffa9`

**Files changed:** 9 files. `+406 −22`.

**Verification results:**
- PR branch (`multica/BET-871-record-originating-issue` @ `aca5049`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0, 1988 pass / 0 fail / 0 skip. Failures: none. log sha256: `914790cf5cb21996a692c6f031f1944d7ec46cea3a2e0d7d787df6d1b9e2e749`
- Base (`main` @ `13c1ffa9`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0, 1968 pass / 0 fail / 0 skip. Failures: none. log sha256: `9e14898d74fc3e802c3a2c98f6a6d6410215f1817f11b27cbdb48438ce6e13d0`
- **Conclusion:** 0 new test failures; the +20 tests on the PR branch are this PR's new cases (forgeRules refs, tmux option helpers, shipPreview linked-issue). Typecheck identical and clean on both branches.
