### PR TITLE
refactor(renderer): one on* Proxy rule + opt-in canvas stub in testHarness (BET-963)

### DIFF
--- a/src/renderer/App.test.tsx
+++ b/src/renderer/App.test.tsx
@@ -18,7 +18,13 @@
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { act } from "react";
-import { installMockApi, resetStore, mount, type Harness } from "./testHarness";
+import {
+  installCanvasStub,
+  installMockApi,
+  resetStore,
+  mount,
+  type Harness,
+} from "./testHarness";
 import { useStore } from "./store";
 
 // App.tsx reads `__MANTA_CHANNEL__` at module top level (a build-time define
@@ -28,25 +34,11 @@ import { useStore } from "./store";
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 (globalThis as any).__MANTA_CHANNEL__ = "prod";
 
-// The full shell imports @xterm's WebGL addon, which probes
-// HTMLCanvasElement.getContext at module-load time. jsdom has no canvas
-// implementation and throws "Not implemented" on every getContext call unless
-// we stub it. Return a minimal 2D-context-shaped object so xterm's WebGL probe
-// sees an unsupported context and falls back instead of throwing.
-if (typeof HTMLCanvasElement !== "undefined") {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  (HTMLCanvasElement.prototype as any).getContext = function (this: any, ..._args: unknown[]) {
-    const noop = () => {};
-    return {
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      measureText: (text: any) => ({ width: (text as string)?.length ?? 0 }),
-      createLinearGradient: () => ({ addColorStop: noop }),
-      createRadialGradient: () => ({ addColorStop: noop }),
-      canvas: this,
-      getImageData: () => ({ data: new Uint8ClampedArray(0) }),
-    } as unknown as CanvasRenderingContext2D;
-  };
-}
+// The full shell imports @xterm's WebGL addon, which probes the canvas
+// 2D context at module-load time. jsdom has no canvas implementation and
+// throws "Not implemented" on every such probe unless we stub it. MUST run
+// before App.tsx (and therefore xterm) evaluates.
+installCanvasStub();
 
 const { App } = await import("./App");
 
@@ -81,26 +73,7 @@ describe("App — onboarding flips on after the shell's first render (BET-959)",
     // manual/disclosure form (same guard PairStep.test.tsx uses).
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__mantaPreload = null;
-    installMockApi({
-      // The shell registers ~13 `window.api.on*` subscriptions. testHarness's
-      // default proxy resolves an unprovided method to a Promise, which the
-      // effects then `return ...` as their cleanup → React throws "destroy is
-      // not a function" on mount. Supply every subscription with a real
-      // cleanup-returning impl so the shell actually mounts.
-      onOpencodeEvent: () => () => {},
-      onSyncDelta: () => () => {},
-      onStatusEvent: () => () => {},
-      onDelegateUpdated: () => () => {},
-      onUsageUpdated: () => () => {},
-      onAgentFileReady: () => () => {},
-      onAppControl: () => () => {},
-      onAutoUpdateDownloaded: () => () => {},
-      onAutoUpdateError: () => () => {},
-      onDesktopNotify: () => () => {},
-      onProgressUpdated: () => () => {},
-      onServerUpdateAvailable: () => () => {},
-      onServerUpdateProgress: () => () => {},
-    });
+    installMockApi();
     resetStore();
     pairShell();
   });

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -58,6 +58,25 @@ if (typeof window !== "undefined" && !window.matchMedia) {
   });
 }
 
+// Opt-in jsdom stub for HTMLCanvasElement.prototype.getContext (@xterm's WebGL
+// addon probes it at import time; jsdom throws). NOT applied at module scope:
+// components branch on `if (!ctx) return;`, and a truthy ctx for every jsdom
+// test would start an rAF draw loop. Call explicitly BEFORE the import.
+export function installCanvasStub(): void {
+  if (typeof HTMLCanvasElement === "undefined") return;
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (HTMLCanvasElement.prototype as any).getContext = function (this: any) {
+    const noop = () => {};
+    return {
+      measureText: (text: unknown) => ({ width: String(text ?? "").length }),
+      createLinearGradient: () => ({ addColorStop: noop }),
+      createRadialGradient: () => ({ addColorStop: noop }),
+      canvas: this,
+      getImageData: () => ({ data: new Uint8ClampedArray(0) }),
+    } as unknown as CanvasRenderingContext2D;
+  };
+}
+
 // A subscriber registered via the mocked `window.api.onOpencodeEvent`.
 type EventListener = (ev: OpencodeEvent) => void;
 
@@ -115,7 +134,6 @@ function defaultApiImpl(): Record<string, unknown> {
     secretsDelete: () => Promise.resolve(),
     webhookList: () => Promise.resolve([]),
     webhookDelete: () => Promise.resolve(),
-    onProgressUpdated: () => () => {},
     progressGet: () => Promise.resolve(null),
     // Voice / files — component may probe these on mount.
     getPathForFile: () => "",
@@ -179,6 +197,9 @@ export function installMockApi(
           return (provided as (...a: unknown[]) => unknown)(...args);
         }
         if (provided !== undefined) return provided;
+        // `onX(cb)` subscriptions must synchronously return an unsubscribe fn
+        // (components `return` it from a useEffect); covers current + future.
+        if (/^on[A-Z]/.test(prop)) return () => {};
         return Promise.resolve(undefined);
       };
     },


### PR DESCRIPTION
Test infrastructure only — `src/renderer/testHarness.tsx` + `src/renderer/App.test.tsx`. No production files touched.

## Change 1 — one Proxy rule replaces 13 on* defaults
The `installMockApi` Proxy `get` trap now returns `() => {}` for any `/^on[A-Z]/` prop before falling through to the resolved-Promise default. A component returning that function straight out of a `useEffect` previously got `destroy is not a function` for any un-stubbed subscription; one rule covers every current and future `on*` method. Deleted the now-redundant `onProgressUpdated` placeholder from `defaultApiImpl()` (kept `onOpencodeEvent`/`onStreamEvent` — real bus wiring).

## Change 2 — opt-in canvas stub
`installCanvasStub()` is now an exported function in testHarness (NOT a module-scope side effect), so the ~70 other jsdom suites that import the harness don't silently get a truthy canvas ctx (which would start an rAF draw loop in VoiceWaveform). `App.test.tsx` calls it explicitly above its `import("./App")`.

## Change 3 — App.test.tsx consumes both
Dropped the inline `getContext` stub block for `installCanvasStub()`, and `installMockApi({13 on*: () => () => {}})` becomes bare `installMockApi()`.

**Files changed:** 2. `[src/renderer/App.test.tsx, src/renderer/testHarness.tsx]`

**diff:** +35 / −41 (net −7 lines).

**Verification results:**
- PR branch (`multica/BET-963-on-cleanup-proxy-stub` @ `2a2780b5`):
  - typecheck: exit 0, errors: none
  - test (`npm test`): renderer 2817 pass / 7 skip / 0 fail (152 files); node:test 2106 pass / 0 fail / 68 suites
  - App.test.tsx (BET-959 guard): 1/1 pass
- Base: `origin/main @ 2a7f2a5a`
- Conclusion: 0 failures on the PR branch; the branch is the full suite run (no base-side comparison run — low-risk test-infra change, App.test regression guard green).