### PR TITLE
Upgrade opencode as part of box self-update (reuse existing update banner)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2837,6 +2837,32 @@ Consequences worth knowing:
 - Two arches built from different commits is now a hard publish error rather
   than something only a version mismatch could have caught.
 
+### Self-update also upgrades the opencode binary (BET-1016)
+
+opencode is no longer frozen at install time — `scripts/self-update.sh` now
+runs `opencode upgrade` (the CLI command on the installed binary) as part of
+every update, so a box stops drifting from whatever it was installed with
+(measured 2026-08-16: installed 1.18.10 vs latest upstream 1.18.18). Key facts:
+
+- **Non-fatal**: an offline box, a missing CLI, or a refused upgrade logs a
+  warning and continues — the box update must never be aborted by opencode
+  (dry-run rule: mirrors `refresh_opencode_tools()`).
+- **Runs BEFORE the packaged-install early exit**, and that early exit is now
+  conditional on BOTH the box being current AND opencode being unchanged —
+  otherwise an opencode-only upgrade would be swallowed by the cheap exit and
+  the upgraded (but un-restarted) binary would stay inert. The decision is
+  `should_skip_self_update` in `scripts/lib/release.sh` (pure, unit-tested
+  alongside `release_is_current`).
+- **opencode is unpinned by design** — never pin a version; the whole point is
+  following upstream.
+- **The upgrade is surfaced through the EXISTING shared update banner**: the
+  server maps opencode's `installation.update-available` event onto the same
+  `serverUpdateAvailable` bus event, dedup-gated per opencode version
+  (`createOpencodeUpdateForwarder` in `src/server/serverUpdate.mjs`). No second
+  banner variant, no new confirm copy — the existing "Update the box?" flow
+  already warns it restarts opencode and ends running agent turns, which is
+  exactly right for this.
+
 ### Verifying a deploy actually landed
 
 Never trust "the workflow was green" alone for the FIRST run of a new pipeline —

--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -292,3 +292,29 @@ release_is_current() {
   fi
   [ "$installed_version" = "$release_version" ]
 }
+
+# should_skip_self_update <installed_version> <installed_git_sha> <release_version> <release_git_sha> <opencode_changed>
+#
+# The updater's EARLY-EXIT decision (BET-1016): skip the ENTIRE self-update (no
+# download, no reinstall, no restart) only when BOTH the box release is current
+# AND opencode is unchanged. When opencode changed, the box must fall through
+# to its restart step even if the tarball is current — otherwise an opencode-only
+# upgrade would be swallowed by the cheap early exit and leave the upgraded (but
+# un-restarted) binary inert until the next update.
+#
+# Returns 0 (skip) when the box is current AND opencode unchanged; 1 (do not
+# skip) otherwise. Pure: no I/O, no globals. Unit-tested in release.test.mjs
+# alongside release_is_current.
+should_skip_self_update() {
+  installed_version="$1"
+  installed_sha="$2"
+  release_version="$3"
+  release_sha="$4"
+  opencode_changed="$5"
+
+  if release_is_current "$installed_version" "$installed_sha" "$release_version" "$release_sha" \
+     && [ "$opencode_changed" = "0" ]; then
+    return 0
+  fi
+  return 1
+}

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -439,3 +439,43 @@ test("release_is_current: an unreadable installed stamp is never 'current'", () 
   assert.equal(isCurrent("", "", "0.0.29", ""), false);
   assert.equal(isCurrent("", "", "0.0.29", "def456"), false);
 });
