### PR TITLE
BET-1000: feat(server): plan page = model-authored full HTML + minimal Powered by Manta overlay

### DIFF
--- a/docs/opencode/skills/manta-plan/prompt.md
+++ b/docs/opencode/skills/manta-plan/prompt.md
@@ -41,13 +41,50 @@ The file must contain:
    by that section's content, styled freely with inline `<style>`/classes as
    you like. The body is fully yours to author — no chrome from us.
 
+**Author a COMPLETE, self-contained standalone HTML page — you are the one who
+owns the whole document.** The renderer serves your page as-is with NO wrapper,
+header, or chrome around it. The full page IS the plan. So the file must carry
+its own:
+
+- `<!DOCTYPE html>` and `<html lang="en">`
+- `<head>` with its own `<title>` (a good plan title) and
+  `<meta name="viewport" content="width=device-width, initial-scale=1">`
+- its own `<style>` (your palette, layout, typography — exactly what you want
+  a reviewer to see; do not rely on any shared/default styling)
+- a `<body>` whose content is the plan
+
+The `plan-meta` script block can live in the `<head>` or `<body>` — it is
+stripped before serving and does not render.
+
 **Contract rule (mandatory):** EVERY `id` in `plan-meta.sections` MUST appear
 as a literal `id="<id>"` attribute on the matching `<h2>` in the body —
 otherwise `plan_render` rejects the publish. If it would reject, fix the
 anchor rather than skipping. Write the prose in ordinary HTML, not markdown;
 the body is served as-is.
 
-**Published-page constraint (storage-free):** the served page runs in a sandboxed origin where `localStorage`/`sessionStorage` are UNAVAILABLE and throw a `SecurityError`. Never use them in the body or in any `<script>` you add. The light/dark theme is handled automatically by the renderer via the `?theme=` URL query string — do NOT write your own theme toggle or persistence logic. Keep the body static HTML; any tiny script must not touch storage.
+**Published-page constraint (storage-free):** the served page runs in a sandboxed origin where `localStorage`/`sessionStorage` are UNAVAILABLE and throw a `SecurityError`. Never use them anywhere in the page. No external CDN/resources/fonts — anything you need must be inline (inline `<style>` and inline SVG are fine). Any `<script>` you add must be storage-free. There is no theme toggle from us — paint your page however you want, but never rely on storage, external resources, or any injected chrome.
+
+**Spec-presentation checklist (a reviewed plan reads like this):**
+1. **Top summary** — an `<h1>` title plus one tight "what / why / outcome"
+   paragraph up front.
+2. **`<nav>` table of contents** linking to each section — one link per
+   `plan-meta.sections` id (those ids become the `id` attrs on the matching
+   `<h2>`s).
+3. **Clear hierarchy + readable type** — comfortable line-height (≈1.5–1.7),
+   ~72ch max prose width, generous padding; consistent spacing; a tasteful,
+   restrained palette.
+4. **Mockup(s)** — realistic product screens (windows/panels/controls) with
+   short captions and behavior notes, designed rather than wireframe-stubs.
+   See the mockups section below.
+5. **Accessibility** — semantic headings, sufficient contrast,
+   visible `focus-visible` states.
+6. **No TODO/lorem/placeholder text** — the page is self-explanatory to a
+   reviewer.
+
+**Overlay is automatic:** a small "Powered by Manta" badge is injected
+automatically at the bottom-right. Keep the bottom-right corner visually clear
+(some breathing room) and **do not add your own branding or footer that would
+collide with it**.
 
 ## 3. Mockups (only for UI/layout changes)
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -137,7 +137,7 @@ import {
   readPairAsset,
 } from "./pairPage.mjs";
 import * as push from "./push.mjs";
-import { registerWithGateway, publicBaseUrl } from "./gatewayRegister.mjs";
+import { registerWithGateway, publicBaseUrl, loadAuthFile, DEFAULT_AUTH_PATH } from "./gatewayRegister.mjs";
 import { readServerVersion, readOpencodeVersion, writeVersionResponse } from "./version.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -2338,8 +2338,9 @@ const handleRequest = async (req, res) => {
         const body = await readJsonBody(req);
         const sessionID = body?.sessionID;
         const sessionDir = await oc.getSessionDirectory(sessionID);
