### PR TITLE
BET-992: feat(renderer): PlanCard always shows the plan page link via a deterministic planSubdomain URL

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -64,7 +64,8 @@ import {
   extractPlanData,
   selectableModelGroups,
 } from "./chatUtils";
-import { isPlanAgent } from "../shared/planMode.mjs";
+import { isPlanAgent, planPageUrl } from "../shared/planMode.mjs";
+import { serverBase } from "./api/httpApi";
 import {
   appendPromptHistory,
   copySavedModels,
@@ -2576,6 +2577,21 @@ export function ChatPanel({
     [sessionId],
   );
 
+  // The PlanCard's "Open page" URL. The eager-publish result wins when it's
+  // present; otherwise fall back to the DETERMINISTIC URL derived from the
+  // session id (`<base>/pages/plan-<shortSessionId>` — the same subdomain the
+  // server publishes under), so a plan_render-published plan ALWAYS shows its
+  // link even before eager-publish returns (BET-992). serverBase may be
+  // unavailable (no server configured); then there is simply no URL.
+  const planCardUrl = useMemo(() => {
+    if (planUrl) return planUrl;
+    try {
+      return planPageUrl(sessionId, serverBase());
+    } catch {
+      return "";
+    }
+  }, [planUrl, sessionId]);
+
   // The plan_exit card, built here and mounted in the transcript tail the SAME
   // way the questions are (it used to be pinned in the CardStack). Building the
   // element here keeps the closures over the plan data + the eager-published
@@ -2598,7 +2614,7 @@ export function ChatPanel({
           onKeepPlanning={(fb) => void keepPlanning(q, fb)}
           onStartDelegate={(m, fb) => startPlanDelegate(q, m, fb)}
           onRememberDelegateModel={rememberDelegateModel}
-          planUrl={planUrl}
+          planUrl={planCardUrl}
           planPublishing={planPublishing}
           onOpenInBrowser={() => {
             // Live page already published → just open it (no re-publish).

--- a/src/server/planPage.mjs
+++ b/src/server/planPage.mjs
@@ -37,40 +37,21 @@ import rehypeHighlight from "rehype-highlight";
 import { visit } from "unist-util-visit";
 import { statePath } from "../shared/paths.mjs";
 import { extractPlanMockups } from "../shared/planMockups.mjs";
+import { planSubdomain } from "../shared/planMode.mjs";
 import { registerPage } from "./servePage.mjs";
+
+// Single source for the subdomain scheme: the shared module owns
+// `planSubdomain`/`planPageUrl` (BET-992). Re-export so existing server
+// consumers importing it from here keep working — same function, not a copy.
+export { planSubdomain };
 
 // 7 days — matching the artifact mailbox, not the 24h serve-page default.
 export const PLAN_TTL_HOURS = 168;
-
-// How many [a-z0-9] chars of the session id survive into the subdomain. Kept
-// short so `plan-` + shortId never approaches the 63-char ceiling.
-const SHORT_ID_LEN = 20;
 
 // Directory the rendered source HTML is staged into before registerPage copies
 // it into the durable pages tree. Goes through statePath() (state-file rule).
 function planSrcDir() {
   return statePath("plan-pages");
-}
-
-// ---------------------------------------------------------------------------
-// Subdomain derivation — pure
-// ---------------------------------------------------------------------------
-
-/**
- * The stable subdomain for a session's plan page: `plan-<shortSessionId>`.
- * `shortSessionId` is the session id lowercased, non-alphanumerics stripped,
- * truncated to SHORT_ID_LEN chars. Returns null when the input yields no
- * usable slug (caller must refuse, matching the "never hand back a 404 URL"
- * rule). The result always satisfies isValidSubdomain.
- */
-export function planSubdomain(sessionID) {
-  if (typeof sessionID !== "string" || sessionID.length === 0) return null;
-  const slug = sessionID
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, "")
-    .slice(0, SHORT_ID_LEN);
-  if (!slug) return null;
-  return `plan-${slug}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/planMode.d.mts
+++ b/src/shared/planMode.d.mts
@@ -19,3 +19,16 @@ export function planModeFromToolPart(part: unknown): boolean | null;
  * (undefined, null, numbers, objects) and empty strings are false.
  */
 export function isPlanAgent(name: unknown): boolean;
+
+/**
+ * The stable subdomain for a session's plan page: `plan-<shortSessionId>`, or
+ * `null` when the input yields no usable slug.
+ */
+export function planSubdomain(sessionID: unknown): string | null;
+
+/**
+ * The deterministic public URL of a session's plan page:
+ * `<baseUrl>/pages/plan-<shortSessionId>`, or `""` when no usable slug. Never
+ * throws.
+ */
+export function planPageUrl(sessionID: unknown, baseUrl: unknown): string;

--- a/src/shared/planMode.mjs
+++ b/src/shared/planMode.mjs
@@ -30,3 +30,40 @@ export function isPlanAgent(name) {
   if (name === undefined || name === null || typeof name !== "string") return false;
   return name === "plan" || name === "manta-plan";
 }
+
+// How many [a-z0-9] chars of the session id survive into the plan subdomain.
+// Kept short so `plan-` + shortId never approaches the 63-char ceiling.
+const SHORT_ID_LEN = 20;
+
+/**
+ * The stable subdomain for a session's plan page: `plan-<shortSessionId>`.
+ * `shortSessionId` is the session id lowercased, non-alphanumerics stripped,
+ * truncated to SHORT_ID_LEN chars. Returns null when the input yields no
+ * usable slug (caller must refuse, matching the "never hand back a 404 URL"
+ * rule). The result always satisfies isValidSubdomain.
+ *
+ * Single source of truth for both the server (which publishes the page under
+ * this subdomain) and the renderer (which derives the deterministic URL for
+ * the PlanCard's "Open page" link — BET-992).
+ */
+export function planSubdomain(sessionID) {
+  if (typeof sessionID !== "string" || sessionID.length === 0) return null;
+  const slug = sessionID
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .slice(0, SHORT_ID_LEN);
+  if (!slug) return null;
+  return `plan-${slug}`;
+}
+
+/**
+ * The deterministic public URL of a session's plan page:
+ * `<baseUrl>/pages/plan-<shortSessionId>`. Trims a trailing slash off
+ * `baseUrl`. Returns "" when `planSubdomain` yields no usable slug. Never
+ * throws.
+ */
+export function planPageUrl(sessionID, baseUrl) {
+  const slug = planSubdomain(sessionID);
+  if (!slug) return "";
+  return `${String(baseUrl).replace(/\/+$/, "")}/pages/${slug}`;
+}

--- a/src/shared/planMode.test.ts
+++ b/src/shared/planMode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { planModeFromToolPart, isPlanAgent } from "./planMode.mjs";
+import { planModeFromToolPart, isPlanAgent, planSubdomain, planPageUrl } from "./planMode.mjs";
 
 describe("planModeFromToolPart", () => {
   it("is true for a completed plan_enter", () => {
@@ -52,5 +52,63 @@ describe("isPlanAgent", () => {
     expect(isPlanAgent(null)).toBe(false);
     expect(isPlanAgent(123)).toBe(false);
     expect(isPlanAgent({})).toBe(false);
+  });
+});
+
+describe("planSubdomain", () => {
+  it("derives plan-<shortSessionId>, lowercased, alphanumerics only, truncated to 20 chars", () => {
+    expect(planSubdomain("AbC-123")).toBe("plan-abc123");
+    expect(planSubdomain("not-a-uuid-123456789012345678901234567890")).toBe(
+      "plan-notauuid1234567890",
+    );
+  });
+
+  it("is stable per session and differs across sessions", () => {
+    const a = "sessA_someid1";
+    const b = "sessB_someid2";
+    expect(planSubdomain(a)).toBe(planSubdomain(a));
+    expect(planSubdomain(a)).not.toBe(planSubdomain(b));
+  });
+
+  it("returns null for empty / unusable input", () => {
+    expect(planSubdomain("")).toBe(null);
+    expect(planSubdomain("   ")).toBe(null);
+    expect(planSubdomain("!!!")).toBe(null);
+    expect(planSubdomain(123)).toBe(null);
+    expect(planSubdomain(null)).toBe(null);
+    expect(planSubdomain(undefined)).toBe(null);
+  });
+});
+
+describe("planPageUrl", () => {
+  it("returns <base>/pages/plan-<shortSessionId>", () => {
+    expect(planPageUrl("sess-abc", "https://box.example.com")).toBe(
+      "https://box.example.com/pages/plan-sessabc",
+    );
+  });
+
+  it("trims a trailing slash off the base", () => {
+    expect(planPageUrl("sess", "https://box.example.com/")).toBe(
+      "https://box.example.com/pages/plan-sess",
+    );
+    expect(planPageUrl("sess", "https://box.example.com///")).toBe(
+      "https://box.example.com/pages/plan-sess",
+    );
+  });
+
+  it("passes the host through unchanged for tailnet or other bases", () => {
+    expect(planPageUrl("sess-1", "http://100.64.0.1:8787")).toBe(
+      "http://100.64.0.1:8787/pages/plan-sess1",
+    );
+  });
+
+  it("returns '' when the slug is unusable", () => {
+    expect(planPageUrl("", "https://box.example.com")).toBe("");
+    expect(planPageUrl("!!!", "https://box.example.com")).toBe("");
+  });
+
+  it("never throws on a bogus baseUrl", () => {
+    expect(() => planPageUrl("sess", null)).not.toThrow();
+    expect(() => planPageUrl("sess", undefined)).not.toThrow();
   });
 });

--- a/src/shared/planMode.test.ts
+++ b/src/shared/planMode.test.ts
@@ -59,7 +59,7 @@ describe("planSubdomain", () => {
   it("derives plan-<shortSessionId>, lowercased, alphanumerics only, truncated to 20 chars", () => {
     expect(planSubdomain("AbC-123")).toBe("plan-abc123");
     expect(planSubdomain("not-a-uuid-123456789012345678901234567890")).toBe(
-      "plan-notauuid1234567890",
+      "plan-notauuid123456789012",
     );
   });
 


### PR DESCRIPTION
**BET-992 — PlanCard always shows the plan page link via a deterministic planSubdomain URL**

The `plan_exit`/PlanCard "Open page" link is currently fed only by the legacy
eager markdown-publish path, so a plan published by `plan_render` (whose URL is
known only to the model) shows a card with no link until eager-publish happens
to return. The plan page URL is deterministic (`plan-<shortSessionId>` under
the box base URL), so the card can always derive it from the session id.

## What changed

- Moved `planSubdomain` into the shared `src/shared/planMode.mjs` (the single
  home, already imported by both server and renderer) and added
  `planPageUrl(sessionID, baseUrl)` → `<base>/pages/plan-<shortSlug>` (trims
  trailing slash on base, returns `""` when no usable slug, never throws).
- `src/server/planPage.mjs` now imports (and re-exports, so existing server
  consumers keep working) the shared `planSubdomain` — the local copy and
  `SHORT_ID_LEN` are gone. Single source of truth, no duplication.
- `src/renderer/ChatPanel.tsx` defaults the PlanCard `planUrl` to
  `planPageUrl(sessionId, serverBase())` so a published plan always shows
  "Open page". An eager-publish result still wins (only the null case is
  filled). `serverBase()` may be unavailable (no server configured) — then no
  URL (caught). No card actions/props changed.
- Added `src/shared/planMode.d.mts` declarations for the two new exports.
- Tests: `planSubdomain` (now shared) + `planPageUrl` cases in
  `src/shared/planMode.test.ts`; existing `planPage`/`planRender`/`servePage`
  server tests still pass via the re-export.

Intentionally unchanged: `plan_render`/`/api/plan-render`, `parsePlanBundle`,
the serve-page registry, and the markdown `renderPlanHtml` pipeline.

**Files changed:** 5 files.
```
 src/renderer/ChatPanel.tsx  | 20 +++++++++++++--
 src/server/planPage.mjs     | 31 +++++------------------
 src/shared/planMode.d.mts   | 13 ++++++++++
 src/shared/planMode.mjs     | 37 ++++++++++++++++++++++++++++
 src/shared/planMode.test.ts | 60 ++++++++++++++++++++++++++++++++++++++++++++-
 5 files changed, 133 insertions(+), 28 deletions(-)
```

**Base: origin/main @ 17dafdb0**

**Verification results:**
- PR branch (`multica/BET-992-planurl-deterministic` @ ad281373):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, vitest 2885 pass / 0 fail / 7 skip; node 2200 pass / 0 fail. log sha256: `423e1a058af03ff91f3076912dd799b5271ca4d8c9706d8de5dbbc73b343185d`
- Base (`main` @ 17dafdb0):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, vitest 2877 pass / 0 fail / 7 skip; node 2200 pass / 0 fail. log sha256: `a4a8d299e41d86fdfd5790c0fe13e0f616dd870ebed78f7faeb8b20d9346eaba`
- **Conclusion:** 0 new failures. 8 new passing tests added (planSubdomain +
  planPageUrl); behavior otherwise unchanged.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`,
`/tmp/test-pr.log`, `/tmp/test-main.log`.

## Self-check

- Criterion 1 (single shared home, no duplicate impl): shared `planMode.mjs`
  owns it; `planPage.mjs` imports/re-exports, local copy + SHORT_ID_LEN
  deleted. → 10/10
- Criterion 2 (PlanCard planUrl defaults to deterministic URL, overrides kept):
  `planCardUrl = planUrl ?? planPageUrl(sessionId, serverBase())`, no other
  props changed. → 10/10
- Criterion 3 (never throws / no new endpoints / no touch to plan_render &
  markdown pipeline): planPageUrl is pure; only ChatPanel + shared files
  touched. → 10/10
- Criterion 4 (tests): planMode.test.ts covers subdomain + URL incl.
  trailing slash, empty slug, host passthrough, never-throw; existing server
  tests pass. → 10/10
