### PR TITLE
feat(server): usage-limit resume engine + delete the reset+60s continuation path (BET-1048)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, type CSSProperties, type ReactNode } from "react";
 import { MotionConfig } from "framer-motion";
-import { Bell, Send, Terminal as TerminalIcon, type LucideIcon } from "lucide-react";
+import { Bell, Terminal as TerminalIcon, type LucideIcon } from "lucide-react";
 import { Sidebar, type SidebarHandle } from "./Sidebar";
 import { Terminal } from "./Terminal";
 import { ChatPanel } from "./ChatPanel";
@@ -24,11 +24,10 @@ import {
   resolveLauncherFlags,
 } from "./chatShared";
 import type { SyncPayload } from "../shared/api";
-import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, pruneVisitedSessions, registerMountedTerminal, shouldResyncWindowsForJobs, dispatchAppControl, formatResetAt, formatResetDistance, type AppControlHandlers, type MountedTerminal } from "./chatUtils";
+import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, pruneVisitedSessions, registerMountedTerminal, shouldResyncWindowsForJobs, dispatchAppControl, formatResetAt, type AppControlHandlers, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
 import { ConfirmModal } from "./ConfirmModal";
-import { Callout } from "./Callout";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
 import { parsePairPayload } from "../shared/pairPayload";
@@ -41,7 +40,6 @@ import {
   buildUsageLevels,
   buildWarnMessage,
   shouldFireUsageAlert,
-  shouldWarnStaleCache,
   type UsageAlertLevel,
 } from "./usageEscalation";
 
@@ -425,14 +423,6 @@ function Shell() {
   // ---- Subscription usage escalation (BET-739) ----
   // Fire-once level map (per `provider:window.kind`); see usageEscalation.ts.
   const usageLevelsRef = useRef<Record<string, UsageAlertLevel>>({});
-  // "Keep going at reset" confirm-modal payload. null = closed.
-  const [keepGoing, setKeepGoing] = useState<{
-    providerLabel: string;
-    windowLabel: string;
-    fireAt: number;
-    sessionID: string;
-  } | null>(null);
-  const cacheTtl = useStore((s) => s.cacheTtl);
 
   // Pull the box's CACHED usage snapshots. This is an in-memory read on the box
   // (no provider request), which is why it is safe to call on every reconnect.
@@ -638,6 +628,12 @@ function Shell() {
   const pushAppToastStore = useStore((s) => s.pushAppToast);
   const dismissAppToastStore = useStore((s) => s.dismissAppToast);
 
+  // The ONE remaining use of this offset is the "Remind me at reset" NOTIFY
+  // action below, which spec §9 explicitly keeps unchanged. The old
+  // "Keep going at reset" continuation path (which used this same helper as
+  // its fixed reset+60s fire instant) is DELETED — resuming an armed
+  // conversation is now entirely the box-side usage-resume engine's job, and
+  // nothing fires a resume at a fixed reset offset any more.
   const fireAtFor = (resetsAt: number | undefined): number | null =>
     resetsAt != null ? resetsAt + 60_000 : null;
 
@@ -666,37 +662,6 @@ function Shell() {
     },
     [],
   );
-
-  const confirmKeepGoing = useCallback(async () => {
-    if (!keepGoing) return;
-    const { fireAt, sessionID, providerLabel: pLabel, windowLabel } = keepGoing;
-    const res = await scheduleAtReset({
-      kind: "prompt",
-      prompt: "Keep going",
-      label: `Keep going: ${pLabel} ${windowLabel} reset`,
-      fireAt,
-      sessionID,
-    });
-    setKeepGoing(null);
-    pushAppToastStore(
-      res.ok && res.job
-        ? {
-            message: toastLine(Send, `“Keep going” will be sent ${formatResetAt(fireAt, Date.now())}.`),
-            actions: [
-              {
-                label: "Undo",
-                onClick: () => {
-                  if (res.job?.id) void window.api.scheduleDelete(res.job.id);
-                },
-              },
-            ],
-          }
-        : {
-            tone: "error",
-            message: `Couldn't schedule “Keep going”: ${res.error ?? "unknown error"}`,
-          },
-    );
-  }, [keepGoing, scheduleAtReset, pushAppToastStore]);
 
   useEffect(() => {
     if (!window.api.onUsageUpdated) return;
@@ -754,18 +719,6 @@ function Shell() {
                           });
                         }
                       })();
-                    },
-                  },
-                  {
-                    label: "Keep going at reset",
-                    onClick: () => {
-                      if (fireAt == null || !sessionID) return;
-                      setKeepGoing({
-                        providerLabel: label,
-                        windowLabel,
-                        fireAt,
-                        sessionID,
-                      });
                     },
                   },
                 ]
@@ -1781,34 +1734,6 @@ function Shell() {
         }}
         onCancel={() => setConfirmServerUpdate(false)}
       />
-
-      {/* Keep going at reset — BET-739 usage escalation confirm. Rendered at
-          App level (like the toasts) so it works over any pane. */}
-      {keepGoing && (
-        <ConfirmModal
-          open
-          title="Send an automatic message at reset?"
-          confirmLabel="Schedule it"
-          confirmTone="primary"
-          body={
-            <>
-              At {formatResetAt(keepGoing.fireAt, Date.now())} MantaUI will send “Keep going” to this
-              session on your behalf and the agent will resume unattended. You can cancel it any
-              time from ⏰ scheduled tasks.
-              {shouldWarnStaleCache(keepGoing.fireAt, Date.now(), cacheTtl) && (
-                <Callout tone="warn">
-                  The reset is {formatResetDistance(keepGoing.fireAt - Date.now())} away — well past
-                  your {cacheTtl === "5m" ? "5 minute" : "1 hour"} prompt-cache window. The whole
-                  conversation will be re-sent and re-billed as fresh input, which costs significantly
-                  more than a reply now.
-                </Callout>
-              )}
-            </>
-          }
-          onConfirm={() => void confirmKeepGoing()}
-          onCancel={() => setKeepGoing(null)}
-        />
-      )}
     </div>
   );
 }

--- a/src/renderer/usageEscalation.test.ts
+++ b/src/renderer/usageEscalation.test.ts
@@ -3,7 +3,6 @@ import {
   usageAlertLevel,
   buildUsageLevels,
   shouldFireUsageAlert,
-  shouldWarnStaleCache,
   buildWarnMessage,
   buildLimitMessage,
 } from "./usageEscalation";
@@ -222,20 +221,6 @@ describe("shouldFireUsageAlert — fire-once semantics", () => {
     const fired = shouldFireUsageAlert(prev, reCross);
     expect(fired).toHaveLength(1);
     expect(fired[0].provider).toBe("codex");
-  });
-});
-
-describe("shouldWarnStaleCache", () => {
-  const now = Date.now();
-  it("is true beyond the 5m TTL and false within it", () => {
-    expect(shouldWarnStaleCache(now + 6 * 60_000, now, "5m")).toBe(true);
-    expect(shouldWarnStaleCache(now + 4 * 60_000, now, "5m")).toBe(false);
-    expect(shouldWarnStaleCache(now + 90_000, now, "5m")).toBe(false);
-  });
-
-  it("is true beyond the 1h TTL and false within it", () => {
-    expect(shouldWarnStaleCache(now + 61 * 60_000, now, "1h")).toBe(true);
-    expect(shouldWarnStaleCache(now + 59 * 60_000, now, "1h")).toBe(false);
   });
 });
 

--- a/src/renderer/usageEscalation.ts
+++ b/src/renderer/usageEscalation.ts
@@ -21,7 +21,7 @@
 // the exact strings the spec dictates.
 
 import type { UsageSnapshot, UsageWindow } from "../shared/types";
