### PR TITLE
BET-981: make a merge-gateway failure fatal on the public path (all-or-nothing gap)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1528,7 +1528,7 @@ main() {
         else
           if [ "$SKIP_PUBLIC_TLS" != "1" ]; then
             die "merge-gateway failed — the gateway token/host could not be persisted, so this box would advertise a hostname whose config is incomplete (see /tmp/manta-gateway-merge.err).
-              Fix the above and run the installer again.
+              Fix the gateway registration issue and run the installer again.
 
               Fix the above and run the installer again — re-running is safe and preserves your box identity."
           fi

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1526,6 +1526,12 @@ main() {
         if printf '%s' "$GW_RESP" | "$NODE" "$LIB" merge-gateway --file "$MANTA_AUTH_FILE" 2>/tmp/manta-gateway-merge.err; then
           ok "gateway registration complete."
         else
+          if [ "$SKIP_PUBLIC_TLS" != "1" ]; then
+            die "merge-gateway failed — the gateway token/host could not be persisted, so this box would advertise a hostname whose config is incomplete (see /tmp/manta-gateway-merge.err).
+              Fix the above and run the installer again.
+
+              Fix the above and run the installer again — re-running is safe and preserves your box identity."
+          fi
           warn "merge-gateway failed (see /tmp/manta-gateway-merge.err) — the server will re-register on next boot."
         fi
       else

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -3337,6 +3337,25 @@ test("BET-980: the gateway fatality is gated on SKIP_PUBLIC_TLS, not INGRESS_MOD
   );
 });
 
+test("install.sh makes a merge-gateway failure fatal on the public path only", () => {
+  // BET-981 closes the last warn-and-continue gap BET-980 left behind: a
+  // failed merge-gateway persistence on the PUBLIC path advertises a hostname
+  // whose config is incomplete, so it must die exactly like the register-POST
+  // failure beside it. On tailscale/macOS (SKIP_PUBLIC_TLS=1) the gateway
+  // token is a best-effort APNs credential, so warn-and-continue stays.
+  const src = readFileSync(INSTALL_SH, "utf-8");
+  assert.match(
+    src,
+    /if \[ "\$SKIP_PUBLIC_TLS" != "1" \]; then\n[ \t]+die "merge-gateway failed/,
+    "a merge-gateway failure must be fatal (die) on the public path only (gated on SKIP_PUBLIC_TLS)",
+  );
+  assert.match(
+    src,
+    /warn "merge-gateway failed \(see \/tmp\/manta-gateway-merge\.err\) — the server will re-register on next boot\."/,
+    "the non-public (tailscale/macOS) merge-gateway failure must stay a warn, not become fatal",
+  );
+});
+
 // ----------------------------------------------------------------------------
 // install.sh — step 7.5.E all-or-nothing (BET-980, supersedes BET-205 §3/§4).
 // ----------------------------------------------------------------------------


### PR DESCRIPTION
## BET-981 — Installer: make a merge-gateway failure fatal on the public path

Closes the last warn-and-continue gap BET-980 left behind in step 7.5 sub-step B/C of `scripts/install.sh`.

### Change
When `merge-gateway` (persisting `gateway_token` + `gateway_host` into `~/.manta/auth.json`) fails:

- **Public path** (`SKIP_PUBLIC_TLS != 1`) → **`die`**, mirroring the shape and closing sentence of the adjacent gateway-registration-POST `die` directly below it. The message states the token/host could not be persisted so the box would advertise a hostname whose config is incomplete, points at `/tmp/manta-gateway-merge.err`, and ends with *"Fix the above and run the installer again — re-running is safe and preserves your box identity."*
- **Tailscale/macOS** (`SKIP_PUBLIC_TLS = 1`) → existing `warn` kept verbatim (best-effort APNs credential; box reachable regardless).

No other code changed. No new env override, no retry loop, no fallback write. Dry-run branch untouched.

### Test
One static-layout guard added near the other step-7.5 guards in `scripts/install.test.mjs` that reads `INSTALL_SH` and asserts both halves of the split (public → `die` gated on `SKIP_PUBLIC_TLS`; non-public → `warn` still present).

### Files changed
2 files. `scripts/install.sh`, `scripts/install.test.mjs`.

**Base: origin/main @ `9fc0bb18`**

**Verification results:**
- PR branch (`multica/BET-981-merge-gateway-fatal-public` @ `fafd2aa9`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2194 pass / 0 fail / 0 skip. Failures: none. log sha256: `5d3a887b09842e34ffb60412e948f329469b43c1c5f965784bda21912fff7b07`
- Base (`main` @ `9fc0bb18`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2193 pass / 0 fail / 0 skip. Failures: none. log sha256: `218edaf2f2c5dd4c28789db24c5354a55c082280437ab8ca9da3170271d0fd11`
- **Conclusion:** 0 new failures. The 1-test delta (2194 vs 2193) is the new BET-981 static guard itself.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
