### PR TITLE
feat(renderer): plan card — upgrade the plan_exit question with a delegate split (BET-951)

### DIFF
--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -12,15 +12,18 @@
 // one shared AskCardShell below (BET-458). BET-415 gave them the 30px icon
 // badge, plain-language titles, checkbox question options and a button ladder.
 
-import { useState, type ReactNode } from "react";
-import { Shield, HelpCircle, Check, Send } from "lucide-react";
-import type { PermissionRequest, ProgressRecord, QuestionRequest } from "../shared/types";
-import { buildQuestionAnswers, canSubmitQuestion } from "./chatUtils";
+import { useMemo, useRef, useState, type ReactNode } from "react";
+import { DraftingCompass, Shield, HelpCircle, Check, Send, ChevronDown } from "lucide-react";
+import type { PermissionRequest, ProgressRecord, QuestionRequest, OpencodeModel } from "../shared/types";
+import { buildQuestionAnswers, canSubmitQuestion, resolveDelegateModel } from "./chatUtils";
+import { resolveActiveModel } from "./chatShared";
 import { Card } from "./Card";
 import { Pill } from "./Pill";
 import { OutputWell } from "./OutputWell";
 import { Button } from "./Button";
 import { StatusDot } from "./StatusDot";
+import { SplitChip } from "./Chip";
+import { ModelMenu } from "./ModelMenu";
 import { renderMarkdown } from "./MarkdownBody";
 
 // ===== Shared ask-card shell (BET-458) =====
