### PR TITLE
fix(renderer): hand off to onCloned synchronously on last-repo clone completion (BET-945)

### DIFF
--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -23,6 +23,7 @@ import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { CloneFromGitHub } from "./CloneFromGitHub";
 import { installMockApi, type MockApi } from "./testHarness";
+import type { ForgeCloneStatus } from "../shared/types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
@@ -61,21 +62,31 @@ let container: HTMLElement | null = null;
 let root: Root | null = null;
 let api: MockApi;
 
-function mountPicker(): void {
+type MountOverrides = {
+  forgeCloneStatus?: () => Promise<ForgeCloneStatus | null>;
+  onCloned?: (paths: string[]) => void;
+};
+
+function mountPicker(overrides: MountOverrides = {}): void {
   ({ api } = installMockApi({
     // Existing credential — the picker renders immediately, skipping the
     // device-connect screen.
     forgeDeviceStart: () => Promise.resolve({ connected: true, grant: null }),
     forgeRepos: () => Promise.resolve({ repos: REPOS, stale: false, error: null }),
     forgeCloneStart: () => Promise.resolve({ id: "c1" }),
-    forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
+    forgeCloneStatus:
+      overrides.forgeCloneStatus ?? (() => Promise.resolve(CLONE_IN_PROGRESS)),
   }));
   container = document.createElement("div");
   document.body.appendChild(container);
   root = createRoot(container);
   act(() => {
     root!.render(
-      <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
+      <CloneFromGitHub
+        defaultRoot="/root"
+        onCancel={() => {}}
+        onCloned={overrides.onCloned ?? (() => {})}
+      />,
     );
   });
 }
@@ -176,5 +187,39 @@ describe("CloneFromGitHub picker", () => {
     // not class-string matching on the whole tree).
     expect(scroller!.contains(cloneButtonFor("0 selected"))).toBe(false);
     expect(scroller!.contains(searchInput())).toBe(false);
+  });
+
+  it("hands off to onCloned when the last (single) repo completes without a render throw", async () => {
+    // Regression for BET-945: driving the final repo to `done:true, ok:true`
+    // used to advance the clone index past the end of the queue, so the very
+    // next render called destFor(queue[index]) on `undefined` and threw
+    // before the effect's completion guard could call onCloned — blanking
+    // the panel instead of handing off.
+    const clonedPaths: string[] = [];
+    mountPicker({
+      onCloned: (paths) => clonedPaths.push(...paths),
+      // Complete the clone on the first status poll.
+      forgeCloneStatus: () =>
+        Promise.resolve({ ...CLONE_IN_PROGRESS, done: true, ok: true, percent: 100 }),
+    });
+    await flushMicro();
+
+    const alphaBox = container!.querySelector(
+      'input[aria-label="Clone alpha"]',
+    ) as HTMLInputElement;
+    expect(alphaBox).toBeTruthy();
+    act(() => {
+      alphaBox.click();
+    });
+    act(() => {
+      cloneButtonFor("1 selected").click();
+    });
+
+    // Drive the poll loop to completion. If the crash regressed, the render
+    // throws here and the act() wrapper rethrows it — the test fails red.
+    await flushMicro();
+    await flushMicro();
+
+    expect(clonedPaths).toEqual(["/root/alpha"]);
   });
 });

--- a/src/renderer/CloneFromGitHub.tsx
+++ b/src/renderer/CloneFromGitHub.tsx
@@ -176,7 +176,17 @@ export function CloneFromGitHub({
         if (st.done) {
           if (st.ok) {
             clonedPathsRef.current.push(dest);
-            setPhase({ kind: "clone", queue, index: phase.index + 1 });
+            const nextIndex = phase.index + 1;
+            if (nextIndex >= queue.length) {
+              // Last repo in the queue finished — hand off to the batch
+              // workspace creation NOW, synchronously. Advancing the index
+              // past the end would render `destFor(queue[index])` with an
+              // out-of-range index and throw on `undefined.name` before the
+              // effect's completion guard could run (BET-945).
+              onCloned(clonedPathsRef.current);
+            } else {
+              setPhase({ kind: "clone", queue, index: nextIndex });
+            }
           } else {
             setPhase({ kind: "failed", repo, message: st.error || "Clone failed", errorKind: cloneErrorKind(st.error || "") });
           }


### PR DESCRIPTION
Fixes the clone **progress** phase crash (BET-945): when the final repo in the clone queue completes, the completion branch advanced the clone index past the end of the queue, so the very next render called `destFor(queue[index])` on `undefined` and threw `TypeError: Cannot read properties of undefined (reading 'name')` at `CloneFromGitHub.tsx:122` via line 349 — before the effect's completion guard could invoke `onCloned`. Result: the panel blanks instead of handing off to the batch workspace-creation step.

**Root-cause fix:** when the last repo completes (`done && ok`), call `onCloned` synchronously at that moment instead of advancing to an out-of-range index. The phase never transitions to an index `>= queue.length`, so the crashing render becomes unreachable. The effect's completion guard stays as a defensive safety net.

**Regression test:** mounts the real picker, selects a repo, starts the clone, drives `forgeCloneStatus` to `done:true, ok:true`, and asserts `onCloned` fires with the cloned path — with no render throw. Red/green verified: against the original code the test fails with the exact crash; with the fix it passes.

**Files changed:** `2` files.
```
src/renderer/CloneFromGitHub.tsx      | 12 ++++++++-
src/renderer/CloneFromGitHub.test.tsx | 51 ++++++++++++++++++++++++++++++++---
```

**Verification results:**
- PR branch (`multica/BET-945-clone-progress-crash` @ `e06fda1`):
  - typecheck: exit `0`. Errors: none. log sha256: `e06fda014d5b6d02b99dfbbea91f352be177a28ece42b7ee8b29fb3a0ced8fd5`
  - test: exit `0`. Renderer `2721` pass / `0` fail / `7` skip · server+scripts `2062` pass / `0` fail / `0` skip. Failures: none. log sha256: `a87f724c5840f90f9eea778d14c23400fb9185df8d03d1c775d2c7c0bc8f29c6`
- Base (`main` @ `3a149dea`):
  - typecheck: exit `0`. Errors: none. log sha256: `e06fda014d5b6d02b99dfbbea91f352be177a28ece42b7ee8b29fb3a0ced8fd5`
  - test: exit `0`. Failures: none. log sha256: `d88b28b0d61b6eadd13e1dec196b89e6c7983bb1231c69174a4883c02acb7f8c`
- **Conclusion:** `0` new failures caused by this PR. The only PR-vs-main difference is the one added regression test.

**Base: origin/main @ `3a149dea`**

Note: this issue was blocked on BET-944 (PR #943) touching the same file; that PR has merged, so this branch is clean to review.
