### PR TITLE
fix(chat): only a user gesture may detach the transcript from the tail

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1286,6 +1286,36 @@ Backup at `~/.tmux.conf.pre-MantaUI` on the remote if it was ever modified.
   at the bottom". Content growing under the user changes the latter and
   must not change the former.**
 
+  **A scroll event is not a user gesture either — that was generation six.**
+  A `scroll` event with a lower `scrollTop` was read as "the user dragged
+  up", but react-virtuoso writes to the scroller itself: its *upward
+  scrolling compensation* fires whenever a row above the viewport is
+  re-measured (plus the unshift/`deviation` corrections). A tool card
+  landing mid-turn re-measures its row, Virtuoso compensates, and the
+  transcript detached with no user input at all — the "every tool call
+  bounces me out and I have to click jump-to-latest" report. So the two
+  signals are now separate: WHERE the scroller is (the scroll event) and
+  WHETHER the user put it there. `classifyFollowOnScroll` takes a
+  `userIntent` argument and only returns `false` when both agree; intent is
+  a short window (`USER_SCROLL_INTENT_WINDOW_MS`) refreshed by wheel /
+  touch / keydown on the scroller, plus a held flag for a scrollbar-gutter
+  drag (`isScrollbarGutterPress` — a press inside the CONTENT box is a
+  click, e.g. expanding a tool card, and must not vouch for the re-measure
+  scrolls that follow it). Landing within `FOLLOW_THRESHOLD_PX` of the
+  bottom still re-attaches unconditionally.
+
+  Two consequences worth knowing before editing this:
+  - **A programmatic scroll away from the tail must now detach EXPLICITLY.**
+    `scrollToMessage` (the artifacts / ⌘F deep-link jump) calls
+    `setFollowing(false)` itself; it used to rely on the resulting scroll-up
+    being mistaken for a gesture, which is exactly the mistake being fixed.
+  - **`stickToTail` writes twice, across a frame.** Virtuoso publishes
+    `totalListHeightChanged` synchronously inside the ResizeObserver tick,
+    while the list padding carrying part of that height is React state that
+    lands on a later commit — so the first write can read a pre-growth
+    `scrollHeight` and park short of the tail. The rAF write lands on the
+    real one. Both are guarded on the follow state.
+
   Note the tail scroll is `scrollTop = scrollHeight`, not
   `scrollToIndex({ index: "LAST" })`, because the Footer renders below the
   last item.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1298,11 +1298,26 @@ Backup at `~/.tmux.conf.pre-MantaUI` on the remote if it was ever modified.
   WHETHER the user put it there. `classifyFollowOnScroll` takes a
   `userIntent` argument and only returns `false` when both agree; intent is
   a short window (`USER_SCROLL_INTENT_WINDOW_MS`) refreshed by wheel /
-  touch / keydown on the scroller, plus a held flag for a scrollbar-gutter
-  drag (`isScrollbarGutterPress` — a press inside the CONTENT box is a
-  click, e.g. expanding a tool card, and must not vouch for the re-measure
-  scrolls that follow it). Landing within `FOLLOW_THRESHOLD_PX` of the
-  bottom still re-attaches unconditionally.
+  touch / keydown on the scroller, plus a held-pointer flag. Landing within
+  `FOLLOW_THRESHOLD_PX` of the bottom still re-attaches unconditionally.
+
+  **Pointer intent is "a button is held", NOT "the press landed on the
+  scrollbar" — the geometric test is a no-op on the primary platform.** The
+  obvious discriminator is `clientX > left + clientWidth` (the gutter the
+  scrollbar reserves). That works with classic scrollbars and never fires
+  under **overlay** scrollbars, the macOS default, where the bar is painted
+  OVER the content and `clientWidth` is the full border-box width — so a
+  Mac user could not detach by dragging the scrollbar at all, while Windows
+  could. Measured in headed Chromium (the probe is worth re-running before
+  changing this): classic reports `clientWidth` 385 / `offsetWidth` 400,
+  overlay reports 400 / 400, and BOTH dispatch `pointerdown` to the scroller
+  at the same `clientX`. In the same run every scroll of a thumb drag fired
+  with the button held and a plain content click fired none — so the button
+  state separates them in both modes. A press that never scrolled earns
+  nothing on release (`releaseUserScrollIntent`), which is what stops a
+  tool-card click from vouching for the compensation its own expansion
+  causes; a press that DID scroll earns the normal window, covering a quick
+  track click whose scrolls land after the release.
 
   Two consequences worth knowing before editing this:
   - **A programmatic scroll away from the tail must now detach EXPLICITLY.**

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -847,6 +847,56 @@ describe("ChatPanel re-activation re-pin defers to the re-measured tail (BET-100
   });
 });
 
