### PR TITLE
feat(renderer): consolidate onboarding step 1 into one four-zone Connect panel (BET-961)

### DIFF
--- a/src/renderer/ConnectPanel.test.tsx
+++ b/src/renderer/ConnectPanel.test.tsx
@@ -1,0 +1,123 @@
+// @vitest-environment jsdom
+//
+// ConnectPanel render tests (BET-961). This component is presentational —
+// it renders a ConnectPanelState descriptor plus a target ReactNode, log
+// lines and an onAction callback. These tests pin the three behaviours the
+// acceptance criteria call out:
+//   1. Zone C is absent when details.kind === "none" and there are no
+//      prompt children — no empty placeholder row.
+//   2. The first action renders as the primary button; the rest as default.
+//   3. The status meta renders in zone B.
+//
+// Pattern from PairStep.test.tsx (uses the shared render harness).
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { ConnectPanel } from "./ConnectPanel";
+import type { ConnectPanelState } from "./connectPanel";
+
+function makeState(patch: Partial<ConnectPanelState> = {}): ConnectPanelState {
+  return {
+    status: {
+      tone: "idle",
+      text: "Ready to install",
+      meta: null,
+      progress: null,
+      sub: null,
+    },
+    details: { kind: "none" },
+    actions: ["install"],
+    hint: null,
+    targetLocked: false,
+    ...patch,
+  };
+}
+
+function renderPanel(state: ConnectPanelState, children?: React.ReactNode) {
+  return mount(
+    <ConnectPanel
+      state={state}
+      target={<div>target-zone</div>}
+      logLines={[]}
+      onAction={() => {}}
+    >
+      {children}
+    </ConnectPanel>,
+  );
+}
+
+describe("ConnectPanel (BET-961)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("omits zone C entirely when details.kind === 'none' and there are no children", () => {
+    h = renderPanel(makeState());
+    // No zone-C surface: no log toggle, no failures copy, no hint/detail body.
+    expect(h.text()).not.toContain("Show log");
+    expect(h.text()).not.toContain("Hide log");
+    expect(h.text()).not.toContain("Nothing was installed or changed");
+    // Zone A + zone B + zone D still render.
+    expect(h.text()).toContain("target-zone");
+    expect(h.text()).toContain("Ready to install");
+  });
+
+  it("renders zone C when a prompt child is present even with details.kind === 'none'", () => {
+    h = renderPanel(makeState(), <div>Trust this host?</div>);
+    expect(h.text()).toContain("Trust this host?");
+  });
+
+  it("renders the status meta in zone B", () => {
+    h = renderPanel(
+      makeState({
+        status: {
+          tone: "running",
+          text: "Installing files",
+          meta: "3 of 6 · 0:24",
+          progress: 0.5,
+          sub: null,
+        },
+      }),
+    );
+    expect(h.text()).toContain("3 of 6 · 0:24");
+    expect(h.text()).toContain("Installing files");
+  });
+
+  it("renders the first action as the primary button and the rest as default", () => {
+    h = renderPanel(makeState({ actions: ["install", "cancel"] }));
+    const buttons = Array.from(h.container.querySelectorAll("button"));
+    expect(buttons.length).toBe(2);
+    // Primary (first) carries the filled accent tone; secondary (default) does not.
+    expect(buttons[0].className).toContain("bg-accent-solid");
+    expect(buttons[1].className).not.toContain("bg-accent-solid");
+    expect(buttons[0].textContent).toBe("Install & pair");
+    expect(buttons[1].textContent).toBe("Cancel");
+  });
+
+  it("labels the pairManually action 'Enter code manually' when it is the primary", () => {
+    h = renderPanel(makeState({ actions: ["pairManually", "retry"] }));
+    const buttons = Array.from(h.container.querySelectorAll("button"));
+    expect(buttons[0].textContent).toBe("Enter code manually");
+    expect(buttons[1].textContent).toBe("Try again");
+  });
+
+  it("renders the 'next' hint right-aligned in zone D", () => {
+    h = renderPanel(
+      makeState({
+        status: {
+          tone: "ok",
+          text: "Connected — your box is ready",
+          meta: "6 of 6 · 1:12",
+          progress: 1,
+          sub: null,
+        },
+        actions: ["next"],
+        hint: "next: connect a provider",
+      }),
+    );
+    expect(h.text()).toContain("next: connect a provider");
+    expect(h.text()).toContain("Next →");
+  });
+});

