### PR TITLE
BET-917: fix(website): repoint dead homepage anchor links to real pages

### DIFF
--- a/website/claude-code-mobile.html
+++ b/website/claude-code-mobile.html
@@ -138,8 +138,8 @@
       <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
       <div class="navlinks">
         <a href="/" class="hide-sm">Home</a>
-        <a href="/#compare" class="hide-sm">Compare</a>
-        <a href="/#how" class="hide-sm">How it works</a>
+        <a href="/vs-orca" class="hide-sm">Compare</a>
+        <a href="/claude-code-remote" class="hide-sm">How it works</a>
         <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
       </div>
     </nav>
@@ -277,9 +277,9 @@
         <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
       </div>
       <div><h4>Product</h4><ul>
-        <li><a href="/#features">Features</a></li><li><a href="/#mobile">Mobile</a></li>
-        <li><a href="/#opensource">Open source</a></li>
-        <li><a href="/#how">How it works</a></li></ul></div>
+        <li><a href="/">Features</a></li><li><a href="/claude-code-mobile">Mobile</a></li>
+        <li><a href="/open-source">Open source</a></li>
+        <li><a href="/claude-code-remote">How it works</a></li></ul></div>
       <div><h4>Compare</h4><ul>
         <li><a href="/vs-orca">vs Orca</a></li>
         <li><a href="/vs-conductor">vs Conductor</a></li>

--- a/website/claude-code-remote.html
+++ b/website/claude-code-remote.html
@@ -131,8 +131,8 @@
       <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
       <div class="navlinks">
         <a href="/" class="hide-sm">Home</a>
-        <a href="/#compare" class="hide-sm">Compare</a>
-        <a href="/#how" class="hide-sm">How it works</a>
+        <a href="/vs-orca" class="hide-sm">Compare</a>
+        <a href="/claude-code-remote" class="hide-sm">How it works</a>
         <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
       </div>
     </nav>
@@ -284,9 +284,9 @@
         <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
       </div>
       <div><h4>Product</h4><ul>
-        <li><a href="/#features">Features</a></li><li><a href="/#mobile">Mobile</a></li>
-        <li><a href="/#opensource">Open source</a></li>
-        <li><a href="/#how">How it works</a></li></ul></div>
+        <li><a href="/">Features</a></li><li><a href="/claude-code-mobile">Mobile</a></li>
+        <li><a href="/open-source">Open source</a></li>
+        <li><a href="/claude-code-remote">How it works</a></li></ul></div>
       <div><h4>Compare</h4><ul>
         <li><a href="/vs-orca">vs Orca</a></li>
         <li><a href="/vs-conductor">vs Conductor</a></li>

--- a/website/claude-code-web-ui.html
+++ b/website/claude-code-web-ui.html
@@ -136,8 +136,8 @@
       <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
       <div class="navlinks">
         <a href="/" class="hide-sm">Home</a>
-        <a href="/#compare" class="hide-sm">Compare</a>
-        <a href="/#how" class="hide-sm">How it works</a>
+        <a href="/vs-orca" class="hide-sm">Compare</a>
+        <a href="/claude-code-remote" class="hide-sm">How it works</a>
         <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
       </div>
     </nav>
@@ -276,9 +276,9 @@
         <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
       </div>
       <div><h4>Product</h4><ul>
-        <li><a href="/#features">Features</a></li><li><a href="/#mobile">Mobile</a></li>
-        <li><a href="/#opensource">Open source</a></li>
-        <li><a href="/#how">How it works</a></li></ul></div>
+        <li><a href="/">Features</a></li><li><a href="/claude-code-mobile">Mobile</a></li>
+        <li><a href="/open-source">Open source</a></li>
+        <li><a href="/claude-code-remote">How it works</a></li></ul></div>
       <div><h4>Compare</h4><ul>
         <li><a href="/vs-orca">vs Orca</a></li>
         <li><a href="/vs-conductor">vs Conductor</a></li>

--- a/website/index.html
+++ b/website/index.html
@@ -136,8 +136,8 @@
       <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
       <div class="navlinks">
         <a href="/" class="hide-sm">Home</a>
-        <a href="/#compare" class="hide-sm">Compare</a>
-        <a href="/#how" class="hide-sm">How it works</a>
+        <a href="/vs-orca" class="hide-sm">Compare</a>
+        <a href="/claude-code-remote" class="hide-sm">How it works</a>
         <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
       </div>
     </nav>
@@ -174,9 +174,9 @@
         <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
       </div>
       <div><h4>Product</h4><ul>
-        <li><a href="/#features">Features</a></li><li><a href="/#mobile">Mobile</a></li>
-        <li><a href="/#opensource">Open source</a></li>
-        <li><a href="/#how">How it works</a></li></ul></div>
+        <li><a href="/">Features</a></li><li><a href="/claude-code-mobile">Mobile</a></li>
+        <li><a href="/open-source">Open source</a></li>
+        <li><a href="/claude-code-remote">How it works</a></li></ul></div>
       <div><h4>Compare</h4><ul>
         <li><a href="/vs-orca">vs Orca</a></li>
         <li><a href="/vs-conductor">vs Conductor</a></li>

--- a/website/llms-full.txt
+++ b/website/llms-full.txt
@@ -3,8 +3,8 @@
 MantaMantaUI
 
         [Home](/)
