### PR TITLE
BET-1078: fix(main): report a refused Desktop-folder permission instead of going silent

### DIFF
--- a/src/main/screenshotDetector.ts
+++ b/src/main/screenshotDetector.ts
@@ -27,6 +27,7 @@
 import { clipboard } from "electron";
 import { basename, join } from "node:path";
 import { watch as fsWatch } from "node:fs";
+import { readdir } from "node:fs/promises";
 import { execFile } from "node:child_process";
 import { promisify } from "node:util";
 import { IPC } from "../shared/types.js";
@@ -36,6 +37,25 @@ const execFileAsync = promisify(execFile);
 
 let screenshotClipboardTimer: ReturnType<typeof setInterval> | null = null;
 let screenshotDesktopWatcher: ReturnType<typeof fsWatch> | null = null;
+
+// A refused Desktop-folder privacy permission silently kills the file watcher
+// (readdir/fs.watch throw EPERM/EACCES). Report the failure to the user once
+// per app run so screenshot auto-attach dying is never silent.
+let unavailableReported = false;
+
+function reportUnavailable(
+  send: (channel: string, payload: unknown) => void,
+  dir: string,
+  err: unknown,
+): void {
+  if (unavailableReported) return;
+  unavailableReported = true;
+  const code = (err as NodeJS.ErrnoException).code;
+  send(IPC.screenshotDetected, {
+    source: "unavailable",
+    reason: `Can't read ${dir}: ${code ?? "unknown error"}`,
+  });
+}
 
 // macOS stamps every screenshot it writes with this extended attribute. It is
 // set by the OS at creation and survives renaming, moving and any locale — it
@@ -84,6 +104,15 @@ async function initFileWatcher(send: (channel: string, payload: unknown) => void
     // the ~/Desktop default. Not an error, must not be logged as one.
   }
   const dir = resolveScreenshotDir(rawLocation);
+  // A refused Desktop-folder privacy permission makes readdir throw EPERM/
+  // EACCES. Probe before watching so the refusal is surfaced to the user
+  // instead of silently killing screenshot auto-attach forever.
+  try {
+    await readdir(dir);
+  } catch (err) {
+    reportUnavailable(send, dir, err);
+    return;
+  }
   try {
     screenshotDesktopWatcher = fsWatch(dir, (event, filename) => {
       if (event !== "rename" || !filename) return;
@@ -99,9 +128,10 @@ async function initFileWatcher(send: (channel: string, payload: unknown) => void
         });
       }, 300);
     });
