### PR TITLE
fix(ios): mic button owns the recording gesture — slide-lock / slide-cancel now work (BET-1051)

### DIFF
--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -91,6 +91,12 @@ struct ComposerView: View {
     @State private var showDocPicker = false
     @State private var photoItems: [PhotosPickerItem] = []
     @State private var micAvailable = false
+    /// When the current mic press began — nil while no finger is down. Sets the
+    /// hold-vs-tap boundary at release (BET-1051).
+    @State private var micTouchStart: Date?
+    /// The live translation of the mic's ongoing drag, fed to the held surface
+    /// overlay so the hint shift + lock-glyph brightening track the finger.
+    @State private var micTranslation: CGSize = .zero
     @State private var hint: String?
     @State private var showHint = false
     @FocusState private var inputFocused: Bool
@@ -192,22 +198,38 @@ struct ComposerView: View {
                 )
                 .transition(.opacity)
             }
-            if recorder.phase == .idle {
-                inputBox
-                    .transition(.opacity)
-            } else {
-                VoiceRecordingSurface(
+            if recorder.phase == .recordingLocked || recorder.phase == .paused {
+                VoiceRecordingLockedView(
                     recorder: recorder,
-                    isRTL: isRTL,
-                    onTake: { take in
-                        Task { await handleVoiceTake(take) }
+                    tokens: tokens,
+                    onTake: { take in Task { await handleVoiceTake(take) } },
+                    onDiscarded: {
+                        UIAccessibility.post(notification: .announcement, argument: "Recording discarded")
                     }
                 )
                 .transition(.opacity)
+            } else {
+                inputBox
+                    .overlay {
+                        if recorder.phase == .recordingHeld || recorder.phase == .cancelling {
+                            VoiceRecordingHeldView(
+                                recorder: recorder,
+                                translation: micTranslation,
+                                isRTL: isRTL,
+                                tokens: tokens
+                            )
+                            .transition(.opacity)
+                        }
+                    }
+                    .transition(.opacity)
             }
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.vertical, Metrics.spacing.sp2)
+        // The recording VoiceOver announcements + haptics, applied ONCE to this
+        // persistent container so `lastAnnounced` survives the held-overlay ⇄
+        // locked-bar swap without resetting (BET-1051).
+        .modifier(VoiceFeedback(recorder: recorder))
         .animation(.smooth(duration: 0.22), value: recorder.phase != .idle)
         // ONE presentation per view. The model sheet, the photo picker and the
         // file importer were all attached HERE, and SwiftUI honours only one of
@@ -844,13 +866,44 @@ struct ComposerView: View {
         .buttonStyle(.plain)
         .simultaneousGesture(
             DragGesture(minimumDistance: 0)
-                .onChanged { _ in startRecordingIfPermitted() }
-                .onEnded { _ in }
+                .onChanged { value in
+                    if micTouchStart == nil {
+                        micTouchStart = Date()
+                        startRecordingIfPermitted()
+                    }
+                    micTranslation = value.translation
+                    recorder.drag(dx: value.translation.width,
+                                  dy: value.translation.height,
+                                  isRTL: isRTL)
+                }
+                .onEnded { _ in
+                    let heldMs = micTouchStart.map { Int(Date().timeIntervalSince($0) * 1000) } ?? 0
+                    micTouchStart = nil
+                    withAnimation(.smooth(duration: 0.22)) { micTranslation = .zero }
+                    finishMicRelease(heldMs: heldMs)
+                }
         )
         .accessibilityLabel("Record")
         .accessibilityHint("Tap to record, then slide up to lock or left to cancel")
         .accessibilityIdentifier("mic-button")
         .disabled(!micAvailable)
+    }
+
+    /// Map the end of the mic's ONE continuous gesture to the machine input that
+    /// gesture just produced. Decides nothing itself — it only picks the input.
+    private func finishMicRelease(heldMs: Int) {
+        switch recorder.phase {
+        case .recordingHeld:
+            if heldMs < Waveform.Constants.tapHoldMs {
+                recorder.lockTake()                       // a tap → hands-free bar
+            } else if let take = recorder.stop() {        // a hold → send
+                Task { await handleVoiceTake(take) }
+            }
+        case .cancelling:
+            recorder.stop()                               // the machine discards
+        default:
+            break                                         // locked, or never armed
+        }
     }
 
     private var micIcon: String {
@@ -876,10 +929,9 @@ struct ComposerView: View {
                 hintState("Microphone permission is required")
                 return
             }
-            // The finger may have lifted while the permission prompt was up;
-            // the held surface (which appears on start) owns the continued
-            // gesture, so we don't re-check here — desktop parity keeps the
-            // arms-the-take on press semantics of BET-1027.
+            // The finger may have lifted while the permission prompt was up; if
+            // it did, the mic gesture's onEnded (which continues to own the
+            // touch — see BET-1051) releases the take normally.
             recordingStartInFlight = false
             recorder.start()
         }

--- a/mobile/native/MantaUI/VoiceGesture.swift
+++ b/mobile/native/MantaUI/VoiceGesture.swift
@@ -12,16 +12,15 @@ import Foundation
 // ```
 // Idle ─────────────────────────────────────────► RecordingHeld
 //   │                                                │
-//   │ press                                          │ release(hold,≥cap? no) → .send
-//   │ tapToggle                                      │ release(too short) → Idle (silent)
+//   │ press                                          │ release(hold) → .send
+//   │                                                │ release(too short) → Idle (silent)
 //   ▼                                                │ drag up   > lockThreshold → RecordingLocked
 // RecordingLocked ◄───────────────────────────────── │ drag left > cancelThreshold → Cancelling
-//   │  tapToggle / tapSend ──► .send                  │
-//   │  tapDiscard ─────────► .discard                 │
-//   │  tapPause ──► Paused ⇄ tapResume                │
-// Cancelling ── dragBack ──► RecordingHeld            │
-//            └─ release ──► .discard                  │
-// RecordingLocked/Paused ── tapToggle ──► .send   (tap-toggle OFF; decision #5)
+//   │  tapSend ──► .send (bar button)                │ tapLock (release under tapHoldMs) → RecordingLocked
+//   │  tapDiscard ───► .discard                      │
+//   │  tapPause ──► Paused ⇄ tapResume               │
+// Cancelling ── dragBack ──► RecordingHeld           │
+//            └─ release ──► .discard                 │
 // any ── elapsed ≥ 300_000ms ──► .send          (the take is KEPT)
 // any ── interrupted ──► .discard
 // ```
@@ -73,11 +72,12 @@ enum VoiceInput: Equatable {
     case tapPause
     case tapResume
     case tapDiscard
-    /// The tap-toggle path (decision #5): a tap ON starts a hands-free,
-    /// finger-up take (→ `.recordingLocked`), a tap while a take is live
-    /// sends it (toggle OFF). Distinct from `.release` so a quick tap is not
+    /// The single meaning of "a press ended quickly enough to be a tap": lock
+    /// the take into the hands-free bar. It no longer toggles anything — a tap
+    /// ON locks (decision #5/#6), and the bar's own send button is the only
+    /// way to stop it. Distinct from `.release` so a quick tap is not
     /// swallowed by the `.release` mis-tap discard rules.
-    case tapToggle
+    case tapLock
 }
 
 enum VoiceGesture {
@@ -168,19 +168,10 @@ enum VoiceGesture {
             default: return (currentPhase, .none)
             }
 
-        case .tapToggle:
+        case .tapLock:
             switch currentPhase {
-            case .idle:
-                // Tap #1: start a finger-up take — the held surface shows
-                // immediately (decision #5: "Tap starts…without sustaining a
-                // drag").
-                return (.recordingHeld, .haptic(.arm))
-            case .recordingHeld, .recordingLocked, .paused:
-                // Tap #2: "…and a second tap stops" — stop and send. From a
-                // locked take this is the same as `.tapSend`.
-                return (.idle, .send)
-            default:
-                return (currentPhase, .none)
+            case .recordingHeld: return (.recordingLocked, .haptic(.lock))
+            default: return (currentPhase, .none)
             }
 
         case .interrupted:

--- a/mobile/native/MantaUI/VoiceRecorder.swift
+++ b/mobile/native/MantaUI/VoiceRecorder.swift
@@ -114,12 +114,7 @@ final class VoiceRecorder: ObservableObject {
             currentPhase: phase, input: .press, elapsedMs: 0)
         phase = nextPhase
         publishHaptic(effect)
-        beginCapture()
-    }
 
-    /// Begin the audio capture after the machine has armed a take. Shared by
-    /// the press-start (`start()`) and the first tap of the tap-toggle path.
-    private func beginCapture() {
         stopRequested = false
         pendingTake = nil
         accumulatedMs = 0
@@ -222,30 +217,15 @@ final class VoiceRecorder: ObservableObject {
         return effect
     }
 
-    /// The tap-toggle path (decision #5): a tap ON starts a hands-free,
-    /// finger-up take (→ `.recordingLocked`); a tap while a take is live sends
-    /// it (toggle OFF). Feed the machine's `.tapToggle`; returns the finished
-    /// take only when the tap ends the take.
-    @discardableResult
-    func tapToggle() -> Take? {
-        if phase == .idle {
-            // Tap #1: start a finger-up take into the held surface.
-            let (next, effect) = VoiceGesture.transition(
-                currentPhase: .idle, input: .tapToggle, elapsedMs: 0)
-            phase = next
-            publishHaptic(effect)
-            beginCapture()
-            return nil
-        }
+    /// Lock a held take into the hands-free bar (decision #5/#6): a press that
+    /// ended under the hold threshold is a tap and locks rather than sending.
+    /// Feeds the machine's `.tapLock`; a locked take keeps recording hands-free.
+    func lockTake() {
         let (next, effect) = VoiceGesture.transition(
-            currentPhase: phase, input: .tapToggle, elapsedMs: currentElapsedMs())
+            currentPhase: phase, input: .tapLock, elapsedMs: currentElapsedMs())
         publishHaptic(effect)
-        if next == .idle {
-            // Tap #2: "a second tap stops" — stop and send.
-            return finalizeTake()
-        }
+        guard next != phase else { return }
         phase = next
-        return nil
     }
 
     /// Locked-bar send: feed the machine's `.tapSend` and return the take.

--- a/mobile/native/MantaUI/VoiceRecordingSurface.swift
+++ b/mobile/native/MantaUI/VoiceRecordingSurface.swift
@@ -11,25 +11,34 @@ import UIKit
 // in `VoiceGesture.swift`. The only branch here is which SURFACE to draw for
 // the phase the machine reports.
 //
-// Both surfaces REPLACE the composer box in place (same outer padding), reuse
-// the composer's shared `BoxChrome` glass, and derive every colour/spacing from
-// the tokens. No hex, no new token, no second glass recipe.
+// These surfaces are PURELY PRESENTATIONAL (BET-1051, decision #4): they render
+// props and call callbacks, and contain no gesture of their own. The ONE drag
+// gesture in the whole voice feature lives on the mic button in ComposerView —
+// the only view guaranteed to exist when the touch begins — and feeds the
+// machine directly. The held surface is drawn as an OVERLAY on the composer box
+// while a finger is down (so the mic button underneath keeps the touch alive for
+// the whole continuous gesture), and the locked bar REPLACES the box once the
+// take is hands-free.
+//
+// Both surfaces reuse the composer's shared `BoxChrome` glass (applied as the
+// LAST modifier in each `body`), and derive every colour/spacing from the
+// tokens. No hex, no new token, no second glass recipe.
 // ===========================================================================
 
 // MARK: - Surface A · Recording — held
 
 /// The finger-down held surface: record dot + timer + the "‹ slide to cancel"
-/// hint, with the lock lane floating to the right. Renders while
-/// `recorder.phase == .recordingHeld` and hosts the ongoing hold gesture
-/// (slide up → lock, slide left → cancel, release → send).
+/// hint, with the lock lane floating to the right. Drawn as an OVERLAY on the
+/// composer box while `recorder.phase == .recordingHeld` (or `.cancelling`), so
+/// the mic button underneath stays alive for the whole continuous gesture. It
+/// has NO gesture of its own — `translation` (fed from the mic's drag) drives
+/// the hint shift and the lock-glyph brightening, and it never decides what the
+/// take should do next.
 struct VoiceRecordingHeldView: View {
     @ObservedObject var recorder: VoiceRecorder
+    let translation: CGSize
     let isRTL: Bool
     let tokens: Tokens
-    var onTake: (VoiceRecorder.Take) -> Void = { _ in }
-
-    @State private var translation: CGSize = .zero
-    @State private var dragStart: Date?
 
     /// The enlarged mic in the lane — 38 (chatHeaderBtn) + 8 (sp2) = 46, derived,
     /// never hardcoded. The glyph sits on the accent at the composer's body size.
@@ -44,7 +53,7 @@ struct VoiceRecordingHeldView: View {
 
         ZStack(alignment: .bottomTrailing) {
             HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
-                AccessoryDot(danger: tokens.danger)
+                VoiceRecordDot(danger: tokens.danger)
                 timer
                 cancelHint(progress: cancelP, shift: hintShift, isRTL: isRTL, isCancelling: isCancelling)
             }
@@ -62,18 +71,7 @@ struct VoiceRecordingHeldView: View {
         // single element instead of propagating to every child in the AX tree.
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("voice-recording-held")
-        .gesture(
-            DragGesture(minimumDistance: 0)
-                .onChanged { value in
-                    if dragStart == nil { dragStart = Date() }
-                    translation = value.translation
-                    recorder.drag(dx: value.translation.width, dy: value.translation.height, isRTL: isRTL)
-                }
-                .onEnded { _ in
-                    withAnimation(.smooth(duration: 0.22)) { translation = .zero }
-                    finishHoldRelease()
-                }
-        )
+        .modifier(BoxChrome(cornerRadius: Metrics.radius.xl, stroke: tokens.borderSubtle, tint: tokens.panel.opacity(0.35)))
     }
 
     // MARK: records
@@ -88,8 +86,7 @@ struct VoiceRecordingHeldView: View {
 
     /// The "‹ slide to cancel" hint — translates with the drag and fades toward
     /// 0 as the cancel threshold is approached. Once the take is actually in
-    /// the cancelling phase it flips to a solid danger "release to cancel" —
-    /// still on the same held surface so the drag gesture stays mounted.
+    /// the cancelling phase it flips to a solid danger "release to cancel".
     @ViewBuilder
     private func cancelHint(progress: Double, shift: CGFloat, isRTL: Bool, isCancelling: Bool) -> some View {
         let text = isCancelling ? "release to cancel" : "‹ slide to cancel"
@@ -113,7 +110,7 @@ struct VoiceRecordingHeldView: View {
 
     /// The floating lock lane — chevron, lock glyph, enlarged mic — appearing
     /// only while held. The lock glyph brightens to `accentTx` as the lock
-    /// threshold is approached.
+    /// threshold is approached (a pure crossfade of the two tokens).
     private func lockLane(lockProgress: Double, isCancelling: Bool) -> some View {
         VStack(spacing: Metrics.spacing.sp2) {
             Image(systemName: "chevron.up")
@@ -121,7 +118,13 @@ struct VoiceRecordingHeldView: View {
                 .foregroundColor(tokens.tx2)
             Image(systemName: "lock")
                 .font(.system(size: Metrics.type.small))
-                .foregroundColor(lockGlyphColor(progress: lockProgress))
+                .foregroundColor(tokens.tx3)
+                .overlay {
+                    Image(systemName: "lock")
+                        .font(.system(size: Metrics.type.small))
+                        .foregroundColor(tokens.accentTx)
+                        .opacity(lockProgress)
+                }
             mic
         }
         .frame(width: Metrics.spacing.spPx * 46)
@@ -129,14 +132,6 @@ struct VoiceRecordingHeldView: View {
         .background(tokens.raised.opacity(0.9), in: Capsule())
         .overlay(Capsule().stroke(tokens.borderSubtle, lineWidth: 1))
         .accessibilityIdentifier("voice-lock-lane")
-    }
-
-    private func lockGlyphColor(progress: Double) -> Color {
-        // Fade tx3 → accentTx as the lock threshold is approached.
-        let p = progress
-        if p >= 1 { return tokens.accentTx }
-        // Linear interpolation between the two token colours.
-        return interpolate(from: tokens.tx3, to: tokens.accentTx, t: p)
     }
 
     private var mic: some View {
@@ -155,64 +150,15 @@ struct VoiceRecordingHeldView: View {
         .frame(width: micDiameter, height: micDiameter)
         .contentShape(Rectangle())
     }
-
-    /// Colour-lerp — both args are token colours, no raw component math.
-    private func interpolate(from a: Color, to b: Color, t: Double) -> Color {
-        guard t > 0 else { return tokens.tx3 }
-        guard t < 1 else { return tokens.accentTx }
-        let uiA = UIColor(a), uiB = UIColor(b)
-        var ra: CGFloat = 0; var ga: CGFloat = 0; var ba: CGFloat = 0; var aa: CGFloat = 0
-        var rb: CGFloat = 0; var gb: CGFloat = 0; var bb: CGFloat = 0; var ab: CGFloat = 0
-        uiA.getRed(&ra, green: &ga, blue: &ba, alpha: &aa)
-        uiB.getRed(&rb, green: &gb, blue: &bb, alpha: &ab)
-        let tt = CGFloat(t)
-        return Color(
-            .sRGB,
-            red: ra + (rb - ra) * tt,
-            green: ga + (gb - ga) * tt,
-            blue: ba + (bb - ba) * tt,
-            opacity: aa + (ab - aa) * tt
-        )
-    }
-
-    // MARK: release
-
-    /// Map the end of a hold to the machine. `VoiceGesture` owns every branch;
-    /// we only pick the INPUT for the gesture that just ended.
-    private func finishHoldRelease() {
-        let heldMs = dragStart.map { Int(Date().timeIntervalSince($0) * 1000) } ?? 0
-        dragStart = nil
-        switch recorder.phase {
-        case .cancelling:
-            // sliding left then release → discard.
-            recorder.stop()
-        case .recordingLocked:
-            // already locked — release is a no-op; the bar owns the take now.
-            break
-        case .recordingHeld:
-            if heldMs < Int(Waveform.Constants.tapHoldMs) {
-                // A tap while held toggles ON → fingers-free locked bar.
-                onTakeFrom(recorder.tapToggle())
-            } else {
-                // A hold + release → send.
-                onTakeFrom(recorder.stop())
-            }
-        default:
-            break
-        }
-    }
-
-    private func onTakeFrom(_ take: VoiceRecorder.Take?) {
-        if let take { onTake(take) }
-    }
 }
 
 // MARK: - Surface C · Recording — locked
 
 /// The hands-free locked surface: head row (record dot, timer, live waveform),
-/// optional remaining-time line, and the discard / pause / send bar. Renders
-/// while the machine is `.recordingLocked` or `.paused`. Tapping the surface
-/// (away from a button) is the tap-toggle OFF — it stops and sends.
+/// optional remaining-time line, and the discard / pause / send bar. Replaces
+/// the composer box while the machine is `.recordingLocked` or `.paused`. The
+/// only interactive elements are the three bar buttons — a tap on the surface's
+/// background does nothing (decision #6, BET-1051: no tap-anywhere-to-send).
 struct VoiceRecordingLockedView: View {
     @ObservedObject var recorder: VoiceRecorder
     let tokens: Tokens
@@ -225,7 +171,7 @@ struct VoiceRecordingLockedView: View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
             // Head row: record dot + timer + live waveform (right-aligned).
             HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
-                VoiceRecordingHeldView.AccessoryDot(danger: tokens.danger)
+                VoiceRecordDot(danger: tokens.danger)
                 timer
                 Spacer(minLength: Metrics.spacing.sp2)
                 VoiceBarsView(peaks: recorder.livePeaks, progress: nil, tokens: tokens,
@@ -260,14 +206,11 @@ struct VoiceRecordingLockedView: View {
         }
         .padding(Metrics.spacing.sp3)
         .contentShape(Rectangle())
-        .onTapGesture {
-            // Tap-toggle OFF: a second tap stops and sends.
-            onTakeFrom(recorder.tapToggle())
-        }
         // One accessibility element for the surface; the bar's three buttons
         // remain separate interactive elements (they carry their own ids).
         .accessibilityElement(children: .contain)
         .accessibilityIdentifier("voice-recording-locked")
+        .modifier(BoxChrome(cornerRadius: Metrics.radius.xl, stroke: tokens.borderSubtle, tint: tokens.panel.opacity(0.35)))
     }
 
     private var remaining: Int {
@@ -339,48 +282,29 @@ struct VoiceRecordingLockedView: View {
     }
 }
 
-// MARK: - Dispatcher
+// MARK: - Feedback modifier
 
-/// Renders whichever surface the machine's `VoicePhase` asks for, and owns the
-/// phase→VoiceOver announcements + haptic playback the machine requests. This
-/// is the single surface ComposerView swaps in for the input box.
-struct VoiceRecordingSurface: View {
+/// Applies the recording machine's VoiceOver announcements + haptic playback to
+/// whatever view owns the recording UI. Applied ONCE to a persistent container
+/// (the composer VStack in ComposerView), so `lastAnnounced` survives the
+/// held-surface overlay ↔ locked-bar replacement without resetting on remount.
+@MainActor
+struct VoiceFeedback: ViewModifier {
     @ObservedObject var recorder: VoiceRecorder
-    let isRTL: Bool
-    var onTake: (VoiceRecorder.Take) -> Void = { _ in }
-
-    private var tokens: Tokens { Tokens.scheme(environment) }
-    @Environment(\.colorScheme) private var environment
-
     @State private var lastAnnounced: VoicePhase?
 
-    var body: some View {
-        // The shared BoxChrome glass — applied ONCE here so each surface uses
-        // exactly the same modifier (no second glass recipe anywhere).
-        Group {
-            switch recorder.phase {
-            case .recordingHeld, .cancelling:
-                // `.cancelling` renders through the held surface too so its
-                // drag gesture stays mounted (swapping it away mid-drag would
-                // cancel the gesture and lose the release→discard).
-                VoiceRecordingHeldView(recorder: recorder, isRTL: isRTL, tokens: tokens, onTake: onTake)
-            case .recordingLocked, .paused:
-                VoiceRecordingLockedView(recorder: recorder, tokens: tokens, onTake: onTake, onDiscarded: { announceDiscard() })
-            default:
-                EmptyView()
+    func body(content: Content) -> some View {
+        content
+            .onAppear { lastAnnounced = recorder.phase }
+            .onChange(of: recorder.phase) { _, newPhase in
+                announce(previous: lastAnnounced, current: newPhase)
+                lastAnnounced = newPhase
             }
-        }
-        .modifier(BoxChrome(cornerRadius: Metrics.radius.xl, stroke: tokens.borderSubtle, tint: tokens.panel.opacity(0.35)))
-        .onAppear { lastAnnounced = recorder.phase }
-        .onChange(of: recorder.phase) { _, newPhase in
-            announce(previous: lastAnnounced, current: newPhase)
-            lastAnnounced = newPhase
-        }
-        .onChange(of: recorder.haptic) { _, newValue in
-            guard let haptic = newValue else { return }
-            VoiceHapticPlayer.play(haptic)
-            recorder.consumeHaptic()
-        }
+            .onChange(of: recorder.haptic) { _, newValue in
+                guard let haptic = newValue else { return }
+                VoiceHapticPlayer.play(haptic)
+                recorder.consumeHaptic()
+            }
     }
 
     // MARK: VoiceOver announcements (decision #4)
@@ -401,10 +325,6 @@ struct VoiceRecordingSurface: View {
             UIAccessibility.post(notification: .announcement, argument: message)
         }
     }
-
-    private func announceDiscard() {
-        UIAccessibility.post(notification: .announcement, argument: "Recording discarded")
-    }
 }
 
 /// Physical playback of a machine-requested haptic. The VIEW maps a machine
@@ -424,23 +344,21 @@ enum VoiceHapticPlayer {
     }
 }
 
-extension VoiceRecordingHeldView {
-    /// The pulsing record dot, shared with the locked surface's head row.
-    struct AccessoryDot: View {
-        let danger: Color
-        @State private var pulse = false
-        var body: some View {
-            Circle()
-                .fill(danger)
-                .frame(width: Metrics.spacing.spPx * 11, height: Metrics.spacing.spPx * 11)
-                .overlay(
-                    Circle()
-                        .stroke(danger.opacity(0.16), lineWidth: 4)
-                )
-                .opacity(pulse ? 1 : 0.55)
-                .animation(.smooth(duration: 0.9).repeatForever(autoreverses: true), value: pulse)
-                .onAppear { pulse = true }
-                .accessibilityHidden(true)
-        }
+/// The pulsing record dot, shared by the held and locked surfaces.
+struct VoiceRecordDot: View {
+    let danger: Color
+    @State private var pulse = false
+    var body: some View {
+        Circle()
+            .fill(danger)
+            .frame(width: Metrics.spacing.spPx * 11, height: Metrics.spacing.spPx * 11)
+            .overlay(
+                Circle()
+                    .stroke(danger.opacity(0.16), lineWidth: 4)
+            )
+            .opacity(pulse ? 1 : 0.55)
+            .animation(.smooth(duration: 0.9).repeatForever(autoreverses: true), value: pulse)
+            .onAppear { pulse = true }
+            .accessibilityHidden(true)
     }
 }

--- a/mobile/native/MantaUITests/VoiceGestureTests.swift
+++ b/mobile/native/MantaUITests/VoiceGestureTests.swift
@@ -184,37 +184,34 @@ final class VoiceGestureTests: XCTestCase {
         XCTAssertEqual(rtlLeft.0, .recordingHeld, "RTL: dragging left must not cancel (mirrored)")
     }
 
-    // MARK: - tap-toggle (decision #5 — tap #1 starts, tap #2 stops)
+    // MARK: - tap-lock (BET-1051, decision #5/#6 — a tap locks, it never sends)
 
-    func testTapToggleFromIdleStartsHeld() {
-        // Tap #1 starts a finger-up take showing the held surface.
-        let (phase, effect) = step(.idle, .tapToggle, elapsedMs: 0)
-        XCTAssertEqual(phase, .recordingHeld)
-        XCTAssertEqual(effect, .haptic(.arm))
+    func testTapLockFromHeldLocks() {
+        // A press that ended under the hold threshold is a tap → lock.
+        let (phase, effect) = step(.recordingHeld, .tapLock, elapsedMs: 300)
+        XCTAssertEqual(phase, .recordingLocked)
+        XCTAssertEqual(effect, .haptic(.lock))
     }
 
-    func testTapToggleFromHeldSends() {
-        // Tap #2 while held: "a second tap stops" → stop and send.
-        let (phase, effect) = step(.recordingHeld, .tapToggle, elapsedMs: 300)
+    func testTapLockFromIdleUnreachableNoop() {
+        // `tapLock` only ever follows a press, so `.idle` is unreachable — but
+        // it must be a safe no-op, not a send.
+        let (phase, effect) = step(.idle, .tapLock, elapsedMs: 0)
         XCTAssertEqual(phase, .idle)
-        XCTAssertEqual(effect, .send)
+        XCTAssertEqual(effect, .none)
     }
 
-    func testTapToggleFromLockedSends() {
-        let (phase, effect) = step(.recordingLocked, .tapToggle, elapsedMs: 5000)
-        XCTAssertEqual(phase, .idle)
-        XCTAssertEqual(effect, .send)
+    func testTapLockFromLockedNoop() {
+        // Decision #6: the bar has an explicit send button; a second tap no
+        // longer sends.
+        let (phase, effect) = step(.recordingLocked, .tapLock, elapsedMs: 5000)
+        XCTAssertEqual(phase, .recordingLocked)
+        XCTAssertEqual(effect, .none)
     }
 
-    func testTapToggleFromPausedSends() {
-        let (phase, effect) = step(.paused, .tapToggle, elapsedMs: 5000)
-        XCTAssertEqual(phase, .idle)
-        XCTAssertEqual(effect, .send)
-    }
-
-    func testTapToggleFromCancellingIgnored() {
-        let (phase, effect) = step(.cancelling, .tapToggle, elapsedMs: 3000)
-        XCTAssertEqual(phase, .cancelling)
+    func testTapLockFromPausedNoop() {
+        let (phase, effect) = step(.paused, .tapLock, elapsedMs: 5000)
+        XCTAssertEqual(phase, .paused)
         XCTAssertEqual(effect, .none)
     }
 

--- a/mobile/native/MantaUIUITests/MantaVoiceRecordingUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaVoiceRecordingUITests.swift
@@ -1,7 +1,8 @@
 import XCTest
 
 // ===========================================================================
-// BET-1028 acceptance captures — the WhatsApp-style recording surfaces.
+// BET-1051 acceptance — the recording gesture is owned by the MIC BUTTON, not
+// by the surface it summons.
 //
 // Driven to a REAL composer-bearing chat against the local capture-fixture box
 // (127.0.0.1:8787, code 123456 — see capture-fixture/fixture-box.mjs), exactly
@@ -9,10 +10,15 @@ import XCTest
 // Groq key so the mic button is available, and its `voice:transcribe` returns an
 // empty transcript, so sending is a harmless no-op (no real transcription).
 //
-// Covers the walkthrough: tap-toggle start/stop (decision #5), hold-and-release,
-// slide-left cancel, slide-up lock, pause/resume while locked, discard while
-// locked. No audio is asserted. Each capture writes a settled PNG + prints the
-// accessibility tree between markers.
+// EVERY recording test drives ONE continuous gesture that begins on the mic
+// button — `XCUIElement.press(forDuration:thenDragTo:)` delivers a single
+// uninterrupted touch. A test that taps the mic and then starts a fresh drag on
+// the surface elsewhere is the exact two-step pattern that let the original bug
+// ship (BET-1051) and must never return.
+//
+// Screenshots are captured only for stable, finger-up states (the idle composer
+// and the locked bar). A press-and-drag is atomic in XCUI, so no snapshot is
+// attempted mid-press.
 // ===========================================================================
 
 final class MantaVoiceRecordingUITests: XCTestCase {
@@ -24,126 +30,119 @@ final class MantaVoiceRecordingUITests: XCTestCase {
     private let pairCode = "123456"
     private let pairServer = "http://127.0.0.1:8787"
 
-    // MARK: - 1. Held → slide up to lock (the core surface + bar)
+    // MARK: - 1. Hold + slide up → lock (THE regression test)
 
-    func testVoiceRecordingHeldThenLocked() throws {
+    /// BET-1051 regression: ONE continuous gesture that begins on the mic. Press
+    /// and slide up 160pt in a single touch; the bar locks. This MUST fail on
+    /// the old surface-owned-gesture build and pass after the change.
+    func testMicHoldSlideUpLocks() throws {
         let app = XCUIApplication()
         app.launch()
         reachChatComposer(app)
 
-        // Composer BEFORE recording — for the no-height-jump comparison.
-        snap(app, marker: "COMPOSER", png: "bet1028-composer.png")
+        // Idle composer — a stable, finger-up state (for the no-height-jump
+        // comparison).
+        snap(app, marker: "COMPOSER", png: "bet1051-composer.png")
 
         let mic = app.buttons["mic-button"]
         XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
-        mic.tap()
-
-        let held = app.descendants(matching: .any)["voice-recording-held"]
-        XCTAssertTrue(held.waitForExistence(timeout: 5), "recording did not start — voice-recording-held missing")
-        snap(app, marker: "REC-HELD", png: "bet1028-held.png")
-
-        // Slide UP well past the 80pt lock threshold (drag beyond the small
-        // surface so the translation reaches it).
-        let holdStart = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.6))
-        holdStart.press(forDuration: 0.2, thenDragTo: holdStart.withOffset(CGVector(dx: 0, dy: -160)))
+        let from = mic.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        from.press(forDuration: 0.6, thenDragTo: from.withOffset(CGVector(dx: 0, dy: -160)))
 
         let locked = app.descendants(matching: .any)["voice-recording-locked"]
         XCTAssertTrue(locked.waitForExistence(timeout: 6), "slide up did not lock — voice-recording-locked missing")
         XCTAssertTrue(app.buttons["voice-discard"].exists, "locked bar missing voice-discard")
         XCTAssertTrue(app.buttons["voice-pause"].exists, "locked bar missing voice-pause")
         XCTAssertTrue(app.buttons["voice-send"].exists, "locked bar missing voice-send")
-        snap(app, marker: "REC-LOCKED", png: "bet1028-locked.png")
+        snap(app, marker: "REC-LOCKED", png: "bet1051-locked.png")
 
-        // Clean up: discard so the simulator isn't left recording.
+        // Clean up so the simulator isn't left recording.
         app.buttons["voice-discard"].tap()
     }
 
-    // MARK: - 2. Tap-toggle: tap #1 starts, tap #2 stops (decision #5)
+    // MARK: - 2. Hold + slide left → cancel (nothing is sent)
 
-    func testVoiceTapToggleStartStop() throws {
+    func testMicHoldSlideLeftCancels() throws {
         let app = XCUIApplication()
         app.launch()
         reachChatComposer(app)
 
         let mic = app.buttons["mic-button"]
         XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
-        // Tap #1: starts, held surface appears.
-        mic.tap()
-        let held = app.descendants(matching: .any)["voice-recording-held"]
-        XCTAssertTrue(held.waitForExistence(timeout: 5), "tap #1 did not start — held missing")
+        let from = mic.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.5))
+        from.press(forDuration: 0.6, thenDragTo: from.withOffset(CGVector(dx: -140, dy: 0)))
 
-        // Tap #2: "a second tap stops" → sends → composer returns.
-        held.coordinate(withNormalizedOffset: CGVector(dx: 0.7, dy: 0.6)).tap()
-        let ended = app.descendants(matching: .any)["voice-recording-held"]
-        XCTAssertFalse(ended.waitForExistence(timeout: 2), "tap #2 did not stop the take — held still present")
-        XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 5), "composer did not return after tap #2")
-    }
-
-    // MARK: - 3. Slide left → cancel (release discards)
-
-    func testVoiceSlideLeftCancels() throws {
-        let app = XCUIApplication()
-        app.launch()
-        reachChatComposer(app)
-
-        let mic = app.buttons["mic-button"]
-        XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
-        mic.tap()
-        let held = app.descendants(matching: .any)["voice-recording-held"]
-        XCTAssertTrue(held.waitForExistence(timeout: 5), "held missing before slide")
-
-        // Drag left well past the 64pt cancel threshold, then release.
-        let holdStart = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.6))
-        holdStart.press(forDuration: 0.2, thenDragTo: holdStart.withOffset(CGVector(dx: -140, dy: 0)))
-
-        let ended = app.descendants(matching: .any)["voice-recording-held"]
-        XCTAssertFalse(ended.waitForExistence(timeout: 2), "slide-left+release did not discard the take")
+        let locked = app.descendants(matching: .any)["voice-recording-locked"]
+        XCTAssertFalse(locked.waitForExistence(timeout: 2), "slide left + release should NOT leave a locked bar")
         XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 5), "composer did not return after cancel")
     }
 
-    // MARK: - 4. Locked bar: pause / resume / discard
+    // MARK: - 3. Hold + release → send
 
-    func testVoiceLockedPauseResumeDiscard() throws {
+    func testMicHoldAndReleaseSends() throws {
         let app = XCUIApplication()
         app.launch()
         reachChatComposer(app)
 
         let mic = app.buttons["mic-button"]
         XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
-        mic.tap()
-        let held = app.descendants(matching: .any)["voice-recording-held"]
-        XCTAssertTrue(held.waitForExistence(timeout: 5), "held missing")
-        let holdStart = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.6))
-        holdStart.press(forDuration: 0.2, thenDragTo: holdStart.withOffset(CGVector(dx: 0, dy: -160)))
-        let locked = app.descendants(matching: .any)["voice-recording-locked"]
-        XCTAssertTrue(locked.waitForExistence(timeout: 6), "slide up did not lock")
+        mic.press(forDuration: 1.2)
 
-        // Pause.
+        let locked = app.descendants(matching: .any)["voice-recording-locked"]
+        XCTAssertFalse(locked.waitForExistence(timeout: 2), "hold+release should not leave a locked bar")
+        XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 5), "composer did not return after release")
+    }
+
+    // MARK: - 4. A tap on the mic goes straight to the locked bar (decision #5)
+
+    func testMicTapLocks() throws {
+        let app = XCUIApplication()
+        app.launch()
+        reachChatComposer(app)
+
+        let locked = micTapLocked(app)
+        snap(app, marker: "TAP-LOCKED", png: "bet1051-tap-locked.png")
+
+        // The bar's send button stops it and the composer returns.
+        app.buttons["voice-send"].tap()
+        XCTAssertFalse(locked.waitForExistence(timeout: 2), "send did not end the locked take")
+        XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 5), "composer did not return after send")
+    }
+
+    // MARK: - 5. Locked bar: pause / resume / discard
+
+    func testLockedBarPauseResumeDiscard() throws {
+        let app = XCUIApplication()
+        app.launch()
+        reachChatComposer(app)
+
+        micTapLocked(app)
+
+        // Pause → the same button flips to a resume glyph.
         app.buttons["voice-pause"].tap()
-        // The pause button flips to a resume glyph — assert the state via the
-        // label/identifier transitions (resume label).
-        let resumeExpectation = app.buttons["voice-pause"]
-        XCTAssertTrue(resumeExpectation.waitForExistence(timeout: 3), "pause button gone")
+        let resume = app.buttons["voice-pause"]
+        let flipped = NSPredicate(format: "label == %@", "Resume recording")
+        let exp = XCTNSPredicateExpectation(predicate: flipped, object: resume)
+        XCTAssertEqual(XCTWaiter().wait(for: [exp], timeout: 3), .completed,
+                       "pause button did not flip to resume")
 
         // Resume.
         app.buttons["voice-pause"].tap()
 
-        // Discard.
+        // Discard → composer returns.
         app.buttons["voice-discard"].tap()
         let ended = app.descendants(matching: .any)["voice-recording-locked"]
         XCTAssertFalse(ended.waitForExistence(timeout: 2), "discard did not end the locked take")
         XCTAssertTrue(app.buttons["send-button"].waitForExistence(timeout: 5), "composer did not return after discard")
     }
 
-    // MARK: - 5. BET-1050 — the locked live bar stays inside the screen ≥30s
+    // MARK: - 6. BET-1050 — the locked live bar stays inside the screen ≥30s
 
     /// BET-1050 acceptance: the live meter is width-derived (not a fixed-width
     /// bar row), so once the 90-bar window fills (~3.6s) and the recording has
     /// run ≥30s the whole locked recording bar must stay fully inside the
-    /// screen — the elapsed timer is never clipped on the left and the
-    /// waveform never crosses the right edge. Measured as the
-    /// `voice-recording-locked` container frame against the screen bounds: the
-    /// OLD fixed-width row forced this container wider than the screen.
+    /// screen. Reaches the locked bar via a quick mic tap (the direct path after
+    /// BET-1051's decision #5).
     func testVoiceLockedOverflowStaysOnScreen() throws {
         let app = XCUIApplication()
         app.launch()
@@ -153,14 +152,8 @@ final class MantaVoiceRecordingUITests: XCTestCase {
         XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
         mic.tap()
 
-        let held = app.descendants(matching: .any)["voice-recording-held"]
-        XCTAssertTrue(held.waitForExistence(timeout: 5), "recording did not start — held missing")
-        // Slide UP well past the 80pt lock threshold.
-        let holdStart = held.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.6))
-        holdStart.press(forDuration: 0.2, thenDragTo: holdStart.withOffset(CGVector(dx: 0, dy: -160)))
-
         let locked = app.descendants(matching: .any)["voice-recording-locked"]
-        XCTAssertTrue(locked.waitForExistence(timeout: 6), "slide up did not lock")
+        XCTAssertTrue(locked.waitForExistence(timeout: 6), "mic.tap() did not lock")
         XCTAssertTrue(app.buttons["voice-discard"].exists, "locked bar missing controls")
 
         // Let it run ≥30s so the live window is full (the bug only appears
@@ -187,15 +180,13 @@ final class MantaVoiceRecordingUITests: XCTestCase {
         XCTAssertFalse(locked.waitForExistence(timeout: 3), "discard did not end the locked take")
     }
 
-    // MARK: - 6. BET-1050 — the finished (.stored) note still renders + seekable
+    // MARK: - 7. BET-1050 — the finished (.stored) note still renders + seekable
 
     /// BET-1050 acceptance item 8: the finished voice-note path is unchanged.
     /// Launches the `voice-note-stored` capture scene (a real `VoiceNotePlayerRow`
     /// with a finished note) and asserts the stored waveform row renders, that
     /// its play cell is present, and that tapping the bars region exercises the
-    /// seek gesture without crashing. Seekability itself is wired by the
-    /// ready-row's non-nil `onSeek` closure → `VoiceBarsView` attaches the tap
-    /// gesture (`onSeek.map { _ in tapSeek(...) }`), which is unchanged.
+    /// seek gesture without crashing.
     func testStoredNoteRendersAndTappable() throws {
         let app = XCUIApplication()
         app.launchEnvironment["MANTA_SCENE"] = "voice-note-stored"
@@ -213,6 +204,18 @@ final class MantaVoiceRecordingUITests: XCTestCase {
     }
 
     // MARK: - Helpers
+
+    /// A quick tap on the mic goes straight to the locked bar (decision #5) —
+    /// this is the direct tap-to-lock path, never a held state.
+    @discardableResult
+    private func micTapLocked(_ app: XCUIApplication) -> XCUIElement {
+        let mic = app.buttons["mic-button"]
+        XCTAssertTrue(mic.waitForExistence(timeout: 10), "mic button missing")
+        mic.tap()
+        let locked = app.descendants(matching: .any)["voice-recording-locked"]
+        XCTAssertTrue(locked.waitForExistence(timeout: 6), "mic tap did not lock — voice-recording-locked missing")
+        return locked
+    }
 
     /// Pair (first run only — the app stays paired between test launches) and
     /// open the fixture's single Chat row so the composer is reachable.


### PR DESCRIPTION
Opened automatically for `multica/BET-1051-mic-owned-recording-gesture2`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1051.