### PR TITLE
fix(renderer): cap and scroll the New workspace repo-setup list

### DIFF
--- a/src/renderer/CloneFromGitHub.tsx
+++ b/src/renderer/CloneFromGitHub.tsx
@@ -30,6 +30,7 @@ import { Checkbox } from "./Checkbox";
 import { Field } from "./Field";
 import { ListRow } from "./ListRow";
 import { ProgressBar } from "./ProgressBar";
+import { ScrollFrame } from "./ScrollFrame";
 import { ConnectGithubPanel, PanelHeader, PANEL_CLASS } from "./ConnectGithub";
 import { formatAge, formatBytes, cloneErrorKind, type CloneErrorKind } from "./chatUtils";
 import type {
@@ -262,82 +263,90 @@ export function CloneFromGitHub({
               </div>
             }
           />
-          <div className="p-4 flex flex-col max-h-[70vh]">
-            <Field
-              ariaLabel="Search repositories"
-              value={search}
-              onChange={(e) => setSearch(e.target.value)}
-              placeholder={`Search ${repos.length} ${repos.length === 1 ? "repository" : "repositories"}…`}
-            />
-            {reposError && (
-              <div className="mt-2">
-                <Callout tone="danger">{reposError}</Callout>
-              </div>
-            )}
-            <div className="mt-1 flex-1 min-h-0 overflow-y-auto">
-              {filtered.map((r) => (
-                <ListRow
-                  key={r.fullName}
-                  leading={
-                    <Checkbox
-                      checked={checked.has(r.fullName)}
-                      onChange={(on) => toggleRepo(r.fullName, on)}
-                      ariaLabel={`Clone ${r.name}`}
+          <ScrollFrame
+            className="p-4"
+            header={
+              <>
+                <Field
+                  ariaLabel="Search repositories"
+                  value={search}
+                  onChange={(e) => setSearch(e.target.value)}
+                  placeholder={`Search ${repos.length} ${repos.length === 1 ? "repository" : "repositories"}…`}
+                />
+                {reposError && (
+                  <div className="mt-2">
+                    <Callout tone="danger">{reposError}</Callout>
+                  </div>
+                )}
+              </>
+            }
+            footer={
+              <>
+                <div className="mt-3 text-[12px] text-text-faint">
+                  Clone into{" "}
+                  {editingRoot ? (
+                    <input
+                      autoFocus
+                      value={root}
+                      onChange={(e) => setRoot(e.target.value)}
+                      onBlur={() => setEditingRoot(false)}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") setEditingRoot(false);
+                      }}
+                      className="font-mono text-[11.5px] text-text bg-inset border border-border rounded-xs px-1 py-px outline-none"
                     />
-                  }
-                  name={r.name}
-                  secondary={r.description || "—"}
-                  trailing={r.pushedAt != null ? formatAge(Date.now() - r.pushedAt) : "—"}
-                />
-              ))}
-              {filtered.length === 0 && !reposError && (
-                <div className="text-[13px] text-text-faint py-2">No repositories match.</div>
-              )}
-            </div>
+                  ) : (
+                    <button
+                      type="button"
+                      onClick={() => setEditingRoot(true)}
+                      className="font-mono text-[11.5px] text-text-muted hover:text-text cursor-text"
+                      title="Change clone root"
+                    >
+                      {root}
+                    </button>
+                  )}{" "}
+                  {!editingRoot && (
+                    <button
+                      type="button"
+                      onClick={() => setEditingRoot(true)}
+                      className="text-[11.5px] text-text-faint underline decoration-dotted hover:text-text-muted"
+                    >
+                      change
+                    </button>
+                  )}
+                </div>
 
-            <div className="mt-3 text-[12px] text-text-faint">
-              Clone into{" "}
-              {editingRoot ? (
-                <input
-                  autoFocus
-                  value={root}
-                  onChange={(e) => setRoot(e.target.value)}
-                  onBlur={() => setEditingRoot(false)}
-                  onKeyDown={(e) => {
-                    if (e.key === "Enter") setEditingRoot(false);
-                  }}
-                  className="font-mono text-[11.5px] text-text bg-inset border border-border rounded-xs px-1 py-px outline-none"
-                />
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => setEditingRoot(true)}
-                  className="font-mono text-[11.5px] text-text-muted hover:text-text cursor-text"
-                  title="Change clone root"
-                >
-                  {root}
-                </button>
-              )}{" "}
-              {!editingRoot && (
-                <button
-                  type="button"
-                  onClick={() => setEditingRoot(true)}
-                  className="text-[11.5px] text-text-faint underline decoration-dotted hover:text-text-muted"
-                >
-                  change
-                </button>
-              )}
-            </div>
-
-            <div className="flex gap-2 mt-3">
-              <Button tone="primary" disabled={selected.length === 0} onClick={() => runClones(selected, 0)}>
-                Clone {selected.length} selected
-              </Button>
-              <Button tone="ghost" onClick={onCancel}>
-                Back
-              </Button>
-            </div>
-          </div>
+                <div className="flex gap-2 mt-3">
+                  <Button tone="primary" disabled={selected.length === 0} onClick={() => runClones(selected, 0)}>
+                    Clone {selected.length} selected
+                  </Button>
+                  <Button tone="ghost" onClick={onCancel}>
+                    Back
+                  </Button>
+                </div>
+              </>
+            }
+            bodyClassName="mt-1"
+          >
+            {filtered.map((r) => (
+              <ListRow
+                key={r.fullName}
+                leading={
+                  <Checkbox
+                    checked={checked.has(r.fullName)}
+                    onChange={(on) => toggleRepo(r.fullName, on)}
+                    ariaLabel={`Clone ${r.name}`}
+                  />
+                }
+                name={r.name}
+                secondary={r.description || "—"}
+                trailing={r.pushedAt != null ? formatAge(Date.now() - r.pushedAt) : "—"}
+              />
+            ))}
+            {filtered.length === 0 && !reposError && (
+              <div className="text-[13px] text-text-faint py-2">No repositories match.</div>
+            )}
+          </ScrollFrame>
         </>
       )}
 

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -44,6 +44,7 @@ import { Card } from "./Card";
 import { Checkbox } from "./Checkbox";
 import { FolderPickerModal } from "./FolderPickerModal";
 import { ListRow } from "./ListRow";
