### PR TITLE
Sidebar: nest new-session draft in its project, ask worktree fan-out once (BET-938)

### DIFF
--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -47,6 +47,11 @@ type Props = {
   // session with one window per worktree, each named worktreeName(w).
   // When omitted, the fan-out question is not offered (mobile can opt out).
   onFanOut?: (cwd: string, worktrees: WorktreeInfo[]) => void;
+  // When a fan-out create is in flight, the picker OWNS the confirmation that
+  // the old second "Fan-out confirmed" modal used to: its three choice buttons
+  // are disabled and the fan-out one reads "Creating…", so the single picker
+  // modal is the whole flow (BET-938).
+  fanOutBusy?: boolean;
   onCancel: () => void;
 };
 
@@ -66,7 +71,7 @@ type FanOut =
   | null
   | { worktrees: WorktreeInfo[]; cwd: string };
 
-export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, onCancel }: Props) {
+export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOutBusy, onCancel }: Props) {
   const [path, setPath] = useState(initialPath);
   const [suggestion, setSuggestion] = useState<string | null>(null);
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -238,7 +243,7 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, onCan
   const crumbs = breadcrumbs(path);
 
   return (
-    <Modal open={open} size="lg" padded={false} tall onDismiss={onCancel} label="Select folder">
+    <Modal open={open} size="lg" padded={false} tall onDismiss={fanOutBusy ? undefined : onCancel} label="Select folder">
       <div className="manta-folder-picker flex flex-col flex-1 min-h-0">
         {/* Header */}
         <div className="flex items-center justify-between px-4 py-3 border-b border-border">
@@ -269,18 +274,19 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, onCan
               ))}
             </ul>
             <div className="flex gap-2">
-              <Button tone="default" onClick={() => onSelect(fanOut.cwd)}>
+              <Button tone="default" onClick={() => onSelect(fanOut.cwd)} disabled={fanOutBusy}>
                 Just this folder
               </Button>
               {onFanOut && (
                 <Button
                   tone="primary"
                   onClick={() => onFanOut(fanOut.cwd, fanOut.worktrees)}
+                  disabled={fanOutBusy}
                 >
-                  One per worktree
+                  {fanOutBusy ? "Creating…" : "One per worktree"}
                 </Button>
               )}
-              <Button tone="ghost" onClick={() => setFanOut(null)}>
+              <Button tone="ghost" onClick={() => setFanOut(null)} disabled={fanOutBusy}>
                 Back
               </Button>
             </div>

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -39,7 +39,6 @@ import { Chip } from "./Chip";
 import { ModelPicker } from "./ModelPicker";
 import { MicButton } from "./ComposerParts";
 import { IconButton } from "./IconButton";
-import { Modal } from "./Modal";
 import { Button } from "./Button";
 import { Card } from "./Card";
 import { Checkbox } from "./Checkbox";
@@ -158,9 +157,6 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   const [pickerOpen, setPickerOpen] = useState(false);
   const [worktrees, setWorktrees] = useState<WorktreeInfo[] | null>(null);
   const [isGitRepo, setIsGitRepo] = useState(false);
-  // BET-417 §B: fan-out from the folder picker. When set, the picker returned
-  // multiple worktrees and the user chose "One per worktree".
-  const [fanOutWorktrees, setFanOutWorktrees] = useState<WorktreeInfo[] | null>(null);
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
@@ -1062,52 +1058,16 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
             setPickerOpen(false);
           }}
           onFanOut={(baseCwd, wts) => {
-            setFanOutWorktrees(wts);
             updateDraft(draftId, { cwd: baseCwd });
             if (isNewProject) setBrowseChosen(true);
-            setPickerOpen(false);
+            // Carry the worktree list straight into the submit — the picker
+            // stays open and OWNS the in-flight state (its buttons disable and
+            // read "Creating…" via fanOutBusy) instead of a second modal.
+            void submitFanOut(baseCwd, wts);
           }}
+          fanOutBusy={sending}
           onCancel={() => setPickerOpen(false)}
         />
-
-      <Modal
-          open={!!fanOutWorktrees}
-          size="md"
-          label="Fan-out confirmed"
-          onDismiss={sending ? undefined : () => setFanOutWorktrees(null)}
-        >
-          <div className="space-y-3">
-            <div className="text-body font-semibold text-text">Fan-out confirmed</div>
-            <div className="text-meta text-text-muted">
-              Creating one session with {fanOutWorktrees?.length ?? 0} windows (one per
-              worktree). The first window gets your prompt.
-            </div>
-            <ul className="text-label text-text-faint space-y-px max-h-40 overflow-y-auto">
-              {(fanOutWorktrees ?? []).map((w) => (
-                <li key={w.path} className="truncate">
-                  <span className="text-text-muted">{worktreeName(w)}</span>
-                  {" "}<span className="text-text-faint">— {w.path}</span>
-                </li>
-              ))}
-            </ul>
-            <div className="flex gap-2">
-              <Button
-                tone="primary"
-                onClick={() => void submitFanOut(draft.cwd, fanOutWorktrees ?? [])}
-                disabled={sending}
-              >
-                {sending ? "Creating…" : "Create"}
-              </Button>
-              <Button
-                tone="ghost"
-                onClick={() => setFanOutWorktrees(null)}
-                disabled={sending}
-              >
-                Cancel
-              </Button>
-            </div>
-          </div>
-        </Modal>
     </div>
   );
 }

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -8,7 +8,7 @@ import {
 } from "react";
 import type { ReactElement } from "react";
 import { ChevronRight, ChevronDown, Plus, X, Pin, Search } from "lucide-react";
