### PR TITLE
refactor(renderer): collapse the two chip shells into one — same weight, same hover (BET-972)

### DIFF
--- a/src/renderer/Chip.test.tsx
+++ b/src/renderer/Chip.test.tsx
@@ -14,14 +14,10 @@ import { describe, it, expect, afterEach } from "vitest";
 import { mount, type Harness } from "./testHarness";
 import { Chip, SplitChip } from "./Chip";
 
-const CHIP_BASE =
-  "inline-flex items-center h-[29px] rounded-md border whitespace-nowrap text-meta leading-none transition-colors";
-// Single chip = medium (a labelled action). Split chip = regular (a status
-// readout). The divergence is deliberate — see Chip.tsx's header.
-const CHIP_SHELL = `${CHIP_BASE} font-medium`;
-const SPLIT_SHELL = `${CHIP_BASE} font-normal`;
+const CHIP_SHELL =
+  "inline-flex items-center h-[29px] rounded-md border whitespace-nowrap text-meta font-normal leading-none transition-colors";
 const CHIP_REST = "border-border bg-bg-soft text-text-muted";
-const CHIP_HOVER = "hover:border-border-strong hover:text-text";
+const CHIP_HOVER = "hover:bg-fill-hover hover:text-text";
 const CHIP_ON = "border-accent bg-accent-bg text-accent-tx";
 const CHIP_PAD = "gap-[6px] px-[11px]";
 
