### PR TITLE
refactor(renderer): shared isPlanAgent predicate for plan-mode recognition (BET-982)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -64,6 +64,7 @@ import {
   extractPlanData,
   selectableModelGroups,
 } from "./chatUtils";
+import { isPlanAgent } from "../shared/planMode.mjs";
 import {
   appendPromptHistory,
   copySavedModels,
@@ -624,7 +625,7 @@ export function ChatPanel({
     if (api.opencodeSessionAgent) {
       api.opencodeSessionAgent(sessionId).then((agent) => {
         if (agent && agent.length > 0) {
-          const planNow = agent === "plan";
+          const planNow = isPlanAgent(agent);
           setPlanOn(planNow);
           writePlanSaved(sessionId, planNow);
           setModelOverride(

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -70,7 +70,7 @@ import {
   authErrorAdvice,
   fetchTranscriptWithRetry,
 } from "../chatUtils";
-import { planModeFromToolPart } from "../../shared/planMode.mjs";
+import { planModeFromToolPart, isPlanAgent } from "../../shared/planMode.mjs";
 import type { TokenUsage } from "../chatShared";
 import { useStore } from "../store";
 import { markFirstToken, markRendered } from "../firstTokenLatency";
@@ -571,7 +571,7 @@ export function useSseBus(params: {
       // server-side state doing it, so MantaUI must mirror it or the chip
       // claims plan mode while the next turn runs as build.
       if (ev.type === "session.next.agent.switched") {
-        setPlanOnRef.current(String(props.agent ?? "") === "plan");
+        setPlanOnRef.current(isPlanAgent(String(props.agent ?? "")));
       }
       if (ev.type === "message.part.updated") {
         const part = props.part as { callID?: unknown } | undefined;

--- a/src/shared/planMode.d.mts
+++ b/src/shared/planMode.d.mts
@@ -13,3 +13,9 @@
  * purpose, must not be reused here.)
  */
 export function planModeFromToolPart(part: unknown): boolean | null;
+
+/**
+ * Whether `name` is a plan-mode agent (`"plan"` or `"manta-plan"`). Non-strings
+ * (undefined, null, numbers, objects) and empty strings are false.
+ */
+export function isPlanAgent(name: unknown): boolean;

--- a/src/shared/planMode.mjs
+++ b/src/shared/planMode.mjs
@@ -22,3 +22,11 @@ export function planModeFromToolPart(part) {
   if (p.tool === "plan_exit") return false;
   return null;
 }
+
+/**
+ * Whether `name` is a plan-mode agent, so manta-plan is recognized uniformly.
+ */
+export function isPlanAgent(name) {
+  if (name === undefined || name === null || typeof name !== "string") return false;
+  return name === "plan" || name === "manta-plan";
+}

--- a/src/shared/planMode.test.ts
+++ b/src/shared/planMode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { planModeFromToolPart } from "./planMode.mjs";
+import { planModeFromToolPart, isPlanAgent } from "./planMode.mjs";
 
 describe("planModeFromToolPart", () => {
   it("is true for a completed plan_enter", () => {
@@ -29,5 +29,28 @@ describe("planModeFromToolPart", () => {
   it("is null for null / undefined", () => {
     expect(planModeFromToolPart(null)).toBe(null);
     expect(planModeFromToolPart(undefined)).toBe(null);
+  });
+});
+
+describe("isPlanAgent", () => {
+  it("is true for 'plan'", () => {
+    expect(isPlanAgent("plan")).toBe(true);
+  });
+
+  it("is true for 'manta-plan'", () => {
+    expect(isPlanAgent("manta-plan")).toBe(true);
+  });
+
+  it("is false for other agent names", () => {
+    expect(isPlanAgent("build")).toBe(false);
+    expect(isPlanAgent("general")).toBe(false);
+    expect(isPlanAgent("")).toBe(false);
+  });
+
+  it("is false for non-strings", () => {
+    expect(isPlanAgent(undefined)).toBe(false);
+    expect(isPlanAgent(null)).toBe(false);
+    expect(isPlanAgent(123)).toBe(false);
+    expect(isPlanAgent({})).toBe(false);
   });
 });


### PR DESCRIPTION
Closes BET-982

Adds the single shared `isPlanAgent` predicate to src/shared/planMode.mjs (plus its .d.mts type) and rewires both renderer call sites to use it, so a future `manta-plan` agent is recognized without re-hardcoding the string.

- src/shared/planMode.mjs — exported `isPlanAgent(name)`: false for undefined/null/non-string, true for `"plan"`/`"manta-plan"`.
- src/renderer/hooks/useSseBus.ts:574 — `=== "plan"` -> `isPlanAgent(...)`.
- src/renderer/ChatPanel.tsx:628 — `agent === "plan"` -> `isPlanAgent(agent)`.
- src/shared/planMode.test.ts — new describe block.

`resolvePlanToggle` (chatUtils.ts) left untouched per scope.

Verification: `npm run typecheck` green; `npm test` 2156 pass (planMode.test.ts 11 pass).