+        const ref = (loadAuthFile(DEFAULT_AUTH_PATH) ?? {}).box_id ?? "";
         const result = await publishPlanBundle(
-          { sessionID, file: body?.file, sessionDir },
+          { sessionID, file: body?.file, sessionDir, ref },
           { ...BUS_PUBLISH_DEPS, baseUrl },
         );
         if (!result.ok) {

--- a/src/server/planDoc.mjs
+++ b/src/server/planDoc.mjs
@@ -1,17 +1,19 @@
 // planDoc.mjs — deterministic single-HTML plan renderer (part of the
-// "single-HTML plan" plan). The manta-plan agent authors ONE HTML file: a small
-// `<script type="application/json" id="plan-meta">` (title + section list) plus
-// a fully model-authored rich HTML body. THIS module is the deterministic
-// renderer: it parses the meta, renders the fixed branded chrome (header,
-// dark/light toggle, base token stylesheet) from that meta, and
-// injects the model body as `<main>`. Structure is guaranteed by the template;
-// the body stays 100% AI-authored.
+// "single-HTML plan" plan). The manta-plan agent authors ONE complete,
+// standalone HTML page: a small `<script type="application/json" id="plan-meta">`
+// (title + section list) plus a fully model-authored rich HTML document with its
+// own `<head>`/`<style>`/`<body>`. THIS module is the deterministic renderer: it
+// parses the meta, strips it, validates the section anchors, and serves the
+// model's page AS-IS (no branded shell, no header, no theme, no token
+// stylesheet — the model's full page IS the plan). The ONLY addition is a
+// minimal self-contained "Powered by Manta" overlay (fixed, bottom-right, own
+// opaque background, links to https://mantaui.com with the box id as `?ref=`).
 //
 // Two pure functions, node:test-friendly, no npm deps beyond what planPage
-// imports. Reuses `escapeHtml`, `LIGHT_TOKENS`, `DARK_TOKENS` from
-// ./planPage.mjs — no redefined tokens, no reimplemented escaping.
+// imports. Reuses `escapeHtml` from ./planPage.mjs — no redefined tokens, no
+// reimplemented escaping.
 
-import { escapeHtml, LIGHT_TOKENS, DARK_TOKENS } from "./planPage.mjs";
+import { escapeHtml } from "./planPage.mjs";
 
 // ---------------------------------------------------------------------------
 // parsePlanBundle — find + parse the meta block, strip it from the body
@@ -106,132 +108,44 @@ export function parsePlanBundle(text) {
 }
 
 // ---------------------------------------------------------------------------
-// renderPlanDoc — the deterministic branded document
+// renderPlanDoc — serve the model's page as-is + one branded overlay
 // ---------------------------------------------------------------------------
 
-// The theme toggle script — inline, self-contained, storage-free. Reads the
-// initial theme from the `?theme=` query string (accepting exactly "dark" |
-// "light"), falling back to prefers-color-scheme; flips `data-theme` on <html>
-// and persists via `history.replaceState` (no reload, no storage). Deliberately
-// NO localStorage/sessionStorage: the page is served in an opaque-origin
-// sandbox (serve-page CSP without allow-same-origin), where storage throws.
-const THEME_SCRIPT = `
-<script>
-(function () {
-  var root = document.documentElement;
-  var match = /^(dark|light)$/.exec(new URLSearchParams(location.search).get("theme") || "");
-  var theme = match ? match[1]
-    : (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches)
-      ? "dark" : "light";
-  root.setAttribute("data-theme", theme);
-  var toggle = document.getElementById("plan-theme-toggle");
-  if (toggle) toggle.addEventListener("click", function () {
-    var next = root.getAttribute("data-theme") === "dark" ? "light" : "dark";
-    root.setAttribute("data-theme", next);
-    try {
-      history.replaceState(null, "", "?theme=" + next);
-    } catch (e) {}
-  });
-})();
-</script>
+// The minimal, self-contained "Powered by Manta" overlay. Single constant, own
+// opaque dark background (visible on any page background), fixed bottom-right.
+// NO storage and NO external resources: inline styles + inline SVG only, safe
+// in the sandboxed opaque origin where localStorage/sessionStorage throw.
+// SPEC — do not redesign. The only substitution is `HREF`.
+function overlayHtml(href) {
+  return `
+<div style="position:fixed;right:16px;bottom:16px;z-index:2147483647;display:inline-flex;align-items:center;gap:9px;padding:8px 14px 8px 10px;border-radius:999px;background:rgba(15,20,38,.86);border:1px solid rgba(255,255,255,.16);box-shadow:0 6px 20px rgba(0,0,0,.28);font:600 13px/1 -apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;">
+  <a href="${href}" target="_blank" rel="noopener noreferrer" title="Built with MantaAI" style="display:inline-flex;align-items:center;gap:8px;text-decoration:none;color:#fff;">
+    <svg width="18" height="18" viewBox="0 0 24 24" aria-hidden="true" style="flex:none"><rect width="24" height="24" rx="6" fill="#1F55D6"/><text x="12" y="16.5" font-size="13" font-weight="700" text-anchor="middle" fill="#fff" font-family="-apple-system,Segoe UI,Roboto,Arial,sans-serif">M</text></svg>
+    <span style="color:#fff;">Powered by Manta</span>
+  </a>
+</div>
 `.trim();
-
-// Minimal prose typography + header styling, all referenced via the
-// imported token blocks (no copied planPage body stylesheet, no external
-// resources).
-const BASE_STYLE = `
-  * { box-sizing: border-box; }
-  html, body { margin: 0; padding: 0; }
-  body {
-    background: var(--canvas);
-    color: var(--tx1);
-    font-family: var(--sans);
-    font-size: 15px;
-    line-height: 1.6;
-    -webkit-font-smoothing: antialiased;
-  }
-  .doc-header {
-    display: flex;
-    align-items: center;
-    gap: 12px;
-    padding: 14px 24px;
-    background: var(--inset);
-    border-bottom: 1px solid var(--border-subtle);
-  }
-  .brand {
-    font-weight: 700;
-    color: var(--accent-tx);
-    letter-spacing: 0.02em;
-  }
-  .doc-title {
-    flex: 1;
-    min-width: 0;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-    color: var(--tx2);
-    font-size: 14px;
-  }
-  .doc-header button {
-    border: 1px solid var(--border);
-    background: var(--card);
-    color: var(--tx1);
-    border-radius: var(--r-sm);
-    padding: 4px 8px;
-    cursor: pointer;
-    font-size: 14px;
-    line-height: 1;
-  }
-  .doc-header button:hover { border-color: var(--border-strong); }
-  .wrap { max-width: 1080px; margin: 0 auto; padding: 32px 40px; }
-  main { color: var(--tx1); }
-  main h1, main h2, main h3, main h4, main h5, main h6 {
-    color: var(--tx1);
-    line-height: 1.3;
-    margin: 1.4em 0 0.6em;
-  }
-  main h1 { font-size: 22px; }
-  main h2 { font-size: 19px; }
-  main h3 { font-size: 16px; }
-  main p { margin: 0.6em 0; }
-  main ul, main ol { margin: 0.6em 0; padding-left: 1.6em; }
-  main li { margin: 0.25em 0; }
-  main a { color: var(--accent-tx); text-decoration: none; }
-  main a:hover { text-decoration: underline; }
-  code {
-    font-family: var(--mono);
-    font-size: 0.9em;
-    background: var(--inset);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--r-xs);
-    padding: 0.1em 0.35em;
-  }
-  pre {
-    background: var(--inset);
-    border: 1px solid var(--border-subtle);
-    border-radius: var(--r-sm);
-    padding: 14px 16px;
-    overflow-x: auto;
-    margin: 0.8em 0;
-  }
-  pre code { background: none; border: 0; padding: 0; }
-`.trim();
+}
 
 /**
- * Render a full, self-contained HTML plan document from a parsed bundle.
+ * Render a single valid HTML plan document from a parsed bundle.
  *
  * - Validates that every `section.id` has a matching `id="<id>"` anchor in the
  *   body — fail-fast on the first missing one.
- * - The model `body` is injected VERBATIM (after the meta is stripped); it is
- *   deliberately NOT re-escaped — it is the model's authored HTML.
- * - Title and header text are escaped via `escapeHtml`.
- * - The only `<script>` is the theme toggle; no iframe, no external resources,
- *   no localStorage.
+ * - Serves the model `body` VERBATIM (after the meta is stripped) — it is the
+ *   model's full, self-contained authoring. Deliberately NOT re-escaped, NOT
+ *   wrapped in any chrome/theme, and NOT sanitized beyond the anchor check.
+ * - If the body is a fragment (no closing `</body>`), wraps it in a minimal
+ *   valid document. If it is a full standalone page, keeps its doctype/head/
+ *   title/style/body exactly.
+ * - Appends ONLY the "Powered by Manta" overlay, immediately before `</body>`
+ *   (or at the very end), with `href = https://mantaui.com` plus
+ *   `?ref=<encoded ref>` when `ref` is a non-empty string.
  *
