### PR TITLE
fix(install): pin a clean install to the release's own commit

### DIFF
--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -124,19 +124,29 @@ jobs:
         if: env.INSTALLER == 'branch'
         run: |
           set -euo pipefail
-          # install.sh re-creates $MANTA_HOME as a git checkout and does
-          # `fetch origin main && reset --hard origin/main` (step 4b) so
-          # self-update.sh has something to pull. Left alone, that would deploy
-          # `main`'s server code even though we are testing a PR — the branch's
+          # install.sh re-creates $MANTA_HOME as a git checkout and resets it to
+          # the RELEASE's own commit (BET-978), so self-update.sh has something
+          # to pull and so a box never runs source its shipped node_modules
+          # can't satisfy. Left alone, that would deploy the released tarball's
+          # server code even though we are testing a PR — the branch's
           # install.sh would run, but every file it deploys (src/server/**, the
-          # launchd templates) would come from main. Publishing HEAD as `main`
-          # in a local bare repo makes the deploy the PR's code, so a change to
-          # a plist or to the server is actually exercised on the Mac.
+          # launchd templates) would come from the release. Publishing HEAD as
+          # `main` in a local bare repo and pointing the pin at it with
+          # MANTA_DEPLOY_REF makes the deploy the PR's code, so a change to a
+          # plist or to the server is actually exercised on the Mac.
           # (node_modules + runtime/ still come from the released tarball —
           # untracked paths survive `reset --hard`.)
+          #
+          # CONSEQUENCE, and it is the point: the PR's source is then paired
+          # with the LAST RELEASE's dependencies, so this job goes red whenever
+          # a PR adds a dependency that no published tarball carries yet. That
+          # is a true statement about clean installs, not a flake — it is the
+          # exact failure BET-978 was opened for. Clear it by publishing a
+          # server release, not by loosening the check.
           git init --bare -q "$RUNNER_TEMP/manta.git"
           git push -q "$RUNNER_TEMP/manta.git" "HEAD:refs/heads/main"
           echo "MANTA_REPO_URL=file://$RUNNER_TEMP/manta.git" >> "$GITHUB_ENV"
+          echo "MANTA_DEPLOY_REF=origin/main" >> "$GITHUB_ENV"
           echo "deploy source: this PR ($(git rev-parse --short HEAD))"
 
       - name: Install box prerequisites (tmux)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2718,6 +2718,38 @@ the dev box (`dev@157.90.224.92`) or the prod box.
   full-release path — the loop over `linux-x64`/`linux-arm64` covers the same
   arches, and preflight refuses to publish unless BOTH are present.
 
+### A clean install runs the RELEASE's source, not `main`'s
+
+**A box's dependencies come from the release tarball and nowhere else** — it
+has no compiler and never runs an install step of its own. So the source tree
+must be the one those dependencies were built for. `install.sh` extracts the
+tarball, then re-materialises the full source from git at **the release's own
+commit** (`git_sha` in `RELEASE.json`), falling back to `origin/main` only for
+a tarball old enough to carry no stamp.
+
+It used to reset to `origin/main` unconditionally, which paired TODAY's source
+with the LAST RELEASE's dependencies. The consequence is worth stating plainly
+because nothing about it is visible from the repo: **from the moment any PR
+adds a dependency until the next release is published, EVERY clean install is
+broken — on prod as well as staging** — while already-installed boxes are
+perfectly fine, because their update path takes source and dependencies
+together from one tarball. The box dies on an unresolved import before it can
+bind, so the only symptom is the installer's "server did not become healthy"
+timeout pointing at `systemctl status`. That is what happened on 2026-08-15
+(the plan-page work added four packages).
+
+Two consequences to keep in mind:
+
+- **Merging does not ship server code to new boxes; publishing a release
+  does.** That was already true of existing boxes and is now uniformly true.
+- **A dependency added to `package.json` reaches a box only through a new
+  tarball.** No box ever resolves one at runtime.
+
+A preflight (`check_release_dependencies` in install.sh, `findMissingDependencies`
+in install-lib.mjs) backstops the rest of the class — a fork via
+`MANTA_REPO_URL`, a hand-run `git pull`, a half-extracted tarball — by naming
+the missing packages at install time instead of leaving a health timeout.
+
 ### A release is identified by its COMMIT, not its version number
 
 **You do not need to bump `package.json` to ship a server release.** A box