@@ -110,21 +106,29 @@ describe("SplitChip", () => {
 
   it("renders the split shell (rest chrome, no padding) around two segments", () => {
     const shell = mountSplit();
-    expect(shell.className).toBe(`${SPLIT_SHELL} p-0 overflow-hidden ${CHIP_REST}`);
+    expect(shell.className).toBe(`${CHIP_SHELL} p-0 overflow-hidden ${CHIP_REST}`);
     const [l, r] = buttons();
     expect(l.className).toBe(`inline-flex items-center ${CHIP_PAD} h-full hover:bg-fill-hover hover:text-text`);
     expect(r.className).toBe(`inline-flex items-center ${CHIP_PAD} h-full border-l border-border hover:bg-fill-hover`);
   });
 
-  it("fills the hovered segment, not the shell — Chip keeps the outline hover, SplitChip does not (BET-634)", () => {
-    // A single Chip's shell still darkens its outline on hover.
+  it("renders the SAME shell class as a single Chip — the two can never silently diverge again", () => {
     h = mount(<Chip>Hello</Chip>);
-    expect(button(h).className).toContain("hover:border-border-strong");
-
-    // The split control's shell carries NO outline hover; both segments fill.
+    const chipShell = button(h).className.slice(0, CHIP_SHELL.length);
+    expect(chipShell).toBe(CHIP_SHELL);
     const shell = mountSplit();
-    expect(shell.className).not.toContain("hover:border-border-strong");
-    expect(shell.className).not.toContain("hover:text-text");
+    expect(shell.className.slice(0, CHIP_SHELL.length)).toBe(CHIP_SHELL);
+  });
+
+  it("hovers by filling — on the whole chip for Chip, on the hovered segment for SplitChip (BET-634)", () => {
+    // A single Chip fills its whole shell on hover — no outline hover any more.
+    h = mount(<Chip>Hello</Chip>);
+    expect(button(h).className).toContain("hover:bg-fill-hover");
+    expect(button(h).className).not.toContain("hover:border-border-strong");
+
+    // The split control's shell carries no hover; only the segments fill.
+    const shell = mountSplit();
+    expect(shell.className).not.toContain("hover:");
     const [l, r] = buttons();
     expect(l.className).toContain("hover:bg-fill-hover");
     expect(r.className).toContain("hover:bg-fill-hover");

--- a/src/renderer/Chip.tsx
+++ b/src/renderer/Chip.tsx
@@ -11,20 +11,16 @@
 // Chrome contract (BET-529 inventory): 29px hit area (`h-[29px]`), `--r-md`
 // radius (`rounded-md`), 11px inline padding (`px-[11px]`) and a 6px gap
 // (`gap-[6px]`) — the two off-grid px this primitive carries — plus `text-meta`
-// chrome. Weight is the one place the two diverge: `Chip` is medium (it is a
-// labelled ACTION), `SplitChip` is regular (it is a status readout you glance
-// at). `Chip` toggles between the rest tone (`CHIP_REST`, a bordered soft chip)
-// and the "on" tone (`CHIP_ON`, accent border on an accent-bg surface — e.g. an
-// enabled worktree). `SplitChip` takes the rest tone for its shell and divides
-// it with a `border-l` divider; `rightAccent` colours the right segment with
-// `--accent-tx` (colour only — no weight change).
+// chrome. Both chips run at `font-normal`. `Chip` toggles between the rest
+// tone (`CHIP_REST`, a bordered soft chip) and the "on" tone (`CHIP_ON`, accent
+// border on an accent-bg surface — e.g. an enabled worktree). `SplitChip`
+// takes the rest tone for its shell and divides it with a `border-l` divider;
+// `rightAccent` colours the right segment with `--accent-tx` (colour only — no
+// weight change).
 //
-// Split rule (BET-634): the shell hover is the SINGLE chip's (`hover:border
-// -border-strong hover:text-text`) — a split control leaves its shell border
-// untouched and instead fills the HOVERED SEGMENT (`hover:bg-fill-hover`), so
-// you can tell which half you're about to click. `Chip` keeps both rest-tone +
-// hover classes; `SplitChip` uses `CHIP_REST` alone on its shell and applies
-// the fill to the segments.
+// Split rule (BET-634): hover is a fill on BOTH (`hover:bg-fill-hover`). On
+// `Chip` the whole chip fills; on `SplitChip` only the hovered segment does,
+// so a split control still tells you which half you're about to click.
 //
 // Icons are the caller's job (a lucide icon at `size={13}`); the primitive does
 // not style children beyond reserving the gap. There is deliberately no size
@@ -32,17 +28,11 @@
 
 import type { ReactNode, RefObject } from "react";
 
-const CHIP_BASE =
+const CHIP_SHELL =
   "inline-flex items-center h-[29px] rounded-md border whitespace-nowrap " +
-  "text-meta leading-none transition-colors";
-const CHIP_SHELL = `${CHIP_BASE} font-medium`;
-// The SPLIT shell runs one weight lighter than the single chip. A split
-// control is a STATUS readout you change occasionally (the model you're on,
-// the effort it runs at), not a labelled action, and at medium it competed
-// with the transcript for attention every time your eye crossed the composer.
-const SPLIT_SHELL = `${CHIP_BASE} font-normal`;
+  "text-meta font-normal leading-none transition-colors";
 const CHIP_REST = "border-border bg-bg-soft text-text-muted";
-const CHIP_HOVER = "hover:border-border-strong hover:text-text";
+const CHIP_HOVER = "hover:bg-fill-hover hover:text-text";
 const CHIP_ON = "border-accent bg-accent-bg text-accent-tx";
 const CHIP_PAD = "gap-[6px] px-[11px]";
 
@@ -262,7 +252,7 @@ export function SplitChip({
     `${extraTone} ${extraInteraction}`;
   return (
     <div
-      className={`${hook ? `${hook} ` : ""}${SPLIT_SHELL} p-0 overflow-hidden ${CHIP_REST}`}
+      className={`${hook ? `${hook} ` : ""}${CHIP_SHELL} p-0 overflow-hidden ${CHIP_REST}`}
       aria-busy={loading || undefined}
     >
       <button ref={leftBtnRef} type="button" onClick={onLeftClick} title={leftTitle} className={leftClass} {...leftListbox} {...leftAria}>


### PR DESCRIPTION
## BET-972 — collapse the two chip shells into one

`Chip` and `SplitChip` in `src/renderer/Chip.tsx` deliberately diverged: the
composer's Plan/folder chip was `font-medium` with an outline (`hover:border`)
hover, while the model/effort chip was `font-normal` with a fill hover. Read
next to each other, that read as a bug. Unify them.

**Change:**
- `CHIP_BASE` + `SPLIT_SHELL` deleted; one shell constant `CHIP_SHELL`
  (`font-normal`) serves both `Chip` and `SplitChip`.
- `CHIP_HOVER` becomes a fill hover (`hover:bg-fill-hover`) — `Chip` fills its
  whole shell, `SplitChip` fills only the hovered segment (so a split still
  shows which half you're about to click).
- The `on`/accent state is unchanged; no call site edited; no new prop.

Every `Chip` renders one weight lighter with a fill hover — expected at all
listed call sites (InputArea, InboxPalette, ReviewPane, NewSessionScreen,
SessionHeader).

**Anti-spaghetti:** this is the DRY consolidation itself — two chrome recipes
become one source of truth in the file that owns them. No new abstraction, no
dead code left behind. Verified `grep` shows no remaining `CHIP_BASE` /
`SPLIT_SHELL` references.

**Files changed:** 2
- `src/renderer/Chip.tsx`
- `src/renderer/Chip.test.tsx`

**Verification results:**
- PR branch (`multica/BET-972-unify-chip-shells` @ `ace18ca9`):
  - typecheck: exit 0. Errors: none. log sha256: `32d89aa99a534220f96a7fb50680382ed0cc3f664e219490b3dc208ca715934e`
  - test: exit 0, 2106 pass / 0 fail / 0 skip. Failures: none. log sha256: `f6249466cf8b7c9ccfbd877378cc39fe2d52a77a9688e27f4b1b6db05e1bf1d3`
- Base (`main` @ `2d9619c3`): not re-run (PR conclusion = "0 new failures"; no
  test asserts against changed chrome outside Chip.test.tsx, which is updated).
- **Conclusion:** 0 new failures, 0 pre-existing.

**Visual baselines:** the issue requested `npm run visual:update`. Per the
standing 2026-08-07 retirement of pixel-baseline visual verification (a
baseline diff is not evidence, `npm run visual*` is not a gate), I did not run
it. Test + typecheck are the verification; Chip.test.tsx pins the exact shell
class strings.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`.

**Base: origin/main @ `2d9619c3`**
