### PR TITLE
fix(renderer): scrollable clone picker, sane card size, filter-independent selection (BET-944)

### DIFF
--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment jsdom
+//
+// Regression tests for the clone picker layout + selection semantics
+// (BET-944).
+//
+// The two defects this pins:
+//   1. `selected` was derived from `filtered`, so once a search term stopped
+//      matching a checked repo, the repo silently vanished from the selection
+//      and from the "Clone N selected" count — the clone could no longer be
+//      started for it. Selection must derive from the full `repos` array.
+//   2. The pick panel was a plain, unbounded div, so with enough repos the
+//      row list pushed the search box and clone button out of view inside the
+//      `overflow-hidden` panel. Now the panel is a bounded flex column whose
+//      repo rows scroll (`overflow-y-auto`) while the search field and button
+//      row stay pinned outside the scroller.
+//
+// These mount the real CloneFromGitHub, stubbing `window.api` with an
+// existing credential (so the picker renders immediately) and a fixed repo
+// list.
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { CloneFromGitHub } from "./CloneFromGitHub";
+import { installMockApi, type MockApi } from "./testHarness";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+type Repo = {
+  name: string;
+  fullName: string;
+  owner: string;
+  description: string | null;
+  pushedAt: number | null;
+  defaultBranch: string;
+  cloneUrl: string;
+  url: string;
+};
+
+const REPOS: Repo[] = [
+  { name: "alpha", fullName: "me/alpha", owner: "me", description: "Alpha", pushedAt: 1000, defaultBranch: "main", cloneUrl: "https://github.com/me/alpha.git", url: "https://github.com/me/alpha" },
+  { name: "beta", fullName: "me/beta", owner: "me", description: "Beta", pushedAt: 800, defaultBranch: "main", cloneUrl: "https://github.com/me/beta.git", url: "https://github.com/me/beta" },
+  { name: "gamma", fullName: "other/gamma", owner: "other", description: "Gamma", pushedAt: 500, defaultBranch: "main", cloneUrl: "https://github.com/other/gamma.git", url: "https://github.com/other/gamma" },
+];
+
+const CLONE_DONE = {
+  id: "c1",
+  name: "alpha",
+  url: "https://github.com/me/alpha.git",
+  dest: "/root/alpha",
+  percent: 100,
+  bytes: 10,
+  done: true,
+  ok: true,
+  error: null,
+  cancelled: false,
+};
+
+let container: HTMLElement | null = null;
+let root: Root | null = null;
+let api: MockApi;
+
+function mountPicker(): void {
+  ({ api } = installMockApi({
+    // Existing credential — the picker renders immediately, skipping the
+    // device-connect screen.
+    forgeDeviceStart: () => Promise.resolve({ connected: true, grant: null }),
+    forgeRepos: () => Promise.resolve({ repos: REPOS, stale: false, error: null }),
+    forgeCloneStart: () => Promise.resolve({ id: "c1" }),
+    forgeCloneStatus: () => Promise.resolve(CLONE_DONE),
+  }));
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(
+      <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
+    );
+  });
+}
+
+async function flushMicro(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await new Promise((r) => setTimeout(r, 0));
+    await Promise.resolve();
+  });
+}
+
+function unmount(): void {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  if (container) {
+    container.remove();
+    container = null;
+  }
+}
+
+function typeInto(input: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  act(() => {
+    setter?.call(input, value);
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  });
+}
+
+function searchInput(): HTMLInputElement {
+  return container!.querySelector(
+    'input[aria-label="Search repositories"]',
+  ) as HTMLInputElement;
+}
+
+function cloneButtonFor(name: string): HTMLButtonElement {
+  return Array.from(container!.querySelectorAll<HTMLButtonElement>("button")).find(
+    (b) => b.textContent?.includes(`Clone ${name}`),
+  ) as HTMLButtonElement;
+}
+
+afterEach(() => {
+  unmount();
+});
+
+describe("CloneFromGitHub picker", () => {
+  it("keeps a checked repo selected when the search term excludes it, and clones it on submit", async () => {
+    mountPicker();
+    await flushMicro();
+
+    const alphaBox = container!.querySelector(
+      'input[aria-label="Clone alpha"]',
+    ) as HTMLInputElement;
+    expect(alphaBox).toBeTruthy();
+    act(() => {
+      alphaBox.click();
+    });
+    expect(cloneButtonFor("1 selected")).toBeTruthy();
+
+    // Search for something that no longer matches alpha.
+    typeInto(searchInput(), "gamma");
+    await flushMicro();
+
+    // alpha's row is filtered out of view…
+    expect(container!.querySelector('input[aria-label="Clone alpha"]')).toBeNull();
+    // …but the selection and the button survive, and are independent of the
+    // filter (§1 regression).
+    expect(cloneButtonFor("1 selected")).toBeTruthy();
+
+    act(() => {
+      cloneButtonFor("1 selected").click();
+    });
+    await flushMicro();
+
+    const startCalls = api.calls.forgeCloneStart ?? [];
+    expect(startCalls.length).toBe(1);
+    // The clone runs for the still-selected (but filtered-out) repo.
+    expect(startCalls[0][0]).toMatchObject({ url: REPOS[0].cloneUrl });
+  });
+
+  it("puts the repo rows in an overflow-y-auto container that excludes the button row", async () => {
+    mountPicker();
+    await flushMicro();
+
+    const scroller = container!.querySelector<HTMLElement>(".overflow-y-auto");
+    expect(scroller).toBeTruthy();
+    // The repo rows live inside the scroller…
+    const alphaBox = container!.querySelector(
+      'input[aria-label="Clone alpha"]',
+    ) as HTMLElement;
+    expect(scroller!.contains(alphaBox)).toBe(true);
+    // …but the button row and the search field do not (§2 — DOM containment,
+    // not class-string matching on the whole tree).
+    expect(scroller!.contains(cloneButtonFor("0 selected"))).toBe(false);
+    expect(scroller!.contains(searchInput())).toBe(false);
+  });
+});

