### PR TITLE
fix(ios): decode model capabilities to the wire shape (BET-886)

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -189,16 +189,15 @@ enum ChatModel {
         return "\(Int((context / 1000).rounded()))k"
     }
 
-    /// Capability glyphs for a catalogue row, in display order:
-    /// "reasoning" when the model exposes reasoning effort (has variants),
-    /// "vision" when it accepts image input. The differentiator at scale is
-    /// capability, not a name — the list is drawn from the model's own data.
+    /// Capability glyphs for a catalogue row, in display order: "reasoning"
+    /// when the model reasons, "vision" when it accepts image input. Both read
+    /// the box's own capability flags rather than being inferred — a model can
+    /// reason without exposing an effort dial, so deriving "reasoning" from the
+    /// presence of variants mislabels it.
     static func capabilityGlyphs(_ model: OpencodeModel) -> [String] {
         var glyphs: [String] = []
-        if !(model.variants ?? []).isEmpty { glyphs.append("reasoning") }
-        if (model.capabilities?.input ?? []).contains(where: { $0.lowercased() == "image" }) {
-            glyphs.append("vision")
-        }
+        if model.capabilities?.reasoning == true { glyphs.append("reasoning") }
+        if model.capabilities?.input?.image == true { glyphs.append("vision") }
         return glyphs
     }
 

