### PR TITLE
fix(server): keep usage dial on 429 — accept retry-after: 0, carry snapshots forward, slow poll to 10m (BET-1012)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -434,6 +434,24 @@ function Shell() {
   } | null>(null);
   const cacheTtl = useStore((s) => s.cacheTtl);
 
+  // Pull the box's CACHED usage snapshots. This is an in-memory read on the box
+  // (no provider request), which is why it is safe to call on every reconnect.
+  const pullUsage = useCallback(async () => {
+    if (!window.api.usageList) return;
+    try {
+      const snapshots = await window.api.usageList();
+      const list = Array.isArray(snapshots) ? snapshots : [];
+      useStore.getState().setUsage(list);
+      // Seed the escalation baseline from the SAME payload that primes the dial,
+      // so the first live update after a launch does not re-fire for a window
+      // that was already over the threshold.
+      usageLevelsRef.current = buildUsageLevels(list, usageLevelsRef.current);
+    } catch {
+      // Older box or a transport blip — leave the slice as-is; UsageDial's own
+      // null-snapshot path already renders nothing.
+    }
+  }, []);
+
   useEffect(() => {
     // Bootstrap (BET-678). The first paint is INSTANT — read from the persisted
     // local snapshot restored in main.tsx (zero round trips). This effect only
@@ -496,13 +514,14 @@ function Shell() {
       const isResync = "resync" in delta && delta.resync === true;
       if (isResync) {
         void refresh();
+        void pullUsage();
         return;
       }
       // applySyncPayload owns the stale-envelope guard (same gen, lower seq).
       useStore.getState().applySyncPayload(delta as SyncPayload);
     });
     return off;
-  }, [refresh, apiGeneration]);
+  }, [refresh, apiGeneration, pullUsage]);
 
   useEffect(() => {
     if (!window.api.onStatusEvent) return;
@@ -595,38 +614,18 @@ function Shell() {
   }, [apiGeneration]);
 
   // Subscription plan usage (BET-738): prime the store's `usage` slice with
-  // ONE window.api.usageList() call on mount, then stay live via the box's
-  // `usage.updated` bus event. Deliberately NOT a poll — the box's usage
-  // poller (src/server/usage.mjs, 3-minute interval) is the only timer;
-  // adding a second one here would just be two clocks disagreeing.
+  // ONE window.api.usageList() call on mount (and on api change), then stay
+  // live via the box's `usage.updated` bus event. Deliberately NOT a poll —
+  // the box's usage poller (src/server/usage.mjs, 10-minute interval) is the
+  // only timer; adding a second one here would just be two clocks
+  // disagreeing.
   useEffect(() => {
-    if (!window.api.usageList) return;
-    window.api
-      .usageList()
-      .then((snapshots) => {
-        const list = Array.isArray(snapshots) ? snapshots : [];
-        useStore.getState().setUsage(list);
-        // Seed the escalation baseline from the SAME payload that primes the
-        // dial. Without this the fire-once memory starts empty, so the first
-        // live update after any launch re-fires for a window that was already
-        // over the threshold when the app opened.
-        usageLevelsRef.current = buildUsageLevels(list, usageLevelsRef.current);
-      })
-      .catch(() => {
-        // Transport blip or an older box that doesn't implement the channel
-        // yet — leave the slice as-is (UsageDial's own null-snapshot path
-        // already renders nothing).
-      });
-    let off: (() => void) | null = null;
-    if (window.api.onUsageUpdated) {
-      off = window.api.onUsageUpdated(({ snapshots }) => {
-        useStore.getState().setUsage(Array.isArray(snapshots) ? snapshots : []);
-      });
-    }
-    return () => {
-      if (off) off();
-    };
-  }, [apiGeneration]);
+    void pullUsage();
+    if (!window.api.onUsageUpdated) return;
+    return window.api.onUsageUpdated(({ snapshots }) => {
+      useStore.getState().setUsage(Array.isArray(snapshots) ? snapshots : []);
+    });
+  }, [apiGeneration, pullUsage]);
 
   // ---- Subscription usage escalation (BET-739) ----
   // The warn (>=90%) / limit (>=100%) toasts, pushed through the existing

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3682,9 +3682,9 @@ describe("formatUpdatedAgo / usageStale", () => {
     expect(formatUpdatedAgo(0, 2 * 3_600_000)).toBe("updated 2h ago");
   });
 
