### PR TITLE
fix(renderer,server): let opencode auto-title chat sessions so first auto-rename is sensible (BET-1100)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -287,7 +287,7 @@ describe("ChatPanel session resources", () => {
           sessionName: "proj",
           windowIndex: 1,
           cwd: "/home/dev/projects/x",
-          title: "proj / cleared",
+          title: "",
         },
       ],
     ]);

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1550,7 +1550,10 @@ export function ChatPanel({
         sessionName: tmuxSession,
         windowIndex,
         cwd: cwd ?? "",
-        title: `${tmuxSession} / cleared`,
+        // Empty title so opencode auto-titles the fresh session from its next
+        // user message; seeding "workspace / cleared" would be read back by the
+        // auto-rename first-name path and stamp a workspace-prefixed name (BET-1100).
+        title: "",
       });
       // /clear carries the session's model forward so the user doesn't re-pick
       // after every clear; plan mode state is carried on top.

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -439,6 +439,12 @@ describe("findSessionTitle", () => {
     expect(findSessionTitle(sessions, "ses_no_title")).toBe("");
   });
 
+  it("returns a contraction title intact (no apostrophe stripping to a fragment) (BET-1100)", () => {
+    expect(findSessionTitle([{ id: "ses_im", title: "I'm just checking the setup" }], "ses_im")).toBe(
+      "I'm just checking the setup",
+    );
+  });
+
   it("returns '' for an empty / missing session list or id", () => {
     expect(findSessionTitle([], "ses_sky")).toBe("");
     expect(findSessionTitle(sessions, "")).toBe("");

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -477,9 +477,13 @@ export async function newSession({ name, cwd, windowName, createDir, chatMode, e
   // making a second one.
   const sid =
     existingSessionId ??
-    (await maybeCreateChatSession(
-      oc, chatMode, dir, `${name} / ${windowName ?? "default"}`, permission,
-    ));
+    // Pass an EMPTY title so opencode auto-generates the session's real title
+    // from its first user message. Seeding a compound `${name} / ${windowName}`
+    // title here disables opencode's auto-title and the BET-1018 auto-rename
+    // first-name path then reads that workspace-prefixed string back and
+    // renames the window to "workspace / fragment" (BET-1100). The tmux window
+    // name itself comes from `windowName` below, not from this title.
+    (await maybeCreateChatSession(oc, chatMode, dir, "", permission));
   const idx = await newSessionGetIndex(name, dir, windowName, !!chatMode);
   await applySessionSurvivability(name);
   if (sid) await restampSessionId(name, idx, sid);
@@ -506,9 +510,9 @@ export async function newWindow({ sessionName, windowName, cwd, chatMode, existi
   const dir = resolveCwdOrThrow(cwd);
   const sid =
     existingSessionId ??
-    (await maybeCreateChatSession(
-      oc, chatMode, dir, `${sessionName} / ${windowName}`, permission,
-    ));
+    // Empty title → opencode auto-titles from the first user message (BET-1100);
+    // see the newSession call for why the compound form poisons auto-rename.
+    (await maybeCreateChatSession(oc, chatMode, dir, "", permission));
   let idx;
   try {
     idx = await newWindowGetIndex(sessionName, windowName, dir, !!chatMode);

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -170,6 +170,10 @@ test("newWindow chatMode:true creates an opencode session AND stamps @manta-sess
   // (1) opencode session created in the window's cwd.
   assert.equal(oc.created.length, 1, "one opencode session created");
   assert.equal(oc.created[0].directory, cwd);
+  // (0) Empty title so opencode auto-titles from the first user message —
+  // a seeded "workspace / window" title is what the auto-rename first-name
+  // path would read back and stamp as "manta / im" (BET-1100).
+  assert.equal(oc.created[0].title, "", "chat session created with an empty title (no workspace-prefixed compound)");
   // (2) holder pane launched (sleep infinity) rather than the default shell.
   const newWin = cmds.find((c) => c.args.includes("new-window"));
   assert.ok(newWin, "new-window issued");
@@ -221,6 +225,7 @@ test("newSession chatMode:true creates an opencode session AND stamps @manta-ses
   }
   assert.equal(oc.created.length, 1, "one opencode session created");
   assert.equal(oc.created[0].directory, cwd);
+  assert.equal(oc.created[0].title, "", "chat session created with an empty title so opencode auto-titles (BET-1100)");
   const newSess = cmds.find((c) => c.args.includes("new-session"));
   assert.ok(newSess, "new-session issued");
   assert.ok(newSess.args.includes(CHAT_HOLDER_CMD), "holder cmd passed to new-session");

--- a/src/shared/streamInterpretation.test.ts
+++ b/src/shared/streamInterpretation.test.ts
@@ -1966,6 +1966,13 @@ describe("sanitizeGeneratedTitle", () => {
     );
   });
 
+  it("preserves a contraction's apostrophe — never strips 'I'm' to 'Im' (BET-1100)", () => {
+    expect(sanitizeGeneratedTitle("I'm just checking out the manta setup")).toBe(
+      "I'm just checking out the manta",
+    );
+    expect(sanitizeGeneratedTitle("I'm FIXING IT")).toBe("I'm FIXING IT");
+  });
+
   it("returns empty for null/blank (caller must skip the rename)", () => {
     expect(sanitizeGeneratedTitle(null)).toBe("");
     expect(sanitizeGeneratedTitle("   ")).toBe("");


### PR DESCRIPTION
## Root cause

A fresh chat window is created with an **initial tmux window name** derived from the first word of the user's prompt (`promptWindowName("I'm just …")` → `im`), AND the opencode session itself is created with a **non-empty title** `"${workspace} / ${windowName}"` (e.g. `manta / im`).

Because opencode is handed a non-empty title at `createSession`, it does **not** auto-generate its own title from the first user message — the session's `title` field stays `manta / im`. The BET-1018 auto-rename *first-name* path (`findSessionTitle` → rename) then reads that **compound, workspace-prefixed string** back and renames the window to `manta / im` on top of the initial `im`. Result: `im` → `manta / im` — not a sensible name, plus a second workspace-prefixed rename.

## Fix

Stop seeding a compound title so opencode auto-titles the session from its first user message (the premise BET-1018 relied on). The auto-rename first-name path now reads opencode's *real* generated title and renames the window once to a clean, correctly-punctuated short name.

- `src/server/tmux.mjs` — `newSession` / `newWindow` pass an **empty** title to `createSession` (was `${name} / ${windowName}` / `${sessionName} / ${windowName}`). The tmux window name is still set from `windowName`; this only stops poisoning the opencode session title.
- `src/renderer/ChatPanel.tsx` — `/clear` creates the fresh session with an empty title (was `${tmuxSession} / cleared`), same fix for the post-clear auto-rename.

No regression to existing behavior: `renameWindow` still skips empty (never blanks a window name), and re-titles still run on opencode's `title` agent (`generateSessionTitle` untouched).

## Tests

- `src/server/tmux.test.mjs` — chat `newWindow` / `newSession` now assert `createSession` receives an empty title (no `workspace / window` compound for the auto-rename to read back).
- `src/renderer/ChatPanel.harness.test.tsx` — `/clear` now expects `title: ""`.
- `src/shared/streamInterpretation.test.ts` — `sanitizeGeneratedTitle` preserves a contraction's apostrophe (`"I'm just checking the manta setup"` → keeps `I'm`, not `Im`).
- `src/renderer/chatUtils.test.ts` — `findSessionTitle` returns a contraction title intact (no apostrophe stripping to a fragment).

**Files changed:** `6` files (`src/server/tmux.mjs`, `src/server/tmux.test.mjs`, `src/renderer/ChatPanel.tsx`, `src/renderer/ChatPanel.harness.test.tsx`, `src/renderer/chatUtils.test.ts`, `src/shared/streamInterpretation.test.ts`).

**Verification results:**
- PR branch (`multica/BET-1100-fix-auto-rename-first-turn-name` @ `06cd541f`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, vitest **3063 passed / 7 skipped (160 files)**, node:test **2349 pass / 0 fail**. Failures: none.
- Base (`main` @ `d4864bd7`): unchanged server/tmux/renderer auto-rename logic; all failures resolved by this PR (none remaining).

**Conclusion:** 0 new failures; the only pre-existing unrelated diff is a test-regenerated `website/sitemap.xml` timestamp, which I reverted and excluded from the PR.

`Base: origin/main @ d4864bd7`

## Self-check (acceptance criteria)
- Fresh window first-turn name from opencode's session title, sensible + punctuated: **9/10** (pre-turn placeholder from `promptWindowName` is transient; the post-first-turn rename now uses opencode's real title).
- Only ONE rename after the first turn (no `workspace / title` second rename): **9/10** — compound title source removed from all three sites (newSession, newWindow, /clear).
- Never blank a window name: **10/10** (rename guard unchanged).
- Re-titles still on the `title` agent: **10/10** (`generateSessionTitle` untouched).
- Existing 5 `findSessionTitle` + 1 `generateSessionTitle` cases still pass: **10/10**.
- `npm run typecheck && npm test` green: **10/10**.
