### PR TITLE
Forge: create PR in one surface - delete the second confirmation card (BET-925)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -80,7 +80,7 @@ import { MantaLoader } from "./MantaLoader";
 import { MeasureColumn } from "./MeasureColumn";
 import { BlockedProgressCard, CompactionCard, PermissionCard, RetryCard } from "./Cards";
 import { Button } from "./Button";
-import { DelegateApprovalCard, ReadOnlyJobBar, ScheduledTasksCard, SecretsCard, ShipConfirmCard, WebhooksCard } from "./PanelCards";
+import { DelegateApprovalCard, ReadOnlyJobBar, ScheduledTasksCard, SecretsCard, WebhooksCard } from "./PanelCards";
 import { CardStack, type PinnedCardRender } from "./components/CardStack";
 import { useSessionResources } from "./hooks/useSessionResources";
 import { useInputHistory } from "./hooks/useInputHistory";
@@ -238,15 +238,27 @@ export function ChatPanel({
 
   // BET-794/867: forge ship + merge for this session. The server resolves cwd →
   // repo → token box-side (a forge token never reaches the renderer). The
-  // branch chip's popover is the merge surface (BET-867); the ShipConfirmCard
-  // is the mandatory human gate before a Draft PR is pushed/opened, and Create
-  // PR ships inline (BET-867 owner-approved departure) — never auto-submitted.
-  const [shipOpen, setShipOpen] = useState(false);
+  // branch chip's popover is the ONE git surface (BET-867): it is the human
+  // gate (BET-794 [SH1]) before a PR is pushed/opened — the ship preview is
+  // loaded, the title shown, and the explicit non-default Create button names
+  // the head, base, file count and title. Create PR ships inline from the
+  // popover — never auto-submitted.
   const [shipProposal, setShipProposal] = useState<{ head: string; base: string; fileCount: number; title: string; body: string } | null>(null);
   const [shipBusy, setShipBusy] = useState(false);
   const [shipError, setShipError] = useState<string | null>(null);
   const [mergeBusy, setMergeBusy] = useState(false);
   const [mergeError, setMergeError] = useState<string | null>(null);
+
+  // BET-925: a few seconds of "Opened #N" in the branch popover after a ship,
+  // so the state swap is affirmed rather than silent. Mirrors the compaction
+  // card's 2.5s hold; the timer is cleared on unmount so a late fire can never
+  // write into a different session.
+  const [shipJustCreated, setShipJustCreated] = useState(false);
+  useEffect(() => {
+    if (!shipJustCreated) return;
+    const t = setTimeout(() => setShipJustCreated(false), 4000);
+    return () => clearTimeout(t);
+  }, [shipJustCreated]);
 
   // BET-418 §D: detect whether THIS session is a background job's child. A
   // job session is read-only (no composer, no cards, no model picker/fork/
@@ -613,7 +625,10 @@ export function ChatPanel({
         ...(modelOverride ? { model: { providerID: modelOverride.providerID, modelID: modelOverride.modelID }, sessionId } : {}),
       });
       if (prev.ok) {
-        setShipProposal({ head: prev.head, base: prev.base, fileCount: prev.fileCount, title: prev.title ?? "", body: prev.body ?? "" });
+        // BET-925: fall back to the head branch name when the box is still
+        // drafting (or returned an empty) title, so the Create button can never
+        // enable on an empty title.
+        setShipProposal({ head: prev.head, base: prev.base, fileCount: prev.fileCount, title: prev.title || prev.head, body: prev.body ?? "" });
       } else {
         setShipProposal(null);
         setShipError(prev.error);
@@ -624,11 +639,12 @@ export function ChatPanel({
     }
   }, [cwd, shipProposal, modelOverride, sessionId]);
 
-  // Confirm → push + create. Only reached after the human confirms the
-  // ShipConfirmCard. The title/body come from shipProposal (the box's preview,
-  // already resolved — no arg this time, the form is gone). On success it opens
-  // the PR in the browser and refreshes the PR (the branch popover swaps in
-  // place to the PR state).
+  // Confirm → push + create, inline from the branch popover (BET-925). Only
+  // reached after the human confirms the popover's Create button. The
+  // title/body come from shipProposal (the box's preview, already resolved).
+  // On success it writes the PR straight into local forge state so the popover
+  // swaps to the PR state in the same tick (no flicker through the ready
+  // state), opens the PR in the browser, then refreshes checks/mergeability.
   const confirmShip = useCallback(async () => {
     if (!cwd) return;
     const { title, body } = shipProposal ?? { title: "", body: "" };
@@ -637,8 +653,12 @@ export function ChatPanel({
     try {
       const res = await window.api.forgeShip({ cwd, title, body });
       if (res.ok) {
-        setShipOpen(false);
+        // Swap the popover to the PR state in the same tick the write returns —
+        // waiting for the next forge poll would flash the ready state back.
+        // refreshForge then reconciles checks / mergeability.
+        setForge((f) => ({ ...f, pr: res.pr }));
         setShipProposal(null);
+        setShipJustCreated(true);
         if (res.url) void window.api.openExternal(res.url);
         void refreshForge(cwd);
       } else {
@@ -650,16 +670,6 @@ export function ChatPanel({
       setShipBusy(false);
     }
   }, [cwd, shipProposal, refreshForge]);
-
-  // Open the ship confirm card — the single human gate for creating a PR.
-  // Loads the preview (head/base/fileCount) so the card shows real facts; if
-  // the preview is already loaded it must not re-fetch. Nothing is pushed or
-  // opened until the user confirms (confirmShip).
-  const openShip = useCallback(() => {
-    setShipError(null);
-    setShipOpen(true);
-    void ensureShipPreview();
-  }, [ensureShipPreview]);
 
   // Merge the shown PR, ALWAYS with the head SHA the user approved.
   const doMerge = useCallback(async () => {
@@ -2300,26 +2310,8 @@ export function ChatPanel({
             setPendingApproval(null);
             void window.api.delegateDecline(id).catch(() => { /* best-effort */ });
           }}
-        />,
-      ));
-      // BET-794 [SH1]: the ship confirm — a human gate, ALWAYS. Shown in the
-      // blocking tier while a ship is in progress; nothing is pushed or opened
-      // until the user confirms here.
-      if (shipOpen) list.push(block(
-        "ship-confirm", blockOrder("ship-confirm"),
-        <ShipConfirmCard
-          proposal={shipProposal ?? { head: "", base: "", fileCount: 0, title: "", body: "" }}
-          busy={shipBusy}
-          error={shipError}
-          onApprove={confirmShip}
-          onDecline={() => {
-            setShipOpen(false);
-            setShipProposal(null);
-            setShipError(null);
-          }}
-        />,
-      ));
-
+          />,
+        ));
       // BET-791 [C9]: a model reporting it has STOPPED and needs a human
       // decision earns the one card `blocked` gets — a warn-toned ask in the
       // blocking tier, alongside permission and question, never below an
@@ -2418,7 +2410,7 @@ export function ChatPanel({
         </div>));
     }
     return list;
-  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipOpen, shipProposal, shipBusy, shipError, confirmShip, liveProgress]);
+  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipProposal, shipBusy, shipError, liveProgress]);
 
 
   if (error || transcriptLoadError) {
@@ -2525,9 +2517,11 @@ export function ChatPanel({
         shipError={shipError}
         shipBase={shipProposal?.base ?? null}
         shipFileCount={shipProposal?.fileCount ?? null}
+        shipTitle={shipProposal ? shipProposal.title : null}
+        justShipped={shipJustCreated}
         base={forge.base}
         aheadCount={forge.aheadCount}
-        onCreatePr={() => void openShip()}
+        onCreatePr={() => void confirmShip()}
         onEnsureShipPreview={() => void ensureShipPreview()}
       />
 

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -11,7 +11,7 @@
 // mobile with no mobile-CSS edits.
 
 import { memo, useEffect, useState } from "react";
-import { Clock, Bell, Webhook, Key, Bot, ArrowLeft, Square, X, GitPullRequest } from "lucide-react";
+import { Clock, Bell, Webhook, Key, Bot, ArrowLeft, Square, X } from "lucide-react";
 import type {
   DelegateApproval,
   DelegateApprovalTool,
@@ -21,7 +21,6 @@ import type {
   SecretScope,
   WebhookMeta,
 } from "../shared/types";
-import { Button } from "./Button";
 import { describeCron, describeNextRun, formatJobSummary } from "./chatUtils";
 import { MetaBadge } from "./chatShared";
 
@@ -605,57 +604,6 @@ export const ReadOnlyJobBar = memo(function ReadOnlyJobBar({
             <Square size={12} aria-hidden="true" /> Stop
           </button>
         )}
-      </div>
-    </div>
-  );
-});
-
-// ===== Forge ship + merge (BET-794) =====
-
-// ShipConfirmCard — the [SH1] human gate. Always shown before anything is
-// pushed or opened; never auto-submitted. Reads top-down: a context line, the
-// resolved title as plain text, then the actions (primary "Create pull
-// request", ghost Cancel). The title/body are edited on GitHub seconds later;
-// this card's only job is the confirm.
-export const ShipConfirmCard = memo(function ShipConfirmCard({
-  proposal,
-  busy,
-  error,
-  onApprove,
-  onDecline,
-}: {
-  proposal: { head: string; base: string; fileCount: number; title?: string; body?: string };
-  busy: boolean;
-  error: string | null;
-  onApprove: () => void;
-  onDecline: () => void;
-}) {
-  return (
-    <div
-      className="rounded-sm border bg-bg-elev px-3 py-2 text-meta"
-      style={{ borderColor: "rgb(var(--accent-rgb) / 0.33)" }}
-    >
-      <div className="mb-2 flex items-center gap-2">
-        <span style={{ color: "var(--accent)" }} className="inline-flex items-center shrink-0">
-          <GitPullRequest size={15} aria-hidden="true" />
-        </span>
-        <span className="text-text-faint text-meta">
-          Open a pull request · {proposal.head}{" "}
-          <span style={{ color: "var(--accent)" }}>→</span> {proposal.base} ·{" "}
-          {proposal.fileCount} file{proposal.fileCount === 1 ? "" : "s"}
-        </span>
-      </div>
-      <div className="truncate text-meta font-medium text-text" title={proposal.title}>
-        {proposal.title || "Untitled pull request"}
-      </div>
-      {error && <div className="text-danger break-words mt-1">{error}</div>}
-      <div className="flex items-center gap-2 mt-2">
-        <Button tone="primary" disabled={busy} onClick={onApprove}>
-          {busy ? "Creating…" : "Create pull request"}
-        </Button>
-        <Button tone="ghost" onClick={onDecline} disabled={busy}>
-          Cancel
-        </Button>
       </div>
     </div>
   );

--- a/src/renderer/SessionHeader.branch.test.tsx
+++ b/src/renderer/SessionHeader.branch.test.tsx
@@ -76,6 +76,7 @@ describe("SessionHeader branch popover (BET-867)", () => {
       pr: null,
       base: "main",
       aheadCount: 3,
+      shipTitle: "some title",
       onCreatePr: vi.fn(),
       onEnsureShipPreview: () => {},
     });
@@ -213,6 +214,7 @@ describe("SessionHeader branch popover (BET-867)", () => {
       aheadCount: 3,
       shipBase: "main",
       shipFileCount: 18,
+      shipTitle: "some title",
       onCreatePr,
       onEnsureShipPreview: () => {},
     });
@@ -220,13 +222,15 @@ describe("SessionHeader branch popover (BET-867)", () => {
     await h.flush();
 
     const createBtn = buttonWithText("Create pull request");
+    expect(createBtn.disabled).toBe(false);
     act(() => createBtn.click());
     expect(onCreatePr).toHaveBeenCalledTimes(1);
 
-    // Preview rows come from the ship preview (Base / Changes).
+    // The ship preview drives the head→base→files line + the drafted title,
+    // both moved up from the deleted confirm card.
     const text = bodyText();
-    expect(text).toContain("Base");
-    expect(text).toContain("18 files");
+    expect(text).toContain("→ main · 18 files");
+    expect(text).toContain("some title");
   });
 
   it("while a ship is in flight the Create pull request button disables and labels Creating…", async () => {
@@ -236,6 +240,7 @@ describe("SessionHeader branch popover (BET-867)", () => {
       pr: null,
       base: "main",
       aheadCount: 3,
+      shipTitle: "some title",
       shipBusy: true,
       shipError: null,
       onCreatePr: vi.fn(),
@@ -245,7 +250,83 @@ describe("SessionHeader branch popover (BET-867)", () => {
     await h.flush();
 
     const text = bodyText();
-    expect(text).toContain("Opening pull request…");
+    // Busy → no "Drafting title…" hint; the button owns the loading state.
+    expect(text).not.toContain("Drafting title…");
     expect(buttonWithText("Creating…").disabled).toBe(true);
+  });
+
+  it("shipTitle null → the Create button is disabled and the body shows Drafting title…", async () => {
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: null,
+      base: "main",
+      aheadCount: 3,
+      shipTitle: null,
+      onCreatePr: vi.fn(),
+      onEnsureShipPreview: () => {},
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    const text = bodyText();
+    expect(text).toContain("Drafting title…");
+    expect(buttonWithText("Create pull request").disabled).toBe(true);
+  });
+
+  it("the drafted title is rendered in the ready state", async () => {
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: null,
+      base: "main",
+      aheadCount: 3,
+      shipTitle: "Show every check in the checks popover",
+      onCreatePr: vi.fn(),
+      onEnsureShipPreview: () => {},
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    expect(bodyText()).toContain("Show every check in the checks popover");
+  });
+
+  it("justShipped with a PR present → the body shows 'Opened #412'", async () => {
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: PR,
+      checksRollup: "green",
+      justShipped: true,
+      onMerge: vi.fn(),
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    expect(bodyText()).toContain("Opened #412");
+  });
+
+  it("with pr null and shipBusy true, clicking outside does not close the popover", async () => {
+    h = mountSessionHeader({
+      branch: "feat/forge-seam",
+      forgeConnected: true,
+      pr: null,
+      base: "main",
+      aheadCount: 3,
+      shipTitle: "some title",
+      shipBusy: true,
+      onCreatePr: vi.fn(),
+      onEnsureShipPreview: () => {},
+    });
+    openBranchChip(h);
+    await h.flush();
+
+    // The drafted title only exists inside the popover panel.
+    expect(bodyText()).toContain("some title");
+    // A click-away is held open while the PR write is settling (BET-925).
+    act(() =>
+      document.body.dispatchEvent(new MouseEvent("mousedown", { bubbles: true })),
+    );
+    expect(bodyText()).toContain("some title");
   });
 });

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -17,7 +17,7 @@ import {
   useState,
   type CSSProperties,
 } from "react";
-import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal, Bot, MessageSquare, Clock, PanelRight, ExternalLink } from "lucide-react";
+import { GitBranch, MoreHorizontal, GitFork, Minimize2, Eraser, Trash2, Terminal, Bot, MessageSquare, Clock, PanelRight, Loader2 } from "lucide-react";
 import {
   ctxStageColor,
   cssVar,
@@ -45,6 +45,7 @@ import { Tag } from "./Tag";
 import { Chip } from "./Chip";
 import { StatusDot } from "./StatusDot";
 import { Callout } from "./Callout";
+import { ForgeMark } from "./ForgeMark";
 import { Dropdown, MenuItem } from "./MenuItem";
 import { Popover } from "./Popover";
 import { ConfirmModal } from "./ConfirmModal";
@@ -105,6 +106,8 @@ export function SessionHeader({
   shipError,
   shipBase,
   shipFileCount,
+  shipTitle,
+  justShipped,
   base,
   aheadCount,
   onCreatePr,
@@ -178,10 +181,18 @@ export function SessionHeader({
   mergeError?: string | null;
   shipBusy?: boolean;
   shipError?: string | null;
-  // The ship preview's base branch + file count (fetched once when the no-PR
-  // popover opens). null while the preview is still loading → rows render "—".
+  // The ship preview's default base branch + file count (fetched once when the
+  // no-PR popover opens). null while the preview is still loading → rows render
+  // "—".
   shipBase?: string | null;
   shipFileCount?: number | null;
+  // The ship preview's resolved PR title. NULL means the preview has not landed
+  // yet (the box drafts it with the session's model, out of band) — the popover
+  // shows a skeleton and holds the Create button disabled until it arrives.
+  shipTitle?: string | null;
+  // True for a few seconds after a PR is created from this popover, so the PR
+  // state can affirm what just happened instead of silently swapping.
+  justShipped?: boolean;
   // The ship gate (BET-892): the session's current branch, the repo default
   // base branch, and commits ahead — supplied by the forge:pull-request poll
   // (no second poll) so the popover can decide whether a Create-PR action is
@@ -395,6 +406,9 @@ export function SessionHeader({
           shipError={shipError ?? null}
           shipBase={shipBase ?? null}
           shipFileCount={shipFileCount ?? null}
+          shipTitle={shipTitle ?? null}
+          justShipped={justShipped ?? false}
+          forgeKind={forgeKind ?? null}
           base={base ?? null}
           aheadCount={aheadCount ?? null}
           onCreatePr={onCreatePr}
@@ -1022,6 +1036,9 @@ type BranchPanelProps = {
   shipError: string | null;
   shipBase: string | null;
   shipFileCount: number | null;
+  shipTitle: string | null;
+  justShipped: boolean;
+  forgeKind: string | null;
   base: string | null;
   aheadCount: number | null;
   onCreatePr?: () => void;
@@ -1072,7 +1089,9 @@ function BranchChip({
       </button>
       <Popover
         open={open}
-        onClose={() => setOpen(false)}
+        // BET-925: a click-away while a PR is being created would tear down the
+        // only surface reporting it. Held open until the write settles.
+        onClose={() => { if (!panelProps.shipBusy) setOpen(false); }}
         anchorRef={triggerRef}
         role="dialog"
         ariaLabel={label}
@@ -1137,6 +1156,9 @@ function BranchPanel({
   shipError,
   shipBase,
   shipFileCount,
+  shipTitle,
+  justShipped,
+  forgeKind,
   base,
   aheadCount,
   onCreatePr,
@@ -1170,31 +1192,45 @@ function BranchPanel({
           <div className="mb-2 text-xs text-text-faint">
             Nothing to ship — no commits ahead of {base}
           </div>
-        ) : (
-          <div className="mb-2 text-xs text-text-faint">
-            {shipBusy ? "Opening pull request…" : "Ready to open a pull request"}
-          </div>
-        )}
-        {shipState !== "no-commits" && (
+        ) : shipState === "ready" ? (
           <>
-            <div className="flex flex-col">
-              <PanelRow label="Base" value={shipBase ?? base ?? "—"} />
-              <PanelRow
-                label="Changes"
-                value={
-                  shipFileCount != null
-                    ? `${shipFileCount} file${shipFileCount === 1 ? "" : "s"}`
-                    : "—"
-                }
-              />
+            <div className="mb-2 text-xs text-text-faint">
+              {branch} <span className="text-accent-tx">→</span> {shipBase ?? base ?? "—"}
+              {shipFileCount != null
+                ? ` · ${shipFileCount} file${shipFileCount === 1 ? "" : "s"}`
+                : ""}
+            </div>
+            <div className="rounded-sm bg-fill p-2">
+              <div className="mb-1 font-mono text-[10px] uppercase tracking-[.08em] text-text-quiet">
+                Title
+              </div>
+              {shipTitle != null ? (
+                <div className="text-meta text-text">{shipTitle}</div>
+              ) : (
+                <>
+                  <div className="mb-1 h-[9px] rounded-xs bg-fill-hover animate-pulse" />
+                  <div className="h-[9px] w-12 rounded-xs bg-fill-hover animate-pulse" />
+                </>
+              )}
             </div>
             <div className="mt-3 flex flex-nowrap items-center gap-2">
-              <Button tone="primary" disabled={shipBusy} onClick={onCreatePr}>
-                {shipBusy ? "Creating…" : "Create pull request"}
+              <Button tone="primary" disabled={shipBusy || shipTitle == null} onClick={onCreatePr}>
+                {shipBusy ? (
+                  <>
+                    <Loader2 size={14} className="animate-spin" aria-hidden="true" /> Creating…
+                  </>
+                ) : (
+                  <>
+                    <ForgeMark kind={forgeKind} /> Create pull request
+                  </>
+                )}
               </Button>
+              {!shipBusy && shipTitle == null && !shipError && (
+                <span className="text-[11px] text-text-quiet">Drafting title…</span>
+              )}
             </div>
           </>
-        )}
+        ) : null}
       </div>
     );
   }
@@ -1216,6 +1252,11 @@ function BranchPanel({
       : { text: "computing…", className: "text-text-faint" };
   return (
     <div className="p-3">
+      {justShipped && (
+        <div className="mb-2">
+          <Callout tone="ok">Opened #{pr.number}</Callout>
+        </div>
+      )}
       <div className="mb-[3px] truncate text-[13.5px] font-semibold leading-snug text-text">
         #{pr.number} {pr.title}
       </div>
@@ -1240,12 +1281,12 @@ function BranchPanel({
           onClick={onMerge}
           title={merge.can ? "Merge this pull request" : merge.reason ?? "not mergeable"}
         >
-          {mergeBusy ? "Merging…" : "Merge"}
+          {mergeBusy ? "Merging…" : (<><ForgeMark kind={forgeKind} /> Merge</>)}
         </Button>
         <Button tone="default" onClick={onReviewChanges}>Review changes</Button>
         {onOpenExternal && (
           <Button tone="ghost" title="Open on GitHub" onClick={() => onOpenExternal(pr.url)}>
-            <ExternalLink size={14} aria-hidden="true" />
+            <ForgeMark kind={forgeKind} />
           </Button>
         )}
       </div>


### PR DESCRIPTION
BET-925 — Forge: create PR in one surface, delete the second confirmation card.

The branch popover is now the only Create-PR surface. The drafted head→base→files
line and the resolved title move up from the deleted `ShipConfirmCard`; the popover
holds its Create button disabled (with a `Drafting title…` hint + skeleton) until the
title arrives, shows `Creating…` while the write settles, then swaps in place to the
PR / merge state with an `Opened #N` affirmation for a few seconds. No second card
ever appears above the composer.

- `ShipConfirmCard` deleted from `PanelCards.tsx`; `shipOpen` state + `openShip`
  deleted from `ChatPanel.tsx`; `onCreatePr` now calls `confirmShip` directly.
- `SessionHeader` gains `shipTitle` / `justShipped` props threaded through `BranchChip`
  → `BranchPanel` (added to the shared `BranchPanelProps`); the popover holds open
  across a click-away while `shipBusy`.
- `ForgeMark` on the Create / Merge / open-on-forge buttons (per decision 4); `Review
  changes` stays bare. `ExternalLink` import removed from `SessionHeader` (unused);
  `Button` + `GitPullRequest` imports removed from `PanelCards`.
- Tests: no-PR Create cases pass `shipTitle`; new cases for title-drafting (disabled +
  `Drafting title…`), drafted-title render, `justShipped` affirmation, and
  click-away-held-open-while-busy.

The standing `[SH1]` human-gate decision (BET-794) survives — a person still clicks an
explicit non-default button that names the head, base, file count and resolved title
before any byte is pushed. The stale "two surfaces" comments were rewritten/deleted
in the same change.

**Files changed:** 4.
```
src/renderer/SessionHeader.tsx             | 91 +++--
src/renderer/ChatPanel.tsx                 | 38 +-  (net -6)
src/renderer/PanelCards.tsx                | 54 --  (net -52)
src/renderer/SessionHeader.branch.test.tsx | 89 ++-
```
App source outside `SessionHeader.tsx` is net-negative (-58 lines).

**Verification results:**
- PR branch (`multica/BET-925-create-pr-one-surface` @ `b452bb52`):
  - typecheck: exit 0. Errors: none. log sha256: `1f130f276b70a4dc1fefdfa6d919ee077b66b0c2ca1dc5d349f0b211ed032930`
  - test: exit 0, 2663 pass / 0 fail / 7 skip (vitest, 142 files) + 2050 pass (server node:test). Failures: none. log sha256: `9db9a992233e4508ec5f8cc5a26d22583a3aa0693beac0c6b90bc300e6299a25`
- Base (`main` @ `44dae607`): BET-924's merged tip; the single required CI job (`typecheck-test`) is green on that base by definition of the merge. The diff from it is exactly the 4 files above.
- **Conclusion:** 0 new failures.

**Base: origin/main @ 44dae607**
