### PR TITLE
feat(website): point Windows buttons at the published installer (BET-930)

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -484,7 +484,7 @@ h1 .grad{background:var(--gradient-brand);-webkit-background-clip:text;backgroun
           <b>you own</b>. Start a task at your desk, approve it from your phone, come back to finished work.</p>
         <div style="display:flex;gap:12px;align-items:center;flex-wrap:wrap;margin-top:28px">
           <a class="btn btn-primary btn-lg" href="/downloads/Manta-latest.dmg">Download for macOS</a>
-          <a class="btn btn-ghost btn-lg" href="#download">Windows</a>
+          <a class="btn btn-ghost btn-lg" href="/downloads/Manta-latest-x64.exe">Download for Windows</a>
         </div>
         <p class="dl-note">Free and open source.</p>
       </div>
@@ -1219,9 +1219,10 @@ h1 .grad{background:var(--gradient-brand);-webkit-background-clip:text;backgroun
         <p style="margin-top:8px;font-size:12px;color:var(--slate-400)">Apple Silicon, macOS 13 and up.<br>Signed and notarised.</p>
         <a class="btn btn-primary" style="width:100%;justify-content:center;margin-top:14px" href="/downloads/Manta-latest.dmg">Download</a></div>
       <div class="card"><div style="font-size:15px;color:var(--text-primary);font-weight:700">Windows</div>
-        <div style="font-family:var(--font-mono);font-size:11px;color:var(--cyan-400);margin-top:7px">Manta-UI-x64.exe</div>
-        <p style="margin-top:8px;font-size:12px;color:var(--slate-400)">Windows 10 and 11, 64-bit.<br>Standard installer.</p>
-        <a class="btn btn-primary" style="width:100%;justify-content:center;margin-top:14px" href="https://github.com/antoinedc/MantaUI/releases">Download</a></div>
+        <div style="font-family:var(--font-mono);font-size:11px;color:var(--cyan-400);margin-top:7px">Manta-latest-x64.exe</div>
+        <p style="margin-top:8px;font-size:12px;color:var(--slate-400)">Windows 10 and 11, 64-bit.<br>
+          <span style="color:var(--amber-500)">Not signed yet, so Windows asks you to confirm.</span></p>
+        <a class="btn btn-primary" style="width:100%;justify-content:center;margin-top:14px" href="/downloads/Manta-latest-x64.exe">Download</a></div>
       <div class="card"><div style="font-size:15px;color:var(--text-primary);font-weight:700">Your box</div>
         <div style="font-family:var(--font-mono);font-size:11px;color:var(--cyan-400);margin-top:7px">install.sh</div>
         <p style="margin-top:8px;font-size:12px;color:var(--slate-400)">Linux or a spare Mac.<br>The app can do this for you.</p>

--- a/website/vs-conductor.html
+++ b/website/vs-conductor.html
@@ -154,7 +154,7 @@
           <tr><td>Approve a command from your phone</td><td class="us on">One tap</td><td class="off">No</td></tr>
           <tr><td>Tells you when the agent is blocked</td><td class="us on">Push to the right device</td><td class="off">No</td></tr>
           <tr><td>Remote access</td><td class="us on">Detected and set up</td><td class="mid">Conductor Cloud (beta, Pro, GitHub-only, 10-workspace cap)</td></tr>
-          <tr><td>Platforms</td><td class="us mid">Linux or macOS box, macOS desktop, iPhone app, browser</td><td class="mid">macOS only. <q>not available for Windows or Linux yet.</q> <span class="src">conductor.build/docs</span></td></tr>
+          <tr><td>Platforms</td><td class="us mid">Linux or macOS box, macOS and Windows desktop, iPhone app, browser</td><td class="mid">macOS only. <q>not available for Windows or Linux yet.</q> <span class="src">conductor.build/docs</span></td></tr>
           <tr><td>Permissions model</td><td class="us on">Explicit permission cards, yolo opt-in</td><td class="off">Agents run without sandboxing</td></tr>
           <tr><td>Sandboxing</td><td class="us on">Commands ask first</td><td class="off">Workspace isolation is development isolation, not a security boundary</td></tr>
           <tr><td>Diff review / inline annotation</td><td class="us off">No</td><td class="on">Yes, with inline comments back to the agent</td></tr>

--- a/website/vs-orca.html
+++ b/website/vs-orca.html
@@ -83,7 +83,7 @@
       "name": "Why is Orca so much more mature?",
       "acceptedAnswer": {
         "@type": "Answer",
-        "text": "Orca is older, has 29.6k stars on GitHub, and is YC-backed. Manta is a solo project and is younger. Maturity buys you a larger surface today (diff review, an editor, more runtimes, a Windows and Linux desktop) and a smaller backlog. We concede the comparison on maturity plainly."
+        "text": "Orca is older, has 29.6k stars on GitHub, and is YC-backed. Manta is a solo project and is younger. Maturity buys you a larger surface today (diff review, an editor, more runtimes, a Linux desktop) and a smaller backlog. We concede the comparison on maturity plainly."
       }
     },
     {
@@ -123,7 +123,7 @@
     <div class="verdict">
       <h2>Verdict</h2>
       <ul>
-        <li><span class="vtag">Pick Orca</span><span><b>If you want 34 agent runtimes, a Monaco-based editor with Design Mode, and you only need your laptop.</b> Orca is the more mature IDE today, and the only one of the two with a Windows or Linux desktop.</span></li>
+        <li><span class="vtag">Pick Orca</span><span><b>If you want 34 agent runtimes, a Monaco-based editor with Design Mode, and you only need your laptop.</b> Orca is the more mature IDE today, and the only one of the two with a Linux desktop.</span></li>
         <li><span class="vtag">Pick Manta</span><span><b>If your agent should keep running after you close the laptop, your phone should be able to approve a command, and you want one self-hosted box rather than a desktop app you have to keep open.</b></span></li>
         <li><span class="vtag">Overlap</span><span>Both give you an agent chat panel, a worktree per session, and a real terminal. The trade-off is where the work lives.</span></li>
       </ul>
@@ -159,7 +159,7 @@
           <tr><td>Diff review / inline annotation</td><td class="us off">No</td><td class="on">Yes</td></tr>
           <tr><td>Built-in code editor</td><td class="us mid">Terminal + chat only</td><td class="on">Monaco with Design Mode</td></tr>
           <tr><td>Agent runtimes supported</td><td class="us mid">2 (Claude Code, opencode)</td><td class="on">34</td></tr>
-          <tr><td>Desktop OS coverage</td><td class="us mid">macOS desktop (box runs on Linux or macOS)</td><td class="on">macOS, Windows, Linux</td></tr>
+          <tr><td>Desktop OS coverage</td><td class="us mid">macOS and Windows desktop, iPhone app (box runs on Linux or macOS)</td><td class="on">macOS, Windows, Linux</td></tr>
           <tr><td>Git worktree per session</td><td class="us on">Yes</td><td class="on">Yes</td></tr>
           <tr><td>Real tmux underneath</td><td class="us on">Yes, you can SSH in</td><td class="off">No</td></tr>
           <tr><td>Agent scheduling, webhooks, secrets</td><td class="us on">Yes</td><td class="off">No</td></tr>
@@ -189,7 +189,7 @@
       <li><span class="ck">›</span><span><b>Agent runtime count.</b> Orca ships 34. Manta ships two today (Claude Code and opencode). If you want Cursor, Codex, Aider and the rest of the field on the same desktop, Orca is the answer.</span></li>
       <li><span class="ck">›</span><span><b>Built-in editor.</b> Monaco with Design Mode lets you edit, preview and let the agent touch the same file. Manta gives you a terminal and a chat panel; your editor stays your editor.</span></li>
       <li><span class="ck">›</span><span><b>Diff review and inline annotation.</b> Orca's PR/merge tail and inline comments back to the agent are the strongest part of the product. Manta has none of it.</span></li>
-      <li><span class="ck">›</span><span><b>Cross-platform desktop.</b> macOS, Windows and Linux. The Manta desktop is macOS only today; the box itself runs on Linux or macOS.</span></li>
+      <li><span class="ck">›</span><span><b>A Linux desktop.</b> Orca ships one; Manta does not. Manta's desktop is macOS and Windows, and the box itself runs on Linux or macOS.</span></li>
       <li><span class="ck">›</span><span><b>Maturity.</b> 29.6k GitHub stars, YC-backed, widely deployed. Manta is new and ships less surface.</span></li>
     </ul>
     <div class="quotebox">
@@ -274,7 +274,7 @@
       <div class="q"><h3>Is Manta a fork of Orca?</h3><p>No. They are separate products with separate codebases. Both are MIT, both run Claude Code in a terminal, and the similarity ends there. Orca is desktop-first and ships 34 agent runtimes; Manta is box-first and ships two.</p></div>
       <div class="q"><h3>Does Manta run on any of Orca's agent runtimes?</h3><p>No. Manta runs Claude Code and opencode in a real tmux session on your box. Orca's runtime count comes from packaging many agent CLIs into the desktop app; Manta does not do that today and would not benefit from the same approach because it does not own the editor.</p></div>
       <div class="q"><h3>Can Manta and Orca share a machine?</h3><p>Yes, on a macOS box. They use different ports and different tmux sessions, so they do not interfere. On a Linux box the same applies; the desktop piece of Orca simply has no Linux desktop binary to launch there.</p></div>
-      <div class="q"><h3>Why is Orca so much more mature?</h3><p>Orca is older, has 29.6k stars on GitHub, and is YC-backed. Manta is a solo project and is younger. Maturity buys you a larger surface today (diff review, an editor, more runtimes, a Windows and Linux desktop) and a smaller backlog. We concede the comparison on maturity plainly.</p></div>
+      <div class="q"><h3>Why is Orca so much more mature?</h3><p>Orca is older, has 29.6k stars on GitHub, and is YC-backed. Manta is a solo project and is younger. Maturity buys you a larger surface today (diff review, an editor, more runtimes, a Linux desktop) and a smaller backlog. We concede the comparison on maturity plainly.</p></div>
       <div class="q"><h3>Which one should I pick if my work runs locally?</h3><p>Orca. Manta is for when the work needs to outlive the laptop, or when you want a phone client that can approve a command. If neither matters and your editor matters most, Orca's Monaco integration is the answer.</p></div>
     </div>
   </div>


### PR DESCRIPTION
**BET-930 — Homepage pass 2 (3/5): point the Windows buttons at the published installer**

Copy-and-links only, exactly per the issue. No CSS, no components, no layout change.

**Files changed:** 3
- `website/index.html` — hero Windows button → `/downloads/Manta-latest-x64.exe` ("Download for Windows"); Windows card renamed to `Manta-latest-x64.exe`, links to the file (not the releases index), and states the SmartScreen warning plainly.
- `website/vs-orca.html` — "macOS desktop" → "macOS and Windows desktop, iPhone app"; concessions list "Cross-platform desktop" → "A Linux desktop"; "Pick Orca" bullet → "only one of the two with a Linux desktop"; both JSON-LD maturity answers (lines ~86 and ~277) → "a Linux desktop".
- `website/vs-conductor.html` — Platforms row "macOS desktop" → "macOS and Windows desktop". The two remaining `Windows` hits there (JSON-LD + FAQ, about Conductor being macOS-only and Manta's *box* running Linux/macOS) are consistent and left untouched.

**Base: `origin/main @ 3c7c285f`**

**Verification results:**
- PR branch (`multica/BET-930-windows-download-links`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 2050 pass / 0 fail / 0 skip.
- Acceptance self-check: `grep -c 'href="#download"' index.html` = 0; no homepage link to `antoinedc/MantaUI/releases`; no "macOS only today"/"macOS desktop" describing the Manta desktop anywhere in `website/*.html`; every remaining `Windows` hit in vs-orca/vs-conductor is consistent with "Manta desktop = macOS and Windows; no Linux desktop".

**⚠ Merge gate (AC1):** `curl -sI https://mantaui.com/downloads/Manta-latest-x64.exe` currently returns **404**. The publish pipeline (BET-929) is merged but the file only goes live when a `win-v*` tag is pushed — one has not been since. Merging this PR while the URL 404s makes the hero's second button dead, which is worse than today's behaviour. **Do not merge until a `win-v*` tag has published and the URL returns 200.**
