### PR TITLE
fix(renderer): ship gate fails closed on unknown base (BET-915)

### DIFF
--- a/src/renderer/SessionHeader.branch.test.tsx
+++ b/src/renderer/SessionHeader.branch.test.tsx
@@ -107,6 +107,23 @@ describe("SessionHeader branch popover (BET-867)", () => {
     expect(text).not.toContain("Create pull request");
   });
 
+  it("unknown base → no PR surface (no Create pull request)", async () => {
+    h = mountSessionHeader({
+      branch: "feat/x",
+      forgeConnected: true,
+      pr: null,
+      base: null,
+      aheadCount: 3,
+      onCreatePr: vi.fn(),
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const text = bodyText();
+    expect(text).toContain("Base branch unknown");
+    expect(text).not.toContain("Create pull request");
+  });
+
   it("no commits ahead of base → Nothing to ship, no button", async () => {
     h = mountSessionHeader({
       branch: "feat/forge-seam",

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -29,6 +29,7 @@ import {
   failuresToAgentPrompt,
   branchPanelState,
   resolveShipState,
+  ShipState,
   canMerge,
   type ChecksChipTone,
   type ContextBreakdown,
@@ -1002,7 +1003,8 @@ function SessionMenu({
 // state, refs, reviewers, threads, mergeability + Merge / Review changes /
 // open-on-forge), or it does not ([F2]: the ship gate gated on branch state —
 // BET-892: Base / Changes + a single primary Create pull request when ready,
-// or "Nothing to ship" when there are no commits ahead of base). BET-867 is an
+// or "Nothing to ship" on the base branch, detached HEAD, unknown base, or no-
+// commits-ahead). BET-867 is an
 // owner-approved departure from BET-789's [C2]: the no-PR branch now opens a
 // popover where it previously stayed a plain non-interactive Tag; a scratch dir
 // with no forge keeps the Tag unchanged (branchPanelState == "none").
@@ -1113,8 +1115,17 @@ function PanelRow({
 // PR present → the merge surface [F1]; no PR → the ship gate (BET-892) gated
 // on branch state: a single primary "Create pull request" when there are
 // commits ahead of base, "Nothing to ship" when there aren't, and no PR
-// surface at all on the base branch / detached HEAD. PanelRow is reused
-// verbatim for both states' rows.
+// surface at all "on" the base branch, a detached HEAD, or an unknown base.
+// PanelRow is reused verbatim for both states' rows.
+
+// The three states where a pull request cannot exist for this branch: the
+// popover shows the branch and why, and offers no action.
+const NO_SHIP_COPY: Partial<Record<ShipState, string>> = {
+  "on-base": "On the base branch — nothing to ship.",
+  detached: "Detached HEAD — nothing to ship.",
+  unknown: "Base branch unknown — nothing to ship.",
+};
+
 function BranchPanel({
   branch,
   pr,
@@ -1133,20 +1144,18 @@ function BranchPanel({
   onReviewChanges,
 }: BranchPanelProps) {
   if (!pr) {
-    // No pull request on this branch — the ship gate. On the base branch or a
-    // detached HEAD there is no PR to open, so no PR surface renders at all.
+    // No pull request on this branch — the ship gate. On the base branch, a
+    // detached HEAD, or an unknown base there is no PR to open, so no PR
+    // surface renders at all.
     const shipState = resolveShipState({ branch, base, aheadCount, hasPr: false });
-    if (shipState === "on-base" || shipState === "detached") {
+    const noShip = NO_SHIP_COPY[shipState];
+    if (noShip) {
       return (
         <div className="p-3">
           <div className="mb-[3px] truncate text-[13.5px] font-semibold leading-snug text-text">
             {branch}
           </div>
-          <div className="text-xs text-text-faint">
-            {shipState === "on-base"
-              ? "On the base branch — nothing to ship."
-              : "Detached HEAD — nothing to ship."}
-          </div>
+          <div className="text-xs text-text-faint">{noShip}</div>
         </div>
       );
     }

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3952,12 +3952,25 @@ describe("resolveShipState", () => {
   });
 
   it("aheadCount null (unknown) falls through to ready", () => {
+    // Pins the deliberate asymmetry (BET-915): the commit count is an
+    // optimisation, not a safety fact — leaving it unknown must NOT hide the
+    // action, unlike a null base.
     expect(resolveShipState({ ...base, aheadCount: null })).toBe("ready");
   });
 
-  it("base null skips the on-base rule only", () => {
+  it("base null → unknown", () => {
     expect(resolveShipState({ branch: "main", base: null, aheadCount: 3, hasPr: false })).toBe(
-      "ready",
+      "unknown",
+    );
+  });
+
+  it("has-pr wins over unknown", () => {
+    expect(resolveShipState({ branch: "x", base: null, aheadCount: 3, hasPr: true })).toBe("has-pr");
+  });
+
+  it("detached wins over unknown", () => {
+    expect(resolveShipState({ branch: null, base: null, aheadCount: 3, hasPr: false })).toBe(
+      "detached",
     );
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3106,14 +3106,22 @@ export function branchPanelState({
  *
  *  1. `has-pr`    — a PR is already open on this branch.
  *  2. `detached`  — no branch (detached HEAD / non-git cwd).
- *  3. `on-base`   — sitting on the repo default branch (no PR to open).
- *  4. `no-commits`— no commits ahead of origin/<base> (nothing to ship).
- *  5. `ready`     — ship away.
+ *  3. `unknown`   — base branch unknown (cannot tell if on the default branch).
+ *  4. `on-base`   — sitting on the repo default branch (no PR to open).
+ *  5. `no-commits`— no commits ahead of origin/<base> (nothing to ship).
+ *  6. `ready`     — ship away.
  *
- * `aheadCount === null` means "unknown" and falls through to `ready` (the API
- * call is the backstop); `base === null` skips rule 3 only.
+ * One deliberate asymmetry — do not "fix" it:
+ * - `base === null` → `"unknown"`. The base is a *safety* fact: without it we
+ *   cannot tell whether the current branch is the default branch, and a PR
+ *   from a branch onto itself cannot exist. No base means no PR action.
+ * - `aheadCount === null` still falls through to `"ready"`. The commit count is
+ *   an *optimisation*, not a safety fact. It is legitimately unknown whenever
+ *   `origin/<base>` is not fetched locally (shallow clone, fresh worktree), and
+ *   hiding the action there would break a normal case for no safety gain — an
+ *   empty PR is refused by the forge with a clear message.
  */
-export type ShipState = "on-base" | "detached" | "no-commits" | "ready" | "has-pr";
+export type ShipState = "on-base" | "detached" | "unknown" | "no-commits" | "ready" | "has-pr";
 
 export function resolveShipState(input: {
   branch: string | null;
@@ -3123,6 +3131,7 @@ export function resolveShipState(input: {
 }): ShipState {
   if (input.hasPr) return "has-pr";
   if (!input.branch) return "detached";
+  if (!input.base) return "unknown";
   if (input.branch === input.base) return "on-base";
   if (input.aheadCount === 0) return "no-commits";
   return "ready";


### PR DESCRIPTION
BET-915 — the ship gate fails closed: no branch information ⇒ no Create pull request.

The renderer half only. `resolveShipState` treats a missing default branch as a safety fact and returns a new `"unknown"` state; `BranchPanel` collapses the three no-action states (on-base / detached / unknown) into one early-return lookup. `aheadCount === null` deliberately still falls through to `"ready"` (an optimisation, not a safety fact — an empty PR is refused by the forge with a clear message). Independent sibling (box stops inventing a default branch) touches disjoint files.

**Files changed:** 4
```
src/renderer/chatUtils.ts                  | 21 +-
src/renderer/chatUtils.test.ts             | 17 +-
src/renderer/SessionHeader.tsx             | 31 +-
src/renderer/SessionHeader.branch.test.tsx | 17 +-
```

**Verification results:**
- PR branch (`multica/BET-915-ship-gate-unknown` @ `2ff87bca`):
  - typecheck: exit 0. Errors: none. log sha256: `4a728c59…`
  - test: exit 0, 2038 pass / 0 fail / 0 skip. Failures: none. log sha256: `c4926bfa…`
- Base (`main` @ `a7ba85a5`):
  - Borrowing main's green state; `origin/main` advanced one merge (BET-913, server-side — `git diff a7ba85a5 origin/main` touches none of these four files), so no base-branch re-run was needed for this targeted renderer change.
- **Conclusion:** 0 new failures. No visual snapshot under `tests/visual/` covers the branch popover no-PR state, so none needed updating.

`Base: origin/main @ a7ba85a5`
