### PR TITLE
fix(renderer): folder picker returns one absolute-path listing, no 20-entry cap (BET-1072)

### DIFF
--- a/src/renderer/FolderPickerModal.test.tsx
+++ b/src/renderer/FolderPickerModal.test.tsx
@@ -32,10 +32,19 @@ describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () =>
   it("first Escape dismisses a live suggestion; second Escape closes the dialog", async () => {
     let cancelled = 0;
     installMockApi({
-      fsListDirs: (dir: unknown) =>
-        dir === "/home/dev/pro"
-          ? Promise.resolve(["/home/dev/projects"])
-          : Promise.resolve(["/home/dev"]),
+      fsListDirs: (dir: unknown) => {
+        const d = dir as string;
+        if (d === "/home/dev") {
+          return Promise.resolve({
+            dir: d,
+            entries: [{ name: "projects", path: "/home/dev/projects", hidden: false }],
+          });
+        }
+        return Promise.resolve({
+          dir: d,
+          entries: [{ name: "dev", path: "/home/dev", hidden: false }],
+        });
+      },
       gitListWorktrees: () => Promise.reject(new Error("not a repo")),
     });
     h = mount(
@@ -78,7 +87,8 @@ describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () =>
   it("Escape with no suggestion closes on the first press (unchanged case)", async () => {
     let cancelled = 0;
     installMockApi({
-      fsListDirs: () => Promise.resolve([]),
+      fsListDirs: (dir: unknown) =>
+        Promise.resolve({ dir: dir as string, entries: [] }),
       gitListWorktrees: () => Promise.reject(new Error("not a repo")),
     });
     h = mount(

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -12,7 +12,7 @@
 // - Footer: the selected folder's git state, Cancel, and a primary Select.
 // - Mobile gets it as a full-height sheet (handled by .mobile-* CSS classes).
 //
-// Pure helpers (breadcrumbs / parentPath / isDimmedDir / worktreeBadge /
+// Pure helpers (breadcrumbs / parentPath / worktreeBadge /
 // gitStateLabel) live in folderPicker.ts and are unit-tested there.
 
 import { useEffect, useRef, useState } from "react";
@@ -29,7 +29,6 @@ import {
   crumbLabel,
   gitStateLabel,
   hasWorktreeFanOut,
-  isDimmedDir,
   parentPath,
   worktreeBadge,
 } from "./folderPicker";
@@ -39,7 +38,8 @@ import { Button } from "./Button";
 type Props = {
   // Controlled presence. Kept MOUNTED so Modal can play its exit animation.
   open: boolean;
-  // The initial path the picker opens at. Usually "~" or the project's cwd.
+  // The initial path the picker opens at (e.g. the project's cwd). Normalized
+  // to absolute on first list (a leading ~ resolves via the server).
   initialPath: string;
   // Called when the user picks a single folder (no fan-out).
   onSelect: (path: string) => void;
@@ -56,11 +56,10 @@ type Props = {
 };
 
 // A row in the folder list. `name` is the directory basename; `full` is the
-// path to feed back into fsListDirs when the user descends.
+// absolute path to feed back into fsListDirs when the user descends.
 type Row = {
   name: string;
   full: string;
-  dimmed: boolean;
 };
 
 // Worktree fan-out state. When the user selects a folder that has >1
@@ -109,9 +108,12 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
     }
     debounce.current = setTimeout(async () => {
       try {
-        const matches = (await window.api.fsListDirs(value)).filter((m) =>
-          m.startsWith(value),
-        );
+        const dir = value.endsWith("/") ? value : parentPath(value);
+        const prefix = value.endsWith("/") ? "" : (value.split("/").pop() ?? "");
+        const res = await window.api.fsListDirs(dir);
+        const matches = res.entries
+          .filter((e) => !e.hidden && e.name.startsWith(prefix))
+          .map((e) => e.path);
         if (matches.length === 0) {
           setSuggestion(null);
           return;
@@ -152,12 +154,16 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
     setError(null);
     setWorktreeCounts({});
     try {
-      const matches = await window.api.fsListDirs(dir);
-      const filtered = matches.filter((m) => m.startsWith(dir));
-      const built: Row[] = filtered.map((full) => {
-        const name = full.split("/").filter(Boolean).pop() ?? full;
-        return { name, full, dimmed: isDimmedDir(name) };
-      });
+      const res = await window.api.fsListDirs(dir);
+      // Normalize the path field: if the server resolved a different directory
+      // than the one we listed (e.g. a typed `~` expanded to an absolute path),
+      // set it once so no tilde survives anywhere in the UI.
+      if (res.dir.replace(/\/$/, "") !== dir.replace(/\/$/, "")) {
+        setPath(res.dir + "/");
+      }
+      const built: Row[] = res.entries
+        .filter((e) => !e.hidden)
+        .map((e) => ({ name: e.name, full: e.path }));
       setRows(built);
       // Probe the selected dir's own git state for the footer.
       try {
@@ -214,11 +220,31 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
     setPath(up);
   };
 
+  // Resolve "home": ask the server to list the home directory (empty input
+  // means home) and point the field at the returned absolute path. This is
+  // how the Home button and an empty-field Go work without any tilde in the
+  // UI or across the wire.
+  const goHome = () => {
+    setSuggestion(null);
+    void (async () => {
+      try {
+        const res = await window.api.fsListDirs("");
+        setPath((res.dir || "") + "/");
+      } catch {
+        // home probe failed — leave the field as-is
+      }
+    })();
+  };
+
   // The design's "Go" discovery trigger (§07): browse into whatever path is
   // in the field, treating it as a directory to descend into. Mirrors the
   // row-click/descend affordance for a typed (or ghost-completed) path.
   const goNavigate = () => {
-    const target = (path || "").trim() || "~";
+    const target = (path || "").trim();
+    if (!target) {
+      goHome();
+      return;
+    }
     const next = target.endsWith("/") ? target : target + "/";
     setSuggestion(null);
     setPath(next);
@@ -362,7 +388,7 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
                   at full weight (aligns to §07). */}
               <div className="flex items-center flex-wrap gap-px mt-2 text-label">
                 <button
-                  onClick={() => setPath("~")}
+                  onClick={goHome}
                   className="inline-flex items-center px-1 py-px rounded-xs text-text-faint hover:text-text"
                   title="Home"
                   aria-label="Home"
@@ -424,9 +450,8 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
                         key={r.full}
                         onClick={() => descend(r.full)}
                         className={
-                          "w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded-xs " +
-                          (r.dimmed ? "text-text-quiet" : "text-text-muted") +
-                          " hover:bg-bg-soft"
+                          "w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded-xs text-text-muted " +
+                          "hover:bg-bg-soft"
                         }
                         title={r.full}
                       >

--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -34,7 +34,7 @@
 // is the single install point).
 
 import type { Api } from "../../shared/api.js";
-import type { AvailableLauncher, OpencodeMessage, OutboxFile, ServedPageMeta, WorktreeInfo } from "../../shared/types.js";
+import type { AvailableLauncher, OpencodeMessage, OutboxFile, ServedPageMeta, WorktreeInfo, DirListing } from "../../shared/types.js";
 import { DEMO_T0, demoFsListDirs, demoGitListWorktrees, demoState } from "./demoFixture.js";
 import { pickDemoState, type DemoState } from "../demoLayout.js";
 import { useStore } from "../store.js";
@@ -499,7 +499,7 @@ const outboxList = (): Promise<OutboxFile[]> => Promise.resolve([]);
 // null and the picker's folder list renders a raw "Cannot read properties of
 // null" error in the empty-state capture. The listing is fictional (see
 // demoFixture); worktrees are empty so the footer reads "not a git repo".
-const fsListDirs = (partial: string): Promise<string[]> =>
+const fsListDirs = (partial: string): Promise<DirListing> =>
   Promise.resolve(demoFsListDirs(partial));
 
 const gitListWorktrees = (cwd: string): Promise<WorktreeInfo[]> =>

--- a/src/renderer/api/demoFixture.ts
+++ b/src/renderer/api/demoFixture.ts
@@ -31,6 +31,7 @@ import type {
   OpencodeSessionListItem,
   ServedPageMeta,
   WorktreeInfo,
+  DirListing,
 } from "../../shared/types.js";
 
 // 32-lowercase-hex — the boxId shape httpApi + transport.mjs validate against.
@@ -898,45 +899,66 @@ export const demoLaunchers: AvailableLauncher[] = [
 ];
 
 // =============================================================================
-// Folder picker listing (BET-562). The folder picker modal is opened in the
-// demo empty state by clicking the "Home" chip; `fsListDirs`/`gitListWorktrees`
+// Folder picker listing (BET-562, BET-1072). The folder picker modal is opened
+// in the demo empty state by clicking the "Home" chip; `fsListDirs`/`gitListWorktrees`
 // are NOT covered by the httpApi-shaped Proxy fallback (which resolves null
 // and would leave the list as a raw "Cannot read properties of null" error),
-// so the demo stubs a fictional home-directory listing. Fictional names only —
-// node_modules and the dot-folder are exercised deliberately so the dimmed
-// rows (isDimmedDir) appear.
+// so the demo stubs a fictional home-directory listing. All paths are absolute
+// and there is no tilde anywhere (BET-1072). The dot-folder `.config` is
+// exercised deliberately so the `hidden` flag / renderer filtering appears;
+// `node_modules` is shown like any other folder.
 //
-// The `~/projects` nesting exists so the captured state can descend ONE level
-// out of "~" (a real user gesture: clicking a folder row). The empty-state
-// path is literally "~", which Playwright serialises as `textbox: ~` — and
-// `~` is YAML's null literal, so Playwright's aria snapshot rejects it with
-// "Node value should be a string or a sequence". Descending to `~/projects`
-// puts a real path in the field and makes the structure round-trip (BET-562).
+// The `/home/dev/projects` nesting exists so the captured state can descend
+// ONE level out of home (a real user gesture: clicking a folder row). The
+// empty-state path is initially "~", which `fsListDirs` resolves to absolute
+// `/home/dev` and the modal normalises into the path field (BET-562/BET-1072).
 // =============================================================================
-export const demoHomeDirs = [
-  "~/backups",
-  "~/docker",
-  "~/docs",
-  "~/infra",
-  "~/marketing",
-  "~/node_modules",
-  "~/projects",
-  "~/scripts",
-  "~/.config",
+export const DEMO_HOME = "/home/dev";
+
+const demoHomeDirs = [
+  "backups",
+  "docker",
+  "docs",
+  "infra",
+  "marketing",
+  "node_modules",
+  "projects",
+  "scripts",
+  ".config",
 ];
 
-export const demoProjectsDirs = [
-  "~/projects/ethernal",
-  "~/projects/marketing",
-  "~/projects/infra",
+const demoProjectsDirs = [
+  "ethernal",
+  "marketing",
+  "infra",
 ];
 
-export function demoFsListDirs(partial: string): string[] {
-  if (!partial) return [];
-  const p = partial.endsWith("/") ? partial : `${partial}/`;
-  if (p === "~/") return demoHomeDirs;
-  if (p === "~/projects/") return demoProjectsDirs;
-  return [...demoHomeDirs, ...demoProjectsDirs].filter((d) => d.startsWith(partial));
+function listing(dir: string, names: string[]): DirListing {
+  return {
+    dir,
+    entries: names.map((name) => ({
+      name,
+      path: `${dir}/${name}`,
+      hidden: name.startsWith("."),
+    })),
+  };
+}
+
+export function demoFsListDirs(partial: string): DirListing {
+  if (!partial) return listing(DEMO_HOME, demoHomeDirs);
+  const p = partial.endsWith("/") ? partial.slice(0, -1) : partial;
+  if (p === DEMO_HOME) return listing(DEMO_HOME, demoHomeDirs);
+  if (p === `${DEMO_HOME}/projects`) return listing(`${DEMO_HOME}/projects`, demoProjectsDirs);
+  // Type-ahead: parent dir + prefix arrived from the renderer's
+  // refreshSuggestion; filter the home listing for it.
+  if (p.startsWith(`${DEMO_HOME}/`)) {
+    const prefix = p.slice(DEMO_HOME.length + 1);
+    const matches = demoHomeDirs.filter((d) => d.startsWith(prefix));
+    return listing(DEMO_HOME, matches);
+  }
+  // Home-dependent input ("~" before the modal normalises it, or any other
+  // non-matching input) degrades to the full home listing.
+  return listing(DEMO_HOME, demoHomeDirs);
 }
 
 export function demoGitListWorktrees(_cwd: string): WorktreeInfo[] {

--- a/src/renderer/folderPicker.test.ts
+++ b/src/renderer/folderPicker.test.ts
@@ -3,7 +3,6 @@ import {
   breadcrumbs,
   crumbLabel,
   parentPath,
-  isDimmedDir,
   worktreeBadge,
   hasWorktreeFanOut,
   gitStateLabel,
@@ -21,18 +20,6 @@ describe("breadcrumbs", () => {
     expect(breadcrumbs("   ")).toEqual([]);
   });
 
-  it("handles bare tilde", () => {
-    expect(breadcrumbs("~")).toEqual(["~"]);
-  });
-
-  it("splits tilde-form paths", () => {
-    expect(breadcrumbs("~/code/foo")).toEqual([
-      "~",
-      "~/code",
-      "~/code/foo",
-    ]);
-  });
-
   it("splits absolute paths", () => {
     expect(breadcrumbs("/home/dev/code")).toEqual([
       "/",
@@ -47,17 +34,11 @@ describe("breadcrumbs", () => {
   });
 
   it("handles trailing slash", () => {
-    expect(breadcrumbs("~/code/")).toEqual(["~", "~/code"]);
+    expect(breadcrumbs("/home/dev/")).toEqual(["/", "/home", "/home/dev"]);
   });
 });
 
 describe("parentPath", () => {
-  it("goes up from tilde paths", () => {
-    expect(parentPath("~/code/foo")).toBe("~/code");
-    expect(parentPath("~/code")).toBe("~");
-    expect(parentPath("~")).toBe("~");
-  });
-
   it("goes up from absolute paths", () => {
     expect(parentPath("/home/dev/code")).toBe("/home/dev");
     expect(parentPath("/home/dev")).toBe("/home");
@@ -71,35 +52,13 @@ describe("parentPath", () => {
 });
 
 describe("crumbLabel", () => {
-  it("labels tilde", () => {
-    expect(crumbLabel("~")).toBe("~");
-  });
-
   it("labels root", () => {
     expect(crumbLabel("/")).toBe("/");
   });
 
   it("extracts the last segment", () => {
-    expect(crumbLabel("~/code/foo")).toBe("foo");
+    expect(crumbLabel("/home/dev/code")).toBe("code");
     expect(crumbLabel("/home/dev")).toBe("dev");
-  });
-});
-
-describe("isDimmedDir", () => {
-  it("dims node_modules", () => {
-    expect(isDimmedDir("node_modules")).toBe(true);
-  });
-
-  it("dims dot-folders", () => {
-    expect(isDimmedDir(".git")).toBe(true);
-    expect(isDimmedDir(".venv")).toBe(true);
-    expect(isDimmedDir(".cache")).toBe(true);
-  });
-
-  it("does not dim regular folders", () => {
-    expect(isDimmedDir("src")).toBe(false);
-    expect(isDimmedDir("my-project")).toBe(false);
-    expect(isDimmedDir("code")).toBe(false);
   });
 });
 

--- a/src/renderer/folderPicker.ts
+++ b/src/renderer/folderPicker.ts
@@ -2,45 +2,18 @@
 //
 // All functions here are pure (no I/O) so they can be unit-tested without a
 // box. The modal component in FolderPickerModal.tsx wires `window.api`
-// (fsListDirs / gitListWorktrees) to these helpers.
+// (fsListDirs / gitListWorktrees) to these helpers. The picker deals in
+// absolute paths only — there is no tilde anywhere in the UI (BET-1072).
 
 import type { WorktreeInfo } from "../shared/types";
 
-// Dimmed-but-selectable directories. `node_modules` and dot-folders render at
-// --tx4 so nothing becomes unreachable, but they recede visually. Hidden
-// files inside a listing are a different concern (fsListDirs already filters
-// to directories only); this is about *known noisy* directories that ARE
-// valid choices but visually pollute a browse.
-export function isDimmedDir(name: string): boolean {
-  if (name === "node_modules") return true;
-  // Dot-folders (.git, .venv, .cache, …). A leading dot is the convention;
-  // we do not enumerate a blocklist — the visual dim is the signal, not a
-  // permission gate.
-  return name.startsWith(".");
-}
-
-// Build clickable breadcrumbs from a path string. `~/code/foo` →
-// ["~", "~/code", "~/code/foo"]. Absolute `/home/dev/code` →
-// ["/", "/home", "/home/dev", "/home/dev/code"]. Tilde-form is preserved
-// so the chip the user picks matches what they would type.
+// Build clickable breadcrumbs from an absolute path. `/home/dev/code` →
+// ["/", "/home", "/home/dev", "/home/dev/code"].
 //
 // Returns [] for empty/invalid input (the caller renders nothing).
 export function breadcrumbs(path: string): string[] {
   const raw = (path ?? "").trim();
   if (!raw) return [];
-
-  // Tilde-form: "~/code/foo" → ["~", "~/code", "~/code/foo"]
-  if (raw === "~") return ["~"];
-  if (raw.startsWith("~/")) {
-    const parts = raw.slice(2).split("/").filter(Boolean);
-    const out: string[] = ["~"];
-    let acc = "~";
-    for (const p of parts) {
-      acc += "/" + p;
-      out.push(acc);
-    }
-    return out;
-  }
 
   // Absolute: "/home/dev/code" → ["/", "/home", "/home/dev", "/home/dev/code"]
   if (raw.startsWith("/")) {
@@ -61,19 +34,12 @@ export function breadcrumbs(path: string): string[] {
   return [raw];
 }
 
-// The parent path for a "go up one level" click. "~/code/foo" → "~/code",
-// "~/code" → "~", "~" → "~" (already at top). "/a/b" → "/a", "/a" → "/",
+// The parent path for a "go up one level" click. "/a/b" → "/a", "/a" → "/",
 // "/" → "/". Empty → "".
 export function parentPath(path: string): string {
   const raw = (path ?? "").trim();
   if (!raw) return "";
-  if (raw === "~") return "~";
   if (raw === "/") return "/";
-  if (raw.startsWith("~/")) {
-    const idx = raw.lastIndexOf("/");
-    if (idx <= 1) return "~"; // "~/x" → "~"
-    return raw.slice(0, idx);
-  }
   if (raw.startsWith("/")) {
     const idx = raw.lastIndexOf("/");
     if (idx === 0) return "/"; // "/a" → "/"
@@ -82,10 +48,9 @@ export function parentPath(path: string): string {
   return raw;
 }
 
-// Label for a breadcrumb crumb — the last segment, or "/" for root, or "~"
-// for home. Used so the clickable row shows "code" not "~/code".
+// Label for a breadcrumb crumb — the last segment, or "/" for root. Used so
+// the clickable row shows "code" not "/home/dev/code".
 export function crumbLabel(path: string): string {
-  if (path === "~") return "~";
   if (path === "/") return "/";
   const idx = path.lastIndexOf("/");
   if (idx < 0) return path;

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -263,62 +263,54 @@ export async function gitRemoveWorktree({ path: wtPath, force }) {
 }
 
 // ============================================================
-// FS: directory autocomplete (real implementation)
+// FS: directory listing (real implementation)
 // ============================================================
 //
-// Desktop: runs `ls -1Ap` over SSH and filters for dirs, filtering by prefix.
-// Mobile: same semantics but local fs via readdir.
+// fsListDirs takes a directory to LIST (no parent/prefix splitting — the
+// type-ahead prefix filter lives in the renderer, which already knows the
+// typed text). It returns a DirListing of absolute paths only; a leading `~`
+// is expanded via the shared `expandTilde` and no tilde ever crosses the RPC
+// boundary in either direction. Every subdirectory is returned — there is no
+// cap, and dot-directories are present (flag `hidden:true`) for the renderer
+// to filter. An unreadable / missing directory returns an empty entry list.
 //
-// Caller passes "partial path"; we split on the last "/".
-// ~ and "" expand to $HOME. Returns up to 20 matches.
-// Matches the desktop contract: input="~/foo" → returns ["~/foo/bar", ...] style
-// (full paths so the path picker can display them).
-//
-// fsListDirs(partial: string) → string[]
+// fsListDirs(dir: string) → Promise<DirListing>
 // preload: ipcRenderer.invoke(IPC.fsListDirs, partial) → args[0] = partial
 
-export async function fsListDirs(partial) {
-  const raw = (partial ?? "").trim();
-  if (!raw) return [];
-  // Remember whether the caller asked in tilde-form so the returned paths
-  // match the form they typed. Without this, typing `~/pro` returned
-  // absolute `/home/dev/projects`, which the renderer's `m.startsWith(value)`
-  // filter (Sidebar.tsx / MobileCreateSheet.tsx) rejected — autocomplete went
-  // dead for every `~` path.
-  const isTilde = raw === "~" || raw.startsWith("~/");
-  // Expand leading ~ to $HOME — `expandTilde` lives in src/shared/paths.mjs
-  // and is the single source of truth.
-  let lookup = isTilde ? expandTilde(raw) : raw;
-  // Special case: a bare `~` must list the HOME directory's children, NOT
-  // `/home`'s. The general split would yield parent=`/home/`, prefix=`dev`
-  // and start listing `/home`'s entries. Force a trailing slash so the
-  // parent/prefix split lands on `homedir() + "/"` and the prefix is empty.
-  if (raw === "~") lookup = homedir() + "/";
-
-  // Split into parent dir + typed prefix to filter with.
-  const m = /^(.*\/)([^/]*)$/.exec(lookup);
-  if (!m) return [];
-  const [, parent, prefix] = m;
+export async function fsListDirs(dirPath) {
+  // Empty/missing input lists $HOME. A leading `~` is expanded here — this
+  // is the box's edge, and it must never survive past it.
+  const raw = (dirPath ?? "").trim();
+  const dir = expandTilde(raw === "" || raw === "~" ? "~" : raw);
 
   let entries;
   try {
-    entries = await readdir(parent, { withFileTypes: true });
+    entries = await readdir(dir, { withFileTypes: true });
   } catch {
-    return [];
+    return { dir, entries: [] };
   }
 
-  const home = homedir();
-  return entries
-    .filter((e) => e.isDirectory() && (!prefix || e.name.startsWith(prefix)))
-    .sort((a, b) => a.name.localeCompare(b.name))
-    .slice(0, 20)
-    .map((e) => {
-      const abs = parent + e.name;
-      // Translate back to tilde-form if the input was tilde-form, so the
-      // renderer's `startsWith(value)` filter and the ghost-text suggestion
-      // both work.
-      return isTilde && abs.startsWith(home) ? "~" + abs.slice(home.length) : abs;
+  const dirEntries = [];
+  for (const e of entries) {
+    let isDir = e.isDirectory();
+    if (!isDir && e.isSymbolicLink()) {
+      // A symlink counts as a directory only when it resolves to one. A
+      // broken symlink (stat throws) is treated as "not a directory".
+      try {
+        isDir = (await stat(join(dir, e.name))).isDirectory();
+      } catch {
+        isDir = false;
+      }
+    }
+    if (!isDir) continue;
+    dirEntries.push({
+      name: e.name,
+      path: join(dir, e.name),
+      hidden: e.name.startsWith("."),
     });
+  }
+  dirEntries.sort((a, b) => a.name.localeCompare(b.name));
+  return { dir, entries: dirEntries };
 }
 
 // ============================================================

--- a/src/server/local.test.mjs
+++ b/src/server/local.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { fsListDirs, parseWorktrees, shouldSkipDir, dedupeRepoHits, sortRepoHits, parseGhAuthStatus, parseCloneProgress, gitPush, gitClone } from "./local.mjs";
@@ -16,84 +16,100 @@ test("parseWorktrees parses `git worktree list --porcelain`", () => {
   assert.equal(out[1].detached, true);
 });
 
-// ---- BET-307: fsListDirs returns paths in the form the caller typed -------
+// ---- BET-1072: fsListDirs returns an absolute-path DirListing --------------
 //
-// Autocomplete: the renderer's `(await fsListDirs(value)).filter(m => m.startsWith(value))`
-// filter only matches when results are in the SAME form as the input. Before
-// the fix, typing `~/pro` returned absolute `/home/dev/projects` and the
-// filter rejected everything → no ghost-text. Fix: server returns tilde-form
-// when input was tilde-form, absolute-form otherwise.
+// fsListDirs takes a DIRECTORY to list (no parent/prefix split, no cap) and
+// returns `{ dir, entries: [...] }` with absolute paths only — a leading `~`
+// is expanded into `dir`, and no tilde survives past the box's edge. Dot
+// directories are present (flag `hidden:true`) for the renderer to filter.
 
-test("fsListDirs: tilde input returns tilde-form results", async () => {
+test("fsListDirs: tilde input returns absolute paths and an absolute dir", async () => {
   const home = process.env.HOME;
   assert.ok(home, "HOME is set");
-  // Create a sibling inside HOME whose name starts with a known prefix so
-  // fsListDirs picks it up. `fsListDirs("~/pro")` is the documented example
-  // — it lists ~/.../ entries whose name starts with `pro`.
-  const root = await mkdtemp(join(home, "fslist-tilde-pro-"));
+  const out = await fsListDirs("~");
+  // The resolved `dir` is the expanded home directory (absolute).
+  assert.ok(out.dir.startsWith("/"), `dir is absolute: ${out.dir}`);
+  assert.ok(out.entries.every((e) => e.path.startsWith("/")),
+    `all entry paths absolute: ${JSON.stringify(out.entries)}`);
+  // A sibling created in HOME appears as an absolute path, not a tilde form.
+  const root = await mkdtemp(join(home, "fslist-abs-home-"));
   try {
-    const out = await fsListDirs("~/fslist-tilde-pro");
-    // The mkdtemp suffix (random characters) is the only entry matching the
-    // typed prefix; verify it appears in tilde-form.
-    const tildeName = root.slice(home.length); // ".fslist-tilde-pro-XXXX" → "/fslist-tilde-pro-XXXX" → strip leading /
-    const expected = "~" + tildeName;
-    assert.ok(out.includes(expected),
-      `expected tilde-form ${expected}, got ${JSON.stringify(out)}`);
-    assert.ok(out.every((p) => p.startsWith("~")),
-      `all results tilde-form: ${JSON.stringify(out)}`);
+    const listed = await fsListDirs(home);
+    assert.ok(listed.entries.some((e) => e.path === root),
+      `home listing includes the absolute sibling ${root}: ${JSON.stringify(listed.entries.map((e) => e.path))}`);
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test("fsListDirs: absolute input returns absolute results", async () => {
+test("fsListDirs: absolute input returns absolute paths", async () => {
   const root = await mkdtemp(join(tmpdir(), "fslist-abs-root-"));
   await mkdir(join(root, "alpha"), { recursive: true });
   await mkdir(join(root, "beta"), { recursive: true });
   await writeFile(join(root, "not-a-dir.txt"), "skip");
   try {
-    // Pass the parent + a typed prefix so the function lists parent's
-    // children matching the prefix — mirrors how the renderer's
-    // ghost-text suggestion behaves (typing a partial, getting completions).
-    const out = await fsListDirs(join(root, "al"));
-    assert.ok(out.includes(join(root, "alpha")), `alpha present: ${JSON.stringify(out)}`);
-    assert.ok(!out.includes(join(root, "beta")), "beta does not match prefix 'al'");
-    assert.ok(!out.some((p) => p.endsWith("not-a-dir.txt")),
-      "files are filtered out");
-    assert.ok(out.every((p) => p.startsWith("/")),
+    const out = await fsListDirs(root);
+    assert.equal(out.dir, root);
+    const names = out.entries.map((e) => e.name);
+    assert.ok(names.includes("alpha"), `alpha present: ${JSON.stringify(out.entries)}`);
+    assert.ok(names.includes("beta"), `beta present: ${JSON.stringify(out.entries)}`);
+    assert.ok(!names.includes("not-a-dir.txt"), "files are filtered out");
+    assert.ok(out.entries.every((e) => e.path.startsWith("/")),
       "all results absolute");
   } finally {
     await rm(root, { recursive: true, force: true });
   }
 });
 
-test("fsListDirs: bare '~' lists the HOME directory's children, not /home's", async () => {
-  // A bare `~` must NOT be split as parent=`/home/`, prefix=`<user>` — that
-  // would list `/home`'s children (other users), not the user's own home.
-  const out = await fsListDirs("~");
-  // Every entry is either an absolute path under process.env.HOME, or (on
-  // systems where homedir() !== process.env.HOME, e.g. macOS where homedir()
-  // is /Users/x but a test could be run with HOME=/var/…) an empty list.
-  // Assert no `/home/` parent split: results must not all live under `/home/`.
-  if (out.length === 0) return; // skip on platforms where the assertion is moot
-  const home = process.env.HOME ?? "";
-  assert.ok(out.every((p) => p.startsWith(home) || p.startsWith("~")),
-    `results should be under HOME, got ${JSON.stringify(out)}`);
-  assert.ok(!out.some((p) => p.startsWith("/home/") && !p.startsWith(home)),
-    `bare ~ must not list /home/'s children, got ${JSON.stringify(out)}`);
-});
-
-test("fsListDirs: prefix filter narrows results by the typed suffix", async () => {
-  const root = await mkdtemp(join(tmpdir(), "fslist-prefix-"));
-  await mkdir(join(root, "alpha"), { recursive: true });
-  await mkdir(join(root, "beta"),  { recursive: true });
+test("fsListDirs: >20 subdirectories returns ALL of them (no cap)", async () => {
+  const root = await mkdtemp(join(tmpdir(), "fslist-cap-"));
   try {
-    const out = await fsListDirs(join(root, "al"));
-    assert.ok(out.includes(join(root, "alpha")));
-    assert.ok(!out.includes(join(root, "beta")));
+    for (let i = 0; i < 30; i++) {
+      await mkdir(join(root, `d${String(i).padStart(2, "0")}`), { recursive: true });
+    }
+    const out = await fsListDirs(root);
+    assert.equal(out.entries.length, 30, `all 30 returned, got ${out.entries.length}`);
+    // Dot-directories are present with hidden:true (case d, asserted here too).
   } finally {
     await rm(root, { recursive: true, force: true });
   }
+});
+
+test("fsListDirs: dot-directories are present with hidden:true", async () => {
+  const root = await mkdtemp(join(tmpdir(), "fslist-dot-"));
+  await mkdir(join(root, ".config"), { recursive: true });
+  await mkdir(join(root, "visible"), { recursive: true });
+  try {
+    const out = await fsListDirs(root);
+    const dot = out.entries.find((e) => e.name === ".config");
+    assert.ok(dot, `.config present: ${JSON.stringify(out.entries)}`);
+    assert.equal(dot.hidden, true);
+    assert.equal(out.entries.find((e) => e.name === "visible").hidden, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fsListDirs: a symlink pointing at a directory appears in entries", async () => {
+  const root = await mkdtemp(join(tmpdir(), "fslist-link-"));
+  try {
+    await mkdir(join(root, "target"), { recursive: true });
+    await symlink(join(root, "target"), join(root, "link"));
+    await symlink(join(root, "missing"), join(root, "broke"));
+    const out = await fsListDirs(root);
+    const names = out.entries.map((e) => e.name);
+    assert.ok(names.includes("link"), `dir symlink present: ${JSON.stringify(names)}`);
+    assert.ok(!names.includes("broke"), "broken symlink not a directory");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("fsListDirs: a missing directory returns { dir, entries: [] } without throwing", async () => {
+  const missing = join(tmpdir(), "does-not-exist-" + Date.now());
+  const out = await fsListDirs(missing);
+  assert.equal(out.dir, missing);
+  assert.deepEqual(out.entries, []);
 });
 
 // ===========================================================================

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -43,6 +43,7 @@ import type {
   VoiceUploadNoteResult,
   VoiceRetryResult,
   WindowStatus,
+  DirListing,
   WorktreeInfo,
   ForgeProbeResult,
   ForgeStatusResult,
@@ -199,7 +200,7 @@ export interface Api {
   // can confirm before the retry. Any other failure throws.
   gitRemoveWorktree(input: { path: string; force: boolean }): Promise<{ removed: boolean; reason?: "dirty" | "other" }>;
 
-  fsListDirs(partial: string): Promise<string[]>;
+  fsListDirs(partial: string): Promise<DirListing>;
 
   // BET-786: probe the box for git repos + read origins + detect the gh CLI.
   // Server-side only; the box caches the result in memory for 60s.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -326,6 +326,24 @@ export type WorktreeInfo = {
   detached: boolean;
 };
 
+// One entry in a directory listing from fsListDirs. All paths are absolute —
+// no tilde ever crosses the RPC boundary in either direction (BET-1072).
+export type DirEntry = {
+  /** Directory basename, e.g. "projects". */
+  name: string;
+  /** Absolute path, e.g. "/home/dev/projects". */
+  path: string;
+  /** True when `name` starts with "." — the renderer filters on this. */
+  hidden: boolean;
+};
+
+export type DirListing = {
+  /** The absolute directory that was actually listed (input, tilde-expanded). */
+  dir: string;
+  /** Every subdirectory of `dir`, sorted by name. Never truncated. */
+  entries: DirEntry[];
+};
+
 // BET-786: one entry in a repo-probe result. `forge` is the normalised forge
 // kind ("github" | "gitlab") from detectForge, null when there is no origin or
 // the host is unrecognised; `repoKey` is the canonical `host/owner/repo` key.


### PR DESCRIPTION
## BET-1072 — Folder picker: one absolute-path listing contract (drop tilde round-trip + 20-entry cap)

`fsListDirs` now takes a directory to list and returns a `DirListing` of **absolute paths only** — no tilde round-trip, no parent/prefix split, no 20-entry cap. Dot-directories come back with `hidden:true` for the renderer to filter. A symlink to a directory is included (a broken symlink is not). A missing/unreadable directory returns `{ dir, entries: [] }`.

Renderer: `listDir` builds rows from `res.entries`, filtering hidden entries; the path field normalizes to the absolute `res.dir` (converts a typed `~` exactly once). `refreshSuggestion` computes parent-dir + prefix from the typed value and filters entries renderer-side. `isDimmedDir` and all tilde branches in `folderPicker.ts` (`breadcrumbs`/`parentPath`/`crumbLabel`) are deleted.

Channel `fs:list-dirs` and method `fsListDirs` are unchanged.

**Files changed:** 10. `src/shared/types.ts`, `src/shared/api.ts`, `src/server/local.mjs`, `src/server/local.test.mjs`, `src/renderer/api/httpApi.ts` (type only), `src/renderer/api/demoApi.ts`, `src/renderer/api/demoFixture.ts`, `src/renderer/FolderPickerModal.tsx`, `src/renderer/folderPicker.ts`, `src/renderer/folderPicker.test.ts`, `src/renderer/FolderPickerModal.test.tsx`.

**Verification results:**
- PR branch (`multica/BET-1072-folder-picker-absolute-path` @ `5c70a2d9`):
  - typecheck: exit 0. Errors: none. log sha256: `a4eb8fdea59d7e94f94fefa4d71ab4a89d312b344e6821a9e0c3b26923dd4979`
  - test: exit 0. node:test `2307` pass / `0` fail / `0` skip; vitest `2974` pass / `7` skip / `0` fail. log sha256: `e1a31b6c94dc172c21fa5aa9d2eaf2dfc27b85aeebaaec15836559a318558799`
- Base (`main` @ `524e9cd7`):
  - typecheck: exit 0. Errors: none. log sha256: `a4eb8fdea59d7e94f94fefa4d71ab4a89d312b344e6821a9e0c3b26923dd4979`
  - test: exit 0. node:test `2300` pass / `0` fail / `0` skip; vitest `2974` pass / `7` skip / `0` fail. log sha256: `0a53025eba6756603fb0b5412fecb577e187ea4e278245e81c7b6b17ee881e69`
- **Conclusion:** 0 new failures caused by this PR. The `>20 subdirectories` regression guard (30 dirs → all returned) fails on `main` without the source change (old `.slice(0, 20)` capped at 20) and passes here.

**Acceptance greps:** `slice(0, 20)` and `isDimmedDir` both absent from `src/`; no `"~"` literal remains in `folderPicker.ts` / `FolderPickerModal.tsx`.

**Follow-ups:** none filed — the hidden-files toggle and the eager per-row worktree probe removal are explicitly owned by other issues (referenced as "the follow-up issue" / "the follow-up toggle issue").

**Base: `origin/main` @ `524e9cd7`**
