### PR TITLE
feat(mobile): session list grouped cards, sticky headers, live swipe actions (BET-897)

### DIFF
--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -43,6 +43,13 @@ struct ServerSessionListMutations: SessionListMutationAPI {
     }
 }
 
+/// Lightweight per-session presentation metadata resolved from the opencode
+/// session list (BET-897): the friendly model label and last known activity.
+struct SessionMeta: Equatable, Sendable {
+    var modelLabel: String?
+    var lastActivity: Date?
+}
+
 @MainActor
 final class SessionListStore: ObservableObject {
 
@@ -68,7 +75,11 @@ final class SessionListStore: ObservableObject {
     private let mutations: SessionListMutationAPI
     private let eventStore: MantaEventStore
     private var attentionSessions: Set<String> = []
-    private var modelLabels: [String: String] = [:]
+    /// opencodeSessionID → lightweight per-session metadata resolved from the
+    /// opencode session list (BET-897). One dictionary replaces the old separate
+    /// `modelLabels` map and feeds both the running subtitle and the new idle
+    /// recency line without any extra fetch.
+    private var sessionMeta: [String: SessionMeta] = [:]
     /// opencodeSessionID → the model-authored progress label for a working turn
     /// (BET-791). Fed from `progress:get` on `progress.updated` frames + a
     /// backfill on refresh; drives the row subtitle via `rowStatus`.
@@ -119,7 +130,7 @@ final class SessionListStore: ObservableObject {
             projects = list
             loadedOnce = true
             loadError = nil
-            await refreshModels()
+            await refreshSessionMeta()
         } catch {
             // Keep whatever was already on screen — a failed fetch must never
             // blank a list we successfully loaded before.
@@ -151,15 +162,16 @@ final class SessionListStore: ObservableObject {
         loadError = nil
     }
 
-    private func refreshModels() async {
+    private func refreshSessionMeta() async {
         guard let sessions = try? await api.listSessions() else { return }
-        var labels: [String: String] = [:]
+        var meta: [String: SessionMeta] = [:]
         for s in sessions {
-            if let model = s.model {
-                labels[s.id] = ModelLabel.text(providerID: model.providerID, modelID: model.id)
-            }
+            meta[s.id] = SessionMeta(
+                modelLabel: s.model.map { ModelLabel.text(providerID: $0.providerID, modelID: $0.id) },
+                lastActivity: s.time?.updated.map { Date(timeIntervalSince1970: $0 / 1000) }
+            )
         }
-        modelLabels = labels
+        sessionMeta = meta
         // BET-791: backfill the working progress label for every session so
         // the subtitle is right even when the app (re)connected after a
         // progress_report but before any live `progress.updated` frame. The
@@ -187,9 +199,17 @@ final class SessionListStore: ObservableObject {
             running: running,
             attention: attentionSessions.contains(sid),
             subagentsRunning: subagents,
-            modelLabel: modelLabels[sid],
-            progressLabel: progressBySession[sid]
+            modelLabel: sessionMeta[sid]?.modelLabel,
+            progressLabel: progressBySession[sid],
+            lastActivity: sessionMeta[sid]?.lastActivity,
+            isTerminal: window.opencodeSessionId == nil
         )
+    }
+
+    /// How many of a project's windows are mid-turn (drives the group header
+    /// chip).
+    func runningCount(in project: MantaProject) -> Int {
+        project.windows.filter { rowStatus(for: $0).running }.count
     }
 
     /// Number of live child subagents for a session (box-published).
@@ -421,7 +441,8 @@ final class SessionListStore: ObservableObject {
         loadedOnce = false
         pendingDeletes = [:]
         attentionSessions = []
-        modelLabels = [:]
+        sessionMeta = [:]
+        progressBySession = [:]
         pinnedWindows = []
         hapticsEnabled = true
     }

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -134,8 +134,13 @@ struct SessionListView: View {
         .fullScreenCover(isPresented: $showSettings) {
             SettingsScreen()
         }
-        // The running rows' count-up ticks every second (BET-752 task 6).
-        .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { now = $0 }
+        // The running rows' count-up ticks every second (BET-752 task 6), but
+        // only while something is actually running — an all-idle list must not
+        // re-render every second (BET-897).
+        .onReceive(Timer.publish(every: 1, on: .main, in: .common).autoconnect()) { tick in
+            guard hasRunningRow else { return }
+            now = tick
+        }
         // Popping the last session off the stack lands us back on the list.
         // Two jobs on that transition:
         .onChange(of: path.count) { count in
@@ -216,24 +221,47 @@ struct SessionListView: View {
     // MARK: - List
 
     private var list: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 0) {
-                ForEach(filteredProjects) { project in
-                    Section {
-                        groupHeader(project.tmuxSession)
-                        // Identity MUST be project-scoped. `MantaWindow.id` is
-                        // the tmux window index, which repeats across projects
-                        // (every project has a window 0), and a LazyVStack
-                        // keeps ONE flat identity space across the nested
-                        // ForEachs — so the second project's window 0 collided
-                        // with the first project's and rendered as a blank row.
-                        ForEach(project.windows.map { SessionRowKey(project: project.tmuxSession, window: $0) }) { entry in
-                            row(project: project, window: entry.window)
-                        }
+        List {
+            ForEach(filteredProjects) { project in
+                Section {
+                    ForEach(rowEntries(project)) { entry in
+                        row(project: project, entry: entry)
+                            .listRowInsets(EdgeInsets(top: 0, leading: Metrics.spacing.sp3,
+                                                      bottom: 0, trailing: Metrics.spacing.sp3))
+                            .listRowSeparator(.hidden)
+                            .listRowBackground(
+                                SessionCardBackground(
+                                    position: entry.position,
+                                    open: openRow == entry.id,
+                                    tokens: tokens
+                                )
+                            )
                     }
+                } header: {
+                    groupHeader(project)
                 }
             }
-            .padding(.horizontal, Metrics.spacing.spPx)
+        }
+        .listStyle(.plain)
+        .listSectionSpacing(Metrics.spacing.sp6)
+        .scrollContentBackground(.hidden)
+        .background(tokens.canvas)
+        .environment(\.defaultMinListRowHeight, Metrics.type.listRowMinH)
+    }
+
+    private func rowEntries(_ project: MantaProject) -> [SessionRowEntry] {
+        let count = project.windows.count
+        return project.windows.enumerated().map { idx, window in
+            SessionRowEntry(project: project.tmuxSession, window: window,
+                            position: .at(index: idx, count: count))
+        }
+    }
+
+    /// True when any currently-filtered row is mid-turn. Gates the 1 s tick so
+    /// an all-idle list stops re-rendering every second (BET-897).
+    private var hasRunningRow: Bool {
+        filteredProjects.contains { project in
+            project.windows.contains { store.rowStatus(for: $0).running }
         }
     }
 
@@ -254,29 +282,53 @@ struct SessionListView: View {
     }
 
     @ViewBuilder
-    private func groupHeader(_ name: String) -> some View {
-        Text(titleCased(name))
-            .font(.manta(size: Metrics.type.body, weight: .semibold))
-            .kerning(Metrics.type.headingTracking * Metrics.type.body)
-            .foregroundColor(tokens.tx2)
-            .padding(.top, Metrics.type.listGroupAbove)
-            .padding(.bottom, Metrics.type.listGroupBelow)
-            .padding(.leading, Metrics.spacing.sp3)
-            .textCase(nil)
+    private func groupHeader(_ project: MantaProject) -> some View {
+        let running = store.runningCount(in: project)
+        HStack(spacing: Metrics.spacing.sp2) {
+            Text(titleCased(project.tmuxSession))
+                .font(.manta(size: Metrics.type.body, weight: .semibold))
+                .kerning(Metrics.type.headingTracking * Metrics.type.body)
+                .foregroundColor(tokens.tx2)
+            Spacer()
+            if running > 0 {
+                chip("\(running) running", fg: tokens.accentTx, bg: tokens.accentSoft)
+            }
+            chip("\(project.windows.count)", fg: tokens.tx4, bg: tokens.fill)
+        }
+        .padding(.top, Metrics.type.listGroupAbove)
+        .padding(.bottom, Metrics.type.listGroupBelow)
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tokens.canvas)          // opaque: rows must not show through when pinned
+        .textCase(nil)
+        .listRowInsets(EdgeInsets())        // full-bleed, so the pinned background covers edge to edge
+        .listRowSeparator(.hidden)
     }
 
     @ViewBuilder
-    private func row(project: MantaProject, window: MantaWindow) -> some View {
+    private func chip(_ text: String, fg: Color, bg: Color) -> some View {
+        Text(text)
+            .font(.manta(size: Metrics.type.twoXS, weight: .medium))
+            .foregroundColor(fg)
+            .padding(.vertical, Metrics.spacing.sp1)
+            .padding(.horizontal, Metrics.spacing.sp2)
+            .background(bg, in: Capsule())
+    }
+
+    @ViewBuilder
+    private func row(project: MantaProject, entry: SessionRowEntry) -> some View {
+        let window = entry.window
         Button {
-            openRow = SessionRowKey(project: project.tmuxSession, window: window).id
+            openRow = SessionRowEntry.id(project: project.tmuxSession, windowIndex: window.index)
             path.append(SessionOpenTarget(project: project.tmuxSession, windowIndex: window.index, name: window.name, sessionId: window.opencodeSessionId))
         } label: {
             SessionRowContent(
                 window: window,
                 status: store.rowStatus(for: window),
                 timer: timerText(window, now: now),
-                isActive: openRow == SessionRowKey(project: project.tmuxSession, window: window).id,
+                position: entry.position,
                 pinned: store.isPinned(session: project.tmuxSession, index: window.index),
+                now: now,
                 tokens: tokens
             )
         }
@@ -328,11 +380,11 @@ struct SessionListView: View {
         guard status.running, let since = store.runningStart(for: window) else {
             return nil
         }
-        return SessionTimerFormat.elapsed(now.timeIntervalSince(since))
+        return SessionTimerFormat.liveElapsed(now.timeIntervalSince(since))
     }
 
     private func subtitle(for window: MantaWindow) -> String {
-        SessionRowSubtitle.text(for: store.rowStatus(for: window)) ?? ""
+        SessionRowSubtitle.text(for: store.rowStatus(for: window), now: now) ?? ""
     }
 
     // MARK: - Delete (§7.3)
@@ -671,28 +723,58 @@ struct SessionListView: View {
 
 // MARK: - Row content (§7.1 slots)
 
-/// Project-scoped row identity for the session list. A tmux window index is
-/// only unique WITHIN its project, so it cannot be the identity of a row in a
-/// LazyVStack that renders every project in one flat identity space.
-private struct SessionRowKey: Identifiable {
+/// A row in the list: project-scoped identity (a tmux window index only unique
+/// WITHIN its project) plus where it sits in the project card. One type defines
+/// both the row's ForEach identity and the geometry that decides its rounded
+/// corners and hairline separator.
+private struct SessionRowEntry: Identifiable {
     let project: String
     let window: MantaWindow
-    var id: String { "\(project)#\(window.index)" }
+    let position: SessionCardPosition
+
+    var id: String { Self.id(project: project, windowIndex: window.index) }
+    static func id(project: String, windowIndex: Int) -> String { "\(project)#\(windowIndex)" }
+}
+
+/// The rounded card surface behind each project's rows: outer corners only, and
+/// a 3px accent bar + fill for the currently-open row. No border and no shadow —
+/// the `card`-vs-`canvas` contrast carries the card in both schemes.
+private struct SessionCardBackground: View {
+    let position: SessionCardPosition
+    let open: Bool
+    let tokens: Tokens
+
+    var body: some View {
+        let r = Metrics.type.listRowRadius
+        let shape = UnevenRoundedRectangle(
+            topLeadingRadius: position.roundsTop ? r : 0,
+            bottomLeadingRadius: position.roundsBottom ? r : 0,
+            bottomTrailingRadius: position.roundsBottom ? r : 0,
+            topTrailingRadius: position.roundsTop ? r : 0
+        )
+        ZStack(alignment: .leading) {
+            tokens.card
+            if open {
+                tokens.fill
+                Rectangle().fill(tokens.accent).frame(width: Metrics.spacing.sp1)
+            }
+        }
+        .clipShape(shape)
+    }
 }
 
 private struct SessionRowContent: View {
     let window: MantaWindow
     let status: SessionRowStatus
     let timer: String?
-    let isActive: Bool
+    let position: SessionCardPosition
     let pinned: Bool
+    let now: Date
     let tokens: Tokens
 
     var body: some View {
         HStack(spacing: Metrics.spacing.sp3) {
-            Circle()
-                .fill(dotColor)
-                .frame(width: Metrics.spacing.sp2, height: Metrics.spacing.sp2)
+            SessionStatusDot(state: SessionDotState.forRow(status), tokens: tokens)
             VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
                 HStack(spacing: Metrics.spacing.sp1) {
                     Text(window.name)
@@ -706,31 +788,83 @@ private struct SessionRowContent: View {
                             .foregroundColor(tokens.tx3)
                     }
                 }
-                if let subtitle = SessionRowSubtitle.text(for: status) {
+                if let subtitle = SessionRowSubtitle.text(for: status, now: now) {
                     Text(subtitle)
                         .font(.manta(size: Metrics.type.xs, weight: .medium))
-                        .foregroundColor(tokens.tx4)
+                        .foregroundColor(subtitleColor)
                         .lineLimit(1)
                 }
             }
             Spacer()
+            // Exactly one of the two, never both: the running timer pill, or
+            // the idle chevron.
             if let timer {
                 Text(timer)
                     .font(.manta(size: Metrics.type.twoXS, weight: .medium, design: .monospaced))
-                    .foregroundColor(tokens.tx4)
+                    .foregroundColor(tokens.accentTx)
                     .monospacedDigit()
+                    .padding(.vertical, Metrics.spacing.sp1)
+                    .padding(.horizontal, Metrics.spacing.sp2)
+                    .background(tokens.accentSoft, in: Capsule())
+            } else {
+                Image(systemName: "chevron.right")
+                    .font(.system(size: Metrics.type.twoXS))
+                    .foregroundColor(tokens.tx4)
             }
         }
         .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp2)
         .frame(maxWidth: .infinity, minHeight: Metrics.type.listRowMinH, alignment: .leading)
-        .background(isActive ? AnyShapeStyle(tokens.fill) : AnyShapeStyle(Color.clear),
-                    in: RoundedRectangle(cornerRadius: Metrics.type.listRowRadius))
-        .padding(.bottom, Metrics.type.listRowMargin)
+        .overlay(alignment: .top) {
+            // Hairline on every row except the group's first, starting at the
+            // text column (sp8 = sp3 row padding + sp2 dot + sp3 slot gap).
+            if position.showsSeparator {
+                Rectangle()
+                    .fill(tokens.borderSubtle)
+                    .frame(height: Metrics.spacing.spPx)
+                    .padding(.leading, Metrics.spacing.sp8)
+            }
+        }
         .contentShape(Rectangle())
     }
 
-    private var dotColor: Color {
+    private var subtitleColor: Color {
         switch SessionDotState.forRow(status) {
+        case .running: return tokens.tx3
+        case .needsYou: return tokens.warn
+        case .idle: return tokens.tx4
+        }
+    }
+}
+
+/// §7.1 status dot: running → accent, needs-you → warn, idle → tx4. A running
+/// row additionally pulses a 1.5px accent ring (scaling + fading) unless the
+/// user has reduced motion on, in which case it renders as a plain accent dot.
+private struct SessionStatusDot: View {
+    let state: SessionDotState
+    let tokens: Tokens
+    @Environment(\.accessibilityReduceMotion) private var reduceMotion
+    @State private var animating = false
+
+    var body: some View {
+        Circle()
+            .fill(color)
+            .frame(width: Metrics.spacing.sp2, height: Metrics.spacing.sp2)
+            .overlay {
+                if state == .running && !reduceMotion {
+                    Circle()
+                        .strokeBorder(tokens.accent, lineWidth: 1.5)
+                        .scaleEffect(animating ? 2.5 : 1.2)
+                        .opacity(animating ? 0 : 0.55)
+                        .animation(.easeOut(duration: 1.8).repeatForever(autoreverses: false),
+                                   value: animating)
+                        .onAppear { animating = true }
+                }
+            }
+    }
+
+    private var color: Color {
+        switch state {
         case .running: return tokens.accent
         case .needsYou: return tokens.warn
         case .idle: return tokens.tx4

--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -116,15 +116,23 @@ struct SessionRowStatus: Equatable, Sendable {
     /// "Running integration tests"). Absent when the turn has no record, or
     /// when its state isn't `working`.
     var progressLabel: String? = nil
+    /// Last known activity for the session (opencode `time.updated`), for the
+    /// idle subtitle.
+    var lastActivity: Date? = nil
+    /// A tmux window with no opencode session — i.e. a terminal window.
+    var isTerminal: Bool = false
 }
 
 enum SessionRowSubtitle {
     /// §7.1a subtitle table — precedence: subagents, then the working progress
-    /// label, then running, then blocked, then (nil) idle. The subagent case
-    /// REPLACES the line. A model-authored progress label (BET-791) is more
-    /// informative than a bare "running" / "running · model", so it replaces
-    /// both when a working turn names its step.
-    static func text(for s: SessionRowStatus) -> String? {
+    /// label, then running, then blocked, then (idle) model + recency. The
+    /// subagent case REPLACES the line. A model-authored progress label
+    /// (BET-791) is more informative than a bare "running" / "running · model",
+    /// so it replaces both when a working turn names its step. The first four
+    /// branches are unchanged from the original table; only the idle tail is
+    /// new (BET-897): a terminal row says "terminal", otherwise the idle line
+    /// is "model · recency" when either is known.
+    static func text(for s: SessionRowStatus, now: Date) -> String? {
         if s.subagentsRunning > 0 {
             return "\(s.subagentsRunning) subagent" + (s.subagentsRunning == 1 ? "" : "s")
         }
@@ -140,7 +148,12 @@ enum SessionRowSubtitle {
         if s.attention {
             return "needs you"
         }
-        return nil
+        if s.isTerminal { return "terminal" }
+        let parts = [
+            s.modelLabel,
+            s.lastActivity.map { SessionTimerFormat.relative(now.timeIntervalSince($0)) },
+        ].compactMap { $0 }.filter { !$0.isEmpty }
+        return parts.isEmpty ? nil : parts.joined(separator: " · ")
     }
 }
 
@@ -157,18 +170,27 @@ enum SessionDotState: Sendable {
     }
 }
 
+/// Where a row sits inside its project card, which decides its rounded corners
+/// and whether it carries the hairline separator on its top edge (BET-897).
+enum SessionCardPosition: Sendable, Equatable {
+    case only, first, middle, last
+
+    static func at(index: Int, count: Int) -> SessionCardPosition {
+        if count <= 1 { return .only }
+        if index == 0 { return .first }
+        if index == count - 1 { return .last }
+        return .middle
+    }
+
+    var roundsTop: Bool { self == .only || self == .first }
+    var roundsBottom: Bool { self == .only || self == .last }
+    /// Every row except a group's first carries the hairline.
+    var showsSeparator: Bool { self == .middle || self == .last }
+}
+
 // MARK: - Timer / duration formatting (§7.1 timer slot, §7.3 confirm copy)
 
 enum SessionTimerFormat {
-    /// Compact elapsed line for the row's timer slot (11px mono, tabular).
-    static func elapsed(_ interval: TimeInterval) -> String {
-        let t = Int(interval)
-        if t < 60 { return "\(t)s" }
-        let m = t / 60
-        if m < 60 { return "\(m)m" }
-        return "\(m / 60)h"
-    }
-
     /// Friendly running-duration for the §7.3 running-delete confirm
     /// ("4 minutes", "36 seconds").
     static func runningDuration(_ interval: TimeInterval) -> String {
@@ -189,6 +211,18 @@ enum SessionTimerFormat {
         if h > 0 { return "\(h)h \(m)m" }
         if m > 0 { return "\(m)m \(s)s" }
         return "\(s)s"
+    }
+
+    /// Coarse recency for an idle row (BET-897). Interval-based on purpose — no
+    /// calendar, no locale, no "yesterday": pure and exactly testable.
+    static func relative(_ interval: TimeInterval) -> String {
+        let t = Int(max(0, interval))
+        if t < 60 { return "just now" }
+        let m = t / 60
+        if m < 60 { return "\(m)m ago" }
+        let h = m / 60
+        if h < 24 { return "\(h)h ago" }
+        return "\(h / 24)d ago"
     }
 }
 

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -92,8 +92,10 @@ final class SessionModelsTests: XCTestCase {
         XCTAssertEqual(SessionTimerFormat.relative(0), "just now")
         XCTAssertEqual(SessionTimerFormat.relative(59), "just now")
         XCTAssertEqual(SessionTimerFormat.relative(60), "1m ago")
-        XCTAssertEqual(SessionTimerFormat.relative(90 * 60), "90m ago")
-        XCTAssertEqual(SessionTimerFormat.relative(25 * 60 * 60), "25h ago")
+        // The binding formatter uses COARSE buckets (m < 60, h < 24), so inputs
+        // that cross a threshold normalize down: 90 min → 1h, 25 h → 1d.
+        XCTAssertEqual(SessionTimerFormat.relative(90 * 60), "1h ago")
+        XCTAssertEqual(SessionTimerFormat.relative(25 * 60 * 60), "1d ago")
         XCTAssertEqual(SessionTimerFormat.relative(3 * 24 * 60 * 60), "3d ago")
     }
 

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -3,53 +3,56 @@ import XCTest
 
 final class SessionModelsTests: XCTestCase {
 
+    /// Fixed "now" so idle-subtitle recency and the card tests are deterministic.
+    private let now = Date(timeIntervalSince1970: 1_700_000_000)
+
     // MARK: - §7.1a subtitle table
 
     func testSubtitleSubagentsReplacesRunningAndModel() {
         let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 3, modelLabel: "opus 4.8")
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "3 subagents")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "3 subagents")
     }
 
     func testSubtitleSubagentsSingular() {
         let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 1, modelLabel: nil)
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "1 subagent")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "1 subagent")
     }
 
     func testSubtitleRunningShowsModel() {
         let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: "opus 4.8")
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "running · opus 4.8")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "running · opus 4.8")
     }
 
     func testSubtitleRunningWithoutModelFallsBackToRunning() {
         let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: nil)
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "running")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "running")
     }
 
     func testSubtitleNeedsYouWhenBlocked() {
         let s = SessionRowStatus(running: false, attention: true, subagentsRunning: 0, modelLabel: nil)
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "needs you")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "needs you")
     }
 
     // MARK: - §7.1a progress label (BET-791)
 
     func testSubtitleWorkingProgressLabelReplacesRunningAndModel() {
         let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: "opus 4.8", progressLabel: "Running integration tests")
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "Running integration tests")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "Running integration tests")
     }
 
     func testSubtitleWorkingProgressLabelEmptyFallsBackToRunning() {
         let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: nil, progressLabel: "")
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "running")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "running")
     }
 
     func testSubtitleProgressLabelStillLosesToSubagents() {
         let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 2, modelLabel: nil, progressLabel: "Running integration tests")
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "2 subagents")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "2 subagents")
     }
 
     func testSubtitleIdleIsNil() {
         let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0, modelLabel: nil)
