### PR TITLE
BET-975: refactor(server): replace hand-rolled plan markdown renderer with remark/rehype

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.29",
+  "version": "0.0.30",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.29",
+      "version": "0.0.30",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",
@@ -20,7 +20,11 @@
         "qrcode-terminal": "^0.11.0",
         "react-markdown": "^10.1.0",
         "react-virtuoso": "^4.18.11",
+        "rehype-stringify": "^10.0.1",
         "remark-gfm": "^4.0.1",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.1.2",
+        "unified": "^11.0.5",
         "web-push": "^3.6.7",
         "ws": "^8.20.1",
         "yaml": "^2.9.0"
@@ -7866,6 +7870,29 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/hast-util-to-html": {
+      "version": "9.0.5",
+      "resolved": "https://registry.npmjs.org/hast-util-to-html/-/hast-util-to-html-9.0.5.tgz",
+      "integrity": "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "html-void-elements": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "stringify-entities": "^4.0.0",
+        "zwitch": "^2.0.4"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hast-util-to-jsx-runtime": {
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
@@ -7960,6 +7987,16 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-void-elements": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/html-void-elements/-/html-void-elements-3.0.0.tgz",
+      "integrity": "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/http_ece": {
@@ -11873,6 +11910,21 @@
       },
       "engines": {
         "node": ">=8.10.0"
+      }
+    },
+    "node_modules/rehype-stringify": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/rehype-stringify/-/rehype-stringify-10.0.1.tgz",
+      "integrity": "sha512-k9ecfXHmIPuFVI61B9DeLPN0qFHfawM6RsuX48hoqlaKSF61RskNjSm1lI8PhBEM0MRdLxVVm4WmTqJQccH9mA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "hast-util-to-html": "^9.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/remark-gfm": {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,11 @@
     "qrcode-terminal": "^0.11.0",
     "react-markdown": "^10.1.0",
     "react-virtuoso": "^4.18.11",
+    "rehype-stringify": "^10.0.1",
     "remark-gfm": "^4.0.1",
+    "remark-parse": "^11.0.0",
+    "remark-rehype": "^11.1.2",
+    "unified": "^11.0.5",
     "web-push": "^3.6.7",
     "ws": "^8.20.1",
     "yaml": "^2.9.0"

--- a/src/server/planPage.mjs
+++ b/src/server/planPage.mjs
@@ -26,6 +26,11 @@
 
 import { mkdir, writeFile } from "node:fs/promises";
 import { join, dirname } from "node:path";
+import { unified } from "unified";
+import remarkParse from "remark-parse";
+import remarkGfm from "remark-gfm";
+import remarkRehype from "remark-rehype";
+import rehypeStringify from "rehype-stringify";
 import { statePath } from "../shared/paths.mjs";
 import { registerPage } from "./servePage.mjs";
 
