### PR TITLE
fix(ios): give the subagent child screen its own store, delete the parent-owned registry (BET-1024)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */; };
 		51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */; };
 		5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */; };
+		E62B9C1D7A4F8E00921C5ADD /* MantaSubagentDrillInUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C3A21B44E7D08512B0300A /* MantaSubagentDrillInUITests.swift */; };
 		5CDC4D3B2FD207C5E38A9AA1 /* MultilineTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */; };
 		5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */; };
 		5E0226E9FAFF3F9CA9F45F8F /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E78B0F5B521937B40937DC /* SettingsScreen.swift */; };
@@ -129,6 +130,7 @@
 		0FCC705A51D162CE3E7E3B00 /* MantaDynamicType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaDynamicType.swift; sourceTree = "<group>"; };
 		15E5DB4B26254A37A3075BD2 /* ArtifactDerivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDerivation.swift; sourceTree = "<group>"; };
 		17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaRunningStateCaptureUITests.swift; sourceTree = "<group>"; };
+		F9C3A21B44E7D08512B0300A /* MantaSubagentDrillInUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSubagentDrillInUITests.swift; sourceTree = "<group>"; };
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		1A81D1BB24FB02E4DFFA04FE /* UsageMeters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageMeters.swift; sourceTree = "<group>"; };
 		1BBC0EC48A556426D44A1A42 /* MantaContextStripVerifyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaContextStripVerifyUITests.swift; sourceTree = "<group>"; };
@@ -408,6 +410,7 @@
 				8D8A1A5388E54F31462D616F /* MantaPairFixture.swift */,
 				AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */,
 				17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */,
+				F9C3A21B44E7D08512B0300A /* MantaSubagentDrillInUITests.swift */,
 				714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */,
 				5EF0199856D7E4C0B0D2595C /* MantaUIOverflowCaptureUITests.swift */,
 			);
@@ -579,6 +582,7 @@
 				EDFF1716E461980191B71C85 /* MantaPairFixture.swift in Sources */,
 				D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */,
 				51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */,
+				E62B9C1D7A4F8E00921C5ADD /* MantaSubagentDrillInUITests.swift in Sources */,
 				4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */,
 				ECB0360A8A26279B6EEF955F /* MantaUIOverflowCaptureUITests.swift in Sources */,
 			);

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -432,14 +432,15 @@ private struct ChatScreenContent: View {
             }
         }
         .navigationDestination(for: SubagentSession.self) { agent in
-            if let child = store.store(for: agent.childSessionId) {
-                ChatSubagentScreen(
-                    title: agent.taskName,
-                    subtitle: agent.subtitle,
-                    store: child,
-                    tokens: tokens
-                )
-            }
+            ChatSubagentScreen(
+                childSessionId: agent.childSessionId,
+                title: agent.taskName,
+                subtitle: agent.subtitle,
+                eventStore: eventStore,
+                api: MantaAPIClient.live(),
+                tokens: tokens
+            )
+            .id(agent.childSessionId)
         }
         // The identity moved into the system navigation bar (BET-821): the bar
         // supplies its own scroll-edge effect and reserves its own space, so the
