### PR TITLE
self-update.sh: upgrade every detected CLI, restart only what changed (BET-1097)

### DIFF
--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -293,27 +293,31 @@ release_is_current() {
   [ "$installed_version" = "$release_version" ]
 }
 
-# should_skip_self_update <installed_version> <installed_git_sha> <release_version> <release_git_sha> <opencode_changed>
+# should_skip_self_update <installed_version> <installed_git_sha> <release_version> <release_git_sha> <clis_changed>
 #
-# The updater's EARLY-EXIT decision (BET-1016): skip the ENTIRE self-update (no
-# download, no reinstall, no restart) only when BOTH the box release is current
-# AND opencode is unchanged. When opencode changed, the box must fall through
-# to its restart step even if the tarball is current — otherwise an opencode-only
-# upgrade would be swallowed by the cheap early exit and leave the upgraded (but
-# un-restarted) binary inert until the next update.
+# The updater's EARLY-EXIT decision (BET-1016, generalised in BET-1097): skip the
+# ENTIRE self-update (no download, no reinstall, no restart) only when BOTH the
+# box release is current AND no CLI changed. When a CLI changed, the box must
+# fall through to its restart step even if the tarball is current — otherwise a
+# CLI-only upgrade would be swallowed by the cheap early exit and leave the
+# upgraded (but un-restarted) binary inert until the next update.
 #
-# Returns 0 (skip) when the box is current AND opencode unchanged; 1 (do not
-# skip) otherwise. Pure: no I/O, no globals. Unit-tested in release.test.mjs
+# `clis_changed` is a flag (0 or 1) the caller sets from the upgrade-clis state
+# file: 1 when ANY changed CLI is listed. opencode is just one row of the
+# catalog; its restart is governed by the conditional restart block, not here.
+#
+# Returns 0 (skip) when the box is current AND no CLI changed; 1 (do not skip)
+# otherwise. Pure: no I/O, no globals. Unit-tested in release.test.mjs
 # alongside release_is_current.
 should_skip_self_update() {
   installed_version="$1"
   installed_sha="$2"
   release_version="$3"
   release_sha="$4"
-  opencode_changed="$5"
+  clis_changed="$5"
 
   if release_is_current "$installed_version" "$installed_sha" "$release_version" "$release_sha" \
-     && [ "$opencode_changed" = "0" ]; then
+     && [ "$clis_changed" = "0" ]; then
     return 0
   fi
   return 1

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -440,15 +440,17 @@ test("release_is_current: an unreadable installed stamp is never 'current'", () 
   assert.equal(isCurrent("", "", "0.0.29", "def456"), false);
 });
 
-// --- should_skip_self_update: the BET-1016 early-exit decision ------------------
+// --- should_skip_self_update: the early-exit decision -------------------------
 //
 // The updater's early exit must skip the whole update ONLY when the box is
-// current AND opencode is unchanged. If opencode changed, the box must keep
-// going so its restart step runs — otherwise an opencode-only upgrade is
-// swallowed by the cheap exit and the new binary never gets restarted. This is
-// the full 2x2 (box-current x opencode-changed) matrix.
+// current AND no CLI changed. If a CLI changed, the box must keep going so its
+// restart step runs — otherwise a CLI-only upgrade is swallowed by the cheap
+// exit and the new binary never gets restarted. `clis_changed` is a flag the
+// caller derives from the upgrade-clis state file: 1 when ANY changed CLI is
+// listed (opencode is now just one row of the catalog). This is the full 2x2
+// (box-current x clis-changed) matrix.
 