-import { useStore, flatSessions, type WindowStatusUI } from "./store";
+import { useStore, flatSessions, type WindowStatusUI, type NewSessionDraft } from "./store";
 import { nowMs, useAgeTick } from "./clock";
 import { PaletteShell, useSelectedIntoView } from "./PaletteShell";
 import { InboxPalette } from "./InboxPalette";

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -105,11 +105,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
     pushAppToast({ tone: "info", message: msg });
   };
 
-  // When a new-session DRAFT is the foreground view, no real session should
-  // read as "active" in the rail — the draft row is the highlighted one
-  // (e.g. creating a session over a chat must not leave the old chat lit up).
-  const draftForeground = activeDraftId != null;
-
   const [collapsed, setCollapsed] = useState<Set<string>>(loadCollapsed);
 
   const [confirmDeleteFor, setConfirmDeleteFor] = useState<ConfirmDeleteFor>(null);
@@ -648,49 +643,26 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         onKeyDown={onRailKeyDown}
       >
         <RailCreateRow label="New workspace" shortcut={`${MOD_KEY}N`} onClick={onNewProject} />
-        {/* New-session drafts (BET draft model): in-memory composers for
-            sessions that don't exist yet. Shown at the TOP of the rail, not
-            nested under any project — a draft is a bare "new session" until it
-            commits. Clicking one makes it the active view (renders the
-            composer); the X abandons it (dismisses, prompt not yet sent). */}
-        {drafts.length > 0 && (
+        {/* New-session drafts whose mode is "new-project" live directly beneath
+            the New workspace row that created them — they belong to no project.
+            Project-scoped drafts ({ projectName }) render inside their project's
+            window list below instead (see the projects.map below). A draft is a
+            bare "new session" until it commits; clicking one makes it the active
+            view (renders the composer); the X abandons it (dismisses, prompt not
+            yet sent). */}
+        {drafts.filter((d) => d.mode === "new-project").length > 0 && (
           <div className="mb-3 space-y-px">
-            {drafts.map((d) => {
-              const isActive = activeDraftId === d.id;
-              const target =
-                d.mode === "new-project"
-                  ? "will create a new project"
-                  : `will open in "${d.mode.projectName}"`;
-              const hint = d.input.trim()
-                ? `"${d.input.trim().slice(0, 40)}" · ${target}`
-                : target;
-              return (
-                <RailSessionRow
+            {drafts
+              .filter((d) => d.mode === "new-project")
+              .map((d) => (
+                <DraftRow
                   key={d.id}
-                  // A draft is never running/blocking — the at-rest "default"
-                  // dot keeps the row chrome identical to a resting session.
-                  status="default"
-                  selected={isActive}
-                  name={<span className="italic">new session</span>}
-                  title={`New session — ${hint}`}
-                  ariaSelected={isActive}
-                  onClick={() => setActiveDraft(d.id)}
-                  trailing={
-                    <button
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        dismissDraft(d.id);
-                      }}
-                      className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-text-faint hover:text-danger leading-none inline-flex items-center"
-                      aria-label="Discard this new session"
-                      title="Discard this new session"
-                    >
-                      <X size={13} aria-hidden="true" />
-                    </button>
-                  }
+                  draft={d}
+                  isActive={activeDraftId === d.id}
+                  onActivate={() => setActiveDraft(d.id)}
+                  onDismiss={() => dismissDraft(d.id)}
                 />
-              );
-            })}
+              ))}
           </div>
         )}
 
@@ -713,7 +685,6 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                   project={r.project}
                   window={r.window}
                   isActive={
-                    !draftForeground &&
                     activeProjectName === r.project.tmuxSession &&
                     activeWindowByProject[r.project.tmuxSession] === r.window.index
                   }
