### PR TITLE
fix(release): ship docs/opencode/skills in the server tarball (v0.0.33)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.32",
+      "version": "0.0.33",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.32",
+  "version": "0.0.33",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -121,7 +121,7 @@ exit $?
 // The canonical `includes` self-update.sh ships with today (pack.mjs INCLUDE
 // + runtime). Not load-bearing on the function's behaviour — each test passes
 // its own — just a realistic fixture.
-const PKG_INCLUDES = ["src", "scripts", "docs/opencode-tools", "package.json", "runtime"];
+const PKG_INCLUDES = ["src", "scripts", "docs/opencode-tools", "docs/opencode/skills", "package.json", "runtime"];
 
 function makePkg(includes) {
   const pkg = mkdtempSync(join(tmpdir(), "manta-rel-pkg-"));
@@ -135,6 +135,7 @@ function makePkg(includes) {
     "src/server/index.mjs": "new index",
     "scripts/self-update.sh": "new self-update",
     "docs/opencode-tools/peers.ts": "new peers",
+    "docs/opencode/skills/manta-plan/prompt.md": "new prompt",
     "package.json": "new package",
     "runtime/node/bin/node": "new node binary",
   };

--- a/scripts/release/pack.mjs
+++ b/scripts/release/pack.mjs
@@ -30,6 +30,8 @@
 //                                    node's ABI on Linux, or taken from the
 //                                    prebuilds node-pty ships for darwin/win32
 //     docs/opencode-tools/           manta-native opencode tool bundle
+//     docs/opencode/skills/          primary-agent prompts (manta-plan) referenced
+//                                    by opencode.jsonc `{file:…}` — BET-984
 //     RELEASE.json                   { name, version, built_at, includes,
 //                                      node, arch }
 //
@@ -140,6 +142,7 @@ const INCLUDE = [
   "src",
   "scripts",
   "docs/opencode-tools",
+  "docs/opencode/skills",
   "package.json",
   "package-lock.json",
   "README.md",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.32",
+ "version": "0.0.33",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
## Summary
Fixes the release packaging bug that broke opencode-serve on every installed box after BET-984.

**The bug:** the `manta-plan` primary agent's prompt (`docs/opencode/skills/manta-plan/prompt.md`) is referenced by `opencode.jsonc` as a `{file:...}` path, but the server tarball's `INCLUDE` allowlist only shipped `docs/opencode-tools`. So an installed box got the agent block pointing at a file that was never installed, and `opencode --serve` failed to start: `bad file reference: "{file:/home/dev/manta/docs/opencode/skills/manta-plan/prompt.md}"`.

**The fix:** add `docs/opencode/skills` to the tarball `INCLUDE` (pack.mjs) + the matching `release.test.mjs` fixture, so both clean installs and self-updates ship the prompt file.

Vendor bumps to **0.0.33**.