### PR TITLE
BET-1002: fix(renderer): bounded transient retry on onboarding auto-claim

### DIFF
--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -36,6 +36,11 @@ import {
   type PreflightFailure,
 } from "./preloadAccess";
 import type { InstallStageId } from "../shared/installStages";
+import {
+  CLAIM_TRANSIENT_ATTEMPTS,
+  CLAIM_TRANSIENT_DELAY_MS,
+  shouldRetryClaim,
+} from "./claimRetry";
 import { ConnectPanel } from "./ConnectPanel";
 import { deriveConnectPanel, type ConnectActionId } from "./connectPanelLogic";
 import {
@@ -669,21 +674,38 @@ export function SshInstallStep({
     setClaimRunning(true);
     setClaimError(null);
     try {
-      // BET-989: a single claim attempt against the code the install already
-      // minted (read from ~/.manta/pairing.json in main). No re-mint, no retry.
-      const outcome = await preload.installerMintAndClaim({
-        alias: resolved.ok ? resolved.target : undefined,
-      });
-      if (outcome.ok) {
-        // Mirror the manual PairStep onPaired — but hold the step on a real
-        // "Connected" state instead of advancing: the user confirms with the
-        // panel's Next button (BET-961), which stops the provider step from
-        // being skipped (BET-960).
-        setPaired(true);
+      // BET-989: a single claim against the code the install already minted
+      // (read from ~/.manta/pairing.json in main). No re-mint over SSH.
+      // BET-1002: wrap that in a SHORT, BOUNDED transient retry — a fresh
+      // install's box registers a new public hostname with the gateway, which
+      // takes a couple of seconds to propagate (Caddy + DNS). The first
+      // auto-claim can hit that window as a network/server_error failure. Retry
+      // only those two transient kinds up to N attempts with a fixed delay;
+      // any non-transient failure (wrong code, malformed response) fails
+      // immediately. Bounded ~20s window, NOT the old 45s "is the box booting"
+      // pump.
+      for (let attempt = 0; attempt < CLAIM_TRANSIENT_ATTEMPTS; attempt++) {
+        const outcome = await preload.installerMintAndClaim({
+          alias: resolved.ok ? resolved.target : undefined,
+        });
+        if (outcome.ok) {
+          // Mirror the manual PairStep onPaired — but hold the step on a real
+          // "Connected" state instead of advancing: the user confirms with the
+          // panel's Next button (BET-961), which stops the provider step from
+          // being skipped (BET-960).
+          setPaired(true);
+          return;
+        }
+        const canRetry = attempt < CLAIM_TRANSIENT_ATTEMPTS - 1 && shouldRetryClaim(outcome.kind);
+        if (canRetry) {
+          await new Promise((r) => setTimeout(r, CLAIM_TRANSIENT_DELAY_MS));
+          continue;
+        }
+        // Final attempt, or a non-transient failure → surface the real error
+        // (the actual outcome.message).
+        setClaimError(outcome.message);
         return;
       }
-      // Failure → surface the real error (the actual outcome.message).
-      setClaimError(outcome.message);
     } catch (e) {
       setClaimError(e instanceof Error ? e.message : String(e));
     } finally {

--- a/src/renderer/claimRetry.test.ts
+++ b/src/renderer/claimRetry.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from "vitest";
+import {
+  CLAIM_TRANSIENT_ATTEMPTS,
+  CLAIM_TRANSIENT_DELAY_MS,
+  shouldRetryClaim,
+} from "./claimRetry";
+
+describe("shouldRetryClaim", () => {
+  it("retries transient failures (network, server_error)", () => {
+    expect(shouldRetryClaim("network")).toBe(true);
+    expect(shouldRetryClaim("server_error")).toBe(true);
+  });
+
+  it("fails immediately on non-transient failures", () => {
+    expect(shouldRetryClaim("wrong_code")).toBe(false);
+    expect(shouldRetryClaim("rate_limited")).toBe(false);
+    expect(shouldRetryClaim("invalid_response")).toBe(false);
+  });
+
+  it("bounds the window at ~20s (5 attempts, 4s apart), not the old 45s pump", () => {
+    expect(CLAIM_TRANSIENT_ATTEMPTS).toBe(5);
+    expect(CLAIM_TRANSIENT_DELAY_MS).toBe(4000);
+  });
+});

--- a/src/renderer/claimRetry.ts
+++ b/src/renderer/claimRetry.ts
@@ -1,0 +1,33 @@
+// claimRetry.ts — bounded transient-retry policy for the onboarding auto-claim.
+//
+// A FRESH install mints a NEW box_id and registers a NEW public hostname with
+// the gateway; it takes a couple of seconds for that hostname to become
+// reachable (gateway + Caddy propagation). The desktop auto-claim fires
+// immediately after install and, on the first try, can hit that window and
+// fail transiently (BET-1002). That transient failure surfaces as a
+// `network` or `server_error` ClaimFailureKind — exactly the ones this module
+// says may be retried.
+//
+// Deliberately NOT in src/shared/claim.mjs (which classifies outcomes): this is
+// a renderer-only retry budget on top of a single claim, and claim.mjs is
+// shared with the manual PairStep path, which must not change. Pure + tested.
+
+import type { ClaimFailureKind } from "../shared/claim.mjs";
+
+// How many total attempts the auto-claim makes (the first attempt plus up to
+// four retries).
+export const CLAIM_TRANSIENT_ATTEMPTS = 5;
+
+// Fixed delay between transient-failure retries.
+export const CLAIM_TRANSIENT_DELAY_MS = 4000;
+
+/**
+ * True when a failed claim is transient and worth retrying. A fresh install's
+ * provisioning window (gateway + Caddy propagation) shows up as a network
+ * failure ("Couldn't reach the server…") or a server_error ("The server had a
+ * problem. Try again."). A non-transient failure (wrong code, malformed
+ * response, rate limit) must fail immediately — never retry a wrong code.
+ */
+export function shouldRetryClaim(kind: ClaimFailureKind): boolean {
+  return kind === "network" || kind === "server_error";
+}


### PR DESCRIPTION
## Summary

**fix(renderer): bounded transient retry on onboarding auto-claim so a fresh install pairs first try** (BET-1002)

A fresh install mints a NEW box_id and registers a NEW public hostname with the gateway; it takes a couple of seconds for that hostname to become reachable (gateway + Caddy propagation). BET-989 made the claim a SINGLE attempt ("no re-mint, no retry"), which removed the transient retry that used to cover exactly this window — so a fresh onboarding only worked on a manual retry.

This wraps the auto-claim in a SHORT, BOUNDED retry:
- Up to `CLAIM_TRANSIENT_ATTEMPTS = 5` attempts, `CLAIM_TRANSIENT_DELAY_MS = 4000` apart (a ~20s bounded window for gateway propagation — NOT the old 45s pump, not infinite polling).
- Retries ONLY the transient `ClaimFailureKind`s: `network` and `server_error`. A non-transient failure (`wrong_code`, `invalid_response`, `rate_limited`) fails immediately — never retries a wrong code.
- The `ClaimOutcome.kind` is read from the returned outcome (no new plumbing). On the final attempt (or a non-transient failure) the current behaviour is kept exactly: `setClaimError(outcome.message)`.
- BET-989 behaviour preserved: the claim still reads `~/.manta/pairing.json` in main — no re-mint over SSH.

New pure, tested helper: `src/renderer/claimRetry.ts` (`shouldRetryClaim` + the two constants) + `src/renderer/claimRetry.test.ts`. Deliberately NOT in `src/shared/claim.mjs` (shared with the manual PairStep path, unchanged) nor in `auth.ts` — neither was touched.

**Files changed:** 3.
`src/renderer/SshInstallStep.tsx` (+13/−…), `src/renderer/claimRetry.ts` (new), `src/renderer/claimRetry.test.ts` (new).

**Verification results:**
- PR branch (`multica/BET-1002-bounded-claim-retry` @ `e8e5ad2c`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2888 pass / 0 fail / 7 skip (vitest) + 2186 pass / 0 fail (node:test). Failures: none. log sha256: `ccc07c72f90595be5a664f7c34a74f649b0560f7cc835751eb2729a7d0d98e97`
- Base (`main` @ `3df8354e`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2885 pass / 0 fail / 7 skip (vitest) + 2186 pass / 0 fail (node:test). Failures: none. log sha256: `76ea2623cd9c6e4541d608493f8f3f92f359289a75dee661390f7a17b8900d82`
- **Conclusion:** 0 test failures new or pre-existing. The PR adds 3 passing tests (the retry-predicate unit tests in `claimRetry.test.ts`). The only log diff beyond the +3 tests is a pre-existing non-fatal jsdom "window.scrollTo not implemented" warning that shifted position — present on main, never a failure.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

**Base:** `origin/main @ 3df8354e`

**Note on the manual acceptance gate:** the issue's gate 2 (wipe/extract a FRESH staging box and run the desktop onboarding to pair on the FIRST attempt) requires driving the real desktop Electron onboarding against `135.181.255.249` — a manual, macOS/desktop-side step I cannot execute from this Linux implementer box (no Mac, no live gateway propagation in this environment). The code-level fix, the retry predicate unit test, and the "box genuinely unreachable → real error after ~20s (no infinite loop)" logic are all in place and green; the live fresh-install onboarding run is the one remaining manual verification for a human/reviewer.
