### PR TITLE
BET-933: follow transcript tail on content growth + jump-to-latest button

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1227,65 +1227,33 @@ Backup at `~/.tmux.conf.pre-MantaUI` on the remote if it was ever modified.
   event in `attachCustomKeyEventHandler`, call `preventDefault()` to kill
   the textarea side, and manually `ptyWrite("\x1b\r")` — the same sequence
   iTerm2's `/terminal-setup` sends. Don't drop the `preventDefault()`.
-- **Chat transcript pin-to-bottom — pre-commit pin state derived from the
-  live DOM in a layout effect, not from event-cached state (v4).** Four
-  designs in this saga, each fixing the previous one's bug:
+- **Chat transcript pin-to-bottom — one explicit "following" state, not
+  derived from the live scroll position (BET-933).** BET-679 moved the
+  transcript to react-virtuoso; the v1–v4 hand-rolled machinery
+  (`pinnedToBottom`, `prevScrollHeight`, `wasAtBottomBeforeCommit`,
+  `classifyScrollForPin`) is gone. This issue removed Virtuoso's
+  `followOutput` / `atBottomStateChange` / `atBottomThreshold` because
+  `followOutput` reacts only to item-COUNT changes and therefore missed
+  every height change (tool cards as their output streams, streaming text,
+  the Footer's working indicator), silently detaching the transcript
+  mid-turn with no user input — and staying detached for the rest of the
+  turn.
 
-  - v1 (pre-631b03e): 80px symmetric threshold. 30px scroll-up left
-    pin=true, next delta snapped.
-  - v2 (631b03e): 8px re-pin + wheel/touch/key intent un-pin. Missed
-    scrollbar-handle drag (no wheel/touch/key event) and got snapped on
-    every `session.status` busy/idle oscillation by a `running` edge
-    effect.
-  - v3 (f1b7341): single 8px symmetric threshold + one `scroll` listener.
-    Right idea, wrong substrate — `scroll` events are async (rAF-batched),
-    but `setMessages` → render → effect is sync in the same task. So mid-
-    streaming wheel-up was eaten: the delta's effect read the STALE
-    pin=true (last scroll event), snapped to bottom, THEN the queued
-    scroll event for the wheel-up dispatched against the post-snap
-    position and re-affirmed pin=true. User's scroll silently erased.
-  - v4 (current): the post-commit stick decision reads the live DOM in a
-    `useLayoutEffect` (synchronous post-commit, pre-paint) and computes
-    pre-commit distance from a tracked `prevScrollHeight` ref:
+  The replacement is one explicit follow state owned by ChatPanel
+  (`followingRef` + its render mirror), turned OFF only by a scroll gesture
+  that moves UP (`classifyFollowOnScroll`, threshold in
+  `FOLLOW_THRESHOLD_PX`), and one auto-follow trigger
+  (`totalListHeightChanged` → `scrollElementToTail`). Content growth fires
+  no scroll event, so it can never flip the state.
 
-      prevDist = max(0, prevScrollHeight - scrollTop - clientHeight)
+  **State the invariant plainly, because five generations of this code have
+  now got it wrong: never derive "should we follow" from "is the scroller
+  at the bottom". Content growing under the user changes the latter and
+  must not change the former.**
 
-    `scrollTop` is preserved by the browser when content is appended, so
-    this is the user's true pre-commit position. No event timing. No
-    stale ref. The pure helper is `wasAtBottomBeforeCommit()` in
-    `chatUtils.ts` (tested with explicit v3-regression cases).
-
-  The `scroll` listener still updates `pinnedToBottom.current` via
-  `classifyScrollForPin()` as a back-channel for callers OUTSIDE the
-  messages commit (the RunningIndicator `atBottom` prop, the isActive
-  re-pin effect). `resizeInput` does NOT use the cached boolean — it
-  reads the live DOM via `classifyScrollForPin` for the same staleness
-  reason. **Do NOT re-introduce a messages-effect that reads
-  `pinnedToBottom.current` instead of `wasAtBottomBeforeCommit`** — that
-  is the v3 regression.
-
-  Trade-off baked in: scrolls of < 8px (single-pixel jiggles) stay pinned
-  and get snapped on the next delta. Intentional — most wheel detents are
-  40-100px, a sub-8px scroll is almost certainly accidental, and
-  re-engaging follow by scrolling to the bottom is trivial.
-
-  **Force-pin paths are limited and explicit**: `submit()` sets
-  `pinnedToBottom.current = true` AND resets `prevScrollHeight.current =
-  0` just before its optimistic `setMessages`. The reset matters —
-  `wasAtBottomBeforeCommit` returns true unconditionally when
-  `prevScrollHeight=0` (first-commit branch), which forces the stick even
-  if the user had scrolled into history before submitting. That's it.
-  Queue drains route through the same `submit()` path so they inherit
-  this force-pin for free. The old `running` false→true edge effect is
-  gone — it fired on every busy/idle oscillation and yanked the viewport
-  mid-turn. **Do NOT reintroduce a `running`-derived force-pin.**
-
-  Also gone: asymmetric hysteresis with a dead-zone (re-introduces v1's
-  bug — the dead zone PRESERVES prior state); wheel/touch/key intent
-  listeners (load-bearing only for v2's missing un-pin path; v4 doesn't
-  need them); the v3 `[messages, liveTodos]` regular effect that read
-  `pinnedToBottom.current` (replaced by the `useLayoutEffect` that reads
-  `wasAtBottomBeforeCommit`).
+  Note the tail scroll is `scrollTop = scrollHeight`, not
+  `scrollToIndex({ index: "LAST" })`, because the Footer renders below the
+  last item.
 
 ## New-project dialog (`Sidebar.tsx`)
 

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -8,7 +8,7 @@
 // (Transcript / Composer / hook extraction) verifiable rather than blind —
 // if any extraction breaks the mount or the event wiring, a test here fails.
 
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act } from "react";
 import { ChatPanel } from "./ChatPanel";
 import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
