### PR TITLE
refactor(renderer): per-segment SplitChip popup, ModelMenu defaultRow, extract selectableModelGroups (BET-948)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.30",
+  "version": "0.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.30",
+      "version": "0.0.29",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/src/renderer/Chip.test.tsx
+++ b/src/renderer/Chip.test.tsx
@@ -233,4 +233,32 @@ describe("SplitChip", () => {
     expect(pl.getAttribute("aria-haspopup")).toBe("listbox");
     expect(pr.getAttribute("aria-haspopup")).toBe("listbox");
   });
+
+  it("per-segment popup: an object marks only the named segment (BET-948)", () => {
+    // `{ right: true }` — a caller whose LEFT segment is a plain action and
+    // whose RIGHT opens a listbox. The action must not falsely claim
+    // aria-haspopup while the listbox segment stays in the coverage registry.
+    mountSplit({ popup: { right: true } });
+    const [l, r] = buttons();
+    expect(l.hasAttribute("aria-haspopup")).toBe(false);
+    expect(r.getAttribute("aria-haspopup")).toBe("listbox");
+
+    // `{ left: true }` — the mirror case.
+    mountSplit({ popup: { left: true } });
+    const [ml, mr] = buttons();
+    expect(ml.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(mr.hasAttribute("aria-haspopup")).toBe(false);
+
+    // Both segments opted in by object behaves like `true`.
+    mountSplit({ popup: { left: true, right: true } });
+    const [bl, br] = buttons();
+    expect(bl.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(br.getAttribute("aria-haspopup")).toBe("listbox");
+
+    // An all-false object is the non-popup default.
+    mountSplit({ popup: { right: false } });
+    const [fl, fr] = buttons();
+    expect(fl.hasAttribute("aria-haspopup")).toBe(false);
+    expect(fr.hasAttribute("aria-haspopup")).toBe(false);
+  });
 });

