### PR TITLE
fix(ios): render the effort control as a UIMenu palette strip and label effort variants in one place (BET-888)

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -189,6 +189,21 @@ enum ChatModel {
         return "\(Int((context / 1000).rounded()))k"
     }
 
+    /// Display label for an effort variant id. A lookup, not a string
+    /// transform: `.capitalized` renders the camel-cased level "xhigh" as
+    /// "Xhigh". Unknown ids fall back to capitalisation so a provider that
+    /// ships a new level still reads sensibly rather than disappearing.
+    static func effortLabel(_ variantID: String) -> String {
+        switch variantID.lowercased() {
+        case "low": return "Low"
+        case "medium": return "Medium"
+        case "high": return "High"
+        case "xhigh": return "xHigh"
+        case "max": return "Max"
+        default: return variantID.capitalized
+        }
+    }
+
     /// Capability glyphs for a catalogue row, in display order: "reasoning"
     /// when the model reasons, "vision" when it accepts image input. Both read
     /// the box's own capability flags rather than being inferred — a model can

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -510,7 +510,7 @@ struct ComposerView: View {
         guard let model = activeModel else { return "Default" }
         var parts = [model.name]
         if let variant = modelStore.variant, !variant.isEmpty {
-            parts.append(variant.capitalized)
+            parts.append(ChatModel.effortLabel(variant))
         }
         return parts.joined(separator: " · ")
     }
@@ -536,19 +536,17 @@ struct ComposerView: View {
             }
         }
 
-        // 3 + 4. Effort (inline segmented) and Fast mode. Omitted when the
-        //    active model offers neither — a model with no variants shows no
-        //    effort control anywhere.
+        // 3 + 4. Effort and Fast mode, each omitted when the active model does
+        //    not offer it. The trailing Divider is conditional so a model with
+        //    neither does not draw two separators back to back.
+        Divider()
+        if showEffortPicker {
+            Section("Effort") { effortPicker }
+        }
+        if showFastToggle {
+            fastToggle
+        }
         if showEffortPicker || showFastToggle {
-            Divider()
-            if showEffortPicker {
-                effortPicker
-            }
-            if showFastToggle {
-                fastToggle
-            }
-            Divider()
-        } else {
             Divider()
         }
 
@@ -584,33 +582,26 @@ struct ComposerView: View {
         return fast.available || fast.on
     }
 
-    /// Inline segmented effort control — a segmented control shows the CURRENT
-    /// value without a second tap, which an effort submenu cannot. The "Default"
-    /// segment is the model's recommended level (no explicit variant).
+    /// Inline effort control. `.palette` is the ONLY picker style a menu
+    /// renders as a horizontal strip — a menu is a UIMenu and discards
+    /// arbitrary layout, so the earlier `VStack` + `.segmented` version drew
+    /// nothing at all. A strip is used rather than a submenu because it shows
+    /// the CURRENT value without a second tap. The "Default" segment is the
+    /// model's own recommended level (no explicit variant).
     private var effortPicker: some View {
-        let selection = Binding<String>(
+        Picker("Effort", selection: Binding<String>(
             get: { modelStore.variant ?? "" },
             set: { newValue in
-                if newValue.isEmpty {
-                    modelStore.setVariant(nil)
-                } else {
-                    modelStore.setVariant(newValue)
-                }
+                modelStore.setVariant(newValue.isEmpty ? nil : newValue)
                 modelStore.recordCurrentChoice()
             }
-        )
-        return VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
-            Text("Effort")
-                .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))
-                .foregroundColor(tokens.tx3)
-            Picker("Effort", selection: selection) {
-                Text("Default").tag("")
-                ForEach(modelStore.activeVariants, id: \.id) { variant in
-                    Text(variant.id.capitalized).tag(variant.id)
-                }
+        )) {
+            Text("Default").tag("")
+            ForEach(modelStore.activeVariants, id: \.id) { variant in
+                Text(ChatModel.effortLabel(variant.id)).tag(variant.id)
             }
-            .pickerStyle(.segmented)
         }
+        .pickerStyle(.palette)
     }
 
     /// Fast-mode toggle — a session-level flag, so it sits at the same level

--- a/mobile/native/MantaUI/ModelRecents.swift
+++ b/mobile/native/MantaUI/ModelRecents.swift
@@ -52,7 +52,7 @@ enum ModelRecents {
         }?.name ?? choice.modelID
         var parts = [name]
         if let variant = choice.variant, !variant.isEmpty {
-            parts.append(variant.capitalized)
+            parts.append(ChatModel.effortLabel(variant))
         }
         if choice.fast { parts.append("⚡") }
         return parts.joined(separator: " · ")

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -237,4 +237,29 @@ final class ModelRecentsTests: XCTestCase {
         XCTAssertTrue(ChatModel.isPickable(models[0]))
         XCTAssertTrue(ChatModel.isPickable(models[1]))
     }
