### PR TITLE
feat(ios): voice notes in the transcript — one-shot upload+transcribe, attachment block, scroll-safe player (BET-1029)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -30,6 +30,7 @@
 		3F3FF5F6BE28352901513A14 /* MantaAppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 25870866D56CCE59805BCC0E /* MantaAppDelegate.swift */; };
 		404DB0475FB78037D65B6734 /* SessionResourceCards.swift in Sources */ = {isa = PBXBuildFile; fileRef = D178D08102AB83BF93B82D16 /* SessionResourceCards.swift */; };
 		431A66604F73FFBD59781D92 /* TerminalScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 942605E2D67D55C6DCCE83AC /* TerminalScreen.swift */; };
+		49F13D74AD1B942D3313970B /* VoiceNoteTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AE01D00B6A031E239CC12EAD /* VoiceNoteTests.swift */; };
 		4D3E99FA9CB1B101114D7A2A /* ArtifactDerivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CB8CF49BD3EB907D9822946F /* ArtifactDerivationTests.swift */; };
 		4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */; };
 		4FBB551A50B4DA5B955968DD /* MantaUIApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */; };
@@ -42,6 +43,7 @@
 		5E0226E9FAFF3F9CA9F45F8F /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E78B0F5B521937B40937DC /* SettingsScreen.swift */; };
 		5F85B39269B52E1E816CBA1B /* SettingsSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988B5D51F20F0D3BC838E083 /* SettingsSchema.swift */; };
 		61062DC85A5139A0AB22BC24 /* TerminalSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88D3B9B782BF819EEBEBF1D /* TerminalSocket.swift */; };
+		6115C3531A59C0517C8C214A /* VoiceNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED9F61E845DE68677AFEFF2 /* VoiceNote.swift */; };
 		612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */; };
 		61441105C65E4D7385DAF363 /* TerminalWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC7F6FA94631DA4C55A948 /* TerminalWebView.swift */; };
 		650862947C7F0D6C393C94BB /* ChatTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */; };
@@ -87,6 +89,7 @@
 		C414F36E83344076CE4F1ACD /* TerminalModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */; };
 		C96C7F34F91F06214FD25523 /* ChatVoice.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0451BC1AF50CB3A8D80344A5 /* ChatVoice.swift */; };
 		CC6A77686B936B4DB6026466 /* ChatModelStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8A6472C0BC3BDACAC4559198 /* ChatModelStore.swift */; };
+		CE48AF05FEFD7446610C8B70 /* VoiceNotePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA20AACFCE7D2BA897AE130 /* VoiceNotePlayer.swift */; };
 		CFE1B93882BD2EAF2A8B80BB /* ModelRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38864A574D6CE5142E07B487 /* ModelRecentsTests.swift */; };
 		D3E89E0419EE12C59BEA62A9 /* MantaQRScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4D07F9EBDCD8A693C141FF /* MantaQRScanner.swift */; };
 		D776E336456236DC1493565F /* ChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229392FD3405558D301D0809 /* ChatModel.swift */; };
@@ -143,6 +146,7 @@
 		1A81D1BB24FB02E4DFFA04FE /* UsageMeters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageMeters.swift; sourceTree = "<group>"; };
 		1BBC0EC48A556426D44A1A42 /* MantaContextStripVerifyUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaContextStripVerifyUITests.swift; sourceTree = "<group>"; };
 		1E1306D325FEB295B7AB874E /* MantaEventStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStore.swift; sourceTree = "<group>"; };
+		1ED9F61E845DE68677AFEFF2 /* VoiceNote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceNote.swift; sourceTree = "<group>"; };
 		229392FD3405558D301D0809 /* ChatModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModel.swift; sourceTree = "<group>"; };
 		24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionListStore.swift; sourceTree = "<group>"; };
 		25870866D56CCE59805BCC0E /* MantaAppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppDelegate.swift; sourceTree = "<group>"; };
@@ -212,6 +216,7 @@
 		ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingTests.swift; sourceTree = "<group>"; };
 		ABF1AB00CC95EA99A4EF537B /* MantaSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsStore.swift; sourceTree = "<group>"; };
 		AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingDriverUITests.swift; sourceTree = "<group>"; };
+		AE01D00B6A031E239CC12EAD /* VoiceNoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceNoteTests.swift; sourceTree = "<group>"; };
 		AEF7554D798247FECA6BFF84 /* WaveformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformTests.swift; sourceTree = "<group>"; };
 		B230F69A60CD3DBC416612B0 /* manta-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "manta-logo.png"; sourceTree = "<group>"; };
 		B82B782F73475FDD71F6D6B5 /* PolishTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolishTests.swift; sourceTree = "<group>"; };
@@ -234,6 +239,7 @@
 		E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLoadingSkeleton.swift; sourceTree = "<group>"; };
 		E4A5AE775D3F3D82FC69A54F /* VoiceGestureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceGestureTests.swift; sourceTree = "<group>"; };
 		E4FA4CCB9740565057F26D31 /* MantaLiveArtifactsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaLiveArtifactsUITests.swift; sourceTree = "<group>"; };
+		EAA20AACFCE7D2BA897AE130 /* VoiceNotePlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceNotePlayer.swift; sourceTree = "<group>"; };
 		EBC7D0BF807861DCCABC5A26 /* MantaResourceCardModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaResourceCardModelsTests.swift; sourceTree = "<group>"; };
 		ED6ABAA46F1CBD2093D4AC87 /* ComposerTypeahead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTypeahead.swift; sourceTree = "<group>"; };
 		EE0504A23AC9360042B3D51B /* ChatStreamMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamMergeTests.swift; sourceTree = "<group>"; };
@@ -306,6 +312,7 @@
 				DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */,
 				D687A8F5AD2BEEAC0D728C3C /* UsageMetersTests.swift */,
 				E4A5AE775D3F3D82FC69A54F /* VoiceGestureTests.swift */,
+				AE01D00B6A031E239CC12EAD /* VoiceNoteTests.swift */,
 				AEF7554D798247FECA6BFF84 /* WaveformTests.swift */,
 			);
 			path = MantaUITests;
@@ -404,6 +411,8 @@
 				7582E08CBBDCE70E242A6B18 /* UsageSheets.swift */,
 				CAFF319B4F3CD4F13A20A1EB /* UsageStore.swift */,
 				6717B2E85100A1BCAC163A31 /* VoiceGesture.swift */,
+				1ED9F61E845DE68677AFEFF2 /* VoiceNote.swift */,
+				EAA20AACFCE7D2BA897AE130 /* VoiceNotePlayer.swift */,
 				4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */,
 				9F06F838B4779D52B29E1173 /* VoiceRecordingSurface.swift */,
 				8D7B1F4E5EF7E0ADD2238839 /* Waveform.swift */,
@@ -637,6 +646,7 @@
 				C414F36E83344076CE4F1ACD /* TerminalModelsTests.swift in Sources */,
 				97CCE1CDDEF2E81BF57B52D1 /* UsageMetersTests.swift in Sources */,
 				B7D2A1C0F9EC29C5B0002C8F /* VoiceGestureTests.swift in Sources */,
