### PR TITLE
feat(renderer): four-state GitHub row in Settings + route rejected clone to sign-in (BET-1059)

### DIFF
--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -333,4 +333,83 @@ describe("CloneFromGitHub picker", () => {
     expect(container!.querySelector(".manta-loader")).toBeNull();
     expect(container!.querySelector('input[aria-label="Clone alpha"]')).toBeTruthy();
   });
+
+  it("routes a rejected repo listing back to the connect panel, not an error message (BET-1059)", async () => {
+    // First forgeDeviceStart call: an existing credential, so the picker (and
+    // the repo fetch) run. When the box reports `rejected` and the component
+    // drops to `connected: false`, the second call keeps it OFF the picker and
+    // ON the connect screen so the user can sign in again — this is what makes
+    // the box's behaviour after clearing a dead credential testable instead of
+    // an infinite re-connect loop.
+    let deviceStartCalls = 0;
+    installMockApi({
+      forgeDeviceStart: () => {
+        deviceStartCalls++;
+        return Promise.resolve(
+          deviceStartCalls === 1
+            ? { connected: true, grant: null }
+            : {
+                connected: false,
+                grant: {
+                  grantId: "g1",
+                  userCode: "ABCD-1234",
+                  verificationUri: "https://github.com/login/device",
+                  expiresIn: 900,
+                  pollInterval: 5,
+                },
+                error: null,
+              },
+        );
+      },
+      forgeRepos: () => Promise.resolve({ repos: [], stale: false, error: "rejected" }),
+      forgeCloneStart: () => Promise.resolve({ id: "c1" }),
+      forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
+      );
+    });
+    await flushMicro();
+    await flushMicro();
+    await flushMicro();
+
+    const text = container!.textContent ?? "";
+    // The connect screen (its device code) is the next screen after the box
+    // clears a dead credential — NOT a permanent error stuck on the picker.
+    expect(text).toContain("ABCD-1234");
+    expect(text).not.toContain("Couldn't list your repositories from GitHub.");
+    expect(text).not.toContain("Clone a repository");
+  });
+
+  it("renders an error message for a network failure and does NOT drop to the connect panel (BET-1059)", async () => {
+    installMockApi({
+      forgeDeviceStart: () => Promise.resolve({ connected: true, grant: null }),
+      forgeRepos: () => Promise.resolve({ repos: [], stale: false, error: "network" }),
+      forgeCloneStart: () => Promise.resolve({ id: "c1" }),
+      forgeCloneStatus: () => Promise.resolve(CLONE_IN_PROGRESS),
+    });
+    container = document.createElement("div");
+    document.body.appendChild(container);
+    root = createRoot(container);
+    act(() => {
+      root!.render(
+        <CloneFromGitHub defaultRoot="/root" onCancel={() => {}} onCloned={() => {}} />,
+      );
+    });
+    await flushMicro();
+    await flushMicro();
+
+    const text = container!.textContent ?? "";
+    // The network message renders inside the picker's error callout…
+    expect(text).toContain(
+      "Couldn't reach GitHub from your box. Check its connection and try again.",
+    );
+    // …and the picker stays up — a blip must not look like a sign-out.
+    expect(text).toContain("Clone a repository");
+    expect(container!.querySelector('input[aria-label="Search repositories"]')).toBeTruthy();
+  });
 });

