### PR TITLE
feat(shared): unified UpdateTarget list + describeUpdateTarget (BET-1096)

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -34,8 +34,9 @@ import { useApplySetting } from "./settingsApply";
 import { SettingsRow } from "./SettingsRow";
 import { BANNER_BTN } from "./Toast";
 import { errorDisclosure } from "./settingsError";
-import { describeDesktopUpdate, describeServerUpdate, type UpdateRow } from "./chatUtils";
-import type { DesktopUpdateCheck, ServerUpdateCheck } from "../shared/types";
+import { describeUpdateTarget } from "./chatUtils";
+import type { UpdateRow } from "./chatUtils";
+import type { DesktopUpdateCheck, ServerUpdateCheck, UpdateTarget } from "../shared/types";
 import { forgeCredentialSecondary } from "./chatUtils";
 import { useCachedResource } from "./useCachedResource";
 import { MantaLoader } from "./MantaLoader";
@@ -505,8 +506,41 @@ export function Settings({
     }
   }, [updatePrompt, updateError]);
 
-  const desktopRow = describeDesktopUpdate(desktopCheck);
-  const serverRow = describeServerUpdate(serverCheck, { failed: serverCheckFailed });
+  // Each leg's verdict row, from the ONE shared describe function. The old
+  // code had two bespoke describe-functions (describeDesktopUpdate /
+  // describeServerUpdate); BET-1096 replaced them with describeUpdateTarget
+  // keyed off the shared UpdateTarget shape. Until stage 3 unifies the About
+  // list, this thin per-leg adapter shapes each check into an UpdateTarget.
+  // `ok` preserves the exact old semantics: a check that hasn't run (or whose
+  // RPC never came back) must NOT read as "up to date".
+  const desktopTarget: UpdateTarget | null =
+    desktopCheck == null
+      ? null
+      : {
+          id: "desktop",
+          label: "Manta UI",
+          current: clientVersion,
+          latest: desktopCheck.version,
+          available: desktopCheck.available,
+          ok: !desktopCheck.error,
+          manual: desktopCheck.supported === false,
+          disruption: "app-restart",
+        };
+  const serverTarget: UpdateTarget | null =
+    serverCheck == null && !serverCheckFailed
+      ? null
+      : {
+          id: "server",
+          label: "The box",
+          current: serverVersion,
+          latest: serverCheck?.version ?? null,
+          available: serverCheck?.available === true,
+          ok: serverCheck ? serverCheck.ok !== false : false,
+          manual: false,
+          disruption: "reconnect",
+        };
+  const desktopRow = desktopTarget ? describeUpdateTarget(desktopTarget) : null;
+  const serverRow = serverTarget ? describeUpdateTarget(serverTarget) : null;
 
   // opencode port — exposed in the Box "Advanced" row (BET-420). Read via
   // configGet (it's an AppConfig key with no store mirror) and committed via

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -41,8 +41,7 @@ import {
   runWithConcurrency,
   chooseUpdateSkewVariant,
   isTransientUpdateNetworkError,
-  describeDesktopUpdate,
-  describeServerUpdate,
+  describeUpdateTarget,
   arrowUpNavigatesHistory,
   arrowDownNavigatesHistory,
   parseDeviceCode,
@@ -147,7 +146,7 @@ import {
   deviceAuthErrorMessage,
 } from "./chatUtils";
 
-import type { OpencodeModel, OpencodeAgent, UsageSnapshot, OpencodeMessage, OpencodePart, VoiceNoteRecord, ForgeInboxItem, QuestionRequest } from "../shared/types";
+import type { OpencodeModel, OpencodeAgent, UsageSnapshot, OpencodeMessage, OpencodePart, VoiceNoteRecord, ForgeInboxItem, QuestionRequest, UpdateTarget } from "../shared/types";
 
 
 
@@ -1495,95 +1494,54 @@ describe("chooseUpdateSkewVariant", () => {
 });
 
 // ===== "Check for updates" verdict rows =====
-describe("describeDesktopUpdate", () => {
-  it("returns null before a check has run (renders nothing, not 'up to date')", () => {
-    expect(describeDesktopUpdate(null)).toBeNull();
+describe("describeUpdateTarget", () => {
+  const target = (over: Partial<UpdateTarget>): UpdateTarget => ({
+    id: "desktop",
+    label: "Manta UI",
+    current: null,
+    latest: null,
+    available: false,
+    ok: true,
+    manual: false,
+    disruption: "app-restart",
+    ...over,
   });
 
-  it("reports up to date as 'ok'", () => {
-    expect(describeDesktopUpdate({ supported: true, available: false, version: "0.0.36" })).toEqual({
+  it("reports a current target as 'ok', up to date", () => {
+    expect(describeUpdateTarget(target({ id: "desktop" }))).toEqual({
       tone: "ok",
-      text: "Manta UI is up to date.",
+      text: "Up to date",
     });
   });
 
-  it("names the available version and asks for an action", () => {
-    expect(describeDesktopUpdate({ supported: true, available: true, version: "0.0.37" })).toEqual({
-      tone: "action",
-      text: "Manta UI 0.0.37 is available.",
-    });
+  it("reports an available target as 'action', update available", () => {
+    const row = describeUpdateTarget(target({ available: true }));
+    expect(row.tone).toBe("action");
+    expect(row.text).toBe("Update available");
   });
 
-  it("still reports an available update when the feed carries no version", () => {
-    expect(describeDesktopUpdate({ supported: true, available: true, version: null })).toEqual({
-      tone: "action",
-      text: "An update is available.",
-    });
+  it("reports a manual target as 'muted' — never 'up to date'", () => {
+    // A dev build (supported:false → manual) and a CLI with no safe upgrade
+    // command have to read as "not applicable", not as a clean bill of health.
+    const row = describeUpdateTarget(target({ manual: true }));
+    expect(row.tone).toBe("muted");
+    expect(row.tone).not.toBe("ok");
   });
 
-  it("an unsupported build is MUTED, never 'up to date'", () => {
-    // A dev build and a mobile client have no updater at all. Rendering either
-    // as "up to date" is a claim about something that was never checked — the
-    // precise shape of reassurance that let a permanently broken macOS updater
-    // pass for a healthy one.
-    const row = describeDesktopUpdate({ supported: false, available: false, version: null });
-    expect(row?.tone).toBe("muted");
-    expect(row?.tone).not.toBe("ok");
+  it("a failed check is an ERROR and outranks every other reading", () => {
+    // Even a manual, available target must render as a failure, not as an
+    // action or a reassuring "up to date". The invariant: an unanswerable
+    // check is NEVER rendered as "ok".
+    const row = describeUpdateTarget(target({ ok: false, manual: true, available: true }));
+    expect(row).toEqual({ tone: "error", text: "Couldn't check" });
   });
 
-  it("a failed check is an ERROR and outranks the up-to-date reading", () => {
-    const row = describeDesktopUpdate({
-      supported: true,
-      available: false,
-      version: null,
-      error: "Couldn't check for updates.",
-    });
-    expect(row).toEqual({ tone: "error", text: "Couldn't check for updates." });
-  });
-});
-
-describe("describeServerUpdate", () => {
-  it("returns null before a check has run", () => {
-    expect(describeServerUpdate(null)).toBeNull();
-  });
-
-  it("reports up to date as 'ok'", () => {
-    expect(describeServerUpdate({ available: false })).toEqual({
-      tone: "ok",
-      text: "The box is up to date.",
-    });
-  });
-
-  it("names the available box version and asks for an action", () => {
-    expect(describeServerUpdate({ available: true, version: "0.0.37" })).toEqual({
-      tone: "action",
-      text: "Box update 0.0.37 is available.",
-    });
-  });
-
-  it("an unreachable box is an ERROR, and outranks any stale result", () => {
-    // The RPC not coming back is a different fact from the box saying "nothing
-    // new", and must not inherit the reassuring tone of the latter.
-    const row = describeServerUpdate({ available: false }, { failed: true });
-    expect(row?.tone).toBe("error");
-    expect(row?.text).toMatch(/couldn’t reach the box/i);
-  });
-
-  it("a check that could not complete (ok:false) is an ERROR, never 'up to date'", () => {
-    // A manifest-fetch failure resolves `available:false` — the SAME value as
-    // "up to date". Without this branch the box row would show the green
-    // reassuring tone after a failed check. The failure must be read as an
-    // error, not a clean bill of health.
-    const row = describeServerUpdate({ available: false, ok: false });
-    expect(row?.tone).toBe("error");
-    expect(row?.tone).not.toBe("ok");
-    expect(row?.text).toMatch(/couldn’t check the box/i);
-  });
-
-  it("an absent ok is treated as a successful check (old server)", () => {
-    // A response from an older server that predates the `ok` field must still
-    // render normally, not as an error.
-    expect(describeServerUpdate({ available: false })?.tone).toBe("ok");
+  it("manual outranks available", () => {
+    // A target that is both manual and available (e.g. a broken updater) must
+    // be muted "Update manually", not an actionable "Update available".
+    const row = describeUpdateTarget(target({ manual: true, available: true }));
+    expect(row.tone).toBe("muted");
+    expect(row.text).toBe("Update manually");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, OpencodeAgent, OpencodeMessage, OpencodeModel, OpencodePart, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, QuestionRequest, RepoHit, SubscriptionStatus, TmuxWindow, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, OpencodeAgent, OpencodeMessage, OpencodeModel, OpencodePart, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, QuestionRequest, RepoHit, SubscriptionStatus, TmuxWindow, UpdateTarget, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 import type { VoiceNoteRecord } from "../shared/types";
 // Value import — `isClientTooOld` is the pure semver compare that drives
@@ -1114,58 +1114,31 @@ export type UpdateRowTone = "ok" | "action" | "muted" | "error";
 export type UpdateRow = { tone: UpdateRowTone; text: string };
 
 /**
- * Describe the desktop leg of an update check.
+ * Describe ONE update target for its row.
  *
- * `supported:false` deliberately maps to "muted", not "ok": an unpacked dev
- * build and a mobile client have no updater at all, and claiming they are "up
- * to date" would be a statement about something that was never checked.
- */
-export function describeDesktopUpdate(
-  r: { supported: boolean; available: boolean; version: string | null; error?: string } | null,
-): UpdateRow | null {
-  if (r == null) return null;
-  if (r.error) return { tone: "error", text: r.error };
-  if (!r.supported) return { tone: "muted", text: "Updates aren’t available in this build." };
-  if (r.available) {
-    return {
-      tone: "action",
-      text: r.version ? `Manta UI ${r.version} is available.` : "An update is available.",
-    };
-  }
-  return { tone: "ok", text: "Manta UI is up to date." };
-}
-
-/**
- * Describe the box leg of an update check.
+ * One function for every target. The old code had two bespoke functions
+ * (`describeDesktopUpdate` / `describeServerUpdate`) doing the same job for
+ * two targets; there are about to be six, so both are replaced by this single
+ * one keyed off the shared `UpdateTarget` shape.
  *
- * The server check resolves `{available:false}` both when the box is current
- * AND when the manifest fetch failed — `createUpdateCheck` swallows fetch
- * errors by design so a flaky feed can never crash the poller. That conflation
- * is invisible and acceptable for a background poll, but it means this row can
- * only ever claim "up to date" as the box's own best answer; `failed` is passed
- * separately by the caller when the RPC itself did not come back.
+ * Rules, in this exact order — the ordering IS the semantics:
+ *  - `!t.ok`       → error, "Couldn't check"
+ *  - `t.manual`    → muted, "Update manually"
+ *  - `t.available` → action, "Update available"
+ *  - else          → ok, "Up to date"
+ *
+ * The invariant that must survive: an unanswerable check is NEVER rendered as
+ * "ok". "Up to date" and "couldn't check" otherwise look identical — both are
+ * a sentence with no button — and a reassuring silence over a failed check is
+ * exactly how a permanently broken macOS updater passed for a healthy one. So
+ * `!ok` wins over everything, and `manual` (a dev build with no updater, or a
+ * CLI with no safe upgrade command) is "muted", never "ok".
  */
-export function describeServerUpdate(
-  r: { available: boolean; version?: string; ok?: boolean } | null,
-  opts: { failed?: boolean } = {},
-): UpdateRow | null {
-  // A genuine failure outranks any reading. Two ways to be here: the RPC that
-  // ran the check never came back (`failed`), or the box's check could not
-  // fetch the manifest (`ok === false`) — in BOTH cases the answer is "we
-  // can't know", NOT the reassuring green "you're up to date", which is what a
-  // swallowed manifest-fetch failure would otherwise render as.
-  if (opts.failed) return { tone: "error", text: "Couldn’t reach the box to check." };
-  if (r == null) return null;
-  if (r.ok === false) {
-    return { tone: "error", text: "Couldn’t check the box for updates right now." };
-  }
-  if (r.available) {
-    return {
-      tone: "action",
-      text: r.version ? `Box update ${r.version} is available.` : "A box update is available.",
-    };
-  }
-  return { tone: "ok", text: "The box is up to date." };
+export function describeUpdateTarget(t: UpdateTarget): UpdateRow {
+  if (!t.ok) return { tone: "error", text: "Couldn't check" };
+  if (t.manual) return { tone: "muted", text: "Update manually" };
+  if (t.available) return { tone: "action", text: "Update available" };
+  return { tone: "ok", text: "Up to date" };
 }
 
 // ===== Box self-update: transient network failure vs real failure =====

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -52,6 +52,7 @@ import {
   startVoiceSweep,
 } from "./voiceNotes.mjs";
 import { startServerUpdatePoller, createOpencodeUpdateForwarder } from "./serverUpdate.mjs";
+import { createCliDetector } from "./cliUpdates.mjs";
 import { runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { startSchedulePoller, createJob, listJobs, deleteJob } from "./schedule.mjs";
 import { startUsagePoller, recheckAdapterAtLimit, providerIDForAdapter, listSnapshots } from "./usage.mjs";
@@ -815,6 +816,12 @@ rpcHandlers = buildHandlers({
     typeof checkServerUpdate === "function"
       ? checkServerUpdate()
       : Promise.resolve({ available: false }),
+  // BET-1096 stage 2: the box-side CLI detector rides the existing
+  // `server:update-check` call, so the response gains the CLI targets (behind
+  // a timeout + try/catch in the handler — a CLI probe can never break the
+  // box-update check). 5-minute cached, in-flight-joining probe; no second
+  // poller, no new channel, no second bus event kind.
+  cliDetector: createCliDetector(),
   // BET-834: voice-note metadata over /rpc (audio goes over REST). Oldest
   // first, filtered by session, no audio bytes.
   voiceNotes: {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -265,6 +265,35 @@ export async function dispatch(handlers, channel, args) {
 //                         regression guard is pinned to it today).
 // Channel key strings MUST match IPC.* values in src/shared/types.ts.
 // Arg shapes MUST match what src/preload/index.ts packs per channel.
+
+// Hard cap on the CLI probe inside `server:update-check`. The detector's own
+// per-probe timeouts bound version reads, but `fetchLatest` has no AbortSignal
+// — a wedged network call could hang the whole click. Matches the renderer's
+// 15s server-leg timeout so the two can't disagree about what "a check that
+// just didn't answer" means.
+const CLI_PROBE_TIMEOUT_MS = 15_000;
+
+/**
+ * Bound a CLI-probe promise with a hard timeout. On expiry it REJECTS, which
+ * the `server:update-check` handler treats as "return without targets" — a CLI
+ * probe must never be able to break the box-update check.
+ */
+function withCliProbeTimeout(promise, timeoutMs) {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(() => reject(new Error("cli probe timeout")), timeoutMs);
+    promise.then(
+      (v) => {
+        clearTimeout(timer);
+        resolve(v);
+      },
+      (e) => {
+        clearTimeout(timer);
+        reject(e);
+      },
+    );
+  });
+}
+
 export function buildHandlers({
   tmux,
   oc,
@@ -278,6 +307,12 @@ export function buildHandlers({
   opencodeVersion,
   runServerSelfUpdate,
   checkServerUpdate = () => Promise.resolve({ available: false }),
+  // Box-side CLI update detector (BET-1096). Null when not wired — the
+  // `server:update-check` handler then returns the box verdict WITHOUT
+  // `targets`, exactly as an older box would.
+  cliDetector = null,
+  // Hard bound on the CLI probe, injectable for tests (defaults to 15s).
+  cliProbeTimeoutMs = CLI_PROBE_TIMEOUT_MS,
   delegate,
   progress,
   voiceNotes,
@@ -825,7 +860,23 @@ export function buildHandlers({
     // Injected via buildHandlers deps for the same reason as
     // runServerSelfUpdate: the poller owns the state and is wired in
     // src/server/index.mjs.
-    "server:update-check": () => checkServerUpdate(),
+    "server:update-check": async () => {
+      const result = await checkServerUpdate();
+      // BET-1096 stage 2: the CLI probe rides the call that already happens so
+      // the box-update check gains the box-side CLI targets without a second
+      // poller or channel. GUARDED: if detection throws or times out, return
+      // the payload WITHOUT `targets` rather than failing the whole check — a
+      // CLI probe must never be able to break the box-update check.
+      if (cliDetector) {
+        try {
+          const targets = await withCliProbeTimeout(cliDetector.detect(), cliProbeTimeoutMs);
+          if (Array.isArray(targets) && targets.length > 0) result.targets = targets;
+        } catch {
+          // Detection threw or timed out — return the box verdict untouched.
+        }
+      }
+      return result;
+    },
 
     // preload: ipcRenderer.invoke(IPC.opencodeDefaultModel)  → no args
     "opencode:default-model": () => oc.getDefaultModel(),

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -711,6 +711,55 @@ test("server:update-check defaults to 'no update' when the dep is not wired", as
   assert.deepEqual(await handlers["server:update-check"](), { available: false });
 });
 
+test("server:update-check attaches CLI `targets` from the cliDetector", async () => {
+  // BET-1096 stage 2: the box-update check gains the box-side CLI targets so
+  // the renderer can assemble ONE UpdateTarget list without a second call.
+  const { deps } = makeDeps([]);
+  deps.checkServerUpdate = async () => ({ available: false });
+  deps.cliDetector = {
+    detect: async () => [
+      { id: "opencode", label: "opencode", current: "1.0.0", latest: "1.1.0", available: true, ok: true, manual: false, disruption: "ends-turns" },
+    ],
+  };
+  const handlers = buildHandlers(deps);
+  const result = await handlers["server:update-check"]();
+  assert.equal(result.available, false);
+  assert.equal(result.targets.length, 1);
+  assert.equal(result.targets[0].id, "opencode");
+});
+
+test("server:update-check swallows a throwing cliDetector and keeps the box verdict", async () => {
+  // A CLI probe must NEVER break the box-update check. Detection throwing or
+  // timing out → the payload comes back WITHOUT `targets`, box verdict intact.
+  const { deps } = makeDeps([]);
+  deps.checkServerUpdate = async () => ({ available: true, version: "9.9.9" });
+  deps.cliDetector = { detect: async () => { throw new Error("probe exploded"); } };
+  const handlers = buildHandlers(deps);
+  const result = await handlers["server:update-check"]();
+  assert.deepEqual(result, { available: true, version: "9.9.9" });
+});
+
+test("server:update-check swallows a timing-out cliDetector and keeps the box verdict", async () => {
+  // The handler bounds the probe with a hard timeout. A probe that never
+  // resolves (wedged network fetch) must not hang the click — it is dropped.
+  const { deps } = makeDeps([]);
+  deps.checkServerUpdate = async () => ({ available: false });
+  deps.cliDetector = { detect: () => new Promise(() => {}) }; // never resolves
+  deps.cliProbeTimeoutMs = 20; // tiny bound for the test
+  const handlers = buildHandlers(deps);
+  const result = await handlers["server:update-check"]();
+  assert.deepEqual(result, { available: false });
+});
+
+test("server:update-check works with no cliDetector wired (older box)", async () => {
+  // buildHandlers must not require the dep: a non-wired detector is the same
+  // shape as an older box with no CLI probe — desktop + server only.
+  const { deps } = makeDeps([]);
+  deps.checkServerUpdate = async () => ({ available: false });
+  const handlers = buildHandlers(deps);
+  assert.deepEqual(await handlers["server:update-check"](), { available: false });
+});
+
 test("server:update-apply propagates runServerSelfUpdate's failure result through the RPC", async () => {
   // Defense-in-depth: when the spawn throws (script missing, no exec
   // bit, EACCES), the channel must surface that to the caller as

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -861,6 +861,39 @@ export type ServerUpdateCheck = {
   version?: string;
   notesUrl?: string | null;
   ok?: boolean;
+  // Box-side CLI update targets (BET-1096, stage 2 of the unified-update
+  // epic). Absent on an older box that predates the CLI probe — consumers
+  // must degrade to displaying just the fixed desktop + server targets.
+  // `available` above keeps its EXACT original meaning (the box SERVER has an
+  // update) — it is load-bearing for the existing poller, banner and push
+  // dedup, and must not be redefined to include the CLIs.
+  targets?: UpdateTarget[];
+};
+
+// Identity of one line in the unified update list (BET-1096). `desktop` and
+// `server` are always present; the four CLIs (opencode / claude / codex / kimi)
+// arrive from the box. `available` means an update exists AND we can apply it;
+// `ok:false` means we could not determine the state — NEVER render that as
+// "up to date". `manual` (no safe upgrade command, or a dev build with no
+// updater) surfaces as a link, not a button.
+export type UpdateTargetId =
+  | "desktop"
+  | "server"
+  | "opencode"
+  | "claude"
+  | "codex"
+  | "kimi";
+
+export type UpdateTarget = {
+  id: UpdateTargetId;
+  label: string; // "Manta UI" | "The box" | "opencode" | "Claude Code" | "Codex" | "Kimi Code"
+  current: string | null;
+  latest: string | null;
+  available: boolean; // an update exists AND we can apply it
+  ok: boolean; // false = we could not determine. NEVER render as up to date.
+  manual: boolean; // no safe upgrade command → link, not a button
+  manualUrl?: string;
+  disruption: "none" | "reconnect" | "ends-turns" | "app-restart";
 };
 
 // Result of an ON-DEMAND desktop update check (`autoUpdate:check`).

--- a/src/shared/updateTargets.d.mts
+++ b/src/shared/updateTargets.d.mts
@@ -1,0 +1,33 @@
+// Hand-written type declarations for updateTargets.mjs. Implementation is plain
+// JS so both the renderer and the server import it natively. Keep in sync with
+// src/shared/updateTargets.mjs.
+import type {
+  UpdateTarget,
+  DesktopUpdateCheck,
+  ServerUpdateCheck,
+} from "./types";
+
+export interface UpdateTargetSummary {
+  count: number;
+  names: string[];
+  disruptions: string[];
+}
+
+/**
+ * Build the canonical UpdateTarget[] from the two update-check results, in a
+ * fixed display order: desktop, server, opencode, then the remaining CLIs
+ * alphabetically by label.
+ */
+export function buildUpdateTargets(args: {
+  desktopCheck?: DesktopUpdateCheck | null;
+  serverCheck?: ServerUpdateCheck | null;
+  clientVersion?: string | null;
+  serverVersion?: string | null;
+}): UpdateTarget[];
+
+/**
+ * Summarize an update list: `count` of targets actually updatable, their
+ * `names` in display order, and the deduped set of their `disruptions`.
+ * `manual` targets never count.
+ */
+export function summarizeUpdates(targets: UpdateTarget[]): UpdateTargetSummary;

--- a/src/shared/updateTargets.mjs
+++ b/src/shared/updateTargets.mjs
@@ -1,0 +1,97 @@
+// updateTargets.mjs — ONE UpdateTarget list for the unified update banner and
+// the Settings → About list (BET-1096, stage 2 of the unified-update epic).
+//
+// Stage 1 (BET-1095) produced the box-side CLI catalog + detector. Before
+// this, the renderer assembled its update picture from two unrelated calls
+// with two unrelated shapes (DesktopUpdateCheck / ServerUpdateCheck) and
+// described each with its own bespoke function. That does not extend to six
+// targets. This module replaces it with a SINGLE UpdateTarget[] in a fixed
+// display order, so the same state always renders the same way — never sorted
+// by discovery or completion order.
+
+// Fixed labels and disruption values for the two non-CLI targets. The CLI ones
+// come from the catalog and ride through `serverCheck.targets` unchanged.
+const DESKTOP_FIXED = { label: "Manta UI", disruption: "app-restart" };
+const SERVER_FIXED = { label: "The box", disruption: "reconnect" };
+
+/**
+ * Build the canonical UpdateTarget[] from the two update-check results.
+ *
+ * Returns the list in this FIXED display order: `desktop`, `server`,
+ * `opencode`, then the remaining CLIs alphabetically by label. The order is a
+ * property of the function, never of the input order, so the same state never
+ * renders two different ways.
+ *
+ * Mapping rules, stated so there is nothing to decide:
+ *  - desktop: `available` = `desktopCheck.available`; `ok` = `!desktopCheck.error`;
+ *    `manual` = `desktopCheck.supported === false`. A dev build (no updater) is
+ *    `ok:true, available:false, manual:true` — rendered as "not applicable",
+ *    never "up to date".
+ *  - server: `available` = `serverCheck.available`; `ok` = `serverCheck.ok !== false`.
+ *  - CLIs: passed straight through from `serverCheck.targets`.
+ *
+ * @param {object} args
+ * @param {object|null} [args.desktopCheck] the DesktopUpdateCheck result
+ * @param {object|null} [args.serverCheck] the ServerUpdateCheck result
+ * @param {string|null} [args.clientVersion] the running desktop version
+ * @param {string|null} [args.serverVersion] the running box version
+ * @returns {Array<object>} UpdateTarget[] in fixed display order
+ */
+export function buildUpdateTargets({
+  desktopCheck = null,
+  serverCheck = null,
+  clientVersion = null,
+  serverVersion = null,
+} = {}) {
+  const desktop = {
+    id: "desktop",
+    label: DESKTOP_FIXED.label,
+    current: clientVersion ?? null,
+    latest: desktopCheck?.version ?? null,
+    available: desktopCheck?.available === true,
+    ok: !desktopCheck?.error,
+    manual: desktopCheck?.supported === false,
+    disruption: DESKTOP_FIXED.disruption,
+  };
+
+  const server = {
+    id: "server",
+    label: SERVER_FIXED.label,
+    current: serverVersion ?? null,
+    latest: serverCheck?.version ?? null,
+    available: serverCheck?.available === true,
+    ok: serverCheck?.ok !== false,
+    manual: false,
+    disruption: SERVER_FIXED.disruption,
+  };
+
+  const clis = Array.isArray(serverCheck?.targets) ? serverCheck.targets : [];
+
+  const opencode = clis.find((t) => t && t.id === "opencode");
+  const rest = clis
+    .filter((t) => t && t.id !== "opencode")
+    .slice()
+    .sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0));
+
+  return [desktop, server, ...(opencode ? [opencode] : []), ...rest];
+}
+
+/**
+ * Summarize an update list into the banner + confirm copy inputs (stage 3).
+ *
+ * `count` is how many targets have an update we can actually apply; `names`
+ * are those targets' labels in display order; `disruptions` is the deduped set
+ * of their disruption values. `manual` targets never count — a "update by hand"
+ * row must not read like something an "Update all" button is about to do.
+ *
+ * @param {Array<object>} targets UpdateTarget[]
+ * @returns {{ count: number, names: string[], disruptions: string[] }}
+ */
+export function summarizeUpdates(targets) {
+  const avail = (Array.isArray(targets) ? targets : []).filter(
+    (t) => t && t.available && !t.manual,
+  );
+  const names = avail.map((t) => t.label);
+  const disruptions = [...new Set(avail.map((t) => t.disruption).filter(Boolean))];
+  return { count: names.length, names, disruptions };
+}

--- a/src/shared/updateTargets.test.ts
+++ b/src/shared/updateTargets.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect } from "vitest";
+import type { UpdateTarget } from "./types";
+import { describeUpdateTarget } from "../renderer/chatUtils";
 import { buildUpdateTargets, summarizeUpdates } from "./updateTargets.mjs";
+
+const cli = (
+  id: UpdateTarget["id"],
+  label: string,
+  disruption: UpdateTarget["disruption"] = "none",
+): UpdateTarget => ({
+  id,
+  label,
+  current: null,
+  latest: null,
+  available: false,
+  ok: true,
+  manual: false,
+  disruption,
+});
 
 describe("buildUpdateTargets", () => {
   it("always emits desktop + server in that fixed order, in front of the CLIs", () => {
@@ -38,6 +55,10 @@ describe("buildUpdateTargets", () => {
     expect(desktop.ok).toBe(true);
     expect(desktop.available).toBe(false);
     expect(desktop.manual).toBe(true);
+    // A dev build is rendered as MUTED ("Update manually"), never "ok" — an
+    // unanswerable check must not read as a clean bill of health.
+    expect(describeUpdateTarget(desktop).tone).toBe("muted");
+    expect(describeUpdateTarget(desktop).tone).not.toBe("ok");
   });
 
   it("a failed desktop check is ok:false", () => {
@@ -101,16 +122,6 @@ describe("buildUpdateTargets", () => {
   });
 
   it("places opencode third and the remaining CLIs alphabetically by label", () => {
-    const cli = (id, label) => ({
-      id,
-      label,
-      current: null,
-      latest: null,
-      available: false,
-      ok: true,
-      manual: false,
-      disruption: "none",
-    });
     const result = buildUpdateTargets({
       desktopCheck: { supported: true, available: false, version: "0.0.36" },
       serverCheck: {
@@ -132,15 +143,12 @@ describe("buildUpdateTargets", () => {
   it("display order is stable regardless of input order", () => {
     // Shuffle both the CLI array and rely on the fixed legs always winning the
     // first two slots. The result must be identical every time.
-    const orderFor = (targets) =>
+    const orderFor = (targets: UpdateTarget[]) =>
       buildUpdateTargets({
         desktopCheck: { supported: true, available: false, version: "0.0.36" },
         serverCheck: { available: false, targets },
       }).map((t) => t.id);
 
-    const cli = (id, label) => ({
-      id, label, current: null, latest: null, available: false, ok: true, manual: false, disruption: "none",
-    });
     const a = [cli("codex", "Codex"), cli("opencode", "opencode"), cli("claude", "Claude Code")];
     const b = [cli("claude", "Claude Code"), cli("codex", "Codex"), cli("opencode", "opencode")];
     expect(orderFor(a)).toEqual(["desktop", "server", "opencode", "claude", "codex"]);
@@ -149,7 +157,12 @@ describe("buildUpdateTargets", () => {
 });
 
 describe("summarizeUpdates", () => {
-  const t = (id, available, manual = false, disruption = "none") => ({
+  const t = (
+    id: UpdateTarget["id"],
+    available: boolean,
+    manual = false,
+    disruption: UpdateTarget["disruption"] = "none",
+  ): UpdateTarget => ({
     id,
     label: id,
     current: null,
@@ -185,8 +198,8 @@ describe("summarizeUpdates", () => {
 
   it("dedupes disruption values", () => {
     const summary = summarizeUpdates([
-      t("a", true, false, "reconnect"),
-      t("b", true, false, "reconnect"),
+      t("claude", true, false, "reconnect"),
+      t("codex", true, false, "reconnect"),
     ]);
     expect(summary.disruptions).toEqual(["reconnect"]);
   });

--- a/src/shared/updateTargets.test.ts
+++ b/src/shared/updateTargets.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect } from "vitest";
+import { buildUpdateTargets, summarizeUpdates } from "./updateTargets.mjs";
+
+describe("buildUpdateTargets", () => {
+  it("always emits desktop + server in that fixed order, in front of the CLIs", () => {
+    const result = buildUpdateTargets({
+      desktopCheck: { supported: true, available: false, version: "0.0.36" },
+      serverCheck: { available: false },
+      clientVersion: "0.0.36",
+      serverVersion: "0.0.36",
+    });
+    expect(result.map((t) => t.id)).toEqual(["desktop", "server"]);
+  });
+
+  it("maps the desktop leg: available / ok / manual per the rules", () => {
+    const result = buildUpdateTargets({
+      desktopCheck: { supported: true, available: true, version: "0.0.37" },
+      serverCheck: { available: false },
+    });
+    const desktop = result[0];
+    expect(desktop).toMatchObject({
+      id: "desktop",
+      label: "Manta UI",
+      latest: "0.0.37",
+      available: true,
+      ok: true,
+      manual: false,
+      disruption: "app-restart",
+    });
+  });
+
+  it("a dev build (supported:false) is ok but manual:true — never available", () => {
+    const result = buildUpdateTargets({
+      desktopCheck: { supported: false, available: false, version: null },
+      serverCheck: { available: false },
+    });
+    const desktop = result[0];
+    expect(desktop.ok).toBe(true);
+    expect(desktop.available).toBe(false);
+    expect(desktop.manual).toBe(true);
+  });
+
+  it("a failed desktop check is ok:false", () => {
+    const result = buildUpdateTargets({
+      desktopCheck: {
+        supported: true,
+        available: false,
+        version: null,
+        error: "Couldn't check for updates.",
+      },
+      serverCheck: { available: false },
+    });
+    expect(result[0].ok).toBe(false);
+  });
+
+  it("maps the server leg: available and ok per the rules", () => {
+    const result = buildUpdateTargets({
+      desktopCheck: { supported: true, available: false, version: "0.0.36" },
+      serverCheck: { available: true, version: "0.0.37" },
+      serverVersion: "0.0.36",
+    });
+    const server = result[1];
+    expect(server).toMatchObject({
+      id: "server",
+      label: "The box",
+      current: "0.0.36",
+      latest: "0.0.37",
+      available: true,
+      ok: true,
+      manual: false,
+      disruption: "reconnect",
+    });
+  });
+
+  it("an absent server `ok` (older box) is treated as a successful check", () => {
+    const result = buildUpdateTargets({
+      desktopCheck: { supported: true, available: false, version: "0.0.36" },
+      serverCheck: { available: false },
+    });
+    expect(result[1].ok).toBe(true);
+  });
+
+  it("explicit server ok:false is propagated (check could not complete)", () => {
+    const result = buildUpdateTargets({
+      desktopCheck: { supported: true, available: false, version: "0.0.36" },
+      serverCheck: { available: false, ok: false },
+    });
+    expect(result[1].ok).toBe(false);
+  });
+
+  it("a serverCheck with no targets yields exactly desktop + server", () => {
+    // An OLDER box predates the CLI probe and has no `targets` at all. The
+    // unified list must degrade to exactly the two fixed targets, never crash.
+    const result = buildUpdateTargets({
+      desktopCheck: { supported: true, available: false, version: "0.0.36" },
+      serverCheck: { available: false },
+      clientVersion: "0.0.36",
+      serverVersion: "0.0.36",
+    });
+    expect(result.map((t) => t.id)).toEqual(["desktop", "server"]);
+  });
+
+  it("places opencode third and the remaining CLIs alphabetically by label", () => {
+    const cli = (id, label) => ({
+      id,
+      label,
+      current: null,
+      latest: null,
+      available: false,
+      ok: true,
+      manual: false,
+      disruption: "none",
+    });
+    const result = buildUpdateTargets({
+      desktopCheck: { supported: true, available: false, version: "0.0.36" },
+      serverCheck: {
+        available: false,
+        targets: [cli("kimi", "Kimi Code"), cli("opencode", "opencode"), cli("claude", "Claude Code"), cli("codex", "Codex")],
+      },
+    });
+    // desktop, server, opencode, then Claude Code / Codex / Kimi Code by label.
+    expect(result.map((t) => t.id)).toEqual([
+      "desktop",
+      "server",
+      "opencode",
+      "claude",
+      "codex",
+      "kimi",
+    ]);
+  });
+
+  it("display order is stable regardless of input order", () => {
+    // Shuffle both the CLI array and rely on the fixed legs always winning the
+    // first two slots. The result must be identical every time.
+    const orderFor = (targets) =>
+      buildUpdateTargets({
+        desktopCheck: { supported: true, available: false, version: "0.0.36" },
+        serverCheck: { available: false, targets },
+      }).map((t) => t.id);
+
+    const cli = (id, label) => ({
+      id, label, current: null, latest: null, available: false, ok: true, manual: false, disruption: "none",
+    });
+    const a = [cli("codex", "Codex"), cli("opencode", "opencode"), cli("claude", "Claude Code")];
+    const b = [cli("claude", "Claude Code"), cli("codex", "Codex"), cli("opencode", "opencode")];
+    expect(orderFor(a)).toEqual(["desktop", "server", "opencode", "claude", "codex"]);
+    expect(orderFor(b)).toEqual(["desktop", "server", "opencode", "claude", "codex"]);
+  });
+});
+
+describe("summarizeUpdates", () => {
+  const t = (id, available, manual = false, disruption = "none") => ({
+    id,
+    label: id,
+    current: null,
+    latest: null,
+    available,
+    ok: true,
+    manual,
+    disruption,
+  });
+
+  it("counts only available targets and returns their names in display order", () => {
+    const summary = summarizeUpdates([
+      t("desktop", false),
+      t("server", true, false, "reconnect"),
+      t("opencode", true, false, "ends-turns"),
+    ]);
+    expect(summary.count).toBe(2);
+    expect(summary.names).toEqual(["server", "opencode"]);
+    // Deduped set of disruption values.
+    expect(summary.disruptions).toEqual(["reconnect", "ends-turns"]);
+  });
+
+  it("manual targets never count, even when available", () => {
+    // A target that claims available but is manual must not be counted — an
+    // "Update all" button must only ever cover things it will actually do.
+    const summary = summarizeUpdates([
+      t("desktop", true, true, "app-restart"),
+      t("server", false),
+    ]);
+    expect(summary.count).toBe(0);
+    expect(summary.names).toEqual([]);
+  });
+
+  it("dedupes disruption values", () => {
+    const summary = summarizeUpdates([
+      t("a", true, false, "reconnect"),
+      t("b", true, false, "reconnect"),
+    ]);
+    expect(summary.disruptions).toEqual(["reconnect"]);
+  });
+});

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
Stage 2 of the unified-update epic (parent d4a884d6). Produces the ONE `UpdateTarget[]` payload the stage-3 banner and the About list will both read. No UI change beyond Settings' describe-call swap.

**Base: origin/main @ `d4864bd7`**

## Deliverables
1. **New `src/shared/updateTargets.mjs`** (pure, tested) — `buildUpdateTargets({desktopCheck, serverCheck, clientVersion, serverVersion})` → `UpdateTarget[]` in fixed order (desktop, server, opencode, remaining CLIs alphabetically by label), plus `summarizeUpdates(targets)` → `{count, names, disruptions}`.
2. **`ServerUpdateCheck.targets?`** — wired `createCliDetector` into the existing `server:update-check` handler (`src/server/rpc.mjs` + `index.mjs`). Guarded: detection throwing OR timing out (15s hard bound, injectable) returns the box verdict WITHOUT `targets`. `available` keeps its exact box-server meaning. No `cli:*` channels, no second poller, no second bus event.
3. **Deleted `describeDesktopUpdate` / `describeServerUpdate`** from `src/renderer/chatUtils.ts`, replaced with `describeUpdateTarget(t)`. `UpdateRow` type kept (Settings' `UpdateResultRow` still uses it). Settings compiles against a thin per-leg adapter until stage 3 unifies the list.

## Notes
- The two deleted describe-functions now exist only in comments (grep-verified).
- `UpdateTarget` / `UpdateTargetId` types live in `src/shared/types.ts` (the wire contract); `updateTargets.d.mts` re-exports them.
- Follow-ups: none filed — this stage intentionally leaves the stage-3 banner/list consumers (`src/shared/updateTargets` call sites, Settings list rendering) out of scope, as the issue specifies.

**Verification results:**
- PR branch (`multica/BET-1096-update-targets` @ `40954a7f`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9…a92f13`
  - test: exit 0. vitest 161 files / 3067 pass / 7 skip; node:test 2353 pass / 0 fail. Failures: none. log sha256: `b293b8ca…a44963a`
- Base (`main` @ `d4864bd7`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9…a92f13`
  - test: exit 0. vitest 160 files / 3061 pass / 7 skip; node:test 2349 pass / 0 fail. Failures: none. log sha256: `a597bf31…9ccdcb0`
- **Conclusion:** 0 new failures; +1 test file, +6 vitest tests, +4 node:test tests (all new coverage for this stage).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.