### PR TITLE
Homepage: enrich the two thin feature tiles (Bring Your Own Plan, Mac Plugins) (BET-921)

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -1083,7 +1083,11 @@ h1 .grad{background:var(--gradient-brand);-webkit-background-clip:text;backgroun
           <div class="x"><div class="t">Self-Hosted</div><div class="d">Runs on your box. No account, no telemetry, no middleman.</div></div>
         </div>
         <div class="btc">
-          <div class="g"><div class="glyph" style="gap:5px"><span class="gchip">claude</span><span class="gchip">codex</span><span class="gchip">kimi</span></div></div>
+          <div class="g"><div class="glyph" style="flex-direction:column;gap:5px;align-items:stretch">
+            <span class="gchip" style="display:flex;align-items:center;gap:7px;justify-content:space-between"><span style="color:var(--text-secondary)">claude</span><span style="color:var(--green-500);font-size:10px">&#10003; your plan</span></span>
+            <span class="gchip" style="display:flex;align-items:center;gap:7px;justify-content:space-between"><span style="color:var(--text-secondary)">codex</span><span style="color:var(--green-500);font-size:10px">&#10003; your plan</span></span>
+            <span class="gchip" style="display:flex;align-items:center;gap:7px;justify-content:space-between"><span style="color:var(--text-secondary)">kimi</span><span style="color:var(--green-500);font-size:10px">&#10003; your plan</span></span>
+          </div></div>
           <div class="x"><div class="t">Bring Your Own Plan</div><div class="d">The subscription you already pay for. Nothing resold.</div></div>
         </div>
         <div class="btc">
@@ -1124,8 +1128,11 @@ h1 .grad{background:var(--gradient-brand);-webkit-background-clip:text;backgroun
           <div class="x"><div class="t">Native Worktrees</div><div class="d">Each job gets its own branch and its own worktree.</div></div>
         </div>
         <div class="btc">
-          <div class="g"><div class="glyph" style="flex-direction:column;gap:5px">
-            <span class="gchip" style="color:var(--cyan-400)">xcodebuild</span><span class="gchip">simctl boot</span></div></div>
+          <div class="g"><div class="glyph" style="flex-direction:column;gap:5px;align-items:stretch">
+            <span class="gchip" style="display:flex;align-items:center;gap:6px;justify-content:space-between"><span style="color:var(--cyan-400);font-weight:700">ios-mantaui</span><span style="opacity:.5;font-size:10px">plugin</span></span>
+            <span class="gchip" style="display:flex;align-items:center;gap:6px;justify-content:space-between"><span style="color:var(--text-secondary)">xcodebuild</span><span style="color:var(--green-500);font-size:10px">&#10003; done</span></span>
+            <span class="gchip" style="display:flex;align-items:center;gap:6px;justify-content:space-between"><span style="color:var(--text-secondary)">simctl boot</span><span style="color:var(--cyan-400);font-size:10px">&#8599; on phone</span></span>
+          </div></div>
           <div class="x"><div class="t">Mac Plugins</div><div class="d">Xcode, simulators and certificates, driven from your phone.</div></div>
         </div>
       </div>


### PR DESCRIPTION
Follow-up from BET-906 (#919). Enriches the two thinnest feature tiles — **Bring Your Own Plan** and **Mac Plugins** — in the same markup-drawn style (`.bt`/`.btc`/`.glyph`/`.gchip`) as the other ten. Tile titles + benefit copy kept verbatim from `docs/specs/homepage-redesign/reference.html` section 8; model names (`claude`/`codex`/`kimi`) unchanged.

**Changes** (`website/index.html` only, +10/−3):
- **Bring Your Own Plan** — now three full-width plan rows, each model with a `✓ your plan` badge (was three bare chips in one row).
- **Mac Plugins** — now a plugin-capability list: `ios-mantaui` header chip + `xcodebuild ✓ done` + `simctl boot ↗ on phone` rows (was two bare chips).

Out of scope untouched: the other ten tiles, no per-tile links/borders, no comparison table, no thirteenth tile.

**Verification (headless render @ 1280/1024/390px):** 12 equal tiles, 4/2/1 per row, no horizontal scrollbar, no console errors, no 404s — all PASS.

**Verification results:**
- PR branch `multica/BET-921-enrich-thin-tiles` @ `d4a4636`:
  - typecheck: exit 0, no errors
  - test: exit 0, 2049 pass / 0 fail / 0 skip
- Base: `origin/main` @ `bb8b99d6`

**Base: origin/main @ bb8b99d6**
