### PR TITLE
chore: release 0.0.31 (server)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.30",
+      "version": "0.0.31",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.30",
+  "version": "0.0.31",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.30",
+ "version": "0.0.31",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Version bump for the server release that unblocks clean installs.

Ships:
- #977 — clean installs check out the release's own commit, plus the missing-dependency preflight
- the first tarball to carry the plan-page render dependencies (`remark`/`rehype`, `highlight.js`) — what every clean install on prod and staging has been failing on

Tagging `server-v28` and `web-v31` once this is in.