### PR TITLE
BET-1044: fix(push): desktop presence from system idle + lock; defer mobile instead of a flat 90s escalation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -556,71 +556,71 @@ re-titles work — the session title is first-name-only and never updates).
 
 ## Web Push notifications (`src/server/push.mjs`)
 
-Mobile PWA gets Web Push (VAPID) for events it can't otherwise see when
-backgrounded: `permission.asked`, `question.asked`, `session.error` (always),
-and `session.idle` → "done" (only if the session was busy AND not being
-watched). The **server** decides whether to surface a push (iOS revokes the
-subscription if a delivered push shows no notification), so suppression logic
-lives in `classifyPushEvent` / `firePush`, not the service worker
-(`src/renderer/public/sw.js` → copied to `mobile/www/sw.js` by `build:mobile`).
+Mobile gets native push (APNs via the gateway) for events it can't otherwise
+see when backgrounded: `permission.asked`, `question.asked`, `session.error`
+(always), and `session.idle` → "done" (only if the session was busy AND not
+being watched). The **server** decides whether to surface a notification, so
+suppression logic lives in `classifyPushEvent` / `firePush`.
 
 - **EVERY notification title is the session's `workspace / session-name`**
   (tmux session / window name), resolved by `firePush` via
   `buildSessionLabel(projects, sid)` over `tmux.listProjects()`. The lookup
   runs for the four notifying types only (`permission.asked`, `question.asked`,
-  `session.error`, `session.idle`) — never for the streaming-event firehose —
-  so we don't pay a tmux query per event. The kind-specific context moves to
-  the BODY (e.g. `Permission needed — …`, `Error — <msg>`, `<header> — <q>`),
-  and each kind falls back to its old descriptive title (`Claude is done`,
-  `Claude hit an error`, …) when the session isn't found in tmux. `classify
-  PushEvent`'s `titleOr(fallback)` helper centralizes this. The "from MantaUI"
-  subtitle under the notification is **iOS injecting the PWA name** — not in
-  our payload, not removable via the Push API.
+  `session.error`, `session.idle`) — never for the streaming-event firehose.
+  The kind-specific context moves to the BODY, and each kind falls back to its
+  old descriptive title when the session isn't found in tmux.
 
-- **Multi-device suppression (Discord rule: active on desktop ⇒ no mobile
-  push).** The desktop Electron app POSTs `/push/desktop-presence {visible}`
-  direct HTTPS to manta-server (`<serverUrl>/push/desktop-presence` with
-  `Authorization: Bearer <boxToken>`). No SSH forward — the server IS the box.
-  Implementation in `src/main/desktopPresence.ts` (`startDesktopPresence`,
-  `sendHeartbeatHttp`).
-  - **ACTIVE = window focused AND recent input — NOT focus alone.**
-    `desktopPresence.ts` gates `visible:true` on
-    `powerMonitor.getSystemIdleTime() < IDLE_ACTIVE_THRESHOLD_S` (30s) in
-    addition to window focus. This is THE fix for "no mobile pushes ever":
-    picking up your phone does **not** blur the desktop window (macOS only
-    fires `browser-window-blur` when another *Mac* app takes focus), so a
-    focus-only signal reports `visible:true` forever and permanently mutes
-    mobile. Idle-gating mirrors Slack/Discord "away" detection. A 10s poll
-    re-evaluates + heartbeats; blur/lock/suspend force an immediate
-    `visible:false`. **Do NOT regress to focus-only presence.**
-  - The server tracks `_desktop = {visible, lastSeen, lastActive}` and ONLY
-    the "done" push is gated by `shouldSuppressForDesktop(desktop, now)`
-    (pure, tested): suppress if desktop is currently `visible`, OR was visible
-    within `DESKTOP_GRACE_MS` (30s) — a quick window-switch shouldn't buzz the
-    phone — but NOT if `lastSeen` is stale past `DESKTOP_PRESENCE_TTL_MS`
-    (60s), so a crashed/asleep/idle desktop can't mute mobile forever.
-  - permission/question/error pushes are blocking and fire on every device
-    regardless (mirrors Slack/Discord still escalating mentions/DMs). Presence
-    is best-effort: if the mobile server is down or the forward isn't up, the
-    POST fails silently and mobile behaves as before (always notifies).
+- **One notification per event (BET-1044).** Each opencode event arrives on
+  BOTH the global stream and the per-directory scoped one. `firePush` drops an
+  event whose id it has already seen via the shared `createSeenIdFilter`
+  (`src/server/seenIds.mjs`, the same filter `streamInterp.mjs` uses), so a
+  `session.error` notifies once, not twice.
+
+- **Cross-device routing = desktop presence + mobile focus (Discord rule).**
+  The desktop Electron app POSTs `/push/desktop-presence` direct HTTPS to
+  manta-server (`<serverUrl>/push/desktop-presence`, `Authorization: Bearer
+  <boxToken>`) every 30s, forever, while it runs. It reports raw observations
+  only — `{idleSeconds, lockedSeconds}` — with **all policy on the server**:
+  - **`desktopPresence.ts` only measures.** `idleSeconds` is system-wide input
+    idle (`powerMonitor.getSystemIdleTime()`); `lockedSeconds` is how long the
+    screen has been locked (null when unlocked). Window **focus is NOT an
+    input** — Manta's normal pattern is to start a turn then work in another
+    app on the same Mac, and a focus-based rule would call that "away" and buzz
+    the phone while the user sits in front of the machine. System-wide input
+    idle correctly reports "present" there (Slack/Teams measure system input,
+    not their own window's focus). Reporting forever also means "app open but
+    user idle" is never mistaken for "app quit" — the server's TTL notices a
+    real quit within ~90s.
+  - **The server turns those into ONE away instant.** `computeAwayAt` merges
+    the idle threshold (`IDLE_AWAY_MS` = 10 min) and the lock threshold
+    (`LOCK_AWAY_MS` = 5 min) into a single epoch instant with `min()` — the two
+    are one calculation, **not two timers**, so a machine that locks after 2
+    minutes crosses at lock+5min and the idle+10min rule doesn't fire
+    separately. `desktopState` then answers present / away / gone: *gone* = no
+    heartbeat within `PRESENCE_TTL_MS` (90s), *away* = past `awayAt`, *present*
+    = otherwise.
+  - The informational-tier router: `present` → desktop now + **defer** the
+    mobile push (parked until the user leaves the desk or the notification goes
+    stale at 30 min — never delivered to a phone in the user's hand); `away` →
+    desktop now + mobile now (the Mac is open, so the desktop notification is
+    there on return); `gone` → mobile only. The old flat 90s escalation timer is
+    replaced by one parked list + one 30s poller (`flushDeferredMobile` /
+    `startDeferredMobilePoller`), re-evaluated against the live `awayAt` — no
+    rescheduling as that instant moves. A lower incoming `idleSeconds` heartbeat
+    means "the user came back" and cancels all parked mobile pushes; a session
+    resuming / its ask being answered cancels by session. Invariant: the phone
+    receives at most ONE delivery per notification.
+  - **Blocking tier (permission/question/error/urgent notify) is unchanged:**
+    both devices immediately, mobile suppressed only when the phone is
+    foregrounded on that same session. Do not touch it.
   - **EXCEPTION — `MessageAbortedError` never pushes.** `classifyPushEvent`'s
-    `session.error` branch reads `properties.error.name` and returns `null`
-    for `MessageAbortedError`. An abort is intentional, not a failure: it
-    fires on both an explicit user abort AND the mid-flight queued-message
-    DRAIN (user submits while running → MantaUI aborts the in-flight turn and
-    resubmits the queued prompt transparently; see the "Queued message drain"
-    pattern). The renderer already swallows this error's banner via
-    `isDrainAbortError`, but that suppression is **renderer-only** — the push
-    pump runs server-side and has zero visibility into `drainAbortRef`. Before
-    this check every drain fired a spurious "Error — The turn failed." push on
-    mobile. Do NOT regress: the name-check is the server's only signal (the
-    abort POST is unmarked and `drainAbortRef` never leaves the browser).
-    Regression test: `session.error MessageAbortedError → NO push` in
-    `src/server/push.test.mjs`.
-  - Observability: the server logs `[push] desktop-presence visible=…` on each
-    heartbeat and `[push] done sid=… suppressForDesktop=… desktop={…}` on every
-    "done" decision (`journalctl --user -u manta-server`). Without these the
-    suppression decision is undiagnosable — keep them.
+    `session.error` branch returns `null` for `MessageAbortedError` (user abort
+    or the queued-message drain). Do NOT regress: the name-check is the server's
+    only signal. Regression test in `src/server/push.test.mjs`.
+  - Observability: the server logs `[push] desktop-presence idle=…s locked=…`
+    on each heartbeat and `[push] route kind=… sid=… → desktop=… mobileNow=…
+    deferMobile=…` on every decision — the load-bearing way to diagnose routing
+    in production. Keep them.
 
 ## Scheduled prompts — MantaUI-native AI tool (`src/server/schedule.mjs`)
 
@@ -853,14 +853,21 @@ routing matrix + scenarios in `docs/manta-tools-notify.md`. Key facts:
   (permission/question/error, or `notify` with `urgent:true`) → every device
   now, no delay. **informational** ("done", normal `notify`) → desktop-first
   ladder.
-- **Escalation = desktop-first, then mobile.** `ESCALATE_MS = 90_000`. When
-  desktop is **idle/away** (heartbeat fresh but `visible:false`) for an
-  informational notif: emit desktop now, schedule a mobile push 90s later keyed
-  by `tag`. Cancel on: desktop becomes **active** (`setDesktopPresence
-  visible:true` → `cancelAllEscalations`), the session resumes / its ask is
-  answered (`cancelEscalationsForSession` from the busy/reply branches in
-  `firePush`), or a same-`tag` re-notify supersedes. Desktop **gone** (TTL
-  lapsed) → mobile immediately (no desktop leg).
+- **Cross-device routing (desktop-first, then deferred mobile).** The desktop
+  reports raw observations (idle + lock) every 30s; the server merges the idle
+  (10 min) and lock (5 min) thresholds into ONE away instant via `computeAwayAt`
+  (a single `min()`, not two timers) and classifies `desktopState` as
+  present/away/gone (`PRESENCE_TTL_MS` = 90s). Informational tier: `present` →
+  desktop now + **defer** mobile (parked in `_deferredMobile`, delivered on a
+  30s `flushDeferredMobile` poll once away/gone, dropped stale after 30 min);
+  `away` → desktop now + mobile now; `gone` → mobile only. **Cancel** the parked
+  push when: a heartbeat reports lower `idleSeconds` (`setDesktopPresence` →
+  `cancelAllDeferredMobile`), the session resumes / its ask is answered
+  (`cancelDeferredMobileForSession` from the busy/reply branches in `firePush`),
+  or a same-`tag` re-notify supersedes. The phone receives at most ONE delivery
+  per notification.
+- **Blocking tier is unchanged:** both devices immediately, mobile suppressed
+  only when the phone is foregrounded on that same session.
 - **The `notify` tool** (`docs/opencode-tools/notify.ts`, COPIED to
   `~/.config/opencode/tools/`, restart `opencode-serve`) is a thin registrar →
   `POST /api/notify {message, title?, urgent?, sessionID}` → `fireNotify`.
@@ -868,9 +875,9 @@ routing matrix + scenarios in `docs/manta-tools-notify.md`. Key facts:
   (`tag:"notify-<sid>"`). The model does NOT pick the device — the router does.
 - **No UI card (v1).** No `notify:*` window.api channels — it's AI-facing +
   server-routed. DND/quiet-hours deferred to v2.
-- Tests: `src/server/push.test.mjs` — `routeNotification` matrix (active /
-  idle / gone × blocking / informational), `notifTier`, and escalation
-  schedule/cancel/supersede (11 new, 41 total). Pure logic only.
+- Tests: `src/server/push.test.mjs` — `routeNotification` matrix (present /
+  away / gone × blocking / informational), `computeAwayAt`/`desktopState`, and
+  deferred flush/cancel/supersede. Pure logic only.
 
 ## Secrets — MantaUI-native AI tool (`src/server/secrets.mjs`)
 

--- a/docs/manta-tools-notify.md
+++ b/docs/manta-tools-notify.md
@@ -44,22 +44,29 @@ AI notify tool ──┤→ manta-server router (push.mjs)
 
 ## The presence model (Slack/Discord parity)
 
-Desktop presence comes from `desktopPresence.ts` heartbeats; three states:
+Desktop presence comes from `desktopPresence.ts` heartbeats. The desktop
+reports raw observations every 30s, unconditionally — `{idleSeconds,
+lockedSeconds}` — and the SERVER computes the desktop's state. Window focus is
+NOT an input: Manta's normal pattern is to start a turn then work in another
+app on the same Mac, and a focus-based rule would call that "away". System-wide
+input idle measures the machine, not a window (Slack/Teams do the same).
+
+The two away conditions are merged into ONE instant by `computeAwayAt`
+(`min()`): idle for 10 min (`IDLE_AWAY_MS`) OR locked for 5 min (`LOCK_AWAY_MS`)
+— whichever trips first wins, so they are one state transition, not two timers.
+`desktopState` then yields three states:
 
 | State | Definition | Source |
 |---|---|---|
-| **active** | a manta window is focused **AND** `getSystemIdleTime() < 30s` | `_desktop.visible === true`, fresh `lastSeen` |
-| **idle / away** | app open (heartbeat fresh, `lastSeen` within 60s TTL) but `visible === false` (blurred or idle >30s) | fresh `lastSeen`, `visible:false`, outside grace |
-| **gone** | no heartbeat for > 60s TTL (app closed, machine asleep) | `lastSeen` stale |
+| **present** | app running and the user is at the machine | heartbeat fresh (`lastSeen` within `PRESENCE_TTL_MS` 90s) AND now before `awayAt` |
+| **away** | app running, but the user has left (locked or idle) | heartbeat fresh AND now past `awayAt` |
+| **gone** | no heartbeat for > 90s TTL (app closed, machine asleep) | `lastSeen` stale |
 
 Mobile presence comes from `/push/focus {sessionId, visible}`:
 - **foreground** (`_focus.visible`) / **background**, plus the session it's
   viewing.
 
-This is exactly Slack/Discord "active / away / offline" per device. The
-"active = focus **AND** recent input" rule is load-bearing and already
-documented in `desktopPresence.ts` — picking up your phone does not blur the Mac
-window, so focus alone would mute mobile forever.
+This is exactly Slack/Discord "active / away / offline" per device.
 
 ## Notification tiers
 
@@ -70,20 +77,21 @@ Two tiers, mirroring how Slack/Discord treat @mentions/DMs vs. channel noise:
   immediately; never delayed, never escalation-gated. (This preserves today's
   behavior: blocking events already fan out to all devices.)
 - **informational** — `session.idle`→"done" and a normal `notify`. Follows the
-  soft **desktop-first → mobile-escalation** ladder below.
+  **desktop-first → deferred-mobile** ladder below.
 
-## Routing matrix (informational tier)
+## Routing matrix (informational tier, by `desktopState`)
 
-For a notification about session `S`, given device states:
+For a notification about session `S`. `deferMobile` = the mobile notification is
+parked (delivered later or dropped stale), never added.
 
-| Desktop | Mobile | Desktop OS notif | Mobile push |
+| Desktop state | Mobile | Desktop OS notif | Mobile push |
 |---|---|---|---|
-| active, viewing `S` | – | – (already on screen) | – |
-| active, other session | – | ✅ now | – |
-| idle/away (app open) | – | ✅ now | ⏳ after `ESCALATE_MS` if unacked |
-| gone | – | – | ✅ now |
-| any | foreground viewing `S` | (desktop rules) | – (in-app already shows it) |
-| gone | foreground other session | – | ✅ (push; PWA shows in-app) |
+| present | not viewing `S` | ✅ now | ⏳ deferred until away/gone or 30-min stale |
+| present | foreground viewing `S` | – (already on screen) | – |
+| away | not viewing `S` | ✅ now | ✅ now |
+| away | foreground viewing `S` | ✅ now | – (in-app already shows it) |
+| gone | not viewing `S` | – | ✅ now |
+| gone | foreground other session | – | ✅ (push) |
 
 **Blocking tier** collapses the matrix: desktop now (unless viewing `S`) **and**
 mobile now (unless mobile foreground viewing `S`) — both, immediately.
@@ -97,38 +105,41 @@ we don't have to plumb the desktop's active session all the way to the server.
 Mobile can't do this — a push can't be un-sent — so mobile's "viewing `S`"
 suppression stays server-side via the existing `/push/focus`.
 
-## Escalation — desktop-first, then mobile if unhandled
+## Deferred mobile — desktop-first, then deliver when the user leaves
 
-`ESCALATE_MS = 90_000` (locked). When the router decides desktop is **idle/away**
-for an informational notification:
+There is no flat escalation timer any more. When the router decides
+`deferMobile` (desktop state `present`), the notification payload is parked in
+one `_deferredMobile` list keyed by `tag`. A single 30s poller
+(`flushDeferredMobile` / `startDeferredMobilePoller`, started from
+`index.mjs` like the other pollers) re-evaluates each parked entry against the
+LIVE `awayAt` on every tick:
 
-1. Emit the desktop directive **now** (the Mac is still open; you may wander
-   back).
-2. Schedule a mobile push for `now + ESCALATE_MS`, keyed by the notification
-   `tag` (per session+kind, so a re-notify replaces rather than stacks a second
-   timer).
-3. **Cancel** the pending escalation when any of:
-   - desktop becomes **active** again (`setDesktopPresence visible:true`) —
-     cancels *all* pending escalations (the user is back at the desk; clicking
-     the desktop notification focuses the app, which trips this naturally);
-   - the session resumes or the ask is answered for `S`
-     (`session.status busy`, `question.replied/rejected`,
-     `permission.replied/rejected`) — cancels escalations for that session;
-   - a newer notification with the same `tag` supersedes it.
+1. Emit the desktop directive **now** (the Mac is open; you may wander back).
+2. Park the mobile push keyed by the notification `tag` (per session+kind, so a
+   re-notify replaces rather than stacks).
+3. On a later flush: desktop **away** or **gone** → deliver to mobile now; held
+   **> 30 min** → drop without delivering (stale); still **present** → leave it.
 
-If the desktop is **gone** (TTL lapsed) there's no desktop leg and the mobile
-push fires immediately — your scenario "AFK too long, I'm probably not at my
-desktop at all" (the heartbeat is what proves the Mac is even reachable).
+**Cancel** without delivering when any of:
+- a heartbeat reports a LOWER `idleSeconds` than the last one (the user came
+  back — `setDesktopPresence` cancels all parked deliveries; they'll see the
+  desktop notification);
+- the session resumes or the ask is answered for `S` (`cancelDeferredMobileForSession`
+  from the busy/reply branches in `firePush`);
+- a newer notification with the same `tag` supersedes it.
+
+If the desktop is **gone** (TTL lapsed) the router routes mobile immediately —
+your scenario "AFK too long, I'm probably not at my desktop at all".
 
 ## The four asked scenarios, mapped
 
-1. **Working on desktop, another session has a notif** → desktop **active** →
-   desktop OS notification only, mobile suppressed. ✅
+1. **Working on desktop, another session has a notif** → desktop **present** →
+   desktop OS notification now, mobile **deferred** until you leave the desk. ✅
 2. **Working on mobile, another session has a notif** → desktop not active →
-   mobile leg fires (the foregrounded PWA shows it in-app; a background PWA gets
-   the push). Desktop silent. ✅
-3. **AFK, desktop open** → desktop **idle/away** → desktop notification now,
-   mobile push escalates after 90s unless you return / handle it. ✅
+   desktop **gone** (or away) → mobile leg fires (a foregrounded phone shows it
+   in-app; a background one gets the push). ✅
+3. **AFK, desktop open** → desktop **away** → desktop notification now + mobile
+   push now. ✅
 4. **AFK too long** → desktop **gone** (no heartbeat) → mobile only, immediately.
    ✅
 
@@ -137,15 +148,14 @@ desktop at all" (the heartbeat is what proves the Mac is even reachable).
 - **Active on desktop but on a different chat than the notif** — desktop OS
   notification (you're at the machine but not looking at that chat); the in-app
   sidebar dot alone is too easy to miss.
-- **Both desktop active + mobile foreground** — desktop wins, mobile suppressed
+- **Both desktop present + mobile foreground** — desktop wins, mobile suppressed
   (Discord rule).
 - **Re-notify / dedupe** — reuse the existing `tag` (`<kind>-<sessionId>`) so a
   second notification for the same session+kind *replaces* the first
-  (`renotify` on the SW; `tag`-collapse on Electron) instead of stacking.
+  (a same-tag entry in `_deferredMobile` is overwritten) instead of stacking.
 - **Subagent / unresolved session** — a "done" whose sessionID has no tmux
-  `@manta-session-id` is a subagent child or orphan; already suppressed by
-  `shouldSuppressUnresolvedDone`. The `notify` tool always carries a real
-  session, so it's unaffected.
+  `@manta-session-id` is a subagent child or orphan; already suppressed.
+  The `notify` tool always carries a real session, so it's unaffected.
 - **Quiet hours / DND** — Slack's signature feature. **Deferred to v2** (locked).
   Sketch: an `AppConfig.quietHours = {start, end}`; during the window force
   informational notifs to silent-mobile-only (or hold), blocking still fires.
@@ -183,13 +193,14 @@ Server-owned core (testable first, no device wiring):
 
 | Piece | File |
 |---|---|
-| Pure router `routeNotification(payload, presence, now)` → `{desktop, mobileNow, escalateAfterMs}` | `src/server/push.mjs` |
-| Escalation timers (`_escalations` Map keyed by tag) + cancel hooks | `src/server/push.mjs` |
+| Pure router `routeNotification(payload, presence, now)` → `{desktop, mobileNow, deferMobile}` | `src/server/push.mjs` |
+| Away calculation + state (`computeAwayAt`, `desktopState`) | `src/server/push.mjs` |
+| Parked mobile list (`_deferredMobile` Map keyed by tag) + flush poller | `src/server/push.mjs` |
 | Desktop sink injection (`setDesktopSink(fn)` → `bus.publish({kind:"desktopNotify"})`) | `src/server/push.mjs` + wired in `src/server/index.mjs` |
 | `POST /api/notify` endpoint | `src/server/index.mjs` |
 | `notify` opencode tool | `docs/opencode-tools/notify.ts` |
 | Tool guidance | `docs/opencode-tools/AGENTS.md` |
-| Tests (router matrix + escalation fire/cancel) | `src/server/push.test.mjs` |
+| Tests (router matrix + deferred flush/cancel) | `src/server/push.test.mjs` |
 
 Desktop leg:
 
@@ -214,7 +225,8 @@ Mobile leg: unchanged transport; the router just gates `sendPush` as today.
 ## Test coverage (`src/server/push.test.mjs`, node:test)
 
 Pure logic only:
-- `routeNotification`: each matrix row (active-viewing/active-other/idle/gone ×
-  blocking/informational), TTL-stale → mobile, grace window.
-- Escalation: idle informational schedules a timer; desktop-active cancels;
-  reply event cancels by session; same-tag supersede replaces.
+- `routeNotification`: each matrix row (present/away/gone × blocking/informational,
+  mobile-viewing suppression).
+- `computeAwayAt` / `desktopState`: idle+lock → one instant; fresh/past-awayAt/stale-TTL → present/away/gone.
+- Deferred delivery: park while present, deliver on away/gone, drop stale after 30 min,
+  cancel on lower-idle heartbeat / by session, same-tag supersede replaces.

--- a/src/main/desktopPresence.ts
+++ b/src/main/desktopPresence.ts
@@ -1,58 +1,59 @@
-// desktopPresence.ts — report "the user is active on desktop" to the mobile
-// server so it can suppress redundant mobile "done" pushes (Discord's
-// "active on desktop ⇒ no mobile push" rule).
+// desktopPresence.ts — report the user's raw system state to the mobile server
+// so it can decide when to push to the phone (and when not to).
+//
+// All policy lives on the server side now (computeAwayAt / desktopState in
+// src/server/push.mjs). This file only measures and reports:
+//   - idleSeconds:  system-wide input idle time (any keyboard/mouse input on
+//                    the machine, in any application)
+//   - lockedSeconds: how long the screen has been locked (or null when unlocked)
+//
+// and it does so EVERY 30s while the app runs, unconditionally. Reporting
+// forever is the point: "app open but user idle" must never be
+// indistinguishable from "app quit" — the server's presence TTL notices a quit
+// within ~90s, and the idle/lock measurements let it decide "away" itself.
 //
 // Transport: direct HTTPS POST to `${serverUrl}/push/desktop-presence` with
 // `Authorization: Bearer <boxToken>`. No SSH forward needed — the server IS the
 // box. If the server isn't running, the POST simply fails and we swallow it —
 // presence is a nice-to-have, never load-bearing.
 //
-// ACTIVE = (a manta window is focused) AND (the user actually touched the
-// keyboard/mouse recently). Window focus ALONE is not enough: picking up your
-// phone does NOT blur the desktop window (macOS only fires blur when another
-// *Mac* app takes focus), so a focus-only signal would keep reporting "active"
-// forever and permanently mute mobile. We therefore gate on
-// powerMonitor.getSystemIdleTime() — exactly how Slack/Discord treat "away":
-// no input for a while ⇒ not actually at the desktop, let mobile notify.
-//
-// We poll every POLL_MS and report:
-//   - visible:true  while focused AND idleTime < IDLE_ACTIVE_THRESHOLD_S
-//   - visible:false otherwise (blurred, OR focused-but-idle = you walked away)
-// plus immediate visible:false on blur / lock / suspend, and a re-evaluate on
-// unlock / resume. The poll doubles as the heartbeat that keeps the server's
-// lastSeen fresh (TTL) while active, and lets it lapse once you go idle.
+// Window focus is deliberately NOT an input. Manta's normal working pattern is:
+// start a turn, then work in another app on the same Mac while it runs. A
+// focus-based rule would call that "away" and buzz the phone while the user is
+// sitting in front of the machine — the exact spam this replaced. System-wide
+// input idle correctly reports "present" in that case (Slack and Teams both
+// measure system input, not their own window's focus).
 
-import { app, BrowserWindow, powerMonitor } from "electron";
+import { powerMonitor } from "electron";
 import { request as httpRequest } from "node:http";
 import { request as httpsRequest } from "node:https";
 import type { AppConfig } from "../shared/types.js";
 
-// How often to re-evaluate active-state and refresh the server's lastSeen.
-// Must be comfortably under the server's DESKTOP_PRESENCE_TTL_MS (60s).
-const POLL_MS = 10_000;
-
-// No keyboard/mouse input for this long ⇒ treat the desktop as "away" even if a
-// manta window is still the frontmost Mac window. Tuned so glancing at your phone
-// for a moment doesn't immediately flip you away, but actually setting the Mac
-// down does. Combined with the server's 30s grace window, the effective
-// hand-off is ~IDLE_ACTIVE_THRESHOLD_S + 30s.
-const IDLE_ACTIVE_THRESHOLD_S = 30;
+// How often to report raw presence observations. Must stay comfortably under
+// the server's PRESENCE_TTL_MS (90s) so a missed beat doesn't read as "gone".
+const POLL_MS = 30_000;
 
 let getConfig: (() => AppConfig) | null = null;
 let pollTimer: NodeJS.Timeout | null = null;
 let started = false;
-let lastReported: boolean | null = null;
+// Epoch-ms when the screen locked or the machine suspended; null when unlocked.
+// Recorded here so a lock→heartbeat reflects the total time locked even between
+// unlock edges, and cleared so an unlocked state reports lockedSeconds: null.
+let lockedAt: number | null = null;
 
-function postPresence(visible: boolean): void {
+function postPresence(idleSeconds: number, lockedSeconds: number | null): void {
   const cfg = getConfig?.();
   if (!cfg) return;
-  sendHeartbeatHttp(cfg, visible);
+  sendHeartbeatHttp(cfg, { idleSeconds, lockedSeconds });
 }
 
-function sendHeartbeatHttp(cfg: AppConfig, visible: boolean): void {
+function sendHeartbeatHttp(
+  cfg: AppConfig,
+  body: { idleSeconds: number; lockedSeconds: number | null },
+): void {
   const serverUrl = (cfg.serverUrl || "").replace(/\/+$/, "");
   if (!serverUrl) return;
-  const body = JSON.stringify({ visible });
+  const payload = JSON.stringify(body);
   const url = new URL("/push/desktop-presence", serverUrl);
   const doRequest = url.protocol === "https:" ? httpsRequest : httpRequest;
   const req = doRequest(
@@ -63,7 +64,7 @@ function sendHeartbeatHttp(cfg: AppConfig, visible: boolean): void {
       method: "POST",
       headers: {
         "content-type": "application/json",
-        "content-length": Buffer.byteLength(body),
+        "content-length": Buffer.byteLength(payload),
         ...(cfg.boxToken ? { authorization: `Bearer ${cfg.boxToken}` } : {}),
       },
       timeout: 4000,
@@ -75,48 +76,30 @@ function sendHeartbeatHttp(cfg: AppConfig, visible: boolean): void {
   );
   req.on("error", () => {});
   req.on("timeout", () => req.destroy());
-  req.write(body);
+  req.write(payload);
   req.end();
 }
 
-function anyWindowFocused(): boolean {
-  return BrowserWindow.getAllWindows().some(
-    (w) => w.isFocused() && w.isVisible(),
-  );
-}
-
-// True when the user is genuinely working at the desktop right now: a manta
-// window is frontmost AND there's been recent keyboard/mouse input.
-function isDesktopActive(): boolean {
-  if (!anyWindowFocused()) return false;
+// System-wide input idle seconds. On throw (some Linux setups lack an idle
+// backend) report 0 — treat an unavailable idle backend as "user is present",
+// the conservative choice, and it preserves the old fallback intent.
+function currentIdleSeconds(): number {
   try {
-    return powerMonitor.getSystemIdleTime() < IDLE_ACTIVE_THRESHOLD_S;
+    return powerMonitor.getSystemIdleTime();
   } catch {
-    // getSystemIdleTime can throw on some Linux setups without an idle backend;
-    // fall back to focus alone there.
-    return true;
+    return 0;
   }
 }
 
-// Always POST while active (heartbeat keeps lastSeen fresh); when inactive,
-// POST only on the active→inactive edge (one clean visible:false), then go
-// quiet so the server's grace+TTL windows can lapse and mobile resumes.
-function evaluateAndReport(): void {
-  const active = isDesktopActive();
-  if (active) {
-    lastReported = true;
-    postPresence(true);
-  } else if (lastReported !== false) {
-    lastReported = false;
-    postPresence(false);
-  }
+function currentLockedSeconds(): number | null {
+  if (lockedAt == null) return null;
+  return (Date.now() - lockedAt) / 1000;
 }
 
-// Force an immediate visible:false (blur / lock / suspend) without waiting for
-// the next poll — promptly un-mutes mobile.
-function reportInactiveNow(): void {
-  lastReported = false;
-  postPresence(false);
+// Report raw observations, unconditionally. All away/present/gone policy is the
+// server's (computeAwayAt / desktopState in push.mjs).
+function report(): void {
+  postPresence(currentIdleSeconds(), currentLockedSeconds());
 }
 
 /**
@@ -128,23 +111,33 @@ export function startDesktopPresence(configGetter: () => AppConfig): void {
   started = true;
   getConfig = configGetter;
 
-  // Focus change → re-evaluate immediately (don't wait up to POLL_MS).
-  app.on("browser-window-focus", () => evaluateAndReport());
-  app.on("browser-window-blur", () => {
-    if (!anyWindowFocused()) reportInactiveNow();
+  // Lock / suspend are PROOF the user left — record the instant and report
+  // immediately so the server's lock-based away calculation starts from
+  // (roughly) the lock, not the next poll.
+  powerMonitor.on("lock-screen", () => {
+    if (lockedAt == null) lockedAt = Date.now();
+    report();
+  });
+  powerMonitor.on("suspend", () => {
+    if (lockedAt == null) lockedAt = Date.now();
+    report();
+  });
+  // Unlock / resume → clear the lock timestamp and report immediately.
+  powerMonitor.on("unlock-screen", () => {
+    lockedAt = null;
+    report();
+  });
+  powerMonitor.on("resume", () => {
+    lockedAt = null;
+    report();
   });
 
-  // System idle / lock / sleep → definitely away.
-  powerMonitor.on("lock-screen", () => reportInactiveNow());
-  powerMonitor.on("suspend", () => reportInactiveNow());
-  // Coming back → re-evaluate from the real focus + idle state.
-  powerMonitor.on("unlock-screen", () => evaluateAndReport());
-  powerMonitor.on("resume", () => evaluateAndReport());
-
-  // Initial state + periodic re-evaluation / heartbeat.
-  evaluateAndReport();
+  // Initial heartbeat + periodic raw reporting. Fires unconditionally —
+  // never goes quiet while the app runs, so a quit (not an idle) is the only
+  // thing that starves the server's TTL.
+  report();
   if (pollTimer) clearInterval(pollTimer);
-  pollTimer = setInterval(evaluateAndReport, POLL_MS);
+  pollTimer = setInterval(report, POLL_MS);
   if (pollTimer.unref) pollTimer.unref();
 }
 
@@ -152,6 +145,6 @@ export function stopDesktopPresence(): void {
   if (pollTimer) clearInterval(pollTimer);
   pollTimer = null;
   started = false;
-  // Best-effort: tell the box we're gone so mobile pushes resume promptly.
-  if (lastReported !== false) reportInactiveNow();
+  // On quit the heartbeat simply stops and the server's PRESENCE_TTL_MS notices
+  // within ~90s — that is the intended "gone" path, not a regression.
 }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -332,6 +332,12 @@ const { stop: stopSchedulePoller } = startSchedulePoller(
   { intervalMs: 30000 },
 );
 
+// Deferred mobile-push deliveries (BET-1044): every 30s, resolve notifications
+// parked by the router (deferMobile) against the live desktop state and deliver
+// the ones whose user has gone away. See push.mjs / startDeferredMobilePoller.
+// eslint-disable-next-line no-unused-vars
+const { stop: stopDeferredMobilePoller } = push.startDeferredMobilePoller();
+
 // Subscription plan usage engine (BET-737): polls each connected provider
 // adapter (claude/codex/kimi — src/server/usageAdapters/) for its rolling-5h
 // + weekly plan usage and publishes `usage.updated` on the bus whenever the
@@ -2553,8 +2559,9 @@ const handleRequest = async (req, res) => {
   // ---------- Native push (APNs) ----------
   // POST /push/focus       body = { sessionId, visible }  (suppress "done" for
   //                        the session the user is actively viewing)
-  // POST /push/desktop-presence body = { visible }  (desktop Electron heartbeat;
-  //                        suppress mobile "done" while active on desktop)
+  // POST /push/desktop-presence body = { idleSeconds, lockedSeconds }  (desktop
+  //                        Electron heartbeat — raw system-idle + screen-lock;
+  //                        server decides away/present/gone)
   // POST /push/register-apns body = { token }  (BET-181: iOS app registers its
   //                        APNs device token. Same Bearer gate as every other
   //                        /push/* route. Server-side mirror of the
@@ -2578,10 +2585,19 @@ const handleRequest = async (req, res) => {
           visible: body?.visible,
         });
       } else if (path === "/push/desktop-presence") {
-        // Desktop (Electron) heartbeat: suppress mobile "done" pushes while
-        // the user is active on desktop. Posted on focus/blur/system-idle.
-        result = push.setDesktopPresence({ visible: body?.visible });
-        console.log(`[push] desktop-presence visible=${!!body?.visible}`);
+        // Desktop (Electron) heartbeat: raw system-idle + screen-lock
+        // observations, posted unconditionally every 30s. Away/present/gone is
+        // decided server-side (computeAwayAt / desktopState). Version skew is
+        // deliberately unhandled: an old desktop posting {visible} sends no
+        // idleSeconds, so the record shows idle 0 and reads "present" until its
+        // heartbeats lapse the TTL, after which it is "gone" and mobile resumes.
+        result = push.setDesktopPresence({
+          idleSeconds: body?.idleSeconds,
+          lockedSeconds: body?.lockedSeconds,
+        });
+        console.log(
+          `[push] desktop-presence idle=${body?.idleSeconds}s locked=${body?.lockedSeconds ?? "-"}`,
+        );
       } else if (path === "/push/answer") {
         // Direct reply to a Question tool from a notification action button.
         // answers is string[][] (one array per question); the SW sends

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -38,6 +38,7 @@ import { publicBaseUrl } from "./gatewayRegister.mjs";
 import * as tmux from "./tmux.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { loadJobs } from "./delegate.mjs";
+import { createSeenIdFilter } from "./seenIds.mjs";
 
 const DIR = statePath();
 const APNS_TOKENS_PATH = join(DIR, "apns-tokens.json");
@@ -105,9 +106,13 @@ export async function addApnsToken(token, { store } = {}) {
     );
   }
   const path = store ?? APNS_TOKENS_PATH;
+  // APNs tokens are hex; case is insignificant, so normalise to lowercase at
+  // this single registration chokepoint — one phone can never occupy two
+  // case-differing entries (which would receive every notification twice).
+  const norm = token.toLowerCase();
   const tokens = await loadApnsTokens(path);
-  const next = tokens.filter((t) => t.token !== token);
-  next.push({ kind: "apns", token, registeredAt: Date.now() });
+  const next = tokens.filter((t) => t.token !== norm);
+  next.push({ kind: "apns", token: norm, registeredAt: Date.now() });
   await saveApnsTokens(next, path);
   return { ok: true, count: next.length };
 }
@@ -118,7 +123,10 @@ export async function removeApnsToken(token, { store } = {}) {
   const path = store ?? APNS_TOKENS_PATH;
   if (!token) return { ok: true, count: (await loadApnsTokens(path)).length };
   const tokens = await loadApnsTokens(path);
-  const next = tokens.filter((t) => t.token !== token);
+  // Normalise the same way addApnsToken does, so a prune of an upper-case
+  // spelling reported by the gateway still matches the stored (lowercased) entry.
+  const key = typeof token === "string" ? token.toLowerCase() : token;
+  const next = tokens.filter((t) => t.token !== key);
   if (next.length !== tokens.length) await saveApnsTokens(next, path);
   return { ok: true, count: next.length };
 }
@@ -150,75 +158,71 @@ export function getFocus() {
 }
 
 // ---------------------------------------------------------------------------
-// Desktop presence — the Electron app reports "I'm focused" so a mobile "done"
-// push is suppressed when the user is heads-down on the desktop (Discord's
-// "active on desktop ⇒ no mobile push" rule). The desktop reaches this server
-// directly over HTTPS and POSTs /push/desktop-presence on focus/blur/system-idle.
-//
-// Two timers gate suppression so a crashed/asleep desktop can't permanently
-// mute mobile:
-//   - lastSeen TTL (DESKTOP_PRESENCE_TTL_MS): no heartbeat in this long ⇒
-//     desktop is gone, mobile pushes resume regardless of the last `visible`.
-//   - grace window (DESKTOP_GRACE_MS): even after an explicit blur/idle, keep
-//     suppressing for this long so a quick desktop window-switch doesn't buzz
-//     the phone. Matches the ~30s Discord-style grace.
-//
-// Single user → a single snapshot. `visible` is the last reported foreground
-// state; `lastActive` is the last time desktop was actually focused (set on a
-// visible:true heartbeat), which the grace window is measured from.
+// Desktop presence — raw observations (idle + lock) POSTed by the app every 30s
+// forever; away/present/gone policy lives here (computeAwayAt + desktopState).
 // ---------------------------------------------------------------------------
 
-export const DESKTOP_PRESENCE_TTL_MS = 60_000; // heartbeat staleness cutoff
-export const DESKTOP_GRACE_MS = 30_000; // keep suppressing after blur/idle
+// No input anywhere for this long ⇒ the user left the desk. 10 min matches
+// Discord's push "inactive timeout" ceiling / Slack's cursor default; long on
+// purpose because waiting on a running turn without typing is normal in manta.
+export const IDLE_AWAY_MS = 10 * 60_000;
+// Screen locked this long ⇒ user left. Locking is PROOF, so far shorter than
+// idle (Slack: 1 min lock vs 10 min idle).
+export const LOCK_AWAY_MS = 5 * 60_000;
+// No heartbeat this long ⇒ app not running (quit/crash/sleep). Comfortably
+// above the desktop's 30s heartbeat interval.
+export const PRESENCE_TTL_MS = 90_000;
 
-let _desktop = { visible: false, lastSeen: 0, lastActive: 0 };
+let _desktop = { lastSeen: 0, idleSeconds: 0, lockedSeconds: null, awayAt: Infinity };
+/** Record a presence heartbeat; detect "the user came back"; recompute awayAt. */
+export function setDesktopPresence({ idleSeconds, lockedSeconds } = {}, now = Date.now()) {
+  // Coerce defensively (a malformed body must never throw or poison the record).
+  const idle =
+    typeof idleSeconds === "number" && Number.isFinite(idleSeconds) && idleSeconds >= 0
+      ? idleSeconds
+      : 0;
+  const locked =
+    typeof lockedSeconds === "number" &&
+    Number.isFinite(lockedSeconds) &&
+    lockedSeconds >= 0
+      ? lockedSeconds
+      : null;
 
-/**
- * Record a desktop presence heartbeat. The desktop posts these on focus, blur,
- * and system idle/resume; an absent heartbeat (TTL) means the desktop is gone.
- * @param {{visible?: boolean}} report
- * @param {number} [now] injectable clock for tests
- */
-export function setDesktopPresence({ visible } = {}, now = Date.now()) {
-  const vis = !!visible;
-  _desktop = {
-    visible: vis,
-    lastSeen: now,
-    // lastActive only advances while the desktop is actually foreground, so the
-    // grace window is measured from when the user last had it focused.
-    lastActive: vis ? now : _desktop.lastActive,
-  };
-  // The user is back at the desk → cancel any pending desktop→mobile
-  // escalations. They'll see the desktop notification (clicking it focuses the
-  // app, which trips this naturally); buzzing the phone now would duplicate.
-  if (vis) cancelAllEscalations();
+  // A LOWER idleSeconds than last = new input since last beat = the user came
+  // back (skip on first beat, lastSeen 0); cancel parked mobile pushes.
+  if (now > 0 && _desktop.lastSeen !== 0 && idle < _desktop.idleSeconds) {
+    cancelAllDeferredMobile();
+  }
+
+  _desktop = { lastSeen: now, idleSeconds: idle, lockedSeconds: locked, awayAt: computeAwayAt({ lastSeen: now, idleSeconds: idle, lockedSeconds: locked }) };
   return _desktop;
 }
 
 export function getDesktopPresence() {
   return _desktop;
 }
+/** The epoch-ms instant at which this desktop is "away". Two conditions, ONE
+ * answer (min): whichever trips first wins, so a machine that locks after 2 min
+ * crosses at lock+5min and idle+10min never fires separately. Infinity when
+ * neither can trip (never in practice — the idle candidate is always finite).
+ */
+export function computeAwayAt({ lastSeen, idleSeconds, lockedSeconds }) {
+  const byIdle = lastSeen + Math.max(0, IDLE_AWAY_MS - idleSeconds * 1000);
+  const byLock =
+    lockedSeconds == null
+      ? Infinity
+      : lastSeen + Math.max(0, LOCK_AWAY_MS - lockedSeconds * 1000);
+  return Math.min(byIdle, byLock);
+}
 
 /**
- * Pure: should a mobile "done" push be suppressed because the desktop is (or
- * was just) active? Suppress when the desktop is focused on ANY session, OR
- * was focused within the grace window — provided the heartbeat is fresh (TTL).
- *
- * @param {{visible:boolean, lastSeen:number, lastActive:number}} desktop
- * @param {number} now
- * @returns {boolean}
+ * Three states (replaces the old visible/stale pair): "gone" = no heartbeat in
+ * TTL (app not running); "away" = running but past awayAt; "present" = running
+ * and the user is at the machine.
  */
-export function shouldSuppressForDesktop(desktop, now = Date.now()) {
-  if (!desktop) return false;
-  // Stale heartbeat → desktop is gone (crash, sleep, network drop). Don't let
-  // a dead desktop mute mobile forever.
-  if (now - (desktop.lastSeen ?? 0) > DESKTOP_PRESENCE_TTL_MS) return false;
-  // Currently foreground on desktop → suppress.
-  if (desktop.visible) return true;
-  // Recently foreground (within the grace window) → still suppress so a quick
-  // desktop window-switch / brief blur doesn't immediately buzz the phone.
-  if (now - (desktop.lastActive ?? 0) <= DESKTOP_GRACE_MS) return true;
-  return false;
+export function desktopState(desktop, now = Date.now()) {
+  if (!desktop || now - (desktop.lastSeen ?? 0) > PRESENCE_TTL_MS) return "gone";
+  return now >= (desktop.awayAt ?? Infinity) ? "away" : "present";
 }
 
 // ---------------------------------------------------------------------------
@@ -229,10 +233,6 @@ export function shouldSuppressForDesktop(desktop, now = Date.now()) {
 // whether it goes to desktop, mobile, both, or escalates desktop→mobile. This
 // is what guarantees "no duplicates": one place sees everything.
 // ---------------------------------------------------------------------------
-
-// How long a desktop-first informational notif waits before escalating to a
-// mobile push, when the desktop is idle/away (app open but no recent input).
-export const ESCALATE_MS = 90_000;
 
 /**
  * Notification tier (Slack/Discord parity):
@@ -249,54 +249,32 @@ export function notifTier(payload) {
 }
 
 /**
- * Pure routing decision for one notification payload.
- *
- * @param {{kind?:string, urgent?:boolean, sessionId?:string|null}} payload
- * @param {{ desktop:any, focusSessionId:string|null, focusVisible:boolean }} presence
- * @param {number} now
- * @returns {{ desktop:boolean, mobileNow:boolean, escalateAfterMs:number|null }}
- *
- * The `desktop:true` directive is "emit a desktop notification"; the Electron
- * app does the final "am I literally viewing this session right now?"
- * suppression locally (it knows its focused window + active session), so we
- * don't plumb the desktop's session to the server. Mobile's "viewing this"
- * suppression must be server-side (a push can't be un-sent) → `focus*`.
+ * Pure routing for one notification. `deferMobile` (= park for the ticker) is
+ * how the phone gets at most one delivery per notif, delayed not added. Desktop
+ * "viewing S" is client-side; mobile's is server-side via `focus*` (can't un-send).
  */
 export function routeNotification(payload, presence, now = Date.now()) {
   const tier = notifTier(payload);
   const desktop = presence?.desktop;
-  // Heartbeat fresh ⇒ the Mac app is reachable (even if the user is idle).
-  const reachable =
-    !!desktop && now - (desktop.lastSeen ?? 0) <= DESKTOP_PRESENCE_TTL_MS;
-  // Active ⇒ focused + recent input (or within the grace window), fresh.
-  const active = shouldSuppressForDesktop(desktop, now);
-  // Mobile is foregrounded ON this very session ⇒ the in-app UI already shows
-  // it; no push needed for this device.
+  const state = desktopState(desktop, now);
   const mobileViewingThis =
     !!presence?.focusVisible &&
     !!presence?.focusSessionId &&
     presence.focusSessionId === payload?.sessionId;
 
   if (tier === "blocking") {
-    // Both devices, now. Desktop client self-suppresses if viewing S.
-    return { desktop: true, mobileNow: !mobileViewingThis, escalateAfterMs: null };
+    // Both devices, now; user has confirmed this branch — do not change it.
+    return { desktop: true, mobileNow: !mobileViewingThis, deferMobile: false };
   }
-
-  // informational
-  if (active) {
-    // At the desk → desktop only.
-    return { desktop: true, mobileNow: false, escalateAfterMs: null };
+  switch (state) {
+    case "present": // at the desk → desktop now, park mobile until they leave
+      return { desktop: true, mobileNow: false, deferMobile: !mobileViewingThis };
+    case "away": // left the desk but Mac open → desktop now + mobile now
+      return { desktop: true, mobileNow: !mobileViewingThis, deferMobile: false };
+    case "gone":
+    default: // desktop not running → mobile only
+      return { desktop: false, mobileNow: !mobileViewingThis, deferMobile: false };
   }
-  if (reachable) {
-    // Idle/away but app open → desktop now, escalate to mobile if unhandled.
-    return {
-      desktop: true,
-      mobileNow: false,
-      escalateAfterMs: mobileViewingThis ? null : ESCALATE_MS,
-    };
-  }
-  // Desktop gone (no heartbeat) → mobile only.
-  return { desktop: false, mobileNow: !mobileViewingThis, escalateAfterMs: null };
 }
 
 // ---------------------------------------------------------------------------
@@ -568,19 +546,15 @@ async function isBackgroundJobSession(sessionId) {
 // Sessions seen "busy" since their last idle — gates the "done" push so we
 // don't notify on spurious idles. Keyed by sessionID.
 const _busy = new Set();
-
+// De-dupes raw opencode events (each arrives on both streams) — see seenIds.mjs.
+const _seenEvents = createSeenIdFilter();
 // Sessions with an unanswered question/permission. While present, the session's
 // idle is "blocked on the user", not "done" — so the "done" push is suppressed
 // (the question/permission push already told them to act).
 const _pending = new Set();
 
 // ---------------------------------------------------------------------------
-// Desktop sink + escalation state
-//
-// `_desktopSink` is injected by index.mjs and publishes a `desktopNotify` bus
-// envelope, which the Electron app consumes and renders as an OS Notification.
-// push.mjs stays decoupled from the bus (mirrors
-// how schedule.mjs takes an injected sendPrompt).
+// Desktop sink + deferred mobile delivery
 // ---------------------------------------------------------------------------
 
 let _desktopSink = null;
@@ -590,44 +564,56 @@ export function setDesktopSink(fn) {
   _desktopSink = typeof fn === "function" ? fn : null;
 }
 
-// Pending desktop→mobile escalations, keyed by notification tag. Each holds the
-// timer + the sessionId so we can cancel by session when the ask is answered.
-const _escalations = new Map();
-
-function cancelEscalation(tag) {
-  const e = _escalations.get(tag);
-  if (e) {
-    clearTimeout(e.timer);
-    _escalations.delete(tag);
+// Parked mobile-push deliveries keyed by tag (same-tag entry is overwritten).
+const _deferredMobile = new Map();
+/** Cancel every parked mobile delivery (user returned to the desk). */
+export function cancelAllDeferredMobile() {
+  _deferredMobile.clear();
+}
+/** Drop parked deliveries for one session (the ask was answered/resumed). */
+export function cancelDeferredMobileForSession(sessionId) {
+  if (!sessionId) return;
+  for (const [tag, entry] of _deferredMobile) {
+    if (entry.sessionId === sessionId) _deferredMobile.delete(tag);
   }
 }
 
-/** Cancel every pending escalation (user returned to the desk). */
-export function cancelAllEscalations() {
-  for (const e of _escalations.values()) clearTimeout(e.timer);
-  _escalations.clear();
+/** Test hook: tags with a parked mobile delivery. */
+export function _deferredMobileTags() {
+  return [..._deferredMobile.keys()];
 }
-
-/** Cancel pending escalations for one session (the ask was answered/resumed). */
-export function cancelEscalationsForSession(sessionId) {
-  if (!sessionId) return;
-  for (const [tag, e] of _escalations) {
-    if (e.sessionId === sessionId) {
-      clearTimeout(e.timer);
-      _escalations.delete(tag);
+/** Walk parked deliveries: deliver when away/gone; drop after 30 min; else leave. */
+export async function flushDeferredMobile(now = Date.now()) {
+  const STALE_DEFERRED_MS = 30 * 60_000;
+  for (const [tag, entry] of [..._deferredMobile]) {
+    const state = desktopState(_desktop, now);
+    if (state === "away" || state === "gone") {
+      _deferredMobile.delete(tag);
+      await sendPush(entry.payload).catch((e) =>
+        console.warn("[push] deferred send failed:", e?.message ?? e),
+      );
+    } else if (now - entry.deferredAt > STALE_DEFERRED_MS) {
+      _deferredMobile.delete(tag);
     }
   }
 }
-
-/** Test hook: tags with a pending escalation timer. */
-export function _pendingEscalationTags() {
-  return [..._escalations.keys()];
+/** 30s poller that flushes parked deliveries; started from index.mjs. */
+export function startDeferredMobilePoller({ intervalMs = 30_000 } = {}) {
+  let inFlight = false;
+  const timer = setInterval(async () => {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await flushDeferredMobile();
+    } finally {
+      inFlight = false;
+    }
+  }, intervalMs);
+  timer.unref?.();
+  return { stop: () => clearInterval(timer) };
 }
 
-/**
- * Run a notification payload through the router and fire the chosen legs.
- * Desktop leg = sink (immediate); mobile leg = push now OR an escalation timer.
- */
+/** Fire routed legs: sink if desktop, sendPush now if mobileNow, else park it. */
 async function dispatchNotification(payload, now = Date.now()) {
   const route = routeNotification(
     payload,
@@ -639,13 +625,13 @@ async function dispatchNotification(payload, now = Date.now()) {
     now,
   );
 
-  // A re-notify for the same tag supersedes any pending escalation.
-  cancelEscalation(payload.tag);
+  // A re-notify for the same tag supersedes any parked delivery.
+  if (_deferredMobile.has(payload.tag)) _deferredMobile.delete(payload.tag);
 
   console.log(
     `[push] route kind=${payload.kind} sid=${payload.sessionId} ` +
       `→ desktop=${route.desktop} mobileNow=${route.mobileNow} ` +
-      `escalateMs=${route.escalateAfterMs ?? "-"}`,
+      `deferMobile=${route.deferMobile}`,
   );
 
   if (route.desktop && _desktopSink) {
@@ -658,13 +644,12 @@ async function dispatchNotification(payload, now = Date.now()) {
 
   if (route.mobileNow) {
     await sendPush(payload);
-  } else if (route.escalateAfterMs != null) {
-    const timer = setTimeout(() => {
-      _escalations.delete(payload.tag);
-      sendPush(payload).catch(() => {});
-    }, route.escalateAfterMs);
-    timer.unref?.();
-    _escalations.set(payload.tag, { timer, sessionId: payload.sessionId ?? null });
+  } else if (route.deferMobile) {
+    _deferredMobile.set(payload.tag, {
+      payload,
+      sessionId: payload.sessionId ?? null,
+      deferredAt: now,
+    });
   }
 }
 
@@ -778,21 +763,29 @@ export async function sendApnsFanout(payload, opts = {}) {
     : loadApnsTokens());
   if (!Array.isArray(tokens) || tokens.length === 0) return;
   const allValues = tokens.map((t) => t?.token).filter((t) => typeof t === "string");
-  // Self-heal: drop store entries the gateway would reject — one invalid
-  // token 400s the WHOLE batch (see isValidApnsToken), so a store poisoned
-  // before registration validation existed would otherwise silence push
-  // forever. Remove them here so the next send is clean.
-  const invalid = allValues.filter((t) => !isValidApnsToken(t));
-  if (invalid.length > 0) {
-    const remove = _removeApnsTokenOverride ?? removeApnsToken;
-    for (const t of invalid) {
-      await remove(t).catch(() => {});
+  // Self-heal before sending: drop entries the gateway would reject (one invalid
+  // token 400s the WHOLE batch) AND collapse case-insensitive duplicates (case is
+  // insignificant, so a two-spelling store delivers twice) — same repair as the
+  // invalid-token self-heal. `remove` is case-insensitive (see removeApnsToken).
+  const pruneToken = _removeApnsTokenOverride ?? removeApnsToken;
+  const survivors = new Set();
+  const toPrune = [];
+  for (const t of allValues) {
+    if (!isValidApnsToken(t) || survivors.has(t.toLowerCase())) {
+      toPrune.push(t);
+    } else {
+      survivors.add(t.toLowerCase());
+    }
+  }
+  if (toPrune.length > 0) {
+    for (const t of toPrune) {
+      await pruneToken(t).catch(() => {});
     }
     console.warn(
-      `[push] pruned ${invalid.length} invalid stored token(s) the gateway would reject`,
+      `[push] pruned ${toPrune.length} stored token(s): invalid or case-duplicate`,
     );
   }
-  const tokenValues = allValues.filter((t) => isValidApnsToken(t));
+  const tokenValues = [...survivors];
   if (tokenValues.length === 0) return;
 
   // Resolve the box identity + gateway_token from auth.json.
@@ -871,6 +864,10 @@ export async function sendApnsFanout(payload, opts = {}) {
  */
 export async function firePush(evt) {
   try {
+    // Each opencode event arrives on BOTH the global and scoped stream; drop one
+    // already seen so one event = one notification (unless it has no id).
+    if (_seenEvents.seen(evt?.id)) return;
+
     const type = evt?.type;
     const props = evt?.properties ?? {};
     const sid = typeof props.sessionID === "string" ? props.sessionID : null;
@@ -883,10 +880,10 @@ export async function firePush(evt) {
       if ((t === "busy" || t === "retry") && sid) {
         _busy.add(sid);
         _pending.delete(sid);
-        // The session resumed → the user is acting on it; cancel any pending
-        // desktop→mobile escalation for it (don't buzz the phone for work
+        // The session resumed → the user is acting on it; cancel any parked
+        // desktop→mobile delivery for it (don't buzz the phone for work
         // that's already moving again).
-        cancelEscalationsForSession(sid);
+        cancelDeferredMobileForSession(sid);
       }
       return;
     }
@@ -902,8 +899,8 @@ export async function firePush(evt) {
         type === "permission.rejected"
       ) {
         _pending.delete(sid);
-        // The ask was answered → cancel its pending escalation.
-        cancelEscalationsForSession(sid);
+        // The ask was answered → cancel its parked delivery.
+        cancelDeferredMobileForSession(sid);
       }
     }
 
@@ -972,8 +969,8 @@ export async function firePush(evt) {
 export function _resetPushState() {
   _busy.clear();
   _pending.clear();
-  cancelAllEscalations();
+  cancelAllDeferredMobile();
   _desktopSink = null;
   _focus = { sessionId: null, visible: false };
-  _desktop = { visible: false, lastSeen: 0, lastActive: 0 };
+  _desktop = { lastSeen: 0, idleSeconds: 0, lockedSeconds: null, awayAt: Infinity };
 }

--- a/src/server/push.test.mjs
+++ b/src/server/push.test.mjs
@@ -8,16 +8,16 @@ import { statePath } from "../shared/paths.mjs";
 import {
   classifyPushEvent,
   buildSessionLabel,
-  shouldSuppressForDesktop,
   shouldSuppressNotification,
   routeNotification,
   notifTier,
   fireNotify,
+  firePush,
   setDesktopPresence,
   setDesktopSink,
-  cancelEscalationsForSession,
-  cancelAllEscalations,
-  _pendingEscalationTags,
+  cancelDeferredMobileForSession,
+  cancelAllDeferredMobile,
+  _deferredMobileTags,
   _resetPushState,
   addApnsToken,
   isValidApnsToken,
@@ -26,9 +26,12 @@ import {
   _loadApnsTokensForTest,
   _setFanoutFakesForTest,
   _resetFanoutFakesForTest,
-  ESCALATE_MS,
-  DESKTOP_PRESENCE_TTL_MS,
-  DESKTOP_GRACE_MS,
+  computeAwayAt,
+  desktopState,
+  flushDeferredMobile,
+  IDLE_AWAY_MS,
+  LOCK_AWAY_MS,
+  PRESENCE_TTL_MS,
 } from "./push.mjs";
 
 const NOFOCUS = { focusSessionId: null, focusVisible: false, wasBusy: false };
@@ -567,60 +570,124 @@ test("buildSessionLabel → null for unknown / missing sessionID", () => {
   assert.equal(buildSessionLabel(null, "ses_a"), null);
 });
 
-// --- Desktop presence suppression (multi-device routing) -------------------
+// --- Desktop presence — away calculation + state (BET-1044) ----------------
 
 const NOW = 1_000_000_000;
 
-test("shouldSuppressForDesktop: desktop focused now → suppress", () => {
+test("computeAwayAt: idle-only (no lock) → lastSeen + 10min", () => {
   assert.equal(
-    shouldSuppressForDesktop(
-      { visible: true, lastSeen: NOW, lastActive: NOW },
-      NOW,
-    ),
-    true,
+    computeAwayAt({ lastSeen: NOW, idleSeconds: 0, lockedSeconds: null }),
+    NOW + IDLE_AWAY_MS,
   );
 });
 
-test("shouldSuppressForDesktop: blurred but within grace → suppress", () => {
-  const t = NOW + DESKTOP_GRACE_MS - 1;
+test("computeAwayAt: already-idle 4 min → lastSeen + 6min", () => {
   assert.equal(
-    shouldSuppressForDesktop(
-      { visible: false, lastSeen: t, lastActive: NOW },
-      t,
-    ),
-    true,
+    computeAwayAt({ lastSeen: NOW, idleSeconds: 240, lockedSeconds: null }),
+    NOW + IDLE_AWAY_MS - 240_000,
   );
 });
 
-test("shouldSuppressForDesktop: blurred past grace → allow push", () => {
-  const t = NOW + DESKTOP_GRACE_MS + 1;
+test("computeAwayAt: locked 0s → lastSeen + 5min (lock beats idle)", () => {
   assert.equal(
-    shouldSuppressForDesktop(
-      { visible: false, lastSeen: t, lastActive: NOW },
-      t,
-    ),
-    false,
+    computeAwayAt({ lastSeen: NOW, idleSeconds: 0, lockedSeconds: 0 }),
+    NOW + LOCK_AWAY_MS,
   );
 });
 
-test("shouldSuppressForDesktop: stale heartbeat (crash/sleep) → allow push", () => {
-  // visible:true but no heartbeat for > TTL → treat desktop as gone.
-  const t = NOW + DESKTOP_PRESENCE_TTL_MS + 1;
+test("computeAwayAt: locked 2min into a 10min idle window → ONE instant at lock+5min", () => {
+  // The reported scenario: a machine that locks after 2 minutes crosses at
+  // lock+5min; the idle+10min rule never fires separately — the two conditions
+  // resolve to one instant via min(), not two timers.
+  const idleAt = NOW + IDLE_AWAY_MS - 120_000; // idle+10min minus 2min elapsed
+  const lockAt = NOW + LOCK_AWAY_MS - 120_000; // lock+5min minus 2min elapsed
   assert.equal(
-    shouldSuppressForDesktop(
-      { visible: true, lastSeen: NOW, lastActive: NOW },
-      t,
-    ),
-    false,
+    computeAwayAt({ lastSeen: NOW, idleSeconds: 120, lockedSeconds: 120 }),
+    lockAt,
+  );
+  assert.notEqual(computeAwayAt({ lastSeen: NOW, idleSeconds: 120, lockedSeconds: 120 }), idleAt);
+});
+
+test("computeAwayAt: idleSeconds already past both thresholds → lastSeen (never negative)", () => {
+  // Long idle + long lock: both candidates clamp to >= lastSeen, min is lastSeen.
+  assert.equal(
+    computeAwayAt({ lastSeen: NOW, idleSeconds: 60 * 60, lockedSeconds: 60 * 60 }),
+    NOW,
   );
 });
 
-test("shouldSuppressForDesktop: no presence ever → allow push", () => {
+test("desktopState: fresh + before awayAt → present", () => {
   assert.equal(
-    shouldSuppressForDesktop({ visible: false, lastSeen: 0, lastActive: 0 }, NOW),
-    false,
+    desktopState({ lastSeen: NOW, idleSeconds: 0, lockedSeconds: null, awayAt: NOW + 1000 }, NOW + 500),
+    "present",
   );
-  assert.equal(shouldSuppressForDesktop(null, NOW), false);
+});
+
+test("desktopState: fresh + past awayAt → away", () => {
+  assert.equal(
+    desktopState({ lastSeen: NOW, idleSeconds: 0, lockedSeconds: null, awayAt: NOW - 1 }, NOW),
+    "away",
+  );
+});
+
+test("desktopState: heartbeat older than TTL → gone", () => {
+  assert.equal(
+    desktopState({ lastSeen: NOW, idleSeconds: 0, lockedSeconds: null, awayAt: NOW + 1000 }, NOW + PRESENCE_TTL_MS + 1),
+    "gone",
+  );
+});
+
+test("desktopState: never-seen record (lastSeen 0) → gone", () => {
+  assert.equal(
+    desktopState({ lastSeen: 0, idleSeconds: 0, lockedSeconds: null, awayAt: Infinity }, NOW),
+    "gone",
+  );
+  assert.equal(desktopState(null, NOW), "gone");
+});
+
+test("setDesktopPresence: a lower incoming idleSeconds cancels all deferred mobile", async () => {
+  _resetPushState();
+  setDesktopSink(() => {});
+  // Desktop present at the real clock (idle 300s, unlocked): an informational
+  // notify routes deferMobile, so something gets parked.
+  setDesktopPresence({ idleSeconds: 300, lockedSeconds: null });
+  await fireNotify({ message: "build done", sessionID: "ses_c" });
+  assert.equal(_deferredMobileTags().length, 1);
+  // User produced input since the last heartbeat → lower idle → the parked push
+  // is cancelled (they'll see the desktop notification).
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null });
+  assert.deepEqual(_deferredMobileTags(), []);
+  _resetPushState();
+});
+
+test("setDesktopPresence: a higher incoming idleSeconds does NOT cancel deferred", async () => {
+  _resetPushState();
+  setDesktopSink(() => {});
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null });
+  await fireNotify({ message: "build done", sessionID: "ses_d" });
+  assert.equal(_deferredMobileTags().length, 1);
+  // Idle grew (user stopped typing) → NOT a "came back" signal → still parked.
+  setDesktopPresence({ idleSeconds: 60, lockedSeconds: null });
+  assert.equal(_deferredMobileTags().length, 1);
+  _resetPushState();
+});
+
+test("setDesktopPresence: the first-ever heartbeat does not throw or cancel deferred", () => {
+  _resetPushState();
+  setDesktopPresence({ idleSeconds: 0, lockedSeconds: null });
+  assert.deepEqual(_deferredMobileTags(), []);
+  _resetPushState();
+});
+
+test("setDesktopPresence: a malformed body does not throw and does not corrupt the record", () => {
+  _resetPushState();
+  const r = setDesktopPresence({ idleSeconds: "junk", lockedSeconds: undefined });
+  assert.equal(r.idleSeconds, 0, "non-finite/absent idle coerced to 0");
+  assert.equal(r.lockedSeconds, null, "absent locked coerced to null");
+  const r2 = setDesktopPresence({ idleSeconds: -3, lockedSeconds: NaN });
+  assert.equal(r2.idleSeconds, 0, "negative idle clamped to 0");
+  assert.equal(r2.lockedSeconds, null, "NaN locked coerced to null");
+  _resetPushState();
 });
 
 test("unrelated event → null", () => {
@@ -635,9 +702,9 @@ test("unrelated event → null", () => {
 // ---------------------------------------------------------------------------
 
 const T = 1_000_000_000;
-const dActive = { visible: true, lastSeen: T, lastActive: T }; // at the desk
-const dIdle = { visible: false, lastSeen: T, lastActive: 0 }; // app open, away
-const dGone = { visible: false, lastSeen: 0, lastActive: 0 }; // no heartbeat
+const dPresent = { lastSeen: T, idleSeconds: 0, lockedSeconds: null, awayAt: T + 100_000 }; // running, user at machine
+const dAway = { lastSeen: T, idleSeconds: 0, lockedSeconds: null, awayAt: T - 1 }; // running, user left
+const dGone = { lastSeen: T - PRESENCE_TTL_MS - 1, idleSeconds: 0, lockedSeconds: null, awayAt: Infinity }; // no heartbeat
 const noMobile = { focusSessionId: null, focusVisible: false };
 
 test("notifTier: blocking vs informational", () => {
@@ -649,24 +716,22 @@ test("notifTier: blocking vs informational", () => {
   assert.equal(notifTier({ kind: "done" }), "informational");
 });
 
-test("route: informational + desktop active → desktop only", () => {
+test("route: informational + desktop present → desktop now, mobile deferred", () => {
   const r = routeNotification(
     { kind: "done", sessionId: "ses_1" },
-    { desktop: dActive, ...noMobile },
+    { desktop: dPresent, ...noMobile },
     T,
   );
-  assert.deepEqual(r, { desktop: true, mobileNow: false, escalateAfterMs: null });
+  assert.deepEqual(r, { desktop: true, mobileNow: false, deferMobile: true });
 });
 
-test("route: informational + desktop idle → desktop now, escalate mobile", () => {
+test("route: informational + desktop away → desktop now + mobile now", () => {
   const r = routeNotification(
     { kind: "done", sessionId: "ses_1" },
-    { desktop: dIdle, ...noMobile },
+    { desktop: dAway, ...noMobile },
     T,
   );
-  assert.equal(r.desktop, true);
-  assert.equal(r.mobileNow, false);
-  assert.equal(r.escalateAfterMs, ESCALATE_MS);
+  assert.deepEqual(r, { desktop: true, mobileNow: true, deferMobile: false });
 });
 
 test("route: informational + desktop gone → mobile only", () => {
@@ -675,16 +740,26 @@ test("route: informational + desktop gone → mobile only", () => {
     { desktop: dGone, ...noMobile },
     T,
   );
-  assert.deepEqual(r, { desktop: false, mobileNow: true, escalateAfterMs: null });
+  assert.deepEqual(r, { desktop: false, mobileNow: true, deferMobile: false });
 });
 
-test("route: informational + mobile foreground on this session → no mobile, no escalation", () => {
-  const idle = routeNotification(
+test("route: informational + mobile foreground on this session → no mobile, no defer", () => {
+  // present + phone viewing this session → nothing parked for mobile.
+  const present = routeNotification(
     { kind: "done", sessionId: "ses_1" },
-    { desktop: dIdle, focusSessionId: "ses_1", focusVisible: true },
+    { desktop: dPresent, focusSessionId: "ses_1", focusVisible: true },
     T,
   );
-  assert.equal(idle.escalateAfterMs, null);
+  assert.deepEqual(present, { desktop: true, mobileNow: false, deferMobile: false });
+  // away + phone viewing this session → desktop only, no mobile.
+  const away = routeNotification(
+    { kind: "done", sessionId: "ses_1" },
+    { desktop: dAway, focusSessionId: "ses_1", focusVisible: true },
+    T,
+  );
+  assert.equal(away.mobileNow, false);
+  assert.equal(away.deferMobile, false);
+  // gone + phone viewing this session → no mobile.
   const gone = routeNotification(
     { kind: "done", sessionId: "ses_1" },
     { desktop: dGone, focusSessionId: "ses_1", focusVisible: true },
@@ -699,7 +774,7 @@ test("route: blocking → both devices now (desktop + mobile), even when gone", 
     { desktop: dGone, ...noMobile },
     T,
   );
-  assert.deepEqual(r, { desktop: true, mobileNow: true, escalateAfterMs: null });
+  assert.deepEqual(r, { desktop: true, mobileNow: true, deferMobile: false });
 });
 
 test("route: blocking + mobile viewing this session → desktop yes, mobile suppressed", () => {
@@ -713,39 +788,165 @@ test("route: blocking + mobile viewing this session → desktop yes, mobile supp
 });
 
 // ---------------------------------------------------------------------------
-// Escalation lifecycle (stateful)
+// Deferred mobile delivery (stateful)
 // ---------------------------------------------------------------------------
 
-test("escalation: idle desktop schedules a mobile escalation; desktop-active cancels it", async () => {
+test("deferred: desktop present parks the mobile push; going away flushes it", async () => {
   _resetPushState();
   setDesktopSink(() => {}); // no-op desktop leg
-  setDesktopPresence({ visible: false }); // fresh heartbeat, idle/away
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }); // fresh, present
   await fireNotify({ message: "build done", sessionID: "ses_esc" });
-  assert.deepEqual(_pendingEscalationTags(), ["notify-ses_esc"]);
-  setDesktopPresence({ visible: true }); // user returns to the desk
-  assert.deepEqual(_pendingEscalationTags(), []);
+  assert.deepEqual(_deferredMobileTags(), ["notify-ses_esc"]);
+  // The user leaves the desk → the next flush delivers.
+  setDesktopPresence({ idleSeconds: 60 * 60, lockedSeconds: null });
+  await flushDeferredMobile();
+  assert.deepEqual(_deferredMobileTags(), []);
   _resetPushState();
 });
 
-test("escalation: answering one session cancels only its escalation", async () => {
+test("deferred: a lower idle heartbeat (user returns) cancels ALL parked deliveries", async () => {
   _resetPushState();
-  setDesktopPresence({ visible: false });
+  setDesktopSink(() => {});
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }); // present
   await fireNotify({ message: "x", sessionID: "ses_a" });
   await fireNotify({ message: "y", sessionID: "ses_b" });
-  assert.equal(_pendingEscalationTags().length, 2);
-  cancelEscalationsForSession("ses_a");
-  assert.deepEqual(_pendingEscalationTags(), ["notify-ses_b"]);
+  assert.equal(_deferredMobileTags().length, 2);
+  setDesktopPresence({ idleSeconds: 0, lockedSeconds: null }); // fresh input
+  assert.deepEqual(_deferredMobileTags(), []);
   _resetPushState();
 });
 
-test("escalation: re-notify same tag supersedes (no duplicate timer)", async () => {
+test("deferred: answering one session cancels only its parked delivery", async () => {
   _resetPushState();
-  setDesktopPresence({ visible: false });
+  setDesktopSink(() => {});
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }); // present
+  await fireNotify({ message: "x", sessionID: "ses_a" });
+  await fireNotify({ message: "y", sessionID: "ses_b" });
+  assert.equal(_deferredMobileTags().length, 2);
+  cancelDeferredMobileForSession("ses_a");
+  assert.deepEqual(_deferredMobileTags(), ["notify-ses_b"]);
+  _resetPushState();
+});
+
+test("deferred: re-notify same tag supersedes (no stack)", async () => {
+  _resetPushState();
+  setDesktopSink(() => {});
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }); // present
   await fireNotify({ message: "first", sessionID: "ses_s" });
   await fireNotify({ message: "second", sessionID: "ses_s" });
-  assert.deepEqual(_pendingEscalationTags(), ["notify-ses_s"]);
-  cancelAllEscalations();
+  assert.deepEqual(_deferredMobileTags(), ["notify-ses_s"]);
+  cancelAllDeferredMobile();
   _resetPushState();
+});
+
+// Counts mobile sends (each sendPush → one APNs fanout fetch). Installs the
+// fanout fakes and returns a counter, for the flush tests below.
+function withFanoutCount() {
+  _resetFanoutFakesForTest();
+  const sends = { count: 0 };
+  _setFanoutFakesForTest({
+    fetchImpl: async () => {
+      sends.count++;
+      return { ok: true, status: 200, json: async () => ({ results: [] }) };
+    },
+    loadApnsTokens: async () => [{ kind: "apns", token: "f1a1", registeredAt: 1 }],
+    removeApnsToken: async () => ({ ok: true, count: 0 }),
+    readBoxGatewayIdentity: async () => ({
+      box_id: "abcdef0123456789abcdef0123456789",
+      gateway_token: "00112233445566778899aabbccddeeff",
+    }),
+    gatewayBase: "https://gateway.test.local",
+  });
+  return sends;
+}
+
+test("flushDeferredMobile: NOT sent while present", async () => {
+  _resetPushState();
+  setDesktopSink(() => {});
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }); // present
+  await fireNotify({ message: "held", sessionID: "ses_h" });
+  const sends = withFanoutCount();
+  await flushDeferredMobile();
+  assert.equal(sends.count, 0, "desktop still present → nothing delivered");
+  assert.equal(_deferredMobileTags().length, 1, "still parked");
+  _resetPushState();
+  _resetFanoutFakesForTest();
+});
+
+test("flushDeferredMobile: IS sent once the state reaches away", async () => {
+  _resetPushState();
+  setDesktopSink(() => {});
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }); // present
+  await fireNotify({ message: "held", sessionID: "ses_h" });
+  const sends = withFanoutCount();
+  // Idle grew to 1h → awayAt is now → the flush sees "away".
+  setDesktopPresence({ idleSeconds: 60 * 60, lockedSeconds: null });
+  await flushDeferredMobile();
+  assert.equal(sends.count, 1, "delivered to mobile once away");
+  assert.deepEqual(_deferredMobileTags(), []);
+  _resetPushState();
+  _resetFanoutFakesForTest();
+});
+
+test("flushDeferredMobile: IS sent when the state reaches gone", async () => {
+  _resetPushState();
+  setDesktopSink(() => {});
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }); // present
+  await fireNotify({ message: "held", sessionID: "ses_ng" });
+  const sends = withFanoutCount();
+  // Same idle (no cancel), but a stale lastSeen past the TTL → gone.
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }, Date.now() - PRESENCE_TTL_MS - 1);
+  await flushDeferredMobile();
+  assert.equal(sends.count, 1, "delivered to mobile once gone");
+  assert.deepEqual(_deferredMobileTags(), []);
+  _resetPushState();
+  _resetFanoutFakesForTest();
+});
+
+test("flushDeferredMobile: dropped without sending after 30 min", async () => {
+  _resetPushState();
+  setDesktopSink(() => {});
+  const t0 = Date.now();
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }, t0); // present
+  await fireNotify({ message: "held", sessionID: "ses_stale" }); // deferredAt ≈ t0
+  // 31 minutes later the desktop is still present (fresh same-idle heartbeat),
+  // but the parked notification is stale → dropped, not sent.
+  const t1 = t0 + 31 * 60_000;
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }, t1);
+  const sends = withFanoutCount();
+  await flushDeferredMobile(t1);
+  assert.equal(sends.count, 0, "stale parked push dropped without sending");
+  assert.deepEqual(_deferredMobileTags(), []);
+  _resetPushState();
+  _resetFanoutFakesForTest();
+});
+
+test("flushDeferredMobile: dropped by cancelDeferredMobileForSession", async () => {
+  _resetPushState();
+  setDesktopSink(() => {});
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null });
+  await fireNotify({ message: "held", sessionID: "ses_cn" });
+  cancelDeferredMobileForSession("ses_cn");
+  assert.deepEqual(_deferredMobileTags(), []);
+  _resetPushState();
+});
+
+test("REGRESSION: a deferred push that becomes deliverable flushes to EXACTLY ONE sendPush", async () => {
+  _resetPushState();
+  setDesktopSink(() => {});
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }); // present
+  await fireNotify({ message: "held", sessionID: "ses_once" });
+  assert.equal(_deferredMobileTags().length, 1);
+  const sends = withFanoutCount();
+  // Make it deliverable (gone) and flush twice — the second flush must send
+  // nothing because the entry was already delivered and removed.
+  setDesktopPresence({ idleSeconds: 5, lockedSeconds: null }, Date.now() - PRESENCE_TTL_MS - 1);
+  await flushDeferredMobile();
+  await flushDeferredMobile();
+  assert.equal(sends.count, 1, "exactly one sendPush across both flushes");
+  assert.deepEqual(_deferredMobileTags(), []);
+  _resetPushState();
+  _resetFanoutFakesForTest();
 });
 
 // ---------------------------------------------------------------------------
@@ -1152,4 +1353,121 @@ test("sendApnsFanout: all-invalid store prunes everything and sends nothing", as
       assert.equal(pruned.length, 1);
     },
   );
+});
+
+// ---------------------------------------------------------------------------
+// APNs case-insensitivity (BET-1044). Device tokens are hex; Apple routes either
+// spelling, so the same phone registered under two cases is ONE device — but an
+// exact-match store treated it as two and delivered every notification twice.
+// ---------------------------------------------------------------------------
+
+test("register-apns REGRESSION: upper- then lower-case same token → ONE entry (BET-1044)", async () => {
+  const store = makeApnsStorePath("case-dedupe");
+  try {
+    await addApnsToken("36DBB6F9abcdef", { store });
+    const r = await addApnsToken("36dbb6f9abcdef", { store });
+    assert.equal(r.count, 1, "case-differing re-registration is an upsert, not an append");
+    const tokens = await _loadApnsTokensForTest(store);
+    assert.equal(tokens.length, 1);
+    assert.equal(tokens[0].token, "36dbb6f9abcdef", "stored lowercased at the chokepoint");
+  } finally {
+    await rm(store, { force: true });
+  }
+});
+
+test("removeApnsToken REGRESSION: opposite case removes the stored entry (BET-1044)", async () => {
+  const store = makeApnsStorePath("case-remove");
+  try {
+    await addApnsToken("36dbb6f9abcdef", { store });
+    const r = await removeApnsToken("36DBB6F9ABCDEF", { store });
+    assert.equal(r.count, 0, "a prune reported in upper case matches the stored entry");
+    assert.equal((await _loadApnsTokensForTest(store)).length, 0);
+  } finally {
+    await rm(store, { force: true });
+  }
+});
+
+test("sendApnsFanout REGRESSION: collapses case-differing duplicate tokens to ONE delivery (BET-1044)", async () => {
+  await withValidationFanout(
+    {
+      storeTokens: [
+        { kind: "apns", token: "AA11", registeredAt: 1 },
+        { kind: "apns", token: "aa11", registeredAt: 2 },
+      ],
+    },
+    async ({ calls, pruned }) => {
+      await sendApnsFanout({ kind: "done" });
+      assert.equal(calls.length, 1);
+      const body = JSON.parse(calls[0].init.body);
+      assert.equal(body.tokens.length, 1, "both spellings → one token in the batch");
+      assert.equal(pruned.length, 1, "the duplicate spelling is self-healed out of the store");
+    },
+  );
+});
+
+// ---------------------------------------------------------------------------
+// One notification per event (BET-1044). Each opencode event arrives twice —
+// once on the global stream, once on the per-directory scoped one — so firePush
+// must drop an event whose id it has already seen, else session.error notifies
+// twice. Uses a permission.asked on a background-job child session: that kind is
+// NOT suppressed (a blocked job must still page the user), so the desktop sink
+// call is a clean per-notification observable.
+// ---------------------------------------------------------------------------
+
+function primeDelegateJob(childId) {
+  const jobsPath = statePath("delegate-jobs.json");
+  mkdirSync(statePath(), { recursive: true });
+  writeFileSync(jobsPath, JSON.stringify({ jobs: [{ childSessionID: childId }] }));
+  return jobsPath;
+}
+
+test("firePush REGRESSION: firing the same event twice → ONE notification (BET-1044)", async () => {
+  const jobsPath = primeDelegateJob("ses_dup1");
+  _resetPushState();
+  const sinkCalls = [];
+  setDesktopSink(() => sinkCalls.push(1));
+  try {
+    const evt = {
+      id: "evt_dup1",
+      type: "permission.asked",
+      properties: { sessionID: "ses_dup1", id: "per_dup1" },
+    };
+    await firePush(evt);
+    await firePush(evt);
+    assert.equal(sinkCalls.length, 1, "same event on both streams → one notification");
+  } finally {
+    rmSync(jobsPath, { force: true });
+    _resetPushState();
+  }
+});
+
+test("firePush: two events with different ids → two notifications", async () => {
+  const jobsPath = primeDelegateJob("ses_dup2");
+  _resetPushState();
+  const sinkCalls = [];
+  setDesktopSink(() => sinkCalls.push(1));
+  try {
+    const a = { id: "evt_a", type: "permission.asked", properties: { sessionID: "ses_dup2", id: "per_a" } };
+    const b = { id: "evt_b", type: "permission.asked", properties: { sessionID: "ses_dup2", id: "per_b" } };
+    await firePush(a);
+    await firePush(b);
+    assert.equal(sinkCalls.length, 2, "two distinct events → two notifications");
+  } finally {
+    rmSync(jobsPath, { force: true });
+    _resetPushState();
+  }
+});
+
+test("firePush: an event with no id is not dropped", async () => {
+  const jobsPath = primeDelegateJob("ses_noid");
+  _resetPushState();
+  const sinkCalls = [];
+  setDesktopSink(() => sinkCalls.push(1));
+  try {
+    await firePush({ type: "permission.asked", properties: { sessionID: "ses_noid", id: "per_noid" } });
+    assert.equal(sinkCalls.length, 1, "an id-less event still notifies (never silently swallowed)");
+  } finally {
+    rmSync(jobsPath, { force: true });
+    _resetPushState();
+  }
 });

--- a/src/server/seenIds.mjs
+++ b/src/server/seenIds.mjs
@@ -1,0 +1,39 @@
+// seenIds.mjs — bounded set of seen event ids, shared by the stream
+// interpreter and the push pump.
+//
+// The SAME opencode event is delivered on both the global stream and the
+// per-directory scoped one, so any consumer that reads raw events sees each
+// event twice. This filter de-duplicates by event id: `seen(id)` returns true
+// iff the id was already recorded (in which case the caller drops the event),
+// records it otherwise, and evicts the oldest half once the window exceeds
+// `cap` so a long-lived process doesn't grow without bound.
+//
+// Lifted verbatim from the inline logic that used to live in
+// streamInterp.mjs — behaviour is already proven there; this is the shared
+// extraction so firePush (src/server/push.mjs) can use the same guard.
+
+export function createSeenIdFilter(cap = 1000) {
+  const seen = new Set();
+  return {
+    /**
+     * @param {unknown} id
+     * @returns {boolean} true if `id` was already recorded (drop the event);
+     *   false if it was new (recorded now) or is not a recordable non-empty
+     *   string (never dropped — an event without an id is never swallowed).
+     */
+    seen(id) {
+      if (typeof id !== "string" || id.length === 0) return false;
+      if (seen.has(id)) return true;
+      seen.add(id);
+      if (seen.size > cap) {
+        // Drop the oldest half; insertion order is preserved by Set.
+        let drop = seen.size - cap / 2;
+        for (const key of seen) {
+          if (drop-- <= 0) break;
+          seen.delete(key);
+        }
+      }
+      return false;
+    },
+  };
+}

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -43,6 +43,7 @@ import {
   ASSUMED_CONTEXT_TOKENS,
 } from "../shared/streamInterpretation.mjs";
 import { planModeFromToolPart } from "../shared/planMode.mjs";
+import { createSeenIdFilter } from "./seenIds.mjs";
 
 const TTL_DEFAULT = "1h";
 
@@ -240,23 +241,9 @@ export function createStreamInterpreter({
   // per-directory scoped one, so interpret() is called twice for it. Un-deduped
   // that doubles every derived event — and because flushed text is APPENDED by
   // the client, a streamed answer arrived on the phone written out twice.
-  // Events carry a unique id; remember a bounded window of them.
-  const seenEventIds = new Set();
-  const SEEN_CAP = 1000;
-  function isDuplicate(id) {
-    if (typeof id !== "string" || id.length === 0) return false;
-    if (seenEventIds.has(id)) return true;
-    seenEventIds.add(id);
-    if (seenEventIds.size > SEEN_CAP) {
-      // Drop the oldest half; insertion order is preserved by Set.
-      let drop = seenEventIds.size - SEEN_CAP / 2;
-      for (const key of seenEventIds) {
-        if (drop-- <= 0) break;
-        seenEventIds.delete(key);
-      }
-    }
-    return false;
-  }
+  // Events carry a unique id; remember a bounded window of them (shared filter,
+  // lifted from this inline block so push.mjs can reuse the same guard).
+  const seenEventIds = createSeenIdFilter();
   function state(sid) {
     if (!sessions.has(sid)) sessions.set(sid, newSessionState());
     return sessions.get(sid);
@@ -283,7 +270,7 @@ export function createStreamInterpreter({
     if (!evt || typeof evt !== "object" || typeof evt.type !== "string") return;
     const sid = evt.properties?.sessionID;
     if (typeof sid !== "string" || sid.length === 0) return; // no session to interpret for
-    if (isDuplicate(evt.id)) return;
+    if (seenEventIds.seen(evt.id)) return;
 
     const st = state(sid);
     switch (evt.type) {


### PR DESCRIPTION
## BET-1044 — Push routing: presence from system idle + lock, deferred mobile delivery, and two duplicate-push fixes

One PR because all three tasks touch `src/server/push.mjs`. Three commits, one per task.

### Task 1 — presence from system idle + screen lock; deferred mobile delivery

- **`src/main/desktopPresence.ts`** now reports raw observations (`idleSeconds`, `lockedSeconds`) every 30s, unconditionally, forever while the app runs. Removed: the local active/idle classification, window-focus input, `visible` on the wire, and the edge-triggered reporting. Lock/suspend → record + heartbeat; unlock/resume → clear + heartbeat. All policy moved to the server.
- **`src/server/push.mjs`**: `computeAwayAt` merges the idle (10 min) and lock (5 min) thresholds into ONE away instant (a `min()`, not two timers); `desktopState` yields present/away/gone. The old `shouldSuppressForDesktop` + grace window + flat 90s escalation timers are gone, replaced by a parked `_deferredMobile` list + a 30s `flushDeferredMobile` / `startDeferredMobilePoller`. Routing matrix: present → desktop now + defer mobile; away → desktop now + mobile now; gone → mobile only. A lower idleSeconds heartbeat (user came back) cancels parked deliveries; a session resuming / ask answered cancels by session; a same-tag re-notify supersedes.
- **`src/server/index.mjs`**: passes `idleSeconds`/`lockedSeconds` through on `/push/desktop-presence`, logs `[push] desktop-presence idle=…s locked=…`, starts the new poller.
- Docs: `AGENTS.md` "Web Push notifications" section + `docs/manta-tools-notify.md` updated (why focus is not an input; why the two thresholds are one calculation).

### Task 2 — APNs device tokens deduped case-insensitively

`addApnsToken` lowercases at the single registration chokepoint; `removeApnsToken` lowercases its argument; `sendApnsFanout` self-heals a poisoned store by collapsing case-equal entries (same block as the invalid-token self-heal). One phone ⇒ one entry ⇒ one delivery.

### Task 3 — one notification per event, not per stream

Lifted the dedup logic from `streamInterp.mjs` into a shared `createSeenIdFilter` (`src/server/seenIds.mjs`); `streamInterp.mjs` uses the shared filter (its tests pass unchanged), and `firePush` drops an event whose id it has already seen (guarded to non-empty string ids), so a `session.error` notifies once.

## Files changed

`8` files. `git diff --stat`:

```
 AGENTS.md                   | 147 +++++++-------
 docs/manta-tools-notify.md  | 128 ++++++------
 src/main/desktopPresence.ts | 157 +++++++--------
 src/server/index.mjs        |  28 ++-
 src/server/push.mjs         | 325 +++++++++++++++----------------
 src/server/push.test.mjs    | 462 +++++++++++++++++++++++++++++++++++++-------
 src/server/seenIds.mjs      |  39 ++++
 src/server/streamInterp.mjs |  23 +--