+import { ScrollFrame } from "./ScrollFrame";
 import { Skeleton } from "./Skeleton";
 import { CloneFromGitHub } from "./CloneFromGitHub";
 import { StatusDot } from "./StatusDot";
@@ -919,30 +920,64 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
                 </div>
               </>
             ) : (
-              <>
-                <div className="text-center space-y-1 mb-4">
-                  <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
-                  <p className="text-body text-text-faint">
-                    Found {probeRepos.length} {probeRepos.length === 1 ? "repository" : "repositories"} on your box.
-                  </p>
-                </div>
+              <ScrollFrame
+                header={
+                  <>
+                    <div className="text-center space-y-1 mb-4">
+                      <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
+                      <p className="text-body text-text-faint">
+                        Found {probeRepos.length} {probeRepos.length === 1 ? "repository" : "repositories"} on your box.
+                      </p>
+                    </div>
 
-                {cliStatus?.authenticated && (
-                  <div className="flex items-center justify-center gap-[7px] -mt-[6px] mb-3 text-[12px] text-text-faint">
-                    <StatusDot tone="ok" />
-                    <span>
-                      GitHub connected as{" "}
-                      <b className="text-text-muted font-semibold">@{cliStatus.login}</b>
-                    </span>
-                    <span
-                      className="text-[11.5px] text-text-faint underline decoration-dotted cursor-default"
-                      title="Not available yet"
-                    >
-                      use a different account
-                    </span>
+                    {cliStatus?.authenticated && (
+                      <div className="flex items-center justify-center gap-[7px] -mt-[6px] mb-3 text-[12px] text-text-faint">
+                        <StatusDot tone="ok" />
+                        <span>
+                          GitHub connected as{" "}
+                          <b className="text-text-muted font-semibold">@{cliStatus.login}</b>
+                        </span>
+                        <span
+                          className="text-[11.5px] text-text-faint underline decoration-dotted cursor-default"
+                          title="Not available yet"
+                        >
+                          use a different account
+                        </span>
+                      </div>
+                    )}
+                  </>
+                }
+                footer={
+                  <div className="flex items-center flex-wrap gap-2 mt-3">
+                    {batchDone && !sending && hasFailed ? (
+                      <Button tone="primary" onClick={() => void finishSetup()}>
+                        Done
+                      </Button>
+                    ) : batchDone ? (
+                      <span className="text-meta text-text-faint">Setting up workspaces…</span>
+                    ) : (
+                      <>
+                        <Button
+                          tone="primary"
+                          onClick={() => void setupWorkspaces()}
+                          disabled={checked.size === 0}
+                        >
+                          Set up {checked.size} workspace{checked.size === 1 ? "" : "s"}
+                        </Button>
+                        <Button tone="default" onClick={() => setPickerOpen(true)}>
+                          Browse for a folder…
+                        </Button>
+                        <Button
+                          tone="default"
+                          onClick={() => setCloneOpen(true)}
+                        >
+                          Clone from GitHub…
+                        </Button>
+                      </>
+                    )}
                   </div>
-                )}
-
+                }
+              >
                 <div className="space-y-1">
                   {rows.map((r) =>
                     batchDone ? (
@@ -1006,36 +1041,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
                     ),
                   )}
                 </div>
-
-                <div className="flex items-center flex-wrap gap-2 mt-3">
-                  {batchDone && !sending && hasFailed ? (
-                    <Button tone="primary" onClick={() => void finishSetup()}>
-                      Done
-                    </Button>
-                  ) : batchDone ? (
-                    <span className="text-meta text-text-faint">Setting up workspaces…</span>
-                  ) : (
-                    <>
-                      <Button
-                        tone="primary"
-                        onClick={() => void setupWorkspaces()}
-                        disabled={checked.size === 0}
-                      >
-                        Set up {checked.size} workspace{checked.size === 1 ? "" : "s"}
-                      </Button>
-                      <Button tone="default" onClick={() => setPickerOpen(true)}>
-                        Browse for a folder…
-                      </Button>
-                      <Button
-                        tone="default"
-                        onClick={() => setCloneOpen(true)}
-                      >
-                        Clone from GitHub…
-                      </Button>
-                    </>
-                  )}
-                </div>
-              </>
+              </ScrollFrame>
             )}
         </>
         )}

