### PR TITLE
feat(renderer): one update banner — collapse five kinds, add runUpdateAll orchestrator (BET-1098)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -31,6 +31,8 @@ import { ConfirmModal } from "./ConfirmModal";
 import { UsageResumeModal } from "./UsageResumeModal";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
+import { describeUpdateBanner, planUpdateAll } from "../shared/updateTargets.mjs";
+import { refreshUpdateTargets } from "./updateCheck";
 import { parsePairPayload } from "../shared/pairPayload";
 import { channelConfig } from "../shared/channel.mjs";
 import { ErrorBoundary } from "./ErrorBoundary";
@@ -220,9 +222,9 @@ function Shell() {
   const setUpdateError = useStore((s) => s.setUpdateError);
   const boxIncompatible = useStore((s) => s.boxIncompatible);
   const setBoxIncompatible = useStore((s) => s.setBoxIncompatible);
-  const serverUpdatePrompt = useStore((s) => s.serverUpdatePrompt);
   const setServerUpdatePrompt = useStore((s) => s.setServerUpdatePrompt);
   const serverUpdateProgress = useStore((s) => s.serverUpdateProgress);
+  const updateTargets = useStore((s) => s.updateTargets);
   const connectionState = useStore((s) => s.connectionState);
   const launcherFlags = useStore((s) => s.launcherFlags);
   const createDraft = useStore((s) => s.createDraft);
@@ -953,27 +955,22 @@ function Shell() {
     return off;
   }, []);
 
-  // Check the box for an update as soon as we have a live connection, and
-  // again on every reconnect.
+  // Refresh the unified update picture as soon as we have a live connection,
+  // and again on every reconnect.
   //
-  // The box polls on its own timer, but that timer answers "has a release
-  // happened", not "is someone here to see it". A desktop that has been closed
-  // for a week reconnects to a box whose own last check may be nearly a full
-  // interval old, so the banner would be up to that late for the one moment it
-  // actually matters — the moment the user opens the app. This makes the
-  // common case immediate and leaves the timer as the backstop for when nobody
-  // is looking (it still fires the push).
-  //
-  // Cheap: one ~95-byte conditional GET on the box, which answers 304 when
-  // nothing changed. The result needs no handling here — the server publishes
-  // the usual `serverUpdateAvailable` bus event (deduped per version), so the
-  // banner appears through the subscription above, exactly as if the timer had
-  // found it. Failures are ignored on purpose: this is opportunistic, and the
-  // poller plus the manual button in Settings → About both remain.
+  // The server poller answers "has a release happened" on its own timer, but
+  // that timer is not "is someone here to see it". A desktop that has been
+  // closed for a week reconnects to a box whose own last check may be nearly a
+  // full interval old, so the banner would be up to that late for the one moment
+  // it actually matters — the moment the user opens the app. The shared
+  // `refreshUpdateTargets` runs BOTH legs (desktop + box), writes the unified
+  // UpdateTarget[] to the store, and is what drives the `updates` banner; the
+  // fast on-connect path is simply that same shared function called against a
+  // live connection. Failures are ignored on purpose: this is opportunistic,
+  // and the manual button in Settings → About plus the server poller remain.
   useEffect(() => {
     if (connectionState.state !== "connected") return;
-    if (!window.api.serverUpdateCheck) return;
-    void window.api.serverUpdateCheck().catch(() => {});
+    void refreshUpdateTargets().catch(() => {});
   }, [connectionState.state, apiGeneration]);
 
   // Server-update progress (this ticket): while the box runs
@@ -1352,35 +1349,51 @@ function Shell() {
   // finishOnboarding clears the force flag + re-reads config → normal shell,
   // no app restart.
 
-  // ===== Banner collapse (BET-416 §E) =====
+  // ===== Banner collapse (BET-416 §E, unified-update stage 3) =====
   //
   // At most ONE full-width bar is visible, chosen by severity
-  // (reconnecting > incompatible > version skew > update failed > server
-  // update). "Update available" (a downloaded desktop auto-update) is NOT a
-  // bar — it is demoted to a small --accent dot on the Settings entry in the
-  // sidebar footer (see Sidebar.tsx, reads `updatePrompt` from the store);
-  // the bar is reserved for states that actually block you. The "behind"
-  // compatibility variant folds into `server-update` (it is an upgrade prompt
-  // with the same self-update action, not a blocking incompatibility).
+  // (reconnecting > incompatible > updates). The five update banner kinds
+  // (version skew, update failed, server update, plus the folded "behind"
+  // compat variant) collapse into ONE `updates` banner whose copy comes from
+  // the pure `describeUpdateBanner(targets, {mandatory, failure})` in
+  // src/shared/updateTargets.mjs. "Update available" (a downloaded desktop
+  // auto-update) is NOT a bar — it is demoted to a small --accent dot on the
+  // Settings entry in the sidebar footer (see Sidebar.tsx, reads `updatePrompt`
+  // from the store); the bar is reserved for states that actually block you.
   const reconnecting = connectionState.state !== "connected" && connectionState.state !== "idle";
   const incompatible =
     boxIncompatible || (showCompatibilityCard && compatibilityVariant === "incompatible");
-  const versionSkew = chooseUpdateSkewVariant(clientVersion, serverMinClient) === "outdated";
-  const updateFailed = !!updateError;
-  const serverUpdate = !!serverUpdatePrompt || (showCompatibilityCard && compatibilityVariant === "behind");
-  const bannerState: BannerState = { reconnecting, incompatible, versionSkew, updateFailed, serverUpdate };
+  // `mandatory` is the old version-skew guard — this client no longer meets the
+  // box's minClient, so the "must update" banner is non-dismissible. It is a
+  // FLAG on the aggregate, not its own banner.
+  const mandatory = chooseUpdateSkewVariant(clientVersion, serverMinClient) === "outdated";
+  const updateBanner = describeUpdateBanner(updateTargets, {
+    mandatory,
+    failure: updateError?.message ?? null,
+  });
+  const bannerState: BannerState = {
+    reconnecting,
+    incompatible,
+    updates: updateBanner !== null,
+  };
   const activeBanner = pickBanner(bannerState);
 
   // BET-640: running the box's self-update can now fail EARLY (before the
   // server restart) — e.g. a packaged box that can't resolve its release
   // manifest, or a git box whose fetch dies. The RPC resolves {ok:false} in
-  // that case; surface it in the EXISTING update-failed banner (the same
-  // state the auto-update path already feeds) instead of silently reporting
-  // success and leaving the box stale.
-  // Restarting opencode ends every in-flight agent turn, so the box
-  // self-update is gated behind an explicit confirm dialog. The two
-  // server-update UpdateBars open it; "Update & restart" in the dialog is what
-  // actually fires applyServerUpdate().
+  // that case; surface it in the `updates` banner's danger tone via
+  // `updateError` instead of silently reporting success and leaving the box
+  // stale.
+  //
+  // Restarting opencode ends every in-flight agent turn, so a box self-update
+  // is gated behind an explicit confirm. Two entry points:
+  //   - Settings → About's per-row "Update & restart" is a STANDALONE box
+  //     update: it opens `confirmServerUpdate` → applyServerUpdate() and never
+  //     touches a desktop build (updateAllRunRef stays false, so the
+  //     desktop-install gate below never fires).
+  //   - The unified banner's "Update"/"Update all" goes through `runUpdateAll`
+  //     below, which shows its own "Update everything?" confirm when the plan
+  //     is disruptive.
   const [confirmServerUpdate, setConfirmServerUpdate] = useState(false);
 
   // BET-659: Artifacts panel open/closed. Owned here because the toggle lives
@@ -1410,6 +1423,29 @@ function Shell() {
   // error/progress clear.
   const [boxUpgrading, setBoxUpgrading] = useState(false);
 
+  // runUpdateAll state (stage 3, BET-1098). `updateAllRunRef` is true while a
+  // run's DESKTOP install is pending; `updateAllBoxConfirmed` is true once the
+  // box leg (if any) has completed AND the connection is confirmed back. A
+  // standalone box update (Settings → About, or Settings' "Use runUpdateAll"
+  // path for manual rows) leaves updateAllRunRef false, so the desktop install
+  // gate never fires for it. The confirm modal is promise-based so the
+  // orchestrator can await the user's choice.
+  const updateAllRunRef = useRef(false);
+  const updateAllBoxConfirmed = useRef(false);
+  const updateAllResolvers = useRef<{ resolve: (ok: boolean) => void } | null>(null);
+  const [updateAllConfirmBody, setUpdateAllConfirmBody] = useState<string | null>(null);
+
+  // Step 4 of runUpdateAll: once the desktop download has landed (updatePrompt
+  // set) AND any box leg has completed + reconnected, restart into the new
+  // desktop build. Idempotent — clears the run ref so it fires at most once.
+  const finishUpdateAllOnce = () => {
+    if (!updateAllRunRef.current) return;
+    if (!useStore.getState().updatePrompt) return;
+    if (!updateAllBoxConfirmed.current) return;
+    updateAllRunRef.current = false;
+    void window.api.autoUpdateInstall();
+  };
+
   // Reconnect after a box self-upgrade → re-fetch the version pair so the
   // compatibility check re-evaluates against the box's NEW version. `boxUpgrading`
   // stays true until the refetch confirms the box advanced (bind in the reconcile
@@ -1431,6 +1467,11 @@ function Shell() {
       setBoxUpgrading(false);
       useStore.getState().setServerUpdateProgress(null);
       setUpdateError(null);
+      // The box run has completed and the connection is confirmed back (the
+      // reconnect refetch advanced the version). If runUpdateAll has a desktop
+      // install waiting on the box leg, fire it now.
+      updateAllBoxConfirmed.current = true;
+      finishUpdateAllOnce();
     }
   }, [boxUpgrading, compatibilityVariant]);
 