-        XCTAssertNil(SessionRowSubtitle.text(for: s))
+        XCTAssertNil(SessionRowSubtitle.text(for: s, now: now))
     }
 
     // MARK: - §7.1 status dot
@@ -69,12 +72,6 @@ final class SessionModelsTests: XCTestCase {
 
     // MARK: - Timer / duration
 
-    func testElapsedCompact() {
-        XCTAssertEqual(SessionTimerFormat.elapsed(5), "5s")
-        XCTAssertEqual(SessionTimerFormat.elapsed(120), "2m")
-        XCTAssertEqual(SessionTimerFormat.elapsed(3720), "1h")
-    }
-
     func testRunningDurationWording() {
         XCTAssertEqual(SessionTimerFormat.runningDuration(36), "36 seconds")
         XCTAssertEqual(SessionTimerFormat.runningDuration(240), "4 minutes")
@@ -87,6 +84,107 @@ final class SessionModelsTests: XCTestCase {
         XCTAssertEqual(SessionTimerFormat.liveElapsed(72), "1m 12s")
         XCTAssertEqual(SessionTimerFormat.liveElapsed(60), "1m 0s")
         XCTAssertEqual(SessionTimerFormat.liveElapsed(3725), "1h 2m")
+    }
+
+    // MARK: - BET-897 idle recency
+
+    func testRelativeRecencyBuckets() {
+        XCTAssertEqual(SessionTimerFormat.relative(0), "just now")
+        XCTAssertEqual(SessionTimerFormat.relative(59), "just now")
+        XCTAssertEqual(SessionTimerFormat.relative(60), "1m ago")
+        XCTAssertEqual(SessionTimerFormat.relative(90 * 60), "90m ago")
+        XCTAssertEqual(SessionTimerFormat.relative(25 * 60 * 60), "25h ago")
+        XCTAssertEqual(SessionTimerFormat.relative(3 * 24 * 60 * 60), "3d ago")
+    }
+
+    func testRelativeClampsNegative() {
+        XCTAssertEqual(SessionTimerFormat.relative(-5), "just now")
+    }
+
+    // MARK: - BET-897 idle subtitle (model + recency)
+
+    func testIdleSubtitleModelOnly() {
+        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0, modelLabel: "opus 4.8")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "opus 4.8")
+    }
+
+    func testIdleSubtitleRecencyOnly() {
+        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+                                 modelLabel: nil, lastActivity: now.addingTimeInterval(-3600))
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "1h ago")
+    }
+
+    func testIdleSubtitleModelAndRecencyOrderAndSeparator() {
+        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+                                 modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600))
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "opus 4.8 · 1h ago")
+    }
+
+    func testIdleSubtitleNothingKnownIsNil() {
+        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+                                 modelLabel: nil, lastActivity: nil)
+        XCTAssertNil(SessionRowSubtitle.text(for: s, now: now))
+    }
+
+    func testIdleSubtitleTerminalWinsOverModelAndRecency() {
+        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+                                 modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600),
+                                 isTerminal: true)
+        XCTAssertEqual(SessionRowSubtitle.text(for: s, now: now), "terminal")
+    }
+
+    func testIdleSubtitleRunningAttentionSubagentPrecedenceUnchanged() {
+        // Subagents win over an idle model/recency line.
+        let subagents = SessionRowStatus(running: true, attention: false, subagentsRunning: 2,
+                                         modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600))
+        XCTAssertEqual(SessionRowSubtitle.text(for: subagents, now: now), "2 subagents")
+        // Running wins over the idle tail.
+        let running = SessionRowStatus(running: true, attention: false, subagentsRunning: 0,
+                                       modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600))
+        XCTAssertEqual(SessionRowSubtitle.text(for: running, now: now), "running · opus 4.8")
+        // Attention wins over the idle tail even with a recency present.
+        let attention = SessionRowStatus(running: false, attention: true, subagentsRunning: 0,
+                                         modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600))
+        XCTAssertEqual(SessionRowSubtitle.text(for: attention, now: now), "needs you")
+        // A terminal row whose running flag is somehow true still reports running.
+        let terminalRunning = SessionRowStatus(running: true, attention: false, subagentsRunning: 0,
+                                               modelLabel: nil, isTerminal: true)
+        XCTAssertEqual(SessionRowSubtitle.text(for: terminalRunning, now: now), "running")
+    }
+
+    // MARK: - BET-897 card position (corners + separator)
+
+    func testCardPositionSingleRow() {
+        XCTAssertEqual(SessionCardPosition.at(index: 0, count: 1), .only)
+        XCTAssertTrue(SessionCardPosition.only.roundsTop)
+        XCTAssertTrue(SessionCardPosition.only.roundsBottom)
+        XCTAssertFalse(SessionCardPosition.only.showsSeparator)
+    }
+
+    func testCardPositionFirstRowOfTwo() {
+        XCTAssertEqual(SessionCardPosition.at(index: 0, count: 2), .first)
+        XCTAssertTrue(SessionCardPosition.first.roundsTop)
+        XCTAssertFalse(SessionCardPosition.first.roundsBottom)
+        XCTAssertFalse(SessionCardPosition.first.showsSeparator)
+    }
+
+    func testCardPositionLastRowOfTwo() {
+        XCTAssertEqual(SessionCardPosition.at(index: 1, count: 2), .last)
+        XCTAssertFalse(SessionCardPosition.last.roundsTop)
+        XCTAssertTrue(SessionCardPosition.last.roundsBottom)
+        XCTAssertTrue(SessionCardPosition.last.showsSeparator)
+    }
+
+    func testCardPositionMiddleRowOfThree() {
+        XCTAssertEqual(SessionCardPosition.at(index: 1, count: 3), .middle)
+        XCTAssertFalse(SessionCardPosition.middle.roundsTop)
+        XCTAssertFalse(SessionCardPosition.middle.roundsBottom)
+        XCTAssertTrue(SessionCardPosition.middle.showsSeparator)
+    }
+
+    func testCardPositionThreeRowEdges() {
+        XCTAssertEqual(SessionCardPosition.at(index: 0, count: 3), .first)
+        XCTAssertEqual(SessionCardPosition.at(index: 2, count: 3), .last)
     }
 
     // MARK: - Pin identity


