### PR TITLE
feat(server): plan_render wiring — /api/plan-render route + custom tool (BET-987)

### DIFF
--- a/docs/opencode-tools/plan-render.ts
+++ b/docs/opencode-tools/plan-render.ts
@@ -1,0 +1,93 @@
+// manta-native `plan_render` tool — global opencode custom tool.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/plan-render.ts ~/.config/opencode/tools/plan-render.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+//
+// This tool is a THIN registrar (same contract as the other MantaUI tools). It
+// POSTs the authored plan HTML bundle path to manta-server
+// (127.0.0.1:8787, same box — no SSH hop), which renders and publishes the
+// plan page through the existing serve-page subsystem. execute() must return
+// promptly — no long-running work.
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
+// tiny local file) so a token rotation never requires an opencode-serve
+// restart. MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+export const plan_render = tool({
+  description: [
+    "Publish the single-HTML plan bundle the plan agent authored: given the",
+    "path to the plan HTML file, render it into a standalone plan page and",
+    "return its public URL. The path must be inside the session's own",
+    "directory (it is resolved and confined there). Call this AFTER writing",
+    "the authored plan HTML bundle; the returned URL is the shareable plan",
+    "page. Then invoke the plan_exit tool separately afterwards to complete",
+    "the plan.",
+  ].join(" "),
+  args: {
+    file: z
+      .string()
+      .describe(
+        "Absolute (or session-relative) path to the authored plan HTML bundle. " +
+          "Must resolve to a path inside the session directory.",
+      ),
+  },
+  async execute(args, context) {
+    const result = await call("POST", "/api/plan-render", {
+      sessionID: context.sessionID,
+      file: args.file,
+    });
+    return `Plan page published at ${result.url}`;
+  },
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -83,6 +83,7 @@ import {
   isValidSubdomain,
 } from "./servePage.mjs";
 import { publishPlanPage, readPlanMarkdown } from "./planPage.mjs";
+import { publishPlanBundle } from "./planRender.mjs";
 import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./peers.mjs";
 import * as appControl from "./appControl.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
@@ -2323,6 +2324,42 @@ const handleRequest = async (req, res) => {
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
       respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Single-HTML plan publish (BET-987) ----------
+  // POST /api/plan-render  body {sessionID, file}
+  //                      → {ok:true, url}   (400 {ok:false, error} on failure)
+  // Called by the remote manta-plan agent's `plan_render` tool. `file` is an
+  // UNTRUSTED path to the authored plan HTML bundle; it is resolved against
+  // the session directory and REJECTED if it escapes (same confinement as
+  // readPlanMarkdown, but no `.md` requirement — the bundle is HTML). The
+  // bundle is parsed + rendered (planDoc.mjs) and published through the
+  // EXISTING serve-page subsystem under the stable `plan-<shortSessionId>`
+  // subdomain with TTL 0 (never expires). The URL is whatever
+  // publishPlanBundle / registerPage returns — never constructed here.
+  if (path === "/api/plan-render") {
+    try {
+      const baseUrl = publicBaseUrl();
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const sessionID = body?.sessionID;
+        const sessionDir = await oc.getSessionDirectory(sessionID);
+        const result = await publishPlanBundle(
+          { sessionID, file: body?.file, sessionDir },
+          { ...BUS_PUBLISH_DEPS, baseUrl },
+        );
+        if (!result.ok) {
+          respondJson(res, 400, { ok: false, error: result.error });
+          return;
+        }
+        respondJson(res, 200, { ok: true, url: result.url });
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { ok: false, error: String(e?.message ?? e) });
     }
     return;
   }

