### PR TITLE
fix(usage): don't alert or red-ring an already-reset window (BET-965)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -581,7 +581,13 @@ function AppInner() {
     window.api
       .usageList()
       .then((snapshots) => {
-        useStore.getState().setUsage(Array.isArray(snapshots) ? snapshots : []);
+        const list = Array.isArray(snapshots) ? snapshots : [];
+        useStore.getState().setUsage(list);
+        // Seed the escalation baseline from the SAME payload that primes the
+        // dial. Without this the fire-once memory starts empty, so the first
+        // live update after any launch re-fires for a window that was already
+        // over the threshold when the app opened.
+        usageLevelsRef.current = buildUsageLevels(list, usageLevelsRef.current);
       })
       .catch(() => {
         // Transport blip or an older box that doesn't implement the channel
@@ -751,7 +757,7 @@ function AppInner() {
       }
       // Write back the CURRENT levels so a holding level doesn't re-fire and a
       // drop (after reset) re-arms the key for the next crossing.
-      usageLevelsRef.current = buildUsageLevels(next);
+      usageLevelsRef.current = buildUsageLevels(next, usageLevelsRef.current);
     });
     return off;
   }, [apiGeneration, scheduleAtReset, pushAppToastStore, dismissAppToastStore]);

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3541,11 +3541,15 @@ describe("formatWindowReset", () => {
     expect(result).toMatch(/^resets in 13h 0m \(\d{2}:\d{2}\)$/);
   });
 
