### PR TITLE
feat: unify timer format to compact 2h57m / 57m / 2h / 45s

### DIFF
--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -200,17 +200,28 @@ enum SessionTimerFormat {
         return "\(m) minute" + (m == 1 ? "" : "s")
     }
 
-    /// Live elapsed for the running row ("12s" / "1m 12s" / "1h 5m"). Unlike the
-    /// compact `elapsed` (the header slot), this keeps the seconds so a running
-    /// turn's elapsed visibly ticks even before the first minute (BET-630, D1).
-    static func liveElapsed(_ interval: TimeInterval) -> String {
+    /// Canonical compact timer format, mirrored 1:1 with the desktop
+    /// `formatTimerDuration` (src/renderer/chatUtils.ts): "2h57m" / "57m" /
+    /// "2h" / "45s". No spaces; seconds only under a minute; hours drop the
+    /// minutes when they are zero. Use THIS for any elapsed/distance timer
+    /// (running row, session list, usage idle text) — the single source of
+    /// truth for the timer shape on iOS.
+    static func compact(_ interval: TimeInterval) -> String {
         let t = Int(interval)
+        guard t > 0 else { return "0s" }
         let s = t % 60
         let m = (t / 60) % 60
         let h = t / 3600
-        if h > 0 { return "\(h)h \(m)m" }
-        if m > 0 { return "\(m)m \(s)s" }
+        if h > 0 { return m > 0 ? "\(h)h\(m)m" : "\(h)h" }
+        if m > 0 { return "\(m)m" }
         return "\(s)s"
+    }
+
+    /// Live elapsed for the running row ("12s" / "1m" / "1h5m"). Ticks
+    /// per-second under a minute (BET-630, D1) then per-minute; reuses the
+    /// canonical `compact` form so every timer reads identically.
+    static func liveElapsed(_ interval: TimeInterval) -> String {
+        compact(interval)
     }
 
     /// Coarse recency for an idle row (BET-897). Interval-based on purpose — no

--- a/mobile/native/MantaUI/UsageMeters.swift
+++ b/mobile/native/MantaUI/UsageMeters.swift
@@ -70,7 +70,7 @@ enum UsageMeters {
     }
 
     /// The relative "how far away" reset distance, floored to at most two
-    /// units — "45m" / "2h 10m" / "2d 4h". Mirrors the desktop
+    /// units — "45m" / "2h10m" / "2d4h". Mirrors the desktop
     /// `formatResetDistance` one-to-one so both clients print the same string
     /// for the same input. Pure arithmetic — no locale involvement.
     static func resetDistance(_ seconds: Int) -> String {
@@ -81,11 +81,11 @@ enum UsageMeters {
         let h = m / 60
         let mm = m % 60
         if seconds < 86400 {
-            return mm == 0 ? "\(h)h" : "\(h)h \(mm)m"
+            return mm == 0 ? "\(h)h" : "\(h)h\(mm)m"
         }
         let d = seconds / 86400
         let hh = (seconds % 86400) / 3600
-        return hh == 0 ? "\(d)d" : "\(d)d \(hh)h"
+        return hh == 0 ? "\(d)d" : "\(d)d\(hh)h"
     }
 
     /// The absolute anchor: "09:00" (same local calendar day), "Thu 09:00"
@@ -103,7 +103,7 @@ enum UsageMeters {
     }
 
     /// The sheet/banner reset line (the caller already supplies the "resets "
-    /// prefix): "in 2h 10m", with an absolute anchor appended only when the
+    /// prefix): "in 2h10m", with an absolute anchor appended only when the
     /// reset is NOT on the same local calendar day. A reset instant that has
     /// already passed reads "resetting…" — the dot carries the old number
     /// forward while the provider catches up (BET-965/967). Mirrors the

--- a/mobile/native/MantaUI/UsageSheets.swift
+++ b/mobile/native/MantaUI/UsageSheets.swift
@@ -186,7 +186,7 @@ struct ContextSheet: View {
         context.segments.first { $0.kind == kind }?.pct ?? 0
     }
 
-    /// "Idle 1h 12m — the cache has gone cold. Clearing now saves re-billing
+    /// "Idle 1h12m — the cache has gone cold. Clearing now saves re-billing
     /// 584k tokens." — driven by idleMs + staleTokens. The warn colour IS the
     /// warning, so it is kept; the font is the platform's footnote.
     @ViewBuilder
@@ -209,11 +209,9 @@ struct ContextSheet: View {
     }
 
     private func idleText(_ ms: Double) -> String {
-        let total = Int(ms / 1000)
-        let hours = total / 3600
-        let minutes = (total % 3600) / 60
-        if hours >= 1 { return minutes > 0 ? "\(hours)h \(minutes)m" : "\(hours)h" }
-        return "\(max(1, minutes))m"
+        // Canonical compact timer form ("2h57m"/"57m"/"45s"), shared with the
+        // running row and the desktop — pass ms/1000 since `compact` takes seconds.
+        SessionTimerFormat.compact(ms / 1000)
     }
 }
 

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -79,11 +79,22 @@ final class SessionModelsTests: XCTestCase {
         XCTAssertEqual(SessionTimerFormat.runningDuration(1), "1 second")
     }
 
-    func testLiveElapsedKeepsSeconds() {
+    func testLiveElapsedCompactNoSpaces() {
         XCTAssertEqual(SessionTimerFormat.liveElapsed(5), "5s")
-        XCTAssertEqual(SessionTimerFormat.liveElapsed(72), "1m 12s")
-        XCTAssertEqual(SessionTimerFormat.liveElapsed(60), "1m 0s")
-        XCTAssertEqual(SessionTimerFormat.liveElapsed(3725), "1h 2m")
+        XCTAssertEqual(SessionTimerFormat.liveElapsed(72), "1m")
+        XCTAssertEqual(SessionTimerFormat.liveElapsed(60), "1m")
+        XCTAssertEqual(SessionTimerFormat.liveElapsed(3725), "1h2m")
+    }
+
+    func testCompactCanonicalLadder() {
+        XCTAssertEqual(SessionTimerFormat.compact(0), "0s")
+        XCTAssertEqual(SessionTimerFormat.compact(45), "45s")
+        XCTAssertEqual(SessionTimerFormat.compact(59), "59s")
+        XCTAssertEqual(SessionTimerFormat.compact(60), "1m")
+        XCTAssertEqual(SessionTimerFormat.compact(3_420), "57m")
+        XCTAssertEqual(SessionTimerFormat.compact(7_800), "2h10m")
+        XCTAssertEqual(SessionTimerFormat.compact(10_620), "2h57m")
+        XCTAssertEqual(SessionTimerFormat.compact(10_800), "3h")
     }
 
     // MARK: - BET-897 idle recency

--- a/mobile/native/MantaUITests/UsageMetersTests.swift
+++ b/mobile/native/MantaUITests/UsageMetersTests.swift
@@ -111,11 +111,11 @@ final class UsageMetersTests: XCTestCase {
         XCTAssertEqual(UsageMeters.resetDistance(-5), "now")
         XCTAssertEqual(UsageMeters.resetDistance(30), "under a minute")
         XCTAssertEqual(UsageMeters.resetDistance(45 * 60), "45m")
-        XCTAssertEqual(UsageMeters.resetDistance(2 * 3600 + 10 * 60), "2h 10m")
+        XCTAssertEqual(UsageMeters.resetDistance(2 * 3600 + 10 * 60), "2h10m")
         XCTAssertEqual(UsageMeters.resetDistance(3 * 3600), "3h")
-        XCTAssertEqual(UsageMeters.resetDistance(26 * 3600), "1d 2h")
+        XCTAssertEqual(UsageMeters.resetDistance(26 * 3600), "1d2h")
         XCTAssertEqual(UsageMeters.resetDistance(48 * 3600), "2d")
-        XCTAssertEqual(UsageMeters.resetDistance(140 * 3600 + 12 * 60), "5d 20h")
+        XCTAssertEqual(UsageMeters.resetDistance(140 * 3600 + 12 * 60), "5d20h")
     }
 
     // MARK: - resetAt / formatReset (shape only — locale-fixed, BET-967)

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -95,6 +95,7 @@ import {
   formatWindowReset,
   formatResetAt,
   formatResetDistance,
+  formatTimerDuration,
   formatUpdatedAgo,
   usageStale,
   pruneVisitedSessions,
@@ -3525,15 +3526,35 @@ describe("usageDialState", () => {
   });
 });
 
+describe("formatTimerDuration", () => {
+  it("renders the canonical compact ladder with no spaces", () => {
+    expect(formatTimerDuration(45_000)).toBe("45s");
+    expect(formatTimerDuration(59_000)).toBe("59s");
+    expect(formatTimerDuration(60_000)).toBe("1m");
+    expect(formatTimerDuration(57 * 60_000)).toBe("57m");
+    expect(formatTimerDuration(2 * 3_600_000 + 10 * 60_000)).toBe("2h10m");
+    expect(formatTimerDuration(2 * 3_600_000 + 57 * 60_000)).toBe("2h57m");
+    expect(formatTimerDuration(3 * 3_600_000)).toBe("3h");
+  });
+
+  it("drops minutes when zero and handles sub-second and non-finite", () => {
+    expect(formatTimerDuration(3 * 3_600_000)).toBe("3h");
+    expect(formatTimerDuration(0)).toBe("0s");
+    expect(formatTimerDuration(-5)).toBe("0s");
+    expect(formatTimerDuration(NaN)).toBe("0s");
+    expect(formatTimerDuration(999)).toBe("1s");
+  });
+});
+
 describe("formatResetDistance", () => {
   it("covers the whole ladder with exact strings", () => {
     expect(formatResetDistance(30_000)).toBe("under a minute");
     expect(formatResetDistance(45 * 60_000)).toBe("45m");
-    expect(formatResetDistance(2 * 3_600_000 + 10 * 60_000)).toBe("2h 10m");
+    expect(formatResetDistance(2 * 3_600_000 + 10 * 60_000)).toBe("2h10m");
     expect(formatResetDistance(3 * 3_600_000)).toBe("3h"); // drop the zero minutes
-    expect(formatResetDistance(26 * 3_600_000)).toBe("1d 2h");
+    expect(formatResetDistance(26 * 3_600_000)).toBe("1d2h");
     expect(formatResetDistance(48 * 3_600_000)).toBe("2d"); // drop the zero hours
-    expect(formatResetDistance(140 * 3_600_000 + 12 * 60_000)).toBe("5d 20h");
+    expect(formatResetDistance(140 * 3_600_000 + 12 * 60_000)).toBe("5d20h");
   });
 
   it("returns 'now' for a missing, non-finite, or past distance", () => {

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -254,6 +254,24 @@ export function formatDuration(ms: number): string {
   return `${s}s`;
 }
 
+// Canonical compact timer format shared across the app (and mirrored 1:1 by the
+// iOS `SessionTimerFormat.compact`): "2h57m" / "57m" / "2h" / "45s". No spaces,
+// h/m/s abbreviations; seconds shown only under a minute; hours drop the
+// minutes when they're zero. Use THIS for any elapsed/distance timer (reset
+// distances, idle text, running rows) instead of hand-rolling another shape.
+// This is the compact *timer* ladder — see `formatDuration` above for the
+// seconds-precise task/turn form ("1m44s", "2h3m4s"), which is a distinct thing.
+export function formatTimerDuration(ms: number): string {
+  if (!Number.isFinite(ms) || ms <= 0) return "0s";
+  const totalSec = Math.round(ms / 1000);
+  const h = Math.floor(totalSec / 3600);
+  const m = Math.floor((totalSec % 3600) / 60);
+  const s = totalSec % 60;
+  if (h > 0) return m > 0 ? `${h}h${m}m` : `${h}h`;
+  if (m > 0) return `${m}m`;
+  return `${s}s`;
+}
+
 // Wall-clock time for the subtle per-message timestamp gutter. Renders a
 // 24-hour "HH:MM" from an epoch-ms value. Returns "" for null/undefined or
 // non-finite input so the caller can render nothing without extra guards.
@@ -2929,21 +2947,16 @@ function isSameLocalDay(a: number, b: number): boolean {
 }
 
 /** The relative "how far away" distance, floored to at most two units:
- *  "45m" / "2h 10m" / "2d 4h". Covers the whole ladder. Pure arithmetic —
- *  no locale involvement. */
+ *  "45m" / "2h10m" / "2d4h". Reuses `formatTimerDuration` for the sub-day
+ *  ladder so h/m timers read identically everywhere. Pure arithmetic — no
+ *  locale involvement. */
 export function formatResetDistance(deltaMs: number): string {
   if (!Number.isFinite(deltaMs) || deltaMs <= 0) return "now";
   if (deltaMs < 60_000) return "under a minute";
-  const m = Math.floor(deltaMs / 60_000);
-  if (deltaMs < 3_600_000) return `${m}m`;
-  const h = Math.floor(m / 60);
-  const mm = m % 60;
-  if (deltaMs < 86_400_000) {
-    return mm === 0 ? `${h}h` : `${h}h ${mm}m`;
-  }
+  if (deltaMs < 86_400_000) return formatTimerDuration(deltaMs);
   const d = Math.floor(deltaMs / 86_400_000);
   const hh = Math.floor((deltaMs % 86_400_000) / 3_600_000);
-  return hh === 0 ? `${d}d` : `${d}d ${hh}h`;
+  return hh === 0 ? `${d}d` : `${d}d${hh}h`;
 }
 
 /** The absolute anchor: "09:00" (same local day), "Thu 09:00" (<7 days), or
@@ -2960,7 +2973,7 @@ export function formatResetAt(
   return RESET_DATE_TIME_FMT.format(resetsAt);
 }
 
-// "resets in 2h 10m" / "resets in 45m" / "resets in 5d 20h (Thu, 21 Aug, 09:00)"
+// "resets in 2h10m" / "resets in 45m" / "resets in 5d20h (Thu, 21 Aug, 09:00)"
 // — the popover's per-window reset line. The absolute anchor is appended only
 // when the reset is NOT on the same local calendar day as `now` (a same-day
 // reset is unambiguous from the relative time alone). Returns null only for a

--- a/src/renderer/usageEscalation.ts
+++ b/src/renderer/usageEscalation.ts
@@ -106,7 +106,7 @@ export function shouldWarnStaleCache(
 
 /**
  * The warn (>=90%) toast body — plain, no actions, takes the default 6s TTL.
- * "Claude Session (5h) 93% used — resets in 2h 10m."
+ * "Claude Session (5h) 93% used — resets in 2h10m."
  */
 export function buildWarnMessage(
   providerLabel: string,


### PR DESCRIPTION
## Summary
Timers across the app (desktop Electron renderer **and** native iOS client) rendered hour/minute durations with **spaces** and inconsistent shapes — e.g. `2h 10m`, `1h 5m`, `5d 20h`. This unifies every elapsed/distance timer onto one compact, no-space format: **`2h57m` / `57m` / `2h` / `45s`**, extracted as a single reusable formatter so future timer code calls one function instead of hand-rolling another shape.

## Changes
**Desktop (`src/renderer/chatUtils.ts`)**
- Added canonical `formatTimerDuration(ms)` → `2h57m` / `57m` / `2h` / `45s` (no spaces; seconds only under a minute; hours drop minutes when zero). Documented as the single source of truth for the timer shape.
- Refactored `formatResetDistance` (`2h 10m` → `2h10m`, `1d 2h` → `1d2h`, `5d 20h` → `5d20h`) to reuse it for the sub-day ladder.
- Updated `formatResetDistance` + new `formatTimerDuration` tests.

**iOS (`mobile/native`)**
- `SessionTimerFormat.compact(_:)` mirrors `formatTimerDuration` 1:1 (keeps the two clients byte-identical for the same input, matching the existing reset-distance mirror contract).
- `liveElapsed` (running row / session-list timer) and `UsageSheets.idleText` now route through it (`1h 5m` → `1h5m`, `1m 12s` → `1m`, `2h 57m` → `2h57m`).
- `UsageMeters.resetDistance` updated to stay mirror-locked with the desktop (`2h10m`, `1d2h`).
- Updated `SessionModelsTests` + `UsageMetersTests`.

## Verification
- `npm run typecheck` ✅
- Renderer vitest: chatUtils suite 576/576 ✅ (full renderer suite green except a pre-existing, environment-dependent `capExecutor` PATH test unrelated to this diff)
- iOS unit tests on simulator: `SessionModelsTests` + `UsageMetersTests` 72/72 ✅

## Notes
- The running-indicator timer now ticks per-second under a minute, then per-minute (was per-second throughout) — a deliberate consequence of the unified ladder; the header/subtitle and turn-footer `formatDuration` (`1m44s`, `2h3m4s`) are left untouched as they're the distinct seconds-precise form.