### PR TITLE
fix(install): accept the gateway's `host` key in merge-gateway

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.34",
+      "version": "0.0.35",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.34",
+  "version": "0.0.35",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/scripts/install-lib.mjs
+++ b/scripts/install-lib.mjs
@@ -1340,9 +1340,25 @@ async function cliMain(argv) {
         return 1;
       }
     }
+    // The gateway's POST /register response names the hostname `host`, NOT
+    // `gateway_host` (src/gateway/index.mjs handleRegister → {host,
+    // gateway_token} on first registration, {host} on every re-registration).
+    // Accept BOTH spellings, exactly as the box-side handshake does
+    // (src/server/gatewayRegister.mjs maps body.host → gateway_host).
+    // Reading only `gateway_host` meant a re-registration response carried
+    // neither recognised field, so merge-gateway failed the "at least one of
+    // gateway_token / gateway_host" invariant — i.e. EVERY re-install of an
+    // already-registered public box aborted (and a first install persisted the
+    // token but silently dropped the hostname).
+    const payloadHost =
+      typeof payload?.gateway_host === "string"
+        ? payload.gateway_host
+        : typeof payload?.host === "string"
+          ? payload.host
+          : null;
     const res = mergeGatewayAuth(existing, {
       gateway_token: typeof payload?.gateway_token === "string" ? payload.gateway_token : null,
-      gateway_host: typeof payload?.gateway_host === "string" ? payload.gateway_host : null,
+      gateway_host: payloadHost,
     });
     if (!res.ok) {
       process.stderr.write(`merge-gateway: ${res.error}\n`);

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -2652,6 +2652,85 @@ test("merge-gateway CLI subcommand persists a missing auth.json (fresh-install s
   }
 });
 
