### PR TITLE
BET-914: fix(forge): an unknown default branch is unknown, not "main"

### DIFF
--- a/src/server/forge/github.mjs
+++ b/src/server/forge/github.mjs
@@ -715,18 +715,19 @@ export function createGithubAdapter(request, requestWrite, requestText = request
 
     /**
      * GET /repos/{o}/{r} — the repo's default branch (the PR base). Returns
-     * `"main"` when the field is missing or the payload is malformed.
+     * `null` (unknown) when the field is missing, the payload is malformed, or
+     * the request fails.
      * @param {{ owner: string, repo: string }} repo
-     * @returns {Promise<string>}
+     * @returns {Promise<string|null>}
      */
     async getDefaultBranch(repo) {
       let data = {};
       try {
         ({ data } = await request(`${apiBase}/repos/${repo.owner}/${repo.repo}`));
       } catch {
-        // fall through to "main"
+        // leave data empty — an unknown default branch is unknown
       }
-      return typeof data?.default_branch === "string" && data.default_branch ? data.default_branch : "main";
+      return typeof data?.default_branch === "string" && data.default_branch ? data.default_branch : null;
     },
 
     /**

--- a/src/server/forge/github.test.mjs
+++ b/src/server/forge/github.test.mjs
@@ -494,10 +494,18 @@ test("getDefaultBranch maps the repo's default_branch", async () => {
   assert.equal(await adapter.getDefaultBranch({ owner: "acme", repo: "widget" }), "develop");
 });
 
-test("getDefaultBranch falls back to main when the field is absent", async () => {
+test("getDefaultBranch returns null when the field is absent", async () => {
   const url = "https://api.github.com/repos/acme/widget";
   const adapter = createGithubAdapter(fakeRequest({ [url]: { full_name: "acme/widget" } }));
-  assert.equal(await adapter.getDefaultBranch({ owner: "acme", repo: "widget" }), "main");
+  assert.equal(await adapter.getDefaultBranch({ owner: "acme", repo: "widget" }), null);
+});
+
+test("getDefaultBranch returns null when the request fails", async () => {
+  const throwing = async () => {
+    throw new Error("rate limited");
+  };
+  const adapter = createGithubAdapter(throwing);
+  assert.equal(await adapter.getDefaultBranch({ owner: "acme", repo: "widget" }), null);
 });
 
 // ---- Work inbox (BET-795) --------------------------------------------------

--- a/src/server/forge/gitlab.mjs
+++ b/src/server/forge/gitlab.mjs
@@ -516,15 +516,16 @@ export function createGitlabAdapter(request, requestWrite, requestText = request
     },
 
     // GET /projects/{encoded id} — the repo's default branch (the PR base).
-    // Returns `"main"` when the field is missing or the payload is malformed.
+    // Returns `null` (unknown) when the field is missing, the payload is
+    // malformed, or the request fails.
     async getDefaultBranch(repo) {
       let data = {};
       try {
         ({ data } = await request(`${apiBase}${projectPath(repo)}`));
       } catch {
-        // fall through to "main"
+        // leave data empty — an unknown default branch is unknown
       }
-      return typeof data?.default_branch === "string" && data.default_branch ? data.default_branch : "main";
+      return typeof data?.default_branch === "string" && data.default_branch ? data.default_branch : null;
     },
   };
 }

--- a/src/server/forge/gitlab.test.mjs
+++ b/src/server/forge/gitlab.test.mjs
@@ -503,8 +503,16 @@ test("getDefaultBranch maps the project's default_branch", async () => {
   assert.equal(await adapter.getDefaultBranch(REPO), "develop");
 });
 
-test("getDefaultBranch falls back to main when the field is absent", async () => {
+test("getDefaultBranch returns null when the field is absent", async () => {
   const url = "https://gitlab.com/api/v4/projects/acme%2Fwidget";
   const adapter = createGitlabAdapter(fakeRequest({ [url]: { path_with_namespace: "acme/widget" } }));
-  assert.equal(await adapter.getDefaultBranch(REPO), "main");
+  assert.equal(await adapter.getDefaultBranch(REPO), null);
+});
+
+test("getDefaultBranch returns null when the request fails", async () => {
+  const throwing = async () => {
+    throw new Error("revoked token");
+  };
+  const adapter = createGitlabAdapter(throwing);
+  assert.equal(await adapter.getDefaultBranch(REPO), null);
 });

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -833,6 +833,7 @@ async function resolveWriteContext(cwd, deps, wantBranch = true) {
 export async function shipPreview(cwd, deps = {}) {
   const ctx = await resolveWriteContext(cwd, deps);
   if (ctx.error) return { ok: false, error: ctx.error };
+  if (!ctx.base) return { ok: false, error: "unknown_base" };
   const base = ctx.base;
   const runGit = deps.run ?? run;
 
@@ -1061,13 +1062,14 @@ async function defaultReadPrTemplate(cwd, deps = {}) {
  * shared 10s `run()`), then createPullRequest with the given config.
  *
  * @param {string} cwd
- * @param {{ title: string, body?: string, base?: string }} input
+ * @param {{ title: string, body?: string }} input
  * @param {object} [deps] injectable I/O
  * @returns {Promise<{ ok: true, pr: object, url: string } | { ok: false, error: string }>}
  */
-export async function shipPullRequest(cwd, { title, body = "", base } = {}, deps = {}) {
+export async function shipPullRequest(cwd, { title, body = "" } = {}, deps = {}) {
   const ctx = await resolveWriteContext(cwd, deps);
   if (ctx.error) return { ok: false, error: ctx.error };
+  if (!ctx.base) return { ok: false, error: "unknown_base" };
   const gitPush = deps.gitPush ?? localGitPush;
 
   try {
@@ -1081,7 +1083,7 @@ export async function shipPullRequest(cwd, { title, body = "", base } = {}, deps
     const res = await ctx.adapter.createPullRequest(ctx.repo, {
       title,
       body,
-      base: base ?? ctx.base,
+      base: ctx.base,
       head: ctx.head,
     });
     pr = res.data;

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -394,7 +394,7 @@ test("shipPullRequest: push (setUpstream) then createPullRequest without a draft
       return { data: created, stale: false };
     },
   };
-  const r = await shipPullRequest("/repo", { title: "Forge seam", body: "B", base: "main" }, {
+  const r = await shipPullRequest("/repo", { title: "Forge seam", body: "B" }, {
     ...SHIP_DEPS,
     getAdapter: () => adapter,
     gitPush: async (i) => { pushed.push(i); return { stdout: "", stderr: "" }; },
@@ -499,17 +499,24 @@ test("shipPullRequest passes the forge-resolved base to createPullRequest", asyn
   assert.equal(created[0].base, "master");
 });
 
-test("shipPullRequest: an explicit base input still wins over the resolved one", async () => {
-  const created = [];
-  const adapter = createSpyAdapter(created);
-  const r = await shipPullRequest("/repo", { title: "t", body: "B", base: "trunk" }, {
-    ...SHIP_DEPS,
-    getAdapter: () => adapter,
-    getDefaultBranch: async () => "master",
+test("shipPreview refuses an unknown base without running any git", async () => {
+  let runCalls = 0;
+  const r = await shipPreview("/repo", {
+    ...linkedShipDeps({ getDefaultBranch: async () => null }),
+    run: async () => { runCalls += 1; return { stdout: "", stderr: "" }; },
   });
-  assert.equal(r.ok, true);
-  assert.equal(created.length, 1);
-  assert.equal(created[0].base, "trunk");
+  assert.deepEqual(r, { ok: false, error: "unknown_base" });
+  assert.equal(runCalls, 0, "no git call happens when the base is unknown");
+});
+
+test("shipPullRequest refuses an unknown base and never pushes", async () => {
+  const pushed = [];
+  const r = await shipPullRequest("/repo", { title: "t", body: "B" }, {
+    ...linkedShipDeps({ getDefaultBranch: async () => null }),
+    gitPush: async (i) => { pushed.push(i); },
+  });
+  assert.deepEqual(r, { ok: false, error: "unknown_base" });
+  assert.equal(pushed.length, 0, "a PR that cannot exist must not leave a pushed branch behind");
 });
 
 test("shipPreview drafts a title from the tip commit (design step 1)", async () => {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -589,13 +589,13 @@ export type ForgeInboxResult = {
 // ----- Forge write path (BET-794) -----
 
 // forge:ship input — push the current branch then (only after the renderer's
-// human confirm card) open a pull request. `base` defaults to "main". PRs are
-// always created as real (non-draft) pull requests (BET-892).
+// human confirm card) open a pull request. The PR base is the forge-resolved
+// repo default branch — callers never supply one. PRs are always created as
+// real (non-draft) pull requests (BET-892).
 export type ForgeShipInput = {
   cwd: string;
   title: string;
   body?: string;
-  base?: string;
 };
 
 export type ForgeShipResult =


### PR DESCRIPTION
## Summary

BET-914: an unknown default branch is now unknown, not `"main"` — and nothing ships against an unknown base.

- **`getDefaultBranch`** (both `github.mjs` and `gitlab.mjs`) returns `string | null`: the repo's `default_branch` when present, `null` when the field is missing, the payload is malformed, or the request fails. The `// fall through to "main"` comment in each `catch` is gone.
- **`shipPreview`** refuses an unknown base (`{ ok: false, error: "unknown_base" }`) before any git call, so the "0 files" lie from an unresolved `origin/main...<head>` diff is impossible.
- **`shipPullRequest`** refuses an unknown base before the push, so a PR that cannot exist never leaves a pushed branch behind. Its now-unused `base` input override is removed — the forge-resolved base is the only resolution path, passed as `base: ctx.base` to `createPullRequest`.
- **`ForgeShipInput`** drops its `base?: string` field.

`normalizeRepo`'s `defaultBranch: r?.default_branch ?? "main"` (github.mjs) is intentionally untouched — different consumer, retains its fallback.

## Verification results

**Files changed:** `7` files: `src/server/forge/{github,gitlab,index}.mjs`, `src/shared/types.ts`, and the three test files.

- PR branch (`multica/BET-914-unknown-default-branch` @ `456b21a4`):
  - typecheck: exit `0`. Errors: none. log sha256: `4a728c595e55b9a3615554f64c306078e7118536ceeeae4a7e7f46d0346eaacf`
  - test: exit `0`, `2041` pass / `0` fail / `0` skip. Failures: none. log sha256: `ac97d570766db96bbcaf0c55f42aefa827164d3931b0e1581693b0e2370b9b4f`
- Base (`origin/main` @ `a7ba85a5`): verified via `git reset --hard origin/main` before branching; base SHA recorded below.
- **Conclusion:** `0` new failures. All tests green on the PR branch.

Base: `origin/main @ a7ba85a5`
