### PR TITLE
Forge: ForgeMark brand-mark component (BET-924)

### DIFF
--- a/src/renderer/ForgeMark.test.tsx
+++ b/src/renderer/ForgeMark.test.tsx
@@ -1,0 +1,67 @@
+// @vitest-environment jsdom
+//
+// Component tests for the ForgeMark brand-mark component (BET-924).
+//
+// ForgeMark renders an inline SVG brand mark for a forge kind. It is
+// decorative BY CONTRACT: monochrome currentColor + aria-hidden, and it must
+// render NOTHING for an unknown/absent kind (never a wrong logo, never a
+// fallback glyph).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { ForgeMark, hasForgeMark } from "./ForgeMark";
+
+function svgEl(h: Harness): SVGSVGElement | null {
+  return h.container.querySelector("svg");
+}
+
+describe("ForgeMark", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it('kind="github" renders one <svg> carrying a <path>, aria-hidden="true"', () => {
+    h = mount(<ForgeMark kind="github" />);
+    const svg = svgEl(h);
+    expect(svg).toBeTruthy();
+    expect(svg?.getAttribute("aria-hidden")).toBe("true");
+    expect(h.container.querySelectorAll("svg").length).toBe(1);
+    expect(svg?.querySelector("path")).toBeTruthy();
+  });
+
+  it('kind="gitlab" renders a <path> with a different `d` than github\'s', () => {
+    h = mount(<ForgeMark kind="github" />);
+    const githubD = h.container.querySelector("path")?.getAttribute("d");
+    h.rerender(<ForgeMark kind="gitlab" />);
+    const gitlabD = h.container.querySelector("path")?.getAttribute("d");
+    expect(githubD).toBeTruthy();
+    expect(gitlabD).toBeTruthy();
+    expect(gitlabD).not.toBe(githubD);
+  });
+
+  it("kind={null} and kind=\"bitbucket\" each render nothing", () => {
+    h = mount(<ForgeMark kind={null} />);
+    expect(h.container.innerHTML).toBe("");
+    h.rerender(<ForgeMark kind="bitbucket" />);
+    expect(h.container.innerHTML).toBe("");
+  });
+
+  it("hasForgeMark: true for github/gitlab, false for null/undefined/empty/bitbucket", () => {
+    expect(hasForgeMark("github")).toBe(true);
+    expect(hasForgeMark("gitlab")).toBe(true);
+    expect(hasForgeMark(null)).toBe(false);
+    expect(hasForgeMark(undefined)).toBe(false);
+    expect(hasForgeMark("")).toBe(false);
+    expect(hasForgeMark("bitbucket")).toBe(false);
+  });
+
+  it("has no className escape hatch — the prop is not accepted (compile-time)", () => {
+    // If ForgeMark ever grew a className prop this directive becomes unused and
+    // typecheck fails — the standing-decision-3 guard lives in the types.
+    // @ts-expect-error — no className escape hatch (M527 standing decision 3)
+    <ForgeMark kind="github" className="text-danger" />;
+    expect(true).toBe(true);
+  });
+});

