### PR TITLE
chore(ios): rejoin the pre-rewrite version line at 1.0.17

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2375,9 +2375,20 @@ after processing, long before a human sees it.
 ### Versioning
 
 `MARKETING_VERSION` (CFBundleShortVersionString) lives in
-`project.pbxproj` (both Debug+Release). Bump it to ship a new TestFlight
-version; the auto-tag workflow keys off it. `CURRENT_PROJECT_VERSION` (build
-number) — Codemagic/ASC handle uniqueness. First shipped version: `1.0.1`.
+`mobile/native/project.yml` (the xcodegen source of truth; the pbxproj is
+derived from it). Bump it to ship a new TestFlight build; the auto-tag workflow
+keys off it. `CURRENT_PROJECT_VERSION` (build number) — Codemagic/ASC handle
+uniqueness. First shipped version: `1.0.1`.
+
+**The version line is CONTINUOUS across the Swift rewrite — do not reset it.**
+The Capacitor app shipped up to `1.0.16`; the native rewrite started its own
+`project.yml` at `0.1.0` and shipped `0.1.0`–`0.1.2`, which reads to a tester as
+the app going BACKWARDS (TestFlight sorts them below every build they already
+had, and the pre-release version list interleaves two unrelated trains). The
+line was rejoined at **`1.0.17`** on 2026-08-14. Anything numbered `0.x` is
+from that brief window — never bump into `0.x` again, and never "start fresh"
+on a rewrite: the users' install history is the thing being versioned, not the
+codebase's.
 
 ## Release & CD pipeline — TAG-DRIVEN, one manual step
 

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -88,7 +88,7 @@ targets:
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         TARGETED_DEVICE_FAMILY: "1,2"
-        MARKETING_VERSION: "0.1.2"
+        MARKETING_VERSION: "1.0.17"
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Automatic
         SWIFT_EMIT_LOC_STRINGS: YES


### PR DESCRIPTION
TestFlight numbering regression from the Swift rewrite.

| | |
|---|---|
| Capacitor app shipped up to | `1.0.16` |
| Native rewrite shipped | `0.1.0` → `0.1.2` |
| This PR | `1.0.17` |

A tester on 1.0.16 sees the 0.1.x builds sort *below* what they already have, and the pre-release version list interleaves two unrelated trains. This bumps `MARKETING_VERSION` to **1.0.17** and writes the rule into AGENTS.md: the version line is continuous across a rewrite — the users' install history is the thing being versioned, not the codebase's.

`CURRENT_PROJECT_VERSION` stays `1`: build numbers are only required to be unique within a marketing version, and `1.0.17` is a fresh one.

Merging auto-creates `ios-v1.0.17` and fires the Codemagic TestFlight build (which now carries the export-compliance fix from #933).