### PR TITLE
fix(ios): held recording surface IS the composer — hidden, not overlaid; animate every phase change; dead-mic fix after lock (BET-1060)

### DIFF
--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -198,7 +198,7 @@ struct ComposerView: View {
                 )
                 .transition(.opacity)
             }
-            if recorder.phase == .recordingLocked || recorder.phase == .paused {
+            if recorder.isHandsFree {
                 VoiceRecordingLockedView(
                     recorder: recorder,
                     tokens: tokens,
@@ -209,19 +209,25 @@ struct ComposerView: View {
                 )
                 .transition(.opacity)
             } else {
-                inputBox
-                    .overlay {
-                        if recorder.phase == .recordingHeld || recorder.phase == .cancelling {
-                            VoiceRecordingHeldView(
-                                recorder: recorder,
-                                translation: micTranslation,
-                                isRTL: isRTL,
-                                tokens: tokens
-                            )
-                            .transition(.opacity)
-                        }
+                // The composer stays MOUNTED while a take is held — the mic button owns
+                // the in-flight touch and a view removed mid-gesture stops receiving it
+                // (BET-1051). It is hidden, not unmounted, so the recording surface is
+                // what you see while the gesture underneath survives.
+                ZStack(alignment: .bottom) {
+                    inputBox
+                        .opacity(recorder.isHeld ? 0 : 1)
+                    if recorder.isHeld {
+                        VoiceRecordingHeldView(
+                            recorder: recorder,
+                            translation: micTranslation,
+                            isRTL: isRTL,
+                            tokens: tokens
+                        )
+                        .frame(maxWidth: .infinity)
+                        .transition(.opacity)
                     }
-                    .transition(.opacity)
+                }
+                .transition(.opacity)
             }
         }
         .padding(.horizontal, Metrics.spacing.sp3)
@@ -230,7 +236,16 @@ struct ComposerView: View {
         // persistent container so `lastAnnounced` survives the held-overlay ⇄
         // locked-bar swap without resetting (BET-1051).
         .modifier(VoiceFeedback(recorder: recorder))
-        .animation(.smooth(duration: 0.22), value: recorder.phase != .idle)
+        .animation(.smooth(duration: 0.22), value: recorder.phase)
+        // A locked take no longer needs the finger, and an idle one has no gesture at
+        // all: either way the press that started it is over, whether or not the drag's
+        // `onEnded` was ever delivered to a view that had already been removed.
+        .onChange(of: recorder.phase) { _, phase in
+            if phase == .idle || recorder.isHandsFree {
+                micTouchStart = nil
+                micTranslation = .zero
+            }
+        }
         // ONE presentation per view. The model sheet, the photo picker and the
         // file importer were all attached HERE, and SwiftUI honours only one of
         // them — which is why attaching a file silently did nothing. The two

--- a/mobile/native/MantaUI/VoiceRecorder.swift
+++ b/mobile/native/MantaUI/VoiceRecorder.swift
@@ -49,6 +49,12 @@ final class VoiceRecorder: ObservableObject {
         phase == .recordingHeld || phase == .recordingLocked
     }
 
+    /// A take with a finger down on it (the armed-cancel state included).
+    var isHeld: Bool { phase == .recordingHeld || phase == .cancelling }
+
+    /// A take that no longer needs the finger: the hands-free bar owns it.
+    var isHandsFree: Bool { phase == .recordingLocked || phase == .paused }
+
     /// The haptic the machine just asked the UI to play (arm / lock /
     /// cancelArmed / send). The recorder computes it from the machine's output
     /// but never plays it — the VIEW plays the haptic it describes, so the view

--- a/mobile/native/MantaUI/VoiceRecordingSurface.swift
+++ b/mobile/native/MantaUI/VoiceRecordingSurface.swift
@@ -52,9 +52,8 @@ struct VoiceRecordingHeldView: View {
         let hintShift = cancelP * (micDiameter + Metrics.spacing.sp3)
 
         ZStack(alignment: .bottomTrailing) {
-            HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
-                VoiceRecordDot(danger: tokens.danger)
-                timer
+            VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+                VoiceTakeHeadline(recorder: recorder, tokens: tokens)
                 cancelHint(progress: cancelP, shift: hintShift, isRTL: isRTL, isCancelling: isCancelling)
             }
             .frame(maxWidth: .infinity, alignment: .leading)
@@ -75,14 +74,6 @@ struct VoiceRecordingHeldView: View {
     }
 
     // MARK: records
-
-    /// The tabular mono-digit elapsed clock.
-    private var timer: some View {
-        Text(Waveform.formatClock(recorder.durationMs))
-            .font(.manta(size: Metrics.type.body, weight: .semibold).monospacedDigit())
-            .foregroundColor(tokens.tx1)
-            .accessibilityHidden(true)
-    }
 
     /// The "‹ slide to cancel" hint — translates with the drag and fades toward
     /// 0 as the cancel threshold is approached. Once the take is actually in
@@ -169,14 +160,9 @@ struct VoiceRecordingLockedView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
-            // Head row: record dot + timer + live waveform (right-aligned).
-            HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
-                VoiceRecordDot(danger: tokens.danger)
-                timer
-                Spacer(minLength: Metrics.spacing.sp2)
-                VoiceBarsView(peaks: recorder.livePeaks, progress: nil, tokens: tokens,
-                              style: .live, onSeek: nil)
-            }
+            // Head row: record dot + elapsed clock + live waveform (shared with
+            // the held surface so there is ONE live-meter call site).
+            VoiceTakeHeadline(recorder: recorder, tokens: tokens)
 
             // Remaining-time line — only inside the warn window.
             if remaining < Waveform.Constants.warnRemainingMs {
@@ -215,13 +201,6 @@ struct VoiceRecordingLockedView: View {
 
     private var remaining: Int {
         max(0, Waveform.Constants.maxDurationMs - recorder.durationMs)
-    }
-
-    private var timer: some View {
-        Text(Waveform.formatClock(recorder.durationMs))
-            .font(.manta(size: Metrics.type.body, weight: .semibold).monospacedDigit())
-            .foregroundColor(tokens.tx1)
-            .accessibilityHidden(true)
     }
 
     private var discardButton: some View {
@@ -341,6 +320,27 @@ enum VoiceHapticPlayer {
         case .cancelArmed:
             UIImpactFeedbackGenerator(style: .rigid).impactOccurred()
         }
+    }
+}
+
+/// Record dot + elapsed clock + live meter — the head row shared by the held
+/// and the locked surface, so there is ONE live-meter call site and ONE clock
+/// rather than a copy per surface.
+struct VoiceTakeHeadline: View {
+    @ObservedObject var recorder: VoiceRecorder
+    let tokens: Tokens
+
+    var body: some View {
+        HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
+            VoiceRecordDot(danger: tokens.danger)
+            Text(Waveform.formatClock(recorder.durationMs))
+                .font(.manta(size: Metrics.type.body, weight: .semibold).monospacedDigit())
+                .foregroundColor(tokens.tx1)
+            Spacer(minLength: Metrics.spacing.sp2)
+            VoiceBarsView(peaks: recorder.livePeaks, progress: nil, tokens: tokens,
+                          style: .live, onSeek: nil)
+        }
+        .accessibilityHidden(true)
     }
 }
 


### PR DESCRIPTION
Opened automatically for `multica/BET-1060-held-recording-surface-composer`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1060.