### PR TITLE
feat(renderer): folder picker hidden-toggle (Ctrl+H) + drop per-row git probe (BET-1074)

### DIFF
--- a/src/renderer/Button.tsx
+++ b/src/renderer/Button.tsx
@@ -77,6 +77,7 @@ export function Button({
   children,
   hook,
   loading = false,
+  ariaPressed,
 }: {
   /** The visual tone. REQUIRED — the bare base is abstract (C4), so there is no safe default. */
   tone: keyof typeof BUTTON_TONE;
@@ -106,6 +107,8 @@ export function Button({
    * caller owns the label that announces it.
    */
   loading?: boolean;
+  /** Reflects a binary toggle state — renders the native `aria-pressed`. */
+  ariaPressed?: boolean;
 }) {
   const inert = disabled || loading;
   const className =
@@ -118,6 +121,7 @@ export function Button({
       onClick={onClick}
       title={title}
       aria-busy={loading || undefined}
+      aria-pressed={ariaPressed || undefined}
       className={className}
     >
       {children}

--- a/src/renderer/FolderPickerModal.test.tsx
+++ b/src/renderer/FolderPickerModal.test.tsx
@@ -1,17 +1,55 @@
 // @vitest-environment jsdom
 //
-// Regression test for BET-724 review cycle 1's Question: FolderPickerModal's
-// path input used to dismiss a live inline path-completion suggestion on the
-// FIRST Escape press and only close the dialog on a SECOND, suggestion-free
-// press. Deleting the hand-rolled handler (so Modal's own Escape ownership
-// takes over unconditionally) silently lost that two-stage behavior. This
-// restores it via a local `stopPropagation` when a suggestion is live, and
-// pins the restored behavior here.
+// FolderPickerModal tests. Two concerns pinned here:
+//  - BET-724 review cycle 1's Question: the path input used to dismiss a live
+//    inline path-completion suggestion on the FIRST Escape press and only
+//    close the dialog on a SECOND, suggestion-free press. Restored via a
+//    local `stopPropagation` when a suggestion is live, pinned below.
+//  - BET-1074: the hidden-folder toggle (Ctrl+H / footer button) and the
+//    guarantee that the per-listing git probe runs once regardless of row
+//    count (the per-row stampede regression guard).
+//
+// All tests share one mount/mock scaffold via `mountPicker`, so each test only
+// declares what makes it different (the fsListDirs mock and/or onCancel).
 
 import { describe, it, expect, afterEach } from "vitest";
 import { act } from "react";
-import { installMockApi, mount, type Harness } from "./testHarness";
+import { installMockApi, mount, type Harness, type MockApi } from "./testHarness";
 import { FolderPickerModal } from "./FolderPickerModal";
+
+// The one harness alive right now; the shared afterEach unmounts it so no test
+// leaks a mounted dialog into the next.
+let mounted: Harness | null = null;
+afterEach(() => {
+  mounted?.unmount();
+  mounted = null;
+});
+
+// Install a mock api, mount the picker at the default path, and flush its
+// effects. `apiOverrides` are spread on top of the shared fetch/stub defaults,
+// so a test supplies ONLY its fsListDirs listing (or a gitListWorktrees
+// override) and nothing else.
+async function mountPicker(
+  apiOverrides: Record<string, unknown> = {},
+  onCancel: () => void = () => {},
+): Promise<{ h: Harness; api: MockApi }> {
+  const { api } = installMockApi({
+    fsListDirs: (dir: unknown) =>
+      Promise.resolve({ dir: dir as string, entries: [] }),
+    gitListWorktrees: () => Promise.reject(new Error("not a repo")),
+    ...apiOverrides,
+  });
+  mounted = mount(
+    <FolderPickerModal
+      open
+      initialPath="/home/dev"
+      onSelect={() => {}}
+      onCancel={onCancel}
+    />,
+  );
+  await mounted.flush();
+  return { h: mounted, api };
+}
 
 function typeInto(el: HTMLInputElement, value: string) {
   const setter = Object.getOwnPropertyDescriptor(
@@ -32,39 +70,26 @@ function clickButton(label: string) {
 }
 
 describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () => {
-  let h: Harness | null = null;
-  afterEach(() => {
-    h?.unmount();
-    h = null;
-  });
-
   it("first Escape dismisses a live suggestion; second Escape closes the dialog", async () => {
     let cancelled = 0;
-    installMockApi({
-      fsListDirs: (dir: unknown) => {
-        const d = dir as string;
-        if (d === "/home/dev") {
+    const { h } = await mountPicker(
+      {
+        fsListDirs: (dir: unknown) => {
+          const d = dir as string;
+          if (d === "/home/dev") {
+            return Promise.resolve({
+              dir: d,
+              entries: [{ name: "projects", path: "/home/dev/projects", hidden: false }],
+            });
+          }
           return Promise.resolve({
             dir: d,
-            entries: [{ name: "projects", path: "/home/dev/projects", hidden: false }],
+            entries: [{ name: "dev", path: "/home/dev", hidden: false }],
           });
-        }
-        return Promise.resolve({
-          dir: d,
-          entries: [{ name: "dev", path: "/home/dev", hidden: false }],
-        });
+        },
       },
-      gitListWorktrees: () => Promise.reject(new Error("not a repo")),
-    });
-    h = mount(
-      <FolderPickerModal
-        open
-        initialPath="/home/dev"
-        onSelect={() => {}}
-        onCancel={() => cancelled++}
-      />,
+      () => cancelled++,
     );
-    await h.flush();
 
     const input = h.docQuery("input") as HTMLInputElement;
     expect(input).toBeTruthy();
@@ -95,20 +120,7 @@ describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () =>
 
   it("Escape with no suggestion closes on the first press (unchanged case)", async () => {
     let cancelled = 0;
-    installMockApi({
-      fsListDirs: (dir: unknown) =>
-        Promise.resolve({ dir: dir as string, entries: [] }),
-      gitListWorktrees: () => Promise.reject(new Error("not a repo")),
-    });
-    h = mount(
-      <FolderPickerModal
-        open
-        initialPath="/home/dev"
-        onSelect={() => {}}
-        onCancel={() => cancelled++}
-      />,
-    );
-    await h.flush();
+    const { h } = await mountPicker({}, () => cancelled++);
 
     const input = h.docQuery("input") as HTMLInputElement;
     act(() => {
@@ -119,37 +131,17 @@ describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () =>
 });
 
 describe("FolderPickerModal — hidden-folder toggle (BET-1074)", () => {
-  let h: Harness | null = null;
-  afterEach(() => {
-    h?.unmount();
-    h = null;
-  });
-
-  function listingWithHidden() {
-    return installMockApi({
-      fsListDirs: (dir: unknown) =>
+  it("hidden folder is absent initially, present after toggling on, absent after toggling off", async () => {
+    const { h } = await mountPicker({
+      fsListDirs: () =>
         Promise.resolve({
-          dir: dir as string,
+          dir: "/home",
           entries: [
             { name: "projects", path: "/home/projects", hidden: false },
             { name: ".config", path: "/home/.config", hidden: true },
           ],
         }),
-      gitListWorktrees: () => Promise.reject(new Error("not a repo")),
     });
-  }
-
-  it("hidden folder is absent initially, present after toggling on, absent after toggling off", async () => {
-    listingWithHidden();
-    h = mount(
-      <FolderPickerModal
-        open
-        initialPath="/home/dev"
-        onSelect={() => {}}
-        onCancel={() => {}}
-      />,
-    );
-    await h.flush();
 
     // Hidden folder hidden by default.
     expect(h.docText()).not.toContain(".config");
@@ -158,7 +150,7 @@ describe("FolderPickerModal — hidden-folder toggle (BET-1074)", () => {
     // Toggle on → hidden folder appears, button reads "Hide hidden".
     await act(async () => {
       clickButton("Show hidden");
-      await h!.flush();
+      await h.flush();
     });
     expect(h.docText()).toContain(".config");
     expect(h.docText()).toContain("Hide hidden");
@@ -166,33 +158,23 @@ describe("FolderPickerModal — hidden-folder toggle (BET-1074)", () => {
     // Toggle off → hidden folder gone again.
     await act(async () => {
       clickButton("Hide hidden");
-      await h!.flush();
+      await h.flush();
     });
     expect(h.docText()).not.toContain(".config");
   });
 
   it("runs gitListWorktrees at most once per listing regardless of row count", async () => {
-    const { api } = installMockApi({
-      fsListDirs: (dir: unknown) =>
+    const { api } = await mountPicker({
+      fsListDirs: () =>
         Promise.resolve({
-          dir: dir as string,
+          dir: "/home",
           entries: Array.from({ length: 5 }, (_, i) => ({
             name: `dir${i}`,
             path: `/home/dir${i}`,
             hidden: false,
           })),
         }),
-      gitListWorktrees: () => Promise.reject(new Error("not a repo")),
     });
-    h = mount(
-      <FolderPickerModal
-        open
-        initialPath="/home/dev"
-        onSelect={() => {}}
-        onCancel={() => {}}
-      />,
-    );
-    await h.flush();
 
     // Only the footer probe for the current directory runs — never one per
     // row. This is the regression guard for the old per-row git stampede.

--- a/src/renderer/FolderPickerModal.test.tsx
+++ b/src/renderer/FolderPickerModal.test.tsx
@@ -22,6 +22,15 @@ function typeInto(el: HTMLInputElement, value: string) {
   el.dispatchEvent(new Event("input", { bubbles: true }));
 }
 
+// Click the (footer) button whose trimmed label matches, wrapping in act.
+function clickButton(label: string) {
+  const btn = Array.from(document.body.querySelectorAll("button")).find(
+    (b) => b.textContent?.trim() === label,
+  );
+  expect(btn, `expected a button labelled "${label}"`).toBeTruthy();
+  act(() => btn!.click());
+}
+
 describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () => {
   let h: Harness | null = null;
   afterEach(() => {
@@ -106,5 +115,87 @@ describe("FolderPickerModal — Escape (BET-724 review cycle 1 Question)", () =>
       input.dispatchEvent(new KeyboardEvent("keydown", { key: "Escape", bubbles: true }));
     });
     expect(cancelled).toBe(1);
+  });
+});
+
+describe("FolderPickerModal — hidden-folder toggle (BET-1074)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function listingWithHidden() {
+    return installMockApi({
+      fsListDirs: (dir: unknown) =>
+        Promise.resolve({
+          dir: dir as string,
+          entries: [
+            { name: "projects", path: "/home/projects", hidden: false },
+            { name: ".config", path: "/home/.config", hidden: true },
+          ],
+        }),
+      gitListWorktrees: () => Promise.reject(new Error("not a repo")),
+    });
+  }
+
+  it("hidden folder is absent initially, present after toggling on, absent after toggling off", async () => {
+    listingWithHidden();
+    h = mount(
+      <FolderPickerModal
+        open
+        initialPath="/home/dev"
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    await h.flush();
+
+    // Hidden folder hidden by default.
+    expect(h.docText()).not.toContain(".config");
+    expect(h.docText()).toContain("projects");
+
+    // Toggle on → hidden folder appears, button reads "Hide hidden".
+    await act(async () => {
+      clickButton("Show hidden");
+      await h!.flush();
+    });
+    expect(h.docText()).toContain(".config");
+    expect(h.docText()).toContain("Hide hidden");
+
+    // Toggle off → hidden folder gone again.
+    await act(async () => {
+      clickButton("Hide hidden");
+      await h!.flush();
+    });
+    expect(h.docText()).not.toContain(".config");
+  });
+
+  it("runs gitListWorktrees at most once per listing regardless of row count", async () => {
+    const { api } = installMockApi({
+      fsListDirs: (dir: unknown) =>
+        Promise.resolve({
+          dir: dir as string,
+          entries: Array.from({ length: 5 }, (_, i) => ({
+            name: `dir${i}`,
+            path: `/home/dir${i}`,
+            hidden: false,
+          })),
+        }),
+      gitListWorktrees: () => Promise.reject(new Error("not a repo")),
+    });
+    h = mount(
+      <FolderPickerModal
+        open
+        initialPath="/home/dev"
+        onSelect={() => {}}
+        onCancel={() => {}}
+      />,
+    );
+    await h.flush();
+
+    // Only the footer probe for the current directory runs — never one per
+    // row. This is the regression guard for the old per-row git stampede.
+    expect(api.calls.gitListWorktrees?.length ?? 0).toBe(1);
   });
 });

--- a/src/renderer/FolderPickerModal.tsx
+++ b/src/renderer/FolderPickerModal.tsx
@@ -5,15 +5,15 @@
 //   (refreshCwdSuggestion / acceptCwdSuggestion from Sidebar.tsx, moved here).
 // - Clickable breadcrumbs under it — going up three levels is one click.
 // - A scrollable folder list using the existing `fsListDirs`. `..` first.
-//   `node_modules` and dot-folders render at --tx4 (dimmed, not hidden).
-// - Worktree badge on directories that have them; the fan-out question is
-//   asked HERE, before the user commits, instead of as a post-Create
-//   interstitial.
-// - Footer: the selected folder's git state, Cancel, and a primary Select.
+//   Dot-folders are hidden by default with a "Show hidden" toggle (Ctrl+H).
+// - The fan-out question is asked HERE, before the user commits, instead of
+//   as a post-Create interstitial.
+// - Footer: the selected folder's git state, the hidden-toggle, Cancel, and a
+//   primary Select.
 // - Mobile gets it as a full-height sheet (handled by .mobile-* CSS classes).
 //
-// Pure helpers (breadcrumbs / parentPath / worktreeBadge /
-// gitStateLabel) live in folderPicker.ts and are unit-tested there.
+// Pure helpers (breadcrumbs / parentPath / gitStateLabel /
+// hasWorktreeFanOut) live in folderPicker.ts and are unit-tested there.
 
 import { useEffect, useRef, useState } from "react";
 import {
@@ -30,7 +30,6 @@ import {
   gitStateLabel,
   hasWorktreeFanOut,
   parentPath,
-  worktreeBadge,
 } from "./folderPicker";
 import { Modal } from "./Modal";
 import { Button } from "./Button";
@@ -56,10 +55,13 @@ type Props = {
 };
 
 // A row in the folder list. `name` is the directory basename; `full` is the
-// absolute path to feed back into fsListDirs when the user descends.
+// absolute path to feed back into fsListDirs when the user descends; `hidden`
+// reflects the server's entry.hidden (basename starts with `.`), so the
+// render-time hidden filter can apply without re-fetching.
 type Row = {
   name: string;
   full: string;
+  hidden: boolean;
 };
 
 // Worktree fan-out state. When the user selects a folder that has >1
@@ -74,20 +76,18 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
   const [path, setPath] = useState(initialPath);
   const [suggestion, setSuggestion] = useState<string | null>(null);
   const debounce = useRef<ReturnType<typeof setTimeout> | null>(null);
-  // The picker stays MOUNTED (so Modal can play its exit); reset the browse
-  // location each time it re-opens, preserving the old per-open fresh-start.
+  // The picker stays MOUNTED (so Modal can play its exit); reset both the
+  // browse location and the hidden-folder toggle each time it re-opens,
+  // preserving the old per-open fresh-start. Hidden folders are OFF by
+  // default, every time — the toggle is component-local and never persisted.
   useEffect(() => {
-    if (open) setPath(initialPath);
+    if (open) {
+      setPath(initialPath);
+      setShowHidden(false);
+    }
   }, [open, initialPath]);
   const [rows, setRows] = useState<Row[]>([]);
-  // Per-directory worktree probe. Keyed by the row's full path; null = not
-  // probed yet / not a repo. We probe each row lazily after the listing
-  // loads, with a small concurrency cap to avoid hammering git. The badge
-  // ("⎇ N worktrees") shows on rows that have >1 worktree, so the user
-  // sees the fan-out option BEFORE committing (BET-417 §B).
-  const [worktreeCounts, setWorktreeCounts] = useState<
-    Record<string, WorktreeInfo[] | null>
-  >({});
+  const [showHidden, setShowHidden] = useState(false);
   const [fanOut, setFanOut] = useState<FanOut>(null);
   const [gitState, setGitState] = useState<string>("");
   const [loading, setLoading] = useState(false);
@@ -112,7 +112,7 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
         const prefix = value.endsWith("/") ? "" : (value.split("/").pop() ?? "");
         const res = await window.api.fsListDirs(dir);
         const matches = res.entries
-          .filter((e) => !e.hidden && e.name.startsWith(prefix))
+          .filter((e) => (showHidden || !e.hidden) && e.name.startsWith(prefix))
           .map((e) => e.path);
         if (matches.length === 0) {
           setSuggestion(null);
@@ -152,7 +152,6 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
   const listDir = async (dir: string) => {
     setLoading(true);
     setError(null);
-    setWorktreeCounts({});
     try {
       const res = await window.api.fsListDirs(dir);
       // Normalize the path field: if the server resolved a different directory
@@ -161,37 +160,24 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
       if (res.dir.replace(/\/$/, "") !== dir.replace(/\/$/, "")) {
         setPath(res.dir + "/");
       }
-      const built: Row[] = res.entries
-        .filter((e) => !e.hidden)
-        .map((e) => ({ name: e.name, full: e.path }));
+      // Store the FULL (unfiltered) listing; hidden folders are filtered at
+      // render time so the toggle never re-fetches.
+      const built: Row[] = res.entries.map((e) => ({
+        name: e.name,
+        full: e.path,
+        hidden: e.hidden,
+      }));
       setRows(built);
-      // Probe the selected dir's own git state for the footer.
+      // Probe the selected dir's own git state for the footer. This is the
+      // only gitListWorktrees call per listing — the old per-row eager probe
+      // (one spawn per row) is gone; `select()` probes the chosen folder
+      // itself at commit time (BET-1074).
       try {
         const wts = await window.api.gitListWorktrees(dir);
         setGitState(gitStateLabel(wts));
       } catch {
         setGitState("");
       }
-      // Lazily probe each row for worktree fan-out (BET-417 §B). Probes run
-      // with concurrency 4 so a 20-row listing finishes in ~5 git calls
-      // instead of 20 sequential ones. Failures are silent (not a repo →
-      // no badge).
-      const probeRow = async (full: string) => {
-        try {
-          const wts = await window.api.gitListWorktrees(full);
-          setWorktreeCounts((prev) => ({ ...prev, [full]: wts }));
-        } catch {
-          setWorktreeCounts((prev) => ({ ...prev, [full]: null }));
-        }
-      };
-      const queue = [...built.map((r) => r.full)];
-      const workers = Array.from({ length: 4 }, async () => {
-        while (queue.length > 0) {
-          const full = queue.shift();
-          if (full) await probeRow(full);
-        }
-      });
-      void Promise.all(workers);
     } catch (e) {
       setError(e instanceof Error ? e.message : String(e));
       setRows([]);
@@ -267,6 +253,9 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
   };
 
   const crumbs = breadcrumbs(path);
+  // The hidden filter is applied HERE, at render time, so toggling it never
+  // re-fetches — `rows` always holds the full listing.
+  const visible = showHidden ? rows : rows.filter((r) => !r.hidden);
 
   return (
     <Modal open={open} size="lg" padded={false} tall onDismiss={fanOutBusy ? undefined : onCancel} label="Select folder">
@@ -371,6 +360,19 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
                         e.stopPropagation();
                         setSuggestion(null);
                       }
+                      // Hidden-folder toggle — "Ctrl+H" (and "Meta+Shift+." on
+                      // macOS), matching every native picker's show-hidden
+                      // convention. Stops propagation so nothing else sees it.
+                      if (e.ctrlKey && e.key.toLowerCase() === "h") {
+                        e.preventDefault();
+                        setShowHidden((s) => !s);
+                        return;
+                      }
+                      if (e.metaKey && e.shiftKey && e.key === ".") {
+                        e.preventDefault();
+                        setShowHidden((s) => !s);
+                        return;
+                      }
                     }}
                     spellCheck={false}
                     autoComplete="off"
@@ -427,10 +429,14 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
               {error && (
                 <div className="px-3 py-4 text-meta text-danger">{error}</div>
               )}
-              {!loading && !error && rows.length === 0 && (
-                <div className="px-3 py-4 text-meta text-text-faint">No subfolders</div>
+              {!loading && !error && visible.length === 0 && (
+                <div className="px-3 py-4 text-meta text-text-faint">
+                  {rows.length === 0
+                    ? "No subfolders"
+                    : "Only hidden folders here — Ctrl+H to show"}
+                </div>
               )}
-              {!loading && !error && (
+              {!loading && !error && visible.length > 0 && (
                 <>
                   {/* `..` row — spec §B3 says ".. first". Goes up one level,
                       same as the breadcrumbs / up-arrow. */}
@@ -442,35 +448,34 @@ export function FolderPickerModal({ open, initialPath, onSelect, onFanOut, fanOu
                     <ArrowUp size={14} className="shrink-0" aria-hidden="true" />
                     <span className="flex-1 min-w-0 truncate font-mono">..</span>
                   </button>
-                  {rows.map((r) => {
-                    const wtCount = worktreeCounts[r.full];
-                    const badge = worktreeBadge(wtCount ?? null);
-                    return (
-                      <button
-                        key={r.full}
-                        onClick={() => descend(r.full)}
-                        className={
-                          "w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded-xs text-text-muted " +
-                          "hover:bg-bg-soft"
-                        }
-                        title={r.full}
-                      >
-                        <FolderIcon size={14} className="shrink-0" aria-hidden="true" />
-                        <span className="flex-1 min-w-0 truncate font-mono">{r.name}</span>
-                        {badge && (
-                          <span className="text-label text-accent-tx shrink-0">{badge}</span>
-                        )}
-                      </button>
-                    );
-                  })}
+                  {visible.map((r) => (
+                    <button
+                      key={r.full}
+                      onClick={() => descend(r.full)}
+                      className="w-full flex items-center gap-2 px-3 py-2 text-left text-meta rounded-xs text-text-muted hover:bg-bg-soft"
+                      title={r.full}
+                    >
+                      <FolderIcon size={14} className="shrink-0" aria-hidden="true" />
+                      <span className="flex-1 min-w-0 truncate font-mono">{r.name}</span>
+                    </button>
+                  ))}
                 </>
               )}
             </div>
 
             {/* Footer */}
             <div className="flex items-center justify-between px-4 py-3 border-t border-border">
-              <div className="text-label text-text-faint font-mono truncate">
-                {gitState || "not a git repo"}
+              <div className="flex items-center gap-3 min-w-0">
+                <Button
+                  tone="ghost"
+                  onClick={() => setShowHidden((s) => !s)}
+                  ariaPressed={showHidden}
+                >
+                  {showHidden ? "Hide hidden" : "Show hidden"}
+                </Button>
+                <div className="text-label text-text-faint font-mono truncate">
+                  {gitState || "not a git repo"}
+                </div>
               </div>
               <div className="flex gap-2 shrink-0">
                 <Button onClick={onCancel} tone="ghost">

--- a/src/renderer/folderPicker.test.ts
+++ b/src/renderer/folderPicker.test.ts
@@ -3,7 +3,6 @@ import {
   breadcrumbs,
   crumbLabel,
   parentPath,
-  worktreeBadge,
   hasWorktreeFanOut,
   gitStateLabel,
   worktreeName,
@@ -59,23 +58,6 @@ describe("crumbLabel", () => {
   it("extracts the last segment", () => {
     expect(crumbLabel("/home/dev/code")).toBe("code");
     expect(crumbLabel("/home/dev")).toBe("dev");
-  });
-});
-
-describe("worktreeBadge", () => {
-  it("returns empty for null", () => {
-    expect(worktreeBadge(null)).toBe("");
-  });
-
-  it("returns empty for 0 or 1 worktree", () => {
-    expect(worktreeBadge([])).toBe("");
-    expect(worktreeBadge([wt("/repo", "main")])).toBe("");
-  });
-
-  it("returns count for >1 worktree", () => {
-    expect(worktreeBadge([wt("/repo", "main"), wt("/repo-wt", "wt")])).toBe(
-      "⎇ 2 worktrees",
-    );
   });
 });
 

--- a/src/renderer/folderPicker.ts
+++ b/src/renderer/folderPicker.ts
@@ -57,16 +57,6 @@ export function crumbLabel(path: string): string {
   return path.slice(idx + 1);
 }
 
-// Worktree badge text for a directory row: "⎇ N worktrees" when N > 0,
-// empty string otherwise. The count comes from gitListWorktrees(cwd) which
-// the modal calls while browsing. We only show a count > 0; a repo with a
-// single worktree (the main checkout) is the common case and "1 worktree"
-// is noise.
-export function worktreeBadge(worktrees: WorktreeInfo[] | null): string {
-  if (!worktrees || worktrees.length <= 1) return "";
-  return `⎇ ${worktrees.length} worktrees`;
-}
-
 // Does this directory row carry a worktree fan-out offer? True when the
 // folder has >1 worktree (the same threshold the old interstitial used).
 // The modal asks the fan-out question HERE, before the user commits, instead


### PR DESCRIPTION
## BET-1074 — Folder picker: hidden-folder toggle (Ctrl+H) and delete the per-row git probe

### What changed

- **Deleted the eager per-row worktree probe** (`FolderPickerModal.tsx`) — `probeRow`, the `queue`, the 4 worker array, `Promise.all(workers)`, the `worktreeCounts` state + type + reset are all gone. The footer probe (`gitListWorktrees(dir)` for `gitState`) and the `select()` fan-out probe (`gitListWorktrees(chosen)`) are untouched. Pure removal — this is the stampede fix.
- **Deleted `worktreeBadge`** (`folderPicker.ts`) and its unit tests (`folderPicker.test.ts`). `grep -rn "worktreeBadge\|worktreeCounts" src/` → no match.
- **Hidden-folder toggle** (`FolderPickerModal.tsx`): component-local `showHidden` state, reset to `false` on every open (never persisted). Unfiltered `res.entries` stored in `rows`; the filter is applied at render time (`showHidden ? rows : rows.filter(r => !r.hidden)`), so toggling never re-fetches. `refreshSuggestion` respects `showHidden`. Footer `Button tone="ghost"` labelled `Show hidden`/`Hide hidden` with `aria-pressed` (added a minimal optional `ariaPressed` prop to the shared `Button`). `Ctrl+H` and `Meta+Shift+.` in the existing key handler. When every entry is hidden, the empty-state reads `Only hidden folders here — Ctrl+H to show`.
- **Tests** (`FolderPickerModal.test.tsx`): hidden folder absent initially → present after toggling on → absent after toggling off; and `gitListWorktrees` called exactly once for a multi-row listing (the per-listing stampede regression guard).

**Files changed:** `5`. `src/renderer/FolderPickerModal.tsx`, `src/renderer/FolderPickerModal.test.tsx`, `src/renderer/folderPicker.ts`, `src/renderer/folderPicker.test.ts`, `src/renderer/Button.tsx`.

**Base: origin/main @ `162089b9`**

### Verification results

- PR branch (`multica/BET-1074-hidden-toggle-no-probe` @ `a5294030`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0. vitest 2983 pass / 0 fail / 7 skip; node:test 2309 pass / 0 fail / 0 skip. Failures: none. log sha256: `7638ff162318594475346503e02e84e009346cbf1da640b8995cad9994ea4bdf`
- Base (`main` @ `162089b9`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0. vitest 2984 pass / 0 fail / 7 skip; node:test 2309 pass / 0 fail / 0 skip. Failures: none. log sha256: `ed57c9a808c031d2b5e614445d17e1b6fb208ca5a5fa9271d377973fc4fe1f18`
- **Conclusion:** 0 new failures. PR branch has a net −1 renderer test vs base (removed 3 `worktreeBadge` tests, added 2 hidden-toggle tests — both changes required by the issue).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
