### PR TITLE
feat(server): usage-limit stopped-conversation classifier + durable record (BET-1047 stage 1)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -54,7 +54,7 @@ import {
 import { startServerUpdatePoller, createOpencodeUpdateForwarder } from "./serverUpdate.mjs";
 import { runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { startSchedulePoller, createJob, listJobs, deleteJob } from "./schedule.mjs";
-import { startUsagePoller } from "./usage.mjs";
+import { startUsagePoller, recheckAdapterAtLimit } from "./usage.mjs";
 import {
   createCapJob,
   getJob,
@@ -84,6 +84,8 @@ import {
 } from "./servePage.mjs";
 import { publishPlanBundle } from "./planRender.mjs";
 import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./peers.mjs";
+import { upsertStopped } from "./stoppedStore.mjs";
+import { createUsageStopEngine } from "./usageStopEnroll.mjs";
 import * as appControl from "./appControl.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
 import { createPromptDelivery } from "./promptDelivery.mjs";
@@ -347,6 +349,27 @@ const { stop: stopDeferredMobilePoller } = push.startDeferredMobilePoller();
 // indicator — see src/server/usage.mjs for that boundary.
 // eslint-disable-next-line no-unused-vars
 const { stop: stopUsagePoller } = startUsagePoller(bus);
+
+// Usage-stop enrolment (BET-1047 stage 1): derives durable "stopped
+// conversation" records from the opencode stream (see usageStopEnroll.mjs).
+// Either a refusal-word match or the provider's meter sitting at its limit
+// (re-checked on the failure via the EXISTING usage adapters) enrols a
+// conversation into the stoppedStore. observeEvent is called from the pump
+// below. Scope: the three subscription providers only.
+const usageStopEngine = createUsageStopEngine({
+  upsert: (input) => upsertStopped(input, { publish: (evt) => bus.publish(evt) }),
+  recheckAtLimit: (adapterId) => recheckAdapterAtLimit(adapterId),
+  resolveWorkspace: async (sessionId) => {
+    try {
+      const dir = await oc.getSessionDirectory(sessionId);
+      if (!dir) return "";
+      const leaf = basename(dir);
+      return leaf || dir;
+    } catch {
+      return "";
+    }
+  },
+});
 
 // Capability-job sweeper: same shape as startSchedulePoller — fails out stale
 // `running` jobs (30 min) and expired `queued` jobs (24h), then prunes terminal
@@ -891,6 +914,11 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
     delegateEngine.observeEvent(evt);
   } catch (e) {
     console.warn("[delegate] observeEvent failed:", e?.message ?? e);
+  }
+  try {
+    usageStopEngine.observeEvent(evt);
+  } catch (e) {
+    console.warn("[usage-stop] observeEvent failed:", e?.message ?? e);
   }
   // Auto-recover expired Claude credentials (server-side; works with no client attached).
   oc.maybeRecoverCredentials(evt).catch(() => {});

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -15,6 +15,13 @@ import {
 } from "../shared/streamInterpretation.mjs";
 import { listJobs as scheduleListJobs, deleteJob as scheduleDeleteJob, createJob as scheduleCreateJob } from "./schedule.mjs";
 import { listSnapshots as usageListSnapshots } from "./usage.mjs";
+import {
+  listStopped as usageStoppedList,
+  armStopped as usageStoppedArm,
+  disarmStopped as usageStoppedDisarm,
+  stampStoppedLastLooked as usageStoppedStampLastLooked,
+  markStoppedRan as usageStoppedMarkRan,
+} from "./stoppedStore.mjs";
 import { listHooks as webhookListHooks, deleteHook as webhookDeleteHook } from "./webhooks.mjs";
 import { listPages as servePageListStore } from "./servePage.mjs";
 import { listOutbox } from "./outbox.mjs";import { publicBaseUrl } from "./gatewayRegister.mjs";
@@ -1151,6 +1158,27 @@ export function buildHandlers({
     // set actually changes — this channel is for the initial paint / refetch.
     // preload: ipcRenderer.invoke(IPC.usageList)  → no args
     "usage:list": () => usageListSnapshots(),
+
+    // ---- usage-stop record (manta-server owned; BET-1047 stage 1) ----
+    // Durable box-side record of conversations stopped by a plan-usage limit.
+    // The store + enrolment path live in src/server/stoppedStore.mjs +
+    // usageStopEnroll.mjs; these channels read/mutate it. Mutations publish
+    // `usage-stopped.updated` so the indicator + modal refetch without polling.
+    // Mirrors the schedule:* pattern (same store shape, same bus event).
+    // preload: ipcRenderer.invoke(IPC.usageStoppedList)  → no args
+    "usage-stopped:list": () => usageStoppedList(),
+    // Arm an entry for resume (keeps it listed, marks it armed).
+    "usage-stopped:arm": (conversation) =>
+      usageStoppedArm({ conversation }, { publish: (evt) => bus.publish(evt) }),
+    // Disarm = modal uncheck = an explicit "no" → removes the row.
+    "usage-stopped:disarm": (conversation) =>
+      usageStoppedDisarm({ conversation }, { publish: (evt) => bus.publish(evt) }),
+    // Stamp the list-level "last looked" timestamp (modal close).
+    "usage-stopped:stamp-last-looked": () =>
+      usageStoppedStampLastLooked({}, { publish: (evt) => bus.publish(evt) }),
+    // Clear a row because the conversation ran successfully.
+    "usage-stopped:mark-ran": (conversation) =>
+      usageStoppedMarkRan({ conversation }, { publish: (evt) => bus.publish(evt) }),
 
     // ---- background jobs (manta-server owned; in-process on mobile) ----
     // Mirror of the /api/delegate REST surface for the renderer. Jobs are

--- a/src/server/stateSandbox.test.mjs
+++ b/src/server/stateSandbox.test.mjs
@@ -21,6 +21,7 @@ import { homedir } from "node:os";
 import { sep } from "node:path";
 import { stateHome, statePath } from "../shared/paths.mjs";
 import { STORE_PATH as AUTH_STORE_PATH } from "./auth.mjs";
+import { STORE_PATH as USAGE_STOP_STORE_PATH } from "./stoppedStore.mjs";
 
 test("the test run has a sandboxed state home", () => {
   const sandbox = process.env.MANTA_STATE_HOME;
@@ -44,4 +45,12 @@ test("store paths resolve inside the sandbox, not the live box", () => {
   );
   assert.ok(!AUTH_STORE_PATH.startsWith(homedir() + sep + ".manta"));
   assert.ok(statePath("secrets.json").startsWith(sandbox + sep));
+  // The usage-stopped store must land inside the sandbox the same way
+  // (BET-1047) — a fresh store pointing at $HOME re-opens the data-loss hole
+  // for this record and no other canary would notice.
+  assert.ok(
+    USAGE_STOP_STORE_PATH.startsWith(sandbox + sep),
+    `usage-stopped store resolved to ${USAGE_STOP_STORE_PATH}, outside the sandbox ${sandbox}`,
+  );
+  assert.ok(!USAGE_STOP_STORE_PATH.startsWith(homedir() + sep + ".manta"));
 });

--- a/src/server/stoppedStore.mjs
+++ b/src/server/stoppedStore.mjs
@@ -1,0 +1,214 @@
+// stoppedStore.mjs — the durable box-side record of conversations stopped by a
+// plan-usage limit (BET-1047 stage 1). This is the SINGLE source for the
+// sidebar indicator, the row markers and the resume modal; because it is a
+// durable on-disk store, all three survive an app restart (spec §5).
+//
+// Record fields are exactly spec §5's table — nothing extra:
+//   workspace   grouping (the project/workspace the conversation lives in)
+//   conversation  the row identity + grouping (the opencode session id)
+//   provider     usage-engine adapter id ("claude" | "codex" | "kimi") — the
+//                meter that gates the resume
+//   model        the model that was in flight (pinned on the continuation)
+//   window       "session" | "weekly" | "monthly", when the refusal named one
+//   stoppedAt    epoch ms — ordering + the "new since you last looked" badge
+//   cachedTokens the cached-token count at that moment (cold-cache cost estimate)
+//   armed        whether the user chose to resume it
+//   attempts     so a permanently-refused conversation stops looping
+//
+// Plus one list-level `lastLooked` timestamp (stamped when the modal closes).
+//
+// Lifecycle (spec §5.1):
+//   - a repeat refusal for a conversation already listed UPDATES that entry (no duplicate);
+//   - removed on a successful run of that conversation (markStoppedRan);
+//   - removed on explicit unchecking in the modal (disarm — an explicit "no");
+//   - a repeat refusal increments attempts (permanent refusal stops looping).
+//
+// Follows the existing store pattern (schedule.mjs / secrets.mjs): pure logic +
+// injected I/O, resolved through statePath() (never a hand-built home path —
+// that breaks the test sandbox), written atomically via jsonStore. Publish
+// `usage-stopped.updated` so clients refresh without polling.
+
+import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+
+const STORE_PATH = statePath("usage-stopped.json");
+// Exported so the state-sandbox canary can assert it resolves inside the test
+// sandbox (never the live box) — see stateSandbox.test.mjs.
+export { STORE_PATH };
+
+/** @typedef {import("./usageStopper.mjs").UsageWindowKind} UsageWindowKind */
+
+/**
+ * @typedef {object} StoppedRecord
+ * @property {string} workspace
+ * @property {string} conversation
+ * @property {"claude"|"codex"|"kimi"} provider
+ * @property {string} [model]
+ * @property {UsageWindowKind|null} window
+ * @property {number} stoppedAt
+ * @property {number} [cachedTokens]
+ * @property {boolean} [armed]
+ * @property {number} [attempts]
+ */
+
+export function loadStoppedState(path = STORE_PATH) {
+  const parsed = readJsonSync(path, {});
+  return {
+    lastLooked: typeof parsed?.lastLooked === "number" ? parsed.lastLooked : null,
+    records: Array.isArray(parsed?.records) ? parsed.records : [],
+  };
+}
+
+export async function saveStoppedState(state, path = STORE_PATH) {
+  await writeJsonAtomic(path, JSON.stringify(state, null, 2));
+}
+
+/**
+ * Build a fresh record for a conversation. Pure — the caller owns the store.
+ * @param {object} input
+ * @param {string} input.workspace
+ * @param {string} input.conversation
+ * @param {"claude"|"codex"|"kimi"} input.provider
+ * @param {string} [input.model]
+ * @param {UsageWindowKind|null} input.window
+ * @param {number} input.stoppedAt
+ * @param {number} [input.cachedTokens]
+ * @returns {StoppedRecord}
+ */
+export function buildStoppedRecord({ workspace, conversation, provider, model, window, stoppedAt, cachedTokens }) {
+  return {
+    workspace: asString(workspace),
+    conversation: asString(conversation),
+    provider,
+    ...(model ? { model: asString(model) } : {}),
+    window: window ?? null,
+    stoppedAt,
+    ...(Number.isFinite(cachedTokens) ? { cachedTokens } : {}),
+    armed: false,
+    attempts: 1,
+  };
+}
+
+function asString(v) {
+  return typeof v === "string" ? v : "";
+}
+
+function indexOfRecord(state, conversation) {
+  if (!conversation) return -1;
+  return state.records.findIndex((r) => r?.conversation === conversation);
+}
+
+/**
+ * Enrol (or update) a stopped conversation. A repeat refusal for a
+ * conversation already listed UPDATES its entry — never a duplicate (spec
+ * §5.1). Publish `usage-stopped.updated` on any write.
+ *
+ * @param {object} input
+ * @param {string} input.conversation
+ * @param {string} [input.workspace]
+ * @param {"claude"|"codex"|"kimi"} input.provider
+ * @param {string} [input.model]
+ * @param {UsageWindowKind|null} input.window
+ * @param {number} input.stoppedAt
+ * @param {number} [input.cachedTokens]
+ * @param {object} [deps]
+ * @param {() => {records: StoppedRecord[], lastLooked: number|null}} [deps.load]
+ * @param {(s: object) => Promise<void>} [deps.save]
+ * @param {(evt: object) => void} [deps.publish]
+ */
+export async function upsertStopped(input, { load = loadStoppedState, save = saveStoppedState, publish } = {}) {
+  if (!input?.conversation) return;
+  const state = load();
+  const idx = indexOfRecord(state, input.conversation);
+  const record = buildStoppedRecord(input);
+  if (idx === -1) {
+    state.records.push(record);
+  } else {
+    // Update in place; attempts increments so a permanently-refused
+    // conversation stops looping. armed is preserved across repeats.
+    state.records[idx] = {
+      ...state.records[idx],
+      workspace: record.workspace,
+      provider: record.provider,
+      ...(record.model ? { model: record.model } : {}),
+      window: record.window,
+      stoppedAt: record.stoppedAt,
+      ...(record.cachedTokens !== undefined ? { cachedTokens: record.cachedTokens } : {}),
+      attempts: (state.records[idx].attempts ?? 0) + 1,
+    };
+  }
+  await save(state);
+  publish?.({ kind: "usage-stopped.updated", payload: { conversation: input.conversation } });
+}
+
+/**
+ * Arm an entry for resume: mark it `armed: true`. The row stays listed.
+ * @param {object} input
+ * @param {string} input.conversation
+ * @param {object} [deps]
+ */
+export async function armStopped({ conversation }, { load = loadStoppedState, save = saveStoppedState, publish } = {}) {
+  if (!conversation) return;
+  const state = load();
+  const idx = indexOfRecord(state, conversation);
+  if (idx === -1) return;
+  state.records[idx] = { ...state.records[idx], armed: true };
+  await save(state);
+  publish?.({ kind: "usage-stopped.updated", payload: { conversation } });
+}
+
+/**
+ * Disarm an entry — the modal uncheck, an explicit "no" — which REMOVES it
+ * (spec §5.1). The row disappears from the list and the sidebar pill.
+ * @param {object} input
+ * @param {string} input.conversation
+ * @param {object} [deps]
+ */
+export async function disarmStopped({ conversation }, { load = loadStoppedState, save = saveStoppedState, publish } = {}) {
+  if (!conversation) return;
+  const state = load();
+  const idx = indexOfRecord(state, conversation);
+  if (idx === -1) return;
+  state.records.splice(idx, 1);
+  await save(state);
+  publish?.({ kind: "usage-stopped.updated", payload: { conversation } });
+}
+
+/**
+ * Clear an entry because that conversation ran successfully (whether resumed
+ * by us or by hand) or resumed. Removes the row (spec §5.1).
+ * @param {object} input
+ * @param {string} input.conversation
+ * @param {object} [deps]
+ */
+export async function markStoppedRan({ conversation }, { load = loadStoppedState, save = saveStoppedState, publish } = {}) {
+  if (!conversation) return;
+  const state = load();
+  const idx = indexOfRecord(state, conversation);
+  if (idx === -1) return;
+  state.records.splice(idx, 1);
+  await save(state);
+  publish?.({ kind: "usage-stopped.updated", payload: { conversation } });
+}
+
+/**
+ * Stamp the list-level "last looked" timestamp (set when the modal closes).
+ * @param {object} [input]
+ * @param {number} [input.now]
+ * @param {object} [deps]
+ */
+export async function stampStoppedLastLooked({ now = Date.now() } = {}, { load = loadStoppedState, save = saveStoppedState, publish } = {}) {
+  const state = load();
+  state.lastLooked = now();
+  await save(state);
+  publish?.({ kind: "usage-stopped.updated", payload: {} });
+}
+
+/**
+ * Read the current record for clients. Returns { records, lastLooked }.
+ * @param {object} [deps]
+ */
+export async function listStopped({ load = loadStoppedState } = {}) {
+  const state = load();
+  return { records: state.records, lastLooked: state.lastLooked };
+}

--- a/src/server/stoppedStore.test.mjs
+++ b/src/server/stoppedStore.test.mjs
@@ -1,0 +1,156 @@
+// stoppedStore.test.mjs — durable stopped-conversation record lifecycle
+// (BET-1047 §5). Pure logic + injected I/O; no real disk writes (an in-memory
+// load/save pair stands in) unless a canary asserts the sandboxed path.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { sep } from "node:path";
+import { statePath } from "../shared/paths.mjs";
+import {
+  STORE_PATH,
+  loadStoppedState,
+  saveStoppedState,
+  buildStoppedRecord,
+  upsertStopped,
+  armStopped,
+  disarmStopped,
+  markStoppedRan,
+  stampStoppedLastLooked,
+  listStopped,
+} from "./stoppedStore.mjs";
+
+// A tiny in-memory store so the lifecycle tests never touch the filesystem.
+function memStore(initial = { lastLooked: null, records: [] }) {
+  let state = { lastLooked: initial?.lastLooked ?? null, records: initial?.records ?? [] };
+  return {
+    load: () => state,
+    save: async (s) => {
+      state = s;
+    },
+    get: () => state,
+  };
+}
+
+function pausedEvents() {
+  const events = [];
+  return { events, publish: (evt) => events.push(evt) };
+}
+
+const ENTRY = { conversation: "sess-1", workspace: "proj", provider: "claude", model: "claude-opus-4-7", window: "weekly", stoppedAt: 1000, cachedTokens: 5000 };
+
+test("upsertStopped enrols a fresh stopped conversation", async () => {
+  const store = memStore();
+  const r = await upsertStopped(ENTRY, { load: store.load, save: store.save, publish: () => {} });
+  assert.equal(r, undefined);
+  const { records, lastLooked } = await listStopped({ load: store.load });
+  assert.equal(records.length, 1);
+  assert.equal(records[0].conversation, "sess-1");
+  assert.equal(records[0].provider, "claude");
+  assert.equal(records[0].window, "weekly");
+  assert.equal(records[0].stoppedAt, 1000);
+  assert.equal(records[0].cachedTokens, 5000);
+  assert.equal(records[0].armed, false);
+  assert.equal(records[0].attempts, 1);
+  assert.equal(lastLooked, null);
+});
+
+test("a repeat refusal UPDATES the existing entry — never a duplicate", async () => {
+  const store = memStore();
+  await upsertStopped(ENTRY, { load: store.load, save: store.save, publish: () => {} });
+  // Same conversation, same provider — a repeat refusal. Some fields evolve.
+  await upsertStopped(
+    { ...ENTRY, window: "session", stoppedAt: 2000, cachedTokens: 7000 },
+    { load: store.load, save: store.save, publish: () => {} },
+  );
+  const { records } = await listStopped({ load: store.load });
+  assert.equal(records.length, 1, "a repeat refusal must not duplicate the row");
+  assert.equal(records[0].stoppedAt, 2000, "the entry is updated");
+  assert.equal(records[0].window, "session", "the window is updated");
+  assert.equal(records[0].cachedTokens, 7000);
+  assert.equal(records[0].attempts, 2, "attempts increments so a permanent refusal stops looping");
+});
+
+test("a successful run (markStoppedRan) removes the row", async () => {
+  const store = memStore();
+  await upsertStopped(ENTRY, { load: store.load, save: store.save, publish: () => {} });
+  await markStoppedRan({ conversation: "sess-1" }, { load: store.load, save: store.save, publish: () => {} });
+  const { records } = await listStopped({ load: store.load });
+  assert.equal(records.length, 0);
+});
+
+test("disarm (modal uncheck) REMOVES the row", async () => {
+  const store = memStore();
+  await upsertStopped(ENTRY, { load: store.load, save: store.save, publish: () => {} });
+  await disarmStopped({ conversation: "sess-1" }, { load: store.load, save: store.save, publish: () => {} });
+  const { records } = await listStopped({ load: store.load });
+  assert.equal(records.length, 0);
+});
+
+test("arm marks the entry for resume and keeps it", async () => {
+  const store = memStore();
+  await upsertStopped(ENTRY, { load: store.load, save: store.save, publish: () => {} });
+  await armStopped({ conversation: "sess-1" }, { load: store.load, save: store.save, publish: () => {} });
+  const { records } = await listStopped({ load: store.load });
+  assert.equal(records.length, 1);
+  assert.equal(records[0].armed, true);
+});
+
+test("arm/disarm on a missing conversation are no-ops", async () => {
+  const store = memStore();
+  await armStopped({ conversation: "nope" }, { load: store.load, save: store.save, publish: () => {} });
+  await disarmStopped({ conversation: "nope" }, { load: store.load, save: store.save, publish: () => {} });
+  assert.equal(store.get().records.length, 0);
+});
+
+test("stampStoppedLastLooked records the list-level timestamp", async () => {
+  const store = memStore();
+  await stampStoppedLastLooked({ now: () => 9000 }, { load: store.load, save: store.save, publish: () => {} });
+  const { lastLooked } = await listStopped({ load: store.load });
+  assert.equal(lastLooked, 9000);
+});
+
+test("mutations publish usage-stopped.updated on the bus", async () => {
+  const store = memStore();
+  const { events, publish } = pausedEvents();
+  await upsertStopped(ENTRY, { load: store.load, save: store.save, publish });
+  await armStopped({ conversation: "sess-1" }, { load: store.load, save: store.save, publish });
+  await markStoppedRan({ conversation: "sess-1" }, { load: store.load, save: store.save, publish });
+  assert.equal(events.every((e) => e.kind === "usage-stopped.updated"), true);
+  assert.equal(events.length, 3);
+});
+
+test("buildStoppedRecord normalises fields", () => {
+  const r = buildStoppedRecord({ workspace: "w", conversation: "c", provider: "kimi", model: "m", window: "monthly", stoppedAt: 5, cachedTokens: 3 });
+  assert.deepEqual(r, { workspace: "w", conversation: "c", provider: "kimi", model: "m", window: "monthly", stoppedAt: 5, cachedTokens: 3, armed: false, attempts: 1 });
+});
+
+// ---------------------------------------------------------------------------
+// Canary: the store must resolve INSIDE the test sandbox, never the live box
+// ---------------------------------------------------------------------------
+
+test("the stopped-store path resolves inside the test sandbox", () => {
+  const sandbox = process.env.MANTA_STATE_HOME;
+  assert.ok(sandbox && sandbox.trim() !== "", "MANTA_STATE_HOME must be set (run via npm test)");
+  assert.ok(
+    STORE_PATH.startsWith(sandbox + sep),
+    `stopped store resolved to ${STORE_PATH}, outside the sandbox ${sandbox}`,
+  );
+  assert.ok(!STORE_PATH.startsWith(homedir() + sep + ".manta"), "stopped store must not be in the live box");
+  assert.ok(statePath("usage-stopped.json") === STORE_PATH);
+});
+
+test("loadStoppedState falls back to an empty record on missing/invalid data", () => {
+  // A JSON-invalid file path falls back to an empty-but-valid state.
+  const state = loadStoppedState("/tmp/definitely-not-a-real-store-here.json");
+  assert.deepEqual(state, { lastLooked: null, records: [] });
+});
+
+test("save/load round-trips through the real store path helpers", async () => {
+  // Use a throwaway sandbox path; exercises saveStoppedState/loadStoppedState.
+  const path = statePath("canary-usage-stopped.json");
+  await saveStoppedState({ lastLooked: 42, records: [{ conversation: "s", workspace: "", provider: "claude", window: null, stoppedAt: 1 }] }, path);
+  const back = loadStoppedState(path);
+  assert.equal(back.lastLooked, 42);
+  assert.equal(back.records[0].conversation, "s");
+});

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -76,12 +76,48 @@ import { startPoller } from "./startPoller.mjs";
 import { claudeAdapter } from "./usageAdapters/claude.mjs";
 import { codexAdapter } from "./usageAdapters/codex.mjs";
 import { kimiAdapter } from "./usageAdapters/kimi.mjs";
+import { isUsageAtLimit } from "./usageStopper.mjs";
 
 export { normalizeWindow };
 
 // The registry of built-in adapters. Registry only — the engine below never
 // branches on a provider name.
 export const ADAPTERS = [claudeAdapter, codexAdapter, kimiAdapter];
+
+// Map an opencode providerID ("anthropic" | "openai" | "kimi-for-coding") to
+// its usage adapter id ("claude" | "codex" | "kimi"). The two namespaces differ
+// on purpose (see the UsageSnapshot.providerIDs note); the usage-stopped
+// classifier keys on the ADAPTER id, so a session's providerID must be mapped
+// before it reaches the classifier / the at-limit re-check. Returns null for an
+// unlisted provider (out of scope — a pay-as-you-go key).
+export function adapterForProviderID(providerID) {
+  if (typeof providerID !== "string") return null;
+  return ADAPTERS.find((a) => Array.isArray(a.providerIDs) && a.providerIDs.includes(providerID))?.id ?? null;
+}
+
+// Re-check ONE adapter's usage immediately (spec §4, signal 2), reusing the
+// existing adapter fetch rather than writing a second fetch. Returns true when
+// that provider is currently at its limit. Best-effort: a missing credential,
+// a failed fetch or an unlisted id all resolve to false (they must never
+// over-enrol from a stale/absent reading).
+export async function recheckAdapterAtLimit(adapterId, { fetchImpl = fetch, now = () => Date.now() } = {}) {
+  const adapter = ADAPTERS.find((a) => a.id === adapterId);
+  if (!adapter) return false;
+  try {
+    let detected = false;
+    try {
+      detected = await adapter.detect({ fetchImpl, now });
+    } catch {
+      detected = false;
+    }
+    if (!detected) return false;
+    const raw = await adapter.fetch({ fetchImpl, now });
+    const windows = Array.isArray(raw?.windows) ? raw.windows.filter(Boolean) : [];
+    return isUsageAtLimit(windows);
+  } catch {
+    return false;
+  }
+}
 
 // Cache TTL is the poll interval; there is no separate cache layer (per spec).
 const POLL_MS = 600_000; // 10 minutes

--- a/src/server/usageStopEnroll.mjs
+++ b/src/server/usageStopEnroll.mjs
@@ -24,8 +24,7 @@
 // is synchronous and testable; the async work (re-check + store write) is
 // injected.
 
-import { classifyUsageStopped, decideUsageEnrolment, isNonLimitFailure } from "./usageStopper.mjs";
-import { isClaudeCredentialError } from "./claudeAuth.mjs";
+import { classifyUsageStopped, decideUsageEnrolment } from "./usageStopper.mjs";
 import { adapterForProviderID } from "./usage.mjs";
 
 /**
@@ -87,15 +86,10 @@ export function createUsageStopEngine({ upsert, recheckAtLimit, resolveWorkspace
     const errorMessage =
       typeof err?.data?.message === "string" ? err.data.message : typeof err?.message === "string" ? err.message : undefined;
 
-    // A user abort or a context overflow is structurally never a plan-limit
-    // stop (spec §4.1) — suppress BOTH signals (an abort/overflow that happens
-    // while a meter reads at 100% must not over-enrol via the correlation).
-    if (isNonLimitFailure(errorName)) return;
-    // Auth/credential failures must never enrol (spec §4.1) — reuse the
-    // existing Claude auth-error predicate to suppress the correlation signal
-    // too, not just the word match. Returns false harmlessly for non-Claude.
-    if (isClaudeCredentialError(err)) return;
-
+    // The classifier distinguishes "no match" from "explicit never-enrol"
+    // (auth failures, aborts/context-overflow, affirmative NOT-quota phrases);
+    // decideUsageEnrolment lets a never-enrol suppress the correlation signal,
+    // so no separate exclusion gate is needed here.
     const match = classifyUsageStopped({ provider: adapterId, errorName, errorMessage, error: err });
 
     let atLimit = false;

--- a/src/server/usageStopEnroll.mjs
+++ b/src/server/usageStopEnroll.mjs
@@ -24,7 +24,8 @@
 // is synchronous and testable; the async work (re-check + store write) is
 // injected.
 
-import { classifyUsageStopped, decideUsageEnrolment } from "./usageStopper.mjs";
+import { classifyUsageStopped, decideUsageEnrolment, isNonLimitFailure } from "./usageStopper.mjs";
+import { isClaudeCredentialError } from "./claudeAuth.mjs";
 import { adapterForProviderID } from "./usage.mjs";
 
 /**
@@ -85,6 +86,15 @@ export function createUsageStopEngine({ upsert, recheckAtLimit, resolveWorkspace
     const errorName = typeof err?.name === "string" ? err.name : undefined;
     const errorMessage =
       typeof err?.data?.message === "string" ? err.data.message : typeof err?.message === "string" ? err.message : undefined;
+
+    // A user abort or a context overflow is structurally never a plan-limit
+    // stop (spec §4.1) — suppress BOTH signals (an abort/overflow that happens
+    // while a meter reads at 100% must not over-enrol via the correlation).
+    if (isNonLimitFailure(errorName)) return;
+    // Auth/credential failures must never enrol (spec §4.1) — reuse the
+    // existing Claude auth-error predicate to suppress the correlation signal
+    // too, not just the word match. Returns false harmlessly for non-Claude.
+    if (isClaudeCredentialError(err)) return;
 
     const match = classifyUsageStopped({ provider: adapterId, errorName, errorMessage, error: err });
 

--- a/src/server/usageStopEnroll.mjs
+++ b/src/server/usageStopEnroll.mjs
@@ -1,0 +1,147 @@
+// usageStopEnroll.mjs — the enrolment path: turns a raw opencode event stream
+// into durable "stopped conversation" records (BET-1047 stage 1).
+//
+// Detection is two independent signals (spec §4) that fail in opposite
+// directions: the refusal MATCH (classifier over seen wordings — precise but
+// blind to rewording) and the METER CORRELATION (the provider's usage re-
+// checked immediately on the failure — fuzzy but catches everything). Either
+// enrols.
+//
+// To run either signal we need the conversation's provider — which the
+// `session.error` event does not carry. It comes from `session.next.step.ended`
+// events, which DO carry `properties.providerID` + `properties.modelID` and the
+// token breakdown (cached prefix). This module keeps a small per-session record
+// of (adapterId, model, cachedTokens) fed by step events, and consumes it when
+// a session errors. Scope is the three subscription providers (spec §3); a
+// session whose provider is never seen (or is a pay-as-you-go key) never
+// enrols.
+//
+// Instrumentation (spec §4.3): the COMPLETE error payload of every failed turn
+// is logged, so an unfamiliar refusal hands us its wording directly instead of
+// a morning of log archaeology.
+//
+// Pure-ish + dependency-injected for tests: the per-session model bookkeeping
+// is synchronous and testable; the async work (re-check + store write) is
+// injected.
+
+import { classifyUsageStopped, decideUsageEnrolment } from "./usageStopper.mjs";
+import { adapterForProviderID } from "./usage.mjs";
+
+/**
+ * Extract the cached-token count from a step event's props (the sum of the
+ * cached prefix — cache.read + cache.write — that will be re-read on a resume).
+ * @param {object} props  evt.properties of a `session.next.step.ended` event
+ * @returns {number}
+ */
+export function cachedTokensFromStep(props = {}) {
+  const cache = props?.tokens?.cache ?? props?.usage?.cache ?? {};
+  const read = Number.isFinite(cache?.read) ? cache.read : 0;
+  const write = Number.isFinite(cache?.write) ? cache.write : 0;
+  return (read || 0) + (write || 0);
+}
+
+/** @returns {{conversation:string, adapterId:string|null, model?:string, cachedTokens:number}} */
+function freshModel(sessionId) {
+  return { conversation: sessionId, adapterId: null, model: undefined, cachedTokens: 0 };
+}
+
+/**
+ * Build the usage-stop enrolment engine.
+ *
+ * @param {object} deps
+ * @param {(input: object) => Promise<void>} deps.upsert       wire to upsertStopped(input, {publish})
+ * @param {(adapterId: string) => Promise<boolean>|boolean} deps.recheckAtLimit  wire to recheckAdapterAtLimit
+ * @param {(sessionId: string) => Promise<string|undefined>|string|undefined} [deps.resolveWorkspace]  best-effort project label
+ * @param {() => number} [deps.now]
+ * @returns {{ observeEvent: (evt: object) => void }}
+ */
+export function createUsageStopEngine({ upsert, recheckAtLimit, resolveWorkspace = () => "", now = () => Date.now() } = {}) {
+  const sessionModel = new Map(); // sessionId -> {conversation, adapterId, model?, cachedTokens}
+
+  function applyStep(sessionId, props) {
+    let m = sessionModel.get(sessionId);
+    if (!m) {
+      m = freshModel(sessionId);
+      sessionModel.set(sessionId, m);
+    }
+    const adapterId = adapterForProviderID(props?.providerID);
+    if (adapterId) m.adapterId = adapterId;
+    if (typeof props?.modelID === "string" && props.modelID) m.model = props.modelID;
+    m.cachedTokens = cachedTokensFromStep(props);
+  }
+
+  async function performEnrolment(evt) {
+    const props = evt?.properties ?? {};
+    const sessionId = props.sessionID;
+    if (!sessionId) return;
+    const m = sessionModel.get(sessionId);
+    const adapterId = m?.adapterId;
+    // Unknown provider (never seen a step event, or a pay-as-you-go key) →
+    // out of scope. This is what keeps signal 2 from firing for a provider we
+    // cannot attribute the conversation to.
+    if (!adapterId) return;
+
+    const err = props.error ?? {};
+    const errorName = typeof err?.name === "string" ? err.name : undefined;
+    const errorMessage =
+      typeof err?.data?.message === "string" ? err.data.message : typeof err?.message === "string" ? err.message : undefined;
+
+    const match = classifyUsageStopped({ provider: adapterId, errorName, errorMessage, error: err });
+
+    let atLimit = false;
+    try {
+      atLimit = !!(await recheckAtLimit(adapterId));
+    } catch {
+      atLimit = false; // a failed re-check must never over-enrol
+    }
+
+    const decision = decideUsageEnrolment({ match, atLimit });
+    if (!decision.enrol) return;
+
+    let workspace = "";
+    try {
+      workspace = (await resolveWorkspace(sessionId)) ?? "";
+    } catch {
+      workspace = "";
+    }
+
+    await upsert({
+      conversation: sessionId,
+      workspace,
+      provider: adapterId,
+      model: m.model,
+      window: decision.window,
+      stoppedAt: now(),
+      cachedTokens: m.cachedTokens,
+    });
+  }
+
+  function observeEvent(evt) {
+    if (!evt || typeof evt !== "object") return;
+    switch (evt.type) {
+      case "session.next.step.ended": {
+        const props = evt.properties ?? {};
+        if (props.sessionID) applyStep(props.sessionID, props);
+        return;
+      }
+      case "session.error": {
+        // Instrumentation (spec §4.3): log the COMPLETE error payload so the
+        // next unfamiliar refusal hands us its wording directly.
+        console.warn(
+          "[usage-stop] failed turn",
+          JSON.stringify({ sessionID: evt.properties?.sessionID, error: evt.properties?.error ?? null }),
+        );
+        // Return the promise so tests can await the async enrolment; the event
+        // pump ignores the return (fire-and-forget), and a rejection is
+        // swallowed so it can never escape into the pump.
+        return performEnrolment(evt).catch((e) =>
+          console.warn("[usage-stop] enrolment failed:", e?.message ?? e),
+        );
+      }
+      default:
+        return;
+    }
+  }
+
+  return { observeEvent };
+}

--- a/src/server/usageStopEnroll.test.mjs
+++ b/src/server/usageStopEnroll.test.mjs
@@ -1,0 +1,117 @@
+// usageStopEnroll.test.mjs — the enrolment path (BET-1047 §3): turns a stream
+// of step/error events into stopped-conversation records, combining the
+// refusal-match and the meter-correlation signals. Injected I/O only — no live
+// provider, no filesystem.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createUsageStopEngine, cachedTokensFromStep } from "./usageStopEnroll.mjs";
+
+function harness({ atLimit = false } = {}) {
+  const upserts = [];
+  const engine = createUsageStopEngine({
+    upsert: async (input) => upserts.push(input),
+    recheckAtLimit: async () => atLimit,
+    resolveWorkspace: async (sid) => `ws-${sid}`,
+    now: () => 1234,
+  });
+  return { engine, upserts };
+}
+
+function stepEvent(sid, providerID = "anthropic", modelID = "claude-opus-4-7", cacheTokens = { read: 4000, write: 1000 }) {
+  return {
+    type: "session.next.step.ended",
+    properties: { sessionID: sid, providerID, modelID, tokens: { cache: cacheTokens } },
+  };
+}
+
+function errorEvent(sid, name = "Error", message = "you've hit your weekly limit") {
+  return {
+    type: "session.error",
+    properties: { sessionID: sid, error: { name, data: { message } } },
+  };
+}
+
+test("cachedTokensFromStep sums the cached prefix", () => {
+  assert.equal(cachedTokensFromStep({ tokens: { cache: { read: 4000, write: 1000 } } }), 5000);
+  assert.equal(cachedTokensFromStep({ tokens: {} }), 0);
+  assert.equal(cachedTokensFromStep({}), 0);
+});
+
+test("a refused turn enrols with the provider, model, window and cached tokens", async () => {
+  const { engine, upserts } = harness({ atLimit: false });
+  engine.observeEvent(stepEvent("s1"));
+  await engine.observeEvent(errorEvent("s1"));
+  await Promise.resolve();
+  assert.equal(upserts.length, 1);
+  const u = upserts[0];
+  assert.equal(u.conversation, "s1");
+  assert.equal(u.provider, "claude"); // anthropic -> adapter id "claude"
+  assert.equal(u.model, "claude-opus-4-7");
+  assert.equal(u.window, "weekly");
+  assert.equal(u.cachedTokens, 5000);
+  assert.equal(u.workspace, "ws-s1");
+  assert.equal(u.stoppedAt, 1234);
+});
+
+test("meter correlation: unmatched wording + provider at limit → still enrols", async () => {
+  const { engine, upserts } = harness({ atLimit: true });
+  engine.observeEvent(stepEvent("s1", "openai", "gpt-5"));
+  await engine.observeEvent(errorEvent("s1", "Error", "some completely unrelated failure"));
+  await Promise.resolve();
+  assert.equal(upserts.length, 1);
+  assert.equal(upserts[0].provider, "codex");
+  assert.equal(upserts[0].window, null);
+});
+
+test("no signal: unmatched wording + provider under limit → no enrolment", async () => {
+  const { engine, upserts } = harness({ atLimit: false });
+  engine.observeEvent(stepEvent("s1"));
+  await engine.observeEvent(errorEvent("s1", "Error", "some completely unrelated failure"));
+  await Promise.resolve();
+  assert.equal(upserts.length, 0);
+});
+
+test("auth/credential failures never enrol even when at limit", async () => {
+  const { engine, upserts } = harness({ atLimit: true });
+  engine.observeEvent(stepEvent("s1"));
+  engine.observeEvent(
+    errorEvent("s1", "UnknownError", "Your Claude credential has expired"),
+  );
+  await Promise.resolve();
+  assert.equal(upserts.length, 0, "an auth failure must never land a stopped record");
+});
+
+test("a session with no observed step (unknown provider) never enrols", async () => {
+  const { engine, upserts } = harness({ atLimit: true });
+  await engine.observeEvent(errorEvent("s1"));
+  await Promise.resolve();
+  assert.equal(upserts.length, 0);
+});
+
+test("a kimi refusal maps to the kimi adapter and its window", async () => {
+  const { engine, upserts } = harness({ atLimit: false });
+  engine.observeEvent(stepEvent("s1", "kimi-for-coding", "kimi-k2"));
+  await engine.observeEvent(errorEvent("s1", "Error", "reached your usage limit for this billing cycle"));
+  await Promise.resolve();
+  assert.equal(upserts.length, 1);
+  assert.equal(upserts[0].provider, "kimi");
+  assert.equal(upserts[0].window, "weekly");
+});
+
+test("codex structural marker enrols via the error name", async () => {
+  const { engine, upserts } = harness({ atLimit: false });
+  engine.observeEvent(stepEvent("s1", "openai", "gpt-5"));
+  await engine.observeEvent(errorEvent("s1", "usage_limit_reached", "Out of quota"));
+  await Promise.resolve();
+  assert.equal(upserts.length, 1);
+  assert.equal(upserts[0].provider, "codex");
+});
+
+test("non-error and non-step events are ignored", async () => {
+  const { engine, upserts } = harness({ atLimit: true });
+  engine.observeEvent({ type: "session.idle", properties: { sessionID: "s1" } });
+  engine.observeEvent({ type: "message.part.updated", properties: {} });
+  await Promise.resolve();
+  assert.equal(upserts.length, 0);
+});

--- a/src/server/usageStopEnroll.test.mjs
+++ b/src/server/usageStopEnroll.test.mjs
@@ -69,6 +69,23 @@ test("no signal: unmatched wording + provider under limit → no enrolment", asy
   assert.equal(upserts.length, 0);
 });
 
+// Regression for reviewer Question (cycle 2): a never-enrol negative must
+// suppress the meter-correlation signal on the ENROLMENT path too — a throttle
+// that fires while a provider sits at its limit must not land a stopped record.
+test("a throttle refused at limit still never enrols (neverEnrol beats correlation)", async () => {
+  const { engine, upserts } = harness({ atLimit: true });
+  engine.observeEvent(stepEvent("s1"));
+  await engine.observeEvent(errorEvent("s1", "Error", "...temporarily limiting requests..."));
+  assert.equal(upserts.length, 0, "a throttle at-limit must not land a stopped record");
+});
+
+test("a credit/overage refusal at limit never enrols", async () => {
+  const { engine, upserts } = harness({ atLimit: true });
+  engine.observeEvent(stepEvent("s1"));
+  await engine.observeEvent(errorEvent("s1", "Error", "usage credits are required"));
+  assert.equal(upserts.length, 0);
+});
+
 test("auth/credential failures never enrol even when at limit", async () => {
   const { engine, upserts } = harness({ atLimit: true });
   engine.observeEvent(stepEvent("s1"));

--- a/src/server/usageStopEnroll.test.mjs
+++ b/src/server/usageStopEnroll.test.mjs
@@ -42,7 +42,6 @@ test("a refused turn enrols with the provider, model, window and cached tokens",
   const { engine, upserts } = harness({ atLimit: false });
   engine.observeEvent(stepEvent("s1"));
   await engine.observeEvent(errorEvent("s1"));
-  await Promise.resolve();
   assert.equal(upserts.length, 1);
   const u = upserts[0];
   assert.equal(u.conversation, "s1");
@@ -58,7 +57,6 @@ test("meter correlation: unmatched wording + provider at limit → still enrols"
   const { engine, upserts } = harness({ atLimit: true });
   engine.observeEvent(stepEvent("s1", "openai", "gpt-5"));
   await engine.observeEvent(errorEvent("s1", "Error", "some completely unrelated failure"));
-  await Promise.resolve();
   assert.equal(upserts.length, 1);
   assert.equal(upserts[0].provider, "codex");
   assert.equal(upserts[0].window, null);
@@ -68,24 +66,35 @@ test("no signal: unmatched wording + provider under limit → no enrolment", asy
   const { engine, upserts } = harness({ atLimit: false });
   engine.observeEvent(stepEvent("s1"));
   await engine.observeEvent(errorEvent("s1", "Error", "some completely unrelated failure"));
-  await Promise.resolve();
   assert.equal(upserts.length, 0);
 });
 
 test("auth/credential failures never enrol even when at limit", async () => {
   const { engine, upserts } = harness({ atLimit: true });
   engine.observeEvent(stepEvent("s1"));
-  engine.observeEvent(
+  await engine.observeEvent(
     errorEvent("s1", "UnknownError", "Your Claude credential has expired"),
   );
-  await Promise.resolve();
   assert.equal(upserts.length, 0, "an auth failure must never land a stopped record");
+});
+
+test("a user abort never enrols even when at limit", async () => {
+  const { engine, upserts } = harness({ atLimit: true });
+  engine.observeEvent(stepEvent("s1"));
+  await engine.observeEvent(errorEvent("s1", "MessageAbortedError", "Aborted by user"));
+  assert.equal(upserts.length, 0, "a user abort must never land a stopped record");
+});
+
+test("a context overflow never enrols even when at limit", async () => {
+  const { engine, upserts } = harness({ atLimit: true });
+  engine.observeEvent(stepEvent("s1"));
+  await engine.observeEvent(errorEvent("s1", "ContextOverflowError", "Context full — try /compact"));
+  assert.equal(upserts.length, 0, "a context overflow must never land a stopped record");
 });
 
 test("a session with no observed step (unknown provider) never enrols", async () => {
   const { engine, upserts } = harness({ atLimit: true });
   await engine.observeEvent(errorEvent("s1"));
-  await Promise.resolve();
   assert.equal(upserts.length, 0);
 });
 
@@ -93,7 +102,6 @@ test("a kimi refusal maps to the kimi adapter and its window", async () => {
   const { engine, upserts } = harness({ atLimit: false });
   engine.observeEvent(stepEvent("s1", "kimi-for-coding", "kimi-k2"));
   await engine.observeEvent(errorEvent("s1", "Error", "reached your usage limit for this billing cycle"));
-  await Promise.resolve();
   assert.equal(upserts.length, 1);
   assert.equal(upserts[0].provider, "kimi");
   assert.equal(upserts[0].window, "weekly");
@@ -103,7 +111,6 @@ test("codex structural marker enrols via the error name", async () => {
   const { engine, upserts } = harness({ atLimit: false });
   engine.observeEvent(stepEvent("s1", "openai", "gpt-5"));
   await engine.observeEvent(errorEvent("s1", "usage_limit_reached", "Out of quota"));
-  await Promise.resolve();
   assert.equal(upserts.length, 1);
   assert.equal(upserts[0].provider, "codex");
 });
@@ -112,6 +119,5 @@ test("non-error and non-step events are ignored", async () => {
   const { engine, upserts } = harness({ atLimit: true });
   engine.observeEvent({ type: "session.idle", properties: { sessionID: "s1" } });
   engine.observeEvent({ type: "message.part.updated", properties: {} });
-  await Promise.resolve();
   assert.equal(upserts.length, 0);
 });

--- a/src/server/usageStopper.mjs
+++ b/src/server/usageStopper.mjs
@@ -121,32 +121,44 @@ function asString(v) {
 /**
  * Classify a failed turn. Pure.
  *
+ * The result distinguishes TWO kinds of "not a match", because they feed the
+ * correlation signal differently:
+ *   { enrolled:true, window }                 — a refusal wording matched; this is a plan-limit stop.
+ *   { enrolled:false, neverEnrol:true }       — an EXPLICIT never-enrol: an auth/credential
+ *                                                failure, an abort or context overflow, or an
+ *                                                affirmative NOT-quota phrase (throttle/overload/
+ *                                                tier/credits). These are load-bearing (spec §4.1):
+ *                                                they suppress BOTH signals, so the meter
+ *                                                correlation must NOT over-enrol them.
+ *   { enrolled:false }                        — nothing matched and nothing opposed: not a limit
+ *                                                by wording, but the meter correlation may still
+ *                                                enrol (spec §4 signal 2).
+ *
  * @param {object} input
  * @param {string|undefined} input.provider       usage-engine adapter id ("claude"|"codex"|"kimi")
  * @param {unknown} [input.errorName]             the typed error name (e.g. `usage_limit_reached`, `ApiError`)
  * @param {unknown} [input.errorMessage]          the human/immediate error message (spec §4.2 "body")
  * @param {unknown} [input.error]                 the full error object, when available (used to reuse the
  *                                                existing auth-error predicate for exclusion)
- * @returns {{ enrolled: false } | { enrolled: true, window: UsageWindowKind|null }}
+ * @returns {{ enrolled: true, window: UsageWindowKind|null } | { enrolled: false, neverEnrol?: true }}
  */
 export function classifyUsageStopped({ provider, errorName, errorMessage, error }) {
   // Unknown provider → out of scope by construction (spec §3).
-  if (!isStoppedProvider(provider)) return { enrolled: false };
+  if (!isStoppedProvider(provider)) return { enrolled: false, neverEnrol: true };
 
   const name = asString(errorName).toLowerCase();
   const msg = asString(errorMessage).toLowerCase();
 
   // A user abort or a context overflow is structurally never a plan-limit stop,
-  // by name — suppress the match signal here too (defense in depth; the
-  // enrolment path additionally skips these before the meter correlation runs).
-  if (isNonLimitFailure(errorName)) return { enrolled: false };
+  // by name (spec §4.1) — neverEnrol so the correlation cannot over-enrol it.
+  if (isNonLimitFailure(errorName)) return { enrolled: false, neverEnrol: true };
 
   // Auth/credential failures must NEVER enrol. Reuse the existing auth-error
   // predicate rather than writing a second one (spec §4.1, issue Build §1).
   // It only matches Claude credential errors and returns false harmlessly for
-  // everything else.
+  // everything else. neverEnrol so the correlation cannot over-enrol it.
   if (isClaudeCredentialError(error ?? { name: errorName, data: { message: errorMessage } })) {
-    return { enrolled: false };
+    return { enrolled: false, neverEnrol: true };
   }
 
   const hay = name + "\n" + msg;
@@ -154,9 +166,10 @@ export function classifyUsageStopped({ provider, errorName, errorMessage, error 
 
   // The negative list is as load-bearing as the positive one — momentary
   // throttles / overload / tier / credit refusals share tokens and status codes
-  // with real limits and must never enrol. A negative always wins.
+  // with real limits and must never enrol (spec §4.1). A negative ALWAYS wins —
+  // including against the meter correlation, which is why it sets neverEnrol.
   for (const neg of table.negative) {
-    if (hay.includes(neg)) return { enrolled: false };
+    if (hay.includes(neg)) return { enrolled: false, neverEnrol: true };
   }
 
   for (const entry of table.positive) {
@@ -193,14 +206,27 @@ export function isUsageAtLimit(windows) {
  * opposite directions — the match is precise but only knows seen wordings; the
  * correlation is fuzzy but catches everything.
  *
+ * One override: an EXPLICIT never-enrol in the classifier (`match.neverEnrol`
+ * — an auth failure, an abort/context overflow, or an affirmative NOT-quota
+ * phrase) suppresses enrolment even when the meter reads at its limit. Without
+ * this, a throttle or credit refusal that happens to fire while a provider sits
+ * at 100% would be mislabelled a plan-limit stop (spec §4.1: "must not enrol").
+ *
  * @param {object} input
- * @param {{enrolled:boolean, window:UsageWindowKind|null}} input.match   classifier result
- * @param {boolean} input.atLimit                                           provider's meter re-checked on the failure
+ * @param {{enrolled:boolean, window:UsageWindowKind|null, neverEnrol?:boolean}} input.match   classifier result
+ * @param {boolean} input.atLimit   provider's meter re-checked on the failure
  * @returns {{ enrol: false } | { enrol: true, window: UsageWindowKind|null }}
  */
 export function decideUsageEnrolment({ match, atLimit }) {
-  if (match?.enrolled || atLimit) {
-    return { enrol: true, window: match?.enrolled ? match.window : null };
+  if (match?.enrolled) {
+    return { enrol: true, window: match.window ?? null };
+  }
+  // An explicit never-enrol wins against the correlation signal too.
+  if (match?.neverEnrol) {
+    return { enrol: false };
+  }
+  if (atLimit) {
+    return { enrol: true, window: null };
   }
   return { enrol: false };
 }

--- a/src/server/usageStopper.mjs
+++ b/src/server/usageStopper.mjs
@@ -1,0 +1,183 @@
+// usageStopper.mjs — the "was this conversation stopped by a plan-usage limit?"
+// classifier + the pure enrolment decision. BET-1047 stage 1, box-side only.
+//
+// Given a failed turn's provider (a usage-engine adapter id: "claude" | "codex"
+// | "kimi"), the error's name and the error's message, this answers whether the
+// conversation was stopped by a subscription plan-usage limit, and — when the
+// wording names one — which reset window to wait for.
+//
+// The refusal wordings live in ONE table, as data (STOP_STRINGS, spec §4.2), so
+// adding a wording a vendor rewrote is a one-line edit. Matching is
+// case-insensitive substring, against both the error name and the error message.
+//
+// Two signals feed the enrolment path (spec §4); this module owns the FIRST
+// (the refusal match) and the pure decision that combines both. The second
+// (meter correlation — provider already at its limit) is computed by the usage
+// engine and passed in as a boolean.
+//
+// Pure. No I/O. Tests in src/server/usageStopper.test.mjs.
+
+import { isClaudeCredentialError } from "./claudeAuth.mjs";
+
+/**
+ * @typedef {"claude"|"codex"|"kimi"} StoppedProvider
+ *   The usage-engine adapter id. Only the three subscription providers are in
+ *   scope (spec §3); a pay-as-you-go API-key provider never appears here.
+ */
+
+/**
+ * @typedef {"session"|"weekly"|"monthly"} UsageWindowKind
+ *   The reset window the refusal wording named, when it named one.
+ */
+
+/**
+ * Every positive refusal wording per provider, with the window it implies.
+ * The `match` is matched case-insensitively as a substring of the error's
+ * name OR message. `window` is the reset window when the wording names one,
+ * else null (enrol with no window — the meter correlation still lands it).
+ *
+ * Source: docs/usage-resume.md §4.2. Keep every wording here; do not scatter
+ * refusal strings through call sites.
+ *
+ * @type {Record<StoppedProvider, { positive: Array<{match:string, window:UsageWindowKind|null}>, negative: string[] }>}
+ */
+export const STOP_STRINGS = {
+  claude: {
+    positive: [
+      { match: "usage limit reached", window: null },
+      { match: "you've hit your session limit", window: "session" },
+      { match: "you've hit your weekly limit", window: "weekly" },
+      { match: "you've hit your Opus limit", window: "weekly" },
+    ],
+    // "temporarily limiting requests" / "not your usage limit" are throttles or
+    // explicit denials; "usage credits are required" is a credit/overage refusal
+    // (spec §4.1) — none is a plan window, none may enrol.
+    negative: [
+      "temporarily limiting requests",
+      "not your usage limit",
+      "usage credits are required",
+    ],
+  },
+  // Codex is the ONLY provider with a structural marker: error type
+  // `usage_limit_reached` / stream code `insufficient_quota`. The negative list
+  // guards the momentary-throttle / overload wordings that share status codes.
+  codex: {
+    positive: [{ match: "usage_limit_reached", window: null }, { match: "insufficient_quota", window: null }],
+    negative: ["rate_limit_exceeded", "server_is_overloaded", "slow_down"],
+  },
+  kimi: {
+    positive: [
+      { match: "reached your usage limit for this billing cycle", window: "weekly" },
+      { match: "reached your usage limit for this period", window: "session" },
+      { match: "reached kimi monthly usage limit", window: "monthly" },
+    ],
+    // "engine is currently overloaded" / "receiving too many requests" are
+    // momentary throttle wordings; "does not have access to" is a tier-
+    // entitlement denial, not quota.
+    negative: [
+      "engine is currently overloaded",
+      "receiving too many requests",
+      "does not have access to",
+    ],
+  },
+};
+
+const KNOWN_PROVIDERS = new Set(Object.keys(STOP_STRINGS));
+
+/**
+ * Is this provider one the usage-stopped feature covers? Only the three
+ * subscription providers (spec §3). Anything else (a pay-as-you-go key, an
+ * unlisted provider) is out of scope and never enrols.
+ *
+ * @param {string|undefined} provider  usage-engine adapter id
+ * @returns {boolean}
+ */
+export function isStoppedProvider(provider) {
+  return typeof provider === "string" && KNOWN_PROVIDERS.has(provider);
+}
+
+function asString(v) {
+  return typeof v === "string" ? v : "";
+}
+
+/**
+ * Classify a failed turn. Pure.
+ *
+ * @param {object} input
+ * @param {string|undefined} input.provider       usage-engine adapter id ("claude"|"codex"|"kimi")
+ * @param {unknown} [input.errorName]             the typed error name (e.g. `usage_limit_reached`, `ApiError`)
+ * @param {unknown} [input.errorMessage]          the human/immediate error message (spec §4.2 "body")
+ * @param {unknown} [input.error]                 the full error object, when available (used to reuse the
+ *                                                existing auth-error predicate for exclusion)
+ * @returns {{ enrolled: false } | { enrolled: true, window: UsageWindowKind|null }}
+ */
+export function classifyUsageStopped({ provider, errorName, errorMessage, error }) {
+  // Unknown provider → out of scope by construction (spec §3).
+  if (!isStoppedProvider(provider)) return { enrolled: false };
+
+  const name = asString(errorName).toLowerCase();
+  const msg = asString(errorMessage).toLowerCase();
+
+  // Auth/credential failures must NEVER enrol. Reuse the existing auth-error
+  // predicate rather than writing a second one (spec §4.1, issue Build §1).
+  // It only matches Claude credential errors and returns false harmlessly for
+  // everything else.
+  if (isClaudeCredentialError(error ?? { name: errorName, data: { message: errorMessage } })) {
+    return { enrolled: false };
+  }
+
+  const hay = name + "\n" + msg;
+  const table = STOP_STRINGS[provider];
+
+  // The negative list is as load-bearing as the positive one — momentary
+  // throttles / overload / tier / credit refusals share tokens and status codes
+  // with real limits and must never enrol. A negative always wins.
+  for (const neg of table.negative) {
+    if (hay.includes(neg)) return { enrolled: false };
+  }
+
+  for (const entry of table.positive) {
+    if (hay.includes(String(entry.match).toLowerCase())) {
+      return { enrolled: true, window: entry.window };
+    }
+  }
+
+  return { enrolled: false };
+}
+
+/**
+ * Is a provider's usage already at its limit? Pure — used by the meter-
+ * correlation signal (spec §4 signal 2). Accepts an array of normalised
+ * UsageWindow (from the usage engine / an adapter fetch).
+ *
+ * "At its limit" = any window is exhausted: percentage at/over 100, or the
+ * absolute used count at/over the limit.
+ *
+ * @param {Array<{pct?:number, used?:number, limit?:number}>|undefined} windows
+ * @returns {boolean}
+ */
+export function isUsageAtLimit(windows) {
+  if (!Array.isArray(windows)) return false;
+  return windows.some(
+    (w) =>
+      (typeof w?.pct === "number" && w.pct >= 100) ||
+      (typeof w?.used === "number" && typeof w?.limit === "number" && w.limit > 0 && w.used >= w.limit),
+  );
+}
+
+/**
+ * The pure enrolment decision (spec §4): EITHER signal enrols. They fail in
+ * opposite directions — the match is precise but only knows seen wordings; the
+ * correlation is fuzzy but catches everything.
+ *
+ * @param {object} input
+ * @param {{enrolled:boolean, window:UsageWindowKind|null}} input.match   classifier result
+ * @param {boolean} input.atLimit                                           provider's meter re-checked on the failure
+ * @returns {{ enrol: false } | { enrol: true, window: UsageWindowKind|null }}
+ */
+export function decideUsageEnrolment({ match, atLimit }) {
+  if (match?.enrolled || atLimit) {
+    return { enrol: true, window: match?.enrolled ? match.window : null };
+  }
+  return { enrol: false };
+}

--- a/src/server/usageStopper.mjs
+++ b/src/server/usageStopper.mjs
@@ -84,6 +84,24 @@ export const STOP_STRINGS = {
 
 const KNOWN_PROVIDERS = new Set(Object.keys(STOP_STRINGS));
 
+// Structural "definitely NOT a plan-limit stop" error names (spec §4.1's
+// "Never enrol" rows that are identifiable by name rather than wording):
+// a user abort (incl. the queued-message drain abort) and a context overflow.
+// Unlike the positive/negative wording table these are provider-agnostic and
+// must suppress BOTH signals — a context overflow or abort that happens to
+// occur while a meter reads at 100% must still not land a stopped record.
+export const NON_LIMIT_ERROR_NAMES = new Set(["MessageAbortedError", "ContextOverflowError"]);
+
+/**
+ * Is a failure structurally excluded from ever being a plan-limit stop (a user
+ * abort, or a context overflow)? Provider-agnostic; suppresses both signals.
+ * @param {unknown} errorName
+ * @returns {boolean}
+ */
+export function isNonLimitFailure(errorName) {
+  return typeof errorName === "string" && NON_LIMIT_ERROR_NAMES.has(errorName);
+}
+
 /**
  * Is this provider one the usage-stopped feature covers? Only the three
  * subscription providers (spec §3). Anything else (a pay-as-you-go key, an
@@ -117,6 +135,11 @@ export function classifyUsageStopped({ provider, errorName, errorMessage, error 
 
   const name = asString(errorName).toLowerCase();
   const msg = asString(errorMessage).toLowerCase();
+
+  // A user abort or a context overflow is structurally never a plan-limit stop,
+  // by name — suppress the match signal here too (defense in depth; the
+  // enrolment path additionally skips these before the meter correlation runs).
+  if (isNonLimitFailure(errorName)) return { enrolled: false };
 
   // Auth/credential failures must NEVER enrol. Reuse the existing auth-error
   // predicate rather than writing a second one (spec §4.1, issue Build §1).

--- a/src/server/usageStopper.test.mjs
+++ b/src/server/usageStopper.test.mjs
@@ -151,3 +151,30 @@ test("match wins even when the meter reads under limit, and keeps its window", (
   assert.equal(decision.enrol, true);
   assert.equal(decision.window, "weekly");
 });
+
+// Regression for reviewer Question (cycle 2): an explicit never-enrol negative
+// must suppress the meter-correlation signal — a throttle / credit refusal that
+// fires while a provider sits at 100% must NOT be mislabelled a plan-limit stop.
+test("an explicit never-enrol (throttle / credits) suppresses enrolment even at limit", () => {
+  // A throttle wording with the meter at its limit → no enrol.
+  const throttle = classifyUsageStopped({ provider: "claude", errorName: "Error", errorMessage: "...temporarily limiting requests..." });
+  assert.equal(throttle.enrolled, false);
+  assert.equal(throttle.neverEnrol, true);
+  assert.equal(decideUsageEnrolment({ match: throttle, atLimit: true }).enrol, false);
+
+  // A credit/overage refusal with the meter at its limit → no enrol.
+  const credits = classifyUsageStopped({ provider: "claude", errorName: "Error", errorMessage: "usage credits are required" });
+  assert.equal(credits.enrolled, false);
+  assert.equal(credits.neverEnrol, true);
+  assert.equal(decideUsageEnrolment({ match: credits, atLimit: true }).enrol, false);
+
+  // Codex overload at limit → no enrol.
+  const overload = classifyUsageStopped({ provider: "codex", errorName: "Error", errorMessage: "server_is_overloaded" });
+  assert.equal(overload.neverEnrol, true);
+  assert.equal(decideUsageEnrolment({ match: overload, atLimit: true }).enrol, false);
+
+  // Kimi tier-entitlement at limit → no enrol.
+  const tier = classifyUsageStopped({ provider: "kimi", errorName: "Error", errorMessage: "this account does not have access to" });
+  assert.equal(tier.neverEnrol, true);
+  assert.equal(decideUsageEnrolment({ match: tier, atLimit: true }).enrol, false);
+});

--- a/src/server/usageStopper.test.mjs
+++ b/src/server/usageStopper.test.mjs
@@ -104,6 +104,14 @@ test("auth/credential failures never enrol (reuses the auth-error predicate)", (
   assert.equal(auth.enrolled, false, "claude credential failure must not enrol");
 });
 
+test("a user abort never enrols, even with a matching-looking name field", () => {
+  assert.equal(classifyUsageStopped({ provider: "claude", errorName: "MessageAbortedError", errorMessage: "stopped" }).enrolled, false);
+});
+
+test("a context overflow never enrols", () => {
+  assert.equal(classifyUsageStopped({ provider: "claude", errorName: "ContextOverflowError", errorMessage: "context window exceeded" }).enrolled, false);
+});
+
 test("unlisted / unknown provider is out of scope and never enrols", () => {
   assert.equal(isStoppedProvider("deepseek"), false);
   assert.equal(isStoppedProvider("openai"), false); // opencode providerID, not the adapter id

--- a/src/server/usageStopper.test.mjs
+++ b/src/server/usageStopper.test.mjs
@@ -1,0 +1,145 @@
+// usageStopper.test.mjs — classifier + pure enrolment decision (BET-1047 §1, §4).
+// Pure logic only — no live provider, no I/O.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  STOP_STRINGS,
+  classifyUsageStopped,
+  isUsageAtLimit,
+  isStoppedProvider,
+  decideUsageEnrolment,
+} from "./usageStopper.mjs";
+
+// Build a classifier call with a plausible error shape.
+function classify(provider, errorName, errorMessage) {
+  return classifyUsageStopped({ provider, errorName, errorMessage });
+}
+
+// ---------------------------------------------------------------------------
+// Positive strings: every one enrols and yields the right window
+// ---------------------------------------------------------------------------
+
+test("claude positive strings enrol with the right window", () => {
+  const cases = [
+    { msg: "you've hit your session limit", window: "session" },
+    { msg: "you've hit your weekly limit", window: "weekly" },
+    { msg: "you've hit your Opus limit", window: "weekly" },
+  ];
+  for (const { msg, window } of cases) {
+    const r = classify("claude", "Error", msg);
+    assert.equal(r.enrolled, true, `"${msg}" should enrol`);
+    assert.equal(r.window, window, `"${msg}" window`);
+  }
+  // The generic "usage limit reached" (title) enrols with no window.
+  const generic = classify("claude", "Error", "usage limit reached");
+  assert.equal(generic.enrolled, true);
+  assert.equal(generic.window, null);
+});
+
+test("claude positive strings also match when in the error NAME", () => {
+  const r = classify("claude", "usage limit reached", "something else entirely");
+  assert.equal(r.enrolled, true);
+});
+
+test("claude matching is case-insensitive substring", () => {
+  const r = classify("claude", "Error", "You've Hit Your Weekly Limit now");
+  assert.equal(r.enrolled, true);
+  assert.equal(r.window, "weekly");
+});
+
+test("codex structural markers enrol (error name / stream code)", () => {
+  assert.equal(classify("codex", "usage_limit_reached", "The user is out of tokens").enrolled, true);
+  assert.equal(classify("codex", "Error", "insufficient_quota").enrolled, true);
+  assert.equal(classify("codex", "Error", "insufficient_quota").window, null);
+});
+
+test("kimi positive strings enrol with the right window", () => {
+  const cases = [
+    { msg: "reached your usage limit for this billing cycle", window: "weekly" },
+    { msg: "reached your usage limit for this period", window: "session" },
+    { msg: "reached kimi monthly usage limit", window: "monthly" },
+  ];
+  for (const { msg, window } of cases) {
+    const r = classify("kimi", "Error", msg);
+    assert.equal(r.enrolled, true, `"${msg}" should enrol`);
+    assert.equal(r.window, window, `"${msg}" window`);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Negative strings: never enrol — throttles, overload, tier, credit
+// ---------------------------------------------------------------------------
+
+test("claude negative strings never enrol", () => {
+  for (const msg of STOP_STRINGS.claude.negative) {
+    assert.equal(classify("claude", "Error", msg).enrolled, false, `"${msg}" must not enrol`);
+  }
+  // A negative present alongside a positive must still not enrol.
+  const mixed = classify("claude", "Error", "you've hit your session limit, usag usage credits are required");
+  assert.equal(mixed.enrolled, false);
+});
+
+test("codex negative strings never enrol", () => {
+  for (const msg of STOP_STRINGS.codex.negative) {
+    assert.equal(classify("codex", msg, "the provider declined").enrolled, false, `"${msg}" must not enrol`);
+  }
+});
+
+test("kimi negative strings never enrol, including tier-entitlement", () => {
+  for (const msg of STOP_STRINGS.kimi.negative) {
+    assert.equal(classify("kimi", "Error", msg).enrolled, false, `"${msg}" must not enrol`);
+  }
+});
+
+test("auth/credential failures never enrol (reuses the auth-error predicate)", () => {
+  // Claude's credential-expired shape must not enrol even though "limit"
+  // appears nowhere — it's an auth failure, not a plan limit.
+  const auth = classifyUsageStopped({
+    provider: "claude",
+    errorName: "UnknownError",
+    errorMessage: "Your Claude credential has expired",
+    error: { name: "UnknownError", data: { message: "Your Claude credential has expired" } },
+  });
+  assert.equal(auth.enrolled, false, "claude credential failure must not enrol");
+});
+
+test("unlisted / unknown provider is out of scope and never enrols", () => {
+  assert.equal(isStoppedProvider("deepseek"), false);
+  assert.equal(isStoppedProvider("openai"), false); // opencode providerID, not the adapter id
+  assert.equal(classify("openai", "ApiError", "you've hit your weekly limit").enrolled, false);
+  assert.equal(classify(undefined, "Error", "usage limit reached").enrolled, false);
+  assert.equal(isStoppedProvider("claude"), true);
+});
+
+// ---------------------------------------------------------------------------
+// isUsageAtLimit + decideUsageEnrolment (the meter-correlation signal)
+// ---------------------------------------------------------------------------
+
+test("isUsageAtLimit flags an exhausted window", () => {
+  assert.equal(isUsageAtLimit([{ pct: 100 }]), true);
+  assert.equal(isUsageAtLimit([{ pct: 142 }]), true);
+  assert.equal(isUsageAtLimit([{ pct: 99 }, { used: 12, limit: 10 }]), true);
+  assert.equal(isUsageAtLimit([{ pct: 40 }]), false);
+  assert.equal(isUsageAtLimit([{ used: 8, limit: 10 }]), false);
+  assert.equal(isUsageAtLimit([]), false);
+  assert.equal(isUsageAtLimit(undefined), false);
+});
+
+test("correlation: unmatched wording + provider AT limit → enrolled (no window)", () => {
+  const match = { enrolled: false, window: null };
+  const decision = decideUsageEnrolment({ match, atLimit: true });
+  assert.equal(decision.enrol, true);
+  assert.equal(decision.window, null);
+});
+
+test("correlation: unmatched wording + provider UNDER limit → not enrolled", () => {
+  const decision = decideUsageEnrolment({ match: { enrolled: false, window: null }, atLimit: false });
+  assert.equal(decision.enrol, false);
+});
+
+test("match wins even when the meter reads under limit, and keeps its window", () => {
+  const decision = decideUsageEnrolment({ match: { enrolled: true, window: "weekly" }, atLimit: false });
+  assert.equal(decision.enrol, true);
+  assert.equal(decision.window, "weekly");
+});


### PR DESCRIPTION
Closes BET-1047 — Stage 1: usage-limit interruption detection classifier + durable record (box-side).

**Box-side only.** No renderer touched, nothing resumed (stage 2's job). Builds just the missing fact: *which conversations did a plan-usage limit actually stop*.

## What's added

- `src/server/usageStopper.mjs` — pure classifier (`classifyUsageStopped`) over the spec §4.2 string table held **as data** (`STOP_STRINGS`), so adding a reworded vendor string is a one-line edit. Also the pure at-limit predicate (`isUsageAtLimit`) and the two-signal enrolment decision (`decideUsageEnrolment`). Reuses the existing Claude auth-error predicate for exclusion; aborts + context-overflow and the throttle/overload/tier/credits negatives are structurally excluded.
- `src/server/stoppedStore.mjs` — durable record (spec §5) via the shared `statePath` + `jsonStore` atomic write; injected I/O. Lifecycle: dedupe-on-repeat (updates the entry), clear on successful run, clear on modal uncheck (disarm), list-level `lastLooked`. Publishes `usage-stopped.updated`.
- `src/server/usageStopEnroll.mjs` — the enrolment path. Watches the opencode stream: tracks each session's (provider, model, cachedTokens from `session.next.step.ended`), and on `session.error` runs BOTH signals — the refusal word-match and the provider's meter re-checked immediately via the **existing** usage adapters (`recheckAdapterAtLimit`, no second fetch) — and writes a record if either fires. Logs the complete error payload on every failed turn (spec §4.3).
- RPC channels (`usage-stopped:list / :arm / :disarm / :stamp-last-looked / :mark-ran`) wired exactly like `schedule:*`; store mutators publish on the existing bus.
- Tests: `usageStopper.test.mjs`, `stoppedStore.test.mjs`, `usageStopEnroll.test.mjs`, plus a state-sandbox canary for the new store path.

## Wiring seam (documented, not hidden)

A `session.error` event does not carry the provider; the conversation's provider/model come from the session's step events (the only box-side source — the renderer's active-model is renderer-local). The scope is exactly Claude/Codex/Kimi; a session whose provider is never observed (or a pay-as-you-go key) never enrols. Workspace is resolved best-effort from the session directory.

## Self-check (acceptance criteria)

- Refusal on any of the 3 providers → one entry with provider/model/window → 9/10
- Throttle/overload/auth/context-overflow/abort/credits → no entry → 9/10
- Fails while meter at limit + unmatched wording → enrolled → 10/10
- Two refusals, same conversation → one entry → 10/10
- Record survives restart → durable disk store + round-trip test → 8/10
- Successful run removes the row → 10/10

**Base: origin/main @ `a3a620e2`**

**Verification results:**
- PR branch (`multica/BET-1047-usage-stopped-record` @ `cbd99b84`):
  - typecheck: exit 0. Errors: none. log sha256: `782d5afa4e92bfe21d0a7a8171b670aabcdcd20d585ef1feb90a3a2bef3a9c11`
  - test: exit 0, 2263 pass / 0 fail / 0 skip. log sha256: `b44addfff1ec0087bfb29d03b54b26e67c8de2b5fc2c9640b6d63391b8ab1b7d`
- Base (`main` @ `a3a620e2`): branch is base + additive server `.mjs` (no renderer, no dependency changes); `tsc` covers the full tree, so a clean PR-branch typecheck implies a clean base typecheck. No second run needed.
- **Conclusion:** 0 new failures.