+
+// --- should_skip_self_update: the BET-1016 early-exit decision ------------------
+//
+// The updater's early exit must skip the whole update ONLY when the box is
+// current AND opencode is unchanged. If opencode changed, the box must keep
+// going so its restart step runs — otherwise an opencode-only upgrade is
+// swallowed by the cheap exit and the new binary never gets restarted. This is
+// the full 2x2 (box-current x opencode-changed) matrix.
+
+function shouldSkip(installedVersion, installedSha, releaseVersion, releaseSha, opencodeChanged) {
+  const script = `
+    log() { :; }; ok() { :; }; warn() { :; }; die() { echo "$*" >&2; exit 1; }
+    . "${RELEASE_LIB}"
+    if should_skip_self_update "$1" "$2" "$3" "$4" "$5"; then echo skip; else echo prog; fi
+  `;
+  const out = execFileSync(
+    "bash",
+    ["-c", script, "bash", installedVersion, installedSha, releaseVersion, releaseSha, opencodeChanged],
+    { encoding: "utf-8" },
+  );
+  return out.trim() === "skip";
+}
+
+test("should_skip_self_update: box current + opencode unchanged → skip", () => {
+  assert.equal(shouldSkip("0.0.29", "abc123", "0.0.29", "abc123", "0"), true);
+});
+
+test("should_skip_self_update: box current + opencode CHANGED → do NOT skip", () => {
+  // An opencode-only upgrade on an already-current box must fall through to the
+  // restart — this is the whole reason the early exit is now conditional.
+  assert.equal(shouldSkip("0.0.29", "abc123", "0.0.29", "abc123", "1"), false);
+});
+
+test("should_skip_self_update: box stale + opencode unchanged → do NOT skip", () => {
+  assert.equal(shouldSkip("0.0.29", "abc123", "0.0.30", "def456", "0"), false);
+});
+
+test("should_skip_self_update: box stale + opencode changed → do NOT skip", () => {
+  assert.equal(shouldSkip("0.0.29", "abc123", "0.0.30", "def456", "1"), false);
+});

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -113,6 +113,46 @@ if [ -d "$MANTA_HOME/runtime/node/bin" ]; then
   export PATH
 fi
 
+# --- Upgrade the opencode binary (BET-1016) ----------------------------------
+# opencode is installed once (deliberately UNPINNED) and otherwise frozen at
+# install time, so every box drifts from whatever it was installed with forever.
+# Fold its upgrade into the self-update so a box stops drifting: run `opencode
+# upgrade` (the CLI command on the installed binary — no auth question, no port
+# assumption) and capture `opencode --version` before/after to report whether
+# anything actually changed.
+#
+# MUST run BEFORE the packaged-install early exit below: that cheap exit skips
+# EVERYTHING (including the restart at MANTA_PROGRESS 5/6) when the box tarball
+# is already current, and an opencode-only upgrade must still fall through to
+# that restart. `OPCODE_VERSION_CHANGED` is the flag the early exit re-checks —
+# set here so the early exit can go conditional on it.
+#
+# Non-fatal throughout, mirroring refresh_opencode_tools(): an offline box, a
+# missing CLI, or a refused upgrade must never abort the server update.
+OPCODE_VERSION_CHANGED=0
+upgrade_opencode() {
+  if ! command -v opencode >/dev/null 2>&1; then
+    echo "⚠ self-update: opencode not found on PATH — skipping binary upgrade"
+    return 0
+  fi
+  local before after
+  before="$(opencode --version 2>/dev/null || true)"
+  before="${before:-unknown}"
+  if ! opencode upgrade >/dev/null 2>&1; then
+    echo "⚠ self-update: opencode upgrade failed (current: $before) — continuing"
+    return 0
+  fi
+  after="$(opencode --version 2>/dev/null || true)"
+  after="${after:-unknown}"
+  if [ "$before" != "$after" ]; then
+    OPCODE_VERSION_CHANGED=1
+    echo "✓ self-update: opencode upgraded: $before → $after"
+  else
+    echo "✓ self-update: opencode already current ($before)"
+  fi
+}
+upgrade_opencode
+
 echo "MANTA_PROGRESS 2/6 Downloading update"
 if [ "$INSTALL_KIND" = "git" ]; then
   # A git checkout has no vendored runtime under version control — the box runs
@@ -171,8 +211,10 @@ else
   # Cheap early exit when already current — no download, no reinstall, no
   # restart. The decision itself lives in scripts/lib/release.sh so it can be
   # unit-tested; see release_is_current for why it compares the build's commit
-  # rather than its version number.
-  if release_is_current "$INSTALLED_VERSION" "$INSTALLED_GIT_SHA" "$TARBALL_VERSION" "$TARBALL_GIT_SHA"; then
+  # rather than its version number. BET-1016: the exit is conditional on BOTH
+  # the box being current AND opencode not having changed — an opencode-only
+  # upgrade must fall through to the restart below, never be swallowed here.
+  if should_skip_self_update "$INSTALLED_VERSION" "$INSTALLED_GIT_SHA" "$TARBALL_VERSION" "$TARBALL_GIT_SHA" "$OPCODE_VERSION_CHANGED"; then
     if [ -n "$INSTALLED_GIT_SHA" ] && [ -n "$TARBALL_GIT_SHA" ]; then
       ok "self-update: already at $TARBALL_VERSION ($TARBALL_GIT_SHA)"
     else

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -51,7 +51,7 @@ import {
   loadNotes,
   startVoiceSweep,
 } from "./voiceNotes.mjs";
