### PR TITLE
BET-993: fix(server): emit a MantaUI plan-ready notification on plan_exit, not opencode's raw plan path

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -64,7 +64,8 @@ import {
   extractPlanData,
   selectableModelGroups,
 } from "./chatUtils";
-import { isPlanAgent } from "../shared/planMode.mjs";
+import { isPlanAgent, planPageUrl } from "../shared/planMode.mjs";
+import { serverBase } from "./api/httpApi";
 import {
   appendPromptHistory,
   copySavedModels,
@@ -2576,6 +2577,21 @@ export function ChatPanel({
     [sessionId],
   );
 
+  // The PlanCard's "Open page" URL. The eager-publish result wins when it's
+  // present; otherwise fall back to the DETERMINISTIC URL derived from the
+  // session id (`<base>/pages/plan-<shortSessionId>` — the same subdomain the
+  // server publishes under), so a plan_render-published plan ALWAYS shows its
+  // link even before eager-publish returns (BET-992). serverBase may be
+  // unavailable (no server configured); then there is simply no URL.
+  const planCardUrl = useMemo(() => {
+    if (planUrl) return planUrl;
+    try {
+      return planPageUrl(sessionId, serverBase());
+    } catch {
+      return "";
+    }
+  }, [planUrl, sessionId]);
+
   // The plan_exit card, built here and mounted in the transcript tail the SAME
   // way the questions are (it used to be pinned in the CardStack). Building the
   // element here keeps the closures over the plan data + the eager-published
@@ -2598,7 +2614,7 @@ export function ChatPanel({
           onKeepPlanning={(fb) => void keepPlanning(q, fb)}
           onStartDelegate={(m, fb) => startPlanDelegate(q, m, fb)}
           onRememberDelegateModel={rememberDelegateModel}
-          planUrl={planUrl}
+          planUrl={planCardUrl}
           planPublishing={planPublishing}
           onOpenInBrowser={() => {
             // Live page already published → just open it (no re-publish).

--- a/src/server/planPage.mjs
+++ b/src/server/planPage.mjs
@@ -37,40 +37,21 @@ import rehypeHighlight from "rehype-highlight";
 import { visit } from "unist-util-visit";
 import { statePath } from "../shared/paths.mjs";
 import { extractPlanMockups } from "../shared/planMockups.mjs";
+import { planSubdomain } from "../shared/planMode.mjs";
 import { registerPage } from "./servePage.mjs";
+
+// Single source for the subdomain scheme: the shared module owns
+// `planSubdomain`/`planPageUrl` (BET-992). Re-export so existing server
+// consumers importing it from here keep working — same function, not a copy.
+export { planSubdomain };
 
 // 7 days — matching the artifact mailbox, not the 24h serve-page default.
 export const PLAN_TTL_HOURS = 168;
-
-// How many [a-z0-9] chars of the session id survive into the subdomain. Kept
-// short so `plan-` + shortId never approaches the 63-char ceiling.
-const SHORT_ID_LEN = 20;
 
 // Directory the rendered source HTML is staged into before registerPage copies
 // it into the durable pages tree. Goes through statePath() (state-file rule).
 function planSrcDir() {
   return statePath("plan-pages");
-}
-
-// ---------------------------------------------------------------------------
-// Subdomain derivation — pure
-// ---------------------------------------------------------------------------
-
-/**
- * The stable subdomain for a session's plan page: `plan-<shortSessionId>`.
- * `shortSessionId` is the session id lowercased, non-alphanumerics stripped,
- * truncated to SHORT_ID_LEN chars. Returns null when the input yields no
- * usable slug (caller must refuse, matching the "never hand back a 404 URL"
- * rule). The result always satisfies isValidSubdomain.
- */
-export function planSubdomain(sessionID) {
-  if (typeof sessionID !== "string" || sessionID.length === 0) return null;
-  const slug = sessionID
-    .toLowerCase()
-    .replace(/[^a-z0-9]/g, "")
-    .slice(0, SHORT_ID_LEN);
-  if (!slug) return null;
-  return `plan-${slug}`;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -304,14 +304,6 @@ export function routeNotification(payload, presence, now = Date.now()) {
 // ---------------------------------------------------------------------------
 
 /**
- * Decide whether an opencode event should produce a notification and, if so,
- * what it says. Pure — all state comes in via `ctx`.
- *
- * @param {{type?: string, properties?: any}} evt
- * @param {{ focusSessionId: string|null, focusVisible: boolean, wasBusy: boolean, pendingAttention?: boolean }} ctx
- * @returns {{ kind: string, title: string, body: string, sessionId: string|null, tag: string }|null}
- */
-/**
  * Whether a question is opencode's plan_exit approval — the "Plan ready"
  * handoff at the end of plan mode (BET-993). opencode's plan_exit question
  * literal starts with "Plan at " and carries header "Build Agent". We match
@@ -329,6 +321,14 @@ function isPlanExitQuestion(q) {
 const PLAN_READY_BODY =
   "Your plan is ready to review — open it, then approve or keep planning.";
 
+/**
+ * Decide whether an opencode event should produce a notification and, if so,
+ * what it says. Pure — all state comes in via `ctx`.
+ *
+ * @param {{type?: string, properties?: any}} evt
+ * @param {{ focusSessionId: string|null, focusVisible: boolean, wasBusy: boolean, pendingAttention?: boolean }} ctx
+ * @returns {{ kind: string, title: string, body: string, sessionId: string|null, tag: string }|null}
+ */
 export function classifyPushEvent(evt, ctx) {
   const type = evt?.type;
   const props = evt?.properties ?? {};

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -33,6 +33,8 @@
 
 import { join } from "node:path";
 import { statePath } from "../shared/paths.mjs";
+import { planPageUrl } from "../shared/planMode.mjs";
+import { publicBaseUrl } from "./gatewayRegister.mjs";
 import * as tmux from "./tmux.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { loadJobs } from "./delegate.mjs";
@@ -309,6 +311,24 @@ export function routeNotification(payload, presence, now = Date.now()) {
  * @param {{ focusSessionId: string|null, focusVisible: boolean, wasBusy: boolean, pendingAttention?: boolean }} ctx
  * @returns {{ kind: string, title: string, body: string, sessionId: string|null, tag: string }|null}
  */
+/**
+ * Whether a question is opencode's plan_exit approval — the "Plan ready"
+ * handoff at the end of plan mode (BET-993). opencode's plan_exit question
+ * literal starts with "Plan at " and carries header "Build Agent". We match
+ * either so the detection survives opencode phrasing drift.
+ */
+function isPlanExitQuestion(q) {
+  if (!q || typeof q !== "object") return false;
+  const question = typeof q.question === "string" ? q.question : "";
+  return question.startsWith("Plan at ") || q.header === "Build Agent";
+}
+
+// MantaUI's notification body for the plan_exit approval, replacing opencode's
+// raw "Plan at <derived .md path>…" text so no opencode path ever leaks to the
+// user. The plan page URL (BET-992) is appended when the box is addressable.
+const PLAN_READY_BODY =
+  "Your plan is ready to review — open it, then approve or keep planning.";
+
 export function classifyPushEvent(evt, ctx) {
   const type = evt?.type;
   const props = evt?.properties ?? {};
@@ -361,14 +381,25 @@ export function classifyPushEvent(evt, ctx) {
       // Body shows the question text, prefixed with the header when we have a
       // label in the title (so the "what kind" cue isn't lost). Without a label
       // the title still carries the header (legacy "Claude: <header>" form).
-      const qBody = first?.question || "Claude needs your input to continue.";
+      // opencode's plan_exit approval is MantaUI's "Plan ready" handoff: swap
+      // the raw "Plan at <path>.md…" question for a clean line + the plan page
+      // URL (BET-992) when the box is addressable. Everything else is unchanged.
+      const isPlan = isPlanExitQuestion(first);
+      let qBody = first?.question || "Claude needs your input to continue.";
+      if (isPlan) {
+        const url = planPageUrl(sessionId, publicBaseUrl());
+        qBody = url ? `${PLAN_READY_BODY}\n\n${url}` : PLAN_READY_BODY;
+      }
       const out = {
         kind: "question",
         title: titleOr(
           first?.header ? `Claude: ${first.header}` : "Claude has a question",
         ),
-        body:
-          label && first?.header ? `${first.header} — ${qBody}` : qBody,
+        body: isPlan
+          ? qBody
+          : label && first?.header
+            ? `${first.header} — ${qBody}`
+            : qBody,
         sessionId,
         tag: `question-${tagBase}`,
         requestId,

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -3,6 +3,8 @@ import assert from "node:assert/strict";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { rm } from "node:fs/promises";
+import { mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { statePath } from "../shared/paths.mjs";
 import {
   classifyPushEvent,
   buildSessionLabel,
@@ -103,6 +105,90 @@ test("question.asked carries the question text + option actions (single select)"
     { action: "ans:1", title: "No" },
     { action: "ans:2", title: "Wait" },
   ]);
+});
+
+test("plan_exit question → MantaUI plan-ready body + plan page URL, no raw path (BET-993)", () => {
+  // Make the box addressable so publicBaseUrl() resolves (auth.json under the
+  // MANTA_STATE_HOME sandbox, read fresh on every call). Cleaned up after.
+  const authPath = statePath("auth.json");
+  mkdirSync(statePath(), { recursive: true });
+  writeFileSync(authPath, JSON.stringify({ gateway_host: "box123.boxes.mantaui.com" }));
+  try {
+    const p = classifyPushEvent(
+      {
+        type: "question.asked",
+        properties: {
+          sessionID: "ses_plan",
+          questions: [
+            {
+              header: "Build Agent",
+              question:
+                "Plan at .opencode/plans/sunny-eagle.md is complete. Would you like to switch to the build agent?",
+            },
+          ],
+        },
+      },
+      NOFOCUS,
+    );
+    assert.equal(p?.kind, "question");
+    assert.match(p?.body ?? "", /Your plan is ready to review/);
+    assert.match(
+      p?.body ?? "",
+      /https:\/\/box123\.boxes\.mantaui\.com\/pages\/plan-sesplan/,
+    );
+    assert.ok(!(p?.body ?? "").includes(".md"), "no raw .md path leaks");
+    assert.ok(!(p?.body ?? "").includes("Plan at"), "no 'Plan at' literal leaks");
+  } finally {
+    rmSync(authPath, { force: true });
+  }
+});
+
+test("plan_exit question with unresolvable URL → body is just the clean line (BET-993)", () => {
+  // No sessionID → planPageUrl cannot build a slug → returns "" → nothing appended.
+  const p = classifyPushEvent(
+    {
+      type: "question.asked",
+      properties: {
+        questions: [{ header: "Build Agent", question: "Plan at foo.md is complete?" }],
+      },
+    },
+    NOFOCUS,
+  );
+  assert.equal(
+    p?.body,
+    "Your plan is ready to review — open it, then approve or keep planning.",
+  );
+  assert.ok(!(p?.body ?? "").includes("Plan at"));
+});
+
+test("plan_exit detected via header alone (question not prefixed with 'Plan at ') (BET-993)", () => {
+  const p = classifyPushEvent(
+    {
+      type: "question.asked",
+      properties: {
+        sessionID: "ses_plan_h",
+        questions: [{ header: "Build Agent", question: "Ready to hand off?" }],
+      },
+    },
+    NOFOCUS,
+  );
+  assert.match(p?.body ?? "", /Your plan is ready to review/);
+  assert.ok(!(p?.body ?? "").includes(".md"));
+});
+
+test("normal question → body unchanged (BET-993 regression)", () => {
+  const p = classifyPushEvent(
+    {
+      type: "question.asked",
+      properties: {
+        sessionID: "ses_norm",
+        questions: [{ header: "Deploy?", question: "Should I deploy to production now?" }],
+      },
+    },
+    NOFOCUS,
+  );
+  assert.equal(p?.kind, "question");
+  assert.equal(p?.body, "Should I deploy to production now?");
 });
 
 test("question.asked with multi-select → text but NO quick actions", () => {

--- a/src/shared/planMode.d.mts
+++ b/src/shared/planMode.d.mts
@@ -19,3 +19,16 @@ export function planModeFromToolPart(part: unknown): boolean | null;
  * (undefined, null, numbers, objects) and empty strings are false.
  */
 export function isPlanAgent(name: unknown): boolean;
+
+/**
+ * The stable subdomain for a session's plan page: `plan-<shortSessionId>`, or
+ * `null` when the input yields no usable slug.
+ */
+export function planSubdomain(sessionID: unknown): string | null;
+
+/**
+ * The deterministic public URL of a session's plan page:
+ * `<baseUrl>/pages/plan-<shortSessionId>`, or `""` when no usable slug. Never
+ * throws.
+ */
+export function planPageUrl(sessionID: unknown, baseUrl: unknown): string;

--- a/src/shared/planMode.mjs
+++ b/src/shared/planMode.mjs
@@ -30,3 +30,40 @@ export function isPlanAgent(name) {
   if (name === undefined || name === null || typeof name !== "string") return false;
   return name === "plan" || name === "manta-plan";
 }
+
+// How many [a-z0-9] chars of the session id survive into the plan subdomain.
+// Kept short so `plan-` + shortId never approaches the 63-char ceiling.
+const SHORT_ID_LEN = 20;
+
+/**
+ * The stable subdomain for a session's plan page: `plan-<shortSessionId>`.
+ * `shortSessionId` is the session id lowercased, non-alphanumerics stripped,
+ * truncated to SHORT_ID_LEN chars. Returns null when the input yields no
+ * usable slug (caller must refuse, matching the "never hand back a 404 URL"
+ * rule). The result always satisfies isValidSubdomain.
+ *
+ * Single source of truth for both the server (which publishes the page under
+ * this subdomain) and the renderer (which derives the deterministic URL for
+ * the PlanCard's "Open page" link — BET-992).
+ */
+export function planSubdomain(sessionID) {
+  if (typeof sessionID !== "string" || sessionID.length === 0) return null;
+  const slug = sessionID
+    .toLowerCase()
+    .replace(/[^a-z0-9]/g, "")
+    .slice(0, SHORT_ID_LEN);
+  if (!slug) return null;
+  return `plan-${slug}`;
+}
+
+/**
+ * The deterministic public URL of a session's plan page:
+ * `<baseUrl>/pages/plan-<shortSessionId>`. Trims a trailing slash off
+ * `baseUrl`. Returns "" when `planSubdomain` yields no usable slug. Never
+ * throws.
+ */
+export function planPageUrl(sessionID, baseUrl) {
+  const slug = planSubdomain(sessionID);
+  if (!slug) return "";
+  return `${String(baseUrl).replace(/\/+$/, "")}/pages/${slug}`;
+}

--- a/src/shared/planMode.test.ts
+++ b/src/shared/planMode.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { planModeFromToolPart, isPlanAgent } from "./planMode.mjs";
+import { planModeFromToolPart, isPlanAgent, planSubdomain, planPageUrl } from "./planMode.mjs";
 
 describe("planModeFromToolPart", () => {
   it("is true for a completed plan_enter", () => {
@@ -52,5 +52,63 @@ describe("isPlanAgent", () => {
     expect(isPlanAgent(null)).toBe(false);
     expect(isPlanAgent(123)).toBe(false);
     expect(isPlanAgent({})).toBe(false);
+  });
+});
+
+describe("planSubdomain", () => {
+  it("derives plan-<shortSessionId>, lowercased, alphanumerics only, truncated to 20 chars", () => {
+    expect(planSubdomain("AbC-123")).toBe("plan-abc123");
+    expect(planSubdomain("not-a-uuid-123456789012345678901234567890")).toBe(
+      "plan-notauuid1234567890",
+    );
+  });
+
+  it("is stable per session and differs across sessions", () => {
+    const a = "sessA_someid1";
+    const b = "sessB_someid2";
+    expect(planSubdomain(a)).toBe(planSubdomain(a));
+    expect(planSubdomain(a)).not.toBe(planSubdomain(b));
+  });
+
+  it("returns null for empty / unusable input", () => {
+    expect(planSubdomain("")).toBe(null);
+    expect(planSubdomain("   ")).toBe(null);
+    expect(planSubdomain("!!!")).toBe(null);
+    expect(planSubdomain(123)).toBe(null);
+    expect(planSubdomain(null)).toBe(null);
+    expect(planSubdomain(undefined)).toBe(null);
+  });
+});
+
+describe("planPageUrl", () => {
+  it("returns <base>/pages/plan-<shortSessionId>", () => {
+    expect(planPageUrl("sess-abc", "https://box.example.com")).toBe(
+      "https://box.example.com/pages/plan-sessabc",
+    );
+  });
+
+  it("trims a trailing slash off the base", () => {
+    expect(planPageUrl("sess", "https://box.example.com/")).toBe(
+      "https://box.example.com/pages/plan-sess",
+    );
+    expect(planPageUrl("sess", "https://box.example.com///")).toBe(
+      "https://box.example.com/pages/plan-sess",
+    );
+  });
+
+  it("passes the host through unchanged for tailnet or other bases", () => {
+    expect(planPageUrl("sess-1", "http://100.64.0.1:8787")).toBe(
+      "http://100.64.0.1:8787/pages/plan-sess1",
+    );
+  });
+
+  it("returns '' when the slug is unusable", () => {
+    expect(planPageUrl("", "https://box.example.com")).toBe("");
+    expect(planPageUrl("!!!", "https://box.example.com")).toBe("");
+  });
+
+  it("never throws on a bogus baseUrl", () => {
+    expect(() => planPageUrl("sess", null)).not.toThrow();
+    expect(() => planPageUrl("sess", undefined)).not.toThrow();
   });
 });

--- a/src/shared/planMode.test.ts
+++ b/src/shared/planMode.test.ts
@@ -59,7 +59,7 @@ describe("planSubdomain", () => {
   it("derives plan-<shortSessionId>, lowercased, alphanumerics only, truncated to 20 chars", () => {
     expect(planSubdomain("AbC-123")).toBe("plan-abc123");
     expect(planSubdomain("not-a-uuid-123456789012345678901234567890")).toBe(
-      "plan-notauuid1234567890",
+      "plan-notauuid123456789012",
     );
   });
 


### PR DESCRIPTION
## What
When opencode emits its `plan_exit` approval question ("Plan at <derived .md path> is complete…", header `"Build Agent"`), the `question.asked` push used to echo the **raw question text**, leaking a bogus `.md` path into the notification. MantaUI now owns plan-ready presentation: for a plan_exit question (`question` starts with `"Plan at "` OR `header === "Build Agent"`), the push body is replaced with a clean MantaUI line plus the deterministic plan page URL (via BET-992's shared `planPageUrl(sessionID, publicBaseUrl())`), appended only when resolvable. All non-plan questions are byte-for-byte unchanged.

**Depends on BET-992 (#997).** This branch is built on `multica/BET-992-planurl-deterministic` so `planPageUrl` (added there to `src/shared/planMode.mjs`) resolves; merge #997 first, then this PR's diff against `main` collapses to the two `push.*` files.

## Verification results
- `npm run typecheck`: exit 0, no errors.
- `npm run test:server`: exit 0, 1670 pass / 0 fail / 0 skip.
- New tests (4) in `src/server/push.test.mjs`:
  - `plan_exit question → MantaUI plan-ready body + plan page URL, no raw path (BET-993)` — body is the clean line + `https://box123.boxes.mantaui.com/pages/plan-sesplan`, contains NO `.md` / `Plan at`.
  - `plan_exit question with unresolvable URL → body is just the clean line (BET-993)` — no empty link appended.
  - `plan_exit detected via header alone` — `"Build Agent"` header catches a non-"Plan at " question.
  - `normal question → body unchanged (BET-993 regression)`.
- Imports: `planPageUrl` from `../shared/planMode.mjs`, `publicBaseUrl` from `./gatewayRegister.mjs` — no re-derived URL builder, no hardcoded host.
