### PR TITLE
refactor(ios): single source for voice gesture thresholds; widen slide-to-cancel (BET-1068)

### DIFF
--- a/mobile/native/MantaUI/VoiceGesture.swift
+++ b/mobile/native/MantaUI/VoiceGesture.swift
@@ -82,16 +82,27 @@ enum VoiceInput: Equatable {
 
 enum VoiceGesture {
 
+    /// The two distances the recording gesture is defined by, in points. The
+    /// machine DECIDES with these and the view DRAWS with them, so they live in
+    /// exactly one place — a view that filled its lane against a different number
+    /// than the machine acted on would show you a lie.
+    enum Thresholds {
+        /// Drag up this far to arm the lock.
+        static let lock: Double = 80
+        /// Drag left (mirrored in RTL) this far to arm cancel.
+        static let cancel: Double = 96
+    }
+
     /// The whole machine. Thresholds are parameters with defaults
-    /// `lockThreshold = 80pt`, `cancelThreshold = 64pt`.
+    /// `lockThreshold = Thresholds.lock`, `cancelThreshold = Thresholds.cancel`.
     /// `isRTL` mirrors the horizontal drag direction for right-to-left layouts.
     static func transition(
         currentPhase: VoicePhase,
         input: VoiceInput,
         elapsedMs: Int,
         isRTL: Bool = false,
-        lockThreshold: Double = 80,
-        cancelThreshold: Double = 64
+        lockThreshold: Double = Thresholds.lock,
+        cancelThreshold: Double = Thresholds.cancel
     ) -> (VoicePhase, VoiceEffect) {
 
         // An external interruption invalidates the take from any phase — it
@@ -222,7 +233,7 @@ enum VoiceGesture {
     /// the vertical axis, so `isRTL` is deliberately absent. The view uses this
     /// to brighten the lock lane / scale its glyph as the lock threshold is
     /// approached; it must NOT decide the transition itself.
-    static func lockProgress(dy: Double, threshold: Double = 80) -> Double {
+    static func lockProgress(dy: Double, threshold: Double = Thresholds.lock) -> Double {
         guard threshold > 0 else { return 0 }
         return min(1, max(0, -dy / threshold))
     }
@@ -230,7 +241,7 @@ enum VoiceGesture {
     /// 0...1 of how far the horizontal drag is toward the cancel threshold,
     /// with the direction mirrored for RTL (mirrors the machine's own mirror
     /// so the hint/veil track the true cancel direction). Clamped.
-    static func cancelProgress(dx: Double, isRTL: Bool, threshold: Double = 64) -> Double {
+    static func cancelProgress(dx: Double, isRTL: Bool, threshold: Double = Thresholds.cancel) -> Double {
         let x = isRTL ? -dx : dx
         guard threshold > 0 else { return 0 }
         return min(1, max(0, -x / threshold))

--- a/mobile/native/MantaUITests/VoiceGestureTests.swift
+++ b/mobile/native/MantaUITests/VoiceGestureTests.swift
@@ -229,19 +229,28 @@ final class VoiceGestureTests: XCTestCase {
 
     func testCancelProgressLTR() {
         XCTAssertEqual(VoiceGesture.cancelProgress(dx: 0, isRTL: false), 0, accuracy: 0.0001)
-        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -64, isRTL: false), 1, accuracy: 0.0001)
-        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -32, isRTL: false), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -VoiceGesture.Thresholds.cancel, isRTL: false), 1, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -(VoiceGesture.Thresholds.cancel / 2), isRTL: false), 0.5, accuracy: 0.0001)
         // Clamped.
         XCTAssertEqual(VoiceGesture.cancelProgress(dx: -200, isRTL: false), 1, accuracy: 0.0001)
         // Dragging right is not cancel in LTR.
-        XCTAssertEqual(VoiceGesture.cancelProgress(dx: 64, isRTL: false), 0, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: VoiceGesture.Thresholds.cancel, isRTL: false), 0, accuracy: 0.0001)
     }
 
     func testCancelProgressMirrorsForRTL() {
         // In RTL the SAME physical drag (right) advances cancel, mirroring the
         // machine's own horizontal mirror.
-        XCTAssertEqual(VoiceGesture.cancelProgress(dx: 64, isRTL: true), 1, accuracy: 0.0001)
-        XCTAssertEqual(VoiceGesture.cancelProgress(dx: 32, isRTL: true), 0.5, accuracy: 0.0001)
-        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -64, isRTL: true), 0, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: VoiceGesture.Thresholds.cancel, isRTL: true), 1, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: VoiceGesture.Thresholds.cancel / 2, isRTL: true), 0.5, accuracy: 0.0001)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -VoiceGesture.Thresholds.cancel, isRTL: true), 0, accuracy: 0.0001)
+    }
+
+    func testProgressHelpersReachOneExactlyAtTheMachineThreshold() {
+        // Just short of the threshold: armed by neither, and not full on the lane.
+        XCTAssertLessThan(VoiceGesture.lockProgress(dy: -(VoiceGesture.Thresholds.lock - 1)), 1)
+        XCTAssertLessThan(VoiceGesture.cancelProgress(dx: -(VoiceGesture.Thresholds.cancel - 1), isRTL: false), 1)
+        // At the threshold: full lane, and the machine acts.
+        XCTAssertEqual(VoiceGesture.lockProgress(dy: -VoiceGesture.Thresholds.lock), 1)
+        XCTAssertEqual(VoiceGesture.cancelProgress(dx: -VoiceGesture.Thresholds.cancel, isRTL: false), 1)
     }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-1068-voice-gesture-thresholds`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1068.