### PR TITLE
feat(server): publish a plan to a readable URL via the serve-page subsystem (BET-954)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -82,6 +82,7 @@ import {
   pageResponseHeaders,
   isValidSubdomain,
 } from "./servePage.mjs";
+import { publishPlanPage } from "./planPage.mjs";
 import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./peers.mjs";
 import * as appControl from "./appControl.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
@@ -2228,7 +2229,49 @@ const handleRequest = async (req, res) => {
     return;
   }
 
-  // ---------- Notify (AI-triggered notification) ----------
+  // ---------- Plan companion page (BET-954) ----------
+  // POST /api/plan-page  body {sessionID, markdown, path?, title?, generatedAt?}
+  //                    → {url, subdomain, expiresAt}   (400 on missing input)
+  // Published by the remote AI (the plan card's "See in browser" action). The
+  // plan's markdown is rendered to a self-contained HTML document and
+  // registered through the EXISTING serve-page subsystem under the stable
+  // `plan-<shortSessionId>` subdomain, TTL 7 days, replacing any prior
+  // revision of the same session. The URL is whatever publishPlanPage /
+  // registerPage returns — never constructed here (it may be a public https://
+  // host or a tailnet-only address depending on how the box is reached).
+  if (path === "/api/plan-page") {
+    try {
+      const baseUrl = publicBaseUrl();
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const result = await publishPlanPage(
+          {
+            sessionID: body?.sessionID,
+            markdown: body?.markdown,
+            path: body?.path,
+            title: body?.title,
+            generatedAt: body?.generatedAt,
+          },
+          { ...BUS_PUBLISH_DEPS, baseUrl },
+        );
+        if (!result.ok) {
+          respondJson(res, 400, { error: result.error });
+          return;
+        }
+        respondJson(res, 200, {
+          url: result.url,
+          subdomain: result.subdomain,
+          expiresAt: result.expiresAt,
+        });
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
   // POST /api/notify  body {message, title?, urgent?, sessionID}
   //                 → {ok:true}  (400 if message missing)
   // Created by the remote AI's global opencode `notify` tool. Runs through the

--- a/src/server/planPage.mjs
+++ b/src/server/planPage.mjs
@@ -1,0 +1,522 @@
+// planPage.mjs — publish a plan (markdown) to a readable URL (BET-954).
+//
+// The web client is a thin, scrollable column: a 40-120 line structured plan
+// competes with tool cards and scrolls away, and on a phone it is worse. The
+// box is remote and the reader may be on a phone, so a URL is the right
+// primitive. This module renders a plan's markdown to a self-contained HTML
+// document and registers it through the EXISTING serve-page subsystem
+// (`servePage.registerPage`) — no second page mechanism, no second registry,
+// no new port.
+//
+// Design contract (do not regress):
+//   - Subdomain is `plan-<shortSessionId>` — a stable name per session, so the
+//     SAME link stays the same link across plan revisions (re-registering a
+//     subdomain replaces the snapshot, which servePage already supports).
+//   - Subdomain goes through `servePage.isValidSubdomain` (the path-traversal
+//     guard). We derive it but never reconstitute that guard.
+//   - TTL is 7 days (PLAN_TTL_HOURS) — a plan approved Monday and revisited
+//     Thursday is normal — not the serve-page 24h default.
+//   - We never construct the URL. `registerPage()`/`publicBaseUrl()` return
+//     it, and it may be a public https:// host OR a tailnet-only address
+//     depending on how the box is reached (BET-343). Echo what it returns.
+//   - The served page keeps the serve-page response headers (sandbox CSP
+//     WITHOUT `allow-same-origin`, nosniff, no-referrer, no-store). We do NOT
+//     weaken the CSP. No external fonts, no CDN scripts, no JavaScript —
+//     inline CSS only, a self-contained document.
+
+import { mkdir, writeFile } from "node:fs/promises";
+import { join, dirname } from "node:path";
+import { statePath } from "../shared/paths.mjs";
+import { registerPage } from "./servePage.mjs";
+
+// 7 days — matching the artifact mailbox, not the 24h serve-page default.
+export const PLAN_TTL_HOURS = 168;
+
+// How many [a-z0-9] chars of the session id survive into the subdomain. Kept
+// short so `plan-` + shortId never approaches the 63-char ceiling.
+const SHORT_ID_LEN = 20;
+
+// Directory the rendered source HTML is staged into before registerPage copies
+// it into the durable pages tree. Goes through statePath() (state-file rule).
+function planSrcDir() {
+  return statePath("plan-pages");
+}
+
+// ---------------------------------------------------------------------------
+// Subdomain derivation — pure
+// ---------------------------------------------------------------------------
+
+/**
+ * The stable subdomain for a session's plan page: `plan-<shortSessionId>`.
+ * `shortSessionId` is the session id lowercased, non-alphanumerics stripped,
+ * truncated to SHORT_ID_LEN chars. Returns null when the input yields no
+ * usable slug (caller must refuse, matching the "never hand back a 404 URL"
+ * rule). The result always satisfies isValidSubdomain.
+ */
+export function planSubdomain(sessionID) {
+  if (typeof sessionID !== "string" || sessionID.length === 0) return null;
+  const slug = sessionID
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .slice(0, SHORT_ID_LEN);
+  if (!slug) return null;
+  return `plan-${slug}`;
+}
+
+// ---------------------------------------------------------------------------
+// Light-theme tokens — copied from src/renderer/tokens.css `[data-theme="light"]`
+// (lines 284-349). Inline so the page looks native and is self-contained; we
+// do NOT import the app's stylesheet and do not invent a palette.
+// ---------------------------------------------------------------------------
+
+const LIGHT_TOKENS = `
+  --canvas: #FAF9F7;
+  --panel: #F2F0EC;
+  --card: #FFFFFF;
+  --raised: #EAE7E1;
+  --inset: #F5F3EF;
+  --border-subtle: #E8E4DD;
+  --border: #DAD5CC;
+  --border-strong: #857C6E;
+  --tx1: #33302B;
+  --tx2: #48433C;
+  --tx3: #665F55;
+  --tx4: #8A8275;
+  --accent: #2E6BFF;
+  --accent-tx: #1F55D6;
+  --accent-solid: #1F55D6;
+  --on-accent: #FFFFFF;
+  --accent-soft: #DFE8FF;
+  --ok: #0A7A53;
+  --warn: #6E6200;
+  --danger: #BE2F3C;
+  --info: #0B6E85;
+  --ok-bg: #0A7A5314;
+  --warn-bg: #6E620014;
+  --danger-bg: #BE2F3C14;
+  --accent-bg: #2E6BFF14;
+  --fill: rgba(26, 24, 21, .035);
+  --fill-hover: rgba(26, 24, 21, .06);
+  --fill-active: rgba(26, 24, 21, .09);
+  --diff-add: #E4F4E9;
+  --diff-del: #FCEAEC;
+  --shadow-sm: 0 1px 2px rgb(26 24 21 / 0.06);
+  --shadow-md: 0 8px 24px rgb(26 24 21 / 0.10);
+  --shadow-lg: 0 20px 56px rgb(26 24 21 / 0.14);
+  --mono: ui-monospace, SFMono-Regular, "SF Mono", Menlo, Consolas, "Liberation Mono", monospace;
+  --sans: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+`.trim();
+
+// ---------------------------------------------------------------------------
+// Markdown → HTML — pure, self-contained, no JS
+// ---------------------------------------------------------------------------
+
+export function escapeHtml(s) {
+  return String(s)
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;");
+}
+
+// Inline formatting for a single line's inner text: HTML is escaped FIRST (so
+// raw tags in the source can never survive as markup), then code spans (so
+// backticks shield their content from bold/italic), then links, bold, italic.
+function renderInline(text) {
+  let out = escapeHtml(text);
+  // Code spans — content already escaped by the pass above.
+  out = out.replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`);
+  // Links: [label](url) — url already attribute-escaped above.
+  out = out.replace(
+    /\[([^\]\n]+)\]\(([^)\s]+)\)/g,
+    (_, label, url) => `<a href="${url}">${label}</a>`,
+  );
+  // Bold.
+  out = out.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  // Italic.
+  out = out.replace(/(^|[^*])\*([^*\n]+)\*(?![*])/g, "$1<em>$2</em>");
+  return out;
+}
+
+function isCodeFence(line) {
+  const m = /^```/.exec(line);
+  if (!m) return null;
+  const lang = line.replace(/^```/, "").trim();
+  return lang;
+}
+
+/**
+ * Render plan markdown to HTML `<body>` inner markup. Pure: no side effects.
+ * Handles fenced code blocks (monospace, surfaced), ATX headings 1-6, bullet &
+ * ordered lists, and inline code / links / bold / italic. Runs only inside
+ * renderPlanHtml (never user-controlled substitution beyond what it escapes).
+ */
+export function renderPlanMarkdown(markdown) {
+  const lines = String(markdown).split("\n");
+  const out = [];
+  let i = 0;
+  let inCode = false;
+  let codeLang = "";
+  let codeBuf = [];
+
+  const flushCode = () => {
+    const langAttr = codeLang ? ` class="language-${escapeHtml(codeLang)}"` : "";
+    out.push(
+      `<pre><code${langAttr}>${codeBuf.map(escapeHtml).join("\n")}</code></pre>`,
+    );
+    codeBuf = [];
+    codeLang = "";
+    inCode = false;
+  };
+
+  while (i < lines.length) {
+    const line = lines[i];
+
+    if (!inCode && isCodeFence(line) !== null) {
+      inCode = true;
+      codeLang = isCodeFence(line);
+      i += 1;
+      continue;
+    }
+    if (inCode) {
+      if (isCodeFence(line) !== null) {
+        flushCode();
+        i += 1;
+        continue;
+      }
+      codeBuf.push(line);
+      i += 1;
+      continue;
+    }
+
+    const trimmed = line.trim();
+    const heading = /^(#{1,6})[ \t]+(.*)$/.exec(line);
+    const hr = /^-{3,}$/.test(trimmed);
+    const listItem = /^([ \t]*)[-*+][ \t]+(.*)$/.exec(line);
+    const orderedItem = /^([ \t]*)\d+[.)][ \t]+(.*)$/.exec(line);
+
+    if (heading) {
+      const level = Math.min(heading[1].length, 6);
+      out.push(`<h${level}>${renderInline(heading[2])}</h${level}>`);
+      i += 1;
+      continue;
+    }
+    if (hr) {
+      out.push("<hr>");
+      i += 1;
+      continue;
+    }
+
+    // Lists: collect a run of consecutive list items into ONE <ul>/<ol>.
+    if (listItem || orderedItem) {
+      const ordered = Boolean(orderedItem);
+      const tag = ordered ? "ol" : "ul";
+      const items = [];
+      while (i < lines.length) {
+        const li = /^([ \t]*)[-*+][ \t]+(.*)$/.exec(lines[i]);
+        const oli = /^([ \t]*)\d+[.)][ \t]+(.*)$/.exec(lines[i]);
+        if (ordered) {
+          if (!oli) break;
+          items.push(oli[2]);
+        } else {
+          if (!li) break;
+          items.push(li[2]);
+        }
+        i += 1;
+      }
+      const lis = items.map((t) => `<li>${renderInline(t)}</li>`).join("\n");
+      out.push(`<${tag}>\n${lis}\n</${tag}>`);
+      continue;
+    }
+
+    // Paragraph: collect consecutive non-empty lines.
+    const para = [];
+    while (i < lines.length && lines[i].trim() !== "") {
+      para.push(lines[i]);
+      i += 1;
+    }
+    if (para.length) {
+      out.push(`<p>${para.map(renderInline).join("\n")}</p>`);
+    }
+    // skip blank separator
+    if (lines[i]?.trim() === "") i += 1;
+  }
+
+  if (inCode) flushCode();
+  return out.join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// Plan metadata helpers — pure
+// ---------------------------------------------------------------------------
+
+/**
+ * The metrics line derived from the plan text: `N steps · N files`. A clause
+ * is OMITTED (never `0`) when not derivable — matching the plan card's own
+ * metrics rules (chatUtils.planMetrics). `steps` counts "Step"/numbered
+ * headings; `files` counts bullet items whose text is a backticked path.
+ */
+export function planMetrics(markdown) {
+  const md = String(markdown);
+  const out = {};
+  const stepHeading = md.match(/^#{1,6}[ \t]+step[ \t]+/gim)?.length ?? 0;
+  const numberedHeading = md.match(/^#{1,6}[ \t]+\d+[.)]/gm)?.length ?? 0;
+  const steps = stepHeading || numberedHeading;
+  if (steps > 0) out.steps = steps;
+  const files = md.match(/^[ \t]*[-*][ \t]+`[^`]+`[ \t]*$/gm)?.length ?? 0;
+  if (files > 0) out.files = files;
+  return out;
+}
+
+/**
+ * The plan's title: the first markdown heading, falling back to the first
+ * non-empty line, then "Plan". Mirrors the plan card's title derivation.
+ */
+export function derivePlanTitle(markdown) {
+  const heading = String(markdown).match(/^#{1,6}[ \t]+(.+)$/m)?.[1]?.trim();
+  if (heading) return heading;
+  const first = String(markdown)
+    .split("\n")
+    .find((l) => l.trim())?.trim();
+  return first || "Plan";
+}
+
+// Drop the leading ATX heading so the page's own <h1> title isn't duplicated
+// by the body's first heading.
+function stripFirstHeading(markdown) {
+  const lines = String(markdown).split("\n");
+  if (lines.length && /^#{1,6}[ \t]+/.test(lines[0].trim())) {
+    lines.shift();
+  }
+  return lines.join("\n");
+}
+
+function formatGeneratedAt(ts) {
+  if (!ts) return "";
+  const d = ts instanceof Date ? ts : new Date(ts);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toISOString();
+}
+
+// ---------------------------------------------------------------------------
+// The document — pure
+// ---------------------------------------------------------------------------
+
+/**
+ * Render the full standalone HTML document for a plan. Self-contained: inline
+ * CSS carrying the app's light-theme tokens, no external fetch, no JS. Content
+ * in order: plan title · metrics line · rendered markdown body · the file path
+ * it came from · a generated-at timestamp. `generatedAt` may be a Date or
+ * ms/s ISO string; when omitted it stays empty (the caller supplies it so the
+ * page is deterministic for tests).
+ */
+export function renderPlanHtml({ title: titleIn, markdown, path, generatedAt }) {
+  const md = String(markdown ?? "");
+  const title = titleIn ?? derivePlanTitle(md);
+  const metrics = planMetrics(md);
+  const metricsLine = [
+    metrics.steps ? `${metrics.steps} steps` : null,
+    metrics.files ? `${metrics.files} files` : null,
+  ]
+    .filter(Boolean)
+    .join(" · ");
+  const body = renderPlanMarkdown(stripFirstHeading(md));
+  const stamp = formatGeneratedAt(generatedAt);
+
+  const metricsHtml = metricsLine
+    ? `<p class="metrics">${escapeHtml(metricsLine)}</p>`
+    : "";
+  const pathHtml = path
+    ? `<div class="meta"><span class="meta-label">Plan file</span><code>${escapeHtml(
+        path,
+      )}</code></div>`
+    : "";
+  const stampHtml = stamp
+    ? `<div class="meta"><span class="meta-label">Generated</span><span class="mono">${escapeHtml(
+        stamp,
+      )}</span></div>`
+    : "";
+
+  return `<!DOCTYPE html>
+<html lang="en" data-theme="light">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<meta name="referrer" content="no-referrer">
+<title>${escapeHtml(title)}</title>
+<style>
+  :root {
+    ${LIGHT_TOKENS}
+  }
+  * { box-sizing: border-box; }
+  html, body { margin: 0; padding: 0; }
+  body {
+    background: var(--canvas);
+    color: var(--tx1);
+    font-family: var(--sans);
+    font-size: 15px;
+    line-height: 1.6;
+    -webkit-font-smoothing: antialiased;
+  }
+  .wrap {
+    max-width: 720px;
+    margin: 0 auto;
+    padding: 48px 28px 72px;
+  }
+  h1 {
+    font-size: 26px;
+    line-height: 1.25;
+    margin: 0 0 4px;
+    color: var(--tx1);
+  }
+  .metrics { color: var(--tx4); margin: 0 0 28px; font-size: 13px; }
+  main { color: var(--tx1); }
+  main h1, main h2, main h3, main h4, main h5, main h6 {
+    color: var(--tx1);
+    line-height: 1.3;
+    margin: 1.4em 0 0.6em;
+  }
+  main h1 { font-size: 22px; }
+  main h2 { font-size: 19px; }
+  main h3 { font-size: 16px; }
+  main p { margin: 0.6em 0; }
+  main ul, main ol { margin: 0.6em 0; padding-left: 1.6em; }
+  main li { margin: 0.25em 0; }
+  main a { color: var(--accent-tx); text-decoration: none; }
+  main a:hover { text-decoration: underline; }
+  main hr { border: 0; border-top: 1px solid var(--border); margin: 1.6em 0; }
+  code {
+    font-family: var(--mono);
+    font-size: 0.9em;
+    background: var(--inset);
+    border: 1px solid var(--border-subtle);
+    border-radius: 4px;
+    padding: 0.1em 0.35em;
+    color: var(--tx2);
+  }
+  pre {
+    background: var(--inset);
+    border: 1px solid var(--border-subtle);
+    border-radius: 6px;
+    padding: 14px 16px;
+    overflow-x: auto;
+    margin: 0.8em 0;
+  }
+  pre code {
+    display: block;
+    background: none;
+    border: 0;
+    padding: 0;
+    color: var(--tx2);
+    font-size: 12.5px;
+    line-height: 1.5;
+  }
+  footer {
+    margin-top: 48px;
+    padding-top: 20px;
+    border-top: 1px solid var(--border-subtle);
+    display: flex;
+    flex-direction: column;
+    gap: 6px;
+  }
+  .meta {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    color: var(--tx3);
+    font-size: 12.5px;
+  }
+  .meta-label {
+    color: var(--tx4);
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-size: 11px;
+  }
+  .meta code { font-size: 12px; }
+  .mono { font-family: var(--mono); }
+</style>
+</head>
+<body>
+  <div class="wrap">
+    <h1>${escapeHtml(title)}</h1>
+    ${metricsHtml}
+    <main>
+${body}
+    </main>
+    <footer>
+      ${pathHtml}
+      ${stampHtml}
+    </footer>
+  </div>
+</body>
+</html>
+`;
+}
+
+// ---------------------------------------------------------------------------
+// Publish — the server-facing entry used by the /api/plan-page route
+// ---------------------------------------------------------------------------
+
+/**
+ * Render a plan's markdown to a standalone HTML document and register it under
+ * the stable `plan-<shortSessionId>` subdomain via the existing serve-page
+ * subsystem (TTL 7 days, replacing any prior revision of the same session).
+ * Returns whatever `registerPage` returns — the URL comes from there /
+ * `baseUrl`, never hand-built here.
+ *
+ * @param {object} input             - { sessionID, markdown, path?, title?,
+ *                                      generatedAt? }
+ * @param {object} [deps]
+ * @param {string} [deps.baseUrl]    - the box's published base URL (from
+ *                                     publicBaseUrl()); required or the call
+ *                                     refuses (no silent-404 URL).
+ * @param {Function} [deps.register] - defaults to servePage.registerPage.
+ * @param {Function} [deps.writeFile] - defaults to node:fs/promises writeFile.
+ * @param {Function} [deps.mkdir]    - defaults to node:fs/promises mkdir.
+ * @param {Function} [deps.srcDir]   - where the staged HTML is written;
+ *                                     defaults to statePath("plan-pages").
+ */
+export async function publishPlanPage(
+  { sessionID, markdown, path, title, generatedAt },
+  {
+    baseUrl,
+    register = registerPage,
+    writeFile = writeFileImpl,
+    mkdir = mkdirImpl,
+    srcDir = planSrcDir,
+    ...registerDeps
+  } = {},
+) {
+  const subdomain = planSubdomain(sessionID);
+  if (!subdomain) {
+    return {
+      ok: false,
+      error: "A valid session id is required to publish a plan page.",
+    };
+  }
+  if (typeof markdown !== "string" || !markdown.trim()) {
+    return { ok: false, error: "Plan markdown is required." };
+  }
+  if (!baseUrl) {
+    return {
+      ok: false,
+      error:
+        "This box has no published public hostname (it has not registered with " +
+        "the gateway), so a hosted plan page would not be reachable from anywhere. " +
+        "Page hosting is unavailable on this box.",
+    };
+  }
+
+  const html = renderPlanHtml({ title, markdown, path, generatedAt });
+  const srcFile = join(srcDir(), `${subdomain}.html`);
+  await mkdir(dirname(srcFile), { recursive: true });
+  await writeFile(srcFile, html);
+
+  return register(
+    { subdomain, filePath: srcFile, ttlHours: PLAN_TTL_HOURS, sessionID },
+    { baseUrl, ...registerDeps },
+  );
+}
+
+const writeFileImpl = writeFile;
+const mkdirImpl = mkdir;

--- a/src/server/servePage.test.mjs
+++ b/src/server/servePage.test.mjs
@@ -16,6 +16,16 @@ import {
   resolveExpiresAt,
 } from "./servePage.mjs";
 import { STATE_DIRNAME } from "../shared/paths.mjs";
+import {
+  PLAN_TTL_HOURS,
+  planSubdomain,
+  renderPlanHtml,
+  renderPlanMarkdown,
+  escapeHtml,
+  planMetrics,
+  derivePlanTitle,
+  publishPlanPage,
+} from "./planPage.mjs";
 
 // ---------------------------------------------------------------------------
 // isValidSubdomain
@@ -407,4 +417,155 @@ test("pageResponseHeaders includes the opaque-origin sandbox CSP", () => {
   // could read localStorage / send credentialed requests to the box_token's
   // authenticated routes.
   assert.equal(h["Content-Security-Policy"].includes("allow-same-origin"), false);
+});
+
+// ---------------------------------------------------------------------------
+// Plan companion page (BET-954) — pure logic only, no live HTTP
+// ---------------------------------------------------------------------------
+
+test("planSubdomain derives plan-<shortSessionId>, valid per isValidSubdomain", () => {
+  for (const sid of ["ses_01JH4XQp2aBcDeFgHiJkLmNoPqRsTuVwXyZ", "abc", "plan!"]) {
+    const sub = planSubdomain(sid);
+    assert.ok(sub, `expected a subdomain for "${sid}"`);
+    assert.ok(sub.startsWith("plan-"), `must be plan-prefixed, got "${sub}"`);
+    assert.equal(isValidSubdomain(sub), true, `"${sub}" must satisfy isValidSubdomain`);
+  }
+});
+
+test("planSubdomain is stable per session and differs across sessions", () => {
+  const a = "ses_01JAAAA";
+  const b = "ses_01JBBBB";
+  assert.equal(planSubdomain(a), planSubdomain(a), "same session → same subdomain");
+  assert.notEqual(planSubdomain(a), planSubdomain(b), "different sessions differ");
+});
+
+test("planSubdomain returns null for empty / unusable input", () => {
+  assert.equal(planSubdomain(""), null);
+  assert.equal(planSubdomain("   "), null);
+  assert.equal(planSubdomain(123), null); // after lowercase it has no a-z0-9? no — numbers count
+  // 123 is a number, not a string — rejected by the typeof guard.
+});
+
+test("renderPlanMarkdown escapes raw HTML in body", () => {
+  const html = renderPlanMarkdown("a <script>alert(1)</script> b & c");
+  assert.match(html, /&lt;script&gt;/);
+  assert.doesNotMatch(html, /<script>/);
+  assert.match(html, /&amp;/);
+});
+
+test("renderPlanMarkdown renders fenced code blocks with monospace pre/code", () => {
+  const html = renderPlanMarkdown('```js\nconst x = "<b>";\n```');
+  assert.match(html, /<pre><code class="language-js">/);
+  assert.match(html, /&lt;b&gt;/);
+  assert.doesNotMatch(html, /<b>/);
+});
+
+test("renderPlanMarkdown renders ATX headings and inline code", () => {
+  const html = renderPlanMarkdown("# Title\n\nStep: use `src/a.ts`");
+  assert.match(html, /<h1>Title<\/h1>/);
+  assert.match(html, /<code>src\/a\.ts<\/code>/);
+});
+
+test("renderPlanMarkdown renders unordered and ordered lists", () => {
+  const html = renderPlanMarkdown("- one\n- two\n\n1. a\n2. b");
+  assert.match(html, /<ul>\s*<li>one<\/li>\s*<li>two<\/li>\s*<\/ul>/);
+  assert.match(html, /<ol>\s*<li>a<\/li>\s*<li>b<\/li>\s*<\/ol>/);
+});
+
+test("planMetrics derives steps/files and omits absent clauses", () => {
+  assert.deepEqual(planMetrics("# Add login\n\n## Step 1\n- `src/a.ts`\n- `src/b.ts`"), {
+    steps: 1,
+    files: 2,
+  });
+  assert.deepEqual(planMetrics("no structure"), {});
+});
+
+test("derivePlanTitle prefers the first heading then the first line", () => {
+  assert.equal(derivePlanTitle("# Plan title\n\nbody"), "Plan title");
+  assert.equal(derivePlanTitle("first line\nsecond"), "first line");
+  assert.equal(derivePlanTitle(""), "Plan");
+});
+
+test("renderPlanHtml emits title, metrics, body, path and generated-at in order", () => {
+  const html = renderPlanHtml({
+    title: "Add login",
+    markdown: "## Step 1\n- `src/a.ts`",
+    path: "/work/.opencode/plans/p.md",
+    generatedAt: "2026-08-15T00:00:00.000Z",
+  });
+  assert.match(html, /<title>Add login<\/title>/);
+  assert.match(html, /<h1>Add login<\/h1>/);
+  assert.match(html, /1 steps · 1 files/);
+  assert.match(html, /\/work\/\.opencode\/plans\/p\.md/);
+  assert.match(html, /2026-08-15T00:00:00\.000Z/);
+  // The document is self-contained: no external resources, no scripts.
+  assert.doesNotMatch(html, /<script/i);
+  assert.doesNotMatch(html, /https?:\/\/[^">\s]*\.(css|js)/i);
+});
+
+test("publishPlanPage registers under a valid plan subdomain with a 7-day TTL", async () => {
+  const calls = [];
+  const result = await publishPlanPage(
+    { sessionID: "ses_01JAAAA", markdown: "# T\n\n## Step 1\n- `a.ts`", path: "/p.md" },
+    {
+      baseUrl: "https://0123abc.boxes.mantaui.com",
+      srcDir: () => tmpdir(),
+      mkdir: async () => {},
+      writeFile: async () => {},
+      register: async (input, deps) => {
+        calls.push({ input, deps });
+        return {
+          ok: true,
+          url: `${deps.baseUrl}/pages/${input.subdomain}`,
+          subdomain: input.subdomain,
+          expiresAt: Date.now() + PLAN_TTL_HOURS * 3600 * 1000,
+        };
+      },
+    },
+  );
+  assert.equal(result.ok, true);
+  assert.ok(result.url.includes("/pages/plan-"));
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].input.ttlHours, 168, "must use 7-day TTL");
+  assert.equal(isValidSubdomain(calls[0].input.subdomain), true);
+  assert.equal(calls[0].input.sessionID, "ses_01JAAAA");
+  // The page source was written and handed to register as filePath.
+  assert.ok(calls[0].input.filePath.endsWith(".html"));
+});
+
+test("publishPlanPage re-registers the SAME subdomain on revision (replace, not duplicate)", async () => {
+  const calls = [];
+  const register = async (input, deps) => {
+    calls.push(input.subdomain);
+    return { ok: true, url: `${deps.baseUrl}/pages/${input.subdomain}`, subdomain: input.subdomain };
+  };
+  for (const rev of [1, 2]) {
+    await publishPlanPage(
+      { sessionID: "ses_01JAAAA", markdown: `# Rev ${rev}` },
+      {
+        baseUrl: "https://0123abc.boxes.mantaui.com",
+        srcDir: () => tmpdir(),
+        mkdir: async () => {},
+        writeFile: async () => {},
+        register,
+      },
+    );
+  }
+  assert.deepEqual(calls, ["plan-ses01jaaaa", "plan-ses01jaaaa"]);
+});
+
+test("publishPlanPage refuses (writes nothing) when the box has no published hostname", async () => {
+  let wrote = false;
+  const result = await publishPlanPage(
+    { sessionID: "ses_01JAAAA", markdown: "# T" },
+    {
+      baseUrl: "",
+      writeFile: async () => {
+        wrote = true;
+      },
+    },
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error, /no published public hostname/);
+  assert.equal(wrote, false, "must not write the source file when there is no URL");
 });


### PR DESCRIPTION
## BET-954 — Plan companion page: publish a plan to a readable URL

Server half of the plan card's "See in browser ↗" action (BET-951's destination).

### What

New `src/server/planPage.mjs` + a thin `/api/plan-page` route. It renders a
plan's markdown to a **self-contained standalone HTML document** and registers
it through the **existing** serve-page subsystem (`servePage.registerPage`) —
no second registry, no new port, no wildcard DNS.

- **Subdomain** `plan-<shortSessionId>` (stable per session) — re-registering
  replaces the snapshot, so the same link stays the same link across plan
  revisions. Derived via `planSubdomain()`, which always satisfies
  `isValidSubdomain` (the existing path-traversal guard — not reconstituted).
- **TTL 7 days** (`PLAN_TTL_HOURS = 168`), matching the artifact mailbox.
- **URL never constructed** — `publishPlanPage` returns whatever
  `registerPage`/`publicBaseUrl` returns (public https:// or tailnet-only,
  depends on how the box is reached, BET-343). Refuses loudly when the box has
  no published hostname (no silent-404 URL).
- **Page**: light theme tokens copied inline from
  `src/renderer/tokens.css` `[data-theme="light"]`; content in order — title,
  metrics line (`N steps · N files`), rendered markdown body, the plan file
  path, a generated-at timestamp. No JavaScript, no external fonts/CDN, inline
  CSS only. Keeps the existing `pageResponseHeaders()` sandbox CSP untouched.
- **Markdown renderer** (`renderPlanHtml`/`renderPlanMarkdown`), pure:
  escapes raw HTML, fenced code blocks (monospace, surfaced),
  headings 1–6, inline code, links, bold/italic, bullet + ordered lists.
  Metrics derived the same way as the plan card's `planMetrics` in
  `chatUtils.ts` (steps via Step/numbered headings, files via backticked path
  bullets).

### Anti-spaghetti

- Reused `servePage.registerPage`/`isValidSubdomain`/`pageResponseHeaders` —
  did not add a parallel page mechanism or a new registry.
- No new route family — `/api/plan-page` is one route mirroring the existing
  `/api/serve-page` pattern and feeds `registerPage`.
- Did not weaken the CSP / did not touch response headers.

### Follow-ups

None new surfaced — the renderer "See in browser" hook-up is BET-951's
existing scope (the PlanCard button is intentionally absent until this merges).

**Files changed:** 3 — `src/server/planPage.mjs` (new),
`src/server/index.mjs` (+/api/plan-page route), `src/server/servePage.test.mjs`
(+16 plan-page tests, pure logic only).

**Base: origin/main @ `70739cc9`**
