### PR TITLE
Sidebar: route all destructive confirms through ConfirmModal (BET-935)

### DIFF
--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -781,7 +781,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                           return (
                             <JobChildRow
                               key={`job:${p.tmuxSession}:${childIdx}`}
-                              project={p}
                               window={childWin}
                               isActive={childActive}
                               status={statusFor(p.tmuxSession, childIdx)}
@@ -1182,7 +1181,6 @@ function WindowRow({
 // tree connector. Only running jobs (or the currently-viewed terminal job)
 // reach this component — the parent filters the rest.
 function JobChildRow({
-  project,
   window: w,
   isActive,
   status,
@@ -1192,7 +1190,6 @@ function JobChildRow({
   onClose,
   title,
 }: {
-  project: Project;
   window: TmuxWindow;
   isActive: boolean;
   status: WindowStatusUI | undefined;

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -6,7 +6,7 @@ import {
   useMemo,
   useState,
 } from "react";
-import type { ReactElement, ReactNode } from "react";
+import type { ReactElement } from "react";
 import { ChevronRight, ChevronDown, X, Pin, Search } from "lucide-react";
 import { useStore, flatSessions, type WindowStatusUI } from "./store";
 import { nowMs, useAgeTick } from "./clock";
@@ -22,9 +22,14 @@ import {
   resolvePin,
   selectCacheTtlMs,
   windowPinId,
+  describeProjectClose,
+  describeSessionClose,
 } from "./chatUtils";
 import { IS_WINDOWS, MOD_KEY } from "./platform";
 import { SessionRow as RailSessionRow, type SessionStatus } from "./SessionRow";
+import { ConfirmModal } from "./ConfirmModal";
+import { Modal } from "./Modal";
+import { Button } from "./Button";
 
 const COLLAPSE_KEY = "manta:collapsed-projects";
 
@@ -386,10 +391,10 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     }
   };
 
-  // Delete / ContextMenu → the SAME inline ConfirmDelete the right-click path
-  // already opens (BET-726 Task 2.1) — right-click's onContextMenu just calls
-  // this same setConfirmDeleteFor shape, so there is no separate "menu" to
-  // build for the ContextMenu key either.
+  // Delete / ContextMenu → the same confirm the right-click path already
+  // opens (BET-726 Task 2.1) — right-click's onContextMenu just calls this
+  // same setConfirmDeleteFor shape, so there is no separate "menu" to build
+  // for the ContextMenu key either.
   const requestDeleteFocused = () => {
     if (!focusedKey) return;
     if (focusedKey.startsWith("group:")) {
@@ -691,12 +696,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                   commitRename={commitRename}
                   cancelRename={() => setRenameTarget(null)}
                   title={rowTitle(r.window)}
-                  confirmDeleteFor={confirmDeleteFor}
-                  setConfirmDeleteFor={setConfirmDeleteFor}
-                  onKillWindow={() => killWindow(r.project.tmuxSession, r.window.index)}
-                  onKillWorktreeDirty={(wtPath, force) =>
-                    killWorktreeDirtyAndClose(r.project.tmuxSession, r.window.index, wtPath, force)
-                  }
                 />
               ))}
             </div>
@@ -732,15 +731,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                   startRename({ kind: "project", old: p.tmuxSession }, p.tmuxSession)
                 }
               />
-
-              {confirmDeleteFor?.kind === "project" &&
-                confirmDeleteFor.project === p.tmuxSession && (
-                  <ConfirmDelete
-                    label={`project "${p.tmuxSession}"`}
-                    onKill={() => killProject(p.tmuxSession)}
-                    onCancel={() => setConfirmDeleteFor(null)}
-                  />
-                )}
 
               {!isCollapsed && (
                 <div className="pl-2 space-y-px mt-px">
@@ -783,12 +773,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                           commitRename={commitRename}
                           cancelRename={() => setRenameTarget(null)}
                           title={rowTitle(w)}
-                          confirmDeleteFor={confirmDeleteFor}
-                          setConfirmDeleteFor={setConfirmDeleteFor}
-                          onKillWindow={() => killWindow(p.tmuxSession, w.index)}
-                          onKillWorktreeDirty={(wtPath, force) =>
-                            killWorktreeDirtyAndClose(p.tmuxSession, w.index, wtPath, force)
-                          }
                         />
                         {kids.map((childIdx, i) => {
                           const childWin = p.windows.find((x) => x.index === childIdx);
@@ -813,9 +797,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                                 })
                               }
                               title={rowTitle(childWin)}
-                              confirmDeleteFor={confirmDeleteFor}
-                              setConfirmDeleteFor={setConfirmDeleteFor}
-                              onKillWindow={() => killWindow(p.tmuxSession, childIdx)}
                             />
                           );
                         })}
@@ -881,6 +862,115 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
       )}
 
       {inboxOpen && <InboxPalette onClose={() => setInboxOpen(false)} />}
