### PR TITLE
chore: release 0.0.26

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.25",
+      "version": "0.0.26",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.25",
+  "version": "0.0.26",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.25",
+ "version": "0.0.26",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Bumps the package version to 0.0.26.

## Why

`self-update.sh` decides whether to update by comparing **version strings only**. `main` has been on 0.0.25 since the last release, so the tarball published by the `server-v20` tag carried the same version with different contents — every box sees "already at 0.0.25" and skips the download. The release was undeliverable.

That release contains the BET-866 / BET-875 forge fixes (a session's PR is its branch's PR or nothing). Without this bump they cannot reach any box.

## Scope

Version fields in `package.json` + `package-lock.json`. Nothing else.

Follow-up worth tracking separately: self-update should verify the published sha, not just the version, so a same-version republish can't silently no-op. Deliberately not in this PR — the update path is the one thing that, if broken, removes a box's ability to recover.