### PR TITLE
BET-996: fix(renderer): themed loading state on provider credential submit button

### DIFF
--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -45,7 +45,7 @@
 // server-side SUBSCRIPTION_PROVIDERS table in subscriptionProviders.mjs.
 
 import { memo, useCallback, useEffect, useRef, useState } from "react";
-import { X } from "lucide-react";
+import { X, Loader2 } from "lucide-react";
 import type { OpencodeProviderAuthRequest } from "../shared/types";
 import {
   connectPhaseLabel,
@@ -56,6 +56,7 @@ import {
   type ConnectPhase,
 } from "./chatUtils";
 import { CopyButton } from "./CopyButton";
+import { Button } from "./Button";
 import { Terminal } from "./Terminal";
 import { useStore } from "./store";
 import { ProcessPanel } from "./ProcessPanel";
@@ -946,13 +947,17 @@ const CredentialInput = memo(function CredentialInput({
           autoCorrect="off"
           className="min-w-0 flex-1 rounded-xs border border-border bg-bg px-2 py-1 font-mono text-text outline-none"
         />
-        <button
+        <Button
+          tone="primary"
           onClick={() => void submit()}
           disabled={!canSubmit}
-          className="shrink-0 px-2 py-1 rounded-xs border disabled:opacity-40 border-border text-text-muted hover:text-text"
+          loading={submitting}
         >
-          {submitting ? "…" : submitLabel}
-        </button>
+          {submitting ? (
+            <Loader2 size={14} className="animate-spin" aria-hidden />
+          ) : null}
+          {submitting ? "Submitting…" : submitLabel}
+        </Button>
       </div>
       {error && <div className="text-danger text-label break-words">{error}</div>}
     </div>


### PR DESCRIPTION
**BET-996** — themed loading state for the provider credential submit button (all providers).

## What
- `src/renderer/ConnectProvider.tsx` — the shared `CredentialInput` submit button (used by every provider input: Claude Code paste-code and API-key providers) now renders as the repo's primary `Button` (`tone="primary"`) with a themed loading state: a lucide `Loader2` + `animate-spin` spinner (inherits the primary `text-on-accent` foreground via `currentColor`) and a `Submitting…` label while the round-trip is in flight. It stays disabled while submitting and on empty input; Enter-key submit, the error line below, and all existing behaviour are unchanged.
- `src/renderer/CustomProviderForm.tsx` — audited and already correct: it uses `Button tone="primary"` with a `Loader2` spinner + disabled state. No change.
- Audited the rest of the renderer for other provider credential submits — none outside the two cards. (The `"…"` states on "Disconnect" / "Refresh" in `SubscriptionsCard.tsx` / `ProvidersCard.tsx` are connect-state buttons, explicitly out of scope per the issue.)

## Anti-spaghetti
- Reused the shared `Button` primitive + existing `Loader2`/`animate-spin` pattern — no new components or tokens.

**Files changed:** `1` file (`src/renderer/ConnectProvider.tsx`).

**Base: origin/main @ `4d43a5a0`**

**Verification results:**
- PR branch (`multica/BET-996-themed-submit-loading` @ `a7bf1295`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2205 pass / 0 fail / 0 skip. Failures: none. log sha256: `94730c02079f0e5db916976c7e05874fb80502e1fc2a0a1da263fc68e9d9d299`
- Base (`main`): base-branch run skipped — `main` is checked out in a sibling worktree, so it can't be checked out here. Change is a single renderer file; the suite that runs this file is the same vitest suite already run green above.
- **Conclusion:** 0 failures on the PR branch; no new failures.
