### PR TITLE
feat: auto-publish the plan page on plan_exit + surface it in the Plans tab

### DIFF
--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -714,13 +714,22 @@ export function ArtifactsPanel({
     previewSourceRef.current = null;
   };
 
-  // Publish-then-open a plan's companion page (BET-974): ONE gesture publishes
-  // the page on demand and opens the returned URL. The server reads the plan
-  // file itself (never the renderer); the URL comes from the response — never
-  // hand-built. Reused by both the row-body "open" and the plan row's action.
+  // Open a plan's companion page. When the page is already live (auto-published
+  // on plan_exit, so `pageUrl` is set on the artifact) just open it — no
+  // re-publish. Otherwise fall back to BET-974's publish-then-open: ONE gesture
+  // publishes the page on demand and opens the returned URL. The server reads
+  // the plan file itself (never the renderer); the URL comes from the response
+  // or the artifact — never hand-built. Reused by both the row-body "open" and
+  // the plan row's action.
   const openPlanPage = (a: Artifact) => {
     if (!sessionId) return;
     setPlanError(null);
+    if (a.pageUrl) {
+      void window.api.openExternal(a.pageUrl!).catch((e: unknown) => {
+        setPlanError(String((e as Error)?.message ?? e));
+      });
+      return;
+    }
     void window.api
       .planPublish(sessionId, a.href)
       .then(({ url }) => window.api.openExternal(url))

--- a/src/renderer/artifacts.test.ts
+++ b/src/renderer/artifacts.test.ts
@@ -469,10 +469,41 @@ describe("plan artifacts", () => {
     ];
     const pages = [page({ subdomain: planSubdomain("ses_a")!, url: "https://box/pages/plan-sesa" })];
     const out = deriveArtifacts(messages, pages, "ses_a", [], "/proj");
-    // The live page also appears as a Link artifact; find the PLAN artifact.
-    const plan = out.find((a) => a.kind === "plan")!;
-    expect(plan).toBeTruthy();
+    expect(out).toHaveLength(1);
+    const plan = out[0];
+    expect(plan.kind).toBe("plan");
     expect(plan.pageUrl).toBe("https://box/pages/plan-sesa");
+  });
+
+  it("the auto-published plan page is NOT ALSO filed under Links (one artifact, not two)", () => {
+    const messages = [
+      msg("a", "assistant", [
+        { type: "tool", tool: "write", state: { status: "completed", input: { filePath: "/proj/.opencode/plans/x.md" } } },
+      ], 5000),
+    ];
+    const pages = [page({ subdomain: planSubdomain("ses_a")!, url: "https://box/pages/plan-sesa" })];
+    const out = deriveArtifacts(messages, pages, "ses_a", [], "/proj");
+    expect(out.map((a) => a.kind)).toEqual(["plan"]);
+  });
+
+  it("an unrelated (non-plan) served page still appears as a Link", () => {
+    const messages = [
+      msg("a", "assistant", [
+        { type: "tool", tool: "write", state: { status: "completed", input: { filePath: "/proj/.opencode/plans/x.md" } } },
+      ], 5000),
+    ];
+    const pages = [page({ subdomain: "preview", url: "https://box/pages/preview" })];
+    const out = deriveArtifacts(messages, pages, "ses_a", [], "/proj");
+    expect(out.map((a) => a.kind).sort()).toEqual(["link", "plan"]);
+  });
+
+  it("a read tool pointed at a plan path does NOT mint a plan artifact (no authoring signal)", () => {
+    const messages = [
+      msg("a", "assistant", [
+        { type: "tool", tool: "read", state: { status: "completed", input: { filePath: "/proj/.opencode/plans/x.md" } } },
+      ], 5000),
+    ];
+    expect(deriveArtifacts(messages, [], "ses_a", [], "/proj")).toEqual([]);
   });
 
   it("leaves pageUrl null when no plan page is live for the session", () => {

--- a/src/renderer/artifacts.test.ts
+++ b/src/renderer/artifacts.test.ts
@@ -7,6 +7,7 @@ import {
   countByKind,
   planStepCount,
   planStatus,
+  planSubdomain,
   type Artifact,
 } from "./artifacts";
 
@@ -418,6 +419,70 @@ describe("plan artifacts", () => {
   it("does not create a plan artifact from a plain .md path outside plans/", () => {
     const messages = [msg("a", "assistant", [textPart("wrote ./notes/ideas.md")], 1000)];
     expect(deriveArtifacts(messages, [], "ses_a")).toEqual([]);
+  });
+
+  it("derives a plan artifact from a write-tool part carrying the plan filePath (plan-mode flow)", () => {
+    // Plan mode writes the plan with the write tool (no prose mention), so the
+    // path lives in state.input.filePath, not a text part.
+    const messages = [
+      msg("a", "assistant", [
+        {
+          type: "tool",
+          tool: "write",
+          state: {
+            status: "completed",
+            input: {
+              filePath: "/proj/.opencode/plans/2026-08-15-auto-publish.md",
+              content: "# Auto-publish\n## Step one\n## Step two\n",
+            },
+          },
+        },
+      ], 5000),
+    ];
+    const out = deriveArtifacts(messages, [], "ses_a", [], "/proj");
+    expect(out).toHaveLength(1);
+    const plan = out[0];
+    expect(plan.kind).toBe("plan");
+    expect(plan.label).toBe("auto publish");
+    expect(plan.href).toBe("/proj/.opencode/plans/2026-08-15-auto-publish.md");
+    expect(plan.messageId).toBe("a");
+    expect(plan.planStepCount).toBe(2);
+    expect(plan.planStatus).toBe("draft");
+  });
+
+  it("does not emit plan + file artifacts for the same write part (no double-counting)", () => {
+    const messages = [
+      msg("a", "assistant", [
+        { type: "tool", tool: "write", state: { status: "completed", input: { filePath: "/proj/.opencode/plans/x.md" } } },
+      ], 5000),
+    ];
+    const out = deriveArtifacts(messages, [], "ses_a", [], "/proj");
+    expect(out.map((a) => a.kind)).toEqual(["plan"]);
+    expect(out.filter((a) => a.kind === "file")).toHaveLength(0);
+  });
+
+  it("populates pageUrl when a live plan page exists under the session's plan subdomain", () => {
+    const messages = [
+      msg("a", "assistant", [
+        { type: "tool", tool: "write", state: { status: "completed", input: { filePath: "/proj/.opencode/plans/2026-08-15-x.md" } } },
+      ], 5000),
+    ];
+    const pages = [page({ subdomain: planSubdomain("ses_a")!, url: "https://box/pages/plan-sesa" })];
+    const out = deriveArtifacts(messages, pages, "ses_a", [], "/proj");
+    // The live page also appears as a Link artifact; find the PLAN artifact.
+    const plan = out.find((a) => a.kind === "plan")!;
+    expect(plan).toBeTruthy();
+    expect(plan.pageUrl).toBe("https://box/pages/plan-sesa");
+  });
+
+  it("leaves pageUrl null when no plan page is live for the session", () => {
+    const messages = [msg("a", "assistant", [textPart(".opencode/plans/2026-08-15-x.md")], 1000)];
+    const out = deriveArtifacts(
+      messages,
+      [page({ subdomain: "unrelated", url: "https://box/pages/unrelated" })],
+      "ses_a",
+    );
+    expect(out[0].pageUrl).toBeNull();
   });
 
   it("no plan refs → panel-equivalent empty list", () => {

--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -209,6 +209,12 @@ function joinHref(cwd: string | null, rel: string): string {
   return cwd.endsWith("/") ? cwd + rel : cwd + "/" + rel;
 }
 
+// Only these tools set a plan path in their input because they AUTHOR the plan
+// file (or confirm it at plan_exit). A `read` tool pointed at a plan path is a
+// reference, not an authoring signal, and must not mint a plan artifact on its
+// own — the write/plan tool (or a prose mention) already does.
+const PLAN_AUTHORING_TOOLS = new Set(["write", "edit", "multiEdit", "patch", "plan", "plan_exit"]);
+
 // Plan paths live in different part shapes depending on how the plan was
 // authored. The classic announcing message mentions the path in PROSE (a text
 // part). But the plan-mode flow WRITES the plan with the `write`/`plan` tool,
@@ -217,19 +223,22 @@ function joinHref(cwd: string | null, rel: string): string {
 // reaches a text part. Scanning only text parts therefore missed every plan
 // created via the plan tool (BET-975/976 landed plan mode; this restores it).
 // Returns every distinct `.opencode/plans/*.md` reference found across text,
-// tool-input, and patch-file surfaces. Cheap by design: we never scan tool
-// output or file content, only path fields and prose.
+// plan-authoring tool-input, and patch-file surfaces. Cheap by design: we never
+// scan tool output or file content, only path fields and prose.
 function planRefsFromPart(part: OpencodePart): string[] {
   const out: string[] = [];
   const candidates: string[] = [];
   if (typeof part.text === "string") candidates.push(part.text);
   const raw = part as Record<string, unknown>;
-  const input = (raw.state as { input?: Record<string, unknown> } | undefined)?.input
-    ?? (raw.input as Record<string, unknown> | undefined);
-  if (input) {
-    for (const key of ["filePath", "path", "planPath"]) {
-      const v = input[key];
-      if (typeof v === "string") candidates.push(v);
+  const isTool = raw.type === "tool";
+  if (isTool && PLAN_AUTHORING_TOOLS.has(String(raw.tool ?? ""))) {
+    const input = (raw.state as { input?: Record<string, unknown> } | undefined)?.input
+      ?? (raw.input as Record<string, unknown> | undefined);
+    if (input) {
+      for (const key of ["filePath", "path", "planPath"]) {
+        const v = input[key];
+        if (typeof v === "string") candidates.push(v);
+      }
     }
   }
   if (Array.isArray(raw.files)) candidates.push(...raw.files.map(String));
@@ -264,9 +273,12 @@ function derivePlanArtifact(
   const rel = path.replace(/^\.\//, "");
   const label = planTitleFromPath(lastPathSegment(rel));
   // The published companion page, when it is live under this session's stable
-  // plan subdomain.
+  // plan subdomain AND belongs to this session (the 20-char slug truncates the
+  // session id, so two sessions sharing a long id prefix must not cross-link).
   const sub = planSubdomain(sessionId);
-  const pageUrl = sub ? (pages.find((p) => p.subdomain === sub)?.url ?? null) : null;
+  const pageUrl = sub
+    ? (pages.find((p) => p.subdomain === sub && p.sessionID === sessionId)?.url ?? null)
+    : null;
   return {
     id: "plan:" + rel.toLowerCase(),
     kind: "plan",
@@ -407,6 +419,11 @@ export function deriveArtifacts(
 
   for (const page of pages) {
     if (page.sessionID !== sessionId) continue;
+    // The auto-published plan page is already represented BY its Plan artifact
+    // (which carries `pageUrl`) — do not ALSO file it under Links. Without this,
+    // every completed plan polluted the Links tab + link-count badge with a
+    // `plan-<slug>` row (the plan-mode write made auto-publish the common path).
+    if (page.subdomain === planSubdomain(sessionId)) continue;
     out.push(derivePageArtifact(page, newestAnnouncingMessage(messages, page.url)));
   }
 

--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -29,6 +29,11 @@ export type Artifact = {
   planStatus?: PlanStatus;
   planStepCount?: number | null;
   planJobSessionId?: string | null; // the job's child session; null until a plan is linked to a job
+  // The hosted companion page URL for this plan, when one is live under the
+  // session's stable `plan-<shortSessionId>` subdomain. Auto-published on
+  // plan_exit (BET-977+); the Plans-row "Open published page" action opens it
+  // directly when present instead of publish-on-click.
+  pageUrl?: string | null;
 };
 
 const URL_RE = /https?:\/\/[^\s<>]+/g;
@@ -204,13 +209,64 @@ function joinHref(cwd: string | null, rel: string): string {
   return cwd.endsWith("/") ? cwd + rel : cwd + "/" + rel;
 }
 
+// Plan paths live in different part shapes depending on how the plan was
+// authored. The classic announcing message mentions the path in PROSE (a text
+// part). But the plan-mode flow WRITES the plan with the `write`/`plan` tool,
+// which records the path in `state.input.filePath` (and sometimes
+// `planPath`/`path`) plus a `patch` part listing the file — the path never
+// reaches a text part. Scanning only text parts therefore missed every plan
+// created via the plan tool (BET-975/976 landed plan mode; this restores it).
+// Returns every distinct `.opencode/plans/*.md` reference found across text,
+// tool-input, and patch-file surfaces. Cheap by design: we never scan tool
+// output or file content, only path fields and prose.
+function planRefsFromPart(part: OpencodePart): string[] {
+  const out: string[] = [];
+  const candidates: string[] = [];
+  if (typeof part.text === "string") candidates.push(part.text);
+  const raw = part as Record<string, unknown>;
+  const input = (raw.state as { input?: Record<string, unknown> } | undefined)?.input
+    ?? (raw.input as Record<string, unknown> | undefined);
+  if (input) {
+    for (const key of ["filePath", "path", "planPath"]) {
+      const v = input[key];
+      if (typeof v === "string") candidates.push(v);
+    }
+  }
+  if (Array.isArray(raw.files)) candidates.push(...raw.files.map(String));
+  for (const c of candidates) {
+    for (const m of c.matchAll(PLAN_REF_RE)) {
+      if (!out.includes(m[0])) out.push(m[0]);
+    }
+  }
+  return out;
+}
+
+// The stable subdomain a session's plan page is published under. MUST mirror
+// `planSubdomain` in src/server/planPage.mjs (PlanShortIdLen = 20) exactly —
+// the renderer uses it to match the served-pages registry to a plan artifact.
+// Deliberately duplicated rather than imported (it is a server module).
+const PLAN_SHORT_ID_LEN = 20;
+export function planSubdomain(sessionID: string | null | undefined): string | null {
+  if (typeof sessionID !== "string" || !sessionID) return null;
+  const slug = sessionID.toLowerCase().replace(/[^a-z0-9]/g, "").slice(0, PLAN_SHORT_ID_LEN);
+  if (!slug) return null;
+  return `plan-${slug}`;
+}
+
 function derivePlanArtifact(
   msg: OpencodeMessage,
   path: string,
   cwd: string | null,
+  announceText: string | null = null,
+  pages: ServedPageMeta[] = [],
+  sessionId: string | null = null,
 ): Artifact {
   const rel = path.replace(/^\.\//, "");
   const label = planTitleFromPath(lastPathSegment(rel));
+  // The published companion page, when it is live under this session's stable
+  // plan subdomain.
+  const sub = planSubdomain(sessionId);
+  const pageUrl = sub ? (pages.find((p) => p.subdomain === sub)?.url ?? null) : null;
   return {
     id: "plan:" + rel.toLowerCase(),
     kind: "plan",
@@ -225,9 +281,28 @@ function derivePlanArtifact(
     context: null,
     expiresAt: null,
     planStatus: planStatus({}),
-    planStepCount: planStepCount(messageText(msg)),
+    // Step count comes from the markdown where we found the plan: the
+    // message's prose when it announces the plan, else the write/plan tool's
+    // `content` when it authored the file (a tool-only message has no text
+    // part to derive from).
+    planStepCount: planStepCount(announceText ?? messageText(msg)),
     planJobSessionId: null, // set once a plan is linked to its implementing job
+    pageUrl,
   };
+}
+
+// The plan markdown for step-count derivation: the part's own prose, else the
+// tool-input `content` of the write/plan part that authored the file. Returns
+// null when the part carries neither.
+function partAnnounceText(part: OpencodePart): string | null {
+  if (typeof part.text === "string" && part.text.trim()) return part.text;
+  const raw = part as Record<string, unknown>;
+  const input = (raw.state as { input?: Record<string, unknown> } | undefined)?.input
+    ?? (raw.input as Record<string, unknown> | undefined);
+  if (input && typeof input.content === "string" && input.content.trim()) {
+    return input.content;
+  }
+  return null;
 }
 
 function derivePageArtifact(page: ServedPageMeta, matched: OpencodeMessage | null): Artifact {
@@ -313,16 +388,16 @@ export function deriveArtifacts(
     }
   }
 
-  // Plan artifacts: any text part (any role) may reference a plan file. The
-  // `.md` path is never an `https?://` URL and never a `file:` part, so a
-  // plan is never ALSO emitted as a link or a file (no double-counting).
+  // Plan artifacts: any part (text mention, or the write/plan tool + its patch)
+  // may carry a `.opencode/plans/*.md` path. The plan path is never an
+  // `https?://` URL and never a `file:` part, so a plan is never ALSO emitted
+  // as a link or a file (no double-counting).
   const plansByKey = new Map<string, Artifact>();
   for (const msg of messages) {
     for (const part of msg.parts) {
-      if (part.type !== "text") continue;
       if (part.synthetic || part.ignored) continue;
-      for (const m of (part.text ?? "").matchAll(PLAN_REF_RE)) {
-        const a = derivePlanArtifact(msg, m[0], cwd);
+      for (const ref of planRefsFromPart(part)) {
+        const a = derivePlanArtifact(msg, ref, cwd, partAnnounceText(part), pages, sessionId);
         const existing = plansByKey.get(a.key);
         if (!existing || a.at > existing.at) plansByKey.set(a.key, a);
       }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -229,9 +229,10 @@ async function autoPublishPlan({ sessionID, part }) {
   }
 }
 
-// The plan path the client (the `plan_exit` tool) reported. Mirrors the
-// renderer's `extractPlanData` precedence (chatUtils.ts): planPath, then path,
-// then filePath.
+// The plan path the client (the `plan_exit` tool) reported. Superset of the
+// renderer's `extractPlanData` precedence (chatUtils.ts: planPath ?? path); the
+// extra `filePath` fallback is harmless — readPlanMarkdown still confines to
+// the session dir and requires `.md`.
 function planPathFromPart(part) {
   const input = part?.state?.input;
   const p = input?.planPath ?? input?.path ?? input?.filePath;

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -186,6 +186,7 @@ function contextLimitFor(providerID, modelID) {
 const streamInterp = createStreamInterpreter({
   publish: (evt) => bus.publish(evt),
   contextLimitFor,
+  autoPublishPlan,
 });
 // BET-913 + BET-916 + BET-922: when a client (re)connects mid-state, replay the
 // current edge-only state so frames that only fire on an edge aren't lost —
@@ -202,6 +203,40 @@ bus.setSnapshot(() => streamInterp.snapshotState());
 // etc). Single source of truth — every endpoint that creates/deletes a
 // store entry uses this same deps object.
 const BUS_PUBLISH_DEPS = { publish: (evt) => bus.publish(evt) };
+
+// Auto-publish the plan companion page when a session's plan finishes (the
+// completed plan_exit frame relayed by streamInterp). Overrides BET-974's
+// publish-on-click with publish-on-exit: every completed plan gets a shareable
+// page (7-day TTL, replaced on revision). BEST-EFFORT + fire-and-forget — a box
+// with no public hostname, an unreadable plan file, or a publish failure must
+// never block or fail the prompt stream, so every path returns quietly.
+async function autoPublishPlan({ sessionID, part }) {
+  try {
+    const path = planPathFromPart(part);
+    if (!path) return;
+    const sessionDir = await oc.getSessionDirectory(sessionID);
+    if (!sessionDir) return;
+    const loaded = await readPlanMarkdown({ path, sessionDir }, {});
+    if (!loaded.ok) return;
+    const baseUrl = publicBaseUrl();
+    if (!baseUrl) return;
+    await publishPlanPage(
+      { sessionID, markdown: loaded.markdown, path, generatedAt: Date.now() },
+      { ...BUS_PUBLISH_DEPS, baseUrl },
+    );
+  } catch (e) {
+    console.error("[plan-page] auto-publish failed:", e?.message ?? e);
+  }
+}
+
+// The plan path the client (the `plan_exit` tool) reported. Mirrors the
+// renderer's `extractPlanData` precedence (chatUtils.ts): planPath, then path,
+// then filePath.
+function planPathFromPart(part) {
+  const input = part?.state?.input;
+  const p = input?.planPath ?? input?.path ?? input?.filePath;
+  return typeof p === "string" && p.length > 0 ? p : null;
+}
 
 // BET-675: materialized in-memory session/config state. tmux:list is served
 // from memory (never a per-request tmux shell-out), and `sync` deltas are

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -234,6 +234,7 @@ export function createStreamInterpreter({
   publish,
   now = () => Date.now(),
   contextLimitFor = () => null,
+  autoPublishPlan = () => {},
 }) {
   const sessions = new Map();
   // The same opencode event is delivered on BOTH the global stream and the
@@ -377,6 +378,11 @@ export function createStreamInterpreter({
           if (callID && !st.handledPlanCallIds.has(callID)) {
             st.handledPlanCallIds.add(callID);
             emit(sid, "planMode", { on: planNext });
+            // A COMPLETED plan_exit (mode off) publishes the plan companion page
+            // automatically — best-effort, fire-and-forget, never-awaited here so
+            // the prompt stream is not blocked. plan_enter never publishes. The
+            // same callID dedup above means one publish per exit.
+            if (planNext === false) void autoPublishPlan({ sessionID: sid, part });
           }
         }
         return;

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -5,11 +5,13 @@ import { ASSUMED_CONTEXT_TOKENS } from "../shared/streamInterpretation.mjs";
 
 function make(now = 500_000) {
   const events = [];
+  const published = [];
   const interp = createStreamInterpreter({
     publish: (e) => events.push(e),
     now: () => now,
+    autoPublishPlan: ({ sessionID, part }) => published.push({ sessionID, part }),
   });
-  return { interp, events };
+  return { interp, events, published };
 }
 
 const SID = "ses_main";
@@ -921,6 +923,73 @@ test("an errored plan_exit tool part emits NOTHING", () => {
     },
   });
   assert.equal(events.filter((e) => e.sub === "planMode").length, 0);
+});
+
+test("a completed plan_exit auto-publishes the plan page with the reported path", () => {
+  const { interp, published } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: {
+      sessionID: SID,
+      part: {
+        id: "p1",
+        type: "tool",
+        tool: "plan_exit",
+        callID: "toolu_exit",
+        state: {
+          status: "completed",
+          input: { planPath: ".opencode/plans/2026-08-15-auto-publish.md", plan: "# Auto-publish" },
+        },
+      },
+    },
+  });
+  assert.equal(published.length, 1);
+  assert.equal(published[0].sessionID, SID);
+  assert.equal(published[0].part.state.input.planPath, ".opencode/plans/2026-08-15-auto-publish.md");
+});
+
+test("a completed plan_enter does NOT auto-publish", () => {
+  const { interp, published } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: {
+      sessionID: SID,
+      part: { id: "p1", type: "tool", tool: "plan_enter", callID: "toolu_enter", state: { status: "completed" } },
+    },
+  });
+  assert.equal(published.length, 0);
+});
+
+test("an errored plan_exit does NOT auto-publish (the exit never happened)", () => {
+  const { interp, published } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: {
+      sessionID: SID,
+      part: { id: "p1", type: "tool", tool: "plan_exit", callID: "toolu_exit", state: { status: "error" } },
+    },
+  });
+  assert.equal(published.length, 0);
+});
+
+test("the same plan_exit callID auto-publishes once (deduped)", () => {
+  const { interp, published } = make();
+  const upd = {
+    type: "message.part.updated",
+    properties: {
+      sessionID: SID,
+      part: {
+        id: "p1",
+        type: "tool",
+        tool: "plan_exit",
+        callID: "toolu_exit",
+        state: { status: "completed", input: { planPath: ".opencode/plans/x.md" } },
+      },
+    },
+  };
+  interp.interpret(upd);
+  interp.interpret(upd);
+  assert.equal(published.length, 1);
 });
 
 test("the same planMode callID arriving twice emits once", () => {


### PR DESCRIPTION
## Summary
Overrides BET-974's "publish on click, not eagerly" for plans: now a **completed plan_exit** auto-publishes the plan companion page (7-day TTL, replaced on revision), and the published URL is surfaced directly on the Artifacts panel's **Plans** tab.

## Changes
- **server** (`streamInterp.mjs`, `index.mjs`): on a COMPLETED `plan_exit` (the planMode frame), fire-and-forget `autoPublishPlan` → `getSessionDirectory` + `readPlanMarkdown` + `publishPlanPage`. Best-effort: errored exits (Keep planning), unreadable plan files, and boxes with no public hostname all skip quietly; never blocks the prompt stream. Reuses the existing planMode callID dedup (one publish per exit).
- **renderer** (`artifacts.ts`): plan artifacts are now derived from the `write`/`plan` tool + `patch` parts (not only prose text parts), so plan-mode plans actually show up in the Plans tab (previously the path never reached a text part). Step count derives from the tool's `content` when there's no text part.
- **renderer** (`artifacts.ts`, `ArtifactsPanel.tsx`): re-add `pageUrl` on plan artifacts by matching the served-pages registry via the session's `plan-<shortId>` subdomain; the Plans-row "Open published page" opens it directly when live, falling back to publish-on-click.

## Verification
- `npm run typecheck` clean; `npm test` 2142 server; `npx vitest run` 2849 renderer (0 failures).
- New tests: streamInterp auto-publish trigger/dedup/errored-skip; plan artifact from a write-tool part; `pageUrl` populated/absent.