### PR TITLE
BET-1110: SwiftPM manifest so pure logic compiles and tests on Linux

### DIFF
--- a/.github/workflows/swift-core-test.yml
+++ b/.github/workflows/swift-core-test.yml
@@ -1,0 +1,40 @@
+# Headless unit tests for the iOS app's pure logic.
+#
+# Runs on ubuntu, in the official Swift image, against mobile/native/Package.swift
+# — a manifest listing the Foundation-only subset of the app's sources. No Xcode,
+# no simulator, ~1 minute.
+#
+# This does NOT replace the macOS build/test job: it cannot see any code touching
+# SwiftUI, UIKit or the simulator. It is a fast first signal on the logic layer.
+#
+# NOT in required-checks.json: the paths filter means most PRs never produce this
+# context, and requiring it would block them all (see AGENTS.md).
+name: Swift Core Tests
+
+on:
+  pull_request:
+    paths:
+      - "mobile/native/**"
+      - ".github/workflows/swift-core-test.yml"
+
+concurrency:
+  group: swift-core-test-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  swift-core-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    container:
+      image: swift:6.1
+    defaults:
+      run:
+        working-directory: mobile/native
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Build
+        run: swift build --build-path .build
+
+      - name: Test
+        run: swift test --build-path .build

--- a/mobile/native/.gitignore
+++ b/mobile/native/.gitignore
@@ -1,0 +1,2 @@
+# SwiftPM build output from Package.swift / verify.sh (see Package.swift header).
+.build/

--- a/mobile/native/Package.swift
+++ b/mobile/native/Package.swift
@@ -1,0 +1,61 @@
+// swift-tools-version: 6.0
+//
+// A LINUX-BUILDABLE VIEW OF THE APP'S PURE LOGIC.
+//
+// This package does not own any source. It lists a subset of the iOS app target's
+// existing files — the ones that import nothing but Foundation — so they can be
+// compiled and unit-tested headlessly with `swift test`, in Docker, on a machine
+// with no Xcode. The Xcode project (generated from project.yml by xcodegen) still
+// compiles the very same files for the app; this is a second, parallel view of
+// them, not a fork.
+//
+// WHY: there is no Swift toolchain on the Linux dev box, so an agent working there
+// otherwise cannot compile or test ANY Swift, and every change round-trips through
+// a Mac. That loop is slow enough that logic regressions ship. Most of the testable
+// logic needs a Mac only by accident of where it lives.
+//
+// The module is deliberately named `MantaUI` so the existing tests' `@testable
+// import MantaUI` resolves unchanged. It is a separate build from the Xcode target
+// of the same name; they never link together.
+//
+// NO `platforms:` CLAUSE ON PURPOSE — declaring an iOS platform would make this
+// unbuildable on Linux, which is the entire point of the package.
+//
+// TO ADD A FILE: append it to `sources` and run ./verify.sh. If it fails to build,
+// it depends on UIKit/SwiftUI (directly or through another type) and does not
+// belong here. Never edit a source file to make it fit.
+
+import PackageDescription
+
+let package = Package(
+    name: "MantaCore",
+    products: [
+        .library(name: "MantaUI", targets: ["MantaUI"])
+    ],
+    targets: [
+        .target(
+            name: "MantaUI",
+            path: "MantaUI",
+            sources: [
+                "ArtifactDerivation.swift",
+                "ChatModel.swift",
+                "MantaModels.swift",
+                "ModelRecents.swift",
+                "VoiceGesture.swift",
+                "Waveform.swift",
+            ],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        ),
+        .testTarget(
+            name: "MantaUITests",
+            dependencies: ["MantaUI"],
+            path: "MantaUITests",
+            sources: [
+                "ArtifactDerivationTests.swift",
+                "VoiceGestureTests.swift",
+                "WaveformTests.swift",
+            ],
+            swiftSettings: [.swiftLanguageMode(.v6)]
+        )
+    ]
+)

--- a/mobile/native/verify.sh
+++ b/mobile/native/verify.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Compile + unit-test the app's pure logic on Linux, in Docker.
+#
+# The Linux dev box has no Swift toolchain, so this runs the official Swift image
+# against mobile/native/Package.swift — a manifest listing the Foundation-only
+# subset of the app's sources (see the comment in Package.swift).
+#
+# This is NOT the merge gate. It cannot see anything that touches SwiftUI, UIKit
+# or the simulator. The full gate is the Mac plugin:
+#   plugin_run("ios-mantaui", { action: "test-unit", branch: "<branch>" })
+# Use this for a fast inner loop, that for sign-off.
+set -euo pipefail
+
+cd "$(dirname "$0")"
+
+IMAGE="${SWIFT_IMAGE:-swift:6.1}"
+
+exec docker run --rm \
+  -v "$PWD:/work" \
+  -w /work \
+  "$IMAGE" \
+  bash -lc "swift build --build-path .build && swift test --build-path .build"


