### PR TITLE
refactor(shared): one Unicode-aware slug function (BET-1115)

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -33,7 +33,7 @@ import {
   clearProgress as defaultClearProgress,
 } from "./progress.mjs";
 import { startPoller } from "./startPoller.mjs";
-import { slugify } from "../shared/worktree.mjs";
+import { slugifyProjectName } from "../shared/projectName.mjs";
 import {
   parseGitStatus,
   summarizeTranscript,
@@ -169,7 +169,7 @@ export function buildCompletionText(job) {
 // prompt, slugified. Pure.
 export function deriveName(prompt) {
   const words = String(prompt ?? "").trim().split(/\s+/).slice(0, 4).join(" ");
-  return slugify(words || "background");
+  return slugifyProjectName(words) || "background";
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/projectName.mjs
+++ b/src/shared/projectName.mjs
@@ -42,11 +42,18 @@ export function generateProjectName(rand = Math.random) {
  * strips leading/trailing `-`; truncates to 32 characters; strips any trailing
  * `-` left by the truncation. Empty or all-punctuation input returns `""`.
  *
+ * Latin diacritics are transliterated (`é` → `e`) via Unicode NFKD
+ * decomposition. Scripts with no ASCII decomposition (CJK, and
+ * non-decomposable Latin letters such as `ß` and `ø`) still slug away — an
+ * all-CJK name returns `""`, which callers already treat as "no usable name".
+ *
  * @param {string} input
  * @returns {string}
  */
 export function slugifyProjectName(input) {
   const slug = String(input ?? "")
+    .normalize("NFKD")
+    .replace(/\p{Diacritic}/gu, "")
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, "-")
     .replace(/^-+|-+$/g, "");

--- a/src/shared/projectName.test.ts
+++ b/src/shared/projectName.test.ts
@@ -57,6 +57,18 @@ describe("slugifyProjectName", () => {
     // trailing "-", which must be stripped.
     expect(slugifyProjectName("a".repeat(31) + "-b")).toBe("a".repeat(31));
   });
+
+  it("transliterates Latin diacritics via Unicode NFKD decomposition", () => {
+    expect(slugifyProjectName("Café Résumé")).toBe("cafe-resume");
+    expect(slugifyProjectName("Ångström IDE")).toBe("angstrom-ide");
+    expect(slugifyProjectName("naïve—dash")).toBe("naive-dash"); // em-dash U+2014
+  });
+
+  it("returns '' for a script with no ASCII decomposition", () => {
+    // A CJK name has no ASCII decomposition, so it yields no slug; callers
+    // already handle '' as "no usable name".
+    expect(slugifyProjectName("日本語")).toBe("");
+  });
 });
 
 describe("projectDirFor", () => {

--- a/src/shared/worktree.d.mts
+++ b/src/shared/worktree.d.mts
@@ -1,5 +1,3 @@
-export function slugify(name: string | null | undefined): string;
-
 export function deriveWorktree(input: {
   repoRoot: string;
   name: string;

--- a/src/shared/worktree.mjs
+++ b/src/shared/worktree.mjs
@@ -1,35 +1,26 @@
 // worktree.mjs — pure logic backing the "auto-create a git worktree when
-// creating a new chat session (window)" feature (BET-246). Three functions:
+// creating a new chat session (window)" feature (BET-246). Two functions:
 //
-//   slugify              — turn a free-form session/window name into a
-//                          filesystem- and git-branch-safe slug.
 //   deriveWorktree       — pick a non-colliding { path, branch } pair for
 //                          a sibling worktree next to the repo root.
 //   isWorktreeDirtyError — classify git's "worktree remove" stderr so the
 //                          renderer can decide whether to confirm a force.
+//
+// The slug comes from the one shared slug function, slugifyProjectName in
+// projectName.mjs (BET-1115).
 //
 // Pure + framework-free (no fs, no fetch). Imports `node:path` only for the
 // pure `dirname` / `basename` helpers — the I/O lives in
 // src/server/local.mjs (gitAddWorktree / gitRemoveWorktree).
 
 import { dirname, basename } from "node:path";
-
-// Lowercase, non-[a-z0-9] runs → "-", trim leading/trailing "-". Empty
-// (or all-symbol / all-unicode) result → "session". Kept in sync with the
-// collision-safe naming style of deriveSubagentName in subagentSync.mjs.
-export function slugify(name) {
-  const slug = String(name ?? "")
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, "-")
-    .replace(/^-+|-+$/g, "");
-  return slug || "session";
-}
+import { slugifyProjectName } from "./projectName.mjs";
 
 /**
  * Compute the { path, branch } for a sibling worktree next to `repoRoot`.
  *
  *   parent = dirname(repoRoot); base = basename(repoRoot).
- *   baseSlug = slugify(name).
+ *   baseSlug = slugifyProjectName(name).
  *   branch candidates: baseSlug, baseSlug-2, baseSlug-3, ...
  *   path  candidates: `${parent}/${base}-${candidate}`, same suffix in lockstep.
  *   Return the first candidate where neither `dirExists(path)` nor
@@ -49,7 +40,7 @@ export function slugify(name) {
 export function deriveWorktree({ repoRoot, name, dirExists, branchExists }) {
   const base = basename(repoRoot);
   const parent = dirname(repoRoot);
-  const baseSlug = slugify(name);
+  const baseSlug = slugifyProjectName(name) || "session";
   let candidate = baseSlug;
   let n = 2;
   while (

--- a/src/shared/worktree.test.ts
+++ b/src/shared/worktree.test.ts
@@ -1,39 +1,8 @@
 import { describe, it, expect } from "vitest";
 import {
-  slugify,
   deriveWorktree,
   isWorktreeDirtyError,
 } from "./worktree.mjs";
-
-describe("slugify", () => {
-  it("lowercases, collapses spaces and strips symbols", () => {
-    expect(slugify("Hello World")).toBe("hello-world");
-  });
-
-  it("collapses runs of non-alphanumeric chars into a single '-'", () => {
-    expect(slugify("foo!!  bar??baz")).toBe("foo-bar-baz");
-  });
-
-  it("trims leading and trailing '-'", () => {
-    expect(slugify("  --hello--  ")).toBe("hello");
-  });
-
-  it("returns 'session' for an all-symbol / empty name", () => {
-    expect(slugify("")).toBe("session");
-    expect(slugify("___")).toBe("session");
-    expect(slugify("   ")).toBe("session");
-    expect(slugify("!!!")).toBe("session");
-  });
-
-  it("strips unicode to a '-', then collapses/trims to 'session'", () => {
-    expect(slugify("café — résumé")).toBe("caf-r-sum");
-  });
-
-  it("treats null/undefined as empty → 'session'", () => {
-    expect(slugify(null as unknown as string)).toBe("session");
-    expect(slugify(undefined as unknown as string)).toBe("session");
-  });
-});
 
 describe("deriveWorktree", () => {
   const REPO = "/home/me/projects/myapp";
@@ -60,6 +29,19 @@ describe("deriveWorktree", () => {
       branchExists: noBranch,
     });
     expect(r).toEqual({ path: `${PARENT}/${BASE}-session`, branch: "session" });
+  });
+
+  it("caps a long name to a 32-character branch", () => {
+    // The 32-char cap now applies to worktree branches too (BET-1115).
+    const name = "x".repeat(40);
+    const r = deriveWorktree({
+      repoRoot: REPO,
+      name,
+      dirExists: noDir,
+      branchExists: noBranch,
+    });
+    expect(r.branch).toHaveLength(32);
+    expect(r.branch).toBe("x".repeat(32));
   });
 
   it("appends -2, -3, … when the directory collides", () => {


### PR DESCRIPTION
Consolidates the two near-identical slug functions in `src/shared/` into the single Unicode-aware `slugifyProjectName`. Deletes `worktree.mjs`'s `slugify` and routes both callers through the surviving one.

- Net deletion: one slug function deleted, two callers moved (no new dependency, no new module)
- `slugifyProjectName` now transliterates Latin diacritics (`Café Résumé` → `cafe-resume`) via Unicode NFKD decomposition; CJK / non-decomposable scripts still slug away (all-CJK → `""`, which callers already handle)
- The 32-char cap now applies to worktree branches and background-job names too (desirable — a branch name is not a place for a 200-char prompt fragment)

Files: `src/shared/projectName.mjs`, `src/shared/worktree.mjs`, `src/shared/worktree.d.mts`, `src/server/delegate.mjs`, `src/shared/{worktree,projectName}.test.ts`

**Verification results:**
- PR branch (`multica/BET-1115-unicode-slug` @ `HEAD`):
  - typecheck: exit 0, no errors
  - test: 2353 pass / 0 fail / 0 skip
- **Conclusion:** 0 failures on the PR branch; no new failures.

Base: origin/main @ 953f0c3d
