### PR TITLE
BET-960: feat(renderer): onboarding never skips the provider step

### DIFF
--- a/src/renderer/Onboarding.tsx
+++ b/src/renderer/Onboarding.tsx
@@ -9,9 +9,8 @@
 //
 // Onboarding's responsibilities beyond the step machine:
 //
-//   1. Verify by working (BET-421 §B). After both steps complete (or after
-//      step 1 alone, when step 2 auto-skipped because a provider was already
-//      connected), `verifyOnboarding` spins up an EPHEMERAL opencode session
+//   1. Verify by working (BET-421 §B). After both steps complete,
+//      `verifyOnboarding` spins up an EPHEMERAL opencode session
 //      (no project, no sidebar entry), sends one probe prompt, waits for a
 //      real assistant reply, and deletes the session. Three named stages
 //      drive a ProcessPanel; on failure the user sees which stage failed +
@@ -25,8 +24,8 @@
 // Per-step bodies:
 //   - Step 1 (Connect)          → PairStep.tsx (SSH picker primary, manual
 //                                 disclosure secondary)
-//   - Step 2 (Connect provider) → ProvidersStep.tsx (auto-skips on mount
-//                                 when a provider is already connected)
+//   - Step 2 (Connect provider) → ProvidersStep.tsx (always shown; renders
+//                                 already-connected providers ticked)
 //   - Success                   → this file
 //
 // Those components own their own footers; the shell hides its generic
@@ -46,7 +45,6 @@ import { PairStep } from "./PairStep";
 import { ProvidersStep } from "./ProvidersStep";
 import {
   verifyOnboarding,
-  hasConnectedProvider,
   pickVerifyLabels,
   verifyStageLabels,
   type VerifyProgress,
@@ -209,9 +207,9 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
     });
   }, [refreshAndInstallTransport]);
 
-  // Step 1 → step 2 (provider needed) OR step 1 → runVerify (provider
-  // already connected). Detecting the latter before stepping forward keeps
-  // the user from blinking through an empty step-2 frame.
+  // Step 1 → step 2. The provider step is always shown; on a box that
+  // already has a provider connected, ProvidersStep displays it ticked and
+  // the user chooses to add more or continue.
   //
   // Failures are contained rather than propagated: this is invoked as
   // `void onPaired()`, so a rejection here is silent and freezes the wizard on
