### PR TITLE
fix(mobile): recompute context percentage from the selected model (BET-1086)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -766,12 +766,19 @@ private struct ChatScreenContent: View {
 
     // MARK: - Context meter (BET-824)
 
-    /// The context percentage from the live stream payload: a real percentage
-    /// when the box reports one, nil when it has none (nil early in a session,
-    /// and again after a compaction). A missing value renders nothing — never
-    /// a confident 0%.
+    /// The context breakdown re-derived against the SELECTED model. One read,
+    /// so the pill's percentage and the sheet's "of N" cannot describe two
+    /// different models (which is exactly what "87% — 174k of 1M" was).
+    private var contextBreakdown: StreamContextPayload? {
+        store.context.map { UsageMeters.recompute($0, limit: activeModelContextLimit) }
+    }
+
+    /// The context percentage from the SELECTED model's breakdown: a real
+    /// percentage when the box reports one, nil when it has none (nil early in
+    /// a session, and again after a compaction). A missing value renders
+    /// nothing — never a confident 0%.
     private var contextPct: Double? {
-        guard let ctx = store.context, ctx.pct.isFinite else { return nil }
+        guard let ctx = contextBreakdown, ctx.pct.isFinite else { return nil }
         return ctx.pct
     }
 
@@ -878,7 +885,7 @@ private struct ChatScreenContent: View {
         // The strip only shows for a known reading, but the context can go
         // unknown in the window between the tap and the sheet presenting —
         // never fabricate a 0% sheet for "we don't know".
-        if let ctx = store.context, UsageMeters.shouldShowContext(pct: ctx.pct) {
+        if let ctx = contextBreakdown, UsageMeters.shouldShowContext(pct: ctx.pct) {
             ContextSheet(
                 context: ctx,
                 cache: store.cache,

--- a/mobile/native/MantaUI/UsageMeters.swift
+++ b/mobile/native/MantaUI/UsageMeters.swift
@@ -148,7 +148,65 @@ enum UsageMeters {
         return "\(formatTokens(cache.staleTokens)) cold"
     }
 
+    /// Re-derive a context breakdown against the model the user has SELECTED.
+    ///
+    /// The box computes `pct` and `segments` against the model that produced
+    /// the last reply — it cannot know the client's per-session override, which
+    /// is local state sent only at submit time. So the derived fields go stale
+    /// the moment the user switches model. The raw token counts do not, and the
+    /// selected model's window is in the catalogue, so the honest number is
+    /// always derivable here. Mirrors the desktop's `computeContextBreakdown`
+    /// (src/shared/streamInterpretation.mjs) so both clients agree.
+    static func recompute(_ ctx: StreamContextPayload, limit: Double?) -> StreamContextPayload {
+        // The desktop's ASSUMED_CONTEXT_TOKENS fallback — used whenever the
+        // selected model's window is unknown or non-positive, exactly as the
+        // shared `computeContextBreakdown` does.
+        let safeLimit = (limit?.isFinite == true && limit! > 0) ? limit! : assumedContextTokens
+
+        // Guard the raw counts: the payload arrives from the box already
+        // rounded and non-negative, but a bad value must never produce NaN or
+        // a negative width. Clamp to [0, ∞) per bucket for the arithmetic only;
+        // the raw fields are copied through unchanged.
+        let fresh  = ctx.freshInput.isFinite  ? max(0, ctx.freshInput)  : 0
+        let read   = ctx.cacheRead.isFinite   ? max(0, ctx.cacheRead)   : 0
+        let write  = ctx.cacheWrite.isFinite  ? max(0, ctx.cacheWrite)  : 0
+        let total  = ctx.totalInput.isFinite  ? max(0, ctx.totalInput)  : 0
+
+        let rawPct = (total / safeLimit) * 100
+        // Rounded, clamped to 0...100 (mirrors `Math.min(100, Math.round(...))`).
+        let pct = min(100, max(0, rawPct.rounded()))
+
+        // Each segment is its bucket over the SELECTED limit, in cost-decreasing
+        // order fresh → cacheWrite → cacheRead, matching the desktop's order.
+        var segments = [
+            StreamContextSegment(kind: "fresh", pct: (fresh / safeLimit) * 100),
+            StreamContextSegment(kind: "cacheWrite", pct: (write / safeLimit) * 100),
+            StreamContextSegment(kind: "cacheRead", pct: (read / safeLimit) * 100),
+        ]
+        // Rescale segments that would sum past 100 the same way the desktop
+        // does (streamInterpretation.mjs), so an over-context payload never
+        // renders widths whose sum exceeds 100.
+        let sum = segments.reduce(0) { $0 + $1.pct }
+        if sum > 100 && sum > 0 {
+            let scale = 100 / sum
+            for i in segments.indices { segments[i].pct *= scale }
+        }
+
+        return StreamContextPayload(
+            freshInput: ctx.freshInput,
+            cacheRead: ctx.cacheRead,
+            cacheWrite: ctx.cacheWrite,
+            totalInput: ctx.totalInput,
+            pct: pct,
+            segments: segments
+        )
+    }
+
     // MARK: - Reset-time absolute formatters (BET-967)
+
+    /// The desktop's `ASSUMED_CONTEXT_TOKENS` (200k) — the denominator when no
+    /// model window is available. Mirrors `computeContextBreakdown`.
+    private static let assumedContextTokens: Double = 200_000
 
     // OS locale on purpose (autoupdatingCurrent), and the TEMPLATE chooses
     // 12- vs 24-hour from the device — never a literal "HH:mm" pattern and

--- a/mobile/native/MantaUITests/UsageMetersTests.swift
+++ b/mobile/native/MantaUITests/UsageMetersTests.swift
@@ -192,6 +192,91 @@ final class UsageMetersTests: XCTestCase {
         XCTAssertEqual(label, "\(UsageMeters.formatTokens(value)) cold")
     }
 
+    // MARK: - recompute (BET-1086 — selected-model context breakdown)
+
+    /// A payload shaped like the box's `opencode:context` — raw counts plus the
+    /// derived `pct`/`segments` the box computed against the LAST-REPLY model's
+    /// window. `totalInput` mirrors the box summing the three disjoint buckets.
+    private func payload(fresh: Double = 0, read: Double = 0, write: Double = 0,
+                         pct: Double = 0,
+                         segments: [StreamContextSegment]) -> StreamContextPayload {
+        StreamContextPayload(
+            freshInput: fresh,
+            cacheRead: read,
+            cacheWrite: write,
+            totalInput: fresh + read + write,
+            pct: pct,
+            segments: segments
+        )
+    }
+
+    /// The reported bug, stated as a test: a 200k-window payload (the box read
+    /// 40k tokens, 20% of 200k) recomputed against the user's SELECTED 1M
+    /// window is one fifth as full — the percentage changes with the model,
+    /// with no new reply and no refetch.
+    func testRecomputeChangesPctWithSelectedModel() {
+        let s = payload(fresh: 40_000, pct: 20,
+                        segments: [StreamContextSegment(kind: "fresh", pct: 20)])
+        let r = UsageMeters.recompute(s, limit: 1_000_000)
+        XCTAssertEqual(r.pct, 4)
+        XCTAssertEqual(r.segments.first { $0.kind == "fresh" }?.pct, 4)
+    }
+
+    /// `limit: nil` falls back to 200k (the desktop's ASSUMED_CONTEXT_TOKENS)
+    /// and reproduces the box's own number for a 200k model — recompute is a
+    /// no-op in the common case. Oracle: streamInterpretation.test.ts sums case
+    /// (input 10k, cache.read 30k, cache.write 5k → pct 23).
+    func testRecomputeNilLimitIsNoOpFor200kModel() {
+        let s = payload(fresh: 10_000, read: 30_000, write: 5_000, pct: 23,
+                        segments: [
+                            StreamContextSegment(kind: "fresh", pct: 5),
+                            StreamContextSegment(kind: "cacheWrite", pct: 2.5),
+                            StreamContextSegment(kind: "cacheRead", pct: 15),
+                        ])
+        let r = UsageMeters.recompute(s, limit: nil)
+        XCTAssertEqual(r.pct, 23)
+        XCTAssertEqual(r.segments.map(\.pct), [5, 2.5, 15])
+        XCTAssertEqual(r.totalInput, 45_000)
+    }
+
+    /// A zero or negative limit must fall back to 200k, never divide by zero
+    /// or produce a negative percentage. Oracle: falls-back-to-ASSUMED case.
+    func testRecomputeNonPositiveLimitFallsBackTo200k() {
+        let s = payload(fresh: 100_000, pct: 50,
+                        segments: [StreamContextSegment(kind: "fresh", pct: 50)])
+        XCTAssertEqual(UsageMeters.recompute(s, limit: 0).pct, 50)
+        XCTAssertEqual(UsageMeters.recompute(s, limit: -200_000).pct, 50)
+    }
+
+    /// The raw counts ride through untouched — only the derived fields change.
+    func testRecomputeCopiesRawCountsThrough() {
+        let s = payload(fresh: 20_000, read: 60_000, write: 20_000, pct: 50,
+                        segments: [StreamContextSegment(kind: "fresh", pct: 20)])
+        let r = UsageMeters.recompute(s, limit: 1_000_000)
+        XCTAssertEqual(r.freshInput, 20_000)
+        XCTAssertEqual(r.cacheRead, 60_000)
+        XCTAssertEqual(r.cacheWrite, 20_000)
+        XCTAssertEqual(r.totalInput, 100_000)
+    }
+
+    /// Over-context: `totalInput` clamps `pct` to 100 and the segment widths
+    /// rescale so they never sum past 100. Oracle: clamps-pct-to-100 case.
+    func testRecomputeClampsPctAndSegmentsWhenOverContext() {
+        let s = payload(fresh: 250_000, pct: 100,
+                        segments: [StreamContextSegment(kind: "fresh", pct: 125)])
+        let r = UsageMeters.recompute(s, limit: 200_000)
+        XCTAssertEqual(r.pct, 100)
+        XCTAssertLessThanOrEqual(r.segments.reduce(0) { $0 + $1.pct }, 100 + 0.001)
+    }
+
+    /// Zero tokens yields 0% and zero-width segments — never NaN.
+    func testRecomputeZeroTokensIsZeroNotNaN() {
+        let r = UsageMeters.recompute(payload(segments: []), limit: 200_000)
+        XCTAssertEqual(r.pct, 0)
+        XCTAssertFalse(r.pct.isNaN)
+        XCTAssertTrue(r.segments.allSatisfy { $0.pct == 0 })
+    }
+
     // MARK: - MeterRing clamp / isFull (BET-877)
 
     /// `pct` is clamped to 0...100 before drawing — a provider can report


### PR DESCRIPTION
iOS-only fix: recompute the context percentage/segments on-device from the
raw token counts, against the model the user has SELECTED, instead of the
box's last-reply-model number. Converges iOS onto the desktop's
`computeContextBreakdown` semantics. No server change, no new wire field, no
refetch.

- `UsageMeters.recompute(_:limit:)` — pure port of
  `computeContextBreakdown` (`src/shared/streamInterpretation.mjs`): safe-limit
  fallback to the 200k `ASSUMED_CONTEXT_TOKENS`, `pct` clamped to 0...100,
  per-segment widths over the selected limit, same over-100 rescale, raw counts
  copied through unchanged.
- `ChatScreen.contextBreakdown` — the single recompute read for BOTH surfaces;
  `contextPct` and `contextSheet` now feed from it, so the pill's % and the
  sheet's "of N" can never describe different models. `activeModelContextLimit`
  unchanged.
- Tests in `UsageMetersTests.swift` covering the 6 required cases, using
  `streamInterpretation.test.ts` as the oracle where a case exists.

**Files changed:** `3`. `mobile/native/MantaUI/UsageMeters.swift`,
`mobile/native/MantaUI/ChatScreen.swift`, `mobile/native/MantaUITests/UsageMetersTests.swift`.

**Verification results:**
- PR branch (`multica/BET-1086-recompute-context-selected-model` @ `dfaa1967`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, `2326` pass / `0` fail / `0` skip.
- Base (`main` @ `23d6d884`):
  - This PR touches only Swift under `mobile/native/`; nothing under `src/`
    changed, so the JS suites are unaffected by construction.
- **Conclusion:** no new failures; the Swift changes are outside the `npm`
  suites (iOS-only, verified by reading per BET-1086 scope). Swift tests here
  will be exercised by the Xcode/Codemagic build on merge.

Cross-cutting follow-ups: none.
