### PR TITLE
Settings: remove Undo from every toast (BET-1055)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -749,17 +749,8 @@ function Shell() {
                           sessionID,
                         });
                         if (res.ok && res.job) {
-                          const jobId = res.job.id;
                           pushAppToastStore({
                             message: toastLine(Bell, `Reminder set for ${formatResetAt(fireAt, Date.now())}.`),
-                            actions: [
-                              {
-                                label: "Undo",
-                                onClick: () => {
-                                  if (jobId) void window.api.scheduleDelete(jobId);
-                                },
-                              },
-                            ],
                           });
                         } else {
                           pushAppToastStore({

--- a/src/renderer/Settings.test.tsx
+++ b/src/renderer/Settings.test.tsx
@@ -17,6 +17,7 @@
 
 import { describe, it, expect, afterEach } from "vitest";
 import { act } from "react";
+import { renderToStaticMarkup } from "react-dom/server";
 import { mount, installMockApi, type Harness } from "./testHarness";
 import { Settings } from "./Settings";
 import { useStore } from "./store";
@@ -199,10 +200,11 @@ describe("Settings — Escape + nested-confirm ownership (BET-724 regression)", 
   });
 });
 
-// BET-942: Settings → Forge → Disconnect now persists a real opt-out on the
-// box, so the toast deliberately has NO Undo action (Undo only restored local
-// state while the box stayed connected — a lie). The disconnect is one RPC
-// call, and the connected row flips to not-connected.
+// BET-1055: Undo has been removed from every toast. The forge disconnect toast
+// (BET-942) is the last confirmation toast Settings keeps, and this test now
+// pins the invariant that it carries NO action array — a toast with an action
+// never auto-dismisses. The disconnect is one RPC call, and the connected row
+// flips to not-connected.
 describe("Settings — Forge Disconnect (BET-942)", () => {
   let h: Harness | null = null;
 
@@ -257,5 +259,75 @@ describe("Settings — Forge Disconnect (BET-942)", () => {
       "Your gh CLI is untouched — Manta will ignore it until you reconnect.",
     );
     expect(toast!.actions, "no Undo action — reconnect only via device sign-in").toBeUndefined();
+  });
+});
+
+// BET-1055: schema-driven settings toasts become error-only. A successful
+// change (optimistic store → configUpdate → reconcile) raises NO toast; a
+// failing configUpdate raises exactly one error toast carrying the disclosure.
+describe("Settings — schema-driven toasts are error-only (BET-1055)", () => {
+  let h: Harness | null = null;
+
+  // "Auto-rename sessions" is a schema toggle (platform "both",
+  // configKey "autoRenameSessions"), committed through applySetting →
+  // configUpdate, and lives on the Sessions tab.
+  const autoRenameInput = () =>
+    h!.container.querySelector<HTMLInputElement>(
+      'input[aria-label="Auto-rename sessions"]',
+    );
+
+  const stubApi = (configUpdate?: () => Promise<unknown>) =>
+    installMockApi({
+      configGet: () => Promise.resolve({}),
+      getClientVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      getServerVersion: () => Promise.resolve({ version: "0.0.0-test" }),
+      launchersList: () => Promise.resolve([]),
+      // configUpdate always resolves to the updated config object in prod; a
+      // bare `undefined` made `next[key]` throw and trip the error path.
+      configUpdate: configUpdate ?? (() => Promise.resolve({})),
+    });
+
+  const toggleAutoRename = () => {
+    const input = autoRenameInput();
+    expect(input, "Auto-rename sessions checkbox").toBeTruthy();
+    act(() => {
+      (input as HTMLInputElement).click();
+    });
+  };
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    useStore.setState({ appToasts: [] });
+  });
+
+  it("no toast when a schema-driven change succeeds", async () => {
+    const { api } = stubApi();
+    h = mount(<Settings onClose={() => {}} initialSection="sessions" />);
+    await h.flush();
+
+    toggleAutoRename();
+    await h.flush();
+
+    expect(api.calls.configUpdate ?? []).toHaveLength(1);
+    expect(useStore.getState().appToasts).toHaveLength(0);
+  });
+
+  it("exactly one error toast with the disclosure when configUpdate fails", async () => {
+    const { api } = stubApi(() => Promise.reject(new Error("boom")));
+    h = mount(<Settings onClose={() => {}} initialSection="sessions" />);
+    await h.flush();
+
+    toggleAutoRename();
+    await h.flush();
+
+    const toasts = useStore.getState().appToasts;
+    expect(toasts).toHaveLength(1);
+    expect(toasts[0].id).toMatch(/^err-/);
+    const disclosure = renderToStaticMarkup(
+      toasts[0].message as unknown as Parameters<typeof renderToStaticMarkup>[0],
+    );
+    expect(disclosure).toContain("set auto-rename sessions.");
+    expect(api.calls.configUpdate ?? []).toHaveLength(1);
   });
 });

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -167,7 +167,7 @@ function SettingField({ entry, value, onCommit, credential }: {
   const [savedAt, setSavedAt] = useState<number | null>(null);
   const focused = useRef(false);
   // Keep the draft in sync with the store ONLY when the field is NOT focused
-  // (so an external change — e.g. Undo from another toast — is picked up,
+  // (so an external change — a rollback, a reset — is picked up,
   // but an in-progress edit is never stomped).
   useEffect(() => { if (!focused.current) setDraft(value); }, [value]);
   return (
@@ -378,11 +378,6 @@ export function Settings({
       const r = await window.api.configUpdate({ skillRegistryUrls: next });
       const saved = (r as Record<string, unknown>).skillRegistryUrls;
       useStore.setState({ skillRegistryUrls: Array.isArray(saved) ? (saved as string[]) : next });
-      push({
-        id: `registry-${Date.now()}`,
-        message: next.length > prev.length ? "Registry URL added" : "Registry URL removed",
-        actions: [{ label: "Undo", onClick: () => { void useStore.setState({ skillRegistryUrls: prev }); window.api.configUpdate({ skillRegistryUrls: prev }).catch(() => {}); } }],
-      });
       requestRestart();
     } catch (e) {
       useStore.setState({ skillRegistryUrls: prev });
@@ -478,7 +473,7 @@ export function Settings({
     if (!preload?.pluginsSetEnabled) return;
     try {
       await preload.pluginsSetEnabled(on);
-      push({ id: `plugins-${Date.now()}`, message: `Plugins ${on ? "enabled" : "disabled"} — restart Manta to apply.`, actions: [{ label: "Undo", onClick: () => { setPluginsOn(prev); void preload.pluginsSetEnabled(prev); } }] });
+      requestRestart();
     } catch (e) {
       setPluginsOn(prev);
       push({ id: `err-plugins-${Date.now()}`, message: errorDisclosure("Couldn't toggle plugins.", e) });
@@ -524,7 +519,6 @@ export function Settings({
     setForgeRulesOn(on);
     try {
       await window.api.configUpdate({ forgeRulesEnabled: on });
-      push({ id: `forge-${Date.now()}`, message: `Forge rules ${on ? "enabled" : "disabled"}.`, actions: [{ label: "Undo", onClick: () => { setForgeRulesOn(prev); void window.api.configUpdate({ forgeRulesEnabled: prev }).catch(() => {}); } }] });
     } catch (e) {
       setForgeRulesOn(prev);
       push({ id: `err-forge-${Date.now()}`, message: errorDisclosure("Couldn't toggle forge rules.", e) });
@@ -586,11 +580,6 @@ export function Settings({
     if (typeof payload.theme === "string") applyTheme(payload.theme as ThemePref);
     try {
       await window.api.configUpdate(payload);
-      push({
-        id: `reset-${Date.now()}`,
-        message: "All settings reset to defaults.",
-        actions: [{ label: "Undo", onClick: () => { void useStore.setState(prev); if (prev.theme) applyTheme(prev.theme as ThemePref); window.api.configUpdate(prev).catch(() => {}); } }],
-      });
     } catch (e) {
       useStore.setState(prev);
       if (prev.theme) applyTheme(prev.theme as ThemePref);

--- a/src/renderer/Toast.test.ts
+++ b/src/renderer/Toast.test.ts
@@ -9,9 +9,12 @@ import {
 
 const base: ToastItem = { id: "x", message: "hi" };
 
+// BET-1055 removed Undo from every toast. This test pins the Toast primitive's
+// generic action rule (an action means no auto-dismiss) with a neutral label —
+// no Settings toast carries an action any more.
 describe("toastTtl", () => {
   it("never auto-dismisses when any action is present", () => {
-    expect(toastTtl({ ...base, actions: [{ label: "Undo", onClick: () => {} }] })).toBeNull();
+    expect(toastTtl({ ...base, actions: [{ label: "Save", onClick: () => {} }] })).toBeNull();
     expect(
       toastTtl({ ...base, actions: [{ label: "Remind me", onClick: () => {} }, { label: "Keep going", onClick: () => {} }] }),
     ).toBeNull();

--- a/src/renderer/settingsApply.ts
+++ b/src/renderer/settingsApply.ts
@@ -4,24 +4,14 @@
 //
 // The stomping bug (sub-issue 13 §"The bug") is fixed by removing the
 // per-field local state + resync effect that overwrote unsaved text. These
-// helpers write to the store directly (optimistic) then to configUpdate,
-// with a toast carrying an Undo action — the "one save model: instant
-// apply + Undo" from §A.
+// helpers write to the store directly (optimistic) then to configUpdate.
+// Success raises no toast (BET-1055); failure rolls back + raises an error.
 
 import { useStore } from "./store";
 import { applyTheme, type ThemePref } from "./theme";
 import type { ToastItem } from "./Toast";
 import { errorDisclosure } from "./settingsError";
 import type { SettingEntry } from "../shared/settingsSchema";
-
-function describeValue(entry: SettingEntry, value: unknown): string {
-  if (entry.control === "toggle") return value ? "on" : "off";
-  if (entry.control === "segmented") {
-    const opt = entry.options?.find((o) => o.value === String(value));
-    return opt?.label ?? String(value);
-  }
-  return String(value);
-}
 
 /**
  * Coerce a UI-produced value to the entry's stored type. Segmented controls
@@ -41,8 +31,9 @@ function coerceSettingValue(entry: SettingEntry, value: unknown): unknown {
 
 /**
  * Instant-apply a single config key. Optimistic store update → configUpdate →
- * reconcile → toast with Undo. Rolls back + raises an error toast on failure.
- * Never throws to the caller. `prevValue` is captured for the Undo action.
+ * reconcile. On failure, rolls back to `prevValue` and raises an error toast.
+ * Success raises no toast (BET-1055). Never throws to the caller. `prevValue`
+ * is captured for rollback on failure.
  */
 export function useApplySetting(pushToast: (t: ToastItem) => void) {
   return async (entry: SettingEntry, value: unknown, prevValue: unknown) => {
@@ -55,23 +46,6 @@ export function useApplySetting(pushToast: (t: ToastItem) => void) {
       const next = await window.api.configUpdate({ [key]: value });
       const reconciled = (next as Record<string, unknown>)[key];
       useStore.setState({ [key]: reconciled ?? value });
-      pushToast({
-        id: `apply-${key}-${Date.now()}`,
-        message: `${entry.label} set to ${describeValue(entry, value)}`,
-        actions: [{
-          label: "Undo",
-          onClick: () => {
-            void useStore.setState({ [key]: prevValue });
-            if (key === "theme") applyTheme(prevValue as ThemePref);
-            window.api.configUpdate({ [key]: prevValue })
-              .then((r) => {
-                const back = (r as Record<string, unknown>)[key];
-                useStore.setState({ [key]: back ?? prevValue });
-              })
-              .catch(() => {});
-          },
-        }],
-      });
     } catch (e) {
       useStore.setState({ [key]: prevValue });
       if (key === "theme") applyTheme(prevValue as ThemePref);


### PR DESCRIPTION
BET-1055 — Settings: remove Undo from every toast; toasts become error-only.

**Base: origin/main @ `50656656`**

Settings no longer pushes a confirmation toast with an Undo action after a
successful change. Successful settings changes raise NO toast (the new value is
visible in the row itself); only failures raise an error toast. This also
removes the class of toasts that carry an action and therefore never
auto-dismiss and pile up in the corner.

### Changes

- **`settingsApply.ts`** — dropped the success toast + `describeValue` (it only fed the "set to X" copy, now dead). Kept the error toast and kept `prevValue` (still needed to roll back in the `catch`).
- **`Settings.tsx`** — dropped the success toasts in `persistRegistryUrls` (#3), `togglePlugins` (#4), `toggleForgeRules` (#5) and `resetAll` (#7); kept each error toast and each `catch` rollback (so `prev` is retained where the catch uses it). **`togglePlugins` now calls `requestRestart()`** instead of a toast: the "restart Manta to apply" hint is surfaced by the existing restart banner (verified the banner does NOT otherwise fire for the plugins toggle). `disconnectForge` (#6) deliberately left exactly as-is (informational toast, no Undo).
- **`App.tsx`** — **scope note:** the reminder-set toast's Undo action was also removed. The issue's enumerated table (1–7) is Settings-only, but its explicit "Done when" gate is `grep -rn '"Undo"' src/renderer/` returning zero — this App.tsx toast was the only other remaining `"Undo"` literal, and it's the same "confirmation toast with an action that never auto-dismisses" class the ticket exists to remove. Flagging it so the one extra site is visible. It does not touch the Toast primitive or store.
- **constraint check** — did NOT modify `Toast.tsx`, the toast store slice (`store.ts`), or `GlobalToasts.tsx`. `grep '"Undo"' src/renderer/` → 0.
- **Tests** — Toast.test fixture action renamed "Undo"→"Save" (neutral, no Settings connotation); BET-1055 comment added to the forge-disconnect invariant test; two new cases pin error-only schema-driven toasts (no toast on success, exactly one disclosure toast on failure).

### Verification results

- PR branch (`multica/BET-1055-remove-undo-toasts` @ `58571c3b`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, **2285 pass / 0 fail / 0 skip**.
- Base (`main` @ `50656656`): not re-run (no new dependency or base-sensitive logic; renderer-only change, base branches cleanly).
- **Conclusion:** 0 new failures; the full suite is green. Diff is a net deletion in source (`settingsApply` −26, `Settings` −11, `App` −9 net); the added lines are the tests the ticket mandates.
