### PR TITLE
fix(release): identify a release by its commit, not its version number

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2718,6 +2718,44 @@ the dev box (`dev@157.90.224.92`) or the prod box.
   full-release path — the loop over `linux-x64`/`linux-arm64` covers the same
   arches, and preflight refuses to publish unless BOTH are present.
 
+### A release is identified by its COMMIT, not its version number
+
+**You do not need to bump `package.json` to ship a server release.** A box
+decides whether it is already running the published build by comparing the
+commit that build was made from — `git_sha`, stamped into both `RELEASE.json`
+(what the box is running) and `releases/manta-latest.txt` (what is published).
+Same commit → skip, no download. Different commit → update, even when both
+sides carry the same version string.
+
+This replaced a version-only comparison, which had a silent and expensive
+failure mode: a release cut without a version bump was indistinguishable from
+the installed one, so `self-update.sh` reported `already at <version>` and
+every box skipped a REAL update. Nothing errored, no workflow went red, and
+the only symptom was that the fix never appeared in production — which on
+2026-08-15 read as "the merged PR didn't work" and sent a debugging session
+after application code that was already correct.
+
+Consequences worth knowing:
+
+- **`version` is now purely a human/compatibility concern.** It still drives
+  the desktop↔box compatibility matrix (`src/shared/compatibility.mjs`), so
+  bump it for a real release; just don't rely on it to move code onto boxes.
+- **Two published releases may legitimately share a version.** Log lines
+  therefore print the commit alongside it — `0.0.29 → 0.0.29` alone reads like
+  a no-op.
+- **The decision is `release_is_current` in `scripts/lib/release.sh`** (pure,
+  unit-tested in `release.test.mjs`), not inline in `self-update.sh`. It falls
+  back to comparing versions when EITHER side has no commit — a box installed
+  before stamps existed, or a tarball packed outside a git checkout — so the
+  behaviour is never worse than before.
+- **Never publish a manifest whose `git_sha` covers only some arches.**
+  `merge-manifest.mjs` drops the key entirely unless every sidecar agreed, and
+  hard-fails if two arches report different commits. A partial stamp is worse
+  than none: a box whose own arch shipped unstamped would never match the
+  published sha and would reinstall the same tarball on every check, forever.
+- Two arches built from different commits is now a hard publish error rather
+  than something only a version mismatch could have caught.
+
 ### Verifying a deploy actually landed
 
 Never trust "the workflow was green" alone for the FIRST run of a new pipeline —

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -252,3 +252,43 @@ install_prod_deps() {
   fi
   die "self-update: dependency install failed and there was no previous node_modules to restore — re-run install.sh"
 }
+
+# release_is_current <installed_version> <installed_git_sha> <release_version> <release_git_sha>
+#
+# Answers the one question the updater asks before downloading anything: is
+# this box already running the published build? Returns 0 (skip the update) or
+# 1 (there is something new).
+#
+# WHY THE COMMIT AND NOT THE VERSION: `version` comes from package.json and is
+# maintained by hand. A release cut without bumping it was byte-for-byte
+# indistinguishable from the installed one as far as this check could tell, so
+# every box reported "already at <version>" and silently skipped a real update
+# — no error, no signal, and no way to notice from the outside except that the
+# fix never shipped. The commit a build came from is its true identity and
+# needs no bookkeeping to stay correct.
+#
+# Both sides must supply a commit for it to be authoritative. When either is
+# missing — a box installed before releases carried one, or a release packed
+# outside a git checkout — fall back to comparing versions, which is exactly
+# the previous behaviour and no worse.
+#
+# Pure: no I/O, no globals. Unit-tested in scripts/lib/release.test.mjs.
+release_is_current() {
+  installed_version="$1"
+  installed_sha="$2"
+  release_version="$3"
+  release_sha="$4"
+
+  if [ -n "$installed_sha" ] && [ -n "$release_sha" ]; then
+    [ "$installed_sha" = "$release_sha" ]
+    return $?
+  fi
+
+  # An empty installed version means we could not read RELEASE.json at all —
+  # treat that as "not current" so the box repairs itself by reinstalling
+  # rather than skipping forever on an unreadable stamp.
+  if [ -z "$installed_version" ]; then
+    return 1
+  fi
+  [ "$installed_version" = "$release_version" ]
+}

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -377,3 +377,64 @@ test("replace_release_payload: signals when it swapped node_modules from the pay
   rmSync(pkg, { recursive: true, force: true });
   rmSync(dest, { recursive: true, force: true });
 });
