### PR TITLE
fix(server): replay running state to /events clients on connect (BET-913)

### DIFF
--- a/src/server/events.mjs
+++ b/src/server/events.mjs
@@ -3,9 +3,24 @@
 
 export function createBus() {
   const subs = new Set();
+  // Optional state replay. `setSnapshot(fn)` registers a provider that returns
+  // the current-state events to emit to each NEW subscriber on connect. The
+  // bus itself is a pure forwarder (no retained history); this is the one
+  // deliberate exception so a (re)connecting client recovers edge-only state.
+  let snapshot = () => [];
   return {
-    subscribe(fn) { subs.add(fn); return () => subs.delete(fn); },
+    subscribe(fn) {
+      subs.add(fn);
+      // Replay current state to the newly (re)connected consumer. Edge-only
+      // frames like `stream.running` never re-fire on their own, so a client
+      // that connects mid-turn would never learn a session is already busy —
+      // this is exactly the force-quit + relaunch case, where the turn timer
+      // must survive a fresh process.
+      for (const evt of snapshot()) { try { fn(evt); } catch {} }
+      return () => subs.delete(fn);
+    },
     publish(evt) { for (const fn of subs) { try { fn(evt); } catch {} } },
+    setSnapshot(fn) { snapshot = fn; },
   };
 }
 

--- a/src/server/events.test.mjs
+++ b/src/server/events.test.mjs
@@ -15,6 +15,40 @@ test("bus delivers published events to subscribers and stops after unsubscribe",
   assert.equal(got.length, 1);
 });
 
+test("bus replays the registered snapshot to a new subscriber (state recovery on connect)", () => {
+  const bus = createBus();
+  bus.setSnapshot(() => [
+    { kind: "stream", sub: "running", sessionId: "ses_1", payload: { running: true, since: 1234 } },
+  ]);
+  const got = [];
+  const off = bus.subscribe((e) => got.push(e));
+  assert.equal(got.length, 1, "snapshot events reach the new subscriber immediately");
+  assert.equal(got[0].sub, "running");
+  assert.equal(got[0].payload.since, 1234);
+  // A second subscriber gets its own replay.
+  const got2 = [];
+  bus.subscribe((e) => got2.push(e));
+  assert.equal(got2.length, 1);
+  // Live events still flow after the snapshot replay.
+  bus.publish({ kind: "stream", sub: "flush", sessionId: "ses_1", payload: {} });
+  assert.equal(got.filter((e) => e.sub === "flush").length, 1);
+  off();
+});
+
+test("bus replays only the snapshot registered at subscribe time", () => {
+  const bus = createBus();
+  // No snapshot set yet -> new subscriber gets nothing replayed.
+  const got = [];
+  bus.subscribe((e) => got.push(e));
+  assert.equal(got.length, 0);
+  bus.setSnapshot(() => [
+    { kind: "stream", sub: "running", sessionId: "ses_1", payload: { running: true, since: 99 } },
+  ]);
+  const got2 = [];
+  bus.subscribe((e) => got2.push(e));
+  assert.equal(got2.length, 1, "subsequent subscriber replays the now-registered snapshot");
+});
+
 // ---------------------------------------------------------------------------
 // attachEventsWs heartbeat (BET-115 fix A, server side)
 //

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -186,6 +186,11 @@ const streamInterp = createStreamInterpreter({
   publish: (evt) => bus.publish(evt),
   contextLimitFor,
 });