-  } catch {
-    // Directory might not exist or be accessible. Silently skip — clipboard
-    // poller still works.
+  } catch (err) {
+    // fs.watch itself can also throw on an inaccessible directory. Same
+    // report-and-stop; clipboard poller still works.
+    reportUnavailable(send, dir, err);
   }
 }
 

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -76,9 +76,9 @@ const api = {
     ipcRenderer.invoke(IPC.readLocalFile, path),
 
   onScreenshotDetected: (
-    cb: (ev: { source: "clipboard" | "file"; path?: string }) => void,
+    cb: (ev: { source: "clipboard" | "file" | "unavailable"; path?: string; reason?: string }) => void,
   ): (() => void) => {
-    const listener = (_: unknown, ev: { source: "clipboard" | "file"; path?: string }) => cb(ev);
+    const listener = (_: unknown, ev: { source: "clipboard" | "file" | "unavailable"; path?: string; reason?: string }) => cb(ev);
     ipcRenderer.on(IPC.screenshotDetected, listener);
     return () => ipcRenderer.removeListener(IPC.screenshotDetected, listener);
   },

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -801,6 +801,15 @@ function Shell() {
     const preload = getMantaPreload();
     if (!preload) return;
     const off = preload.onScreenshotDetected((ev) => {
+      if (ev.source === "unavailable") {
+        useStore.getState().pushAppToast({
+          tone: "error",
+          message:
+            `Screenshot detection is off — ${ev.reason ?? "the folder can't be read"}. ` +
+            `Grant Manta UI access under System Settings > Privacy & Security > Files and Folders, then restart the app.`,
+        });
+        return;
+      }
       // Read the bytes HERE, once. Two reasons this is not just moved code:
       // the clipboard can hold something else by the time the user clicks, and
       // doing it here collapses the old accept path's file-vs-clipboard branch

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -770,7 +770,7 @@ export const httpApi: Api = {
 
   // -- screenshot detection (SSE push) --
   onScreenshotDetected: (cb) =>
-    on<{ source: "clipboard" | "file"; path?: string }>("screenshot", cb),
+    on<{ source: "clipboard" | "file" | "unavailable"; path?: string; reason?: string }>("screenshot", cb),
 
   // Desktop OS-notification directives from manta-server's notification router.
   // The /events WS delivers `desktopNotify` envelopes; subscribing here wires

--- a/src/renderer/preloadAccess.ts
+++ b/src/renderer/preloadAccess.ts
@@ -34,7 +34,7 @@ export type { InstallerEvent, InstallerState, InstallerStageSnapshotRow, Preflig
  */
 export interface MantaPreload {
   onScreenshotDetected(
-    cb: (ev: { source: "clipboard" | "file"; path?: string }) => void,
+    cb: (ev: { source: "clipboard" | "file" | "unavailable"; path?: string; reason?: string }) => void,
   ): () => void;
   // Subscribe to manta:// pair links delivered by the OS protocol handler.
   // The renderer validates the URL with parsePairPayload and routes it into

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -287,7 +287,7 @@ export interface Api {
   clipboardReadImage(): Promise<ArrayBuffer | null>;
 
   onScreenshotDetected(
-    cb: (ev: { source: "clipboard" | "file"; path?: string }) => void,
+    cb: (ev: { source: "clipboard" | "file" | "unavailable"; path?: string; reason?: string }) => void,
   ): () => void;
 
   // manta-server's notification router decided the desktop should show an OS


### PR DESCRIPTION
Closes BET-1078

## What
When macOS gates the Desktop folder behind a privacy permission the user has
denied (or never accepted), `fs.watch` on that folder fails and the old code
swallowed it in a bare `catch {}` — screenshot auto-attach died silently with
no toast, no error, no path back.

This probes the watch directory with `readdir` (which throws `EPERM`/`EACCES`
on a refusal) before calling `fs.watch`, and reports the failure to the
renderer as a new `unavailable` source on the existing `screenshotDetected`
channel. `App.tsx` renders it as an error toast naming the System Settings >
Privacy & Security > Files and Folders path and a restart. Reported once per
app run.

## Design decisions honored
- No TCC-db read / no `tccutil` / no `sqlite3` — operational detection only.
- No new IPC channel, preload method, or `Api` entry — extended the existing
  `screenshotDetected` payload with `source: "unavailable"` + `reason`.
- Text-only toast; no System Settings deep-link button.

## Files changed
5 files.
- `src/main/screenshotDetector.ts` — `readdir` probe + `reportUnavailable`
  (once-per-run guard), replaces the bare `catch {}`.
- `src/shared/api.ts`, `src/preload/index.ts`, `src/renderer/preloadAccess.ts`
  — widened `screenshotDetected` payload type (byte-identical across all
  three).
- `src/renderer/api/httpApi.ts` — same payload type on the mobile/web shim.
- `src/renderer/App.tsx` — early `source === "unavailable"` branch that pushes
  an error toast and returns before the byte-reading block.

**Verification results:**
- PR branch (`multica/BET-1078-screenshot-permission-report`):
  - typecheck: exit 0, errors none, log sha256 `b3e043f9…`
  - test: exit 0, 2313 pass / 0 fail / 0 skip, log sha256 `da187ba9…`
- Base (`main` @ `c2702f58`):
  - typecheck: exit 0, errors none, log sha256 `b3e043f9…`
  - test: exit 0, 2313 pass / 0 fail / 0 skip, log sha256 `018b3322…`
- Conclusion: 0 new failures; identical pass count. `git grep -n "catch {}"
  src/main/screenshotDetector.ts` returns nothing; the three payload
  declarations are byte-identical.
- **Base: origin/main @ c2702f58**

Note: the runtime toast path is macOS/Electron-only and can't be exercised in
this headless Linux environment (the detector no-ops on non-darwin). The logic
is verified via typecheck + unit tests; manual verification of the toast
requires a Mac.