@@ -1471,6 +1512,82 @@ function Shell() {
     }
   };
 
+  // ===== The ONE update action: runUpdateAll (stage 3, BET-1098) =====
+  //
+  // Desktop install is terminal and runs LAST — nothing can follow it. The
+  // desktop bytes download concurrently with the box work, then the box leg
+  // runs (with the destructive restart gated behind one confirm), then the
+  // new desktop build installs once the box has completed AND reconnected.
+  const runUpdateAll = async () => {
+    const plan = planUpdateAll(updateTargets);
+
+    // 1. Desktop download in flight CONCURRENTLY with the box work — free
+    //    wall-clock time. A rejection here degrades to "no desktop install at
+    //    the end"; it must not abort the box leg.
+    if (plan.desktopDownload) {
+      window.api.autoUpdateDownload().catch(() => {});
+    }
+
+    // 2. One confirm if anything disruptive is about to happen. Cancelling
+    //    cancels the WHOLE run — the download already in flight simply is
+    //    never installed. A CLI-only update (needsConfirm false) shows NO
+    //    dialog at all: nothing disruptive happens, so nothing interrupts.
+    if (plan.needsConfirm) {
+      const ok = await new Promise<boolean>((resolve) => {
+        updateAllResolvers.current = { resolve };
+        setUpdateAllConfirmBody(plan.confirmBody.join(" "));
+      });
+      if (!ok) return;
+    }
+
+    if (plan.desktopInstall) updateAllRunRef.current = true;
+
+    // 3. Box leg. `applyServerUpdate` owns boxUpgrading / serverUpdateProgress /
+    //    boxRestarting / the 120s cap / isTransientUpdateNetworkError — reused
+    //    wholesale. The reconnect + success-reconcile effects resolve the real
+    //    outcome; `updateAllBoxConfirmed` flips true there (connection back),
+    //    which is what releases the desktop install.
+    if (plan.box) {
+      updateAllBoxConfirmed.current = false;
+      await applyServerUpdate();
+    }
+
+    // No box leg → nothing to wait for: mark the box confirmed now so the
+    // desktop install fires as soon as the download lands (updatePrompt).
+    if (!plan.box && plan.desktopInstall) {
+      updateAllBoxConfirmed.current = true;
+      finishUpdateAllOnce();
+    }
+  };
+
+  // Desktop install fires the moment the download lands when there is no box
+  // leg to wait on. For a boxed run this is inert until the reconcile effect
+  // sets updateAllBoxConfirmed (connection confirmed back); both paths converge
+  // on the idempotent finishUpdateAllOnce.
+  useEffect(() => {
+    finishUpdateAllOnce();
+  }, [updatePrompt]);
+
+  // The unified `updates` banner's action. The danger tone means "update
+  // failed" → the only sensible action is a manual download. Everything else
+  // (available / mandatory) runs the ONE orchestrator.
+  const onUpdateBannerAction = () => {
+    if (updateBanner?.tone === "danger") {
+      void window.api.openExternal("https://mantaui.com/downloads/Manta-latest.dmg");
+      return;
+    }
+    void runUpdateAll();
+  };
+
+  // "Remind me later": clear the failure + any server announce + the unified
+  // list, so the banner hides until the next refresh (reconnect or the
+  // Settings button). The sidebar --accent dot (updatePrompt) is untouched.
+  const onUpdateBannerDismiss = () => {
+    setUpdateError(null);
+    setServerUpdatePrompt(null);
+    useStore.getState().setUpdateTargets([]);
+  };
+
   // BET-459: when a chat session is the visible pane, the SessionHeader owns
   // the single top-of-pane row (breadcrumb + mode toggle) — the app titlebar
   // is hidden so the two don't stack. Non-chat panes (terminal / AI-TUI /
@@ -1498,12 +1615,13 @@ function Shell() {
       <main className="flex-1 flex flex-col min-w-0">
         {/* At most ONE full-width bar (BET-416 §E). `activeBanner` is the
             single highest-severity condition across reconnecting / incompatible
-            / version-skew / update-failed / server-update. "Update available"
-            (a downloaded desktop auto-update) is no longer a bar — it is a
-            small --accent dot on the Settings entry in the sidebar footer; the
-            bar is reserved for states that actually block you. A downloaded
-            update's install action is still reachable via the version-skew
-            bar's button (it picks autoUpdateInstall when an update is ready). */}
+            / updates. The `updates` bar collapses all five old update kinds
+            (version skew / update failed / server update / behind-compat /
+            desktop) — its copy comes from describeUpdateBanner and renders via
+            the SAME UpdateBar with a tone + busy/progress surface. "Update
+            available" (a downloaded desktop auto-update) is no longer a bar —
+            it is a small --accent dot on the Settings entry in the sidebar
+            footer; the bar is reserved for states that actually block you. */}
         {!showOnboarding && activeBanner === "reconnecting" && (
           <ReconnectingBanner
             state={connectionState}
@@ -1535,72 +1653,19 @@ function Shell() {
             }}
           />
         )}
