### PR TITLE
feat(server): BET-991 planDoc — storage-free ?theme= theme, drop renderer Summary, widen body

### DIFF
--- a/docs/opencode/skills/manta-plan/prompt.md
+++ b/docs/opencode/skills/manta-plan/prompt.md
@@ -47,6 +47,8 @@ otherwise `plan_render` rejects the publish. If it would reject, fix the
 anchor rather than skipping. Write the prose in ordinary HTML, not markdown;
 the body is served as-is.
 
+**Published-page constraint (storage-free):** the served page runs in a sandboxed origin where `localStorage`/`sessionStorage` are UNAVAILABLE and throw a `SecurityError`. Never use them in the body or in any `<script>` you add. The light/dark theme is handled automatically by the renderer via the `?theme=` URL query string — do NOT write your own theme toggle or persistence logic. Keep the body static HTML; any tiny script must not touch storage.
+
 ## 3. Mockups (only for UI/layout changes)
 
 If the plan involves a UI or layout change, render the high-fidelity preview

--- a/src/server/planDoc.mjs
+++ b/src/server/planDoc.mjs
@@ -3,7 +3,7 @@
 // `<script type="application/json" id="plan-meta">` (title + section list) plus
 // a fully model-authored rich HTML body. THIS module is the deterministic
 // renderer: it parses the meta, renders the fixed branded chrome (header,
-// dark/light toggle, summary/TOC, base token stylesheet) from that meta, and
+// dark/light toggle, base token stylesheet) from that meta, and
 // injects the model body as `<main>`. Structure is guaranteed by the template;
 // the body stays 100% AI-authored.
 //
@@ -109,34 +109,34 @@ export function parsePlanBundle(text) {
 // renderPlanDoc — the deterministic branded document
 // ---------------------------------------------------------------------------
 
-// The theme toggle script — inline, self-contained, in-memory only. Sets the
-// theme from a variable (falling back to prefers-color-scheme) on load, and
-// flips `data-theme` on <html> when the header button is clicked. Deliberately
-// NO localStorage: the page is served in an opaque-origin sandbox (serve-page
-// CSP without allow-same-origin), where localStorage throws.
+// The theme toggle script — inline, self-contained, storage-free. Reads the
+// initial theme from the `?theme=` query string (accepting exactly "dark" |
+// "light"), falling back to prefers-color-scheme; flips `data-theme` on <html>
+// and persists via `history.replaceState` (no reload, no storage). Deliberately
+// NO localStorage/sessionStorage: the page is served in an opaque-origin
+// sandbox (serve-page CSP without allow-same-origin), where storage throws.
 const THEME_SCRIPT = `
 <script>
 (function () {
-  var theme = "";
   var root = document.documentElement;
-  function apply() {
-    if (!theme) {
-      theme = (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches)
-        ? "dark" : "light";
-    }
-    root.setAttribute("data-theme", theme);
-  }
-  apply();
+  var match = /^(dark|light)$/.exec(new URLSearchParams(location.search).get("theme") || "");
+  var theme = match ? match[1]
+    : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches)
+      ? "dark" : "light";
+  root.setAttribute("data-theme", theme);
   var toggle = document.getElementById("plan-theme-toggle");
   if (toggle) toggle.addEventListener("click", function () {
-    theme = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
-    root.setAttribute("data-theme", theme);
+    var next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
+    root.setAttribute("data-theme", next);
+    try {
+      history.replaceState(null, "", "?theme=" + next);
+    } catch (e) {}
   });
 })();
 </script>
 `.trim();
 
-// Minimal prose typography + header/summary styling, all referenced via the
+// Minimal prose typography + header styling, all referenced via the
 // imported token blocks (no copied planPage body stylesheet, no external
 // resources).
 const BASE_STYLE = `
@@ -183,25 +183,7 @@ const BASE_STYLE = `
     line-height: 1;
   }
   .doc-header button:hover { border-color: var(--border-strong); }
