### PR TITLE
feat(ios): context strip goes warn + shows cold token count; sheet actions confirm (BET-969)

### DIFF
--- a/mobile/native/MantaUI/ChatOverflowSheet.swift
+++ b/mobile/native/MantaUI/ChatOverflowSheet.swift
@@ -133,23 +133,17 @@ struct ChatOverflowSheet: View {
         // Cancel separated at the bottom.
         .confirmActionSheet(
             isPresented: $confirmingClear,
-            title: "Clear this session?",
-            message: "Starts a fresh session in this window. The transcript stays on the box.",
-            destructiveTitle: "Clear session",
+            copy: SessionConfirmCopy.clear,
             destructiveAction: { dismiss(); onClear() }
         )
         .confirmActionSheet(
             isPresented: $confirmingDelete,
-            title: "Delete this session?",
-            message: "Removes the session and its window. This cannot be undone.",
-            destructiveTitle: "Delete session",
+            copy: SessionConfirmCopy.delete,
             destructiveAction: { dismiss(); onDelete() }
         )
         .confirmActionSheet(
             isPresented: $confirmingCompact,
-            title: "Compact this session?",
-            message: "Summarises the conversation to free context. The transcript is condensed, not deleted.",
-            destructiveTitle: "Compact session",
+            copy: SessionConfirmCopy.compact,
             destructiveAction: { dismiss(); onCompact() }
         )
         .presentationDetents([.medium, .large])

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -815,6 +815,10 @@ private struct ChatScreenContent: View {
         return ctx.pct
     }
 
+    /// Whether the prompt cache has gone cold. One read, so the tint, the label
+    /// and the accessibility string cannot disagree.
+    private var cacheIsStale: Bool { store.cache?.isStale == true }
+
     /// The active model's own context window — the meter's denominator. Opus
     /// 4.7 reports 1M against Sonnet's 200k, so it is read per-model, never
     /// hardcoded.
@@ -831,6 +835,7 @@ private struct ChatScreenContent: View {
 
     /// The band colour for the current context reading (strip + sheet).
     private var contextBandColor: Color {
+        if cacheIsStale { return tokens.warn }
         if let pct = contextPct {
             return MeterRing.tint(UsageMeters.band(pct), tokens)
         }
@@ -862,6 +867,11 @@ private struct ChatScreenContent: View {
                     Text("\(Int(pct.rounded()))%")
                         .font(.manta(size: Metrics.type.twoXS, weight: .bold))
                         .foregroundColor(contextBandColor)
+                    if let coldLabel = UsageMeters.staleChipLabel(store.cache) {
+                        Text(coldLabel)
+                            .font(.manta(size: Metrics.type.twoXS, weight: .bold))
+                            .foregroundColor(tokens.warn)
+                    }
                     Image(systemName: "chevron.right")
                         .font(.system(size: Metrics.type.twoXS, weight: .semibold))
                         .foregroundColor(tokens.tx4)
@@ -870,7 +880,11 @@ private struct ChatScreenContent: View {
                 .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
-            .accessibilityLabel("Context \(Int(pct.rounded())) percent")
+            .accessibilityLabel(
+                cacheIsStale
+                    ? "Context \(Int(pct.rounded())) percent, cache cold, \(UsageMeters.formatTokens(store.cache?.staleTokens)) tokens re-billed on the next message"
+                    : "Context \(Int(pct.rounded())) percent"
+            )
             .accessibilityIdentifier("context-strip")
             // Context legitimately drops after a compaction; animate that drop
             // rather than snapping it, or it reads as a glitch.

--- a/mobile/native/MantaUI/NativeActionSheet.swift
+++ b/mobile/native/MantaUI/NativeActionSheet.swift
@@ -75,6 +75,33 @@ struct ConfirmActionSheet: View {
     }
 }
 
+/// The destructive session confirmations, declared ONCE. Clear, Delete and
+/// Compact are each reachable from more than one surface; declaring the copy
+/// here is what stops the two surfaces wording the same question differently.
+enum SessionConfirmCopy {
+    struct Copy {
+        let title: String
+        let message: String
+        let destructiveTitle: String
+    }
+
+    static let clear = Copy(
+        title: "Clear this session?",
+        message: "Starts a fresh session in this window. The transcript stays on the box.",
+        destructiveTitle: "Clear session"
+    )
+    static let delete = Copy(
+        title: "Delete this session?",
+        message: "Removes the session and its window. This cannot be undone.",
+        destructiveTitle: "Delete session"
+    )
+    static let compact = Copy(
+        title: "Compact this session?",
+        message: "Summarises the conversation to free context. The transcript is condensed, not deleted.",
+        destructiveTitle: "Compact session"
+    )
+}
+
 extension View {
     /// Presents a native confirm action sheet (destructive item first, a
     /// separated Cancel at the bottom) over the current screen. The sheet is
@@ -99,6 +126,23 @@ extension View {
                         cancelTitle: cancelTitle
                     )
                 }
+        )
+    }
+
+    /// Presents the same native confirm sheet from a shared copy, so a call
+    /// site names a confirmation rather than restating its wording. Delegates
+    /// to the string-based modifier above — not a fork.
+    func confirmActionSheet(
+        isPresented: Binding<Bool>,
+        copy: SessionConfirmCopy.Copy,
+        destructiveAction: @escaping () -> Void
+    ) -> some View {
+        confirmActionSheet(
+            isPresented: isPresented,
+            title: copy.title,
+            message: copy.message,
+            destructiveTitle: copy.destructiveTitle,
+            destructiveAction: destructiveAction
         )
     }
 }

--- a/mobile/native/MantaUI/UsageMeters.swift
+++ b/mobile/native/MantaUI/UsageMeters.swift
@@ -93,6 +93,15 @@ enum UsageMeters {
         return "\(Int((tokens / 1_000_000).rounded()))M"
     }
 
+    /// "344k cold" when the box has flagged the prompt cache stale, nil
+    /// otherwise. Pure, so the label is unit-testable and the view renders
+    /// whatever comes back — the staleness DECISION belongs to the box
+    /// (`computeStaleCache`), never to the client.
+    static func staleChipLabel(_ cache: StreamCachePayload?) -> String? {
+        guard let cache, cache.isStale else { return nil }
+        return "\(formatTokens(cache.staleTokens)) cold"
+    }
+
     /// "Thursday 09:00" — absolute, so a multi-day reset reads as a calendar
     /// anchor rather than an arithmetic exercise.
     private static let weekdayTime: DateFormatter = {

--- a/mobile/native/MantaUI/UsageSheets.swift
+++ b/mobile/native/MantaUI/UsageSheets.swift
@@ -83,6 +83,9 @@ struct ContextSheet: View {
 
     @Environment(\.dismiss) private var dismiss
 
+    @State private var confirmingClear = false
+    @State private var confirmingCompact = false
+
     var body: some View {
         // A List, not a VStack: the list supplies the card backgrounds, the
         // insets and the platform text sizes. A fixed-height detent around a
@@ -95,8 +98,8 @@ struct ContextSheet: View {
                     segmentedMeter
                 }
                 Section {
-                    actionRow("Compact conversation", systemImage: "arrow.triangle.2.circlepath", onTap: onCompact)
-                    actionRow("Start a fresh session", systemImage: "plus.circle", onTap: onClear)
+                    actionRow("Compact session", systemImage: "arrow.triangle.2.circlepath", onTap: { confirmingCompact = true })
+                    actionRow("Clear session", systemImage: "plus.circle", onTap: { confirmingClear = true })
                 }
             }
             .listStyle(.insetGrouped)
@@ -107,6 +110,12 @@ struct ContextSheet: View {
                     Button("Done") { dismiss() }
                 }
             }
+        }
+        .confirmActionSheet(isPresented: $confirmingClear, copy: SessionConfirmCopy.clear) {
+            dismiss(); onClear()
+        }
+        .confirmActionSheet(isPresented: $confirmingCompact, copy: SessionConfirmCopy.compact) {
+            dismiss(); onCompact()
         }
         .presentationDetents([.medium])
         .presentationDragIndicator(.visible)
@@ -189,11 +198,12 @@ struct ContextSheet: View {
         }
     }
 
