### PR TITLE
chore: release 0.0.27

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.26",
+      "version": "0.0.27",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.26",
+  "version": "0.0.27",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.26",
+ "version": "0.0.27",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Version bump so the server tarball published by the next `server-v*` tag is actually installable.

`self-update.sh` compares only the version string (`scripts/self-update.sh:167-171`), so a release built under an existing version is silently skipped by every box. `server-v22` republished `0.0.26` carrying the BET-891 / BET-892 forge fixes — no box would take it. Same trap as the 0.0.25 → 0.0.26 bump.

Also bumps `website/updates/server.json`, the in-app update offer a running box polls every 6h; left at 0.0.26 it would never offer 0.0.27.

Deploy order after merge: `server-v23` first (publishes the 0.0.27 tarball), then `web-v26` (points the update offer at it).