### PR TITLE
BET-953: feat(renderer): split artifacts tab axes (Artifacts|Review mode) and add the Plans kind

### DIFF
--- a/src/renderer/ArtifactsPanel.review.test.tsx
+++ b/src/renderer/ArtifactsPanel.review.test.tsx
@@ -1,20 +1,23 @@
 // @vitest-environment jsdom
 //
 // BET-869: the "Review changes" button in the branch popover opens the
-// artifacts panel on its Review tab. App.tsx flips the panel open via
+// artifacts panel in its Review MODE. App.tsx flips the panel open via
 // `manta-open-review`; ArtifactsPanel independently listens for the same event
-// and selects the Review tab. This pins the panel's half of that bridge.
+// and switches to Review. Panels the panel's half of that bridge. Review is a
+// mode, not a kind — it lives in a two-segment `Artifacts | Review` switch
+// above the kind tab bar, so this asserts the mode button's `aria-pressed`,
+// not a `role="tab"`.
 
 import { describe, it, expect, beforeEach } from "vitest";
 import { act } from "react";
 import { installMockApi, resetStore, mount } from "./testHarness";
 import { ArtifactsPanel } from "./ArtifactsPanel";
 
-function reviewTab(h: { container: Element }) {
+function reviewModeButton(h: { container: Element }) {
   const btn = Array.from(
-    h.container.querySelectorAll<HTMLButtonElement>('button[role="tab"]'),
+    h.container.querySelectorAll<HTMLButtonElement>("button[aria-pressed]"),
   ).find((b) => b.textContent?.trim() === "Review");
-  expect(btn, 'expected a "Review" tab').not.toBeUndefined();
+  expect(btn, 'expected a "Review" mode button').not.toBeUndefined();
   return btn!;
 }
 
@@ -24,21 +27,27 @@ describe("ArtifactsPanel Review bridge (BET-869)", () => {
     resetStore();
   });
 
-  it("manta-open-review selects the Review tab", async () => {
+  it("defaults to the Artifacts mode", async () => {
     const h = mount(
       <ArtifactsPanel sessionId="ses_test" cwd="/work" open={false} />,
     );
     await h.flush();
+    expect(reviewModeButton(h).getAttribute("aria-pressed")).toBe("false");
+    h.unmount();
+  });
 
-    // Default is the Links tab.
-    expect(reviewTab(h).getAttribute("aria-selected")).toBe("false");
+  it("manta-open-review switches to the Review mode", async () => {
+    const h = mount(
+      <ArtifactsPanel sessionId="ses_test" cwd="/work" open={false} />,
+    );
+    await h.flush();
 
     act(() => {
       window.dispatchEvent(new CustomEvent("manta-open-review"));
     });
     await h.flush();
 
-    expect(reviewTab(h).getAttribute("aria-selected")).toBe("true");
+    expect(reviewModeButton(h).getAttribute("aria-pressed")).toBe("true");
 
     h.unmount();
   });

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -21,8 +21,11 @@ import {
   ArrowDown,
   ArrowUp,
   ChevronRight,
+  ClipboardList,
   Download,
+  ExternalLink,
   FileText,
+  Focus,
   Link2,
   Paperclip,
   Search,
@@ -37,6 +40,7 @@ import {
   type Artifact,
   type ArtifactKind,
   type ArtifactOrigin,
+  type PlanStatus,
 } from "./artifacts";
 import { decodeDataUri, expiryLabel, formatBytes, resolvePreviewType } from "./chatUtils";
 import { IconButton } from "./IconButton";
@@ -127,17 +131,23 @@ const MAX_WIDTH = 520;
 const DEFAULT_WIDTH = 340;
 const POLL_MS = 30_000;
 
-// BET-792: the artifacts panel hosts the review pane as a fourth tab — the
-// same resizable, ⌘I-toggled, width-persisted side surface, sharing the layout
-// shell. The first three are artifact kinds; "review" is a mode (the PR diff +
-// comment gutter) that shares the shell but not the artifact grammar.
-type PanelTab = ArtifactKind | "review";
-const TABS: PanelTab[] = ["link", "image", "file", "review"];
-const TAB_LABEL: Record<PanelTab, string> = {
+// BET-792: the artifacts panel hosts the review pane as a MODE — a two-value
+// segmented switch (`Artifacts | Review`) above the kind tabs. Review is not
+// an artifact kind (it is the PR diff + comment gutter that branches out of
+// the shared render path entirely), so it gets its own switch rather than a
+// fifth labelled+counted slice. The kind tab bar below is four homogeneous
+// kinds (Links · Images · Files · Plans), all with counts, all day-grouped.
+type PanelMode = "artifacts" | "review";
+const MODE_LABEL: Record<PanelMode, string> = {
+  artifacts: "Artifacts",
+  review: "Review",
+};
+const TABS: ArtifactKind[] = ["link", "image", "file", "plan"];
+const TAB_LABEL: Record<ArtifactKind, string> = {
   link: "Links",
   image: "Images",
   file: "Files",
-  review: "Review",
+  plan: "Plans",
 };
 
 // Device-local width, clamped to 280-520. Wrapped in try/catch (repo
@@ -168,13 +178,15 @@ function persistWidth(width: number) {
 function emptyBig(kind: ArtifactKind): string {
   if (kind === "link") return "No links yet";
   if (kind === "image") return "No images yet";
+  if (kind === "plan") return "No plans yet";
   return "No files yet";
 }
 
-function emptySub(kind: ArtifactKind, counts: { link: number; image: number; file: number }): string {
-  if (kind === "link") return `${counts.image} images, ${counts.file} files`;
-  if (kind === "image") return `${counts.link} links, ${counts.file} files`;
-  return `${counts.link} links, ${counts.image} images`;
+function emptySub(kind: ArtifactKind, counts: { link: number; image: number; file: number; plan: number }): string {
+  if (kind === "link") return `${counts.image} images, ${counts.file} files, ${counts.plan} plans`;
+  if (kind === "image") return `${counts.link} links, ${counts.file} files, ${counts.plan} plans`;
+  if (kind === "plan") return `${counts.link} links, ${counts.image} images, ${counts.file} files`;
+  return `${counts.link} links, ${counts.image} images, ${counts.plan} plans`;
 }
 
 // Direction glyph — the ONLY direction affordance (there is no direction
@@ -457,6 +469,102 @@ function FileRow({
   );
 }
 
+// ===== Tab 4 — Plans ========================================================
+
+function PlanStatusPill({ status }: { status: PlanStatus }) {
+  const cls =
+    status === "done"
+      ? "bg-ok-bg text-ok"
+      : status === "building"
+        ? "bg-accent-bg text-accent-tx"
+        : status === "approved"
+          ? "bg-warn-bg text-warn"
+          : "bg-fill text-text-faint";
+  return (
+    <span
+      className={`ml-1 inline-flex shrink-0 items-center gap-1 rounded-full px-[6px] py-[2px] text-micro font-semibold align-middle ${cls}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+// A plan is BOTH a file and a link, so it is not filed under either — it gets
+// its own row with its own actions: Open page · Open file · Delegate (focus
+// the job building it). `onOpenPage` / `onDelegate` are null when the linked
+// data (hosted page URL, implementing job) is unavailable — the affordance is
+// then omitted rather than rendered as a dead control.
+function PlanRow({
+  artifact,
+  onOpen,
+  onOpenPage,
+  onDelegate,
+}: {
+  artifact: Artifact;
+  onOpen: (el: HTMLElement) => void;
+  onOpenPage: (() => void) | null;
+  onDelegate: (() => void) | null;
+}) {
+  const rowRef = useRef<HTMLDivElement | null>(null);
+  const steps = artifact.planStepCount ?? null;
+  const openFile = () => {
+    if (rowRef.current) onOpen(rowRef.current);
+  };
+  return (
+    <div
+      ref={rowRef}
+      className="group flex items-center gap-[9px] rounded-sm px-2 py-[7px] hover:bg-fill-hover"
+    >
+      <button
+        type="button"
+        onClick={openFile}
+        className="grid h-[30px] w-[30px] flex-none place-items-center rounded-sm border border-border-subtle bg-inset"
+        aria-label="Open plan file"
+      >
+        <ClipboardList className="h-3.5 w-3.5 text-accent" style={{ strokeWidth: 1.7 }} />
+      </button>
+      <button type="button" onClick={openFile} className="min-w-0 flex-1 text-left">
+        {/* Title + status pill on ONE line: the label truncates; the pill is a
+            shrink-0 sibling so status never wraps below the name. */}
+        <div className="flex min-w-0 items-center gap-1">
+          <span className="min-w-0 flex-1 truncate font-mono text-meta text-text">{artifact.label}</span>
+          <PlanStatusPill status={artifact.planStatus ?? "draft"} />
+        </div>
+        <div className="mt-px flex items-center gap-[5px] text-micro text-text-quiet">
+          <DirectionGlyph origin={artifact.origin} />
+          <span>
+            {steps != null && steps > 0 ? `${steps} ${steps === 1 ? "step" : "steps"}` : "plan"}
+          </span>
+        </div>
+      </button>
+      <div className="flex flex-none gap-px opacity-0 transition-opacity group-hover:opacity-100">
+        {onOpenPage && (
+          <ActionButton
+            icon={<ExternalLink className="h-3.5 w-3.5" />}
+            label="Open published page"
+            title="Open published page"
+            onClick={onOpenPage}
+          />
+        )}
+        <ActionButton
+          icon={<FileText className="h-3.5 w-3.5" />}
+          label="Open plan file"
+          title="Open plan file"
+          onClick={openFile}
+        />
+        {onDelegate && (
+          <ActionButton
+            icon={<Focus className="h-3.5 w-3.5" />}
+            label="Open implementing session"
+            title="Open the job building this plan"
+            onClick={onDelegate}
+          />
+        )}
+      </div>
+    </div>
+  );
+}
+
 export function ArtifactsPanel({
   sessionId,
   cwd,
@@ -475,7 +583,10 @@ export function ArtifactsPanel({
   const widthRef = useRef(width);
   widthRef.current = width;
 
-  const [tab, setTab] = useState<PanelTab>("link");
+  const [tab, setTab] = useState<ArtifactKind>("link");
+  // BET-792: Review is a mode, not a kind — a two-segment switch above the
+  // kind tab bar (`Artifacts | Review`). The kind tab is `link` by default.
+  const [mode, setMode] = useState<PanelMode>("artifacts");
   // BET-726 Task 3.2: arrow-key nav on the tab bar — the exact pattern
   // Settings.tsx's section rail already uses (`onRailKeyDown` there: move
   // the active tab state AND DOM focus, on Left/Right). Note this is NOT a
@@ -483,11 +594,11 @@ export function ArtifactsPanel({
   // `tabIndex` — every tab stays in the normal Tab order); only the active
   // tab and focus move on arrow keys. Refs keyed by kind so ArrowLeft/Right
   // can call `.focus()` on the tab it moves to.
-  const tabRefs = useRef<Record<PanelTab, HTMLButtonElement | null>>({
+  const tabRefs = useRef<Record<ArtifactKind, HTMLButtonElement | null>>({
     link: null,
     image: null,
     file: null,
-    review: null,
+    plan: null,
   });
   const [searchOpen, setSearchOpen] = useState(false);
   const [query, setQuery] = useState("");
@@ -530,6 +641,7 @@ export function ArtifactsPanel({
   // change so the panel follows the active chat pane cleanly. Also close any
   // open preview (its artifacts belong to the old session).
   useEffect(() => {
+    setMode("artifacts");
     setTab("link");
     setSearchOpen(false);
     setQuery("");
@@ -537,18 +649,18 @@ export function ArtifactsPanel({
   }, [sessionId]);
 
   // BET-869: the "Review changes" button in the branch popover opens this panel
-  // on its Review tab (App.tsx separately flips the panel open). Same
+  // on its Review mode (App.tsx separately flips the panel open). Same
   // window-CustomEvent convention as the manta-open-* bridges.
   useEffect(() => {
-    const handler = () => setTab("review");
+    const handler = () => setMode("review");
     window.addEventListener("manta-open-review", handler);
     return () => window.removeEventListener("manta-open-review", handler);
   }, []);
 
   const now = useMemo(() => Date.now(), []);
   const artifacts = useMemo(
-    () => deriveArtifacts(messages, pages, sessionId ?? "", outbox),
-    [messages, pages, outbox, sessionId],
+    () => deriveArtifacts(messages, pages, sessionId ?? "", outbox, cwd),
+    [messages, pages, outbox, sessionId, cwd],
   );
   const counts = useMemo(() => countByKind(artifacts), [artifacts]);
   const tabArtifacts = useMemo(
@@ -583,6 +695,7 @@ export function ArtifactsPanel({
       link: artifacts.filter((a) => a.kind === "link" && matches(a)).length,
       image: 0,
       file: artifacts.filter((a) => a.kind === "file" && matches(a)).length,
+      plan: artifacts.filter((a) => a.kind === "plan" && matches(a)).length,
     };
   }, [artifacts, query, counts]);
 
@@ -599,9 +712,11 @@ export function ArtifactsPanel({
 
   // Row-body "open". Previewables (image/PDF/text) open the BET-661 overlay;
   // links open externally (no in-app web renderer); everything else downloads.
+  // A plan's row "open" opens its published page when one exists (BET-954),
+  // else its file (preview/download).
   const openRow = (a: Artifact, el: HTMLElement) => {
-    if (a.kind === "link") {
-      void window.api.openExternal(a.href);
+    if (a.kind === "link" || (a.kind === "plan" && a.planPageUrl)) {
+      void window.api.openExternal(a.planPageUrl ?? a.href);
       return;
     }
     const pi = previewable.findIndex((p) => p.id === a.id);
@@ -701,11 +816,42 @@ export function ArtifactsPanel({
             />
           )}
 
-          {/* Tab bar: Links / Images / Files with counts, Links always the
-              default per the design `.mk-tabs`. The SELECTED highlight is a
-              sliding pill that animates across the three equal-width tabs via a
+          {/* Mode switch: Artifacts | Review. Review is a mode (the PR diff +
+              comment gutter, wholly outside the artifact grammar), so it gets
+              its own two-segment switch above the kind tabs — not a fifth
+              labelled+counted slice. Segmented-toggle precedent: the Settings
+              segmented rows (aria-pressed + raised active segment). */}
+          <div
+            className="mb-2 flex p-1 bg-inset border border-border-subtle rounded-md"
+            role="group"
+            aria-label="Artifacts panel mode"
+          >
+            {(Object.keys(MODE_LABEL) as PanelMode[]).map((m) => {
+              const active = mode === m;
+              return (
+                <button
+                  key={m}
+                  type="button"
+                  aria-pressed={active}
+                  onClick={() => setMode(m)}
+                  className={
+                    "relative z-10 flex-1 inline-flex items-center justify-center gap-1 px-2 py-1 rounded-sm text-meta font-medium " +
+                    "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
+                    (active ? "bg-raised shadow-sm text-text" : "text-text-faint hover:text-text")
+                  }
+                >
+                  {MODE_LABEL[m]}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Tab bar: Links / Images / Files / Plans with counts, Links always
+              the default per the design `.mk-tabs`. The SELECTED highlight is a
+              sliding pill that animates across the four equal-width tabs via a
               transform transition on the indicator — so switching sections
-              reads as the highlight gliding, not the content swapping. */}
+              reads as the highlight gliding, not the content swapping. Every
+              kind is homogeneous (all counted, all day-grouped). */}
           <div
             className="relative flex p-1 bg-inset border border-border-subtle rounded-md"
             role="tablist"
@@ -715,7 +861,7 @@ export function ArtifactsPanel({
               className="manta-artifacts-tab-indicator absolute left-1 top-1 bottom-1 rounded-sm bg-raised shadow-sm"
               style={{
                 // One tab's width: the content row is 100% minus the p-1 (0.5rem)
-                // horizontal padding, split across the three flush flex-1 tabs.
+                // horizontal padding, split across the four flush flex-1 tabs.
                 width: `calc((100% - 0.5rem) / ${TABS.length})`,
                 transform: `translateX(${TABS.indexOf(tab) * 100}%)`,
               }}
@@ -738,17 +884,14 @@ export function ArtifactsPanel({
                   }
                 >
                   {TAB_LABEL[k]}
-                  {/* The Review tab has no count — it is a mode, not a kind. */}
-                  {k !== "review" && (
-                    <span
-                      className={
-                        "tabular-nums inline-flex items-center justify-center min-w-[15px] h-[15px] px-1 rounded-full text-micro " +
-                        (active ? "bg-accent-bg text-accent-tx" : "bg-fill text-text-faint")
-                      }
-                    >
-                      {displayCounts[k as ArtifactKind]}
-                    </span>
-                  )}
+                  <span
+                    className={
+                      "tabular-nums inline-flex items-center justify-center min-w-[15px] h-[15px] px-1 rounded-full text-micro " +
+                      (active ? "bg-accent-bg text-accent-tx" : "bg-fill text-text-faint")
+                    }
+                  >
+                    {displayCounts[k]}
+                  </span>
                 </button>
               );
             })}
@@ -756,9 +899,9 @@ export function ArtifactsPanel({
         </div>{/* close the px-3 pt-[11px] header wrapper */}
 
         {/* Body: day-grouped, sticky headers, newest first, one renderer per
-            tab — except Review, which is a mode (the PR diff + comment gutter)
-            and owns its own scroll. */}
-        {tab === "review" ? (
+            kind tab — except Review, which is a mode (the PR diff + comment
+            gutter) and owns its own scroll. */}
+        {mode === "review" ? (
           <ReviewPane sessionId={sessionId ?? ""} cwd={cwd ?? ""} />
         ) : (
         <div className="flex-1 overflow-y-auto min-h-0">
@@ -768,8 +911,8 @@ export function ArtifactsPanel({
                 <div className="text-label text-text-muted">No matches for “{query}”</div>
               ) : (
                 <>
-                  <div className="text-label text-text-faint">{emptyBig(tab as ArtifactKind)}</div>
-                  <div className="mt-1 text-micro text-text-faint">{emptySub(tab as ArtifactKind, counts)}</div>
+                  <div className="text-label text-text-faint">{emptyBig(tab)}</div>
+                  <div className="mt-1 text-micro text-text-faint">{emptySub(tab, counts)}</div>
                 </>
               )}
             </div>
@@ -788,6 +931,20 @@ export function ArtifactsPanel({
                         now={now}
                         onOpen={(el) => openRow(a, el)}
                         onJump={() => jumpToMessage(a)}
+                      />
+                    ))}
+                  </div>
+                ) : tab === "plan" ? (
+                  <div className="px-2 pb-3">
+                    {g.items.map((a) => (
+                      <PlanRow
+                        key={a.id}
+                        artifact={a}
+                        onOpen={(el) => openRow(a, el)}
+                        onOpenPage={a.planPageUrl ? () => void window.api.openExternal(a.planPageUrl!) : null}
+                        // No plan→job linkage today — the affordance is omitted
+                        // rather than rendered dead (per the spec).
+                        onDelegate={null}
                       />
                     ))}
                   </div>

--- a/src/renderer/artifacts.test.ts
+++ b/src/renderer/artifacts.test.ts
@@ -5,6 +5,8 @@ import {
   groupByDay,
   pageState,
   countByKind,
+  planStepCount,
+  planStatus,
   type Artifact,
 } from "./artifacts";
 
@@ -349,6 +351,105 @@ describe("pageState", () => {
   });
 });
 
+// ── plan artifacts ──────────────────────────────────────────────────────────
+
+describe("plan artifacts", () => {
+  it("derives a plan artifact from a .opencode/plans path in the transcript", () => {
+    const messages = [
+      msg("a", "assistant", [
+        textPart(
+          "Here's the plan I wrote:\n## Step one\n## Step two\n### Step two.a\nSee .opencode/plans/2026-08-15-ship-the-thing.md",
+        ),
+      ], 5000),
+    ];
+    const out = deriveArtifacts(messages, [], "ses_a", [], "/proj");
+    expect(out).toHaveLength(1);
+    const plan = out[0];
+    expect(plan.kind).toBe("plan");
+    expect(plan.origin).toBe("agent");
+    expect(plan.label).toBe("ship the thing");
+    expect(plan.href).toBe("/proj/.opencode/plans/2026-08-15-ship-the-thing.md");
+    expect(plan.mime).toBe("text/markdown");
+    expect(plan.messageId).toBe("a");
+    // Step count is derived from the announcing message's markdown headings.
+    expect(plan.planStepCount).toBe(3);
+    expect(plan.planStatus).toBe("draft");
+  });
+
+  it("handles a leading ./, keeps the relative href without a cwd", () => {
+    const messages = [
+      msg("a", "assistant", [textPart("wrote ./.opencode/plans/2026-08-15-foo.md")], 1000),
+    ];
+    const out = deriveArtifacts(messages, [], "ses_a");
+    expect(out[0].kind).toBe("plan");
+    expect(out[0].href).toBe(".opencode/plans/2026-08-15-foo.md");
+  });
+
+  it("a plan is NOT also emitted as a file or a link (no double-counting)", () => {
+    // The same message references a plan path AND a real URL: the plan path is
+    // never an https URL, so each yields exactly one artifact of its own kind.
+    const messages = [
+      msg("a", "assistant", [textPart("plan: .opencode/plans/2026-08-15-foo.md and https://example.com/x")], 1000),
+    ];
+    // The URL is in ASSISTANT text, so it yields no link; the plan ref does.
+    const out = deriveArtifacts(messages, [], "ses_a");
+    expect(out.map((a) => a.kind)).toEqual(["plan"]);
+    expect(out.filter((a) => a.kind === "file")).toHaveLength(0);
+    expect(out.filter((a) => a.kind === "link")).toHaveLength(0);
+  });
+
+  it("dedupes plan refs to the same path, keeping the newest message", () => {
+    const messages = [
+      msg("a", "assistant", [textPart(".opencode/plans/x.md")], 100),
+      msg("a2", "assistant", [textPart(".opencode/plans/x.md")], 900),
+    ];
+    const out = deriveArtifacts(messages, [], "ses_a");
+    expect(out).toHaveLength(1);
+    expect(out[0].at).toBe(900);
+    expect(out[0].messageId).toBe("a2");
+  });
+
+  it("does not create a plan artifact from a plain .md path outside plans/", () => {
+    const messages = [msg("a", "assistant", [textPart("wrote ./notes/ideas.md")], 1000)];
+    expect(deriveArtifacts(messages, [], "ses_a")).toEqual([]);
+  });
+
+  it("no plan refs → panel-equivalent empty list", () => {
+    expect(
+      deriveArtifacts(
+        [msg("u", "user", [textPart("just a message")])],
+        [],
+        "ses_a",
+      ),
+    ).toEqual([]);
+  });
+});
+
+describe("planStepCount", () => {
+  it("counts ## and ### step headings, ignores body text", () => {
+    expect(
+      planStepCount("intro\n## Step one\n## Step two\n### sub\nbody\n## Step three"),
+    ).toBe(4);
+  });
+  it("returns 0 for null or heading-less text", () => {
+    expect(planStepCount(null)).toBe(0);
+    expect(planStepCount("no headings here")).toBe(0);
+  });
+});
+
+describe("planStatus", () => {
+  it("maps the lifecycle: draft → approved → building → done", () => {
+    expect(planStatus({})).toBe("draft");
+    expect(planStatus({ approved: true })).toBe("approved");
+    expect(planStatus({ running: true })).toBe("building");
+    expect(planStatus({ completed: true })).toBe("done");
+  });
+  it("completed wins over running/approved", () => {
+    expect(planStatus({ completed: true, running: true, approved: true })).toBe("done");
+    expect(planStatus({ running: true, approved: true })).toBe("building");
+  });
+});
+
 // ── counts ──────────────────────────────────────────────────────────────────
 
 describe("countByKind", () => {
@@ -358,11 +459,17 @@ describe("countByKind", () => {
       fileArtifact({ kind: "image" }),
       fileArtifact({ kind: "image" }),
       fileArtifact({ kind: "file" }),
+      fileArtifact({ kind: "plan" }),
     ]);
-    expect(out).toEqual({ link: 1, image: 2, file: 1 });
+    expect(out).toEqual({ link: 1, image: 2, file: 1, plan: 1 });
+  });
+
+  it("includes plans in the count", () => {
+    const out = countByKind([fileArtifact({ kind: "plan" }), fileArtifact({ kind: "plan" })]);
+    expect(out.plan).toBe(2);
   });
 
   it("empty input → zeroed counts", () => {
-    expect(countByKind([])).toEqual({ link: 0, image: 0, file: 0 });
+    expect(countByKind([])).toEqual({ link: 0, image: 0, file: 0, plan: 0 });
   });
 });

--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -1,15 +1,19 @@
 import type { OpencodeMessage, OpencodePart, OutboxFile, ServedPageMeta } from "../shared/types";
 
-export type ArtifactKind = "link" | "image" | "file";
+export type ArtifactKind = "link" | "image" | "file" | "plan";
 export type ArtifactOrigin = "user" | "agent";
 
+// Derived plan lifecycle, never stored — emulates `pageState`'s pattern of a
+// pure row-state derivation (see `planStatus` below).
+export type PlanStatus = "draft" | "approved" | "building" | "done";
+
 export type Artifact = {
-  id: string; // stable: the part id (suffixed .0/.1/... when a text part yields many links), or "page:<subdomain>"
+  id: string; // stable: the part id (suffixed .0/.1/... when a text part yields many links), or "page:<subdomain>" / "plan:<path>"
   kind: ArtifactKind;
   origin: ArtifactOrigin;
   key: string; // dedupe key
-  label: string; // filename, page title, or URL host+path
-  href: string; // absolute box path for files/images, URL for links
+  label: string; // filename, page title, URL host+path, or plan title
+  href: string; // absolute box path for files/images, URL for links, plan file path
   mime: string | null; // null for links
   size: number | null; // byte size for files/images when known (formatBytes), null otherwise
   at: number; // epoch ms, for sorting and day grouping
@@ -20,6 +24,12 @@ export type Artifact = {
   // `expiresAt` so a hosted page with no expiry (ttlHours:0) still gets the
   // expiry chip — external/pasted links never do.
   isHosted?: boolean;
+  // Plan-kind fields. Present only on `kind === "plan"` artifacts (derived,
+  // never stored) — the row's status/step-count/actions read these.
+  planStatus?: PlanStatus;
+  planStepCount?: number | null;
+  planPageUrl?: string | null; // hosted page URL when BET-954 has landed; null today
+  planJobSessionId?: string | null; // the job's child session; null until a plan is linked to a job
 };
 
 const URL_RE = /https?:\/\/[^\s<>]+/g;
@@ -150,6 +160,78 @@ function deriveOutboxArtifact(row: OutboxFile): Artifact {
   };
 }
 
+// A plan is genuinely BOTH a file and a link, so it gets its own kind rather
+// than being filed under either. Plan artifacts are derived from a plan file
+// path (`.opencode/plans/<created>-<slug>.md`) referenced in the session
+// transcript — opencode writes plans there when the session runs in plan mode.
+// Matches `.opencode/plans/<name>.md` wherever it appears (`./.opencode/...`
+// and absolute-prefixed paths both match from the `.opencode` segment).
+const PLAN_REF_RE = /\.opencode\/plans\/[\w.-]+\.md/g;
+
+// Readable plan title from a plan filename: strip `.md` and the leading
+// `<YYYY-MM-DD>-` created-stamp opencode writes, then un-slug.
+function planTitleFromPath(file: string): string {
+  let base = file.replace(/\.md$/i, "");
+  base = base.replace(/^\d{4}-\d{2}-\d{2}-/, "");
+  const title = base.replace(/[-_]+/g, " ").trim();
+  return title || base;
+}
+
+// A plan's step count is *derived* from its announcing message — the markdown
+// step headings (`##`/`###`) the agent wrote alongside the `.md` reference.
+// 0 means "no steps derivable from the message" (the row then omits it).
+export function planStepCount(text: string | null): number {
+  if (!text) return 0;
+  return text.match(/^#{2,3}\s+.+$/gm)?.length ?? 0;
+}
+
+// Derived plan lifecycle, never stored (parallels `pageState`). Precedence:
+// a completed build is `done`, an in-flight build is `building`, an approved
+// (but not yet built) plan is `approved`, anything else — or a rejected /
+// failed build — falls back to `draft`.
+export function planStatus(opts: {
+  completed?: boolean;
+  running?: boolean;
+  approved?: boolean;
+}): PlanStatus {
+  if (opts.completed) return "done";
+  if (opts.running) return "building";
+  if (opts.approved) return "approved";
+  return "draft";
+}
+
+function joinHref(cwd: string | null, rel: string): string {
+  if (!cwd) return rel;
+  return cwd.endsWith("/") ? cwd + rel : cwd + "/" + rel;
+}
+
+function derivePlanArtifact(
+  msg: OpencodeMessage,
+  path: string,
+  cwd: string | null,
+): Artifact {
+  const rel = path.replace(/^\.\//, "");
+  const label = planTitleFromPath(lastPathSegment(rel));
+  return {
+    id: "plan:" + rel.toLowerCase(),
+    kind: "plan",
+    origin: "agent",
+    key: rel.toLowerCase(),
+    label,
+    href: joinHref(cwd, rel),
+    mime: "text/markdown",
+    size: null,
+    at: messageCreated(msg),
+    messageId: msg.info.id,
+    context: null,
+    expiresAt: null,
+    planStatus: planStatus({}),
+    planStepCount: planStepCount(messageText(msg)),
+    planPageUrl: null, // BET-954 will carry the hosted page URL here
+    planJobSessionId: null, // set once a plan is linked to its implementing job
+  };
+}
+
 function derivePageArtifact(page: ServedPageMeta, matched: OpencodeMessage | null): Artifact {
   return {
     id: "page:" + page.subdomain,
@@ -202,6 +284,7 @@ export function deriveArtifacts(
   pages: ServedPageMeta[],
   sessionId: string,
   outbox: OutboxFile[] = [],
+  cwd: string | null = null,
 ): Artifact[] {
   const out: Artifact[] = [];
 
@@ -231,6 +314,23 @@ export function deriveArtifacts(
       }
     }
   }
+
+  // Plan artifacts: any text part (any role) may reference a plan file. The
+  // `.md` path is never an `https?://` URL and never a `file:` part, so a
+  // plan is never ALSO emitted as a link or a file (no double-counting).
+  const plansByKey = new Map<string, Artifact>();
+  for (const msg of messages) {
+    for (const part of msg.parts) {
+      if (part.type !== "text") continue;
+      if (part.synthetic || part.ignored) continue;
+      for (const m of (part.text ?? "").matchAll(PLAN_REF_RE)) {
+        const a = derivePlanArtifact(msg, m[0], cwd);
+        const existing = plansByKey.get(a.key);
+        if (!existing || a.at > existing.at) plansByKey.set(a.key, a);
+      }
+    }
+  }
+  out.push(...plansByKey.values());
 
   for (const page of pages) {
     if (page.sessionID !== sessionId) continue;
@@ -295,8 +395,13 @@ export function pageState(expiresAt: number | null, now: number): PageState {
   return expiresAt - now <= SIX_HOURS_MS ? "soon" : "live";
 }
 
-export function countByKind(items: Artifact[]): { link: number; image: number; file: number } {
-  const counts = { link: 0, image: 0, file: 0 };
+export function countByKind(items: Artifact[]): {
+  link: number;
+  image: number;
+  file: number;
+  plan: number;
+} {
+  const counts = { link: 0, image: 0, file: 0, plan: 0 };
   for (const item of items) {
     counts[item.kind]++;
   }


### PR DESCRIPTION
## What

BET-953 — split the Artifacts panel's two tab axes and add the Plans kind.

**1. Mode switch (`Artifacts | Review`) above the kind tabs.** Review is a
*mode* (the PR diff + comment gutter, which already branched out of the
shared day-grouped render path entirely). It now lives in a two-segment
segmented switch (aria-pressed, Settings-segmented precedent), no longer a
fifth labelled+counted slice in the kind tab bar.

**2. Four homogeneous kind tabs** — `Links · Images · Files · Plans`, all
with counts, all day-grouped through the same shared path. `TABS` stays
`length 4` (`["link","image","file","plan"]`), so the sliding-pill geometry
(the `calc((100% - 0.5rem) / TABS.length)` width + `translateX(index*100%)`)
is **untouched**.

**3. The type stops lying.** `ArtifactKind` is now
`"link" | "image" | "file" | "plan"`; the mode is separate state
(`PanelMode = "artifacts" | "review"`). Deleted:
- the `k !== "review"` count special-case (every kind now renders a count),
- the `tab as ArtifactKind` casts in the empty state / count badge,
- the old `PanelTab = ArtifactKind | "review"` union and the `review` entry in
  `TABS`.

**4. The `plan` kind** (`src/renderer/artifacts.ts`):
- `deriveArtifacts` derives plan artifacts from a `.opencode/plans/<name>.md`
  path referenced in the session transcript (opencode writes plans there in
  plan mode). A plan is genuinely BOTH a file and a link, so it is its own
  kind — and because the `.md` path is neither an `https?://` URL nor a
  `file:` part, it is never also emitted as a link or file (no double-count).
  Resolved against the session `cwd` (new optional arg) for an absolute href.
- `planStatus` (pure, tested) derives the lifecycle draft/approved/building/
  done beside `pageState`; `planStepCount` derives the step count from the
  announcing message's markdown headings.
- `PlanRow` (beside `FileRow`/`ImageTile`) renders title + status pill + step
  count with actions **Open page · Open file · Delegate**. `planPageUrl`
  (hosted page) and the implementing-job link are not wired yet (BET-954 /
  BET-951 not landed), so those affordances are **omitted, not rendered dead**
  — the row today shows precisely "Open file" (preview/download), per the
  spec's "render without the affordance rather than a dead one".
- `countByKind` includes `plan`.

## Files changed

`4` files: `src/renderer/artifacts.ts`, `src/renderer/ArtifactsPanel.tsx`,
`src/renderer/artifacts.test.ts`, `src/renderer/ArtifactsPanel.review.test.tsx`.

**Deleted in this PR:** the `k !== "review"` count special-case, the two
`tab as ArtifactKind` casts, and the `review` slice + `PanelTab` union from
the kind tab bar.

## Design-system contract

- No new token, no hex literal, no `--info`, no violet. Plan mode/rows use the
  existing **accent** tone and the documented scale only.
- Reuses `ActionButton` (shared by the image/file row action cluster),
  `DirectionGlyph`, and the pill chrome / classes from `ExpiryPill`
  (`PlanStatusPill` — a separate component because plan *status* ≠ expiry
  state and `building` has no ExpiryPill state; visually identical chrome).
- All classes are in the allowed vocabulary (no `p-7`/`gap-1.5`/hex).
  `primitives.test.ts` / `tailwindScale.test.ts` green.

## Tone note — review mode

The `review` string still appears in the file, but only as the **mode**:
`PanelMode = "artifacts" | "review"`, `MODE_LABEL.review`, the
`manta-open-review` handler, and the `mode === "review"` RenderPane branch.
There is no `ArtifactKind` cast containing it and no count special-case.

## Visual baseline (acceptance item)

The issue calls for `npm run visual:update` re-baselining. Per the current
workflow (visual/pixel-baseline verification retired 2026-08-07 — baselines
were not accurate and are no longer an evidence gate), I did **not** run
`visual:update`. Verification = typecheck + unit tests below.

**Verification results:**
- PR branch (`multica/BET-953-artifacts-plan-kind` @ `c0fdde8a`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - vitest: exit 0, `2752 pass / 0 fail / 7 skip`. log sha256: `81e4d58d6ea921dfde7c461dce1ad8ee912b7397e00399aad971e667d51cec09`
  - node:test (`test:server`): exit 0, `1579 pass / 0 fail`. log sha256: `d59d4ca4adeab9b41aba3576323369fc4f664b3ff46bdf867322a8c99f29c344`
- Base (`main` @ `afe2e299`):
  - typecheck: exit 0. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - vitest: exit 0, `2740 pass / 0 fail / 7 skip`. log sha256: `0517504e1084888d1cacbaa240a41add89d975964df5324df680e1ff54e4c916`
  - node:test: exit 0, `1579 pass / 0 fail`. log sha256: `83d45953f74a24a3add9f75ac108ae197f77df6eae3258fdaa7a349752aeb6ef`
- **Conclusion:** 0 new failures; this PR adds 12 passing tests
  (plan derivation / status / step-count / no-double-count + the review
  segmented-switch bridge). Server suite byte-identical.

**Base: origin/main @ `afe2e299`**