--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -18,7 +18,7 @@
 // existing credential (so the picker renders immediately) and a fixed repo
 // list.
 
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { CloneFromGitHub } from "./CloneFromGitHub";
@@ -44,15 +44,15 @@ const REPOS: Repo[] = [
   { name: "gamma", fullName: "other/gamma", owner: "other", description: "Gamma", pushedAt: 500, defaultBranch: "main", cloneUrl: "https://github.com/other/gamma.git", url: "https://github.com/other/gamma" },
 ];
 
-const CLONE_DONE = {
+const CLONE_IN_PROGRESS = {
   id: "c1",
   name: "alpha",
   url: "https://github.com/me/alpha.git",
   dest: "/root/alpha",
-  percent: 100,
-  bytes: 10,
-  done: true,
-  ok: true,
+  percent: 0,
+  bytes: 0,
+  done: false,
+  ok: false,
   error: null,
   cancelled: false,
 };
@@ -68,7 +68,7 @@ function mountPicker(): void {
     forgeDeviceStart: () => Promise.resolve({ connected: true, grant: null }),
     forgeRepos: () => Promise.resolve({ repos: REPOS, stale: false, error: null }),
     forgeCloneStart: () => Promise.resolve({ id: "c1" }),
-    forgeCloneStatus: () => Promise.resolve(CLONE_DONE),
+    forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
   }));
   container = document.createElement("div");
   document.body.appendChild(container);

--- a/src/renderer/CloneFromGitHub.tsx
+++ b/src/renderer/CloneFromGitHub.tsx
@@ -115,7 +115,7 @@ export function CloneFromGitHub({
     });
   };
 
-  const selected = filtered.filter((r) => checked.has(r.fullName));
+  const selected = repos.filter((r) => checked.has(r.fullName));
 
   // Derive the on-disk destination for a repo: <root>/<name>.
   const destFor = (repo: ForgeRepo) =>
