### PR TITLE
feat(forge): generate PR title/body with the session's selected model, out of band (BET-893)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -600,13 +600,18 @@ export function ChatPanel({
 
   // Fetch the ship preview once (the branch popover's no-PR state shows
   // Base / Changes). Click-only surface ⇒ fetched on popover open, never
-  // polled, and not re-fetched if already loaded for this cwd.
+  // polled, and not re-fetched if already loaded for this cwd. The session's
+  // selected model + sessionId ride along (BET-893) so the box can generate
+  // the title/body with that model, out of band.
   const ensureShipPreview = useCallback(async () => {
     if (!cwd) return;
     setShipError(null);
     if (shipProposal) return;
     try {
-      const prev = await window.api.forgeShipPreview({ cwd });
+      const prev = await window.api.forgeShipPreview({
+        cwd,
+        ...(modelOverride ? { model: { providerID: modelOverride.providerID, modelID: modelOverride.modelID }, sessionId } : {}),
+      });
       if (prev.ok) {
         setShipProposal({ head: prev.head, base: prev.base, fileCount: prev.fileCount, title: prev.title ?? "", body: prev.body ?? "" });
       } else {
@@ -617,7 +622,7 @@ export function ChatPanel({
       setShipProposal(null);
       setShipError(e instanceof Error ? e.message : "could not prepare the pull request");
     }
-  }, [cwd, shipProposal]);
+  }, [cwd, shipProposal, modelOverride, sessionId]);
 
   // Confirm → push + create. Only reached after the human confirms the
   // ShipConfirmCard. The title/body come from shipProposal (the box's preview,

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -29,6 +29,8 @@
 
 import { rollupChecks, unsupportedByForge, repoKey as forgeRepoKey, repoKeyParts } from "../../shared/forge.mjs";
 import { run } from "../tmux.mjs";
+import { createSession as ocCreateSession, sendPrompt as ocSendPrompt, listMessages as ocListMessages, deleteSessionRaw as ocDeleteSessionRaw } from "../opencode.mjs";
+import { buildPrDescriptionPrompt, parsePrDescription, extractTranscriptText, extractAssistantText } from "./shipDescription.mjs";
 import { gitRemoteOrigin as localGitRemoteOrigin, detectForgeCli as localDetectForgeCli, gitPush as localGitPush, configGet as localConfigGet } from "../local.mjs";
 import { detectForgeWithHosts } from "./selfhost.mjs";
 import { resolveToken as authResolveToken } from "./auth.mjs";
@@ -842,6 +844,17 @@ export async function shipPreview(cwd, deps = {}) {
     // origin/<base> may not exist locally yet — best-effort empty.
   }
 
+  // BET-893: when the caller supplies the session's selected model, generate
+  // the title + body OUT OF BAND (a throwaway opencode session — never the
+  // user's own transcript) and use it. A generation failure NEVER surfaces as
+  // an error: we fall through to the deterministic draft below.
+  if (deps.model) {
+    const generated = await tryGeneratePrDescription(cwd, ctx, { base, files, deps });
+    if (generated) {
+      return { ok: true, head: ctx.head, base, fileCount: files.length, title: generated.title, body: generated.body };
+    }
+  }
+
   const title = await draftTitle(cwd, ctx.head, deps);
   const body = await draftBody(cwd, ctx.head, base, files, {
     ...deps,
@@ -849,6 +862,90 @@ export async function shipPreview(cwd, deps = {}) {
     prRepoKey: forgeRepoKey(ctx.forge),
   });
   return { ok: true, head: ctx.head, base, fileCount: files.length, title, body };
+}
+
+// Throwaway-session naming + poll cadence for the out-of-band generation.
+const PR_DESC_SESSION_TITLE = "manta: pr description";
+const PR_DESC_POLL_MS = 1000;
+const PR_DESC_DEADLINE_MS = 60000;
+
+/**
+ * Generate the PR title + body with the session's selected model, OUT OF BAND
+ * (BET-893). A throwaway opencode session — created WITHOUT a tmux window, so
+ * it never appears in the sidebar and never enters the user's own conversation
+ * — is created → prompted → polled → deleted. Everything opencode owns
+ * (createSession, sendPrompt, listMessages, deleteSessionRaw) is injectable as
+ * deps so tests never touch a live opencode.
+ *
+ * Returns `{ title, body }` on success, or null on ANY failure/timeout so the
+ * caller falls back to the deterministic draft. Never throws.
+ */
+async function tryGeneratePrDescription(cwd, ctx, { base, files, deps }) {
+  const {
+    model, sessionId,
+    run: runGit = run,
+    readPrTemplate = defaultReadPrTemplate,
+    createSession = ocCreateSession,
+    sendPrompt = ocSendPrompt,
+    listMessages = ocListMessages,
+    deleteSessionRaw = ocDeleteSessionRaw,
+    pollMs = PR_DESC_POLL_MS,
+    deadlineMs = PR_DESC_DEADLINE_MS,
+  } = deps;
+
+  let commits = [];
+  try {
+    const { stdout } = await runGit("git", ["-C", cwd, "log", "--pretty=%s", `origin/${base}..${ctx.head}`]);
+    commits = String(stdout ?? "").split("\n").map((l) => l.trim()).filter((l) => l.length > 0);
+  } catch {
+    // origin/<base>..<head> may not resolve locally — best-effort empty.
+  }
+
+  let transcript = "";
+  if (sessionId) {
+    try {
+      transcript = extractTranscriptText(await listMessages(sessionId));
+    } catch {
+      // Transcript is best-effort *why* context; generation still runs without it.
+    }
+  }
+
+  let template = "";
+  try {
+    template = (await readPrTemplate(cwd, deps)) ?? "";
+  } catch {
+    /* no template — the prompt just omits the template block */
+  }
+
+  const prompt = buildPrDescriptionPrompt({ head: ctx.head, base, files, commits, template, transcript });
+
+  let sid = null;
+  try {
+    const created = await createSession({ directory: cwd, title: PR_DESC_SESSION_TITLE });
+    sid = created?.id;
+    if (!sid) return null;
+    await sendPrompt({ sessionId: sid, text: prompt, model: { providerID: model.providerID, modelID: model.modelID } });
+
+    const deadline = Date.now() + deadlineMs;
+    while (Date.now() < deadline) {
+      await new Promise((resolve) => setTimeout(resolve, pollMs));
+      let detail;
+      try {
+        detail = extractAssistantText(await listMessages(sid));
+      } catch {
+        // Poll hiccup — keep waiting until the deadline.
+        continue;
+      }
+      if (detail) return parsePrDescription(detail);
+    }
+    return null; // deadline passed without a completed assistant turn
+  } catch {
+    return null;
+  } finally {
+    if (sid) {
+      try { await deleteSessionRaw(sid); } catch { /* best-effort */ }
+    }
+  }
 }
 
 // PR templates, in GitHub's usual discovery order. Resolved against the repo

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -30,7 +30,7 @@
 import { rollupChecks, unsupportedByForge, repoKey as forgeRepoKey, repoKeyParts } from "../../shared/forge.mjs";
 import { run } from "../tmux.mjs";
 import { createSession as ocCreateSession, sendPrompt as ocSendPrompt, listMessages as ocListMessages, deleteSessionRaw as ocDeleteSessionRaw } from "../opencode.mjs";
-import { buildPrDescriptionPrompt, parsePrDescription, extractTranscriptText, extractAssistantText } from "./shipDescription.mjs";
+import { buildPrDescriptionPrompt, parsePrDescription, extractTranscriptText, extractCompletedAssistantText } from "./shipDescription.mjs";
 import { gitRemoteOrigin as localGitRemoteOrigin, detectForgeCli as localDetectForgeCli, gitPush as localGitPush, configGet as localConfigGet } from "../local.mjs";
 import { detectForgeWithHosts } from "./selfhost.mjs";
 import { resolveToken as authResolveToken } from "./auth.mjs";
@@ -931,12 +931,18 @@ async function tryGeneratePrDescription(cwd, ctx, { base, files, deps }) {
       await new Promise((resolve) => setTimeout(resolve, pollMs));
       let detail;
       try {
-        detail = extractAssistantText(await listMessages(sid));
+        // Completion-aware: returns null while the assistant turn is STILL in
+        // flight, so we never capture partial, mid-stream text as the final
+        // PR description. (BET-893 reviewer Block — first poll at ~1s would
+        // otherwise hand back a truncated reply on a real model call.)
+        detail = extractCompletedAssistantText(await listMessages(sid));
       } catch {
         // Poll hiccup — keep waiting until the deadline.
         continue;
       }
-      if (detail) return parsePrDescription(detail);
+      if (detail === null) continue; // assistant turn still in flight
+      if (!detail) return null; // completed turn produced no text → fallback
+      return parsePrDescription(detail);
     }
     return null; // deadline passed without a completed assistant turn
   } catch {

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -618,6 +618,134 @@ test("shipPreview with a linked issue and no template still emits the close line
   assert.match(r.body, /^Closes #7\n\n/);
 });
 
+// ---- shipPreview PR-description generation (BET-893) ------------------------
+//
+// When deps.model + deps.sessionId are supplied, shipPreview tries to generate
+// the title/body out of band (a throwaway opencode session) and falls back to
+// the deterministic draft on ANY failure. All opencode calls are injected;
+// nothing touches a live opencode.
+
+// A fake `run` that serves the diff (files) and log (commits) git commands
+// shipPreview + the generator run, and nothing else.
+function genGitRun({ files = "a.ts\nb.ts\n", commits = "feat: one\ntest: two\n" } = {}) {
+  return async (_bin, args) => {
+    const joined = (args ?? []).join(" ");
+    if (joined.includes("diff --name-only")) return { stdout: files, stderr: "" };
+    if (joined.includes("log --pretty=%s")) return { stdout: commits, stderr: "" };
+    throw new Error(`unexpected git invocation: ${joined}`);
+  };
+}
+
+// Build Inject-PR-description deps. `sessionListing` is what the throwaway
+// session's listMessages poll returns; the calling session's transcript
+// (sessionId) returns a fixed "why" message. Collects the session ids passed
+// to deleteSessionRaw so tests can assert cleanup on both paths.
+function prDescDeps({
+  sessionListing,
+  throwOnCreate = false,
+  throwOnPrompt = false,
+  dead = false,
+} = {}) {
+  const deleted = [];
+  const created = [];
+  const conversationTranscript = [
+    { info: { role: "user" }, parts: [{ type: "text", text: "reviewed this branch already" }] },
+  ];
+  const deps = {
+    ...SHIP_DEPS,
+    currentBranch: async () => "feat/forge-seam",
+    model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    sessionId: "user-session-1",
+    run: genGitRun(),
+    createSession: async (opts) => {
+      created.push(opts);
+      if (throwOnCreate) throw new Error("create boom");
+      return { id: "pr-desc-throwaway" };
+    },
+    sendPrompt: async () => { if (throwOnPrompt) throw new Error("prompt boom"); },
+    listMessages: async (id) => {
+      if (dead) throw new Error("messages boom");
+      if (id === "user-session-1") return conversationTranscript;
+      return sessionListing;
+    },
+    deleteSessionRaw: async (id) => { deleted.push(id); },
+  };
+  return { deps, deleted, created };
+}
+
+test("shipPreview uses the session model's out-of-band generated title/body on success", async () => {
+  const { deps, deleted } = prDescDeps({
+    sessionListing: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Model written title\n\nModel written body.\n" }] }],
+  });
+  const r = await shipPreview("/repo", deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.title, "Model written title");
+  assert.equal(r.body, "Model written body.");
+  assert.deepEqual(deleted, ["pr-desc-throwaway"], "throwaway session deleted on success");
+});
+
+test("shipPreview falls back to the deterministic draft when generation throws", async () => {
+  const { deps, deleted } = prDescDeps({ throwOnPrompt: true });
+  const r = await shipPreview("/repo", deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.title, "Forge seam", "deterministic humanised-branch title");
+  assert.match(r.body, /^## What\n\nOpens feat\/forge-seam → main\./);
+  assert.deepEqual(deleted, ["pr-desc-throwaway"], "throwaway session deleted on the failure path");
+});
+
+test("shipPreview falls back when generation never completes (deadline)", async () => {
+  const { deps, deleted } = prDescDeps({
+    sessionListing: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "" }] }],
+  });
+  Object.assign(deps, { deadlineMs: 40, pollMs: 10 });
+  const r = await shipPreview("/repo", deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.title, "Forge seam");
+  assert.match(r.body, /^## What/);
+  assert.deepEqual(deleted, ["pr-desc-throwaway"]);
+});
+
+test("shipPreview falls back when the model reply is unparseable (null)", async () => {
+  const { deps, deleted } = prDescDeps({
+    sessionListing: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "   \n\n " }] }],
+  });
+  Object.assign(deps, { deadlineMs: 100, pollMs: 10 });
+  const r = await shipPreview("/repo", deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.title, "Forge seam");
+  assert.deepEqual(deleted, ["pr-desc-throwaway"], "throwaway session deleted when reply is unparseable");
+});
+
+test("shipPreview falls back when reading the throwaway session's messages throws", async () => {
+  const { deps } = prDescDeps({ dead: true });
+  Object.assign(deps, { deadlineMs: 40, pollMs: 10 });
+  const r = await shipPreview("/repo", deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.title, "Forge seam");
+});
+
+test("shipPreview falls back when session create returns no id", async () => {
+  const { deps, deleted } = prDescDeps({});
+  deps.createSession = async () => ({});
+  const r = await shipPreview("/repo", deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.title, "Forge seam");
+  assert.deepEqual(deleted, [], "no session existed → nothing to delete");
+});
+
+test("shipPreview's model generation is skipped entirely when no model is supplied", async () => {
+  const { deps } = prDescDeps({});
+  delete deps.model;
+  delete deps.sessionId;
+  let created = false;
+  deps.createSession = async () => { created = true; return { id: "x" }; };
+  const r = await shipPreview("/repo", deps);
+  assert.equal(created, false, "no throwaway session for a model-less preview");
+  assert.equal(r.ok, true);
+  assert.equal(r.title, "Forge seam", "byte-identical deterministic draft");
+});
+
+
 
 // ---- forgeDiffForCwd (BET-792) ---------------------------------------------
 

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -637,20 +637,31 @@ function genGitRun({ files = "a.ts\nb.ts\n", commits = "feat: one\ntest: two\n" 
 }
 
 // Build Inject-PR-description deps. `sessionListing` is what the throwaway
-// session's listMessages poll returns; the calling session's transcript
-// (sessionId) returns a fixed "why" message. Collects the session ids passed
-// to deleteSessionRaw so tests can assert cleanup on both paths.
+// session's listMessages poll returns (a fixed snapshot); `transcriptSeq` is an
+// OPTIONAL ordered list of snapshots served one per poll (last repeats) for
+// simulating a stream that grows partial→complete. `completed` is the unix-ms
+// stamp that makes an assistant turn read as finished (opencode sets it only
+// when the turn is fully done). The calling session's transcript (sessionId)
+// returns a fixed "why" message. Collects the session ids passed to
+// deleteSessionRaw so tests can assert cleanup on both paths.
+function assistantCompleted(parts, stamp) {
+  return {
+    info: { role: "assistant", time: { completed: stamp } },
+    parts: parts.map((text) => ({ type: "text", text })),
+  };
+}
 function prDescDeps({
   sessionListing,
+  transcriptSeq,
   throwOnCreate = false,
   throwOnPrompt = false,
   dead = false,
 } = {}) {
   const deleted = [];
-  const created = [];
   const conversationTranscript = [
     { info: { role: "user" }, parts: [{ type: "text", text: "reviewed this branch already" }] },
   ];
+  let polls = 0;
   const deps = {
     ...SHIP_DEPS,
     currentBranch: async () => "feat/forge-seam",
@@ -658,7 +669,6 @@ function prDescDeps({
     sessionId: "user-session-1",
     run: genGitRun(),
     createSession: async (opts) => {
-      created.push(opts);
       if (throwOnCreate) throw new Error("create boom");
       return { id: "pr-desc-throwaway" };
     },
@@ -666,22 +676,49 @@ function prDescDeps({
     listMessages: async (id) => {
       if (dead) throw new Error("messages boom");
       if (id === "user-session-1") return conversationTranscript;
+      if (transcriptSeq) {
+        const snap = transcriptSeq[Math.min(polls, transcriptSeq.length - 1)];
+        polls++;
+        return snap;
+      }
       return sessionListing;
     },
     deleteSessionRaw: async (id) => { deleted.push(id); },
   };
-  return { deps, deleted, created };
+  return { deps, deleted };
 }
 
 test("shipPreview uses the session model's out-of-band generated title/body on success", async () => {
   const { deps, deleted } = prDescDeps({
-    sessionListing: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Model written title\n\nModel written body.\n" }] }],
+    sessionListing: [assistantCompleted(["Model written title\n\nModel written body.\n"], 1000)],
   });
   const r = await shipPreview("/repo", deps);
   assert.equal(r.ok, true);
   assert.equal(r.title, "Model written title");
   assert.equal(r.body, "Model written body.");
   assert.deepEqual(deleted, ["pr-desc-throwaway"], "throwaway session deleted on success");
+});
+
+test("shipPreview waits for the assistant turn to complete — a partial-then-grows stream is not returned early", async () => {
+  // The reviewed Block: the first poll observes a PARTIAL assistant message
+  // (no info.time.completed — generation still streaming) and must NOT be
+  // returned as the final PR description. Only after a later poll shows the
+  // turn COMPLETE (time.completed set) do we parse it.
+  const { deps, deleted } = prDescDeps({
+    transcriptSeq: [
+      // poll 1: partial, in-flight (no completion stamp)
+      [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Model written t" }] }],
+      // poll 2: still streaming
+      [{ info: { role: "assistant" }, parts: [{ type: "text", text: "Model written title v" }] }],
+      // poll 3: complete
+      [assistantCompleted(["Model written title\n\nModel written body.\n"], 2000)],
+    ],
+  });
+  const r = await shipPreview("/repo", deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.title, "Model written title", "full completed text, not the partial");
+  assert.equal(r.body, "Model written body.");
+  assert.deepEqual(deleted, ["pr-desc-throwaway"]);
 });
 
 test("shipPreview falls back to the deterministic draft when generation throws", async () => {
@@ -695,7 +732,9 @@ test("shipPreview falls back to the deterministic draft when generation throws",
 
 test("shipPreview falls back when generation never completes (deadline)", async () => {
   const { deps, deleted } = prDescDeps({
-    sessionListing: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "" }] }],
+    // An assistant message that is STILL IN FLIGHT (no completion stamp) — the
+    // loop keeps polling and blows the 60s budget → fallback.
+    sessionListing: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "still streaming..." }] }],
   });
   Object.assign(deps, { deadlineMs: 40, pollMs: 10 });
   const r = await shipPreview("/repo", deps);
@@ -705,9 +744,19 @@ test("shipPreview falls back when generation never completes (deadline)", async 
   assert.deepEqual(deleted, ["pr-desc-throwaway"]);
 });
 
+test("shipPreview falls back when a completed turn produced no text", async () => {
+  const { deps, deleted } = prDescDeps({
+    sessionListing: [assistantCompleted([""], 1000)],
+  });
+  const r = await shipPreview("/repo", deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.title, "Forge seam");
+  assert.deepEqual(deleted, ["pr-desc-throwaway"]);
+});
+
 test("shipPreview falls back when the model reply is unparseable (null)", async () => {
   const { deps, deleted } = prDescDeps({
-    sessionListing: [{ info: { role: "assistant" }, parts: [{ type: "text", text: "   \n\n " }] }],
+    sessionListing: [assistantCompleted(["   \n\n "], 1000)],
   });
   Object.assign(deps, { deadlineMs: 100, pollMs: 10 });
   const r = await shipPreview("/repo", deps);

--- a/src/server/forge/shipDescription.mjs
+++ b/src/server/forge/shipDescription.mjs
@@ -8,6 +8,8 @@
 // turn the raw inputs into a prompt and to turn the model's raw reply into a
 // `{ title, body }`.
 
+import { isAssistantTurnComplete } from "../../shared/streamInterpretation.mjs";
+
 // Hard cap on how much transcript context we hand the model. The conversation
 // is the *why* behind the diff — that is the point — but a whole session is
 // too much. Oldest text drops first so the model sees the most recent context.
@@ -48,6 +50,26 @@ export function extractAssistantText(messages) {
     }
   }
   return out.join("");
+}
+
+// Whether the throwaway-generator transcript holds a COMPLETED assistant turn.
+// Unlike the shared `isAssistantTurnComplete` (which reads an EMPTY transcript
+// as "nothing running" = complete), the generator must NOT treat an empty
+// transcript as complete — there is a window right after create+prompt where
+// zero messages exist server-side yet, and treating that as "done" would fall
+// back prematurely. So we add an explicit non-empty guard on top.
+export function isPrGenerationComplete(messages) {
+  return Array.isArray(messages) && messages.length > 0 && isAssistantTurnComplete(messages);
+}
+
+/** The COMPLETED assistant reply text, or null while the turn is still in
+ *  flight. This is the completion-aware extractor the poll loop uses: it will
+ *  not hand back partial, mid-stream text. Returns "" when the transcript is
+ *  complete but produced no text.
+ */
+export function extractCompletedAssistantText(messages) {
+  if (!isPrGenerationComplete(messages)) return null;
+  return extractAssistantText(messages);
 }
 
 /** Truncate a transcript string to the character cap, dropping the OLDEST text

--- a/src/server/forge/shipDescription.mjs
+++ b/src/server/forge/shipDescription.mjs
@@ -1,0 +1,116 @@
+// shipDescription.mjs — pure helpers for generating a PR title + body with the
+// session's selected model, OUT OF BAND (BET-893).
+//
+// Everything in this module is pure: no I/O, no opencode, no network — so it
+// is unit-testable in isolation. `shipPreview` in index.mjs owns the I/O
+// (spinning up a throwaway opencode session, polling it, deleting it) and the
+// fallback to the deterministic `draftTitle` / `draftBody`; it is only here to
+// turn the raw inputs into a prompt and to turn the model's raw reply into a
+// `{ title, body }`.
+
+// Hard cap on how much transcript context we hand the model. The conversation
+// is the *why* behind the diff — that is the point — but a whole session is
+// too much. Oldest text drops first so the model sees the most recent context.
+export const TRANSCRIPT_CHAR_CAP = 8000;
+
+// Default: how many trailing transcript messages count as context.
+export const DEFAULT_LAST_MESSAGES = 20;
+
+/** Join the `text` parts of the LAST `last` messages of an opencode transcript
+ *  into one string (one part per line). Only `text` parts count — tool calls,
+ *  tool output and other part types are dropped. Oldest selected message first.
+ */
+export function extractTranscriptText(messages, { last = DEFAULT_LAST_MESSAGES } = {}) {
+  if (!Array.isArray(messages)) return "";
+  const selected = messages.slice(-last);
+  const lines = [];
+  for (const m of selected) {
+    for (const p of m?.parts ?? []) {
+      if (p?.type === "text" && typeof p.text === "string" && p.text) lines.push(p.text);
+    }
+  }
+  return lines.join("\n");
+}
+
+/** The raw concatenated assistant text from a transcript — used to detect that
+ *  the throwaway session's generation produced a reply. Returns `""` while no
+ *  assistant text is present (generation still running). The text is NOT
+ *  trimmed here so a whitespace-only reply stays distinguishable from "nothing
+ *  yet" — `parsePrDescription` (which trims the title line) decides whether a
+ *  non-empty reply is actually usable.
+ */
+export function extractAssistantText(messages) {
+  const out = [];
+  for (const m of Array.isArray(messages) ? messages : []) {
+    if (m?.info?.role !== "assistant") continue;
+    for (const p of m?.parts ?? []) {
+      if (p?.type === "text" && typeof p.text === "string") out.push(p.text);
+    }
+  }
+  return out.join("");
+}
+
+/** Truncate a transcript string to the character cap, dropping the OLDEST text
+ *  first (keep the newest tail). A string already under the cap is returned
+ *  unchanged.
+ */
+export function truncateTranscript(text, cap = TRANSCRIPT_CHAR_CAP) {
+  const s = String(text ?? "");
+  if (s.length <= cap) return s;
+  return s.slice(s.length - cap);
+}
+
+/** Build the prompt for the out-of-band PR-description generation.
+ *
+ *  The output contract is stated IN the prompt: first line = title (max 72
+ *  chars, no trailing period), then a blank line, then the markdown body. A
+ *  non-empty repo template is FILLED IN rather than replaced. The transcript
+ *  (the *why*) is truncated to the 8000-char cap, oldest first.
+ */
+export function buildPrDescriptionPrompt({ head, base, files, commits, template, transcript } = {}) {
+  const parts = [
+    "You are helping open a pull request for the branch currently open in Manta.",
+    "Write the pull request title and description for these changes.",
+    "Output contract: the FIRST line is the title (max 72 chars, no trailing period).",
+    "Then a BLANK line. Then the description body in markdown.",
+  ];
+
+  const tpl = String(template ?? "").trim();
+  if (tpl) {
+    parts.push("", "The repository has a pull-request template. FILL IT IN rather than replacing it:", "", tpl);
+  }
+
+  if (Array.isArray(commits) && commits.length) {
+    parts.push("", "Commits since the base branch:", ...commits.map((c) => `- ${c}`));
+  }
+
+  if (Array.isArray(files) && files.length) {
+    parts.push("", "Changed files:", ...files.map((f) => `- ${f}`));
+  }
+
+  const branch = [head, base].filter(Boolean).join(" → ");
+  if (branch) parts.push("", `Branch: ${branch}`);
+
+  const ctxText = truncateTranscript(transcript);
+  if (ctxText) {
+    parts.push("", "Relevant conversation transcript (context — the *why* behind these changes):", "", ctxText);
+  }
+
+  return parts.join("\n");
+}
+
+/** Parse the model's reply into a `{ title, body }` PR draft. The first non-empty
+ *  line is the title; everything after it is the body (trimmed). Trust the model
+ *  on length — a title over 72 chars is returned as-is, never silently truncated
+ *  (the prompt requested ≤72; parsing must not second-guess the model). Returns
+ *  null only for genuinely unparseable input (not a string, or an empty title).
+ */
+export function parsePrDescription(text) {
+  if (typeof text !== "string") return null;
+  const normalized = text.replace(/^\uFEFF/, "");
+  const lines = normalized.split(/\r?\n/);
+  const title = (lines[0] ?? "").trim();
+  if (!title) return null;
+  const body = lines.slice(1).join("\n").trim();
+  return { title, body };
+}

--- a/src/server/forge/shipDescription.test.mjs
+++ b/src/server/forge/shipDescription.test.mjs
@@ -1,0 +1,163 @@
+// shipDescription.test.mjs — pure helpers for the out-of-band PR-description
+// generation (BET-893). No opencode, no network, no filesystem: everything
+// here is string/array logic.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildPrDescriptionPrompt,
+  parsePrDescription,
+  extractTranscriptText,
+  extractAssistantText,
+  truncateTranscript,
+  TRANSCRIPT_CHAR_CAP,
+} from "./shipDescription.mjs";
+
+// ---------------------------------------------------------------------------
+// extractTranscriptText — last-N messages, text parts only
+// ---------------------------------------------------------------------------
+
+function msg(role, parts) {
+  return { info: { role }, parts };
+}
+
+test("extractTranscriptText joins text parts of the last N messages, oldest first", () => {
+  const messages = [
+    msg("user", [{ type: "text", text: "oldest" }]),
+    msg("user", [{ type: "text", text: "second" }]),
+    msg("assistant", [{ type: "text", text: "a\nmulti\nline" }]),
+  ];
+  assert.equal(extractTranscriptText(messages), "oldest\nsecond\na\nmulti\nline");
+});
+
+test("extractTranscriptText defaults to the last 20 messages", () => {
+  const messages = [];
+  for (let i = 0; i < 25; i++) messages.push(msg("user", [{ type: "text", text: `m${i}` }]));
+  const text = extractTranscriptText(messages);
+  assert.equal(text.split("\n").length, 20);
+  assert.ok(text.includes("m5"), "oldest kept message");
+  assert.ok(!text.includes("m0"), "messages older than the last 20 are dropped");
+});
+
+test("extractTranscriptText honours an explicit last count and skips non-text parts", () => {
+  const messages = [
+    msg("user", [{ type: "text", text: "a" }]),
+    msg("assistant", [
+      { type: "text", text: "b" },
+      { type: "tool", state: { status: "completed" }, tool: "bash", input: {}, output: "ignored" },
+      { type: "text", text: "c" },
+    ]),
+  ];
+  assert.equal(extractTranscriptText(messages, { last: 1 }), "b\nc");
+});
+
+test("extractTranscriptText is tolerant of non-array input", () => {
+  assert.equal(extractTranscriptText(undefined), "");
+  assert.equal(extractTranscriptText(null), "");
+  assert.equal(extractTranscriptText("nope"), "");
+});
+
+test("extractAssistantText returns only assistant text; empty when absent", () => {
+  const messages = [
+    msg("user", [{ type: "text", text: "question" }]),
+    msg("assistant", [{ type: "text", text: "  the answer  " }]),
+  ];
+  assert.equal(extractAssistantText(messages), "  the answer  ");
+  assert.equal(extractAssistantText([msg("user", [{ type: "text", text: "x" }])]), "");
+  assert.equal(extractAssistantText([]), "");
+});
+
+// ---------------------------------------------------------------------------
+// truncateTranscript + buildPrDescriptionPrompt
+// ---------------------------------------------------------------------------
+
+test("truncateTranscript keeps the newest tail, dropping oldest first", () => {
+  assert.equal(truncateTranscript("short"), "short");
+  const head = "X".repeat(100);
+  const tail = "Y".repeat(TRANSCRIPT_CHAR_CAP);
+  const out = truncateTranscript(head + tail);
+  assert.equal(out.length, TRANSCRIPT_CHAR_CAP);
+  assert.ok(out.startsWith("Y"), "keeps the newest tail");
+  assert.ok(!out.includes("X"), "oldest head dropped first");
+});
+
+test("buildPrDescriptionPrompt includes commits, files, and the template when present", () => {
+  const prompt = buildPrDescriptionPrompt({
+    head: "feat/forge-seam",
+    base: "main",
+    files: ["src/server/forge/index.mjs", "src/shared/types.ts"],
+    commits: ["feat(forge): add ship preview", "refactor(server): inject opencode deps"],
+    template: "## Summary\n\n${head} → ${base}",
+    transcript: "the why",
+  });
+  assert.ok(prompt.includes("feat(forge): add ship preview"));
+  assert.ok(prompt.includes("refactor(server): inject opencode deps"));
+  assert.ok(prompt.includes("src/server/forge/index.mjs"));
+  assert.ok(prompt.includes("src/shared/types.ts"));
+  assert.ok(prompt.includes("FILL IT IN"), "template instructs fill-in, not replace");
+  assert.ok(prompt.includes("the why"));
+  assert.ok(prompt.includes("feat/forge-seam → main"));
+  assert.ok(prompt.includes("FIRST line is the title"), "output contract stated");
+});
+
+test("buildPrDescriptionPrompt omits commits/files/template blocks when absent", () => {
+  const prompt = buildPrDescriptionPrompt({ head: "feat/x", base: "main" });
+  assert.ok(!prompt.includes("Commits since"));
+  assert.ok(!prompt.includes("Changed files"));
+  assert.ok(!prompt.includes("FILL IT IN"));
+  assert.ok(!prompt.includes("Relevant conversation transcript"));
+});
+
+test("buildPrDescriptionPrompt truncates the transcript at the 8000-char cap", () => {
+  const transcript = "x".repeat(TRANSCRIPT_CHAR_CAP + 5000);
+  const prompt = buildPrDescriptionPrompt({ head: "h", base: "b", transcript });
+  // The transcript's own tail appears; the overlong head is gone.
+  assert.ok(prompt.includes("x".repeat(500)), "tail of transcript kept");
+  assert.ok(prompt.length < (TRANSCRIPT_CHAR_CAP + 5000), "transcript truncated");
+});
+
+// ---------------------------------------------------------------------------
+// parsePrDescription
+// ---------------------------------------------------------------------------
+
+test("parsePrDescription: normal shape with a blank line", () => {
+  assert.deepEqual(parsePrDescription("Fix the login redirect\n\nBody here.\n- bullet"), {
+    title: "Fix the login redirect",
+    body: "Body here.\n- bullet",
+  });
+});
+
+test("parsePrDescription: missing blank line still parses (title first line, rest body)", () => {
+  assert.deepEqual(parsePrDescription("Fix the login redirect\nBody with no blank"), {
+    title: "Fix the login redirect",
+    body: "Body with no blank",
+  });
+});
+
+test("parsePrDescription: empty body is valid", () => {
+  assert.deepEqual(parsePrDescription("Just a title\n\n"), {
+    title: "Just a title",
+    body: "",
+  });
+});
+
+test("parsePrDescription: a title over 72 chars is still returned, never silently truncated", () => {
+  const longTitle = "This is an extremely long pull request title that absolutely exceeds seventy two characters";
+  assert.ok(longTitle.length > 72);
+  const out = parsePrDescription(`${longTitle}\n\nBody`);
+  assert.equal(out.title, longTitle);
+  assert.equal(out.body, "Body");
+});
+
+test("parsePrDescription: garbage input returns null", () => {
+  assert.equal(parsePrDescription(null), null);
+  assert.equal(parsePrDescription(undefined), null);
+  assert.equal(parsePrDescription(42), null);
+  assert.equal(parsePrDescription(""), null);
+  assert.equal(parsePrDescription("   \n  "), null);
+});
+
+test("parsePrDescription: a BOM is tolerated and blank leading lines fold into the title", () => {
+  const out = parsePrDescription("\uFEFFTidy title\n\nBody");
+  assert.deepEqual(out, { title: "Tidy title", body: "Body" });
+});

--- a/src/server/forge/shipDescription.test.mjs
+++ b/src/server/forge/shipDescription.test.mjs
@@ -9,6 +9,8 @@ import {
   parsePrDescription,
   extractTranscriptText,
   extractAssistantText,
+  extractCompletedAssistantText,
+  isPrGenerationComplete,
   truncateTranscript,
   TRANSCRIPT_CHAR_CAP,
 } from "./shipDescription.mjs";
@@ -65,6 +67,40 @@ test("extractAssistantText returns only assistant text; empty when absent", () =
   assert.equal(extractAssistantText(messages), "  the answer  ");
   assert.equal(extractAssistantText([msg("user", [{ type: "text", text: "x" }])]), "");
   assert.equal(extractAssistantText([]), "");
+});
+
+// --- completion-aware extractor (BET-893 reviewer Block) ---------------------
+
+function assistantMsg(text, { completed } = {}) {
+  return {
+    info: { role: "assistant", ...(completed ? { time: { completed } } : {}) },
+    parts: [text ? { type: "text", text } : { type: "text", text: "" }],
+  };
+}
+
+test("isPrGenerationComplete requires a non-empty transcript AND a completed assistant turn", () => {
+  // Empty transcript must NOT read as complete — the window right after
+  // create+prompt has zero messages server-side yet (the shared helper reads
+  // empty as "complete", which would fall back prematurely here).
+  assert.equal(isPrGenerationComplete([]), false);
+  assert.equal(isPrGenerationComplete(undefined), false);
+  // A user message only → turn in flight.
+  assert.equal(isPrGenerationComplete([msg("user", [{ type: "text", text: "go" }])]), false);
+  // Assistant message without a completion stamp → still in flight (partial).
+  assert.equal(isPrGenerationComplete([assistantMsg("partial text")]), false);
+  // Assistant message WITH info.time.completed → complete.
+  assert.equal(isPrGenerationComplete([assistantMsg("final", { completed: 12345 })]), true);
+});
+
+test("extractCompletedAssistantText returns null while the turn is in flight, text only once complete", () => {
+  // Partial / still-streaming assistant text is NOT returned — the fix for the
+  // reviewed Block (never capture a truncated reply as the final description).
+  assert.equal(extractCompletedAssistantText([assistantMsg("truncated...")]), null);
+  assert.equal(extractCompletedAssistantText([msg("user", [{ type: "text", text: "go" }])]), null);
+  // Once complete, returns the assistant text.
+  assert.equal(extractCompletedAssistantText([assistantMsg("Full title\n\nFull body", { completed: 1 })]), "Full title\n\nFull body");
+  // Complete but no text → "" (the caller falls back).
+  assert.equal(extractCompletedAssistantText([assistantMsg("", { completed: 1 })]), "");
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -371,6 +371,8 @@ export function buildHandlers({
     },
     "forge:ship-preview": async (input) => {
       const cwd = typeof input === "object" && input !== null ? input.cwd : "";
+      const model = typeof input === "object" && input !== null ? input.model : undefined;
+      const sessionId = typeof input === "object" && input !== null ? input.sessionId : undefined;
       // Seed the PR body with a "Closes #N" line from the originating issue
       // (BET-871): resolve the session's window from the shipping cwd and read
       // the `@manta-forge-issue` user-option the inbox's Start-a-session flow
@@ -379,6 +381,12 @@ export function buildHandlers({
       // byte-identical body. No second session-link store — the tmux window IS
       // the app session.
       return shipPreview(cwd, {
+        model,
+        sessionId,
+        createSession: oc.createSession,
+        sendPrompt: oc.sendPrompt,
+        listMessages: oc.listMessages,
+        deleteSessionRaw: oc.deleteSessionRaw,
         linkedIssue: async () => {
           if (!cwd) return null;
           const win = await tmux.findWindowForCwd(cwd);

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -608,7 +608,17 @@ export type ForgeShipResult =
 // step 1) the confirm card displays as plain text (BET-892 — the title/body
 // are edited on GitHub, not in the card). The body honours the repo's PR
 // template when one exists.
-export type ForgeShipPreviewInput = { cwd: string };
+//
+// BET-893: when the caller supplies the session's selected `model` (and the
+// calling `sessionId` for transcript context), the box generates the title +
+// body with that model OUT OF BAND — a throwaway opencode session, never the
+// user's own conversation. With no model, the box falls back to the
+// deterministic draft (tip-commit title / template-or-files body).
+export type ForgeShipPreviewInput = {
+  cwd: string;
+  model?: { providerID: string; modelID: string };
+  sessionId?: string;
+};
 
 export type ForgeShipPreviewResult =
   | { ok: true; head: string; base: string; fileCount: number; title: string; body: string }


### PR DESCRIPTION
## Summary

When the user ships a feature branch from a chat session on the box, the PR title/body is now written by the **session's selected model**, generated **out of band** — never appearing in the user's own conversation.

- The confirm card still shows the resolved title/body as plain text (BET-892 shape); the box now generates them with `deps.model` when supplied.
- Generation runs in a **throwaway opencode session** (`create → prompt → poll → delete`, `finally` on every path). No tmux window is stamped, so it never shows in the sidebar; the user's own transcript is never touched.
- The prompt carries the *why*: the last 20 messages of the calling session's transcript (text parts only, truncated to 8000 chars, oldest dropped first), plus commits, changed files, and the repo PR template (which is FILLED IN, not replaced).
- **All four opencode calls (`createSession`, `sendPrompt`, `listMessages`, `deleteSessionRaw`) are injectable deps**, alongside the existing `run` and `readPrTemplate`, so tests never touch a live opencode.

### Fallback — untouched, never an error

`draftTitle` / `draftBody` / `defaultReadPrTemplate` are **kept** as the deterministic fallback. Generation failure **never** surfaces as an error: `shipPreview` always returns a usable title/body. Falls back when any of:

- no model supplied on the input
- session create / prompt / message read throws
- no completed assistant text within the 60s deadline
- `parsePrDescription` returns `null`

### New pure module

`src/server/forge/shipDescription.mjs` — `buildPrDescriptionPrompt`, `parsePrDescription`, plus `extractTranscriptText` / `extractAssistantText` / `truncateTranscript`. All pure and unit-tested; `shipPreview` in `index.mjs` owns the I/O + fallback.

## Verification results

- `npm run typecheck` — **pass**
- `npm test` — **2029 pass, 0 fail** (includes 15 new `shipDescription` tests + 9 new `shipPreview` generation/fallback tests)
- `git diff --stat origin/main...HEAD` — only the intended files:
  - `src/server/forge/shipDescription.mjs` (new)
  - `src/server/forge/shipDescription.test.mjs` (new)
  - `src/server/forge/index.mjs` (+ out-of-band orchestration)
  - `src/server/forge/index.test.mjs`
  - `src/server/rpc.mjs` (`forge:ship-preview` wires injectable opencode deps)
  - `src/shared/types.ts` (`ForgeShipPreviewInput` + model/sessionId)
  - `src/renderer/ChatPanel.tsx` (passes model + sessionId)

## Test-important behaviors (as specified)

- A title over 72 chars is **returned as-is** by `parsePrDescription` — the model is trusted, never silently truncated (explicitly asserted).
- The throwaway session is deleted on **both** success and failure paths (asserted).
- With generation disabled or failing, behaviour is **byte-identical** to today's deterministic draft (asserted: no throwaway session when no model is supplied).

**Base: origin/main @ `7fb5b7b7`**
