### PR TITLE
fix(ios): mirror plan-mode switches into the composer's Plan chip (BET-977)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -272,6 +272,15 @@ private struct ChatScreenContent: View {
                 MantaPushRouter.shared.visibleSessionID = nil
                 Task { try? await MantaAPIClient.live().reportFocus(sessionId: nil, visible: false) }
             }
+            // BET-977: the box mirrors opencode's LOCAL plan_enter/plan_exit via
+            // the `planMode` frame. Route it into the session's ChatModelStore
+            // through `setPlan` — the SAME entry point the Plan chip's tap uses,
+            // so the value is persisted per-session identically and there is no
+            // second persistence path. Published edge-triggers on change, so this
+            // fires once per actual plan-mode switch.
+            .onReceive(store.$planOn) { on in
+                if let on { modelStore.setPlan(on) }
+            }
             // 5s branch poll (desktop cadence) so a terminal-side checkout
             // reflects within one tick (BET-747 gap #13). Cancelled on disappear.
             .task { await pollBranch() }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -168,6 +168,7 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var todos: StreamTodosPayload?
     @Published private(set) var questions: [QuestionRequest] = []
     @Published private(set) var permissions: [PermissionRequest] = []
+    @Published private(set) var planOn: Bool?
     @Published private(set) var subagents: [StreamSubagentPayload] = []
     @Published private(set) var childStores: [String: ChatSessionStore] = [:]
     /// Prompts accepted mid-turn, FIFO. Drained one per idle edge — never
