### PR TITLE
feat(ios): WhatsApp-style voice recording surfaces — slide to cancel, slide up to lock, locked bar (BET-1028)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */; };
 		4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */; };
 		51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */; };
+		52C319CA847D3FECBC1297E2 /* VoiceRecordingSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F06F838B4779D52B29E1173 /* VoiceRecordingSurface.swift */; };
 		578DA0FFC68283A72AF914E8 /* VoiceGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6717B2E85100A1BCAC163A31 /* VoiceGesture.swift */; };
 		5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */; };
 		5CDC4D3B2FD207C5E38A9AA1 /* MultilineTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */; };
@@ -49,6 +50,7 @@
 		685261838F0EFABC1AB8B6B1 /* MantaPairingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */; };
 		68760CC316BA947A82F360EE /* Scrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C440016971186430E8C464B /* Scrim.swift */; };
 		6A720AF41BDA6F4FC40A5585 /* ChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7631E09B6FF7B150392A83 /* ChatModels.swift */; };
+		708332CA7D72971C6626C9FC /* MantaVoiceRecordingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B1B02BB0060065B306394F /* MantaVoiceRecordingUITests.swift */; };
 		74D756D48A7D2A5483170A8B /* MantaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872DDE9D9BAD041950DAC24A /* MantaLoader.swift */; };
 		754FEC92229B58783D516DC4 /* ModelPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C97C92B5E1ADA62F799D73 /* ModelPickerSheet.swift */; };
 		75B97ECFE219AB9C7D45EDE3 /* Waveform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7B1F4E5EF7E0ADD2238839 /* Waveform.swift */; };
@@ -164,6 +166,7 @@
 		4F7631E09B6FF7B150392A83 /* ChatModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModels.swift; sourceTree = "<group>"; };
 		570E190164DB3AB83DC14283 /* MantaChatSurfaceCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaChatSurfaceCaptureUITests.swift; sourceTree = "<group>"; };
 		57FFB984A951D5C7BD8D02F9 /* MantaSettingsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsTests.swift; sourceTree = "<group>"; };
+		59B1B02BB0060065B306394F /* MantaVoiceRecordingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaVoiceRecordingUITests.swift; sourceTree = "<group>"; };
 		5AE55697AC4EC2304E05D8A1 /* BranchLabelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BranchLabelTests.swift; sourceTree = "<group>"; };
 		5B4D07F9EBDCD8A693C141FF /* MantaQRScanner.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaQRScanner.swift; sourceTree = "<group>"; };
 		5C02DA420B52094269A88E80 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
@@ -201,6 +204,7 @@
 		9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaTransportTests.swift; sourceTree = "<group>"; };
 		9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaActionRPCWireTests.swift; sourceTree = "<group>"; };
 		9DD6CA51FD8B7CE80314E0CD /* ModelRecents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelRecents.swift; sourceTree = "<group>"; };
+		9F06F838B4779D52B29E1173 /* VoiceRecordingSurface.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceRecordingSurface.swift; sourceTree = "<group>"; };
 		A1E78B0F5B521937B40937DC /* SettingsScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsScreen.swift; sourceTree = "<group>"; };
 		A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptComponents.swift; sourceTree = "<group>"; };
 		A2C97C92B5E1ADA62F799D73 /* ModelPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPickerSheet.swift; sourceTree = "<group>"; };
@@ -401,6 +405,7 @@
 				CAFF319B4F3CD4F13A20A1EB /* UsageStore.swift */,
 				6717B2E85100A1BCAC163A31 /* VoiceGesture.swift */,
 				4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */,
+				9F06F838B4779D52B29E1173 /* VoiceRecordingSurface.swift */,
 				8D7B1F4E5EF7E0ADD2238839 /* Waveform.swift */,
 				6C581AFB55001DF333A22728 /* Resources */,
 			);
@@ -431,6 +436,7 @@
 				12A39FBE813A8B20F7F00055 /* MantaSubagentDrillInUITests.swift */,
 				714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */,
 				5EF0199856D7E4C0B0D2595C /* MantaUIOverflowCaptureUITests.swift */,
+				59B1B02BB0060065B306394F /* MantaVoiceRecordingUITests.swift */,
 			);
 			path = MantaUIUITests;
 			sourceTree = "<group>";
@@ -603,6 +609,7 @@
 				DE5E17651AB0E9C750C4D712 /* MantaSubagentDrillInUITests.swift in Sources */,
 				4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */,
 				ECB0360A8A26279B6EEF955F /* MantaUIOverflowCaptureUITests.swift in Sources */,
+				708332CA7D72971C6626C9FC /* MantaVoiceRecordingUITests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -699,6 +706,7 @@
 				1E8A1AB9FB3945E6092CA2E2 /* UsageStore.swift in Sources */,
 				578DA0FFC68283A72AF914E8 /* VoiceGesture.swift in Sources */,
 				98A26A0ABAFE54728AE97FEE /* VoiceRecorder.swift in Sources */,
