### PR TITLE
build(desktop): name mac artifacts by target ext, unbreaking the zip

### DIFF
--- a/electron-builder.staging.yml
+++ b/electron-builder.staging.yml
@@ -13,11 +13,13 @@
 #   - publish.url — staging app reads its auto-update feed from the /staging path;
 #                  electron-updater's "generic" provider polls this and offers an
 #                  in-app upgrade.
-#   - mac.artifactName — base inherits `${productName}-${version}-${arch}.dmg` which
-#                  would produce a filename containing spaces and parentheses
-#                  ("Manta UI (Staging)-0.0.17-arm64.dmg"). That breaks the
-#                  scp / sha256sum steps in scripts/release/publish.sh. Override
-#                  to a hyphenated, no-space filename.
+#   - mac.artifactName — base inherits `${productName}-${version}-${arch}.${ext}`
+#                  which would produce a filename containing spaces and
+#                  parentheses ("Manta UI (Staging)-0.0.17-arm64.dmg"). That
+#                  breaks the scp / sha256sum steps in scripts/release/publish.sh.
+#                  Override to a hyphenated, no-space filename — but KEEP
+#                  `${ext}`: this name covers the zip target too, and a
+#                  hardcoded `.dmg` makes 7-Zip fail the build (E_INVALIDARG).
 #
 # Everything else (entitlements, hardenedRuntime, target arch, notarize:true,
 # win nsis signing posture, linux AppImage executableName, files exclusion of
@@ -39,4 +41,4 @@ publish:
   url: https://mantaui.com/staging/updates
 
 mac:
-  artifactName: "Manta-UI-Staging-${version}-${arch}.dmg"
+  artifactName: "Manta-UI-Staging-${version}-${arch}.${ext}"

--- a/electron-builder.yml
+++ b/electron-builder.yml
@@ -97,7 +97,13 @@ mac:
   entitlements: "assets/entitlements.mac.plist"
   entitlementsInherit: "assets/entitlements.mac.plist"
   darkModeSupport: true
-  artifactName: "${productName}-${version}-${arch}.dmg"
+  # `${ext}` is MANDATORY here, not cosmetic: this name applies to EVERY mac
+  # target, so a hardcoded `.dmg` also renames the zip. electron-builder then
+  # asks 7-Zip to create `… -arm64.dmg`, 7-Zip cannot infer a format from that
+  # extension, and the whole build dies with `E_INVALIDARG` right after the DMG
+  # is packed — which is exactly what broke mac-v0.0.36 the day the zip target
+  # landed. The dmg filename is unchanged by this.
+  artifactName: "${productName}-${version}-${arch}.${ext}"
   # Distribution OUTSIDE the App Store: sign with a "Developer ID Application"
   # certificate. electron-builder auto-selects it from the login keychain when
   # present (or set CSC_LINK/CSC_KEY_PASSWORD to a .p12). Explicit so an App


### PR DESCRIPTION
`mac.artifactName` applies to EVERY mac target, so the hardcoded `.dmg` also renamed the zip added yesterday for macOS auto-update. electron-builder then asked 7-Zip to create `Manta UI-<version>-arm64.dmg`; 7-Zip cannot infer an archive format from that extension and failed with `E_INVALIDARG`, killing the build immediately after the DMG was packed.

Both the post-merge build on main and the `mac-v0.0.36` tag build failed there, so **0.0.36 never published** — the download page and update feed are still on 0.0.35, and macOS auto-update is still inert in the field.

Fix: use `${ext}` in the prod and staging configs. DMG filenames are unchanged; the zip now gets `.zip`. The publish/verify steps already glob `*.zip`, so nothing downstream changes.

Needs a fresh `mac-v0.0.37` tag after merge (`mac-v0.0.36` is spent — re-pushing an existing tag fires nothing).