@@ -205,7 +205,7 @@ export function CloneFromGitHub({
     // this is strictly the repo-retry path.
     runClones(
       [
-        ...filtered.filter((r) => checked.has(r.fullName) && r.fullName !== phase.repo?.fullName),
+        ...repos.filter((r) => checked.has(r.fullName) && r.fullName !== phase.repo?.fullName),
         phase.repo,
       ],
       0,
@@ -252,7 +252,7 @@ export function CloneFromGitHub({
               </div>
             }
           />
-          <div className="p-4">
+          <div className="p-4 flex flex-col max-h-[70vh]">
             <Field
               ariaLabel="Search repositories"
               value={search}
@@ -264,7 +264,7 @@ export function CloneFromGitHub({
                 <Callout tone="danger">{reposError}</Callout>
               </div>
             )}
-            <div className="mt-1">
+            <div className="mt-1 flex-1 min-h-0 overflow-y-auto">
               {filtered.map((r) => (
                 <ListRow
                   key={r.fullName}

--- a/src/renderer/ConnectGithub.tsx
+++ b/src/renderer/ConnectGithub.tsx
@@ -53,7 +53,7 @@ export function PanelHeader({
 
 // The shared chrome wrapper for every clone-flow panel. One definition, here.
 export const PANEL_CLASS =
-  "w-full max-w-[420px] rounded-lg border border-border bg-bg-elev overflow-hidden";
+  "w-full max-w-[520px] rounded-lg border border-border bg-bg-elev overflow-hidden";
 
 // mm:ss countdown label — mono so it doesn't jitter.
 function countdownLabel(remainingMs: number): string {

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -1038,7 +1038,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
               </>
             )}
         </>
-        ))}
+        )}
 
         {error && (
           <Card danger>

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -721,6 +721,13 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
     // scripts/visual/screens.mjs). One stable attribute per screen root, so
     // the harness never depends on a class name or DOM position.
     <div data-screen="welcome" className="h-full flex flex-col items-center justify-center px-8">
+      {cloneOpen ? (
+        <CloneFromGitHub
+          defaultRoot={proposedCloneRoot}
+          onCancel={() => setCloneOpen(false)}
+          onCloned={(paths) => void setupCloned(paths)}
+        />
+      ) : (
       <div className="w-full max-w-[720px] rounded-xl border border-border-subtle bg-bg-elev px-6 py-10 flex flex-col gap-2">
         {showComposer ? (
         <>
@@ -856,15 +863,6 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
             )}
         </div>
         </>
-        ) : (
-        cloneOpen ? (
-          <div className="flex justify-center">
-            <CloneFromGitHub
-              defaultRoot={proposedCloneRoot}
-              onCancel={() => setCloneOpen(false)}
-              onCloned={(paths) => void setupCloned(paths)}
-            />
-          </div>
         ) : (
         <>
             {zeroState === "scanning" ? (
@@ -1048,6 +1046,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
           </Card>
         )}
       </div>
+      )}
 
       <FolderPickerModal
           open={pickerOpen}


### PR DESCRIPTION
Closes BET-944.

## Changes
1. **Filter-independent selection** — `selected` and the `retryClone` queue now derive from the full `repos` array, not `filtered`. A checked repo survives a search term that hides it (and still counts/clones). No new chrome.
2. **Scrollable list** — the `pick` panel is now a bounded `flex flex-col max-h-[70vh]` column: search field + error callout pinned at top, repo rows in a `flex-1 min-h-0 overflow-y-auto` scroller (`min-h-0` required for overflow to engage), "Clone into" line + button row pinned at bottom outside the scroller. No virtualisation / load-more / row cap.
3. **Panel owns the card** — when `cloneOpen` is true, `NewSessionScreen` renders `CloneFromGitHub` centred as the card, skipping the 720px wrapper. `PANEL_CLASS` widened 420px → 520px (shared with the connect panel — one width for the whole flow).

## Not touched
- `clone` (progress) and `failed` phases, `ConnectGithubPanel`/device flow, `src/server/**`, other `NewSessionScreen` branches.

## Tests
Added `src/renderer/CloneFromGitHub.test.tsx` (stubbed `window.api`, existing credential so the picker renders immediately):
1. check a repo → search a term that excludes it → button still reads "Clone 1 selected" and clicking starts the clone for that repo (§1 regression guard).
2. the repo-row container carries `overflow-y-auto` and the button row + search field are outside it (DOM-containment assertion, §2 regression guard).

## Verification
- `npm run typecheck` — pass
- `npm test` — 2057 pass / 0 fail
- No visual snapshot covers the clone picker screen; the `welcome` snapshot (composer state) is behavior-identical and unchanged.