@@ -219,19 +217,13 @@ export function Onboarding({ onDone }: { onDone: () => void }) {
   // point, so we advance regardless — ProvidersStep surfaces its own load
   // error if the box is still unreachable.
   const onPaired = useCallback(async () => {
-    let connected = false;
     try {
       await refreshAndInstallTransport();
-      connected = await hasConnectedProvider(window.api);
     } catch (e) {
       console.warn("[manta] post-pair pre-flight failed; advancing anyway:", e);
     }
-    if (connected) {
-      await runVerify();
-    } else {
-      setPos(2);
-    }
-  }, [refreshAndInstallTransport, runVerify]);
+    setPos(2);
+  }, [refreshAndInstallTransport]);
 
   // Step 2 → verify (provider connect just landed → run the verify).
   const onProviderContinue = useCallback(() => {

--- a/src/renderer/ProvidersStep.test.tsx
+++ b/src/renderer/ProvidersStep.test.tsx
@@ -1,0 +1,73 @@
+// @vitest-environment jsdom
+//
+// Render-harness tests for ProvidersStep (BET-960). The provider step is
+// always shown: it must NOT auto-advance on mount, and it must render
+// already-connected providers ticked with Continue enabled.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { installMockApi, resetStore, mount, type Harness } from "./testHarness";
+import { ProvidersStep } from "./ProvidersStep";
+
+function noop() {
+  /* swallow */
+}
+
+describe("ProvidersStep render harness (BET-960)", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    installMockApi();
+    resetStore();
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function continueButton(): HTMLButtonElement | null {
+    const btns = Array.from(h!.container.querySelectorAll("button"));
+    return (
+      (btns.find((b) => b.textContent?.includes("Continue")) as
+        | HTMLButtonElement
+        | undefined) ?? null
+    );
+  }
+
+  it("does not advance on mount and enables Continue when one provider is connected", async () => {
+    installMockApi({
+      opencodeProviderAuth: () =>
+        Promise.resolve({
+          action: "status",
+          providers: [
+            { id: "anthropic", label: "Anthropic", plan: "Pro", connected: true },
+          ],
+        }),
+    });
+    const onContinue = vi.fn(noop);
+    h = mount(<ProvidersStep onBack={noop} onContinue={onContinue} />);
+    await h.flush();
+
+    expect(onContinue).not.toHaveBeenCalled();
+    expect(h.text()).toContain("Anthropic");
+    expect(h.text()).toContain("connected");
+    expect(continueButton()?.disabled).toBe(false);
+  });
+
+  it("keeps Continue disabled when zero providers are connected", async () => {
+    installMockApi({
+      opencodeProviderAuth: () =>
+        Promise.resolve({
+          action: "status",
+          providers: [
+            { id: "anthropic", label: "Anthropic", plan: "Pro", connected: false },
+          ],
+        }),
+    });
+    h = mount(<ProvidersStep onBack={noop} onContinue={noop} />);
+    await h.flush();
+
+    expect(h.text()).toContain("Anthropic");
+    expect(continueButton()?.disabled).toBe(true);
+  });
+});

--- a/src/renderer/ProvidersStep.tsx
+++ b/src/renderer/ProvidersStep.tsx
@@ -2,18 +2,14 @@
 // shell (BET-49-T4, BET-315, BET-356). Mounts into Onboarding.tsx's step-2
 // slot.
 //
-// BET-356 behaviour: this step auto-skips when the box already has a
-// connected provider. On mount, the step probes `opencodeProviderAuth
-// ({action: "status"})`; if any row reports `connected: true` it calls
-// `onContinue()` immediately and renders nothing. The user sees step 2
-// for at most one frame on a resumed flow with a pre-connected box.
-//
-// When zero providers are connected, the step renders the registry-driven
+// The provider step is always shown. On mount, the step probes
+// `opencodeProviderAuth ({action: "status"})` and renders the registry-driven
 // connect list (one row per provider declared in
-// src/server/subscriptionProviders.mjs). Each Connect delegates to the
-// shared <ConnectProvider> card (BET-312, BET-354) — same component the
-// Settings → Subscriptions card consumes, so an in-app Anthropic sign-in
-// works identically here and there.
+// src/server/subscriptionProviders.mjs). A box that already has a connected
+// provider shows that row ticked with "connected"; the user can add more or
+// continue. Each Connect delegates to the shared <ConnectProvider> card
+// (BET-312, BET-354) — same component the Settings → Subscriptions card
+// consumes, so an in-app Anthropic sign-in works identically here and there.
 //
 // Helpers (canContinueProviders) used to live in `providersStepLogic.ts`;
 // they're now inlined because that file became dead weight after the model
@@ -25,7 +21,7 @@
 // `canContinueProviders(statuses)` is still the Continue gate — a
 // subscription connected seconds ago counts immediately because the same
 // `status` action drives the row badges and the gate, by construction
-// (BET-315). The shell's auto-skip on mount relies on the same probe.
+// (BET-315).
 //
 // Props:
 //   onBack     — go to the previous step (Connect).
@@ -61,16 +57,11 @@ export function ProvidersStep({
 }) {
   const [statuses, setStatuses] = useState<SubscriptionStatus[] | null>(null);
   const [loadError, setLoadError] = useState<string | null>(null);
-  const [autoSkipped, setAutoSkipped] = useState(false);
   // Exactly one row can be mid-mutation at a time.
   const [connectingId, setConnectingId] = useState<string | null>(null);
   const [showCustom, setShowCustom] = useState(false);
 
-  // Refresh + auto-skip on mount. The auto-skip path calls `onContinue`
-  // exactly once (latched via `autoSkipped`) so a late-arriving status
-  // response after the auto-skip fires cannot double-advance the shell.
-  // The shell's own progress dot math already collapses a "step 2 for
-  // one frame" jump — the user sees no flicker.
+  // Refresh on mount (and after a custom provider save / connect done).
   const refresh = useCallback(async () => {
     setLoadError(null);
     if (typeof window.api.opencodeProviderAuth !== "function") {
@@ -86,18 +77,11 @@ export function ProvidersStep({
         return;
       }
       setStatuses(res.providers);
-      // Auto-skip: with at least one provider connected, this step is
-      // done before the user sees it. Latch so a re-fetch (e.g. after a
-      // custom provider save) cannot fire onContinue a second time.
-      if (!autoSkipped && res.providers.some((p) => p.connected)) {
-        setAutoSkipped(true);
-        onContinue();
-      }
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : String(e));
       setStatuses([]);
     }
-  }, [autoSkipped, onContinue]);
+  }, [onContinue]);
 
   useEffect(() => {
     void refresh();
@@ -112,11 +96,6 @@ export function ProvidersStep({
     },
     [refresh],
   );
-
-  // Render nothing while the auto-skip path is in flight (the shell will
-  // have already advanced). Returning null here is what keeps the user
-  // from seeing a flash of the provider list before onContinue fires.
-  if (autoSkipped) return null;
 
   return (
     <div>
@@ -137,6 +116,10 @@ export function ProvidersStep({
             Retry
           </button>
         </div>
+      )}
+
+      {statuses === null && !loadError && (
+        <div className="text-body text-text-faint">Checking connected providers…</div>
       )}
 
       {/* Subscriptions — one row per provider from the registry. */}

--- a/src/renderer/onboardingUtils.ts
+++ b/src/renderer/onboardingUtils.ts
@@ -61,10 +61,9 @@ export function prevPosition(pos: OnboardingPosition): OnboardingPosition {
 // onboarding concerns. What we CAN tell from config alone is whether the box
 // is paired. Whether a provider is connected is a live box query, NOT a
 // config field, so we resolve to step 2 whenever paired and let the Provider
-// step's mount effect auto-advance past itself when a provider is already
-// connected. Net: re-entering onboarding on a paired box lands on step 2 for
-// at most one frame, then auto-skips to success — the user sees no flicker
-// because step 2's "ready" path is empty rendering.
+// step hold the screen: it probes the box on mount and renders whatever is
+// already connected, letting the user add more or continue. Net:
+// re-entering onboarding on a paired box always lands on step 2.
 //
 // The 32-hex boxToken gate mirrors the transport-mode detection in
 // `resolveTransportMode`, so a malformed token does not falsely advance the

--- a/src/renderer/onboardingVerify.test.ts
+++ b/src/renderer/onboardingVerify.test.ts
@@ -5,7 +5,6 @@ import {
   VERIFY_DEFAULT_TIMEOUT_MS,
   verifyStageLabels,
   verifyOnboarding,
-  hasConnectedProvider,
   pickVerifyLabels,
   type VerifyApi,
 } from "./onboardingVerify";
@@ -221,28 +220,6 @@ describe("verifyOnboarding", () => {
       expect(out.message).toContain("didn't reply");
     }
     expect(api.opencodeDeleteSessionRaw).toHaveBeenCalledWith("eph-1");
-  });
-});
-
-describe("hasConnectedProvider", () => {
-  it("returns true when at least one provider is connected", async () => {
-    const api = makeApi({
-      opencodeProviderAuth: (vi.fn(async () => ({
-        action: "status",
-        providers: [{ id: "anthropic", connected: false }, { id: "openai", connected: true }],
-      })) as unknown) as VerifyApi["opencodeProviderAuth"],
-    });
-    expect(await hasConnectedProvider(api)).toBe(true);
-  });
-
-  it("returns false when nothing is connected", async () => {
-    const api = makeApi({
-      opencodeProviderAuth: (vi.fn(async () => ({
-        action: "status",
-        providers: [{ id: "anthropic", connected: false }],
-      })) as unknown) as VerifyApi["opencodeProviderAuth"],
-    });
-    expect(await hasConnectedProvider(api)).toBe(false);
   });
 });
 

--- a/src/renderer/onboardingVerify.ts
+++ b/src/renderer/onboardingVerify.ts
@@ -181,29 +181,6 @@ export async function verifyOnboarding(deps: {
   }
 }
 
-// ---------- pre-connect provider check ----------
-
-// Quick `is there at least one provider connected` probe — used by the
-// Connect step to decide whether to skip step 2 entirely. Same source
-// (`opencodeProviderAuth({action:"status"})`) that ProvidersStep consumes
-// for its Continue gate, so the two paths agree by construction.
-export async function hasConnectedProvider(api: VerifyApi): Promise<boolean> {
-  try {
-    const res = await api.opencodeProviderAuth({ action: "status" });
-    if (!res || typeof res !== "object") return false;
-    const providers = (res as { providers?: unknown }).providers;
-    if (!Array.isArray(providers)) return false;
-    return providers.some(
-      (p) =>
-        typeof p === "object" &&
-        p !== null &&
-        (p as { connected?: unknown }).connected === true,
-    );
-  } catch {
-    return false;
-  }
-}
-
 // Resolve a (providerLabel, modelLabel) pair for the stage labels from the
 // status probe. The first connected provider's label + the configured
 // default model. Pure so the test can assert; returns nulls when nothing


### PR DESCRIPTION
## What

Removes the three mechanisms that made onboarding skip the provider step on a box that already had a provider connected. The provider step is now always shown.

**Deletions**
- `src/renderer/ProvidersStep.tsx`: removed `autoSkipped` state, the mount-time auto-skip (`onContinue` fire when any provider is connected), the `if (autoSkipped) return null` early return, and its dep-array slot; rewrote the header comment that documented the auto-skip as headline behaviour.
- `src/renderer/Onboarding.tsx`: `onPaired` now always advances to step 2 (`setPos(2)`) after the existing try/catch around `refreshAndInstallTransport`; deleted the `hasConnectedProvider` probe and the `connected ? runVerify() : setPos(2)` branch. Dropped `hasConnectedProvider` from the import; updated the header comments.
- `src/renderer/onboardingVerify.ts`: deleted `hasConnectedProvider` (now consumerless) and its test cases.

**Addition**
- `ProvidersStep.tsx`: renders `Checking connected providers…` while the status probe is in flight (`statuses === null && !loadError`), above the provider list.

**Explicitly unchanged**: `canContinueProviders` / the Continue gate, connected-row green-check + "connected" label, `runVerify` (still fired only from `onProviderContinue`), the custom-endpoint disclosure and `CustomProviderForm`.

**Tests**
- New `src/renderer/ProvidersStep.test.tsx` (jsdom): one connected provider → `onContinue` NOT called on mount, provider row in DOM, Continue enabled; zero connected → Continue disabled.

**Files changed:** `6` files. `src/renderer/{Onboarding.tsx, ProvidersStep.tsx, ProvidersStep.test.tsx, onboardingUtils.ts, onboardingVerify.ts, onboardingVerify.test.ts}`
- PR branch (`multica/BET-960-onboarding-never-skip-provider` @ `66e0146`):
  - typecheck: exit 0. Errors: none. log sha256: `bf033d003056c6c0f8d888e97b0a95849c0f195856d6d5eb8b4a8759c2e1a308`
  - test: exit 0, 2102 pass / 0 fail / 0 skip. Failures: none. log sha256: `a9a0a024938942c8567f3f38844b68c1e6d0b45fe499ab1f92933764cf160f5f`
- Base (`main` @ `fe468ca`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit 0, 2102 pass / 0 fail / 0 skip. Failures: none. log sha256: `8b767482973dbf5204c303fabb3e530315f2e55a82fbda59f5e904d2683041a0`
- **Conclusion:** 0 new failures, 0 pre-existing (identical between branches); this PR adds 2 new passing tests.

Base: `origin/main @ fe468ca`