@@ -419,6 +420,7 @@ final class ChatSessionStore: ObservableObject {
         sessionError = s.sessionError
         todos = s.todos
         subagents = s.subagents
+        planOn = s.planOn
 
         // Which frame (if any) just changed this session's stream state. The
         // `$sessionStates` sink fires on every republish, so the stamp only

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -77,6 +77,10 @@ struct MantaSessionStreamState: Equatable, Sendable {
     var todos: StreamTodosPayload?
     var questions: StreamQuestionsPayload?
     var permissions: StreamPermissionsPayload?
+    /// The plan-mode state the box last reported for this session (BET-977).
+    /// `nil` until a `planMode` frame arrives — mirrors opencode's local switch
+    /// so the Plan chip turns itself off the moment the model exits planning.
+    var planOn: Bool?
     var subagents: [StreamSubagentPayload] = []
     /// Live tools in flight keyed by their stable tool part id (`idx`), and
     /// the order they started in. A `toolEnded` removes the idx from the order
@@ -230,6 +234,8 @@ enum MantaStreamRouter {
             s.questions = try? frame.decodedPayload(StreamQuestionsPayload.self)
         case "permissions":
             s.permissions = try? frame.decodedPayload(StreamPermissionsPayload.self)
+        case "planMode":
+            s.planOn = try? frame.decodedPayload(StreamPlanModePayload.self)?.on
         case "subagent":
             if let p = try? frame.decodedPayload(StreamSubagentPayload.self) {
                 // Upsert keyed by the subagent's child-session id (BET-672): a

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -262,6 +262,13 @@ struct StreamPermissionsPayload: Codable, Equatable, Sendable {
     var permissions: [PermissionRequest]
 }
 
+/// `sub: "planMode"` — the box mirrors opencode's LOCAL plan_enter/plan_exit
+/// switch so the phone's Plan chip stays honest (BET-977). `on` is the plan
+/// mode the model is now in.
+struct StreamPlanModePayload: Codable, Equatable, Sendable {
+    var on: Bool
+}
+
 /// `sub: "subagent"` — extractSubagentInfo + runningCount.
 struct StreamSubagentPayload: Codable, Equatable, Sendable {
     var childSessionId: String

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -309,6 +309,27 @@ final class MantaEventStreamRouterTests: XCTestCase {
         XCTAssertEqual(state.turnComplete, true)
     }
 
+    // MARK: - Plan-mode mirror (BET-977)
+
+    func testPlanModeFrameToRecordedValue() throws {
+        // The box mirrors opencode's LOCAL plan switch: a completed plan_enter
+        // emits {on:true}, plan_exit {on:false}. The router records whichever
+        // value landed so the per-session store can route it to setPlan.
+        let enter = try MantaStreamFrame.parse(#"{"kind":"stream","sub":"planMode","sessionId":"ses_1","payload":{"on":true}}"#)
+        var state = MantaStreamRouter.applying(enter, to: nil)
+        XCTAssertEqual(state.planOn, true)
+
+        let exit = try MantaStreamFrame.parse(#"{"kind":"stream","sub":"planMode","sessionId":"ses_1","payload":{"on":false}}"#)
+        state = MantaStreamRouter.applying(exit, to: state)
+        XCTAssertEqual(state.planOn, false)
+    }
+
+    func testPlanModeStartsNilUntilAFrameLands() {
+        // A fresh session has no plan-mode fact until the box emits one.
+        let state = MantaSessionStreamState(sessionId: "ses_1")
+        XCTAssertNil(state.planOn)
+    }
+
     // MARK: - Turn-start stamp (BET-896)
 
     /// The box stamps `since` (epoch ms) on the idle->busy edge; the router

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -27,7 +27,6 @@ import {
   formatAge,
   shouldAbortForQueuedDrain,
   isToolStepBoundary,
-  planModeFromToolPart,
   isDrainAbortError,
   isUnknownChannelError,
   describeCron,
@@ -981,37 +980,6 @@ describe("isToolStepBoundary", () => {
     expect(isToolStepBoundary({})).toBe(false);
     expect(isToolStepBoundary({ type: "tool" })).toBe(false);
     expect(isToolStepBoundary("tool")).toBe(false);
-  });
-});
-
-describe("planModeFromToolPart", () => {
-  it("is true for a completed plan_enter", () => {
-    expect(planModeFromToolPart({ type: "tool", tool: "plan_enter", state: { status: "completed" } })).toBe(true);
-  });
-
-  it("is false for a completed plan_exit", () => {
-    expect(planModeFromToolPart({ type: "tool", tool: "plan_exit", state: { status: "completed" } })).toBe(false);
-  });
-
-  it("is null for an errored plan_exit (the regression: a rejected switch did not happen)", () => {
-    expect(planModeFromToolPart({ type: "tool", tool: "plan_exit", state: { status: "error" } })).toBe(null);
-  });
-
-  it("is null for an errored plan_enter", () => {
-    expect(planModeFromToolPart({ type: "tool", tool: "plan_enter", state: { status: "error" } })).toBe(null);
-  });
-
-  it("is null for a completed non-plan tool", () => {
-    expect(planModeFromToolPart({ type: "tool", tool: "bash", state: { status: "completed" } })).toBe(null);
-  });
-
-  it("is null for a non-tool part", () => {
-    expect(planModeFromToolPart({ type: "text", state: { status: "completed" } })).toBe(null);
-  });
-
-  it("is null for null / undefined", () => {
-    expect(planModeFromToolPart(null)).toBe(null);
-    expect(planModeFromToolPart(undefined)).toBe(null);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -585,26 +585,6 @@ export function isToolStepBoundary(part: unknown): boolean {
 }
 
 /**
- * The plan-mode state a tool part asserts, or `null` if it asserts nothing.
- *
- * Only a COMPLETED plan_enter/plan_exit counts. An ERRORED one is a switch that
- * did NOT happen — most importantly the plan card's "Keep planning", which
- * answers the plan question "No" and so rejects the `plan_exit` tool. Reading
- * that as an exit dropped the session out of plan mode behind the user's back.
- * (This is why the drain's `isToolStepBoundary`, which accepts `error` on
- * purpose, must not be reused here.)
- */
-export function planModeFromToolPart(part: unknown): boolean | null {
-  if (!part || typeof part !== "object") return null;
-  const p = part as { type?: unknown; tool?: unknown; state?: { status?: unknown } };
-  if (p.type !== "tool") return null;
-  if (p.state?.status !== "completed") return null;
-  if (p.tool === "plan_enter") return true;
-  if (p.tool === "plan_exit") return false;
-  return null;
-}
-
-/**
  * Should a step boundary trigger a drain-abort? True when at least one prompt
  * is queued AND we have not already issued a drain-abort for the current turn
  * (`alreadyDraining` guards re-entrancy against the multiple boundary events

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -65,12 +65,12 @@ import {
   isDrainAbortError,
   shouldAbortForQueuedDrain,
   isToolStepBoundary,
-  planModeFromToolPart,
   collectChildSessionIds,
   hydrateQuestion,
   authErrorAdvice,
   fetchTranscriptWithRetry,
 } from "../chatUtils";
+import { planModeFromToolPart } from "../../shared/planMode.mjs";
 import type { TokenUsage } from "../chatShared";
 import { useStore } from "../store";
 import { markFirstToken, markRendered } from "../firstTokenLatency";

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -42,6 +42,7 @@ import {
   buildTitleInstruction,
   ASSUMED_CONTEXT_TOKENS,
 } from "../shared/streamInterpretation.mjs";
+import { planModeFromToolPart } from "../shared/planMode.mjs";
 
 const TTL_DEFAULT = "1h";
 
@@ -90,6 +91,7 @@ function newSessionState() {
     runningSince: null,        // epoch ms when the running turn started (idle->busy edge)
     runningType: null,         // last session.status type ("busy"|"working"|"retry"|null); preserved for the connect-time snapshot replay
     todos: null,               // liveTodos (todo.updated) ; null = not seen
+    handledPlanCallIds: new Set(), // callIDs that already emitted a planMode frame
     msgByMsgId: new Map(),     // messageID -> minimal message for turn detection
     userTurnCount: 0,
     contextEmitted: null,      // { totalInput, limit } of the last context emit
@@ -362,6 +364,28 @@ export function createStreamInterpreter({
         // tool part, so it gets a toolStarted/…/toolEnded pair too — harmless
         // alongside the richer `subagent` frame.
         if (part?.type === "tool") updateToolFrames(st, sid, part, emit);
+        // Plan-mode mirror (BET-977). Plan mode is NOT server state — opencode
+        // switches its agent locally on plan_enter/plan_exit, so the box must
+        // relay the fact for the phone's Plan chip to stay honest. Only a
+        // COMPLETED plan_enter/plan_exit asserts a mode (an errored one,
+        // e.g. "Keep planning" rejecting the exit, changed nothing). De-duped
+        // per callID exactly like the desktop, so the same completed tool part
+        // arriving twice emits one frame.
+        const planNext = planModeFromToolPart(part);
+        if (planNext !== null) {
+          const callID = typeof part?.callID === "string" ? part.callID : "";
+          if (callID && !st.handledPlanCallIds.has(callID)) {
+            st.handledPlanCallIds.add(callID);
+            emit(sid, "planMode", { on: planNext });
+          }
+        }
+        return;
+      }
+      case "session.next.agent.switched": {
+        // Report a switch that already happened (mirrors the desktop's
+        // `session.next.agent.switched` branch). `properties.agent` is
+        // opencode's own agent name — plan mode is exactly agent "plan".
+        emit(sid, "planMode", { on: String(evt.properties?.agent ?? "") === "plan" });
         return;
       }
       case "session.created": {

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -882,3 +882,79 @@ test("the same event also emits a cache frame", () => {
   interp.interpret(updatedWith(ASSISTANT_MSG));
   assert.equal(events.filter((e) => e.sub === "cache").length, 1);
 });
+
+test("a completed plan_exit tool part emits one planMode {on:false} frame", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: {
+      sessionID: SID,
+      part: { id: "p1", type: "tool", tool: "plan_exit", callID: "toolu_exit", state: { status: "completed" } },
+    },
+  });
+  const pm = events.filter((e) => e.sub === "planMode");
+  assert.equal(pm.length, 1);
+  assert.equal(pm[0].payload.on, false);
+});
+
+test("a completed plan_enter tool part emits one planMode {on:true} frame", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: {
+      sessionID: SID,
+      part: { id: "p1", type: "tool", tool: "plan_enter", callID: "toolu_enter", state: { status: "completed" } },
+    },
+  });
+  const pm = events.filter((e) => e.sub === "planMode");
+  assert.equal(pm.length, 1);
+  assert.equal(pm[0].payload.on, true);
+});
+
+test("an errored plan_exit tool part emits NOTHING", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: {
+      sessionID: SID,
+      part: { id: "p1", type: "tool", tool: "plan_exit", callID: "toolu_exit", state: { status: "error" } },
+    },
+  });
+  assert.equal(events.filter((e) => e.sub === "planMode").length, 0);
+});
+
+test("the same planMode callID arriving twice emits once", () => {
+  const { interp, events } = make();
+  const upd = {
+    type: "message.part.updated",
+    properties: {
+      sessionID: SID,
+      part: { id: "p1", type: "tool", tool: "plan_exit", callID: "toolu_exit", state: { status: "completed" } },
+    },
+  };
+  interp.interpret(upd);
+  interp.interpret(upd);
+  assert.equal(events.filter((e) => e.sub === "planMode").length, 1);
+});
+
+test("session.next.agent.switched to plan emits planMode {on:true}", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "session.next.agent.switched",
+    properties: { sessionID: SID, agent: "plan" },
+  });
+  const pm = events.filter((e) => e.sub === "planMode");
+  assert.equal(pm.length, 1);
+  assert.equal(pm[0].payload.on, true);
+});
+
+test("session.next.agent.switched away from plan emits planMode {on:false}", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "session.next.agent.switched",
+    properties: { sessionID: SID, agent: "build" },
+  });
+  const pm = events.filter((e) => e.sub === "planMode");
+  assert.equal(pm.length, 1);
+  assert.equal(pm[0].payload.on, false);
+});

--- a/src/shared/planMode.d.mts
+++ b/src/shared/planMode.d.mts
@@ -1,0 +1,15 @@
+// Hand-written type declarations for planMode.mjs. Implementation is plain JS
+// so both the renderer tsconfig and the server import it without crossing a
+// process boundary. Keep in sync with src/shared/planMode.mjs.
+
+/**
+ * The plan-mode state a tool part asserts, or `null` if it asserts nothing.
+ *
+ * Only a COMPLETED plan_enter/plan_exit counts. An ERRORED one is a switch that
+ * did NOT happen — most importantly the plan card's "Keep planning", which
+ * answers the plan question "No" and so rejects the `plan_exit` tool. Reading
+ * that as an exit dropped the session out of plan mode behind the user's back.
+ * (This is why the drain's `isToolStepBoundary`, which accepts `error` on
+ * purpose, must not be reused here.)
+ */
+export function planModeFromToolPart(part: unknown): boolean | null;

--- a/src/shared/planMode.mjs
+++ b/src/shared/planMode.mjs
@@ -1,0 +1,24 @@
+// planMode.mjs — the ONE shared rule for reading plan-mode state off a tool
+// part (BET-977). Consumed by the desktop renderer (useSseBus.ts) AND the box's
+// stream interpreter (streamInterp.mjs) so both mirror opencode's local
+// plan_enter/plan_exit switch identically. Do not copy this elsewhere.
+
+/**
+ * The plan-mode state a tool part asserts, or `null` if it asserts nothing.
+ *
+ * Only a COMPLETED plan_enter/plan_exit counts. An ERRORED one is a switch that
+ * did NOT happen — most importantly the plan card's "Keep planning", which
+ * answers the plan question "No" and so rejects the `plan_exit` tool. Reading
+ * that as an exit dropped the session out of plan mode behind the user's back.
+ * (This is why the drain's `isToolStepBoundary`, which accepts `error` on
+ * purpose, must not be reused here.)
+ */
+export function planModeFromToolPart(part) {
+  if (!part || typeof part !== "object") return null;
+  const p = part;
+  if (p.type !== "tool") return null;
+  if (p.state?.status !== "completed") return null;
+  if (p.tool === "plan_enter") return true;
+  if (p.tool === "plan_exit") return false;
+  return null;
+}

--- a/src/shared/planMode.test.ts
+++ b/src/shared/planMode.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import { planModeFromToolPart } from "./planMode.mjs";
+
+describe("planModeFromToolPart", () => {
+  it("is true for a completed plan_enter", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "plan_enter", state: { status: "completed" } })).toBe(true);
+  });
+
+  it("is false for a completed plan_exit", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "plan_exit", state: { status: "completed" } })).toBe(false);
+  });
+
+  it("is null for an errored plan_exit (the regression: a rejected switch did not happen)", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "plan_exit", state: { status: "error" } })).toBe(null);
+  });
+
+  it("is null for an errored plan_enter", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "plan_enter", state: { status: "error" } })).toBe(null);
+  });
+
+  it("is null for a completed non-plan tool", () => {
+    expect(planModeFromToolPart({ type: "tool", tool: "bash", state: { status: "completed" } })).toBe(null);
+  });
+
+  it("is null for a non-tool part", () => {
+    expect(planModeFromToolPart({ type: "text", state: { status: "completed" } })).toBe(null);
+  });
+
+  it("is null for null / undefined", () => {
+    expect(planModeFromToolPart(null)).toBe(null);
+    expect(planModeFromToolPart(undefined)).toBe(null);
+  });
+});


### PR DESCRIPTION
Opened automatically for `multica/BET-977-ios-planmode-mirror`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-977.