-  it("returns null for a missing or past timestamp", () => {
+  it("returns null for a missing or non-finite timestamp", () => {
     expect(formatWindowReset(null, 0)).toBeNull();
     expect(formatWindowReset(undefined, 0)).toBeNull();
-    expect(formatWindowReset(-1, 0)).toBeNull();
     expect(formatWindowReset(NaN, 0)).toBeNull();
+  });
+
+  it("returns 'resetting…' once the reset instant has passed", () => {
+    expect(formatWindowReset(-1, 0)).toBe("resetting…");
+    expect(formatWindowReset(0, 0)).toBe("resetting…");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2906,15 +2906,18 @@ export function usageDialState(
 // "resets in 2h 10m" / "resets in 45m" — the popover's per-window reset
 // line. When the reset is more than 12h out, the absolute clock time is
 // appended (reuses formatClockTime, above) so a far-off reset isn't only
-// relative. Floors to the minute; returns null for a missing/past timestamp
-// so the caller omits the line rather than showing a negative duration.
+// relative. Floors to the minute. Returns null only for a missing/non-finite
+// timestamp; once the reset instant has passed it returns "resetting…".
 export function formatWindowReset(
   resetsAt: number | null | undefined,
   nowMs: number,
 ): string | null {
   if (resetsAt == null || !Number.isFinite(resetsAt)) return null;
   const deltaMs = resetsAt - nowMs;
-  if (deltaMs <= 0) return null;
+  // The reset instant has passed but the provider has not published the new
+  // window yet (server marks the window `stale`). The dial carries the old
+  // number forward, so say why it looks wrong instead of showing no line.
+  if (deltaMs <= 0) return "resetting…";
   const totalMin = Math.floor(deltaMs / 60_000);
   const h = Math.floor(totalMin / 60);
   const m = totalMin % 60;

--- a/src/renderer/usageEscalation.test.ts
+++ b/src/renderer/usageEscalation.test.ts
@@ -13,13 +13,16 @@ import type { UsageSnapshot } from "../shared/types";
 
 function snap(
   provider: string,
-  windows: Array<{ kind: string; label: string; pct: number; resetsAt?: number }>,
+  windows: Array<{ kind: string; label: string; pct: number; resetsAt?: number; stale?: boolean }>,
 ): UsageSnapshot {
   return {
     provider,
     providerIDs: [provider],
     fetchedAt: 0,
-    windows: windows.map((w) => ({ kind: w.kind, label: w.label, pct: w.pct, resetsAt: w.resetsAt })),
+    windows: windows.map((w) => {
+      const base = { kind: w.kind, label: w.label, pct: w.pct, resetsAt: w.resetsAt };
+      return w.stale ? { ...base, stale: true } : base;
+    }),
   };
 }
 
@@ -56,6 +59,16 @@ describe("buildUsageLevels", () => {
     expect(buildUsageLevels(null)).toEqual({});
     expect(buildUsageLevels(undefined)).toEqual({});
     expect(buildUsageLevels([])).toEqual({});
+  });
+
+  it("carries a stale window's previous level forward and does not read its pct", () => {
+    const prev = { "claude:session": "limit" as const };
+    const staleLow = [snap("claude", [{ kind: "session", label: "S", pct: 0, stale: true }])];
+    const levels = buildUsageLevels(staleLow, prev);
+    expect(levels["claude:session"]).toBe("limit");
+    // A fresh window still reads its pct — the stale carry is not a blanket hold.
+    const freshLow = [snap("claude", [{ kind: "session", label: "S", pct: 0 }])];
+    expect(buildUsageLevels(freshLow, prev)["claude:session"]).toBe("none");
   });
 });
 
@@ -133,6 +146,36 @@ describe("shouldFireUsageAlert — fire-once semantics", () => {
     const fired = shouldFireUsageAlert(prev, weeklyUp);
     expect(fired).toHaveLength(1);
     expect(fired[0].key).toBe("claude:weekly");
+  });
+
+  it("fires nothing for a stale window even at 100%", () => {
+    const prev = buildUsageLevels([snap("claude", [{ kind: "session", label: "S", pct: 40 }])]);
+    const stale = [snap("claude", [{ kind: "session", label: "S", pct: 100, stale: true }])];
+    expect(shouldFireUsageAlert(prev, stale)).toHaveLength(0);
+  });
+
+  it("never fires or re-arms across a stale boundary (100 → stale 100 → 0 → 100)", () => {
+    let prev: Record<string, ReturnType<typeof usageAlertLevel>> = {};
+    const atLimit = [snap("claude", [{ kind: "session", label: "S", pct: 100 }])];
+
+    let fired = shouldFireUsageAlert(prev, atLimit);
+    expect(fired).toHaveLength(1);
+    expect(fired[0].level).toBe("limit");
+    prev = buildUsageLevels(atLimit, prev); // { "claude:session": "limit" }
+
+    const stale = [snap("claude", [{ kind: "session", label: "S", pct: 100, stale: true }])];
+    expect(shouldFireUsageAlert(prev, stale)).toHaveLength(0);
+    prev = buildUsageLevels(stale, prev);
+    expect(prev["claude:session"]).toBe("limit");
+
+    const reset = [snap("claude", [{ kind: "session", label: "S", pct: 0 }])];
+    expect(shouldFireUsageAlert(prev, reset)).toHaveLength(0);
+    prev = buildUsageLevels(reset, prev);
+    expect(prev["claude:session"]).toBe("none");
+
+    fired = shouldFireUsageAlert(prev, atLimit);
+    expect(fired).toHaveLength(1);
+    expect(fired[0].level).toBe("limit");
   });
 
   it("tracks two providers independently", () => {

--- a/src/renderer/usageEscalation.ts
+++ b/src/renderer/usageEscalation.ts
@@ -12,6 +12,11 @@
 // (i.e. after the window resets). The previous-level map lives in a ref held
 // by the subscriber; this module is pure.
 //
+// Stale rule: a window whose reset instant has already passed (`stale: true`)
+// is reporting the OLD window's numbers. It must never raise an alert — the
+// key carries its previous level forward instead of re-arming (a re-arm at the
+// boundary is precisely what lets the same limit fire twice across a reset).
+//
 // There is deliberately no React and no provider-name branching here beyond
 // the exact strings the spec dictates.
 
@@ -35,11 +40,18 @@ export function usageAlertLevel(pct: number): UsageAlertLevel {
  *  Windows absent from the snapshots are absent from the record — the
  *  subscriber writes this back into its prev map after each event, which is
  *  what re-arms a key once a window resets and drops below the threshold. */
-export function buildUsageLevels(snapshots: UsageSnapshot[] | null | undefined): Record<string, UsageAlertLevel> {
+export function buildUsageLevels(
+  snapshots: UsageSnapshot[] | null | undefined,
+  prev: Record<string, UsageAlertLevel> = {},
+): Record<string, UsageAlertLevel> {
   const out: Record<string, UsageAlertLevel> = {};
   for (const snap of snapshots ?? []) {
     for (const win of snap.windows ?? []) {
-      out[`${snap.provider}:${win.kind}`] = usageAlertLevel(win.pct);
+      const key = `${snap.provider}:${win.kind}`;
+      // A stale window's pct belongs to the window that just ended. Carrying
+      // the level forward keeps fire-once intact across the boundary: the key
+      // neither re-arms (which would re-fire the same limit) nor disappears.
+      out[key] = win.stale ? (prev[key] ?? "none") : usageAlertLevel(win.pct);
     }
   }
   return out;
@@ -66,6 +78,7 @@ export function shouldFireUsageAlert(
   const fired: UsageAlert[] = [];
   for (const snap of next ?? []) {
     for (const win of snap.windows ?? []) {
+      if (win.stale) continue;
       const key = `${snap.provider}:${win.kind}`;
       const newLevel = usageAlertLevel(win.pct);
       const oldLevel = prev[key] ?? "none";

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -35,6 +35,12 @@
  * @property {number} [limit]    Absolute cap when the provider exposes one.
  * @property {number} [resetsAt] Epoch MILLISECONDS.
  * @property {boolean} [binding] The provider says this window bites first.
+ * @property {boolean} [stale] True when this reading describes a window whose
+ *   reset instant has already passed: the provider has not published the new
+ *   window's numbers yet, so `pct` still belongs to the window that just
+ *   ended. Set by the poller (this module), never by an adapter. Consumers
+ *   must not raise an alert from a stale window; the dial carries the last
+ *   reading forward and labels it "resetting…" rather than blanking.
  */
 /**
  * @typedef {Object} UsageSnapshot
@@ -79,6 +85,9 @@ export const ADAPTERS = [claudeAdapter, codexAdapter, kimiAdapter];
 
 // Cache TTL is the poll interval; there is no separate cache layer (per spec).
 const POLL_MS = 180_000; // 3 minutes
+// How long after a tick that first saw an expired window we re-poll, so the
+// carried-forward reading is replaced in seconds rather than up to POLL_MS.
+const STALE_RETRY_MS = 20_000;
 // Default per-adapter backoff on a bare 429 (no usable Retry-After).
 const DEFAULT_RATE_LIMIT_BACKOFF_MS = 15 * 60_000; // 15 minutes
 
@@ -100,6 +109,7 @@ function contentKey(results) {
  * @param {typeof fetch} [opts.fetchImpl]
  * @param {() => number} [opts.now]
  * @param {(evt: {kind:string, payload:object}) => void} [opts.publish]
+ * @param {number} [opts.staleRetryMs]
  * @returns {{ tick: () => Promise<void>, stop: () => void, snapshots: UsageSnapshot[] }}
  */
 export function createUsagePoller({
@@ -107,6 +117,7 @@ export function createUsagePoller({
   fetchImpl = fetch,
   now = () => Date.now(),
   publish,
+  staleRetryMs = STALE_RETRY_MS,
 } = {}) {
   let snapshots = [];
   let lastContentKey = null;
@@ -119,6 +130,11 @@ export function createUsagePoller({
   // failure TRANSITION rather than once per tick while a provider stays
   // broken.
   const failing = new Set();
+  // Whether the PREVIOUS tick saw an expired window — the fast re-poll is
+  // armed on the false->true edge only (see the header note on why a
+  // retry-while-stale loop would never terminate for an idle user).
+  let hadStale = false;
+  let staleRetry = null;
 
   function warnOnce(adapterId, e) {
     if (failing.has(adapterId)) return;
@@ -197,6 +213,26 @@ export function createUsagePoller({
       // BUS PUBLISH ("publish … only when the serialized snapshot set
       // actually changed") — it says nothing about the cache, so gating only
       // the publish call below satisfies both with no trade-off.
+      // A window whose reset instant has passed is reporting the OLD window's
+      // numbers. Flag it rather than dropping it — the dial carries the last
+      // reading forward — and never let it drive an alert downstream.
+      let anyStale = false;
+      for (const snap of results) {
+        for (const w of snap.windows) {
+          if (w.resetsAt != null && w.resetsAt <= nowMs) {
+            w.stale = true;
+            anyStale = true;
+          }
+        }
+      }
+      if (anyStale && !hadStale) {
+        console.log(`[usage] window past its reset instant — re-polling in ${staleRetryMs}ms`);
+        clearTimeout(staleRetry);
+        staleRetry = setTimeout(() => void tick(), staleRetryMs);
+        staleRetry?.unref?.();
+      }
+      hadStale = anyStale;
+
       snapshots = results;
       const key = contentKey(results);
       if (key !== lastContentKey) {
@@ -211,6 +247,7 @@ export function createUsagePoller({
   return {
     tick,
     stop() {
+      clearTimeout(staleRetry);
       stopped = true;
     },
     get snapshots() {

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -583,3 +583,74 @@ test("kimi adapter: detect() requires a non-empty key", async () => {
   assert.equal(await kimiAdapter.detect({ readKey: async () => null }), false);
   assert.equal(await kimiAdapter.detect({ readKey: async () => "" }), false);
 });
+
+// ----------------------------------------------------------------------------
+// Stale-window handling (BET-965)
+// ----------------------------------------------------------------------------
+
+test("poller: a window past its reset instant is published stale, values carried forward unchanged", async () => {
+  let nowMs = 1000;
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => ({
+      windows: [{ kind: "session", label: "s", pct: 78, used: 78, resetsAt: 500 }],
+    }),
+  });
+  const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs });
+  await poller.tick();
+  const w = poller.snapshots[0].windows[0];
+  assert.equal(w.stale, true);
+  assert.equal(w.pct, 78, "carry-forward must not alter the pct");
+  assert.equal(w.used, 78, "carry-forward must not alter reported absolutes");
+});
+
+test("poller: a window with resetsAt in the future has no stale key", async () => {
+  let nowMs = 1000;
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => ({ windows: [{ kind: "session", label: "s", pct: 50, resetsAt: 5000 }] }),
+  });
+  const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs });
+  await poller.tick();
+  const w = poller.snapshots[0].windows[0];
+  assert.equal("stale" in w, false, "future resetsAt must not attach stale (only-attach-when-true)");
+});
+
+test("poller: a window with no resetsAt is never marked stale", async () => {
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => ({ windows: [{ kind: "session", label: "s", pct: 50 }] }),
+  });
+  const poller = createUsagePoller({ adapters: [adapter], now: () => 1000 });
+  await poller.tick();
+  const w = poller.snapshots[0].windows[0];
+  assert.equal("stale" in w, false);
+});
+
+test("poller: first stale tick re-polls once; a second consecutive stale tick arms nothing (edge-only)", async () => {
+  let nowMs = 1000;
+  let fetchCalls = 0;
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => {
+      fetchCalls++;
+      return { windows: [{ kind: "session", label: "s", pct: 78, resetsAt: 500 }] };
+    },
+  });
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs, staleRetryMs: 5 });
+
+  await poller.tick(); // first stale tick → arms one retry
+  assert.equal(fetchCalls, 1);
+
+  await sleep(40); // the armed retry lands
+  assert.equal(fetchCalls, 2, "the false->true edge must trigger exactly one extra re-poll");
+
+  const before = fetchCalls;
+  await poller.tick(); // still stale, but hadStale is already true → no new arm
+  assert.equal(fetchCalls, before + 1, "an explicit tick still runs its fetch");
+  const afterManual = fetchCalls;
+
+  await sleep(40); // nothing was armed — no further fetch
+  assert.equal(fetchCalls, afterManual, "a second consecutive stale tick arms no further retry");
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1619,6 +1619,13 @@ export type UsageWindow = {
   limit?: number; // absolute cap when the provider exposes one
   resetsAt?: number; // epoch ms
   binding?: boolean; // the provider says this window bites first
+  // True when this reading describes a window whose reset instant has already
+  // passed: the provider has not published the new window's numbers yet, so
+  // `pct` still belongs to the window that just ended. Set by the poller
+  // (src/server/usage.mjs), never by an adapter. Consumers must not raise an
+  // alert from a stale window; the dial carries the last reading forward and
+  // labels it "resetting…" rather than blanking.
+  stale?: boolean;
 };
 export type UsageSnapshot = {
   provider: string; // adapter id: "claude" | "codex" | "kimi"


### PR DESCRIPTION
Fixes BET-965: an already-reset plan window must not fire a "limit reached" alert or a full-red dial.

## Symptom
At the reset boundary the provider still reports the just-ended window's percentage alongside a `resetsAt` that has already passed, so that reading drove both the ring colour and the escalation toast as if it were live.

## Two independent defects, both fixed
1. **No staleness guard** — the poller now flags a window `stale: true` when its reset instant has passed; the renderer never alerts from a stale window and carries the level forward instead of re-arming (which is what let the same limit fire twice).
2. **Fire-once baseline never seeded** — the mount-time prime now seeds the escalation baseline from the same payload that primes the dial, so the first live update after any launch no longer re-alerts for a window already over the threshold.

Plus: one fast re-poll (20s) armed on the stale edge (false→true) only; and the popover's reset line labels the past-reset case "resetting…" instead of showing nothing.

Per decisions 1/2/3/4 in the issue: stale windows carry forward (never blank / never reset to 0%), no new stale-specific ring style, staleness is computed only in the poller (never an adapter, never normalizeWindow), and the one-fast-re-poll is bounded by the edge rule (no retry counter).

Files changed (5 source + 3 test):

```
src/shared/types.ts                  |  7 ++
src/server/usage.mjs                 | 37 ++++++++++
src/renderer/usageEscalation.ts      | 17 +++++-
src/renderer/App.tsx                 | 10 +++++-
src/renderer/chatUtils.ts            |  9 +--
src/renderer/usageEscalation.test.ts | 47 +++++++
src/renderer/chatUtils.test.ts       |  8 +-
src/server/usage.test.mjs            | 71 ++++++++++++
```

No new dependency, no new file, no change to normalizeWindow.mjs or any adapter. Net source additions: 78 lines (< 90 budget).

**Verification results:**
- PR branch (`multica/BET-965-usage-stale-window` @ `4a638d52`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit 0, 2093 pass / 0 fail / 0 skip (first full run). Failures: none. log sha256: `a559d34d4a348981a820a98e65ace2b45750f0ebb032fcb8e11ffc9b4d037d837`
- Base (`main` @ `70739cc9`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit 0, 2089 pass / 0 fail / 0 skip. Failures: none. log sha256: `19d4e8514264dac76df7634fd5f3a39abec87d0006692e66bd1db26bf7171076`
- **Conclusion:** 0 new failures. (One teed run showed `src/server/pty.test.mjs` fail under full-suite load; it passes 10/10 in isolation and passed my first full run — pre-existing flake, unrelated to this PR.)

Logs cached at /tmp/typecheck-pr.log, /tmp/typecheck-main.log, /tmp/test-pr.log, /tmp/test-main.log.

Base: origin/main @ `70739cc9`
