### PR TITLE
docs(AGENTS): remove deleted voice command classifier (BET-1021)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1906,13 +1906,13 @@ path for the chat-window `·N` count.
 
 ## Voice / speech-to-text (Groq)
 
-Push-to-talk mic button in the chat input. Hold = record. Tap (≤500ms) =
-**dictate** — transcript inserted at the caret. Hold-with-⌥ (desktop) or
-long-press ≥500ms (touch) = **command** mode — transcript routed through
-the rules classifier and (on no match) a Groq llama call returning a
-structured `VoiceAction` that's dispatched panel-side (clear/compact/fork/
-abort/model/answer/permission/etc) or App-side (switch-window/new-session/
-open-settings, via a `manta-voice-app-action` `CustomEvent`).
+Push-to-talk mic button in the chat input. Hold = record, release = send to
+transcription; tap toggles recording on/off. The transcript is inserted at
+the caret as plain dictation. **There is no command/classifier mode.** The
+former rules-first classifier, its Groq LLM fallback, `VoiceAction`
+dispatch, and the `manta-voice-app-action` `CustomEvent` were removed from
+the codebase — `src/shared/voiceClassifier.mjs` and the `voiceCommandModel`
+setting no longer exist. Do not reintroduce them.
 
 **Audio pipeline (identical on both transports):**
 1. `useVoiceRecorder` (`src/renderer/voice.ts`) drives a `MediaRecorder`
@@ -1923,24 +1923,18 @@ open-settings, via a `manta-voice-app-action` `CustomEvent`).
    `ArrayBuffer` to main/server. The mobile HTTP shim base64-encodes the
    buffer because the RPC body is JSON; `rpc.mjs` decodes back to a
    `Buffer`.
-3. `src/shared/groq.mjs` POSTs multipart to
-   `https://api.groq.com/openai/v1/audio/transcriptions` with the
-   configured key + model (default `whisper-large-v3-turbo`).
-4. In command mode, the renderer follows up with
-   `voiceClassifyCommand({transcript})`. `src/shared/voiceClassifier.mjs`
-   runs the rules first (zero-cost), falls back to
-   `chat/completions` with JSON-mode (default
-   `llama-3.1-8b-instant`) — `coerceLlmAction` validates the reply and
-   degrades to `{kind:"unknown",transcript}` on malformed input.
+3. `src/shared/groq.mjs` (a transcription-only client — it exports exactly
+   `filenameFor` and `transcribeAudio`, no chat/completions call) POSTs
+   multipart to `https://api.groq.com/openai/v1/audio/transcriptions`
+   with the configured key + model (default `whisper-large-v3-turbo`).
 
-**Why classify on the server side:** the Groq API key never leaves main/
-server, same trust boundary as opencode auth. The renderer only ever sees
-audio bytes and the final `VoiceAction`.
+The Groq API key stays on main/server — the renderer only ever sends audio
+bytes and receives the transcript back.
 
-**Settings:** `groqApiKey` (gates the mic button — empty = hidden),
-`voiceTranscriptionModel`, `voiceCommandModel`. All three live in
-AppConfig and the store; UI in `Settings.tsx` and `MobileSettings.tsx`.
-Stored plaintext, same as other MantaUI credentials.
+**Settings:** `groqApiKey` (gates the mic button — empty = hidden) and
+`voiceTranscriptionModel`. Both live in AppConfig and the store; UI in
+`Settings.tsx` and `MobileSettings.tsx`. Stored plaintext, same as other
+MantaUI credentials.
 
 **Mobile permissions:** `RECORD_AUDIO` + `MODIFY_AUDIO_SETTINGS` in
 `mobile/android/.../AndroidManifest.xml`; `NSMicrophoneUsageDescription`
@@ -1948,27 +1942,14 @@ in `mobile/ios/.../Info.plist`. Without these the first
 `getUserMedia({audio:true})` call insta-rejects with `NotAllowedError`
 before the OS prompt fires.
 
-**Pure helpers (tested):**
-- `classifyByRules`, `normalizeTranscript`, `coerceLlmAction`,
-  `buildClassifierPrompt` in `src/shared/voiceClassifier.mjs`
-  (tested by `src/shared/voiceClassifier.test.ts`).
-- `pickRecorderMime`, `fuzzyMatchModel`, `resolveQuestionAnswer`,
-  `describeVoiceAction` in `src/renderer/voice.ts` (tested by
-  `src/renderer/voice.test.ts`).
+**Pure helpers (tested):** recording + timing in `src/renderer/voice.ts`
+(tested by `src/renderer/voice.test.ts`): `VoicePhase`, `VoiceArtifact`,
+`elapsedReset/Current/Pause/Resume`, `nearLimitAt`, `isTooShort`,
+`pickRecorderMime`, `useVoiceRecorder`. (`fuzzyMatchModel` lives in
+`src/shared/modelGuide.mjs`, used by app control — it is not part of the
+recorder and is not exported from `voice.ts`.)
 