### PR DESCRIPTION
## What

Adds a SwiftPM manifest so the app's pure Foundation-only logic compiles and unit-tests headlessly on Linux (no Mac, no Xcode, no toolchain on the box). A parallel build of the same sources — nothing is moved or edited.

- `mobile/native/Package.swift` (NEW) — module `MantaUI`, Swift 6 language mode, **zero dependencies**, **no `platforms:` clause**. Lists existing files explicitly, in place.
- `mobile/native/verify.sh` (NEW, mode 100755) — `swift build && swift test` in the `swift:6.1` Docker image.
- `mobile/native/.gitignore` (NEW) — ignores `.build/`.
- `.github/workflows/swift-core-test.yml` (NEW) — `Swift Core Tests` on the logic layer (not in `required-checks.json`; paths-filtered).

No `.swift` file was moved, renamed or edited. `project.yml` and `project.pbxproj` untouched (BET-1103/1104/1105 own those).

## File set (derived mechanically, per ticket Step 1–3)

**Sources (6):** `ArtifactDerivation`, `ChatModel`, `MantaModels`, `ModelRecents`, `VoiceGesture`, `Waveform` — from the ticket's seed plus the Foundation-only candidates the seed depends on (`ChatModel`, `MantaModels`).

**Tests (3):** `ArtifactDerivationTests`, `VoiceGestureTests`, `WaveformTests`.

**Candidate files dropped from the seed, and why** (per Step 3 — never edited a source to make it fit):
- `ComposerTypeahead` + `ComposerTypeaheadTests` — needs `SendPromptInput` (`ChatModels.swift`)
- `PlanDerivation` + `PlanDerivationTests` — needs `ChatJSON` (`ChatModels.swift`)
- `UsageMeters` + `UsageMetersTests` — needs `StreamContextPayload`/`Segment`/`CachePayload` (`MantaStreamModels.swift`), which needs `MantaError` (`MantaAPIClient.swift`) — not Linux-buildable (`URLSession` → FoundationNetworking + heavy deps)
- `ChatModels.swift` (source only) — declares types requiring `TranscriptComponents.swift` (SwiftUI/MarkdownView) and `MantaEventStore.swift` (Combine)
- `ModelRecentsTests` (test only) — needs `ChatModelStore` (Combine)

`ModelRecents.swift` source stays (compiles with `ChatModel`+`MantaModels`) though its test was dropped.

## Verification

- **Image used:** `swift:6.1` (the default in verify.sh worked; no fallback).
- **Sources:** 6. **Tests:** 3 test files, **65 tests**, 0 failures.
- **Break-it check:** changed `Waveform.Constants.sampleIntervalMs` 40→41 → `verify.sh` went RED (`XCTAssertEqual failed ("41") is not equal to ("40")`), then `git checkout` restored → green (65/65). Proves the tests really execute.
- **Mac gate (`ios-mantaui` action=test-unit): GREEN.** 552 tests, 0 failures — iOS build unaffected.
- **CI:** `Swift Core Tests` job green on this PR (run success, ~43s). Also `typecheck-test`, `swiftlint`, `duplication-gate` green.
- **`git diff --stat`:** only new files; zero `.swift` modified, zero `project.yml`, zero pbxproj.

```
 .github/workflows/swift-core-test.yml | 40 +++++++
 mobile/native/.gitignore              |  2 +
 mobile/native/Package.swift           | 61 +++++++
 mobile/native/verify.sh               | 22 +++++
 4 files changed, 125 insertions(+)
```

> Note: the first Mac-gate run on this branch went red on `ToolOutputPreviewTests.testThirtyLinesKeepsLastTwelveWithPrefix`. That was the stale-base artifact fixed by BET-1106 (a `contains("line 1")` substring false-positive — the kept tail "line 19" contains the substring "line 1"); the fix landed on `main` after this branch's original base. Rebased onto current `main` (base `e27e119`) and re-ran: green. This PR adds no code to that test path.

Base: `origin/main @ e27e119`
