### PR TITLE
fix(server): apply skillRegistryUrls to opencode skills.urls (BET-1031)

### DIFF
--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -452,6 +452,23 @@ export async function setSubagents(ops, deps = {}) {
 }
 
 /**
+ * Apply the user's configured skill-registry URLs to opencode's `skills.urls`
+ * via PATCH /global/config — the single opencode.jsonc writer (BET-1019).
+ * The renderer persists the list to config.json via config:update; this is the
+ * server-side half of BET-1031 that actually makes opencode honor it
+ * (previously nothing on the server read skillRegistryUrls into opencode, so
+ * adding a registry in Settings "saved" but did nothing).
+ *
+ * The endpoint deep-merges `skills`, so unrelated skills keys (e.g. `command`)
+ * are untouched. Does NOT restart opencode; like providers/subagents, opencode
+ * only re-reads `skills` at startup and the caller decides whether to restart.
+ */
+export async function setSkillRegistryUrls(urls = [], deps = {}) {
+  const patch = deps.patch ?? patchGlobalConfig;
+  return patch({ skills: { urls: Array.isArray(urls) ? urls : [] } });
+}
+
+/**
  * Reconcile the full model list against opencode.jsonc's configured agent
  * blocks + the caller-supplied deactivated set (BET-123 "auto-register every
  * model" feature), then apply the diff via the EXISTING setSubagents writer

--- a/src/server/providers.test.mjs
+++ b/src/server/providers.test.mjs
@@ -20,6 +20,7 @@ import {
   readAgentBlocks,
   getSubagents,
   setSubagents,
+  setSkillRegistryUrls,
   syncSubagents,
   mantaPlanAgentBlock,
   ensureMantaPlanAgent,
@@ -852,6 +853,51 @@ describe("setSubagents", () => {
     assert.equal(result.ok, false);
     assert.match(result.error, /remove/i);
     assert.equal(patched, false, "rejects the batch before any upsert PATCH");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// setSkillRegistryUrls — the BET-1031 writer. Routes the user's registry list
+// to opencode's `skills.urls` through PATCH /global/config, touching only the
+// `urls` key (deep-merge) so unrelated keys are preserved.
+// ---------------------------------------------------------------------------
+
+describe("setSkillRegistryUrls", () => {
+  it("patches skills.urls with the given list", async () => {
+    const patches = [];
+    const result = await setSkillRegistryUrls(
+      ["https://example.com/a.json", "https://example.com/b.json"],
+      { patch: async (p) => { patches.push(p); return { ok: true }; } },
+    );
+    assert.equal(result.ok, true);
+    assert.equal(patches.length, 1);
+    assert.deepEqual(patches[0], { skills: { urls: ["https://example.com/a.json", "https://example.com/b.json"] } });
+  });
+
+  it("patches only urls, never other skills keys", async () => {
+    const patches = [];
+    await setSkillRegistryUrls(["https://example.com/a.json"], {
+      patch: async (p) => { patches.push(p); return { ok: true }; },
+    });
+    const keys = Object.keys(patches[0].skills);
+    assert.deepEqual(keys, ["urls"], "deep-merge patch must carry only the urls key");
+  });
+
+  it("normalizes a non-array value to an empty list (defensive, no throw)", async () => {
+    const patches = [];
+    const result = await setSkillRegistryUrls(null, {
+      patch: async (p) => { patches.push(p); return { ok: true }; },
+    });
+    assert.equal(result.ok, true);
+    assert.deepEqual(patches[0].skills.urls, []);
+  });
+
+  it("propagates a failed opencode write back to the caller", async () => {
+    const result = await setSkillRegistryUrls(["https://example.com/a.json"], {
+      patch: async () => ({ ok: false, error: "opencode config endpoint unreachable: boom" }),
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /unreachable/);
   });
 });
 

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -289,7 +289,19 @@ export function buildHandlers({
     // preload: ipcRenderer.invoke(IPC.configUpdate, patch)  → args[0] = patch (Partial<AppConfig>)
     // BET-675: after a successful write, push the new config into syncState so
     // the materialized config delta is published for sync subscribers.
+    //
+    // BET-1031: skillRegistryUrls is the one Settings field that must ALSO be
+    // applied to opencode itself (its `skills.urls`), not just persisted to
+    // config.json. Written to opencode FIRST through the single endpoints
+    // writer; only on success is config.json persisted, so a registry change
+    // that can't reach opencode fails loudly (renderer reverts + errors)
+    // instead of "appears to save but does nothing". opencode re-reads
+    // `skills` at startup, like subagents.
     "config:update": async (patch) => {
+      if (Array.isArray(patch?.skillRegistryUrls)) {
+        const applied = await providers.setSkillRegistryUrls(patch.skillRegistryUrls);
+        if (!applied.ok) throw new Error(applied.error);
+      }
       const next = await local.configUpdate(patch);
       syncState.applyConfig(next);
       return next;


### PR DESCRIPTION
Fixes BET-1031: skillRegistryUrls never applied to opencode.jsonc on the server.

## What
Settings → AI → Skills registry URLs were persisted to `~/.manta/config.json` via `config:update` but nothing on the server ever wrote them into opencode's `skills.urls` — so adding a registry appeared to save and did nothing.

## Change
- `src/server/providers.mjs`: new `setSkillRegistryUrls(urls)` writer that routes the list through the single `PATCH /global/config` endpoint (`patchGlobalConfig`, from BET-1019); deep-merge touches only `skills.urls`, leaving unrelated keys/comments intact.
- `src/server/rpc.mjs`: `config:update` now writes `skillRegistryUrls` to opencode FIRST, and only on success persists config.json + publishes syncState. A registry change that can't reach opencode fails loudly (renderer reverts + error toast) instead of silently no-oping. Other config fields are unaffected (the write runs only when `patch.skillRegistryUrls` is an array).
- `src/server/providers.test.mjs`: 4 new tests (routes urls, only-urls key, defensive non-array, propagated failure).

Requires an opencode restart to take effect (opencode re-reads `skills` at startup) — same as subagents; restart is left to the caller rather than auto-triggered.

**Files changed:** `3`. `src/server/providers.mjs`, `src/server/rpc.mjs`, `src/server/providers.test.mjs`

**Verification results:**
- PR branch (`multica/BET-1031-skill-registry-urls-server` @ `HEAD`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, `2184` pass / `0` fail / `0` skip.
- Base (`main` @ `1c938f00`):
  - typecheck: exit 0. Errors: none (not re-run; branch == origin/main + isolated server change).
  - test: not re-run (pre-existing pass state; change is additive server-side, no baseline drift expected).
- **Conclusion:** 0 new failures. `npm test` full suite green on the PR branch (2184/2184).

Base: origin/main @ 1c938f00
