### PR TITLE
BET-1009: fix(onboarding): real loading states on the provider step

### DIFF
--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -56,7 +56,6 @@ import {
   type ConnectPhase,
 } from "./chatUtils";
 import { CopyButton } from "./CopyButton";
-import { Button } from "./Button";
 import { Terminal } from "./Terminal";
 import { useStore } from "./store";
 import { ProcessPanel } from "./ProcessPanel";
@@ -941,23 +940,21 @@ const CredentialInput = memo(function CredentialInput({
               void submit();
             }
           }}
+          disabled={submitting}
           placeholder={placeholder}
           spellCheck={false}
           autoCapitalize="off"
           autoCorrect="off"
-          className="min-w-0 flex-1 rounded-xs border border-border bg-bg px-2 py-1 font-mono text-text outline-none"
+          className="min-w-0 flex-1 rounded-xs border border-border bg-bg px-2 py-1 font-mono text-text outline-none disabled:opacity-60"
         />
-        <Button
-          tone="primary"
+        <button
           onClick={() => void submit()}
           disabled={!canSubmit}
-          loading={submitting}
+          className="shrink-0 inline-flex items-center gap-[6px] px-2 py-1 rounded-xs border disabled:opacity-40 border-border text-text-muted hover:text-text"
         >
-          {submitting ? (
-            <Loader2 size={14} className="animate-spin" aria-hidden />
-          ) : null}
-          {submitting ? "Submitting…" : submitLabel}
-        </Button>
+          {submitting ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
+          {submitting ? "Saving…" : submitLabel}
+        </button>
       </div>
       {error && <div className="text-danger text-label break-words">{error}</div>}
     </div>

--- a/src/renderer/CustomProviderForm.tsx
+++ b/src/renderer/CustomProviderForm.tsx
@@ -45,6 +45,9 @@ export function CustomProviderForm({
   const [baseURL, setBaseURL] = useState("");
   const [apiKey, setApiKey] = useState("");
   const [phase, setPhase] = useState<Phase>("editing");
+  // Names the slow part of save() so the button can announce it: "Saving…"
+  // while the provider is written, then "Restarting opencode…" (BET-1009).
+  const [saveStep, setSaveStep] = useState<"save" | "restart" | null>(null);
   const [error, setError] = useState<string | null>(null);
   const [models, setModels] = useState<{ id: string }[] | null>(null);
   const [checked, setChecked] = useState<Set<string>>(new Set());
@@ -54,6 +57,7 @@ export function CustomProviderForm({
 
   const reset = () => {
     setPhase("editing");
+    setSaveStep(null);
     setModels(null);
     setChecked(new Set());
     setError(null);
@@ -104,9 +108,10 @@ export function CustomProviderForm({
       setError("Select at least one model.");
       return;
     }
-    setPhase("probing"); // reuse the busy flag for the save call
+    setPhase("probing"); // keep the busy flag for disabling
     setError(null);
     try {
+      setSaveStep("save");
       const res = await window.api.opencodeSetProviders({
         upsert: [
           {
@@ -121,8 +126,10 @@ export function CustomProviderForm({
       if (!res.ok) {
         setError(res.error ?? "Couldn't save the provider.");
         setPhase("ready");
+        setSaveStep(null);
         return;
       }
+      setSaveStep("restart");
       try {
         await window.api.opencodeRestart();
       } catch (e) {
@@ -132,20 +139,26 @@ export function CustomProviderForm({
           }`,
         );
         setPhase("ready");
+        setSaveStep(null);
         return;
       }
+      // Stay busy (and mounted) until the parent's re-probe resolves — clearing
+      // first is what left a blank gap while opencode was still restarting.
+      await onSaved();
       setName("");
       setBaseURL("");
       setApiKey("");
+      setSaveStep(null);
       reset();
-      await onSaved();
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setPhase("ready");
+      setSaveStep(null);
     }
   };
 
   const busy = phase === "probing";
+  const inSave = saveStep !== null;
 
   if (compact) {
     return (
@@ -191,21 +204,21 @@ export function CustomProviderForm({
           />
         )}
         <div className="flex gap-2 pt-1">
-          {phase !== "ready" ? (
+          {inSave || phase === "ready" ? (
+            <button
+              onClick={() => void save()}
+              disabled={busy || checked.size === 0}
+              className="px-3 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
+            >
+              {saveStep === "save" ? "Saving…" : saveStep === "restart" ? "Restarting opencode…" : `Save ${checked.size} model${checked.size === 1 ? "" : "s"}`}
+            </button>
+          ) : (
             <button
               onClick={() => void probe()}
               disabled={busy || draftErr !== null}
               className="px-3 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
             >
               {busy ? "Probing…" : "Probe"}
-            </button>
-          ) : (
-            <button
-              onClick={() => void save()}
-              disabled={busy || checked.size === 0}
-              className="px-3 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
-            >
-              {busy ? "Saving…" : `Save ${checked.size} model${checked.size === 1 ? "" : "s"}`}
             </button>
           )}
         </div>
@@ -260,7 +273,17 @@ export function CustomProviderForm({
         />
       )}
       <div className="flex items-center gap-2">
-        {phase !== "ready" ? (
+        {inSave || phase === "ready" ? (
+          <Button
+            tone="primary"
+            type="button"
+            onClick={() => void save()}
+            disabled={busy || checked.size === 0}
+          >
+            {inSave ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
+            {saveStep === "save" ? "Saving…" : saveStep === "restart" ? "Restarting opencode…" : `Save ${checked.size} model${checked.size === 1 ? "" : "s"}`}
+          </Button>
+        ) : (
           <Button
             tone="primary"
             type="button"
@@ -269,16 +292,6 @@ export function CustomProviderForm({
           >
             {busy ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
             {busy ? "Probing…" : "Probe endpoint"}
-          </Button>
-        ) : (
-          <Button
-            tone="primary"
-            type="button"
-            onClick={() => void save()}
-            disabled={busy || checked.size === 0}
-          >
-            {busy ? <Loader2 size={14} className="animate-spin" aria-hidden /> : null}
-            {busy ? "Saving…" : `Save ${checked.size} model${checked.size === 1 ? "" : "s"}`}
           </Button>
         )}
       </div>

--- a/src/renderer/ProvidersStep.test.tsx
+++ b/src/renderer/ProvidersStep.test.tsx
@@ -5,11 +5,28 @@
 // already-connected providers ticked with Continue enabled.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { act } from "react";
 import { installMockApi, resetStore, mount, type Harness } from "./testHarness";
 import { ProvidersStep } from "./ProvidersStep";
 
 function noop() {
   /* swallow */
+}
+
+function buttonByText(h: Harness, text: string): HTMLButtonElement | undefined {
+  const btns = Array.from(h.container.querySelectorAll("button"));
+  return (btns.find((b) => b.textContent?.includes(text)) as
+    | HTMLButtonElement
+    | undefined);
+}
+
+function setInputValue(el: HTMLInputElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLInputElement.prototype,
+    "value",
+  )?.set;
+  setter?.call(el, value);
+  el.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
 describe("ProvidersStep render harness (BET-960)", () => {
@@ -69,5 +86,78 @@ describe("ProvidersStep render harness (BET-960)", () => {
 
     expect(h.text()).toContain("Anthropic");
     expect(continueButton()?.disabled).toBe(true);
+  });
+
+  it("shows the Manta loader beside 'Checking connected providers…' while the mount probe is in flight", async () => {
+    // Never resolves — the mount probe stays in flight, statuses stays null,
+    // so the probing row must be showing rather than a silent blank line.
+    installMockApi({
+      opencodeProviderAuth: () => new Promise(() => {}),
+    });
+    h = mount(<ProvidersStep onBack={noop} onContinue={noop} />);
+    await h.flush();
+
+    expect(h.text()).toContain("Checking connected providers…");
+    expect(h.container.querySelector(".manta-loader")).toBeTruthy();
+  });
+
+  it("shows the loader row again while a post-connect refresh re-probes (list never sits stale)", async () => {
+    let authCalls = 0;
+    installMockApi({
+      opencodeProviderAuth: () => {
+        authCalls += 1;
+        if (authCalls === 1) {
+          // Mount probe resolves: one provider, not connected.
+          return Promise.resolve({
+            action: "status",
+            providers: [
+              { id: "anthropic", label: "Anthropic", plan: "Pro", connected: false },
+            ],
+          });
+        }
+        // The post-connect re-probe stays in flight, so `refreshing` remains
+        // true and the stale list must not just sit there.
+        return new Promise(() => {});
+      },
+      opencodeDiscoverModels: () =>
+        Promise.resolve({ ok: true, models: [{ id: "m1" }, { id: "m2" }] }),
+      opencodeSetProviders: () => Promise.resolve({ ok: true }),
+      opencodeRestart: () => Promise.resolve(),
+    });
+    h = mount(<ProvidersStep onBack={noop} onContinue={noop} />);
+    await h.flush();
+
+    // Mount probe settled: the list is up and the loader row is gone.
+    expect(h.text()).toContain("Anthropic");
+    expect(h.text()).not.toContain("Checking connected providers…");
+
+    // Reveal the custom-endpoint form, fill it, and probe a model list.
+    act(() => {
+      buttonByText(h!, "Use your own API endpoint instead")?.click();
+    });
+    await h.flush();
+    const inputs = Array.from(h!.container.querySelectorAll("input"));
+    expect(inputs.length).toBeGreaterThanOrEqual(3);
+    act(() => {
+      setInputValue(inputs[0] as HTMLInputElement, "MyCustom");
+      setInputValue(inputs[1] as HTMLInputElement, "https://api.example.com/v1");
+      setInputValue(inputs[2] as HTMLInputElement, "sekret");
+    });
+    await h.flush();
+    act(() => {
+      buttonByText(h!, "Probe endpoint")?.click();
+    });
+    await h.flush();
+    expect(h!.text()).toContain("found");
+
+    // Save the custom endpoint. onSaved fires the parent refresh (which now
+    // hangs), so the loader row must reappear while the list re-probes.
+    act(() => {
+      buttonByText(h!, "Save")?.click();
+    });
+    await h.flush();
+
+    expect(h!.text()).toContain("Checking connected providers…");
+    expect(h!.container.querySelector(".manta-loader")).toBeTruthy();
   });
 });

--- a/src/renderer/ProvidersStep.tsx
+++ b/src/renderer/ProvidersStep.tsx
@@ -34,6 +34,7 @@ import { Check } from "lucide-react";
 import type { SubscriptionStatus } from "../shared/types";
 import { ConnectProvider } from "./ConnectProvider";
 import { CustomProviderForm } from "./CustomProviderForm";
+import { MantaLoader } from "./MantaLoader";
 import { StepFooter } from "./onboardingUi";
 
 const DANGER = "var(--danger)";
@@ -60,13 +61,18 @@ export function ProvidersStep({
   // Exactly one row can be mid-mutation at a time.
   const [connectingId, setConnectingId] = useState<string | null>(null);
   const [showCustom, setShowCustom] = useState(false);
+  // True while a re-probe (post-connect refresh) is in flight, so the stale
+  // list never just sits there after a connect completes.
+  const [refreshing, setRefreshing] = useState(false);
 
   // Refresh on mount (and after a custom provider save / connect done).
   const refresh = useCallback(async () => {
+    setRefreshing(true);
     setLoadError(null);
     if (typeof window.api.opencodeProviderAuth !== "function") {
       setLoadError("Couldn't reach the box to check providers.");
       setStatuses([]);
+      setRefreshing(false);
       return;
     }
     try {
@@ -80,8 +86,10 @@ export function ProvidersStep({
     } catch (e) {
       setLoadError(e instanceof Error ? e.message : String(e));
       setStatuses([]);
+    } finally {
+      setRefreshing(false);
     }
-  }, [onContinue]);
+  }, []);
 
   useEffect(() => {
     void refresh();
@@ -97,6 +105,15 @@ export function ProvidersStep({
     [refresh],
   );
 
+  // One waiting image for both the mount probe and the post-connect re-probe
+  // (BET-1009) — the Manta loader beside "Checking connected providers…".
+  const probingRow = (
+    <div className="flex items-center gap-2 text-body text-text-faint">
+      <MantaLoader size="inline" />
+      <span>Checking connected providers…</span>
+    </div>
+  );
+
   return (
     <div>
       <h2 className="text-display font-semibold tracking-tight text-text mb-2">
@@ -105,6 +122,8 @@ export function ProvidersStep({
       <p className="text-body text-text-muted leading-relaxed mb-6 max-w-md">
         Sign in with a subscription you already pay for. You can add more later.
       </p>
+
+      {statuses === null && !loadError && probingRow}
 
       {loadError && (
         <div role="alert" className="text-body mb-4" style={{ color: DANGER }}>
@@ -118,9 +137,9 @@ export function ProvidersStep({
         </div>
       )}
 
-      {statuses === null && !loadError && (
-        <div className="text-body text-text-faint">Checking connected providers…</div>
-      )}
+      {/* While a post-connect re-probe runs the list would otherwise sit
+          stale ("not connected") until it resolves — show the same loader row. */}
+      {refreshing && statuses !== null && probingRow}
 
       {/* Subscriptions — one row per provider from the registry. */}
       <div className="space-y-2">


### PR DESCRIPTION
fix(onboarding): real loading states on the provider step — Manta loader on the probe, busy credential submit

Implements BET-1009. Adds the app's existing waiting affordances to the three dead intervals on the provider ("Connect your subscriptions") step. No new spinner style, no new component, no new token.

**Files changed:** 4 files.
- `src/renderer/ProvidersStep.tsx` — MantaLoader (`size="inline"`) beside "Checking connected providers…" for both the mount probe (`statuses === null`) and the post-connect re-probe (new `refreshing` state, same shared `probingRow`, so the list never sits silently stale after a connect). Refactored `refresh()` into try/catch/finally and fixed its stale `[onContinue]` dependency to `[]`.
- `src/renderer/ConnectProvider.tsx` — the shared `CredentialInput` (backs both the API-key and OAuth-code fields): input disabled while submitting + `disabled:opacity-60`, and the submit button now shows `Loader2 size={14} animate-spin` + "Saving…" instead of the bare ellipsis.
- `src/renderer/CustomProviderForm.tsx` — `save()` reordered so the form stays busy (and mounted) through `onSaved()` — fields are only cleared/`reset()` after the parent's re-probe resolves, closing the blank-gap window after a custom-endpoint save. Added `saveStep` so the save button reads "Saving…" then "Restarting opencode…". Applied to the shared component's save flow in both the onboarding (non-compact) and Settings (compact) render paths (the `save()` logic is shared, so leaving compact's render path would have been a 1-of-2-site fix).
- `src/renderer/ProvidersStep.test.tsx` — 2 new tests: the probing row (with the Manta loader) renders while `statuses === null`, and renders again while a post-connect refresh is in flight.

**Verification results:**
- PR branch (`multica/BET-1009-real-loading-states` @ `ace11efd`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2899 pass / 7 skip (vitest) + 2155 pass / 0 fail (node:test). Failures: none. log sha256: `f1670feb6090db651a130f357f26cf10e9eeca467c2f215258bb107b4acf7f45`
- Base (`main` @ `db2aa6f4`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2155 pass / 0 fail (node:test). Failures: none. log sha256: `dbaae89935202a0c76f5a57047e45163402e3fa24decc32f676ba2940af6fd6b`
- **Conclusion:** 0 new failures, 0 pre-existing failures (both branches fully green).
- **Base:** `origin/main` @ `db2aa6f4`

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