+
+    // MARK: - ChatModel.effortLabel (BET-888)
+
+    func testEffortLabelKnownLevels() {
+        XCTAssertEqual(ChatModel.effortLabel("low"), "Low")
+        XCTAssertEqual(ChatModel.effortLabel("medium"), "Medium")
+        XCTAssertEqual(ChatModel.effortLabel("high"), "High")
+        XCTAssertEqual(ChatModel.effortLabel("xhigh"), "xHigh")
+        XCTAssertEqual(ChatModel.effortLabel("max"), "Max")
+    }
+
+    func testEffortLabelIsCaseInsensitive() {
+        XCTAssertEqual(ChatModel.effortLabel("XHIGH"), "xHigh")
+    }
+
+    func testEffortLabelUnknownFallsBack() {
+        XCTAssertEqual(ChatModel.effortLabel("turbo"), "Turbo")
+    }
+
+    func testRecentsLabelUsesEffortLabel() {
+        let c = ModelChoice(providerID: "anthropic", modelID: "opus", variant: "xhigh", fast: false)
+        let label = ModelRecents.label(for: c, models: [])
+        XCTAssertTrue(label.contains("xHigh"))
+        XCTAssertFalse(label.contains("Xhigh"))
+    }
 }


### PR DESCRIPTION
Fixes the two defects in BET-888: the effort control in the model menu could not render (it was a `VStack` + `.segmented` Picker inside a menu, which a `UIMenu` discards), and effort labels were formatted three different ways via `.capitalized` (which renders `xhigh` as "Xhigh").

## Changes

**Task 1 — effort control renders as a menu palette strip.** `effortPicker` is now a bare `Picker` with `.pickerStyle(.palette)` — the only picker style a `UIMenu` renders as a horizontal strip. It is wrapped in `Section("Effort")` in the menu (the `Section` header supplies the "Effort" label, replacing the deleted `Text`). No `VStack`, no `Text` label, no custom styling.

**Task 2 — one effort label.** New `ChatModel.effortLabel(_:)` is the single source of truth; all three call sites route through it (chip text, recents label, picker rows). `.capitalized` is gone from `ComposerView.swift` and `ModelRecents.swift` (grep-confirmed).

**Task 3 — tests.** Four new tests in `ModelRecentsTests.swift` (the file that already owns `ChatModel` pure-logic tests), including `testEffortLabelKnownLevels` which pins `xhigh → "xHigh"` (the regression) and `testRecentsLabelUsesEffortLabel` which pins the recents call site to the lookup.

## Deleted vs added (house rule 1: removal beats addition)

Production net is **+5 lines**, from the single mandated new symbol `ChatModel.effortLabel` (+14). Everything else is removed:
- Deleted: the `VStack` wrapper, the `Text("Effort")` styled label, the `.font`/`.foregroundColor` styling, the `if/else` in the picker setter (collapsed to one line — the store already treats empty as clear), the duplicated `Divider` branch, and two `.capitalized` calls.
- Added: one `effortLabel` lookup, `.pickerStyle(.palette)`, and the `Section` wrapper.

## Verification results

Verified via the `ios-mantaui` plugin on the Mac, branch `multica/BET-888-ios-effort-picker`, tip `9ea5651c`:
- **compile-only**: recorded verdict `COMPILE: PASS (app target only, NO tests) 9ea5651c [multica/BET-888-ios-effort-picker]`. `XCODEGEN: PASS`; build log has no compile errors — only pre-existing warnings (deprecated `onChange(of:perform:)` in ComposerView.swift:173, Sendable-concurrency warnings on other files, Crashlytics dSYM script-phase warning).
- **test-unit**: job finished `done` (the merge gate — both bundles compiled, UI bundle not run), UNIT: PASS. On the pre-rebase tip (`29e9e264`, byte-identical tree) the plugin printed: `Executed 368 tests, with 0 failures (0 unexpected) in 1.238 (1.490) seconds`.

**Menu rendering is UNVERIFIED.** A `.palette` strip inside a `UIMenu` is a UIKit presentation — no unit test covers it, and there is no paired-device/simulator run in this PR. **This is the one thing a reviewer should check on device.** No menu-rendering test is attempted.

**Base:** `origin/main @ 1de20bef`.
