### PR TITLE
chore: release 0.0.28 (server/desktop) + iOS 0.1.1

### DIFF
--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -88,7 +88,7 @@ targets:
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         TARGETED_DEVICE_FAMILY: "1,2"
-        MARKETING_VERSION: "0.1.0"
+        MARKETING_VERSION: "0.1.1"
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Automatic
         SWIFT_EMIT_LOC_STRINGS: YES

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.27",
+      "version": "0.0.28",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.27",
+  "version": "0.0.28",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.27",
+ "version": "0.0.28",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Version bump so every release track can ship from current main.

| Track | Was live | This ships |
|---|---|---|
| Box server tarballs | 0.0.27 (5 src commits stale) | 0.0.28 |
| In-app server update offer | 0.0.27 | 0.0.28 |
| macOS desktop DMG | 0.0.18 | 0.0.28 |
| Windows installer | 0.0.22 | 0.0.28 |
| iOS native (TestFlight) | 0.1.0, 1047 commits behind | 0.1.1 |

The server bump is not cosmetic: main carries five `src/`+`scripts/` commits past the published 0.0.27 tarball, so republishing under the same version would leave every running box on stale bytes with no update offer. `website/updates/server.json` is the offer boxes poll every 6h, so it moves with it.

Merging this auto-cuts `ios-v0.1.1` (ios-release-tag.yml) and fires Codemagic. The remaining tags (`server-v*`, `web-v*`, `mac-v*`, `win-v*`, `gateway-v*`) are pushed by hand afterwards, one at a time.