### PR TITLE
fix(ios): render live subagent cards and bound inline tool output (BET-1085)

### DIFF
--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -213,7 +213,10 @@ enum ChatSubagentMapper {
         return SubagentSession(
             taskName: taskName,
             status: .running,
-            duration: ChatDuration.text(seconds: payload.durationMs),
+            // `durationMs` is MILLISECONDS on the wire (the desktop reference
+            // renders it via ms/1000); ChatDuration.text takes seconds, so
+            // convert before the helper — 1200 → 1.2 → "1.2s".
+            duration: ChatDuration.text(seconds: payload.durationMs.map { $0 / 1000 }),
             transcript: [],
             childSessionId: payload.childSessionId
         )

--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -372,7 +372,7 @@ enum ChatTranscriptMapper {
 
         guard !(liveSteps.isEmpty && liveSubagents.isEmpty) else { return blocks }
 
-        var liveRows = liveSteps.map { .step($0) }
+        var liveRows: [StepGroupRow] = liveSteps.map { .step($0) }
         liveRows.append(contentsOf: liveSubagents.map { .subagent($0) })
 
         // Dedup against ids the canonical transcript already owns — STEP rows

--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -175,12 +175,47 @@ enum ChatSubagentMapper {
             duration = nil
         }
 
+        // The row's id must be unique per task part and stable across rebuilds:
+        // the child opencode session id when known, otherwise the tool's callID
+        // (never the task name — two subagents run under the same title would
+        // collide). See SubagentSession.init.
+        let callID = ChatJSON.string(part.extra["callID"])
+
         return SubagentSession(
             taskName: taskName,
             status: status,
             duration: duration,
             transcript: [],
-            childSessionId: childSessionId
+            childSessionId: childSessionId,
+            fallbackId: (callID?.isEmpty == false) ? callID : nil
+        )
+    }
+
+    /// The LIVE-subagent path: map the box's `stream/subagent` frame onto the
+    /// same SubagentSession the canonical mapper produces, so a running card
+    /// renders immediately from the live feed. `childSessionId` is always
+    /// present here — the box only emits the frame once opencode has stamped
+    /// the child session id.
+    static func session(from payload: StreamSubagentPayload) -> SubagentSession {
+        // Task name: the box's title first, then the description, then the
+        // agent id — a published subagent always carries at least a title.
+        let taskName: String
+        if let t = payload.title, !t.isEmpty {
+            taskName = t
+        } else if let d = payload.description, !d.isEmpty {
+            taskName = d
+        } else if let a = payload.agent, !a.isEmpty {
+            taskName = a
+        } else {
+            taskName = "subagent"
+        }
+
+        return SubagentSession(
+            taskName: taskName,
+            status: .running,
+            duration: ChatDuration.text(seconds: payload.durationMs),
+            transcript: [],
+            childSessionId: payload.childSessionId
         )
     }
 }
@@ -278,8 +313,8 @@ enum ChatTranscriptMapper {
         return blocks
     }
 
-    /// Append the still-running LIVE tools (streamed mid-turn by the box) to the
-    /// transcript, in the turn that spawned them.
+    /// Append the still-running LIVE tools AND live subagents (streamed mid-turn
+    /// by the box) to the transcript, in the turn that spawned them.
     ///
     /// This is the replacement for the deleted pinned running-tool overlay:
     /// a tool call renders inside the transcript (tailing its output as a live
