### PR TITLE
refactor(forge): Create PR primary action — drop draft ship, gate on branch state (BET-892)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -568,7 +568,10 @@ export function ChatPanel({
     pr: PullRequest | null;
     checks: ForgeCheckRun[];
     rollup: CheckRollup;
-  }>({ connected: false, kind: null, pr: null, checks: [], rollup: "none" });
+    branch: string | null;
+    base: string | null;
+    aheadCount: number | null;
+  }>({ connected: false, kind: null, pr: null, checks: [], rollup: "none", branch: null, base: null, aheadCount: null });
   const refreshForge = useCallback(async (cwdArg: string) => {
     try {
       const [status, prResult] = await Promise.all([
@@ -586,6 +589,9 @@ export function ChatPanel({
         pr: prResult.pr,
         checks: prResult.checks ?? [],
         rollup: prResult.rollup ?? "none",
+        branch: prResult.branch ?? null,
+        base: prResult.base ?? null,
+        aheadCount: prResult.aheadCount ?? null,
       });
     } catch {
       // non-fatal — the forge read path is best-effort; keep last-known.
@@ -613,18 +619,22 @@ export function ChatPanel({
     }
   }, [cwd, shipProposal]);
 
-  // Confirm → push + create. Only ever called from the ShipConfirmCard or the
-  // inline Create PR handler. On success it refreshes the PR (the branch
-  // popover swaps in place to the PR state).
-  const confirmShip = useCallback(async (input: { title: string; body: string; draft: boolean }) => {
+  // Confirm → push + create. Only reached after the human confirms the
+  // ShipConfirmCard. The title/body come from shipProposal (the box's preview,
+  // already resolved — no arg this time, the form is gone). On success it opens
+  // the PR in the browser and refreshes the PR (the branch popover swaps in
+  // place to the PR state).
+  const confirmShip = useCallback(async () => {
     if (!cwd) return;
+    const { title, body } = shipProposal ?? { title: "", body: "" };
     setShipBusy(true);
     setShipError(null);
     try {
-      const res = await window.api.forgeShip({ cwd, ...input });
+      const res = await window.api.forgeShip({ cwd, title, body });
       if (res.ok) {
         setShipOpen(false);
         setShipProposal(null);
+        if (res.url) void window.api.openExternal(res.url);
         void refreshForge(cwd);
       } else {
         setShipError(res.error);
@@ -634,19 +644,9 @@ export function ChatPanel({
     } finally {
       setShipBusy(false);
     }
-  }, [cwd, refreshForge]);
+  }, [cwd, shipProposal, refreshForge]);
 
-  // Create PR — the inline, no-form path (BET-867 owner-approved departure
-  // from BET-794's mandatory-confirm rule). A human clicking a button labelled
-  // `Create PR` is the explicit confirm. Ships the same title/body the Draft
-  // card would have shown, as a real (non-draft) PR. One code path: both this
-  // and Draft PR… end in confirmShip.
-  const createPr = useCallback(() => {
-    if (!shipProposal) return;
-    void confirmShip({ title: shipProposal.title, body: shipProposal.body, draft: false });
-  }, [shipProposal, confirmShip]);
-
-  // Open the ship confirm card — the always-on human gate for Draft PR….
+  // Open the ship confirm card — the single human gate for creating a PR.
   // Loads the preview (head/base/fileCount) so the card shows real facts; if
   // the preview is already loaded it must not re-fetch. Nothing is pushed or
   // opened until the user confirms (confirmShip).
@@ -2520,8 +2520,9 @@ export function ChatPanel({
         shipError={shipError}
         shipBase={shipProposal?.base ?? null}
         shipFileCount={shipProposal?.fileCount ?? null}
-        onDraftPr={() => void openShip()}
-        onCreatePr={() => void createPr()}
+        base={forge.base}
+        aheadCount={forge.aheadCount}
+        onCreatePr={() => void openShip()}
         onEnsureShipPreview={() => void ensureShipPreview()}
       />
 

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -22,8 +22,6 @@ import type {
   WebhookMeta,
 } from "../shared/types";
 import { Button } from "./Button";
-import { Chip } from "./Chip";
-import { Field } from "./Field";
 import { describeCron, describeNextRun, formatJobSummary } from "./chatUtils";
 import { MetaBadge } from "./chatShared";
 
@@ -615,10 +613,10 @@ export const ReadOnlyJobBar = memo(function ReadOnlyJobBar({
 // ===== Forge ship + merge (BET-794) =====
 
 // ShipConfirmCard — the [SH1] human gate. Always shown before anything is
-// pushed or opened; never auto-submitted. Reads top-down: a context line, an
-// editable title, an editable body, then the actions (primary "Open pull
-// request", a Draft toggle, ghost Cancel). Order matters: one submit action
-// with a modifier, not two submit actions.
+// pushed or opened; never auto-submitted. Reads top-down: a context line, the
+// resolved title as plain text, then the actions (primary "Create pull
+// request", ghost Cancel). The title/body are edited on GitHub seconds later;
+// this card's only job is the confirm.
 export const ShipConfirmCard = memo(function ShipConfirmCard({
   proposal,
   busy,
@@ -629,20 +627,9 @@ export const ShipConfirmCard = memo(function ShipConfirmCard({
   proposal: { head: string; base: string; fileCount: number; title?: string; body?: string };
   busy: boolean;
   error: string | null;
-  onApprove: (input: { title: string; body: string; draft: boolean }) => void;
+  onApprove: () => void;
   onDecline: () => void;
 }) {
-  const [title, setTitle] = useState("");
-  const [body, setBody] = useState("");
-  const [draft, setDraft] = useState(true);
-  useEffect(() => {
-    // Seed the editable fields from the server / agent draft (design §4.5
-    // step 1 — honouring the repo's PR template); the user can still edit them.
-    setTitle(proposal?.title ?? "");
-    setBody(proposal?.body ?? "");
-    setDraft(true);
-  }, [proposal?.head, proposal?.title, proposal?.body]);
-  const canSubmit = title.trim().length > 0 && !busy;
   return (
     <div
       className="rounded-sm border bg-bg-elev px-3 py-2 text-meta"
@@ -658,40 +645,17 @@ export const ShipConfirmCard = memo(function ShipConfirmCard({
           {proposal.fileCount} file{proposal.fileCount === 1 ? "" : "s"}
         </span>
       </div>
-      <div className="flex flex-col gap-2">
-        <Field
-          ariaLabel="Pull request title"
-          value={title}
-          onChange={(e) => setTitle(e.target.value)}
-          placeholder="Pull request title"
-          mono={false}
-          disabled={busy}
-        />
-        <textarea
-          value={body}
-          onChange={(e) => setBody(e.target.value)}
-          placeholder="Describe the change…"
-          spellCheck={false}
-          disabled={busy}
-          rows={3}
-          aria-label="Pull request body"
-          className="w-full bg-bg-soft border border-border-strong rounded-md text-meta text-text-muted px-4 py-3 focus:outline-none focus:border-accent resize-y"
-        />
+      <div className="truncate text-meta font-medium text-text" title={proposal.title}>
+        {proposal.title || "Untitled pull request"}
       </div>
       {error && <div className="text-danger break-words mt-1">{error}</div>}
       <div className="flex items-center gap-2 mt-2">
-        <Button tone="primary" disabled={!canSubmit} onClick={() => onApprove({ title, body, draft })}>
-          {busy ? "Opening…" : "Open pull request"}
+        <Button tone="primary" disabled={busy} onClick={onApprove}>
+          {busy ? "Creating…" : "Create pull request"}
         </Button>
-        <Chip on={draft} onClick={() => setDraft((d) => !d)} title="Toggle draft mode">
-          Draft
-        </Chip>
         <Button tone="ghost" onClick={onDecline} disabled={busy}>
           Cancel
         </Button>
-      </div>
-      <div className="text-text-faint text-label mt-1">
-        Never auto-submitted — nothing is pushed or opened until you confirm here.
       </div>
     </div>
   );

--- a/src/renderer/SessionHeader.branch.test.tsx
+++ b/src/renderer/SessionHeader.branch.test.tsx
@@ -69,12 +69,13 @@ describe("SessionHeader branch popover (BET-867)", () => {
     h = null;
   });
 
-  it("no PR + forge connected → Draft PR… / Create PR, and NOT Merge", async () => {
+  it("no PR + forge connected (ready) → a single Create pull request, and NOT Merge", async () => {
     h = mountSessionHeader({
       branch: "feat/forge-seam",
       forgeConnected: true,
       pr: null,
-      onDraftPr: vi.fn(),
+      base: "main",
+      aheadCount: 3,
       onCreatePr: vi.fn(),
       onEnsureShipPreview: () => {},
     });
@@ -82,12 +83,45 @@ describe("SessionHeader branch popover (BET-867)", () => {
     await h.flush();
 
     const text = bodyText();
-    expect(text).toContain("No pull request on this branch");
-    expect(text).toContain("Draft PR…");
-    expect(text).toContain("Create PR");
+    expect(text).toContain("Create pull request");
     expect(text).not.toContain("Merge");
+    expect(text).not.toContain("Draft PR…");
     // No PR → no merge surface / no reviewers rows.
     expect(text).not.toContain("Review changes");
+  });
+
+  it("on the base branch the popover renders no PR surface (no Create pull request)", async () => {
+    h = mountSessionHeader({
+      branch: "main",
+      forgeConnected: true,
+      pr: null,
+      base: "main",
+      aheadCount: 0,
+      onCreatePr: vi.fn(),
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const text = bodyText();
+    expect(text).toContain("On the base branch");
+    expect(text).not.toContain("Create pull request");
+  });
+
+  it("no commits ahead of base → Nothing to ship, no button", async () => {
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: null,
+      base: "main",
+      aheadCount: 0,
+      onCreatePr: vi.fn(),
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const text = bodyText();
+    expect(text).toContain("Nothing to ship");
+    expect(text).not.toContain("Create pull request");
   });
 
   it("PR present → Merge, Review changes and the Open-on-GitHub tooltip button, and NOT Create PR", async () => {
@@ -107,7 +141,7 @@ describe("SessionHeader branch popover (BET-867)", () => {
     expect(text).toContain("Reviewers");
     expect(text).toContain("Unresolved threads");
     expect(text).toContain("Review changes");
-    expect(text).not.toContain("Create PR");
+    expect(text).not.toContain("Create pull request");
     expect(buttonWithText("Merge")).toBeTruthy();
 
     // Icon-only open-on-forge: the label lives in `title`, not button text.
@@ -152,22 +186,23 @@ describe("SessionHeader branch popover (BET-867)", () => {
     expect(mergeBtn.title).toBe("checks failing");
   });
 
-  it("Create PR click calls the injected create handler exactly once", async () => {
+  it("Create pull request click calls the injected create handler exactly once", async () => {
     const onCreatePr = vi.fn();
     h = mountSessionHeader({
       branch: "feat/forge-seam",
       forgeConnected: true,
       pr: null,
+      base: "main",
+      aheadCount: 3,
       shipBase: "main",
       shipFileCount: 18,
       onCreatePr,
-      onDraftPr: vi.fn(),
       onEnsureShipPreview: () => {},
     });
     openBranchChip(h);
     await h.flush();
 
-    const createBtn = buttonWithText("Create PR");
+    const createBtn = buttonWithText("Create pull request");
     act(() => createBtn.click());
     expect(onCreatePr).toHaveBeenCalledTimes(1);
 
@@ -177,14 +212,15 @@ describe("SessionHeader branch popover (BET-867)", () => {
     expect(text).toContain("18 files");
   });
 
-  it("while a ship is in flight both buttons disable and Create PR labels Creating…", async () => {
+  it("while a ship is in flight the Create pull request button disables and labels Creating…", async () => {
     h = mountSessionHeader({
       branch: "feat/forge-seam",
       forgeConnected: true,
       pr: null,
+      base: "main",
+      aheadCount: 3,
       shipBusy: true,
       shipError: null,
-      onDraftPr: vi.fn(),
       onCreatePr: vi.fn(),
       onEnsureShipPreview: () => {},
     });
@@ -193,7 +229,6 @@ describe("SessionHeader branch popover (BET-867)", () => {
 
     const text = bodyText();
     expect(text).toContain("Opening pull request…");
-    expect(buttonWithText("Draft PR…").disabled).toBe(true);
     expect(buttonWithText("Creating…").disabled).toBe(true);
   });
 });

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -28,6 +28,7 @@ import {
   shouldOfferForgeConnect,
   failuresToAgentPrompt,
   branchPanelState,
+  resolveShipState,
   canMerge,
   type ChecksChipTone,
   type ContextBreakdown,
@@ -103,7 +104,8 @@ export function SessionHeader({
   shipError,
   shipBase,
   shipFileCount,
-  onDraftPr,
+  base,
+  aheadCount,
   onCreatePr,
   onEnsureShipPreview,
 }: {
@@ -179,7 +181,14 @@ export function SessionHeader({
   // popover opens). null while the preview is still loading → rows render "—".
   shipBase?: string | null;
   shipFileCount?: number | null;
-  onDraftPr?: () => void;
+  // The ship gate (BET-892): the session's current branch, the repo default
+  // base branch, and commits ahead — supplied by the forge:pull-request poll
+  // (no second poll) so the popover can decide whether a Create-PR action is
+  // even shown before anything is clicked.
+  base?: string | null;
+  aheadCount?: number | null;
+  // Opens the (single) Create-PR confirmation. Optional so non-forge callers /
+  // tests stay byte-identical.
   onCreatePr?: () => void;
   onEnsureShipPreview?: () => void;
 }) {
@@ -370,8 +379,9 @@ export function SessionHeader({
             metadata beside the breadcrumb rather than as a control. When the
             forge is connected the chip opens the ONE git surface — the branch
             popover [BET-867] — carrying either the PR (merge surface) or the
-            Draft PR / Create PR offer; a scratch dir with no forge keeps the
-            plain non-interactive Tag (byte-identical to today). */}
+            Create-PR offer gated on branch state (BET-892); a scratch dir
+            with no forge keeps the plain non-interactive Tag (byte-identical
+            to today). */}
       {branchState !== "none" ? (
         <BranchChip
           branch={branch ?? ""}
@@ -384,7 +394,8 @@ export function SessionHeader({
           shipError={shipError ?? null}
           shipBase={shipBase ?? null}
           shipFileCount={shipFileCount ?? null}
-          onDraftPr={onDraftPr}
+          base={base ?? null}
+          aheadCount={aheadCount ?? null}
           onCreatePr={onCreatePr}
           onEnsureShipPreview={onEnsureShipPreview}
           onOpenExternal={onOpenExternal}
@@ -989,11 +1000,12 @@ function SessionMenu({
 // attribute, not a peer — no second PR chip). With the forge connected it
 // opens the branch popover in two states — the branch has a PR ([F1]: title,
 // state, refs, reviewers, threads, mergeability + Merge / Review changes /
-// open-on-forge), or it does not ([F2]: Base / Changes from the ship preview
-// + Draft PR… / Create PR). BET-867 is an owner-approved departure from
-// BET-789's [C2]: the no-PR branch now opens a popover where it previously
-// stayed a plain non-interactive Tag; a scratch dir with no forge keeps the
-// Tag unchanged (branchPanelState == "none").
+// open-on-forge), or it does not ([F2]: the ship gate gated on branch state —
+// BET-892: Base / Changes + a single primary Create pull request when ready,
+// or "Nothing to ship" when there are no commits ahead of base). BET-867 is an
+// owner-approved departure from BET-789's [C2]: the no-PR branch now opens a
+// popover where it previously stayed a plain non-interactive Tag; a scratch dir
+// with no forge keeps the Tag unchanged (branchPanelState == "none").
 //
 // The panel props are shared by BranchChip and BranchPanel (the chip passes
 // them straight through) — one type, no parallel re-declaration.
@@ -1008,7 +1020,8 @@ type BranchPanelProps = {
   shipError: string | null;
   shipBase: string | null;
   shipFileCount: number | null;
-  onDraftPr?: () => void;
+  base: string | null;
+  aheadCount: number | null;
   onCreatePr?: () => void;
   onOpenExternal?: (url: string) => void;
   onReviewChanges?: () => void;
@@ -1097,8 +1110,11 @@ function PanelRow({
 }
 
 // The branch popover's single surface, branching on `pr` presence (BET-867).
-// PR present → the merge surface [F1]; no PR → the Draft PR… / Create PR
-// offer [F2][F3][F4]. PanelRow is reused verbatim for both states' rows.
+// PR present → the merge surface [F1]; no PR → the ship gate (BET-892) gated
+// on branch state: a single primary "Create pull request" when there are
+// commits ahead of base, "Nothing to ship" when there aren't, and no PR
+// surface at all on the base branch / detached HEAD. PanelRow is reused
+// verbatim for both states' rows.
 function BranchPanel({
   branch,
   pr,
@@ -1110,13 +1126,30 @@ function BranchPanel({
   shipError,
   shipBase,
   shipFileCount,
-  onDraftPr,
+  base,
+  aheadCount,
   onCreatePr,
   onOpenExternal,
   onReviewChanges,
 }: BranchPanelProps) {
   if (!pr) {
-    // No pull request on this branch [F2] — the Draft PR… / Create PR offer.
+    // No pull request on this branch — the ship gate. On the base branch or a
+    // detached HEAD there is no PR to open, so no PR surface renders at all.
+    const shipState = resolveShipState({ branch, base, aheadCount, hasPr: false });
+    if (shipState === "on-base" || shipState === "detached") {
+      return (
+        <div className="p-3">
+          <div className="mb-[3px] truncate text-[13.5px] font-semibold leading-snug text-text">
+            {branch}
+          </div>
+          <div className="text-xs text-text-faint">
+            {shipState === "on-base"
+              ? "On the base branch — nothing to ship."
+              : "Detached HEAD — nothing to ship."}
+          </div>
+        </div>
+      );
+    }
     return (
       <div className="p-3">
         <div className="mb-[3px] truncate text-[13.5px] font-semibold leading-snug text-text">
@@ -1124,30 +1157,35 @@ function BranchPanel({
         </div>
         {shipError ? (
           <div className="mb-2 break-words text-xs text-danger">{shipError}</div>
+        ) : shipState === "no-commits" ? (
+          <div className="mb-2 text-xs text-text-faint">
+            Nothing to ship — no commits ahead of {base}
+          </div>
         ) : (
           <div className="mb-2 text-xs text-text-faint">
-            {shipBusy ? "Opening pull request…" : "No pull request on this branch"}
+            {shipBusy ? "Opening pull request…" : "Ready to open a pull request"}
           </div>
         )}
-        <div className="flex flex-col">
-          <PanelRow label="Base" value={shipBase ?? "—"} />
-          <PanelRow
-            label="Changes"
-            value={
-              shipFileCount != null
-                ? `${shipFileCount} file${shipFileCount === 1 ? "" : "s"}`
-                : "—"
-            }
-          />
-        </div>
-        <div className="mt-3 flex flex-nowrap items-center gap-2">
-          <Button tone="primary" disabled={shipBusy} onClick={onDraftPr}>
-            Draft PR…
-          </Button>
-          <Button tone="default" disabled={shipBusy} onClick={onCreatePr}>
-            {shipBusy ? "Creating…" : "Create PR"}
-          </Button>
-        </div>
+        {shipState !== "no-commits" && (
+          <>
+            <div className="flex flex-col">
+              <PanelRow label="Base" value={shipBase ?? base ?? "—"} />
+              <PanelRow
+                label="Changes"
+                value={
+                  shipFileCount != null
+                    ? `${shipFileCount} file${shipFileCount === 1 ? "" : "s"}`
+                    : "—"
+                }
+              />
+            </div>
+            <div className="mt-3 flex flex-nowrap items-center gap-2">
+              <Button tone="primary" disabled={shipBusy} onClick={onCreatePr}>
+                {shipBusy ? "Creating…" : "Create pull request"}
+              </Button>
+            </div>
+          </>
+        )}
       </div>
     );
   }

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -105,6 +105,7 @@ import {
   homeRelativePath,
   planHighlightRanges,
   canMerge,
+  resolveShipState,
   describeMergeFailure,
   commentableLines,
   cloneErrorKind,
@@ -3918,6 +3919,46 @@ describe("failuresToAgentPrompt", () => {
 
   it("no failing checks → empty body", () => {
     expect(failuresToAgentPrompt([])).toBe("");
+  });
+});
+
+describe("resolveShipState", () => {
+  const base = { branch: "feat/x", base: "main", aheadCount: 3, hasPr: false };
+
+  it("has-pr wins even when branch === base", () => {
+    expect(resolveShipState({ branch: "main", base: "main", aheadCount: 0, hasPr: true })).toBe(
+      "has-pr",
+    );
+  });
+
+  it("detached when no branch", () => {
+    expect(resolveShipState({ branch: null, base: "main", aheadCount: 3, hasPr: false })).toBe(
+      "detached",
+    );
+  });
+
+  it("on-base when the branch is the default branch", () => {
+    expect(resolveShipState({ branch: "main", base: "main", aheadCount: 3, hasPr: false })).toBe(
+      "on-base",
+    );
+  });
+
+  it("no-commits when aheadCount is 0", () => {
+    expect(resolveShipState({ ...base, aheadCount: 0 })).toBe("no-commits");
+  });
+
+  it("ready by default", () => {
+    expect(resolveShipState(base)).toBe("ready");
+  });
+
+  it("aheadCount null (unknown) falls through to ready", () => {
+    expect(resolveShipState({ ...base, aheadCount: null })).toBe("ready");
+  });
+
+  it("base null skips the on-base rule only", () => {
+    expect(resolveShipState({ branch: "main", base: null, aheadCount: 3, hasPr: false })).toBe(
+      "ready",
+    );
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3099,6 +3099,35 @@ export function branchPanelState({
   return pr ? "pr" : "no-pr";
 }
 
+/**
+ * The ship gate for the forge surface (BET-892): whether a "Create pull
+ * request" action even makes sense for the current branch, evaluated in this
+ * order — first match wins.
+ *
+ *  1. `has-pr`    — a PR is already open on this branch.
+ *  2. `detached`  — no branch (detached HEAD / non-git cwd).
+ *  3. `on-base`   — sitting on the repo default branch (no PR to open).
+ *  4. `no-commits`— no commits ahead of origin/<base> (nothing to ship).
+ *  5. `ready`     — ship away.
+ *
+ * `aheadCount === null` means "unknown" and falls through to `ready` (the API
+ * call is the backstop); `base === null` skips rule 3 only.
+ */
+export type ShipState = "on-base" | "detached" | "no-commits" | "ready" | "has-pr";
+
+export function resolveShipState(input: {
+  branch: string | null;
+  base: string | null;
+  aheadCount: number | null;
+  hasPr: boolean;
+}): ShipState {
+  if (input.hasPr) return "has-pr";
+  if (!input.branch) return "detached";
+  if (input.branch === input.base) return "on-base";
+  if (input.aheadCount === 0) return "no-commits";
+  return "ready";
+}
+
 // ---- Forge review pane (BET-792) -------------------------------------------
 
 // The line anchor a comment may attach to, in the forge-neutral shape the spec

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -951,8 +951,8 @@ async function defaultReadPrTemplate(cwd, deps = {}) {
  * Ship: push the current branch, then open a pull request for it. The human
  * gate (issue §4) lives ABOVE this — this function is the push+create step
  * that runs only after an explicit confirm. It is the ONE code path for
- * "open a PR", reused by the human ship action and any future automated one
- * (a background job reaches it as a draft and never merges).
+ * "open a PR", reused by the human ship action and any future automated one.
+ * PRs are always created as real (non-draft) pull requests (BET-892).
  *
  * Push uses gitPush (120s timeout — a real network push is killed by the
  * shared 10s `run()`), then createPullRequest with the given config.

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -611,21 +611,49 @@ async function listOpenPrs(adapter, repo) {
  */
 export async function pullRequestForCwd(cwd, deps = {}) {
   const currentBranch = deps.currentBranch ?? defaultCurrentBranch;
+  const getDefaultBranch = deps.getDefaultBranch ?? defaultGetDefaultBranch;
+  const runGit = deps.run ?? run;
 
   const ctx = await resolveForgeContext(cwd, deps);
-  if (ctx.error) return { ...EMPTY, error: ctx.error };
+
+  // Branch state for the ship gate (BET-892), resolved from the same context
+  // `resolveWriteContext` uses — NOT a second poll or a new RPC. Best-effort:
+  // anything that fails resolves to null. `base` is the repo default branch
+  // (from the forge API); `aheadCount` is commits ahead of origin/<base>.
+  const branch = ctx.error ? null : await currentBranch(cwd);
+  let base = null;
+  if (!ctx.error) {
+    try {
+      base = await getDefaultBranch({ adapter: ctx.adapter, repo: ctx.repo });
+    } catch {
+      base = null;
+    }
+  }
+  let aheadCount = null;
+  if (branch && base) {
+    try {
+      const { stdout } = await runGit("git", ["-C", cwd, "rev-list", "--count", `origin/${base}..${branch}`]);
+      aheadCount = Number(String(stdout ?? "").trim());
+      if (!Number.isFinite(aheadCount) || aheadCount < 0) aheadCount = null;
+    } catch {
+      aheadCount = null;
+    }
+  }
+  const shipState = { branch, base, aheadCount };
+
+  if (ctx.error) return { ...EMPTY, ...shipState, error: ctx.error };
   const { adapter, repo } = ctx;
 
   const { prs: prArr, stale, rateLimited } = await listOpenPrs(adapter, repo);
-  if (rateLimited) return { ...EMPTY, stale: true };
+  if (rateLimited) return { ...EMPTY, ...shipState, stale: true };
 
-  if (prArr.length === 0) return { ...EMPTY, stale };
+  if (prArr.length === 0) return { ...EMPTY, ...shipState, stale };
 
-  const branch = await currentBranch(cwd);
-  if (!branch) return { ...EMPTY, stale };
+  const branchName = await currentBranch(cwd);
+  if (!branchName) return { ...EMPTY, ...shipState, stale };
 
-  const candidate = prArr.find((p) => p.headRef === branch);
-  if (!candidate) return { ...EMPTY, stale };
+  const candidate = prArr.find((p) => p.headRef === branchName);
+  if (!candidate) return { ...EMPTY, ...shipState, stale };
 
   // Full normalised representation — getPullRequest populates reviewers + the
   // unresolved-thread count that the list endpoint cannot. Falls back to the
@@ -652,7 +680,7 @@ export async function pullRequestForCwd(cwd, deps = {}) {
     staleChecks = true;
   }
 
-  return { pr, checks, rollup: rollupChecks(checks), stale: staleChecks, error: null };
+  return { pr, checks, rollup: rollupChecks(checks), stale: staleChecks, error: null, ...shipState };
 }
 
 // ---- Inbox seed prompt (BET-795) ----------------------------------------
@@ -930,11 +958,11 @@ async function defaultReadPrTemplate(cwd, deps = {}) {
  * shared 10s `run()`), then createPullRequest with the given config.
  *
  * @param {string} cwd
- * @param {{ title: string, body?: string, base?: string, draft?: boolean }} input
+ * @param {{ title: string, body?: string, base?: string }} input
  * @param {object} [deps] injectable I/O
  * @returns {Promise<{ ok: true, pr: object, url: string } | { ok: false, error: string }>}
  */
-export async function shipPullRequest(cwd, { title, body = "", base, draft = false } = {}, deps = {}) {
+export async function shipPullRequest(cwd, { title, body = "", base } = {}, deps = {}) {
   const ctx = await resolveWriteContext(cwd, deps);
   if (ctx.error) return { ok: false, error: ctx.error };
   const gitPush = deps.gitPush ?? localGitPush;
@@ -952,7 +980,6 @@ export async function shipPullRequest(cwd, { title, body = "", base, draft = fal
       body,
       base: base ?? ctx.base,
       head: ctx.head,
-      draft: draft ?? false,
     });
     pr = res.data;
   } catch (e) {

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -289,6 +289,42 @@ test("pullRequestForCwd: the match is exact, not positional", async () => {
   assert.equal(r.pr.headRef, "feature/x");
 });
 
+test("pullRequestForCwd: supplies branch/base/aheadCount for the ship gate", async () => {
+  const r = await pullRequestForCwd("/repo", {
+    gitRemoteOrigin: async () => "https://github.com/acme/widget.git",
+    currentBranch: async () => "feature/x",
+    getDefaultBranch: async () => "main",
+    run: async (_cmd, args) => {
+      assert.deepEqual(args, ["-C", "/repo", "rev-list", "--count", "origin/main..feature/x"]);
+      return { stdout: "5\n", stderr: "" };
+    },
+    resolveToken: async () => ({ token: "ghp_t", source: "cli" }),
+    getAdapter: () => fakeAdapter({ prs: [] }),
+  });
+  assert.equal(r.pr, null);
+  assert.equal(r.error, null);
+  assert.equal(r.branch, "feature/x");
+  assert.equal(r.base, "main");
+  assert.equal(r.aheadCount, 5);
+});
+
+test("pullRequestForCwd: aheadCount is null when the rev-list call throws", async () => {
+  const r = await pullRequestForCwd("/repo", {
+    gitRemoteOrigin: async () => "https://github.com/acme/widget.git",
+    currentBranch: async () => "feature/x",
+    getDefaultBranch: async () => "main",
+    run: async () => {
+      throw new Error("origin/main not fetched locally");
+    },
+    resolveToken: async () => ({ token: "ghp_t", source: "cli" }),
+    getAdapter: () => fakeAdapter({ prs: [] }),
+  });
+  assert.equal(r.pr, null);
+  assert.equal(r.branch, "feature/x");
+  assert.equal(r.base, "main");
+  assert.equal(r.aheadCount, null);
+});
+
 test("getAdapter throws UnsupportedByForgeError for an unknown kind", async () => {
   const runtime = createForgeRuntime({ fetch: async () => json({}, 200, {}) });
   assert.throws(() => runtime.getAdapter("gitea", "t"), (e) => e.name === "UnsupportedByForgeError");
@@ -352,11 +388,18 @@ test("shipPullRequest: no forge → no_forge, never pushes", async () => {
   assert.equal(pushed.length, 0);
 });
 
-test("shipPullRequest: push (setUpstream) then createPullRequest with draft", async () => {
+test("shipPullRequest: push (setUpstream) then createPullRequest without a draft flag", async () => {
+  let createArg = null;
   const pushed = [];
-  const created = { ...OPEN_PR, number: 88, draft: true };
-  const adapter = writeAdapter({ created });
-  const r = await shipPullRequest("/repo", { title: "Forge seam", body: "B", base: "main", draft: true }, {
+  const created = { ...OPEN_PR, number: 88 };
+  const adapter = {
+    kind: "github",
+    createPullRequest: async (_repo, input) => {
+      createArg = input;
+      return { data: created, stale: false };
+    },
+  };
+  const r = await shipPullRequest("/repo", { title: "Forge seam", body: "B", base: "main" }, {
     ...SHIP_DEPS,
     getAdapter: () => adapter,
     gitPush: async (i) => { pushed.push(i); return { stdout: "", stderr: "" }; },
@@ -365,6 +408,13 @@ test("shipPullRequest: push (setUpstream) then createPullRequest with draft", as
   assert.equal(r.url, created.url);
   assert.equal(pushed.length, 1);
   assert.deepEqual(pushed[0], { cwd: "/repo", branch: "feature/forge", setUpstream: true });
+  assert.deepEqual(createArg, {
+    title: "Forge seam",
+    body: "B",
+    base: "main",
+    head: "feature/forge",
+  });
+  assert.equal("draft" in createArg, false, "no draft flag is sent to the adapter");
 });
 
 test("shipPullRequest: push failure surfaces a push-failed error, never creates", async () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -604,8 +604,9 @@ export type ForgeShipResult =
 
 // forge:ship-preview — the facts the confirm card needs BEFORE anything is
 // pushed: the head branch, the base branch (PR target), a best-effort count
-// of files changed on the branch, and a **drafted title + body** (design §4.5
-// step 1) the card seeds editable fields from. The body honours the repo's PR
+// of files changed on the branch, and a **resolved title + body** (design §4.5
+// step 1) the confirm card displays as plain text (BET-892 — the title/body
+// are edited on GitHub, not in the card). The body honours the repo's PR
 // template when one exists.
 export type ForgeShipPreviewInput = { cwd: string };
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -500,6 +500,13 @@ export type ForgePullRequestResult = {
   rollup: CheckRollup;
   stale: boolean;
   error: "no_forge" | "not_connected" | null;
+  // Branch state for the ship gate (BET-892), so the forge surface can decide
+  // whether a "Create pull request" action even makes sense BEFORE anything is
+  // clicked. `base` is the repo default branch (resolved box-side), `aheadCount`
+  // is commits ahead of `origin/<base>` (null when unknown / not fetched).
+  branch: string | null;
+  base: string | null;
+  aheadCount: number | null;
 };
 
 // A normalised forge review thread (the review pane's "incoming thread").
@@ -582,13 +589,13 @@ export type ForgeInboxResult = {
 // ----- Forge write path (BET-794) -----
 
 // forge:ship input — push the current branch then (only after the renderer's
-// human confirm card) open a pull request. `base` defaults to "main".
+// human confirm card) open a pull request. `base` defaults to "main". PRs are
+// always created as real (non-draft) pull requests (BET-892).
 export type ForgeShipInput = {
   cwd: string;
   title: string;
   body?: string;
   base?: string;
-  draft?: boolean;
 };
 
 export type ForgeShipResult =


### PR DESCRIPTION
## Summary

Makes **Create PR** the single primary action for the forge surface, deleting the draft-PR toggle and the editable ship form, gating the ship surface on branch state, and opening a created PR in the browser. Mostly removal.

### What changed

- **Draft-PR creation removed from the ship path.** `ShipConfirmCard` no longer has a draft toggle or editable title/body — it is a plain human gate rendering the resolved title as text (editable on GitHub seconds later). `shipPullRequest` no longer sends `draft`; `ForgeShipInput.draft` is gone. (The review-draft in `src/server/forge/draft.mjs` / `ReviewPane.tsx` is untouched.)
- **Ship gate (`resolveShipState` in `chatUtils.ts`).** One pure helper: `has-pr` → `detached` → `on-base` → `no-commits` → `ready`. The forge surface (the branch popover, BET-867 — the old `ForgeCard` was absorbed into it, so this issue's `ForgeCard` references map to `BranchPanel` in `SessionHeader.tsx`) now shows a single primary **Create pull request** when ready, "Nothing to ship — no commits ahead of `<base>`" when there are no commits, and no PR surface on the base branch / detached HEAD.
- **`branch` / `base` / `aheadCount` supplied by the existing `forge:pull-request` poll** (no new poll / RPC). `pullRequestForCwd` resolves the current branch, the repo default base (BET-891's `getDefaultBranch`), and commits ahead via `git rev-list --count origin/<base>..<head>`, each `null` on failure.
- **PR opens in the browser on success** in `confirmShip` via the existing `openExternal`.

### Base

`Base: origin/main @ 97a9b43d`

### Verification results

- PR branch (`multica/BET-892-create-pr-primary` @ `4903a5ae`):
  - typecheck: exit 0. Errors: none. log sha256: `4a728c595e55b9a3615554f64c306078e7118536ceeeae4a7e7f46d0346eaacf`
  - test: exit 0. Renderer (vitest) 2650 pass / 0 fail / 7 skip; server (node:test) 2007 pass / 0 fail. Failures: none. log sha256: `07cbda4ff7d5523d82b26202e16b83c6d11f18fb3c3817a6b8a60ecf2372eb9d`
- Base (`main` @ `97a9b43d`):
  - typecheck: exit 0. Errors: none. log sha256: `4a728c595e55b9a3615554f64c306078e7118536ceeeae4a7e7f46d0346eaacf`
  - test: exit 0. Renderer (vitest) 2641 pass / 0 fail / 7 skip; server (node:test) 2005 pass / 0 fail. Failures: none. log sha256: `0e162de0ae2e9dddb3cf91221ea4da3eeb170788b9a0decbb4fbb8228870ba84`
- **Conclusion:** 0 new failures on the PR branch; the delta is only additive tests (+9 renderer, +2 server) covering `resolveShipState` and the new `pullRequestForCwd` ship-state/branch fields.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
