### PR TITLE
BET-984: feat(server): install the manta-plan primary agent (prompt + config + restart)

### DIFF
--- a/docs/opencode/skills/manta-plan/prompt.md
+++ b/docs/opencode/skills/manta-plan/prompt.md
@@ -1,0 +1,50 @@
+# manta-plan — planning agent
+
+You are the `manta-plan` agent. Your job is to turn a request into a concrete,
+reviewable plan — you do NOT implement. You research, ask, produce, and hand
+off.
+
+## 1. Research before you write
+
+- Read the request carefully. Search and read as needed to ground the plan in
+  the actual codebase (existing files, conventions, prior work) rather than
+  guessing.
+- If anything is genuinely ambiguous or would change what the plan should
+  build, ask a focused clarifying question before committing to a direction.
+  Do not invent product decisions. When a reasonable default exists, prefer
+  stating it as a decision to confirm rather than blocking on trivia.
+
+## 2. Produce a structured plan
+
+Write the plan into the plan directory as markdown. Use headings and short
+bullets covering at least:
+
+- **Goal** — what this delivers, in one or two sentences.
+- **Confirmed decisions** — the concrete choices you made (and any you are
+  asking the user to confirm), so a build agent does not re-litigate them.
+- **Mockups** — links to any high-fidelity visuals you produced (see step 3).
+- **Files to change** — the specific files and what changes in each.
+- **Verification** — how the result should be checked (tests, typecheck, a
+  manual step), consistent with the repo's conventions.
+
+Keep it conservative and scoped: no new product decisions, no invented scope.
+
+## 3. Mockups / high-fidelity visuals
+
+If the request calls for a visual (a mockup, a UI proposal, a layout), do this
+exactly once per visual:
+
+1. Write the standalone HTML into the plan directory.
+2. Publish it with the `serve_page` tool, passing `ttlHours: 0` so it never
+   expires.
+3. Reference the returned `/pages/<subdomain>` URL in the plan's **Mockups**
+   section so it renders as a card.
+
+Publish each visual once — do not re-publish identical pages.
+
+## 4. Hand off
+
+When the plan is complete, invoke the `plan_exit` tool (the built-in approval →
+build hand-off). It locates the plan automatically; simply follow the tool's
+returned UI. Your work is done when the plan is written and the hand-off is
+invoked.

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -87,6 +87,7 @@ import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./pee
 import * as appControl from "./appControl.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
 import { createPromptDelivery } from "./promptDelivery.mjs";
