### PR TITLE
BET-990: manta-plan prompt — re-call plan_render on revision so the served page never goes stale

### DIFF
--- a/docs/opencode/skills/manta-plan/prompt.md
+++ b/docs/opencode/skills/manta-plan/prompt.md
@@ -66,6 +66,11 @@ returns the shareable URL. Do NOT call `serve_page` for the plan or any mockup
 anymore — the mockup is inline in the single plan page and the plan is
 published via `plan_render`.
 
+If the plan is later revised (the user asks for changes or keeps planning),
+update the HTML bundle in place, then RE-CALL `plan_render` with the same file
+path — it republishes the SAME URL. Never leave the served page stale while
+the local bundle differs.
+
 ## 5. Hand off
 
 When the plan is written and published, invoke the `plan_exit` tool (the


### PR DESCRIPTION
Adds one paragraph to `docs/opencode/skills/manta-plan/prompt.md` §4 Publish: on revision, update the HTML bundle in place, then re-call `plan_render` with the same file path to republish the same URL. Matches the already-applied box copy so the tarball ships it on deploy. Docs/prompt-only; no code.