```

Both `src/main/desktopPresence.ts` and `src/server/push.mjs` are NET SMALLER than `main`. No occurrence of `DESKTOP_GRACE_MS`, `ESCALATE_MS`, `shouldSuppressForDesktop`, or `anyWindowFocused` remains anywhere in the repo.

## Verification results

- PR branch (`multica/BET-1044-push-presence` @ `b1c716a8`):
  - typecheck: exit `0`. Errors: none. log sha256: `6e5e641a9769bff9efa7c143ea24b33d6df06880966801044d15cdcc72444d69`
  - test: exit `0`, `2211` pass / `0` fail / `0` skip. Failures: none. log sha256: `1d04f5e86e4d87f9224ab540fb27985a9dcf8abdf23b309536ae637866f38e44`
- Base: `main` @ `f9f2ef14` (origin/main has since advanced to `80963642` — the intervening PRs #1042/#1043 touch only mobile/native + renderer provider/opencode/rpc files, none overlapping this PR's changed files, so no conflict).
- Conclusion: `0` new test failures.

Logs cached at `/tmp/tc-pr.log` and `/tmp/t-pr.log` for spot-check.

## Follow-up shipped

None — all three tasks are contained in this PR. (The retired-but-not-asserted `notifTier`/blocking branch are left as-is per the issue: "the user has confirmed it is correct.")