+
+      {/*
+        Destructive-confirm surfaces (BET-935). Both sit at the Sidebar root,
+        as siblings of the palettes and OUTSIDE the scroll container, so no row
+        ever shifts when one opens. D1 is the two-way ConfirmModal (session /
+        project close); D2 is the three-way dirty-worktree modal built on the
+        raw Modal primitive (ConfirmModal renders exactly Cancel + one confirm,
+        and the dirty case has three outcomes).
+      */}
+      {(() => {
+        const c = confirmDeleteFor;
+        if (!c || c.kind === "worktree-dirty") {
+          // Keep the modal MOUNTED with open={false} so its exit animation plays.
+          return (
+            <ConfirmModal
+              open={false}
+              title=""
+              body=""
+              confirmLabel=""
+              onConfirm={() => {}}
+              onCancel={() => setConfirmDeleteFor(null)}
+            />
+          );
+        }
+        const proj = projects.find((p) => p.tmuxSession === c.project);
+        const copy =
+          c.kind === "session"
+            ? describeSessionClose({
+                name: c.name,
+                running: statusFor(c.project, c.index)?.running ?? false,
+                worktreePath: worktreeCleanOnClose
+                  ? (proj?.windows.find((w) => w.index === c.index)?.worktreePath ?? null)
+                  : null,
+              })
+            : describeProjectClose({
+                name: c.project,
+                sessionCount: proj?.windows.length ?? 0,
+                runningCount:
+                  proj?.windows.filter((w) => statusFor(c.project, w.index)?.running).length ?? 0,
+                // Project close does NOT remove worktrees yet. Workstream 3 adds
+                // that AND flips this to the real count. Do not pass a count here.
+                worktreeCount: 0,
+              });
+        return (
+          <ConfirmModal
+            open
+            title={copy.title}
+            body={copy.body}
+            confirmLabel={copy.confirmLabel}
+            onConfirm={() => {
+              if (c.kind === "session") void killWindow(c.project, c.index);
+              else void killProject(c.project);
+            }}
+            onCancel={() => setConfirmDeleteFor(null)}
+          />
+        );
+      })()}
+
+      <Modal
+        size="sm"
+        open={confirmDeleteFor?.kind === "worktree-dirty"}
+        onDismiss={() => setConfirmDeleteFor(null)}
+        label="Uncommitted changes in this worktree"
+      >
+        <div className="space-y-4">
+          <h3 className="text-title font-semibold">Uncommitted changes in this worktree</h3>
+          <div className="text-body text-text-faint">
+            <code className="break-all">
+              {confirmDeleteFor?.kind === "worktree-dirty" ? confirmDeleteFor.worktreePath : ""}
+            </code>{" "}
+            has uncommitted changes. Removing the worktree will permanently delete that work.
+          </div>
+          <div className="flex justify-end gap-2">
+            <Button tone="ghost" onClick={() => setConfirmDeleteFor(null)}>
+              Cancel
+            </Button>
+            <Button
+              tone="default"
+              onClick={() => {
+                if (confirmDeleteFor?.kind === "worktree-dirty") {
+                  void killWorktreeDirtyAndClose(
+                    confirmDeleteFor.project,
+                    confirmDeleteFor.index,
+                    confirmDeleteFor.worktreePath,
+                    false,
+                  );
+                }
+              }}
+            >
+              Keep worktree
+            </Button>
+            <Button
+              tone="danger"
+              onClick={() => {
+                if (confirmDeleteFor?.kind === "worktree-dirty") {
+                  void killWorktreeDirtyAndClose(
+                    confirmDeleteFor.project,
+                    confirmDeleteFor.index,
+                    confirmDeleteFor.worktreePath,
+                    true,
+                  );
+                }
+              }}
+            >
+              Remove worktree
+            </Button>
+          </div>
+        </div>
+      </Modal>
     </aside>
   );
 });