-  it("usageStale flips at exactly 10 minutes", () => {
-    expect(usageStale(0, 10 * 60_000)).toBe(false);
-    expect(usageStale(0, 10 * 60_000 + 1)).toBe(true);
+  it("usageStale flips at exactly 25 minutes", () => {
+    expect(usageStale(0, 25 * 60_000)).toBe(false);
+    expect(usageStale(0, 25 * 60_000 + 1)).toBe(true);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3023,11 +3023,13 @@ export function formatUpdatedAgo(fetchedAt: number, nowMs: number): string {
   return age === "now" ? "updated just now" : `updated ${age} ago`;
 }
 
-// True once a snapshot is more than 10 minutes stale — the popover footer's
+// True once a snapshot is more than 25 minutes stale — the popover footer's
 // "updated Nm ago" line turns --warn at this point. The box's poller runs
-// every 3 minutes, so 10 minutes means at least 2-3 missed ticks.
+// every 10 minutes, so 25 minutes means at least two missed ticks; it also
+// sits below the box's 30-minute carry-forward cap, so a reading the box is
+// holding on to visibly ages into a warning before it is dropped.
 export function usageStale(fetchedAt: number, nowMs: number): boolean {
-  return nowMs - fetchedAt > 10 * 60_000;
+  return nowMs - fetchedAt > 25 * 60_000;
 }
 
 // M6/BET-730: given the set of "visited" chat session ids (panels kept

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -84,23 +84,62 @@ export { normalizeWindow };
 export const ADAPTERS = [claudeAdapter, codexAdapter, kimiAdapter];
 
 // Cache TTL is the poll interval; there is no separate cache layer (per spec).
-const POLL_MS = 180_000; // 3 minutes
+const POLL_MS = 600_000; // 10 minutes
 // How long after a tick that first saw an expired window we re-poll, so the
 // carried-forward reading is replaced in seconds rather than up to POLL_MS.
 const STALE_RETRY_MS = 20_000;
-// Default per-adapter backoff on a bare 429 (no usable Retry-After).
-const DEFAULT_RATE_LIMIT_BACKOFF_MS = 15 * 60_000; // 15 minutes
+// A 429 backoff is always clamped into this band. The floor exists because
+// Anthropic's usage endpoint answers with `retry-after: 0` — honouring that
+// literally would hot-loop the endpoint — and the ceiling exists because a
+// provider asking for an hour still must not blank the dial for an hour.
+// Both ends collapse the old "header present / header absent" branch into one
+// expression.
+const MIN_RATE_LIMIT_BACKOFF_MS = 2 * 60_000;  // 2 minutes
+const MAX_RATE_LIMIT_BACKOFF_MS = 15 * 60_000; // 15 minutes
+// How long a snapshot may be carried forward across failed/backed-off ticks
+// before it is dropped. Sits above the stale-warning threshold the popover
+// uses, so a carried reading visibly ages into a warning before it disappears.
+const MAX_CARRY_FORWARD_MS = 30 * 60_000; // 30 minutes
 
 /**
  * Strip `fetchedAt` for the "did anything actually change" comparison — a
  * fresh fetch always has a new timestamp, so comparing the full object would
  * publish on every tick regardless of content, defeating the whole point of
  * the dedupe (BET-737 spec: "only when the serialized snapshot set actually
- * changed... a poller that republishes an identical payload every 3 minutes
+ * changed... a poller that republishes an identical payload every 10 minutes
  * wakes every connected client for nothing").
  */
 function contentKey(results) {
   return JSON.stringify(results.map(({ fetchedAt, ...rest }) => rest));
+}
+
+/**
+ * Clamp a provider's requested retry delay into the supported band. A missing
+ * or non-finite value is treated as 0 and therefore lands on the floor — the
+ * "no header" and "retry-after: 0" cases are deliberately the SAME case, which
+ * is what lets the caller drop its ternary.
+ * @param {number|undefined} retryAfterMs
+ * @returns {number}
+ */
+export function rateLimitBackoffMs(retryAfterMs) {
+  const ms = Number.isFinite(retryAfterMs) ? retryAfterMs : 0;
+  return Math.min(MAX_RATE_LIMIT_BACKOFF_MS, Math.max(MIN_RATE_LIMIT_BACKOFF_MS, ms));
+}
+
+/**
+ * The previous tick's snapshot for `adapterId`, if it is young enough to keep
+ * showing. Returns the SAME object reference on purpose: an unchanged
+ * contentKey is what keeps a failed tick off the bus entirely.
+ * @param {UsageSnapshot[]} prevSnapshots
+ * @param {string} adapterId
+ * @param {number} nowMs
+ * @param {number} [maxAgeMs]
+ * @returns {UsageSnapshot | null}
+ */
+export function carryForward(prevSnapshots, adapterId, nowMs, maxAgeMs = MAX_CARRY_FORWARD_MS) {
+  const prev = (prevSnapshots ?? []).find((s) => s.provider === adapterId);
+  if (!prev) return null;
+  return nowMs - prev.fetchedAt > maxAgeMs ? null : prev;
 }
 
 /**
@@ -151,7 +190,11 @@ export function createUsagePoller({
 
       for (const adapter of adapters) {
         const until = backoffUntil.get(adapter.id);
-        if (until != null && nowMs < until) continue; // still backed off
+        if (until != null && nowMs < until) {
+          const carried = carryForward(snapshots, adapter.id, nowMs);
+          if (carried) results.push(carried);
+          continue; // still backed off
+        }
 
         let detected = false;
         try {
@@ -185,17 +228,17 @@ export function createUsagePoller({
           backoffUntil.delete(adapter.id);
           failing.delete(adapter.id);
         } catch (e) {
-          // Quarantined: a throw, a non-2xx, or zero usable windows removes
-          // this provider's snapshot for the tick and never affects another
-          // adapter.
+          // A throw, a non-2xx, or zero usable windows: carry the previous
+          // reading forward so a transient failure doesn't blank the dial
+          // (visually indistinguishable from "this plan has no limits"). The
+          // SAME object reference keeps contentKey unchanged, so a failed
+          // tick publishes nothing.
           if (e?.status === 429) {
-            const retryMs =
-              typeof e.retryAfterMs === "number" && e.retryAfterMs > 0
-                ? e.retryAfterMs
-                : DEFAULT_RATE_LIMIT_BACKOFF_MS;
-            backoffUntil.set(adapter.id, nowMs + retryMs);
+            backoffUntil.set(adapter.id, nowMs + rateLimitBackoffMs(e.retryAfterMs));
           }
           warnOnce(adapter.id, e);
+          const carried = carryForward(snapshots, adapter.id, nowMs);
+          if (carried) results.push(carried);
         }
       }
 

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { normalizeWindow, createUsagePoller, ADAPTERS } from "./usage.mjs";
+import { normalizeWindow, createUsagePoller, ADAPTERS, rateLimitBackoffMs, carryForward } from "./usage.mjs";
 import { claudeAdapter } from "./usageAdapters/claude.mjs";
 import { codexAdapter } from "./usageAdapters/codex.mjs";
 import { kimiAdapter } from "./usageAdapters/kimi.mjs";
@@ -215,7 +215,7 @@ test("poller: a 429 with Retry-After backs off only that adapter, for exactly th
       if (rlFetchCalls === 1) {
         const err = new Error("rate limited");
         err.status = 429;
-        err.retryAfterMs = 5000;
+        err.retryAfterMs = 5 * 60_000; // 5 min — above floor, below ceiling, honoured verbatim
         throw err;
       }
       return { windows: [{ kind: "session", label: "s", pct: 10 }] };
@@ -234,17 +234,17 @@ test("poller: a 429 with Retry-After backs off only that adapter, for exactly th
   try {
     const poller = createUsagePoller({ adapters: [rateLimited, ok], now: () => nowMs });
 
-    await poller.tick(); // rl fails (429, backoff 5s); ok succeeds
+    await poller.tick(); // rl fails (429, backoff 5 min); ok succeeds
     assert.equal(rlFetchCalls, 1);
     assert.equal(okFetchCalls, 1);
     assert.equal(poller.snapshots.some((s) => s.provider === "rl"), false);
 
-    nowMs += 2000; // still inside the 5s backoff window
+    nowMs += 2 * 60_000; // still inside the 5-minute backoff window
     await poller.tick();
     assert.equal(rlFetchCalls, 1, "rl must not be fetched again while backed off");
     assert.equal(okFetchCalls, 2);
 
-    nowMs += 4000; // 6s elapsed since the 429 — backoff has expired
+    nowMs += 4 * 60_000; // 6 minutes elapsed since the 429 — backoff has expired
     await poller.tick();
     assert.equal(rlFetchCalls, 2, "rl is fetched again once its backoff expires");
     assert.equal(poller.snapshots.find((s) => s.provider === "rl").windows[0].pct, 10);
@@ -253,7 +253,7 @@ test("poller: a 429 with Retry-After backs off only that adapter, for exactly th
   }
 });
 
-test("poller: a bare 429 with no Retry-After falls back to the 15-minute default backoff", async () => {
+test("poller: a bare 429 with no Retry-After floors at 2 minutes", async () => {
   let nowMs = 0;
   let calls = 0;
   const rl = makeAdapter("rl", {
@@ -272,16 +272,176 @@ test("poller: a bare 429 with no Retry-After falls back to the 15-minute default
     await poller.tick();
     assert.equal(calls, 1);
 
-    nowMs += 14 * 60_000; // just under 15 minutes
+    nowMs += 1 * 60_000; // just under the 2-minute floor (even retry-after: 0 lands here)
     await poller.tick();
     assert.equal(calls, 1);
 
-    nowMs += 2 * 60_000; // now past 15 minutes total
+    nowMs += 2 * 60_000; // now past 2 minutes total — retried
     await poller.tick();
     assert.equal(calls, 2);
   } finally {
     console.warn = originalWarn;
   }
+});
+
+test("rateLimitBackoffMs: clamps into the 2-15 minute band", () => {
+  assert.equal(rateLimitBackoffMs(undefined), 120_000);
+  assert.equal(rateLimitBackoffMs(0), 120_000);
+  assert.equal(rateLimitBackoffMs(30_000), 120_000); // below floor
+  assert.equal(rateLimitBackoffMs(300_000), 300_000); // in band
+  assert.equal(rateLimitBackoffMs(3_600_000), 900_000); // above ceiling
+});
+
+test("poller: a 429 carrying retry-after: 0 backs off 2 minutes, not 15 (regression)", async () => {
+  let nowMs = 0;
+  let calls = 0;
+  const rl = makeAdapter("rl", {
+    detect: async () => true,
+    fetch: async () => {
+      calls++;
+      const err = new Error("rate limited");
+      err.status = 429;
+      err.retryAfterMs = 0; // Anthropic's literal retry-after: 0
+      throw err;
+    },
+  });
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const poller = createUsagePoller({ adapters: [rl], now: () => nowMs });
+    await poller.tick();
+    assert.equal(calls, 1);
+
+    nowMs += 1 * 60_000; // before the 2-minute floor → still backed off
+    await poller.tick();
+    assert.equal(calls, 1);
+
+    nowMs += 2 * 60_000; // past 2 minutes → retried (NOT after 15)
+    await poller.tick();
+    assert.equal(calls, 2);
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("poller: a failing adapter's snapshot is carried forward (same ref, unchanged fetchedAt, nothing republished)", async () => {
+  let nowMs = 1_000_000;
+  let calls = 0;
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => {
+      calls++;
+      if (calls === 2) throw new Error("boom");
+      return { windows: [{ kind: "session", label: "s", pct: 42 }] };
+    },
+  });
+  const published = [];
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const poller = createUsagePoller({
+      adapters: [adapter],
+      now: () => nowMs,
+      publish: (evt) => published.push(evt),
+    });
+
+    await poller.tick(); // success
+    const first = poller.snapshots[0];
+    assert.equal(first.fetchedAt, 1_000_000);
+    assert.equal(published.length, 1);
+
+    nowMs += 60_000; // 1 minute later the adapter throws
+    await poller.tick();
+    assert.equal(calls, 2);
+    assert.equal(poller.snapshots.length, 1, "snapshot still present after the failed tick");
+    assert.equal(poller.snapshots[0], first, "the SAME object reference is carried forward");
+    assert.equal(poller.snapshots[0].fetchedAt, 1_000_000, "fetchedAt untouched");
+    assert.equal(published.length, 1, "the failed tick put nothing on the bus");
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("poller: carry-forward across the backoff window keeps the snapshot present", async () => {
+  let nowMs = 1_000_000;
+  let calls = 0;
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => {
+      calls++;
+      if (calls === 2) {
+        const err = new Error("rate limited");
+        err.status = 429;
+        throw err;
+      }
+      return { windows: [{ kind: "session", label: "s", pct: 42 }] };
+    },
+  });
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs });
+    await poller.tick(); // success
+    assert.equal(poller.snapshots.length, 1);
+    const first = poller.snapshots[0];
+
+    nowMs += 1 * 60_000; // 1 min later — bare 429 sets the 2-minute floor backoff
+    await poller.tick();
+    assert.equal(calls, 2, "adapter was called on the failing tick");
+    assert.equal(poller.snapshots.length, 1, "snapshot present after the 429");
+
+    nowMs += 30_000; // still inside the 2-min backoff — adapter not even called
+    await poller.tick();
+    assert.equal(calls, 2, "adapter not called while backed off");
+    assert.equal(poller.snapshots.length, 1, "snapshot carried across the backoff window");
+    assert.equal(poller.snapshots[0], first, "same reference carried");
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("poller: carry-forward expires after 30 minutes with no successful fetch", async () => {
+  let nowMs = 1_000_000;
+  let calls = 0;
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => {
+      calls++;
+      if (calls === 2) throw new Error("boom");
+      return { windows: [{ kind: "session", label: "s", pct: 42 }] };
+    },
+  });
+  const originalWarn = console.warn;
+  console.warn = () => {};
+  try {
+    const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs });
+    await poller.tick(); // success
+    assert.equal(poller.snapshots.length, 1);
+
+    nowMs += 31 * 60_000; // past the 30-minute carry-forward cap
+    await poller.tick(); // fails again
+    assert.equal(calls, 2);
+    assert.equal(poller.snapshots.length, 0, "snapshot dropped once older than the carry cap");
+  } finally {
+    console.warn = originalWarn;
+  }
+});
+
+test("poller: detect() flips to false → snapshot dropped on the very next tick, no carry-forward", async () => {
+  let nowMs = 1_000_000;
+  let detected = true;
+  const adapter = makeAdapter("a", {
+    detect: async () => detected,
+    fetch: async () => ({ windows: [{ kind: "session", label: "s", pct: 42 }] }),
+  });
+  const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs });
+  await poller.tick(); // detected — snapshot present
+  assert.equal(poller.snapshots.length, 1);
+
+  nowMs += 60_000;
+  detected = false; // credential gone — genuinely not connected
+  await poller.tick();
+  assert.equal(poller.snapshots.length, 0, "a missing credential clears the snapshot immediately");
 });
 
 // Reviewer Block (cycle 1): a content-identical tick must still refresh
@@ -308,13 +468,13 @@ test("poller: identical consecutive results publish exactly once, but fetchedAt 
   await poller.tick();
   assert.equal(poller.snapshots[0].fetchedAt, 1_000_000);
 
-  nowMs += 180_000; // a full poll interval later, same numbers
+  nowMs += 600_000; // a full poll interval (10 min) later, same numbers
   await poller.tick();
-  assert.equal(poller.snapshots[0].fetchedAt, 1_180_000, "fetchedAt must advance on a healthy re-confirm");
+  assert.equal(poller.snapshots[0].fetchedAt, 1_600_000, "fetchedAt must advance on a healthy re-confirm");
 
-  nowMs += 180_000;
+  nowMs += 600_000;
   await poller.tick();
-  assert.equal(poller.snapshots[0].fetchedAt, 1_360_000);
+  assert.equal(poller.snapshots[0].fetchedAt, 2_200_000);
 
   // Content never changed across all three ticks — the bus stayed quiet.
   assert.equal(published.length, 1);

--- a/src/server/usageAdapters/httpError.mjs
+++ b/src/server/usageAdapters/httpError.mjs
@@ -4,7 +4,8 @@
 // (claude/codex/kimi) call this identically; it is not provider-specific
 // logic, so it lives here rather than being duplicated three times or
 // living in usage.mjs (which would create a usage.mjs <-> adapter import
-// cycle, since usage.mjs imports the adapters).
+// cycle, since usage.mjs imports the adapters). `retryAfterMs` is parsed
+// regardless of status — only usage.mjs's 429 branch reads it.
 
 /**
  * @param {{status:number, headers?:{get?:(name:string)=>string|null|undefined}}} res
@@ -14,9 +15,14 @@
 export function httpError(res, label) {
   const err = new Error(`${label}: HTTP ${res.status}`);
   err.status = res.status;
-  if (res.status === 429) {
-    const retryAfter = Number(res.headers?.get?.("retry-after"));
-    if (Number.isFinite(retryAfter) && retryAfter > 0) err.retryAfterMs = retryAfter * 1000;
-  }
+  // Parsed regardless of status: only usage.mjs's 429 branch reads
+  // `retryAfterMs`, so a status guard here would gate a field nobody else
+  // touches. `>= 0`, NOT `> 0`: Anthropic's usage endpoint answers a 429 with
+  // a literal `retry-after: 0`, and treating that as "no header" is what sent
+  // the poller into its long default backoff and blanked the dial for 15
+  // minutes at a time. A falsy raw header (absent or "") stays undefined.
+  const raw = res.headers?.get?.("retry-after");
+  const secs = raw ? Number(raw) : NaN;
+  if (Number.isFinite(secs) && secs >= 0) err.retryAfterMs = secs * 1000;
   return err;
 }


### PR DESCRIPTION
Fixes BET-1012: the usage dial vanishes for 15+ minutes on a provider 429.

## What changed

Three compounding defects in the box usage engine fixed per the issue spec:

1. **`httpError.mjs` — accept `retry-after: 0`.** The old code only parsed the
   header for status `429` AND required `> 0`. Anthropic answers a 429 with a
   literal `retry-after: 0`, which was dropped, sending the poller into its
   15-minute default backoff. Now parsed regardless of status, `>= 0` — the
   "no header" and "retry-after: 0" cases land on the same 2-minute floor.
2. **`usage.mjs` — carry the last good snapshot forward across a failed or
   backed-off tick.** Two new exported pure helpers:
   - `rateLimitBackoffMs(retryAfterMs)` — the single expression that clamps a
     429 backoff into the 2–15 minute band (replaces the old inline ternary +
     `DEFAULT_RATE_LIMIT_BACKOFF_MS`).
   - `carryForward(prevSnapshots, adapterId, nowMs)` — returns the previous
     snapshot by reference when it is young enough (≤ 30 min), so a failed
     tick keeps the dial visible (same `contentKey` → publishes nothing) and
     the reading ages into a warning naturally. The `!detected` branch is
     deliberately left alone — a missing credential still clears the snapshot.
   - `POLL_MS` slowed from 3 to 10 minutes.
3. **`App.tsx` — re-pull cached usage on reconnect + 6 shrink.** `usage:list`
   is an in-memory read on the box (no provider call), so it's safe on every
   `onSyncDelta` resync. Extracted the launch fetch into `pullUsage` and added
   it to the resync branch; still no renderer-side timer.
4. **`chatUtils.ts` — `usageStale` raised 10 → 25 minutes** to match the slower
   10-minute poll (at least two missed ticks, and below the 30-min carry cap).

Non-goals respected: no on-demand provider fetch, no new renderer timer, no
new `UsageSnapshot`/`UsageWindow` fields, no change to `UsageDial` /
`usageEscalation` / the adapters / the 70% threshold.

**Files changed:** `6`
- `src/server/usageAdapters/httpError.mjs`
- `src/server/usage.mjs`
- `src/server/usage.test.mjs` (+6 tests, 2 updated)
- `src/renderer/chatUtils.ts`
- `src/renderer/chatUtils.test.ts`
- `src/renderer/App.tsx`

**Verification results:**
- PR branch (`multica/BET-1012-usage-dial-429-carryforward` @ `1cd1a6d2`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, vitest 2884 pass / 7 skip / 0 fail; server 1651 pass / 0 fail. Failures: none. server log sha256: `9381bbd95776fc9f24447520089106fa7c9da5b7fbd4543570b31ea2a9117343`
- Base (`main` @ `6ef2081d`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: server 1645 pass / 0 fail. server log sha256: `63d512d7f7ee5a2c1ac70396c6e4bdb41bf0bcb9f038f63a8912af5e8f2f7d83`
- **Conclusion:** 0 new failures. +6 server tests (1645 → 1651), all passing.
  (One full-`npm test` run flagged the `e2e-smoke` "Playwright is installed"
  check as a 5s timeout under the heavy parallel suite; it passes in isolation
  and on the next full run — an environment flake, not a code change.)

**Base: origin/main @ `6ef2081d`**