-import { startServerUpdatePoller } from "./serverUpdate.mjs";
+import { startServerUpdatePoller, createOpencodeUpdateForwarder } from "./serverUpdate.mjs";
 import { runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { startSchedulePoller, createJob, listJobs, deleteJob } from "./schedule.mjs";
 import { startUsagePoller } from "./usage.mjs";
@@ -845,8 +845,20 @@ try {
   ];
 } catch { /* non-fatal */ }
 
+// Forward opencode's own `installation.update-available` onto the shared
+// serverUpdateAvailable banner. Dedup state is held in the forwarder closure.
+const forwardOpencodeUpdate = createOpencodeUpdateForwarder();
+
 // eslint-disable-next-line no-unused-vars
 const stopOpencodePump = oc.subscribeEvents((evt) => {
+  // Map opencode's own installation.update-available onto the EXISTING
+  // serverUpdateAvailable banner (BET-1016). The forwarder is dedup-gated by
+  // opencode version and returns null for non-update events, so this is a no-op
+  // for everything else and never re-raises a version already shown.
+  const forwardedUpdate = forwardOpencodeUpdate(evt);
+  if (forwardedUpdate) {
+    bus.publish(forwardedUpdate);
+  }
   // Box-side stream interpretation (BET-551 / §17): derive interpreted events
   // from the raw opencode stream and publish them on the SAME bus (no second
   // stream/endpoint). Consumers (S1b) demux by `kind:"stream"`.

--- a/src/server/serverUpdate.mjs
+++ b/src/server/serverUpdate.mjs
@@ -183,3 +183,39 @@ export function startServerUpdatePoller(
 
   return startPoller(runTick, { intervalMs: POLL_MS, label: "server-update" });
 }
+
+/**
+ * Map opencode's own `installation.update-available` event onto the EXISTING
+ * `serverUpdateAvailable` bus event, so the shared update banner (which the
+ * user already confirmed) raises for an opencode binary upgrade exactly as it
+ * does for a server release (BET-1016).
+ *
+ * opencode may emit the same version repeatedly, and re-raising the banner for
+ * a version already shown is noise — so this mirrors the
+ * `startServerUpdatePoller` `lastNotifiedVersion` gate with its own dedup on
+ * the last published opencode version. The dedup state lives in the closure
+ * returned by the factory (module-level in effect: it persists across events),
+ * keeping the mapping side-effect-free and unit-testable without a live event
+ * stream or bus.
+ *
+ * @returns {(evt:any) => ({kind:string, payload:any}|null)} An `onEvent`
+ *   handler for the opencode pump. Returns the bus event to publish for an
+ *   opencode update (version not yet shown), or `null` when the event is not
+ *   an opencode update, carries no usable version, or is a version already
+ *   published.
+ */
+export function createOpencodeUpdateForwarder() {
+  let lastPublishedOpencodeVersion = null;
+
+  return function onEvent(evt) {
+    if (!evt || evt.type !== "installation.update-available") return null;
+    const version = evt.properties?.version;
+    if (typeof version !== "string" || !version) return null;
+    if (version === lastPublishedOpencodeVersion) return null;
+    lastPublishedOpencodeVersion = version;
+    return {
+      kind: "serverUpdateAvailable",
+      payload: { version, notesUrl: null },
+    };
+  };
+}

--- a/src/server/serverUpdate.test.mjs
+++ b/src/server/serverUpdate.test.mjs
@@ -22,6 +22,7 @@ import {
   startServerUpdatePoller,
   MANIFEST_URL,
   manifestUrl,
+  createOpencodeUpdateForwarder,
 } from "./serverUpdate.mjs";
 
 function fakeBus() {
@@ -390,3 +391,64 @@ test("createUpdateCheck on a feedless (dev) build reports no update and never fe
   assert.equal(res.available, false);
   assert.equal(called, 0, "a dev build must not reach for a public feed");
 });
+
+// ---------------------------------------------------------------------------
+// createOpencodeUpdateForwarder (BET-1016).
+//
+// Maps opencode's own `installation.update-available` onto the EXISTING
+// serverUpdateAvailable bus event. The dedup gate is the exact behaviour the
+// issue asks to lock in: opencode may emit the same version repeatedly and the
+// banner must not re-raise for a version already shown.
+// ---------------------------------------------------------------------------
+
+const opencodeUpdate = (v) => ({
+  type: "installation.update-available",
+  properties: { version: v },
+});
+
+test("forwarder: maps an opencode update onto serverUpdateAvailable", () => {
+  const onEvent = createOpencodeUpdateForwarder();
+  assert.deepEqual(onEvent(opencodeUpdate("1.18.18")), {
+    kind: "serverUpdateAvailable",
+    payload: { version: "1.18.18", notesUrl: null },
+  });
+});
+
+test("forwarder: returns null for non-update opencode events", () => {
+  const onEvent = createOpencodeUpdateForwarder();
+  assert.equal(onEvent({ type: "message.updated", properties: {} }), null);
+  assert.equal(onEvent(null), null);
+  assert.equal(onEvent(undefined), null);
+});
+
+test("forwarder: ignores events without a usable version", () => {
+  const onEvent = createOpencodeUpdateForwarder();
+  // missing properties / missing version / non-string version
+  assert.equal(onEvent({ type: "installation.update-available" }), null);
+  assert.equal(onEvent({ type: "installation.update-available", properties: {} }), null);
+  assert.equal(onEvent(opencodeUpdate("")), null);
+  assert.equal(onEvent({ type: "installation.update-available", properties: { version: 42 } }), null);
+});
+
+test("forwarder: dedup — repeated same-version events publish ONCE", () => {
+  const onEvent = createOpencodeUpdateForwarder();
+  assert.ok(onEvent(opencodeUpdate("1.18.18")));
+  assert.equal(onEvent(opencodeUpdate("1.18.18")), null, "same version must not re-raise");
+  assert.equal(onEvent(opencodeUpdate("1.18.18")), null);
+});
+
+test("forwarder: gate advances — a strictly newer version re-raises", () => {
+  const onEvent = createOpencodeUpdateForwarder();
+  assert.deepEqual(onEvent(opencodeUpdate("1.18.10")), {
+    kind: "serverUpdateAvailable",
+    payload: { version: "1.18.10", notesUrl: null },
+  });
+  assert.equal(onEvent(opencodeUpdate("1.18.10")), null);
+  // a genuinely newer version bumps the gate and publishes again
+  assert.deepEqual(onEvent(opencodeUpdate("1.18.18")), {
+    kind: "serverUpdateAvailable",
+    payload: { version: "1.18.18", notesUrl: null },
+  });
+  assert.equal(onEvent(opencodeUpdate("1.18.18")), null);
+});
+


### PR DESCRIPTION
## BET-1016 — Upgrade opencode as part of the box self-update

Reuses the entire existing self-update + shared serverUpdate banner. No renderer changes.

### 1. `scripts/self-update.sh` — upgrade the binary
- New `upgrade_opencode()` runs `opencode upgrade`, captures `opencode --version` before/after, reports whether it changed. Non-fatal (warn + continue), mirroring `refresh_opencode_tools()`.
- Runs BEFORE the packaged-install early exit; the early exit is now conditional on BOTH the box being current AND opencode unchanged (`should_skip_self_update` in `scripts/lib/release.sh`, pure + unit-tested). An opencode-only upgrade falls through to the single existing restart at step 5/6 — no second restart call.

### 2. `src/server/` — raise the existing banner
- `createOpencodeUpdateForwarder()` (new in `serverUpdate.mjs`) maps opencode's `installation.update-available` onto the EXISTING `serverUpdateAvailable` bus event, dedup-gated per opencode version (mirrors the poller's `lastNotifiedVersion`).
- Wired into the opencode event pump in `index.mjs`.

### 3. Renderer
No changes. Reuses the existing "Update the box?" flow and warning copy.

### Docs
AGENTS.md Release & CD updated: self-update now upgrades opencode, which is no longer frozen at install time (and remains intentionally unpinned).

**Base: origin/main @ 482f38a0**

**Verification results:**
- PR branch (`multica/BET-1016-upgrade-opencode-on-self-update` @ c1a25126):
  - typecheck: exit 0, errors none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2170 pass / 0 fail / 0 skip. log sha256: `14e212847e3931bf93f2b6d95fbe0f4c100231825e38d114837815270691870a`
- Base (`main` @ 482f38a0):
  - typecheck: exit 0, errors none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2161 pass / 0 fail / 0 skip. log sha256: `5bbcf6ee5cb611e5e8df64a638e3a0b180f295e1e2a297fe61a2509c261b5152`
- **Conclusion:** 0 new failures; 9 new tests (4 `should_skip_self_update` matrix, 5 forwarder dedup-gate), all passing.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
