### PR TITLE
Sidebar: require ⌘⌫ for destructive keys, add Home/End, fix project-close leaks (BET-937)

### DIFF
--- a/src/renderer/Sidebar.test.tsx
+++ b/src/renderer/Sidebar.test.tsx
@@ -125,3 +125,96 @@ describe("Sidebar — nested-control keydown guard (BET-726 review cycle 1 Block
     expect((renameInput as HTMLInputElement).value).toBe("win");
   });
 });
+
+describe("Sidebar — destructive-key modifier gate + Home/End (BET-937)", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    // localStorage persists across tests in this file; clear it so the
+    // sidebar's collapse/pin state can't leak in from an earlier test and
+    // change the nav-order this block asserts on.
+    localStorage.clear();
+    installMockApi({
+      configUpdate: (patch: Record<string, unknown>) =>
+        Promise.resolve({ pinnedWindows: (patch as { pinnedWindows?: string[] }).pinnedWindows ?? [] }),
+    });
+    resetStore({
+      // pinnedWindows must be empty: a prior test toggles a pin and zustand
+      // keeps it across tests otherwise, which would change navKeys ordering.
+      pinnedWindows: [],
+      projects: [
+        proj({
+          tmuxSession: "proj",
+          windows: [
+            { index: 0, name: "win", active: true, paneCurrentPath: "/x", opencodeSessionId: null },
+          ],
+        }),
+      ],
+    });
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function mountSidebar(): Harness {
+    h = mount(
+      <Sidebar onOpenSettings={() => {}} onNewProject={() => {}} onNewSessionInProject={() => {}} />,
+    );
+    return h;
+  }
+
+  function focusWindowRow() {
+    const tree = h!.container.querySelector('[role="tree"]') as HTMLElement;
+    act(() => {
+      tree.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    });
+    act(() => {
+      tree.dispatchEvent(new KeyboardEvent("keydown", { key: "ArrowDown", bubbles: true }));
+    });
+  }
+
+  function keyOnTree(key: string, init: { metaKey?: boolean; ctrlKey?: boolean } = {}) {
+    const tree = h!.container.querySelector('[role="tree"]') as HTMLElement;
+    act(() => {
+      tree.dispatchEvent(new KeyboardEvent("keydown", { key, bubbles: true, ...init }));
+    });
+  }
+
+  it("bare Backspace/Delete on a focused row does nothing (no confirm)", () => {
+    mountSidebar();
+    focusWindowRow();
+    keyOnTree("Backspace");
+    keyOnTree("Delete");
+    // The delete confirm renders through a portal to document.body.
+    expect(h!.docText()).not.toContain("Close session");
+  });
+
+  it("⌘⌫ opens the confirm for the focused row", () => {
+    mountSidebar();
+    focusWindowRow();
+    keyOnTree("Backspace", { metaKey: true });
+    expect(h!.docText()).toContain("Close session");
+  });
+
+  it("Ctrl+Delete opens the confirm for the focused row", () => {
+    mountSidebar();
+    focusWindowRow();
+    keyOnTree("Delete", { ctrlKey: true });
+    expect(h!.docText()).toContain("Close session");
+  });
+
+  it("Home and End jump to the first / last rail row", () => {
+    mountSidebar();
+    keyOnTree("End");
+    const endItems = h!.container.querySelectorAll('[role="treeitem"]');
+    const focusedEnd = [...endItems].find((el) => el.getAttribute("tabindex") === "0");
+    expect(focusedEnd?.textContent).toContain("win");
+
+    keyOnTree("Home");
+    const homeItems = h!.container.querySelectorAll('[role="treeitem"]');
+    const focusedHome = [...homeItems].find((el) => el.getAttribute("tabindex") === "0");
+    expect(focusedHome?.textContent).toContain("proj");
+  });
+});

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -20,6 +20,7 @@ import {
   fuzzySessionScore,
   isJobRow,
   resolvePin,
+  projectForNavKey,
   selectCacheTtlMs,
   windowPinId,
   describeProjectClose,
@@ -139,11 +140,20 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   useImperativeHandle(ref, () => ({
     openNewProject: () => onNewProject(),
     openNewSessionInActive: () => {
-      if (activeProjectName) {
-        onNewSessionInProject(activeProjectName);
+      // ⌘T follows rail focus first (BET-937): the project the user is
+      // actually looking at, then the active project, else nothing. A pin
+      // resolves via resolvePin; win/job/group keys name their session
+      // directly.
+      let target: string | null = projectForNavKey(focusedKey);
+      if (!target && focusedKey?.startsWith("pin:")) {
+        target = resolvePin(projects, focusedKey.slice("pin:".length))?.project.tmuxSession ?? null;
+      }
+      target ??= activeProjectName;
+      if (target) {
+        onNewSessionInProject(target);
         setCollapsed((prev) => {
           const next = new Set(prev);
-          next.delete(activeProjectName);
+          next.delete(target);
           return next;
         });
       }
@@ -234,11 +244,48 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
 
   const killProject = async (project: string) => {
     setConfirmDeleteFor(null);
+    // BET-937 Task 2A: honour worktreeCleanOnClose when destroying a project.
+    // Remove every clean worktree the project's sessions owned; a dirty one
+    // is kept (never force-removed, no per-worktree confirm). Do this BEFORE
+    // the tmux kill so a worktree can't be half-destroyed mid-close, but a
+    // failure here must never abort the kill — killing the tmux session is
+    // the user's actual intent and always happens.
+    const proj = projects.find((p) => p.tmuxSession === project);
+    const skipped: string[] = [];
+    if (worktreeCleanOnClose && proj) {
+      const wtPaths = proj.windows
+        .map((w) => w.worktreePath)
+        .filter((p): p is string => p != null);
+      for (const path of wtPaths) {
+        try {
+          const res = await window.api.gitRemoveWorktree({ path, force: false });
+          if (res && res.removed === false && res.reason === "dirty") {
+            skipped.push(path);
+          }
+        } catch (e) {
+          showError(e);
+        }
+      }
+    }
     try {
       await window.api.tmuxKillSession(project);
+      try {
+        // BET-937 Task 2C: drop the project's stored metadata (defaultCwd)
+        // so a later project of the same name can't inherit a stale path.
+        // A failure must not block the refresh — the tmux session is already
+        // gone and a stale config entry is far less bad than a stale rail.
+        await window.api.projectMetaDelete(project);
+      } catch (e) {
+        showError(e);
+      }
       await refresh();
     } catch (e) {
       showError(e);
+    }
+    if (skipped.length === 1) {
+      showNotice(`Kept worktree at ${skipped[0]} — it has uncommitted changes.`);
+    } else if (skipped.length > 1) {
+      showNotice(`Kept ${skipped.length} worktrees with uncommitted changes.`);
     }
   };
 
@@ -470,15 +517,26 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         e.preventDefault();
         renameFocused();
         break;
-      // Backspace alongside Delete: the Mac keyboard's only "delete" key
-      // reports as Backspace in the DOM (there's no forward-delete key on
-      // most Mac keyboards) — binding only "Delete" would leave Mac users
-      // without this path. A focused RenameInput stops propagation on its
-      // own keydown, so this never fires mid-rename.
+      // Home / End jump to the first / last rail row (WAI-ARIA Tree View).
+      case "Home":
+        e.preventDefault();
+        if (navKeys.length) setFocusedKey(navKeys[0]);
+        break;
+      case "End":
+        e.preventDefault();
+        if (navKeys.length) setFocusedKey(navKeys[navKeys.length - 1]);
+        break;
+      // Delete / Backspace are destructive — they require a modifier (⌘ or
+      // Ctrl) to guard against the most reflexive key on the board (BET-937).
+      // Bare Backspace/Delete does nothing at all: no preventDefault, no
+      // confirm. A focused RenameInput stops propagation on its own keydown,
+      // so this never fires mid-rename.
       case "Delete":
       case "Backspace":
-        e.preventDefault();
-        requestDeleteFocused();
+        if (e.metaKey || e.ctrlKey) {
+          e.preventDefault();
+          requestDeleteFocused();
+        }
         break;
       case "ContextMenu":
         e.preventDefault();
@@ -889,9 +947,12 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                 sessionCount: proj?.windows.length ?? 0,
                 runningCount:
                   proj?.windows.filter((w) => statusFor(c.project, w.index)?.running).length ?? 0,
-                // Project close does NOT remove worktrees yet. Workstream 3 adds
-                // that AND flips this to the real count. Do not pass a count here.
-                worktreeCount: 0,
+                // BET-937 Task 2B: the real number of worktrees project close
+                // will remove — every window with a worktree, or 0 when
+                // worktreeCleanOnClose is off.
+                worktreeCount: worktreeCleanOnClose
+                  ? (proj?.windows.filter((w) => w.worktreePath != null).length ?? 0)
+                  : 0,
               });
         return (
           <ConfirmModal

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -64,6 +64,7 @@ import {
   windowPinId,
   parsePinId,
   resolvePin,
+  projectForNavKey,
   fuzzySessionScore,
   computeJobNesting,
   shouldResyncWindowsForJobs,
@@ -2318,6 +2319,34 @@ describe("windowPinId / parsePinId / resolvePin", () => {
     expect(resolvePin(projects, "p/2")?.window.index).toBe(2);
     expect(resolvePin(projects, "p/9")).toBeNull();
     expect(resolvePin(projects, "missing/2")).toBeNull();
+  });
+});
+
+describe("projectForNavKey", () => {
+  it("resolves a group key to its session", () => {
+    expect(projectForNavKey("group:better-ui")).toBe("better-ui");
+  });
+
+  it("resolves window and job keys to their session", () => {
+    expect(projectForNavKey("win:better-ui:3")).toBe("better-ui");
+    expect(projectForNavKey("job:better-ui:4")).toBe("better-ui");
+  });
+
+  it("returns null for pin keys (the caller resolves pins)", () => {
+    expect(projectForNavKey("pin:anything")).toBeNull();
+  });
+
+  it("returns null for null and garbage", () => {
+    expect(projectForNavKey(null)).toBeNull();
+    expect(projectForNavKey("garbage")).toBeNull();
+    expect(projectForNavKey("")).toBeNull();
+    expect(projectForNavKey("win:")).toBeNull();
+  });
+
+  it("resolves a session name containing a colon", () => {
+    expect(projectForNavKey("group:a:b")).toBe("a:b");
+    expect(projectForNavKey("win:a:b:3")).toBe("a:b");
+    expect(projectForNavKey("job:a:b:7")).toBe("a:b");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1670,6 +1670,24 @@ export function resolvePin(
   return win ? { project: proj, window: win } : null;
 }
 
+// The project a rail nav key belongs to, or null when it names no project.
+// `group:<session>` → `<session>`; `win:<session>:<idx>` and
+// `job:<session>:<idx>` → `<session>`. `pin:<id>` and any other key → null
+// (the caller resolves pins via `resolvePin`, and a malformed key names
+// nothing). The encoding always ends in a trailing `:<index>`, so the session
+// is everything after the 4-char kind/colon prefix and before the LAST colon
+// — safe even for a session name that itself contains a colon.
+export function projectForNavKey(key: string | null): string | null {
+  if (!key) return null;
+  if (key.startsWith("group:")) return key.slice("group:".length);
+  if (key.startsWith("win:") || key.startsWith("job:")) {
+    const rest = key.slice(4);
+    const colon = rest.lastIndexOf(":");
+    return colon < 0 ? null : rest.slice(0, colon);
+  }
+  return null;
+}
+
 // ⌘K palette fuzzy match. Subsequence match (case-insensitive) across the
 // session (window) name and workspace (project) name. Returns a score > 0
 // when the query matches, 0 when it doesn't. Tighter/earlier matches score


### PR DESCRIPTION
**BET-937 — Sidebar: require ⌘⌫ for destructive keys, add Home/End, fix two silent leaks on project close**

Workstream 3 of 4 (depends on BET-935 + BET-936, both landed in main).

## Part 1 — destructive keys + Home/End + ⌘T follows rail focus

- **1A** `onRailKeyDown`: `Delete`/`Backspace` now require `metaKey || ctrlKey` to open the delete confirm. Bare Backspace/Delete does nothing (no `preventDefault`, no confirm). `ContextMenu` unchanged. The button-descendant guard (BET-726) is untouched.
- **1B** `Home`/`End` jump focus to the first / last `navKeys` row (WAI-ARIA Tree View).
- **1C** `openNewSessionInActive` (⌘T) now resolves its target project from rail focus first — `group:<s>`/`win:<s>:<i>`/`job:<s>:<i>` name their session, `pin:<id>` resolves via `resolvePin` — then falls back to `activeProjectName`, else does nothing. Keeps the un-collapse side effect; the handle method is not renamed.
- New pure `projectForNavKey(key)` in `chatUtils.ts` (the rail key→project mapping is parsed in three places) with tests covering group/win/job/pin/null/garbage/colon-in-name.

## Part 2 — two silent leaks in project close (`killProject`)

- **2A** When `worktreeCleanOnClose` is on, project close removes every clean worktree before killing the tmux session; a dirty one is skipped (`{ removed:false, reason:"dirty" }`), never force-removed, never three-way prompted. Skipped paths → one toast (`Kept worktree at <path> — it has uncommitted changes.` / `Kept N worktrees with uncommitted changes.`). A per-worktree throw routes to `showError` and never aborts the tmux kill.
- **2B** The `describeProjectClose` confirm now gets the real `worktreeCount` (windows with a non-null `worktreePath`, or 0 when the setting is off) instead of the hardcoded 0 from workstream 1.
- **2C** After the tmux session is killed, `projectMetaDelete(project)` is called before `refresh()`, wrapped so a failure can't block the refresh (routes to `showError`).

## Verification results

**Files changed:** 4 files. `src/renderer/Sidebar.tsx`, `src/renderer/Sidebar.test.tsx`, `src/renderer/chatUtils.ts`, `src/renderer/chatUtils.test.ts` (+214/−13).

- PR branch (`multica/BET-937-destructive-keys-worktree-leaks` @ `fda7bc38`):
  - typecheck: exit 0. Errors: none. log sha256: `e06fda014d5b6d02b99dfbbea91f352be177a28ece42b7ee8b29fb3a0ced8fd5`
  - test: renderer vitest 2707 pass / 7 skip; server node:test 2050 pass / 0 fail. Failures: none. log sha256: `f3f34e524454d621f7a630290c06bcbf1014df5386753be0f95f5ef9340befdc`
- Base (`main` @ `2424eeb4`):
  - typecheck: exit 0. Errors: none. log sha256: `e06fda014d5b6d02b99dfbbea91f352be177a28ece42b7ee8b29fb3a0ced8fd5`
  - test: renderer vitest 2698 pass / 7 skip; server node:test 2050 pass / 0 fail. Failures: none. log sha256: `ef23fb88769c94e1b9facc3606c88b7cbdd1b7b6d6adf52483e36491fbb937cf`
- **Conclusion:** 0 new failures on the PR branch; the only renderer delta is the 9 new tests this PR adds.

**Base: origin/main @ 2424eeb4** (branched from 2424eeb4)
