### PR TITLE
BET-1054: refactor(server): throw GithubRequestError on read path + extract clearStoredToken

### DIFF
--- a/src/server/forge/auth.mjs
+++ b/src/server/forge/auth.mjs
@@ -34,7 +34,7 @@
 
 import { randomBytes } from "node:crypto";
 import { runLoginShell } from "../launchers.mjs";
-import { resolveSecret, loadSecrets, setSecret } from "../secrets.mjs";
+import { resolveSecret, loadSecrets, setSecret, listSecrets, deleteSecret } from "../secrets.mjs";
 import { configGet, configUpdate } from "../local.mjs";
 import { readFile as fsReadFile } from "node:fs/promises";
 import { homedir } from "node:os";
@@ -270,6 +270,24 @@ export async function rotateOauthPair(refresh, persistPair) {
  */
 export function invalidateToken(host) {
   CACHE.delete(host);
+}
+
+/**
+ * Delete the shared GITHUB_TOKEN secret that Manta's own device flow wrote, and
+ * drop every cached resolution for it. The ONLY credential Manta may delete —
+ * an env var and the user's `gh` CLI login are not ours to touch.
+ *
+ * Deliberately does NOT set `forgeDisconnected`: that flag means "the user asked
+ * us to ignore GitHub", which is a different thing from "this credential is dead".
+ * Setting it here would also suppress a perfectly good `gh` CLI login.
+ */
+export async function clearStoredToken({ list = listSecrets, remove = deleteSecret } = {}) {
+  const entry = list({ includeAll: true }).find(
+    (s) => s.key === "GITHUB_TOKEN" && s.scope === "shared",
+  );
+  if (entry) await remove(entry.id);
+  invalidateToken(GITHUB_CLI_HOST);
+  return { cleared: Boolean(entry) };
 }
 
 /**

--- a/src/server/forge/auth.test.mjs
+++ b/src/server/forge/auth.test.mjs
@@ -3,7 +3,7 @@
 
 import { test, beforeEach } from "node:test";
 import assert from "node:assert/strict";
-import { resolveToken, invalidateToken, normalizeUserCode, startDeviceGrant, pollDeviceGrant, ExpiredCodeError, DeviceFlowNotConfiguredError, DEVICE_CLIENT_ID, DEVICE_CLIENT_ID_PLACEHOLDER } from "./auth.mjs";
+import { resolveToken, invalidateToken, normalizeUserCode, startDeviceGrant, pollDeviceGrant, ExpiredCodeError, DeviceFlowNotConfiguredError, DEVICE_CLIENT_ID, DEVICE_CLIENT_ID_PLACEHOLDER, clearStoredToken } from "./auth.mjs";
 
 // The module-level auth cache persists across test cases in this file — clear
 // it before each so a cached github.com resolution from one test can't leak
@@ -386,4 +386,46 @@ test("device grant: the production default client_id is real, not the placeholde
   const fetchFn = makeFetch(async () => ({ error: "authorization_pending" }));
   const started = await startDeviceGrant({ fetch: fetchFn, now: clock.now });
   assert.equal(started.pollInterval, 5, "the default id is unguarded — the device flow actually runs");
+});
+
+// ---- clearStoredToken (BET-1054) -------------------------------------------
+// Injection is mandatory — this suite runs on a live box and must never reach
+// the real secrets store. list/remove are stubbed in every case below.
+
+test("clearStoredToken deletes the shared GITHUB_TOKEN and returns {cleared:true}", async () => {
+  const removed = [];
+  const secrets = [
+    { id: "s1", key: "GITHUB_TOKEN", value: "ghp_shared", scope: "shared", sessionID: null, project: null },
+    { id: "s2", key: "OTHER", value: "v", scope: "shared", sessionID: null, project: null },
+  ];
+  const r = await clearStoredToken({
+    list: () => secrets,
+    remove: (id) => (removed.push(id), Promise.resolve()),
+  });
+  assert.deepEqual(r, { cleared: true });
+  assert.deepEqual(removed, ["s1"], "only the shared GITHUB_TOKEN is removed");
+});
+
+test("clearStoredToken is a no-op returning {cleared:false} when no such secret exists", async () => {
+  const removed = [];
+  const r = await clearStoredToken({
+    list: () => [{ id: "s1", key: "OTHER", scope: "shared", sessionID: null, project: null }],
+    remove: (id) => (removed.push(id), Promise.resolve()),
+  });
+  assert.deepEqual(r, { cleared: false });
+  assert.deepEqual(removed, []);
+});
+
+test("clearStoredToken does not delete a non-shared GITHUB_TOKEN nor other keys", async () => {
+  const removed = [];
+  const secrets = [
+    { id: "s1", key: "GITHUB_TOKEN", value: "ghp", scope: "session", sessionID: "ses_1", project: null },
+    { id: "s2", key: "OTHER", value: "v", scope: "shared", sessionID: null, project: null },
+  ];
+  const r = await clearStoredToken({
+    list: () => secrets,
+    remove: (id) => (removed.push(id), Promise.resolve()),
+  });
+  assert.deepEqual(r, { cleared: false });
+  assert.deepEqual(removed, []);
 });

--- a/src/server/forge/index.mjs
+++ b/src/server/forge/index.mjs
@@ -67,6 +67,28 @@ export class ForgeRateLimitedError extends Error {
   }
 }
 
+/**
+ * Classify a forge request failure into an actionable kind. Pure.
+ *
+ * SAFETY PROPERTY: only "rejected" is destructive downstream (it is the only
+ * kind that may cause a stored credential to be deleted). Every other kind is
+ * inert, so a misclassification among them is cosmetic, never damaging. Keep it
+ * that way — do not widen what maps to "rejected".
+ *
+ * @param {unknown} err
+ * @returns {"rejected"|"rate_limited"|"forbidden"|"network"|"unknown"}
+ */
+export function classifyForgeError(err) {
+  if (err && err.name === "ForgeRateLimitedError") return "rate_limited";
+  const status = err && typeof err.status === "number" ? err.status : null;
+  if (status === 401) return "rejected";
+  if (status === 429) return "rate_limited";
+  if (status === 403) return "forbidden";
+  // The request layer only throws without a status when `fetch` itself failed.
+  if (status === null) return "network";
+  return "unknown";
+}
+
 function bucketOf(url) {
   try {
     return new URL(url).hostname;
@@ -229,9 +251,7 @@ async function fetchOne(url, token, tokenHeader, bucket, cacheKey, accept, parse
     throw new ForgeRateLimitedError(url);
   }
 
-  if (!res.ok) {
-    throw new Error(`github request failed (${res.status}) for ${url}`);
-  }
+  if (!res.ok) throw new GithubRequestError(res.status, url);
 
   const data = await parse(res);
   const etag = res.headers.get("etag");

--- a/src/server/forge/index.test.mjs
+++ b/src/server/forge/index.test.mjs
@@ -25,6 +25,7 @@ import {
   seedPromptFor,
   INBOX_SEED_PROMPT,
   ForgeRateLimitedError,
+  classifyForgeError,
 } from "./index.mjs";
 import { getDraft, putComment } from "./draft.mjs";
 import { detectForgeWithHosts } from "./selfhost.mjs";
@@ -323,6 +324,24 @@ test("pullRequestForCwd: aheadCount is null when the rev-list call throws", asyn
 test("getAdapter throws UnsupportedByForgeError for an unknown kind", async () => {
   const runtime = createForgeRuntime({ fetch: async () => json({}, 200, {}) });
   assert.throws(() => runtime.getAdapter("gitea", "t"), (e) => e.name === "UnsupportedByForgeError");
+});
+
+test("classifyForgeError maps known failure kinds", () => {
+  assert.equal(classifyForgeError(new ForgeRateLimitedError(URL)), "rate_limited");
+  assert.equal(classifyForgeError({ status: 401 }), "rejected");
+  assert.equal(classifyForgeError({ status: 429 }), "rate_limited");
+  assert.equal(classifyForgeError({ status: 403 }), "forbidden");
+  assert.equal(classifyForgeError(new Error("offline")), "network");
+  assert.equal(classifyForgeError({ status: 500 }), "unknown");
+  assert.equal(classifyForgeError(null), "network");
+});
+
+test("read-path failure throws GithubRequestError carrying the status", async () => {
+  const runtime = createForgeRuntime({ fetch: async () => ({ ok: false, status: 401 }) });
+  await assert.rejects(
+    runtime.requestLayer.getJson(URL, { token: "t" }),
+    (e) => e.name === "GithubRequestError" && e.status === 401,
+  );
 });
 
 test("a configured self-hosted host routes through the box op with its apiBase", async () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -43,10 +43,8 @@ import { searchMessages } from "./messageSearch.mjs";
 import { MIN_CLIENT } from "./version.mjs";
 import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, replyThreadForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
 import { listRules as forgeListRules, formatIssueRef, parseIssueRef } from "./forgeRules.mjs";
-import { invalidateToken as invalidateForgeToken } from "./forge/auth.mjs";
+import { clearStoredToken } from "./forge/auth.mjs";
 import { parseRules as parseForgeRules } from "../shared/forgeRules.mjs";
-
-const GH_HOST = "github.com";
 
 // The number of rules (event entries) in a repo's rules YAML — shown in
 // Settings [G1] so a valid repo reads "3 rules".
@@ -422,10 +420,7 @@ export function buildHandlers({
     // secret is not an error). A successful device sign-in clears the flag.
     "forge:disconnect": async () => {
       await local.configUpdate({ forgeDisconnected: true });
-      const secrets = secretsListStore({ includeAll: true });
-      const ghToken = secrets.find((s) => s.key === "GITHUB_TOKEN" && s.scope === "shared");
-      if (ghToken) await secretsDeleteStore(ghToken.id);
-      invalidateForgeToken(GH_HOST);
+      await clearStoredToken();
       return { ok: true };
     },
 


### PR DESCRIPTION
## Summary
Pure refactor, no behaviour change (BET-1054). Unlocks credential-validity detection.

- **Read path**: `fetchOne` now throws the existing `GithubRequestError(status, url)` (byte-identical message, carries `.status`/`.url`) instead of a hand-rolled bare `Error`. Read path and write path now agree; deletes the duplicated template.
- **New pure classifier** `classifyForgeError` (exported, unused for now — a follow-up probe consumes it). Only `rejected` (401) is destructive downstream; 403 → `forbidden` (SSO org, credential valid), rate-limit/network/unknown are inert.
- **Extracted `clearStoredToken`** into `forge/auth.mjs` (injected `list`/`remove`). `forge:disconnect` delegates to it and no longer owns secrets-store internals. Removed `invalidateForgeToken` import + `GH_HOST` const from `rpc.mjs` (both genuinely unused after extraction; `secretsListStore`/`secretsDeleteStore` kept — still used by other handlers).

## Acceptance checks
- `grep -rn "github request failed" src/server` → exactly one hit (the `GithubRequestError` constructor in `github.mjs:35`).
- `forge:disconnect` handler is 4 lines, no secret-store calls.
- No new module / RPC channel / config field; no renderer/preload/main or GitLab changes.

## Files changed: 5
`src/server/forge/auth.mjs`, `src/server/forge/auth.test.mjs`, `src/server/forge/index.mjs`, `src/server/forge/index.test.mjs`, `src/server/rpc.mjs`

**Base: origin/main @ `2fb521b3`**

**Verification results:**
- PR branch (`multica/BET-1054-forge-readpath-githubreqerr`):
  - typecheck: exit 0. Errors: none. log sha256: `a4eb8fdea59d7e94f94fefa4d71ab4a89d312b344e6821a9e0c3b26923dd4979`
  - test: exit 0, 2289 pass / 0 fail / 0 skip. Failures: none. log sha256: `e84ec9e1f51a7e1d2ca464eaa6267fb6c291a6700505047054e88d541a52c984`
- Base (`main @ 2fb521b3`):
  - typecheck: exit 0. Errors: none. log sha256: `a4eb8fdea59d7e94f94fefa4d71ab4a89d312b344e6821a9e0c3b26923dd4979`
  - test: exit 0, 2284 pass / 0 fail / 0 skip. Failures: none. log sha256: `8502944eaa3b6011989887e7b032e410b896dfa2ac27283b32ce2c8755b65839`
- **Conclusion:** 0 new failures; the 5-test delta (2289 vs 2284) is the 5 new tests this PR adds.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.