### PR TITLE
BET-907: refactor(website): hoist duplicated inline CSS into site.css

### DIFF
--- a/website/claude-code-mobile.html
+++ b/website/claude-code-mobile.html
@@ -12,12 +12,7 @@
 <link rel="stylesheet" href="/site.css">
 <style>
 
-/* page-specific: hero, phone mockup with permission card and dictation bar */
-.hero-comp{padding:64px 0 36px;text-align:center}
-.hero-comp .wrap{position:relative;z-index:1}
-.hero-comp h1{font-size:clamp(32px,5vw,52px);line-height:1.1;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin:0 auto 18px;max-width:880px}
-.hero-comp .lede{font-size:clamp(15.5px,1.9vw,18px);color:var(--text-tertiary);max-width:720px;margin:0 auto;line-height:1.55}
-
+/* page-specific: phone mockup with permission card and dictation bar */
 .phwrap{display:flex;justify-content:center;margin:42px 0 0}
 .phone{width:284px;height:572px;border-radius:38px;border:1px solid var(--border-strong);background:var(--surface-inset);box-shadow:var(--shadow-xl);padding:14px;position:relative;overflow:hidden}
 .phone::before{content:"";position:absolute;top:12px;left:50%;transform:translateX(-50%);width:96px;height:5px;border-radius:99px;background:var(--navy-600);z-index:3}

--- a/website/claude-code-remote.html
+++ b/website/claude-code-remote.html
@@ -12,12 +12,7 @@
 <link rel="stylesheet" href="/site.css">
 <style>
 
-/* page-specific: hero, tmux + VPS mockup, ingress panel */
-.hero-comp{padding:64px 0 36px;text-align:center}
-.hero-comp .wrap{position:relative;z-index:1}
-.hero-comp h1{font-size:clamp(32px,5vw,52px);line-height:1.1;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin:0 auto 18px;max-width:880px}
-.hero-comp .lede{font-size:clamp(15.5px,1.9vw,18px);color:var(--text-tertiary);max-width:720px;margin:0 auto;line-height:1.55}
-
+/* page-specific: tmux + VPS mockup, ingress panel */
 .hostmock{margin:42px auto 0;max-width:880px;background:var(--surface-card);border:1px solid var(--border-default);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-xl)}
 .hostmock .top{display:flex;align-items:center;gap:10px;padding:11px 14px;background:var(--surface-panel);border-bottom:1px solid var(--border-subtle);font-family:var(--font-mono);font-size:12px;color:var(--slate-400)}
 .hostmock .dots{display:flex;gap:6px;margin-right:6px}

--- a/website/claude-code-web-ui.html
+++ b/website/claude-code-web-ui.html
@@ -12,12 +12,7 @@
 <link rel="stylesheet" href="/site.css">
 <style>
 
-/* page-specific: hero, browser mockup, worktree panel */
-.hero-comp{padding:64px 0 36px;text-align:center}
-.hero-comp .wrap{position:relative;z-index:1}
-.hero-comp h1{font-size:clamp(32px,5vw,52px);line-height:1.1;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin:0 auto 18px;max-width:880px}
-.hero-comp .lede{font-size:clamp(15.5px,1.9vw,18px);color:var(--text-tertiary);max-width:720px;margin:0 auto;line-height:1.55}
-
+/* page-specific: browser mockup, worktree panel */
 .browsermock{margin:42px auto 0;max-width:980px;background:var(--surface-card);border:1px solid var(--border-default);border-radius:var(--radius-xl);overflow:hidden;box-shadow:var(--shadow-xl)}
 .browsermock .urlbar{display:flex;align-items:center;gap:10px;padding:10px 14px;background:var(--surface-panel);border-bottom:1px solid var(--border-subtle);font-family:var(--font-mono);font-size:12px;color:var(--slate-400)}
 .browsermock .dots{display:flex;gap:6px;margin-right:6px}