--- a/src/renderer/Chip.tsx
+++ b/src/renderer/Chip.tsx
@@ -137,11 +137,17 @@ export function SplitChip({
   /**
    * OPT-IN popup semantics. SplitChip is a generic split control — its two
    * segments are plain buttons and it does NOT assume either opens a popup.
-   * A caller whose segments genuinely toggle a listbox (e.g. ModelPicker)
-   * passes `popup` to add `aria-haspopup="listbox"` to both segment buttons;
-   * a non-popup adopter (e.g. a checkbox row) omits it.
+   * A caller whose segments GENUINELY toggle a listbox (e.g. ModelPicker)
+   * opts in to add `aria-haspopup="listbox"` to the segment button(s). A
+   * caller whose left segment is a plain action and whose RIGHT segment opens
+   * a listbox passes `{ right: true }` so the action button never falsely
+   * claims `aria-haspopup` while the listbox segment still lands in the
+   * popup-coverage registry (which keys on `[aria-haspopup]`):
+   *   - `true`          → both segments.
+   *   - `{ left?, right? }` → per segment.
+   *   - omitted/`false` → neither (the non-popup default).
    */
-  popup?: boolean;
+  popup?: boolean | { left?: boolean; right?: boolean };
   /**
    * OPTIONAL third segment, for a boolean TOGGLE that belongs to the same
    * control (e.g. the composer's ⚡ fast-mode switch, which modifies the model
@@ -188,7 +194,12 @@ export function SplitChip({
   /** Forwarded to the RIGHT segment button (used as the effort dropdown's anchor). */
   rightBtnRef?: RefObject<HTMLButtonElement>;
 }) {
-  const listbox = popup ? { "aria-haspopup": "listbox" as const } : {};
+  // `aria-haspopup` is opted in per segment: `true` covers both, an object
+  // covers whichever segment it names, omitted/`false` covers neither.
+  const popupLeft = popup === true || (typeof popup === "object" && popup.left === true);
+  const popupRight = popup === true || (typeof popup === "object" && popup.right === true);
+  const leftListbox = popupLeft ? { "aria-haspopup": "listbox" as const } : {};
+  const rightListbox = popupRight ? { "aria-haspopup": "listbox" as const } : {};
   const leftAria = leftExpanded !== undefined ? { "aria-expanded": leftExpanded } : {};
   const rightAria = rightExpanded !== undefined ? { "aria-expanded": rightExpanded } : {};
   const idle = loading ? " cursor-default" : " hover:bg-fill-hover hover:text-text";
@@ -234,10 +245,10 @@ export function SplitChip({
       className={`${hook ? `${hook} ` : ""}${SPLIT_SHELL} p-0 overflow-hidden ${CHIP_REST}`}
       aria-busy={loading || undefined}
     >
-      <button ref={leftBtnRef} type="button" onClick={onLeftClick} title={leftTitle} className={leftClass} {...listbox} {...leftAria}>
+      <button ref={leftBtnRef} type="button" onClick={onLeftClick} title={leftTitle} className={leftClass} {...leftListbox} {...leftAria}>
         {left}
       </button>
-      <button ref={rightBtnRef} type="button" onClick={onRightClick} title={rightTitle} className={rightClass} {...listbox} {...rightAria}>
+      <button ref={rightBtnRef} type="button" onClick={onRightClick} title={rightTitle} className={rightClass} {...rightListbox} {...rightAria}>
         {right}
       </button>
       {extra !== undefined && (

--- a/src/renderer/ModelMenu.test.tsx
+++ b/src/renderer/ModelMenu.test.tsx
@@ -101,3 +101,49 @@ describe("ModelMenu footer — Manage models… (BET-645)", () => {
     }
   });
 });
+
+describe("ModelMenu defaultRow — pinned top-row copy override (BET-948)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("omitted → today's exact 'Server default' label + sub line", () => {    h = mount(
+      <ModelMenu
+        open
+        anchorRef={anchorRef()}
+        groups={GROUPS}
+        modelOverride={null}
+        defaultModel={{ providerID: "anthropic", modelID: "claude-opus-4-7" }}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const text = surface().textContent ?? "";
+    expect(text).toContain("Server default");
+    expect(text).toContain("Claude Opus 4.7 · set in Settings");
+  });
+
+  it("overrides ONLY the pinned row's label/sub, leaving the body unchanged", () => {
+    h = mount(
+      <ModelMenu
+        open
+        anchorRef={anchorRef()}
+        groups={GROUPS}
+        modelOverride={null}
+        defaultModel={{ providerID: "anthropic", modelID: "claude-opus-4-7" }}
+        defaultRow={{ label: "Inherit build model", sub: "uses this session's model" }}
+        onSelect={() => {}}
+        onClose={() => {}}
+      />,
+    );
+    const text = surface().textContent ?? "";
+    expect(text).toContain("Inherit build model");
+    expect(text).toContain("uses this session's model");
+    // Today's "set in Settings" copy is gone from the pinned row.
+    expect(text).not.toContain("set in Settings");
+    // The body's model row is untouched.
+    expect(text).toContain("Claude Opus 4.7");
+  });
+});