-**Locked decisions:**
-- Modifier-based mode switch on ONE button — don't add a second
-  "command" button to the composer. Mobile composer real estate is
-  already tight (see "Reshaping reused ChatPanel/Terminal internals on
-  mobile" above).
-- **`useVoiceRecorder` owns the long-press → command promotion** — the
-  button passes `start("dictate")` and the HOOK schedules the
-  `longPressMs` timer that flips its own `modeRef` + the exposed
-  `mode` state. The MicButton reads `mode` from the hook for its
-  label. Do NOT reintroduce a parallel `modeRef` in the button —
-  that was PR #4's W2 bug: the button promoted its own ref but never
-  told the hook, so long-press on touch always transcribed as
-  dictate. The hook's `mode` is the single source of truth.
+**Locked decisions (recorder):**
 - **`MediaRecorder.start(250)` timeslice** — without it, iOS WKWebView
   17.x sometimes delivers the final `dataavailable` AFTER `onstop`,
   leaving an empty chunks array. 250ms forces periodic emission. The
@@ -1981,23 +1962,10 @@ before the OS prompt fires.
 - **Phase guard uses a ref, not state** — `phaseRef.current` is
   updated synchronously by `setPhaseSync` so two `pointerdown` events
   inside the same React commit can't both pass the re-entrancy guard.
-- **Voice action dispatcher picks the NEWEST pending card** via a
-  local `findLast` helper, not `.find()`. Matches the visual stack:
-  the topmost PermissionCard / QuestionCard is the most recent ask,
-  which is what the user is looking at when they say "yes" / "reject".
-- **"reject" falls through from permission to question** — when no
-  permission is pending but a question is, "reject" dismisses the
-  question via `rejectQuestion`. `allow-once` / `allow-always` have
-  no question equivalent and surface a hint if no permission is open.
-- Rules-first classifier — never go LLM-only. The bare `yes`/`no` /
-  `clear` / `compact` paths fire in ~0ms with no token spend.
 - Batch transcription (no streaming) — Groq's HTTP API has no native
   streaming STT endpoint and short clips return in ~200-500ms. Don't
   reintroduce a chunked-streaming spike; it under-delivered vs the
   added complexity in spike testing.
-- Numeric switch-window indices in 1..9 only — both the rules
-  classifier and `coerceLlmAction` reject out-of-range and string-typed
-  indices, matching ⌘1..9's domain.
 
 ## File upload paths (chat-mode)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,7 +76,7 @@ session-state snapshot.
   and tests.
 - `src/shared/` — transport mode resolution (`transport.mjs`), plus pure logic
   shared by renderer + server (`groq.mjs`, `subagentSync.mjs`,
-  `voiceClassifier.mjs`, `modelGuide.mjs`).
+  `modelGuide.mjs`).
 
 ## Build / run
 


### PR DESCRIPTION
Fixes BET-1021 — documentation only.

Rewrites the `## Voice / speech-to-text (Groq)` section of `AGENTS.md` to describe what exists and deletes every reference to the removed voice command classifier:

- Removes command mode, the rules-first classifier + LLM fallback, `VoiceAction` dispatch, and the `manta-voice-app-action` CustomEvent.
- Removes `voiceClassifier.mjs`, `voiceCommandModel`, and the classifier pure-helpers from the helpers list.
- Documents `src/shared/groq.mjs` as transcription-only (`filenameFor` / `transcribeAudio`), keeps the two remaining settings (`groqApiKey`, `voiceTranscriptionModel`), the audio pipeline, and the mobile permission requirements.
- Keeps the recorder locked decisions that still apply (250ms timeslice, cancel-after-getUserMedia, phase-guard ref, batch transcription).
- Notes `fuzzyMatchModel` lives in `src/shared/modelGuide.mjs`, not `voice.ts`.

All claims verified by grep against the current tree before writing.

The auto-rename and self-update passages were already updated by BET-1018 (#1027) and BET-1016 (#1025), both merged — left untouched.

**Files changed:** 1 (`AGENTS.md`).

**Verification results:**
- PR branch (`multica/BET-1021-agents-voice-cleanup` @ `11350a7f`):
  - typecheck: pass, 0 errors
  - test: 2193 pass / 0 fail / 0 skip
- Base (`main` @ `950ef751`):
  - typecheck: pass
- **Conclusion:** 0 failures — docs-only change.
- CI: `typecheck-test` check green on the PR.

**Base: origin/main @ `950ef751`**

Docs only — no `src/` changes. This issue is the documentation companion to the already-removed voice classifier; no code follow-ups.
