### PR TITLE
Auto-rename: use opencode's own session title + title agent (BET-1018)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -528,6 +528,32 @@ out on load (`src/main/config.ts`).
 **Mode detection:** if `boxToken` is set → HTTP mode (normal). No fallback to
 SSH — the old `host`-based mode is fully removed.
 
+## Auto-rename (session titles) — BET-1018
+
+When `autoRenameSessions` is on, a chat-mode window gets its **first name from
+opencode's own session title**, which opencode derives from the FIRST user
+message for free (`GET /session`, read via `opencodeListSessions(cwd)` →
+`findSessionTitle`). Before that, the empty-first-name case was only named on
+the every-5th-turn drift rename. If the title isn't populated yet the effect
+skips silently and retries on the next turn; never blank a window name.
+
+Subsequent **re-titles** (every `AUTO_RENAME_EVERY_N_TURNS` = 5 turns) run on
+opencode's **"title" agent** (`agent:"title"` in `generateSessionTitle`'s
+prompt_async body in `src/server/opencode.mjs`) — its own cheap naming model,
+not our main model — returning a clean short name. `sanitizeGeneratedTitle`
+stays as a safety net on both paths.
+
+**DO NOT add structured output to that prompt_async call.** Passing
+`{"format":{"type":"json_schema",…}}` is ACCEPTED on opencode 1.18.10, but
+opencode defaults `retryCount` and its own reader then rejects the whole
+session's message list with a permanent HTTP 400 — the entire transcript
+becomes unreadable, not just that one message. See the code comment at
+`generateSessionTitle`.
+
+Do not change `AUTO_RENAME_EVERY_N_TURNS` (cadence is a separate concern) and
+do not delete the throwaway-session mechanism (it's still how drift-tracking
+re-titles work — the session title is first-name-only and never updates).
+
 ## Web Push notifications (`src/server/push.mjs`)
 
 Mobile PWA gets Web Push (VAPID) for events it can't otherwise see when

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -48,6 +48,7 @@ import {
   buildTitlePromptInput,
   buildTitleInstruction,
   sanitizeGeneratedTitle,
+  findSessionTitle,
   detectCommandFromText,
   type EntryMotionState,
   type StaleCacheResult,
@@ -1651,10 +1652,52 @@ export function ChatPanel({
     if (autoRenameInFlightRef.current) return;
 
     const turns = countUserTurns(messages);
-    if (!shouldAutoRename(turns)) return;
     if (turns <= lastAutoRenamedTurnRef.current) return; // already done this turn
 
     pendingRenameRef.current = false;
+
+    // Shared rename tail: sanitize → rename the tmux window → refresh. Both
+    // the first-name path and the every-Nth-turn path funnel through here so
+    // there's exactly ONE rename code path.
+    const renameWindow = async (raw: string) => {
+      const name = sanitizeGeneratedTitle(raw);
+      // Empty → generation failed/timed out; skip silently (never blank the
+      // window name, and the rename IPC rejects empty names anyway).
+      if (!name) return;
+      await window.api.tmuxRenameWindow({
+        sessionName: tmuxSession,
+        windowIndex,
+        newName: name,
+      });
+      await refresh();
+    };
+
+    // FIRST NAME — opencode already titles every session from its FIRST user
+    // message for free, so the first rename reads that title (one cheap list
+    // call) instead of spinning up a throwaway generation session. Only runs
+    // before any auto-rename this session; once lastAutoRenamedTurnRef is set,
+    // the every-Nth-turn path below takes over for drift tracking. If the
+    // title isn't populated yet, skip silently and let the next turn retry.
+    if (lastAutoRenamedTurnRef.current === 0) {
+      autoRenameInFlightRef.current = true;
+      void (async () => {
+        try {
+          const sessions = await window.api.opencodeListSessions(cwd ?? "");
+          const title = findSessionTitle(sessions, sessionId);
+          if (title) {
+            await renameWindow(title);
+            lastAutoRenamedTurnRef.current = turns;
+          }
+        } catch {
+          /* auto-rename is best-effort — never surface an error banner */
+        } finally {
+          autoRenameInFlightRef.current = false;
+        }
+      })();
+      return;
+    }
+
+    if (!shouldAutoRename(turns)) return;
 
     const input = buildTitlePromptInput(messages);
     if (!input) return;
@@ -1667,23 +1710,14 @@ export function ChatPanel({
           directory: cwd ?? "",
           instruction: buildTitleInstruction(input),
         });
-        const name = sanitizeGeneratedTitle(raw);
-        // Empty → generation failed/timed out; skip silently (never blank the
-        // window name, and the rename IPC rejects empty names anyway).
-        if (!name) return;
-        await window.api.tmuxRenameWindow({
-          sessionName: tmuxSession,
-          windowIndex,
-          newName: name,
-        });
-        await refresh();
+        await renameWindow(raw);
       } catch {
         /* auto-rename is best-effort — never surface an error banner */
       } finally {
         autoRenameInFlightRef.current = false;
       }
     })();