-import { formatWindowReset, selectCacheTtlMs } from "./chatUtils";
+import { formatWindowReset } from "./chatUtils";
 
 /** >=90 = warn, >=100 = limit; anything below 90 is "none". */
 export type UsageAlertLevel = "none" | "warn" | "limit";
@@ -91,20 +91,6 @@ export function shouldFireUsageAlert(
     }
   }
   return fired;
-}
-
-/**
- * "Shall the 'keep going' modal show the amber stale-cache warning?" True when
- * the reset is beyond the configured prompt-cache window — exactly when the
- * cached prefix will have expired and the next turn re-bills the whole
- * conversation as fresh input. Reuses selectCacheTtlMs (do not re-derive).
- */
-export function shouldWarnStaleCache(
-  fireAt: number,
-  now: number,
-  cacheTtl: "5m" | "1h",
-): boolean {
-  return fireAt - now > selectCacheTtlMs(cacheTtl);
 }
 
 /**

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -54,7 +54,7 @@ import {
 import { startServerUpdatePoller, createOpencodeUpdateForwarder } from "./serverUpdate.mjs";
 import { runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { startSchedulePoller, createJob, listJobs, deleteJob } from "./schedule.mjs";
-import { startUsagePoller, recheckAdapterAtLimit } from "./usage.mjs";
+import { startUsagePoller, recheckAdapterAtLimit, providerIDForAdapter, listSnapshots } from "./usage.mjs";
 import {
   createCapJob,
   getJob,
@@ -84,8 +84,9 @@ import {
 } from "./servePage.mjs";
 import { publishPlanBundle } from "./planRender.mjs";
 import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./peers.mjs";
-import { upsertStopped } from "./stoppedStore.mjs";
+import { upsertStopped, markStoppedRan, bumpStoppedAttempts } from "./stoppedStore.mjs";
 import { createUsageStopEngine } from "./usageStopEnroll.mjs";
+import { createUsageResumeEngine } from "./usageResume.mjs";
 import * as appControl from "./appControl.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
 import { createPromptDelivery } from "./promptDelivery.mjs";
@@ -348,7 +349,40 @@ const { stop: stopDeferredMobilePoller } = push.startDeferredMobilePoller();
 // (src/server/rpc.mjs → usage.mjs listSnapshots()). NOT the context-window
 // indicator — see src/server/usage.mjs for that boundary.
 // eslint-disable-next-line no-unused-vars
-const { stop: stopUsagePoller } = startUsagePoller(bus);
+const { stop: stopUsagePoller, tick: usagePollerTick } = startUsagePoller(bus);
+
+// Usage-stop resume engine (BET-1048): watches the ARMED entries in the
+// usage-stopped record and resumes them once their provider's usage genuinely
+// recovers — sending the literal "Keep going" on the model pinned in the
+// record, staggered a few seconds apart, via the shared prompt-delivery engine
+// (so a mid-turn conversation defers until idle). It reuses THIS usage poller:
+// every `usage.updated` snapshot drives a check, and a one-shot re-check timer
+// at the earliest still-limited provider reset forces usagePollerTick() to
+// re-fetch immediately — no second polling loop. observeEvent is fed the
+// opencode pump below. This engine replaces (and only the engine replaces) the
+// old renderer-side reset+60s continuation path, which is deleted.
+const resumeEngine = createUsageResumeEngine({
+  markRan: (input) => markStoppedRan(input, { publish: (evt) => bus.publish(evt) }),
+  bumpAttempts: (input) => bumpStoppedAttempts(input, { publish: (evt) => bus.publish(evt) }),
+  deliver: (args) => promptDelivery.deliver(args),
+  providerIDForAdapter,
+  forceRecheck: () => usagePollerTick(),
+  publish: (evt) => bus.publish(evt),
+});
+// eslint-disable-next-line no-unused-vars
+const stopUsageResume = bus.subscribe((evt) => {
+  if (evt?.kind === "usage.updated" && Array.isArray(evt.payload?.snapshots)) {
+    void resumeEngine.deliverSnapshots(evt.payload.snapshots).catch((e) =>
+      console.warn("[usage-resume] deliverSnapshots failed:", e?.message ?? e),
+    );
+  }
+});
+// Prime on startup: covers the poller's immediate first tick racing our
+// subscription, and the "box asleep across the reset -> run on wake, however
+// late" case — evaluate now against whatever the poller already has cached.
+void resumeEngine.deliverSnapshots(listSnapshots()).catch((e) =>
+  console.warn("[usage-resume] initial deliverSnapshots failed:", e?.message ?? e),
+);
 
 // Usage-stop enrolment (BET-1047 stage 1): derives durable "stopped
 // conversation" records from the opencode stream (see usageStopEnroll.mjs).
@@ -919,6 +953,13 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
     usageStopEngine.observeEvent(evt);
   } catch (e) {
     console.warn("[usage-stop] observeEvent failed:", e?.message ?? e);
+  }
+  // Resume engine outcome watching: a refused "Keep going" re-queues (or is
+  // flagged at the cap); an idle/step without a refusal clears the record.
+  try {
+    resumeEngine.observeEvent(evt);
+  } catch (e) {
+    console.warn("[usage-resume] observeEvent failed:", e?.message ?? e);
   }
   // Auto-recover expired Claude credentials (server-side; works with no client attached).
   oc.maybeRecoverCredentials(evt).catch(() => {});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -380,6 +380,10 @@ const stopUsageResume = bus.subscribe((evt) => {
 // Prime on startup: covers the poller's immediate first tick racing our
 // subscription, and the "box asleep across the reset -> run on wake, however
 // late" case — evaluate now against whatever the poller already has cached.
+// Safe by construction: with no reading yet (the pre-first-poll cache is
+// empty) the engine WAITS, so this warmup can never send "Keep going" before
+// the first real poll confirms quota returned. Recovery is then driven by the
+// first real `usage.updated`.
 void resumeEngine.deliverSnapshots(listSnapshots()).catch((e) =>
   console.warn("[usage-resume] initial deliverSnapshots failed:", e?.message ?? e),
 );

--- a/src/server/stoppedStore.mjs
+++ b/src/server/stoppedStore.mjs
@@ -192,6 +192,28 @@ export async function markStoppedRan({ conversation }, { load = loadStoppedState
 }
 
 /**
+ * Record that a resumed conversation came back refused, incrementing its
+ * `attempts` in place so a permanently-refused conversation stops looping
+ * (spec §8 + §5: "A conversation that ... still refused stays in the list and
+ * waits for the next check. After a small number of attempts it stops retrying
+ * and is flagged"). Unlike upsertStopped this does NOT refresh stoppedAt or
+ * provide — a repeat refusal must not reset the "new since last looked" badge
+ * or clobber the model/window that enrolled it.
+ * @param {object} input
+ * @param {string} input.conversation
+ * @param {object} [deps]
+ */
+export async function bumpStoppedAttempts({ conversation }, { load = loadStoppedState, save = saveStoppedState, publish } = {}) {
+  if (!conversation) return;
+  const state = load();
+  const idx = indexOfRecord(state, conversation);
+  if (idx === -1) return;
+  state.records[idx] = { ...state.records[idx], attempts: (state.records[idx].attempts ?? 0) + 1 };
+  await save(state);
+  publish?.({ kind: "usage-stopped.updated", payload: { conversation } });
+}
+
+/**
  * Stamp the list-level "last looked" timestamp (set when the modal closes).
  * @param {object} [input]
  * @param {number} [input.now]

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -95,6 +95,18 @@ export function adapterForProviderID(providerID) {
   return ADAPTERS.find((a) => Array.isArray(a.providerIDs) && a.providerIDs.includes(providerID))?.id ?? null;
 }
 
+// The reverse mapping: usage adapter id ("claude" | "codex" | "kimi") -> the
+// opencode providerID it covers. The resume engine needs this to send a "Keep
+// going" continuation on the pinned model: the stopped record stores the model
+// by its usage ADAPTER id, but opencode's prompt injector keys the model
+// override by opencode providerID + modelID, and the two namespaces differ on
+// purpose (see adapterForProviderID). Each adapter covers exactly one opencode
+// providerID today. Returns null for an unlisted adapter (out of scope).
+export function providerIDForAdapter(adapterId) {
+  if (typeof adapterId !== "string") return null;
+  return ADAPTERS.find((a) => a.id === adapterId && Array.isArray(a.providerIDs) && a.providerIDs.length > 0)?.providerIDs[0] ?? null;
+}
+
 // Re-check ONE adapter's usage immediately (spec §4, signal 2), reusing the
 // existing adapter fetch rather than writing a second fetch. Returns true when
 // that provider is currently at its limit. Best-effort: a missing credential,
@@ -376,6 +388,11 @@ export function startUsagePoller(bus, { intervalMs = POLL_MS } = {}) {
       poller.stop();
       if (activePoller === poller) activePoller = null;
     },
+    // The resume engine reuses THIS poller to force one immediate re-check at
+    // a provider's expected reset instant (BET-1048) instead of running a
+    // second polling loop. Exposing the underlying tick lets a caller
+    // re-fetch usage on demand; the engine is the only caller today.
+    tick: () => poller.tick(),
   };
 }
 

--- a/src/server/usageResume.mjs
+++ b/src/server/usageResume.mjs
@@ -1,0 +1,379 @@
+// usageResume.mjs — the resume engine (BET-1048, box-side). Watches the armed
+// entries in the usage-stopped record (BET-1047) and resumes them once their
+// provider's usage genuinely recovers.
+//
+// Replaces the old single-conversation "Keep going at reset" path, which
+// fired at a fixed reset+60s whether or not quota returned, was silently
+// dropped if the box slept through that minute, and ran on no pinned model.
+// The old path (renderer confirm dialog + per-continuation scheduler job +
+// its Undo) is deleted; THIS engine is the only thing that resumes an armed
+// conversation. See docs/usage-resume.md §8 + §9 and the BET-1048 issue.
+//
+// Design (per the issue, all load-bearing):
+//  - Gate on recovery, not a clock: an armed conversation waits until EVERY
+//    window its provider reports is under its limit (not just the named one).
+//  - Reuse the existing usage poller: the engine is driven by its
+//    `usage.updated` snapshots, and schedules a ONE-SHOT re-check at the
+//    expected reset instant which forces the poller to tick immediately —
+//    no second polling loop.
+//  - Stagger: continuations in a batch go out a few seconds apart, so a dozen
+//    conversations firing at once can't re-exhaust a fresh window.
+//  - The prompt is the literal "Keep going", on the model pinned in the record.
+//  - Mid-turn deferral reuses the shared prompt-delivery engine (the ONLY
+//    deferral mechanism) — no second deferral is written here.
+//  - A conversation that comes back still refused stays armed and waits for
+//    the next check. After a small number of attempts it stops retrying and
+//    is flagged as needing attention (never loops forever, never drops
+//    silently).
+//  - Late resume: if the box was asleep past the reset, the batch runs on
+//    wake, however late. Deliberate — no expiry.
+//  - On a successful resume the entry leaves the record.
+//
+// Shape: pure decision logic (planResumeBatch / refusalAction) separated from
+// the sending I/O, both dependency-injected — the prevailing convention
+// (usage.mjs / usageStopEnroll.mjs). This is ONE module with ONE entry point
+// (`createUsageResumeEngine`).
+
+import { isUsageAtLimit, classifyUsageStopped } from "./usageStopper.mjs";
+import { loadStoppedState } from "./stoppedStore.mjs";
+
+/** The exact continuation prompt. Kept as a constant so it has one home. */
+export const KEEP_GOING_PROMPT = "Keep going";
+
+/**
+ * The most times a permanently-refused conversation will be resumed before it
+ * stops retrying and is flagged. Deliberately small ("a small number"). An
+ * armed entry's `attempts` starts at 1 (it was stopped once) and is bumped on
+ * each refused resume; the batch keeps sending while attempts <= this, and a
+ * refusal that would push attempts past it flags the entry.
+ */
+export const MAX_RESUME_ATTEMPTS = 3;
+
+/**
+ * Delay between stacked continuations in a single batch. "A few seconds
+ * apart" — long enough that a burst of resumes cannot re-exhaust a freshly
+ * reset window at the same instant.
+ */
+export const STAGGER_MS = 4_000;
+
+const PROVIDER_NOT_READY = "wait"; // provider still at/over its limit (or no reading) → wait
+const PROVIDER_READY = "ready"; // every window under its limit → may resume
+const PROVIDER_FLAGGED = "flagged"; // attempts exhausted → stop retrying, needs attention
+
+/**
+ * Build `{ adapterId -> UsageWindow[] }` from poller snapshots. Present
+ * windows only; a provider with no snapshot simply has no windows, which
+ * isUsageAtLimit treats as not-at-limit (we must never block a resume on a
+ * reading we do not have).
+ * @param {Array<{provider:string, windows?:Array<object>}|undefined>|null|undefined} snapshots
+ * @returns {Record<string, object[]>}
+ */
+export function windowsFromSnapshots(snapshots) {
+  const out = {};
+  for (const s of snapshots ?? []) {
+    if (!s || typeof s?.provider !== "string") continue;
+    const windows = Array.isArray(s.windows) ? s.windows.filter(Boolean) : [];
+    // Only key providers we actually have a usable reading for — a provider
+    // with no windows is absent, never "under its limit" (isUsageAtLimit([])
+    // is false, but that reading doesn't exist and must not hold a resume up).
+    if (windows.length > 0) out[s.provider] = windows;
+  }
+  return out;
+}
+
+/**
+ * The pure resume decision for one armed entry against its provider's current
+ * windows. Never raises a reading we do not have: no windows -> ready (the
+ * gate is "every window under its limit", and there are none to block it).
+ * @param {object} entry  an armed StoppedRecord
+ * @param {object[]|undefined} windows  the provider's windows (all of them)
+ * @param {object} [cfg]
+ * @param {number} [cfg.maxAttempts]
+ * @returns {"wait"|"ready"|"flagged"}
+ */
+export function providerState(entry, windows, { maxAttempts = MAX_RESUME_ATTEMPTS } = {}) {
+  // An entry that has exhausted its retries stops being resumed and is
+  // surfaced as needing attention — it stays in the record, armed, but is
+  // never sent again (spec §8 / issue "up to the cap, then flagged").
+  if ((entry?.attempts ?? 0) > maxAttempts) return PROVIDER_FLAGGED;
+  if (isUsageAtLimit(windows)) return PROVIDER_NOT_READY;
+  return PROVIDER_READY;
+}
+
+/**
+ * Pure batch planner. Given the full record and the current per-provider
+ * windows, decide an ordered set of resume sends, the flagged entries, and
+ * when to re-check next.
+ *
+ * Returns:
+ *   sends          [{conversation, provider, model, at}] — armed + recovered +
+ *                  not-flagged, ordered by stoppedAt (oldest first), each
+ *                  stamped with a stagger time `at = now + idx*STAGGER_MS` so
+ *                  the I/O layer simply sends on `at`.
+ *   flagged        [{conversation, provider, attempts}] — armed + recovered but
+ *                  attempts exhausted: needs attention, no send.
+ *   nextRecheckAt  epoch ms — the earliest FUTURE reset instant among the armed
+ *                  providers that are still at their limit (the ones waiting on
+ *                  a clock). null when nothing is waiting or data is absent.
+ *
+ * @param {Array<object>|undefined} records
+ * @param {Record<string, object[]>} windowsByProvider
+ * @param {object} [cfg]
+ * @param {() => number} [cfg.now]
+ * @param {number} [cfg.staggerMs]
+ * @param {number} [cfg.maxAttempts]
+ */
+export function planResumeBatch(records, windowsByProvider = {}, { now = () => Date.now(), staggerMs = STAGGER_MS, maxAttempts = MAX_RESUME_ATTEMPTS } = {}) {
+  const nowMs = now();
+  const armed = (records ?? []).filter((r) => r?.armed === true);
+  // Deterministic order for the stagger: oldest stopped first.
+  armed.sort((a, b) => (a?.stoppedAt ?? 0) - (b?.stoppedAt ?? 0));
+
+  const sends = [];
+  const flagged = [];
+  let nextRecheckAt = null;
+
+  for (const entry of armed) {
+    const provider = entry?.provider;
+    const windows = windowsByProvider?.[provider];
+    const state = providerState(entry, windows, { maxAttempts });
+    if (state === PROVIDER_NOT_READY || state === PROVIDER_FLAGGED) {
+      // Flagged entries are surfaced (never looped) and skipped.
+      if (state === PROVIDER_FLAGGED) {
+        flagged.push({ conversation: entry.conversation, provider, attempts: entry.attempts ?? 0 });
+      }
+      // Still-limited entries are the ones a reset re-check can unblock: the
+      // earliest reset instant (a past reset — the box slept through it —
+      // re-checks immediately, however late). Clamped to `now` so a reset that
+      // already passed still schedules an immediate re-poll, never a past one.
+      if (state === PROVIDER_NOT_READY && Array.isArray(windows)) {
+        for (const w of windows) {
+          if (typeof w?.resetsAt !== "number" || !Number.isFinite(w.resetsAt)) continue;
+          const when = Math.max(w.resetsAt, nowMs);
+          if (nextRecheckAt == null || when < nextRecheckAt) nextRecheckAt = when;
+        }
+      }
+      continue;
+    }
+    // state === ready → recovered, resume it.
+    sends.push({
+      conversation: entry.conversation,
+      provider,
+      ...(typeof entry.model === "string" && entry.model ? { model: entry.model } : {}),
+      at: nowMs + sends.length * staggerMs,
+    });
+  }
+
+  return { sends, flagged, nextRecheckAt };
+}
+
+/**
+ * Pure post-refusal decision. After a resumed conversation comes back refused,
+ * does it re-queue for the next check, or has it hit the attempt cap and must
+ * be flagged?
+ * @param {object} entry  the current record entry (pre-refusal attempts)
+ * @param {object} [cfg]
+ * @param {number} [cfg.maxAttempts]
+ * @returns {{action:"requeue"}|{action:"flag", attempts:number}}
+ */
+export function refusalAction(entry, { maxAttempts = MAX_RESUME_ATTEMPTS } = {}) {
+  const next = (entry?.attempts ?? 0) + 1;
+  // Re-queue while we have not yet exceeded the cap; flag the moment this
+  // refusal would push us past it ("up to the cap, then flagged").
+  return next > maxAttempts ? { action: "flag", attempts: next } : { action: "requeue" };
+}
+
+/**
+ * The resume engine. ONE entry point. Pure decision logic (above) + injected
+ * I/O (below): the caller wires real loading/publishing/prompt delivery and
+ * the tests wire fakes. In production (index.mjs):
+ *   - `deliverSnapshots(snapshots)` is called on every `usage.updated` bus
+ *     event (from the existing usage poller) and schedules a one-shot re-check
+ *     at the earliest future reset — an injected `forceRecheck` (wired to the
+ *     poller's own tick) is invoked when that timer fires, so the poller does
+ *     the fetching and there is no second polling loop.
+ *   - `observeEvent(evt)` is fed the opencode stream so the engine can tell a
+ *     refused resume (re-queue/flag) from a successful one (remove the entry).
+ *
+ * @param {object} deps
+ * @param {() => Promise<{records:Array<object>, lastLooked:number|null}>} [deps.load]
+ * @param {(input:{conversation:string})=>Promise<void>} [deps.markRan]     wire to markStoppedRan
+ * @param {(input:{conversation:string})=>Promise<void>} [deps.bumpAttempts] wire to bumpStoppedAttempts
+ * @param {(args:{sessionId:string, text:string, model?:object})=>Promise<unknown>} [deps.deliver]
+ *   wire to promptDelivery.deliver — the shared defer-until-idle path.
+ * @param {(adapterId:string)=>string|null} [deps.providerIDForAdapter]  adapter id -> opencode providerID
+ * @param {() => Promise<void>} [deps.forceRecheck]  forces the usage poller to tick once
+ * @param {(evt:object)=>void} [deps.publish]  bus publish (usage-stopped.updated / .needs-attention)
+ * @param {() => number} [deps.now]
+ * @param {(fn:()=>void, ms:number)=>ReturnType<typeof setTimeout>} [deps.setTimeoutFn]
+ * @param {(t?:unknown)=>void} [deps.clearTimeoutFn]
+ * @param {number} [deps.staggerMs]
+ * @param {number} [deps.maxAttempts]
+ * @returns {{
+ *   deliverSnapshots: (snapshots:Array<object>|null|undefined)=>Promise<void>,
+ *   observeEvent: (evt:object|null|undefined)=>void,
+ *   stop: ()=>void,
+ * }}
+ */
+export function createUsageResumeEngine({
+  load = loadStoppedState,
+  markRan = async () => {},
+  bumpAttempts = async () => {},
+  deliver = async () => {},
+  providerIDForAdapter = () => null,
+  forceRecheck = async () => {},
+  publish = () => {},
+  now = Date.now,
+  setTimeoutFn = setTimeout,
+  clearTimeoutFn = clearTimeout,
+  staggerMs = STAGGER_MS,
+  maxAttempts = MAX_RESUME_ATTEMPTS,
+} = {}) {
+  // Conversations we have sent "Keep going" to and are awaiting the outcome
+  // of — used by observeEvent to tell a refused resume from a successful one.
+  const pendingResume = new Set();
+  // The single one-shot re-check timer (never a second polling loop), plus the
+  // per-send stagger timers for the current batch.
+  let recheckTimer = null;
+  const sendTimers = new Set();
+
+  function clearAll() {
+    if (recheckTimer != null) {
+      clearTimeoutFn(recheckTimer);
+      recheckTimer = null;
+    }
+    for (const t of sendTimers) clearTimeoutFn(t);
+    sendTimers.clear();
+  }
+
+  function scheduleRecheck(atMs) {
+    if (recheckTimer != null) {
+      clearTimeoutFn(recheckTimer);
+      recheckTimer = null;
+    }
+    if (typeof atMs !== "number" || !Number.isFinite(atMs)) return;
+    const delay = Math.max(0, atMs - now());
+    recheckTimer = setTimeoutFn(() => {
+      recheckTimer = null;
+      // Fire-and-forget: a failed recheck is caught inside the poller's tick.
+      void forceRecheck();
+    }, delay);
+    // Don't hold the process open for a re-check that may be far off (the same
+    // discipline as the poller's own timers). Injectable fakes need no unref.
+    recheckTimer?.unref?.();
+  }
+
+  function scheduleSend(send, atMs) {
+    const delay = Math.max(0, atMs - now());
+    const timer = setTimeoutFn(() => {
+      sendTimers.delete(timer);
+      void sendOne(send);
+    }, delay);
+    sendTimers.add(timer);
+    timer?.unref?.();
+  }
+
+  // Send one "Keep going" on the model pinned in the record, through the shared
+  // prompt-delivery engine (which defers to idle if the conversation is busy).
+  async function sendOne(send) {
+    pendingResume.add(send.conversation);
+    const providerID = send.provider ? providerIDForAdapter(send.provider) : null;
+    const model =
+      providerID && typeof send.model === "string" && send.model
+        ? { providerID, modelID: send.model }
+        : null;
+    const res = await deliver({
+      sessionId: send.conversation,
+      text: KEEP_GOING_PROMPT,
+      ...(model ? { model } : {}),
+    });
+    // A rejected delivery (queue at its cap) was not queued — don't hold the
+    // conversation pending for an outcome that will not come (BET-772).
+    if (res?.rejected) pendingResume.delete(send.conversation);
+  }
+
+  // A resume came back refused by the plan limit again. Re-queue up to the cap,
+  // then flag as needing attention. The entry stays armed either way.
+  async function handleRefusal(sid, evt) {
+    const { records = [] } = await load();
+    const entry = records.find((r) => r?.conversation === sid);
+    if (!entry) return; // already removed — nothing to re-queue
+    const props = evt?.properties ?? {};
+    const err = props.error ?? {};
+    const errorName = typeof err?.name === "string" ? err.name : undefined;
+    const errorMessage =
+      typeof err?.data?.message === "string" ? err.data.message : typeof err?.message === "string" ? err.message : undefined;
+    // Only a genuine plan-limit refusal (the classifier reuses the SAME
+    // classifier as enrolment — there is exactly one) re-queues. Any other
+    // error leaves the entry armed to wait for the next check un-bumped.
+    const match = classifyUsageStopped({ provider: entry.provider, errorName, errorMessage, error: err });
+    if (!match?.enrolled) return;
+    const action = refusalAction(entry, { maxAttempts });
+    await bumpAttempts({ conversation: sid });
+    if (action.action === "flag") {
+      publish({ kind: "usage-stopped.needs-attention", payload: { conversation: sid, attempts: action.attempts } });
+    }
+  }
+
+  /**
+   * React to fresh usage snapshots: plan + fire the batch and re-arm the
+   * one-shot re-check at the earliest still-limited provider reset.
+   * @param {Array<object>|null|undefined} snapshots
+   */
+  async function deliverSnapshots(snapshots) {
+    const { records = [] } = await load();
+    const windows = windowsFromSnapshots(snapshots);
+    const { sends, flagged, nextRecheckAt } = planResumeBatch(records, windows, {
+      now,
+      staggerMs,
+      maxAttempts,
+    });
+    // `flagged` (attempts exhausted) are surfaced exactly once, at the flag
+    // TRANSITION in observeEvent/handleRefusal — never re-published every check
+    // (that would spam the bus for a permanently-refused entry). Here they are
+    // simply never scheduled a send again.
+    for (const send of sends) scheduleSend(send, send.at);
+    scheduleRecheck(nextRecheckAt);
+  }
+
+  /**
+   * Observe the opencode stream for the outcome of a pending resume:
+   *   - a plan-limit refusal (session.error that the classifier enrols) →
+   *     re-queue (or flag at the cap);
+   *   - reaching idle WITHOUT such an error → the resume ran, remove the entry.
+   * @param {object|null|undefined} evt
+   */
+  function observeEvent(evt) {
+    if (!evt || typeof evt !== "object") return;
+    const sid = evt?.properties?.sessionID;
+    if (typeof sid !== "string" || !sid) return;
+    if (evt.type === "session.error") {
+      if (!pendingResume.has(sid)) return;
+      pendingResume.delete(sid);
+      void handleRefusal(sid, evt).catch((e) => console.warn("[usage-resume] refusal handling failed:", e?.message ?? e));
+      return;
+    }
+    if (evt.type === "session.idle" && pendingResume.has(sid)) {
+      // No plan-limit error fired before idle → the "Keep going" turn completed.
+      // Remove the entry from the record (successful resume, spec §5.1/§8).
+      pendingResume.delete(sid);
+      void markRan({ conversation: sid }).catch((e) => console.warn("[usage-resume] markRan failed:", e?.message ?? e));
+      return;
+    }
+    if (evt.type === "session.next.step.ended" && pendingResume.has(sid)) {
+      // The model actually produced a step after our resume — an early, strong
+      // success signal; clear the entry promptly rather than on a later idle.
+      pendingResume.delete(sid);
+      void markRan({ conversation: sid }).catch((e) => console.warn("[usage-resume] markRan failed:", e?.message ?? e));
+    }
+  }
+
+  return {
+    deliverSnapshots,
+    observeEvent,
+    stop() {
+      clearAll();
+      pendingResume.clear();
+    },
+  };
+}

