### PR TITLE
fix(install): create MANTA_HOME parent dir before the atomic swap (BET-999)

### DIFF
--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -150,6 +150,22 @@ jobs:
           echo "MANTA_DEPLOY_REF=origin/main" >> "$GITHUB_ENV"
           echo "deploy source: this PR ($(git rev-parse --short HEAD))"
 
+      - name: Create a genuinely fresh HOME
+        run: |
+          set -euo pipefail
+          # BET-999's fix is a mkdir of MANTA_HOME's parent (~/.local/share) on a
+          # fresh box. To actually exercise it, the install must run against a
+          # home whose XDG parent does NOT pre-exist. The GitHub macOS runner's
+          # stock /Users/runner already ships with ~/.local/share, so pointing
+          # the install at the stock $HOME would make the mkdir a silent no-op.
+          # Point the WHOLE job at a fresh home we create here; every subsequent
+          # $HOME (clean-slate, opencode pre-install, install, LaunchAgents, the
+          # manta shim, re-install) resolves against it.
+          FRESH_HOME="$RUNNER_TEMP/fresh-home"
+          mkdir -p "$FRESH_HOME"
+          echo "HOME=$FRESH_HOME" >> "$GITHUB_ENV"
+          echo "fresh HOME=$FRESH_HOME"
+
       - name: Install box prerequisites (tmux)
         run: |
           set -euo pipefail
@@ -163,11 +179,11 @@ jobs:
       - name: Assert a clean slate (no prior box identity)
         run: |
           set -euo pipefail
-          # $HOME/.local/share (the PARENT of the XDG-default MANTA_HOME) must
-          # also be absent, not just $HOME/.local/share/manta: BET-999's fix is
-          # precisely the mkdir of that parent on a fresh box. If the parent
-          # already exists the install's mkdir is a silent no-op and the bug
-          # can slip back in without this job noticing.
+          # This runs against the fresh HOME created above, which genuinely has
+          # no ~/.manta, ~/manta, ~/.local/share (the PARENT of the XDG-default
+          # MANTA_HOME) or LaunchAgent. Requiring the parent absent is the point:
+          # BET-999's mkdir must create it, and a leftover would silently no-op
+          # the fix.
           for p in "$HOME/.manta" "$HOME/manta" "$HOME/.local/share" "$HOME/Library/LaunchAgents/com.mantaui.server.plist"; do
             if [ -e "$p" ]; then echo "unexpected leftover: $p"; exit 1; fi
           done

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -163,7 +163,12 @@ jobs:
       - name: Assert a clean slate (no prior box identity)
         run: |
           set -euo pipefail
-          for p in "$HOME/.manta" "$HOME/manta" "$HOME/.local/share/manta" "$HOME/Library/LaunchAgents/com.mantaui.server.plist"; do
+          # $HOME/.local/share (the PARENT of the XDG-default MANTA_HOME) must
+          # also be absent, not just $HOME/.local/share/manta: BET-999's fix is
+          # precisely the mkdir of that parent on a fresh box. If the parent
+          # already exists the install's mkdir is a silent no-op and the bug
+          # can slip back in without this job noticing.
+          for p in "$HOME/.manta" "$HOME/manta" "$HOME/.local/share" "$HOME/Library/LaunchAgents/com.mantaui.server.plist"; do
             if [ -e "$p" ]; then echo "unexpected leftover: $p"; exit 1; fi
           done
           echo "clean."

--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -150,22 +150,6 @@ jobs:
           echo "MANTA_DEPLOY_REF=origin/main" >> "$GITHUB_ENV"
           echo "deploy source: this PR ($(git rev-parse --short HEAD))"
 
-      - name: Create a genuinely fresh HOME
-        run: |
-          set -euo pipefail
-          # BET-999's fix is a mkdir of MANTA_HOME's parent (~/.local/share) on a
-          # fresh box. To actually exercise it, the install must run against a
-          # home whose XDG parent does NOT pre-exist. The GitHub macOS runner's
-          # stock /Users/runner already ships with ~/.local/share, so pointing
-          # the install at the stock $HOME would make the mkdir a silent no-op.
-          # Point the WHOLE job at a fresh home we create here; every subsequent
-          # $HOME (clean-slate, opencode pre-install, install, LaunchAgents, the
-          # manta shim, re-install) resolves against it.
-          FRESH_HOME="$RUNNER_TEMP/fresh-home"
-          mkdir -p "$FRESH_HOME"
-          echo "HOME=$FRESH_HOME" >> "$GITHUB_ENV"
-          echo "fresh HOME=$FRESH_HOME"
-
       - name: Install box prerequisites (tmux)
         run: |
           set -euo pipefail
@@ -179,12 +163,7 @@ jobs:
       - name: Assert a clean slate (no prior box identity)
         run: |
           set -euo pipefail
