### PR TITLE
fix(renderer): use success-green dot for finished sessions

### DIFF
--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -1037,7 +1037,11 @@ function dotFor(status: WindowStatusUI | undefined): { variant: SessionStatus; t
     };
   }
   if (status.attention && !status.running) {
-    return { variant: "idle", title: "Finished — click to view" };
+    // A finished-but-unseen window is a SUCCESS state, so it takes the `--ok`
+    // green dot. It used to take amber `--warn`, which in light mode
+    // (`#6E6200`) reads as almost the same muted olive-grey as the at-rest
+    // `--tx4` dot (`#8A8275`) — the two states were indistinguishable at 7px.
+    return { variant: "ok", title: "Done — click to view" };
   }
   if (status.running) {
     // BET-791: the model-authored progress label (when a working turn names


### PR DESCRIPTION
**Problem:** In light mode the sidebar's finished-but-unseen status dot used the amber `--warn` token (`#6E6200`), which at 7px reads almost identically to the at-rest dot (`--tx4`, `#8A8275`). Idle and done were visually indistinguishable.

**Fix:** switch the finished dot to the existing `--ok` success token (`#0A7A53` light). Green vs grey is unambiguous and carries the state's success meaning. Tooltip also updated: "Finished" → "Done".

Uses the existing `ok` dot variant + `bg-ok` class — no new tokens. Only `src/renderer/Sidebar.tsx` (`dotFor`) changed.