- * @param {{ title:string, sections:Array<{id:string,heading:string}>, body:string }} input
+ * @param {{ title:string, sections:Array<{id:string,heading:string}>, body:string, ref?:string }} input
  * @returns {{ ok:true, html:string }} | {{ ok:false, error:string }}
  */
-export function renderPlanDoc({ title, sections, body }) {
+export function renderPlanDoc({ title, sections, body, ref }) {
   if (typeof title !== "string" || title.length === 0) {
     return { ok: false, error: "a non-empty title is required" };
   }
@@ -249,38 +163,34 @@ export function renderPlanDoc({ title, sections, body }) {
     }
   }
 
-  const html = `<!DOCTYPE html>
-<html lang="en" data-theme="light">
+  const href =
+    typeof ref === "string" && ref.length > 0
+      ? `https://mantaui.com?ref=${encodeURIComponent(ref)}`
+      : "https://mantaui.com";
+  const overlay = overlayHtml(href);
+
+  let html;
+  if (body.includes("</body>")) {
+    // Full standalone page — preserve it verbatim, inject exactly one overlay
+    // immediately before the LAST </body>.
+    const last = body.lastIndexOf("</body>");
+    html = body.slice(0, last) + overlay + "\n" + body.slice(last);
+  } else {
+    // Fragment — wrap in a minimal valid document with the overlay inside.
+    html = `<!DOCTYPE html>
+<html lang="en">
 <head>
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1">
-<meta name="referrer" content="no-referrer">
 <title>${escapeHtml(title)}</title>
-<style>
-  :root {
-    ${LIGHT_TOKENS}
-  }
-  [data-theme="dark"] {
-    ${DARK_TOKENS}
-  }
-  ${BASE_STYLE}
-</style>
 </head>
 <body>
-  <header class="doc-header">
-    <span class="brand">Manta</span>
-    <span class="doc-title">${escapeHtml(title)}</span>
-    <button id="plan-theme-toggle" type="button" title="Toggle theme">&#9680;</button>
-  </header>
-  <div class="wrap">
-    <main>
 ${body}
-    </main>
-  </div>
-  ${THEME_SCRIPT}
+${overlay}
 </body>
 </html>
 `;
+  }
 
   return { ok: true, html };
 }

