### PR TITLE
fix(renderer): a reset usage window contributes nothing — kill red 100% ring and false limit toast (BET-1039)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -445,7 +445,7 @@ function Shell() {
       // Seed the escalation baseline from the SAME payload that primes the dial,
       // so the first live update after a launch does not re-fire for a window
       // that was already over the threshold.
-      usageLevelsRef.current = buildUsageLevels(list, usageLevelsRef.current);
+      usageLevelsRef.current = buildUsageLevels(list);
     } catch {
       // Older box or a transport blip — leave the slice as-is; UsageDial's own
       // null-snapshot path already renders nothing.
@@ -779,7 +779,7 @@ function Shell() {
       }
       // Write back the CURRENT levels so a holding level doesn't re-fire and a
       // drop (after reset) re-arms the key for the next crossing.
-      usageLevelsRef.current = buildUsageLevels(next, usageLevelsRef.current);
+      usageLevelsRef.current = buildUsageLevels(next);
     });
     return off;
   }, [apiGeneration, scheduleAtReset, pushAppToastStore, dismissAppToastStore]);

--- a/src/renderer/UsageDial.tsx
+++ b/src/renderer/UsageDial.tsx
@@ -20,6 +20,7 @@ import {
   selectUsageSnapshot,
   usageDialState,
   usageStale,
+  usageTone,
   type UsageDialTone,
 } from "./chatUtils";
 import { useStore } from "./store";
@@ -49,22 +50,14 @@ export function providerLabel(provider: string): string {
   return PROVIDER_LABELS[provider] ?? provider.charAt(0).toUpperCase() + provider.slice(1);
 }
 
-// Ring colour per threshold. Identical to windowFillColor's scale on purpose:
-// the dial is a summary of the popover's rows, so a user glancing at the ring
-// and then opening the popover must not see two different colours for the same
-// number. (An earlier spec kept the ring off --ok below 70 so it read as
-// "pay attention only"; that produced a grey ring above a green bar.)
+// The ONE usage colour ladder — the ring and every popover row go through it,
+// so a user glancing at the ring and then opening the popover can never see
+// two different colours for the same number. (An earlier spec kept the ring
+// off --ok below 70 so it read as "pay attention only"; that produced a grey
+// ring above a green bar.)
 function toneRingColor(tone: UsageDialTone): string {
   if (tone === "over" || tone === "danger") return cssVar("--danger");
   if (tone === "warn") return cssVar("--warn");
-  return cssVar("--ok");
-}
-
-// Popover fill colour per window threshold — same three thresholds as the
-// dial, and both return --ok below 70, so the ring and the rows agree.
-function windowFillColor(pct: number): string {
-  if (pct >= 90) return cssVar("--danger");
-  if (pct >= 70) return cssVar("--warn");
   return cssVar("--ok");
 }
 
