### PR TITLE
fix(server): replay pending questions/permissions on /events reconnect (BET-916)

### DIFF
--- a/src/server/events.mjs
+++ b/src/server/events.mjs
@@ -12,10 +12,12 @@ export function createBus() {
     subscribe(fn) {
       subs.add(fn);
       // Replay current state to the newly (re)connected consumer. Edge-only
-      // frames like `stream.running` never re-fire on their own, so a client
-      // that connects mid-turn would never learn a session is already busy —
-      // this is exactly the force-quit + relaunch case, where the turn timer
-      // must survive a fresh process.
+      // frames — `stream.running`, and the pending `stream.questions` /
+      // `stream.permissions` (BET-916) — never re-fire on their own, so a
+      // client that connects mid-state would never learn a session is already
+      // busy or already blocked on an interactive card. This is exactly the
+      // force-quit + relaunch case, where those recoverable states must
+      // survive a fresh process.
       for (const evt of snapshot()) { try { fn(evt); } catch {} }
       return () => subs.delete(fn);
     },

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -186,11 +186,13 @@ const streamInterp = createStreamInterpreter({
   publish: (evt) => bus.publish(evt),
   contextLimitFor,
 });
-// BET-913: when a client (re)connects mid-turn, replay the current busy state
-// so edge-only frames like `running` aren't lost — this is what lets the iOs
-// turn timer survive a force-quit + relaunch. `snapshotBusy()` returns events
-// for sessions already running; the bus replays them to each new subscriber.
-bus.setSnapshot(() => streamInterp.snapshotBusy());
+// BET-913 + BET-916: when a client (re)connects mid-state, replay the current
+// edge-only state so frames that only fire on an edge aren't lost — `running`
+// (lets the iOS turn timer survive a force-quit + relaunch) plus pending
+// `questions` / `permissions` (lets a pending interactive card reappear and
+// stay answerable on a thin client). `snapshotState()` returns these events;
+// the bus replays them to each new subscriber.
+bus.setSnapshot(() => streamInterp.snapshotState());
 // Shared deps passed to store-mutating helpers so they can publish the
 // `*.updated` bus event the renderer cards listen for (JobCard, WebhooksCard,
 // etc). Single source of truth — every endpoint that creates/deletes a

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -563,12 +563,22 @@ export function createStreamInterpreter({
   return {
     interpret,
     getState: (sid) => sessions.get(sid),
-    // Replay events for sessions that are currently running, for the bus's
-    // connect-time snapshot (BET-913). The `running` frame is emitted only on
-    // the idle->busy EDGE, so a client that (re)connects mid-turn never saw
-    // it — this reconstructs it (with the original `since`, so the turn timer
-    // survives a force-quit + relaunch). Empty when nothing is busy.
-    snapshotBusy() {
+    // Replay current edge-only state for the bus's connect-time snapshot
+    // (BET-913 + BET-916). These frames are emitted only on an EDGE — their
+    // current value is never re-sent on its own — so a client that
+    // (re)connects mid-state never sees them: the `running` frame fires only
+    // on the idle->busy edge (the turn timer survives a force-quit +
+    // relaunch only if this is reconstructed with the ORIGINAL `since`), and
+    // `questions` / `permissions` frames fire only as `question.*` /
+    // `permission.*` events arrive. A fresh /events subscription therefore
+    // recovers the still-pending interactive cards too. Each is replayed with
+    // exactly the same envelope the live path emits, so a reconnecting client
+    // needs no change. Empty when there is nothing to replay.
+    //
+    // Replayed independently of one another and of `st.running`: a pending
+    // question/permission blocks the turn but never sets `running`, so gating
+    // on `running` would skip exactly the sessions that need the replay.
+    snapshotState() {
       const out = [];
       for (const [sid, st] of sessions) {
         if (st.running && st.runningSince != null) {
@@ -581,6 +591,22 @@ export function createStreamInterpreter({
               type: st.runningType ?? null,
               since: st.runningSince,
             },
+          });
+        }
+        if (st.questions.length > 0) {
+          out.push({
+            kind: "stream",
+            sub: "questions",
+            sessionId: sid,
+            payload: { questions: st.questions },
+          });
+        }
+        if (st.permissions.length > 0) {
+          out.push({
+            kind: "stream",
+            sub: "permissions",
+            sessionId: sid,
+            payload: { permissions: st.permissions },
           });
         }
       }

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -359,17 +359,17 @@ test("session.status busy emits a running frame with a non-null since", () => {
   assert.equal(ev.payload.since, 42_000, "stamped from the injectable now()");
 });
 
-test("snapshotBusy replays a running frame for a currently-busy session only (BET-913)", () => {
+test("snapshotState replays a running frame for a currently-busy session only (BET-913)", () => {
   const { interp } = make(42_000);
   // Nothing busy yet -> no replay events.
-  assert.deepEqual(interp.snapshotBusy(), []);
+  assert.deepEqual(interp.snapshotState(), []);
   // Start a turn; the replay carries the frame the busy->idle edge never
   // re-emits, with the ORIGINAL since so the timer survives a fresh process.
   interp.interpret({
     type: "session.status",
     properties: { sessionID: SID, status: { type: "busy" } },
   });
-  const snap = interp.snapshotBusy();
+  const snap = interp.snapshotState();
   assert.equal(snap.length, 1);
   assert.equal(snap[0].kind, "stream");
   assert.equal(snap[0].sub, "running");
@@ -379,16 +379,104 @@ test("snapshotBusy replays a running frame for a currently-busy session only (BE
   assert.equal(snap[0].payload.type, "busy", "last status type preserved additively");
   // An idle session leaves nothing to replay.
   interp.interpret({ type: "session.idle", properties: { sessionID: SID } });
-  assert.deepEqual(interp.snapshotBusy(), []);
+  assert.deepEqual(interp.snapshotState(), []);
 });
 
-test("snapshotBusy ignores sessions that were never marked running", () => {
+test("snapshotState ignores sessions that were never marked running", () => {
   const { interp } = make();
   interp.interpret({
     type: "message.part.delta",
     properties: { sessionID: SID, messageID: "m", part: { id: "p", type: "text", text: "hi" } },
   });
-  assert.deepEqual(interp.snapshotBusy(), []);
+  assert.deepEqual(interp.snapshotState(), []);
+});
+
+// BET-916 — sibling of BET-913: pending questions/permissions are edge-only too
+// (`question.*` / `permission.*` frames fire only as events arrive), so a fresh
+// /events subscription would drop the still-pending interactive card. The
+// snapshot replays them regardless of `running` — a pending question/blocks a
+// turn without ever setting `running`, so gating on `running` would skip them.
+
+test("snapshotState replays a pending questions frame independent of running (BET-916)", () => {
+  const { interp } = make();
+  interp.interpret({
+    type: "question.asked",
+    properties: {
+      sessionID: SID,
+      id: "que_1",
+      tool: { messageID: "m", callID: "call_1" },
+      questions: [{ text: "Option one?" }],
+    },
+  });
+  // The live path never set `running` for this session — the snapshot must
+  // still replay the question, or a reconnecting client is blocked but
+  // unanswerable on the box.
+  assert.equal(interp.getState(SID).running, false, "question doesn't set running");
+  const snap = interp.snapshotState();
+  const q = snap.find((e) => e.sub === "questions");
+  assert.ok(q, "a questions frame is replayed");
+  assert.equal(q.kind, "stream");
+  assert.equal(q.sessionId, SID);
+  assert.equal(q.payload.questions.length, 1);
+  assert.equal(q.payload.questions[0].id, "call_1", "real request id survives for answering");
+});
+
+test("snapshotState replays a pending permissions frame independent of running (BET-916)", () => {
+  const { interp } = make();
+  interp.interpret({
+    type: "permission.asked",
+    properties: { sessionID: SID, id: "perm_1", prompt: "Allow reading ~/secrets.json?" },
+  });
+  assert.equal(interp.getState(SID).running, false, "permission doesn't set running");
+  const snap = interp.snapshotState();
+  const p = snap.find((e) => e.sub === "permissions");
+  assert.ok(p, "a permissions frame is replayed");
+  assert.equal(p.kind, "stream");
+  assert.equal(p.sessionId, SID);
+  assert.equal(p.payload.permissions.length, 1);
+  assert.equal(p.payload.permissions[0].id, "perm_1", "real request id survives for answering");
+});
+
+test("snapshotState does not replay resolved/empty questions or permissions", () => {
+  const { interp } = make();
+  interp.interpret({
+    type: "question.asked",
+    properties: {
+      sessionID: SID,
+      id: "que_1",
+      tool: { messageID: "m", callID: "call_1" },
+      questions: [{ text: "?" }],
+    },
+  });
+  interp.interpret({
+    type: "question.replied",
+    properties: { sessionID: SID, id: "que_1" },
+  });
+  assert.equal(interp.getState(SID).questions.length, 0);
+  assert.deepEqual(interp.snapshotState(), [], "nothing pending, nothing replayed");
+});
+
+test("snapshotState replays running + questions + permissions together, each with its own frame", () => {
+  const { interp } = make(42_000);
+  interp.interpret({
+    type: "session.status",
+    properties: { sessionID: SID, status: { type: "busy" } },
+  });
+  interp.interpret({
+    type: "question.asked",
+    properties: {
+      sessionID: SID,
+      id: "que_1",
+      tool: { messageID: "m", callID: "call_1" },
+      questions: [{ text: "?" }],
+    },
+  });
+  interp.interpret({
+    type: "permission.asked",
+    properties: { sessionID: SID, id: "perm_1", prompt: "p" },
+  });
+  const subs = interp.snapshotState().map((e) => e.sub).sort();
+  assert.deepEqual(subs, ["permissions", "questions", "running"]);
 });
 
 test("a second busy while already running emits the SAME since (clock not restarted)", () => {


### PR DESCRIPTION
**Files changed:** 4 files. `src/server/streamInterp.mjs`, `src/server/streamInterp.test.mjs`, `src/server/index.mjs`, `src/server/events.mjs`.

Widens the box's connect-time snapshot from `snapshotBusy` (running only, BET-913) to `snapshotState`, which also replays the current pending `questions` and `permissions` frames for sessions that have them — **independent of running state**. A pending question/permission blocks the turn without ever setting `running`, so gating the replay on `running` would skip exactly the sessions that need it (a force-quit + relaunch on iOS leaves the session blocked on the box and unanswerable from the phone, because a transcript-recovered question has no `requestId`).

Frame envelopes match the live emit path exactly (`emit(sid, "questions", { questions })` / `emit(sid, "permissions", { permissions })`), verified against `MantaEventStreamTests.swift` — so no client change is needed. `events.mjs` is untouched functionally (already generic via `bus.setSnapshot`); only the snapshot producer changed in `index.mjs`.

**Base: origin/main @ `5565eea1`**

**Verification results:**
- PR branch (`multica/BET-916-replay-questions-permissions` @ `862075a1`):
  - typecheck: exit 0. Errors: none. log sha256: `0b7dea94646e4783be73effeb4d4720a52642e6fa37f425d5a8d095e7dce90ec`
  - test: exit 0, 2049 pass / 0 fail / 0 skip. Failures: none. log sha256: `0c4be2fea804acb864f1f8e56d1d5b930902ce41bac2e42aaf5570bb6b8e7926`
- Base (`main` @ `5565eea1`): unchanged behavior — no existing test modified; the 6 new BET-916 tests are additive-only.

**Conclusion:** 0 new failures, 0 pre-existing failures. Typecheck + full suite green.
