### PR TITLE
Settings: remove duplicated pane chrome, drop Box ID, fix reset-row layout, add credential-save state (BET-1058)

### DIFF
--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -364,11 +364,8 @@ export function ModelsCard() {
   }, [models, searchQuery]);
 
   return (
-    <div className="space-y-3 pt-2 border-t border-border">
+    <div className="space-y-3">
       <div>
-        <label className="block text-micro font-semibold uppercase text-text-muted mb-1">
-          Models
-        </label>
         <div className="text-meta text-text-faint">
           <b className="text-text-muted">Default</b> = the model new &amp; cleared sessions start on (exactly one; must be Main-available).{" "}
           <b className="text-text-muted">Main</b> = selectable as the chat main agent (off hides it from the composer's model picker).{" "}

--- a/src/renderer/ProvidersCard.tsx
+++ b/src/renderer/ProvidersCard.tsx
@@ -89,11 +89,6 @@ export function ProvidersCard({ onRestartNeeded }: Props) {
 
   return (
     <div className="space-y-2">
-      <div className="text-meta text-text-faint">
-        OpenAI-compatible endpoints opencode can serve. Refresh to discover models,
-        then enable the ones you want in the model picker.
-      </div>
-
       {error && <div className="text-meta text-danger">{error}</div>}
 
       {loading ? (

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -162,12 +162,13 @@ function SegmentedField({ entry, value, onApply }: {
 // confirmation (role=status), no toast. The ONE blur-commit exception called
 // out in the spec.
 function SettingField({ entry, value, onCommit, credential }: {
-  entry: SettingEntry; value: string; onCommit: (v: string) => void;
+  entry: SettingEntry; value: string; onCommit: (v: string) => void | Promise<void>;
   credential?: boolean;
 }) {
   const id = fieldId(entry);
   const [draft, setDraft] = useState(value);
   const [savedAt, setSavedAt] = useState<number | null>(null);
+  const [saving, setSaving] = useState(false);
   const focused = useRef(false);
   // Keep the draft in sync with the store ONLY when the field is NOT focused
   // (so an external change — a rollback, a reset — is picked up,
@@ -187,14 +188,29 @@ function SettingField({ entry, value, onCommit, credential }: {
       onFocus={() => { focused.current = true; }}
       onBlur={() => {
         focused.current = false;
-        if (draft !== value) {
-          onCommit(draft);
-          if (credential) setSavedAt(Date.now());
+        if (draft !== value && !saving) {
+          void (async () => {
+            setSaving(true);
+            try {
+              await onCommit(draft);
+              if (credential) setSavedAt(Date.now());
+            } finally {
+              setSaving(false);
+            }
+          })();
         }
       }}
       autoComplete={credential ? "off" : undefined}
       help={entry.help}
-      footer={credential && savedAt ? <div role="status" className="text-meta text-ok">Saved</div> : undefined}
+      footer={
+        saving ? (
+          <div role="status" className="text-meta text-text-faint flex items-center gap-2">
+            <MantaLoader size="inline" /> Saving…
+          </div>
+        ) : credential && savedAt ? (
+          <div role="status" className="text-meta text-ok">Saved</div>
+        ) : undefined
+      }
     />
   );
 }
@@ -281,7 +297,6 @@ export function Settings({
   const updatePrompt = useStore((s) => s.updatePrompt);
   const boxToken = useStore((s) => s.boxToken);
   const serverUrl = useStore((s) => s.serverUrl);
-  const boxId = useStore((s) => s.boxId);
   const push = useStore((s) => s.pushAppToast);
   const applySetting = useApplySetting(push);
   const dialogRef = useDialog(onClose);
@@ -654,10 +669,10 @@ export function Settings({
       case "segmented":
         return <SegmentedField entry={entry} value={String(cur ?? "")} onApply={(v) => void commitKey(entry, v)} />;
       case "password":
-        return <SettingField credential entry={entry} value={String(cur ?? "")} onCommit={(v) => void commitKey(entry, v.trim())} />;
+        return <SettingField credential entry={entry} value={String(cur ?? "")} onCommit={(v) => commitKey(entry, v.trim())} />;
       case "text":
       case "path":
-        return <SettingField entry={entry} value={String(cur ?? "")} onCommit={(v) => void commitKey(entry, v)} />;
+        return <SettingField entry={entry} value={String(cur ?? "")} onCommit={(v) => commitKey(entry, v)} />;
       default:
         return null;
     }
@@ -682,7 +697,7 @@ export function Settings({
             )}
           </GroupCard>
           <GroupCard title="Danger zone" danger>
-            <div className="flex items-start justify-between gap-4">
+            <div className="space-y-3">
               <div className="text-body text-text-faint">Restore every setting below to its default. This does not remove your box pairing or projects.</div>
               <Button onClick={() => setConfirmReset(true)} tone="danger">Reset all settings…</Button>
             </div>
@@ -706,10 +721,6 @@ export function Settings({
                 <dt className="text-text-faint shrink-0">Server URL</dt>
                 <dd className="text-text-muted font-mono break-all">{serverUrl || "—"}</dd>
               </div>
-              <div className="flex gap-2">
-                <dt className="text-text-faint shrink-0">Box ID</dt>
-                <dd className="text-text-muted font-mono break-all">{boxId || "—"}</dd>
-              </div>
               {serverVersion && (
                 <div className="flex gap-2">
                   <dt className="text-text-faint shrink-0">Server</dt>
@@ -721,7 +732,7 @@ export function Settings({
 
           <GroupCard title="Devices">
             <AddPhonePanel />
-            <div className="flex items-center justify-between">
+            <div className="space-y-3">
               <div className="text-body text-text-faint">Re-run the guided setup (pairing, providers, first project).</div>
               <Button onClick={() => { void useStore.getState().relaunchOnboarding(); onClose(); }} tone="default">Run setup again</Button>
             </div>
@@ -751,7 +762,7 @@ export function Settings({
           </GroupCard>
 
           <GroupCard title="Danger zone" danger>
-            <div className="flex items-center justify-between">
+            <div className="space-y-3">
               <div className="text-body text-text-faint">Forget this box on the desktop. If the box is reachable, its current token is revoked too.</div>
               <Button onClick={() => setConfirmRemove(true)} disabled={removingBox} tone="default">
                 {removingBox ? "Removing…" : "Remove box"}
@@ -781,7 +792,7 @@ export function Settings({
     }
     if (section === "models") {
       return (
-        <GroupCard>
+        <GroupCard title="Models">
           <ModelsCard />
         </GroupCard>
       );

--- a/src/renderer/SubscriptionsCard.tsx
+++ b/src/renderer/SubscriptionsCard.tsx
@@ -67,10 +67,7 @@ export function SubscriptionsCard() {
   }, [refresh]);
 
   return (
-    <div className="space-y-2 pt-2 border-t border-border">
-      <label className="block text-micro font-semibold uppercase text-text-muted">
-        Subscriptions
-      </label>
+    <div className="space-y-2">
       <div className="text-meta text-text-faint space-y-1">
         <div>
           Sign in with a subscription you already pay for. Manta never sees


### PR DESCRIPTION
Five small, independent cleanups in the desktop Settings dialog. All decisions already made in BET-1058.

## Changes

1. **SubscriptionsCard** — removed the duplicated `Subscriptions` label + top border (the `GroupCard title="Subscriptions"` already provides the heading).
2. **ModelsCard** — removed the duplicated `Models` label + top border; the descriptive paragraph stays. Gave the previously untitled wrapping card `title="Models"`.
3. **ProvidersCard** — removed the helper copy duplicated from `Settings.tsx` (the Custom endpoints card keeps the one in Settings).
4. **Box tab** — removed the "Box ID" row and the now-unused `boxId` store selector (Server URL / connection status / server version remain). `boxId` stays in the store — other code uses it.
5. **Danger/action rows** — the "Reset all settings", "Run setup again", and "Remove box" rows now stack the explanation above the button (`space-y-3`) instead of squeezing them into one `justify-between` row, so the button never wraps on narrow windows.
6. **Credential-save state** — `SettingField` gained a `saving` state shown as `MantaLoader inline` + "Saving…"; `onCommit` is now awaitable (`void | Promise<void>`), the two call sites drop their `void`, and "Saved" only renders after the commit resolves. Non-credential text fields share the same path (one code path, not two).

## Constraints honored
- Net deletion overall; only additions are the stacked-row markup + the `saving` state.
- Tailwind token classes only (`space-y-3`, `text-meta`, `text-text-faint`, `gap-2`, `flex`) — no new CSS vars / hex / px.
- No `className`/`size` added to any primitive; nothing added to `MantaLoader`. No new files / deps / RPC / server changes.

**Base: origin/main @ c10c3f22**

**Files changed:** 4 files (all `src/renderer/`): Settings.tsx, ModelsCard.tsx, ProvidersCard.tsx, SubscriptionsCard.tsx.

**Verification results:**
- PR branch (`multica/BET-1058-settings-pane-chrome-cleanup` @ 56155b3):
  - typecheck: exit 0, no errors
  - test: exit 0, 2300 pass / 0 fail / 0 skip / 0 todo
- Base (`main` @ c10c3f22):
  - typecheck: exit 0, no errors
  - test: exit 0, 2300 pass
- **Conclusion:** 0 new failures; no test failures introduced by this PR.

Manual flows to eyeball (Cmd+,): Accounts → "Subscriptions" once + no stray rule; Custom endpoints helper copy once; Models → "Models" as card title + no stray rule; Box tab → no Box ID; General → Danger zone rows stacked with button never wrapping.