+test("merge-gateway CLI accepts the gateway's REAL re-register response ({host} only)", () => {
+  // REGRESSION: the gateway names the hostname `host`, not `gateway_host`
+  // (src/gateway/index.mjs handleRegister). A re-registration returns
+  // { host } with NO token, so a CLI that reads only `gateway_host` saw
+  // neither field and failed the "at least one of gateway_token /
+  // gateway_host" invariant. Since a merge failure is FATAL on the public
+  // path, that aborted every re-install of an already-registered box.
+  // The tests above passed only because they fed a payload shape the
+  // gateway never emits.
+  const dir = mkdtempSync(join(tmpdir(), "manta-merge-gateway-reregister-"));
+  const authFile = join(dir, "auth.json");
+  writeFileSync(
+    authFile,
+    JSON.stringify({
+      box_id: HEX32,
+      box_token: "11112222333344445555666677778888",
+      created_at: 1700000000000,
+      gateway_token: "abc123abc123abc123abc123abc123ab",
+      gateway_host: `${HEX32}.boxes.mantaui.com`,
+    }),
+  );
+  try {
+    try {
+      execSync(`node ${join(__dirname, "install-lib.mjs")} merge-gateway --file ${authFile}`, {
+        input: JSON.stringify({ host: `${HEX32}.boxes.mantaui.com` }),
+        encoding: "utf8",
+        stdio: ["pipe", "pipe", "pipe"],
+      });
+    } catch (e) {
+      assert.fail(`merge-gateway must exit 0 on a re-register response; got: ${e.stderr ?? e.message}`);
+    }
+    const written = JSON.parse(readFileSync(authFile, "utf-8"));
+    assert.equal(written.box_token, "11112222333344445555666677778888");
+    assert.equal(written.gateway_token, "abc123abc123abc123abc123abc123ab", "token must survive a token-less response");
+    assert.equal(written.gateway_host, `${HEX32}.boxes.mantaui.com`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("merge-gateway CLI persists the hostname from a FIRST-registration response ({host, gateway_token})", () => {
+  // The first-registration shape is {host, gateway_token}. Reading only
+  // `gateway_host` persisted the token but silently DROPPED the hostname,
+  // leaving the installer's published-URL resolution dependent on the
+  // server re-registering on its next boot.
+  const dir = mkdtempSync(join(tmpdir(), "manta-merge-gateway-first-"));
+  const authFile = join(dir, "auth.json");
+  writeFileSync(authFile, JSON.stringify({ box_id: HEX32, box_token: "tok", created_at: 1 }));
+  try {
+    execSync(`node ${join(__dirname, "install-lib.mjs")} merge-gateway --file ${authFile}`, {
+      input: JSON.stringify({ host: `${HEX32}.boxes.mantaui.com`, gateway_token: "abc123abc123abc123abc123abc123ab" }),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const written = JSON.parse(readFileSync(authFile, "utf-8"));
+    assert.equal(written.gateway_token, "abc123abc123abc123abc123abc123ab");
+    assert.equal(written.gateway_host, `${HEX32}.boxes.mantaui.com`, "host must be persisted, not dropped");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("merge-gateway CLI prefers gateway_host when BOTH spellings are present", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-merge-gateway-both-"));
+  const authFile = join(dir, "auth.json");
+  writeFileSync(authFile, JSON.stringify({ box_id: HEX32, box_token: "tok", created_at: 1 }));
+  try {
+    execSync(`node ${join(__dirname, "install-lib.mjs")} merge-gateway --file ${authFile}`, {
+      input: JSON.stringify({ host: "from-host.example", gateway_host: "from-gateway-host.example" }),
+      encoding: "utf8",
+      stdio: ["pipe", "pipe", "pipe"],
+    });
+    const written = JSON.parse(readFileSync(authFile, "utf-8"));
+    assert.equal(written.gateway_host, "from-gateway-host.example");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
 test("merge-gateway CLI subcommand refuses to overwrite a corrupt auth.json", () => {
   const dir = mkdtempSync(join(tmpdir(), "manta-merge-gateway-corrupt-"));
   const authFile = join(dir, "auth.json");

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.34",
+ "version": "0.0.35",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
## The bug

Re-running the installer on an already-registered public box aborts with:

```
✗ merge-gateway failed — the gateway token/host could not be persisted, so this
  box would advertise a hostname whose config is incomplete
```

Reproduced on the staging box and confirmed against the live gateway.

## Root cause

The gateway and the installer disagree on one field name. `POST /register`
returns the hostname as **`host`** (`src/gateway/index.mjs` `handleRegister`):

- first registration → `{ host, gateway_token }`
- **re-registration → `{ host }` only** (verified live:
  `{"host":"632f65e3….boxes.mantaui.com"}`)

The `merge-gateway` CLI read only `payload.gateway_host`, so:

- **re-install**: neither recognised field present → the merge failed the
  "at least one of gateway_token / gateway_host" invariant. Since #(BET-442)
  made that failure fatal on the public path, **every re-install of an
  already-registered public box aborts**, with a healthy box and a complete
  `auth.json` sitting right there.
- **first install**: the token was persisted but the hostname was silently
  **dropped**, leaving published-URL resolution dependent on the server
  re-registering on its next boot.

The box-side handshake (`src/server/gatewayRegister.mjs`) has always mapped
`body.host → gateway_host` correctly — which is why boxes worked and only the
installer broke.

## The fix

Accept both spellings in the CLI, mirroring `gatewayRegister.mjs`.
`gateway_host` wins when both are present.

## Why the tests didn't catch it

They fed a payload shape the gateway never emits (`{gateway_token,
gateway_host}`). The three new cases use the **real** first-register,
re-register, and both-spellings payloads. Red/green verified — 153 and 154 fail
without the fix.

## Verification

- `npm run typecheck` + `npm test` green (2158 tests).
- End-to-end on the staging box with `MANTA_DEPLOY_REF` pinned to this branch:
  `✓ gateway registration complete` → DNS resolved → Caddy reloaded → server
  healthy → pairing code minted. Box identity preserved byte-for-byte.

Also bumps the version to 0.0.35 for the release that carries this.

## Note for whoever cuts the release

This does not reach any box until a release is **published** — install.sh resets
its source to the release's own commit, so a merge alone changes nothing for
installs.