### PR TITLE
BET-1076: refactor(main): extract screenshot detector out of index.ts

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -7,8 +7,8 @@ import {
   nativeImage,
   shell,
 } from "electron";
-import { basename, join } from "node:path";
-import { existsSync, watch as fsWatch } from "node:fs";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
 import { readFile } from "node:fs/promises";
 import { homedir } from "node:os";
 import { fileURLToPath } from "node:url";
@@ -31,6 +31,11 @@ import {
   startCapExecutor,
   stopCapExecutor,
 } from "./capExecutor.js";
+import {
+  startScreenshotDetector,
+  stopScreenshotDetector,
+  readClipboardImageBuffer,
+} from "./screenshotDetector.js";
 import { checkForUpdates } from "./autoUpdate.js";
 import { titleBarOptions } from "./windowChrome.js";
 import { registerInstallerHandlers } from "./installer/handlers.js";
@@ -67,106 +72,6 @@ function commit(next: Partial<AppConfig>): AppConfig {
   config = { ...config, ...next };
   saveConfig(config);
   return config;
-}
-
-// ===== Screenshot detector =====
-//
-// Two parallel detection paths — together they cover all four macOS screenshot
-// shortcuts without any native module:
-//
-// 1. Clipboard poller (500ms): catches ⌘⇧Control+3/4 (clipboard-only shots).
-//    Tracks clipboard "generation" by hashing availableFormats() + image size;
-//    when a new image appears it pushes screenshotDetected to the renderer.
-//    We intentionally do NOT read the full pixel buffer every tick — only
-//    formats + size, so the poll is cheap. The renderer calls uploadBuffer
-//    which reads the clipboard once via a separate IPC.
-//
-// 2. Desktop folder watcher: catches ⌘⇧3/4 (file-only shots). macOS names
-//    them "Screenshot YYYY-MM-DD at HH.MM.SS.png". The fs.watch callback
-//    fires on the rename event (file creation) and we filter by that pattern.
-//    We push the absolute path so the renderer can scp it directly via
-//    uploadFiles (no extra read needed).
-//
-// Both paths are no-ops when no mainWindow exists. The Desktop watcher is
-// started once at app-ready and never restarted (the Desktop path doesn't
-// change). The clipboard poller is the same.
-
-const SCREENSHOT_RE = /^Screenshot \d{4}-\d{2}-\d{2} at \d{2}\.\d{2}\.\d{2}.*\.png$/i;
-
-let screenshotClipboardTimer: ReturnType<typeof setInterval> | null = null;
-let screenshotDesktopWatcher: ReturnType<typeof fsWatch> | null = null;
-
-// Cheap fingerprint: join of available formats + "<w>x<h>". We don't hash
-// pixel data — just enough to detect "something new appeared".
-function clipboardImageFingerprint(): string {
-  const fmts = clipboard.availableFormats().join(",");
-  if (!fmts.includes("image")) return "";
-  const img = clipboard.readImage();
-  if (img.isEmpty()) return "";
-  const { width, height } = img.getSize();
-  return `${fmts}|${width}x${height}`;
-}
-
-function startScreenshotDetector(): void {
-  // macOS-only: the clipboard fingerprint relies on Mac's screencapture
-  // populating the clipboard on ⌘⇧^3/4, and the file watcher targets the
-  // Mac-default `~/Desktop/Screenshot YYYY-MM-DD at HH.MM.SS.png` filename.
-  // On Linux/Windows both paths would no-op at best and burn CPU on the
-  // 500ms clipboard poller at worst.
-  if (process.platform !== "darwin") return;
-
-  // --- Clipboard poller ---
-  let lastFingerprint = clipboardImageFingerprint();
-  screenshotClipboardTimer = setInterval(() => {
-    if (!mainWindow || mainWindow.isDestroyed()) return;
-    const fp = clipboardImageFingerprint();
-    if (fp && fp !== lastFingerprint) {
-      lastFingerprint = fp;
-      mainWindow.webContents.send(IPC.screenshotDetected, { source: "clipboard" });
-    }
-  }, 500);
-
-  // --- Desktop folder watcher ---
-  const desktop = join(homedir(), "Desktop");
-  try {
-    screenshotDesktopWatcher = fsWatch(desktop, (event, filename) => {
-      if (!mainWindow || mainWindow.isDestroyed()) return;
-      if (event !== "rename" || !filename) return;
-      if (!SCREENSHOT_RE.test(basename(filename))) return;
-      const fullPath = join(desktop, filename);
-      // Small delay — fs.watch fires on the rename (inode creation) before
-      // the file is fully written. 300ms is enough for a PNG flush.
-      setTimeout(() => {
-        if (!mainWindow || mainWindow.isDestroyed()) return;
-        mainWindow.webContents.send(IPC.screenshotDetected, {
-          source: "file",
-          path: fullPath,
-        });
-      }, 300);
-    });
-  } catch {
-    // Desktop might not exist or be accessible (e.g. on Linux in dev).
-    // Silently skip — clipboard poller still works.
-  }
-}
-
-function stopScreenshotDetector(): void {
-  if (screenshotClipboardTimer) {
-    clearInterval(screenshotClipboardTimer);
-    screenshotClipboardTimer = null;
-  }
-  if (screenshotDesktopWatcher) {
-    screenshotDesktopWatcher.close();
-    screenshotDesktopWatcher = null;
-  }
-}
-
-// IPC: renderer calls this to read the current clipboard image as PNG bytes.
-// Separate from the poller so we only read full pixel data on demand.
-function readClipboardImageBuffer(): Buffer | null {
-  const img = clipboard.readImage();
-  if (img.isEmpty()) return null;
-  return img.toPNG();
 }
 
 function createWindow(): void {
@@ -300,7 +205,11 @@ app.whenReady().then(() => {
     if (coldPairUrl) {
       mainWindow?.webContents.send(IPC.pairLinkReceived, coldPairUrl);
     }
-    startScreenshotDetector();
+    startScreenshotDetector((channel, payload) => {
+      if (mainWindow && !mainWindow.isDestroyed()) {
+        mainWindow.webContents.send(channel, payload);
+      }
+    });
     // Report desktop focus to the mobile server so it suppresses redundant
     // mobile "done" pushes while the user is active on desktop.
     startDesktopPresence(() => config);

--- a/src/main/screenshotDetector.ts
+++ b/src/main/screenshotDetector.ts
@@ -1,0 +1,104 @@
+// ===== Screenshot detector =====
+//
+// Two parallel detection paths — together they cover all four macOS screenshot
+// shortcuts without any native module:
+//
+// 1. Clipboard poller (500ms): catches ⌘⇧Control+3/4 (clipboard-only shots).
+//    Tracks clipboard "generation" by hashing availableFormats() + image size;
+//    when a new image appears it pushes screenshotDetected to the renderer.
+//    We intentionally do NOT read the full pixel buffer every tick — only
+//    formats + size, so the poll is cheap. The renderer calls uploadBuffer
+//    which reads the clipboard once via a separate IPC.
+//
+// 2. Desktop folder watcher: catches ⌘⇧3/4 (file-only shots). macOS names
+//    them "Screenshot YYYY-MM-DD at HH.MM.SS.png". The fs.watch callback
+//    fires on the rename event (file creation) and we filter by that pattern.
+//    We push the absolute path so the renderer can scp it directly via
+//    uploadFiles (no extra read needed).
+//
+// Both paths are no-ops when no mainWindow exists. The Desktop watcher is
+// started once at app-ready and never restarted (the Desktop path doesn't
+// change). The clipboard poller is the same.
+
+import { clipboard } from "electron";
+import { basename, join } from "node:path";
+import { watch as fsWatch } from "node:fs";
+import { homedir } from "node:os";
+import { IPC } from "../shared/types.js";
+
+const SCREENSHOT_RE = /^Screenshot \d{4}-\d{2}-\d{2} at \d{2}\.\d{2}\.\d{2}.*\.png$/i;
+
+let screenshotClipboardTimer: ReturnType<typeof setInterval> | null = null;
+let screenshotDesktopWatcher: ReturnType<typeof fsWatch> | null = null;
+
+// Cheap fingerprint: join of available formats + "<w>x<h>". We don't hash
+// pixel data — just enough to detect "something new appeared".
+function clipboardImageFingerprint(): string {
+  const fmts = clipboard.availableFormats().join(",");
+  if (!fmts.includes("image")) return "";
+  const img = clipboard.readImage();
+  if (img.isEmpty()) return "";
+  const { width, height } = img.getSize();
+  return `${fmts}|${width}x${height}`;
+}
+
+export function startScreenshotDetector(
+  send: (channel: string, payload: unknown) => void,
+): void {
+  // macOS-only: the clipboard fingerprint relies on Mac's screencapture
+  // populating the clipboard on ⌘⇧^3/4, and the file watcher targets the
+  // Mac-default `~/Desktop/Screenshot YYYY-MM-DD at HH.MM.SS.png` filename.
+  // On Linux/Windows both paths would no-op at best and burn CPU on the
+  // 500ms clipboard poller at worst.
+  if (process.platform !== "darwin") return;
+
+  // --- Clipboard poller ---
+  let lastFingerprint = clipboardImageFingerprint();
+  screenshotClipboardTimer = setInterval(() => {
+    const fp = clipboardImageFingerprint();
+    if (fp && fp !== lastFingerprint) {
+      lastFingerprint = fp;
+      send(IPC.screenshotDetected, { source: "clipboard" });
+    }
+  }, 500);
+
+  // --- Desktop folder watcher ---
+  const desktop = join(homedir(), "Desktop");
+  try {
+    screenshotDesktopWatcher = fsWatch(desktop, (event, filename) => {
+      if (event !== "rename" || !filename) return;
+      if (!SCREENSHOT_RE.test(basename(filename))) return;
+      const fullPath = join(desktop, filename);
+      // Small delay — fs.watch fires on the rename (inode creation) before
+      // the file is fully written. 300ms is enough for a PNG flush.
+      setTimeout(() => {
+        send(IPC.screenshotDetected, {
+          source: "file",
+          path: fullPath,
+        });
+      }, 300);
+    });
+  } catch {
+    // Desktop might not exist or be accessible (e.g. on Linux in dev).
+    // Silently skip — clipboard poller still works.
+  }
+}
+
+export function stopScreenshotDetector(): void {
+  if (screenshotClipboardTimer) {
+    clearInterval(screenshotClipboardTimer);
+    screenshotClipboardTimer = null;
+  }
+  if (screenshotDesktopWatcher) {
+    screenshotDesktopWatcher.close();
+    screenshotDesktopWatcher = null;
+  }
+}
+
+// IPC: renderer calls this to read the current clipboard image as PNG bytes.
+// Separate from the poller so we only read full pixel data on demand.
+export function readClipboardImageBuffer(): Buffer | null {
+  const img = clipboard.readImage();
+  if (img.isEmpty()) return null;
+  return img.toPNG();
+}


### PR DESCRIPTION
Pure refactor — no behaviour change. Extracts the macOS screenshot auto-attach detector out of `src/main/index.ts` into a dedicated `src/main/screenshotDetector.ts`, matching the `desktopPresence.ts` / `desktopNotify.ts` `startX`/`stopX` precedent.

## What moved (verbatim, except the single signature change)
- The whole `// ===== Screenshot detector =====` comment block, `SCREENSHOT_RE`, the two module-level `let`s, `clipboardImageFingerprint()`, `startScreenshotDetector()`, `stopScreenshotDetector()`, `readClipboardImageBuffer()`.
- `startScreenshotDetector` now takes a `send: (channel, payload) => void` sender. The three `if (!mainWindow || mainWindow.isDestroyed()) return;` guards were deleted; the caller's closure in index.ts now owns that check.
- `600ms` → keeps the exact original **500ms poll / 300ms settle**, the `process.platform !== "darwin"` early return, the silent `catch {}` around `fs.watch`, and the verbatim `SCREENSHOT_RE` pattern.
- No IPC channel, payload, preload, renderer, or shared-type changes. No new npm dependency.

## Call sites updated in `src/main/index.ts`
- inside `did-finish-load` → `startScreenshotDetector((channel, payload) => … webContents.send …)`
- inside `window-all-closed` and `before-quit` → `stopScreenshotDetector()` (unchanged text, now the imported one)
- the `clipboardReadImage` handler imports `readClipboardImageBuffer` from the new module

## Imports cleaned up
- Removed `basename` and `watch as fsWatch` from index.ts (`git grep` confirmed both only fed the moved block). Kept `homedir`, `join`, `clipboard`, `readFile` — all still used by unrelated code in index.ts.

**Files changed:** 2.
- `src/main/index.ts` (−103 lines)
- `src/main/screenshotDetector.ts` (+104 lines, new)

**Base: origin/main @ `ed72768`**

**Verification results:**
- PR branch (`multica/BET-1076-extract-screenshot-detector` @ `8a41a90`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 1, 2188 pass / 2 fail / 0 skip. Failures: `src/server/providers.test.mjs`, `src/server/rpc.test.mjs`. log sha256: `a4cc17b58a736174e3bdf68096936e8a2c71ea8eab60daeae6acc6ad2992bde7`
- Base (`main` @ `ed72768`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 1, 2188 pass / 2 fail / 0 skip. Failures: `src/server/providers.test.mjs`, `src/server/rpc.test.mjs`. log sha256: `d673ba8bf1a72c5e756fe6a2680ed4786a5e890d0e1686dcff3e57adf445b30a`
- **Conclusion:** 2 test failures are pre-existing (identical between branches, in `src/server/` which this PR does not touch); 0 failures are new; 0 resolved by this PR.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