+				52C319CA847D3FECBC1297E2 /* VoiceRecordingSurface.swift in Sources */,
 				75B97ECFE219AB9C7D45EDE3 /* Waveform.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -74,6 +74,7 @@ struct ComposerView: View {
     /// owns forking + navigation; the composer just triggers it.
     var onSlashFork: (() -> Void)? = nil
     @Environment(\.colorScheme) private var colorScheme
+    @Environment(\.layoutDirection) private var layoutDirection
 
     @State private var text = ""
     @State private var attachments: [ComposerAttachment] = []
@@ -86,8 +87,9 @@ struct ComposerView: View {
     @FocusState private var inputFocused: Bool
     @StateObject private var recorder = VoiceRecorder()
     /// High-water flag for a press whose permission prompt is still resolving —
-    /// lets `micPress` re-check the finger is still down after the await.
-    @State private var micPressActive = false
+    /// lets the mic's press-start re-check after the await so a second change
+    /// doesn't double-request permission.
+    @State private var recordingStartInFlight = false
     /// Auto-dismiss task for the currently shown hint — tied to the hint's own
     /// identity so a new hint cancels and restarts the 4 s timer.
     @State private var hintDismissTask: Task<Void, Never>?
@@ -112,6 +114,9 @@ struct ComposerView: View {
     @State private var fileSearchTask: Task<Void, Never>?
     @State private var fileSearchSeq = 0
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
+    /// Whether the layout direction is right-to-left — mirrored for the
+    /// slide-to-cancel gesture (the machine + progress helpers mirror dx).
+    private var isRTL: Bool { layoutDirection == .rightToLeft }
 
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
@@ -155,10 +160,28 @@ struct ComposerView: View {
             // line, INSIDE the same glass as the input. Hence the composer is
             // two rows by default — type up top, act below — rather than a
             // one-row capsule with inline controls.
-            inputBox
+            //
+            // While a voice take is active the input box is REPLACED in place
+            // by the recording surface (BET-1028, decision #1) — same position,
+            // same outer padding, so nothing in the layout jumps. The surface
+            // renders the machine's `VoicePhase`; it owns no transition logic.
+            if recorder.phase == .idle {
+                inputBox
+                    .transition(.opacity)
+            } else {
+                VoiceRecordingSurface(
+                    recorder: recorder,
+                    isRTL: isRTL,
+                    onTake: { take in
+                        Task { await transcribe(data: take.data) }
+                    }
+                )
+                .transition(.opacity)
+            }
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
+        .animation(.smooth(duration: 0.22), value: recorder.phase != .idle)
         // ONE presentation per view. The model sheet, the photo picker and the
         // file importer were all attached HERE, and SwiftUI honours only one of
         // them — which is why attaching a file silently did nothing. The two
@@ -772,8 +795,7 @@ struct ComposerView: View {
 
     private var micButton: some View {
         Button {
-            // Tap without hold = no-op (recording is gesture-driven); kept as a
-            // hit target with an accessibility action that starts dictation.
+            // No-op on tap alone; recording is gesture-driven.
         } label: {
             ZStack {
                 // The disc is drawn only while RECORDING. At rest the glyph
@@ -795,10 +817,11 @@ struct ComposerView: View {
         .buttonStyle(.plain)
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
-                .onChanged { _ in micPress() }
-                .onEnded { _ in micRelease() }
+                .onChanged { _ in startRecordingIfPermitted() }
+                .onEnded { _ in }
         )
-        .accessibilityLabel("Hold to dictate")
+        .accessibilityLabel("Record")
+        .accessibilityHint("Tap to record, then slide up to lock or left to cancel")
         .accessibilityIdentifier("mic-button")
         .disabled(!micAvailable)
     }
@@ -815,36 +838,23 @@ struct ComposerView: View {
         recorder.isRecording ? tokens.onAccent : tokens.tx2
     }
 
-    private func micPress() {
-        guard micAvailable, !recorder.isRecording else { return }
-        // onChanged fires repeatedly during the permission await — one Task only.
-        guard !micPressActive else { return }
-        micPressActive = true
+    private func startRecordingIfPermitted() {
+        guard micAvailable, !recorder.isRecording, !recordingStartInFlight else { return }
+        recordingStartInFlight = true
         Task {
             let granted = await recorder.requestPermission()
             guard granted else {
-                micPressActive = false
+                recordingStartInFlight = false
                 recorder.fail("Microphone permission needed")
                 hintState("Microphone permission is required")
                 return
             }
-            // The finger may have lifted while the permission prompt was up —
-            // starting now would record with no press and wedge the phase guard
-            // (desktop parity: "cancel checked AFTER getUserMedia resolves").
-            guard micPressActive else { return }
+            // The finger may have lifted while the permission prompt was up;
+            // the held surface (which appears on start) owns the continued
+            // gesture, so we don't re-check here — desktop parity keeps the
+            // arms-the-take on press semantics of BET-1027.
+            recordingStartInFlight = false
             recorder.start()
-        }
-    }
-
-    private func micRelease() {
-        micPressActive = false
-        guard let take = recorder.stop() else {
-            // Too short — treat as an accidental tap, not an error (§ desktop
-            // too-short guard). Quiet.
-            return
-        }
-        Task {
-            await transcribe(data: take.data)
         }
     }
 
@@ -1186,7 +1196,7 @@ struct ComposerView: View {
 /// differ only in this number, and SwiftUI can interpolate it. Passing an
 /// `AnyShape` instead (a Capsule or a RoundedRectangle) type-erases the
 /// animatable data, which is what made the change snap in one frame.
-private struct BoxChrome: ViewModifier {
+struct BoxChrome: ViewModifier {
     let cornerRadius: CGFloat
     let stroke: Color
     /// A LIGHT wash laid UNDER the glass so the box reads slightly less

--- a/mobile/native/MantaUI/VoiceGesture.swift
+++ b/mobile/native/MantaUI/VoiceGesture.swift
@@ -10,19 +10,18 @@ import Foundation
 // re-basing that keeps paused time out of the cap, decision #5).
 //
 // ```
-//                  press
-// Idle ─────────────────────────► RecordingHeld
-//                                   │
-//    release, elapsed ≥ 400ms ──────┤──► .send
-//    release, elapsed < 400ms ──────┤──► Idle          (silent, no callback)
-//    drag up   > lockThreshold ─────┤──► RecordingLocked
-//    drag left > cancelThreshold ───┤──► Cancelling
-//                                   │
-// RecordingLocked ── tapSend ──► .send
-//                 ├─ tapPause ──► Paused ⇄ tapResume
-//                 └─ tapDiscard ──► .discard
-// Cancelling ── dragBack ──► RecordingHeld
-//            └─ release ──► .discard
+// Idle ─────────────────────────────────────────► RecordingHeld
+//   │                                                │
+//   │ press                                          │ release(hold,≥cap? no) → .send
+//   │ tapToggle                                      │ release(too short) → Idle (silent)
+//   ▼                                                │ drag up   > lockThreshold → RecordingLocked
+// RecordingLocked ◄───────────────────────────────── │ drag left > cancelThreshold → Cancelling
+//   │  tapToggle / tapSend ──► .send                  │
+//   │  tapDiscard ─────────► .discard                 │
+//   │  tapPause ──► Paused ⇄ tapResume                │
+// Cancelling ── dragBack ──► RecordingHeld            │
+//            └─ release ──► .discard                  │
+// RecordingLocked/Paused ── tapToggle ──► .send   (tap-toggle OFF; decision #5)
 // any ── elapsed ≥ 300_000ms ──► .send          (the take is KEPT)
 // any ── interrupted ──► .discard
 // ```
@@ -74,6 +73,11 @@ enum VoiceInput: Equatable {
     case tapPause
     case tapResume
     case tapDiscard
+    /// The tap-toggle path (decision #5): a tap ON starts a hands-free,
+    /// finger-up take (→ `.recordingLocked`), a tap while a take is live
+    /// sends it (toggle OFF). Distinct from `.release` so a quick tap is not
+    /// swallowed by the `.release` mis-tap discard rules.
+    case tapToggle
 }
 
 enum VoiceGesture {
@@ -164,6 +168,21 @@ enum VoiceGesture {
             default: return (currentPhase, .none)
             }
 
+        case .tapToggle:
+            switch currentPhase {
+            case .idle, .recordingHeld:
+                // Tap ON: start (or keep) a finger-up, hands-free take. A tap
+                // never needs the drag to be sustained, so it lands directly in
+                // the locked bar rather than the finger-down held surface —
+                // exactly the "usable without sustaining a drag" of decision #5.
+                return (.recordingLocked, .haptic(.arm))
+            case .recordingLocked, .paused:
+                // Tap OFF: stop and send.
+                return (.idle, .send)
+            default:
+                return (currentPhase, .none)
+            }
+
         case .interrupted:
             // handled above (unreachable)
             return (.idle, .discard)
@@ -203,5 +222,26 @@ enum VoiceGesture {
         default:
             return (currentPhase, .none)
         }
+    }
+
+    // MARK: - Drag → progress mapping (pure, view-facing)
+
+    /// 0...1 of how far the vertical drag is toward the lock threshold (lock is
+    /// sliding UP, so a negative `dy` advances it). Clamped. RTL never mirrors
+    /// the vertical axis, so `isRTL` is deliberately absent. The view uses this
+    /// to brighten the lock lane / scale its glyph as the lock threshold is
+    /// approached; it must NOT decide the transition itself.
+    static func lockProgress(dy: Double, threshold: Double = 80) -> Double {
+        guard threshold > 0 else { return 0 }
+        return min(1, max(0, -dy / threshold))
+    }
+
+    /// 0...1 of how far the horizontal drag is toward the cancel threshold,
+    /// with the direction mirrored for RTL (mirrors the machine's own mirror
+    /// so the hint/veil track the true cancel direction). Clamped.
+    static func cancelProgress(dx: Double, isRTL: Bool, threshold: Double = 64) -> Double {
+        let x = isRTL ? -dx : dx
+        guard threshold > 0 else { return 0 }
+        return min(1, max(0, -x / threshold))
     }
 }

--- a/mobile/native/MantaUI/VoiceGesture.swift
+++ b/mobile/native/MantaUI/VoiceGesture.swift
@@ -170,14 +170,14 @@ enum VoiceGesture {
 
         case .tapToggle:
             switch currentPhase {
-            case .idle, .recordingHeld:
-                // Tap ON: start (or keep) a finger-up, hands-free take. A tap
-                // never needs the drag to be sustained, so it lands directly in
-                // the locked bar rather than the finger-down held surface —
-                // exactly the "usable without sustaining a drag" of decision #5.
-                return (.recordingLocked, .haptic(.arm))
-            case .recordingLocked, .paused:
-                // Tap OFF: stop and send.
+            case .idle:
+                // Tap #1: start a finger-up take — the held surface shows
+                // immediately (decision #5: "Tap starts…without sustaining a
+                // drag").
+                return (.recordingHeld, .haptic(.arm))
+            case .recordingHeld, .recordingLocked, .paused:
+                // Tap #2: "…and a second tap stops" — stop and send. From a
+                // locked take this is the same as `.tapSend`.
                 return (.idle, .send)
             default:
                 return (currentPhase, .none)

--- a/mobile/native/MantaUI/VoiceRecorder.swift
+++ b/mobile/native/MantaUI/VoiceRecorder.swift
@@ -53,6 +53,14 @@ final class VoiceRecorder: ObservableObject {
         phase == .recordingHeld || phase == .recordingLocked
     }
 
+    /// The haptic the machine just asked the UI to play (arm / lock /
+    /// cancelArmed / send). The recorder computes it from the machine's output
+    /// but never plays it — the VIEW plays the haptic it describes, so the view
+    /// chooses nothing on its own (BET-1028: "Fire the haptics the machine
+    /// asks for; the view chooses no haptics itself"). Cleared by
+    /// `consumeHaptic()` once fired.
+    @Published private(set) var haptic: VoiceHaptic?
+
     /// Last non-phase error surfaced to the UI (e.g. a denied permission).
     @Published private(set) var lastError: String?
 
@@ -106,9 +114,10 @@ final class VoiceRecorder: ObservableObject {
         guard phase == .idle else { return }
 
         // Recording starts on PRESS (decision #4); the machine arms the take.
-        let (nextPhase, _effect) = VoiceGesture.transition(
+        let (nextPhase, effect) = VoiceGesture.transition(
             currentPhase: phase, input: .press, elapsedMs: 0)
         phase = nextPhase
+        publishHaptic(effect)
         stopRequested = false
         pendingTake = nil
         accumulatedMs = 0
@@ -166,24 +175,95 @@ final class VoiceRecorder: ObservableObject {
         let elapsed = currentElapsedMs()
         let (_next, effect) = VoiceGesture.transition(
             currentPhase: phase, input: .release, elapsedMs: elapsed)
-        recorder?.stop()
-        deactivateSession()
+        publishHaptic(effect)
 
         switch effect {
         case .send:
-            guard let url = fileURL,
-                  let data = try? Data(contentsOf: url), !data.isEmpty else {
-                reset()
-                return nil
-            }
-            let take = Take(data: data, durationMs: elapsed, peaks: storedPeaks)
-            reset()
-            return take
+            return finalizeTake()
         default:
             // Too short (silent mis-tap) or cancelled/discarded.
             reset()
             return nil
         }
+    }
+
+    /// The shared tail of every send path: stop capture, deactivate the audio
+    /// session, read the file, reset, and return the take. `nil` only when the
+    /// file is empty/missing (treated as "no speech", not an error).
+    private func finalizeTake() -> Take? {
+        recorder?.stop()
+        deactivateSession()
+        guard let url = fileURL,
+              let data = try? Data(contentsOf: url), !data.isEmpty else {
+            reset()
+            return nil
+        }
+        let take = Take(data: data, durationMs: currentElapsedMs(), peaks: storedPeaks)
+        publishHaptic(.send)
+        reset()
+        return take
+    }
+
+    /// Feed a drag translation from the held surface to the machine (BET-1028
+    /// slide-to-cancel / slide-up-to-lock). Only meaningful while the take is
+    /// held or cancelling; locked takes ignore drags. Returns the effect so the
+    /// view can play the haptic the machine asked for.
+    @discardableResult
+    func drag(dx: Double, dy: Double, isRTL: Bool = false) -> VoiceEffect {
+        guard phase == .recordingHeld || phase == .cancelling else { return .none }
+        let (next, effect) = VoiceGesture.transition(
+            currentPhase: phase, input: .drag(dx: dx, dy: dy),
+            elapsedMs: currentElapsedMs(), isRTL: isRTL)
+        phase = next
+        publishHaptic(effect)
+        return effect
+    }
+
+    /// The tap-toggle path (decision #5): a tap ON starts a hands-free,
+    /// finger-up take (→ `.recordingLocked`); a tap while a take is live sends
+    /// it (toggle OFF). Feed the machine's `.tapToggle`; returns the finished
+    /// take only when the tap ends the take.
+    @discardableResult
+    func tapToggle() -> Take? {
+        guard phase != .idle else { return nil }
+        let (next, effect) = VoiceGesture.transition(
+            currentPhase: phase, input: .tapToggle, elapsedMs: currentElapsedMs())
+        publishHaptic(effect)
+        if next == .idle {
+            // toggle OFF → stop and send.
+            return finalizeTake()
+        }
+        phase = next
+        return nil
+    }
+
+    /// Locked-bar send: feed the machine's `.tapSend` and return the take.
+    @discardableResult
+    func sendLockedTake() -> Take? {
+        guard phase == .recordingLocked || phase == .paused else { return nil }
+        let (next, effect) = VoiceGesture.transition(
+            currentPhase: phase, input: .tapSend, elapsedMs: currentElapsedMs())
+        publishHaptic(effect)
+        guard next == .idle else { return nil }
+        return finalizeTake()
+    }
+
+    /// Locked-bar discard: feed the machine's `.tapDiscard` and reset. Returns
+    /// whether the take was actually discarded (false when no live take).
+    @discardableResult
+    func discardLockedTake() -> Bool {
+        guard phase == .recordingLocked || phase == .paused else { return false }
+        let (next, _effect) = VoiceGesture.transition(
+            currentPhase: phase, input: .tapDiscard, elapsedMs: currentElapsedMs())
+        guard next == .idle else { return false }
+        reset()
+        return true
+    }
+
+    /// Clear the published haptic after the view has played it, so a later
+    /// identical haptic still fires its `.onChange`.
+    func consumeHaptic() {
+        haptic = nil
     }
 
     /// Pause an active locked take (the sibling locked-bar UI). Paused time is
@@ -213,6 +293,17 @@ final class VoiceRecorder: ObservableObject {
     /// not alter the gesture phase — take state is owned by the machine.
     func fail(_ message: String) {
         lastError = message
+    }
+
+    /// Publish the machine's haptic intent (arm / lock / cancelArmed / send).
+    /// The recorder never plays a haptic — the view does, from the value the
+    /// machine produced.
+    private func publishHaptic(_ effect: VoiceEffect) {
+        switch effect {
+        case .haptic(let h): haptic = h
+        case .send: haptic = .send
+        case .none, .discard: break
+        }
     }
 
     // MARK: - Metering
@@ -320,6 +411,7 @@ final class VoiceRecorder: ObservableObject {
         livePeaks = []
         storedPeaks = []
         lastLinearLevel = 0
+        haptic = nil
         phase = .idle
     }
 }

--- a/mobile/native/MantaUI/VoiceRecorder.swift
+++ b/mobile/native/MantaUI/VoiceRecorder.swift
@@ -118,6 +118,12 @@ final class VoiceRecorder: ObservableObject {
             currentPhase: phase, input: .press, elapsedMs: 0)
         phase = nextPhase
         publishHaptic(effect)
+        beginCapture()
+    }
+
+    /// Begin the audio capture after the machine has armed a take. Shared by
+    /// the press-start (`start()`) and the first tap of the tap-toggle path.
+    private func beginCapture() {
         stopRequested = false
         pendingTake = nil
         accumulatedMs = 0
@@ -225,12 +231,20 @@ final class VoiceRecorder: ObservableObject {
     /// take only when the tap ends the take.
     @discardableResult
     func tapToggle() -> Take? {
-        guard phase != .idle else { return nil }
+        if phase == .idle {
+            // Tap #1: start a finger-up take into the held surface.
+            let (next, effect) = VoiceGesture.transition(
+                currentPhase: .idle, input: .tapToggle, elapsedMs: 0)
+            phase = next
+            publishHaptic(effect)
+            beginCapture()
+            return nil
+        }
         let (next, effect) = VoiceGesture.transition(
             currentPhase: phase, input: .tapToggle, elapsedMs: currentElapsedMs())
         publishHaptic(effect)
         if next == .idle {
-            // toggle OFF → stop and send.
+            // Tap #2: "a second tap stops" — stop and send.
             return finalizeTake()
         }
         phase = next

--- a/mobile/native/MantaUI/VoiceRecordingSurface.swift
+++ b/mobile/native/MantaUI/VoiceRecordingSurface.swift
@@ -1,0 +1,459 @@
+import SwiftUI
+import UIKit
+
+// ===========================================================================
+// BET-1028 — the WhatsApp-style recording surfaces.
+//
+// The view layer over the pure gesture machine (`VoiceGesture.swift`) and the
+// metering recorder (`VoiceRecorder.swift`, BET-1027). It renders the machine's
+// `VoicePhase` and sends INPUTS (press / drag / release / tap) to it; it owns
+// NO transition logic — every `if` deciding what recording should do next lives
+// in `VoiceGesture.swift`. The only branch here is which SURFACE to draw for
+// the phase the machine reports.
+//
+// Both surfaces REPLACE the composer box in place (same outer padding), reuse
+// the composer's shared `BoxChrome` glass, and derive every colour/spacing from
+// the tokens. No hex, no new token, no second glass recipe.
+// ===========================================================================
+
+/// The live, scrolling waveform bar row. Takes peaks ALREADY bucketed to
+/// `0...1` (newest at the trailing edge) by the caller. It deliberately does
+/// NOT call `Waveform.normalizeForDisplay` — the live meter pins its ceiling
+/// at 1.0 on purpose (see the `Waveform` doc), and renormalising a scrolling
+/// window would make every previously-drawn bar jump each time a new loudest
+/// sample arrives.
+struct VoiceLiveWaveform: View {
+    let peaks: [Double]
+    let tokens: Tokens
+
+    var body: some View {
+        let barWidth = Metrics.spacing.spPx * 2
+        let barGap = Metrics.spacing.spPx * 2
+        let maxBarHeight = Metrics.spacing.sp5
+        HStack(alignment: .center, spacing: barGap) {
+            ForEach(Array(peaks.enumerated()), id: \.offset) { index, peak in
+                let p = min(1, max(0, peak))
+                RoundedRectangle(cornerRadius: Metrics.radius.full, style: .continuous)
+                    .fill(tokens.accentTx.opacity(0.9))
+                    .frame(width: barWidth, height: max(barWidth, maxBarHeight * p))
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .trailing)
+        .frame(height: maxBarHeight)
+        .clipped()
+        .accessibilityLabel("Live audio waveform")
+    }
+}
+
+// MARK: - Surface A · Recording — held
+
+/// The finger-down held surface: record dot + timer + the "‹ slide to cancel"
+/// hint, with the lock lane floating to the right. Renders while
+/// `recorder.phase == .recordingHeld` and hosts the ongoing hold gesture
+/// (slide up → lock, slide left → cancel, release → send).
+struct VoiceRecordingHeldView: View {
+    @ObservedObject var recorder: VoiceRecorder
+    let isRTL: Bool
+    let tokens: Tokens
+    var onTake: (VoiceRecorder.Take) -> Void = { _ in }
+
+    @State private var translation: CGSize = .zero
+    @State private var dragStart: Date?
+
+    /// The enlarged mic in the lane — 38 (chatHeaderBtn) + 8 (sp2) = 46, derived,
+    /// never hardcoded. The glyph sits on the accent at the composer's body size.
+    private var micDiameter: CGFloat { Metrics.type.chatHeaderBtn + Metrics.spacing.sp2 }
+    private var micGlyphSize: CGFloat { Metrics.type.body }
+
+    var body: some View {
+        let lockP = VoiceGesture.lockProgress(dy: translation.height)
+        let cancelP = VoiceGesture.cancelProgress(dx: translation.width, isRTL: isRTL)
+        let hintShift = cancelP * (micDiameter + Metrics.spacing.sp3)
+
+        ZStack(alignment: .bottomTrailing) {
+            HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
+                AccessoryDot(danger: tokens.danger)
+                timer
+                cancelHint(progress: cancelP, shift: hintShift, isRTL: isRTL)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+
+            lockLane(lockProgress: lockP)
+                .padding(.trailing, Metrics.spacing.sp3)
+                .padding(.bottom, Metrics.spacing.sp2)
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp3)
+        .contentShape(Rectangle())
+        .gesture(
+            DragGesture(minimumDistance: 0)
+                .onChanged { value in
+                    if dragStart == nil { dragStart = Date() }
+                    translation = value.translation
+                    recorder.drag(dx: value.translation.width, dy: value.translation.height, isRTL: isRTL)
+                }
+                .onEnded { _ in
+                    withAnimation(.smooth(duration: 0.22)) { translation = .zero }
+                    finishHoldRelease()
+                }
+        )
+        .accessibilityIdentifier("voice-recording-held")
+    }
+
+    // MARK: records
+
+    /// The tabular mono-digit elapsed clock.
+    private var timer: some View {
+        Text(Waveform.formatClock(recorder.durationMs))
+            .font(.manta(size: Metrics.type.body, weight: .semibold).monospacedDigit())
+            .foregroundColor(tokens.tx1)
+            .accessibilityHidden(true)
+    }
+
+    /// The "‹ slide to cancel" hint — translates with the drag and fades toward
+    /// 0 as the cancel threshold is approached.
+    @ViewBuilder
+    private func cancelHint(progress: Double, shift: CGFloat, isRTL: Bool) -> some View {
+        HStack {
+            if isRTL { Spacer(minLength: 0) }
+            Text("‹ slide to cancel")
+                .font(.manta(size: Metrics.type.small))
+                .foregroundColor(tokens.tx3)
+                .opacity(0.85 * (1 - progress))
+                .offset(x: isRTL ? -shift : shift)
+                .animation(.smooth(duration: 0.05), value: shift)
+            if !isRTL { Spacer(minLength: 0) }
+        }
+        .frame(maxWidth: .infinity)
+        .accessibilityHidden(true)
+    }
+
+    // MARK: lock lane
+
+    /// The floating lock lane — chevron, lock glyph, enlarged mic — appearing
+    /// only while held. The lock glyph brightens to `accentTx` as the lock
+    /// threshold is approached.
+    private func lockLane(lockProgress: Double) -> some View {
+        VStack(spacing: Metrics.spacing.sp2) {
+            Image(systemName: "chevron.up")
+                .font(.system(size: Metrics.type.xs, weight: .bold))
+                .foregroundColor(tokens.tx2)
+            Image(systemName: "lock")
+                .font(.system(size: Metrics.type.small))
+                .foregroundColor(lockGlyphColor(progress: lockProgress))
+            mic
+        }
+        .frame(width: Metrics.spacing.spPx * 46)
+        .padding(.vertical, Metrics.spacing.sp3)
+        .background(tokens.raised.opacity(0.9), in: Capsule())
+        .overlay(Capsule().stroke(tokens.borderSubtle, lineWidth: 1))
+        .accessibilityIdentifier("voice-lock-lane")
+    }
+
+    private func lockGlyphColor(progress: Double) -> Color {
+        // Fade tx3 → accentTx as the lock threshold is approached.
+        let p = progress
+        if p >= 1 { return tokens.accentTx }
+        // Linear interpolation between the two token colours.
+        return interpolate(from: tokens.tx3, to: tokens.accentTx, t: p)
+    }
+
+    private var mic: some View {
+        ZStack {
+            Circle()
+                .fill(tokens.accentSolid)
+                .frame(width: micDiameter, height: micDiameter)
+                .overlay(
+                    Circle()
+                        .stroke(tokens.accent.opacity(0.14), lineWidth: 8)
+                )
+            Image(systemName: "mic.fill")
+                .font(.system(size: micGlyphSize, weight: .semibold))
+                .foregroundColor(tokens.onAccent)
+        }
+        .frame(width: micDiameter, height: micDiameter)
+        .contentShape(Rectangle())
+    }
+
+    /// Colour-lerp — both args are token colours, no raw component math.
+    private func interpolate(from a: Color, to b: Color, t: Double) -> Color {
+        guard t > 0 else { return tokens.tx3 }
+        guard t < 1 else { return tokens.accentTx }
+        let uiA = UIColor(a), uiB = UIColor(b)
+        var ra: CGFloat = 0; var ga: CGFloat = 0; var ba: CGFloat = 0; var aa: CGFloat = 0
+        var rb: CGFloat = 0; var gb: CGFloat = 0; var bb: CGFloat = 0; var ab: CGFloat = 0
+        uiA.getRed(&ra, green: &ga, blue: &ba, alpha: &aa)
+        uiB.getRed(&rb, green: &gb, blue: &bb, alpha: &ab)
+        let tt = CGFloat(t)
+        return Color(
+            .sRGB,
+            red: ra + (rb - ra) * tt,
+            green: ga + (gb - ga) * tt,
+            blue: ba + (bb - ba) * tt,
+            opacity: aa + (ab - aa) * tt
+        )
+    }
+
+    // MARK: release
+
+    /// Map the end of a hold to the machine. `VoiceGesture` owns every branch;
+    /// we only pick the INPUT for the gesture that just ended.
+    private func finishHoldRelease() {
+        let heldMs = dragStart.map { Int(Date().timeIntervalSince($0) * 1000) } ?? 0
+        dragStart = nil
+        switch recorder.phase {
+        case .cancelling:
+            // sliding left then release → discard.
+            recorder.stop()
+        case .recordingLocked:
+            // already locked — release is a no-op; the bar owns the take now.
+            break
+        case .recordingHeld:
+            if heldMs < Int(Waveform.Constants.tapHoldMs) {
+                // A tap while held toggles ON → fingers-free locked bar.
+                onTakeFrom(recorder.tapToggle())
+            } else {
+                // A hold + release → send.
+                onTakeFrom(recorder.stop())
+            }
+        default:
+            break
+        }
+    }
+
+    private func onTakeFrom(_ take: VoiceRecorder.Take?) {
+        if let take { onTake(take) }
+    }
+}
+
+// MARK: - Surface C · Recording — locked
+
+/// The hands-free locked surface: head row (record dot, timer, live waveform),
+/// optional remaining-time line, and the discard / pause / send bar. Renders
+/// while the machine is `.recordingLocked` or `.paused`. Tapping the surface
+/// (away from a button) is the tap-toggle OFF — it stops and sends.
+struct VoiceRecordingLockedView: View {
+    @ObservedObject var recorder: VoiceRecorder
+    let tokens: Tokens
+    var onTake: (VoiceRecorder.Take) -> Void = { _ in }
+    var onDiscarded: () -> Void = {}
+
+    private let buttonSize = Metrics.type.chatHeaderBtn
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
+            // Head row: record dot + timer + live waveform (right-aligned).
+            HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
+                VoiceRecordingHeldView.AccessoryDot(danger: tokens.danger)
+                timer
+                Spacer(minLength: Metrics.spacing.sp2)
+                VoiceLiveWaveform(peaks: recorder.livePeaks, tokens: tokens)
+                    .frame(maxWidth: .infinity)
+            }
+
+            // Remaining-time line — only inside the warn window.
+            if remaining < Waveform.Constants.warnRemainingMs {
+                Text(Waveform.formatClock(remaining) + " left")
+                    .font(.manta(size: Metrics.type.twoXS))
+                    .foregroundColor(tokens.warn)
+            }
+
+            // Discard / pause / send bar.
+            HStack(spacing: Metrics.spacing.sp6) {
+                discardButton
+                Spacer(minLength: 0)
+                pauseButton
+                Spacer(minLength: 0)
+                sendButton
+            }
+            .padding(.horizontal, Metrics.spacing.sp2)
+
+            // Hint.
+            Text("tap ❙❙ to pause · ➤ transcribes and sends")
+                .font(.manta(size: Metrics.type.twoXS))
+                .foregroundColor(tokens.tx4)
+                .frame(maxWidth: .infinity)
+                .lineLimit(1)
+                .minimumScaleFactor(0.8)
+                .accessibilityHidden(true)
+        }
+        .padding(Metrics.spacing.sp3)
+        .contentShape(Rectangle())
+        .onTapGesture {
+            // Tap-toggle OFF: a second tap stops and sends.
+            onTakeFrom(recorder.tapToggle())
+        }
+        .accessibilityIdentifier("voice-recording-locked")
+    }
+
+    private var remaining: Int {
+        max(0, Waveform.Constants.maxDurationMs - recorder.durationMs)
+    }
+
+    private var timer: some View {
+        Text(Waveform.formatClock(recorder.durationMs))
+            .font(.manta(size: Metrics.type.body, weight: .semibold).monospacedDigit())
+            .foregroundColor(tokens.tx1)
+            .accessibilityHidden(true)
+    }
+
+    private var discardButton: some View {
+        Button {
+            if recorder.discardLockedTake() {
+                onDiscarded()
+            }
+        } label: {
+            Image(systemName: "trash")
+                .font(.system(size: Metrics.type.small, weight: .semibold))
+                .foregroundColor(tokens.tx2)
+                .frame(width: buttonSize, height: buttonSize)
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Discard recording")
+        .accessibilityIdentifier("voice-discard")
+    }
+
+    private var pauseButton: some View {
+        Button {
+            if recorder.phase == .paused {
+                recorder.resume()
+            } else {
+                recorder.pause()
+            }
+        } label: {
+            Image(systemName: recorder.phase == .paused ? "play.fill" : "pause.fill")
+                .font(.system(size: Metrics.type.small, weight: .semibold))
+                .foregroundColor(tokens.danger)
+                .frame(width: buttonSize, height: buttonSize)
+                .overlay(Circle().stroke(tokens.danger, lineWidth: 2))
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(recorder.phase == .paused ? "Resume recording" : "Pause recording")
+        .accessibilityIdentifier("voice-pause")
+    }
+
+    private var sendButton: some View {
+        Button {
+            onTakeFrom(recorder.sendLockedTake())
+        } label: {
+            Image(systemName: "arrow.up")
+                .font(.system(size: Metrics.type.body, weight: .semibold))
+                .foregroundColor(tokens.onAccent)
+                .frame(width: buttonSize, height: buttonSize)
+                .background(AnyShapeStyle(tokens.accentSolid), in: Circle())
+                .contentShape(Circle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel("Send recording")
+        .accessibilityIdentifier("voice-send")
+    }
+
+    private func onTakeFrom(_ take: VoiceRecorder.Take?) {
+        if let take { onTake(take) }
+    }
+}
+
+// MARK: - Dispatcher
+
+/// Renders whichever surface the machine's `VoicePhase` asks for, and owns the
+/// phase→VoiceOver announcements + haptic playback the machine requests. This
+/// is the single surface ComposerView swaps in for the input box.
+struct VoiceRecordingSurface: View {
+    @ObservedObject var recorder: VoiceRecorder
+    let isRTL: Bool
+    var onTake: (VoiceRecorder.Take) -> Void = { _ in }
+
+    private var tokens: Tokens { Tokens.scheme(environment) }
+    @Environment(\.colorScheme) private var environment
+
+    @State private var lastAnnounced: VoicePhase?
+
+    var body: some View {
+        // The shared BoxChrome glass — applied ONCE here so each surface uses
+        // exactly the same modifier (no second glass recipe anywhere).
+        Group {
+            switch recorder.phase {
+            case .recordingHeld:
+                VoiceRecordingHeldView(recorder: recorder, isRTL: isRTL, tokens: tokens, onTake: onTake)
+            case .recordingLocked, .paused:
+                VoiceRecordingLockedView(recorder: recorder, tokens: tokens, onTake: onTake, onDiscarded: { announceDiscard() })
+            default:
+                EmptyView()
+            }
+        }
+        .modifier(BoxChrome(cornerRadius: Metrics.radius.xl, stroke: tokens.borderSubtle, tint: tokens.panel.opacity(0.35)))
+        .onAppear { lastAnnounced = recorder.phase }
+        .onChange(of: recorder.phase) { _, newPhase in
+            announce(previous: lastAnnounced, current: newPhase)
+            lastAnnounced = newPhase
+        }
+        .onChange(of: recorder.haptic) { _, newValue in
+            guard let haptic = newValue else { return }
+            VoiceHapticPlayer.play(haptic)
+            recorder.consumeHaptic()
+        }
+    }
+
+    // MARK: VoiceOver announcements (decision #4)
+
+    // Delivered as polite `UIAccessibility` announcements — the canonical live
+    // region for a dialog-free state change. The timer is deliberately excluded.
+
+    private func announce(previous: VoicePhase?, current: VoicePhase) {
+        let message: String? = switch (previous, current) {
+        case (.idle, .recordingHeld), (.idle, .recordingLocked): "Recording started"
+        case (.recordingHeld, .recordingLocked): "Recording locked"
+        case (.recordingLocked, .paused): "Recording paused"
+        case (.paused, .recordingLocked): "Recording resumed"
+        case (.cancelling, .idle): "Recording discarded"
+        default: nil
+        }
+        if let message {
+            UIAccessibility.post(notification: .announcement, argument: message)
+        }
+    }
+
+    private func announceDiscard() {
+        UIAccessibility.post(notification: .announcement, argument: "Recording discarded")
+    }
+}
+
+/// Physical playback of a machine-requested haptic. The VIEW maps a machine
+/// haptic to the strongest system feedback for it, but never decides WHEN one
+/// fires — that is the machine's output.
+@MainActor
+enum VoiceHapticPlayer {
+    static func play(_ haptic: VoiceHaptic) {
+        switch haptic {
+        case .arm:
+            UIImpactFeedbackGenerator(style: .light).impactOccurred()
+        case .lock, .send:
+            UIImpactFeedbackGenerator(style: .medium).impactOccurred()
+        case .cancelArmed:
+            UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
+        }
+    }
+}
+
+extension VoiceRecordingHeldView {
+    /// The pulsing record dot, shared with the locked surface's head row.
+    struct AccessoryDot: View {
+        let danger: Color
+        @State private var pulse = false
+        var body: some View {
+            Circle()
+                .fill(danger)
+                .frame(width: Metrics.spacing.spPx * 11, height: Metrics.spacing.spPx * 11)
+                .overlay(
+                    Circle()
+                        .stroke(danger.opacity(0.16), lineWidth: 4)
+                )
+                .opacity(pulse ? 1 : 0.55)
+                .animation(.smooth(duration: 0.9).repeatForever(autoreverses: true), value: pulse)
+                .onAppear { pulse = true }
+                .accessibilityHidden(true)
+        }
+    }
+}

--- a/mobile/native/MantaUI/VoiceRecordingSurface.swift
+++ b/mobile/native/MantaUI/VoiceRecordingSurface.swift
@@ -68,23 +68,29 @@ struct VoiceRecordingHeldView: View {
     var body: some View {
         let lockP = VoiceGesture.lockProgress(dy: translation.height)
         let cancelP = VoiceGesture.cancelProgress(dx: translation.width, isRTL: isRTL)
+        let isCancelling = recorder.phase == .cancelling
         let hintShift = cancelP * (micDiameter + Metrics.spacing.sp3)
 
         ZStack(alignment: .bottomTrailing) {
             HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
                 AccessoryDot(danger: tokens.danger)
                 timer
-                cancelHint(progress: cancelP, shift: hintShift, isRTL: isRTL)
+                cancelHint(progress: cancelP, shift: hintShift, isRTL: isRTL, isCancelling: isCancelling)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
 
-            lockLane(lockProgress: lockP)
+            lockLane(lockProgress: lockP, isCancelling: isCancelling)
                 .padding(.trailing, Metrics.spacing.sp3)
                 .padding(.bottom, Metrics.spacing.sp2)
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp3)
         .contentShape(Rectangle())
+        // One accessibility element for the whole held surface (children stay
+        // individually reachable), so `voice-recording-held` resolves to a
+        // single element instead of propagating to every child in the AX tree.
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("voice-recording-held")
         .gesture(
             DragGesture(minimumDistance: 0)
                 .onChanged { value in
@@ -97,7 +103,6 @@ struct VoiceRecordingHeldView: View {
                     finishHoldRelease()
                 }
         )
-        .accessibilityIdentifier("voice-recording-held")
     }
 
     // MARK: records
@@ -111,15 +116,20 @@ struct VoiceRecordingHeldView: View {
     }
 
     /// The "‹ slide to cancel" hint — translates with the drag and fades toward
-    /// 0 as the cancel threshold is approached.
+    /// 0 as the cancel threshold is approached. Once the take is actually in
+    /// the cancelling phase it flips to a solid danger "release to cancel" —
+    /// still on the same held surface so the drag gesture stays mounted.
     @ViewBuilder
-    private func cancelHint(progress: Double, shift: CGFloat, isRTL: Bool) -> some View {
+    private func cancelHint(progress: Double, shift: CGFloat, isRTL: Bool, isCancelling: Bool) -> some View {
+        let text = isCancelling ? "release to cancel" : "‹ slide to cancel"
+        let color = isCancelling ? tokens.danger : tokens.tx3
+        let opacity = isCancelling ? 1.0 : 0.85 * (1 - progress)
         HStack {
             if isRTL { Spacer(minLength: 0) }
-            Text("‹ slide to cancel")
-                .font(.manta(size: Metrics.type.small))
-                .foregroundColor(tokens.tx3)
-                .opacity(0.85 * (1 - progress))
+            Text(text)
+                .font(.manta(size: Metrics.type.small, weight: isCancelling ? mantaFontWeight(Metrics.type.semibold) : .regular))
+                .foregroundColor(color)
+                .opacity(opacity)
                 .offset(x: isRTL ? -shift : shift)
                 .animation(.smooth(duration: 0.05), value: shift)
             if !isRTL { Spacer(minLength: 0) }
@@ -133,7 +143,7 @@ struct VoiceRecordingHeldView: View {
     /// The floating lock lane — chevron, lock glyph, enlarged mic — appearing
     /// only while held. The lock glyph brightens to `accentTx` as the lock
     /// threshold is approached.
-    private func lockLane(lockProgress: Double) -> some View {
+    private func lockLane(lockProgress: Double, isCancelling: Bool) -> some View {
         VStack(spacing: Metrics.spacing.sp2) {
             Image(systemName: "chevron.up")
                 .font(.system(size: Metrics.type.xs, weight: .bold))
@@ -283,6 +293,9 @@ struct VoiceRecordingLockedView: View {
             // Tap-toggle OFF: a second tap stops and sends.
             onTakeFrom(recorder.tapToggle())
         }
+        // One accessibility element for the surface; the bar's three buttons
+        // remain separate interactive elements (they carry their own ids).
+        .accessibilityElement(children: .contain)
         .accessibilityIdentifier("voice-recording-locked")
     }
 
@@ -375,7 +388,10 @@ struct VoiceRecordingSurface: View {
         // exactly the same modifier (no second glass recipe anywhere).
         Group {
             switch recorder.phase {
-            case .recordingHeld:
+            case .recordingHeld, .cancelling:
+                // `.cancelling` renders through the held surface too so its
+                // drag gesture stays mounted (swapping it away mid-drag would
+                // cancel the gesture and lose the release→discard).
                 VoiceRecordingHeldView(recorder: recorder, isRTL: isRTL, tokens: tokens, onTake: onTake)
             case .recordingLocked, .paused:
                 VoiceRecordingLockedView(recorder: recorder, tokens: tokens, onTake: onTake, onDiscarded: { announceDiscard() })

--- a/mobile/native/MantaUITests/VoiceGestureTests.swift
+++ b/mobile/native/MantaUITests/VoiceGestureTests.swift
@@ -183,4 +183,66 @@ final class VoiceGestureTests: XCTestCase {
         let rtlLeft = step(.recordingHeld, .drag(dx: -100, dy: 0), elapsedMs: 100, isRTL: true)
         XCTAssertEqual(rtlLeft.0, .recordingHeld, "RTL: dragging left must not cancel (mirrored)")
     }
+
+    // MARK: - tap-toggle (decision #5)
+
+    func testTapToggleFromIdleLocksHandsFree() {
+        let (phase, effect) = step(.idle, .tapToggle, elapsedMs: 0)
+        XCTAssertEqual(phase, .recordingLocked)
+        XCTAssertEqual(effect, .haptic(.arm))
+    }
+
+    func testTapToggleFromHeldLocks() {
+        let (phase, effect) = step(.recordingHeld, .tapToggle, elapsedMs: 300)
+        XCTAssertEqual(phase, .recordingLocked)
+        XCTAssertEqual(effect, .haptic(.arm))
+    }
+
+    func testTapToggleFromLockedSends() {
+        let (phase, effect) = step(.recordingLocked, .tapToggle, elapsedMs: 5000)
+        XCTAssertEqual(phase, .idle)
+        XCTAssertEqual(effect, .send)
+    }
+
+    func testTapToggleFromPausedSends() {
+        let (phase, effect) = step(.paused, .tapToggle, elapsedMs: 5000)
+        XCTAssertEqual(phase, .idle)
+        XCTAssertEqual(effect, .send)
+    }
+
+    func testTapToggleFromCancellingIgnored() {
+        let (phase, effect) = step(.cancelling, .tapToggle, elapsedMs: 3000)
+        XCTAssertEqual(phase, .cancelling)
+        XCTAssertEqual(effect, .none)
+    }
+
+    // MARK: - drag → progress mapping (view-facing, BET-1028)
+
+    func testLockProgress() {
+        XCTAssertEqual(VoiceGesture.lockProgress(dy: 0), 0, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.lockProgress(dy: -80), 1, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.lockProgress(dy: -40), 0.5, accuracy: 0.0001)
+        // Clamped above threshold.
+        XCTAssertEqual(VoiceGesture.lockProgress(dy: -200), 1, accuracy: 0.0001)
+        // Positive dy (dragging down) is never lock progress.
+        XCTAssertEqual(VoiceGesture.lockProgress(dy: 40), 0, accuracy: 0.0001)
+    }
+
+    func testCancelProgressLTR() {
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: 0, isRTL: false), 0, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -64, isRTL: false), 1, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -32, isRTL: false), 0.5, accuracy: 0.0001)
+        // Clamped.
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -200, isRTL: false), 1, accuracy: 0.0001)
+        // Dragging right is not cancel in LTR.
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: 64, isRTL: false), 0, accuracy: 0.0001)
+    }
+
+    func testCancelProgressMirrorsForRTL() {
+        // In RTL the SAME physical drag (right) advances cancel, mirroring the
+        // machine's own horizontal mirror.
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: 64, isRTL: true), 1, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: 32, isRTL: true), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -64, isRTL: true), 0, accuracy: 0.0001)
+    }
 }

--- a/mobile/native/MantaUITests/VoiceGestureTests.swift
+++ b/mobile/native/MantaUITests/VoiceGestureTests.swift
@@ -184,18 +184,20 @@ final class VoiceGestureTests: XCTestCase {
         XCTAssertEqual(rtlLeft.0, .recordingHeld, "RTL: dragging left must not cancel (mirrored)")
     }
 
-    // MARK: - tap-toggle (decision #5)
+    // MARK: - tap-toggle (decision #5 — tap #1 starts, tap #2 stops)
 
-    func testTapToggleFromIdleLocksHandsFree() {
+    func testTapToggleFromIdleStartsHeld() {
+        // Tap #1 starts a finger-up take showing the held surface.
         let (phase, effect) = step(.idle, .tapToggle, elapsedMs: 0)
-        XCTAssertEqual(phase, .recordingLocked)
+        XCTAssertEqual(phase, .recordingHeld)
         XCTAssertEqual(effect, .haptic(.arm))
     }
 
-    func testTapToggleFromHeldLocks() {
+    func testTapToggleFromHeldSends() {
+        // Tap #2 while held: "a second tap stops" → stop and send.
         let (phase, effect) = step(.recordingHeld, .tapToggle, elapsedMs: 300)
-        XCTAssertEqual(phase, .recordingLocked)
-        XCTAssertEqual(effect, .haptic(.arm))
+        XCTAssertEqual(phase, .idle)
+        XCTAssertEqual(effect, .send)
     }
 
     func testTapToggleFromLockedSends() {

--- a/mobile/native/MantaUIUITests/MantaVoiceRecordingUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaVoiceRecordingUITests.swift
@@ -4,15 +4,15 @@ import XCTest
 // BET-1028 acceptance captures — the WhatsApp-style recording surfaces.
 //
 // Driven to a REAL composer-bearing chat against the local capture-fixture box
-// (127.0.0.1:8787), exactly like MantaRunningStateCaptureUITests:
-//   1. Tap the mic button → assert `voice-recording-held` appears.
-//   2. Swipe UP on the held surface → assert `voice-recording-locked` appears
-//      with `voice-discard` / `voice-pause` / `voice-send` present.
+// (127.0.0.1:8787, code 123456 — see capture-fixture/fixture-box.mjs), exactly
+// like MantaRunningStateCaptureUITests. The fixture's `config:get` now returns a
+// Groq key so the mic button is available, and its `voice:transcribe` returns an
+// empty transcript, so sending is a harmless no-op (no real transcription).
 //
-// No audio is asserted (the fixture box owns the live stream; the mic hardware
-// path is not asserted). The fixture box must have a Groq key configured so the
-// mic button is available, and the simulator must grant mic permission once.
-// Evidence: each capture writes a settled PNG + prints the accessibility tree.
+// Covers the walkthrough: tap-toggle start/stop (decision #5), hold-and-release,
+// slide-left cancel, slide-up lock, pause/resume while locked, discard while
+// locked. No audio is asserted. Each capture writes a settled PNG + prints the
+// accessibility tree between markers.
 // ===========================================================================
 
 final class MantaVoiceRecordingUITests: XCTestCase {
@@ -21,28 +21,31 @@ final class MantaVoiceRecordingUITests: XCTestCase {
         continueAfterFailure = false
     }
 
-    private let pairCode = ProcessInfo.processInfo.environment["MANTA_PAIR_CODE"] ?? "123456"
-    private let pairServer = ProcessInfo.processInfo.environment["MANTA_PAIR_SERVER"] ?? "http://127.0.0.1:8787"
+    private let pairCode = "123456"
+    private let pairServer = "http://127.0.0.1:8787"
+
+    // MARK: - 1. Held → slide up to lock (the core surface + bar)
 
     func testVoiceRecordingHeldThenLocked() throws {
         let app = XCUIApplication()
         app.launch()
+        reachChatComposer(app)
 
-        pairIfNeeded(app)
-        openChatRow(app)
+        // Composer BEFORE recording — for the no-height-jump comparison.
+        snap(app, marker: "COMPOSER", png: "bet1028-composer.png")
 
         let mic = app.buttons["mic-button"]
-        XCTAssertTrue(mic.waitForExistence(timeout: 25), "mic button missing — is the mic available (Groq key)?")
+        XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
         mic.tap()
 
         let held = app.descendants(matching: .any)["voice-recording-held"]
         XCTAssertTrue(held.waitForExistence(timeout: 5), "recording did not start — voice-recording-held missing")
         snap(app, marker: "REC-HELD", png: "bet1028-held.png")
 
-        // Slide UP to lock.
-        let start = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.7))
-        let end = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))
-        start.press(forDuration: 0.2, thenDragTo: end)
+        // Slide UP well past the 80pt lock threshold (drag beyond the small
+        // surface so the translation reaches it).
+        let holdStart = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.6))
+        holdStart.press(forDuration: 0.2, thenDragTo: holdStart.withOffset(CGVector(dx: 0, dy: -160)))
 
         let locked = app.descendants(matching: .any)["voice-recording-locked"]
         XCTAssertTrue(locked.waitForExistence(timeout: 6), "slide up did not lock — voice-recording-locked missing")
@@ -50,9 +53,105 @@ final class MantaVoiceRecordingUITests: XCTestCase {
         XCTAssertTrue(app.buttons["voice-pause"].exists, "locked bar missing voice-pause")
         XCTAssertTrue(app.buttons["voice-send"].exists, "locked bar missing voice-send")
         snap(app, marker: "REC-LOCKED", png: "bet1028-locked.png")
+
+        // Clean up: discard so the simulator isn't left recording.
+        app.buttons["voice-discard"].tap()
     }
 
-    // MARK: - Pairing (idempotent)
+    // MARK: - 2. Tap-toggle: tap #1 starts, tap #2 stops (decision #5)
+
+    func testVoiceTapToggleStartStop() throws {
+        let app = XCUIApplication()
+        app.launch()
+        reachChatComposer(app)
+
+        let mic = app.buttons["mic-button"]
+        XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
+        // Tap #1: starts, held surface appears.
+        mic.tap()
+        let held = app.descendants(matching: .any)["voice-recording-held"]
+        XCTAssertTrue(held.waitForExistence(timeout: 5), "tap #1 did not start — held missing")
+
+        // Tap #2: "a second tap stops" → sends → composer returns.
+        held.coordinate(withNormalizedOffset: CGVector(dx: 0.7, dy: 0.6)).tap()
+        let ended = app.descendants(matching: .any)["voice-recording-held"]
+        XCTAssertFalse(ended.waitForExistence(timeout: 2), "tap #2 did not stop the take — held still present")
+        XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 5), "composer did not return after tap #2")
+    }
+
+    // MARK: - 3. Slide left → cancel (release discards)
+
+    func testVoiceSlideLeftCancels() throws {
+        let app = XCUIApplication()
+        app.launch()
+        reachChatComposer(app)
+
+        let mic = app.buttons["mic-button"]
+        XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
+        mic.tap()
+        let held = app.descendants(matching: .any)["voice-recording-held"]
+        XCTAssertTrue(held.waitForExistence(timeout: 5), "held missing before slide")
+
+        // Drag left well past the 64pt cancel threshold, then release.
+        let holdStart = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.6))
+        holdStart.press(forDuration: 0.2, thenDragTo: holdStart.withOffset(CGVector(dx: -140, dy: 0)))
+
+        let ended = app.descendants(matching: .any)["voice-recording-held"]
+        XCTAssertFalse(ended.waitForExistence(timeout: 2), "slide-left+release did not discard the take")
+        XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 5), "composer did not return after cancel")
+    }
+
+    // MARK: - 4. Locked bar: pause / resume / discard
+
+    func testVoiceLockedPauseResumeDiscard() throws {
+        let app = XCUIApplication()
+        app.launch()
+        reachChatComposer(app)
+
+        let mic = app.buttons["mic-button"]
+        XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
+        mic.tap()
+        let held = app.descendants(matching: .any)["voice-recording-held"]
+        XCTAssertTrue(held.waitForExistence(timeout: 5), "held missing")
+        let holdStart = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.6))
+        holdStart.press(forDuration: 0.2, thenDragTo: holdStart.withOffset(CGVector(dx: 0, dy: -160)))
+        let locked = app.descendants(matching: .any)["voice-recording-locked"]
+        XCTAssertTrue(locked.waitForExistence(timeout: 6), "slide up did not lock")
+
+        // Pause.
+        app.buttons["voice-pause"].tap()
+        // The pause button flips to a resume glyph — assert the state via the
+        // label/identifier transitions (resume label).
+        let resumeExpectation = app.buttons["voice-pause"]
+        XCTAssertTrue(resumeExpectation.waitForExistence(timeout: 3), "pause button gone")
+
+        // Resume.
+        app.buttons["voice-pause"].tap()
+
+        // Discard.
+        app.buttons["voice-discard"].tap()
+        let ended = app.descendants(matching: .any)["voice-recording-locked"]
+        XCTAssertFalse(ended.waitForExistence(timeout: 2), "discard did not end the locked take")
+        XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 5), "composer did not return after discard")
+    }
+
+    // MARK: - Helpers
+
+    /// Pair (first run only — the app stays paired between test launches) and
+    /// open the fixture's single Chat row so the composer is reachable.
+    private func reachChatComposer(_ app: XCUIApplication) {
+        pairIfNeeded(app)
+        XCTAssertTrue(app.staticTexts["Sessions"].waitForExistence(timeout: 20), "session list never appeared")
+        let row = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label BEGINSWITH 'Chat'"))
+            .firstMatch
+        if row.waitForExistence(timeout: 10) {
+            row.tap()
+        } else {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.30)).tap()
+        }
+        XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 30), "chat did not open to a composer")
+    }
 
     private func pairIfNeeded(_ app: XCUIApplication) {
         let otp = app.textFields["onboarding-otp"]
@@ -66,7 +165,6 @@ final class MantaVoiceRecordingUITests: XCTestCase {
         XCTAssertTrue(serverField.waitForExistence(timeout: 5), "server URL field never appeared")
         serverField.tap()
         serverField.typeText(pairServer)
-
         app.buttons["Continue"].firstMatch.tap()
 
         let notifications = app.staticTexts["Know when it needs you"]
@@ -84,19 +182,6 @@ final class MantaVoiceRecordingUITests: XCTestCase {
         app.launch()
     }
 
-    private func openChatRow(_ app: XCUIApplication) {
-        XCTAssertTrue(app.staticTexts["Sessions"].waitForExistence(timeout: 20), "session list never appeared")
-        let row = app.descendants(matching: .any)
-            .matching(NSPredicate(format: "label BEGINSWITH 'Chat'"))
-            .firstMatch
-        if row.waitForExistence(timeout: 10) {
-            row.tap()
-        } else {
-            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.30)).tap()
-        }
-        XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 30), "chat did not open to a composer")
-    }
-
     /// Writes a settled PNG and prints the accessibility tree between markers.
     private func snap(_ app: XCUIApplication, marker: String, png: String) {
         let shot = XCUIScreen.main.screenshot()
@@ -110,7 +195,6 @@ final class MantaVoiceRecordingUITests: XCTestCase {
 
     private func answerAlertIfPresent() {
         let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
-        // Mic permission — grant the first time it appears.
         for label in ["Allow", "OK", "Don't Allow"] {
             let button = springboard.buttons[label]
             if button.waitForExistence(timeout: 2) {

--- a/mobile/native/MantaUIUITests/MantaVoiceRecordingUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaVoiceRecordingUITests.swift
@@ -1,0 +1,122 @@
+import XCTest
+
+// ===========================================================================
+// BET-1028 acceptance captures — the WhatsApp-style recording surfaces.
+//
+// Driven to a REAL composer-bearing chat against the local capture-fixture box
+// (127.0.0.1:8787), exactly like MantaRunningStateCaptureUITests:
+//   1. Tap the mic button → assert `voice-recording-held` appears.
+//   2. Swipe UP on the held surface → assert `voice-recording-locked` appears
+//      with `voice-discard` / `voice-pause` / `voice-send` present.
+//
+// No audio is asserted (the fixture box owns the live stream; the mic hardware
+// path is not asserted). The fixture box must have a Groq key configured so the
+// mic button is available, and the simulator must grant mic permission once.
+// Evidence: each capture writes a settled PNG + prints the accessibility tree.
+// ===========================================================================
+
+final class MantaVoiceRecordingUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    private let pairCode = ProcessInfo.processInfo.environment["MANTA_PAIR_CODE"] ?? "123456"
+    private let pairServer = ProcessInfo.processInfo.environment["MANTA_PAIR_SERVER"] ?? "http://127.0.0.1:8787"
+
+    func testVoiceRecordingHeldThenLocked() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        pairIfNeeded(app)
+        openChatRow(app)
+
+        let mic = app.buttons["mic-button"]
+        XCTAssertTrue(mic.waitForExistence(timeout: 25), "mic button missing — is the mic available (Groq key)?")
+        mic.tap()
+
+        let held = app.descendants(matching: .any)["voice-recording-held"]
+        XCTAssertTrue(held.waitForExistence(timeout: 5), "recording did not start — voice-recording-held missing")
+        snap(app, marker: "REC-HELD", png: "bet1028-held.png")
+
+        // Slide UP to lock.
+        let start = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.7))
+        let end = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))
+        start.press(forDuration: 0.2, thenDragTo: end)
+
+        let locked = app.descendants(matching: .any)["voice-recording-locked"]
+        XCTAssertTrue(locked.waitForExistence(timeout: 6), "slide up did not lock — voice-recording-locked missing")
+        XCTAssertTrue(app.buttons["voice-discard"].exists, "locked bar missing voice-discard")
+        XCTAssertTrue(app.buttons["voice-pause"].exists, "locked bar missing voice-pause")
+        XCTAssertTrue(app.buttons["voice-send"].exists, "locked bar missing voice-send")
+        snap(app, marker: "REC-LOCKED", png: "bet1028-locked.png")
+    }
+
+    // MARK: - Pairing (idempotent)
+
+    private func pairIfNeeded(_ app: XCUIApplication) {
+        let otp = app.textFields["onboarding-otp"]
+        guard otp.waitForExistence(timeout: 3) else { return }
+        otp.tap()
+        otp.typeText(pairCode)
+
+        let advanced = app.buttons["My box isn't reachable from the internet"]
+        if advanced.exists { advanced.tap() }
+        let serverField = app.textFields["onboarding-server-url"]
+        XCTAssertTrue(serverField.waitForExistence(timeout: 5), "server URL field never appeared")
+        serverField.tap()
+        serverField.typeText(pairServer)
+
+        app.buttons["Continue"].firstMatch.tap()
+
+        let notifications = app.staticTexts["Know when it needs you"]
+        let failure = app.staticTexts["onboarding-failure-subtitle"]
+        let deadline = Date().addingTimeInterval(45)
+        while Date() < deadline, !notifications.exists, !failure.exists {
+            usleep(300_000)
+        }
+        XCTAssertFalse(failure.exists, "pairing failed")
+        XCTAssertTrue(notifications.exists, "notifications primer never appeared after claim")
+        app.buttons["Continue"].firstMatch.tap()
+
+        answerAlertIfPresent()
+        app.terminate()
+        app.launch()
+    }
+
+    private func openChatRow(_ app: XCUIApplication) {
+        XCTAssertTrue(app.staticTexts["Sessions"].waitForExistence(timeout: 20), "session list never appeared")
+        let row = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label BEGINSWITH 'Chat'"))
+            .firstMatch
+        if row.waitForExistence(timeout: 10) {
+            row.tap()
+        } else {
+            app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.30)).tap()
+        }
+        XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 30), "chat did not open to a composer")
+    }
+
+    /// Writes a settled PNG and prints the accessibility tree between markers.
+    private func snap(_ app: XCUIApplication, marker: String, png: String) {
+        let shot = XCUIScreen.main.screenshot()
+        let out = URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(png)
+        try? shot.pngRepresentation.write(to: out)
+        print("BET1028SHOT marker=\(marker) path=\(out.path)")
+        print("AX-TREE-BEGIN \(marker)")
+        print(app.debugDescription)
+        print("AX-TREE-END \(marker)")
+    }
+
+    private func answerAlertIfPresent() {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        // Mic permission — grant the first time it appears.
+        for label in ["Allow", "OK", "Don't Allow"] {
+            let button = springboard.buttons[label]
+            if button.waitForExistence(timeout: 2) {
+                button.tap()
+                return
+            }
+        }
+    }
+}

--- a/mobile/native/capture-fixture/fixture-box.mjs
+++ b/mobile/native/capture-fixture/fixture-box.mjs
@@ -162,7 +162,9 @@ function rpc(channel, args) {
     case "secrets:list":
       return SECRETS;
     case "config:get":
-      return { pinnedWindows: [], hapticsEnabled: true };
+      // BET-1028: expose a Groq key so the composer's mic button is available
+      // (it is hidden otherwise — the mic gate reads `groqApiKey` from here).
+      return { pinnedWindows: [], hapticsEnabled: true, groqApiKey: "fixture-groq-key" };
     case "config:update":
       return {};
     case "opencode:models":


### PR DESCRIPTION
Opened automatically for `multica/BET-1028-ios-voice-recording-surfaces`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1028.