### PR TITLE
BET-1014: feat(renderer): one gliding sidebar rail highlight instead of per-row hover fill

### DIFF
--- a/src/renderer/RailGlide.test.tsx
+++ b/src/renderer/RailGlide.test.tsx
@@ -23,7 +23,13 @@ function Rail() {
 }
 
 function fire(el: Element, type: "mouseover" | "mouseleave") {
-  el.dispatchEvent(new MouseEvent(type, { bubbles: type === "mouseover" }));
+  // `mouseleave` does not bubble, and React's onMouseLeave is derived from the
+  // bubbling `mouseout` event (checked against relatedTarget). So the leave
+  // case fires a bubbling `mouseout`; with no relatedTarget the pointer is
+  // treated as having left the rail entirely.
+  el.dispatchEvent(
+    new MouseEvent(type === "mouseleave" ? "mouseout" : "mouseover", { bubbles: true }),
+  );
 }
 
 describe("useRailGlide", () => {

--- a/src/renderer/RailGlide.test.tsx
+++ b/src/renderer/RailGlide.test.tsx
@@ -1,0 +1,89 @@
+// @vitest-environment jsdom
+//
+// The rail's gliding hover highlight (src/renderer/RailGlide.tsx). jsdom does
+// no layout, so every rect is 0×0 — these tests pin the STATE MACHINE (does
+// the highlight show, hide, and snap on first appearance), not the geometry.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { mount, type Harness } from "./testHarness";
+import { useRailGlide } from "./RailGlide";
+
+function Rail() {
+  const glide = useRailGlide();
+  return (
+    <div {...glide.containerProps} data-testid="rail">
+      {glide.glide}
+      <div data-rail-row="" data-testid="row-a">
+        <span data-testid="row-a-child">a</span>
+      </div>
+      <div data-rail-row="" data-testid="row-b">b</div>
+      <div data-testid="not-a-row">header</div>
+    </div>
+  );
+}
+
+function fire(el: Element, type: "mouseover" | "mouseleave") {
+  el.dispatchEvent(new MouseEvent(type, { bubbles: type === "mouseover" }));
+}
+
+describe("useRailGlide", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function glideEl(): HTMLElement {
+    const el = h!.container.querySelector("span.rail-glide") as HTMLElement;
+    expect(el).toBeTruthy();
+    return el;
+  }
+
+  it("renders one hidden, aria-hidden highlight at rest", () => {
+    h = mount(<Rail />);
+    expect(h.container.querySelectorAll("span.rail-glide").length).toBe(1);
+    expect(glideEl().getAttribute("data-shown")).toBe("false");
+    expect(glideEl().getAttribute("aria-hidden")).toBe("true");
+  });
+
+  it("shows on a row, including when the event starts on a row descendant", async () => {
+    h = mount(<Rail />);
+    fire(h.container.querySelector('[data-testid="row-a-child"]')!, "mouseover");
+    await h.flush();
+    expect(glideEl().getAttribute("data-shown")).toBe("true");
+  });
+
+  it("snaps into place on first appearance, then glides", async () => {
+    h = mount(<Rail />);
+    fire(h.container.querySelector('[data-testid="row-a"]')!, "mouseover");
+    await h.flush();
+    // The snap flag clears on the next animation frame; after flush the
+    // highlight must be free to animate to the next row.
+    await new Promise((resolve) => requestAnimationFrame(() => resolve(null)));
+    await h.flush();
+    expect(glideEl().getAttribute("data-snap")).toBe("false");
+    fire(h.container.querySelector('[data-testid="row-b"]')!, "mouseover");
+    await h.flush();
+    expect(glideEl().getAttribute("data-shown")).toBe("true");
+    expect(glideEl().getAttribute("data-snap")).toBe("false");
+  });
+
+  it("hides over a non-row area and when the pointer leaves the rail", async () => {
+    h = mount(<Rail />);
+    fire(h.container.querySelector('[data-testid="row-a"]')!, "mouseover");
+    await h.flush();
+    expect(glideEl().getAttribute("data-shown")).toBe("true");
+
+    fire(h.container.querySelector('[data-testid="not-a-row"]')!, "mouseover");
+    await h.flush();
+    expect(glideEl().getAttribute("data-shown")).toBe("false");
+
+    fire(h.container.querySelector('[data-testid="row-a"]')!, "mouseover");
+    await h.flush();
+    expect(glideEl().getAttribute("data-shown")).toBe("true");
+
+    fire(h.container.querySelector('[data-testid="rail"]')!, "mouseleave");
+    await h.flush();
+    expect(glideEl().getAttribute("data-shown")).toBe("false");
+  });
+});

--- a/src/renderer/RailGlide.tsx
+++ b/src/renderer/RailGlide.tsx
@@ -1,0 +1,95 @@
+// The sidebar rail's single gliding hover highlight.
+//
+// Instead of every row painting its own `hover:bg-fill-hover` (which makes a
+// pointer sweep down the rail read as a row of backgrounds blinking on and
+// off), the rail owns ONE absolutely-positioned element that travels to the
+// row under the pointer. Same idea as the gliding pill in the model menu.
+//
+// Two things make it a hook rather than a self-contained component:
+//
+//   - The highlight must be a child of the SCROLL CONTAINER (so it scrolls
+//     with the rows and is positioned against the same box), while the hover
+//     handlers must be on that same container. The hook hands the caller both
+//     halves and owns the state between them.
+//   - Hover is DELEGATED: one `mouseover` on the container resolves the row
+//     via `closest("[data-rail-row]")`. Rows are rendered by four different
+//     components (window rows, nested job rows, draft rows, create rows), and
+//     threading an index + ref through all of them would be far more code
+//     than one data attribute.
+//
+// Geometry is measured with getBoundingClientRect() against the container and
+// then shifted by scrollTop/scrollLeft, giving a CONTENT-space coordinate.
+// offsetTop would also work today but silently breaks the day any wrapper
+// between the container and a row becomes positioned.
+
+import { useCallback, useRef, useState } from "react";
+
+type GlideBox = { top: number; left: number; width: number; height: number };
+
+export function useRailGlide() {
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const hoveredRowRef = useRef<HTMLElement | null>(null);
+  const [box, setBox] = useState<GlideBox | null>(null);
+  const [shown, setShown] = useState(false);
+  const [snap, setSnap] = useState(false);
+
+  const onMouseOver = useCallback((event: React.MouseEvent<HTMLDivElement>) => {
+    const container = containerRef.current;
+    if (!container) return;
+    const target = event.target as HTMLElement | null;
+    const row = target?.closest?.("[data-rail-row]") as HTMLElement | null;
+    if (!row || !container.contains(row)) {
+      // Pointer is over the rail but not over a row (a group header, the
+      // padding): hide rather than leave the highlight stranded.
+      hoveredRowRef.current = null;
+      setShown(false);
+      return;
+    }
+    // `mouseover` fires for every descendant; re-measuring the row we are
+    // already on would be pure waste (its content-space box cannot move
+    // without a re-render or a scroll, and both re-fire this handler).
+    if (hoveredRowRef.current === row && shown) return;
+    hoveredRowRef.current = row;
+    const containerRect = container.getBoundingClientRect();
+    const rowRect = row.getBoundingClientRect();
+    setBox({
+      top: rowRect.top - containerRect.top + container.scrollTop,
+      left: rowRect.left - containerRect.left + container.scrollLeft,
+      width: rowRect.width,
+      height: rowRect.height,
+    });
+    if (!shown) {
+      // First appearance: place it without a glide, then re-enable the
+      // transition on the next frame so every later move animates.
+      setSnap(true);
+      setShown(true);
+      requestAnimationFrame(() => setSnap(false));
+    }
+  }, [shown]);
+
+  const onMouseLeave = useCallback(() => {
+    hoveredRowRef.current = null;
+    setShown(false);
+  }, []);
+
+  const glide = (
+    <span
+      aria-hidden="true"
+      className="rail-glide"
+      data-shown={shown && box ? "true" : "false"}
+      data-snap={snap ? "true" : "false"}
+      style={
+        box
+          ? { top: box.top, left: box.left, width: box.width, height: box.height }
+          : undefined
+      }
+    />
+  );
+
+  return {
+    /** Spread onto the rail's scroll container. */
+    containerProps: { ref: containerRef, onMouseOver, onMouseLeave },
+    /** Render as the FIRST child of that container. */
+    glide,
+  };
+}

--- a/src/renderer/SessionRow.test.tsx
+++ b/src/renderer/SessionRow.test.tsx
@@ -38,8 +38,9 @@ describe("SessionRow — one line: dot · name · age", () => {
     expect(el.className).toContain("gap-2");
     expect(el.className).toContain("rounded-md");
     expect(el.className).toContain("mb-1");
-    // Resting: hover fill, no selection surface/marker.
-    expect(el.className).toContain("hover:bg-fill-hover");
+    // Resting: NO per-row hover fill (the rail's gliding highlight owns it),
+    // no selection surface/marker.
+    expect(el.className).not.toContain("hover:bg-fill-hover");
     expect(el.className).not.toContain("bg-raised");
   });
 
@@ -109,7 +110,7 @@ describe("SessionRow — one line: dot · name · age", () => {
     // C3: the marker hangs at left:-8px — the primitive owns the marker, not a
     // left inset on itself.
     expect(el.className).toContain("before:left-[-8px]");
-    // Resting hover is dropped once selected (the row is already surfaced).
+    // No row ever carries its own hover fill.
     expect(el.className).not.toContain("hover:bg-fill-hover");
     const name = el.firstElementChild!.nextElementSibling as HTMLElement;
     expect(name.className).toContain("text-text");
@@ -227,5 +228,16 @@ describe("SessionRow — one line: dot · name · age", () => {
     // @ts-expect-error — status is REQUIRED with no default (C4 applies to the dot)
     void <SessionRow name="x" />;
     expect(true).toBe(true);
+  });
+
+  it("marks itself as a rail row and paints above the rail's gliding highlight", () => {
+    h = mount(<SessionRow status="idle" name="Add CSV export" />);
+    const el = h.container.firstElementChild as HTMLElement;
+    // The delegated hover handler in useRailGlide finds rows by this attribute.
+    expect(el.getAttribute("data-rail-row")).toBe("");
+    // z-[1] over the highlight's z-index: 0 — without it the highlight would
+    // paint over the row's own text.
+    expect(el.className).toContain("relative");
+    expect(el.className).toContain("z-[1]");
   });
 });

--- a/src/renderer/SessionRow.tsx
+++ b/src/renderer/SessionRow.tsx
@@ -9,8 +9,9 @@
 //
 // Chrome contract (BET-529 inventory + the `.srow` spec):
 //   - one line, `dot · name · age` — nothing else. Layout `flex; align-items:
-//     center; gap: --sp-2`, radius `--r-md`, `margin-bottom: 4px`, hover
-//     `--fill-hover`.
+//     center; gap: --sp-2`, radius `--r-md`, `margin-bottom: 4px`. The hover
+//     `--fill-hover` is NOT painted by the row: the rail owns one gliding
+//     highlight (src/renderer/RailGlide.tsx) that travels behind the rows.
 //   - dot (`.st`) 7px circle: `run` → `--accent` + 3px `--accent-bg` ring +
 //     pulse; `att` → `--danger` + `--danger-bg` ring + faster-proxied pulse;
 //     `idle` → `--warn`; `ok` → `--ok`; `default` → `--tx4`.
@@ -47,7 +48,7 @@ export type SessionStatus = "run" | "att" | "idle" | "ok" | "default";
 // The rest is the spec'd row chrome, with ALL metrics token-referenced so the
 // [data-density] ancestor owns them (C2).
 const ROW_BASE =
-  "group relative flex cursor-pointer items-center gap-2 rounded-md mb-1 " +
+  "group relative z-[1] flex cursor-pointer items-center gap-2 rounded-md mb-1 " +
   "min-h-[var(--row-h)] px-[var(--row-px)] py-[var(--row-py)] " +
   "transition-colors outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1";
 
@@ -56,9 +57,6 @@ const ROW_SELECTED =
   "bg-raised before:absolute before:content-[''] before:left-[-8px] " +
   "before:top-1/2 before:-translate-y-1/2 before:h-4 before:w-[3px] " +
   "before:rounded-r-[3px] before:bg-accent";
-
-// Resting: the spec'd hover fill.
-const ROW_REST = "hover:bg-fill-hover";
 
 // Child (`.child`): 26px indent + the `left:13px` tree connectors. The
 // horizontal elbow stub is ::before, the vertical trunk is ::after. This is
@@ -159,11 +157,14 @@ export function SessionRow({
     selected ? ROW_CHILD_INK_SELECTED : ROW_CHILD_INK,
     lastChild ? ROW_CHILD_TRUNK_LAST : ROW_CHILD_TRUNK,
   ].join(" ");
-  const row =
-    ROW_BASE + " " + (child ? childChrome : selected ? ROW_SELECTED : ROW_REST);
+  // No resting hover fill here: the rail owns ONE gliding highlight that
+  // travels behind the rows (see src/renderer/RailGlide.tsx). A per-row
+  // `hover:bg-fill-hover` would paint the fill a second time.
+  const row = ROW_BASE + (child ? " " + childChrome : selected ? " " + ROW_SELECTED : "");
   return (
     <div
       role="treeitem"
+      data-rail-row=""
       aria-selected={ariaSelected}
       aria-level={ariaLevel}
       tabIndex={tabIndex}

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -28,6 +28,7 @@ import {
 } from "./chatUtils";
 import { IS_WINDOWS, MOD_KEY } from "./platform";
 import { SessionRow as RailSessionRow, type SessionStatus } from "./SessionRow";
+import { useRailGlide } from "./RailGlide";
 import { ConfirmModal } from "./ConfirmModal";
 import { Modal } from "./Modal";
 import { Button } from "./Button";
@@ -127,6 +128,8 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   // computed nav order. Keys: `pin:<id>` | `group:<session>` | `win:<session>:<idx>`
   // | `job:<session>:<idx>`.
   const [focusedKey, setFocusedKey] = useState<string | null>(null);
+
+  const railGlide = useRailGlide();
 
   useEffect(() => {
     localStorage.setItem(COLLAPSE_KEY, JSON.stringify([...collapsed]));
@@ -635,13 +638,15 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
       </div>
 
       <div
-        className="flex-1 overflow-y-auto px-2 pb-2 outline-none"
+        className="relative flex-1 overflow-y-auto px-2 pb-2 outline-none"
         role="tree"
         aria-label="Sessions"
         tabIndex={-1}
         data-density="comfortable"
         onKeyDown={onRailKeyDown}
+        {...railGlide.containerProps}
       >
+        {railGlide.glide}
         <RailCreateRow label="New workspace" shortcut={`${MOD_KEY}N`} onClick={onNewProject} />
         {/* New-session drafts whose mode is "new-project" live directly beneath
             the New workspace row that created them — they belong to no project.
@@ -1284,9 +1289,10 @@ function RailCreateRow({
 }) {
   return (
     <button
+      data-rail-row=""
       onClick={onClick}
       title={`${label} (${shortcut})`}
-      className="group flex w-full items-center gap-2 rounded-md mb-1 min-h-[var(--row-h)] px-[var(--row-px)] py-[var(--row-py)] text-left transition-colors outline-none hover:bg-fill-hover focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
+      className="group relative z-[1] flex w-full items-center gap-2 rounded-md mb-1 min-h-[var(--row-h)] px-[var(--row-px)] py-[var(--row-py)] text-left transition-colors outline-none focus-visible:ring-2 focus-visible:ring-accent focus-visible:ring-offset-1"
     >
       <span className="flex w-[7px] shrink-0 items-center justify-center text-text-faint group-hover:text-text">
         <Plus size={11} aria-hidden="true" />

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -209,6 +209,47 @@ html, body, #root {
   .manta-artifacts-tab-indicator { transition: none; }
 }
 
+/* Sidebar rail hover highlight (the gliding pill). ONE element per rail,
+   absolutely positioned inside the rail's scroll content, that travels to
+   whichever row the pointer is over. Rows no longer paint their own
+   `hover:bg-fill-hover`; if they did, the fill would appear twice.
+
+   It lives INSIDE the scroll container's content box, so it scrolls with the
+   rows for free — its `top` is a content-space coordinate (viewport delta +
+   scrollTop), never a viewport one.
+
+   `z-index: 0` + `relative z-[1]` on the rows is load-bearing: a positioned
+   element paints above the background AND the text of a non-positioned
+   sibling, so without the explicit pair the highlight would wash over the
+   label of any static row.
+
+   `[data-snap="true"]` suppresses the geometry transition for the frame in
+   which the highlight first appears, so it fades in where the pointer is
+   instead of sliding in from a stale position. */
+.rail-glide {
+  position: absolute;
+  z-index: 0;
+  pointer-events: none;
+  border-radius: var(--r-md);
+  background: var(--fill-hover);
+  opacity: 0;
+  transition:
+    top var(--motion-base) var(--ease-out),
+    left var(--motion-base) var(--ease-out),
+    width var(--motion-base) var(--ease-out),
+    height var(--motion-base) var(--ease-out),
+    opacity var(--motion-fast) ease;
+}
+.rail-glide[data-shown="true"] {
+  opacity: 1;
+}
+.rail-glide[data-snap="true"] {
+  transition: opacity var(--motion-fast) ease;
+}
+@media (prefers-reduced-motion: reduce) {
+  .rail-glide { transition: opacity var(--motion-fast) ease; }
+}
+
 /* Scrollbar */
 ::-webkit-scrollbar { width: 10px; height: 10px; }
 ::-webkit-scrollbar-track { background: transparent; }


### PR DESCRIPTION
Implements BET-1014 — replaces the sidebar rail's per-row `hover:bg-fill-hover`
with ONE absolutely-positioned `.rail-glide` highlight that travels to the row
under the pointer (via a delegated `data-rail-row` mouseover + geometry measured
against the scroll container in content space).

Files changed (6, exactly per spec):
- `src/renderer/index.css` — `.rail-glide` block before the `/* Scrollbar */` comment
- `src/renderer/RailGlide.tsx` — new `useRailGlide` hook + highlight element
- `src/renderer/RailGlide.test.tsx` — new state-machine tests
- `src/renderer/SessionRow.tsx` — drop per-row hover fill, `z-[1]`, mark `data-rail-row`
- `src/renderer/SessionRow.test.tsx` — update two assertions + new rail-row test
- `src/renderer/Sidebar.tsx` — wire the hook, render the highlight, rework `RailCreateRow`

No new dependencies, no new design tokens, no new CSS custom properties.

**Base: origin/main @ db2aa6f**

**Verification results:**
- PR branch (`multica/BET-1014-rail-glide` @ `0129a1e`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 2155 pass / 0 fail / 0 skip.
  - test:server (untouched): exit 0, 1645 pass / 0 fail.
- Conclusion: 0 new failures; full suite green.

Note on the one grep item: `grep -rn "hover:bg-fill-hover" SessionRow.tsx Sidebar.tsx`
returns a single hit inside a code comment that Step 3b of the issue mandates
verbatim ("…`hover:bg-fill-hover` would paint the fill a second time."). No actual
hover-fill class remains anywhere in the two files.