@@ -971,32 +1061,20 @@ function PinSlot({
 }
 
 // One composed session row: the SessionRow primitive PLUS the session delete
-// affordance. Right-clicking a row requests the delete confirm (the same
-// context-menu behaviour both window and job rows share) and, when armed, the
-// ConfirmDelete dialog renders below the row. Both the top-level window rows
-// and the nested job rows render through this, so the delete-on-context-menu
-// handler + ConfirmDelete block live in exactly ONE place — without it the
-// SessionRow migration would reintroduce the 17-line clone between
-// WindowRow/JobChildRow that BET-536 is supposed to remove.
+// affordance. Right-clicking a row requests the delete confirm (BET-935 routes
+// the confirm into the shared root modal rather than rendering it inline
+// below the row). Both the top-level window rows and the nested job rows
+// render through this, so the delete-on-context-menu handler lives in exactly
+// ONE place — without it the SessionRow migration would reintroduce the
+// 17-line clone between WindowRow/JobChildRow that BET-536 is supposed to
+// remove.
 function DeletableSessionRow({
   row,
-  showConfirm,
-  label,
-  onKill,
-  onCancel,
   onRequestDelete,
-  children,
 }: {
   /** The SessionRow element; its onContextMenu is overridden to request the delete. */
   row: ReactElement;
-  showConfirm: boolean;
-  /** ConfirmDelete label, e.g. `session "Deploy"`. */
-  label: string;
-  onKill: () => void;
-  onCancel: () => void;
   onRequestDelete: () => void;
-  /** Optional extra sibling confirm dialogs (e.g. the worktree-dirty prompt). */
-  children?: ReactNode;
 }) {
   return (
     <div>
@@ -1007,8 +1085,6 @@ function DeletableSessionRow({
           onRequestDelete();
         },
       })}
-      {showConfirm && <ConfirmDelete label={label} onKill={onKill} onCancel={onCancel} />}
-      {children}
     </div>
   );
 }