@@ -70,6 +75,8 @@ export function planSubdomain(sessionID) {
 // ---------------------------------------------------------------------------
 
 const LIGHT_TOKENS = `
+  --r-xs: 4px;
+  --r-sm: 6px;
   --canvas: #FAF9F7;
   --panel: #F2F0EC;
   --card: #FFFFFF;
@@ -119,131 +126,28 @@ export function escapeHtml(s) {
     .replace(/"/g, "&quot;");
 }
 
-// Inline formatting for a single line's inner text: HTML is escaped FIRST (so
-// raw tags in the source can never survive as markup), then code spans (so
-// backticks shield their content from bold/italic), then links, bold, italic.
-function renderInline(text) {
-  let out = escapeHtml(text);
-  // Code spans — content already escaped by the pass above.
-  out = out.replace(/`([^`]+)`/g, (_, code) => `<code>${code}</code>`);
-  // Links: [label](url) — url already attribute-escaped above.
-  out = out.replace(
-    /\[([^\]\n]+)\]\(([^)\s]+)\)/g,
-    (_, label, url) => `<a href="${url}">${label}</a>`,
-  );
-  // Bold.
-  out = out.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
-  // Italic.
-  out = out.replace(/(^|[^*])\*([^*\n]+)\*(?![*])/g, "$1<em>$2</em>");
-  return out;
-}
-
-function isCodeFence(line) {
-  const m = /^```/.exec(line);
-  if (!m) return null;
-  const lang = line.replace(/^```/, "").trim();
-  return lang;
-}
-
 /**
- * Render plan markdown to HTML `<body>` inner markup. Pure: no side effects.
- * Handles fenced code blocks (monospace, surfaced), ATX headings 1-6, bullet &
- * ordered lists, and inline code / links / bold / italic. Runs only inside
- * renderPlanHtml (never user-controlled substitution beyond what it escapes).
+ * Render plan markdown to HTML `<body>` inner markup.
+ *
+ * The SAME engine the in-app transcript uses (react-markdown is remark/rehype,
+ * with the same remark-gfm), so a plan reads identically in the chat panel and
+ * on its shared page. Pure and synchronous — `renderPlanHtml` is a pure
+ * function and its tests depend on that.
+ *
+ * SECURITY: `remark-rehype` DROPS raw HTML by default, so markup embedded in a
+ * plan can never reach the page. Do NOT add `allowDangerousHtml` or
+ * `rehype-raw` — that is the whole sanitisation story, and the page's sandbox
+ * CSP is a second line, not the first.
  */
 export function renderPlanMarkdown(markdown) {
-  const lines = String(markdown).split("\n");
-  const out = [];
-  let i = 0;
-  let inCode = false;
-  let codeLang = "";
-  let codeBuf = [];
-
-  const flushCode = () => {
-    const langAttr = codeLang ? ` class="language-${escapeHtml(codeLang)}"` : "";
-    out.push(
-      `<pre><code${langAttr}>${codeBuf.map(escapeHtml).join("\n")}</code></pre>`,
-    );
-    codeBuf = [];
-    codeLang = "";
-    inCode = false;
-  };
-
-  while (i < lines.length) {
-    const line = lines[i];
-
-    if (!inCode && isCodeFence(line) !== null) {
-      inCode = true;
-      codeLang = isCodeFence(line);
-      i += 1;
-      continue;
-    }
-    if (inCode) {
-      if (isCodeFence(line) !== null) {
-        flushCode();
-        i += 1;
-        continue;
-      }
-      codeBuf.push(line);
-      i += 1;
-      continue;
-    }
-
-    const trimmed = line.trim();
-    const heading = /^(#{1,6})[ \t]+(.*)$/.exec(line);
-    const hr = /^-{3,}$/.test(trimmed);
-    const listItem = /^([ \t]*)[-*+][ \t]+(.*)$/.exec(line);
-    const orderedItem = /^([ \t]*)\d+[.)][ \t]+(.*)$/.exec(line);
-
-    if (heading) {
-      const level = Math.min(heading[1].length, 6);
-      out.push(`<h${level}>${renderInline(heading[2])}</h${level}>`);
-      i += 1;
-      continue;
-    }
-    if (hr) {
-      out.push("<hr>");
-      i += 1;
-      continue;
-    }
-
-    // Lists: collect a run of consecutive list items into ONE <ul>/<ol>.
-    if (listItem || orderedItem) {
-      const ordered = Boolean(orderedItem);
-      const tag = ordered ? "ol" : "ul";
-      const items = [];
-      while (i < lines.length) {
-        const li = /^([ \t]*)[-*+][ \t]+(.*)$/.exec(lines[i]);
-        const oli = /^([ \t]*)\d+[.)][ \t]+(.*)$/.exec(lines[i]);
-        if (ordered) {
-          if (!oli) break;
-          items.push(oli[2]);
-        } else {
-          if (!li) break;
-          items.push(li[2]);
-        }
-        i += 1;
-      }
-      const lis = items.map((t) => `<li>${renderInline(t)}</li>`).join("\n");
-      out.push(`<${tag}>\n${lis}\n</${tag}>`);
-      continue;
-    }
-
-    // Paragraph: collect consecutive non-empty lines.
-    const para = [];
-    while (i < lines.length && lines[i].trim() !== "") {
-      para.push(lines[i]);
-      i += 1;
-    }
-    if (para.length) {
-      out.push(`<p>${para.map(renderInline).join("\n")}</p>`);
-    }
-    // skip blank separator
-    if (lines[i]?.trim() === "") i += 1;
-  }
-
-  if (inCode) flushCode();
-  return out.join("\n");
+  return String(
+    unified()
+      .use(remarkParse)
+      .use(remarkGfm)
+      .use(remarkRehype)
+      .use(rehypeStringify)
+      .processSync(String(markdown)),
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -390,14 +294,14 @@ export function renderPlanHtml({ title: titleIn, markdown, path, generatedAt }) 
     font-size: 0.9em;
     background: var(--inset);
     border: 1px solid var(--border-subtle);
-    border-radius: 4px;
+    border-radius: var(--r-xs);
     padding: 0.1em 0.35em;
     color: var(--tx2);
   }
   pre {
     background: var(--inset);
     border: 1px solid var(--border-subtle);
-    border-radius: 6px;
+    border-radius: var(--r-sm);
     padding: 14px 16px;
     overflow-x: auto;
     margin: 0.8em 0;
@@ -411,6 +315,43 @@ export function renderPlanHtml({ title: titleIn, markdown, path, generatedAt }) 
     font-size: 12.5px;
     line-height: 1.5;
   }
