### PR TITLE
fix(renderer): remove dead CSS containment rule that broke session-header dialogs (BET-884)

### DIFF
--- a/src/renderer/Modal.test.tsx
+++ b/src/renderer/Modal.test.tsx
@@ -18,7 +18,7 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { readFileSync } from "node:fs";
-import { fileURLToPath } from "node:url";
+import { resolve } from "node:path";
 import { act } from "react";
 import { mount, type Harness } from "./testHarness";
 import { Modal } from "./Modal";
@@ -267,13 +267,12 @@ describe("Modal — Escape + focus trap + restore (BET-724)", () => {
 // from disk so the rule fires even if a sheet is no longer imported
 // anywhere. Mirrors the source-reading style of primitives.test.ts.
 describe("no CSS containment in renderer stylesheets (BET-884)", () => {
-  const RENDERER = fileURLToPath(new URL(".", import.meta.url));
-  const SHEETS = ["index.css", "tokens.css"];
+  const SHEETS = [resolve("src/renderer", "index.css"), resolve("src/renderer", "tokens.css")];
   const CONT_CONTAINMENT = /(?:container-type\s*:|container\s*:|contain\s*:)/;
 
   for (const file of SHEETS) {
     it(`${file} has no containment declaration`, () => {
-      const css = readFileSync(new URL(file, RENDERER), "utf8");
+      const css = readFileSync(file, "utf8");
       const offenders = css
         .split("\n")
         .map((line, i) => ({ line: line.trim(), n: i + 1 }))

--- a/src/renderer/Modal.test.tsx
+++ b/src/renderer/Modal.test.tsx
@@ -17,6 +17,8 @@
 // clean.
 
 import { describe, it, expect, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
 import { act } from "react";
 import { mount, type Harness } from "./testHarness";
 import { Modal } from "./Modal";
@@ -253,4 +255,38 @@ describe("Modal — Escape + focus trap + restore (BET-724)", () => {
     expect(document.activeElement).toBe(opener);
     opener.remove();
   });
+});
+
+// BET-884: no stylesheet under src/renderer may declare CSS containment.
+// `container-type: inline-size` (and any `container:` / `contain:`) applies
+// layout containment, which makes the element the containing block for every
+// `position: fixed` descendant AND traps its z-index in a new stacking
+// context — silently breaking every dialog rendered beneath it (the
+// session-header confirm dialogs were rendered inside the 44px header, their
+// panels clipped above the window and their buttons dead). Files are read
+// from disk so the rule fires even if a sheet is no longer imported
+// anywhere. Mirrors the source-reading style of primitives.test.ts.
+describe("no CSS containment in renderer stylesheets (BET-884)", () => {
+  const RENDERER = fileURLToPath(new URL(".", import.meta.url));
+  const SHEETS = ["index.css", "tokens.css"];
+  const CONT_CONTAINMENT = /(?:container-type\s*:|container\s*:|contain\s*:)/;
+
+  for (const file of SHEETS) {
+    it(`${file} has no containment declaration`, () => {
+      const css = readFileSync(new URL(file, RENDERER), "utf8");
+      const offenders = css
+        .split("\n")
+        .map((line, i) => ({ line: line.trim(), n: i + 1 }))
+        .filter(({ line }) => CONT_CONTAINMENT.test(line))
+        .map((o) => `${o.n}: ${o.line}`);
+      expect(
+        offenders,
+        `${file} must not declare CSS containment — containment makes an ` +
+          `element the containing block / stacking context for Modal's ` +
+          `position:fixed overlay, silently breaking every dialog rendered ` +
+          `beneath it (BET-884). Offending line(s): ` +
+          (offenders.join(" | ") || "none"),
+      ).toEqual([]);
+    });
+  }
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2702,10 +2702,10 @@ export type StatusItem = {
   render: () => ReactNode;
 };
 
-// The two container breakpoints the spec mandates (BET-782 §3). The header is
-// a CSS container query (`container: sessionheader / inline-size`); the width
-// passed in here is that container's inline size — NOT the viewport, which
-// measures the wrong thing when the sidebar / artifacts panel resize the pane.
+// The two container breakpoints the spec mandates (BET-782 §3). The width
+// passed in here is the header element's own measured width, taken by a
+// ResizeObserver in SessionHeader.tsx — NOT the viewport, which measures
+// the wrong thing when the sidebar / artifacts panel resize the pane.
 const STATUS_CUT_560 = 560;
 const STATUS_CUT_420 = 420;
 // The overflow cut refuses to auto-hide anything at ≥ 80 (artifacts / menu are

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -55,16 +55,6 @@ html, body, #root {
   box-shadow: var(--shadow-sm), 0 0 0 3px var(--accent-bg);
 }
 
-/* BET-782: the session header is a container query. The pane's width is a
-   function of the sidebar + artifacts panel, NOT the viewport, so a viewport
-   breakpoint measures the wrong thing — the cut is driven by the container's
-   inline size. selectStatusItems (chatUtils) mirrors this with the same two
-   breakpoint constants (560 / 420); the container context here is what makes
-   the header a container-query surface rather than a media-query one. */
-.manta-session-header {
-  container: sessionheader / inline-size;
-}
-
 /* Trailing spacer inside any header row that reaches the top-right of the
    window. Zero-width off Windows. */
 .titlebar-inset-right {


### PR DESCRIPTION
**BET-884 — Fix: session-header confirm dialogs break (dead CSS containment rule)**

The confirm dialogs in the session menu (Delete session / Clear session) rendered
inside the 44px header: the overlay was centred on the header strip, and its
buttons were unclickable.

**Root cause (already diagnosed, not re-investigated):** a dead CSS rule left
behind by BET-811 declared `container: sessionheader / inline-size;` on
`.manta-session-header`. `container-type: inline-size` applies layout
containment, which makes the header the containing block for every
`position: fixed` descendant AND a stacking context — so `Modal`'s `fixed inset-0
z-50` overlay resolved against the 44px header box and its z-index was trapped
under the transcript/composer, which won hit-testing.

**The fix — a pure deletion (no workaround, no portal, no z-index overrides):**
1. Deleted the dead rule + its BET-782 comment block from `src/renderer/index.css`.
2. Kept the `manta-session-header` class on the header element untouched
   (the overflow test + visual gate still query it).
3. Rewrote the now-false "container query" comment in `src/renderer/chatUtils.ts`
   to say the width is the header's own measured width from a `ResizeObserver`
   in `SessionHeader.tsx`.
4. Added a regression guard to `src/renderer/Modal.test.tsx`: no stylesheet under
   `src/renderer` may declare CSS containment (`contain:` / `container:` /
   `container-type:`), read from disk with a message naming the file + line.

**Out of scope (as specified):** `Modal.tsx`, `ConfirmModal.tsx`,
`SessionHeader.tsx` render tree, `selectStatusItems`, and the `ResizeObserver`
were all left untouched. No portal added to `Modal` (separate follow-up issue).

**Base:** `origin/main @ 5128a664`

**Verification results:**
- PR branch (`multica/BET-884-remove-dead-css-containment` @ `e4425166`):
  - typecheck: exit 0. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit 0. Renderer `141` files passed, `2641` passed / `7` skipped; server `1988` passed / `0` fail. Failures: none.
    log sha256: `50c85837710f6554399558c3c98d6917c4f843f5c0028d3387e5cd3ef4cc265d`
- Guard test verified by hand: pasting the deleted rule back into `index.css`
  makes the new containment test fail naming file + line; reverted after.

**Conclusion:** 0 new failures. This is a 3-file dead-code deletion + one guard
test; the base-branch re-run is not meaningful here.
