### PR TITLE
BET-1001: fix(chat): pin session-switch re-pin to true tail via layout-aware scroll

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1020,8 +1020,18 @@ export function ChatPanel({
   useEffect(() => {
     if (!isActive) return;
     if (!followingRef.current) return;
-    scrollToTail();
-  }, [isActive, scrollToTail]);
+    // Re-activation re-pin. MUST use Virtuoso's scrollToIndex here, NOT
+    // scrollToTail()/scrollElementToTail: this effect runs right after the
+    // panel's display:none -> block flip, before react-virtuoso has re-measured
+    // the scroller (its ResizeObserver fires only after this effect). A raw
+    // `el.scrollTop = el.scrollHeight` read at this instant is stale/short and
+    // lands the transcript ABOVE the tail. scrollToIndex converges on the true
+    // tail (it is layout-aware and accounts for the transcript footer) - same
+    // behaviour as the pre-5ac17b3 code. All OTHER scrollToTail() callers run on
+    // a visible, already-measured scroller, so they keep using the raw write.
+    setFollowing(true);
+    virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end" });
+  }, [isActive, setFollowing]);
 
   // Catch-up refetch on reactivation. While inactive, scheduleRefetch and the
   // delta buffer are suppressed (see the gating refs near refetchTimer) so we


### PR DESCRIPTION
**fix(chat): pin session-switch re-pin to true tail via layout-aware scroll**

## What & why
Switching between chat-mode sessions in the sidebar made the newly-focused
transcript land slightly **above** the true bottom ("scroll goes back up a bit
every time"). Root cause: the reactivation re-pin effect (ChatPanel.tsx:1020)
did a raw `el.scrollTop = el.scrollHeight` write right after the panel's
`display:none -> block` flip, **before** react-virtuoso's ResizeObserver has
re-measured the scroller. The `scrollHeight` read at that instant is
stale/short (omits tail rows + the not-yet-measured footer), so the re-pin
lands above the tail. This regressed in `5ac17b3`.

## The fix (locked, no design decision)
The reactivation effect now uses Virtuoso's layout-aware
`scrollToIndex({ index: "LAST", align: "end" })` (which converges on the true
tail and accounts for the transcript footer — the same behaviour as the
pre-`5ac17b3` code) instead of the raw scroll write. `setFollowing(true)` is
kept so the follow state stays true through the scroll. **No other
`scrollToTail()` caller changed** — submit force-pin, composer resize, and
question reveal all run on a visible, already-measured scroller and remain
correct.

**Files changed:** 1 file. `src/renderer/ChatPanel.tsx`

**Base: origin/main @ `85bcb72a`**

## Verification results
- PR branch (`multica/BET-1001-session-switch-repin` @ `fa480eef`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2186 pass / 0 fail / 0 skip. Failures: none. log sha256: `1b9c696216905773b5f1e67d2c513f0add0424877a882143909883ce35b7dc8c`
- Base (`main` @ `85bcb72a`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2186 pass / 0 fail / 0 skip. Failures: none. log sha256: `1b9c696216905773b5f1e67d2c513f0add0424877a882143909883ce35b7dc8c`
- **Conclusion:** 0 test failures are pre-existing (results byte-identical to `main`), 0 new, 0 resolved.

## Note on Step 1 / live verification
The issue's Step 1 asks to confirm the root cause with a temporary probe in a
live app run (switch sessions 20+ times). This environment is a headless Linux
box with no GUI, so interactive session-switching verification cannot be run
here. The root cause was already confirmed by the issue's investigation and the
fix is locked (Step 2, "no design decision needed"). Typecheck + unit tests
pass; the manual visual acceptance criteria (1–5) require a human on a real
display to confirm.