--- a/src/renderer/ForgeMark.tsx
+++ b/src/renderer/ForgeMark.tsx
@@ -1,0 +1,57 @@
+// ForgeMark — the forge brand mark (GitHub today; GitLab when an adapter exists).
+//
+// lucide-react ships NO brand glyphs — they were removed upstream — so the two
+// paths live here rather than as a new dependency: `simple-icons` /
+// `react-icons` would add a multi-megabyte icon set for two marks.
+//
+// Decorative BY CONTRACT: monochrome `currentColor`, `aria-hidden`, and never
+// the only label — every call site pairs it with real text (or, for the
+// icon-only open-on-forge button, a `title`). That is what GitHub's brand
+// guidelines ask for when the mark indicates GitHub, and it is why there is no
+// `label`/`title` prop here.
+//
+// An unknown or absent kind renders NOTHING (not a wrong logo, not a fallback
+// glyph): a session on a forge we have no adapter for must not claim GitHub.
+// Call sites that draw a separator beside the mark gate it on `hasForgeMark`.
+//
+// No `className` escape hatch (M527 standing decision 3).
+
+const FORGE_PATHS: Record<string, string> = {
+  github:
+    "M12 .297c-6.63 0-12 5.373-12 12 0 5.303 3.438 9.8 8.205 11.385.6.113.82-.258.82-.577 0-.285-.01-1.04-.015-2.04-3.338.724-4.042-1.61-4.042-1.61C4.422 18.07 3.633 17.7 3.633 17.7c-1.087-.744.084-.729.084-.729 1.205.084 1.838 1.236 1.838 1.236 1.07 1.835 2.809 1.305 3.495.998.108-.776.417-1.305.76-1.605-2.665-.3-5.466-1.332-5.466-5.93 0-1.31.465-2.38 1.235-3.22-.135-.303-.54-1.523.105-3.176 0 0 1.005-.322 3.3 1.23.96-.267 1.98-.399 3-.405 1.02.006 2.04.138 3 .405 2.28-1.552 3.285-1.23 3.285-1.23.645 1.653.24 2.873.12 3.176.765.84 1.23 1.91 1.23 3.22 0 4.61-2.805 5.625-5.475 5.92.42.36.81 1.096.81 2.22 0 1.606-.015 2.896-.015 3.286 0 .315.21.69.825.57C20.565 22.092 24 17.592 24 12.297c0-6.627-5.373-12-12-12",
+  gitlab:
+    "m23.6 9.593-.034-.086L20.3.98a.85.85 0 0 0-.336-.405.875.875 0 0 0-1 .054.875.875 0 0 0-.29.44l-2.205 6.748H7.537L5.332 1.07a.857.857 0 0 0-.29-.442.875.875 0 0 0-1-.053.858.858 0 0 0-.336.405L.433 9.502l-.033.086a6.066 6.066 0 0 0 2.012 7.01l.011.01.03.021 4.976 3.726 2.462 1.864 1.5 1.132a1.008 1.008 0 0 0 1.22 0l1.499-1.132 2.462-1.864 5.006-3.749.012-.01a6.068 6.068 0 0 0 2.01-7.003Z",
+};
+
+/** Whether `kind` has a mark to draw. Call sites use this to decide whether to
+ * render the hairline separator that sits beside the mark — without it they
+ * would draw a separator next to nothing. */
+export function hasForgeMark(kind: string | null | undefined): boolean {
+  return !!kind && kind in FORGE_PATHS;
+}
+
+export function ForgeMark({
+  kind,
+  size = 14,
+}: {
+  /** The forge the session's origin resolves to — `forgeKind` from the forge
+   * read path. `"github"` is the only adapter today. */
+  kind: string | null | undefined;
+  /** Pixel size, like a lucide icon's `size`. 11 in chips, 14 in buttons. */
+  size?: number;
+}) {
+  const d = kind ? FORGE_PATHS[kind] : undefined;
+  if (!d) return null;
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      aria-hidden="true"
+      className="shrink-0"
+    >
+      <path d={d} />
+    </svg>
+  );
+}


### PR DESCRIPTION
## BET-924 — ForgeMark brand-mark component

`lucide-react` ships no GitHub/GitLab glyph (removed upstream), so the two
Simple Icons path strings live in a tiny local component rather than pulling in
a multi-megabyte icon set. This PR is **only** the component + its test — it
changes no existing surface and registers no chrome primitive.

**Files changed:** `2` files (both new, nothing modified).
- `src/renderer/ForgeMark.tsx` — `ForgeMark` + `hasForgeMark`
- `src/renderer/ForgeMark.test.tsx`

Nailed to the contract: monochrome `currentColor`, `aria-hidden="true"`, no
`label`/`title` prop (decorative by contract), unknown/absent kind renders
nothing, `hasForgeMark` gates separators, size defaults to 14, and no
`className` escape hatch (guarded by a compile-time `@ts-expect-error`).

Not registered in `primitives.test.ts` nor `docs/components.md` (per the issue
— it's an icon, not an M527 chrome primitive).

**Verification results:**
- PR branch (`multica/BET-924-forge-mark` @ `79941150`):
  - typecheck: exit 0. Errors: none
  - test: exit 0, 2050 pass / 0 fail / 0 skip. Failures: none (ForgeMark suite: 5/5 pass)
- Base (`origin/main` @ `8f3aea64`):
  - No existing file modified; full suite green on the PR branch implies base parity (only additive new files)
- **Conclusion:** 0 new failures. This PR adds files only; it cannot regress existing behavior.

**Base: origin/main @ `8f3aea64`**
