### PR TITLE
feat(server): box-side CLI catalog, detection and latest-version probes (BET-1095)

### DIFF
--- a/src/server/cliUpdates.mjs
+++ b/src/server/cliUpdates.mjs
@@ -1,0 +1,333 @@
+// cliUpdates.mjs — box-side CLI catalog, installed-count and latest-version
+// probes (BET-1095, stage 1 of the unified-update epic).
+//
+// Answers, for each CLI in the catalog (opencode / claude / codex / kimi):
+//   * is it installed, and at what version?
+//   * what is the latest published version?
+//   * what command upgrades it (or should the UI show a manual link)?
+//
+// The name/version/upgrade data lives in src/shared/cliCatalog.mjs — this file
+// only probes reality against that table. Everything here is dependency-
+// injected (access / spawn / fetchJson) so every function is unit-testable
+// with no real process spawn and no real network.
+
+import { join } from "node:path";
+import { constants } from "node:fs";
+import { access as fsAccess } from "node:fs/promises";
+import { spawn as nodeSpawn } from "node:child_process";
+import { CLI_CATALOG, resolveUpgradeCommand } from "../shared/cliCatalog.mjs";
+import { isUpdateAvailable } from "../shared/versionCompare.mjs";
+import { createJsonFetcher } from "./conditionalFetch.mjs";
+
+// Default deps — the real-server wiring. Tests inject stubs for all of these.
+const defaultAccess = (p, mode) => fsAccess(p, mode);
+const defaultSpawn = (cmd, args, opts) => nodeSpawn(cmd, args, opts);
+
+// ---------------------------------------------------------------------------
+// resolveBinary
+// ---------------------------------------------------------------------------
+
+// THE PATH TRAP — this ordering is the whole reason this function exists.
+// A process spawned by manta-server gets the SYSTEM path only. `~/.local/bin`
+// (claude) and `~/.opencode/bin` (opencode) are added by `~/.bashrc`, which a
+// non-login shell never reads — so every one of these CLIs is INVISIBLE unless
+// PATH is pinned. `scripts/self-update.sh` already pins PATH for exactly this
+// reason. Search these pinned dirs, in order, before `process.env.PATH`.
+//
+// Never shells out to `which`/`command -v` — check X_OK access on each
+// candidate directly.
+
+/**
+ * Resolve a CLI binary to an absolute path, or null if it is not executable
+ * anywhere we look.
+ *
+ * @param {string} bin
+ * @param {object} deps
+ * @param {(path:string, mode:number) => Promise<void>} deps.access - rejects
+ *   (or resolves) for non-accessible (accessible) paths, mirroring
+ *   fs.promises.access.
+ * @param {Record<string,string>} deps.env - the environment (for HOME an PATH).
+ * @returns {Promise<string|null>}
+ */
+export async function resolveBinary(bin, { access, env }) {
+  const home = env?.HOME ?? "";
+  const pinned = [
+    join(home, ".local", "bin"),
+    join(home, ".opencode", "bin"),
+    join(home, ".bun", "bin"),
+    "/opt/homebrew/bin",
+    "/usr/local/bin",
+  ];
+  const pathDirs = (env?.PATH ?? "").split(":").filter(Boolean);
+
+  for (const dir of [...pinned, ...pathDirs]) {
+    const candidate = join(dir, bin);
+    try {
+      await access(candidate, constants.X_OK);
+      return candidate;
+    } catch {
+      // not executable here — keep searching
+    }
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// readVersion
+// ---------------------------------------------------------------------------
+
+const VERSION_RE = /\d+\.\d+\.\d+(?:[-.\w]*)?/;
+
+/**
+ * Spawn `<absPath> --version` and read the first dotted version out of stdout.
+ *
+ * Every CLI in the catalog prints something like `2.1.233 (Claude Code)` or
+ * `codex-cli 0.147.0`; the regex covers both. Any throw, non-zero exit, or
+ * 10s timeout → returns null (never propagates).
+ *
+ * @param {string} absPath
+ * @param {object} deps
+ * @param {(cmd:string, args:string[], opts:any) => import("node:child_process").ChildProcess} deps.spawn
+ * @param {number} [deps.timeoutMs=10000]
+ * @returns {Promise<string|null>}
+ */
+export function readVersion(absPath, { spawn, timeoutMs = 10_000 }) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn(absPath, ["--version"], { timeout: timeoutMs });
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    let out = "";
+    child.stdout?.on("data", (d) => {
+      out += String(d);
+    });
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        /* already dead */
+      }
+      resolve(null);
+    }, timeoutMs);
+
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        resolve(null);
+        return;
+      }
+      const m = out.match(VERSION_RE);
+      resolve(m ? m[0] : null);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// fetchLatest
+// ---------------------------------------------------------------------------
+
+/**
+ * Fetch the latest published version for a catalog entry.
+ *
+ *   - `kind:"npm"`    → GET https://registry.npmjs.org/<pkg>/latest, read `.version`
+ *   - `kind:"github"` → GET https://api.github.com/repos/<repo>/releases/latest,
+ *                       read `.tag_name`, strip a leading `v`
+ *
+ * Any failure (network, non-2xx, unparseable, missing field) → null.
+ *
+ * @param {object} entry - a CLI_CATALOG entry
+ * @param {object} deps
+ * @param {(url:string) => Promise<any>} deps.fetchJson
+ * @returns {Promise<string|null>}
+ */
+export async function fetchLatest(entry, { fetchJson }) {
+  const meta = entry?.latest;
+  try {
+    if (meta?.kind === "npm") {
+      const data = await fetchJson(`https://registry.npmjs.org/${meta.pkg}/latest`);
+      return typeof data?.version === "string" ? data.version : null;
+    }
+    if (meta?.kind === "github") {
+      const data = await fetchJson(`https://api.github.com/repos/${meta.repo}/releases/latest`);
+      if (typeof data?.tag_name !== "string") return null;
+      return data.tag_name.replace(/^v/, "");
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// npmGlobalRoot
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve `npm root -g` (5s timeout; null on any failure). Used to decide
+ * whether a binary is npm-managed so `resolveUpgradeCommand` can prefer an
+ * `npm install -g` over a vendor installer that would shadow it.
+ */
+function defaultGetNpmGlobalRoot({ spawn }) {
+  return new Promise((resolve) => {
+    let child;
+    try {
+      child = spawn("npm", ["root", "-g"], { timeout: 5000 });
+    } catch {
+      resolve(null);
+      return;
+    }
+
+    let out = "";
+    child.stdout?.on("data", (d) => {
+      out += String(d);
+    });
+
+    const timer = setTimeout(() => {
+      try {
+        child.kill();
+      } catch {
+        /* already dead */
+      }
+      resolve(null);
+    }, 5000);
+
+    child.on("error", () => {
+      clearTimeout(timer);
+      resolve(null);
+    });
+
+    child.on("close", (code) => {
+      clearTimeout(timer);
+      if (code !== 0) {
+        resolve(null);
+        return;
+      }
+      const trimmed = out.trim();
+      resolve(trimmed || null);
+    });
+  });
+}
+
+// ---------------------------------------------------------------------------
+// detectClis
+// ---------------------------------------------------------------------------
+
+/**
+ * Probe the INSTALLED CLIs across the catalog.
+ *
+ * Returns one CliStatus per installed CLI (a CLI with no executable binary is
+ * omitted from the array entirely):
+ *   { id, label, current, latest, available, ok, manual, manualUrl, disruption, upgrade }
+ *
+ * - `available` = `current` and `latest` both known AND `latest > current`
+ *   (reuses versionCompare — never a hand-rolled comparator).
+ * - `ok` = false when `latest` could not be determined. An unknown is NEVER
+ *   reported as up to date.
+ * - `manual` = true when `resolveUpgradeCommand(...)` returned null.
+ * - `available` is always false whenever `manual` is true — "Update all" only
+ *   ever counts things it will actually do.
+ *
+ * @param {object} deps
+ * @param {(...) => Promise<void>} [deps.access]
+ * @param {object} [deps.env]
+ * @param {(...) => import("node:child_process").ChildProcess} [deps.spawn]
+ * @param {(url:string) => Promise<any>} [deps.fetchJson]
+ * @param {({spawn}) => Promise<string|null>} [deps.getNpmGlobalRoot]
+ * @returns {Promise<Array<object>>}
+ */
+export async function detectClis(deps = {}) {
+  const access = deps.access ?? defaultAccess;
+  const env = deps.env ?? process.env;
+  const spawn = deps.spawn ?? defaultSpawn;
+  const getNpmGlobalRoot = deps.getNpmGlobalRoot ?? defaultGetNpmGlobalRoot;
+
+  // The npm global root is threaded into resolveUpgradeCommand so npm-managed
+  // binaries upgrade via npm (vendor installer would shadow npm's copy).
+  const npmGlobalRoot = await getNpmGlobalRoot({ spawn });
+
+  const results = [];
+  for (const entry of CLI_CATALOG) {
+    const absPath = await resolveBinary(entry.bin, { access, env });
+    if (!absPath) continue; // not installed → omitted entirely
+
+    const current = await readVersion(absPath, { spawn });
+    const latest = await fetchLatest(entry, { fetchJson: deps.fetchJson });
+
+    const upgrade = resolveUpgradeCommand(entry, absPath, npmGlobalRoot);
+    const manual = upgrade === null;
+    // `available` requires a real upgrade path + both versions known + newest.
+    const available =
+      !manual &&
+      current != null &&
+      latest != null &&
+      isUpdateAvailable(current, latest);
+    // Unknown latest is NEVER reported as up to date.
+    const ok = latest != null;
+
+    results.push({
+      id: entry.id,
+      label: entry.label,
+      current,
+      latest,
+      available,
+      ok,
+      manual,
+      manualUrl: entry.manualUrl,
+      disruption: entry.disruption,
+      upgrade,
+    });
+  }
+  return results;
+}
+
+// ---------------------------------------------------------------------------
+// createCliDetector — cached, in-flight-joining detect()
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a `{ detect() }` handle with a 5-minute result cache and an in-flight
+ * join. Same shape as `createUpdateCheck` in serverUpdate.mjs: a concurrent
+ * caller JOINS the in-flight promise rather than getting a stale early return.
+ * Probing costs up to 4 process spawns plus 4 HTTPS requests, which is why the
+ * result is cached and why two callers within a probe must not double it.
+ *
+ * @param {object} [deps] passed through to `detectClis` per detect
+ * @returns {{ detect: () => Promise<Array<object>> }}
+ */
+export function createCliDetector(deps = {}) {
+  const TTL_MS = 5 * 60 * 1000;
+  let inFlight = null;
+  let lastResult = null;
+  let lastAt = 0;
+
+  function detect() {
+    // Join the in-flight probe rather than starting a second one.
+    if (inFlight) return inFlight;
+    // Serve a fresh-enough cached result.
+    if (lastResult && Date.now() - lastAt < TTL_MS) {
+      return Promise.resolve(lastResult);
+    }
+    inFlight = detectClis(deps)
+      .then((res) => {
+        lastResult = res;
+        lastAt = Date.now();
+        return res;
+      })
+      .finally(() => {
+        inFlight = null;
+      });
+    return inFlight;
+  }
+
+  return { detect };
+}

--- a/src/server/cliUpdates.test.mjs
+++ b/src/server/cliUpdates.test.mjs
@@ -1,0 +1,291 @@
+// Tests for the box-side CLI probe (BET-1095 stage 1).
+//
+// All injected I/O — no real process spawn, no real network, no real fs. The
+// npm/brew/vendor decision logic itself is covered in
+// src/shared/cliCatalog.test.ts; here we pin the probe glue that feeds it
+// (resolveBinary's PATH pinning, readVersion's parsing, fetchLatest's URL
+// shapes, detectClis' aggregation + the detector cache).
+//
+// Run via `npm run test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import {
+  resolveBinary,
+  readVersion,
+  fetchLatest,
+  detectClis,
+  createCliDetector,
+} from "./cliUpdates.mjs";
+
+// ---------------------------------------------------------------------------
+// resolveBinary — THE PATH TRAP regression
+// ---------------------------------------------------------------------------
+
+// A fake access() that grants X_OK on exactly the given paths.
+function makeAccess(executable) {
+  const set = new Set(executable);
+  return async (p) => {
+    if (!set.has(p)) throw new Error("ENOENT");
+  };
+}
+
+test("resolveBinary: finds a binary in a pinned dir ABSENT from process.env.PATH", async () => {
+  // THE regression this exists for: ~/.local/bin (claude) and ~/.opencode/bin
+  // (opencode) are added by ~/.bashrc, which a non-login manta-server shell
+  // never reads — so they never appear in PATH and the CLI would be invisible
+  // without the pinned search.
+  const env = {
+    HOME: "/home/user",
+    PATH: "/usr/bin:/bin", // deliberately does NOT include ~/.local/bin
+  };
+  const access = makeAccess(["/home/user/.local/bin/claude"]);
+
+  const found = await resolveBinary("claude", { access, env });
+  assert.equal(found, "/home/user/.local/bin/claude");
+});
+
+test("resolveBinary: returns null when nothing is executable", async () => {
+  const env = { HOME: "/home/user", PATH: "/usr/bin:/bin" };
+  const access = makeAccess([]);
+  assert.equal(await resolveBinary("doesnotexist", { access, env }), null);
+});
+
+test("resolveBinary: falls back to a PATH-visible binary not in a pinned dir", async () => {
+  const env = { HOME: "/home/user", PATH: "/usr/bin:/home/user/.opencode/bin" };
+  const access = makeAccess(["/home/user/.opencode/bin/opencode"]);
+  assert.equal(await resolveBinary("opencode", { access, env }), "/home/user/.opencode/bin/opencode");
+});
+
+// ---------------------------------------------------------------------------
+// readVersion
+// ---------------------------------------------------------------------------
+
+function fakeSpawnResult({ stdout = "", code = 0, error = false, never = false }) {
+  return () => {
+    const child = new EventEmitter();
+    child.stdout = new EventEmitter();
+    child.kill = () => {};
+    if (never) return child; // never emits → exercises the timeout path
+    process.nextTick(() => {
+      if (error) {
+        child.emit("error", new Error("spawn failed"));
+        return;
+      }
+      child.stdout.emit("data", stdout);
+      child.emit("close", code);
+    });
+    return child;
+  };
+}
+
+test("readVersion: parses '2.1.233 (Claude Code)'", async () => {
+  const v = await readVersion("/x/claude", {
+    spawn: fakeSpawnResult({ stdout: "2.1.233 (Claude Code)" }),
+  });
+  assert.equal(v, "2.1.233");
+});
+
+test("readVersion: parses 'codex-cli 0.147.0'", async () => {
+  const v = await readVersion("/x/codex", {
+    spawn: fakeSpawnResult({ stdout: "codex-cli 0.147.0" }),
+  });
+  assert.equal(v, "0.147.0");
+});
+
+test("readVersion: returns null on a non-zero exit", async () => {
+  const v = await readVersion("/x/claude", {
+    spawn: fakeSpawnResult({ stdout: "2.1.233", code: 1 }),
+  });
+  assert.equal(v, null);
+});
+
+test("readVersion: returns null on a spawn error", async () => {
+  const v = await readVersion("/x/claude", {
+    spawn: fakeSpawnResult({ error: true }),
+  });
+  assert.equal(v, null);
+});
+
+test("readVersion: returns null on unparseable output", async () => {
+  const v = await readVersion("/x/claude", {
+    spawn: fakeSpawnResult({ stdout: "no version here at all" }),
+  });
+  assert.equal(v, null);
+});
+
+test("readVersion: returns null on timeout (never resolves)", async () => {
+  const v = await readVersion("/x/claude", {
+    spawn: fakeSpawnResult({ never: true }),
+    timeoutMs: 20, // inject a tiny timeout instead of the 10s production default
+  });
+  assert.equal(v, null);
+});
+
+// ---------------------------------------------------------------------------
+// fetchLatest
+// ---------------------------------------------------------------------------
+
+test("fetchLatest: npm kind reads .version from the registry latest endpoint", async () => {
+  let url = null;
+  const v = await fetchLatest(
+    { latest: { kind: "npm", pkg: "@anthropic-ai/claude-code" } },
+    {
+      fetchJson: async (u) => {
+        url = u;
+        return { version: "2.1.233" };
+      },
+    },
+  );
+  assert.equal(v, "2.1.233");
+  assert.equal(url, "https://registry.npmjs.org/@anthropic-ai/claude-code/latest");
+});
+
+test("fetchLatest: github kind reads tag_name and strips a leading v", async () => {
+  let url = null;
+  const v = await fetchLatest(
+    { latest: { kind: "github", repo: "anomalyco/opencode" } },
+    {
+      fetchJson: async (u) => {
+        url = u;
+        return { tag_name: "v0.145.0" };
+      },
+    },
+  );
+  assert.equal(v, "0.145.0");
+  assert.equal(url, "https://api.github.com/repos/anomalyco/opencode/releases/latest");
+});
+
+test("fetchLatest: any failure → null (never propagates)", async () => {
+  for (const fetchJson of [
+    async () => {
+      throw new Error("network unreachable");
+    },
+    async () => ({ no_version_field: true }),
+    async () => null,
+  ]) {
+    assert.equal(
+      await fetchLatest({ latest: { kind: "npm", pkg: "@x/y" } }, { fetchJson }),
+      null,
+    );
+  }
+});
+
+// ---------------------------------------------------------------------------
+// detectClis
+// ---------------------------------------------------------------------------
+
+function detectDeps({ installed, versions = {}, latests = {}, root = null, spawn }) {
+  const access = makeAccess(installed);
+  const getNpmGlobalRoot = async () => root;
+  // readVersion uses deps.spawn; default to a "1.0.0" printer per bin.
+  const realSpawn =
+    spawn ??
+    ((bin) =>
+      fakeSpawnResult({
+        stdout: versions[bin] ?? "1.0.0",
+      })());
+  const fetchJson = async (url) => {
+    // yield a newer latest by default unless overridden
+    return latests[url] ?? { version: "9.9.9", tag_name: "v9.9.9" };
+  };
+  const env = { HOME: "/home/user", PATH: "/usr/bin:/bin" };
+  return { access, env, spawn: realSpawn, fetchJson, getNpmGlobalRoot };
+}
+
+test("detectClis: omits a non-installed CLI entirely", async () => {
+  // Only claude resolves to a binary; the other three are absent from the
+  // result array.
+  const deps = detectDeps({ installed: ["/home/user/.local/bin/claude"] });
+  const result = await detectClis(deps);
+  assert.deepEqual(
+    result.map((c) => c.id),
+    ["claude"],
+  );
+});
+
+test("detectClis: ok:false when latest is unknown (never reports up to date)", async () => {
+  const deps = detectDeps({
+    installed: ["/home/user/.local/bin/claude"],
+    latests: {},
+  });
+  const deps2 = { ...deps, fetchJson: async () => null };
+  const [claude] = await detectClis(deps2);
+  assert.equal(claude.ok, false);
+  assert.equal(claude.available, false, "unknown latest must not be 'up to date'");
+});
+
+test("detectClis: available is never true when manual is true (brew-managed)", async () => {
+  // claude resolved inside /opt/homebrew → resolveUpgradeCommand refuses →
+  // manual:true → available must be false even though latest > current.
+  const deps = detectDeps({
+    installed: ["/opt/homebrew/bin/claude"],
+    versions: { "/opt/homebrew/bin/claude": "1.0.0" },
+  });
+  const [claude] = await detectClis(deps);
+  assert.equal(claude.manual, true);
+  assert.equal(claude.available, false, "a manual-only upgrade must never be counted as available");
+  assert.equal(claude.upgrade, null);
+});
+
+test("detectClis: npm-managed binary upgrades via npm (available + non-manual)", async () => {
+  // claude resolves to a binary inside the npm global root; the threaded
+  // npmGlobalRoot makes resolveUpgradeCommand prefer `npm install -g` over the
+  // vendor [`claude`,`update`] (vendor installer would shadow npm's copy).
+  const root = "/usr/local/bin";
+  const claudePath = `${root}/claude`;
+  const deps = detectDeps({
+    installed: [claudePath],
+    versions: { [claudePath]: "1.0.0" },
+    root,
+  });
+  const [claude] = await detectClis(deps);
+  assert.deepEqual(claude.upgrade, ["npm", "install", "-g", "@anthropic-ai/claude-code@latest"]);
+  assert.equal(claude.manual, false);
+  assert.equal(claude.available, true, "1.0.0 → 9.9.9 with an npm path must be available");
+  assert.equal(claude.ok, true);
+});
+
+test("detectClis: a plain vendor-managed binary reports available", async () => {
+  const path = "/usr/local/bin/claude";
+  const deps = detectDeps({
+    installed: [path],
+    versions: { [path]: "1.0.0" },
+  });
+  const [claude] = await detectClis(deps);
+  assert.equal(claude.manual, false);
+  assert.deepEqual(claude.upgrade, ["claude", "update"]);
+  assert.equal(claude.available, true);
+});
+
+// ---------------------------------------------------------------------------
+// createCliDetector — cache + in-flight join
+// ---------------------------------------------------------------------------
+
+test("detector: two concurrent detect() calls perform ONE probe round", async () => {
+  let rootProbes = 0;
+  const byPath = {
+    "/usr/local/bin/claude": "1.0.0",
+    "/home/user/.opencode/bin/opencode": "1.1.1",
+  };
+  const deps = detectDeps({
+    installed: Object.keys(byPath),
+    versions: byPath,
+    root: null,
+    spawn: (bin) => fakeSpawnResult({ stdout: byPath[bin] })(),
+  });
+  deps.getNpmGlobalRoot = async () => {
+    rootProbes += 1;
+    return null;
+  };
+
+  const detector = createCliDetector(deps);
+  const [a, b] = await Promise.all([detector.detect(), detector.detect()]);
+  assert.deepEqual(a, b, "both callers see the SAME result (join, not stale)");
+  assert.equal(rootProbes, 1, "two concurrent callers must not double the probe work");
+
+  // A subsequent call within the 5-min TTL serves the cache without probing.
+  await detector.detect();
+  assert.equal(rootProbes, 1, "cached result must not re-probe");
+});

--- a/src/server/conditionalFetch.mjs
+++ b/src/server/conditionalFetch.mjs
@@ -1,0 +1,70 @@
+// conditionalFetch.mjs — shared conditional-GET JSON fetcher.
+//
+// Extracted from src/server/serverUpdate.mjs (the old `createManifestFetcher`),
+// so that both the server-manifest poller AND the CLI update probes
+// (src/server/cliUpdates.mjs) reuse the SAME ETag-caching fetch instead of
+// growing a second copy. The three invariants below were each a real bug once;
+// they are carried over verbatim and pinned by the existing serverUpdate tests
+// (which must keep passing against the thin `createManifestFetcher` wrapper).
+
+/**
+ * Build a conditional-GET fetcher that caches the last successful body and
+ * revalidates it with `If-None-Match` on every later call.
+ *
+ * The body it fetches changes rarely but is polled forever, so re-downloading
+ * it on every tick is pure waste. When the origin answers `304 Not Modified`
+ * it carries no body to parse, so the cached body is returned as-is — keeping
+ * the caller's contract unchanged (the returned function always resolves to a
+ * parsed JSON value) without the caller knowing anything about caching.
+ *
+ * Invariants (each one is deliberate):
+ *   1. `fetchImpl` is resolved PER CALL, not captured at construction. A
+ *      caller (or a test) that replaces `globalThis.fetch` after import must
+ *      still take effect.
+ *   2. The ETag is cached ONLY after the body successfully parses. Caching a
+ *      validator for a body we failed to read would make every later call a
+ *      304 that returns a stale/absent body — a permanently stuck fetch that
+ *      looks healthy.
+ *   3. A 304 with no cached body throws. Possible only if a proxy fabricates
+ *      a 304; throwing is the safe direction (callers treat a throw as
+ *      "couldn't tell", never as a false positive).
+ *
+ * Each returned fetcher owns its OWN cache, so tests get a clean one per call
+ * and the poller's fetcher is never shared with an unrelated caller.
+ *
+ * @param {object} [opts]
+ * @param {(url:string, init?:any) => Promise<Response>} [opts.fetchImpl]
+ * @param {string} [opts.label] used in error messages ("manifest fetch",
+ *   "fetch", …). Defaults to "fetch".
+ * @returns {(url:string, init?:any) => Promise<any>} resolves to parsed JSON
+ */
+export function createJsonFetcher({ fetchImpl, label = "fetch" } = {}) {
+  let etag = null;
+  let cached = null;
+
+  return async function fetchJson(url, init) {
+    // Invariant 1 — resolve the fetch impl fresh on every call.
+    const doFetch = fetchImpl ?? globalThis.fetch;
+
+    const headers = etag
+      ? { "if-none-match": etag, ...(init?.headers ?? {}) }
+      : init?.headers;
+    const res = await doFetch(url, headers ? { ...init, headers } : init);
+
+    // Invariant 3 — a 304 with nothing cached must not masquerade as a body.
+    if (res.status === 304) {
+      if (cached === null) {
+        throw new Error(`${label} returned 304 with no cached body`);
+      }
+      return cached;
+    }
+    if (!res.ok) throw new Error(`${label} failed: ${res.status}`);
+
+    const body = await res.json();
+    // Invariant 2 — only remember the validator once the body parsed.
+    const nextEtag = res.headers?.get?.("etag") ?? null;
+    etag = typeof nextEtag === "string" && nextEtag !== "" ? nextEtag : null;
+    cached = body;
+    return body;
+  };
+}

--- a/src/server/serverUpdate.mjs
+++ b/src/server/serverUpdate.mjs
@@ -19,6 +19,7 @@
 import { isUpdateAvailable } from "../shared/versionCompare.mjs";
 import { resolveBoxChannel } from "../shared/channel.mjs";
 import { startPoller } from "./startPoller.mjs";
+import { createJsonFetcher } from "./conditionalFetch.mjs";
 
 // 30 min. This was 6h, chosen when every poll cost a full manifest download.
 // It no longer does: `defaultFetchManifest` sends `If-None-Match`, and the
@@ -62,6 +63,11 @@ export const MANIFEST_URL = "https://mantaui.com/updates/server.json";
 /**
  * Build a conditional-GET manifest fetcher.
  *
+ * Thin wrapper over the shared `createJsonFetcher` (src/server/conditionalFetch.mjs):
+ * the ETag-caching conditional-GET body lives there so the CLI update probes
+ * (cliUpdates.mjs) reuse the SAME logic. This wrapper only pins the default
+ * URL and the "manifest" error label.
+ *
  * The manifest is a ~95-byte JSON file that changes a handful of times a month,
  * polled forever by every box. Re-downloading it on every tick is pure waste,
  * and that waste is what forced the poll interval to be slow (6h) in the first
@@ -80,38 +86,11 @@ export const MANIFEST_URL = "https://mantaui.com/updates/server.json";
  *
  * Each returned fetcher owns its own cache, so tests get a clean one per call
  * and the poller's fetcher is never shared with an unrelated caller.
- *
- * `fetchImpl` is resolved PER CALL, not captured at construction: the previous
- * `defaultFetchManifest` was a plain function that called the global `fetch`
- * when invoked, so a caller (or a test) replacing `globalThis.fetch` after
- * import still took effect. Binding it once at module load would have silently
- * removed that.
  */
 export function createManifestFetcher({ fetchImpl } = {}) {
-  let etag = null;
-  let cached = null;
-
-  return async function fetchManifest(url = MANIFEST_URL) {
-    const doFetch = fetchImpl ?? globalThis.fetch;
-    const headers = etag ? { "if-none-match": etag } : undefined;
-    const res = await doFetch(url, headers ? { headers } : undefined);
-
-    if (res.status === 304) {
-      if (cached === null) {
-        throw new Error("manifest fetch returned 304 with no cached manifest");
-      }
-      return cached;
-    }
-    if (!res.ok) throw new Error(`manifest fetch failed: ${res.status}`);
-
-    const manifest = await res.json();
-    // Only remember the validator once the body parsed — caching an ETag for a
-    // body we failed to read would make every later poll a 304 that returns a
-    // stale/absent manifest.
-    const nextEtag = res.headers?.get?.("etag") ?? null;
-    etag = typeof nextEtag === "string" && nextEtag !== "" ? nextEtag : null;
-    cached = manifest;
-    return manifest;
+  const fetchJson = createJsonFetcher({ fetchImpl, label: "manifest fetch" });
+  return async function fetchManifest(url = MANIFEST_URL, init) {
+    return fetchJson(url, init);
   };
 }
 

--- a/src/shared/cliCatalog.d.mts
+++ b/src/shared/cliCatalog.d.mts
@@ -1,0 +1,35 @@
+// Hand-written type declarations for cliCatalog.mjs. Implementation is plain
+// JS so both the renderer tsconfig and the server-side .mjs import it natively.
+// Keep in sync with src/shared/cliCatalog.mjs.
+
+export interface CliCatalogEntry {
+  id: string;
+  label: string;
+  bin: string;
+  latest: { kind: "npm"; pkg: string } | { kind: "github"; repo: string };
+  npmPackage: string | null;
+  upgrade: string[];
+  manualUrl: string;
+  disruption: string;
+}
+
+export const CLI_CATALOG: CliCatalogEntry[];
+
+/**
+ * Which command upgrades this CLI, given where its binary actually is.
+ * Returns null = "we cannot upgrade this safely" → the UI shows a manual link.
+ * Precedence: npm-managed → `npm install -g <pkg>@latest`; Homebrew-managed →
+ * null; entry.upgrade verbatim; else null.
+ *
+ * `entry` is loosely typed because the function reads only `npmPackage` and
+ * `upgrade`.
+ */
+export function resolveUpgradeCommand(
+  entry:
+    | Partial<CliCatalogEntry>
+    | { npmPackage?: string | null; upgrade?: string[] | null }
+    | null
+    | undefined,
+  resolvedPath: string | null | undefined,
+  npmGlobalRoot: string | null | undefined,
+): string[] | null;

--- a/src/shared/cliCatalog.mjs
+++ b/src/shared/cliCatalog.mjs
@@ -1,0 +1,117 @@
+// cliCatalog.mjs — THE single source of truth for which AI CLIs exist on a
+// box, how to find out their version, and what command upgrades them.
+//
+// Both consumers — the box server (src/server/cliUpdates.mjs, this epic) and
+// `scripts/self-update.sh` (stage 2) — read THIS table and nothing else. Do
+// not duplicate any of it anywhere.
+//
+// Security note on the upgrade commands: the two `["sh","-c", …]` pipelines
+// are CONSTANTS from this table. They are verified against each vendor's
+// current docs and are NEVER built from any input. `resolveUpgradeCommand`
+// may return an entry's `upgrade` verbatim, but nothing ever interpolates
+// into these pipelines.
+//
+// The ONLY place install-method branching lives is `resolveUpgradeCommand`
+// below — every other module reads this file's data and this function's
+// verdict.
+
+export const CLI_CATALOG = [
+  {
+    id: "opencode",
+    label: "opencode",
+    bin: "opencode",
+    latest: { kind: "github", repo: "anomalyco/opencode" },
+    npmPackage: null,
+    upgrade: ["opencode", "upgrade"],
+    manualUrl: "https://opencode.ai/docs",
+    disruption: "ends-turns",
+  },
+
+  {
+    id: "claude",
+    label: "Claude Code",
+    bin: "claude",
+    latest: { kind: "npm", pkg: "@anthropic-ai/claude-code" },
+    npmPackage: "@anthropic-ai/claude-code",
+    upgrade: ["claude", "update"],
+    manualUrl: "https://docs.claude.com/en/docs/claude-code/setup",
+    disruption: "none",
+  },
+
+  {
+    id: "codex",
+    label: "Codex",
+    bin: "codex",
+    latest: { kind: "npm", pkg: "@openai/codex" },
+    npmPackage: "@openai/codex",
+    upgrade: ["sh", "-c", "curl -fsSL https://chatgpt.com/codex/install.sh | sh"],
+    manualUrl: "https://developers.openai.com/codex",
+    disruption: "none",
+  },
+
+  {
+    id: "kimi",
+    label: "Kimi Code",
+    bin: "kimi",
+    latest: { kind: "npm", pkg: "@moonshot-ai/kimi-code" },
+    npmPackage: "@moonshot-ai/kimi-code",
+    upgrade: ["sh", "-c", "curl -fsSL https://code.kimi.com/kimi-code/install.sh | bash"],
+    manualUrl: "https://moonshotai.github.io/kimi-code/en/guides/getting-started",
+    disruption: "none",
+  },
+];
+
+// Homebrew-managed install prefixes. Re-running a vendor installer over a
+// brew-managed binary installs a shadowing second copy — the upgrade must
+// refuse rather than do that.
+const HOMEBREW_PREFIXES = ["/opt/homebrew/", "/usr/local/Cellar/", "/home/linuxbrew/"];
+
+function isInside(base, p) {
+  if (typeof base !== "string" || base === "" || typeof p !== "string") return false;
+  if (p === base) return true;
+  return p.startsWith(base.endsWith("/") ? base : base + "/");
+}
+
+/** Is `p` inside any known Homebrew install prefix? */
+function isHomebrewManaged(p) {
+  if (typeof p !== "string") return false;
+  return HOMEBREW_PREFIXES.some((prefix) => p.startsWith(prefix));
+}
+
+/**
+ * Which command upgrades this CLI, given where its binary actually is.
+ *
+ * Returns null = "we cannot upgrade this safely" → the UI shows a manual link.
+ *
+ * Precedence, in this exact order — four branches, no more:
+ *   1. npm-managed (resolvedPath inside npmGlobalRoot, entry exposes an npm
+ *      package) → `npm install -g <pkg>@latest`. npm root WINS over the
+ *      vendor installer because the vendor installer would shadow npm's copy.
+ *   2. Homebrew-managed → null. Vendor installer over a brew-managed binary
+ *      creates a shadowing second copy.
+ *   3. entry.upgrade → returned verbatim.
+ *   4. → null.
+ *
+ * @param {{ npmPackage: string|null, upgrade?: string[] }} entry
+ * @param {string} [resolvedPath] absolute path the binary resolved to
+ * @param {string} [npmGlobalRoot] `npm root -g` output, when known
+ * @returns {string[]|null}
+ */
+export function resolveUpgradeCommand(entry, resolvedPath, npmGlobalRoot) {
+  if (!entry || typeof resolvedPath !== "string") return null;
+
+  if (
+    typeof npmGlobalRoot === "string" &&
+    npmGlobalRoot !== "" &&
+    entry.npmPackage &&
+    isInside(npmGlobalRoot, resolvedPath)
+  ) {
+    return ["npm", "install", "-g", `${entry.npmPackage}@latest`];
+  }
+
+  if (isHomebrewManaged(resolvedPath)) return null;
+
+  if (Array.isArray(entry.upgrade) && entry.upgrade.length > 0) return entry.upgrade;
+
+  return null;
+}

--- a/src/shared/cliCatalog.test.ts
+++ b/src/shared/cliCatalog.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect } from "vitest";
+import { CLI_CATALOG, resolveUpgradeCommand } from "./cliCatalog.mjs";
+
+describe("CLI_CATALOG", () => {
+  it("has the four expected CLIs with their manual URLs", () => {
+    expect(CLI_CATALOG.map((c) => c.id)).toEqual([
+      "opencode",
+      "claude",
+      "codex",
+      "kimi",
+    ]);
+    for (const entry of CLI_CATALOG) {
+      expect(entry.label).toBeTruthy();
+      expect(entry.bin).toBeTruthy();
+      expect(entry.upgrade).toBeInstanceOf(Array);
+      expect(entry.manualUrl).toBeTruthy();
+      expect(entry.disruption).toBeTruthy();
+    }
+  });
+
+  it("marks opencode as the only non-npm, github-tracked CLI", () => {
+    const opencode = CLI_CATALOG.find((c) => c.id === "opencode");
+    expect(opencode.latest).toEqual({ kind: "github", repo: "anomalyco/opencode" });
+    expect(opencode.npmPackage).toBeNull();
+    expect(opencode.upgrade).toEqual(["opencode", "upgrade"]);
+  });
+
+  it("opencode is the only ends-turns-disruptive install", () => {
+    expect(CLI_CATALOG.filter((c) => c.disruption === "ends-turns").map((c) => c.id)).toEqual([
+      "opencode",
+    ]);
+  });
+});
+
+describe("resolveUpgradeCommand", () => {
+  const npmCli = {
+    id: "claude",
+    npmPackage: "@anthropic-ai/claude-code",
+    upgrade: ["claude", "update"],
+  };
+
+  it("never interpolates into the pinned sh -c pipelines (returns them verbatim)", () => {
+    for (const entry of CLI_CATALOG) {
+      if (entry.upgrade[0] !== "sh") continue;
+      // Re-resolving an arbitrary path outside npm/homebrew must hand back the
+      // exact constant, byte-for-byte.
+      const cmd = resolveUpgradeCommand(entry, "/usr/bin/" + entry.bin, null);
+      expect(cmd).toEqual(entry.upgrade);
+      expect(cmd.join(" ")).not.toContain("undefined");
+      expect(cmd.join(" ")).not.toContain("[object");
+    }
+  });
+
+  it("returns the vendor upgrade command when nothing special manages the binary", () => {
+    expect(resolveUpgradeCommand(npmCli, "/usr/local/bin/claude", null)).toEqual([
+      "claude",
+      "update",
+    ]);
+  });
+
+  it("branch 1 — npm root wins over the vendor installer", () => {
+    // Even though claude has a vendor `["claude","update"]`, an npm-managed
+    // binary must upgrade via npm so the vendor installer never shadows it.
+    expect(
+      resolveUpgradeCommand(npmCli, "/usr/local/lib/node_modules/@anthropic-ai/claude-code/cli.js", "/usr/local/lib/node_modules"),
+    ).toEqual(["npm", "install", "-g", "@anthropic-ai/claude-code@latest"]);
+  });
+
+  it("branch 1 — npm root with a trailing slash still matches", () => {
+    expect(
+      resolveUpgradeCommand(npmCli, "/usr/local/lib/node_modules/@anthropic-ai/claude-code/x", "/usr/local/lib/node_modules/"),
+    ).toEqual(["npm", "install", "-g", "@anthropic-ai/claude-code@latest"]);
+  });
+
+  it("branch 1 — requires an npmPackage; opencode never falls into npm", () => {
+    const opencode = CLI_CATALOG.find((c) => c.id === "opencode");
+    expect(
+      resolveUpgradeCommand(opencode, "/usr/local/lib/node_modules/opencode", "/usr/local/lib/node_modules"),
+    ).toEqual(["opencode", "upgrade"]);
+  });
+
+  it("branch 2 — refuses a brew-managed binary even when an upgrade exists", () => {
+    for (const prefix of ["/opt/homebrew/bin/claude", "/usr/local/Cellar/claude/2.0.0/bin/claude", "/home/linuxbrew/linuxbrew/bin/claude"]) {
+      expect(resolveUpgradeCommand(npmCli, prefix, null)).toBeNull();
+      expect(resolveUpgradeCommand(npmCli, prefix, "/usr/local/lib/node_modules")).toBeNull();
+    }
+  });
+
+  it("branch 2 — a sibling under /usr/local/bin (non-Cellar) is NOT brew and upgrades normally", () => {
+    expect(resolveUpgradeCommand(npmCli, "/usr/local/bin/claude", null)).toEqual(["claude", "update"]);
+  });
+
+  it("branch 4 — null upgrade returns null (manual)", () => {
+    expect(resolveUpgradeCommand({ id: "x", npmPackage: null, upgrade: null }, "/usr/bin/x", null)).toBeNull();
+    expect(resolveUpgradeCommand(npmCli, null, null)).toBeNull();
+    expect(resolveUpgradeCommand(null, "/usr/bin/x", null)).toBeNull();
+  });
+});

--- a/src/shared/cliCatalog.test.ts
+++ b/src/shared/cliCatalog.test.ts
@@ -19,7 +19,7 @@ describe("CLI_CATALOG", () => {
   });
 
   it("marks opencode as the only non-npm, github-tracked CLI", () => {
-    const opencode = CLI_CATALOG.find((c) => c.id === "opencode");
+    const opencode = CLI_CATALOG.find((c) => c.id === "opencode")!;
     expect(opencode.latest).toEqual({ kind: "github", repo: "anomalyco/opencode" });
     expect(opencode.npmPackage).toBeNull();
     expect(opencode.upgrade).toEqual(["opencode", "upgrade"]);
@@ -44,7 +44,7 @@ describe("resolveUpgradeCommand", () => {
       if (entry.upgrade[0] !== "sh") continue;
       // Re-resolving an arbitrary path outside npm/homebrew must hand back the
       // exact constant, byte-for-byte.
-      const cmd = resolveUpgradeCommand(entry, "/usr/bin/" + entry.bin, null);
+      const cmd = resolveUpgradeCommand(entry, "/usr/bin/" + entry.bin, null) as string[];
       expect(cmd).toEqual(entry.upgrade);
       expect(cmd.join(" ")).not.toContain("undefined");
       expect(cmd.join(" ")).not.toContain("[object");


### PR DESCRIPTION
Box-side CLI catalog, detection and latest-version probes (BET-1095, stage 1 of the unified-update epic). Box side only — no UI, no RPC, no upgrade execution.

**Files changed:** `7` files, +953/−30.
- `src/shared/cliCatalog.mjs` (+117) — new. `CLI_CATALOG` (opencode/claude/codex/kimi) + the single `resolveUpgradeCommand` branching function (4 branches, exact precedence).
- `src/shared/cliCatalog.test.ts` (+98) — new. Catalog shape + all four `resolveUpgradeCommand` branches (npm-root-wins, brew refusal, piped sh -c returned verbatim).
- `src/shared/cliCatalog.d.mts` (+35) — new. Hand-written TS decls for the JS module.
- `src/server/conditionalFetch.mjs` (+70) — new. `createJsonFetcher` extracted from `serverUpdate.mjs`; all three invariant comments carried over.
- `src/server/serverUpdate.mjs` (−30) — `createManifestFetcher` is now a thin wrapper over `createJsonFetcher` (single copy of the ETag-caching logic).
- `src/server/cliUpdates.mjs` (+333) — new. `resolveBinary` (PATH-pinned search), `readVersion`, `fetchLatest`, `detectClis`, `createCliDetector` (5-min cache + in-flight join).
- `src/server/cliUpdates.test.mjs` (+291) — new. Injected-only tests for all of the above.

All new tests pass; existing `serverUpdate.mjs` tests pass unchanged (the refactor did not change behaviour).

**Base: origin/main @ `40fef817`**

**Verification results:**
- PR branch (`multica/BET-1095-cli-catalog-detection` @ `ca968211`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, `2349` pass / `0` fail / `0` skip (node:test) + `3056` pass / `7` skipped (vitest, 160 files). Failures: none. log sha256: `c61a5bfe95429a62fbee1ca2eb3f0091938d4d8032a23e775085ac4d7b004f29`
- Base (`main` @ `40fef817`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, `2331` pass / `0` fail / `0` skip (node:test). Failures: none. log sha256: `77d60c52347dce1e00cbdf52d135aed463d1ddcec0b84d7617dd80e403f92a75`
- **Conclusion:** `0` failures on either branch. The PR adds `29` new tests (18 node:test `cliUpdates` + 11 vitest `cliCatalog`), all green; no new failures introduced and none pre-existing.

Logs cached at `/tmp/tc-1095.log`, `/tmp/tc-main.log`, `/tmp/test-1095.log`, `/tmp/test-main.log` for reviewer spot-check.

**Out of scope (per the issue):** no RPC channel (stage 2), no UI, no upgrade execution (stage 2's `self-update.sh` sibling), no installing an absent CLI. `scripts/self-update.sh` (stage 2) will consume `src/shared/cliCatalog.mjs` as the single source of truth.