--- a/mobile/native/MantaUI/ChatModelCatalog.swift
+++ b/mobile/native/MantaUI/ChatModelCatalog.swift
@@ -19,7 +19,6 @@ final class ChatModelCatalog: ObservableObject {
 
     @Published private(set) var models: [OpencodeModel] = []
     @Published private(set) var defaultModel: OpencodeModelID?
-    @Published private(set) var loadFailed = false
     /// True once the model list has arrived (or failed). Drives the composer
     /// pill's loading state and the picker's "Loading models…" placeholder.
     @Published private(set) var loaded = false
@@ -37,9 +36,7 @@ final class ChatModelCatalog: ObservableObject {
     /// call while a fetch is in flight, or after one has completed, does
     /// nothing — which is what lets every ChatModelStore (including a freshly
     /// rebuilt one after a clear) share the same loaded list. A failed/empty
-    /// fetch still flips `loaded` (so the pill leaves its loading state); the
-    /// HTTP error is not distinguished from a genuinely empty box — matching
-    /// the prior per-store behaviour.
+    /// fetch still flips `loaded` (so the pill leaves its loading state).
     func loadIfNeeded() {
         guard !didStart, !loaded else { return }
         didStart = true
@@ -49,7 +46,6 @@ final class ChatModelCatalog: ObservableObject {
             await MainActor.run {
                 self.models = modelsResult
                 self.defaultModel = defaultResult
-                self.loadFailed = modelsResult.isEmpty && defaultResult == nil
                 self.loaded = true
             }
         }

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -24,7 +24,6 @@ final class ChatModelStore: ObservableObject {
     @Published private(set) var models: [OpencodeModel] = []
     @Published private(set) var defaultModel: OpencodeModelID?
     @Published private(set) var override: OpencodeModelID?
-    @Published private(set) var loadFailed = false
     /// True once the shared catalog has its list (mirrored from the catalog).
     /// Drives the composer pill's loading state.
     @Published private(set) var loaded = false
@@ -47,13 +46,12 @@ final class ChatModelStore: ObservableObject {
         self.override = Self.loadOverride(for: sessionId)
         self.variant = UserDefaults.standard.string(forKey: Self.variantKey(for: sessionId))
 
-        // Seed + mirror the shared catalog so the box-wide list, default and
-        // failure state are published here (keeps every existing caller reading
+        // Seed + mirror the shared catalog so the box-wide list and default are
+        // published here (keeps every existing caller reading
         // `modelStore.models` unchanged). A clear rebuilds this store, but the
         // catalog is already loaded, so it seeds instantly — no refetch.
         self.models = catalog.models
         self.defaultModel = catalog.defaultModel
-        self.loadFailed = catalog.loadFailed
         self.loaded = catalog.loaded
         self.recents = ModelRecents.load()
         catalog.objectWillChange
@@ -65,7 +63,6 @@ final class ChatModelStore: ObservableObject {
     private func mirrorCatalog() {
         models = catalog.models
         defaultModel = catalog.defaultModel
-        loadFailed = catalog.loadFailed
         loaded = catalog.loaded
     }
 

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -278,18 +278,31 @@ struct OpencodeModel: Codable, Equatable, Sendable {
     /// context window (Opus 4.7 reports 1M, Sonnet 200k) — the denominator the
     /// context meter must use, never a hardcoded 200k.
     var limit: ModelLimit? = nil
-    /// The model's declared input/output capabilities (`{tools, input, output}`
-    /// from the box's `getProviders()`/`listModels()`). `input` is the list of
-    /// accepted input modalities ("text", "image", ...) — whether the row shows
-    /// a "vision" glyph. Absent for providers that don't annotate it.
+    /// The model's declared capabilities from the box (the wire object also
+    /// carries `temperature`, `attachment`, `toolcall`, `output`,
+    /// `interleaved` — declared as our `ModelCapabilities` only reads what the
+    /// catalogue row renders). `input.image` is whether the row shows a
+    /// "vision" glyph. Absent for providers that don't annotate it.
     var capabilities: ModelCapabilities? = nil
 }
 
 /// The model's advertised capabilities from `opencode:models` (`capabilities`).
+///
+/// Declares ONLY the two facts the catalogue row renders. The wire object also
+/// carries `temperature`, `attachment`, `toolcall`, `output` and `interleaved`,
+/// and `interleaved` is a Bool on some models and an object on others — so
+/// declaring a field this app does not use is a decode failure waiting to
+/// happen. Unknown keys are ignored by the synthesized Decodable; a key that is
+/// present with the wrong TYPE throws and takes the whole model list with it,
+/// which is exactly how the catalogue silently came up empty.
 struct ModelCapabilities: Codable, Equatable, Sendable {
-    var tools: Bool?
-    var input: [String]?
-    var output: [String]?
+    /// Input modalities, an OBJECT of flags on the wire (`{"text":true,
+    /// "image":true,…}`) — never a list of strings.
+    struct Modalities: Codable, Equatable, Sendable {
+        var image: Bool?
+    }
+    var reasoning: Bool?
+    var input: Modalities?
 }
 
 /// The model's advertised limits from `opencode:models` (`limit: { context }`).

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -109,34 +109,132 @@ final class ModelRecentsTests: XCTestCase {
 
     // MARK: - ChatModel.capabilityGlyphs
 
-    private func gylphModel(variants: Int = 0, input: [String] = []) -> OpencodeModel {
+    /// Builds a catalogue row with the capability flags directly (mirroring
+    /// the wire shape: `reasoning` and `input.image` are the declared Bool
+    /// flags, not a variant list). `nil` = the key is absent on the wire.
+    private func gylphModel(reasoning: Bool? = nil, image: Bool? = nil) -> OpencodeModel {
         OpencodeModel(
             id: "m",
             providerID: "p",
             name: "m",
-            variants: (0..<variants).map { OpencodeModel.Variant(id: "v\($0)") },
-            capabilities: ModelCapabilities(input: input)
+            capabilities: ModelCapabilities(
+                reasoning: reasoning,
+                input: image.map { ModelCapabilities.Modalities(image: $0) }
+            )
         )
     }
 
-    func testReasoningFromVariants() {
-        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(variants: 3)), ["reasoning"])
+    func testReasoningFromCapabilityFlag() {
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(reasoning: true)), ["reasoning"])
     }
 
-    func testVisionFromImageInput() {
-        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(input: ["text", "image"])), ["vision"])
+    func testVisionFromImageFlag() {
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(image: true)), ["vision"])
     }
 
     func testBothInOrderReasoningThenVision() {
-        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(variants: 5, input: ["text", "image"])), ["reasoning", "vision"])
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(reasoning: true, image: true)), ["reasoning", "vision"])
     }
 
     func testEmptyWhenNeither() {
         XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel()), [])
-        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(input: ["text"])), [])
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(reasoning: false)), [])
     }
 
