### PR TITLE
BET-1005 feat(renderer): single-HTML plan — deterministic Open page, PlanCard loading + feedback Send, remove md planPublish

### DIFF
--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -47,6 +47,7 @@ import { IconButton } from "./IconButton";
 import { ArtifactPreview } from "./ArtifactPreview";
 import { ReviewPane } from "./ReviewPane";
 import { authHeaders, clientToken, serverBase } from "./api/httpApi";
+import { planPageUrl } from "../shared/planMode.mjs";
 
 // Resolve an artifact's bytes to a Blob. An artifact's `href` is not always a
 // box filesystem path: a self-contained image part carries a `data:` URI (its
@@ -714,28 +715,19 @@ export function ArtifactsPanel({
     previewSourceRef.current = null;
   };
 
-  // Open a plan's companion page. When the page is already live (auto-published
-  // on plan_exit, so `pageUrl` is set on the artifact) just open it — no
-  // re-publish. Otherwise fall back to BET-974's publish-then-open: ONE gesture
-  // publishes the page on demand and opens the returned URL. The server reads
-  // the plan file itself (never the renderer); the URL comes from the response
-  // or the artifact — never hand-built. Reused by both the row-body "open" and
-  // the plan row's action.
+  // Open a plan's companion page. The single-HTML flow publishes it at
+  // plan_render time under the DETERMINISTIC subdomain
+  // (`<base>/pages/plan-<shortSessionId>`), so we open the artifact's `pageUrl`
+  // when present, else the deterministic URL — never publish-on-demand.
   const openPlanPage = (a: Artifact) => {
     if (!sessionId) return;
     setPlanError(null);
-    if (a.pageUrl) {
-      void window.api.openExternal(a.pageUrl!).catch((e: unknown) => {
+    const url = a.pageUrl || planPageUrl(sessionId, serverBase());
+    if (url) {
+      void window.api.openExternal(url).catch((e: unknown) => {
         setPlanError(String((e as Error)?.message ?? e));
       });
-      return;
     }
-    void window.api
-      .planPublish(sessionId, a.href)
-      .then(({ url }) => window.api.openExternal(url))
-      .catch((e: unknown) => {
-        setPlanError(String((e as Error)?.message ?? e));
-      });
   };
 
   // Row-body "open". Previewables (image/PDF/text) open the BET-661 overlay;

--- a/src/renderer/Cards.tsx
+++ b/src/renderer/Cards.tsx
@@ -526,32 +526,32 @@ export function PlanCard({
   sessionModel,
   buildModelName,
   atDelegateCap,
+  busy = null,
   onBuildHere,
-  onKeepPlanning,
+  onSendFeedback,
   onStartDelegate,
   onRememberDelegateModel,
   onOpenInBrowser,
   planUrl = null,
-  planPublishing = false,
 }: {
-  data: { title: string; path?: string; metrics: { steps?: number; files?: number } };
+  data: { title: string };
   models: Array<[string, OpencodeModel[]]> | null;
   remembered: import("./chatShared").ModelSelection | null;
   sessionModel: import("./chatShared").ModelSelection | null;
   buildModelName: string;
   atDelegateCap: boolean;
+  /** The pending async action on the card; drives loading + disabling. */
+  busy?: "build" | "delegate" | "feedback" | null;
   onBuildHere: (feedback: string) => void;
-  onKeepPlanning: (feedback: string) => void;
+  onSendFeedback: (feedback: string) => void;
   onOpenInBrowser: () => void;
   onStartDelegate: (
     model: import("./chatShared").ModelSelection | null,
     feedback: string,
   ) => void;
   onRememberDelegateModel: (model: import("./chatShared").ModelSelection | null) => void;
-  /** Eagerly-published shareable page URL for this session's plan (before plan_exit). */
+  /** The deterministic shareable page URL for this session's plan. */
   planUrl?: string | null;
-  /** True while the page is being published. */
-  planPublishing?: boolean;
 }) {
   // Level 1 of the model precedence — an explicit pick made on THIS card wins
   // while it is open. Written through to the remembered key on pick (see
@@ -578,26 +578,10 @@ export function PlanCard({
   const modelLabel =
     shortModelName(resolvedOpencode?.name) ?? delegateModel?.modelID ?? "model";
 
-  // `N steps · N files` — each clause omitted (never `0`) when not derivable.
-  const metricsLine = [
-    data.metrics.steps ? `${data.metrics.steps} steps` : null,
-    data.metrics.files ? `${data.metrics.files} files` : null,
-  ]
-    .filter(Boolean)
-    .join(" · ");
-
-  const busy = atDelegateCap;
-
   const body = (
     <>
-      {(metricsLine || data.path) && (
-        <div className="text-text-faint mb-px">
-          {metricsLine}
-          {metricsLine && data.path ? " · " : ""}
-          {data.path && <span className="text-text-quiet">{data.path}</span>}
-        </div>
-      )}
-      {/* Free-text feedback — QuestionCard's field recipe verbatim. */}
+      {/* Free-text feedback — QuestionCard's field recipe verbatim, with a Send
+          button at the END of the row as the submit affordance. */}
       <div className="flex items-center gap-2 border border-border rounded-md bg-bg px-3 py-2 mt-2">
         <Send size={14} aria-hidden="true" className="text-text-quiet shrink-0" />
         <input
@@ -605,11 +589,29 @@ export function PlanCard({
           placeholder="Anything to change before we start?"
           value={feedback}
           onChange={(e) => setFeedback(e.target.value)}
+          onKeyDown={(e) => {
+            if (e.key === "Enter" && feedback.trim() && busy === null) {
+              e.preventDefault();
+              onSendFeedback(feedback);
+            }
+          }}
           className="flex-1 min-w-0 bg-transparent border-0 outline-none text-meta text-text placeholder:text-text-faint"
         />
+        <Button
+          tone="ghost"
+          type="button"
+          loading={busy === "feedback"}
+          disabled={busy !== null || !feedback.trim()}
+          onClick={() => onSendFeedback(feedback)}
+          title="Send feedback"
+          hook="manta-plan-send-feedback"
+        >
+          <Send size={14} aria-hidden="true" />
+          Send
+        </Button>
       </div>
-      {/* Once the page is published (eager, before plan_exit) surface the URL so
-          the reader can open/share it without clicking anything. */}
+      {/* Once the page is live surface the URL so the reader can open/share it
+          without clicking anything. */}
       {planUrl && (
         <div
           className="flex items-center gap-1 text-meta text-text-quiet mt-2 truncate"
@@ -622,13 +624,13 @@ export function PlanCard({
     </>
   );
 
-  // Actions, in order: [Build here] [Delegate ▾] [See in browser ↗] spacer [Keep planning].
-  const splitTitle = busy
+  // Actions, in order: [Build here] [Delegate ▾] [Open page].
+  const splitTitle = atDelegateCap
     ? "Too many background jobs running (5)"
     : "Start a background job in its own worktree";
   const actions = (
     <>
-      <Button tone="primary" onClick={() => onBuildHere(feedback)}>
+      <Button tone="primary" onClick={() => onBuildHere(feedback)} loading={busy === "build"} disabled={busy !== null}>
         Build here
       </Button>
       <SplitButton
@@ -647,30 +649,18 @@ export function PlanCard({
         leftHook="manta-plan-delegate-btn"
         rightHook="manta-plan-delegate-model-btn"
         leftTitle={splitTitle}
-        rightTitle={busy ? splitTitle : "Model this background job will run on"}
-        disabled={busy}
-        loading={models === null}
+        rightTitle={atDelegateCap ? splitTitle : "Model this background job will run on"}
+        disabled={busy !== null || atDelegateCap}
+        loading={busy === "delegate" || models === null}
       />
       <Button
         tone="ghost"
         onClick={onOpenInBrowser}
-        loading={planPublishing}
-        disabled={planPublishing || (!planUrl && !data.path)}
-        title={
-          planUrl
-            ? "Open the published plan page"
-            : data.path
-              ? "Publish this plan to a shareable page and open it"
-              : undefined
-        }
+        title="Open the published plan page"
         hook="manta-plan-open-page"
       >
-        {planUrl ? "Open page" : planPublishing ? "Publishing…" : "See in browser"}
+        Open page
         <ArrowUpRight size={14} aria-hidden="true" />
-      </Button>
-      <div className="flex-1" />
-      <Button tone="ghost" onClick={() => onKeepPlanning(feedback)}>
-        Keep planning
       </Button>
     </>
   );

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -2430,45 +2430,6 @@ export function ChatPanel({
     [planQuestions, messages],
   );
 
-  // Eager publish of the plan companion page so the shareable URL shows up in
-  // the card BEFORE plan_exit completes. The subdomain is stable per session
-  // (`plan-<shortId>`), so re-publishing replaces the snapshot under the same
-  // URL. Fire-and-forget + deduped by the plan QUESTION (not the file path) —
-  // a "Keep planning" revision is a NEW question reusing the same path, so it
-  // re-publishes fresh content instead of serving the stale snapshot. A
-  // failure is silent and falls back to publish-on-click.
-  const [planUrl, setPlanUrl] = useState<string | null>(null);
-  const [planPublishing, setPlanPublishing] = useState(false);
-  const publishedPlanQuestionRef = useRef<string | null>(null);
-  const publishPlanEager = useCallback(
-    (qId: string, path: string) => {
-      if (!path || publishedPlanQuestionRef.current === qId) return;
-      publishedPlanQuestionRef.current = qId;
-      // New/revised plan → drop the old URL and show the loading state until
-      // the fresh page is published.
-      setPlanUrl(null);
-      setPlanPublishing(true);
-      window.api
-        .planPublish(sessionId, path)
-        .then(({ url }) => setPlanUrl(url))
-        .catch(() => { /* fall back to publish-on-click */ })
-        .finally(() => setPlanPublishing(false));
-    },
-    [sessionId],
-  );
-  useEffect(() => {
-    // Only the panel the user is actually viewing publishes eagerly; a hidden
-    // panel's plan page is published lazily once it becomes active.
-    if (!isActive) return;
-    for (const q of planQuestions) {
-      const data = planDataByQuestion.get(q.id);
-      if (data?.path) {
-        publishPlanEager(q.id, data.path);
-        break;
-      }
-    }
-  }, [planQuestions, planDataByQuestion, publishPlanEager, isActive]);
-
   // Delegate split control (BET-951).
   // Level 3 of the model precedence — "same as current" means the BUILD model,
   // not the plan model the composer chip may be showing while plan mode is on.
@@ -2563,7 +2524,7 @@ export function ChatPanel({
 
   const startPlanDelegate = useCallback(
     (q: QuestionRequest, m: ModelSelection | null, feedback: string) => {
-      void window.api
+      return window.api
         .delegateStart({
           prompt: buildPlanPrompt(q, feedback),
           sessionID: sessionId,
@@ -2577,38 +2538,29 @@ export function ChatPanel({
     [buildPlanPrompt, sessionId, cwd],
   );
 
-  const openPlanInBrowser = useCallback(
-    (path: string) => {
-      void window.api
-        .planPublish(sessionId, path)
-        .then(({ url }) => window.api.openExternal(url))
-        .catch((e: unknown) => {
-          setSendError(String((e as Error)?.message ?? e));
-        });
-    },
-    [sessionId],
-  );
-
-  // The PlanCard's "Open page" URL. The eager-publish result wins when it's
-  // present; otherwise fall back to the DETERMINISTIC URL derived from the
-  // session id (`<base>/pages/plan-<shortSessionId>` — the same subdomain the
-  // server publishes under), so a plan_render-published plan ALWAYS shows its
-  // link even before eager-publish returns (BET-992). serverBase may be
-  // unavailable (no server configured); then there is simply no URL.
+  // The PlanCard's "Open page" URL. Single-HTML plans are published by the
+  // model's plan_render tool under the DETERMINISTIC per-session subdomain
+  // (`<base>/pages/plan-<shortSessionId>`); there is no eager-publish state and
+  // no `.md` publish path. serverBase may be unavailable (no server
+  // configured); then there is simply no URL.
   const planCardUrl = useMemo(() => {
-    if (planUrl) return planUrl;
     try {
       return planPageUrl(sessionId, serverBase());
     } catch {
       return "";
     }
-  }, [planUrl, sessionId]);
+  }, [sessionId]);
 
   // The plan_exit card, built here and mounted in the transcript tail the SAME
   // way the questions are (it used to be pinned in the CardStack). Building the
-  // element here keeps the closures over the plan data + the eager-published
+  // element here keeps the closures over the plan data + the deterministic
   // URL; Transcript just mounts it. The stable `key={q.id}` preserves the
   // card's internal state (feedback / open model menu) across updates.
+  //
+  // ONE pending-action state drives the loading/disabled of all three actions
+  // (Build here / Delegate / Send feedback) while their async call is in
+  // flight — SQL no loading state existed before.
+  const [pendingAction, setPendingAction] = useState<"build" | "delegate" | "feedback" | null>(null);
   const planCard = useMemo(() => {
     for (const q of planQuestions) {
       const data = planDataByQuestion.get(q.id);
@@ -2622,25 +2574,29 @@ export function ChatPanel({
           sessionModel={sessionModel}
           buildModelName={activeModel?.name ?? ""}
           atDelegateCap={atDelegateCap}
-          onBuildHere={(fb) => void buildHere(q, fb)}
-          onKeepPlanning={(fb) => void keepPlanning(q, fb)}
-          onStartDelegate={(m, fb) => startPlanDelegate(q, m, fb)}
+          busy={pendingAction}
+          onBuildHere={(fb) => {
+            setPendingAction("build");
+            void buildHere(q, fb).finally(() => setPendingAction(null));
+          }}
+          onSendFeedback={(fb) => {
+            setPendingAction("feedback");
+            void keepPlanning(q, fb).finally(() => setPendingAction(null));
+          }}
+          onStartDelegate={(m, fb) => {
+            setPendingAction("delegate");
+            void startPlanDelegate(q, m, fb).finally(() => setPendingAction(null));
+          }}
           onRememberDelegateModel={rememberDelegateModel}
           planUrl={planCardUrl}
-          planPublishing={planPublishing}
           onOpenInBrowser={() => {
-            // Live page already published → just open it (no re-publish).
-            if (planUrl) {
-              void window.api.openExternal(planUrl).catch(() => { /* best-effort */ });
-              return;
-            }
-            if (data.path) openPlanInBrowser(data.path);
+            if (planCardUrl) void window.api.openExternal(planCardUrl).catch(() => { /* best-effort */ });
           }}
         />
       );
     }
     return null;
-  }, [planQuestions, planDataByQuestion, delegateSelectable, rememberedDelegateModel, sessionModel, activeModel, atDelegateCap, buildHere, keepPlanning, startPlanDelegate, rememberDelegateModel, planUrl, planPublishing, openPlanInBrowser]);
+  }, [planQuestions, planDataByQuestion, delegateSelectable, rememberedDelegateModel, sessionModel, activeModel, atDelegateCap, pendingAction, buildHere, keepPlanning, startPlanDelegate, rememberDelegateModel, planCardUrl]);
 
   const cards = useMemo<PinnedCardRender[]>(() => {
     const list: PinnedCardRender[] = [];

--- a/src/renderer/PlanCard.test.tsx
+++ b/src/renderer/PlanCard.test.tsx
@@ -3,9 +3,10 @@
 // Component tests for the PlanCard (BET-951) — the upgraded plan_exit card in
 // the pinned card stack. Detection itself (isPlanExitQuestion / extractPlanData)
 // is pinned in chatUtils.test.ts; here we pin the card surface: badge, title,
-// metrics + path, the action row, the delegate split's per-segment popup
-// semantics, the cap-disabled title, and that the generic QuestionCard path
-// still renders an ordinary (non-plan) question untouched.
+// the feedback input + Send button, the action row (Build here / Delegate /
+// Open page), the delegate split's per-segment popup semantics, the cap-disabled
+// title, the per-action loading states (busy), and that the generic QuestionCard
+// path still renders an ordinary (non-plan) question untouched.
 
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
 import { act } from "react";
@@ -26,8 +27,6 @@ const GROUPS: Array<[string, OpencodeModel[]]> = [
 
 const DATA = {
   title: "Add login",
-  path: "/work/plan.md",
-  metrics: { steps: 2, files: 1 },
   text: "# Add login\n## Step 1\n- `src/a.ts`",
 };
 
@@ -36,6 +35,30 @@ function modelBtn(h: Harness | null): HTMLButtonElement {
 }
 function delegateBtn(h: Harness | null): HTMLButtonElement {
   return (h as Harness).container.querySelector(".manta-plan-delegate-btn") as HTMLButtonElement;
+}
+function sendBtn(h: Harness | null): HTMLButtonElement {
+  return (h as Harness).container.querySelector(".manta-plan-send-feedback") as HTMLButtonElement;
+}
+function openBtn(h: Harness | null): HTMLButtonElement {
+  return (h as Harness).container.querySelector(".manta-plan-open-page") as HTMLButtonElement;
+}
+function buildBtn(h: Harness | null): HTMLButtonElement {
+  return Array.from((h as Harness).container.querySelectorAll("button")).find(
+    (b) => (b.textContent ?? "").trim() === "Build here",
+  ) as HTMLButtonElement;
+}
+
+// Set a controlled <input>'s value the way React expects (native setter +
+// input event) so onChange fires and the component's `feedback` state updates.
+function typeInto(el: HTMLInputElement, value: string): void {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  act(() => {
+    setter?.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  });
 }
 
 describe("PlanCard (BET-951)", () => {
@@ -60,7 +83,7 @@ describe("PlanCard (BET-951)", () => {
         buildModelName="Claude Opus 4.7"
         atDelegateCap={false}
         onBuildHere={() => {}}
-        onKeepPlanning={() => {}}
+        onSendFeedback={() => {}}
         onStartDelegate={() => {}}
         onRememberDelegateModel={() => {}}
         onOpenInBrowser={() => {}}
@@ -68,20 +91,58 @@ describe("PlanCard (BET-951)", () => {
       />,
     );
 
-  it("renders badge, title, metrics + path and the action row", () => {
+  it("renders badge, title and the action row (no metrics, no path, no Keep planning)", () => {
     h = render();
     expect(h.text()).toContain("Add login");
-    expect(h.text()).toContain("2 steps");
-    expect(h.text()).toContain("1 files");
-    expect(h.text()).toContain("/work/plan.md");
     expect(h.text()).toContain("Build here");
     expect(h.text()).toContain("Delegate");
-    expect(h.text()).toContain("Keep planning");
+    expect(h.text()).toContain("Open page");
+    expect(h.text()).toContain("Send");
+    expect(h.text()).not.toContain("steps");
+    expect(h.text()).not.toContain("files");
+    expect(h.text()).not.toContain("plan.md");
+    expect(h.text()).not.toContain("Keep planning");
   });
 
-  it("omits the '0 steps' clause when metrics cannot be derived", () => {
-    h = render({ data: { ...DATA, metrics: {} } });
-    expect(h.text()).not.toContain("0 steps");
+  it("renders the Send button, disabled until feedback is typed", () => {
+    h = render();
+    expect(sendBtn(h).disabled).toBe(true);
+    const input = h.container.querySelector('input[placeholder*="Anything to change"]') as HTMLInputElement;
+    typeInto(input, "make it faster");
+    expect(sendBtn(h).disabled).toBe(false);
+  });
+
+  it("Send submits the typed feedback", () => {
+    let fb = "";
+    h = render({ onSendFeedback: (f: string) => { fb = f; } });
+    const input = h.container.querySelector('input[placeholder*="Anything to change"]') as HTMLInputElement;
+    typeInto(input, "make it faster");
+    act(() => sendBtn(h).click());
+    expect(fb).toBe("make it faster");
+  });
+
+  it("build loading: Build here loads, others disabled while busy === 'build'", () => {
+    h = render({ busy: "build" });
+    expect(buildBtn(h).getAttribute("aria-busy")).toBe("true");
+    expect(buildBtn(h).disabled).toBe(true);
+    expect(delegateBtn(h).disabled).toBe(true);
+    expect(sendBtn(h).disabled).toBe(true);
+  });
+
+  it("delegate loading: Delegate loads, others disabled while busy === 'delegate'", () => {
+    h = render({ busy: "delegate" });
+    // SplitButton puts aria-busy on its shell <div>, and loading disables both segments.
+    expect(delegateBtn(h).parentElement!.getAttribute("aria-busy")).toBe("true");
+    expect(delegateBtn(h).disabled).toBe(true);
+    expect(buildBtn(h).disabled).toBe(true);
+    expect(sendBtn(h).disabled).toBe(true);
+  });
+
+  it("feedback loading: Send loads, others disabled while busy === 'feedback'", () => {
+    h = render({ busy: "feedback" });
+    expect(sendBtn(h).getAttribute("aria-busy")).toBe("true");
+    expect(buildBtn(h).disabled).toBe(true);
+    expect(delegateBtn(h).disabled).toBe(true);
   });
 
   it("delegate split: the model segment carries aria-haspopup, the action segment does NOT", () => {
@@ -116,38 +177,19 @@ describe("PlanCard (BET-951)", () => {
     expect(h.text()).toContain("Claude");
   });
 
-  it("shows a loading state on the page button while the page is publishing", () => {
-    h = render({ planPublishing: true });
-    expect(h.text()).toContain("Publishing…");
-    const btn = h.container.querySelector(".manta-plan-open-page") as HTMLButtonElement;
-    expect(btn.disabled).toBe(true);
-    expect(btn.getAttribute("aria-busy")).toBe("true");
-  });
-
-  it("renders the published URL and an 'Open page' action once the page is live", () => {
-    h = render({ planUrl: "https://box/pages/plan-sesa" });
-    expect(h.text()).toContain("https://box/pages/plan-sesa");
-    expect(h.text()).toContain("Open page");
-    const btn = h.container.querySelector(".manta-plan-open-page") as HTMLButtonElement;
-    expect(btn.getAttribute("title")).toMatch(/published plan page/);
-    expect(btn.disabled).toBe(false);
-  });
-
-  it("falls back to publish-on-click 'See in browser' when no page is live yet", () => {
+  it("Open page is always enabled and labelled 'Open page', firing onOpenInBrowser", () => {
     let fired = false;
     h = render({ onOpenInBrowser: () => { fired = true; } });
-    expect(h.text()).toContain("See in browser");
-    expect(h.container.querySelector(".manta-plan-open-page")).toBeTruthy();
-    const btn = h.container.querySelector(".manta-plan-open-page") as HTMLButtonElement;
-    expect(btn.disabled).toBe(false);
-    act(() => btn.click());
+    expect(h.text()).toContain("Open page");
+    expect(openBtn(h).disabled).toBe(false);
+    act(() => openBtn(h).click());
     expect(fired).toBe(true);
   });
 
-  it("disables the page button when there is no plan path and no live URL", () => {
-    h = render({ data: { ...DATA, path: undefined } });
-    const btn = h.container.querySelector(".manta-plan-open-page") as HTMLButtonElement;
-    expect(btn.disabled).toBe(true);
+  it("renders the deterministic published URL in the body", () => {
+    h = render({ planUrl: "https://box/pages/plan-sesa" });
+    expect(h.text()).toContain("https://box/pages/plan-sesa");
+    expect(h.text()).toContain("Open page");
   });
 });
 

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -114,7 +114,6 @@ export const DEMO_UNIMPLEMENTED = [
   "opencodeSetSubagents",
   "opencodeSyncSubagents",
   "peekRemoteFile",
-  "planPublish",
   "pluginsRegistry",
    "progressGet",
    "projectMetaDelete",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -934,31 +934,6 @@ export const httpApi: Api = {
     }
   },
 
-  /**
-   * Publish (or refresh) the hosted companion page for a session's plan and
-   * return its public URL. The server reads the plan file itself (never the
-   * renderer); `path` is the plan's path as reported by the plan_exit tool.
-   * The URL comes from the response — never constructed here (it may be a
-   * public https:// host or a tailnet-only address).
-   */
-  planPublish: async (sessionID, path) => {
-    const url = `${serverBase()}/api/plan-page`;
-    const res = await fetch(url, {
-      method: "POST",
-      headers: authHeaders(clientToken(), { "content-type": "application/json" }),
-      body: JSON.stringify({ sessionID, path }),
-    });
-    if (res.status === 401) throw new AuthRequiredError();
-    let json: { url?: string; error?: string } = {};
-    try {
-      json = (await res.json()) as { url?: string; error?: string };
-    } catch {
-      /* non-JSON body (proxy/HTML error) */
-    }
-    if (!res.ok || !json.url) throw new Error(json.error ?? `HTTP ${res.status}`);
-    return { url: json.url };
-  },
-
   // -- PTY --
   ptySpawn: (opts) => rpc(IPC.ptySpawn, opts),
   ptyWrite: (sessionKey, data) => rpc(IPC.ptyWrite, sessionKey, data),

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -133,9 +133,7 @@ import {
   describeSessionClose,
   describeProjectClose,
   isPlanExitQuestion,
-  planMetrics,
   extractPlanData,
-  planPathsFromMessages,
   planRefsFromPart,
   resolveDelegateModel,
 } from "./chatUtils";
@@ -5105,38 +5103,11 @@ describe("isPlanExitQuestion", () => {
   });
 });
 
-describe("planMetrics", () => {
-  it("omits steps and files when nothing is derivable", () => {
-    expect(planMetrics("Just prose.")).toEqual({});
-  });
-
-  it("counts 'Step N' headings as steps", () => {
-    const r = planMetrics("## Step 1\nx\n## Step 2\ny\n## Step 3\nz");
-    expect(r.steps).toBe(3);
-  });
-
-  it("counts numbered headings as steps", () => {
-    const r = planMetrics("## 1. first\n## 2. second");
-    expect(r.steps).toBe(2);
-  });
-
-  it("counts backticked file bullets as files", () => {
-    const r = planMetrics("- `src/a.ts`\n- `src/b.ts`\n");
-    expect(r.files).toBe(2);
-  });
-
-  it("does not print 0 for an absent clause", () => {
-    const r = planMetrics("### Do x\n- `src/a.ts`");
-    expect(r.steps).toBeUndefined();
-    expect(r.files).toBe(1);
-  });
-});
-
 describe("extractPlanData", () => {
   const planq = (callID: string): QuestionRequest =>
     ({ id: "q1", sessionID: "s1", questions: [], tool: { messageID: "m1", callID } }) as QuestionRequest;
 
-  it("title from first heading, path + metrics from the tool input", () => {
+  it("title from first heading + the plan text from the tool input", () => {
     const msg: OpencodeMessage = {
       info: {} as never,
       parts: [
@@ -5145,14 +5116,13 @@ describe("extractPlanData", () => {
           id: "p",
           messageID: "m1",
           callID: "call-exit",
-          state: { status: "completed", input: { tool: "plan_exit", planPath: "/work/plan.md", plan: "# Add login\n## Step 1\n- `src/a.ts`" } },
+          state: { status: "completed", input: { tool: "plan_exit", plan: "# Add login\n## Step 1\n- `src/a.ts`" } },
         },
       ],
     };
     const d = extractPlanData(planq("call-exit"), [msg]);
     expect(d.title).toBe("Add login");
-    expect(d.path).toBe("/work/plan.md");
-    expect(d.metrics).toEqual({ steps: 1, files: 1 });
+    expect(d.text).toContain("## Step 1");
   });
 
   it("falls back to the question header when no plan text is present", () => {
@@ -5160,94 +5130,45 @@ describe("extractPlanData", () => {
     q.questions = [{ question: "Plan at /p is complete. Would you like to switch?", header: "Build Agent", options: [] }];
     const d = extractPlanData(q, []);
     expect(d.title).toBe("Build Agent");
-    expect(d.metrics).toEqual({});
-    expect(d.path).toBeUndefined();
-  });
-
-  it("resolves the plan path from the authoring tool when the plan_exit input is empty", () => {
-    // plan_exit (opencode's built-in) carries NO input — the path only lives in
-    // the `plan`-authoring tool that wrote the file. The tolerant fallback must
-    // surface it so the plan card can publish the companion page.
-    const q = planq("call-exit");
-    const msg: OpencodeMessage = {
-      info: {} as never,
-      parts: [
-        {
-          type: "tool",
-          id: "p-write",
-          messageID: "m1",
-          callID: "call-write",
-          tool: "plan",
-          state: { status: "completed", input: { filePath: ".opencode/plans/2026-08-15-fix.md" } },
-        },
-        {
-          type: "tool",
-          id: "p-exit",
-          messageID: "m2",
-          callID: "call-exit",
-          tool: "plan_exit",
-          state: { status: "completed", input: {} },
-        },
-      ],
-    };
-    const d = extractPlanData(q, [msg]);
-    expect(d.title).toBe("Plan complete");
-    expect(d.path).toBe(".opencode/plans/2026-08-15-fix.md");
-  });
-
-  it("plan_exit input wins over the transcript fallback", () => {
-    const q = planq("call-exit");
-    const msg: OpencodeMessage = {
-      info: {} as never,
-      parts: [
-        { type: "tool", id: "p-write", messageID: "m1", callID: "c-w", tool: "plan", state: { status: "completed", input: { filePath: ".opencode/plans/older.md" } } },
-        { type: "tool", id: "p-exit", messageID: "m2", callID: "call-exit", tool: "plan_exit", state: { status: "completed", input: { planPath: ".opencode/plans/newer.md" } } },
-      ],
-    };
-    const d = extractPlanData(q, [msg]);
-    expect(d.path).toBe(".opencode/plans/newer.md");
+    expect(d.text).toBe("");
   });
 });
 
-describe("planPathsFromMessages", () => {
+describe("planRefsFromPart", () => {
   const part = (over: Record<string, unknown>): OpencodePart =>
     ({ type: "tool", id: "p", messageID: "m", ...over }) as OpencodePart;
 
   it("collects .opencode/plans refs across text, tool input, and patch files", () => {
-    const msg: OpencodeMessage = {
-      info: {} as never,
-      parts: [
-        part({ type: "text", text: "Plan: .opencode/plans/a.md" }),
-        part({ tool: "write", state: { status: "completed", input: { filePath: ".opencode/plans/b.md" } } }),
-        part({ tool: "multiEdit", files: [".opencode/plans/c.md"] }),
-        part({ tool: "read", state: { status: "completed", input: { filePath: ".opencode/plans/ignored.md" } } }),
-      ],
-    };
-    expect(planPathsFromMessages([msg]).sort()).toEqual([
+    expect(planRefsFromPart(part({ type: "text", text: "Plan: .opencode/plans/a.md" }))).toEqual([
       ".opencode/plans/a.md",
-      ".opencode/plans/b.md",
+    ]);
+    expect(
+      planRefsFromPart(part({ tool: "write", state: { status: "completed", input: { filePath: ".opencode/plans/b.md" } } })),
+    ).toEqual([".opencode/plans/b.md"]);
+    expect(planRefsFromPart(part({ tool: "multiEdit", files: [".opencode/plans/c.md"] }))).toEqual([
       ".opencode/plans/c.md",
     ]);
+    expect(
+      planRefsFromPart(part({ tool: "read", state: { status: "completed", input: { filePath: ".opencode/plans/ignored.md" } } })),
+    ).toEqual([]);
   });
 
   it("does not treat a read reference as an authoring signal", () => {
-    const msg: OpencodeMessage = {
-      info: {} as never,
-      parts: [part({ tool: "read", state: { status: "completed", input: { filePath: ".opencode/plans/x.md" } } })],
-    };
-    expect(planPathsFromMessages([msg])).toEqual([]);
-    expect(planRefsFromPart(msg.parts[0])).toEqual([]);
+    expect(
+      planRefsFromPart(part({ tool: "read", state: { status: "completed", input: { filePath: ".opencode/plans/x.md" } } })),
+    ).toEqual([]);
   });
 
-  it("deduplicates identical refs", () => {
-    const msg: OpencodeMessage = {
-      info: {} as never,
-      parts: [
-        part({ tool: "plan", state: { status: "completed", input: { path: ".opencode/plans/same.md" } } }),
-        part({ type: "text", text: ".opencode/plans/same.md" }),
-      ],
-    };
-    expect(planPathsFromMessages([msg])).toEqual([".opencode/plans/same.md"]);
+  it("deduplicates identical refs within a part", () => {
+    expect(
+      planRefsFromPart(
+        part({
+          tool: "plan",
+          state: { status: "completed", input: { path: ".opencode/plans/same.md" } },
+          text: ".opencode/plans/same.md",
+        }),
+      ),
+    ).toEqual([".opencode/plans/same.md"]);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2130,11 +2130,11 @@ export function resolvePlanToggle(
 // ===== Plan card data (BET-951) =====
 //
 // The plan_exit question is upgraded into a plan card in the pinned card
-// stack. Its title ("the plan's title/first heading"), the metrics line
-// (`N steps · N files`) and the plan path are all derived from the plan text
-// the `plan_exit` tool call carried. Detection is EXACT, never heuristic: the
-// question's `tool.callID` links back to the `plan_exit` tool part in the
-// transcript — match on that, never on the question text.
+// stack. Its title ("the plan's title/first heading") and the FULL plan text
+// are derived from the `plan_exit` tool call's carried plan. Detection is
+// EXACT, never heuristic: the question's `tool.callID` links back to the
+// `plan_exit` tool part in the transcript — match on that, never on the
+// question text.
 
 // A tool part may surface its name/callID directly (the live `message.part.*`
 // event shape used by useSseBus) or nested under `state.input` (the reconciled
@@ -2167,24 +2167,6 @@ export function isPlanExitQuestion(
     }
   }
   return false;
-}
-
-/**
- * The metrics line for the plan card: `N steps · N files`, derived from the
- * plan text. A clause is OMITTED (not `0`) when it cannot be derived — the
- * card never prints `0 steps`. `steps` counts step/labelled-numbered headings;
- * `files` counts bullet list items whose text is a backticked path (the
- * conventional `- \`path\`` file listing). Empty / no-match → `{}`.
- */
-export function planMetrics(text: string): { steps?: number; files?: number } {
-  const out: { steps?: number; files?: number } = {};
-  const stepHeading = text.match(/^#{1,6}[ \t]+step[ \t]+/gim)?.length ?? 0;
-  const numberedHeading = text.match(/^#{1,6}[ \t]+\d+[.)]/gm)?.length ?? 0;
-  const steps = stepHeading || numberedHeading;
-  if (steps > 0) out.steps = steps;
-  const files = text.match(/^[ \t]*[-*][ \t]+`[^`]+`[ \t]*$/gm)?.length ?? 0;
-  if (files > 0) out.files = files;
-  return out;
 }
 
 // ---- Plan-file discovery (tolerant of how the plan was authored) ----
@@ -2236,40 +2218,21 @@ export function planRefsFromPart(part: OpencodePart): string[] {
   return out;
 }
 
-/** Every distinct `.opencode/plans/*.md` reference across a transcript. */
-export function planPathsFromMessages(
-  messages: OpencodeMessage[] | null,
-): string[] {
-  const out: string[] = [];
-  for (const msg of messages ?? []) {
-    for (const part of msg.parts) {
-      for (const ref of planRefsFromPart(part)) {
-        if (!out.includes(ref)) out.push(ref);
-      }
-    }
-  }
-  return out;
-}
-
 /**
  * The plan card's display data: the title (first markdown heading of the plan
- * text, falling back to the question header), the plan file path when known,
- * the metrics, and the FULL plan text (what "Build here" resubmits as the next
- * prompt with the build model). Everything is tolerant — when the `plan_exit`
- * part's input carries no plan text the card still renders, just with the
- * question's header as the title and no metrics.
+ * text, falling back to the question header) and the FULL plan text (what
+ * "Build here" resubmits as the next prompt with the build model). Everything
+ * is tolerant — when the `plan_exit` part's input carries no plan text the
+ * card still renders, just with the question's header as the title.
  */
 export function extractPlanData(
   question: QuestionRequest,
   messages: OpencodeMessage[] | null,
 ): {
   title: string;
-  path?: string;
-  metrics: { steps?: number; files?: number };
   text: string;
 } {
   let text = "";
-  let path = "";
   for (const msg of messages ?? []) {
     for (const part of msg.parts) {
       if (part.type !== "tool") continue;
@@ -2280,19 +2243,10 @@ export function extractPlanData(
         | Record<string, unknown>
         | undefined;
       const t = input?.plan ?? input?.content ?? input?.text;
-      const p = input?.planPath ?? input?.path;
       if (typeof t === "string") text = t;
-      if (typeof p === "string") path = p;
       break;
     }
   }
-  // The plan_exit input often carries no path (opencode's plan_exit tool takes
-  // no arguments). Fall back to tolerant discovery across the transcript so
-  // the plan's `.opencode/plans/*.md` path (found in the `write`/`plan` tool
-  // that authored it, or a prose mention) still resolves — this is what lets
-  // the plan card publish the companion page even before plan_exit completes.
-  // Most recent plan wins (`at(-1)`): messages are append-ordered.
-  if (!path) path = planPathsFromMessages(messages).at(-1) ?? "";
   const firstHeading = text.match(/^#{1,6}[ \t]+(.+)$/m)?.[1]?.trim();
   const firstLine = text.split("\n").find((l) => l.trim())?.trim();
   const title =
@@ -2300,12 +2254,7 @@ export function extractPlanData(
     firstLine ??
     question.questions[0]?.header ??
     "Plan complete";
-  return {
-    title,
-    path: path || undefined,
-    metrics: planMetrics(text),
-    text,
-  };
+  return { title, text };
 }
 
 // ===== resolveDelegateModel (BET-951) =====

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -304,12 +304,6 @@ export interface Api {
 
   peekRemoteFile(remotePath: string): Promise<void>;
   openExternal(url: string): Promise<void>;
-  /**
-   * Publish (or refresh) the hosted companion page for a session's plan and
-   * return its public URL. The server reads the plan file itself; `path` is
-   * the plan's path as reported by the plan_exit tool.
-   */
-  planPublish(sessionID: string, path: string): Promise<{ url: string }>;
 
   // Agent → laptop file push (outbox). `onAgentFileReady` fires when a file
   // appears in the remote ~/.manta-outbox/. `agentPullFile` pulls it to the


### PR DESCRIPTION
Implements BET-1005 — the renderer half of going single-HTML-only for plans.

**Base: origin/main @ 6b302bdb**

What this PR does:
- (2) PlanCard "Open page" now ALWAYS opens the deterministic URL `planPageUrl(sessionId, serverBase())` — fixing the bug where a single-HTML plan (eager-publish absent, `.md` path gone) made the button do nothing.
- (3) Build here / Delegate now show per-action loading states while their async call is in flight, driven by ONE `busy` prop.
- (4) Removed the awkward "Keep planning" button; added a Send button at the end of the feedback input row that submits feedback (reusing `keepPlanning`), with its own loading state.
- Removed the renderer's markdown `planPublish` plumbing and the md path/metrics, and pointed ArtifactsPanel's plan-open at the deterministic URL.

Files changed (renderer + shared only — no src/server touched):
```
 src/renderer/ArtifactsPanel.tsx       |  24 +--
 src/renderer/Cards.tsx                |  84 +++-----------
 src/renderer/ChatPanel.tsx            | 100 +++-----------------
 src/renderer/PlanCard.test.tsx        | 124 +++++++++++++---------
 src/renderer/api/demoCoverage.test.ts |   1 -
 src/renderer/api/httpApi.ts           |  25 -------
 src/renderer/chatUtils.test.ts        | 133 +++++++++-----------------
 src/renderer/chatUtils.ts             |  61 ++-----------
 src/shared/api.ts                     |   6 --
```

Note: `planRefsFromPart` + its `PLAN_REF_RE`/`PLAN_AUTHORING_TOOLS` were KEPT (not deleted) because `src/renderer/artifacts.ts` still uses them to detect `.opencode/plans/*.md` plan artifacts in the artifacts panel. Only `planMetrics` and `planPathsFromMessages` (used solely by `extractPlanData`) were removed.

Verification: `npm run typecheck` clean; `npm test` (vitest 2884 pass / 7 skip) + `npm run test:server` (1676 pass) green.