@@ -287,7 +322,10 @@ enum ChatTranscriptMapper {
     /// `.running` step keyed by the SAME `callID` the canonical `stepIdentity`
     /// uses, so a live row and its completed canonical sibling share one
     /// identity and the turn-boundary refetch replaces the row IN PLACE — no
-    /// remove-and-reinsert flash (the whole point of this issue).
+    /// remove-and-reinsert flash (the whole point of this issue). A live
+    /// subagent becomes a `.subagent` card sourced from the box's `subagent`
+    /// frame, so the card renders while the subagent runs instead of arriving
+    /// only once it finishes.
     ///
     /// A live tool whose `callID` the transcript already owns is skipped: the
     /// canonical step has taken over, so appending again would duplicate it.
@@ -295,11 +333,19 @@ enum ChatTranscriptMapper {
     /// turn's rail); if the last step block is a rolled-up summary — completed
     /// content a running tool does not belong to — or there is none, a fresh
     /// group is opened at the end.
-    static func appendingLiveTools(_ liveTools: [LiveTool], to blocks: [TranscriptBlock]) -> [TranscriptBlock] {
-        guard !liveTools.isEmpty else { return blocks }
-
-        let liveSteps: [ToolStep] = liveTools.map { tool in
-            ToolStep(
+    static func appendingLive(
+        tools: [LiveTool],
+        subagents: [StreamSubagentPayload],
+        to blocks: [TranscriptBlock]
+    ) -> [TranscriptBlock] {
+        // A task part streams as an ordinary tool AND as the richer `subagent`
+        // frame (src/server/streamInterp.mjs documents the tool triple as
+        // redundant). Rendering both gives a bare "task" row next to the real
+        // card — and the tool row is the one that dumps the subagent's whole
+        // result into an unbounded view. The subagent frame is the only source.
+        let liveSteps: [ToolStep] = tools.compactMap { tool in
+            guard tool.name?.lowercased() != "task" else { return nil }
+            return ToolStep(
                 id: tool.callID.isEmpty ? tool.idx : tool.callID,
                 verb: StepVerb.text(for: tool.name ?? "tool"),
                 target: tool.presentationHint.flatMap { $0.isEmpty ? nil : $0 } ?? tool.name ?? "tool",
@@ -309,19 +355,31 @@ enum ChatTranscriptMapper {
             )
         }
 
+        // A finished subagent belongs to the canonical transcript, which owns it
+        // after the turn-boundary refetch; keeping the live copy too would
+        // double the row. Only pending/running payloads become live cards.
+        let liveSubagents: [SubagentSession] = subagents.compactMap { payload in
+            switch (payload.status ?? "").lowercased() {
+            case "pending", "running":
+                return ChatSubagentMapper.session(from: payload)
+            default:
+                return nil
+            }
+        }
+
+        guard !(liveSteps.isEmpty && liveSubagents.isEmpty) else { return blocks }
+
+        var liveRows = liveSteps.map { .step($0) }
+        liveRows.append(contentsOf: liveSubagents.map { .subagent($0) })
+
+        // Dedup against ids the canonical transcript already owns — STEP rows
+        // and SUBAGENT rows alike — so a live card disappears the instant the
+        // canonical one lands rather than briefly showing twice.
         let existingIDs = Set(blocks.flatMap { block -> [String] in
             guard case .steps(let content) = block else { return [] }
-            return content.rows.compactMap { row -> String? in
-                guard case .step(let step) = row else { return nil }
-                return step.id
-            }
+            return content.rows.map(\.id)
         })
-        // A live tool becomes a `.step` row — the `.rows` case holds
-        // `[StepGroupRow]`, and a step row is the step payload wrapped in
-        // `.step`. Deduping uses the ToolStep id before wrapping.
-        let toAppend: [StepGroupRow] = liveSteps
-            .filter { !existingIDs.contains($0.id) }
-            .map { .step($0) }
+        let toAppend = liveRows.filter { !existingIDs.contains($0.id) }
         guard !toAppend.isEmpty else { return blocks }
 
         var result = blocks
@@ -514,6 +572,46 @@ enum ChatQuestionAnswers {
             }
         }
         return true
+    }
+}
+
+// MARK: - Bounded tool-output preview
+
+/// The bounded preview of a tool's output shown inline in the transcript.
+///
+/// The box streams up to 20,000 characters per tool and flushes a tool's ENTIRE
+/// final output one frame before it marks the tool ended, so an inline view with
+/// no bound briefly renders thousands of points of text inside a self-sizing
+/// cell — which is what pushed the composer off screen. The full text is always
+/// one tap away (a subagent's on its drill-in screen; a command's in the
+/// terminal), so the inline copy is a peek, not the record.
+enum ToolOutputPreview {
+    static let maxLines = 12
+    static let maxCharacters = 2_000
+
+    /// Keep the LAST `maxLines` lines (output is a tail — the newest lines are
+    /// the interesting ones), then hard-cap the result to the last
+    /// `maxCharacters` characters so a single enormous line cannot escape the
+    /// line bound.
+    static func tail(_ output: String) -> String {
+        // An empty or whitespace-only input returns the input unchanged.
+        if output.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return output
+        }
+
+        let lines = output.components(separatedBy: "\n")
+        var result = output
+        var trimmed = false
+        if lines.count > maxLines {
+            result = lines.suffix(maxLines).joined(separator: "\n")
+            trimmed = true
+        }
+        if result.count > maxCharacters {
+            result = String(result.suffix(maxCharacters))
+            trimmed = true
+        }
+        // One prefix, whichever bound bit — so the reader can see it is a tail.
+        return trimmed ? "… \n" + result : result
     }
 }
 

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -630,7 +630,7 @@ final class ChatSessionStore: ObservableObject {
         // pristine while the live rows tail their output and vanish on
         // turnComplete (when the canonical refetch takes them over as steps).
         let liveTools = eventStore.sessionStates[sessionId]?.runningTools ?? []
-        let liveTranscript = ChatTranscriptMapper.appendingLiveTools(liveTools, to: transcript)
+        let liveTranscript = ChatTranscriptMapper.appendingLive(tools: liveTools, subagents: subagents, to: transcript)
 
         // Terminal state of the current turn, MOVED out of the pinned area into
         // the transcript, at the end of the turn it belongs to: session errors

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -297,7 +297,7 @@ struct StepRowView: View {
             .buttonStyle(.plain)
 
             if expanded, let output = step.output {
-                Text(output)
+                Text(ToolOutputPreview.tail(output))
                     .font(.manta(size: Metrics.type.xs, design: .monospaced))
                     .foregroundColor(tokens.tx3)
                     .fixedSize(horizontal: false, vertical: true)
@@ -488,9 +488,14 @@ struct SubagentSession: Identifiable, Hashable {
     /// (BET-576); the S4b fixture leaves it nil (there is no child session).
     let childSessionId: String?
 
-    init(taskName: String, status: SubagentStatus, duration: String?, transcript: [TranscriptBlock], childSessionId: String? = nil) {
-        // Fixtures carry no child session, so they fall back to the task name.
-        self.id = childSessionId ?? "task:\(taskName)"
+    init(taskName: String, status: SubagentStatus, duration: String?, transcript: [TranscriptBlock], childSessionId: String? = nil, fallbackId: String? = nil) {
+        // The id must be unique per task part and stable across rebuilds: the
+        // child opencode session id when known, otherwise the explicitly
+        // provided tool-call discriminator (`fallbackId`). It is NEVER invented
+        // from the task name in production — two subagents run under the same
+        // title would collide. A nil fallback only reaches the fixture-only
+        // capture harness, whose single-row screens need no uniqueness.
+        self.id = childSessionId ?? fallbackId ?? "task:\(taskName)"
         self.taskName = taskName
         self.status = status
         self.duration = duration
@@ -498,13 +503,23 @@ struct SubagentSession: Identifiable, Hashable {
         self.childSessionId = childSessionId
     }
 
-    // Navigation values are compared by identity, never by deep transcript
-    // equality (which would also recurse). The transcript is content the
-    // destination view reads, not something that defines the route.
+    // Equality tracks the presentational fields that define the row — id,
+    // taskName, status, duration, childSessionId — so a subagent's status,
+    // title or duration changing registers as a change and the transcript diff
+    // re-applies it. `transcript` is deliberately excluded: it is content the
+    // destination screen reads, not something that defines the row, and
+    // comparing it would recurse through the whole block tree on every streamed
+    // event.
     static func == (lhs: SubagentSession, rhs: SubagentSession) -> Bool {
         lhs.id == rhs.id
+            && lhs.taskName == rhs.taskName
+            && lhs.status == rhs.status
+            && lhs.duration == rhs.duration
+            && lhs.childSessionId == rhs.childSessionId
     }
     func hash(into hasher: inout Hasher) {
+        // A hash may be coarser than equality; combining only `id` keeps
+        // navigation cheap while remaining consistent with a wider equality.
         hasher.combine(id)
     }
 

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -216,6 +216,126 @@ final class ChatTranscriptTests: XCTestCase {
                      "no state.metadata.sessionId means the child screen shows the empty state")
     }
 
+    // MARK: - Live subagent cards (BET-1085)
+    //
+    // The box publishes a `stream/subagent` frame per subagent while it runs,
+    // and the chat screen builds a live `.subagent` card from it — so the card
+    // appears immediately instead of only after the subagent finishes. These
+    // pin the running case that the completed-by-default fixtures below never
+    // exercised.
+
+    private func runningPayload(_ childSessionId: String = "ses_child") -> StreamSubagentPayload {
+        StreamSubagentPayload(
+            childSessionId: childSessionId,
+            agent: nil,
+            description: nil,
+            prompt: nil,
+            status: "running",
+            title: "unblock sweep",
+            output: nil,
+            truncated: nil,
+            durationMs: 1200,
+            runningCount: nil,
+            model: nil
+        )
+    }
+
+    /// A `task` part inside a still-in-flight assistant message (`time.completed
+    /// == nil`) yields no `.subagent` row from the canonical mapper. Pins the
+    /// skip at ChatModels.swift:267 as intentional — the live card is the only
+    /// in-flight surface, and un-skipping would render every streaming answer
+    /// twice.
+    func testTaskPartInFlightMessageProducesNoCanonicalSubagent() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [
+            taskPart("t1", "m1", childID: "ses_child", title: "sweep", status: "running"),
+        ], completed: false)]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs)
+        XCTAssertTrue(blocks.isEmpty,
+                      "an in-flight assistant message must not emit a canonical subagent row")
+    }
+
+    func testLiveSubagentAppendsRunningCard() {
+        let blocks = ChatTranscriptMapper.appendingLive(tools: [], subagents: [runningPayload()], to: [])
+        guard case .steps(.rows(let rows)) = blocks.last, rows.count == 1, case .subagent(let agent) = rows[0] else {
+            return XCTFail("expected exactly one live subagent row")
+        }
+        XCTAssertEqual(agent.taskName, "unblock sweep")
+        XCTAssertEqual(agent.childSessionId, "ses_child")
+        XCTAssertEqual(agent.status, .running)
+        XCTAssertEqual(agent.duration, "1.2s")
+    }
+
+    func testLiveSubagentCompletedIsNotAppended() {
+        let done = StreamSubagentPayload(
+            childSessionId: "ses_child", agent: nil, description: nil, prompt: nil,
+            status: "completed", title: "sweep", output: nil, truncated: nil,
+            durationMs: nil, runningCount: nil, model: nil
+        )
+        let blocks = ChatTranscriptMapper.appendingLive(tools: [], subagents: [done], to: [])
+        XCTAssertTrue(blocks.isEmpty,
+                      "a finished subagent belongs to the canonical transcript, not the live feed")
+    }
+
+    func testLiveSubagentDedupedAgainstCanonicalRow() {
+        let canonical = SubagentSession(taskName: "sweep", status: .running, duration: nil, transcript: [], childSessionId: "ses_child")
+        let blocks: [TranscriptBlock] = [.steps(.rows([.subagent(canonical)]))]
+        let merged = ChatTranscriptMapper.appendingLive(tools: [], subagents: [runningPayload()], to: blocks)
+        guard case .steps(.rows(let rows)) = merged[0] else {
+            return XCTFail("expected a steps group")
+        }
+        XCTAssertEqual(rows.count, 1,
+                       "a live card whose id the canonical transcript already owns must not be appended")
+    }
+
+    func testLiveTaskToolRowIsSuppressed() {
+        let task = LiveTool(idx: "t1", callID: "toolu_1", name: "task", presentationHint: "Find the skill", status: "running")
+        let taskBlocks = ChatTranscriptMapper.appendingLive(tools: [task], subagents: [], to: [])
+        XCTAssertTrue(taskBlocks.isEmpty,
+                      "the redundant task tool row must not render — the subagent frame owns the card")
+
+        let bash = LiveTool(idx: "t2", callID: "toolu_2", name: "bash", presentationHint: "run tests", status: "running")
+        let bashBlocks = ChatTranscriptMapper.appendingLive(tools: [bash], subagents: [], to: [])
+        guard case .steps(.rows(let rows)) = bashBlocks[0], rows.count == 1, case .step = rows[0] else {
+            return XCTFail("a non-task live tool must still append a step row")
+        }
+    }
+
+    func testSubagentIdIsUniquePerCallWithoutChildSession() {
+        func part(_ id: String, _ callID: String) -> OpencodePart {
+            let state: [String: JSONValue] = ["status": str("running"), "title": str("sweep")]
+            return OpencodePart(type: "tool", id: id, messageID: "m1", extra: [
+                "tool": str("task"),
+                "callID": str(callID),
+                "state": jsonObject(state),
+            ])
+        }
+        let a = ChatSubagentMapper.session(from: part("t1", "toolu_1"))
+        let b = ChatSubagentMapper.session(from: part("t2", "toolu_2"))
+        XCTAssertNotNil(a)
+        XCTAssertNotNil(b)
+        XCTAssertNil(a?.childSessionId)
+        XCTAssertNil(b?.childSessionId)
+        XCTAssertNotEqual(a?.id, b?.id,
+                          "two task parts with different call ids must not collide on the same row id")
+    }
+
+    func testSubagentEqualityTracksStatusAndDuration() {
+        let base = SubagentSession(taskName: "sweep", status: .running, duration: "1m12s", transcript: [])
+        let same = SubagentSession(taskName: "sweep", status: .running, duration: "1m12s", transcript: [])
+        XCTAssertEqual(base, same)
+
+        let differentStatus = SubagentSession(taskName: "sweep", status: .done, duration: "1m12s", transcript: [])
+        XCTAssertNotEqual(base, differentStatus, "a changed status is a change the diff must see")
+
+        let differentDuration = SubagentSession(taskName: "sweep", status: .running, duration: "2m01s", transcript: [])
+        XCTAssertNotEqual(base, differentDuration, "a changed duration is a change the diff must see")
+
+        // `transcript` is deliberately excluded from equality — it is content
+        // the destination screen reads, not something that defines the row.
+        let withTranscript = SubagentSession(taskName: "sweep", status: .running, duration: "1m12s", transcript: [.prose("x", at: nil)])
+        XCTAssertEqual(base, withTranscript, "equality must not depend on transcript content")
+    }
+
     /// Ownership moved to the child screen (BET-1024): a store constructed for
     /// a child session id is no longer placed in a parent-owned registry, so
     /// two screens opened on the same child id get two INDEPENDENT stores
@@ -506,7 +626,7 @@ final class ChatTranscriptTests: XCTestCase {
         ])]
         let blocks = ChatTranscriptMapper.blocks(from: canonical)
         let live = [LiveTool(idx: "t2", callID: "toolu_2", name: "read", presentationHint: "Read a.ts", status: "running")]
-        let merged = ChatTranscriptMapper.appendingLiveTools(live, to: blocks)
+        let merged = ChatTranscriptMapper.appendingLive(tools: live, subagents: [], to: blocks)
         guard case .steps(.rows(let rows)) = merged[0], rows.count == 2,
               case .step(let step) = rows[0], case .step(let liveStep) = rows[1] else {
             return XCTFail("expected both steps in one group")
@@ -526,7 +646,7 @@ final class ChatTranscriptTests: XCTestCase {
         ])]
         let blocks = ChatTranscriptMapper.blocks(from: canonical)
         let live = [LiveTool(idx: "t1", callID: "t1", name: "bash", presentationHint: nil, status: "running")]
-        let merged = ChatTranscriptMapper.appendingLiveTools(live, to: blocks)
+        let merged = ChatTranscriptMapper.appendingLive(tools: live, subagents: [], to: blocks)
         guard case .steps(.rows(let rows)) = merged[0] else {
             return XCTFail("expected a steps group")
         }
@@ -536,15 +656,15 @@ final class ChatTranscriptTests: XCTestCase {
     func testLiveToolCreatesGroupWhenNoStepsExist() {
         let blocks = ChatTranscriptMapper.blocks(from: [])
         let live = [LiveTool(idx: "t1", callID: "toolu_1", name: "bash", presentationHint: nil, status: "running")]
-        let merged = ChatTranscriptMapper.appendingLiveTools(live, to: blocks)
+        let merged = ChatTranscriptMapper.appendingLive(tools: live, subagents: [], to: blocks)
         guard case .steps(.rows(let rows)) = merged.last else {
             return XCTFail("expected a steps group to be created at the tail")
         }
         XCTAssertEqual(rows.count, 1)
     }
 
-    func testAppendingLiveToolsIsANoOpWhenEmpty() {
+    func testAppendingLiveIsANoOpWhenNothingToAppend() {
         let blocks = ChatTranscriptMapper.blocks(from: [])
-        XCTAssertTrue(ChatTranscriptMapper.appendingLiveTools([], to: blocks).isEmpty)
+        XCTAssertTrue(ChatTranscriptMapper.appendingLive(tools: [], subagents: [], to: blocks).isEmpty)
     }
 }

--- a/mobile/native/MantaUITests/ToolOutputPreviewTests.swift
+++ b/mobile/native/MantaUITests/ToolOutputPreviewTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import MantaUI
+
+// BET-1085 — the bounded inline preview of a tool's output. The box streams up
+// to 20,000 chars per tool and flushes the ENTIRE final output one frame before
+// toolEnded, so an unbounded inline view blows out a self-sizing cell and shoves
+// the composer off screen. The preview must never exceed 12 lines / 2,000 chars,
+// and a trimmed tail is flagged with a "… " prefix.
+
+final class ToolOutputPreviewTests: XCTestCase {
+
+    func testShortOutputIsUnchanged() {
+        XCTAssertEqual(ToolOutputPreview.tail("hello"), "hello")
+    }
+
+    func testThirtyLinesKeepsLastTwelveWithPrefix() {
+        let lines = (1...30).map { "line \($0)" }
+        let output = ToolOutputPreview.tail(lines.joined(separator: "\n"))
+        XCTAssertTrue(output.hasPrefix("… \n"), "a line-trimmed tail must carry the prefix")
+        XCTAssertEqual(output.components(separatedBy: "\n").count, ToolOutputPreview.maxLines + 1,
+                       "prefix line + the kept \(ToolOutputPreview.maxLines) lines")
+        XCTAssertTrue(output.hasSuffix("line 30"), "the tail must keep the NEWEST lines")
+        XCTAssertFalse(output.contains("line 1"), "the head-most lines must be dropped")
+    }
+
+    func testSingleEnormousLineIsCharacterBounded() {
+        let line = String(repeating: "x", count: 5_000)
+        let output = ToolOutputPreview.tail(line)
+        XCTAssertTrue(output.hasPrefix("… \n"))
+        XCTAssertEqual(output.count - "… \n".count, ToolOutputPreview.maxCharacters,
+                       "a single line over the character bound must be tail-capped to maxCharacters")
+    }
+
+    func testEmptyAndWhitespaceOnlyInputIsUnchanged() {
+        XCTAssertEqual(ToolOutputPreview.tail(""), "")
+        XCTAssertEqual(ToolOutputPreview.tail("   \n  "), "   \n  ")
+    }
+
+    func testExactlyTwelveLinesIsUnchangedAndUnprefixed() {
+        let lines = (1...12).map { "line \($0)" }
+        let joined = lines.joined(separator: "\n")
+        let output = ToolOutputPreview.tail(joined)
+        XCTAssertEqual(output, joined)
+        XCTAssertFalse(output.hasPrefix("… "), "12 lines is exactly at the bound — no trim, no prefix")
+    }
+}


### PR DESCRIPTION
fix(ios): render live subagent cards and bound inline tool output (BET-1085)

Branch: `multica/BET-1085-ios-subagent-card`
Base: `origin/main` @ `23d6d884`

## What & why

While a `task` subagent runs, the iOS transcript showed empty space where its card should be — the card only existed once the subagent finished, and the moment it finished the composer was shoved off screen. Two independent causes, both fixed client-side (`mobile/native/`, no `src/` changes):

1. **The in-flight card streamed but was never read.** The box already publishes a `stream/subagent` frame per running subagent; the chat screen only consumed it for the session-list subtitle. This wires it into the live transcript path.
   - `ChatModels.swift: appendingLive(...)` replaces `appendingLiveTools(...)`, appending running live subagents alongside live tools.
   - Live `task` tool rows are suppressed (the tool triple is redundant next to the richer `subagent` frame, and the tool row is the one that dumped the whole result into an unbounded view).
   - Finished (`completed`/`error`) payloads are dropped — that's the canonical transcript's job after the turn-boundary refetch.
   - Dedup now covers subagent rows too, so a live card disappears the instant the canonical one lands.
   - `ChatSubagentMapper.session(from: StreamSubagentPayload)` is the second entry point next to the canonical mapper.

2. **Unbounded tool-output view blew out the layout.** A still-`running` step row is force-expanded, and the expanded well rendered the entire (up to 20,000 char) final output with no cap — thousands of points of text inside a self-sizing cell. Added `ToolOutputPreview.tail(_:)` (last 12 lines, then last 2,000 chars, `… `-prefixed when trimmed) and applied it at the single render site.

Plus two correctness fixes required to make the live card actually update and stay unique:
- `SubagentSession` id now falls back to the tool `callID` (never the task name), so distinct task parts can't collide (init takes an explicit `fallbackId`; fixture sites compile via a default).
- `SubagentSession ==` widened to compare `id, taskName, status, duration, childSessionId` (excluding `transcript`), so a row redraws when its status/title/duration changes. `hash` stays id-only.

## Verification results

- typecheck: exit 0, no errors. (2 configs, `tsconfig.node` + `tsconfig.web`.)
- test: exit 0, **2326 pass / 0 fail / 0 skip**.
- This ticket changes **no TypeScript** — the gate is defence-in-depth only.
- iOS Swift suite: **not runnable on the Linux box (no Xcode/swift toolchain); verified by reading.** New tests added:
  - `ChatTranscriptTests`: `testTaskPartInFlightMessageProducesNoCanonicalSubagent`, `testLiveSubagentAppendsRunningCard`, `testLiveSubagentCompletedIsNotAppended`, `testLiveSubagentDedupedAgainstCanonicalRow`, `testLiveTaskToolRowIsSuppressed`, `testSubagentIdIsUniquePerCallWithoutChildSession`, `testSubagentEqualityTracksStatusAndDuration`, plus existing live-tool tests migrated to the `appendingLive(tools:subagents:to:)` signature.
  - `ToolOutputPreviewTests` (new file): short unchanged; 30 lines → last 12 + prefix; single 5,000-char line → last 2,000 + prefix; empty/whitespace unchanged; exactly 12 lines unchanged + unprefixed.
- `git grep -n "appendingLiveTools"` under `mobile/native` → **nothing** (Definition of Done).

Out of scope honored: no `src/` changes, no server-side removal of the redundant tool triple, no un-skipping of the in-flight assistant message, no new store/`@Published`/RPC/stream frame, no new expand affordance, no changes to `ChatSubagentScreen`/`TranscriptListView`/fixtures.
