### PR TITLE
fix(renderer): onboarding Continue button shrink-to-fit, right-aligned

### DIFF
--- a/src/renderer/onboardingUi.tsx
+++ b/src/renderer/onboardingUi.tsx
@@ -136,7 +136,7 @@ export function StepFooter({
         <ArrowLeft />
         Back
       </button>
-      <Button tone="primary" block type="button" onClick={onContinue} disabled={continueDisabled}>
+      <Button tone="primary" type="button" onClick={onContinue} disabled={continueDisabled}>
         {continueLabel}
         <ArrowRight />
       </Button>


### PR DESCRIPTION
## What

Onboarding step footer: the primary **Continue** button was stretched full-width via the `block` prop. Removed the `block` prop so it shrinks to content-width while staying right-aligned in the `justify-between` footer. The Back button, footer layout, and `continueDisabled` gate are untouched.

Fixes BET-997.

## Self-check

- **CRITERION 1: Continue button content-width, right-aligned, on all onboarding steps** → 10/10. All steps use the same `StepFooter`; the single shared button no longer carries `block`, so every step inherits shrink-to-fit. The flex row's `justify-between` keeps it right-aligned.
- **CRITERION 2: No functional/layout regression to the footer (Back left, gap preserved)** → 10/10. Only the `block` prop removed from the Continue button; no CSS/layout changes.

Base: origin/main @ 0ee14f2e

**Files changed:** 1 file. `src/renderer/onboardingUi.tsx`

**Verification results:**
- PR branch (`multica/BET-997-onboarding-continue-shrink` @ `fc3bf2e9`):
  - typecheck: exit `0`. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit `0`, 2178 pass / 0 fail / 0 skip. Failures: none. log sha256: `c9f99857f7910f8c36eb1aea83c1d909b26bea5cdf9cdda7292c7e554131fb6e`
- Base (`main` @ `0ee14f2e`):
  - typecheck: exit `0`. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit `0`, 2178 pass / 0 fail / 0 skip. Failures: none. log sha256: `bc9565b1a755ac18cb534087807c77bf032e4bf434d5239fdfca5dac9d045331`
- **Conclusion:** 0 new failures, 0 pre-existing. (PR test log hash differs from base only by run metadata; both suites report identical pass/fail counts.)

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