-        [Compare](/#compare)
-        [How it works](/#how)
+        [Compare](/vs-orca)
+        [How it works](/claude-code-remote)
         [GitHub](https://github.com/antoinedc/MantaUI)
 
     # Claude Code on your phone, with full parity
@@ -109,12 +109,12 @@ Straight to the box. The phone pairs with the box directly over HTTPS, the same 
 
       #### Product
 
-        - [Features](/#features)
-- [Mobile](/#mobile)
+        - [Features](/)
+- [Mobile](/claude-code-mobile)
 
-        - [Open source](/#opensource)
+        - [Open source](/open-source)
 
-        - [How it works](/#how)
+        - [How it works](/claude-code-remote)
 
       #### Compare
 
@@ -153,8 +153,8 @@ Straight to the box. The phone pairs with the box directly over HTTPS, the same 
 MantaMantaUI
 
         [Home](/)
-        [Compare](/#compare)
-        [How it works](/#how)
+        [Compare](/vs-orca)
+        [How it works](/claude-code-remote)
         [GitHub](https://github.com/antoinedc/MantaUI)
 
     # Run Claude Code on a server you control
@@ -277,12 +277,12 @@ Yes, and the install script is auditable before you pipe it into bash. The repos
 
       #### Product
 
-        - [Features](/#features)
-- [Mobile](/#mobile)
+        - [Features](/)
+- [Mobile](/claude-code-mobile)
 
-        - [Open source](/#opensource)
+        - [Open source](/open-source)
 
-        - [How it works](/#how)
+        - [How it works](/claude-code-remote)
 
       #### Compare
 
@@ -321,8 +321,8 @@ Yes, and the install script is auditable before you pipe it into bash. The repos
 MantaMantaUI
 
         [Home](/)
-        [Compare](/#compare)
-        [How it works](/#how)
+        [Compare](/vs-orca)
+        [How it works](/claude-code-remote)
         [GitHub](https://github.com/antoinedc/MantaUI)
 
     # A self-hosted web UI for Claude Code
@@ -428,12 +428,12 @@ Yes. The browser is a client to the box, not the place where the agent runs. Clo
 
       #### Product
 
-        - [Features](/#features)
-- [Mobile](/#mobile)
+        - [Features](/)
+- [Mobile](/claude-code-mobile)
 
-        - [Open source](/#opensource)
+        - [Open source](/open-source)
 
-        - [How it works](/#how)
+        - [How it works](/claude-code-remote)
 
       #### Compare
 
@@ -472,235 +472,9 @@ Yes. The browser is a client to the box, not the place where the agent runs. Clo
 MantaMantaUI
 
         [Home](/)
-        [Compare](/#compare)
-        [How it works](/#how)
+        [Compare](/vs-orca)
+        [How it works](/claude-code-remote)
         [GitHub](https://github.com/antoinedc/MantaUI)
-
-    # Your agents keep working after you close the laptop
-
-    Manta runs Claude Code and opencode in real tmux on a Linux box or Mac you own. The desktop app and the phone app are both full clients. Close either one and the work carries on.
-
-        Coding agent
-        Manual
-
-          Set up this box as a Manta UI server, a self-hosted Claude Code client for desktop and mobile. Follow https://mantaui.com/llms-install.md exactly.
-
-          this.textContent='Copy',1400)">Copy
-
-        Paste this into Claude Code, opencode or Cursor on the box you want to use.
-
-          `$ curl -fsSL https://mantaui.com/install.sh | bash`
-          this.textContent='Copy',1400)">Copy
-
-        Runs on Linux or macOS. No Node install, no compiler, no sudo. Prints a pairing code when it finishes.
-
-      [Download for macOS](https://mantaui.com/downloads/Manta-latest.dmg)
-      See how it compares
-
-    Free. No signup. Runs on hardware you already own.
-
-        The difference
-        ## Shut the lid and the work carries on
-
-        Manta's server runs on your box as a system service. Your agents live in real tmux windows. The desktop app and the phone app are clients, so you can close every one of them and nothing stops.
-
-          - ✓ Agents keep working with no client connected
-
-          - ✓ Reconnect from any device and the full history is there
-
-          - ✓ Survives a reboot, because it is a system service
-
-          - ✓ Your phone buzzes when the agent needs a decision
-
-          Orca's own docs: Closing the desktop app drops the connection. There is no cloud relay.
-          Conductor sells this as their paid beta: close your laptop during a task and the agent keeps going.
-          quoted verbatim, linked and dated on /vs/orca and /vs/conductor
-
-            9:41
-            Tuesday, 14 October
-
-                Mantanow
-
-              ethernal / feat-auth
-              Permission needed: Bash(rm -rf ./dist)
-              DenyAllow
-
-      What you get
-      ## Everything the agent does, on every device
-
-      The desktop app and the phone app run the same code, so the transcript, the tool output and the approval buttons are identical on both.
-
-        ### Real tmux underneath
-
-        A chat panel and a real `tmux` terminal for every window. Your box stays a normal tmux server, so you can still SSH in and attach to the same session.
-
-        Orca and Conductor each run their own process model. Neither leaves the box usable without their app.
-
-        ### The phone app is the same app
-
-        Same code as the desktop: full transcript, live command output, approvals, dictation and file uploads. A native iPhone app, and any browser everywhere else.
-
-        Orca calls its mobile app "read-mostly" and "intentionally not a full editor". Conductor has no phone app.
-
-        ### Notifications that know where you are
-
-        Working at your desk? Your phone stays quiet. Away from it? The desktop gets it first and your phone 90 seconds later. Anything blocking reaches every device at once.
-
-        Neither competitor routes notifications at all.
-
-        ### You approve what runs
-
-        Permissions and questions arrive as cards you answer with one tap. Allow, deny, or write a clarification. Trust a whole session when you want it to move faster.
-
-        Orca ships --dangerously-skip-permissions pre-filled. Conductor's docs say agents run without sandboxing.
-
-        ### A worktree per session
-
-        New sessions in a git repo branch their own sibling worktree, so several agents work in parallel without standing on each other. Close the session and Manta offers to remove the worktree, asking first if anything is uncommitted.
-
-        Command output also streams live, and a context bar splits fresh tokens from cached ones so a cold cache does not surprise you.
-
-        ### It works out how to reach you
-
-        The installer checks whether Tailscale is already running. If it is, your devices connect over your tailnet and nothing is published to the internet. If it is not, the box gets its own hostname and an HTTPS certificate. You do not pick.
-
-        Orca requires Tailscale and tells you not to expose its port to the internet. Here a tailnet is one of two supported paths, not a prerequisite.
-
-      Nobody else does this
-      ## The agent can reach you between turns
-
-      Manta gives the agent a few tools of its own. It can put work on a timer, wake up when something happens outside, or ask for your attention on whichever device you are using.
-
-        ### Schedule
-
-        Ask it to check the deploy every five minutes. The prompt re-runs in this session on a cron, on the server, whether or not you are connected.
-
-        ### Webhooks
-
-        Hand your CI a signed URL. The session wakes up when the build finishes, instead of burning tokens asking whether it is done yet.
-
-        ### Secrets
-
-        The agent gets a file path, never the value. Your token goes into the command at run time and never appears in the transcript.
-
-        ### Notify
-
-        Ask to be told when the migration finishes. Manta picks the device based on where you have actually been active.
-
-        ### Peers
-
-        Agents in the same workspace can see and message each other, so one can warn another before touching a file it is editing.
-
-        ### Serve page
-
-        The agent publishes a preview to a URL you can open on any device, with no file transfer in between.
-
-      Setup
-      ## Paired in under a minute
-
-      No SSH keys to distribute and no tunnel to keep alive. The server installs on your box, works out how to make itself reachable, and you pair each device once.
-
-        STEP 01
-        ### Install on your box
-
-        One command. It ships its own Node runtime, so there is no compiler and no package manager involved. It then works out how devices will reach the box: over your tailnet if Tailscale is already running, otherwise through Caddy and a Let's Encrypt certificate on <your-box>.boxes.mantaui.com.
-
-        STEP 02
-        ### Pair a device
-
-        Type in the six-digit code the installer printed. The device gets a token, and every call after that is authenticated over HTTPS.
-
-        STEP 03
-        ### Start working
-
-        Create a project and open a session. Install the phone app, pair it with a second code, and the same sessions are there.
-
-```
-   Desktop app                Phone app                  Browser
-        │                          │                         │
-        └──────────────────  HTTPS  ────────────────────────┘
-                                │
-   <box_id>.boxes.mantaui.com   or   your box on the tailnet
-   Caddy + Let's Encrypt                  if Tailscale is already running
-
-        the installer detects which one applies and sets it up
-                                │
-                       YOUR LINUX BOX OR MAC
-              manta-server  ── owns tmux, files, config, secrets
-                ├── tmux ── your sessions  (keep running with 0 clients)
-                └── opencode ── chat mode and agent tools
-```
-
-      Away from your desk
-      ## The whole session on your phone
-
-      Reading a terminal UI on a phone keyboard is miserable. This is the actual client: read the diff, approve the risky command, dictate what to do next.
-
-          - ✓ A native iPhone app, and any browser everywhere else
-
-          - ✓ Full transcript, live command output and inline diffs
-
-          - ✓ Answer permissions and questions with one tap
-
-          - ✓ Dictate a reply instead of typing it
-
-          - ✓ Push for permissions, questions, errors and finished work
-
-          - ✓ Talks straight to your box, with no account in between
-
-          A phone client that cannot approve a permission also cannot unblock an agent. The work still waits until you get back to your laptop, which defeats the point of carrying it around.
-
-      Manta UI session with live tool output
-
-      Honest comparison
-      ## How Manta compares
-
-      Orca and Conductor run agents on your laptop. Termius over SSH runs them on a VPS already, which is most of the way there. These are the axes we chose to compete on. The full picture, including what the others do better, is on each comparison page.
-
-          Manta UI
-          Orca
-          Conductor
-          Termius + SSH
-
-          Agents run onYour VPSYour desktopYour MacYour VPS
-          Keeps running with every client closedYesNoPaid betaYes
-          Phone clientThe full appRead-mostlyNoneTerminal only
-          Approve a command from your phoneOne tapLimitedNoType into the TUI
-          Tells you when the agent is blockedPushNoNoNo
-          Remote accessDetected and set upTailscale requiredCloud betaSSH keys by hand
-          Git worktree per sessionYesYesYesBy hand
-          Agent scheduling, webhooks, secretsYesNoNoNo
-          Real tmux underneathYesNoNoYes
-          Account requiredNoFor mobileYesTo sync
-          LicenceMITMITProprietaryProprietary
-          PriceFreeFreeFree, plus ProFree, plus paid
-
-          [Full comparison →](/vs-orca)
-          [Full comparison →](/vs-conductor)
-          [Full comparison →](/vs-ssh-tmux)
-
-      If you already run Claude Code on a VPS and reach it with Termius, you have solved the hard part. What Manta adds is a readable transcript instead of a TUI, one-tap approvals, and a notification the moment the agent gets stuck.
-      Orca and Conductor each do things Manta does not, including diff review and a built-in editor, and Orca supports far more agent runtimes. Each comparison page lays that out in full. Sourced from public docs, dated and linked.
-
-      Open source
-      ## Yours to run, read and fork
-
-      Being open source is table stakes here, because Orca is MIT too. The combination is what differs: open source, self-hosted, no account, and a server that outlives whichever client you happen to be holding.
-
-          - ✓Runs on hardware you own. There is no hosted control plane, no workspace limit and no seat count.
-
-          - ✓Your code stays on the box. The only thing that leaves is your agent talking to its model provider.
-
-          - ✓Nothing to sign up for. Pairing is a six-digit code your own machine generates.
-
-          - ✓Read [install.sh](/install.sh) before you pipe it into bash. We would rather you did.
-
-          - ✓MIT licensed. Fork it, run your own gateway, write your own client.
-
-         antoinedc / MantaUI
-        Open-source, self-hosted Claude Code and opencode client. Agents run in real tmux on your own Linux box or Mac, and you drive them from desktop, phone or browser over HTTPS.
-
-          MIT licenceTypeScriptIssues open
 
       FAQ
       ## Questions people actually ask
@@ -739,322 +513,17 @@ Claude Code and opencode today. Anything that runs in a terminal works in termin
 
 It overlaps with both, on a different bet. They run agents on your Mac and give you a window onto them. Manta runs agents on a box you own and gives every device the same window, so the work outlives whatever you are holding.
 
-    ## Put it on your own box
-
-    Free, no signup, and it runs on hardware you already have.
-
-        `$ curl -fsSL https://mantaui.com/install.sh | bash`
-        this.textContent='Copy',1400)">Copy
-
-      [Download for macOS](https://mantaui.com/downloads/Manta-latest.dmg)
-
-      Read the docs
-
         MantaMantaUI
         Self-hosted coding agents you can reach from anywhere.
 
       #### Product
 
-        - [Features](/#features)
-- [Mobile](/#mobile)
-
-        - [Open source](/#opensource)
-
-        - [How it works](/#how)
-
-      #### Compare
-
-        - [vs Orca](/vs-orca)
-
-        - [vs Conductor](/vs-conductor)
-
-        - [vs SSH and tmux](/vs-ssh-tmux)
-
-      #### Use cases
-
-        - [Claude Code web UI](/claude-code-web-ui)
-
-        - [Claude Code on mobile](/claude-code-mobile)
-
-        - [Claude Code remote](/claude-code-remote)
+        - [Features](/)
+- [Mobile](/claude-code-mobile)
 
         - [Open source](/open-source)
 
-      #### Resources
-
-        - [GitHub](https://github.com/antoinedc/MantaUI)
-
-        - [Pricing](/pricing)
-
-        - [Privacy](/privacy)
-
-        - [Terms](/terms)
-
-      MIT licensed. Built for people who pair with agents.
-      llms.txt · llms-full.txt · /.well-known/agent-skills
-
-        The difference
-        ## Shut the lid and the work carries on
-
-        Manta's server runs on your box as a system service. Your agents live in real tmux windows. The desktop app and the phone app are clients, so you can close every one of them and nothing stops.
-
-          - ✓ Agents keep working with no client connected
-
-          - ✓ Reconnect from any device and the full history is there
-
-          - ✓ Survives a reboot, because it is a system service
-
-          - ✓ Your phone buzzes when the agent needs a decision
-
-          Orca's own docs: Closing the desktop app drops the connection. There is no cloud relay.
-          Conductor sells this as their paid beta: close your laptop during a task and the agent keeps going.
-          quoted verbatim, linked and dated on /vs/orca and /vs/conductor
-
-            9:41
-            Tuesday, 14 October
-
-                Mantanow
-
-              ethernal / feat-auth
-              Permission needed: Bash(rm -rf ./dist)
-              DenyAllow
-
-      What you get
-      ## Everything the agent does, on every device
-
-      The desktop app and the phone app run the same code, so the transcript, the tool output and the approval buttons are identical on both.
-
-        ### Real tmux underneath
-
-        A chat panel and a real `tmux` terminal for every window. Your box stays a normal tmux server, so you can still SSH in and attach to the same session.
-
-        Orca and Conductor each run their own process model. Neither leaves the box usable without their app.
-
-        ### The phone app is the same app
-
-        Same code as the desktop: full transcript, live command output, approvals, dictation and file uploads. A native iPhone app, and any browser everywhere else.
-
-        Orca calls its mobile app "read-mostly" and "intentionally not a full editor". Conductor has no phone app.
-
-        ### Notifications that know where you are
-
-        Working at your desk? Your phone stays quiet. Away from it? The desktop gets it first and your phone 90 seconds later. Anything blocking reaches every device at once.
-
-        Neither competitor routes notifications at all.
-
-        ### You approve what runs
-
-        Permissions and questions arrive as cards you answer with one tap. Allow, deny, or write a clarification. Trust a whole session when you want it to move faster.
-
-        Orca ships --dangerously-skip-permissions pre-filled. Conductor's docs say agents run without sandboxing.
-
-        ### A worktree per session
-
-        New sessions in a git repo branch their own sibling worktree, so several agents work in parallel without standing on each other. Close the session and Manta offers to remove the worktree, asking first if anything is uncommitted.
-
-        Command output also streams live, and a context bar splits fresh tokens from cached ones so a cold cache does not surprise you.
-
-        ### It works out how to reach you
-
-        The installer checks whether Tailscale is already running. If it is, your devices connect over your tailnet and nothing is published to the internet. If it is not, the box gets its own hostname and an HTTPS certificate. You do not pick.
-
-        Orca requires Tailscale and tells you not to expose its port to the internet. Here a tailnet is one of two supported paths, not a prerequisite.
-
-      Nobody else does this
-      ## The agent can reach you between turns
-
-      Manta gives the agent a few tools of its own. It can put work on a timer, wake up when something happens outside, or ask for your attention on whichever device you are using.
-
-        ### Schedule
-
-        Ask it to check the deploy every five minutes. The prompt re-runs in this session on a cron, on the server, whether or not you are connected.
-
-        ### Webhooks
-
-        Hand your CI a signed URL. The session wakes up when the build finishes, instead of burning tokens asking whether it is done yet.
-
-        ### Secrets
-
-        The agent gets a file path, never the value. Your token goes into the command at run time and never appears in the transcript.
-
-        ### Notify
-
-        Ask to be told when the migration finishes. Manta picks the device based on where you have actually been active.
-
-        ### Peers
-
-        Agents in the same workspace can see and message each other, so one can warn another before touching a file it is editing.
-
-        ### Serve page
-
-        The agent publishes a preview to a URL you can open on any device, with no file transfer in between.
-
-      Setup
-      ## Paired in under a minute
-
-      No SSH keys to distribute and no tunnel to keep alive. The server installs on your box, works out how to make itself reachable, and you pair each device once.
-
-        STEP 01
-        ### Install on your box
-
-        One command. It ships its own Node runtime, so there is no compiler and no package manager involved. It then works out how devices will reach the box: over your tailnet if Tailscale is already running, otherwise through Caddy and a Let's Encrypt certificate on <your-box>.boxes.mantaui.com.
-
-        STEP 02
-        ### Pair a device
-
-        Type in the six-digit code the installer printed. The device gets a token, and every call after that is authenticated over HTTPS.
-
-        STEP 03
-        ### Start working
-
-        Create a project and open a session. Install the phone app, pair it with a second code, and the same sessions are there.
-
-```
-   Desktop app                Phone app                  Browser
-        │                          │                         │
-        └──────────────────  HTTPS  ────────────────────────┘
-                                │
-   <box_id>.boxes.mantaui.com   or   your box on the tailnet
-   Caddy + Let's Encrypt                  if Tailscale is already running
-
-        the installer detects which one applies and sets it up
-                                │
-                       YOUR LINUX BOX OR MAC
-              manta-server  ── owns tmux, files, config, secrets
-                ├── tmux ── your sessions  (keep running with 0 clients)
-                └── opencode ── chat mode and agent tools
-```
-
-      Away from your desk
-      ## The whole session on your phone
-
-      Reading a terminal UI on a phone keyboard is miserable. This is the actual client: read the diff, approve the risky command, dictate what to do next.
-
-          - ✓ A native iPhone app, and any browser everywhere else
-
-          - ✓ Full transcript, live command output and inline diffs
-
-          - ✓ Answer permissions and questions with one tap
-
-          - ✓ Dictate a reply instead of typing it
-
-          - ✓ Push for permissions, questions, errors and finished work
-
-          - ✓ Talks straight to your box, with no account in between
-
-          A phone client that cannot approve a permission also cannot unblock an agent. The work still waits until you get back to your laptop, which defeats the point of carrying it around.
-
-      Manta UI session with live tool output
-
-      Honest comparison
-      ## How Manta compares
-
-      Orca and Conductor run agents on your laptop. Termius over SSH runs them on a VPS already, which is most of the way there. These are the axes we chose to compete on. The full picture, including what the others do better, is on each comparison page.
-
-          Manta UI
-          Orca
-          Conductor
-          Termius + SSH
-
-          Agents run onYour VPSYour desktopYour MacYour VPS
-          Keeps running with every client closedYesNoPaid betaYes
-          Phone clientThe full appRead-mostlyNoneTerminal only
-          Approve a command from your phoneOne tapLimitedNoType into the TUI
-          Tells you when the agent is blockedPushNoNoNo
-          Remote accessDetected and set upTailscale requiredCloud betaSSH keys by hand
-          Git worktree per sessionYesYesYesBy hand
-          Agent scheduling, webhooks, secretsYesNoNoNo
-          Real tmux underneathYesNoNoYes
-          Account requiredNoFor mobileYesTo sync
-          LicenceMITMITProprietaryProprietary
-          PriceFreeFreeFree, plus ProFree, plus paid
-
-          [Full comparison →](/vs-orca)
-          [Full comparison →](/vs-conductor)
-          [Full comparison →](/vs-ssh-tmux)
-
-      If you already run Claude Code on a VPS and reach it with Termius, you have solved the hard part. What Manta adds is a readable transcript instead of a TUI, one-tap approvals, and a notification the moment the agent gets stuck.
-      Orca and Conductor each do things Manta does not, including diff review and a built-in editor, and Orca supports far more agent runtimes. Each comparison page lays that out in full. Sourced from public docs, dated and linked.
-
-      Open source
-      ## Yours to run, read and fork
-
-      Being open source is table stakes here, because Orca is MIT too. The combination is what differs: open source, self-hosted, no account, and a server that outlives whichever client you happen to be holding.
-
-          - ✓Runs on hardware you own. There is no hosted control plane, no workspace limit and no seat count.
-
-          - ✓Your code stays on the box. The only thing that leaves is your agent talking to its model provider.
-
-          - ✓Nothing to sign up for. Pairing is a six-digit code your own machine generates.
-
-          - ✓Read [install.sh](/install.sh) before you pipe it into bash. We would rather you did.
-
-          - ✓MIT licensed. Fork it, run your own gateway, write your own client.
-
-         antoinedc / MantaUI
-        Open-source, self-hosted Claude Code and opencode client. Agents run in real tmux on your own Linux box or Mac, and you drive them from desktop, phone or browser over HTTPS.
-
-          MIT licenceTypeScriptIssues open
-
-      FAQ
-      ## Questions people actually ask
-
-      Each answer is written to be quotable on its own, and each one maps to a page we want to rank for.
-
-      ### Does the agent keep running if I close my laptop?
-
-Yes. The server runs on your box as a system service and your agents live in real tmux sessions. Every client is disposable, so you can close all of them and the work continues. Reconnect later and the full history is still there.
-
-      ### Do I need Tailscale, a VPN or port forwarding?
-
-No, and you do not have to decide either. The installer checks whether Tailscale is already running on the box. If it is, your devices connect over your tailnet and nothing is published to the internet. If it is not, the box gets its own hostname and a Let's Encrypt certificate. Either way there is nothing to port-forward and no tunnel to keep alive, and you can force either path if you prefer.
-
-      ### Can I really use Claude Code from my phone?
-
-Yes, and the phone app is the same app as the desktop rather than a status viewer. You get the full transcript, live command output, approvals, dictation and file uploads, in a native iPhone app or any browser.
-
-      ### I already SSH into a VPS with Termius. Why switch?
-
-You have already solved the part most tools get wrong, which is keeping the agent alive when you walk away. What you do not get is a readable transcript instead of a terminal UI, buttons to approve a command, or a notification when the agent stops and waits for you. Manta runs on the same box and you can still SSH in alongside it.
-
-      ### What does it cost?
-
-Nothing. Manta is free and open source. You pay whoever supplies your agent, so an Anthropic subscription or an API key, and you supply the box.
-
-      ### Does my code leave my box?
-
-No. Transcripts, uploads, secrets and configuration stay on your machine. The only outbound traffic is your agent talking to its model provider, plus a small push payload carrying the session name if you turn on phone notifications.
-
-      ### Which agents does it work with?
-
-Claude Code and opencode today. Anything that runs in a terminal works in terminal mode, and the chat panel is built on opencode.
-
-      ### Is this an alternative to Conductor or Orca?
-
-It overlaps with both, on a different bet. They run agents on your Mac and give you a window onto them. Manta runs agents on a box you own and gives every device the same window, so the work outlives whatever you are holding.
-
-    ## Put it on your own box
-
-    Free, no signup, and it runs on hardware you already have.
-
-        `$ curl -fsSL https://mantaui.com/install.sh | bash`
-        this.textContent='Copy',1400)">Copy
-
-      [Download for macOS](https://mantaui.com/downloads/Manta-latest.dmg)
-
-      Read the docs
-
-        MantaMantaUI
-        Self-hosted coding agents you can reach from anywhere.
-
-      #### Product
-
-        - [Features](/#features)
-- [Mobile](/#mobile)
-
-        - [Open source](/#opensource)
-
-        - [How it works](/#how)
+        - [How it works](/claude-code-remote)
 
       #### Compare
 
@@ -1095,8 +564,8 @@ It overlaps with both, on a different bet. They run agents on your Mac and give 
 MantaMantaUI
 
         [Home](/)
-        [Compare](/#compare)
-        [How it works](/#how)
+        [Compare](/vs-orca)
+        [How it works](/claude-code-remote)
         [GitHub](https://github.com/antoinedc/MantaUI)
 
     # Open source and self-hosted
@@ -1191,12 +660,12 @@ Only to your model provider and to APNs, when you have phone notifications turne
 
       #### Product
 
-        - [Features](/#features)
-- [Mobile](/#mobile)
+        - [Features](/)
+- [Mobile](/claude-code-mobile)
 
-        - [Open source](/#opensource)
+        - [Open source](/open-source)
 
-        - [How it works](/#how)
+        - [How it works](/claude-code-remote)
 
       #### Compare
 
@@ -1235,8 +704,8 @@ Only to your model provider and to APNs, when you have phone notifications turne
 MantaMantaUI
 
         [Home](/)
-        [Compare](/#compare)
-        [How it works](/#how)
+        [Compare](/vs-orca)
+        [How it works](/claude-code-remote)
         [GitHub](https://github.com/antoinedc/MantaUI)
 
     # Manta is free. You supply the box.
@@ -1361,12 +830,12 @@ The server stops. The data is plain text on the disk, so a reinstall on a new bo
 
       #### Product
 
-        - [Features](/#features)
-- [Mobile](/#mobile)
+        - [Features](/)
+- [Mobile](/claude-code-mobile)
 
-        - [Open source](/#opensource)
+        - [Open source](/open-source)
 
-        - [How it works](/#how)
+        - [How it works](/claude-code-remote)
 
       #### Compare
 
@@ -1591,8 +1060,8 @@ MantaMantaUI
 MantaMantaUI
 
         [Home](/)
-        [Compare](/#compare)
-        [How it works](/#how)
+        [Compare](/vs-orca)
+        [How it works](/claude-code-remote)
         [GitHub](https://github.com/antoinedc/MantaUI)
 
     # Manta UI vs Conductor
@@ -1746,12 +1215,12 @@ Conductor. Its Mac-native editor, diff review with inline comments back to the a
 
       #### Product
 
-        - [Features](/#features)
-- [Mobile](/#mobile)
+        - [Features](/)
+- [Mobile](/claude-code-mobile)
 
-        - [Open source](/#opensource)
+        - [Open source](/open-source)
 
-        - [How it works](/#how)
+        - [How it works](/claude-code-remote)
 
       #### Compare
 
@@ -1763,11 +1232,11 @@ Conductor. Its Mac-native editor, diff review with inline comments back to the a
 
       #### Use cases
 
-        - [Claude Code on mobile](/#mobile)
+        - [Claude Code on mobile](/claude-code-mobile)
 
-        - [Claude Code remote](/#how)
+        - [Claude Code remote](/claude-code-remote)
 
-        - [Notifications](/#features)
+        - [Notifications](/)
 
       #### Resources
 
@@ -1788,8 +1257,8 @@ Conductor. Its Mac-native editor, diff review with inline comments back to the a
 MantaMantaUI
 
         [Home](/)
-        [Compare](/#compare)
-        [How it works](/#how)
+        [Compare](/vs-orca)
+        [How it works](/claude-code-remote)
         [GitHub](https://github.com/antoinedc/MantaUI)
 
     # Manta UI vs Orca
@@ -1938,12 +1407,12 @@ Orca. Manta is for when the work needs to outlive the laptop, or when you want a
 
       #### Product
 
-        - [Features](/#features)
-- [Mobile](/#mobile)
+        - [Features](/)
+- [Mobile](/claude-code-mobile)
 
-        - [Open source](/#opensource)
+        - [Open source](/open-source)
 
-        - [How it works](/#how)
+        - [How it works](/claude-code-remote)
 
       #### Compare
 
@@ -1955,11 +1424,11 @@ Orca. Manta is for when the work needs to outlive the laptop, or when you want a
 
       #### Use cases
 
-        - [Claude Code on mobile](/#mobile)
+        - [Claude Code on mobile](/claude-code-mobile)
 
-        - [Claude Code remote](/#how)
+        - [Claude Code remote](/claude-code-remote)
 
-        - [Notifications](/#features)
+        - [Notifications](/)
 
       #### Resources
 
@@ -1980,8 +1449,8 @@ Orca. Manta is for when the work needs to outlive the laptop, or when you want a
 MantaMantaUI
 
         [Home](/)
-        [Compare](/#compare)
-        [How it works](/#how)
+        [Compare](/vs-orca)
+        [How it works](/claude-code-remote)
         [GitHub](https://github.com/antoinedc/MantaUI)
 
     # Manta UI vs Termius + SSH
@@ -2136,12 +1605,12 @@ If your current setup covers your needs, keep it. Manta is for the cases SSH doe
 
       #### Product
 
-        - [Features](/#features)
-- [Mobile](/#mobile)
+        - [Features](/)
+- [Mobile](/claude-code-mobile)
 
-        - [Open source](/#opensource)
+        - [Open source](/open-source)
 
-        - [How it works](/#how)
+        - [How it works](/claude-code-remote)
 
       #### Compare
 
@@ -2153,11 +1622,11 @@ If your current setup covers your needs, keep it. Manta is for the cases SSH doe
 
       #### Use cases
 
-        - [Claude Code on mobile](/#mobile)
+        - [Claude Code on mobile](/claude-code-mobile)
 
-        - [Claude Code remote](/#how)
+        - [Claude Code remote](/claude-code-remote)
 
-        - [Notifications](/#features)
+        - [Notifications](/)
 
       #### Resources
 

--- a/website/open-source.html
+++ b/website/open-source.html
@@ -119,8 +119,8 @@
       <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
       <div class="navlinks">
         <a href="/" class="hide-sm">Home</a>
-        <a href="/#compare" class="hide-sm">Compare</a>
-        <a href="/#how" class="hide-sm">How it works</a>
+        <a href="/vs-orca" class="hide-sm">Compare</a>
+        <a href="/claude-code-remote" class="hide-sm">How it works</a>
         <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
       </div>
     </nav>
@@ -240,9 +240,9 @@
         <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
       </div>
       <div><h4>Product</h4><ul>
-        <li><a href="/#features">Features</a></li><li><a href="/#mobile">Mobile</a></li>
-        <li><a href="/#opensource">Open source</a></li>
-        <li><a href="/#how">How it works</a></li></ul></div>
+        <li><a href="/">Features</a></li><li><a href="/claude-code-mobile">Mobile</a></li>
+        <li><a href="/open-source">Open source</a></li>
+        <li><a href="/claude-code-remote">How it works</a></li></ul></div>
       <div><h4>Compare</h4><ul>
         <li><a href="/vs-orca">vs Orca</a></li>
         <li><a href="/vs-conductor">vs Conductor</a></li>

--- a/website/pricing.html
+++ b/website/pricing.html
@@ -123,8 +123,8 @@
       <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
       <div class="navlinks">
         <a href="/" class="hide-sm">Home</a>
-        <a href="/#compare" class="hide-sm">Compare</a>
-        <a href="/#how" class="hide-sm">How it works</a>
+        <a href="/vs-orca" class="hide-sm">Compare</a>
+        <a href="/claude-code-remote" class="hide-sm">How it works</a>
         <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
       </div>
     </nav>
@@ -270,9 +270,9 @@
         <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
       </div>
       <div><h4>Product</h4><ul>
-        <li><a href="/#features">Features</a></li><li><a href="/#mobile">Mobile</a></li>
-        <li><a href="/#opensource">Open source</a></li>
-        <li><a href="/#how">How it works</a></li></ul></div>
+        <li><a href="/">Features</a></li><li><a href="/claude-code-mobile">Mobile</a></li>
+        <li><a href="/open-source">Open source</a></li>
+        <li><a href="/claude-code-remote">How it works</a></li></ul></div>
       <div><h4>Compare</h4><ul>
         <li><a href="/vs-orca">vs Orca</a></li>
         <li><a href="/vs-conductor">vs Conductor</a></li>

--- a/website/vs-conductor.html
+++ b/website/vs-conductor.html
@@ -107,8 +107,8 @@
       <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
       <div class="navlinks">
         <a href="/" class="hide-sm">Home</a>
-        <a href="/#compare" class="hide-sm">Compare</a>
-        <a href="/#how" class="hide-sm">How it works</a>
+        <a href="/vs-orca" class="hide-sm">Compare</a>
+        <a href="/claude-code-remote" class="hide-sm">How it works</a>
         <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
       </div>
     </nav>
@@ -306,17 +306,17 @@
         <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
       </div>
       <div><h4>Product</h4><ul>
-        <li><a href="/#features">Features</a></li><li><a href="/#mobile">Mobile</a></li>
-        <li><a href="/#opensource">Open source</a></li>
-        <li><a href="/#how">How it works</a></li></ul></div>
+        <li><a href="/">Features</a></li><li><a href="/claude-code-mobile">Mobile</a></li>
+        <li><a href="/open-source">Open source</a></li>
+        <li><a href="/claude-code-remote">How it works</a></li></ul></div>
       <div><h4>Compare</h4><ul>
         <li><a href="/vs-orca">vs Orca</a></li>
         <li><a href="/vs-conductor">vs Conductor</a></li>
         <li><a href="/vs-ssh-tmux">vs SSH and tmux</a></li></ul></div>
       <div><h4>Use cases</h4><ul>
-        <li><a href="/#mobile">Claude Code on mobile</a></li>
-        <li><a href="/#how">Claude Code remote</a></li>
-        <li><a href="/#features">Notifications</a></li></ul></div>
+        <li><a href="/claude-code-mobile">Claude Code on mobile</a></li>
+        <li><a href="/claude-code-remote">Claude Code remote</a></li>
+        <li><a href="/">Notifications</a></li></ul></div>
       <div><h4>Resources</h4><ul>
         <li><a href="https://github.com/antoinedc/MantaUI">GitHub</a></li>
         <li><a href="/privacy">Privacy</a></li>

--- a/website/vs-orca.html
+++ b/website/vs-orca.html
@@ -107,8 +107,8 @@
       <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
       <div class="navlinks">
         <a href="/" class="hide-sm">Home</a>
-        <a href="/#compare" class="hide-sm">Compare</a>
-        <a href="/#how" class="hide-sm">How it works</a>
+        <a href="/vs-orca" class="hide-sm">Compare</a>
+        <a href="/claude-code-remote" class="hide-sm">How it works</a>
         <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
       </div>
     </nav>
@@ -301,17 +301,17 @@
         <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
       </div>
       <div><h4>Product</h4><ul>
-        <li><a href="/#features">Features</a></li><li><a href="/#mobile">Mobile</a></li>
-        <li><a href="/#opensource">Open source</a></li>
-        <li><a href="/#how">How it works</a></li></ul></div>
+        <li><a href="/">Features</a></li><li><a href="/claude-code-mobile">Mobile</a></li>
+        <li><a href="/open-source">Open source</a></li>
+        <li><a href="/claude-code-remote">How it works</a></li></ul></div>
       <div><h4>Compare</h4><ul>
         <li><a href="/vs-orca">vs Orca</a></li>
         <li><a href="/vs-conductor">vs Conductor</a></li>
         <li><a href="/vs-ssh-tmux">vs SSH and tmux</a></li></ul></div>
       <div><h4>Use cases</h4><ul>
-        <li><a href="/#mobile">Claude Code on mobile</a></li>
-        <li><a href="/#how">Claude Code remote</a></li>
-        <li><a href="/#features">Notifications</a></li></ul></div>
+        <li><a href="/claude-code-mobile">Claude Code on mobile</a></li>
+        <li><a href="/claude-code-remote">Claude Code remote</a></li>
+        <li><a href="/">Notifications</a></li></ul></div>
       <div><h4>Resources</h4><ul>
         <li><a href="https://github.com/antoinedc/MantaUI">GitHub</a></li>
         <li><a href="/privacy">Privacy</a></li>

--- a/website/vs-ssh-tmux.html
+++ b/website/vs-ssh-tmux.html
@@ -107,8 +107,8 @@
       <div class="brand"><img src="manta-logo.png" alt="Manta"><span>Manta<b>UI</b></span></div>
       <div class="navlinks">
         <a href="/" class="hide-sm">Home</a>
-        <a href="/#compare" class="hide-sm">Compare</a>
-        <a href="/#how" class="hide-sm">How it works</a>
+        <a href="/vs-orca" class="hide-sm">Compare</a>
+        <a href="/claude-code-remote" class="hide-sm">How it works</a>
         <a href="https://github.com/antoinedc/MantaUI" class="btn btn-ghost">GitHub</a>
       </div>
     </nav>
@@ -306,17 +306,17 @@
         <p style="margin-top:11px;font-size:13px;color:var(--slate-500);max-width:250px">Self-hosted coding agents you can reach from anywhere.</p>
       </div>
       <div><h4>Product</h4><ul>
-        <li><a href="/#features">Features</a></li><li><a href="/#mobile">Mobile</a></li>
-        <li><a href="/#opensource">Open source</a></li>
-        <li><a href="/#how">How it works</a></li></ul></div>
+        <li><a href="/">Features</a></li><li><a href="/claude-code-mobile">Mobile</a></li>
+        <li><a href="/open-source">Open source</a></li>
+        <li><a href="/claude-code-remote">How it works</a></li></ul></div>
       <div><h4>Compare</h4><ul>
         <li><a href="/vs-orca">vs Orca</a></li>
         <li><a href="/vs-conductor">vs Conductor</a></li>
         <li><a href="/vs-ssh-tmux">vs SSH and tmux</a></li></ul></div>
       <div><h4>Use cases</h4><ul>
-        <li><a href="/#mobile">Claude Code on mobile</a></li>
-        <li><a href="/#how">Claude Code remote</a></li>
-        <li><a href="/#features">Notifications</a></li></ul></div>
+        <li><a href="/claude-code-mobile">Claude Code on mobile</a></li>
+        <li><a href="/claude-code-remote">Claude Code remote</a></li>
+        <li><a href="/">Notifications</a></li></ul></div>
       <div><h4>Resources</h4><ul>
         <li><a href="https://github.com/antoinedc/MantaUI">GitHub</a></li>
         <li><a href="/privacy">Privacy</a></li>


### PR DESCRIPTION
Fixes BET-917: the BET-902 homepage redesign removed the `#features #mobile #opensource #how #compare` sections, but the nav and footer on all 9 marketing pages still linked to those fragments — every click scrolled to nothing.

Remapped each dead fragment to the site's existing real route, consistently across the shared chrome (and the regenerated `llms-full.txt` mirror):

- `/#compare` → `/vs-orca` (nav "Compare")
- `/#how` → `/claude-code-remote` (nav "How it works", footer "How it works", vs "Claude Code remote")
- `/#features` → `/` (footer "Features", vs "Notifications" — the feature/notification summary now lives on the FAQ homepage)
- `/#mobile` → `/claude-code-mobile` (footer "Mobile", vs "Claude Code on mobile")
- `/#opensource` → `/open-source` (footer "Open source")

No homepage sections reintroduced. No markup other than href corrections (the other pages render identically). `sitemap.xml` was deliberately NOT touched — the generator's only change there is lastmod timestamp churn, no links.

**Files changed:** 10 files — `website/{index,claude-code-mobile,claude-code-remote,claude-code-web-ui,open-source,pricing,vs-orca,vs-conductor,vs-ssh-tmux}.html` + regenerated `website/llms-full.txt`.

**Base: origin/main @ a7ba85a5**

**Verification results:**
- PR branch (`multica/BET-917-dead-anchors`): typecheck exit 0, errors none; test exit 0, 2038 pass / 0 fail / 0 skip.
- `grep -rn 'href="/#' website/*.html` → no matches (acceptance #1).
- Every remaining internal href resolves to a real page (`/`, `/vs-*`, `/claude-code-*`, `/open-source`, `/pricing`, `/privacy`, `/terms`) — no dead anchors (acceptance #2).
- This is static HTML; tsc/vitest/node:test don't ingest `website/*.html`, so the suite is a no-op gate for this change (still run and green). `build-website-assets.test.mjs` (which validates the generated mirrors) passes.
