### PR TITLE
chore(release): bump to 0.0.36 (BET-1065 fix deploy)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.35",
+      "version": "0.0.36",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.35",
+  "version": "0.0.36",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.35",
+ "version": "0.0.36",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Deploy gate for BET-1065 (tailnet boxes hand out dead public URLs).

- bump package.json + package-lock.json to 0.0.36 (server version compared by the update banner)
- bump website/updates/server.json to 0.0.36 (the feed boxes poll for the banner)

The BET-1065 code fix is already merged to main (PR #1066). This only raises the version so affected boxes surface the 'Server update available' banner. Merging this is the prerequisite to cutting server-v34 + web-v34.