### PR TITLE
BET-905: feat(website): add the five stage sections (1.0 Install to 5.0 Delegate)

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -266,6 +266,16 @@ h1 .grad{background:var(--gradient-brand);-webkit-background-clip:text;backgroun
 @media(max-width:600px){
   #download .wrap>div{grid-template-columns:repeat(2,minmax(0,1fr)) !important}
 }
+/* BET-905 AC#4 — the five stage sections (1.0-5.0) use inline grid-column
+   definitions from the reference, which are not responsive. Stack their content
+   grids to a single column at narrow widths (mirroring BET-904's hero fix) and
+   let the fixed-width app window / phone / cards shrink below intrinsic width,
+   so none of them overflow the viewport at 390px. No markup change: the selector
+   targets the grid wrapper div that follows each stage section's lede paragraph. */
+@media(max-width:900px){
+  .stage-lede + div[style*="display:grid"]{grid-template-columns:minmax(0,1fr) !important}
+  .stage-lede + div[style*="display:grid"] > *{min-width:0}
+}
 </style>
 
 <!-- BEGIN:head-meta -->

--- a/website/index.html
+++ b/website/index.html
@@ -580,6 +580,463 @@ h1 .grad{background:var(--gradient-brand);-webkit-background-clip:text;backgroun
   </div>
 </section>
 
+<section>
+  <div class="wrap">
+    <div class="stage-head"><span class="sn">1.0</span><h2>Install</h2></div>
+    <p class="stage-lede">The desktop app installs everything on the machine you choose, over SSH, and pairs itself.
+      No terminal, no keys to copy, no tunnel to configure.</p>
+    
+<div style="display:grid;grid-template-columns:1.1fr .9fr;gap:18px;align-items:start">
+  <div class="ob">
+    <div class="obh"><h4>Where should your agents run?</h4>
+      <p>Manta found these in your SSH config. It installs everything itself, nothing to type on the far end.</p></div>
+    <div class="hostrow sel"><span class="radio on"></span>
+      <span><b style="color:var(--text-primary)">hetzner-box</b> &nbsp;Ubuntu 24.04, always on</span>
+      <span class="sub">157.90.224.92</span></div>
+    <div class="hostrow"><span class="radio"></span>
+      <span>mac-mini &nbsp;macOS, Apple Silicon</span><span class="sub">local network</span></div>
+    <div class="hostrow"><span class="radio"></span>
+      <span style="color:var(--slate-400)">Another machine</span><span class="sub">host or IP</span></div>
+    <div class="obf">
+      <span class="btn sm pri">Install and pair</span>
+      <span style="font-size:11px;color:var(--slate-500)">Takes about 90 seconds</span></div>
+  </div>
+  <div style="display:flex;flex-direction:column;gap:14px">
+    <div class="term" style="font-size:11px;padding:13px 15px">
+      <div><span class="g"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M3 8.4 6.2 11.6 13 4.8"/></svg></span> runtime installed <span class="c">node 24, no system packages touched</span></div>
+      <div><span class="g"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M3 8.4 6.2 11.6 13 4.8"/></svg></span> manta-server running <span class="c">127.0.0.1:8787</span></div>
+      <div><span class="g"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M3 8.4 6.2 11.6 13 4.8"/></svg></span> reachable over HTTPS <span class="c">certificate issued</span></div>
+      <div><span class="b"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M5 3.4 12.2 8 5 12.6z" fill="currentColor" stroke="none"/></svg></span> waiting for a device&#8230;</div>
+    </div>
+    <div class="cd" style="text-align:center;padding:18px">
+      <div style="font-size:10px;font-weight:800;letter-spacing:.12em;text-transform:uppercase;color:var(--slate-500)">Pairing code</div>
+      <div class="code6" style="justify-content:center;margin-top:11px">
+        <span>4</span><span>1</span><span>9</span><span>2</span><span>0</span><span class="a">7</span></div>
+      <div style="font-size:11px;color:var(--slate-500);margin-top:11px">Type it on your phone to add it too. Expires in 5 minutes.</div>
+    </div>
+  </div>
+</div>
+  </div>
+</section>
+<section class="sunk">
+  <div class="wrap">
+    <div class="stage-head"><span class="sn">2.0</span><h2>Run</h2></div>
+    <p class="stage-lede">A readable transcript, the diff inline, one tap to approve a command, and an actual tmux
+      terminal underneath when you want one.</p>
+    
+<div class="aw">
+  <div class="chrome"><i></i><i></i><i></i><span class="t">Manta UI</span></div>
+  <div class="body">
+    
+<div class="sb">
+  <div class="sbh">Workspace<span class="sp"><span><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="7" cy="7" r="4.2"/><path d="M10.2 10.2 14 14"/></svg></span><span>+</span></span></div>
+  
+    <div class="grp">INFRA</div>
+    
+      <div class="ses on">
+        <span class="dot run"></span><span class="nm">Deploy billing service</span>
+        <span class="tm">4m</span>
+      </div>
+      <div class="ses att">
+        <span class="dot att"></span><span class="nm">Fix red CI on main</span>
+        <span class="tm" style="color:var(--amber-500);font-weight:800">!</span>
+      </div>
+    <div class="grp">ETHERNAL</div>
+    
+      <div class="ses">
+        <span class="dot run"></span><span class="nm">Add CSV export</span>
+        <span class="tm">2m</span>
+      </div>
+      <div class="ses">
+        <span class="dot "></span><span class="nm">Refactor auth middleware</span>
+        <span class="tm">14m</span>
+      </div>
+      <div class="ses">
+        <span class="dot "></span><span class="nm">Investigate 500s in /orders</span>
+        <span class="tm">1h</span>
+      </div>
+    <div class="grp">MARKETING</div>
+    
+      <div class="ses">
+        <span class="dot ok"></span><span class="nm">Landing page copy</span>
+        <span class="tm">now</span>
+      </div>
+      <div class="ses">
+        <span class="dot "></span><span class="nm">Build pipeline</span>
+        <span class="tm">3h</span>
+      </div>
+  <div class="sbf">Settings</div>
+</div>
+    <div class="main">
+      
+<div class="hdr">
+  <span class="crumb">infra / Deploy billing service</span>
+  <span class="chip"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="4.6" cy="3.6" r="1.7"/><circle cx="4.6" cy="12.4" r="1.7"/><circle cx="11.4" cy="6" r="1.7"/><path d="M4.6 5.3v5.4M11.4 7.7c0 2-1.6 2.6-3.4 2.9"/></svg> feat/orders-csv</span>
+  <span class="ctx">
+    <span class="ctxbar">
+      <b style="width:44%;background:var(--blue-500)"></b>
+      <b style="width:16%;background:var(--amber-500)"></b>
+      <b style="width:22%;background:var(--cyan-400)"></b>
+    </span>
+    <span class="ctxpc">38%</span>
+    <span class="hicon"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><rect x="2" y="3" width="12" height="10" rx="1.6"/><path d="M10 3v10"/></svg></span><span class="hicon"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="3.4" cy="8" r=".9" fill="currentColor" stroke="none"/><circle cx="8" cy="8" r=".9" fill="currentColor" stroke="none"/><circle cx="12.6" cy="8" r=".9" fill="currentColor" stroke="none"/></svg></span>
+  </span>
+</div>
+      <div class="tr"><div class="um">Add a <code>/export.csv</code> endpoint that streams the result set as CSV, header row
+    first. Use the streaming helper so we don't hold 100k rows in memory.</div><div class="tool"><span class="dot ok"></span>Read(app/routes/orders.py)</div>
+    <div class="sub">Read 23 lines</div><div class="tool"><span class="dot ok"></span>Edit(app/routes/orders.py)
+    <span class="meta"><span class="add">+38</span> <span class="del">-4</span></span></div>
+<div class="diff">
+  <div class="ln m"><span class="g">11</span><span class="s">-</span><span class="c">async def list_orders(status: str | None = None):</span></div>
+  <div class="ln p"><span class="g">11</span><span class="s">+</span><span class="c">async def list_orders(</span></div>
+  <div class="ln p"><span class="g">12</span><span class="s">+</span><span class="c">    status: str | None = Query(default=None),</span></div>
+  <div class="ln p"><span class="g">13</span><span class="s">+</span><span class="c">    created_after: datetime | None = Query(default=None),</span></div>
+  <div class="ln p"><span class="g">14</span><span class="s">+</span><span class="c">) -> list[dict]:</span></div>
+  <div class="ln"><span class="g">15</span><span class="s"></span><span class="c">    query = Order.query(session)</span></div>
+  <div class="ln"><span class="g">16</span><span class="s"></span><span class="c">    <span class="kw">if</span> status: query = query.filter(Order.status == status)</span></div>
+  <div class="ln p"><span class="g">17</span><span class="s">+</span><span class="c"><span class="kw">    return</span> [o.to_dict() <span class="kw">for</span> o <span class="kw">in</span> (<span class="kw">await</span> query.all())]</span></div>
+</div><div class="tool"><span class="dot run"></span>Bash(pytest tests/test_orders.py)
+    <span class="meta">running 12s</span></div>
+    <div class="sub">collected 24 items<br>tests/test_orders.py .......</div></div>
+      
+      
+<div class="comp">
+  <div class="box">Reply, or describe the next task<span class="send"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M14 2 7.2 8.8M14 2l-4.4 12-2.4-5.2L2 6.4z"/></svg></span></div>
+  <div class="meta">
+    <span class="mp b">Opus 4.7 &#9662;</span><span class="mp">High &#9662;</span>
+    <span class="mi"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M11.5 7.2 7 11.7a2.6 2.6 0 0 1-3.7-3.7l5-5a1.8 1.8 0 0 1 2.5 2.5l-5 5a.9.9 0 0 1-1.3-1.3l4.4-4.4"/></svg></span>
+    <span style="margin-left:auto;display:flex;gap:10px"><span class="mi"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="8" cy="8" r="5.6"/><path d="M8 4.8V8l2.2 1.4"/></svg></span><span class="mi"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="5.4" cy="8" r="2.6"/><path d="M8 8h6M12 8v2.2M10.2 8v1.6"/></svg></span><span class="mi"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M4.5 12.4a2.6 2.6 0 1 0 0-5.2M4.5 7.2V4.6A2.2 2.2 0 0 1 6.7 2.4h2M11.5 12.4h-3"/></svg></span></span>
+  </div>
+  <div class="perm"><span>Permissions on, click to bypass</span></div>
+</div>
+      
+    </div>
+  </div>
+</div>
+  </div>
+</section>
+<section>
+  <div class="wrap">
+    <div class="stage-head"><span class="sn">3.0</span><h2>Leave</h2></div>
+    <p class="stage-lede">Shut the laptop and the work does not stop, because it was never running there. When the
+      agent needs you, the notification finds whichever device you are actually using.</p>
+    
+<div style="display:grid;grid-template-columns:1fr 262px;gap:32px;align-items:center">
+  <div style="display:flex;flex-direction:column;gap:12px">
+    <div class="aw" style="opacity:.4;filter:saturate(.45)">
+      <div class="chrome"><i></i><i></i><i></i><span class="t">Manta UI (disconnected)</span></div>
+      <div class="body">
+<div class="sb narrow">
+  <div class="sbh">Workspace<span class="sp"><span><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="7" cy="7" r="4.2"/><path d="M10.2 10.2 14 14"/></svg></span><span>+</span></span></div>
+  
+    <div class="grp">INFRA</div>
+    
+      <div class="ses on">
+        <span class="dot run"></span><span class="nm">Deploy billing service</span>
+        <span class="tm">4m</span>
+      </div>
+      <div class="ses att">
+        <span class="dot att"></span><span class="nm">Fix red CI on main</span>
+        <span class="tm" style="color:var(--amber-500);font-weight:800">!</span>
+      </div>
+    <div class="grp">ETHERNAL</div>
+    
+      <div class="ses">
+        <span class="dot run"></span><span class="nm">Add CSV export</span>
+        <span class="tm">2m</span>
+      </div>
+      <div class="ses">
+        <span class="dot "></span><span class="nm">Refactor auth middleware</span>
+        <span class="tm">14m</span>
+      </div>
+      <div class="ses">
+        <span class="dot "></span><span class="nm">Investigate 500s in /orders</span>
+        <span class="tm">1h</span>
+      </div>
+    <div class="grp">MARKETING</div>
+    
+      <div class="ses">
+        <span class="dot ok"></span><span class="nm">Landing page copy</span>
+        <span class="tm">now</span>
+      </div>
+      <div class="ses">
+        <span class="dot "></span><span class="nm">Build pipeline</span>
+        <span class="tm">3h</span>
+      </div>
+  <div class="sbf">Settings</div>
+</div><div class="main">
+<div class="hdr">
+  <span class="crumb">Deploy billing service</span>
+  <span class="chip"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="4.6" cy="3.6" r="1.7"/><circle cx="4.6" cy="12.4" r="1.7"/><circle cx="11.4" cy="6" r="1.7"/><path d="M4.6 5.3v5.4M11.4 7.7c0 2-1.6 2.6-3.4 2.9"/></svg> feat/orders-csv</span>
+  <span class="ctx">
+    <span class="ctxbar">
+      <b style="width:44%;background:var(--blue-500)"></b>
+      <b style="width:16%;background:var(--amber-500)"></b>
+      <b style="width:22%;background:var(--cyan-400)"></b>
+    </span>
+    <span class="ctxpc">38%</span>
+    <span class="hicon"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><rect x="2" y="3" width="12" height="10" rx="1.6"/><path d="M10 3v10"/></svg></span><span class="hicon"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="3.4" cy="8" r=".9" fill="currentColor" stroke="none"/><circle cx="8" cy="8" r=".9" fill="currentColor" stroke="none"/><circle cx="12.6" cy="8" r=".9" fill="currentColor" stroke="none"/></svg></span>
+  </span>
+</div>
+        <div class="tr" style="min-height:118px;align-items:center;justify-content:center">
+          <div class="am" style="color:var(--slate-500)">Laptop asleep</div></div></div></div>
+    </div>
+    <div style="display:flex;align-items:center;gap:12px;padding:0 4px">
+      <span style="font-size:12px;color:var(--slate-500);flex:none">Meanwhile, on the box</span>
+      <span style="flex:1;height:1px;background:var(--navy-700)"></span>
+    </div>
+    <div class="joblist">
+      <div class="jh">Still running<span style="margin-left:auto;font-family:var(--font-mono)">3 sessions</span></div>
+      <div class="jr"><span class="dot run"></span><span class="jb">infra / Deploy billing service</span>
+        <span class="jm"><span>step 4 of 6</span><span style="color:var(--cyan-400)">18m</span></span></div>
+      <div class="jr"><span class="dot run"></span><span class="jb">ethernal / Add CSV export</span>
+        <span class="jm"><span>running tests</span><span style="color:var(--cyan-400)">6m</span></span></div>
+      <div class="jr"><span class="dot ok"></span><span class="jb">marketing / Landing page copy</span>
+        <span class="jm"><span>done, waiting for you</span></span></div>
+    </div>
+  </div>
+  <div style="display:flex;flex-direction:column;gap:14px;align-items:center">
+    
+<div style="width:214px;border-radius:32px;border:5px solid var(--surface-raised);background:#000;
+  overflow:hidden;box-shadow:0 22px 46px rgba(2,4,12,.62);flex:none">
+  <img src="data:image/webp;base64,UklGRvAgAABXRUJQVlA4IOQgAADQfgCdASosAXUBPpVGnkwlo6KipTCp4LASiWlu/Eb44Oh5B5TYVu2z5nbUAPQA/YDrZchz82/23wH/v39q/uX7begP4n8k/dfy8/wPtO2A2od8g+5f6D+++eP+n/wH4+egP5Z+8/7P1Avyj+Qf5f+yep99D2JmfeYF6g/Q/+z/jPOG9S/zX9+/dP3E/Lf67/o/uV+wD+N/0T/MfnJ/iPkj/TeA392/yP/W/Sj9o/sA/mH9M/0P9x/0v7IfSN/K/+3/Qebj80/z//o/z3wDfzT+yf+H/JdqT0Y/3oI6DcMBIyRIv10IykrLfnoaEAjAF79rEOCDBfpEz682q9N3fSLFm9UYQg9XCKNe68ZipT7eMNrZVrgpyVC2iJF+umF6shVPw4JAJEjpNZUXW0dYM6mrM5eYNtEORb3B+hRh3e2GtfvOzfC1tGYZQgvgnRrvJwNtwvQvvJqImyuh++Ahxw5cKrfe4paUWFnQj4v7hgK/mEF041ecsI8TZdzQCdWEJJBlRxbCOFOiTFP2Hmkdn127nop9z4Z1JMLG38wG4sJXGr6BT0VkI6MHMT2oZ/6XnnMExW/OcNA/H1YdpJVTGCrnArzA7aCOU6zE5gK52jqNgwsiQR9KKdoWCzQ7Ct9g65iMI1xEYWyztLTCC5Qb5c0ADcu/MBvjRqk/HreVBWWuIjsjWaLTVfMGHP79rHyrferDMfHwlxb4sz5OGfE4vBO4iMf2Ia0rZITHoCQZ4VMxxA2RWpICjm2pTxZT0PN+ffTCnuNvWSJ9Evt/IabB2PyaVuMEydtPPhHfhQSNFfQxEkW2zbf+RYAa6PjAmWjNz2WyqgUz4r5/VpUFkBH0QMUa46SnkO79v9BiDmqpARQrMbd/bVGEzEqvqFMkBpVXALJiLP7HlBkwplc4FogtU4jz9cD21qG8DA7kuPUALB1k6fNICwJua7LuxhCWQwIkAl6sq38XXdP9zsA2ZXDpHx66AaZxe2Nhbp9qYXVi14CR14LoXIDkHKfsW5EjeiZwYAnbZ7sWzVT+F5ydcq3Ox2fV5unC+QFUNXoZQy/09PHFU2Ugnyy9FI9CWZA47CLDWvUSMd6OhPMsRWcE/NE4lJDs3hY0PbMaoWCjoQKt4We5PcpmbB5jmEHaxdiCRyhAQdvv6oCAAwnBEccTpkUC6poIv0oOA3scPb+jzZJUfJ4E9lFdccQDLLcvA/roR8BIyRIv1yFCp2G2kbJP5Op/kHJmeOUpxMtLdFfVycmrvJdCPgqSGiuyDY+Vb7+AZaU6mHTAHX5AhZm0ZyF+T93s/MUAVukSc3MkW8aY44YCRkiJExfLOSV78B1JchuqNiALOixu95LoR9dwy0AkX66GFrQA/v6+yMWlM1LlC5S6kytCm11j86QnOsJrezX8+Gu3s1BOCSEyFV/wgYDEs0iupFvUw6hZw4p/g1ok/jVzlTu8UQ2Q8wRVgXBwkyDtASeNEkfb/ZIU+SG2cqMsw0uI53EDhGqQJI/w5j77r9/he7V/4kR88151QYR2LipO0XhrILjEeJFdlLTxJpphtqe9yFmu7mhrWbt40iWvygi7ALCYnq8E9IEAge+FQ3/uRUj4fA+oHxqrUisH/xslCMkLNZEqcKJzzkfiZ3vpmZ8w9Tl7NU1938b1vKOxb7/SoRkpmR2QbMksjUwHTWkChzZQhQHg1kd+KGuD/3yChb3vSJTSMlwgIxwoSbrwGmCjuOly6F3QEV/jxF0UcY/NwVrpl9NDr67wRBsRFjE60CTt6RaRhKKXI47FQir4jr3GmxiGSJC5CeCyLeT3x62XCamz6bNAohGbjf/4IppErWNP3QKXsg18cpm64SOTIP8xmNADjvCfqaaS4aKhuABLIMs546UQeah69DYmSjDNqj8+Br8UdNKH3gWB6j+3X6N47yxdbebu9PE4GE4mjJqQfPT7pX81iDaH+xt6T5YAtf9dcBqmufiri0L3VBw4GiUOLy6W5utYq8Qet/7dHCWlyHzViQJlwBmFRiAD42sRCNz3O7yaGokbdx+Ha1yR/DQ4wFa4pBfYJWlYA5l3LSeG1/rgHxmnIK9pAJGYdlcrvmoQTO/+Teh/Hd9Pb1TREEy56KaReZsex3lWV4FtmtrgR81fXNdJtbBxXD/mXRI2eE0ODNkDkiqXym/lTm/2y2CDNj8E8/bC0FABLahbXXpFoAoWeoNQzRF+Vo1EAIsELwQACYpN+I/dLD72VGuClYobieo/BpvXhAZPSqWVCPVvtL1gYrihIYKtL1A9eH0Qs2R9Qe40Ppy2kgAiRfdzCwsx/ei829CmF9jRtrWNLXeN/ujZjys4J8btc4BLTNcVUH319xyjoaBCDRlGliHkeJ9Fis1qRgK8n1vZpv/VM78vXET0cJvHYNoT+hkKFloMr41tpYxvhMUeBL+5zKsUD2WDqOz5HnkP1g82CVoCBq2FR1IPMzbsHI7ZzT1t6pftF14FylO6zJN98ku96+YzPf6FbhAeDs0yoPEWFhYVwDeVlZWVlctLTTzX7ZpWEADmSRgd/d2OhcvZrXJ9VWtwlKh/KZRceGl2OU05P/ks5T+9g1cKqYKwav0dhDvowV2QSGVuwn6qu+l8CuKzgumt2MNxr2fdRBzYF9J14mlrH222/e3ggcncOJC9lge9JlotFYyBqqETYnqLqAxwuM4VnL7IKnBrc9fheOw06BPj/Q/ltVq+yRJgeX6FUIHhF/Gz57b7kk3L6EOLpNMva/GHAaR4Ne6pa1XwafyzuSpEC/06GKk8gcz0uN0JWk/yQO1z1HarbS4YBKETGRNOMnDrF3pKdQXUc348aqAQu6FS280W6RLyQAUV+mDZS5m2EYmBboShvpTOPVs48iUpltfETY6NvFbY2Abt2BcnVUIKBBMAMvaH7SdqomUoWxSkiG1UmDvS/xnHzCogPkfxMp7O5KpDmXfYubHOERdhoKBdkZEoSS4v9nRb3FAJrDPGNA/A22fhJ0GAg/K83MnUUGftw2Fmrcpo5m2EXbfddn25ueOzZLhp2IXr7FZgGwGi1xmnGEt2yK/+BNyG2dRGPnNFXh4SYcYLXMn1/klCzU0N6zInnRmNIIhIxMC11PTXRjwF+pZeBfnVKrQH1y4pOCBGF0miwVBxUNztNR6tVSzrt6mCl5nWkZjPM3rrjhxJnG9yF5Pe3BYF9JKXyTgLBw1il8rTV6489GppzSbKXDvDcOA3O037wMx3w9CTaGwiiDY/c6pcBJFazmc2gqd4Mulwu9Fkt1FIV3ZYH0YWhIoyGuJG6/l4+lF1kva2x2S/GLAKy6XwlEvBegyjc5aFQaVmNJB9I5m+Uvdi9o4ECs6bWO/2XqTX5AuZm0miwIrkQhEbA5Ryp+px8EuIDaYCc9DkqHG2vjTZ4H24ypVBys9ACbXRKUXxq0fbKd8a5LNZsMw+h9X+AEKCHhVPZRlIYQv6J+R0YjFOuDEwb2fpq1NJFHHFwgIMBYLI1CoHyspF2z870xXwizyHHMLQjSdY8T5/Fm7cA/DqOa20etmgAHu+mG96oqWvZfR24/8cChKpFHzEpQzT4tI38x2Kafl3/j9D7gwoTcJjHWfoVCld3U5iJyL/rQ25+/5jfisdyrzY750yx2QrBWD/ABO4AnN32VbitBa3Ms9jtEVn+t1qcTn2qqGG429nX9Xt+C8uf0GA2MdJXjBEU+aWjt+/f6AacZD2oOlHc7Lnqqi7RL0fiMITk2tvgt9gDXwzDLA4wcxS7sXt3JaefYoIQlYgBTzxsuv7wh15FOaC9nIduO7oAxZkCYfu0j75ldyErpmBbTwbhOTQxWazjqzQPzAVoTSZlDHADSgLp7RuJPf9/XkQYCUjSra5zhgx7IBrawV/+oV94vVUUkNVWBv//oy0+I+PWOwbWmPJbZl9eGTx03zL7KfTPYPDGWZjw4WcU1c/thyhVtzIl9jl1NQWFvIc1pDGLEhnk5xhejJHOyakRMOTCjhAHEXNz4YHhWGk/NP1rrRQ9gTaKrskulsEBQ9mjpsQ13abznr+5KVQJG+E//zW75HLDY5n42AWCkFiOxB8k5pj0rPIA2zGQe7Wc5IQTsLjI9ZXoYcOvfggVr5iIY6KnUpo8gsPH+m6iJhcEzXj6qM4k4lstvea+Eh8xj4E0RiqdOIxVtrs1jmsHIXvimTgqu+6fAk6SC9WiCplsfmiCIkoS7i0Mc6BVHTVTCcaJyVtD6MfDV3gg31oIIIb863rkm+Mzsn6ZvcvZZPiqO+VY/uBfuiFiJnIicfItDAvyfkDEzYQux40i1yqRJ9M1s0Bbcgmj1WUeQljXmh4HhMRNaRt6x0qSx+FYdxdma1O7EGjAmAOPo0wgOsOJq8GjYzVcKCuMEeMX7K7YLdte77TFAse+Rk1ZprSmHORlsSNh9Wyz0miV7OPgfwChugPNx8Vk7QkagZYGi9QSaBSx/etNlpXgC/5Eiigk7GB3F1w20KjtUGF3SVQXu7OKR5n29ChfzTfs1YHqGpwiR2Xur5mT6s7aQdL2Tlk7rgSS53acxmmFgXMkOYWlW8cEJsQUqDgqSmfNTdIuYEwvkEkrdjJJsD35nq1Y3PH6Bsi/43NHfqA0fybzQDtmZqLTieg2c8i3q4ZbYReMm2vb9RHjNwwmUav6O2sUb3LF360pZtO8Slt6Q1BAAF9/PcRSnyzfcdEYvMeWCEQ63qK+0zajmrJc5L/vsm05Yyiu7uwG6gcfTjMwpNWz7bbOhXwxaii21l8oEknjIFovyoshvZJ4ln1zuLkgDBOGUIrtngWaljaa80K2/PYoHy1O91vLAgewMZf6e1f7AxhfnqFwm4NnT25P2q7T+K6K/O5mpmY0KoOngqf08pwFI7aWMdUWqoBlg1BL/OCb2QBJECX6jOJBX4sAAO13C28UpKCvdNX7sBdWvPWYwEl9yTocQQyZkGEO/cf02fTSubUIETE/s+jndE3xtC9kAbnXjr4WFi7V2NFYt5HpDqL/PH5O1lKGF7sfzukLJr2klbTi6zkbawFjqqrHERmcGBA/qas2zE0Cnfu6PWHbZfhARmfgXghZ1a1Z0sf955tQmaI7tkZsYPYliQOh/ejIXjuUVVO8AUinixbaVV4mQ9tL8vQyns0CYv1FageR57L3qF1+btz01MRz+ReLmcE8i6Y/jFCKumQFOHOkEz+7mHv+oGU8PU1VcnfKrAGGAO13++ai9mfnbtqt5y06aeB5HzPCusw+x2RLO27pdBasdD7H39/Cbq5Uu1sFvI7ycq0v9WV7wqVGsrJKrsRlnAbkR+G9KInrkaA+WaAvEuvz/XB7IfSeEaYB9AuahUwmK2yzyX/6TlVPIUAPGQCesbvnFf6DFdP+hnGF1RqC21u/cYsc8r2wj66k386cCk7EPqmbHixbKgBqN1qBrS+rx43u3XmpoltcJUGTXAUEdwGHEM4R9ht19BsLi9Q/CJtkW8wD4Wys9K/BKzr8W2ihFD8NdF8od/l5ZgRgWnwBckyahffY+GkyuVf1GmK/nL8OJpY9JXDPVnLTJBwVNIDDHnX9vfo38nwfFdAvqLxraI8rddddVTXAyXLRoYVbK4lbRVEFTT/v9ylC2iTIc8tkBOy1hRMbzxHBONJoy1LOMHN5pNQv7359mgjqqDIT4Kdsm9z5ycs22WXjz81vkJgjzZGcpRALEHd6+R5oKJsWJ8bFpf78LDLfmSO7pexthf/NDevbcIcE8+oDy1AbU2lypKa9vdpJccsSTnySAotFWthYDa6E0f3Bj6gUdIWowVeZiqsX+CiZ+R8wyJQRMb0ELydnRUZvvofrnnA0gYceiLH1Hlrion3Z6xbcZC9/apBbI8l1CiGzCu1dN5HbzPx2+mZU/F4KX4o2kvYU+Zh09BztUNtx1QvHmTOBqcSZallLRK/nk2d9RX9uKjCgebfv/UsbED25T70fD9/Gixo/yI/RROYJP52CzlTd+D3WtU7dBtksxPGwPcUn2B/q4BPaLsL1ls3K8ObWyQF8FDC+G0t9zXD+JztY5q+eZDQaQFGzAOQ8p7KgWr0Xk4aCj5SO0hsCTL2LItqJroy+TIbKXrMs6MxrjO5oo5QxkpY3QQCGgEml83vmWUa/hu+S0sagjKEiMS6pWfhu+nj3oMna2jwHB7zoGXpC+NG81MRY9I+N2wMuLh5U+2FnsDdsOCqpagSMZSspToc/PxNCWy1BFinEUbz9c6Dq1ntKVZMlcZRZr+/So7mQeoJw38bqHGYx4RBevQENZcThuyFBRYtgQr7NT3zkzakQERr/LPIefI44JAYMvjV/guVejCbMmBmJtx6Jw7/DUIPJsFmfB5XoWTtPEBasjMmk6J2LCK/GVKyFVa20yz2oO0KrnXdxKBVrJ43xBYgUWyf3RSVvxj/Br1M0KUtsTnuQ4oNX9tELU4QCBCUOzRy0Vv4Gc6oS0wITu/lixc+Z6Hx5kJSaSqPGuiohxkxKGe2w0OekhjI3BB62mwA6C2PlYIWFJO8TlnHkQTj8Uwc65BcAwRreE4y81ESnSDRBy3s4oLyX+UhEe85HsAp0zCR+mZSYE/jymT4a1bV4u/jvr+sDENkA0r8sCXypDbc8txVoPASdifz/Mlh4ioV7bx+OOfoD6tkOguWYU95yOiexSYXvdFSksAKI225uBB/zJy3avZNu9mg1DTMk43TSCLIbDDAn3+g2HmblhPw/6dhcalGzXBFM5CQDcSGHX3oUZWnS/dyoEYwHA1Y2zjnvujlWdZ01v6NZxDgjCJlX5T7064niwsiPRRDPDNQfirAYmwepi22kRWuKiGYycAM2uHXDCkkGa9b7aXmBvEtmTQd1OY+i5Amzv1Ipim9M0Fc1GmgM7l5d3FLnSEfr+Ae84q+yO4ZheC1CriekSHK/xQRNG5ieBQoO7MQeqSyDt4R9Wh9ISbxZwu+r+b9FYs+u1uF25y294P2jVVlC3qSYz60teI2B6aGlVJAQlF8xgyx9f00LkZ624E9GCE6g7dTwg685DsIk2G0y2w6I9tAbcl1rTynhqNtv02Ood40jTQW4UWH/snO59pZ7RjgSxba6DKawNAR2bCNSTUPig6sk1HStsTkanOeKABMA8Hf3lAJt3sXW9EqXNeaJQ2dGw6UP79A/AyctRA1gGP6kqb6RfYc8dYsKYJaQpQuzlp4Or4JK+26XV/Ugv5J88mX3X0tji5OIp+bAUWp5KI3viRxWSLdashioevvy8lbLB1dL0yI+f04zAwHuDpYcj6rtPZZZb42zvQVB5gIA0JEn8QhAoRPSDkiXbCzZoBKDv44HGQtAZ92pbBv/xtBGuSkyQ7WHZ4ojT3XR2+Dh7Ve7P/ChzQ3QT3iYLc8sOw9KXX7yjqXoPAAn87d7iJsSNvNh42jGRJH9UIlk+MfLQOht8Tp0w6sZIQZctp8XaAXcTDxamMSrL4s9sP2jWMLAjJW7W0lSYj8SnuIG5BgWS4j+eZ4pjK5jcGXJVi9M/hQUJYf1KxjkrS+6C04S64fGE2gdp2cI7gcnQ8sK4Gll6AKHnzaWKO1X32yhnAmC88W27YTYYvXN50Qb1Yad9tA4vHXAoUdHI1hH3RkZpey4ge0lfeMAMvaZ4EQSTy9Y2ofI1T2cZ64d1IgrG5UcCiJ7SV7+yD7AMBn72abxAHcXmreA9NiCirGKq+TI25inLErdAL7rbUXBWx2kQHUNnrhzSSUjhkLz5lCIo0AfkgDxiXWbu3l37M0l88WUB7Et5YVF12aUqWDB5x6Si4psezX+fexkHeDdXW9YXWVAme99eba/MblQgYXsYlKHoNT2A8bunK+71AgAbXzI0SnVhb7U1P4uzEWzrE6mAMcy3I2MAZNfPpnFpwxkQWgC5v7YlwQjDJc6Wopah+PUK1lzvD8LLu14I2e3MDFKtoxj3zqg9kuq3Z/iaukrelskia8o8FiD6zOZuHBhQuPIBktmfie9JSgOQQlYb5cuSGkuZgBlWRU8LIrEAgTXsIpGjw9xO5tp+Vi5FBxK+pvh3tbpNTNyAoPxh7laZW4kheeHPkfnMKjByb75XG81BKRgp2vkktN1N4W8HSRAx8lWBSrU1g2k7SmTiibcYWuSxwSoO6eRMdPJztVQE+c3VDaVT0twLNoa+eVrdcySte3iQ5Pscr/tgKS8jr6UwA2NX9GrPImfUeFhOmpMKD5aHehfBFPgLfLfTpJjtkb9fw54GBvriX2ZdX00uyjVuBh/sSLIuoo1GgoMQMe8FlTrvxuDef1sebXJPzYIAr1FxZxKVe8lZMpMozq02jH5dMUww080N3lId4nS100wSfyjkIMWBN/Mbasm7I2lvpsuyghXCCwtraqmkAXOq6TUbpJ4DSultwNmwTCI+htlKHe6GrwjAhTQOEANmPU1C9r6t2d+J1/A1FVGelDORQlU+NU6LEI2g9glZaf9EjnorS1M4uqTe8JrAyv+jC4uQNnef+mfR9UPXn403RsQRH44c8n+4FvQTtf2BU25T7Sn/otPx+0gi8OLBFxcq1qB5BZ5A95TV8UgIyDwE3wmgDpvcY/Fo+3f4dfmUBR+u0lga7OsjzczAYgOvHqymEaAbVBVU9q/hIYQeviCbHAuDntplYlVNXqtFQet+08zolMmPl6bu40BW/IXGFGyrYdHSGCq/fVyhFclYwHDVMhXEfu1XAHwczUtIpi5IhE53Ovjxeay5LH2GNi7vzgFBuJuzxg7YP5+aLxkT1RfZ2IHuThCq2eTeBao3bJl+8PQyhThmilruJ1nKXqJYuspqilt6JehfA0ulvhMfG/gMVGWxEdmQFwGmoIVrUXqHbGeencQfYt0FlBhl/r3NnL9KFyDaMMA2wZ1/h2c5Pj3rFEsw5CwVvU4Up3a5WuFGQ8T3ZnKdqaWT+GlQnzngEmPmAc8fHKx1QLKIfWwsAOv/8uND7jeorcQ6w+hoWhkRS9Jz9SvTvZWES+SDim7YW/+UgxZlMfAPMIYzP2CUHFwLvlj4C65rIyX6puiJVqmmxT/g9uKJ/oXI2+H/dTNP5pkFReZ2b8Vg1fpXD48RiMWm19hKft/ygcP8A5NVBI7b0Ni/4LN3NtlX/3Acnqtnj08rCBE4p1sZ56zL5ijHohatkdHTkTMHIAQ0eX1SBuBKZI0OSpbxb9lIUCDVIN937jRvUJNok9aF+itjmSQivd0Mh/IOwKMK6ifu96GY5NxdtwxNTtoMXxo4mFzXXEOk5EfqNPkBlCIZ4WlhvPGGTN2DTziEDCkmBXmFd3WZo6pSa2JqjZmR/WrXoLXpVVY7RwufOMsQIuB1akvCnnp40eEK88M7TcqScFyyML9o8+LazXpbIv6sLicJu5GLQAeWwlXNrWxS/3rZIyVKtZEjjgwJnuA+VqiQGWO2HZEGvHd3wnmyFx6y6Dk5yJHO5mvVWCFFSnHZsxVeqY84rLpUrhJGzcBdb9sAqQMm120Y2PtN+FAj7xlLQ4EXjGddtwe63NcqJmr4u4u34SkOPEN9sAkphmbEkugQADBDIbm7XERLujoslfuqx9KmN+Ar3f0vg06JlEtvk4S60Vc8q5PHNR7ZIUL/luxjK/92io7bFQPrRe0GNw37aKUaB8cpij7uO9+sPAEgV20e7Lz2yR9gtI1XKODrb+xST9ajyKETishTrqJHV99AodnS5eW0gcvssn79Lu9gSfnlADFeRdFUPLopgdYgKjf3hf+wCZ+Rf+6owyx8KPiRHZm/xiQTjla129xPBePt/tBKe60eEbv7oRdX20qoduTfBOOqwQ80mpnbQENCUBzLCth7PmX7Ux+COyfD4tmm7ZWZd5oI6/sCjBmjd5oNAboK0yxjaKfRB7HXFgZ/G0Wj9XCIuIkP3GaE0vJur9oMqXSsMsl1JWgUUFNYcKbGwLXs596P83YTLlajmO00r0/cmCxTJN9gAWs/vTHaZvXDLc0CUCg3OmBXBCW8cSLzib/PemDA7DQ8mcivI+Wch0VA9dfVijdznP2iDaeUDqBHs3fF+n1Tol9s30n3M8xrWgpDt0EiaTQ2N3P9qZqum01Dy+0YJFeif8YFhzObb1IlL/sjPhUjn8EE5Sr1gLj1CYkNLSlazcMhTyPZFXHqHn02VMJpU0aAwJZ9nhSi8spFYMLHVbaQ8GVv3eHVswWf34gartQ66r/EtAp1I+1Tx/vUymw2syPeo3IvWmlwaEKsPyV2LX+6oVJqdpBNEkV/NAzf1jv+50WAfLCjDCIdJHtWm6+IcypzbndKhlnqWPiTjeuFAvLLuW5oeqq9FeJ7wmRuEB0xD9EWET9gOhVxRW12XVERq25olvR8Ukqo/rFJ2CKtBJV78/doCvf524rqYVAXWpVw/GBswdtsW+UhfeQSxDTaeJDNamLQ0jHkia9s8JJq1ECySbwM+SqDEnVvYF2oIIDlVVC47160EBqzR33eUMI+fmXIxyEq/U6AmaDaXzakyZkFma0GM/oE/1qEna7PlcDm/uzC4xisIID8AOIHHaKc108PgJQRlL+VhyKWNDZKDH9LpZ/Mn8iuECEuApZV0UpGD65r94QC9lzkG3BDX9d8iI9tGn4gxjVDLt0ivhrSAsZDWFT6VobhGwz4cab+8NPkoBCZk9CXeUgGfcBSVCoGUuFzFX4cXWt783jZ/sHztHxmsUctGzSq96Qk6JDwIMprCqqN9+17KN0LuHm+VzNSI8hrgheDE9TAnSfI8RrtMSHb1LMu6+T47t2y/y4iGvwPuJ0Xqrg7JvkpAyaDjsQwx1fCaHSba0oFuvvOpYLRpKWO9JLzUUFaUtGoXrEtiyojXPmbC4wPs5uMyIGWC5wOBRPxVYOARxUeWRgWgSDxFZ6gAd8C/TBmJ8F97GPkzs24Sv8N+gX2kD9LgbzFvpKCh6gr+SkzdhtYHQUEKuLjfAAthm2cDgkhlmD3XUHlUpQa08XU+/UM8qzf4xufQE8XZJ+i6gvbV91UuSu4R9AZnd4YkxhlGI7ZWIcWmsDT9/DAnQCtr0bbSSsatI7w7bFO8ny8HtZmIx9PHu/gFbgvJ1yo9Nnbv+dAjaxd+tGrk8s0awURCLffLLvEAYludozm0+RJ/Bv+22PVaZOWgRa//88gJ1oH/5DKmNf/l2W6hnJ7htUbaC3fEIyOpVpjmaUQPp8aFW+1ZcPxXlA4A2jKNmEIpAf4+wJIw/KxOZVYlxjWVeM7yLreuJlnGJFIaQl8Ao7b6v2SPPPBJSAB/y3v/og8CuVUPXpf9Cu4XQNS7qQAA7dzguxAAAAA==" style="display:block;width:100%">
+</div>
+    <div style="font-size:12px;color:var(--slate-500);text-align:center;max-width:250px">
+      The same session, on the phone. It tells you when it needs you.</div>
+  </div>
+</div>
+  </div>
+</section>
+<section class="sunk">
+  <div class="wrap">
+    <div class="stage-head"><span class="sn">4.0</span><h2>Automate</h2></div>
+    <p class="stage-lede">An agent can be woken by something happening: a labelled issue, a failed build, a time of
+      day. It works in its own branch and leaves you a pull request.</p>
+    
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:22px;align-items:start">
+  <div class="chain">
+    <div class="node"><div class="nt">Nobody is at the keyboard<span class="tag">03:14</span></div>
+      <div class="nb" style="color:var(--red-500)">checks.failed on main</div></div>
+    <div class="arrow">&#8595;</div>
+    <div class="node"><div class="nt">Your rule decides what happens<span class="tag">on your box</span></div>
+      <div class="nb">when CI fails on my branch &#8594; start an agent</div></div>
+    <div class="arrow">&#8595;</div>
+    <div class="node hi"><div class="nt"><span class="dot run"></span>An agent starts in its own copy of the repo</div>
+      <div class="nb"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="4.6" cy="3.6" r="1.7"/><circle cx="4.6" cy="12.4" r="1.7"/><circle cx="11.4" cy="6" r="1.7"/><path d="M4.6 5.3v5.4M11.4 7.7c0 2-1.6 2.6-3.4 2.9"/></svg> manta/fix-orders-csv-flake<br>
+        <span style="color:var(--green-500)">+18</span> <span style="color:var(--red-500)">-3</span> in 2 files, 6m 41s</div></div>
+    <div class="arrow">&#8595;</div>
+    <div class="node"><div class="nt">A draft pull request is waiting<span class="tag">03:21</span></div>
+      <div class="nb" style="color:var(--green-500)">#412 opened, tests green</div></div>
+    <div class="arrow">&#8595;</div>
+    <div class="notif"><span class="ic"></span>
+      <div><div class="t">infra / Fix red CI on main</div>
+        <div class="b">Done. Draft PR #412 is waiting for review.</div></div><span class="w">07:02</span></div>
+    <p style="text-align:center;font-size:11.5px;color:var(--slate-500);margin-top:2px">You were asleep for all of it.</p>
+  </div>
+  <div style="display:flex;flex-direction:column;gap:16px">
+    <div class="cd">
+      <h3 style="font-size:16px">On a timer, too</h3>
+      <p style="font-size:12.5px;color:var(--slate-400);margin-top:5px">Ask once, in plain English.</p>
+      <div class="joblist" style="margin-top:11px">
+        <div class="jh">Scheduled<span style="margin-left:auto;font-family:var(--font-mono)">3</span></div>
+        <div class="jr"><span class="jb" style="color:var(--cyan-400);min-width:104px">every 5 min</span>
+          <span style="color:var(--slate-300)">check the deploy, tell me if it goes red</span>
+          <span class="jm">in 2m</span></div>
+        <div class="jr"><span class="jb" style="color:var(--cyan-400);min-width:104px">weekdays 9:00</span>
+          <span style="color:var(--slate-300)">summarise what changed overnight</span>
+          <span class="jm">tomorrow</span></div>
+        <div class="jr"><span class="jb" style="color:var(--cyan-400);min-width:104px">Sundays 18:00</span>
+          <span style="color:var(--slate-300)">run the dependency audit</span>
+          <span class="jm">in 4d</span></div>
+      </div>
+    </div>
+    <div class="cd">
+      <h3 style="font-size:16px">And it can drive your Mac</h3>
+      <p style="font-size:12.5px;color:var(--slate-400);margin-top:5px">Ask from your phone. Xcode, your simulators and your
+        signing certificates do the work at home.</p>
+      <div class="term" style="margin-top:11px;font-size:11px;padding:12px 14px">
+        <div><span class="g"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M5 3.4 12.2 8 5 12.6z" fill="currentColor" stroke="none"/></svg></span> build and launch MantaUI <span class="c">on Antoine&#8217;s MacBook Pro</span></div>
+        <div><span class="c"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M5 3.4 12.2 8 5 12.6z" fill="currentColor" stroke="none"/></svg> xcodebuild&#8230;</span> <span class="g"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M3 8.4 6.2 11.6 13 4.8"/></svg> 48s</span></div>
+        <div><span class="c"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M5 3.4 12.2 8 5 12.6z" fill="currentColor" stroke="none"/></svg> boot simulator&#8230;</span> <span class="g"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M3 8.4 6.2 11.6 13 4.8"/></svg> 6s</span></div>
+        <div><span class="g"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.8" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M3 8.4 6.2 11.6 13 4.8"/></svg></span> the app is open on the simulator</div>
+      </div>
+    </div>
+  </div>
+</div>
+  </div>
+</section>
+<section>
+  <div class="wrap">
+    <div class="stage-head"><span class="sn">5.0</span><h2>Delegate</h2></div>
+    <p class="stage-lede">Hand off a job and it gets its own copy of the repository and its own branch. Five can run
+      at once without touching each other, or what you are editing.</p>
+    
+<div style="display:grid;grid-template-columns:1fr 1fr;gap:22px;align-items:start">
+  <div class="aw">
+    <div class="chrome"><i></i><i></i><i></i><span class="t">Manta UI</span></div>
+    <div class="body">
+      <div class="sb">
+        <div class="sbh">Workspace<span class="sp"><span><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="7" cy="7" r="4.2"/><path d="M10.2 10.2 14 14"/></svg></span><span>+</span></span></div>
+        <div class="grp">INFRA</div>
+        <div class="ses on"><span class="dot run"></span><span class="nm">Deploy billing service</span><span class="tm">18m</span></div>
+        <div style="padding:2px 0 0 14px;border-left:1px solid var(--navy-700);margin-left:16px">
+          <div class="ses" style="padding-left:6px"><span class="dot run"></span>
+              <span class="nm" style="font-size:10.5px">fix-orders-csv-flake</span><span class="tm">6m</span></div><div class="ses" style="padding-left:6px"><span class="dot ok"></span>
+              <span class="nm" style="font-size:10.5px">bump-deps-june</span><span class="tm">22m</span></div><div class="ses" style="padding-left:6px"><span class="dot run"></span>
+              <span class="nm" style="font-size:10.5px">audit-server-spawns</span><span class="tm">3m</span></div><div class="ses" style="padding-left:6px"><span class="dot run"></span>
+              <span class="nm" style="font-size:10.5px">backfill-tests</span><span class="tm">11m</span></div><div class="ses" style="padding-left:6px"><span class="dot ok"></span>
+              <span class="nm" style="font-size:10.5px">docs-refresh</span><span class="tm">31m</span></div>
+        </div>
+        <div class="grp">ETHERNAL</div>
+        <div class="ses"><span class="dot"></span><span class="nm">Add CSV export</span><span class="tm">2m</span></div>
+        <div class="sbf">Settings</div>
+      </div>
+      <div class="main">
+        
+<div class="hdr">
+  <span class="crumb">Deploy billing service</span>
+  <span class="chip"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="4.6" cy="3.6" r="1.7"/><circle cx="4.6" cy="12.4" r="1.7"/><circle cx="11.4" cy="6" r="1.7"/><path d="M4.6 5.3v5.4M11.4 7.7c0 2-1.6 2.6-3.4 2.9"/></svg> feat/orders-csv</span>
+  <span class="ctx">
+    <span class="ctxbar">
+      <b style="width:44%;background:var(--blue-500)"></b>
+      <b style="width:16%;background:var(--amber-500)"></b>
+      <b style="width:22%;background:var(--cyan-400)"></b>
+    </span>
+    <span class="ctxpc">38%</span>
+    <span class="hicon"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><rect x="2" y="3" width="12" height="10" rx="1.6"/><path d="M10 3v10"/></svg></span><span class="hicon"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="3.4" cy="8" r=".9" fill="currentColor" stroke="none"/><circle cx="8" cy="8" r=".9" fill="currentColor" stroke="none"/><circle cx="12.6" cy="8" r=".9" fill="currentColor" stroke="none"/></svg></span>
+  </span>
+</div>
+        <div class="tr">
+          <div class="um">Split this into five jobs and run them in parallel. Don&#8217;t let them tread on each other.</div>
+          <div class="am">Started five background jobs. Each has its own copy of the repo and its own branch,
+            so nothing they do can collide with what you are editing. I will report back as each finishes.</div>
+          <div class="tool"><span class="dot ok"></span>Task(bump-deps-june)
+            <span class="meta">done, PR #409</span></div>
+          <div class="tool"><span class="dot run"></span>Task(fix-orders-csv-flake)
+            <span class="meta">running 6m</span></div>
+        </div>
+        
+<div class="comp">
+  <div class="box">Ask for anything else while these run<span class="send"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M14 2 7.2 8.8M14 2l-4.4 12-2.4-5.2L2 6.4z"/></svg></span></div>
+  <div class="meta">
+    <span class="mp b">Opus 4.7 &#9662;</span><span class="mp">High &#9662;</span>
+    <span class="mi"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M11.5 7.2 7 11.7a2.6 2.6 0 0 1-3.7-3.7l5-5a1.8 1.8 0 0 1 2.5 2.5l-5 5a.9.9 0 0 1-1.3-1.3l4.4-4.4"/></svg></span>
+    <span style="margin-left:auto;display:flex;gap:10px"><span class="mi"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="8" cy="8" r="5.6"/><path d="M8 4.8V8l2.2 1.4"/></svg></span><span class="mi"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="5.4" cy="8" r="2.6"/><path d="M8 8h6M12 8v2.2M10.2 8v1.6"/></svg></span><span class="mi"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><path d="M4.5 12.4a2.6 2.6 0 1 0 0-5.2M4.5 7.2V4.6A2.2 2.2 0 0 1 6.7 2.4h2M11.5 12.4h-3"/></svg></span></span>
+  </div>
+  <div class="perm"><span>Permissions on, click to bypass</span></div>
+</div>
+      </div>
+    </div>
+  </div>
+  <div style="display:flex;flex-direction:column;gap:14px">
+    <div class="joblist">
+      <div class="jh">Background jobs<span style="margin-left:auto;font-family:var(--font-mono)">3 running, 2 done</span></div>
+      
+        <div class="jr"><span class="dot run"></span><span class="jb"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="4.6" cy="3.6" r="1.7"/><circle cx="4.6" cy="12.4" r="1.7"/><circle cx="11.4" cy="6" r="1.7"/><path d="M4.6 5.3v5.4M11.4 7.7c0 2-1.6 2.6-3.4 2.9"/></svg> fix-orders-csv-flake</span>
+          <span class="jm"><span style="font-family:var(--font-mono);color:var(--slate-500)">+18 -3</span>
+            <span style="color:var(--cyan-400)">running</span>
+            <span>6m</span></span></div>
+        <div class="jr"><span class="dot ok"></span><span class="jb"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="4.6" cy="3.6" r="1.7"/><circle cx="4.6" cy="12.4" r="1.7"/><circle cx="11.4" cy="6" r="1.7"/><path d="M4.6 5.3v5.4M11.4 7.7c0 2-1.6 2.6-3.4 2.9"/></svg> bump-deps-june</span>
+          <span class="jm"><span style="font-family:var(--font-mono);color:var(--slate-500)">+204 -196</span>
+            <span style="color:var(--green-500)">done, PR #409</span>
+            <span>22m</span></span></div>
+        <div class="jr"><span class="dot run"></span><span class="jb"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="4.6" cy="3.6" r="1.7"/><circle cx="4.6" cy="12.4" r="1.7"/><circle cx="11.4" cy="6" r="1.7"/><path d="M4.6 5.3v5.4M11.4 7.7c0 2-1.6 2.6-3.4 2.9"/></svg> audit-server-spawns</span>
+          <span class="jm"><span style="font-family:var(--font-mono);color:var(--slate-500)">+0 -0</span>
+            <span style="color:var(--cyan-400)">running</span>
+            <span>3m</span></span></div>
+        <div class="jr"><span class="dot run"></span><span class="jb"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="4.6" cy="3.6" r="1.7"/><circle cx="4.6" cy="12.4" r="1.7"/><circle cx="11.4" cy="6" r="1.7"/><path d="M4.6 5.3v5.4M11.4 7.7c0 2-1.6 2.6-3.4 2.9"/></svg> backfill-tests</span>
+          <span class="jm"><span style="font-family:var(--font-mono);color:var(--slate-500)">+312 -8</span>
+            <span style="color:var(--cyan-400)">running</span>
+            <span>11m</span></span></div>
+        <div class="jr"><span class="dot ok"></span><span class="jb"><svg viewBox="0 0 16 16" width="12" height="12" fill="none" stroke="currentColor"
+    stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round"
+    style="flex:none;vertical-align:-1px"><circle cx="4.6" cy="3.6" r="1.7"/><circle cx="4.6" cy="12.4" r="1.7"/><circle cx="11.4" cy="6" r="1.7"/><path d="M4.6 5.3v5.4M11.4 7.7c0 2-1.6 2.6-3.4 2.9"/></svg> docs-refresh</span>
+          <span class="jm"><span style="font-family:var(--font-mono);color:var(--slate-500)">+64 -12</span>
+            <span style="color:var(--green-500)">done, PR #410</span>
+            <span>31m</span></span></div>
+    </div>
+    <div class="cd">
+      <p style="font-size:12.5px;color:var(--slate-400)">Each job is a real branch you can check out, review and merge
+        like any other. Nothing is hidden in a service you cannot see.</p>
+    </div>
+  </div>
+</div>
+  </div>
+</section>
 <!-- ============ 9. FAQ ============ -->
 <section>
   <div class="wrap">


### PR DESCRIPTION
## Summary

Builds the five numbered stage sections for the homepage redesign — **1.0 Install → 5.0 Delegate** — sitting between the problem band and the FAQ. This is the spine of the page whose table of contents is the hero rail.

Ports **sections 3–7** from `docs/specs/homepage-redesign/reference.html` **verbatim** into `website/index.html`, the same way BET-904 ported the hero/problem-band/FAQ.

## What landed

| # | Heading | Background |
|---|---|---|
| 1.0 | Install | plain |
| 2.0 | Run | `.sunk` |
| 3.0 | Leave | plain |
| 4.0 | Automate | `.sunk` |
| 5.0 | Delegate | plain |

Each section uses `.stage-head` / `.stage-lede` with the lede copied verbatim from the reference. 2.0, 3.0 and 5.0 reuse the same `.aw` app-window component (BET-904's), differing only by the arguments the reference passes (full-vs-`.narrow` sidebar, with/without a composer, dimmed-disconnected state, nested background jobs). No `<video>`, no permission card in 2.0, no floating notification card in 3.0 — the phone in 3.0 is the exact reference placeholder.

## Acceptance checklist

1. ✅ Five sections in order between the problem band and the FAQ, byte-matching the reference markup.
2. ✅ `<style>` diff = one small responsive block only (see "CSS addition" below), no other new CSS. Every class the sections need was already landed by BET-904.
3. ✅ No new hex literals — the only hex in the added markup (`#000` phone frame) is copied verbatim from the reference.
4. ✅ No horizontal scrollbar and **no overflow** at 1280 / 1024 / 390 / 360 (verified headless with CDP device-metrics: `scrollWidth === clientWidth` at every width, and no section scrolls).
5. ✅ `.aw` appears in the hero (BET-904), 2.0, 3.0 and 5.0 — 4 instances, all the same component structure.
6. ✅ No JS errors; the only 404 is the browser's automatic `/favicon.ico` probe, identical to the pre-change baseline (the page declares no favicon).

## CSS addition (acceptance 2 explanation)

One page-scoped, mobile-only rule was added to `website/index.html`'s inline `<style>`, the **same pattern BET-904's reviewer required for AC#4** on the hero:

```css
@media(max-width:900px){
  .stage-lede + div[style*="display:grid"]{grid-template-columns:minmax(0,1fr) !important}
  .stage-lede + div[style*="display:grid"] > *{min-width:0}
}
```

**Why BET-904 could not have carried it:** the five stage sections did not exist in `website/index.html` until this PR — BET-904 only ported the hero/problem-band/FAQ and explicitly left sections 3–7 markup to this issue. So there was no markup to attach responsive rules to. The sections' content grids are defined inline in the reference (`grid-template-columns:1fr 262px` / `1fr 1fr` / `1.1fr .9fr`), so they don't respond to viewport width; at 390px they overflowed (3.0 ≈ 868px, 4.0 ≈ 441px) and would have failed AC#4 exactly as BET-904 did before its own fix.

The rule stacks each section's content grid to a single column and lets the fixed-width `.aw` / phone / cards shrink, mirroring BET-904's `.hero-grid` fix. `!important` is required because the columns come from the reference's inline styles. It touches no markup, no hex, and desktop (>900px) is verbatim to the reference. Note this is the *same* treatment BET-904 applied to the hero, applied now to the newly-ported sections — it is the established AC#4 resolution, not a redesign. (A follow-up was filed for this and then cancelled as redundant once the fix landed here.)

---
**Base:** `origin/main` @ `8868c4fd`