--- a/src/server/planDoc.test.mjs
+++ b/src/server/planDoc.test.mjs
@@ -94,51 +94,104 @@ test("parsePlanBundle: non-string input returns error", () => {
 // renderPlanDoc
 // ---------------------------------------------------------------------------
 
-function renderSample() {
+function renderSample(ref) {
   const parsed = parsePlanBundle(SAMPLE_BUNDLE);
   assert.equal(parsed.ok, true);
-  return renderPlanDoc(parsed);
+  return renderPlanDoc({ ...parsed, ref });
 }
 
-test("renderPlanDoc: returns a full document with header, branding, and toggle", () => {
-  const r = renderSample();
+const FULL_DOC_SAMPLE = `<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>Model's Own Title</title>
+<script type="application/json" id="plan-meta">
+{"title":"Meta Title","sections":[{"id":"intro","heading":"Intro"},{"id":"steps","heading":"Steps"}]}
+</script>
+<style>body { color: #111; }</style>
+</head>
+<body>
+<h1 id="intro">Intro</h1>
+<p>model authored <strong>content</strong>.</p>
+<h2 id="steps">Steps</h2>
+</body>
+</html>`;
+
+test("renderPlanDoc: full-doc body is preserved verbatim with one overlay before </body>", () => {
+  const parsed = parsePlanBundle(FULL_DOC_SAMPLE);
+  assert.equal(parsed.ok, true);
+  const r = renderPlanDoc({ ...parsed, ref: "box123" });
   assert.equal(r.ok, true);
+  // The model's own document structure is intact — own title + style preserved.
   assert.ok(r.html.startsWith("<!DOCTYPE html>"));
-  assert.ok(r.html.includes("<html lang=\"en\""));
-  assert.ok(r.html.includes("<header"));
-  assert.ok(r.html.includes(">Manta</span>"));
-  assert.ok(r.html.includes("plan-theme-toggle"));
+  assert.ok(r.html.includes("<html lang=\"en\">"));
+  assert.ok(r.html.includes("<title>Model's Own Title</title>"), "model's own <title> intact");
+  assert.ok(r.html.includes("<style>body { color: #111; }</style>"), "model's own <style> intact");
+  assert.ok(!r.html.includes("Meta Title</title>"), "renderer did not inject its own title");
+  // Exactly one overlay, injected before the LAST </body>.
+  const overlays = r.html.match(/Powered by Manta/g) ?? [];
+  assert.equal(overlays.length, 1, "exactly one overlay");
+  assert.ok(r.html.includes("<a href=\"https://mantaui.com?ref=box123\""));
+  const bodyLoc = r.html.lastIndexOf("</body>");
+  const overlayLoc = r.html.lastIndexOf("Powered by Manta");
+  assert.ok(overlayLoc < bodyLoc, "overlay injected before </body>");
 });
 
-test("renderPlanDoc: includes the theme toggle script and no localStorage/iframe/external", () => {
-  const r = renderSample();
-  assert.ok(r.html.includes("prefers-color-scheme"));
-  assert.ok(r.html.includes("data-theme"));
-  assert.ok(r.html.includes("URLSearchParams"), "theme read via URLSearchParams");
-  assert.ok(r.html.includes("history.replaceState"), "theme persisted via history.replaceState");
-  assert.ok(r.html.includes("\"?theme=\" + next"), "replaceState writes ?theme= next");
-  assert.ok(!r.html.toLowerCase().includes("localstorage"));
-  assert.ok(!r.html.toLowerCase().includes("sessionstorage"));
-  assert.ok(!r.html.toLowerCase().includes("<iframe"));
-  assert.ok(!r.html.includes("http://"));
-  assert.ok(!r.html.includes("https://"));
+test("renderPlanDoc: fragment body is wrapped in a single valid doc with the meta title", () => {
+  const r = renderPlanDoc({
+    title: "Fragment Plan",
+    sections: [{ id: "a", heading: "A" }],
+    body: "<h2 id=\"a\">A</h2><p>hello</p>",
+    ref: "box9",
+  });
+  assert.equal(r.ok, true);
+  assert.ok(r.html.startsWith("<!DOCTYPE html>\n<html lang=\"en\">"));
+  assert.ok(r.html.includes("<meta name=\"viewport\""));
+  assert.ok(r.html.includes("<title>Fragment Plan</title>"), "meta title used");
+  assert.ok(r.html.includes("<h2 id=\"a\">A</h2><p>hello</p>"), "fragment body preserved");
+  assert.ok(r.html.includes("\n</body>\n</html>\n"), "wrapped as one valid doc");
+  assert.ok(r.html.includes("<a href=\"https://mantaui.com?ref=box9\""));
+});
+
+test("renderPlanDoc: non-empty ref adds ?ref=<encoded id> to the overlay href", () => {
+  const r = renderSample("a b&c");
+  assert.equal(r.ok, true);
+  assert.ok(r.html.includes("https://mantaui.com?ref=a%20b%26c"), "ref URL-encoded");
+});
+
+test("renderPlanDoc: empty / absent ref yields plain https://mantaui.com with no ?ref=", () => {
+  for (const ref of ["", undefined]) {
+    const r = renderSample(ref);
+    assert.equal(r.ok, true);
+    assert.ok(r.html.includes("<a href=\"https://mantaui.com\""), "plain href when ref empty/absent");
+    assert.ok(!r.html.includes("?ref="), "no ?ref query when ref empty/absent");
+  }
 });
 
 test("renderPlanDoc: renders NO Summary nav even when sections.length > 1", () => {
   const parsed = parsePlanBundle(SAMPLE_BUNDLE);
   assert.equal(parsed.ok, true);
   assert.ok(parsed.sections.length > 1, "sample has multiple sections");
-  const r = renderPlanDoc(parsed);
+  const r = renderSample("box");
   assert.equal(r.ok, true);
   assert.ok(!r.html.includes("Summary"));
   assert.ok(!r.html.includes("class=\"summary\""));
   assert.ok(!r.html.includes("aria-label=\"Summary\""));
 });
 
-test("renderPlanDoc: base stylesheet widens the body container to 1080px", () => {
-  const r = renderSample();
-  assert.ok(r.html.includes(".wrap { max-width: 1080px; margin: 0 auto; padding: 32px 40px; }"));
-  assert.ok(!r.html.includes("max-width: 720px"));
+test("renderPlanDoc: output contains NO shell / theme / token / storage remnants", () => {
+  const r = renderSample("box1");
+  assert.equal(r.ok, true);
+  const lower = r.html.toLowerCase();
+  assert.ok(!r.html.includes("plan-theme-toggle"), "no theme toggle");
+  assert.ok(!r.html.includes("doc-header"), "no doc header");
+  assert.ok(!lower.includes("data-theme"), "no data-theme");
+  assert.ok(!r.html.includes("LIGHT_TOKENS"), "no light token block");
+  assert.ok(!r.html.includes("DARK_TOKENS"), "no dark token block");
+  assert.ok(!lower.includes("localstorage"), "no localStorage");
+  assert.ok(!lower.includes("sessionstorage"), "no sessionStorage");
+  assert.ok(!r.html.includes("THEME_SCRIPT"), "no theme script");
+  assert.ok(!r.html.includes("BASE_STYLE"), "no base style");
 });
 
 test("renderPlanDoc: renders NO Summary block when sections.length <= 1", () => {

--- a/src/server/planRender.mjs
+++ b/src/server/planRender.mjs
@@ -58,7 +58,7 @@ function confineToSession({ file, sessionDir }) {
  * page (TTL 0 = never expires). Returns whatever `registerPage` returns — the
  * URL comes from there / `baseUrl`, never hand-built here.
  *
- * @param {{ sessionID?: unknown, file?: unknown, sessionDir?: unknown }} input
+ * @param {{ sessionID?: unknown, file?: unknown, sessionDir?: unknown, ref?: unknown }} input
  * @param {object} [deps]
  * @param {string} [deps.baseUrl]     - the box's published base URL (from
  *                                      publicBaseUrl()); required or the call
@@ -71,7 +71,7 @@ function confineToSession({ file, sessionDir }) {
  * @param {Function} [deps.register]  - defaults to servePage.registerPage.
  */
 export async function publishPlanBundle(
-  { sessionID, file, sessionDir },
+  { sessionID, file, sessionDir, ref },
   {
     baseUrl,
     readFile = readFileImpl,
@@ -116,6 +116,7 @@ export async function publishPlanBundle(
     title: parsed.title,
     sections: parsed.sections,
     body: parsed.body,
+    ref,
   });
   if (!rendered.ok) return rendered;
 

--- a/src/server/planRender.test.mjs
+++ b/src/server/planRender.test.mjs
@@ -139,6 +139,37 @@ test("publishPlanBundle confines a relative in-session path by resolving against
   assert.ok(calls.readFile.includes(SESSION_DIR), "read resolved against sessionDir");
 });
 
+test("publishPlanBundle threads `ref` through into the rendered overlay href", async () => {
+  const sections = [{ id: "overview", heading: "Overview" }];
+  const text = bundle(sections);
+  const { calls, deeps } = makeDeeps({ readText: text });
+  const result = await publishPlanBundle(
+    { sessionID: SESSION_ID, file: "plan.html", sessionDir: SESSION_DIR, ref: "boxABC" },
+    deeps,
+  );
+  assert.equal(result.ok, true);
+  const written = calls.writtenFile.data;
+  assert.ok(
+    written.includes("<a href=\"https://mantaui.com?ref=boxABC\""),
+    "ref reaches the overlay href in the staged html",
+  );
+  assert.ok(written.includes("Powered by Manta"), "overlay present");
+});
+
+test("publishPlanBundle with no ref yields a plain overlay href", async () => {
+  const sections = [{ id: "overview", heading: "Overview" }];
+  const text = bundle(sections);
+  const { calls, deeps } = makeDeeps({ readText: text });
+  const result = await publishPlanBundle(
+    { sessionID: SESSION_ID, file: "plan.html", sessionDir: SESSION_DIR },
+    deeps,
+  );
+  assert.equal(result.ok, true);
+  const written = calls.writtenFile.data;
+  assert.ok(written.includes("<a href=\"https://mantaui.com\""), "plain href when no ref");
+  assert.ok(!written.includes("?ref="), "no ?ref= when no ref");
+});
+
 test("publishPlanBundle surfaces an I/O read failure as {ok:false,error}, not a throw", async () => {
   const { deeps } = makeDeeps();
   const result = await publishPlanBundle(


### PR DESCRIPTION
## BET-1000 — plan page = model-authored full HTML + minimal "Powered by Manta" overlay

Stops wrapping the plan page in a branded shell. The model's complete standalone
page IS the plan now: the renderer strips the meta, validates the section
anchors, serves the body verbatim (wrapping a fragment only in a minimal doc),
and appends exactly one fixed bottom-right "Powered by Manta" overlay linking to
`https://mantaui.com` with the box id as `?ref=`.

**Scope guard:** box copy untouched; only repo `origin/main` files. Removed
chrome = deletion, no orphaned `THEME_SCRIPT`/`BASE_STYLE`/`doc-header`.
`parsePlanBundle`, the plan-meta contract, `servePage.registerPage`, the
plan-subdomain/URL subsystem, and the markdown `planPage.renderPlanHtml`
pipeline + its token exports are unchanged. Overlay is storage-free and
external-resource-free (inline SVG + styles only). Box id is threaded via
`loadAuthFile` — never hardcoded.

**Files changed:** 6
`src/server/planDoc.mjs`, `src/server/planRender.mjs`, `src/server/index.mjs`,
`src/server/planDoc.test.mjs`, `src/server/planRender.test.mjs`,
`docs/opencode/skills/manta-plan/prompt.md`

**Verification results:**
- PR branch (`multica/BET-1000-plan-overlay` @ `6f2405c4`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test:server: exit 0, 1676 pass / 0 fail / 0 skip. log sha256: `9cd23feee593d4e9f2c22c3e3995746837d996a4df78b09c3447f8da21bdfa0f`
- Base (`main` @ `ad417605`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test:server: exit 0, 1672 pass / 0 fail / 0 skip. log sha256: `9c4e83aff5ddfcc2ef9a9e98e6a6197b2537677557e14468dfab2c4735a52643`
- **Conclusion:** 4 new tests (2 planDoc + 2 planRender), 0 new failures, 0 pre-existing failures.

Logs at `/tmp/typecheck-{pr,main}.log`, `/tmp/test-{pr,main}.log`.

**Base: origin/main @ ad417605**

Manual smoke (node): full-doc bundle keeps its own `<title>`/`<style>`, injects
exactly one overlay before `</body>` with `?ref=`; fragment yields one valid doc
with the meta `<title>` and plain `https://mantaui.com` when `ref` empty; no
`plan-theme-toggle` / `doc-header` / `data-theme` / `LIGHT`/`DARK` tokens /
`localStorage` / `sessionStorage` anywhere.

No follow-ups filed — scope was fully contained; nothing above the filing bar was
surfaced.
