### PR TITLE
fix(ios): reconcile running state on reconnect via authoritative runningSet (BET-922)

### DIFF
--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -242,6 +242,11 @@ final class ChatSessionStore: ObservableObject {
     /// `false`) must not clobber the optimistic `true` — but once the box
     /// reports running at all, the snapshot is authoritative.
     private var optimisticRunning = false
+    /// The last `runningSetSeq` this store has folded into its running state. A
+    /// change in it means the box has (re)stated the authoritative running set
+    /// since `send()` stamped `optimisticRunning`, so the optimistic flag must
+    /// yield (BET-922).
+    private var lastRunningSetSeq = 0
     private var didRunOnce = false
     /// Test seams (internal, readable via `@testable`): count one-time vs
     /// resumable work so tests can assert the split without touching live
@@ -427,6 +432,14 @@ final class ChatSessionStore: ObservableObject {
         // stale previous-turn `false` must not clobber while the box hasn't yet
         // confirmed. Reading the snapshot (not a per-frame stamp) also makes
         // this robust to frames that coalesce between publishes.
+        // The box's authoritative running set supersedes the optimistic stamp
+        // `send()` set — without this, a send whose acknowledging frame was
+        // missed leaves the working row lit forever (BET-922).
+        let seq = eventStore.runningSetSeq
+        if seq != lastRunningSetSeq {
+            lastRunningSetSeq = seq
+            optimisticRunning = false
+        }
         if optimisticRunning, (carried.running || s.running == true) {
             optimisticRunning = false
         }

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -251,6 +251,36 @@ enum MantaStreamRouter {
         return s
     }
 
+    /// Replace running state across ALL known sessions from the box's
+    /// authoritative set. A session absent from the set is not running.
+    /// Only `running` / `runningSince` are touched — `turnComplete`, `chunks`
+    /// and `tools` are deliberately left alone (turn retirement + tool rows are
+    /// owned by the reconnect transcript refetch; synthesising `turnComplete`
+    /// here would double-fire the completion haptic).
+    static func applyingRunningSet(
+        _ payload: StreamRunningSetPayload,
+        to states: [String: MantaSessionStreamState]
+    ) -> [String: MantaSessionStreamState] {
+        var next = states
+        let bySession = Dictionary(uniqueKeysWithValues: payload.sessions.map { ($0.sessionId, $0) })
+        for (sid, var s) in next {
+            let entry = bySession[sid]
+            s.running = entry != nil
+            s.runningSince = resolveRunningSince(
+                running: entry != nil, since: entry?.since, current: s.runningSince
+            )
+            next[sid] = s
+        }
+        // A session the device has never seen a frame for can still be running.
+        for entry in payload.sessions where next[entry.sessionId] == nil {
+            var s = MantaSessionStreamState(sessionId: entry.sessionId)
+            s.running = true
+            s.runningSince = resolveRunningSince(running: true, since: entry.since, current: nil)
+            next[entry.sessionId] = s
+        }
+        return next
+    }
+
     /// Retire the live chunks whose message the canonical transcript now
     /// carries. Pure so the retirement rule is testable without a socket.
     ///
@@ -320,6 +350,12 @@ final class MantaEventStore: ObservableObject {
     /// can't tell a consumer which fields the frame just delivered. This is the
     /// per-frame delta the single-writer merge (BET-668) feeds off.
     private(set) var lastStreamFrame: StreamFrameStamp?
+
+    /// Bumped on every authoritative running-set apply. A consumer holding
+    /// optimistic local running state compares against this to know the box
+    /// has since spoken definitively. Not `@Published` — `sessionStates` is,
+    /// and it is reassigned in the same call, so observers already re-run.
+    private(set) var runningSetSeq: Int = 0
 
     /// Which session the most recent stream frame targeted and the `sub` it
     /// carried. `sub == nil` for a non-routed frame (nothing turn-state-related
@@ -439,11 +475,23 @@ final class MantaEventStore: ObservableObject {
         lastFrameAt = Date()
         guard let frame = try? MantaStreamFrame.parse(text) else { return }
         if frame.isHeartbeat { return }
-        if frame.kind == "stream" {
+        if frame.kind == "runningSet" {
+            applyRunningSet(frame)
+        } else if frame.kind == "stream" {
             routeStream(frame)
         } else {
             rawFrameHandler?(frame)
         }
+    }
+
+    /// The box's authoritative running set, replayed on every (re)connect.
+    /// Deliberately NOT behind `routeStream`'s `degraded` guard: a client that
+    /// discarded frames while unreachable is exactly the client whose running
+    /// state needs correcting the moment it hears from the box again.
+    private func applyRunningSet(_ frame: MantaStreamFrame) {
+        guard let p = try? frame.decodedPayload(StreamRunningSetPayload.self) else { return }
+        sessionStates = MantaStreamRouter.applyingRunningSet(p, to: sessionStates)
+        runningSetSeq += 1
     }
 
     private func routeStream(_ frame: MantaStreamFrame) {

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -160,6 +160,18 @@ struct StreamRunningPayload: Codable, Equatable, Sendable {
     var since: Double?          // epoch ms; absent on an older box
 }
 
+/// `kind: "runningSet"` — the COMPLETE set of sessions the box currently has
+/// running, replayed on every (re)connect. Authoritative: a session absent from
+/// `sessions` is NOT running (BET-922).
+struct StreamRunningSetPayload: Codable, Equatable, Sendable {
+    struct Entry: Codable, Equatable, Sendable {
+        var sessionId: String
+        var since: Double?
+        var type: String?
+    }
+    var sessions: [Entry]
+}
+
 /// `sub: "turnComplete"` — emitted by `message.updated`/`session.idle`.
 struct StreamTurnCompletePayload: Codable, Equatable, Sendable {
     var complete: Bool

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -149,6 +149,39 @@ final class ChatStreamMergeTests: XCTestCase {
         XCTAssertFalse(store.running)
     }
 
+    /// BET-922: a send whose acknowledging frame was missed can leave the
+    /// optimistic `running = true` lit forever. The box's authoritative
+    /// `runningSet` (replayed on every reconnect) must supersede it: once the
+    /// set has spoken, the accumulated snapshot is authoritative even if it
+    /// says idle.
+    func testRunningSetSupersedesOptimisticRunning() async {
+        let stream = TestStreamControl()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = ChatSessionStore(
+            sessionId: "ses",
+            eventStore: eventStore,
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!, tokenProvider: { nil }, session: Self.succeedingSession())
+        )
+        await Task.yield()
+
+        // Establish snapshot state for the session (running stays nil) so the
+        // running-set apply reaches the running merge rather than the
+        // no-state early return.
+        stream.inject(#"{"kind":"stream","sub":"context","sessionId":"ses","payload":{"freshInput":0,"cacheRead":0,"cacheWrite":0,"totalInput":0,"pct":0,"segments":[]}}"#)
+        await Task.yield()
+
+        let ok = await store.send(text: "hello", attachments: [], model: nil)
+        XCTAssertTrue(ok)
+        XCTAssertTrue(store.running, "a send reports running optimistically")
+
+        // The box reconnects and states the authoritative running set: this
+        // session is NOT in it. The optimistic flag must yield, so the working
+        // row is NOT left lit forever even though no 'running' frame arrived.
+        stream.inject(#"{"kind":"runningSet","payload":{"sessions":[]}}"#)
+        await Task.yield()
+        XCTAssertFalse(store.running, "an authoritative running set supersedes the optimistic flag")
+    }
+
     /// Block 2: a local transcript-refetch republish (retireCoveredStreamText)
     /// must NOT replay the previous frame's fields over an optimistic send — the
     /// freshly-minted tail and optimistic running survive it.

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -371,6 +371,87 @@ final class MantaEventStreamRouterTests: XCTestCase {
         XCTAssertEqual(resulting, original)
     }
 
+    // MARK: - Running-set reconcile on reconnect (BET-922)
+
+    /// The box's reconnect snapshot is an authoritative `runningSet` frame. A
+    /// session in the set is running, with `since` converted ms -> seconds.
+    func testRunningSetMarksListedSessionRunningWithSinceConverted() {
+        var states: [String: MantaSessionStreamState] = [:]
+        states["ses_1"] = MantaSessionStreamState(sessionId: "ses_1")
+        let payload = StreamRunningSetPayload(sessions: [
+            .init(sessionId: "ses_1", since: 1_700_000_000_000, type: "busy")
+        ])
+        states = MantaStreamRouter.applyingRunningSet(payload, to: states)
+        XCTAssertEqual(states["ses_1"]?.running, true)
+        XCTAssertEqual(states["ses_1"]?.runningSince, Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    /// REGRESSION (the whole point of BET-922): a session latched `running:true`
+    /// in state but absent from the authoritative set must flip to idle. Silence
+    /// from the box is now "it stopped".
+    func testRunningSetClearsLatchedRunningAbsentFromTheSet() {
+        var states: [String: MantaSessionStreamState] = [:]
+        var s = MantaSessionStreamState(sessionId: "ses_1")
+        s.running = true
+        s.runningSince = Date(timeIntervalSince1970: 1000)
+        states["ses_1"] = s
+        let payload = StreamRunningSetPayload(sessions: [])
+        states = MantaStreamRouter.applyingRunningSet(payload, to: states)
+        XCTAssertEqual(states["ses_1"]?.running, false)
+        XCTAssertNil(states["ses_1"]?.runningSince)
+    }
+
+    /// A session the device has never seen a frame for can still be running on
+    /// the box, so the set must materialise it.
+    func testRunningSetCreatesStateForSessionItHasNeverSeen() {
+        var states: [String: MantaSessionStreamState] = [:]
+        let payload = StreamRunningSetPayload(sessions: [
+            .init(sessionId: "ses_new", since: 1_700_000_000_000, type: nil)
+        ])
+        states = MantaStreamRouter.applyingRunningSet(payload, to: states)
+        XCTAssertEqual(states["ses_new"]?.running, true)
+        XCTAssertEqual(states["ses_new"]?.runningSince, Date(timeIntervalSince1970: 1_700_000_000))
+    }
+
+    /// An empty set is the correction a stale client needs: every running
+    /// session is cleared.
+    func testRunningSetEmptyClearsEveryRunningSession() {
+        var states: [String: MantaSessionStreamState] = [:]
+        for id in ["ses_a", "ses_b"] {
+            var s = MantaSessionStreamState(sessionId: id)
+            s.running = true
+            s.runningSince = Date(timeIntervalSince1970: 1000)
+            states[id] = s
+        }
+        states = MantaStreamRouter.applyingRunningSet(
+            StreamRunningSetPayload(sessions: []), to: states
+        )
+        XCTAssertEqual(states["ses_a"]?.running, false)
+        XCTAssertEqual(states["ses_b"]?.running, false)
+        XCTAssertNil(states["ses_a"]?.runningSince)
+        XCTAssertNil(states["ses_b"]?.runningSince)
+    }
+
+    /// Only `running` / `runningSince` are reconciled — turn retirement, stream
+    /// chunks and live tools are owned by the reconnect transcript refetch and
+    /// must survive the apply untouched.
+    func testRunningSetLeavesTurnCompleteChunksAndToolsUntouched() {
+        var s = MantaSessionStreamState(sessionId: "ses_1")
+        s.turnComplete = true
+        s.chunks = [StreamTextChunk(partID: "p", messageID: "m", field: "text", text: "hi")]
+        s.tools["t1"] = LiveTool(idx: "t1", callID: "t1", name: "bash", presentationHint: nil, status: "running")
+        s.toolStartOrder = ["t1"]
+        let payload = StreamRunningSetPayload(sessions: [
+            .init(sessionId: "ses_1", since: 1_700_000_000_000, type: "busy")
+        ])
+        let next = MantaStreamRouter.applyingRunningSet(payload, to: ["ses_1": s])
+        XCTAssertEqual(next["ses_1"]?.running, true)
+        XCTAssertEqual(next["ses_1"]?.turnComplete, true)
+        XCTAssertEqual(next["ses_1"]?.chunks, [StreamTextChunk(partID: "p", messageID: "m", field: "text", text: "hi")])
+        XCTAssertEqual(next["ses_1"]?.tools["t1"]?.name, "bash")
+        XCTAssertEqual(next["ses_1"]?.toolStartOrder, ["t1"])
+    }
+
     // MARK: - Subagent upsert (BET-672)
 
     /// A subagent that goes running→done for the SAME child must leave exactly
@@ -726,6 +807,53 @@ final class MantaEventStoreTests: XCTestCase {
         let store = makeStore(fake)
         fake.inject(#"{"kind":"heartbeat","ts":1e12}"#)
         XCTAssertTrue(store.sessionStates.isEmpty)
+    }
+
+    // MARK: - Running-set routing (BET-922)
+
+    /// A `runningSet` frame reconciles running state across sessions and bumps
+    /// `runningSetSeq`.
+    func testRunningSetFrameReconcilesAndBumpsSeq() throws {
+        let fake = FakeStreamControl()
+        fake.drive(.connected)
+        let store = makeStore(fake)
+
+        // Session latched running by a live `running` frame...
+        fake.inject(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true,"since":1700000000000}}"#)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.running, true)
+
+        XCTAssertEqual(store.runningSetSeq, 0)
+        // ...then the box's authoritative set omits it -> cleared.
+        fake.inject(#"{"kind":"runningSet","payload":{"sessions":[]}}"#)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.running, false)
+        XCTAssertNil(store.sessionStates["ses_1"]?.runningSince)
+        XCTAssertEqual(store.runningSetSeq, 1)
+    }
+
+    /// The running set is delivered even while degraded: a client that dropped
+    /// frames while unreachable is exactly the one whose running state needs
+    /// correcting the moment the box speaks again.
+    func testRunningSetAppliesEvenWhileDegraded() throws {
+        let fake = FakeStreamControl()
+        fake.hasConnectedOnce = true
+        fake.drive(.connected)
+        let store = makeStore(fake)
+
+        fake.inject(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true,"since":1700000000000}}"#)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.running, true)
+
+        fake.drive(.reconnecting(attempt: 1, backoffMs: 1000))
+        XCTAssertTrue(store.degraded)
+
+        // A normal stream frame is dropped while degraded...
+        fake.inject(#"{"kind":"stream","sub":"flush","sessionId":"ses_1","payload":{"messageID":"m","partID":"p","field":"text","text":"ignored"}}"#)
+        XCTAssertNil(store.sessionStates["ses_1"]?.textByPart["p"])
+        XCTAssertEqual(store.sessionStates["ses_1"]?.running, true)
+
+        // ...but the runningSet still lands and corrects the latched flag.
+        fake.inject(#"{"kind":"runningSet","payload":{"sessions":[]}}"#)
+        XCTAssertEqual(store.sessionStates["ses_1"]?.running, false)
+        XCTAssertEqual(store.runningSetSeq, 1)
     }
 
     // MARK: - Turn-complete chunk eviction for unobserved sessions (BET-672)

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -186,12 +186,15 @@ const streamInterp = createStreamInterpreter({
   publish: (evt) => bus.publish(evt),
   contextLimitFor,
 });
-// BET-913 + BET-916: when a client (re)connects mid-state, replay the current
-// edge-only state so frames that only fire on an edge aren't lost — `running`
-// (lets the iOS turn timer survive a force-quit + relaunch) plus pending
-// `questions` / `permissions` (lets a pending interactive card reappear and
-// stay answerable on a thin client). `snapshotState()` returns these events;
-// the bus replays them to each new subscriber.
+// BET-913 + BET-916 + BET-922: when a client (re)connects mid-state, replay the
+// current edge-only state so frames that only fire on an edge aren't lost —
+// the COMPLETE running picture as one authoritative `runningSet` frame (the
+// reconcile-on-reconnect fix; a session absent from the set is not running,
+// which is what clears a client latched on a turn that ended while it was
+// disconnected) plus pending `questions` / `permissions` (lets a pending
+// interactive card reappear and stay answerable on a thin client).
+// `snapshotState()` returns these events; the bus replays them to each new
+// subscriber.
 bus.setSnapshot(() => streamInterp.snapshotState());
 // Shared deps passed to store-mutating helpers so they can publish the
 // `*.updated` bus event the renderer cards listen for (JobCard, WebhooksCard,

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -564,35 +564,36 @@ export function createStreamInterpreter({
     interpret,
     getState: (sid) => sessions.get(sid),
     // Replay current edge-only state for the bus's connect-time snapshot
-    // (BET-913 + BET-916). These frames are emitted only on an EDGE — their
-    // current value is never re-sent on its own — so a client that
-    // (re)connects mid-state never sees them: the `running` frame fires only
-    // on the idle->busy edge (the turn timer survives a force-quit +
-    // relaunch only if this is reconstructed with the ORIGINAL `since`), and
-    // `questions` / `permissions` frames fire only as `question.*` /
-    // `permission.*` events arrive. A fresh /events subscription therefore
-    // recovers the still-pending interactive cards too. Each is replayed with
-    // exactly the same envelope the live path emits, so a reconnecting client
-    // needs no change. Empty when there is nothing to replay.
+    // (BET-913 + BET-916 + BET-922). These frames are emitted only on an EDGE —
+    // their current value is never re-sent on its own — so a client that
+    // (re)connects mid-state never sees them: `questions` / `permissions`
+    // frames fire only as `question.*` / `permission.*` events arrive, and the
+    // running set below is reconstructed live. A fresh /events subscription
+    // therefore recovers the still-pending interactive cards too. Each is
+    // replayed with exactly the same envelope the live path emits, so a
+    // reconnecting client needs no change.
+    //
+    // The COMPLETE set of currently-running sessions is replayed to every new
+    // /events subscriber as ONE authoritative `runningSet` frame (BET-922).
+    // BET-913 replayed one `stream/running` frame per busy session, which could
+    // only ever ADD running state — a client that missed a turn ending stayed
+    // latched forever. The set is always exactly one frame, index 0, even when
+    // the list is empty: "nothing is running" is the correction a stale client
+    // needs, and a client that receives nothing learns nothing. A session
+    // absent from the set is NOT running.
     //
     // Replayed independently of one another and of `st.running`: a pending
     // question/permission blocks the turn but never sets `running`, so gating
     // on `running` would skip exactly the sessions that need the replay.
     snapshotState() {
-      const out = [];
+      const running = [];
       for (const [sid, st] of sessions) {
         if (st.running && st.runningSince != null) {
-          out.push({
-            kind: "stream",
-            sub: "running",
-            sessionId: sid,
-            payload: {
-              running: true,
-              type: st.runningType ?? null,
-              since: st.runningSince,
-            },
-          });
+          running.push({ sessionId: sid, since: st.runningSince, type: st.runningType ?? null });
         }
+      }
+      const out = [{ kind: "runningSet", payload: { sessions: running } }];
+      for (const [sid, st] of sessions) {
         if (st.questions.length > 0) {
           out.push({
             kind: "stream",

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -359,10 +359,19 @@ test("session.status busy emits a running frame with a non-null since", () => {
   assert.equal(ev.payload.since, 42_000, "stamped from the injectable now()");
 });
 
-test("snapshotState replays a running frame for a currently-busy session only (BET-913)", () => {
+test("snapshotState always emits exactly one runningSet frame, even with nothing running (BET-922)", () => {
   const { interp } = make(42_000);
-  // Nothing busy yet -> no replay events.
-  assert.deepEqual(interp.snapshotState(), []);
+  // Nothing busy yet -> the set must STILL be exactly one frame, because an
+  // empty list is the correction a stale client needs (the old shape returned
+  // nothing and could never clear a latched `running:true`).
+  const empty = interp.snapshotState();
+  assert.equal(empty.length, 1);
+  assert.equal(empty[0].kind, "runningSet");
+  assert.deepEqual(empty[0].payload.sessions, [], "nothing running = an empty, authoritative set");
+});
+
+test("snapshotState lists a busy session in the runningSet with its original since (BET-922)", () => {
+  const { interp } = make(42_000);
   // Start a turn; the replay carries the frame the busy->idle edge never
   // re-emits, with the ORIGINAL since so the timer survives a fresh process.
   interp.interpret({
@@ -370,16 +379,18 @@ test("snapshotState replays a running frame for a currently-busy session only (B
     properties: { sessionID: SID, status: { type: "busy" } },
   });
   const snap = interp.snapshotState();
-  assert.equal(snap.length, 1);
-  assert.equal(snap[0].kind, "stream");
-  assert.equal(snap[0].sub, "running");
-  assert.equal(snap[0].sessionId, SID);
-  assert.equal(snap[0].payload.running, true);
-  assert.equal(snap[0].payload.since, 42_000, "original idle->busy stamp, not reconnect time");
-  assert.equal(snap[0].payload.type, "busy", "last status type preserved additively");
-  // An idle session leaves nothing to replay.
+  assert.equal(snap.length, 1, "only the runningSet when nothing else is pending");
+  assert.equal(snap[0].kind, "runningSet");
+  assert.equal(snap[0].payload.sessions.length, 1);
+  assert.equal(snap[0].payload.sessions[0].sessionId, SID);
+  assert.equal(snap[0].payload.sessions[0].since, 42_000, "original idle->busy stamp, not reconnect time");
+  assert.equal(snap[0].payload.sessions[0].type, "busy", "last status type preserved additively");
+  // An idle session drops out of the set entirely — absent == not running.
   interp.interpret({ type: "session.idle", properties: { sessionID: SID } });
-  assert.deepEqual(interp.snapshotState(), []);
+  const afterIdle = interp.snapshotState();
+  assert.equal(afterIdle.length, 1);
+  assert.equal(afterIdle[0].kind, "runningSet");
+  assert.deepEqual(afterIdle[0].payload.sessions, [], "a session that went idle drops out of the set");
 });
 
 test("snapshotState ignores sessions that were never marked running", () => {
@@ -388,7 +399,10 @@ test("snapshotState ignores sessions that were never marked running", () => {
     type: "message.part.delta",
     properties: { sessionID: SID, messageID: "m", part: { id: "p", type: "text", text: "hi" } },
   });
-  assert.deepEqual(interp.snapshotState(), []);
+  const snap = interp.snapshotState();
+  assert.equal(snap.length, 1);
+  assert.equal(snap[0].kind, "runningSet");
+  assert.deepEqual(snap[0].payload.sessions, []);
 });
 
 // BET-916 — sibling of BET-913: pending questions/permissions are edge-only too
@@ -453,7 +467,11 @@ test("snapshotState does not replay resolved/empty questions or permissions", ()
     properties: { sessionID: SID, id: "que_1" },
   });
   assert.equal(interp.getState(SID).questions.length, 0);
-  assert.deepEqual(interp.snapshotState(), [], "nothing pending, nothing replayed");
+  const snap = interp.snapshotState();
+  assert.equal(snap.length, 1, "only the always-present runningSet remains");
+  assert.equal(snap[0].kind, "runningSet");
+  assert.equal(snap.filter((e) => e.sub === "questions").length, 0, "no questions frame pending");
+  assert.equal(snap.filter((e) => e.sub === "permissions").length, 0, "no permissions frame pending");
 });
 
 test("snapshotState replays running + questions + permissions together, each with its own frame", () => {
@@ -475,8 +493,12 @@ test("snapshotState replays running + questions + permissions together, each wit
     type: "permission.asked",
     properties: { sessionID: SID, id: "perm_1", prompt: "p" },
   });
-  const subs = interp.snapshotState().map((e) => e.sub).sort();
-  assert.deepEqual(subs, ["permissions", "questions", "running"]);
+  const snap = interp.snapshotState();
+  assert.equal(snap[0].kind, "runningSet", "running is one authoritative frame, not one per session");
+  assert.equal(snap[0].payload.sessions.length, 1);
+  assert.equal(snap[0].payload.sessions[0].sessionId, SID);
+  const subs = snap.slice(1).map((e) => e.sub).sort();
+  assert.deepEqual(subs, ["permissions", "questions"]);
 });
 
 test("a second busy while already running emits the SAME since (clock not restarted)", () => {


### PR DESCRIPTION
Opened automatically for `multica/BET-922-running-reconcile`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-922.