### PR TITLE
feat(server): fail soft on permission/question listing errors (BET-1020)

### DIFF
--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -917,6 +917,30 @@ function extractAssistantText(msgs) {
 // merged multi-directory fetch) is deleted. listPermissions/listQuestions are
 // back to plain scoped reads of the requested session's directory.
 
+/** Fetch a pending-items listing and soften a non-OK response.
+ *  opencode's listings are not all-or-nothing safe: a single malformed pending
+ *  item makes GET /permission (or /question) return 400 for the WHOLE array
+ *  (upstream #38912) — which would otherwise throw and blank out the card the
+ *  user is waiting on. Treat a non-OK response as "no pending items I can
+ *  see": warn once and return []. The live SSE path remains the primary
+ *  source; these listings are reconciliation only. Scoped to the two READ
+ *  listings below — NOT a general-purpose opencode wrapper.
+ *  @param {string} endpoint  API path with `?directory=` already applied.
+ *  @param {string} label     caller name, for the warning.
+ *  @returns {Promise<Array<unknown>>}
+ */
+async function fetchPendingList(endpoint, label) {
+  const res = await ocFetch(apiUrl(endpoint));
+  if (!res.ok) {
+    console.warn(
+      `opencode ${label}: non-OK ${res.status} (${await res.text()}); treating as no pending items`,
+    );
+    return [];
+  }
+  const all = await res.json();
+  return Array.isArray(all) ? all : [];
+}
+
 /** List all pending tool-use permissions.
  *  Scoped to the session's directory when sessionId is provided. opencode's
  *  WorkspaceRoutingMiddleware makes the UNSCOPED endpoint return [] for
@@ -929,12 +953,7 @@ function extractAssistantText(msgs) {
  */
 export async function listPermissions(sessionId) {
   const dirQ = sessionId ? await getSessionDirectoryQuery(sessionId) : "";
-  const res = await ocFetch(apiUrl(`/permission${dirQ}`));
-  if (!res.ok) {
-    throw new Error(`opencode listPermissions ${res.status}: ${await res.text()}`);
-  }
-  const all = await res.json();
-  const list = Array.isArray(all) ? all : [];
+  const list = await fetchPendingList(`/permission${dirQ}`, "listPermissions");
   // opencode's /permission is `?directory=`-scoped, not session-scoped: a
   // directory can hold pending items from multiple sessions (orphan/subagent
   // sessions included). Filter the directory-wide response down to the
@@ -979,12 +998,7 @@ export async function replyPermission({ requestId, reply, sessionId }) {
  */
 export async function listQuestions(sessionId) {
   const dirQ = sessionId ? await getSessionDirectoryQuery(sessionId) : "";
-  const res = await ocFetch(apiUrl(`/question${dirQ}`));
-  if (!res.ok) {
-    throw new Error(`opencode listQuestions ${res.status}: ${await res.text()}`);
-  }
-  const all = await res.json();
-  const list = Array.isArray(all) ? all : [];
+  const list = await fetchPendingList(`/question${dirQ}`, "listQuestions");
   // opencode's /question is `?directory=`-scoped, not session-scoped — see
   // listPermissions above. Filter to the requested sessionId (BET-110).
   // Background-job children no longer surface here (BET-418 §A).

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -18,6 +18,7 @@ import {
   listPermissions,
   listQuestions,
   replyPermission,
+  replyQuestion,
   subscribeEvents,
   selectStreamsToEvict,
   isStreamDeaf,
@@ -867,6 +868,102 @@ test("listQuestions without sessionId returns unfiltered directory-wide list", a
     async () => {
       const result = await listQuestions(null);
       assert.equal(result.length, 2, "unscoped call returns full list");
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Fail-soft listing on non-OK (BET-1020)
+//
+// Upstream opencode #38912: GET /permission returns 400 whenever ANY pending
+// request carries unset optional metadata (glob / grep / webfetch / etc.). The
+// whole array is validated at once, so one malformed pending item 400s the
+// entire listing — including the good request the user is waiting on. The
+// READ listings must fail soft (return []) so the live SSE path, the primary
+// source, keeps driving the card; the REPLY path must keep throwing.
+// ---------------------------------------------------------------------------
+
+test("listPermissions returns [] on a 400 and does not throw", async () => {
+  _resetSessionDirectoryCache();
+  await withMockFetch(
+    async (url) => {
+      if (String(url).includes("/permission")) {
+        return new Response("one malformed pending item", { status: 400 });
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const result = await listPermissions();
+      assert.deepEqual(result, [], "400 must yield an empty list, not throw");
+    },
+  );
+});
+
+test("listQuestions returns [] on a non-OK and does not throw", async () => {
+  _resetSessionDirectoryCache();
+  await withMockFetch(
+    async (url) => {
+      if (String(url).includes("/question")) {
+        return new Response("boom", { status: 500 });
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const result = await listQuestions("ses_B");
+      assert.deepEqual(result, [], "non-OK must yield an empty list, not throw");
+    },
+  );
+});
+
+// The fail-soft treatment is scoped to the two READ listings. A failed REPLY
+// must still surface — the user pressed a button and deserves to know it did
+// not land (BET-1020 non-goals).
+test("replyPermission still throws on a non-OK reply", async () => {
+  _resetSessionDirectoryCache();
+  await withMockFetch(
+    async (url) => {
+      if (String(url).startsWith("http://127.0.0.1:4096/session?directory=")) {
+        return new Response(JSON.stringify({ id: "ses_r", directory: "/proj/r" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (String(url).includes("/reply")) {
+        return new Response("nope", { status: 400 });
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      await assert.rejects(
+        replyPermission({ requestId: "per_x", reply: "always", sessionId: "ses_r" }),
+        /replyPermission/,
+        "a failed permission reply must still throw",
+      );
+    },
+  );
+});
+
+test("replyQuestion still throws on a non-OK reply", async () => {
+  _resetSessionDirectoryCache();
+  await withMockFetch(
+    async (url) => {
+      if (String(url).startsWith("http://127.0.0.1:4096/session?directory=")) {
+        return new Response(JSON.stringify({ id: "ses_rq", directory: "/proj/rq" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      if (String(url).includes("/reply")) {
+        return new Response("nope", { status: 400 });
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      await assert.rejects(
+        replyQuestion({ requestId: "que_x", answers: [["a"]], sessionId: "ses_rq" }),
+        /replyQuestion/,
+        "a failed question reply must still throw",
+      );
     },
   );
 });


### PR DESCRIPTION
## BET-1020 — Permission/question listing fails soft

`listPermissions` and `listQuestions` threw on any non-OK response from
opencode's `GET /permission` / `GET /question`. Upstream opencode #38912 makes
GET /permission return 400 whenever ANY pending request carries unset optional
metadata (glob / grep / webfetch / websearch / apply_patch) — one malformed
pending item poisons the whole listing, so the throw blanked out the card the
user was waiting on and the turn hung with no error.

### Change
- Added one shared helper `fetchPendingList(endpoint, label)`: on a non-OK
  response it logs a warning (with status + body) and returns `[]` instead of
  throwing. Both READ listings now use it.
- `listPermissions` and `listQuestions` keep their directory-scoping and
  session filtering untouched (BET-110 logic is load-bearing, left as-is).
- The REPLY paths (`replyPermission`, `replyQuestion`) still throw on failure
  — a failed reply must surface to the user (issue non-goal). Not touched.

### Anti-spaghetti
- The identical throw-on-non-OK shape existed in exactly two places
  (listPermissions, listQuestions); both share the fix via the one helper.
- The helper is explicitly scoped to these two read listings (not a
  general-purpose opencode wrapper) per the issue guardrails.

### Tests
- `listPermissions` returns `[]` on a 400 and does not throw.
- `listQuestions` returns `[]` on a non-OK and does not throw.
- `replyPermission` / `replyQuestion` still throw on a non-OK reply (pins the
  non-goal).

**Files changed:** 2 files (`src/server/opencode.mjs`, `src/server/opencode.test.mjs`)

**Verification results:**
- PR branch (`multica/BET-1020-fail-soft-permission-listing` @ `09eeb3ab`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2165 pass / 0 fail / 0 skip. log sha256: `fb42ee77e3a8d9fa23ec03e4c6d7cff665496c81f49489f2251d54f601de76d9`
- Base (`main` @ `482f38a0`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2161 pass / 0 fail / 0 skip. log sha256: `597aa425aa3b5c2fe33ec7ad30bd52e9bf957dbda9c30cee644bdbc2ac35d910`
- **Conclusion:** 0 new failures; +4 tests added by this PR (2161 → 2165).

Base: origin/main @ `482f38a0`
