### PR TITLE
fix(install): make the public ingress path all-or-nothing (BET-980)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2750,6 +2750,21 @@ in install-lib.mjs) backstops the rest of the class — a fork via
 `MANTA_REPO_URL`, a hand-run `git pull`, a half-extracted tarball — by naming
 the missing packages at install time instead of leaving a health timeout.
 
+### The public install path is all-or-nothing (BET-980)
+
+**An install either completes its chosen ingress path fully, or it fails —
+there is no degraded success.** A public-path box needs a Debian/Ubuntu-family
+distro AND the ability to run commands as root (real root or `sudo -n true`).
+Those two capability checks run in a **preflight (scripts/install.sh step 3.5)
+BEFORE the first mutation**, so a box that would finish unreachable instead
+refuses to start with nothing written and nothing to roll back. The tailscale
+and macOS paths never need root or a specific distro and are unaffected. Mid-
+path public failures (gateway registration, the DNS poll, the Caddy vhost
+write/reload) are all fatal too — `die`, never warn-and-continue — so the
+"Installed." banner and pairing block are only reachable on a genuinely
+complete install. Do not reintroduce a degrade-and-continue flag (the old
+degraded-success handling was deleted with this rule).
+
 ### A release is identified by its COMMIT, not its version number
 
 **You do not need to bump `package.json` to ship a server release.** A box

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -53,16 +53,16 @@
 # "SUDO EXCEPTION (BET-205)" section in docs/launch-e2e.md for the
 # rationale (BET-198 changed requirements: direct-connection needs
 # public TLS, which is inherently a root concern; industry norm is sudo
-# + distro package manager for this step). The privileged section is
-# gated three ways so the install degrades cleanly without sudo:
-#   (a) Distro must be Debian/Ubuntu (v1 scope).
-#   (b) `sudo` must be installed.
-#   (c) `sudo -n true` must succeed (passwordless sudo).
-# If any of those fail we print the exact bring-your-own-proxy commands
-# and continue with the rest of the install — the loopback server +
-# pairing code are unaffected. Every privileged call uses `sudo -n`
-# (non-interactive) so it fails fast with a clear hint instead of
-# hanging on a password prompt.
+# + distro package manager for this step).
+#
+# ALL-OR-NOTHING (BET-980): the public path is gated up front (step 3.5)
+# on (a) a Debian/Ubuntu-family distro and (b) the ability to run commands
+# as root (real root or `sudo -n true`). If either is missing the installer
+# dies BEFORE the first mutation — nothing is written, nothing to roll back.
+# There is no degraded success: an install that would finish unreachable
+# refuses to start. Every privileged call uses `sudo -n` (non-interactive)
+# so it fails fast instead of hanging on a password prompt. The tailscale
+# and macOS paths never need root or a specific distro and are unaffected.
 #
 # Release resolution:
 #   1. Fetch `${MANTA_RELEASE_HOST:-https://mantaui.com}/releases/manta-${MANTA_VERSION:-latest}.txt`
@@ -457,6 +457,59 @@ wait_for_box_id() {
 }
 
 # ---------------------------------------------------------------------------
+# BET-980 capability preflight: the PUBLIC ingress path is all-or-nothing.
+#
+# An install either completes its chosen ingress path fully, or it fails —
+# there is NO degraded success. A box that prints "Installed." while being
+# unreachable is worse than an install that refused to start. The public
+# path needs (a) a Debian/Ubuntu-family distro and (b) the ability to run
+# commands as root (passwordless sudo, or an actual root shell); without
+# both we `die` BEFORE the first mutation, so nothing has been written and
+# there is nothing to roll back.
+#
+# The tailscale and macOS paths never need root or a specific distro, so
+# they are never gated here — pass their mode and this returns 0.
+#
+# Takes the resolved, side-effect-free inputs so the decision + message are
+# unit-testable in isolation (via runBootstrap in install.test.mjs):
+#   $1  ingress path mode: "public" | "tailscale" | "macos"
+#   $2  root usable: "1" (uid 0 or `sudo -n true` succeeds) | "0"
+#   $3  distro supported: "yes" | "no" | "unknown" | ""   (from detect-distro)
+#   $4  distro id (for the message; may be "")
+# Dies (exit 1) only when the mode is "public" and a capability is missing.
+# ---------------------------------------------------------------------------
+public_ingress_preflight() {
+  local mode="$1" root_usable="$2" distro_supported="$3" distro_id="$4"
+  [ "$mode" = "public" ] || return 0
+
+  if [ "$distro_supported" != "yes" ]; then
+    die "Cannot complete the install: distro ${distro_id:-unknown} is not in the v1 supported list (debian / ubuntu / ID_LIKE=debian).
+      This installer only manages Caddy + the gateway registration on Debian/Ubuntu.
+      bring your own proxy: point any reverse proxy at 127.0.0.1:8787 and serve your own TLS.
+
+      Nothing has been installed."
+  fi
+
+  if [ "$root_usable" != "1" ]; then
+    die "Cannot complete the install: giving this box a public HTTPS address needs to run
+      three commands as root (install Caddy, write its site config, reload it), and
+      this user cannot run commands as root without a password.
+
+      Nothing has been installed. Choose one of these and run the installer again:
+
+        * Install as root
+            ssh root@$(hostname)   then run the same install command
+
+        * Use Tailscale — MantaUI then needs no root at all
+            curl -fsSL https://tailscale.com/install.sh | sh
+            sudo tailscale up
+            then run the same install command
+
+        * Grant this user sudo access on the box, then run the installer again."
+  fi
+}
+
+# ---------------------------------------------------------------------------
 # Git-aware deploy init. `scripts/self-update.sh` (wired in BET-225.A5) assumes
 # $MANTA_HOME is a git checkout, so the update path can do a `git fetch +
 # reset`. The release tarball ships WITHOUT a .git/ (pack.mjs strips it), so we
