### PR TITLE
feat(renderer): show the plan page URL in the plan card before plan_exit

### DIFF
--- a/src/renderer/Button.tsx
+++ b/src/renderer/Button.tsx
@@ -57,6 +57,7 @@ export function Button({
   title,
   children,
   hook,
+  loading = false,
 }: {
   /** The visual tone. REQUIRED — the bare base is abstract (C4), so there is no safe default. */
   tone: keyof typeof BUTTON_TONE;
@@ -78,16 +79,24 @@ export function Button({
    * chrome, so it is not the `className` escape hatch the epic forbids.
    */
   hook?: string;
+  /**
+   * A transient resolving state (the action is in flight). Mirrors
+   * SplitButton.loading: the button reads as disabled + `aria-busy` until the
+   * work settles. Presentational — the caller owns the label that announces it.
+   */
+  loading?: boolean;
 }) {
+  const inert = disabled || loading;
   const className =
     `${hook ? `${hook} ` : ""}${BUTTON_BASE} ${BUTTON_TONE[tone]}` +
     (block ? ` ${BUTTON_BLOCK}` : "");
   return (
     <button
       type={type}
-      disabled={disabled}
+      disabled={inert}
       onClick={onClick}
       title={title}
+      aria-busy={loading || undefined}
       className={className}
     >
       {children}

--- a/src/renderer/Button.tsx
+++ b/src/renderer/Button.tsx
@@ -80,9 +80,9 @@ export function Button({
    */
   hook?: string;
   /**
-   * A transient resolving state (the action is in flight). Mirrors
-   * SplitButton.loading: the button reads as disabled + `aria-busy` until the
-   * work settles. Presentational — the caller owns the label that announces it.
+   * A transient resolving state (the action is in flight). The button renders
+   * as disabled + `aria-busy` until the work settles. Presentational — the
+   * caller owns the label that announces it.
    */
   loading?: boolean;
 }) {

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -13,7 +13,7 @@
 // badge, plain-language titles, checkbox question options and a button ladder.
 
 import { useMemo, useRef, useState, type ReactNode } from "react";
-import { DraftingCompass, Shield, HelpCircle, Check, Send, ChevronDown, ArrowUpRight } from "lucide-react";
+import { DraftingCompass, Shield, HelpCircle, Check, Send, ChevronDown, ArrowUpRight, Link2 } from "lucide-react";
 import type { PermissionRequest, ProgressRecord, QuestionRequest, OpencodeModel } from "../shared/types";
 import {
   buildQuestionAnswers,
@@ -511,8 +511,9 @@ export function QuestionCard({
 //
 // Upgrades the plan_exit question (detected EXACTLY via isPlanExitQuestion —
 // the matching `plan_exit` tool callID, never the question text) into a
-// dedicated card in the pinned card stack. Blocking tier: it is an unanswered
-// ask, rendered beside permission/question, never below an ambient card.
+// dedicated card. Rendered in the transcript TAIL, the same way the question
+// cards are (it used to be pinned in the card stack). It is an unanswered ask
+// like the questions beside it, never below an ambient card.
 //
 // The delegate split reuses the shared split control (SplitButton — the Button
 // chrome brother of SplitChip) fed by the EXISTING ModelMenu; model precedence
@@ -530,6 +531,8 @@ export function PlanCard({
   onStartDelegate,
   onRememberDelegateModel,
   onOpenInBrowser,
+  planUrl = null,
+  planPublishing = false,
 }: {
   data: { title: string; path?: string; metrics: { steps?: number; files?: number } };
   models: Array<[string, OpencodeModel[]]> | null;
@@ -545,6 +548,10 @@ export function PlanCard({
     feedback: string,
   ) => void;
   onRememberDelegateModel: (model: import("./chatShared").ModelSelection | null) => void;
+  /** Eagerly-published shareable page URL for this session's plan (before plan_exit). */
+  planUrl?: string | null;
+  /** True while the page is being published. */
+  planPublishing?: boolean;
 }) {
   // Level 1 of the model precedence — an explicit pick made on THIS card wins
   // while it is open. Written through to the remembered key on pick (see
@@ -601,6 +608,17 @@ export function PlanCard({
           className="flex-1 min-w-0 bg-transparent border-0 outline-none text-meta text-text placeholder:text-text-faint"
         />
       </div>
+      {/* Once the page is published (eager, before plan_exit) surface the URL so
+          the reader can open/share it without clicking anything. */}
+      {planUrl && (
+        <div
+          className="flex items-center gap-1 text-meta text-text-quiet mt-2 truncate"
+          title={planUrl}
+        >
+          <Link2 size={13} aria-hidden="true" className="shrink-0" />
+          <span className="truncate">{planUrl}</span>
+        </div>
+      )}
     </>
   );
 
@@ -636,11 +654,18 @@ export function PlanCard({
       <Button
         tone="ghost"
         onClick={onOpenInBrowser}
-        disabled={!data.path}
-        title={data.path ? "Publish this plan to a shareable page and open it" : undefined}
+        loading={planPublishing}
+        disabled={planPublishing}
+        title={
+          planUrl
+            ? "Open the published plan page"
+            : data.path
+              ? "Publish this plan to a shareable page and open it"
+              : undefined
+        }
         hook="manta-plan-open-page"
       >
-        See in browser
+        {planUrl ? "Open page" : planPublishing ? "Publishing…" : "See in browser"}
         <ArrowUpRight size={14} aria-hidden="true" />
       </Button>
       <div className="flex-1" />

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -655,7 +655,7 @@ export function PlanCard({
         tone="ghost"
         onClick={onOpenInBrowser}
         loading={planPublishing}
-        disabled={planPublishing}
+        disabled={planPublishing || (!planUrl && !data.path)}
         title={
           planUrl
             ? "Open the published plan page"

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -2419,15 +2419,20 @@ export function ChatPanel({
   // Eager publish of the plan companion page so the shareable URL shows up in
   // the card BEFORE plan_exit completes. The subdomain is stable per session
   // (`plan-<shortId>`), so re-publishing replaces the snapshot under the same
-  // URL. Fire-and-forget + deduped by path (publish once per plan file) — a
+  // URL. Fire-and-forget + deduped by the plan QUESTION (not the file path) —
+  // a "Keep planning" revision is a NEW question reusing the same path, so it
+  // re-publishes fresh content instead of serving the stale snapshot. A
   // failure is silent and falls back to publish-on-click.
   const [planUrl, setPlanUrl] = useState<string | null>(null);
   const [planPublishing, setPlanPublishing] = useState(false);
-  const publishedPlanPathRef = useRef<string | null>(null);
+  const publishedPlanQuestionRef = useRef<string | null>(null);
   const publishPlanEager = useCallback(
-    (path: string) => {
-      if (!path || publishedPlanPathRef.current === path) return;
-      publishedPlanPathRef.current = path;
+    (qId: string, path: string) => {
+      if (!path || publishedPlanQuestionRef.current === qId) return;
+      publishedPlanQuestionRef.current = qId;
+      // New/revised plan → drop the old URL and show the loading state until
+      // the fresh page is published.
+      setPlanUrl(null);
       setPlanPublishing(true);
       window.api
         .planPublish(sessionId, path)
@@ -2438,14 +2443,17 @@ export function ChatPanel({
     [sessionId],
   );
   useEffect(() => {
+    // Only the panel the user is actually viewing publishes eagerly; a hidden
+    // panel's plan page is published lazily once it becomes active.
+    if (!isActive) return;
     for (const q of planQuestions) {
       const data = planDataByQuestion.get(q.id);
       if (data?.path) {
-        publishPlanEager(data.path);
+        publishPlanEager(q.id, data.path);
         break;
       }
     }
-  }, [planQuestions, planDataByQuestion, publishPlanEager]);
+  }, [planQuestions, planDataByQuestion, publishPlanEager, isActive]);
 
   // Delegate split control (BET-951).
   // Level 3 of the model precedence — "same as current" means the BUILD model,

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -2416,6 +2416,37 @@ export function ChatPanel({
     [planQuestions, messages],
   );
 
+  // Eager publish of the plan companion page so the shareable URL shows up in
+  // the card BEFORE plan_exit completes. The subdomain is stable per session
+  // (`plan-<shortId>`), so re-publishing replaces the snapshot under the same
+  // URL. Fire-and-forget + deduped by path (publish once per plan file) — a
+  // failure is silent and falls back to publish-on-click.
+  const [planUrl, setPlanUrl] = useState<string | null>(null);
+  const [planPublishing, setPlanPublishing] = useState(false);
+  const publishedPlanPathRef = useRef<string | null>(null);
+  const publishPlanEager = useCallback(
+    (path: string) => {
+      if (!path || publishedPlanPathRef.current === path) return;
+      publishedPlanPathRef.current = path;
+      setPlanPublishing(true);
+      window.api
+        .planPublish(sessionId, path)
+        .then(({ url }) => setPlanUrl(url))
+        .catch(() => { /* fall back to publish-on-click */ })
+        .finally(() => setPlanPublishing(false));
+    },
+    [sessionId],
+  );
+  useEffect(() => {
+    for (const q of planQuestions) {
+      const data = planDataByQuestion.get(q.id);
+      if (data?.path) {
+        publishPlanEager(data.path);
+        break;
+      }
+    }
+  }, [planQuestions, planDataByQuestion, publishPlanEager]);
+
   // Delegate split control (BET-951).
   // Level 3 of the model precedence — "same as current" means the BUILD model,
   // not the plan model the composer chip may be showing while plan mode is on.
@@ -2536,6 +2567,44 @@ export function ChatPanel({
     [sessionId],
   );
 
+  // The plan_exit card, built here and mounted in the transcript tail the SAME
+  // way the questions are (it used to be pinned in the CardStack). Building the
+  // element here keeps the closures over the plan data + the eager-published
+  // URL; Transcript just mounts it. The stable `key={q.id}` preserves the
+  // card's internal state (feedback / open model menu) across updates.
+  const planCard = useMemo(() => {
+    for (const q of planQuestions) {
+      const data = planDataByQuestion.get(q.id);
+      if (!data) continue;
+      return (
+        <PlanCard
+          key={q.id}
+          data={data}
+          models={delegateSelectable}
+          remembered={rememberedDelegateModel}
+          sessionModel={sessionModel}
+          buildModelName={activeModel?.name ?? ""}
+          atDelegateCap={atDelegateCap}
+          onBuildHere={(fb) => void buildHere(q, fb)}
+          onKeepPlanning={(fb) => void keepPlanning(q, fb)}
+          onStartDelegate={(m, fb) => startPlanDelegate(q, m, fb)}
+          onRememberDelegateModel={rememberDelegateModel}
+          planUrl={planUrl}
+          planPublishing={planPublishing}
+          onOpenInBrowser={() => {
+            // Live page already published → just open it (no re-publish).
+            if (planUrl) {
+              void window.api.openExternal(planUrl).catch(() => { /* best-effort */ });
+              return;
+            }
+            if (data.path) openPlanInBrowser(data.path);
+          }}
+        />
+      );
+    }
+    return null;
+  }, [planQuestions, planDataByQuestion, delegateSelectable, rememberedDelegateModel, sessionModel, activeModel, atDelegateCap, buildHere, keepPlanning, startPlanDelegate, rememberDelegateModel, planUrl, planPublishing, openPlanInBrowser]);
+
   const cards = useMemo<PinnedCardRender[]>(() => {
     const list: PinnedCardRender[] = [];
     const block = (id: string, order: number, render: React.ReactNode): PinnedCardRender =>
@@ -2588,33 +2657,9 @@ export function ChatPanel({
           <BlockedProgressCard progress={liveProgress} />,
         ));
       }
-      // Plan card (BET-951): the plan_exit question, blocking tier — it is an
-      // unanswered ask, beside permission, never below an ambient card. The
-      // delegate split reuses SplitChip + the existing ModelMenu (no new
-      // split/dropdown surface).
-      planQuestions.forEach((q) => {
-        const data = planDataByQuestion.get(q.id);
-        if (!data) return;
-        list.push(block(
-          `plan-${q.id}`, blockOrder(`plan-${q.id}`),
-          <PlanCard
-            key={q.id}
-            data={data}
-            models={delegateSelectable}
-            remembered={rememberedDelegateModel}
-            sessionModel={sessionModel}
-            buildModelName={activeModel?.name ?? ""}
-            atDelegateCap={atDelegateCap}
-            onBuildHere={(fb) => void buildHere(q, fb)}
-            onKeepPlanning={(fb) => void keepPlanning(q, fb)}
-            onStartDelegate={(m, fb) => startPlanDelegate(q, m, fb)}
-            onRememberDelegateModel={rememberDelegateModel}
-            onOpenInBrowser={() => {
-              if (data.path) openPlanInBrowser(data.path);
-            }}
-          />,
-        ));
-      });
+      // NOTE: the plan_exit card (PlanCard) is intentionally NOT here any more
+      // — it now renders in the transcript tail, mounted the same way as the
+      // question cards (see `planCard`, passed to <Transcript>).
     }
     // Ambient tier — fixed priority, independent of arrival order.
     if (retryInfo) list.push(amb("retry",
@@ -2702,7 +2747,7 @@ export function ChatPanel({
         </div>));
     }
     return list;
-  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipProposal, shipBusy, shipError, liveProgress, planQuestions, planDataByQuestion, delegateSelectable, rememberedDelegateModel, sessionModel, activeModel, atDelegateCap, buildHere, keepPlanning, startPlanDelegate, rememberDelegateModel, openPlanInBrowser]);
+  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipProposal, shipBusy, shipError, liveProgress]);
 
 
   if (error || transcriptLoadError) {
@@ -2849,6 +2894,7 @@ export function ChatPanel({
             onRetryVoiceNote={retryVoiceNote}
             onReplyQuestion={replyQuestion}
             onRejectQuestion={rejectQuestion}
+            planCard={planCard}
             scrollerElRef={scrollerElRef}
             followingRef={followingRef}
             onFollowingChange={setFollowing}

--- a/src/renderer/PlanCard.test.tsx
+++ b/src/renderer/PlanCard.test.tsx
@@ -115,6 +115,34 @@ describe("PlanCard (BET-951)", () => {
     h = render({ remembered });
     expect(h.text()).toContain("Claude");
   });
+
+  it("shows a loading state on the page button while the page is publishing", () => {
+    h = render({ planPublishing: true });
+    expect(h.text()).toContain("Publishing…");
+    const btn = h.container.querySelector(".manta-plan-open-page") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+    expect(btn.getAttribute("aria-busy")).toBe("true");
+  });
+
+  it("renders the published URL and an 'Open page' action once the page is live", () => {
+    h = render({ planUrl: "https://box/pages/plan-sesa" });
+    expect(h.text()).toContain("https://box/pages/plan-sesa");
+    expect(h.text()).toContain("Open page");
+    const btn = h.container.querySelector(".manta-plan-open-page") as HTMLButtonElement;
+    expect(btn.getAttribute("title")).toMatch(/published plan page/);
+    expect(btn.disabled).toBe(false);
+  });
+
+  it("falls back to publish-on-click 'See in browser' when no page is live yet", () => {
+    let fired = false;
+    h = render({ onOpenInBrowser: () => { fired = true; } });
+    expect(h.text()).toContain("See in browser");
+    expect(h.container.querySelector(".manta-plan-open-page")).toBeTruthy();
+    const btn = h.container.querySelector(".manta-plan-open-page") as HTMLButtonElement;
+    expect(btn.disabled).toBe(false);
+    act(() => btn.click());
+    expect(fired).toBe(true);
+  });
 });
 
 describe("QuestionCard still renders an ordinary (non-plan) question (BET-951)", () => {

--- a/src/renderer/PlanCard.test.tsx
+++ b/src/renderer/PlanCard.test.tsx
@@ -143,6 +143,12 @@ describe("PlanCard (BET-951)", () => {
     act(() => btn.click());
     expect(fired).toBe(true);
   });
+
+  it("disables the page button when there is no plan path and no live URL", () => {
+    h = render({ data: { ...DATA, path: undefined } });
+    const btn = h.container.querySelector(".manta-plan-open-page") as HTMLButtonElement;
+    expect(btn.disabled).toBe(true);
+  });
 });
 
 describe("QuestionCard still renders an ordinary (non-plan) question (BET-951)", () => {

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -66,6 +66,10 @@ export type TranscriptContext = {
   questions: QuestionRequest[];
   onReplyQuestion: (q: QuestionRequest, answers: string[][]) => void;
   onRejectQuestion: (q: QuestionRequest) => void;
+  // The plan_exit card (the Build/Delegate/Keep-planning ask), rendered in the
+  // tail the same way as question cards. Built by ChatPanel (closures over the
+  // plan data + session); Transcript just mounts it.
+  planCard?: React.ReactNode;
   // BET-837: the pending voice-note row (upload/transcribe in flight) renders
   // here — after the message list, before the working indicator. When it
   // resolves into a real note it lands as a VoicePlayer on its message row.
@@ -301,6 +305,14 @@ export function TranscriptTail({ context }: { context: TranscriptContext }) {
           ))}
         </div>
       )}
+      {/* The plan_exit card renders in the tail exactly like the question cards
+          above — same chrome, same scroll-with-the-conversation placement (it
+          used to be pinned in the card stack). */}
+      {context.planCard && (
+        <ErrorBoundary>
+          {context.planCard}
+        </ErrorBoundary>
+      )}
     </div>
   );
 }
@@ -346,6 +358,8 @@ export type TranscriptProps = {
   onRetryVoiceNote: (noteId: string) => void;
   onReplyQuestion: (q: QuestionRequest, answers: string[][]) => void;
   onRejectQuestion: (q: QuestionRequest) => void;
+  // The plan_exit card, mounted in the tail (see TranscriptContext.planCard).
+  planCard?: React.ReactNode;
   // The Virtuoso scroll container, published upward so ChatPanel's
   // scrollToTail can address the real bottom (Footer included).
   scrollerElRef: React.MutableRefObject<HTMLElement | null>;
@@ -383,6 +397,7 @@ export function Transcript({
   onRetryVoiceNote,
   onReplyQuestion,
   onRejectQuestion,
+  planCard,
   scrollerElRef,
   followingRef,
   onFollowingChange,
@@ -457,6 +472,7 @@ export function Transcript({
     questions,
     onReplyQuestion,
     onRejectQuestion,
+    planCard,
     pendingVoiceNote,
     onRetryVoiceNote,
   };


### PR DESCRIPTION
## Summary
The plan exit card (**Build here / Delegate ▾ / ... / Keep planning**) now shows the **shareable plan page URL before the user exits plan mode**, and is rendered in the **transcript tail the same way as the question cards** (instead of being pinned in the card stack above the composer).

## What changed
- **Eager publish**: the plan companion page is published the moment the card shows (deduplicated per plan file, fire-and-forget). The returned URL is surfaced right in the card.
- **Page button** (`Cards.tsx`): shows a **loading state** while the page is being built, becomes a live **"Open page ↗"** link once published, and falls back to publish-on-click otherwise.
- **`Button.loading`** (new): `aria-busy` + disabled while the action is in flight (mirrors `SplitButton.loading`).
- **Move to transcript tail**: `PlanCard` is built in ChatPanel and mounted via a new `TranscriptContext.planCard`, rendered in `TranscriptTail` beside the question cards. Removed from the pinned `CardStack`.

Uses the existing `/api/plan-page` publish endpoint unchanged; the plan subdomain (`plan-<shortId>`) is stable, so re-publishing replaces the snapshot and the URL stays current across "Keep planning" revisions. The post-exit auto-publish remains as a backstop.

## Verification
- `npm run typecheck` clean.
- `npx vitest run` — 2877 renderer tests pass (incl. 4 new PlanCard tests).
- `npm run test:server` — 1624 pass.

## Notes
- Worktree was rebased onto `origin/main` (was a stale probe branch lacking the plan-page feature).
- Native iOS client untouched (separate follow-up if desired).