### PR TITLE
refactor(ios): remember plan and build models separately, seed plan mode from the box (BET-1025)

### DIFF
--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -54,9 +54,10 @@ final class ChatModelStore: ObservableObject {
         self.sessionId = sessionId
         self.catalog = catalog
         self.api = api
-        self.override = Self.loadOverride(for: sessionId)
+        let planOn = UserDefaults.standard.bool(forKey: Self.planKey(for: sessionId))
+        self.planOn = planOn
+        self.override = Self.loadOverride(for: sessionId, mode: planOn ? .plan : .build)
         self.variant = UserDefaults.standard.string(forKey: Self.variantKey(for: sessionId))
-        self.planOn = UserDefaults.standard.bool(forKey: Self.planKey(for: sessionId))
 
         // Seed + mirror the shared catalog so the box-wide list and default are
         // published here (keeps every existing caller reading
@@ -78,9 +79,24 @@ final class ChatModelStore: ObservableObject {
         loaded = catalog.loaded
     }
 
-    /// The UserDefaults key mirroring the desktop's per-session model key.
-    static func storageKey(for sessionId: String) -> String {
-        "manta:chat:\(sessionId):model"
+    /// Which model a session remembers. Plan and build are remembered
+    /// separately so switching modes restores the model the user last chose
+    /// for that mode — and so "Build here" has a build model to return to.
+    /// Mirrors the desktop keys in src/renderer/chatShared.tsx exactly.
+    enum ModelMode: String {
+        case build
+        case plan
+    }
+
+    /// The UserDefaults key mirroring the desktop's per-session model key —
+    /// one per mode. `build` uses the original `…:model` key so every
+    /// existing session keeps its model and nothing migrates; `plan` gets its
+    /// own key (`…:model:plan`), same stored shape.
+    static func storageKey(for sessionId: String, mode: ModelMode) -> String {
+        switch mode {
+        case .build: return "manta:chat:\(sessionId):model"
+        case .plan:  return "manta:chat:\(sessionId):model:plan"
+        }
     }
 
     static func variantKey(for sessionId: String) -> String {
@@ -112,10 +128,22 @@ final class ChatModelStore: ObservableObject {
     /// before a clear swaps the id, so the rebuilt store for the new session
     /// picks up the same model the user had chosen — matching the desktop,
     /// which copies the override into the new session's key on /clear.
+    ///
+    /// Copies BOTH per-mode model keys (mirroring the desktop's
+    /// `copySavedModels`), preserving their independence: the RAW stored value
+    /// of each key is copied — not `loadOverride`, whose plan→build fallback
+    /// would stamp the build model into a plan key that was never explicitly
+    /// written — and a plan key absent on the source stays absent on the new
+    /// session. The old session's keys are left alone.
     func rebind(to newSessionId: String) {
         guard newSessionId != sessionId else { return }
-        if let override {
-            UserDefaults.standard.set(ChatModel.encode(override), forKey: Self.storageKey(for: newSessionId))
+        let defaults = UserDefaults.standard
+        for mode in [ModelMode.build, .plan] {
+            let fromKey = Self.storageKey(for: sessionId, mode: mode)
+            let toKey = Self.storageKey(for: newSessionId, mode: mode)
+            if let raw = defaults.string(forKey: fromKey) {
+                defaults.set(raw, forKey: toKey)
+            }
         }
         if let variant, !variant.isEmpty {
             UserDefaults.standard.set(variant, forKey: Self.variantKey(for: newSessionId))
@@ -136,16 +164,23 @@ final class ChatModelStore: ObservableObject {
         return SendPromptInput.Model(providerID: active.providerID, modelID: active.modelID, variant: variant)
     }
 
-    /// Set (or clear, with nil) the per-session override, persisting it. A
-    /// model change drops the effort variant: the levels one model offers mean
-    /// nothing on another, and most models offer none at all.
+    /// The mode the session is currently in — drives which per-mode key the
+    /// model selection reads and writes. Plan builds on the plan key; build
+    /// (and the default) use the build key.
+    var mode: ModelMode { planOn ? .plan : .build }
+
+    /// Set (or clear, with nil) the per-session override, persisting it to the
+    /// CURRENT mode's key. A model change drops the effort variant: the levels
+    /// one model offers mean nothing on another, and most models offer none at
+    /// all.
     func setOverride(_ id: OpencodeModelID?) {
         let modelChanged = id != override
         override = id
+        let key = Self.storageKey(for: sessionId, mode: mode)
         if let id {
-            UserDefaults.standard.set(ChatModel.encode(id), forKey: Self.storageKey(for: sessionId))
+            UserDefaults.standard.set(ChatModel.encode(id), forKey: key)
         } else {
-            UserDefaults.standard.removeObject(forKey: Self.storageKey(for: sessionId))
+            UserDefaults.standard.removeObject(forKey: key)
         }
         if modelChanged { setVariant(nil) }
     }
@@ -236,14 +271,39 @@ final class ChatModelStore: ObservableObject {
         ChatModel.planToggle(agents: agents, on: planOn)
     }
 
-    /// Flip plan mode for this session, persisting the boolean.
+    /// Flip plan mode for this session, persisting the boolean. When the mode
+    /// actually changes, the composer's active model becomes the mode being
+    /// entered's remembered model (mirroring `ChatPanel.tsx`'s togglePlan):
+    /// reading plan pulls the plan key, falling back to build; reading build
+    /// never consults the plan key. The model key is NOT written here — only
+    /// on an explicit model pick.
     func setPlan(_ on: Bool) {
+        let modeChanged = on != planOn
         planOn = on
         UserDefaults.standard.set(on, forKey: Self.planKey(for: sessionId))
+        guard modeChanged else { return }
+        let remembered = Self.loadOverride(for: sessionId, mode: mode)
+        if remembered != override {
+            override = remembered
+            setVariant(nil)
+        }
     }
 
-    static func loadOverride(for sessionId: String) -> OpencodeModelID? {
-        guard let raw = UserDefaults.standard.string(forKey: storageKey(for: sessionId)) else { return nil }
-        return ChatModel.decode(raw)
+    /// The remembered per-session model for a mode, or nil when the session
+    /// has none (the server default applies). Plan reads the plan key first,
+    /// falling back to the build key when the plan key is absent — that is the
+    /// desktop's asymmetric rule and is what makes a first toggle to plan keep
+    /// the build model until the user picks one while in plan mode. Build never
+    /// falls back to plan. A present-but-malformed value counts as absent for
+    /// the purpose of the fallback.
+    static func loadOverride(for sessionId: String, mode: ModelMode) -> OpencodeModelID? {
+        let key = storageKey(for: sessionId, mode: mode)
+        if let raw = UserDefaults.standard.string(forKey: key), let decoded = ChatModel.decode(raw) {
+            return decoded
+        }
+        if mode == .plan, let build = loadOverride(for: sessionId, mode: .build) {
+            return build
+        }
+        return nil
     }
 }

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -258,6 +258,7 @@ private struct ChatScreenContent: View {
                 store.start()
                 modelStore.load()
                 modelStore.loadAgentsIfNeeded()
+                seedPlanModeFromBox()
                 Task { await settingsStore.load() }
                 usageStore.start()
                 MantaPushRouter.shared.visibleSessionID = store.sessionId
@@ -545,6 +546,21 @@ private struct ChatScreenContent: View {
         let api = MantaAPIClient.live()
         if let jobs = try? await api.listSchedules(sessionId: store.sessionId) {
             scheduleCount = jobs.count
+        }
+    }
+
+    /// Seed plan mode from opencode's own session agent (the desktop's
+    /// BET-949 §5 behaviour). A session pre-set to plan OUTSIDE this device is
+    /// only discoverable here — its stored `planOn` key can't know, so the chip
+    /// would otherwise read off until some unrelated event happened to arrive.
+    /// Non-fatal: on failure or absence the stored value is left alone and no
+    /// error is surfaced. `setPlan` also re-reads the model for the mode being
+    /// entered, so the composer shows that mode's remembered model.
+    private func seedPlanModeFromBox() {
+        Task {
+            guard let agent = try? await MantaAPIClient.live().sessionAgent(sessionId: store.sessionId) else { return }
+            let planNow = agent == "plan"
+            modelStore.setPlan(planNow)
         }
     }
 

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -296,6 +296,15 @@ final class MantaAPIClient: Sendable {
         try await call("opencode:agents", args: [], as: [OpencodeAgent].self) ?? []
     }
 
+    /// `opencode:session-agent` — the agent opencode currently has attached to
+    /// this session ("plan", "build", …). Authoritative: a session put into
+    /// plan mode outside this device is only discoverable this way. Nil when
+    /// absent / unknown / the box erred — failure is non-fatal (the caller
+    /// keeps its stored value).
+    func sessionAgent(sessionId: String) async throws -> String? {
+        try await call("opencode:session-agent", args: [sessionId], as: String.self)
+    }
+
     /// `opencode:compact-session` — free context for the voice `compact` action.
     func compactSession(sessionId: String) async throws {
         _ = try await callVoid("opencode:compact-session", args: [sessionId])

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -440,3 +440,130 @@ final class ModelRecentsTests: XCTestCase {
         }
     }
 }
+
+// ===========================================================================
+// BET-1025 — ChatModelStore per-mode model keys. Plan and build are remembered
+// separately (desktop: `manta:chat:<sid>:model` / `…:model:plan`), plan falls
+// back to build when its own key is absent, build never falls back to plan, and
+// toggling modes restores each mode's remembered model with no cross-
+// contamination. The literal key strings are assertions, because cross-client
+// compatibility depends on them matching the desktop's keys byte-for-byte.
+// ===========================================================================
+
+@MainActor
+final class ChatModelStoreKeyTests: XCTestCase {
+
+    private let sid = "test-session"
+    private let otherSid = "test-session-2"
+    private var buildKey: String { ChatModelStore.storageKey(for: sid, mode: .build) }
+    private var planKey: String { ChatModelStore.storageKey(for: sid, mode: .plan) }
+    private var otherBuildKey: String { ChatModelStore.storageKey(for: otherSid, mode: .build) }
+    private var otherPlanKey: String { ChatModelStore.storageKey(for: otherSid, mode: .plan) }
+    private var workingKeys: [String] {
+        [buildKey, planKey, otherBuildKey, otherPlanKey,
+         ChatModelStore.planKey(for: sid), ChatModelStore.variantKey(for: sid),
+         ChatModelStore.planKey(for: otherSid), ChatModelStore.variantKey(for: otherSid)]
+    }
+
+    override func setUp() {
+        super.setUp()
+        for key in workingKeys { UserDefaults.standard.removeObject(forKey: key) }
+    }
+
+    override func tearDown() {
+        for key in workingKeys { UserDefaults.standard.removeObject(forKey: key) }
+        super.tearDown()
+    }
+
+    private func store(_ id: String) -> ChatModelStore {
+        ChatModelStore(sessionId: id, api: MantaAPIClient(serverURL: URL(string: "https://example.com")!))
+    }
+
+    private func model(_ m: String) -> OpencodeModelID {
+        OpencodeModelID(providerID: "anthropic", modelID: m)
+    }
+
+    // MARK: - Literal key strings (cross-client compatibility)
+
+    func testStorageKeyLiteralStrings() {
+        XCTAssertEqual(ChatModelStore.storageKey(for: "S", mode: .build), "manta:chat:S:model")
+        XCTAssertEqual(ChatModelStore.storageKey(for: "S", mode: .plan), "manta:chat:S:model:plan")
+    }
+
+    // MARK: - Read with fallback
+
+    func testPlanReadWithPlanValueStoredReturnsIt() {
+        UserDefaults.standard.set(ChatModel.encode(model("plan-model")), forKey: planKey)
+        UserDefaults.standard.set(ChatModel.encode(model("build-model")), forKey: buildKey)
+        XCTAssertEqual(ChatModelStore.loadOverride(for: sid, mode: .plan), model("plan-model"))
+    }
+
+    func testPlanReadWithOnlyBuildValueReturnsBuild() {
+        UserDefaults.standard.set(ChatModel.encode(model("build-model")), forKey: buildKey)
+        XCTAssertEqual(ChatModelStore.loadOverride(for: sid, mode: .plan), model("build-model"))
+    }
+
+    func testBuildReadWithOnlyPlanValueReturnsNil() {
+        UserDefaults.standard.set(ChatModel.encode(model("plan-model")), forKey: planKey)
+        XCTAssertNil(ChatModelStore.loadOverride(for: sid, mode: .build))
+    }
+
+    func testPlanReadWithNothingStoredReturnsNil() {
+        XCTAssertNil(ChatModelStore.loadOverride(for: sid, mode: .plan))
+        XCTAssertNil(ChatModelStore.loadOverride(for: sid, mode: .build))
+    }
+
+    // MARK: - rebind copies BOTH keys, leaves the old ones alone
+
+    func testRebindCopiesBothKeysAndLeavesOldAlone() {
+        UserDefaults.standard.set(ChatModel.encode(model("build-model")), forKey: buildKey)
+        UserDefaults.standard.set(ChatModel.encode(model("plan-model")), forKey: planKey)
+        store(sid).rebind(to: otherSid)
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: otherBuildKey), ChatModel.encode(model("build-model")))
+        XCTAssertEqual(UserDefaults.standard.string(forKey: otherPlanKey), ChatModel.encode(model("plan-model")))
+        // The source session's keys are untouched.
+        XCTAssertEqual(UserDefaults.standard.string(forKey: buildKey), ChatModel.encode(model("build-model")))
+        XCTAssertEqual(UserDefaults.standard.string(forKey: planKey), ChatModel.encode(model("plan-model")))
+    }
+
+    func testRebindLeavesAbsentPlanKeyAbsentOnDestination() {
+        // Only a build model stored — the destination must NOT get a plan key
+        // stamped with the build fallback (that would "activate" plan mode).
+        UserDefaults.standard.set(ChatModel.encode(model("build-model")), forKey: buildKey)
+        store(sid).rebind(to: otherSid)
+
+        XCTAssertEqual(UserDefaults.standard.string(forKey: otherBuildKey), ChatModel.encode(model("build-model")))
+        XCTAssertNil(UserDefaults.standard.string(forKey: otherPlanKey))
+    }
+
+    // MARK: - Mode toggle restores each mode's model (no cross-contamination)
+
+    func testTogglePlanTwiceReturnsOriginalModel() {
+        let s = store(sid)
+
+        s.setOverride(model("build-a"))                    // pick A in build mode
+        XCTAssertEqual(UserDefaults.standard.string(forKey: buildKey), ChatModel.encode(model("build-a")))
+        XCTAssertEqual(s.override, model("build-a"))
+
+        s.setPlan(true)                                    // plan on — plan key absent, falls back to build-a
+        XCTAssertEqual(s.override, model("build-a"))
+
+        s.setOverride(model("plan-b"))                     // pick B in plan mode
+        XCTAssertEqual(UserDefaults.standard.string(forKey: planKey), ChatModel.encode(model("plan-b")))
+        XCTAssertEqual(s.override, model("plan-b"))
+
+        s.setPlan(false)                                   // plan off — build key holds A again
+        XCTAssertEqual(s.override, model("build-a"))
+
+        s.setPlan(true)                                    // plan on again — plan key holds B
+        XCTAssertEqual(s.override, model("plan-b"))
+    }
+
+    func testModeDoesNotWriteWhenValueUnchanged() {
+        let s = store(sid)
+        s.setPlan(false)                                   // already build — no re-read, no write
+        XCTAssertNil(UserDefaults.standard.string(forKey: buildKey))
+        XCTAssertNil(UserDefaults.standard.string(forKey: planKey))
+    }
+}


### PR DESCRIPTION
Opened automatically for `multica/BET-1025-ios-plan-build-models`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1025.