--- a/src/renderer/ScrollFrame.test.tsx
+++ b/src/renderer/ScrollFrame.test.tsx
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+//
+// ScrollFrame is the shared "capped list" scroll treatment (BET-944
+// follow-up): a flex column capped at maxHeight whose body scrolls while
+// header and footer stay pinned. This pins the one invariant that was broken
+// independently in CloneFromGitHub and NewSessionScreen — the body must live
+// in an overflow container that EXCLUDES the header/footer, so a long list
+// scrolls and the action button never gets pushed off-screen.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { ScrollFrame } from "./ScrollFrame";
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true;
+
+let container: HTMLElement | null = null;
+let root: Root | null = null;
+
+function mount(children: React.ReactNode): void {
+  container = document.createElement("div");
+  document.body.appendChild(container);
+  root = createRoot(container);
+  act(() => {
+    root!.render(children);
+  });
+}
+
+afterEach(() => {
+  act(() => {
+    root?.unmount();
+  });
+  root = null;
+  if (container) {
+    container.remove();
+    container = null;
+  }
+});
+
+describe("ScrollFrame", () => {
+  it("renders children in an overflow-y-auto container that excludes header and footer", () => {
+    mount(
+      <ScrollFrame
+        header={<div id="my-header" />}
+        footer={<div id="my-footer" />}
+      >
+        <li id="row-a" />
+        <li id="row-b" />
+      </ScrollFrame>,
+    );
+
+    const scroller = container!.querySelector<HTMLElement>(".overflow-y-auto");
+    expect(scroller).toBeTruthy();
+
+    // The rows live inside the scroller…
+    expect(scroller!.contains(container!.querySelector("#row-a")!)).toBe(true);
+    expect(scroller!.contains(container!.querySelector("#row-b")!)).toBe(true);
+
+    // …but the header and footer are pinned OUTSIDE it.
+    expect(scroller!.contains(container!.querySelector("#my-header")!)).toBe(false);
+    expect(scroller!.contains(container!.querySelector("#my-footer")!)).toBe(false);
+
+    // The column carries the height cap + the flex rules the body needs to
+    // shrink (without it, overflow-y:auto silently does nothing).
+    const col = scroller!.parentElement!;
+    expect(col.classList.contains("max-h-[70vh]")).toBe(true);
+    expect(col.classList.contains("flex")).toBe(true);
+    expect(col.classList.contains("flex-col")).toBe(true);
+    expect(scroller!.classList.contains("flex-1")).toBe(true);
+    expect(scroller!.classList.contains("min-h-0")).toBe(true);
+  });
+
+  it("honors a custom maxHeight and forwards className/bodyClassName", () => {
+    mount(
+      <ScrollFrame
+        maxHeight="max-h-[50vh]"
+        className="p-4"
+        bodyClassName="mt-1"
+      >
+        <div id="row" />
+      </ScrollFrame>,
+    );
+    const scroller = container!.querySelector<HTMLElement>(".overflow-y-auto")!;
+    const col = scroller!.parentElement!;
+    expect(col.classList.contains("max-h-[50vh]")).toBe(true);
+    expect(col.classList.contains("max-h-[70vh]")).toBe(false);
+    expect(col.classList.contains("p-4")).toBe(true);
+    expect(scroller.classList.contains("mt-1")).toBe(true);
+  });
+
+  it("renders with no header or footer when omitted", () => {
+    mount(<ScrollFrame><div id="only" /></ScrollFrame>);
+    const scroller = container!.querySelector<HTMLElement>(".overflow-y-auto")!;
+    expect(scroller.contains(container!.querySelector("#only")!)).toBe(true);
+    // No stray pinned header/footer wrappers.
+    expect(container!.querySelectorAll(".shrink-0").length).toBe(0);
+  });
+});