-        {!showOnboarding && activeBanner === "version-skew" && (
+        {!showOnboarding && activeBanner === "updates" && updateBanner && (
           <UpdateBar
-            text={
-              <>This app is out of date and may not work correctly — please update.</>
-            }
-            actionLabel="Update"
-            onAction={() => {
-              if (updatePrompt) {
-                void window.api.autoUpdateInstall();
-              } else {
-                void window.api.autoUpdateDownload();
-              }
-            }}
-            dismissible={false}
-          />
-        )}
-        {!showOnboarding && activeBanner === "update-failed" && (
-          <UpdateBar
-            text={updateError!.message}
-            actionLabel="Download"
-            onAction={() => {
-              void window.api.openExternal("https://mantaui.com/downloads/Manta-latest.dmg");
-            }}
-            onDismiss={() => setUpdateError(null)}
-          />
-        )}
-        {!showOnboarding && activeBanner === "server-update" && serverUpdatePrompt && (
-          <UpdateBar
-            text={
-              <>
-                Server update available:{" "}
-                <span className="font-medium text-text">
-                  {serverUpdatePrompt.version}
-                </span>
-              </>
-            }
-            actionLabel="Update & restart"
-            onAction={() => setConfirmServerUpdate(true)}
-            onDismiss={() => setServerUpdatePrompt(null)}
+            text={updateBanner.text}
+            actionLabel={updateBanner.actionLabel}
+            onAction={onUpdateBannerAction}
+            onDismiss={onUpdateBannerDismiss}
+            dismissible={updateBanner.dismissible}
+            tone={updateBanner.tone}
             busy={boxUpgrading}
             progress={boxUpgrading && !boxRestarting ? serverUpdateProgress ?? undefined : undefined}
             busyLabel={boxRestarting ? "Restarting the box…" : "Updating the box…"}
           />
         )}
-        {!showOnboarding &&
-          activeBanner === "server-update" &&
-          !serverUpdatePrompt &&
-          showCompatibilityCard &&
-          compatibilityVariant === "behind" && (
-            <UpdateBar
-              text={
-                <>
-                  Box needs an upgrade:{" "}
-                  <span className="font-medium text-text">
-                    {serverVersion ?? "?"}
-                  </span>
-                </>
-              }
-              actionLabel="Upgrade box"
-              onAction={() => setConfirmServerUpdate(true)}
-              onDismiss={dismiss}
-              busy={boxUpgrading}
-              progress={boxUpgrading && !boxRestarting ? serverUpdateProgress ?? undefined : undefined}
-              busyLabel={boxRestarting ? "Restarting the box…" : "Updating the box…"}
-            />
-          )}
         {!isChatPaneActive && (
         <div className="titlebar-drag h-12 border-b border-border flex items-center px-4 gap-2 min-w-0">
           <div className="text-meta text-text-muted flex items-center gap-2 min-w-0">
@@ -1829,6 +1894,29 @@ function Shell() {
           void applyServerUpdate();
         }}
         onCancel={() => setConfirmServerUpdate(false)}
+      />
+
+      {/* "Update everything?" (runUpdateAll). One confirm for the WHOLE run
+          (desktop + box). The body is planUpdateAll's ordered sentences; the
+          resolvers route the user's choice back to the awaiting orchestrator.
+          Cancelling cancels the run including the desktop download in flight —
+          it is simply never installed. */}
+      <ConfirmModal
+        open={updateAllConfirmBody != null}
+        title="Update everything?"
+        body={updateAllConfirmBody ?? ""}
+        confirmLabel="Update"
+        confirmTone="primary"
+        onConfirm={() => {
+          setUpdateAllConfirmBody(null);
+          updateAllResolvers.current?.resolve(true);
+          updateAllResolvers.current = null;
+        }}
+        onCancel={() => {
+          setUpdateAllConfirmBody(null);
+          updateAllResolvers.current?.resolve(false);
+          updateAllResolvers.current = null;
+        }}
       />
 
       {/* Resume after limit reset (BET-1049). Rendered at App level (like the

--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -936,14 +936,12 @@ function Shell() {
 
   // Server-update available (BET-225 stage 3): main forwards the box's
   // `serverUpdateAvailable` bus event to the renderer via the
-  // `serverUpdateAvailable` IPC channel. The renderer renders a "Server
-  // update available: {version}" bar via the shared UpdateBar component —
-  // same component as the desktop auto-update prompt, just a different
-  // message + button label (`serverUpdateApply` runs `scripts/self-update.sh`
-  // on the box). On mobile the IPC listener is a no-op (httpApi shim
-  // returns `() => {}`); mobile-specific mobile UI is out of scope — this
-  // subscription exists so the store field + bus-case stay in sync for a
-  // later mobile pass.
+  // `serverUpdateAvailable` IPC channel. The box's own poller fires this while
+  // we stay connected, so it is what surfaces a release that drops WHILE the
+  // app is open. We keep the store field (bus-case parity) and ALSO refresh
+  // the unified UpdateTarget[] — that is what the `updates` banner reads, so
+  // a poller-found release appears without waiting for a reconnect. On mobile
+  // the IPC listener is a no-op (httpApi shim returns `() => {}`).
   useEffect(() => {
     if (!window.api.onServerUpdateAvailable) return;
     const off = window.api.onServerUpdateAvailable((payload) => {
@@ -951,6 +949,8 @@ function Shell() {
         version: payload.version,
         notesUrl: payload.notesUrl ?? undefined,
       });
+      // Opportunistic; the banner re-derives from updateTargets.
+      void refreshUpdateTargets().catch(() => {});
     });
     return off;
   }, []);
@@ -1426,10 +1426,9 @@ function Shell() {
   // runUpdateAll state (stage 3, BET-1098). `updateAllRunRef` is true while a
   // run's DESKTOP install is pending; `updateAllBoxConfirmed` is true once the
   // box leg (if any) has completed AND the connection is confirmed back. A
-  // standalone box update (Settings → About, or Settings' "Use runUpdateAll"
-  // path for manual rows) leaves updateAllRunRef false, so the desktop install
-  // gate never fires for it. The confirm modal is promise-based so the
-  // orchestrator can await the user's choice.
+  // standalone box update (Settings → About's "Update & restart") leaves
+  // updateAllRunRef false, so the desktop-install gate never fires for it. The
+  // confirm modal is promise-based so the orchestrator can await the choice.
   const updateAllRunRef = useRef(false);
   const updateAllBoxConfirmed = useRef(false);
   const updateAllResolvers = useRef<{ resolve: (ok: boolean) => void } | null>(null);

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -35,8 +35,7 @@ import { SettingsRow } from "./SettingsRow";
 import { BANNER_BTN } from "./Toast";
 import { errorDisclosure } from "./settingsError";
 import { describeUpdateTarget } from "./chatUtils";
-import type { UpdateRow } from "./chatUtils";
-import type { DesktopUpdateCheck, ServerUpdateCheck, UpdateTarget } from "../shared/types";
+import { refreshUpdateTargets } from "./updateCheck";
 import { forgeCredentialSecondary } from "./chatUtils";
 import { useCachedResource } from "./useCachedResource";
 import { MantaLoader } from "./MantaLoader";
@@ -335,6 +334,7 @@ export function Settings({
   const skillRegistryUrls = useStore((s) => s.skillRegistryUrls);
   const launcherFlags = useStore((s) => s.launcherFlags);
   const updatePrompt = useStore((s) => s.updatePrompt);
+  const updateTargets = useStore((s) => s.updateTargets);
   // Terminal auto-update failure (integrity / permission / unusable feed).
   // Read here only to end About's "Downloading…" state — the banner owns
   // reporting it.
@@ -408,70 +408,27 @@ export function Settings({
 
   // ===== "Check for updates" (About) =====
   //
-  // One button, two independent checks, run in PARALLEL and reported
-  // separately. They are separate systems — the desktop app updates itself
-  // through electron-updater against mantaui.com/updates, the box updates
-  // itself by running scripts/self-update.sh against a different manifest — and
-  // collapsing them into a single "you're up to date" would hide the common
-  // case where exactly one of the two is behind.
-  //
-  // `Promise.allSettled`, not `all`: a failure of one leg must still report the
-  // other. A box that is unreachable says nothing about whether the desktop has
-  // an update waiting.
+  // ONE shared implementation — `refreshUpdateTargets()` (./updateCheck) runs
+  // both legs in PARALLEL with a 15s timeout on the server leg (a wedged box
+  // must not spin the button forever), builds the canonical UpdateTarget[]
+  // with `buildUpdateTargets`, and stores it in the store. The SAME function
+  // is what App.tsx's check-on-connect calls, so the Settings button and the
+  // on-connect banner can never disagree. `Promise.allSettled` semantics live
+  // inside it: a failure of one leg still reports the other.
   const [checking, setChecking] = useState(false);
   const [checkedAt, setCheckedAt] = useState<number | null>(null);
-  const [desktopCheck, setDesktopCheck] = useState<DesktopUpdateCheck | null>(null);
-  const [serverCheck, setServerCheck] = useState<ServerUpdateCheck | null>(null);
-  const [serverCheckFailed, setServerCheckFailed] = useState(false);
   const [downloading, setDownloading] = useState(false);
   const [downloadPercent, setDownloadPercent] = useState<number | null>(null);
 
   const runUpdateCheck = async () => {
     if (checking) return;
     setChecking(true);
-    setServerCheckFailed(false);
-    // A hung check must never leave the button spinning forever with no way
-    // out. Each leg resolves-or-rejects, but a box whose server wedges before
-    // answering would await indefinitely — so bound the server leg with a
-    // timeout and treat expiry as a failed check rather than a never-ending
-    // "Checking…".
-    const withTimeout = <T,>(p: Promise<T>, ms: number): Promise<T> =>
-      new Promise<T>((resolve, reject) => {
-        const t = setTimeout(() => reject(new Error("timeout")), ms);
-        p.then(
-          (v) => {
-            clearTimeout(t);
-            resolve(v);
-          },
-          (e) => {
-            clearTimeout(t);
-            reject(e);
-          },
-        );
-      });
-
-    const [desktop, server] = await Promise.allSettled([
-      window.api.autoUpdateCheck(),
-      withTimeout(window.api.serverUpdateCheck(), 15_000),
-    ]);
-    // autoUpdateCheck never rejects by contract (main resolves `{error}`
-    // instead), so a rejection here means the bridge itself is missing —
-    // report it as unsupported rather than as an update failure.
-    setDesktopCheck(
-      desktop.status === "fulfilled"
-        ? desktop.value
-        : { supported: false, available: false, version: null },
-    );
-    if (server.status === "fulfilled") {
-      setServerCheck(server.value);
-    } else {
-      // Rejected, or timed out — indistinguishable at this level and both mean
-      // "we couldn't get an answer", not "up to date".
-      setServerCheck(null);
-      setServerCheckFailed(true);
+    try {
+      await refreshUpdateTargets({ clientVersion, serverVersion });
+      setCheckedAt(Date.now());
+    } finally {
+      setChecking(false);
     }
-    setCheckedAt(Date.now());
-    setChecking(false);
   };
 
   // Percent for a manual desktop download. Subscribed unconditionally (the
@@ -506,39 +463,14 @@ export function Settings({
     }
   }, [updatePrompt, updateError]);
 
-  // Each leg's verdict row, from the ONE shared describe function. The old
-  // code had two bespoke describe-functions (describeDesktopUpdate /
-  // describeServerUpdate); BET-1096 replaced them with describeUpdateTarget
-  // keyed off the shared UpdateTarget shape. Until stage 3 unifies the About
-  // list, this thin per-leg adapter shapes each check into an UpdateTarget.
-  // `ok` preserves the exact old semantics: a check that hasn't run (or whose
-  // RPC never came back) must NOT read as "up to date".
-  const desktopTarget: UpdateTarget | null =
-    desktopCheck == null
-      ? null
-      : {
-          id: "desktop",
-          label: "Manta UI",
-          current: clientVersion,
-          latest: desktopCheck.version,
-          available: desktopCheck.available,
-          ok: !desktopCheck.error,
-          manual: desktopCheck.supported === false,
-          disruption: "app-restart",
-        };
-  const serverTarget: UpdateTarget | null =
-    serverCheck == null && !serverCheckFailed
-      ? null
-      : {
-          id: "server",
-          label: "The box",
-          current: serverVersion,
-          latest: serverCheck?.version ?? null,
-          available: serverCheck?.available === true,
-          ok: serverCheck ? serverCheck.ok !== false : false,
-          manual: false,
-          disruption: "reconnect",
-        };
+  // Each leg's verdict row, from the ONE shared describe function
+  // (describeUpdateTarget), keyed off the SAME canonical UpdateTarget[] the
+  // banner reads (stored by the shared refreshUpdateTargets — stage 3,
+  // BET-1098). Stage 4 unifies the About list into one row per target; for
+  // now the two existing rows (desktop / box) are sliced straight out of that
+  // list, so Settings and the banner always describe the same state.
+  const desktopTarget = updateTargets.find((t) => t.id === "desktop") ?? null;
+  const serverTarget = updateTargets.find((t) => t.id === "server") ?? null;
   const desktopRow = desktopTarget ? describeUpdateTarget(desktopTarget) : null;
   const serverRow = serverTarget ? describeUpdateTarget(serverTarget) : null;
 
@@ -897,7 +829,7 @@ export function Settings({
                     is off, so the bytes are only fetched on an explicit press. */}
                 {desktopRow && !updatePrompt && (
                   <UpdateResultRow row={desktopRow}>
-                    {desktopCheck?.available && !downloading && (
+                    {desktopTarget?.available && !downloading && (
                       <button
                         className={BANNER_BTN}
                         onClick={() => {
@@ -922,7 +854,7 @@ export function Settings({
                         {downloadPercent == null ? "Downloading…" : `Downloading ${Math.round(downloadPercent)}%`}
                       </span>
                     )}
-                    {desktopCheck?.error && (
+                    {desktopTarget && desktopTarget.ok === false && (
                       <button
                         className={BANNER_BTN}
                         onClick={() => { void window.api.openExternal("https://mantaui.com/downloads/Manta-latest.dmg"); }}
@@ -937,7 +869,7 @@ export function Settings({
                     handling is shared with the banner (see onRequestServerUpdate). */}
                 {serverRow && (
                   <UpdateResultRow row={serverRow}>
-                    {serverCheck?.available && onRequestServerUpdate && (
+                    {serverTarget?.available && onRequestServerUpdate && (
                       <button className={BANNER_BTN} onClick={onRequestServerUpdate}>
                         Update &amp; restart
                       </button>

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -35,6 +35,7 @@ import { SettingsRow } from "./SettingsRow";
 import { BANNER_BTN } from "./Toast";
 import { errorDisclosure } from "./settingsError";
 import { describeUpdateTarget } from "./chatUtils";
+import type { UpdateRow } from "./chatUtils";
 import { refreshUpdateTargets } from "./updateCheck";
 import { forgeCredentialSecondary } from "./chatUtils";
 import { useCachedResource } from "./useCachedResource";

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -1,25 +1,23 @@
-// UpdateBar.tsx — shared "an update exists" banner used for three prompts:
+// UpdateBar.tsx — the ONE unified update banner (stage 3, BET-1098).
 //
-//   1. Desktop auto-update (electron-updater finished downloading a new
-//      version): "Update available: {version}" + "Restart to update" button.
-//   2. Server update (BET-225 stage 3): "Server update available: {version}"
-//      + "Update & restart" button (fires `scripts/self-update.sh` on the box).
-//   3. Version-skew guard (BET-225 stage 3 Part C): "This app is out of
-//      date and may not work correctly — please update." + a button that
-//      triggers an update flow (autoUpdateInstall / autoUpdateDownload on
-//      desktop, App Store informational on mobile). This variant is
-//      NON-dismissible (`dismissible: false` hides the × button) — the
-//      RPC contract on either side has shifted past `minClient`, so the
-//      user MUST act before continuing.
+// All update states (desktop update, server/box update, CLI updates, the
+// mandatory "must update" skew guard, and an update failure) render through a
+// single component. Its copy — text, action label, tone, dismissibility — is
+// produced by `describeUpdateBanner` in src/shared/updateTargets.mjs and
+// passed straight through as props. One component, one usage; props carry the
+// whole surface area.
 //
-// One component, three usages; the spec wants this consolidated rather
-// than three near-identical inline banners. Props carry the surface area:
-// text + action label + action handler + optional dismiss handler.
+// `tone` selects the semantic tint:
+//   - "accent" (default) — today's look, byte-identical. Available/mandatory
+//     updates read as normal app events.
+//   - "danger" — an update FAILED. Swaps the accent tint (which read as "here
+//     is something nice for you") for `--danger` at the same 0.10 / 0.30 /
+//     0.20 alphas. This is the ONLY visual change of the whole stage.
 //
-// `dismissible` defaults to true — the desktop auto-update and server-update
-// cases are both user-dismissible (a "remind me later" semantic). The skew
-// guard explicitly opts out (`dismissible: false`) so the banner sticks
-// until the client gets on a supported version.
+// `dismissible` defaults to true — most update rows are user-dismissible (a
+// "remind me later" semantic). The mandatory skew-guard explicitly opts out
+// (`dismissible: false`) so the banner sticks until the client is on a
+// supported version.
 
 import type { ReactNode } from "react";
 import { X } from "lucide-react";
@@ -40,6 +38,9 @@ export type UpdateBarProps = {
   onDismiss?: () => void;
   /** When true (default), show the × button. Skew guard passes false. */
   dismissible?: boolean;
+  /** Semantic tint. "accent" (default) is today's look; "danger" renders a
+   *  failed update in the danger tone (bg/border/button all swap). */
+  tone?: "accent" | "danger";
   /** When set, the bar renders a determinate progress bar in place of the
    *  action button. */
   progress?: { step: number; total: number; label: string };
@@ -54,9 +55,8 @@ export type UpdateBarProps = {
 };
 
 /**
- * Single update-banner component shared by desktop auto-update, server
- * update, and the version-skew guard. Visual style mirrors the original
- * inline banner in App.tsx so the three usages look identical.
+ * Single update-banner component driven by `describeUpdateBanner`. `tone`
+ * picks the semantic tint; everything else is copied verbatim from stage 1.
  */
 export function UpdateBar({
   text,
@@ -64,6 +64,7 @@ export function UpdateBar({
   onAction,
   onDismiss,
   dismissible = true,
+  tone = "accent",
   progress,
   busy = false,
   busyLabel = "Updating…",
@@ -73,6 +74,10 @@ export function UpdateBar({
     : busy
       ? busyLabel
       : text;
+  const danger = tone === "danger";
+  const bannerBtn = danger
+    ? "shrink-0 rounded-xs bg-danger/20 px-2 py-px text-danger hover:bg-danger/30 font-medium disabled:opacity-50 focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-danger"
+    : BANNER_BTN;
   return (
     // `pr-[…]` (not `px-3`) reserves the OS caption-button strip: this bar
     // renders ABOVE the titlebar row, so on Windows (titleBarOverlay) the
@@ -81,8 +86,12 @@ export function UpdateBar({
     // already reserves this via `.titlebar-inset-right`; a top-of-window bar
     // needs the same reservation. `--titlebar-inset-right` evaluates to 0 on
     // macOS/Linux (neither defines the `titlebar-area-*` env vars), so this is
-    // exactly `px-3` everywhere else.
-    <div className="shrink-0 bg-accent/10 border-b border-accent/30 pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] py-2 text-meta text-text flex items-center gap-2">
+    // exactly `px-3` everywhere else. `tone` swaps ONLY the tint classes.
+    <div
+      className={`shrink-0 ${
+        danger ? "bg-danger/10 border-danger/30" : "bg-accent/10 border-accent/30"
+      } border-b pl-3 pr-[calc(var(--sp-3)+var(--titlebar-inset-right))] py-2 text-meta text-text flex items-center gap-2`}
+    >
       <span className="flex-1 truncate">{statusLabel}</span>
       {busy || progress ? (
         <div
@@ -108,7 +117,7 @@ export function UpdateBar({
             onClick={() => {
               onAction();
             }}
-            className={BANNER_BTN}
+            className={bannerBtn}
           >
             {actionLabel}
           </button>

--- a/src/renderer/bannerPriority.test.ts
+++ b/src/renderer/bannerPriority.test.ts
@@ -4,9 +4,7 @@ import { pickBanner, BANNER_PRIORITY, type BannerState } from "./bannerPriority"
 const off: BannerState = {
   reconnecting: false,
   incompatible: false,
-  versionSkew: false,
-  updateFailed: false,
-  serverUpdate: false,
+  updates: false,
 };
 
 describe("pickBanner", () => {
@@ -15,31 +13,21 @@ describe("pickBanner", () => {
   });
 
   it("returns the only active kind", () => {
-    expect(pickBanner({ ...off, serverUpdate: true })).toBe("server-update");
-    expect(pickBanner({ ...off, updateFailed: true })).toBe("update-failed");
-    expect(pickBanner({ ...off, versionSkew: true })).toBe("version-skew");
+    expect(pickBanner({ ...off, updates: true })).toBe("updates");
     expect(pickBanner({ ...off, incompatible: true })).toBe("incompatible");
     expect(pickBanner({ ...off, reconnecting: true })).toBe("reconnecting");
   });
 
   it("picks the highest severity when several co-occur", () => {
     // all on → reconnecting wins
-    expect(pickBanner({ ...off, reconnecting: true, incompatible: true, versionSkew: true, updateFailed: true, serverUpdate: true })).toBe("reconnecting");
+    expect(pickBanner({ ...off, reconnecting: true, incompatible: true, updates: true })).toBe("reconnecting");
     // reconnecting off → incompatible wins
-    expect(pickBanner({ ...off, incompatible: true, versionSkew: true, updateFailed: true, serverUpdate: true })).toBe("incompatible");
-    // reconnecting + incompatible off → version-skew wins
-    expect(pickBanner({ ...off, versionSkew: true, updateFailed: true, serverUpdate: true })).toBe("version-skew");
-    // only the two lowest → update-failed wins over server-update
-    expect(pickBanner({ ...off, updateFailed: true, serverUpdate: true })).toBe("update-failed");
+    expect(pickBanner({ ...off, incompatible: true, updates: true })).toBe("incompatible");
+    // only the low tier → updates wins
+    expect(pickBanner({ ...off, updates: true })).toBe("updates");
   });
 
   it("priority order is exactly the spec severity chain", () => {
-    expect(BANNER_PRIORITY).toEqual([
-      "reconnecting",
-      "incompatible",
-      "version-skew",
-      "update-failed",
-      "server-update",
-    ]);
+    expect(BANNER_PRIORITY).toEqual(["reconnecting", "incompatible", "updates"]);
   });
 });

--- a/src/renderer/bannerPriority.ts
+++ b/src/renderer/bannerPriority.ts
@@ -1,48 +1,41 @@
-// ===== Banner priority (BET-416 §E) =====
+// ===== Banner priority (BET-416 §E, stage 3 of the unified-update epic) =====
 //
-// App.tsx used to stack up to six full-width bars — five UpdateBar variants
-// (app update, update error, server update, version skew, compatibility) plus
-// ReconnectingBanner — that could all co-occur. The spec collapses them to
-// AT MOST ONE bar, chosen by severity:
+// App.tsx renders AT MOST ONE full-width bar, chosen by severity. The spec
+// collapsed the five update banner kinds (version-skew, update-failed,
+// server-update, plus the folded "behind" compat variant) into ONE `updates`
+// banner — its copy is produced by `describeUpdateBanner` in
+// src/shared/updateTargets.mjs. So the priority chain is:
 //
-//   reconnecting > incompatible > version skew > update failed > server update
+//   reconnecting > incompatible > updates
+//
+// `reconnecting` and `incompatible` stay ABOVE `updates` because they are a
+// different class of problem (connectivity, and a hard wire-contract block) —
+// an update prompt must not mask a broken link or a version that cannot talk
+// to the box at all.
 //
 // "Update available" (a downloaded desktop auto-update) is NOT a bar at all —
 // it is demoted to a small --accent dot on the Settings entry in the sidebar
 // footer; the bar is reserved for states that actually block you.
 //
 // `pickBanner` is pure so the severity order is unit-tested without mounting
-// App. The "behind" compatibility variant (box on the supported major but
-// older than the desktop) folds into `server-update` — it is an upgrade
-// prompt with the same self-update action, not a blocking incompatibility.
+// App.
 
-export type BannerKind =
-  | "reconnecting"
-  | "incompatible"
-  | "version-skew"
-  | "update-failed"
-  | "server-update";
+export type BannerKind = "reconnecting" | "incompatible" | "updates";
 
 export type BannerState = {
   /** Events-WebSocket is degraded (anything but connected/idle). */
   reconnecting: boolean;
   /** Desktop↔box are on different majors (wire-contract mismatch). */
   incompatible: boolean;
-  /** Client is older than the server's `minClient` (non-dismissible). */
-  versionSkew: boolean;
-  /** A desktop auto-update failed (integrity / permission). */
-  updateFailed: boolean;
-  /** A server update is available, OR the box is "behind" (upgradeable). */
-  serverUpdate: boolean;
+  /** Any update state warrants the banner (available / mandatory / failed). */
+  updates: boolean;
 };
 
 /** Severity order, highest first. */
 export const BANNER_PRIORITY: BannerKind[] = [
   "reconnecting",
   "incompatible",
-  "version-skew",
-  "update-failed",
-  "server-update",
+  "updates",
 ];
 
 /** Map a BannerKind to its BannerState flag (kebab kind → camelCase flag). */
@@ -50,9 +43,7 @@ function flagFor(kind: BannerKind, state: BannerState): boolean {
   switch (kind) {
     case "reconnecting": return state.reconnecting;
     case "incompatible": return state.incompatible;
-    case "version-skew": return state.versionSkew;
-    case "update-failed": return state.updateFailed;
-    case "server-update": return state.serverUpdate;
+    case "updates": return state.updates;
   }
 }
 

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -9,6 +9,7 @@ import type {
   UsageSnapshot,
   StoppedRecord,
   WindowStatus,
+  UpdateTarget,
 } from "../shared/types";
 import type { ConnectionState } from "../shared/net/state.js";
 import type { SyncPayload } from "../shared/api.js";
@@ -477,6 +478,11 @@ type State = {
   // updateDownloaded event). Guarded — the mobile httpApi shim's
   // onAutoUpdate* are no-ops, so this is desktop-only.
   updatePrompt: { version: string; releaseName?: string } | null;
+  // Canonical unified update list (stage 3, BET-1098). Produced by the shared
+  // `refreshUpdateTargets()` over both update-check legs and read by App.tsx
+  // to drive the single `updates` banner (via describeUpdateBanner /
+  // planUpdateAll) and by Settings → About. Empty [] until the first refresh.
+  updateTargets: UpdateTarget[];
   // A TERMINAL auto-update failure (integrity / permission). Set from main's
   // autoUpdate:error IPC, which only fires for failures the user must act on
   // — transient network errors are filtered server-side of the bridge.
@@ -686,6 +692,7 @@ type State = {
   removePendingScreenshots: (ids: string[]) => void;
   setAgentFileToast: (t: AgentFileReady | null) => void;
   setUpdatePrompt: (p: { version: string; releaseName?: string } | null) => void;
+  setUpdateTargets: (t: UpdateTarget[]) => void;
   setUpdateError: (p: { message: string; raw: string } | null) => void;
   setBoxIncompatible: (b: boolean) => void;
   setServerUpdatePrompt: (
@@ -754,6 +761,7 @@ export const useStore = create<State>((set, get) => ({
   appToasts: [],
   systemNotice: null,
   updatePrompt: null,
+  updateTargets: [],
   updateError: null,
   boxIncompatible: false,
   serverUpdatePrompt: null,
@@ -1077,6 +1085,7 @@ export const useStore = create<State>((set, get) => ({
     set((prev) => ({ appToasts: prev.appToasts.filter((t) => t.id !== id) })),
   setSystemNotice: (t) => set({ systemNotice: t }),
   setUpdatePrompt: (p) => set({ updatePrompt: p }),
+  setUpdateTargets: (t) => set({ updateTargets: t }),
   setUpdateError: (p) => set({ updateError: p }),
   setBoxIncompatible: (b) => set({ boxIncompatible: b }),
   setServerUpdatePrompt: (p) => set({ serverUpdatePrompt: p }),

--- a/src/renderer/updateCheck.ts
+++ b/src/renderer/updateCheck.ts
@@ -1,0 +1,73 @@
+// updateCheck.ts — the ONE shared "check for updates" (stage 3, BET-1098).
+//
+// Settings → About button and App.tsx's check-on-connect used to run their own
+// copies of the same two-leg check (autoUpdateCheck + serverUpdateCheck). The
+// spec lifts that into a single implementation that runs BOTH legs in parallel,
+// builds the canonical UpdateTarget[] via `buildUpdateTargets`, stores it in
+// the store, and returns it. Two callers, one code path — they can never
+// disagree.
+//
+// The 15s timeout stays on the server leg: a wedged box must not spin the
+// Settings button (or the on-connect check) forever.
+
+import { buildUpdateTargets } from "../shared/updateTargets.mjs";
+import type { UpdateTarget } from "../shared/types";
+import { useStore } from "./store";
+
+export async function refreshUpdateTargets(opts: {
+  clientVersion?: string | null;
+  serverVersion?: string | null;
+} = {}): Promise<UpdateTarget[]> {
+  // A hung check must never leave the caller spinning forever with no way out.
+  // Each leg resolves-or-rejects, but a box whose server wedges before answering
+  // would await indefinitely — so bound the server leg with a timeout and treat
+  // expiry as a failed check rather than a never-ending wait.
+  const withTimeout = <T,>(p: Promise<T>, ms: number): Promise<T> =>
+    new Promise<T>((resolve, reject) => {
+      const t = setTimeout(() => reject(new Error("timeout")), ms);
+      p.then(
+        (v) => {
+          clearTimeout(t);
+          resolve(v);
+        },
+        (e) => {
+          clearTimeout(t);
+          reject(e);
+        },
+      );
+    });
+
+  const serverLeg =
+    typeof window.api.serverUpdateCheck === "function"
+      ? withTimeout(window.api.serverUpdateCheck(), 15_000)
+      : Promise.resolve(null);
+
+  // `Promise.allSettled`, not `all`: a failure of one leg must still report the
+  // other. A box that is unreachable says nothing about whether the desktop has
+  // an update waiting.
+  const [desktop, server] = await Promise.allSettled([
+    window.api.autoUpdateCheck(),
+    serverLeg,
+  ]);
+
+  // autoUpdateCheck never rejects by contract (main resolves `{error}` instead),
+  // so a rejection here means the bridge itself is missing — report it as
+  // unsupported rather than as an update failure.
+  const desktopCheck =
+    desktop.status === "fulfilled"
+      ? desktop.value
+      : { supported: false, available: false, version: null };
+  // Rejected, or timed out — indistinguishable at this level and both mean
+  // "we couldn't get an answer", not "up to date". buildUpdateTargets maps
+  // null to a server target with no available update.
+  const serverCheck = server.status === "fulfilled" ? server.value : null;
+
+  const targets = buildUpdateTargets({
+    desktopCheck,
+    serverCheck,
+    clientVersion: opts.clientVersion ?? null,
+    serverVersion: opts.serverVersion ?? null,
+  });
+  useStore.getState().setUpdateTargets(targets);
+  return targets;
+}

--- a/src/shared/updateTargets.d.mts
+++ b/src/shared/updateTargets.d.mts
@@ -31,3 +31,33 @@ export function buildUpdateTargets(args: {
  * `manual` targets never count.
  */
 export function summarizeUpdates(targets: UpdateTarget[]): UpdateTargetSummary;
+
+export interface UpdateBanner {
+  text: string;
+  actionLabel: string;
+  tone: "accent" | "danger";
+  dismissible: boolean;
+}
+
+/**
+ * Decide what the ONE unified update banner says: the copy for the `updates`
+ * banner, or `null` when there is nothing to show. Precedence: failure set →
+ * mandatory → exactly-one available → 2+ available → null.
+ */
+export function describeUpdateBanner(
+  targets: UpdateTarget[],
+  opts: { mandatory: boolean; failure: string | null },
+): UpdateBanner | null;
+
+export interface UpdateAllPlan {
+  desktopDownload: boolean; // desktop target available
+  box: boolean; // ANY box-side target available (server, opencode, or a CLI)
+  desktopInstall: boolean; // same as desktopDownload; runs last
+  needsConfirm: boolean; // true iff any available target's disruption !== "none"
+  confirmBody: string[]; // sentences, in order
+}
+
+/**
+ * Plan a single "Update all" run over the target list.
+ */
+export function planUpdateAll(targets: UpdateTarget[]): UpdateAllPlan;

--- a/src/shared/updateTargets.mjs
+++ b/src/shared/updateTargets.mjs
@@ -95,3 +95,129 @@ export function summarizeUpdates(targets) {
   const disruptions = [...new Set(avail.map((t) => t.disruption).filter(Boolean))];
   return { count: names.length, names, disruptions };
 }
+
+/**
+ * Decide what the ONE unified update banner says (stage 3, BET-1098).
+ *
+ * Pure: given the canonical `UpdateTarget[]` (fixed display order) plus two
+ * aggregate flags, produce the banner copy — or `null` when there is nothing
+ * to say. This is what collapses the five banner kinds (version-skew,
+ * update-failed, server-update, plus the folded "behind" compat variant) into
+ * one `updates` banner.
+ *
+ * Precedence is exactly this order:
+ *   1. `failure` set        → danger, dismissible  ("update failed")
+ *   2. `mandatory`          → accent, NON-dismissible ("must update to keep
+ *                             working with this box" — the old version-skew)
+ *   3. exactly 1 available   → `${label} has an update available`
+ *   4. 2+ available          → `${n} updates available · ${names}`
+ *   5. else                  → `null` (no banner)
+ *
+ * `available` means the update exists AND we can apply it; `manual` targets
+ * never count (a "update by hand" row is not something an Update button does).
+ * `names` are the available labels in the FIXED display order joined by ", ";
+ * past three, take the first three and append ` +${n-3} more`.
+ *
+ * @param {Array<object>} targets UpdateTarget[] in fixed display order
+ * @param {{ mandatory: boolean, failure: string | null }} opts
+ * @returns {{ text: string, actionLabel: string, tone: "accent"|"danger",
+ *            dismissible: boolean } | null}
+ */
+export function describeUpdateBanner(targets, { mandatory = false, failure = null } = {}) {
+  if (failure != null && failure !== "") {
+    return {
+      text: `Update failed: ${failure}`,
+      actionLabel: "Download manually",
+      tone: "danger",
+      dismissible: true,
+    };
+  }
+
+  const avail = (Array.isArray(targets) ? targets : []).filter(
+    (t) => t && t.available && !t.manual,
+  );
+
+  if (mandatory) {
+    return {
+      text: "Manta UI must be updated to keep working with this box",
+      actionLabel: "Update",
+      tone: "accent",
+      dismissible: false,
+    };
+  }
+
+  if (avail.length === 1) {
+    return {
+      text: `${avail[0].label} has an update available`,
+      actionLabel: "Update",
+      tone: "accent",
+      dismissible: true,
+    };
+  }
+
+  if (avail.length >= 2) {
+    let names = avail
+      .slice(0, 3)
+      .map((t) => t.label)
+      .join(", ");
+    if (avail.length > 3) names += ` +${avail.length - 3} more`;
+    return {
+      text: `${avail.length} updates available · ${names}`,
+      actionLabel: "Update all",
+      tone: "accent",
+      dismissible: true,
+    };
+  }
+
+  return null;
+}
+
+/**
+ * Plan a single "Update all" run over the canonical `UpdateTarget[]` (stage 3).
+ *
+ * `box` means ANY box-side target is updatable (server, opencode, or a CLI);
+ * `desktopDownload` / `desktopInstall` are the desktop leg (runs last).
+ * `needsConfirm` is true iff any available target's disruption is not "none"
+ * — a CLI-only update (all disruptions "none") needs NO confirm and NO dialog.
+ *
+ * `confirmBody` is the ordered confirm sentences:
+ *   1. any `ends-turns`                 → "Updating opencode restarts it, …"
+ *   2. any `reconnect` and NO ends-turns → "The box will restart briefly …"
+ *   3. any `app-restart`                 → "Manta UI will restart itself …"
+ * Rule 2 is suppressed when rule 1 applies (an opencode restart already
+ * implies the box restart — never print both).
+ *
+ * @param {Array<object>} targets UpdateTarget[]
+ * @returns {{ desktopDownload: boolean, box: boolean, desktopInstall: boolean,
+ *             needsConfirm: boolean, confirmBody: string[] }}
+ */
+export function planUpdateAll(targets) {
+  const avail = (Array.isArray(targets) ? targets : []).filter(
+    (t) => t && t.available && !t.manual,
+  );
+  const desktopDownload = avail.some((t) => t.id === "desktop");
+  const box = avail.some((t) => t.id !== "desktop");
+  const hasEndsTurns = avail.some((t) => t.disruption === "ends-turns");
+  const hasReconnect = avail.some((t) => t.disruption === "reconnect");
+  const hasAppRestart = avail.some((t) => t.disruption === "app-restart");
+
+  const confirmBody = [];
+  if (hasEndsTurns) {
+    confirmBody.push(
+      "Updating opencode restarts it, which ends every agent turn currently running. Any unsaved work in a running turn is lost.",
+    );
+  } else if (hasReconnect) {
+    confirmBody.push("The box will restart briefly and reconnect on its own.");
+  }
+  if (hasAppRestart) {
+    confirmBody.push("Manta UI will restart itself once the box is done.");
+  }
+
+  return {
+    desktopDownload,
+    box,
+    desktopInstall: desktopDownload,
+    needsConfirm: avail.some((t) => t.disruption !== "none"),
+    confirmBody,
+  };
+}

--- a/src/shared/updateTargets.test.ts
+++ b/src/shared/updateTargets.test.ts
@@ -1,7 +1,12 @@
 import { describe, it, expect } from "vitest";
 import type { UpdateTarget } from "./types";
 import { describeUpdateTarget } from "../renderer/chatUtils";
-import { buildUpdateTargets, summarizeUpdates } from "./updateTargets.mjs";
+import {
+  buildUpdateTargets,
+  summarizeUpdates,
+  describeUpdateBanner,
+  planUpdateAll,
+} from "./updateTargets.mjs";
 
 const cli = (
   id: UpdateTarget["id"],
@@ -202,5 +207,219 @@ describe("summarizeUpdates", () => {
       t("codex", true, false, "reconnect"),
     ]);
     expect(summary.disruptions).toEqual(["reconnect"]);
+  });
+});
+
+describe("describeUpdateBanner", () => {
+  const t = (
+    id: UpdateTarget["id"],
+    label: string,
+    available = false,
+    manual = false,
+    disruption: UpdateTarget["disruption"] = "none",
+  ): UpdateTarget => ({
+    id,
+    label,
+    current: null,
+    latest: null,
+    available,
+    ok: !manual,
+    manual,
+    disruption,
+  });
+
+  it("failure set → danger, dismissible, Download manually", () => {
+    const banner = describeUpdateBanner([], { mandatory: false, failure: "checksum mismatch" });
+    expect(banner).toEqual({
+      text: "Update failed: checksum mismatch",
+      actionLabel: "Download manually",
+      tone: "danger",
+      dismissible: true,
+    });
+  });
+
+  it("failure outranks mandatory and every count", () => {
+    const banner = describeUpdateBanner(
+      [t("desktop", "Manta UI", true)],
+      { mandatory: true, failure: "permission denied" },
+    );
+    expect(banner?.tone).toBe("danger");
+    expect(banner?.text).toBe("Update failed: permission denied");
+  });
+
+  it("mandatory → accent, NON-dismissible, must-update copy", () => {
+    const banner = describeUpdateBanner([], { mandatory: true, failure: null });
+    expect(banner).toEqual({
+      text: "Manta UI must be updated to keep working with this box",
+      actionLabel: "Update",
+      tone: "accent",
+      dismissible: false,
+    });
+  });
+
+  it("mandatory renders even with no targets available", () => {
+    const banner = describeUpdateBanner([t("desktop", "Manta UI", false)], {
+      mandatory: true,
+      failure: null,
+    });
+    expect(banner?.tone).toBe("accent");
+  });
+
+  it("exactly one available → '<label> has an update available' for every target", () => {
+    for (const label of ["Manta UI", "The box", "opencode", "Claude Code", "Codex", "Kimi Code"]) {
+      const banner = describeUpdateBanner([t("claude", label, true)], {
+        mandatory: false,
+        failure: null,
+      });
+      expect(banner).toEqual({
+        text: `${label} has an update available`,
+        actionLabel: "Update",
+        tone: "accent",
+        dismissible: true,
+      });
+    }
+  });
+
+  it("two available → 'N updates available · names' in display order", () => {
+    const banner = describeUpdateBanner(
+      [t("desktop", "Manta UI", true), t("server", "The box", true, false, "reconnect")],
+      { mandatory: false, failure: null },
+    );
+    expect(banner).toEqual({
+      text: "2 updates available · Manta UI, The box",
+      actionLabel: "Update all",
+      tone: "accent",
+      dismissible: true,
+    });
+  });
+
+  it("three available → all three names", () => {
+    const banner = describeUpdateBanner(
+      [
+        t("desktop", "Manta UI", true),
+        t("server", "The box", true, false, "reconnect"),
+        t("opencode", "opencode", true, false, "ends-turns"),
+      ],
+      { mandatory: false, failure: null },
+    );
+    expect(banner?.text).toBe("3 updates available · Manta UI, The box, opencode");
+  });
+
+  it("past three names → keep first three and append '+N more'", () => {
+    const banner = describeUpdateBanner(
+      [
+        t("desktop", "Manta UI", true),
+        t("server", "The box", true, false, "reconnect"),
+        t("opencode", "opencode", true, false, "ends-turns"),
+        t("claude", "Claude Code", true),
+      ],
+      { mandatory: false, failure: null },
+    );
+    expect(banner?.text).toBe("4 updates available · Manta UI, The box, opencode +1 more");
+  });
+
+  it("zero available → null (no banner)", () => {
+    const banner = describeUpdateBanner(
+      [t("desktop", "Manta UI", false), t("server", "The box", false)],
+      { mandatory: false, failure: null },
+    );
+    expect(banner).toBeNull();
+  });
+
+  it("manual targets never count as available", () => {
+    const banner = describeUpdateBanner(
+      [t("desktop", "Manta UI", true, true), t("server", "The box", false)],
+      { mandatory: false, failure: null },
+    );
+    expect(banner).toBeNull();
+  });
+});
+
+describe("planUpdateAll", () => {
+  const t = (
+    id: UpdateTarget["id"],
+    available = false,
+    manual = false,
+    disruption: UpdateTarget["disruption"] = "none",
+  ): UpdateTarget => ({
+    id,
+    label: id,
+    current: null,
+    latest: null,
+    available,
+    ok: !manual,
+    manual,
+    disruption,
+  });
+
+  it("desktop + box: both legs, needsConfirm on reconnect", () => {
+    const plan = planUpdateAll([
+      t("desktop", true, false, "app-restart"),
+      t("server", true, false, "reconnect"),
+    ]);
+    expect(plan).toMatchObject({
+      desktopDownload: true,
+      desktopInstall: true,
+      box: true,
+      needsConfirm: true,
+    });
+    expect(plan.confirmBody).toEqual([
+      "The box will restart briefly and reconnect on its own.",
+      "Manta UI will restart itself once the box is done.",
+    ]);
+  });
+
+  it("server-only: box leg, no desktop", () => {
+    const plan = planUpdateAll([t("server", true, false, "reconnect")]);
+    expect(plan.desktopDownload).toBe(false);
+    expect(plan.desktopInstall).toBe(false);
+    expect(plan.box).toBe(true);
+    expect(plan.needsConfirm).toBe(true);
+  });
+
+  it("desktop+server: opencode ends-turns sentence replaces the reconnect sentence", () => {
+    const plan = planUpdateAll([
+      t("desktop", true, false, "app-restart"),
+      t("server", true, false, "reconnect"),
+      t("opencode", true, false, "ends-turns"),
+    ]);
+    // ends-turns suppresses reconnect (an opencode restart implies the box
+    // restart), but app-restart still appears.
+    expect(plan.confirmBody).toEqual([
+      "Updating opencode restarts it, which ends every agent turn currently running. Any unsaved work in a running turn is lost.",
+      "Manta UI will restart itself once the box is done.",
+    ]);
+  });
+
+  it("CLI-only (disruption none) → no confirm and no dialog", () => {
+    const plan = planUpdateAll([t("claude", true, false, "none")]);
+    expect(plan.box).toBe(true);
+    expect(plan.desktopDownload).toBe(false);
+    expect(plan.needsConfirm).toBe(false);
+    expect(plan.confirmBody).toEqual([]);
+  });
+
+  it("desktop-only → box false, needsConfirm on app-restart", () => {
+    const plan = planUpdateAll([t("desktop", true, false, "app-restart")]);
+    expect(plan.desktopDownload).toBe(true);
+    expect(plan.box).toBe(false);
+    expect(plan.needsConfirm).toBe(true);
+    expect(plan.confirmBody).toEqual(["Manta UI will restart itself once the box is done."]);
+  });
+
+  it("manual targets never count toward any leg", () => {
+    const plan = planUpdateAll([
+      t("desktop", true, true, "app-restart"),
+      t("server", true, true, "reconnect"),
+    ]);
+    expect(plan.desktopDownload).toBe(false);
+    expect(plan.box).toBe(false);
+    expect(plan.needsConfirm).toBe(false);
+    expect(plan.confirmBody).toEqual([]);
+  });
+
+  it("app-restart alone does NOT suppress the reconnect sentence (no ends-turns)", () => {
+    const plan = planUpdateAll([t("server", true, false, "reconnect")]);
+    expect(plan.confirmBody).toEqual(["The box will restart briefly and reconnect on its own."]);
   });
 });


### PR DESCRIPTION
Stage 3 of the unified-update epic. Depends on the stage-2 aggregate (`src/shared/updateTargets.mjs`, merged as BET-1096).

## What changed

- **Deliverable 1 — banner kinds collapse.** `bannerPriority.ts` now has exactly three kinds: `reconnecting > incompatible > updates`. `BannerState` drops `versionSkew`/`updateFailed`/`serverUpdate`, gains `updates`. `pickBanner`/`flagFor` shrink to match.
- **Deliverable 2 — `tone` on `UpdateBar`.** New prop `tone?: "accent" | "danger"` (default `"accent"`, byte-identical to today). `"danger"` swaps only the three tint classes (`bg-danger/10`, `border-danger/30`, button `bg-danger/20 text-danger hover:bg-danger/30`), using the existing `--danger-rgb` token. Header comment rewritten (no more "three usages").
- **Deliverable 3 — `describeUpdateBanner`** (pure, `updateTargets.mjs`). Copy table verbatim (failure / mandatory / 1 available / 2+ / null), fixed precedence, `>3` names truncation.
- **Deliverable 4 — `planUpdateAll`** (pure, same module). Desktop/box/install legs, `needsConfirm`, ordered `confirmBody` with the ends-turns → reconnect suppression rule; CLI-only → no confirm.
- **Deliverable 5 — `runUpdateAll` orchestrator** in `App.tsx`. Desktop download fires concurrently (rejection swallowed), one "Update everything?" confirm, box leg reuses the existing `applyServerUpdate` machinery unchanged, desktop install is terminal and gated on `updateAllRunRef` + `updateAllBoxConfirmed`. All four old per-banner branches (version-skew / update-failed / server-update / behind-compat) deleted.
- **Deliverable 6 — one check, not two.** `refreshUpdateTargets()` (`src/renderer/updateCheck.ts`) runs both legs in parallel with the 15s server-leg timeout, builds `UpdateTarget[]`, stores it in the store. Used by the Settings button AND the App check-on-connect AND the poller's `serverUpdateAvailable` event.

## Tests
- `updateTargets.test.ts`: every copy-table row, precedence, `>3` names truncation, all `planUpdateAll` combinations including the CLI-only no-confirm case and the ends-turns suppression rule.
- `bannerPriority.test.ts`: updated for the three kinds.
- `npm run typecheck` clean; `npm test` green (2353 pass, 0 fail).

## Out of scope (unchanged)
Settings About list visual restructure (stage 4), per-target banner buttons, snooze/schedule, release notes, the sidebar Settings accent dot.