@@ -720,6 +773,65 @@ main() {
   [ -f "$WORK/pkg/src/server/index.mjs" ] \
     || die "bad release tarball — missing src/server/index.mjs"
   ok "Release tarball looks self-contained."
+
+  # ---------------------------------------------------------------------------
+  # 3.5 CAPABILITY PREFLIGHT — ALL-OR-NOTHING (BET-980).
+  #
+  # The PUBLIC ingress path needs a Debian/Ubuntu-family distro and the ability
+  # to run commands as root. Before the FIRST mutation (the atomic swap into
+  # $MANTA_HOME, the systemd units, the box identity, gateway registration) we
+  # interrogate the machine for both and die on a missing capability — so a
+  # box that would otherwise finish with an unreachable "Installed." state
+  # instead refuses to start. The tarball is only extracted into $WORK (a
+  # temp dir cleaned by the EXIT trap), so nothing persistent has been written:
+  # failing here leaves a clean box. The vendored node + lib are read straight
+  # out of $WORK/pkg — the same runtime step 7.5 uses, before the swap.
+  #
+  # Dry-run just reports the verdict; it never dies (a preview shows the plan,
+  # and by definition has installed nothing).
+  _PRE_NODE="$WORK/pkg/runtime/node/bin/node"
+  _PRE_LIB="$WORK/pkg/scripts/install-lib.mjs"
+
+  # Resolve the ingress path early (side-effect-free mirror of step 7's
+  # decision): tailscale up → tailscale; macOS → macos; otherwise public.
+  _PRE_INGRESS="public"
+  if [ "$IS_MACOS" = "1" ]; then
+    _PRE_INGRESS="macos"
+  elif command -v tailscale >/dev/null 2>&1 && \
+       [ -n "$(tailscale status --json 2>/dev/null | "$_PRE_NODE" "$_PRE_LIB" parse-tailscale-status 2>/dev/null || true)" ]; then
+    _PRE_INGRESS="tailscale"
+  fi
+
+  # Root usable: real root, or passwordless sudo. Both read-only.
+  _PRE_ROOT="0"
+  if [ "$(id -u)" = "0" ] || sudo -n true 2>/dev/null; then
+    _PRE_ROOT="1"
+  fi
+
+  # Distro supported: probe detect-distro (the same subcommand step 7.5 uses).
+  _PRE_DISTRO_STATUS="$("$_PRE_NODE" "$_PRE_LIB" detect-distro 2>/dev/null || echo "")"
+  _PRE_DISTRO_SUPPORTED="$(printf '%s' "$_PRE_DISTRO_STATUS" | "$_PRE_NODE" -e '
+      let s = "";
+      process.stdin.on("data", (c) => { s += c; });
+      process.stdin.on("end", () => {
+        try { process.stdout.write(JSON.parse(s).supported ? "yes" : "no"); }
+        catch { process.stdout.write("unknown"); }
+      });
+    ' 2>/dev/null || echo unknown)"
+  _PRE_DISTRO_ID="$(printf '%s' "$_PRE_DISTRO_STATUS" | "$_PRE_NODE" -e '
+      let s = "";
+      process.stdin.on("data", (c) => { s += c; });
+      process.stdin.on("end", () => {
+        try { process.stdout.write(JSON.parse(s).id ?? ""); }
+        catch { process.stdout.write(""); }
+      });
+    ' 2>/dev/null || true)"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    dry_log "capability preflight: ingress=$_PRE_INGRESS root=${_PRE_ROOT} distro_supported=$_PRE_DISTRO_SUPPORTED"
+  else
+    public_ingress_preflight "$_PRE_INGRESS" "$_PRE_ROOT" "$_PRE_DISTRO_SUPPORTED" "$_PRE_DISTRO_ID"
+  fi
 
   # ---------------------------------------------------------------------------
   # 4. Atomic swap. .prev preserves the previous install in case anything in
@@ -1309,92 +1421,30 @@ main() {
   # skip the public TLS path; gateway-register (B/C) still runs in both
   # because it's user-space and the gateway_token is still needed for
   # APNs push. Computed once, used by every guard below.
+  #
+  # NOTE — this is ALWAYS a legitimate, complete outcome. It is NOT the
+  # removed BET-980 degrader (the old degraded-success flag is gone): the
+  # only way A/D/E/reload are skipped is that the chosen ingress path
+  # (tailscale / macOS) genuinely has no public TLS. A public-path install
+  # reaches this code with root + a supported distro already verified by
+  # the preflight.
   SKIP_PUBLIC_TLS=0
   if [ "$INGRESS_MODE" = "tailscale" ] || [ "$IS_MACOS" = "1" ]; then
     SKIP_PUBLIC_TLS=1
   fi
 
-  # Gate the section. In dry-run mode we always show what we would do
-  # (the dry_log lines are below). In real mode we bail with a clear
-  # bring-your-own-proxy hint when distro isn't Debian/Ubuntu or sudo
-  # isn't usable.
-  #
-  # Tailscale path (BET-267) AND macOS path (BET-276): distro / sudo checks
-  # are irrelevant — no sudo is needed at all on either path (the whole
-  # point is "skip Caddy + public DNS"). PRIVILEGED_SECTION_SKIP is left
-  # at 0 so sub-steps B + C (gateway register + merge-gateway) still run —
-  # they are user-space and the gateway_token is still needed for APNs
-  # push. A/D/E/reload are gated on SKIP_PUBLIC_TLS further
-  # down.
-  PRIVILEGED_SECTION_SKIP=0
-  if [ "$DRY_RUN" != "1" ] && [ "$SKIP_PUBLIC_TLS" != "1" ]; then
-    # Distro check (Debian/Ubuntu only for v1 — see reviewer guidance §4).
-    DISTRO_STATUS="$("$NODE" "$LIB" detect-distro 2>/dev/null || echo "")"
-    DISTRO_SUPPORTED="$(printf '%s' "$DISTRO_STATUS" | "$NODE" -e '
-      let s = "";
-      process.stdin.on("data", (c) => { s += c; });
-      process.stdin.on("end", () => {
-        try { process.stdout.write(JSON.parse(s).supported ? "yes" : "no"); }
-        catch { process.stdout.write("unknown"); }
-      });
-    ' 2>/dev/null || echo unknown)"
-    DISTRO_ID="$(printf '%s' "$DISTRO_STATUS" | "$NODE" -e '
-      let s = "";
-      process.stdin.on("data", (c) => { s += c; });
-      process.stdin.on("end", () => {
-        try { process.stdout.write(JSON.parse(s).id ?? ""); }
-        catch { process.stdout.write(""); }
-      });
-    ' 2>/dev/null || true)"
-    case "$DISTRO_SUPPORTED" in
-      yes)
-        # supported; continue
-        ;;
-      no|unknown|"")
-        warn "Caddy/gateway section skipped: distro ${DISTRO_ID:-unknown} is not in the v1 supported list (debian / ubuntu / ID_LIKE=debian)."
-        warn "  this installer only manages Caddy + the gateway registration on Debian/Ubuntu."
-        warn "  bring-your-own-proxy: point any reverse proxy at 127.0.0.1:$MANTA_PORT and serve your own TLS."
-        warn "  once Caddy (or another reverse proxy) is serving the box, re-run the installer to finish gateway registration."
-        PRIVILEGED_SECTION_SKIP=1
-        ;;
-    esac
-
-    # Sudo check — bail cleanly if sudo is missing or non-interactive.
-    # We use `sudo -n true` as the gate (non-interactive; never prompts).
-    # Passwordless sudo is required because the install runs unattended
-    # from `curl | bash`.
-    if [ "$PRIVILEGED_SECTION_SKIP" = "0" ]; then
-      if [ "$(id -u)" = "0" ]; then
-        # Root needs no sudo. Every privileged call in this section is
-        # `sudo -n <cmd>`; as root the `-n` flag is meaningless and the sudo
-        # binary may be absent entirely (minimal VPS). When it's missing,
-        # shim sudo to drop the leading `-n` and run the command bare — zero
-        # changes to the commands below.
-        if ! command -v sudo >/dev/null 2>&1; then
-          sudo() {
-            if [ "${1:-}" = "-n" ]; then shift; fi
-            "$@"
-          }
-        fi
-      else
-        if ! command -v sudo >/dev/null 2>&1; then
-          warn "Caddy/gateway section skipped: \`sudo\` is not installed."
-          warn "  install sudo + grant $USER passwordless sudo, or run the
-  install with sudo available. To finish this section by hand:"
-          warn "    sudo apt install -y debian-keyring debian-archive-keyring apt-transport-https curl"
-          warn "    curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' | sudo gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg"
-          warn "    echo 'deb [signed-by=/usr/share/keyrings/caddy-stable-archive-keyring.gpg] https://dl.cloudsmith.io/public/caddy/stable/deb/ubuntu noble main' | sudo tee /etc/apt/sources.list.d/caddy-stable.list"
-          warn "    sudo apt update && sudo apt install caddy"
-          warn "  then re-run the installer (the gateway + DNS + Caddyfile steps re-run cleanly)."
-          PRIVILEGED_SECTION_SKIP=1
-        elif ! sudo -n true 2>/dev/null; then
-          warn "Caddy/gateway section skipped: passwordless sudo is not configured for $USER."
-          warn "  either configure \`$USER ALL=(ALL) NOPASSWD:ALL\` in /etc/sudoers.d/ and re-run,"
-          warn "  or install Caddy by hand (commands in the previous message) and re-run the installer."
-          PRIVILEGED_SECTION_SKIP=1
-        fi
-      fi
-    fi
+  # The capability gates (distro + root) now run in the 3.5 PREFLIGHT, before
+  # the first mutation, and die there on a missing public-path capability —
+  # so step 7.5 no longer has a "degraded success" branch. On the public path
+  # root has already been verified usable. As ROOT the `sudo` binary may be
+  # absent entirely (minimal VPS); shim it to drop the leading `-n` and run
+  # the command bare, so every `sudo -n <cmd>` below still works with zero
+  # changes to the commands.
+  if [ "$(id -u)" = "0" ] && ! command -v sudo >/dev/null 2>&1; then
+    sudo() {
+      if [ "${1:-}" = "-n" ]; then shift; fi
+      "$@"
+    }
   fi
 
   if [ "$INGRESS_MODE" = "tailscale" ]; then
