### PR TITLE
BET-1075: feat(renderer): stop pre-selecting repos in the new-project zero state

### DIFF
--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -53,7 +53,6 @@ import { useVoiceRecorder } from "./voice";
 import {
   describeRepoRow,
   formatAge,
-  initialRepoSelection,
   zeroStateMode,
   type RepoRow,
 } from "./chatUtils";
@@ -166,7 +165,6 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   // Probe the box for git repos + the gh CLI. The scan is purely additive: if
   // it fails or is unavailable we degrade to exactly today's behaviour (the
   // folder picker), never a state worse than the one the screen used to have.
-  const PROBE_PRE_CHECK_CAP = 8;
   const [probePending, setProbePending] = useState(false);
   const [probeFailed, setProbeFailed] = useState(false);
   const [probeRepos, setProbeRepos] = useState<RepoHit[]>([]);
@@ -245,18 +243,6 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
     probeFailed,
     repos: probeRepos,
   });
-
-  // Pre-check rule: check what already exists on disk, capped at 8, most
-  // recent first. Never check anything that would require a clone.
-  useEffect(() => {
-    if (probePending || probeFailed) {
-      setChecked(new Set());
-      return;
-    }
-    setChecked(
-      new Set(initialRepoSelection(rows, PROBE_PRE_CHECK_CAP).map((r) => r.path)),
-    );
-  }, [probePending, probeFailed, rows]);
 
   const toggleRow = (path: string, on: boolean) => {
     setChecked((prev) => {

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -109,7 +109,6 @@ import {
   shouldOfferForgeConnect,
   failuresToAgentPrompt,
   zeroStateMode,
-  initialRepoSelection,
   describeRepoRow,
   homeRelativePath,
   planHighlightRanges,
@@ -4025,38 +4024,6 @@ describe("zeroStateMode", () => {
 
   it("returns fresh (not degraded) when the probe succeeded with zero repos", () => {
     expect(zeroStateMode({ probePending: false, probeFailed: false, repos: [] })).toBe("fresh");
-  });
-});
-
-describe("initialRepoSelection", () => {
-  it("checks every local row when they fit under the cap", () => {
-    const repos = [
-      repoRow({ path: "/a", lastCommitAt: 3 }),
-      repoRow({ path: "/b", lastCommitAt: 2 }),
-      repoRow({ path: "/c", lastCommitAt: 1 }),
-    ];
-    const sel = initialRepoSelection(repos, 8);
-    expect(sel.map((r) => r.path)).toEqual(["/a", "/b", "/c"]);
-  });
-
-  it("caps the checked set at the cap, most-recent first (12 repos -> 8)", () => {
-    const repos = Array.from({ length: 12 }, (_, i) =>
-      repoRow({ path: `/r${i}`, lastCommitAt: 12 - i }),
-    );
-    const sel = initialRepoSelection(repos, 8);
-    expect(sel).toHaveLength(8);
-    expect(sel[0].path).toBe("/r0");
-    expect(sel[1].path).toBe("/r1");
-    expect(sel[7].path).toBe("/r7");
-  });
-
-  it("never pre-checks a non-local row, even a recent one", () => {
-    const repos = [
-      repoRow({ path: "/local-repo", lastCommitAt: 2 }),
-      repoRow({ path: "/clone-repo", lastCommitAt: 99, local: false }),
-    ];
-    const sel = initialRepoSelection(repos, 8);
-    expect(sel.map((r) => r.path)).toEqual(["/local-repo"]);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3370,23 +3370,6 @@ export function zeroStateMode(input: {
   return input.repos.length > 0 ? "list" : "fresh";
 }
 
-// The pre-checked set of repos, capped at `cap`. Rows are considered
-// most-recent-first and only *local* rows can be pre-checked (anything that
-// would require a clone must land unchecked). The cap stops a box with many
-// repos from silently creating that many tmux sessions.
-export function initialRepoSelection(repos: RepoRow[], cap: number): RepoRow[] {
-  const sorted = [...repos].sort(
-    (a, b) => (b.lastCommitAt ?? 0) - (a.lastCommitAt ?? 0),
-  );
-  const selected: RepoRow[] = [];
-  for (const repo of sorted) {
-    if (!repo.local) continue;
-    if (selected.length >= cap) break;
-    selected.push(repo);
-  }
-  return selected;
-}
-
 // Substitute a leading home-dir prefix with `~` for display, matching the
 // manta-forge zero-state mockup (`~/scratch`). Given no homeDir (unavailable),
 // the absolute path is shown unchanged. Pure.

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -706,6 +706,7 @@ export async function scanRepos({
   maxResults = 50,
   timeoutMs = 4000,
   readdir: readdirImpl = readdir,
+  readFile: readFileImpl = readFile,
   realpath: realpathImpl = realpath,
   stat: statImpl = stat,
   gitRun = run,
@@ -726,6 +727,7 @@ export async function scanRepos({
       hits,
       seenReal,
       readdir: readdirImpl,
+      readFile: readFileImpl,
       realpath: realpathImpl,
       stat: statImpl,
       gitRun,
@@ -765,11 +767,14 @@ async function walkRoot(dir, depth, ctx) {
   } catch {
     return; // unreadable / missing — skip quietly
   }
-  // A directory containing a .git entry is a repo. Detect by readdir, NOT by
-  // spawning git, and do not descend into it — the outermost repo wins.
-  if (entries.some((e) => e.name === ".git")) {
+  // A directory holding a real `.git` is a repo. Detect by readdir, NOT by
+  // spawning git, and do not descend into it — the outermost repo wins. When
+  // the `.git` entry is not a real one, keep descending as usual. The home
+  // root is the one exception: home is never offered as a workspace even when
+  // it holds a `.git` (recordRepo skips it), so its children are still scanned.
+  if (await isRepoDir(entries, dir, ctx)) {
     await recordRepo(dir, ctx);
-    return;
+    if (dir !== ctx.home) return;
   }
   if (depth >= ctx.maxDepth) return;
   for (const e of entries) {
@@ -780,6 +785,24 @@ async function walkRoot(dir, depth, ctx) {
   }
 }
 
+async function isRepoDir(entries, dir, ctx) {
+  const git = entries.find((e) => e.name === ".git");
+  if (!git) return false;
+  // A `.git` directory is a normal checkout. No extra I/O in this common case.
+  if (git.isDirectory()) return true;
+  // A `.git` file is a linked worktree / submodule only when its first bytes
+  // are "gitdir:". Anything else named `.git` is not a repository — recording
+  // it would offer the user a workspace no git command will work in.
+  if (!git.isFile()) return false;
+  let text;
+  try {
+    text = await ctx.readFile(join(dir, ".git"), "utf8");
+  } catch {
+    return false;
+  }
+  return typeof text === "string" && text.startsWith("gitdir:");
+}
+
 async function recordRepo(dir, ctx) {
   // Dedupe by resolved real path first (a symlinked root must not double-report).
   let real;
@@ -788,6 +811,11 @@ async function recordRepo(dir, ctx) {
   } catch {
     real = dir;
   }
+  // The home directory itself is never a workspace, even when it holds a
+  // `.git` (dotfiles kept in a repo). It stays a scan root — its children are
+  // still scanned — but it is not offered as a project. Compare on the
+  // resolved real path so a symlinked home is caught too.
+  if (ctx.home && real === ctx.home) return;
   if (ctx.seenReal.has(real)) return;
   ctx.seenReal.add(real);
 

--- a/src/server/local.test.mjs
+++ b/src/server/local.test.mjs
@@ -4,7 +4,7 @@ import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { fsListDirs, parseWorktrees, shouldSkipDir, dedupeRepoHits, sortRepoHits, parseGhAuthStatus, parseCloneProgress, gitPush, gitClone } from "./local.mjs";
+import { fsListDirs, parseWorktrees, shouldSkipDir, dedupeRepoHits, sortRepoHits, parseGhAuthStatus, parseCloneProgress, gitPush, gitClone, scanRepos } from "./local.mjs";
 
 test("parseWorktrees parses `git worktree list --porcelain`", () => {
   const out = parseWorktrees(
@@ -326,4 +326,89 @@ test("gitClone: no token emits no -c argument at all", async () => {
   await gitClone({ url: "https://github.com/acme/public.git" }, { spawn });
   assert.ok(!calls[0].includes("-c"), "public clone emits no extraheader");
   assert.deepEqual(calls[0], ["-C", "/", "clone", "--progress", "https://github.com/acme/public.git"]);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1075: only real git repos are offered, and never $HOME itself. The scan
+// runs against an injected readdir/readFile/realpath/stat/gitRun so no real
+// filesystem is touched. `dirs` maps a directory to its Dirent-like entries;
+// `files` maps a path to the bytes readFile returns (absent = ENOENT).
+// ---------------------------------------------------------------------------
+
+function scanEnt(name, type) {
+  return {
+    name,
+    isDirectory: () => type === "dir",
+    isFile: () => type === "file",
+  };
+}
+
+function fakeRepoSys({ dirs, files = {} }) {
+  return {
+    readdir: async (dir) => dirs[dir] ?? [],
+    realpath: async (p) => p,
+    stat: async () => ({ mtimeMs: 1 }),
+    readFile: async (p) => {
+      if (!(p in files)) throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      return files[p];
+    },
+    gitRun: async () => ({ stdout: "" }),
+  };
+}
+
+test("scanRepos: a directory whose .git is a directory is recorded", async () => {
+  const sys = fakeRepoSys({
+    dirs: {
+      "/home/u": [scanEnt("projects", "dir")],
+      "/home/u/projects": [scanEnt("repoa", "dir")],
+      "/home/u/projects/repoa": [scanEnt(".git", "dir")],
+    },
+  });
+  const { repos } = await scanRepos({ roots: ["/home/u"], home: "/home/u", ...sys });
+  assert.ok(repos.some((r) => r.path === "/home/u/projects/repoa"),
+    `ordinary .git dir recorded: ${JSON.stringify(repos.map((r) => r.path))}`);
+});
+
+test("scanRepos: a .git file starting with gitdir: is recorded (worktree/submodule)", async () => {
+  const sys = fakeRepoSys({
+    dirs: {
+      "/home/u": [scanEnt("projects", "dir")],
+      "/home/u/projects": [scanEnt("wt", "dir")],
+      "/home/u/projects/wt": [scanEnt(".git", "file")],
+    },
+    files: { "/home/u/projects/wt/.git": "gitdir: /home/u/main/.git/worktrees/wt" },
+  });
+  const { repos } = await scanRepos({ roots: ["/home/u"], home: "/home/u", ...sys });
+  assert.ok(repos.some((r) => r.path === "/home/u/projects/wt"),
+    `gitdir: worktree recorded: ${JSON.stringify(repos.map((r) => r.path))}`);
+});
+
+test("scanRepos: a .git file with other content is not a repo, but its subdirs are scanned", async () => {
+  const sys = fakeRepoSys({
+    dirs: {
+      "/home/u": [scanEnt("fake", "dir")],
+      "/home/u/fake": [scanEnt(".git", "file"), scanEnt("child", "dir")],
+      "/home/u/fake/child": [scanEnt(".git", "dir")],
+    },
+    files: { "/home/u/fake/.git": "this is not a gitdir at all" },
+  });
+  const { repos } = await scanRepos({ roots: ["/home/u"], home: "/home/u", ...sys });
+  assert.ok(!repos.some((r) => r.path === "/home/u/fake"),
+    "bogus .git file is not offered");
+  assert.ok(repos.some((r) => r.path === "/home/u/fake/child"),
+    "the bogus dir is still descended into, so its real repo shows up");
+});
+
+test("scanRepos: $HOME itself is never a workspace, while its children are scanned", async () => {
+  const sys = fakeRepoSys({
+    dirs: {
+      "/home/u": [scanEnt(".git", "dir"), scanEnt("projects", "dir")],
+      "/home/u/projects": [scanEnt("repo", "dir")],
+      "/home/u/projects/repo": [scanEnt(".git", "dir")],
+    },
+  });
+  const { repos } = await scanRepos({ roots: ["/home/u"], home: "/home/u", ...sys });
+  const paths = repos.map((r) => r.path);
+  assert.ok(!paths.includes("/home/u"), `home excluded: ${JSON.stringify(paths)}`);
+  assert.ok(paths.includes("/home/u/projects/repo"), `home's children still scanned: ${JSON.stringify(paths)}`);
 });


### PR DESCRIPTION
BET-1075 implementer PR (auto-opened by agent-branch sweep; body rewritten by the implementer).

## What and why

Two onboarding fixes for the new-project zero state:

1. **Nothing is pre-selected.** The zero state previously auto-checked up to 8
   detected repositories (`PROBE_PRE_CHECK_CAP` → `initialRepoSelection`),
   newest first, so a first run defaulted to "create eight workspaces I didn't
   ask for". Creating workspaces is not reversible-feeling, so nothing is now
   checked by default: `initialRepoSelection` and `PROBE_PRE_CHECK_CAP` are
   deleted, the pre-check `useEffect` is deleted, and the "Set up N" action
   stays disabled until the user checks a repo (already wired via
   `checked.size === 0`). `checked` resets per session/draft through the
   existing probe effect.

2. **Only real git repos are offered, and never `$HOME`.** The scan used to
   treat any directory containing an entry *named* `.git` as a repo. Now
   (`src/server/local.mjs`):
   - `.git` is a directory → repo (normal checkout; no extra I/O).
   - `.git` is a file → accepted only when its first bytes are `gitdir:`
     (linked worktree / submodule); other contents are skipped *and still
     descended into*.
   - `$HOME` itself is never recorded as a workspace (even with a dotfiles
     repo's `.git`) but remains a scan root — its children still get scanned.

## Files changed (5)

- `src/renderer/NewSessionScreen.tsx`
- `src/renderer/chatUtils.ts`
- `src/renderer/chatUtils.test.ts`
- `src/server/local.mjs`
- `src/server/local.test.mjs`

Base: origin/main @ `162089b`

**Verification results:**
- PR branch (`multica/BET-1075-no-preselect-repos` @ `5fbe86e`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 2313 pass / 0 fail / 0 skip.
- Base (`main` @ `162089b`): both suites green at the base (branch is a linear
  two-commit stack on main; the full `npm test` on the PR branch ran the whole
  suite including untouched modules).
- **Conclusion:** 0 new failures.
- Acceptance greps:
  - `grep -rn "initialRepoSelection\|PROBE_PRE_CHECK_CAP" src/` → no match.
- Tests added (`src/server/local.test.mjs`): a `.git` directory is recorded; a
  `.git` file starting with `gitdir:` is recorded; a `.git` file with other
  content is not a repo but its subdirectories are still scanned; `$HOME`
  itself is never a workspace while its children still are.