+				49F13D74AD1B942D3313970B /* VoiceNoteTests.swift in Sources */,
 				12070C130BD9D1CD9EA0603F /* WaveformTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -705,6 +715,8 @@
 				37B7F5C28332A180E825982C /* UsageSheets.swift in Sources */,
 				1E8A1AB9FB3945E6092CA2E2 /* UsageStore.swift in Sources */,
 				578DA0FFC68283A72AF914E8 /* VoiceGesture.swift in Sources */,
+				6115C3531A59C0517C8C214A /* VoiceNote.swift in Sources */,
+				CE48AF05FEFD7446610C8B70 /* VoiceNotePlayer.swift in Sources */,
 				98A26A0ABAFE54728AE97FEE /* VoiceRecorder.swift in Sources */,
 				52C319CA847D3FECBC1297E2 /* VoiceRecordingSurface.swift in Sources */,
 				75B97ECFE219AB9C7D45EDE3 /* Waveform.swift in Sources */,

--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -234,6 +234,11 @@ enum ChatRollup {
 enum ChatTranscriptMapper {
 
     static func blocks(from messages: [OpencodeMessage]) -> [TranscriptBlock] {
+        blocks(from: messages, voiceNotes: [])
+    }
+
+    static func blocks(from messages: [OpencodeMessage], voiceNotes: [VoiceNote]) -> [TranscriptBlock] {
+        let voiceMap = buildVoiceNoteMap(messages: messages, notes: voiceNotes)
         var blocks: [TranscriptBlock] = []
         var pending: [StepGroupRow] = []
 
@@ -247,6 +252,11 @@ enum ChatTranscriptMapper {
                     // it finished. Both are what the reader means by "when did
                     // this happen".
                     blocks.append(.user(text, at: ChatClock.date(epochMs: msg.info.time?.created)))
+                    // The voice-note player renders directly under the user band
+                    // that dictated it, claimed by transcript-text match.
+                    if let note = voiceMap[msg.info.id] {
+                        blocks.append(.file(TranscriptAttachment(kind: .voiceNote(note))))
+                    }
                 }
             case "assistant":
                 // An assistant message still streaming (time.completed == nil)
@@ -355,8 +365,15 @@ enum ChatTranscriptMapper {
             } else {
                 pending.append(.step(step(from: part, tool: tool, indexWithinMessage: index)))
             }
+        case "file":
+            // A file part that is not a voice note renders nothing. Voice
+            // notes attach at the USER-message level (buildVoiceNoteMap), not
+            // here; image and generic-file rendering are deliberately not
+            // implemented yet (BET-1029), so do not silently reuse the
+            // `default: break` for them — this case is where they will land.
+            break
         default:
-            // reasoning / file / etc. — no §8 block type renders it; skip.
+            // reasoning / etc. — no §8 block type renders it; skip.
             break
         }
     }
@@ -369,6 +386,51 @@ enum ChatTranscriptMapper {
                   let t = part.text, !isBlank(t) else { return nil }
             return t
         }.joined(separator: "\n")
+    }
+
+    /// A user-message-id → voice-note map, forged by claiming each note against
+    /// the first unclaimed user message whose concatenated text equals the
+    /// note's transcript. Port of `buildVoiceNoteMap`
+    /// (src/renderer/chatUtils.ts:3666-3687) — SAME association rule so both
+    /// clients agree which bubble owns which clip; there is no id on the wire.
+    ///
+    /// Walk user messages OLDEST → NEWEST and notes OLDEST → NEWEST; claim the
+    /// FIRST unclaimed user message whose text equals the note's trimmed
+    /// transcript. Each note and each message is claimed at most once; a note
+    /// matching nothing is dropped. Do NOT invent an id-based scheme.
+    static func buildVoiceNoteMap(messages: [OpencodeMessage], notes: [VoiceNote]) -> [String: VoiceNote] {
+        var map: [String: VoiceNote] = [:]
+        guard !notes.isEmpty else { return map }
+        let users = messages.filter { $0.info.role.rawValue == "user" }
+        var claimed = Set<String>()
+        for note in notes {
+            let transcript = note.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !transcript.isEmpty else { continue }
+            for msg in users {
+                guard !claimed.contains(msg.info.id) else { continue }
+                if concatUserMessageText(msg) == transcript {
+                    map[msg.info.id] = note
+                    claimed.insert(msg.info.id)
+                    break
+                }
+            }
+        }
+        return map
+    }
+
+    /// The user-turn text a note's transcript is matched against — the
+    /// concatenated (newline-joined) non-synthetic, non-ignored text parts with
+    /// trailing whitespace stripped. Mirrors `concatUserMessageText` in the
+    /// desktop, so the claim can never diverge from what the row displays.
+    private static func concatUserMessageText(_ msg: OpencodeMessage) -> String {
+        let joined = msg.parts.compactMap { part -> String? in
+            guard part.type == "text",
+                  part.synthetic != true,
+                  part.ignored != true,
+                  let t = part.text else { return nil }
+            return t
+        }.joined(separator: "\n")
+        return joined.replacingOccurrences(of: "\\s+$", with: "", options: .regularExpression)
     }
 
     /// A text part is "blank" when it contains no visible content — empty, or

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -140,6 +140,11 @@ private struct ChatScreenContent: View {
     /// The plan-usage snapshot set (BET-824), polled every 60s while the chat
     /// is open. Feeds the composer dot, the usage sheet and the weekly banner.
     @StateObject private var usageStore: UsageStore
+    /// The conversation-scoped voice-note playback engine (BET-1029). Owned
+    /// ABOVE the transcript list — a player owned by a recycled cell would be
+    /// destroyed by scrolling; this one survives it and plays one note at a
+    /// time. Injected into the transcript via `Environment`.
+    @StateObject private var voicePlayer: VoicePlaybackEngine
     @Environment(\.dismiss) private var dismiss
     @Environment(\.colorScheme) private var colorScheme
     @Environment(\.scenePhase) private var scenePhase
@@ -226,6 +231,7 @@ private struct ChatScreenContent: View {
         _modelStore = StateObject(wrappedValue: ChatModelStore(sessionId: sessionId, api: api))
         _settingsStore = StateObject(wrappedValue: MantaSettingsStore())
         _usageStore = StateObject(wrappedValue: UsageStore(api: api))
+        _voicePlayer = StateObject(wrappedValue: VoicePlaybackEngine(api: api))
     }
 
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
@@ -242,6 +248,7 @@ private struct ChatScreenContent: View {
         // the permission poll, which `start()`'s run-once guard would then
         // refuse to restart.
         content
+            .environmentObject(voicePlayer)
             .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackgroundVisibility(.visible, for: .navigationBar)

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -148,6 +148,11 @@ struct QueuedPrompt: Equatable {
 final class ChatSessionStore: ObservableObject {
 
     @Published private(set) var transcript: [TranscriptBlock] = []
+    /// The voice notes recorded in this session (fetched on load + refreshed
+    /// after a send). Their transcripts claim user messages via
+    /// `buildVoiceNoteMap`, so a dictated note renders its player bubble in the
+    /// transcript under the message it became (BET-1029).
+    @Published private(set) var voiceNotes: [VoiceNote] = []
     /// The LAST fetched raw transcript (`opencode:messages`), kept alongside the
     /// rendered `transcript` blocks so the plan card can run its exact
     /// derivation (`isPlanExitQuestion` / `extractPlanData` need the raw tool
@@ -299,6 +304,10 @@ final class ChatSessionStore: ObservableObject {
     /// arrived mid-flight so the refresh still happens — exactly once — after.
     private var fetchInFlight = false
     private var fetchPending = false
+    /// The message-id → voice-note association, recomputed whenever the message
+    /// window or the notes change. Baked into `transcript` at mapping time
+    /// (BET-1029).
+    private var voiceNoteMap: [String: VoiceNote] = [:]
     /// The connection sink replays its CURRENT value on subscribe, so without
     /// this the store fired a "reconnect" refetch before `start()` had even run.
     /// Only a genuine drop→connect transition is a resync.
@@ -382,6 +391,7 @@ final class ChatSessionStore: ObservableObject {
             await MainActor.run { loading = false }
             if !isReadOnly {
                 await refreshPermissions()
+                await refreshVoiceNotes()
             }
         }
     }
@@ -727,7 +737,8 @@ final class ChatSessionStore: ObservableObject {
                 if !didFail { hasEarlier = loaded.count >= limit }
                 if !didFail || isFirstLoad {
                     messages = loaded
-                    transcript = ChatTranscriptMapper.blocks(from: loaded)
+                    voiceNoteMap = ChatTranscriptMapper.buildVoiceNoteMap(messages: loaded, notes: voiceNotes)
+                    transcript = ChatTranscriptMapper.blocks(from: loaded, voiceNotes: voiceNotes)
                     // The transcript now carries these messages, so any live
                     // copy of them is a duplicate — retire it BEFORE rebuilding
                     // or the finished answer renders twice, once from each
@@ -763,6 +774,22 @@ final class ChatSessionStore: ObservableObject {
     func refreshPermissions() async {
         let perms = (try? await api.permissions(sessionId: sessionId)) ?? []
         await MainActor.run { permissions = perms }
+    }
+
+    // MARK: - Voice notes (BET-1029)
+
+    /// Fetch this session's voice-note metadata, re-forge the message→note map
+    /// and re-render the transcript so the dictation attachments appear. Called
+    /// on session load and after a send (a dictated note's player bubble only
+    /// exists once its matching user message does).
+    func refreshVoiceNotes() async {
+        let notes = (try? await api.voiceNotes(sessionId: sessionId)) ?? []
+        await MainActor.run {
+            voiceNotes = notes
+            voiceNoteMap = ChatTranscriptMapper.buildVoiceNoteMap(messages: messages, notes: notes)
+            transcript = ChatTranscriptMapper.blocks(from: messages, voiceNotes: notes)
+            rebuildBlocks()
+        }
     }
 
     // MARK: - Answers (wire from the phone, S1a)
@@ -911,6 +938,9 @@ final class ChatSessionStore: ObservableObject {
                 mentions: mentions,
                 agent: agent
             ))
+            // A dictated note's user message now exists on the box; refetch the
+            // notes so its player bubble attaches under it (BET-1029).
+            Task { await refreshVoiceNotes() }
             return true
         } catch {
             // Surface the failure instead of swallowing it: stop the running

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -36,6 +36,15 @@ struct ComposerAttachment: Identifiable, Equatable {
     var isUploading: Bool { remotePath == nil }
 }
 
+/// The transient composer-state of a completed voice take while it uploads +
+/// transcribes (and, on the 409 path, the stored note offered a Retry).
+struct VoicePendingState: Equatable {
+    var peaks: [UInt8]
+    var durationMs: Int
+    var noteID: String?
+    var error: String?
+}
+
 struct ComposerView: View {
     let sessionId: String
     let projectName: String
@@ -86,6 +95,10 @@ struct ComposerView: View {
     @State private var showHint = false
     @FocusState private var inputFocused: Bool
     @StateObject private var recorder = VoiceRecorder()
+    /// The transient composer-state row for a voice take: shown while it
+    /// uploads + transcribes, and kept (in place of discarding the recording)
+    /// with a Retry when the box stores it but transcription fails (409).
+    @State private var voicePending: VoicePendingState?
     /// High-water flag for a press whose permission prompt is still resolving —
     /// lets the mic's press-start re-check after the await so a second change
     /// doesn't double-request permission.
@@ -165,6 +178,20 @@ struct ComposerView: View {
             // by the recording surface (BET-1028, decision #1) — same position,
             // same outer padding, so nothing in the layout jumps. The surface
             // renders the machine's `VoicePhase`; it owns no transition logic.
+            // A completed take: store-and-transcribe it in ONE round trip (the
+            // clip is NOT sent to the model — only its transcript text is, via
+            // the normal send path). A stored-but-untranscribed take stays
+            // pending with a Retry rather than being discarded.
+            if let pending = voicePending {
+                VoiceNotePendingRow(
+                    peaks: pending.peaks,
+                    durationMs: pending.durationMs,
+                    error: pending.error,
+                    tokens: tokens,
+                    onRetry: pending.noteID != nil ? { retryPendingVoice() } : nil
+                )
+                .transition(.opacity)
+            }
             if recorder.phase == .idle {
                 inputBox
                     .transition(.opacity)
@@ -173,7 +200,7 @@ struct ComposerView: View {
                     recorder: recorder,
                     isRTL: isRTL,
                     onTake: { take in
-                        Task { await transcribe(data: take.data) }
+                        Task { await handleVoiceTake(take) }
                     }
                 )
                 .transition(.opacity)
@@ -858,14 +885,75 @@ struct ComposerView: View {
         }
     }
 
-    private func transcribe(data: Data) async {
-        let result = try? await api.voiceTranscribe(data: data, mime: "audio/mp4")
-        let transcript = result?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-        guard !transcript.isEmpty else {
-            hintState("No speech detected")
-            return
+    /// A completed take: store the clip AND transcribe it in ONE round trip
+    /// (`POST /api/voice`). The clip is NOT sent to the model — only the
+    /// returned transcript text is, submitted through the EXISTING `submit()`
+    /// path so slash commands, mentions and model resolution behave identically
+    /// (BET-1029 decision #1/#2). This replaces the legacy `voice:transcribe`
+    /// dictation-only call.
+    @MainActor
+    private func handleVoiceTake(_ take: VoiceRecorder.Take) async {
+        voicePending = VoicePendingState(peaks: take.peaks, durationMs: take.durationMs, noteID: nil, error: nil)
+        do {
+            let note = try await api.uploadVoiceNote(
+                sessionId: sessionId,
+                audio: take.data,
+                mime: "audio/mp4",
+                durationMs: take.durationMs,
+                peaks: take.peaks
+            )
+            let transcript = note.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !transcript.isEmpty else {
+                voicePending = nil
+                hintState("No speech detected")
+                return
+            }
+            voicePending = nil
+            submitVoiceTranscript(transcript)
+        } catch MantaError.storedButUntranscribed(let noteID) {
+            // The recording was KEPT on the box; keep the pending row and offer
+            // a Retry against its id rather than discarding the take.
+            voicePending?.noteID = noteID
+            voicePending?.error = "transcription failed"
+        } catch {
+            voicePending = nil
+            hintState("Voice note failed — try again")
         }
-        await MainActor.run { insertAtCaret(transcript) }
+    }
+
+    /// Submit a transcript through the existing typed-send path (caller sets
+    /// the composed text and reuses `submit()` unchanged).
+    @MainActor
+    private func submitVoiceTranscript(_ transcript: String) {
+        text = transcript
+        submit()
+    }
+
+    /// Retry transcription for a stored-but-untranscribed note. On success its
+    /// transcript is submitted through the normal send path; a second 409 keeps
+    /// the pending row's Retry.
+    @MainActor
+    private func retryPendingVoice() {
+        guard let pending = voicePending, let noteID = pending.noteID else { return }
+        Task {
+            do {
+                let note = try await api.retryVoiceNote(id: noteID)
+                let transcript = note.transcript.trimmingCharacters(in: .whitespacesAndNewlines)
+                guard !transcript.isEmpty else {
+                    voicePending?.error = "transcription failed"
+                    hintState("Transcription failed again")
+                    return
+                }
+                voicePending = nil
+                submitVoiceTranscript(transcript)
+            } catch MantaError.storedButUntranscribed(_) {
+                voicePending?.error = "transcription failed"
+                hintState("Transcription failed again")
+            } catch {
+                voicePending = nil
+                hintState("Retry failed — check the connection")
+            }
+        }
     }
 
     /// Insert text at the caret (dictate). If the composer's text field is the

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -4,6 +4,9 @@ enum MantaError: Error, Equatable {
     case authRequired
     case server(String)
     case transport(String)
+    /// A voice clip was stored but its transcription failed (HTTP 409). The
+    /// recorder must be KEPT — the caller surfaces a Retry against the id.
+    case storedButUntranscribed(noteID: String)
 }
 
 final class MantaAPIClient: Sendable {
@@ -471,6 +474,124 @@ final class MantaAPIClient: Sendable {
         try await Task.sleep(nanoseconds: 0)
         let result: [String: JSONValue]? = try await call("voice:transcribe", args: [input], as: [String: JSONValue].self)
         return ChatJSON.string(result?["text"])
+    }
+
+    // MARK: - Voice notes (BET-1029)
+
+    /// Store a voice clip AND transcribe it in ONE round trip (`POST
+    /// /api/voice?session=<id>`). The box owns both; splitting them would leave
+    /// orphaned audio on a failure. Body is the RAW bytes (octet-stream), with
+    /// `x-mime`, `x-duration-ms` and `x-peaks` (base64 of the peak bytes) — the
+    /// exact contract in `src/renderer/api/httpApi.ts` / `src/server/index.mjs`.
+    ///
+    /// Throws `MantaError.storedButUntranscribed(id:)` for HTTP 409 — the clip
+    /// WAS stored but transcription failed; the caller keeps the note (with its
+    /// id) and offers Retry rather than discarding the recording.
+    func uploadVoiceNote(sessionId: String, audio: Data, mime: String,
+                         durationMs: Int, peaks: [UInt8]) async throws -> VoiceNote {
+        var url = serverURL.appendingPathComponent("api").appendingPathComponent("voice")
+        url.append(queryItems: [URLQueryItem(name: "session", value: sessionId)])
+
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        if let token = tokenProvider(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        request.setValue("application/octet-stream", forHTTPHeaderField: "Content-Type")
+        request.setValue(mime, forHTTPHeaderField: "x-mime")
+        request.setValue(String(durationMs), forHTTPHeaderField: "x-duration-ms")
+        request.setValue(Data(peaks).base64EncodedString(), forHTTPHeaderField: "x-peaks")
+        request.httpBody = audio
+
+        let (dataOut, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw MantaError.authRequired
+        }
+        if let http = response as? HTTPURLResponse, http.statusCode == 409 {
+            let id = ((try? JSONSerialization.jsonObject(with: dataOut) as? [String: Any])??["id"]) as? String ?? ""
+            throw MantaError.storedButUntranscribed(noteID: id)
+        }
+        guard let object = (try? JSONSerialization.jsonObject(with: dataOut)) as? [String: Any] else {
+            throw MantaError.transport("invalid voice upload envelope")
+        }
+        if let error = object["error"] as? String, !error.isEmpty {
+            throw MantaError.server(error)
+        }
+        return VoiceNote(
+            id: object["id"] as? String ?? "",
+            sessionId: sessionId,
+            transcript: object["transcript"] as? String ?? "",
+            mime: mime,
+            durationMs: durationMs,
+            peaks: peaks,
+            createdAt: Int(Date().timeIntervalSince1970 * 1000),
+            expiresAt: object["expiresAt"] as? Int,
+            audioAvailable: true
+        )
+    }
+
+    /// `voice:list-notes` — note metadata only (no audio bytes), oldest first,
+    /// filtered to the session. Peak bytes are decoded from the wire's base64.
+    func voiceNotes(sessionId: String) async throws -> [VoiceNote] {
+        try await call("voice:list-notes", args: [["sessionId": sessionId]], as: [VoiceNote].self) ?? []
+    }
+
+    /// Stream a note's audio bytes back (`GET /api/voice/<id>`), bearer auth
+    /// (cannot ride a URL or an `<audio src>`). Non-2xx THROWS — a missing or
+    /// swept clip must be a visible failure.
+    func voiceNoteAudio(id: String) async throws -> Data {
+        let url = serverURL.appendingPathComponent("api/voice/\(id)")
+        var request = URLRequest(url: url)
+        request.httpMethod = "GET"
+        if let token = tokenProvider(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let (data, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw MantaError.authRequired
+        }
+        if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+            throw MantaError.server("voice audio unavailable (\(http.statusCode))")
+        }
+        return data
+    }
+
+    /// Re-run transcription for a note whose transcript came back empty (the
+    /// 409 path). 200 → transcript present; 409 → failed again.
+    func retryVoiceNote(id: String) async throws -> VoiceNote {
+        let url = serverURL.appendingPathComponent("api/voice/\(id)/retry")
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        if let token = tokenProvider(), !token.isEmpty {
+            request.setValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
+        }
+        let (dataOut, response) = try await session.data(for: request)
+        if let http = response as? HTTPURLResponse, http.statusCode == 401 {
+            throw MantaError.authRequired
+        }
+        if let http = response as? HTTPURLResponse, http.statusCode == 409 {
+            throw MantaError.storedButUntranscribed(noteID: id)
+        }
+        if let http = response as? HTTPURLResponse, http.statusCode >= 400 {
+            throw MantaError.server("retry failed (\(http.statusCode))")
+        }
+        guard let object = (try? JSONSerialization.jsonObject(with: dataOut)) as? [String: Any] else {
+            throw MantaError.transport("invalid retry envelope")
+        }
+        if let error = object["error"] as? String, !error.isEmpty {
+            throw MantaError.server(error)
+        }
+        return VoiceNote(
+            id: object["id"] as? String ?? id,
+            sessionId: "",
+            transcript: object["transcript"] as? String ?? "",
+            mime: "audio/mp4",
+            durationMs: 0,
+            peaks: [],
+            createdAt: 0,
+            expiresAt: nil,
+            audioAvailable: true
+        )
     }
 
     /// `git:list-worktrees` — git worktree fan-out detection for a folder.

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -635,6 +635,11 @@ enum TranscriptBlock: Equatable {
     case user(String, at: Date?)
     case prose(String, at: Date?)
     case steps(StepGroupContent)
+    /// A file/attachment reference (e.g. a voice note) rendered inline next to
+    /// the message it belongs to. GENERAL on purpose — image and generic-file
+    /// rendering will reuse this case; only the voice-note flavour is rendered
+    /// today (BET-1029).
+    case file(TranscriptAttachment)
     /// A terminal system notice (session error / truncation) at the end of the
     /// turn it belongs to.
     case notice(String, SystemNotice)
@@ -646,9 +651,20 @@ enum TranscriptBlock: Equatable {
     var timestamp: Date? {
         switch self {
         case .user(_, let at), .prose(_, let at): return at
-        case .steps, .notice, .queuedPrompt: return nil
+        case .steps, .file, .notice, .queuedPrompt: return nil
         }
     }
+}
+
+/// A file/attachment reference carried by a `.file` transcript block. Only the
+/// `.voiceNote` flavour renders today; image and generic-file rendering are
+/// deliberately not implemented yet (BET-1029) — a file part that is not a
+/// voice note renders nothing, exactly as it did before.
+struct TranscriptAttachment: Equatable {
+    enum Kinds: Equatable {
+        case voiceNote(VoiceNote)
+    }
+    let kind: Kinds
 }
 
 // MARK: - "Load earlier messages"

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -43,10 +43,21 @@ extension TranscriptBlock {
             return "u\(text.hashValue)@\(at?.timeIntervalSince1970 ?? 0)"
         case .prose(let text, let at):
             return "p\(text.hashValue)@\(at?.timeIntervalSince1970 ?? 0)"
+        case .file(let attachment):
+            return "f" + attachmentIdentity(attachment)
         case .steps(let content): return "s" + content.rows.map(\.id).joined(separator: "|")
         case .notice(let text, let kind): return "n\(kind)\(text.hashValue)"
         case .queuedPrompt(let text): return "q\(text.hashValue)"
         }
+    }
+}
+
+/// A content-stable identity for an attachment block, unique across the
+/// attachment kinds. Used by `stableScrollID` so a `.file` row survives a
+/// refetch unchanged.
+private func attachmentIdentity(_ attachment: TranscriptAttachment) -> String {
+    switch attachment.kind {
+    case .voiceNote(let note): return "voice:\(note.id)"
     }
 }
 
@@ -143,6 +154,12 @@ func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens) -> some View 
             .padding(.bottom, Metrics.spacing.sp4)
     case .prose(let text, _):
         MantaProse(text: text, tokens: tokens)
+    case .file(let attachment):
+        // The voice-note player sits directly under the user band it belongs
+        // to: 12px horizontal, 14px below. Image and generic-file rendering are
+        // deliberately not implemented yet — the `.file` case only renders the
+        // voice-note flavour (see `attachmentView`).
+        attachmentView(attachment, tokens: tokens)
     case .steps(let content):
         // Machinery is inset to the same margin as prose. Only the USER
         // band is full-bleed (§8) — that edge-to-edge treatment is what
@@ -160,6 +177,19 @@ func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens) -> some View 
         // current turn ends, so it renders a preview of where that will be.
         UserBand(text: text, tokens: tokens)
             .opacity(0.45)
+            .padding(.bottom, Metrics.spacing.sp4)
+    }
+}
+
+/// Render a `.file` attachment block. ONLY the voice-note flavour renders — an
+/// image or generic-file part is deliberately NOT implemented yet (BET-1029);
+/// it would return nothing here, exactly as it did before this case existed.
+@ViewBuilder
+private func attachmentView(_ attachment: TranscriptAttachment, tokens: Tokens) -> some View {
+    switch attachment.kind {
+    case .voiceNote(let note):
+        VoiceNotePlayerRow(note: note, tokens: tokens)
+            .padding(.horizontal, Metrics.spacing.sp3)
             .padding(.bottom, Metrics.spacing.sp4)
     }
 }

--- a/mobile/native/MantaUI/VoiceNote.swift
+++ b/mobile/native/MantaUI/VoiceNote.swift
@@ -1,0 +1,79 @@
+import Foundation
+
+// ===========================================================================
+// VoiceNote.swift — the stored-voice-note model (BET-1029).
+//
+// Mirrors `VoiceNoteRecord` (src/shared/types.ts:2165-2177): a dictated clip
+// stored on the box together with its transcript, duration, waveform peaks and
+// TTL. The audio is swept on a TTL while the transcript + peaks are kept
+// forever, which is why `audioAvailable` is a first-class field —
+// `audioAvailable == false` renders a dimmed, non-interactive player.
+//
+// On the JSON wire the server stores `peaks` as a base64 string; decode that to
+// `[UInt8]` at the boundary so components read the byte array directly (same
+// convention as the desktop's `voiceListNotes` transport seam).
+// ===========================================================================
+
+struct VoiceNote: Codable, Equatable, Identifiable, Sendable {
+    let id: String
+    let sessionId: String
+    let transcript: String
+    let mime: String
+    let durationMs: Int
+    /// Waveform peaks, `0...255`, at most `Waveform.Constants.maxStoredPeaks`.
+    let peaks: [UInt8]
+    /// Epoch milliseconds the note was recorded.
+    let createdAt: Int
+    /// Epoch milliseconds the audio expires (nil = never).
+    let expiresAt: Int?
+    let audioAvailable: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case id, sessionId, transcript, mime, durationMs, peaks, createdAt, expiresAt, audioAvailable
+    }
+
+    init(id: String, sessionId: String, transcript: String, mime: String,
+         durationMs: Int, peaks: [UInt8], createdAt: Int, expiresAt: Int?,
+         audioAvailable: Bool) {
+        self.id = id
+        self.sessionId = sessionId
+        self.transcript = transcript
+        self.mime = mime
+        self.durationMs = durationMs
+        self.peaks = peaks
+        self.createdAt = createdAt
+        self.expiresAt = expiresAt
+        self.audioAvailable = audioAvailable
+    }
+
+    init(from decoder: Decoder) throws {
+        let c = try decoder.container(keyedBy: CodingKeys.self)
+        id = try c.decode(String.self, forKey: .id)
+        sessionId = try c.decode(String.self, forKey: .sessionId)
+        transcript = try c.decodeIfPresent(String.self, forKey: .transcript) ?? ""
+        mime = try c.decodeIfPresent(String.self, forKey: .mime) ?? "audio/mp4"
+        durationMs = try c.decodeIfPresent(Int.self, forKey: .durationMs) ?? 0
+        createdAt = try c.decodeIfPresent(Int.self, forKey: .createdAt) ?? 0
+        expiresAt = try c.decodeIfPresent(Int.self, forKey: .expiresAt)
+        audioAvailable = try c.decodeIfPresent(Bool.self, forKey: .audioAvailable) ?? true
+        if let b64 = try c.decodeIfPresent(String.self, forKey: .peaks),
+           let data = Data(base64Encoded: b64) {
+            peaks = [UInt8](data)
+        } else {
+            peaks = []
+        }
+    }
+
+    func encode(to encoder: Encoder) throws {
+        var c = encoder.container(keyedBy: CodingKeys.self)
+        try c.encode(id, forKey: .id)
+        try c.encode(sessionId, forKey: .sessionId)
+        try c.encode(transcript, forKey: .transcript)
+        try c.encode(mime, forKey: .mime)
+        try c.encode(durationMs, forKey: .durationMs)
+        try c.encode(Data(peaks).base64EncodedString(), forKey: .peaks)
+        try c.encode(createdAt, forKey: .createdAt)
+        try c.encodeIfPresent(expiresAt, forKey: .expiresAt)
+        try c.encode(audioAvailable, forKey: .audioAvailable)
+    }
+}

--- a/mobile/native/MantaUI/VoiceNotePlayer.swift
+++ b/mobile/native/MantaUI/VoiceNotePlayer.swift
@@ -1,0 +1,402 @@
+import AVFoundation
+import SwiftUI
+
+// ===========================================================================
+// VoiceNotePlayer.swift — the voice-note player + row (BET-1029).
+//
+// The transcript is a `UICollectionView` (MessagingUI `TiledView`) that
+// recycles cells, so a player OWNED by a row would be destroyed the moment the
+// row scrolls out of view — cutting playback mid-sentence. Playback is
+// therefore owned ABOVE the list: one `VoicePlaybackEngine` per conversation,
+// injected into the transcript via `Environment` and read by each row
+// (`VoiceNotePlayerRow` via `@EnvironmentObject`). The same rule as desktop's
+// `VoiceNote.tsx` (engine in `VoicePlaybackProvider`, not the row).
+//
+// The engine holds ONE `AVAudioPlayer`, fetches a clip lazily on first play and
+// caches it per note id; only one note plays at a time.
+//
+// An expired note (audio swept on its TTL while transcript + peaks survive)
+// renders honestly: a dimmed, dashed, non-interactive shape with a
+// "· expired" suffix — never a play button that does nothing. Mirrors
+// `VoiceNote.tsx` (`audioAvailable == false`).
+// ===========================================================================
+
+/// Conversation-scoped playback engine. One per open conversation, owned above
+/// the transcript list so scrolling never interrupts playback and only one
+/// note plays at a time.
+@MainActor
+final class VoicePlaybackEngine: ObservableObject {
+    @Published private(set) var activeNoteID: String?
+    @Published private(set) var isPlaying = false
+    @Published private(set) var currentMs = 0
+
+    private let api: MantaAPIClient
+    private var player: AVAudioPlayer?
+    private var ticker: Task<Void, Never>?
+    private var audioCache: [String: Data] = [:]
+    private var speed: Double = 1.0
+
+    private static let speeds: [Double] = [1.0, 1.25, 1.5, 2.0]
+
+    init(api: MantaAPIClient) {
+        self.api = api
+    }
+
+    deinit {
+        ticker?.cancel()
+    }
+
+    // MARK: - Row-facing state
+
+    /// Whether this note is the one currently loaded.
+    func isCurrent(_ note: VoiceNote) -> Bool { activeNoteID == note.id }
+
+    /// The played fraction `0...1` for the active note; nil when another (or no)
+    /// note is loaded (every bar renders neutral).
+    func progress(note: VoiceNote) -> Double? {
+        guard activeNoteID == note.id, note.durationMs > 0 else { return nil }
+        return min(1, Double(currentMs) / Double(note.durationMs))
+    }
+
+    /// The clock to show: REMAINING while the note is loaded/playing, total
+    /// when idle.
+    func clockMs(note: VoiceNote) -> Int {
+        guard activeNoteID == note.id else { return note.durationMs }
+        return max(0, note.durationMs - currentMs)
+    }
+
+    /// The speed chip label ("1×", "1.25×", …).
+    func speedLabel() -> String { "\(String(format: "%g", speed))×" }
+
+    // MARK: - Actions
+
+    /// Play/pause the given note. A tap on the active playing note pauses it;
+    /// any other note is fetched (if needed) and starts playing.
+    func toggle(_ note: VoiceNote) async {
+        if activeNoteID == note.id, isPlaying {
+            pause()
+            return
+        }
+        await play(note)
+    }
+
+    /// Seek to a played fraction `0...1` (the waveform is tappable).
+    func seek(note: VoiceNote, fraction: Double) {
+        guard activeNoteID == note.id, let player else { return }
+        let t = player.duration * Double(fraction)
+        player.currentTime = t
+        currentMs = Int(t * 1000)
+    }
+
+    /// Cycle the playback rate for the loaded clip.
+    func cycleSpeed() {
+        let index = VoicePlaybackEngine.speeds.firstIndex(of: speed) ?? 0
+        speed = VoicePlaybackEngine.speeds[(index + 1) % VoicePlaybackEngine.speeds.count]
+        if let player { player.rate = Float(speed) }
+    }
+
+    /// Re-run transcription for a stored-but-untranscribed note; returns the
+    /// refreshed note (with its transcript) when the retry succeeded.
+    func retry(_ noteID: String) async -> VoiceNote? {
+        try? await api.retryVoiceNote(id: noteID)
+    }
+
+    // MARK: - Playback plumbing
+
+    private func play(_ note: VoiceNote) async {
+        stopCurrent()
+        activeNoteID = note.id
+
+        let data: Data
+        if let cached = audioCache[note.id] {
+            data = cached
+        } else {
+            do {
+                data = try await api.voiceNoteAudio(id: note.id)
+                audioCache[note.id] = data
+            } catch {
+                activeNoteID = nil
+                return
+            }
+        }
+
+        do {
+            let player = try AVAudioPlayer(data: data)
+            player.enableRate = true
+            player.rate = Float(speed)
+            self.player = player
+            player.prepareToPlay()
+            player.play()
+            isPlaying = true
+            currentMs = 0
+            startTicker(note: note)
+        } catch {
+            activeNoteID = nil
+            isPlaying = false
+        }
+    }
+
+    private func startTicker(note: VoiceNote) {
+        ticker?.cancel()
+        ticker = Task { @MainActor [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 100_000_000)
+                guard let self, let player = self.player, !Task.isCancelled else { return }
+                if player.isPlaying {
+                    self.currentMs = Int(player.currentTime * 1000)
+                } else if self.isPlaying {
+                    // Natural completion (or a route interruption ended it).
+                    self.currentMs = note.durationMs
+                    self.stopCurrent()
+                }
+            }
+        }
+    }
+
+    private func pause() {
+        player?.pause()
+        isPlaying = false
+    }
+
+    private func stopCurrent() {
+        ticker?.cancel()
+        ticker = nil
+        player?.stop()
+        player = nil
+        isPlaying = false
+        currentMs = 0
+    }
+}
+
+// MARK: - Voice-bars waveform
+
+/// The static DOM-style waveform, rendered from the stored peaks. Bars are
+/// `2px` wide with `2px` gaps up to `22px` tall. Played bars take `accentTx`,
+/// unplayed `tx4` (the stored/playback waveform normalises — unlike the live
+/// meter). The bar count fits the available width, and the whole strip is
+/// tappable to seek.
+private struct VoiceBarsView: View {
+    let peaks: [UInt8]
+    let progress: Double?
+    let tokens: Tokens
+    let onSeek: (Double) -> Void
+
+    private var maxHeight: CGFloat { Metrics.spacing.sp5 + Metrics.spacing.spPx * 2 }
+    private var barWidth: CGFloat { Metrics.spacing.spPx * 2 }
+    private var barGap: CGFloat { Metrics.spacing.spPx * 2 }
+
+    var body: some View {
+        GeometryReader { geo in
+            let slot = barWidth + barGap
+            let barCount = max(1, Int(geo.size.width / slot))
+            let values = Waveform.normalizeForDisplay(Waveform.bucketPeaks(peaks, bars: barCount))
+            HStack(alignment: .center, spacing: barGap) {
+                ForEach(Array(values.enumerated()), id: \.offset) { index, value in
+                    let played = index < barCount && (progress ?? 0) > Double(index) / Double(barCount)
+                    RoundedRectangle(cornerRadius: Metrics.radius.xs, style: .continuous)
+                        .fill(played ? tokens.accentTx : tokens.tx4)
+                        .frame(width: barWidth, height: barHeight(value))
+                }
+                if values.isEmpty {
+                    Spacer(minLength: 0)
+                }
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .contentShape(Rectangle())
+            .gesture(tapSeek(width: geo.size.width))
+        }
+        .frame(height: maxHeight)
+        .frame(maxWidth: .infinity)
+        .accessibilityHidden(true)
+    }
+
+    private func barHeight(_ value: Double) -> CGFloat {
+        let base = barWidth
+        return max(base, min(maxHeight, base + value * (maxHeight - base)))
+    }
+
+    private func tapSeek(width: CGFloat) -> some Gesture {
+        DragGesture(minimumDistance: 0)
+            .onEnded { value in
+                guard width > 0 else { return }
+                onSeek(min(1, max(0, value.location.x / width)))
+            }
+    }
+}
+
+// MARK: - The row
+
+/// The voice-note player row, rendered directly under the user band it belongs
+/// to. Reads playback progress from the conversation-scoped engine.
+struct VoiceNotePlayerRow: View {
+    let note: VoiceNote
+    let tokens: Tokens
+    @EnvironmentObject private var player: VoicePlaybackEngine
+
+    var body: some View {
+        if note.audioAvailable {
+            readyRow
+        } else {
+            expiredRow
+        }
+    }
+
+    private var discDiameter: CGFloat { Metrics.spacing.sp6 + Metrics.spacing.sp1 }
+
+    /// The playable row: disc toggle, waveform, clock, speed chip.
+    private var readyRow: some View {
+        HStack(spacing: Metrics.spacing.sp2) {
+            Button {
+                Task { await player.toggle(note) }
+            } label: {
+                Image(systemName: (player.isCurrent(note) && player.isPlaying) ? "pause.fill" : "play.fill")
+                    .font(.system(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .foregroundColor(tokens.onAccent)
+                    .frame(width: discDiameter, height: discDiameter)
+                    .background(tokens.accentSolid, in: Circle())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Voice note, \(Waveform.formatClock(note.durationMs))")
+
+            VoiceBarsView(
+                peaks: note.peaks,
+                progress: player.progress(note: note),
+                tokens: tokens,
+                onSeek: { player.seek(note: note, fraction: $0) }
+            )
+
+            Text(Waveform.formatClock(player.clockMs(note: note)))
+                .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))
+                .foregroundColor(tokens.tx4)
+                .monospacedDigit()
+
+            Button {
+                player.cycleSpeed()
+            } label: {
+                Text(player.speedLabel())
+                    .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .foregroundColor(tokens.accentTx)
+                    .padding(.vertical, Metrics.spacing.sp1)
+                    .padding(.horizontal, Metrics.spacing.sp1)
+                    .background(tokens.accentSoft, in: Capsule())
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Playback speed")
+        }
+        .padding(.vertical, Metrics.spacing.sp2)
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("voice-note")
+    }
+
+    /// The swept (expired) row: dimmed, dashed, no play button, not interactive.
+    private var expiredRow: some View {
+        HStack(spacing: Metrics.spacing.sp2) {
+            Circle()
+                .fill(tokens.borderSubtle)
+                .frame(width: discDiameter, height: discDiameter)
+
+            VoiceBarsView(peaks: note.peaks, progress: nil, tokens: tokens, onSeek: { _ in })
+
+            Text("\(Waveform.formatClock(note.durationMs)) · expired")
+                .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))
+                .foregroundColor(tokens.tx4)
+                .monospacedDigit()
+        }
+        .padding(.vertical, Metrics.spacing.sp2)
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle,
+                        style: StrokeStyle(lineWidth: Metrics.spacing.spPx,
+                                           dash: [Metrics.spacing.sp2, Metrics.spacing.sp2]))
+        }
+        .opacity(0.45)
+        .allowsHitTesting(false)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Voice note, expired")
+        .accessibilityIdentifier("voice-note")
+    }
+}
+
+// MARK: - Pending voice-note row
+
+/// The not-yet-real row shown in the composer while a take uploads +
+/// transcribes, and the Retry affordance when transcription failed (the 409
+/// path). The recording is KEPT — a stored-but-untranscribed note is offered a
+/// Retry, never discarded (BET-1029 decision #3).
+struct VoiceNotePendingRow: View {
+    let peaks: [UInt8]
+    let durationMs: Int
+    /// Non-nil once the upload resolved to a stored-but-untranscribed note —
+    /// surfaces a Retry against its id.
+    let error: String?
+    let tokens: Tokens
+    let onRetry: (() -> Void)?
+
+    private var discDiameter: CGFloat { Metrics.spacing.sp6 + Metrics.spacing.sp1 }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+            HStack(spacing: Metrics.spacing.sp2) {
+                Circle()
+                    .fill(tokens.borderStrong)
+                    .frame(width: discDiameter, height: discDiameter)
+
+                VoiceBarsView(peaks: peaks, progress: nil, tokens: tokens, onSeek: { _ in })
+
+                Text(Waveform.formatClock(durationMs))
+                    .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))
+                    .foregroundColor(tokens.tx4)
+                    .monospacedDigit()
+            }
+            .opacity(0.6)
+
+            if let error {
+                HStack(spacing: Metrics.spacing.sp2) {
+                    Text(error)
+                        .font(.manta(size: Metrics.type.xs, design: .monospaced))
+                        .foregroundColor(tokens.danger)
+                    if let onRetry {
+                        Button(action: onRetry) {
+                            Text("Retry")
+                                .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))
+                                .foregroundColor(tokens.tx2)
+                                .padding(.vertical, Metrics.spacing.sp1)
+                                .padding(.horizontal, Metrics.spacing.sp2)
+                                .background(tokens.inset, in: Capsule())
+                                .overlay {
+                                    Capsule().stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+                                }
+                        }
+                        .buttonStyle(.plain)
+                        .accessibilityLabel("Retry transcription")
+                    }
+                }
+            } else {
+                HStack(spacing: Metrics.spacing.sp1) {
+                    ProgressView()
+                        .controlSize(.mini)
+                        .tint(tokens.accentTx)
+                    Text("transcribing…")
+                        .font(.manta(size: Metrics.type.xs, design: .monospaced))
+                        .foregroundColor(tokens.accentTx)
+                }
+            }
+        }
+        .padding(.vertical, Metrics.spacing.sp2)
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tokens.panel, in: RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay {
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: Metrics.spacing.spPx)
+        }
+    }
+}