--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -175,6 +175,102 @@ export function checkIdentity(cfg, { exists = existsSync } = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// Deploy ref — WHICH commit the git checkout at $MANTA_HOME is reset to
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve the commit an installed box's git checkout should be reset to,
+ * from the release's own RELEASE.json text.
+ *
+ * WHY THIS EXISTS (BET-978). install.sh extracts a pinned release tarball —
+ * which is where `node_modules/` comes from, because the box deliberately
+ * never builds dependencies itself — and then re-materialises the full source
+ * tree from git. Resetting that tree to `origin/main` mixes two different
+ * builds: TODAY's source against the LAST RELEASE's dependencies. Every
+ * dependency added since the last published tarball is then simply absent, the
+ * server dies on an unresolved import before it can bind, and the installer
+ * reports only a health-check timeout.
+ *
+ * That is not a hypothetical: a plan-page change added four packages, and from
+ * that merge until the next release EVERY clean install on prod and staging
+ * failed exactly this way, while already-installed boxes (which replace source
+ * and dependencies together from one tarball) were fine.
+ *
+ * Pinning the reset to the release's own commit removes the class of failure:
+ * source and dependencies come from the same build by construction, so adding
+ * a dependency can never break a clean install again. New code reaches a box
+ * the same way it always did — by publishing a release, which self-update.sh
+ * then applies wholesale.
+ *
+ * Returns { sha, source }:
+ *   sha=<40-hex>, source="release"  → pin to the release commit (normal).
+ *   sha=null,     source="fallback" → RELEASE.json is missing / has no usable
+ *                                     git_sha (a tarball packed outside a git
+ *                                     checkout, or one built before the stamp
+ *                                     existed). Caller falls back to
+ *                                     origin/main — never worse than before.
+ */
+export function resolveDeployRef(releaseJsonText) {
+  const fallback = (reason) => ({ sha: null, source: "fallback", reason });
+  if (typeof releaseJsonText !== "string" || releaseJsonText.trim() === "") {
+    return fallback("no RELEASE.json");
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(releaseJsonText);
+  } catch {
+    return fallback("RELEASE.json is not valid JSON");
+  }
+  const sha = parsed?.git_sha;
+  // A full 40-char hex object name only. A short sha would still resolve, but
+  // the packer always writes the full one, so anything else means the file was
+  // hand-edited or truncated — fall back rather than trust it.
+  if (typeof sha !== "string" || !/^[0-9a-f]{40}$/.test(sha)) {
+    return fallback("RELEASE.json carries no usable git_sha");
+  }
+  return { sha, source: "release", reason: "pinned to the release commit" };
+}
+
+// ---------------------------------------------------------------------------
+// Dependency preflight — catch a source/dependency mismatch before boot
+// ---------------------------------------------------------------------------
+
+/**
+ * List the runtime dependencies declared in package.json that are NOT present
+ * in node_modules.
+ *
+ * The backstop to resolveDeployRef: pinning the checkout makes the common
+ * mismatch unreachable, but a box can still end up with a tree the tarball's
+ * dependencies don't satisfy (a fork via MANTA_REPO_URL, a hand-run `git
+ * pull`, a half-extracted tarball). When that happens the failure surfaces as
+ * a module-not-found crash inside a supervised service — the installer sees
+ * only "server did not become healthy", and the operator gets pointed at
+ * `systemctl status` to discover a missing package. Naming the packages at
+ * install time turns a 60-attempt timeout into one actionable line.
+ *
+ * Injectable `exists` for tests. Scoped shrewdly: `dependencies` only, never
+ * devDependencies (the tarball is built --omit=dev on purpose).
+ */
+export function findMissingDependencies(
+  pkgJsonText,
+  { modulesDir = "node_modules", exists = existsSync, join: joinPath = join } = {},
+) {
+  let parsed;
+  try {
+    parsed = JSON.parse(pkgJsonText ?? "");
+  } catch {
+    // An unreadable package.json is a different (louder) problem, and guessing
+    // at a dependency list from it would be worse than saying nothing.
+    return [];
+  }
+  const deps = parsed?.dependencies;
+  if (!deps || typeof deps !== "object") return [];
+  return Object.keys(deps)
+    .filter((name) => !exists(joinPath(modulesDir, name, "package.json")))
+    .sort();
+}
+
+// ---------------------------------------------------------------------------
 // Health-wait poller
 // ---------------------------------------------------------------------------
 
@@ -1315,6 +1411,38 @@ async function cliMain(argv) {
     process.stderr.write(reason + "\n");
     return 0;
   }
+  if (cmd === "deploy-ref") {
+    // node install-lib.mjs deploy-ref --release <path/to/RELEASE.json>
+    // Prints the commit to reset the deploy checkout to, or nothing when the
+    // release carries no usable stamp (install.sh then falls back to
+    // origin/main). The reason goes to stderr so it can be logged.
+    const path = flags.release || join(resolveConfig().mantaHome ?? ".", "RELEASE.json");
+    let text = "";
+    try {
+      text = readFileSync(path, "utf-8");
+    } catch {
+      text = "";
+    }
+    const { sha, reason } = resolveDeployRef(text);
+    if (sha) process.stdout.write(sha + "\n");
+    process.stderr.write(reason + "\n");
+    return 0;
+  }
+  if (cmd === "check-deps") {
+    // node install-lib.mjs check-deps --home <MANTA_HOME>
+    // Prints one missing dependency name per line; exit 0 either way. The
+    // caller decides how loud to be — this command only reports.
+    const home = flags.home || resolveConfig().mantaHome || ".";
+    let pkg = "";
+    try {
+      pkg = readFileSync(join(home, "package.json"), "utf-8");
+    } catch {
+      pkg = "";
+    }
+    const missing = findMissingDependencies(pkg, { modulesDir: join(home, "node_modules") });
+    if (missing.length) process.stdout.write(missing.join("\n") + "\n");
+    return 0;
+  }
   if (cmd === "merge-opencode-config") {
     // Read raw text from stdin, write the merged text to stdout, and the
     // `corrupt` flag to stderr (so install.sh can branch on it for the
@@ -1698,6 +1826,8 @@ function parseFlags(args) {
     "cli-codex",
     "cli-kimi",
     "connected",
+    "release",
+    "home",
   ]);
   for (let i = 0; i < args.length; i++) {
     const tok = args[i];

--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -175,63 +175,6 @@ export function checkIdentity(cfg, { exists = existsSync } = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Deploy ref — WHICH commit the git checkout at $MANTA_HOME is reset to
-// ---------------------------------------------------------------------------
-
-/**
- * Resolve the commit an installed box's git checkout should be reset to,
- * from the release's own RELEASE.json text.
- *
- * WHY THIS EXISTS (BET-978). install.sh extracts a pinned release tarball —
- * which is where `node_modules/` comes from, because the box deliberately
- * never builds dependencies itself — and then re-materialises the full source
- * tree from git. Resetting that tree to `origin/main` mixes two different
- * builds: TODAY's source against the LAST RELEASE's dependencies. Every
- * dependency added since the last published tarball is then simply absent, the
- * server dies on an unresolved import before it can bind, and the installer
- * reports only a health-check timeout.
- *
- * That is not a hypothetical: a plan-page change added four packages, and from
- * that merge until the next release EVERY clean install on prod and staging
- * failed exactly this way, while already-installed boxes (which replace source
- * and dependencies together from one tarball) were fine.
- *
- * Pinning the reset to the release's own commit removes the class of failure:
- * source and dependencies come from the same build by construction, so adding
- * a dependency can never break a clean install again. New code reaches a box
- * the same way it always did — by publishing a release, which self-update.sh
- * then applies wholesale.
- *
- * Returns { sha, source }:
- *   sha=<40-hex>, source="release"  → pin to the release commit (normal).
- *   sha=null,     source="fallback" → RELEASE.json is missing / has no usable
- *                                     git_sha (a tarball packed outside a git
- *                                     checkout, or one built before the stamp
- *                                     existed). Caller falls back to
- *                                     origin/main — never worse than before.
- */
-export function resolveDeployRef(releaseJsonText) {
-  const fallback = (reason) => ({ sha: null, source: "fallback", reason });
-  if (typeof releaseJsonText !== "string" || releaseJsonText.trim() === "") {
-    return fallback("no RELEASE.json");
-  }
-  let parsed;
-  try {
-    parsed = JSON.parse(releaseJsonText);
-  } catch {
-    return fallback("RELEASE.json is not valid JSON");
-  }
-  const sha = parsed?.git_sha;
-  // A full 40-char hex object name only. A short sha would still resolve, but
-  // the packer always writes the full one, so anything else means the file was
-  // hand-edited or truncated — fall back rather than trust it.
-  if (typeof sha !== "string" || !/^[0-9a-f]{40}$/.test(sha)) {
-    return fallback("RELEASE.json carries no usable git_sha");
-  }
-  return { sha, source: "release", reason: "pinned to the release commit" };
-}
-
-// ---------------------------------------------------------------------------
 // Dependency preflight — catch a source/dependency mismatch before boot
 // ---------------------------------------------------------------------------
 
@@ -239,7 +182,8 @@ export function resolveDeployRef(releaseJsonText) {
  * List the runtime dependencies declared in package.json that are NOT present
  * in node_modules.
  *
- * The backstop to resolveDeployRef: pinning the checkout makes the common
+ * The backstop to install.sh's release-commit pin: pinning the checkout makes
+ * the common
  * mismatch unreachable, but a box can still end up with a tree the tarball's
  * dependencies don't satisfy (a fork via MANTA_REPO_URL, a hand-run `git
  * pull`, a half-extracted tarball). When that happens the failure surfaces as
@@ -1411,23 +1355,6 @@ async function cliMain(argv) {
     process.stderr.write(reason + "\n");
     return 0;
   }
-  if (cmd === "deploy-ref") {
-    // node install-lib.mjs deploy-ref --release <path/to/RELEASE.json>
-    // Prints the commit to reset the deploy checkout to, or nothing when the
-    // release carries no usable stamp (install.sh then falls back to
-    // origin/main). The reason goes to stderr so it can be logged.
-    const path = flags.release || join(resolveConfig().mantaHome ?? ".", "RELEASE.json");
-    let text = "";
-    try {
-      text = readFileSync(path, "utf-8");
-    } catch {
-      text = "";
-    }
-    const { sha, reason } = resolveDeployRef(text);
-    if (sha) process.stdout.write(sha + "\n");
-    process.stderr.write(reason + "\n");
-    return 0;
-  }
   if (cmd === "check-deps") {
     // node install-lib.mjs check-deps --home <MANTA_HOME>
     // Prints one missing dependency name per line; exit 0 either way. The
@@ -1826,7 +1753,6 @@ function parseFlags(args) {
     "cli-codex",
     "cli-kimi",
     "connected",
-    "release",
     "home",
   ]);
   for (let i = 0; i < args.length; i++) {

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -456,10 +456,93 @@ wait_for_box_id() {
   return 1
 }
 
+# ---------------------------------------------------------------------------
+# Git-aware deploy init. `scripts/self-update.sh` (wired in BET-225.A5) assumes
+# $MANTA_HOME is a git checkout, so the update path can do a `git fetch +
+# reset`. The release tarball ships WITHOUT a .git/ (pack.mjs strips it), so we
+# re-create one here. Idempotent: a re-run on an existing deploy updates the
+# remote URL in place (handles renames) and re-resets, so the tarball and the
+# working tree always agree. Untracked files (runtime/, RELEASE.json) survive —
+# `git reset --hard` only touches tracked paths.
+#
+# WE RESET TO THE RELEASE'S OWN COMMIT, NOT origin/main (BET-978). The tarball
+# is where node_modules comes from — the box never builds dependencies itself —
+# so resetting the source to main pairs TODAY's code with the LAST RELEASE's
+# dependencies. Every package added since that release is then missing, the
+# server dies on an unresolved import before it binds, and the installer can
+# only report a health-check timeout. That broke EVERY clean install on prod
+# and staging for the window between a dependency-adding merge and the next
+# release, while already-installed boxes (which take source and dependencies
+# from one tarball) were fine. Pinning makes the two agree by construction. New
+# code still reaches boxes the normal way: publish a release, self-update
+# applies it wholesale.
+#
+# $1=MANTA_HOME  $2=repo url  $3=node binary  $4=install-lib.mjs
+deploy_git_checkout() {
+  local home="$1" repo_url="$2" node_bin="$3" lib="$4"
+  local deploy_sha deploy_ref="origin/main"
+
+  log "Initialising git checkout at $home (origin=$repo_url)"
+  if [ ! -d "$home/.git" ]; then
+    git -C "$home" init -q -b main \
+      || die "git init failed at $home — install git and retry"
+  fi
+  # `git remote add` fails if the remote already exists (re-run case);
+  # `set-url` is the idempotent override.
+  git -C "$home" remote set-url origin "$repo_url" 2>/dev/null \
+    || git -C "$home" remote add origin "$repo_url"
+  git -C "$home" fetch origin main -q \
+    || die "git fetch origin main failed — check network / MANTA_REPO_URL"
+
+  # Which commit? The release stamps its own into RELEASE.json. Empty output
+  # means this tarball predates the stamp (or was packed outside a git
+  # checkout) — then, and only then, fall back to origin/main.
+  deploy_sha="$("$node_bin" "$lib" deploy-ref --release "$home/RELEASE.json" 2>/dev/null || echo "")"
+  if [ -n "$deploy_sha" ]; then
+    # The release commit is normally an ancestor of main and already local
+    # after the fetch above. If it isn't (a release built from a branch since
+    # force-pushed, say), ask the remote for it directly — and only fall back
+    # if the remote can't serve it either, since a checkout at main is still
+    # better than no checkout at all.
+    if git -C "$home" cat-file -e "${deploy_sha}^{commit}" 2>/dev/null \
+      || git -C "$home" fetch origin "$deploy_sha" -q 2>/dev/null; then
+      deploy_ref="$deploy_sha"
+    else
+      warn "release commit ${deploy_sha} is not fetchable — falling back to origin/main"
+    fi
+  fi
+  git -C "$home" reset --hard "$deploy_ref" -q \
+    || die "git reset --hard $deploy_ref failed at $home"
+  ok "Deploy is git-aware: $(git -C "$home" rev-parse --short HEAD) (ref: $deploy_ref)"
+}
+
+# ---------------------------------------------------------------------------
+# Dependency preflight. The pin above makes the usual source/dependency
+# mismatch unreachable, but a fork via MANTA_REPO_URL, a hand-run `git pull`,
+# or a half-extracted tarball can still leave a tree the shipped node_modules
+# doesn't satisfy. Unchecked, that surfaces as a supervised service
+# crash-looping on a module-not-found: the installer reports only "server did
+# not become healthy" and the operator is sent to read service logs to discover
+# a missing package. Name the packages here instead, while we can still say
+# what's wrong.
+#
+# $1=MANTA_HOME  $2=node binary  $3=install-lib.mjs
+check_release_dependencies() {
+  local home="$1" node_bin="$2" lib="$3" missing
+  missing="$("$node_bin" "$lib" check-deps --home "$home" 2>/dev/null || echo "")"
+  [ -n "$missing" ] || return 0
+  die "this release is inconsistent — its source needs packages its node_modules does not have:
+$(printf '  - %s\n' $missing)
+       The server cannot start like this. This is a release-packaging bug, not
+       a problem with your machine — please report it. Re-running the installer
+       once a fixed release is published will resolve it."
+}
+
 # Test mode: when sourced by scripts/install.test.mjs with MANTA_INSTALL_TEST_MODE=1,
 # only the bash helpers (log/ok/warn/die + manifest_get + _sha256_of +
 # verify_sha256 + resolve_arch + launchd_agent_path +
-# print_provider_detection_summary + read_box_id / wait_for_box_id) are
+# print_provider_detection_summary + read_box_id / wait_for_box_id +
+# deploy_git_checkout / check_release_dependencies) are
 # loaded. The actual install does NOT run. Lets the unit tests exercise
 # the helpers with mocked `uname`/etc. without hitting the network. See
 # scripts/install.test.mjs.
@@ -640,45 +723,25 @@ main() {
        die "could not move extracted tarball into $MANTA_HOME — previous install restored"
     }
 
-  # ---------------------------------------------------------------------------
-  # 4b. Git-aware deploy init. `scripts/self-update.sh` (wired in BET-225.A5)
-  #     assumes $MANTA_HOME is a git checkout pointed at origin/main, so the
-  #     update path can do `git fetch + reset --hard origin/main`. The release
-  #     tarball ships WITHOUT a .git/ (pack.mjs strips it), so we re-create one
-  #     here. Idempotent: a re-run on an existing deploy updates the remote
-  #     URL in place (handles renames) and re-resets to origin/main so the
-  #     tarball + the working tree always agree. Untracked files
-  #     (runtime/, RELEASE.json) survive — `git reset --hard` only touches
-  #     tracked paths.
-  # ---------------------------------------------------------------------------
-  MANTA_REPO_URL="${MANTA_REPO_URL:-https://github.com/antoinedc/MantaUI.git}"
-  if [ "$DRY_RUN" = "1" ]; then
-    dry_log "would init git at $MANTA_HOME, fetch $MANTA_REPO_URL, reset --hard origin/main"
-  else
-    log "Initialising git checkout at $MANTA_HOME (origin=$MANTA_REPO_URL)"
-    if [ ! -d "$MANTA_HOME/.git" ]; then
-      git -C "$MANTA_HOME" init -q -b main \
-        || die "git init failed at $MANTA_HOME — install git and retry"
-    fi
-    # `git remote add` fails if the remote already exists (re-run case);
-    # `set-url` is the idempotent override.
-    git -C "$MANTA_HOME" remote set-url origin "$MANTA_REPO_URL" 2>/dev/null \
-      || git -C "$MANTA_HOME" remote add origin "$MANTA_REPO_URL"
-    git -C "$MANTA_HOME" fetch origin main -q \
-      || die "git fetch origin main failed — check network / MANTA_REPO_URL"
-    git -C "$MANTA_HOME" reset --hard origin/main -q \
-      || die "git reset --hard origin/main failed at $MANTA_HOME"
-    ok "Deploy is git-aware: $(git -C "$MANTA_HOME" rev-parse --short HEAD)"
-  fi
-
   # From here on, EVERY node invocation uses the vendored binary explicitly.
-  # No path lookup, no reliance on a system node.
+  # No path lookup, no reliance on a system node. Resolved BEFORE the git step
+  # below because that step asks the tested lib which commit to pin to.
   NODE="$MANTA_HOME/runtime/node/bin/node"
   export PATH="$MANTA_HOME/runtime/node/bin:$PATH"
 
   # Now use the REAL tested lib for everything downstream.
   LIB="$MANTA_HOME/scripts/install-lib.mjs"
   [ -f "$LIB" ] || die "tarball is missing scripts/install-lib.mjs — bad release?"
+
+  # 4b/4c — see deploy_git_checkout() / check_release_dependencies() above.
+  MANTA_REPO_URL="${MANTA_REPO_URL:-https://github.com/antoinedc/MantaUI.git}"
+  if [ "$DRY_RUN" = "1" ]; then
+    dry_log "would init git at $MANTA_HOME, fetch $MANTA_REPO_URL, reset --hard to the release commit"
+    dry_log "would verify every declared dependency is present in $MANTA_HOME/node_modules"
+  else
+    deploy_git_checkout "$MANTA_HOME" "$MANTA_REPO_URL" "$NODE" "$LIB"
+    check_release_dependencies "$MANTA_HOME" "$NODE" "$LIB"
+  fi
 
   # Resolve the canonical config (exports MANTA_HOME, MANTA_AUTH_FILE, MANTA_PORT,
   # MANTA_HEALTH_URL, …). Version comes from package.json when unset.

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -477,6 +477,20 @@ wait_for_box_id() {
 # code still reaches boxes the normal way: publish a release, self-update
 # applies it wholesale.
 #
+# `MANTA_DEPLOY_REF` overrides the pin with any ref (e.g. `origin/main`, a
+# branch, a sha). That is how you deploy a branch to a box on purpose — and how
+# the macOS install smoke keeps exercising a PR's own server/plist code while
+# installing the last published tarball.
+#
+# The stamp is read HERE, in bash, and NOT through install-lib.mjs. install.sh
+# is served fresh from the website, but the lib comes from the extracted
+# TARBALL — which is by definition an older release and need not know any
+# subcommand added since. Asking it would make this decision silently
+# unavailable on exactly the installs that need it (verified: the macOS smoke
+# fell back to origin/main because the 0.0.30 lib had no `deploy-ref`). The
+# pattern doubles as the validation: only a full 40-char hex matches, so a
+# truncated or hand-edited stamp yields nothing and falls back.
+#
 # $1=MANTA_HOME  $2=repo url  $3=node binary  $4=install-lib.mjs
 deploy_git_checkout() {
   local home="$1" repo_url="$2" node_bin="$3" lib="$4"
@@ -494,10 +508,20 @@ deploy_git_checkout() {
   git -C "$home" fetch origin main -q \
     || die "git fetch origin main failed — check network / MANTA_REPO_URL"
 
-  # Which commit? The release stamps its own into RELEASE.json. Empty output
-  # means this tarball predates the stamp (or was packed outside a git
-  # checkout) — then, and only then, fall back to origin/main.
-  deploy_sha="$("$node_bin" "$lib" deploy-ref --release "$home/RELEASE.json" 2>/dev/null || echo "")"
+  # An explicit override wins outright — deploying a branch is a deliberate act.
+  if [ -n "${MANTA_DEPLOY_REF:-}" ]; then
+    git -C "$home" fetch origin "$MANTA_DEPLOY_REF" -q 2>/dev/null || true
+    git -C "$home" reset --hard "$MANTA_DEPLOY_REF" -q \
+      || die "git reset --hard $MANTA_DEPLOY_REF failed at $home (MANTA_DEPLOY_REF)"
+    ok "Deploy pinned by MANTA_DEPLOY_REF: $(git -C "$home" rev-parse --short HEAD) ($MANTA_DEPLOY_REF)"
+    return 0
+  fi
+
+  # Which commit? The release stamps its own into RELEASE.json. Empty means
+  # this tarball predates the stamp (or was packed outside a git checkout) —
+  # then, and only then, fall back to origin/main.
+  deploy_sha="$(sed -n 's/.*"git_sha"[[:space:]]*:[[:space:]]*"\([0-9a-f]\{40\}\)".*/\1/p' \
+    "$home/RELEASE.json" 2>/dev/null | head -1)"
   if [ -n "$deploy_sha" ]; then
     # The release commit is normally an ancestor of main and already local
     # after the fetch above. If it isn't (a release built from a branch since

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -10,6 +10,8 @@ import {
   resolveConfig,
   parsePort,
   checkIdentity,
+  resolveDeployRef,
+  findMissingDependencies,
   waitForHealth,
   readBoxIdentity,
   formatPairingOutput,
@@ -5572,4 +5574,208 @@ test("BET-446: seeding still merges the plugin when OPENCODE_CLAUDE_AUTH_PLUGIN 
   assert.match(out, /opencode\.jsonc seeded\./, `must print the success line:\n${out}`);
   assert.ok(config !== null, "the merged opencode.jsonc must be written");
   assert.match(config, /opencode-claude-auth@latest/, "the plugin must still be seeded into the config");
+});
+
+// ----------------------------------------------------------------------------
+// BET-978 — a clean install must run the release's OWN source, not main's.
+// ----------------------------------------------------------------------------
+//
+// The failure this locks out: install.sh extracts a pinned release tarball
+// (the only source of node_modules — the box never builds dependencies) and
+// then re-materialises the source tree from git. Resetting that tree to
+// origin/main paired TODAY's source with the LAST RELEASE's dependencies, so
+// every package added since the last publish was missing. The server exited on
+// an unresolved import before binding, and the installer could only report
+// "server did not become healthy". It broke EVERY clean install on prod and
+// staging between a dependency-adding merge and the next release.
+
+test("BET-978: resolveDeployRef pins to the release's own commit", () => {
+  const sha = "d3cb8aceb94540030ca65bb28cf7ea732bd17e73";
+  const got = resolveDeployRef(JSON.stringify({ version: "0.0.30", git_sha: sha }));
+  assert.equal(got.sha, sha);
+  assert.equal(got.source, "release");
+});
+
+test("BET-978: resolveDeployRef falls back when the release carries no usable stamp", () => {
+  // A tarball packed outside a git checkout, or one older than the stamp.
+  for (const text of [
+    "",
+    "not json",
+    JSON.stringify({ version: "0.0.29" }),
+    JSON.stringify({ version: "0.0.29", git_sha: null }),
+    JSON.stringify({ version: "0.0.29", git_sha: "" }),
+    JSON.stringify({ version: "0.0.29", git_sha: "d3cb8ac" }), // short — never written by the packer
+    JSON.stringify({ version: "0.0.29", git_sha: "Z".repeat(40) }),
+  ]) {
+    const got = resolveDeployRef(text);
+    assert.equal(got.sha, null, `must not trust ${JSON.stringify(text)}`);
+    assert.equal(got.source, "fallback");
+  }
+  // …and a non-string input can't throw.
+  assert.equal(resolveDeployRef(undefined).sha, null);
+});
+
+test("BET-978: findMissingDependencies names the packages a release is short of", () => {
+  const pkg = JSON.stringify({
+    dependencies: { unified: "^11", "rehype-stringify": "^10", ws: "^8" },
+    devDependencies: { vitest: "^2" },
+  });
+  const present = new Set(["node_modules/unified/package.json", "node_modules/ws/package.json"]);
+  const missing = findMissingDependencies(pkg, { exists: (p) => present.has(p) });
+  assert.deepEqual(missing, ["rehype-stringify"], "only the absent runtime dependency");
+
+  // devDependencies are never checked — the tarball is built --omit=dev.
+  const allPresent = findMissingDependencies(pkg, {
+    exists: (p) => !p.includes("vitest"),
+  });
+  assert.deepEqual(allPresent, []);
+
+  // Nothing to say about an unreadable or dependency-less package.json.
+  assert.deepEqual(findMissingDependencies("not json", { exists: () => false }), []);
+  assert.deepEqual(findMissingDependencies("{}", { exists: () => false }), []);
+});
+
+// The behavioural half: run the REAL deploy_git_checkout() out of the REAL
+// install.sh against a throwaway git repo, so a regression in the shipped
+// script is what goes red — not a copy of its logic living in the test.
+//
+// Layout mirrors a freshly extracted tarball: $MANTA_HOME holds RELEASE.json
+// and no .git/. `origin` is a local repo with two commits — the "release" one
+// and a later "main" one carrying a file the release doesn't have (standing in
+// for a dependency-adding merge).
+function runDeployGitCheckout({ releaseJson, node = process.execPath }) {
+  const dir = mkdtempSync(join(tmpdir(), "manta-deploy-"));
+  const origin = join(dir, "origin");
+  const home = join(dir, "manta");
+  mkdirSync(origin, { recursive: true });
+  mkdirSync(home, { recursive: true });
+  const git = (args, cwd) =>
+    execSync(`git ${args}`, {
+      cwd,
+      encoding: "utf8",
+      env: {
+        ...process.env,
+        GIT_AUTHOR_NAME: "t", GIT_AUTHOR_EMAIL: "t@t",
+        GIT_COMMITTER_NAME: "t", GIT_COMMITTER_EMAIL: "t@t",
+      },
+    });
+  git("init -q -b main .", origin);
+  writeFileSync(join(origin, "marker.txt"), "release-source\n");
+  git("add -A", origin);
+  git('commit -qm "release commit"', origin);
+  const releaseSha = git("rev-parse HEAD", origin).trim();
+  writeFileSync(join(origin, "marker.txt"), "main-source\n");
+  git("add -A", origin);
+  git('commit -qm "later main commit"', origin);
+  const mainSha = git("rev-parse HEAD", origin).trim();
+
+  if (releaseJson !== null) {
+    writeFileSync(
+      join(home, "RELEASE.json"),
+      typeof releaseJson === "function" ? releaseJson(releaseSha) : releaseJson,
+    );
+  }
+
+  const script = join(dir, "test.sh");
+  writeFileSync(
+    script,
+    `#!/usr/bin/env bash
+set +e
+# warn()/die() write to stderr, and runAndCapture only keeps stderr on a
+# non-zero exit — merge so the fallback WARNING is assertable on success too.
+exec 2>&1
+export MANTA_INSTALL_TEST_MODE=1
+source '${INSTALL_SH}'
+deploy_git_checkout '${home}' '${origin}' '${node}' '${join(__dirname, "install-lib.mjs")}'
+echo "HEAD=$(git -C '${home}' rev-parse HEAD)"
+echo "MARKER=$(cat '${home}/marker.txt')"
+`,
+    { mode: 0o755 },
+  );
+  const out = runAndCapture(script);
+  try {
+    return { out, releaseSha, mainSha };
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("BET-978: a clean install checks out the RELEASE's commit, not main's", () => {
+  const { out, releaseSha, mainSha } = runDeployGitCheckout({
+    releaseJson: (sha) => JSON.stringify({ version: "0.0.30", git_sha: sha }),
+  });
+  assert.match(out, new RegExp(`HEAD=${releaseSha}`), `must land on the release commit:\n${out}`);
+  assert.match(out, /MARKER=release-source/, `working tree must be the release's source:\n${out}`);
+  assert.doesNotMatch(out, new RegExp(`HEAD=${mainSha}`), "must NOT land on main");
+});
+
+test("BET-978: a release with no commit stamp still falls back to main", () => {
+  // Pre-stamp tarballs, or one packed outside a git checkout — never worse
+  // than the old behaviour.
+  for (const releaseJson of [null, JSON.stringify({ version: "0.0.29" })]) {
+    const { out, mainSha } = runDeployGitCheckout({ releaseJson });
+    assert.match(out, new RegExp(`HEAD=${mainSha}`), `must fall back to main:\n${out}`);
+    assert.match(out, /MARKER=main-source/, `${out}`);
+  }
+});
+
+test("BET-978: an unfetchable release commit warns and falls back rather than dying", () => {
+  const { out, mainSha } = runDeployGitCheckout({
+    releaseJson: JSON.stringify({ version: "9.9.9", git_sha: "a".repeat(40) }),
+  });
+  assert.match(out, /is not fetchable — falling back to origin\/main/, `must say why:\n${out}`);
+  assert.match(out, new RegExp(`HEAD=${mainSha}`), `a checkout at main beats no checkout:\n${out}`);
+});
+
+// The dependency preflight, run for real out of the shipped script.
+function runCheckReleaseDependencies({ pkgJson, present = [] }) {
+  const dir = mkdtempSync(join(tmpdir(), "manta-deps-"));
+  const home = join(dir, "manta");
+  mkdirSync(join(home, "node_modules"), { recursive: true });
+  writeFileSync(join(home, "package.json"), pkgJson);
+  for (const name of present) {
+    mkdirSync(join(home, "node_modules", name), { recursive: true });
+    writeFileSync(join(home, "node_modules", name, "package.json"), "{}");
+  }
+  const script = join(dir, "test.sh");
+  writeFileSync(
+    script,
+    `#!/usr/bin/env bash
+set +e
+exec 2>&1
+export MANTA_INSTALL_TEST_MODE=1
+source '${INSTALL_SH}'
+check_release_dependencies '${home}' '${process.execPath}' '${join(__dirname, "install-lib.mjs")}'
+echo "EXIT=$?"
+`,
+    { mode: 0o755 },
+  );
+  const out = runAndCapture(script);
+  try {
+    return out;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("BET-978: the installer names the missing packages instead of timing out on health", () => {
+  const out = runCheckReleaseDependencies({
+    pkgJson: JSON.stringify({
+      dependencies: { ws: "^8", "rehype-stringify": "^10", "highlight.js": "^11" },
+    }),
+    present: ["ws"],
+  });
+  assert.match(out, /this release is inconsistent/, `must state the real cause:\n${out}`);
+  assert.match(out, /rehype-stringify/, "must name the missing package");
+  assert.match(out, /highlight\.js/, "must name every missing package");
+  assert.doesNotMatch(out, /EXIT=0/, "must abort the install, not continue to a doomed start");
+});
+
+test("BET-978: the preflight is silent when the release is consistent", () => {
+  const out = runCheckReleaseDependencies({
+    pkgJson: JSON.stringify({ dependencies: { ws: "^8" }, devDependencies: { vitest: "^2" } }),
+    present: ["ws"],
+  });
+  assert.match(out, /EXIT=0/, `a consistent release must pass:\n${out}`);
+  assert.doesNotMatch(out, /inconsistent/, `${out}`);
 });

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -49,6 +49,10 @@ const __dirname = dirname(fileURLToPath(import.meta.url));
 // duplication gate over its token threshold.
 const scriptFile = (...parts) => readFileSync(join(__dirname, ...parts), "utf-8");
 const INSTALL_SH = join(__dirname, "install.sh");
+const LIB_MJS = join(__dirname, "install-lib.mjs");
+// warn()/die() write to stderr, and runAndCapture only keeps stderr on a
+// non-zero exit — merge so a WARNING is assertable on the success path too.
+const STDERR_TO_STDOUT = "exec 2>&1";
 
 // A canonical 32-lowercase-hex token — mirrors the test constants in
 // src/main/auth.test.ts and src/shared/transport.test.ts so the install
@@ -1407,6 +1411,21 @@ test("install.sh is bash-syntax-clean (bash -n)", () => {
   }
 });
 
+// Scan install.sh's non-comment lines for a forbidden pattern, returning
+// "line N: <text>" for each offender. Three static guards below share this:
+// they differ only in the regex and the failure message, and inlining the
+// scan in each is what tipped the duplication gate over its token threshold.
+function scanInstallSh(pattern) {
+  const lines = readFileSync(INSTALL_SH, "utf-8").split("\n");
+  const offenders = [];
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^\s*#/.test(line)) continue; // skip comment lines
+    if (pattern.test(line)) offenders.push(`line ${i + 1}: ${line.trim()}`);
+  }
+  return offenders;
+}
+
 test("install.sh guards every MANTA_CLAUDE_AUTH_PLUGIN use against set -u (BET-319 regression)", () => {
   // install.sh runs under `set -euo pipefail`. The first BET-319 iteration
   // referenced $MANTA_CLAUDE_AUTH_PLUGIN directly inside `[ -n "$VAR" ]`,
@@ -1417,18 +1436,10 @@ test("install.sh guards every MANTA_CLAUDE_AUTH_PLUGIN use against set -u (BET-3
   // static guard pins the fix: every NON-COMMENT reference to the var must
   // use the `${VAR:-}` default-expansion form (or be inside a branch that is
   // only reached after a `:-` guard already proved it set).
-  const src = readFileSync(INSTALL_SH, "utf-8");
-  const lines = src.split("\n");
-  const offenders = [];
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (/^\s*#/.test(line)) continue; // skip comment lines
-    // A bare `$MANTA_CLAUDE_AUTH_PLUGIN` or `"$MANTA_CLAUDE_AUTH_PLUGIN"`
-    // (no `${...:-}` form) is the bug. The safe form is `${MANTA_CLAUDE_AUTH_PLUGIN:-}`.
-    // We detect a bare expansion as `$VAR` NOT immediately followed by `{`.
-    const bare = /\$MANTA_CLAUDE_AUTH_PLUGIN(?!\{)/.test(line);
-    if (bare) offenders.push(`line ${i + 1}: ${line.trim()}`);
-  }
+  // A bare `$MANTA_CLAUDE_AUTH_PLUGIN` or `"$MANTA_CLAUDE_AUTH_PLUGIN"` (no
+  // `${...:-}` form) is the bug. The safe form is `${MANTA_CLAUDE_AUTH_PLUGIN:-}`.
+  // A bare expansion is `$VAR` NOT immediately followed by `{`.
+  const offenders = scanInstallSh(/\$MANTA_CLAUDE_AUTH_PLUGIN(?!\{)/);
   assert.deepEqual(
     offenders,
     [],
@@ -1446,15 +1457,7 @@ test("install.sh guards every OPENCODE_CLAUDE_AUTH_PLUGIN use against set -u (BE
   // unset var is a hard abort mid-install — the same class of failure
   // BET-319 fixed for the override. This static guard pins the fix: every
   // non-comment reference must use the `${VAR:-}` default-expansion form.
-  const src = readFileSync(INSTALL_SH, "utf-8");
-  const lines = src.split("\n");
-  const offenders = [];
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (/^\s*#/.test(line)) continue; // skip comment lines
-    const bare = /\$OPENCODE_CLAUDE_AUTH_PLUGIN(?!\{)/.test(line);
-    if (bare) offenders.push(`line ${i + 1}: ${line.trim()}`);
-  }
+  const offenders = scanInstallSh(/\$OPENCODE_CLAUDE_AUTH_PLUGIN(?!\{)/);
   assert.deepEqual(
     offenders,
     [],
@@ -1474,18 +1477,10 @@ test("install.sh brace-delimits every $VAR adjacent to the … ellipsis (BET-319
   // We flag any non-comment line where `$IDENT` (not `${IDENT}`) is
   // immediately followed by `…` — i.e. a bare expansion abutting the
   // ellipsis with no brace or other delimiter between them.
-  const src = readFileSync(INSTALL_SH, "utf-8");
-  const lines = src.split("\n");
-  const offenders = [];
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (/^\s*#/.test(line)) continue; // skip comment lines
-    // Match `$IDENT…` where IDENT is a bash identifier (letters, digits,
-    // underscore) and the `$` is NOT immediately followed by `{`. The `…`
-    // must directly follow the identifier with no intervening delimiter.
-    const bare = /\$([A-Za-z_][A-Za-z0-9_]*)…/.test(line);
-    if (bare) offenders.push(`line ${i + 1}: ${line.trim()}`);
-  }
+  // Match `$IDENT…` where IDENT is a bash identifier (letters, digits,
+  // underscore) and the `$` is NOT immediately followed by `{`. The `…` must
+  // directly follow the identifier with no intervening delimiter.
+  const offenders = scanInstallSh(/\$([A-Za-z_][A-Za-z0-9_]*)…/);
   assert.deepEqual(
     offenders,
     [],
@@ -5649,25 +5644,13 @@ function runDeployGitCheckout({ releaseJson, deployRef = "", node = process.exec
     );
   }
 
-  const script = join(dir, "test.sh");
-  writeFileSync(
-    script,
-    `#!/usr/bin/env bash
-set +e
-# warn()/die() write to stderr, and runAndCapture only keeps stderr on a
-# non-zero exit — merge so the fallback WARNING is assertable on success too.
-exec 2>&1
-export MANTA_INSTALL_TEST_MODE=1
-${deployRef ? `export MANTA_DEPLOY_REF='${deployRef}'` : ""}
-source '${INSTALL_SH}'
-deploy_git_checkout '${home}' '${origin}' '${node}' '${join(__dirname, "install-lib.mjs")}'
-echo "HEAD=$(git -C '${home}' rev-parse HEAD)"
-echo "MARKER=$(cat '${home}/marker.txt')"
-`,
-    { mode: 0o755 },
-  );
-  const out = runAndCapture(script);
   try {
+    const out = runBootstrap({
+      preBody: `${STDERR_TO_STDOUT}\n${deployRef ? `export MANTA_DEPLOY_REF='${deployRef}'` : ""}`,
+      func: `deploy_git_checkout '${home}' '${origin}' '${node}' '${LIB_MJS}'
+echo "HEAD=$(git -C '${home}' rev-parse HEAD)"
+echo "MARKER=$(cat '${home}/marker.txt')"`,
+    });
     return { out, releaseSha, mainSha };
   } finally {
     rmSync(dir, { recursive: true, force: true });
@@ -5719,22 +5702,11 @@ function runCheckReleaseDependencies({ pkgJson, present = [] }) {
     mkdirSync(join(home, "node_modules", name), { recursive: true });
     writeFileSync(join(home, "node_modules", name, "package.json"), "{}");
   }
-  const script = join(dir, "test.sh");
-  writeFileSync(
-    script,
-    `#!/usr/bin/env bash
-set +e
-exec 2>&1
-export MANTA_INSTALL_TEST_MODE=1
-source '${INSTALL_SH}'
-check_release_dependencies '${home}' '${process.execPath}' '${join(__dirname, "install-lib.mjs")}'
-echo "EXIT=$?"
-`,
-    { mode: 0o755 },
-  );
-  const out = runAndCapture(script);
   try {
-    return out;
+    return runBootstrap({
+      preBody: STDERR_TO_STDOUT,
+      func: `check_release_dependencies '${home}' '${process.execPath}' '${LIB_MJS}'`,
+    });
   } finally {
     rmSync(dir, { recursive: true, force: true });
   }
@@ -5750,7 +5722,7 @@ test("BET-978: the installer names the missing packages instead of timing out on
   assert.match(out, /this release is inconsistent/, `must state the real cause:\n${out}`);
   assert.match(out, /rehype-stringify/, "must name the missing package");
   assert.match(out, /highlight\.js/, "must name every missing package");
-  assert.doesNotMatch(out, /EXIT=0/, "must abort the install, not continue to a doomed start");
+  assert.doesNotMatch(out, /BOOTSTRAP_EXIT=0/, "must abort the install, not continue to a doomed start");
 });
 
 test("BET-978: the preflight is silent when the release is consistent", () => {
@@ -5758,7 +5730,7 @@ test("BET-978: the preflight is silent when the release is consistent", () => {
     pkgJson: JSON.stringify({ dependencies: { ws: "^8" }, devDependencies: { vitest: "^2" } }),
     present: ["ws"],
   });
-  assert.match(out, /EXIT=0/, `a consistent release must pass:\n${out}`);
+  assert.match(out, /BOOTSTRAP_EXIT=0/, `a consistent release must pass:\n${out}`);
   assert.doesNotMatch(out, /inconsistent/, `${out}`);
 });
 

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -10,7 +10,6 @@ import {
   resolveConfig,
   parsePort,
   checkIdentity,
-  resolveDeployRef,
   findMissingDependencies,
   waitForHealth,
   readBoxIdentity,
@@ -5589,32 +5588,6 @@ test("BET-446: seeding still merges the plugin when OPENCODE_CLAUDE_AUTH_PLUGIN 
 // "server did not become healthy". It broke EVERY clean install on prod and
 // staging between a dependency-adding merge and the next release.
 
-test("BET-978: resolveDeployRef pins to the release's own commit", () => {
-  const sha = "d3cb8aceb94540030ca65bb28cf7ea732bd17e73";
-  const got = resolveDeployRef(JSON.stringify({ version: "0.0.30", git_sha: sha }));
-  assert.equal(got.sha, sha);
-  assert.equal(got.source, "release");
-});
-
-test("BET-978: resolveDeployRef falls back when the release carries no usable stamp", () => {
-  // A tarball packed outside a git checkout, or one older than the stamp.
-  for (const text of [
-    "",
-    "not json",
-    JSON.stringify({ version: "0.0.29" }),
-    JSON.stringify({ version: "0.0.29", git_sha: null }),
-    JSON.stringify({ version: "0.0.29", git_sha: "" }),
-    JSON.stringify({ version: "0.0.29", git_sha: "d3cb8ac" }), // short — never written by the packer
-    JSON.stringify({ version: "0.0.29", git_sha: "Z".repeat(40) }),
-  ]) {
-    const got = resolveDeployRef(text);
-    assert.equal(got.sha, null, `must not trust ${JSON.stringify(text)}`);
-    assert.equal(got.source, "fallback");
-  }
-  // …and a non-string input can't throw.
-  assert.equal(resolveDeployRef(undefined).sha, null);
-});
-
 test("BET-978: findMissingDependencies names the packages a release is short of", () => {
   const pkg = JSON.stringify({
     dependencies: { unified: "^11", "rehype-stringify": "^10", ws: "^8" },
@@ -5643,7 +5616,7 @@ test("BET-978: findMissingDependencies names the packages a release is short of"
 // and no .git/. `origin` is a local repo with two commits — the "release" one
 // and a later "main" one carrying a file the release doesn't have (standing in
 // for a dependency-adding merge).
-function runDeployGitCheckout({ releaseJson, node = process.execPath }) {
+function runDeployGitCheckout({ releaseJson, deployRef = "", node = process.execPath }) {
   const dir = mkdtempSync(join(tmpdir(), "manta-deploy-"));
   const origin = join(dir, "origin");
   const home = join(dir, "manta");
@@ -5685,6 +5658,7 @@ set +e
 # non-zero exit — merge so the fallback WARNING is assertable on success too.
 exec 2>&1
 export MANTA_INSTALL_TEST_MODE=1
+${deployRef ? `export MANTA_DEPLOY_REF='${deployRef}'` : ""}
 source '${INSTALL_SH}'
 deploy_git_checkout '${home}' '${origin}' '${node}' '${join(__dirname, "install-lib.mjs")}'
 echo "HEAD=$(git -C '${home}' rev-parse HEAD)"
@@ -5712,7 +5686,15 @@ test("BET-978: a clean install checks out the RELEASE's commit, not main's", () 
 test("BET-978: a release with no commit stamp still falls back to main", () => {
   // Pre-stamp tarballs, or one packed outside a git checkout — never worse
   // than the old behaviour.
-  for (const releaseJson of [null, JSON.stringify({ version: "0.0.29" })]) {
+  for (const releaseJson of [
+    null,                                                     // no RELEASE.json at all
+    "not json",                                               // unparseable
+    JSON.stringify({ version: "0.0.29" }),                    // packed before the stamp
+    JSON.stringify({ version: "0.0.29", git_sha: null }),
+    JSON.stringify({ version: "0.0.29", git_sha: "" }),
+    JSON.stringify({ version: "0.0.29", git_sha: "d3cb8ac" }), // short — never written by the packer
+    JSON.stringify({ version: "0.0.29", git_sha: "Z".repeat(40) }), // not hex
+  ]) {
     const { out, mainSha } = runDeployGitCheckout({ releaseJson });
     assert.match(out, new RegExp(`HEAD=${mainSha}`), `must fall back to main:\n${out}`);
     assert.match(out, /MARKER=main-source/, `${out}`);
@@ -5778,4 +5760,32 @@ test("BET-978: the preflight is silent when the release is consistent", () => {
   });
   assert.match(out, /EXIT=0/, `a consistent release must pass:\n${out}`);
   assert.doesNotMatch(out, /inconsistent/, `${out}`);
+});
+
+test("BET-978: MANTA_DEPLOY_REF overrides the pin, so a branch can be deployed on purpose", () => {
+  // The escape hatch the macOS install smoke uses: install the last published
+  // tarball but deploy THIS branch's source, so a PR's server/plist changes
+  // are what gets exercised. Without it, pinning would silently make that
+  // workflow test main instead of the PR.
+  const { out, releaseSha, mainSha } = runDeployGitCheckout({
+    releaseJson: (sha) => JSON.stringify({ version: "0.0.30", git_sha: sha }),
+    deployRef: "origin/main",
+  });
+  assert.match(out, /pinned by MANTA_DEPLOY_REF/, `must say the override won:\n${out}`);
+  assert.match(out, new RegExp(`HEAD=${mainSha}`), `override beats the release stamp:\n${out}`);
+  assert.doesNotMatch(out, new RegExp(`HEAD=${releaseSha}`), "must not use the release commit");
+});
+
+test("BET-978: the release stamp is read without install-lib, which ships in the OLDER tarball", () => {
+  // install.sh is served fresh from the website; install-lib.mjs comes from the
+  // extracted tarball and cannot know a subcommand added after it was packed.
+  // Reading the stamp through the lib made the pin silently unavailable on
+  // exactly the installs that need it (the macOS smoke fell back to
+  // origin/main against the 0.0.30 lib). Passing a node binary that fails on
+  // sight proves the decision no longer depends on it.
+  const { out, releaseSha } = runDeployGitCheckout({
+    releaseJson: (sha) => JSON.stringify({ version: "0.0.30", git_sha: sha }),
+    node: "/nonexistent/node",
+  });
+  assert.match(out, new RegExp(`HEAD=${releaseSha}`), `must still pin without a working lib:\n${out}`);
 });


### PR DESCRIPTION
## The bug

Every clean install was failing — on **prod as well as staging** — with:

```
▸ Waiting for the server to become healthy at http://127.0.0.1:8787/auth/status…
✗ server did not become healthy — check logs
```

The real error was only visible in the service journal:

```
Cannot find package 'rehype-stringify' imported from ~/manta/src/server/planPage.mjs
```

## Root cause

`install.sh` does two things that contradict each other:

1. extracts a **pinned release tarball** — the only source of `node_modules`, because the box deliberately never builds dependencies itself;
2. then force-resets the source tree to **`origin/main`**.

So a fresh box runs today's source against the dependency set frozen at the last published release. Every package added since that release is missing, the server dies on an unresolved import before it can bind, and the installer can only report a health-check timeout.

The plan-page work added four packages (`rehype-stringify`, `rehype-slug`, `rehype-highlight`, `rehype-autolink-headings`, plus `highlight.js`); the newest prod tarball (0.0.30, `d3cb8ac`) predates them.

**Already-installed boxes were fine** — their update path replaces source *and* dependencies together from one tarball — which is why this went unnoticed. Only first installs get the mismatch, and they get it for the whole window between a dependency-adding merge and the next release.

## The fix

Reset to the **release's own commit** (`git_sha`, already stamped into `RELEASE.json` and the manifest) instead of `origin/main`. Source and dependencies then come from the same build by construction, and adding a dependency can never break a clean install again. New code still reaches boxes the normal way: publish a release, self-update applies it wholesale.

A tarball with no stamp (packed outside a git checkout, or older than the stamp) still falls back to `origin/main`, so behaviour is never worse than before. An unfetchable commit warns and falls back rather than dying — a checkout at main beats no checkout.

**Backstop:** a dependency preflight for the rest of the class (a fork via `MANTA_REPO_URL`, a hand-run `git pull`, a half-extracted tarball). It names the missing packages at install time:

```
✗ this release is inconsistent — its source needs packages its node_modules does not have:
  - highlight.js
  - rehype-stringify
```

instead of leaving the operator to find them in service logs after 60 failed health attempts.

## Tests

The git block and the preflight moved into named functions (`deploy_git_checkout`, `check_release_dependencies`) so the tests run the **real shipped code** against a throwaway git repo, rather than asserting on the script's text:

- lands on the release commit, not main (working tree content asserted, not just the sha)
- no stamp → falls back to main
- unstamped/unfetchable commit → warns, falls back, does not die
- preflight names every missing package and aborts; silent when consistent
- `resolveDeployRef` / `findMissingDependencies` unit tests (short sha, non-hex, bad JSON, devDependencies excluded)

`npm run typecheck` clean, full suite green (2130 passing).

## Follow-up (not in this PR)

A fresh server release still has to be published for prod and staging to unblock today's installs — this PR only stops it recurring.