### PR TITLE
BET-970: refactor(renderer): replace hardcoded WEEKDAYS/MONTHS with Intl day label (BET-966 follow-up)

### DIFF
--- a/src/renderer/artifacts.test.ts
+++ b/src/renderer/artifacts.test.ts
@@ -314,14 +314,20 @@ describe("groupByDay", () => {
   const older = new Date(2026, 7, 3, 9, 0).getTime();
 
   it("groups Today / Yesterday / older with item order preserved and newest first", () => {
+    // The older-group label follows the OS locale (Intl), so derive the
+    // expectation rather than hardcoding an en-US string.
+    const olderLabel = new Intl.DateTimeFormat(undefined, {
+      weekday: "short", day: "numeric", month: "short",
+    }).format(older);
     const out = groupByDay(
       [img("/a/today2", today + 1000), img("/a/older", older), img("/a/today1", today), img("/a/yest", yesterday)],
       now,
     );
-    expect(out.map((g) => g.label)).toEqual(["Today", "Yesterday", "Mon 3 Aug"]);
+    expect(out.map((g) => g.label)).toEqual(["Today", "Yesterday", olderLabel]);
     expect(out[0].items.map((a) => a.href)).toEqual(["/a/today2", "/a/today1"]);
     expect(out[1].items.map((a) => a.href)).toEqual(["/a/yest"]);
     expect(out[2].items.map((a) => a.href)).toEqual(["/a/older"]);
+    expect(out[2].label).toContain("3");
   });
 
   it("empty input → empty groups", () => {

--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -346,11 +346,16 @@ export function deriveArtifacts(
   return dedupeByKey(out).sort((a, b) => b.at - a.at);
 }
 
-const WEEKDAYS = ["Sun", "Mon", "Tue", "Wed", "Thu", "Fri", "Sat"];
-const MONTHS = [
-  "Jan", "Feb", "Mar", "Apr", "May", "Jun",
-  "Jul", "Aug", "Sep", "Oct", "Nov", "Dec",
-];
+// Locale-driven "older than yesterday" group label — "Mon, 3 Aug" / "Mon, Aug 3"
+// depending on the OS locale. Module-level so the (expensive) Intl object is
+// constructed once, not per group. Mirrors the RESET_*_FMT consts in
+// chatUtils.ts (BET-966). Deliberately no year: the label is a within-recent-
+// history grouping header, and adding a year is a behaviour change, not this task.
+const GROUP_DAY_FMT = new Intl.DateTimeFormat(undefined, {
+  weekday: "short",
+  day: "numeric",
+  month: "short",
+});
 
 // Calendar-day index (days since epoch) in LOCAL time, DST-safe by offsetting
 // the timestamp to UTC before dividing — makes "today/yesterday/older" and
@@ -381,8 +386,7 @@ export function groupByDay(items: Artifact[], now: number): Array<{ label: strin
 function groupLabel(idx: number, today: number, atMs: number): string {
   if (idx === today) return "Today";
   if (idx === today - 1) return "Yesterday";
-  const d = new Date(atMs);
-  return `${WEEKDAYS[d.getDay()]} ${d.getDate()} ${MONTHS[d.getMonth()]}`;
+  return GROUP_DAY_FMT.format(atMs);
 }
 
 export type PageState = "live" | "soon" | "expired" | null;


### PR DESCRIPTION
## Summary

Refactors the "older than yesterday" artifact group label in `src/renderer/artifacts.ts` to use a locale-driven `Intl.DateTimeFormat` instead of hardcoded `WEEKDAYS`/`MONTHS` arrays. Closes the last hand-rolled calendar arrays in `src/renderer` (BET-966 removed the one in `usageEscalation.ts`).

- Deletes the `WEEKDAYS` and `MONTHS` consts (nothing else references them — `git grep` returns nothing).
- Adds one module-level `GROUP_DAY_FMT` const (`Intl.DateTimeFormat(undefined, { weekday, day, month })`), constructed once rather than per group.
- `groupLabel`'s final line now returns `GROUP_DAY_FMT.format(atMs)`; the local `new Date(atMs)` is removed since `format` accepts a number.
- Updates the `groupByDay` test to derive the older-label expectation from Intl instead of hardcoding an en-US string, and asserts the day number is present.

No behavior change intended beyond labels now following the OS locale. Blast radius is exactly two files.

**Base: origin/main @ `2a7f2a5a`**

## Notes / deviations
- The issue's "Done when" wants "more lines deleted than added in `artifacts.ts`" — that criterion is not met because the issue mandates the 6-line explanatory comment verbatim ("do not deviate"). Net additions 11 vs deletions 7 in `artifacts.ts`. All other criteria hold (`git grep` clean, typecheck + tests pass).

## Verification results
**Files changed:** 2 files. `src/renderer/artifacts.ts`, `src/renderer/artifacts.test.ts`

- PR branch (`multica/BET-970-intl-day-labels` @ `bd9a7b9c`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit 0, 2106 pass / 0 fail / 0 skip. Failures: none. log sha256: `4468855fcc29efeb4e065fb98fcd919a16092a013d48b228861d578a1ac258a6`
- Base (`main` @ `2a7f2a5a`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit 0, 2106 pass / 0 fail / 0 skip. Failures: none. log sha256: `74e98153fc43f038f013ff86ec6355a20a1bc4aa5b9af58fb36f75ecd863c341`
- **Conclusion:** 0 new failures, 0 pre-existing failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