--- a/website/open-source.html
+++ b/website/open-source.html
@@ -12,12 +12,7 @@
 <link rel="stylesheet" href="/site.css">
 <style>
 
-/* page-specific: hero, license card, install audit panel */
-.hero-comp{padding:64px 0 36px;text-align:center}
-.hero-comp .wrap{position:relative;z-index:1}
-.hero-comp h1{font-size:clamp(32px,5vw,52px);line-height:1.1;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin:0 auto 18px;max-width:880px}
-.hero-comp .lede{font-size:clamp(15.5px,1.9vw,18px);color:var(--text-tertiary);max-width:720px;margin:0 auto;line-height:1.55}
-
+/* page-specific: license card, install audit panel */
 .repoc{margin:42px auto 0;max-width:760px;background:var(--surface-card);border:1px solid var(--border-default);border-radius:var(--radius-xl);padding:24px 26px;box-shadow:var(--shadow-xl)}
 .repoc .rh{display:flex;align-items:center;gap:10px;font-family:var(--font-mono);font-size:14px;color:var(--slate-200);margin-bottom:14px;font-weight:600}
 .repoc .rh svg{width:18px;height:18px;stroke:var(--slate-400);fill:none;stroke-width:1.8}

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -12,12 +12,7 @@
 <link rel="stylesheet" href="/site.css">
 <style>
 
-/* page-specific: hero, three-column "what you pay for" panels */
-.hero-comp{padding:64px 0 36px;text-align:center}
-.hero-comp .wrap{position:relative;z-index:1}
-.hero-comp h1{font-size:clamp(32px,5vw,52px);line-height:1.1;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin:0 auto 18px;max-width:880px}
-.hero-comp .lede{font-size:clamp(15.5px,1.9vw,18px);color:var(--text-tertiary);max-width:720px;margin:0 auto;line-height:1.55}
-
+/* page-specific: three-column "what you pay for" panels */
 .pricegrid{display:grid;grid-template-columns:repeat(3,1fr);gap:16px;max-width:980px;margin:42px auto 0}
 @media(max-width:880px){.pricegrid{grid-template-columns:1fr}}
 .pricegrid .pcard{background:var(--surface-card);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:22px 24px;text-align:left}

