### PR TITLE
feat(server,renderer): make GitHub Disconnect a persisted opt-out (BET-942)

### DIFF
--- a/src/renderer/Settings.test.tsx
+++ b/src/renderer/Settings.test.tsx
@@ -19,6 +19,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { act } from "react";
 import { mount, installMockApi, type Harness } from "./testHarness";
 import { Settings } from "./Settings";
+import { useStore } from "./store";
 
 // The confirm used for test 1. "Reset all settings?" (confirmReset) opens from
 // the default General tab's Danger zone.
@@ -153,5 +154,66 @@ describe("Settings — Escape + nested-confirm ownership (BET-724 regression)", 
     // Wrapped to the confirm's first control (Cancel) — still inside it.
     expect(document.activeElement).toBe(focusables[0]);
     expect(confirm!.contains(document.activeElement)).toBe(true);
+  });
+});
+
+// BET-942: Settings → Forge → Disconnect now persists a real opt-out on the
+// box, so the toast deliberately has NO Undo action (Undo only restored local
+// state while the box stayed connected — a lie). The disconnect is one RPC
+// call, and the connected row flips to not-connected.
+describe("Settings — Forge Disconnect (BET-942)", () => {
+  let h: Harness | null = null;
+
+  const stubApi = (forgeDisconnectMock: () => void) =>
+    installMockApi({
+      configGet: () => Promise.resolve({}),
+      getClientVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      getServerVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      pluginsRegistry: () => Promise.resolve([]),
+      launchersList: () => Promise.resolve([]),
+      forgeStatus: () =>
+        Promise.resolve({
+          connected: true,
+          login: "octocat",
+          kind: "github",
+          source: "cli",
+        }),
+      forgeRulesList: () => Promise.resolve([]),
+      forgeDisconnect: () => Promise.resolve({ ok: true }).then(forgeDisconnectMock),
+    });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    useStore.setState({ appToasts: [] });
+  });
+
+  it("clicking Disconnect calls forgeDisconnect once and the toast has no Undo action", async () => {
+    const calls: string[] = [];
+    const { api } = stubApi(() => {
+      calls.push("disconnect");
+    });
+    h = mount(<Settings onClose={() => {}} initialSection="extensions" />);
+    await h.flush();
+    await h.flush();
+
+    const disconnect = [...h.container.querySelectorAll("button")].find(
+      (b) => (b.textContent ?? "").trim() === "Disconnect",
+    );
+    expect(disconnect, "the Disconnect button on the connected row").toBeTruthy();
+    act(() => (disconnect as HTMLButtonElement).click());
+    await h.flush();
+
+    expect(api.calls.forgeDisconnect ?? []).toHaveLength(1);
+    expect(calls).toEqual(["disconnect"]);
+
+    const toast = useStore
+      .getState()
+      .appToasts.find((t) => String(t.message).includes("Disconnected GitHub"));
+    expect(toast, "the disconnect confirmation toast").toBeTruthy();
+    expect(toast!.message).toContain(
+      "Your gh CLI is untouched — Manta will ignore it until you reconnect.",
+    );
+    expect(toast!.actions, "no Undo action — reconnect only via device sign-in").toBeUndefined();
   });
 });

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -510,11 +510,13 @@ export function Settings({
     }
   };
   const disconnectForge = async () => {
-    const prev = forgeStatus;
     try {
       const r = await window.api.forgeDisconnect();
       if (r?.ok) setForgeStatus({ connected: false });
-      push({ id: `forge-dc-${Date.now()}`, message: "Disconnected the GitHub account on this box.", actions: [{ label: "Undo", onClick: () => setForgeStatus(prev) }] });
+      // No Undo action here — Undo was a lie (it only restored local state
+      // while the box stayed disconnected). The box now ignores the gh CLI
+      // until a successful device sign-in clears the flag (BET-942).
+      push({ id: `forge-dc-${Date.now()}`, message: "Disconnected GitHub. Your gh CLI is untouched — Manta will ignore it until you reconnect." });
     } catch (e) {
       push({ id: `err-forge-dc-${Date.now()}`, message: errorDisclosure("Couldn't disconnect GitHub.", e) });
     }
@@ -816,7 +818,7 @@ export function Settings({
               <ListRow
                 leading={<StatusDot tone="idle" />}
                 name="GitHub"
-                secondary="Not connected — authenticate the gh CLI on this box to register forge webhooks."
+                secondary="Not connected."
               />
             )}
             {/* Divider — the mockup's border-top between connection and rules. */}

--- a/src/server/forge/auth.mjs
+++ b/src/server/forge/auth.mjs
@@ -35,6 +35,7 @@
 import { randomBytes } from "node:crypto";
 import { runLoginShell } from "../launchers.mjs";
 import { resolveSecret, loadSecrets, setSecret } from "../secrets.mjs";
+import { configGet, configUpdate } from "../local.mjs";
 import { readFile as fsReadFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -187,14 +188,26 @@ function storedToken(host, loadSecretsFn) {
  * `invalidateToken` clears a host's entry for the rotation case.
  *
  * @param {string} host
- * @param {{ shell?: (cmd: string) => Promise<{stdout: string}>, loadSecretsFn?: () => unknown, env?: NodeJS.ProcessEnv, now?: () => number }} [opts]
+ * @param {{ shell?: (cmd: string) => Promise<{stdout: string}>, loadSecretsFn?: () => unknown, env?: NodeJS.ProcessEnv, now?: () => number, getConfig?: () => Promise<{ forgeDisconnected?: boolean }> }} [opts]
  * @returns {Promise<{ token: string, source: "env" | "cli" | "stored" } | null>}
  */
 export async function resolveToken(
   host,
-  { shell = runLoginShell, loadSecretsFn = loadSecrets, env = process.env, now = Date.now, readFile, home } = {},
+  { shell = runLoginShell, loadSecretsFn = loadSecrets, env = process.env, now = Date.now, readFile, home, getConfig = configGet } = {},
 ) {
   if (typeof host !== "string" || !host) return null;
+
+  // BET-942: an explicit Disconnect opt-out short-circuits the whole ladder
+  // before the cache and before any rung — even if the env var / gh CLI /
+  // stored secret would match. The read is best-effort: an unreadable config
+  // is treated as NOT disconnected, so a corrupt config can't lock the user
+  // out of their own forge.
+  try {
+    const cfg = await getConfig();
+    if (cfg?.forgeDisconnected === true) return null;
+  } catch {
+    /* unreadable config → not disconnected */
+  }
 
   const hit = CACHE.get(host);
   if (hit && now() - hit.at < TTL_MS) {
@@ -257,6 +270,15 @@ export async function rotateOauthPair(refresh, persistPair) {
  */
 export function invalidateToken(host) {
   CACHE.delete(host);
+}
+
+/**
+ * Clear the persisted disconnect opt-out (a successful sign-in reconnects).
+ * Rides the same box config writer every config field uses.
+ * @param {{ update?: (patch: object) => Promise<unknown> }} [opts]
+ */
+export async function clearDisconnect({ update = configUpdate } = {}) {
+  await update({ forgeDisconnected: false });
 }
 
 // ===========================================================================
@@ -419,12 +441,12 @@ export function cancelDeviceGrant(grantId) {
  * when it's absent/invalid); `expired_token` throws ExpiredCodeError ([E2]).
  *
  * @param {string} grantId
- * @param {{ clientId?: string, fetch?: typeof fetch, now?: () => number, storeToken?: (token: string) => Promise<{ ok: boolean, error?: string }> }} [opts]
+ * @param {{ clientId?: string, fetch?: typeof fetch, now?: () => number, storeToken?: (token: string) => Promise<{ ok: boolean, error?: string }>, clearDisconnect?: () => Promise<unknown> }} [opts]
  * @returns {Promise<{ status: "pending" | "done", pollInterval?: number }>}
  */
 export async function pollDeviceGrant(
   grantId,
-  { clientId = DEVICE_CLIENT_ID, fetch: fetchFn = globalThis.fetch, now = Date.now, storeToken = defaultStoreToken } = {},
+  { clientId = DEVICE_CLIENT_ID, fetch: fetchFn = globalThis.fetch, now = Date.now, storeToken = defaultStoreToken, clearDisconnect: clearDisconnectFn = clearDisconnect } = {},
 ) {
   const grant = ACTIVE_GRANTS.get(grantId);
   if (!grant) {
@@ -468,6 +490,7 @@ export async function pollDeviceGrant(
   const stored = await storeToken(raw.access_token);
   if (!stored.ok) throw new Error(stored.error || "couldn't store the token");
   ACTIVE_GRANTS.delete(grantId);
+  await clearDisconnectFn();
   invalidateToken(GITHUB_CLI_HOST);
   return { status: "done" };
 }

--- a/src/server/forge/auth.test.mjs
+++ b/src/server/forge/auth.test.mjs
@@ -130,6 +130,52 @@ test("resolveToken: CLI failure (gh missing) falls through to stored", async () 
   assert.deepEqual(r, { token: "ghp_stored", source: "stored" });
 });
 
+test("resolveToken: persisted disconnect flag returns null even when every rung matches", async () => {
+  // Env var AND gh CLI AND a stored secret would all match — but the box has
+  // been explicitly disconnected, so the ladder resolves nothing.
+  const r = await resolveToken("github.com", {
+    env: { MANTA_GITHUB_TOKEN: "ghp_env" },
+    shell: shellReturning("ghp_cli\n"),
+    loadSecretsFn: loadWith(STORED),
+    getConfig: async () => ({ forgeDisconnected: true }),
+  });
+  assert.equal(r, null);
+});
+
+test("resolveToken: disconnected flag resolves null without invoking the shell or secrets", async () => {
+  let shellCalls = 0;
+  const r = await resolveToken("github.com", {
+    env: { MANTA_GITHUB_TOKEN: "ghp_env" },
+    shell: async () => (shellCalls++, { stdout: "ghp_cli\n" }),
+    loadSecretsFn: loadWith(STORED),
+    getConfig: async () => ({ forgeDisconnected: true }),
+  });
+  assert.equal(r, null);
+  assert.equal(shellCalls, 0, "disconnect short-circuits before the CLI rung");
+});
+
+test("resolveToken: absent/other config leaves the ladder unchanged", async () => {
+  const r = await resolveToken("github.com", {
+    env: NO_ENV,
+    shell: shellReturning("ghp_cli\n"),
+    loadSecretsFn: loadWith([]),
+    getConfig: async () => ({}),
+  });
+  assert.deepEqual(r, { token: "ghp_cli", source: "cli" });
+});
+
+test("resolveToken: an unreadable config resolves normally (not treated as disconnected)", async () => {
+  const r = await resolveToken("github.com", {
+    env: NO_ENV,
+    shell: shellReturning("ghp_cli\n"),
+    loadSecretsFn: loadWith([]),
+    getConfig: async () => {
+      throw new Error("corrupt config");
+    },
+  });
+  assert.deepEqual(r, { token: "ghp_cli", source: "cli" });
+});
+
 test("resolveToken: cached hit within TTL does not re-invoke the shell", async () => {
   const clock = makeClock();
   const seen = [];
@@ -211,9 +257,9 @@ test("device grant: happy path returns a RENDERER-SAFE shape and stores the toke
   assert.equal(typeof started.grantId, "string");
 
   let stored = null;
-  const pending = await pollDeviceGrant(started.grantId, { fetch: fetchFn, now: clock.now, storeToken: async (t) => (stored = t, { ok: true }) });
+  const pending = await pollDeviceGrant(started.grantId, { fetch: fetchFn, now: clock.now, storeToken: async (t) => (stored = t, { ok: true }), clearDisconnect: async () => {} });
   assert.deepEqual(pending, { status: "pending", pollInterval: 5 });
-  const done = await pollDeviceGrant(started.grantId, { fetch: fetchFn, now: clock.now, storeToken: async (t) => (stored = t, { ok: true }) });
+  const done = await pollDeviceGrant(started.grantId, { fetch: fetchFn, now: clock.now, storeToken: async (t) => (stored = t, { ok: true }), clearDisconnect: async () => {} });
   assert.deepEqual(done, { status: "done" });
   assert.equal(stored, "ghp_device_ok", "token stored under GITHUB_TOKEN");
   // The device_code used on the wire is the box-side secret, never surfaced.
@@ -289,6 +335,25 @@ test("device grant: token is reused at next boot (stored secret resolves)", asyn
   });
   assert.deepEqual(r, { token: "ghp_device_ok", source: "stored" });
   invalidateToken("github.com");
+});
+
+test("device grant: success path clears the persisted disconnect flag (reconnect)", async () => {
+  // A box that was disconnected stays disconnected until a successful device
+  // sign-in — which must clear the opt-out so the ladder resolves again.
+  const clock = makeClock();
+  let cleared = 0;
+  const fetchFn = makeFetch(async () => ({ access_token: "ghp_reconnect", token_type: "bearer" }));
+  const started = await startDeviceGrant({ clientId: "Iv1.realclientid", fetch: fetchFn, now: clock.now });
+  const done = await pollDeviceGrant(started.grantId, {
+    fetch: fetchFn,
+    now: clock.now,
+    storeToken: okStore,
+    clearDisconnect: async () => {
+      cleared++;
+    },
+  });
+  assert.deepEqual(done, { status: "done" });
+  assert.equal(cleared, 1, "a successful device sign-in reconnects by clearing the flag");
 });
 
 test("normalizeUserCode strips dashes/whitespace and uppercases", () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -346,7 +346,17 @@ export function buildHandlers({
       }));
     },
     // preload: ipcRenderer.invoke(IPC.forgeDisconnect) → no args
-    "forge:disconnect": () => {
+    // BET-942: Disconnect is now a PERSISTED opt-out, not a 60s-cache clear.
+    // While the flag is set the credential ladder (auth.mjs resolveToken)
+    // resolves nothing regardless of env/CLI/secret — so the gh CLI is NOT
+    // logged out (not ours to touch) but the box ignores it. We also delete
+    // the shared GITHUB_TOKEN secret Manta's own device flow wrote (a missing
+    // secret is not an error). A successful device sign-in clears the flag.
+    "forge:disconnect": async () => {
+      await local.configUpdate({ forgeDisconnected: true });
+      const secrets = secretsListStore({ includeAll: true });
+      const ghToken = secrets.find((s) => s.key === "GITHUB_TOKEN" && s.scope === "shared");
+      if (ghToken) await secretsDeleteStore(ghToken.id);
       invalidateForgeToken(GH_HOST);
       return { ok: true };
     },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -137,6 +137,11 @@ export type AppConfig = {
   // Rides the generic configGet/configUpdate channel like every other
   // AppConfig field.
   forgeConnectOfferDismissed?: boolean;
+  // BET-942: set by Settings → Forge → Disconnect. While true the box's forge
+  // credential ladder resolves nothing, even if the gh CLI / env var / stored
+  // secret would match. Cleared by a successful device sign-in. Rides the
+  // generic configGet/configUpdate channel like the field above.
+  forgeDisconnected?: boolean;
   // Global default model for all new and cleared chat sessions. Stored as
   // { providerID, modelID } so the per-session localStorage override and
   // this setting use the same shape. When absent, opencode picks its own


### PR DESCRIPTION
## Summary

Makes GitHub **Disconnect** actually disconnect. Previously `forge:disconnect` only cleared a 60-second in-memory token cache, so the very next `resolveToken` re-walked the env → `gh` CLI → stored-secret ladder, found the `gh` CLI, and reported connected again the moment Settings reopened.

Disconnect is now an explicit, **persisted opt-out** flag on the box (`forgeDisconnected` in config):

- **`resolveToken`** (the ONE forge token resolver) short-circuits to `null` — before the cache and before any rung — while the flag is set, even when the env var / gh CLI / stored secret would match. The `gh` CLI is NOT logged out (not ours to touch), the box just ignores it. An unreadable config is treated as *not* disconnected so a corrupt config can't lock the user out.
- **`forge:disconnect` RPC** persists `{forgeDisconnected:true}`, deletes the shared `GITHUB_TOKEN` secret Manta's own device flow wrote (missing secret is not an error), then invalidates the token cache.
- **`clearDisconnect`** helper is exported and called from `pollDeviceGrant`'s success path immediately before the existing cache invalidation — so completing any device sign-in reconnects.
- **Settings** drops the now-lying Undo action (it only restored local state), fixes the toast copy, and shortens the not-connected row to "Not connected."

Out of scope (unchanged): no Reconnect button (reconnect flows through the existing device-sign-in surfaces), no change to `forgeStatus`'s return shape, nothing in the forge adapters.

**Files changed:** 6 files.
- src/shared/types.ts — `forgeDisconnected?: boolean` next to `forgeConnectOfferDismissed`
- src/server/forge/auth.mjs — flag gate in `resolveToken`, `clearDisconnect` helper wired into device-grant success
- src/server/forge/rpc.mjs — `forge:disconnect` persists flag + deletes stored secret
- src/server/forge/auth.test.mjs — 5 new tests
- src/renderer/Settings.tsx — toast copy, no Undo, "Not connected."
- src/renderer/Settings.test.tsx — Disconnect calls forgeDisconnect once, toast has no Undo

**Base: origin/main @ 8f776f8c**

## Verification results
- PR branch (`multica/BET-942-forge-disconnect-persist` @ `fb3088e5`):
  - typecheck: exit 0. Errors: none. log sha256: `e06fda014d5b6d02b99dfbbea91f352be177a28ece42b7ee8b29fb3a0ced8fd5`
  - test: exit 0, 2062 pass / 0 fail / 0 skip. Failures: none. log sha256: `272e22f5e4233eac892bd8ea4e58f93614e428d4be05f2adae03e7f82c22b00d`
- Base (`main` @ `8f776f8c`):
  - typecheck: exit 0. Errors: none. log sha256: `e06fda014d5b6d02b99dfbbea91f352be177a28ece42b7ee8b29fb3a0ced8fd5`
  - test: exit 0, 2057 pass / 0 fail / 0 skip. Failures: none. log sha256: `d0eefeacb60f7410baa54f4c740b6384d8d9e7e9410dbfb30a67d995273f89d2`
- **Conclusion:** 0 test failures are pre-existing (identical behavior between branches), 5 tests are new on this PR (resolveToken disconnect cases + device-grant reconnect), 0 failures were introduced. All green.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
