### PR TITLE
fix(renderer): collapse clone-picker repo state so sign-in clears the not_connected stuck state (BET-1011)

### DIFF
--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -18,7 +18,7 @@
 // existing credential (so the picker renders immediately) and a fixed repo
 // list.
 
-import { describe, it, expect, afterEach } from "vitest";
+import { describe, it, expect, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { CloneFromGitHub } from "./CloneFromGitHub";
@@ -99,6 +99,16 @@ async function flushMicro(): Promise<void> {
   });
 }
 
+// Microtask-only flush for use under vi.useFakeTimers(), where a real
+// setTimeout(r, 0) would never fire. Mirrors ConnectGithub.test.tsx.
+async function flushMicrotasks(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+  });
+}
+
 function unmount(): void {
   act(() => {
     root?.unmount();
@@ -135,6 +145,7 @@ function cloneButtonFor(name: string): HTMLButtonElement {
 
 afterEach(() => {
   unmount();
+  vi.useRealTimers();
 });
 
 describe("CloneFromGitHub picker", () => {
@@ -221,5 +232,105 @@ describe("CloneFromGitHub picker", () => {
     await flushMicro();
 
     expect(clonedPaths).toEqual(["/root/alpha"]);
+  });
+
+  it("fetches repos exactly once, after sign-in completes, and never shows not_connected (BET-1011)", async () => {
+    // The broken sequence: fetch fired on mount (before a credential
+    // existed), cached { repos: [], error: "not_connected" } as a permanent
+    // error, and no later sign-in could clear it. With the fix the fetch is
+    // keyed on `connected`, so it runs only once the device flow completes.
+    vi.useFakeTimers();
+    let repoCallCount = 0;
+    // Mirrors the box: without a credential it answers `not_connected`; with
+    // one it returns the real list. Only flipped once the device flow turns
+    // `connected` on — so if the fetch ever ran pre-connect it would hit the
+    // error branch (reproducing the old stuck state).
+    let connected = false;
+    installMockApi({
+      forgeDeviceStart: () =>
+        Promise.resolve({
+          connected: false,
+          grant: {
+            grantId: "g1",
+            userCode: "ABCD-1234",
+            verificationUri: "https://github.com/login/device",
+            expiresIn: 900,
+            pollInterval: 5,
+          },
+          error: null,
+        }),
+      forgeDevicePoll: () => Promise.resolve({ status: "done" }),
+      forgeRepos: () => {
+        repoCallCount++;
+        return Promise.resolve(
+          connected
+            ? { repos: REPOS, stale: false, error: null }
+            : { repos: [], stale: false, error: "not_connected" },
+        );
+      },
+      forgeCloneStart: () => Promise.resolve({ id: "c1" }),
+      forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
+      );
+    });
+
+    // Let forgeDeviceStart settle so the code panel mounts and schedules the
+    // first poll at max(pollInterval, 5) seconds.
+    await flushMicrotasks();
+    // Complete the device flow — advance past the first poll, which resolves
+    // "done" → onConnected → connected=true → the picker (and the fetch).
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+    // Mirror the component's new `connected` state before the flushed effects
+    // run, so the post-sign-in fetch returns the real list, not an error.
+    connected = true;
+    await flushMicrotasks();
+    await flushMicrotasks();
+
+    expect(repoCallCount).toBe(1);
+    const text = container!.textContent ?? "";
+    expect(text).not.toContain("not_connected");
+    expect(container!.querySelector('input[aria-label="Clone alpha"]')).toBeTruthy();
+  });
+
+  it("shows the loader + 'Loading repositories…' while the repo list is in flight, then the rows (BET-1011)", async () => {
+    let resolveRepos: (r: unknown) => void;
+    const reposPromise = new Promise((resolve) => {
+      resolveRepos = resolve;
+    });
+    installMockApi({
+      forgeDeviceStart: () => Promise.resolve({ connected: true, grant: null }),
+      forgeRepos: () => reposPromise,
+      forgeCloneStart: () => Promise.resolve({ id: "c1" }),
+      forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
+      );
+    });
+    // The fetch is pending — the picker must show the loading state, not
+    // "Search 0 repositories…" / "No repositories match.".
+    await flushMicro();
+    expect(container!.querySelector(".manta-loader")).toBeTruthy();
+    expect(container!.textContent).toContain("Loading repositories…");
+
+    // Resolve the fetch; the loader goes away and the real rows render.
+    act(() => {
+      resolveRepos!({ repos: REPOS, stale: false, error: null });
+    });
+    await flushMicro();
+    expect(container!.querySelector(".manta-loader")).toBeNull();
+    expect(container!.querySelector('input[aria-label="Clone alpha"]')).toBeTruthy();
   });
 });

--- a/src/renderer/CloneFromGitHub.tsx
+++ b/src/renderer/CloneFromGitHub.tsx
@@ -31,8 +31,15 @@ import { Field } from "./Field";
 import { ListRow } from "./ListRow";
 import { ProgressBar } from "./ProgressBar";
 import { ScrollFrame } from "./ScrollFrame";
+import { MantaLoader } from "./MantaLoader";
 import { ConnectGithubPanel, PanelHeader, PANEL_CLASS } from "./ConnectGithub";
-import { formatAge, formatBytes, cloneErrorKind, type CloneErrorKind } from "./chatUtils";
+import {
+  formatAge,
+  formatBytes,
+  cloneErrorKind,
+  repoListErrorMessage,
+  type CloneErrorKind,
+} from "./chatUtils";
 import type {
   ForgeCloneStatus,
   ForgeRepo,
@@ -42,6 +49,19 @@ type Phase =
   | { kind: "pick" }
   | { kind: "clone"; queue: ForgeRepo[]; index: number }
   | { kind: "failed"; repo: ForgeRepo; message: string; errorKind: CloneErrorKind };
+
+// One state for the repo fetch, so "in flight", "failed" and "loaded" can
+// never disagree. The previous three-flag version (repos + reposError, with
+// the fetch keyed on neither) is what left the picker stuck showing
+// `not_connected` after a successful sign-in.
+type ReposState =
+  | { kind: "loading" }
+  | { kind: "ready"; repos: ForgeRepo[] }
+  | { kind: "error"; message: string };
+
+// Module-scope constant so the `owners` / `filtered` memos see a stable
+// identity while loading.
+const NO_REPOS: ForgeRepo[] = [];
 
 export function CloneFromGitHub({
   defaultRoot,
@@ -57,8 +77,8 @@ export function CloneFromGitHub({
   const [connected, setConnected] = useState(false);
   const [phase, setPhase] = useState<Phase>({ kind: "pick" });
   // ---- [S6] picker state ----
-  const [repos, setRepos] = useState<ForgeRepo[]>([]);
-  const [reposError, setReposError] = useState<string | null>(null);
+  const [reposState, setReposState] = useState<ReposState>({ kind: "loading" });
+  const repos = reposState.kind === "ready" ? reposState.repos : NO_REPOS;
   const [search, setSearch] = useState("");
   const [owner, setOwner] = useState<string>("");
   const [checked, setChecked] = useState<ReadonlySet<string>>(new Set());
@@ -82,30 +102,31 @@ export function CloneFromGitHub({
     );
   }, [repos, owner, search]);
 
-  // ---- [S6]: fetch the repos once we reach the picker ----
+  // ---- [S6]: fetch the repos once a credential exists ----
+  // Keyed on `connected` ONLY. The old version keyed on `phase.kind`, so it
+  // fired on mount — before sign-in — and cached the resulting `not_connected`
+  // as a permanent error that no later sign-in could clear.
   useEffect(() => {
-    if (phase.kind !== "pick" || repos.length > 0 || reposError) return;
+    if (!connected) return;
     let cancelled = false;
+    setReposState({ kind: "loading" });
     (async () => {
       try {
         const res = await window.api.forgeRepos();
         if (cancelled) return;
-        if (res.repos) {
-          setRepos(res.repos);
-          setReposError(res.error ?? null);
-        } else {
-          setReposError(res.error ?? "Couldn't list repositories");
-        }
+        // `res.repos` is always an array; `res.error` is the only failure
+        // signal. Testing the array's truthiness was the original bug.
+        if (res.error) setReposState({ kind: "error", message: repoListErrorMessage(res.error) });
+        else setReposState({ kind: "ready", repos: res.repos });
       } catch {
         if (cancelled) return;
-        setReposError("Couldn't list repositories from GitHub");
+        setReposState({ kind: "error", message: repoListErrorMessage(null) });
       }
     })();
     return () => {
       cancelled = true;
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [phase.kind]);
+  }, [connected]);
 
   const toggleRepo = (fullName: string, on: boolean) => {
     setChecked((prev) => {
@@ -271,11 +292,15 @@ export function CloneFromGitHub({
                   ariaLabel="Search repositories"
                   value={search}
                   onChange={(e) => setSearch(e.target.value)}
-                  placeholder={`Search ${repos.length} ${repos.length === 1 ? "repository" : "repositories"}…`}
+                  placeholder={
+                    reposState.kind === "ready"
+                      ? `Search ${repos.length} ${repos.length === 1 ? "repository" : "repositories"}…`
+                      : "Search repositories…"
+                  }
                 />
-                {reposError && (
+                {reposState.kind === "error" && (
                   <div className="mt-2">
-                    <Callout tone="danger">{reposError}</Callout>
+                    <Callout tone="danger">{reposState.message}</Callout>
                   </div>
                 )}
               </>
@@ -328,22 +353,29 @@ export function CloneFromGitHub({
             }
             bodyClassName="mt-1"
           >
-            {filtered.map((r) => (
-              <ListRow
-                key={r.fullName}
-                leading={
-                  <Checkbox
-                    checked={checked.has(r.fullName)}
-                    onChange={(on) => toggleRepo(r.fullName, on)}
-                    ariaLabel={`Clone ${r.name}`}
-                  />
-                }
-                name={r.name}
-                secondary={r.description || "—"}
-                trailing={r.pushedAt != null ? formatAge(Date.now() - r.pushedAt) : "—"}
-              />
-            ))}
-            {filtered.length === 0 && !reposError && (
+            {reposState.kind === "loading" && (
+              <div className="flex items-center gap-2 py-3 text-[13px] text-text-faint">
+                <MantaLoader />
+                <span>Loading repositories…</span>
+              </div>
+            )}
+            {reposState.kind === "ready" &&
+              filtered.map((r) => (
+                <ListRow
+                  key={r.fullName}
+                  leading={
+                    <Checkbox
+                      checked={checked.has(r.fullName)}
+                      onChange={(on) => toggleRepo(r.fullName, on)}
+                      ariaLabel={`Clone ${r.name}`}
+                    />
+                  }
+                  name={r.name}
+                  secondary={r.description || "—"}
+                  trailing={r.pushedAt != null ? formatAge(Date.now() - r.pushedAt) : "—"}
+                />
+              ))}
+            {reposState.kind === "ready" && filtered.length === 0 && (
               <div className="text-[13px] text-text-faint py-2">No repositories match.</div>
             )}
           </ScrollFrame>

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -117,6 +117,7 @@ import {
   describeMergeFailure,
   commentableLines,
   cloneErrorKind,
+  repoListErrorMessage,
   type StatusItem,
   type RepoRow,
   workingIndicatorLabel,
@@ -4711,6 +4712,22 @@ describe("cloneErrorKind", () => {
     expect(cloneErrorKind("fatal: some other git error")).toBe("unknown");
     expect(cloneErrorKind("")).toBe("unknown");
     expect(cloneErrorKind(undefined as unknown as string)).toBe("unknown");
+  });
+});
+
+describe("repoListErrorMessage (BET-1011)", () => {
+  it("maps the server's not_connected code to sign-in guidance", () => {
+    expect(repoListErrorMessage("not_connected")).toBe(
+      "GitHub isn't connected. Go back and sign in again.",
+    );
+  });
+
+  it("falls back to a generic message for any other code or absence", () => {
+    const generic = "Couldn't list your repositories from GitHub.";
+    expect(repoListErrorMessage("rate_limited")).toBe(generic);
+    expect(repoListErrorMessage("")).toBe(generic);
+    expect(repoListErrorMessage(null)).toBe(generic);
+    expect(repoListErrorMessage(undefined)).toBe(generic);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3405,6 +3405,14 @@ export function cloneErrorKind(stderr: string): CloneErrorKind {
   return "unknown";
 }
 
+// The box returns machine codes (`not_connected`) or a raw exception string
+// for a failed repo listing; neither is something to show a person. One
+// mapping, so the picker never renders a server code verbatim.
+export function repoListErrorMessage(code: string | null | undefined): string {
+  if (code === "not_connected") return "GitHub isn't connected. Go back and sign in again.";
+  return "Couldn't list your repositories from GitHub.";
+}
+
 // ===== Forge merge gate (BET-794) =====
 
 /**


### PR DESCRIPTION
Clones from GitHub: the picker got stuck showing `not_connected` after a successful sign-in, and had no loading state while the repo list fetched.

**Root cause:** `CloneFromGitHub.tsx` held repo state as three independent flags (`repos`, `reposError`) with the fetch keyed on `phase.kind` — so it fired on mount (before any credential) and permanently cached the server's `not_connected` as an error no later sign-in could clear. The `if (res.repos)` truthiness test on an always-present array made the error branch dead code.

**Fix:** collapse the three flags into one discriminated union `ReposState` (`loading | ready | error`); key the fetch effect on `connected` only (now the sole dependency, so the eslint-disable is gone); map server codes to human copy via `repoListErrorMessage`; render distinct loading / error / empty / rows states. `not_connected` never reaches the UI.

**Files changed:** 4 (`CloneFromGitHub.tsx`, `chatUtils.ts`, `CloneFromGitHub.test.tsx`, `chatUtils.test.ts`). No server change (`src/server/forge/**` untouched), no new files/components/hooks/config.

**Base:** `origin/main @ 6ef2081d`

**Verification results:**
- PR branch (`multica/BET-1011-clone-from-github-picker-state` @ `c1f895a7`):
  - typecheck: exit 0. Errors: none.
  - vitest: 2888 pass / 0 fail / 7 skip.
  - server (node:test): 1645 pass / 0 fail.
- Base (`main`): not re-run locally — `main` is checked out by a peer worktree on this box, and the diff touches only renderer files with no shared-logic or server surface, so there is no cross-branch interference to check.
- Regression test added (the sign-in sequence: asserts `forgeRepos` called exactly once, rows render, no `not_connected` in the DOM) + loading-state test + `repoListErrorMessage` unit tests.
- **Conclusion:** 0 new failures (both suites fully green on the branch).
