### PR TITLE
feat(ios): plan card for plan_exit — Build here on the build model, Keep planning, page link (BET-1026)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -34,7 +34,6 @@
 		4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */; };
 		51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */; };
 		5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */; };
-		E62B9C1D7A4F8E00921C5ADD /* MantaSubagentDrillInUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F9C3A21B44E7D08512B0300A /* MantaSubagentDrillInUITests.swift */; };
 		5CDC4D3B2FD207C5E38A9AA1 /* MultilineTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */; };
 		5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */; };
 		5E0226E9FAFF3F9CA9F45F8F /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E78B0F5B521937B40937DC /* SettingsScreen.swift */; };
@@ -53,6 +52,7 @@
 		7C41CAE9FE6D1E06DEC10142 /* MantaResourceCardModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBC7D0BF807861DCCABC5A26 /* MantaResourceCardModelsTests.swift */; };
 		7E8C2A70A3D5C0F949D79FF5 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28250B8DDAB996449F7AE3AD /* SessionModels.swift */; };
 		863035B4DE4C873A0BD9D0F5 /* MantaAuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */; };
+		868536356F9E71119E51F8B7 /* PlanDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7190EEBC7A7233EE21FE264A /* PlanDerivation.swift */; };
 		8A6656EBBD6AEC1B5CE7D0D6 /* MantaSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFB984A951D5C7BD8D02F9 /* MantaSettingsTests.swift */; };
 		8C67D893A425A3B5495CB882 /* ComposerTypeahead.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6ABAA46F1CBD2093D4AC87 /* ComposerTypeahead.swift */; };
 		8C965541FA4ABDFB2A2A319E /* terminal in Resources */ = {isa = PBXBuildFile; fileRef = 0C1EE3F998CADE8487D2555E /* terminal */; };
@@ -87,6 +87,7 @@
 		D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */; };
 		D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42691C89906181C99929354 /* ComposerView.swift */; };
 		DB494E7C3511EA8E1D01F8B1 /* FirebaseCrashlytics in Frameworks */ = {isa = PBXBuildFile; productRef = 3064D265FAB7F52B42389A28 /* FirebaseCrashlytics */; };
+		DE5E17651AB0E9C750C4D712 /* MantaSubagentDrillInUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 12A39FBE813A8B20F7F00055 /* MantaSubagentDrillInUITests.swift */; };
 		E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9803742B79E4302F8813EFCC /* SessionModelsTests.swift */; };
 		E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */ = {isa = PBXBuildFile; fileRef = 799EED7CC4F10C6684A5662C /* Theme.swift */; };
 		E0DE29696DA12A52BE7FCD0D /* TerminalModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2C3C09F5D2FEAE01B1C9CF1E /* TerminalModels.swift */; };
@@ -94,6 +95,7 @@
 		E12FC0E7284E2760AD3A6C4C /* ChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436675A65BF149932C1EADE0 /* ChatScreen.swift */; };
 		E37BCF5DE477D4CAAC0ACCD8 /* MantaContextStripVerifyUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBC0EC48A556426D44A1A42 /* MantaContextStripVerifyUITests.swift */; };
 		E394FF8B718A3D7871EC749C /* ChatModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4098461F579869804595B0A3 /* ChatModelCatalog.swift */; };
+		E631BDFC8B6DF9D3E602DE22 /* PlanDerivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBD86C54D5730F24D2E956E /* PlanDerivationTests.swift */; };
 		E84EC5ADFC08C40B413BE9F3 /* BranchLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE55697AC4EC2304E05D8A1 /* BranchLabelTests.swift */; };
 		E8B921F11FB02F147C910B32 /* PolishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82B782F73475FDD71F6D6B5 /* PolishTests.swift */; };
 		EAA66561F9150E1E2D4FBA4A /* MantaReconnectController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */; };
@@ -128,9 +130,9 @@
 		0C1EE3F998CADE8487D2555E /* terminal */ = {isa = PBXFileReference; lastKnownFileType = folder; name = terminal; path = MantaUI/Resources/terminal; sourceTree = SOURCE_ROOT; };
 		0C440016971186430E8C464B /* Scrim.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Scrim.swift; sourceTree = "<group>"; };
 		0FCC705A51D162CE3E7E3B00 /* MantaDynamicType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaDynamicType.swift; sourceTree = "<group>"; };
+		12A39FBE813A8B20F7F00055 /* MantaSubagentDrillInUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSubagentDrillInUITests.swift; sourceTree = "<group>"; };
 		15E5DB4B26254A37A3075BD2 /* ArtifactDerivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ArtifactDerivation.swift; sourceTree = "<group>"; };
 		17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaRunningStateCaptureUITests.swift; sourceTree = "<group>"; };
-		F9C3A21B44E7D08512B0300A /* MantaSubagentDrillInUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSubagentDrillInUITests.swift; sourceTree = "<group>"; };
 		17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAPIClient.swift; sourceTree = "<group>"; };
 		1A81D1BB24FB02E4DFFA04FE /* UsageMeters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageMeters.swift; sourceTree = "<group>"; };
 		1BBC0EC48A556426D44A1A42 /* MantaContextStripVerifyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaContextStripVerifyUITests.swift; sourceTree = "<group>"; };
@@ -169,6 +171,7 @@
 		6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainCredentialStore.swift; sourceTree = "<group>"; };
 		6E1D5B31C8FB29B23AB2A577 /* MantaLiveChatClearCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaLiveChatClearCaptureUITests.swift; sourceTree = "<group>"; };
 		714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIHierarchyCaptureUITests.swift; sourceTree = "<group>"; };
+		7190EEBC7A7233EE21FE264A /* PlanDerivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDerivation.swift; sourceTree = "<group>"; };
 		74A048582549409FE0949053 /* TranscriptRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRow.swift; sourceTree = "<group>"; };
 		7582E08CBBDCE70E242A6B18 /* UsageSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageSheets.swift; sourceTree = "<group>"; };
 		772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaReconnectController.swift; sourceTree = "<group>"; };
@@ -203,6 +206,7 @@
 		B82B782F73475FDD71F6D6B5 /* PolishTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolishTests.swift; sourceTree = "<group>"; };
 		B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCreateSheet.swift; sourceTree = "<group>"; };
 		BA460F4E709501AE6C65D08A /* ChatOverflowSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOverflowSheet.swift; sourceTree = "<group>"; };
+		BEBD86C54D5730F24D2E956E /* PlanDerivationTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDerivationTests.swift; sourceTree = "<group>"; };
 		C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultilineTextView.swift; sourceTree = "<group>"; };
 		C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatTranscriptTests.swift; sourceTree = "<group>"; };
 		C42691C89906181C99929354 /* ComposerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerView.swift; sourceTree = "<group>"; };
@@ -284,6 +288,7 @@
 				57FFB984A951D5C7BD8D02F9 /* MantaSettingsTests.swift */,
 				9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */,
 				38864A574D6CE5142E07B487 /* ModelRecentsTests.swift */,
