### PR TITLE
Sidebar: nested background-job tree connector is broken between siblings

### DIFF
--- a/docs/screens/redesign-spec.html
+++ b/docs/screens/redesign-spec.html
@@ -1219,7 +1219,8 @@ table.spec tr:last-child td{border-bottom:0}
 
 <style>
 .srow.child{padding-left:26px;position:relative}
-.srow.child::after{content:"";position:absolute;left:13px;top:0;bottom:50%;width:1px;background:var(--border)}
+.srow.child::after{content:"";position:absolute;left:13px;top:-4px;bottom:0;width:1px;background:var(--border)}
+.srow.child:last-child::after{bottom:50%}
 .srow.child::before{content:"";position:absolute;left:13px;top:50%;width:7px;height:1px;background:var(--border);transform:none;border-radius:0}
 .srow.child.on::before,.srow.child.on::after{background:var(--accent)}
 .jobwin{border:1px solid var(--border);border-radius:var(--r-xl);overflow:hidden;box-shadow:var(--shadow-lg);

--- a/src/renderer/SessionRow.test.tsx
+++ b/src/renderer/SessionRow.test.tsx
@@ -135,6 +135,23 @@ describe("SessionRow — one line: dot · name · age", () => {
     expect(el.className).not.toContain("before:bg-border");
   });
 
+  it("a child's trunk spans the gutter, and only the last child stops at the elbow", () => {
+    h = mount(<SessionRow status="ok" name="mid" child />);
+    let el = h.container.firstElementChild as HTMLElement;
+    // Starts 4px above its own box — the exact negative of ROW_BASE's mb-1 —
+    // so it meets whatever sits above, and runs to its own bottom edge.
+    expect(el.className).toContain("after:-top-1");
+    expect(el.className).toContain("after:bottom-0");
+    expect(el.className).not.toContain("after:bottom-1/2");
+    h.unmount();
+
+    h = mount(<SessionRow status="ok" name="last" child lastChild />);
+    el = h.container.firstElementChild as HTMLElement;
+    expect(el.className).toContain("after:-top-1");
+    expect(el.className).toContain("after:bottom-1/2");
+    expect(el.className).not.toContain("after:bottom-0");
+  });
+
   it("a stale age is visibility-hidden at rest and reveals on row hover", () => {
     h = mount(<SessionRow status="default" name="x" age="2h" ageStale />);
     const el = h.container.firstElementChild as HTMLElement;

--- a/src/renderer/SessionRow.tsx
+++ b/src/renderer/SessionRow.tsx
@@ -61,22 +61,30 @@ const ROW_SELECTED =
 const ROW_REST = "hover:bg-fill-hover";
 
 // Child (`.child`): 26px indent + the `left:13px` tree connectors. The
-// horizontal connector reuses ::before, the vertical uses ::after.
+// horizontal elbow stub is ::before, the vertical trunk is ::after. This is
+// the geometry EVERY child shares; only the ink (rest vs selected) and the
+// trunk's end (mid vs full row) vary, as the two pairs below.
+//
+// The trunk starts 4px ABOVE the row (`-top-1`, the exact negative of
+// ROW_BASE's `mb-1` gutter), so it closes the gap to whatever sits above it —
+// the parent row for the first child, the previous sibling for the rest.
 const ROW_CHILD =
   "pl-[26px] " +
   "before:absolute before:content-[''] before:left-[13px] before:top-1/2 " +
-  "before:h-px before:w-[7px] before:bg-border " +
-  "after:absolute after:content-[''] after:left-[13px] after:top-0 after:bottom-1/2 " +
-  "after:w-px after:bg-border";
+  "before:h-px before:w-[7px] " +
+  "after:absolute after:content-[''] after:left-[13px] after:-top-1 " +
+  "after:w-px";
 
-// Selected child: the connectors turn `--accent` (`.srow.child.on`), replacing
-// the normal row's marker.
-const ROW_CHILD_SELECTED =
-  "pl-[26px] " +
-  "before:absolute before:content-[''] before:left-[13px] before:top-1/2 " +
-  "before:h-px before:w-[7px] before:bg-accent " +
-  "after:absolute after:content-[''] after:left-[13px] after:top-0 after:bottom-1/2 " +
-  "after:w-px after:bg-accent";
+// Connector ink: --border at rest, --accent when the child is selected
+// (`.srow.child.on`), replacing the normal row's marker.
+const ROW_CHILD_INK = "before:bg-border after:bg-border";
+const ROW_CHILD_INK_SELECTED = "before:bg-accent after:bg-accent";
+
+// Trunk end. A child with a sibling below runs to its own bottom edge, where
+// that sibling's `-top-1` picks it up, so the tree reads as one unbroken line.
+// The LAST child stops at the elbow so the tree doesn't dangle past the group.
+const ROW_CHILD_TRUNK = "after:bottom-0";
+const ROW_CHILD_TRUNK_LAST = "after:bottom-1/2";
 
 // The 7px status dot. The base carries no background — the variant owns the
 // colour outright so two bg-* classes never fight over CSS source order. The
@@ -106,6 +114,7 @@ export function SessionRow({
   status,
   selected = false,
   child = false,
+  lastChild = false,
   name,
   age,
   ageStale = false,
@@ -124,6 +133,9 @@ export function SessionRow({
   selected?: boolean;
   /** `.child` — 26px indent + the `left:13px` tree connectors. */
   child?: boolean;
+  /** Last child in its group — the trunk stops at the elbow instead of
+   *  running on to the next sibling. Ignored unless `child`. */
+  lastChild?: boolean;
   /** The one-line name (`.t`). */
   name: ReactNode;
   /** The trailing age (`.age`). Empty in a reserved 20px slot when omitted. */
@@ -142,10 +154,13 @@ export function SessionRow({
   onClick?: () => void;
   onContextMenu?: (e: React.MouseEvent) => void;
 }) {
+  const childChrome = [
+    ROW_CHILD,
+    selected ? ROW_CHILD_INK_SELECTED : ROW_CHILD_INK,
+    lastChild ? ROW_CHILD_TRUNK_LAST : ROW_CHILD_TRUNK,
+  ].join(" ");
   const row =
-    ROW_BASE +
-    " " +
-    (child ? (selected ? ROW_CHILD_SELECTED : ROW_CHILD) : selected ? ROW_SELECTED : ROW_REST);
+    ROW_BASE + " " + (child ? childChrome : selected ? ROW_SELECTED : ROW_REST);
   return (
     <div
       role="treeitem"

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -790,7 +790,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                             killWorktreeDirtyAndClose(p.tmuxSession, w.index, wtPath, force)
                           }
                         />
-                        {kids.map((childIdx) => {
+                        {kids.map((childIdx, i) => {
                           const childWin = p.windows.find((x) => x.index === childIdx);
                           if (!childWin) return null;
                           const childActive = isProjectActive && activeWinIdx === childIdx;
@@ -802,6 +802,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                               isActive={childActive}
                               status={statusFor(p.tmuxSession, childIdx)}
                               focused={focusedKey === `job:${p.tmuxSession}:${childIdx}`}
+                              lastChild={i === kids.length - 1}
                               onActivate={() => activateWindow(p, childIdx)}
                               onClose={() =>
                                 setConfirmDeleteFor({
@@ -1138,6 +1139,7 @@ function JobChildRow({
   isActive,
   status,
   focused,
+  lastChild,
   onActivate,
   onClose,
   title,
@@ -1150,6 +1152,7 @@ function JobChildRow({
   isActive: boolean;
   status: WindowStatusUI | undefined;
   focused: boolean;
+  lastChild: boolean;
   onActivate: () => void;
   onClose: () => void;
   title: string;
@@ -1171,6 +1174,7 @@ function JobChildRow({
           statusTitle={dot.title}
           selected={isActive}
           child
+          lastChild={lastChild}
           name={w.name}
           age={age.text}
           ageStale={age.stale}


### PR DESCRIPTION
Fixes BET-899: the nested background-job tree connector drew a broken trunk between siblings.

**Fix:** each child's trunk now starts 4px above its own box (`after:-top-1`, the exact negative of the `mb-1` gutter) so the first child meets the parent row and each sibling picks up exactly where the previous one ended. Only the last child stops at the elbow (`after:bottom-1/2`). No `firstChild` prop needed — the upward start closes the parent gap, and upward-extension avoids the double-paint a downward variant would introduce.

**Root cause:** `SessionRow` had no notion of "last child" and drew each child's trunk from its own top down to its own centre, leaving the bottom half of the row plus the 4px inter-row gutter blank.

**Verification results:** see PR comment / commit. typecheck + `npm test` pass (2007 pass, 0 fail). The visual rail screenshot will diff as expected; refreshed the spec page to keep spec and port in agreement.

Base: origin/main @ 7fb5b7b7