--- a/src/renderer/CloneFromGitHub.tsx
+++ b/src/renderer/CloneFromGitHub.tsx
@@ -114,6 +114,13 @@ export function CloneFromGitHub({
       try {
         const res = await window.api.forgeRepos();
         if (cancelled) return;
+        if (res.error === "rejected" || res.error === "not_connected") {
+          // The box cleared the dead credential; its own sign-in panel is the
+          // next screen. `forgeDeviceStart` no longer short-circuits, so the
+          // real device flow runs.
+          setConnected(false);
+          return;
+        }
         // `res.repos` is always an array; `res.error` is the only failure
         // signal. Testing the array's truthiness was the original bug.
         if (res.error) setReposState({ kind: "error", message: repoListErrorMessage(res.error) });

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -34,6 +34,7 @@ import { useApplySetting } from "./settingsApply";
 import { SettingsRow } from "./SettingsRow";
 import { BANNER_BTN } from "./Toast";
 import { errorDisclosure } from "./settingsError";
+import { forgeCredentialSecondary } from "./chatUtils";
 import {
   useLaunchers,
   updateLauncherFlag,
@@ -510,7 +511,7 @@ export function Settings({
     let cancelled = false;
     const load = () => {
       window.api.configGet().then((c) => { if (!cancelled) setForgeRulesOn(c.forgeRulesEnabled === true); }).catch(() => {});
-      window.api.forgeStatus().then((s) => { if (!cancelled) setForgeStatus(s); }).catch(() => {});
+      window.api.forgeStatus({ validate: true }).then((s) => { if (!cancelled) setForgeStatus(s); }).catch(() => {});
       window.api.forgeRulesList()
         .then((rows) => { if (!cancelled) { setForgeRules(rows); setForgeRulesError(null); } })
         .catch((e) => { if (!cancelled) setForgeRulesError(e instanceof Error ? e.message : String(e)); });
@@ -541,12 +542,6 @@ export function Settings({
     } catch (e) {
       push({ id: `err-forge-dc-${Date.now()}`, message: errorDisclosure("Couldn't disconnect GitHub.", e) });
     }
-  };
-  const sourceTextFor = (source: string | null | undefined): string => {
-    if (source === "cli") return "from the gh CLI on your box";
-    if (source === "env") return "from the MANTA_GITHUB_TOKEN env var";
-    if (source === "stored") return "signed in on this box";
-    return "connected";
   };
 
   // Remove box — in-app confirm replaces window.confirm (BET-419 §D).
@@ -828,11 +823,17 @@ export function Settings({
                 came from · Disconnect. Naming the token's provenance is the
                 point — "from the gh CLI on your box" reads as a courtesy, not
                 surveillance. */}
-            {forgeStatus?.connected ? (
+            {forgeStatus === null ? (
               <ListRow
-                leading={<StatusDot tone="ok" />}
+                leading={<StatusDot tone="idle" />}
                 name="GitHub"
-                secondary={forgeStatus.login ? `@${forgeStatus.login} · ${sourceTextFor(forgeStatus.source)}` : sourceTextFor(forgeStatus.source)}
+                secondary="Checking…"
+              />
+            ) : forgeStatus.connected ? (
+              <ListRow
+                leading={<StatusDot tone={forgeStatus.valid === false ? "warn" : "ok"} />}
+                name="GitHub"
+                secondary={forgeCredentialSecondary(forgeStatus)}
                 trailing={<button onClick={() => void disconnectForge()} className="text-label px-3 py-1 rounded-full border border-border text-text-muted hover:text-text">Disconnect</button>}
               />
             ) : (

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -119,6 +119,7 @@ import {
   commentableLines,
   cloneErrorKind,
   repoListErrorMessage,
+  forgeCredentialSecondary,
   type StatusItem,
   type RepoRow,
   workingIndicatorLabel,
@@ -4782,18 +4783,80 @@ describe("cloneErrorKind", () => {
 });
 
 describe("repoListErrorMessage (BET-1011)", () => {
-  it("maps the server's not_connected code to sign-in guidance", () => {
+  it("maps the server's not_connected and rejected codes to sign-in guidance", () => {
     expect(repoListErrorMessage("not_connected")).toBe(
       "GitHub isn't connected. Go back and sign in again.",
+    );
+    expect(repoListErrorMessage("rejected")).toBe(
+      "GitHub isn't connected. Go back and sign in again.",
+    );
+  });
+
+  it("explains a rate-limited listing", () => {
+    expect(repoListErrorMessage("rate_limited")).toBe(
+      "GitHub's rate limit is used up. Try again in a few minutes.",
+    );
+  });
+
+  it("explains a forbidden listing with an SSO hint", () => {
+    expect(repoListErrorMessage("forbidden")).toBe(
+      "GitHub refused this request. If the repositories belong to an organisation, it may require SSO authorisation for your sign-in.",
+    );
+  });
+
+  it("explains a network failure", () => {
+    expect(repoListErrorMessage("network")).toBe(
+      "Couldn't reach GitHub from your box. Check its connection and try again.",
     );
   });
 
   it("falls back to a generic message for any other code or absence", () => {
     const generic = "Couldn't list your repositories from GitHub.";
-    expect(repoListErrorMessage("rate_limited")).toBe(generic);
+    expect(repoListErrorMessage("bogus")).toBe(generic);
     expect(repoListErrorMessage("")).toBe(generic);
     expect(repoListErrorMessage(null)).toBe(generic);
     expect(repoListErrorMessage(undefined)).toBe(generic);
+  });
+});
+
+describe("forgeCredentialSecondary (BET-1059)", () => {
+  it("explains a rejected gh CLI credential", () => {
+    expect(forgeCredentialSecondary({ login: "a", source: "cli", valid: false })).toBe(
+      "GitHub rejected the gh CLI sign-in on your box. Run `gh auth login` there, or Disconnect.",
+    );
+  });
+
+  it("explains a rejected env-var credential", () => {
+    expect(forgeCredentialSecondary({ login: "a", source: "env", valid: false })).toBe(
+      "GitHub rejected the MANTA_GITHUB_TOKEN environment variable on your box. Replace it there, or Disconnect.",
+    );
+  });
+
+  it("explains a rejected stored credential without a provenance hint", () => {
+    expect(forgeCredentialSecondary({ login: "a", source: "stored", valid: false })).toBe(
+      "GitHub rejected this sign-in. Disconnect, then connect again.",
+    );
+    expect(forgeCredentialSecondary({ login: null, source: null, valid: false })).toBe(
+      "GitHub rejected this sign-in. Disconnect, then connect again.",
+    );
+  });
+
+  it("valid with a login → @login · <where>", () => {
+    expect(forgeCredentialSecondary({ login: "antoinedc", source: "cli", valid: true })).toBe(
+      "@antoinedc · from the gh CLI on your box",
+    );
+  });
+
+  it("valid with no login → the bare <where>", () => {
+    expect(forgeCredentialSecondary({ login: null, source: "stored", valid: true })).toBe(
+      "signed in on this box",
+    );
+  });
+
+  it("valid null is treated like valid true — not-yet-probed never renders as rejected", () => {
+    expect(forgeCredentialSecondary({ login: "antoinedc", source: "env", valid: null })).toBe(
+      "@antoinedc · from the MANTA_GITHUB_TOKEN env var",
+    );
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3444,12 +3444,48 @@ export function cloneErrorKind(stderr: string): CloneErrorKind {
   return "unknown";
 }
 
-// The box returns machine codes (`not_connected`) or a raw exception string
-// for a failed repo listing; neither is something to show a person. One
-// mapping, so the picker never renders a server code verbatim.
+// The box returns machine codes (`not_connected`, `rejected`, `rate_limited`,
+// `forbidden`, `network`) or a raw exception string for a failed repo listing;
+// neither is something to show a person. One mapping, so the picker never
+// renders a server code verbatim.
 export function repoListErrorMessage(code: string | null | undefined): string {
-  if (code === "not_connected") return "GitHub isn't connected. Go back and sign in again.";
+  if (code === "not_connected" || code === "rejected") {
+    return "GitHub isn't connected. Go back and sign in again.";
+  }
+  if (code === "rate_limited") {
+    return "GitHub's rate limit is used up. Try again in a few minutes.";
+  }
+  if (code === "forbidden") {
+    return "GitHub refused this request. If the repositories belong to an organisation, it may require SSO authorisation for your sign-in.";
+  }
+  if (code === "network") {
+    return "Couldn't reach GitHub from your box. Check its connection and try again.";
+  }
   return "Couldn't list your repositories from GitHub.";
+}
+
+/** The secondary line on the Settings GitHub row: who is connected, where the
+ *  credential came from, and — when GitHub has rejected it — what to do. Pure. */
+export function forgeCredentialSecondary(status: {
+  login: string | null;
+  source: "cli" | "env" | "stored" | null;
+  valid: boolean | null;
+}): string {
+  if (status.valid === false) {
+    if (status.source === "cli") {
+      return "GitHub rejected the gh CLI sign-in on your box. Run `gh auth login` there, or Disconnect.";
+    }
+    if (status.source === "env") {
+      return "GitHub rejected the MANTA_GITHUB_TOKEN environment variable on your box. Replace it there, or Disconnect.";
+    }
+    return "GitHub rejected this sign-in. Disconnect, then connect again.";
+  }
+  const where =
+    status.source === "cli" ? "from the gh CLI on your box"
+    : status.source === "env" ? "from the MANTA_GITHUB_TOKEN env var"
+    : status.source === "stored" ? "signed in on this box"
+    : "connected";
+  return status.login ? `@${status.login} · ${where}` : where;
 }
 
 // ===== Forge merge gate (BET-794) =====


### PR DESCRIPTION
## BET-1059 — forge (desktop UI): four-state GitHub row in Settings + rejection routes the clone card to sign-in

BET-1056 (merged, PR #1058) added `forgeStatus({ validate })`, the `valid` field on `ForgeStatusResult`, and the `forgeRepos` error codes. This surfaces that signal in the desktop UI.

**Files changed:** 5 files.
- `src/renderer/chatUtils.ts` — `forgeCredentialSecondary` (moved/renamed from `sourceTextFor`), extended `repoListErrorMessage` for the new codes
- `src/renderer/Settings.tsx` — pass `{ validate: true }`, three-branch GitHub row (Checking… / connected+validity / not-connected), delete local `sourceTextFor`
- `src/renderer/CloneFromGitHub.tsx` — a `rejected` listing drops to the connect panel
- `src/renderer/chatUtils.test.ts`, `src/renderer/CloneFromGitHub.test.tsx` — new/extended tests

**Verification results:**
- PR branch (`multica/BET-1059-forge-settings-github-row` @ `27c21625`):
  - typecheck: exit 0. Errors: none. log sha256: `a4eb8fdea59d7e94f94fefa4d71ab4a89d312b344e6821a9e0c3b26923dd4979`
  - test: exit 0, renderer 2974 pass / 0 fail, server 2300 pass / 0 fail. Failures: none. log sha256: `1487f8910a6a4ce98fb1b652a5ef361c3995b99c89a2d1718cb8be063ba523da`
- Base (`main` @ `2781b6bc`):
  - typecheck: exit 0. Errors: none. log sha256: `a4eb8fdea59d7e94f94fefa4d71ab4a89d312b344e6821a9e0c3b26923dd4979` (byte-identical — no type-level change)
  - test: exit 0, renderer 2963 pass / 0 fail, server 2300 pass / 0 fail. Failures: none. log sha256: `4f1e71636e14983eaa845bf39f1f19d837e0f76983e4025607d5647e78186e53`
- **Conclusion:** 0 new failures. 11 new tests added (all pass) — no pre-existing failures on either branch.

**Base: origin/main @ `2781b6bc`**

Notes:
- No `src/server/`, `mobile/native/`, preload, or `src/main/` touched.
- `sourceTextFor` is gone from `src/renderer` (renamed to `forgeCredentialSecondary` in `chatUtils.ts`).
- No client-side validation timer added — the box owns the hour TTL.
