### PR TITLE
fix(renderer): "Keep planning" silently drops the session out of plan mode

### DIFF
--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -27,6 +27,7 @@ import {
   formatAge,
   shouldAbortForQueuedDrain,
   isToolStepBoundary,
+  planModeFromToolPart,
   isDrainAbortError,
   isUnknownChannelError,
   describeCron,
@@ -980,6 +981,37 @@ describe("isToolStepBoundary", () => {
     expect(isToolStepBoundary({})).toBe(false);
     expect(isToolStepBoundary({ type: "tool" })).toBe(false);
     expect(isToolStepBoundary("tool")).toBe(false);
+  });
+});
+
+describe("planModeFromToolPart", () => {
+  it("is true for a completed plan_enter", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "plan_enter", state: { status: "completed" } })).toBe(true);
+  });
+
+  it("is false for a completed plan_exit", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "plan_exit", state: { status: "completed" } })).toBe(false);
+  });
+
+  it("is null for an errored plan_exit (the regression: a rejected switch did not happen)", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "plan_exit", state: { status: "error" } })).toBe(null);
+  });
+
+  it("is null for an errored plan_enter", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "plan_enter", state: { status: "error" } })).toBe(null);
+  });
+
+  it("is null for a completed non-plan tool", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "bash", state: { status: "completed" } })).toBe(null);
+  });
+
+  it("is null for a non-tool part", () => {
+    expect(planModeFromToolPart({ type: "text", state: { status: "completed" } })).toBe(null);
+  });
+
+  it("is null for null / undefined", () => {
+    expect(planModeFromToolPart(null)).toBe(null);
+    expect(planModeFromToolPart(undefined)).toBe(null);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -585,6 +585,26 @@ export function isToolStepBoundary(part: unknown): boolean {
 }
 
 /**
+ * The plan-mode state a tool part asserts, or `null` if it asserts nothing.
+ *
+ * Only a COMPLETED plan_enter/plan_exit counts. An ERRORED one is a switch that
+ * did NOT happen — most importantly the plan card's "Keep planning", which
+ * answers the plan question "No" and so rejects the `plan_exit` tool. Reading
+ * that as an exit dropped the session out of plan mode behind the user's back.
+ * (This is why the drain's `isToolStepBoundary`, which accepts `error` on
+ * purpose, must not be reused here.)
+ */
+export function planModeFromToolPart(part: unknown): boolean | null {
+  if (!part || typeof part !== "object") return null;
+  const p = part as { type?: unknown; tool?: unknown; state?: { status?: unknown } };
+  if (p.type !== "tool") return null;
+  if (p.state?.status !== "completed") return null;
+  if (p.tool === "plan_enter") return true;
+  if (p.tool === "plan_exit") return false;
+  return null;
+}
+
+/**
  * Should a step boundary trigger a drain-abort? True when at least one prompt
  * is queued AND we have not already issued a drain-abort for the current turn
  * (`alreadyDraining` guards re-entrancy against the multiple boundary events

--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -882,3 +882,104 @@ describe("useSseBus question.asked refetch gating (BET-418)", () => {
     expect(after).toBe(before);
   });
 });
+
+// BET-973 — the plan-mode mirror must only react to a COMPLETED plan_enter/
+// plan_exit. "Keep planning" answers the plan question "No", which REJECTS the
+// plan_exit tool, so its part lands in `error` — an errored switch did NOT
+// happen and must not flip the chip. The old block reused isToolStepBoundary
+// (which accepts `error` on purpose for the drain), reading an errored
+// plan_exit as a real exit and silently dropping the session out of plan mode.
+// PlanProbe owns useSseBus directly and captures the plan setter so the tests
+// can assert exactly when it is (or isn't) called.
+describe("useSseBus plan-mode mirror (BET-973)", () => {
+  let planCalls: boolean[] | null = null;
+  let h: ReturnType<typeof mount> | null = null;
+  let bus: ReturnType<typeof installMockApi>["bus"];
+
+  beforeEach(() => {
+    ({ bus } = installMockApi());
+    resetStore();
+    planCalls = [];
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function PlanProbe() {
+    const [, setMessages] = useState<OpencodeMessage[] | null>(null);
+    const childSessionIds = useRef<Set<string>>(new Set());
+    const childMessagesRef = useRef<Map<string, OpencodeMessage[]>>(new Map());
+    const expandedTasksRef = useRef<Set<string>>(new Set());
+    const childRefetchTimers = useRef<Map<string, ReturnType<typeof setTimeout>>>(new Map());
+    const isActiveRef = useRef<boolean>(true);
+    const refetchOwedWhileInactive = useRef<boolean>(false);
+    const submitRef = useRef<() => void>(() => {});
+    useSseBus({
+      sessionId: "ses_test",
+      cwd: "/home/dev/projects/x",
+      setMessages,
+      setRefreshing: () => {},
+      scheduleRefetch: () => {},
+      fetchOpts: () => ({}),
+      spliceMessage: () => {},
+      scheduleChildRefetch: () => {},
+      childSessionIds,
+      childMessagesRef,
+      expandedTasksRef,
+      childRefetchTimers,
+      isActiveRef,
+      refetchOwedWhileInactive,
+      applyStreamFlush: () => 0,
+      providerID: null,
+      setPlanOn: (next: boolean) => { planCalls?.push(next); },
+      submit: () => {},
+      submitRef,
+    });
+    return <div />;
+  }
+
+  const emitToolPart = async (part: unknown, messageID = "msg_1") => {
+    await act(async () => {
+      act(() =>
+        bus.emit({
+          type: "message.part.updated",
+          properties: { sessionID: "ses_test", messageID, part },
+        }),
+      );
+      await Promise.resolve();
+    });
+  };
+
+  it("does not call the plan setter on an errored plan_exit (Keep planning)", async () => {
+    h = mount(<PlanProbe />);
+    await h.flush();
+
+    await emitToolPart({ type: "tool", tool: "plan_exit", callID: "toolu_1", state: { status: "error" } });
+
+    expect(planCalls).toEqual([]);
+  });
+
+  it("does not call the plan setter on an errored plan_enter", async () => {
+    h = mount(<PlanProbe />);
+    await h.flush();
+
+    await emitToolPart({ type: "tool", tool: "plan_enter", callID: "toolu_1", state: { status: "error" } });
+
+    expect(planCalls).toEqual([]);
+  });
+
+  it("calls the plan setter on a completed plan_exit, deduplicating by callID", async () => {
+    h = mount(<PlanProbe />);
+    await h.flush();
+
+    await emitToolPart({ type: "tool", tool: "plan_exit", callID: "toolu_1", state: { status: "completed" } });
+    expect(planCalls).toEqual([false]);
+
+    // A second emission with the SAME callID (opencode re-emits a completed
+    // part) must NOT re-apply — even a plan_enter sharing the id is ignored.
+    await emitToolPart({ type: "tool", tool: "plan_enter", callID: "toolu_1", state: { status: "completed" } });
+    expect(planCalls).toEqual([false]);
+  });
+});

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -65,6 +65,7 @@ import {
   isDrainAbortError,
   shouldAbortForQueuedDrain,
   isToolStepBoundary,
+  planModeFromToolPart,
   collectChildSessionIds,
   hydrateQuestion,
   authErrorAdvice,
@@ -572,16 +573,14 @@ export function useSseBus(params: {
       if (ev.type === "session.next.agent.switched") {
         setPlanOnRef.current(String(props.agent ?? "") === "plan");
       }
-      if (ev.type === "message.part.updated" && isToolStepBoundary(props.part)) {
-        const part = props.part as {
-          tool?: unknown;
-          callID?: unknown;
-        } | undefined;
-        if (part?.tool === "plan_enter" || part?.tool === "plan_exit") {
-          const callID = String(part.callID ?? "");
+      if (ev.type === "message.part.updated") {
+        const part = props.part as { callID?: unknown } | undefined;
+        const next = planModeFromToolPart(props.part);
+        if (next !== null) {
+          const callID = String(part?.callID ?? "");
           if (callID && !handledPlanCallIdsRef.current.has(callID)) {
             handledPlanCallIdsRef.current.add(callID);
-            setPlanOnRef.current(part.tool === "plan_enter");
+            setPlanOnRef.current(next);
           }
         }
       }


### PR DESCRIPTION
Fixes BET-973.

## Problem
In the plan-exit card, "Keep planning" answers the plan question "No", which REJECTS the `plan_exit` tool — so its part lands in `error`. The plan-mode mirror in `useSseBus.ts` reused `isToolStepBoundary` (which accepts `error` on purpose for the queued-message drain) and read that errored `plan_exit` as the model leaving plan mode, silently dropping the session out of plan mode while the UI still showed the Plan chip on.

## Fix
- New pure helper `planModeFromToolPart` in `src/renderer/chatUtils.ts`: only a **COMPLETED** `plan_enter`/`plan_exit` asserts a mode (`true`/`false`); an ERRORED one is a switch that did NOT happen and returns `null`.
- `useSseBus.ts`'s plan block (BET-949) now uses it (callID de-dup kept exactly as-is). The `session.next.agent.switched` branch is untouched.
- `isToolStepBoundary` is unchanged and still used by its genuine caller, the queued-message drain.

## Do NOT (honored)
- Did not make `keepPlanning` re-assert `setPlanOn(true)` (a second racing path that would flicker).
- Did not touch `ChatPanel.buildHere` (answering "Yes" still flips plan off correctly).

## Files changed
- `src/renderer/chatUtils.ts` (new predicate, 20 lines)
- `src/renderer/hooks/useSseBus.ts` (use the predicate)
- `src/renderer/chatUtils.test.ts` (7 new unit tests)
- `src/renderer/hooks/useSseBus.test.tsx` (3 new hook tests)

## Verification results
- PR branch (`multica/BET-973-keep-planning-planmode` @ `58df6285`):
  - typecheck: exit 0, errors: none
  - test: exit 0, 2106 pass / 0 fail / 0 skip
- Base (`main` @ `2d9619c3`):
  - unchanged by this PR
- New `planModeFromToolPart` tests: completed `plan_enter`→true, completed `plan_exit`→false, **errored `plan_exit`→null (the regression)**, errored `plan_enter`→null, completed non-plan tool→null, non-tool part→null, null/undefined→null — all pass.
- Hook tests: errored `plan_exit`/`plan_enter` do NOT call the plan setter; a completed `plan_exit` calls it once, and a same-`callID` re-emission (even a `plan_enter` sharing the id) is deduped.

Manual click-through (enter plan → Keep planning → chip stays on) can't be run here — no live box — but the hook probe pins the exact setter behavior the manual step checks.

Base: origin/main @ 2d9619c3