### PR TITLE
BET-1017: fix(server): derive context usage for an idle session (opencode:context)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -759,6 +759,7 @@ rpcHandlers = buildHandlers({
         }));
     },
   },
+  contextLimitFor,
 });
 
 // Server-update checker: polls https://mantaui.com/updates/server.json every

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -8,6 +8,11 @@ import { gzipSync } from "node:zlib";
 import { homedir } from "node:os";
 import { transcribeAudio } from "../shared/groq.mjs";
 import { expandTilde } from "../shared/paths.mjs";
+import {
+  computeContextBreakdown,
+  selectLatestTokenUsage,
+  ASSUMED_CONTEXT_TOKENS,
+} from "../shared/streamInterpretation.mjs";
 import { listJobs as scheduleListJobs, deleteJob as scheduleDeleteJob, createJob as scheduleCreateJob } from "./schedule.mjs";
 import { listSnapshots as usageListSnapshots } from "./usage.mjs";
 import { listHooks as webhookListHooks, deleteHook as webhookDeleteHook } from "./webhooks.mjs";
@@ -227,6 +232,7 @@ export function buildHandlers({
   delegate,
   progress,
   voiceNotes,
+  contextLimitFor = () => null,
 }) {
   // The sole resolver for project cwd — no longer mirrored to a desktop-main
   // copy (the src/main/index.ts duplicate was retired in the HTTP-only
@@ -620,6 +626,22 @@ export function buildHandlers({
     // the full transcript. The native iOS client passes {limit, slim}. The
     // duplicated tool stdout is stripped server-side for every client.
     "opencode:messages": (sessionId, opts) => oc.listMessages(sessionId, opts ?? {}),
+
+    // Context usage for a session that may be idle. The live `stream/context`
+    // frame is emitted only when an assistant message arrives, so a client
+    // opening an existing conversation has nothing to render until the next
+    // turn. This derives the same payload from the persisted transcript, using
+    // the same shared breakdown function, so an idle session is correct on
+    // open. Returns null when the transcript has no billed assistant turn yet.
+    "opencode:context": async (sessionId) => {
+      const messages = await oc.listMessages(sessionId, { slim: true });
+      const found = selectLatestTokenUsage(messages);
+      if (!found) return null;
+      const limit =
+        contextLimitFor(found.providerID, found.modelID) ??
+        ASSUMED_CONTEXT_TOKENS;
+      return computeContextBreakdown(found.tokens, limit);
+    },
 
     // Single-message fetch for live-turn splice (returns null on miss).
     "opencode:message": (sessionId, messageId) =>

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -14,6 +14,10 @@ import { statePath } from "../shared/paths.mjs";
 import { mkdtempSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
+import {
+  computeContextBreakdown,
+  ASSUMED_CONTEXT_TOKENS,
+} from "../shared/streamInterpretation.mjs";
 
 test("dispatch routes a known channel to its handler with args", async () => {
   const handlers = { "echo:it": async (a, b) => ({ sum: a + b }) };
@@ -899,4 +903,51 @@ test("forge:ship returns the forge result unchanged and performs no config write
   const res = await handlers["forge:ship"]({ cwd });
   assert.deepEqual(res, { ok: false, error: "no_forge" });
   assert.equal(calls.projectMetaUpsert.length, 0);
+});
+
+test("opencode:context derives a breakdown from a billed assistant message", async () => {
+  const tokens = { input: 50_000, cache: { read: 10_000, write: 0 } };
+  const listCalls = [];
+  const deps = makeDeps([]).deps;
+  deps.oc.listMessages = async (sessionId, opts) => {
+    assert.equal(sessionId, "ses_idle");
+    listCalls.push(opts);
+    return [{ info: { role: "assistant", tokens, providerID: "anthropic", modelID: "claude-sonnet-4-6" } }];
+  };
+  const handlers = buildHandlers(deps);
+  const res = await handlers["opencode:context"]("ses_idle");
+  assert.deepEqual(listCalls, [{ slim: true }]);
+  assert.deepEqual(res, computeContextBreakdown(tokens, ASSUMED_CONTEXT_TOKENS));
+});
+
+test("opencode:context uses contextLimitFor and falls back to ASSUMED_CONTEXT_TOKENS", async () => {
+  const tokens = { input: 100_000, cache: { read: 0, write: 0 } };
+  const deps = makeDeps([]).deps;
+  deps.oc.listMessages = async () => [
+    { info: { role: "assistant", tokens, providerID: "anthropic", modelID: "claude-sonnet-4-6" } },
+  ];
+
+  const withLimit = buildHandlers({
+    ...deps,
+    contextLimitFor: () => 400_000,
+  });
+  const limited = await withLimit["opencode:context"]("s");
+  assert.deepEqual(limited, computeContextBreakdown(tokens, 400_000));
+
+  const fallback = buildHandlers({
+    ...deps,
+    contextLimitFor: () => null,
+  });
+  const fellBack = await fallback["opencode:context"]("s");
+  assert.deepEqual(fellBack, computeContextBreakdown(tokens, ASSUMED_CONTEXT_TOKENS));
+
+  assert.notEqual(limited.pct, fellBack.pct);
+});
+
+test("opencode:context returns null for an empty transcript", async () => {
+  const deps = makeDeps([]).deps;
+  deps.oc.listMessages = async () => [];
+  const handlers = buildHandlers(deps);
+  const res = await handlers["opencode:context"]("ses_empty");
+  assert.equal(res, null);
 });

--- a/src/shared/streamInterpretation.d.mts
+++ b/src/shared/streamInterpretation.d.mts
@@ -95,6 +95,10 @@ export function computeContextBreakdown(
   limit: number,
 ): ContextBreakdown;
 
+export function selectLatestTokenUsage(
+  messages: unknown,
+): { tokens: Record<string, unknown>; providerID: string | null; modelID: string | null } | null;
+
 export function isTerminalTodo(t: Record<string, unknown>): boolean;
 
 export function allTodosTerminal(todos: Array<Record<string, unknown>>): boolean;

--- a/src/shared/streamInterpretation.mjs
+++ b/src/shared/streamInterpretation.mjs
@@ -403,6 +403,41 @@ export function computeContextBreakdown(tokens, limit) {
 }
 
 /**
+ * The newest assistant token usage in a transcript that actually consumed
+ * context, plus the model that produced it (so the caller can resolve the
+ * context window).
+ *
+ * Walks BACKWARDS and returns the first assistant message whose combined input
+ * (fresh + cache read + cache write) is greater than zero. Messages reporting
+ * zero are skipped: a freshly-streaming message reports zeros, and treating
+ * one as authoritative makes the context meter blink off mid-turn.
+ *
+ * Mirrors the desktop `latestTokens` selector in src/renderer/ChatPanel.tsx so
+ * both clients agree on which message is authoritative.
+ *
+ * @param {any[]} messages transcript as returned by listMessages
+ * @returns {{tokens: any, providerID: string|null, modelID: string|null}|null}
+ */
+export function selectLatestTokenUsage(messages) {
+  if (!Array.isArray(messages)) return null;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    const info = messages[i]?.info;
+    if (info?.role !== "assistant") continue;
+    const t = info.tokens;
+    if (!t) continue;
+    const totalInput =
+      (t.input ?? 0) + (t.cache?.read ?? 0) + (t.cache?.write ?? 0);
+    if (totalInput <= 0) continue;
+    return {
+      tokens: t,
+      providerID: info.providerID ?? null,
+      modelID: info.modelID ?? null,
+    };
+  }
+  return null;
+}
+
+/**
  * True when a todo item is in a terminal state (completed or cancelled).
  * Both liveTodos (from todo.updated SSE) and transcript-scraped TodoWrite
  * inputs surface a free-form `status` string; opencode's canonical terminal

--- a/src/shared/streamInterpretation.test.ts
+++ b/src/shared/streamInterpretation.test.ts
@@ -33,6 +33,7 @@ import {
   selectActiveTodos,
   selectCacheTtlMs,
   selectLastAssistantCompletion,
+  selectLatestTokenUsage,
   selectVisibleTodos,
   shouldAutoRename,
   shouldDropEventForSessionFilter,
@@ -151,6 +152,77 @@ describe("computeContextBreakdown", () => {
     );
     // 100_000 / 200_000 = 50%
     expect(b.pct).toBe(50);
+  });
+});
+
+describe("selectLatestTokenUsage", () => {
+  const billed = (over = {}) => ({
+    info: { role: "assistant", tokens: { input: 100, cache: { read: 0, write: 0 } }, ...over },
+  });
+
+  it("returns null for empty, null, and non-array input", () => {
+    expect(selectLatestTokenUsage([])).toBeNull();
+    expect(selectLatestTokenUsage(null)).toBeNull();
+    expect(selectLatestTokenUsage(undefined)).toBeNull();
+    expect(selectLatestTokenUsage({})).toBeNull();
+  });
+
+  it("returns null for a transcript with only user messages", () => {
+    expect(
+      selectLatestTokenUsage([{ info: { role: "user", tokens: { input: 50 } } }]),
+    ).toBeNull();
+  });
+
+  it("skips an assistant message with no tokens", () => {
+    const first = billed();
+    const messages = [first, { info: { role: "assistant" } }];
+    const found = selectLatestTokenUsage(messages);
+    if (!found) throw new Error("expected a billed assistant message");
+    expect(found.tokens).toBe(first.info.tokens);
+  });
+
+  it("skips a zero-billed assistant message and returns an earlier billed one", () => {
+    const zero = {
+      info: {
+        role: "assistant",
+        tokens: { input: 0, cache: { read: 0, write: 0 } },
+      },
+    };
+    const earlier = { info: { role: "assistant", tokens: { input: 200 } } };
+    const found = selectLatestTokenUsage([earlier, zero]);
+    if (!found) throw new Error("expected a billed assistant message");
+    expect(found.tokens).toBe(earlier.info.tokens);
+  });
+
+  it("returns the newest billed assistant message when several are billed", () => {
+    const older = { info: { role: "assistant", tokens: { input: 10 } } };
+    const newer = { info: { role: "assistant", tokens: { input: 30 } } };
+    const found = selectLatestTokenUsage([older, newer]);
+    if (!found) throw new Error("expected a billed assistant message");
+    expect(found.tokens).toBe(newer.info.tokens);
+  });
+
+  it("counts cache.read alone as billed even when input is zero", () => {
+    const read = {
+      info: { role: "assistant", tokens: { input: 0, cache: { read: 40, write: 0 } } },
+    };
+    const found = selectLatestTokenUsage([read]);
+    if (!found) throw new Error("expected a billed assistant message");
+    expect(found.tokens).toBe(read.info.tokens);
+  });
+
+  it("surfaces providerID/modelID from the matching message, null when omitted", () => {
+    const withIds = billed({ providerID: "anthropic", modelID: "claude-opus-4-7" });
+    const found = selectLatestTokenUsage([withIds]);
+    if (!found) throw new Error("expected a billed assistant message");
+    expect(found.providerID).toBe("anthropic");
+    expect(found.modelID).toBe("claude-opus-4-7");
+
+    const bare = billed();
+    const bareFound = selectLatestTokenUsage([bare]);
+    if (!bareFound) throw new Error("expected a billed assistant message");
+    expect(bareFound.providerID).toBeNull();
+    expect(bareFound.modelID).toBeNull();
   });
 });
 


### PR DESCRIPTION
## What

Fixes BET-1017: an idle iOS session showed no context meter on open because the phone learned context usage only from live `stream/context` frames.

Adds a new read-only RPC channel `opencode:context` that derives the same context breakdown from the **persisted transcript** using the same shared breakdown function, so an idle session is correct on open.

- `src/shared/streamInterpretation.mjs`: new pure export `selectLatestTokenUsage` — walks the transcript backwards and returns the newest assistant message that actually consumed context (combined input + cache read + cache write > 0), skipping zero-billed messages. Mirrors the desktop `latestTokens` selector so both clients agree on the authoritative message.
- `src/shared/streamInterpretation.d.mts`: type declaration for the new export.
- `src/server/rpc.mjs`: new `opencode:context` handler (read-only). Adds `contextLimitFor` as a buildHandlers dep with a safe `() => null` default so existing tests keep working. Reuses `computeContextBreakdown` as-is.
- `src/server/index.mjs`: passes the existing module-scope `contextLimitFor` into `buildHandlers`.
- Tests for both new functions.

No change to the return shape of `opencode:messages`. No change under `src/renderer/`. No new files.

**Files changed:** 6 files (1 addition each to index.mjs + d.mts, 22 to rpc.mjs, 51 to rpc.test.mjs, 35 to streamInterpretation.mjs, 72 to streamInterpretation.test.ts)

**Verification results:**
- PR branch (`multica/BET-1017-context-idle-session` @ `9eef0d1c`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2164 pass / 0 fail / 0 skip. Failures: none. log sha256: `90d4c4775ed963b3c1290e864ffbc7dd13543b57806e00b2264221994ffd5b1f`
- Base (`main` @ `482f38a0`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2161 pass / 0 fail / 0 skip. Failures: none. log sha256: `597aa425aa3b5c2fe33ec7ad30bd52e9bf957dbda9c30cee644bdbc2ac35d910`
- **Conclusion:** 0 test failures are pre-existing (the suite shows ~1-test run-to-run variance unrelated to this additive change), 0 failures are new and caused by this PR.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

**Base: origin/main @ 482f38a0**

Follow-up filed: BET-1030 (PM) — wire the native iOS client to call `opencode:context` on session open.