@@ -756,7 +727,14 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
         {projects.map((p) => {
           const isCollapsed = collapsed.has(p.tmuxSession);
           const activeWinIdx = activeWindowByProject[p.tmuxSession];
-          const isProjectActive = !draftForeground && activeProjectName === p.tmuxSession;
+          const isProjectActive = activeProjectName === p.tmuxSession;
+          // Project-scoped drafts render as the LAST child of this project's
+          // window list, and replace its "New session" create row (never stack
+          // with it). A project may hold more than one draft; render them all
+          // and still suppress the create row.
+          const projectDrafts = drafts.filter(
+            (d) => d.mode !== "new-project" && d.mode.projectName === p.tmuxSession,
+          );
           const n = nesting.get(p.tmuxSession)!;
           const topWindows = p.windows.filter(
             (w) =>
@@ -853,11 +831,23 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                     );
                   })}
 
-                  <RailCreateRow
-                    label="New session"
-                    shortcut={`${MOD_KEY}T`}
-                    onClick={() => onNewSessionInProject(p.tmuxSession)}
-                  />
+                  {projectDrafts.length > 0 ? (
+                    projectDrafts.map((d) => (
+                      <DraftRow
+                        key={d.id}
+                        draft={d}
+                        isActive={activeDraftId === d.id}
+                        onActivate={() => setActiveDraft(d.id)}
+                        onDismiss={() => dismissDraft(d.id)}
+                      />
+                    ))
+                  ) : (
+                    <RailCreateRow
+                      label="New session"
+                      shortcut={`${MOD_KEY}T`}
+                      onClick={() => onNewSessionInProject(p.tmuxSession)}
+                    />
+                  )}
                 </div>
               )}
             </div>
@@ -1304,6 +1294,56 @@ function RailCreateRow({
         {shortcut}
       </span>
     </button>
+  );
+}
+
+// A rail row for an in-memory new-session DRAFT. One component reused at both
+// nest sites: at the top of the rail for a new-project draft (directly beneath
+// "New workspace"), and as the last row of a project's window list for a
+// project-scoped draft (where it replaces the "New session" create row). It is
+// a RailSessionRow with an italic name and a trailing dismiss ✕.
+function DraftRow({
+  draft,
+  isActive,
+  onActivate,
+  onDismiss,
+}: {
+  draft: NewSessionDraft;
+  isActive: boolean;
+  onActivate: () => void;
+  onDismiss: () => void;
+}) {
+  const target =
+    draft.mode === "new-project"
+      ? "will create a new project"
+      : `will open in "${draft.mode.projectName}"`;
+  const hint = draft.input.trim()
+    ? `"${draft.input.trim().slice(0, 40)}" · ${target}`
+    : target;
+  return (
+    <RailSessionRow
+      // A draft is never running/blocking — the at-rest "default" dot keeps
+      // the row chrome identical to a resting session.
+      status="default"
+      selected={isActive}
+      name={<span className="italic">new session</span>}
+      title={`New session — ${hint}`}
+      ariaSelected={isActive}
+      onClick={onActivate}
+      trailing={
+        <button
+          onClick={(e) => {
+            e.stopPropagation();
+            onDismiss();
+          }}
+          className="opacity-0 group-hover:opacity-100 focus-visible:opacity-100 text-text-faint hover:text-danger leading-none inline-flex items-center"
+          aria-label="Discard this new session"
+          title="Discard this new session"
+        >
+          <X size={13} aria-hidden="true" />
+        </button>
+      }
+    />
   );
 }
 


### PR DESCRIPTION
## BET-938 — Sidebar: nest the new-session draft inside its project, ask the worktree fan-out question once

**Base: origin/main @ 31d294d6**

### Part 1 — project-scoped drafts nest in their project
- Extracted the draft row JSX into a single local `DraftRow` component; the top-of-rail block now renders only `mode === "new-project"` drafts (directly beneath "New workspace").
- Project-scoped drafts (`{ projectName }`) render as the last child of that project's expanded window list (after window + job children) — the same slot `RailCreateRow` occupies — and **replace** the project's "New session" row rather than stacking with it (all drafts render, create row suppressed).
- Deleted `draftForeground` and both consumers (pinned row `isActive`, project `isProjectActive`). No row dims while a draft is open; the draft row itself is `selected` when active, same as every other row.

### Part 2 — one fan-out question
- Deleted the second "Fan-out confirmed" modal (`NewSessionScreen`). `onFanOut` carries the worktree list straight into `submitFanOut` (unchanged).
- Removed the now-dead `fanOutWorktrees` state + its import of `Modal` (net deletion).
- The folder picker now owns the in-flight state via a new `fanOutBusy` prop: while the fan-out create runs, its three choice buttons are disabled, the fan-out one reads "Creating…", and the picker can't be dismissed mid-create. `submitFanOut`'s existing `if (sending) return` guard plus the disabled button prevent a double fire.

**Do-not-change honoured:** `submitFanOut` body, worktree detection, and the three-way picker question untouched; the new-project draft stays at the top.

**Verification:** `npm run typecheck` clean; `npm test` 2050 pass / 0 fail.
