### PR TITLE
fix(renderer): refresh() falls back to configGet on unpaired boot (BET-932)

### DIFF
--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -1063,6 +1063,35 @@ describe("sync snapshot / applySyncPayload (BET-678)", () => {
     (window as unknown as { api?: unknown }).api = prev;
   });
 
+  // REGRESSION (fresh-install onboarding deadlock): on an unpaired desktop
+  // boot main.tsx never installs httpApi, so window.api is the preload
+  // OS-bridge — which has NO syncSnapshot. refresh() used to call it
+  // unguarded, throw, and leave `loaded` false forever; App gates onboarding
+  // on `loaded`, so the pairing wizard could never render and the app sat on
+  // an infinite spinner with an empty workspace list. refresh() must fall
+  // back to configGet (present on both transports) and still flip `loaded`.
+  it("refresh() falls back to configGet when the transport has no syncSnapshot", async () => {
+    const prev = (window as unknown as { api?: unknown }).api;
+    let configGetCalls = 0;
+    (window as unknown as { api: unknown }).api = {
+      // No syncSnapshot — exactly the unpaired preload bridge's shape.
+      configGet: async () => {
+        configGetCalls++;
+        return { projects: [] };
+      },
+    };
+    useStore.setState({ loaded: false, boxToken: "seed", serverUrl: "seed" });
+    await expect(useStore.getState().refresh()).resolves.toBeUndefined();
+    expect(configGetCalls).toBe(1);
+    const s = useStore.getState();
+    // `loaded` is what unblocks App's onboarding gate.
+    expect(s.loaded).toBe(true);
+    // An unpaired config must resolve to onboarding, not carry stale pairing.
+    expect(s.boxToken).toBe("");
+    expect(s.serverUrl).toBe("");
+    (window as unknown as { api?: unknown }).api = prev;
+  });
+
   // Drive the REAL write path (loadPersistedSnapshot → applySyncPayload →
   // debounced persist), so the fields the snapshot carries are exactly what
   // schedulePersist writes — not a value planted by hand. `boxId` seeds the

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -848,6 +848,24 @@ export const useStore = create<State>((set, get) => ({
   setSeedPrompt: (p) => set({ seedPrompt: p }),
 
   refresh: async () => {
+    // GUARD (fresh-install deadlock): on an UNPAIRED desktop boot main.tsx
+    // never installs httpApi (desktopHttpClientSeed is null without a
+    // serverUrl + valid boxToken), so `window.api` is still the Electron
+    // preload OS-bridge — which has no `syncSnapshot` (httpApi-only). Calling
+    // it unguarded throws, App's bootstrap classifies the TypeError as a
+    // transient failure and retries every 10s forever, `applyConfig` never
+    // runs, `loaded` stays false — and App's onboarding gate
+    // (`loaded && …resolveTransportMode(…) === "onboarding"`) can therefore
+    // NEVER fire. The user gets an infinite spinner with an empty workspace
+    // list instead of the pairing wizard. `configGet` exists on BOTH
+    // transports, and the local config is the only thing an unpaired app can
+    // (or should) load — there is no box to sync with yet. Onboarding.tsx's
+    // refreshAndInstallTransport documents the same hazard on the post-pair
+    // path; this is the pre-pair half.
+    if (!window.api.syncSnapshot) {
+      get().applyConfig(mergeLocalPairing(await window.api.configGet()));
+      return;
+    }
     // BET-678: single cursor RPC. Pass the last-confirmed cursor so the box
     // returns only the deltas we missed (or a full snapshot when the cursor
     // is absent / a new server generation). ApplySyncPayload routes each


### PR DESCRIPTION
## What this fixes

**User-visible symptom:** every fresh desktop install is dead on first launch — the pairing/onboarding wizard never shows; the app renders an empty workspace list behind an infinite spinner.

**One-line cause:** on startup the app asked for data through a sync method that only exists once the app is paired to a box, so on an unpaired boot the call threw, the bootstrap classified it as a transient failure and retried every 10s forever, and the `loaded` flag that gates the onboarding wizard never got set.

**The fix:** a single fallback at the shared chokepoint (`refresh()` in `src/renderer/store.ts`). When the HTTP transport isn't installed (no `serverUrl` + valid `boxToken`), `refresh()` falls back to `configGet`, which exists on both transports and is the only thing an unpaired app can meaningfully load. Because every caller — the bootstrap effect, `finishOnboarding`, and the resync effects — routes through `refresh()`, no other caller needs its own guard. Reuses the existing module-private `mergeLocalPairing` so an already-paired install is never flipped back into onboarding.

Exactly two files changed; no new files, no new abstraction, no preload changes.

## Regression test

Added to the existing BET-678 `describe` block in `src/renderer/store.test.ts`. **Verified red/green:** with the fix stashed the new test fails (`TypeError: window.api.syncSnapshot is not a function`), and with the fix applied it passes.

## Verification

- PR branch (`multica/BET-932-onboarding-refresh-guard` @ `f771c55`):
  - typecheck: exit 0, errors none. log sha256: `1f130f276b70a4dc1fefdfa6d919ee077b66b0c2ca1dc5d349f0b211ed032930`
  - test: exit 0, vitest 143 files passed / 2679 passed / 7 skipped; server 2050 pass / 0 fail. log sha256: `1457dac14100012b25b167ba198bc609814d7eecc951033da6c671ae4e111cf9`
- Base (`main` @ `76d0d97`):
  - typecheck: exit 0, errors none. log sha256: `1f130f276b70a4dc1fefdfa6d919ee077b66b0c2ca1dc5d349f0b211ed032930`
  - test: exit 0, vitest 143 files passed / 2678 passed / 7 skipped; server 2050 pass / 0 fail. log sha256: `0516331cd3571f78e92b5a3a1cc2cef4b2744845344e1351213a3bc9205bb26a`
- **Conclusion:** diff is 47 added lines, 0 removed. The single test-count delta (2679 vs 2678) is the new regression test. 0 new failures.

**Base: origin/main @ `76d0d97`**

## Release note

This blocks 100% of new users and needs a **patch release on the desktop channel** (`mac-v*` tag, and `win-v*` for the Windows installer) once merged — merging alone does not ship it.