+  main blockquote {
+    margin: 0.8em 0;
+    padding: 0.1em 0 0.1em 14px;
+    border-left: 2px solid var(--border);
+    color: var(--tx3);
+  }
+  main ul ul, main ul ol, main ol ul, main ol ol { margin: 0.25em 0; }
+  main li > p { margin: 0.25em 0; }
+  /* GFM task list: the checkbox replaces the marker, so the item un-indents
+     back to the list's own left edge. */
+  main li:has(> input[type="checkbox"]) {
+    list-style: none;
+    margin-left: -1.4em;
+  }
+  main li > input[type="checkbox"] {
+    margin: 0 6px 0 0;
+    vertical-align: baseline;
+    accent-color: var(--accent-solid);
+  }
+  main del { color: var(--tx4); }
+  main img { max-width: 100%; height: auto; border-radius: var(--r-sm); }
+  main table {
+    display: block;
+    overflow-x: auto;
+    max-width: 100%;
+    border-collapse: collapse;
+    margin: 0.9em 0;
+    font-size: 13.5px;
+  }
+  main th, main td {
+    border: 1px solid var(--border-subtle);
+    padding: 6px 10px;
+    text-align: left;
+    vertical-align: top;
+  }
+  main th { background: var(--inset); color: var(--tx2); font-weight: 600; }
+  main tr:nth-child(even) td { background: var(--fill); }
   footer {
     margin-top: 48px;
     padding-top: 20px;

--- a/src/server/servePage.test.mjs
+++ b/src/server/servePage.test.mjs
@@ -446,17 +446,23 @@ test("planSubdomain returns null for empty / unusable input", () => {
   // 123 is a number, not a string — rejected by the typeof guard.
 });
 
-test("renderPlanMarkdown escapes raw HTML in body", () => {
+test("renderPlanMarkdown drops raw HTML and escapes entity-like text", () => {
   const html = renderPlanMarkdown("a <script>alert(1)</script> b & c");
-  assert.match(html, /&lt;script&gt;/);
-  assert.doesNotMatch(html, /<script>/);
-  assert.match(html, /&amp;/);
+  // remark-rehype DROPS raw HTML rather than escaping it: the script tag never
+  // appears as markup, but its text content still renders as plain text.
+  assert.doesNotMatch(html, /<script/i);
+  assert.match(html, /alert\(1\)/);
+  assert.doesNotMatch(html, /<\/script>/i);
+  // `&` is still HTML-escaped (the unified pipeline emits the hex form).
+  assert.match(html, /&amp;|&#x26;|&#38;/);
 });
 
 test("renderPlanMarkdown renders fenced code blocks with monospace pre/code", () => {
   const html = renderPlanMarkdown('```js\nconst x = "<b>";\n```');
   assert.match(html, /<pre><code class="language-js">/);
-  assert.match(html, /&lt;b&gt;/);
+  // The unified pipeline HTML-escapes the source's `<` (as the hex form) so a
+  // literal `<b>` can never surface as a tag.
+  assert.match(html, /&#x3C;b&gt;|&lt;b&gt;|&#x3C;b>/);
   assert.doesNotMatch(html, /<b>/);
 });
 
@@ -470,6 +476,53 @@ test("renderPlanMarkdown renders unordered and ordered lists", () => {
   const html = renderPlanMarkdown("- one\n- two\n\n1. a\n2. b");
   assert.match(html, /<ul>\s*<li>one<\/li>\s*<li>two<\/li>\s*<\/ul>/);
   assert.match(html, /<ol>\s*<li>a<\/li>\s*<li>b<\/li>\s*<\/ol>/);
+});
+
+test("renderPlanMarkdown nests bullet lists inside their parent item", () => {
+  const html = renderPlanMarkdown("- top\n  - child\n    - grandchild");
+  assert.match(
+    html,
+    /<li>top\s*<ul>\s*<li>child\s*<ul>\s*<li>grandchild<\/li>\s*<\/ul>\s*<\/li>\s*<\/ul>\s*<\/li>/,
+  );
+});
+
+test("renderPlanMarkdown renders GFM task lists as disabled checkboxes", () => {
+  const html = renderPlanMarkdown("- [x] done\n- [ ] not done");
+  assert.match(html, /<input type="checkbox" checked disabled>/);
+  assert.match(html, /<input type="checkbox" disabled>/);
+  assert.match(html, /done/);
+});
+
+test("renderPlanMarkdown renders GFM tables with thead", () => {
+  const html = renderPlanMarkdown("| a | b |\n|---|---|\n| 1 | 2 |");
+  assert.match(html, /<table>\s*<thead>/);
+  assert.match(html, /<th>a<\/th>/);
+  assert.match(html, /<td>1<\/td>/);
+});
+
+test("renderPlanMarkdown renders blockquotes", () => {
+  const html = renderPlanMarkdown("> quoted");
+  assert.match(html, /<blockquote>/);
+  assert.match(html, /quoted/);
+});
+
+test("renderPlanMarkdown renders strikethrough", () => {
+  const html = renderPlanMarkdown("~~x~~");
+  assert.match(html, /<del>x<\/del>/);
+});
+
+test("renderPlanMarkdown auto-links bare URLs", () => {
+  const html = renderPlanMarkdown("see https://example.com/x now");
+  assert.match(
+    html,
+    /<a href="https:\/\/example\.com\/x">https:\/\/example\.com\/x<\/a>/,
+  );
+});
+
+test("renderPlanMarkdown drops raw HTML (img with onerror) entirely", () => {
+  const html = renderPlanMarkdown("<img src=x onerror=alert(1)>");
+  assert.doesNotMatch(html, /<img/i);
+  assert.doesNotMatch(html, /onerror/i);
 });
 
 test("planMetrics derives steps/files and omits absent clauses", () => {


### PR DESCRIPTION
Refactors `src/server/planPage.mjs` to render a plan's markdown with the SAME
unified (remark/rehype + remark-gfm) pipeline the in-app transcript already
uses via react-markdown, deleting ~130 lines of hand-rolled regex.

**What changed**
- Deleted `renderInline` / `isCodeFence` and the body of `renderPlanMarkdown`;
  kept `escapeHtml` (still used for title/path/timestamp). New
  `renderPlanMarkdown` is a synchronous `unified()` pipeline
  (`remark-parse` → `remark-gfm` → `remark-rehype` → `rehype-stringify`).
- Added `unified`, `remark-parse`, `remark-rehype`, `rehype-stringify` to
  `dependencies` (NOT devDependencies — the server tarball ships `node_modules`).
  `remark-gfm` was already a dep; no second GFM impl.
- Security: `remark-rehype` DROPS raw HTML by default — no
  `allowDangerousHtml` / `rehype-raw`, so embedded markup can never reach the
  page. The sandbox CSP is a second line, not the first.
- Token hygiene: added `--r-xs`/`--r-sm` to `LIGHT_TOKENS` and replaced the
  hardcoded `4px`/`6px` code/pre radii with them.
- New CSS (all existing tokens) for what the old renderer could never emit:
  blockquotes, nested lists, GFM task-list checkboxes, `<del>`, `<img>`, and
  tables.

**Tests** — updated the two assertions that depended on the old dialect
(hex HTML-escapes `&#x3C;`/`&#x26;`, and raw HTML is dropped not escaped) and
added coverage for: nested bullet list → nested `<ul>` in `<li>`, `- [x]`
→ checked disabled checkbox, GFM table → `<table><thead>`, `> quoted` →
`<blockquote>`, `~~x~~` → `<del>`, bare URL auto-linking, and
`<img src=x onerror=alert(1)>` never appearing as a tag.

**Base:** `origin/main @ 2d9619c3`

**Files changed:** 4 files (`package.json`, `package-lock.json`,
`src/server/planPage.mjs`, `src/server/servePage.test.mjs`)

**Verification results:**
- PR branch (`multica/BET-975-plan-md-rehype` @ `69089fc8`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 2113 pass / 0 fail / 0 skip. (server `servePage.test.mjs`:
    42 pass / 0 fail.)
- Conclusion: 0 new failures. The two changed assertions live in tests this
  PR modifies; all other pre-existing behaviors (code fences, ATX headings,
  lists, escaping) continue to pass on the new engine.