-function shouldSkip(installedVersion, installedSha, releaseVersion, releaseSha, opencodeChanged) {
+function shouldSkip(installedVersion, installedSha, releaseVersion, releaseSha, clisChanged) {
   const script = `
     log() { :; }; ok() { :; }; warn() { :; }; die() { echo "$*" >&2; exit 1; }
     . "${RELEASE_LIB}"
@@ -456,26 +458,26 @@ function shouldSkip(installedVersion, installedSha, releaseVersion, releaseSha, 
   `;
   const out = execFileSync(
     "bash",
-    ["-c", script, "bash", installedVersion, installedSha, releaseVersion, releaseSha, opencodeChanged],
+    ["-c", script, "bash", installedVersion, installedSha, releaseVersion, releaseSha, clisChanged],
     { encoding: "utf-8" },
   );
   return out.trim() === "skip";
 }
 
-test("should_skip_self_update: box current + opencode unchanged → skip", () => {
+test("should_skip_self_update: box current + no CLI changed → skip", () => {
   assert.equal(shouldSkip("0.0.29", "abc123", "0.0.29", "abc123", "0"), true);
 });
 
-test("should_skip_self_update: box current + opencode CHANGED → do NOT skip", () => {
-  // An opencode-only upgrade on an already-current box must fall through to the
+test("should_skip_self_update: box current + a CLI CHANGED → do NOT skip", () => {
+  // A CLI-only upgrade on an already-current box must fall through to the
   // restart — this is the whole reason the early exit is now conditional.
   assert.equal(shouldSkip("0.0.29", "abc123", "0.0.29", "abc123", "1"), false);
 });
 
-test("should_skip_self_update: box stale + opencode unchanged → do NOT skip", () => {
+test("should_skip_self_update: box stale + no CLI changed → do NOT skip", () => {
   assert.equal(shouldSkip("0.0.29", "abc123", "0.0.30", "def456", "0"), false);
 });
 
-test("should_skip_self_update: box stale + opencode changed → do NOT skip", () => {
+test("should_skip_self_update: box stale + a CLI changed → do NOT skip", () => {
   assert.equal(shouldSkip("0.0.29", "abc123", "0.0.30", "def456", "1"), false);
 });

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -152,10 +152,13 @@ fi
 if [ -n "$CLIS_CHANGED" ]; then CLIS_CHANGED_FLAG=1; else CLIS_CHANGED_FLAG=0; fi
 
 # --- Payload-replaced flag (BET-1097) -----------------------------------------
-# Tracks whether this run swapped the box payload (a git reset --hard, or a
-# release tarball extraction). Set at the ONE place each kind does its swap; the
-# conditional restart block reads this single flag to decide opencode-and-server
-# vs opencode-only vs nothing.
+# Tracks whether this run ACTUALLY swapped the box payload (a git reset --hard
+# that moved HEAD, or a release tarball extraction). Set at the ONE place each
+# kind does its swap, and ONLY when the swap really changes the payload — a
+# current box (git box already on origin/main, or packaged box already at the
+# published build) that only upgraded a CLI must leave this 0 so the restart
+# block drops to opencode-only / nothing. The conditional restart block reads
+# this single flag to decide opencode-and-server vs opencode-only vs nothing.
 PAYLOAD_REPLACED=0
 
 echo "MANTA_PROGRESS 3/7 Downloading update"
@@ -166,9 +169,17 @@ if [ "$INSTALL_KIND" = "git" ]; then
   log "self-update: fetching origin/main into $MANTA_HOME"
   git -C "$MANTA_HOME" fetch origin main -q
 
-  log "self-update: resetting to origin/main"
-  git -C "$MANTA_HOME" reset --hard origin/main -q
-  PAYLOAD_REPLACED=1
+  # Only mark the payload replaced when the reset actually moves the checkout.
+  # A git box already on origin/main with only a CLI changed must not restart
+  # both services (BET-1097 review fix): PAYLOAD_REPLACED reflects whether the
+  # payload genuinely changed, not merely that the reset command ran.
+  if [ "$(git -C "$MANTA_HOME" rev-parse HEAD)" != "$(git -C "$MANTA_HOME" rev-parse origin/main)" ]; then
+    log "self-update: resetting to origin/main"
+    git -C "$MANTA_HOME" reset --hard origin/main -q
+    PAYLOAD_REPLACED=1
+  else
+    log "self-update: already at origin/main"
+  fi
 else
   # packaged install — download + verify + extract the release tarball and
   # replace only the payload paths the release owns.
@@ -229,47 +240,66 @@ else
     fi
     exit 0
   fi
-  if [ -n "$INSTALLED_GIT_SHA" ] && [ -n "$TARBALL_GIT_SHA" ]; then
-    log "self-update: new build $INSTALLED_GIT_SHA → $TARBALL_GIT_SHA"
-  fi
 
-  WORK="$(mktemp -d "${TMPDIR:-/tmp}/manta-update.XXXXXX")"
-  trap 'rm -rf "$WORK"' EXIT
-
-  log "self-update: downloading $host/releases/$TARBALL_FILE"
-  curl -fsSL "$host/releases/$TARBALL_FILE" -o "$WORK/manta.tar.gz" \
-    || die "self-update: download failed: $host/releases/$TARBALL_FILE"
-
-  log "self-update: verifying tarball sha256…"
-  verify_sha256 "$WORK/manta.tar.gz" "$TARBALL_SHA"
-
-  log "self-update: extracting to $WORK/pkg…"
-  mkdir "$WORK/pkg"
-  tar -xzf "$WORK/manta.tar.gz" -C "$WORK/pkg" --strip-components=1 \
-    || die "self-update: extract failed"
-
-  # A torn/corrupt download must never overwrite a working install — confirm
-  # the payload is complete before replacing anything.
-  [ -f "$WORK/pkg/src/server/index.mjs" ] \
-    || die "self-update: bad tarball — missing src/server/index.mjs"
-  [ -f "$WORK/pkg/RELEASE.json" ] \
-    || die "self-update: bad tarball — missing RELEASE.json"
-
-  # Replace ONLY the paths the incoming release owns (`includes` in its
-  # RELEASE.json — read from the INCOMING release, not the installed one, so a
-  # box installed before a path joined the list still picks it up). This is a
-  # single call into scripts/lib/release.sh: it stages each path as
-  # `<dest>/<rel>.new` and swaps with `mv`, so a failed copy can never leave a
-  # half-written tree — most important for `runtime/`, which the running server
-  # executes from. It also stamps RELEASE.json so the box records its version.
-  replace_release_payload "$WORK/pkg" "$MANTA_HOME" "$NODE_CMD"
-  PAYLOAD_REPLACED=1
-  # Report the commit alongside the version: two releases legitimately share a
-  # version number now, so "0.0.29 → 0.0.29" alone reads like a no-op.
-  if [ -n "$TARBALL_GIT_SHA" ]; then
-    ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION, commit $TARBALL_GIT_SHA)"
+  # Split the payload decision from the early exit. `should_skip_self_update`
+  # returns "carry on" for BOTH a stale box AND a current box whose CLI(s)
+  # changed — so re-check `release_is_current` here to decide whether there is
+  # actually a payload swap to do. This is the fix for the review Block:
+  # PAYLOAD_REPLACED must reflect whether the payload ACTUALLY changed (box was
+  # stale), not merely that the replace function ran. A current box with a
+  # CLI-only upgrade must NOT set PAYLOAD_REPLACED — that would restart both
+  # services and kill every running agent turn for no reason.
+  if release_is_current "$INSTALLED_VERSION" "$INSTALLED_GIT_SHA" "$TARBALL_VERSION" "$TARBALL_GIT_SHA"; then
+    # Box is already current; we only got here because a CLI changed. Fall
+    # through to deps/tools/restart WITHOUT touching the payload.
+    if [ -n "$TARBALL_GIT_SHA" ]; then
+      ok "self-update: already at $TARBALL_VERSION ($TARBALL_GIT_SHA); CLI(s) updated → no payload swap"
+    else
+      ok "self-update: already at $TARBALL_VERSION; CLI(s) updated → no payload swap"
+    fi
   else
-    ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION)"
+    if [ -n "$INSTALLED_GIT_SHA" ] && [ -n "$TARBALL_GIT_SHA" ]; then
+      log "self-update: new build $INSTALLED_GIT_SHA → $TARBALL_GIT_SHA"
+    fi
+
+    WORK="$(mktemp -d "${TMPDIR:-/tmp}/manta-update.XXXXXX")"
+    trap 'rm -rf "$WORK"' EXIT
+
+    log "self-update: downloading $host/releases/$TARBALL_FILE"
+    curl -fsSL "$host/releases/$TARBALL_FILE" -o "$WORK/manta.tar.gz" \
+      || die "self-update: download failed: $host/releases/$TARBALL_FILE"
+
+    log "self-update: verifying tarball sha256…"
+    verify_sha256 "$WORK/manta.tar.gz" "$TARBALL_SHA"
+
+    log "self-update: extracting to $WORK/pkg…"
+    mkdir "$WORK/pkg"
+    tar -xzf "$WORK/manta.tar.gz" -C "$WORK/pkg" --strip-components=1 \
+      || die "self-update: extract failed"
+
+    # A torn/corrupt download must never overwrite a working install — confirm
+    # the payload is complete before replacing anything.
+    [ -f "$WORK/pkg/src/server/index.mjs" ] \
+      || die "self-update: bad tarball — missing src/server/index.mjs"
+    [ -f "$WORK/pkg/RELEASE.json" ] \
+      || die "self-update: bad tarball — missing RELEASE.json"
+
+    # Replace ONLY the paths the incoming release owns (`includes` in its
+    # RELEASE.json — read from the INCOMING release, not the installed one, so a
+    # box installed before a path joined the list still picks it up). This is a
+    # single call into scripts/lib/release.sh: it stages each path as
+    # `<dest>/<rel>.new` and swaps with `mv`, so a failed copy can never leave a
+    # half-written tree — most important for `runtime/`, which the running server
+    # executes from. It also stamps RELEASE.json so the box records its version.
+    replace_release_payload "$WORK/pkg" "$MANTA_HOME" "$NODE_CMD"
+    PAYLOAD_REPLACED=1
+    # Report the commit alongside the version: two releases legitimately share a
+    # version number now, so "0.0.29 → 0.0.29" alone reads like a no-op.
+    if [ -n "$TARBALL_GIT_SHA" ]; then
+      ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION, commit $TARBALL_GIT_SHA)"
+    else
+      ok "self-update: replaced release payload ($INSTALLED_VERSION → $TARBALL_VERSION)"
+    fi
   fi
 fi
 

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -73,7 +73,7 @@ exec >>"$LOG_FILE" 2>&1
 . "$MANTA_HOME/scripts/lib/release.sh"
 
 # --- Detect install kind ------------------------------------------------------
-echo "MANTA_PROGRESS 1/6 Checking for updates"
+echo "MANTA_PROGRESS 1/7 Checking for updates"
 if [ -d "$MANTA_HOME/.git" ]; then
   INSTALL_KIND=git
 elif [ -f "$MANTA_HOME/RELEASE.json" ]; then
@@ -113,47 +113,52 @@ if [ -d "$MANTA_HOME/runtime/node/bin" ]; then
   export PATH
 fi
 
-# --- Upgrade the opencode binary (BET-1016) ----------------------------------
-# opencode is installed once (deliberately UNPINNED) and otherwise frozen at
-# install time, so every box drifts from whatever it was installed with forever.
-# Fold its upgrade into the self-update so a box stops drifting: run `opencode
-# upgrade` (the CLI command on the installed binary — no auth question, no port
-# assumption) and capture `opencode --version` before/after to report whether
-# anything actually changed.
+# --- Upgrade every installed AI CLI (BET-1097) --------------------------------
+# opencode, claude, codex, kimi are installed once (deliberately UNPINNED) and
+# otherwise frozen at install time, so every box drifts from whatever it was
+# installed with. The whole upgrade loop lives in node (scripts/upgrade-clis.mjs,
+# reusing the stage-1 catalog + detector — the ONE place that knows how to find
+# and upgrade a CLI). It writes a state file with `CLIS_CHANGED` (comma-separated
+# ids of CLIs whose version actually changed) and `OPENCODE_CHANGED=0|1`, which
+# we source below to drive the early exit and the conditional restarts.
 #
-# MUST run BEFORE the packaged-install early exit below: that cheap exit skips
-# EVERYTHING (including the restart at MANTA_PROGRESS 5/6) when the box tarball
-# is already current, and an opencode-only upgrade must still fall through to
-# that restart. `OPCODE_VERSION_CHANGED` is the flag the early exit re-checks —
-# set here so the early exit can go conditional on it.
+# MUST run BEFORE the packaged-install early exit and before any payload
+# replacement: that cheap exit skips EVERYTHING (including the restarts) when
+# the box tarball is already current, and a CLI-only upgrade must still fall
+# through to the restart(s) that apply. RUNS ON THE RUNTIME NODE THE SCRIPT
+# ALREADY PINNED ON PATH ($MANTA_HOME/runtime/node/bin — NODE_CMD).
 #
 # Non-fatal throughout, mirroring refresh_opencode_tools(): an offline box, a
-# missing CLI, or a refused upgrade must never abort the server update.
-OPCODE_VERSION_CHANGED=0
-upgrade_opencode() {
-  if ! command -v opencode >/dev/null 2>&1; then
-    echo "⚠ self-update: opencode not found on PATH — skipping binary upgrade"
-    return 0
-  fi
-  local before after
-  before="$(opencode --version 2>/dev/null || true)"
-  before="${before:-unknown}"
-  if ! opencode upgrade >/dev/null 2>&1; then
-    echo "⚠ self-update: opencode upgrade failed (current: $before) — continuing"
-    return 0
-  fi
-  after="$(opencode --version 2>/dev/null || true)"
-  after="${after:-unknown}"
-  if [ "$before" != "$after" ]; then
-    OPCODE_VERSION_CHANGED=1
-    echo "✓ self-update: opencode upgraded: $before → $after"
+# missing CLI, a refused upgrade, a vendor endpoint that 500s, or even a node
+# that cannot run the script must never abort the server update.
+echo "MANTA_PROGRESS 2/7 Updating command-line tools"
+CLIS_CHANGED=""
+OPENCODE_CHANGED=0
+CLI_STATE_FILE="$STATE_HOME/.manta/upgrade-clis.state"
+if [ -x "$NODE_CMD" ] && [ -f "$MANTA_HOME/scripts/upgrade-clis.mjs" ]; then
+  if "$NODE_CMD" "$MANTA_HOME/scripts/upgrade-clis.mjs" \
+       --progress-step=2 --progress-total=7 --state-file="$CLI_STATE_FILE"; then
+    if [ -f "$CLI_STATE_FILE" ]; then
+      . "$CLI_STATE_FILE"
+      CLIS_CHANGED="${CLIS_CHANGED:-}"
+      OPENCODE_CHANGED="${OPENCODE_CHANGED:-0}"
+    fi
   else
-    echo "✓ self-update: opencode already current ($before)"
+    echo "⚠ self-update: CLI upgrade script failed — continuing with no CLI changes"
   fi
-}
-upgrade_opencode
+else
+  echo "⚠ self-update: node unavailable — skipping CLI upgrades"
+fi
+if [ -n "$CLIS_CHANGED" ]; then CLIS_CHANGED_FLAG=1; else CLIS_CHANGED_FLAG=0; fi
 
-echo "MANTA_PROGRESS 2/6 Downloading update"
+# --- Payload-replaced flag (BET-1097) -----------------------------------------
+# Tracks whether this run swapped the box payload (a git reset --hard, or a
+# release tarball extraction). Set at the ONE place each kind does its swap; the
+# conditional restart block reads this single flag to decide opencode-and-server
+# vs opencode-only vs nothing.
+PAYLOAD_REPLACED=0
+
+echo "MANTA_PROGRESS 3/7 Downloading update"
 if [ "$INSTALL_KIND" = "git" ]; then
   # A git checkout has no vendored runtime under version control — the box runs
   # whatever Node is on PATH. So a git box's runtime is only ever updated by
@@ -163,6 +168,7 @@ if [ "$INSTALL_KIND" = "git" ]; then
 
   log "self-update: resetting to origin/main"
   git -C "$MANTA_HOME" reset --hard origin/main -q
+  PAYLOAD_REPLACED=1
 else
   # packaged install — download + verify + extract the release tarball and
   # replace only the payload paths the release owns.
@@ -211,10 +217,11 @@ else
   # Cheap early exit when already current — no download, no reinstall, no
   # restart. The decision itself lives in scripts/lib/release.sh so it can be
   # unit-tested; see release_is_current for why it compares the build's commit
-  # rather than its version number. BET-1016: the exit is conditional on BOTH
-  # the box being current AND opencode not having changed — an opencode-only
-  # upgrade must fall through to the restart below, never be swallowed here.
-  if should_skip_self_update "$INSTALLED_VERSION" "$INSTALLED_GIT_SHA" "$TARBALL_VERSION" "$TARBALL_GIT_SHA" "$OPCODE_VERSION_CHANGED"; then
+  # rather than its version number. The exit is conditional on BOTH the box
+  # being current AND no CLI having changed (BET-1016, generalised in BET-1097)
+  # — a CLI-only upgrade must fall through to the restart below, never be
+  # swallowed here.
+  if should_skip_self_update "$INSTALLED_VERSION" "$INSTALLED_GIT_SHA" "$TARBALL_VERSION" "$TARBALL_GIT_SHA" "$CLIS_CHANGED_FLAG"; then
     if [ -n "$INSTALLED_GIT_SHA" ] && [ -n "$TARBALL_GIT_SHA" ]; then
       ok "self-update: already at $TARBALL_VERSION ($TARBALL_GIT_SHA)"
     else
@@ -256,6 +263,7 @@ else
   # half-written tree — most important for `runtime/`, which the running server
   # executes from. It also stamps RELEASE.json so the box records its version.
   replace_release_payload "$WORK/pkg" "$MANTA_HOME" "$NODE_CMD"
+  PAYLOAD_REPLACED=1
   # Report the commit alongside the version: two releases legitimately share a
   # version number now, so "0.0.29 → 0.0.29" alone reads like a no-op.
   if [ -n "$TARBALL_GIT_SHA" ]; then
@@ -265,7 +273,7 @@ else
   fi
 fi
 
-echo "MANTA_PROGRESS 3/6 Installing dependencies"
+echo "MANTA_PROGRESS 4/7 Installing dependencies"
 install_prod_deps "$MANTA_HOME"
 
 # --- Refresh the manta-native opencode tools --------------------------------
@@ -332,7 +340,7 @@ refresh_opencode_tools() {
   echo "✓ self-update: opencode tools refreshed ($changed of $copied changed)"
 }
 
-echo "MANTA_PROGRESS 4/6 Refreshing AI tools"
+echo "MANTA_PROGRESS 5/7 Refreshing AI tools"
 refresh_opencode_tools
 
 # --- Sync opencode agent guidance (BET-640) -----------------------------------
@@ -342,36 +350,66 @@ refresh_opencode_tools
 # update without rewriting existing (possibly user-edited) sections.
 sync_opencode_guidance "$MANTA_HOME/docs/opencode-tools/AGENTS.md" "${OPENCODE_CONFIG_DIR:-$HOME/.config/opencode}/AGENTS.md"
 
-echo "MANTA_PROGRESS 5/6 Restarting opencode"
-# Restart opencode so refreshed tools are actually loaded. opencode only
-# re-scans its tools/ directory at startup, so without this an update
-# leaves the new tools inert on disk. UNCONDITIONAL: the user confirmed a
-# restart before the update started, so the behaviour must be predictable
-# rather than depending on whether any tool file happened to change.
-if command -v systemctl >/dev/null 2>&1; then
-  echo "▸ self-update: restarting opencode-serve"
-  systemctl --user restart opencode-serve || echo "⚠ self-update: opencode restart failed"
-elif [ "$(uname -s)" = "Darwin" ]; then
-  echo "▸ self-update: kickstarting com.mantaui.opencode LaunchAgent"
-  launchctl kickstart -k "gui/$(id -u)/com.mantaui.opencode" || echo "⚠ self-update: opencode restart failed"
-else
-  echo "⚠ self-update: no systemctl/launchctl — restart opencode manually"
-fi
+# --- Conditional restarts (BET-1097) ------------------------------------------
+# Replacing a CLI binary on Linux does NOT disturb a running process — a running
+# opencode/claude session keeps the old version until it is next launched. So we
+# restart ONLY what actually needs it:
+#
+#   | Condition                                     | Restart                |
+#   |-----------------------------------------------|------------------------|
+#   | box payload was replaced (git reset / tarball)| opencode AND server   |
+#   | opencode changed, payload did not             | opencode only         |
+#   | only other CLIs changed                       | NOTHING               |
+#
+# `PAYLOAD_REPLACED` is the single flag set at the one place each install kind
+# swaps its payload. `OPENCODE_CHANGED` comes from the upgrade-clis state file.
+# A skipped step emits no MANTA_PROGRESS line; the bar jumps forward (the
+# progress parser requires strictly-increasing steps).
 
-echo "MANTA_PROGRESS 6/6 Restarting box server"
-# Restart the supervisor that runs manta-server. Linux uses the systemd
-# --user unit (default since v1); macOS (BET-277) uses the LaunchAgent
-# installed by install.sh — `launchctl kickstart -k` kills any running
-# instance and starts a fresh one. Other hosts have no persistent
-# supervisor and the user is expected to restart by hand.
-if command -v systemctl >/dev/null 2>&1; then
-  echo "▸ self-update: restarting manta-server.service"
-  systemctl --user restart manta-server.service
-elif [ "$(uname -s)" = "Darwin" ]; then
-  echo "▸ self-update: kickstarting com.mantaui.server LaunchAgent"
-  launchctl kickstart -k "gui/$(id -u)/com.mantaui.server"
+restart_opencode() {
+  # Restart opencode so refreshed tools are actually loaded. opencode only
+  # re-scans its tools/ directory at startup, so without this an update leaves
+  # the new tools inert on disk.
+  if command -v systemctl >/dev/null 2>&1; then
+    echo "▸ self-update: restarting opencode-serve"
+    systemctl --user restart opencode-serve || echo "⚠ self-update: opencode restart failed"
+  elif [ "$(uname -s)" = "Darwin" ]; then
+    echo "▸ self-update: kickstarting com.mantaui.opencode LaunchAgent"
+    launchctl kickstart -k "gui/$(id -u)/com.mantaui.opencode" || echo "⚠ self-update: opencode restart failed"
+  else
+    echo "⚠ self-update: no systemctl/launchctl — restart opencode manually"
+  fi
+}
+
+restart_server() {
+  # Restart the supervisor that runs manta-server. Linux uses the systemd
+  # --user unit (default since v1); macOS (BET-277) uses the LaunchAgent
+  # installed by install.sh — `launchctl kickstart -k` kills any running
+  # instance and starts a fresh one. Other hosts have no persistent
+  # supervisor and the user is expected to restart by hand.
+  if command -v systemctl >/dev/null 2>&1; then
+    echo "▸ self-update: restarting manta-server.service"
+    systemctl --user restart manta-server.service
+  elif [ "$(uname -s)" = "Darwin" ]; then
+    echo "▸ self-update: kickstarting com.mantaui.server LaunchAgent"
+    launchctl kickstart -k "gui/$(id -u)/com.mantaui.server"
+  else
+    echo "⚠ self-update: no systemctl/launchctl — restart manta-server manually"
+  fi
+}
+
+if [ "$PAYLOAD_REPLACED" = "1" ]; then
+  echo "MANTA_PROGRESS 6/7 Restarting opencode"
+  restart_opencode
+  echo "MANTA_PROGRESS 7/7 Restarting box server"
+  restart_server
+elif [ "$OPENCODE_CHANGED" = "1" ]; then
+  echo "MANTA_PROGRESS 6/7 Restarting opencode"
+  restart_opencode
 else
-  echo "⚠ self-update: no systemctl/launchctl — restart manta-server manually"
+  # Only other CLIs changed → restart nothing. Replacing a CLI binary does not
+  # disturb a running process, so there is nothing to restart.
+  echo "✓ self-update: CLI(s) updated; no restart needed (payload untouched, opencode unchanged)"
 fi
 
 echo "✓ self-update: complete"

--- a/scripts/upgrade-clis.mjs
+++ b/scripts/upgrade-clis.mjs
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+// upgrade-clis.mjs — the whole "upgrade every installed AI CLI" loop (BET-1097,
+// stage 2 of the unified-update epic).
+//
+// `scripts/self-update.sh` calls this exactly once, in place of the old
+// `upgrade_opencode()`. It reads the stage-1 catalog + detector directly
+// (src/shared/cliCatalog.mjs + src/server/cliUpdates.mjs), so there is exactly
+// ONE place that knows how to find and upgrade a CLI — bash never re-implements
+// any of it.
+//
+// For each INSTALLED CLI with a RESOLVED upgrade command it:
+//   * prints `MANTA_PROGRESS <step>/<total> Updating <label>` before running it
+//     (the SAME step number every time — the refined label updates the bar text
+//     without advancing it),
+//   * reads the version, runs the upgrade command, reads the version again,
+//   * a CLI whose version string changed is a CHANGED CLI.
+//
+// Rules:
+//   * Non-fatal throughout — an offline box, a missing CLI, a refused upgrade
+//     or a vendor endpoint that 500s logs a warning and moves on. A CLI must
+//     never abort a box update.
+//   * Per-CLI timeout 10 minutes.
+//   * `manual` CLIs (no resolvable upgrade command — e.g. a Homebrew-managed
+//     binary) are skipped silently.
+//   * On exit it ALWAYS writes the state file (`CLIS_CHANGED=` +
+//     `OPENCODE_CHANGED=`), even on failure (empty values), so bash never reads
+//     a stale one.
+//
+// Usage:
+//   node scripts/upgrade-clis.mjs \
+//     --progress-step=2 --progress-total=7 --state-file=<path>
+
+import { spawn as nodeSpawn } from "node:child_process";
+import { constants } from "node:fs";
+import { access as fsAccess } from "node:fs/promises";
+import { writeFileSync } from "node:fs";
+import { CLI_CATALOG } from "../src/shared/cliCatalog.mjs";
+import { detectClis, readVersion, resolveBinary } from "../src/server/cliUpdates.mjs";
+
+const PER_CLI_TIMEOUT_MS = 10 * 60 * 1000;
+
+function parseArgs(argv) {
+  const out = { progressStep: "2", progressTotal: "7", stateFile: null };
+  for (const arg of argv) {
+    if (arg.startsWith("--progress-step=")) out.progressStep = arg.slice("--progress-step=".length);
+    else if (arg.startsWith("--progress-total=")) out.progressTotal = arg.slice("--progress-total=".length);
+    else if (arg.startsWith("--state-file=")) out.stateFile = arg.slice("--state-file=".length);
+  }
+  return out;
+}
+
+function warn(message) {
+  process.stderr.write(`⚠ upgrade-clis: ${message}\n`);
+}
+
+// Run one upgrade command array (`["opencode","upgrade"]`, `["npm","install","-g",…]`,
+// or a `["sh","-c",…]` pipeline). Streams child stdout/stderr through so the
+// self-update log shows what the vendor installer did. Resolves on exit 0,
+// rejects otherwise. Per-CLI timeout is enforced by spawn's `timeout`.
+function runUpgrade(argv) {
+  const [cmd, ...args] = argv;
+  return new Promise((resolve, reject) => {
+    let child;
+    try {
+      child = nodeSpawn(cmd, args, { stdio: "inherit", timeout: PER_CLI_TIMEOUT_MS });
+    } catch (e) {
+      reject(e);
+      return;
+    }
+    child.on("error", reject);
+    child.on("close", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${cmd} exited with code ${code}`));
+    });
+  });
+}
+
+function writeStateFile(file, cliIds, opencodeChanged) {
+  const body = `CLIS_CHANGED=${cliIds.join(",")}\nOPENCODE_CHANGED=${opencodeChanged}\n`;
+  try {
+    writeFileSync(file, body, "utf8");
+  } catch (e) {
+    warn(`cannot write state file ${file}: ${e.message}`);
+  }
+}
+
+async function main() {
+  const { progressStep, progressTotal, stateFile } = parseArgs(process.argv.slice(2));
+  const changed = [];
+  let opencodeChanged = 0;
+
+  try {
+    const results = await detectClis();
+    for (const r of results) {
+      // A CLI with no resolved upgrade command (`manual`) is skipped silently —
+      // it has no safe upgrade path and must not disturb the run.
+      if (!Array.isArray(r.upgrade) || r.upgrade.length === 0) continue;
+
+      // Same step every time, refined label — the bar must not jump per CLI.
+      process.stdout.write(`MANTA_PROGRESS ${progressStep}/${progressTotal} Updating ${r.label}\n`);
+
+      const before = r.current ?? null;
+      try {
+        await runUpgrade(r.upgrade);
+      } catch (e) {
+        warn(`${r.label}: upgrade failed (${e.message}) — continuing`);
+        continue;
+      }
+
+      // Re-read the version to see whether the upgrade actually changed it.
+      const entry = CLI_CATALOG.find((c) => c.id === r.id);
+      let after = null;
+      if (entry?.bin) {
+        const absPath = await resolveBinary(entry.bin, { access: fsAccess, env: process.env });
+        if (absPath) after = await readVersion(absPath, { spawn: nodeSpawn });
+      }
+
+      if (after && after !== before) {
+        changed.push(r.id);
+        if (r.id === "opencode") opencodeChanged = 1;
+        process.stdout.write(`✓ upgrade-clis: ${r.label} upgraded: ${before ?? "unknown"} → ${after}\n`);
+      } else {
+        const shown = after ?? before ?? "unknown";
+        process.stdout.write(`✓ upgrade-clis: ${r.label} already current (${shown})\n`);
+      }
+    }
+  } catch (e) {
+    warn(`unexpected error: ${e.message} — continuing`);
+  } finally {
+    // Always write the state file, even on failure, so bash never reads a stale
+    // one from a previous run.
+    if (stateFile) writeStateFile(stateFile, changed, opencodeChanged);
+  }
+}
+
+main();

--- a/src/server/opencodeAdmin.test.mjs
+++ b/src/server/opencodeAdmin.test.mjs
@@ -173,10 +173,10 @@ describe("runServerSelfUpdate", () => {
     writeFileSync(
       logPath,
       [
-        "MANTA_PROGRESS 1/6 Checking for updates",
+        "MANTA_PROGRESS 1/7 Checking for updates",
         "▸ self-update: fetching origin/main",
-        "MANTA_PROGRESS 2/6 Downloading update",
-        "MANTA_PROGRESS 3/6 Installing dependencies",
+        "MANTA_PROGRESS 2/7 Updating command-line tools",
+        "MANTA_PROGRESS 3/7 Downloading update",
         "",
       ].join("\n"),
     );
@@ -208,13 +208,13 @@ describe("runServerSelfUpdate", () => {
     );
     assert.deepEqual(progress[0].payload, {
       step: 1,
-      total: 6,
+      total: 7,
       label: "Checking for updates",
     });
     assert.deepEqual(progress[2].payload, {
       step: 3,
-      total: 6,
-      label: "Installing dependencies",
+      total: 7,
+      label: "Downloading update",
     });
   });
 


### PR DESCRIPTION
## BET-1097 — self-update.sh: upgrade every detected CLI, restart only what changed

Stage 2 of the unified-update epic (parallel to the aggregate-payload issue). Box side, bash + one node script. Depends on stage 1 (BET-1095, merged) — reuses `src/shared/cliCatalog.mjs` and `src/server/cliUpdates.mjs` directly.

**Files changed:** 5

- `scripts/upgrade-clis.mjs` (new) — the whole "upgrade every installed AI CLI" loop in node, reusing the stage-1 catalog + detector so bash never re-implements CLI discovery/upgrade. Uses `src/server/cliUpdates.mjs`'s `detectClis` for installed probes + resolved upgrade commands; iterates only CLIs with a resolved (non-`manual`) upgrade command, runs the upgrade with a 10-minute per-CLI timeout, re-reads the version, flags a version string change as a CHANGED CLI, and always writes the state file (`CLIS_CHANGED` comma-separated ids + `OPENCODE_CHANGED=0|1`) even on failure. Non-fatal throughout.
- `scripts/self-update.sh` — deleted `upgrade_opencode()`; calls `upgrade-clis.mjs` at the same point (before the packaged early exit and before any payload replacement) using the pinned runtime node. Early exit now passes `clis_changed` (1 when the state file lists ANY changed CLI, not just opencode). Progress markers become the constant total 7 (`1 Checking for updates`, `2 Updating command-line tools`, `3 Downloading update`, `4 Installing dependencies`, `5 Refreshing AI tools`, `6 Restarting opencode`, `7 Restarting box server`); a skipped step emits nothing and the bar jumps forward. Restarts are now conditional on a single `PAYLOAD_REPLACED` flag (set at the two swap sites: `git reset --hard` and `replace_release_payload`) + `OPENCODE_CHANGED` per the three-rule table:
  - payload replaced → opencode AND server
  - opencode changed, payload not → opencode only
  - only other CLIs changed → nothing
- `scripts/lib/release.sh` / `scripts/lib/release.test.mjs` — `should_skip_self_update` param renamed `opencode_changed` → `clis_changed`; test updated (pure unit test, 2x2 matrix same semantics).
- `src/server/opencodeAdmin.test.mjs` — illustrative progress markers seeded in the poller test updated to the 7-step scheme.

**Base:** origin/main @ d4864bd7

## Verification results

**Manual CLI-upgrade run (issue verification step 1 & 2)** — ran on the box (opencode was 1.18.10, latest 1.18.18; claude 2.1.233; codex + kimi not installed), exactly as the issue specifies:

```
node scripts/upgrade-clis.mjs --progress-step=2 --progress-total=7 --state-file=/tmp/cli.state
MANTA_PROGRESS 2/7 Updating opencode
✓ upgrade-clis: opencode upgraded: 1.18.10 → 1.18.18
MANTA_PROGRESS 2/7 Updating Claude Code
✓ upgrade-clis: Claude Code upgraded: 2.1.233 → 2.1.234
```
- opencode actually upgraded 1.18.10 → 1.18.18 → `OPENCODE_CHANGED=1` ✓
- codex and kimi silently absent (not installed) — no error, no warning ✓
- State file: `CLIS_CHANGED=opencode,claude` / `OPENCODE_CHANGED=1` ✓
- The CLI loop itself performs zero restarts — it is purely the upgrade loop.

**Verification step 3 (CLI-only run restarts neither service):** not runnable in this environment — running the full `self-update.sh` here would `git reset --hard` the worktree and drive systemctl/launchctl restarts against this agent host. The restart decision is code-reviewed: the "nothing" branch fires when `$PAYLOAD_REPLACED=0` and `$OPENCODE_CHANGED!=1` (only non-opencode CLIs changed), and the CLI upgrade step is provably restart-free (shown above). The full-script CLI-only / payload-untouched path needs the real dev box to observe in `~/.manta/self-update.log`.

**Automated verification (`npm run typecheck && npm test`):**
- typecheck: exit 0, no errors
- test: exit 0, 2349 pass / 0 fail / 0 skip
- targeted: `release.test.mjs` + `opencodeAdmin.test.mjs` — 36 pass / 0 fail

**Follow-up filed:** none — all in-scope items delivered per spec (out-of-scope explicitly excluded: UI, bus events, installing absent CLIs, manifest/tarball logic).
