### PR TITLE
BET-941: Clone picker — Basic token auth, no token persistence, paginate repo listing

### DIFF
--- a/src/server/forge/github.mjs
+++ b/src/server/forge/github.mjs
@@ -732,17 +732,29 @@ export function createGithubAdapter(request, requestWrite, requestText = request
 
     /**
      * GET /user/repos — the repos the connected user can actually PUSH to,
-     * most-recently-pushed first. Filtering to write access is what keeps the
-     * clone picker usable: a read-only repo you cannot push to is noise here,
-     * so it is dropped (from `/user/repos`' per-repo `permissions.push`).
-     * Normalised to a forge-neutral shape; the renderer groups by `owner`.
+     * most-recently-pushed first. Paginates (100 per request) until a page
+     * returns fewer than `per_page` rows, with a hard cap of 5 pages (500
+     * repos) so a pathological account cannot hang the picker. Each page URL
+     * is distinct, so the ETag/single-flight cache keys them separately.
+     * Filtering to write access keeps the clone picker usable: a read-only
+     * repo you cannot push to is noise here, so it is dropped (from
+     * `/user/repos`' per-repo `permissions.push`). Normalised to a
+     * forge-neutral shape; the renderer groups by `owner`.
      *
      * @returns {Promise<{ data: Array<object>, stale: boolean }>}
      */
     async listMyRepos() {
-      const url = `${apiBase}/user/repos?sort=pushed&per_page=100&affiliation=owner,collaborator,organization_member`;
-      const { data, stale } = await request(url);
-      return { data: pushableRepos(data), stale };
+      const raw = [];
+      let stale = false;
+      for (let page = 1; page <= 5; page++) {
+        const url = `${apiBase}/user/repos?sort=pushed&per_page=100&affiliation=owner,collaborator,organization_member&page=${page}`;
+        const { data, stale: pageStale } = await request(url);
+        const rows = Array.isArray(data) ? data : [];
+        if (pageStale) stale = true;
+        raw.push(...rows);
+        if (rows.length < 100) break;
+      }
+      return { data: pushableRepos(raw), stale };
     },
   };
 }