@@ -497,6 +500,176 @@ export function QuestionCard({
         </>
       }
     />
+  );
+}
+
+// ===== Plan card (BET-951) =====
+//
+// Upgrades the plan_exit question (detected EXACTLY via isPlanExitQuestion —
+// the matching `plan_exit` tool callID, never the question text) into a
+// dedicated card in the pinned card stack. Blocking tier: it is an unanswered
+// ask, rendered beside permission/question, never below an ambient card.
+//
+// The delegate split reuses SplitChip (no new split control) fed by the
+// EXISTING ModelMenu; model precedence lives in resolveDelegateModel (a pure
+// chatUtils helper), never inline here.
+
+export function PlanCard({
+  data,
+  models,
+  remembered,
+  sessionModel,
+  buildModelName,
+  atDelegateCap,
+  onBuildHere,
+  onKeepPlanning,
+  onStartDelegate,
+  onRememberDelegateModel,
+}: {
+  data: { title: string; path?: string; metrics: { steps?: number; files?: number } };
+  models: Array<[string, OpencodeModel[]]> | null;
+  remembered: import("./chatShared").ModelSelection | null;
+  sessionModel: import("./chatShared").ModelSelection | null;
+  buildModelName: string;
+  atDelegateCap: boolean;
+  onBuildHere: (feedback: string) => void;
+  onKeepPlanning: (feedback: string) => void;
+  onStartDelegate: (
+    model: import("./chatShared").ModelSelection | null,
+    feedback: string,
+  ) => void;
+  onRememberDelegateModel: (model: import("./chatShared").ModelSelection | null) => void;
+}) {
+  // Level 1 of the model precedence — an explicit pick made on THIS card wins
+  // while it is open. Written through to the remembered key on pick (see
+  // onRememberDelegateModel) so it survives reopening.
+  const [picked, setPicked] = useState<import("./chatShared").ModelSelection | null>(null);
+  const [menuOpen, setMenuOpen] = useState(false);
+  const [feedback, setFeedback] = useState("");
+  const modelBtnRef = useRef<HTMLButtonElement>(null);
+
+  const resolution = useMemo(
+    () => resolveDelegateModel({ picked, remembered, sessionModel, selectable: models }),
+    [picked, remembered, sessionModel, models],
+  );
+  const delegateModel = resolution.model;
+  const allModels = useMemo(() => models?.flatMap(([, ms]) => ms) ?? [], [models]);
+  const resolvedOpencode = useMemo(
+    () => resolveActiveModel(allModels, delegateModel, null),
+    [allModels, delegateModel],
+  );
+  // The right segment truncates to the model family name before anything else
+  // shrinks (BET-951).
+  const familyLabel =
+    resolvedOpencode?.family ?? resolvedOpencode?.providerID ?? delegateModel?.modelID ?? "model";
+
+  // `N steps · N files` — each clause omitted (never `0`) when not derivable.
+  const metricsLine = [
+    data.metrics.steps ? `${data.metrics.steps} steps` : null,
+    data.metrics.files ? `${data.metrics.files} files` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+
+  const busy = atDelegateCap;
+
+  const body = (
+    <>
+      {(metricsLine || data.path) && (
+        <div className="text-text-faint mb-px">
+          {metricsLine}
+          {metricsLine && data.path ? " · " : ""}
+          {data.path && <span className="text-text-quiet">{data.path}</span>}
+        </div>
+      )}
+      {/* Free-text feedback — QuestionCard's field recipe verbatim. */}
+      <div className="flex items-center gap-2 border border-border rounded-md bg-bg px-3 py-2 mt-2">
+        <Send size={14} aria-hidden="true" className="text-text-quiet shrink-0" />
+        <input
+          type="text"
+          placeholder="Anything to change before we start?"
+          value={feedback}
+          onChange={(e) => setFeedback(e.target.value)}
+          className="flex-1 min-w-0 bg-transparent border-0 outline-none text-meta text-text placeholder:text-text-faint"
+        />
+      </div>
+    </>
+  );
+
+  // Actions, in order: [Build here] [Delegate ▾] spacer [Keep planning].
+  // "See in browser ↗" is intentionally ABSENT — BET-954 (its data source) has
+  // not merged, so shipping it would be shipping a dead button.
+  const splitTitle = busy
+    ? "Too many background jobs running (5)"
+    : "Start a background job in its own worktree";
+  const actions = (
+    <>
+      <Button tone="primary" onClick={() => onBuildHere(feedback)}>
+        Build here
+      </Button>
+      <SplitChip
+        left={<span className={busy ? "opacity-50" : undefined}>Delegate</span>}
+        right={
+          <span className={"flex items-center gap-1 truncate" + (busy ? " opacity-50" : "")}>
+            <span className="truncate max-w-[80px]">{familyLabel}</span>
+            <ChevronDown size={13} aria-hidden="true" className="shrink-0 text-text-faint" />
+          </span>
+        }
+        onLeftClick={() => {
+          if (!busy) onStartDelegate(delegateModel, feedback);
+        }}
+        onRightClick={() => {
+          if (!busy) setMenuOpen((o) => !o);
+        }}
+        popup={{ right: true }}
+        rightAccent={resolution.overridden}
+        rightExpanded={menuOpen}
+        rightBtnRef={modelBtnRef}
+        leftHook="manta-plan-delegate-btn"
+        rightHook="manta-plan-delegate-model-btn"
+        leftTitle={splitTitle}
+        rightTitle={busy ? splitTitle : "Model this background job will run on"}
+        loading={models === null}
+      />
+      <div className="flex-1" />
+      <Button tone="ghost" onClick={() => onKeepPlanning(feedback)}>
+        Keep planning
+      </Button>
+    </>
+  );
+
+  return (
+    <>
+      <AskCardShell
+        badge={<DraftingCompass size={16} aria-hidden="true" />}
+        badgeBg="var(--accent-bg)"
+        badgeColor="var(--accent-tx)"
+        title={data.title}
+        subtitle={buildModelName ? `Ready to build · ${buildModelName}` : "Ready to build"}
+        body={body}
+        actions={actions}
+      />
+      {menuOpen && (
+        <ModelMenu
+          open={menuOpen}
+          anchorRef={modelBtnRef}
+          groups={models}
+          modelOverride={delegateModel}
+          defaultModel={null}
+          // "Same as current" = the session's BUILD model — never the plan
+          // model (the composer chip may be showing the plan model while plan
+          // mode is on). Sending a background job to the planning model is the
+          // bug the precedence order exists to prevent.
+          defaultRow={{ label: "Same as this session", sub: buildModelName }}
+          onSelect={(m) => {
+            setPicked(m);
+            onRememberDelegateModel(m);
+            setMenuOpen(false);
+          }}
+          onClose={() => setMenuOpen(false)}
+        />
+      )}
+    </>
   );
 }
 

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -60,6 +60,9 @@ import {
   describeMergeFailure,
   progressAttentionKind,
   resolvePlanToggle,
+  isPlanExitQuestion,
+  extractPlanData,
+  selectableModelGroups,
 } from "./chatUtils";
 import {
   appendPromptHistory,
@@ -71,6 +74,8 @@ import {
   writeSavedModel,
   readPlanSaved,
   writePlanSaved,
+  readSavedDelegateModel,
+  writeSavedDelegateModel,
   resolveActiveModel,
   type AgentMention,
   type Attachment,
@@ -83,7 +88,7 @@ import { useModelCatalog } from "./modelCatalog";
 import { useAgentCatalog } from "./agentCatalog";
 import { MantaLoader } from "./MantaLoader";
 import { MeasureColumn } from "./MeasureColumn";
-import { BlockedProgressCard, CompactionCard, PermissionCard, RetryCard } from "./Cards";
+import { BlockedProgressCard, CompactionCard, PermissionCard, PlanCard, RetryCard } from "./Cards";
 import { Button } from "./Button";
 import { DelegateApprovalCard, ReadOnlyJobBar, ScheduledTasksCard, SecretsCard, WebhooksCard } from "./PanelCards";
 import { CardStack, type PinnedCardRender } from "./components/CardStack";
@@ -2353,6 +2358,131 @@ export function ChatPanel({
   // (second pass finds the id already present) and the per-session-instance
   // lifetime (ChatPanel is keyed by session id in App) makes it self-resetting.
   const blockingArrival = useRef<Map<string, number>>(new Map());
+
+  // ===== Plan card (BET-951) =====
+  // The plan_exit question is upgraded into a blocking plan card in the pinned
+  // card stack. Detection is EXACT — `isPlanExitQuestion` matches the question's
+  // `tool.callID` against a `plan_exit` tool part in the transcript, never the
+  // question text. These are also EXCLUDED from the inline transcript question
+  // rendering below so they never appear twice (once inline as a generic
+  // QuestionCard, once in the stack).
+  const planQuestions = useMemo(
+    () => questions.filter((q) => isPlanExitQuestion(q, messages)),
+    [questions, messages],
+  );
+  const planDataByQuestion = useMemo(
+    () => new Map(planQuestions.map((q) => [q.id, extractPlanData(q, messages)])),
+    [planQuestions, messages],
+  );
+
+  // Delegate split control (BET-951).
+  // Level 3 of the model precedence — "same as current" means the BUILD model,
+  // not the plan model the composer chip may be showing while plan mode is on.
+  // Until per-mode models land there is only one model per session and this is
+  // simply the active model, but the lookup keeps working when they arrive.
+  const sessionModel = useMemo<ModelSelection | null>(
+    () =>
+      modelOverride ??
+      (defaultModel
+        ? { providerID: defaultModel.providerID, modelID: defaultModel.modelID }
+        : null),
+    [modelOverride, defaultModel],
+  );
+  const delegateSelectable = useMemo(
+    () => selectableModelGroups(models, deactivatedMainModels),
+    [models, deactivatedMainModels],
+  );
+  // Level 2 — the remembered delegation model for this project (written ONLY on
+  // an explicit pick; an inherited default is never promoted into it).
+  const delegateProjectKey = tmuxSession ?? sessionId;
+  const rememberedDelegateModel = useMemo(
+    () => readSavedDelegateModel(delegateProjectKey),
+    [delegateProjectKey],
+  );
+  // Hard cap of five concurrent background jobs, box-wide (MAX_RUNNING_JOBS in
+  // src/server/delegate.mjs). At the cap the split control is disabled with a
+  // title saying so, rather than accepting the click and failing after.
+  const runningDelegates = useMemo(
+    () => Object.values(jobs).filter((j) => j.status === "running").length,
+    [jobs],
+  );
+  const atDelegateCap = runningDelegates >= 5;
+
+  const rememberDelegateModel = useCallback(
+    (m: ModelSelection | null) => writeSavedDelegateModel(delegateProjectKey, m),
+    [delegateProjectKey],
+  );
+
+  const buildPlanPrompt = useCallback(
+    (q: QuestionRequest, feedback: string) => {
+      const text = extractPlanData(q, messages).text;
+      const trimmed = feedback.trim();
+      return trimmed ? `${text}\n\n${trimmed}` : text;
+    },
+    [messages],
+  );
+
+  const buildHere = useCallback(
+    async (q: QuestionRequest, feedback: string) => {
+      // Answer "Yes" so opencode switches to the build agent...
+      await replyQuestion(q, [["Yes"]]);
+      // ...then re-send the plan text ourselves WITH the BUILD model. opencode's
+      // "Yes" path stamps the injected build turn with the model of the last
+      // user message — which, because MantaUI sends the model per prompt, is the
+      // PLAN model. That is exactly why this is a resubmit, not a toggle.
+      setPlanOn(false);
+      writePlanSaved(sessionId, false);
+      try {
+        await window.api.opencodePrompt(
+          sessionId,
+          buildPlanPrompt(q, feedback),
+          sessionModel ?? undefined,
+          [],
+          undefined,
+          undefined,
+        );
+      } catch (e) {
+        setSendError(String((e as Error)?.message ?? e));
+      }
+    },
+    [replyQuestion, sessionId, sessionModel, buildPlanPrompt, setPlanOn],
+  );
+
+  const keepPlanning = useCallback(
+    async (q: QuestionRequest, feedback: string) => {
+      // Answer "No" → RejectedError, plan mode STAYS ON.
+      await replyQuestion(q, [["No"]]);
+      // If the user asked for a change, hand that back to the plan agent so it
+      // refines the plan (still in plan mode — no edits).
+      const trimmed = feedback.trim();
+      if (trimmed) {
+        const planAgent = plan.available && plan.on ? plan.agent : undefined;
+        try {
+          await window.api.opencodePrompt(sessionId, trimmed, undefined, [], undefined, planAgent);
+        } catch (e) {
+          setSendError(String((e as Error)?.message ?? e));
+        }
+      }
+    },
+    [replyQuestion, sessionId, plan],
+  );
+
+  const startPlanDelegate = useCallback(
+    (q: QuestionRequest, m: ModelSelection | null, feedback: string) => {
+      void window.api
+        .delegateStart({
+          prompt: buildPlanPrompt(q, feedback),
+          sessionID: sessionId,
+          directory: cwd,
+          model: m ? { providerID: m.providerID, modelID: m.modelID } : undefined,
+        })
+        .catch((e: unknown) => {
+          setSendError(String((e as Error)?.message ?? e));
+        });
+    },
+    [buildPlanPrompt, sessionId, cwd],
+  );
+
   const cards = useMemo<PinnedCardRender[]>(() => {
     const list: PinnedCardRender[] = [];
     const block = (id: string, order: number, render: React.ReactNode): PinnedCardRender =>
@@ -2405,6 +2535,30 @@ export function ChatPanel({
           <BlockedProgressCard progress={liveProgress} />,
         ));
       }
+      // Plan card (BET-951): the plan_exit question, blocking tier — it is an
+      // unanswered ask, beside permission, never below an ambient card. The
+      // delegate split reuses SplitChip + the existing ModelMenu (no new
+      // split/dropdown surface).
+      planQuestions.forEach((q) => {
+        const data = planDataByQuestion.get(q.id);
+        if (!data) return;
+        list.push(block(
+          `plan-${q.id}`, blockOrder(`plan-${q.id}`),
+          <PlanCard
+            key={q.id}
+            data={data}
+            models={delegateSelectable}
+            remembered={rememberedDelegateModel}
+            sessionModel={sessionModel}
+            buildModelName={activeModel?.name ?? ""}
+            atDelegateCap={atDelegateCap}
+            onBuildHere={(fb) => void buildHere(q, fb)}
+            onKeepPlanning={(fb) => void keepPlanning(q, fb)}
+            onStartDelegate={(m, fb) => startPlanDelegate(q, m, fb)}
+            onRememberDelegateModel={rememberDelegateModel}
+          />,
+        ));
+      });
     }
     // Ambient tier — fixed priority, independent of arrival order.
     if (retryInfo) list.push(amb("retry",
@@ -2492,7 +2646,7 @@ export function ChatPanel({
         </div>));
     }
     return list;
-  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipProposal, shipBusy, shipError, liveProgress]);
+  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipProposal, shipBusy, shipError, liveProgress, planQuestions, planDataByQuestion, delegateSelectable, rememberedDelegateModel, sessionModel, activeModel, atDelegateCap, buildHere, keepPlanning, startPlanDelegate, rememberDelegateModel]);
 
 
   if (error || transcriptLoadError) {
@@ -2630,7 +2784,7 @@ export function ChatPanel({
             // BET-418 §D: a job session is read-only — never show its (anyway
             // impossible) question cards. Defensive: a job's pre-flight ruleset
             // means it never generates asks.
-            questions={jobOwnership ? [] : questions}
+            questions={jobOwnership ? [] : questions.filter((q) => !isPlanExitQuestion(q, messages))}
             turnInfo={turnInfo}
             finishByMessageId={finishByMessageId}
             userCommandInfo={userCommandInfo}

--- a/src/renderer/PlanCard.test.tsx
+++ b/src/renderer/PlanCard.test.tsx
@@ -1,0 +1,145 @@
+// @vitest-environment jsdom
+//
+// Component tests for the PlanCard (BET-951) — the upgraded plan_exit card in
+// the pinned card stack. Detection itself (isPlanExitQuestion / extractPlanData)
+// is pinned in chatUtils.test.ts; here we pin the card surface: badge, title,
+// metrics + path, the action row, the delegate split's per-segment popup
+// semantics, the cap-disabled title, and that the generic QuestionCard path
+// still renders an ordinary (non-plan) question untouched.
+
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { act } from "react";
+import { mount, type Harness } from "./testHarness";
+import { PlanCard, QuestionCard } from "./Cards";
+import type { ModelSelection } from "./chatShared";
+import type { QuestionRequest, OpencodeModel } from "../shared/types";
+
+const GROUPS: Array<[string, OpencodeModel[]]> = [
+  [
+    "anthropic",
+    [
+      { id: "claude-opus-4-7", providerID: "anthropic", name: "Claude Opus 4.7", family: "Claude" },
+      { id: "claude-sonnet-4-6", providerID: "anthropic", name: "Claude Sonnet 4.6", family: "Claude" },
+    ],
+  ],
+];
+
+const DATA = {
+  title: "Add login",
+  path: "/work/plan.md",
+  metrics: { steps: 2, files: 1 },
+  text: "# Add login\n## Step 1\n- `src/a.ts`",
+};
+
+function modelBtn(h: Harness | null): HTMLButtonElement {
+  return (h as Harness).container.querySelector(".manta-plan-delegate-model-btn") as HTMLButtonElement;
+}
+function delegateBtn(h: Harness | null): HTMLButtonElement {
+  return (h as Harness).container.querySelector(".manta-plan-delegate-btn") as HTMLButtonElement;
+}
+
+describe("PlanCard (BET-951)", () => {
+  let h: Harness | null = null;
+  beforeEach(() => {
+    // The ModelMenu portals to <body>; keep it clean between tests.
+    document.body.innerHTML = "";
+  });
+  afterEach(() => {
+    h?.unmount();
+    document.body.innerHTML = "";
+    h = null;
+  });
+
+  const render = (props: Partial<Parameters<typeof PlanCard>[0]> = {}) =>
+    mount(
+      <PlanCard
+        data={DATA}
+        models={GROUPS}
+        remembered={null}
+        sessionModel={null}
+        buildModelName="Claude Opus 4.7"
+        atDelegateCap={false}
+        onBuildHere={() => {}}
+        onKeepPlanning={() => {}}
+        onStartDelegate={() => {}}
+        onRememberDelegateModel={() => {}}
+        {...props}
+      />,
+    );
+
+  it("renders badge, title, metrics + path and the action row", () => {
+    h = render();
+    expect(h.text()).toContain("Add login");
+    expect(h.text()).toContain("2 steps");
+    expect(h.text()).toContain("1 files");
+    expect(h.text()).toContain("/work/plan.md");
+    expect(h.text()).toContain("Build here");
+    expect(h.text()).toContain("Delegate");
+    expect(h.text()).toContain("Keep planning");
+  });
+
+  it("omits the '0 steps' clause when metrics cannot be derived", () => {
+    h = render({ data: { ...DATA, metrics: {} } });
+    expect(h.text()).not.toContain("0 steps");
+  });
+
+  it("delegate split: the model segment carries aria-haspopup, the action segment does NOT", () => {
+    h = render();
+    expect(modelBtn(h).getAttribute("aria-haspopup")).toBe("listbox");
+    expect(delegateBtn(h).hasAttribute("aria-haspopup")).toBe(false);
+  });
+
+  it("opens the ModelMenu (portalled to body) anchored to the model segment", () => {
+    h = render();
+    act(() => modelBtn(h).click());
+    const surface = document.body.querySelector(".manta-model-dropdown") as HTMLElement;
+    expect(surface).toBeTruthy();
+    expect(surface.textContent).toContain("Same as this session");
+    expect(surface.textContent).toContain("Claude Opus 4.7");
+  });
+
+  it("atDelegateCap titles both split segments that the cap is hit, and ignores clicks", () => {
+    h = render({ atDelegateCap: true });
+    expect(modelBtn(h).getAttribute("title")).toContain("Too many background jobs");
+    expect(delegateBtn(h).getAttribute("title")).toContain("Too many background jobs");
+    let fired = false;
+    h?.unmount();
+    h = render({ atDelegateCap: true, onStartDelegate: () => { fired = true; } });
+    act(() => delegateBtn(h).click());
+    expect(fired).toBe(false);
+  });
+
+  it("a remembered model is shown on the split's right segment", () => {
+    const remembered: ModelSelection = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+    h = render({ remembered });
+    expect(h.text()).toContain("Claude");
+  });
+});
+
+describe("QuestionCard still renders an ordinary (non-plan) question (BET-951)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("renders the generic question form for a question with no plan_exit tool link", () => {
+    const q: QuestionRequest = {
+      id: "q1",
+      sessionID: "s1",
+      requestId: "que_1",
+      questions: [
+        {
+          question: "Which column ordering?",
+          header: "CSV export",
+          options: [{ label: "A", description: "a" }],
+        },
+      ],
+    };
+    h = mount(<QuestionCard request={q} onReply={() => {}} onReject={() => {}} />);
+    expect(h.text()).toContain("CSV export");
+    expect(h.text()).toContain("Submit");
+    // A plan card surface must not appear for an ordinary question.
+    expect(h.container.querySelector(".manta-plan-delegate-btn")).toBeNull();
+  });
+});

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -296,6 +296,35 @@ export function writePlanSaved(sessionId: string, on: boolean): void {
   } catch { /* quota / disabled storage */ }
 }
 
+// Per-project remembered DELEGATION model (BET-951). Written ONLY on an
+// explicit user pick from the plan card's delegate split (never promoted from
+// an inherited default — that would pin whatever happened to be current the
+// first time). Level 2 of resolveDelegateModel's precedence.
+export function delegateModelKey(projectKey: string): string {
+  return `manta:delegate:${projectKey}:model`;
+}
+
+export function readSavedDelegateModel(projectKey: string): ModelSelection | null {
+  try {
+    const raw = localStorage.getItem(delegateModelKey(projectKey));
+    if (!raw) return null;
+    const parsed = JSON.parse(raw);
+    if (parsed && typeof parsed.providerID === "string" && typeof parsed.modelID === "string") {
+      return parsed as ModelSelection;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeSavedDelegateModel(projectKey: string, m: ModelSelection | null): void {
+  try {
+    if (m) localStorage.setItem(delegateModelKey(projectKey), JSON.stringify(m));
+    else localStorage.removeItem(delegateModelKey(projectKey));
+  } catch { /* quota / disabled storage */ }
+}
+
 // Resolve the active OpencodeModel for the NEXT prompt from the available
 // model list + the per-session override + the server default. modelOverride
 // wins; otherwise the server default's provider/model is looked up. Returns

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -129,9 +129,13 @@ import {
   FOLLOW_THRESHOLD_PX,
   describeSessionClose,
   describeProjectClose,
+  isPlanExitQuestion,
+  planMetrics,
+  extractPlanData,
+  resolveDelegateModel,
 } from "./chatUtils";
 
-import type { OpencodeModel, OpencodeAgent, UsageSnapshot, OpencodeMessage, VoiceNoteRecord, ForgeInboxItem } from "../shared/types";
+import type { OpencodeModel, OpencodeAgent, UsageSnapshot, OpencodeMessage, VoiceNoteRecord, ForgeInboxItem, QuestionRequest } from "../shared/types";
 
 
 
@@ -4920,5 +4924,184 @@ describe("describeProjectClose", () => {
       worktreeCount: 0,
     });
     expect(r.body).not.toContain("worktree");
+  });
+});
+
+describe("isPlanExitQuestion", () => {
+  const planq = (callID?: string): QuestionRequest =>
+    ({
+      id: "q1",
+      sessionID: "s1",
+      questions: [],
+      tool: callID ? { messageID: "m1", callID } : undefined,
+    }) as QuestionRequest;
+
+  const part = (tool: string, callID: string) =>
+    ({ type: "tool", id: "p", messageID: "m1", tool, callID });
+
+  it("true when a transcript tool part named plan_exit carries the question's callID", () => {
+    const msg: OpencodeMessage = {
+      info: {} as never,
+      parts: [
+        part("read", "call-read"),
+        part("plan_exit", "call-exit"),
+      ],
+    };
+    expect(isPlanExitQuestion(planq("call-exit"), [msg])).toBe(true);
+  });
+
+  it("false when the matching callID belongs to a DIFFERENT tool", () => {
+    const msg: OpencodeMessage = { info: {} as never, parts: [part("edit", "call-exit")] };
+    expect(isPlanExitQuestion(planq("call-exit"), [msg])).toBe(false);
+  });
+
+  it("false for an ordinary question with no tool call", () => {
+    expect(isPlanExitQuestion(planq(undefined), null)).toBe(false);
+  });
+
+  it("false when no part matches the callID even if a plan_exit part exists", () => {
+    const msg: OpencodeMessage = { info: {} as never, parts: [part("plan_exit", "other")] };
+    expect(isPlanExitQuestion(planq("call-exit"), [msg])).toBe(false);
+  });
+
+  it("matches a nested state.input.tool shape (reconciled transcript part)", () => {
+    const msg: OpencodeMessage = {
+      info: {} as never,
+      parts: [
+        {
+          type: "tool",
+          id: "p",
+          messageID: "m1",
+          callID: "call-exit",
+          state: { status: "completed", input: { tool: "plan_exit", planPath: "/x/plan.md" } },
+        },
+      ],
+    };
+    expect(isPlanExitQuestion(planq("call-exit"), [msg])).toBe(true);
+  });
+});
+
+describe("planMetrics", () => {
+  it("omits steps and files when nothing is derivable", () => {
+    expect(planMetrics("Just prose.")).toEqual({});
+  });
+
+  it("counts 'Step N' headings as steps", () => {
+    const r = planMetrics("## Step 1\nx\n## Step 2\ny\n## Step 3\nz");
+    expect(r.steps).toBe(3);
+  });
+
+  it("counts numbered headings as steps", () => {
+    const r = planMetrics("## 1. first\n## 2. second");
+    expect(r.steps).toBe(2);
+  });
+
+  it("counts backticked file bullets as files", () => {
+    const r = planMetrics("- `src/a.ts`\n- `src/b.ts`\n");
+    expect(r.files).toBe(2);
+  });
+
+  it("does not print 0 for an absent clause", () => {
+    const r = planMetrics("### Do x\n- `src/a.ts`");
+    expect(r.steps).toBeUndefined();
+    expect(r.files).toBe(1);
+  });
+});
+
+describe("extractPlanData", () => {
+  const planq = (callID: string): QuestionRequest =>
+    ({ id: "q1", sessionID: "s1", questions: [], tool: { messageID: "m1", callID } }) as QuestionRequest;
+
+  it("title from first heading, path + metrics from the tool input", () => {
+    const msg: OpencodeMessage = {
+      info: {} as never,
+      parts: [
+        {
+          type: "tool",
+          id: "p",
+          messageID: "m1",
+          callID: "call-exit",
+          state: { status: "completed", input: { tool: "plan_exit", planPath: "/work/plan.md", plan: "# Add login\n## Step 1\n- `src/a.ts`" } },
+        },
+      ],
+    };
+    const d = extractPlanData(planq("call-exit"), [msg]);
+    expect(d.title).toBe("Add login");
+    expect(d.path).toBe("/work/plan.md");
+    expect(d.metrics).toEqual({ steps: 1, files: 1 });
+  });
+
+  it("falls back to the question header when no plan text is present", () => {
+    const q = planq("call-exit");
+    q.questions = [{ question: "Plan at /p is complete. Would you like to switch?", header: "Build Agent", options: [] }];
+    const d = extractPlanData(q, []);
+    expect(d.title).toBe("Build Agent");
+    expect(d.metrics).toEqual({});
+    expect(d.path).toBeUndefined();
+  });
+});
+
+describe("resolveDelegateModel", () => {
+  const sel = (providerID: string, modelID: string): import("./chatShared").ModelSelection =>
+    ({ providerID, modelID });
+  const groups = (ids: Array<[string, string]>): Array<[string, OpencodeModel[]]> =>
+    [...new Set(ids.map(([p]) => p))].map((p) => [
+      p,
+      ids.filter(([pp]) => pp === p).map(([, id]) => ({ id, providerID: p, name: id }) as OpencodeModel),
+    ]);
+
+  it("level 1: an explicit pick wins while open", () => {
+    const r = resolveDelegateModel({
+      picked: sel("anthropic", "opus"),
+      remembered: sel("anthropic", "sonnet"),
+      sessionModel: sel("anthropic", "haiku"),
+      selectable: groups([["anthropic", "opus"], ["anthropic", "sonnet"], ["anthropic", "haiku"]]),
+    });
+    expect(r.model).toEqual(sel("anthropic", "opus"));
+    expect(r.overridden).toBe(true);
+  });
+
+  it("level 2: the remembered override is used when no explicit pick", () => {
+    const r = resolveDelegateModel({
+      picked: null,
+      remembered: sel("anthropic", "sonnet"),
+      sessionModel: sel("anthropic", "haiku"),
+      selectable: groups([["anthropic", "sonnet"], ["anthropic", "haiku"]]),
+    });
+    expect(r.model).toEqual(sel("anthropic", "sonnet"));
+    expect(r.overridden).toBe(true);
+  });
+
+  it("level 3: falls through to the build/session model when neither pick nor remember", () => {
+    const r = resolveDelegateModel({
+      picked: null,
+      remembered: null,
+      sessionModel: sel("anthropic", "haiku"),
+      selectable: groups([["anthropic", "haiku"]]),
+    });
+    expect(r.model).toEqual(sel("anthropic", "haiku"));
+    expect(r.overridden).toBe(false);
+  });
+
+  it("falls through to level 3 when the remembered model is deactivated (not selectable)", () => {
+    const r = resolveDelegateModel({
+      picked: null,
+      remembered: sel("anthropic", "sonnet"),
+      sessionModel: sel("anthropic", "haiku"),
+      selectable: groups([["anthropic", "haiku"]]), // sonnet deactivated
+    });
+    expect(r.model).toEqual(sel("anthropic", "haiku"));
+    expect(r.overridden).toBe(false);
+  });
+
+  it("keeps the remembered pick (not silently falling through) while models are still loading", () => {
+    const r = resolveDelegateModel({
+      picked: null,
+      remembered: sel("anthropic", "sonnet"),
+      sessionModel: sel("anthropic", "haiku"),
+      selectable: null, // loading — cannot validate
+    });
+    expect(r.model).toEqual(sel("anthropic", "sonnet"));
+    expect(r.overridden).toBe(true);
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, OpencodeAgent, OpencodeMessage, OpencodeModel, OpencodePart, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, OpencodeAgent, OpencodeMessage, OpencodeModel, OpencodePart, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, QuestionRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 import type { VoiceNoteRecord } from "../shared/types";
 // Value import — `isClientTooOld` is the pure semver compare that drives
@@ -2105,6 +2105,175 @@ export function resolvePlanToggle(
       ? "Plan mode on — edits blocked. Click to build."
       : "Plan mode off — click to plan without editing",
   };
+}
+
+// ===== Plan card data (BET-951) =====
+//
+// The plan_exit question is upgraded into a plan card in the pinned card
+// stack. Its title ("the plan's title/first heading"), the metrics line
+// (`N steps · N files`) and the plan path are all derived from the plan text
+// the `plan_exit` tool call carried. Detection is EXACT, never heuristic: the
+// question's `tool.callID` links back to the `plan_exit` tool part in the
+// transcript — match on that, never on the question text.
+
+// A tool part may surface its name/callID directly (the live `message.part.*`
+// event shape used by useSseBus) or nested under `state.input` (the reconciled
+// transcript shape Toolkit parts carry). Read both tolerantly.
+function toolPartName(part: OpencodePart): string {
+  const direct = part.tool;
+  if (typeof direct === "string" && direct) return direct;
+  const state = part.state as { input?: { tool?: unknown } } | undefined;
+  const nested = state?.input?.tool;
+  return typeof nested === "string" ? nested : "";
+}
+
+/**
+ * Is `question` the plan_exit ask? True iff a transcript tool part named
+ * `plan_exit` carries the SAME `callID` as `question.tool.callID`. A callID is
+ * required (an orphaned/recovered question without one can never be matched)
+ * and the match must be exact — the question text is never consulted.
+ */
+export function isPlanExitQuestion(
+  question: QuestionRequest,
+  messages: OpencodeMessage[] | null,
+): boolean {
+  const qCallID = question.tool?.callID;
+  if (!qCallID) return false;
+  for (const msg of messages ?? []) {
+    for (const part of msg.parts) {
+      if (part.type !== "tool") continue;
+      if (part.callID !== qCallID) continue;
+      if (toolPartName(part) === "plan_exit") return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * The metrics line for the plan card: `N steps · N files`, derived from the
+ * plan text. A clause is OMITTED (not `0`) when it cannot be derived — the
+ * card never prints `0 steps`. `steps` counts step/labelled-numbered headings;
+ * `files` counts bullet list items whose text is a backticked path (the
+ * conventional `- \`path\`` file listing). Empty / no-match → `{}`.
+ */
+export function planMetrics(text: string): { steps?: number; files?: number } {
+  const out: { steps?: number; files?: number } = {};
+  const stepHeading = text.match(/^#{1,6}[ \t]+step[ \t]+/gim)?.length ?? 0;
+  const numberedHeading = text.match(/^#{1,6}[ \t]+\d+[.)]/gm)?.length ?? 0;
+  const steps = stepHeading || numberedHeading;
+  if (steps > 0) out.steps = steps;
+  const files = text.match(/^[ \t]*[-*][ \t]+`[^`]+`[ \t]*$/gm)?.length ?? 0;
+  if (files > 0) out.files = files;
+  return out;
+}
+
+/**
+ * The plan card's display data: the title (first markdown heading of the plan
+ * text, falling back to the question header), the plan file path when known,
+ * the metrics, and the FULL plan text (what "Build here" resubmits as the next
+ * prompt with the build model). Everything is tolerant — when the `plan_exit`
+ * part's input carries no plan text the card still renders, just with the
+ * question's header as the title and no metrics.
+ */
+export function extractPlanData(
+  question: QuestionRequest,
+  messages: OpencodeMessage[] | null,
+): {
+  title: string;
+  path?: string;
+  metrics: { steps?: number; files?: number };
+  text: string;
+} {
+  let text = "";
+  let path = "";
+  for (const msg of messages ?? []) {
+    for (const part of msg.parts) {
+      if (part.type !== "tool") continue;
+      if (part.callID !== question.tool?.callID) continue;
+      if (toolPartName(part) !== "plan_exit") continue;
+      const state = part.state as { input?: Record<string, unknown> } | undefined;
+      const input = (state?.input ?? part.input) as
+        | Record<string, unknown>
+        | undefined;
+      const t = input?.plan ?? input?.content ?? input?.text;
+      const p = input?.planPath ?? input?.path;
+      if (typeof t === "string") text = t;
+      if (typeof p === "string") path = p;
+      break;
+    }
+  }
+  const firstHeading = text.match(/^#{1,6}[ \t]+(.+)$/m)?.[1]?.trim();
+  const firstLine = text.split("\n").find((l) => l.trim())?.trim();
+  const title =
+    firstHeading ??
+    firstLine ??
+    question.questions[0]?.header ??
+    "Plan complete";
+  return {
+    title,
+    path: path || undefined,
+    metrics: planMetrics(text),
+    text,
+  };
+}
+
+// ===== resolveDelegateModel (BET-951) =====
+//
+// The delegate split control's model precedence — implement EXACTLY this
+// order, in a pure helper:
+//   1. An explicit pick made on the card (component state) — wins while open.
+//   2. The last model EXPLICITLY overridden for a delegation in this project
+//      (the `manta:delegate:<projectKey>:model` key). Never promote an
+//      inherited default into a remembered one — the memory would just pin
+//      whatever happened to be current the first time.
+//   3. The session's BUILD-side model.
+//
+// "Same as current" means the BUILD model — NOT whatever the composer chip is
+// showing (plan mode may be on, so the chip could show the plan model).
+// Sending a background job to the planning model is the bug this order exists
+// to prevent. Until per-mode models land there is only one model per session
+// and (3) is simply that model; the lookup keeps working when they arrive.
+//
+// If a remembered model is no longer selectable (deactivated in Settings or
+// gone from the catalog), fall through to (3) silently — never render a dead
+// label. Carries the full `{providerID, modelID, variant?}` shape.
+//
+// `overridden` reports whether an explicit override (level 1 or 2) is in
+// effect — the split control's right-segment accent.
+export type DelegateModelResolution = {
+  model: import("./chatShared").ModelSelection | null;
+  overridden: boolean;
+};
+
+function selectionKey(s: { providerID: string; modelID: string }): string {
+  return `${s.providerID}/${s.modelID}`;
+}
+
+export function resolveDelegateModel(input: {
+  picked: import("./chatShared").ModelSelection | null;
+  remembered: import("./chatShared").ModelSelection | null;
+  sessionModel: import("./chatShared").ModelSelection | null;
+  selectable: Array<[string, OpencodeModel[]]> | null;
+}): DelegateModelResolution {
+  const { picked, remembered, sessionModel, selectable } = input;
+  // While models are still loading we cannot validate, so a remembered or
+  // picked selection must not be discarded just because the catalogue isn't
+  // in yet — the live session model is a fine stand-in until it re-resolves.
+  const selectableKeys =
+    selectable === null
+      ? null
+      : new Set(
+          selectable
+            .flatMap(([, ms]) => ms)
+            .map((m) => `${m.providerID}/${m.id}`),
+        );
+  const usable = (s: import("./chatShared").ModelSelection | null): boolean =>
+    !!s && (selectableKeys === null || selectableKeys.has(selectionKey(s)));
+  if (usable(picked) && picked)
+    return { model: { ...picked }, overridden: true };
+  if (usable(remembered) && remembered)
+    return { model: { ...remembered }, overridden: true };
+  return { model: sessionModel ? { ...sessionModel } : null, overridden: false };
 }
 
 // ===== Transcript entry motion =====


### PR DESCRIPTION
Closes BET-951.

Upgrades the plan_exit question into a blocking plan card in the pinned card stack.

## What

- **Detection is exact**: `isPlanExitQuestion` matches the question's `tool.callID` against a `plan_exit` tool part in the transcript (never the question text).
- **`PlanCard`** in `Cards.tsx` through the module-private `AskCardShell` (no new card surface): DraftingCompass badge in accent tone (not warn), title from the plan's first heading, `N steps · N files` metrics + plan path body, the free-text feedback field (QuestionCard's recipe verbatim), and the action row **Build here / Delegate ▾ / (spacer) / Keep planning**.
- **Delegate split reuses `SplitChip`** (no new split control) fed by the EXISTING `ModelMenu` (`popup={{right:true}}` — only the model segment carries `aria-haspopup="listbox"`; the action segment does NOT).
- **Model precedence in a pure tested helper** `resolveDelegateModel` (chatUtils): explicit pick → remembered override (`manta:delegate:<projectKey>:model`, written only on explicit pick) → the session's **build** model, with silent fall-through when a remembered model is deactivated. Carries the full `{providerID, modelID, variant?}` shape.
- **Build here** answers "Yes" then resubmits the plan text with the build model (a resubmit, not a toggle) — opencode's "Yes" path stamps the injected build turn with the *plan* model because MantaUI sends the model per prompt.
- **Keep planning** answers "No" (plan mode stays on); free-text feedback is handed to the plan agent.
- **Cap handling**: disabled control with an explanatory title at `MAX_RUNNING_JOBS` (5), read from the delegate list the renderer already has.
- **See in browser is intentionally omitted** — BET-954 (its data source) has not merged.
- Plan questions are excluded from the inline transcript so they don't render twice.

## Deleted / reused
- Reused `AskCardShell`, `SplitChip`, `ModelMenu`, `selectableModelGroups`, `resolveActiveModel`. No new card surface, no new split control, no new dropdown.

## Verification results
- typecheck: exit 0 (both tsconfig.node.json + tsconfig.web.json)
- test: `npm test` — vitest 2764 passed / 7 skipped; node:test 2089 passed / 0 failed
- New tests: `resolveDelegateModel` precedence (all three levels + fall-through on deactivated + loading), `planMetrics`, `isPlanExitQuestion`, `extractPlanData`, and PlanCard component tests (badge/title/actions, split aria, menu opens, cap title, remembered model, generic-question path intact).

Base: origin/main @ afe2e29