### PR TITLE
feat(mobile): replace composer model menu with the cockpit sheet (BET-894)

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -216,6 +216,42 @@ enum ChatModel {
         return glyphs
     }
 
+    // MARK: - Cockpit + catalogue copy (BET-894)
+
+    /// The catalogue row's badge line: context size, then capability glyphs —
+    /// "1M · reasoning · vision". Any absent part is omitted, never rendered
+    /// empty. Moved verbatim from the old `ModelPickerSheet.badgeText` so the
+    /// string lives in the pure layer, not a view.
+    static func catalogueBadge(_ m: OpencodeModel) -> String {
+        var parts: [String] = []
+        if let ctx = contextSize(m.limit?.context) {
+            parts.append(ctx)
+        }
+        parts.append(contentsOf: capabilityGlyphs(m))
+        return parts.joined(separator: " · ")
+    }
+
+    /// The cockpit card's subtitle: provider, then "<context> context" when the
+    /// limit is known, then the capability glyphs — "anthropic · 1M context ·
+    /// reasoning". Any absent part is omitted, never rendered empty; a missing
+    /// limit must not leave a stray " · ".
+    static func cardSubtitle(_ m: OpencodeModel) -> String {
+        var parts = [m.providerID]
+        if let ctx = contextSize(m.limit?.context) {
+            parts.append("\(ctx) context")
+        }
+        parts.append(contentsOf: capabilityGlyphs(m))
+        return parts.joined(separator: " · ")
+    }
+
+    /// How many models the catalogue will actually show in its "All models · N"
+    /// count — the total across `groups(_:)`, so the count can never disagree
+    /// with the list beneath it (which likewise excludes disabled/deprecated
+    /// models and `-fast` twins whose base twin survives).
+    static func pickableCount(_ models: [OpencodeModel]) -> Int {
+        groups(models).reduce(0) { $0 + $1.models.count }
+    }
+
     /// Encode a selection as the persisted `providerID/modelID` string.
     static func encode(_ id: OpencodeModelID) -> String {
         "\(id.providerID)/\(id.modelID)"

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -445,18 +445,16 @@ struct ComposerView: View {
         .presentationDetents([.large])
     }
 
-    // MARK: - Model pill → menu (BET-825)
+    // MARK: - Model pill → cockpit sheet (BET-894)
 
-    /// The composer chip: a real control (a `Menu`) anchored on a filled
-    /// capsule. The capsule is ONE token — "✦ Opus 4.7 · High" plus a bolt when
-    /// fast — with a fill, so the resolved (model · effort · fast) triple reads
-    /// at a glance and the model name can never wrap. The menu holds the common
-    /// case (recents + inline effort + fast); the catalogue sheet is reached
-    /// only from "More Models…".
+    /// The composer chip: a plain button anchored on a filled capsule. The
+    /// capsule is ONE token — "✦ Opus 4.7 · High" plus a bolt when fast — with
+    /// a fill, so the resolved (model · effort · fast) triple reads at a glance
+    /// and the model name can never wrap. Tapping opens the model sheet, whose
+    /// cockpit hosts the effort/fast controls + recents that a SwiftUI `Menu`
+    /// (a UIKit menu) cannot lay out — see `ModelPickerSheet`'s header comment.
     private var modelPill: some View {
-        Menu {
-            modelMenuContent
-        } label: {
+        Button { showModelPicker = true } label: {
             chipLabel
         }
         .accessibilityLabel("Model")
@@ -513,111 +511,6 @@ struct ComposerView: View {
             parts.append(ChatModel.effortLabel(variant))
         }
         return parts.joined(separator: " · ")
-    }
-
-    // MARK: - Tier 1 menu content
-
-    /// The menu: recents + Server default, inline effort + fast, then the
-    /// catalogue sheet. Order is HIG-driven (most-frequent first).
-    @ViewBuilder
-    private var modelMenuContent: some View {
-        // 1. Recents (most recent first) + the ever-present Server-default
-        //    escape. Each recent is a (model, effort, fast) triple.
-        if !modelStore.recents.isEmpty {
-            ForEach(modelStore.recents, id: \.self) { choice in
-                recentButton(choice)
-            }
-        }
-        Button(action: { modelStore.setOverride(nil) }) {
-            HStack {
-                Text("Server default")
-                Spacer()
-                if modelStore.override == nil { Image(systemName: "checkmark") }
-            }
-        }
-
-        // 3 + 4. Effort and Fast mode, each omitted when the active model does
-        //    not offer it. The trailing Divider is conditional so a model with
-        //    neither does not draw two separators back to back.
-        Divider()
-        if showEffortPicker {
-            Section("Effort") { effortPicker }
-        }
-        if showFastToggle {
-            fastToggle
-        }
-        if showEffortPicker || showFastToggle {
-            Divider()
-        }
-
-        // 6. The catalogue sheet — the ellipsis (per HIG, it opens another view).
-        Button { showModelPicker = true } label: {
-            Label("More Models…", systemImage: "ellipsis")
-        }
-    }
-
-    private func recentButton(_ choice: ModelChoice) -> some View {
-        Button(action: { modelStore.apply(choice) }) {
-            HStack {
-                Text(ModelRecents.label(for: choice, models: modelStore.models))
-                    .lineLimit(1)
-                Spacer()
-                if modelStore.activeChoice == choice {
-                    Image(systemName: "checkmark")
-                }
-            }
-        }
-    }
-
-    private var showEffortPicker: Bool {
-        !modelStore.activeVariants.isEmpty
-    }
-
-    private var fastToggleState: ChatModel.FastToggle {
-        ChatModel.fastToggle(models: modelStore.models, active: activeModel, variantId: modelStore.variant)
-    }
-
-    private var showFastToggle: Bool {
-        let fast = fastToggleState
-        return fast.available || fast.on
-    }
-
-    /// Inline effort control. `.palette` is the ONLY picker style a menu
-    /// renders as a horizontal strip — a menu is a UIMenu and discards
-    /// arbitrary layout, so the earlier `VStack` + `.segmented` version drew
-    /// nothing at all. A strip is used rather than a submenu because it shows
-    /// the CURRENT value without a second tap. The "Default" segment is the
-    /// model's own recommended level (no explicit variant).
-    private var effortPicker: some View {
-        Picker("Effort", selection: Binding<String>(
-            get: { modelStore.variant ?? "" },
-            set: { newValue in
-                modelStore.setVariant(newValue.isEmpty ? nil : newValue)
-                modelStore.recordCurrentChoice()
-            }
-        )) {
-            Text("Default").tag("")
-            ForEach(modelStore.activeVariants, id: \.id) { variant in
-                Text(ChatModel.effortLabel(variant.id)).tag(variant.id)
-            }
-        }
-        .pickerStyle(.palette)
-    }
-
-    /// Fast-mode toggle — a session-level flag, so it sits at the same level
-    /// as effort, never nested under it. Omitted when the model has no fast twin.
-    private var fastToggle: some View {
-        let fast = fastToggleState
-        return Toggle(isOn: Binding(
-            get: { fast.on },
-            set: { on in
-                modelStore.setFast(on)
-                modelStore.recordCurrentChoice()
-            }
-        )) {
-            Label("Fast mode", systemImage: fast.on ? "bolt.fill" : "bolt")
-        }
-        .disabled(!fast.available)
     }
 
     // MARK: - Scroll to bottom

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -381,8 +381,8 @@ struct ModelChip: View {
     let title: String
     let selected: Bool
     let tokens: Tokens
-    let action: () -> Void
     var accessibilityIdentifier: String?
+    let action: () -> Void
 
     var body: some View {
         Button(action: action) {

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -1,27 +1,292 @@
 import SwiftUI
 
 // ===========================================================================
-// Tier 2 — the model CATALOGUE (BET-825).
+// Model picker — the COCKPIT sheet (proposal A, BET-894).
 //
-// Reached ONLY from the composer chip's menu → "More Models…". This is the
-// escape hatch for the long tail (searchable grouped list), not the front door
-// — the common case lives in the menu (recents + inline effort + fast).
+// The front door is a sheet (the "cockpit"), reached by tapping the composer's
+// model chip: the active model as a card with its effort + fast controls inside
+// it, a recents row, and the single route to the full catalogue ("All models").
+// The catalogue is a PUSHED second tier (`ModelCatalogueView`), not a detent.
 //
-// The sheet opens at medium (recents + search visible) and drags to large to
-// reveal the full grouped catalogue. Effort and Fast mode are GONE from here:
-// they moved to the menu (Tier 1), so a decision is never set in two places.
-// The effort/fast sections this sheet used to own were the duplicate code
-// path this work exists to remove.
+// Why not a `Menu` (the old proposal B)? A SwiftUI `Menu` renders as a UIKit
+// menu, and a UIKit menu's contents can only be buttons, toggles, submenus and
+// dividers — it cannot host arbitrary layout. So the "inline segmented effort
+// control" and the recents/capability chips the menu attempted are silently
+// dropped or degraded to a plain option list at runtime. The sheet is the one
+// surface that can render the agreed design. Do not revert to a menu: the
+// segmented picker and the card layout only survive as the sheet's.
 //
-// Each row carries its context size + capability glyphs ("1M · reasoning ·
-// vision") — at this scale the differentiator is capability, not name. The k/M
-// badge comes from the shared `ChatModel.contextSize` (a port of the desktop's
-// `formatModelContextSize`), never re-derived inline.
+// Every visual decision is the spec in BET-894; nothing is invented here.
+// Text uses `Font.manta(size:weight:)` (Dynamic Type scales reading text);
+// chrome glyphs use `.system(size:)`. `UsageSheets.swift` is the house
+// reference for sheet chrome, card containers and action rows.
 // ===========================================================================
 
+/// The cockpit sheet — the model picker's front door. Medium detent at rest;
+/// grows to large only when the catalogue is pushed. Dragging between detents
+/// changes nothing about the content.
 struct ModelPickerSheet: View {
     @ObservedObject var modelStore: ChatModelStore
     @Environment(\.dismiss) private var dismiss
+    @Environment(\.colorScheme) private var colorScheme
+
+    @State private var detent: PresentationDetent = .medium
+    @State private var showCatalogue = false
+
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    private var activeModel: OpencodeModel? {
+        ChatModel.activeModel(modelStore.models, override: modelStore.override, default: modelStore.defaultModel)
+    }
+
+    private var fastToggleState: ChatModel.FastToggle {
+        ChatModel.fastToggle(models: modelStore.models, active: activeModel, variantId: modelStore.variant)
+    }
+
+    private var showFastToggle: Bool {
+        let fast = fastToggleState
+        return fast.available || fast.on
+    }
+
+    var body: some View {
+        NavigationStack {
+            ScrollView {
+                if modelStore.loaded {
+                    cockpit
+                } else {
+                    // Box-wide model list still arriving — an explicit loading
+                    // state rather than an empty sheet.
+                    ProgressView("Loading models…")
+                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+                }
+            }
+            .navigationTitle("Model")
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .navigationDestination(isPresented: $showCatalogue) {
+                ModelCatalogueView(modelStore: modelStore, onPick: { dismiss() })
+            }
+        }
+        // Medium shows the cockpit; pushing the catalogue grows the sheet to
+        // large, and popping returns it to medium. Dragging medium↔large by
+        // hand changes nothing about the content.
+        .presentationDetents([.medium, .large], selection: $detent)
+        .presentationDragIndicator(.visible)
+        .onChange(of: showCatalogue) { _, isPresented in
+            detent = isPresented ? .large : .medium
+        }
+        .onAppear { modelStore.load() }
+    }
+
+    /// Top to bottom: the active-model card, the recents chips, and the only
+    /// route to the catalogue.
+    private var cockpit: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+            activeModelCard
+            if showRecents {
+                recentsBlock
+            }
+            allModelsRow
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp4)
+        .accessibilityIdentifier("model-cockpit")
+    }
+
+    // MARK: - Active-model card
+
+    /// One container holding the model + its effort + its fast flag, because
+    /// effort is a property OF the selected model and must read as attached to
+    /// it. Same recipe as `UsageWindowRow` (UsageSheets.swift).
+    private var activeModelCard: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+            identityRow
+            if !modelStore.activeVariants.isEmpty {
+                effortControl
+            }
+            if showFastToggle {
+                fastToggle
+            }
+        }
+        .padding(Metrics.spacing.sp3)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.lg))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.lg)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+    }
+
+    private var identityRow: some View {
+        HStack(spacing: Metrics.spacing.sp2) {
+            Image(systemName: "sparkles")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.accentTx)
+                .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                .background(tokens.accentSoft, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+            VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
+                Text(activeModelName)
+                    .font(.manta(size: Metrics.type.body, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                    .lineLimit(1)
+                Text(activeModelSubtitle)
+                    .font(.manta(size: Metrics.type.xs))
+                    .foregroundColor(tokens.tx4)
+                    .lineLimit(1)
+            }
+            Spacer(minLength: 0)
+        }
+    }
+
+    private var activeModelName: String {
+        activeModel?.name ?? "Server default"
+    }
+
+    private var activeModelSubtitle: String {
+        guard let model = activeModel else {
+            return "Using the model your box is configured to use."
+        }
+        return ChatModel.cardSubtitle(model)
+    }
+
+    /// The "Reasoning effort" label above the segmented picker.
+    private var effortLabel: some View {
+        Text("Reasoning effort")
+            .font(.manta(size: Metrics.type.twoXS, weight: .semibold))
+            .foregroundColor(tokens.tx3)
+    }
+
+    /// Segmented effort control, moved from the old composer menu. The
+    /// "Default" segment is the model's own recommended level (no explicit
+    /// variant); a `Menu` could not render this as a strip, the sheet can.
+    private var effortControl: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            effortLabel
+            Picker("Reasoning effort", selection: Binding<String>(
+                get: { modelStore.variant ?? "" },
+                set: { newValue in
+                    modelStore.setVariant(newValue.isEmpty ? nil : newValue)
+                    modelStore.recordCurrentChoice()
+                }
+            )) {
+                Text("Default").tag("")
+                ForEach(modelStore.activeVariants, id: \.id) { variant in
+                    Text(ChatModel.effortLabel(variant.id)).tag(variant.id)
+                }
+            }
+            .pickerStyle(.segmented)
+        }
+    }
+
+    /// Fast-mode toggle — a session-level flag, so it sits at the same level
+    /// as effort, never nested under it. Omitted when the model has no fast
+    /// twin. Moved from the old composer menu verbatim.
+    private var fastToggle: some View {
+        let fast = fastToggleState
+        return Toggle(isOn: Binding(
+            get: { fast.on },
+            set: { on in
+                modelStore.setFast(on)
+                modelStore.recordCurrentChoice()
+            }
+        )) {
+            VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
+                Label("Fast mode", systemImage: fast.on ? "bolt.fill" : "bolt")
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                Text("lower latency twin")
+                    .font(.manta(size: Metrics.type.twoXS))
+                    .foregroundColor(tokens.tx4)
+            }
+        }
+        .disabled(!fast.available)
+        .tint(tokens.accentSolid)
+    }
+
+    // MARK: - Recents
+
+    /// Show the block unless the only chip it would render is an unselected
+    /// "Server default" — i.e. no recents AND an override is set.
+    private var showRecents: Bool {
+        !modelStore.recents.isEmpty || modelStore.override == nil
+    }
+
+    private var recentsBlock: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            Text("Recent")
+                .font(.manta(size: Metrics.type.twoXS, weight: .semibold))
+                .foregroundColor(tokens.tx3)
+            WrapLayout(spacing: Metrics.spacing.sp2) {
+                ForEach(modelStore.recents, id: \.self) { choice in
+                    ModelChip(
+                        title: ModelRecents.label(for: choice, models: modelStore.models),
+                        selected: modelStore.activeChoice == choice,
+                        tokens: tokens
+                    ) {
+                        modelStore.apply(choice)
+                        dismiss()
+                    }
+                }
+                ModelChip(
+                    title: "Server default",
+                    selected: modelStore.override == nil,
+                    tokens: tokens
+                ) {
+                    modelStore.setOverride(nil)
+                    dismiss()
+                }
+            }
+        }
+    }
+
+    // MARK: - All-models row
+
+    /// The only route to the catalogue. Mirrors `ContextSheet`'s action-row
+    /// recipe (UsageSheets.swift): accent glyph, title, spacer, count, chevron.
+    private var allModelsRow: some View {
+        Button { showCatalogue = true } label: {
+            HStack(spacing: Metrics.spacing.sp2) {
+                Image(systemName: "magnifyingglass")
+                    .font(.system(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.accentTx)
+                Text("All models")
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                Spacer(minLength: 0)
+                Text("\(ChatModel.pickableCount(modelStore.models))")
+                    .font(.manta(size: Metrics.type.small))
+                    .foregroundColor(tokens.tx4)
+                Image(systemName: "chevron.right")
+                    .font(.system(size: Metrics.type.xs))
+                    .foregroundColor(tokens.tx4)
+            }
+            .padding(Metrics.spacing.sp3)
+            .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.lg))
+            .overlay(
+                RoundedRectangle(cornerRadius: Metrics.radius.lg)
+                    .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+            )
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityIdentifier("model-all-models")
+    }
+}
+
+// MARK: - The catalogue (pushed tier)
+
+/// The long-tail model list, pushed from the cockpit's "All models" row. This
+/// is today's whole sheet body, moved: searchable grouped list, rows with a
+/// context/capability badge. The "Server default" + recents sections moved OUT
+/// to the cockpit — nothing is pickable in two places any more.
+struct ModelCatalogueView: View {
+    @ObservedObject var modelStore: ChatModelStore
+    /// Called when a model is picked so the whole sheet dismisses — one hop
+    /// back to the conversation, not back to the cockpit.
+    let onPick: () -> Void
     @Environment(\.colorScheme) private var colorScheme
     @State private var query = ""
 
@@ -42,92 +307,25 @@ struct ModelPickerSheet: View {
         modelStore.recordCurrentChoice()
     }
 
-    /// The row's badge line: context size, then capability glyphs.
-    private func badgeText(_ m: OpencodeModel) -> String {
-        var parts: [String] = []
-        if let ctx = ChatModel.contextSize(m.limit?.context) {
-            parts.append(ctx)
-        }
-        parts.append(contentsOf: ChatModel.capabilityGlyphs(m))
-        return parts.joined(separator: " · ")
-    }
-
     var body: some View {
-        NavigationStack {
-            Group {
-                if modelStore.loaded {
-                    List {
-                        serverDefaultSection
-                        if !modelStore.recents.isEmpty {
-                            recentsSection
-                        }
-                        providerSections
-                    }
-                    .searchable(
-                        text: $query,
-                        placement: .navigationBarDrawer(displayMode: .always),
-                        prompt: "Search models"
-                    )
-                } else {
-                    // Box-wide model list still arriving — an explicit loading
-                    // state rather than an empty list.
-                    ProgressView("Loading models…")
-                        .frame(maxWidth: .infinity, maxHeight: .infinity)
+        Group {
+            if modelStore.loaded {
+                List {
+                    providerSections
                 }
-            }
-            .navigationTitle("All models")
-            .navigationBarTitleDisplayMode(.inline)
-            .toolbar {
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Done") { dismiss() }
-                }
+                .searchable(
+                    text: $query,
+                    placement: .navigationBarDrawer(displayMode: .always),
+                    prompt: "Search models"
+                )
+            } else {
+                ProgressView("Loading models…")
+                    .frame(maxWidth: .infinity, maxHeight: .infinity)
             }
         }
-        // Medium shows the recents + search; dragging up reveals the full
-        // grouped catalogue. Not `.large`-only — that is the old full-height
-        // sheet this replaces.
-        .presentationDetents([.medium, .large])
-        .presentationDragIndicator(.visible)
-        .onAppear { modelStore.load() }
-    }
-
-    /// The "Server default" row — pinned first, the effective model when no
-    /// override is set.
-    private var serverDefaultSection: some View {
-        Section {
-            Button { setOverrideAndDismiss(nil) } label: {
-                HStack {
-                    Text("Server default")
-                    Spacer()
-                    if modelStore.override == nil { checkmark }
-                }
-            }
-            .accessibilityIdentifier("model-server-default")
-        } header: {
-            Text("Model")
-        } footer: {
-            if modelStore.override == nil {
-                Text("Using the model your box is configured to use.")
-            }
-        }
-    }
-
-    /// The recently-used triples, most recent first — the habitual models the
-    /// menu already surfaces, kept here so the medium detent of this sheet
-    /// reads like the same habit.
-    private var recentsSection: some View {
-        Section("Recents") {
-            ForEach(modelStore.recents, id: \.self) { choice in
-                Button { applyAndDismiss(choice) } label: {
-                    HStack {
-                        Text(ModelRecents.label(for: choice, models: modelStore.models))
-                            .lineLimit(1)
-                        Spacer()
-                        if modelStore.activeChoice == choice { checkmark }
-                    }
-                }
-            }
-        }
+        .navigationTitle("All models")
+        .navigationBarTitleDisplayMode(.inline)
+        // Pushed view: no Done button, no detents — those belong to the sheet root.
     }
 
     /// The model list, grouped into a Section per provider. Empty-query misses
@@ -142,13 +340,14 @@ struct ModelPickerSheet: View {
             ForEach(groups, id: \.provider) { group in
                 Section {
                     ForEach(group.models, id: \.id) { m in
-                        Button { select(m); dismiss() } label: {
+                        Button { select(m); onPick() } label: {
                             HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
                                 VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
                                     Text(m.name)
                                         .lineLimit(1)
-                                    if !badgeText(m).isEmpty {
-                                        Text(badgeText(m))
+                                    let badge = ChatModel.catalogueBadge(m)
+                                    if !badge.isEmpty {
+                                        Text(badge)
                                             .font(.manta(size: Metrics.type.xs))
                                             .foregroundColor(tokens.tx3)
                                     }
@@ -165,19 +364,77 @@ struct ModelPickerSheet: View {
         }
     }
 
-    private func setOverrideAndDismiss(_ id: OpencodeModelID?) {
-        modelStore.setOverride(id)
-        dismiss()
-    }
-
-    private func applyAndDismiss(_ choice: ModelChoice) {
-        modelStore.apply(choice)
-        dismiss()
-    }
-
     private var checkmark: some View {
         Image(systemName: "checkmark")
             .font(.system(size: Metrics.type.small, weight: .semibold))
             .foregroundStyle(.tint)
+    }
+}
+
+// MARK: - Reusable chip + wrap primitive
+
+/// A selectable pill chip used by every chip on the picker screen (recents, and
+/// the next issue's filter row). Styling reuses the composer chip's own padding
+/// + fill vocabulary.
+struct ModelChip: View {
+    let title: String
+    let selected: Bool
+    let tokens: Tokens
+    let action: () -> Void
+
+    var body: some View {
+        Button(action: action) {
+            Text(title)
+                .font(.manta(size: Metrics.type.small, weight: selected ? .semibold : .regular))
+                .lineLimit(1)
+                .padding(.vertical, Metrics.spacing.sp1)
+                .padding(.horizontal, Metrics.spacing.sp2)
+                .background(selected ? tokens.accentSoft : tokens.fill, in: Capsule())
+                .foregroundColor(selected ? tokens.accentTx : tokens.tx2)
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+/// Left-aligned wrapping row — the recents chips are variable-width and must
+/// wrap, which no stock stack does. Kept private to the picker; if a second
+/// caller appears, move it, don't copy it.
+struct WrapLayout: Layout {
+    var spacing: CGFloat
+
+    func sizeThatFits(proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) -> CGSize {
+        let maxWidth = proposal.replacingUnspecifiedDimensions().width
+        var x: CGFloat = 0
+        var y: CGFloat = 0
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth, x > 0 {
+                x = 0
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + spacing
+        }
+        return CGSize(width: maxWidth, height: y + rowHeight)
+    }
+
+    func placeSubviews(in bounds: CGRect, proposal: ProposedViewSize, subviews: Subviews, cache: inout ()) {
+        let maxWidth = bounds.width
+        var x = bounds.minX
+        var y = bounds.minY
+        var rowHeight: CGFloat = 0
+        for subview in subviews {
+            let size = subview.sizeThatFits(.unspecified)
+            if x + size.width > maxWidth, x > bounds.minX {
+                x = bounds.minX
+                y += rowHeight + spacing
+                rowHeight = 0
+            }
+            subview.place(at: CGPoint(x: x, y: y), proposal: ProposedViewSize(size))
+            rowHeight = max(rowHeight, size.height)
+            x += size.width + spacing
+        }
     }
 }

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -233,7 +233,8 @@ struct ModelPickerSheet: View {
                 ModelChip(
                     title: "Server default",
                     selected: modelStore.override == nil,
-                    tokens: tokens
+                    tokens: tokens,
+                    accessibilityIdentifier: "model-server-default"
                 ) {
                     modelStore.setOverride(nil)
                     dismiss()
@@ -381,6 +382,7 @@ struct ModelChip: View {
     let selected: Bool
     let tokens: Tokens
     let action: () -> Void
+    var accessibilityIdentifier: String?
 
     var body: some View {
         Button(action: action) {
@@ -393,6 +395,7 @@ struct ModelChip: View {
                 .foregroundColor(selected ? tokens.accentTx : tokens.tx2)
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier(accessibilityIdentifier ?? "")
     }
 }
 

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -262,4 +262,77 @@ final class ModelRecentsTests: XCTestCase {
         XCTAssertTrue(label.contains("xHigh"))
         XCTAssertFalse(label.contains("Xhigh"))
     }
+
+    // MARK: - Cockpit + catalogue copy (BET-894): catalogueBadge / cardSubtitle / pickableCount
+
+    /// A bare model for the badge/subtitle tests, with the context limit and
+    /// capability flags explicit the way the wire object carries them.
+    private func badgeModel(context: Double?, reasoning: Bool? = nil, image: Bool? = nil) -> OpencodeModel {
+        OpencodeModel(
+            id: "m",
+            providerID: "anthropic",
+            name: "m",
+            limit: context.map { ModelLimit(context: $0) },
+            capabilities: ModelCapabilities(
+                reasoning: reasoning,
+                input: image.map { ModelCapabilities.Modalities(image: $0) }
+            )
+        )
+    }
+
+    // MARK: - ChatModel.catalogueBadge
+
+    func testCatalogueBadgeFullModel() {
+        let m = badgeModel(context: 1_000_000, reasoning: true, image: true)
+        XCTAssertEqual(ChatModel.catalogueBadge(m), "1M · reasoning · vision")
+    }
+
+    func testCatalogueBadgeNoLimitGlyphsOnly() {
+        let m = badgeModel(context: nil, reasoning: true, image: true)
+        XCTAssertEqual(ChatModel.catalogueBadge(m), "reasoning · vision")
+    }
+
+    func testCatalogueBadgeNoLimitNoCapabilitiesIsEmpty() {
+        let m = badgeModel(context: nil)
+        XCTAssertEqual(ChatModel.catalogueBadge(m), "")
+    }
+
+    // MARK: - ChatModel.cardSubtitle
+
+    func testCardSubtitleFullModel() {
+        let m = badgeModel(context: 1_000_000, reasoning: true)
+        XCTAssertEqual(ChatModel.cardSubtitle(m), "anthropic · 1M context · reasoning")
+    }
+
+    func testCardSubtitleMissingLimitOmitsContextClause() {
+        let m = badgeModel(context: nil, reasoning: true)
+        XCTAssertEqual(ChatModel.cardSubtitle(m), "anthropic · reasoning")
+    }
+
+    func testCardSubtitleNoCapabilitiesProviderAndContext() {
+        let m = badgeModel(context: 1_000_000)
+        XCTAssertEqual(ChatModel.cardSubtitle(m), "anthropic · 1M context")
+    }
+
+    // MARK: - ChatModel.pickableCount
+
+    func testPickableCountExcludesDisabledDeprecatedAndFastTwins() {
+        let base = OpencodeModel(id: "gpt-5.6", providerID: "openai", name: "GPT-5.6")
+        // The -fast twin of a visible base is a MODE, not a choice — excluded.
+        let fast = OpencodeModel(id: "gpt-5.6-fast", providerID: "openai", name: "GPT-5.6 Fast")
+        let disabled = OpencodeModel(id: "disabled", providerID: "openai", name: "Disabled", enabled: false)
+        let deprecated = OpencodeModel(id: "deprecated", providerID: "openai", name: "Deprecated", status: "deprecated")
+        let regular = OpencodeModel(id: "gpt-4o", providerID: "openai", name: "GPT-4o")
+        let models = [base, fast, disabled, deprecated, regular]
+
+        XCTAssertEqual(ChatModel.pickableCount(models), 2)
+        // Must equal the sum of the sections `groups(_:)` actually renders.
+        let groupsSum = ChatModel.groups(models).reduce(0) { $0 + $1.models.count }
+        XCTAssertEqual(ChatModel.pickableCount(models), groupsSum)
+    }
+
+    func testPickableCountSingleModel() {
+        let models = [OpencodeModel(id: "opus", providerID: "anthropic", name: "Claude Opus 4.7")]
+        XCTAssertEqual(ChatModel.pickableCount(models), 1)
+    }
 }


### PR DESCRIPTION
## BET-894 — iOS model picker: replace the composer menu with the cockpit sheet (proposal A)

Proposal B (menu) is gone. Tapping the composer chip now opens a **cockpit
sheet** at the medium detent; the catalogue is a pushed second tier reached only
from the "All models" row. A SwiftUI `Menu` renders as a UIKit menu, which
cannot host arbitrary layout — a VStack/picker inside a menu silently degrades.
The sheet is the only surface that can render the agreed design.

### Files changed
- `mobile/native/MantaUI/ComposerView.swift` — pill is now a plain Button; effort/fast/recents moved to the sheet
- `mobile/native/MantaUI/ModelPickerSheet.swift` — rewritten: cockpit (`ModelPickerSheet`) + catalogue (`ModelCatalogueView`) + `WrapLayout`
- `mobile/native/MantaUI/ChatModel.swift` — `catalogueBadge`, `cardSubtitle`, `pickableCount` (pure)
- `mobile/native/MantaUITests/ModelRecentsTests.swift` — tests for the three new pure functions

### Deleted symbols (removal beats addition)
From `ComposerView.swift`:
- `modelMenuContent`
- `recentButton`
- `effortPicker`
- `fastToggle`
- `showEffortPicker`
- `showFastToggle`
- `fastToggleState`

From `ModelPickerSheet.swift` (old):
- `serverDefaultSection`
- `recentsSection`
- `badgeText` (moved verbatim → `ChatModel.catalogueBadge`)
- `setOverrideAndDismiss`
- `applyAndDismiss`

Kept: `ModelPickerSheet` (struct name, so the `.sheet` line / "one presentation
per view" arrangement is untouched), `activeModel`, `isFastActive`,
`resolvedChipText`, the sheet-presentation line, and the whole `ChatModelStore`
/ `ModelRecents` / `ChatModel` selection surface. `grep -n "Menu {" ComposerView.swift`
now returns only the attach button's menu.

New view structs beyond `ModelChip` and `WrapLayout`: none.

Base: origin/main @ `ac5d5577`

### Verification results
- PR branch (`multica/BET-894-ios-model-cockpit-sheet` @ `a27f99c1`):
  - compile-only (`ios-mantaui` plugin, Mac): **PASS** — no compiler errors (`ios-build-errors` empty)
  - GitHub CI `ios-build` (**macos-26 runner**): **PASS** — `xcodebuild build-for-testing` compiled the app **and both test bundles**, including `MantaUITests` (the new pure-function tests compile)
  - GitHub CI `typecheck-test`: **PASS**
  - test-unit execution (`ios-mantaui` plugin): still in-flight after >1h on the Mac at time of hand-off; the unit bundle it runs compiled clean per CI `ios-build`. The Mac plugin records its verdict durably on the box.
- Base (`main`): unchanged iOS gates.

The code-compile gates — the only thing this change can break at build time —
are green on two independent runners (Mac plugin + GitHub macos-26).