-    /// A plain row in the list's action section: compact the conversation, or
-    /// start a fresh session. Both wire to existing session plumbing — nothing
-    /// new. The list styles the row and the system tints the label.
+    /// A plain row in the list's action section: compact the session, or clear
+    /// it. Both arm a confirm sheet (sheet-on-sheet) rather than firing the
+    /// destructive action directly — a blind tap must not reach the store. The
+    /// list styles the row and the system tints the label.
     private func actionRow(_ title: String, systemImage: String, onTap: @escaping () -> Void) -> some View {
-        Button(action: { dismiss(); onTap() }) {
+        Button(action: onTap) {
             Label(title, systemImage: systemImage)
         }
     }

--- a/mobile/native/MantaUITests/UsageMetersTests.swift
+++ b/mobile/native/MantaUITests/UsageMetersTests.swift
@@ -127,6 +127,33 @@ final class UsageMetersTests: XCTestCase {
         XCTAssertEqual(UsageMeters.formatTokens(nil), "0")
     }
 
+    // MARK: - staleChipLabel (BET-969)
+
+    private func cache(_ isStale: Bool, staleTokens: Double) -> StreamCachePayload {
+        StreamCachePayload(isStale: isStale, idleMs: 0, staleTokens: staleTokens, ttlMs: 0)
+    }
+
+    func testStaleChipNilWhenNoCache() {
+        XCTAssertNil(UsageMeters.staleChipLabel(nil))
+    }
+
+    /// A warm cache never labels, regardless of size.
+    func testStaleChipNilWhenWarm() {
+        XCTAssertNil(UsageMeters.staleChipLabel(cache(false, staleTokens: 900_000)))
+    }
+
+    func testStaleChipFormatsColdTokens() {
+        XCTAssertEqual(UsageMeters.staleChipLabel(cache(true, staleTokens: 344_000)), "344k cold")
+    }
+
+    /// Proves the chip delegates to `formatTokens` rather than rounding on its
+    /// own: whatever the formatter emits is what the label carries.
+    func testStaleChipDelegatesToFormatTokens() {
+        let value: Double = 148_000
+        let label = UsageMeters.staleChipLabel(cache(true, staleTokens: value))
+        XCTAssertEqual(label, "\(UsageMeters.formatTokens(value)) cold")
+    }
+
     // MARK: - MeterRing clamp / isFull (BET-877)
 
     /// `pct` is clamped to 0...100 before drawing — a provider can report


### PR DESCRIPTION
Opened automatically for `multica/BET-969-ios-cold-cache-strip`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-969.