+// BET-913: when a client (re)connects mid-turn, replay the current busy state
+// so edge-only frames like `running` aren't lost — this is what lets the iOs
+// turn timer survive a force-quit + relaunch. `snapshotBusy()` returns events
+// for sessions already running; the bus replays them to each new subscriber.
+bus.setSnapshot(() => streamInterp.snapshotBusy());
 // Shared deps passed to store-mutating helpers so they can publish the
 // `*.updated` bus event the renderer cards listen for (JobCard, WebhooksCard,
 // etc). Single source of truth — every endpoint that creates/deletes a

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -88,6 +88,7 @@ function newSessionState() {
     cachedTokens: 0,
     running: false,
     runningSince: null,        // epoch ms when the running turn started (idle->busy edge)
+    runningType: null,         // last session.status type ("busy"|"working"|"retry"|null); preserved for the connect-time snapshot replay
     todos: null,               // liveTodos (todo.updated) ; null = not seen
     msgByMsgId: new Map(),     // messageID -> minimal message for turn detection
     userTurnCount: 0,
@@ -454,6 +455,7 @@ export function createStreamInterpreter({
         // pre-S1b renderer semantics) — the box is the single source of truth,
         // so it must report the same value the renderer's raw handler does.
         setRunning(st, type === "busy" || type === "working" || type === "retry");
+        st.runningType = type ?? null;
         // `type` is ADDITIVE, not the indicator: `running` stays the single
         // source of truth for the running boolean, while `type` carries the
         // raw "busy" | "working" | "retry" (or null) so a thin client (iOS)
@@ -561,6 +563,29 @@ export function createStreamInterpreter({
   return {
     interpret,
     getState: (sid) => sessions.get(sid),
+    // Replay events for sessions that are currently running, for the bus's
+    // connect-time snapshot (BET-913). The `running` frame is emitted only on
+    // the idle->busy EDGE, so a client that (re)connects mid-turn never saw
+    // it — this reconstructs it (with the original `since`, so the turn timer
+    // survives a force-quit + relaunch). Empty when nothing is busy.
+    snapshotBusy() {
+      const out = [];
+      for (const [sid, st] of sessions) {
+        if (st.running && st.runningSince != null) {
+          out.push({
+            kind: "stream",
+            sub: "running",
+            sessionId: sid,
+            payload: {
+              running: true,
+              type: st.runningType ?? null,
+              since: st.runningSince,
+            },
+          });
+        }
+      }
+      return out;
+    },
     sessions,
   };
 }

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -359,6 +359,38 @@ test("session.status busy emits a running frame with a non-null since", () => {
   assert.equal(ev.payload.since, 42_000, "stamped from the injectable now()");
 });
 
+test("snapshotBusy replays a running frame for a currently-busy session only (BET-913)", () => {
+  const { interp } = make(42_000);
+  // Nothing busy yet -> no replay events.
+  assert.deepEqual(interp.snapshotBusy(), []);
+  // Start a turn; the replay carries the frame the busy->idle edge never
+  // re-emits, with the ORIGINAL since so the timer survives a fresh process.
+  interp.interpret({
+    type: "session.status",
+    properties: { sessionID: SID, status: { type: "busy" } },
+  });
+  const snap = interp.snapshotBusy();
+  assert.equal(snap.length, 1);
+  assert.equal(snap[0].kind, "stream");
+  assert.equal(snap[0].sub, "running");
+  assert.equal(snap[0].sessionId, SID);
+  assert.equal(snap[0].payload.running, true);
+  assert.equal(snap[0].payload.since, 42_000, "original idle->busy stamp, not reconnect time");
+  assert.equal(snap[0].payload.type, "busy", "last status type preserved additively");
+  // An idle session leaves nothing to replay.
+  interp.interpret({ type: "session.idle", properties: { sessionID: SID } });
+  assert.deepEqual(interp.snapshotBusy(), []);
+});
+
+test("snapshotBusy ignores sessions that were never marked running", () => {
+  const { interp } = make();
+  interp.interpret({
+    type: "message.part.delta",
+    properties: { sessionID: SID, messageID: "m", part: { id: "p", type: "text", text: "hi" } },
+  });
+  assert.deepEqual(interp.snapshotBusy(), []);
+});
+
 test("a second busy while already running emits the SAME since (clock not restarted)", () => {
   let clock = 100_000;
   const events = [];


### PR DESCRIPTION
## Why

BET-913: the turn timer is lost after a force-quit + relaunch on iOS. Root cause is server-side: the stream interpreter emits the `running` frame only on the idle→busy edge (`setRunning`), and the `/events` bus is pure pub/sub with no snapshot/replay. A client that (re)connects mid-turn — exactly what a force-quit does — never receives a `running { running: true, since }` frame for the still-in-progress turn, so iOS can never recover `runningSince` and the timer silently drops.

## Fix

Mechanism chosen: **snapshot/replay on subscribe** (one of the two options the issue suggested).

- `src/server/events.mjs` — `createBus()` gains `setSnapshot(fn)`. On `subscribe`, the bus replays the snapshot provider's events to the newly (re)connected consumer before registering it. The bus has exactly two subscribers (the `/events` SSE + WS attach fns), so this replay is scoped precisely to clients — no internal listener is affected.
- `src/server/streamInterp.mjs` — new `snapshotBusy()` returns a `stream.running` frame (with the **original** `since`, so the timer counts from the real turn start, not the reconnect) for every session currently `running`. Also preserves the last status `type` (`runningType`) so the replayed frame matches the live edge frame additively.
- `src/server/index.mjs` — wires `bus.setSnapshot(() => streamInterp.snapshotBusy())`.

No iOS change — out of scope by the issue. The replayed frame matches the existing `stream.running` contract (`{ running, since }`, `type` additive) the native client already consumes (`MantaEventStreamTests.swift` pins `running` + `since` -> `runningSince`).

## Verification results

**Files changed:** `5` files. `src/server/events.mjs`, `src/server/streamInterp.mjs`, `src/server/index.mjs`, `src/server/events.test.mjs`, `src/server/streamInterp.test.mjs` (+2 tests each).

- PR branch (`multica/BET-913-stream-running-replay` @ `3690a8c6`):
  - typecheck: exit 0. Errors: none. log sha256: `4a728c595e55b9a3615554f64c306078e7118536ceeeae4a7e7f46d0346eaacf`
  - test: exit 0, 2042 pass / 0 fail / 0 skip. Failures: none. log sha256: `e83b30f3a8a5129ee03a1190a47e08686fcd30e9ba4515f287e97a596002fd15`
- Base (`main` @ `720d9d7a`):
  - typecheck: exit 0. Errors: none. log sha256: `4a728c595e55b9a3615554f64c306078e7118536ceeeae4a7e7f46d0346eaacf`
  - test: exit 0, 2038 pass / 0 fail / 0 skip. Failures: none. log sha256: `79e3caf53ee46dbb067b96f00a0534b3b9bbbd5d4b2dbf9ae09ca9626782775e`
- **Conclusion:** 0 failures new; 4 new tests are the ones added by this PR. Typecheck log byte-identical to main.

**Base: origin/main @ `720d9d7a`**

**On-device re-verification owed:** the acceptance criterion (session-list row + chat running indicator show ~`1m` after force-quit + reopen) is an on-device check only `macos` can run against a real box. Flag for `macos` re-verify once merged.
