### PR TITLE
fix(renderer): don't mergeLocalPairing on the unpaired refresh fallback; use typeof capability probe (BET-958)

### DIFF
--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -1077,16 +1077,19 @@ describe("sync snapshot / applySyncPayload (BET-678)", () => {
       // No syncSnapshot — exactly the unpaired preload bridge's shape.
       configGet: async () => {
         configGetCalls++;
-        return { projects: [] };
+        return { serverUrl: "", boxId: "", boxToken: "" };
       },
     };
     useStore.setState({ loaded: false, boxToken: "seed", serverUrl: "seed" });
+    // Must resolve, not throw: the without-guard path would TypeError on the
+    // missing syncSnapshot and leave `loaded` false → infinite spinner.
     await expect(useStore.getState().refresh()).resolves.toBeUndefined();
     expect(configGetCalls).toBe(1);
     const s = useStore.getState();
     // `loaded` is what unblocks App's onboarding gate.
     expect(s.loaded).toBe(true);
-    // An unpaired config must resolve to onboarding, not carry stale pairing.
+    // Raw config applied with no pairing overlay: an unpaired config must
+    // resolve to onboarding, not carry stale pairing.
     expect(s.boxToken).toBe("");
     expect(s.serverUrl).toBe("");
     (window as unknown as { api?: unknown }).api = prev;

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -861,9 +861,11 @@ export const useStore = create<State>((set, get) => ({
     // transports, and the local config is the only thing an unpaired app can
     // (or should) load — there is no box to sync with yet. Onboarding.tsx's
     // refreshAndInstallTransport documents the same hazard on the post-pair
-    // path; this is the pre-pair half.
-    if (!window.api.syncSnapshot) {
-      get().applyConfig(mergeLocalPairing(await window.api.configGet()));
+    // path; this is the pre-pair half. Same `typeof … !== "function"`
+    // capability-probe pattern used in App.tsx (onSyncDelta / onStatusEvent)
+    // and ProvidersStep (opencodeProviderAuth).
+    if (typeof window.api.syncSnapshot !== "function") {
+      get().applyConfig(await window.api.configGet());
       return;
     }
     // BET-678: single cursor RPC. Pass the last-confirmed cursor so the box


### PR DESCRIPTION
## What & why

A fresh, never-paired desktop boot was deadlocked on the full-screen loader: `store.refresh()` calls `window.api.syncSnapshot(...)`, which the preload OS-bridge (the transport before pairing) does NOT implement. That TypeError was classified as a transient failure and retried forever, `loaded` never flipped, and onboarding never rendered.

The fallback guard was introduced by BET-932, but it (a) used `!window.api.syncSnapshot` rather than the repo's `typeof … !== "function"` capability-probe pattern and (b) still overlaid `mergeLocalPairing` on the fallback path. This PR aligns the fix with BET-958's spec:

- `src/renderer/store.ts` — probe with `typeof window.api.syncSnapshot !== "function"`; on the unpaired path apply the raw `configGet()` result directly (no `mergeLocalPairing`). On a genuinely-unpaired install there is no localStorage pairing to overlay, so the raw config is correct.
- `src/renderer/store.test.ts` — the unpaired test now resolves `configGet` to `{ serverUrl: "", boxId: "", boxToken: "" }` and asserts `refresh()` resolves (no throw) and `loaded === true`. The paired cursor path test is unchanged.

**RED before:** temporarily removing the guard makes the unpaired test fail (`syncSnapshot` undefined → TypeError → `loaded` stays false) — 1 failed.
**GREEN after:** guard restored, all tests pass.

Files changed: `2`. `src/renderer/store.ts`, `src/renderer/store.test.ts`.

Base: origin/main @ `49916dfe`

## Verification results
- PR branch (`multica/BET-958-unpaired-refresh` @ `72d45688`):
  - typecheck: exit 0, no errors. log sha256 `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test (npm test): exit 0, vitest 2752 pass / 7 skip, server 2089 pass / 0 fail. log sha256 `88f3f42cec6483f41070b76886fbf74d435315a00eb5e5c28c6bec14209108b4`
- Base (`main` @ `49916dfe`):
  - typecheck: exit 0, no errors. log sha256 `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test (npm test): exit 0, server 2089 pass / 0 fail. log sha256 `35293b1b9af2840f86155aab52cc6c8a770c183836d33ab1dae75b9ca00ece6c`
- **Conclusion:** 0 new failures. Server counts identical between branches (2089/0). The store-guard change is verified via the targeted vitest run (80 store tests pass on PR) and the red/green demonstration.

Logs cached at `/tmp/tc-pr.log`, `/tmp/test-pr.log`, `/tmp/vitest-pr.log`, `/tmp/tc-main.log`, `/tmp/test-main.log`.