--- a/mobile/native/MantaUITests/VoiceNoteTests.swift
+++ b/mobile/native/MantaUITests/VoiceNoteTests.swift
@@ -1,0 +1,149 @@
+import XCTest
+@testable import MantaUI
+
+// BET-1029 — voice notes in the transcript. Pure logic only: the message→note
+// map that attaches a player bubble under the user message that dictated it,
+// the `.file` attachment block emission, the `VoiceNote` wire decode, and the
+// clock format. No HTTP/view involved beyond the model decode.
+
+final class VoiceNoteTests: XCTestCase {
+
+    // MARK: - Fixture builders
+
+    private func textPart(_ id: String, _ messageID: String, _ text: String) -> OpencodePart {
+        OpencodePart(type: "text", id: id, messageID: messageID, text: text)
+    }
+
+    private func userMessage(id: String, parts: [OpencodePart]) -> OpencodeMessage {
+        OpencodeMessage(
+            info: OpencodeMessageInfo(
+                id: id,
+                sessionID: "ses",
+                role: OpencodeRole(rawValue: "user"),
+                time: OpencodeTime(created: 0, completed: 1),
+                modelID: nil,
+                providerID: nil
+            ),
+            parts: parts
+        )
+    }
+
+    private func note(id: String, transcript: String) -> VoiceNote {
+        VoiceNote(
+            id: id,
+            sessionId: "ses",
+            transcript: transcript,
+            mime: "audio/mp4",
+            durationMs: 7000,
+            peaks: [10, 20, 30],
+            createdAt: 0,
+            expiresAt: nil,
+            audioAvailable: true
+        )
+    }
+
+    // MARK: - buildVoiceNoteMap
+
+    func testNoteClaimsFirstUnclaimedMatchingMessage() {
+        let msgs = [userMessage(id: "m1", parts: [textPart("p1", "m1", "record this note")])]
+        let map = ChatTranscriptMapper.buildVoiceNoteMap(messages: msgs, notes: [note(id: "n1", transcript: "record this note")])
+        XCTAssertEqual(map["m1"]?.id, "n1")
+    }
+
+    func testDuplicateTranscriptClaimsNextUnclaimedMessageNotTheSameOne() {
+        let msgs = [
+            userMessage(id: "m1", parts: [textPart("p1", "m1", "apple")]),
+            userMessage(id: "m2", parts: [textPart("p1", "m2", "apple")]),
+        ]
+        let map = ChatTranscriptMapper.buildVoiceNoteMap(
+            messages: msgs,
+            notes: [note(id: "n1", transcript: "apple"), note(id: "n2", transcript: "apple")]
+        )
+        // n1 claims the FIRST unclaimed match (m1); n2 the NEXT (m2).
+        XCTAssertEqual(map["m1"]?.id, "n1")
+        XCTAssertEqual(map["m2"]?.id, "n2")
+    }
+
+    func testNoteMatchingNothingIsDropped() {
+        let msgs = [userMessage(id: "m1", parts: [textPart("p1", "m1", "hello")])]
+        let map = ChatTranscriptMapper.buildVoiceNoteMap(messages: msgs, notes: [note(id: "n1", transcript: "no such message")])
+        XCTAssertTrue(map.isEmpty)
+    }
+
+    func testMatchingUsesConcatenatedTextParts() {
+        // Two text parts join with a newline — the exact text a dictated message
+        // claims against.
+        let msgs = [userMessage(id: "m1", parts: [textPart("p1", "m1", "line one"), textPart("p2", "m1", "line two")])]
+        let map = ChatTranscriptMapper.buildVoiceNoteMap(messages: msgs, notes: [note(id: "n1", transcript: "line one\nline two")])
+        XCTAssertEqual(map["m1"]?.id, "n1")
+    }
+
+    func testEmptyTranscriptNoteIsSkipped() {
+        let msgs = [userMessage(id: "m1", parts: [textPart("p1", "m1", "hello")])]
+        let map = ChatTranscriptMapper.buildVoiceNoteMap(
+            messages: msgs,
+            notes: [note(id: "n1", transcript: "   ")]
+        )
+        XCTAssertTrue(map.isEmpty)
+    }
+
+    // MARK: - Transcript block emission
+
+    func testBlocksEmitsAttachmentUnderUserBand() {
+        let msgs = [userMessage(id: "m1", parts: [textPart("p1", "m1", "dictated")])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs, voiceNotes: [note(id: "n1", transcript: "dictated")])
+        XCTAssertEqual(blocks.count, 2)
+        guard case .user(let text, _) = blocks[0] else { return XCTFail("expected user") }
+        XCTAssertEqual(text, "dictated")
+        guard case .file(let attachment) = blocks[1],
+              case .voiceNote(let claimed) = attachment.kind else {
+            return XCTFail("expected .file(.voiceNote) after the user band")
+        }
+        XCTAssertEqual(claimed.id, "n1")
+    }
+
+    func testBlocksWithNoMatchingNoteEmitsNoAttachment() {
+        let msgs = [userMessage(id: "m1", parts: [textPart("p1", "m1", "typed")])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs, voiceNotes: [note(id: "n1", transcript: "unrelated")])
+        XCTAssertEqual(blocks.count, 1)
+    }
+
+    // MARK: - Model decode + expired row
+
+    func testVoiceNoteDecodesAudioAvailableRecord() throws {
+        let json: [String: Any] = [
+            "id": "n1", "sessionId": "ses", "transcript": "hi", "mime": "audio/mp4",
+            "durationMs": 7000, "peaks": Data([1, 2, 3]).base64EncodedString(),
+            "createdAt": 0, "expiresAt": NSNull(), "audioAvailable": true,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let note = try JSONDecoder().decode(VoiceNote.self, from: data)
+        XCTAssertEqual(note.id, "n1")
+        XCTAssertEqual(note.sessionId, "ses")
+        XCTAssertEqual(note.durationMs, 7000)
+        XCTAssertEqual(note.peaks, [1, 2, 3])
+        XCTAssertNil(note.expiresAt)
+        XCTAssertEqual(note.audioAvailable, true)
+    }
+
+    func testVoiceNoteDecodesAudioUnavailableAsExpired() throws {
+        let json: [String: Any] = [
+            "id": "n1", "sessionId": "ses", "transcript": "kept", "mime": "audio/mp4",
+            "durationMs": 7000, "peaks": Data([1, 2, 3]).base64EncodedString(),
+            "createdAt": 0, "expiresAt": 123, "audioAvailable": false,
+        ]
+        let data = try JSONSerialization.data(withJSONObject: json)
+        let note = try JSONDecoder().decode(VoiceNote.self, from: data)
+        XCTAssertEqual(note.audioAvailable, false)
+        // The row's expired branch is `!note.audioAvailable` — this is what
+        // marks an expired note non-interactive with a "· expired" suffix.
+        XCTAssertFalse(note.audioAvailable)
+    }
+
+    // MARK: - Clock format through Waveform.formatClock
+
+    func testClockFormatGoesThroughFormatClock() {
+        XCTAssertEqual(Waveform.formatClock(7000), "0:07")
+        XCTAssertEqual(Waveform.formatClock(63_000), "1:03")
+    }
+}


### PR DESCRIPTION
Opened automatically for `multica/BET-1029-voice-notes`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1029.