### PR TITLE
fix(box): tailnet boxes hand out dead public URLs — flip publicBaseUrl precedence (BET-1065)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -709,11 +709,13 @@ generates on the box. Follows the same "MantaUI tools" pattern as the scheduler
   one Caddy already reverse-proxies to `127.0.0.1:8787` for the SPA, with an
   automatic LE cert — nothing new to provision. `gateway_host` is read fresh
   per call from `~/.manta/auth.json` via `publicBaseUrl()` in
-  `gatewayRegister.mjs`. **Resolution order (BET-349):** `gateway_host`
-  wins; a Tailscale-only box with no `gateway_host` falls back to the
-  tailnet `serverUrl` in `~/.manta/ingress.json`; otherwise `registerPage`
-  fails loudly with a clear error — never hands back a URL that would
-  silently 404 (BET-343).
+   `gatewayRegister.mjs`. **Resolution order (BET-349):** a Tailscale-mode
+   box's tailnet `serverUrl` in `~/.manta/ingress.json` wins, because a
+   tailnet box still registers with the gateway (for the APNs token) so it
+   HAS a `gateway_host` even though nothing listens on it — that hostname is
+   not evidence of public reachability; otherwise `gateway_host` from
+   `~/.manta/auth.json`; else `registerPage` fails loudly with a clear
+   error — never hands back a URL that would silently 404 (BET-343).
 - **Sandbox CSP is load-bearing.** Pages now share an origin with the SPA
   (which keeps the box_token in localStorage), so the response carries
   `Content-Security-Policy: sandbox allow-scripts allow-forms allow-popups

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -1474,8 +1474,10 @@ main() {
   # --- B/C. Register with the gateway + persist gateway_token -------------
   # B (POST /register) and C (merge-gateway into auth.json) are user-space and
   # run in BOTH ingress modes. On tailscale the gateway records an A record
-  # that is unused but harmless; the persisted gateway_token is still the
-  # APNs push credential (BET-198). On the PUBLIC path a registration failure
+  # that is unused on this path and must NEVER be treated as evidence of
+  # public reachability (nothing terminates TLS on it); the persisted
+  # gateway_token is still the APNs push credential (BET-198). On the PUBLIC
+  # path a registration failure
   # is fatal (there is no public ingress without it); on tailscale / macOS it
   # stays a warn — the server re-registers on every restart and the APNs token
   # is best-effort at install time.

--- a/src/server/gatewayRegister.mjs
+++ b/src/server/gatewayRegister.mjs
@@ -56,10 +56,13 @@ export function loadAuthFile(path) {
 
 // The box's own public base URL, or "" when the box has no reachable
 // hostname. Resolves in order:
-//   1. gateway_host from auth.json → https://<host> (published FQDN wins)
-//   2. serverUrl from ingress.json, only when mode === "tailscale"
-//      (Tailscale-only box — the tailnet address IS reachable from the tailnet)
+//   1. serverUrl from ingress.json when mode === "tailscale" — the only
+//      reachable address on that path (installer skips Caddy / public TLS).
+//   2. gateway_host from auth.json → https://<host>
 //   3. "" (unaddressable — caller must refuse rather than return a 404 URL)
+//
+// A tailnet box still registers with the gateway (APNs push token), so
+// gateway_host is NOT evidence anything listens on it.
 //
 // Reads both files fresh on each call: registerWithGateway() may write
 // gateway_host AFTER the server has booted, and install.sh may rewrite
@@ -68,14 +71,12 @@ export function loadAuthFile(path) {
 // rather than auth.mjs's loadAuth() because the latter deliberately drops
 // gateway_host (only returns {box_id, box_token, created_at}).
 export function publicBaseUrl(path = DEFAULT_AUTH_PATH) {
-  const auth = loadAuthFile(path);
-  const host = auth?.gateway_host;
-  if (typeof host === "string" && host) return `https://${host}`;
-
   const ingress = loadAuthFile(join(dirname(path), "ingress.json"));
   if (ingress?.mode === "tailscale" && typeof ingress.serverUrl === "string" && ingress.serverUrl) {
     return ingress.serverUrl;
   }
+  const host = loadAuthFile(path)?.gateway_host;
+  if (typeof host === "string" && host) return `https://${host}`;
   return "";
 }
 

--- a/src/server/gatewayRegister.test.mjs
+++ b/src/server/gatewayRegister.test.mjs
@@ -418,14 +418,15 @@ test("publicBaseUrl reads fresh on each call (no module-scope cache)", async () 
 });
 
 // ----------------------------------------------------------------------------
