### PR TITLE
BET-1116: free-form scratch project name, drop reroll and git controls

### DIFF
--- a/src/renderer/NewSessionScreen.harness.test.tsx
+++ b/src/renderer/NewSessionScreen.harness.test.tsx
@@ -354,32 +354,7 @@ describe("NewSessionScreen scratch mode (BET-1093)", () => {
     expect(nameInput!.value).toMatch(/^[a-z]+-[a-z]+-[a-z]+$/);
   });
 
-  it("reroll produces a different project name", async () => {
-    const d = scratchDraft();
-    mountScratch(d);
-    await h!.flush();
-
-    const nameInput = h!.container.querySelector(
-      'input[aria-label="Project name"]',
-    ) as HTMLInputElement;
-    const first = nameInput!.value;
-    expect(first).toBe("fresh-app");
-
-    const reroll = [...h!.container.querySelectorAll("button")].find(
-      (b) => b.getAttribute("aria-label") === "Pick another name",
-    );
-    expect(reroll).toBeTruthy();
-    act(() => reroll!.click());
-    await h!.flush();
-
-    const second = (
-      h!.container.querySelector('input[aria-label="Project name"]') as HTMLInputElement
-    ).value;
-    expect(second).not.toBe(first);
-    expect(second).toMatch(/^[a-z]+-[a-z]+-[a-z]+$/);
-  });
-
-  it("slugifies the typed project name as the user types", async () => {
+  it("keeps the typed project name verbatim and previews the derived folder", async () => {
     const d = scratchDraft();
     mountScratch(d);
     await h!.flush();
@@ -390,11 +365,47 @@ describe("NewSessionScreen scratch mode (BET-1093)", () => {
     act(() => typeIntoInput(nameInput, "My App"));
     await h!.flush();
 
+    // The field keeps the typed text verbatim — never rewritten to a slug.
     expect(
       (
         h!.container.querySelector('input[aria-label="Project name"]') as HTMLInputElement
       ).value,
-    ).toBe("my-app");
+    ).toBe("My App");
+    // The destination line previews the DERIVED folder slug (root is /home).
+    expect(h!.text()).toContain("/home/my-app");
+  });
+
+  it("a name with no letters or digits disables create and explains why", async () => {
+    const d = scratchDraft({ input: "" });
+    mountScratch(d);
+    await h!.flush();
+
+    const nameInput = h!.container.querySelector(
+      'input[aria-label="Project name"]',
+    ) as HTMLInputElement;
+    act(() => typeIntoInput(nameInput, "!!!"));
+    await h!.flush();
+
+    const create = h!.container.querySelector(
+      'button[aria-label="Create workspace"]',
+    ) as HTMLButtonElement;
+    expect(create).toBeTruthy();
+    expect(create.disabled).toBe(true);
+    expect(h!.text()).toContain("Add at least one letter or number");
+  });
+
+  it("scratch mode renders no branch or worktree control", async () => {
+    const d = scratchDraft();
+    mountScratch(d);
+    await h!.flush();
+
+    expect(
+      h!.container.querySelector('input[aria-label="Worktree branch name"]'),
+    ).toBeNull();
+    expect(
+      h!.container.querySelector('input[aria-label="Create in a fresh git worktree"]'),
+    ).toBeNull();
+    expect(h!.text()).not.toContain("worktree");
   });
 
   it("submit with an empty prompt creates the scratch dir, no createDir, no queued prompt", async () => {

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -33,7 +33,6 @@ import {
   Loader2,
   Mic,
   Paperclip,
-  RotateCw,
 } from "lucide-react";
 import { useStore } from "./store";
 import { Chip } from "./Chip";
@@ -432,6 +431,14 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
     return s;
   }, [fsEntries, existingProjects]);
 
+  // The folder name is DERIVED from the typed project name — the user types
+  // freely, the filesystem gets a safe slug. One derivation, read by the
+  // destination line, the collision hint and the create button.
+  const scratchFolder = useMemo(
+    () => slugifyProjectName(draft.projectName),
+    [draft.projectName],
+  );
+
   useEffect(() => {
     if (!draft.scratch || !draft.scratchRoot) {
       setFsEntries(new Set());
@@ -761,9 +768,9 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   // git repo, so the worktree intent can't be honored yet. Render the chip
   // unchecked and enabled so the picker can choose a folder first.
   const emptyWorktree = isNewProject && !isGitRepo;
-  // A repo with no commits has nothing to branch from, and an empty scratch
-  // project is by definition commit-less — force the worktree checkbox off.
-  const worktreeChipEnabled = !draft.scratch && (emptyWorktree || isGitRepo);
+  // A repo with no commits has nothing to branch from. The worktree checkbox
+  // no longer renders in scratch mode, so there's no scratch guard needed.
+  const worktreeChipEnabled = emptyWorktree || isGitRepo;
 
   // The repo-probe zero state is the NEW-project zero state only. The
   // new-session-in-an-existing-project variant keeps today's composer
@@ -776,7 +783,15 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   // mode with an empty prompt (the action creates the project), otherwise the
   // standard "Start a session".
   const createLabel = draft.scratch && !draft.input.trim() ? "Create workspace" : "Start a session";
-  const scratchNameTaken = draft.scratch && !!draft.projectName && scratchTaken.has(draft.projectName);
+  // One hint slot for the scratch name: either it cannot produce a folder at
+  // all, or it collides with something already under the root. Never both.
+  const scratchHint = !draft.scratch
+    ? null
+    : !scratchFolder
+      ? "Add at least one letter or number — that becomes the folder name."
+      : scratchTaken.has(scratchFolder)
+        ? `${scratchFolder} already exists — will create ${uniqueSessionName(scratchFolder, scratchTaken)}`
+        : null;
 
   return (
     // data-screen is the visual harness's handle on this screen (see
@@ -811,77 +826,71 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
           )}
         </div>
 
-        {/* Chip row — in scratch mode the name input + reroll replace the folder
-            chip; the branch chip + worktree checkbox stay in both modes. */}
+        {/* Chip row — in scratch mode ONLY the name input renders; a brand-new
+            empty directory has no branch and nothing to branch from, so there
+            is no folder chip, no branch chip and no worktree checkbox. */}
         <div className="self-start flex flex-col gap-2">
         <div className="flex items-center gap-2">
           {draft.scratch ? (
-            <>
-              <input
-                value={draft.projectName}
-                onChange={(e) =>
-                  updateDraft(draftId, { projectName: slugifyProjectName(e.target.value) })
-                }
-                spellCheck={false}
-                className="h-8 w-[240px] rounded-md border border-accent bg-bg-soft px-3 text-meta font-mono text-text outline-none focus:border-accent"
-                placeholder="project-name"
-                aria-label="Project name"
-              />
-              <IconButton
-                icon={<RotateCw />}
-                label="Pick another name"
-                onClick={() => updateDraft(draftId, { projectName: generateProjectName() })}
-              />
-            </>
-          ) : (
-            <Chip
-              onClick={() => {
-                setPickerTarget("cwd");
-                setPickerOpen(true);
-              }}
-              title={draft.cwd || "Select folder"}
-            >
-              <FolderIcon size={13} className="shrink-0 text-text-muted" aria-hidden="true" />
-              <span className="truncate max-w-[200px]">{folderLabel}</span>
-              <ChevronDown size={13} className="shrink-0 text-text-faint" aria-hidden="true" />
-            </Chip>
-          )}
-
-          {draft.wantWorktree && isGitRepo ? (
             <input
-              value={draft.worktreeBranch}
-              onChange={(e) => updateDraft(draftId, { worktreeBranch: e.target.value })}
+              value={draft.projectName}
+              onChange={(e) => updateDraft(draftId, { projectName: e.target.value })}
               spellCheck={false}
-              className="h-8 w-[132px] rounded-md border border-accent bg-bg-soft px-3 text-meta font-mono text-text outline-none focus:border-accent"
-              placeholder="branch-name"
-              aria-label="Worktree branch name"
+              className="h-8 w-[240px] rounded-md border border-accent bg-bg-soft px-3 text-meta text-text outline-none focus:border-accent"
+              placeholder="Project name"
+              aria-label="Project name"
             />
           ) : (
-            // When "worktree" is unchecked the branch is not editable — it is
-            // metadata about the folder, not a control. An inert Tag (no
-            // button, no onClick, no popover) matches the session header's
-            // branch badge and avoids a dead hover affordance.
-            <Tag
-              size="sm"
-              icon={<GitBranch size={11} aria-hidden="true" className="shrink-0" />}
-              title={branchName ? `On branch ${branchName}` : "Not a git repository"}
-            >
-              <span className="truncate max-w-[120px]">{branchName ?? "no branch"}</span>
-            </Tag>
-          )}
+            <>
+              <Chip
+                onClick={() => {
+                  setPickerTarget("cwd");
+                  setPickerOpen(true);
+                }}
+                title={draft.cwd || "Select folder"}
+              >
+                <FolderIcon size={13} className="shrink-0 text-text-muted" aria-hidden="true" />
+                <span className="truncate max-w-[200px]">{folderLabel}</span>
+                <ChevronDown size={13} className="shrink-0 text-text-faint" aria-hidden="true" />
+              </Chip>
 
-          <Checkbox
-            checked={draft.wantWorktree}
-            disabled={!worktreeChipEnabled}
-            onChange={(v) => updateDraft(draftId, { wantWorktree: v })}
-            label="worktree"
-            ariaLabel="Create in a fresh git worktree"
-          />
+              {draft.wantWorktree && isGitRepo ? (
+                <input
+                  value={draft.worktreeBranch}
+                  onChange={(e) => updateDraft(draftId, { worktreeBranch: e.target.value })}
+                  spellCheck={false}
+                  className="h-8 w-[132px] rounded-md border border-accent bg-bg-soft px-3 text-meta font-mono text-text outline-none focus:border-accent"
+                  placeholder="branch-name"
+                  aria-label="Worktree branch name"
+                />
+              ) : (
+                // When "worktree" is unchecked the branch is not editable — it is
+                // metadata about the folder, not a control. An inert Tag (no
+                // button, no onClick, no popover) matches the session header's
+                // branch badge and avoids a dead hover affordance.
+                <Tag
+                  size="sm"
+                  icon={<GitBranch size={11} aria-hidden="true" className="shrink-0" />}
+                  title={branchName ? `On branch ${branchName}` : "Not a git repository"}
+                >
+                  <span className="truncate max-w-[120px]">{branchName ?? "no branch"}</span>
+                </Tag>
+              )}
+
+              <Checkbox
+                checked={draft.wantWorktree}
+                disabled={!worktreeChipEnabled}
+                onChange={(v) => updateDraft(draftId, { wantWorktree: v })}
+                label="worktree"
+                ariaLabel="Create in a fresh git worktree"
+              />
+            </>
+          )}
         </div>
 
         {draft.scratch && (
           <div className="text-meta text-text-faint font-mono">
-            ↳ {draft.scratchRoot}/{draft.projectName} ·{" "}
+            ↳ {draft.scratchRoot}/{scratchFolder} ·{" "}
             <button
               type="button"
               onClick={() => {
@@ -895,12 +904,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
           </div>
         )}
 
-        {scratchNameTaken && (
-          <span className="text-meta text-warn">
-            {draft.projectName} already exists — will create{" "}
-            {uniqueSessionName(draft.projectName, scratchTaken)}
-          </span>
-        )}
+        {scratchHint && <span className="text-meta text-warn">{scratchHint}</span>}
         </div>
 
         {/* Composer — a single tall input card. */}
@@ -928,7 +932,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
 
           <button
             onClick={() => void submit()}
-            disabled={sending || (!draft.input.trim() && !draft.scratch)}
+            disabled={sending || (draft.scratch ? !scratchFolder : !draft.input.trim())}
             aria-label={createLabel}
             title={
               sending


### PR DESCRIPTION
BET-1116 — Start from scratch: free-form project name, drop the reroll button and the git controls

Renderer-only. Types the project name verbatim (no per-keystroke slugify), derives the folder name once via `scratchFolder`, removes the "Pick another name" reroll button, removes the RotateCw import, and makes scratch mode render NO git controls (no branch chip, no worktree checkbox). One derived `scratchHint` drives the collision/warning line, and the create button refuses a name that cannot produce a folder.

Server unchanged — `projectCreateScratch` remains the single source of truth for the final directory name; `submit()` still sends `{ root, name: draft.projectName }`.

No new store field/action, no new RPC channel, no new component.

Base: origin/main @ 953f0c3d
