### PR TITLE
feat(renderer): wire the Connect GitHub banner button (BET-943)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -93,6 +93,8 @@ import { VoicePlaybackProvider } from "./hooks/useVoicePlayback";
 import { Transcript } from "./Transcript";
 import { Composer } from "./Composer";
 import { SessionHeader } from "./SessionHeader";
+import { Modal } from "./Modal";
+import { ConnectGithubPanel } from "./ConnectGithub";
 import { buildVoiceNoteMap } from "./chatUtils";
 import type { VoiceNoteRecord } from "../shared/types";
 import type { PendingVoiceNote } from "./VoiceNote";
@@ -720,6 +722,13 @@ export function ChatPanel({
       // persistent across restarts is best-effort; the optimistic hide stands.
     }
   }, []);
+
+  // BET-943: the ConnectOffer's "Connect" chip opens the device-code modal.
+  // The modal stays MOUNTED and gated by this flag (that is how `Modal` plays
+  // its exit animation). onConnected closes it and re-reads forgeStatus so the
+  // offer disappears and the checks/PR chips appear — no second refresh path.
+  const [connectGithubOpen, setConnectGithubOpen] = useState(false);
+  const openConnectGithub = useCallback(() => setConnectGithubOpen(true), []);
 
   // Branch indicator: poll every 5s while this session is visible. Gated on
   // isActive — hidden panels stop polling; the effect re-fires (one
@@ -2526,6 +2535,7 @@ export function ChatPanel({
         }
         onFillComposer={updateInputWithHistoryReset}
         onDismissForgeConnect={dismissForgeConnect}
+        onConnectForge={openConnectGithub}
         onMerge={() => void doMerge()}
         mergeBusy={mergeBusy}
         mergeError={mergeError}
@@ -2721,6 +2731,26 @@ export function ChatPanel({
         onPaste={onPaste}
       />
       )}
+
+      {/* BET-943: "Connect GitHub" device-code modal, opened from the session
+          header's connect offer. Kept MOUNTED + gated by `open` (how `Modal`
+          plays its exit animation). onConnected closes it and re-reads
+          forgeStatus so the offer disappears and the checks/PR chips appear. */}
+      <Modal
+        open={connectGithubOpen}
+        onDismiss={() => setConnectGithubOpen(false)}
+        size="sm"
+        padded={false}
+        label="Connect GitHub"
+      >
+        <ConnectGithubPanel
+          onConnected={() => {
+            setConnectGithubOpen(false);
+            if (cwd) void refreshForge(cwd);
+          }}
+          onCancel={() => setConnectGithubOpen(false)}
+        />
+      </Modal>
     </div>
   );
 }

--- a/src/renderer/SessionHeader.connect.test.tsx
+++ b/src/renderer/SessionHeader.connect.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment jsdom
+//
+// BET-943: the ConnectOffer's "Connect" chip (shown in a forge-origin session
+// while the forge is disconnected and not dismissed) is wired through
+// onConnectForge. These mount the real <SessionHeader> via the render harness
+// and assert the chip's presence/behaviour — and that omitting onConnectForge
+// (tests, non-forge callers) renders the × only, never a button that does
+// nothing.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
+import {
+  installMockApi,
+  resetStore,
+  mountSessionHeader,
+  type Harness,
+} from "./testHarness";
+
+const connectButton = (h: Harness) =>
+  [...h.container.querySelectorAll("button")].find(
+    (b) => b.textContent === "Connect",
+  );
+const dismissButton = (h: Harness) =>
+  [...h.container.querySelectorAll("button")].find(
+    (b) => b.textContent === "×",
+  );
+
+function mountDisconnected({
+  onConnectForge,
+  onDismissForgeConnect,
+}: {
+  onConnectForge?: () => void;
+  onDismissForgeConnect?: () => void;
+} = {}) {
+  return mountSessionHeader({
+    forgeKind: "github",
+    forgeConnected: false,
+    forgeConnectOfferDismissed: false,
+    onConnectForge,
+    onDismissForgeConnect,
+  });
+}
+
+describe("SessionHeader connect offer (BET-943)", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    installMockApi();
+    resetStore();
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    document.body.innerHTML = "";
+  });
+
+  it("renders the Connect chip and clicking it calls onConnectForge once", () => {
+    const onConnectForge = vi.fn();
+    h = mountDisconnected({ onConnectForge });
+
+    const chip = connectButton(h);
+    expect(chip, "expected a Connect chip").toBeTruthy();
+    act(() => chip!.click());
+
+    expect(onConnectForge).toHaveBeenCalledTimes(1);
+  });
+
+  it("omitting onConnectForge renders the × but no Connect chip", () => {
+    h = mountDisconnected();
+
+    expect(connectButton(h), "expected no Connect chip").toBeUndefined();
+    expect(dismissButton(h), "expected the × to still render").toBeTruthy();
+  });
+});

