### PR TITLE
fix(ios): assert head lines dropped without substring false-positive in tool preview test (BET-1106)

### DIFF
--- a/mobile/native/MantaUITests/ToolOutputPreviewTests.swift
+++ b/mobile/native/MantaUITests/ToolOutputPreviewTests.swift
@@ -20,7 +20,8 @@ final class ToolOutputPreviewTests: XCTestCase {
         XCTAssertEqual(output.components(separatedBy: "\n").count, ToolOutputPreview.maxLines + 1,
                        "prefix line + the kept \(ToolOutputPreview.maxLines) lines")
         XCTAssertTrue(output.hasSuffix("line 30"), "the tail must keep the NEWEST lines")
-        XCTAssertFalse(output.contains("line 1"), "the head-most lines must be dropped")
+        XCTAssertFalse(output.contains("line 1\n"), "the head-most lines must be dropped")
+        XCTAssertTrue(output.contains("line 19"), "the tail must start at the 19th line")
     }
 
     func testSingleEnormousLineIsCharacterBounded() {


### PR DESCRIPTION
Opened automatically for `multica/BET-1106-tool-output-preview-test-assert`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1106.