--- a/src/server/planRender.mjs
+++ b/src/server/planRender.mjs
@@ -1,0 +1,135 @@
+// planRender.mjs — publish a single-HTML plan bundle (BET-987).
+//
+// The server-side orchestration behind the `plan_render` custom tool and the
+// `POST /api/plan-render` route. It reads the authored plan HTML bundle (the
+// file is UNTRUSTED — confined to the session directory, same approach as
+// `readPlanMarkdown` but WITHOUT the `.md` requirement, since the bundle is
+// HTML), parses it via `parsePlanBundle`, renders the branded document via
+// `renderPlanDoc`, stages the result under `statePath("plan-pages")`, and
+// registers it through the EXISTING `servePage.registerPage` subsystem with
+// TTL 0 (never expires) under the stable `plan-<shortSessionId>` subdomain.
+//
+// REUSE ONLY — no second registry, no new store, no duplicated confinement or
+// URL building. The URL always comes from `registerPage`.
+
+import { readFile as readFileImpl, mkdir as mkdirImpl, writeFile as writeFileImpl } from "node:fs/promises";
+import { join, dirname, resolve, sep } from "node:path";
+import { statePath } from "../shared/paths.mjs";
+import { parsePlanBundle, renderPlanDoc } from "./planDoc.mjs";
+import { planSubdomain } from "./planPage.mjs";
+import { registerPage } from "./servePage.mjs";
+
+// Directory the rendered source HTML is staged into before registerPage copies
+// it into the durable pages tree. Goes through statePath() (state-file rule).
+function planSrcDir() {
+  return statePath("plan-pages");
+}
+
+/**
+ * Resolve an UNTRUSTED plan file path against the session directory and reject
+ * it if the result escapes. Mirrors `readPlanMarkdown`'s confinement approach
+ * (resolve + require-inside-root) but does NOT require `.md` — the bundle is
+ * an HTML file.
+ *
+ * @returns {{ ok:true, abs:string }} | {{ ok:false, error:string }}
+ */
+function confineToSession({ file, sessionDir }) {
+  if (
+    !sessionDir ||
+    typeof sessionDir !== "string" ||
+    sessionDir.length === 0
+  ) {
+    return { ok: false, error: "A session directory is required to read the plan file." };
+  }
+  if (typeof file !== "string" || file.length === 0) {
+    return { ok: false, error: "A plan file path is required." };
+  }
+  const abs = resolve(sessionDir, file);
+  const root = resolve(sessionDir) + sep;
+  if (abs !== resolve(sessionDir) && !abs.startsWith(root)) {
+    return { ok: false, error: "Plan file path is outside the session directory." };
+  }
+  return { ok: true, abs };
+}
+
+/**
+ * Read a single-HTML plan bundle off disk (confined to the session dir), parse
+ * + render it, and publish it via the existing serve-page subsystem as a plan
+ * page (TTL 0 = never expires). Returns whatever `registerPage` returns — the
+ * URL comes from there / `baseUrl`, never hand-built here.
+ *
+ * @param {{ sessionID?: unknown, file?: unknown, sessionDir?: unknown }} input
+ * @param {object} [deps]
+ * @param {string} [deps.baseUrl]     - the box's published base URL (from
+ *                                      publicBaseUrl()); required or the call
+ *                                      refuses (no silent-404 URL).
+ * @param {Function} [deps.readFile]  - defaults to node:fs/promises readFile.
+ * @param {Function} [deps.writeFile] - defaults to node:fs/promises writeFile.
+ * @param {Function} [deps.mkdir]     - defaults to node:fs/promises mkdir.
+ * @param {Function} [deps.srcDir]    - where the staged HTML is written;
+ *                                      defaults to statePath("plan-pages").
+ * @param {Function} [deps.register]  - defaults to servePage.registerPage.
+ */
+export async function publishPlanBundle(
+  { sessionID, file, sessionDir },
+  {
+    baseUrl,
+    readFile = readFileImpl,
+    writeFile = writeFileImpl,
+    mkdir = mkdirImpl,
+    srcDir = planSrcDir,
+    register = registerPage,
+    ...registerDeps
+  } = {},
+) {
+  if (typeof sessionID !== "string" || sessionID.length === 0) {
+    return { ok: false, error: "A valid session id is required." };
+  }
+  const subdomain = planSubdomain(sessionID);
+  if (!subdomain) {
+    return { ok: false, error: "A valid session id is required to publish a plan page." };
+  }
+  if (!baseUrl) {
+    return {
+      ok: false,
+      error:
+        "This box has no published public hostname (it has not registered with " +
+        "the gateway), so a hosted plan page would not be reachable from anywhere. " +
+        "Page hosting is unavailable on this box.",
+    };
+  }
+
+  const confined = confineToSession({ file, sessionDir });
+  if (!confined.ok) return confined;
+
+  let text;
+  try {
+    text = await readFile(confined.abs, "utf8");
+  } catch (e) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+
+  const parsed = parsePlanBundle(text);
+  if (!parsed.ok) return parsed;
+
+  const rendered = renderPlanDoc({
+    title: parsed.title,
+    sections: parsed.sections,
+    body: parsed.body,
+  });
+  if (!rendered.ok) return rendered;
+
+  try {
+    const srcFile = join(srcDir(), `${subdomain}.html`);
+    await mkdir(dirname(srcFile), { recursive: true });
+    await writeFile(srcFile, rendered.html);
+  } catch (e) {
+    return { ok: false, error: String(e?.message ?? e) };
+  }
+  const srcFile = join(srcDir(), `${subdomain}.html`);
+
+  return register(
+    { subdomain, filePath: srcFile, ttlHours: 0, sessionID },
+    { baseUrl, ...registerDeps },
+  );
+}

