### PR TITLE
refactor(ios): mirror the shared reset-time rules and follow the device locale (BET-967)

### DIFF
--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -449,6 +449,12 @@ struct UsageWindow: Codable, Equatable, Sendable {
     /// Epoch milliseconds of the reset.
     var resetsAt: Double? = nil
     var binding: Bool? = nil
+    /// True when this reading describes a window whose reset instant has already
+    /// passed — the provider has not published the new window's numbers yet, so
+    /// `pct` still belongs to the window that just ended. Set by the box's usage
+    /// poller (src/server/usage.mjs). Never raise a warning from a stale window;
+    /// carry the last reading forward and label it.
+    var stale: Bool? = nil
 }
 
 /// One provider's full `usage:list` snapshot.

--- a/mobile/native/MantaUI/UsageMeters.swift
+++ b/mobile/native/MantaUI/UsageMeters.swift
@@ -60,26 +60,62 @@ enum UsageMeters {
     /// Whether the one-per-session weekly warning banner should show: the
     /// weekly window exists AND is ≥ 90% AND has not already been shown this
     /// session. It is the only thing standing between a green 5-hour dot and
-    /// a multi-day lockout the user did not see coming.
+    /// a multi-day lockout the user did not see coming. A STALE window (whose
+    /// reset instant has already passed) never raises the ≥90% banner — the
+    /// numbers still belong to a window that has ended.
     static func shouldShowWeeklyBanner(_ weekly: UsageWindow?, alreadyShown: Bool) -> Bool {
         guard let weekly, !alreadyShown else { return false }
+        if weekly.stale == true { return false }
         return weekly.pct >= 90
     }
 
-    /// Compact reset label under 24h ("in 4h 12m"); absolute weekday + time
-    /// ("Thursday 09:00") at 24h and beyond — the format the sheet and the
-    /// banner both use, the caller supplying cap/case.
+    /// The relative "how far away" reset distance, floored to at most two
+    /// units — "45m" / "2h 10m" / "2d 4h". Mirrors the desktop
+    /// `formatResetDistance` one-to-one so both clients print the same string
+    /// for the same input. Pure arithmetic — no locale involvement.
+    static func resetDistance(_ seconds: Int) -> String {
+        if seconds <= 0 { return "now" }
+        if seconds < 60 { return "under a minute" }
+        let m = seconds / 60
+        if seconds < 3600 { return "\(m)m" }
+        let h = m / 60
+        let mm = m % 60
+        if seconds < 86400 {
+            return mm == 0 ? "\(h)h" : "\(h)h \(mm)m"
+        }
+        let d = seconds / 86400
+        let hh = (seconds % 86400) / 3600
+        return hh == 0 ? "\(d)d" : "\(d)d \(hh)h"
+    }
+
+    /// The absolute anchor: "09:00" (same local calendar day), "Thu 09:00"
+    /// (< 7 days away), or "Thu 21 Aug 09:00" otherwise — device locale, never
+    /// a hardcoded pattern. Mirrors the desktop `formatResetAt`.
+    static func resetAt(_ resetsAt: Date, now: Date) -> String {
+        let calendar = Calendar.current
+        if calendar.isDate(resetsAt, inSameDayAs: now) {
+            return Self.resetTimeFmt.string(from: resetsAt)
+        }
+        if resetsAt.timeIntervalSince(now) < 7 * 86400 {
+            return Self.resetDayTimeFmt.string(from: resetsAt)
+        }
+        return Self.resetDateTimeFmt.string(from: resetsAt)
+    }
+
+    /// The sheet/banner reset line (the caller already supplies the "resets "
+    /// prefix): "in 2h 10m", with an absolute anchor appended only when the
+    /// reset is NOT on the same local calendar day. A reset instant that has
+    /// already passed reads "resetting…" — the dot carries the old number
+    /// forward while the provider catches up (BET-965/967). Mirrors the
+    /// desktop `formatWindowReset`.
     static func formatReset(_ resetsAt: Date, now: Date) -> String {
         let seconds = Int(resetsAt.timeIntervalSince(now))
-        if seconds > 0 && seconds < 24 * 3600 {
-            let hours = seconds / 3600
-            let minutes = (seconds % 3600) / 60
-            if hours >= 1 {
-                return minutes > 0 ? "in \(hours)h \(minutes)m" : "in \(hours)h"
-            }
-            return "in \(max(1, minutes))m"
+        if seconds <= 0 { return "resetting…" }
+        let line = "in " + resetDistance(seconds)
+        if Calendar.current.isDate(resetsAt, inSameDayAs: now) {
+            return line
         }
-        return Self.weekdayTime.string(from: resetsAt)
+        return line + " (" + resetAt(resetsAt, now: now) + ")"
     }
 
     /// "824k" / "1M" / "148k" — the compact token-count display for the
@@ -102,12 +138,20 @@ enum UsageMeters {
         return "\(formatTokens(cache.staleTokens)) cold"
     }
 
-    /// "Thursday 09:00" — absolute, so a multi-day reset reads as a calendar
-    /// anchor rather than an arithmetic exercise.
-    private static let weekdayTime: DateFormatter = {
+    // MARK: - Reset-time absolute formatters (BET-967)
+
+    // OS locale on purpose (autoupdatingCurrent), and the TEMPLATE chooses
+    // 12- vs 24-hour from the device — never a literal "HH:mm" pattern and
+    // never a fixed POSIX locale. That single rule is what stops iOS
+    // contradicting the desktop reset line.
+    private static let resetTimeFmt: DateFormatter = Self.makeFmt(template: "jmm")
+    private static let resetDayTimeFmt: DateFormatter = Self.makeFmt(template: "Ejmm")
+    private static let resetDateTimeFmt: DateFormatter = Self.makeFmt(template: "EMMMdjmm")
+
+    private static func makeFmt(template: String) -> DateFormatter {
         let f = DateFormatter()
-        f.locale = Locale(identifier: "en_US_POSIX")
-        f.dateFormat = "EEEE HH:mm"
+        f.locale = Locale.autoupdatingCurrent
+        f.setLocalizedDateFormatFromTemplate(template)
         return f
-    }()
+    }
 }

--- a/mobile/native/MantaUITests/UsageMetersTests.swift
+++ b/mobile/native/MantaUITests/UsageMetersTests.swift
@@ -5,7 +5,8 @@ import XCTest
 // BET-824 — pure decisions of the plan + context meters (UsageMeters). No view,
 // no HTTP, no box. Tests every boundary exactly: 69.9/70/89.9/90, a missing
 // value rendering nothing (sessionWindow nil), a snapshot holding only a
-// weekly window, and `formatReset` under and over 24h.
+// weekly window, the reset-distance ladder (BET-967) and the stale-window
+// banner gate (BET-965/967).
 // ===========================================================================
 
 final class UsageMetersTests: XCTestCase {
@@ -86,35 +87,72 @@ final class UsageMetersTests: XCTestCase {
         XCTAssertFalse(UsageMeters.shouldShowWeeklyBanner(nil, alreadyShown: false))
     }
 
-    // MARK: - formatReset (under / over 24h)
-
-    func testFormatResetUnder24h() {
-        let now = Date(timeIntervalSince1970: 1_700_000_000)
-        let resetsAt = now.addingTimeInterval(4 * 3600 + 12 * 60)
-        XCTAssertEqual(UsageMeters.formatReset(resetsAt, now: now), "in 4h 12m")
+    /// A STALE weekly window (reset instant already passed, provider hasn't
+    /// published the new numbers yet) must not raise the ≥90% banner — the pct
+    /// still belongs to the window that just ended (BET-965/967).
+    func testBannerHiddenWhenWeeklyStale() {
+        var weekly = window("weekly", pct: 95)
+        weekly.stale = true
+        XCTAssertFalse(UsageMeters.shouldShowWeeklyBanner(weekly, alreadyShown: false))
     }
 
-    func testFormatResetUnderAnHour() {
-        let now = Date(timeIntervalSince1970: 1_700_000_000)
-        let resetsAt = now.addingTimeInterval(45 * 60)
-        XCTAssertEqual(UsageMeters.formatReset(resetsAt, now: now), "in 45m")
+    /// Sanity: a FRESH 95% window still raises the banner even at the same pct.
+    func testBannerShownWhenWeeklyFresh() {
+        let weekly = window("weekly", pct: 95)
+        XCTAssertTrue(UsageMeters.shouldShowWeeklyBanner(weekly, alreadyShown: false))
     }
 
-    /// Exactly 24h is NOT under 24h — it flips to the absolute weekday form.
-    func testFormatResetAt24hIsAbsolute() {
-        let now = Date(timeIntervalSince1970: 1_700_000_000)
-        let resetsAt = now.addingTimeInterval(24 * 3600)
+    // MARK: - resetDistance (exact desktop ladder — BET-966/967)
+
+    /// Exact strings, mirroring the desktop `formatResetDistance` table
+    /// including the drop-zero and the motivating 140h 12m cases.
+    func testResetDistanceExactLadder() {
+        XCTAssertEqual(UsageMeters.resetDistance(0), "now")
+        XCTAssertEqual(UsageMeters.resetDistance(-5), "now")
+        XCTAssertEqual(UsageMeters.resetDistance(30), "under a minute")
+        XCTAssertEqual(UsageMeters.resetDistance(45 * 60), "45m")
+        XCTAssertEqual(UsageMeters.resetDistance(2 * 3600 + 10 * 60), "2h 10m")
+        XCTAssertEqual(UsageMeters.resetDistance(3 * 3600), "3h")
+        XCTAssertEqual(UsageMeters.resetDistance(26 * 3600), "1d 2h")
+        XCTAssertEqual(UsageMeters.resetDistance(48 * 3600), "2d")
+        XCTAssertEqual(UsageMeters.resetDistance(140 * 3600 + 12 * 60), "5d 20h")
+    }
+
+    // MARK: - resetAt / formatReset (shape only — locale-fixed, BET-967)
+
+    /// The absolute anchor is device-locale: all three tiers render non-empty,
+    /// and the same-day tier carries no calendar date.
+    func testResetAtTiersNonEmpty() {
+        let now = Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: Date())!
+        XCTAssertFalse(UsageMeters.resetAt(now.addingTimeInterval(2 * 3600), now: now).isEmpty)
+        XCTAssertFalse(UsageMeters.resetAt(now.addingTimeInterval(24 * 3600), now: now).isEmpty)
+        XCTAssertFalse(UsageMeters.resetAt(now.addingTimeInterval(10 * 24 * 3600), now: now).isEmpty)
+    }
+
+    /// A same-local-day reset has no anchor — no "(" — and reads "in <distance>".
+    func testFormatResetSameDayNoAnchor() {
+        let now = Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: Date())!
+        let resetsAt = now.addingTimeInterval(2 * 3600)
         let result = UsageMeters.formatReset(resetsAt, now: now)
-        XCTAssertFalse(result.hasPrefix("in "), "24h+ must be an absolute weekday, not a relative countdown")
-        XCTAssertTrue(result.contains(":"), "weekday form is 'Thursday 09:00'")
+        XCTAssertFalse(result.contains("("), "same-day reset must not append an anchor, got: \(result)")
+        XCTAssertTrue(result.contains(UsageMeters.resetDistance(Int(resetsAt.timeIntervalSince(now)))))
     }
 
-    func testFormatResetBeyond24h() {
-        let now = Date(timeIntervalSince1970: 1_700_000_000)
+    /// A cross-day reset appends " (…)" and still contains the distance.
+    func testFormatResetCrossDayHasAnchor() {
+        let now = Calendar.current.date(bySettingHour: 12, minute: 0, second: 0, of: Date())!
         let resetsAt = now.addingTimeInterval(3 * 24 * 3600)
         let result = UsageMeters.formatReset(resetsAt, now: now)
-        XCTAssertFalse(result.hasPrefix("in "))
-        XCTAssertTrue(result.contains(":"))
+        XCTAssertTrue(result.contains("("), "cross-day reset must append an anchor, got: \(result)")
+        XCTAssertTrue(result.contains(")"))
+        XCTAssertTrue(result.contains(UsageMeters.resetDistance(Int(resetsAt.timeIntervalSince(now)))))
+    }
+
+    /// A reset instant that has already passed reads exactly "resetting…".
+    func testFormatResetPastIsResetting() {
+        let now = Date()
+        let resetsAt = now.addingTimeInterval(-60)
+        XCTAssertEqual(UsageMeters.formatReset(resetsAt, now: now), "resetting…")
     }
 
     // MARK: - formatTokens


### PR DESCRIPTION
Opened automatically for `multica/BET-967-ios-reset-time-mirror`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-967.