### PR TITLE
fix(renderer): plan card — Give Delegate button chrome and a friendly model name (BET-971)

### DIFF
--- a/src/renderer/Button.test.tsx
+++ b/src/renderer/Button.test.tsx
@@ -14,7 +14,7 @@ import { mount, type Harness } from "./testHarness";
 import { Button } from "./Button";
 
 const CHROME =
-  "inline-flex items-center gap-[6px] h-8 px-[14px] rounded-md border text-[12.5px] font-medium leading-none transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent disabled:opacity-50 disabled:cursor-not-allowed";
+  "inline-flex items-center h-8 rounded-md border text-[12.5px] font-medium leading-none transition-colors focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent disabled:opacity-50 disabled:cursor-not-allowed gap-[6px] px-[14px]";
 
 const TONE = {
   default: "border-border bg-bg text-text hover:bg-raised hover:border-border-strong",

--- a/src/renderer/Button.tsx
+++ b/src/renderer/Button.tsx
@@ -29,13 +29,15 @@
 // than as a `w-full` at the call site precisely because that would be the
 // className escape hatch by another name.
 
-import type { ReactNode } from "react";
+import type { ReactNode, RefObject } from "react";
 
-const BUTTON_BASE =
-  "inline-flex items-center gap-[6px] h-8 px-[14px] rounded-md border " +
+const BUTTON_CHROME =
+  "inline-flex items-center h-8 rounded-md border " +
   "text-[12.5px] font-medium leading-none transition-colors " +
   "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
   "disabled:opacity-50 disabled:cursor-not-allowed";
+const BUTTON_PAD = "gap-[6px] px-[14px]";
+const BUTTON_BASE = `${BUTTON_CHROME} ${BUTTON_PAD}`;
 
 const BUTTON_TONE = {
   default: "border-border bg-bg text-text hover:bg-raised hover:border-border-strong",
@@ -90,5 +92,103 @@ export function Button({
     >
       {children}
     </button>
+  );
+}
+
+// M527.SplitButton — a two-segment ACTION with Button chrome (BET-951 follow-up).
+//
+// Same relationship to `Button` that `SplitChip` has to `Chip`: one shell, two
+// segments, a `border-l` divider, and the split rule from BET-634 — the shell
+// border is left alone on hover and the HOVERED SEGMENT fills
+// (`hover:bg-fill-hover`), so you can tell which half you are about to click.
+//
+// It exists because a split control in a row of `Button`s must be a `Button`:
+// `SplitChip` is 29px/regular-weight and reads as a status readout beside
+// 32px/medium actions. There is deliberately NO `tone` prop — the split form is
+// only ever the default tone (a primary split would put two accent surfaces in
+// one control), and no `extra` third segment (that is the composer's ⚡ toggle,
+// which is a Chip concern).
+const SPLIT_BUTTON_TONE = "border-border bg-bg text-text";
+
+export function SplitButton({
+  left,
+  right,
+  onLeftClick,
+  onRightClick,
+  rightAccent = false,
+  leftTitle,
+  rightTitle,
+  leftHook,
+  rightHook,
+  rightExpanded,
+  rightBtnRef,
+  disabled = false,
+  loading = false,
+}: {
+  /** Left-segment content — the action label. */
+  left: ReactNode;
+  /** Right-segment content — what the action will run against (e.g. a model). */
+  right: ReactNode;
+  onLeftClick: () => void;
+  onRightClick: () => void;
+  /** Accent the right segment (`--accent-tx`). Colour only — never weight. */
+  rightAccent?: boolean;
+  leftTitle?: string;
+  rightTitle?: string;
+  /** Stable `manta-*` identity class for the LEFT segment button. */
+  leftHook?: string;
+  /**
+   * Stable `manta-*` identity class for the RIGHT segment button. The right
+   * segment always carries `aria-haspopup="listbox"`, so the popup coverage
+   * registry keys on THIS hook, not on the shell.
+   */
+  rightHook?: string;
+  /** `aria-expanded` for the right segment — whether its listbox is open. */
+  rightExpanded?: boolean;
+  /** Forwarded to the RIGHT segment button (the dropdown's anchor). */
+  rightBtnRef?: RefObject<HTMLButtonElement>;
+  /** Both segments become native-`disabled` (dimmed, not clickable). */
+  disabled?: boolean;
+  /**
+   * The control is still resolving what it describes (e.g. the model catalog
+   * has not loaded). Presentational only, mirroring SplitChip.loading: both
+   * segments drop their hover affordance and the shell reports `aria-busy`.
+   */
+  loading?: boolean;
+}) {
+  const inert = disabled || loading;
+  const segBase = `inline-flex items-center ${BUTTON_PAD} h-full transition-colors`;
+  const hover = inert ? "" : " hover:bg-fill-hover";
+  const leftClass = `${leftHook ? `${leftHook} ` : ""}${segBase}${hover}`;
+  const rightClass =
+    `${rightHook ? `${rightHook} ` : ""}${segBase} border-l border-border${hover}` +
+    (rightAccent && !inert ? " text-accent-tx" : "");
+  return (
+    <div
+      className={`${BUTTON_CHROME} p-0 overflow-hidden ${SPLIT_BUTTON_TONE}`}
+      aria-busy={loading || undefined}
+    >
+      <button
+        type="button"
+        onClick={onLeftClick}
+        disabled={disabled}
+        title={leftTitle}
+        className={leftClass}
+      >
+        {left}
+      </button>
+      <button
+        ref={rightBtnRef}
+        type="button"
+        onClick={onRightClick}
+        disabled={disabled}
+        title={rightTitle}
+        aria-haspopup="listbox"
+        aria-expanded={rightExpanded}
+        className={rightClass}
+      >
+        {right}
+      </button>
+    </div>
   );
 }

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -15,14 +15,18 @@
 import { useMemo, useRef, useState, type ReactNode } from "react";
 import { DraftingCompass, Shield, HelpCircle, Check, Send, ChevronDown } from "lucide-react";
 import type { PermissionRequest, ProgressRecord, QuestionRequest, OpencodeModel } from "../shared/types";
-import { buildQuestionAnswers, canSubmitQuestion, resolveDelegateModel } from "./chatUtils";
+import {
+  buildQuestionAnswers,
+  canSubmitQuestion,
+  resolveDelegateModel,
+  shortModelName,
+} from "./chatUtils";
 import { resolveActiveModel } from "./chatShared";
 import { Card } from "./Card";
 import { Pill } from "./Pill";
 import { OutputWell } from "./OutputWell";
-import { Button } from "./Button";
+import { Button, SplitButton } from "./Button";
 import { StatusDot } from "./StatusDot";
-import { SplitChip } from "./Chip";
 import { ModelMenu } from "./ModelMenu";
 import { renderMarkdown } from "./MarkdownBody";
 
@@ -510,9 +514,9 @@ export function QuestionCard({
 // dedicated card in the pinned card stack. Blocking tier: it is an unanswered
 // ask, rendered beside permission/question, never below an ambient card.
 //
-// The delegate split reuses SplitChip (no new split control) fed by the
-// EXISTING ModelMenu; model precedence lives in resolveDelegateModel (a pure
-// chatUtils helper), never inline here.
+// The delegate split reuses the shared split control (SplitButton — the Button
+// chrome brother of SplitChip) fed by the EXISTING ModelMenu; model precedence
+// lives in resolveDelegateModel (a pure chatUtils helper), never inline here.
 
 export function PlanCard({
   data,
@@ -558,10 +562,12 @@ export function PlanCard({
     () => resolveActiveModel(allModels, delegateModel, null),
     [allModels, delegateModel],
   );
-  // The right segment truncates to the model family name before anything else
-  // shrinks (BET-951).
-  const familyLabel =
-    resolvedOpencode?.family ?? resolvedOpencode?.providerID ?? delegateModel?.modelID ?? "model";
+  // The right segment names the model the way every other picker does — the
+  // human name, shortened past its brand prefix exactly as the composer chip
+  // shortens it (shortModelName). The raw modelID is the LAST resort, for a
+  // model that is not in the loaded catalog at all.
+  const modelLabel =
+    shortModelName(resolvedOpencode?.name) ?? delegateModel?.modelID ?? "model";
 
   // `N steps · N files` — each clause omitted (never `0`) when not derivable.
   const metricsLine = [
@@ -607,21 +613,16 @@ export function PlanCard({
       <Button tone="primary" onClick={() => onBuildHere(feedback)}>
         Build here
       </Button>
-      <SplitChip
-        left={<span className={busy ? "opacity-50" : undefined}>Delegate</span>}
+      <SplitButton
+        left="Delegate"
         right={
-          <span className={"flex items-center gap-1 truncate" + (busy ? " opacity-50" : "")}>
-            <span className="truncate max-w-[80px]">{familyLabel}</span>
+          <span className="flex items-center gap-1 truncate">
+            <span className="truncate max-w-[110px]">{modelLabel}</span>
             <ChevronDown size={13} aria-hidden="true" className="shrink-0 text-text-faint" />
           </span>
         }
-        onLeftClick={() => {
-          if (!busy) onStartDelegate(delegateModel, feedback);
-        }}
-        onRightClick={() => {
-          if (!busy) setMenuOpen((o) => !o);
-        }}
-        popup={{ right: true }}
+        onLeftClick={() => onStartDelegate(delegateModel, feedback)}
+        onRightClick={() => setMenuOpen((o) => !o)}
         rightAccent={resolution.overridden}
         rightExpanded={menuOpen}
         rightBtnRef={modelBtnRef}
@@ -629,6 +630,7 @@ export function PlanCard({
         rightHook="manta-plan-delegate-model-btn"
         leftTitle={splitTitle}
         rightTitle={busy ? splitTitle : "Model this background job will run on"}
+        disabled={busy}
         loading={models === null}
       />
       <div className="flex-1" />

--- a/src/renderer/SplitButton.test.tsx
+++ b/src/renderer/SplitButton.test.tsx
@@ -1,0 +1,144 @@
+// @vitest-environment jsdom
+//
+// Component tests for the SplitButton chrome primitive (BET-971).
+//
+// SplitButton is a two-segment ACTION wearing `Button`'s chrome — the split
+// brother of SplitChip (a 29px status readout). It exists so a split control
+// sitting in a row of `Button`s is itself a `Button` (32px / medium). The
+// contract is asserted on the exact class strings, same as the other
+// primitives (see Chip.test.tsx): a retune of either primitive's chrome fails
+// here immediately.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { SplitButton } from "./Button";
+
+const BUTTON_CHROME =
+  "inline-flex items-center h-8 rounded-md border " +
+  "text-[12.5px] font-medium leading-none transition-colors " +
+  "focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-accent " +
+  "disabled:opacity-50 disabled:cursor-not-allowed";
+const BUTTON_PAD = "gap-[6px] px-[14px]";
+const SPLIT_BUTTON_TONE = "border-border bg-bg text-text";
+const SEG_BASE = `inline-flex items-center ${BUTTON_PAD} h-full transition-colors`;
+
+describe("SplitButton", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function buttons(): HTMLButtonElement[] {
+    const els = h!.container.querySelectorAll("button");
+    expect(els.length).toBe(2);
+    return Array.from(els) as HTMLButtonElement[];
+  }
+
+  // Every case mounts the same two-segment baseline and varies ONE prop.
+  type SplitProps = Partial<Parameters<typeof SplitButton>[0]>;
+  function mountBtn(props: SplitProps = {}): HTMLElement {
+    h?.unmount();
+    h = mount(
+      <SplitButton
+        left={<span>L</span>}
+        right={<span>R</span>}
+        onLeftClick={() => {}}
+        onRightClick={() => {}}
+        {...props}
+      />,
+    );
+    return h.container.firstElementChild as HTMLElement;
+  }
+
+  it("has no className escape hatch — the prop is not accepted (compile-time)", () => {
+    // @ts-expect-error — SplitButton must NOT accept className (M527 decision 3)
+    void <SplitButton left={<>l</>} right={<>r</>} onLeftClick={() => {}} onRightClick={() => {}} className="bg-red-500" />;
+    expect(true).toBe(true);
+  });
+
+  it("wears Button's shell chrome — h-8 (32px), medium weight — not SplitChip's 29px status shell", () => {
+    const shell = mountBtn();
+    expect(shell.className).toBe(`${BUTTON_CHROME} p-0 overflow-hidden ${SPLIT_BUTTON_TONE}`);
+    expect(shell.className).toContain("h-8");
+    expect(shell.className).toContain("font-medium");
+    expect(shell.className).not.toContain("h-[29px]");
+  });
+
+  it("renders both segments as <button> with the shared padding", () => {
+    mountBtn();
+    const [l, r] = buttons();
+    expect(l.tagName).toBe("BUTTON");
+    expect(r.tagName).toBe("BUTTON");
+    expect(l.className).toBe(`${SEG_BASE} hover:bg-fill-hover`);
+    expect(r.className).toBe(`${SEG_BASE} border-l border-border hover:bg-fill-hover`);
+  });
+
+  it("right segment carries aria-haspopup=listbox and its hook (the popup coverage registry key)", () => {
+    mountBtn({ rightHook: "manta-plan-delegate-model-btn" });
+    const [l, r] = buttons();
+    expect(r.getAttribute("aria-haspopup")).toBe("listbox");
+    expect(r.className).toContain("manta-plan-delegate-model-btn");
+    // The LEFT segment is a plain action — it must not claim aria-haspopup.
+    expect(l.hasAttribute("aria-haspopup")).toBe(false);
+    // Without the prop, no hook class leaks.
+    mountBtn();
+    expect(buttons()[1].className).not.toContain("manta-");
+  });
+
+  it("applies leftHook/rightHook to the segment buttons, not the shell", () => {
+    const shell = mountBtn({
+      leftHook: "manta-plan-delegate-btn",
+      rightHook: "manta-plan-delegate-model-btn",
+    });
+    expect(shell.className).not.toContain("manta-plan-delegate-btn");
+    expect(shell.className).not.toContain("manta-plan-delegate-model-btn");
+    const [l, r] = buttons();
+    expect(l.className).toContain("manta-plan-delegate-btn");
+    expect(r.className).toContain("manta-plan-delegate-model-btn");
+  });
+
+  it("disabled marks BOTH segment buttons native-disabled (dimmed, not clickable)", () => {
+    mountBtn({ disabled: true });
+    const [l, r] = buttons();
+    expect(l.disabled).toBe(true);
+    expect(r.disabled).toBe(true);
+  });
+
+  it("fires onLeftClick and onRightClick independently", () => {
+    let l = 0;
+    let r = 0;
+    mountBtn({ onLeftClick: () => l++, onRightClick: () => r++ });
+    const [bl, br] = buttons();
+    bl.click();
+    expect(l).toBe(1);
+    expect(r).toBe(0);
+    br.click();
+    expect(l).toBe(1);
+    expect(r).toBe(1);
+  });
+
+  it("rightAccent colours the right segment only (--accent-tx, no weight change)", () => {
+    mountBtn({ rightAccent: true });
+    const [l, r] = buttons();
+    expect(r.className).toContain("text-accent-tx");
+    expect(l.className).not.toContain("text-accent-tx");
+
+    mountBtn();
+    expect(buttons()[1].className).not.toContain("text-accent-tx");
+  });
+
+  it("loading is presentational: shell aria-busy, segments not disabled, hover dropped", () => {
+    const shell = mountBtn({ loading: true });
+    expect(shell.getAttribute("aria-busy")).toBe("true");
+    const [l, r] = buttons();
+    expect(l.disabled).toBe(false);
+    expect(r.disabled).toBe(false);
+    expect(l.className).not.toContain("hover:");
+    expect(r.className).not.toContain("hover:");
+
+    // Absent the prop nothing leaks.
+    const rest = mountBtn();
+    expect(rest.hasAttribute("aria-busy")).toBe(false);
+  });
+});


### PR DESCRIPTION
Implements BET-971: the plan-exit card's Delegate control was a `SplitChip` (29px / regular weight / status readout) sitting in a row of `Button`s, and the model segment showed a raw model id.

**Part A — `src/renderer/Button.tsx`**
- Split `BUTTON_BASE` into `BUTTON_CHROME` / `BUTTON_PAD`/`BUTTON_BASE` exactly mirroring Chip.tsx's `CHIP_BASE`/`CHIP_PAD` split. `Button` itself still composes `BUTTON_BASE`, so no existing button moves.
- Added `SplitButton`, a two-segment ACTION wearing Button's chrome, per the BET-634 split rule (shell border untouched on hover, hovered segment fills). No `tone` prop, no `extra` third segment, no `className` escape hatch.

**Part B — `src/renderer/Cards.tsx`**
- `PlanCard`'s delegate split now uses `SplitButton`; the manual `opacity-50` spans and `if (!busy)` guards are gone (`disabled` on a real button dims + prevents the click).
- Model segment label = `shortModelName(resolvedOpencode?.name)` (e.g. "Opus 5") with the raw modelID as last resort; `max-w-[80px]` → `max-w-[110px]`.
- Removed the now-unused `SplitChip` import and `family`/`providerID` label reads.

**Tests**
- New `src/renderer/SplitButton.test.tsx` (shell h-8 / both `<button>`s / right aria-haspopup + hook / disabled both segments / no-className type error / hooks on segments not shell / accent colour-only / loading presentational).
- `Button.test.tsx` chrome constant updated for the mandated class-order change (padding now after the chrome, from the BUTTON_PAD split) — same class set, order only.

**Verification results:**
- PR branch (`multica/BET-971-plan-card-splitbutton`): typecheck exit 0, no errors; test exit 0, 153 files / 2834 tests pass, 0 fail.
- Visual gate: no plan-card screen exists in `scripts/visual/screens.mjs` (BET-954 not merged), so no baseline to regenerate; the `manta-plan-delegate-btn` / `manta-plan-delegate-model-btn` hooks are preserved on the new SplitButton segments.

Base: origin/main @ 2d9619c3