### PR TITLE
fix(forge): resolve PR base branch from the forge instead of assuming main (BET-891)

### DIFF
--- a/src/server/forge/github.mjs
+++ b/src/server/forge/github.mjs
@@ -714,6 +714,22 @@ export function createGithubAdapter(request, requestWrite, requestText = request
     },
 
     /**
+     * GET /repos/{o}/{r} — the repo's default branch (the PR base). Returns
+     * `"main"` when the field is missing or the payload is malformed.
+     * @param {{ owner: string, repo: string }} repo
+     * @returns {Promise<string>}
+     */
+    async getDefaultBranch(repo) {
+      let data = {};
+      try {
+        ({ data } = await request(`${apiBase}/repos/${repo.owner}/${repo.repo}`));
+      } catch {
+        // fall through to "main"
+      }
+      return typeof data?.default_branch === "string" && data.default_branch ? data.default_branch : "main";
+    },
+
+    /**
      * GET /user/repos — the repos the connected user can actually PUSH to,
      * most-recently-pushed first. Filtering to write access is what keeps the
      * clone picker usable: a read-only repo you cannot push to is noise here,

--- a/src/server/forge/github.test.mjs
+++ b/src/server/forge/github.test.mjs
@@ -486,6 +486,20 @@ test("listMyRepos drops read-only repos and orders most-recently-pushed first", 
   assert.ok(!data.some((r) => r.fullName === "acme/readonly"));
 });
 
+// ---- getDefaultBranch: the single-repo default-branch read (BET-891) -------
+
+test("getDefaultBranch maps the repo's default_branch", async () => {
+  const url = "https://api.github.com/repos/acme/widget";
+  const adapter = createGithubAdapter(fakeRequest({ [url]: { default_branch: "develop" } }));
+  assert.equal(await adapter.getDefaultBranch({ owner: "acme", repo: "widget" }), "develop");
+});
+
+test("getDefaultBranch falls back to main when the field is absent", async () => {
+  const url = "https://api.github.com/repos/acme/widget";
+  const adapter = createGithubAdapter(fakeRequest({ [url]: { full_name: "acme/widget" } }));
+  assert.equal(await adapter.getDefaultBranch({ owner: "acme", repo: "widget" }), "main");
+});
+
 // ---- Work inbox (BET-795) --------------------------------------------------
 
 test("buildInboxQueries returns the three cross-repo populations with their reasons", () => {

--- a/src/server/forge/gitlab.mjs
+++ b/src/server/forge/gitlab.mjs
@@ -514,5 +514,17 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
       const { data } = await requestWrite(url, { method: "PUT", body: { body } });
       return { data: { id: data?.id ?? null }, stale: false };
     },
+
+    // GET /projects/{encoded id} — the repo's default branch (the PR base).
+    // Returns `"main"` when the field is missing or the payload is malformed.
+    async getDefaultBranch(repo) {
+      let data = {};
+      try {
+        ({ data } = await request(`${apiBase}${projectPath(repo)}`));
+      } catch {
+        // fall through to "main"
+      }
+      return typeof data?.default_branch === "string" && data.default_branch ? data.default_branch : "main";
+    },
   };
 }

--- a/src/server/forge/gitlab.test.mjs
+++ b/src/server/forge/gitlab.test.mjs
@@ -496,3 +496,15 @@ test("parseGlabToken reads the token for a host from glab config text", () => {
   assert.equal(parseGlabToken(cfg, "missing.com"), null);
   assert.equal(parseGlabToken("", "gitlab.com"), null);
 });
+
+test("getDefaultBranch maps the project's default_branch", async () => {
+  const url = "https://gitlab.com/api/v4/projects/acme%2Fwidget";
+  const adapter = createGitlabAdapter(fakeRequest({ [url]: { default_branch: "develop" } }));
+  assert.equal(await adapter.getDefaultBranch(REPO), "develop");
+});
+
+test("getDefaultBranch falls back to main when the field is absent", async () => {
+  const url = "https://gitlab.com/api/v4/projects/acme%2Fwidget";
+  const adapter = createGitlabAdapter(fakeRequest({ [url]: { path_with_namespace: "acme/widget" } }));
+  assert.equal(await adapter.getDefaultBranch(REPO), "main");
+});

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -488,6 +488,13 @@ async function defaultCurrentBranch(cwd) {
   }
 }
 
+// Resolve the PR base default from the forge API (the single source of truth),
+// never from a local git ref. Injectable via `deps.getDefaultBranch` so tests
+// stay I/O-free.
+async function defaultGetDefaultBranch({ adapter, repo }) {
+  return adapter.getDefaultBranch(repo);
+}
+
 // The shared cwd → origin → forge → token → adapter scaffold that every
 // cwd-scoped forge read/write resolves. pullRequestForCwd, resolveWriteContext
 // (and its write/draft consumers) and forgeDiffForCwd all did this by hand;
@@ -760,16 +767,19 @@ export async function forgeInbox(deps = {}) {
 // thing we push and open a PR from).
 async function resolveWriteContext(cwd, deps, wantBranch = true) {
   const currentBranch = deps.currentBranch ?? defaultCurrentBranch;
+  const getDefaultBranch = deps.getDefaultBranch ?? defaultGetDefaultBranch;
 
   const ctx = await resolveForgeContext(cwd, deps);
   if (ctx.error) return { error: ctx.error };
   const { forge, repo, adapter } = ctx;
   let head = null;
+  let base = null;
   if (wantBranch) {
     head = await currentBranch(cwd);
     if (!head) return { error: "no_branch" };
+    base = await getDefaultBranch({ adapter, repo });
   }
-  return { forge, repo, adapter, head };
+  return { forge, repo, adapter, head, base };
 }
 
 /**
@@ -793,11 +803,12 @@ async function resolveWriteContext(cwd, deps, wantBranch = true) {
 export async function shipPreview(cwd, deps = {}) {
   const ctx = await resolveWriteContext(cwd, deps);
   if (ctx.error) return { ok: false, error: ctx.error };
-  const base = deps.defaultBase ?? "main";
+  const base = ctx.base;
+  const runGit = deps.run ?? run;
 
   let files = [];
   try {
-    const { stdout } = await run("git", ["-C", cwd, "diff", "--name-only", `origin/${base}...${ctx.head}`, "--"]);
+    const { stdout } = await runGit("git", ["-C", cwd, "diff", "--name-only", `origin/${base}...${ctx.head}`, "--"]);
     files = String(stdout ?? "").split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
   } catch {
     // origin/<base> may not exist locally yet — best-effort empty.
@@ -939,7 +950,7 @@ export async function shipPullRequest(cwd, { title, body = "", base, draft = fal
     const res = await ctx.adapter.createPullRequest(ctx.repo, {
       title,
       body,
-      base: base ?? "main",
+      base: base ?? ctx.base,
       head: ctx.head,
       draft: draft ?? false,
     });

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -324,6 +324,7 @@ function writeAdapter({ created = { ...OPEN_PR, number: 77 }, merge = { merged: 
 const SHIP_DEPS = {
   gitRemoteOrigin: async () => "https://github.com/acme/widget.git",
   currentBranch: async () => "feature/forge",
+  getDefaultBranch: async () => "main",
   resolveToken: async () => ({ token: "ghp_t", source: "cli" }),
   getAdapter: () => writeAdapter(),
   gitPush: async (input) => ({ input }),
@@ -409,6 +410,59 @@ test("shipPreview returns head, base and a best-effort file count", async () => 
   assert.equal(r.head, "feat/forge-seam");
   assert.equal(r.base, "main");
   assert.equal(typeof r.fileCount, "number");
+});
+
+test("shipPreview uses the forge-resolved default branch for base and the diff range", async () => {
+  const gitCalls = [];
+  const r = await shipPreview("/repo", {
+    ...SHIP_DEPS,
+    currentBranch: async () => "feat/forge-seam",
+    getDefaultBranch: async () => "master",
+    run: async (cmd, args) => { gitCalls.push({ cmd, args }); return { stdout: "a.ts\nb.ts\n", stderr: "" }; },
+  });
+  assert.equal(r.ok, true);
+  assert.equal(r.base, "master");
+  assert.equal(r.fileCount, 2);
+  const diff = gitCalls.find((c) => c.args.includes("diff"));
+  assert.ok(diff, "git diff ran");
+  assert.ok(
+    diff.args.includes("origin/master...feat/forge-seam"),
+    `diff range uses origin/<base>...<head>, got ${JSON.stringify(diff.args)}`
+  );
+});
+
+test("shipPullRequest passes the forge-resolved base to createPullRequest", async () => {
+  const created = [];
+  const adapter = {
+    kind: "github",
+    createPullRequest: async (_repo, input) => { created.push(input); return { data: { ...OPEN_PR, number: 77 }, stale: false }; },
+    merge: async () => ({ data: { merged: true }, stale: false }),
+  };
+  const r = await shipPullRequest("/repo", { title: "t", body: "B" }, {
+    ...SHIP_DEPS,
+    getAdapter: () => adapter,
+    getDefaultBranch: async () => "master",
+  });
+  assert.equal(r.ok, true);
+  assert.equal(created.length, 1);
+  assert.equal(created[0].base, "master");
+});
+
+test("shipPullRequest: an explicit base input still wins over the resolved one", async () => {
+  const created = [];
+  const adapter = {
+    kind: "github",
+    createPullRequest: async (_repo, input) => { created.push(input); return { data: { ...OPEN_PR, number: 77 }, stale: false }; },
+    merge: async () => ({ data: { merged: true }, stale: false }),
+  };
+  const r = await shipPullRequest("/repo", { title: "t", body: "B", base: "trunk" }, {
+    ...SHIP_DEPS,
+    getAdapter: () => adapter,
+    getDefaultBranch: async () => "master",
+  });
+  assert.equal(r.ok, true);
+  assert.equal(created.length, 1);
+  assert.equal(created[0].base, "trunk");
 });
 
 test("shipPreview drafts a title from the tip commit (design step 1)", async () => {


### PR DESCRIPTION
Opened automatically for `multica/BET-891-forge-default-branch`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-891.