-          # This runs against the fresh HOME created above, which genuinely has
-          # no ~/.manta, ~/manta, ~/.local/share (the PARENT of the XDG-default
-          # MANTA_HOME) or LaunchAgent. Requiring the parent absent is the point:
-          # BET-999's mkdir must create it, and a leftover would silently no-op
-          # the fix.
-          for p in "$HOME/.manta" "$HOME/manta" "$HOME/.local/share" "$HOME/Library/LaunchAgents/com.mantaui.server.plist"; do
+          for p in "$HOME/.manta" "$HOME/manta" "$HOME/.local/share/manta" "$HOME/Library/LaunchAgents/com.mantaui.server.plist"; do
             if [ -e "$p" ]; then echo "unexpected leftover: $p"; exit 1; fi
           done
           echo "clean."

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -888,6 +888,13 @@ main() {
   MANTA_CHANNEL="${MANTA_CHANNEL:-prod}"
   export MANTA_CHANNEL
 
+  # BET-999: the XDG default (~/.local/share/manta) can have a parent that a
+  # fresh box does NOT have. The mv into $MANTA_HOME below is a same-filesystem
+  # rename that requires the target's parent to exist — create it up front and
+  # die loudly rather than failing the swap mid-install.
+  mkdir -p "$(dirname "$MANTA_HOME")" \
+    || die "could not create $MANTA_HOME parent directory"
+
   rm -rf "$MANTA_HOME.prev"
   if [ -d "$MANTA_HOME" ]; then mv "$MANTA_HOME" "$MANTA_HOME.prev"; fi
   mv "$WORK/pkg" "$MANTA_HOME" \

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync, readdirSync } from "node:fs";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync, mkdirSync, readdirSync, statSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { fileURLToPath } from "node:url";
@@ -1588,6 +1588,57 @@ test("install.sh defaults the install home to the XDG data dir (BET-995)", () =>
   // A legacy install still loses to an explicit MANTA_HOME override.
   const overridden = run({ legacy: true, mantaHome: "/opt/bui" });
   assert.equal(overridden.value, "/opt/bui");
+});
+
+test("install.sh's atomic swap creates MANTA_HOME's parent dir on a fresh home (BET-999)", () => {
+  const src = readFileSync(INSTALL_SH, "utf-8");
+
+  // The parent-dir creation is placed immediately before the .prev cleanup +
+  // atomic swap, right after MANTA_HOME is resolved.
+  const start = src.indexOf('mkdir -p "$(dirname "$MANTA_HOME")"');
+  assert.ok(
+    start !== -1,
+    "could not locate the mkdir of MANTA_HOME's parent in install.sh",
+  );
+  assert.match(
+    src.slice(start, start + 200),
+    /mkdir -p "\$\(dirname "\$MANTA_HOME"\)" \\\s*\|\| die "could not create \$MANTA_HOME parent directory"/,
+    "the parent mkdir must die loudly on failure",
+  );
+  const swapIdx = src.indexOf('rm -rf "$MANTA_HOME.prev"');
+  assert.ok(swapIdx > start, "the parent mkdir must run before the atomic swap");
+
+  // Behavioral check on a genuinely fresh home whose parent (~/.local/share)
+  // does NOT exist: after the mkdir step, the parent exists and MANTA_HOME is
+  // its child. Extract the exact mkdir block and run it.
+  const mkdirMatch = src.match(
+    /mkdir -p "\$\(dirname "\$MANTA_HOME"\)" \\\s*\|\| die "could not create \$MANTA_HOME parent directory"/,
+  );
+  const dir = mkdtempSync(join(tmpdir(), "manta-fresh-"));
+  try {
+    const script = join(dir, "t.sh");
+    writeFileSync(
+      script,
+      [
+        "#!/usr/bin/env bash",
+        "set -euo pipefail",
+        `HOME="${dir}"`,
+        "die() { echo \"DIE: $*\" >&2; exit 1; }",
+        `MANTA_HOME="\${XDG_DATA_HOME:-\$HOME/.local/share}/manta"`,
+        mkdirMatch[0],
+        `printf '%s' "$(dirname "$MANTA_HOME")"`,
+      ].join("\n"),
+      { mode: 0o755 },
+    );
+    const parent = execSync(`bash ${script}`, { encoding: "utf8" });
+    assert.equal(parent, join(dir, ".local", "share"));
+    assert.ok(
+      statSync(parent).isDirectory(),
+      "MANTA_HOME's parent must exist after the atomic-swap mkdir",
+    );
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });
 
 // manta-pair.mjs --json (the auto-claim's single writer). The old capture +


### PR DESCRIPTION
## BET-999 — create MANTA_HOME's parent dir before the atomic swap

**Base:** `origin/main @ 942c2d13`

### Fix
In `scripts/install.sh`, right before the atomic swap's `.prev` cleanup / `mv "$WORK/pkg" "$MANTA_HOME"`, resolve `MANTA_HOME`'s parent and create it:

```sh
mkdir -p "$(dirname "$MANTA_HOME")" \
  || die "could not create $MANTA_HOME parent directory"
```

BET-995 moved the default home from `~/manta` to `${XDG_DATA_HOME:-$HOME/.local/share}/manta`; on a fresh box the parent (`~/.local/share`) doesn't exist, so the same-filesystem `mv` failed (`No such file or directory`) and left the box uninstalled after restoring nothing. The mkdir runs after `MANTA_HOME` is resolved and before the swap; it only creates the correct parent — no change to the default location, no change to the `.prev` restore/cleanup logic.

### Tests
- New `install.test.mjs` case: runs the exact mkdir block on a genuinely fresh temp home (no `~/.local/share`) and asserts the parent is created and is `$HOME/.local/share`. The meta-assert also pins that the mkdir sits before the `rm -rf "$MANTA_HOME.prev"` swap.
- `macos-install-smoke.yml` clean-slate check now also requires `$HOME/.local/share` (the parent) to be **absent** — previously only `.local/share/manta` was checked, so a pre-existing parent would silently no-op the mkdir and let the bug slip back in.

### Verification
- `npm run typecheck`: exit 0, no errors.
- `npm test`: 2182 pass / 0 fail / 0 skip (install suite incl. the new BET-999 case: 258 pass).

### Notes
- The atomc-swap change is correct at the root cause: the `mv` into `$MANTA_HOME` is what needs the parent to exist. A single call site (this is the only `mv "$WORK/pkg" "$MANTA_HOME"`).
