### PR TITLE
ci(ios): run the 548 existing unit tests on every PR (BET-1107)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -59,18 +59,18 @@ jobs:
           set -euo pipefail
           UDID=$(xcrun simctl list devices available --json \
             | python3 -c '
-import json, sys
-runtimes = json.load(sys.stdin)["devices"]
-best = None
-for runtime, devices in sorted(runtimes.items()):
-    if "iOS" not in runtime:
-        continue
-    for device in devices:
-        if device.get("isAvailable") and device["name"].startswith("iPhone"):
-            best = device["udid"]
-if best:
-    print(best)
-')
+            import json, sys
+            runtimes = json.load(sys.stdin)["devices"]
+            best = None
+            for runtime, devices in sorted(runtimes.items()):
+                if "iOS" not in runtime:
+                    continue
+                for device in devices:
+                    if device.get("isAvailable") and device["name"].startswith("iPhone"):
+                        best = device["udid"]
+            if best:
+                print(best)
+            ')
           if [ -z "$UDID" ]; then
             echo "::error::No available iPhone simulator on this runner."
             xcrun simctl list devices available

--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -1,6 +1,12 @@
-# iOS compile gate (BET-651). Compiles the native app + BOTH test bundles for
-# any PR that touches mobile/native. build-for-testing, never `test` —
-# execution stays on the Mac plugin; this gate only proves the Swift compiles.
+# iOS build + unit-test gate. Compiles the native app + both test bundles for
+# any PR that touches mobile/native, then RUNS the MantaUITests unit bundle on
+# a simulator.
+#
+# Only the UNIT bundle runs here. MantaUIUITests is deliberately excluded: it is
+# the hierarchy-dump leg of the capture harness (driven by capture.sh, see
+# mobile/native/FINDINGS.md), not a regression suite, and simulator UI tests are
+# slow and flake-prone on a shared runner. It stays a manual / Mac-plugin run.
+#
 # NOT in required-checks.json: the paths filter means most PRs never produce
 # this context, and requiring it would block them all (see AGENTS.md).
 #
@@ -9,7 +15,7 @@
 # which only Xcode 26 can read; macos-14's Xcode 15.4 cannot open it at all
 # ("future Xcode project file format (77)" — verified live on the first run).
 # macos-26 ships Xcode 26 on a standard (free) runner.
-name: iOS Build
+name: iOS Build & Test
 
 on:
   pull_request:
@@ -24,7 +30,7 @@ concurrency:
 jobs:
   ios-build:
     runs-on: macos-26
-    timeout-minutes: 30
+    timeout-minutes: 45
     defaults:
       run:
         working-directory: mobile/native
@@ -41,17 +47,65 @@ jobs:
           restore-keys: |
             ios-build-${{ runner.os }}-
 
-      - name: Install xcodegen
-        run: brew install xcodegen
+      - name: Install xcodegen + xcbeautify
+        run: brew install xcodegen xcbeautify
 
       - name: Generate Xcode project (project.yml is the source of truth)
         run: xcodegen generate
 
+      - name: Pick a simulator
+        id: sim
+        run: |
+          set -euo pipefail
+          UDID=$(xcrun simctl list devices available --json \
+            | python3 -c '
+import json, sys
+runtimes = json.load(sys.stdin)["devices"]
+best = None
+for runtime, devices in sorted(runtimes.items()):
+    if "iOS" not in runtime:
+        continue
+    for device in devices:
+        if device.get("isAvailable") and device["name"].startswith("iPhone"):
+            best = device["udid"]
+if best:
+    print(best)
+')
+          if [ -z "$UDID" ]; then
+            echo "::error::No available iPhone simulator on this runner."
+            xcrun simctl list devices available
+            exit 1
+          fi
+          echo "udid=$UDID" >> "$GITHUB_OUTPUT"
+          echo "Selected simulator $UDID"
+
       - name: Compile app + test bundles
         run: |
           set -o pipefail
-          xcodebuild build-for-testing \
+          NSUnbufferedIO=YES xcodebuild build-for-testing \
             -project MantaUI.xcodeproj \
             -scheme MantaUI \
-            -destination 'generic/platform=iOS Simulator' \
-            CODE_SIGNING_ALLOWED=NO
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | xcbeautify --renderer github-actions
+
+      - name: Run unit tests (MantaUITests)
+        run: |
+          set -o pipefail
+          NSUnbufferedIO=YES xcodebuild test-without-building \
+            -project MantaUI.xcodeproj \
+            -scheme MantaUI \
+            -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
+            -only-testing:MantaUITests \
+            -resultBundlePath TestResults.xcresult \
+            CODE_SIGNING_ALLOWED=NO \
+            2>&1 | xcbeautify --renderer github-actions
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ios-test-results
+          path: mobile/native/TestResults.xcresult
+          retention-days: 7
+          if-no-files-found: ignore


### PR DESCRIPTION
Closes BET-1107 — ci(ios): run the 548 existing unit tests on every PR.

## Scope
Only `.github/workflows/ios-build.yml` changed. Nothing under `mobile/native/`, no `required-checks.json`, no branch ruleset.

**Base:** `origin/main` @ `30e565c8`

## What changed
- Header comment rewritten to describe a build + unit-test gate; the `macos-26` rationale paragraph preserved verbatim.
- Job display name `iOS Build` → `iOS Build & Test` (job key `ios-build:` unchanged, so the required-check context stays stable).
- `timeout-minutes: 30` → `45` (simulator boot + test execution added).
- Installs `xcbeautify` alongside `xcodegen`.
- New "Pick a simulator" step: discovers an available iPhone simulator dynamically (`xcrun simctl`), fails loudly with the full device list if none matches.
- Compile step split into TWO steps: `build-for-testing` (compile) and `test-without-building` with `-only-testing:MantaUITests` (unit bundle only — `MantaUIUITests` deliberately excluded).
- Both xcodebuild steps use `set -o pipefail` + `2>&1 | xcbeautify --renderer github-actions`; `set -o pipefail` is load-bearing (without it a failing build reports green).
- Uploads `TestResults.xcresult` on failure, 7-day retention.

## Verification (actual CI run on this PR)
No code changed, so `npm run typecheck && npm test` is N/A; verification is the CI run itself. The `ios-build` job ran on `macos-26` (10m11s) and:
- "Pick a simulator" selected a UDID ✓
- Compile step passed ✓
- **Test step ran: `Executed 548 tests, with 2 failures (1 unexpected)`** (job exit 65 — a failing test correctly fails the job).

### The two failing tests (real, not workflow/environmental)
Confirmed from the run log and GitHub annotations. Both live in `mobile/native/` — NOT fixed here (BET-1103/1104/1105 are in flight against these files); reported and filed as follow-ups per BET-1107:

1. `testThirtyLinesKeepsLastTwelveWithPrefix`
   - `XCTAssertFalse failed - the head-most lines must be dropped`
   - `mobile/native/MantaUITests/ToolOutputPreviewTests.swift:23`
2. `testTokenRoundTripsThroughKeychainAndIsAbsentFromUserDefaults`
   - `failed: caught error: "status(-34018)"` (Keychain errSecMissingEntitlement)
   - `mobile/native/MantaUITests/MantaTransportTests.swift:233`

No `XCTSkip` / `-skip-testing:` was used — a failing test fails the job, as the ticket requires. Follow-up issues filed (one per test): BET-1112, BET-1113.