--- a/src/renderer/ModelMenu.tsx
+++ b/src/renderer/ModelMenu.tsx
@@ -31,6 +31,7 @@ export function ModelMenu({
   onClose,
   open,
   anchorRef,
+  defaultRow,
 }: {
   groups: Array<[string, OpencodeModel[]]> | null;
   modelOverride: ModelSelection | null;
@@ -39,6 +40,14 @@ export function ModelMenu({
   onClose: () => void;
   open: boolean;
   anchorRef: RefObject<HTMLElement>;
+  /**
+   * Copy override for the pinned top (server-default) row ONLY — the row that
+   * means "no override". A second consumer (the delegate model picker) needs
+   * it to mean "inherit this session's build model" rather than "set in
+   * Settings". Omitted → today's exact strings ("Server default" /
+   * "<model> · set in Settings" / "opencode decides").
+   */
+  defaultRow?: { label?: string; sub?: string };
 }) {
   const [query, setQuery] = useState("");
   const [highlight, setHighlight] = useState(-1);
@@ -61,6 +70,10 @@ export function ModelMenu({
     ? `${serverModel.name} · set in Settings`
     : "opencode decides";
   const serverSelected = modelOverride == null;
+  // `defaultRow` overrides ONLY this pinned row's label/sub — the copy that
+  // signals "no override". Omitted, today's exact strings stand.
+  const defaultLabel = defaultRow?.label ?? "Server default";
+  const defaultSub = defaultRow?.sub ?? serverSub;
 
   const filtered = useMemo(
     () => (groups == null ? null : filterModelGroups(groups, query)),
@@ -199,8 +212,8 @@ export function ModelMenu({
           id="server-default"
           selected={serverSelected}
           active={highlight === 0}
-          label="Server default"
-          sub={serverSub}
+          label={defaultLabel}
+          sub={defaultSub}
           onSelect={() => {
             onSelect(null);
             onClose();

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -81,8 +81,8 @@ export function ModelPicker({
 
   // The models a user may actually switch TO: enabled, not deprecated, not
   // deactivated in Settings. Both the dropdown and the ⚡ toggle read from the
-  // same chatUtils source of truth (the `enabled !== false` filter lives there
-  // and nowhere else), so a model hidden in Settings can't be reached by
+  // same chatUtils source of truth (the enabled/status/deactivated gate lives
+  // there and nowhere else), so a model hidden in Settings can't be reached by
   // either route.
   // (`activeModel` below deliberately resolves against the FULL list — an
   // already-selected model must keep displaying its own name even if it was

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -16,7 +16,7 @@ import { useMemo, useRef, useState } from "react";
 import { ChevronDown, Sparkles, Zap, ZapOff } from "lucide-react";
 import type { OpencodeModel } from "../shared/types";
 import { type ModelSelection, resolveActiveModel } from "./chatShared";
-import { hideFastSiblingGroups, resolveFastToggle, titleCase } from "./chatUtils";
+import { selectableModelGroups, selectableModelList, resolveFastToggle, titleCase } from "./chatUtils";
 import { SplitChip } from "./Chip";
 import { EffortMenu } from "./EffortMenu";
 import { ModelMenu } from "./ModelMenu";
@@ -80,38 +80,25 @@ export function ModelPicker({
   const effortBtnRef = useRef<HTMLButtonElement>(null);
 
   // The models a user may actually switch TO: enabled, not deprecated, not
-  // deactivated in Settings. Both the dropdown and the ⚡ toggle read from this
-  // one set, so a model hidden in Settings can't be reached by either route.
+  // deactivated in Settings. Both the dropdown and the ⚡ toggle read from the
+  // same chatUtils source of truth (the `enabled !== false` filter lives there
+  // and nowhere else), so a model hidden in Settings can't be reached by
+  // either route.
   // (`activeModel` below deliberately resolves against the FULL list — an
   // already-selected model must keep displaying its own name even if it was
   // later deactivated.)
-  const selectableModels = useMemo(() => {
-    if (!models) return null;
-    const deactivatedMain = new Set(deactivatedMainModels ?? []);
-    return models.filter(
-      (m) =>
-        m.enabled !== false &&
-        m.status !== "deprecated" &&
-        !deactivatedMain.has(`${m.providerID}/${m.id}`),
-    );
-  }, [models, deactivatedMainModels]);
+  const selectableModels = useMemo(
+    () => selectableModelList(models, deactivatedMainModels),
+    [models, deactivatedMainModels],
+  );
 
-  // Group models by providerID so the list reads e.g. "anthropic" → 3 models.
-  const groups = useMemo(() => {
-    if (!selectableModels) return null;
-    const map = new Map<string, OpencodeModel[]>();
-    for (const m of selectableModels) {
-      const arr = map.get(m.providerID) ?? [];
-      arr.push(m);
-      map.set(m.providerID, arr);
-    }
-    const sorted = [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
-    // "Fast" flavours (`<id>-fast`) are a MODE of their base model, not a
-    // separate choice — they're reached through the ⚡ segment below, so they
-    // don't get a row here. `hideFastSiblingGroups` keeps an orphan whose base
-    // is missing/deactivated, which would otherwise become unreachable.
-    return hideFastSiblingGroups(sorted);
-  }, [selectableModels]);
+  // The dropdown's candidate set: selectable models grouped by provider,
+  // sorted, with `-fast` siblings folded into their base (they're reached
+  // through the ⚡ segment). Shared with the delegate model picker.
+  const groups = useMemo(
+    () => selectableModelGroups(models, deactivatedMainModels),
+    [models, deactivatedMainModels],
+  );
 
   // Resolve the active model object (for the friendly name + variant list).
   // Shared resolution path with ChatPanel (BET-415 duplication gate).

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -77,6 +77,7 @@ import {
   fastModelId,
   hideFastSiblingGroups,
   resolveFastToggle,
+  selectableModelGroups,
   filterModelGroups,
   moveMenuHighlight,
   MAX_PREVIEW_BYTES,
@@ -2797,6 +2798,64 @@ describe("fast-mode model helpers", () => {
       available: false,
       on: false,
     });
+  });
+});
+
+// ===== selectableModelGroups =====
+
+describe("selectableModelGroups", () => {
+  const M = (
+    providerID: string,
+    id: string,
+    extra: Partial<OpencodeModel> = {},
+  ): OpencodeModel => ({ id, providerID, name: id, ...extra }) as OpencodeModel;
+
+  it("returns null for null input (the loading signal)", () => {
+    expect(selectableModelGroups(null, undefined)).toBeNull();
+  });
+
+  it("filters out disabled, deprecated and deactivated models", () => {
+    const models = [
+      M("a", "keep"),
+      M("a", "disabled", { enabled: false }),
+      M("a", "deprecated", { status: "deprecated" }),
+      M("a", "deactivated"),
+    ];
+    const out = selectableModelGroups(models, ["a/deactivated"]);
+    const ids = out![0][1].map((m) => m.id);
+    expect(ids).toEqual(["keep"]);
+  });
+
+  it("groups and sorts by providerID", () => {
+    const models = [
+      M("zetta", "z1"),
+      M("alpha", "a1"),
+      M("alpha", "a2"),
+      M("zetta", "z2"),
+    ];
+    const out = selectableModelGroups(models, undefined)!;
+    expect(out.map(([p]) => p)).toEqual(["alpha", "zetta"]);
+    expect(out[0][1].map((m) => m.id)).toEqual(["a1", "a2"]);
+    expect(out[1][1].map((m) => m.id)).toEqual(["z1", "z2"]);
+  });
+
+  it("folds fast siblings but keeps an orphan whose base is gone", () => {
+    const models = [
+      M("openai", "gpt-5.6"),
+      M("openai", "gpt-5.6-fast"),
+      M("x", "solo-fast"),
+    ];
+    const out = selectableModelGroups(models, undefined)!;
+    const openai = out.find(([p]) => p === "openai")![1].map((m) => m.id);
+    expect(openai).toEqual(["gpt-5.6"]);
+    // The orphan fast model (no base to fold into / reach it by) survives.
+    const x = out.find(([p]) => p === "x")![1].map((m) => m.id);
+    expect(x).toEqual(["solo-fast"]);
+  });
+
+  it("an empty selection yields an empty (not null) grouped list", () => {
+    const models = [M("a", "off", { enabled: false })];
+    expect(selectableModelGroups(models, undefined)).toEqual([]);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1951,6 +1951,56 @@ export function hideFastSiblingGroups(
   return out;
 }
 
+// ===== selectableModelGroups =====
+//
+// The model set a user may actually switch TO — the answer to "does
+// delegation respect the Main toggle?". Enabled, not deprecated, not
+// deactivated in Settings (`deactivatedMainModels`), grouped by provider,
+// sorted, then `hideFastSiblingGroups`. Shared by ModelPicker's dropdown and
+// the delegate model picker so both read one source of truth (the `enabled !==
+// false` filter lives here and nowhere else in the renderer).
+
+/**
+ * The flat selectable model list (enabled, not deprecated, not deactivated).
+ * `null` input → `null` (the loading signal callers rely on). The flat list,
+ * not the grouped one, is what `resolveFastToggle` needs — it must still see a
+ * `-fast` twin whose base is present, which `hideFastSiblingGroups` would fold
+ * out of the groups.
+ */
+export function selectableModelList(
+  models: OpencodeModel[] | null,
+  deactivatedMainModels: string[] | undefined,
+): OpencodeModel[] | null {
+  if (!models) return null;
+  const deactivatedMain = new Set(deactivatedMainModels ?? []);
+  return models.filter(
+    (m) =>
+      m.enabled !== false &&
+      m.status !== "deprecated" &&
+      !deactivatedMain.has(`${m.providerID}/${m.id}`),
+  );
+}
+
+/**
+ * The grouped, sorted, fast-sibling-folded selectable list — the candidate
+ * model set for dropdowns and pickers. `null` models → `null` (loading).
+ */
+export function selectableModelGroups(
+  models: OpencodeModel[] | null,
+  deactivatedMainModels: string[] | undefined,
+): Array<[string, OpencodeModel[]]> | null {
+  const selectable = selectableModelList(models, deactivatedMainModels);
+  if (selectable === null) return null;
+  const map = new Map<string, OpencodeModel[]>();
+  for (const m of selectable) {
+    const arr = map.get(m.providerID) ?? [];
+    arr.push(m);
+    map.set(m.providerID, arr);
+  }
+  const sorted = [...map.entries()].sort(([a], [b]) => a.localeCompare(b));
+  return hideFastSiblingGroups(sorted);
+}
+
 export type FastToggleState = {
   /** The toggle can be clicked (a counterpart exists that keeps the effort). */
   available: boolean;


### PR DESCRIPTION
## BET-948 — prereqs for the plan-mode model card

Three renderer refactors that remove/unify code, no visual change.

### 1. `SplitChip` `popup` is now per-segment
`src/renderer/Chip.tsx` — widened `popup?: boolean | { left?: boolean; right?: boolean }`.
`true` → both segments (unchanged); object → the named segment(s); omitted/`false` → neither.
Note the new `{ left?: boolean; right?: boolean }` shape is the only way a caller whose LEFT
segment is a plain action and whose RIGHT opens a listbox avoids falsely claiming
`aria-haspopup` on the action while keeping the listbox segment in the popup-coverage
registry. `ModelPicker` keeps passing plain `popup` (unchanged); the `extra` segment still
takes `aria-pressed`, never `aria-haspopup`.

**Deleted:** the shared `listbox` object spread onto both buttons → two per-segment objects.

### 2. `ModelMenu` pinned default row — one copy-override prop
`src/renderer/ModelMenu.tsx` — added ONE optional `defaultRow?: { label?: string; sub?: string }`
that overrides only the pinned top (server-default) row's copy — the row meaning "no override".
Omitted → today's exact strings. No second menu component, no mode-enum branch.

### 3. `selectableModelGroups` extracted to `chatUtils.ts`
Moved the candidate-model-set computation (enabled, not deprecated, not in
`deactivatedMainModels`, grouped by provider, sorted, then `hideFastSiblingGroups` — reused,
not re-implemented) into a pure, tested helper. `ModelPicker` deletes both `useMemo` blocks
(the old `selectableModels` and `groups` inline computations) and calls the helper. Its
`activeModel` still resolves against the FULL `models` list (an already-selected,
later-deactivated model keeps displaying its name).

Supporting helper `selectableModelList` (the flat, pre-fast-fold list) was also exported from
`chatUtils.ts`: `resolveFastToggle` needs to still see a `-fast` twin whose base is present,
which `hideFastSiblingGroups` folds out of the grouped list — feeding it the folded groups
would break the ⚡ toggle. The enabled/status/deactivated gate lives in chatUtils and nowhere
else (`grep "enabled !== false"` matches only `src/renderer/chatUtils.ts`).

Base: `origin/main @ cc3c042e`

**Files changed:** 7 files. `src/renderer/Chip.tsx`, `Chip.test.tsx`, `ModelMenu.tsx`,
`ModelMenu.test.tsx`, `ModelPicker.tsx`, `chatUtils.ts`, `chatUtils.test.ts`

**Verification results:**
- PR branch (`multica/BET-948-renderer-primitives` @ `b154e99a`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit 0. Renderer vitest `2734 passed / 7 skipped`; server node:test `2079 pass / 0 fail`. log sha256: `ce2f1bda857f51a39b03f275d5933e3debd2d8f487191be3d69cf092e5e62479`
- Base (`main` @ `cc3c042e`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit 0. Renderer vitest `2726 passed / 7 skipped`; server node:test `2079 pass / 0 fail`. log sha256: `52baa4cd0823e6efeccb543b32e48968597548b313c44483db81a6680d0ae607`
- **Conclusion:** 0 new failures. The PR adds 8 renderer tests (Chip per-segment popup ×4, ModelMenu defaultRow ×2, selectableModelGroups ×5).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
