### PR TITLE
fix(chat): defer re-activation re-pin until scroller re-measures (BET-1003)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -731,6 +731,97 @@ describe("ChatPanel composer submit", () => {
   });
 });
 
+// ===== Re-activation re-pin defers the tail scroll until the scroller
+// re-measures (BET-1003) =====
+//
+// While a panel is inactive (display:none) the scroller has no layout and is
+// not re-measured, yet content keeps growing beneath/inside it. On reactivation
+// the user must land EXACTLY at the true tail. A tail write issued in the SAME
+// commit as the re-activation (either the raw scrollTop = scrollHeight or
+// Virtuoso's scrollToIndex(LAST,end), the BET-1001 approach) reads the stale
+// pre-layout height and leaves the transcript ~216px above the tail. The fix
+// defers the true-bottom write by 2x rAF so it reads the freshly re-measured
+// scrollHeight and pins exactly to it. This test pins the deferral: NO element
+// write in the reactivation commit, and the deferred write lands exactly on
+// the (re-measured) tail. It fails on the synchronous BET-1001 scrollToIndex
+// re-pin and passes on the deferred scrollElementToTail fix.
+describe("ChatPanel re-activation re-pin defers to the re-measured tail (BET-1003)", () => {
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("writes no tail scroll in the reactivation commit, then lands on the fresh tail after 2 rAF", async () => {
+    const transcript = [
+      {
+        info: {
+          id: "msg_a1",
+          sessionID: "ses_test",
+          role: "assistant" as const,
+          time: { created: 1, completed: 2 },
+        },
+        parts: [
+          { type: "text", id: "prt_a1", messageID: "msg_a1", text: "ready" },
+        ],
+      },
+    ];
+    installMockApi({
+      opencodeMessages: () => Promise.resolve(transcript as never),
+    });
+    resetStore();
+
+    // Content is already present while the panel mounts hidden, so the
+    // scroller mounts (Virtuoso renders its rows on a non-empty transcript)
+    // but the re-activation re-pin effect early-returns on isActive=false.
+    h = mount(<ChatPanel {...PROPS} isActive={false} />);
+    await h.flush();
+
+    const el = h.container.querySelector('[data-testid="virtuoso-scroller"]') as HTMLElement;
+    expect(el).toBeTruthy();
+
+    // The just-un-hidden scroller re-measures once it has layout: emulate that
+    // fresh measurement reporting a taller tail (content arrived while hidden).
+    // The fix must read this FRESH height at defer time, not the stale value.
+    let scrollHeight = 2000;
+    Object.defineProperty(el, "scrollHeight", {
+      get: () => scrollHeight,
+      configurable: true,
+    });
+    const writes: number[] = [];
+    Object.defineProperty(el, "scrollTop", {
+      set: (v: number) => {
+        writes.push(v);
+      },
+      get: () => (writes.length ? writes[writes.length - 1] : 0),
+      configurable: true,
+    });
+    // Drop any scrolls from the initial hidden mount (e.g. composer resize).
+    writes.length = 0;
+
+    // Content grew while hidden -> once visible the scroller measures taller.
+    scrollHeight = 4216;
+
+    // Re-activate the panel (App.tsx's display:none -> block flip + the
+    // isActive false->true prop, which drives this re-activation effect).
+    h.rerender(<ChatPanel {...PROPS} isActive={true} />);
+
+    // Not in the reactivation commit itself: the true-bottom write is
+    // deferred until the browser re-lays out the now-visible scroller.
+    expect(writes).toEqual([]);
+
+    // Advance past the two rAF frames -> the deferred write lands exactly on
+    // the freshly re-measured tail (scrollHeight = the grown true tail).
+    await act(async () => {
+      await new Promise((r) => setTimeout(r, 60));
+    });
+
+    expect(writes).toContain(4216);
+    expect(writes[writes.length - 1]).toBe(4216);
+  });
+});
+
 // ===== Abort self-heals orphaned questions (BET-116) =====
 //
 // opencode's /question pending list is cumulative and never expires. A

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1020,17 +1020,19 @@ export function ChatPanel({
   useEffect(() => {
     if (!isActive) return;
     if (!followingRef.current) return;
-    // Re-activation re-pin. MUST use Virtuoso's scrollToIndex here, NOT
-    // scrollToTail()/scrollElementToTail: this effect runs right after the
-    // panel's display:none -> block flip, before react-virtuoso has re-measured
-    // the scroller (its ResizeObserver fires only after this effect). A raw
-    // `el.scrollTop = el.scrollHeight` read at this instant is stale/short and
-    // lands the transcript ABOVE the tail. scrollToIndex converges on the true
-    // tail (it is layout-aware and accounts for the transcript footer) - same
-    // behaviour as the pre-5ac17b3 code. All OTHER scrollToTail() callers run on
-    // a visible, already-measured scroller, so they keep using the raw write.
+    // Re-activation re-pin. The scroller was display:none while inactive, so at
+    // this instant it has NOT re-measured: both a synchronous el.scrollTop =
+    // el.scrollHeight and Virtuoso's scrollToIndex(LAST,end) land SHORT (the
+    // real increaseViewportBy bottom crowds out the tail). Defer the true-bottom
+    // write to after the browser has re-laid-out the now-visible scroller
+    // (2x rAF — scrollHeight is then the real tail), and pin exactly to it. All
+    // OTHER scrollToTail() callers run on a visible, measured scroller and stay
+    // as they are. (BET-1003 — supersedes the BET-1001 scrollToIndex approach
+    // which still landed ~216px above the tail under "content grew while
+    // hidden".)
     setFollowing(true);
-    virtuosoRef.current?.scrollToIndex({ index: "LAST", align: "end" });
+    const el = scrollerElRef.current;
+    requestAnimationFrame(() => requestAnimationFrame(() => scrollElementToTail(el)));
   }, [isActive, setFollowing]);
 
   // Catch-up refetch on reactivation. While inactive, scheduleRefetch and the


### PR DESCRIPTION
## Summary
BET-1001's fix (PR #1008) merged a `scrollToIndex({index:"LAST", align:"end"})` re-pin that STILL lands ~216px above the true bottom when the target session grew content while hidden. Root cause (locked in the issue): the re-activation re-pin runs as a plain `useEffect` in the same React commit as the `display:none → block` flip, before react-virtuoso has re-measured the just-un-hidden scroller — so both a synchronous `scrollTop = scrollHeight` and `scrollToIndex(LAST,end)` read a stale pre-layout height.

This change defers the true-bottom write to `scrollElementToTail` by **2× requestAnimationFrame** so it reads the freshly re-measured `scrollHeight` and pins exactly to the tail. All other `scrollToTail()` callers (submit force-pin, question reveal, composer resize) run on a visible, already-measured scroller and are unchanged — only the re-activation effect is touched.

## Verification
- New harness regression test `ChatPanel re-activation re-pin defers to the re-measured tail (BET-1003)`: asserts **no** scroller write in the reactivation commit and a deferred write landing on the freshly re-measured (grown) tail.
  - **Fails on the old synchronous `scrollToIndex` re-pin** (confirmed by reverting the effect): `AssertionError: expected [] to include 4216`.
  - **Passes on the fix**.
- Full `npm test`: 2886 passed / 7 skipped, vitest 153 files (2886 passed) + server/node suites 2186 pass / 0 fail.
- `npm run typecheck`: exit 0, no errors.

**Files changed:** 2 files.
- `src/renderer/ChatPanel.tsx` — re-activation re-pin defers tail scroll by 2× rAF.
- `src/renderer/ChatPanel.harness.test.tsx` — regression test (BET-1003).

**Base: origin/main @ 3df8354e**

## Self-check vs acceptance criteria
1. Session switches rest at true bottom — mechanism pinned by regression test (deferred write lands on re-measured tail); live 20× session-switch run is the documented BET-1001 repro (2×rAF = 0 distance).
2. Streaming stays pinned / following true — unchanged behavior (no change to follow machinery or streaming).
3. Jump-to-latest preserves genuine scroll-up semantics — unaffected.
4. No regression to submit force-pin / question reveal / composer resize — those callers untouched; full suite green.
5. Resting distance 0 under "content grew while hidden" — the exact case the fix targets; the raw-value (live ~216px) is documented in BET-1003's own reproduction table.
6. typecheck + test pass — verified above.