+
+// --- release_is_current: the updater's skip decision ------------------------
+//
+// The regression this pins: the check used to compare `version` only, so a
+// release cut without bumping package.json looked identical to the installed
+// build. Every box reported "already at <version>" and skipped a real update
+// — silently, with no error to notice. Identity is now the build's commit.
+
+function isCurrent(installedVersion, installedSha, releaseVersion, releaseSha) {
+  const script = `
+    log() { :; }; ok() { :; }; warn() { :; }; die() { echo "$*" >&2; exit 1; }
+    . "${RELEASE_LIB}"
+    if release_is_current "$1" "$2" "$3" "$4"; then echo current; else echo stale; fi
+  `;
+  const out = execFileSync(
+    "bash",
+    ["-c", script, "bash", installedVersion, installedSha, releaseVersion, releaseSha],
+    { encoding: "utf-8" },
+  );
+  return out.trim() === "current";
+}
+
+test("release_is_current: same commit → skip, even when both sides share a version", () => {
+  assert.equal(isCurrent("0.0.29", "abc123", "0.0.29", "abc123"), true);
+});
+
+test("release_is_current: different commit at the SAME version → update (the regression)", () => {
+  // This is the exact case that shipped nothing: package.json was never
+  // bumped, so a real code change published as 0.0.29 over an installed
+  // 0.0.29 was skipped by every box.
+  assert.equal(isCurrent("0.0.29", "abc123", "0.0.29", "def456"), false);
+});
+
+test("release_is_current: different commit at a different version → update", () => {
+  assert.equal(isCurrent("0.0.29", "abc123", "0.0.30", "def456"), false);
+});
+
+test("release_is_current: no commit on either side falls back to comparing versions", () => {
+  assert.equal(isCurrent("0.0.29", "", "0.0.29", ""), true);
+  assert.equal(isCurrent("0.0.29", "", "0.0.30", ""), false);
+});
+
+test("release_is_current: a box predating commit stamps still updates normally", () => {
+  // Installed RELEASE.json has no git_sha; the published release does. Falls
+  // back to versions rather than treating "" as a mismatch, which would make
+  // the box reinstall the same tarball on every check.
+  assert.equal(isCurrent("0.0.29", "", "0.0.29", "def456"), true);
+  assert.equal(isCurrent("0.0.29", "", "0.0.30", "def456"), false);
+});
+
+test("release_is_current: a release packed outside a checkout falls back to versions", () => {
+  assert.equal(isCurrent("0.0.29", "abc123", "0.0.29", ""), true);
+  assert.equal(isCurrent("0.0.29", "abc123", "0.0.30", ""), false);
+});
+
+test("release_is_current: an unreadable installed stamp is never 'current'", () => {
+  // Skipping forever on a corrupt RELEASE.json would strand the box; letting
+  // it reinstall repairs it.
+  assert.equal(isCurrent("", "", "0.0.29", ""), false);
+  assert.equal(isCurrent("", "", "0.0.29", "def456"), false);
+});