-// publicBaseUrl — tailscale fallback (BET-349). A Tailscale-only box never
-// registers with the gateway (no gateway_host), but it has a reachable
-// tailnet address recorded in ~/.manta/ingress.json. The resolver MUST fall
-// back to ingress.json's serverUrl when mode === "tailscale", else serve_page
-// refuses to register a page on what is in fact a reachable box.
+// publicBaseUrl — tailscale precedence (BET-349). A Tailscale-only box DOES
+// register with the gateway (it needs the gateway_token for APNs push), so it
+// has a gateway_host even though nothing listens on it — that hostname is not
+// evidence of public reachability. The resolver MUST therefore win for the
+// ingress.json serverUrl when mode === "tailscale": it is the only reachable
+// address on that path.
 // ----------------------------------------------------------------------------
 
-test("publicBaseUrl: gateway_host wins over a tailscale ingress.json", async () => {
+test("publicBaseUrl: tailscale ingress.json wins over gateway_host", async () => {
   const path = tmpAuthPath("public-base-gateway-wins");
   await writeAuth(path, {
     box_id: BOX_ID,
@@ -438,7 +439,7 @@ test("publicBaseUrl: gateway_host wins over a tailscale ingress.json", async () 
     tailnetIp: "100.64.0.1",
     serverUrl: "http://100.64.0.1:8787",
   }, null, 2), { mode: 0o600 });
-  assert.equal(publicBaseUrl(path), `https://${BOX_ID}.boxes.mantaui.com`);
+  assert.equal(publicBaseUrl(path), "http://100.64.0.1:8787");
 });
 
 test("publicBaseUrl: tailscale ingress.json when no gateway_host (BET-349 regression)", async () => {


### PR DESCRIPTION
Fixes BET-1065

## What changed

Flips the precedence in `publicBaseUrl()` (`src/server/gatewayRegister.mjs`) so a recorded Tailscale ingress wins over `gateway_host`:

- **Before:** `gateway_host` from `auth.json` → `https://<host>`; only fell back to the tailnet `serverUrl` when `gateway_host` was absent.
- **After:** `serverUrl` from `ingress.json` wins when `mode === "tailscale"`, then `gateway_host`, then `""`.

## Why

A Tailscale-only box still registers with the gateway (it needs the APNs push token), so it HAS a `gateway_host` even though nothing listens on that hostname (the installer skips Caddy/public TLS on the tailnet path). The old ordering handed out dead public URLs for every page/plan/webhook on a tailnet box. The tailnet address is the reachable one.

## Scope

- Resolver reordering only — no new helper/config key/probe, no call-site changes.
- Flipped the one test whose setup already covered this exact case (renamed to `publicBaseUrl: tailscale ingress.json wins over gateway_host`, expected value now the tailnet URL); the other five `publicBaseUrl` tests pass unchanged.
- Two comment corrections (`AGENTS.md`, `scripts/install.sh`) that taught the old (wrong) model.
- No installer/forge/reachability changes — explicitly out of scope.

**Files changed:** 4 files: `src/server/gatewayRegister.mjs`, `src/server/gatewayRegister.test.mjs`, `AGENTS.md`, `scripts/install.sh`

**Base:** origin/main @ `2907b21c`

**Verification results:**
- PR branch (`multica/BET-1065-flip-publicbaseurl-precedence` @ `dcaecf02`):
  - typecheck: exit 0, no errors. log sha256: `a4eb8fdea59d7e94f94fefa4d71ab4a89d312b344e6821a9e0c3b26923dd4979`
  - test: exit 0, `2981 passed | 7 skipped (vitest)` + `2300 pass / 0 fail (node:test)`. log sha256: `656e780aaae4b4530e2707579da1bd59eb656949309ec037b52c000ffb6a9396`
- Base (`origin/main` @ `2907b21c`, checked out via worktree to a pristine tree):
  - typecheck: exit 0, no errors. log sha256: `a4eb8fdea59d7e94f94fefa4d71ab4a89d312b344e6821a9e0c3b26923dd4979`
  - test: exit 0, `2981 passed | 7 skipped (vitest)` + `2300 pass / 0 fail (node:test)`. log sha256: `0e79fe34aace1897789b6371b5edf92f909d9920c92633dc64df875ecec2d78e`
- **Conclusion:** 0 new failures, 0 resolved. The flipped test asserts the tailnet URL; the untouched five `publicBaseUrl` tests (public-mode / no-ingress / malformed-ingress / empty-host / fresh-read) pass unchanged, proving public-mode boxes are unaffected.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-main.log`.