--- a/website/privacy.html
+++ b/website/privacy.html
@@ -10,23 +10,6 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/site.css">
-<style>
-
-/* prose column */
-.doc{padding:80px 0 96px}
-.doc .wrap{max-width:780px}
-.doc h1{font-size:clamp(28px,4.2vw,42px);font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin-bottom:8px;line-height:1.15}
-.doc .lede{font-size:17px;color:var(--text-tertiary);margin-bottom:36px;line-height:1.55}
-.doc h2{font-size:22px;font-weight:700;color:var(--text-primary);margin:40px 0 12px;letter-spacing:-.01em}
-.doc h3{font-size:16px;font-weight:600;color:var(--text-primary);margin:24px 0 8px}
-.doc p{margin-bottom:14px;color:var(--text-secondary)}
-.doc ul{margin:0 0 14px 22px;color:var(--text-secondary)}
-.doc li{margin-bottom:6px}
-.doc code{font-family:var(--font-mono);font-size:13px;color:var(--cyan-300);background:#0E1B33;padding:1px 6px;border-radius:4px}
-.doc hr{border:0;border-top:1px solid var(--border-subtle);margin:32px 0}
-.doc .meta{font-size:13px;color:var(--slate-500);margin-bottom:24px}
-.doc .pill{display:inline-block;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--amber-500);background:#F0A9341A;border:1px solid #F0A9343d;border-radius:var(--radius-full);padding:2px 10px;margin-bottom:18px}
-</style>
 
 <!-- BEGIN:head-meta -->
 <link rel="canonical" href="https://mantaui.com/privacy">

--- a/website/site.css
+++ b/website/site.css
@@ -119,3 +119,40 @@ section{position:relative;padding:78px 0}
 .fbrand img{width:23px;height:23px}
 
 @media(prefers-reduced-motion:reduce){*{animation:none!important;transition:none!important;scroll-behavior:auto}.hero-video{display:none}}
+
+/* hero — shared by pricing, open-source, the /vs/ pages, and the claude-code pages */
+.hero-comp{padding:64px 0 36px;text-align:center}
+.hero-comp .wrap{position:relative;z-index:1}
+.hero-comp h1{font-size:clamp(32px,5vw,52px);line-height:1.1;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin:0 auto 18px;max-width:880px}
+.hero-comp .lede{font-size:clamp(15.5px,1.9vw,18px);color:var(--text-tertiary);max-width:720px;margin:0 auto;line-height:1.55}
+
+/* verdict box — vs-conductor, vs-orca, vs-ssh-tmux */
+.verdict{background:var(--surface-card);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:24px 26px;max-width:880px;margin:40px auto 0}
+.verdict h2{font-size:11.5px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--cyan-400);margin-bottom:14px}
+.verdict ul{list-style:none;display:flex;flex-direction:column;gap:13px}
+.verdict li{display:flex;gap:14px;align-items:flex-start;font-size:14.5px;color:var(--text-secondary);line-height:1.55}
+.verdict li b{color:var(--text-primary);font-weight:600}
+.verdict .vtag{flex-shrink:0;font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.06em;color:var(--cyan-400);padding:4px 9px;border-radius:var(--radius-full);background:#49D7F51F;border:1px solid #49D7F53d;text-transform:uppercase;min-width:80px;text-align:center}
+
+/* architecture comparison — vs-conductor, vs-orca, vs-ssh-tmux */
+.arch-compare{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:28px}
+@media(max-width:780px){.arch-compare{grid-template-columns:1fr}}
+.arch-card{background:var(--surface-inset);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:18px 20px}
+.arch-card h3{font-size:14px;color:var(--text-primary);font-weight:600;margin-bottom:10px;letter-spacing:-.01em}
+.arch-card pre{font-family:var(--font-mono);font-size:11.5px;line-height:1.7;color:var(--slate-300);white-space:pre}
+.arch-card .hl{color:var(--cyan-400)}.arch-card .gr{color:var(--green-500)}.arch-card .dm{color:var(--slate-500)}
+
+/* prose column — privacy, terms */
+.doc{padding:80px 0 96px}
+.doc .wrap{max-width:780px}
+.doc h1{font-size:clamp(28px,4.2vw,42px);font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin-bottom:8px;line-height:1.15}
+.doc .lede{font-size:17px;color:var(--text-tertiary);margin-bottom:36px;line-height:1.55}
+.doc h2{font-size:22px;font-weight:700;color:var(--text-primary);margin:40px 0 12px;letter-spacing:-.01em}
+.doc h3{font-size:16px;font-weight:600;color:var(--text-primary);margin:24px 0 8px}
+.doc p{margin-bottom:14px;color:var(--text-secondary)}
+.doc ul{margin:0 0 14px 22px;color:var(--text-secondary)}
+.doc li{margin-bottom:6px}
+.doc code{font-family:var(--font-mono);font-size:13px;color:var(--cyan-300);background:#0E1B33;padding:1px 6px;border-radius:4px}
+.doc hr{border:0;border-top:1px solid var(--border-subtle);margin:32px 0}
+.doc .meta{font-size:13px;color:var(--slate-500);margin-bottom:24px}
+.doc .pill{display:inline-block;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--amber-500);background:#F0A9341A;border:1px solid #F0A9343d;border-radius:var(--radius-full);padding:2px 10px;margin-bottom:18px}

--- a/website/terms.html
+++ b/website/terms.html
@@ -10,23 +10,6 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/site.css">
-<style>
-
-/* prose column */
-.doc{padding:80px 0 96px}
-.doc .wrap{max-width:780px}
-.doc h1{font-size:clamp(28px,4.2vw,42px);font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin-bottom:8px;line-height:1.15}
-.doc .lede{font-size:17px;color:var(--text-tertiary);margin-bottom:36px;line-height:1.55}
-.doc h2{font-size:22px;font-weight:700;color:var(--text-primary);margin:40px 0 12px;letter-spacing:-.01em}
-.doc h3{font-size:16px;font-weight:600;color:var(--text-primary);margin:24px 0 8px}
-.doc p{margin-bottom:14px;color:var(--text-secondary)}
-.doc ul{margin:0 0 14px 22px;color:var(--text-secondary)}
-.doc li{margin-bottom:6px}
-.doc code{font-family:var(--font-mono);font-size:13px;color:var(--cyan-300);background:#0E1B33;padding:1px 6px;border-radius:4px}
-.doc hr{border:0;border-top:1px solid var(--border-subtle);margin:32px 0}
-.doc .meta{font-size:13px;color:var(--slate-500);margin-bottom:24px}
-.doc .pill{display:inline-block;font-size:11px;font-weight:600;letter-spacing:.08em;text-transform:uppercase;color:var(--amber-500);background:#F0A9341A;border:1px solid #F0A9343d;border-radius:var(--radius-full);padding:2px 10px;margin-bottom:18px}
-</style>
 
 <!-- BEGIN:head-meta -->
 <link rel="canonical" href="https://mantaui.com/terms">

--- a/website/vs-conductor.html
+++ b/website/vs-conductor.html
@@ -10,29 +10,6 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/site.css">
-<style>
-
-/* page-specific: hero, verdict box, architectural difference */
-.hero-comp{padding:64px 0 36px;text-align:center}
-.hero-comp .wrap{position:relative;z-index:1}
-.hero-comp h1{font-size:clamp(32px,5vw,52px);line-height:1.1;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin:0 auto 18px;max-width:880px}
-.hero-comp .lede{font-size:clamp(15.5px,1.9vw,18px);color:var(--text-tertiary);max-width:720px;margin:0 auto;line-height:1.55}
-
-.verdict{background:var(--surface-card);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:24px 26px;max-width:880px;margin:40px auto 0}
-.verdict h2{font-size:11.5px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--cyan-400);margin-bottom:14px}
-.verdict ul{list-style:none;display:flex;flex-direction:column;gap:13px}
-.verdict li{display:flex;gap:14px;align-items:flex-start;font-size:14.5px;color:var(--text-secondary);line-height:1.55}
-.verdict li b{color:var(--text-primary);font-weight:600}
-.verdict .vtag{flex-shrink:0;font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.06em;color:var(--cyan-400);padding:4px 9px;border-radius:var(--radius-full);background:#49D7F51F;border:1px solid #49D7F53d;text-transform:uppercase;min-width:80px;text-align:center}
-
-.arch-compare{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:28px}
-@media(max-width:780px){.arch-compare{grid-template-columns:1fr}}
-.arch-card{background:var(--surface-inset);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:18px 20px}
-.arch-card h3{font-size:14px;color:var(--text-primary);font-weight:600;margin-bottom:10px;letter-spacing:-.01em}
-.arch-card pre{font-family:var(--font-mono);font-size:11.5px;line-height:1.7;color:var(--slate-300);white-space:pre}
-.arch-card .hl{color:var(--cyan-400)}.arch-card .gr{color:var(--green-500)}.arch-card .dm{color:var(--slate-500)}
-
-</style>
 
 <!-- BEGIN:head-meta -->
 <link rel="canonical" href="https://mantaui.com/vs-conductor">

--- a/website/vs-orca.html
+++ b/website/vs-orca.html
@@ -10,29 +10,6 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/site.css">
-<style>
-
-/* page-specific: hero, verdict box, architectural difference */
-.hero-comp{padding:64px 0 36px;text-align:center}
-.hero-comp .wrap{position:relative;z-index:1}
-.hero-comp h1{font-size:clamp(32px,5vw,52px);line-height:1.1;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin:0 auto 18px;max-width:880px}
-.hero-comp .lede{font-size:clamp(15.5px,1.9vw,18px);color:var(--text-tertiary);max-width:720px;margin:0 auto;line-height:1.55}
-
-.verdict{background:var(--surface-card);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:24px 26px;max-width:880px;margin:40px auto 0}
-.verdict h2{font-size:11.5px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--cyan-400);margin-bottom:14px}
-.verdict ul{list-style:none;display:flex;flex-direction:column;gap:13px}
-.verdict li{display:flex;gap:14px;align-items:flex-start;font-size:14.5px;color:var(--text-secondary);line-height:1.55}
-.verdict li b{color:var(--text-primary);font-weight:600}
-.verdict .vtag{flex-shrink:0;font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.06em;color:var(--cyan-400);padding:4px 9px;border-radius:var(--radius-full);background:#49D7F51F;border:1px solid #49D7F53d;text-transform:uppercase;min-width:80px;text-align:center}
-
-.arch-compare{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:28px}
-@media(max-width:780px){.arch-compare{grid-template-columns:1fr}}
-.arch-card{background:var(--surface-inset);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:18px 20px}
-.arch-card h3{font-size:14px;color:var(--text-primary);font-weight:600;margin-bottom:10px;letter-spacing:-.01em}
-.arch-card pre{font-family:var(--font-mono);font-size:11.5px;line-height:1.7;color:var(--slate-300);white-space:pre}
-.arch-card .hl{color:var(--cyan-400)}.arch-card .gr{color:var(--green-500)}.arch-card .dm{color:var(--slate-500)}
-
-</style>
 
 <!-- BEGIN:head-meta -->
 <link rel="canonical" href="https://mantaui.com/vs-orca">

--- a/website/vs-ssh-tmux.html
+++ b/website/vs-ssh-tmux.html
@@ -10,29 +10,6 @@
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
 <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/site.css">
-<style>
-
-/* page-specific: hero, verdict box, architectural difference */
-.hero-comp{padding:64px 0 36px;text-align:center}
-.hero-comp .wrap{position:relative;z-index:1}
-.hero-comp h1{font-size:clamp(32px,5vw,52px);line-height:1.1;font-weight:800;letter-spacing:-.03em;color:var(--text-primary);margin:0 auto 18px;max-width:880px}
-.hero-comp .lede{font-size:clamp(15.5px,1.9vw,18px);color:var(--text-tertiary);max-width:720px;margin:0 auto;line-height:1.55}
-
-.verdict{background:var(--surface-card);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:24px 26px;max-width:880px;margin:40px auto 0}
-.verdict h2{font-size:11.5px;font-weight:700;letter-spacing:.14em;text-transform:uppercase;color:var(--cyan-400);margin-bottom:14px}
-.verdict ul{list-style:none;display:flex;flex-direction:column;gap:13px}
-.verdict li{display:flex;gap:14px;align-items:flex-start;font-size:14.5px;color:var(--text-secondary);line-height:1.55}
-.verdict li b{color:var(--text-primary);font-weight:600}
-.verdict .vtag{flex-shrink:0;font-family:var(--font-mono);font-size:11px;font-weight:700;letter-spacing:.06em;color:var(--cyan-400);padding:4px 9px;border-radius:var(--radius-full);background:#49D7F51F;border:1px solid #49D7F53d;text-transform:uppercase;min-width:80px;text-align:center}
-
-.arch-compare{display:grid;grid-template-columns:1fr 1fr;gap:18px;margin-top:28px}
-@media(max-width:780px){.arch-compare{grid-template-columns:1fr}}
-.arch-card{background:var(--surface-inset);border:1px solid var(--border-default);border-radius:var(--radius-lg);padding:18px 20px}
-.arch-card h3{font-size:14px;color:var(--text-primary);font-weight:600;margin-bottom:10px;letter-spacing:-.01em}
-.arch-card pre{font-family:var(--font-mono);font-size:11.5px;line-height:1.7;color:var(--slate-300);white-space:pre}
-.arch-card .hl{color:var(--cyan-400)}.arch-card .gr{color:var(--green-500)}.arch-card .dm{color:var(--slate-500)}
-
-</style>
 
 <!-- BEGIN:head-meta -->
 <link rel="canonical" href="https://mantaui.com/vs-ssh-tmux">


### PR DESCRIPTION
## BET-907 — Hoist duplicated inline CSS into `site.css`

Pure deduplication: every rule in this PR is **moved verbatim** (byte-identical)
from each page's inline `<style>` block into `site.css`. No token value, colour,
or rule body changed anywhere. `website/index.html` is untouched (homepage
rebuild / BET-903 owns it).

### What moved

- **hero** (`.hero-comp`, `.hero-comp .wrap`, `.hero-comp h1`, `.hero-comp .lede`)
  — 8 pages: pricing, open-source, vs-conductor, vs-orca, vs-ssh-tmux,
  claude-code-mobile, claude-code-remote, claude-code-web-ui
- **verdict box** (`.verdict`, `.verdict h2/.ul/.li/li b/.vtag`) — 3 pages:
  vs-conductor, vs-orca, vs-ssh-tmux
- **architecture comparison** (`.arch-compare` incl. its `@media` rule,
  `.arch-card`, `.arch-card h3/pre/.hl/.gr/.dm`) — 3 pages: vs-conductor,
  vs-orca, vs-ssh-tmux
- **prose column** (`.doc`, `.doc .wrap/h1/.lede/h2/h3/p/ul/li/code/hr/.meta/.pill`)
  — 2 pages: privacy, terms

Hoisted into `site.css` at the end, each under a comment naming the pages that
use it (matching the existing `/* comparison table */` / `/* .checks */`
convention). Appending at the end means they land after every base definition,
so cascade order + specificity match what the inline blocks produced (inline
`<style>` came after the `site.css` `<link>`).

Deliberately broader than the issue's table, because the empirical dedupe scan
found three more byte-identical duplicates that the table missed — plain
`.hero-comp` and `.doc .meta` / `.doc .pill`. Left hoisting them out would have
failed acceptance (the dedupe script would still print them).

### Left alone, per the issue

Two selectors are byte-identical in count but **differ between pages**, so
they were intentionally **not** hoisted (the issue's "leave those alone and
list them" rule):

- `.phone::before` — differs between `claude-code-mobile.html` (notch 96px,
  top 12px) and `index.html` (notch 92px, top 11px)
- `.phone .scr` — differs between `claude-code-mobile.html` (margin-top 22px /
  22px-height, flex column) and `index.html` (margin-top 20px / 20px-height,
  position relative)

### Housekeeping done as part of the move

- Page-specific inline comments trimmed of the now-shared `"hero"` mention
  (kept the remaining genuinely page-specific list) on the 5 pages that still
  have inline styles.
- Inline `<style>` blocks that became empty were deleted entirely: privacy,
  terms, and all three `/vs/` pages.

### Verification

- **Dedupe script** (`python3 dedupe-scan`): prints **nothing** when re-run.
- **`git diff --stat`**: net-negative — 11 files, +42 / −133 (net −91).
- **Byte-identical move**: `git diff` shows removed inline rules are
  byte-identical to the added `site.css` rules; no body/colour/token edits.
- **Ordering**: `site.css` has no bare `h1`/`h2` element selectors that could
  collide with `.hero-comp h1` / `.doc h2` (the two the issue flagged); hoisted
  rules placed last so any same-specificity conflict resolves exactly as when
  they were inline.
- **Zero visual change**: rendered all 11 pages at 1280px before and after
  (network resources blocked for deterministic loading) and pixel-diffed —
  **all 11 identical**, including the untouched `index.html` control.

**Base: `origin/main` @ `d4da1f70`**
