### PR TITLE
feat(renderer): sticky per-mode models — plan model thinks, build model does (BET-950)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1064,7 +1064,7 @@ function AppInner() {
           const sel: ModelSelection = { providerID, modelID };
           const apply = panelModelControl.current.get(sessionId);
           if (apply) apply(sel);
-          else writeSavedModel(sessionId, sel);
+          else writeSavedModel(sessionId, "build", sel);
         },
         renameSession: () => {
           // tmux is the source of truth; the existing refresh re-reads it.

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -63,9 +63,11 @@ import {
 } from "./chatUtils";
 import {
   appendPromptHistory,
+  copySavedModels,
   guessMime,
   mimeToInputMode,
   modelInputModes,
+  modelKey,
   modelSupportsAttachments,
   readSavedModel,
   writeSavedModel,
@@ -74,6 +76,7 @@ import {
   resolveActiveModel,
   type AgentMention,
   type Attachment,
+  type ModelMode,
   type ModelSelection,
   type SessionMode,
   type TaskContextValue,
@@ -404,11 +407,14 @@ export function ChatPanel({
 
   // ===== Per-session model override =====
   // Declared before useSseBus: the auth-banner providerID below derives from
-  // it. Initialized from the per-session localStorage override, falling back
-  // to the persisted global default (the same seed useSseBus's providerID
-  // used to recompute from readSavedModel on every render).
+  // it. Initialized from the per-session localStorage override for the ACTIVE
+  // mode (per-mode since BET-950 — plan mode falls back to the build key when
+  // no plan key exists), falling back to the persisted global default (the
+  // same seed useSseBus's providerID used to recompute from readSavedModel on
+  // every render).
   const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
-    readSavedModel(sessionId) ?? configDefaultModel ?? null,
+    readSavedModel(sessionId, readPlanSaved(sessionId) ? "plan" : "build") ??
+    configDefaultModel ?? null,
   );
   // Active-model providerID for the auth-error banner (BET-316). Per-session
   // override wins over the persisted default; null if neither is set. Memoized
@@ -433,12 +439,17 @@ export function ChatPanel({
     [agents, planOn],
   );
   const togglePlan = useCallback(() => {
-    setPlanOn((prev) => {
-      const next = !prev;
-      writePlanSaved(sessionId, next);
-      return next;
-    });
-  }, [sessionId]);
+    const next = !planOn;
+    setPlanOn(next);
+    writePlanSaved(sessionId, next);
+    // Requirement 1 (BET-950): toggling re-reads the model for the mode we are
+    // entering so the composer's model chip visibly changes. Zero-config:
+    // readSavedModel's plan→build fallback means a first toggle to plan keeps
+    // the build model until the user picks one while in plan mode. The plan
+    // key is NOT written here — only on an explicit model pick.
+    const mode: ModelMode = next ? "plan" : "build";
+    setModelOverride(readSavedModel(sessionId, mode) ?? configDefaultModel ?? null);
+  }, [planOn, sessionId, configDefaultModel]);
   // Honesty sync from useSseBus: opencode's OWN agent switches (plan_enter /
   // plan_exit / agent.switched) drive this so the chip never lies about the
   // agent the next turn will run as. Also persists so a re-mount seeds right.
@@ -593,8 +604,11 @@ export function ChatPanel({
   // useSseBus's effect now.
   useEffect(() => {
     setError(null);
-    setModelOverride(readSavedModel(sessionId) ?? configDefaultModel ?? null);
-    setPlanOn(readPlanSaved(sessionId));
+    const planOnStart = readPlanSaved(sessionId);
+    setPlanOn(planOnStart);
+    setModelOverride(
+      readSavedModel(sessionId, planOnStart ? "plan" : "build") ?? configDefaultModel ?? null,
+    );
     // Seed plan mode from the session's own `agent` field when present (BET-949
     // §5): a session pre-set to plan OUTSIDE MantaUI would otherwise show the
     // chip off and send the next prompt as build — the stored key alone can't
@@ -605,8 +619,12 @@ export function ChatPanel({
     if (api.opencodeSessionAgent) {
       api.opencodeSessionAgent(sessionId).then((agent) => {
         if (agent && agent.length > 0) {
-          setPlanOn(agent === "plan");
-          writePlanSaved(sessionId, agent === "plan");
+          const planNow = agent === "plan";
+          setPlanOn(planNow);
+          writePlanSaved(sessionId, planNow);
+          setModelOverride(
+            readSavedModel(sessionId, planNow ? "plan" : "build") ?? configDefaultModel ?? null,
+          );
         }
       }).catch(() => { /* non-fatal — stored-key seed stands */ });
     }
@@ -1420,28 +1438,48 @@ export function ChatPanel({
   const commandsRef = useRef(commands);
   commandsRef.current = commands;
 
-  // If a saved modelOverride references a model that isn't in the current
-  // list of connected models (common after switching providers or fixing
+  // If a saved model (in EITHER per-mode key) references one that isn't in the
+  // current list of connected models (common after switching providers or fixing
   // listModels' source endpoint), clear it. Otherwise the server rejects the
-  // prompt with a not-found error and nothing reaches the transcript.
+  // prompt with a not-found error and nothing reaches the transcript. Heals both
+  // keys (BET-950) so a stale model in the inactive mode's key is dropped too.
+  // Reads each mode's RAW key (not readSavedModel, whose plan→build fallback
+  // would mask which key actually held the stale value).
   useEffect(() => {
-    if (!models || !modelOverride) return;
-    const found = models.find(
-      (m) =>
-        m.providerID === modelOverride.providerID && m.id === modelOverride.modelID,
-    );
-    if (!found) {
-      setModelOverride(null);
-      writeSavedModel(sessionId, null);
-    }
-  }, [models, modelOverride, sessionId]);
+    if (!models) return;
+    const isStale = (sel: { providerID: string; modelID: string }) =>
+      !models.some((m) => m.providerID === sel.providerID && m.id === sel.modelID);
+    const heal = (mode: ModelMode) => {
+      let saved: ModelSelection | null = null;
+      try {
+        const raw = localStorage.getItem(modelKey(sessionId, mode));
+        if (raw) {
+          const p = JSON.parse(raw);
+          if (p && typeof p.providerID === "string" && typeof p.modelID === "string") {
+            saved = p as ModelSelection;
+          }
+        }
+      } catch { /* non-JSON / disabled storage — nothing to heal */ }
+      if (!saved || !isStale(saved)) return;
+      writeSavedModel(sessionId, mode, null);
+      // Drop the active override when the cleared key is what's in play: the
+      // active mode's own key, or the build fallback a plan session is using.
+      const active: ModelMode = planOn ? "plan" : "build";
+      if (mode === active) setModelOverride(null);
+      else if (modelOverride && modelOverride.providerID === saved.providerID
+        && modelOverride.modelID === saved.modelID) setModelOverride(null);
+    };
+    heal("build");
+    heal("plan");
+  }, [models, modelOverride, planOn, sessionId]);
 
   const selectModel = useCallback(
     (m: ModelSelection | null) => {
+      const mode: ModelMode = planOn ? "plan" : "build";
       setModelOverride(m);
-      writeSavedModel(sessionId, m);
+      writeSavedModel(sessionId, mode, m);
     },
-    [sessionId],
+    [sessionId, planOn],
   );
 
   // App-control (BET-840/841): expose this panel's `selectModel` to App so the
@@ -1507,17 +1545,20 @@ export function ChatPanel({
         cwd: cwd ?? "",
         title: `${tmuxSession} / cleared`,
       });
-      if (cleared?.newSessionId && modelOverride) {
-        writeSavedModel(cleared.newSessionId, modelOverride);
-      }
-      if (cleared?.newSessionId && planOn) {
-        writePlanSaved(cleared.newSessionId, true);
+      // /clear carries BOTH per-mode model keys forward (BET-950) so the user
+      // doesn't re-pick after every clear. copySavedModels preserves their
+      // independence; plan mode state is carried on top.
+      if (cleared?.newSessionId) {
+        copySavedModels(sessionId, cleared.newSessionId);
+        if (planOn) {
+          writePlanSaved(cleared.newSessionId, true);
+        }
       }
       await refresh();
     } catch (e) {
       setSendError(String((e as Error)?.message ?? e));
     }
-  }, [tmuxSession, windowIndex, cwd, modelOverride, planOn, refresh]);
+  }, [tmuxSession, windowIndex, cwd, planOn, refresh]);
 
   // Current-value ref mirrors for `submit` — declared AFTER submit in this file
   // (the established commandsRef pattern), so submit reads these instead of

--- a/src/renderer/chatShared.test.ts
+++ b/src/renderer/chatShared.test.ts
@@ -16,6 +16,9 @@ import {
   findLast,
   readSavedMode,
   writeSavedMode,
+  readSavedModel,
+  writeSavedModel,
+  copySavedModels,
   resolveLauncherFlags,
   readPromptHistory,
   appendPromptHistory,
@@ -248,7 +251,97 @@ describe("readSavedMode / writeSavedMode (BET-138)", () => {
       expect(readSavedMode("sess-1")).toBe("chat");
     } finally {
       Storage.prototype.getItem = orig;
+     }
+   });
+ });
+
+describe("readSavedModel / writeSavedModel per-mode (BET-950)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  const build = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+  const plan = { providerID: "anthropic", modelID: "claude-opus-4-7" };
+
+  it("build mode uses the original legacy key", () => {
+    writeSavedModel("sess-1", "build", build);
+    expect(localStorage.getItem("manta:chat:sess-1:model")).toBe(JSON.stringify(build));
+    expect(localStorage.getItem("manta:chat:sess-1:model:plan")).toBeNull();
+  });
+
+  it("plan mode uses its own key, leaving the build key untouched", () => {
+    writeSavedModel("sess-1", "build", build);
+    writeSavedModel("sess-1", "plan", plan);
+    expect(localStorage.getItem("manta:chat:sess-1:model")).toBe(JSON.stringify(build));
+    expect(localStorage.getItem("manta:chat:sess-1:model:plan")).toBe(JSON.stringify(plan));
+    expect(readSavedModel("sess-1", "build")).toEqual(build);
+    expect(readSavedModel("sess-1", "plan")).toEqual(plan);
+  });
+
+  it("plan key absent → returns the build model (zero-config fallback)", () => {
+    writeSavedModel("sess-1", "build", build);
+    expect(readSavedModel("sess-1", "plan")).toEqual(build);
+  });
+
+  it("both keys absent → null for both modes", () => {
+    expect(readSavedModel("sess-1", "build")).toBeNull();
+    expect(readSavedModel("sess-1", "plan")).toBeNull();
+  });
+
+  it("writing an explicit plan pick leaves the build key untouched", () => {
+    writeSavedModel("sess-1", "build", build);
+    writeSavedModel("sess-1", "plan", plan);
+    expect(readSavedModel("sess-1", "build")).toEqual(build);
+    expect(readSavedModel("sess-1", "plan")).toEqual(plan);
+  });
+
+  it("writing null clears only that mode's key", () => {
+    writeSavedModel("sess-1", "build", build);
+    writeSavedModel("sess-1", "plan", plan);
+    writeSavedModel("sess-1", "plan", null);
+    expect(readSavedModel("sess-1", "plan")).toEqual(build); // falls back to build
+    expect(localStorage.getItem("manta:chat:sess-1:model:plan")).toBeNull();
+    expect(readSavedModel("sess-1", "build")).toEqual(build);
+  });
+
+  it("is scoped per session id", () => {
+    writeSavedModel("sess-1", "plan", plan);
+    expect(readSavedModel("sess-2", "plan")).toBeNull();
+  });
+
+  it("falls back to null on storage error for a present build key", () => {
+    writeSavedModel("sess-1", "build", build);
+    const orig = Storage.prototype.getItem;
+    Storage.prototype.getItem = () => {
+      throw new Error("storage disabled");
+    };
+    try {
+      expect(readSavedModel("sess-1", "build")).toBeNull();
+    } finally {
+      Storage.prototype.getItem = orig;
     }
+  });
+});
+
+describe("copySavedModels /clear carry-forward (BET-950)", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  const build = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+  const plan = { providerID: "anthropic", modelID: "claude-opus-4-7" };
+
+  it("carries both keys when both are present", () => {
+    writeSavedModel("sess-1", "build", build);
+    writeSavedModel("sess-1", "plan", plan);
+    copySavedModels("sess-1", "sess-2");
+    expect(readSavedModel("sess-2", "build")).toEqual(build);
+    expect(readSavedModel("sess-2", "plan")).toEqual(plan);
+  });
+
+  it("does not stamp a build model into the destination plan key when the source plan key is absent", () => {
+    writeSavedModel("sess-1", "build", build);
+    copySavedModels("sess-1", "sess-2");
+    expect(readSavedModel("sess-2", "build")).toEqual(build);
+    expect(localStorage.getItem("manta:chat:sess-2:model:plan")).toBeNull();
   });
 });
 

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -250,14 +250,27 @@ export function guessMime(filename: string): string {
 // means "let opencode pick its default" — matches the prompt_async fallback.
 export type ModelSelection = { providerID: string; modelID: string; variant?: string };
 
-export function modelKey(sessionId: string): string {
-  return `manta:chat:${sessionId}:model`;
+// Per-mode storage (BET-950). "build" uses the original `…:model` key so every
+// existing session keeps its model and nothing migrates; "plan" gets its own
+// key (`…:model:plan`), same JSON shape. Zero-config: readSavedModel falls back
+// to the build key when the plan key is absent, so plan mode uses the build
+// model until the user picks one while in plan mode.
+export type ModelMode = "build" | "plan";
+
+export function modelKey(sessionId: string, mode: ModelMode): string {
+  return mode === "plan"
+    ? `manta:chat:${sessionId}:model:plan`
+    : `manta:chat:${sessionId}:model`;
 }
 
-export function readSavedModel(sessionId: string): ModelSelection | null {
+export function readSavedModel(sessionId: string, mode: ModelMode): ModelSelection | null {
   try {
-    const raw = localStorage.getItem(modelKey(sessionId));
-    if (!raw) return null;
+    const raw = localStorage.getItem(modelKey(sessionId, mode));
+    if (!raw) {
+      // Zero-config until used: plan mode with no plan key uses the build model.
+      if (mode === "plan") return readSavedModel(sessionId, "build");
+      return null;
+    }
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed.providerID === "string" && typeof parsed.modelID === "string") {
       return parsed as ModelSelection;
@@ -268,11 +281,28 @@ export function readSavedModel(sessionId: string): ModelSelection | null {
   }
 }
 
-export function writeSavedModel(sessionId: string, m: ModelSelection | null): void {
+export function writeSavedModel(sessionId: string, mode: ModelMode, m: ModelSelection | null): void {
   try {
-    if (m) localStorage.setItem(modelKey(sessionId), JSON.stringify(m));
-    else localStorage.removeItem(modelKey(sessionId));
+    if (m) localStorage.setItem(modelKey(sessionId, mode), JSON.stringify(m));
+    else localStorage.removeItem(modelKey(sessionId, mode));
   } catch { /* quota / disabled storage */ }
+}
+
+// /clear carry-forward (BET-950): copy BOTH per-mode model keys from one
+// session id to another, preserving their independence. Copies the RAW value of
+// each key (not readSavedModel, whose plan→build fallback would stamp the build
+// model into a plan key that was never explicitly written), and leaves the
+// destination plan key absent when the source plan key is absent.
+export function copySavedModels(fromSessionId: string, toSessionId: string): void {
+  for (const mode of ["build", "plan"] as const) {
+    let raw: string | null = null;
+    try { raw = localStorage.getItem(modelKey(fromSessionId, mode)); } catch { continue; }
+    if (raw === null) continue;
+    try {
+      if (raw) localStorage.setItem(modelKey(toSessionId, mode), raw);
+      else localStorage.removeItem(modelKey(toSessionId, mode));
+    } catch { /* quota / disabled storage */ }
+  }
 }
 
 // Per-session plan-mode override (BET-949). Deliberately its OWN storage key —


### PR DESCRIPTION
## What

Per-mode sticky models (BET-950): plan mode remembers its own model, so the plan model thinks and the build model does.

- `readSavedModel`/`writeSavedModel` now take a mode (`"build" | "plan"`) — one pair, not two (chatShared.tsx). Build keeps the existing `manta:chat:<sid>:model` key unchanged (zero migration); plan gets `manta:chat:<sid>:model:plan`, same JSON shape.
- Toggling plan mode re-reads the model for the mode being entered and updates `modelOverride`, so the composer model chip visibly changes. The plan model key is only written on an explicit pick while in plan mode — never on a mode switch (zero-config: no plan key → plan mode uses the build model).
- `selectModel` picks the target key from the current mode.
- The self-heal (clear a saved model that left the live catalog) now heals BOTH keys.
- `/clear` carries both keys forward via `copySavedModels` (new tested helper).
- Added `copySavedModels` (chatShared.tsx); the old inline build-override carry-forward in `clearSession` was replaced by it.

**Build model stays trivially reachable while plan mode is on:** BET-951's "Build here" / Delegate should call `readSavedModel(sessionId, "build")` — the explicit named accessor this ticket exposes. (BET-951 still needs wiring that control to it; out of scope here.)

## Hygiene

- `modelOverride` was removed from `clearSession`'s dep list (it's no longer referenced there after the carry-forward moved to `copySavedModels`).
- App-control's `switch-model` writes the build key (`readSavedModel(..., "build")`), preserving prior behavior.

## Tests

Added `chatShared.test.ts` blocks: per-mode read/write (legacy key preserved, plan key independent, plan-absent → build fallback, per-mode clear, per-session scoping, storage-error fallback) and `copySavedModels` (carries both, does not stamp build into an absent plan key).

**Files changed:** 4 (`src/renderer/ChatPanel.tsx`, `src/renderer/App.tsx`, `src/renderer/chatShared.tsx`, `src/renderer/chatShared.test.ts`)

**Base: origin/main @ `afe2e299`**

**Verification results:**
- PR branch (`multica/BET-950-sticky-models` @ `dbc16a3f`):
  - typecheck: exit `0`. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit `0`, `2089` pass / `0` fail / `0` skip. Failures: none. log sha256: `abaffa241ab6c1ec86f781e91008322f9d26db41513573feb41eeef605fc0791`
- Base (`main` @ `afe2e299`):
  - typecheck: exit `0`. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit `0`, `2089` pass / `0` fail / `0` skip. Failures: none. log sha256: `6373e1cdeb33f3f93d7b24a6a0d0f8ef5f8c663cb699bcd1fc29252618a952c5`
- **Conclusion:** `0` test failures are new; identical pass counts on both branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
