### PR TITLE
feat(renderer): plan mode (BET-949) — agent wire, composer toggle, honesty

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -595,6 +595,21 @@ export function ChatPanel({
     setError(null);
     setModelOverride(readSavedModel(sessionId) ?? configDefaultModel ?? null);
     setPlanOn(readPlanSaved(sessionId));
+    // Seed plan mode from the session's own `agent` field when present (BET-949
+    // §5): a session pre-set to plan OUTSIDE MantaUI would otherwise show the
+    // chip off and send the next prompt as build — the stored key alone can't
+    // know. Session.agent takes precedence over the stored key; on failure or
+    // absence we keep the stored-key seed. Guarded like modelCatalog: the
+    // pre-pairing preload subset lacks the method, and calling it throws.
+    const api = window.api as Partial<typeof window.api>;
+    if (api.opencodeSessionAgent) {
+      api.opencodeSessionAgent(sessionId).then((agent) => {
+        if (agent && agent.length > 0) {
+          setPlanOn(agent === "plan");
+          writePlanSaved(sessionId, agent === "plan");
+        }
+      }).catch(() => { /* non-fatal — stored-key seed stands */ });
+    }
     setAttachments([]);
     setAgentMentions([]);
     setSystemNotice(null);

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -59,6 +59,7 @@ import {
   parseModelRef,
   describeMergeFailure,
   progressAttentionKind,
+  resolvePlanToggle,
 } from "./chatUtils";
 import {
   appendPromptHistory,
@@ -68,6 +69,8 @@ import {
   modelSupportsAttachments,
   readSavedModel,
   writeSavedModel,
+  readPlanSaved,
+  writePlanSaved,
   resolveActiveModel,
   type AgentMention,
   type Attachment,
@@ -77,6 +80,7 @@ import {
   type TokenUsage,
 } from "./chatShared";
 import { useModelCatalog } from "./modelCatalog";
+import { useAgentCatalog } from "./agentCatalog";
 import { MantaLoader } from "./MantaLoader";
 import { MeasureColumn } from "./MeasureColumn";
 import { BlockedProgressCard, CompactionCard, PermissionCard, RetryCard } from "./Cards";
@@ -416,6 +420,33 @@ export function ChatPanel({
     [modelOverride, configDefaultModel],
   );
 
+  // ===== Per-session plan mode (BET-949) =====
+  // Local on/off, seeded from the per-session storage key (the `Session.agent`
+  // seed falls back to this). The honesty handlers in useSseBus sync this from
+  // opencode's own agent-switch events (plan_enter/plan_exit / agent.switched),
+  // so the chip never claims plan mode while the next turn would run as build.
+  const [planOn, setPlanOn] = useState<boolean>(() => readPlanSaved(sessionId));
+  // The `plan` agent availability comes from the shared box-level catalog.
+  const { agents } = useAgentCatalog();
+  const plan = useMemo(
+    () => resolvePlanToggle(agents, planOn),
+    [agents, planOn],
+  );
+  const togglePlan = useCallback(() => {
+    setPlanOn((prev) => {
+      const next = !prev;
+      writePlanSaved(sessionId, next);
+      return next;
+    });
+  }, [sessionId]);
+  // Honesty sync from useSseBus: opencode's OWN agent switches (plan_enter /
+  // plan_exit / agent.switched) drive this so the chip never lies about the
+  // agent the next turn will run as. Also persists so a re-mount seeds right.
+  const syncPlan = useCallback((next: boolean) => {
+    setPlanOn(next);
+    writePlanSaved(sessionId, next);
+  }, [sessionId]);
+
   // ===== SSE bus state (extracted to useSseBus) =====
   const {
     running,
@@ -482,6 +513,7 @@ export function ChatPanel({
     refetchOwedWhileInactive,
     applyStreamFlush,
     providerID,
+    setPlanOn: syncPlan,
     submit: () => {}, // placeholder — ChatPanel's submit is used below
     submitRef,
   });
@@ -562,6 +594,7 @@ export function ChatPanel({
   useEffect(() => {
     setError(null);
     setModelOverride(readSavedModel(sessionId) ?? configDefaultModel ?? null);
+    setPlanOn(readPlanSaved(sessionId));
     setAttachments([]);
     setAgentMentions([]);
     setSystemNotice(null);
@@ -981,6 +1014,10 @@ export function ChatPanel({
     const typed = (textOverride ?? input).trim();
     const text = pathRefText ? (typed ? `${typed} ${pathRefText}` : pathRefText) : typed;
     if (!text) return;
+    // Resolve the agent at SUBMIT time (not queue time) — a mode flipped
+    // mid-turn must apply to the turn that actually runs (BET-949). Only send
+    // it when plan is genuinely available AND on.
+    const planAgent = plan.available && plan.on ? plan.agent : undefined;
     // Record the prompt into the per-window localStorage list BEFORE the
     // running-queue early-return so queued prompts also persist (a queued
     // prompt still belongs to this tmux window — `/clear` shouldn't lose it).
@@ -1113,6 +1150,7 @@ export function ChatPanel({
           command: cmdName!,
           arguments: slashMatch[2] ?? "",
           model: modelOverride ?? undefined,
+          agent: planAgent,
           attachments: readyAttachments,
         });
       } else {
@@ -1148,6 +1186,7 @@ export function ChatPanel({
           modelOverride ?? undefined,
           readyAttachments,
           resolvedMentions.length > 0 ? resolvedMentions : undefined,
+          planAgent,
         );
       }
       setAttachments([]);
@@ -1167,7 +1206,7 @@ export function ChatPanel({
     // (clear/fork/compact) are read via their ref mirror below (declared after
     // submit in this file — the established commandsRef pattern) so submit
     // always sees their current value without them re-rotating this callback.
-  }, [input, running, sessionId, modelOverride, attachments, agentMentions, tmuxSession, windowIndex]);
+  }, [input, running, sessionId, modelOverride, attachments, agentMentions, tmuxSession, windowIndex, plan]);
 
   // Always-current ref to submit — lets the queued-message effect call the
   // latest version without adding submit to the effect's dependency array
@@ -1456,11 +1495,14 @@ export function ChatPanel({
       if (cleared?.newSessionId && modelOverride) {
         writeSavedModel(cleared.newSessionId, modelOverride);
       }
+      if (cleared?.newSessionId && planOn) {
+        writePlanSaved(cleared.newSessionId, true);
+      }
       await refresh();
     } catch (e) {
       setSendError(String((e as Error)?.message ?? e));
     }
-  }, [tmuxSession, windowIndex, cwd, modelOverride, refresh]);
+  }, [tmuxSession, windowIndex, cwd, modelOverride, planOn, refresh]);
 
   // Current-value ref mirrors for `submit` — declared AFTER submit in this file
   // (the established commandsRef pattern), so submit reads these instead of
@@ -2681,6 +2723,8 @@ export function ChatPanel({
         models={models}
         modelOverride={modelOverride}
         defaultModel={defaultModel}
+        plan={plan}
+        onTogglePlan={togglePlan}
         activeProviderID={activeModel?.providerID ?? null}
         deactivatedMainModels={deactivatedMainModels}
         onOpenModels={ensureModels}

--- a/src/renderer/Chip.tsx
+++ b/src/renderer/Chip.tsx
@@ -52,6 +52,7 @@ export function Chip({
   title,
   children,
   hook,
+  disabled = false,
 }: {
   /** The "on"/active state — accent border + accent-bg surface. Default off. */
   on?: boolean;
@@ -67,10 +68,29 @@ export function Chip({
    * chrome, so it is not the `className` escape hatch the epic forbids.
    */
   hook?: string;
+  /**
+   * The control is unavailable (e.g. plan mode when the box has no `plan`
+   * agent). Follows SplitChip's `extraDisabled` recipe: dimmed, no hover,
+   * `cursor-not-allowed`, not clickable. Tone is resolved BEFORE the disabled
+   * check so an on-but-frozen control keeps its accent and dims instead of
+   * flattening to grey and lying about its state.
+   */
+  disabled?: boolean;
 }) {
-  const className = `${hook ? `${hook} ` : ""}${CHIP_SHELL} ${CHIP_PAD} ${on ? CHIP_ON : `${CHIP_REST} ${CHIP_HOVER}`}`;
+  const tone = disabled
+    ? `${on ? CHIP_ON : CHIP_REST} opacity-50 cursor-not-allowed`
+    : on
+      ? CHIP_ON
+      : `${CHIP_REST} ${CHIP_HOVER}`;
+  const className = `${hook ? `${hook} ` : ""}${CHIP_SHELL} ${CHIP_PAD} ${tone}`;
   return (
-    <button type="button" onClick={onClick} title={title} className={className}>
+    <button
+      type="button"
+      onClick={disabled ? undefined : onClick}
+      disabled={disabled}
+      title={title}
+      className={className}
+    >
       {children}
     </button>
   );

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -17,13 +17,14 @@
 // a focus state instead of hairline dividers around a naked textarea.
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { Mic, Shield, Square } from "lucide-react";
+import { DraftingCompass, Mic, Shield, Square } from "lucide-react";
 import type { OpencodeModel } from "../shared/types";
 import type { Voice } from "./hooks/useVoice";
 import {
   arrowDownNavigatesHistory,
   arrowUpNavigatesHistory,
   type CaretRow,
+  type PlanToggleState,
 } from "./chatUtils";
 import {
   type ModelSelection,
@@ -32,6 +33,7 @@ import {
 } from "./chatShared";
 import { baseModelId, isFastModelId, shortModelName } from "./chatUtils";
 import { ModelPicker } from "./ModelPicker";
+import { Chip } from "./Chip";
 import { MeasureColumn } from "./MeasureColumn";
 import {
   AttachButton,
@@ -146,6 +148,8 @@ export function InputArea({
   models,
   modelOverride,
   defaultModel,
+  plan,
+  onTogglePlan,
   activeProviderID,
   deactivatedMainModels,
   onOpenModels,
@@ -209,6 +213,9 @@ export function InputArea({
   deactivatedMainModels: string[];
   onOpenModels: () => void;
   onSelectModel: (m: ModelSelection | null) => void;
+  // Plan-mode chip (BET-949): the resolved toggle state + the flip handler.
+  plan: PlanToggleState;
+  onTogglePlan: () => void;
   scheduleCount: number;
   onSchedules: () => void;
   onSecrets: () => void;
@@ -385,6 +392,15 @@ export function InputArea({
           value={input}
           onChange={(e) => setInput(e.target.value)}
           onKeyDown={(e) => {
+            // ⇧Tab toggles plan mode (BET-949). The composer textarea owns its
+            // focus, so overriding reverse tab-traversal here is safe — this is
+            // composer-scoped, not a window binding. Gated on availability so a
+            // box with no `plan` agent can't be toggled into a frozen state.
+            if (e.key === "Tab" && e.shiftKey && plan.available) {
+              e.preventDefault();
+              onTogglePlan();
+              return;
+            }
             if (typeaheadOpen) {
               if (e.key === "ArrowDown") {
                 e.preventDefault();
@@ -503,6 +519,28 @@ export function InputArea({
             onSelect={onSelectModel}
             labelOverride={shortLabel}
           />
+          {/* Plan mode chip (BET-949) — the counterpart to the model picker.
+              Loading renders a chip-sized pulse placeholder (same bg-border
+              animate-pulse recipe as ModelPicker's SkeletonBar); unavailable
+              renders the chip disabled-equivalent with an explanatory title. */}
+          {plan.loading ? (
+            <span
+              className="inline-flex items-center h-[9px] rounded-full bg-border animate-pulse"
+              style={{ width: 64 }}
+              aria-hidden="true"
+            />
+          ) : (
+            <Chip
+              on={plan.on}
+              onClick={onTogglePlan}
+              disabled={!plan.available}
+              title={plan.title}
+              hook="manta-plan-toggle"
+            >
+              <DraftingCompass size={13} aria-hidden="true" />
+              Plan
+            </Chip>
+          )}
           {/* Input-mode affordances (🎤 / 📎) sit HERE, beside the model
               group, rather than inside the input box. They choose HOW you
               compose — the same category as which model you compose for —
@@ -572,8 +610,17 @@ export function InputArea({
       </div>
       {/* Trust toggle — labelled control with a Shield icon (BET-415).
           Replaces the ▶▶/▷▷ glyphs. Same chatAutoAllow behaviour, same
-          config key. Danger colour when bypassing. */}
+          config key. Danger colour when bypassing.
+          In plan mode (BET-949) nothing is bypassed — the edit tools are gone —
+          so this row reports "Plan mode — edits blocked" instead and the
+          bypass state is not shown. Two contradictory permission claims stacked
+          together is how users stop believing either. */}
       <div className="pb-3 flex items-center">
+        {plan.on ? (
+          <span className="inline-flex items-center gap-2 text-[11px] leading-none font-normal py-[6px] px-0 text-text-muted">
+            Plan mode — edits blocked
+          </span>
+        ) : (
         <button
           onClick={() => setChatAutoAllow(!chatAutoAllow)}
           className={
@@ -597,6 +644,7 @@ export function InputArea({
             ? "Bypassing permissions"
             : "Permissions on — click to bypass"}
         </button>
+        )}
       </div>
       </MeasureColumn>
     </div>

--- a/src/renderer/agentCatalog.ts
+++ b/src/renderer/agentCatalog.ts
@@ -1,0 +1,88 @@
+// Shared agent catalog — the opencode agent list (`build`/`plan`/general +
+// subagents), cached ONCE for the whole renderer instead of per caller.
+//
+// WHY THIS EXISTS (BET-949). The agent list is a box-level resource: it does
+// not depend on which session is open. It used to be fetched ad hoc by the
+// @-typeahead (`useTypeahead`) for its own `useState`. Plan mode (the composer
+// chip's enablement) needed the same list, and two uncoordinated fetchers of
+// one box-level list is the drift this module removes. It mirrors
+// `modelCatalog.ts` structurally: module-level cache, background refresh past
+// STALE_MS, in-flight dedupe, a listener set, and a `useAgentCatalog()` hook.
+
+import { useEffect, useState } from "react";
+import type { OpencodeAgent } from "../shared/types";
+
+type Snapshot = {
+  agents: OpencodeAgent[] | null;
+};
+
+// How long a cached catalog is served without a background refresh. Short
+// enough that a Settings/agent change lands on the next session switch; long
+// enough that flipping between sessions doesn't hammer the box.
+const STALE_MS = 10_000;
+
+let cache: Snapshot = { agents: null };
+let fetchedAt = 0;
+let inFlight: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+// Fetch the agent list, deduped: concurrent callers share one round trip.
+//
+// GUARD (same reason as modelCatalog): `opencodeAgents` lives ONLY on
+// httpApi. On a fresh/unpaired desktop boot `window.api` is still the raw
+// preload OS-bridge subset where it is undefined, and calling it throws
+// synchronously from the commit phase — which `.catch` cannot see and which
+// unmounts the whole tree.
+function load(): void {
+  if (inFlight) return;
+  // The `as` cast is deliberate: the `Api` type declares it present, but the
+  // pre-pairing preload subset installed on `window.api` does not have it, so
+  // the runtime check is real even though TS thinks it is redundant.
+  const api = window.api as Partial<typeof window.api>;
+  if (!api.opencodeAgents) return;
+  inFlight = window.api
+    .opencodeAgents()
+    .then((agents) => {
+      cache = { agents };
+      fetchedAt = Date.now();
+      emit();
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+}
+
+/**
+ * The shared agent catalog. Returns the cached value synchronously on first
+ * render and re-renders when a background refresh brings something new.
+ */
+export function useAgentCatalog(): Snapshot {
+  const [snapshot, setSnapshot] = useState<Snapshot>(cache);
+  useEffect(() => {
+    const onChange = () => setSnapshot(cache);
+    listeners.add(onChange);
+    if (cache.agents == null || Date.now() - fetchedAt > STALE_MS) load();
+    // Adopt anything that landed between this component's render and its
+    // effect (another caller's in-flight fetch resolving).
+    if (cache !== snapshot) onChange();
+    return () => {
+      listeners.delete(onChange);
+    };
+    // Mount-only: the catalog is session-independent, so nothing here varies.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return snapshot;
+}
+
+/**
+ * Force the shared agent catalog to re-fetch from the server without waiting
+ * for STALE_MS.
+ */
+export function refreshAgentCatalog(): void {
+  fetchedAt = 0;
+  if (!inFlight) load();
+}

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -109,6 +109,7 @@ export const DEMO_UNIMPLEMENTED = [
   "opencodeRestart",
   "opencodeRunCommand",
   "opencodeSearchMessages",
+  "opencodeSessionAgent",
   "opencodeSetProviders",
   "opencodeSetSubagents",
   "opencodeSyncSubagents",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1016,6 +1016,7 @@ export const httpApi: Api = {
   opencodeDiscoverModels: (baseURL, apiKey) => rpc(IPC.opencodeDiscoverModels, baseURL, apiKey),
   opencodeGetSubagents: () => rpc(IPC.opencodeGetSubagents),
   opencodeSetSubagents: (ops) => rpc(IPC.opencodeSetSubagents, ops),
+  opencodeSessionAgent: (sessionId) => rpc(IPC.opencodeSessionAgent, sessionId),
   opencodeSyncSubagents: (input) => rpc(IPC.opencodeSyncSubagents, input),
   opencodeRestart: () => rpc(IPC.opencodeRestart),
   opencodeDefaultModel: () => rpc(IPC.opencodeDefaultModel),

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -981,8 +981,8 @@ export const httpApi: Api = {
    *   ipcRenderer.invoke(IPC.opencodePrompt, { sessionId, text, model, attachments, mentions })
    * We mirror that packing exactly.
    */
-  opencodePrompt: (sessionId, text, model, attachments, mentions) =>
-    rpc(IPC.opencodePrompt, { sessionId, text, model, attachments, mentions }),
+  opencodePrompt: (sessionId, text, model, attachments, mentions, agent) =>
+    rpc(IPC.opencodePrompt, { sessionId, text, model, attachments, mentions, agent }),
 
   opencodeAbort: (sessionId) => rpc(IPC.opencodeAbort, sessionId),
   opencodePermissions: (sessionId) =>

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -275,6 +275,27 @@ export function writeSavedModel(sessionId: string, m: ModelSelection | null): vo
   } catch { /* quota / disabled storage */ }
 }
 
+// Per-session plan-mode override (BET-949). Deliberately its OWN storage key —
+// NOT folded into the `manta:chat:<sid>:model` JSON blob (that blob is a model
+// selection and the native iOS client stores it in an incompatible format).
+// Value is the literal "1" when on, absent otherwise.
+export function planKey(sessionId: string): string {
+  return `manta:chat:${sessionId}:plan`;
+}
+
+export function readPlanSaved(sessionId: string): boolean {
+  try {
+    return localStorage.getItem(planKey(sessionId)) === "1";
+  } catch { /* disabled storage */ return false; }
+}
+
+export function writePlanSaved(sessionId: string, on: boolean): void {
+  try {
+    if (on) localStorage.setItem(planKey(sessionId), "1");
+    else localStorage.removeItem(planKey(sessionId));
+  } catch { /* quota / disabled storage */ }
+}
+
 // Resolve the active OpencodeModel for the NEXT prompt from the available
 // model list + the per-session override + the server default. modelOverride
 // wins; otherwise the server default's provider/model is looked up. Returns

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -77,6 +77,7 @@ import {
   fastModelId,
   hideFastSiblingGroups,
   resolveFastToggle,
+  resolvePlanToggle,
   selectableModelGroups,
   filterModelGroups,
   moveMenuHighlight,
@@ -130,7 +131,7 @@ import {
   describeProjectClose,
 } from "./chatUtils";
 
-import type { OpencodeModel, UsageSnapshot, OpencodeMessage, VoiceNoteRecord, ForgeInboxItem } from "../shared/types";
+import type { OpencodeModel, OpencodeAgent, UsageSnapshot, OpencodeMessage, VoiceNoteRecord, ForgeInboxItem } from "../shared/types";
 
 
 
@@ -2798,6 +2799,49 @@ describe("fast-mode model helpers", () => {
       available: false,
       on: false,
     });
+  });
+});
+
+// ===== resolvePlanToggle =====
+
+describe("resolvePlanToggle", () => {
+  const A = (name: string, mode?: string): OpencodeAgent =>
+    ({ name, mode } as OpencodeAgent);
+
+  it("null agents → loading, unavailable, carries the requested on state", () => {
+    expect(resolvePlanToggle(null, true)).toMatchObject({
+      available: false,
+      on: true,
+      loading: true,
+    });
+    expect(resolvePlanToggle(null, false).loading).toBe(true);
+  });
+
+  it("no plan agent → unavailable, off", () => {
+    const r = resolvePlanToggle([A("build", "primary"), A("x", "subagent")], false);
+    expect(r).toMatchObject({ available: false, on: false });
+    expect(r.title).toContain("no plan agent");
+  });
+
+  it("no plan agent but on → unavailable but stays lit (honest frozen control)", () => {
+    const r = resolvePlanToggle([A("build", "primary")], true);
+    expect(r).toMatchObject({ available: false, on: true });
+    expect(r.title).toContain("Plan mode on");
+  });
+
+  it("plan agent → available, off, agent resolved", () => {
+    const r = resolvePlanToggle([A("build", "primary"), A("plan", "primary")], false);
+    expect(r).toMatchObject({ available: true, on: false, agent: "plan" });
+  });
+
+  it("plan agent → available, on", () => {
+    const r = resolvePlanToggle([A("plan", "primary")], true);
+    expect(r).toMatchObject({ available: true, on: true, agent: "plan" });
+  });
+
+  it("a plan agent that is a subagent does not count", () => {
+    const r = resolvePlanToggle([A("plan", "subagent")], false);
+    expect(r.available).toBe(false);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, OpencodeMessage, OpencodeModel, OpencodePart, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, OpencodeAgent, OpencodeMessage, OpencodeModel, OpencodePart, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 import type { VoiceNoteRecord } from "../shared/types";
 // Value import — `isClientTooOld` is the pure semver compare that drives
@@ -2068,6 +2068,42 @@ export function resolveFastToggle(
       ...(variantId === undefined ? {} : { variant: variantId }),
     },
     title: on ? "Fast mode on — click for the standard model" : "Fast mode off — click for the faster model",
+  };
+}
+
+// ===== resolvePlanToggle =====
+//
+// The composer's Plan-mode chip (BET-949). Same three-state shape as the fast
+// toggle above and the same "unavailable gets its own glyph" philosophy: a
+// lit-but-frozen control is honest; a control that flips itself to "off" lies.
+// The `plan` primary agent is native opencode — plan mode REMOVES the edit
+// tools from the model's toolbelt, so it raises no permission cards. The chip
+// is usable only when the box actually exposes a `plan` agent.
+export type PlanToggleState = {
+  available: boolean;
+  on: boolean;
+  loading?: boolean;
+  agent?: string;
+  title: string;
+};
+
+export function resolvePlanToggle(
+  agents: OpencodeAgent[] | null,
+  on: boolean,
+): PlanToggleState {
+  if (!agents) return { available: false, on, loading: true, title: "Loading agents…" };
+  const plan = agents.find((a) => a.name === "plan" && a.mode !== "subagent");
+  if (!plan)
+    return on
+      ? { available: false, on: true, title: "Plan mode on (plan agent unavailable)" }
+      : { available: false, on: false, title: "This box has no plan agent" };
+  return {
+    available: true,
+    on,
+    agent: plan.name,
+    title: on
+      ? "Plan mode on — edits blocked. Click to build."
+      : "Plan mode off — click to plan without editing",
   };
 }
 

--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -753,6 +753,7 @@ describe("useSseBus running settle on turnComplete (BET-692)", () => {
       refetchOwedWhileInactive,
       applyStreamFlush: () => 0,
       providerID: null,
+      setPlanOn: () => {},
       submit: () => {},
       submitRef,
     });

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -186,6 +186,10 @@ export function useSseBus(params: {
   providerID: string | null;
   submit: () => void;
   submitRef: React.RefObject<(textOverride?: string) => void>;
+  // Plan-mode honesty sync (BET-949). Called when opencode reports its own
+  // agent switching (plan_enter/plan_exit tool parts, session.next.agent.
+  // switched) so the composer chip never claims a mode the next turn won't run.
+  setPlanOn: (on: boolean) => void;
 }): SseBus {
   const {
     sessionId,
@@ -203,6 +207,7 @@ export function useSseBus(params: {
     providerID,
     submit,
     submitRef,
+    setPlanOn,
   } = params;
 
   const [running, setRunning] = useState(false);
@@ -231,6 +236,14 @@ export function useSseBus(params: {
   // provider/model mid-session leaves the banner keyed to the old provider.
   const providerIDRef = useRef(providerID);
   providerIDRef.current = providerID;
+  // Ref mirror of setPlanOn so the SSE handler (deps [sessionId]) always syncs
+  // against the CURRENT session's setter, not the one captured at mount.
+  const setPlanOnRef = useRef(setPlanOn);
+  setPlanOnRef.current = setPlanOn;
+  // Re-entrancy guard for the plan_enter/plan_exit tool parts: the same tool
+  // part arrives repeatedly as it streams (like the drain abort), so act once
+  // per callID. Mirrors drainAbortRef's guard pattern.
+  const handledPlanCallIdsRef = useRef<Set<string>>(new Set());
   const [stepTokens, setStepTokens] = useState<(TokenUsage & { cost: number }) | null>(null);
   const [compactionState, setCompactionState] = useState<{
     reason: string;
@@ -550,6 +563,27 @@ export function useSseBus(params: {
         }
         // Truncation classification moved to the box → stream.truncation
         // (consumed below); finishByMessageId is stamped there, not here.
+      }
+
+      // Plan-mode honesty (BET-949). opencode's OWN client does the mode switch
+      // locally (`plan_exit` → build, `plan_enter` → plan); there is no
+      // server-side state doing it, so MantaUI must mirror it or the chip
+      // claims plan mode while the next turn runs as build.
+      if (ev.type === "session.next.agent.switched") {
+        setPlanOnRef.current(String(props.agent ?? "") === "plan");
+      }
+      if (ev.type === "message.part.updated" && isToolStepBoundary(props.part)) {
+        const part = props.part as {
+          tool?: unknown;
+          callID?: unknown;
+        } | undefined;
+        if (part?.tool === "plan_enter" || part?.tool === "plan_exit") {
+          const callID = String(part.callID ?? "");
+          if (callID && !handledPlanCallIdsRef.current.has(callID)) {
+            handledPlanCallIdsRef.current.add(callID);
+            setPlanOnRef.current(part.tool === "plan_enter");
+          }
+        }
       }
 
       if (ev.type.startsWith("session.next.compaction.")) {

--- a/src/renderer/hooks/useTypeahead.ts
+++ b/src/renderer/hooks/useTypeahead.ts
@@ -19,13 +19,14 @@
 // verbatim on selection.
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import type { OpencodeAgent, OpencodeCommand } from "../../shared/types";
+import type { OpencodeCommand } from "../../shared/types";
 import {
   filterCommands,
   dedupeAgainstBuiltins,
   MANTA_BUILTIN_COMMANDS,
   MANTA_BUILTIN_NAMES,
 } from "../chatUtils";
+import { useAgentCatalog, refreshAgentCatalog } from "../agentCatalog";
 import type {
   TypeaheadState,
   TypeaheadRow,
@@ -82,7 +83,9 @@ export function useTypeahead(params: {
 
   const [typeahead, setTypeahead] = useState<TypeaheadState | null>(null);
   const [commands, setCommands] = useState<OpencodeCommand[] | null>(null);
-  const [agents, setAgents] = useState<OpencodeAgent[] | null>(null);
+  // Agents come from the shared box-level catalog (BET-949) — the same single
+  // fetch that powers the plan-mode chip. No per-typeahead copy.
+  const { agents } = useAgentCatalog();
   const [fileResults, setFileResults] = useState<string[]>([]);
   const fileSearchSeqRef = useRef(0);
   const fileSearchTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -94,14 +97,6 @@ export function useTypeahead(params: {
       setCommands(c);
     } catch { /* non-fatal */ }
   }, [commands]);
-
-  const ensureAgents = useCallback(async () => {
-    if (agents) return;
-    try {
-      const a = await window.api.opencodeAgents();
-      setAgents(a);
-    } catch { /* non-fatal */ }
-  }, [agents]);
 
   // File search: sequence-tracked so stale responses don't clobber the
   // latest. Empty query is passed through — opencode's /find/file returns a
@@ -178,11 +173,11 @@ export function useTypeahead(params: {
       setTypeahead(t);
       if (t) {
         if (t.mode === "command") void ensureCommands();
-        else if (t.mode === "agent") void ensureAgents();
+        else if (t.mode === "agent" && agents == null) refreshAgentCatalog();
         else if (t.mode === "file") void searchFiles(t.query);
       }
     },
-    [detectTypeahead, ensureCommands, ensureAgents, searchFiles],
+    [detectTypeahead, ensureCommands, agents, searchFiles],
   );
 
   // Build the active typeahead's filtered result list.

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -694,6 +694,32 @@ export async function listSessions(directory) {
 }
 
 /**
+ * Read a single session's active `agent` field (BET-949). Used to seed the
+ * plan-mode toggle from a session already set to plan OUTSIDE MantaUI (e.g.
+ * via opencode's own `plan_enter`/agent endpoint), so the chip matches the
+ * agent the next turn will actually run before the honesty sync's first event.
+ *
+ * @param {string} sessionId
+ * @returns {Promise<string | null>} the agent name (e.g. "plan"), or null when
+ *   absent / the session is unknown / the box errored (best-effort — a failed
+ *   seed falls back to the stored key).
+ */
+export async function getSessionAgent(sessionId) {
+  try {
+    const res = await ocFetch(apiUrl(`/session/${encodeURIComponent(sessionId)}`));
+    if (!res.ok) {
+      await discardBody(res);
+      return null;
+    }
+    const body = await res.json();
+    const agent = typeof body?.agent === "string" ? body.agent : null;
+    return agent && agent.length > 0 ? agent : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Does this opencode session still exist?
  *
  * Answered with a DIRECT lookup (`GET /session/{id}`), never by scanning

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -619,9 +619,9 @@ export async function getMessage(sessionId, messageId) {
  * Send a user message (prompt_async — returns 204 immediately; response
  * streams via SSE). Model is per-prompt; omit to use opencode's default.
  *
- * @param {{ sessionId: string, text: string, model?: { providerID: string, modelID: string, variant?: string }, attachments?: Array<{ remotePath: string, mime: string, filename?: string }>, mentions?: Array<{ name: string, source: { value: string, start: number, end: number } }> }} opts
+ * @param {{ sessionId: string, text: string, model?: { providerID: string, modelID: string, variant?: string }, agent?: string, attachments?: Array<{ remotePath: string, mime: string, filename?: string }>, mentions?: Array<{ name: string, source: { value: string, start: number, end: number } }> }} opts
  */
-export async function sendPrompt({ sessionId, text, model, attachments, mentions }) {
+export async function sendPrompt({ sessionId, text, model, agent, attachments, mentions }) {
   // Scope tools + events to the session's worktree. The matching per-directory
   // subscription in subscribeEvents below ensures the events still reach
   // listeners (the global /event subscription wouldn't see them otherwise).
@@ -650,6 +650,7 @@ export async function sendPrompt({ sessionId, text, model, attachments, mentions
     body.model = { providerID: model.providerID, modelID: model.modelID };
     if (model.variant) body.variant = model.variant;
   }
+  if (agent) body.agent = agent;
 
   const res = await ocFetch(apiUrl(url), {
     method: "POST",
@@ -1715,9 +1716,9 @@ export async function findFiles({ query, directory }) {
  * Invoke a slash command inside a session.
  * model is serialised as "providerID/modelID" string (unlike prompt_async's object).
  *
- * @param {{ sessionId: string, command: string, arguments: string, attachments?: Array<{ remotePath: string, mime: string, filename?: string }>, model?: { providerID: string, modelID: string, variant?: string } }} opts
+ * @param {{ sessionId: string, command: string, arguments: string, attachments?: Array<{ remotePath: string, mime: string, filename?: string }>, model?: { providerID: string, modelID: string, variant?: string }, agent?: string }} opts
  */
-export async function runCommand({ sessionId, command, arguments: argumentsStr, attachments, model }) {
+export async function runCommand({ sessionId, command, arguments: argumentsStr, attachments, model, agent }) {
   const dirQ = await getSessionDirectoryQuery(sessionId);
   const url = `/session/${encodeURIComponent(sessionId)}/command${dirQ}`;
   const parts = [];
@@ -1736,6 +1737,7 @@ export async function runCommand({ sessionId, command, arguments: argumentsStr, 
     body.model = `${model.providerID}/${model.modelID}`;
     if (model.variant) body.variant = model.variant;
   }
+  if (agent) body.agent = agent;
   const res = await ocFetch(apiUrl(url), {
     method: "POST",
     headers: { "content-type": "application/json" },

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -5,6 +5,7 @@ import {
   parseSseFrame,
   createSession,
   sendPrompt,
+  getSessionAgent,
   listMessages,
   getMessage,
   slimTranscript,
@@ -306,6 +307,36 @@ test("sendPrompt includes agent when passed and omits it when not", async () => 
   assert.ok(
     bodies.some((b) => !("agent" in b)),
     "expected an agent-less body for the plain prompt",
+  );
+});
+
+test("getSessionAgent returns the session's agent field (or null)", async () => {
+  // BET-949: seeds the plan toggle from a session already set to plan outside
+  // MantaUI. Returns the agent name, and null on absence / non-OK.
+  await withMockFetch(
+    async (url) => {
+      if (String(url).includes("/session/ses_plan")) {
+        return new Response(
+          JSON.stringify({ id: "ses_plan", agent: "plan", directory: "/w" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (String(url).includes("/session/ses_build")) {
+        return new Response(
+          JSON.stringify({ id: "ses_build", directory: "/w" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (String(url).includes("/session/ses_gone")) {
+        return new Response(null, { status: 404 });
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      assert.equal(await getSessionAgent("ses_plan"), "plan");
+      assert.equal(await getSessionAgent("ses_build"), null);
+      assert.equal(await getSessionAgent("ses_gone"), null);
+    },
   );
 });
 

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -275,6 +275,40 @@ test("createSession primes directory cache; sendPrompt then appends ?directory="
   );
 });
 
+test("sendPrompt includes agent when passed and omits it when not", async () => {
+  // BET-949: the plan-mode chip must drive `agent:"plan"` on the prompt_async
+  // body; an omitted agent keeps today's body byte-identical.
+  _resetSessionDirectoryCache();
+  const bodies = [];
+  await withMockFetch(
+    async (url, opts) => {
+      if (String(url).includes("/ses_a/prompt_async")) {
+        bodies.push(opts.body ? JSON.parse(String(opts.body)) : {});
+        return new Response(null, { status: 204 });
+      }
+      if (String(url).startsWith("http://127.0.0.1:4096/session?directory=")) {
+        return new Response(
+          JSON.stringify({ id: "ses_a", title: "t", directory: "/w", projectID: "p" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      await sendPrompt({ sessionId: "ses_a", text: "plan it", agent: "plan" });
+      await sendPrompt({ sessionId: "ses_a", text: "build it" });
+    },
+  );
+  assert.ok(
+    bodies.some((b) => b.agent === "plan"),
+    "expected an agent:plan body for the plan-mode prompt",
+  );
+  assert.ok(
+    bodies.some((b) => !("agent" in b)),
+    "expected an agent-less body for the plain prompt",
+  );
+});
+
 test("createSession expands a leading ~ before POSTing (no /home/$USER/~ corruption)", async () => {
   // Regression: resolveProjectCwd (/clear, /fork) returns raw `~/projects/x`.
   // createSession passed it straight to opencode, which resolves the tilde

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -749,6 +749,10 @@ export function buildHandlers({
     // preload: ipcRenderer.invoke(IPC.opencodeAgents)  → no args
     "opencode:agents": () => oc.listAgents(),
 
+    // preload: ipcRenderer.invoke(IPC.opencodeSessionAgent, sessionId)
+    // → args[0] = sessionId; opencode.mjs getSessionAgent expects the same
+    "opencode:session-agent": (sessionId) => oc.getSessionAgent(sessionId),
+
     // preload: ipcRenderer.invoke(IPC.opencodeFindFiles, { query, directory })
     // → args[0] = { query, directory }; opencode.mjs findFiles expects same shape
     "opencode:find-files": (input) => oc.findFiles(input),

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -389,6 +389,9 @@ export interface Api {
     upsert?: SubagentInput[];
     remove?: string[];
   }): Promise<{ ok: boolean; error?: string }>;
+  // BET-949: the session's active agent (e.g. "plan"), or null when absent /
+  // unknown. Seeds the plan-mode toggle before the honesty sync's first event.
+  opencodeSessionAgent(sessionId: string): Promise<string | null>;
   // BET-123: reconcile configured agent blocks against the model list +
   // deactivated set; returns the resulting SubagentDef[].
   opencodeSyncSubagents(input: {

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -352,6 +352,7 @@ export interface Api {
     model?: PromptModel,
     attachments?: PromptAttachment[],
     mentions?: PromptAgentMention[],
+    agent?: string,
   ): Promise<void>;
   opencodeAbort(sessionId: string): Promise<void>;
   // `sessionId` scopes the list to the session's workspace directory —
@@ -578,6 +579,7 @@ export interface Api {
     command: string;
     arguments: string;
     model?: PromptModel;
+    agent?: string;
     attachments?: PromptAttachment[];
   }): Promise<void>;
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1177,6 +1177,11 @@ export const IPC = {
   opencodeForkSession: "opencode:fork-session",     // returns new sessionId
   opencodeCompactSession: "opencode:compact-session",
   opencodeDeleteSession: "opencode:delete-session",
+  // BET-949: read a single session's `agent` field (GET /session/{id}) so the
+  // plan-mode toggle can seed from a session already set to plan outside
+  // MantaUI, before the honesty sync's first event. Returns the agent name or
+  // null when absent/unknown.
+  opencodeSessionAgent: "opencode:session-agent",
   // Typeahead sources for the input area (@-mention files/agents, /-commands).
   opencodeCommands: "opencode:commands",
   opencodeAgents: "opencode:agents",


### PR DESCRIPTION
## Plan mode (BET-949): wire `agent`, the composer toggle, and keeping it honest

**Base: origin/main @ `8843116b`**

### What this does

Plan mode is opencode's native `plan` primary agent. Activating it is ONE field
on the prompt body — `agent: "plan"` — and the renderer must send it on every
prompt (the `/session/{id}/agent` endpoint changes the label but NOT what the
prompt route runs). This PR wires `agent` through the whole prompt path, adds a
composer Plan chip, and keeps the chip honest against opencode's own agent
switches.

### The prompt path (6 sites, mirroring `variant`)

- `src/shared/api.ts` — `opencodePrompt` gains optional `agent?: string`; `opencodeRunCommand` input gains `agent?`.
- `src/renderer/api/httpApi.ts` — passes `agent` through the rpc payload.
- `src/server/opencode.mjs` — `sendPrompt` and `runCommand` add `body.agent = agent` beside `body.model`/`body.variant`.
- `src/renderer/ChatPanel.tsx` — resolves the agent at SUBMIT time (`plan.available && plan.on ? plan.agent : undefined`) and passes it to both prompt calls. Omitted agent → body identical to today.
- `src/server/opencode.test.mjs` — new test asserting `agent:"plan"` present when passed, absent when not.
- `src/server/rpc.mjs` — already forwards the whole input object; verified, no change needed.

### Agent catalog (removes the duplicate fetcher)

- `src/renderer/agentCatalog.ts` — structural copy of `modelCatalog.ts` (module cache, `STALE_MS=10_000`, in-flight dedupe, listener set, `useAgentCatalog()` + `refreshAgentCatalog()`).
- `src/renderer/hooks/useTypeahead.ts` — **deleted** its ad-hoc agents fetch (`ensureAgents` + local `agents` state); it now reads the shared catalog. Two uncoordinated fetchers of the same box-level list was the thing this removes.

### `resolvePlanToggle` (pure, tested)

`src/renderer/chatUtils.ts` — three-state `PlanToggleState` mirroring `resolveFastToggle`: loading when agents resolve, unavailable (with the `on` state kept lit when frozen) when no `plan` primary agent exists. Five branches tested in `chatUtils.test.ts`.

### The chip

`src/renderer/InputArea.tsx` — a `Chip` (existing primitive) with `DraftingCompass` immediately after `ModelPicker`. "On" = `Chip`'s `on` prop (accent tone, per the design-system contract — no violet, no new token). Unavailable → new `Chip` `disabled` prop (SplitChip's `extraDisabled` recipe). Loading → a `bg-border animate-pulse` bar (ModelPicker's `SkeletonBar` recipe — no chip-owned chrome in InputArea).

### Keep it honest

`src/renderer/hooks/useSseBus.ts` — mirrors opencode's OWN client-side mode switch. `session.next.agent.switched` (`properties.agent === "plan"`) and completed `plan_enter`/`plan_exit` tool parts set plan state, once per `callID` (re-entrancy guarded like `drainAbortRef`). Without this the chip would claim plan mode while the next turn ran as build.

### State

- `src/renderer/chatShared.tsx` — `planKey`/`readPlanSaved`/`writePlanSaved`, own key `manta:chat:<sid>:plan` (value `"1"`), kept OUT of the model JSON blob (iOS-incompatible). Seeded from the stored key; carried across `/clear`.
- `src/renderer/ChatPanel.tsx` — `planOn` state + `syncPlan` (state + storage) wired into `useSseBus`.

### Trust row

`InputArea.tsx` — while plan is on, "Permissions" row reads **"Plan mode — edits blocked"** and the bypass state is not shown.

### Keybinding

`Shift+Tab` in the composer toggles plan (composer-scoped, not a window binding), gated on availability.

### Deletion list

- `useTypeahead`'s ad-hoc agent fetch (`ensureAgents`, its `agents` state, and the import) — the catalog now owns the single fetch.

### Reviewer Question — resolved (Section 5 seed)

The renderer had no session fetch, so plan mode seeded only from the stored key. This PR now adds `opencode:session-agent` (`GET /session/{id}` → `agent`) across `src/shared/api.ts`, `src/renderer/api/httpApi.ts`, `src/server/rpc.mjs`, and `src/server/opencode.mjs` (`getSessionAgent`), and seeds the ChatPanel toggle from it when present — a session pre-set to plan outside MantaUI no longer shows the chip off and sends the next prompt as build. Falls back to the stored key when absent/errored, per the spec chain. Server test pins the fetch shape.

- **Live-box hand-verify** of `prompt_async` carrying `agent:"plan"`: the server test pins it, but I could not hand-verify against a running opencode box from this run.

### Verification

- `npm run typecheck`: exit 0, no errors.
- `npm test`: 147 renderer files / 2740 tests pass; 2088 server tests pass; exit 0.