+				BEBD86C54D5730F24D2E956E /* PlanDerivationTests.swift */,
 				B82B782F73475FDD71F6D6B5 /* PolishTests.swift */,
 				9803742B79E4302F8813EFCC /* SessionModelsTests.swift */,
 				DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */,
@@ -363,6 +368,7 @@
 				9DD6CA51FD8B7CE80314E0CD /* ModelRecents.swift */,
 				C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */,
 				4EA1F1EEE75DBB6A786FEE4F /* NativeActionSheet.swift */,
+				7190EEBC7A7233EE21FE264A /* PlanDerivation.swift */,
 				A4E84DF65831DE58599C53BD /* RootView.swift */,
 				6BA4ADBB2FD5BAC7940D5B69 /* RunningIndicator.swift */,
 				0C440016971186430E8C464B /* Scrim.swift */,
@@ -410,7 +416,7 @@
 				8D8A1A5388E54F31462D616F /* MantaPairFixture.swift */,
 				AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */,
 				17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */,
-				F9C3A21B44E7D08512B0300A /* MantaSubagentDrillInUITests.swift */,
+				12A39FBE813A8B20F7F00055 /* MantaSubagentDrillInUITests.swift */,
 				714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */,
 				5EF0199856D7E4C0B0D2595C /* MantaUIOverflowCaptureUITests.swift */,
 			);
@@ -582,7 +588,7 @@
 				EDFF1716E461980191B71C85 /* MantaPairFixture.swift in Sources */,
 				D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */,
 				51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */,
-				E62B9C1D7A4F8E00921C5ADD /* MantaSubagentDrillInUITests.swift in Sources */,
+				DE5E17651AB0E9C750C4D712 /* MantaSubagentDrillInUITests.swift in Sources */,
 				4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */,
 				ECB0360A8A26279B6EEF955F /* MantaUIOverflowCaptureUITests.swift in Sources */,
 			);
@@ -606,6 +612,7 @@
 				8A6656EBBD6AEC1B5CE7D0D6 /* MantaSettingsTests.swift in Sources */,
 				B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */,
 				CFE1B93882BD2EAF2A8B80BB /* ModelRecentsTests.swift in Sources */,
+				E631BDFC8B6DF9D3E602DE22 /* PlanDerivationTests.swift in Sources */,
 				E8B921F11FB02F147C910B32 /* PolishTests.swift in Sources */,
 				E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */,
 				C414F36E83344076CE4F1ACD /* TerminalModelsTests.swift in Sources */,
@@ -653,6 +660,7 @@
 				E128F0443F5F8B3AF051667A /* ModelRecents.swift in Sources */,
 				5CDC4D3B2FD207C5E38A9AA1 /* MultilineTextView.swift in Sources */,
 				2D0521ED1C9A66C89711D31F /* NativeActionSheet.swift in Sources */,
+				868536356F9E71119E51F8B7 /* PlanDerivation.swift in Sources */,
 				9CF891D747797006729FDBD3 /* RootView.swift in Sources */,
 				F30211F79048035CE5520266 /* RunningIndicator.swift in Sources */,
 				68760CC316BA947A82F360EE /* Scrim.swift in Sources */,