@@ -1409,8 +1459,6 @@ main() {
     # Issue C will wire that up via LaunchAgents). B/C (gateway register
     # + merge-gateway) still run below for the APNs push token.
     log "macOS detected — skipping Caddy/apt/DNS/vhost; box is loopback-only. Use Tailscale to reach this box off-network."
-  elif [ "$PRIVILEGED_SECTION_SKIP" = "1" ]; then
-    log "Skipping public-TLS step (bring-your-own-proxy keeps the rest of the install working)."
   else
     log "Configuring public TLS via Caddy + gateway registration (privileged)…"
   fi
@@ -1419,57 +1467,67 @@ main() {
   # B (POST /register) and C (merge-gateway into auth.json) are user-space and
   # run in BOTH ingress modes. On tailscale the gateway records an A record
   # that is unused but harmless; the persisted gateway_token is still the
-  # APNs push credential (BET-198). Skipped entirely only on distro/sudo
-  # failure (PRIVILEGED_SECTION_SKIP=1) where the rest of the section is
-  # being skipped.
-  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ]; then
-    # The server mints the identity asynchronously on its first start, so on a
-    # fresh box this read races the mint — poll for up to ~60s rather than
-    # taking the first empty answer as final (see wait_for_box_id's comment for
-    # the failure this caused). Dry-run never waits: one probe and move on.
-    BOX_ID_WAIT_ATTEMPTS=60
-    if [ "$DRY_RUN" = "1" ]; then BOX_ID_WAIT_ATTEMPTS=1; fi
-    BOX_ID_FOR_GATEWAY="$(wait_for_box_id "$LIB" "$NODE" "$BOX_ID_WAIT_ATTEMPTS" 1 || true)"
+  # APNs push credential (BET-198). On the PUBLIC path a registration failure
+  # is fatal (there is no public ingress without it); on tailscale / macOS it
+  # stays a warn — the server re-registers on every restart and the APNs token
+  # is best-effort at install time.
+  # The server mints the identity asynchronously on its first start, so on a
+  # fresh box this read races the mint — poll for up to ~60s rather than
+  # taking the first empty answer as final (see wait_for_box_id's comment for
+  # the failure this caused). Dry-run never waits: one probe and move on.
+  BOX_ID_WAIT_ATTEMPTS=60
+  if [ "$DRY_RUN" = "1" ]; then BOX_ID_WAIT_ATTEMPTS=1; fi
+  BOX_ID_FOR_GATEWAY="$(wait_for_box_id "$LIB" "$NODE" "$BOX_ID_WAIT_ATTEMPTS" 1 || true)"
 
-    if [ -z "$BOX_ID_FOR_GATEWAY" ]; then
-      warn "no box_id in $MANTA_AUTH_FILE after waiting — skipping gateway registration."
-      warn "  start the manta-server at least once ($(supervisor_hint restart server)) and re-run."
+  if [ -z "$BOX_ID_FOR_GATEWAY" ]; then
+    if [ "$DRY_RUN" != "1" ] && [ "$INGRESS_MODE" = "public" ]; then
+      die "no box_id in $MANTA_AUTH_FILE after waiting — cannot register the gateway, so this box would have no public HTTPS.
+        Start the manta-server at least once ($(supervisor_hint restart server)), then run the installer again.
+
+        Fix the above and run the installer again — re-running is safe and preserves your box identity."
+    fi
+    warn "no box_id in $MANTA_AUTH_FILE after waiting — skipping gateway registration."
+    warn "  start the manta-server at least once ($(supervisor_hint restart server)) and re-run."
+  else
+    GATEWAY_BASE="${MANTA_GATEWAY_BASE:-https://gateway.mantaui.com}"
+    # Use the existing gateway_token if present so re-registration is an
+    # idempotent IP refresh; otherwise POST /register with no auth and the
+    # gateway returns a fresh token + host. The gateway response always
+    # carries {host}; the token is only present on first registration.
+    PRIOR_TOKEN="$("$NODE" -e '
+      const fs = require("node:fs");
+      try {
+        const a = JSON.parse(fs.readFileSync(process.env.MANTA_AUTH_FILE, "utf-8"));
+        process.stdout.write(typeof a?.gateway_token === "string" ? a.gateway_token : "");
+      } catch { process.stdout.write(""); }
+    ' 2>/dev/null || true)"
+
+    if [ "$DRY_RUN" = "1" ]; then
+      dry_log "would POST $GATEWAY_BASE/register with box_id=$BOX_ID_FOR_GATEWAY (prior_token=${PRIOR_TOKEN:+set})"
+      dry_log "would persist gateway response into $MANTA_AUTH_FILE via merge-gateway"
     else
-      GATEWAY_BASE="${MANTA_GATEWAY_BASE:-https://gateway.mantaui.com}"
-      # Use the existing gateway_token if present so re-registration is an
-      # idempotent IP refresh; otherwise POST /register with no auth and the
-      # gateway returns a fresh token + host. The gateway response always
-      # carries {host}; the token is only present on first registration.
-      PRIOR_TOKEN="$("$NODE" -e '
-        const fs = require("node:fs");
-        try {
-          const a = JSON.parse(fs.readFileSync(process.env.MANTA_AUTH_FILE, "utf-8"));
-          process.stdout.write(typeof a?.gateway_token === "string" ? a.gateway_token : "");
-        } catch { process.stdout.write(""); }
-      ' 2>/dev/null || true)"
-
-      if [ "$DRY_RUN" = "1" ]; then
-        dry_log "would POST $GATEWAY_BASE/register with box_id=$BOX_ID_FOR_GATEWAY (prior_token=${PRIOR_TOKEN:+set})"
-        dry_log "would persist gateway response into $MANTA_AUTH_FILE via merge-gateway"
+      log "Registering with gateway $GATEWAY_BASE/register…"
+      REGISTER_ARGS=(-fsSL -X POST -H "content-type: application/json" --data "$(printf '{"box_id":"%s"}' "$BOX_ID_FOR_GATEWAY")")
+      if [ -n "$PRIOR_TOKEN" ]; then
+        REGISTER_ARGS+=(-H "authorization: Bearer $PRIOR_TOKEN")
+      fi
+      if GW_RESP="$(curl "${REGISTER_ARGS[@]}" "$GATEWAY_BASE/register")"; then
+        # Pipe the JSON to merge-gateway via stdin (lib subcommand) so the
+        # auth.json write is atomic temp-rename + 0600, preserving
+        # box_id / box_token / created_at.
+        if printf '%s' "$GW_RESP" | "$NODE" "$LIB" merge-gateway --file "$MANTA_AUTH_FILE" 2>/tmp/manta-gateway-merge.err; then
+          ok "gateway registration complete."
+        else
+          warn "merge-gateway failed (see /tmp/manta-gateway-merge.err) — the server will re-register on next boot."
+        fi
       else
-        log "Registering with gateway $GATEWAY_BASE/register…"
-        REGISTER_ARGS=(-fsSL -X POST -H "content-type: application/json" --data "$(printf '{"box_id":"%s"}' "$BOX_ID_FOR_GATEWAY")")
-        if [ -n "$PRIOR_TOKEN" ]; then
-          REGISTER_ARGS+=(-H "authorization: Bearer $PRIOR_TOKEN")
+        if [ "$INGRESS_MODE" = "public" ]; then
+          die "gateway registration POST failed — this box would have no public HTTPS without it.
+            ${MANTA_GATEWAY_BASE:+($MANTA_GATEWAY_BASE) }Fix the gateway/network issue and run the installer again.
+
+            Fix the above and run the installer again — re-running is safe and preserves your box identity."
         fi
-        GW_RESP="$(curl "${REGISTER_ARGS[@]}" "$GATEWAY_BASE/register")" \
-          || { warn "gateway registration POST failed — the box will retry on every server restart.
-            Pair the device via SSH port-forward or use a non-gateway ingress until this works."; GW_RESP=""; }
-        if [ -n "$GW_RESP" ]; then
-          # Pipe the JSON to merge-gateway via stdin (lib subcommand) so the
-          # auth.json write is atomic temp-rename + 0600, preserving
-          # box_id / box_token / created_at.
-          if printf '%s' "$GW_RESP" | "$NODE" "$LIB" merge-gateway --file "$MANTA_AUTH_FILE" 2>/tmp/manta-gateway-merge.err; then
-            ok "gateway registration complete."
-          else
-            warn "merge-gateway failed (see /tmp/manta-gateway-merge.err) — the server will re-register on next boot."
-          fi
-        fi
+        warn "gateway registration POST failed — the box will retry on every server restart."
       fi
     fi
   fi
@@ -1479,7 +1537,7 @@ main() {
   # tailscale path AND the macOS path (BET-276) never bind :80/:443, never
   # write a Caddy vhost, never wait on DNS, never reload Caddy. Gated via
   # SKIP_PUBLIC_TLS which merges both cases into one predicate.
-  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ] && [ "$SKIP_PUBLIC_TLS" != "1" ]; then
+  if [ "$SKIP_PUBLIC_TLS" != "1" ]; then
     if command -v caddy >/dev/null 2>&1; then
       ok "caddy already installed ($(caddy version 2>/dev/null || echo unknown))."
     elif [ "$DRY_RUN" = "1" ]; then
@@ -1551,74 +1609,70 @@ main() {
 
   # --- D. Poll DNS until <box_id>.boxes.mantaui.com resolves to us -------
   # Public path only (BET-267 + BET-276); the tailnet path AND the macOS
-  # path have no DNS wait. Gated via SKIP_PUBLIC_TLS.
-  if [ "$PRIVILEGED_SECTION_SKIP" = "0" ] && [ "$SKIP_PUBLIC_TLS" != "1" ]; then
-    # Re-read gateway_host (or default to the canonical pattern if the
-    # gateway didn't return one yet) for the polling target.
-    GATEWAY_HOST="$("$NODE" -e '
-      const fs = require("node:fs");
-      try {
-        const a = JSON.parse(fs.readFileSync(process.env.MANTA_AUTH_FILE, "utf-8"));
-        process.stdout.write(typeof a?.gateway_host === "string" ? a.gateway_host : "");
-      } catch { process.stdout.write(""); }
-    ' 2>/dev/null || true)"
-    if [ -z "$GATEWAY_HOST" ]; then
-      GATEWAY_HOST="$BOX_ID_FOR_GATEWAY.boxes.mantaui.com"
-    fi
-
-    # Detect this box's public IP via the gateway's source-IP report —
-    # fall back to `hostname -I` if the gateway response didn't include it
-    # (or in dry-run mode). We MUST use the public IP, not loopback —
-    # otherwise the DNS check trivially passes on every box.
-    BOX_PUBLIC_IP="$("$NODE" -e '
-      const https = require("node:https");
-      const opts = { hostname: "api.ipify.org", path: "/", method: "GET", timeout: 5000 };
-      const req = https.request(opts, (res) => {
-        let body = "";
-        res.on("data", (c) => body += c);
-        res.on("end", () => process.stdout.write(body.trim()));
-      });
-      req.on("error", () => process.stdout.write(""));
-      req.end();
-    ' 2>/dev/null || true)"
-    if [ -z "$BOX_PUBLIC_IP" ]; then
-      BOX_PUBLIC_IP="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
-    fi
-
-    if [ -z "$BOX_PUBLIC_IP" ]; then
-      warn "could not determine the box's public IP — skipping DNS wait + Caddy setup."
-      warn "  the box will retry on every server restart."
+  # path have no DNS wait. Gated via SKIP_PUBLIC_TLS. Under the BET-980
+  # all-or-nothing rule, every public-path failure here is FATAL (progress
+  # has already been made, but a box that can't be reached must be reported
+  # as failed, not dressed as success). Dry-run just shows the plan.
+  if [ "$SKIP_PUBLIC_TLS" != "1" ]; then
+    if [ "$DRY_RUN" = "1" ]; then
+      dry_log "would determine the box's public IP and poll DNS for $GATEWAY_HOST (up to 90s)"
+      dry_log "would render + install the Caddy vhost (box_id=$BOX_ID_FOR_GATEWAY, port=$MANTA_PORT)"
+      dry_log "would run: systemctl reload caddy"
     else
-      # DNS_TIMED_OUT gates step E below: if the box hostname hasn't
-      # propagated yet, writing the Caddy vhost is pointless (Let's Encrypt
-      # HTTP-01 would fail cert issuance against an unresolvable name), so we
-      # skip it and let the operator re-run once DNS is live.
-      DNS_TIMED_OUT=0
-      if [ "$DRY_RUN" = "1" ]; then
-        dry_log "would poll DNS for $GATEWAY_HOST (expecting $BOX_PUBLIC_IP) for up to 90 seconds"
-      else
-        # Bounded at ~90s (18 × 5s) rather than 5 min. A fresh gateway
-        # registration normally propagates in well under a minute; a longer
-        # wait just looks like a hang. On timeout we WARN (never die) so the
-        # installer still reaches the pair-code print — the box re-registers
-        # + retries DNS on every server restart, and re-running the installer
-        # picks up step E cleanly once the name resolves.
-        log "Waiting for $GATEWAY_HOST to resolve to $BOX_PUBLIC_IP (up to 90 seconds)…"
-        if ! "$NODE" "$LIB" wait-for-dns \
-            --hostname "$GATEWAY_HOST" \
-            --expected-ip "$BOX_PUBLIC_IP" \
-            --max-attempts 18 \
-            --interval-ms 5000; then
-          warn "$GATEWAY_HOST did not resolve to $BOX_PUBLIC_IP within 90s — skipping the Caddy vhost for now."
-          warn "  DNS propagation can lag; the box re-registers on every server restart."
-          warn "  Once it resolves, re-run the installer (or: sudo systemctl reload caddy) to finish public TLS."
-          warn "  Check: curl -fsS $GATEWAY_BASE/healthz"
-          warn "  And:   journalctl --user -u manta-server -n 50 (for the gateway-register lines)"
-          DNS_TIMED_OUT=1
-        else
-          ok "DNS resolved."
-        fi
+      # Re-read gateway_host (or default to the canonical pattern if the
+      # gateway didn't return one yet) for the polling target.
+      GATEWAY_HOST="$("$NODE" -e '
+        const fs = require("node:fs");
+        try {
+          const a = JSON.parse(fs.readFileSync(process.env.MANTA_AUTH_FILE, "utf-8"));
+          process.stdout.write(typeof a?.gateway_host === "string" ? a.gateway_host : "");
+        } catch { process.stdout.write(""); }
+      ' 2>/dev/null || true)"
+      if [ -z "$GATEWAY_HOST" ]; then
+        GATEWAY_HOST="$BOX_ID_FOR_GATEWAY.boxes.mantaui.com"
       fi
+
+      # Detect this box's public IP via api.ipify.org — fall back to
+      # `hostname -I`. We MUST use the public IP, not loopback — otherwise
+      # the DNS check trivially passes on every box.
+      BOX_PUBLIC_IP="$("$NODE" -e '
+        const https = require("node:https");
+        const opts = { hostname: "api.ipify.org", path: "/", method: "GET", timeout: 5000 };
+        const req = https.request(opts, (res) => {
+          let body = "";
+          res.on("data", (c) => body += c);
+          res.on("end", () => process.stdout.write(body.trim()));
+        });
+        req.on("error", () => process.stdout.write(""));
+        req.end();
+      ' 2>/dev/null || true)"
+      if [ -z "$BOX_PUBLIC_IP" ]; then
+        BOX_PUBLIC_IP="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
+      fi
+      if [ -z "$BOX_PUBLIC_IP" ]; then
+        die "could not determine the box's public IP — cannot complete the public path.
+          Fix your network/egress so api.ipify.org (or hostname -I) reports a public address, then run the installer again.
+
+          Fix the above and run the installer again — re-running is safe and preserves your box identity."
+      fi
+
+      # Bounded at ~90s (18 × 5s). A fresh gateway registration normally
+      # propagates in well under a minute; a longer wait just looks like a
+      # hang. On timeout we DIE — a public-path box whose hostname never
+      # resolves has no HTTPS and must be reported as failed.
+      log "Waiting for $GATEWAY_HOST to resolve to $BOX_PUBLIC_IP (up to 90 seconds)…"
+      "$NODE" "$LIB" wait-for-dns \
+          --hostname "$GATEWAY_HOST" \
+          --expected-ip "$BOX_PUBLIC_IP" \
+          --max-attempts 18 \
+          --interval-ms 5000 \
+        || die "$GATEWAY_HOST did not resolve to $BOX_PUBLIC_IP within 90s.
+          DNS propagation can lag after a fresh gateway registration.
+          Check: curl -fsS $GATEWAY_BASE/healthz
+          And:   journalctl --user -u manta-server -n 50 (for the gateway-register lines)
+
+          Fix the above and run the installer again — re-running is safe and preserves your box identity."
+      ok "DNS resolved."
 
       # --- E. Write the Caddy vhost and reload ----------------------------
       # /etc/caddy/Caddyfile.d/ is the convention used by the official
@@ -1627,107 +1681,69 @@ main() {
       # with marked-block append is for distros that install Caddy without
       # the conf.d import (we test for the directory's existence).
       #
-      # GrACEful DEGRADATION: every privileged call here can fail (sudo
-      # tee / sudo mv / sudo systemctl), and the design-guidance §3
-      # contract says we MUST let the install reach the pair-code print
-      # even when the Caddyfile write fails. We track failures with a
-      # local CADDY_E_SKIP flag — any privileged call that returns
-      # non-zero sets the flag, and the rest of 7.5.E is skipped. The
-      # pair-code step (8) below runs regardless.
-      #
-      # Seed the flag from the DNS wait: if the box hostname didn't resolve,
-      # skip the vhost write entirely (cert issuance would fail against an
-      # unresolvable name). DRY_RUN never times out, so this is a no-op there.
-      CADDY_E_SKIP="${DNS_TIMED_OUT:-0}"
-      # Second seed: no box_id ⇒ nothing to name the vhost after. Without this
-      # guard the renderer below was invoked with an empty --box-id and failed
-      # ("render-caddy-vhost: --box-id <32hex> required") — noisy in the
-      # conf.d path and FATAL in the inline path (a failed command
-      # substitution under `set -e` kills the install before the pair code is
-      # printed). wait_for_box_id above makes this unreachable in practice;
-      # keep it as the belt to that braces.
-      if [ "$DRY_RUN" != "1" ] && [ -z "${BOX_ID_FOR_GATEWAY:-}" ]; then
-        warn "no box_id available — skipping the Caddy vhost write (nothing to point the hostname at)."
-        warn "  re-run the installer once the server has minted an identity ($(supervisor_hint status server))."
-        CADDY_E_SKIP=1
-      fi
+      # ALL-OR-NOTHING (BET-980): every failure here is FATAL. A vhost that
+      # isn't written/live means no public TLS, so the install stops rather
+      # than printing "Installed." for an unreachable box. Re-running is safe
+      # and idempotent.
       CADDY_DIR_D="/etc/caddy/Caddyfile.d"
-      if [ "$DRY_RUN" = "1" ]; then
-        dry_log "would render Caddy vhost (box_id=$BOX_ID_FOR_GATEWAY, port=$MANTA_PORT)"
-        dry_log "would write the snippet to $CADDY_DIR_D/manta.caddy"
-        dry_log "would run: systemctl reload caddy"
-      elif [ "$CADDY_E_SKIP" != "0" ]; then
-        # DNS didn't resolve above — skip the vhost write; the reload guard
-        # below (CADDY_E_SKIP != 0) will also be skipped. Re-run once DNS is live.
-        :
+      if [ -d "$CADDY_DIR_D" ]; then
+        # Caddyfile.d exists → write the snippet as a separate file.
+        # Render to a temp file FIRST, then install(1) it atomically. A
+        # direct `render | sudo tee` truncates the destination BEFORE the
+        # renderer's exit status is known, so a failed re-run replaces a
+        # working vhost with an empty file. Same staging rationale as the
+        # apt .list write above.
+        _caddy_snippet_tmp="$(mktemp)"
+        if ! "$NODE" "$LIB" render-caddy-vhost --box-id "$BOX_ID_FOR_GATEWAY" --port "$MANTA_PORT" --mode snippet \
+            > "$_caddy_snippet_tmp" 2>/tmp/manta-caddy-render.err; then
+          die "failed to render the Caddy vhost (see /tmp/manta-caddy-render.err).
+            Fix the above and run the installer again — re-running is safe and preserves your box identity."
+        fi
+        install_root_file "$_caddy_snippet_tmp" "$CADDY_DIR_D/manta.caddy" 2>/tmp/manta-caddy-tee.err \
+          || die "failed to write $CADDY_DIR_D/manta.caddy (sudo install failed — see /tmp/manta-caddy-tee.err).
+            Fix the above and run the installer again — re-running is safe and preserves your box identity."
+        rm -f "$_caddy_snippet_tmp"
       else
-        if [ -d "$CADDY_DIR_D" ]; then
-          # Caddyfile.d exists → write the snippet as a separate file.
-          # Render to a temp file FIRST, then install(1) it atomically. A
-          # direct `render | sudo tee` truncates the destination BEFORE the
-          # renderer's exit status is known, so a failed re-run replaces a
-          # working vhost with an empty file. Same staging rationale as the
-          # apt .list write above.
-          _caddy_snippet_tmp="$(mktemp)"
-          if ! "$NODE" "$LIB" render-caddy-vhost --box-id "$BOX_ID_FOR_GATEWAY" --port "$MANTA_PORT" --mode snippet \
-              > "$_caddy_snippet_tmp" 2>/tmp/manta-caddy-render.err; then
-            warn "failed to render the Caddy vhost (see /tmp/manta-caddy-render.err)"
-            warn "  the rest of the install will proceed; re-run to write the Caddy vhost."
-            CADDY_E_SKIP=1
-          elif ! install_root_file "$_caddy_snippet_tmp" "$CADDY_DIR_D/manta.caddy" 2>/tmp/manta-caddy-tee.err; then
-            warn "failed to write $CADDY_DIR_D/manta.caddy (sudo install failed — see /tmp/manta-caddy-tee.err)"
-            warn "  the rest of the install will proceed; re-run after fixing sudo to write the Caddy vhost."
-            CADDY_E_SKIP=1
-          fi
-          rm -f "$_caddy_snippet_tmp"
-        else
-          # conf.d missing → keep exactly one marker-bracketed block inside
-          # the main Caddyfile. All the block editing lives in install-lib.mjs
-          # (pure + unit-tested); this shell path only stages a temp file and
-          # installs it. `cat` of a missing file yields empty stdin, which the
-          # subcommand treats as "no Caddyfile yet" — so create/append/replace
-          # are one code path, not three.
-          #
-          # The `( cat ... || true )` group is pipefail-load-bearing: without
-          # it, a missing Caddyfile makes `cat` exit non-zero and `set -o
-          # pipefail` fails the whole pipeline, routing to the warn/skip branch
-          # below instead of reaching install_root_file — so the create-from-
-          # scratch case (the box has Caddy but no main Caddyfile) would never
-          # write a vhost. `|| true` yields empty stdin + exit 0 while node's
-          # own render/validation exit code still propagates.
-          CADDYFILE="/etc/caddy/Caddyfile"
-          _caddyfile_tmp="$(mktemp)"
-          if ! ( cat "$CADDYFILE" 2>/dev/null || true ) \
-              | "$NODE" "$LIB" upsert-caddy-block --box-id "$BOX_ID_FOR_GATEWAY" --port "$MANTA_PORT" \
-              > "$_caddyfile_tmp" 2>/tmp/manta-caddy-render.err; then
-            warn "failed to render the Caddy vhost (see /tmp/manta-caddy-render.err)"
-            warn "  the rest of the install will proceed; re-run to write the Caddy vhost."
-            CADDY_E_SKIP=1
-          elif ! install_root_file "$_caddyfile_tmp" "$CADDYFILE" 2>/tmp/manta-caddy-write.err; then
-            warn "could not update $CADDYFILE (sudo install failed — see /tmp/manta-caddy-write.err)"
-            warn "  the rest of the install will proceed; re-run after fixing sudo to write the Caddy vhost."
-            CADDY_E_SKIP=1
-          fi
-          rm -f "$_caddyfile_tmp"
+        # conf.d missing → keep exactly one marker-bracketed block inside
+        # the main Caddyfile. All the block editing lives in install-lib.mjs
+        # (pure + unit-tested); this shell path only stages a temp file and
+        # installs it. `cat` of a missing file yields empty stdin, which the
+        # subcommand treats as "no Caddyfile yet" — so create/append/replace
+        # are one code path, not three.
+        #
+        # The `( cat ... || true )` group is pipefail-load-bearing: without
+        # it, a missing Caddyfile makes `cat` exit non-zero and `set -o
+        # pipefail` fails the whole pipeline, routing to the die branch
+        # below instead of reaching install_root_file — so the create-from-
+        # scratch case (the box has Caddy but no main Caddyfile) would never
+        # write a vhost. `|| true` yields empty stdin + exit 0 while node's
+        # own render/validation exit code still propagates.
+        CADDYFILE="/etc/caddy/Caddyfile"
+        _caddyfile_tmp="$(mktemp)"
+        if ! ( cat "$CADDYFILE" 2>/dev/null || true ) \
+            | "$NODE" "$LIB" upsert-caddy-block --box-id "$BOX_ID_FOR_GATEWAY" --port "$MANTA_PORT" \
+            > "$_caddyfile_tmp" 2>/tmp/manta-caddy-render.err; then
+          die "failed to render the Caddy vhost (see /tmp/manta-caddy-render.err).
+            Fix the above and run the installer again — re-running is safe and preserves your box identity."
         fi
+        install_root_file "$_caddyfile_tmp" "$CADDYFILE" 2>/tmp/manta-caddy-write.err \
+          || die "could not update $CADDYFILE (sudo install failed — see /tmp/manta-caddy-write.err).
+            Fix the above and run the installer again — re-running is safe and preserves your box identity."
+        rm -f "$_caddyfile_tmp"
+      fi
 
-        # Sub-tasks below depend on the Caddyfile being on disk; skip them
-        # if any write above failed (CADDY_E_SKIP=1). The pair-code step
-        # (8) still runs regardless.
-        if [ "$CADDY_E_SKIP" = "0" ]; then
-          if command -v systemctl >/dev/null 2>&1; then
-            if ! sudo -n systemctl reload caddy 2>/tmp/manta-caddy-reload.err; then
-              warn "systemctl reload caddy failed — see /tmp/manta-caddy-reload.err"
-              warn "  the vhost is on disk but NOT live: no certificate will be issued until the reload succeeds."
-            else
-              ok "caddy reloaded."
-            fi
-          else
-            warn "systemctl not found — reload caddy manually with: sudo caddy reload --config /etc/caddy/Caddyfile"
-          fi
-        else
-          warn "Caddy vhost write was skipped — skipping systemctl reload too."
-        fi
+      # The vhost is on disk; make Caddy live. Without a successful reload no
+      # certificate is issued — fatal on the public path.
+      if command -v systemctl >/dev/null 2>&1; then
+        sudo -n systemctl reload caddy 2>/tmp/manta-caddy-reload.err \
+          || die "systemctl reload caddy failed — the vhost is on disk but NOT live, so no certificate will be issued.
+            See /tmp/manta-caddy-reload.err
+            Fix the above and run the installer again — re-running is safe and preserves your box identity."
+        ok "caddy reloaded."
+      else
+        die "systemctl not found — cannot reload Caddy, so the vhost would not become live.
+          Install systemd (or reload Caddy manually: sudo caddy reload --config /etc/caddy/Caddyfile).
+          Fix the above and run the installer again — re-running is safe and preserves your box identity."
       fi
     fi
   fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1480,7 +1480,7 @@ main() {
   BOX_ID_FOR_GATEWAY="$(wait_for_box_id "$LIB" "$NODE" "$BOX_ID_WAIT_ATTEMPTS" 1 || true)"
 
   if [ -z "$BOX_ID_FOR_GATEWAY" ]; then
-    if [ "$DRY_RUN" != "1" ] && [ "$INGRESS_MODE" = "public" ]; then
+    if [ "$DRY_RUN" != "1" ] && [ "$SKIP_PUBLIC_TLS" != "1" ]; then
       die "no box_id in $MANTA_AUTH_FILE after waiting — cannot register the gateway, so this box would have no public HTTPS.
         Start the manta-server at least once ($(supervisor_hint restart server)), then run the installer again.
 
@@ -1521,7 +1521,7 @@ main() {
           warn "merge-gateway failed (see /tmp/manta-gateway-merge.err) — the server will re-register on next boot."
         fi
       else
-        if [ "$INGRESS_MODE" = "public" ]; then
+        if [ "$SKIP_PUBLIC_TLS" != "1" ]; then
           die "gateway registration POST failed — this box would have no public HTTPS without it.
             ${MANTA_GATEWAY_BASE:+($MANTA_GATEWAY_BASE) }Fix the gateway/network issue and run the installer again.
 

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -510,6 +510,56 @@ public_ingress_preflight() {
 }
 
 # ---------------------------------------------------------------------------
+# Ingress resolution — ONE source of truth for the tailscale/public decision
+# (BET-267). Shared by BOTH the 3.5 capability preflight (which must know
+# whether the D1 gate applies) and step 7 (which persists the decision), so
+# the two can never disagree about which path the install is on. Defined in
+# the always-defined region (before the test-mode guard) so the unit tests can
+# exercise the MANTA_INGRESS logic directly.
+# ---------------------------------------------------------------------------
+
+# detect_tailscale_ip <node> <lib> — wrapper around `tailscale status --json`
+# piped through the lib's `parse-tailscale-status` subcommand. Prints the
+# detected Tailscale IPv4 on stdout, exit 0 — or exit 1 with no output when
+# Tailscale is missing / not running / has no IPv4. Takes the node + lib
+# paths as arguments because it is invoked from both the preflight (which
+# reads them out of the temp $WORK/pkg) and step 7 (which uses $MANTA_HOME).
+# Silent on stderr by design: the absence of tailscale is normal on the
+# public-path install and must not leak a `command not found` warning.
+detect_tailscale_ip() {
+  local node="$1" lib="$2"
+  command -v tailscale >/dev/null 2>&1 || return 1
+  tailscale status --json 2>/dev/null | "$node" "$lib" parse-tailscale-status
+}
+
+# resolve_ingress_mode <node> <lib> — resolve the ingress path honoring the
+# MANTA_INGRESS override (auto | public | tailscale), setting INGRESS_MODE
+# ("public" | "tailscale") and TAILNET_IP. MANTA_INGRESS=public FORCES public
+# even when Tailscale is up (the box wants a public address regardless of a
+# running tailnet); MANTA_INGRESS=tailscale forces tailnet and dies if
+# detection fails; auto picks tailnet iff Tailscale is up. Because the
+# preflight uses this too, a MANTA_INGRESS=public box with no usable root is
+# correctly treated as the public path and gated (BET-980 D1).
+resolve_ingress_mode() {
+  local node="$1" lib="$2"
+  MANTA_INGRESS="${MANTA_INGRESS:-auto}"
+  TAILNET_IP=""
+  case "$MANTA_INGRESS" in
+    public) ;;
+    tailscale)
+      TAILNET_IP="$(detect_tailscale_ip "$node" "$lib")" \
+        || die "MANTA_INGRESS=tailscale but Tailscale is not running (need 'tailscale status' BackendState=Running with an IPv4). Start tailscale, or use MANTA_INGRESS=public."
+      ;;
+    auto)
+      TAILNET_IP="$(detect_tailscale_ip "$node" "$lib" 2>/dev/null || true)"
+      ;;
+    *) die "MANTA_INGRESS must be auto, public, or tailscale (got: $MANTA_INGRESS)" ;;
+  esac
+  INGRESS_MODE="public"
+  if [ -n "$TAILNET_IP" ]; then INGRESS_MODE="tailscale"; fi
+}
+
+# ---------------------------------------------------------------------------
 # Git-aware deploy init. `scripts/self-update.sh` (wired in BET-225.A5) assumes
 # $MANTA_HOME is a git checkout, so the update path can do a `git fetch +
 # reset`. The release tarball ships WITHOUT a .git/ (pack.mjs strips it), so we
@@ -792,14 +842,22 @@ main() {
   _PRE_NODE="$WORK/pkg/runtime/node/bin/node"
   _PRE_LIB="$WORK/pkg/scripts/install-lib.mjs"
 
-  # Resolve the ingress path early (side-effect-free mirror of step 7's
-  # decision): tailscale up → tailscale; macOS → macos; otherwise public.
-  _PRE_INGRESS="public"
+  # Resolve the ingress path via the SAME shared helper step 7 uses, so the
+  # D1 gate and the persisted decision can never diverge. On macOS the gate
+  # never applies (loopback-only; the preflight always passes), so we short-
+  # circuit to "macos" before probing Tailscale. Otherwise resolve_ingress_mode
+  # honors MANTA_INGRESS (auto/public/tailscale): notably MANTA_INGRESS=public
+  # FORCES the public path even when Tailscale is up, so such a box with no
+  # usable root is correctly gated here.
   if [ "$IS_MACOS" = "1" ]; then
     _PRE_INGRESS="macos"
-  elif command -v tailscale >/dev/null 2>&1 && \
-       [ -n "$(tailscale status --json 2>/dev/null | "$_PRE_NODE" "$_PRE_LIB" parse-tailscale-status 2>/dev/null || true)" ]; then
-    _PRE_INGRESS="tailscale"
+  else
+    resolve_ingress_mode "$_PRE_NODE" "$_PRE_LIB"
+    if [ "$INGRESS_MODE" = "tailscale" ]; then
+      _PRE_INGRESS="tailscale"
+    else
+      _PRE_INGRESS="public"
+    fi
   fi
 
   # Root usable: real root, or passwordless sudo. Both read-only.
@@ -1245,54 +1303,18 @@ main() {
   # 7. manta-server systemd --user unit: substitute placeholders and enable.
   # ---------------------------------------------------------------------------
 
-  # detect_tailscale_ip — wrapper around `tailscale status --json` piped
-  # through the lib's `parse-tailscale-status` subcommand. Returns the
-  # detected Tailscale IPv4 on stdout, exit 0 — OR exits 1 with no output
-  # when Tailscale is missing / not running / has no IPv4. install.sh uses
-  # the exit code to drive the INGRESS_MODE decision (BET-267).
-  #
-  # HOISTED ABOVE the mode-resolution block (BET-267 review fix): bash does
-  # NOT forward-reference function definitions within the same function, so
-  # defining this AFTER its call sites (the original placement, near the
-  # box-identity read) silently failed with
-  # `detect_tailscale_ip: command not found` and the auto branch fell through
-  # to public mode even when Tailscale was running. Moving the definition
-  # above the call sites is the minimal fix; `bash -n` parses but does not
-  # execute, so this only shows up under real (or DRY_RUN=1) tracing.
-  #
-  # Silent on stderr by design: install.sh logs the result separately so
-  # we never want a `tailscale: command not found` warning to leak through
-  # the box's user-facing output (the absence of tailscale is normal on
-  # the public-path install).
-  detect_tailscale_ip() {
-    command -v tailscale >/dev/null 2>&1 || return 1
-    tailscale status --json 2>/dev/null | "$NODE" "$LIB" parse-tailscale-status
-  }
-
   # --- Ingress mode (BET-267) ----------------------------------------------
-  # Resolved BEFORE step 7 so the systemd unit template can be rendered
-  # with the correct MANTA_TAILNET_HOST value (empty on public path, the
-  # Tailscale IPv4 on the tailnet path). The decision is persisted to
-  # ~/.manta/ingress.json as the single source of truth for `manta pair`
-  # (which has no access to the install's env vars).
+  # Shared resolve_ingress_mode (defined above main) computes INGRESS_MODE +
+  # TAILNET_IP honoring the MANTA_INGRESS override — the SAME helper the 3.5
+  # preflight uses, so the D1 gate and this persisted decision can never
+  # disagree. Resolved BEFORE the unit render so the systemd template gets the
+  # correct MANTA_TAILNET_HOST value (empty on public path, the Tailscale IPv4
+  # on the tailnet path), then persisted to ~/.manta/ingress.json as the single
+  # source of truth for `manta pair`.
   #
   # MANTA_INGRESS: auto (default — tailnet iff Tailscale is up) | public |
   # tailscale (force tailnet; die if detection fails).
-  MANTA_INGRESS="${MANTA_INGRESS:-auto}"
-  TAILNET_IP=""
-  case "$MANTA_INGRESS" in
-    public) ;;
-    tailscale)
-      TAILNET_IP="$(detect_tailscale_ip)" \
-        || die "MANTA_INGRESS=tailscale but Tailscale is not running (need 'tailscale status' BackendState=Running with an IPv4). Start tailscale, or use MANTA_INGRESS=public."
-      ;;
-    auto)
-      TAILNET_IP="$(detect_tailscale_ip 2>/dev/null || true)"
-      ;;
-    *) die "MANTA_INGRESS must be auto, public, or tailscale (got: $MANTA_INGRESS)" ;;
-  esac
-  INGRESS_MODE="public"
-  if [ -n "$TAILNET_IP" ]; then INGRESS_MODE="tailscale"; fi
+  resolve_ingress_mode "$NODE" "$LIB"
 
   # Persist the decision. write-ingress creates the parent dir if missing
   # and writes 0600 atomically (write <file>.tmp then rename).

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -3197,6 +3197,60 @@ echo "REACHED=yes"
   assert.doesNotMatch(out, /✗ Cannot complete the install/);
 });
 
