### PR TITLE
fix(renderer): fall back to the title agent for the first auto-rename (BET-1100 follow-up)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -1196,3 +1196,78 @@ describe("ChatPanel auto-rename single rename (BET-1101)", () => {
     expect(api.calls.tmuxRenameWindow ?? []).toHaveLength(1);
   });
 });
+
+// ===== Auto-rename first-turn fallback (BET-1100 follow-up) =====
+//
+// BET-1100/1101 assumed opencode auto-titles a session from its first user
+// message "for free". That premise is FALSE — a session created with an empty
+// title stays empty-titled even after its first turn (verified live against
+// opencode 1.18.10). So the first-name path read back "" and skipped the
+// rename, leaving the creation-time first-word placeholder ("im"). This pins
+// the fix: when opencode has no title, the first turn falls through to
+// opencodeGenerateTitle (the title agent) so it still renames exactly once.
+describe("ChatPanel auto-rename first-turn fallback (BET-1100 follow-up)", () => {
+  let api: MockApi;
+  let bus: MockEventBus;
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("generates a title when opencode left the session untitled, renaming once", async () => {
+    // opencode has NOT titled the session (title:""), as on a live box.
+    ({ api, bus } = installMockApi({
+      opencodeListSessions: () =>
+        Promise.resolve([{ id: "ses_test", title: "" }]),
+      opencodeGenerateTitle: () => Promise.resolve("Manta setup check"),
+    }));
+    resetStore({ autoRenameSessions: true });
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const textarea = h.container.querySelector("textarea") as HTMLTextAreaElement;
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    await act(async () => {
+      setter?.call(textarea, "I'm just checking the manta setup");
+      textarea.dispatchEvent(new Event("input", { bubbles: true }));
+    });
+    await act(async () => {
+      textarea.dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await h.flush();
+    expect(h.text()).toContain("I'm just checking the manta setup");
+
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: true },
+    });
+    await emitStreamAndFlush(bus, h, {
+      sub: "running",
+      sessionId: "ses_test",
+      payload: { running: false },
+    });
+
+    // The empty title forced the title-agent fallback, which produced the name.
+    expect(api.calls.opencodeGenerateTitle ?? []).toHaveLength(1);
+    const renames = api.calls.tmuxRenameWindow ?? [];
+    expect(renames.length).toBe(1);
+    expect(renames[0][0]).toEqual({
+      sessionName: "proj",
+      windowIndex: 1,
+      newName: "Manta setup check",
+    });
+
+    // No second rename shortly after.
+    await new Promise((r) => setTimeout(r, 60));
+    await h.flush();
+    expect(api.calls.tmuxRenameWindow ?? []).toHaveLength(1);
+  });
+});

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1661,12 +1661,10 @@ export function ChatPanel({
       await refresh();
     };
 
-    // FIRST NAME — opencode already titles every session from its FIRST user
-    // message for free, so the first rename reads that title (one cheap list
-    // call) instead of spinning up a throwaway generation session. Only runs
-    // before any auto-rename this session; once lastAutoRenamedTurnRef is set,
-    // the every-Nth-turn path below takes over for drift tracking. If the
-    // title isn't populated yet, skip silently and let the next turn retry.
+    // FIRST NAME — opencode's own session title is the preferred first name
+    // (one cheap list call instead of a throwaway generation session). Only
+    // runs before any auto-rename this session; once lastAutoRenamedTurnRef
+    // is set, the every-Nth-turn path below takes over for drift tracking.
     if (lastAutoRenamedTurnRef.current === 0) {
       autoRenameInFlightRef.current = true;
       void (async () => {
@@ -1676,7 +1674,21 @@ export function ChatPanel({
           if (title) {
             await renameWindow(title);
             lastAutoRenamedTurnRef.current = turns;
+            return;
           }
+          // opencode does NOT auto-title a session created with an empty
+          // title — verified live (1.18.10): the title stays "" even after
+          // the first turn. BET-1100 assumed it did, so the first-name path
+          // read back "" and silently skipped, leaving the creation-time
+          // first-word placeholder ("im"). Fall through to the title agent
+          // (opencodeGenerateTitle) so the first turn still yields exactly
+          // ONE sensible rename.
+          const raw = await window.api.opencodeGenerateTitle({
+            directory: cwd ?? "",
+            instruction: buildTitleInstruction(buildTitlePromptInput(messages)),
+          });
+          await renameWindow(raw);
+          lastAutoRenamedTurnRef.current = turns;
         } catch {
           /* auto-rename is best-effort — never surface an error banner */
         } finally {


### PR DESCRIPTION
## Problem

BET-1100/1101 fixed the "Im then manta / Im" symptom by passing an EMPTY session title at all chat create sites, relying on the premise that **opencode auto-titles a session from its first user message "for free"**. That premise is **false**.

Verified live against the opencode on the box (1.18.10):

- `POST /session { title: "" }` → title is `""`
- after a real first user prompt + completed turn, `GET /session` still shows `title: ""`

So on a fresh chat window the first-name auto-rename path (`findSessionTitle` → rename) reads back an empty title, silently skips, and the window keeps its creation-time **first-word placeholder** ("im"). User-facing symptom: **"the first prompt just renames it to the first word, then no auto rename."**

The prior automated coverage mocked a titled session, so it never exercised the actual (empty) live-box case.

## Fix

In the auto-rename **first-name** path (`src/renderer/ChatPanel.tsx`), when `findSessionTitle` yields no title, **fall through to `opencodeGenerateTitle`** (the `title` agent — the same robust path the every-Nth-turn renames use). This guarantees a fresh window gets **exactly ONE sensible, punctuated rename** after its first turn instead of keeping the first-word placeholder. Verified the title agent returns e.g. `"Manta setup check"` for `"I'm just checking the manta setup"`.

The cheap fast-path (opencode's own title) is preserved for sessions that do carry one.

## Tests

- `src/renderer/ChatPanel.harness.test.tsx` — new regression test: session untitled → first turn calls `opencodeGenerateTitle` exactly once and renames once with the generated title, with no second rename shortly after.
- `npm run typecheck` ✅ · `npm test` ✅ (161 files, 3088 passed / 7 skipped) · `npm run test:server` ✅.

Closes the live regression from BET-1100 (merged on a false premise).