### PR TITLE
feat(renderer): fold manual pairing + clipboard link into the Connect panel's zone A (BET-962)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.30",
+  "version": "0.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.30",
+      "version": "0.0.29",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/src/renderer/ConnectPanel.tsx
+++ b/src/renderer/ConnectPanel.tsx
@@ -50,6 +50,8 @@ const ACTION_LABEL: Record<ConnectActionId, string> = {
   retry: "Try again",
   editTarget: "Edit target",
   pairManually: "Pair manually",
+  connect: "Connect",
+  discard: "Discard",
 };
 
 function actionLabel(id: ConnectActionId, index: number): string {
@@ -99,7 +101,7 @@ export function ConnectPanel({
   /** Wires the "Copy diagnostics" button (shown only on install failure). */
   onCopyDiagnostics?: () => void | Promise<void>;
 }): JSX.Element {
-  const { status, details, actions, hint } = state;
+  const { status, details, actions, hint, disabledActions } = state;
 
   // Log open/closed toggle, auto-reset to each details phase's defaultOpen.
   const [logOpen, setLogOpen] = useState(
@@ -140,6 +142,10 @@ export function ConnectPanel({
   // one that carries the "takes about a minute" hint and no in-flight meta —
   // that combination is exactly when the button becomes clickable.
   const installDisabled = status.progress === null && !hint;
+
+  const actionDisabled = (id: ConnectActionId): boolean =>
+    (id === "install" && installDisabled) ||
+    Boolean(disabledActions?.includes(id));
 
   const showZoneC = details.kind !== "none" || Boolean(children);
 
@@ -251,7 +257,7 @@ export function ConnectPanel({
             <Button
               key={id}
               tone={i === 0 ? "primary" : "default"}
-              disabled={id === "install" && installDisabled}
+              disabled={actionDisabled(id)}
               onClick={() => onAction(id)}
             >
               {actionLabel(id, i)}

--- a/src/renderer/PairStep.test.tsx
+++ b/src/renderer/PairStep.test.tsx
@@ -1,18 +1,17 @@
 // @vitest-environment jsdom
 //
-// Render-harness tests for PairStep (BET-382 §"Tests").
+// Render-harness tests for PairStep (BET-382 §"Tests", rewritten for BET-962).
 //
-// Covers:
-//   1. Deep-link-open — a pending manta://pair prefill opens the manual
-//      form on first paint and pre-fills Box ID + Code, and hides the
-//      SSH picker.
-//   2. Closed-by-default — no pending deep link + no preload, the manual
-//      form is NOT in the DOM until "Pair to an existing box" is pressed;
-//      pressing it mounts the form, and the button flips to "Hide".
-//   3. Submit-stays-disabled — the manual form's Connect button stays
-//      disabled until Box ID + Code are both valid, and is enabled when
-//      they are. Reuses the same canConnectSetup gate the production
-//      component uses — no validation logic is duplicated here.
+// PairStep now owns a single Connect panel whose zone A switches between the
+// SSH host picker (`ssh`) and manual code entry (`manual`). With no SSH
+// installer (the harness forces `__mantaPreload = null`) there is no picker,
+// so manual mode is the default. Covers:
+//   1. Default — manual fields are in the DOM, idle status, mode-switch link.
+//   2. Deep-link — a pending manta://pair prefill forces manual mode, fills
+//      the fields, shows "Pairing link ready" + Discard, and hides the picker.
+//   3. Connect-disabled — the manual panel's Connect stays disabled until
+//      Box ID + Code are both valid (same canConnectSetup gate in use).
+//   4. Mode switch — "Back to the host picker" swaps zone A out of manual.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act } from "react";
@@ -33,15 +32,29 @@ function noopOnPaired() {
   /* swallow — tests assert on DOM, not the callback */
 }
 
-describe("PairStep render harness (BET-382)", () => {
+function buttonByText(container: HTMLElement, text: string): HTMLButtonElement | null {
+  const buttons = Array.from(container.querySelectorAll("button"));
+  return (buttons.find((b) => b.textContent?.trim() === text) as
+    | HTMLButtonElement
+    | undefined) ?? null;
+}
+
+function setInputValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
+}
+
+describe("PairStep render harness (BET-382 / BET-962)", () => {
   let h: Harness | null = null;
 
   beforeEach(() => {
-    // PairStep renders SshInstallStep when getMantaPreload() is non-null,
-    // which would try to call installerListHosts() on mount. Force the
-    // preload off so the SSH picker path doesn't enter these tests —
-    // the SSH path is its own component (SshInstallStep.tsx) and is
-    // covered by BET-355/383, not here.
+    // Force the SSH installer off so the picker path doesn't enter these
+    // tests — the SSH path is its own component (SshInstallStep.tsx). With
+    // no installer, PairStep enters manual mode by default (BET-962).
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__mantaPreload = null;
     installMockApi();
@@ -72,41 +85,24 @@ describe("PairStep render harness (BET-382)", () => {
     expect(h.text()).not.toContain("Advanced");
   });
 
-  it("closed by default — manual form is NOT in the DOM until the button is pressed", () => {
+  it("defaults to manual mode without an installer — fields in the DOM, idle status", () => {
     h = mount(<PairStep onPaired={noopOnPaired} />);
-    // No input rows on first paint (SSH picker is off; the form lives
-    // behind the toggle).
-    expect(h.container.querySelector("#pair-box-id")).toBeNull();
-    expect(h.container.querySelector("#pair-code")).toBeNull();
-    expect(h.container.querySelector("#pair-host")).toBeNull();
-
-    const toggle = h.container.querySelector(
-      "button",
-    ) as HTMLButtonElement | null;
-    expect(toggle).not.toBeNull();
-    expect(toggle?.textContent).toBe("Pair to an existing box");
-
-    // Open it.
-    act(() => toggle?.click());
+    // No pending link + no installer → manual mode is the default (no picker
+    // to show instead). The manual fields render in zone A.
     expect(h.container.querySelector("#pair-box-id")).not.toBeNull();
     expect(h.container.querySelector("#pair-code")).not.toBeNull();
     expect(h.container.querySelector("#pair-host")).not.toBeNull();
-    // Button label flips while open.
-    expect(toggle?.textContent).toBe("Hide");
-
-    // Close again — form unmounts.
-    act(() => toggle?.click());
-    expect(h.container.querySelector("#pair-box-id")).toBeNull();
-    expect(h.container.querySelector("#pair-code")).toBeNull();
+    // Zone B shows the idle manual status; zone A carries the mode-switch link.
+    expect(h.text()).toContain("Enter the 6-digit code from the box");
+    expect(h.text()).toContain("Back to the host picker");
   });
 
-  it("deep-link-open — pending pair link opens the form pre-filled and hides the SSH picker", () => {
+  it("deep-link — pending pair link forces manual mode and pre-fills the fields", () => {
     act(() => {
       useStore.setState({ pendingPairLink: VALID_LINK });
     });
     h = mount(<PairStep onPaired={noopOnPaired} />);
 
-    // Form is open on first paint.
     const boxId = h.container.querySelector(
       "#pair-box-id",
     ) as HTMLInputElement | null;
@@ -118,142 +114,93 @@ describe("PairStep render harness (BET-382)", () => {
     expect(boxId?.value).toBe(VALID_BOX);
     expect(code?.value).toBe(VALID_CODE);
 
-    // Toggle button reads "Hide".
-    const toggle = h.container.querySelector("button");
-    expect(toggle?.textContent).toBe("Hide");
+    // The prefill row: "Pairing link ready" + Connect/Discard.
+    expect(h.text()).toContain("Pairing link ready");
+    expect(h.text()).toContain("Discard");
+    expect(buttonByText(h.container, "Connect")).not.toBeNull();
 
-    // SSH picker must be hidden — no <select id="ssh-host"> (which is what
-    // SshInstallStep renders). This is the same assertion BET-335 already
-    // covers; we re-state it here because the BET-382 dedupe touches the
-    // same showSshPicker branch.
+    // SSH picker must be hidden — no <select id="ssh-host">.
     expect(h.container.querySelector("#ssh-host")).toBeNull();
   });
 
   it("Connect stays disabled until Box ID + Code are both valid", () => {
     h = mount(<PairStep onPaired={noopOnPaired} />);
-    act(() => {
-      (
-        h!.container.querySelector("button") as HTMLButtonElement | null
-      )?.click();
-    });
-    const submit = h.container.querySelector(
-      "button[type=submit]",
-    ) as HTMLButtonElement | null;
-    expect(submit).not.toBeNull();
-    expect(submit?.disabled).toBe(true);
+    const container = h.container;
 
-    const boxId = h.container.querySelector(
+    const connect = () => buttonByText(container, "Connect");
+    expect(connect()).not.toBeNull();
+    expect(connect()?.disabled).toBe(true);
+
+    const boxId = container.querySelector(
       "#pair-box-id",
     ) as HTMLInputElement | null;
-    const code = h.container.querySelector(
+    const code = container.querySelector(
       "#pair-code",
     ) as HTMLInputElement | null;
 
     // Box ID alone — still disabled.
-    act(() => {
-      boxId!.focus();
-      // emulate a React-style input event by setting the native value +
-      // dispatching an input event the React state listens to.
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )?.set;
-      setter?.call(boxId, VALID_BOX);
-      boxId!.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-    expect(submit?.disabled).toBe(true);
+    act(() => setInputValue(boxId!, VALID_BOX));
+    expect(connect()?.disabled).toBe(true);
 
     // Bad code — still disabled.
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )?.set;
-      setter?.call(code, "12345");
-      code!.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-    expect(submit?.disabled).toBe(true);
+    act(() => setInputValue(code!, "12345"));
+    expect(connect()?.disabled).toBe(true);
 
     // Good code — now enabled.
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )?.set;
-      setter?.call(code, VALID_CODE);
-      code!.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-    expect(submit?.disabled).toBe(false);
+    act(() => setInputValue(code!, VALID_CODE));
+    expect(connect()?.disabled).toBe(false);
 
     // Now blank the Box ID — must disable again (gate re-evaluates).
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )?.set;
-      setter?.call(boxId, "");
-      boxId!.dispatchEvent(new Event("input", { bubbles: true }));
-    });
-    expect(submit?.disabled).toBe(true);
+    act(() => setInputValue(boxId!, ""));
+    expect(connect()?.disabled).toBe(true);
   });
 
   it("Host field surfaces the inline server-URL validation error", () => {
     h = mount(<PairStep onPaired={noopOnPaired} />);
-    act(() => {
-      (
-        h!.container.querySelector("button") as HTMLButtonElement | null
-      )?.click();
-    });
     const host = h.container.querySelector(
       "#pair-host",
     ) as HTMLInputElement | null;
     expect(host).not.toBeNull();
 
     // Type a non-http(s) value — should flag invalid.
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )?.set;
-      setter?.call(host, "ftp://nope.example.com");
-      host!.dispatchEvent(new Event("input", { bubbles: true }));
-    });
+    act(() => setInputValue(host!, "ftp://nope.example.com"));
     expect(host?.getAttribute("aria-invalid")).toBe("true");
     expect(h.text()).toContain(
       "Server URL must start with http:// or https://",
     );
 
     // A valid https URL clears it.
-    act(() => {
-      const setter = Object.getOwnPropertyDescriptor(
-        window.HTMLInputElement.prototype,
-        "value",
-      )?.set;
-      setter?.call(host, "https://box.example.com");
-      host!.dispatchEvent(new Event("input", { bubbles: true }));
-    });
+    act(() => setInputValue(host!, "https://box.example.com"));
     expect(host?.getAttribute("aria-invalid")).toBe("false");
     expect(h.text()).not.toContain(
       "Server URL must start with http:// or https://",
     );
   });
 
-  it("footer hint mentions `manta pair` and there is no Skip-setup button", () => {
+  it("zone C hint mentions `manta pair` and there is no Skip-setup button", () => {
     h = mount(<PairStep onPaired={noopOnPaired} />);
-    act(() => {
-      (
-        h!.container.querySelector("button") as HTMLButtonElement | null
-      )?.click();
-    });
     expect(h.text()).toContain("manta pair");
-    // The form-footer hint AND the toggle button are the only buttons on
-    // the step when the form is open — no third "Skip setup" anywhere.
-    const buttons = Array.from(h.container.querySelectorAll("button"));
-    const labels = buttons.map((b) => b.textContent?.trim());
+    const labels = Array.from(h.container.querySelectorAll("button")).map((b) =>
+      b.textContent?.trim(),
+    );
     expect(labels.some((l) => l === "Skip setup")).toBe(false);
-    // And the footer hint is in a <p>, not in the per-input help text under
-    // the Code input.
+    // The hint is in zone C, not under the Code input.
     const codeInput = h.container.querySelector("#pair-code");
     expect(codeInput?.parentElement?.querySelector("p")).toBeNull();
+  });
+
+  it("mode switch — 'Back to the host picker' swaps zone A out of manual", () => {
+    h = mount(<PairStep onPaired={noopOnPaired} />);
+    expect(h.container.querySelector("#pair-box-id")).not.toBeNull();
+
+    const back = buttonByText(h.container, "Back to the host picker");
+    expect(back).not.toBeNull();
+    act(() => back!.click());
+
+    // Without an installer, ssh mode renders SshInstallStep's fallback; the
+    // manual fields leave the DOM.
+    expect(h.container.querySelector("#pair-box-id")).toBeNull();
+    expect(h.container.querySelector("#pair-code")).toBeNull();
+    expect(h.text()).toContain("SSH installer");
   });
 });

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -279,7 +279,7 @@ function ManualPairPanel({
             className="text-label font-medium text-text-muted flex items-center gap-2"
           >
             Host
-            {fromClipboard && (
+            {fromClipboard && prefill && (
               <span className="inline-flex items-center gap-2 text-meta rounded-full px-2 py-1 bg-accent-bg text-accent border border-accent">
                 from clipboard
               </span>

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -1,27 +1,27 @@
 // PairStep.tsx — Step 1 (Connect) of the desktop onboarding shell (BET-356).
 //
-// One heading, one primary action (BET-382). The SSH picker is the primary
-// surface; the manual pairing form sits behind a plain text button labelled
-// "Pair to an existing box" / "Hide" so a box the user can't reach over SSH
-// (corporate VPN, jump host, manual VPS install) still has an escape hatch.
-// The two paths share the same `onPaired` callback so the shell advances
-// identically regardless of which one closed the deal.
+// One Connect panel, two modes (BET-962). Zone A is either the SSH host
+// picker (default — `ssh` mode, rendered by SshInstallStep) or the manual
+// code-entry fields (`manual` mode). A plain text link under zone A toggles
+// between them: "Enter a pairing code instead" ↔ "Back to the host picker".
+// Zones B, C and D behave identically in both modes — both feed the SAME
+// four-zone ConnectPanel through the single deriveConnectPanel descriptor, so
+// there is exactly one function deciding what the panel says.
 //
-// The deep-link manta://pair?box=…&code=… flow (#277, BET-335, BET-336)
-// remains in scope: if a valid pair-link is pending at mount, the SSH
-// picker is hidden and the manual form is pre-filled from it (one row,
-// three fields: Host · Box ID · Code), so a single click on Connect IS the
-// confirmation. The picker returns next time the user re-enters onboarding
-// from a clean state.
+// The manual path:
+//   - A pending deep-link (manta://pair?box=…&code=…) forces manual mode on
+//     mount with the fields pre-filled — one click on Connect confirms.
+//   - A clipboard pair-link (BET-704) switches zone A to manual mode, fills
+//     the fields through the SAME pendingPairLink path (no second prefill
+//     mechanism), and renders a "from clipboard" chip beside the address.
+//   - A successful claim lands on the same "Connected — your box is ready" +
+//     Next → state the SSH path ends on, so both pairing paths converge.
 //
-// Props:
-//   onPaired — successful pair (SSH install + claim OR manual claim). The
-//              shell decides what to do next — usually it runs the
-//              post-pair verification (BET-356 §4 "verify by working").
+// Both modes call `onPaired` when the panel's Next is pressed; the shell
+// decides what to do next (usually post-pair verification, BET-356 §4).
 //
-// Onboarding.tsx's `skip` / store.skipOnboarding are still reachable from
-// Settings ("re-run onboarding" path) and stay wired up — the prop is gone
-// from PairStep but the action is not.
+// Onboarding.tsx's `skip` / store.skipOnboarding stays reachable from
+// Settings and is unaffected.
 
 import { useEffect, useRef, useState } from "react";
 import {
@@ -31,13 +31,14 @@ import {
 } from "../shared/setupLogic";
 import { detectPairClipboard } from "../shared/pairPayload";
 import { PairingCodeInput } from "./PairingCodeInput";
-import { Button } from "./Button";
 import { isValidBoxToken } from "../shared/transport.mjs";
 import { claimBox } from "./pairClaim";
 import { useStore } from "./store";
 import { SshInstallStep } from "./SshInstallStep";
 import { getMantaPreload } from "./preloadAccess";
 import { channelConfig } from "../shared/channel.mjs";
+import { ConnectPanel } from "./ConnectPanel";
+import { deriveConnectPanel, type ConnectActionId } from "./connectPanel";
 
 const DANGER = "var(--danger)"; // inline error text
 const SERVER_URL_ERROR = "Server URL must start with http:// or https://";
@@ -64,27 +65,31 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
   const hasSshInstaller = getMantaPreload() !== null;
 
   // Deep-link (BET-335) — if a manta://pair?... URL is pending in the store
-  // at mount, prefill the manual form from it and force the disclosure open
-  // so the user sees the address they're about to pair against. When no
-  // link is pending, show the SSH picker as the primary surface.
+  // at mount, prefill the manual form from it and force manual mode so the
+  // user sees the address they're about to pair against. When no link is
+  // pending and an SSH installer exists, show the picker as the default mode.
   const pendingPairLink = useStore.getState().pendingPairLink;
   const prefill = prefillFromPairLink(pendingPairLink, PAIR_PREFILL_SCHEME);
-  const [disclosureOpen, setDisclosureOpen] = useState(() => Boolean(prefill));
-  // On a renderer without an SSH installer (mobile / web), the picker is
-  // unavailable — surface the manual form immediately rather than render an
-  // empty shell.
-  const showSshPicker = hasSshInstaller && !prefill;
+
+  // Mode of zone A (BET-962). A pending deep-link forces manual mode on
+  // mount; on a renderer without an SSH installer the picker is unavailable,
+  // so manual mode becomes the default. Otherwise the picker is primary.
+  const [mode, setMode] = useState<"ssh" | "manual">(() =>
+    prefill ? "manual" : hasSshInstaller ? "ssh" : "manual",
+  );
+  // Whether the current prefill came from the clipboard (vs a deep-link) —
+  // renders the "from clipboard" chip beside the address.
+  const [fromClipboard, setFromClipboard] = useState(false);
 
   // Clipboard pair-link detection (BET-704): a user who received a pairing
   // link elsewhere (chat message, terminal copy) shouldn't have to retype
   // it. Checked on mount AND on window focus while this step is shown — no
-  // polling/intervals. A hit renders a dismissible banner; "Use it" routes
-  // through the SAME pendingPairLink mechanism the OS deep-link handler
-  // uses (App.tsx's onPairLink → setPendingPairLink → prefillFromPairLink),
-  // so there is exactly one prefill code path. The user still clicks
-  // Connect — this never auto-claims.
+  // polling/intervals. A hit switches zone A to manual mode and routes
+  // through the SAME pendingPairLink mechanism the OS deep-link handler uses
+  // (App.tsx's onPairLink → setPendingPairLink → prefillFromPairLink), so
+  // there is exactly one prefill code path. The user still clicks Connect —
+  // this never auto-claims.
   const lastClipboardRef = useRef<string | null>(null);
-  const [clipboardHit, setClipboardHit] = useState<string | null>(null);
 
   useEffect(() => {
     const preload = getMantaPreload();
@@ -96,12 +101,15 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
         try {
           text = await preload.readClipboardText();
         } catch {
-          return; // clipboard read failed — silently no banner
+          return; // clipboard read failed — silently no-op
         }
         const trimmed = (text ?? "").trim();
         if (!trimmed || trimmed === lastClipboardRef.current) return;
         if (!detectPairClipboard(trimmed, PAIR_PREFILL_SCHEME)) return;
-        setClipboardHit(trimmed);
+        lastClipboardRef.current = trimmed;
+        useStore.getState().setPendingPairLink(trimmed);
+        setFromClipboard(true);
+        setMode("manual");
       })();
     };
 
@@ -109,19 +117,6 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
     window.addEventListener("focus", check);
     return () => window.removeEventListener("focus", check);
   }, []);
-
-  const dismissClipboardHit = () => {
-    lastClipboardRef.current = clipboardHit;
-    setClipboardHit(null);
-  };
-
-  const useClipboardHit = () => {
-    if (!clipboardHit) return;
-    lastClipboardRef.current = clipboardHit;
-    useStore.getState().setPendingPairLink(clipboardHit);
-    setClipboardHit(null);
-    setDisclosureOpen(true);
-  };
 
   return (
     <div>
@@ -133,93 +128,65 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
         and pairs with this app — no terminal needed.
       </p>
 
-      {showSshPicker && (
+      {mode === "ssh" ? (
         <div className="mb-6">
           <SshInstallStep
             onPaired={onPaired}
-            onPairManually={() => setDisclosureOpen(true)}
+            // BET-962: the picker's "Enter a pairing code instead" link (and
+            // the install-failed "Pair manually" action) switch zone A to
+            // manual mode — there is no separate disclosure any more.
+            onPairManually={() => setMode("manual")}
           />
         </div>
-      )}
-
-      <button
-        type="button"
-        onClick={() => setDisclosureOpen((v) => !v)}
-        className="text-meta text-text-faint hover:text-text-muted underline underline-offset-4 decoration-border-strong transition-colors mt-6"
-      >
-        {disclosureOpen ? "Hide" : "Pair to an existing box"}
-      </button>
-      {clipboardHit && (
-        <div className="mt-3 flex items-center justify-between gap-3 rounded-sm border border-border bg-bg-soft px-3 py-2 text-body text-text">
-          <span>Pairing link detected</span>
-          <div className="flex items-center gap-3">
-            <button
-              type="button"
-              onClick={useClipboardHit}
-              className="text-body font-medium text-accent hover:underline"
-            >
-              Use it
-            </button>
-            <button
-              type="button"
-              onClick={dismissClipboardHit}
-              aria-label="Dismiss"
-              className="text-text-faint hover:text-text-muted"
-            >
-              ×
-            </button>
-          </div>
-        </div>
-      )}
-      {disclosureOpen && (
+      ) : (
         // Keyed on pendingPairLink so a clipboard "Use it" click prefills a
-        // manual form that is ALREADY open (a fresh mount is the only way
+        // manual panel that is ALREADY open (a fresh mount is the only way
         // this component's useState-seeded fields pick up a new prefill —
-        // the same mechanism the deep-link path already relies on, just
-        // made to also work when the form was open before the link arrived).
-        <ManualPairForm
+        // the same mechanism the deep-link path already relies on).
+        <ManualPairPanel
           key={pendingPairLink ?? "no-prefill"}
           prefill={prefill}
+          fromClipboard={fromClipboard}
           onPaired={onPaired}
+          onBackToPicker={() => setMode("ssh")}
         />
       )}
     </div>
   );
 }
 
-// Manual code-entry form. Extracted from PairStep so the disclosure can
-// mount it as a self-contained block. The pure validation/submit-gate lives
-// in shared/setupLogic.ts (canConnectSetup / normalizeServerUrl);
-// this component is wiring + JSX only — no validation logic is duplicated
-// here (BET-382).
-//
-// Layout (BET-382): one row of three fields on ≥640px (Host · Box ID · Code),
-// stacked to one column under `sm`. The "Host" input replaces the old
-// "Advanced → Server URL" disclosure — the value still flows through
-// `serverUrl` state and the same `Server URL must start with http:// or
-// https://` validation, so the tailnet path (BET-268) and the deep-link
-// prefill (BET-336) keep working unchanged.
-function ManualPairForm({
+// Manual code-entry mode of the Connect panel's zone A (BET-962). Renders the
+// same Host / Box ID / Code grid the old standalone ManualPairForm had —
+// moved unchanged into zone A — but no longer owns status, actions or the
+// footer button: those are the Connect panel's zones B and D, fed by
+// deriveConnectPanel below. Pure validation stays in shared/setupLogic.ts
+// (canConnectSetup / normalizeServerUrl); this component is wiring + JSX only.
+function ManualPairPanel({
   prefill,
+  fromClipboard,
   onPaired,
+  onBackToPicker,
 }: {
   prefill: ReturnType<typeof prefillFromPairLink>;
+  fromClipboard: boolean;
   onPaired: () => void;
+  onBackToPicker: () => void;
 }) {
   const [boxId, setBoxId] = useState(() => prefill?.boxId ?? "");
   const [code, setCode] = useState(() => prefill?.code ?? "");
   const [serverUrl, setServerUrl] = useState(() => prefill?.serverUrl ?? "");
   const [submitting, setSubmitting] = useState(false);
-  const [error, setError] = useState<string | null>(null);
+  const [claimError, setClaimError] = useState<string | null>(null);
+  const [paired, setPaired] = useState(false);
   const codeRef = useRef<HTMLInputElement>(null);
 
-  // Deep-link failure reason (BET-335). Rendered in the same inline slot
-  // a manual Connect failure uses; consume-on-read so a re-fire still
-  // changes the value.
+  // Deep-link failure reason (BET-335). Rendered as the claim error the
+  // manual panel surfaces; consume-on-read so a re-fire still changes the
+  // value.
   const pairLinkError = useStore((s) => s.pairLinkError);
   useEffect(() => {
     if (!pairLinkError) return;
-    setError(pairLinkError);
+    setClaimError(pairLinkError);
     useStore.getState().setPairLinkError(null);
     codeRef.current?.focus();
   }, [pairLinkError]);
@@ -228,17 +195,26 @@ function ManualPairForm({
   const serverUrlInvalid =
     serverUrlTrimmed !== "" && normalizeServerUrl(serverUrlTrimmed) === null;
 
-  const connectEnabled = canConnectSetup({
+  const canConnect = canConnectSetup({
     boxId,
     code,
     submitting,
     serverUrl: serverUrlTrimmed,
   });
 
+  const connectState = deriveConnectPanel({
+    mode: "manual",
+    paired,
+    claimError,
+    prefillPresent: Boolean(prefill),
+    canConnect,
+    submitting,
+  });
+
   const connect = async () => {
-    if (!connectEnabled) return;
+    if (!canConnect) return;
     setSubmitting(true);
-    setError(null);
+    setClaimError(null);
     const result = await claimBox({
       boxId: boxId.trim(),
       code,
@@ -247,36 +223,67 @@ function ManualPairForm({
     if (result.ok) {
       useStore.getState().setPendingPairLink(null);
       setSubmitting(false);
-      onPaired();
+      // Hold the step on the "Connected" + Next → state (BET-962 converges
+      // the manual path on the SSH path's ending) instead of auto-advancing.
+      setPaired(true);
       return;
     }
     setSubmitting(false);
-    setError(result.message);
+    setClaimError(result.message);
     codeRef.current?.focus();
   };
 
-  const onFormSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    void connect();
-  };
+  function handleAction(id: ConnectActionId) {
+    switch (id) {
+      case "connect":
+        void connect();
+        break;
+      case "discard":
+        // Toss the pending prefill and fall back to idle code entry.
+        useStore.getState().setPendingPairLink(null);
+        setBoxId("");
+        setCode("");
+        setServerUrl("");
+        setClaimError(null);
+        break;
+      case "cancel":
+        setSubmitting(false);
+        break;
+      case "retry":
+        void connect();
+        break;
+      case "next":
+        onPaired();
+        break;
+      default:
+        break;
+    }
+  }
 
   const boxIdLooksBad = boxId.trim() !== "" && !isValidBoxToken(boxId.trim());
+  const locked = connectState.targetLocked;
 
-  return (
-    <form onSubmit={onFormSubmit} className="flex flex-col gap-4 mt-3">
+  // Zone A — the manual code-entry fields, in the same responsive grid the
+  // old standalone form used, plus the mode-switch link back to the picker.
+  const zoneA = (
+    <div className="space-y-2">
       <div className="grid grid-cols-1 sm:grid-cols-[1.5fr_1.5fr_0.9fr] gap-3 items-end">
-        {/* Host — replaces the old Advanced → Server URL disclosure. The
-            value is still named `serverUrl` and still flows through
-            normalizeServerUrl / canConnectSetup, so the tailnet path
-            (BET-268) and the deep-link server= override (BET-336) work
-            unchanged. The validation error renders inline under this input
-            only (the grid cell wraps input + error). */}
+        {/* Host — the value still flows through `serverUrl` state and the same
+            `Server URL must start with http:// or https://` validation, so the
+            tailnet path (BET-268) and the deep-link server= override (BET-336)
+            keep working unchanged. A clipboard-detected link shows the
+            "from clipboard" chip beside the address. */}
         <div className="flex flex-col gap-2">
           <label
             htmlFor="pair-host"
-            className="text-label font-medium text-text-muted"
+            className="text-label font-medium text-text-muted flex items-center gap-2"
           >
             Host
+            {fromClipboard && (
+              <span className="inline-flex items-center gap-1.5 text-meta rounded-full px-2 py-0.5 bg-accent-bg text-accent border border-accent">
+                from clipboard
+              </span>
+            )}
           </label>
           <input
             id="pair-host"
@@ -285,11 +292,11 @@ function ManualPairForm({
             autoComplete="off"
             spellCheck={false}
             placeholder="https://box.mantaui.com"
-            disabled={submitting}
+            disabled={locked}
             value={serverUrl}
             onChange={(e) => {
               setServerUrl(e.target.value);
-              setError(null);
+              setClaimError(null);
             }}
             aria-invalid={serverUrlInvalid}
             aria-describedby={serverUrlInvalid ? "pair-host-err" : undefined}
@@ -326,11 +333,11 @@ function ManualPairForm({
             autoComplete="off"
             spellCheck={false}
             placeholder="0d5784a7a43451f4ad70dd3d9ee5cf72"
-            disabled={submitting}
+            disabled={locked}
             value={boxId}
             onChange={(e) => {
               setBoxId(e.target.value.trim());
-              setError(null);
+              setClaimError(null);
             }}
             aria-invalid={boxIdLooksBad}
             className="w-full rounded-sm bg-bg border px-3 py-2 text-body font-mono text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
@@ -338,9 +345,7 @@ function ManualPairForm({
           />
         </div>
 
-        {/* Pairing code — 6 digits, monospace, centered. Drops the
-            previous text-2xl + tracking-[0.4em] (oversized); becomes a
-            normal-size input that still reads as "this is a code". */}
+        {/* Pairing code — 6 digits, monospace, centered. */}
         <div className="flex flex-col gap-2">
           <label
             htmlFor="pair-code"
@@ -351,39 +356,35 @@ function ManualPairForm({
           <PairingCodeInput
             id="pair-code"
             ref={codeRef}
-            disabled={submitting}
-            hasError={error != null}
+            disabled={locked}
+            hasError={claimError != null}
             value={code}
             onChange={(v) => {
               setCode(v);
-              setError(null);
+              setClaimError(null);
             }}
             className="w-full rounded-sm bg-bg border border-border px-3 py-2 text-center font-mono tracking-[0.22em] text-text outline-none transition-colors focus:border-accent disabled:opacity-60"
           />
         </div>
       </div>
 
-      {error && (
-        <div role="alert" className="text-body" style={{ color: DANGER }}>
-          {error}
-        </div>
-      )}
+      {/* BET-962: mode switch back to the host picker — zone A link. */}
+      <button
+        type="button"
+        onClick={onBackToPicker}
+        className="text-meta text-text-faint hover:text-text-muted underline underline-offset-4 decoration-border-strong transition-colors"
+      >
+        Back to the host picker
+      </button>
+    </div>
+  );
 
-      {/* Footer: hint (left) + Connect (right). The Skip-setup button was
-          removed in BET-382; `skip` / skipOnboarding remain reachable from
-          Settings for users who need to re-run onboarding. */}
-      <div className="flex items-center justify-between gap-3 pt-1">
-        <p className="text-meta text-text-faint">
-          Run{" "}
-          <code className="rounded-xs bg-bg px-2 py-px text-label font-mono text-text-muted">
-            manta pair
-          </code>{" "}
-          on the box to get a code.
-        </p>
-        <Button tone="primary" type="submit" disabled={!connectEnabled}>
-          {submitting ? "Connecting…" : "Connect"}
-        </Button>
-      </div>
-    </form>
+  return (
+    <ConnectPanel
+      state={connectState}
+      target={zoneA}
+      logLines={[]}
+      onAction={handleAction}
+    />
   );
 }

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -280,7 +280,7 @@ function ManualPairPanel({
           >
             Host
             {fromClipboard && (
-              <span className="inline-flex items-center gap-1.5 text-meta rounded-full px-2 py-0.5 bg-accent-bg text-accent border border-accent">
+              <span className="inline-flex items-center gap-2 text-meta rounded-full px-2 py-1 bg-accent-bg text-accent border border-accent">
                 from clipboard
               </span>
             )}

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -618,6 +618,7 @@ export function SshInstallStep({
   const connectState = useMemo(
     () =>
       deriveConnectPanel({
+        mode: "ssh",
         hostsLoaded,
         targetError,
         running,
@@ -838,6 +839,17 @@ export function SshInstallStep({
           {targetError}
         </p>
       )}
+
+      {/* BET-962: manual pairing is a MODE of zone A, not a separate form —
+          a plain-text link under the picker switches to code entry. Same link
+          styling the old PairStep disclosure toggle used. */}
+      <button
+        type="button"
+        onClick={onPairManually}
+        className="text-meta text-text-faint hover:text-text-muted underline underline-offset-4 decoration-border-strong transition-colors"
+      >
+        Enter a pairing code instead
+      </button>
     </div>
   );
 

--- a/src/renderer/connectPanel.test.ts
+++ b/src/renderer/connectPanel.test.ts
@@ -13,6 +13,7 @@ import {
 } from "./connectPanel";
 
 const base: ConnectInput = {
+  mode: "ssh",
   hostsLoaded: true,
   targetError: null,
   running: false,
@@ -30,7 +31,7 @@ const base: ConnectInput = {
   paired: false,
 };
 
-const status = (patch: Partial<ConnectInput>) => {
+const status = (patch: Partial<Extract<ConnectInput, { mode: "ssh" }>>) => {
   const s = deriveConnectPanel({ ...base, ...patch });
   return { tone: s.status.tone, text: s.status.text, meta: s.status.meta };
 };
@@ -247,5 +248,119 @@ describe("deriveConnectPanel — precedence table (BET-961)", () => {
     expect(deriveConnectPanel({ ...base, claimRunning: true }).targetLocked).toBe(true);
     expect(deriveConnectPanel({ ...base, paired: true }).targetLocked).toBe(true);
     expect(deriveConnectPanel(base).targetLocked).toBe(false);
+  });
+});
+
+// Manual mode (BET-962) — one case per row in the issue's table.
+function manual(patch: Partial<ConnectInput>): ConnectInput {
+  return {
+    mode: "manual",
+    claimError: null,
+    paired: false,
+    prefillPresent: false,
+    canConnect: false,
+    submitting: false,
+    ...patch,
+  } as ConnectInput;
+}
+
+describe("deriveConnectPanel — manual mode rows (BET-962)", () => {
+  it("M1 — prefill present: 'Pairing link ready' + Connect/Discard", () => {
+    const s = deriveConnectPanel(
+      manual({ prefillPresent: true, canConnect: true }),
+    );
+    expect(s.status).toEqual({
+      tone: "idle",
+      text: "Pairing link ready",
+      meta: null,
+      progress: null,
+      sub: null,
+    });
+    expect(s.details.kind).toBe("none");
+    expect(s.actions).toEqual(["connect", "discard"]);
+    expect(s.hint).toBeNull();
+    expect(s.targetLocked).toBe(false);
+  });
+
+  it("M2 — idle manual: 'Enter the 6-digit code from the box' + hint; Connect disabled until canConnect", () => {
+    const idle = deriveConnectPanel(manual({}));
+    expect(idle.status).toEqual({
+      tone: "idle",
+      text: "Enter the 6-digit code from the box",
+      meta: null,
+      progress: null,
+      sub: null,
+    });
+    expect(idle.details).toEqual({
+      kind: "hint",
+      text: "Run `manta pair` on the box to get a code.",
+    });
+    expect(idle.actions).toEqual(["connect"]);
+    expect(idle.disabledActions).toEqual(["connect"]);
+
+    // canConnectSetup passes → Connect enabled (no disabledActions).
+    const ready = deriveConnectPanel(manual({ canConnect: true }));
+    expect(ready.disabledActions).toBeUndefined();
+  });
+
+  it("M3 — submitting: 'Pairing with this app' + cancel, zone A locked", () => {
+    const s = deriveConnectPanel(manual({ submitting: true, canConnect: true }));
+    expect(s.status).toEqual({
+      tone: "running",
+      text: "Pairing with this app",
+      meta: null,
+      progress: null,
+      sub: null,
+    });
+    expect(s.details.kind).toBe("none");
+    expect(s.actions).toEqual(["cancel"]);
+    expect(s.targetLocked).toBe(true);
+  });
+
+  it("M4 — claim failed: the message claimBox returned + Try again", () => {
+    const s = deriveConnectPanel(manual({ claimError: "Claim failed: nope" }));
+    expect(s.status).toEqual({
+      tone: "error",
+      text: "Claim failed: nope",
+      meta: null,
+      progress: null,
+      sub: null,
+    });
+    expect(s.details.kind).toBe("none");
+    expect(s.actions).toEqual(["retry"]);
+    expect(s.targetLocked).toBe(false);
+  });
+
+  it("M5 — claim succeeded: 'Connected — your box is ready' + Next → (same ending as SSH)", () => {
+    const s = deriveConnectPanel(manual({ paired: true }));
+    expect(s.status).toEqual({
+      tone: "ok",
+      text: "Connected — your box is ready",
+      meta: null,
+      progress: null,
+      sub: null,
+    });
+    expect(s.details.kind).toBe("none");
+    expect(s.actions).toEqual(["next"]);
+    expect(s.targetLocked).toBe(true);
+  });
+
+  it("precedence — paired beats a claim error in manual mode", () => {
+    const s = deriveConnectPanel(manual({ paired: true, claimError: "x" }));
+    expect(s.status.text).toBe("Connected — your box is ready");
+    expect(s.actions).toEqual(["next"]);
+  });
+
+  it("precedence — claim error and submitting beat prefill present", () => {
+    expect(
+      deriveConnectPanel(
+        manual({ prefillPresent: true, claimError: "x" }),
+      ).status.text,
+    ).toBe("x");
+    expect(
+      deriveConnectPanel(
+        manual({ prefillPresent: true, submitting: true }),
+      ).status.text,
+    ).toBe("Pairing with this app");
   });
 });

--- a/src/renderer/connectPanel.ts
+++ b/src/renderer/connectPanel.ts
@@ -1,17 +1,24 @@
-// connectPanel.ts — the single lever that collapses SshInstallStep's many
-// render branches into one four-zone Connect panel (BET-961).
+// connectPanel.ts — the single lever that collapses the onboarding step-1
+// Connect panel's many render branches into one four-zone descriptor (BET-961).
 //
-// SshInstallStep holds ~15 pieces of state (hosts, targetError, running,
-// stage, elapsed, done, installError, preflightFailure, the two prompts, the
-// claim trio, cancelled, paired). Today each combination gets its own ad-hoc
-// branch, so status appears in five vertical positions and errors come in four
-// shapes. This module maps that state onto ONE descriptor — status (tone/text/
-// meta/progress/sub), details (log/failures/hint/none), actions, hint and an
-// A-zone lock — and ConnectPanel.tsx renders that descriptor, so nothing moves
-// between states.
+// PairStep shows ONE Connect panel in two modes (BET-962): `ssh` (the host
+// picker + install) or `manual` (code entry). Both modes share the same four
+// zones — A·target, B·status, C·details, D·actions — and both funnel through
+// this one function, which decides what the panel says from a mode-
+// discriminated input. There is deliberately no second derive function and no
+// mode branch inside ConnectPanel.tsx; the component just renders whatever
+// descriptor this module produces.
+//
+// SshInstallStep feeds the `ssh` branch of `ConnectInput` (its ~15 pieces of
+// install state); the manual code-entry mode feeds the `manual` branch.
+// Today each combination used to get its own ad-hoc branch, so status
+// appeared in five vertical positions and errors in four shapes. This module
+// maps that state onto ONE descriptor — status (tone/text/meta/progress/sub),
+// details (log/failures/hint/none), actions, hint and the zone-A lock — and
+// ConnectPanel.tsx renders that descriptor, so nothing moves between states.
 //
 // Pure, no JSX, no React. The precedence rules below are the acceptance gate:
-// one first-match-wins table, eleven rows, evaluated in exactly this order.
+// one first-match-wins table per mode, rows evaluated in exactly this order.
 //
 // Reused, not reimplemented:
 //   - stage label / index / total -> currentStageInfo (src/shared/installStages.ts)
@@ -34,7 +41,9 @@ export type ConnectActionId =
   | "next"
   | "retry"
   | "editTarget"
-  | "pairManually";
+  | "pairManually"
+  | "connect"
+  | "discard";
 
 export type ConnectPanelState = {
   status: {
@@ -46,28 +55,58 @@ export type ConnectPanelState = {
   };
   details: ConnectDetails;
   actions: ConnectActionId[]; // first is primary, rest secondary
+  /** Action ids whose button must render disabled. The manual mode's Connect
+   *  stays disabled until `canConnectSetup` passes; the ssh mode has its own
+   *  inline gate. Absent/undefined = nothing disabled beyond the panel's own
+   *  install gate. */
+  disabledActions?: ConnectActionId[];
   hint: string | null; // right-aligned text in zone D
   targetLocked: boolean;
 };
+
+/** The claim outcome — shared by both modes. */
+export type SharedConnectFields = {
+  claimError: string | null; // the message claimBox / mint returned on failure
+  paired: boolean; // claim succeeded — the terminal "Connected" row for both modes
+};
+
+/** The SSH-install mode's state (owned by SshInstallStep). */
+export type SshConnectFields = {
+  hostsLoaded: boolean;
+  targetError: string | null;
+  running: boolean;
+  stage: InstallStageId;
+  elapsedSeconds: number;
+  logLineCount: number;
+  done: { ok: boolean; code: number | null; signal: string | null } | null;
+  installError: string | null;
+  preflightFailure: { failures: Array<{ cause: string; action: string }> } | null;
+  awaitingPrompt: boolean; // fingerprintPrompt !== null || passphrasePrompt !== null
+  claimRunning: boolean;
+  claimElapsed: number | null;
+  cancelled: boolean;
+};
+
+/** The manual code-entry mode's state (BET-962). */
+export type ManualConnectFields = {
+  prefillPresent: boolean; // clipboard / deep-link prefill → "Pairing link ready"
+  canConnect: boolean; // canConnectSetup result → Connect disabled until true
+  submitting: boolean; // claim in flight
+};
+
+export type ConnectInput =
+  | ({ mode: "ssh" } & SshConnectFields & SharedConnectFields)
+  | ({ mode: "manual" } & ManualConnectFields & SharedConnectFields);
 
 /** The row-4 pairing-failed hint. `manta pair` is rendered as <code> by
  *  ConnectPanel by splitting the backticks — keep the backticks here. */
 const CLAIM_FAILED_HINT =
   "The box is running. Run `manta pair` on it for a fresh 6-digit code, then enter it here.";
 
-/**
- * Build the thing ConnectPanel renders. `targetLocked` locks zone A (the
- * host picker) — true while an install or claim is in flight, or after
- * pairing succeeded.
- */
-function computeTargetLocked(input: ConnectInput): boolean {
-  return input.running || input.claimRunning || input.paired;
-}
-
 /** `<stage meta>` — `${index} of ${total}` plus the elapsed time while the
  *  operation is actively progressing (install running OR claim retrying).
  *  Matches the mockup: running stages and the claim states both show time. */
-function stageMeta(input: ConnectInput): string {
+function stageMeta(input: Extract<ConnectInput, { mode: "ssh" }>): string {
   const { index, total } = currentStageInfo(input.stage);
   const active = input.running || input.claimRunning;
   return active
@@ -86,33 +125,99 @@ function logDetails(
   return { kind: "log", defaultOpen, showCopyDiagnostics };
 }
 
-export type ConnectInput = {
-  hostsLoaded: boolean;
-  targetError: string | null;
-  running: boolean;
-  stage: InstallStageId;
-  elapsedSeconds: number;
-  logLineCount: number;
-  done: { ok: boolean; code: number | null; signal: string | null } | null;
-  installError: string | null;
-  preflightFailure: { failures: Array<{ cause: string; action: string }> } | null;
-  awaitingPrompt: boolean; // fingerprintPrompt !== null || passphrasePrompt !== null
-  claimRunning: boolean;
-  claimElapsed: number | null;
-  claimError: string | null;
-  cancelled: boolean;
-  paired: boolean;
-};
-
 /**
- * Evaluate the precedence table first-match-wins. The table order in the
- * switch below is load-bearing — never reorder a row. `paired` beats
- * everything (a completed pair must hand off to the provider step); a user
- * `cancelled` beats `done.ok === false` (a cancel surfaces as a neutral
+ * Evaluate the mode's precedence table first-match-wins. The table order in
+ * each block is load-bearing — never reorder a row. In both modes `paired`
+ * beats everything (a completed pair must hand off to the provider step); a
+ * user `cancelled` beats `done.ok === false` (a cancel surfaces as a neutral
  * `done` with SIGTERM, and must not read as a failure).
  */
 export function deriveConnectPanel(input: ConnectInput): ConnectPanelState {
-  const targetLocked = computeTargetLocked(input);
+  // ===== manual mode (rows M1–M5, BET-962) =====
+  if (input.mode === "manual") {
+    // M5 — claim succeeded → same terminal row as SSH: Connected + Next →.
+    if (input.paired) {
+      return {
+        status: {
+          tone: "ok",
+          text: "Connected — your box is ready",
+          meta: null,
+          progress: null,
+          sub: null,
+        },
+        details: { kind: "none" },
+        actions: ["next"],
+        hint: null,
+        targetLocked: true,
+      };
+    }
+    // M4 — claim failed: surface the exact message claimBox returned.
+    if (input.claimError) {
+      return {
+        status: {
+          tone: "error",
+          text: input.claimError,
+          meta: null,
+          progress: null,
+          sub: null,
+        },
+        details: { kind: "none" },
+        actions: ["retry"],
+        hint: null,
+        targetLocked: false,
+      };
+    }
+    // M3 — submitting.
+    if (input.submitting) {
+      return {
+        status: {
+          tone: "running",
+          text: "Pairing with this app",
+          meta: null,
+          progress: null,
+          sub: null,
+        },
+        details: { kind: "none" },
+        actions: ["cancel"],
+        hint: null,
+        targetLocked: true,
+      };
+    }
+    // M1 — clipboard / deep-link prefill present: Confirm or discard it.
+    if (input.prefillPresent) {
+      return {
+        status: {
+          tone: "idle",
+          text: "Pairing link ready",
+          meta: null,
+          progress: null,
+          sub: null,
+        },
+        details: { kind: "none" },
+        actions: ["connect", "discard"],
+        hint: null,
+        targetLocked: false,
+      };
+    }
+    // M2 — idle manual (default): the code is typed by hand.
+    return {
+      status: {
+        tone: "idle",
+        text: "Enter the 6-digit code from the box",
+        meta: null,
+        progress: null,
+        sub: null,
+      },
+      details: { kind: "hint", text: "Run `manta pair` on the box to get a code." },
+      actions: ["connect"],
+      disabledActions: input.canConnect ? undefined : ["connect"],
+      hint: null,
+      targetLocked: false,
+    };
+  }
+
+  // ===== SSH install mode (rows 1–11) =====
+  const targetLocked = input.running || input.claimRunning || input.paired;
   const { index, total, label } = currentStageInfo(input.stage);
   const progress = index / total;
 


### PR DESCRIPTION
## Summary

BET-962 — manual pairing becomes a **mode of zone A** of the onboarding Connect
panel, not a second, parallel form. Zones B/C/D behave identically in both
modes; both funnel through the single `deriveConnectPanel` descriptor (now
mode-aware via a `mode: "ssh" | "manual"` input).

## Changes

- **`src/renderer/connectPanel.ts`** — `ConnectInput` is now a mode-discriminated
  union (`ssh` | `manual`). Five explicit manual rows added (prefill-ready /
  idle / submitting / claim-failed / claim-succeeded), evaluated first-match-wins
  inside the SAME `deriveConnectPanel`. Both modes end on the same
  "Connected — your box is ready" + `Next →` row.
- **`src/renderer/PairStep.tsx`** — owns the mode switch. `ssh` mode renders the
  host picker; `manual` mode renders the Host/Box ID/Code fields moved unchanged
  into zone A. The `disclosureOpen` state, the disclosure toggle, and the
  standalone `ManualPairForm` error slot + footer are deleted. The clipboard
  banner is gone; a detected link routes through the existing
  `pendingPairLink` prefill path, switches zone A to manual, and renders a
  "from clipboard" chip beside the address. A pending deep-link forces manual
  mode on mount.
- **`src/renderer/ConnectPanel.tsx`** — adds the `connect`/`discard` action
  labels and a `disabledActions` field so the manual Connect can render disabled
  until `canConnectSetup` passes. No mode branch inside the panel component.
- **`src/renderer/SshInstallStep.tsx`** — zone A gains the "Enter a pairing code
  instead" link (reusing the old disclosure link styling) which flips to manual
  mode via the existing `onPairManually` hook.
- **Tests** — `connectPanel.test.ts` gained one case per manual row (+ precedence),
  `PairStep.test.tsx` rewritten against the mode switch (deep-link prefill,
  manual default, Connect-disabled-until-valid, Host validation, mode switch).

## Verification results

**Files changed:** 6. `src/renderer/connectPanel.ts`, `PairStep.tsx`, `ConnectPanel.tsx`,
`SshInstallStep.tsx`, `connectPanel.test.ts`, `PairStep.test.tsx`.

- PR branch (`multica/BET-962-fold-manual-pairing` @ `c6cab01a`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit 0, 2825 pass / 0 fail / 7 skip (vitest: 152 files, 2825 pass, 7 skip) + node:test 2106 pass / 0 fail. Failures: none. log sha256: `a559a7fa09ea4ec83193d7efb6ea625906b9256197eacfa81b2a9c4cefd74ea6`
- Base (`main` @ `2a7f2a5a`): unchanged — the PR branch touches only the 6 renderer files above; no new CSS/Tailwind token (tailwindScale gate enforces this).
- **Conclusion:** 0 new failures, 0 pre-existing. Both suites green on the PR branch.

## Acceptance

- `npm run typecheck && npm test` → pass.
- `grep -n "disclosureOpen\|clipboardHit" src/renderer/PairStep.tsx` → no matches.
- Both pairing paths end on the same `Next →` state.
- No new CSS variable or Tailwind token added.

**Base: origin/main @ `2a7f2a5a`**