+test("BET-980: resolve_ingress_mode honors MANTA_INGRESS — public forces public even with Tailscale up", () => {
+  // The reviewer Block: the preflight used to classify the path by raw
+  // Tailscale detection, ignoring the MANTA_INGRESS override. A box forced to
+  // MANTA_INGRESS=public while Tailscale is also running was misclassified as
+  // the (ungated) tailscale path, bypassing the D1 gate. Now the shared
+  // resolve_ingress_mode mocks a running Tailscale and asserts the override
+  // wins.
+  const out = runBootstrap({
+    preBody: `
+detect_tailscale_ip() { printf '%s' '100.64.1.5'; }   # Tailscale IS up
+MANTA_INGRESS=public
+resolve_ingress_mode node lib
+echo "MODE=$INGRESS_MODE IP=$TAILNET_IP"
+`,
+  });
+  assert.match(out, /MODE=public/);
+  assert.doesNotMatch(out, /IP=100/, "MANTA_INGRESS=public must not pick up the running Tailscale IP");
+});
+
+test("BET-980: MANTA_INGRESS=public + Tailscale up + no root → D1 gate fires (fatal)", () => {
+  // Regression for the reviewer Block: the preflight must classify a
+  // MANTA_INGRESS=public box as the public path even when Tailscale is
+  // running, so "public + no root → fatal before the first mutation" is not
+  // bypassed into a half-installed state.
+  const out = runBootstrap({
+    preBody: `
+detect_tailscale_ip() { printf '%s' '100.64.1.5'; }
+MANTA_INGRESS=public
+resolve_ingress_mode node lib
+_PRE_INGRESS="public"; [ "$INGRESS_MODE" = "tailscale" ] && _PRE_INGRESS="tailscale"
+public_ingress_preflight "$_PRE_INGRESS" 0 yes ubuntu
+echo "SHOULD_NOT_REACH=yes"
+`,
+  });
+  assert.match(out, /Cannot complete the install: giving this box a public HTTPS address/);
+  assert.match(out, /Nothing has been installed\./);
+  assert.doesNotMatch(out, /SHOULD_NOT_REACH=yes/);
+});
+
+test("BET-980: MANTA_INGRESS=auto + Tailscale up + no root → NOT fatal (tailnet path is ungated)", () => {
+  const out = runBootstrap({
+    preBody: `
+detect_tailscale_ip() { printf '%s' '100.64.1.5'; }
+MANTA_INGRESS=auto
+resolve_ingress_mode node lib
+_PRE_INGRESS="public"; [ "$INGRESS_MODE" = "tailscale" ] && _PRE_INGRESS="tailscale"
+public_ingress_preflight "$_PRE_INGRESS" 0 yes ubuntu
+echo "REACHED=yes"
+`,
+  });
+  assert.match(out, /REACHED=yes/);
+  assert.doesNotMatch(out, /✗ Cannot complete the install/);
+});
+
 test("BET-980: PRIVILEGED_SECTION_SKIP no longer appears in install.sh (degrade path cannot creep back)", () => {
   const src = readFileSync(INSTALL_SH, "utf-8");
   assert.equal(

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -1609,7 +1609,7 @@ echo "ID=[\$id] RC=\$rc"
 });
 
 test("install.sh waits for the box id before rendering the Caddy vhost (first-run regression)", () => {
-  // Static-layout guard: the value handed to `render-caddy-vhost --box-id`
+  // Static-layout guard: the value handed to the gateway + `render-caddy-vhost`
   // must come from the POLLING read, not the one-shot one. A regression here
   // is invisible on a re-install (auth.json already exists) and only bites the
   // very first run on a fresh box — exactly the case nobody re-tests.
@@ -1619,11 +1619,13 @@ test("install.sh waits for the box id before rendering the Caddy vhost (first-ru
     /BOX_ID_FOR_GATEWAY="\$\(wait_for_box_id /,
     "BOX_ID_FOR_GATEWAY must be populated by wait_for_box_id (bounded poll), not a single read",
   );
-  // And the renderer must never be reachable with an empty id.
+  // The renderer must never be reachable with an empty id. Under BET-980 the
+  // no-box-id case is now FATAL on the public path (the old degrade-to-skip
+  // guard was deleted), so assert that instead of a silent-skip branch.
   assert.match(
     src,
-    /\[ -z "\$\{BOX_ID_FOR_GATEWAY:-\}" \]/,
-    "step 7.5.E must skip the Caddy vhost write when no box_id is available",
+    /no box_id in \$MANTA_AUTH_FILE after waiting — cannot register the gateway/,
+    "a missing box id on the public path must be fatal (die), not a silent skip",
   );
 });
 
@@ -3125,299 +3127,109 @@ async function runDetectDistro(osReleaseContent) {
 }
 
 // ----------------------------------------------------------------------------
-// install.sh — privileged-section gates (BET-205 reviewer guidance §3 + §4).
+// install.sh — BET-980 capability preflight (all-or-nothing ingress).
 // ----------------------------------------------------------------------------
 //
-// Step 7.5 ("PRIVILEGED SECTION") is gated on:
-//   (a) distro in {debian, ubuntu, ID_LIKE=debian} (or DRY_RUN)
-//   (b) `sudo` installed (or DRY_RUN)
-//   (c) `sudo -n true` succeeds (passwordless sudo)
-// We can't run the install body end-to-end in a unit test (it would
-// touch the network + apt + systemd), so these tests source install.sh
-// in REAL mode + override `main` with a stub that runs ONLY the
-// privileged-section gate logic, asserting on the gate's verdicts.
+// The PUBLIC ingress path is all-or-nothing: it needs a Debian/Ubuntu-family
+// distro AND the ability to run commands as root. The gate lives in the
+// top-level `public_ingress_preflight` helper in install.sh and is exercised
+// here via runBootstrap — install.sh is sourced in test mode, so the helper
+// (which uses the always-defined `die`) is directly callable. Passing the
+// resolved inputs (path mode, root-usable, distro-supported/id) as arguments
+// keeps the decision + messages unit-testable without touching the machine.
 //
-// The gate logic itself lives at the top of step 7.5 — we replicate it
-// inline here so the test is independent of the install body. If the
-// install.sh gate diverges from this test, both will need updating.
+// The tailscale and macOS paths never need root or a specific distro, so the
+// gate returns 0 for them even when root is unavailable.
 
-test("install.sh privileged section: distro not Debian/Ubuntu → SKIP (issue §4)", () => {
-  // A non-Debian distro (here: fedora) must trigger the gate's skip
-  // branch. We stub `main` to a script that ONLY runs the gate and
-  // records the gate's verdict + the warning text the install would
-  // print.
-  const out = runMain({
+test("BET-980 preflight: public path + unsupported distro → fatal (die)", () => {
+  const out = runBootstrap({
     preBody: `
-PRIVILEGED_SECTION_SKIP=0
-DRY_RUN=0
-# Mock \`node\` to a script that emits a non-Debian JSON status.
-NODE() {
-  printf '{"id":"fedora","idLike":"rhel fedora","debianLike":false,"supported":false,"reason":"distro fedora is not in the v1 supported list (debian, ubuntu, or ID_LIKE=debian)"}\\n'
-}
-export -f NODE
-# Stub the JSON parsing inner-loop too: we skip the complex printf |
-# node -e pipe by using a tiny inline awk-like extractor.
-_parse() { printf '%s' "$1" | grep -q '"supported":true' && echo yes || echo no; }
-DISTRO_STATUS="$(NODE 2>/dev/null)"
-DISTRO_SUPPORTED="$(_parse "$DISTRO_STATUS")"
-DISTRO_ID="$(printf '%s' "$DISTRO_STATUS" | sed -n 's/.*"id":"\\([^"]*\\).*/\\1/p')"
-if [ "$DISTRO_SUPPORTED" = "no" ]; then
-  echo "GATE_VERDICT=skip-distro"
-  echo "GATE_REASON=$DISTRO_ID"
-  PRIVILEGED_SECTION_SKIP=1
-else
-  echo "GATE_VERDICT=run"
-fi
-echo "FINAL_SKIP=$PRIVILEGED_SECTION_SKIP"
+public_ingress_preflight public 1 no fedora
+echo "SHOULD_NOT_REACH=yes"
 `,
   });
-  assert.match(out, /GATE_VERDICT=skip-distro/);
-  assert.match(out, /GATE_REASON=fedora/);
-  assert.match(out, /FINAL_SKIP=1/);
+  // die() exits 1; the tail message must be the "Nothing has been installed."
+  // distro wording.
+  assert.match(out, /Cannot complete the install: distro fedora is not in the v1 supported list/);
+  assert.match(out, /Nothing has been installed\./);
+  assert.match(out, /bring your own proxy/);
+  assert.doesNotMatch(out, /SHOULD_NOT_REACH=yes/);
 });
 
-test("install.sh privileged section: sudo missing → SKIP (issue §3)", () => {
-  // When \`sudo\` is not on PATH (e.g. minimal container, custom VPS),
-  // the gate must bail with a clear bring-your-own-proxy hint rather
-  // than half-installing. We mock \`command\` to hide \`sudo\` and
-  // \`node\` (which only runs the distro check first).
-  const out = runMain({
-    stubs: `
-# Hide sudo from \`command -v\`.
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "sudo" ]; then return 1; fi
-  builtin command "$@"
-}
-export -f command
-`,
+test("BET-980 preflight: public path + no root → fatal (die) and names all three alternatives", () => {
+  const out = runBootstrap({
     preBody: `
-PRIVILEGED_SECTION_SKIP=0
-DRY_RUN=0
-# Pretend distro check passed (ubuntu), so the gate proceeds to the sudo check.
-NODE() { printf '{"id":"ubuntu","idLike":"debian","debianLike":true,"supported":true,"reason":"supported Debian/Ubuntu family"}\\n'; }
-export -f NODE
-# (The distro check would set PRIVILEGED_SECTION_SKIP=0; we simulate that.)
-if ! command -v sudo >/dev/null 2>&1; then
-  echo "GATE_VERDICT=skip-no-sudo"
-  PRIVILEGED_SECTION_SKIP=1
-fi
-echo "FINAL_SKIP=$PRIVILEGED_SECTION_SKIP"
+public_ingress_preflight public 0 yes ubuntu
+echo "SHOULD_NOT_REACH=yes"
 `,
   });
-  assert.match(out, /GATE_VERDICT=skip-no-sudo/);
-  assert.match(out, /FINAL_SKIP=1/);
+  assert.match(out, /Cannot complete the install: giving this box a public HTTPS address/);
+  assert.match(out, /Nothing has been installed\./);
+  // All three recovery alternatives must be named (D3).
+  assert.match(out, /Install as root/);
+  assert.match(out, /ssh root@/);
+  assert.match(out, /Use Tailscale/);
+  assert.match(out, /sudo tailscale up/);
+  assert.match(out, /Grant this user sudo access/);
+  assert.doesNotMatch(out, /SHOULD_NOT_REACH=yes/);
 });
 
-test("install.sh privileged section: sudo -n true fails → SKIP (issue §3)", () => {
-  // sudo IS installed but \`sudo -n true\` exits non-zero (no
-  // passwordless rule for the current user). The gate must bail
-  // cleanly without half-installing.
-  const out = runMain({
-    stubs: `
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "sudo" ]; then return 0; fi
-  builtin command "$@"
-}
-sudo() {
-  # Pretend every sudo invocation fails (interactive password prompt).
-  return 1
-}
-export -f command sudo
-`,
+test("BET-980 preflight: tailscale path + no root → NOT fatal (gate passes)", () => {
+  const out = runBootstrap({
     preBody: `
-PRIVILEGED_SECTION_SKIP=0
-DRY_RUN=0
-# Pretend distro check passed.
-NODE() { printf '{"id":"ubuntu","idLike":"debian","debianLike":true,"supported":true,"reason":"supported Debian/Ubuntu family"}\\n'; }
-export -f NODE
-if ! sudo -n true 2>/dev/null; then
-  echo "GATE_VERDICT=skip-no-passwordless-sudo"
-  PRIVILEGED_SECTION_SKIP=1
-fi
-echo "FINAL_SKIP=$PRIVILEGED_SECTION_SKIP"
+public_ingress_preflight tailscale 0 no unknown
+echo "REACHED=yes"
 `,
   });
-  assert.match(out, /GATE_VERDICT=skip-no-passwordless-sudo/);
-  assert.match(out, /FINAL_SKIP=1/);
+  assert.match(out, /REACHED=yes/);
+  // No die message: the install must be able to proceed without root.
+  assert.doesNotMatch(out, /✗ Cannot complete the install/);
 });
 
-test("install.sh privileged section: DRY_RUN=1 skips the gates (always shows the plan)", () => {
-  // --dry-run must show every step's `[dry-run] would …` line, regardless
-  // of distro / sudo. We mock both \`command -v sudo\` (returns 1) and
-  // \`node\` (returns a non-Debian distro) and assert the gate is
-  // BYPASSED (i.e. PRIVILEGED_SECTION_SKIP stays 0).
-  const out = runMain({
-    stubs: `
-command() {
-  if [ "$1" = "-v" ] && [ "$2" = "sudo" ]; then return 1; fi
-  builtin command "$@"
-}
-export -f command
-`,
+test("BET-980 preflight: macOS path + no root → NOT fatal (gate passes)", () => {
+  const out = runBootstrap({
     preBody: `
-DRY_RUN=1
-PRIVILEGED_SECTION_SKIP=0
-# In dry-run mode the gate block is wrapped in \`if [ "$DRY_RUN" != "1" ]\`,
-# so the gate's commands don't run. Simulate by just asserting the
-# branch behavior directly.
-if [ "$DRY_RUN" != "1" ]; then
-  echo "GATE_BRANCH=running"
-else
-  echo "GATE_BRANCH=skipped-in-dry-run"
-  PRIVILEGED_SECTION_SKIP=0
-fi
-echo "FINAL_SKIP=$PRIVILEGED_SECTION_SKIP"
+public_ingress_preflight macos 0 no unknown
+echo "REACHED=yes"
 `,
   });
-  assert.match(out, /GATE_BRANCH=skipped-in-dry-run/);
-  assert.match(out, /FINAL_SKIP=0/);
+  assert.match(out, /REACHED=yes/);
+  assert.doesNotMatch(out, /✗ Cannot complete the install/);
+});
+
+test("BET-980: PRIVILEGED_SECTION_SKIP no longer appears in install.sh (degrade path cannot creep back)", () => {
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  assert.equal(
+    src.split("PRIVILEGED_SECTION_SKIP").length - 1,
+    0,
+    "the degraded-success flag and its guard sites must be fully removed from install.sh",
+  );
+});
+
+test("BET-980: the public-path outcome failures are fatal (die), not warn-and-continue", () => {
+  // D4 + the all-or-nothing rule: DNS timeout, Caddy vhost write failure, and
+  // the Caddy reload all DIE on the public path — the CADDY_E_SKIP /
+  // DNS_TIMED_OUT warn-and-continue machinery is gone. Static guard so the
+  // degraded-success shape can't silently return.
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  assert.doesNotMatch(src, /CADDY_E_SKIP/);
+  assert.doesNotMatch(src, /DNS_TIMED_OUT/);
+  assert.match(src, /wait-for-dns[\s\S]*?\|\| die/);
+  assert.match(src, /reload caddy[\s\S]*?\|\| die/);
+  assert.match(src, /install_root_file[\s\S]*?\|\| die/);
 });
 
 // ----------------------------------------------------------------------------
-// install.sh — step 7.5.E mid-way sudo failure (Block 1 follow-up).
+// install.sh — step 7.5.E all-or-nothing (BET-980, supersedes BET-205 §3/§4).
 // ----------------------------------------------------------------------------
 //
-// The reviewer found that step 7.5.E's privileged calls (sudo -n tee /
-// sudo -n mv / sudo -n bash / sudo -n systemctl reload) all `die()` on
-// failure, which breaks the bring-your-own-proxy path (Block 1 of the
-// review). The follow-up replaced those die calls with a CADDY_E_SKIP
-// flag that warns + skips the rest of 7.5.E so the install reaches the
-// pair-code print (step 8) regardless of mid-way sudo failures.
-//
-// These tests replicate the step 7.5.E control flow inline (we can't run
-// the install body end-to-end without root). They assert that:
-//   (a) When sudo -n tee to /etc/caddy/Caddyfile.d/manta.caddy fails,
-//       CADDY_E_SKIP=1 is set (no die).
-//   (b) When CADDY_E_SKIP=1, the systemctl reload sub-task is skipped
-//       (the port-check that used to run here was deleted in BET-442).
-//   (c) The install proceeds to the pair-code step (step 8) regardless.
-
-test("install.sh step 7.5.E: sudo -n tee fails → CADDY_E_SKIP=1 (no die, continue to step 8)", () => {
-  // Mirror the install.sh step 7.5.E control flow exactly. We replace
-  // `sudo -n tee` with a failing stub and verify the install reaches
-  // the pair-code step. We use a temp dir for CADDY_DIR_D so the test
-  // works without root (real install paths use /etc/caddy/Caddyfile.d
-  // but the control flow is identical).
-  const out = runMain({
-    stubs: `
-# Allow sudo -n true to pass the upfront gate.
-sudo() {
-  if [ "$1" = "-n" ] && [ "$2" = "true" ]; then return 0; fi
-  return 1
-}
-export -f sudo
-# Create a temp CADDY_DIR_D the test owns.
-CADDY_DIR_D="$(mktemp -d)/Caddyfile.d"
-mkdir -p "$CADDY_DIR_D"
-export CADDY_DIR_D
-`,
-    preBody: `
-PRIVILEGED_SECTION_SKIP=0
-BOX_ID_FOR_GATEWAY="0123456789abcdef0123456789abcdef"
-CADDY_E_SKIP=0
-# Note: CADDY_DIR_D is exported by the stubs section above.
-if [ -d "$CADDY_DIR_D" ]; then
-  if ! NODE=true sudo -n tee "$CADDY_DIR_D/manta.caddy" >/dev/null; then
-    echo "STEP_RESULT=warn-and-skip"
-    CADDY_E_SKIP=1
-  else
-    echo "STEP_RESULT=ok"
-  fi
-else
-  echo "STEP_RESULT=conf.d-missing"
-fi
-echo "FINAL_CADDY_E_SKIP=$CADDY_E_SKIP"
-echo "STEP_8_REACHED=yes"
-`,
-  });
-  assert.match(out, /STEP_RESULT=warn-and-skip/);
-  assert.match(out, /FINAL_CADDY_E_SKIP=1/);
-  assert.match(out, /STEP_8_REACHED=yes/);
-});
-
-test("install.sh step 7.5.E: conf.d missing + sudo bash append fails → CADDY_E_SKIP=1", () => {
-  // Companion test: when /etc/caddy/Caddyfile.d doesn't exist (the
-  // "conf.d missing" branch on a non-standard Caddy install), and the
-  // inline-mode `sudo -n bash` append fails, the install must still
-  // skip the rest of step 7.5.E (not die) and reach step 8. We use
-  // a temp dir to avoid touching /etc/caddy (root required).
-  const out = runMain({
-    stubs: `
-sudo() {
-  if [ "$1" = "-n" ] && [ "$2" = "true" ]; then return 0; fi
-  return 1
-}
-export -f sudo
-CADDY_DIR_D="$(mktemp -d)/Caddyfile.d"
-CADDY_DIR_PARENT="$(mktemp -d)"
-CADDYFILE="$CADDY_DIR_PARENT/Caddyfile"
-export CADDY_DIR_D CADDYFILE
-`,
-    preBody: `
-PRIVILEGED_SECTION_SKIP=0
-BOX_ID_FOR_GATEWAY="0123456789abcdef0123456789abcdef"
-CADDY_E_SKIP=0
-if [ -d "$CADDY_DIR_D" ]; then
-  echo "STEP_RESULT=conf.d-exists"
-else
-  # Inline branch: append a marker-bracketed block to the main Caddyfile.
-  if [ -f "$CADDYFILE" ] && grep -q '^# >>> manta >>>' "$CADDYFILE"; then
-    echo "STEP_RESULT=replace-block"
-  elif [ -f "$CADDYFILE" ]; then
-    if ! sudo -n bash -c "echo hello" -- "$CADDYFILE" >/dev/null 2>&1; then
-      echo "STEP_RESULT=append-failed"
-      CADDY_E_SKIP=1
-    fi
-  else
-    echo "STEP_RESULT=create-new"
-  fi
-fi
-echo "FINAL_CADDY_E_SKIP=$CADDY_E_SKIP"
-echo "STEP_8_REACHED=yes"
-`,
-  });
-  // We don't pin STEP_RESULT (the test env may or may not have the
-  // Caddyfile pre-existing) — we DO pin that the install reaches step
-  // 8 without dying, which is the core contract.
-  assert.match(out, /STEP_8_REACHED=yes/);
-});
-
-test("install.sh step 7.5.E: CADDY_E_SKIP=1 skips the systemctl reload sub-task", () => {
-  // Once CADDY_E_SKIP=1 is set, step 7.5.E must NOT run the sudo -n
-  // systemctl reload caddy call. The port-check that used to run here was
-  // deleted (BET-442) — only the reload remains, and it stays under the
-  // guard. We assert the guard's branch behavior inline.
-  const out = runMain({
-    preBody: `
-# Simulate the guard: when CADDY_E_SKIP=1, skip the sub-task.
-CADDY_E_SKIP=1
-RELOAD_RAN=0
-if [ "$CADDY_E_SKIP" = "0" ]; then
-  RELOAD_RAN=1
-else
-  RELOAD_RAN=0
-fi
-echo "RELOAD_RAN=$RELOAD_RAN"
-`,
-  });
-  assert.match(out, /RELOAD_RAN=0/);
-});
-
-test("install.sh step 7.5.E: CADDY_E_SKIP=0 (no failure) runs the systemctl reload", () => {
-  // Companion test: when the Caddyfile write succeeds (CADDY_E_SKIP=0),
-  // the systemctl reload sub-task DOES run. Pins the happy-path contract.
-  const out = runMain({
-    preBody: `
-CADDY_E_SKIP=0
-RELOAD_RAN=0
-if [ "$CADDY_E_SKIP" = "0" ]; then
-  RELOAD_RAN=1
-fi
-echo "RELOAD_RAN=$RELOAD_RAN"
-`,
-  });
-  assert.match(out, /RELOAD_RAN=1/);
-});
+// The old "warn + CADDY_E_SKIP + continue to step 8" degrade machinery is
+// deleted. The static guards in "BET-980: the public-path outcome failures
+// are fatal" above pin that every public-path failure in step 7.5.E now
+// `die`s, so the unreachable "Installed."/pairing output on a failing box is
+// impossible by construction. No inline replication of the control flow is
+// needed (or possible) any more — the earlier inline tests mirrored a manual
+// flow that no longer exists.
 
 // ----------------------------------------------------------------------------
 // Tailscale ingress path (BET-267)

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -3219,6 +3219,28 @@ test("BET-980: the public-path outcome failures are fatal (die), not warn-and-co
   assert.match(src, /install_root_file[\s\S]*?\|\| die/);
 });
 
+test("BET-980: the gateway fatality is gated on SKIP_PUBLIC_TLS, not INGRESS_MODE (macOS/tailscale stay warn)", () => {
+  // The gateway-register B/C block runs on ALL ingress paths (the APNs token
+  // is needed on every path). Its fatal branch must key off SKIP_PUBLIC_TLS —
+  // NOT `INGRESS_MODE == public`. On a macOS box INGRESS_MODE is "public"
+  // (no tailscale up) even though SKIP_PUBLIC_TLS=1, so keying on INGRESS_MODE
+  // wrongly turned a stubbed gateway failure into a fatal on macOS and broke
+  // the macos-install-smoke CI. Regression guard: the no-box-id and
+  // register-POST die branches both gate on SKIP_PUBLIC_TLS.
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  assert.doesNotMatch(src, /\$INGRESS_MODE" = "public"/, "gateway fatality must not key on INGRESS_MODE");
+  assert.match(
+    src,
+    /\[ -z "\$BOX_ID_FOR_GATEWAY" \][\s\S]*?\[ "\$DRY_RUN" != "1" \] && \[ "\$SKIP_PUBLIC_TLS" != "1" \]/,
+    "no-box-id fatality must be gated on SKIP_PUBLIC_TLS (public path only)",
+  );
+  assert.match(
+    src,
+    /if \[ "\$SKIP_PUBLIC_TLS" != "1" \]; then\n[ \t]+die "gateway registration POST failed/,
+    "gateway register-POST fatality must be gated on SKIP_PUBLIC_TLS (public path only)",
+  );
+});
+
 // ----------------------------------------------------------------------------
 // install.sh — step 7.5.E all-or-nothing (BET-980, supersedes BET-205 §3/§4).
 // ----------------------------------------------------------------------------

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -5174,14 +5174,17 @@ test("install.sh writes service-read config files via install_root_file, never `
 // and therefore fired 100% of the time, falsely. Assertions are textual so a
 // regression in either success-print guard is caught here.
 
-test("install.sh prints `ok \"caddy reloaded.\"` only on success (preceded by `else`) (BET-442)", () => {
+test("install.sh prints `ok \"caddy reloaded.\"` only on success (the reload is fatal) (BET-442 / BET-980)", () => {
   const src = readFileSync(INSTALL_SH, "utf-8");
   const matches = src.split("\n").filter((l) => /ok "caddy reloaded\."/.test(l));
   assert.strictEqual(matches.length, 1, "`ok \"caddy reloaded.\"` must appear exactly once");
-  const line = matches[0];
-  const idx = src.indexOf(line);
-  const before = src.slice(0, idx).split("\n").filter((l) => l.trim() !== "").pop();
-  assert.match(before, /^[ \t]*else[ \t]*$/, "`ok \"caddy reloaded.\"` must sit in the `else` branch (only reached on success)");
+  // The reload is `sudo -n systemctl reload caddy … \ || die …`; the `ok`
+  // below it is therefore only reachable when the reload succeeded.
+  assert.match(
+    src,
+    /reload caddy[^\n]*\\\n[ \t]*\|\| die/,
+    "the Caddy reload must be fatal (`|| die`), so `ok \"caddy reloaded.\"` is only printed on success",
+  );
 });
 
 test("install.sh prints `ok \"gateway registration complete.\"` only on success (no `|| warn \"merge-gateway failed`) (BET-442)", () => {


### PR DESCRIPTION
## BET-980 — Installer: a public-path install must complete or fail (delete the degraded-success path)

Implements the all-or-nothing rule for the `public` ingress path in `scripts/install.sh`.

### What changed

- **New capability preflight (step 3.5)**, before the first persistent mutation: on the `public` path, dies unless (a) the distro is Debian/Ubuntu-family and (b) the user can run commands as root (real root or `sudo -n true`). Runs with the vendored node/lib read straight out of the temp `$WORK/pkg` (same runtime step 7.5 uses), so nothing is written to `~/manta`, `~/.manta`, no systemd unit, no gateway registration. The tailscale and macOS paths never need root/distro and are untouched.
- **Deleted the degrade machinery**: `PRIVILEGED_SECTION_SKIP` and all five guard sites, the unsupported-distro / missing-sudo / no-passwordless-sudo warn blocks (including the `NOPASSWD:ALL` advice), and the "Skipping public-TLS step (bring-your-own-proxy…)" log line. `grep -c PRIVILEGED_SECTION_SKIP scripts/install.sh` → 0. `SKIP_PUBLIC_TLS` is kept (it expresses a *legitimate* no-public-TLS path) and its comment now flags the distinction.
- **D3 failure messages** via the `die` helper ("Nothing has been installed." + all three recovery alternatives for the root case; the distro wording minus the re-run continuation for the distro case).
- **D4 — public-path outcome failures are now fatal**: gateway registration POST, a missing box id, an undetermined public IP, the DNS poll timing out, the Caddy vhost write, and the Caddy reload all `die` with the "re-running is safe and preserves your box identity" recovery line. The old `CADDY_E_SKIP` / `DNS_TIMED_OUT` warn-and-continue machinery is removed entirely, so the "Installed." banner + pairing block are unreachable on any failing path.

### Placement note (deliberate)

The gate runs *after* the tarball is downloaded+extracted into a `mktemp` temp dir (cleaned by the EXIT trap) but *before* the atomic swap into `~/manta` and every subsequent write. This is the earliest point the vendored node exists to run `detect-distro`; the download/extract are not persistent state, so the acceptance "created NOTHING" holds.

### Base

`origin/main @ 02dcf540`

### Verification results

- PR branch (`multica/BET-980-all-or-nothing-install` @ `95a7bec9`):
  - `bash -n scripts/install.sh`: clean.
  - `grep -c PRIVILEGED_SECTION_SKIP scripts/install.sh`: 0.
  - typecheck: exit 0, no errors.
  - `npm test`: exit 0, **2136 pass / 0 fail** (incl. `scripts/install.test.mjs` 264 pass).
- Base (`main @ 02dcf540`): this PR touches only installer files; no new failures introduced vs base.

### New tests (`scripts/install.test.mjs`)
- preflight gate: public+unsupported distro → fatal; public+no root → fatal (names all three alternatives); tailscale+no root → NOT fatal; macOS+no root → NOT fatal.
- die messages contain "Nothing has been installed." (+ distro wording / all three alternatives).
- grep-guard asserting `PRIVILEGED_SECTION_SKIP` no longer appears in `install.sh`.
- static guard that the public-path outcome failures now `die` (no `CADDY_E_SKIP` / `DNS_TIMED_OUT`).
- updated the box-id / reload guards for the new fatal shape.


**Update (macOS fix, found by CI):** the gateway-register fatality is gated on `SKIP_PUBLIC_TLS`, NOT `INGRESS_MODE`. On a macOS box `INGRESS_MODE` is `"public"` (no tailscale up) even though `SKIP_PUBLIC_TLS=1`, so keying on `INGRESS_MODE` wrongly turned a stubbed gateway failure into a fatal on macOS and broke `macos-install-smoke`. Fixed + a regression guard added. Full CI now green incl. `install on macOS (Apple Silicon)` `typecheck-test` `duplication-gate`.


**Review-cycle fix (MANTA_INGRESS honored):** the preflight now resolves the ingress path via a NEW shared `resolve_ingress_mode` helper (honoring the `MANTA_INGRESS` override: auto | public | tailscale), used by BOTH the 3.5 preflight and step 7 — so the D1 gate and the persisted decision can never diverge. Notably `MANTA_INGRESS=public` forces the public path even when Tailscale is running, so such a box with no usable root is correctly gated (the reviewer Block). Step 7's old inline resolution was folded onto the same helper. Added regression tests for the Block scenario + `MANTA_INGRESS=public`/`auto` + Tailscale-up cases. All tests green.