--- a/src/server/planRender.test.mjs
+++ b/src/server/planRender.test.mjs
@@ -1,0 +1,150 @@
+// Tests for planRender.mjs — single-HTML plan publish orchestration (BET-987).
+// All I/O is injected (fake readFile / writeFile / mkdir / register / srcDir),
+// so no live HTTP and no real page files. Run via `npm run test:server`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { publishPlanBundle } from "./planRender.mjs";
+import { planSubdomain } from "./planPage.mjs";
+
+const BASE_URL = "https://0123abc.boxes.mantaui.com";
+const SESSION_ID = "sess-123xYZ";
+const SESSION_DIR = "/sessions/sess-123xYZ";
+
+function bundle(sections, bodyTail = "") {
+  const body =
+    `<h2 id="${sections[0].id}">${sections[0].heading}</h2>` +
+    sections
+      .slice(1)
+      .map((s) => `<h2 id="${s.id}">${s.heading}</h2>`)
+      .join("") +
+    bodyTail;
+  return `<script type="application/json" id="plan-meta">${JSON.stringify({
+    title: "Ship the thing",
+    sections,
+  })}</script>
+${body}`;
+}
+
+function makeDeeps({ readText, registerReturn } = {}) {
+  const calls = {
+    readFile: null,
+    writtenFile: null,
+    register: null,
+    registerCalls: [],
+  };
+  return {
+    calls,
+    deeps: {
+      baseUrl: BASE_URL,
+      srcDir: () => "/stage",
+      readFile: async (p) => {
+        calls.readFile = p;
+        if (readText !== undefined) return readText;
+        throw new Error("no fake read");
+      },
+      writeFile: async (p, data) => {
+        calls.writtenFile = { p, data };
+      },
+      mkdir: async () => {},
+      register: async (args, deps) => {
+        calls.registerCalls.push({ args, deps });
+        if (registerReturn !== undefined) return registerReturn;
+        return { ok: true, url: `${BASE_URL}/pages/${args.subdomain}`, subdomain: args.subdomain };
+      },
+    },
+  };
+}
+
+test("publishPlanBundle rejects a plan file path that escapes the session directory", async () => {
+  const { calls, deeps } = makeDeeps();
+  const result = await publishPlanBundle(
+    { sessionID: SESSION_ID, file: "../evil.html", sessionDir: SESSION_DIR },
+    deeps,
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error, /outside the session directory/);
+  assert.equal(calls.registerCalls.length, 0, "register never called");
+});
+
+test("publishPlanBundle rejects a missing session directory", async () => {
+  const { deeps } = makeDeeps();
+  const result = await publishPlanBundle(
+    { sessionID: SESSION_ID, file: "plan.html", sessionDir: "" },
+    deeps,
+  );
+  assert.equal(result.ok, false);
+  assert.match(result.error, /session directory is required/);
+});
+
+test("publishPlanBundle returns (not throws) a missing-meta error", async () => {
+  const { calls, deeps } = makeDeeps({ readText: "<html><body>no meta</body></html>" });
+  const result = await publishPlanBundle(
+    { sessionID: SESSION_ID, file: "plan.html", sessionDir: SESSION_DIR },
+    deeps,
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "no plan-meta");
+  assert.equal(calls.registerCalls.length, 0, "register never called on parse failure");
+});
+
+test("publishPlanBundle returns (not throws) a missing-anchor error", async () => {
+  // Section references an id that's NOT in the body → renderPlanDoc fails.
+  const text = `<script type="application/json" id="plan-meta">${JSON.stringify({
+    title: "T",
+    sections: [{ id: "missing", heading: "Missing" }],
+  })}</script>
+<h2 id="overview">Overview</h2>`;
+  const { calls, deeps } = makeDeeps({ readText: text });
+  const result = await publishPlanBundle(
+    { sessionID: SESSION_ID, file: "plan.html", sessionDir: SESSION_DIR },
+    deeps,
+  );
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "section id 'missing' not found in body");
+  assert.equal(calls.registerCalls.length, 0, "register never called on render failure");
+});
+
+test("publishPlanBundle on success calls register with ttlHours 0 and echoes the URL", async () => {
+  const sections = [
+    { id: "overview", heading: "Overview" },
+    { id: "steps", heading: "Steps" },
+  ];
+  const text = bundle(sections);
+  const { calls, deeps } = makeDeeps({ readText: text });
+  const result = await publishPlanBundle(
+    { sessionID: SESSION_ID, file: "plan.html", sessionDir: SESSION_DIR },
+    deeps,
+  );
+  assert.equal(result.ok, true);
+  const expectedSub = planSubdomain(SESSION_ID);
+  assert.equal(result.url, `${BASE_URL}/pages/${expectedSub}`);
+  assert.equal(calls.registerCalls.length, 1);
+  const { args, deps } = calls.registerCalls[0];
+  assert.equal(args.subdomain, expectedSub);
+  assert.equal(args.ttlHours, 0, "TTL 0 — never expires");
+  assert.equal(args.sessionID, SESSION_ID);
+  assert.equal(deps.baseUrl, BASE_URL);
+  assert.ok(args.filePath, "a staged file path is handed to register");
+});
+
+test("publishPlanBundle confines a relative in-session path by resolving against sessionDir", async () => {
+  const text = bundle([{ id: "overview", heading: "Overview" }]);
+  const { calls, deeps } = makeDeeps({ readText: text });
+  const result = await publishPlanBundle(
+    { sessionID: SESSION_ID, file: ".opencode/plans/plan.html", sessionDir: SESSION_DIR },
+    deeps,
+  );
+  assert.equal(result.ok, true);
+  assert.ok(calls.readFile.includes(SESSION_DIR), "read resolved against sessionDir");
+});
+
+test("publishPlanBundle surfaces an I/O read failure as {ok:false,error}, not a throw", async () => {
+  const { deeps } = makeDeeps();
+  const result = await publishPlanBundle(
+    { sessionID: SESSION_ID, file: "missing.html", sessionDir: SESSION_DIR },
+    deeps,
+  );
+  assert.equal(result.ok, false);
+  assert.equal(typeof result.error, "string");
+});