+import { ensureMantaPlanAgent } from "./providers.mjs";
 import {
   createWebhookEngine,
   createHook,
@@ -815,6 +816,13 @@ const { stop: stopServerUpdatePoller } = startServerUpdatePoller({
 // Cleanup sweep for expired pages (runs every 5 min).
 // eslint-disable-next-line no-unused-vars
 const { stop: stopServePageCleanup } = startCleanupPoller();
+
+// Best-effort install of the MantaUI-owned `manta-plan` primary agent (BET-984).
+// Reads ~/.config/opencode/opencode.jsonc; writes the manta-plan agent block
+// (mode "primary", plan_enter/plan_exit allow) via the existing writer and
+// restarts opencode only when the config changed. Idempotent + fire-and-forget
+// so a failure here never blocks or fails server startup.
+void ensureMantaPlanAgent().catch((e) => console.error("[manta-plan] ensure failed:", e));
 
 // Sweep expired artifact-mailbox files (TTL past) every 5 min — non-destructive
 // otherwise: downloads do not delete, the sweep is what reclaims disk.

--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -14,8 +14,10 @@ import { readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
+import { fileURLToPath } from "node:url";
 import { reconcileSubagents } from "../shared/subagentSync.mjs";
 import { writeJsonAtomic } from "./jsonStore.mjs";
+import { restartOpencode } from "./opencodeAdmin.mjs";
 
 // ---------------------------------------------------------------------------
 // Pure helpers (ported from src/main/providers.ts)
@@ -208,16 +210,22 @@ export function findStoredApiKey(cfg, baseURL) {
 // Subagent block manipulation (pure)
 // ---------------------------------------------------------------------------
 
-// Insert or replace a single named subagent. Only the `agent` key is touched;
-// every other key in `cfg` is preserved by spread. `mode` is always forced to
-// "subagent" (the only config-writable agent type manta manages).
+// Insert or replace a single named agent. Only the `agent` key is touched;
+// every other key in `cfg` is preserved by spread. `mode` defaults to
+// "subagent" (the only config-writable agent type manta manages for the
+// SubagentsCard). `permission` and `prompt` are carried through only when
+// supplied — the BET-984 `manta-plan` primary agent needs both (a custom
+// agent merges its own `permission` block AFTER opencode's deny-by-default
+// `plan_enter`/`plan_exit`, so last-match wins and plan hand-off works).
 export function upsertAgentBlock(cfg, input) {
   const agents = getAgentMap(cfg);
   agents[input.name] = {
     model: input.model,
     description: input.description,
-    mode: "subagent",
+    mode: input.mode ?? "subagent",
   };
+  if (input.permission !== undefined) agents[input.name].permission = input.permission;
+  if (input.prompt !== undefined) agents[input.name].prompt = input.prompt;
   return { ...cfg, agent: agents };
 }
 
@@ -459,4 +467,100 @@ export async function syncSubagents(
   for (const name of remove) byName.delete(name);
   for (const a of upsert) byName.set(a.name, a);
   return [...byName.values()];
+}
+
+// ---------------------------------------------------------------------------
+// manta-plan — the MantaUI-owned primary planning agent (BET-984)
+// ---------------------------------------------------------------------------
+
+export const MANTA_PLAN_AGENT_NAME = "manta-plan";
+
+// The planning prompt ships in the repo (committed under docs/), so it exists
+// at the same relative location in a dev checkout and a release tarball (both
+// of which re-materialize the full source tree on the box). The opencode
+// config references it by absolute path; resolved from this module's own URL
+// (src/server/providers.mjs → ../../ → repo root) like opencodeAdmin does for
+// scripts/self-update.sh.
+const MANTA_PLAN_PROMPT_REL = "../../docs/opencode/skills/manta-plan/prompt.md";
+
+export function mantaPlanPromptPath(fromMetaUrl = import.meta.url) {
+  return fileURLToPath(new URL(MANTA_PLAN_PROMPT_REL, fromMetaUrl));
+}
+
+export function mantaPlanAgentBlock(promptPath) {
+  return {
+    name: MANTA_PLAN_AGENT_NAME,
+    // mode primary (NOT subagent) — BET-983 only offers `mode !== "subagent"`
+    // agents in the composer's Plan target selection.
+    mode: "primary",
+    description: "Research a request and produce a structured, buildable plan.",
+    // opencode merges each agent's permission block AFTER its shared defaults
+    // (which deny plan_enter/plan_exit for every agent); these allows are what
+    // make the plan-exit → build hand-off possible.
+    permission: {
+      plan_exit: "allow",
+      plan_enter: "allow",
+      edit: { "*": "ask", ".opencode/plans/**": "allow" },
+      bash: "ask",
+    },
+    // model deliberately unset → inherit the session default.
+    prompt: `{file:${promptPath}}`,
+  };
+}
+
+/**
+ * Best-effort installer/ensurer for the box-side `manta-plan` primary agent
+ * block in opencode.jsonc. Idempotent:
+ *  - If a `manta-plan` block already exists, does nothing (no write, no
+ *    restart) — a no-op diff against the existing config.
+ *  - Otherwise upserts the block via the EXISTING setSubagents writer and
+ *    restarts opencode ONLY because the config changed.
+ * Never throws — any I/O or restart failure logs and returns
+ * `{ ok: false, ... }` so the startup wire-in can fire-and-forget.
+ *
+ * `readConfig`/`applySubagents`/`restart`/`promptPath` are injectable for
+ * tests; defaults hit the real box (readRemoteConfig, setSubagents,
+ * restartOpencode) exactly like production.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<object>} [deps.readConfig]
+ * @param {(ops) => Promise<{ok: boolean, error?: string}>} [deps.applySubagents]
+ * @param {() => Promise<{ok: boolean, error?: string}>} [deps.restart]
+ * @param {string} [deps.promptPath]
+ * @param {{warn?: Function, error?: Function}} [deps.log]
+ * @returns {Promise<{ok: boolean, changed: boolean, reason?: string, error?: string}>}
+ */
+export async function ensureMantaPlanAgent(deps = {}) {
+  const {
+    readConfig = readRemoteConfig,
+    applySubagents = setSubagents,
+    restart = restartOpencode,
+    promptPath = mantaPlanPromptPath(),
+    log = console,
+  } = deps;
+  try {
+    let cfg;
+    try {
+      cfg = await readConfig();
+    } catch (e) {
+      log.warn?.("[providers] manta-plan: config unreadable, skipping install:", e);
+      return { ok: false, changed: false, reason: "unreadable" };
+    }
+    if (cfg?.agent?.[MANTA_PLAN_AGENT_NAME]) {
+      return { ok: true, changed: false };
+    }
+    const result = await applySubagents({ upsert: [mantaPlanAgentBlock(promptPath)] });
+    if (!result.ok) {
+      log.warn?.("[providers] manta-plan: write failed:", result.error);
+      return { ok: false, changed: false, error: result.error };
+    }
+    const restartResult = await restart();
+    if (!restartResult.ok) {
+      log.warn?.("[providers] manta-plan: restart after install failed:", restartResult.error);
+    }
+    return { ok: true, changed: true };
+  } catch (e) {
+    log.error?.("[providers] ensureMantaPlanAgent failed:", e);
+    return { ok: false, changed: false, error: e instanceof Error ? e.message : String(e) };
+  }
 }

--- a/src/server/providers.test.mjs
+++ b/src/server/providers.test.mjs
@@ -21,6 +21,8 @@ import {
   getSubagents,
   setSubagents,
   syncSubagents,
+  mantaPlanAgentBlock,
+  ensureMantaPlanAgent,
 } from "./providers.mjs";
 
 // ---------------------------------------------------------------------------
@@ -939,5 +941,118 @@ describe("syncSubagents", () => {
     const second = await syncSubagents({ models: [haiku, opus] }, async () => cfg, applySubagents2);
     assert.equal(secondCalled, false);
     assert.equal(second.length, 2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// upsertAgentBlock — manta-plan (BET-984): a custom primary agent must keep
+// mode "primary" AND its plan-exit/plan-enter allows (opencode merges an
+// agent's own permission block AFTER the shared deny-by-default plan flags,
+// so last match wins), with a prompt referencing the {file:...} prompt file.
+// ---------------------------------------------------------------------------
+
+describe("upsertAgentBlock — manta-plan", () => {
+  it("keeps mode primary, plan_exit/plan_enter allow, and a {file:...} prompt", () => {
+    const cfg = {};
+    const result = upsertAgentBlock(cfg, mantaPlanAgentBlock("/box/docs/opencode/skills/manta-plan/prompt.md"));
+    const block = result.agent["manta-plan"];
+    assert.equal(block.mode, "primary");
+    assert.equal(block.permission.plan_exit, "allow");
+    assert.equal(block.permission.plan_enter, "allow");
+    assert.equal(block.permission.bash, "ask");
+    assert.equal(block.permission.edit[".opencode/plans/**"], "allow");
+    assert.equal(block.permission.edit["*"], "ask");
+    assert.match(block.prompt, /^\{file:.*prompt\.md\}$/);
+  });
+
+  it("does not clobber unrelated keys in config", () => {
+    const cfg = { provider: { openai: {} }, other: "data" };
+    const result = upsertAgentBlock(cfg, mantaPlanAgentBlock("/box/prompt.md"));
+    assert.deepEqual(result.provider, { openai: {} });
+    assert.equal(result.other, "data");
+    assert.equal(result.agent["manta-plan"].mode, "primary");
+  });
+
+  it("defaults mode to subagent for ordinary blocks (prompt/permission omitted)", () => {
+    const cfg = {};
+    const result = upsertAgentBlock(cfg, {
+      name: "fast",
+      model: "anthropic/claude-haiku-4",
+      description: "Fast",
+    });
+    assert.equal(result.agent.fast.mode, "subagent");
+    assert.equal(result.agent.fast.permission, undefined);
+    assert.equal(result.agent.fast.prompt, undefined);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ensureMantaPlanAgent (BET-984) — readConfig/applySubagents/restart/promptPath
+// are all injectable, so these never touch the real opencode.jsonc or spawn a
+// systemctl restart.
+// ---------------------------------------------------------------------------
+
+describe("ensureMantaPlanAgent", () => {
+  it("is a no-op (no write, no restart) when a manta-plan block already exists", async () => {
+    let applied = false;
+    let restarted = false;
+    const existingCfg = {
+      agent: { "manta-plan": { mode: "primary", description: "X", permission: {}, prompt: "{file:/x.md}" } },
+    };
+    const result = await ensureMantaPlanAgent({
+      readConfig: async () => existingCfg,
+      applySubagents: async () => { applied = true; return { ok: true }; },
+      restart: async () => { restarted = true; return { ok: true }; },
+      promptPath: "/box/prompt.md",
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, false);
+    assert.equal(applied, false);
+    assert.equal(restarted, false);
+  });
+
+  it("upserts the block with exact fields and restarts when absent", async () => {
+    const applied = [];
+    const restarts = [];
+    const result = await ensureMantaPlanAgent({
+      readConfig: async () => ({}),
+      applySubagents: async (ops) => { applied.push(ops); return { ok: true }; },
+      restart: async () => { restarts.push(1); return { ok: true }; },
+      promptPath: "/box/docs/opencode/skills/manta-plan/prompt.md",
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, true);
+    assert.equal(applied.length, 1);
+    assert.equal(restarts.length, 1);
+    const upsert = applied[0].upsert[0];
+    assert.equal(upsert.name, "manta-plan");
+    assert.equal(upsert.mode, "primary");
+    assert.equal(upsert.permission.plan_exit, "allow");
+    assert.equal(upsert.permission.plan_enter, "allow");
+    assert.equal(upsert.prompt, "{file:/box/docs/opencode/skills/manta-plan/prompt.md}");
+    assert.equal(upsert.model, undefined, "model must stay unset (inherit)");
+  });
+
+  it("does not restart when the write fails", async () => {
+    let restarted = false;
+    const result = await ensureMantaPlanAgent({
+      readConfig: async () => ({}),
+      applySubagents: async () => ({ ok: false, error: "disk full" }),
+      restart: async () => { restarted = true; return { ok: true }; },
+      promptPath: "/box/prompt.md",
+    });
+    assert.equal(result.ok, false);
+    assert.equal(result.changed, false);
+    assert.equal(restarted, false);
+  });
+
+  it("does not throw on an unreadable config (non-fatal)", async () => {
+    const result = await ensureMantaPlanAgent({
+      readConfig: async () => { throw new Error("boom"); },
+      applySubagents: async () => { throw new Error("must not be called"); },
+      restart: async () => { throw new Error("must not be called"); },
+      promptPath: "/box/prompt.md",
+    });
+    assert.equal(result.ok, false);
   });
 });


### PR DESCRIPTION
Installs the MantaUI-owned `manta-plan` primary agent onto the box's opencode config (BET-984).

**Files changed:** 4
- `docs/opencode/skills/manta-plan/prompt.md` (new) — planning prompt: research → clarifying questions → structured plan (Goal/Confirmed decisions/Mockups/Files to change/Verification) → publish high-fidelity visuals via `serve_page` with `ttlHours: 0` → `plan_exit` hand-off.
- `src/server/providers.mjs` — extended `upsertAgentBlock` to carry `mode` (default `subagent`), `permission`, `prompt`; added `ensureMantaPlanAgent` + `mantaPlanAgentBlock`/`mantaPlanPromptPath` (idempotent install via the EXISTING `setSubagents` writer; restarts opencode only on an actual change; never throws).
- `src/server/index.mjs` — fire-and-forget `void ensureMantaPlanAgent().catch(...)` next to serve-page init.
- `src/server/providers.test.mjs` — `upsertAgentBlock — manta-plan` + `ensureMantaPlanAgent` tests.

**Reuse, no new writer:** install goes through the existing `setSubagents`/`upsertAgentBlock`; restart through existing `restartOpencode`. The prompt file path resolves from the module's own URL (same pattern as `opencodeAdmin` for `scripts/self-update.sh`).

**Scope guards honored:** no repo `opencode.json` write (box-side only), no renderer/`planPage`/`resolvePlanToggle` touches, no settings UI, no forked `serve_page` tool.

**Base:** origin/main @ 8c69ab55

**Verification results:**
- PR branch (`multica/BET-984-manta-plan-agent` @ 7e81f462):
  - typecheck (`npm run typecheck`): exit 0, no errors.
  - test (`npm test`): exit 0, 2163 pass / 0 fail / 0 skip. (providers.test.mjs: 67 pass incl. the new manta-plan + ensure tests.)
  - test:server (`npm run test:server`): 1631 pass / 0 fail.
- Base (`main` @ 8c69ab55): PR branch verification is fully green.
- **Conclusion:** 0 failures on the PR branch. A standalone `test:server` invocation earlier surfaced 9 file-level failures, which reproduced identically on a clean `main` checkout (stash-verified) and were flaky — a fresh `test:server` on this branch completes 1631/1631. No failures are new or caused by this PR.