### PR TITLE
fix(server): emit context/cache frames from message.updated (BET-887)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -141,9 +141,51 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 const PROJECT_ROOT = join(__dirname, "..", "..");
 
 const bus = createBus();
+// Model context windows for the interpreter's context reading. listModels() is
+// a provider round-trip, so it is fetched once and refreshed only when a model
+// we have never seen appears (a newly connected provider). A miss returns null
+// and the interpreter falls back to the assumed window rather than blocking.
+let modelContextLimits = null;
+let modelContextRefresh = null;
+function refreshModelContextLimits() {
+  if (modelContextRefresh) return modelContextRefresh;
+  modelContextRefresh = (async () => {
+    try {
+      const models = await oc.listModels();
+      const next = new Map();
+      for (const m of models ?? []) {
+        const ctx = m?.limit?.context;
+        if (typeof ctx === "number" && Number.isFinite(ctx) && ctx > 0) {
+          next.set(`${m.providerID}/${m.id}`, ctx);
+        }
+      }
+      modelContextLimits = next;
+    } catch {
+      modelContextLimits = modelContextLimits ?? new Map();
+    } finally {
+      modelContextRefresh = null;
+    }
+  })();
+  return modelContextRefresh;
+}
+function contextLimitFor(providerID, modelID) {
+  if (!providerID || !modelID) return null;
+  if (modelContextLimits === null) {
+    void refreshModelContextLimits();
+    return null;
+  }
+  const hit = modelContextLimits.get(`${providerID}/${modelID}`);
+  if (hit) return hit;
+  void refreshModelContextLimits();
+  return null;
+}
+
 // Box-side stream interpretation (BET-551): interprets the opencode stream on
 // the box and republishes derived events on THIS bus (single stream/endpoint).
-const streamInterp = createStreamInterpreter({ publish: (evt) => bus.publish(evt) });
+const streamInterp = createStreamInterpreter({
+  publish: (evt) => bus.publish(evt),
+  contextLimitFor,
+});
 // Shared deps passed to store-mutating helpers so they can publish the
 // `*.updated` bus event the renderer cards listen for (JobCard, WebhooksCard,
 // etc). Single source of truth — every endpoint that creates/deletes a

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -23,7 +23,6 @@ import {
   isSafeCut,
   FLUSH_MAX_AGE_MS,
   computeContextBreakdown,
-  resolveContextLimit,
   selectCacheTtlMs,
   computeStaleCache,
   selectLastAssistantCompletion,
@@ -91,6 +90,7 @@ function newSessionState() {
     todos: null,               // liveTodos (todo.updated) ; null = not seen
     msgByMsgId: new Map(),     // messageID -> minimal message for turn detection
     userTurnCount: 0,
+    contextEmitted: null,      // { totalInput, limit } of the last context emit
   };
 }
 
@@ -226,7 +226,11 @@ function updateToolFrames(st, sid, part, emit) {
  * wrapper over events.mjs). `now()` returns epoch-ms. Returns `{ interpret,
  * getState }`.
  */
