### PR TITLE
fix(server): thread an optional model through prompt delivery (BET-947)

### DIFF
--- a/docs/opencode-tools/delegate.ts
+++ b/docs/opencode-tools/delegate.ts
@@ -109,8 +109,10 @@ export const delegate = tool({
       .string()
       .optional()
       .describe(
-        "Optional free-text model id for the job's session, passed straight " +
-          "through to the box. When omitted the job uses the box's default model. " +
+        "Optional model id for the job's session, as free text.\u200b " +
+          "When omitted the job uses the box's default model. The value must be " +
+          "a model id the box knows (matched by the box, not freeform): a bad " +
+          "value fails loudly rather than silently picking a different model. " +
           "Not validated client-side.",
       ),
     tools: z

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -40,6 +40,7 @@ import {
   describeChatActivity,
 } from "./peers.mjs";
 import { extractSubagentInfo } from "../shared/streamInterpretation.mjs";
+import { fuzzyMatchModel, suggestModels } from "../shared/modelGuide.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants (mirrors capabilities.mjs exactly — reuse, do not diverge)
@@ -325,6 +326,7 @@ async function registerJob(
     name,
     prompt,
     model,
+    requestedModel,
     cwd,
     worktree,
     branch,
@@ -391,6 +393,10 @@ async function registerJob(
     name,
     prompt,
     model: model ?? null,
+    // What was ASKED for (canonical "providerID/modelID" string or null).
+    // Never overwritten — distinct from `job.model`, which tickActivity stamps
+    // with the model OBSERVED in the child's own transcript (BET-947).
+    requestedModel: requestedModel ?? null,
     parentSessionID,
     parentDirectory,
     childSessionID,
@@ -427,16 +433,79 @@ async function registerJob(
 }
 
 /**
- * @param {{prompt:string, model?:string, parentSessionID:string, parentDirectory:string,
+ * Resolve a delegate `model` argument to the structured shape deliver() and
+ * sendPrompt() accept ({providerID, modelID, variant?}).
+ *
+ * A structured `{providerID, modelID, variant?}` value is accepted as-is
+ * (skips matching — the renderer sends this shape). Free text is matched
+ * against the box's known models with the SHARED fuzzy matcher
+ * (src/shared/modelGuide.mjs — the same one app-control uses for
+ * manta_switch_model; do not write a second matcher). No match → {ok:false}
+ * naming the closest candidates, so a bad value fails loudly instead of
+ * silently falling back to opencode's default.
+ *
+ * `requested` is the canonical "providerID/modelID" string recorded on the job
+ * as `requestedModel` (what was asked for, never overwritten).
+ *
+ * @param {unknown} model
+ * @param {Array<object>} models oc.listModels() output
+ * @returns {{ok:true, model:{providerID:string, modelID:string, variant?:string}|null, requested:string|null}|{ok:false, error:string}}
+ */
+export function resolveRequestedModel(model, models) {
+  if (model && typeof model === "object" && !Array.isArray(model)) {
+    if (
+      typeof model.providerID === "string" &&
+      model.providerID &&
+      typeof model.modelID === "string" &&
+      model.modelID
+    ) {
+      const structured = { providerID: model.providerID, modelID: model.modelID };
+      if (typeof model.variant === "string" && model.variant) {
+        structured.variant = model.variant;
+      }
+      return {
+        ok: true,
+        model: structured,
+        requested: `${model.providerID}/${model.modelID}`,
+      };
+    }
+    return { ok: false, error: "model must be free text or an object with string providerID and modelID." };
+  }
+  const query = typeof model === "string" ? model.trim() : "";
+  if (!query) {
+    // No model requested — byte-identical to today: the box's default applies.
+    return { ok: true, model: null, requested: null };
+  }
+  const resolved = fuzzyMatchModel(query, models);
+  if (!resolved) {
+    const suggestions = suggestModels(query, models, 3);
+    const hint = suggestions.length
+      ? ` Closest models: ${suggestions.map((s) => `${s.providerID}/${s.id}`).join(", ")}.`
+      : " No models are currently available on this box.";
+    return { ok: false, error: `No model matched "${model}".${hint}` };
+  }
+  return {
+    ok: true,
+    model: { providerID: resolved.providerID, modelID: resolved.id },
+    requested: `${resolved.providerID}/${resolved.id}`,
+  };
+}
+
+/**
+ * @param {{prompt:string, model?:string|{providerID:string, modelID:string, variant?:string}, parentSessionID:string, parentDirectory:string,
  *          link?: {issue?:{repoKey:string,number:number}, pr?:{repoKey:string,number:number}}|null}} input
+ *        `model` (BET-947) — optional model for the job's session: free text
+ *        resolved via the shared fuzzy matcher, or a structured
+ *        {providerID, modelID, variant?} used as-is. Unmatchable free text
+ *        fails the delegation loudly naming candidates.
  *        `link` (BET-844) — the optional session link (at most one issue + one
  *        PR, `{issue?, pr?}` shape) a forge-triggered delegate carries so the
  *        progress sink addresses the linked issue/PR. Stored on the job record.
  * @param {object} deps injected I/O (load/save/publish/deliver/listProjects/
- *        newWindow/gitAddWorktree/gitRun/oc listMessages/now)
+ *        newWindow/gitAddWorktree/gitRun/oc listMessages/listModels/now)
  */
 export async function startJob(input, deps = {}) {
-  const { deliver } = deps;
+  const { deliver, listModels } = deps;
 
   const prompt = String(input?.prompt ?? "");
   const parentSessionID = input?.parentSessionID;
@@ -444,6 +513,21 @@ export async function startJob(input, deps = {}) {
 
   if (!parentSessionID) return { ok: false, error: "parentSessionID is required" };
   if (!parentDirectory) return { ok: false, error: "parentDirectory is required" };
+
+  // Resolve the requested model once, up front. A structured model is used
+  // as-is; free text is matched against the box's known models via the shared
+  // fuzzy matcher, and an unmatchable value fails the delegation loudly
+  // (naming candidates) rather than silently falling back to the default. A
+  // missing input model leaves both null — the box default, byte-identical to
+  // today. Only fetch the model list when a model was actually requested.
+  let requestedModel = null;
+  let deliverModel = null;
+  if (input?.model) {
+    const resolved = resolveRequestedModel(input.model, listModels ? await listModels() : []);
+    if (!resolved.ok) return resolved;
+    requestedModel = resolved.requested;
+    deliverModel = resolved.model;
+  }
 
   // The whole creation — nesting + cap checks, worktree, window, record append —
   // runs inside the jobs-store lock so a concurrent `delegate` POST cannot pass
@@ -515,7 +599,8 @@ export async function startJob(input, deps = {}) {
         parentDirectory,
         name,
         prompt,
-        model: input?.model,
+        model: requestedModel,
+        requestedModel,
         cwd,
         worktree,
         branch,
@@ -531,11 +616,14 @@ export async function startJob(input, deps = {}) {
 
   if (!reg.ok) return reg;
 
-  // 8. Send the opening prompt via the shared delivery module's deliver.
+  // 8. Send the opening prompt via the shared delivery module's deliver. The
+  //    requested model (resolved above) is threaded through so a delegate that
+  //    asked for a specific model actually runs on it; omitted → the default.
   try {
     await deliver({
       sessionId: reg.job.childSessionID,
       text: buildJobPrompt({ prompt, worktree: reg.job.worktree, branch: reg.job.branch }),
+      ...(deliverModel ? { model: deliverModel } : {}),
     });
   } catch (e) {
     // deliver never rejects in production, but guard anyway — the job is
@@ -597,6 +685,7 @@ export async function adoptSubagentJob(
         name,
         prompt,
         model,
+        requestedModel: null,
         cwd: parentDirectory,
         worktree: null,
         branch: null,

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -442,6 +442,99 @@ test("startJob leaves the link null when none is provided", async () => {
   assert.equal(job.link, null);
 });
 
+// ----------------------------------------------------------------------------
+// BET-947 — startJob model threading (structured, free text, no-match, none)
+// ----------------------------------------------------------------------------
+
+function mockModels() {
+  return [
+    { providerID: "anthropic", id: "claude-opus-4-5", name: "Claude Opus 4.5" },
+    { providerID: "anthropic", id: "claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+    { providerID: "deepseek", id: "deepseek-chat", name: "DeepSeek Chat" },
+  ];
+}
+
+function startHarness(childSessionId) {
+  const h = harness([]);
+  h.deps.gitAddWorktree = async () => { throw new Error("not a git repository"); };
+  h.deps.listProjects = async () => [
+    { tmuxSession: "s", windows: [{ index: 1, opencodeSessionId: "parent", paneCurrentPath: "/repo" }] },
+  ];
+  h.deps.newWindow = async () => ({ sessionId: childSessionId, windowIndex: 1 });
+  return h;
+}
+
+test("startJob with a structured model passes it to deliver and records requestedModel (BET-947)", async () => {
+  const h = startHarness("child_struct");
+  const res = await startJob(
+    { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo",
+      model: { providerID: "anthropic", modelID: "claude-opus-4-5" } },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.equal(h.delivered.length, 1);
+  assert.deepEqual(h.delivered[0].model, { providerID: "anthropic", modelID: "claude-opus-4-5" });
+  const job = h.jobs.find((j) => j.childSessionID === "child_struct");
+  assert.equal(job.requestedModel, "anthropic/claude-opus-4-5");
+});
+
+test("startJob resolves free text matching a known model and passes it (BET-947)", async () => {
+  const h = startHarness("child_freetext");
+  h.deps.listModels = async () => mockModels();
+  const res = await startJob(
+    { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo", model: "opus" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.equal(h.delivered.length, 1);
+  assert.deepEqual(h.delivered[0].model, { providerID: "anthropic", modelID: "claude-opus-4-5" });
+  const job = h.jobs.find((j) => j.childSessionID === "child_freetext");
+  assert.equal(job.requestedModel, "anthropic/claude-opus-4-5");
+});
+
+test("startJob with unmatchable free text rejects and names candidates (BET-947)", async () => {
+  const h = harness([]);
+  h.deps.listModels = async () => mockModels();
+  const res = await startJob(
+    { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo", model: "claude zzz" },
+    h.deps,
+  );
+  assert.equal(res.ok, false);
+  assert.match(res.error, /No model matched "claude zzz"/);
+  assert.match(res.error, /Closest models: /);
+  assert.match(res.error, /anthropic\/claude-/);
+  assert.equal(h.delivered.length, 0, "no prompt delivered on a bad model");
+  assert.equal(h.jobs.length, 0, "no job persisted on a bad model");
+});
+
+test("startJob with no model calls deliver without a model key (BET-947 regression)", async () => {
+  const h = startHarness("child_default");
+  const res = await startJob(
+    { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.equal(h.delivered.length, 1);
+  assert.equal("model" in h.delivered[0], false, "no model key on the default path");
+  const job = h.jobs.find((j) => j.childSessionID === "child_default");
+  assert.equal(job.requestedModel, null);
+});
+
+test("requestedModel survives a tickActivity that rewrites job.model (BET-947)", async () => {
+  const running = runningJob(0);
+  running.requestedModel = "anthropic/claude-opus-4-5";
+  running.model = "anthropic/claude-opus-4-5";
+  running.activity = null;
+  const h = harness([running]);
+  h.deps.listMessages = async () => [
+    modelMessage("anthropic", "claude-sonnet-4-6"), // observed differs from requested
+  ];
+  await tickActivity(h.deps);
+  const job = h.jobs[0];
+  assert.equal(job.model, "anthropic/claude-sonnet-4-6", "job.model reflects the OBSERVED model");
+  assert.equal(job.requestedModel, "anthropic/claude-opus-4-5", "requestedModel is never overwritten");
+});
+
 test("startJob refuses nesting when parentSessionID is a live job's childSessionID", async () => {
   const live = { ...runningJob(0), childSessionID: "child_live", status: "running" };
   const h = harness([live]);

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -406,6 +406,7 @@ const delegateEngine = createDelegateEngine({
   gitRemoveWorktree: (input) => local.gitRemoveWorktree(input),
   gitRun: (args) => tmux.run("git", args),
   listMessages: (sid) => oc.listMessages(sid),
+  listModels: (overrides) => oc.listModels(overrides),
   abortSession: (sid) => oc.abortSession(sid),
   // BET-418 §B: detect a running job whose parent opencode session is gone so
   // the sweeper can stop + clean it up (nobody left to report to).

--- a/src/server/promptDelivery.mjs
+++ b/src/server/promptDelivery.mjs
@@ -31,13 +31,19 @@
  * Build the shared prompt-delivery engine.
  *
  * @param {object} deps
- * @param {(args:{sessionId:string, text:string})=>Promise<unknown>} deps.sendPrompt
+ * @param {(args:{sessionId:string, text:string, model?:{providerID:string, modelID:string, variant?:string}})=>Promise<unknown>} deps.sendPrompt
  *        The underlying opencode prompt injector (oc.sendPrompt).
- * @returns {{deliver: (args:{sessionId:string, text:string})=>Promise<{delivered:boolean, queued:boolean, rejected?:boolean}>, observeEvent:(evt:unknown)=>void, isBusy:(sessionId:string)=>boolean}}
+ * @returns {{deliver: (args:{sessionId:string, text:string, model?:{providerID:string, modelID:string, variant?:string}})=>Promise<{delivered:boolean, queued:boolean, rejected?:boolean}>, observeEvent:(evt:unknown)=>void, isBusy:(sessionId:string)=>boolean}}
  */
 export function createPromptDelivery({ sendPrompt }) {
   const busy = new Set(); // sessionIds currently running a turn
-  const pending = new Map(); // sessionId -> [text, ...] queued while busy
+  const pending = new Map(); // sessionId -> [{text, model}, ...] queued while busy
+
+  // Build the sendPrompt argument, including `model` only when one was given —
+  // an omitted model must leave the call byte-identical to the pre-model engine.
+  function withModel(sessionId, text, model) {
+    return model ? { sessionId, text, model } : { sessionId, text };
+  }
 
   // Upper bound on deferred prompts per session (BET-772). Chosen well above
   // what a realistic burst needs but small enough that a flood cannot balloon
@@ -53,9 +59,9 @@ export function createPromptDelivery({ sendPrompt }) {
     // itself (e.g. a second webhook arriving while we flush) is not lost —
     // it lands in a fresh queue rather than being iterated mid-flush.
     pending.delete(sessionId);
-    for (const text of queue) {
+    for (const { text, model } of queue) {
       try {
-        await sendPrompt({ sessionId, text });
+        await sendPrompt(withModel(sessionId, text, model));
       } catch (e) {
         // Warn and continue: one wedged delivery must not strand the rest of
         // the queued prompts behind it.
@@ -94,7 +100,7 @@ export function createPromptDelivery({ sendPrompt }) {
     return busy.has(sessionId);
   }
 
-  async function deliver({ sessionId, text }) {
+  async function deliver({ sessionId, text, model }) {
     if (busy.has(sessionId)) {
       const q = pending.get(sessionId) ?? [];
       if (q.length >= MAX_PENDING_PER_SESSION) {
@@ -107,12 +113,12 @@ export function createPromptDelivery({ sendPrompt }) {
         );
         return { delivered: false, queued: false, rejected: true };
       }
-      q.push(text);
+      q.push({ text, model });
       pending.set(sessionId, q);
       return { delivered: false, queued: true };
     }
     try {
-      await sendPrompt({ sessionId, text });
+      await sendPrompt(withModel(sessionId, text, model));
       return { delivered: true, queued: false };
     } catch (e) {
       // Never reject: callers swallow errors and a rejection would surface as

--- a/src/server/promptDelivery.test.mjs
+++ b/src/server/promptDelivery.test.mjs
@@ -207,3 +207,34 @@ test("11. bounding is per-session: a full queue for one session does not reject 
   assert.equal(s2.queued, true);
   assert.equal(s2.rejected, undefined);
 });
+
+test("12. idle deliver with a model forwards it; without one omits the key (BET-947)", async () => {
+  const { engine, calls } = makeEngine();
+  const model = { providerID: "anthropic", modelID: "claude-opus-4-5" };
+  const withModel = await engine.deliver({ sessionId: "s1", text: "hi", model });
+  assert.equal(withModel.delivered, true);
+  assert.deepEqual(calls[0], { sessionId: "s1", text: "hi", model });
+});
+
+test("13. deliver without a model leaves sendPrompt byte-identical to pre-model (BET-947)", async () => {
+  const { engine, calls } = makeEngine();
+  const res = await engine.deliver({ sessionId: "s1", text: "hi" });
+  assert.equal(res.delivered, true);
+  assert.deepEqual(calls[0], { sessionId: "s1", text: "hi" });
+  assert.equal("model" in calls[0], false, "no model key when one was not given");
+});
+
+test("14. deferred delivery preserves the model across the busy drain (BET-947)", async () => {
+  const { engine, calls } = makeEngine();
+  engine.observeEvent({
+    type: "session.status",
+    properties: { sessionID: "s1", status: { type: "busy" } },
+  });
+  const model = { providerID: "deepseek", modelID: "deepseek-chat" };
+  const res = await engine.deliver({ sessionId: "s1", text: "deferred", model });
+  assert.equal(res.queued, true);
+  engine.observeEvent({ type: "session.idle", properties: { sessionID: "s1" } });
+  await new Promise((r) => setTimeout(r, 5));
+  assert.equal(calls.length, 1);
+  assert.deepEqual(calls[0], { sessionId: "s1", text: "deferred", model });
+});


### PR DESCRIPTION
## What

BET-947 — thread an optional model through the shared prompt-delivery engine so server-initiated delegates can actually run on a specified model.

- `src/server/promptDelivery.mjs`: `deliver` now accepts an optional `model?: {providerID, modelID, variant?}` and forwards it to `sendPrompt` at both call sites (direct + deferred-queue drain). Omitted → byte-identical to before. The deferred queue now carries each prompt's model so it survives a busy deferral.
- `src/server/delegate.mjs`: `startJob` resolves the `model` argument ONCE and threads it to the opening-prompt `deliver` call. Free text is resolved with the existing shared matcher (`fuzzyMatchModel`/`suggestModels` from `src/shared/modelGuide.mjs` — the same one app-control uses; no second matcher written). A structured `{providerID, modelID, variant?}` is accepted as-is (skips matching, for the renderer). Unmatchable free text fails the delegation loudly, naming candidates — no silent fallback. Split the record: `requestedModel` (what was asked, never overwritten) vs `model` (keeps its current observed-effective-model meaning via the existing `tickActivity` writer, unchanged).
- `src/server/index.mjs`: wired `listModels` into the delegate engine so free-text resolution works in production.
- `docs/opencode-tools/delegate.ts`: the `model` tool arg description now states it must be a model id the box knows and that a bad value fails loudly.

## What was deleted / unified

- The old `job.model`-means-two-things ambiguity is split into `job.requestedModel` (request) and `job.model` (observed) — no new field semantics to converge later.
- No new model-resolution function: reused the existing `fuzzyMatchModel`/`suggestModels` rather than adding a second matcher (matches the issue's explicit constraint).

## Out of scope (unchanged)

- schedule / webhooks / peers / capNotifier still call `deliver` without a model and keep their current behaviour, as specified.

## Verification

- `npm run typecheck`: exit 0, no errors.
- `npm test`: exit 0, 2087 pass / 0 fail / 0 skip.

**Base: origin/main @ cc3c042e**
