### PR TITLE
docs(ios): write the Swift half of AGENTS.md — agents get 6 lines of Swift guidance today (BET-1109)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,6 +78,13 @@ session-state snapshot.
   shared by renderer + server (`groq.mjs`, `subagentSync.mjs`,
   `modelGuide.mjs`).
 
+## Native iOS app — see `mobile/native/AGENTS.md`
+
+The Swift/iOS client has its own agent guide at **`mobile/native/AGENTS.md`**: architecture,
+the xcodegen build model, how to verify Swift changes (there is no Swift toolchain on the Linux
+box), the Swift 6 concurrency rules, and the transcript-list crash history. Read it before
+touching anything under `mobile/native/`.
+
 ## Build / run
 
 ```

--- a/mobile/native/AGENTS.md
+++ b/mobile/native/AGENTS.md
@@ -1,0 +1,302 @@
+# Native iOS app — agent guide
+
+This file is the Swift half of the repo's agent guidance. The root `AGENTS.md`
+covers the Electron desktop app and the Node box server; this one covers the
+~21k lines of Swift in `mobile/native/` — the app where the live crashes are.
+
+Read this before touching anything under `mobile/native/`. It is a map, not a
+tutorial; every claim below was verified against the code at the time of
+writing (2026-08-18). If a number or path reads wrong now, trust the code.
+
+## 1. Orientation
+
+`mobile/native/` is the **native iOS client** for MantaUI: a SwiftUI app
+(`${PRODUCT_BUNDLE_IDENTIFIER}` = `com.antoinedc.mantaui`) that talks to the
+box server over HTTPS with a bearer token from the Keychain. It is one
+consumer of the box's RPC + `/events` HTTP surface, exactly parallel to the
+desktop and web clients described in root `AGENTS.md` — this client just
+speaks to it natively rather than through Electron.
+
+It sits in the monorepo under `mobile/native/` alongside `mobile/www/` (the
+retired web bundle — not this). The box server/desktop concerns in root
+`AGENTS.md` still apply; this file only layers the Swift-specific detail on
+top.
+
+## 2. Layout and architecture
+
+- **One flat app target.** All application code lives in `MantaUI/` — **63
+  `.swift` files, 21,322 lines** (counted `find MantaUI -name '*.swift'`).
+  There is no module split: no SwiftPM target for the app itself, no
+  architecture framework, no DI container. View models are plain SwiftUI
+  `ObservableObject` stores.
+- **The mass is in a few files.** Know where the size is before you edit:
+
+  | file | lines |
+  |---|---|
+  | `MantaUI/ChatScreen.swift` | 1,710 |
+  | `MantaUI/ComposerView.swift` | 1,426 |
+  | `MantaUI/ChatSessionStore.swift` | 1,080 |
+  | `MantaUI/SessionListView.swift` | 956 |
+  | `MantaUI/TranscriptComponents.swift` | 796 |
+  | `MantaUI/MantaOnboarding.swift` | 759 |
+  | `MantaUI/MantaAPIClient.swift` | 738 |
+
+- **15 `ObservableObject` stores** (`UsageStore`, `VoiceRecorder`,
+  `MantaQRScannerModel`, `VoicePlaybackEngine`, `TerminalSessionState`,
+  `MantaOnboardingFlow`, `ComposerTextController`, `ChatModelCatalog`,
+  `SessionListStore`, `MantaSettingsStore`, `ChatSessionStore`,
+  `ChatModelStore`, `MantaPushRouter`, `MantaPairingRouter`,
+  `MantaEventStore`). Every one is `@MainActor`-isolated — see Concurrency.
+- **Two files are machine-generated and compiled in from outside this
+  directory.** `project.yml` references them by path (`../../generated/swift/`),
+  so they are NOT part of the `MantaUI/` folder entry:
+
+  | generated file | generator | source |
+  |---|---|---|
+  | `generated/swift/Theme.swift` | `npm run gen:swift-tokens` (`scripts/gen-swift-tokens.mjs`) | `src/renderer/tokens.css` |
+  | `generated/swift/SettingsSchema.swift` | `npm run gen:swift-settings` (`scripts/gen-swift-settings.mjs`) | `src/shared/settingsSchema.ts` |
+
+  **Never edit them by hand.** They are regenerated from TypeScript sources and
+  committed; a hand-edit is silently discarded on the next regeneration, and CI
+  runs `--check` on both generators to catch drift. The Swift source of truth
+  for design tokens and the settings inventory is the generated file.
+- **Two test bundles, doing very different jobs:**
+
+  - `MantaUITests` — the **real unit suite**: 23 files, **552 `func test…`
+    methods** (XCTest). This is the merge gate.
+  - `MantaUIUITests` — **NOT a conventional regression suite.** Project.yml's
+    own comment and `FINDINGS.md` are explicit: it is the **hierarchy-dump leg
+    of the native capture harness**, driven by `capture.sh`, and its tests
+    pair against a fixture box on `127.0.0.1:8787` that only the capture
+    harness runs. Run in Xcode or CI without that fixture they go red for
+    environmental reasons on any branch. **Do not treat a `MantaUIUITests`
+    red as a code verdict, and do not add "regression" tests to it.**
+
+## 3. Build: xcodegen is the source of truth
+
+`mobile/native/project.yml` is **authoritative**; the committed
+`MantaUI.xcodeproj/project.pbxproj` is **generated**. Never hand-edit the
+`.pbxproj` — the next `xcodegen generate` discards it.
+
+- Regenerate with `xcodegen generate` inside `mobile/native/` (this requires a
+  **Mac** — there is no xcodegen on the Linux box). The `ios-regen-pbxproj`
+  plugin on the Mac exists precisely for this: it regenerates the committed
+  `.pbxproj` and pushes a branch when `project.yml` changes from the box.
+- The two Swift generators above run before xcodegen in the build (and on CI);
+  see §4 for the Mac-side plugin that does this.
+- `project.yml` declares `SWIFT_VERSION: "6.0"` and `deploymentTarget: "26.0"`
+  (iOS 26). The generated project is Xcode format 77, so it needs Xcode 26 —
+  this is why CI runs on `macos-26` (see §4).
+
+## 4. Verification — what an agent can and cannot do here
+
+**There is no Swift toolchain, no Xcode and no simulator on the Linux dev
+box** (verified: `swift`, `xcodebuild`, `xcrun` are all absent). An agent
+working there **cannot compile, run or test Swift directly.** Do not attempt
+it and do not report a build/test result you did not obtain.
+
+The route to the Mac is the **plugin system** (see root `AGENTS.md`). The
+relevant plugin is **`ios-mantaui`** — read its manifest with `plugin_get`
+before running it. Its actions:
+
+| action | what it does |
+|---|---|
+| `preflight` | read-only: reports Xcode/xcodegen/repo/signing/devices; **replays the previous run's verdict** |
+| `device` | builds (Debug, `iphoneos`) + installs + launches on a real iPhone |
+| `simulator` | builds (Debug), boots and launches in the iOS Simulator |
+| `compile-only` | compiles the app target for a generic simulator destination, runs NO tests |
+| `test` | runs **both** bundles — **not a usable gate** (UI tests go red environmentally, see §2) |
+| `test-unit` | **the deterministic merge gate**: builds both bundles but runs only `MantaUITests` |
+| `logs` | tail of the most recent build log (the job log is head-capped) |
+| `devices` | lists iPhones the Mac can see |
+
+Key facts that make or break a run:
+
+- **`action: "test-unit"` is the signal an agent should actually use** — it
+  closes the hole in `compile-only` (which builds the app target and runs
+  nothing) without importing the UI bundle's flake. Inputs: `branch`,
+  `simulator` (default `iPhone 17 Pro`), `team_id`.
+- The Mac clone is **force-reset** to the requested branch and is shared with
+  other builds — never expect it to hold uncommitted work.
+- **`test-unit`, `simulator` and `logs` all exist** — BET-1103/1104/1105
+  reference them by name and they are real actions on `ios-mantaui`.
+
+**CI** (`.github/workflows/ios-build.yml`, on `main` at time of writing): a
+single job on `macos-26` that `brew install xcodegen`, `xcodegen generate`,
+then `xcodebuild build-for-testing` for `generic/platform=iOS Simulator`
+(`CODE_SIGNING_ALLOWED=NO`). It is **compile-only** — it proves the app and
+both test bundles compile, but never runs tests; execution stays on the Mac
+plugin. It is NOT in `required-checks.json` (only `typecheck-test` is
+required; the path filter means most PRs never trigger it). **There is no
+SwiftLint workflow on `main` yet** — do not describe one as existing.
+
+**Reading production crashes:** crashes are captured by **Firebase
+Crashlytics** (replaced the box-upload PLCrashReporter) and read through the
+`firebase` MCP server's `crashlytics_*` tools. Root `AGENTS.md` documents this
+in full — the `## iOS crash reporting — Firebase Crashlytics` and `Reading
+crashes from an agent session (Firebase MCP)` sections, including the required
+`appId` and the four traps that look like missing data. **Go read that section
+rather than re-deriving it here.** Two headlines worth repeating because they
+are cheap to trip on: Debug-build symbols are attributed to
+`MantaUI.debug.dylib` (not `MantaUI`), and `topIssues` returns only OPEN
+issues.
+
+## 5. Concurrency rules
+
+The codebase is in **Swift 6 language mode** (`SWIFT_VERSION: "6.0"` in
+`project.yml`) and its concurrency hygiene is genuinely good. The purpose of
+this section is to keep an agent from degrading it.
+
+Verified state (counted across `MantaUI/`):
+
+- **Every one of the 15 `ObservableObject` stores is `@MainActor`-isolated.**
+- **No file-scope `var`/`let`** and **no `static var`** anywhere in the app
+  target. Global/static mutable state is absent by construction.
+- **No `actor` declarations** and **no `Task.detached`** calls.
+- **`@unchecked Sendable` appears exactly once** —
+  `MantaAppDelegate.swift:214` (`NotificationCompletionHandler`), with a
+  comment justifying it.
+
+Rules for new code, which follow directly from the above:
+
+- New stores are `@MainActor final class ...: ObservableObject`.
+- No new global mutable state. If a singleton is needed it is `static let`,
+  and either main-actor-isolated or an immutable value type.
+- `@unchecked Sendable` requires a comment explaining why it is safe. One
+  justified instance exists; do not add more casually.
+- Prefer structured `Task {}` (which inherits the enclosing actor context)
+  over `Task.detached`.
+
+One caution worth internalizing: **Swift 6 mode converts some previously-silent
+data races into deterministic runtime traps at Objective-C boundaries.** A new
+crash after a concurrency-annotation change is often a pre-existing race
+becoming visible, not a newly introduced bug — treat it as a signal, not a
+regression to hide.
+
+## 6. Crash-prone patterns — the section with teeth
+
+The classic Swift footguns are in good shape here. Counted:
+
+| pattern | count | where |
+|---|---|---|
+| `try!` | 2 | both are `try! NSRegularExpression` on a static regex (ArtifactDerivation, PlanDerivation) — safe by construction |
+| `as!` | 1 | `MultilineTextView.swift:134` (`as! WrappingTextView`) |
+| `fatalError(` | 4 | all `required init?(coder:)` = "not used" no-op storyboard-coder inits |
+| force-unwrap operators | ~3 | `UsageMeters` `limit!`, `MantaPairingModels` `$0!`, `MantaEventStore` `callID!` — plus a handful of implicitly-unwrapped bridge props (`WKWebView!`, `UIButton!`) |
+
+That is a healthy profile. **Keep it that way** — new `try!`/`as!`/force-unwrap
+need the same level of justification.
+
+But — **this is not where the app actually crashes.** The live Crashlytics
+issues are all in the **chat transcript list**, which is backed by the
+third-party `MessagingUI` `TiledView` (a `UICollectionView` wrapper). As of
+2026-08-18 the three OPEN fatal issues on Crashlytics are:
+
+- `TiledView.swift … _TiledView.applyChange(_:from:)` — `Invalid batch updates
+  detected` / `attempt to delete item 0 from section 0 which only contains 0
+  items`
+- `TiledView.swift … _TiledView.applyChange(_:from:)` — `NSInternalInconsistencyException`
+- `Deque+Collection.swift … Deque.subscript.getter` — `EXC_BREAKPOINT`
+
+**The failure mode:** `TiledView` keeps a log of changes and replays it to
+animate updates; when that log disagrees with the actual transcript, UIKit
+detects the impossible arithmetic and deliberately terminates the process.
+The two in-app names to know:
+
+- `ChatSessionStore.swift:172` — comment on the `rows` property headlined
+  **`invalid-batch-updates / deque-out-of-bounds crash pair`**: the `TiledView`
+  data source is owned by each view (not the store) so its change log and the
+  view's replay cursor share a lifetime. A store-owned data source replays from
+  the beginning against a final snapshot whenever a new view is created — the
+  exact crash pair this comment names.
+- `TranscriptRow.swift` — `uniqueTranscriptRows` (and the `stableScrollID`
+  extension): `MessagingUI`'s `ListDataSource.apply` builds
+  `Dictionary(uniqueKeysWithValues:)` over row ids on its diff path, which
+  **traps on a duplicate**. A comment documents that the app crashed exactly
+  when scrolling up after `loadEarlier()` widened the window into older
+  history where ids collided.
+
+**The operative rule for an agent: anything that changes transcript row
+identity, row ordering, or the update path is high-risk.** Row ids must be
+deterministic and reproducible from the block alone, because a canonical
+refetch re-derives them (see `stableScrollID`/`uniqueTranscriptRows`).
+
+This area has been diagnosed and fixed **more than once** and has recurred
+each time. BET-1103, BET-1104 and BET-1105 were rewriting exactly this — the
+`.steps` block identity and the transcript tests. **As of `origin/main` @
+`ea515d14` all three have merged** (PRs #1103/#1104/#1105); check whether they
+are on your base before touching row identity, and treat any new
+`TiledView`/batch-update crash as a likely regression of this family.
+
+## 7. Networking and error handling
+
+- **One RPC client:** `MantaUI/MantaAPIClient.swift` — a single `URLSession`
+  client over the box's JSON-RPC-ish surface (`channel` + `args` per method,
+  bearer `Authorization` header from `KeychainCredentialStore`). It exposes
+  `call` / `callRequired` / `callVoid` helpers and the raw methods the screens
+  need.
+- **The error it throws:** `MantaError` — `authRequired`, `server(String)`,
+  `transport(String)`, and `storedButUntranscribed(noteID:)` (the voice-clip
+  409 path where the recorder must be kept so the caller can surface a retry).
+- **Two WebSocket paths, two owners:**
+  - `MantaEventStore.swift` owns the `/events` stream (`comps?.path = "/events"`),
+    the interpreted event bus the session list and chat stores consume.
+  - `TerminalSocket.swift` owns the terminal WebSocket
+    (`URLSessionWebSocketTask`) — the `WKWebView` deliberately never opens a
+    connection of its own, so a reconnect keeps the terminal text alive in
+    native code.
+- **The honest state of error handling:**
+  - Catch blocks are consistently handled: **34 catch blocks, zero empty**
+    (no `catch {}`, no `catch { _ in }`).
+  - But there are **~99 `try?` sites** that swallow failures silently. The
+    largest concentrations are `MantaEventStore.swift` (18), `ChatScreen.swift`
+    (9), `ComposerView.swift` (6). Many are legitimate — tolerant decoding of
+    unknown stream frames, `try? JSONSerialization` where a nil just means
+    "not that shape", sleeps. A smaller set are genuinely fire-and-forget
+    network calls where the caller chose to ignore the failure. Before relying
+    on a `try?` you did not write, read the surrounding comment to tell which
+    kind it is.
+
+## 8. Testing conventions
+
+- **Framework: XCTest.** There is no Swift Testing (`@Test` / `import
+  Testing`) anywhere in the repo (verified).
+- **The real suite is `MantaUITests`: 552 `func test…` methods across 23
+  files** (counted). `MantaUIUITests` are capture drivers — see §2, not a
+  regression suite.
+- **The pattern the codebase already follows:** pure, derivable logic is
+  factored into separate types, and **those** are what the unit suite targets.
+  Real examples: `ChatModels.swift` (wire→`TranscriptBlock` mapping) tested by
+  `ChatTranscriptTests` + `ChatStreamMergeTests`; `MantaPairingModels.swift`
+  (pairing/claim logic) tested by `MantaPairingTests`; `PlanDerivation.swift` /
+  `ArtifactDerivation.swift` by their tests; `SessionModels.swift` by
+  `SessionModelsTests`; `Waveform.swift`, `VoiceGesture.swift`,
+  `ComposerTypeahead`, `ModelRecents`, `UsageMeters`, `TerminalModels` all
+  follow the same extract-and-test shape.
+- **Instruction for new work:** when adding logic to a large view or store
+  (the mass in §2), **extract the pure part into its own type and unit-test
+  it**, rather than testing through the UI. This is not a nicety — it is how
+  this codebase keeps a 1,700-line `ChatScreen` and a 1,080-line
+  `ChatSessionStore` correct.
+
+## 9. Known traps
+
+A short list of things that have bitten before and are non-obvious. Root
+`AGENTS.md` documents the Crashlytics/dSYM/TestFlight traps in detail — go to
+its iOS sections for the full write-up; the essentials are:
+
+- **Crashlytics dSYM:** Debug-installed builds need the `dSYM` BUNDLE uploaded
+  (the split `ENABLE_DEBUG_DYLIB` two-UUID trap) or crashes stay
+  unsymbolicated. Do not "fix" the in-build upload phase back to Firebase's
+  `Crashlytics/run` wrapper — it silently uploaded nothing. By reference to
+  root `AGENTS.md`.
+- **`MantaUIUITests` need the fixture box** on `127.0.0.1:8787`; run without
+  it, they fail environmentally. Never a code verdict.
+- **Generated Swift** (`Theme.swift`, `SettingsSchema.swift`): edit the
+  TypeScript source and regenerate (`npm run gen:swift-*`), never the `.swift`.
+  CI's `--check` gate fails on drift.
+- **`project.pbxproj` is generated** — edit `project.yml` and re-`xcodegen`,
+  never the `.pbxproj` by hand.
+- **The transcript-list crash family** (§6) is the app's live crash surface —
+  treat row-identity/ordering changes as high-risk and check whether
+  BET-1103/1104/1105 are present on your base.

--- a/mobile/native/AGENTS.md
+++ b/mobile/native/AGENTS.md
@@ -222,11 +222,14 @@ deterministic and reproducible from the block alone, because a canonical
 refetch re-derives them (see `stableScrollID`/`uniqueTranscriptRows`).
 
 This area has been diagnosed and fixed **more than once** and has recurred
-each time. BET-1103, BET-1104 and BET-1105 were rewriting exactly this — the
-`.steps` block identity and the transcript tests. **As of `origin/main` @
-`ea515d14` all three have merged** (PRs #1103/#1104/#1105); check whether they
-are on your base before touching row identity, and treat any new
-`TiledView`/batch-update crash as a likely regression of this family.
+each time. BET-1103, BET-1104 and BET-1105 have been rewriting exactly this:
+BET-1103 (stable identity for the `.steps` transcript block) **has merged**
+into `main`, while BET-1104 (replacing the hand-rolled transcript gestures
+with MessagingUI's own) and BET-1105 are **not merged** as of 2026-08-18.
+**Check which of these are on your base** (and whether they have merged/landed
+since) before touching row identity, row ordering, or the update path, and
+treat any new `TiledView`/batch-update crash as a likely regression of this
+family.
 
 ## 7. Networking and error handling
 
@@ -298,5 +301,5 @@ its iOS sections for the full write-up; the essentials are:
 - **`project.pbxproj` is generated** — edit `project.yml` and re-`xcodegen`,
   never the `.pbxproj` by hand.
 - **The transcript-list crash family** (§6) is the app's live crash surface —
-  treat row-identity/ordering changes as high-risk and check whether
-  BET-1103/1104/1105 are present on your base.
+  treat row-identity/ordering changes as high-risk and check which of
+  BET-1103/1104/1105 (see §6) have landed on your base.


### PR DESCRIPTION
**docs(ios): Swift half of AGENTS.md (BET-1109)**

Writes the missing native-iOS agent guide at `mobile/native/AGENTS.md` (302 lines, inside the 250–450 target) and adds the one-block pointer to root `AGENTS.md` (the only other change: +7 lines, block inserted after the `## Layout` bullet list, nothing else touched).

**Files changed:** 2.
- `mobile/native/AGENTS.md` (new)
- `AGENTS.md` (+7 lines, pointer block only)

No `.swift`, `project.yml` or `MantaUI.xcodeproj` file touched.

**Verification** — docs-only change (markdown); the TR typecheck/test gates are unaffected by `.md` files, so they were not rerun. `git diff --stat` confirms exactly the two intended files.

Every factual claim was verified directly against the code:

- **63 `.swift` files / 21,322 lines** under `MantaUI/` (`wc -l`).
- **Largest files**: ChatScreen 1710, ComposerView 1426, ChatSessionStore 1080, SessionListView 956, TranscriptComponents 796, MantaOnboarding 759, MantaAPIClient 738.
- **Concurrency** (Swift 6 mode, `project.yml` `SWIFT_VERSION: "6.0"`): 15 `ObservableObject` stores all `@MainActor`; **no** file-scope `var`/`static var`; **no** `actor`/`Task.detached`; **`@unchecked Sendable` appears once** (`MantaAppDelegate.swift:214`) with a justification comment.
- **Crash-pattern counts**: `try!`=2 (both `try! NSRegularExpression` on static regexes), `as!`=1 (`MultilineTextView.swift:134`), `fatalError(`=4 (all unused `required init?(coder:)` "not used"), force-unwrap operators ≈3 (`UsageMeters` `limit!`, `MantaPairingModels` `$0!`, `MantaEventStore` `callID!`) + a few implicitly-unwrapped bridge props.
- **Where it actually crashes**: all 3 OPEN Crashlytics fatals are in `MessagingUI` `TiledView` (`_TiledView.applyChange`– invalid batch updates / `Deque.subscript.getter` EXC_BREAKPOINT) — confirms the transcript-list claim. Cited `ChatSessionStore.swift:172` (`invalid-batch-updates / deque-out-of-bounds crash pair`) and `TranscriptRow.swift` `uniqueTranscriptRows` duplicate-id trap.
- **Networking**: single `MantaAPIClient.swift` throwing `MantaError` (`authRequired`/`server(String)`/`transport(String)`/`storedButUntranscribed(noteID:)`); WebSocket owners `MantaEventStore` (`/events`) and `TerminalSocket`. 34 catch blocks, **zero empty**; **~99 `try?`** sites (18 in MantaEventStore, 9 in ChatScreen, 6 in ComposerView).
- **Tests**: XCTest only (no Swift Testing `@Test`). `MantaUITests` = 23 files, **552 `func test…`** methods. `MantaUIUITests` are capture-driver hierarchy dumps (driven by `capture.sh`, pair against fixture box on 127.0.0.1:8787) — not a regression suite (per project.yml comment + `FINDINGS.md`).
- **Plugin** (`plugin_get("ios-mantaui")`): actions `preflight/devices/device/simulator/compile-only/test/test-unit/logs` read from the live manifest — `test-unit`, `simulator`, `logs` all confirmed to exist. Documented `test-unit` as the deterministic merge gate.
- **No Swift toolchain on this box** (verified: `which swift/xcodebuild/xcrun` all empty).
- **CI on main**: `ios-build.yml` is compile-only (`xcodegen generate` then `xcodebuild build-for-testing` on `macos-26`, `CODE_SIGNING_ALLOWED=NO`); NOT in `required-checks.json` (only `typecheck-test`); **no SwiftLint workflow on main**.
- **xcodegen source of truth** + two generated files referenced by path from `project.yml`: `generated/swift/Theme.swift` (`gen:swift-tokens` ← `src/renderer/tokens.css`) and `SettingsSchema.swift` (`gen:swift-settings` ← `src/shared/settingsSchema.ts`); CI `--check` catches drift; never hand-edit.
- **BET-1103/1104/1105** merge state (corrected in review): BET-1103 (stable `.steps` block identity) **has merged** into `main` as PR #1105 (it is on this base, `origin/main` @ `ea515d14`); BET-1104 (replacing the hand-rolled transcript gestures) is **open** as PR #1111; BET-1105 has **no PR yet**. The doc's §6/§9 now instruct agents to check which of these have landed on their base before touching row identity/ordering/update path.

**Claims I could not verify:** none of the outlined facts failed to check; everything the outline named is present and confirmed. Live crash counts are as-of 2026-08-18 and will drift.

**Base: origin/main @ ea515d14**

