### PR TITLE
fix(renderer): raise shared restart banner on skill registry change, drop ProvidersCard's dead one (BET-1035)

### DIFF
--- a/src/renderer/ProvidersCard.tsx
+++ b/src/renderer/ProvidersCard.tsx
@@ -6,25 +6,22 @@ import { Checkbox } from "./Checkbox";
 
 type Props = {
   /**
-   * BET-420: raised when an endpoint mutation needs an opencode restart. When
-   * provided (desktop Settings), the card does NOT render its own restart
-   * banner — the Settings panel shows ONE shared restart banner instead. When
-   * omitted (mobile), the card keeps its inline "Apply Now / Apply Later"
-   * banner so mobile still has a restart affordance.
+   * BET-420: raised when an endpoint mutation needs an opencode restart. The
+   * card never renders its own restart UI — the Settings panel owns the ONE
+   * shared restart banner (BET-420), and this callback drives it.
    *
    * BET-421 §D: the add-endpoint form (CustomProviderForm) handles its OWN
    * save + restart internally (probe → save → restart), so it does NOT route
    * through this callback — only the per-endpoint toggle/remove mutations do.
    */
-  onRestartNeeded?: () => void;
+  onRestartNeeded: () => void;
 };
 
-export function ProvidersCard({ onRestartNeeded }: Props = {}) {
+export function ProvidersCard({ onRestartNeeded }: Props) {
   const [endpoints, setEndpoints] = useState<ProviderEndpoint[] | null>(null);
   const [discovered, setDiscovered] = useState<Record<string, { id: string }[]>>({});
   const [discoverError, setDiscoverError] = useState<Record<string, string>>({});
   const [busy, setBusy] = useState<string | null>(null); // endpoint id being mutated
-  const [restartNeeded, setRestartNeeded] = useState(false);
   const [globalError, setGlobalError] = useState<string | null>(null);
 
   const load = useCallback(() => {
@@ -61,11 +58,6 @@ export function ProvidersCard({ onRestartNeeded }: Props = {}) {
     }
   }, [busy]);
 
-  const flagRestart = () => {
-    if (onRestartNeeded) onRestartNeeded();
-    else setRestartNeeded(true);
-  };
-
   const toggleModel = useCallback(async (ep: ProviderEndpoint, modelId: string) => {
     if (busy) return;
     const enabled = ep.enabledModels.includes(modelId)
@@ -78,7 +70,7 @@ export function ProvidersCard({ onRestartNeeded }: Props = {}) {
         upsert: [{ id: ep.id, name: ep.name, baseURL: ep.baseURL, enabledModels: enabled }],
       });
       if (!res.ok) { setGlobalError(res.error ?? "Save failed"); return; }
-      flagRestart();
+      onRestartNeeded();
       load();
     } catch (e) {
       setGlobalError(e instanceof Error ? e.message : String(e));
@@ -96,7 +88,7 @@ export function ProvidersCard({ onRestartNeeded }: Props = {}) {
       if (!res.ok) { setGlobalError(res.error ?? "Remove failed"); return; }
       setDiscovered((d) => { const { [ep.id]: _drop, ...rest } = d; return rest; });
       setDiscoverError((er) => { const { [ep.id]: _drop, ...rest } = er; return rest; });
-      flagRestart();
+      onRestartNeeded();
       load();
     } catch (e) {
       setGlobalError(e instanceof Error ? e.message : String(e));
@@ -104,23 +96,6 @@ export function ProvidersCard({ onRestartNeeded }: Props = {}) {
       setBusy(null);
     }
   }, [busy, load, onRestartNeeded]);
-
-  const [restarting, setRestarting] = useState(false);
-  const applyRestart = useCallback(async () => {
-    if (restarting) return;
-    setRestarting(true);
-    setGlobalError(null);
-    try {
-      await window.api.opencodeRestart();
-      setRestartNeeded(false);
-    } catch (e) {
-      // A restart that killed the session but failed to bring opencode back is
-      // the worst-perceived outcome — never let it fail silently.
-      setGlobalError(`Restart failed: ${e instanceof Error ? e.message : String(e)}`);
-    } finally {
-      setRestarting(false);
-    }
-  }, [restarting]);
 
   return (
     <div className="space-y-2">
@@ -180,24 +155,6 @@ export function ProvidersCard({ onRestartNeeded }: Props = {}) {
         compact
         onSaved={load}
       />
-
-      {/* Mobile-only restart banner (desktop routes through the panel banner
-          via onRestartNeeded, so this never renders on desktop). */}
-      {!onRestartNeeded && restartNeeded && (
-        <div className="flex items-center gap-2 text-meta bg-bg-soft border border-border rounded-xs p-2">
-          <span className="flex-1 text-text-muted">
-            Restart opencode now to apply? (interrupts active sessions)
-          </span>
-          <button onClick={applyRestart} disabled={restarting}
-            className="px-2 py-1 bg-accent/20 border border-accent rounded-xs text-text disabled:opacity-40">
-            {restarting ? "Restarting…" : "Apply Now"}
-          </button>
-          <button onClick={() => setRestartNeeded(false)} disabled={restarting}
-            className="px-2 py-1 border border-border rounded-xs text-text-muted disabled:opacity-40">
-            Apply Later
-          </button>
-        </div>
-      )}
     </div>
   );
 }

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -412,6 +412,7 @@ export function Settings({
         message: next.length > prev.length ? "Registry URL added" : "Registry URL removed",
         actions: [{ label: "Undo", onClick: () => { void useStore.setState({ skillRegistryUrls: prev }); window.api.configUpdate({ skillRegistryUrls: prev }).catch(() => {}); } }],
       });
+      requestRestart();
     } catch (e) {
       useStore.setState({ skillRegistryUrls: prev });
       push({ id: `err-registry-${Date.now()}`, message: errorDisclosure("Couldn't update skill registries.", e) });

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -514,8 +514,9 @@ type State = {
   // three per-card restart prompts that used to live in ModelsCard,
   // ProvidersCard and ConnectProvider. Cleared by the banner's restart button
   // (and by any other path that restarts opencode, e.g. ConnectProvider's
-  // connect-completion restart). Desktop-only concept; mobile keeps its own
-  // inline restart prompt inside ProvidersCard.
+  // connect-completion restart). Desktop-only concept; there is no inline
+  // restart prompt anywhere else (the old ProvidersCard fallback was removed
+  // with BET-1035 — this banner is the ONE restart affordance).
   opencodeRestartNeeded: boolean;
   setOpencodeRestartNeeded: (v: boolean) => void;
   // ----- derived selectors -----


### PR DESCRIPTION
**BET-1035** — Skill registry change owes an opencode restart: raise the shared banner, delete ProvidersCard's dead one.

## What changed

**Part 1 — Settings.tsx** (`persistRegistryUrls`): on the success path of a skill registry add/remove, call the existing `requestRestart()` helper, which raises the shared `opencodeRestartNeeded` flag → the one Settings restart banner (BET-420) appears. Not raised on the `catch` path. No new state, no new toast, no confirm dialog, no `opencodeRestart` call from this control.

**Part 2 — ProvidersCard.tsx**: deleted the card's own inline restart machinery that was kept as a "mobile fallback" (mobile client retired by BET-559; the card has exactly one mount site that always passes `onRestartNeeded`). Removed `restartNeeded`/`restarting` state, the `applyRestart` callback, the mobile-only "Apply Now / Apply Later" JSX block, and the `flagRestart` passthrough (now calling `onRestartNeeded()` directly at the two mutation sites). Made the `onRestartNeeded` prop required and dropped the `= {}` default, so there is no longer any path where the card mutates config without a restart affordance. Dependencies arrays left as-is (both call sites now reference `onRestartNeeded` directly). No imports became unused.

**store.ts**: updated a stale comment that claimed mobile kept an inline restart prompt inside ProvidersCard.

## Files changed

3 files, `-41` net:
- `src/renderer/Settings.tsx` (+1)
- `src/renderer/ProvidersCard.tsx` (−43)
- `src/renderer/store.ts` (+1 net comment-only)

## Tests

No test file exists for `ProvidersCard` or the Settings registry control, and no shared harness for them exists in `src/renderer/` — per the issue, skipped adding tests rather than standing up a new harness. Both existing suites pass unchanged.

## Verification results

Files changed: 3.

- PR branch (`multica/BET-1035-restart-banner` @ `80a56074`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2193 pass / 0 fail / 0 skip. Failures: none. log sha256: `022f27fee0ae606ad07f1b1ce54cff2802dc57dd09fb3d95cb228836c5986c8f`
- Base (`main` @ `9fc0bb18`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2193 pass / 0 fail / 0 skip. Failures: none. log sha256: `938aa10346b7d4904d978c0957d39f44d22643faf3167571837b2074c4e4700b`
- Conclusion: 0 new failures, 0 pre-existing (both branches green: 2193/2193/0). Typecheck logs byte-identical between branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ `9fc0bb18`**