-  .wrap { max-width: 720px; margin: 0 auto; padding: 28px; }
-  .summary {
-    margin: 0 0 28px;
-    padding: 14px 18px;
-    background: var(--inset);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--r-sm);
-  }
-  .summary-title {
-    margin: 0 0 8px;
-    font-size: 11px;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    color: var(--tx4);
-  }
-  .summary ul { margin: 0; padding: 0; list-style: none; }
-  .summary li { margin: 3px 0; font-size: 13.5px; }
-  .summary a { color: var(--tx2); text-decoration: none; }
-  .summary a:hover { color: var(--accent-tx); text-decoration: underline; }
+  .wrap { max-width: 1080px; margin: 0 auto; padding: 32px 40px; }
   main { color: var(--tx1); }
   main h1, main h2, main h3, main h4, main h5, main h6 {
     color: var(--tx1);
@@ -239,10 +221,10 @@ const BASE_STYLE = `
  * Render a full, self-contained HTML plan document from a parsed bundle.
  *
  * - Validates that every `section.id` has a matching `id="<id>"` anchor in the
- *   body (so TOC links never dead-end) — fail-fast on the first missing one.
+ *   body — fail-fast on the first missing one.
  * - The model `body` is injected VERBATIM (after the meta is stripped); it is
  *   deliberately NOT re-escaped — it is the model's authored HTML.
- * - Title, headings, and header text are escaped via `escapeHtml`.
+ * - Title and header text are escaped via `escapeHtml`.
  * - The only `<script>` is the theme toggle; no iframe, no external resources,
  *   no localStorage.
  *
@@ -266,20 +248,6 @@ export function renderPlanDoc({ title, sections, body }) {
       return { ok: false, error: `section id '${s.id}' not found in body` };
     }
   }
-
-  const tocHtml =
-    sections.length > 1
-      ? `<nav class="summary" aria-label="Summary">
-  <p class="summary-title">Summary</p>
-  <ul>
-${sections
-  .map(
-    (s) => `    <li><a href="#${escapeHtml(s.id)}">${escapeHtml(s.heading)}</a></li>`,
-  )
-  .join("\n")}
-  </ul>
-</nav>`
-      : "";
 
   const html = `<!DOCTYPE html>
 <html lang="en" data-theme="light">
@@ -305,7 +273,6 @@ ${sections
     <button id="plan-theme-toggle" type="button" title="Toggle theme">&#9680;</button>
   </header>
   <div class="wrap">
-    ${tocHtml}
     <main>
 ${body}
     </main>

--- a/src/server/planDoc.test.mjs
+++ b/src/server/planDoc.test.mjs
@@ -114,18 +114,31 @@ test("renderPlanDoc: includes the theme toggle script and no localStorage/iframe
   const r = renderSample();
   assert.ok(r.html.includes("prefers-color-scheme"));
   assert.ok(r.html.includes("data-theme"));
+  assert.ok(r.html.includes("URLSearchParams"), "theme read via URLSearchParams");
+  assert.ok(r.html.includes("history.replaceState"), "theme persisted via history.replaceState");
+  assert.ok(r.html.includes("\"?theme=\" + next"), "replaceState writes ?theme= next");
   assert.ok(!r.html.toLowerCase().includes("localstorage"));
+  assert.ok(!r.html.toLowerCase().includes("sessionstorage"));
   assert.ok(!r.html.toLowerCase().includes("<iframe"));
   assert.ok(!r.html.includes("http://"));
   assert.ok(!r.html.includes("https://"));
 });
 
-test("renderPlanDoc: renders Summary/TOC when sections.length > 1, with #id links", () => {
+test("renderPlanDoc: renders NO Summary nav even when sections.length > 1", () => {
+  const parsed = parsePlanBundle(SAMPLE_BUNDLE);
+  assert.equal(parsed.ok, true);
+  assert.ok(parsed.sections.length > 1, "sample has multiple sections");
+  const r = renderPlanDoc(parsed);
+  assert.equal(r.ok, true);
+  assert.ok(!r.html.includes("Summary"));
+  assert.ok(!r.html.includes("class=\"summary\""));
+  assert.ok(!r.html.includes("aria-label=\"Summary\""));
+});
+
+test("renderPlanDoc: base stylesheet widens the body container to 1080px", () => {
   const r = renderSample();
-  assert.ok(r.html.includes("Summary"));
-  assert.ok(r.html.includes("href=\"#intro\""));
-  assert.ok(r.html.includes("href=\"#steps\""));
-  assert.ok(r.html.includes("href=\"#outro\""));
+  assert.ok(r.html.includes(".wrap { max-width: 1080px; margin: 0 auto; padding: 32px 40px; }"));
+  assert.ok(!r.html.includes("max-width: 720px"));
 });
 
 test("renderPlanDoc: renders NO Summary block when sections.length <= 1", () => {
@@ -163,7 +176,7 @@ test("renderPlanDoc: injects the body verbatim without double-escaping sentinels
   assert.ok(!r.html.includes("&amp;lt;"), "< must not become &amp;lt;");
 });
 
-test("renderPlanDoc: escapes title and heading text", () => {
+test("renderPlanDoc: escapes title text", () => {
   const body = "<p id=\"x\">anchor</p><p id=\"y\">anchor2</p>";
   const r = renderPlanDoc({
     title: "A < Title & More",
@@ -175,5 +188,4 @@ test("renderPlanDoc: escapes title and heading text", () => {
   });
   assert.equal(r.ok, true);
   assert.ok(r.html.includes("A &lt; Title &amp; More"), "title escaped");
-  assert.ok(r.html.includes("L &lt; R"), "heading escaped in TOC");
 });


### PR DESCRIPTION
Storage-free ?theme= theme toggle, removed renderer-generated Summary/TOC, widened body container to 1080px in planDoc.mjs (proper fix; box already patched for relief).

**Files changed:** 3
- `src/server/planDoc.mjs` — THEME_SCRIPT now reads `?theme=` via `URLSearchParams` (dark|light, falls back to prefers-color-scheme), flips data-theme + persists via `history.replaceState(null,"","?theme="+next)` wrapped in try/catch; NO localStorage/sessionStorage. Removed the renderer-generated Summary nav (`tocHtml` const, its template usage, and all `.summary*` CSS rules). Kept section-id anchor validation and the `sections` meta contract unchanged. Widen `.wrap` to `max-width:1080px; padding:32px 40px`.
- `src/server/planDoc.test.mjs` — added no-storage + URLSearchParams/history.replaceState assertion; added no-Summary-nav-when->1-section test; added max-width:1080px test; updated the summary/heading-escape tests for removal.
- `docs/opencode/skills/manta-plan/prompt.md` — added the verbatim storage-free published-page paragraph after the Contract rule paragraph.

**Verification results:**
- `npm run test:server`: 1667 pass / 0 fail (planDoc 15/15).
- `npm run typecheck`: clean.
- `npm test` (full suite): 2201 pass / 0 fail.

**New THEME_SCRIPT** (no storage tokens, ?theme= read, history.replaceState write):
```
(function () {
  var root = document.documentElement;
  var match = /^(dark|light)$/.exec(new URLSearchParams(location.search).get("theme") || "");
  var theme = match ? match[1]
    : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches)
      ? "dark" : "light";
  root.setAttribute("data-theme", theme);
  var toggle = document.getElementById("plan-theme-toggle");
  if (toggle) toggle.addEventListener("click", function () {
    var next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
    root.setAttribute("data-theme", next);
    try {
      history.replaceState(null, "", "?theme=" + next);
    } catch (e) {}
  });
})();
```
Confirmed: no `localStorage`/`sessionStorage` in output, no `class="summary"` in render (even with multiple sections), `.wrap { max-width: 1080px; … }` present in rendered `<style>`, no `max-width: 720px` remains. Diff touches only the three repo files above.

Base: origin/main @ 17dafdb0