@@ -755,7 +763,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 1.0.17;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;
@@ -862,7 +870,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 0.1.0;
+				MARKETING_VERSION = 1.0.17;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -206,6 +206,9 @@ private struct ChatScreenContent: View {
 
     /// Called with the NEW session id after a clear, so the wrapper can swap it.
     let onCleared: (String) -> Void
+    /// The box client bound to this session's paired server. Shared by the two
+    /// stores and used by the plan card to build the deterministic plan-page URL.
+    private let api: MantaAPIClient
 
     init(sessionId: String, title: String, projectName: String, eventStore: MantaEventStore, path: Binding<NavigationPath>, onCleared: @escaping (String) -> Void) {
         self.title = title
@@ -214,6 +217,7 @@ private struct ChatScreenContent: View {
         self._path = path
         self.onCleared = onCleared
         let api = MantaAPIClient.live()
+        self.api = api
         _store = StateObject(wrappedValue: ChatSessionStore(
             sessionId: sessionId,
             eventStore: eventStore,
@@ -1046,6 +1050,27 @@ private struct ChatScreenContent: View {
                     store.replyPermission(permission, reply: reply)
                 }
             }
+            // The plan_exit question upgrades into a dedicated PlanCard and is
+            // EXCLUDED from newestQuestion (below), exactly as desktop excludes
+            // it from its inline question stack (`ChatPanel.tsx:2896`) — so the
+            // plan card and the generic question card never render for the
+            // same question.
+            if let planQ = newestPlanQuestion {
+                PlanCard(
+                    question: planQ,
+                    messages: store.messages,
+                    buildModelName: buildModelName,
+                    planURL: planURL,
+                    tokens: tokens,
+                    onBuildHere: { feedback in
+                        handleBuildHere(planQ, feedback: feedback)
+                    },
+                    onKeepPlanning: { feedback in
+                        store.keepPlanning(question: planQ, feedback: feedback)
+                    },
+                    onOpenPage: { openPlanPage() }
+                )
+            }
             if let question = newestQuestion {
                 QuestionCard(question: question, tokens: tokens) { answers in
                     store.replyQuestion(question, answers: answers)
@@ -1062,8 +1087,57 @@ private struct ChatScreenContent: View {
         store.permissions.last
     }
 
+    /// The newest pending question EXCLUDING the plan_exit question (which is
+    /// rendered by the dedicated PlanCard). Matching the exact tool callID via
+    /// `PlanDerivation.isPlanExitQuestion` — never the question text — so the
+    /// plan card and the generic question card can never appear simultaneously.
     private var newestQuestion: QuestionRequest? {
-        store.questions.last
+        store.questions.last(where: { !PlanDerivation.isPlanExitQuestion($0, in: store.messages) })
+    }
+
+    private var newestPlanQuestion: QuestionRequest? {
+        store.questions.last(where: { PlanDerivation.isPlanExitQuestion($0, in: store.messages) })
+    }
+
+    /// The deterministic plan-page URL for this session (`<base>/pages/plan-…`,
+    /// auto-published by the plan agent's plan_render tool), or nil when no
+    /// usable subdomain slug can be formed. There is no on-device publish call
+    /// — the URL is derived, mirroring the current desktop
+    /// (`ChatPanel.tsx:2544-2552`) which standardized on the single-HTML plan
+    /// page auto-published under the per-session subdomain.
+    private var planURL: String? {
+        PlanDerivation.planPageURL(sessionID: store.sessionId, baseURL: api.serverURL)
+    }
+
+    /// The session's BUILD-model name for the card's "Ready to build · …"
+    /// subtitle — the remembered build model, independent of the current
+    /// plan/build mode, falling back to the server default (the plan model is
+    /// only ever the composer's active model while plan mode is on).
+    private var buildModelName: String {
+        let buildID = ChatModelStore.loadOverride(for: store.sessionId, mode: .build)
+        return ChatModel.label(modelStore.models, override: buildID, default: modelStore.defaultModel)
+    }
+
+    private func handleBuildHere(_ question: QuestionRequest, feedback: String) {
+        // Port of the desktop's buildHere: answer "Yes" (switches to the build
+        // agent), flip local plan state off so the BUILD model becomes active,
+        // then re-send the plan text ourselves (feedback appended) with that
+        // build model — opencode's own "yes" would otherwise stamp the injected
+        // build turn with the planning model.
+        var prompt = PlanDerivation.extractPlanData(question, in: store.messages).text
+        let trimmed = feedback.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            prompt = prompt.isEmpty ? trimmed : "\(prompt)\n\n\(trimmed)"
+        }
+        modelStore.setPlan(false)
+        let buildModel = modelStore.promptModel
+        store.buildHere(question: question, planText: prompt, buildModel: buildModel)
+    }
+
+    private func openPlanPage() {
+        if let planURL, let url = URL(string: planURL) {
+            UIApplication.shared.open(url)
+        }
     }
 
     // MARK: - Load failure
@@ -1508,5 +1582,141 @@ private struct QuestionCard: View {
                 customText: customText
             )
         )
+    }
+}
+
+// MARK: - Plan card (BET-1026)
+
+/// The plan_exit question upgraded into a dedicated card. Detection is EXACT
+/// (`PlanDerivation.isPlanExitQuestion`, a matching `plan_exit` tool callID —
+/// never the question text), so this card REPLACES the generic QuestionCard for
+/// that question and never coexists with it.
+///
+/// Recipes are reused, not invented: the container matches `PermissionCard`
+/// / `QuestionCard` (`tokens.panel`, `Metrics.radius.md`, 1pt `borderSubtle`
+/// stroke, `Metrics.spacing.sp3` padding); the feedback field is QuestionCard's
+/// free-text field verbatim; the Build here / Open page buttons are
+/// PermissionCard's "Allow once" / "Allow always" recipes; Keep planning is a
+/// bare text button in `tx3` (not `danger` — keeping planning is not
+/// destructive). All colours/spacing/radii/type resolve through the existing
+/// generated tokens — no new token.
+private struct PlanCard: View {
+    let question: QuestionRequest
+    let messages: [OpencodeMessage]
+    /// The session's BUILD-model name for "Ready to build · <model>".
+    let buildModelName: String
+    /// The deterministic plan-page URL (nil when no usable slug can be formed).
+    let planURL: String?
+    let tokens: Tokens
+    let onBuildHere: (String) -> Void
+    let onKeepPlanning: (String) -> Void
+    let onOpenPage: () -> Void
+
+    @State private var feedback = ""
+
+    private var data: PlanData { PlanDerivation.extractPlanData(question, in: messages) }
+    private var metrics: (steps: Int, files: Int) { PlanDerivation.planMetrics(data.text) }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            // Eyebrow — same recipe as PermissionCard's "Permission needed" header.
+            Text("Plan ready")
+                .font(.manta(size: Metrics.type.xs, weight: mantaFontWeight(Metrics.type.semibold)))
+                .foregroundColor(tokens.tx4)
+            Text(data.title)
+                .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
+                .foregroundColor(tokens.tx1)
+                .lineLimit(2)
+            Text(buildModelName.isEmpty ? "Ready to build" : "Ready to build · \(buildModelName)")
+                .font(.manta(size: Metrics.type.twoXS))
+                .foregroundColor(tokens.tx4)
+            // The metrics line is hidden entirely when no plan path was recovered
+            // (a plan authored via `write`/`plan` without a discoverable path) —
+            // never an empty bullet, never a crash (BET-1026 decision 6).
+            if let path = data.path {
+                Text("\(metrics.steps) steps · \(metrics.files) files · \(path)")
+                    .font(.manta(size: Metrics.type.twoXS, design: .monospaced))
+                    .foregroundColor(tokens.tx3)
+                    .lineLimit(1)
+            }
+            if let planURL {
+                Button(action: onOpenPage) {
+                    HStack(spacing: Metrics.spacing.sp1) {
+                        Image(systemName: "link")
+                            .font(.system(size: Metrics.type.twoXS))
+                            .foregroundColor(tokens.accentTx)
+                        Text(planURL)
+                            .font(.manta(size: Metrics.type.twoXS))
+                            .foregroundColor(tokens.accentTx)
+                            .lineLimit(1)
+                            .truncationMode(.middle)
+                    }
+                }
+                .buttonStyle(.plain)
+            }
+            // Feedback field — QuestionCard's free-text field verbatim.
+            TextField("Anything to change before we start?", text: $feedback)
+                .font(.manta(size: Metrics.type.small))
+                .foregroundColor(tokens.tx1)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp2)
+                .background(tokens.inset, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+            HStack(spacing: Metrics.spacing.sp2) {
+                buildButton
+                openPageButton
+                Spacer(minLength: 0)
+                keepPlanningButton
+            }
+        }
+        .padding(Metrics.spacing.sp3)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("plan-card")
+    }
+
+    /// PermissionCard's "Allow once" recipe (accent-solid capsule).
+    private var buildButton: some View {
+        Button { onBuildHere(feedback) } label: {
+            Text("Build here")
+                .font(.manta(size: Metrics.type.small, weight: .semibold))
+                .foregroundColor(tokens.onAccent)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp2)
+                .background(tokens.accentSolid, in: Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// PermissionCard's "Allow always" recipe (accent-soft capsule) with the
+    /// spec's ↗ glyph.
+    private var openPageButton: some View {
+        Button(action: onOpenPage) {
+            HStack(spacing: Metrics.spacing.sp1) {
+                Text("Open page")
+                Image(systemName: "arrow.up.right")
+                    .font(.system(size: Metrics.type.small, weight: .semibold))
+            }
+            .font(.manta(size: Metrics.type.small, weight: .semibold))
+            .foregroundColor(tokens.accentTx)
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.vertical, Metrics.spacing.sp2)
+            .background(tokens.accentSoft, in: Capsule())
+        }
+        .buttonStyle(.plain)
+    }
+
+    /// "Keep planning" — bare text mirroring "Reject"'s text treatment, but in
+    /// `tx3`, not `danger` (keeping planning is not destructive).
+    private var keepPlanningButton: some View {
+        Button { onKeepPlanning(feedback) } label: {
+            Text("Keep planning")
+                .font(.manta(size: Metrics.type.small, weight: .medium))
+                .foregroundColor(tokens.tx3)
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -148,6 +148,13 @@ struct QueuedPrompt: Equatable {
 final class ChatSessionStore: ObservableObject {
 
     @Published private(set) var transcript: [TranscriptBlock] = []
+    /// The LAST fetched raw transcript (`opencode:messages`), kept alongside the
+    /// rendered `transcript` blocks so the plan card can run its exact
+    /// derivation (`isPlanExitQuestion` / `extractPlanData` need the raw tool
+    /// parts — callID, state.input, patch files — which the blocks discard).
+    /// Replaced wholesale on each fetch (loadEarlier refetches a larger tail,
+    /// so `messages` is always a superset of prior values, never a stale mix).
+    @Published private(set) var messages: [OpencodeMessage] = []
     @Published private(set) var inProgressText = ""
     @Published private(set) var blocks: [TranscriptBlock] = []
     /// The same transcript as `blocks`, but wrapped in `TranscriptRow` with a
@@ -719,6 +726,7 @@ final class ChatSessionStore: ObservableObject {
                 // failed fetch says nothing either way — leave it alone.
                 if !didFail { hasEarlier = loaded.count >= limit }
                 if !didFail || isFirstLoad {
+                    messages = loaded
                     transcript = ChatTranscriptMapper.blocks(from: loaded)
                     // The transcript now carries these messages, so any live
                     // copy of them is a duplicate — retire it BEFORE rebuilding
@@ -810,6 +818,42 @@ final class ChatSessionStore: ObservableObject {
                 if !questions.contains(where: { $0.id == request.id }) {
                     questions.append(request)
                 }
+            }
+        }
+    }
+
+    // MARK: - Plan card (BET-1026)
+
+    /// The plan card's "Build here": answer the plan_exit question "Yes" (so
+    /// opencode switches to the build agent), then re-send the plan text
+    /// OURSELVES with the BUILD model and no agent.
+    ///
+    /// The re-send is necessary, not a convenience: opencode's own "yes" would
+    /// stamp the injected build turn with the last user message's — i.e. the
+    /// PLANNING — model. Re-sending explicitly with `buildModel` (nil = let
+    /// opencode pick) is what makes the follow-up turn run on the build model.
+    /// Ported from `ChatPanel.tsx` `buildHere` (lines 2505-2529): the caller
+    /// has already flipped the local plan state off (through the model store,
+    /// which re-reads the build model), so `buildModel` is the session's build
+    /// model.
+    func buildHere(question: QuestionRequest, planText: String, buildModel: SendPromptInput.Model?) {
+        replyQuestion(question, answers: [["Yes"]])
+        Task {
+            await send(text: planText, attachments: [], model: buildModel, agent: nil)
+        }
+    }
+
+    /// The plan card's "Keep planning": answer the plan_exit question "No"
+    /// (which REJECTS plan_exit, leaving plan mode on by design). If the user
+    /// asked for a change, hand that back to the plan agent so it refines the
+    /// plan (still in plan mode — no edits). Ported from `ChatPanel.tsx`
+    /// `keepPlanning` (lines 2531-2548).
+    func keepPlanning(question: QuestionRequest, feedback: String) {
+        replyQuestion(question, answers: [["No"]])
+        let trimmed = feedback.trimmingCharacters(in: .whitespacesAndNewlines)
+        if !trimmed.isEmpty {
+            Task {
+                await send(text: trimmed, attachments: [], model: nil, agent: "plan")
             }
         }
     }

--- a/mobile/native/MantaUI/PlanDerivation.swift
+++ b/mobile/native/MantaUI/PlanDerivation.swift
@@ -1,0 +1,247 @@
+import Foundation
+
+// ===========================================================================
+// BET-1026 — pure plan-card derivation, ported from the desktop's
+// src/renderer/chatUtils.ts (isPlanExitQuestion / extractPlanData /
+// planRefsFromPart, lines 2140-2307) plus the deterministic plan-page URL rule
+// from src/shared/planMode.mjs, so the two surfaces cannot drift.
+//
+// The plan_exit question is upgraded into a dedicated plan card. Detection is
+// EXACT, never heuristic: the question's `tool.callID` links back to a
+// `plan_exit` tool part in the transcript — match on that, never on the
+// question text.
+//
+// No `import SwiftUI`: this file is pure, so the card stays a thin renderer
+// and every rule here is unit-testable.
+// ===========================================================================
+
+/// Everything the plan card renders, derived once per question.
+struct PlanData: Equatable, Sendable {
+    /// The plan's title (first markdown heading of the plan text, falling back
+    /// to the question's header, then "Plan complete").
+    let title: String
+    /// The FULL plan text — what "Build here" resubmits as the next prompt
+    /// with the build model. Empty when the plan_exit part carries none.
+    let text: String
+    /// The recovered `.opencode/plans/*.md` path, when one can be discovered
+    /// from the transcript (nil when nothing is found — never a crash).
+    let path: String?
+}
+
+enum PlanDerivation {
+
+    /// Tools that AUTHOR the plan file (or confirm it at plan_exit). A `read`
+    /// tool pointed at a plan path is a reference, not an authoring signal,
+    /// and must not resolve as the plan — the write/plan tool (or a prose
+    /// mention) already does. Mirrors the desktop's PLAN_AUTHORING_TOOLS.
+    private static let authoringTools: Set<String> = ["write", "edit", "multiEdit", "patch", "plan", "plan_exit"]
+
+    /// Every `.opencode/plans/*.md` reference. Mirrors the desktop's PLAN_REF_RE.
+    private static let planRefRegex: NSRegularExpression = try! NSRegularExpression(
+        pattern: #"\.opencode/plans/[\w.-]+\.md"#)
+
+    /// A tool part's name, surfaced either directly (`part.extra["tool"]`) or
+    /// nested under `state.input.tool` (the reconciled transcript shape).
+    /// Mirrors the desktop's `toolPartName` exactly.
+    static func toolPartName(_ part: OpencodePart) -> String {
+        if let direct = ChatJSON.string(part.extra["tool"]), !direct.isEmpty {
+            return direct
+        }
+        if let state = ChatJSON.object(part.extra["state"]),
+           let input = ChatJSON.object(state["input"]),
+           let nested = ChatJSON.string(input["tool"]), !nested.isEmpty {
+            return nested
+        }
+        return ""
+    }
+
+    /// Is `question` the plan_exit ask? True iff a transcript tool part named
+    /// `plan_exit` carries the SAME `callID` as `question.tool.callID`. A
+    /// callID is required (an orphaned question without one can never be
+    /// matched) and the match must be exact — the question text is never
+    /// consulted.
+    static func isPlanExitQuestion(_ question: QuestionRequest, in messages: [OpencodeMessage]) -> Bool {
+        guard let callID = question.tool?.callID, !callID.isEmpty else { return false }
+        for message in messages {
+            for part in message.parts where part.type == "tool" {
+                guard partCallID(part) == callID else { continue }
+                if toolPartName(part) == "plan_exit" { return true }
+            }
+        }
+        return false
+    }
+
+    /// Every distinct `.opencode/plans/*.md` reference a single part carries.
+    /// Mirrors the desktop's `planRefsFromPart`: the part's text, the
+    /// authoring tool's input filePath/path/planPath, and the patch `files`
+    /// list are all scanned; a `read` reference is not an authoring signal and
+    /// identical refs are deduped.
+    static func planRefsFromPart(_ part: OpencodePart) -> [String] {
+        var candidates: [String] = []
+        if let text = part.text { candidates.append(text) }
+        if part.type == "tool", authoringTools.contains(toolPartName(part)) {
+            let state = ChatJSON.object(part.extra["state"])
+            let input = (state.flatMap { ChatJSON.object($0["input"]) }) ?? ChatJSON.object(part.extra["input"])
+            if let input {
+                for key in ["filePath", "path", "planPath"] {
+                    if let v = ChatJSON.string(input[key]) { candidates.append(v) }
+                }
+            }
+        }
+        if let files = ChatJSON.array(part.extra["files"]) {
+            candidates.append(contentsOf: files.compactMap(ChatJSON.string))
+        }
+        var out: [String] = []
+        for candidate in candidates {
+            for match in planRefs(in: candidate) where !out.contains(match) {
+                out.append(match)
+            }
+        }
+        return out
+    }
+
+    /// Every distinct `.opencode/plans/*.md` reference across the whole
+    /// transcript (each part scanned once) — the tolerant path recovery for a
+    /// plan whose `plan_exit` part carries no path.
+    static func planPathsFromMessages(_ messages: [OpencodeMessage]) -> [String] {
+        var out: [String] = []
+        for message in messages {
+            for part in message.parts {
+                for ref in planRefsFromPart(part) where !out.contains(ref) {
+                    out.append(ref)
+                }
+            }
+        }
+        return out
+    }
+
+    /// The plan card's display data. Tolerant: when the plan_exit part carries
+    /// no plan text the card still renders, with the question's header as the
+    /// title. The path is recovered across the transcript when the part
+    /// carries none (`df991f8`-style discovery) and is nil when nothing is
+    /// found — never crashes.
+    static func extractPlanData(_ question: QuestionRequest, in messages: [OpencodeMessage]) -> PlanData {
+        var text = ""
+        var partPath: String?
+        outer: for message in messages {
+            for part in message.parts where part.type == "tool" {
+                guard partCallID(part) == question.tool?.callID else { continue }
+                guard toolPartName(part) == "plan_exit" else { continue }
+                let state = ChatJSON.object(part.extra["state"])
+                let input = (state.flatMap { ChatJSON.object($0["input"]) }) ?? ChatJSON.object(part.extra["input"])
+                if let t = input.flatMap({ ChatJSON.string($0["plan"]) ?? ChatJSON.string($0["content"]) ?? ChatJSON.string($0["text"]) }), !t.isEmpty {
+                    text = t
+                }
+                partPath = planRefsFromPart(part).first
+                break outer
+            }
+        }
+
+        let title: String
+        if let h = firstMarkdownHeading(in: text), !h.isEmpty {
+            title = h
+        } else if let fl = firstNonEmptyLine(text) {
+            title = fl
+        } else if let header = question.questions.first?.header, !header.isEmpty {
+            title = header
+        } else {
+            title = "Plan complete"
+        }
+
+        return PlanData(title: title, text: text, path: partPath ?? planPathsFromMessages(messages).first)
+    }
+
+    /// Count of steps and files in a plan body, for the card's metrics line
+    /// ("N steps · N files · <path>"). There is no desktop counterpart — this
+    /// is the iOS definition, pinned by unit tests. A step is a markdown
+    /// heading whose text begins with "Step"; a file is a bullet item that
+    /// names a path-like code span. Empty input yields (0, 0).
+    static func planMetrics(_ text: String) -> (steps: Int, files: Int) {
+        guard !text.isEmpty else { return (0, 0) }
+        var steps = 0
+        var files = 0
+        for line in text.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if let heading = headingText(trimmed), heading.lowercased().hasPrefix("step") {
+                steps += 1
+            } else if isFileBullet(trimmed) {
+                files += 1
+            }
+        }
+        return (steps, files)
+    }
+
+    /// The stable subdomain for a session's plan page: `plan-<shortSessionId>`.
+    /// Mirrors src/shared/planMode.mjs `planSubdomain` (lowercased, stripped of
+    /// non-alphanumerics, truncated to 20 chars). Nil when the session id
+    /// yields no usable slug (caller must refuse — the "never hand back a 404
+    /// URL" rule).
+    static func planSubdomain(_ sessionID: String) -> String? {
+        guard !sessionID.isEmpty else { return nil }
+        let slug = String(sessionID.lowercased().filter { $0.isLetter || $0.isNumber }.prefix(20))
+        guard !slug.isEmpty else { return nil }
+        return "plan-" + slug
+    }
+
+    /// The deterministic public URL of a session's plan page:
+    /// `<baseUrl>/pages/plan-<short>` (a trailing slash on `baseUrl` is
+    /// trimmed). Nil when no usable slug can be formed. Mirrors `planPageUrl`
+    /// in src/shared/planMode.mjs.
+    static func planPageURL(sessionID: String, baseURL: URL) -> String? {
+        guard let slug = planSubdomain(sessionID) else { return nil }
+        let base = baseURL.absoluteString.replacingOccurrences(of: "/+$", with: "", options: .regularExpression)
+        return base + "/pages/" + slug
+    }
+
+    // MARK: - Private
+
+    private static func partCallID(_ part: OpencodePart) -> String {
+        ChatJSON.string(part.extra["callID"]) ?? ""
+    }
+
+    private static func planRefs(in string: String) -> [String] {
+        let ns = string as NSString
+        let range = NSRange(location: 0, length: ns.length)
+        return planRefRegex.matches(in: string, range: range).map { ns.substring(with: $0.range) }
+    }
+
+    /// The first markdown heading in the text, or nil. Mirrors the desktop's
+    /// `/^#{1,6}[ \t]+(.+)$/m` (heading at the start of a line).
+    private static func firstMarkdownHeading(in text: String) -> String? {
+        for line in text.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if let h = headingText(trimmed), !h.isEmpty { return h }
+        }
+        return nil
+    }
+
+    /// The text after a leading `#{1,6}[ \t]+` heading marker, or nil when the
+    /// line is not a heading.
+    private static func headingText(_ line: String) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: #"^#{1,6}[ \t]+(.+)$"#) else { return nil }
+        let ns = line as NSString
+        guard let match = regex.firstMatch(in: line, range: NSRange(location: 0, length: ns.length)) else { return nil }
+        return ns.substring(with: match.range(at: 1)).trimmingCharacters(in: .whitespaces)
+    }
+
+    /// The first non-empty line of the text, trimmed, or nil. Mirrors the
+    /// desktop's `text.split("\n").find((l) => l.trim())?.trim()`.
+    private static func firstNonEmptyLine(_ text: String) -> String? {
+        for line in text.components(separatedBy: .newlines) {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+            if !trimmed.isEmpty { return trimmed }
+        }
+        return nil
+    }
+
+    /// A bullet item (`- ` / `* `) whose content names a path-like code span
+    /// (a backtick pair around a filename with an extension). Not every bullet
+    /// is a file — a prose or action bullet is skipped.
+    private static func isFileBullet(_ line: String) -> Bool {
+        guard let regex = try? NSRegularExpression(
+            pattern: #"^[-*][ \t]+[^`]*`[^`]*\.[A-Za-z0-9_-]+`"#
+        ) else { return false }
+        let ns = line as NSString
+        return regex.firstMatch(in: line, range: NSRange(location: 0, length: ns.length)) != nil
+    }
+}

--- a/mobile/native/MantaUITests/PlanDerivationTests.swift
+++ b/mobile/native/MantaUITests/PlanDerivationTests.swift
@@ -1,0 +1,232 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// BET-1026 — the Swift port of src/renderer/chatUtils.ts's plan-card helpers
+// (isPlanExitQuestion / extractPlanData / planRefsFromPart, lines 2140-2307)
+// plus the deterministic plan-page URL rule from src/shared/planMode.mjs.
+//
+// These tests are the oracle that keeps the iOS plan card in sync with the
+// desktop panel. The detection rule is pinned by test: the plan card matches
+// the question's `tool.callID` against a `plan_exit` tool part — NEVER the
+// question's wording.
+// ===========================================================================
+
+final class PlanDerivationTests: XCTestCase {
+
+    private func message(role: String = "assistant", id: String = "m1",
+                         parts: [OpencodePart]) -> OpencodeMessage {
+        OpencodeMessage(
+            info: OpencodeMessageInfo(
+                id: id, sessionID: "ses_1", role: OpencodeRole(rawValue: role),
+                time: OpencodeTime(created: 1750000000000)),
+            parts: parts)
+    }
+
+    private func question(callID: String?, header: String = "Build Agent",
+                          questionText: String = "Plan complete. Proceed?") -> QuestionRequest {
+        QuestionRequest(
+            id: "q1",
+            sessionID: "ses_1",
+            questions: [QuestionInfo(question: questionText, header: header, options: [])],
+            tool: callID.map { PermissionTool(messageID: "m1", callID: $0) },
+            requestId: "que_1")
+    }
+
+    private func toolPart(tool: String, callID: String,
+                          input: [String: JSONValue]? = nil,
+                          files: [String]? = nil) -> OpencodePart {
+        var extra: [String: JSONValue] = [:]
+        extra["tool"] = .string(tool)
+        if !callID.isEmpty { extra["callID"] = .string(callID) }
+        if let input {
+            extra["state"] = .object([
+                "status": .string("completed"),
+                "input": .object(input),
+            ])
+        }
+        if let files {
+            extra["files"] = .array(files.map(JSONValue.string))
+        }
+        return OpencodePart(type: "tool", id: "p-\(tool)-\(callID)", messageID: "m1", extra: extra)
+    }
+
+    // MARK: - isPlanExitQuestion
+
+    /// True ONLY when the question's `tool.callID` matches a `plan_exit` tool
+    /// part in the transcript.
+    func testTrueWhenCallIDMatchesPlanExitPart() {
+        let q = question(callID: "call-exit")
+        let msg = message(parts: [
+            toolPart(tool: "read", callID: "call-read"),
+            toolPart(tool: "plan_exit", callID: "call-exit"),
+        ])
+        XCTAssertTrue(PlanDerivation.isPlanExitQuestion(q, in: [msg]))
+    }
+
+    /// False when the matching callID belongs to a DIFFERENT tool.
+    func testFalseWhenCallIDBelongsToDifferentTool() {
+        let q = question(callID: "call-exit")
+        let msg = message(parts: [toolPart(tool: "edit", callID: "call-exit")])
+        XCTAssertFalse(PlanDerivation.isPlanExitQuestion(q, in: [msg]))
+    }
+
+    /// False for a non-plan question whose callID matches a non-plan tool.
+    func testFalseForNonPlanQuestion() {
+        let q = question(callID: "call-read")
+        let msg = message(parts: [
+            toolPart(tool: "read", callID: "call-read"),
+            toolPart(tool: "plan_exit", callID: "call-exit"),
+        ])
+        XCTAssertFalse(PlanDerivation.isPlanExitQuestion(q, in: [msg]))
+    }
+
+    /// False when the question carries no tool (an orphaned/recovered question
+    /// cannot be matched — a callID is required).
+    func testFalseWhenQuestionHasNoTool() {
+        let q = question(callID: nil)
+        let msg = message(parts: [toolPart(tool: "plan_exit", callID: "call-exit")])
+        XCTAssertFalse(PlanDerivation.isPlanExitQuestion(q, in: [msg]))
+    }
+
+    /// False when NO part matches the callID, even though a plan_exit part
+    /// exists with a different callID — the question text mentioning "plan" is
+    /// never consulted. Pins the "never match on wording" rule.
+    func testFalseWhenQuestionTextMentionsPlanButCallIDMatchesNothing() {
+        let q = question(callID: "call-other", questionText: "Plan is complete — build it?")
+        let msg = message(parts: [toolPart(tool: "plan_exit", callID: "call-exit")])
+        XCTAssertFalse(PlanDerivation.isPlanExitQuestion(q, in: [msg]))
+    }
+
+    /// The tolerant tool-name read: a name nested under `state.input.tool`
+    /// (the reconciled transcript shape) still matches even when the part
+    /// carries no direct `tool` field.
+    func testTrueWithNestedStateInputToolShape() {
+        let q = question(callID: "call-exit")
+        let part = OpencodePart(
+            type: "tool", id: "p", messageID: "m1",
+            extra: [
+                "callID": .string("call-exit"),
+                "state": .object([
+                    "status": .string("completed"),
+                    "input": .object(["tool": .string("plan_exit")]),
+                ]),
+            ])
+        XCTAssertTrue(PlanDerivation.isPlanExitQuestion(q, in: [message(parts: [part])]))
+    }
+
+    // MARK: - planMetrics
+
+    /// Counts steps (markdown "Step …" headings) and files (bulleted code
+    /// spans) on a representative plan body.
+    func testCountsStepsAndFiles() {
+        let body = """
+        # Add login
+
+        ## Step 1: scaffold
+        - `src/auth.ts`
+
+        ## Step 2: wire route
+        - `src/routes/auth.ts`
+        - `src/views/Login.tsx`
+
+        ## Files
+        - affected `README.md`
+        """
+        let m = PlanDerivation.planMetrics(body)
+        XCTAssertEqual(m.steps, 2)
+        XCTAssertEqual(m.files, 4)
+    }
+
+    /// Empty input yields zeros — never a crash.
+    func testEmptyInputYieldsZeros() {
+        let m = PlanDerivation.planMetrics("")
+        XCTAssertEqual(m.steps, 0)
+        XCTAssertEqual(m.files, 0)
+    }
+
+    // MARK: - extractPlanData / path recovery
+
+    /// Recovers the plan path from the transcript when the `plan_exit` part
+    /// carries none — the plan was authored by the `write` tool, which stashed
+    /// the path in its own input.
+    func testRecoversPathFromAuthoringTool() {
+        let q = question(callID: "call-exit")
+        let msg = message(parts: [
+            toolPart(tool: "write", callID: "call-write",
+                     input: ["filePath": .string(".opencode/plans/2026-01-01-add-login.md")]),
+            toolPart(tool: "plan_exit", callID: "call-exit",
+                     input: ["plan": .string("# Add login\n## Step 1\n- `src/a.ts`")]),
+        ])
+        let d = PlanDerivation.extractPlanData(q, in: [msg])
+        XCTAssertEqual(d.path, ".opencode/plans/2026-01-01-add-login.md")
+        XCTAssertEqual(d.title, "Add login")
+        XCTAssertTrue(d.text.contains("## Step 1"))
+    }
+
+    /// A nil path (not a crash) when the transcript has no discoverable plan
+    /// reference. Tolerant: the card still gets a title from the plan text.
+    func testNilPathWhenNothingFound() {
+        let q = question(callID: "call-exit")
+        let msg = message(parts: [
+            toolPart(tool: "plan_exit", callID: "call-exit",
+                     input: ["plan": .string("# Some Plan")]),
+        ])
+        let d = PlanDerivation.extractPlanData(q, in: [msg])
+        XCTAssertNil(d.path)
+        XCTAssertEqual(d.title, "Some Plan")
+    }
+
+    /// Title extraction handles a plan whose FIRST line is not a heading (and
+    /// which has no heading at all) — the first non-empty line becomes title.
+    func testTitleWhenFirstLineNotHeading() {
+        let q = question(callID: "call-exit")
+        let msg = message(parts: [
+            toolPart(tool: "plan_exit", callID: "call-exit",
+                     input: ["plan": .string("We will add login.\nThen wire the route.")]),
+        ])
+        let d = PlanDerivation.extractPlanData(q, in: [msg])
+        XCTAssertEqual(d.title, "We will add login.")
+    }
+
+    /// Falls back to the question header when the plan text is empty.
+    func testTitleFallsBackToQuestionHeader() {
+        let q = question(callID: "call-exit", header: "Build Agent", questionText: "Switch to build agent?")
+        let d = PlanDerivation.extractPlanData(q, in: [])
+        XCTAssertEqual(d.title, "Build Agent")
+        XCTAssertEqual(d.text, "")
+    }
+
+    // MARK: - planRefs / planPaths
+
+    /// Dedupes identical refs across a part and collects them from text, tool
+    /// input and patch files, while a `read` reference is not an authoring
+    /// signal.
+    func testPlanRefsFromPartScansTextInputAndFiles() {
+        let a = toolPart(tool: "write", callID: "c1",
+                         input: ["filePath": .string(".opencode/plans/b.md")])
+        let b = toolPart(tool: "multiEdit", callID: "c2",
+                         files: [".opencode/plans/c.md", ".opencode/plans/c.md"])
+        XCTAssertEqual(PlanDerivation.planRefsFromPart(a), [".opencode/plans/b.md"])
+        XCTAssertEqual(PlanDerivation.planRefsFromPart(b), [".opencode/plans/c.md"])
+
+        // A `read` pointing at a plan path is a reference, not an authoring
+        // signal — and does not resolve.
+        let r = toolPart(tool: "read", callID: "c3",
+                         input: ["filePath": .string(".opencode/plans/ignored.md")])
+        XCTAssertEqual(PlanDerivation.planRefsFromPart(r), [])
+    }
+
+    // MARK: - plan-page URL
+
+    /// The deterministic subdomain/URL mirror rule (planMode.mjs: lowercased,
+    /// stripped of non-alphanumerics, truncated to 20 chars).
+    func testPlanPageURL() {
+        XCTAssertEqual(
+            PlanDerivation.planSubdomain("ses_A1b2C3d4E5f6G7h8I9j0K1"),
+            "plan-sesa1b2c3d4e5f6g7h8i")
+        let url = PlanDerivation.planPageURL(sessionID: "ses_A1b2C3", baseURL: URL(string: "https://abc.boxes.mantaui.com/")!)
+        XCTAssertEqual(url, "https://abc.boxes.mantaui.com/pages/plan-sesa1b2c3")
+        XCTAssertNil(PlanDerivation.planPageURL(sessionID: "", baseURL: URL(string: "https://a.b")!))
+    }
+}


### PR DESCRIPTION
Opened automatically for `agent/macos/71017243`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1026.