### PR TITLE
fix(ios): lock crossfades into the hands-free bar instead of cutting (BET-1082)

### DIFF
--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -198,24 +198,31 @@ struct ComposerView: View {
                 )
                 .transition(.opacity)
             }
-            if recorder.isHandsFree {
-                VoiceRecordingLockedView(
-                    recorder: recorder,
-                    tokens: tokens,
-                    onTake: { take in Task { await handleVoiceTake(take) } },
-                    onDiscarded: {
-                        UIAccessibility.post(notification: .announcement, argument: "Recording discarded")
-                    }
-                )
-                .transition(.opacity)
-            } else {
-                // ONE glass box, always. While a take is held the box keeps its size and
-                // its chrome and swaps its CONTENTS for the recording surface (see
-                // `inputBox`) — the composer stays MOUNTED because the mic button owns the
-                // in-flight touch and a view removed mid-gesture stops receiving it
-                // (BET-1051).
+            // ONE glass box, always. While a take is held the box keeps its size and
+            // its chrome and swaps its CONTENTS for the recording surface (see
+            // `inputBox`) — the composer stays MOUNTED because the mic button owns the
+            // in-flight touch and a view removed mid-gesture stops receiving it
+            // (BET-1051). The hands-free locked bar rides in the SAME ZStack and
+            // crossfades in on the phase-keyed `.smooth` curve (BET-1082): `inputBox`
+            // is only faded out + made inert while the take is hands-free, never
+            // swapped out structurally — a structural if/else removal/insertion here
+            // was what made the lock CUT to the bar instead of animating into it.
+            ZStack(alignment: .top) {
                 inputBox
+                    .opacity(recorder.isHandsFree ? 0 : 1)
+                    .allowsHitTesting(!recorder.isHandsFree)
+                    .accessibilityHidden(recorder.isHandsFree)
+                if recorder.isHandsFree {
+                    VoiceRecordingLockedView(
+                        recorder: recorder,
+                        tokens: tokens,
+                        onTake: { take in Task { await handleVoiceTake(take) } },
+                        onDiscarded: {
+                            UIAccessibility.post(notification: .announcement, argument: "Recording discarded")
+                        }
+                    )
                     .transition(.opacity)
+                }
             }
         }
         .padding(.horizontal, Metrics.spacing.sp3)


### PR DESCRIPTION
**Base: origin/main @ bfd2769b**

## Problem

Locking a voice take (BET-1064 QA) **cut** to the hands-free bar instead of
animating into it. `lockProgress` reached 1 and the lane outline changed, but
the composer instantly swapped to the locked bar with no transition.

## Root cause

The held→locked swap in `ComposerView` was a structural `if/else`:

```swift
if recorder.isHandsFree {
    VoiceRecordingLockedView(...).transition(.opacity)
} else {
    inputBox.transition(.opacity)
}
```

...animated by the parent's `.animation(.smooth(duration: 0.22), value:
recorder.phase)`. An insertion/removal at that *top-level branch* of the
composer VStack is exactly the case that doesn't reliably pick up the
phase-keyed animation: the locked bar appeared via a different update path than
the inner held-surface transitions (which do animate). Net effect: the take
snapped to the bar.

## Fix

Both surfaces now share **one `ZStack`**, and `inputBox` is never unmounted:

- `inputBox` stays mounted and merely fades to `opacity 0` when hands-free,
  with `allowsHitTesting(false)` + `accessibilityHidden(true)` so the invisible
  composer can't swallow taps or get read by VoiceOver.
- `VoiceRecordingLockedView` crossfades in over it with `.transition(.opacity)`.

Both the `inputBox` opacity and the locked-bar insertion are keyed off the
same `recorder.phase` change, so the lock dissolves into the hands-free bar on
the same `.smooth(0.22)` curve every other phase change uses.

**BET-1051 honoured, stronger than before:** the composer box is *never* removed
mid-gesture — it stayed mounted while held (BET-1060) and now also stays
mounted through the lock, only hidden. The mic button's in-flight touch is
never orphaned by an unmount.

**Phase machine untouched** — `VoiceGesture.swift` and `VoiceRecorder.swift`
are not modified; this is purely presentational.

## Files changed

- `mobile/native/MantaUI/ComposerView.swift` (1 file, +23/−16)

## Verification results

The change is **Swift-only** — it is not exercised by the repo's npm typecheck
or node/vitest suites. Both branch runs are identical by construction, captured
below for completeness:

- PR branch (`multica/BET-1082-lock-animate` @ `ab397d9d`):
  - typecheck: exit 0, no errors. log sha256: `b3e043f9…2a21a92f13`
  - test: exit 0, **2326 pass / 0 fail / 0 skip**. log sha256: `049b6989…d9c9c3`
- Base (`main` @ `bfd2769b`):
  - typecheck: exit 0, no errors. log sha256: `b3e043f9…2a21a92f13` (byte-identical)
  - test: exit 0, **2326 pass / 0 fail / 0 skip**. log sha256: `fec4aada…fbdde76b`
- **Conclusion:** 0 new failures. The only pending verification is the native
  Swift animation, which the repo's test toolchains cannot run.

## Native Swift verification (macos / human sim)

The `.smooth` opacity crossfade cannot be asserted by the project's XCTest/UI
tests — XCUI observes end states, not animation frames. The existing UI test
`MantaVoiceRecordingUITests.testMicHoldSlideUpLocks` (`MantaUIUITests/
MantaVoiceRecordingUITests.swift`) already proves the locked surface **mounts**
after the slide-up gesture; it cannot prove *animated* vs *snapped*.

Verification step for `macos` / a human sim run (the acceptance "no cut" from
the issue):
1. Build `ios-mantaui`, install + launch in the Simulator.
2. On the mic button: press, slide up 160pt, release.
3. Visually confirm the held surface **dissolves** into the hands-free bar over
   ~0.22s on the smooth curve (crossfade), rather than instantly swapping.

Per the issue's allowance, this is documented — not faked — because animation
frames are not measurable in the available test harness.
