### PR TITLE
BET-1043: fix(server): run the Codex oauth-auto callback detached and poll it via oauth-status

### DIFF
--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -49,6 +49,7 @@ import { X, Loader2 } from "lucide-react";
 import type { OpencodeProviderAuthRequest } from "../shared/types";
 import {
   connectPhaseLabel,
+  deviceAuthErrorMessage,
   deviceCodeFallback,
   formatRemaining,
   isPollExpired,
@@ -69,6 +70,10 @@ import { DeviceCodeSteps } from "./DeviceFlow";
 // The caps (5 min / 30 s / 5 min) are intentionally separate and live as
 // constants here so a future tuning pass touches one place, not three.
 const DEVICE_POLL_INTERVAL_MS = 3_000;
+// Display-only: fed to the ProcessPanel `remainingLabel`. The expiry
+// deadline itself is owned by the server (OAUTH_CALLBACK_LIMIT_MS in
+// subscriptionProviders.mjs) — this must MATCH it and exists only for the
+// countdown. (BET-1043)
 const DEVICE_POLL_LIMIT_MS = 5 * 60 * 1_000;
 const RESTART_POLL_INTERVAL_MS = 3_000;
 const RESTART_POLL_LIMIT_MS = 30_000;
@@ -439,29 +444,27 @@ export function ConnectProvider({
     // the 5-minute install cap.
   }, [phase.kind, phase.kind === "installingClaudeCli" ? phase.ptySessionKey : null, safeSetPhase, mounted]);
 
-  // Device-code poll (waiting). Polls `{action:"status"}` every 3s; the
-  // provider-id appearing in `connected[]` is the success signal (opencode
-  // has acknowledged the OAuth callback). Hard cap of 5 minutes — device
-  // codes do expire, and an unbounded poll would leave the user staring at
-  // a dead code. Cleanup runs on every phase change AND on unmount, so the
+  // Device-code poll (waiting). The server fired the oauth-auto callback
+  // DETACHED at `start` (opencode's callback blocks until the user approves
+  // on the provider's device page); this polls `{action:"oauth-status"}`
+  // every 3s to read its outcome. We deliberately do NOT watch `status` /
+  // (`connected[]` — opencode only computes that set at startup, so it
+  // cannot flip mid-wait). Expiry is owned by the server alone: a terminal
+  // `error` state (including "expired") is what the renderer turns into a
+  // failure. Cleanup runs on every phase change AND on unmount, so the
   // interval is freed as soon as we leave `waiting`.
   useEffect(() => {
     if (phase.kind !== "waiting") return;
-    const startedAt = Date.now();
     const handle = window.setInterval(async () => {
-      if (isPollExpired(startedAt, Date.now(), DEVICE_POLL_LIMIT_MS)) {
-        window.clearInterval(handle);
-        safeSetPhase({ kind: "failed", message: "The sign-in code expired. Try again." });
-        return;
-      }
       try {
-        const res = await window.api.opencodeProviderAuth({ action: "status" });
-        if (
-          res.action === "status" &&
-          res.providers.some((p) => p.id === id && p.connected)
-        ) {
+        const res = await window.api.opencodeProviderAuth({ action: "oauth-status", id });
+        if (res.action !== "oauth-status") return;
+        if (res.state === "ok") {
           window.clearInterval(handle);
           safeSetPhase({ kind: "applying", restartConfirmed: false });
+        } else if (res.state === "error") {
+          window.clearInterval(handle);
+          safeSetPhase({ kind: "failed", message: deviceAuthErrorMessage(res.error) });
         }
       } catch {
         /* keep polling; box may be transiently unreachable */

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -138,6 +138,7 @@ import {
   extractPlanData,
   planRefsFromPart,
   resolveDelegateModel,
+  deviceAuthErrorMessage,
 } from "./chatUtils";
 
 import type { OpencodeModel, OpencodeAgent, UsageSnapshot, OpencodeMessage, OpencodePart, VoiceNoteRecord, ForgeInboxItem, QuestionRequest } from "../shared/types";
@@ -5316,5 +5317,20 @@ describe("resolveDelegateModel", () => {
     });
     expect(r.model).toEqual(sel("anthropic", "sonnet"));
     expect(r.overridden).toBe(true);
+  });
+});
+
+// ===== deviceAuthErrorMessage (BET-1043) =====
+
+describe("deviceAuthErrorMessage", () => {
+  it('maps "expired" to the expiry copy', () => {
+    expect(deviceAuthErrorMessage("expired")).toBe("The sign-in code expired. Try again.");
+  });
+  it('maps "not_started" to the not-started copy', () => {
+    expect(deviceAuthErrorMessage("not_started")).toBe("Sign-in didn't start. Try again.");
+  });
+  it("falls back to the generic copy for anything else / undefined", () => {
+    expect(deviceAuthErrorMessage("bad_response")).toBe("Sign-in failed. Try again.");
+    expect(deviceAuthErrorMessage(undefined)).toBe("Sign-in failed. Try again.");
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1387,6 +1387,17 @@ export function isPollExpired(
   return now - startedAt >= limitMs;
 }
 
+/**
+ * Map the `oauth-status` action's error vocabulary to a user-facing message
+ * on the connect card. The server owns the expiry deadline now (BET-1043),
+ * so "expired" from here is truthful — the device code really did time out.
+ */
+export function deviceAuthErrorMessage(error?: string): string {
+  if (error === "expired") return "The sign-in code expired. Try again.";
+  if (error === "not_started") return "Sign-in didn't start. Try again.";
+  return "Sign-in failed. Try again.";
+}
+
 // ===== Terminal keyboard shortcuts (BET-333) =====
 //
 // Inside a terminal, plain Ctrl on Windows / Linux is the application's own

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1236,17 +1236,25 @@ export async function startProviderOauth(providerID, methodIndex) {
 }
 
 /**
- * Complete a paste-back OAuth flow (POST /provider/{id}/oauth/callback {method, code}).
+ * Complete an OAuth device flow (POST /provider/{id}/oauth/callback {method[, code]}).
+ * Serves BOTH modes with one function: a `code`-mode flow sends the
+ * user-typed code; an `auto`-mode flow omits `code` entirely, in which
+ * case opencode's callback BLOCKS until the user approves on the
+ * provider's device page.
  * @param {string} providerID
  * @param {number} methodIndex
- * @param {string} code   the user-typed code from the device / browser page
+ * @param {string} code   the user-typed code for a `code`-mode flow; pass
+ *                        `""` for an `auto`-mode flow, where the call blocks
+ *                        until the user approves on the provider's device page.
  */
 export async function completeProviderOauth(providerID, methodIndex, code) {
   try {
+    const body = { method: methodIndex };
+    if (typeof code === "string" && code !== "") body.code = code;
     const res = await ocFetch(apiUrl(`/provider/${encodeURIComponent(providerID)}/oauth/callback`), {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ method: methodIndex, code }),
+      body: JSON.stringify(body),
     });
     if (!res.ok) {
       const detail = await res.text().catch(() => "");

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -43,6 +43,7 @@ import {
   parseProviderApiKey,
   readProviderApiKey,
   opencodeAuthPath,
+  completeProviderOauth,
 } from "./opencode.mjs";
 import { homedir } from "node:os";
 import { join } from "node:path";
@@ -2241,6 +2242,47 @@ test("generateSessionTitle sends agent:title and never a format/model field", as
       assert.equal(promptBody.agent, "title", "retitle must run on the title agent");
       assert.equal("format" in promptBody, false, "must never send a format/structured-output field");
       assert.equal("model" in promptBody, false, "title agent uses its own model, not our main model");
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// completeProviderOauth (BET-1043)
+// ---------------------------------------------------------------------------
+//
+// The oauth-auto (Codex headless) path fires the callback with NO code —
+// opencode then blocks polling the device-token endpoint. The oauth-code
+// path sends the user-typed code. One function must serve both, and only
+// include `code` in the body when it is a non-empty string.
+
+test("completeProviderOauth omits code from the body when passed empty string (oauth-auto)", async () => {
+  let captured = null;
+  await withMockFetch(
+    async (url, init) => {
+      captured = { url: String(url), method: init.method, body: JSON.parse(init.body) };
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const r = await completeProviderOauth("openai", 1, "");
+      assert.ok(r.ok);
+      assert.equal(captured.url, "http://127.0.0.1:4096/provider/openai/oauth/callback");
+      assert.deepEqual(captured.body, { method: 1 });
+      assert.ok(!("code" in captured.body), "empty code must be omitted entirely");
+    },
+  );
+});
+
+test("completeProviderOauth includes code in the body when passed a real code (oauth-code)", async () => {
+  let captured = null;
+  await withMockFetch(
+    async (url, init) => {
+      captured = { method: init.method, body: JSON.parse(init.body) };
+      return new Response(null, { status: 204 });
+    },
+    async () => {
+      const r = await completeProviderOauth("openai", 1, "ABCD-1234");
+      assert.ok(r.ok);
+      assert.deepEqual(captured.body, { method: 1, code: "ABCD-1234" });
     },
   );
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -103,6 +103,49 @@ export function _resetClaudeLoginSessions() {
   _claudeLoginSessions.clear();
 }
 
+// Device-flow (oauth-auto) callbacks in flight, keyed by provider id.
+// opencode's POST /oauth/callback BLOCKS until the user approves on the
+// provider's device page, so it is fired detached and its outcome is read
+// back by the `oauth-status` action. One entry per provider: a restarted
+// flow calls authorize again, which replaces opencode's own pending entry,
+// so overwriting here is correct.
+const _oauthCallbacks = new Map();
+
+/** Test-only: peek the in-flight device-flow callbacks. */
+export function _getOauthCallbacks() {
+  return new Map(_oauthCallbacks);
+}
+
+/** Test-only: clear between scenarios. */
+export function _resetOauthCallbacks() {
+  _oauthCallbacks.clear();
+}
+
+/**
+ * Fire an oauth-auto (Codex headless) callback DETACHED and record its
+ * outcome for the `oauth-status` action to read back. opencode's callback
+ * is a blocking device-token poll that settles minutes later — long after
+ * the `start` response has gone back to the renderer — so we must not
+ * await it here. It can never reject: an unhandled rejection would take
+ * the server down, so both settle paths record into the map instead.
+ */
+function startOauthCallback(oc, id, methodIndex) {
+  _oauthCallbacks.set(id, { startedAt: Date.now(), state: "pending" });
+  // Detached ON PURPOSE: this promise settles minutes later, long after the
+  // `start` response has gone back to the renderer.
+  oc.completeProviderOauth(id, methodIndex, "")
+    .then((r) => {
+      _oauthCallbacks.set(id, r?.ok
+        ? { startedAt: Date.now(), state: "ok" }
+        : { startedAt: Date.now(), state: "error", error: r?.error ?? "failed" });
+      if (!r?.ok) console.warn(`[provider-auth] ${id}: oauth callback failed (${r?.error ?? "failed"})`);
+    })
+    .catch((e) => {
+      _oauthCallbacks.set(id, { startedAt: Date.now(), state: "error", error: "unreachable" });
+      console.warn(`[provider-auth] ${id}: oauth callback threw:`, e?.message ?? e);
+    });
+}
+
 /**
  * Spawn-side metadata registrar for a Claude login flow. Called by the
  * `opencode:provider-auth start` action when `describeConnectShape` returns
@@ -989,6 +1032,10 @@ export function buildHandlers({
         if (shape === "claude-login") {
           return await startClaudeLogin(id);
         }
+        // oauth-auto (Codex headless): opencode's callback blocks until the
+        // user approves on the device page. Fire it detached and let the
+        // renderer poll the outcome via `oauth-status`.
+        if (shape === "oauth-auto") startOauthCallback(oc, id, resolved.index);
         return {
           action: "start",
           shape,
@@ -996,6 +1043,15 @@ export function buildHandlers({
           instructions: authorize?.instructions || undefined,
           methodIndex: resolved.index,
         };
+      }
+      if (action === "oauth-status") {
+        const id = String(req?.id ?? "");
+        const result = subscriptionProviders.classifyOauthCallback(
+          _oauthCallbacks.get(id),
+          Date.now(),
+        );
+        if (result.state !== "pending") _oauthCallbacks.delete(id);
+        return { action: "oauth-status", ...result };
       }
       if (action === "code") {
         const id = String(req?.id ?? "");

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -1044,15 +1044,6 @@ export function buildHandlers({
           methodIndex: resolved.index,
         };
       }
-      if (action === "oauth-status") {
-        const id = String(req?.id ?? "");
-        const result = subscriptionProviders.classifyOauthCallback(
-          _oauthCallbacks.get(id),
-          Date.now(),
-        );
-        if (result.state !== "pending") _oauthCallbacks.delete(id);
-        return { action: "oauth-status", ...result };
-      }
       if (action === "code") {
         const id = String(req?.id ?? "");
         const methodIndex = Number(req?.methodIndex ?? -1);
@@ -1062,6 +1053,15 @@ export function buildHandlers({
         }
         const r = await oc.completeProviderOauth(id, methodIndex, code);
         return { action: "code", ok: !!r?.ok, error: r?.ok ? undefined : r?.error };
+      }
+      if (action === "oauth-status") {
+        const id = String(req?.id ?? "");
+        const result = subscriptionProviders.classifyOauthCallback(
+          _oauthCallbacks.get(id),
+          Date.now(),
+        );
+        if (result.state !== "pending") _oauthCallbacks.delete(id);
+        return { action: "oauth-status", ...result };
       }
       if (action === "key") {
         const id = String(req?.id ?? "");

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -7,6 +7,8 @@ import {
   acceptsGzip,
   GZIP_MIN_BYTES,
   SELF_UPDATE_SCRIPT,
+  _getOauthCallbacks,
+  _resetOauthCallbacks,
 } from "./rpc.mjs";
 import { gunzipSync } from "node:zlib";
 import { savePages } from "./servePage.mjs";
@@ -67,6 +69,10 @@ function makeDeps(projects, liveProjects = []) {
       oc: {
         createSession: async (i) => { calls.createSession.push(i); return { id: "ses_new" }; },
         forkSession: async (i) => { calls.forkSession.push(i); return { id: "ses_forked" }; },
+        // BET-1043: default no-op for the detached oauth-auto callback so
+        // oauth-auto tests that don't care about it just settle cleanly.
+        // Tests that assert the callback behaviour override this.
+        completeProviderOauth: async () => ({ ok: true }),
       },
       pty: {},
       bus: {},
@@ -950,4 +956,120 @@ test("opencode:context returns null for an empty transcript", async () => {
   const handlers = buildHandlers(deps);
   const res = await handlers["opencode:context"]("ses_empty");
   assert.equal(res, null);
+});
+
+// ---- BET-1043: oauth-auto detached callback + oauth-status ----
+//
+// The oauth-auto (Codex headless) callback BLOCKS until the user approves on
+// the device page, so the rpc `start` branch fires it DETACHED with an empty
+// code and the renderer polls its outcome via `oauth-status` instead of
+// watching `connected[]`.
+
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
+
+// Shared setup: openai resolves to the headless oauth method → oauth-auto
+// shape. The caller overrides `completeProviderOauth` as needed.
+function setupOauthAutoDeps(deps) {
+  deps.oc.listProviderAuthMethods = async () => ({
+    ok: true,
+    methods: { openai: [{ type: "oauth", label: "ChatGPT headless" }] },
+  });
+  deps.oc.startProviderOauth = async () => ({
+    ok: true,
+    url: "https://auth.openai.com/codex/device",
+    method: "auto",
+  });
+}
+
+test("opencode:provider-auth start fires the oauth-auto callback detached with empty code and returns immediately (BET-1043)", async () => {
+  const { deps } = makeDeps([]);
+  setupOauthAutoDeps(deps);
+  const calls = [];
+  // Never settles — the handler must STILL resolve with the oauth-auto shape
+  // without waiting on the blocking callback.
+  deps.oc.completeProviderOauth = (id, index, code) => {
+    calls.push({ id, index, code });
+    return new Promise(() => {});
+  };
+  _resetOauthCallbacks();
+  const handlers = buildHandlers(deps);
+  const result = await handlers["opencode:provider-auth"]({ action: "start", id: "openai" });
+  assert.equal(result.action, "start");
+  assert.equal(result.shape, "oauth-auto");
+  assert.equal(result.methodIndex, 0);
+  assert.deepEqual(calls, [{ id: "openai", index: 0, code: "" }],
+    "must call completeProviderOauth exactly once, with the RESOLVED index and empty code");
+});
+
+test("opencode:provider-auth oauth-status reports pending then ok, then clears (BET-1043)", async () => {
+  const gate = deferred();
+  const { deps } = makeDeps([]);
+  setupOauthAutoDeps(deps);
+  deps.oc.completeProviderOauth = () => gate.promise;
+  _resetOauthCallbacks();
+  const handlers = buildHandlers(deps);
+  await handlers["opencode:provider-auth"]({ action: "start", id: "openai" });
+
+  // In flight → pending.
+  const pending = await handlers["opencode:provider-auth"]({ action: "oauth-status", id: "openai" });
+  assert.deepEqual(pending, { action: "oauth-status", state: "pending" });
+
+  // Approve → next poll reports ok.
+  gate.resolve({ ok: true });
+  await gate.promise;
+  const ok = await handlers["opencode:provider-auth"]({ action: "oauth-status", id: "openai" });
+  assert.deepEqual(ok, { action: "oauth-status", state: "ok" });
+
+  // Terminal state clears the entry → a later poll is not_started.
+  const again = await handlers["opencode:provider-auth"]({ action: "oauth-status", id: "openai" });
+  assert.deepEqual(again, { action: "oauth-status", state: "error", error: "not_started" });
+});
+
+test("opencode:provider-auth oauth-status surfaces a failed callback as error (BET-1043)", async () => {
+  const gate = deferred();
+  const { deps } = makeDeps([]);
+  setupOauthAutoDeps(deps);
+  deps.oc.completeProviderOauth = () => gate.promise;
+  _resetOauthCallbacks();
+  const handlers = buildHandlers(deps);
+  await handlers["opencode:provider-auth"]({ action: "start", id: "openai" });
+  gate.resolve({ ok: false, error: "bad_response" });
+  await gate.promise;
+  const r = await handlers["opencode:provider-auth"]({ action: "oauth-status", id: "openai" });
+  assert.deepEqual(r, { action: "oauth-status", state: "error", error: "bad_response" });
+});
+
+test("opencode:provider-auth oauth-status for an unknown provider returns not_started (BET-1043)", async () => {
+  const { deps } = makeDeps([]);
+  _resetOauthCallbacks();
+  const handlers = buildHandlers(deps);
+  const r = await handlers["opencode:provider-auth"]({ action: "oauth-status", id: "openai" });
+  assert.deepEqual(r, { action: "oauth-status", state: "error", error: "not_started" });
+});
+
+test("opencode:provider-auth start does NOT fire the detached callback for claude-login or api-key providers (BET-1043)", async () => {
+  const { deps } = makeDeps([]);
+  deps.oc.listProviderAuthMethods = async () => ({
+    ok: true,
+    methods: {
+      // anthropic (claude-login via empty URL) and kimi (no methods → api-key)
+      anthropic: [{ type: "oauth", label: "Switch Claude Code account" }],
+      "kimi-for-coding": [],
+    },
+  });
+  deps.oc.startProviderOauth = async () => ({ ok: true, url: "", method: "auto" });
+  let called = 0;
+  deps.oc.completeProviderOauth = async () => { called++; return { ok: true }; };
+  _resetOauthCallbacks();
+  const handlers = buildHandlers(deps);
+
+  await handlers["opencode:provider-auth"]({ action: "start", id: "anthropic" });
+  assert.equal(called, 0, "claude-login must NOT fire the callback");
+
+  await handlers["opencode:provider-auth"]({ action: "start", id: "kimi-for-coding" });
+  assert.equal(called, 0, "api-key (kimi) must NOT fire the callback");
 });

--- a/src/server/subscriptionProviders.mjs
+++ b/src/server/subscriptionProviders.mjs
@@ -248,3 +248,32 @@ export function subscriptionStatuses(connected) {
     connected: set.has(p.id),
   }));
 }
+
+// ---------------------------------------------------------------------------
+// OAuth callback classification (BET-1043)
+// ---------------------------------------------------------------------------
+//
+// opencode's `oauth-auto` (Codex headless) callback BLOCKS for as long as
+// the user takes to approve on the provider's device page, so the server
+// fires it detached and reads its outcome back via the `oauth-status`
+// action. This classifier turns the in-flight map entry into the wire
+// payload. Pure — the caller owns the map and the clock.
+
+export const OAUTH_CALLBACK_LIMIT_MS = 5 * 60 * 1000;
+
+/**
+ * Classify an in-flight device-flow callback for the `oauth-status` action.
+ * Pure — the caller owns the map and the clock.
+ *
+ * entry: {startedAt:number, state:"pending"|"ok"|"error", error?:string} | undefined
+ * returns: {state:"pending"} | {state:"ok"} | {state:"error", error:string}
+ */
+export function classifyOauthCallback(entry, now, limitMs = OAUTH_CALLBACK_LIMIT_MS) {
+  if (!entry) return { state: "error", error: "not_started" };
+  if (entry.state === "pending" && now - entry.startedAt > limitMs) {
+    return { state: "error", error: "expired" };
+  }
+  if (entry.state === "pending") return { state: "pending" };
+  if (entry.state === "ok") return { state: "ok" };
+  return { state: "error", error: entry.error || "failed" };
+}

--- a/src/server/subscriptionProviders.test.mjs
+++ b/src/server/subscriptionProviders.test.mjs
@@ -9,6 +9,8 @@ import {
   resolveAuthMethod,
   describeConnectShape,
   subscriptionStatuses,
+  classifyOauthCallback,
+  OAUTH_CALLBACK_LIMIT_MS,
 } from "./subscriptionProviders.mjs";
 
 // Live snapshot of GET /provider/auth on the dev box, copied verbatim from
@@ -270,5 +272,60 @@ describe("subscriptionStatuses", () => {
     assert.equal(kimi.label, "Kimi");
     assert.equal(kimi.plan, "Kimi For Coding");
     assert.equal(kimi.console, "https://www.kimi.com/code/console");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// classifyOauthCallback (BET-1043)
+// ---------------------------------------------------------------------------
+
+describe("classifyOauthCallback", () => {
+  it("no entry → not_started", () => {
+    assert.deepEqual(classifyOauthCallback(undefined, Date.now()), {
+      state: "error",
+      error: "not_started",
+    });
+  });
+
+  it("pending within the limit → pending", () => {
+    const now = 10_000;
+    assert.deepEqual(
+      classifyOauthCallback({ startedAt: 5_000, state: "pending" }, now),
+      { state: "pending" },
+    );
+  });
+
+  it("pending at exactly the limit boundary is still pending (not expired)", () => {
+    const now = 10_000;
+    // now - startedAt === limitMs → NOT > limitMs → still pending.
+    assert.deepEqual(
+      classifyOauthCallback({ startedAt: now - OAUTH_CALLBACK_LIMIT_MS, state: "pending" }, now),
+      { state: "pending" },
+    );
+  });
+
+  it("pending past the limit → expired", () => {
+    const now = 10_000;
+    assert.deepEqual(
+      classifyOauthCallback({ startedAt: now - (OAUTH_CALLBACK_LIMIT_MS + 1), state: "pending" }, now),
+      { state: "error", error: "expired" },
+    );
+  });
+
+  it("ok → ok", () => {
+    assert.deepEqual(classifyOauthCallback({ startedAt: 5_000, state: "ok" }, Date.now()), {
+      state: "ok",
+    });
+  });
+
+  it("error → error with its stored error, defaulting to 'failed'", () => {
+    assert.deepEqual(
+      classifyOauthCallback({ startedAt: 5_000, state: "error", error: "bad_response" }, Date.now()),
+      { state: "error", error: "bad_response" },
+    );
+    assert.deepEqual(
+      classifyOauthCallback({ startedAt: 5_000, state: "error" }, Date.now()),
+      { state: "error", error: "failed" },
+    );
   });
 });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2217,7 +2217,13 @@ export type VoiceRetryResult =
 //   "disconnect"  → remove the provider's auth from opencode's store.
 //
 // "shape" on the `start` response is what the renderer keys the UI on:
-//   "oauth-auto"  — paste-back device flow (URL on user's device).
+//   "oauth-auto"  — opencode's Codex headless flow. The server fires the
+//                   callback DETACHED (`POST /provider/{id}/oauth/callback`
+//                   blocks until the user approves on the device page) and
+//                   the renderer polls its outcome via the `oauth-status`
+//                   action instead of watching `connected[]` (opencode only
+//                   computes that set at startup). See rpc.mjs's `start`
+//                   branch and the `oauth-status` action.
 //   "oauth-code"  — same UX, but opencode returned a short code to show inline.
 //   "api-key"     — render the password input (or the no-flow case).
 
@@ -2270,7 +2276,8 @@ export type OpencodeProviderAuthRequest =
   // tick while in the claude-login phase. Server-side: file mtime check
   // + restartOpencode() if changed + connected[] verification. The
   // server retains startedAt across requests by keying off sessionKey.
-  | { action: "claude-status"; sessionKey: string; startedAt: number };
+  | { action: "claude-status"; sessionKey: string; startedAt: number }
+  | { action: "oauth-status"; id: string };
 
 export type OpencodeProviderAuthResult =
   | { action: "status"; providers: SubscriptionStatus[] }
@@ -2296,4 +2303,5 @@ export type OpencodeProviderAuthResult =
   // the keep-polling case; `pre-existing` is a distinct failure (the
   // user already had a working login and the connect was a no-op);
   // `completed` means restartOpencode fired + the connect[ed] probe ran.
-  | { action: "claude-status"; ok: boolean; progress?: ClaudeLoginProgress; error?: string };
+  | { action: "claude-status"; ok: boolean; progress?: ClaudeLoginProgress; error?: string }
+  | { action: "oauth-status"; state: "pending" | "ok" | "error"; error?: string };


### PR DESCRIPTION
Closes BET-1043 — Codex connect never completes.

## What & why

opencode's device flow is **two** calls: `POST /oauth/authorize` parks an
in-memory completion routine and returns a device URL/code; `POST
/oauth/callback` *runs* that routine. For the Codex headless (`oauth-auto`)
method the routine is a blocking poll of OpenAI's device-token endpoint that
writes the credential on approval. MantaUI only ever called `authorize`, so
nothing polled OpenAI, the credential was never written, and the card spun
until the (fake) 5-minute expiry.

## The change (all decisions per the issue)

1. **`opencode.mjs`** — `completeProviderOauth` now includes `code` in the
   body only when it is a non-empty string, so the single function serves
   both `code`- and `auto`-mode with an unchanged signature/error vocabulary.
2. **`subscriptionProviders.mjs`** — one pure classifier
   `classifyOauthCallback(entry, now, limitMs)` + `OAUTH_CALLBACK_LIMIT_MS`
   (5 min). Exhaustive rules incl. the not-expired boundary
   (`now - startedAt > limitMs`).
3. **`rpc.mjs`** — on `shape === "oauth-auto"` in `start`, fires the callback
   DETACHED (`startOauthCallback`; never rejects) with `{method}` only; new
   `oauth-status` action classifies the in-flight entry and deletes it on a
   terminal state.
4. **`types.ts`** — `oauth-status` request + result added to the existing
   union; `oauth-auto` doc corrected (it said "paste-back device flow").
5. **`chatUtils.ts`** — `deviceAuthErrorMessage(error)` maps
   `expired`/`not_started`/other to user copy.
6. **`ConnectProvider.tsx`** — the `waiting` poll now reads `oauth-status`
   instead of `GET /provider` `connected[]` (opencode only computes that set
   at startup, so it could never flip mid-wait). The `isPollExpired`/
   `DEVICE_POLL_LIMIT_MS` deadline check and the hardcoded expiry string were
   **deleted** — expiry is now owned by the server alone (one deadline, one
   place) and `oauth-status` reports `error: "expired"` truthfully. The
   `applying` restart + 30s `connected[]` poll is untouched.

Out of scope (per issue §8): no changes to the `oauth-code` paste-back path,
no abort/cancel, no `ocFetch` timeout, no new UI/components/channel.

## Files changed (10)

- `src/server/opencode.mjs` / `opencode.test.mjs`
- `src/server/subscriptionProviders.mjs` / `subscriptionProviders.test.mjs`
- `src/server/rpc.mjs` / `rpc.test.mjs`
- `src/shared/types.ts`
- `src/renderer/chatUtils.ts` / `chatUtils.test.ts`
- `src/renderer/ConnectProvider.tsx`

**Verification results:**
- PR branch (`multica/BET-1043-codex-oauth-callback` @ `c79dca86`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2203 pass / 0 fail / 0 skip. log sha256: `9587a64fb2e60adf9cb967806319e6c5e4a43f2cfd63d49e2f72c75ea6155b6b`
- Base (`main` @ `f9f2ef14`):
  - typecheck: exit 0. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit 0, 2190 pass / 0 fail / 0 skip. log sha256: `dde615dc81557554473e060f8b43c1eedc8140ee9f34f1f2f0c1ab8a71c970cf`
- **Conclusion:** 0 failures on both branches; the PR adds 13 tests, all passing. No new failures introduced.

`Base: origin/main @ f9f2ef14`

## Tests added

- `classifyOauthCallback` — all 5 rules incl. the `now - startedAt === limitMs` still-pending boundary.
- `completeProviderOauth` — omits `code` for `""`, includes it for a real code.
- rpc — `start` fires the detached callback exactly once with the resolved index + empty code and returns immediately (never-settling stub); `oauth-status` pending→ok→cleared and error propagation; unknown provider `not_started`; no callback fired for `claude-login`/`api-key` (kimi).
- `deviceAuthErrorMessage` — all three cases.

Manual GUI verification (dev box: connect Codex → approve on device page → card flips in ~5s; and the 5-min no-approve expiry) cannot be run from this Linux box — no dev box/Apple toolchain. It is covered by the classifier + mapper unit tests.
