### PR TITLE
fix(renderer): restore mutation-error feedback in Settings cards (BET-1063)

### DIFF
--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -108,7 +108,7 @@ export function ConnectProvider({
 }: {
   id: string;
   label: string;
-  onDone: (connected: boolean) => void;
+  onDone: () => void;
   onCancel: () => void;
 }): JSX.Element {
   const [phase, setPhase] = useState<ConnectPhase>({ kind: "starting" });
@@ -552,7 +552,7 @@ export function ConnectProvider({
   // the flow never advanced; BET-354 cycle-2 Block #1).
   useEffect(() => {
     if (phase.kind !== "done") return;
-    onDone(true);
+    onDone();
   }, [phase.kind, onDone]);
 
   const retry = useCallback(() => {

--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -184,6 +184,7 @@ export function ModelsCard() {
     loading,
     error,
     refresh,
+    mutate,
   } = useCachedResource<{ models: OpencodeModel[]; cfg: AppConfig }>("models", async () => {
     const [modelList, cfg] = await Promise.all([
       window.api.opencodeModels(),
@@ -237,26 +238,26 @@ export function ModelsCard() {
     async (key: string, currentlyMain: boolean) => {
       if (busy || !models) return;
       setBusy(key);
-      try {
-        const nextMain = new Set(deactivatedMain);
-        if (currentlyMain) nextMain.add(key);
-        else nextMain.delete(key);
-        const nextMainList = [...nextMain];
-        // Invariant: a saved defaultModel MUST be Main-available. When the
-        // user turns Main off on the current default, clear defaultModel in
-        // the SAME save so the persisted config never violates the invariant.
-        const isCurrentDefault =
-          currentlyMain &&
-          savedDefault != null &&
-          modelKey(savedDefault.providerID, savedDefault.modelID) === key;
-        const patch: Record<string, unknown> = { deactivatedMainModels: nextMainList };
-        if (isCurrentDefault) {
-          // `null` (not `undefined`) — JSON.stringify drops `undefined` keys,
-          // so passing null is the only way the server actually clears the
-          // field. The store's applyConfig normalizes any null back to null
-          // and the existing defaultModel?: type allows absence.
-          patch.defaultModel = null;
-        }
+      const nextMain = new Set(deactivatedMain);
+      if (currentlyMain) nextMain.add(key);
+      else nextMain.delete(key);
+      const nextMainList = [...nextMain];
+      // Invariant: a saved defaultModel MUST be Main-available. When the
+      // user turns Main off on the current default, clear defaultModel in
+      // the SAME save so the persisted config never violates the invariant.
+      const isCurrentDefault =
+        currentlyMain &&
+        savedDefault != null &&
+        modelKey(savedDefault.providerID, savedDefault.modelID) === key;
+      const patch: Record<string, unknown> = { deactivatedMainModels: nextMainList };
+      if (isCurrentDefault) {
+        // `null` (not `undefined`) — JSON.stringify drops `undefined` keys,
+        // so passing null is the only way the server actually clears the
+        // field. The store's applyConfig normalizes any null back to null
+        // and the existing defaultModel?: type allows absence.
+        patch.defaultModel = null;
+      }
+      await mutate(async () => {
         const cfg = await window.api.configUpdate(patch);
         const resolvedList = cfg.deactivatedMainModels ?? nextMainList;
         setDeactivatedMain(new Set(resolvedList));
@@ -267,22 +268,21 @@ export function ModelsCard() {
           // typed for setting, not clearing).
           useStore.setState({ defaultModel: null });
         }
-      } finally {
-        setBusy(null);
-      }
+      });
+      setBusy(null);
     },
-    [busy, models, deactivatedMain, savedDefault],
+    [busy, mutate, models, deactivatedMain, savedDefault],
   );
 
   const toggleSub = useCallback(
     async (key: string, currentlyActive: boolean) => {
       if (busy || !models) return;
       setBusy(key);
-      try {
-        const nextSet = new Set(deactivatedSub);
-        if (currentlyActive) nextSet.add(key);
-        else nextSet.delete(key);
-        const nextList = [...nextSet];
+      const nextSet = new Set(deactivatedSub);
+      if (currentlyActive) nextSet.add(key);
+      else nextSet.delete(key);
+      const nextList = [...nextSet];
+      await mutate(async () => {
         const cfg = await window.api.configUpdate({ deactivatedSubagents: nextList });
         const resolvedList = cfg.deactivatedSubagents ?? nextList;
         await window.api.opencodeSyncSubagents({
@@ -293,11 +293,10 @@ export function ModelsCard() {
         // Sub toggles write opencode.jsonc agent blocks — a restart is
         // required for opencode to re-read them. Raise the panel banner.
         useStore.getState().setOpencodeRestartNeeded(true);
-      } finally {
-        setBusy(null);
-      }
+      });
+      setBusy(null);
     },
-    [busy, models, deactivatedSub],
+    [busy, mutate, models, deactivatedSub],
   );
 
   // Default radio — single-select. Writes defaultModel via the store's
@@ -306,14 +305,13 @@ export function ModelsCard() {
     async (providerID: string, modelID: string) => {
       if (busy) return;
       setBusy("__default__");
-      try {
+      await mutate(async () => {
         await setStoreDefaultModel({ providerID, modelID });
         void refresh();
-      } finally {
-        setBusy(null);
-      }
+      });
+      setBusy(null);
     },
-    [busy, setStoreDefaultModel, refresh],
+    [busy, mutate, setStoreDefaultModel, refresh],
   );
 
   // Save a model display override (name / description / context) drafted in the
@@ -325,7 +323,7 @@ export function ModelsCard() {
     async (key: string, _model: OpencodeModel, override: ModelOverride) => {
       if (busy) return;
       setBusy(key);
-      try {
+      await mutate(async () => {
         const cfg = await window.api.configGet();
         const existing = cfg.modelOverrides ?? {};
         const next = { ...existing };
@@ -337,11 +335,10 @@ export function ModelsCard() {
         await refresh();
         setEditing(null);
         refreshModelCatalog();
-      } finally {
-        setBusy(null);
-      }
+      });
+      setBusy(null);
     },
-    [busy, refresh],
+    [busy, mutate, refresh],
   );
 
   // ---- Render ----

--- a/src/renderer/ProvidersCard.tsx
+++ b/src/renderer/ProvidersCard.tsx
@@ -27,6 +27,7 @@ export function ProvidersCard({ onRestartNeeded }: Props) {
     loading,
     error,
     refresh,
+    mutate,
   } = useCachedResource<ProviderEndpoint[]>("providers", () =>
     window.api.opencodeGetProviders(),
   );
@@ -60,32 +61,30 @@ export function ProvidersCard({ onRestartNeeded }: Props) {
       ? ep.enabledModels.filter((m) => m !== modelId)
       : [...ep.enabledModels, modelId];
     setBusy(ep.id);
-    try {
+    await mutate(async () => {
       const res = await window.api.opencodeSetProviders({
         upsert: [{ id: ep.id, name: ep.name, baseURL: ep.baseURL, enabledModels: enabled }],
       });
-      if (!res.ok) return;
+      if (!res.ok) throw new Error(res.error ?? "Save failed");
       onRestartNeeded();
       refresh();
-    } finally {
-      setBusy(null);
-    }
-  }, [busy, refresh, onRestartNeeded]);
+    });
+    setBusy(null);
+  }, [busy, mutate, refresh, onRestartNeeded]);
 
   const removeEndpoint = useCallback(async (ep: ProviderEndpoint) => {
     if (busy) return;
     setBusy(ep.id);
-    try {
+    await mutate(async () => {
       const res = await window.api.opencodeSetProviders({ remove: [ep.id] });
-      if (!res.ok) return;
+      if (!res.ok) throw new Error(res.error ?? "Remove failed");
       setDiscovered((d) => { const { [ep.id]: _drop, ...rest } = d; return rest; });
       setDiscoverError((er) => { const { [ep.id]: _drop, ...rest } = er; return rest; });
       onRestartNeeded();
       refresh();
-    } finally {
-      setBusy(null);
-    }
-  }, [busy, refresh, onRestartNeeded]);
+    });
+    setBusy(null);
+  }, [busy, mutate, refresh, onRestartNeeded]);
 
   return (
     <div className="space-y-2">

--- a/src/renderer/ProvidersStep.tsx
+++ b/src/renderer/ProvidersStep.tsx
@@ -98,7 +98,7 @@ export function ProvidersStep({
   const canContinue = canContinueProviders(statuses ?? []);
 
   const onConnectDone = useCallback(
-    (_ok: boolean) => {
+    () => {
       setConnectingId(null);
       void refresh();
     },

--- a/src/renderer/SubscriptionsCard.tsx
+++ b/src/renderer/SubscriptionsCard.tsx
@@ -30,6 +30,7 @@ export function SubscriptionsCard() {
     loading,
     error,
     refresh,
+    mutate,
   } = useCachedResource<SubscriptionStatus[]>("subscriptions", async () => {
     const res = await window.api.opencodeProviderAuth({ action: "status" });
     // Route protocol surprises through the hook's error path rather than
@@ -49,16 +50,17 @@ export function SubscriptionsCard() {
     async (id: string) => {
       if (busy) return;
       setBusy(id);
-      try {
-        await window.api.opencodeProviderAuth({ action: "disconnect", id });
-      } finally {
-        setBusy(null);
-        setDisconnectConfirmId(null);
+      await mutate(async () => {
+        const res = await window.api.opencodeProviderAuth({ action: "disconnect", id });
+        if (res.action !== "disconnect") throw new Error("Unexpected response from the box.");
+        if (!res.ok) throw new Error(res.error ?? "Disconnect failed.");
         // Refetch to reflect the box's current state after the mutation.
         void refresh();
-      }
+      });
+      setBusy(null);
+      setDisconnectConfirmId(null);
     },
-    [busy, refresh],
+    [busy, mutate, refresh],
   );
 
   const onConnectDone = useCallback(() => {

--- a/src/renderer/useCachedResource.test.tsx
+++ b/src/renderer/useCachedResource.test.tsx
@@ -17,7 +17,7 @@ function Probe({
   resourceKey: string;
   fetcher: () => Promise<number>;
 }) {
-  const { data, loading, error, refresh } = useCachedResource<number>(resourceKey, fetcher);
+  const { data, loading, error, refresh, mutate } = useCachedResource<number>(resourceKey, fetcher);
   return (
     <div>
       <span data-testid="loading">{String(loading)}</span>
@@ -25,6 +25,12 @@ function Probe({
       <span data-testid="error">{error ?? ""}</span>
       <button data-testid="refresh" onClick={() => void refresh()}>
         refresh
+      </button>
+      <button data-testid="mutate-fail" onClick={() => void mutate(async () => { throw new Error("nope"); })}>
+        mutate fail
+      </button>
+      <button data-testid="mutate-ok" onClick={() => void mutate(async () => {})}>
+        mutate ok
       </button>
     </div>
   );
@@ -109,6 +115,41 @@ describe("useCachedResource", () => {
     invalidateCachedResource("invalidate");
     h = mount(<Probe resourceKey="invalidate" fetcher={async () => 42} />);
     expect(loadState()).toEqual({ loading: "true", data: "null", error: "" });
+    await h.flush();
+    expect(loadState()).toEqual({ loading: "false", data: "42", error: "" });
+  });
+
+  it("mutate failure sets error and leaves cached data alone", async () => {
+    h = mount(<Probe resourceKey="mutate-fail" fetcher={async () => 42} />);
+    await h.flush();
+    expect(loadState()).toEqual({ loading: "false", data: "42", error: "" });
+    act(() => {
+      document.body.querySelector('[data-testid="mutate-fail"]')?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+    await h.flush();
+    // Error surfaces, cached data untouched, loading never flips.
+    expect(loadState()).toEqual({ loading: "false", data: "42", error: "nope" });
+  });
+
+  it("mutate success clears a previous error", async () => {
+    h = mount(<Probe resourceKey="mutate-ok" fetcher={async () => 42} />);
+    await h.flush();
+    // Set an error first via a failing mutate.
+    act(() => {
+      document.body.querySelector('[data-testid="mutate-fail"]')?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
+    await h.flush();
+    expect(loadState().error).toBe("nope");
+    // A succeeding mutate clears it, data unchanged.
+    act(() => {
+      document.body.querySelector('[data-testid="mutate-ok"]')?.dispatchEvent(
+        new MouseEvent("click", { bubbles: true }),
+      );
+    });
     await h.flush();
     expect(loadState()).toEqual({ loading: "false", data: "42", error: "" });
   });

--- a/src/renderer/useCachedResource.ts
+++ b/src/renderer/useCachedResource.ts
@@ -31,6 +31,20 @@ export function useCachedResource<T>(
   error: string | null;
   /** Force a refetch and update the cache. Never flips `loading`. */
   refresh: () => Promise<void>;
+  /** Run a mutation that writes to this resource, routing a failure into the
+   *  SAME `error` this hook already exposes — so the card needs no second
+   *  error state and no extra JSX. Never throws and never flips `loading`.
+   *
+   *  On success `error` is cleared. On a throw the message lands in `error`
+   *  and NOTHING ELSE RUNS — which is why every call site puts its own
+   *  `refresh()` INSIDE `fn`: a refresh after a failed mutation would call
+   *  `load()`, whose success path clears `error`, wiping the message that was
+   *  just set. (A failed mutation changed nothing on the box, so there is
+   *  nothing to refetch anyway.)
+   *
+   *  An API that reports failure as a RESULT rather than a rejection (e.g.
+   *  `{ ok: false, error }`) must be turned into a `throw` inside `fn`. */
+  mutate: (fn: () => Promise<void>) => Promise<void>;
 } {
   const [data, setData] = useState<T | null>(() =>
     cache.has(key) ? (cache.get(key) as T) : null,
@@ -80,7 +94,16 @@ export function useCachedResource<T>(
     await load(false);
   }, [load]);
 
-  return { data, loading, error, refresh };
+  const mutate = useCallback(async (fn: () => Promise<void>) => {
+    try {
+      await fn();
+      if (!cancelledRef.current) setError(null);
+    } catch (e) {
+      if (!cancelledRef.current) setError(e instanceof Error ? e.message : String(e));
+    }
+  }, []);
+
+  return { data, loading, error, refresh, mutate };
 }
 
 export function invalidateCachedResource(key: string): void {


### PR DESCRIPTION
## What
Restore mutation-error feedback in the Settings cards (silent since BET-1057).

A failed Settings mutation (disconnect, provider toggle/remove, model main/sub/default/edit)
was 100% silent — the control snapped back with no message, reading as a frozen UI. Rather
than re-adding a per-card `error` state + try/catch (the duplication BET-1057 deleted), this
adds ONE shared helper to the hook that already owns the error state: `mutate()` on
`useCachedResource`. Every call site puts its own `refresh()` inside `fn`, so a failed
mutation never runs a refresh (which would clear the just-set error, since a failed mutation
changed nothing on the box).

**Net effect:** three duplicated `try/finally` error paths collapse into one. Each card's
failure lands in the same `error` it already renders (`text-danger` div) — **no card gains a
single line of JSX.**

## Scope (per BET-1063)
- `src/renderer/useCachedResource.ts` — add `mutate`.
- `src/renderer/SubscriptionsCard.tsx` — `disconnect` (1 site; restores the previously-ignored
  `action`/`ok` response checks; `refresh()` moves from `finally` into the success path, which
  the `mutate` contract requires).
- `src/renderer/ProvidersCard.tsx` — `toggleModel`, `removeEndpoint` (2 sites; `if (!res.ok)
  return` silent-swallow → `throw`).
- `src/renderer/ModelsCard.tsx` — `toggleMain`, `toggleSub`, `setDefault`, `saveOverride`
  (4 sites; `toggleMain`/`toggleSub` deliberately gain NO `refresh()` to avoid triggering the
  heavy `"models"` fetcher on every checkbox click; `saveOverride`'s success-only steps stay
  inside `fn`).
- Tests in `src/renderer/useCachedResource.test.tsx` (2 new cases).
- Step 3 hygiene: narrowed `ConnectProvider.onDone(true)` → `onDone()` (dead param; both call
  sites ignore the argument; no third consumer reads it).

**Out of scope (explicitly per issue, not touched):** `Settings.tsx` (`togglePlugins`,
`toggleForgeRules`, `disconnectForge` — already surface failures via toast, not silent);
`ProvidersCard.discover` (keeps its own per-endpoint `discoverError`); `busy` stays per-card.

**Files changed:** 7.

Base: origin/main @ `bfd2769b`

**Verification results:**
- PR branch (`multica/BET-1063-mutation-error-feedback` @ `a3f182e2`):
  - typecheck: exit 0, errors none. log sha256 `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2326 pass / 0 fail / 0 skip. log sha256 `05d0e7cad75072c3997819078d4822ccf133f195d22eec7628b56d67a88b5f6f`
- Base (`main` @ `bfd2769b`): the checked-out main baseline; this PR is renderer-only (no
  server/shared impact), so server suite is unaffected. All 2326 tests pass on the PR branch.
- **Conclusion:** 0 new failures, 0 pre-existing failures on the PR branch.
- Acceptance greps (all pass): no `globalError`/`displayError`/`setError` in any card; no
  `if (!res.ok) return` in ProvidersCard; each card renders exactly ONE hook `text-danger`
  error div (ProvidersCard's per-endpoint `discoverError` div is the expected second).
- Diff stat: `git diff --stat origin/main...HEAD` → 7 files, 129 insertions(+)/67 deletions(-);
  cards net shorter or equal (SubscriptionsCard +2 is the issue-mandated restored response checks).

No follow-ups filed — the issue's explicitly out-of-scope items (Settings toasts) are already
non-silent and are a separate call per the issue itself.
