### PR TITLE
iOS: canonical subagent (and step-row) durations convert ms→s (BET-1087)

### DIFF
--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -170,7 +170,11 @@ enum ChatSubagentMapper {
         let duration: String?
         if let start = ChatJSON.number(time?["start"]),
            let end = ChatJSON.number(time?["end"]) {
-            duration = ChatDuration.text(seconds: end - start)
+            // `state.time.start/end` are MILLISECONDS on the wire (opencode
+            // stamps tool time in ms — see `ChatDuration.text`); divide by 1000
+            // before the seconds-format helper, mirroring the live path — a
+            // task that ran 1.2s must not render as "20m0s".
+            duration = ChatDuration.text(seconds: (end - start) / 1000)
         } else {
             duration = nil
         }
@@ -536,10 +540,14 @@ enum ChatTranscriptMapper {
         return "\(part.messageID)-step-\(indexWithinMessage)"
     }
 
+    /// Tool-part `state.time.start/end` are MILLISECONDS on the wire (opencode
+    /// stamps tool time in ms — see `ChatDuration.text`); `ChatDuration.text`
+    /// takes seconds, so convert before the helper — a step that ran 0.4s must
+    /// not render as "6m40s". Mirrors the subagent paths.
     private static func durationSeconds(state: [String: JSONValue]?, time: [String: JSONValue]?) -> Double? {
         if let start = ChatJSON.number(time?["start"]),
            let end = ChatJSON.number(time?["end"]) {
-            return end - start
+            return (end - start) / 1000
         }
         return nil
     }

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -18,7 +18,7 @@ final class ChatTranscriptTests: XCTestCase {
         OpencodePart(type: "text", id: id, messageID: messageID, text: text)
     }
 
-    private func toolPart(_ id: String, _ messageID: String, tool: String, status: String, input: [String: JSONValue], output: String? = nil, start: Double? = 100, end: Double? = 100.4) -> OpencodePart {
+    private func toolPart(_ id: String, _ messageID: String, tool: String, status: String, input: [String: JSONValue], output: String? = nil, start: Double? = 12000, end: Double? = 12400) -> OpencodePart {
         var state: [String: JSONValue] = [
             "status": str(status),
             "input": jsonObject(input),
@@ -39,7 +39,7 @@ final class ChatTranscriptTests: XCTestCase {
             "title": str(title),
             "metadata": jsonObject(["sessionId": str(childID)]),
         ]
-        stateObject["time"] = jsonObject(["start": num(0), "end": num(5)])
+        stateObject["time"] = jsonObject(["start": num(1200), "end": num(2400)])
         return OpencodePart(type: "tool", id: id, messageID: messageID, extra: [
             "tool": str("task"),
             "state": jsonObject(stateObject),
@@ -152,7 +152,7 @@ final class ChatTranscriptTests: XCTestCase {
 
     func testBashStepMapsToRanVerbAndCommandTarget() {
         let msgs = [message(id: "m1", role: "assistant", parts: [
-            toolPart("t1", "m1", tool: "bash", status: "completed", input: ["command": str("multica issue get BET-520")], output: "Blocked", start: 100, end: 100.4),
+            toolPart("t1", "m1", tool: "bash", status: "completed", input: ["command": str("multica issue get BET-520")], output: "Blocked", start: 12000, end: 12400),
         ])]
         let blocks = ChatTranscriptMapper.blocks(from: msgs)
         guard case .steps(.rows(let rows)) = blocks[0], rows.count == 1, case .step(let step) = rows[0] else {
@@ -193,7 +193,9 @@ final class ChatTranscriptTests: XCTestCase {
         XCTAssertEqual(agent.taskName, "unblock sweep")
         XCTAssertEqual(agent.childSessionId, "ses_child")
         XCTAssertEqual(agent.status, .running)
-        XCTAssertEqual(agent.duration, "5.0s")
+        // 2400 - 1200 = 1200ms = 1.2s; a ms-on-the-wire value must not render
+        // 1000× inflated ("20m0s") like it did before the ms→s fix.
+        XCTAssertEqual(agent.duration, "1.2s")
     }
 
     /// A task part not yet stamped with `state.metadata.sessionId` (the 


### PR DESCRIPTION
## Fix: canonical subagent (and step-row) durations now convert ms→s (BET-1087)

Follow-up to BET-1085. The canonical subagent path fed opencode's **millisecond**
`state.time.start/end` straight into `ChatDuration.text(seconds:)`, so a subagent
that ran 1.2s rendered as **"20m0s"** and the live card visibly jumped from the
correct duration to a 1000×-inflated one the instant the turn-boundary refetch
took over. This mirrors BET-1085's live-path fix (`durationMs/1000`) onto the
canonical mapper.

**Confirmed in the same pass (same bug):** the `ToolStep` step-row duration path
(`durationSeconds`) had the identical defect — `state.time.end - state.time.start`
(ms) into `ChatDuration.text(seconds:)`, so a 0.4s bash step rendered as "6m40s".
Per the issue's scope guard ("unless the same ms-vs-seconds confusion is confirmed
there"), I confirmed it by reading the shared `state.time` schema and fixed it too
(that path already had its own independent test, updated to ms values).

### Changes
- `mobile/native/MantaUI/ChatModels.swift`
  - `ChatSubagentMapper.session(from part:)` — canonical path: `/1000` before `ChatDuration.text` (mirror the live path).
  - `ChatTranscriptMapper.ToolStep.durationSeconds` — returns `(end - start) / 1000`, same fix for the step-row path.
- `mobile/native/MantaUITests/ChatTranscriptTests.swift`
  - `taskPart` fixture: synthetic seconds-like `start:0, end:5` → real ms `start:1200, end:2400`; `testTaskPartMapsToSubagentWithChildSession` now asserts `"1.2s"` (was `"5.0s"`).
  - `toolPart` default + `testBashStepMapsToRanVerbAndCommandTarget`: seconds-like `100→100.4` → ms `12000→12400`, still asserting `"0.4s"`.

The live-path `session(from payload:)` was already correct and is untouched.
No other `ChatDuration.text` call sites feed ms values (only the corrected canonical
path, the corrected step-row path, and the already-correct live path).

### Verification results
- PR branch (`multica/BET-1087-canonical-subagent-duration-ms` @ `6aa45fb8`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 2326 pass / 0 fail / 0 skip. Failures: none.
- Swift unit tests cannot be executed on this Linux box (no Apple toolchain) — they
  run on the `ios-build` CI job (Apple infra), as established for BET-1085.
- No TypeScript changed; `npm run typecheck && npm test` green.

Base: origin/main @ `76a3b375`