--- a/src/renderer/SessionHeader.connect.test.tsx
+++ b/src/renderer/SessionHeader.connect.test.tsx
@@ -67,7 +67,7 @@ describe("SessionHeader connect offer (BET-943)", () => {
   });
 
   it("omitting onConnectForge renders the × but no Connect chip", () => {
-    h = mountDisconnected();
+    h = mountDisconnected({ onDismissForgeConnect: () => {} });
 
     expect(connectButton(h), "expected no Connect chip").toBeUndefined();
     expect(dismissButton(h), "expected the × to still render").toBeTruthy();

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -101,6 +101,7 @@ export function SessionHeader({
   onReviewChanges,
   onFillComposer,
   onDismissForgeConnect,
+  onConnectForge,
   onMerge,
   mergeBusy,
   mergeError,
@@ -174,6 +175,10 @@ export function SessionHeader({
   onReviewChanges?: () => void;
   onFillComposer?: (text: string) => void;
   onDismissForgeConnect?: () => void;
+  // BET-943: wires the ConnectOffer's "Connect" chip. When omitted (tests,
+  // non-forge callers), the offer renders the × only — a chip that looks like
+  // a button and does nothing is the bug this issue fixes.
+  onConnectForge?: () => void;
   // BET-867: the branch chip's popover is the ONE git surface. Merge + ship
   // live here now (the pinned forge card is deleted), so ChatPanel threads the
   // ship/merge state + handlers down. All optional so non-forge callers / tests
@@ -449,7 +454,9 @@ export function SessionHeader({
       {/* BET-789 §4.5 [S10]: the one-line contextual connect offer, under the
             header bar (never a modal / toast / Settings badge). Only in a
             forge-origin session while disconnected and not dismissed. */}
-      {offerConnect && <ConnectOffer onDismiss={onDismissForgeConnect} />}
+      {offerConnect && (
+        <ConnectOffer onDismiss={onDismissForgeConnect} onConnect={onConnectForge} />
+      )}
     </>
   );
 }
@@ -1458,11 +1465,18 @@ function ChecksPanel({
 //
 // The ENTIRE visible chrome delta for the project's existing-user acquisition
 // path: one dismissible Callout line under the header, in a forge-origin
-// session while the forge is disconnected. "Connect" is inert (a later issue
-// wires it); the × dismisses permanently, per-box, via the store + configUpdate
+// session while the forge is disconnected. "Connect" opens the device-code
+// modal (wired by ChatPanel's onConnectForge); the × dismisses permanently,
+// per-box, via the store + configUpdate
 // (wired by ChatPanel's onDismissForgeConnect — the offer only re-appears when
 // the config flag is cleared).
-function ConnectOffer({ onDismiss }: { onDismiss?: () => void }) {
+function ConnectOffer({
+  onDismiss,
+  onConnect,
+}: {
+  onDismiss?: () => void;
+  onConnect?: () => void;
+}) {
   return (
     <div className="px-3 pb-2">
       <Callout tone="info">
@@ -1471,8 +1485,7 @@ function ConnectOffer({ onDismiss }: { onDismiss?: () => void }) {
             Connect GitHub to see checks and pull requests for this repo.
           </span>
           <span className="flex items-center gap-2">
-            {/* "Connect" is inert in BET-789. */}
-            <Chip on>Connect</Chip>
+            {onConnect && <Chip onClick={onConnect}>Connect</Chip>}
             {onDismiss && (
               <Chip onClick={onDismiss} title="Dismiss">
                 ×


### PR DESCRIPTION
Opened automatically for `multica/BET-943-wire-connect-github`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-943.