### PR TITLE
feat(renderer): dial holds its place and pulses while a quota resets

### DIFF
--- a/src/renderer/UsageDial.tsx
+++ b/src/renderer/UsageDial.tsx
@@ -90,10 +90,11 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
   const label = providerLabel(snapshot.provider);
   const windowLabel = state.window?.label ?? "usage";
   const resetLine = formatWindowReset(state.window?.resetsAt, nowMs);
-  const title =
-    `${label} · ${pctClamped}% of the ${windowLabel}` +
-    (resetLine ? ` — ${resetLine}` : "") +
-    " · click for details";
+  const title = state.awaitingReset
+    ? `${label} · the ${windowLabel} quota is resetting · click for details`
+    : `${label} · ${pctClamped}% of the ${windowLabel}` +
+      (resetLine ? ` — ${resetLine}` : "") +
+      " · click for details";
 
   return (
     <>
@@ -119,7 +120,10 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
             2/24 of the box, both scaled by the 16px icon size. */}
         <span
           aria-hidden="true"
-          className="inline-flex items-center justify-center"
+          className={
+            "inline-flex items-center justify-center" +
+            (state.awaitingReset ? " animate-pulse" : "")
+          }
           style={{ width: 16, height: 16 }}
         >
           <span
@@ -174,6 +178,12 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
             )}
           </div>
 
