### PR TITLE
BET-885: Portal Modal to document.body so no ancestor can capture its fixed overlay

### DIFF
--- a/src/renderer/ConfirmModal.test.tsx
+++ b/src/renderer/ConfirmModal.test.tsx
@@ -18,7 +18,10 @@ describe("ConfirmModal", () => {
   });
 
   function buttons(harness: Harness): HTMLButtonElement[] {
-    return [...harness.container.querySelectorAll("button")] as HTMLButtonElement[];
+    // ConfirmModal renders through Modal's portal to document.body.
+    return [
+      ...harness.docQuery('div[role="dialog"]')!.querySelectorAll("button"),
+    ] as HTMLButtonElement[];
   }
 
   it("renders the title and body when open", () => {
@@ -32,8 +35,8 @@ describe("ConfirmModal", () => {
         onCancel={() => {}}
       />,
     );
-    expect(h.text()).toContain("Delete this session?");
-    expect(h.text()).toContain("This can't be undone.");
+    expect(h.docText()).toContain("Delete this session?");
+    expect(h.docText()).toContain("This can't be undone.");
   });
 
   it("renders nothing when closed", () => {
@@ -47,7 +50,7 @@ describe("ConfirmModal", () => {
         onCancel={() => {}}
       />,
     );
-    expect(h.text()).not.toContain("Delete this session?");
+    expect(h.docText()).not.toContain("Delete this session?");
   });
 
   it("Cancel fires onCancel, not onConfirm", () => {
@@ -103,7 +106,7 @@ describe("ConfirmModal", () => {
         onCancel={() => cancelled++}
       />,
     );
-    const dialog = h.container.querySelector('div[role="dialog"]')!;
+    const dialog = h.docQuery('div[role="dialog"]')!;
     dialog.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     expect(cancelled).toBe(1);
     expect(confirmed).toBe(0);

--- a/src/renderer/FolderPickerModal.test.tsx
+++ b/src/renderer/FolderPickerModal.test.tsx
@@ -48,7 +48,7 @@ describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () =>
     );
     await h.flush();
 
-    const input = h.container.querySelector("input") as HTMLInputElement;
+    const input = h.docQuery("input") as HTMLInputElement;
     expect(input).toBeTruthy();
 
     act(() => {
@@ -59,14 +59,14 @@ describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () =>
     await act(async () => {
       await new Promise((r) => setTimeout(r, 150));
     });
-    expect(h.text()).toContain("jects/"); // the ghost-text tail of "/home/dev/projects/"
+    expect(h.docText()).toContain("jects/"); // the ghost-text tail of "/home/dev/projects/"
 
     // First Escape: dismisses the suggestion, dialog stays open.
     act(() => {
       input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     });
     expect(cancelled).toBe(0);
-    expect(h.text()).not.toContain("jects/");
+    expect(h.docText()).not.toContain("jects/");
 
     // Second Escape, no suggestion live: bubbles to Modal and closes.
     act(() => {
@@ -91,7 +91,7 @@ describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () =>
     );
     await h.flush();
 
-    const input = h.container.querySelector("input") as HTMLInputElement;
+    const input = h.docQuery("input") as HTMLInputElement;
     act(() => {
       input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     });

--- a/src/renderer/MenuItem.test.tsx
+++ b/src/renderer/MenuItem.test.tsx
@@ -342,10 +342,11 @@ describe("SessionHeader session menu — Delete/Clear confirm (BET-724 §D7)", (
     return el!;
   }
 
-  // The confirm's own action button lives inside the Modal's dialog panel —
-  // this only searches there, never the dropdown's menuitem rows.
+  // The confirm's own action button lives inside the Modal's dialog panel
+  // (portalled to document.body) — this only searches there, never the
+  // dropdown's menuitem rows.
   function confirmButtonByText(text: string): HTMLButtonElement {
-    const dialog = h!.container.querySelector('div[role="dialog"]') as HTMLElement;
+    const dialog = h!.docQuery('div[role="dialog"]') as HTMLElement;
     expect(dialog).toBeTruthy();
     const el = [...dialog.querySelectorAll("button")].find(
       (b) => b.textContent === text,
@@ -359,7 +360,7 @@ describe("SessionHeader session menu — Delete/Clear confirm (BET-724 §D7)", (
     openMenuWith({ onDelete: () => deleted++ });
     act(() => menuItemByText("Delete session").click());
     expect(deleted).toBe(0);
-    expect(h!.text()).toContain("Delete this session?");
+    expect(h!.docText()).toContain("Delete this session?");
   });
 
   it("confirming Delete calls onDelete exactly once", () => {
@@ -383,7 +384,7 @@ describe("SessionHeader session menu — Delete/Clear confirm (BET-724 §D7)", (
     openMenuWith({ onClear: () => cleared++ });
     act(() => menuItemByText("Clear session").click());
     expect(cleared).toBe(0);
-    expect(h!.text()).toContain("Clear this conversation?");
+    expect(h!.docText()).toContain("Clear this conversation?");
   });
 
   it("confirming Clear calls onClear exactly once", () => {
@@ -400,7 +401,7 @@ describe("SessionHeader session menu — Delete/Clear confirm (BET-724 §D7)", (
       onDelete: () => {},
     });
     act(() => menuItemByText("Delete session").click());
-    expect(h!.text()).toContain("fix-onboarding");
+    expect(h!.docText()).toContain("fix-onboarding");
   });
 });
 
@@ -478,7 +479,7 @@ describe("SessionMenu — keyboard roving focus (BET-741)", () => {
     // (BET-724 §D7) — same activation path a click would take.
     press(menuEl(), "Enter");
     expect(deleted).toBe(0);
-    expect(h!.text()).toContain("Delete this session?");
+    expect(h!.docText()).toContain("Delete this session?");
   });
 
   it("Home/End rove focus to the first/last row", () => {

--- a/src/renderer/Modal.test.tsx
+++ b/src/renderer/Modal.test.tsx
@@ -36,13 +36,15 @@ describe("Modal", () => {
   });
 
   function overlayEl(harness: Harness): HTMLElement {
-    const el = harness.container.firstElementChild as HTMLElement;
+    // Modal portals to document.body, so the overlay (the dialog's parent) is
+    // not inside `container`.
+    const el = harness.docQuery('div[role="dialog"]')!.parentElement as HTMLElement;
     expect(el.className).toBe(OVERLAY);
     return el;
   }
 
   function panelEl(harness: Harness): HTMLElement {
-    const el = harness.container.querySelector('div[role="dialog"]') as HTMLElement;
+    const el = harness.docQuery('div[role="dialog"]') as HTMLElement;
     expect(el).toBeTruthy();
     return el;
   }
@@ -105,27 +107,27 @@ describe("Modal", () => {
 
   it("renders children while open (default true)", () => {
     h = mount(<Modal label="L">content</Modal>);
-    expect(h.text()).toContain("content");
+    expect(h.docText()).toContain("content");
   });
 
   it("renders nothing when open is false", () => {
     h = mount(<Modal open={false} label="L">content</Modal>);
-    expect(h.text()).not.toContain("content");
-    expect(h.container.querySelector('div[role="dialog"]')).toBeNull();
+    expect(h.docText()).not.toContain("content");
+    expect(h.docQuery('div[role="dialog"]')).toBeNull();
   });
 
   it("removes the dialog from the DOM after close + exit animation", async () => {
     // Modal stays MOUNTED while open; when `open` flips false, the exit
     // animation runs and AnimatePresence removes the chrome only afterwards.
     h = mount(<Modal label="L">content</Modal>);
-    expect(h.text()).toContain("content");
+    expect(h.docText()).toContain("content");
     h.rerender(<Modal open={false} label="L">content</Modal>);
     // Let the 0.18s exit run to completion; 400ms comfortably exceeds it.
     await act(async () => {
       await new Promise((r) => setTimeout(r, 400));
     });
-    expect(h.text()).not.toContain("content");
-    expect(h.container.querySelector('div[role="dialog"]')).toBeNull();
+    expect(h.docText()).not.toContain("content");
+    expect(h.docQuery('div[role="dialog"]')).toBeNull();
   });
 });
 
@@ -144,7 +146,7 @@ describe("Modal — Escape + focus trap + restore (BET-724)", () => {
         <button>ok</button>
       </Modal>,
     );
-    const btn = h.container.querySelector("button")!;
+    const btn = h.docQuery("button")!;
     act(() => {
       btn.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     });
@@ -157,14 +159,14 @@ describe("Modal — Escape + focus trap + restore (BET-724)", () => {
         <button>ok</button>
       </Modal>,
     );
-    const btn = h.container.querySelector("button")!;
+    const btn = h.docQuery("button")!;
     expect(() => {
       act(() => {
         btn.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
       });
     }).not.toThrow();
-    expect(h.text()).toContain("ok");
-    expect(h.container.querySelector('div[role="dialog"]')).toBeTruthy();
+    expect(h.docText()).toContain("ok");
+    expect(h.docQuery('div[role="dialog"]')).toBeTruthy();
   });
 
   it("focuses the first focusable element inside the panel on open", () => {
@@ -177,13 +179,13 @@ describe("Modal — Escape + focus trap + restore (BET-724)", () => {
         </div>
       </Modal>,
     );
-    const buttons = h.container.querySelectorAll("button");
+    const buttons = h.docQuery('div[role="dialog"]')!.querySelectorAll("button");
     expect(document.activeElement).toBe(buttons[0]);
   });
 
   it("falls back to focusing the panel itself (tabIndex=-1) when nothing inside is focusable", () => {
     h = mount(<Modal label="L">plain text</Modal>);
-    const panel = h.container.querySelector('div[role="dialog"]') as HTMLElement;
+    const panel = h.docQuery('div[role="dialog"]') as HTMLElement;
     expect(panel).toBeTruthy();
     expect(document.activeElement).toBe(panel);
     expect(panel.getAttribute("tabindex")).toBe("-1");
@@ -196,7 +198,7 @@ describe("Modal — Escape + focus trap + restore (BET-724)", () => {
         <button>second</button>
       </Modal>,
     );
-    const buttons = [...h.container.querySelectorAll("button")] as HTMLButtonElement[];
+    const buttons = [...h.docQuery('div[role="dialog"]')!.querySelectorAll("button")] as HTMLButtonElement[];
     buttons[1].focus();
     act(() => {
       buttons[1].dispatchEvent(
@@ -245,7 +247,7 @@ describe("Modal — Escape + focus trap + restore (BET-724)", () => {
         <input autoFocus placeholder="path" />
       </Modal>,
     );
-    const input = h.container.querySelector("input")!;
+    const input = h.docQuery("input")!;
     // Focus stayed on the autofocused input, NOT the earlier Close button.
     expect(document.activeElement).toBe(input);
 

--- a/src/renderer/Modal.tsx
+++ b/src/renderer/Modal.tsx
@@ -21,6 +21,7 @@
 // `useFocusTrap` hook (lifted from Settings' `useDialog`, BET-419 §C).
 
 import { motion, AnimatePresence } from "framer-motion";
+import { createPortal } from "react-dom";
 import { useRef, type KeyboardEvent, type MouseEvent, type ReactNode } from "react";
 import { useFocusTrap } from "./useFocusTrap";
 import { MOTION_BASE, MOTION_EASE, MOTION_FAST } from "./chatMotion";
@@ -79,7 +80,15 @@ export function Modal({
         }
       }
     : undefined;
-  return (
+  // Portal the whole chrome to document.body (BET-885): Modal's overlay is
+  // `position: fixed`, and a containment/stacks-transform declaration on any
+  // ANCESTOR (contain, transform, filter, backdrop-filter, perspective,
+  // container-type, will-change) silently turns that ancestor into the
+  // containing block / stacking context for the fixed overlay — rendering the
+  // dialog relative to an arbitrary DOM region (e.g. a 44px header strip)
+  // with dead buttons. Portal to body makes every such ancestor irrelevant,
+  // for every dialog, present and future.
+  return createPortal(
     <AnimatePresence>
       {open && (
         <motion.div
@@ -107,6 +116,7 @@ export function Modal({
           </motion.div>
         </motion.div>
       )}
-    </AnimatePresence>
+    </AnimatePresence>,
+    document.body,
   );
 }

--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -21,7 +21,6 @@
 // inside the card).
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { createPortal } from "react-dom";
 import { Pencil, X } from "lucide-react";
 import { describeModel } from "../shared/modelGuide.mjs";
 import { formatModelContextSize } from "./chatUtils";
@@ -557,19 +556,14 @@ export function ModelsCard() {
         if (target) lastEditModel.current = target;
         const model = lastEditModel.current ?? models[0];
         if (!model) return null;
-        // Render through a portal to document.body: the modal is the only one
-        // in the app nested inside the full-screen Settings dialog, and
-        // portaling it out of that frequently re-rendering subtree guarantees
-        // a store-driven Settings re-render can never remount it (which would
-        // drop focus from the field being typed in).
-        return createPortal(
+        // Modal portals itself to document.body (BET-885).
+        return (
           <EditModelModal
             model={model}
             open={!!target}
             onSave={(override) => void saveOverride(modelKey(model.providerID, model.id), model, override)}
             onCancel={() => setEditing(null)}
-          />,
-          document.body,
+          />
         );
       })()}
     </div>

--- a/src/renderer/Settings.test.tsx
+++ b/src/renderer/Settings.test.tsx
@@ -34,13 +34,14 @@ describe("Settings — Escape + nested-confirm ownership (BET-724 regression)", 
       getServerVersion: () => Promise.resolve({ version: "0.0.0-test" }),
     });
 
+  // Settings' own full-screen dialog lives in `container`; the nested
+  // ConfirmModal renders through Modal's portal to document.body — so to see
+  // BOTH (and count them), query document.body (the container is its child).
   const dialogs = (): HTMLElement[] =>
-    [...h!.container.querySelectorAll<HTMLElement>('[role="dialog"]')];
+    [...document.body.querySelectorAll<HTMLElement>('[role="dialog"]')];
 
   const confirmDialog = (): HTMLElement | null =>
-    h!.container.querySelector<HTMLElement>(
-      `[role="dialog"][aria-label="${CONFIRM_LABEL}"]`,
-    );
+    h!.docQuery<HTMLElement>(`[role="dialog"][aria-label="${CONFIRM_LABEL}"]`);
 
   const clickResetConfirm = () => {
     const btn = [...h!.container.querySelectorAll("button")].find(

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -221,6 +221,11 @@ export type Harness = {
   flush: () => Promise<void>;
   html: () => string;
   text: () => string;
+  /** Portal-aware query — Modal renders through a portal to document.body, so a
+   *  dialog is NOT inside `container`. Use for anything rendered by <Modal>. */
+  docQuery: <T extends Element = HTMLElement>(sel: string) => T | null;
+  /** Portal-aware text — same reason as docQuery. */
+  docText: () => string;
 };
 
 export type MountOptions = {
@@ -269,6 +274,8 @@ export function mount(el: React.ReactElement, opts: MountOptions = {}): Harness 
     flush,
     html: () => container.innerHTML,
     text: () => container.textContent ?? "",
+    docQuery: (sel) => document.body.querySelector(sel),
+    docText: () => document.body.textContent ?? "",
   };
 }
 


### PR DESCRIPTION
## What

Hardens `Modal` against CSS containment / stacking-transform ancestors silently capturing its `fixed inset-0` overlay. Instead of rendering relative to an arbitrary DOM ancestor, `Modal` now portals its chrome to `document.body`, making containment declarations on any ancestor permanently irrelevant.

### Changes

- **`src/renderer/Modal.tsx`** — wrap the whole `<AnimatePresence>` tree in `createPortal(<tree>, document.body)`. Nothing else changed: class strings, sizes, `padded`/`tall`/`onDismiss`/`label`/`open`, focus trap, animation constants all untouched. No `container`/`target` prop, no `#modal-root`, no `className` escape hatch.
- **`src/renderer/ModelsCard.tsx`** — delete the now-redundant bespoke `createPortal` around the edit-model modal; render `<EditModelModal>` directly. Removed the now-unused `createPortal` import and replaced the stale "portal out of the re-rendering subtree" comment (which misstated how React portals work) with a one-line note that Modal portals itself. The `lastEditModel.current` / `target` / `!model` guards are unchanged.
- **`src/renderer/testHarness.tsx`** — added exactly two portal-aware members to `Harness`: `docQuery(sel)` (queries `document.body`) and `docText()` (reads `document.body.textContent`), used by every affected test rather than scattering raw body queries.
- **Test updates** (mechanical, no assertion weakened/retargeted): moved dialog queries/`text()` reads that target Modal-rendered content off `container` → the portal-aware helpers in `Modal.test.tsx`, `ConfirmModal.test.tsx`, `MenuItem.test.tsx`, `Settings.test.tsx`, `FolderPickerModal.test.tsx`. Non-Modal elements (menu rows, buttons, fields, the Settings full-screen dialog) still query `container`/`document.body` exactly as before.

### Base

`Base: origin/main @ c799415c`

### Verification results

**Files changed:** `8` files. See diff --stat above.

- PR branch (`multica/BET-885-modal-portal` @ `cbfb18e1`):
  - typecheck: exit `0`. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit `0`, `1988` pass / `0` fail / `0` skip. Failures: none. log sha256: `c43d0cbee95c6b82f22a21297e7a151b7feb3c0fcf227c2ab1d95a44b7f408bc`
- Base (`main` @ `c799415c`):
  - typecheck: exit `0`. Errors: none. log sha256: `19d583391c8b1ca203d401be3a20c862f1928db9d37421f1fb14aeb3f1076e1c`
  - test: exit `0`, `1988` pass / `0` fail / `0` skip. Failures: none. log sha256: `7f6e33a5319aad54d0b96b768367d6b1a5e1d2c54fca41e370320b9a34f55d4f`
- **Conclusion:** `0` new failures, `0` pre-existing. PR branch fully green (typecheck byte-identical to base).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

### Note on verification step 3

`grep -rn "createPortal" src/renderer/` matches `Modal.tsx` **and** `Popover.tsx`. ModelsCard's bespoke portal is gone. `Popover.tsx`'s portal is a pre-existing, separate concern: it ports a positioning-sensitive dropdown surface to body (not a modal dialog), is unrelated to the containment bug this issue fixes, and is explicitly out of scope. Leaving it; flagging so the grep criterion isn't read strictly.

### Out of scope (unchanged)

No `index.css` / `SessionHeader.tsx` / `chatUtils.ts` changes. No dialog copy/size/tone/buttons changed. Non-Modal full-screen overlays (Settings, PaletteShell, etc.) untouched.