-export function createStreamInterpreter({ publish, now = () => Date.now() }) {
+export function createStreamInterpreter({
+  publish,
+  now = () => Date.now(),
+  contextLimitFor = () => null,
+}) {
   const sessions = new Map();
   // The same opencode event is delivered on BOTH the global stream and the
   // per-directory scoped one, so interpret() is called twice for it. Un-deduped
@@ -353,6 +357,44 @@ export function createStreamInterpreter({ publish, now = () => Date.now() }) {
         return;
       }
       case "message.updated": {
+        // Context + cache reading from the live token breakdown. The
+        // `session.next.step.ended` event that used to be the only source of
+        // these frames does not fire on the deployed opencode build, so the
+        // iOS context strip had no data. `message.updated` for an assistant
+        // message carries the same token breakdown + model — emit `context`
+        // and `cache` here instead. Deduped per session so the many `updated`
+        // events in a turn do not spam the stream.
+        const msgInfo = evt.properties?.info ?? evt.properties?.message;
+        if (msgInfo?.role === "assistant" && msgInfo?.tokens) {
+          const tokens = msgInfo.tokens;
+          const totalInput =
+            (tokens.input ?? 0) +
+            (tokens.cache?.read ?? 0) +
+            (tokens.cache?.write ?? 0);
+          if (totalInput > 0) {
+            const limit =
+              contextLimitFor(msgInfo.providerID, msgInfo.modelID) ??
+              ASSUMED_CONTEXT_TOKENS;
+            if (
+              !st.contextEmitted ||
+              st.contextEmitted.totalInput !== totalInput ||
+              st.contextEmitted.limit !== limit
+            ) {
+              st.contextEmitted = { totalInput, limit };
+              emit(sid, "context", computeContextBreakdown(tokens, limit));
+              st.cachedTokens =
+                (tokens?.cache?.read ?? 0) + (tokens?.cache?.write ?? 0) ||
+                st.cachedTokens;
+              emit(sid, "cache", computeStaleCache({
+                lastCompleted: st.lastCompleted,
+                now: now(),
+                ttlMs: selectCacheTtlMs(TTL_DEFAULT),
+                cachedTokens: st.cachedTokens,
+                running: st.running,
+              }));
+            }
+          }
+        }
         // turn-complete detection from the transcript payload when present
         const msg = evt.properties?.message ?? evt.properties?.info;
         if (Array.isArray(evt.properties?.messages)) {
@@ -446,7 +488,9 @@ export function createStreamInterpreter({ publish, now = () => Date.now() }) {
         }
         const tokens = props.tokens ?? props.usage;
         if (tokens) {
-          const limit = resolveContextLimit(props.model) ?? ASSUMED_CONTEXT_TOKENS;
+          const limit =
+            contextLimitFor(props.providerID, props.modelID) ??
+            ASSUMED_CONTEXT_TOKENS;
           emit(sid, "context", computeContextBreakdown(tokens, limit));
           // cache staleness: cachedTokens ~ cached prefix size
           st.cachedTokens =

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { createStreamInterpreter } from "./streamInterp.mjs";
+import { ASSUMED_CONTEXT_TOKENS } from "../shared/streamInterpretation.mjs";
 
 function make(now = 500_000) {
   const events = [];
@@ -554,4 +555,101 @@ test("live tool frames are additive — running/truncation/sessionError still fi
   interp.interpret(toolPartUpdated({ id: "t1", tool: "bash", status: "running", metaOutput: "hi" }));
   assert.equal(events.filter((e) => e.sub === "toolStarted").length, 1);
   assert.equal(events.filter((e) => e.sub === "toolOutput").length, 1);
+});
+
+// Context/cache reading from message.updated (BET-887). The
+// `session.next.step.ended` event that used to be the only source of these
+// frames never fires on the deployed opencode build, so the interpreter reads
+// the live token breakdown off assistant `message.updated` events instead.
+// All tests inject a stub `contextLimitFor` (never a live box).
+const ASSISTANT_MSG = {
+  id: "msg_000209d3a001K1l3sjt4jY58Sa",
+  role: "assistant",
+  sessionID: "ses_fffe287c0ffeShSHRqaJKxqpNn",
+  providerID: "anthropic",
+  modelID: "claude-opus-5",
+  tokens: {
+    total: 185763,
+    input: 2,
+    output: 2054,
+    reasoning: 0,
+    cache: { write: 1516, read: 182191 },
+  },
+  cost: 0.1519305,
+};
+
+function updatedWith(info) {
+  return { type: "message.updated", properties: { sessionID: SID, info } };
+}
+
+function makeCtx(contextLimitFor) {
+  const events = [];
+  const interp = createStreamInterpreter({
+    publish: (e) => events.push(e),
+    contextLimitFor,
+  });
+  return { interp, events };
+}
+
+test("message.updated with assistant tokens emits a context frame", () => {
+  const { interp, events } = makeCtx(() => 1_000_000);
+  interp.interpret(updatedWith(ASSISTANT_MSG));
+  const ctx = events.filter((e) => e.sub === "context");
+  assert.equal(ctx.length, 1);
+  // (2 + 182191 + 1516) / 1_000_000 -> 18.37 -> 18
+  assert.equal(ctx[0].payload.pct, 18);
+});
+
+test("the context denominator comes from the resolver", () => {
+  const calls = [];
+  const { interp, events } = makeCtx((providerID, modelID) => {
+    calls.push([providerID, modelID]);
+    return 200_000;
+  });
+  interp.interpret(updatedWith(ASSISTANT_MSG));
+  const ctx = events.filter((e) => e.sub === "context");
+  assert.equal(ctx.length, 1);
+  // (2 + 182191 + 1516) / 200_000 -> 91.85 -> 92
+  assert.equal(ctx[0].payload.pct, 92);
+  assert.deepEqual(calls, [["anthropic", "claude-opus-5"]]);
+});
+
+test("a resolver miss falls back to the assumed window", () => {
+  const { interp, events } = makeCtx(() => null);
+  interp.interpret(updatedWith(ASSISTANT_MSG));
+  const ctx = events.filter((e) => e.sub === "context");
+  assert.equal(ctx.length, 1);
+  // (2 + 182191 + 1516) / 200_000 -> 91.85 -> 92
+  assert.equal(ctx[0].payload.pct, Math.round((183709 / ASSUMED_CONTEXT_TOKENS) * 100));
+});
+
+test("repeated message.updated events are deduped per session", () => {
+  const { interp, events } = makeCtx(() => 1_000_000);
+  interp.interpret(updatedWith(ASSISTANT_MSG));
+  interp.interpret(updatedWith(ASSISTANT_MSG));
+  interp.interpret(updatedWith(ASSISTANT_MSG));
+  assert.equal(events.filter((e) => e.sub === "context").length, 1);
+  assert.equal(events.filter((e) => e.sub === "cache").length, 1);
+  // a changed input total is a different reading -> a second frame
+  interp.interpret(updatedWith({ ...ASSISTANT_MSG, tokens: { ...ASSISTANT_MSG.tokens, input: 20 } }));
+  assert.equal(events.filter((e) => e.sub === "context").length, 2);
+});
+
+test("no context frame for a user message, a token-less message, or an all-zero token set", () => {
+  const { interp, events } = makeCtx(() => 1_000_000);
+  // user role -> nothing
+  interp.interpret(updatedWith({ ...ASSISTANT_MSG, role: "user" }));
+  // assistant but no tokens -> nothing
+  interp.interpret(updatedWith({ ...ASSISTANT_MSG, tokens: undefined }));
+  // assistant but all-zero input buckets -> nothing (fabricated-0% guard)
+  interp.interpret(
+    updatedWith({ ...ASSISTANT_MSG, tokens: { input: 0, output: 0, cache: { read: 0, write: 0 } } }),
+  );
+  assert.equal(events.filter((e) => e.sub === "context").length, 0);
+});
+
+test("the same event also emits a cache frame", () => {
+  const { interp, events } = makeCtx(() => 1_000_000);
+  interp.interpret(updatedWith(ASSISTANT_MSG));
+  assert.equal(events.filter((e) => e.sub === "cache").length, 1);
 });


### PR DESCRIPTION
Opened automatically for `multica/BET-887-box-context-frame`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-887.