-    func testVisionCaseInsensitive() {
-        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(input: ["Image"])), ["vision"])
+    func testNoVisionWhenImageFlagMissingOrFalse() {
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(image: false)), [])
+        XCTAssertEqual(ChatModel.capabilityGlyphs(gylphModel(reasoning: true, image: false)), ["reasoning"])
+    }
+
+    // MARK: - Wire decode (regression guard)
+    //
+    // Captured verbatim from `POST /rpc/opencode:models` on a live box. The
+    // point of this fixture is that it is NOT hand-written: the previous
+    // capability tests built ModelCapabilities in Swift and passed green while
+    // every real model failed to decode. Note `interleaved` is a Bool on the
+    // first model and an OBJECT on the second — declaring a field this app
+    // does not use would fail here.
+    private static let wireModelsJSON = """
+    [
+      {
+        "id": "claude-opus-4-7",
+        "providerID": "anthropic",
+        "family": "claude-opus",
+        "name": "Claude Opus 4.7",
+        "status": "active",
+        "limit": { "context": 1000000, "output": 128000 },
+        "capabilities": {
+          "temperature": false,
+          "reasoning": true,
+          "attachment": true,
+          "toolcall": true,
+          "input":  { "text": true, "audio": false, "image": true,  "video": false, "pdf": true  },
+          "output": { "text": true, "audio": false, "image": false, "video": false, "pdf": false },
+          "interleaved": false
+        },
+        "variants": [
+          { "id": "low" }, { "id": "medium" }, { "id": "high" },
+          { "id": "xhigh" }, { "id": "max" }
+        ]
+      },
+      {
+        "id": "nemotron-3.5-lightning-free",
+        "providerID": "opencode",
+        "family": "nemotron-free",
+        "name": "Nemotron 3.5 Lightning Free",
+        "status": "active",
+        "limit": { "context": 262144, "output": 262144 },
+        "capabilities": {
+          "temperature": true,
+          "reasoning": true,
+          "attachment": false,
+          "toolcall": true,
+          "input":  { "text": true, "audio": false, "image": false, "video": false, "pdf": false },
+          "output": { "text": true, "audio": false, "image": false, "video": false, "pdf": false },
+          "interleaved": { "field": "reasoning_content" }
+        }
+      }
+    ]
+    """
+
+    private func wireModels() throws -> [OpencodeModel] {
+        try JSONDecoder().decode(
+            [OpencodeModel].self,
+            from: Data(Self.wireModelsJSON.utf8))
+    }
+
+    func testWireModelsDecode() throws {
+        let models = try wireModels()
+        XCTAssertEqual(models.count, 2)
+        XCTAssertEqual(models[0].providerID, "anthropic")
+        XCTAssertEqual(models[0].id, "claude-opus-4-7")
+        XCTAssertEqual(models[0].name, "Claude Opus 4.7")
+        XCTAssertEqual(models[1].providerID, "opencode")
+        XCTAssertEqual(models[1].id, "nemotron-3.5-lightning-free")
+        XCTAssertEqual(models[1].name, "Nemotron 3.5 Lightning Free")
+    }
+
+    func testWireContextLimits() throws {
+        let models = try wireModels()
+        XCTAssertEqual(ChatModel.contextSize(models[0].limit?.context), "1M")
+        XCTAssertEqual(ChatModel.contextSize(models[1].limit?.context), "262k")
+    }
+
+    func testWireCapabilityGlyphs() throws {
+        let models = try wireModels()
+        XCTAssertEqual(ChatModel.capabilityGlyphs(models[0]), ["reasoning", "vision"])
+        XCTAssertEqual(ChatModel.capabilityGlyphs(models[1]), ["reasoning"])
+    }
+
+    func testWireVariants() throws {
+        let models = try wireModels()
+        XCTAssertEqual(models[0].variants?.map(\.id), ["low", "medium", "high", "xhigh", "max"])
+        XCTAssertEqual(models[1].variants?.count ?? 0, 0)
+    }
+
+    func testWireModelIsPickable() throws {
+        let models = try wireModels()
+        XCTAssertTrue(ChatModel.isPickable(models[0]))
+        XCTAssertTrue(ChatModel.isPickable(models[1]))
     }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-886-ios-model-decode`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-886.