### PR TITLE
BET-1103: fix(ios): stable identity for the .steps transcript block

### DIFF
--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -45,7 +45,17 @@ extension TranscriptBlock {
             return "p\(text.hashValue)@\(at?.timeIntervalSince1970 ?? 0)"
         case .file(let attachment):
             return "f" + attachmentIdentity(attachment)
-        case .steps(let content): return "s" + content.rows.map(\.id).joined(separator: "|")
+        // The FIRST row's id, not all of them joined. A step group grows by APPENDING
+        // rows, so the first row's id is fixed for the life of the group while a
+        // concatenation changes on every new step — which made the diff see a
+        // different row and delete + re-insert the whole group per tool call. Same
+        // stable-identity treatment `ToolStep.id` already gets (see the comment on
+        // `ToolStep.id`), applied to the group that contains them.
+        //
+        // Two step groups can never collide: a row id is a tool callID (or the
+        // part id), unique per call. An empty group falls back to a constant, and
+        // `uniqueTranscriptRows` suffixes any duplicate anyway.
+        case .steps(let content): return "s" + (content.rows.first?.id ?? "empty")
         case .notice(let text, let kind): return "n\(kind)\(text.hashValue)"
         case .queuedPrompt(let text): return "q\(text.hashValue)"
         }

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -597,6 +597,48 @@ final class ChatTranscriptTests: XCTestCase {
                        "non-colliding blocks must keep their content-stable ids unchanged")
     }
 
+    // MARK: - Step-group identity (BET-1103)
+    //
+    // A step group grows by appending rows. Its id must therefore be fixed for the
+    // life of the group: an id derived from ALL row ids changes on every new step,
+    // so the diff sees a different row and deletes + re-inserts the whole group on
+    // every tool call — visible jank, and the remove/insert traffic behind the
+    // `_TiledView.applyChange` crashes.
+
+    private func step(_ id: String) -> StepGroupRow {
+        .step(ToolStep(id: id, verb: "Read", target: "a.swift",
+                       duration: "0.4s", status: .completed, output: nil))
+    }
+
+    func testStepGroupIDIsUnchangedWhenAStepIsAppended() {
+        let before = TranscriptBlock.steps(.rows([step("call-1")]))
+        let after = TranscriptBlock.steps(.rows([step("call-1"), step("call-2")]))
+        XCTAssertEqual(before.stableScrollID, after.stableScrollID,
+                       "appending a step must not change the group's id, or the whole group is deleted and re-inserted")
+    }
+
+    func testStepGroupIDIsUnchangedWhenTheGroupRollsUp() {
+        let rows = [step("call-1"), step("call-2"), step("call-3")]
+        let plain = TranscriptBlock.steps(.rows(rows))
+        let rolled = TranscriptBlock.steps(.rollup(summary: "▸ 3 steps", rows: rows))
+        XCTAssertEqual(plain.stableScrollID, rolled.stableScrollID,
+                       "rolling up is the same group and must be an in-place update, not a remove + insert")
+    }
+
+    func testDifferentStepGroupsGetDifferentIDs() {
+        let a = TranscriptBlock.steps(.rows([step("call-1")]))
+        let b = TranscriptBlock.steps(.rows([step("call-9")]))
+        XCTAssertNotEqual(a.stableScrollID, b.stableScrollID,
+                          "two distinct step groups must not share an id")
+    }
+
+    func testEmptyStepGroupsStillGetUniqueRowIDs() {
+        let blocks: [TranscriptBlock] = [.steps(.rows([])), .steps(.rows([]))]
+        let rows = uniqueTranscriptRows(blocks)
+        XCTAssertEqual(Set(rows.map(\.id)).count, 2,
+                       "uniqueTranscriptRows must still de-duplicate empty step groups")
+    }
+
     // MARK: - Step disclosure (BET-823)
 
     func testStepDisclosureStateDefaults() {


### PR DESCRIPTION
## What

Fixes the `.steps` transcript block's scroll identity so it stops deleting + re-inserting the whole step group on every tool call.

`TranscriptBlock.stableScrollID` for the `.steps` case used the CONCATENATION of every child row id, so adding a tool step changed the block's id and made the diff see a brand-new row — the whole group was torn down and rebuilt on every tool step (the visible jank, and the remove/insert traffic behind the `_TiledView.applyChange` crashes). Now it uses the FIRST row's id, which is fixed for the life of the group (a group grows by appending rows; two groups can't collide since a row id is a unique tool callID/part id; empty groups fall back to a constant, and `uniqueTranscriptRows` suffixes any duplicate anyway).

**One production line** changed in `mobile/native/MantaUI/TranscriptRow.swift` plus 4 tests in `mobile/native/MantaUITests/ChatTranscriptTests.swift`. Nothing else in the repo is touched.

Base: origin/main @ `c8ea7ae`

## Verification (`ios-mantaui action=test-unit` — the merge gate)

- **PR branch** (`multica/BET-1103-stable-steps-group-identity` @ `db965b8`): `552 tests, 1 failure`. The single failure is `ToolOutputPreviewTests.testThirtyLinesKeepsLastTwelveWithPrefix`.
- **Base (`main` @ `c8ea7ae`)**: `548 tests, 1 failure` — **the identical test/failure**.

The `/ToolOutputPreviewTests` failure is pre-existing and unrelated to this change (broken assertion from BET-1085: it checks `output.contains("line 1")`, but the kept tail's first line `"line 19"` contains the substring `"line 1"`, so the assertion always fails). My 4 new `ChatTranscriptTests` all pass — 548 → 552, with the same single pre-existing failure. This PR introduces **zero** new failures.