--- a/src/server/forge/github.test.mjs
+++ b/src/server/forge/github.test.mjs
@@ -433,7 +433,7 @@ test("replyToThread POSTs a reply body + reviewed commit to the thread endpoint"
 // ---- listMyRepos (BET-796): the clone picker's remote repo source -----------
 
 test("listMyRepos drops read-only repos and orders most-recently-pushed first", async () => {
-  const url = "https://api.github.com/user/repos?sort=pushed&per_page=100&affiliation=owner,collaborator,organization_member";
+  const url = "https://api.github.com/user/repos?sort=pushed&per_page=100&affiliation=owner,collaborator,organization_member&page=1";
   const adapter = createGithubAdapter(
     fakeRequest({
       [url]: [
@@ -484,6 +484,74 @@ test("listMyRepos drops read-only repos and orders most-recently-pushed first", 
   assert.equal(data[1].defaultBranch, "main");
   assert.equal(data[1].cloneUrl, "https://github.com/octo/manta-skills.git");
   assert.ok(!data.some((r) => r.fullName === "acme/readonly"));
+});
+
+test("listMyRepos paginates until a short page and returns the union", async () => {
+  const page = (n, count) =>
+    Array.from({ length: count }, (_, i) => ({
+      name: `repo-${n}-${i}`,
+      full_name: `acme/repo-${n}-${i}`,
+      owner: { login: "acme" },
+      pushed_at: "2026-08-01T00:00:00Z",
+      default_branch: "main",
+      clone_url: `https://github.com/acme/repo-${n}-${i}.git`,
+      html_url: `https://github.com/acme/repo-${n}-${i}`,
+      permissions: { push: true },
+    }));
+  const requested = [];
+  const request = async (url) => {
+    requested.push(url);
+    const pageNum = Number(new URL(url).searchParams.get("page"));
+    return { data: pageNum === 1 ? page(1, 100) : page(2, 37), stale: false };
+  };
+  const adapter = createGithubAdapter(request);
+  const { data } = await adapter.listMyRepos();
+  assert.equal(requested.length, 2, "a full page then a short page stops after two requests");
+  assert.equal(data.length, 137, "both pages are concatenated before filtering");
+});
+
+test("listMyRepos caps at 5 pages so a pathological account cannot hang the picker", async () => {
+  const full = Array.from({ length: 100 }, (_, i) => ({
+    name: `r${i}`,
+    full_name: `acme/r${i}`,
+    owner: { login: "acme" },
+    pushed_at: "2026-08-01T00:00:00Z",
+    default_branch: "main",
+    clone_url: `https://github.com/acme/r${i}.git`,
+    html_url: `https://github.com/acme/r${i}`,
+    permissions: { push: true },
+  }));
+  let count = 0;
+  const request = async () => {
+    count += 1;
+    return { data: full, stale: false };
+  };
+  const adapter = createGithubAdapter(request);
+  const { data } = await adapter.listMyRepos();
+  assert.equal(count, 5, "a full page every time stops at the 5-page cap");
+  assert.equal(data.length, 500);
+});
+
+test("listMyRepos reports stale when any page was stale", async () => {
+  const full = Array.from({ length: 100 }, (_, i) => ({
+    name: `r${i}`,
+    full_name: `acme/r${i}`,
+    owner: { login: "acme" },
+    pushed_at: "2026-08-01T00:00:00Z",
+    default_branch: "main",
+    clone_url: `https://github.com/acme/r${i}.git`,
+    html_url: `https://github.com/acme/r${i}`,
+    permissions: { push: true },
+  }));
+  const request = async (url) => {
+    const pageNum = Number(new URL(url).searchParams.get("page"));
+    const data = pageNum === 1 ? full : full.slice(0, 10);
+    return { data, stale: pageNum === 2 };
+  };
+  const adapter = createGithubAdapter(request);
+  const { data, stale } = await adapter.listMyRepos();
+  assert.equal(stale, true, "a stale page 2 marks the whole result stale");
+  assert.ok(data.length > 0);
 });
 
 // ---- getDefaultBranch: the single-repo default-branch read (BET-891) -------

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -558,7 +558,13 @@ export function parseCloneProgress(line) {
 // `{ percent, bytes }` snapshot (the latest parseable state) as chunks arrive.
 // An optional `token` is injected as an HTTP extraheader (`git -c
 // http.extraheader`) so private-repo clones authenticate without the token
-// ever appearing in the displayed URL. Injected `spawn`/`parse` seam for tests.
+// ever appearing in the displayed URL. The credential uses GitHub's documented
+// HTTP **Basic** scheme with the token as the password under the
+// `x-access-token` username (server-side GitHub tokens are rejected under
+// `Authorization: Bearer`). `-c` must precede the `clone` subcommand (a
+// git-global option, per `spawnGitLong`'s `["git", "-C", cwd, ...args]` shape)
+// so the credential is applied to the fetch without being persisted into the
+// newly created repo's `.git/config`. Injected `spawn`/`parse` seam for tests.
 export async function gitClone(
   { url, dest, onProgress, timeoutMs = GIT_NET_TIMEOUT_MS, signal, token } = {},
   { spawn = nodeSpawn, parse = parseCloneProgress } = {},
@@ -575,12 +581,15 @@ export async function gitClone(
         }
       : undefined;
   const authArgs = token
-    ? ["-c", `http.extraheader=Authorization: Bearer ${token}`]
+    ? [
+        "-c",
+        `http.extraheader=Authorization: Basic ${Buffer.from(`x-access-token:${token}`).toString("base64")}`,
+      ]
     : [];
   return spawnGitLong(
     {
       cwd: "/",
-      args: ["clone", "--progress", ...authArgs, url, ...(dest ? [dest] : [])],
+      args: [...authArgs, "clone", "--progress", url, ...(dest ? [dest] : [])],
       onProgress: emit,
       timeoutMs,
       spawn,

--- a/src/server/local.test.mjs
+++ b/src/server/local.test.mjs
@@ -4,7 +4,7 @@ import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fsListDirs, parseWorktrees, shouldSkipDir, dedupeRepoHits, sortRepoHits, parseGhAuthStatus, parseCloneProgress, gitPush } from "./local.mjs";
+import { fsListDirs, parseWorktrees, shouldSkipDir, dedupeRepoHits, sortRepoHits, parseGhAuthStatus, parseCloneProgress, gitPush, gitClone } from "./local.mjs";
 
 test("parseWorktrees parses `git worktree list --porcelain`", () => {
   const out = parseWorktrees(
@@ -289,4 +289,25 @@ test("gitPush: explicit remote is honored with setUpstream", async () => {
   const { spawn, calls } = makeSpawn();
   await gitPush({ cwd: "/r", branch: "feat/x", remote: "upstream", setUpstream: true }, { spawn });
   assert.deepEqual(calls[0], ["-C", "/r", "push", "-u", "upstream", "feat/x"]);
+});
+
+test("gitClone: token emits -c BEFORE clone with an HTTP Basic x-access-token header", async () => {
+  const { spawn, calls } = makeSpawn();
+  await gitClone({ url: "https://github.com/acme/private.git", dest: "/d", token: "tok_123" }, { spawn });
+  const argv = calls[0];
+  const cIdx = argv.indexOf("-c");
+  const cloneIdx = argv.indexOf("clone");
+  assert.ok(cIdx !== -1 && cloneIdx !== -1, "both -c and clone are present");
+  assert.ok(cIdx < cloneIdx, "-c must precede clone so the credential is not persisted");
+  const header = argv[cIdx + 1];
+  assert.ok(header.startsWith("http.extraheader=Authorization: Basic "), "header uses HTTP Basic");
+  const b64 = header.slice("http.extraheader=Authorization: Basic ".length);
+  assert.equal(Buffer.from(b64, "base64").toString("utf8"), "x-access-token:tok_123");
+});
+
+test("gitClone: no token emits no -c argument at all", async () => {
+  const { spawn, calls } = makeSpawn();
+  await gitClone({ url: "https://github.com/acme/public.git" }, { spawn });
+  assert.ok(!calls[0].includes("-c"), "public clone emits no extraheader");
+  assert.deepEqual(calls[0], ["-C", "/", "clone", "--progress", "https://github.com/acme/public.git"]);
 });


### PR DESCRIPTION
BET-941 — Clone picker: fix the auth scheme that breaks every private-repo clone, stop persisting the token, paginate the listing

Closes issue BET-941.

## Changes

**`src/server/local.mjs` — `gitClone`**
- Auth header changed from `Authorization: Bearer <token>` to GitHub's documented HTTP **Basic** scheme: `Authorization: Basic base64("x-access-token:<token>")`. GitHub's private-repo HTTPS endpoint rejects Bearer (401), which is why every private-repo clone failed regardless of the user's actual permissions; public repos worked only because they need no credential.
- Moved `-c http.extraheader=...` to git's global-option position, **before** the `clone` subcommand, so the credential applies to the fetch but is not persisted into the cloned repo's `.git/config` (the old post-subcommand `-c` wrote the token into every cloned repo in plaintext).
- Block comment updated to document the Basic scheme + the `-c` placement requirement. `authArgs` is never logged (argv array, no shell; `spawnGitLong` builds errors from stderr only).

**`src/server/forge/github.mjs` — `listMyRepos`**
- Now paginates: loops 1..5, requesting 100-row pages until a page returns fewer than 100, hard-capped at 5 pages (500 repos) so a pathological account can't hang the picker. Each page URL is distinct, so the existing ETag/single-flight cache keys them separately with no change there.
- Concatenates raw pages then runs the unchanged, pure `pushableRepos()` over the combined array once.
- `stale` is true if any page was stale.

## Filtering — unchanged
`pushableRepos` still keeps only repos where GitHub reports `permissions.push === true`. No relaxation to `permissions.pull`, no network preflight, no archived/fork/visibility filters.

## Out of scope (per issue)
No `src/renderer/**`, no `src/server/forge/gitlab.mjs`, no `resolveToken`/credential-ladder changes.

## Tests
- `src/server/local.test.mjs`: three `gitClone` tests asserting (a) `-c` precedes `clone`, (b) the header starts `Authorization: Basic ` and base64-decodes to `x-access-token:<token>`, (c) no token → no `-c` emitted.
- `src/server/forge/github.test.mjs`: existing `listMyRepos` test updated for the paginated URL; new tests — full-then-short page issues exactly two requests and returns the union; a full-every-time stub stops after 5 requests; `stale` is true when any page is stale.

**Base: origin/main @ `0cdaa9b4`**
