### PR TITLE
BET-934: fix(renderer): cap the typeahead popup to the composer measure column

### DIFF
--- a/src/renderer/Composer.tsx
+++ b/src/renderer/Composer.tsx
@@ -15,8 +15,8 @@
 //
 // Attachment chips render INSIDE the InputArea box (BET-416 §B), so they are
 // threaded straight through via InputAreaProps; Composer no longer renders an
-// AttachmentStrip sibling above the box. The TypeaheadPopup still floats
-// ABOVE the box (it anchors to the box's top edge).
+// AttachmentStrip sibling above the box. The TypeaheadPopup renders directly
+// ABOVE the box in normal flow, measure-capped like the box itself (BET-934).
 //
 // The InputArea prop surface is large (~40 fields) and its type is declared
 // inline in InputArea.tsx, so rather than duplicate it we accept exactly
@@ -55,7 +55,7 @@ export function Composer({
       {/* Typeahead popup — shown the moment typeahead state is set, even */}
       {/* if the result list is still loading. Empty rows render a small */}
       {/* "Searching…" placeholder so the user sees instant feedback. Floats */}
-      {/* above the composer box (anchors to its top edge, BET-416 §C). */}
+      {/* renders directly above the composer box in normal flow, measure-capped like the box (BET-934). */}
       {typeahead && (
         <TypeaheadPopup
           rows={typeaheadRows}

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -18,6 +18,7 @@ import { formatClock, VOICE_TAP_HOLD_MS } from "../shared/waveform.mjs";
 // model/effort menus use (PaletteShell.tsx) — keeps the keyboard-selected
 // @-file row visible when it moves past the popup's scroll fold.
 import { useSelectedIntoView } from "./PaletteShell";
+import { MeasureColumn } from "./MeasureColumn";
 
 /**
  * The send glyph: lucide's paper plane as a SOLID shape.
@@ -364,10 +365,11 @@ export function PendingScreenshotStrip({
 
 // ===== Typeahead popup =====
 //
-// Anchored above the composer box's top edge. Card elevation (--card bg,
-// --border, --shadow-md), 12px radius, max-height with scroll. Keyboard
-// up/down/Enter/Tab/Esc nav is handled by InputArea — this component is
-// purely visual + mouse selection. The selected row uses --accent-bg.
+// Sits directly above the composer box in normal flow, inside the same 72ch
+// measure column so its edges align with the input box. Card elevation
+// (--card bg, --border, --shadow-md), 12px radius, max-height with scroll.
+// Keyboard up/down/Enter/Tab/Esc nav is handled by InputArea — this component
+// is purely visual + mouse selection. The selected row uses --accent-bg.
 
 export function TypeaheadPopup({
   rows,
@@ -383,42 +385,44 @@ export function TypeaheadPopup({
   emptyHint: string;
 }) {
   return (
-    <div
-      className="shrink-0 mx-4 mb-1 max-h-[240px] overflow-y-auto rounded-lg border border-border bg-bg-soft text-meta font-mono shadow-md"
-    >
-      {rows.length === 0 && (
-        <div className="px-2 py-1 text-text-faint italic">{emptyHint}</div>
-      )}
-      {rows.map((row, idx) => {
-        const active = idx === selectedIdx;
-        // Special-case the "no attachment support" warning row — render in
-        // red, non-selectable (clicking is a no-op).
-        const isWarning = row.kind === "file" && row.key === "" && row.primary.startsWith("⚠");
-        if (isWarning) {
-          return (
-            <div
-              key={`warn:${idx}`}
-              className="px-2 py-1 flex items-center gap-2 text-danger bg-danger-bg cursor-default"
-            >
-              <span className="truncate flex-1">{row.primary}</span>
-              {row.secondary && (
-                <span className="text-danger/70 truncate max-w-[50%] text-label">
-                  {row.secondary}
-                </span>
-              )}
-            </div>
-          );
-        }
-        return (
-          <TypeaheadRowButton
-            key={`${row.kind}:${row.key}`}
-            row={row}
-            active={active}
-            onSelect={() => onSelect(row)}
-            onHover={() => onHover(idx)}
-          />
-        );
-      })}
+    <div className="shrink-0">
+      <MeasureColumn>
+        <div className="mb-1 max-h-[240px] overflow-y-auto rounded-lg border border-border bg-bg-soft text-meta font-mono shadow-md">
+          {rows.length === 0 && (
+            <div className="px-2 py-1 text-text-faint italic">{emptyHint}</div>
+          )}
+          {rows.map((row, idx) => {
+            const active = idx === selectedIdx;
+            // Special-case the "no attachment support" warning row — render in
+            // red, non-selectable (clicking is a no-op).
+            const isWarning = row.kind === "file" && row.key === "" && row.primary.startsWith("⚠");
+            if (isWarning) {
+              return (
+                <div
+                  key={`warn:${idx}`}
+                  className="px-2 py-1 flex items-center gap-2 text-danger bg-danger-bg cursor-default"
+                >
+                  <span className="truncate flex-1">{row.primary}</span>
+                  {row.secondary && (
+                    <span className="text-danger/70 truncate max-w-[50%] text-label">
+                      {row.secondary}
+                    </span>
+                  )}
+                </div>
+              );
+            }
+            return (
+              <TypeaheadRowButton
+                key={`${row.kind}:${row.key}`}
+                row={row}
+                active={active}
+                onSelect={() => onSelect(row)}
+                onHover={() => onHover(idx)}
+              />
+            );
+          })}
+        </div>
+      </MeasureColumn>
     </div>
   );
 }


### PR DESCRIPTION
## BET-934 — Composer typeahead dropdown (/ and @) spans full width

Feed the typeahead popup through `MeasureColumn` (the composer's own reading-column primitive) and drop its `mx-4`, so the dropdown's left/right edges line up exactly with the composer input box on wide windows. On narrow windows it fills the available width the same way the composer does.

**Files changed:** 2
- `src/renderer/ComposerParts.tsx` — wrap `TypeaheadPopup`'s content in `MeasureColumn` (default `width="measure"`, `stacked={false}`, no props); `shrink-0` stays on the outer plain `div`; removed `mx-4`; added the `MeasureColumn` import; updated the popup's descriptive comment.
- `src/renderer/Composer.tsx` — comment-only tidy-up (the popup no longer "floats/anchors" — it renders directly above the box in normal flow, measure-capped like the box). No logic change.

**Verification results:**
- PR branch (`multica/BET-934-typeahead-measure` @ `79e7bda7`):
  - typecheck: exit 0. Errors: none. log sha256: `1f130f276b70a4dc1fefdfa6d919ee077b66b0c2ca1dc5d349f0b211ed032930`
  - test: exit 0, 2050 pass / 0 fail / 0 skip. Failures: none. log sha256: `7b0923e2c2b81cf9daa85ff3bbe6608cc9f69593ff2e982d700652919737e39b`
- Base (`main` @ `f169b64b`):
  - typecheck: exit 0. Errors: none. log sha256: `1f130f276b70a4dc1fefdfa6d919ee077b66b0c2ca1dc5d349f0b211ed032930`
  - test: exit 0, 2050 pass / 0 fail / 0 skip. Failures: none. log sha256: `751dc7059eb5f2faf38cf66d27473a84f9a753ca7f98c733cca31c730813c145`
- **Conclusion:** 0 new failures. Both branches identical (2050 pass / 0 fail). This change touches no pure logic, so no new unit test is required (per issue scope).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ f169b64b**