### PR DESCRIPTION
## Summary
Makes the single-HTML plan renderer (BET-986) reachable. Adds a `plan_render`
custom tool and a `POST /api/plan-render` route that read the authored plan
HTML bundle (confined to the session dir), parse + render it, and publish it
through the **existing** serve-page subsystem (TTL 0 = never expires).

Depends on BET-986 (`planDoc.mjs: parsePlanBundle` / `renderPlanDoc`), which is
**already merged in `main`** (#992) — this PR does NOT carry any BET-986 code,
it imports the merged `planDoc.mjs`.

## Changes (only BET-987 files)
- `src/server/planRender.mjs` (+ `planRender.test.mjs`): `publishPlanBundle` —
  confinement reuse + render→stage→`registerPage` sequence, all deps injectable
- `src/server/index.mjs`: `POST /api/plan-render` route
- `docs/opencode-tools/plan-render.ts`: thin `plan_render` registrar tool
  (installed to `~/.config/opencode/tools/`, `opencode-serve` restarted)

## Reuse (no new registry/store)
`parsePlanBundle`/`renderPlanDoc` (planDoc), `planSubdomain` (planPage),
`registerPage` (servePage), `publicBaseUrl` (gatewayRegister). Confinement
mirrors `readPlanMarkdown` but does NOT require `.md` (bundle is HTML).

## Verify
- `npm run test:server` — 1666 pass (incl. `planRender` suite; `planDoc` suite
  comes from merged BET-986)
- `npm run typecheck` — clean
- escape path → `Plan file path is outside the session directory.` (rejected)
- missing-meta / missing-anchor errors returned as `{ok:false,error}`, not thrown
- valid bundle → staged HTML rendered + `…/pages/plan-<shortSessionId>` URL (ttl 0)