### PR TITLE
feat(ios): plan mode toggle in the composer control row (BET-952)

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -87,6 +87,51 @@ enum ChatModel {
         )
     }
 
+    // MARK: - Plan-mode toggle (desktop `resolvePlanToggle` port)
+
+    /// The plan-mode toggle state (BET-952). Plan mode is a per-turn decision,
+    /// not a model property, so availability is purely "does this box expose a
+    /// `plan` primary agent". Mirrors the desktop `resolvePlanToggle` three
+    /// states; `agent` is the resolved agent name to send on `opencode:prompt`.
+    struct PlanToggle {
+        /// The toggle can be clicked (a `plan` agent exists on the box).
+        let available: Bool
+        /// Plan mode is ON (persisted per session).
+        let on: Bool
+        /// True while the agents list hasn't arrived yet (the chip is a loading
+        /// placeholder). Omitted (false) in the resolved states, mirroring TS.
+        let loading: Bool
+        /// The resolved agent name to send, nil when unavailable.
+        let agent: String?
+        /// Human copy explaining the current state.
+        let title: String
+    }
+
+    /// Resolve the plan toggle for the box's agent list. `nil` agents = still
+    /// loading. An explicit `on:true, available:false` (a plan agent vanished
+    /// mid-toggle) stays LIT — a control that flips itself to "off" lies.
+    /// Titles are byte-identical to the TS `resolvePlanToggle`.
+    static func planToggle(agents: [OpencodeAgent]?, on: Bool) -> PlanToggle {
+        guard let agents else {
+            return PlanToggle(available: false, on: on, loading: true, agent: nil, title: "Loading agents…")
+        }
+        let plan = agents.first { $0.name == "plan" && $0.mode != "subagent" }
+        guard let plan else {
+            return on
+                ? PlanToggle(available: false, on: true, loading: false, agent: nil, title: "Plan mode on (plan agent unavailable)")
+                : PlanToggle(available: false, on: false, loading: false, agent: nil, title: "This box has no plan agent")
+        }
+        return PlanToggle(
+            available: true,
+            on: on,
+            loading: false,
+            agent: plan.name,
+            title: on
+                ? "Plan mode on — edits blocked. Click to build."
+                : "Plan mode off — click to plan without editing"
+        )
+    }
+
     // MARK: - Grouping & filtering (desktop `groups` + `filterModelGroups`)
 
     /// Group models by provider, providers ordered alphabetically (matching

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -35,16 +35,28 @@ final class ChatModelStore: ObservableObject {
     /// first. Persisted PER BOX (a habit, not a conversation), unlike the
     /// override/variant above which are per-session.
     @Published private(set) var recents: [ModelChoice] = []
+    /// Plan mode is ON for this session (the per-session `manta:chat:<sid>:plan`
+    /// boolean — BET-952). A plain Bool, deliberately NOT folded into the model
+    /// blob: iOS stores that as a distinct "providerID/modelID" string.
+    @Published private(set) var planOn: Bool
+    /// The box's agent list, once fetched (`opencode:agents`). Nil = not loaded
+    /// yet (the plan chip shows a loading placeholder); a list with no `plan`
+    /// primary agent makes the chip unavailable.
+    @Published private(set) var agents: [OpencodeAgent]?
 
     let sessionId: String
     private let catalog: ChatModelCatalog
+    private let api: MantaAPIClient
+    private var didLoadAgents = false
     private var cancellables: Set<AnyCancellable> = []
 
     init(sessionId: String, api: MantaAPIClient, catalog: ChatModelCatalog = .shared) {
         self.sessionId = sessionId
         self.catalog = catalog
+        self.api = api
         self.override = Self.loadOverride(for: sessionId)
         self.variant = UserDefaults.standard.string(forKey: Self.variantKey(for: sessionId))
+        self.planOn = UserDefaults.standard.bool(forKey: Self.planKey(for: sessionId))
 
         // Seed + mirror the shared catalog so the box-wide list and default are
         // published here (keeps every existing caller reading
@@ -75,8 +87,25 @@ final class ChatModelStore: ObservableObject {
         "manta:chat:\(sessionId):variant"
     }
 
+    /// The per-session plan-mode key (BET-952), a plain Bool — never folded
+    /// into the model blob (see the `planOn` doc).
+    static func planKey(for sessionId: String) -> String {
+        "manta:chat:\(sessionId):plan"
+    }
+
     func load() {
         catalog.loadIfNeeded()
+    }
+
+    /// Fetch the box's agent list once (`opencode:agents`) so the plan chip can
+    /// decide availability. Idempotent: a second call does nothing.
+    func loadAgentsIfNeeded() {
+        guard !didLoadAgents else { return }
+        didLoadAgents = true
+        Task {
+            let result = (try? await api.agents()) ?? []
+            await MainActor.run { self.agents = result }
+        }
     }
 
     /// Carry the current override + variant to a NEW session id. Called just
@@ -90,6 +119,9 @@ final class ChatModelStore: ObservableObject {
         }
         if let variant, !variant.isEmpty {
             UserDefaults.standard.set(variant, forKey: Self.variantKey(for: newSessionId))
+        }
+        if planOn {
+            UserDefaults.standard.set(planOn, forKey: Self.planKey(for: newSessionId))
         }
     }
 
@@ -193,6 +225,21 @@ final class ChatModelStore: ObservableObject {
         let currentVariant = variant
         setOverride(OpencodeModelID(providerID: target.providerID, modelID: target.modelID))
         if let currentVariant { setVariant(currentVariant) }
+    }
+
+    // MARK: - Plan mode (BET-952)
+
+    /// The resolved plan toggle for the composer chip: availability from the
+    /// fetched agent list, `on` from the persisted per-session flag, `agent`
+    /// (when on) the value to send on `opencode:prompt`.
+    var planToggle: ChatModel.PlanToggle {
+        ChatModel.planToggle(agents: agents, on: planOn)
+    }
+
+    /// Flip plan mode for this session, persisting the boolean.
+    func setPlan(_ on: Bool) {
+        planOn = on
+        UserDefaults.standard.set(on, forKey: Self.planKey(for: sessionId))
     }
 
     static func loadOverride(for sessionId: String) -> OpencodeModelID? {

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -258,6 +258,7 @@ private struct ChatScreenContent: View {
                 // window/branch lookup.
                 store.start()
                 modelStore.load()
+                modelStore.loadAgentsIfNeeded()
                 Task { await settingsStore.load() }
                 usageStore.start()
                 MantaPushRouter.shared.visibleSessionID = store.sessionId

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -141,6 +141,7 @@ struct QueuedPrompt: Equatable {
     let attachments: [SendPromptInput.Attachment]
     let model: SendPromptInput.Model?
     let mentions: [SendPromptInput.Mention]?
+    let agent: String?
 }
 
 @MainActor
@@ -837,11 +838,11 @@ final class ChatSessionStore: ObservableObject {
     /// the UI doesn't sit on a forever-spinner, and the caller is told so it
     /// can restore the user's typed text.
     @discardableResult
-    func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?, mentions: [SendPromptInput.Mention]? = nil) async -> Bool {
+    func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?, mentions: [SendPromptInput.Mention]? = nil, agent: String? = nil) async -> Bool {
         // A send while the turn runs must not reach opencode — it would abort
         // the in-flight turn implicitly. Queue it; the idle edge drains FIFO.
         if running {
-            queuedPrompts.append(QueuedPrompt(text: text, attachments: attachments, model: model, mentions: mentions))
+            queuedPrompts.append(QueuedPrompt(text: text, attachments: attachments, model: model, mentions: mentions, agent: agent))
             return true
         }
         // Echo the message straight into the transcript and assume the turn is
@@ -876,7 +877,8 @@ final class ChatSessionStore: ObservableObject {
                 text: text,
                 model: model,
                 attachments: attachments.isEmpty ? nil : attachments,
-                mentions: mentions
+                mentions: mentions,
+                agent: agent
             ))
             return true
         } catch {
@@ -915,7 +917,7 @@ final class ChatSessionStore: ObservableObject {
         guard !running, !queuedPrompts.isEmpty else { return }
         let next = queuedPrompts.removeFirst()
         Task { @MainActor in
-            let ok = await send(text: next.text, attachments: next.attachments, model: next.model, mentions: next.mentions)
+            let ok = await send(text: next.text, attachments: next.attachments, model: next.model, mentions: next.mentions, agent: next.agent)
             if !ok {
                 // The send failed after the box accepted going idle — don't lose
                 // the prompt silently. Put it back at the FRONT and tell the user.

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -253,6 +253,16 @@ struct ComposerView: View {
                     .clipped()
             }
 
+            // Plan mode label — one line above the text area so the mode stays
+            // visible where you type (BET-952). Phones lose ambient state
+            // fastest, so plan mode must be readable at a glance.
+            if modelStore.planOn {
+                Label("Plan mode · edits blocked", systemImage: planIcon)
+                    .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.medium)))
+                    .foregroundColor(tokens.accentTx)
+                    .padding(.bottom, Metrics.spacing.spPx)
+            }
+
             // The message line.
             textArea
 
@@ -287,12 +297,14 @@ struct ComposerView: View {
     private var controlRow: some View {
         HStack(spacing: Metrics.spacing.sp2) {
             // Model + dot + attach sit close together; the dot hugs the model
-            // label. Final order `[modelPill] [dot] [attach]` — the dot is
+            // label. Final order `[modelPill] [dot] [plan] [attach]` — the dot is
             // always present (textless), between the label and the paperclip.
+            // The plan chip sits immediately after the model pill (BET-952).
             HStack(spacing: 0) {
                 modelPill
                 usageDot
             }
+            planToggleChip
             attachButton
             Spacer(minLength: 0)
             if micAvailable {
@@ -333,7 +345,52 @@ struct ComposerView: View {
     /// Accent while a background refetch is in flight, and never while a turn
     /// runs — the two states must not share an indicator (BET-630 D1).
     private var borderColor: Color {
-        store.refreshing && !store.running ? tokens.accent : tokens.borderSubtle
+        // Plan mode tints the whole glass box with the accent tone so the mode
+        // is visible where you type (BET-952). Same tone as the "on" state.
+        if modelStore.planOn { return tokens.accent }
+        return store.refreshing && !store.running ? tokens.accent : tokens.borderSubtle
+    }
+
+    /// The plan-mode capsule in the control row, immediately after the model
+    /// pill (BET-952). Deliberately a per-turn, consequential control, so it
+    /// lives in the composer row — NOT the model sheet. Hidden entirely when
+    /// unavailable-and-off (the iOS convention used for fast on a narrow
+    /// screen), so a box with no plan agent shows no greyed chip.
+    @ViewBuilder
+    private var planToggleChip: some View {
+        let plan = modelStore.planToggle
+        if !plan.available && !plan.on {
+            EmptyView()
+        } else {
+            Button {
+                modelStore.setPlan(!plan.on)
+            } label: {
+                HStack(spacing: Metrics.spacing.sp1) {
+                    Image(systemName: planIcon)
+                        .font(.system(size: Metrics.type.xs, weight: .medium))
+                    Text("Plan")
+                        .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
+                }
+                .foregroundColor(plan.on ? tokens.accentTx : tokens.tx2)
+                .padding(.vertical, Metrics.spacing.sp1)
+                .padding(.horizontal, Metrics.spacing.sp2)
+                .background(plan.on ? tokens.accentSoft : tokens.inset, in: Capsule())
+            }
+            .buttonStyle(.plain)
+            // A lit-but-unavailable chip is honest, not toggleable: the plan
+            // agent vanished mid-toggle, so it must not be clickable to "off".
+            .disabled(!plan.available)
+            .accessibilityLabel("Plan mode")
+            .accessibilityHint(plan.title)
+            .accessibilityIdentifier("plan-mode-toggle")
+        }
+    }
+
+    /// The plan chip glyph — `compass.drawing` (the SF counterpart of the
+    /// desktop `DraftingCompass`), falling back to `pencil.and.ruler` when the
+    /// symbol is unavailable on the deployment target.
+    private var planIcon: String {
+        UIImage(systemName: "compass.drawing") != nil ? "compass.drawing" : "pencil.and.ruler"
     }
 
     /// The message field at the top of the box. It reports its own height so
@@ -893,10 +950,12 @@ struct ComposerView: View {
         }
         let sentText = trimmed
         let mentions = draftMentions.isEmpty ? nil : draftMentions
+        // Send the resolved plan agent only while plan mode is actually on.
+        let agent = modelStore.planToggle.on ? modelStore.planToggle.agent : nil
         Task { @MainActor in
             // On a failed send the store rolled its running state back; restore
             // the user's message so it is never silently lost, and surface why.
-            let ok = await store.send(text: sentText, attachments: sendAttachments, model: model, mentions: mentions)
+            let ok = await store.send(text: sentText, attachments: sendAttachments, model: model, mentions: mentions, agent: agent)
             if !ok {
                 text = sentText
                 surfaceHint("Send failed — message restored")

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -69,6 +69,9 @@ final class MantaAPIClient: Sendable {
             }
             argsDict["model"] = modelDict
         }
+        if let agent = input.agent {
+            argsDict["agent"] = agent
+        }
         if let attachments = input.attachments {
             argsDict["attachments"] = attachments.map { attachment in
                 var dict: [String: Any] = [
@@ -273,6 +276,12 @@ final class MantaAPIClient: Sendable {
     /// opencode picks its own.
     func defaultModel() async throws -> OpencodeModelID? {
         try await call("opencode:default-model", args: [], as: OpencodeModelID.self)
+    }
+
+    /// `opencode:agents` — the box's named agents (plan primary agent, etc).
+    /// Feeds the plan-mode toggle's availability (BET-952).
+    func agents() async throws -> [OpencodeAgent] {
+        try await call("opencode:agents", args: [], as: [OpencodeAgent].self) ?? []
     }
 
     /// `opencode:compact-session` — free context for the voice `compact` action.

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -237,15 +237,32 @@ struct SendPromptInput: Sendable {
     var model: Model?
     var attachments: [Attachment]?
     var mentions: [Mention]?
+    /// Send the prompt as a named opencode agent (e.g. `"plan"` mode) on
+    /// `opencode:prompt`, structurally identical to the `variant` field. Omitted
+    /// → the body carries no `agent` key (BET-949/BET-952).
+    var agent: String?
 
     init(sessionId: String, text: String, model: Model? = nil,
-         attachments: [Attachment]? = nil, mentions: [Mention]? = nil) {
+         attachments: [Attachment]? = nil, mentions: [Mention]? = nil,
+         agent: String? = nil) {
         self.sessionId = sessionId
         self.text = text
         self.model = model
         self.attachments = attachments
         self.mentions = mentions
+        self.agent = agent
     }
+}
+
+/// A named opencode agent (the `plan` primary agent, subagents, …), mirrored from
+/// the box's `GET /agent` (desktop `OpencodeAgent`). Only the fields the plan
+/// toggle reads are required.
+struct OpencodeAgent: Codable, Equatable, Sendable {
+    var name: String
+    var description: String?
+    var mode: String?
+    var native: Bool?
+    var builtIn: Bool?
 }
 
 enum PermissionReply: String, Sendable {

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -171,6 +171,54 @@ final class ComposerTests: XCTestCase {
         XCTAssertEqual(ChatModel.filteredGroups(g, query: "  ").first?.models.count, 2)
     }
 
+    // MARK: - ChatModel.planToggle (BET-952, mirrors desktop resolvePlanToggle)
+
+    private func agent(_ name: String, mode: String?) -> OpencodeAgent {
+        OpencodeAgent(name: name, description: nil, mode: mode, native: nil, builtIn: nil)
+    }
+
+    func testPlanToggleNilAgentsIsLoading() {
+        let r = ChatModel.planToggle(agents: nil, on: false)
+        XCTAssertTrue(r.loading)
+        XCTAssertFalse(r.available)
+        XCTAssertEqual(r.title, "Loading agents…")
+    }
+
+    func testPlanToggleNoPlanAgentIsUnavailableOff() {
+        let r = ChatModel.planToggle(agents: [agent("build", mode: "primary")], on: false)
+        XCTAssertFalse(r.available)
+        XCTAssertFalse(r.on)
+        XCTAssertEqual(r.title, "This box has no plan agent")
+        XCTAssertNil(r.agent)
+    }
+
+    func testPlanToggleNoPlanAgentButOnStaysLit() {
+        let r = ChatModel.planToggle(agents: [agent("build", mode: "primary")], on: true)
+        XCTAssertFalse(r.available)
+        XCTAssertTrue(r.on)
+        XCTAssertEqual(r.title, "Plan mode on (plan agent unavailable)")
+    }
+
+    func testPlanToggleSubagentNamedPlanDoesNotCount() {
+        let r = ChatModel.planToggle(agents: [agent("plan", mode: "subagent")], on: false)
+        XCTAssertFalse(r.available)
+        XCTAssertEqual(r.title, "This box has no plan agent")
+    }
+
+    func testPlanToggleAvailableOffAndOn() {
+        let agents = [agent("build", mode: "primary"), agent("plan", mode: "primary")]
+        let off = ChatModel.planToggle(agents: agents, on: false)
+        XCTAssertTrue(off.available)
+        XCTAssertFalse(off.on)
+        XCTAssertEqual(off.agent, "plan")
+        XCTAssertEqual(off.title, "Plan mode off — click to plan without editing")
+        let on = ChatModel.planToggle(agents: agents, on: true)
+        XCTAssertTrue(on.available)
+        XCTAssertTrue(on.on)
+        XCTAssertEqual(on.agent, "plan")
+        XCTAssertEqual(on.title, "Plan mode on — edits blocked. Click to build.")
+    }
+
     // MARK: - ChatVoice.mime
 
     func testMimeFromFilenameExtension() {

--- a/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
+++ b/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
@@ -262,6 +262,30 @@ final class MantaActionRPCWireTests: XCTestCase {
         XCTAssertEqual(source?["end"] as? Int, 18)
     }
 
+    /// A plan-mode prompt carries `agent` onto `opencode:prompt` args (BET-952),
+    /// structurally identical to how `model`/`variant` travel — and omits the
+    /// key entirely when unset, so a build-mode prompt is byte-identical.
+    func testSendPromptCarriesAgentWhenSetAndOmitsWhenNil() async throws {
+        let client = makeClient()
+        _ = try await client.sendPrompt(SendPromptInput(
+            sessionId: "ses_1",
+            text: "plan this",
+            agent: "plan"
+        ))
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/opencode:prompt")
+        var args = CapturingURLProtocol.bodyJSON(CapturingURLProtocol.cache.last!)?["args"] as? [Any]
+        var payload = args?.first as? [String: Any]
+        XCTAssertEqual(payload?["agent"] as? String, "plan")
+
+        _ = try await client.sendPrompt(SendPromptInput(
+            sessionId: "ses_1",
+            text: "build this"
+        ))
+        args = CapturingURLProtocol.bodyJSON(CapturingURLProtocol.cache.last!)?["args"] as? [Any]
+        payload = args?.first as? [String: Any]
+        XCTAssertNil(payload?["agent"])
+    }
+
     // MARK: - artifacts / agent-file outbox (BET-750)
 
     /// `outbox:list` is dispatched as `fn(sessionId)` — scoped to the session —


### PR DESCRIPTION
## Plan mode (BET-949): wire `agent`, the composer toggle, and keeping it honest

**Base: origin/main @ `8843116b`**

### What this does

Plan mode is opencode's native `plan` primary agent. Activating it is ONE field
on the prompt body — `agent: "plan"` — and the renderer must send it on every
prompt (the `/session/{id}/agent` endpoint changes the label but NOT what the
prompt route runs). This PR wires `agent` through the whole prompt path, adds a
composer Plan chip, and keeps the chip honest against opencode's own agent
switches.

### The prompt path (6 sites, mirroring `variant`)

- `src/shared/api.ts` — `opencodePrompt` gains optional `agent?: string`; `opencodeRunCommand` input gains `agent?`.
- `src/renderer/api/httpApi.ts` — passes `agent` through the rpc payload.
- `src/server/opencode.mjs` — `sendPrompt` and `runCommand` add `body.agent = agent` beside `body.model`/`body.variant`.
- `src/renderer/ChatPanel.tsx` — resolves the agent at SUBMIT time (`plan.available && plan.on ? plan.agent : undefined`) and passes it to both prompt calls. Omitted agent → body identical to today.
- `src/server/opencode.test.mjs` — new test asserting `agent:"plan"` present when passed, absent when not.
- `src/server/rpc.mjs` — already forwards the whole input object; verified, no change needed.

### Agent catalog (removes the duplicate fetcher)

- `src/renderer/agentCatalog.ts` — structural copy of `modelCatalog.ts` (module cache, `STALE_MS=10_000`, in-flight dedupe, listener set, `useAgentCatalog()` + `refreshAgentCatalog()`).
- `src/renderer/hooks/useTypeahead.ts` — **deleted** its ad-hoc agents fetch (`ensureAgents` + local `agents` state); it now reads the shared catalog. Two uncoordinated fetchers of the same box-level list was the thing this removes.

### `resolvePlanToggle` (pure, tested)

`src/renderer/chatUtils.ts` — three-state `PlanToggleState` mirroring `resolveFastToggle`: loading when agents resolve, unavailable (with the `on` state kept lit when frozen) when no `plan` primary agent exists. Five branches tested in `chatUtils.test.ts`.

### The chip

`src/renderer/InputArea.tsx` — a `Chip` (existing primitive) with `DraftingCompass` immediately after `ModelPicker`. "On" = `Chip`'s `on` prop (accent tone, per the design-system contract — no violet, no new token). Unavailable → new `Chip` `disabled` prop (SplitChip's `extraDisabled` recipe). Loading → a `bg-border animate-pulse` bar (ModelPicker's `SkeletonBar` recipe — no chip-owned chrome in InputArea).

### Keep it honest

`src/renderer/hooks/useSseBus.ts` — mirrors opencode's OWN client-side mode switch. `session.next.agent.switched` (`properties.agent === "plan"`) and completed `plan_enter`/`plan_exit` tool parts set plan state, once per `callID` (re-entrancy guarded like `drainAbortRef`). Without this the chip would claim plan mode while the next turn ran as build.

### State

- `src/renderer/chatShared.tsx` — `planKey`/`readPlanSaved`/`writePlanSaved`, own key `manta:chat:<sid>:plan` (value `"1"`), kept OUT of the model JSON blob (iOS-incompatible). Seeded from the stored key; carried across `/clear`.
- `src/renderer/ChatPanel.tsx` — `planOn` state + `syncPlan` (state + storage) wired into `useSseBus`.

### Trust row

`InputArea.tsx` — while plan is on, "Permissions" row reads **"Plan mode — edits blocked"** and the bypass state is not shown.

### Keybinding

`Shift+Tab` in the composer toggles plan (composer-scoped, not a window binding), gated on availability.

### Deletion list

- `useTypeahead`'s ad-hoc agent fetch (`ensureAgents`, its `agents` state, and the import) — the catalog now owns the single fetch.

### Notes / deferrals

- **Session.agent seeding**: the seed chain is "Session.agent field → stored key → off". The renderer has no `GET /session/{id}` fetch, so seeding here is the stored-key path (the honesty sync keeps it correct once events flow). Adding the session fetch would be a new RPC — out of scope; a small follow-up.
- **Live-box hand-verify** of `prompt_async` carrying `agent:"plan"`: the server test pins it, but I could not hand-verify against a running opencode box from this run.

### Verification

- `npm run typecheck`: exit 0, no errors.
- `npm test`: 147 renderer files / 2740 tests pass; 2088 server tests pass; exit 0.
