### PR TITLE
fix(renderer): resolve plan path from the authoring tool for eager publish

### DIFF
--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -1,4 +1,5 @@
 import type { OpencodeMessage, OpencodePart, OutboxFile, ServedPageMeta } from "../shared/types";
+import { planRefsFromPart } from "./chatUtils";
 
 export type ArtifactKind = "link" | "image" | "file" | "plan";
 export type ArtifactOrigin = "user" | "agent";
@@ -166,11 +167,9 @@ function deriveOutboxArtifact(row: OutboxFile): Artifact {
 
 // A plan is genuinely BOTH a file and a link, so it gets its own kind rather
 // than being filed under either. Plan artifacts are derived from a plan file
-// path (`.opencode/plans/<created>-<slug>.md`) referenced in the session
-// transcript — opencode writes plans there when the session runs in plan mode.
-// Matches `.opencode/plans/<name>.md` wherever it appears (`./.opencode/...`
-// and absolute-prefixed paths both match from the `.opencode` segment).
-const PLAN_REF_RE = /\.opencode\/plans\/[\w.-]+\.md/g;
+// path (`.opencode/plans/<created>-<slug>.md`, matched by `planRefsFromPart` in
+// chatUtils) referenced in the session transcript — opencode writes plans there
+// when the session runs in plan mode.
 
 // Readable plan title from a plan filename: strip `.md` and the leading
 // `<YYYY-MM-DD>-` created-stamp opencode writes, then un-slug.
@@ -207,47 +206,6 @@ export function planStatus(opts: {
 function joinHref(cwd: string | null, rel: string): string {
   if (!cwd) return rel;
   return cwd.endsWith("/") ? cwd + rel : cwd + "/" + rel;
-}
-
-// Only these tools set a plan path in their input because they AUTHOR the plan
-// file (or confirm it at plan_exit). A `read` tool pointed at a plan path is a
-// reference, not an authoring signal, and must not mint a plan artifact on its
-// own — the write/plan tool (or a prose mention) already does.
-const PLAN_AUTHORING_TOOLS = new Set(["write", "edit", "multiEdit", "patch", "plan", "plan_exit"]);
-
-// Plan paths live in different part shapes depending on how the plan was
-// authored. The classic announcing message mentions the path in PROSE (a text
-// part). But the plan-mode flow WRITES the plan with the `write`/`plan` tool,
-// which records the path in `state.input.filePath` (and sometimes
-// `planPath`/`path`) plus a `patch` part listing the file — the path never
-// reaches a text part. Scanning only text parts therefore missed every plan
-// created via the plan tool (BET-975/976 landed plan mode; this restores it).
-// Returns every distinct `.opencode/plans/*.md` reference found across text,
-// plan-authoring tool-input, and patch-file surfaces. Cheap by design: we never
-// scan tool output or file content, only path fields and prose.
-function planRefsFromPart(part: OpencodePart): string[] {
-  const out: string[] = [];
-  const candidates: string[] = [];
-  if (typeof part.text === "string") candidates.push(part.text);
-  const raw = part as Record<string, unknown>;
-  const isTool = raw.type === "tool";
-  if (isTool && PLAN_AUTHORING_TOOLS.has(String(raw.tool ?? ""))) {
-    const input = (raw.state as { input?: Record<string, unknown> } | undefined)?.input
-      ?? (raw.input as Record<string, unknown> | undefined);
-    if (input) {
-      for (const key of ["filePath", "path", "planPath"]) {
-        const v = input[key];
-        if (typeof v === "string") candidates.push(v);
-      }
-    }
-  }
-  if (Array.isArray(raw.files)) candidates.push(...raw.files.map(String));
-  for (const c of candidates) {
-    for (const m of c.matchAll(PLAN_REF_RE)) {
-      if (!out.includes(m[0])) out.push(m[0]);
-    }
-  }
-  return out;
 }
 
 // The stable subdomain a session's plan page is published under. MUST mirror

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -135,10 +135,12 @@ import {
   isPlanExitQuestion,
   planMetrics,
   extractPlanData,
+  planPathsFromMessages,
+  planRefsFromPart,
   resolveDelegateModel,
 } from "./chatUtils";
 
-import type { OpencodeModel, OpencodeAgent, UsageSnapshot, OpencodeMessage, VoiceNoteRecord, ForgeInboxItem, QuestionRequest } from "../shared/types";
+import type { OpencodeModel, OpencodeAgent, UsageSnapshot, OpencodeMessage, OpencodePart, VoiceNoteRecord, ForgeInboxItem, QuestionRequest } from "../shared/types";
 
 
 
@@ -5121,6 +5123,92 @@ describe("extractPlanData", () => {
     expect(d.title).toBe("Build Agent");
     expect(d.metrics).toEqual({});
     expect(d.path).toBeUndefined();
+  });
+
+  it("resolves the plan path from the authoring tool when the plan_exit input is empty", () => {
+    // plan_exit (opencode's built-in) carries NO input — the path only lives in
+    // the `plan`-authoring tool that wrote the file. The tolerant fallback must
+    // surface it so the plan card can publish the companion page.
+    const q = planq("call-exit");
+    const msg: OpencodeMessage = {
+      info: {} as never,
+      parts: [
+        {
+          type: "tool",
+          id: "p-write",
+          messageID: "m1",
+          callID: "call-write",
+          tool: "plan",
+          state: { status: "completed", input: { filePath: ".opencode/plans/2026-08-15-fix.md" } },
+        },
+        {
+          type: "tool",
+          id: "p-exit",
+          messageID: "m2",
+          callID: "call-exit",
+          tool: "plan_exit",
+          state: { status: "completed", input: {} },
+        },
+      ],
+    };
+    const d = extractPlanData(q, [msg]);
+    expect(d.title).toBe("Plan complete");
+    expect(d.path).toBe(".opencode/plans/2026-08-15-fix.md");
+  });
+
+  it("plan_exit input wins over the transcript fallback", () => {
+    const q = planq("call-exit");
+    const msg: OpencodeMessage = {
+      info: {} as never,
+      parts: [
+        { type: "tool", id: "p-write", messageID: "m1", callID: "c-w", tool: "plan", state: { status: "completed", input: { filePath: ".opencode/plans/older.md" } } },
+        { type: "tool", id: "p-exit", messageID: "m2", callID: "call-exit", tool: "plan_exit", state: { status: "completed", input: { planPath: ".opencode/plans/newer.md" } } },
+      ],
+    };
+    const d = extractPlanData(q, [msg]);
+    expect(d.path).toBe(".opencode/plans/newer.md");
+  });
+});
+
+describe("planPathsFromMessages", () => {
+  const part = (over: Record<string, unknown>): OpencodePart =>
+    ({ type: "tool", id: "p", messageID: "m", ...over }) as OpencodePart;
+
+  it("collects .opencode/plans refs across text, tool input, and patch files", () => {
+    const msg: OpencodeMessage = {
+      info: {} as never,
+      parts: [
+        part({ type: "text", text: "Plan: .opencode/plans/a.md" }),
+        part({ tool: "write", state: { status: "completed", input: { filePath: ".opencode/plans/b.md" } } }),
+        part({ tool: "multiEdit", files: [".opencode/plans/c.md"] }),
+        part({ tool: "read", state: { status: "completed", input: { filePath: ".opencode/plans/ignored.md" } } }),
+      ],
+    };
+    expect(planPathsFromMessages([msg]).sort()).toEqual([
+      ".opencode/plans/a.md",
+      ".opencode/plans/b.md",
+      ".opencode/plans/c.md",
+    ]);
+  });
+
+  it("does not treat a read reference as an authoring signal", () => {
+    const msg: OpencodeMessage = {
+      info: {} as never,
+      parts: [part({ tool: "read", state: { status: "completed", input: { filePath: ".opencode/plans/x.md" } } })],
+    };
+    expect(planPathsFromMessages([msg])).toEqual([]);
+    expect(planRefsFromPart(msg.parts[0])).toEqual([]);
+  });
+
+  it("deduplicates identical refs", () => {
+    const msg: OpencodeMessage = {
+      info: {} as never,
+      parts: [
+        part({ tool: "plan", state: { status: "completed", input: { path: ".opencode/plans/same.md" } } }),
+        part({ type: "text", text: ".opencode/plans/same.md" }),
+      ],
+    };
+    expect(planPathsFromMessages([msg])).toEqual([".opencode/plans/same.md"]);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2185,6 +2185,70 @@ export function planMetrics(text: string): { steps?: number; files?: number } {
   return out;
 }
 
+// ---- Plan-file discovery (tolerant of how the plan was authored) ----
+//
+// Plan paths live in different part shapes depending on how the plan was
+// authored. The classic announcing message mentions the path in PROSE (a text
+// part). But the plan-mode flow WRITES the plan with the `write`/`plan` tool —
+// which records the path in `state.input.filePath` (and sometimes
+// `planPath`/`path`) plus a `patch` part listing the file — so the path never
+// reaches a text part, and `plan_exit` sometimes doesn't echo it either.
+// Scanning only one surface (e.g. only the plan_exit input) misses plans
+// authored via the plan tool. So we scan text, authoring-tool input, and
+// patch-file lists for any `.opencode/plans/*.md` reference. Cheap by design:
+// we never read tool output or file content, only path fields and prose.
+
+const PLAN_REF_RE = /\.opencode\/plans\/[\w.-]+\.md/g;
+
+// Tools that AUTHOR the plan file (or confirm it at plan_exit). A `read` tool
+// pointed at a plan path is a reference, not an authoring signal, and must not
+// resolve as the plan — the write/plan tool (or a prose mention) already does.
+const PLAN_AUTHORING_TOOLS = new Set([
+  "write", "edit", "multiEdit", "patch", "plan", "plan_exit",
+]);
+
+/** Every distinct `.opencode/plans/*.md` reference a single part carries. */
+export function planRefsFromPart(part: OpencodePart): string[] {
+  const out: string[] = [];
+  const candidates: string[] = [];
+  if (typeof part.text === "string") candidates.push(part.text);
+  const raw = part as Record<string, unknown>;
+  const isTool = raw.type === "tool";
+  if (isTool && PLAN_AUTHORING_TOOLS.has(String(raw.tool ?? ""))) {
+    const input =
+      (raw.state as { input?: Record<string, unknown> } | undefined)?.input ??
+      (raw.input as Record<string, unknown> | undefined);
+    if (input) {
+      for (const key of ["filePath", "path", "planPath"]) {
+        const v = input[key];
+        if (typeof v === "string") candidates.push(v);
+      }
+    }
+  }
+  if (Array.isArray(raw.files)) candidates.push(...raw.files.map(String));
+  for (const c of candidates) {
+    for (const m of c.matchAll(PLAN_REF_RE)) {
+      if (!out.includes(m[0])) out.push(m[0]);
+    }
+  }
+  return out;
+}
+
+/** Every distinct `.opencode/plans/*.md` reference across a transcript. */
+export function planPathsFromMessages(
+  messages: OpencodeMessage[] | null,
+): string[] {
+  const out: string[] = [];
+  for (const msg of messages ?? []) {
+    for (const part of msg.parts) {
+      for (const ref of planRefsFromPart(part)) {
+        if (!out.includes(ref)) out.push(ref);
+      }
+    }
+  }
+  return out;
+}
+
 /**
  * The plan card's display data: the title (first markdown heading of the plan
  * text, falling back to the question header), the plan file path when known,
@@ -2220,6 +2284,13 @@ export function extractPlanData(
       break;
     }
   }
+  // The plan_exit input often carries no path (opencode's plan_exit tool takes
+  // no arguments). Fall back to tolerant discovery across the transcript so
+  // the plan's `.opencode/plans/*.md` path (found in the `write`/`plan` tool
+  // that authored it, or a prose mention) still resolves — this is what lets
+  // the plan card publish the companion page even before plan_exit completes.
+  // Most recent plan wins (`at(-1)`): messages are append-ordered.
+  if (!path) path = planPathsFromMessages(messages).at(-1) ?? "";
   const firstHeading = text.match(/^#{1,6}[ \t]+(.+)$/m)?.[1]?.trim();
   const firstLine = text.split("\n").find((l) => l.trim())?.trim();
   const title =


### PR DESCRIPTION
## Summary

The plan exit card's **eager page-publish** (added in #983, "show the plan page URL in the card before plan_exit") depended on `extractPlanData(...).path`, which read **only** the `plan_exit` tool part's input (`input.planPath ?? input.path`). opencode's built-in `plan_exit` takes no arguments, so when the plan was authored with the `write`/`plan` tool the path came back empty — the eager publish never fired, and the card showed a disabled "See in browser" button with no URL, even though the card was displayed.

## What changed

- **`chatUtils.ts`**: moved the tolerant plan-path discovery (`planRefsFromPart`, `planPathsFromMessages`, `PLAN_REF_RE`, authoring-tool set) out of `artifacts.ts` into the shared pure-logic module, and made `extractPlanData` fall back to it when the `plan_exit` input carries no path.
- **`artifacts.ts`**: now imports the shared `planRefsFromPart` instead of its own private copy (single source of truth — the Plans tab and the plan card stay in sync).
- The `/api/plan-page` endpoint already accepts a resolved `path` (reads the markdown from the session dir), so no server change is needed — the card now publishes the companion page during `plan`-mode authoring, URL appears while the card is displayed.

## Verification

- `npx tsc --noEmit` clean.
- `npx vitest run` — 2883 passed (incl. new tests: plan_exit-empty-input fallback, plan_exit-input-wins, planPathsFromMessages across text/tool-input/patch, read-not-authoring, dedupe).
- `npm run test:server` — 1624 passed.

## Notes

The plan subdomain (`plan-<shortId>`) is unchanged and stable, so a re-publish still replaces the snapshot under the same URL across "Keep planning" revisions.