### PR TITLE
BET-940: fix(renderer): reschedule device poll on slow_down + extract one GitHub connect surface

### DIFF
--- a/src/renderer/CloneFromGitHub.tsx
+++ b/src/renderer/CloneFromGitHub.tsx
@@ -22,7 +22,7 @@
 // the zero-state batch workspace creation verbatim — this component only
 // produces directories on disk.
 
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { ChevronDown } from "lucide-react";
 import { Button } from "./Button";
 import { Callout } from "./Callout";
@@ -30,48 +30,17 @@ import { Checkbox } from "./Checkbox";
 import { Field } from "./Field";
 import { ListRow } from "./ListRow";
 import { ProgressBar } from "./ProgressBar";
-import { DeviceCodeSteps } from "./DeviceFlow";
+import { ConnectGithubPanel, PanelHeader, PANEL_CLASS } from "./ConnectGithub";
 import { formatAge, formatBytes, cloneErrorKind, type CloneErrorKind } from "./chatUtils";
 import type {
   ForgeCloneStatus,
-  ForgeDeviceGrant,
   ForgeRepo,
 } from "../shared/types";
 
 type Phase =
-  | { kind: "connect" }
-  | { kind: "notConfigured" }
   | { kind: "pick" }
   | { kind: "clone"; queue: ForgeRepo[]; index: number }