@@ -1062,8 +1063,27 @@ private struct ChatScreenContent: View {
 struct ChatSubagentScreen: View {
     let title: String
     let subtitle: String
-    @ObservedObject var store: ChatSessionStore
+    let childSessionId: String?
+    /// The child screen OWNS its store (BET-1024). Keyed by the child session
+    /// id and constructed from the shared eventStore + api, it is tied to this
+    /// screen's identity via `.id(childSessionId)` at the call site — so a
+    /// parent-side push/dismiss or any store sweep can never rebind this
+    /// screen to a different, empty store. The parent owns nothing about it.
+    @StateObject private var store: ChatSessionStore
     let tokens: Tokens
+
+    init(childSessionId: String?, title: String, subtitle: String, eventStore: MantaEventStore, api: MantaAPIClient, tokens: Tokens) {
+        self.childSessionId = childSessionId
+        self.title = title
+        self.subtitle = subtitle
+        self.tokens = tokens
+        _store = StateObject(wrappedValue: ChatSessionStore(
+            sessionId: childSessionId ?? "",
+            eventStore: eventStore,
+            api: api,
+            isReadOnly: true
+        ))
+    }
 
     /// Drives MessagingUI's `TiledView` scroll layer for the child transcript:
     /// stays on the newest message as the child streams, and stops following
@@ -1082,6 +1102,37 @@ struct ChatSubagentScreen: View {
     @State private var dataSource = ListDataSource<TranscriptRow>()
 
     var body: some View {
+        content
+            .navigationTitle(title)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackgroundVisibility(.visible, for: .navigationBar)
+            .toolbarBackground(tokens.canvas, for: .navigationBar)
+            .toolbar {
+                ToolbarItem(placement: .subtitle) {
+                    Text(subtitle)
+                        .font(.manta(size: Metrics.type.xs, weight: .semibold))
+                        .foregroundColor(tokens.tx4)
+                        .lineLimit(1)
+                }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier("subagent-scene")
+    }
+
+    /// Unset when a task part has not yet been stamped with a child session id
+    /// (see `SubagentSession`): there is nothing to stream yet, so explain it
+    /// instead of pushing a silent blank screen.
+    private var hasSession: Bool { !(childSessionId?.isEmpty ?? true) }
+
+    @ViewBuilder private var content: some View {
+        if hasSession {
+            transcript
+        } else {
+            emptyState
+        }
+    }
+
+    private var transcript: some View {
         TiledView(dataSource: dataSource, scrollPosition: $scrollPosition) { row in
             TranscriptBlockCell(item: row, tokens: tokens)
         }
@@ -1098,22 +1149,18 @@ struct ChatSubagentScreen: View {
             dataSource.apply(rows)
         }
         .background(tokens.canvas.ignoresSafeArea())
-        .navigationTitle(title)
-        .navigationBarTitleDisplayMode(.inline)
-        .toolbarBackgroundVisibility(.visible, for: .navigationBar)
-        .toolbarBackground(tokens.canvas, for: .navigationBar)
-        .toolbar {
-            ToolbarItem(placement: .subtitle) {
-                Text(subtitle)
-                    .font(.manta(size: Metrics.type.xs, weight: .semibold))
-                    .foregroundColor(tokens.tx4)
-                    .lineLimit(1)
-            }
-        }
         .onAppear { store.start() }
         .onDisappear { store.stop() }
-        .accessibilityElement(children: .contain)
-        .accessibilityIdentifier("subagent-scene")
+    }
+
+    private var emptyState: some View {
+        Text("This task has not started yet.")
+            .font(.manta(size: Metrics.type.small))
+            .foregroundColor(tokens.tx3)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(tokens.canvas.ignoresSafeArea())
     }
 }
 

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -170,7 +170,6 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var permissions: [PermissionRequest] = []
     @Published private(set) var planOn: Bool?
     @Published private(set) var subagents: [StreamSubagentPayload] = []
-    @Published private(set) var childStores: [String: ChatSessionStore] = [:]
     /// Prompts accepted mid-turn, FIFO. Drained one per idle edge — never
     /// POSTed while `running`, which is what used to implicitly abort the
     /// in-flight turn.
@@ -348,11 +347,10 @@ final class ChatSessionStore: ObservableObject {
 
     func stop() {
         // The session is leaving the screen: it is no longer a consumer of
-        // this session's stream chunks, and its subagent stores can all go
-        // (BET-672). Dropping the dictionary here is the teardown-path half of
-        // child-store eviction — the transcript-capped half runs per rebuild.
+        // this session's stream chunks. A push is not a dismissal — the child
+        // subagent screen owns ITS OWN store (BET-1024), so nothing here
+        // touches any child; this releases the parent's own resources only.
         eventStore.unregisterSession(sessionId)
-        childStores.removeAll()
         // A queued prompt must never fire into a session the user has left.
         queuedPrompts.removeAll()
     }
@@ -512,19 +510,6 @@ final class ChatSessionStore: ObservableObject {
         // running (the drain's send sets it optimistically) or an empty queue.
         drainQueuedPromptIfIdle()
 
-        // Register a store for any subagent that has a child session id, so the
-        // drill-in destination can resolve it without mutating state during a
-        // view update (BET-576). Registering does NOT start it: the child's own
-        // screen calls `start()` on appear. Starting them here meant opening a
-        // parent session downloaded a full extra transcript for EVERY subagent
-        // in its history, none of which is on screen.
-        for payload in s.subagents {
-            let childID = payload.childSessionId
-            if !childID.isEmpty, childStores[childID] == nil {
-                _ = ensureChildStore(childID)
-            }
-        }
-
         // Refetch the canonical transcript at turn boundaries so a finished
         // turn's blocks (steps/prose/subagents) land as real content. The fetch
         // itself retires the live text it now covers (see `fetchTranscript`) —
@@ -646,39 +631,6 @@ final class ChatSessionStore: ObservableObject {
                 + uniqueTranscriptRows(trailing)
         }
         rows = newRows
-        // Cap the subagent stores at the children the CURRENT transcript can
-        // actually drill into; stores left over from a previous transcript no
-        // longer show a row the user could open (BET-672).
-        evictChildStores()
-    }
-
-    /// The child session ids present in the CURRENT transcript's subagent rows.
-    /// The drill-in only ever happens from these rows, so they are exactly the
-    /// set a live `childStores` needs to hold; anything else is a leak.
-    private var childIDsInTranscript: Set<String> {
-        var ids = Set<String>()
-        for block in transcript {
-            guard case .steps(let content) = block else { continue }
-            let rows: [StepGroupRow]
-            switch content {
-            case .rows(let r): rows = r
-            case .rollup(_, let r): rows = r
-            }
-            for row in rows {
-                if case .subagent(let agent) = row, let id = agent.childSessionId, !id.isEmpty {
-                    ids.insert(id)
-                }
-            }
-        }
-        return ids
-    }
-
-    private func evictChildStores() {
-        guard !childStores.isEmpty else { return }
-        let live = childIDsInTranscript
-        for id in childStores.keys where !live.contains(id) {
-            childStores.removeValue(forKey: id)
-        }
     }
 
     // MARK: - Refetch
@@ -1000,30 +952,6 @@ final class ChatSessionStore: ObservableObject {
         }
         replyQuestion(question, answers: answers)
         return nil
-    }
-
-    // MARK: - Subagent drill-in (BET-576)
-
-    func ensureChildStore(_ childSessionId: String) -> ChatSessionStore {
-        if let existing = childStores[childSessionId] {
-            return existing
-        }
-        let child = ChatSessionStore(
-            sessionId: childSessionId,
-            eventStore: eventStore,
-            api: api,
-            isReadOnly: true
-        )
-        childStores[childSessionId] = child
-        // NOT started here — `ChatSubagentScreen.onAppear` calls `start()`, so
-        // a child's transcript is fetched when the user opens it and not
-        // before. See the registration comment in `applyStreamState`.
-        return child
-    }
-
-    func store(for childSessionId: String?) -> ChatSessionStore? {
-        guard let childSessionId else { return nil }
-        return ensureChildStore(childSessionId)
     }
 
     // MARK: - Header

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -196,6 +196,42 @@ final class ChatTranscriptTests: XCTestCase {
         XCTAssertEqual(agent.duration, "5.0s")
     }
 
+    /// A task part not yet stamped with `state.metadata.sessionId` (the 
+    /// not-started case, see `TranscriptComponents.SubagentSession`) maps to a
+    /// SubagentSession whose `childSessionId` is nil — the empty-state case,
+    /// which the child screen explains instead of pushing a silent blank.
+    func testTaskPartWithoutSessionMapsToSubagentWithNilChildSession() {
+        let state: [String: JSONValue] = [
+            "status": str("running"),
+            "title": str("unblock sweep"),
+        ]
+        let part = OpencodePart(type: "tool", id: "t1", messageID: "m1", extra: [
+            "tool": str("task"),
+            "state": jsonObject(state),
+        ])
+        let agent = ChatSubagentMapper.session(from: part)
+        XCTAssertNotNil(agent)
+        XCTAssertEqual(agent?.taskName, "unblock sweep")
+        XCTAssertNil(agent?.childSessionId,
+                     "no state.metadata.sessionId means the child screen shows the empty state")
+    }
+
+    /// Ownership moved to the child screen (BET-1024): a store constructed for
+    /// a child session id is no longer placed in a parent-owned registry, so
+    /// two screens opened on the same child id get two INDEPENDENT stores
+    /// rather than a shared parent-cached one that a push/dismiss can destroy.
+    @MainActor
+    func testTwoChildStoresForKeyAreIndependentInstances() {
+        let eventStore = MantaEventStore()
+        let api = MantaAPIClient(serverURL: URL(string: "https://127.0.0.1:1")!)
+        let a = ChatSessionStore(sessionId: "ses_child", eventStore: eventStore, api: api, isReadOnly: true)
+        let b = ChatSessionStore(sessionId: "ses_child", eventStore: eventStore, api: api, isReadOnly: true)
+        XCTAssertFalse(a === b,
+                       "two stores for the same child session id must be independent objects, not shared parent-registry state")
+        XCTAssertEqual(a.sessionId, "ses_child")
+        XCTAssertEqual(b.sessionId, "ses_child")
+    }
+
     // MARK: - Rollup
 
     func testThreeConsecutiveStepsRollUp() {

--- a/mobile/native/MantaUIUITests/MantaSubagentDrillInUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaSubagentDrillInUITests.swift
@@ -1,0 +1,79 @@
+import XCTest
+
+// BET-1024: drilling into a subagent row must land on a LIVE child transcript
+// that stays populated after the push animation settles. Regression test for
+// the "flicker briefly, then permanently blank" bug: the old parent-owned
+// child store was destroyed on the parent's `onDisappear` (a push) and the
+// child screen was rebound to a brand-new, never-started empty store at the end
+// of the animation.
+//
+// Because the bug surfaces AFTER the push settles, an immediate assertion would
+// pass even against the broken build (store A's content is still on screen
+// mid-animation). We wait out the push transition, then require at least one
+// real transcript element — the empty rebind has nothing to render.
+//
+// Like the other live-box drives, this test skips unless the environment is
+// actually paired to a box whose open session contains a subagent row.
+final class MantaSubagentDrillInUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private func openChat(in app: XCUIApplication) {
+        _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
+        let wanted = ProcessInfo.processInfo.environment["MANTA_OPEN_ROW"] ?? ""
+        let hops = wanted.split(separator: "|").map(String.init)
+        if hops.isEmpty {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+            sleep(4)
+            return
+        }
+        for hop in hops {
+            let prefix = NSPredicate(format: "label BEGINSWITH %@", hop)
+            let users = app.descendants(matching: .any).matching(prefix)
+            let target = users.allElementsBoundByIndex
+                .first { $0.elementType != .button }
+                ?? users.firstMatch
+            guard target.waitForExistence(timeout: 10) else {
+                print("BET-1024 open-miss=\(hop)")
+                break
+            }
+            target.tap()
+            sleep(4)
+        }
+    }
+
+    func testSubagentDrillInStaysPopulatedAfterPushSettles() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        openChat(in: app)
+
+        // The parent transcript must expose a subagent row to drill into.
+        let agentRow = app.descendants(matching: .any)["agent-row"].firstMatch
+        guard agentRow.waitForExistence(timeout: 10) else {
+            throw XCTSkip("no subagent row in the open session — nothing to drill into")
+        }
+        agentRow.tap()
+        print("BET-1024 drill-in: agent-row tapped")
+
+        // The pushed child scene presents.
+        let scene = app.descendants(matching: .any)["subagent-scene"].firstMatch
+        guard scene.waitForExistence(timeout: 10) else {
+            throw XCTSkip("subagent scene never appeared")
+        }
+
+        // The bug manifests AFTER the push animation completes, so wait it out
+        // before asserting content — an immediate check passes against the
+        // broken build.
+        usleep(useconds_t(3.0 * 1_000_000))
+
+        let prose = app.descendants(matching: .any)["assistant-prose"].firstMatch
+        let user = app.descendants(matching: .any)["user-band"].firstMatch
+        let steps = app.descendants(matching: .any)["step-rows"].firstMatch
+        print("BET-1024 drill-in: prose=\(prose.exists) user=\(user.exists) steps=\(steps.exists)")
+        XCTAssertTrue(prose.exists || user.exists || steps.exists,
+                      "child transcript is blank after the push settled — the child store was rebound to an empty one")
+    }
+}


### PR DESCRIPTION
Opened automatically for `multica/BET-1024-subagent-store-ownership`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1024.