### PR TITLE
chore(release): 0.0.34

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.33",
+      "version": "0.0.34",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.33",
+  "version": "0.0.34",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.33",
+ "version": "0.0.34",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Version bump for the 0.0.34 release cut (server, web, mac desktop, windows desktop).

66 commits since `server-v31` / `web-v32` / `mac-v0.0.33` / `win-v0.0.33`.

Desktop artifact filenames and the electron-updater feed key off `package.json`'s version, so the bump has to land before the `mac-v*` / `win-v*` tags are pushed — otherwise the new DMG/exe would carry the already-published 0.0.33 version and existing installs would never see the update.