-  | { kind: "expired" }
-  | { kind: "failed"; repo: ForgeRepo | null; message: string; errorKind: CloneErrorKind };
-
-// mm:ss countdown label — mono so it doesn't jitter.
-function countdownLabel(remainingMs: number): string {
-  const s = Math.max(0, Math.floor(remainingMs / 1000));
-  const m = Math.floor(s / 60);
-  const sec = s % 60;
-  return `${m}:${String(sec).padStart(2, "0")}`;
-}
-
-// The panel title row (.mhead where it is REAL — [S5] [S6] [E2] [E3]).
-function PanelHeader({
-  title,
-  trailing,
-}: {
-  title: React.ReactNode;
-  trailing?: React.ReactNode;
-}) {
-  return (
-    <div className="flex items-center gap-2 px-3 py-2 border-b border-border-subtle text-[13px] font-medium text-text">
-      {title}
-      {trailing != null && <span className="ml-auto">{trailing}</span>}
-    </div>
-  );
-}
-
-const PANEL_CLASS =
-  "w-full max-w-[420px] rounded-lg border border-border bg-bg-elev overflow-hidden";
+  | { kind: "failed"; repo: ForgeRepo; message: string; errorKind: CloneErrorKind };
 
 export function CloneFromGitHub({
   defaultRoot,
@@ -82,12 +51,10 @@ export function CloneFromGitHub({
   onCancel: () => void;
   onCloned: (paths: string[]) => void;
 }): JSX.Element {
-  const [phase, setPhase] = useState<Phase>({ kind: "connect" });
-  // ---- [S5] device grant state ----
-  const [grant, setGrant] = useState<ForgeDeviceGrant | null>(null);
-  const [remainingMs, setRemainingMs] = useState(0);
-  const [copiedNote, setCopiedNote] = useState(false);
-  const grantRef = useRef<ForgeDeviceGrant | null>(null);
+  // The whole device-connect flow lives in ConnectGithubPanel; this flag just
+  // gates whether the connect screen (pre-credential) or the picker shows.
+  const [connected, setConnected] = useState(false);
+  const [phase, setPhase] = useState<Phase>({ kind: "pick" });
   // ---- [S6] picker state ----
   const [repos, setRepos] = useState<ForgeRepo[]>([]);
   const [reposError, setReposError] = useState<string | null>(null);
@@ -113,91 +80,6 @@ export function CloneFromGitHub({
         (!q || r.fullName.toLowerCase().includes(q) || r.name.toLowerCase().includes(q)),
     );
   }, [repos, owner, search]);
-
-  // ---- [S5]: connect (device flow) ----
-  // On mount, ask the box to start a device grant. A box that already has a
-  // credential (CLI/secret) skips straight to the picker.
-  useEffect(() => {
-    let cancelled = false;
-    (async () => {
-      try {
-        const res = await window.api.forgeDeviceStart();
-        if (cancelled) return;
-        if ("notConfigured" in res && res.notConfigured) {
-          // The box's device-grant id is a placeholder (BET-849) — surface a
-          // clear "not configured" state, never a guaranteed-dead-end screen.
-          setPhase({ kind: "notConfigured" });
-          return;
-        }
-        if (res.connected) {
-          setPhase({ kind: "pick" });
-          return;
-        }
-        const g = res.grant!;
-        grantRef.current = g;
-        setGrant(g);
-        setRemainingMs(g.expiresIn * 1000);
-        setCopiedNote(false);
-        // Rule 5: copy the code automatically — the user pastes, not retypes.
-        window.api
-          .clipboardWriteText(g.userCode)
-          .then(() => setCopiedNote(true), () => {});
-      } catch {
-        if (cancelled) return;
-        setPhase({ kind: "failed", repo: null, message: "Couldn't reach the box. Try again.", errorKind: "unknown" });
-      }
-    })();
-    return () => {
-      cancelled = true;
-    };
-  }, [phase.kind === "connect" ? phase.kind : null]);
-
-  // Device poll + countdown while connecting.
-  useEffect(() => {
-    if (phase.kind !== "connect" || !grant) return;
-    const startedAt = Date.now();
-    const deadline = startedAt + grant.expiresIn * 1000;
-    let intervalMs = Math.max(grant.pollInterval, 5) * 1000;
-    const ticker = window.setInterval(() => {
-      setRemainingMs(deadline - Date.now());
-    }, 1000);
-    const poll = async () => {
-      try {
-        const res = await window.api.forgeDevicePoll({ grantId: grant.grantId });
-        if (res.status === "done") {
-          window.clearInterval(ticker);
-          setPhase({ kind: "pick" });
-          return;
-        }
-        if (res.status === "expired") {
-          window.clearInterval(ticker);
-          setPhase({ kind: "expired" });
-          return;
-        }
-        if (res.status === "pending") {
-          // slow_down may have lengthened the interval — respect the new value.
-          if (res.pollInterval) intervalMs = res.pollInterval * 1000;
-        }
-      } catch {
-        // transient — keep polling
-      }
-    };
-    const handle = window.setInterval(poll, intervalMs);
-    // Poll immediately once (the pending → done transition can resolve fast).
-    void poll();
-    return () => {
-      window.clearInterval(ticker);
-      window.clearInterval(handle);
-    };
-    // Narrowed to the discriminant so cosmetic state changes don't reset timers.
-  }, [phase.kind, phase.kind === "connect" ? grant?.grantId : null]);
-
-  const cancelConnect = useCallback(() => {
-    if (grantRef.current) {
-      void window.api.forgeDeviceCancel({ grantId: grantRef.current.grantId });
-    }
-    onCancel(); // back to [S4] with nothing changed
-  }, [onCancel]);
 
   // ---- [S6]: fetch the repos once we reach the picker ----
   useEffect(() => {
@@ -319,13 +201,8 @@ export function CloneFromGitHub({
 
   const retryClone = () => {
     if (phase.kind !== "failed") return;
-    // A connection-level failure (no repo) restarts the device flow.
-    if (!phase.repo) {
-      grantRef.current = null;
-      setGrant(null);
-      setPhase({ kind: "connect" });
-      return;
-    }
+    // A connection-level failure now surfaces inside ConnectGithubPanel, so
+    // this is strictly the repo-retry path.
     runClones(
       [
         ...filtered.filter((r) => checked.has(r.fullName) && r.fullName !== phase.repo?.fullName),
@@ -344,36 +221,10 @@ export function CloneFromGitHub({
   // ===== Rendering =====
   return (
     <div className={PANEL_CLASS}>
-      {phase.kind === "connect" && !grant && (
-        <div className="p-4 text-[13px] text-text-muted">Preparing sign-in…</div>
-      )}
-
-      {phase.kind === "connect" && grant && (
+      {!connected ? (
+        <ConnectGithubPanel onConnected={() => setConnected(true)} onCancel={onCancel} />
+      ) : (
         <>
-          <PanelHeader
-            title="Connect GitHub · Waiting for sign-in"
-            trailing={
-              <span className="font-mono tabular-nums text-[11px] text-text-faint">
-                {countdownLabel(remainingMs)} remaining
-              </span>
-            }
-          />
-          <div className="p-4">
-            <DeviceCodeSteps
-              url={grant.verificationUri}
-              displayUrl={grant.verificationUri.replace(/^https?:\/\//, "")}
-              code={grant.userCode}
-              autoCopied={copiedNote}
-            />
-            <div className="flex gap-2 mt-3">
-              <Button tone="ghost" onClick={cancelConnect}>
-                Cancel
-              </Button>
-            </div>
-          </div>
-        </>
-      )}
-
       {phase.kind === "pick" && (
         <>
           <PanelHeader
@@ -505,61 +356,13 @@ export function CloneFromGitHub({
         </div>
       )}
 
-      {phase.kind === "notConfigured" && (
-        <>
-          <PanelHeader title="Connect GitHub" />
-          <div className="p-4">
-            <Callout tone="warn">
-              GitHub sign-in isn't configured on this box yet.
-            </Callout>
-            <div className="flex gap-2 mt-3">
-              <Button tone="ghost" onClick={onCancel}>
-                Back
-              </Button>
-            </div>
-          </div>
-        </>
-      )}
-
-      {phase.kind === "expired" && (
-        <>
-          <PanelHeader title="Connect GitHub · Failed" />
-          <div className="p-4">
-            <Callout tone="danger">
-              The sign-in code expired before it was entered.
-            </Callout>
-            <div className="flex gap-2 mt-3">
-              <Button
-                tone="primary"
-                onClick={() => {
-                  grantRef.current = null;
-                  setGrant(null);
-                  setPhase({ kind: "connect" });
-                }}
-              >
-                Try again
-              </Button>
-              <Button tone="ghost" onClick={onCancel}>
-                Skip for now
-              </Button>
-            </div>
-          </div>
-        </>
-      )}
-
       {phase.kind === "failed" && (
         <>
           <PanelHeader title="Clone failed" />
           <div className="p-4">
             <Callout tone="danger">
-              {phase.repo ? (
-                <>
-                  <b className="text-text">{phase.repo.name}</b> —{" "}
-                  {failedMessage(phase.errorKind, phase.message)}
-                </>
-              ) : (
-                phase.message
-              )}
+              <b className="text-text">{phase.repo.name}</b> —{" "}
+              {failedMessage(phase.errorKind, phase.message)}
             </Callout>
             <div className="flex gap-2 mt-3 items-center">
               <Button tone="primary" onClick={retryClone}>
@@ -573,6 +376,8 @@ export function CloneFromGitHub({
               </Button>
             </div>
           </div>
+        </>
+      )}
         </>
       )}
     </div>

--- a/src/renderer/ConnectGithub.test.tsx
+++ b/src/renderer/ConnectGithub.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment jsdom
+//
+// Regression tests for the GitHub device-connect poll loop (BET-940).
+//
+// The defect this pins: CloneFromGitHub's connect phase polled on a FIXED 5s
+// `setInterval` armed once, so when GitHub's `slow_down` lengthened the
+// required gap the renderer assigned the new interval to a variable that was
+// never read again — the loop could never catch up and the screen hung. On
+// top of that, an immediate `poll()` on effect setup tripped `slow_down`
+// instantly (doubly so under StrictMode's double-invoked effects).
+//
+// ConnectGithubPanel fixes all of it: one self-rescheduling timeout chain that
+// re-reads the interval from every response, no immediate first poll, and a
+// three-consecutive-error budget that stops the loop and renders the
+// "couldn't sign in" panel.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ConnectGithubPanel } from "./ConnectGithub";
+import { installMockApi } from "./testHarness";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+const GRANT = {
+  grantId: "grant-1",
+  userCode: "WDJB-MJHT",
+  verificationUri: "https://github.com/login/device",
+  expiresIn: 900,
+  pollInterval: 5,
+};
+
+let container: HTMLElement | null = null;
+let root: Root | null = null;
+
+function mountPanel(opts: {
+  poll: (...args: unknown[]) => unknown;
+  onConnected?: () => void;
+  onCancel?: () => void;
+  start?: () => Promise<unknown>;
+}): void {
+  installMockApi({
+    forgeDeviceStart: opts.start ?? (() => Promise.resolve({ connected: false, grant: GRANT, error: null })),
+    forgeDevicePoll: opts.poll,
+    clipboardWriteText: () => Promise.resolve(),
+    forgeDeviceCancel: () => Promise.resolve({ ok: true }),
+  });
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(
+      <ConnectGithubPanel
+        onConnected={opts.onConnected ?? (() => {})}
+        onCancel={opts.onCancel ?? (() => {})}
+      />,
+    );
+  });
+}
+
+async function flushMicro(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
+function unmountPanel(): void {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  if (container) {
+    container.remove();
+    container = null;
+  }
+}
+
+function text(): string {
+  return container?.textContent ?? "";
+}
+
+afterEach(() => {
+  unmountPanel();
+  vi.useRealTimers();
+});
+
+describe("ConnectGithubPanel poll loop", () => {
+  it("does not poll before the first interval elapses (regression: immediate poll)", async () => {
+    vi.useFakeTimers();
+    const poll = vi.fn().mockResolvedValue({ status: "pending", pollInterval: 5 });
+    mountPanel({ poll });
+    await flushMicro();
+
+    expect(poll).not.toHaveBeenCalled();
+    // Before the first 5s interval: still nothing.
+    act(() => {
+      vi.advanceTimersByTime(4000);
+    });
+    expect(poll).not.toHaveBeenCalled();
+
+    // At the first interval the chain starts.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    await flushMicro();
+    expect(poll).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-arms the next poll at the server-returned interval (10s, not 5s)", async () => {
+    vi.useFakeTimers();
+    const poll = vi.fn().mockResolvedValue({ status: "pending", pollInterval: 10 });
+    mountPanel({ poll });
+    await flushMicro();
+
+    // First poll at the initial 5s.
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    await flushMicro();
+    expect(poll).toHaveBeenCalledTimes(1);
+
+    // The response said 10s. At t=9s after the first poll it must NOT fire.
+    act(() => {
+      vi.advanceTimersByTime(9000);
+    });
+    expect(poll).toHaveBeenCalledTimes(1);
+
+    // It fires at 10s after the first poll.
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    await flushMicro();
+    expect(poll).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops after three consecutive error responses and renders the error panel", async () => {
+    vi.useFakeTimers();
+    const poll = vi.fn().mockResolvedValue({ status: "error", error: "boom" });
+    mountPanel({ poll });
+    await flushMicro();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    await flushMicro();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    await flushMicro();
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    await flushMicro();
+
+    expect(poll).toHaveBeenCalledTimes(3);
+    expect(text()).toContain("Couldn't sign in");
+    expect(text()).toContain("boom");
+
+    // Loop is stopped — advancing time fires no further polls.
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    expect(poll).toHaveBeenCalledTimes(3);
+  });
+
+  it("calls onConnected exactly once on a done response and stops the loop", async () => {
+    vi.useFakeTimers();
+    const poll = vi.fn().mockResolvedValue({ status: "done" });
+    const onConnected = vi.fn();
+    mountPanel({ poll, onConnected });
+    await flushMicro();
+
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    await flushMicro();
+    expect(onConnected).toHaveBeenCalledTimes(1);
+
+    // Loop stopped — no further polls, and onConnected doesn't fire again.
+    act(() => {
+      vi.advanceTimersByTime(10000);
+    });
+    expect(poll).toHaveBeenCalledTimes(1);
+    expect(onConnected).toHaveBeenCalledTimes(1);
+  });
+
+  it("calls onConnected immediately when the box already has a credential", async () => {
+    const onConnected = vi.fn();
+    mountPanel({
+      poll: vi.fn(),
+      onConnected,
+      start: () => Promise.resolve({ connected: true, grant: null }),
+    });
+    await flushMicro();
+    expect(onConnected).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders the not-configured panel when the box's client id is a placeholder", async () => {
+    mountPanel({
+      poll: vi.fn(),
+      start: () => Promise.resolve({ connected: false, notConfigured: true, grant: null }),
+    });
+    await flushMicro();
+    expect(text()).toContain("GitHub sign-in isn't configured on this box yet");
+  });
+});

--- a/src/renderer/ConnectGithub.tsx
+++ b/src/renderer/ConnectGithub.tsx
@@ -1,0 +1,333 @@
+// ConnectGithub.tsx — the ONE GitHub device-connect surface (BET-940).
+//
+// Extracted from CloneFromGitHub's [S5] connect phase so the banner wiring (a
+// separate issue) can reuse the identical screen. There must be exactly one
+// implementation of the device flow; it lives here and only here.
+//
+// The component owns, internally:
+//   - the `forgeDeviceStart()` call on mount and its three outcomes
+//     (`connected` → onConnected; `notConfigured` → the "sign-in isn't
+//     configured" panel; otherwise → show the code);
+//   - the countdown + auto clipboard copy of the user code;
+//   - the Cancel button (calls `forgeDeviceCancel` then `onCancel`);
+//   - the "code expired" panel (Try again → restart the flow, Skip for now →
+//     `onCancel`);
+//   - a "couldn't sign in" panel for the error case (Try again / Cancel).
+//
+// POLL-LOOP INVARIANTS (BET-940 §2):
+//   - One self-rescheduling timeout chain, never `setInterval`. The interval
+//     is re-read from EVERY response so GitHub's `slow_down` lengthening is
+//     always honoured — a fixed 5s interval can never catch up once the
+//     required gap exceeds it, and the screen would hang forever.
+//   - NO immediate first poll. GitHub cannot have authorised before the first
+//     interval elapses, and a back-to-back poll (e.g. React StrictMode's
+//     double effect setup) is exactly what trips `slow_down`.
+//   - Three consecutive error responses stop the loop and show the
+//     "couldn't sign in" panel. No silent catch — transport failures are
+//     logged and count toward the same budget.
+
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Button } from "./Button";
+import { Callout } from "./Callout";
+import { DeviceCodeSteps } from "./DeviceFlow";
+import { ship } from "./log";
+import type { ForgeDeviceGrant } from "../shared/types";
+
+// The panel title row (.mhead where it is REAL — [S5] [S6] [E2] [E3]). Moved
+// here so the picker/clone/failed panels in CloneFromGitHub import it rather
+// than redeclaring a second definition.
+export function PanelHeader({
+  title,
+  trailing,
+}: {
+  title: React.ReactNode;
+  trailing?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-3 py-2 border-b border-border-subtle text-[13px] font-medium text-text">
+      {title}
+      {trailing != null && <span className="ml-auto">{trailing}</span>}
+    </div>
+  );
+}
+
+// The shared chrome wrapper for every clone-flow panel. One definition, here.
+export const PANEL_CLASS =
+  "w-full max-w-[420px] rounded-lg border border-border bg-bg-elev overflow-hidden";
+
+// mm:ss countdown label — mono so it doesn't jitter.
+function countdownLabel(remainingMs: number): string {
+  const s = Math.max(0, Math.floor(remainingMs / 1000));
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return `${m}:${String(sec).padStart(2, "0")}`;
+}
+
+// Consecutive `error`/transport failures, or any one start failure, will stop
+// the loop and surface the "couldn't sign in" panel.
+const MAX_CONSECUTIVE_ERRORS = 3;
+
+type Stage =
+  | { kind: "starting" }
+  | { kind: "code" }
+  | { kind: "notConfigured" }
+  | { kind: "expired" }
+  | { kind: "error"; message: string };
+
+export function ConnectGithubPanel({
+  onConnected,
+  onCancel,
+}: {
+  onConnected: () => void;
+  onCancel: () => void;
+}): JSX.Element {
+  const [stage, setStage] = useState<Stage>({ kind: "starting" });
+  const [grant, setGrant] = useState<ForgeDeviceGrant | null>(null);
+  const [remainingMs, setRemainingMs] = useState(0);
+  const [copiedNote, setCopiedNote] = useState(false);
+  const grantRef = useRef<ForgeDeviceGrant | null>(null);
+  // Bumped to restart the whole flow (Try again from the expired/error panes).
+  const [bootSeq, setBootSeq] = useState(0);
+
+  // Callbacks are held in refs so neither the start effect (keyed on bootSeq)
+  // nor the poll effect (keyed on the grant id) re-fires when the parent's
+  // inline handlers change identity on a re-render.
+  const onConnectedRef = useRef(onConnected);
+  onConnectedRef.current = onConnected;
+  const onCancelRef = useRef(onCancel);
+  onCancelRef.current = onCancel;
+
+  // ---- [S5]: start the device grant (mount + every Try again) ----
+  // A box that already has a credential (CLI/secret) skips straight to the
+  // picker via onConnected.
+  useEffect(() => {
+    let cancelled = false;
+    setStage({ kind: "starting" });
+    setGrant(null);
+    setCopiedNote(false);
+    (async () => {
+      try {
+        const res = await window.api.forgeDeviceStart();
+        if (cancelled) return;
+        if ("notConfigured" in res && res.notConfigured) {
+          // The box's device-grant id is a placeholder (BET-849) — surface a
+          // clear "not configured" state, never a guaranteed-dead-end screen.
+          setStage({ kind: "notConfigured" });
+          return;
+        }
+        if (res.connected) {
+          onConnectedRef.current();
+          return;
+        }
+        const g = res.grant!;
+        grantRef.current = g;
+        setGrant(g);
+        setRemainingMs(g.expiresIn * 1000);
+        setStage({ kind: "code" });
+        // Rule 5: copy the code automatically — the user pastes, not retypes.
+        window.api
+          .clipboardWriteText(g.userCode)
+          .then(() => setCopiedNote(true), () => {});
+      } catch {
+        if (cancelled) return;
+        // A connection-level failure surfaces here, not in a caller phase.
+        setStage({ kind: "error", message: "Couldn't reach the box. Try again." });
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, [bootSeq]);
+
+  // ---- [S5]: poll the grant + countdown tick ----
+  // One self-rescheduling timeout chain. The first poll is scheduled at the
+  // full interval (never immediately); after every response the interval is
+  // re-read so slow_down's lengthening is always honoured.
+  useEffect(() => {
+    if (!stage.kind || stage.kind !== "code" || !grant) return;
+    const deadline = Date.now() + grant.expiresIn * 1000;
+    // Mutable per chain; re-read from every response (§2a).
+    let intervalSec = Math.max(grant.pollInterval, 5);
+    // Local error budget — reset by any non-error response (§2c).
+    let consecutiveErrors = 0;
+    let cancelled = false;
+    let inFlight = false;
+    let pollTimer: number | undefined;
+    let ticker: number | undefined;
+
+    const stop = () => {
+      cancelled = true;
+      if (pollTimer !== undefined) window.clearTimeout(pollTimer);
+      if (ticker !== undefined) window.clearInterval(ticker);
+    };
+
+    const fail = (message: string) => {
+      stop();
+      setStage({ kind: "error", message });
+    };
+
+    const scheduleNext = () => {
+      pollTimer = window.setTimeout(runPoll, intervalSec * 1000);
+    };
+
+    const runPoll = async () => {
+      if (cancelled || inFlight) return;
+      inFlight = true;
+      let res;
+      try {
+        res = await window.api.forgeDevicePoll({ grantId: grant.grantId });
+      } catch (e) {
+        // No silent catch — log it and count it toward the error budget.
+        ship("warn", "github device poll failed", { error: String(e) });
+        consecutiveErrors++;
+        inFlight = false;
+        if (cancelled) return;
+        if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+          fail("Couldn't reach the box. Try again.");
+          return;
+        }
+        scheduleNext();
+        return;
+      }
+      inFlight = false;
+      if (cancelled) return;
+      if (res.status === "done") {
+        stop();
+        onConnectedRef.current();
+        return;
+      }
+      if (res.status === "expired") {
+        stop();
+        setStage({ kind: "expired" });
+        return;
+      }
+      if (res.status === "pending") {
+        consecutiveErrors = 0;
+        if (res.pollInterval) intervalSec = Math.max(res.pollInterval, 5);
+        scheduleNext();
+        return;
+      }
+      if (res.status === "error") {
+        consecutiveErrors++;
+        if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
+          fail(res.error || "GitHub sign-in failed.");
+          return;
+        }
+        scheduleNext();
+        return;
+      }
+    };
+
+    // Countdown is separate from the poll loop (pure clock, no network).
+    ticker = window.setInterval(() => setRemainingMs(deadline - Date.now()), 1000);
+    // NO immediate poll — schedule the first at the full interval.
+    scheduleNext();
+    return stop;
+    // Narrowed to the grant id so cosmetic state (remainingMs, copiedNote)
+    // changes never reset the timers.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [grant?.grantId]);
+
+  const restart = useCallback(() => {
+    grantRef.current = null;
+    setCopiedNote(false);
+    setBootSeq((s) => s + 1);
+  }, []);
+
+  const cancelConnect = useCallback(() => {
+    if (grantRef.current) {
+      void window.api.forgeDeviceCancel({ grantId: grantRef.current.grantId });
+    }
+    onCancelRef.current(); // back to [S4] with nothing changed
+  }, []);
+
+  const cancel = useCallback(() => {
+    onCancelRef.current();
+  }, []);
+
+  return (
+    <>
+      {stage.kind === "starting" && (
+        <div className="p-4 text-[13px] text-text-muted">Preparing sign-in…</div>
+      )}
+
+      {stage.kind === "code" && grant && (
+        <>
+          <PanelHeader
+            title="Connect GitHub · Waiting for sign-in"
+            trailing={
+              <span className="font-mono tabular-nums text-[11px] text-text-faint">
+                {countdownLabel(remainingMs)} remaining
+              </span>
+            }
+          />
+          <div className="p-4">
+            <DeviceCodeSteps
+              url={grant.verificationUri}
+              displayUrl={grant.verificationUri.replace(/^https?:\/\//, "")}
+              code={grant.userCode}
+              autoCopied={copiedNote}
+            />
+            <div className="flex gap-2 mt-3">
+              <Button tone="ghost" onClick={cancelConnect}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {stage.kind === "notConfigured" && (
+        <>
+          <PanelHeader title="Connect GitHub" />
+          <div className="p-4">
+            <Callout tone="warn">
+              GitHub sign-in isn't configured on this box yet.
+            </Callout>
+            <div className="flex gap-2 mt-3">
+              <Button tone="ghost" onClick={cancel}>
+                Back
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {stage.kind === "expired" && (
+        <>
+          <PanelHeader title="Connect GitHub · Failed" />
+          <div className="p-4">
+            <Callout tone="danger">
+              The sign-in code expired before it was entered.
+            </Callout>
+            <div className="flex gap-2 mt-3">
+              <Button tone="primary" onClick={restart}>
+                Try again
+              </Button>
+              <Button tone="ghost" onClick={cancel}>
+                Skip for now
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+
+      {stage.kind === "error" && (
+        <>
+          <PanelHeader title="Connect GitHub · Failed" />
+          <div className="p-4">
+            <Callout tone="danger">Couldn't sign in: {stage.message}</Callout>
+            <div className="flex gap-2 mt-3">
+              <Button tone="primary" onClick={restart}>
+                Try again
+              </Button>
+              <Button tone="ghost" onClick={cancel}>
+                Cancel
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/server/forge/auth.mjs
+++ b/src/server/forge/auth.mjs
@@ -281,9 +281,9 @@ export function invalidateToken(host) {
 //   2. `user_code` is NOT baked into the verification URL (no query string) —
 //      that would lengthen what the user types and remove our ability to
 //      highlight a typo.
-//   3. `slow_down` adds 5s PERMANENTLY to the poll interval (GitHub's
-//      directive); `authorization_pending` keeps polling; `expired_token` is a
-//      typed ExpiredCodeError ([E2]).
+//   3. `slow_down` trusts GitHub's authoritative `interval` when present and
+//      falls back to +5s (GitHub's own directive); `authorization_pending`
+//      keeps polling; `expired_token` is a typed ExpiredCodeError ([E2]).
 //   4. normalizeUserCode strips dashes/whitespace and uppercases before any
 //      comparison, so `wdjb-mjht ` matches `WDJBMJHT`.
 //   5. The code is copied to the clipboard automatically (the renderer does
@@ -415,8 +415,8 @@ export function cancelDeviceGrant(grantId) {
  * in the secrets vault under `GITHUB_TOKEN` (shared scope) via storeToken and
  * the ladder's resolution cache is invalidated so the stored secret is picked
  * up next boot. `authorization_pending` returns `{ status: "pending" }`;
- * `slow_down` bumps the poll interval +5s permanently; `expired_token` throws
- * ExpiredCodeError ([E2]).
+ * `slow_down` trusts GitHub's authoritative `interval` (falling back to +5s
+ * when it's absent/invalid); `expired_token` throws ExpiredCodeError ([E2]).
  *
  * @param {string} grantId
  * @param {{ clientId?: string, fetch?: typeof fetch, now?: () => number, storeToken?: (token: string) => Promise<{ ok: boolean, error?: string }> }} [opts]
@@ -454,7 +454,8 @@ export async function pollDeviceGrant(
   }
   if (raw.error === "authorization_pending") return { status: "pending", pollInterval: grant.intervalSec };
   if (raw.error === "slow_down") {
-    grant.intervalSec += 5;
+    const next = Number(raw.interval);
+    grant.intervalSec = Number.isFinite(next) && next > 0 ? next : grant.intervalSec + 5;
     return { status: "pending", pollInterval: grant.intervalSec };
   }
   if (raw.error === "expired_token") {

--- a/src/server/forge/auth.test.mjs
+++ b/src/server/forge/auth.test.mjs
@@ -220,7 +220,7 @@ test("device grant: happy path returns a RENDERER-SAFE shape and stores the toke
   assert.ok(seen.every((d) => d === "DEVICE_CODE_SECRET"));
 });
 
-test("device grant: slow_down adds 5s PERMANENTLY to the poll interval", async () => {
+test("device grant: slow_down without an interval falls back to previous + 5", async () => {
   const clock = makeClock();
   const fetchFn = makeFetch(async () => ({ error: "slow_down", error_description: "slow" }));
   const started = await startDeviceGrant({ clientId: "Iv1.realclientid", fetch: fetchFn, now: clock.now });
@@ -229,6 +229,24 @@ test("device grant: slow_down adds 5s PERMANENTLY to the poll interval", async (
   assert.equal(p1.pollInterval, 10);
   const p2 = await pollDeviceGrant(started.grantId, { fetch: fetchFn, now: clock.now, storeToken: okStore });
   assert.equal(p2.pollInterval, 15);
+});
+
+test("device grant: slow_down trusts GitHub's authoritative interval field", async () => {
+  const clock = makeClock();
+  const fetchFn = makeFetch(async () => ({ error: "slow_down", interval: 12 }));
+  const started = await startDeviceGrant({ clientId: "Iv1.realclientid", fetch: fetchFn, now: clock.now });
+  const p1 = await pollDeviceGrant(started.grantId, { fetch: fetchFn, now: clock.now, storeToken: okStore });
+  assert.equal(p1.pollInterval, 12, "the server-returned interval wins, not the +5 guess");
+  const p2 = await pollDeviceGrant(started.grantId, { fetch: fetchFn, now: clock.now, storeToken: okStore });
+  assert.equal(p2.pollInterval, 12, "the same interval is reused, not incremented again");
+});
+
+test("device grant: slow_down with an invalid interval falls back to previous + 5", async () => {
+  const clock = makeClock();
+  const fetchFn = makeFetch(async () => ({ error: "slow_down", interval: "nope" }));
+  const started = await startDeviceGrant({ clientId: "Iv1.realclientid", fetch: fetchFn, now: clock.now });
+  const p1 = await pollDeviceGrant(started.grantId, { fetch: fetchFn, now: clock.now, storeToken: okStore });
+  assert.equal(p1.pollInterval, 10);
 });
 
 test("device grant: authorization_pending keeps polling at the same interval", async () => {


### PR DESCRIPTION
Fixes the GitHub device sign-in hang (BET-940).

## What changed

- **New `src/renderer/ConnectGithub.tsx`** — the ONE device-connect surface (`ConnectGithubPanel`), extracted from CloneFromGitHub's connect phase. Also moves `PanelHeader` + `PANEL_CLASS` here (exported, imported back) so there's a single definition of each.
- **Fixed poll loop** (the core defect): CloneFromGitHub polled on a fixed 5s `setInterval` armed once, so when GitHub's `slow_down` lengthened the required gap the new interval was assigned to a variable never read again — the loop could never catch up and the screen hung. The new panel uses one self-rescheduling `setTimeout` chain that re-reads the interval from every response, schedules the FIRST poll at the full interval (no immediate poll — that's what trips `slow_down`, doubly under StrictMode), and guards re-entrancy.
- **No silent catch**: transport failures are logged via `ship("warn", …)` and count toward the consecutive-error budget.
- **Three consecutive `error` responses** stop the loop and render a new "couldn't sign in" panel with Try again / Cancel.
- **`src/server/forge/auth.mjs`** — `slow_down` now trusts GitHub's authoritative `interval` field (falling back to previous + 5) instead of unconditionally adding 5.
- **`CloneFromGitHub.tsx`** — 595 → 400 lines; no device-flow logic remains.

## Verification results
- PR branch (`multica/BET-940-fix-github-device-poll` @ `0d9cce57`): typecheck exit 0 (no errors); test 2052 pass / 0 fail.
- Server auth tests: 23 pass (incl. new slow_down interval-preference + fallback cases).
- New renderer tests (`ConnectGithub.test.tsx`, fake timers + stubbed `window.api`): 6 pass — no-poll-before-first-interval, re-arm at server interval (10s not 5s), 3-consecutive-errors → error panel, done → `onConnected` exactly once, immediate-connected, not-configured.
- `Base: origin/main @ 0cdaa9b4`

**Base comparison:** `main` @ `0cdaa9b4` — typecheck exit 0, test 2050 pass / 0 fail. Conclusion: 0 new failures on this PR (2 new node tests + 6 new vitest tests added, all green).
