### PR TITLE
feat(server): create scratch project directory (project:create-scratch) (BET-1091)

### DIFF
--- a/src/renderer/api/demoApi.ts
+++ b/src/renderer/api/demoApi.ts
@@ -505,6 +505,13 @@ const fsListDirs = (partial: string): Promise<DirListing> =>
 const gitListWorktrees = (cwd: string): Promise<WorktreeInfo[]> =>
   Promise.resolve(demoGitListWorktrees(cwd));
 
+// BET-1091: create a scratch project dir. Fictional — the demo has no box
+// filesystem tree to create a directory in, so it returns a plausible path
+// named after the requested (already-slugified) name. Stubbed explicitly so
+// the coverage test's unimplemented list stays accurate.
+const projectCreateScratch = (input: { root: string; name: string }): Promise<{ path: string; name: string }> =>
+  Promise.resolve({ path: "/home/demo/projects/" + input.name, name: input.name });
+
 // Version guard (BET-225 stage 3 Part C + BET-357 §3). Pretend the client and
 // server are the aligned default unless the demo state needs a specific version
 // pair to drive a banner — the renderer reads these in an effect and derives
@@ -602,6 +609,7 @@ export const explicitMethods = {
   outboxList,
   fsListDirs,
   gitListWorktrees,
+  projectCreateScratch,
   getClientVersion,
   getServerVersion,
   onAutoUpdateError,

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -706,6 +706,8 @@ export const httpApi: Api = {
 
   // -- filesystem --
   fsListDirs: (partial) => rpc(IPC.fsListDirs, partial),
+  // BET-1091: create an empty, git-initialised scratch project directory.
+  projectCreateScratch: (input) => rpc(IPC.projectCreateScratch, input),
 
   // -- repo probe (BET-786) --
   forgeProbe: () => rpc(IPC.forgeProbe),

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -9,12 +9,13 @@
 
 import { run } from "./tmux.mjs";
 import { spawn as nodeSpawn } from "node:child_process";
-import { readdir, readFile, stat, realpath } from "node:fs/promises";
+import { readdir, readFile, stat, realpath, mkdir } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname, basename } from "node:path";
 import { statePath, expandTilde } from "../shared/paths.mjs";
 import { deriveWorktree, isWorktreeDirtyError } from "../shared/worktree.mjs";
+import { slugifyProjectName, uniqueSessionName } from "../shared/projectName.mjs";
 import { detectForge, repoKey } from "../shared/forge.mjs";
 import { runLoginShell } from "./launchers.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
@@ -260,6 +261,54 @@ export async function gitRemoveWorktree({ path: wtPath, force }) {
     }
   }
   return { removed: true };
+}
+
+// ============================================================
+// Scratch project — create an empty, git-initialised directory (BET-1091)
+// ============================================================
+//
+// createScratchProject({ root, name }) → { path, name }
+// preload: ipcRenderer.invoke(IPC.projectCreateScratch, { root, name })
+//   → args[0] = { root: string, name: string }
+//
+// Creates an empty project directory directly under `root` and initialises git
+// in it, returning the REAL absolute path. The renderer (stage 4) feeds that
+// path into the existing session-creation call exactly as if the user had
+// browsed to the folder, so nothing downstream changes.
+//
+// The requested `name` is slugified via the shared `slugifyProjectName` and
+// de-duplicated against the directories already present under `root` via the
+// shared `uniqueSessionName` (`name`, `name-2`, `name-3`, …). A missing root
+// is NOT an error — `mkdir` with `recursive:true` creates it. The git init is
+// NON-FATAL: a plain directory without git is still a usable workspace, and
+// the box may have no git. Errors from the root/name guards and the mkdir
+// propagate (fail-closed) so the renderer can show them inline.
+export async function createScratchProject({ root, name }) {
+  if (!root || !root.trim()) throw new Error("root is required");
+  const slug = slugifyProjectName(name);
+  if (!slug) throw new Error("name is required");
+  const baseRoot = expandTilde(root.trim());
+  // Build the set of names already taken directly under root. A missing /
+  // unreadable root is not an error here — the recursive mkdir below creates
+  // it, so treat it as an empty set.
+  let taken = new Set();
+  try {
+    const entries = await readdir(baseRoot, { withFileTypes: true });
+    taken = new Set(entries.filter((e) => e.isDirectory()).map((e) => e.name));
+  } catch {
+    taken = new Set();
+  }
+  const resolvedName = uniqueSessionName(slug, taken);
+  const path = join(baseRoot, resolvedName);
+  await mkdir(path, { recursive: true });
+  // NON-FATAL: a box without git still gets a usable directory.
+  try {
+    await run("git", ["-C", path, "init", "-b", "main"]);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.warn(`createScratchProject: git init failed (non-fatal): ${msg}`);
+  }
+  return { path, name: resolvedName };
 }
 
 // ============================================================