--- a/src/renderer/ConnectPanel.tsx
+++ b/src/renderer/ConnectPanel.tsx
@@ -70,7 +70,7 @@ function renderHintSegments(text: string) {
       return (
         <code
           key={i}
-          className="font-mono text-label bg-inset rounded-xs px-1.5 py-px text-text-muted"
+          className="font-mono text-label bg-bg rounded-xs px-2 py-px text-text-muted"
         >
           {part.slice(1, -1)}
         </code>
@@ -165,7 +165,7 @@ export function ConnectPanel({
           )}
         </div>
         {status.progress !== null && (
-          <div className="h-[3px] rounded-full bg-border-subtle mt-2.5 overflow-hidden">
+          <div className="h-[3px] rounded-full bg-border-subtle mt-3 overflow-hidden">
             <div
               className="h-full rounded-full transition-[width] duration-300"
               style={{
@@ -202,7 +202,7 @@ export function ConnectPanel({
                 {logOpen && (
                   <div
                     ref={logRef}
-                    className="mt-2 bg-inset border border-border-subtle rounded-sm px-3 py-2 font-mono text-meta text-text-faint overflow-y-auto"
+                    className="mt-2 bg-bg-elev border border-border-subtle rounded-sm px-3 py-2 font-mono text-meta text-text-faint overflow-y-auto"
                     style={{ maxHeight: 172 }}
                   >
                     {logLines.map((l, i) => (

--- a/src/renderer/ConnectPanel.tsx
+++ b/src/renderer/ConnectPanel.tsx
@@ -1,0 +1,267 @@
+// ConnectPanel.tsx — the consolidated four-zone onboarding step-1 panel
+// (BET-961). Renders the ConnectPanelState descriptor that connectPanel.ts
+// derives from SshInstallStep's state.
+//
+// One panel, four fixed zones, in a fixed order: A·target (the host picker
+// ReactNode passed in), B·status (tone, text, meta, bar, sub), C·details
+// (log / failures / hint — or the inline prompt children), D·actions
+// (primary + at most one secondary, plus an optional right-aligned hint).
+// Nothing moves between states; every state reuses the same four slots.
+//
+// Presentational only: the only local state is the log open/closed toggle,
+// which auto-resets to each state's `defaultOpen` when the details phase
+// changes. Every colour/size/radius below maps to an existing token.
+
+import { useEffect, useRef, useState, type ReactNode } from "react";
+import { ChevronUp, ChevronDown } from "lucide-react";
+import { Button } from "./Button";
+import type { ConnectActionId, ConnectPanelState } from "./connectPanel";
+
+// ---- tone -> colour maps: the ONLY place tone becomes colour ----
+const DOT: Record<string, string> = {
+  idle: "bg-text-quiet",
+  neutral: "bg-text-quiet",
+  running: "bg-accent animate-pulse",
+  attention: "bg-warn animate-pulse",
+  ok: "bg-ok",
+  error: "bg-danger",
+};
+const TEXT: Record<string, string> = {
+  idle: "text-text-faint",
+  neutral: "text-text-faint",
+  running: "text-text",
+  attention: "text-warn",
+  ok: "text-ok",
+  error: "text-danger",
+};
+const BAR: Record<string, string> = {
+  idle: "var(--accent)",
+  neutral: "var(--accent)",
+  running: "var(--accent)",
+  attention: "var(--accent)",
+  ok: "var(--ok)",
+  error: "var(--danger)",
+};
+
+const ACTION_LABEL: Record<ConnectActionId, string> = {
+  install: "Install & pair",
+  cancel: "Cancel",
+  next: "Next →",
+  retry: "Try again",
+  editTarget: "Edit target",
+  pairManually: "Pair manually",
+};
+
+function actionLabel(id: ConnectActionId, index: number): string {
+  // Row 4 leads with "Enter code manually", row 5 trails with "Pair manually".
+  // The pairManually action's label depends on whether it's the primary — the
+  // exact distinction the table encodes.
+  if (id === "pairManually" && index === 0) return "Enter code manually";
+  return ACTION_LABEL[id];
+}
+
+/**
+ * Split a hint on backtick-delimited code spans so `manta pair` renders as
+ * inline <code>. Generic — any future backticked command works too.
+ */
+function renderHintSegments(text: string) {
+  return text.split(/(`[^`]+`)/g).map((part, i) => {
+    if (part.startsWith("`") && part.endsWith("`")) {
+      return (
+        <code
+          key={i}
+          className="font-mono text-label bg-inset rounded-xs px-1.5 py-px text-text-muted"
+        >
+          {part.slice(1, -1)}
+        </code>
+      );
+    }
+    return <span key={i}>{part}</span>;
+  });
+}
+
+export function ConnectPanel({
+  state,
+  target,
+  logLines,
+  onAction,
+  children,
+  onCopyDiagnostics,
+}: {
+  state: ConnectPanelState;
+  /** Zone A body — the host picker. Placed inside the panel's zone A. */
+  target: ReactNode;
+  /** Live install log lines for the zone-C log pane. */
+  logLines: string[];
+  onAction: (id: ConnectActionId) => void;
+  /** Zone-C prompt slot (fingerprint / passphrase cards). */
+  children?: ReactNode;
+  /** Wires the "Copy diagnostics" button (shown only on install failure). */
+  onCopyDiagnostics?: () => void | Promise<void>;
+}): JSX.Element {
+  const { status, details, actions, hint } = state;
+
+  // Log open/closed toggle, auto-reset to each details phase's defaultOpen.
+  const [logOpen, setLogOpen] = useState(
+    details.kind === "log" ? details.defaultOpen : false,
+  );
+  const logRef = useRef<HTMLDivElement | null>(null);
+
+  // Reset the toggle when the details PHASE changes (kind / defaultOpen /
+  // copy flag), not on every re-render — the derived `details` object is
+  // fresh each render (elapsed-seconds ticks), so comparing identities is
+  // useless; compare the phase-relevant fields instead. This is what auto-
+  // opens the log on failure ("row 5") while leaving the user free to open/
+  // close it during an install without the next tick slamming it shut.
+  const prevDetailsRef = useRef(details);
+  useEffect(() => {
+    const prev = prevDetailsRef.current;
+    let phaseChanged = prev.kind !== details.kind;
+    if (!phaseChanged && details.kind === "log" && prev.kind === "log") {
+      phaseChanged =
+        prev.defaultOpen !== details.defaultOpen ||
+        prev.showCopyDiagnostics !== details.showCopyDiagnostics;
+    }
+    if (phaseChanged) {
+      setLogOpen(details.kind === "log" ? details.defaultOpen : false);
+    }
+    prevDetailsRef.current = details;
+  }, [details]);
+
+  // Auto-scroll the log to the bottom on new lines (matches ProcessPanel).
+  useEffect(() => {
+    if (logOpen && logRef.current && logLines.length > 0) {
+      logRef.current.scrollTop = logRef.current.scrollHeight;
+    }
+  }, [logLines, logOpen]);
+
+  // Row 9/10 (hosts not loaded / invalid target) and row 3 (cancelled, meta
+  // set) all offer `install`. The only ready one is row 11, which is the only
+  // one that carries the "takes about a minute" hint and no in-flight meta —
+  // that combination is exactly when the button becomes clickable.
+  const installDisabled = status.progress === null && !hint;
+
+  const showZoneC = details.kind !== "none" || Boolean(children);
+
+  return (
+    <section className="bg-bg-elev border border-border rounded-lg overflow-hidden shadow-sm">
+      {/* ZONE A — target (host picker) */}
+      <div className="px-4 py-3 border-b border-border-subtle">{target}</div>
+
+      {/* ZONE B — status */}
+      <div className="px-4 py-3 border-b border-border-subtle">
+        <div className="flex items-center gap-2">
+          <span
+            aria-hidden
+            className={`w-2 h-2 rounded-full shrink-0 ${DOT[status.tone]}`}
+          />
+          <span className={`text-body flex-1 min-w-0 ${TEXT[status.tone]}`}>
+            {status.text}
+          </span>
+          {status.meta && (
+            <span className="text-meta font-mono text-text-quiet whitespace-nowrap">
+              {status.meta}
+            </span>
+          )}
+        </div>
+        {status.progress !== null && (
+          <div className="h-[3px] rounded-full bg-border-subtle mt-2.5 overflow-hidden">
+            <div
+              className="h-full rounded-full transition-[width] duration-300"
+              style={{
+                width: `${Math.round(status.progress * 100)}%`,
+                background: BAR[status.tone],
+              }}
+            />
+          </div>
+        )}
+        {status.sub && (
+          <div className="text-meta text-text-quiet mt-2">{status.sub}</div>
+        )}
+      </div>
+
+      {/* ZONE C — details (omitted entirely when there's nothing to show) */}
+      {showZoneC && (
+        <div className="px-4 py-3 border-b border-border-subtle">
+          {children ??
+            (details.kind === "log" ? (
+              <div>
+                <button
+                  type="button"
+                  onClick={() => setLogOpen((o) => !o)}
+                  aria-expanded={logOpen}
+                  className="flex items-center gap-2 text-meta text-text-faint hover:text-text"
+                >
+                  {logOpen ? (
+                    <ChevronUp size={12} aria-hidden />
+                  ) : (
+                    <ChevronDown size={12} aria-hidden />
+                  )}
+                  {logOpen ? "Hide log" : "Show log"}
+                </button>
+                {logOpen && (
+                  <div
+                    ref={logRef}
+                    className="mt-2 bg-inset border border-border-subtle rounded-sm px-3 py-2 font-mono text-meta text-text-faint overflow-y-auto"
+                    style={{ maxHeight: 172 }}
+                  >
+                    {logLines.map((l, i) => (
+                      <div key={i}>{l}</div>
+                    ))}
+                  </div>
+                )}
+                {details.showCopyDiagnostics && (
+                  <div className="mt-2">
+                    <Button tone="default" onClick={() => void onCopyDiagnostics?.()}>
+                      Copy diagnostics
+                    </Button>
+                  </div>
+                )}
+              </div>
+            ) : details.kind === "failures" ? (
+              <div>
+                <ul className="flex flex-col gap-2">
+                  {details.items.map((f, i) => (
+                    <li
+                      key={i}
+                      className="border border-danger bg-danger-bg rounded-sm px-3 py-2"
+                    >
+                      <div className="text-body font-medium text-danger">{f.cause}</div>
+                      <div className="text-meta text-text-faint mt-px">{f.action}</div>
+                    </li>
+                  ))}
+                </ul>
+                <p className="text-meta text-text-faint mt-2">
+                  Nothing was installed or changed — the checks run before any
+                  write.
+                </p>
+              </div>
+            ) : details.kind === "hint" ? (
+              <p className="text-meta text-text-faint">
+                {renderHintSegments(details.text)}
+              </p>
+            ) : null)}
+        </div>
+      )}
+
+      {/* ZONE D — actions */}
+      <div className="px-4 py-3">
+        <div className="flex items-center gap-2 flex-wrap">
+          {actions.map((id, i) => (
+            <Button
+              key={id}
+              tone={i === 0 ? "primary" : "default"}
+              disabled={id === "install" && installDisabled}
+              onClick={() => onAction(id)}
+            >
+              {actionLabel(id, i)}
+            </Button>
+          ))}
+          {hint && (
+            <span className="text-meta text-text-quiet ml-auto">{hint}</span>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -135,7 +135,10 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
 
       {showSshPicker && (
         <div className="mb-6">
-          <SshInstallStep onPaired={onPaired} />
+          <SshInstallStep
+            onPaired={onPaired}
+            onPairManually={() => setDisclosureOpen(true)}
+          />
         </div>
       )}
 

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -29,14 +29,15 @@
 // pure src/shared/sshTarget.ts target resolver). This component is React
 // state + per-event dispatch + JSX, nothing more.
 
-import { useCallback, useEffect, useState, useRef } from "react";
+import { useCallback, useEffect, useState, useRef, useMemo } from "react";
 import {
   getMantaPreload,
   type InstallerEvent,
   type PreflightFailure,
 } from "./preloadAccess";
-import { currentStageInfo, INSTALL_STAGES, type InstallStageId } from "../shared/installStages";
-import { ProcessPanel } from "./ProcessPanel";
+import type { InstallStageId } from "../shared/installStages";
+import { ConnectPanel } from "./ConnectPanel";
+import { deriveConnectPanel, type ConnectActionId } from "./connectPanel";
 import {
   CUSTOM_HOST_VALUE,
   resolveInstallTarget,
@@ -44,9 +45,9 @@ import {
   type HostFieldSelection,
 } from "../shared/sshTarget";
 import { claimWithRetry } from "./claimRetry";
+import { Button } from "./Button";
 
 const ACCENT = "var(--accent)";
-const ACCENT_SOLID = "var(--accent-solid)"; // filled buttons (BET-409 AA)
 const DANGER = "var(--danger)";
 
 // Keep the last N log lines only — main already caps its own tail at 200
@@ -60,19 +61,20 @@ const LOG_LINES_MAX = 500;
 const JUST_REFRESHED_DECAY_MS = 60_000;
 
 const INITIAL_STAGE: InstallStageId = "preflight";
-const INITIAL_STAGE_INFO = currentStageInfo(INITIAL_STAGE);
-
-// The installer's ProcessPanel stages — the ordered INSTALL_STAGES labels.
-// `currentStageInfo` is 1-based, so the panel's 0-based activeIndex is
-// `stageIndex - 1`. Using all six entries preserves the original "N of 6"
-// counter (the SSH installer always showed six steps).
-const INSTALL_STAGE_LABELS: string[] = INSTALL_STAGES.map((s) => s.label);
 
 function sleep(ms: number): Promise<void> {
   return new Promise((r) => setTimeout(r, ms));
 }
 
-export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
+export function SshInstallStep({
+  onPaired,
+  onPairManually,
+}: {
+  onPaired: () => void;
+  /** BET-961: the pairing-failed "Enter code manually" action — PairStep
+   *  wires it to opening its existing manual-pairing disclosure. */
+  onPairManually?: () => void;
+}) {
   // The preload bridge — null on mobile/web (the issue's "SSH is installer-
   // only" rule means this UI never renders without a preload). Render an
   // explicit fallback instead of silently failing — mirrors how PairStep
@@ -116,7 +118,6 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   const [running, setRunning] = useState(false);
   const [activeHandle, setActiveHandle] = useState<string | null>(null);
   const [stage, setStage] = useState<InstallStageId>(INITIAL_STAGE);
-  const [stageIndex, setStageIndex] = useState(INITIAL_STAGE_INFO.index);
   const [elapsedSeconds, setElapsedSeconds] = useState(0);
   const [lines, setLines] = useState<string[]>([]);
   const [done, setDone] = useState<
@@ -154,6 +155,10 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
   // True after the user cancels an install, until the next install starts —
   // renders a neutral "Install cancelled." card instead of a failure one.
   const [cancelled, setCancelled] = useState(false);
+  // BET-961: true once install + auto-claim both succeed. The consolidated
+  // panel then shows a real "Connected" state with a Next button (instead of
+  // auto-advancing invisibly); Next calls onPaired() → onboarding step 2.
+  const [paired, setPaired] = useState(false);
 
   // BET-705 a: handles whose install is over (cancelled, or finished) and must
   // never affect the UI again. Guards against a late `done`/`error` from an
@@ -264,7 +269,6 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         setRunning(true);
         setActiveHandle(s.trustHandleId);
         setStage(INITIAL_STAGE);
-        setStageIndex(INITIAL_STAGE_INFO.index);
         setFingerprintPrompt({
           handleId: s.trustHandleId,
           algo: s.pendingFingerprint.algo,
@@ -277,7 +281,6 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         setRunning(true);
         setActiveHandle(s.passphraseHandleId);
         setStage(INITIAL_STAGE);
-        setStageIndex(INITIAL_STAGE_INFO.index);
         setPassphrasePrompt({
           handleId: s.passphraseHandleId,
           prompt: "Enter the passphrase for your SSH key:",
@@ -286,14 +289,12 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
         return;
       }
       if (s.active) {
-        const info = currentStageInfo(s.stage);
         setRunning(true);
         // BET-705 b: restore the active handle so Cancel works after a
         // renderer remount (previously this was never restored, so cancel
         // no-opped).
         setActiveHandle(s.activeHandleId);
         setStage(s.stage);
-        setStageIndex(info.index);
         setLines(s.logTail);
       } else if (s.preflight && !s.preflight.ok) {
         setPreflightFailure({ failures: s.preflight.failures });
@@ -324,12 +325,9 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
               : next;
           });
           break;
-        case "stage": {
-          const info = currentStageInfo(evt.stage);
+        case "stage":
           setStage(evt.stage);
-          setStageIndex(info.index);
           break;
-        }
         case "preflight-failed":
           // Nothing was written to the box — the progress panel never
           // shows for this case.
@@ -452,7 +450,6 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     // filtering against a prior, now-dead handle.
     setActiveHandle(null);
     setStage(INITIAL_STAGE);
-    setStageIndex(INITIAL_STAGE_INFO.index);
     setElapsedSeconds(0);
     // Mount the progress panel immediately on click — no gap before the
     // main process's response comes back.
@@ -557,9 +554,11 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
       // yet) every few seconds up to a 45s budget, with a visible countdown.
       const { outcome } = await claimWithRetry(attempt, { sleep, now: Date.now });
       if (outcome.ok) {
-        // Mirror the manual PairStep onPaired — advances onboarding to
-        // step 2 exactly as a typed pairing code would.
-        onPaired();
+        // Mirror the manual PairStep onPaired — but hold the step on a real
+        // "Connected" state instead of advancing: the user confirms with the
+        // panel's Next button (BET-961), which stops the provider step from
+        // being skipped (BET-960).
+        setPaired(true);
         return;
       }
       // Non-transient failure, or the retry budget exhausted → the real error.
@@ -588,9 +587,73 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
     await navigator.clipboard.writeText(r);
   }
 
+  // BET-961: the consolidated panel's actions dispatch onto the exact same
+  // functions the old per-branch buttons called.
+  function handleAction(id: ConnectActionId) {
+    switch (id) {
+      case "install":
+        void startInstall();
+        break;
+      case "cancel":
+        void cancelInstall();
+        break;
+      case "next":
+        onPaired();
+        break;
+      case "retry":
+        void startInstall();
+        break;
+      case "editTarget":
+        setPreflightFailure(null);
+        break;
+      case "pairManually":
+        onPairManually?.();
+        break;
+    }
+  }
+
   // ---------- Render ----------
-  const installDisabled =
-    running || claimRunning || !resolveInstallTarget(currentSelection()).ok;
+  const targetLocked = running || claimRunning || paired;
+
+  const connectState = useMemo(
+    () =>
+      deriveConnectPanel({
+        hostsLoaded,
+        targetError,
+        running,
+        stage,
+        elapsedSeconds,
+        logLineCount: lines.length,
+        done,
+        installError,
+        preflightFailure,
+        awaitingPrompt: fingerprintPrompt !== null || passphrasePrompt !== null,
+        claimRunning,
+        claimElapsed,
+        claimError,
+        cancelled,
+        paired,
+      }),
+    [
+      hostsLoaded,
+      targetError,
+      running,
+      stage,
+      elapsedSeconds,
+      lines.length,
+      done,
+      installError,
+      preflightFailure,
+      fingerprintPrompt,
+      passphrasePrompt,
+      claimRunning,
+      claimElapsed,
+      claimError,
+      cancelled,
+      paired,
+    ],
+  );
+
   const hostCountLabel = hostsLoading
     ? "reading ~/.ssh/config…"
     : !hostsLoaded
@@ -598,415 +661,273 @@ export function SshInstallStep({ onPaired }: { onPaired: () => void }) {
       : hosts.length === 0
         ? "No hosts in ~/.ssh/config"
         : `${hosts.length} hosts from ~/.ssh/config${justRefreshed ? " · just now" : ""}`;
-  // Keep the panel (status line + log) mounted through an install error too
-  // — that's the log line the user needs most ("is it stuck, or just
-  // slow?"). Only the preflight-failure card excludes it (nothing was
-  // written to the box, so there's no install log to show).
-  const showProgress =
-    !preflightFailure &&
-    (running || done !== null || (installError !== null && lines.length > 0));
+
+  // Zone A — the host picker (header + select + refresh + custom-host panel
+  // + inline target validation error). ConnectPanel owns the four-zone panel
+  // chrome; this node is its zone-A body. `disabled` follows `targetLocked`
+  // so the picker is frozen while an install/claim is in flight or after
+  // pairing succeeds (BET-961).
+  const zoneA = (
+    <div className="space-y-2">
+      <div className="flex items-center justify-between gap-2">
+        <label
+          className="text-label font-medium text-text-muted"
+          htmlFor="ssh-host"
+        >
+          Box address
+        </label>
+        <span className="text-meta text-text-quiet">{hostCountLabel}</span>
+      </div>
+      <div className="flex gap-2">
+        <select
+          id="ssh-host"
+          value={alias}
+          onChange={(e) => {
+            setAlias(e.target.value);
+            setTargetError(null);
+          }}
+          disabled={targetLocked}
+          className="flex-1 min-w-0 rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+        >
+          {hosts.map((h) => (
+            <option key={h.alias} value={h.alias}>
+              {h.alias}
+              {h.patterns.length > 1 ? ` (${h.patterns.join(", ")})` : ""}
+            </option>
+          ))}
+          <option value={CUSTOM_HOST_VALUE}>Custom host…</option>
+        </select>
+        <button
+          type="button"
+          onClick={() => void loadHosts({ manual: true })}
+          disabled={hostsLoading || targetLocked}
+          aria-label="Refresh host list"
+          title="Re-read ~/.ssh/config"
+          className="w-[34px] h-[34px] shrink-0 flex items-center justify-center rounded-sm bg-bg-elev border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors disabled:opacity-50"
+        >
+          <svg
+            viewBox="0 0 24 24"
+            fill="none"
+            stroke="currentColor"
+            strokeWidth={2}
+            strokeLinecap="round"
+            strokeLinejoin="round"
+            className={`w-3.5 h-3.5${hostsLoading ? " animate-spin" : ""}`}
+            aria-hidden
+          >
+            <path d="M21 12a9 9 0 1 1-2.6-6.4" />
+            <path d="M21 3v6h-6" />
+          </svg>
+        </button>
+      </div>
+
+      {/* Custom host panel — only rendered for the custom sentinel once the
+          host list has settled (see the original BET-384 comment above). */}
+      {hostsLoaded && alias === CUSTOM_HOST_VALUE && (
+        <div className="rounded-sm border border-border bg-bg-soft p-4 space-y-3">
+          <div className="grid grid-cols-[1fr_90px] gap-3">
+            <div className="flex flex-col gap-1">
+              <label
+                className="text-label font-medium text-text-muted"
+                htmlFor="ssh-custom-host"
+              >
+                Host or IP
+              </label>
+              <input
+                id="ssh-custom-host"
+                type="text"
+                placeholder="box.example.com"
+                value={customHost}
+                onChange={(e) => {
+                  setCustomHost(e.target.value);
+                  setTargetError(null);
+                }}
+                disabled={targetLocked}
+                className="w-full rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label
+                className="text-label font-medium text-text-muted"
+                htmlFor="ssh-custom-port"
+              >
+                Port
+              </label>
+              <input
+                id="ssh-custom-port"
+                type="text"
+                inputMode="numeric"
+                placeholder="22"
+                value={customPort}
+                onChange={(e) => {
+                  setCustomPort(e.target.value);
+                  setTargetError(null);
+                }}
+                disabled={targetLocked}
+                className="w-full rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+              />
+            </div>
+          </div>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+              <label
+                className="text-label font-medium text-text-muted"
+                htmlFor="ssh-custom-user"
+              >
+                User
+              </label>
+              <input
+                id="ssh-custom-user"
+                type="text"
+                placeholder="root"
+                value={customUser}
+                onChange={(e) => {
+                  setCustomUser(e.target.value);
+                  setTargetError(null);
+                }}
+                disabled={targetLocked}
+                className="w-full rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+              />
+            </div>
+            <div className="flex flex-col gap-1">
+              <label
+                className="text-label font-medium text-text-muted"
+                htmlFor="ssh-custom-identity"
+              >
+                Identity file
+              </label>
+              <div className="flex gap-2">
+                <input
+                  id="ssh-custom-identity"
+                  type="text"
+                  placeholder="~/.ssh/id_ed25519"
+                  value={customIdentityFile}
+                  onChange={(e) => {
+                    setCustomIdentityFile(e.target.value);
+                    setTargetError(null);
+                  }}
+                  disabled={targetLocked}
+                  className="flex-1 min-w-0 rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+                />
+                <button
+                  type="button"
+                  onClick={async () => {
+                    const result = await preload.dialogShowOpenFile();
+                    if (!result.canceled) {
+                      setCustomIdentityFile(result.path);
+                      setTargetError(null);
+                    }
+                  }}
+                  disabled={targetLocked}
+                  className="shrink-0 px-3 py-2 rounded-sm text-body font-medium bg-bg-elev border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors disabled:opacity-50"
+                >
+                  Browse
+                </button>
+              </div>
+            </div>
+          </div>
+          <p className="text-meta text-text-faint">
+            Leave a field empty to let OpenSSH decide. These are used for
+            this box only — your ~/.ssh/config is never written to.
+          </p>
+        </div>
+      )}
+
+      {targetError && (
+        <p className="text-meta" style={{ color: DANGER }}>
+          {targetError}
+        </p>
+      )}
+    </div>
+  );
 
   return (
     <div className="space-y-5">
-      {/* Host picker — PairStep owns the step-level heading + intro
-          (BET-382); this component drops straight into the picker.
-          BET-384: exactly one host control, always a <select> — "Custom
-          host…" is a permanent last option, present whether or not the
-          config has entries, never a second input rendered alongside it. */}
-      <section className="space-y-2">
-        <div className="flex items-center justify-between gap-2">
-          <label className="text-body font-medium" htmlFor="ssh-host">
-            Host
-          </label>
-          <span className="text-meta text-text-faint">{hostCountLabel}</span>
-        </div>
-        <div className="flex gap-2">
-          <select
-            id="ssh-host"
-            value={alias}
-            onChange={(e) => {
-              setAlias(e.target.value);
-              setTargetError(null);
-            }}
-            disabled={running || claimRunning}
-            className="flex-1 min-w-0 rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
+      <ConnectPanel
+        state={connectState}
+        target={zoneA}
+        logLines={lines}
+        onAction={handleAction}
+        onCopyDiagnostics={copyDiagnostics}
+      >
+        {/* BET-361: inline fingerprint prompt — zone-C children. The install
+            is paused, so the card takes the place of attention until the
+            user answers. */}
+        {fingerprintPrompt ? (
+          <div
+            className="rounded-sm p-4 space-y-3"
+            style={{ border: `1px solid ${ACCENT}` }}
           >
-            {hosts.map((h) => (
-              <option key={h.alias} value={h.alias}>
-                {h.alias}
-                {h.patterns.length > 1 ? ` (${h.patterns.join(", ")})` : ""}
-              </option>
-            ))}
-            <option value={CUSTOM_HOST_VALUE}>Custom host…</option>
-          </select>
-          <button
-            type="button"
-            onClick={() => void loadHosts({ manual: true })}
-            disabled={hostsLoading || running || claimRunning}
-            aria-label="Refresh host list"
-            title="Re-read ~/.ssh/config"
-            className="w-[34px] h-[34px] shrink-0 flex items-center justify-center rounded-sm bg-bg-elev border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors disabled:opacity-50"
-          >
-            <svg
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth={2}
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              className={`w-3.5 h-3.5${hostsLoading ? " animate-spin" : ""}`}
-              aria-hidden
-            >
-              <path d="M21 12a9 9 0 1 1-2.6-6.4" />
-              <path d="M21 3v6h-6" />
-            </svg>
-          </button>
-        </div>
-
-        {/* Custom host panel — only rendered for the custom sentinel, AND
-            only once the host load has settled (review cycle 1 Block):
-            `alias` starts on the sentinel so the <select> always has a
-            valid selected option before installerListHosts() resolves,
-            but painting the panel during that window means a populated
-            ~/.ssh/config flashes the full four-field panel open and then
-            collapses once the real alias list lands. Gating on
-            `hostsLoaded` too keeps decision #3 intact — hostsLoaded is
-            true in both loadHosts' success and catch paths, so the
-            empty-config case still opens the panel pre-selected, exactly
-            as required — while a populated config never shows it before
-            the list is ready. No second host control ever coexists with
-            the select either way. */}
-        {hostsLoaded && alias === CUSTOM_HOST_VALUE && (
-          <div className="rounded-sm border border-border bg-bg-soft p-4 space-y-3">
-            <div className="grid grid-cols-[1fr_90px] gap-3">
-              <div className="flex flex-col gap-1">
-                <label
-                  className="text-label font-medium text-text-muted"
-                  htmlFor="ssh-custom-host"
-                >
-                  Host or IP
-                </label>
-                <input
-                  id="ssh-custom-host"
-                  type="text"
-                  placeholder="box.example.com"
-                  value={customHost}
-                  onChange={(e) => {
-                    setCustomHost(e.target.value);
-                    setTargetError(null);
-                  }}
-                  disabled={running || claimRunning}
-                  className="w-full rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <label
-                  className="text-label font-medium text-text-muted"
-                  htmlFor="ssh-custom-port"
-                >
-                  Port
-                </label>
-                <input
-                  id="ssh-custom-port"
-                  type="text"
-                  inputMode="numeric"
-                  placeholder="22"
-                  value={customPort}
-                  onChange={(e) => {
-                    setCustomPort(e.target.value);
-                    setTargetError(null);
-                  }}
-                  disabled={running || claimRunning}
-                  className="w-full rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
-                />
-              </div>
-            </div>
-            <div className="flex flex-col gap-3">
-              <div className="flex flex-col gap-1">
-                <label
-                  className="text-label font-medium text-text-muted"
-                  htmlFor="ssh-custom-user"
-                >
-                  User
-                </label>
-                <input
-                  id="ssh-custom-user"
-                  type="text"
-                  placeholder="root"
-                  value={customUser}
-                  onChange={(e) => {
-                    setCustomUser(e.target.value);
-                    setTargetError(null);
-                  }}
-                  disabled={running || claimRunning}
-                  className="w-full rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
-                />
-              </div>
-              <div className="flex flex-col gap-1">
-                <label
-                  className="text-label font-medium text-text-muted"
-                  htmlFor="ssh-custom-identity"
-                >
-                  Identity file
-                </label>
-                {/* BET-387: Browse button opens the native file picker via
-                    the preload's dialogShowOpenFile bridge (defaults to
-                    ~/.ssh/). A plain text input remains the fallback —
-                    typing a path directly still works, and the field is
-                    fully usable on mobile/web where the bridge is absent
-                    (the button is hidden there). */}
-                <div className="flex gap-2">
-                  <input
-                    id="ssh-custom-identity"
-                    type="text"
-                    placeholder="~/.ssh/id_ed25519"
-                    value={customIdentityFile}
-                    onChange={(e) => {
-                      setCustomIdentityFile(e.target.value);
-                      setTargetError(null);
-                    }}
-                    disabled={running || claimRunning}
-                    className="flex-1 min-w-0 rounded-sm bg-bg-elev px-3 py-2 text-body border border-border focus:outline-none focus:ring-2 focus:ring-accent"
-                  />
-                  <button
-                    type="button"
-                    onClick={async () => {
-                      const result = await preload.dialogShowOpenFile();
-                      if (!result.canceled) {
-                        setCustomIdentityFile(result.path);
-                        setTargetError(null);
-                      }
-                    }}
-                    disabled={running || claimRunning}
-                    className="shrink-0 px-3 py-2 rounded-sm text-body font-medium bg-bg-elev border border-border text-text-muted hover:text-text hover:border-border-strong transition-colors disabled:opacity-50"
-                  >
-                    Browse
-                  </button>
-                </div>
-              </div>
-            </div>
-            <p className="text-meta text-text-faint">
-              Leave a field empty to let OpenSSH decide. These are used for
-              this box only — your ~/.ssh/config is never written to.
+            <div className="text-body font-medium">Trust this host?</div>
+            <p className="text-meta text-text-muted">
+              The host's identity can't be verified yet. Its{" "}
+              {fingerprintPrompt.algo} key fingerprint is:
             </p>
+            <code
+              className="block text-meta font-mono break-all rounded-xs px-2 py-2 bg-bg-elev"
+              style={{ color: ACCENT }}
+            >
+              {fingerprintPrompt.sha256}
+            </code>
+            <p className="text-meta text-text-faint">
+              Only trust this if you recognize the fingerprint (for example,
+              from your VPS console). The key is saved to
+              ~/.ssh/known_hosts so future connections skip this prompt.
+            </p>
+            <div className="flex gap-2 pt-px">
+              <Button tone="primary" onClick={() => void trustHostDecision(true)}>
+                Trust &amp; continue
+              </Button>
+              <Button tone="danger" onClick={() => void trustHostDecision(false)}>
+                Don't trust
+              </Button>
+            </div>
           </div>
-        )}
-
-        {/* Hoisted out of the custom panel (review cycle 1 nit): the panel
-            only renders for the custom branch, but resolveInstallTarget
-            can also reject the alias branch (defensive — unreachable
-            through this UI today since the <select>'s only values are a
-            parsed alias or the sentinel, but resolveInstallTarget is a
-            shared pure function and must not silently swallow a future
-            caller's bad input). Rendering the error here, outside the
-            panel, means it's never lost regardless of which branch
-            produced it. */}
-        {targetError && (
-          <p className="text-meta" style={{ color: DANGER }}>
-            {targetError}
-          </p>
-        )}
-
-        <div className="flex gap-2 pt-2">
-          <button
-            onClick={startInstall}
-            disabled={installDisabled}
-            className="px-4 py-2 rounded-sm text-body font-medium disabled:opacity-50"
-            style={{ background: ACCENT_SOLID, color: "var(--on-accent)" }}
+        ) : passphrasePrompt ? (
+          /* BET-360: inline passphrase prompt — zone-C children. The install
+             is paused; the user enters the passphrase once. */
+          <div
+            className="rounded-sm p-4 space-y-3"
+            style={{ border: `1px solid ${ACCENT}` }}
           >
-            {running ? "Installing…" : "Install & pair"}
-          </button>
-          {running && (
-            <button
-              onClick={cancelInstall}
-              className="px-4 py-2 rounded-sm text-body font-medium"
-              style={{ border: `1px solid ${DANGER}`, color: DANGER }}
+            <div className="text-body font-medium">{passphrasePrompt.prompt}</div>
+            <p className="text-meta text-text-muted">
+              Your SSH key is passphrase-protected and not loaded in
+              ssh-agent. Enter the passphrase to decrypt it for this
+              install — it is used only in-memory and never stored.
+            </p>
+            <form
+              onSubmit={(e) => {
+                e.preventDefault();
+                void submitPassphrase(passphraseInput.length > 0);
+              }}
+              className="space-y-2"
             >
-              Cancel
-            </button>
-          )}
-        </div>
-      </section>
-
-      {/* Preflight failure — checks ran before any write; must not read as
-          a failed install. Never shown alongside the progress panel. */}
-      {preflightFailure && (
-        <section className="space-y-2 text-body">
-          <ul className="space-y-1">
-            {preflightFailure.failures.map((f, i) => (
-              <li
-                key={i}
-                className="rounded-sm px-3 py-2"
-                style={{ border: `1px solid ${DANGER}`, color: DANGER }}
-              >
-                <div className="font-medium">{f.cause}</div>
-                <div className="text-meta mt-px opacity-80">{f.action}</div>
-              </li>
-            ))}
-          </ul>
-          <p className="text-meta text-text-muted">
-            Nothing was installed or changed on the box — the checks run
-            before any write.
-          </p>
-        </section>
-      )}
-
-      {/* Status line + progress bar + live log — mounted on click, streams,
-          auto-scrolls, collapses to the single line on success. The shared
-          ProcessPanel (BET-421 §A) renders the chrome; the fingerprint and
-          passphrase prompts pass as children so they render between the bar
-          and the log, exactly where they lived before the extraction. */}
-      {showProgress && (
-        <ProcessPanel
-          stages={INSTALL_STAGE_LABELS}
-          activeIndex={Math.max(0, stageIndex - 1)}
-          status={
-            done ? (done.ok ? "done" : "error") : installError ? "error" : "running"
-          }
-          elapsedSeconds={elapsedSeconds}
-          logLines={lines}
-          onCopyDiagnostics={copyDiagnostics}
-        >
-          {/* BET-361: inline fingerprint prompt. The install is paused — the
-              log has nothing new to show, so the card takes the place of
-              attention until the user answers. */}
-          {fingerprintPrompt && (
-            <div
-              className="rounded-sm p-4 space-y-3"
-              style={{ border: `1px solid ${ACCENT}` }}
-            >
-              <div className="text-body font-medium">Trust this host?</div>
-              <p className="text-meta text-text-muted">
-                The host's identity can't be verified yet. Its{" "}
-                {fingerprintPrompt.algo} key fingerprint is:
-              </p>
-              <code
-                className="block text-meta font-mono break-all rounded-xs px-2 py-2 bg-bg-elev"
-                style={{ color: ACCENT }}
-              >
-                {fingerprintPrompt.sha256}
-              </code>
-              <p className="text-meta text-text-faint">
-                Only trust this if you recognize the fingerprint (for example,
-                from your VPS console). The key is saved to
-                ~/.ssh/known_hosts so future connections skip this prompt.
-              </p>
+              <input
+                type="password"
+                value={passphraseInput}
+                onChange={(e) => setPassphraseInput(e.target.value)}
+                autoFocus
+                placeholder="Passphrase"
+                className="w-full rounded-sm px-3 py-2 text-body bg-bg-elev"
+                style={{ border: `1px solid ${ACCENT}` }}
+              />
               <div className="flex gap-2 pt-px">
-                <button
-                  onClick={() => void trustHostDecision(true)}
-                  className="px-3 py-2 rounded-sm text-body font-medium"
-                  style={{ background: ACCENT_SOLID, color: "var(--on-accent)" }}
+                <Button
+                  type="submit"
+                  tone="primary"
+                  disabled={passphraseInput.length === 0}
                 >
-                  Trust &amp; continue
-                </button>
-                <button
-                  onClick={() => void trustHostDecision(false)}
-                  className="px-3 py-2 rounded-sm text-body font-medium"
-                  style={{ border: `1px solid ${DANGER}`, color: DANGER }}
-                >
-                  Don't trust
-                </button>
+                  Unlock &amp; continue
+                </Button>
+                <Button tone="danger" onClick={() => void submitPassphrase(false)}>
+                  Cancel
+                </Button>
               </div>
-            </div>
-          )}
-          {/* BET-360: inline passphrase prompt. The install is paused —
-              the key is passphrase-protected and not in ssh-agent. The
-              user enters the passphrase once; main caches it in a temp
-              file for every ssh invocation in the rest of the flow. */}
-          {passphrasePrompt && (
-            <div
-              className="rounded-sm p-4 space-y-3"
-              style={{ border: `1px solid ${ACCENT}` }}
-            >
-              <div className="text-body font-medium">{passphrasePrompt.prompt}</div>
-              <p className="text-meta text-text-muted">
-                Your SSH key is passphrase-protected and not loaded in
-                ssh-agent. Enter the passphrase to decrypt it for this
-                install — it is used only in-memory and never stored.
-              </p>
-              <form
-                onSubmit={(e) => {
-                  e.preventDefault();
-                  void submitPassphrase(passphraseInput.length > 0);
-                }}
-                className="space-y-2"
-              >
-                <input
-                  type="password"
-                  value={passphraseInput}
-                  onChange={(e) => setPassphraseInput(e.target.value)}
-                  autoFocus
-                  placeholder="Passphrase"
-                  className="w-full rounded-sm px-3 py-2 text-body bg-bg-elev"
-                  style={{ border: `1px solid ${ACCENT}` }}
-                />
-                <div className="flex gap-2 pt-px">
-                  <button
-                    type="submit"
-                    disabled={passphraseInput.length === 0}
-                    className="px-3 py-2 rounded-sm text-body font-medium disabled:opacity-40"
-                    style={{ background: ACCENT_SOLID, color: "var(--on-accent)" }}
-                  >
-                    Unlock &amp; continue
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => void submitPassphrase(false)}
-                    className="px-3 py-2 rounded-sm text-body font-medium"
-                    style={{ border: `1px solid ${DANGER}`, color: DANGER }}
-                  >
-                    Cancel
-                  </button>
-                </div>
-              </form>
-            </div>
-          )}
-        </ProcessPanel>
-      )}
-
-      {/* In-flight claim only. There is no success message: a successful
-          claim advances onboarding to step 2, which unmounts this step.
-          BET-705 c: while retrying a transient failure we show the elapsed
-          countdown ("the box is starting up"). */}
-      {claimRunning && (
-        <section className="text-body">
-          {claimElapsed !== null && claimElapsed > 0
-            ? `Pairing… the box is starting up (${claimElapsed}s)`
-            : "Pairing…"}
-        </section>
-      )}
-      {/* BET-705 d: a user cancel is not a failure — render a neutral card and
-          let the normal "Install & pair" affordance reset the flow. */}
-      {cancelled && <section className="text-body">Install cancelled.</section>}
-      {done && !done.ok && !cancelled && (
-        <section
-          className="text-body space-y-2"
-          style={{ color: DANGER }}
-        >
-          {/* No Copy diagnostics button here: ProcessPanel renders exactly one
-              on error, directly under the failed stage. This section used to
-              render a second copy of it. */}
-          <div>
-            Install failed (exit code {done.code ?? "—"}
-            {done.signal ? `, signal ${done.signal}` : ""}).
+            </form>
           </div>
-        </section>
-      )}
-      {installError && (
-        <section className="text-body" style={{ color: DANGER }}>
-          {installError}
-        </section>
-      )}
-      {claimError && (
-        <section className="text-body space-y-1" style={{ color: DANGER }}>
-          <div>{claimError}</div>
-          <div>
-            Pair manually: run <code>manta pair</code> on the box for a fresh
-            6-digit code, then open the "Pair to an existing box" form on this
-            page and enter it.
-          </div>
-        </section>
-      )}
+        ) : null}
+      </ConnectPanel>
     </div>
   );
 }

--- a/src/renderer/connectPanel.test.ts
+++ b/src/renderer/connectPanel.test.ts
@@ -1,0 +1,251 @@
+// connectPanel.test.ts — deriveConnectPanel precedence-table tests (BET-961).
+//
+// One case per precedence row (11 rows), asserting tone / text / meta /
+// progress / details.kind / actions, plus the two invariants the acceptance
+// gate calls out: logLineCount === 0 never yields a "log" details kind, and a
+// higher-precedence row wins over a lower one (a user cancel beats a
+// `done.ok === false`; a pair beats an install error).
+
+import { describe, it, expect } from "vitest";
+import {
+  deriveConnectPanel,
+  type ConnectInput,
+} from "./connectPanel";
+
+const base: ConnectInput = {
+  hostsLoaded: true,
+  targetError: null,
+  running: false,
+  stage: "preflight",
+  elapsedSeconds: 0,
+  logLineCount: 0,
+  done: null,
+  installError: null,
+  preflightFailure: null,
+  awaitingPrompt: false,
+  claimRunning: false,
+  claimElapsed: null,
+  claimError: null,
+  cancelled: false,
+  paired: false,
+};
+
+const status = (patch: Partial<ConnectInput>) => {
+  const s = deriveConnectPanel({ ...base, ...patch });
+  return { tone: s.status.tone, text: s.status.text, meta: s.status.meta };
+};
+
+describe("deriveConnectPanel — precedence table (BET-961)", () => {
+  it("row 1 — paired: 'Connected' + progress 1 + next action", () => {
+    const s = deriveConnectPanel({
+      ...base,
+      paired: true,
+      elapsedSeconds: 72,
+      logLineCount: 2,
+    });
+    expect(status({ paired: true, elapsedSeconds: 72 })).toEqual({
+      tone: "ok",
+      text: "Connected — your box is ready",
+      meta: "6 of 6 · 1:12",
+    });
+    expect(s.status.progress).toBe(1);
+    expect(s.details.kind).toBe("log");
+    expect(s.actions).toEqual(["next"]);
+    expect(s.hint).toBe("next: connect a provider");
+  });
+
+  it("row 2 — preflight failure: 'Couldn't reach the box' + failures", () => {
+    const s = deriveConnectPanel({
+      ...base,
+      stage: "preflight",
+      preflightFailure: {
+        failures: [{ cause: "SSH authentication failed", action: "Add your key" }],
+      },
+    });
+    expect(status({ stage: "preflight", preflightFailure: { failures: [] } })).toEqual({
+      tone: "error",
+      text: "Couldn't reach the box",
+      meta: "1 of 6",
+    });
+    expect(s.status.progress).toBe(1 / 6);
+    expect(s.details.kind).toBe("failures");
+    if (s.details.kind === "failures") {
+      expect(s.details.items[0].cause).toBe("SSH authentication failed");
+    }
+    expect(s.actions).toEqual(["retry", "editTarget"]);
+  });
+
+  it("row 3 — cancelled: neutral tone + 'stopped at N of M'", () => {
+    const s = deriveConnectPanel({ ...base, cancelled: true, stage: "extract", logLineCount: 3 });
+    expect(status({ cancelled: true, stage: "extract" })).toEqual({
+      tone: "neutral",
+      text: "Cancelled",
+      meta: "stopped at 3 of 6",
+    });
+    expect(s.status.progress).toBe(3 / 6);
+    expect(s.details.kind).toBe("log");
+    expect(s.actions).toEqual(["install"]);
+  });
+
+  it("row 4 — claim error: 'Installed, but pairing didn't complete' + hint", () => {
+    const s = deriveConnectPanel({ ...base, claimError: "x", stage: "pairing" });
+    expect(status({ claimError: "x", stage: "pairing" })).toEqual({
+      tone: "error",
+      text: "Installed, but pairing didn't complete",
+      meta: "5 of 6",
+    });
+    expect(s.status.progress).toBe(5 / 6);
+    expect(s.details.kind).toBe("hint");
+    expect(s.actions).toEqual(["pairManually", "retry"]);
+  });
+
+  it("row 5 — install failed: names the stage + exit code; log auto-opens with copy", () => {
+    const s = deriveConnectPanel({
+      ...base,
+      done: { ok: false, code: 1, signal: null },
+      stage: "extract",
+      logLineCount: 2,
+    });
+    expect(status({ done: { ok: false, code: 1, signal: null }, stage: "extract" })).toEqual({
+      tone: "error",
+      text: 'Install failed at “Installing files”',
+      meta: "3 of 6 · exit 1",
+    });
+    expect(s.details.kind).toBe("log");
+    if (s.details.kind === "log") {
+      expect(s.details.defaultOpen).toBe(true);
+      expect(s.details.showCopyDiagnostics).toBe(true);
+    }
+    expect(s.actions).toEqual(["retry", "pairManually"]);
+
+    // code null → no "· exit …" suffix.
+    const noCode = deriveConnectPanel({ ...base, installError: "boom", stage: "extract" });
+    expect(noCode.status.meta).toBe("3 of 6");
+  });
+
+  it("row 6 — awaiting prompt: 'Waiting for you' + cancel, details none", () => {
+    const s = deriveConnectPanel({
+      ...base,
+      awaitingPrompt: true,
+      running: true,
+      stage: "service",
+      elapsedSeconds: 11,
+    });
+    expect(status({ awaitingPrompt: true, running: true, stage: "service", elapsedSeconds: 11 })).toEqual({
+      tone: "attention",
+      text: "Waiting for you",
+      meta: "4 of 6 · 0:11",
+    });
+    expect(s.status.progress).toBe(4 / 6);
+    expect(s.details.kind).toBe("none");
+    expect(s.actions).toEqual(["cancel"]);
+  });
+
+  it("row 7 — claim running: 'box is still starting' wording + retry substatus", () => {
+    const s = deriveConnectPanel({
+      ...base,
+      claimRunning: true,
+      claimElapsed: 5,
+      stage: "pairing",
+      elapsedSeconds: 53,
+      logLineCount: 1,
+    });
+    expect(status({ claimRunning: true, claimElapsed: 5, stage: "pairing", elapsedSeconds: 53 })).toEqual({
+      tone: "running",
+      text: "Pairing — the box is still starting",
+      meta: "5 of 6 · 0:53",
+    });
+    expect(s.status.sub).toBe("retrying every 2s · this is normal on a fresh install");
+    expect(s.actions).toEqual(["cancel"]);
+
+    // claimElapsed === 0 → plain "Pairing with this app", no substatus.
+    const t0 = deriveConnectPanel({ ...base, claimRunning: true, claimElapsed: 0, stage: "pairing" });
+    expect(t0.status.text).toBe("Pairing with this app");
+    expect(t0.status.sub).toBeNull();
+  });
+
+  it("row 8 — running: stage label + elapsed meta", () => {
+    const s = deriveConnectPanel({
+      ...base,
+      running: true,
+      stage: "download",
+      elapsedSeconds: 13,
+      logLineCount: 1,
+    });
+    expect(status({ running: true, stage: "download", elapsedSeconds: 13 })).toEqual({
+      tone: "running",
+      text: "Download release",
+      meta: "2 of 6 · 0:13",
+    });
+    expect(s.status.progress).toBe(2 / 6);
+    expect(s.details.kind).toBe("log");
+    expect(s.actions).toEqual(["cancel"]);
+  });
+
+  it("row 9 — hosts not loaded yet: disabled install", () => {
+    const s = deriveConnectPanel({ ...base, hostsLoaded: false });
+    expect(status({ hostsLoaded: false })).toEqual({
+      tone: "idle",
+      text: "Reading ~/.ssh/config…",
+      meta: null,
+    });
+    expect(s.status.progress).toBeNull();
+    expect(s.details.kind).toBe("none");
+    expect(s.actions).toEqual(["install"]);
+  });
+
+  it("row 10 — invalid target: 'Check the highlighted field'", () => {
+    const s = deriveConnectPanel({ ...base, targetError: "Port must be a number" });
+    expect(status({ targetError: "Port must be a number" })).toEqual({
+      tone: "attention",
+      text: "Check the highlighted field",
+      meta: null,
+    });
+    expect(s.status.progress).toBeNull();
+    expect(s.details.kind).toBe("none");
+    expect(s.actions).toEqual(["install"]);
+  });
+
+  it("row 11 — otherwise: ready to install, with the minute hint", () => {
+    const s = deriveConnectPanel(base);
+    expect(status({})).toEqual({
+      tone: "idle",
+      text: "Ready to install",
+      meta: null,
+    });
+    expect(s.status.progress).toBeNull();
+    expect(s.details.kind).toBe("none");
+    expect(s.actions).toEqual(["install"]);
+    expect(s.hint).toBe("takes about a minute");
+  });
+
+  it("logLineCount === 0 never yields a 'log' details kind", () => {
+    const s = deriveConnectPanel({ ...base, running: true, logLineCount: 0, stage: "service" });
+    expect(s.details.kind).not.toBe("log");
+    expect(s.details.kind).toBe("none");
+  });
+
+  it("higher precedence beats lower — cancel beats done.ok === false", () => {
+    const s = deriveConnectPanel({
+      ...base,
+      cancelled: true,
+      done: { ok: false, code: null, signal: null },
+    });
+    expect(s.status.text).toBe("Cancelled");
+    expect(s.status.tone).toBe("neutral");
+  });
+
+  it("higher precedence beats lower — paired beats an install error", () => {
+    const s = deriveConnectPanel({ ...base, paired: true, installError: "boom" });
+    expect(s.status.text).toBe("Connected — your box is ready");
+    expect(s.status.tone).toBe("ok");
+    expect(s.actions).toEqual(["next"]);
+  });
+
+  it("targetLocked is true while running, claiming, or paired", () => {
+    expect(deriveConnectPanel({ ...base, running: true }).targetLocked).toBe(true);
+    expect(deriveConnectPanel({ ...base, claimRunning: true }).targetLocked).toBe(true);
+    expect(deriveConnectPanel({ ...base, paired: true }).targetLocked).toBe(true);
+    expect(deriveConnectPanel(base).targetLocked).toBe(false);
+  });
+});

--- a/src/renderer/connectPanel.ts
+++ b/src/renderer/connectPanel.ts
@@ -1,0 +1,309 @@
+// connectPanel.ts — the single lever that collapses SshInstallStep's many
+// render branches into one four-zone Connect panel (BET-961).
+//
+// SshInstallStep holds ~15 pieces of state (hosts, targetError, running,
+// stage, elapsed, done, installError, preflightFailure, the two prompts, the
+// claim trio, cancelled, paired). Today each combination gets its own ad-hoc
+// branch, so status appears in five vertical positions and errors come in four
+// shapes. This module maps that state onto ONE descriptor — status (tone/text/
+// meta/progress/sub), details (log/failures/hint/none), actions, hint and an
+// A-zone lock — and ConnectPanel.tsx renders that descriptor, so nothing moves
+// between states.
+//
+// Pure, no JSX, no React. The precedence rules below are the acceptance gate:
+// one first-match-wins table, eleven rows, evaluated in exactly this order.
+//
+// Reused, not reimplemented:
+//   - stage label / index / total -> currentStageInfo (src/shared/installStages.ts)
+//   - elapsed formatting           -> formatElapsed (src/renderer/ProcessPanel.tsx)
+
+import { currentStageInfo, type InstallStageId } from "../shared/installStages";
+import { formatElapsed } from "./ProcessPanel";
+
+export type ConnectTone = "idle" | "running" | "attention" | "ok" | "error" | "neutral";
+
+export type ConnectDetails =
+  | { kind: "none" }
+  | { kind: "log"; defaultOpen: boolean; showCopyDiagnostics: boolean }
+  | { kind: "failures"; items: Array<{ cause: string; action: string }> }
+  | { kind: "hint"; text: string };
+
+export type ConnectActionId =
+  | "install"
+  | "cancel"
+  | "next"
+  | "retry"
+  | "editTarget"
+  | "pairManually";
+
+export type ConnectPanelState = {
+  status: {
+    tone: ConnectTone;
+    text: string;
+    meta: string | null; // e.g. "3 of 6 · 0:24"
+    progress: number | null; // 0..1, null = no bar
+    sub: string | null; // second line under the bar
+  };
+  details: ConnectDetails;
+  actions: ConnectActionId[]; // first is primary, rest secondary
+  hint: string | null; // right-aligned text in zone D
+  targetLocked: boolean;
+};
+
+/** The row-4 pairing-failed hint. `manta pair` is rendered as <code> by
+ *  ConnectPanel by splitting the backticks — keep the backticks here. */
+const CLAIM_FAILED_HINT =
+  "The box is running. Run `manta pair` on it for a fresh 6-digit code, then enter it here.";
+
+/**
+ * Build the thing ConnectPanel renders. `targetLocked` locks zone A (the
+ * host picker) — true while an install or claim is in flight, or after
+ * pairing succeeded.
+ */
+function computeTargetLocked(input: ConnectInput): boolean {
+  return input.running || input.claimRunning || input.paired;
+}
+
+/** `<stage meta>` — `${index} of ${total}` plus the elapsed time while the
+ *  operation is actively progressing (install running OR claim retrying).
+ *  Matches the mockup: running stages and the claim states both show time. */
+function stageMeta(input: ConnectInput): string {
+  const { index, total } = currentStageInfo(input.stage);
+  const active = input.running || input.claimRunning;
+  return active
+    ? `${index} of ${total} · ${formatElapsed(input.elapsedSeconds)}`
+    : `${index} of ${total}`;
+}
+
+/** A log details kind, degraded to `none` when there are no lines to show —
+ *  an action must never offer a log button over an empty pane. */
+function logDetails(
+  defaultOpen: boolean,
+  showCopyDiagnostics: boolean,
+  logLineCount: number,
+): ConnectDetails {
+  if (logLineCount === 0) return { kind: "none" };
+  return { kind: "log", defaultOpen, showCopyDiagnostics };
+}
+
+export type ConnectInput = {
+  hostsLoaded: boolean;
+  targetError: string | null;
+  running: boolean;
+  stage: InstallStageId;
+  elapsedSeconds: number;
+  logLineCount: number;
+  done: { ok: boolean; code: number | null; signal: string | null } | null;
+  installError: string | null;
+  preflightFailure: { failures: Array<{ cause: string; action: string }> } | null;
+  awaitingPrompt: boolean; // fingerprintPrompt !== null || passphrasePrompt !== null
+  claimRunning: boolean;
+  claimElapsed: number | null;
+  claimError: string | null;
+  cancelled: boolean;
+  paired: boolean;
+};
+
+/**
+ * Evaluate the precedence table first-match-wins. The table order in the
+ * switch below is load-bearing — never reorder a row. `paired` beats
+ * everything (a completed pair must hand off to the provider step); a user
+ * `cancelled` beats `done.ok === false` (a cancel surfaces as a neutral
+ * `done` with SIGTERM, and must not read as a failure).
+ */
+export function deriveConnectPanel(input: ConnectInput): ConnectPanelState {
+  const targetLocked = computeTargetLocked(input);
+  const { index, total, label } = currentStageInfo(input.stage);
+  const progress = index / total;
+
+  // 1 — paired.
+  if (input.paired) {
+    return {
+      status: {
+        tone: "ok",
+        text: "Connected — your box is ready",
+        meta: `${total} of ${total} · ${formatElapsed(input.elapsedSeconds)}`,
+        progress: 1,
+        sub: null,
+      },
+      details: logDetails(false, false, input.logLineCount),
+      actions: ["next"],
+      hint: "next: connect a provider",
+      targetLocked,
+    };
+  }
+
+  // 2 — preflight failed (nothing written).
+  if (input.preflightFailure) {
+    return {
+      status: {
+        tone: "error",
+        text: "Couldn't reach the box",
+        meta: stageMeta(input),
+        progress,
+        sub: null,
+      },
+      details: { kind: "failures", items: input.preflightFailure.failures },
+      actions: ["retry", "editTarget"],
+      hint: null,
+      targetLocked,
+    };
+  }
+
+  // 3 — user cancelled (neutral, not a failure).
+  if (input.cancelled) {
+    return {
+      status: {
+        tone: "neutral",
+        text: "Cancelled",
+        meta: `stopped at ${index} of ${total}`,
+        progress,
+        sub: null,
+      },
+      details: logDetails(false, false, input.logLineCount),
+      actions: ["install"],
+      hint: null,
+      targetLocked,
+    };
+  }
+
+  // 4 — installed, but the claim (pairing) failed.
+  if (input.claimError) {
+    return {
+      status: {
+        tone: "error",
+        text: "Installed, but pairing didn't complete",
+        meta: "5 of 6",
+        progress,
+        sub: null,
+      },
+      details: { kind: "hint", text: CLAIM_FAILED_HINT },
+      actions: ["pairManually", "retry"],
+      hint: null,
+      targetLocked,
+    };
+  }
+
+  // 5 — install failed (hard error, or a non-cancel `done` with !ok).
+  if (input.installError || (input.done && !input.done.ok)) {
+    const code = input.done?.code ?? null;
+    const meta =
+      code === null
+        ? `${index} of ${total}`
+        : `${index} of ${total} · exit ${code}`;
+    return {
+      status: {
+        tone: "error",
+        text: `Install failed at “${label}”`,
+        meta,
+        progress,
+        sub: null,
+      },
+      details: logDetails(true, true, input.logLineCount),
+      actions: ["retry", "pairManually"],
+      hint: null,
+      targetLocked,
+    };
+  }
+
+  // 6 — paused waiting on the user (fingerprint / passphrase prompt).
+  if (input.awaitingPrompt) {
+    return {
+      status: {
+        tone: "attention",
+        text: "Waiting for you",
+        meta: stageMeta(input),
+        progress,
+        sub: null,
+      },
+      details: { kind: "none" }, // the prompt renders as zone-C children
+      actions: ["cancel"],
+      hint: null,
+      targetLocked,
+    };
+  }
+
+  // 7 — auto-claim retrying (the box is still booting).
+  if (input.claimRunning) {
+    const booting = input.claimElapsed !== null && input.claimElapsed > 0;
+    return {
+      status: {
+        tone: "running",
+        text: booting ? "Pairing — the box is still starting" : "Pairing with this app",
+        meta: stageMeta(input),
+        progress,
+        sub: booting ? "retrying every 2s · this is normal on a fresh install" : null,
+      },
+      details: logDetails(false, false, input.logLineCount),
+      actions: ["cancel"],
+      hint: null,
+      targetLocked,
+    };
+  }
+
+  // 8 — install in flight.
+  if (input.running) {
+    return {
+      status: {
+        tone: "running",
+        text: label,
+        meta: stageMeta(input),
+        progress,
+        sub: null,
+      },
+      details: logDetails(false, false, input.logLineCount),
+      actions: ["cancel"],
+      hint: null,
+      targetLocked,
+    };
+  }
+
+  // 9 — hosts still loading.
+  if (!input.hostsLoaded) {
+    return {
+      status: {
+        tone: "idle",
+        text: "Reading ~/.ssh/config…",
+        meta: null,
+        progress: null,
+        sub: null,
+      },
+      details: { kind: "none" },
+      actions: ["install"],
+      hint: null,
+      targetLocked,
+    };
+  }
+
+  // 10 — invalid target.
+  if (input.targetError) {
+    return {
+      status: {
+        tone: "attention",
+        text: "Check the highlighted field",
+        meta: null,
+        progress: null,
+        sub: null,
+      },
+      details: { kind: "none" },
+      actions: ["install"],
+      hint: null,
+      targetLocked,
+    };
+  }
+
+  // 11 — otherwise: ready to install.
+  return {
+    status: {
+      tone: "idle",
+      text: "Ready to install",
+      meta: null,
+      progress: null,
+      sub: null,
+    },
+    details: { kind: "none" },
+    actions: ["install"],
+    hint: "takes about a minute",
+    targetLocked,
+  };
+}


### PR DESCRIPTION
## What

Consolidates onboarding step 1's SSH path into **one four-zone Connect panel** — the design approved in the mockup (`/pages/step1-states`). Status is always zone B, detail always zone C, and there is never a second button outside zone D. Fixes the current scatter where status appears in five vertical positions and errors have four presentations.

**Files changed:** 6. `SshInstallStep.tsx` loses ~350 lines of render code.

- `src/renderer/connectPanel.ts` (new, pure): `deriveConnectPanel()` maps SshInstallStep's state onto one `ConnectPanelState` descriptor via an 11-row first-match-wins precedence table. Reuses `currentStageInfo` + `formatElapsed`; `progress = index/total`.
- `src/renderer/ConnectPanel.tsx` (new, presentational): renders the descriptor in four zones. Log open/closed is the only local state; no zone labels. Uses `Button` + lucide `ChevronUp/Down`.
- `src/renderer/SshInstallStep.tsx`: rewired. Adds `paired` state (auto-claim success now shows a real "Connected" state + `Next →` instead of invisible auto-advance — wire the manual path, BET-962). Zone A (host picker) and the fingerprint/passphrase prompts moved in as `target`/`children`. `onAction` dispatches to the existing install/cancel/next/retry/editTarget/pairManually functions. Dead `ProcessPanel` usage + trailing status/error sections deleted. Ad-hoc inline-styled buttons → `<Button>`.
- `src/renderer/PairStep.tsx`: passes `onPairManually` (opens the existing manual disclosure).
- Tests: `connectPanel.test.ts` (one case per precedence row + the two invariants), `ConnectPanel.test.tsx` (jsdom: zone C absent when nothing to show, primary action, meta in zone B).

The manual pairing form + clipboard banner keep working exactly as today (below the panel) and are folded into zone A by **BET-962** (already filed, blocked on this).

## Notes / deliberate deviations

- **Invalid classes remapped to enforced tokens.** The issue's markup used `px-1.5`, `mt-2.5` and `bg-inset`. The repo's `tailwindScale.test.ts` rejects off-grid spacing values (not in `theme.spacing`) and `primitives.test.ts` (BET-588) restricts `bg-inset` to its named owners — and its own comment forbids "add a file to a row to make a red test green." So: `px-1.5 → px-2`, `mt-2.5 → mt-3`, log pane `bg-inset → bg-bg-elev` (matches ProcessPanel's log pane), hint `manta pair` chip `bg-inset → bg-bg` (matches PairStep's existing code chip). No new token added; every class maps to an existing one.
- **Added `onCopyDiagnostics` prop to ConnectPanel** (not in the literal prop list) — the "Copy diagnostics" button must stay functional (deliverable 3), and it needs a callback. It's absent-only for non-failure states.
- **`stageIndex` state removed** — it fed only the deleted `ProcessPanel` stage index; nothing reads it now.

## Verification results

- **Branch** `multica/BET-961-connect-step1-panel` @ `72e9fcf`, base `origin/main @ 2aa59d6`
- `npm run typecheck`: exit 0, no errors
- `npm test`: vitest **2816 passed / 7 skipped** across 152 files (0 fail); node:test **2106 pass / 0 fail**

## Done-when checks

- [x] `npm run typecheck && npm test` pass
- [x] Rendered panel matches the mockup for every in-scope state (01–04, 07–17)
- [x] No new CSS variable / Tailwind token
- [x] `grep -n "ProcessPanel" src/renderer/SshInstallStep.tsx` → empty; `ProcessPanel.tsx` untouched
