### PR TITLE
fix(ios): one width-derived waveform view — live meter fits the screen (BET-1050)

### DIFF
--- a/mobile/native/MantaUI/MantaAppRoot.swift
+++ b/mobile/native/MantaUI/MantaAppRoot.swift
@@ -72,6 +72,13 @@ struct MantaAppRoot: View {
                 // sample turn (bold/italic/inline code, fenced code, table) —
                 // the acceptance fixtures, no live box required.
                 MantaProseCaptureScene()
+            } else if let scene, scene == "voice-note-stored" {
+                // BET-1050 harness fixture: render the real `VoiceNotePlayerRow`
+                // (the `.stored` waveform) for a finished note, so the stored/
+                // playback path is evidenced on-device with no live box — the
+                // overflow bug never touched this path, but the reviewer asked
+                // to see it render post-change.
+                VoiceNoteStoredCaptureScene()
             } else if let scene, !scene.isEmpty {
                 // Capture-harness fixture mode — bypass the pair gate so the
                 // measurement scenes stay reachable (S4b parent/child baseline).

--- a/mobile/native/MantaUI/VoiceNotePlayer.swift
+++ b/mobile/native/MantaUI/VoiceNotePlayer.swift
@@ -170,16 +170,30 @@ final class VoicePlaybackEngine: ObservableObject {
 
 // MARK: - Voice-bars waveform
 
-/// The static DOM-style waveform, rendered from the stored peaks. Bars are
-/// `2px` wide with `2px` gaps up to `22px` tall. Played bars take `accentTx`,
-/// unplayed `tx4` (the stored/playback waveform normalises — unlike the live
-/// meter). The bar count fits the available width, and the whole strip is
-/// tappable to seek.
-private struct VoiceBarsView: View {
+/// The one width-derived bar-row view, shared by the stored/playback waveform
+/// and the LIVE meter. Bars are `2px` wide with `2px` gaps; the bar COUNT is
+/// derived from the available width via `GeometryReader` and the peaks are
+/// bucketed down to it with the shared `Waveform.bucketPeaks`. The `Style`
+/// expresses the two callers' differences (see `Style` below); everything
+/// else — the width-derived bar count, `barWidth`, `barGap`, `maxHeight`,
+/// `barHeight`, the `RoundedRectangle` radius — is identical for both.
+struct VoiceBarsView: View {
+    enum Style {
+        /// A finished note: peaks are normalised so the loudest bar is full
+        /// height, bars run leading→trailing, and `progress` colours the played
+        /// prefix `accentTx` against `tx4`.
+        case stored
+        /// The live meter: NOT normalised (the ceiling is pinned at 1.0 on
+        /// purpose — see `Waveform.normalizeForDisplay`), newest sample at the
+        /// TRAILING edge, every bar `accentTx` at 0.9 opacity.
+        case live
+    }
+
     let peaks: [UInt8]
     let progress: Double?
     let tokens: Tokens
-    let onSeek: (Double) -> Void
+    let style: Style
+    let onSeek: ((Double) -> Void)?
 
     private var maxHeight: CGFloat { Metrics.spacing.sp5 + Metrics.spacing.spPx * 2 }
     private var barWidth: CGFloat { Metrics.spacing.spPx * 2 }
@@ -189,25 +203,36 @@ private struct VoiceBarsView: View {
         GeometryReader { geo in
             let slot = barWidth + barGap
             let barCount = max(1, Int(geo.size.width / slot))
-            let values = Waveform.normalizeForDisplay(Waveform.bucketPeaks(peaks, bars: barCount))
+            let bucketed = Waveform.bucketPeaks(peaks, bars: barCount)
+            let values = style == .stored ? Waveform.normalizeForDisplay(bucketed) : bucketed
+            let alignment: Alignment = style == .stored ? .leading : .trailing
             HStack(alignment: .center, spacing: barGap) {
                 ForEach(Array(values.enumerated()), id: \.offset) { index, value in
                     let played = index < barCount && (progress ?? 0) > Double(index) / Double(barCount)
                     RoundedRectangle(cornerRadius: Metrics.radius.xs, style: .continuous)
-                        .fill(played ? tokens.accentTx : tokens.tx4)
+                        .fill(fillStyle(played: played))
                         .frame(width: barWidth, height: barHeight(value))
                 }
                 if values.isEmpty {
                     Spacer(minLength: 0)
                 }
             }
-            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .leading)
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: alignment)
             .contentShape(Rectangle())
-            .gesture(tapSeek(width: geo.size.width))
+            .gesture(onSeek.map { _ in tapSeek(width: geo.size.width) })
         }
         .frame(height: maxHeight)
         .frame(maxWidth: .infinity)
         .accessibilityHidden(true)
+    }
+
+    private func fillStyle(played: Bool) -> Color {
+        switch style {
+        case .stored:
+            return played ? tokens.accentTx : tokens.tx4
+        case .live:
+            return tokens.accentTx.opacity(0.9)
+        }
     }
 
     private func barHeight(_ value: Double) -> CGFloat {
@@ -218,7 +243,7 @@ private struct VoiceBarsView: View {
     private func tapSeek(width: CGFloat) -> some Gesture {
         DragGesture(minimumDistance: 0)
             .onEnded { value in
-                guard width > 0 else { return }
+                guard width > 0, let onSeek else { return }
                 onSeek(min(1, max(0, value.location.x / width)))
             }
     }
@@ -262,6 +287,7 @@ struct VoiceNotePlayerRow: View {
                 peaks: note.peaks,
                 progress: player.progress(note: note),
                 tokens: tokens,
+                style: .stored,
                 onSeek: { player.seek(note: note, fraction: $0) }
             )
 
@@ -301,7 +327,7 @@ struct VoiceNotePlayerRow: View {
                 .fill(tokens.borderSubtle)
                 .frame(width: discDiameter, height: discDiameter)
 
-            VoiceBarsView(peaks: note.peaks, progress: nil, tokens: tokens, onSeek: { _ in })
+            VoiceBarsView(peaks: note.peaks, progress: nil, tokens: tokens, style: .stored, onSeek: nil)
 
             Text("\(Waveform.formatClock(note.durationMs)) · expired")
                 .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))
@@ -349,7 +375,7 @@ struct VoiceNotePendingRow: View {
                     .fill(tokens.borderStrong)
                     .frame(width: discDiameter, height: discDiameter)
 
-                VoiceBarsView(peaks: peaks, progress: nil, tokens: tokens, onSeek: { _ in })
+                VoiceBarsView(peaks: peaks, progress: nil, tokens: tokens, style: .stored, onSeek: nil)
 
                 Text(Waveform.formatClock(durationMs))
                     .font(.manta(size: Metrics.type.twoXS, weight: mantaFontWeight(Metrics.type.semibold)))

--- a/mobile/native/MantaUI/VoiceNotePlayer.swift
+++ b/mobile/native/MantaUI/VoiceNotePlayer.swift
@@ -426,3 +426,60 @@ struct VoiceNotePendingRow: View {
         }
     }
 }
+
+// MARK: - Capture-harness scene
+
+/// Harness-only capture scene (BET-1050), elected via `MANTA_SCENE=voice-note-
+/// stored` — never rendered in normal app use. Shows the real
+/// `VoiceNotePlayerRow` for a finished note, i.e. the `.stored` waveform path
+/// (normalised, leading-aligned, seekable via `onSeek`), evidenced on-device
+/// with no live box.
+struct VoiceNoteStoredCaptureScene: View {
+    @StateObject private var engine: VoicePlaybackEngine
+
+    init() {
+        _engine = StateObject(wrappedValue: VoicePlaybackEngine(
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1")!)))
+    }
+
+    @Environment(\.colorScheme) private var colorScheme
+    private var tokens: Tokens { Tokens.scheme(colorScheme) }
+
+    /// A finished note whose peaks spell a normalised stored waveform.
+    private var note: VoiceNote {
+        VoiceNote(
+            id: "fixture-n1",
+            sessionId: "s1",
+            transcript: "This is a finished voice note rendered from stored peaks.",
+            mime: "audio/mp4",
+            durationMs: 12800,
+            peaks: fixturePeaks,
+            createdAt: 0,
+            expiresAt: nil,
+            audioAvailable: true
+        )
+    }
+
+    /// Deterministic stored peaks (`0...255`) shaped like a waveform.
+    private var fixturePeaks: [UInt8] {
+        var out = [UInt8]()
+        out.reserveCapacity(Waveform.Constants.maxStoredPeaks)
+        for i in 0..<Waveform.Constants.maxStoredPeaks {
+            let phase = Double(i) / Double(Waveform.Constants.maxStoredPeaks) * .pi * 4
+            let envelope = 0.3 + 0.7 * abs(sin(phase))
+            out.append(Waveform.quantizePeak(envelope))
+        }
+        return out
+    }
+
+    var body: some View {
+        tokens.canvas
+            .ignoresSafeArea()
+            .overlay(alignment: .bottom) {
+                VoiceNotePlayerRow(note: note, tokens: tokens)
+                    .environmentObject(engine)
+                    .padding(Metrics.spacing.sp3)
+                    .padding(.bottom, Metrics.spacing.sp6)
+            }
+    }
+}

--- a/mobile/native/MantaUI/VoiceRecorder.swift
+++ b/mobile/native/MantaUI/VoiceRecorder.swift
@@ -36,14 +36,10 @@ final class VoiceRecorder: ObservableObject {
     /// recording UI can render held/locked/paused/cancelling surfaces.
     @Published private(set) var phase: VoicePhase = .idle
 
-    /// The live meter tail — the last `VOICE_LIVE_WINDOW_BARS` linear samples,
-    /// `0...1`. NOT renormalised (see `Waveform.normalizeForDisplay` doc — the
+    /// The live meter tail — the last `VOICE_LIVE_WINDOW_BARS` quantized
+    /// samples. NOT renormalised (see `Waveform.normalizeForDisplay` doc — the
     /// live meter pins its ceiling at 1.0 on purpose).
-    @Published private(set) var livePeaks: [Double] = []
-
-    /// The stored peak set for the note — `downsamplePeaks` at
-    /// `VOICE_MAX_STORED_PEAKS` (`0...255`, max per bucket, never mean).
-    @Published private(set) var storedPeaks: [UInt8] = []
+    @Published private(set) var livePeaks: [UInt8] = []
 
     /// Elapsed recording time in ms, with paused time excluded (decision #5).
     @Published private(set) var durationMs: Int = 0
@@ -204,7 +200,8 @@ final class VoiceRecorder: ObservableObject {
             reset()
             return nil
         }
-        let take = Take(data: data, durationMs: currentElapsedMs(), peaks: storedPeaks)
+        let take = Take(data: data, durationMs: currentElapsedMs(),
+                        peaks: Waveform.downsamplePeaks(peakBuf, max: Waveform.Constants.maxStoredPeaks))
         publishHaptic(.send)
         reset()
         return take
@@ -363,8 +360,7 @@ final class VoiceRecorder: ObservableObject {
 
     private func appendPeak(_ level: Double) {
         peakBuf.append(level)
-        livePeaks = Array(peakBuf.suffix(Waveform.Constants.liveWindowBars))
-        storedPeaks = Waveform.downsamplePeaks(peakBuf, max: Waveform.Constants.maxStoredPeaks)
+        livePeaks = peakBuf.suffix(Waveform.Constants.liveWindowBars).map(Waveform.quantizePeak)
     }
 
     /// Decision #6: reaching the cap SENDS the take — it is parked so the next
@@ -375,7 +371,8 @@ final class VoiceRecorder: ObservableObject {
             reset()
             return
         }
-        pendingTake = Take(data: data, durationMs: elapsed, peaks: storedPeaks)
+        pendingTake = Take(data: data, durationMs: elapsed,
+                           peaks: Waveform.downsamplePeaks(peakBuf, max: Waveform.Constants.maxStoredPeaks))
         reset()
     }
 
@@ -423,7 +420,6 @@ final class VoiceRecorder: ObservableObject {
         durationMs = 0
         peakBuf = []
         livePeaks = []
-        storedPeaks = []
         lastLinearLevel = 0
         haptic = nil
         phase = .idle

--- a/mobile/native/MantaUI/VoiceRecordingSurface.swift
+++ b/mobile/native/MantaUI/VoiceRecordingSurface.swift
@@ -16,35 +16,6 @@ import UIKit
 // the tokens. No hex, no new token, no second glass recipe.
 // ===========================================================================
 
-/// The live, scrolling waveform bar row. Takes peaks ALREADY bucketed to
-/// `0...1` (newest at the trailing edge) by the caller. It deliberately does
-/// NOT call `Waveform.normalizeForDisplay` — the live meter pins its ceiling
-/// at 1.0 on purpose (see the `Waveform` doc), and renormalising a scrolling
-/// window would make every previously-drawn bar jump each time a new loudest
-/// sample arrives.
-struct VoiceLiveWaveform: View {
-    let peaks: [Double]
-    let tokens: Tokens
-
-    var body: some View {
-        let barWidth = Metrics.spacing.spPx * 2
-        let barGap = Metrics.spacing.spPx * 2
-        let maxBarHeight = Metrics.spacing.sp5
-        HStack(alignment: .center, spacing: barGap) {
-            ForEach(Array(peaks.enumerated()), id: \.offset) { index, peak in
-                let p = min(1, max(0, peak))
-                RoundedRectangle(cornerRadius: Metrics.radius.full, style: .continuous)
-                    .fill(tokens.accentTx.opacity(0.9))
-                    .frame(width: barWidth, height: max(barWidth, maxBarHeight * p))
-            }
-        }
-        .frame(maxWidth: .infinity, alignment: .trailing)
-        .frame(height: maxBarHeight)
-        .clipped()
-        .accessibilityLabel("Live audio waveform")
-    }
-}
-
 // MARK: - Surface A · Recording — held
 
 /// The finger-down held surface: record dot + timer + the "‹ slide to cancel"
@@ -257,8 +228,8 @@ struct VoiceRecordingLockedView: View {
                 VoiceRecordingHeldView.AccessoryDot(danger: tokens.danger)
                 timer
                 Spacer(minLength: Metrics.spacing.sp2)
-                VoiceLiveWaveform(peaks: recorder.livePeaks, tokens: tokens)
-                    .frame(maxWidth: .infinity)
+                VoiceBarsView(peaks: recorder.livePeaks, progress: nil, tokens: tokens,
+                              style: .live, onSeek: nil)
             }
 
             // Remaining-time line — only inside the warn window.

--- a/mobile/native/MantaUITests/WaveformTests.swift
+++ b/mobile/native/MantaUITests/WaveformTests.swift
@@ -92,6 +92,27 @@ final class WaveformTests: XCTestCase {
         }
     }
 
+    /// The fix the live meter relies on (BET-1050): the bar count the view
+    /// derives from its width must never OVER-produce bars — at most `n`
+    /// values for any requested `n`, so the row can never demand more space
+    /// than its container offers.
+    func testBucketPeaksReturnsAtMostBarsAcrossTheWindow() {
+        let peaks = (0..<90).map { UInt8($0) }
+        for n in 1...200 {
+            let out = Waveform.bucketPeaks(peaks, bars: n)
+            XCTAssertLessThanOrEqual(out.count, n, "bars=\(n) produced \(out.count) values")
+        }
+    }
+
+    /// BET-1050 adds the live meter as another caller that hits the
+    /// fewer-peaks-than-bars case (the first ~3.6s of every recording): one
+    /// value per peak, never stretched to fill the window.
+    func testBucketPeaksOneValuePerPeakWhenFewerPeaksThanBars() {
+        let peaks: [UInt8] = [128, 64, 255]
+        let out = Waveform.bucketPeaks(peaks, bars: 90)
+        XCTAssertEqual(out, [128.0 / 255.0, 64.0 / 255.0, 255.0 / 255.0])
+    }
+
     // MARK: - normalizeForDisplay
 
     func testNormalizeForDisplayEmpty() {

--- a/mobile/native/MantaUIUITests/MantaVoiceRecordingUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaVoiceRecordingUITests.swift
@@ -135,6 +135,83 @@ final class MantaVoiceRecordingUITests: XCTestCase {
         XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 5), "composer did not return after discard")
     }
 
+    // MARK: - 5. BET-1050 — the locked live bar stays inside the screen ≥30s
+
+    /// BET-1050 acceptance: the live meter is width-derived (not a fixed-width
+    /// bar row), so once the 90-bar window fills (~3.6s) and the recording has
+    /// run ≥30s the whole locked recording bar must stay fully inside the
+    /// screen — the elapsed timer is never clipped on the left and the
+    /// waveform never crosses the right edge. Measured as the
+    /// `voice-recording-locked` container frame against the screen bounds: the
+    /// OLD fixed-width row forced this container wider than the screen.
+    func testVoiceLockedOverflowStaysOnScreen() throws {
+        let app = XCUIApplication()
+        app.launch()
+        reachChatComposer(app)
+
+        let mic = app.buttons["mic-button"]
+        XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
+        mic.tap()
+
+        let held = app.descendants(matching: .any)["voice-recording-held"]
+        XCTAssertTrue(held.waitForExistence(timeout: 5), "recording did not start — held missing")
+        // Slide UP well past the 80pt lock threshold.
+        let holdStart = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.6))
+        holdStart.press(forDuration: 0.2, thenDragTo: holdStart.withOffset(CGVector(dx: 0, dy: -160)))
+
+        let locked = app.descendants(matching: .any)["voice-recording-locked"]
+        XCTAssertTrue(locked.waitForExistence(timeout: 6), "slide up did not lock")
+        XCTAssertTrue(app.buttons["voice-discard"].exists, "locked bar missing controls")
+
+        // Let it run ≥30s so the live window is full (the bug only appears
+        // once it fills) and the elapsed timer passes 0:30. The app records
+        // independently of the test thread, so blocking here is fine.
+        sleep(42)
+
+        // The whole bar must be inside the screen: not clipped left, not
+        // overflowing right.
+        let width = app.frame.width
+        let f = locked.frame
+        XCTAssertGreaterThanOrEqual(f.minX, 0, "recording bar clipped on the LEFT (minX=\(f.minX))")
+        XCTAssertLessThanOrEqual(f.maxX, width,
+                                 "recording bar overflows the RIGHT edge (maxX=\(f.maxX) > screen \(width))")
+        XCTAssertLessThanOrEqual(f.width, width,
+                                 "recording bar is wider than the screen (width \(f.width) > \(width))")
+
+        // Screenshot at ≥30s (the helper prints the on-simulator path + the AX
+        // tree, so both legs of evidence are emitted).
+        snap(app, marker: "REC-LOCKED-40S", png: "bet1050-locked-40s.png")
+
+        // Clean up so the simulator isn't left recording.
+        app.buttons["voice-discard"].tap()
+        XCTAssertFalse(locked.waitForExistence(timeout: 3), "discard did not end the locked take")
+    }
+
+    // MARK: - 6. BET-1050 — the finished (.stored) note still renders + seekable
+
+    /// BET-1050 acceptance item 8: the finished voice-note path is unchanged.
+    /// Launches the `voice-note-stored` capture scene (a real `VoiceNotePlayerRow`
+    /// with a finished note) and asserts the stored waveform row renders, that
+    /// its play cell is present, and that tapping the bars region exercises the
+    /// seek gesture without crashing. Seekability itself is wired by the
+    /// ready-row's non-nil `onSeek` closure → `VoiceBarsView` attaches the tap
+    /// gesture (`onSeek.map { _ in tapSeek(...) }`), which is unchanged.
+    func testStoredNoteRendersAndTappable() throws {
+        let app = XCUIApplication()
+        app.launchEnvironment["MANTA_SCENE"] = "voice-note-stored"
+        app.launch()
+
+        let note = app.descendants(matching: .any)["voice-note"]
+        XCTAssertTrue(note.waitForExistence(timeout: 8), "finished note row (voice-note) did not render")
+
+        snap(app, marker: "STORED-NOTE", png: "bet1050-stored-note.png")
+
+        // Tap the bars region to exercise the seek gesture (a no-op without a
+        // loaded clip, but it must not crash and the row must stay present).
+        note.coordinate(withNormalizedOffset: CGVector(dx: 0.45, dy: 0.5)).tap()
+        XCTAssertTrue(note.exists, "stored note row vanished after tapping the bars")
+    }
+
     // MARK: - Helpers
 
     /// Pair (first run only — the app stays paired between test launches) and


### PR DESCRIPTION
Opened automatically for `multica/BET-1050-one-width-derived-waveform`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1050.