### PR TITLE
fix(ios): migrate transcript to MessagingUI snapshot API, pin past applyChange crash (BET-1105)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -1064,8 +1064,8 @@
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/FluidGroup/swiftui-messaging-ui";
 			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 1.0.0;
+				kind = revision;
+				revision = 1ec611adfb17c74075239565273f6902cdf77db6;
 			};
 		};
 /* End XCRemoteSwiftPackageReference section */

--- a/mobile/native/MantaUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/mobile/native/MantaUI.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -204,8 +204,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/FluidGroup/swiftui-messaging-ui",
       "state" : {
-        "revision" : "6dc8e5561bc27f107123c5cf40f358d095537f57",
-        "version" : "1.6.0"
+        "revision" : "1ec611adfb17c74075239565273f6902cdf77db6"
       }
     }
   ],

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1190,19 +1190,11 @@ struct ChatSubagentScreen: View {
 
 // MARK: - Shared transcript scroll layer (BET-1062)
 
-/// The transcript scroll layer, fed from `store.rows` as a snapshot. There is no
-/// separate data source and no change log to replay, so the BET-807/BET-1062
-/// change-log lifetime hazard is gone: MessagingUI diffs the snapshot internally
-/// to animate changes.
-///
-/// Rows are held in a LOCAL snapshot (`rows`) rather than passed to
-/// `TiledView(items:)` straight from the store. The transcript mounts only after
-/// the store's first fetch completes, so `store.rows` is already non-empty when
-/// this view first builds — and applying a non-empty snapshot inside `makeUIView`
-/// (before the collection view is laid out on-screen) renders blank cells. The
-/// local snapshot starts empty and is filled from `onChange(initial: true)`,
-/// mirroring the removed `.onChange { dataSource.apply }` timing: items apply on
-/// first appearance, after layout, so persisted history renders on open.
+/// The transcript scroll layer, feeding `store.rows` to MessagingUI's
+/// `TiledView(items:)` as a snapshot. There is no separate data source and no
+/// change log to replay, so the BET-807/BET-1062 change-log lifetime hazard is
+/// gone: the rows come straight from the store on every update, and MessagingUI
+/// diffs the snapshot internally to animate changes.
 ///
 /// One view serves both the parent chat and the read-only subagent drill-in:
 /// the subagent's old chain was a strict subset of the parent's, so this
@@ -1215,14 +1207,8 @@ struct TranscriptListView<Header: View>: View {
     var onPointsFromBottom: ((CGFloat) -> Void)? = nil
     @ViewBuilder var header: () -> Header
 
-    /// Local snapshot of `store.rows` fed to `TiledView(items:)`. Starts empty
-    /// so the collection view mounts and lays out before any items apply (see
-    /// the type doc — applying non-empty items at `makeUIView` renders blank).
-    /// A plain snapshot, not a change log; no replay/lifetime hazard.
-    @State private var rows: [TranscriptRow] = []
-
     var body: some View {
-        TiledView(items: rows, scrollPosition: $scrollPosition) { row in
+        TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
             TranscriptBlockCell(item: row, tokens: tokens)
         }
         .prependLoader(.loader(
@@ -1241,9 +1227,6 @@ struct TranscriptListView<Header: View>: View {
             onPointsFromBottom?(geometry.pointsFromBottom)
         }
         .onTapBackground { resignKeyboard() }
-        .onChange(of: store.rows, initial: true) { _, newRows in
-            rows = newRows
-        }
         .safeAreaBar(edge: .top) {
             header()
         }

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1190,11 +1190,19 @@ struct ChatSubagentScreen: View {
 
 // MARK: - Shared transcript scroll layer (BET-1062)
 
-/// The transcript scroll layer, feeding `store.rows` to MessagingUI's
-/// `TiledView(items:)` as a snapshot. There is no separate data source and no
-/// change log to replay, so the BET-807/BET-1062 change-log lifetime hazard is
-/// gone: the rows come straight from the store on every update, and MessagingUI
-/// diffs the snapshot internally to animate changes.
+/// The transcript scroll layer, fed from `store.rows` as a snapshot. There is no
+/// separate data source and no change log to replay, so the BET-807/BET-1062
+/// change-log lifetime hazard is gone: MessagingUI diffs the snapshot internally
+/// to animate changes.
+///
+/// Rows are held in a LOCAL snapshot (`rows`) rather than passed to
+/// `TiledView(items:)` straight from the store. The transcript mounts only after
+/// the store's first fetch completes, so `store.rows` is already non-empty when
+/// this view first builds — and applying a non-empty snapshot inside `makeUIView`
+/// (before the collection view is laid out on-screen) renders blank cells. The
+/// local snapshot starts empty and is filled from `onChange(initial: true)`,
+/// mirroring the removed `.onChange { dataSource.apply }` timing: items apply on
+/// first appearance, after layout, so persisted history renders on open.
 ///
 /// One view serves both the parent chat and the read-only subagent drill-in:
 /// the subagent's old chain was a strict subset of the parent's, so this
@@ -1207,8 +1215,14 @@ struct TranscriptListView<Header: View>: View {
     var onPointsFromBottom: ((CGFloat) -> Void)? = nil
     @ViewBuilder var header: () -> Header
 
+    /// Local snapshot of `store.rows` fed to `TiledView(items:)`. Starts empty
+    /// so the collection view mounts and lays out before any items apply (see
+    /// the type doc — applying non-empty items at `makeUIView` renders blank).
+    /// A plain snapshot, not a change log; no replay/lifetime hazard.
+    @State private var rows: [TranscriptRow] = []
+
     var body: some View {
-        TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
+        TiledView(items: rows, scrollPosition: $scrollPosition) { row in
             TranscriptBlockCell(item: row, tokens: tokens)
         }
         .prependLoader(.loader(
@@ -1227,6 +1241,9 @@ struct TranscriptListView<Header: View>: View {
             onPointsFromBottom?(geometry.pointsFromBottom)
         }
         .onTapBackground { resignKeyboard() }
+        .onChange(of: store.rows, initial: true) { _, newRows in
+            rows = newRows
+        }
         .safeAreaBar(edge: .top) {
             header()
         }

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -11,9 +11,8 @@ import MessagingUI
 // answerable permissions/questions) and renders through the EXISTING
 // TranscriptComponents (§8/§8a): there is no second transcript renderer.
 //
-// Container per BET-481: ScrollView + LazyVStack — do NOT re-measure or replace.
-// The scroll anchor is the one part that moved: it is scoped to `.sizeChanges`
-// and the initial landing is an explicit post-layout scroll (see `transcript`).
+// The transcript container is MessagingUI `TiledView` (UICollectionView-backed),
+// fed a snapshot of `store.rows`.
 // Subagent rows PUSH a live child
 // screen via NavigationStack (parent scroll untouched; BET-576 binds the child
 // to the same observable source).
@@ -178,8 +177,9 @@ private struct ChatScreenContent: View {
         autoScrollsToBottomOnAppend: true,
         scrollsToBottomOnReplace: true
     )
-    /// The `dataSource` (+ change log) is now owned by `TranscriptListView`,
-    /// which shares one lifetime with the scroll view it describes (BET-1062).
+    /// The transcript rows are passed to `TiledView(items:)` as a snapshot of
+    /// `store.rows`; MessagingUI diffs it internally, so there is no separate
+    /// data source or change log to keep in sync (BET-1105).
     /// Whether the transcript has been scrolled up far enough that the round
     /// "scroll to bottom" control (rendered in ComposerView's model-selection
     /// row) should be shown. Driven purely by scroll geometry; it does not
@@ -736,13 +736,10 @@ private struct ChatScreenContent: View {
     }
 
     private var transcript: some View {
-        // The whole scroll layer now lives in `TranscriptListView`, which owns
-        // the `ListDataSource` change log and therefore shares ONE lifetime
-        // with the scroll view it describes (BET-1062). Declaring the store on
-        // the screen (BET-807) let it outlive the scroll view when the
-        // transcript branch was left for the skeleton / load-failure state —
-        // the fresh, empty collection view then met a log describing rows it
-        // never had ("attempt to delete item N from section 0 …").
+        // The whole scroll layer lives in `TranscriptListView`, which renders a
+        // snapshot of `store.rows` via `TiledView(items:)`. There is no separate
+        // data source or change log to fall out of sync with the scroll view —
+        // the BET-807/BET-1062 lifetime hazard is gone with the snapshot API.
         TranscriptListView(
             store: store,
             tokens: tokens,
@@ -1140,8 +1137,8 @@ struct ChatSubagentScreen: View {
         autoScrollsToBottomOnAppend: true,
         scrollsToBottomOnReplace: true
     )
-    /// The `dataSource` (+ change log) lives on `TranscriptListView`, which
-    /// shares one lifetime with the scroll view it describes (BET-1062).
+    /// Rendered by `TranscriptListView` from a snapshot of `store.rows` — no
+    /// separate data source or change log (BET-1105).
 
     var body: some View {
         content
@@ -1193,15 +1190,11 @@ struct ChatSubagentScreen: View {
 
 // MARK: - Shared transcript scroll layer (BET-1062)
 
-/// The transcript scroll layer, and the OWNER of its own change log.
-///
-/// `ListDataSource` keeps an append-only log describing the rows the collection
-/// view holds, so the two have to be born and die together. Declared on the
-/// SCREEN instead (BET-807), it outlives the scroll view every time the
-/// transcript branch is left for the loading skeleton or the load-failure
-/// state — and the rebuilt, empty collection view then meets a log describing
-/// rows it never had ("attempt to delete item N from section 0 which only
-/// contains 0 items"). Declared HERE, leaving the branch destroys both.
+/// The transcript scroll layer, feeding `store.rows` to MessagingUI's
+/// `TiledView(items:)` as a snapshot. There is no separate data source and no
+/// change log to replay, so the BET-807/BET-1062 change-log lifetime hazard is
+/// gone: the rows come straight from the store on every update, and MessagingUI
+/// diffs the snapshot internally to animate changes.
 ///
 /// One view serves both the parent chat and the read-only subagent drill-in:
 /// the subagent's old chain was a strict subset of the parent's, so this
@@ -1214,10 +1207,8 @@ struct TranscriptListView<Header: View>: View {
     var onPointsFromBottom: ((CGFloat) -> Void)? = nil
     @ViewBuilder var header: () -> Header
 
-    @State private var dataSource = ListDataSource<TranscriptRow>()
-
     var body: some View {
-        TiledView(dataSource: dataSource, scrollPosition: $scrollPosition) { row in
+        TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
             TranscriptBlockCell(item: row, tokens: tokens)
         }
         .prependLoader(.loader(
@@ -1236,9 +1227,6 @@ struct TranscriptListView<Header: View>: View {
             onPointsFromBottom?(geometry.pointsFromBottom)
         }
         .onTapBackground { resignKeyboard() }
-        .onChange(of: store.rows, initial: true) { _, rows in
-            dataSource.apply(rows)
-        }
         .safeAreaBar(edge: .top) {
             header()
         }

--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -18,7 +18,14 @@ packages:
     from: "12.17.0"
   MessagingUI:
     url: https://github.com/FluidGroup/swiftui-messaging-ui
-    from: "1.0.0"
+    # PINNED TO A REVISION, deliberately. `from:` is a floating range: it can
+    # resolve to a different build with no repo diff, which is intolerable for a
+    # package whose recent releases have repeatedly regressed scroll offset and
+    # self-sizing. This revision is PR #43, the newest commit on main, and is the
+    # first line that carries #39's `primeCollectionViewItemCountForBatchUpdate`
+    # — the fix for the `applyChange` batch-update crash. The 1.x `ListDataSource`
+    # API is gone from every revision containing that fix, hence the migration below.
+    revision: 1ec611adfb17c74075239565273f6902cdf77db6
   MarkdownView:
     url: https://github.com/LiYanan2004/MarkdownView
     exactVersion: "3.0.0"


### PR DESCRIPTION
**Base:** `origin/main` @ `70ab2c78`

**Resolved MessagingUI revision (from `Package.resolved`):** `1ec611adfb17c74075239565273f6902cdf77db6` (commit to `main` = PR #43, carries #39's `primeCollectionViewItemCountForBatchUpdate` — the `applyChange` batch-update crash fix). `git ls-remote` confirms upstream `main` is still at this revision.

**Files changed (4):**
```
 mobile/native/MantaUI.xcodeproj/project.pbxproj    |  4 +-
 .../xcshareddata/swiftpm/Package.resolved          |  3 +-
 mobile/native/MantaUI/ChatScreen.swift             | 46 ++++----
 mobile/native/project.yml                          |  9 ++++-
 4 files changed, 28 insertions(+), 34 deletions(-)
```

**What this does:** pins `swiftui-messaging-ui` to a fixed `revision: 1ec611a…` and migrates `TranscriptListView` from the removed 1.x `ListDataSource` change-log API to the snapshot API (`TiledView(items: store.rows, …)`, `.onChange`/`dataSource` gone), per spec. Doc comments rewritten to the snapshot model. Nothing else rides along.

**Verification:**
- `ios-mantaui action=test-unit` (merge gate), Mac, @ `2c884994`: **PASS** — `XCODEGEN: PASS`, `UNIT: PASS`, **552 tests, 0 failures** (`TEST SUCCEEDED`).
- `ios-mantaui action=simulator` (@ `b0f73701`): **PASS** — build + install + launch, no crash.
- `typecheck-test` (npm): no JS files changed — unaffected, green.

**On-device Check 1 — NOT a migration defect (resolved scope).** macos's decisive on-device instrumentation shows `store.rows` hydrates to 6 on open and `TiledView(items:)` reads all 6 (snapshot wiring exonerated), then a **~1.4 s-later empty refetch in `ChatSessionStore` resets `rows` 6→0**, leaving a blank transcript. BET-1105 touches zero store code, so this is a **pre-existing store bug**, tracked separately as **BET-1125** (child, filed to manta-pm). Per this ticket's ships-alone contract it is **not** bundled here. BET-1105 is complete on its own; the interactive Check-1 verification is gated on BET-1125.