--- a/src/server/usageResume.mjs
+++ b/src/server/usageResume.mjs
@@ -73,9 +73,9 @@ export function windowsFromSnapshots(snapshots) {
   for (const s of snapshots ?? []) {
     if (!s || typeof s?.provider !== "string") continue;
     const windows = Array.isArray(s.windows) ? s.windows.filter(Boolean) : [];
-    // Only key providers we actually have a usable reading for — a provider
-    // with no windows is absent, never "under its limit" (isUsageAtLimit([])
-    // is false, but that reading doesn't exist and must not hold a resume up).
+    // Only key providers we actually have a usable reading for. A provider
+    // with no windows is ABSENT, and an absent reading must HOLD a resume up
+    // (providerState waits) — never resume on a reading we do not have.
     if (windows.length > 0) out[s.provider] = windows;
   }
   return out;
@@ -83,10 +83,21 @@ export function windowsFromSnapshots(snapshots) {
 
 /**
  * The pure resume decision for one armed entry against its provider's current
- * windows. Never raises a reading we do not have: no windows -> ready (the
- * gate is "every window under its limit", and there are none to block it).
+ * windows. Gates on recovery, not on a clock: the entry is only `ready` when
+ * we have a real window reading for its provider showing it under its limit.
+ *
+ * "No reading yet" (provider absent from the snapshot set, or an empty windows
+ * array) is categorically DIFFERENT from "recovered" — at boot the poller's
+ * first tick is still in flight, so before it lands the snapshot set is empty
+ * and, until the warmup drives a real `usage.updated`, resuming on that empty
+ * state would send "Keep going" with zero evidence quota returned. That is the
+ * exact failure mode this feature exists to remove, so a missing reading is
+ * `wait`, never `ready`. The warmup (the first real poll) then supplies a fresh
+ * reading and sets recovery.
+ *
  * @param {object} entry  an armed StoppedRecord
- * @param {object[]|undefined} windows  the provider's windows (all of them)
+ * @param {object[]|undefined} windows  the provider's windows (all of them), or
+ *                                     undefined when we hold no reading for it
  * @param {object} [cfg]
  * @param {number} [cfg.maxAttempts]
  * @returns {"wait"|"ready"|"flagged"}
@@ -96,8 +107,9 @@ export function providerState(entry, windows, { maxAttempts = MAX_RESUME_ATTEMPT
   // surfaced as needing attention — it stays in the record, armed, but is
   // never sent again (spec §8 / issue "up to the cap, then flagged").
   if ((entry?.attempts ?? 0) > maxAttempts) return PROVIDER_FLAGGED;
-  if (isUsageAtLimit(windows)) return PROVIDER_NOT_READY;
-  return PROVIDER_READY;
+  // No usable reading -> wait (never resume on an absent reading).
+  if (!Array.isArray(windows) || windows.length === 0) return PROVIDER_NOT_READY;
+  return isUsageAtLimit(windows) ? PROVIDER_NOT_READY : PROVIDER_READY;
 }
 
 /**

--- a/src/server/usageResume.test.mjs
+++ b/src/server/usageResume.test.mjs
@@ -137,11 +137,12 @@ test("gating: not sent while ANY window for the provider is at its limit", () =>
   assert.equal(unblocked.sends[0].conversation, "a");
 });
 
-test("gating: no snapshot for the provider never blocks a resume", () => {
-  // There are no windows to be over the limit, so the gate (every window under
-  // its limit) cannot hold us back — never wait on a reading we do not have.
+test("gating: no reading for the provider → wait (nothing sent, never resume on an absent reading)", () => {
+  // An absent/empty reading (e.g. the pre-first-poll empty snapshot set at
+  // boot) is categorically different from "recovered": we must not resume on
+  // zero evidence that quota returned.
   const { sends } = planResumeBatch([armed("a")], {}, { now: () => T0 });
-  assert.equal(sends.length, 1);
+  assert.equal(sends.length, 0);
 });
 
 test("stagger: sends are ordered oldest-first and spaced a few seconds apart", () => {
@@ -242,6 +243,28 @@ test("engine: nothing sent while a window is at its limit, and a recheck is arme
   // engine itself sends nothing (that happens on the next deliverSnapshots).
   assert.equal(called.forceRecheck, 1);
   assert.equal(called.deliver.length, 0);
+});
+
+test("engine: boot with an empty snapshot set sends nothing until a real reading exists", async () => {
+  const { engine, timers, called } = harness({
+    records: [armed("a")],
+  });
+  // The poller's first tick is still in flight at boot, so the snapshot set is
+  // empty (listSnapshots() returns []). Resuming here would send "Keep going"
+  // with zero evidence quota returned — the exact failure mode this issue
+  // exists to eliminate. Must be wait, not ready.
+  await engine.deliverSnapshots([]);
+  assert.equal(called.deliver.length, 0);
+  assert.deepEqual(timers.pending.map((t) => t.ms), []); // nothing armed either
+
+  // The warmup's first real poll supplies a fresh reading showing recovery →
+  // then (and only then) the continuation goes out.
+  await engine.deliverSnapshots(snapshotsFor({ claude: [win("session", 20)] }));
+  assert.equal(called.deliver.length, 0); // staggered, not yet fired
+  timers.fireAll();
+  await flush();
+  assert.equal(called.deliver.length, 1);
+  assert.equal(called.deliver[0].text, KEEP_GOING_PROMPT);
 });
 
 test("engine: refusal re-queues, retried on the next check, flagged after the cap", async () => {

--- a/src/server/usageResume.test.mjs
+++ b/src/server/usageResume.test.mjs
@@ -1,0 +1,345 @@
+// usageResume.test.mjs — the resume engine (BET-1048). Pure decision logic +
+// injected I/O only — no live provider, no real timers, no filesystem.
+//
+// Covers the BET-1048 acceptance: gating on recovery (every window, not just
+// the named one); stagger order + spacing; refusal re-queue up to an attempt
+// cap then flagged; mid-turn deferral (routes through the shared delivery
+// path); late resume after a simulated sleep; and a regression that the old
+// fixed reset+60s fire instant is gone.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  KEEP_GOING_PROMPT,
+  STAGGER_MS,
+  MAX_RESUME_ATTEMPTS,
+  windowsFromSnapshots,
+  planResumeBatch,
+  refusalAction,
+  providerState,
+  createUsageResumeEngine,
+} from "./usageResume.mjs";
+
+const T0 = 1_000_000;
+
+// Flush the microtask + macrotask queues so fire-and-forget async callbacks
+// (sendOne / handleRefusal) settle deterministically.
+const flush = () => new Promise((r) => setTimeout(r, 0));
+
+function snapshotsFor(windowsByProvider) {
+  return Object.entries(windowsByProvider).map(([provider, windows]) => ({ provider, windows }));
+}
+
+function fakeTimers() {
+  const pending = [];
+  let id = 0;
+  return {
+    pending,
+    setTimeoutFn: (fn, ms) => {
+      const t = { id: ++id, fn, ms };
+      pending.push(t);
+      return { id: t.id, unref() {} };
+    },
+    clearTimeoutFn: (t) => {
+      const i = pending.findIndex((p) => p.id === t?.id);
+      if (i >= 0) pending.splice(i, 1);
+    },
+    fireAll() {
+      const due = pending.splice(0);
+      for (const t of due) t.fn();
+    },
+  };
+}
+
+// Build an engine wired to fakes. `records` is the live record; `windows` the
+// current usage snapshots (adapter -> windows). Mirrors stoppedStore's pure
+// load/save so attempts bumps propagate back into `records`.
+function harness({ records = [], over = {} } = {}) {
+  const timers = fakeTimers();
+  const recordsLive = structuredClone(records);
+  const called = { deliver: [], markRan: [], bumpAttempts: [], published: [], forceRecheck: 0 };
+  const engine = createUsageResumeEngine({
+    load: async () => ({ records: recordsLive, lastLooked: null }),
+    markRan: async ({ conversation }) => {
+      called.markRan.push(conversation);
+      recordsLive.splice(recordsLive.findIndex((r) => r.conversation === conversation), 1);
+    },
+    bumpAttempts: async ({ conversation }) => {
+      called.bumpAttempts.push(conversation);
+      const r = recordsLive.find((x) => x.conversation === conversation);
+      if (r) r.attempts = (r.attempts ?? 0) + 1;
+    },
+    deliver: async (args) => {
+      called.deliver.push(args);
+      return { delivered: true, queued: false };
+    },
+    providerIDForAdapter: (a) => ({ claude: "anthropic" })[a] ?? null,
+    forceRecheck: async () => {
+      called.forceRecheck += 1;
+    },
+    publish: (evt) => called.published.push(evt),
+    now: () => T0,
+    setTimeoutFn: timers.setTimeoutFn,
+    clearTimeoutFn: timers.clearTimeoutFn,
+    ...over,
+  });
+  return { engine, timers, called, recordsLive };
+}
+
+function armed(conversation, stopper = {}) {
+  return {
+    conversation,
+    workspace: "ws",
+    provider: "claude",
+    model: "claude-opus-4-7",
+    window: "session",
+    stoppedAt: 100,
+    armed: true,
+    attempts: 1,
+    ...stopper,
+  };
+}
+
+function win(kind, pct, resetsAt) {
+  return { kind, label: kind, pct, ...(resetsAt != null ? { resetsAt } : {}) };
+}
+
+// ---------------------------------------------------------------------------
+// Pure decision logic
+// ---------------------------------------------------------------------------
+
+test("windowsFromSnapshots groups windows by adapter and drops empties", () => {
+  assert.deepEqual(
+    windowsFromSnapshots([
+      { provider: "claude", windows: [win("session", 40), win("weekly", 10)] },
+      { provider: "codex", windows: [] },
+      { provider: "kimi", windows: [win("monthly", 99)] },
+    ]),
+    { claude: [win("session", 40), win("weekly", 10)], kimi: [win("monthly", 99)] },
+  );
+  assert.deepEqual(windowsFromSnapshots(null), {});
+  // A provider whose only windows are null/empty is absent (never a reading).
+  assert.equal(windowsFromSnapshots([{ provider: "claude", windows: [null] }]).claude, undefined);
+});
+
+test("gating: not sent while ANY window for the provider is at its limit", () => {
+  const rec = [armed("a")];
+  // Session under limit, weekly still exhausted → must NOT send. "Every window
+  // checked, not just the named one": the record named the session window, but
+  // the exhausted weekly window still blocks.
+  const blocked = planResumeBatch(rec, { claude: [win("session", 40), win("weekly", 100)] }, { now: () => T0 });
+  assert.equal(blocked.sends.length, 0);
+  assert.equal(blocked.flagged.length, 0);
+
+  // Same record, all windows under limit → send.
+  const unblocked = planResumeBatch(rec, { claude: [win("session", 40), win("weekly", 10)] }, { now: () => T0 });
+  assert.equal(unblocked.sends.length, 1);
+  assert.equal(unblocked.sends[0].conversation, "a");
+});
+
+test("gating: no snapshot for the provider never blocks a resume", () => {
+  // There are no windows to be over the limit, so the gate (every window under
+  // its limit) cannot hold us back — never wait on a reading we do not have.
+  const { sends } = planResumeBatch([armed("a")], {}, { now: () => T0 });
+  assert.equal(sends.length, 1);
+});
+
+test("stagger: sends are ordered oldest-first and spaced a few seconds apart", () => {
+  const rec = [
+    armed("c", { stoppedAt: 300 }),
+    armed("a", { stoppedAt: 100 }),
+    armed("b", { stoppedAt: 200 }),
+  ];
+  const { sends } = planResumeBatch(rec, { claude: [win("session", 30)] }, { now: () => T0 });
+  assert.deepEqual(
+    sends.map((s) => s.conversation),
+    ["a", "b", "c"],
+  );
+  assert.deepEqual(
+    sends.map((s) => s.at),
+    [T0, T0 + STAGGER_MS, T0 + 2 * STAGGER_MS],
+  );
+  // Each send carries the model pinned in the record.
+  for (const s of sends) assert.equal(s.model, "claude-opus-4-7");
+});
+
+test("flagged: an entry that exhausted its attempts is never sent again", () => {
+  const rec = [armed("a", { attempts: MAX_RESUME_ATTEMPTS + 1 })];
+  const { sends, flagged } = planResumeBatch(rec, { claude: [win("session", 30)] }, { now: () => T0 });
+  assert.equal(sends.length, 0);
+  assert.deepEqual(flagged.map((f) => f.conversation), ["a"]);
+});
+
+test("nextRecheckAt is the earliest future reset of still-limited providers (not reset+60s)", () => {
+  const rec = [armed("a"), armed("b", { provider: "kimi" })];
+  const windows = {
+    claude: [win("session", 100, T0 + 60_000)],
+    kimi: [win("monthly", 100, T0 + 500_000)],
+  };
+  const { sends, nextRecheckAt } = planResumeBatch(rec, windows, { now: () => T0 });
+  assert.equal(sends.length, 0); // still limited → nothing sent
+  // The engine re-checks AT the reset instant, not reset+60s — the offset the
+  // old path fired on is gone.
+  assert.equal(nextRecheckAt, T0 + 60_000);
+});
+
+test("providerState distinguishes wait / ready / flagged", () => {
+  assert.equal(providerState(armed("a"), [{ pct: 30 }]), "ready");
+  assert.equal(providerState(armed("a"), [{ pct: 100 }]), "wait");
+  assert.equal(providerState(armed("a", { attempts: 99 }), [{ pct: 30 }], { maxAttempts: 3 }), "flagged");
+});
+
+test("refusalAction re-queues up to the cap, then flags", () => {
+  assert.deepEqual(refusalAction(armed("a", { attempts: 1 })), { action: "requeue" });
+  assert.deepEqual(refusalAction(armed("a", { attempts: 2 })), { action: "requeue" });
+  assert.deepEqual(refusalAction(armed("a", { attempts: MAX_RESUME_ATTEMPTS })), {
+    action: "flag",
+    attempts: MAX_RESUME_ATTEMPTS + 1,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Engine (I/O seam)
+// ---------------------------------------------------------------------------
+
+test("engine: recovered batch is sent staggered, on the pinned model, literal 'Keep going'", async () => {
+  const { engine, timers, called } = harness({
+    records: [
+      armed("a", { stoppedAt: 100 }),
+      armed("b", { stoppedAt: 200 }),
+      armed("c", { stoppedAt: 300 }),
+    ],
+    windows: { claude: [win("session", 20)] },
+  });
+  await engine.deliverSnapshots(snapshotsFor({ claude: [win("session", 20)] }));
+  // Nothing sent yet — sends are staggered.
+  assert.equal(called.deliver.length, 0);
+  assert.deepEqual(
+    timers.pending.map((t) => t.ms),
+    [0, STAGGER_MS, 2 * STAGGER_MS],
+  );
+  timers.fireAll();
+  await flush();
+  assert.equal(called.deliver.length, 3);
+  for (const d of called.deliver) {
+    assert.equal(d.text, KEEP_GOING_PROMPT);
+    assert.deepEqual(d.model, { providerID: "anthropic", modelID: "claude-opus-4-7" });
+  }
+});
+
+test("engine: nothing sent while a window is at its limit, and a recheck is armed at the reset", async () => {
+  const { engine, timers, called } = harness({
+    records: [armed("a")],
+    windows: { claude: [win("session", 100, T0 + 60_000)] },
+  });
+  await engine.deliverSnapshots(snapshotsFor({ claude: [win("session", 100, T0 + 60_000)] }));
+  assert.equal(called.deliver.length, 0);
+  // One recheck timer at the reset instant (60s away) — no second polling loop.
+  assert.deepEqual(timers.pending.map((t) => t.ms), [60_000]);
+  timers.fireAll();
+  await flush();
+  // The recheck fires the poller, which re-fetches and republishes — the
+  // engine itself sends nothing (that happens on the next deliverSnapshots).
+  assert.equal(called.forceRecheck, 1);
+  assert.equal(called.deliver.length, 0);
+});
+
+test("engine: refusal re-queues, retried on the next check, flagged after the cap", async () => {
+  const err = {
+    type: "session.error",
+    properties: { sessionID: "a", error: { name: "Error", data: { message: "you've hit your weekly limit" } } },
+  };
+  const { engine, timers, called, recordsLive } = harness({
+    records: [armed("a", { attempts: 1 })],
+    windows: { claude: [win("session", 20)] },
+  });
+
+  // attempts=1: first resume → refused → re-queue (attempts=2), no flag.
+  await engine.deliverSnapshots(snapshotsFor({ claude: [win("session", 20)] }));
+  timers.fireAll();
+  await flush();
+  assert.equal(called.deliver.length, 1);
+  engine.observeEvent(err);
+  await flush();
+  assert.equal(called.bumpAttempts.length, 1);
+  assert.equal(recordsLive[0].attempts, 2);
+  assert.equal(called.published.some((e) => e.kind === "usage-stopped.needs-attention"), false);
+  assert.deepEqual(called.markRan, []); // refused → entry stays in the record
+
+  // attempts=2: same refusal → re-queue (attempts=3).
+  await engine.deliverSnapshots(snapshotsFor({ claude: [win("session", 20)] }));
+  timers.fireAll();
+  await flush();
+  engine.observeEvent(err);
+  await flush();
+  assert.equal(recordsLive[0].attempts, 3);
+
+  // attempts=3: third refusal pushes past the cap → bumped to 4 and flagged.
+  await engine.deliverSnapshots(snapshotsFor({ claude: [win("session", 20)] }));
+  timers.fireAll();
+  await flush();
+  engine.observeEvent(err);
+  await flush();
+  assert.equal(recordsLive[0].attempts, MAX_RESUME_ATTEMPTS + 1);
+  assert.equal(called.published.some((e) => e.kind === "usage-stopped.needs-attention"), true);
+  assert.deepEqual(called.markRan, []);
+
+  // A further check never sends again: flagged.
+  await engine.deliverSnapshots(snapshotsFor({ claude: [win("session", 20)] }));
+  assert.equal(called.deliver.length, 3); // no new sends after flagging
+});
+
+test("engine: successful resume removes the entry on idle (mid-turn defers via delivery, not before)", async () => {
+  const { engine, timers, called, recordsLive } = harness({
+    records: [armed("a")],
+    windows: { claude: [win("session", 20)] },
+  });
+  await engine.deliverSnapshots(snapshotsFor({ claude: [win("session", 20)] }));
+  timers.fireAll();
+  await flush();
+  assert.equal(called.deliver.length, 1);
+  // Conversation is mid-turn: nothing is marked ran or refused before idle.
+  assert.deepEqual(called.markRan, []);
+  assert.deepEqual(called.bumpAttempts, []);
+  // It goes idle without a plan-limit refusal → resume succeeded → entry leaves
+  // the record.
+  engine.observeEvent({ type: "session.idle", properties: { sessionID: "a" } });
+  await flush();
+  assert.deepEqual(called.markRan, ["a"]);
+  assert.equal(recordsLive.length, 0);
+});
+
+test("engine: late resume — recovers however late, with no expiry", async () => {
+  // The reset instant passed hours ago while the box was asleep; on wake the
+  // engine re-evaluates and sends despite the elapsed time. Deliberate: no
+  // "late" expiry.
+  const { engine, timers, called } = harness({
+    records: [armed("a")],
+    windows: { claude: [win("session", 0, T0 - 5 * 60 * 60_000)] }, // reset long past, usage recovered
+  });
+  await engine.deliverSnapshots(snapshotsFor({ claude: [win("session", 0, T0 - 5 * 60 * 60_000)] }));
+  timers.fireAll();
+  await flush();
+  assert.equal(called.deliver.length, 1);
+  assert.equal(called.deliver[0].text, KEEP_GOING_PROMPT);
+});
+
+test("regression: the engine never fires at a fixed reset+60s offset", async () => {
+  // The old path armed a continuation to fire at reset + 60_000 regardless of
+  // recovery. The new engine (a) re-checks AT the reset instant (nextRecheckAt
+  // === resetsAt, not resetsAt + 60s) and (b) never schedules a send while the
+  // meter is still limited even if the clock has passed reset+60s.
+  const windows = { claude: [win("session", 100, T0)] }; // reset instant is NOW
+  const { sends, nextRecheckAt } = planResumeBatch([armed("a")], windows, { now: () => T0 });
+  assert.equal(nextRecheckAt, T0); // not T0 + 60_000
+  assert.equal(sends.length, 0); // still at limit → nothing forced at +60s
+
+  // And a reflect-style source check: the renderer's per-conversation
+  // continuation scheduling (the confirm-dialog state + the "schedule a
+  // 'Keep going' prompt job" callbacks that created the old scheduler job) is
+  // gone — arming now lives in the box-side record and the engine resumes it.
+  const fs = await import("node:fs");
+  const appSrc = fs.readFileSync(new URL("../renderer/App.tsx", import.meta.url), "utf8");
+  assert.ok(!appSrc.includes("confirmKeepGoing"), "renderer per-continuation scheduler job is gone");
+  assert.ok(!appSrc.includes("setKeepGoing"), "renderer 'Keep going' confirm dialog + its state are gone");
+});


### PR DESCRIPTION
**BET-1048 — Usage-limit resume engine + delete the reset+60s continuation path (box-side)**

Builds the box-side resume engine that replaces the old single-conversation "Keep going at reset" path. Reads the armed entries in the usage-stopped record (BET-1047) and resumes them once their provider's usage genuinely recovers.

**Base:** `origin/main @ ea5fe5d7`

**Files changed:** 8 files. `src/server/usageResume.mjs` (new, engine + pure decision logic), `src/server/usageResume.test.mjs` (new, 14 tests), `src/server/stoppedStore.mjs` (new `bumpStoppedAttempts` store fn), `src/server/usage.mjs` (`providerIDForAdapter` + `startUsagePoller` exposes `tick`), `src/server/index.mjs` (wire the engine: subscribe to `usage.updated`, prime on startup, feed the pump), `src/renderer/App.tsx` (delete continuation), `src/renderer/usageEscalation.ts`(+test) (drop now-dead `shouldWarnStaleCache`).

**What it does**
- **Gates on recovery, not a clock.** An armed conversation waits until EVERY window its provider reports is under its limit (`isUsageAtLimit` over the full window list — waiting on the 5-hour reset while the weekly window is also exhausted resumes nothing).
- **Reuses the existing usage poller.** The engine is driven by the poller's `usage.updated` snapshots and schedules a ONE-SHOT re-check at the earliest still-limited provider's reset instant, which calls the poller's `tick()` to re-fetch immediately — **no second polling loop**.
- **Stagger.** Continuations in a batch go out `STAGGER_MS` (4s) apart, oldest-stopped first, so a burst can't re-exhaust a fresh window at the same instant.
- **The prompt is the literal `Keep going`, on the model pinned in the record** (`providerIDForAdapter(provider)` + the record's model id).
- **Mid-turn defers until idle** — the engine sends through the shared `promptDelivery.deliver` (the ONE deferral mechanism); no second one is written.
- **Refused → re-queue; cap → flagged.** A resumed conversation that comes back as a plan-limit refusal (reusing the same classifier as enrolment) stays armed, its `attempts` bumped, and is retried on the next check; past `MAX_RESUME_ATTEMPTS` it stops retrying and publishes `usage-stopped.needs-attention`. Never loops, never drops silently.
- **Successful resume removes the entry** (reaches idle / produces a step with no refusal → `markStoppedRan`).
- **Late resume on wake, however late** — deliberate, no expiry.

**Delete — in this PR, not a follow-up**
- The renderer's "Keep going at reset" confirm dialog + its state (`setKeepGoing`/`confirmKeepGoing`).
- The per-continuation scheduler job this feature created and its Undo toast (arming now lives in the record).
- The fixed `reset + 60s` fire instant **for the continuation**.
- The generic scheduler itself is untouched (it still serves the AI's scheduling tool and the retained "Remind me at reset" notify, which stays **unchanged**).

**Note on "Do not touch the renderer":** the new *feature surface* (sidebar pill, row markers, the arm modal — spec §6–7) is intentionally NOT built here; that is a later stage. The only renderer changes are the required **deletions** — the issue's Delete section mandates them in this PR ("the failure mode to avoid: two things would then resume the same conversation") and the acceptance calls for grepping them gone. `grep` confirms no `confirmKeepGoing` / `setKeepGoing` / "Keep going at reset" continuation remains in the renderer. The remaining `resetsAt + 60_000` in `App.tsx` now serves **only** the retained "Remind me at reset" reminder (spec §9 keeps it unchanged).

**Verification results:**
- PR branch (`multica/BET-1048-resume-engine` @ `4cee02ed`):
  - typecheck: exit 0. Errors: none. log sha256: `a4eb8fdea59d7e94f94fefa4d71ab4a89d312b344e6821a9e0c3b26923dd4979`
  - test (`npm test` = vitest + node:test): exit 0. Renderer `2930 passed / 7 skipped`; server `2283 pass / 0 fail`. Failures: none. log sha256: `8797d01b7290e4c6fe6a0b0806de5cc311553c99b97db10f0ee9523679f5e651`
- Base (`origin/main` @ `ea5fe5d7`): not re-run — the `main` worktree is occupied by another session in this workspace. All new unit tests pass on the PR branch; the one intermittent `usage.test.mjs` poller failure seen once under full-suite load (`2 !== 4`, 5ms real timers) passes reliably in isolation and is untouched by this change (it exercises `createUsagePoller` directly).
- **Conclusion:** 0 new failures, 0 pre-existing failures reproduced on this branch.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`.

**Tests added** (`usageResume.test.mjs`, pure/injected-only):
- Gating: not sent before recovery; **every window** checked, not just the named one.
- Stagger order + spacing (oldest-first, `0/STAGGER/2*STAGGER`).
- Refusal re-queues; attempt cap honoured; flagged after the cap.
- Mid-turn deferral (routes through shared delivery; no send before idle).
- Late resume after a simulated sleep past the reset.
- Regression: the fixed-offset (reset+60s) continuation path no longer fires / is gone from the renderer.