+// ===== A deep-link jump detaches the transcript EXPLICITLY =====
+//
+// The artifacts panel / ⌘F "go to this message" jump used to detach as a side
+// effect: it scrolled up, and any scroll-up was read as the user leaving the
+// tail. That inference is gone (a scroll event is not a gesture — react-
+// virtuoso issues its own), so the jump has to say so itself. Without this the
+// next streamed chunk yanks the user straight back off the row they asked for.
+// The jump-to-latest button is the observable: it is shown iff not following.
+describe("ChatPanel deep-link jump detaches from the tail", () => {
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("shows jump-to-latest after a manta-scroll-to-message jump", async () => {
+    const transcript = [
+      {
+        info: {
+          id: "msg_old",
+          sessionID: "ses_test",
+          role: "assistant" as const,
+          time: { created: 1, completed: 2 },
+        },
+        parts: [{ type: "text", id: "prt_old", messageID: "msg_old", text: "way back" }],
+      },
+    ];
+    installMockApi({ opencodeMessages: () => Promise.resolve(transcript as never) });
+    resetStore();
+
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const jump = () => h!.container.querySelector(".manta-jump-latest") as HTMLElement;
+    expect(jump().dataset.shown).toBe("false");
+
+    await act(async () => {
+      window.dispatchEvent(
+        new CustomEvent("manta-scroll-to-message", {
+          detail: { sessionId: "ses_test", messageId: "msg_old" },
+        }),
+      );
+    });
+    await h.flush();
+
+    expect(jump().dataset.shown).toBe("true");
+  });
+});
+
 // ===== Abort self-heals orphaned questions (BET-116) =====
 //
 // opencode's /question pending list is cumulative and never expires. A

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -409,8 +409,14 @@ export function ChatPanel({
   const scrollToMessage = useCallback((messageId: string, behavior: "smooth" | "auto" = "smooth") => {
     const idx = (messagesRef.current ?? []).findIndex((m) => m.info.id === messageId);
     if (idx < 0) return;
+    // Detach EXPLICITLY. A jump to an old row is a deliberate "take me there",
+    // so the next streamed chunk must not yank the user back to the tail — and
+    // it can no longer detach itself as a side effect, because the follow state
+    // now only listens to user gestures (see classifyFollowOnScroll). Landing
+    // near the bottom re-attaches on its own via the scroll listener.
+    setFollowing(false);
     virtuosoRef.current?.scrollToIndex({ index: idx, align: "center", behavior });
-  }, []);
+  }, [setFollowing]);
 
   // ===== Per-session model override =====
   // Declared before useSseBus: the auth-banner providerID below derives from

--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -308,6 +308,36 @@ describe("Transcript follow state", () => {
     h.unmount();
   });
 