--- a/src/server/local.test.mjs
+++ b/src/server/local.test.mjs
@@ -2,9 +2,10 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
 import { mkdir, mkdtemp, rm, symlink, writeFile } from "node:fs/promises";
+import { existsSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
-import { fsListDirs, parseWorktrees, shouldSkipDir, dedupeRepoHits, sortRepoHits, parseGhAuthStatus, parseCloneProgress, gitPush, gitClone, scanRepos } from "./local.mjs";
+import { basename, join } from "node:path";
+import { fsListDirs, parseWorktrees, shouldSkipDir, dedupeRepoHits, sortRepoHits, parseGhAuthStatus, parseCloneProgress, gitPush, gitClone, scanRepos, createScratchProject } from "./local.mjs";
 
 test("parseWorktrees parses `git worktree list --porcelain`", () => {
   const out = parseWorktrees(
@@ -411,4 +412,65 @@ test("scanRepos: $HOME itself is never a workspace, while its children are scann
   const paths = repos.map((r) => r.path);
   assert.ok(!paths.includes("/home/u"), `home excluded: ${JSON.stringify(paths)}`);
   assert.ok(paths.includes("/home/u/projects/repo"), `home's children still scanned: ${JSON.stringify(paths)}`);
+});
+
+// ---- BET-1091: createScratchProject (scratch project dir) ------------------
+//
+// Pure/temp-dir logic only, consistent with the rest of the file. The git
+// init runs for real (git is present on the box) — we assert `.git` exists
+// but never shell out to a separate repo fixture.
+
+test("createScratchProject: fresh root creates the dir, returns an absolute path, and initialises git", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scratch-fresh-"));
+  try {
+    const out = await createScratchProject({ root, name: "foo" });
+    assert.ok(out.path.startsWith("/"), `path is absolute: ${out.path}`);
+    assert.equal(out.name, "foo");
+    assert.equal(basename(out.path), "foo");
+    assert.ok(existsSync(join(out.path, ".git")), `.git present in ${out.path}`);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("createScratchProject: colliding name resolves to name-2 and leaves the original untouched", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scratch-collide-"));
+  await mkdir(join(root, "foo"), { recursive: true });
+  try {
+    const out = await createScratchProject({ root, name: "foo" });
+    assert.equal(out.name, "foo-2");
+    assert.ok(existsSync(join(root, "foo")), "original foo untouched");
+    assert.ok(existsSync(out.path), "foo-2 created");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("createScratchProject: a non-existent root is created (recursive), no throw", async () => {
+  const base = await mkdtemp(join(tmpdir(), "scratch-missing-"));
+  const root = join(base, "does", "not", "exist");
+  try {
+    const out = await createScratchProject({ root, name: "foo" });
+    assert.ok(existsSync(out.path), "nested root created");
+    assert.ok(existsSync(join(out.path, ".git")), ".git exists in created root");
+  } finally {
+    await rm(base, { recursive: true, force: true });
+  }
+});
+
+test("createScratchProject: unslugged input 'My App' creates 'my-app'", async () => {
+  const root = await mkdtemp(join(tmpdir(), "scratch-slug-"));
+  try {
+    const out = await createScratchProject({ root, name: "My App" });
+    assert.equal(out.name, "my-app");
+    assert.equal(basename(out.path), "my-app");
+    assert.ok(existsSync(out.path));
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("createScratchProject: empty root and empty name each reject with the stated message", async () => {
+  await assert.rejects(createScratchProject({ root: "   ", name: "foo" }), /root is required/);
+  await assert.rejects(createScratchProject({ root: "/tmp", name: "   " }), /name is required/);
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -378,6 +378,13 @@ export function buildHandlers({
     // preload: ipcRenderer.invoke(IPC.fsListDirs, partial)  → args[0] = partial (string)
     "fs:list-dirs": (partial) => local.fsListDirs(partial),
 
+    // BET-1091: create an empty, git-initialised scratch project directory.
+    // Returns the real absolute path for stage 4 to feed into the existing
+    // session-creation call. Creates a directory and nothing else.
+    // preload: ipcRenderer.invoke(IPC.projectCreateScratch, { root, name })
+    //   → args[0] = { root: string, name: string }
+    "project:create-scratch": (i) => local.createScratchProject(i),
+
     // BET-786: probe the box for git repos + read origins + detect the gh CLI.
     // Server-side only; no renderer-supplied depth/caps (a renderer-supplied
     // depth would be a DoS on the user's own box).

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -204,6 +204,11 @@ export interface Api {
 
   fsListDirs(partial: string): Promise<DirListing>;
 
+  // BET-1091: create an empty, git-initialised scratch project directory
+  // under `root`, returning the real absolute path. The renderer (stage 4)
+  // feeds `path` into the existing session-creation call.
+  projectCreateScratch(input: { root: string; name: string }): Promise<{ path: string; name: string }>;
+
   // BET-786: probe the box for git repos + read origins + detect the gh CLI.
   // Server-side only; the box caches the result in memory for 60s.
   forgeProbe(): Promise<ForgeProbeResult>;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1037,6 +1037,11 @@ export const IPC = {
   // Directory autocomplete: given a partial path, list matching subdirectories
   fsListDirs: "fs:list-dirs",
 
+  // BET-1091: create an empty, git-initialised scratch project directory
+  // under `root`, returning the real absolute path for the session-creation
+  // flow.
+  projectCreateScratch: "project:create-scratch",
+
   // BET-786: probe the box for git repos + read their origins + detect the gh
   // CLI. Server-side only, cached in server memory for 60s.
   forgeProbe: "forge:probe",


### PR DESCRIPTION
## BET-1091 — Server: create a scratch project directory (`project:create-scratch`)

Stage 2 of 4 for "Start from scratch" (SERVER + CONTRACT WIRING ONLY. No UI.)

Adds ONE RPC that creates an empty project directory on the box, initialises
git in it, and returns the real absolute path. Stage 4 feeds that path into
the EXISTING session-creation call, so nothing downstream changes.

### What changed (7 files)

- **`src/server/local.mjs`** — new `createScratchProject({ root, name })`:
  guards empty root/name; expands `~` via the shared `expandTilde`
  (`src/shared/paths.mjs`); slugifies via shared `slugifyProjectName`;
  de-dups against existing dirs under `root` via shared `uniqueSessionName`
  (both from `src/shared/projectName.mjs` — no new helpers); recursive
  `mkdir`; NON-FATAL `git init -b main` via the shared `run()` argv helper;
  returns `{ path, name }` (absolute path). Errors for root/name/mkdir
  propagate fail-closed, mirroring `gitAddWorktree`.
- **`src/server/rpc.mjs`** — `"project:create-scratch": (i) => local.createScratchProject(i)` with `// preload:` comment, alongside the other `local.*` channels.
- **`src/shared/types.ts`** — IPC map `projectCreateScratch: "project:create-scratch"`.
- **`src/shared/api.ts`** — `Api.projectCreateScratch` signature.
- **`src/renderer/api/httpApi.ts`** — `projectCreateScratch: (input) => rpc(...)`.
- **`src/renderer/api/demoApi.ts`** — explicit demo stub returning a plausible path (keeps the demo-coverage test honest; NOT added to `DEMO_UNIMPLEMENTED`).
- **`src/server/local.test.mjs`** — 5 temp-dir tests (fresh root + `.git`; collision → `foo-2` leaves original untouched; non-existent root created; unslugged `My App` → `my-app`; empty root/name reject).

Does NOT create a tmux/opencode session or window, does NOT add an
"is this name free" RPC, does NOT touch `NewSessionScreen.tsx`.

### Verification

- typecheck: exit 0, errors: none
- test (`vitest run` + node:test server/shared/gateway/scripts): **2331 pass / 0 fail / 0 skip**
- New `createScratchProject` tests: 5/5 pass

Base: origin/main @ `adb64ba3`
