### PR TITLE
Remove dead removeProviderBlock/removeAgentBlock helpers (BET-1032)

### DIFF
--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -1,7 +1,7 @@
 // providers.mjs — Provider management for the manta mobile server.
 //
 // Ports the pure helpers from src/main/providers.ts (parseModelsResponse,
-// upsertProviderBlock, removeProviderBlock, readProviderEndpoints,
+// upsertProviderBlock, readProviderEndpoints,
 // findStoredApiKey, stripUrlUserinfo) and adds server-side I/O functions:
 //   discoverModels    — fetch <baseURL>/models directly (server IS the box)
 //   setProviders      — read/merge/write opencode.jsonc locally
@@ -132,12 +132,6 @@ export function upsertProviderBlock(cfg, input) {
   return { ...cfg, provider: providers };
 }
 
-export function removeProviderBlock(cfg, id) {
-  const providers = getProviderMap(cfg);
-  delete providers[id];
-  return { ...cfg, provider: providers };
-}
-
 // Project the config's provider map down to renderer-safe metadata. Never
 // includes the apiKey value — only whether one is present — and scrubs any
 // credential embedded in the baseURL.
@@ -148,10 +142,10 @@ export function removeProviderBlock(cfg, id) {
 // opencode-claude-auth) have no baseURL and MUST be excluded — rendering them
 // in the card gives them a Refresh button that fetches `"" + "/models"`
 // ("unreachable: could not reach the endpoint"), and worse, a model toggle or
-// ✕ on that row would route the block through upsertProviderBlock /
-// removeProviderBlock, overwriting it with npm:"@ai-sdk/openai-compatible" +
-// empty baseURL and corrupting the plugin auth. They still appear in the model
-// dropdown, which reads the live /provider endpoint instead.
+// ✕ on that row would route the block through upsertProviderBlock, overwriting
+// it with npm:"@ai-sdk/openai-compatible" + empty baseURL and corrupting the
+// plugin auth. They still appear in the model dropdown, which reads the live
+// /provider endpoint instead.
 export function readProviderEndpoints(cfg) {
   const providers = getProviderMap(cfg);
   return Object.entries(providers)
@@ -199,12 +193,6 @@ export function upsertAgentBlock(cfg, input) {
   };
   if (input.permission !== undefined) agents[input.name].permission = input.permission;
   if (input.prompt !== undefined) agents[input.name].prompt = input.prompt;
-  return { ...cfg, agent: agents };
-}
-
-export function removeAgentBlock(cfg, name) {
-  const agents = getAgentMap(cfg);
-  delete agents[name];
   return { ...cfg, agent: agents };
 }
 

--- a/src/server/providers.test.mjs
+++ b/src/server/providers.test.mjs
@@ -8,7 +8,6 @@ import assert from "node:assert/strict";
 import {
   parseModelsResponse,
   upsertProviderBlock,
-  removeProviderBlock,
   readProviderEndpoints,
   findStoredApiKey,
   discoverModels,
@@ -16,7 +15,6 @@ import {
   setProviders,
   getProviderEndpoints,
   upsertAgentBlock,
-  removeAgentBlock,
   readAgentBlocks,
   getSubagents,
   setSubagents,
@@ -229,39 +227,6 @@ describe("upsertProviderBlock", () => {
       enabledModels: [],
     });
     assert.equal(result.provider.existing.options.apiKey, "");
-  });
-});
-
-// ---------------------------------------------------------------------------
-// removeProviderBlock
-// ---------------------------------------------------------------------------
-
-describe("removeProviderBlock", () => {
-  it("removes an existing provider", () => {
-    const cfg = {
-      provider: {
-        keep: { npm: "x", name: "Keep", options: {}, models: {} },
-        remove: { npm: "x", name: "Remove", options: {}, models: {} },
-      },
-    };
-    const result = removeProviderBlock(cfg, "remove");
-    assert.ok(result.provider.keep);
-    assert.equal(result.provider.remove, undefined);
-  });
-
-  it("is a no-op when provider does not exist", () => {
-    const cfg = { provider: { only: { npm: "x", name: "Only", options: {}, models: {} } } };
-    const result = removeProviderBlock(cfg, "ghost");
-    assert.ok(result.provider.only);
-    assert.equal(Object.keys(result.provider).length, 1);
-  });
-
-  it("handles config with no provider key", () => {
-    const cfg = { skills: {} };
-    const result = removeProviderBlock(cfg, "anything");
-    // When there's no provider key, getProviderMap returns {} and the spread
-    // sets provider to {} (not undefined). This is the actual behavior.
-    assert.deepEqual(result.provider, {});
   });
 });
 
@@ -712,26 +677,6 @@ describe("upsertAgentBlock", () => {
     });
     assert.equal(result.agent.fast.model, "anthropic/claude-haiku-4");
     assert.equal(result.agent.fast.description, "New");
-  });
-});
-
-describe("removeAgentBlock", () => {
-  it("removes the named agent", () => {
-    const cfg = {
-      agent: {
-        fast: { model: "anthropic/claude-haiku-4", description: "Fast", mode: "subagent" },
-        deep: { model: "anthropic/claude-opus-4", description: "Deep", mode: "subagent" },
-      },
-    };
-    const result = removeAgentBlock(cfg, "fast");
-    assert.equal(result.agent.fast, undefined);
-    assert.deepEqual(result.agent.deep, cfg.agent.deep);
-  });
-
-  it("preserves other keys in config", () => {
-    const cfg = { agent: { fast: {} }, provider: { openai: {} } };
-    const result = removeAgentBlock(cfg, "fast");
-    assert.deepEqual(result.provider, { openai: {} });
   });
 });
 


### PR DESCRIPTION
Opened automatically for `multica/BET-1032-remove-provider-agent-block`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1032.