--- a/scripts/release/merge-manifest.mjs
+++ b/scripts/release/merge-manifest.mjs
@@ -31,7 +31,7 @@ function log(msg) {
 // `archKey` is the underscore form (linux_x64 / linux_arm64 / darwin_arm64).
 // Values may contain `=` — split on the first one only.
 function parseSidecar(body) {
-  const out = { version: null, arches: {} };
+  const out = { version: null, gitSha: null, arches: {} };
   for (const line of body.split(/\r?\n/)) {
     if (!line.includes("=")) continue;
     const eq = line.indexOf("=");
@@ -39,6 +39,12 @@ function parseSidecar(body) {
     const value = line.slice(eq + 1);
     if (key === "version") {
       if (out.version === null) out.version = value;
+      continue;
+    }
+    // The commit the arch was built from — the box's update identity. Absent
+    // when pack.mjs ran outside a git checkout; see the merge rule in main().
+    if (key === "git_sha") {
+      if (out.gitSha === null && value !== "") out.gitSha = value;
       continue;
     }
     // Recognize file_<archkey> + sha256_<archkey>. Drop unknown keys.
@@ -77,6 +83,11 @@ function parseArgs(argv) {
 async function main() {
   const { inputs, outPath } = parseArgs(process.argv.slice(2));
   let version = null;
+  let gitSha = null;
+  // A sidecar built outside a git checkout carries no commit. Tracked
+  // separately from `gitSha` so "nobody reported one" is distinguishable from
+  // "one arch reported one and another didn't" — see the emit rule below.
+  let missingGitSha = false;
   // Order of insertion = order of sidecar args = order in the combined file.
   const arches = {};
   for (const input of inputs) {
@@ -87,11 +98,29 @@ async function main() {
     else if (parsed.version !== version) {
       die(`version mismatch: ${input} has version=${parsed.version}, expected ${version} (sidecar args must come from the same release commit)`);
     }
+    // Two arches built from different commits is the failure this check
+    // exists for — publishing them under one manifest would ship a release
+    // whose halves disagree about what they contain.
+    if (parsed.gitSha === null) missingGitSha = true;
+    else if (gitSha === null) gitSha = parsed.gitSha;
+    else if (parsed.gitSha !== gitSha) {
+      die(`git_sha mismatch: ${input} has git_sha=${parsed.gitSha}, expected ${gitSha} (sidecar args must come from the same release commit)`);
+    }
     for (const [archKey, entry] of Object.entries(parsed.arches)) {
       arches[archKey] = entry;
     }
   }
   const lines = [`version=${version}`];
+  // Emit the commit ONLY when every sidecar agreed on one. A partial answer
+  // would be worse than none: a box whose own arch was built without a commit
+  // stamp would compare its null against the published sha, never match, and
+  // reinstall the same tarball on every single update check — forever. Falling
+  // back to the version-only comparison is the safe degradation.
+  if (gitSha !== null && !missingGitSha) {
+    lines.push(`git_sha=${gitSha}`);
+  } else if (gitSha !== null) {
+    log(`⚠ dropping git_sha — not every sidecar carried one; boxes fall back to comparing versions`);
+  }
   for (const [archKey, { file, sha }] of Object.entries(arches)) {
     lines.push(`file_${archKey}=${file}`);
     lines.push(`sha256_${archKey}=${sha}`);

--- a/scripts/release/merge-manifest.test.mjs
+++ b/scripts/release/merge-manifest.test.mjs
@@ -134,3 +134,78 @@ test("merges three per-arch sidecars (linux_x64 + linux_arm64 + darwin_arm64)", 
     rmSync(dir, { recursive: true, force: true });
   }
 });
+
+// --- git_sha: the release's update identity -------------------------------
+//
+// The box decides "am I already running this?" by comparing the commit the
+// release was built from, because `version` is maintained by hand and a
+// release cut without a bump used to be indistinguishable from the installed
+// one — every box silently skipped a real update. These cases pin the
+// merger's half of that contract.
+
+test("carries git_sha into the combined manifest, right after version", () => {
+  const dir = fresh();
+  try {
+    const a = writeSidecar(dir, "a.txt", "version=1.2.3\ngit_sha=abc123\nfile_linux_x64=manta-1.2.3-linux-x64.tar.gz\nsha256_linux_x64=aaaa\n");
+    const b = writeSidecar(dir, "b.txt", "version=1.2.3\ngit_sha=abc123\nfile_linux_arm64=manta-1.2.3-linux-arm64.tar.gz\nsha256_linux_arm64=bbbb\n");
+    const out = join(dir, "combined.txt");
+    runMerge([a, b, "--out", out]);
+    const got = readFileSync(out, "utf-8");
+    assert.equal(
+      got,
+      "version=1.2.3\ngit_sha=abc123\nfile_linux_x64=manta-1.2.3-linux-x64.tar.gz\nsha256_linux_x64=aaaa\nfile_linux_arm64=manta-1.2.3-linux-arm64.tar.gz\nsha256_linux_arm64=bbbb\n",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("dies when two arches were built from different commits", () => {
+  // Same version, different commits: exactly the case a version-only check
+  // cannot see. Publishing these under one manifest ships a release whose
+  // halves disagree about what they contain.
+  const dir = fresh();
+  try {
+    const a = writeSidecar(dir, "a.txt", "version=1.2.3\ngit_sha=abc123\nfile_linux_x64=manta-1.2.3-linux-x64.tar.gz\nsha256_linux_x64=aaaa\n");
+    const b = writeSidecar(dir, "b.txt", "version=1.2.3\ngit_sha=def456\nfile_linux_arm64=manta-1.2.3-linux-arm64.tar.gz\nsha256_linux_arm64=bbbb\n");
+    assert.throws(
+      () => runMerge([a, b, "--out", join(dir, "combined.txt")], { stdio: "pipe" }),
+      /git_sha mismatch/,
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("drops git_sha entirely when only some sidecars carry one", () => {
+  // A partial answer is worse than none: a box whose own arch shipped without
+  // a commit stamp would never match the published sha and would reinstall the
+  // same tarball on every update check, forever.
+  const dir = fresh();
+  try {
+    const a = writeSidecar(dir, "a.txt", "version=1.2.3\ngit_sha=abc123\nfile_linux_x64=manta-1.2.3-linux-x64.tar.gz\nsha256_linux_x64=aaaa\n");
+    const b = writeSidecar(dir, "b.txt", "version=1.2.3\nfile_linux_arm64=manta-1.2.3-linux-arm64.tar.gz\nsha256_linux_arm64=bbbb\n");
+    const out = join(dir, "combined.txt");
+    runMerge([a, b, "--out", out], { stdio: "pipe" });
+    const got = readFileSync(out, "utf-8");
+    assert.ok(!got.includes("git_sha"), `expected no git_sha in:\n${got}`);
+    assert.ok(got.startsWith("version=1.2.3\nfile_linux_x64="), got);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("a release with no commit anywhere still merges (version-only fallback)", () => {
+  const dir = fresh();
+  try {
+    const a = writeSidecar(dir, "a.txt", "version=1.2.3\nfile_linux_x64=manta-1.2.3-linux-x64.tar.gz\nsha256_linux_x64=aaaa\n");
+    const out = join(dir, "combined.txt");
+    runMerge([a, "--out", out]);
+    assert.equal(
+      readFileSync(out, "utf-8"),
+      "version=1.2.3\nfile_linux_x64=manta-1.2.3-linux-x64.tar.gz\nsha256_linux_x64=aaaa\n",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});

--- a/scripts/release/pack.mjs
+++ b/scripts/release/pack.mjs
@@ -82,6 +82,30 @@ function resolveArch(arch) {
   }
 }
 
+// The commit this release was built from — the release's true identity.
+//
+// WHY THIS EXISTS: the box's updater used to decide "am I already running the
+// published release?" by comparing `version` alone. That number is maintained
+// by hand, so a release cut without bumping it was INDISTINGUISHABLE from the
+// one already installed and every box silently skipped a real update — the
+// failure is invisible (the updater cheerfully reports "already at 0.0.29")
+// and lasts until someone notices the fix never shipped. Identifying a build
+// by its commit removes the class of mistake: same commit = genuinely the same
+// code, different commit = a real update, no bookkeeping required.
+//
+// Resolution order: an explicit override, then CI's own commit variable, then
+// the working checkout. Falls back to null OUTSIDE a git checkout (a tarball
+// built from an exported source tree is still valid) — the manifest key is
+// then omitted and the updater degrades to its old version-only comparison.
+function resolveGitSha() {
+  const fromEnv = process.env.MANTA_GIT_SHA || process.env.GITHUB_SHA;
+  if (fromEnv && /^[0-9a-f]{7,40}$/i.test(fromEnv.trim())) return fromEnv.trim().toLowerCase();
+  const r = spawnSync("git", ["-C", REPO_ROOT, "rev-parse", "HEAD"], { encoding: "utf-8" });
+  const out = (r.stdout || "").trim();
+  if (r.status === 0 && /^[0-9a-f]{40}$/i.test(out)) return out.toLowerCase();
+  return null;
+}
+
 function log(msg) {
   process.stdout.write(`▸ ${msg}\n`);
 }
@@ -347,6 +371,18 @@ async function main() {
   // `ARCH_KEY` is the underscore form (matches install.sh's manifest_get
   // keys). Resolved once here so nothing else in main() re-spells them.
   const { key: ARCH_KEY, file: ARCH } = resolveArch(args.arch);
+
+  // Resolved once, up front, so the RELEASE.json stamp and the manifest key
+  // can never disagree about which commit this tarball came from.
+  const gitSha = resolveGitSha();
+  if (gitSha) {
+    log(`Release commit: ${gitSha}`);
+  } else {
+    log(
+      "⚠ no git commit resolved (not a git checkout and no MANTA_GIT_SHA/GITHUB_SHA) — " +
+        "boxes will fall back to comparing version numbers, so an unbumped release will be skipped",
+    );
+  }
   // nodejs.org's tarball filename token is exactly the hyphen form, so the
   // vendored-node URL + cache key + sha lookup all use this single string.
   const NODE_TARBALL = `node-v${NODE_VERSION}-${ARCH}.tar.gz`;
@@ -412,6 +448,11 @@ async function main() {
       {
         name: "manta",
         version,
+        // The commit this payload was built from. `replace_release_payload`
+        // stamps this file onto the box, so the installed RELEASE.json is how
+        // the box knows which build it is actually running. null only when
+        // packed outside a git checkout.
+        git_sha: gitSha,
         built_at: new Date().toISOString(),
         node: NODE_VERSION,
         arch: ARCH,
@@ -435,12 +476,19 @@ async function main() {
   // 7. Manifest — flat key=value, parseable in bash before any node exists on
   //    the box. install.sh uses this to fetch + verify the tarball. The
   //    sha256 is computed AFTER tar (the tarball is the artifact being verified).
-  //    Keys: version, file_<arch> (underscore form — matches install.sh's
-  //    manifest_get calls), sha256_<arch>.
+  //    Keys: version, git_sha, file_<arch> (underscore form — matches
+  //    install.sh's manifest_get calls), sha256_<arch>.
+  //
+  //    `git_sha` is in the manifest as well as RELEASE.json so the box can
+  //    answer "is this a new build?" from the manifest ALONE — preserving the
+  //    cheap early exit, i.e. no tarball download when nothing changed. It is
+  //    omitted entirely when unresolved rather than written empty, so an older
+  //    box parsing this file sees no key and behaves exactly as before.
   log(`Writing manifest ${outManifest}…`);
   const tarSha = await sha256OfFile(outFile);
   const manifest =
     `version=${version}\n` +
+    (gitSha ? `git_sha=${gitSha}\n` : "") +
     `file_${ARCH_KEY}=${`manta-${version}-${ARCH}.tar.gz`}\n` +
     `sha256_${ARCH_KEY}=${tarSha}\n`;
   await writeFile(outManifest, manifest);

--- a/scripts/release/pack.test.mjs
+++ b/scripts/release/pack.test.mjs
@@ -154,3 +154,92 @@ test("BET-829: node_modules stays release-owned so the box never rebuilds deps l
     "node_modules must be release-owned — the tarball ships a prebuilt, arch- and ABI-verified tree",
   );
 });
+
+// --- resolveGitSha: the release's update identity ---------------------------
+//
+// The box decides "am I already running the published build?" by comparing the
+// commit a release was built from. Before that, it compared `version` alone —
+// a hand-maintained number — so a release cut without a bump was
+// indistinguishable from the installed one and every box silently skipped a
+// real update, reporting "already at <version>" with no error anywhere.
+//
+// Same source-reading harness as the array-literal tests above: pack.mjs can't
+// be imported (main() runs on import and hits the network), so we lift the
+// function out of the source and evaluate it against injected dependencies.
+
+function evalFunctionDecl(declName, scope = {}) {
+  const m = PACK_SRC.match(new RegExp(`\\nfunction\\s+${declName}\\s*\\([\\s\\S]*?\\n\\}`));
+  assert.ok(m, `could not find function ${declName} in pack.mjs`);
+  return Function(
+    ...Object.keys(scope),
+    `${m[0]}; return ${declName};`,
+  )(...Object.values(scope));
+}
+
+// A spawnSync stub standing in for `git rev-parse HEAD`.
+function gitStub(result) {
+  return () => result;
+}
+
+const NOT_A_REPO = { status: 128, stdout: "" };
+const HEAD = "a".repeat(40);
+
+test("resolveGitSha prefers an explicit override over the checkout", () => {
+  const resolveGitSha = evalFunctionDecl("resolveGitSha", {
+    process: { env: { MANTA_GIT_SHA: "abc1234" } },
+    spawnSync: gitStub({ status: 0, stdout: `${HEAD}\n` }),
+    REPO_ROOT: "/repo",
+  });
+  assert.equal(resolveGitSha(), "abc1234");
+});
+
+test("resolveGitSha falls back to CI's own commit variable", () => {
+  const resolveGitSha = evalFunctionDecl("resolveGitSha", {
+    process: { env: { GITHUB_SHA: HEAD.toUpperCase() } },
+    spawnSync: gitStub(NOT_A_REPO),
+    REPO_ROOT: "/repo",
+  });
+  // Normalized so a manifest value and a RELEASE.json value can be compared
+  // as plain strings on the box, where there is no case-insensitive compare.
+  assert.equal(resolveGitSha(), HEAD);
+});
+
+test("resolveGitSha reads the working checkout when nothing is injected", () => {
+  const resolveGitSha = evalFunctionDecl("resolveGitSha", {
+    process: { env: {} },
+    spawnSync: gitStub({ status: 0, stdout: `${HEAD}\n` }),
+    REPO_ROOT: "/repo",
+  });
+  assert.equal(resolveGitSha(), HEAD);
+});
+
+test("resolveGitSha returns null outside a git checkout rather than failing the pack", () => {
+  // A tarball built from an exported source tree is still a valid release —
+  // it just degrades the box to the old version-only comparison.
+  const resolveGitSha = evalFunctionDecl("resolveGitSha", {
+    process: { env: {} },
+    spawnSync: gitStub(NOT_A_REPO),
+    REPO_ROOT: "/repo",
+  });
+  assert.equal(resolveGitSha(), null);
+});
+
+test("resolveGitSha ignores a malformed override instead of stamping garbage", () => {
+  // A stamped non-sha would never match any box's RELEASE.json, making every
+  // box reinstall the same tarball on every update check.
+  const resolveGitSha = evalFunctionDecl("resolveGitSha", {
+    process: { env: { MANTA_GIT_SHA: "not-a-sha" } },
+    spawnSync: gitStub({ status: 0, stdout: `${HEAD}\n` }),
+    REPO_ROOT: "/repo",
+  });
+  assert.equal(resolveGitSha(), HEAD);
+});
+
+test("the release stamp and the manifest key come from the same resolved value", () => {
+  // RELEASE.json (what the box reports it is running) and the manifest (what
+  // the box compares against) must never disagree about the commit — if they
+  // can drift, the box either skips a real update or reinstalls forever.
+  assert.match(PACK_SRC, /const gitSha = resolveGitSha\(\);/);
+  assert.match(PACK_SRC, /git_sha: gitSha,/);
+  assert.match(PACK_SRC, /gitSha \? `git_sha=\$\{gitSha\}\\n` : ""/);
+});

--- a/scripts/release/pack.test.mjs
+++ b/scripts/release/pack.test.mjs
@@ -16,19 +16,14 @@ import assert from "node:assert/strict";
 // is cheap — but `main()` runs on import and would fail in this harness.
 // Trick: spawn a sub-node that runs the script with --arch foo, and capture
 // the die() message — that's the test surface for the unknown-arch branch.
-// For the happy-path cases we replicate resolveArch's mapping inline
-// (string switch); since the function is a pure 1:1 lookup the duplication
-// is small and the risk of drift is captured by the dedicated unknown-arch
-// integration test below.
-
+//
+// The happy-path cases used to re-declare resolveArch's mapping inline, which
+// meant the assertions could keep passing after pack.mjs changed. They now run
+// the REAL function, lifted out of the source by `evalFunctionDecl` (defined
+// with the git-commit cases below — a function declaration, so hoisted). Pure
+// 1:1 lookup with no dependencies, so it needs no injected scope.
 function resolveArch(arch) {
-  switch (arch) {
-    case "x64":          return { key: "linux_x64",    file: "linux-x64" };
-    case "arm64":        return { key: "linux_arm64",  file: "linux-arm64" };
-    case "darwin-arm64": return { key: "darwin_arm64", file: "darwin-arm64" };
-    default:
-      throw new Error(`unsupported --arch ${JSON.stringify(arch)} (expected: x64 | arm64 | darwin-arm64)`);
-  }
+  return evalFunctionDecl("resolveArch")(arch);
 }
 
 test("resolveArch(\"x64\") returns linux_x64 / linux-x64", () => {
@@ -157,11 +152,11 @@ test("BET-829: node_modules stays release-owned so the box never rebuilds deps l
 
 // --- resolveGitSha: the release's update identity ---------------------------
 //
-// The box decides "am I already running the published build?" by comparing the
-// commit a release was built from. Before that, it compared `version` alone —
-// a hand-maintained number — so a release cut without a bump was
-// indistinguishable from the installed one and every box silently skipped a
-// real update, reporting "already at <version>" with no error anywhere.
+// Why a release is identified by its commit rather than its version lives on
+// resolveGitSha in pack.mjs and in AGENTS.md; it is deliberately not restated
+// here. These cases pin the resolution order and the two shapes that would
+// break a box: a missing commit (must degrade, not fail) and a malformed one
+// (must never be stamped).
 //
 // Same source-reading harness as the array-literal tests above: pack.mjs can't
 // be imported (main() runs on import and hits the network), so we lift the

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -151,6 +151,9 @@ else
   log "self-update: channel=${MANTA_CHANNEL:-prod} release host=$host"
 
   INSTALLED_VERSION="$("$NODE_CMD" -e 'process.stdout.write((JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).version)||"")' "$MANTA_HOME/RELEASE.json")"
+  # The commit the installed payload was built from. Empty on a box installed
+  # before releases carried one — handled by the fallback in the skip check.
+  INSTALLED_GIT_SHA="$("$NODE_CMD" -e 'process.stdout.write((JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).git_sha)||"")' "$MANTA_HOME/RELEASE.json" 2>/dev/null || echo "")"
 
   log "self-update: fetching manifest from $host/releases/manta-latest.txt"
   manifest="$(curl -fsSL "$host/releases/manta-latest.txt")" \
@@ -160,14 +163,25 @@ else
   TARBALL_FILE="$(manifest_get "$manifest" "file_${ARCH_KEY}")"
   TARBALL_SHA="$(manifest_get "$manifest" "sha256_${ARCH_KEY}")"
   TARBALL_VERSION="$(manifest_get "$manifest" "version")"
+  TARBALL_GIT_SHA="$(manifest_get "$manifest" "git_sha")"
   if [ -z "$TARBALL_FILE" ] || [ -z "$TARBALL_SHA" ] || [ -z "$TARBALL_VERSION" ]; then
     die "self-update: manifest is malformed or has no ${ARCH_KEY} build"
   fi
 
-  # Cheap early exit when already current — no download, no reinstall, no restart.
-  if [ -n "$INSTALLED_VERSION" ] && [ "$INSTALLED_VERSION" = "$TARBALL_VERSION" ]; then
-    ok "self-update: already at $TARBALL_VERSION"
+  # Cheap early exit when already current — no download, no reinstall, no
+  # restart. The decision itself lives in scripts/lib/release.sh so it can be
+  # unit-tested; see release_is_current for why it compares the build's commit
+  # rather than its version number.
+  if release_is_current "$INSTALLED_VERSION" "$INSTALLED_GIT_SHA" "$TARBALL_VERSION" "$TARBALL_GIT_SHA"; then
+    if [ -n "$INSTALLED_GIT_SHA" ] && [ -n "$TARBALL_GIT_SHA" ]; then
+      ok "self-update: already at $TARBALL_VERSION ($TARBALL_GIT_SHA)"
+    else
+      ok "self-update: already at $TARBALL_VERSION"
+    fi
     exit 0
+  fi
+  if [ -n "$INSTALLED_GIT_SHA" ] && [ -n "$TARBALL_GIT_SHA" ]; then
+    log "self-update: new build $INSTALLED_GIT_SHA → $TARBALL_GIT_SHA"
   fi
 
   WORK="$(mktemp -d "${TMPDIR:-/tmp}/manta-update.XXXXXX")"
@@ -200,7 +214,13 @@ else
   # half-written tree — most important for `runtime/`, which the running server
   # executes from. It also stamps RELEASE.json so the box records its version.
   replace_release_payload "$WORK/pkg" "$MANTA_HOME" "$NODE_CMD"
-  ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION)"
+  # Report the commit alongside the version: two releases legitimately share a
+  # version number now, so "0.0.29 → 0.0.29" alone reads like a no-op.
+  if [ -n "$TARBALL_GIT_SHA" ]; then
+    ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION, commit $TARBALL_GIT_SHA)"
+  else
+    ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION)"
+  fi
 fi
 
 echo "MANTA_PROGRESS 3/6 Installing dependencies"

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.29",
+ "version": "0.0.30",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
## Problem

The box decided *"am I already running the published release?"* by comparing `version` alone. That number is maintained by hand, so a release cut without a bump was indistinguishable from the one already installed: `self-update.sh` reported `already at 0.0.29` and **every box silently skipped a real update**.

The failure is invisible — nothing errors, no workflow goes red, and the only symptom is that the fix never appears in production. Today that read as "the merged PR didn't work" and sent a debugging session after application code that was already correct (BET-942 was merged, green, and simply never running on the box).

## Change

A build's identity becomes the commit it came from, which needs no bookkeeping to stay correct.

- **`pack.mjs`** resolves the commit (`MANTA_GIT_SHA` → `GITHUB_SHA` → the checkout) and stamps it into **both** `RELEASE.json` (what the box is running) and the per-arch manifest (what it compares against), resolved once so the two can't disagree. Absent outside a git checkout — the key is then omitted rather than written empty.
- **`merge-manifest.mjs`** carries it through, **hard-fails when two arches report different commits**, and **drops the key unless every sidecar agreed**. A partial stamp is worse than none: a box whose own arch shipped unstamped would never match the published sha and would reinstall the same tarball on every check, forever.
- **`self-update.sh`**'s skip check moves into `release_is_current` (`scripts/lib/release.sh`) so it is unit-testable, and **falls back to comparing versions** whenever either side has no commit — a box installed before stamps existed, or a tarball packed outside a checkout. Never worse than the previous behaviour.

`version` stays a human/compatibility concern: it still drives the desktop↔box compatibility matrix and the update *notification* in `website/updates/server.json` (which an existing test already forces to move with `package.json` — that guard caught this PR's bump and is working as intended).

## The bump is the bootstrap

Installed boxes carry no commit stamp yet, so this change has to reach them by version one last time. Every release after it is identified by commit, and forgetting to bump can no longer cause a silent skip.

## Verification

- `npm run typecheck` clean; `npm test` green (2079 node:test, 2723 vitest).
- 16 new cases: commit resolution + precedence + malformed-override rejection (`pack.test.mjs`), manifest merge / mismatch / partial-drop (`merge-manifest.test.mjs`), and the skip decision including the exact regression — same version, different commit → **update** (`release.test.mjs`).
- Walked end-to-end against the real scripts and this repo's HEAD: manifest emitted with `git_sha`, then `release_is_current` returns SKIP on the same commit, UPDATE on a different commit at the *same* version, and SKIP for a box predating stamps.