@@ -1034,10 +1110,6 @@ function WindowRow({
   commitRename,
   cancelRename,
   title,
-  confirmDeleteFor,
-  setConfirmDeleteFor,
-  onKillWindow,
-  onKillWorktreeDirty,
 }: {
   project: Project;
   window: TmuxWindow;
@@ -1058,23 +1130,11 @@ function WindowRow({
   commitRename: () => void;
   cancelRename: () => void;
   title: string;
-  confirmDeleteFor: ConfirmDeleteFor;
-  setConfirmDeleteFor: (v: ConfirmDeleteFor) => void;
-  onKillWindow: () => void;
-  onKillWorktreeDirty: (wtPath: string, force: boolean) => void;
 }) {
   const isRenaming =
     renameTarget?.kind === "window" &&
     renameTarget.project === project.tmuxSession &&
     renameTarget.index === w.index;
-  const showConfirm =
-    confirmDeleteFor?.kind === "session" &&
-    confirmDeleteFor.project === project.tmuxSession &&
-    confirmDeleteFor.index === w.index;
-  const showWorktreeConfirm =
-    confirmDeleteFor?.kind === "worktree-dirty" &&
-    confirmDeleteFor.project === project.tmuxSession &&
-    confirmDeleteFor.index === w.index;
   const dot = dotFor(status);
   const age = useAge(status);
   return (
@@ -1113,20 +1173,8 @@ function WindowRow({
           onClick={onActivate}
         />
       }
-      showConfirm={showConfirm}
-      label={`session "${w.name}"`}
-      onKill={onKillWindow}
-      onCancel={() => setConfirmDeleteFor(null)}
       onRequestDelete={onClose}
-    >
-      {showWorktreeConfirm && confirmDeleteFor?.kind === "worktree-dirty" && (
-        <ConfirmWorktreeDirty
-          worktreePath={confirmDeleteFor.worktreePath}
-          onRemove={() => onKillWorktreeDirty(confirmDeleteFor.worktreePath, true)}
-          onKeep={() => onKillWorktreeDirty(confirmDeleteFor.worktreePath, false)}
-        />
-      )}
-    </DeletableSessionRow>
+    />
   );
 }
 
@@ -1143,9 +1191,6 @@ function JobChildRow({
   onActivate,
   onClose,
   title,
-  confirmDeleteFor,
-  setConfirmDeleteFor,
-  onKillWindow,
 }: {
   project: Project;
   window: TmuxWindow;
@@ -1156,14 +1201,7 @@ function JobChildRow({
   onActivate: () => void;
   onClose: () => void;
   title: string;
-  confirmDeleteFor: ConfirmDeleteFor;
-  setConfirmDeleteFor: (v: ConfirmDeleteFor) => void;
-  onKillWindow: () => void;
 }) {
-  const showConfirm =
-    confirmDeleteFor?.kind === "session" &&
-    confirmDeleteFor.project === project.tmuxSession &&
-    confirmDeleteFor.index === w.index;
   const dot = dotFor(status);
   const age = useAge(status);
   return (
@@ -1185,10 +1223,6 @@ function JobChildRow({
           onClick={onActivate}
         />
       }
-      showConfirm={showConfirm}
-      label={`session "${w.name}"`}
-      onKill={onKillWindow}
-      onCancel={() => setConfirmDeleteFor(null)}
       onRequestDelete={onClose}
     />
   );
@@ -1430,81 +1464,3 @@ function RenameInput({
   );
 }
 
-function ConfirmDelete({
-  label,
-  onKill,
-  onCancel,
-}: {
-  label: string;
-  onKill: () => void;
-  onCancel: () => void;
-}) {
-  return (
-    <div className="ml-2 mt-1 mb-1 px-2 py-2 rounded-xs bg-bg-soft border border-border space-y-2">
-      <div className="text-meta text-text-muted">Close {label}?</div>
-      <div className="flex flex-wrap gap-1">
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onKill();
-          }}
-          className="text-meta px-2 py-px rounded-xs bg-transparent text-danger hover:bg-danger-bg focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
-          title="kill the tmux session/window on the remote"
-        >
-          Kill on server
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onCancel();
-          }}
-          className="text-meta px-2 py-px text-text-faint hover:text-text"
-        >
-          Cancel
-        </button>
-      </div>
-    </div>
-  );
-}
-
-function ConfirmWorktreeDirty({
-  worktreePath,
-  onRemove,
-  onKeep,
-}: {
-  worktreePath: string;
-  onRemove: () => void;
-  onKeep: () => void;
-}) {
-  return (
-    <div className="ml-2 mt-1 mb-1 px-2 py-2 rounded-xs bg-bg-soft border border-border space-y-2">
-      <div className="text-meta text-text-muted">
-        <code className="break-all">{worktreePath}</code> has uncommitted
-        changes. Removing the worktree will permanently delete that work.
-        Remove anyway?
-      </div>
-      <div className="flex flex-wrap gap-1">
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onRemove();
-          }}
-          className="text-meta px-2 py-px rounded-xs bg-transparent text-danger hover:bg-danger-bg focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent"
-          title="git worktree remove --force (discards uncommitted changes)"
-        >
-          Remove
-        </button>
-        <button
-          onClick={(e) => {
-            e.stopPropagation();
-            onKeep();
-          }}
-          className="text-meta px-2 py-px text-text-faint hover:text-text"
-          title="leave the worktree + branch on disk; just close the session"
-        >
-          Keep worktree
-        </button>
-      </div>
-    </div>
-  );
-}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -124,6 +124,8 @@ import {
   scrollElementToTail,
   classifyFollowOnScroll,
   FOLLOW_THRESHOLD_PX,
+  describeSessionClose,
+  describeProjectClose,
 } from "./chatUtils";
 
 import type { OpencodeModel, UsageSnapshot, OpencodeMessage, VoiceNoteRecord, ForgeInboxItem } from "../shared/types";
@@ -4676,5 +4678,115 @@ describe("classifyFollowOnScroll", () => {
     expect(
       classifyFollowOnScroll({ scrollTop: 900, scrollHeight: 1000, clientHeight: 100 }, 999999),
     ).toBe(true);
+  });
+});
+
+// ===== describeSessionClose / describeProjectClose (BET-935) =====
+
+describe("describeSessionClose", () => {
+  it("idle + no worktree → exact single sentence", () => {
+    expect(describeSessionClose({ name: "Deploy", running: false, worktreePath: null })).toEqual({
+      title: 'Close “Deploy”?',
+      body: "Its tmux window will be killed on the box.",
+      confirmLabel: "Close session",
+    });
+  });
+
+  it("running → body ends with the running-turn sentence", () => {
+    const r = describeSessionClose({ name: "Deploy", running: true, worktreePath: null });
+    expect(r.body).toMatch(/A turn is currently running and will be stopped\.$/);
+  });
+
+  it("worktree → body contains the literal path", () => {
+    const r = describeSessionClose({
+      name: "Deploy",
+      running: false,
+      worktreePath: "/srv/manta/ethernal",
+    });
+    expect(r.body).toContain("/srv/manta/ethernal");
+  });
+
+  it("running + worktree → all three sentences, in order", () => {
+    const r = describeSessionClose({
+      name: "Deploy",
+      running: true,
+      worktreePath: "/srv/manta/ethernal",
+    });
+    expect(r.body).toBe(
+      "Its tmux window will be killed on the box. " +
+        "A turn is currently running and will be stopped. " +
+        "Its worktree at /srv/manta/ethernal will be removed.",
+    );
+  });
+
+  it("title quotes the name with curly quotes", () => {
+    const r = describeSessionClose({ name: "api", running: false, worktreePath: null });
+    expect(r.title).toBe("Close “api”?");
+  });
+});
+
+describe("describeProjectClose", () => {
+  it("0 sessions → no count clause in title, tmux-session body variant", () => {
+    const r = describeProjectClose({
+      name: "orphan",
+      sessionCount: 0,
+      runningCount: 0,
+      worktreeCount: 0,
+    });
+    expect(r.title).toBe("Close “orphan”?");
+    expect(r.body).toBe("Its tmux session will be killed on the box.");
+    expect(r.confirmLabel).toBe("Close project");
+  });
+
+  it("1 session → singular count clauses", () => {
+    const r = describeProjectClose({
+      name: "manta",
+      sessionCount: 1,
+      runningCount: 0,
+      worktreeCount: 0,
+    });
+    expect(r.title).toBe("Close “manta” and its 1 session?");
+    expect(r.body).toBe("All 1 tmux window will be killed on the box.");
+  });
+
+  it("4 sessions, 2 running → plural mid-turn sentence", () => {
+    const r = describeProjectClose({
+      name: "manta",
+      sessionCount: 4,
+      runningCount: 2,
+      worktreeCount: 0,
+    });
+    expect(r.body).toContain("2 sessions are mid-turn and will be stopped.");
+  });
+
+  it("4 sessions, 1 running → singular mid-turn sentence", () => {
+    const r = describeProjectClose({
+      name: "manta",
+      sessionCount: 4,
+      runningCount: 1,
+      worktreeCount: 0,
+    });
+    expect(r.body).toContain("1 session is mid-turn and will be stopped.");
+  });
+
+  it("runningCount 0 → mid-turn sentence absent (never '0 sessions are…')", () => {
+    const r = describeProjectClose({
+      name: "manta",
+      sessionCount: 4,
+      runningCount: 0,
+      worktreeCount: 0,
+    });
+    expect(r.body).not.toContain("mid-turn");
+    expect(r.body).not.toContain("0 sessions");
+  });
+
+  it("worktreeCount 0 → worktree sentence absent", () => {
+    const r = describeProjectClose({
+      name: "manta",
+      sessionCount: 4,
+      runningCount: 1,
+      worktreeCount: 0,
+    });
+    expect(r.body).not.toContain("worktree");
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3420,3 +3420,61 @@ export function classifyFollowOnScroll(
   if (m.scrollTop < prevScrollTop) return false;
   return null;
 }
+
+/**
+ * Confirm copy for destructive "Close" actions in the sidebar rail (BET-935).
+ * Pure string assembly so the confirm wording is testable without a DOM.
+ */
+
+export type CloseConfirmCopy = {
+  title: string;
+  body: string;
+  confirmLabel: string;
+};
+
+/** Confirm copy for closing ONE session (a tmux window). */
+export function describeSessionClose(args: {
+  name: string;
+  /** true when a turn is in flight for this window. */
+  running: boolean;
+  /** The worktree that WILL be removed, or null when none will be. */
+  worktreePath: string | null;
+}): CloseConfirmCopy {
+  const parts = ["Its tmux window will be killed on the box."];
+  if (args.running) parts.push("A turn is currently running and will be stopped.");
+  if (args.worktreePath) parts.push(`Its worktree at ${args.worktreePath} will be removed.`);
+  return {
+    title: `Close “${args.name}”?`,
+    body: parts.join(" "),
+    confirmLabel: "Close session",
+  };
+}
+
+/** Confirm copy for closing a WHOLE project (a tmux session). */
+export function describeProjectClose(args: {
+  name: string;
+  sessionCount: number;
+  runningCount: number;
+  /** Worktrees that WILL be removed. Pass 0 when project close does not remove them. */
+  worktreeCount: number;
+}): CloseConfirmCopy {
+  const { name, sessionCount, runningCount, worktreeCount } = args;
+  const title =
+    sessionCount === 0
+      ? `Close “${name}”?`
+      : `Close “${name}” and its ${sessionCount} session${sessionCount === 1 ? "" : "s"}?`;
+  const parts = [
+    sessionCount === 0
+      ? "Its tmux session will be killed on the box."
+      : `All ${sessionCount} tmux window${sessionCount === 1 ? "" : "s"} will be killed on the box.`,
+  ];
+  if (runningCount > 0) {
+    parts.push(
+      `${runningCount} session${runningCount === 1 ? " is" : "s are"} mid-turn and will be stopped.`,
+    );
+  }
+  if (worktreeCount > 0) {
+    parts.push(`${worktreeCount} worktree${worktreeCount === 1 ? "" : "s"} will be removed.`);
+  }
+  return { title, body: parts.join(" "), confirmLabel: "Close project" };
+}


### PR DESCRIPTION
## BET-935 — Sidebar: route all destructive confirms through ConfirmModal, delete the two bespoke inline confirms

Workstream 1 of 4. **Net deletion** (~174 lines in Sidebar.tsx). No new dialog/confirm component, no right-click context menu changes, no undo.

### What changed

**Task A — pure copy builders (with tests)**
- Added `describeSessionClose` / `describeProjectClose` (+ `CloseConfirmCopy` type) to `src/renderer/chatUtils.ts`, and 11 exact-string tests in `chatUtils.test.ts`.

**Task B — deleted the two bespoke components**
- Removed `ConfirmDelete` and `ConfirmWorktreeDirty` entirely from `Sidebar.tsx` (both now-dead inline confirms).

**Task C — removed all four inline render sites + dead props**
- Pinned section, under the project header, under top-level window rows, and under job child rows no longer render a confirm.
- Simplified `DeletableSessionRow` to the context-menu wrapper only (right-click still requests the delete).
- Dropped the now-unused `confirmDeleteFor` / `setConfirmDeleteFor` / `onKillWindow` / `onKillWorktreeDirty` props from `WindowRow`, `JobChildRow`, and the surplus `project` prop from `JobChildRow`'s type.

**Task D — two render surfaces at the Sidebar root** (siblings of the palettes, outside the scroll container):
- **D1** — two-way `ConfirmModal` (session / project close), copy derived from `confirmDeleteFor` via the new builders; mounted-but-closed elsewhere so the exit animation plays.
- **D2** — three-way dirty-worktree modal on the raw `<Modal size="sm">` primitive (ConfirmModal is exactly Cancel + one confirm; the dirty case has three outcomes). No secondary-action prop added to ConfirmModal. Both action buttons call the unchanged `killWorktreeDirtyAndClose(project, index, worktreePath, force)`.

### Honoured constraints
- `ConfirmDeleteFor` union and `confirmDeleteFor` state unchanged.
- `killWindow` / `killWorktreeDirtyAndClose` / `killProject` behaviour unchanged (only who renders the confirm changed).
- Keyboard / right-click / Delete / Backspace / ContextMenu triggers untouched (workstream 3 owns the keyboard).
- `SessionHeader`'s "Delete session" wording untouched (it is the only surface allowed to say "Delete").
- `showNotice("Kept worktree at …")` toast preserved.
- **`worktreeCount: 0` for project close is deliberate** — closing a project removes no worktrees today; workstream 3 flips it.
- Vocabulary: `git grep` shows no "Kill on server" / "Kill" in any user-visible string across `src/renderer/`.

### Cross-cutting note
Workstreams 2 and 3 are sequenced after this one and edit the same `Sidebar.tsx` regions (lines ~780–800 and the root confirm surfaces). Expected to conflict and be rebased in sequence.

**Base: origin/main @ a4142986**
