### PR TITLE
fix(ios): add keychain-access-groups entitlement to MantaUITests target (BET-1113)

### DIFF
--- a/.github/workflows/ios-build.yml
+++ b/.github/workflows/ios-build.yml
@@ -86,7 +86,13 @@ jobs:
             -project MantaUI.xcodeproj \
             -scheme MantaUI \
             -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
-            CODE_SIGNING_ALLOWED=NO \
+            # Ad-hoc sign (the gate used CODE_SIGNING_ALLOWED=NO): the Keychain
+            # round-trip test needs keychain-access-groups embedded in a code
+            # signature; an unsigned bundle carries no entitlements, so the
+            # simulator rejects every SecItem call with errSecMissingEntitlement
+            # (-34018). CODE_SIGN_IDENTITY=- embeds the project.yml entitlements
+            # ad-hoc, which is all a simulator destination requires.
+            CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES \
             2>&1 | xcbeautify --renderer github-actions
 
       - name: Run unit tests (MantaUITests)
@@ -98,7 +104,13 @@ jobs:
             -destination "platform=iOS Simulator,id=${{ steps.sim.outputs.udid }}" \
             -only-testing:MantaUITests \
             -resultBundlePath TestResults.xcresult \
-            CODE_SIGNING_ALLOWED=NO \
+            # Ad-hoc sign (the gate used CODE_SIGNING_ALLOWED=NO): the Keychain
+            # round-trip test needs keychain-access-groups embedded in a code
+            # signature; an unsigned bundle carries no entitlements, so the
+            # simulator rejects every SecItem call with errSecMissingEntitlement
+            # (-34018). CODE_SIGN_IDENTITY=- embeds the project.yml entitlements
+            # ad-hoc, which is all a simulator destination requires.
+            CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES \
             2>&1 | xcbeautify --renderer github-actions
 
       - name: Upload test results

--- a/mobile/native/MantaUITests/MantaUITests.entitlements
+++ b/mobile/native/MantaUITests/MantaUITests.entitlements
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>keychain-access-groups</key>
+	<array>
+		<string>$(AppIdentifierPrefix)com.antoinedc.mantaui.tests</string>
+		<string>$(AppIdentifierPrefix)com.antoinedc.mantaui</string>
+	</array>
+</dict>
+</plist>

--- a/mobile/native/TEST-REPORT-BET-1113.md
+++ b/mobile/native/TEST-REPORT-BET-1113.md
@@ -1,0 +1,46 @@
+# BET-1113 — iOS Simulator test-run report (macos verification)
+
+Verified on Antoine's Mac (agent `macos`) against the exact branch source
+(`multica/BET-1113-ios-keychain-entitlement`, head `bb4e65ff`), in a clean
+git worktree so the shared checkout was not disturbed.
+
+## Environment
+
+- Xcode 26.6 (Build 17F113)
+- Swift 6.3.3
+- iOS Simulator: iPhone 17 Pro — iOS 26.5 (device id `25EEA3D7-2995-4B76-A991-7F817E94A4FB`, iOS 26.5)
+- Project regenerated with `xcodegen generate` from `mobile/native/project.yml`
+  (the committed source of truth, which wires `CODE_SIGN_ENTITLEMENTS` =
+  `MantaUITests/MantaUITests.entitlements` into the `MantaUITests` target).
+
+## Result — the reported failure is fixed
+
+The failing test now passes:
+
+```
+Test Case '-[MantaUITests.MantaTransportTests
+  testTokenRoundTripsThroughKeychainAndIsAbsentFromUserDefaults]' passed (0.013 seconds).
+Test Suite 'MantaTransportTests' passed at 2026-08-18 14:35:24.867.
+     Executed 1 test, with 0 failures (0 unexpected) in 0.013 (0.014) seconds
+** TEST EXECUTE SUCCEEDED **
+```
+
+No `errSecMissingEntitlement` (`-34018`) and the `UserDefaults`-absence
+assertion is green: the token round-trips through the Keychain and is absent
+from `UserDefaults`.
+
+## Full MantaUITests suite
+
+```
+Executed 552 tests, with 0 failures (0 unexpected) in 1.079 (1.311) seconds
+** TEST SUCCEEDED **
+```
+
+This reproduces/re-exceeds the CI suite scale noted in BET-1113 (CI reported
+~548 total; local run has 552 due to in-flight test additions on the branch).
+
+## Conclusion
+
+manta-dev's fix (add `keychain-access-groups` entitlement to the `MantaUITests`
+target via `mobile/native/project.yml` + `MantaUITests.entitlements`) resolves
+the simulator Keychain round-trip failure. Ready for manta-reviewer.

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -170,6 +170,10 @@ targets:
       base:
         PRODUCT_BUNDLE_IDENTIFIER: com.antoinedc.mantaui.tests
         GENERATE_INFOPLIST_FILE: YES
+        # Simulator keychain access (KeychainCredentialStore) requires the
+        # keychain-access-groups entitlement; without it the test bundle hits
+        # errSecMissingEntitlement (-34018) and the token never round-trips.
+        CODE_SIGN_ENTITLEMENTS: MantaUITests/MantaUITests.entitlements
         CODE_SIGN_STYLE: Automatic
   # The UI test bundle is the hierarchy-dump leg of the native capture harness.
   # It launches the app and prints the accessibility tree (see capture.sh and


### PR DESCRIPTION
Fixes BET-1113: `testTokenRoundTripsThroughKeychainAndIsAbsentFromUserDefaults` fails with `errSecMissingEntitlement` (-34018) on the CI simulator.

## Root cause (two parts)

1. **No Keychain entitlement** — the `MantaUITests` bundle was signed with no entitlements at all, so `KeychainCredentialStore`'s `SecItem…` calls (generic password) hit `errSecMissingEntitlement` and the token never round-trips.
2. **CI never embeds entitles anyway** — the `ios-build` gate ("iOS Build & Test") ran both `build-for-testing` and `test-without-building` with `CODE_SIGNING_ALLOWED=NO`, so no bundle (app or test) was ever code-signed and the entitlement could not be in any signature. A local run that signs normally is green but is not CI's config, so it does not satisfy the gate.

## Fix
- Added `mobile/native/MantaUITests/MantaUITests.entitlements` with a `keychain-access-groups` array (test + host-app groups).
- Wired `CODE_SIGN_ENTITLEMENTS: MantaUITests/MantaUITests.entitlements` into the `MantaUITests` target in `mobile/native/project.yml` (xcodegen source of truth; CI regenerates the pbxproj).
- Changed `.github/workflows/ios-build.yml` (both steps) from `CODE_SIGNING_ALLOWED=NO` to ad-hoc signing (`CODE_SIGN_IDENTITY=- CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=YES`), so xcodebuild embeds the Keychain entitlement ad-hoc on the simulator destination. Ad-hoc is all a simulator needs; no signing cert/team required.
- No Swift source changes; the test's `UserDefaults`-absence assertions are untouched.

## Verification
- `macos` confirmed the test passes on a real signed simulator run (552 tests, 0 failures) — recorded at `mobile/native/TEST-REPORT-BET-1113.md`.
- The authoritative check is the `ios-build` gate on this PR, which was re-triggered on head `5c770477` with the ad-hoc-sign fix and must now come back green (previously it failed -34018 with `CODE_SIGNING_ALLOWED=NO`).

Base: origin/main @ 4b837c88 (rebased to pick up the BET-1107 gate).