-  }, [running, messages, autoRenameSessions, tmuxSession, windowIndex, cwd, refresh]);
+  }, [running, messages, autoRenameSessions, tmuxSession, windowIndex, cwd, refresh, sessionId]);
 
   // ===== Voice (extracted to useVoice) =====
   const voice = useVoice({

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -16,6 +16,7 @@ import {
   filterCommands,
   dedupeAgainstBuiltins,
   formatModelContextSize,
+  findSessionTitle,
   formatHiddenTodosSummary,
   summarizeTodoProgress,
   todoStatusOf,
@@ -402,6 +403,39 @@ describe("formatModelContextSize", () => {
     expect(formatModelContextSize(-1)).toBeNull();
     expect(formatModelContextSize(Infinity)).toBeNull();
     expect(formatModelContextSize(NaN)).toBeNull();
+  });
+});
+
+// ===== findSessionTitle (BET-1018) =====
+describe("findSessionTitle", () => {
+  const sessions = [
+    { id: "ses_sky", title: "Sky colour" },
+    { id: "ses_pay", title: "  Payment webhook retry idempotency  " },
+    { id: "ses_untitled", title: "" },
+    { id: "ses_no_title" },
+  ];
+
+  it("returns the title for a matching session id", () => {
+    expect(findSessionTitle(sessions, "ses_sky")).toBe("Sky colour");
+  });
+
+  it("trims surrounding whitespace from the title", () => {
+    expect(findSessionTitle(sessions, "ses_pay")).toBe("Payment webhook retry idempotency");
+  });
+
+  it("returns '' when the session id has no match", () => {
+    expect(findSessionTitle(sessions, "ses_missing")).toBe("");
+  });
+
+  it("returns '' when the session carries no usable title", () => {
+    expect(findSessionTitle(sessions, "ses_untitled")).toBe("");
+    expect(findSessionTitle(sessions, "ses_no_title")).toBe("");
+  });
+
+  it("returns '' for an empty / missing session list or id", () => {
+    expect(findSessionTitle([], "ses_sky")).toBe("");
+    expect(findSessionTitle(sessions, "")).toBe("");
+    expect(findSessionTitle(undefined as never, "ses_sky")).toBe("");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -140,6 +140,21 @@ export function formatModelContextSize(
   return `${Math.round(context / 1000)}k`;
 }
 
+// Find the opencode session title for a given session id, from the session
+// list returned by opencodeListSessions (GET /session). opencode names every
+// session from its FIRST user message for free, so this supplies the FIRST
+// auto-rename name without burning a throwaway generation session (BET-1018).
+// Returns "" when the session is missing or hasn't been titled yet — the
+// caller skips the rename and retries on the next turn.
+export function findSessionTitle(
+  sessions: { id: string; title?: string }[],
+  sessionId: string,
+): string {
+  if (!sessions || !sessionId) return "";
+  const s = sessions.find((x) => x.id === sessionId);
+  return s && typeof s.title === "string" ? s.title.trim() : "";
+}
+
 // Title-case a model variant / effort id for display: "high" → "High",
 // "extended-thinking" → "Extended Thinking". The raw id is preserved for the
 // wire; this is display-only. Extracted to chatUtils so ModelPicker's effort

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -827,12 +827,6 @@ export async function deleteSessionRaw(sessionId) {
 // erroring.
 export async function generateSessionTitle({ directory, instruction }) {
   const absDir = expandTilde(directory);
-  let model = null;
-  try {
-    model = await getDefaultModel();
-  } catch {
-    /* non-fatal */
-  }
 
   let sid = null;
   try {
@@ -850,10 +844,16 @@ export async function generateSessionTitle({ directory, instruction }) {
     }
     sid = (await createRes.json()).id;
 
-    const promptBody = { parts: [{ type: "text", text: instruction }] };
-    if (model) {
-      promptBody.model = { providerID: model.providerID, modelID: model.modelID };
-    }
+    // Run the retitle on opencode's own "title" agent: it uses its cheap
+    // naming model (instead of our main model) and returns a clean short name
+    // with no prose. sanitizeGeneratedTitle stays as a safety net.
+    //
+    // DO NOT add structured output here. Passing
+    // {"format":{"type":"json_schema",...}} to prompt_async is ACCEPTED on
+    // opencode 1.18.10, but opencode defaults `retryCount` and its own reader
+    // then rejects the whole session's message list with HTTP 400 forever —
+    // the entire transcript becomes unreadable, not just this message.
+    const promptBody = { parts: [{ type: "text", text: instruction }], agent: "title" };
     const promptRes = await ocFetch(
       apiUrl(
         `/session/${encodeURIComponent(sid)}/prompt_async?directory=${encodeURIComponent(absDir)}`,

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -37,6 +37,7 @@ import {
   discardBody,
   getProviders,
   getDefaultModel,
+  generateSessionTitle,
   listModels,
   claudeCliStatus,
   parseProviderApiKey,
@@ -2193,5 +2194,53 @@ test("listReferences degrades to [] when the payload has no data array", async (
   await withMockFetch(
     async () => new Response(JSON.stringify({ location: { directory: "/box" } })),
     async () => assert.deepEqual(await listReferences(), []),
+  );
+});
+
+// generateSessionTitle (BET-1018) — retitles run on opencode's own "title"
+// agent. Assert the prompt_async body sends `agent:"title"` and NEVER a
+// `format` (structured-output) field or a main-model override: json_schema on
+// prompt_async is accepted by opencode 1.18.10 but poisons the whole session
+// transcript with a permanent HTTP 400.
+// ---------------------------------------------------------------------------
+test("generateSessionTitle sends agent:title and never a format/model field", async () => {
+  let promptBody = null;
+  await withMockFetch(
+    async (url, opts) => {
+      const u = String(url);
+      if (u.includes("/prompt_async")) {
+        promptBody = JSON.parse(String(opts?.body ?? "{}"));
+        return new Response(null, { status: 204 });
+      }
+      if (u.includes("/message")) {
+        return new Response(
+          JSON.stringify([
+            {
+              info: { role: "assistant" },
+              parts: [{ type: "text", text: "Payment webhook retry idempotency" }],
+            },
+          ]),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      if (u.includes("/session?directory=")) {
+        return new Response(JSON.stringify({ id: "ses_title" }), {
+          status: 200,
+          headers: { "content-type": "application/json" },
+        });
+      }
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const title = await generateSessionTitle({
+        directory: "/w",
+        instruction: "Title this session",
+      });
+      assert.equal(title, "Payment webhook retry idempotency");
+      assert.ok(promptBody, "expected a prompt_async body");
+      assert.equal(promptBody.agent, "title", "retitle must run on the title agent");
+      assert.equal("format" in promptBody, false, "must never send a format/structured-output field");
+      assert.equal("model" in promptBody, false, "title agent uses its own model, not our main model");
+    },
   );
 });


### PR DESCRIPTION
## What & why

Auto-rename only fired on every 5th completed user turn, so short sessions were **never** named — and each drift rename burned a throwaway opencode session on our main model. opencode already titles every session for free; we just never read it.

1. **First name from opencode's own session title.** In the auto-rename effect, before the every-Nth-turn logic, if the window hasn't been auto-renamed yet (`lastAutoRenamedTurnRef === 0`), read the session title via `opencodeListSessions(cwd)` → new pure `findSessionTitle(sessions, sessionId)` helper and rename the tmux window from it (BET-1018). If the title isn't populated yet, skip silently and retry next turn. Reuses the existing sanitize + rename + refresh path (refactored into one shared `renameWindow` tail — no second rename code path). Never blanks a window name.
2. **Re-titles run on the title agent.** `generateSessionTitle` now sends `agent:"title"` on the prompt_async body, running opencode's own cheap naming model instead of our main model (dropped the `getDefaultModel` override). `sanitizeGeneratedTitle` stays as a safety net.
3. **No structured output.** Added a code comment recording that `json_schema` format poisons the whole session transcript on opencode 1.18.10 (accepts it, then its own reader 400s the message list forever). Tests assert no `format` field is ever sent.

## Guardrails honored
- `AUTO_RENAME_EVERY_N_TURNS` unchanged.
- Throwaway-session mechanism kept (still how drift-tracking re-titles work).
- No second rename path / sanitizer / IPC channel added.
- `AGENTS.md` updated: first name = opencode title, re-titles = title agent, structured output is a known trap on 1.18.10.

**Files changed:** 5 files.
- `src/renderer/ChatPanel.tsx` — first-name from session title, shared rename tail
- `src/renderer/chatUtils.ts` — `findSessionTitle` helper
- `src/renderer/chatUtils.test.ts` — `findSessionTitle` tests
- `src/server/opencode.mjs` — `agent:"title"` + structured-output warning comment
- `src/server/opencode.test.mjs` — prompt_async body shape test

**Verification results:**
- PR branch (`multica/BET-1018-rename-title` @ `367fceec`):
  - typecheck: exit 0. Errors: none. log sha256: `0470e3206cfd630eb016fec608ccbfe07a599b2551eba331043bfc269cbcf41a`
  - test: exit 0, 2162 pass / 0 fail / 0 skip. Failures: none. log sha256: `b7269861e3903fabfa974fdc1f112267e115e4534d2d4830920bf998d680c20c`
- Base (`main` @ `482f38a0`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2161 pass / 0 fail / 0 skip. Failures: none. log sha256: `d511eaffb743517c1e1129f44b7d3af74c73cc143db9dd423c64ecdbd6fadb1b`
- **Conclusion:** 0 new failures; the only delta is the new tests added by this PR (5 renderer `findSessionTitle` cases + 1 server `generateSessionTitle` case). Base passed too.

Base: origin/main @ 482f38a0
