### PR TITLE
chore: release 0.0.32 (server)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.31",
+      "version": "0.0.32",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.31",
+  "version": "0.0.32",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.31",
+ "version": "0.0.32",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
## Summary
Bumps the server release to **0.0.32** (`package.json`, `package-lock.json`, `website/updates/server.json`).

Ships the unreleased `src/server/` work since 0.0.31:
- **BET-984** — installs the `manta-plan` primary agent (prompt + config + opencode restart)
- **BET-985** — shared mockup-link detector + `serve_page` cards on the plan page
- **BET-982** — shared `isPlanAgent` predicate refactor

This is the tarball that lets clean installs (prod + staging) pick up the plan-mode server work.