### PR TITLE
refactor(ios): fold context meter into header below branch, pad it, show only >0% (BET-1022)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -243,7 +243,6 @@ private struct ChatScreenContent: View {
             .toolbarBackgroundVisibility(.visible, for: .navigationBar)
             .toolbarBackground(tokens.canvas, for: .navigationBar)
             .toolbar {
-                ToolbarItem(placement: .subtitle) { subtitleChip }
                 ToolbarItem(placement: .primaryAction) {
                     Button { showOverflow = true } label: {
                         Image(systemName: "ellipsis")
@@ -787,7 +786,7 @@ private struct ChatScreenContent: View {
         // overlay. It renders whenever the reading is known (see `contextStrip`)
         // and animates in above the transcript.
         .safeAreaBar(edge: .top) {
-            contextStrip
+            sessionHeaderBlock
         }
         // A tap on the transcript lowers the keyboard. (TiledView handles the
         // scroll-driven interactive keyboard dismiss itself.)
@@ -852,6 +851,27 @@ private struct ChatScreenContent: View {
         return tokens.tx4
     }
 
+    /// The header block mounted via `.safeAreaBar(edge: .top)` below the system
+    /// navigation bar: a branch row (when a branch exists) stacked over a
+    /// full-width context row. Its own background is fully opaque `tokens.canvas`
+    /// so the bar's default material is not visible — that removes the seam
+    /// between the solid nav bar and the block. The branch row drops out
+    /// entirely when there is no branch (`subtitleChip` renders nothing then).
+    @ViewBuilder
+    private var sessionHeaderBlock: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp1) {
+            subtitleChip
+            contextStrip
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.bottom, Metrics.spacing.sp2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tokens.canvas)
+        .overlay(alignment: .bottom) {
+            Rectangle().fill(tokens.borderSubtle).frame(height: 1)
+        }
+    }
+
     /// Full-width, one-tap strip directly under the navigation bar: the word
     /// "Context", a linear meter filling the remaining width, the percentage,
     /// a chevron. Always rendered for a KNOWN reading, because a meter that
@@ -864,7 +884,7 @@ private struct ChatScreenContent: View {
     /// and VoiceOver announces it so.
     @ViewBuilder
     private var contextStrip: some View {
-        if let pct = contextPct {
+        if let pct = contextPct, UsageMeters.shouldShowContext(pct: pct) {
             Button { showContextSheet = true } label: {
                 HStack(spacing: Metrics.spacing.sp2) {
                     Text("Context")
@@ -907,7 +927,7 @@ private struct ChatScreenContent: View {
         // The strip only shows for a known reading, but the context can go
         // unknown in the window between the tap and the sheet presenting —
         // never fabricate a 0% sheet for "we don't know".
-        if let ctx = store.context {
+        if let ctx = store.context, UsageMeters.shouldShowContext(pct: ctx.pct) {
             ContextSheet(
                 context: ctx,
                 cache: store.cache,
@@ -1103,18 +1123,10 @@ struct ChatSubagentScreen: View {
 
     var body: some View {
         content
-            .navigationTitle(title)
+            .navigationTitle(subtitle.isEmpty ? title : "\(title) · \(subtitle)")
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackgroundVisibility(.visible, for: .navigationBar)
             .toolbarBackground(tokens.canvas, for: .navigationBar)
-            .toolbar {
-                ToolbarItem(placement: .subtitle) {
-                    Text(subtitle)
-                        .font(.manta(size: Metrics.type.xs, weight: .semibold))
-                        .foregroundColor(tokens.tx4)
-                        .lineLimit(1)
-                }
-            }
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("subagent-scene")
     }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -446,7 +446,7 @@ final class ChatSessionStore: ObservableObject {
         // meter for an idle conversation on open, when no such frame has
         // arrived yet.
         context = s.context ?? transcriptContext
-        cache = s.cache
+        if let c = s.cache { cache = c }
         truncation = s.truncation
         sessionError = s.sessionError
         todos = s.todos

--- a/mobile/native/MantaUI/UsageMeters.swift
+++ b/mobile/native/MantaUI/UsageMeters.swift
@@ -36,6 +36,16 @@ enum UsageMeters {
         return .ok
     }
 
+    /// Whether the context meter should render at all.
+    ///
+    /// Above zero only: a fresh session with no billed turn reports 0% and a
+    /// "Context 0%" row is noise. `nil` (unknown) and non-finite values never
+    /// render.
+    static func shouldShowContext(pct: Double?) -> Bool {
+        guard let pct, pct.isFinite else { return false }
+        return pct > 0
+    }
+
     /// The 5-hour session window across all snapshots, or nil. `nil` is the
     /// signal that hides the usage dot — e.g. a snapshot set
     /// holding only a weekly window.

--- a/mobile/native/MantaUITests/UsageMetersTests.swift
+++ b/mobile/native/MantaUITests/UsageMetersTests.swift
@@ -212,4 +212,18 @@ final class UsageMetersTests: XCTestCase {
         XCTAssertTrue(MeterRing.isFull(100))
         XCTAssertTrue(MeterRing.isFull(120))
     }
+
+    // MARK: - shouldShowContext (BET-1022)
+
+    /// A fresh session with no billed turn reports 0%; a "Context 0%" row is
+    /// noise and must not render. `nil` (unknown) and non-finite values never
+    /// render either. Anything above zero renders.
+    func testShouldShowContextGate() {
+        XCTAssertFalse(UsageMeters.shouldShowContext(pct: nil))
+        XCTAssertFalse(UsageMeters.shouldShowContext(pct: 0))
+        XCTAssertFalse(UsageMeters.shouldShowContext(pct: Double.nan))
+        XCTAssertFalse(UsageMeters.shouldShowContext(pct: Double.infinity))
+        XCTAssertTrue(UsageMeters.shouldShowContext(pct: 0.4))
+        XCTAssertTrue(UsageMeters.shouldShowContext(pct: 100))
+    }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-1022-context-meter-header`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1022.