### PR TITLE
fix(ios): count turn timers from the box-reported start (BET-896)

### DIFF
--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -486,12 +486,9 @@ final class ChatSessionStore: ObservableObject {
             streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
             liveTailRowID = streamingTailID
         }
-        // runningSince tracks the turn that's running for the header timer.
-        if running {
-            if runningSince == nil { runningSince = Date() }
-        } else {
-            runningSince = nil
-        }
+        // Prefer the box's turn start; keep the optimistic stamp `send()` set
+        // until the first frame confirms it; fall back only if neither exists.
+        runningSince = running ? (s.runningSince ?? runningSince ?? Date()) : nil
 
         // The session just went idle (stream fold set `running = false`): any
         // queued prompt may now be sent. Guard-based, so firing on whichever

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -67,6 +67,8 @@ struct MantaSessionStreamState: Equatable, Sendable {
     /// with its paragraphs shuffled.
     var chunks: [StreamTextChunk] = []
     var running: Bool?
+    /// When the running turn started, as reported by the box. Nil when idle.
+    var runningSince: Date?
     var turnComplete: Bool?
     var context: StreamContextPayload?
     var cache: StreamCachePayload?
@@ -141,6 +143,15 @@ struct MantaSessionStreamState: Equatable, Sendable {
 // MARK: - Pure routing (box `stream.*` subs -> session state)
 
 enum MantaStreamRouter {
+    /// Box-reported start wins; an older box that omits it keeps whatever we
+    /// already had, and only a turn we have never seen a start for falls back
+    /// to the local clock.
+    private static func resolveRunningSince(running: Bool, since: Double?, current: Date?) -> Date? {
+        guard running else { return nil }
+        if let since { return Date(timeIntervalSince1970: since / 1000) }
+        return current ?? Date()
+    }
+
     /// Apply one frame to a session's state. Pure so the mapping is testable.
     static func applying(_ frame: MantaStreamFrame, to state: MantaSessionStreamState?) -> MantaSessionStreamState {
         guard frame.kind == "stream", let sub = frame.sub else {
@@ -155,6 +166,7 @@ enum MantaStreamRouter {
         case "running":
             if let p = try? frame.decodedPayload(StreamRunningPayload.self) {
                 s.running = p.running
+                s.runningSince = resolveRunningSince(running: p.running, since: p.since, current: s.runningSince)
                 // A new turn clears any stale error surfaced by the previous one.
                 if p.running { s.sessionError = nil }
             }
@@ -169,6 +181,7 @@ enum MantaStreamRouter {
                 // life of the session, so the working row and session-list timer
                 // never stopped.
                 s.running = p.running
+                s.runningSince = resolveRunningSince(running: p.running, since: p.since, current: s.runningSince)
             }
             // A finished turn has no running tools; the canonical refetch now
             // owns them as step rows, so drop the live map to bound memory

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -157,12 +157,14 @@ struct StreamFlushPayload: Codable, Equatable, Sendable {
 /// `sub: "running"` — derived from `session.status` (busy/tworking/retry).
 struct StreamRunningPayload: Codable, Equatable, Sendable {
     var running: Bool
+    var since: Double?          // epoch ms; absent on an older box
 }
 
 /// `sub: "turnComplete"` — emitted by `message.updated`/`session.idle`.
 struct StreamTurnCompletePayload: Codable, Equatable, Sendable {
     var complete: Bool
     var running: Bool
+    var since: Double?
 }
 
 /// `sub: "truncation"` — classifyFinish result, box-classified.

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -63,14 +63,10 @@ final class SessionListStore: ObservableObject {
     @Published private(set) var hapticsEnabled = true
     /// pinID -> pending delete being held within its 5 s undo window.
     @Published private(set) var pendingDeletes: [String: PendingDelete] = [:]
-    /// opencodeSessionID -> when its turn started running (drives the §7.1
-    /// timer slot while running).
-    @Published private(set) var runningSince: [String: Date] = [:]
 
     private let api: MantaAPIClient
     private let mutations: SessionListMutationAPI
     private let eventStore: MantaEventStore
-    private var cancellables: Set<AnyCancellable> = []
     private var attentionSessions: Set<String> = []
     private var modelLabels: [String: String] = [:]
     /// opencodeSessionID → the model-authored progress label for a working turn
@@ -92,26 +88,12 @@ final class SessionListStore: ObservableObject {
             self?.trackAttention(frame: frame)
             self?.trackProgress(frame: frame)
         }
-        eventStore.$sessionStates
-            .receive(on: DispatchQueue.main)
-            .sink { [weak self] _ in self?.trackRunning(now: Date()) }
-            .store(in: &cancellables)
     }
 
-    private func trackRunning(now: Date) {
-        var changed = false
-        for (sid, state) in eventStore.sessionStates {
-            if state.running == true {
-                if runningSince[sid] == nil {
-                    runningSince[sid] = now
-                    changed = true
-                }
-            } else if runningSince[sid] != nil {
-                runningSince.removeValue(forKey: sid)
-                changed = true
-            }
-        }
-        if changed { objectWillChange.send() }
+    /// When this window's running turn started, as reported by the box.
+    func runningStart(for window: MantaWindow) -> Date? {
+        guard let sid = window.opencodeSessionId else { return nil }
+        return eventStore.sessionStates[sid]?.runningSince
     }
 
     /// Re-fetch the list (pull-to-refresh / foreground / reconnect / after
@@ -438,7 +420,6 @@ final class SessionListStore: ObservableObject {
         loadError = nil
         loadedOnce = false
         pendingDeletes = [:]
-        runningSince = [:]
         attentionSessions = []
         modelLabels = [:]
         pinnedWindows = []

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -325,7 +325,7 @@ struct SessionListView: View {
 
     private func timerText(_ window: MantaWindow, now: Date) -> String? {
         let status = store.rowStatus(for: window)
-        guard status.running, let sid = window.opencodeSessionId, let since = store.runningSince[sid] else {
+        guard status.running, let since = store.runningStart(for: window) else {
             return nil
         }
         return SessionTimerFormat.elapsed(now.timeIntervalSince(since))
@@ -351,7 +351,7 @@ struct SessionListView: View {
     }
 
     private func runningDuration(of window: MantaWindow) -> String {
-        guard let sid = window.opencodeSessionId, let since = store.runningSince[sid] else {
+        guard let since = store.runningStart(for: window) else {
             return SessionTimerFormat.runningDuration(0)
         }
         return SessionTimerFormat.runningDuration(Date().timeIntervalSince(since))

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -309,6 +309,61 @@ final class MantaEventStreamRouterTests: XCTestCase {
         XCTAssertEqual(state.turnComplete, true)
     }
 
+    // MARK: - Turn-start stamp (BET-896)
+
+    /// The box stamps `since` (epoch ms) on the idle->busy edge; the router
+    /// converts it to a Date (ms -> seconds) that the UI counts from.
+    func testRunningFrameWithSinceProducesMatchingDate() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true,"since":1700000000000}}"#),
+            to: state
+        )
+        XCTAssertEqual(state.runningSince, Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    /// An older box omits `since`; a running:true frame must keep whatever we
+    /// already had rather than restart the clock.
+    func testRunningFrameWithoutSinceKeepsExistingStamp() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state.runningSince = Date(timeIntervalSince1970: 1234)
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#),
+            to: state
+        )
+        XCTAssertEqual(state.runningSince, Date(timeIntervalSince1970: 1234))
+    }
+
+    /// running:true with neither a box stamp nor an existing value falls back
+    /// to the local clock so a timer still shows.
+    func testRunningFrameWithoutSinceAndNoExistingFallsBackToNow() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#),
+            to: state
+        )
+        XCTAssertNotNil(state.runningSince)
+    }
+
+    /// running:false on either sub clears the stamp back to nil.
+    func testRunningFalseClearsStamp() throws {
+        var state = MantaSessionStreamState(sessionId: "ses_1")
+        state.runningSince = Date(timeIntervalSince1970: 5000)
+        state = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":false,"since":null}}"#),
+            to: state
+        )
+        XCTAssertNil(state.runningSince)
+
+        var state2 = MantaSessionStreamState(sessionId: "ses_1")
+        state2.runningSince = Date(timeIntervalSince1970: 5000)
+        state2 = MantaStreamRouter.applying(
+            try MantaStreamFrame.parse(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses_1","payload":{"complete":true,"running":false,"since":null}}"#),
+            to: state2
+        )
+        XCTAssertNil(state2.runningSince)
+    }
+
     func testNonStreamFrameLeavesStateUntouched() throws {
         let original = MantaSessionStreamState(sessionId: "ses_1")
         let status = try MantaStreamFrame.parse(#"{"kind":"status","payload":[]}"#)

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -87,6 +87,7 @@ function newSessionState() {
     lastCompleted: null,
     cachedTokens: 0,
     running: false,
+    runningSince: null,        // epoch ms when the running turn started (idle->busy edge)
     todos: null,               // liveTodos (todo.updated) ; null = not seen
     msgByMsgId: new Map(),     // messageID -> minimal message for turn detection
     userTurnCount: 0,
@@ -261,6 +262,20 @@ export function createStreamInterpreter({
     publish({ kind: "stream", sub, sessionId: sid, payload });
   }
 
+  // The single place `running` changes. Stamps the idle->busy EDGE only, so a
+  // mid-turn status re-emit cannot restart the clock, and clears the stamp
+  // wherever the turn stops.
+  function setRunning(st, running) {
+    if (running && !st.running) st.runningSince = now();
+    if (!running) st.runningSince = null;
+    st.running = running;
+  }
+
+  function emitTurnComplete(sid, st, complete) {
+    setRunning(st, st.running && !complete);
+    emit(sid, "turnComplete", { complete, running: st.running, since: st.runningSince });
+  }
+
   function interpret(evt) {
     if (!evt || typeof evt !== "object" || typeof evt.type !== "string") return;
     const sid = evt.properties?.sessionID;
@@ -417,7 +432,7 @@ export function createStreamInterpreter({
               }
             }
           }
-          emit(sid, "turnComplete", { complete, running: st.running && !complete });
+          emitTurnComplete(sid, st, complete);
           return;
         }
         // `properties.info` IS the message info, not a `{info}` wrapper —
@@ -427,7 +442,7 @@ export function createStreamInterpreter({
         const wrapped = msg?.info ? msg : msg ? { info: msg } : null;
         if (wrapped?.info?.id) st.msgByMsgId.set(wrapped.info.id, wrapped);
         const complete = isAssistantTurnComplete([...st.msgByMsgId.values()]);
-        emit(sid, "turnComplete", { complete, running: st.running && !complete });
+        emitTurnComplete(sid, st, complete);
         return;
       }
       case "session.status": {
@@ -438,18 +453,17 @@ export function createStreamInterpreter({
         // retry is a live turn for the renderer's running indicator (matches
         // pre-S1b renderer semantics) — the box is the single source of truth,
         // so it must report the same value the renderer's raw handler does.
-        st.running = type === "busy" || type === "working" || type === "retry";
+        setRunning(st, type === "busy" || type === "working" || type === "retry");
         // `type` is ADDITIVE, not the indicator: `running` stays the single
         // source of truth for the running boolean, while `type` carries the
         // raw "busy" | "working" | "retry" (or null) so a thin client (iOS)
         // can distinguish a retry from a plain busy spinner without changing
         // what desktop already reads. Desktop ignores the new field.
-        emit(sid, "running", { running: st.running, type });
+        emit(sid, "running", { running: st.running, type, since: st.runningSince });
         return;
       }
       case "session.idle": {
-        st.running = false;
-        emit(sid, "turnComplete", { complete: true, running: false });
+        emitTurnComplete(sid, st, true);
         return;
       }
       case "session.error": {
@@ -461,12 +475,11 @@ export function createStreamInterpreter({
         const err = evt.properties?.error;
         const name = typeof err?.name === "string" ? err.name : null;
         if (name === "MessageAbortedError") return;
-        st.running = false;
         const message =
           typeof err?.data?.message === "string" ? err.data.message :
           typeof err?.message === "string" ? err.message : "The turn failed.";
         emit(sid, "sessionError", { name, message });
-        emit(sid, "turnComplete", { complete: true, running: false });
+        emitTurnComplete(sid, st, true);
         return;
       }
       case "session.next.step.ended": {

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -343,6 +343,93 @@ test("session.status retry reports running true and carries type retry (parity w
   assert.equal(ev.payload.type, "retry");
 });
 
+// BET-896: the box stamps the idle->busy edge so the phone can count from the
+// real turn start instead of when the phone noticed. `since` is epoch ms or
+// null, and is never restarted by a mid-turn re-emit.
+
+test("session.status busy emits a running frame with a non-null since", () => {
+  const { interp, events } = make(42_000);
+  interp.interpret({
+    type: "session.status",
+    properties: { sessionID: SID, status: { type: "busy" } },
+  });
+  const ev = events.find((e) => e.sub === "running");
+  assert.ok(ev);
+  assert.equal(ev.payload.running, true);
+  assert.equal(ev.payload.since, 42_000, "stamped from the injectable now()");
+});
+
+test("a second busy while already running emits the SAME since (clock not restarted)", () => {
+  let clock = 100_000;
+  const events = [];
+  const interp = createStreamInterpreter({
+    publish: (e) => events.push(e),
+    now: () => clock,
+  });
+  const busy = () =>
+    interp.interpret({
+      type: "session.status",
+      properties: { sessionID: SID, status: { type: "busy" } },
+    });
+  busy();
+  clock = 300_000; // the turn "has been running" for 200s by the second status
+  busy();
+  const frames = events.filter((e) => e.sub === "running");
+  assert.equal(frames.length, 2);
+  assert.equal(frames[0].payload.since, 100_000);
+  assert.equal(frames[1].payload.since, 100_000, "edge stamp survives a re-emit");
+});
+
+test("session.idle emits turnComplete with running:false and since:null", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "session.status",
+    properties: { sessionID: SID, status: { type: "busy" } },
+  });
+  interp.interpret({ type: "session.idle", properties: { sessionID: SID } });
+  const ev = events.find((e) => e.sub === "turnComplete");
+  assert.ok(ev);
+  assert.equal(ev.payload.complete, true);
+  assert.equal(ev.payload.running, false);
+  assert.equal(ev.payload.since, null, "the stamp is cleared when the turn stops");
+});
+
+test("session.error (non-abort) emits turnComplete with since:null", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "session.error",
+    properties: {
+      sessionID: SID,
+      error: { name: "ApiError", message: "boom" },
+    },
+  });
+  const ev = events.find((e) => e.sub === "turnComplete");
+  assert.ok(ev);
+  assert.equal(ev.payload.running, false);
+  assert.equal(ev.payload.since, null);
+});
+
+test("a message.updated mid-turn emits turnComplete with running:true and the original since", () => {
+  const { interp, events } = make(77_000);
+  interp.interpret({
+    type: "session.status",
+    properties: { sessionID: SID, status: { type: "busy" } },
+  });
+  // An assistant message with no completion time is mid-turn (complete:false).
+  interp.interpret({
+    type: "message.updated",
+    properties: {
+      sessionID: SID,
+      info: { id: "msg1", role: "assistant", sessionID: SID, time: { created: 1 } },
+    },
+  });
+  const ev = events.find((e) => e.sub === "turnComplete");
+  assert.ok(ev);
+  assert.equal(ev.payload.complete, false);
+  assert.equal(ev.payload.running, true, "still running mid-turn");
+  assert.equal(ev.payload.since, 77_000, "original edge stamp still attached");
+});
+
 // ---------------------------------------------------------------------------
 // Real-wire regression tests.
 //


### PR DESCRIPTION
BET-896 — iOS + box: turn timers must count from the real turn start, not from when the phone noticed.

## What changed

The turn-start timestamp now originates on the box (which has watched the session the whole time), rides the interpreted stream, and is measured against on the phone.

**Box** (`src/server/streamInterp.mjs`):
- `newSessionState()` gains `runningSince` next to `running`.
- Two helpers `setRunning` / `emitTurnComplete` are the single place `running` changes and the single emitter of `turnComplete`. The idle→busy EDGE stamps `since` (epoch ms); a mid-turn re-emit never restarts the clock; stopping clears it.
- `session.status` now emits `{ running, type, since }`; both `message.updated` turnComplete sites, `session.idle`, and `session.error` route through `emitTurnComplete`.
- Grep-verified: zero `st.running = ` outside `setRunning`, zero literal `emit(sid, "turnComplete", …)` outside `emitTurnComplete`.
- 5 new tests in `src/server/streamInterp.test.mjs` (incl. clock-not-restarted driven via the injectable `now`).

**iOS** — `since` is optional so an older box keeps working:
- `MantaStreamModels.swift`: `since: Double?` added to `StreamRunningPayload` and `StreamTurnCompletePayload`.
- `MantaEventStore.swift`: `MantaSessionStreamState.runningSince: Date?`; one `MantaStreamRouter.resolveRunningSince(running:since:current:)` rule called from both the `running` and `turnComplete` cases (box start wins → keep existing → local-clock fallback).
- `SessionListStore.swift`: redundant `runningSince` bookkeeping deleted (property, `trackRunning`, the `$sessionStates` sink, the `cancellables` set, and the `resetForBoxChange` line) → replaced by a `runningStart(for:)` read-through accessor. **Net −19 lines.**
- `SessionListView.swift`: `timerText` and `runningDuration` now read `store.runningStart(for: window)`.
- `ChatSessionStore.swift`: fold block prefers the box's `s.runningSince`; keeps the optimistic `send()` stamp until the first frame confirms; falls back to local clock.
- 4 new router tests in `MantaEventStreamTests.swift`.

## Verified locally (Linux box)

- `npm run typecheck`: exit 0, errors none.
- `npm test`: 2012 pass / 0 fail / 0 skip (includes the 5 new `streamInterp` cases; `SessionListStore`/Swift are not covered by `npm test`).
- Greps from acceptance (`st.running = ` and literal `turnComplete` emit) pass.

## Not executed here (Mac/toolchain)

- Xcode build + Swift unit tests: I run on a Linux box with no Apple toolchain; these need the Mac (or Codemagic CI). Swift source + tests follow the ticket's prescribed code exactly.
- Manual force-quit / background persistence checks on a real box: Apple-side, not run here.

## Notes

- `streamInterp.mjs` nets **+13 lines** (helpers added at the prescribed single choke point absorb the collapsed per-site assignments; the redundancy removed nets against that). `SessionListStore.swift` nets **−19**. I kept the two prescribed helpers exactly as specified rather than compressing them further.
- Re-render after deleting the session-list sink: the view holds `MantaEventStore` as an `@EnvironmentObject` and `sessionStates` is `@Published`, so it still re-renders when a session goes busy — to be confirmed by the manual check on a real box.

Base: origin/main @ 7fb5b7b7