+          {state.awaitingReset && (
+            <div className="mb-3 text-meta text-text-faint">
+              Quota is being reset. Usage numbers might look off for a few minutes.
+            </div>
+          )}
+
           <div className="flex flex-col gap-3">
             {snapshot.windows.map((w) => (
               <UsageWindowRow key={w.kind} usageWindow={w} nowMs={nowMs} />
@@ -211,10 +221,15 @@ export const UsageDial = memo(function UsageDial({ providerID }: UsageDialProps)
 // never hardcodes "session"/"weekly" so a provider with a third window (or a
 // daily one) renders with zero changes here.
 function UsageWindowRow({ usageWindow: w, nowMs }: { usageWindow: UsageWindow; nowMs: number }) {
-  const pctClamped = Math.max(0, Math.min(100, w.pct));
+  // Awaiting its replacement numbers: show no value and no fill rather than a
+  // figure we know is the previous window's. The notice above the list says
+  // why, and formatWindowReset already renders "resetting…" below.
+  const awaitingReset = w.stale === true;
+  const pctClamped = awaitingReset ? 0 : Math.max(0, Math.min(100, w.pct));
   const fill = toneRingColor(usageTone(pctClamped));
-  const value =
-    w.used != null && w.limit != null
+  const value = awaitingReset
+    ? "—"
+    : w.used != null && w.limit != null
       ? `${w.used.toLocaleString()} / ${w.limit.toLocaleString()} · ${pctClamped}%`
       : `${pctClamped}%`;
   const resetLine = formatWindowReset(w.resetsAt, nowMs);

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -3590,6 +3590,7 @@ describe("usageDialState", () => {
       visible: false,
       pct: 0,
       tone: "under",
+      awaitingReset: false,
       window: null,
     });
   });
@@ -3597,6 +3598,36 @@ describe("usageDialState", () => {
   it("a null snapshot is not visible", () => {
     expect(usageDialState(null, true).visible).toBe(false);
     expect(usageDialState(undefined, true).visible).toBe(false);
+  });
+
+  it("a waiting primary keeps its own window, reports no value, and holds its place", () => {
+    const snap = usageSnapshot({ windows: [
+      { kind: "session", label: "Session (5h)", pct: 100, stale: true },
+      { kind: "weekly", label: "Weekly", pct: 45 },
+    ] });
+    const st = usageDialState(snap, false);
+    expect(st.awaitingReset).toBe(true);
+    expect(st.window?.kind).toBe("session"); // never switches to the weekly window
+    expect(st.pct).toBe(0);
+    expect(st.tone).toBe("under");
+    expect(st.visible).toBe(true);           // stays on screen rather than vanishing
+  });
+
+  it("a live primary is untouched", () => {
+    const st = usageDialState(usageSnapshot({ windows: [{ kind: "session", label: "S", pct: 95 }] }), false);
+    expect(st.awaitingReset).toBe(false);
+    expect(st.pct).toBe(95);
+    expect(st.tone).toBe("danger");
+  });
+
+  it("a waiting NON-primary window does not blank the primary", () => {
+    const snap = usageSnapshot({ windows: [
+      { kind: "session", label: "S", pct: 80 },
+      { kind: "weekly", label: "W", pct: 99, stale: true },
+    ] });
+    const st = usageDialState(snap, false);
+    expect(st.awaitingReset).toBe(false);
+    expect(st.pct).toBe(80);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2904,6 +2904,9 @@ export type UsageDialState = {
   visible: boolean;
   pct: number;
   tone: UsageDialTone;
+  // The reported window has passed its reset instant and the provider has not
+  // published its replacement numbers yet.
+  awaitingReset: boolean;
   // The window the dial reports — always `windows[0]`, the snapshot's primary
   // (shortest) window. NOT the highest-pct one: visibility uses the worst
   // window, but the number and colour shown are the primary window's.
@@ -2933,7 +2936,7 @@ export function usageDialState(
 ): UsageDialState {
   const windows = snapshot?.windows ?? [];
   if (windows.length === 0) {
-    return { visible: false, pct: 0, tone: "under", window: null };
+    return { visible: false, pct: 0, tone: "under", awaitingReset: false, window: null };
   }
   // The dial reports the PRIMARY window — `windows[0]`, which every adapter
   // emits shortest-first (session before weekly; see the ordering contract on
@@ -2949,10 +2952,19 @@ export function usageDialState(
   // empty, or the number about to block you is invisible unless the opt-in
   // "always show" setting is on.
   const worstPct = windows.reduce((max, w) => (w.pct > max ? w.pct : max), 0);
+  // A window past its reset instant is reporting the number the PREVIOUS
+  // window finished on. We keep reporting that SAME window (switching to the
+  // next one would silently swap which number the dial means), but we report
+  // no value for it: pct 0 and the neutral tone render the existing ring as an
+  // empty track with no branching in the component. Visibility deliberately
+  // still uses the pre-reset worst pct, so the dial holds its place instead of
+  // vanishing.
+  const awaitingReset = primary.stale === true;
   return {
     visible: worstPct >= 70 || alwaysShow,
-    pct: primary.pct,
-    tone: usageTone(primary.pct),
+    pct: awaitingReset ? 0 : primary.pct,
+    tone: awaitingReset ? "under" : usageTone(primary.pct),
+    awaitingReset,
     window: primary,
   };
 }

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -88,6 +88,13 @@ const POLL_MS = 600_000; // 10 minutes
 // How long after a tick that first saw an expired window we re-poll, so the
 // carried-forward reading is replaced in seconds rather than up to POLL_MS.
 const STALE_RETRY_MS = 20_000;
+// How many CONSECUTIVE fast re-polls a waiting window may trigger. Bounded on
+// purpose: a provider only publishes the replacement numbers once there is
+// activity, so an idle user's window can sit past its reset instant
+// indefinitely and an unbounded retry-while-stale loop would hammer a
+// rate-limited endpoint forever. Three attempts covers the ordinary case in
+// about a minute, then we fall back to the normal poll.
+const MAX_STALE_RETRIES = 3;
 // A 429 backoff is always clamped into this band. The floor exists because
 // Anthropic's usage endpoint answers with `retry-after: 0` — honouring that
 // literally would hot-loop the endpoint — and the ceiling exists because a
@@ -169,10 +176,10 @@ export function createUsagePoller({
   // failure TRANSITION rather than once per tick while a provider stays
   // broken.
   const failing = new Set();
-  // Whether the PREVIOUS tick saw an expired window — the fast re-poll is
-  // armed on the false->true edge only (see the header note on why a
-  // retry-while-stale loop would never terminate for an idle user).
-  let hadStale = false;
+  // How many consecutive fast re-polls the current waiting streak has already
+  // used. Reset to 0 the moment no window is waiting, so each reset boundary
+  // gets its own budget.
+  let staleRetries = 0;
   let staleRetry = null;
 
   function warnOnce(adapterId, e) {
@@ -268,13 +275,19 @@ export function createUsagePoller({
           }
         }
       }
-      if (anyStale && !hadStale) {
-        console.log(`[usage] window past its reset instant — re-polling in ${staleRetryMs}ms`);
+      if (!anyStale) {
+        staleRetries = 0;
+        clearTimeout(staleRetry);
+      } else if (staleRetries < MAX_STALE_RETRIES) {
+        staleRetries += 1;
+        console.log(
+          `[usage] window past its reset instant — re-polling in ${staleRetryMs}ms ` +
+            `(${staleRetries}/${MAX_STALE_RETRIES})`,
+        );
         clearTimeout(staleRetry);
         staleRetry = setTimeout(() => void tick(), staleRetryMs);
         staleRetry?.unref?.();
       }
-      hadStale = anyStale;
 
       snapshots = results;
       const key = contentKey(results);

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -787,30 +787,58 @@ test("poller: a window with no resetsAt is never marked stale", async () => {
   assert.equal("stale" in w, false);
 });
 
-test("poller: first stale tick re-polls once; a second consecutive stale tick arms nothing (edge-only)", async () => {
+test("poller: a waiting window re-polls a bounded number of times, then stops", async () => {
   let nowMs = 1000;
   let fetchCalls = 0;
   const adapter = makeAdapter("a", {
     detect: async () => true,
     fetch: async () => {
       fetchCalls++;
+      // resetsAt stays in the past: the provider never publishes replacements,
+      // which is the idle-user case the bound exists for.
       return { windows: [{ kind: "session", label: "s", pct: 78, resetsAt: 500 }] };
     },
   });
   const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
   const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs, staleRetryMs: 5 });
 
-  await poller.tick(); // first stale tick → arms one retry
+  await poller.tick(); // retry 1 armed
   assert.equal(fetchCalls, 1);
 
-  await sleep(40); // the armed retry lands
-  assert.equal(fetchCalls, 2, "the false->true edge must trigger exactly one extra re-poll");
+  // Each armed retry is itself a tick that arms the next, up to the cap of 3.
+  await sleep(60);
+  assert.equal(fetchCalls, 4, "the initial tick plus exactly MAX_STALE_RETRIES re-polls");
 
-  const before = fetchCalls;
-  await poller.tick(); // still stale, but hadStale is already true → no new arm
-  assert.equal(fetchCalls, before + 1, "an explicit tick still runs its fetch");
-  const afterManual = fetchCalls;
+  await sleep(60);
+  assert.equal(fetchCalls, 4, "the budget is spent — no further re-poll while it stays stale");
+});
 
-  await sleep(40); // nothing was armed — no further fetch
-  assert.equal(fetchCalls, afterManual, "a second consecutive stale tick arms no further retry");
+test("poller: the retry budget re-arms once the window stops waiting", async () => {
+  let nowMs = 1000;
+  let fetchCalls = 0;
+  let resetsAt = 500; // in the past → waiting
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => {
+      fetchCalls++;
+      return { windows: [{ kind: "session", label: "s", pct: 78, resetsAt }] };
+    },
+  });
+  const sleep = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+  const poller = createUsagePoller({ adapters: [adapter], now: () => nowMs, staleRetryMs: 5 });
+
+  await poller.tick();
+  await sleep(60);
+  const spent = fetchCalls;
+  assert.ok(spent >= 2, "budget was used while waiting");
+
+  resetsAt = 99999; // provider published the new window
+  await poller.tick();
+  await sleep(30);
+  const afterFresh = fetchCalls;
+
+  resetsAt = 500; // a later boundary
+  await poller.tick();
+  await sleep(60);
+  assert.ok(fetchCalls > afterFresh + 1, "a fresh boundary gets a fresh retry budget");
 });


### PR DESCRIPTION
BET-1041 — follow-up to BET-1039 (colour-ladder change already in main via PR #1039).

When the reported window has passed its reset instant and the provider hasn't published the replacement numbers yet (`stale: true`):
- The dial keeps its slot (visibility still uses pre-reset worst pct), empties its ring (pct 0 + neutral tone render the existing conic-gradient as an empty track with NO new component branching), pulses with Tailwind's existing `animate-pulse`, and stays clickable. It never switches to a different window.
- Popover gains the verbatim notice above the window list; the waiting row shows `—` with an empty bar (its existing `resetting…` line stays).
- Server: bounded fast re-poll — `MAX_STALE_RETRIES` (3) consecutive re-polls per waiting streak at `STALE_RETRY_MS`, budget reset the moment no window is waiting, then fall back to `POLL_MS`. No renderer timer/refetch; the pulse is pure CSS.

No CSS keyframe, colour, token, tone value, or reduced-motion block added.

Base: origin/main @ 7975b10d