--- a/src/renderer/ScrollFrame.tsx
+++ b/src/renderer/ScrollFrame.tsx
@@ -1,0 +1,49 @@
+import type { ReactNode } from "react";
+
+// ScrollFrame.tsx — the shared "capped-height list" scroll treatment.
+//
+// A flex column capped at `maxHeight` whose BODY scrolls while `header` and
+// `footer` stay pinned. Extracted so the clone picker (CloneFromGitHub) and
+// the "New workspace" repo-setup list (NewSessionScreen) share ONE layout
+// instead of each hand-rolling `flex-1 min-h-0 overflow-y-auto` inside an
+// ad-hoc `max-h-*`.
+//
+// This is what keeps the action button reachable no matter how long the list
+// gets: the body takes the leftover space and scrolls, while header/footer
+// never move — so on a machine with dozens of repos, the search/status stays
+// on top and "Set up N workspace(s)" / "Clone N selected" stays in view.
+//
+// Without the `max-height` cap the body has nothing to shrink against and
+// `overflow-y-auto` silently does nothing, so the list just grows and pushes
+// the footer off-screen (the bug BET-944 fixed for the clone picker, and
+// which this component generalises to every bounded list).
+
+export function ScrollFrame({
+  header,
+  children,
+  footer,
+  className = "",
+  bodyClassName = "",
+  maxHeight = "max-h-[70vh]",
+}: {
+  /** Pinned above the scrolled body (e.g. a search field or a header). */
+  header?: ReactNode;
+  /** The scrollable middle — the list rows. */
+  children: ReactNode;
+  /** Pinned below the scrolled body (e.g. the action buttons). */
+  footer?: ReactNode;
+  /** Extra classes on the outer column (padding, borders, …). */
+  className?: string;
+  /** Extra classes on the scrolled body (margin/spacing relative to header/footer). */
+  bodyClassName?: string;
+  /** Height cap for the column. Pass "max-h-none" to disable. */
+  maxHeight?: string;
+}) {
+  return (
+    <div className={`flex flex-col ${maxHeight} ${className}`}>
+      {header != null && <div className="shrink-0">{header}</div>}
+      <div className={`min-h-0 flex-1 overflow-y-auto ${bodyClassName}`}>{children}</div>
+      {footer != null && <div className="shrink-0">{footer}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
Extracts the bounded-list scroll treatment into a shared **`ScrollFrame`** component and applies it to **both** repo lists:
- `CloneFromGitHub`'s clone picker (behavior unchanged — was already fixed by BET-944)
- `NewSessionScreen`'s "New workspace" repo-setup list (**the actual bug**)

## The bug
The "New workspace" setup list ("Found N repositories on your box" → "Set up N workspaces") was **unbounded**. With dozens of box repos, the list grew full-height and pushed the action buttons below the fold with **no scrolling**, making the "Set up N workspaces" submit unreachable — centered, ~100% height, no scrollbar.

The clone picker had the *same* bug and was fixed by BET-944 inline; this PR shares that fix instead of duplicating it.

## Why a shared component
Both screens are a checkboxed repo list + pinned action footer, but they are **not** the same picker (local-repo setup vs GitHub clone: different data, search/filter, and per-row batch states). So instead of a forced conditional mega-picker, only the load-bearing invariant is shared: **`ScrollFrame`** = a height-capped flex column (`max-h-[70vh]`) whose body scrolls (`flex-1 min-h-0 overflow-y-auto`) while header/footer stay pinned. Each screen keeps its domain rows/header/footer.

## Verification
- Live in the running dev app: the setup list caps at 599px (70vh) and scrolls (1102px of 28 repos in a 460px viewport, `overflow:auto`); "Set up N workspaces" button stays visible (top 696px < 856px window).
- `npm run typecheck`: clean.
- Tests: new `ScrollFrame.test.tsx` (3) + existing `CloneFromGitHub` / `NewSessionScreen` / `ConnectGithub` suites all pass (17 total).