@@ -32,56 +32,13 @@ const PROPS = {
   isActive: true,
 };
 
-// react-virtuoso mock (BET-802) — one test needs to OBSERVE every
-// `scrollToIndex` call the panel makes, but Virtuoso recreates its imperative
-// handle object on every render, so a handle spied after mount goes stale the
-// moment the submit re-render lands. Instead of reaching into internals, we
-// wrap the REAL `<Virtuoso>` (delegating all rendering so the other harness
-// tests are untouched) and, in a layout effect that runs after Virtuoso sets
-// ref.current but before passiv ive effects (where ChatPanel's post-commit
-// force-tail scroll lives), route every `scrollToIndex` on the current handle
-// through a module-scope observer the test installs. Layout effects flush
-// bottom-up, so the child Virtuoso's handle exists before this wrapper runs.
-vi.mock("react-virtuoso", async (importOriginal) => {
-  const actual = await importOriginal<typeof import("react-virtuoso")>();
-  const React = await import("react");
-  const { forwardRef: fwd, useLayoutEffect: layout, useRef: ref } = React;
-
-  // Registry the BET-802 test reads/writes. `observer` receives every
-  // scrollToIndex call; `container` is where the panel is mounted, so the
-  // observer can capture the transcript text at the moment of the call.
-  (globalThis as { __virtuosoScrollObserver?: unknown }).__virtuosoScrollObserver = null;
-  (globalThis as { __virtuosoContainer?: unknown }).__virtuosoContainer = null;
-
-  const Virtuoso = fwd(function Virtuoso(props: Record<string, unknown>, forwarded: unknown) {
-    const mountedRef = ref<boolean>(false);
-    layout(() => {
-      // `forwarded` is the panel's virtuosoRef; Virtuoso (child, rendered
-      // below) sets forwarded.current to a fresh handle during its own layout
-      // effect, which flushes before this one.
-      const handle = (forwarded as { current?: { scrollToIndex?: unknown } } | null)?.current;
-      if (handle && typeof handle.scrollToIndex === "function") {
-        const base = (handle.scrollToIndex as (...a: unknown[]) => unknown).bind(handle);
-        (handle as { scrollToIndex: (...a: unknown[]) => unknown }).scrollToIndex =
-          (...args: unknown[]) => {
-            const container = (globalThis as any).__virtuosoContainer as HTMLElement | null;
-            const observer = (globalThis as any).__virtuosoScrollObserver as
-              | ((args: unknown[], text: string) => void)
-              | null;
-            if (observer) observer(args, container?.textContent ?? "");
-            return base(...args);
-          };
-      }
-      mountedRef.current = true;
-    });
-    return React.createElement(
-      actual.Virtuoso,
-      { ...(props as Record<string, unknown>), ref: forwarded } as never,
-    );
-  });
-
-  return { ...actual, Virtuoso };
-});
+// react-virtuoso is NOT mocked here. BET-802 needed to observe the panel's
+// imperative scroll; the panel no longer scrolls through Virtuoso's handle —
+// since BET-933 it scrolls the scroller ELEMENT directly (scrollTop =
+// scrollHeight via scrollerRef), so the mock and its globals are gone. The
+// BET-802 ordering property (the tail scroll happens only after the
+// optimistic user row is committed) is asserted against the scroller element
+// in the test below.
 
 describe("ChatPanel render harness", () => {
   let bus: MockEventBus;
@@ -705,19 +662,17 @@ describe("ChatPanel composer submit", () => {
     expect(textarea.value).toBe("previous prompt");
   });
 
-  it("scrolls the transcript to the tail only after the optimistic message is committed (BET-802)", async () => {
-    // Capture every scrollToIndex the panel fires, together with the
-    // transcript text at the instant of the call, via the react-virtuoso mock
-    // defined at the top of this file (Virtuoso recreates its handle on every
-    // render, so an instance-level spy goes stale the moment submit commits).
-    const calls: Array<{ args: unknown[]; text: string }> = [];
-    (globalThis as any).__virtuosoScrollObserver = (args: unknown[], text: string) => {
-      calls.push({ args, text });
-    };
-    (globalThis as any).__virtuosoContainer = null;
+  it("scrolls the transcript to the tail only after the optimistic message is committed (BET-802, BET-933)", async () => {
+    // The panel now scrolls the scroller ELEMENT (scrollTop = scrollHeight via
+    // ChatPanel's scrollToTail) instead of Virtuoso's imperative handle. The
+    // scroller is the element Virtuoso stamps `data-testid="virtuoso-scroller"`
+    // on and hands to `scrollerRef` (stable in the mock context too). We spy on
+    // its `scrollTop` setter, capturing the transcript text at the instant of
+    // each write, and stub `scrollHeight` (jsdom reports 0).
+    const calls: Array<{ v: number; text: string }> = [];
 
     // Seed one transcript row so the message-list branch (and thus the
-    // Virtuoso handle) is mounted before we submit; an empty initial fetch
+    // Virtuoso scroller) is mounted before we submit; an empty initial fetch
     // would render only the welcome state and no Virtuoso at all.
     const transcript = [
       {
@@ -739,8 +694,18 @@ describe("ChatPanel composer submit", () => {
     resetStore();
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();
-    (globalThis as any).__virtuosoContainer = h.container;
-    const before = calls.length;
+
+    const el = h.container.querySelector('[data-testid="virtuoso-scroller"]') as HTMLElement;
+    expect(el).toBeTruthy();
+    const container = h.container;
+    Object.defineProperty(el, "scrollHeight", { value: 4242, configurable: true });
+    Object.defineProperty(el, "scrollTop", {
+      set: (v: number) => {
+        calls.push({ v, text: container.textContent ?? "" });
+      },
+      get: () => 0,
+      configurable: true,
+    });
 
     const textarea = h.container.querySelector("textarea") as HTMLTextAreaElement;
     await act(async () => {
@@ -755,29 +720,14 @@ describe("ChatPanel composer submit", () => {
 
     // The optimistic user message committed into the DOM…
     expect(h.text()).toContain("please scroll to me");
-    // …and at least one force-pin to "LAST" fired for it (the submit
-    // force-pin), at a moment when that very message was already rendered.
-    // If submit scrolled inline against the stale list, the "LAST" call would
-    // capture a transcript without the new message — the exact BET-802 bug.
-    const scrollsAfterSubmit = calls.slice(before);
-    const lastScrolled = scrollsAfterSubmit.some(
-      (c) => (c.args[0] as { index?: unknown } | undefined)?.index === "LAST",
+    // …and at least one tail scroll (to the stubbed scrollHeight) fired at a
+    // moment when that very message was already rendered. If submit scrolled
+    // inline against the stale list, the write would capture a transcript
+    // without the new message — the exact BET-802 bug.
+    const hadMessageWhenScrolled = calls.some(
+      (c) => c.v === 4242 && c.text.includes("please scroll to me"),
     );
-    const lastEndScrolled = scrollsAfterSubmit.some(
-      (c) => (c.args[0] as { index?: unknown; align?: unknown } | undefined)?.index === "LAST"
-        && (c.args[0] as { index?: unknown; align?: unknown } | undefined)?.align === "end",
-    );
-    const hadMessageWhenLastScrolled = scrollsAfterSubmit.some(
-      (c) =>
-        (c.args[0] as { index?: unknown } | undefined)?.index === "LAST"
-        && c.text.includes("please scroll to me"),
-    );
-    expect(lastScrolled).toBe(true);
-    expect(lastEndScrolled).toBe(true);
-    expect(hadMessageWhenLastScrolled).toBe(true);
-
-    (globalThis as any).__virtuosoScrollObserver = null;
-    (globalThis as any).__virtuosoContainer = null;
+    expect(hadMessageWhenScrolled).toBe(true);
   });
 });
 

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -16,7 +16,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { VirtuosoHandle } from "react-virtuoso";
-import { Clock, X } from "lucide-react";
+import { ArrowDown, Clock, X } from "lucide-react";
 import type {
   AvailableLauncher,
   CheckRollup,
@@ -358,7 +358,7 @@ export function ChatPanel({
   // growing under the user must not detach them — see the header comment on
   // classifyFollowOnScroll.
   const followingRef = useRef(true);
-  const [, setFollowingState] = useState(true);
+  const [following, setFollowingState] = useState(true);
   const setFollowing = useCallback((v: boolean) => {
     if (followingRef.current === v) return;
     followingRef.current = v;
@@ -2541,39 +2541,56 @@ export function ChatPanel({
         onEnsureShipPreview={() => void ensureShipPreview()}
       />
 
-      <VoicePlaybackProvider active={isActive}>
-        <Transcript
-          messages={messages}
-          virtuosoRef={virtuosoRef}
-          sessionId={sessionId}
-          setMessages={setMessages}
-          loadedAllRef={loadedAllRef}
-          taskContextValue={taskContextValue}
-          showThinking={showThinking}
-          running={running}
-          liveTurn={liveTurn}
-          progress={liveProgress}
-          isActive={isActive}
-          activeTodos={activeTodos}
-          onDismissTodos={dismissTodos}
-          // BET-418 §D: a job session is read-only — never show its (anyway
-          // impossible) question cards. Defensive: a job's pre-flight ruleset
-          // means it never generates asks.
-          questions={jobOwnership ? [] : questions}
-          turnInfo={turnInfo}
-          finishByMessageId={finishByMessageId}
-          userCommandInfo={userCommandInfo}
-          voiceNoteByMessageId={voiceNoteByMessageId}
-          pendingVoiceNote={pendingVoiceNote}
-          onRetryVoiceNote={retryVoiceNote}
-          onReplyQuestion={replyQuestion}
-          onRejectQuestion={rejectQuestion}
-          scrollerElRef={scrollerElRef}
-          followingRef={followingRef}
-          onFollowingChange={setFollowing}
-          motionStateRef={motionStateRef}
-        />
-      </VoicePlaybackProvider>
+      {/* The transcript region owns its own positioning context so the
+          jump-to-latest button floats at the BOTTOM OF THE TRANSCRIPT — above
+          the card stack and the composer, both of which change height. */}
+      <div className="relative flex-1 min-h-0 flex flex-col">
+        <VoicePlaybackProvider active={isActive}>
+          <Transcript
+            messages={messages}
+            virtuosoRef={virtuosoRef}
+            sessionId={sessionId}
+            setMessages={setMessages}
+            loadedAllRef={loadedAllRef}
+            taskContextValue={taskContextValue}
+            showThinking={showThinking}
+            running={running}
+            liveTurn={liveTurn}
+            progress={liveProgress}
+            isActive={isActive}
+            activeTodos={activeTodos}
+            onDismissTodos={dismissTodos}
+            // BET-418 §D: a job session is read-only — never show its (anyway
+            // impossible) question cards. Defensive: a job's pre-flight ruleset
+            // means it never generates asks.
+            questions={jobOwnership ? [] : questions}
+            turnInfo={turnInfo}
+            finishByMessageId={finishByMessageId}
+            userCommandInfo={userCommandInfo}
+            voiceNoteByMessageId={voiceNoteByMessageId}
+            pendingVoiceNote={pendingVoiceNote}
+            onRetryVoiceNote={retryVoiceNote}
+            onReplyQuestion={replyQuestion}
+            onRejectQuestion={rejectQuestion}
+            scrollerElRef={scrollerElRef}
+            followingRef={followingRef}
+            onFollowingChange={setFollowing}
+            motionStateRef={motionStateRef}
+          />
+        </VoicePlaybackProvider>
+        <button
+          type="button"
+          className="manta-jump-latest"
+          data-shown={!following}
+          aria-hidden={following}
+          tabIndex={following ? -1 : 0}
+          aria-label="Jump to latest"
+          title="Jump to latest"
+          onClick={scrollToTail}
+        >
+          <ArrowDown size={16} aria-hidden />
+        </button>
+      </div>
 
       {/* Pinned card stack above the composer (BET-783): blocking always
           above ambient, at most one blocking expanded, at most two ambient

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -53,6 +53,7 @@ import {
   type StaleCacheResult,
   type PendingScrollWin,
   isApprovalCoveredByAlways,
+  scrollElementToTail,
   MANTA_BUILTIN_COMMANDS,
   MANTA_BUILTIN_NAMES,
   parseModelRef,
@@ -346,7 +347,26 @@ export function ChatPanel({
   // and the deep-link jumps — plus a live at-bottom flag (the replacement for
   // the deleted `pinnedToBottom` ref) fed by Virtuoso's atBottomStateChange.
   const virtuosoRef = useRef<VirtuosoHandle>(null);
-  const atBottomRef = useRef(true);
+  // Whether the transcript is following the tail. The REF is the source of
+  // truth (imperative readers — resizeInput, the re-activation effect, the
+  // growth handler in Transcript — must not wait for a render); the state is
+  // its render mirror, needed only so the jump-to-latest button can appear.
+  // The equality guard is load-bearing: a scroll fires this on every event and
+  // an unguarded setState would re-render the panel on every scroll frame.
+  //
+  // This deliberately does NOT track "is the scroller at the bottom". Content
+  // growing under the user must not detach them — see the header comment on
+  // classifyFollowOnScroll.
+  const followingRef = useRef(true);
+  const [, setFollowingState] = useState(true);
+  const setFollowing = useCallback((v: boolean) => {
+    if (followingRef.current === v) return;
+    followingRef.current = v;
+    setFollowingState(v);
+  }, []);
+  // The Virtuoso scroll container, captured by Transcript via Virtuoso's
+  // `scrollerRef` prop. Same ownership pattern as loadedAllRef / motionStateRef.
+  const scrollerElRef = useRef<HTMLElement | null>(null);
   // Set by submit(), consumed by the force-tail effect below. Submit cannot
   // scroll inline: the optimistic row it just queued is not committed yet, so
   // `index: "LAST"` would resolve to the PREVIOUS last message.
@@ -356,19 +376,16 @@ export function ChatPanel({
   // cancelled before starting a new one, and cleared in the session-change
   // cleanup so a wait can't fire against a transcript the user has left.
   const messageFlashCancelRef = useRef<(() => void) | null>(null);
-  const onAtBottomChange = useCallback((atBottom: boolean) => {
-    atBottomRef.current = atBottom;
-  }, []);
   // The ONE way this panel scrolls the transcript to its tail. Every caller
   // goes through here: submit's force-pin, the question-card reveal, the
-  // composer-resize rescue and the re-activation re-pin. `atBottomRef` is set
-  // eagerly rather than waiting for Virtuoso's async atBottomStateChange, so
-  // the followOutput gate and resizeInput's rescue agree with the scroll we
-  // just asked for.
-  const scrollToTail = useCallback((behavior: "auto" | "smooth" = "auto") => {
-    atBottomRef.current = true;
-    virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end", behavior });
-  }, []);
+  // composer-resize rescue, the re-activation re-pin and the jump-to-latest
+  // button. The follow state is set eagerly here rather than waiting for any
+  // async signal, so the growth handler and the rescues agree with the scroll
+  // we just asked for.
+  const scrollToTail = useCallback(() => {
+    setFollowing(true);
+    scrollElementToTail(scrollerElRef.current);
+  }, [setFollowing]);
   // Mirror of `messages` for event listeners (deep-link jumps) that need the
   // current list without re-registering on every message update.
   const messagesRef = useRef(messages);
@@ -751,7 +768,7 @@ export function ChatPanel({
         if (questions.length > 0) {
           // The question cards live in the transcript's footer; scroll the last
           // row into view so the footer (with the cards) is revealed.
-          scrollToTail("smooth");
+          scrollToTail();
           wantQuestionScroll.current = false;
         }
       }
@@ -856,23 +873,22 @@ export function ChatPanel({
   // start: questions arrive via the async fetch after this panel mounts).
   useEffect(() => {
     if (wantQuestionScroll.current && questions.length > 0) {
-      scrollToTail("smooth");
+      scrollToTail();
       wantQuestionScroll.current = false;
     }
   }, [questions, scrollToTail]);
 
-  // Textarea auto-resize up to a 6-line cap. After resizing, if the scroll
-  // container is at the bottom we re-scroll so the input growing pushes the
-  // chat content up rather than sliding over it. Follows Virtuoso's live
-  // at-bottom flag (fed by atBottomStateChange) — the replacement for the
-  // deleted pin refs.
+  // Textarea auto-resize up to a 6-line cap. After resizing, if the transcript
+  // is following the tail we re-scroll so the input growing pushes the chat
+  // content up rather than sliding over it. Follows the panel's follow state
+  // — the replacement for the deleted pin refs.
   const resizeInput = useCallback(() => {
     const el = inputRef.current;
     if (!el) return;
     el.style.height = "auto";
     const cap = 6 * 20;
     el.style.height = `${Math.min(el.scrollHeight, cap)}px`;
-    if (atBottomRef.current) {
+    if (followingRef.current) {
       scrollToTail();
     }
   }, [scrollToTail]);
@@ -914,14 +930,14 @@ export function ChatPanel({
   // GOTCHA (inherited from the pin machinery): while App.tsx hides an inactive
   // panel with `display:none`, the scroller has no layout. New messages keep
   // accumulating while hidden, and on re-activation the user should be back at
-  // the tail if they were there when the panel was deactivated. `atBottomRef`
-  // retains its last value across the hidden window (hidden panels fire no
-  // at-bottom change), so gating on it reproduces the old "was at bottom when
-  // deactivated" rule. Virtuoso owns the scroll position now, so a single
-  // scrollToIndex on reactivation is all that's needed.
+  // the tail if they were there when the panel was deactivated. The panel's
+  // follow state retains its last value across the hidden window (hidden
+  // panels fire no scroll events), so gating on it reproduces the old "was at
+  // bottom when deactivated" rule; a single tail scroll on reactivation is
+  // all that's needed.
   useEffect(() => {
     if (!isActive) return;
-    if (!atBottomRef.current) return;
+    if (!followingRef.current) return;
     scrollToTail();
   }, [isActive, scrollToTail]);
 
@@ -2552,7 +2568,9 @@ export function ChatPanel({
           onRetryVoiceNote={retryVoiceNote}
           onReplyQuestion={replyQuestion}
           onRejectQuestion={rejectQuestion}
-          onAtBottomChange={onAtBottomChange}
+          scrollerElRef={scrollerElRef}
+          followingRef={followingRef}
+          onFollowingChange={setFollowing}
           motionStateRef={motionStateRef}
         />
       </VoicePlaybackProvider>

--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -67,7 +67,9 @@ function props(messages: OpencodeMessage[], running = false): TranscriptProps {
     sessionId: "s1",
     setMessages: () => {},
     loadedAllRef: { current: false },
-    onAtBottomChange: () => {},
+    scrollerElRef: { current: null },
+    followingRef: { current: true },
+    onFollowingChange: () => {},
     taskContextValue: {
       childMessages: new Map(),
       liveChildStatus: new Map(),

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -18,7 +18,7 @@
 // provider VALUE is memoized by ChatPanel (`taskContextValue`) for keystroke
 // stability, so passing it through as a prop keeps that identity intact.
 
-import { forwardRef, useEffect, useMemo, useState } from "react";
+import { forwardRef, useCallback, useEffect, useMemo, useState } from "react";
 import { AnimatePresence, MotionConfig, motion } from "framer-motion";
 import { Virtuoso, type ListProps, type VirtuosoHandle } from "react-virtuoso";
 import { TaskContext, type TaskContextValue, presentVerbFor } from "./chatShared";
@@ -38,6 +38,8 @@ import {
   isRenderableMessage,
   updateEntryMotion,
   formatDuration,
+  scrollElementToTail,
+  classifyFollowOnScroll,
   type EntryMotionState,
   type LiveTurn,
   workingIndicatorLabel,
@@ -344,7 +346,14 @@ export type TranscriptProps = {
   onRetryVoiceNote: (noteId: string) => void;
   onReplyQuestion: (q: QuestionRequest, answers: string[][]) => void;
   onRejectQuestion: (q: QuestionRequest) => void;
-  onAtBottomChange: (atBottom: boolean) => void;
+  // The Virtuoso scroll container, published upward so ChatPanel's
+  // scrollToTail can address the real bottom (Footer included).
+  scrollerElRef: React.MutableRefObject<HTMLElement | null>;
+  // Whether the transcript is following the tail. Read (never written) by the
+  // growth handler; ChatPanel owns it. See setFollowing there.
+  followingRef: React.MutableRefObject<boolean>;
+  // Called with the new follow state when a scroll event decides one.
+  onFollowingChange: (following: boolean) => void;
   // The shared entry-motion state (owned by ChatPanel, registered to here and
   // to useTranscriptState's reconcile path). Using the parent's ref keeps the
   // reconcile registration and the render fold on the SAME state object.
@@ -374,7 +383,9 @@ export function Transcript({
   onRetryVoiceNote,
   onReplyQuestion,
   onRejectQuestion,
-  onAtBottomChange,
+  scrollerElRef,
+  followingRef,
+  onFollowingChange,
   motionStateRef,
 }: TranscriptProps) {
   // Entry motion (transcript-motion). A message that arrives while the user is
@@ -464,6 +475,33 @@ export function Transcript({
     virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end" });
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [hasMessages]);
+
+  // The transcript's ONLY auto-follow. `totalListHeightChanged` fires whenever
+  // the scrollable content changes height for ANY reason — a new message row,
+  // a tool card growing as its output streams, the Footer's working indicator
+  // animating open (Virtuoso's totalListHeight sums header + footer + list, so
+  // one signal covers all of it). This replaces `followOutput`, which fired
+  // only on item-COUNT changes and therefore missed every one of those.
+  const stickToTail = useCallback(() => {
+    if (!followingRef.current) return;
+    scrollElementToTail(scrollerElRef.current);
+  }, [followingRef, scrollerElRef]);
+
+  // The user's intent, and the only thing that can stop the follow. Content
+  // growth fires no scroll event, so it cannot reach this listener — which is
+  // exactly why the transcript can no longer detach on its own.
+  useEffect(() => {
+    const el = scrollerElRef.current;
+    if (!el) return;
+    let prevScrollTop = el.scrollTop;
+    const onScroll = () => {
+      const next = classifyFollowOnScroll(el, prevScrollTop);
+      prevScrollTop = el.scrollTop;
+      if (next !== null) onFollowingChange(next);
+    };
+    el.addEventListener("scroll", onScroll, { passive: true });
+    return () => el.removeEventListener("scroll", onScroll);
+  }, [hasMessages, onFollowingChange, scrollerElRef]);
 
   return (
     // Wrap in reducedMotion="user" so framer-motion disables every chat entry
@@ -560,9 +598,10 @@ export function Transcript({
                   />
                 );
               }}
-              followOutput={(isAtBottom) => (isAtBottom ? "smooth" : false)}
-              atBottomStateChange={onAtBottomChange}
-              atBottomThreshold={8}
+              scrollerRef={(el) => {
+                scrollerElRef.current = el as HTMLElement | null;
+              }}
+              totalListHeightChanged={stickToTail}
               firstItemIndex={firstItemIndex}
               alignToBottom
               increaseViewportBy={{ top: 600, bottom: 200 }}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -121,6 +121,9 @@ import {
   dispatchAppControl,
   sortInbox,
   inboxReasonLabel,
+  scrollElementToTail,
+  classifyFollowOnScroll,
+  FOLLOW_THRESHOLD_PX,
 } from "./chatUtils";
 
 import type { OpencodeModel, UsageSnapshot, OpencodeMessage, VoiceNoteRecord, ForgeInboxItem } from "../shared/types";
@@ -4613,5 +4616,65 @@ describe("sortInbox", () => {
     const before = [...rows];
     sortInbox(rows);
     expect(rows.map((r) => r.number)).toEqual(before.map((r) => r.number));
+  });
+});
+
+describe("scrollElementToTail", () => {
+  it("does not throw on a null element", () => {
+    expect(() => scrollElementToTail(null)).not.toThrow();
+  });
+
+  it("sets scrollTop to the element's scrollHeight", () => {
+    const el = { scrollTop: 5, scrollHeight: 4242 } as HTMLElement;
+    scrollElementToTail(el);
+    expect(el.scrollTop).toBe(4242);
+  });
+});
+
+describe("classifyFollowOnScroll", () => {
+  it("is following at the exact bottom (distance 0)", () => {
+    // scrollHeight - scrollTop - clientHeight === 0
+    expect(classifyFollowOnScroll({ scrollTop: 600, scrollHeight: 1000, clientHeight: 400 }, 600))
+      .toBe(true);
+  });
+
+  it("is following when distance equals FOLLOW_THRESHOLD_PX (inclusive boundary)", () => {
+    expect(
+      classifyFollowOnScroll(
+        { scrollTop: 1000 - FOLLOW_THRESHOLD_PX, scrollHeight: 1000, clientHeight: 0 },
+        500,
+      ),
+    ).toBe(true);
+  });
+
+  it("is null (no decision) when away from the bottom but scrollTop increased", () => {
+    // Scrolling down through history must not toggle anything.
+    expect(
+      classifyFollowOnScroll({ scrollTop: 700, scrollHeight: 1000, clientHeight: 100 }, 500),
+    ).toBe(null);
+  });
+
+  it("is false (stop following) when away from the bottom and scrollTop decreased", () => {
+    // The user scrolled up — the only un-follow path.
+    expect(
+      classifyFollowOnScroll({ scrollTop: 300, scrollHeight: 1000, clientHeight: 100 }, 500),
+    ).toBe(false);
+  });
+
+  it("REGRESSION: content growth must not detach the transcript", () => {
+    // scrollHeight grew a lot, scrollTop unchanged, distance far past the
+    // threshold -> scrollTop did NOT decrease, so the event is `null`. This
+    // is the bug: a growing tool card must never detach the transcript.
+    expect(
+      classifyFollowOnScroll({ scrollTop: 500, scrollHeight: 2000, clientHeight: 100 }, 500),
+    ).toBe(null);
+  });
+
+  it("is following when the scroller clamped scrollTop down but lands at the bottom", () => {
+    // The transcript shrank so the browser clamped scrollTop down; the result
+    // is at the bottom, so following wins (bottom check evaluated first).
+    expect(
+      classifyFollowOnScroll({ scrollTop: 900, scrollHeight: 1000, clientHeight: 100 }, 999999),
+    ).toBe(true);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3378,3 +3378,45 @@ export function sortInbox(items: ForgeInboxItem[]): ForgeInboxItem[] {
   }
   return [...byKey.values()].sort((a, b) => b.updatedAt - a.updatedAt);
 }
+
+/**
+ * Scroll a scroll container to its very bottom.
+ *
+ * `scrollTop = scrollHeight` (rather than Virtuoso's
+ * `scrollToIndex({ index: "LAST", align: "end" })`) because the transcript's
+ * Footer — the working indicator, the todo checklist, the question cards —
+ * renders BELOW the last item, and an item-aligned scroll leaves it under the
+ * fold. The browser clamps an over-large `scrollTop`, so no max() is needed.
+ * Instant only, deliberately: a smooth scroll toward a target that is still
+ * growing lands short, which is one of the ways the transcript used to detach.
+ */
+export function scrollElementToTail(el: HTMLElement | null): void {
+  if (!el) return;
+  el.scrollTop = el.scrollHeight;
+}
+
+/**
+ * Decide what a scroll event means for the transcript's "following" state.
+ *
+ * Returns the NEW following value, or `null` when the event carries no
+ * decision (leave the state alone). This is the whole reason the transcript no
+ * longer detaches on its own: content growing does not fire a scroll event, so
+ * it can never reach this function, and only a real position change can turn
+ * following off.
+ *
+ * - Landing within FOLLOW_THRESHOLD_PX of the bottom always means following,
+ *   whatever caused it (the user scrolling back down, our own tail scroll, or
+ *   the scroller clamping after the transcript shrank on /compact).
+ * - Moving UP while away from the bottom is the only thing that stops it.
+ */
+export const FOLLOW_THRESHOLD_PX = 64;
+
+export function classifyFollowOnScroll(
+  m: { scrollTop: number; scrollHeight: number; clientHeight: number },
+  prevScrollTop: number,
+): boolean | null {
+  const distanceFromBottom = m.scrollHeight - m.scrollTop - m.clientHeight;
+  if (distanceFromBottom <= FOLLOW_THRESHOLD_PX) return true;
+  if (m.scrollTop < prevScrollTop) return false;
+  return null;
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -118,6 +118,65 @@ html, body, #root {
   .manta-recording-dot { animation: none; }
 }
 
+/* Jump to latest (BET-933). The escape hatch shown when the transcript has
+   stopped following the tail. It floats over the BOTTOM OF THE TRANSCRIPT
+   (its container is the transcript region in ChatPanel, not the panel root)
+   so it clears the card stack and the composer, both of which change height.
+   Centred rather than right-aligned: the right-hand column already carries
+   the usage dial and the schedules/secrets/webhooks buttons.
+
+   Hidden AND out of the tab order while following — a permanently visible
+   control reads as chrome and gets ignored, which is the whole failure this
+   affordance exists to fix.
+
+   Tokens only. --sp-8 is the 32px hit area (the mockup's 34px snapped to the
+   spacing grid); --card / --border / --shadow-md is the standard floating-
+   surface trio; --accent-tx / --accent is IconButton's hover pair. The 8px
+   entry offset is --sp-2. It is NOT built on CardMount: that animates
+   height 0 -> auto, which is meaningless for an absolutely positioned circle. */
+.manta-jump-latest {
+  position: absolute;
+  left: 50%;
+  bottom: var(--sp-4);
+  z-index: 5;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: var(--sp-8);
+  height: var(--sp-8);
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: var(--r-full);
+  background: var(--card);
+  color: var(--tx2);
+  box-shadow: var(--shadow-md);
+  cursor: pointer;
+  opacity: 0;
+  transform: translate(-50%, var(--sp-2)) scale(0.96);
+  pointer-events: none;
+  transition:
+    opacity var(--motion-base) var(--ease-out),
+    transform var(--motion-base) var(--ease-out),
+    color var(--motion-fast) var(--ease-out),
+    border-color var(--motion-fast) var(--ease-out);
+}
+.manta-jump-latest[data-shown="true"] {
+  opacity: 1;
+  transform: translate(-50%, 0) scale(1);
+  pointer-events: auto;
+}
+.manta-jump-latest:hover {
+  color: var(--accent-tx);
+  border-color: var(--accent);
+}
+.manta-jump-latest:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .manta-jump-latest { transition: none; }
+}
+
 /* MantaLoader — the two counter-rotating arcs (src/renderer/MantaLoader.tsx).
    Speeds are the native client's, verbatim: 0.9s clockwise outer, 1.4s
    anticlockwise inner. The mismatched periods are what stop the pair reading


### PR DESCRIPTION
Implements BET-933: replaces the transcript's auto-follow (`followOutput`, which only fired on item-COUNT changes and silently detached the transcript on every height change — tool cards, streaming text, the Footer's working indicator) with one explicit "following" state turned off only by a scroll-up gesture, plus a jump-to-latest button escape hatch.

**Files changed:** 8 files.
- `src/renderer/chatUtils.ts` — `scrollElementToTail`, `classifyFollowOnScroll`, `FOLLOW_THRESHOLD_PX` (pure helpers).
- `src/renderer/ChatPanel.tsx` — `followingRef` + mirror state behind one setter; `scrollerElRef`; `scrollToTail()` rewritten to `scrollTop = scrollHeight` on the scroller element; jump-to-latest button.
- `src/renderer/Transcript.tsx` — deleted `followOutput`/`atBottomStateChange`/`atBottomThreshold`; added `scrollerRef` + `totalListHeightChanged` → `stickToTail`; the scroll listener → `classifyFollowOnScroll`; three new props.
- `src/renderer/index.css` — `.manta-jump-latest` rule set (copied verbatim from the issue).
- `src/renderer/chatUtils.test.ts` — 8 new pure tests (incl. a named REGRESSION for growth-not-detaching).
- `src/renderer/ChatPanel.harness.test.tsx` — deleted the ~50-line `vi.mock("react-virtuoso")` scaffold; rewrote the BET-802 test against the scroller element.
- `AGENTS.md` — rewrote the stale "Chat transcript pin-to-bottom" section.

**Base: origin/main @ 9347d583**

**Two documented deviations from the issue's constraint list (both mandatory to satisfy the issue's own green-build gate, no design choice made):**
1. `src/renderer/Transcript.test.tsx` is not on the allowed touch list, but its `props()` fixture passes the removed `onAtBottomChange` prop, which breaks typecheck once the required `scrollerElRef`/`followingRef`/`onFollowingChange` props land. I made the minimal 3-line fixture change (replaced that one line with the three new required props). Required to keep `npm run typecheck` green.
2. "Net line count must go DOWN" does not hold in aggregate: the issue mandates verbatim additions (the 59-line CSS block, 8 tests, 2 pure helpers with their spec doc-comments) that outweigh the removals (mock −50, AGENTS −32, dead props). Every added line is specified verbatim by the issue; I added nothing beyond it. Production files plus mandated additions net +158. The specific removal goals (mock, AGENTS, dead props) were all done.

**Verification results:**
- PR branch (`multica/BET-933-follow-transcript-tail` @ `fc73fb37`):
  - typecheck: exit 0. Errors: none. log sha256: `1f130f276b70a4dc1fefdfa6d919ee077b66b0c2ca1dc5d349f0b211ed032930`
  - test: exit 0. vitest 2687 pass / 7 skip; node:test 2050 pass / 0 fail. Failures: none. log sha256: `141701378e0a39b36a8759c24d9418d582842139ae7b7d9f79fb3caf7a73a02d`
- Base (`main` @ `9347d583`):
  - typecheck: exit 0. Errors: none. log sha256: `1f130f276b70a4dc1fefdfa6d919ee077b66b0c2ca1dc5d349f0b211ed032930`
  - test: exit 0. vitest 2679 pass / 7 skip; node:test 2050 pass / 0 fail. Failures: none. log sha256: `55dfb194279c61068c61c685ef8c900f2c3d9eb30b6c892f5ea7c68969d16ff2`
- **Conclusion:** 0 new failures. 8 new tests added (all pass). No failures resolved/regressed.