@@ -219,7 +212,7 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
 // daily one) renders with zero changes here.
 function UsageWindowRow({ usageWindow: w, nowMs }: { usageWindow: UsageWindow; nowMs: number }) {
   const pctClamped = Math.max(0, Math.min(100, w.pct));
-  const fill = windowFillColor(pctClamped);
+  const fill = toneRingColor(usageTone(pctClamped));
   const value =
     w.used != null && w.limit != null
       ? `${w.used.toLocaleString()} / ${w.limit.toLocaleString()} · ${pctClamped}%`

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3598,6 +3598,37 @@ describe("usageDialState", () => {
     expect(usageDialState(null, true).visible).toBe(false);
     expect(usageDialState(undefined, true).visible).toBe(false);
   });
+
+  it("every window stale hides the dial even with always-show on", () => {
+    const snap = usageSnapshot({
+      windows: [
+        { kind: "session", label: "Session (5h)", pct: 100, resetsAt: 100, stale: true },
+        { kind: "weekly", label: "Weekly", pct: 100, resetsAt: 100, stale: true },
+      ],
+    });
+    const state = usageDialState(snap, true);
+    expect(state.visible).toBe(false);
+  });
+
+  it("a stale session yields to a live weekly, which becomes the primary", () => {
+    const snap = usageSnapshot({
+      windows: [
+        { kind: "session", label: "Session (5h)", pct: 100, resetsAt: 100, stale: true },
+        { kind: "weekly", label: "Weekly", pct: 95 },
+      ],
+    });
+    const state = usageDialState(snap, false);
+    expect(state.visible).toBe(true);
+    expect(state.pct).toBe(95);
+    expect(state.window?.kind).toBe("weekly");
+  });
+
+  it("a window with no stale flag behaves exactly as before (undefined is not stale)", () => {
+    const snap = usageSnapshot({ windows: [{ kind: "session", label: "s", pct: 72 }] });
+    const state = usageDialState(snap, false);
+    expect(state.visible).toBe(true);
+    expect(state.pct).toBe(72);
+  });
 });
 
 describe("formatTimerDuration", () => {

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2911,7 +2911,7 @@ export type UsageDialState = {
   window: UsageWindow | null;
 };
 
-function usageTone(pct: number): UsageDialTone {
+export function usageTone(pct: number): UsageDialTone {
   if (pct >= 100) return "over";
   if (pct >= 90) return "danger";
   if (pct >= 70) return "warn";
@@ -2932,7 +2932,13 @@ export function usageDialState(
   snapshot: UsageSnapshot | null | undefined,
   alwaysShow: boolean,
 ): UsageDialState {
-  const windows = snapshot?.windows ?? [];
+  // A stale window is reporting the number the PREVIOUS window finished on, so
+  // it contributes nothing: not the value, not the colour, and not the
+  // visibility decision. Dropping it here reuses every path below — if it was
+  // the only window the existing zero-window early return hides the dial, and
+  // if a live window remains that window becomes the primary. This is the same
+  // rule shouldFireUsageAlert applies to the alert path.
+  const windows = (snapshot?.windows ?? []).filter((w) => !w.stale);
   if (windows.length === 0) {
     return { visible: false, pct: 0, tone: "under", window: null };
   }

--- a/src/renderer/usageEscalation.test.ts
+++ b/src/renderer/usageEscalation.test.ts
@@ -59,16 +59,6 @@ describe("buildUsageLevels", () => {
     expect(buildUsageLevels(undefined)).toEqual({});
     expect(buildUsageLevels([])).toEqual({});
   });
-
-  it("carries a stale window's previous level forward and does not read its pct", () => {
-    const prev = { "claude:session": "limit" as const };
-    const staleLow = [snap("claude", [{ kind: "session", label: "S", pct: 0, stale: true }])];
-    const levels = buildUsageLevels(staleLow, prev);
-    expect(levels["claude:session"]).toBe("limit");
-    // A fresh window still reads its pct — the stale carry is not a blanket hold.
-    const freshLow = [snap("claude", [{ kind: "session", label: "S", pct: 0 }])];
-    expect(buildUsageLevels(freshLow, prev)["claude:session"]).toBe("none");
-  });
 });
 
 describe("shouldFireUsageAlert — fire-once semantics", () => {
@@ -160,16 +150,16 @@ describe("shouldFireUsageAlert — fire-once semantics", () => {
     let fired = shouldFireUsageAlert(prev, atLimit);
     expect(fired).toHaveLength(1);
     expect(fired[0].level).toBe("limit");
-    prev = buildUsageLevels(atLimit, prev); // { "claude:session": "limit" }
+    prev = buildUsageLevels(atLimit); // { "claude:session": "limit" }
 
     const stale = [snap("claude", [{ kind: "session", label: "S", pct: 100, stale: true }])];
     expect(shouldFireUsageAlert(prev, stale)).toHaveLength(0);
-    prev = buildUsageLevels(stale, prev);
+    prev = buildUsageLevels(stale);
     expect(prev["claude:session"]).toBe("limit");
 
     const reset = [snap("claude", [{ kind: "session", label: "S", pct: 0 }])];
     expect(shouldFireUsageAlert(prev, reset)).toHaveLength(0);
-    prev = buildUsageLevels(reset, prev);
+    prev = buildUsageLevels(reset);
     expect(prev["claude:session"]).toBe("none");
 
     fired = shouldFireUsageAlert(prev, atLimit);
@@ -198,6 +188,53 @@ describe("shouldFireUsageAlert — fire-once semantics", () => {
     const fired = shouldFireUsageAlert(prev, reCross);
     expect(fired).toHaveLength(1);
     expect(fired[0].provider).toBe("codex");
+  });
+});
+
+describe("reset boundary", () => {
+  const snap = (pct: number, resetsAt: number, stale?: boolean) =>
+    [
+      {
+        provider: "claude",
+        providerIDs: ["anthropic"],
+        fetchedAt: 0,
+        windows: [
+          {
+            kind: "session",
+            label: "Session (5h)",
+            pct,
+            resetsAt,
+            ...(stale ? { stale: true } : {}),
+          },
+        ],
+      },
+    ] as any;
+
+  it("app open across the boundary stays silent", () => {
+    let prev = buildUsageLevels(snap(100, 2000));
+    expect(shouldFireUsageAlert(prev, snap(100, 2000, true))).toEqual([]);
+    prev = buildUsageLevels(snap(100, 2000, true));
+    expect(shouldFireUsageAlert(prev, snap(100, 20000))).toEqual([]);
+  });
+
+  it("REGRESSION: cold start during the stale window, counts still high, stays silent", () => {
+    // The rolling 5h window does not drop to zero at its reset instant, so this
+    // is the ordinary case, not a corner case. Before the fix this fired "limit".
+    const prev = buildUsageLevels(snap(100, 2000, true));
+    expect(shouldFireUsageAlert(prev, snap(100, 20000))).toEqual([]);
+  });
+
+  it("cold start during the stale window, counts truly reset, stays silent", () => {
+    const prev = buildUsageLevels(snap(100, 2000, true));
+    expect(shouldFireUsageAlert(prev, snap(2, 20000))).toEqual([]);
+  });
+
+  it("still re-arms: after a real reset a later climb fires exactly once", () => {
+    let prev = buildUsageLevels(snap(100, 2000));
+    prev = buildUsageLevels(snap(2, 20000));
+    expect(shouldFireUsageAlert(prev, snap(100, 20000)).map((x) => x.level)).toEqual(["limit"]);
+    prev = buildUsageLevels(snap(100, 20000));
+    expect(shouldFireUsageAlert(prev, snap(100, 20000))).toEqual([]);
   });
 });
 

--- a/src/renderer/usageEscalation.ts
+++ b/src/renderer/usageEscalation.ts
@@ -13,9 +13,9 @@
 // by the subscriber; this module is pure.
 //
 // Stale rule: a window whose reset instant has already passed (`stale: true`)
-// is reporting the OLD window's numbers. It must never raise an alert — the
-// key carries its previous level forward instead of re-arming (a re-arm at the
-// boundary is precisely what lets the same limit fire twice across a reset).
+// is reporting the OLD window's numbers. It must never RAISE an alert — see
+// the guard in shouldFireUsageAlert. It is deliberately NOT special-cased when
+// computing the baseline; see buildUsageLevels.
 //
 // There is deliberately no React and no provider-name branching here beyond
 // the exact strings the spec dictates.
@@ -39,19 +39,22 @@ export function usageAlertLevel(pct: number): UsageAlertLevel {
 /** The current alert level for every present `provider:window.kind` key.
  *  Windows absent from the snapshots are absent from the record — the
  *  subscriber writes this back into its prev map after each event, which is
- *  what re-arms a key once a window resets and drops below the threshold. */
+ *  what re-arms a key once a window resets and drops below the threshold.
+ *
+ *  A stale window is NOT special-cased here on purpose. Its `pct` is the
+ *  number the window that just ended finished on, so reading it verbatim
+ *  records the level we would already have alerted at — which is exactly the
+ *  fire-once baseline we want, and it is correct on a COLD START too. An
+ *  earlier version defaulted a stale window to "none" when there was no prior
+ *  level, which armed the alert at zero while usage was really at 100% and
+ *  made the next update look like a fresh climb into the limit. */
 export function buildUsageLevels(
   snapshots: UsageSnapshot[] | null | undefined,
-  prev: Record<string, UsageAlertLevel> = {},
 ): Record<string, UsageAlertLevel> {
   const out: Record<string, UsageAlertLevel> = {};
   for (const snap of snapshots ?? []) {
     for (const win of snap.windows ?? []) {
-      const key = `${snap.provider}:${win.kind}`;
-      // A stale window's pct belongs to the window that just ended. Carrying
-      // the level forward keeps fire-once intact across the boundary: the key
-      // neither re-arms (which would re-fire the same limit) nor disappears.
-      out[key] = win.stale ? (prev[key] ?? "none") : usageAlertLevel(win.pct);
+      out[`${snap.provider}:${win.kind}`] = usageAlertLevel(win.pct);
     }
   }
   return out;


### PR DESCRIPTION
Opened automatically for `multica/BET-1039-stale-window-contributes-nothing`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1039.