### PR TITLE
fix(ios): replace the two hand-rolled transcript gestures with MessagingUI's own (BET-1104)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1235,13 +1235,13 @@ struct TranscriptListView<Header: View>: View {
         .onTiledScrollGeometryChange { geometry in
             onPointsFromBottom?(geometry.pointsFromBottom)
         }
+        .onTapBackground { resignKeyboard() }
         .onChange(of: store.rows, initial: true) { _, rows in
             dataSource.apply(rows)
         }
         .safeAreaBar(edge: .top) {
             header()
         }
-        .simultaneousGesture(TapGesture().onEnded { resignKeyboard() })
     }
 
     /// Lower the keyboard by asking whoever holds first responder to give it

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -119,13 +119,13 @@ extension StepGroupContent {
 /// scroll pan) slides the cell left to reveal it on a leftward drag. Every
 /// TiledView surface shares this cell, so both the parent chat and the subagent
 /// drill-in get the gutter with no per-screen code.
+@MainActor
 struct TranscriptBlockCell: TiledCellContent {
     typealias StateValue = Void
 
     let item: TranscriptRow
     let tokens: Tokens
 
-    @MainActor
     func body(context: CellContext<Void>) -> some View {
         // The reveal offset now comes from MessagingUI's OWN pan recogniser, which
         // is installed on the collection view and declares simultaneous recognition

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -119,7 +119,6 @@ extension StepGroupContent {
 /// scroll pan) slides the cell left to reveal it on a leftward drag. Every
 /// TiledView surface shares this cell, so both the parent chat and the subagent
 /// drill-in get the gutter with no per-screen code.
-@MainActor
 struct TranscriptBlockCell: TiledCellContent {
     typealias StateValue = Void
 
@@ -131,9 +130,15 @@ struct TranscriptBlockCell: TiledCellContent {
         // is installed on the collection view and declares simultaneous recognition
         // with its scroll pan. The SwiftUI DragGesture this replaces did not, and
         // competed with the scroll view for the initiating touch — the "transcript
-        // needs a second swipe" bug. `rubberbandedOffset` is the library's damped
-        // travel, replacing our hand-rolled gutterTravel ratio.
-        let reveal = context.cellReveal?.rubberbandedOffset(max: TranscriptGutter.gutterWidth) ?? 0
+        // needs a second swipe" bug.
+        //
+        // `CellReveal.rubberbandedOffset(max:)` is main-actor-isolated, but the
+        // `TiledCellContent` conformance here must stay nonisolated (Swift 6
+        // rejects main-actor isolation on a nonisolated protocol conformance as a
+        // data-race), so we read the library's raw `CellReveal.offset` — positive
+        // as the user swipes left — and clamp it to the gutter width ourselves,
+        // substituting a hard stop for the library's rubber-banding.
+        let reveal = min(max(0, context.cellReveal?.offset ?? 0), TranscriptGutter.gutterWidth)
 
         return cellContent
             .offset(x: -reveal)

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -132,13 +132,30 @@ struct TranscriptBlockCell: TiledCellContent {
         // competed with the scroll view for the initiating touch — the "transcript
         // needs a second swipe" bug.
         //
-        // `CellReveal.rubberbandedOffset(max:)` is main-actor-isolated, but the
-        // `TiledCellContent` conformance here must stay nonisolated (Swift 6
-        // rejects main-actor isolation on a nonisolated protocol conformance as a
-        // data-race), so we read the library's raw `CellReveal.offset` — positive
-        // as the user swipes left — and clamp it to the gutter width ourselves,
-        // substituting a hard stop for the library's rubber-banding.
-        let reveal = min(max(0, context.cellReveal?.offset ?? 0), TranscriptGutter.gutterWidth)
+        // `CellReveal` is @MainActor-isolated and `body(context:)` here must stay
+        // nonisolated (Swift 6 rejects main-actor isolation on a nonisolated
+        // protocol conformance as a data-race), so the main-actor reveal state is
+        // passed down to `TranscriptCellReveal`, whose own `View.body` runs on the
+        // main actor and can read `rubberbandedOffset(max:)`.
+        TranscriptCellReveal(
+            cellReveal: context.cellReveal,
+            item: item,
+            tokens: tokens
+        )
+    }
+}
+
+/// Applies MessagingUI's reveal offset to a transcript cell. A plain `View`
+/// (NOT `@MainActor`-declared, so its init stays nonisolated and callable from
+/// the cell's nonisolated `body`) whose `body` reads the main-actor reveal
+/// state legally — SwiftUI's `View.body` is `@MainActor`.
+private struct TranscriptCellReveal: View {
+    let cellReveal: CellReveal?
+    let item: TranscriptRow
+    let tokens: Tokens
+
+    var body: some View {
+        let reveal = cellReveal?.rubberbandedOffset(max: TranscriptGutter.gutterWidth) ?? 0
 
         return cellContent
             .offset(x: -reveal)

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -114,10 +114,11 @@ extension StepGroupContent {
 /// chat uses — this is not a parallel renderer.
 ///
 /// The wall-clock timestamp gutter rides WITH the cell: an overlay parks it off
-/// the trailing edge, and the `TranscriptGutterReveal` gesture (ported verbatim
-/// from the legacy TranscriptView) slides the cell left to reveal it on a
-/// leftward drag. Every TiledView surface shares this cell, so both the parent
-/// chat and the subagent drill-in get the gutter with no per-screen code.
+/// the trailing edge, and MessagingUI's own reveal offset (driven off the cell's
+/// `context.cellReveal`, from the library's pan recogniser integrated with the
+/// scroll pan) slides the cell left to reveal it on a leftward drag. Every
+/// TiledView surface shares this cell, so both the parent chat and the subagent
+/// drill-in get the gutter with no per-screen code.
 struct TranscriptBlockCell: TiledCellContent {
     typealias StateValue = Void
 
@@ -125,22 +126,25 @@ struct TranscriptBlockCell: TiledCellContent {
     let tokens: Tokens
 
     func body(context: CellContext<Void>) -> some View {
-        TranscriptGutterReveal {
-            // The LIVE streaming tail (a `.prose` with no completion time)
-            // renders as lightweight plain text rather than a full
-            // `MarkdownView` re-parse of the accumulated turn each flush
-            // (BET-752 task 1). Completed canonical prose keeps its markdown.
-            cellContent
-                .overlay(alignment: .trailing) {
-                    TimestampGutterLabel(
-                        date: item.block.timestamp,
-                        width: TranscriptGutter.gutterWidth,
-                        tokens: tokens
-                    )
-                    .offset(x: TranscriptGutter.gutterWidth)
-                    .allowsHitTesting(false)
-                }
-        }
+        // The reveal offset now comes from MessagingUI's OWN pan recogniser, which
+        // is installed on the collection view and declares simultaneous recognition
+        // with its scroll pan. The SwiftUI DragGesture this replaces did not, and
+        // competed with the scroll view for the initiating touch — the "transcript
+        // needs a second swipe" bug. `rubberbandedOffset` is the library's damped
+        // travel, replacing our hand-rolled gutterTravel ratio.
+        let reveal = context.cellReveal?.rubberbandedOffset(max: TranscriptGutter.gutterWidth) ?? 0
+
+        return cellContent
+            .offset(x: -reveal)
+            .overlay(alignment: .trailing) {
+                TimestampGutterLabel(
+                    date: item.block.timestamp,
+                    width: TranscriptGutter.gutterWidth,
+                    tokens: tokens
+                )
+                .offset(x: TranscriptGutter.gutterWidth - reveal)
+                .allowsHitTesting(false)
+            }
     }
 
     @ViewBuilder
@@ -231,7 +235,7 @@ struct SystemNoticeView: View {
     }
 }
 
-/// Gutter geometry, defined ONCE and shared by the cell's reveal gesture and the
+/// Gutter geometry, defined ONCE and shared by the cell's reveal offset and the
 /// legacy TranscriptView (no duplicate constants).
 enum TranscriptGutter {
     /// Width of the revealed timestamp strip / how far the cell slides.
@@ -239,47 +243,4 @@ enum TranscriptGutter {
     /// Finger travel needed for a full reveal. Longer than the strip itself,
     /// so the strip arrives damped instead of slamming open on a flick.
     static let gutterTravel: CGFloat = 96
-}
-
-/// Applies the legacy swipe-to-reveal-timestamp gesture to a single cell,
-/// ported VERBATIM from the old TranscriptView: same finger-travel threshold,
-/// same offset math, same spring.
-///
-/// A wrapper View so the `@GestureState` lives in a SwiftUI-backed view — the
-/// cell itself is a `TiledCellContent` (not a `View`), and `@GestureState`
-/// needs real DynamicProperty storage. The gesture is simultaneous with the
-/// scroll view's own pan and deliberately inert unless the movement is clearly
-/// sideways and leftward, so neither gesture steals from the other.
-struct TranscriptGutterReveal<Content: View>: View {
-    private let content: Content
-
-    /// Live drag offset, negative (leftward) and clamped to the strip width.
-    /// `@GestureState` resets itself the instant the finger lifts, which is what
-    /// springs the cell back with no release handler of our own.
-    @GestureState private var gutterReveal: CGFloat = 0
-
-    init(@ViewBuilder content: () -> Content) {
-        self.content = content()
-    }
-
-    var body: some View {
-        content
-            .offset(x: gutterReveal)
-            .animation(.interactiveSpring(response: 0.28, dampingFraction: 0.86), value: gutterReveal)
-            .simultaneousGesture(gutterGesture)
-    }
-
-    private var gutterGesture: some Gesture {
-        DragGesture(minimumDistance: 16)
-            .updating($gutterReveal) { value, state, _ in
-                let dx = value.translation.width
-                let dy = value.translation.height
-                guard dx < 0, -dx > abs(dy) * 1.5 else {
-                    state = 0
-                    return
-                }
-                let progress = min(1, -dx / TranscriptGutter.gutterTravel)
-                state = -TranscriptGutter.gutterWidth * progress
-            }
-    }
 }

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -125,6 +125,7 @@ struct TranscriptBlockCell: TiledCellContent {
     let item: TranscriptRow
     let tokens: Tokens
 
+    @MainActor
     func body(context: CellContext<Void>) -> some View {
         // The reveal offset now comes from MessagingUI's OWN pan recogniser, which
         // is installed on the collection view and declares simultaneous recognition


### PR DESCRIPTION
## BET-1104 — replace the two hand-rolled transcript gestures with MessagingUI's own

**Base: origin/main @ `953f0c3d`** (rebased onto latest main; includes BET-1103's stable `.steps` identity and all CI/docs changes).

### What changed

Two files, both under `mobile/native/MantaUI/`:

**`ChatScreen.swift` (Change 1 — tap-to-dismiss-keyboard).** Deleted
`.simultaneousGesture(TapGesture().onEnded { resignKeyboard() })` and added
`.onTapBackground { resignKeyboard() }` **above** `.onChange(of: store.rows, …)`
(the first type-erasing `View` modifier, so the ordering rule holds).
`resignKeyboard()` is unchanged and still the implementation.

**`TranscriptRow.swift` (Change 2 — swipe-to-reveal timestamp).**
- Deleted the per-cell SwiftUI `TranscriptGutterReveal` (the `@GestureState`
  `DragGesture`) that competed with the scroll pan.
- The reveal is now driven by MessagingUI's own pan recogniser via
  `context.cellReveal`. Sign convention follows `CellReveal`: positive on
  left-swipe, applied as `-reveal` on the content and `gutterWidth - reveal`
  on the timestamp label.
- `TranscriptGutter.gutterWidth` (58) unchanged.
- `gutterTravel` was **kept**, not deleted: it is still referenced by the
  legacy `TranscriptView` reveal in `TranscriptComponents.swift`, so removing
  it would have broken that file (per the issue's instruction to keep it if
  still referenced).

### Concurrency note (departed from the issue's sketch — this is the fix)

The issue's `AFTER` sketch called `context.cellReveal?.rubberbandedOffset(max:)`
directly in `TranscriptBlockCell.body(context:)`. That does not compile under
this app's **Swift 6 strict mode** (the merge gate confirmed it):

- `CellReveal` is `@MainActor @Observable final class` (`offset` and
  `rubberbandedOffset` are main-actor-isolated).
- `TiledCellContent.body(context:)` is a **nonisolated** protocol requirement,
  and Swift 6 rejects *any* main-actor isolation on the conformance — both
  `@MainActor` on the method ("cannot satisfy nonisolated requirement") and
  `@MainActor` on the struct ("conformance crosses into main actor-isolated
  code") were compile errors.

The working pattern: the cell's nonisolated `body` passes `context.cellReveal`
down to a plain **`TranscriptCellReveal: View`** child (init stays nonisolated,
so it's constructible from the cell body), whose own `View.body` runs on the
main actor and reads `rubberbandedOffset(max:)` legally.

### Verification

- **Compile + unit gate**: `ios-mantaui action=test-unit` on the rebased tip
  `8875dd52` — **PASS, 552 tests, 0 failures**.
- **Simulator build + launch**: `ios-mantaui action=simulator` — **PASS**
  (iPhone 17 Pro; app launched).
- **Three gesture behaviours (hands-on)**: **NOT yet verified from this run.**
  These need interactive simulator gestures (tap background with keyboard up,
  swipe-left reveal, first-swipe scroll) which cannot be synthesized from the
  Linux box. Delegated for hands-on confirmation. Will not claim these pass.

### Definition of done
- [x] `.simultaneousGesture(TapGesture…)` deleted; `.onTapBackground` added above `.onChange`
- [x] `resignKeyboard()` kept and still the implementation
- [x] Cell body driven by `context.cellReveal`; `TranscriptGutterReveal` deleted
- [x] `ios-mantaui action=test-unit` green — 552 tests, 0 failures
- [ ] Three gesture behaviours confirmed hands-on (delegated)
- [x] PR opened with the issue key in the TITLE
