### PR TITLE
fix(ios): the lock arms on drag and commits on RELEASE, not the instant you cross the threshold (BET-1069)

### DIFF
--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -916,6 +916,8 @@ struct ComposerView: View {
             }
         case .cancelling:
             recorder.stop()                               // the machine discards
+        case .lockArmed:
+            recorder.commitArmedLock()                // released at the top → hands-free
         default:
             break                                         // locked, or never armed
         }

--- a/mobile/native/MantaUI/VoiceGesture.swift
+++ b/mobile/native/MantaUI/VoiceGesture.swift
@@ -14,11 +14,11 @@ import Foundation
 //   │                                                │
 //   │ press                                          │ release(hold) → .send
 //   │                                                │ release(too short) → Idle (silent)
-//   ▼                                                │ drag up   > lockThreshold → RecordingLocked
-// RecordingLocked ◄───────────────────────────────── │ drag left > cancelThreshold → Cancelling
-//   │  tapSend ──► .send (bar button)                │ tapLock (release under tapHoldMs) → RecordingLocked
+//   ▼                                                │ drag up  > lockThreshold → LockArmed
+// RecordingLocked ◄── release(armed commits) ── LockArmed
+//   │  tapSend ──► .send (bar button)                │  └─ drag back down (< lockThreshold) → RecordingHeld
 //   │  tapDiscard ───► .discard                      │
-//   │  tapPause ──► Paused ⇄ tapResume               │
+//   │  tapPause ──► Paused ⇄ tapResume               │ drag left > cancelThreshold → Cancelling
 // Cancelling ── dragBack ──► RecordingHeld           │
 //            └─ release ──► .discard                 │
 // any ── elapsed ≥ 300_000ms ──► .send          (the take is KEPT)
