### PR TITLE
fix(ios): plan toggle becomes a bare icon; model chip shortens and truncates (BET-1081)

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -249,6 +249,34 @@ enum ChatModel {
         }
     }
 
+    /// The vendor words the composer chip strips off a model's friendly name.
+    /// PORTED VERBATIM from `MODEL_BRAND_PREFIXES` in
+    /// `src/renderer/chatUtils.ts` — including the capitalisation, which is the
+    /// desktop's match and is therefore ours. When that list changes, change it
+    /// here; do not "improve" one side alone.
+    static let modelBrandPrefixes: Set<String> = [
+        "Claude", "Gemini", "DeepSeek", "Grok", "Mistral",
+        "Llama", "Qwen", "Command", "Gemma", "Phi", "Gpt",
+    ]
+
+    /// Compact display name for the composer chip — the Swift twin of the
+    /// desktop's `shortModelName`. The name opencode returns is usually
+    /// "<brand> <family> <version>" ("Claude Opus 5"); the chip shows the family
+    /// and version only ("Opus 5"), leaving the effort run beside it as the only
+    /// other token. An unknown prefix falls through unchanged, so no name is ever
+    /// mangled — and a name that is nothing BUT a brand word is returned whole
+    /// rather than emptied.
+    static func shortName(_ name: String) -> String {
+        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard let space = trimmed.firstIndex(of: " ") else { return trimmed }
+        guard modelBrandPrefixes.contains(String(trimmed[trimmed.startIndex..<space])) else {
+            return trimmed
+        }
+        let rest = trimmed[trimmed.index(after: space)...]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return rest.isEmpty ? trimmed : rest
+    }
+
     /// Capability glyphs for a catalogue row, in display order: "reasoning"
     /// when the model reasons, "vision" when it accepts image input. Both read
     /// the box's own capability flags rather than being inferred — a model can

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -455,16 +455,19 @@ struct ComposerView: View {
             Button {
                 modelStore.setPlan(!plan.on)
             } label: {
-                HStack(spacing: Metrics.spacing.sp1) {
-                    Image(systemName: planIcon)
-                        .font(.system(size: Metrics.type.xs, weight: .medium))
-                    Text("Plan")
-                        .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
-                }
-                .foregroundColor(plan.on ? tokens.accentTx : tokens.tx2)
-                .padding(.vertical, Metrics.spacing.sp1)
-                .padding(.horizontal, Metrics.spacing.sp2)
-                .background(plan.on ? tokens.accentSoft : tokens.inset, in: Capsule())
+                // Same shape as attach and mic: a bare glyph on a fixed
+                // `chatHeaderBtn` square, with a fill ONLY when it is on. A
+                // resting fill made this the one control in the row that read as
+                // a button rather than an affordance, and the label made it the
+                // one control whose width changed when its state did — which is
+                // the whole "animation" on toggle. Fixed frame, no text: the only
+                // thing that changes is the background.
+                Image(systemName: planIcon)
+                    .font(.system(size: Metrics.type.body, weight: .medium))
+                    .foregroundColor(plan.on ? tokens.accentTx : tokens.tx2)
+                    .frame(width: Metrics.type.chatHeaderBtn, height: Metrics.type.chatHeaderBtn)
+                    .background(plan.on ? tokens.accentSoft : Color.clear, in: Circle())
+                    .contentShape(Rectangle())
             }
             .buttonStyle(.plain)
             // A lit-but-unavailable chip is honest, not toggleable: the plan
@@ -609,8 +612,10 @@ struct ComposerView: View {
     }
 
     /// The chip's single-line label: "✦ Opus 4.7 · High" + bolt when fast.
-    /// `.lineLimit(1)` + `.fixedSize(horizontal:)` is load-bearing — the model
-    /// name must never wrap at any Dynamic Type size.
+    /// `.lineLimit(1)` is load-bearing — the model name must never wrap at any
+    /// Dynamic Type size. It must NOT be paired with `.fixedSize(horizontal:)`:
+    /// that pins the text to its natural width, so a long name pushes the control
+    /// row past the composer box and off the screen edge instead of truncating.
     private var chipLabel: some View {
         HStack(spacing: Metrics.spacing.sp1) {
             if modelStore.loaded {
@@ -619,7 +624,7 @@ struct ComposerView: View {
                 Text(resolvedChipText)
                     .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                     .lineLimit(1)
-                    .fixedSize(horizontal: true, vertical: false)
+                    .truncationMode(.tail)
                 if isFastActive {
                     Image(systemName: "bolt.fill")
                         .font(.system(size: Metrics.type.xs, weight: .semibold))
@@ -636,7 +641,6 @@ struct ComposerView: View {
         .padding(.vertical, Metrics.spacing.sp1)
         .padding(.horizontal, Metrics.spacing.sp2)
         .background(tokens.accentSoft, in: Capsule())
-        .lineLimit(1)
     }
 
     private var activeModel: OpencodeModel? {
@@ -653,7 +657,7 @@ struct ComposerView: View {
     /// one visible is how a quota gets burned on max effort unnoticed.
     private var resolvedChipText: String {
         guard let model = activeModel else { return "Default" }
-        var parts = [model.name]
+        var parts = [ChatModel.shortName(model.name)]
         if let variant = modelStore.variant, !variant.isEmpty {
             parts.append(ChatModel.effortLabel(variant))
         }

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -219,6 +219,33 @@ final class ComposerTests: XCTestCase {
         XCTAssertEqual(on.title, "Plan mode on — edits blocked. Click to build.")
     }
 
+    // MARK: - ChatModel.shortName
+
+    func testShortNameStripsKnownBrandPrefix() {
+        XCTAssertEqual(ChatModel.shortName("Claude Opus 5"), "Opus 5")
+    }
+
+    func testShortNameLeavesUnknownPrefixAlone() {
+        XCTAssertEqual(ChatModel.shortName("Kimi K3 Turbo"), "Kimi K3 Turbo")
+    }
+
+    func testShortNameLeavesSingleWordAlone() {
+        XCTAssertEqual(ChatModel.shortName("Claude"), "Claude")
+        XCTAssertEqual(ChatModel.shortName("o3"), "o3")
+    }
+
+    func testShortNameMatchingIsCaseSensitive() {
+        XCTAssertEqual(ChatModel.shortName("claude opus 5"), "claude opus 5")
+    }
+
+    func testShortNameHandlesSurroundingAndDoubledInnerWhitespace() {
+        XCTAssertEqual(ChatModel.shortName("  Claude  Opus 5  "), "Opus 5")
+    }
+
+    func testShortNameRemovesOnlyFirstWord() {
+        XCTAssertEqual(ChatModel.shortName("Gemini Claude Weird"), "Claude Weird")
+    }
+
     // MARK: - ChatVoice.mime
 
     func testMimeFromFilenameExtension() {


### PR DESCRIPTION
Opened automatically for `multica/BET-1081-composer-chip-and-plan-icon`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1081.