### PR TITLE
BET-895: feat(mobile): capability filters and counted search on the model catalogue

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -209,11 +209,71 @@ enum ChatModel {
     /// the box's own capability flags rather than being inferred — a model can
     /// reason without exposing an effort dial, so deriving "reasoning" from the
     /// presence of variants mislabels it.
+    ///
+    /// The predicates are the two private helpers BELOW (`reasoningCapability` /
+    /// `visionCapability`), which share a single definition each with the
+    /// catalogue's capability filter (`matches(_:filter:in:)`). If the filter
+    /// and the badge ever disagreed, a row would show a glyph yet vanish under
+    /// the matching chip — the exact failure BET-895 exists to prevent.
     static func capabilityGlyphs(_ model: OpencodeModel) -> [String] {
         var glyphs: [String] = []
-        if model.capabilities?.reasoning == true { glyphs.append("reasoning") }
-        if model.capabilities?.input?.image == true { glyphs.append("vision") }
+        if reasoningCapability(model) { glyphs.append("reasoning") }
+        if visionCapability(model) { glyphs.append("vision") }
         return glyphs
+    }
+
+    /// The one "does this model reason" notion — shared by the reasoning badge
+    /// and the Reasoning filter. Reads the box's own `capabilities.reasoning`
+    /// flag (BET-825), never inferred from the presence of variants.
+    private static func reasoningCapability(_ model: OpencodeModel) -> Bool {
+        model.capabilities?.reasoning == true
+    }
+
+    /// The one "does this model accept images" notion — shared by the vision
+    /// badge and the Vision filter. Reads the box's own `input.image` flag.
+    private static func visionCapability(_ model: OpencodeModel) -> Bool {
+        model.capabilities?.input?.image == true
+    }
+
+    /// The catalogue's capability filter. `all` is the identity filter and is
+    /// the default; the other three narrow by a property the model itself
+    /// declares, so a provider that annotates nothing simply never matches.
+    enum ModelCapabilityFilter: String, CaseIterable, Sendable {
+        case all, reasoning, vision, fast
+
+        /// The chip's label — "All", "Reasoning", "Vision", "Fast".
+        var title: String {
+            switch self {
+            case .all: return "All"
+            case .reasoning: return "Reasoning"
+            case .vision: return "Vision"
+            case .fast: return "Fast"
+            }
+        }
+    }
+
+    /// Whether `model` satisfies `filter`. `all` matches everything (the
+    /// identity filter). `reasoning`/`vision` share their predicate with
+    /// `capabilityGlyphs`, so a filter never disagrees with the badge it
+    /// narrows. `fast` needs the whole `models` list because a fast twin is a
+    /// SEPARATE model id (`<id>-fast`), not a flag on the model.
+    static func matches(_ model: OpencodeModel,
+                        filter: ModelCapabilityFilter,
+                        in models: [OpencodeModel]) -> Bool {
+        switch filter {
+        case .all:
+            return true
+        case .reasoning:
+            return reasoningCapability(model)
+        case .vision:
+            return visionCapability(model)
+        case .fast:
+            return models.contains {
+                $0.providerID == model.providerID
+                    && $0.id == fastModelID(model.id)
+                    && isPickable($0)
+            }
+        }
     }
 
     // MARK: - Cockpit + catalogue copy (BET-894)

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -290,11 +290,20 @@ struct ModelCatalogueView: View {
     let onPick: () -> Void
     @Environment(\.colorScheme) private var colorScheme
     @State private var query = ""
+    /// The active capability filter. View state only — resets to `.all` every
+    /// time the catalogue is opened; it is a lookup aid, not a preference.
+    @State private var filter: ChatModel.ModelCapabilityFilter = .all
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
+    /// One pipeline, one place: capability filter → group → query. The filter
+    /// runs over the full model list first (a `fast` twin must be found in the
+    /// WHOLE list, including a model the filter would otherwise drop), then
+    /// `groups`/`filteredGroups` handle the pickable grouping and the search.
     private var groups: [(provider: String, models: [OpencodeModel])] {
-        ChatModel.filteredGroups(ChatModel.groups(modelStore.models), query: query)
+        let all = modelStore.models
+        let filtered = all.filter { ChatModel.matches($0, filter: filter, in: all) }
+        return ChatModel.filteredGroups(ChatModel.groups(filtered), query: query)
     }
 
     private func isSelected(_ m: OpencodeModel) -> Bool {
@@ -312,12 +321,13 @@ struct ModelCatalogueView: View {
         Group {
             if modelStore.loaded {
                 List {
+                    capabilityFilterSection
                     providerSections
                 }
                 .searchable(
                     text: $query,
                     placement: .navigationBarDrawer(displayMode: .always),
-                    prompt: "Search models"
+                    prompt: "Search \(ChatModel.pickableCount(modelStore.models)) models"
                 )
             } else {
                 ProgressView("Loading models…")
@@ -329,14 +339,38 @@ struct ModelCatalogueView: View {
         // Pushed view: no Done button, no detents — those belong to the sheet root.
     }
 
+    /// The catalogue's capability filter row: "All · Reasoning · Vision ·
+    /// Fast", exactly one active at a time (`.all` on entry). A plain
+    /// `HStack` — the four short chips fit one line, so this neither wraps nor
+    /// scrolls. It is the `List`'s first `Section` with no header, so it
+    /// scrolls with the content rather than pinning, and its row insets match
+    /// the model rows around it.
+    private var capabilityFilterSection: some View {
+        Section {
+            HStack(spacing: Metrics.spacing.sp2) {
+                ForEach(ChatModel.ModelCapabilityFilter.allCases, id: \.self) { f in
+                    ModelChip(
+                        title: f.title,
+                        selected: filter == f,
+                        tokens: tokens,
+                        accessibilityIdentifier: "model-filter-\(f.rawValue)"
+                    ) {
+                        filter = f
+                    }
+                }
+            }
+            .padding(.vertical, Metrics.spacing.sp1)
+        }
+    }
+
     /// The model list, grouped into a Section per provider. Empty-query misses
-    /// render the platform search empty state rather than ad-hoc text.
+    /// AND a capability filter with no matches both render the platform search
+    /// empty state — a user who filters to Vision on a box with no vision model
+    /// gets the platform state, not a blank list.
     @ViewBuilder
     private var providerSections: some View {
         if groups.isEmpty {
-            if !query.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                ContentUnavailableView.search(text: "No models match")
-            }
+            ContentUnavailableView.search(text: "No models match")
         } else {
             ForEach(groups, id: \.provider) { group in
                 Section {

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -335,4 +335,108 @@ final class ModelRecentsTests: XCTestCase {
         let models = [OpencodeModel(id: "opus", providerID: "anthropic", name: "Claude Opus 4.7")]
         XCTAssertEqual(ChatModel.pickableCount(models), 1)
     }
+
+    // MARK: - ChatModel.ModelCapabilityFilter.matches (BET-895)
+
+    /// The capability filter shares its reasoning/vision predicates with
+    /// `capabilityGlyphs`, so the model's capability flags drive both.
+    private func capFilterModel(id: String = "m", providerID: String = "p",
+                                name: String = "m", enabled: Bool? = nil,
+                                reasoning: Bool? = nil, image: Bool? = nil) -> OpencodeModel {
+        OpencodeModel(
+            id: id,
+            providerID: providerID,
+            name: name,
+            enabled: enabled,
+            capabilities: ModelCapabilities(
+                reasoning: reasoning,
+                input: image.map { ModelCapabilities.Modalities(image: $0) }
+            )
+        )
+    }
+
+    func testAllFilterMatchesEverythingIncludingDisabled() {
+        let pickable = capFilterModel(id: "a")
+        let disabled = capFilterModel(id: "b", enabled: false)
+        let models = [pickable, disabled]
+        for m in models {
+            XCTAssertTrue(ChatModel.matches(m, filter: .all, in: models))
+        }
+        XCTAssertTrue(ChatModel.matches(disabled, filter: .all, in: models))
+    }
+
+    func testAllFilterIsIdentity() {
+        XCTAssertEqual(ChatModel.matches(capFilterModel(), filter: .all, in: []), true)
+    }
+
+    func testReasoningFilterUsesCapabilityFlag() {
+        let reasoning = capFilterModel(reasoning: true)
+        let notReasoning = capFilterModel()
+        XCTAssertTrue(ChatModel.matches(reasoning, filter: .reasoning, in: [reasoning]))
+        XCTAssertFalse(ChatModel.matches(notReasoning, filter: .reasoning, in: [notReasoning]))
+    }
+
+    func testVisionFilterUsesImageCapability() {
+        let vision = capFilterModel(image: true)
+        let notVision = capFilterModel()
+        XCTAssertTrue(ChatModel.matches(vision, filter: .vision, in: [vision]))
+        XCTAssertFalse(ChatModel.matches(notVision, filter: .vision, in: [notVision]))
+    }
+
+    func testFastFilterMatchesWhenPickableTwinPresent() {
+        let base = capFilterModel(id: "gpt-5.6", providerID: "openai", name: "GPT-5.6")
+        let fast = capFilterModel(id: "gpt-5.6-fast", providerID: "openai", name: "GPT-5.6 Fast")
+        XCTAssertTrue(ChatModel.matches(base, filter: .fast, in: [base, fast]))
+    }
+
+    func testFastFilterRejectsWhenTwinAbsent() {
+        let base = capFilterModel(id: "gpt-5.6", providerID: "openai", name: "GPT-5.6")
+        XCTAssertFalse(ChatModel.matches(base, filter: .fast, in: [base]))
+    }
+
+    func testFastFilterRejectsDisabledTwin() {
+        let base = capFilterModel(id: "gpt-5.6", providerID: "openai", name: "GPT-5.6")
+        let disabledFast = capFilterModel(id: "gpt-5.6-fast", providerID: "openai", name: "Fast", enabled: false)
+        XCTAssertFalse(ChatModel.matches(base, filter: .fast, in: [base, disabledFast]))
+    }
+
+    func testFastTwinMustShareProvider() {
+        let base = capFilterModel(id: "m", providerID: "p1", name: "M")
+        let otherProviderFast = capFilterModel(id: "m-fast", providerID: "p2", name: "M Fast")
+        XCTAssertFalse(ChatModel.matches(base, filter: .fast, in: [base, otherProviderFast]))
+    }
+
+    func testFastModelIsItsOwnTwinThroughFastModelID() {
+        // `fastModelID` leaves a fast id unchanged, so a fast model scheduled
+        // against the fast filter matches itself (it is pickable). This pins
+        // that the `-fast` rule is derived, never re-invented.
+        let fast = capFilterModel(id: "gpt-5.6-fast", providerID: "openai", name: "Fast")
+        XCTAssertTrue(ChatModel.matches(fast, filter: .fast, in: [fast]))
+    }
+
+    /// BET-895's consistency rule: the filter and the badge must never
+    /// disagree. For every combination of capability flags, `matches(.vision)`
+    /// is true exactly when `capabilityGlyphs` contains "vision", and likewise
+    /// for "reasoning" — a row that shows a glyph must not vanish under the
+    /// matching chip.
+    func testFilterAgreesWithGlyphs() {
+        let reasons: [Bool?] = [nil, true, false]
+        let images: [Bool?] = [nil, true, false]
+        for reasoning in reasons {
+            for image in images {
+                let m = capFilterModel(reasoning: reasoning, image: image)
+                let glyphs = ChatModel.capabilityGlyphs(m)
+                XCTAssertEqual(
+                    ChatModel.matches(m, filter: .vision, in: [m]),
+                    glyphs.contains("vision"),
+                    "reasoning=\(String(describing: reasoning)) image=\(String(describing: image))"
+                )
+                XCTAssertEqual(
+                    ChatModel.matches(m, filter: .reasoning, in: [m]),
+                    glyphs.contains("reasoning"),
+                    "reasoning=\(String(describing: reasoning)) image=\(String(describing: image))"
+                )
+            }
+        }
+    }
 }


### PR DESCRIPTION
## iOS model catalogue: capability filters and a counted search (BET-895)

Adds the capability filter row (All · Reasoning · Vision · Fast) and the
counted search prompt ("Search N models") to `ModelCatalogueView`.

### What changed

- **`ChatModel.swift`** — new `ModelCapabilityFilter` enum (`all`/`reasoning`/
  `vision`/`fast`, with `title`) and `ChatModel.matches(_:filter:in:)`.
  Refactored `capabilityGlyphs` to route both of its predicates through two
  private helpers (`reasoningCapability` / `visionCapability`) that `matches`
  also calls, so the filter and the badge can never disagree.
- **`ModelPickerSheet.swift`** (`ModelCatalogueView`) — a first `Section`
  holding the four chips (no header, row insets matching the model rows,
  `.padding(.vertical, sp1)`); the search prompt uses
  `ChatModel.pickableCount`; `groups` is the single pipeline
  `filter → groups → query`; an empty result (from filter OR query) renders
  `ContentUnavailableView.search`, never a blank list.
- **`ModelRecentsTests.swift`** — unit tests for `matches` (all/reasoning/
  vision/fast incl. pickable-twin, disabled-twin, cross-provider) and the
  mandatory filter↔badge consistency test.

### Reused symbols (house rule: no new literals / no duplicated predicates)

- `ChatModel.pickableCount(_:)` (counted search) — **reused**, not counted
  inline.
- `ChatModel.fastModelID` / `ChatModel.isPickable` (fast predicate) —
  **reused**, `-fast` suffix rule never re-derived.
- `ChatModel.capabilityGlyphs` predicates → extracted to two private helpers
  so `matches` and the badge share ONE definition each.
- `ModelChip` — **reused verbatim** (the only chip style; no fork).
- `Metrics.spacing.sp1`/`sp2`, `Tokens`, `Font.manta`, `.system(size:)` — all
  existing; **no new tokens required**.

### Interpretation note (spec-vs-code)

The issue prose described `reasoning` as "non-empty `variants`" and vision as
`input` containing `"image"` (an array form), and its example tests used
`input: ["text","image"]`. That does not match the **merged** canonical
`capabilityGlyphs`/`ModelCapabilities` this issue consumes (from BET-825/886/
894): `reasoning` is the box's `capabilities.reasoning` Bool flag, and vision
is the `input.image` Bool flag — and the wire fixture `testWireModelsJSON`
proves `input` is an object of flags, not an array of strings. The issue's own
binding constraint — "`capabilityGlyphs` and `matches` disagreeing is the exact
failure this instruction prevents" — plus the consistency test ("`matches(.vision)`
iff `capabilityGlyphs` contains 'vision'") force the two to share a predicate.
I therefore reused the merged predicates (the "same source `capabilityGlyphs`
uses", per the issue) via shared helpers, rather than regressing the documented
BET-825 decision (which explicitly rejects deriving "reasoning" from variants)
or risking the BET-886-hardened decode path. Acceptance behaviour (Vision shows
exactly the vision-glyph models; Fast shows only models with a pickable fast
twin; filter+search compose; empty state on no match; reset to All on reopen)
is fully satisfied. The `fast`/`all` semantics are as specified.

### Verification

**Files changed:** `3` files: `mobile/native/MantaUI/ChatModel.swift`,
`mobile/native/MantaUI/ModelPickerSheet.swift`,
`mobile/native/MantaUITests/ModelRecentsTests.swift`.

- `plugin_run("ios-mantaui", {action:"compile-only"})` on
  `multica/BET-895-ios-catalogue-capability-filters` @ `2ede187c` → **PASS**
  (recorded verdict: `COMPILE: PASS (app target only, NO tests) 2ede187c`).
  No errors.
- `plugin_run("ios-mantaui", {action:"test-unit"})` on the same branch →
  **PASS** (job `done`; builds both bundles incl. the test bundle containing
  the new `matches` tests, runs `MantaUITests` only). xcodebuild exits
  non-zero on any test failure, so exit 0 = all unit tests green.
  (First attempt was `UNATTRIBUTABLE` — the shared Mac build clone was
  force-reset to BET-897's branch mid-run by a concurrent build. Retried
  successfully when the clone stayed on this branch: no code change.)
- Base: `origin/main @ 87d2f63f`.

No LS/JS tests apply (this is native Swift; the only applicable gates are the
iOS compile + unit bundle above, both green).