@@ -37,6 +37,11 @@ import Foundation
 enum VoicePhase: Equatable {
     case idle
     case recordingHeld
+    /// The finger is still down, at or past the top of the lock lane. The lock is
+    /// ARMED, not committed — exactly like `.cancelling` on the horizontal axis.
+    /// Only the RELEASE commits it, so the user can drag back down and change
+    /// their mind.
+    case lockArmed
     case recordingLocked
     case paused
     case cancelling
@@ -118,7 +123,7 @@ enum VoiceGesture {
         // Reaching the hard cap within a recording phase SENDS the take; it is
         // kept, never discarded (decision #6). Paused time never counts toward
         // the cap, so the caller's rebased elapsed only reaches it while live.
-        if (currentPhase == .recordingHeld || currentPhase == .recordingLocked),
+        if (currentPhase == .recordingHeld || currentPhase == .lockArmed || currentPhase == .recordingLocked),
            elapsedMs >= Waveform.Constants.maxDurationMs {
             return (.idle, .send)
         }
@@ -146,6 +151,10 @@ enum VoiceGesture {
                 return (.idle, .send)
             case .cancelling:
                 return (.idle, .discard)
+            case .lockArmed:
+                // Released at the top of the lane: the take goes hands-free. It is NOT
+                // sent — the bar's own send button is the only thing that sends it.
+                return (.recordingLocked, .none)
             default:
                 return (currentPhase, .none)
             }
@@ -201,14 +210,22 @@ enum VoiceGesture {
         switch currentPhase {
         case .recordingHeld:
             if dy < -lockThreshold {
-                // slide up to lock the take
-                return (.recordingLocked, .haptic(.lock))
+                // Slide up ARMS the lock; the release commits it.
+                return (.lockArmed, .haptic(.lock))
             }
             if x < -cancelThreshold {
                 // slide left to arm cancel (mirrored for RTL upstream)
                 return (.cancelling, .haptic(.cancelArmed))
             }
             return (.recordingHeld, .none)
+
+        case .lockArmed:
+            // Dragging back down out of the lock zone disarms it, exactly as dragging
+            // back out of the cancel zone returns a `.cancelling` take to held.
+            if dy >= -lockThreshold {
+                return (.recordingHeld, .none)
+            }
+            return (.lockArmed, .none)
 
         case .cancelling:
             // dragging back out of the cancel zone returns to the held take

--- a/mobile/native/MantaUI/VoiceRecorder.swift
+++ b/mobile/native/MantaUI/VoiceRecorder.swift
@@ -46,11 +46,11 @@ final class VoiceRecorder: ObservableObject {
 
     /// Whether capture is actively running (the take is live on the mic).
     var isRecording: Bool {
-        phase == .recordingHeld || phase == .recordingLocked
+        phase == .recordingHeld || phase == .lockArmed || phase == .recordingLocked
     }
 
-    /// A take with a finger down on it (the armed-cancel state included).
-    var isHeld: Bool { phase == .recordingHeld || phase == .cancelling }
+    /// A take with a finger down on it (both armed states included).
+    var isHeld: Bool { phase == .recordingHeld || phase == .cancelling || phase == .lockArmed }
 
     /// A take that no longer needs the finger: the hands-free bar owns it.
     var isHandsFree: Bool { phase == .recordingLocked || phase == .paused }
@@ -214,7 +214,7 @@ final class VoiceRecorder: ObservableObject {
     /// view can play the haptic the machine asked for.
     @discardableResult
     func drag(dx: Double, dy: Double, isRTL: Bool = false) -> VoiceEffect {
-        guard phase == .recordingHeld || phase == .cancelling else { return .none }
+        guard phase == .recordingHeld || phase == .cancelling || phase == .lockArmed else { return .none }
         let (next, effect) = VoiceGesture.transition(
             currentPhase: phase, input: .drag(dx: dx, dy: dy),
             elapsedMs: currentElapsedMs(), isRTL: isRTL)
@@ -231,6 +231,18 @@ final class VoiceRecorder: ObservableObject {
             currentPhase: phase, input: .tapLock, elapsedMs: currentElapsedMs())
         publishHaptic(effect)
         guard next != phase else { return }
+        phase = next
+    }
+
+    /// Commit an ARMED lock: the finger left the screen at the top of the lock
+    /// lane, so the take goes hands-free rather than being sent. The mirror of a
+    /// release while `.cancelling`, which discards — the drag ARMS, the release
+    /// COMMITS.
+    func commitArmedLock() {
+        guard phase == .lockArmed else { return }
+        let (next, effect) = VoiceGesture.transition(
+            currentPhase: phase, input: .release, elapsedMs: currentElapsedMs())
+        publishHaptic(effect)
         phase = next
     }
 

--- a/mobile/native/MantaUITests/VoiceGestureTests.swift
+++ b/mobile/native/MantaUITests/VoiceGestureTests.swift
@@ -49,10 +49,33 @@ final class VoiceGestureTests: XCTestCase {
 
     // MARK: - drag to lock / cancel
 
-    func testDragUpLocks() {
+    func testDragUpArmsTheLockButDoesNotCommitIt() {
         let (phase, effect) = step(.recordingHeld, .drag(dx: 0, dy: -100), elapsedMs: 100)
-        XCTAssertEqual(phase, .recordingLocked)
+        XCTAssertEqual(phase, .lockArmed)
         XCTAssertEqual(effect, .haptic(.lock))
+    }
+
+    func testDragBackDownFromArmedReturnsToHeld() {
+        let (phase, _) = step(.lockArmed, .drag(dx: 0, dy: -10), elapsedMs: 200)
+        XCTAssertEqual(phase, .recordingHeld)
+    }
+
+    func testReleaseWhileArmedLocks() {
+        let (phase, effect) = step(.lockArmed, .release, elapsedMs: 3000)
+        XCTAssertEqual(phase, .recordingLocked)
+        XCTAssertEqual(effect, .none)
+    }
+
+    func testCapSendsFromArmedToo() {
+        let (phase, effect) = step(.lockArmed, .tick, elapsedMs: Waveform.Constants.maxDurationMs)
+        XCTAssertEqual(phase, .idle)
+        XCTAssertEqual(effect, .send)
+    }
+
+    func testInterruptedWhileArmedDiscards() {
+        let (phase, effect) = step(.lockArmed, .interrupted, elapsedMs: 2000)
+        XCTAssertEqual(phase, .idle)
+        XCTAssertEqual(effect, .discard)
     }
 
     func testLockedTakeIgnoresFurtherDrags() {


### PR DESCRIPTION
Fixes BET-1069 — the lock phase now ARMS on drag and COMMITS on RELEASE, mirroring the cancel lane.

## What changed
- `.recordingHeld` drag up → `.lockArmed` (haptic on arm only) instead of jumping straight to `.recordingLocked`.
- `.lockArmed` drag back down → `.recordingHeld` (disarm); release at the top → `.recordingLocked` (hands-free, not sent).
- `.lockArmed` added to the hard-cap guard, `isRecording`, `isHeld`, and the `drag` guard.
- `commitArmedLock()` commits an armed take on release from the composer; header ASCII diagram updated.

## Verification
- iOS Simulator build OK; `MantaUITests` unit suite passes (524 tests / 0 failures, 33 `VoiceGestureTests` green) — confirmed by the Mac host.
- `VoiceGestureTests` rewritten: `testDragUpArmsTheLockButDoesNotCommitIt`, `testDragBackDownFromArmedReturnsToHeld`, `testReleaseWhileArmedLocks`, `testCapSendsFromArmedToo`, `testInterruptedWhileArmedDiscards`.
- Reviewer: clean PASS (0 Blocks, 0 Questions).