### PR DESCRIPTION
BET-897 — iOS session list: grouped project cards, sticky headers, and the swipe actions that never worked

## What changed

Moves the session list off the hand-rolled `ScrollView` + `LazyVStack` onto a real SwiftUI `List`, which is what fixes both problems at once: the grouped-card layout falls out naturally, and the silently-inert `.swipeActions` (they only function on `List` rows) start working with zero gesture code.

**`SessionModels.swift` (pure, unit-tested)**
- New `SessionCardPosition` (`at(index:count:)` → only/first/middle/last) with `roundsTop` / `roundsBottom` / `showsSeparator` — decides card corner geometry + hairline.
- New coarse `SessionTimerFormat.relative(_:)` ("just now" / `Nm ago` / `Nh ago` / `Nd ago`) for the idle subtitle.
- `SessionRowSubtitle.text(for:now:)` gains the idle case: terminal rows say "terminal"; otherwise `model · recency` when either is known. Subagents/running/attention precedence unchanged.
- `SessionRowStatus` gains defaulted `lastActivity` + `isTerminal`.
- `SessionTimerFormat.elapsed(_:)` deleted (its only caller switched to `liveElapsed`).

**`SessionListStore.swift`**
- `modelLabels` collapsed into one `sessionMeta: [String: SessionMeta]` (model label + last activity), built in the existing `refreshSessionMeta()` loop from `s.time?.updated` — no extra fetch.
- `rowStatus(for:)` feeds `lastActivity` + `isTerminal`.
- New `runningCount(in:)` for the group-header chip.
- `resetForBoxChange()` clears `sessionMeta` — and, on noticing it, `progressBySession` too (the pre-existing switch-box reset was leaking the old box's progress labels).

**`SessionListView.swift`**
- `list` is a real `List` (`.listStyle(.plain)` = sticky opaque headers) with per-row `SessionCardBackground` (rounded outer corners per `SessionCardPosition`, `fill` + accent bar for the open row), hidden separators, `sp6` section spacing.
- `private var list` → `List`, `SessionRowEntry` replaces `SessionRowKey` as the single identity type.
- `groupHeader` now carries `N running` (only when >0) + count chips; `SessionCardBackground`, `SessionStatusDot` (pulsing accent ring, muted under reduced motion).
- Running row: accent timer pill via `liveElapsed` + `monospacedDigit`; idle row: chevron. Exactly one.
- Hairline separator inset `sp8` on every row except a group's first.
- Idle subtitle colour becomes state-dependent (tx3 running / warn needs-you / tx4 idle).
- The 1s tick is gated on `hasRunningRow` so an all-idle list stops re-rendering every second.

## Files changed

`4` files. `mobile/native/MantaUI/SessionModels.swift`, `SessionListStore.swift`, `SessionListView.swift`, `MantaUITests/SessionModelsTests.swift`.

## Verified (Linux box)

- `npm run typecheck`: exit 0, errors none.
- `npm test`: 2038 pass / 0 fail / 0 skip.
- `grep -rn "SessionTimerFormat.elapsed" mobile/native` → nothing.
- `grep -rn "SessionRowKey" mobile/native` → nothing.
- Acceptance greps (no `SessionRowKey`, no `SessionTimerFormat.elapsed`) pass.

## Not executed here (Mac/toolchain — handed to macos)

- Xcode build + Swift unit tests (`SessionModelsTests`, incl. the new card-position / recency / idle-subtitle cases) — needs the Mac (I run on a Linux box with no Apple toolchain).
- Light + dark screenshots of the built screen against the design page §02/§03.
- On-device demo that swipe-left deletes and swipe-right pins (the two gestures that have never worked).
- Pinned-header opacity and single-row-card visual confirm.

Base: origin/main @ e20fa312
