### PR TITLE
feat(renderer): new-session composer parity with the session composer (BET-1088)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -169,7 +169,7 @@ type Props = {
   // used by the optimistic "new session" flow so the first prompt + running
   // indicator appear immediately in the real chat view. Optional; present
   // only on the transient panel rendered while the tmux window is created.
-  autoSubmit?: { text: string; model?: ModelSelection };
+  autoSubmit?: { text: string; model?: ModelSelection; plan?: boolean };
   // App-control (BET-840/841): App owns the single `appControl` bus listener
   // and reaches the open panel for a `switch-model` action through these.
   // `selectModel` is registered so a model-switch applies the override through
@@ -1275,8 +1275,16 @@ export function ChatPanel({
   useEffect(() => {
     if (!autoSubmit || autoSubmitted.current) return;
     autoSubmitted.current = true;
-    const { text, model } = autoSubmit;
+    const { text, model, plan } = autoSubmit;
     setModelOverride(model ?? null);
+    // The draft's plan mode rides the same one-shot channel as the model
+    // (the new panel can mount before the draft finishes handing off, and its
+    // plan state is seeded once from storage at mount — a side-channel write
+    // could land after that read). syncPlan triggers a re-render that
+    // reassigns submitRef.current to a closure holding the new plan, and the
+    // actual submit stays deferred in the setTimeout below, so the first turn
+    // runs as the chosen agent.
+    syncPlan(plan ?? false);
     setInput(text);
     // Clear the one-shot INSIDE the fired timeout, never in the effect body.
     // Clearing the store flips autoSubmit → undefined, which re-runs this
@@ -1299,7 +1307,7 @@ export function ChatPanel({
       // cleanup, so there is still exactly one submission per autoSubmit value.
       autoSubmitted.current = false;
     };
-  }, [autoSubmit, setModelOverride, setInput]);
+  }, [autoSubmit, setModelOverride, setInput, syncPlan]);
 
   // BET-795: inbox "Start a session" — seed the composer (setInput) but do NOT
   // submit. One-shot via the same ref guard idiom as autoSubmit. Clearing the

--- a/src/renderer/ComposerParts.tsx
+++ b/src/renderer/ComposerParts.tsx
@@ -6,7 +6,7 @@
 // and the press-and-hold mic button. InputArea.tsx composes them.
 
 import { useRef } from "react";
-import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip, Trash2, Pause, Play } from "lucide-react";
+import { Clock, Key, Webhook, X, Mic, Loader2, Paperclip, Trash2, Pause, Play, DraftingCompass, Shield } from "lucide-react";
 import type { VoicePhase } from "./voice";
 import { type Attachment, type TypeaheadRow } from "./chatShared";
 import type { PendingScreenshot } from "./store";
@@ -19,6 +19,8 @@ import { formatClock, VOICE_TAP_HOLD_MS } from "../shared/waveform.mjs";
 // @-file row visible when it moves past the popup's scroll fold.
 import { useSelectedIntoView } from "./PaletteShell";
 import { MeasureColumn } from "./MeasureColumn";
+import { Chip } from "./Chip";
+import type { PlanToggleState } from "./chatUtils";
 
 /**
  * The send glyph: lucide's paper plane as a SOLID shape.
@@ -661,5 +663,95 @@ export function MicButton({
     >
       {busy ? <Loader2 size={16} aria-hidden="true" className="animate-spin" /> : <Mic size={16} aria-hidden="true" />}
     </button>
+  );
+}
+
+// ===== Plan mode chip (BET-949) =====
+//
+// Shared by the session composer (InputArea) and the pre-session composer
+// (NewSessionScreen) — both render the same three-state control: a loading
+// pulse while the plan agent is unresolved, a disabled chip with an
+// explanatory title when this box has no plan agent, and a live toggle when
+// it does. Loading renders a chip-sized pulse placeholder (same bg-border
+// animate-pulse recipe as ModelPicker's SkeletonBar); unavailable renders
+// the chip disabled-equivalent with an explanatory title.
+export function PlanChip({
+  plan,
+  onToggle,
+}: {
+  plan: PlanToggleState;
+  onToggle: () => void;
+}) {
+  return plan.loading ? (
+    <span
+      className="inline-flex items-center h-[9px] rounded-full bg-border animate-pulse"
+      style={{ width: 64 }}
+      aria-hidden="true"
+    />
+  ) : (
+    <Chip
+      on={plan.on}
+      onClick={onToggle}
+      disabled={!plan.available}
+      title={plan.title}
+      hook="manta-plan-toggle"
+    >
+      <DraftingCompass size={13} aria-hidden="true" />
+      Plan
+    </Chip>
+  );
+}
+
+// ===== Trust / permissions row (BET-415) =====
+//
+// The ambient state line under the composer: in plan mode the edit tools are
+// gone so nothing is bypassed and the row reports "Plan mode — edits blocked"
+// WITHOUT rendering the bypass button — two contradictory permission claims
+// stacked together is how users stop believing either. Otherwise it toggles
+// chatAutoAllow (a single global config value: flipping it here flips it
+// everywhere), going danger-coloured while bypassing. Shared with the
+// pre-session composer so a draft and a session never disagree.
+export function TrustRow({
+  planOn,
+  chatAutoAllow,
+  setChatAutoAllow,
+}: {
+  planOn: boolean;
+  chatAutoAllow: boolean;
+  setChatAutoAllow: (v: boolean) => Promise<void>;
+}) {
+  return (
+    <div className="pb-3 flex items-center">
+      {planOn ? (
+        <span className="inline-flex items-center gap-2 text-[11px] leading-none font-normal py-[6px] px-0 text-text-muted">
+          <Shield size={14} aria-hidden="true" />
+          Plan mode — edits blocked
+        </span>
+      ) : (
+        <button
+          onClick={() => setChatAutoAllow(!chatAutoAllow)}
+          className={
+            // Smaller + regular weight (was 11.5px medium): this is an ambient
+            // state line under the composer, not a call to action. The danger
+            // colour is what makes the bypassing state read — the type does
+            // not need to carry it too.
+            "inline-flex items-center gap-2 text-[11px] leading-none font-normal py-[6px] px-0 " +
+            (chatAutoAllow
+              ? "text-danger hover:text-danger"
+              : "text-text-muted hover:text-text-muted")
+          }
+          title={
+            chatAutoAllow
+              ? "Bypassing permissions — click to re-enable approval"
+              : "Permissions on — click to bypass"
+          }
+        >
+          <Shield size={14} aria-hidden="true" />
+          {chatAutoAllow
+            ? "Bypassing permissions"
+            : "Permissions on — click to bypass"}
+        </button>
+      )}
+    </div>
   );
 }

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -17,7 +17,7 @@
 // a focus state instead of hairline dividers around a naked textarea.
 
 import { useEffect, useMemo, useRef, useState } from "react";
-import { DraftingCompass, Mic, Shield, Square } from "lucide-react";
+import { Mic, Square } from "lucide-react";
 import type { OpencodeModel } from "../shared/types";
 import type { Voice } from "./hooks/useVoice";
 import {
@@ -33,15 +33,16 @@ import {
 } from "./chatShared";
 import { baseModelId, isFastModelId, shortModelName } from "./chatUtils";
 import { ModelPicker } from "./ModelPicker";
-import { Chip } from "./Chip";
 import { MeasureColumn } from "./MeasureColumn";
 import {
   AttachButton,
   AttachmentStrip,
   MicButton,
+  PlanChip,
   RecordingRow,
   SendFilled,
   SessionToolbar,
+  TrustRow,
   PendingScreenshotStrip,
 } from "./ComposerParts";
 import type { PendingScreenshot } from "./store";
@@ -519,28 +520,9 @@ export function InputArea({
             onSelect={onSelectModel}
             labelOverride={shortLabel}
           />
-          {/* Plan mode chip (BET-949) — the counterpart to the model picker.
-              Loading renders a chip-sized pulse placeholder (same bg-border
-              animate-pulse recipe as ModelPicker's SkeletonBar); unavailable
-              renders the chip disabled-equivalent with an explanatory title. */}
-          {plan.loading ? (
-            <span
-              className="inline-flex items-center h-[9px] rounded-full bg-border animate-pulse"
-              style={{ width: 64 }}
-              aria-hidden="true"
-            />
-          ) : (
-            <Chip
-              on={plan.on}
-              onClick={onTogglePlan}
-              disabled={!plan.available}
-              title={plan.title}
-              hook="manta-plan-toggle"
-            >
-              <DraftingCompass size={13} aria-hidden="true" />
-              Plan
-            </Chip>
-          )}
+          {/* Plan mode chip (BET-949) — shared PlanChip, also used by the
+              new-session composer, so the two controls never drift. */}
+          <PlanChip plan={plan} onToggle={onTogglePlan} />
           {/* Input-mode affordances (🎤 / 📎) sit HERE, beside the model
               group, rather than inside the input box. They choose HOW you
               compose — the same category as which model you compose for —
@@ -607,44 +589,12 @@ export function InputArea({
         </span>
       </div>
       {/* Trust toggle — labelled control with a Shield icon (BET-415).
-          Replaces the ▶▶/▷▷ glyphs. Same chatAutoAllow behaviour, same
-          config key. Danger colour when bypassing.
-          In plan mode (BET-949) nothing is bypassed — the edit tools are gone —
-          so this row reports "Plan mode — edits blocked" instead and the
-          bypass state is not shown. Two contradictory permission claims stacked
-          together is how users stop believing either. */}
-      <div className="pb-3 flex items-center">
-        {plan.on ? (
-          <span className="inline-flex items-center gap-2 text-[11px] leading-none font-normal py-[6px] px-0 text-text-muted">
-            <Shield size={14} aria-hidden="true" />
-            Plan mode — edits blocked
-          </span>
-        ) : (
-        <button
-          onClick={() => setChatAutoAllow(!chatAutoAllow)}
-          className={
-            // Smaller + regular weight (was 11.5px medium): this is an ambient
-            // state line under the composer, not a call to action. The danger
-            // colour is what makes the bypassing state read — the type does
-            // not need to carry it too.
-            "inline-flex items-center gap-2 text-[11px] leading-none font-normal py-[6px] px-0 " +
-            (chatAutoAllow
-              ? "text-danger hover:text-danger"
-              : "text-text-muted hover:text-text-muted")
-          }
-          title={
-            chatAutoAllow
-              ? "Bypassing permissions — click to re-enable approval"
-              : "Permissions on — click to bypass"
-          }
-        >
-          <Shield size={14} aria-hidden="true" />
-          {chatAutoAllow
-            ? "Bypassing permissions"
-            : "Permissions on — click to bypass"}
-        </button>
-        )}
-      </div>
+          Shared TrustRow (also used by the new-session composer). In plan
+          mode nothing is bypassed — the edit tools are gone — so the row
+          reports "Plan mode — edits blocked" instead and the bypass state is
+          not shown. Two contradictory permission claims stacked together is
+          how users stop believing either. */}
+      <TrustRow planOn={plan.on} chatAutoAllow={chatAutoAllow} setChatAutoAllow={setChatAutoAllow} />
       </MeasureColumn>
     </div>
   );

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -47,7 +47,6 @@ export function ModelPicker({
   deactivatedMainModels,
   onOpen,
   onSelect,
-  defaultLabel = null,
   labelOverride = null,
 }: {
   modelLabel: string | null;
@@ -60,14 +59,9 @@ export function ModelPicker({
   deactivatedMainModels?: string[];
   onOpen: () => void;
   onSelect: (m: ModelSelection | null) => void;
-  // Welcome-screen helpers for the model button label.
-  //   - `defaultLabel` (e.g. "Auto"): shown when NO per-session override is
-  //     active (the server default is in effect).
-  //   - `labelOverride`: shown unconditionally, highest precedence — lets a
-  //     caller display "Auto" until the user first picks a model, even when
-  //     the override is seeded from the configured default.
-  // Both are no-ops for callers that don't pass them (ChatPanel).
-  defaultLabel?: string | null;
+  // Welcome-screen helper for the model button label: shown unconditionally,
+  // highest precedence — lets a caller display "Auto" until the user first
+  // picks a model. A no-op for callers that don't pass it (ChatPanel).
   labelOverride?: string | null;
 }) {
   const [modelOpen, setModelOpen] = useState(false);
@@ -124,16 +118,11 @@ export function ModelPicker({
       ? "Default"
       : "High";
 
-  // Friendly display name for the model button. Falls back through the same
-  // precedence as the old label: override → default → last-used → stub.
-  // `defaultLabel` (e.g. "Auto", the welcome-screen convention) replaces the
-  // resolved name when the server default is active and no override is set;
-  // `labelOverride` wins unconditionally (highest precedence).
+  // Friendly display name for the model button: the caller's labelOverride
+  // (highest precedence), else the resolved active model name, else the
+  // modelLabel prop, else the "opencode" stub.
   const modelDisplayName =
-    labelOverride ??
-    (modelOverride == null && defaultLabel
-      ? defaultLabel
-      : activeModel?.name ?? modelLabel ?? "opencode");
+    labelOverride ?? activeModel?.name ?? modelLabel ?? "opencode";
 
   // ⚡ fast-mode toggle — the third segment. Flipping it swaps the active model
   // for its `-fast` twin (or back), carrying the selected effort across. It is

--- a/src/renderer/NewSessionScreen.harness.test.tsx
+++ b/src/renderer/NewSessionScreen.harness.test.tsx
@@ -20,9 +20,14 @@
 //      way App.tsx's launchersList effect does.
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { act } from "react";
 import { installMockApi, resetStore, mount, type Harness } from "./testHarness";
 import { NewSessionScreen, uniqueSessionName } from "./NewSessionScreen";
 import type { NewSessionDraft } from "./store";
+import { useStore } from "./store";
+import { refreshModelCatalog } from "./modelCatalog";
+import { refreshAgentCatalog } from "./agentCatalog";
+import type { WorktreeInfo } from "../shared/types";
 
 // The two methods that live ONLY on httpApi and are therefore absent from
 // the preload bridge a fresh desktop boot starts on.
@@ -39,7 +44,7 @@ function draft(overrides: Partial<NewSessionDraft> = {}): NewSessionDraft {
     wantWorktree: false,
     worktreeBranch: "worktree",
     model: null,
-    modelTouched: false,
+    plan: false,
     input: "",
     ...overrides,
   };
@@ -54,6 +59,10 @@ function mountDraft(overrides: Partial<NewSessionDraft> = {}): Harness {
 describe("NewSessionScreen mount against an unpaired window.api", () => {
   let h: Harness | null = null;
 
+  // The model/agent catalogs are module-level cached; a given test forces a
+  // fresh fetch AFTER installing its window.api so counts stay deterministic
+  // (see the "still fetches models" case) and snapshots don't leak across
+  // mounts. The store reset here keeps the baseline reproducible.
   beforeEach(() => {
     resetStore({ projects: [] });
   });
@@ -100,6 +109,10 @@ describe("NewSessionScreen mount against an unpaired window.api", () => {
 
   it("still fetches models when window.api IS the paired httpApi", async () => {
     const { api } = installMockApi();
+    // Force a re-fetch with the freshly-installed api (the shared catalog is
+    // module-cached, so without this an earlier mount's snapshot short-circuits).
+    refreshModelCatalog();
+    refreshAgentCatalog();
 
     h = mountDraft();
     await h.flush();
@@ -107,6 +120,150 @@ describe("NewSessionScreen mount against an unpaired window.api", () => {
     // The guard must not have silently disabled the happy path.
     expect(api.calls.opencodeModels?.length ?? 0).toBe(1);
     expect(api.calls.opencodeDefaultModel?.length ?? 0).toBe(1);
+  });
+});
+
+// Composer-parity tests (BET-1088): the pre-session composer renders the same
+// controls as a real session's composer — read-only branch badge when the
+// worktree isn't wanted, the configured default model (never the "Auto"
+// label), the plan chip, the trust row + usage dial, and the plan flag carried
+// into the created session's first prompt. All drive the new-session (composer)
+// branch, reached with a project-scoped draft.
+describe("NewSessionScreen composer parity (BET-1088)", () => {
+  let h: Harness | null = null;
+
+  const GIT_WT: WorktreeInfo[] = [
+    { path: "/x", head: "abc", branch: "main", bare: false, detached: false },
+  ];
+
+  const composerDraft = (overrides: Partial<NewSessionDraft> = {}): NewSessionDraft =>
+    draft({ mode: { projectName: "proj" }, cwd: "/x", ...overrides });
+
+  function mountComposer(
+    d: NewSessionDraft,
+    apiOverrides: Record<string, unknown> = {},
+    storeOverrides: Partial<ReturnType<typeof useStore.getState>> = {},
+  ): Harness {
+    installMockApi({
+      gitListWorktrees: () => Promise.resolve(GIT_WT),
+      ...apiOverrides,
+    });
+    // Fresh catalog fetch against the just-installed api — the catalogs are
+    // module-cached and an earlier test's snapshot would otherwise short-circuit
+    // the override below (e.g. the model-name test needs these models).
+    refreshModelCatalog();
+    refreshAgentCatalog();
+    resetStore({ projects: [], activeDraftId: d.id, drafts: [d], ...storeOverrides });
+    h = mount(<NewSessionScreen draftId={d.id} />);
+    return h;
+  }
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("renders the branch as a non-button badge (no hover affordance) when worktree is unchecked", async () => {
+    mountComposer(composerDraft({ wantWorktree: false }));
+    await h!.flush();
+    // The branch name is shown as metadata.
+    expect(h!.text()).toContain("main");
+    // It is NOT a button carrying the branch text — an inert Tag, not a control.
+    const buttons = [...h!.container.querySelectorAll("button")].filter((b) =>
+      b.textContent?.includes("main"),
+    );
+    expect(buttons).toHaveLength(0);
+  });
+
+  it("keeps the editable worktree branch input when worktree is wanted in a git repo", async () => {
+    mountComposer(composerDraft({ wantWorktree: true }));
+    await h!.flush();
+    expect(
+      h!.container.querySelector('input[aria-label="Worktree branch name"]'),
+    ).toBeTruthy();
+  });
+
+  it("shows the configured default model's name, not the 'Auto' label", async () => {
+    const d = composerDraft();
+    // Seed the draft through createDraft so model comes from the store default
+    // (mirror ChatPanel's readSavedModel ?? configDefaultModel seed).
+    useStore.setState({ defaultModel: { providerID: "anthropic", modelID: "claude-x" } });
+    mountComposer(d, {
+      opencodeModels: () =>
+        Promise.resolve([
+          { id: "claude-x", providerID: "anthropic", name: "Claude X", limit: { context: 200000 } },
+        ]),
+      opencodeDefaultModel: () =>
+        Promise.resolve({ providerID: "anthropic", modelID: "claude-x" }),
+    });
+    await h!.flush();
+    expect(h!.text()).toContain("Claude X");
+    expect(h!.text()).not.toContain("Auto");
+  });
+
+  it("toggles the Plan chip and ships plan:true on the created session's first prompt", async () => {
+    const d = composerDraft({ input: "hello" });
+    mountComposer(
+      d,
+      {
+        opencodeAgents: () =>
+          Promise.resolve([
+            { name: "plan", mode: "primary", description: "plan", models: [], model: "x" },
+          ]),
+        tmuxNewWindow: () =>
+          Promise.resolve({ sessionId: "ses-1", windowIndex: 0, projects: [] }),
+      },
+      {
+        projects: [
+          {
+            tmuxSession: "proj",
+            defaultCwd: "/x",
+            attached: false,
+            windows: [
+              {
+                index: 0,
+                name: "w",
+                active: true,
+                paneCurrentPath: "/x",
+                opencodeSessionId: "ses-1",
+              },
+            ],
+          },
+        ],
+        // Neutralize dismissDraft (BEFORE mount, since submit() closes over the
+        // store binding from the render): submit() removes the draft at the
+        // end, and a directly-mounted NewSessionScreen then re-renders with the
+        // removed draft — its early `if (!draft) return null` drops hooks and
+        // React throws. In the real app App unmounts the screen on
+        // activeDraftId change instead, so this stub is only a harness shim to
+        // let the assertion reach the first-prompt channel.
+        dismissDraft: () => {},
+      },
+    );
+    await h!.flush();
+
+    // Toggle plan on via the chip.
+    const chip = [...h!.container.querySelectorAll("button")].find(
+      (b) => b.textContent?.trim() === "Plan",
+    );
+    expect(chip, "expected a Plan chip").toBeTruthy();
+    act(() => chip!.click());
+    await h!.flush();
+    expect(
+      useStore.getState().drafts.find((x) => x.id === d.id)?.plan,
+    ).toBe(true);
+
+    // Submit → the first-prompt channel carries plan:true.
+    const start = h!.container.querySelector(
+      'button[aria-label="Start a session"]',
+    ) as HTMLButtonElement;
+    expect(start).toBeTruthy();
+    act(() => start.click());
+    await h!.flush();
+
+    const asp = useStore.getState().autoSubmitPrompt;
+    expect(asp?.plan).toBe(true);
+    expect(asp?.text).toBe("hello");
   });
 });
 

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -36,8 +36,12 @@ import {
 } from "lucide-react";
 import { useStore } from "./store";
 import { Chip } from "./Chip";
+import { Tag } from "./Tag";
 import { ModelPicker } from "./ModelPicker";
-import { MicButton } from "./ComposerParts";
+import { useModelCatalog } from "./modelCatalog";
+import { useAgentCatalog } from "./agentCatalog";
+import { MicButton, PlanChip, TrustRow } from "./ComposerParts";
+import { UsageDial } from "./UsageDial";
 import { IconButton } from "./IconButton";
 import { Button } from "./Button";
 import { Card } from "./Card";
@@ -53,13 +57,13 @@ import { useVoiceRecorder } from "./voice";
 import {
   describeRepoRow,
   formatAge,
+  resolvePlanToggle,
   zeroStateMode,
   type RepoRow,
 } from "./chatUtils";
 import type { VoicePhase } from "./voice";
 import type {
   ForgeCliStatus,
-  OpencodeModel,
   Project,
   RepoHit,
   TmuxCreateResult,
@@ -411,40 +415,34 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
 
 
 
-  // Model state — fetched on mount (same pattern as ChatPanel).
-  const [models, setModels] = useState<OpencodeModel[] | null>(null);
-  const [serverDefault, setServerDefault] = useState<{
-    providerID: string;
-    modelID: string;
-  } | null>(null);
+  // Model state — the SHARED cached catalog (same hook as ChatPanel), so the
+  // picker renders its last-known models synchronously on remount instead of
+  // flashing empty while a fresh fetch runs. The shared module carries the
+  // same pre-pairing httpApi-only guard this screen's old local fetch had.
+  const { models, defaultModel: serverDefault } = useModelCatalog();
 
-  useEffect(() => {
-    let cancelled = false;
-    // GUARD (same pattern as App.tsx's launchersList effect): both of these
-    // live ONLY on httpApi. On a fresh/unpaired desktop boot `window.api` is
-    // still the raw preload OS-bridge subset, where they are undefined —
-    // calling them throws synchronously from the commit phase, which `.catch`
-    // cannot see and which unmounts the whole tree.
-    if (window.api.opencodeModels) {
-      window.api
-        .opencodeModels()
-        .then((list) => { if (!cancelled) setModels(list); })
-        .catch(() => {});
-    }
-    if (window.api.opencodeDefaultModel) {
-      window.api
-        .opencodeDefaultModel()
-        .then((d) => { if (!cancelled) setServerDefault(d); })
-        .catch(() => {});
-    }
-    return () => { cancelled = true; };
-  }, []);
-
+  // Active model object for the usage dial + model menu. Resolved through the
+  // same shared path ChatPanel uses so the welcome composer and a session
+  // never disagree about which model is active.
   const activeModel = useMemo(
     () => resolveActiveModel(models, draft.model, serverDefault),
     [models, draft.model, serverDefault],
   );
-  void activeModel; // used by ModelPicker via models + draft.model
+
+  // Plan mode availability comes from the shared box-level agent catalog
+  // (same source as a real session's composer), resolved against the draft's
+  // own plan flag. The chip drives draft.plan, which submit() carries into the
+  // created session's first turn.
+  const { agents } = useAgentCatalog();
+  const plan = useMemo(
+    () => resolvePlanToggle(agents, draft.plan),
+    [agents, draft.plan],
+  );
+
+  // Trust row: chatAutoAllow is a single global config value — flipping it
+  // here flips it everywhere (no per-draft copy; a draft isn't a session).
+  const chatAutoAllow = useStore((s) => s.chatAutoAllow);
+  const setChatAutoAllow = useStore((s) => s.setChatAutoAllow);
 
   // ---- resolve cwd for new-session mode ----
   // In new-session mode, the cwd defaults to the project's cwd (inherited
@@ -577,8 +575,15 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
 
       // Queue the first prompt for the App-mounted ChatPanel (which auto-submits
       // it through its own optimistic path) and navigate to the new session.
+      // The plan flag rides the same one-shot channel so the draft's plan mode
+      // lands on the session's FIRST turn (see ChatPanel's autoSubmit effect).
       if (sessionId) {
-        setAutoSubmitPrompt({ sid: sessionId, text, model: draft.model ?? undefined });
+        setAutoSubmitPrompt({
+          sid: sessionId,
+          text,
+          model: draft.model ?? undefined,
+          plan: draft.plan,
+        });
       }
       // Navigate to the new session (setActive + box-side select-window so the
       // PTY follows) — one store action shared with the sidebar/jump flows.
@@ -658,10 +663,16 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
       }
 
       if (sessionId && text) {
+        // 6th param is the agent. Fan-out can't use the autoSubmit channel (it
+        // sends directly), so resolve the plan agent here exactly as ChatPanel
+        // does (plan.available && plan.on) so the two paths cannot diverge.
         await window.api.opencodePrompt(
           sessionId,
           text,
           draft.model ?? undefined,
+          undefined,
+          undefined,
+          plan.available && plan.on ? plan.agent : undefined,
         );
       }
 
@@ -748,14 +759,17 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
               aria-label="Worktree branch name"
             />
           ) : (
-            <Chip on={draft.wantWorktree} onClick={() => {}} title="Current git branch">
-              <GitBranch size={13} className="shrink-0" aria-hidden="true" />
-              {branchName ? (
-                <span className="truncate max-w-[120px]">{branchName}</span>
-              ) : (
-                <span className="text-text-faint">no branch</span>
-              )}
-            </Chip>
+            // When "worktree" is unchecked the branch is not editable — it is
+            // metadata about the folder, not a control. An inert Tag (no
+            // button, no onClick, no popover) matches the session header's
+            // branch badge and avoids a dead hover affordance.
+            <Tag
+              size="sm"
+              icon={<GitBranch size={11} aria-hidden="true" className="shrink-0" />}
+              title={branchName ? `On branch ${branchName}` : "Not a git repository"}
+            >
+              <span className="truncate max-w-[120px]">{branchName ?? "no branch"}</span>
+            </Tag>
           )}
 
           <Checkbox
@@ -807,50 +821,63 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
           </button>
         </div>
 
-        {/* Controls row — model ▸ effort, then attach + dictate. */}
-        <div className="flex items-center gap-2 self-start">
-          <ModelPicker
-            modelLabel={null}
-            models={models}
-            modelOverride={draft.model}
-            defaultModel={serverDefault}
-            deactivatedMainModels={deactivatedMainModels}
-            onOpen={() => {}}
-            onSelect={(m: ModelSelection | null) => {
-              // null = clear back to the server default ("Auto").
-              updateDraft(draftId, {
-                model: m,
-                modelTouched: m != null,
-              });
-            }}
-            labelOverride={draft.modelTouched ? null : "Auto"}
-          />
-
-          <IconButton
-            icon={<Paperclip />}
-            label="Attach a file"
-            title="Attaching files is not available when starting a session"
-            size="xl"
-            disabled
-          />
-
-          {voiceEnabled ? (
-            <MicButton
-              phase={voicePhase}
-              onStart={() => { voiceRecorder.start(); }}
-              onStop={voiceRecorder.stop}
-              onCancel={voiceRecorder.cancel}
+        {/* Controls row — model ▸ effort + plan chip on the left, attach +
+            dictate beside them, with the usage dial grouped right (mirrors the
+            session composer's meta footer layout). No SessionToolbar here —
+            schedules/secrets/webhooks are session-scoped and there is no
+            session yet. */}
+        <div className="py-1 flex items-center justify-between gap-3 flex-wrap">
+          <span className="flex items-center gap-2 min-w-0 flex-wrap">
+            <ModelPicker
+              modelLabel={null}
+              models={models}
+              modelOverride={draft.model}
+              defaultModel={serverDefault}
+              deactivatedMainModels={deactivatedMainModels}
+              onOpen={() => {}}
+              onSelect={(m: ModelSelection | null) => {
+                // null = clear back to the server default.
+                updateDraft(draftId, { model: m });
+              }}
             />
-          ) : (
-              <IconButton
-                icon={<Mic />}
-                label="Dictate"
-                title="Dictation needs a Groq API key in Settings"
-                size="xl"
-                disabled
+            <PlanChip
+              plan={plan}
+              onToggle={() => updateDraft(draftId, { plan: !draft.plan })}
+            />
+
+            <IconButton
+              icon={<Paperclip />}
+              label="Attach a file"
+              title="Attaching files is not available when starting a session"
+              size="xl"
+              disabled
+            />
+
+            {voiceEnabled ? (
+              <MicButton
+                phase={voicePhase}
+                onStart={() => { voiceRecorder.start(); }}
+                onStop={voiceRecorder.stop}
+                onCancel={voiceRecorder.cancel}
               />
-            )}
+            ) : (
+                <IconButton
+                  icon={<Mic />}
+                  label="Dictate"
+                  title="Dictation needs a Groq API key in Settings"
+                  size="xl"
+                  disabled
+                />
+              )}
+          </span>
+          <span className="shrink-0 flex items-center gap-2 flex-wrap">
+            <UsageDial providerID={activeModel?.providerID ?? null} />
+          </span>
         </div>
+
+        {/* Permissions row — the shared trust toggle (plan mode reads "Plan
+            mode — edits blocked"; else the chatAutoAllow bypass). */}
+        <TrustRow planOn={plan.on} chatAutoAllow={chatAutoAllow} setChatAutoAllow={setChatAutoAllow} />
         </>
         ) : (
         <>

--- a/src/renderer/Sidebar.test.tsx
+++ b/src/renderer/Sidebar.test.tsx
@@ -418,3 +418,72 @@ describe("Sidebar — project close worktree-cleanup + toast path (killProject, 
     ).toBe(true);
   });
 });
+
+describe("Sidebar — only the active draft is highlighted (BET-1088)", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    localStorage.clear();
+    installMockApi({
+      configUpdate: (patch: Record<string, unknown>) =>
+        Promise.resolve({ pinnedWindows: (patch as { pinnedWindows?: string[] }).pinnedWindows ?? [] }),
+    });
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("with a project-scoped draft active, no session row is selected but the draft row + group header keep their state", async () => {
+    resetStore({
+      activeProjectName: "proj",
+      activeWindowByProject: { proj: 0 },
+      activeDraftId: "draft-1",
+      drafts: [
+        {
+          id: "draft-1",
+          mode: { projectName: "proj" },
+          cwd: "/x",
+          wantWorktree: false,
+          worktreeBranch: "worktree",
+          model: null,
+          plan: false,
+          input: "",
+        },
+      ],
+      projects: [
+        proj({
+          tmuxSession: "proj",
+          windows: [
+            { index: 0, name: "win", active: true, paneCurrentPath: "/x", opencodeSessionId: null },
+          ],
+        }),
+      ],
+    });
+    h = mount(
+      <Sidebar onOpenSettings={() => {}} onNewProject={() => {}} onNewSessionInProject={() => {}} onOpenResumeModal={() => {}} />,
+    );
+    await h.flush();
+
+    // Exactly one selected row: the draft. The session the user came from must
+    // not also claim to be current.
+    const selected = h.container.querySelectorAll('[aria-selected="true"]');
+    expect(selected.length).toBe(1);
+    expect(selected[0].textContent).toContain("new session");
+
+    // The window row is present but NOT selected.
+    const winRow = [...h.container.querySelectorAll('[role="treeitem"]')].find((el) =>
+      el.textContent?.includes("win"),
+    );
+    expect(winRow).toBeTruthy();
+    expect(winRow!.getAttribute("aria-selected")).toBe("false");
+
+    // The project group header keeps its active tint (a project-scoped draft
+    // genuinely lives inside that project).
+    const headerName = [...h.container.querySelectorAll("span")].find(
+      (el) => el.textContent?.trim() === "proj" && el.className.includes("text-text"),
+    );
+    expect(headerName).toBeTruthy();
+  });
+});

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -103,6 +103,10 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
   const worktreeCleanOnClose = useStore((s) => s.worktreeCleanOnClose);
   const drafts = useStore((s) => s.drafts);
   const activeDraftId = useStore((s) => s.activeDraftId);
+  // A draft is the active VIEW (App renders NewSessionScreen for it), so no
+  // real session row is current. The project GROUP header keeps its tint — a
+  // project-scoped draft genuinely lives inside that project.
+  const rowsSelectable = activeDraftId == null;
   const setActiveDraft = useStore((s) => s.setActiveDraft);
   const dismissDraft = useStore((s) => s.dismissDraft);
   // Downloaded desktop auto-update (BET-416 §E): signalled as a dot on the
@@ -716,6 +720,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                   project={r.project}
                   window={r.window}
                   isActive={
+                    rowsSelectable &&
                     activeProjectName === r.project.tmuxSession &&
                     activeWindowByProject[r.project.tmuxSession] === r.window.index
                   }
@@ -795,7 +800,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
               {!isCollapsed && (
                 <div className="pl-2 space-y-px mt-px">
                   {topWindows.map((w) => {
-                    const isActive = isProjectActive && activeWinIdx === w.index;
+                    const isActive = rowsSelectable && isProjectActive && activeWinIdx === w.index;
                     const kids = n.children.get(w.index) ?? [];
                     return (
                       <div key={w.index}>
@@ -838,7 +843,7 @@ export const Sidebar = forwardRef<SidebarHandle, Props>(function Sidebar(
                         {kids.map((childIdx, i) => {
                           const childWin = p.windows.find((x) => x.index === childIdx);
                           if (!childWin) return null;
-                          const childActive = isProjectActive && activeWinIdx === childIdx;
+                          const childActive = rowsSelectable && isProjectActive && activeWinIdx === childIdx;
                           return (
                             <JobChildRow
                               key={`job:${p.tmuxSession}:${childIdx}`}

--- a/src/renderer/store.test.ts
+++ b/src/renderer/store.test.ts
@@ -754,6 +754,16 @@ describe("new-session drafts", () => {
     expect(d.wantWorktree).toBe(false);
   });
 
+  it("createDraft seeds model from the store defaultModel and plan defaults to false", () => {
+    useStore.setState({ defaultModel: { providerID: "anthropic", modelID: "claude-sonnet-4" } });
+    const id = useStore.getState().createDraft("new-project");
+    const d = useStore.getState().drafts.find((x) => x.id === id)!;
+    // Mirrors ChatPanel's readSavedModel ?? configDefaultModel seed.
+    expect(d.model).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4" });
+    // A fresh session defaults to build mode (readPlanSaved on an unknown id).
+    expect(d.plan).toBe(false);
+  });
+
   it("createDraft new-session mode targets the project and seeds cwd from config", () => {
     useStore.setState({ worktreePerSession: true });
     useStore.getState().createDraft({ projectName: "better-ui" });

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -221,7 +221,10 @@ export type NewSessionDraft = {
   worktreeBranch: string;
   // null = auto / not explicitly picked (presentational only until submit).
   model: ModelSelection | null;
-  modelTouched: boolean;
+  // Plan mode for the FIRST turn of the session this draft creates. A fresh
+  // session defaults to build mode when opened (readPlanSaved returns false
+  // for an unknown session id), mirrored here.
+  plan: boolean;
   input: string;
 };
 
@@ -407,7 +410,7 @@ type State = {
   // A one-shot prompt for a freshly-created chat session to auto-submit on its
   // first mount (draft → new-session flow). Consumed (cleared) by the panel
   // once it fires, so re-navigating to the session never re-sends it.
-  autoSubmitPrompt: { sid: string; text: string; model?: ModelSelection } | null;
+  autoSubmitPrompt: { sid: string; text: string; model?: ModelSelection; plan?: boolean } | null;
   // BET-795: a one-shot composer SEED — the inbox's "Start a session" lands in
   // a chat session with the prompt seeded into the composer but NOT submitted
   // (the user reviews + hits Enter). Delivered to the session's ChatPanel like
@@ -555,7 +558,7 @@ type State = {
   dismissDraft: (id: string) => void;
   setActiveDraft: (id: string) => void;
   setAutoSubmitPrompt: (
-    p: { sid: string; text: string; model?: ModelSelection } | null,
+    p: { sid: string; text: string; model?: ModelSelection; plan?: boolean } | null,
   ) => void;
   setSeedPrompt: (p: { sid: string; text: string } | null) => void;
   refresh: () => Promise<void>;
@@ -823,6 +826,7 @@ export const useStore = create<State>((set, get) => ({
   createDraft: (mode) => {
     const id = newDraftId();
     const worktreePerSession = get().worktreePerSession;
+    const defaultModel = get().defaultModel;
     set((prev) => ({
       drafts: [
         ...prev.drafts,
@@ -832,8 +836,12 @@ export const useStore = create<State>((set, get) => ({
           cwd: mode === "new-project" ? "~" : "",
           wantWorktree: mode === "new-project" ? false : worktreePerSession ?? true,
           worktreeBranch: "worktree",
-          model: null,
-          modelTouched: false,
+          // Seed from the configured global default (mirror ChatPanel's
+          // readSavedModel ?? configDefaultModel), NOT null — the model menu's
+          // "Server default" row still works because the picker's "clear back
+          // to default" onSelect writes model:null explicitly.
+          model: defaultModel ?? null,
+          plan: false,
           input: "",
         },
       ],


### PR DESCRIPTION
## BET-1088 — New-session composer parity with the session composer

Closes the six gaps between the pre-session composer (`NewSessionScreen`) and
the real in-session composer (`InputArea`):

1. **Branch 💡 read-only badge** — when "worktree" is unchecked, the branch
   renders as an inert `Tag` (`sm`) like the session header's badge, not a
   dead-click `Chip`. No button, no onClick, no popover. The editable
   worktree-branch input is unchanged.
2. **Model defaults to the configured default** — deleted the screen's private
   model fetch in favour of the shared cached `useModelCatalog` (the picker no
   longer flashes empty on remount); `createDraft` now seeds `model` from the
   store's `defaultModel` (mirroring `readSavedModel ?? configDefaultModel`);
   removed `modelTouched` and the `"Auto"` label; removed ModelPicker's now-
   unreferenced `defaultLabel` prop. `grep modelTouched|defaultLabel` → only
   `ModelMenu.tsx`'s unrelated local (verified).
3. **Plan chip + permissions row extracted** — `PlanChip` and `TrustRow` moved
   into shared `ComposerParts.tsx`, used by BOTH `InputArea` and
   `NewSessionScreen` (no duplication, jscpd-safe).
4. **Plan mode on the new-session composer** — new `plan` field on the draft;
   the chip renders beside the model picker; plan travels to the created
   session through the existing first-prompt channel (`autoSubmitPrompt.plan`
   → `ChatPanel`'s `autoSubmit` effect calls the existing `syncPlan` before the
   deferred submit). Fan-out path passes the plan agent (6th param) directly.
5. **Usage dial + trust row** — `UsageDial` renders in the composer's meta row
   (using the now-real `activeModel`), and `TrustRow` sits beneath it; both
   mirror the session composer's layout. `chatAutoAllow` stays a single global
   value (no per-draft copy).
6. **Sidebar highlights only the active draft** — `rowsSelectable` gates the
   pinned / window / job-child selected chrome when a draft is the active view;
   the project group header keeps its tint.

**Files changed:** 10 (8 source + 2 test files). `src/renderer/{NewSessionScreen,InputArea,ComposerParts,ChatPanel,ModelPicker,store,Sidebar}.ts(x|tsx)` + `NewSessionScreen.harness.test.tsx`, `Sidebar.test.tsx`, `store.test.ts`.

**Self-check:**
- C1 branch badge → 9/10 (won't regress: covered by new harness test + EDITED input guard)
- C2 default model → 10/10 (grep clean; seeding + label removal both verified)
- C3 PlanChip/TrustRow extraction → 9/10 (behaviour-preserving, shared, no dup)
- C4 plan mode carry-through → 9/10 (ordering preserved; fan-out agent mirrored)
- C5 trust row + usage dial → 9/10
- C6 sidebar active-draft drill → 9/10 (covered by new Sidebar test)
- Verification → 10/10 (0 failures both branches)

**Verification results:**
- PR branch (`multica/BET-1088-new-session-composer-parity` @ `30aa504e`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, vitest 3021 pass / 7 skip, node:test 2326 pass / 0 fail. Failures: none. log sha256: `42c4c0e15eaa252d0334d2a7217e70bb85970a2181734dd59dc65fb5520fd81f`
- Base (`main` @ `f836f0fe`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, vitest 3015 pass / 7 skip, node:test 2326 pass / 0 fail. Failures: none. log sha256: `60bac78a3051a06f4186e1cbc007490e8f3ddd820259247e33f3830390c569cb`
- **Conclusion:** 0 failures on both branches. PR adds 6 new tests (all pass); no pre-existing failures, no new failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

**Base: origin/main @ `f836f0fe`**
