### PR TITLE
refactor(renderer): one model per session — delete the per-mode model slot (BET-1038)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1092,7 +1092,7 @@ function Shell() {
           const sel: ModelSelection = { providerID, modelID };
           const apply = panelModelControl.current.get(sessionId);
           if (apply) apply(sel);
-          else writeSavedModel(sessionId, "build", sel);
+          else writeSavedModel(sessionId, sel);
         },
         renameSession: () => {
           // tmux is the source of truth; the existing refresh re-reads it.

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -69,7 +69,7 @@ import { isPlanAgent, planPageUrl } from "../shared/planMode.mjs";
 import { serverBase } from "./api/httpApi";
 import {
   appendPromptHistory,
-  copySavedModels,
+  copySavedModel,
   guessMime,
   mimeToInputMode,
   modelInputModes,
@@ -84,7 +84,6 @@ import {
   resolveActiveModel,
   type AgentMention,
   type Attachment,
-  type ModelMode,
   type ModelSelection,
   type SessionMode,
   type TaskContextValue,
@@ -415,14 +414,11 @@ export function ChatPanel({
 
   // ===== Per-session model override =====
   // Declared before useSseBus: the auth-banner providerID below derives from
-  // it. Initialized from the per-session localStorage override for the ACTIVE
-  // mode (per-mode since BET-950 — plan mode falls back to the build key when
-  // no plan key exists), falling back to the persisted global default (the
-  // same seed useSseBus's providerID used to recompute from readSavedModel on
-  // every render).
+  // it. Initialized from the per-session localStorage override for the session,
+  // falling back to the persisted global default (the same seed useSseBus's
+  // providerID used to recompute from readSavedModel on every render).
   const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
-    readSavedModel(sessionId, readPlanSaved(sessionId) ? "plan" : "build") ??
-    configDefaultModel ?? null,
+    readSavedModel(sessionId) ?? configDefaultModel ?? null,
   );
   // Active-model providerID for the auth-error banner (BET-316). Per-session
   // override wins over the persisted default; null if neither is set. Memoized
@@ -450,14 +446,7 @@ export function ChatPanel({
     const next = !planOn;
     setPlanOn(next);
     writePlanSaved(sessionId, next);
-    // Requirement 1 (BET-950): toggling re-reads the model for the mode we are
-    // entering so the composer's model chip visibly changes. Zero-config:
-    // readSavedModel's plan→build fallback means a first toggle to plan keeps
-    // the build model until the user picks one while in plan mode. The plan
-    // key is NOT written here — only on an explicit model pick.
-    const mode: ModelMode = next ? "plan" : "build";
-    setModelOverride(readSavedModel(sessionId, mode) ?? configDefaultModel ?? null);
-  }, [planOn, sessionId, configDefaultModel]);
+  }, [planOn, sessionId]);
   // Honesty sync from useSseBus: opencode's OWN agent switches (plan_enter /
   // plan_exit / agent.switched) drive this so the chip never lies about the
   // agent the next turn will run as. Also persists so a re-mount seeds right.
@@ -615,7 +604,7 @@ export function ChatPanel({
     const planOnStart = readPlanSaved(sessionId);
     setPlanOn(planOnStart);
     setModelOverride(
-      readSavedModel(sessionId, planOnStart ? "plan" : "build") ?? configDefaultModel ?? null,
+      readSavedModel(sessionId) ?? configDefaultModel ?? null,
     );
     // Seed plan mode from the session's own `agent` field when present (BET-949
     // §5): a session pre-set to plan OUTSIDE MantaUI would otherwise show the
@@ -630,9 +619,6 @@ export function ChatPanel({
           const planNow = isPlanAgent(agent);
           setPlanOn(planNow);
           writePlanSaved(sessionId, planNow);
-          setModelOverride(
-            readSavedModel(sessionId, planNow ? "plan" : "build") ?? configDefaultModel ?? null,
-          );
         }
       }).catch(() => { /* non-fatal — stored-key seed stands */ });
     }
@@ -1458,48 +1444,35 @@ export function ChatPanel({
   const commandsRef = useRef(commands);
   commandsRef.current = commands;
 
-  // If a saved model (in EITHER per-mode key) references one that isn't in the
-  // current list of connected models (common after switching providers or fixing
-  // listModels' source endpoint), clear it. Otherwise the server rejects the
-  // prompt with a not-found error and nothing reaches the transcript. Heals both
-  // keys (BET-950) so a stale model in the inactive mode's key is dropped too.
-  // Reads each mode's RAW key (not readSavedModel, whose plan→build fallback
-  // would mask which key actually held the stale value).
+  // If the saved model references one that isn't in the current list of
+  // connected models (common after switching providers or fixing listModels'
+  // source endpoint), clear it. Otherwise the server rejects the prompt with a
+  // not-found error and nothing reaches the transcript.
   useEffect(() => {
     if (!models) return;
-    const isStale = (sel: { providerID: string; modelID: string }) =>
-      !models.some((m) => m.providerID === sel.providerID && m.id === sel.modelID);
-    const heal = (mode: ModelMode) => {
-      let saved: ModelSelection | null = null;
-      try {
-        const raw = localStorage.getItem(modelKey(sessionId, mode));
-        if (raw) {
-          const p = JSON.parse(raw);
-          if (p && typeof p.providerID === "string" && typeof p.modelID === "string") {
-            saved = p as ModelSelection;
-          }
+    let saved: ModelSelection | null = null;
+    try {
+      const raw = localStorage.getItem(modelKey(sessionId));
+      if (raw) {
+        const p = JSON.parse(raw);
+        if (p && typeof p.providerID === "string" && typeof p.modelID === "string") {
+          saved = p as ModelSelection;
         }
-      } catch { /* non-JSON / disabled storage — nothing to heal */ }
-      if (!saved || !isStale(saved)) return;
-      writeSavedModel(sessionId, mode, null);
-      // Drop the active override when the cleared key is what's in play: the
-      // active mode's own key, or the build fallback a plan session is using.
-      const active: ModelMode = planOn ? "plan" : "build";
-      if (mode === active) setModelOverride(null);
-      else if (modelOverride && modelOverride.providerID === saved.providerID
-        && modelOverride.modelID === saved.modelID) setModelOverride(null);
-    };
-    heal("build");
-    heal("plan");
-  }, [models, modelOverride, planOn, sessionId]);
+      }
+    } catch { /* non-JSON / disabled storage — nothing to heal */ }
+    if (!saved) return;
+    const sel = saved;
+    if (models.some((m) => m.providerID === sel.providerID && m.id === sel.modelID)) return;
+    writeSavedModel(sessionId, null);
+    setModelOverride(null);
+  }, [models, sessionId]);
 
   const selectModel = useCallback(
     (m: ModelSelection | null) => {
-      const mode: ModelMode = planOn ? "plan" : "build";
       setModelOverride(m);
-      writeSavedModel(sessionId, mode, m);
+      writeSavedModel(sessionId, m);
     },
-    [sessionId, planOn],
+    [sessionId],
   );
 
   // App-control (BET-840/841): expose this panel's `selectModel` to App so the
@@ -1565,11 +1538,10 @@ export function ChatPanel({
         cwd: cwd ?? "",
         title: `${tmuxSession} / cleared`,
       });
-      // /clear carries BOTH per-mode model keys forward (BET-950) so the user
-      // doesn't re-pick after every clear. copySavedModels preserves their
-      // independence; plan mode state is carried on top.
+      // /clear carries the session's model forward so the user doesn't re-pick
+      // after every clear; plan mode state is carried on top.
       if (cleared?.newSessionId) {
-        copySavedModels(sessionId, cleared.newSessionId);
+        copySavedModel(sessionId, cleared.newSessionId);
         if (planOn) {
           writePlanSaved(cleared.newSessionId, true);
         }
@@ -2465,10 +2437,8 @@ export function ChatPanel({
   );
 
   // Delegate split control (BET-951).
-  // Level 3 of the model precedence — "same as current" means the BUILD model,
-  // not the plan model the composer chip may be showing while plan mode is on.
-  // Until per-mode models land there is only one model per session and this is
-  // simply the active model, but the lookup keeps working when they arrive.
+  // Level 3 of the model precedence — "same as current" means the session's one
+  // model (there is exactly one per session now).
   const sessionModel = useMemo<ModelSelection | null>(
     () =>
       modelOverride ??
@@ -2515,10 +2485,9 @@ export function ChatPanel({
     async (q: QuestionRequest, feedback: string) => {
       // Answer "Yes" so opencode switches to the build agent...
       await replyQuestion(q, [["Yes"]]);
-      // ...then re-send the plan text ourselves WITH the BUILD model. opencode's
-      // "Yes" path stamps the injected build turn with the model of the last
-      // user message — which, because MantaUI sends the model per prompt, is the
-      // PLAN model. That is exactly why this is a resubmit, not a toggle.
+      // ...then re-send the plan text ourselves with the user's feedback
+      // appended. This is a resubmit (not a toggle) so the feedback text lands
+      // in the build turn with the session's one model.
       setPlanOn(false);
       writePlanSaved(sessionId, false);
       try {

--- a/src/renderer/chatShared.test.ts
+++ b/src/renderer/chatShared.test.ts
@@ -18,7 +18,7 @@ import {
   writeSavedMode,
   readSavedModel,
   writeSavedModel,
-  copySavedModels,
+  copySavedModel,
   resolveLauncherFlags,
   readPromptHistory,
   appendPromptHistory,
@@ -255,93 +255,55 @@ describe("readSavedMode / writeSavedMode (BET-138)", () => {
    });
  });
 
-describe("readSavedModel / writeSavedModel per-mode (BET-950)", () => {
+describe("readSavedModel / writeSavedModel", () => {
   beforeEach(() => {
     localStorage.clear();
   });
-  const build = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
-  const plan = { providerID: "anthropic", modelID: "claude-opus-4-7" };
+  const sel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
 
-  it("build mode uses the original legacy key", () => {
-    writeSavedModel("sess-1", "build", build);
-    expect(localStorage.getItem("manta:chat:sess-1:model")).toBe(JSON.stringify(build));
-    expect(localStorage.getItem("manta:chat:sess-1:model:plan")).toBeNull();
+  it("writes then reads back the same selection", () => {
+    writeSavedModel("sess-1", sel);
+    expect(readSavedModel("sess-1")).toEqual(sel);
   });
 
-  it("plan mode uses its own key, leaving the build key untouched", () => {
-    writeSavedModel("sess-1", "build", build);
-    writeSavedModel("sess-1", "plan", plan);
-    expect(localStorage.getItem("manta:chat:sess-1:model")).toBe(JSON.stringify(build));
-    expect(localStorage.getItem("manta:chat:sess-1:model:plan")).toBe(JSON.stringify(plan));
-    expect(readSavedModel("sess-1", "build")).toEqual(build);
-    expect(readSavedModel("sess-1", "plan")).toEqual(plan);
+  it("writeSavedModel(sid, null) clears it; read returns null", () => {
+    writeSavedModel("sess-1", sel);
+    writeSavedModel("sess-1", null);
+    expect(readSavedModel("sess-1")).toBeNull();
+    expect(localStorage.getItem("manta:chat:sess-1:model")).toBeNull();
   });
 
-  it("plan key absent → returns the build model (zero-config fallback)", () => {
-    writeSavedModel("sess-1", "build", build);
-    expect(readSavedModel("sess-1", "plan")).toEqual(build);
+  it("unset session reads null", () => {
+    expect(readSavedModel("sess-1")).toBeNull();
   });
 
-  it("both keys absent → null for both modes", () => {
-    expect(readSavedModel("sess-1", "build")).toBeNull();
-    expect(readSavedModel("sess-1", "plan")).toBeNull();
+  it("a session's model is isolated from another session id", () => {
+    writeSavedModel("sess-1", sel);
+    expect(readSavedModel("sess-2")).toBeNull();
   });
 
-  it("writing an explicit plan pick leaves the build key untouched", () => {
-    writeSavedModel("sess-1", "build", build);
-    writeSavedModel("sess-1", "plan", plan);
-    expect(readSavedModel("sess-1", "build")).toEqual(build);
-    expect(readSavedModel("sess-1", "plan")).toEqual(plan);
-  });
-
-  it("writing null clears only that mode's key", () => {
-    writeSavedModel("sess-1", "build", build);
-    writeSavedModel("sess-1", "plan", plan);
-    writeSavedModel("sess-1", "plan", null);
-    expect(readSavedModel("sess-1", "plan")).toEqual(build); // falls back to build
-    expect(localStorage.getItem("manta:chat:sess-1:model:plan")).toBeNull();
-    expect(readSavedModel("sess-1", "build")).toEqual(build);
-  });
-
-  it("is scoped per session id", () => {
-    writeSavedModel("sess-1", "plan", plan);
-    expect(readSavedModel("sess-2", "plan")).toBeNull();
-  });
-
-  it("falls back to null on storage error for a present build key", () => {
-    writeSavedModel("sess-1", "build", build);
-    const orig = Storage.prototype.getItem;
-    Storage.prototype.getItem = () => {
-      throw new Error("storage disabled");
-    };
-    try {
-      expect(readSavedModel("sess-1", "build")).toBeNull();
-    } finally {
-      Storage.prototype.getItem = orig;
-    }
+  it("malformed (non-JSON) stored value reads null and does not throw", () => {
+    localStorage.setItem("manta:chat:sess-1:model", "{not json");
+    expect(() => readSavedModel("sess-1")).not.toThrow();
+    expect(readSavedModel("sess-1")).toBeNull();
   });
 });
 
-describe("copySavedModels /clear carry-forward (BET-950)", () => {
+describe("copySavedModel /clear carry-forward", () => {
   beforeEach(() => {
     localStorage.clear();
   });
-  const build = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
-  const plan = { providerID: "anthropic", modelID: "claude-opus-4-7" };
+  const sel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
 
-  it("carries both keys when both are present", () => {
-    writeSavedModel("sess-1", "build", build);
-    writeSavedModel("sess-1", "plan", plan);
-    copySavedModels("sess-1", "sess-2");
-    expect(readSavedModel("sess-2", "build")).toEqual(build);
-    expect(readSavedModel("sess-2", "plan")).toEqual(plan);
+  it("copies the source session's model to the destination session id", () => {
+    writeSavedModel("sess-1", sel);
+    copySavedModel("sess-1", "sess-2");
+    expect(readSavedModel("sess-2")).toEqual(sel);
   });
 
-  it("does not stamp a build model into the destination plan key when the source plan key is absent", () => {
-    writeSavedModel("sess-1", "build", build);
-    copySavedModels("sess-1", "sess-2");
-    expect(readSavedModel("sess-2", "build")).toEqual(build);
-    expect(localStorage.getItem("manta:chat:sess-2:model:plan")).toBeNull();
+  it("is a no-op when the source has no stored model (destination stays null)", () => {
+    copySavedModel("sess-1", "sess-2");
+    expect(readSavedModel("sess-2")).toBeNull();
   });
 });
 

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -250,27 +250,14 @@ export function guessMime(filename: string): string {
 // means "let opencode pick its default" — matches the prompt_async fallback.
 export type ModelSelection = { providerID: string; modelID: string; variant?: string };
 
-// Per-mode storage (BET-950). "build" uses the original `…:model` key so every
-// existing session keeps its model and nothing migrates; "plan" gets its own
-// key (`…:model:plan`), same JSON shape. Zero-config: readSavedModel falls back
-// to the build key when the plan key is absent, so plan mode uses the build
-// model until the user picks one while in plan mode.
-export type ModelMode = "build" | "plan";
-
-export function modelKey(sessionId: string, mode: ModelMode): string {
-  return mode === "plan"
-    ? `manta:chat:${sessionId}:model:plan`
-    : `manta:chat:${sessionId}:model`;
+export function modelKey(sessionId: string): string {
+  return `manta:chat:${sessionId}:model`;
 }
 
-export function readSavedModel(sessionId: string, mode: ModelMode): ModelSelection | null {
+export function readSavedModel(sessionId: string): ModelSelection | null {
   try {
-    const raw = localStorage.getItem(modelKey(sessionId, mode));
-    if (!raw) {
-      // Zero-config until used: plan mode with no plan key uses the build model.
-      if (mode === "plan") return readSavedModel(sessionId, "build");
-      return null;
-    }
+    const raw = localStorage.getItem(modelKey(sessionId));
+    if (!raw) return null;
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed.providerID === "string" && typeof parsed.modelID === "string") {
       return parsed as ModelSelection;
@@ -281,28 +268,21 @@ export function readSavedModel(sessionId: string, mode: ModelMode): ModelSelecti
   }
 }
 
-export function writeSavedModel(sessionId: string, mode: ModelMode, m: ModelSelection | null): void {
+export function writeSavedModel(sessionId: string, m: ModelSelection | null): void {
   try {
-    if (m) localStorage.setItem(modelKey(sessionId, mode), JSON.stringify(m));
-    else localStorage.removeItem(modelKey(sessionId, mode));
+    if (m) localStorage.setItem(modelKey(sessionId), JSON.stringify(m));
+    else localStorage.removeItem(modelKey(sessionId));
   } catch { /* quota / disabled storage */ }
 }
 
-// /clear carry-forward (BET-950): copy BOTH per-mode model keys from one
-// session id to another, preserving their independence. Copies the RAW value of
-// each key (not readSavedModel, whose plan→build fallback would stamp the build
-// model into a plan key that was never explicitly written), and leaves the
-// destination plan key absent when the source plan key is absent.
-export function copySavedModels(fromSessionId: string, toSessionId: string): void {
-  for (const mode of ["build", "plan"] as const) {
-    let raw: string | null = null;
-    try { raw = localStorage.getItem(modelKey(fromSessionId, mode)); } catch { continue; }
-    if (raw === null) continue;
-    try {
-      if (raw) localStorage.setItem(modelKey(toSessionId, mode), raw);
-      else localStorage.removeItem(modelKey(toSessionId, mode));
-    } catch { /* quota / disabled storage */ }
-  }
+// /clear carry-forward: copy the session's model to the new session id so the
+// user doesn't have to re-pick after every clear. Copies the RAW stored value.
+export function copySavedModel(fromSessionId: string, toSessionId: string): void {
+  try {
+    const raw = localStorage.getItem(modelKey(fromSessionId));
+    if (raw === null) return;
+    localStorage.setItem(modelKey(toSessionId), raw);
+  } catch { /* quota / disabled storage */ }
 }
 
 // Per-session plan-mode override (BET-949). Deliberately its OWN storage key —

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2283,11 +2283,10 @@ export function extractPlanData(
 //      whatever happened to be current the first time.
 //   3. The session's BUILD-side model.
 //
-// "Same as current" means the BUILD model — NOT whatever the composer chip is
-// showing (plan mode may be on, so the chip could show the plan model).
+// "Same as current" means the session's one model — there is exactly one model
+// per session now, so (3) is simply that model.
 // Sending a background job to the planning model is the bug this order exists
-// to prevent. Until per-mode models land there is only one model per session
-// and (3) is simply that model; the lookup keeps working when they arrive.
+// to prevent.
 //
 // If a remembered model is no longer selectable (deactivated in Settings or
 // gone from the catalog), fall through to (3) silently — never render a dead


### PR DESCRIPTION
**Files changed:** 5 files. `src/renderer/chatShared.tsx`, `src/renderer/ChatPanel.tsx`, `src/renderer/App.tsx`, `src/renderer/chatShared.test.ts`, `src/renderer/chatUtils.ts`.

Deletes the per-mode model slot (BET-950) — one model per session under `manta:chat:<sid>:model`. Removed `ModelMode`, the `mode` parameter, the `…:model:plan` key, renamed `copySavedModels`→`copySavedModel`, and rewrote the stale build/plan comments.

**Verification results:**
- PR branch (`multica/BET-1038-delete-per-mode-model` @ `02f2a13c`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2193 pass / 0 fail / 0 skip. Failures: none. log sha256: `20308a7f6db631c0d5df94835172075c801c381b65ab196f451c46de2a7c1f0b`
- Base (`main` @ `9fc0bb18`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2188 pass / 0 fail / 0 skip. Failures: none. log sha256: `1536c00ecf3a0eeb02c54a76545dfa72de602375941072401f6dfd0e0ae1e6ba`
- **Conclusion:** 0 new test failures (5 new cases added, all pass); typecheck byte-identical between branches. Trap grep `model:plan\|ModelMode\|copySavedModels` returns nothing in `src/`. Net line count −90.

**Base: origin/main @ 9fc0bb18**