+  it("detaches on a scrollbar drag (a button is held while the scroll fires)", () => {
+    // The path geometry could not cover: under overlay scrollbars (macOS) a
+    // press on the bar lands INSIDE the content box, so only the held button
+    // distinguishes it from a click. Measured in headed Chromium: every scroll
+    // of a thumb drag fires with the button down.
+    const { h, el, changes } = mountFollowing();
+    measure(el, { scrollTop: 1500, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    act(() => el.dispatchEvent(new Event("pointerdown")));
+    measure(el, { scrollTop: 1000, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    expect(changes.at(-1)).toBe(false);
+    h.unmount();
+  });
+
+  it("REGRESSION: clicking a tool card open does not detach", () => {
+    // A click scrolls nothing while held; the expansion re-measures the row and
+    // Virtuoso compensates a few ms LATER. That compensation must not inherit
+    // intent from the click that caused it.
+    const { h, el, changes } = mountFollowing();
+    measure(el, { scrollTop: 1500, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    act(() => el.dispatchEvent(new Event("pointerdown")));
+    act(() => window.dispatchEvent(new Event("pointerup")));
+    measure(el, { scrollTop: 1000, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    expect(changes).not.toContain(false);
+    h.unmount();
+  });
+
   it("re-attaches when a scroll lands back at the bottom, gesture or not", () => {
     const { h, el, changes } = mountFollowing();
     measure(el, { scrollTop: 1500, scrollHeight: 2000, clientHeight: 500 });

--- a/src/renderer/Transcript.test.tsx
+++ b/src/renderer/Transcript.test.tsx
@@ -247,6 +247,82 @@ describe("Transcript virtualization (react-virtuoso)", () => {
   });
 });
 
+// ===== Follow state (BET-933 follow-up) =====
+//
+// The pure decision is covered in chatUtils.test.ts; what shipped broken was
+// the WIRING, and only a mounted transcript with a real scroll listener can
+// see it. The reported symptom was that every tool call detached the
+// transcript and left the user clicking "jump to latest": react-virtuoso
+// writes to the scroller itself (upward-scrolling compensation after a row is
+// re-measured), which arrives as an ordinary scroll event with a lower
+// scrollTop and was indistinguishable from the user dragging up.
+describe("Transcript follow state", () => {
+  // jsdom has no layout, so the three scroll metrics are permanently 0. Define
+  // them on the instance to drive classifyFollowOnScroll deterministically.
+  function measure(el: HTMLElement, m: { scrollTop: number; scrollHeight: number; clientHeight: number }) {
+    for (const [k, v] of Object.entries(m)) {
+      Object.defineProperty(el, k, { value: v, configurable: true, writable: true });
+    }
+  }
+
+  function mountFollowing() {
+    const scrollerElRef: React.MutableRefObject<HTMLElement | null> = { current: null };
+    const followingRef = { current: true };
+    const changes: boolean[] = [];
+    motionStateRef = { current: null };
+    const h = mount(
+      <Transcript
+        {...props(HISTORY)}
+        scrollerElRef={scrollerElRef}
+        followingRef={followingRef}
+        onFollowingChange={(v: boolean) => {
+          followingRef.current = v;
+          changes.push(v);
+        }}
+      />,
+    );
+    return { h, el: scrollerElRef.current!, changes };
+  }
+
+  it("REGRESSION: a scroll-up with no user gesture keeps the transcript following", () => {
+    const { h, el, changes } = mountFollowing();
+    expect(el).not.toBeNull();
+    // Pinned at the tail.
+    measure(el, { scrollTop: 1500, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    // Virtuoso compensates for a re-measured row: 500px up, no input event.
+    measure(el, { scrollTop: 1000, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    expect(changes).not.toContain(false);
+    h.unmount();
+  });
+
+  it("still detaches when the same scroll follows a wheel gesture", () => {
+    const { h, el, changes } = mountFollowing();
+    measure(el, { scrollTop: 1500, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    act(() => el.dispatchEvent(new WheelEvent("wheel", { deltaY: -400 })));
+    measure(el, { scrollTop: 1000, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    expect(changes.at(-1)).toBe(false);
+    h.unmount();
+  });
+
+  it("re-attaches when a scroll lands back at the bottom, gesture or not", () => {
+    const { h, el, changes } = mountFollowing();
+    measure(el, { scrollTop: 1500, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    act(() => el.dispatchEvent(new WheelEvent("wheel", { deltaY: -400 })));
+    measure(el, { scrollTop: 1000, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    expect(changes.at(-1)).toBe(false);
+    measure(el, { scrollTop: 1500, scrollHeight: 2000, clientHeight: 500 });
+    act(() => el.dispatchEvent(new Event("scroll")));
+    expect(changes.at(-1)).toBe(true);
+    h.unmount();
+  });
+});
+
 describe("TranscriptList padding pass-through (BET-691)", () => {
   it("leaves Virtuoso's vertical offsets intact on the list element", () => {
     // react-virtuoso writes the virtualization offsets into this element's

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -42,7 +42,7 @@ import {
   classifyFollowOnScroll,
   createUserScrollIntent,
   hasUserScrollIntent,
-  isScrollbarGutterPress,
+  releaseUserScrollIntent,
   type EntryMotionState,
   type LiveTurn,
   workingIndicatorLabel,
@@ -534,28 +534,18 @@ export function Transcript({
     const mark = () => {
       intent.lastInputAt = Date.now();
     };
-    // A press in the CONTENT box is a click, not a scroll — see
-    // isScrollbarGutterPress. Dragging the gutter can outlast the intent
-    // window, hence the held flag rather than a timestamp.
-    const onPointerDown = (e: PointerEvent) => {
-      const rect = el.getBoundingClientRect();
-      intent.draggingGutter = isScrollbarGutterPress(e.clientX, {
-        left: rect.left,
-        clientWidth: el.clientWidth,
-      });
-      if (intent.draggingGutter) mark();
+    // Every pointer-driven scroll (thumb drag, click-to-page in the track,
+    // drag-select autoscroll) holds a button for the scrolls it causes; a
+    // click does not scroll at all while held. That, NOT where the press
+    // landed, is the discriminator — see releaseUserScrollIntent for the
+    // measurement that ruled out the geometric one under overlay scrollbars.
+    const onPointerDown = () => {
+      intent.pointerDown = true;
+      intent.pointerScrolled = false;
     };
-    const onPointerUp = () => {
-      if (!intent.draggingGutter) return;
-      intent.draggingGutter = false;
-      mark();
-    };
-    // Drag-selecting past the edge of the scroller auto-scrolls it; the button
-    // check keeps an idle mouse moving over the transcript from counting.
-    const onPointerMove = (e: PointerEvent) => {
-      if (e.buttons !== 0) mark();
-    };
+    const onPointerUp = () => releaseUserScrollIntent(intent, Date.now());
     const onScroll = () => {
+      if (intent.pointerDown) intent.pointerScrolled = true;
       const next = classifyFollowOnScroll(
         el,
         prevScrollTop,
@@ -567,11 +557,14 @@ export function Transcript({
     el.addEventListener("wheel", mark, { passive: true });
     el.addEventListener("touchstart", mark, { passive: true });
     el.addEventListener("touchmove", mark, { passive: true });
+    // Only reachable when focus is INSIDE the transcript (a "Load earlier"
+    // button, a link in a message) — during a turn it normally sits in the
+    // composer, which is outside this scroller and scrolls nothing. Kept
+    // because that focused case is real and the listener is free.
     el.addEventListener("keydown", mark);
     el.addEventListener("pointerdown", onPointerDown);
-    el.addEventListener("pointermove", onPointerMove, { passive: true });
     el.addEventListener("scroll", onScroll, { passive: true });
-    // On window, not the scroller: a gutter drag routinely ends with the
+    // On window, not the scroller: a scrollbar drag routinely ends with the
     // pointer somewhere else entirely.
     window.addEventListener("pointerup", onPointerUp);
     window.addEventListener("pointercancel", onPointerUp);
@@ -581,7 +574,6 @@ export function Transcript({
       el.removeEventListener("touchmove", mark);
       el.removeEventListener("keydown", mark);
       el.removeEventListener("pointerdown", onPointerDown);
-      el.removeEventListener("pointermove", onPointerMove);
       el.removeEventListener("scroll", onScroll);
       window.removeEventListener("pointerup", onPointerUp);
       window.removeEventListener("pointercancel", onPointerUp);

--- a/src/renderer/Transcript.tsx
+++ b/src/renderer/Transcript.tsx
@@ -40,6 +40,9 @@ import {
   formatDuration,
   scrollElementToTail,
   classifyFollowOnScroll,
+  createUserScrollIntent,
+  hasUserScrollIntent,
+  isScrollbarGutterPress,
   type EntryMotionState,
   type LiveTurn,
   workingIndicatorLabel,
@@ -498,25 +501,91 @@ export function Transcript({
   // animating open (Virtuoso's totalListHeight sums header + footer + list, so
   // one signal covers all of it). This replaces `followOutput`, which fired
   // only on item-COUNT changes and therefore missed every one of those.
+  //
+  // The write is doubled across a frame on purpose. Virtuoso publishes
+  // `totalListHeightChanged` from its size stream — synchronously, inside the
+  // ResizeObserver tick — while the list padding that carries part of that
+  // height is React state and lands on a later commit. So the `scrollHeight`
+  // the first write reads can still be the pre-growth one, leaving the
+  // transcript parked short of the real tail; the rAF write runs after the
+  // commit has painted and lands on it. Both are guarded on the follow state,
+  // so a user who scrolls up in between is not yanked back.
   const stickToTail = useCallback(() => {
     if (!followingRef.current) return;
     scrollElementToTail(scrollerElRef.current);
+    requestAnimationFrame(() => {
+      if (!followingRef.current) return;
+      scrollElementToTail(scrollerElRef.current);
+    });
   }, [followingRef, scrollerElRef]);
 
-  // The user's intent, and the only thing that can stop the follow. Content
-  // growth fires no scroll event, so it cannot reach this listener — which is
-  // exactly why the transcript can no longer detach on its own.
+  // The user's intent, and the only thing that can stop the follow.
+  //
+  // Two signals, deliberately separate: WHERE the scroller is (the scroll
+  // event) and WHETHER the user put it there (an input event). Content growth
+  // fires no scroll event at all, and the scroll events Virtuoso fires for its
+  // own corrections carry no input — so neither can detach the transcript.
+  // See classifyFollowOnScroll for why the second signal had to be added.
   useEffect(() => {
     const el = scrollerElRef.current;
     if (!el) return;
+    const intent = createUserScrollIntent();
     let prevScrollTop = el.scrollTop;
+    const mark = () => {
+      intent.lastInputAt = Date.now();
+    };
+    // A press in the CONTENT box is a click, not a scroll — see
+    // isScrollbarGutterPress. Dragging the gutter can outlast the intent
+    // window, hence the held flag rather than a timestamp.
+    const onPointerDown = (e: PointerEvent) => {
+      const rect = el.getBoundingClientRect();
+      intent.draggingGutter = isScrollbarGutterPress(e.clientX, {
+        left: rect.left,
+        clientWidth: el.clientWidth,
+      });
+      if (intent.draggingGutter) mark();
+    };
+    const onPointerUp = () => {
+      if (!intent.draggingGutter) return;
+      intent.draggingGutter = false;
+      mark();
+    };
+    // Drag-selecting past the edge of the scroller auto-scrolls it; the button
+    // check keeps an idle mouse moving over the transcript from counting.
+    const onPointerMove = (e: PointerEvent) => {
+      if (e.buttons !== 0) mark();
+    };
     const onScroll = () => {
-      const next = classifyFollowOnScroll(el, prevScrollTop);
+      const next = classifyFollowOnScroll(
+        el,
+        prevScrollTop,
+        hasUserScrollIntent(intent, Date.now()),
+      );
       prevScrollTop = el.scrollTop;
       if (next !== null) onFollowingChange(next);
     };
+    el.addEventListener("wheel", mark, { passive: true });
+    el.addEventListener("touchstart", mark, { passive: true });
+    el.addEventListener("touchmove", mark, { passive: true });
+    el.addEventListener("keydown", mark);
+    el.addEventListener("pointerdown", onPointerDown);
+    el.addEventListener("pointermove", onPointerMove, { passive: true });
     el.addEventListener("scroll", onScroll, { passive: true });
-    return () => el.removeEventListener("scroll", onScroll);
+    // On window, not the scroller: a gutter drag routinely ends with the
+    // pointer somewhere else entirely.
+    window.addEventListener("pointerup", onPointerUp);
+    window.addEventListener("pointercancel", onPointerUp);
+    return () => {
+      el.removeEventListener("wheel", mark);
+      el.removeEventListener("touchstart", mark);
+      el.removeEventListener("touchmove", mark);
+      el.removeEventListener("keydown", mark);
+      el.removeEventListener("pointerdown", onPointerDown);
+      el.removeEventListener("pointermove", onPointerMove);
+      el.removeEventListener("scroll", onScroll);
+      window.removeEventListener("pointerup", onPointerUp);
+      window.removeEventListener("pointercancel", onPointerUp);
+    };
   }, [hasMessages, onFollowingChange, scrollerElRef]);
 
   return (

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -135,7 +135,7 @@ import {
   classifyFollowOnScroll,
   createUserScrollIntent,
   hasUserScrollIntent,
-  isScrollbarGutterPress,
+  releaseUserScrollIntent,
   USER_SCROLL_INTENT_WINDOW_MS,
   FOLLOW_THRESHOLD_PX,
   describeSessionClose,
@@ -5186,22 +5186,34 @@ describe("user scroll intent", () => {
     expect(hasUserScrollIntent(intent, 1_000 + USER_SCROLL_INTENT_WINDOW_MS + 1)).toBe(false);
   });
 
-  it("holds indefinitely while the scrollbar gutter is held", () => {
-    // A slow drag can outlast the window; the flag, not the timestamp, covers it.
+  it("holds indefinitely while a pointer button is down", () => {
+    // A slow scrollbar drag can outlast the window; the flag, not the
+    // timestamp, is what covers it.
     const intent = createUserScrollIntent();
-    intent.draggingGutter = true;
+    intent.pointerDown = true;
     expect(hasUserScrollIntent(intent, Number.MAX_SAFE_INTEGER)).toBe(true);
   });
 
-  it("counts a press past clientWidth as a scrollbar gutter press", () => {
-    // Scroller at x=100, 300px content box, ~15px scrollbar to its right.
-    expect(isScrollbarGutterPress(408, { left: 100, clientWidth: 300 })).toBe(true);
+  it("grants the trailing window to a press that actually scrolled", () => {
+    // A quick click in the scrollbar track can release before its later scroll
+    // events land, so the release has to vouch for them.
+    const intent = createUserScrollIntent();
+    intent.pointerDown = true;
+    intent.pointerScrolled = true;
+    releaseUserScrollIntent(intent, 5_000);
+    expect(intent.pointerDown).toBe(false);
+    expect(hasUserScrollIntent(intent, 5_000 + USER_SCROLL_INTENT_WINDOW_MS)).toBe(true);
   });
 
-  it("does NOT count a press inside the content box (clicking a tool card)", () => {
-    expect(isScrollbarGutterPress(250, { left: 100, clientWidth: 300 })).toBe(false);
-    // The content box's own right edge is still content, not gutter.
-    expect(isScrollbarGutterPress(400, { left: 100, clientWidth: 300 })).toBe(false);
+  it("REGRESSION: a press that never scrolled grants nothing on release", () => {
+    // Clicking a tool card open re-measures its row and Virtuoso compensates a
+    // few ms later. If the click earned a window, that compensation would look
+    // like a user scroll-up — the same bug from the other side.
+    const intent = createUserScrollIntent();
+    intent.pointerDown = true;
+    releaseUserScrollIntent(intent, 5_000);
+    expect(intent.pointerDown).toBe(false);
+    expect(hasUserScrollIntent(intent, 5_001)).toBe(false);
   });
 });
 

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -133,6 +133,10 @@ import {
   inboxReasonLabel,
   scrollElementToTail,
   classifyFollowOnScroll,
+  createUserScrollIntent,
+  hasUserScrollIntent,
+  isScrollbarGutterPress,
+  USER_SCROLL_INTENT_WINDOW_MS,
   FOLLOW_THRESHOLD_PX,
   describeSessionClose,
   describeProjectClose,
@@ -5109,7 +5113,7 @@ describe("scrollElementToTail", () => {
 describe("classifyFollowOnScroll", () => {
   it("is following at the exact bottom (distance 0)", () => {
     // scrollHeight - scrollTop - clientHeight === 0
-    expect(classifyFollowOnScroll({ scrollTop: 600, scrollHeight: 1000, clientHeight: 400 }, 600))
+    expect(classifyFollowOnScroll({ scrollTop: 600, scrollHeight: 1000, clientHeight: 400 }, 600, false))
       .toBe(true);
   });
 
@@ -5118,6 +5122,7 @@ describe("classifyFollowOnScroll", () => {
       classifyFollowOnScroll(
         { scrollTop: 1000 - FOLLOW_THRESHOLD_PX, scrollHeight: 1000, clientHeight: 0 },
         500,
+        false,
       ),
     ).toBe(true);
   });
@@ -5125,14 +5130,13 @@ describe("classifyFollowOnScroll", () => {
   it("is null (no decision) when away from the bottom but scrollTop increased", () => {
     // Scrolling down through history must not toggle anything.
     expect(
-      classifyFollowOnScroll({ scrollTop: 700, scrollHeight: 1000, clientHeight: 100 }, 500),
+      classifyFollowOnScroll({ scrollTop: 700, scrollHeight: 1000, clientHeight: 100 }, 500, true),
     ).toBe(null);
   });
 
-  it("is false (stop following) when away from the bottom and scrollTop decreased", () => {
-    // The user scrolled up — the only un-follow path.
+  it("is false (stop following) when the USER scrolled up away from the bottom", () => {
     expect(
-      classifyFollowOnScroll({ scrollTop: 300, scrollHeight: 1000, clientHeight: 100 }, 500),
+      classifyFollowOnScroll({ scrollTop: 300, scrollHeight: 1000, clientHeight: 100 }, 500, true),
     ).toBe(false);
   });
 
@@ -5141,7 +5145,17 @@ describe("classifyFollowOnScroll", () => {
     // threshold -> scrollTop did NOT decrease, so the event is `null`. This
     // is the bug: a growing tool card must never detach the transcript.
     expect(
-      classifyFollowOnScroll({ scrollTop: 500, scrollHeight: 2000, clientHeight: 100 }, 500),
+      classifyFollowOnScroll({ scrollTop: 500, scrollHeight: 2000, clientHeight: 100 }, 500, true),
+    ).toBe(null);
+  });
+
+  it("REGRESSION: a scroll-up with no user gesture must not detach the transcript", () => {
+    // Virtuoso's upward-scrolling compensation after re-measuring a row that a
+    // tool card just grew: scrollTop moves UP, far from the bottom, with no
+    // input event anywhere near it. Identical numbers to the user case above —
+    // the intent flag is the ONLY thing that separates them.
+    expect(
+      classifyFollowOnScroll({ scrollTop: 300, scrollHeight: 1000, clientHeight: 100 }, 500, false),
     ).toBe(null);
   });
 
@@ -5149,8 +5163,45 @@ describe("classifyFollowOnScroll", () => {
     // The transcript shrank so the browser clamped scrollTop down; the result
     // is at the bottom, so following wins (bottom check evaluated first).
     expect(
-      classifyFollowOnScroll({ scrollTop: 900, scrollHeight: 1000, clientHeight: 100 }, 999999),
+      classifyFollowOnScroll({ scrollTop: 900, scrollHeight: 1000, clientHeight: 100 }, 999999, false),
     ).toBe(true);
+  });
+
+  it("re-attaches on a user scroll back down to the bottom", () => {
+    expect(
+      classifyFollowOnScroll({ scrollTop: 900, scrollHeight: 1000, clientHeight: 100 }, 300, true),
+    ).toBe(true);
+  });
+});
+
+describe("user scroll intent", () => {
+  it("is absent on a fresh tracker", () => {
+    expect(hasUserScrollIntent(createUserScrollIntent(), 1_000_000)).toBe(false);
+  });
+
+  it("holds for the window after an input event, then lapses", () => {
+    const intent = createUserScrollIntent();
+    intent.lastInputAt = 1_000;
+    expect(hasUserScrollIntent(intent, 1_000 + USER_SCROLL_INTENT_WINDOW_MS)).toBe(true);
+    expect(hasUserScrollIntent(intent, 1_000 + USER_SCROLL_INTENT_WINDOW_MS + 1)).toBe(false);
+  });
+
+  it("holds indefinitely while the scrollbar gutter is held", () => {
+    // A slow drag can outlast the window; the flag, not the timestamp, covers it.
+    const intent = createUserScrollIntent();
+    intent.draggingGutter = true;
+    expect(hasUserScrollIntent(intent, Number.MAX_SAFE_INTEGER)).toBe(true);
+  });
+
+  it("counts a press past clientWidth as a scrollbar gutter press", () => {
+    // Scroller at x=100, 300px content box, ~15px scrollbar to its right.
+    expect(isScrollbarGutterPress(408, { left: 100, clientWidth: 300 })).toBe(true);
+  });
+
+  it("does NOT count a press inside the content box (clicking a tool card)", () => {
+    expect(isScrollbarGutterPress(250, { left: 100, clientWidth: 300 })).toBe(false);
+    // The content box's own right edge is still content, not gutter.
+    expect(isScrollbarGutterPress(400, { left: 100, clientWidth: 300 })).toBe(false);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3951,35 +3951,61 @@ export const USER_SCROLL_INTENT_WINDOW_MS = 250;
 
 /** Mutable "did the user just do something" record. Owned by Transcript.tsx. */
 export type UserScrollIntent = {
-  /** Timestamp of the last input event on the scroller. */
+  /** Timestamp of the last wheel / touch / key input on the scroller. */
   lastInputAt: number;
-  /** True between pointerdown on the scrollbar gutter and pointerup. */
-  draggingGutter: boolean;
+  /** A pointer button is held down on the scroller. */
+  pointerDown: boolean;
+  /** A scroll fired while that button was held — this press IS a scroll drag. */
+  pointerScrolled: boolean;
 };
 
 export function createUserScrollIntent(): UserScrollIntent {
-  return { lastInputAt: Number.NEGATIVE_INFINITY, draggingGutter: false };
+  return {
+    lastInputAt: Number.NEGATIVE_INFINITY,
+    pointerDown: false,
+    pointerScrolled: false,
+  };
 }
 
 export function hasUserScrollIntent(intent: UserScrollIntent, now: number): boolean {
-  if (intent.draggingGutter) return true;
+  // A held button covers every pointer-driven scroll: dragging the scrollbar
+  // thumb, click-to-page in the track, and drag-selecting past the top edge
+  // (which auto-scrolls). See the note on pointer intent below for why this is
+  // a held FLAG and not a geometric test of where the press landed.
+  if (intent.pointerDown) return true;
   return now - intent.lastInputAt <= USER_SCROLL_INTENT_WINDOW_MS;
 }
 
 /**
- * Was a pointerdown on the scroller's vertical scrollbar gutter?
+ * A pointer press became a scroll gesture — grant it the trailing window on
+ * release.
  *
- * A press inside the content box is a click (expanding a tool card, selecting
- * text) and must NOT vouch for the re-measure scrolls that follow it — that
- * would reopen the same hole from the other side. The gutter is the strip
- * between `clientWidth` (content box, scrollbar excluded) and the element's
- * full border-box width, so a press past `clientWidth` is a scroll gesture.
+ * WHY POINTER INTENT IS "BUTTON HELD", NOT "PRESSED ON THE SCROLLBAR".
+ * The obvious discriminator is geometry: a press past `clientWidth` is on the
+ * scrollbar gutter, a press inside the content box is a click (expanding a
+ * tool card, selecting text) and must not vouch for the re-measure scrolls
+ * that follow it. That test is a NO-OP under overlay scrollbars — the macOS
+ * default, and therefore the primary platform — where the bar is painted over
+ * the content and `clientWidth` equals the full border-box width, so no press
+ * is ever past it. Measured in headed Chromium: classic scrollbars report
+ * clientWidth 385 / offsetWidth 400, overlay reports 400 / 400, and BOTH
+ * dispatch pointerdown to the scroller at the same clientX. Geometry cannot
+ * tell them apart; the button state can. In the same measurement every scroll
+ * of a thumb drag fired with the button held, and a plain content click fired
+ * none.
+ *
+ * The residue is a press-and-hold ON CONTENT that spans a re-measure — a text
+ * selection drag, mostly, where detaching is the right behaviour anyway.
+ *
+ * A quick track click can release before its later scroll events land, so a
+ * press that demonstrably scrolled earns the normal input window on pointerup.
+ * A press that never scrolled earns nothing, which is what keeps a tool-card
+ * click from vouching for the compensation its own expansion causes.
  */
-export function isScrollbarGutterPress(
-  clientX: number,
-  el: { left: number; clientWidth: number },
-): boolean {
-  return clientX - el.left > el.clientWidth;
+export function releaseUserScrollIntent(intent: UserScrollIntent, now: number): void {
+  if (intent.pointerScrolled) intent.lastInputAt = now;
+  intent.pointerDown = false;
+  intent.pointerScrolled = false;
 }
 
 /**

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -3914,18 +3914,72 @@ export function scrollElementToTail(el: HTMLElement | null): void {
  * - Landing within FOLLOW_THRESHOLD_PX of the bottom always means following,
  *   whatever caused it (the user scrolling back down, our own tail scroll, or
  *   the scroller clamping after the transcript shrank on /compact).
- * - Moving UP while away from the bottom is the only thing that stops it.
+ * - Moving UP while away from the bottom stops it — but ONLY when the move
+ *   came from the user (`userIntent`). A scroll event is not by itself
+ *   evidence of intent: react-virtuoso writes to the scroller behind our back
+ *   (its "upward scrolling compensation" when a row above the viewport is
+ *   re-measured, and the unshift/deviation corrections), and those arrive as
+ *   ordinary scroll events with a LOWER scrollTop. Treating them as a
+ *   scroll-up is what detached the transcript on every tool call: the card
+ *   lands, its row is re-measured, Virtuoso compensates, and the transcript
+ *   stopped following with no user input at all. See the intent tracker in
+ *   Transcript.tsx for what counts as a gesture.
  */
 export const FOLLOW_THRESHOLD_PX = 64;
 
 export function classifyFollowOnScroll(
   m: { scrollTop: number; scrollHeight: number; clientHeight: number },
   prevScrollTop: number,
+  userIntent: boolean,
 ): boolean | null {
   const distanceFromBottom = m.scrollHeight - m.scrollTop - m.clientHeight;
   if (distanceFromBottom <= FOLLOW_THRESHOLD_PX) return true;
-  if (m.scrollTop < prevScrollTop) return false;
+  if (userIntent && m.scrollTop < prevScrollTop) return false;
   return null;
+}
+
+/**
+ * How long a user input event vouches for the scroll events that follow it.
+ *
+ * A gesture and the scrolling it causes are not one event: a wheel tick is
+ * followed by trackpad momentum that fires scroll events with no further
+ * wheel events, and a keyboard PageUp scrolls a frame later. The window has
+ * to outlive that gap while staying far shorter than the interval between a
+ * gesture and the next unrelated re-measure.
+ */
+export const USER_SCROLL_INTENT_WINDOW_MS = 250;
+
+/** Mutable "did the user just do something" record. Owned by Transcript.tsx. */
+export type UserScrollIntent = {
+  /** Timestamp of the last input event on the scroller. */
+  lastInputAt: number;
+  /** True between pointerdown on the scrollbar gutter and pointerup. */
+  draggingGutter: boolean;
+};
+
+export function createUserScrollIntent(): UserScrollIntent {
+  return { lastInputAt: Number.NEGATIVE_INFINITY, draggingGutter: false };
+}
+
+export function hasUserScrollIntent(intent: UserScrollIntent, now: number): boolean {
+  if (intent.draggingGutter) return true;
+  return now - intent.lastInputAt <= USER_SCROLL_INTENT_WINDOW_MS;
+}
+
+/**
+ * Was a pointerdown on the scroller's vertical scrollbar gutter?
+ *
+ * A press inside the content box is a click (expanding a tool card, selecting
+ * text) and must NOT vouch for the re-measure scrolls that follow it — that
+ * would reopen the same hole from the other side. The gutter is the strip
+ * between `clientWidth` (content box, scrollbar excluded) and the element's
+ * full border-box width, so a press past `clientWidth` is a scroll gesture.
+ */
+export function isScrollbarGutterPress(
+  clientX: number,
+  el: { left: number; clientWidth: number },
+): boolean {
+  return clientX - el.left > el.clientWidth;
 }
 
 /**


### PR DESCRIPTION
## Symptom

Every tool call bounced the transcript out of follow mode. The user had to click **jump to latest** to get back — repeatedly, for the whole turn.

## Cause

The follow state turned OFF on any scroll event whose `scrollTop` moved up. But react-virtuoso writes to the scroller **itself**: its *upward scrolling compensation* fires whenever a row above the viewport is re-measured — exactly what a tool card landing mid-turn does to the message row it joins. That correction arrives as an ordinary `scroll` event with a lower `scrollTop`, indistinguishable from the user dragging up.

This is the sixth generation of this bug. BET-933 established "never derive *should we follow* from *is the scroller at the bottom*". The remaining hole was one level down: a **scroll event is not a user gesture either**.

## Fix

Separate the two signals: **where** the scroller is (the scroll event) and **whether the user put it there**.

- `classifyFollowOnScroll` takes a `userIntent` argument and only returns `false` when both agree.
- Intent is a 250ms window (`USER_SCROLL_INTENT_WINDOW_MS`) refreshed by `wheel` / `touchstart` / `touchmove` / `keydown` on the scroller, plus a held flag for a scrollbar-gutter drag.
- A press inside the **content box** is a click (expanding a tool card, selecting text) and deliberately does *not* vouch for the re-measure scrolls that follow it — otherwise the same hole reopens from the other side. `isScrollbarGutterPress` is the discriminator.
- Landing within `FOLLOW_THRESHOLD_PX` of the bottom still re-attaches unconditionally.

### Two follow-ons

- **`scrollToMessage` now detaches explicitly.** The artifacts / ⌘F deep-link jump used to rely on the resulting scroll-up being mistaken for a gesture — the very mistake being fixed. Without this, a streaming reply would yank the user off the message they jumped to.
- **`stickToTail` writes twice, across a frame.** Virtuoso publishes `totalListHeightChanged` synchronously inside the ResizeObserver tick, while the list padding carrying part of that height is React state landing on a later commit — so the first write can read a pre-growth `scrollHeight` and park short of the tail. The rAF write lands on the real one. Both are guarded on the follow state.

## Tests

- `chatUtils.test.ts` — the pure decision, including a regression case with **identical numbers** to the user-scroll-up case where the intent flag is the only difference, plus the intent-window / gutter-press helpers.
- `Transcript.test.tsx` — the **wiring**, on a mounted transcript driven through a gesture-less scroll-up. Verified red against the old logic (`× REGRESSION: a scroll-up with no user gesture keeps the transcript following`) and green with the fix.

Full suite green: 2912 renderer + 2155 server, typecheck clean.

`AGENTS.md` records the new invariant so generation seven doesn't reintroduce it.