### PR TITLE
BET-983: feat(renderer): plan toggle prefers manta-plan agent, falls back to plan

### DIFF
--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -2854,6 +2854,45 @@ describe("resolvePlanToggle", () => {
   });
 });
 
+describe("resolvePlanToggle — agent preference", () => {
+  const A = (name: string, mode?: string): OpencodeAgent =>
+    ({ name, mode } as OpencodeAgent);
+
+  it("both plan and manta-plan present → prefers manta-plan", () => {
+    const r = resolvePlanToggle(
+      [A("plan", "primary"), A("manta-plan", "primary")],
+      false,
+    );
+    expect(r.agent).toBe("manta-plan");
+  });
+
+  it("only plan present → falls back to plan", () => {
+    const r = resolvePlanToggle([A("plan", "primary")], false);
+    expect(r.agent).toBe("plan");
+  });
+
+  it("only manta-plan present → selects manta-plan", () => {
+    const r = resolvePlanToggle([A("manta-plan", "primary")], false);
+    expect(r.agent).toBe("manta-plan");
+  });
+
+  it("neither present / only subagents → unavailable", () => {
+    const r = resolvePlanToggle(
+      [A("build", "primary"), A("manta-plan", "subagent")],
+      false,
+    );
+    expect(r.available).toBe(false);
+  });
+
+  it("a manta-plan subagent is not picked; primary plan is preferred", () => {
+    const r = resolvePlanToggle(
+      [A("plan", "primary"), A("manta-plan", "subagent")],
+      false,
+    );
+    expect(r.agent).toBe("plan");
+  });
+});
+
 // ===== selectableModelGroups =====
 
 describe("selectableModelGroups", () => {

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2110,7 +2110,9 @@ export function resolvePlanToggle(
   on: boolean,
 ): PlanToggleState {
   if (!agents) return { available: false, on, loading: true, title: "Loading agents…" };
-  const plan = agents.find((a) => a.name === "plan" && a.mode !== "subagent");
+  const plan = ["manta-plan", "plan"]
+    .map((name) => agents.find((a) => a.name === name && a.mode !== "subagent"))
+    .find((a) => !!a);
   if (!plan)
     return on
       ? { available: false, on: true, title: "Plan mode on (plan agent unavailable)" }


### PR DESCRIPTION
## BET-983 — plan toggle prefers manta-plan, falls back to plan

Fixes the Plan-toggle selection so it routes to the MantaUI-owned `manta-plan`
primary agent when present, and falls back to opencode's built-in `plan`.

### Preference-order logic

`resolvePlanToggle` (src/renderer/chatUtils.ts) now walks a preference order
`["manta-plan", "plan"]`, picking the first agent in that order that is present
in the catalog with `mode !== "subagent"`. Shared `find`, no bespoke per-name
branch, no exported helper. When neither is available it keeps the existing
`available: false` behaviour, titles/paths byte-identical.

### Tests (src/renderer/chatUtils.test.ts)

New `describe("resolvePlanToggle — agent preference")` block:
- both `plan` and `manta-plan` (both primary) → `agent === "manta-plan"`
- only `plan` → `agent === "plan"` (fallback preserved)
- only `manta-plan` → `agent === "manta-plan"`
- neither / only subagents → `available === false`
- guard: a `manta-plan` subagent (mode `"subagent"`) is NOT picked; the primary
  `plan` is preferred over it

### Scope guards respected
- Did not touch the three `agent === "plan"` recognition sites (BET-982)
- No change to return shape, callers, or signature
- No config flag / settings UI added
- No comments added

### Verification
- `npm run typecheck` — green
- `npm test` — 2156 pass / 0 fail (renderer chatUtils 586 pass)
