### PR TITLE
BET-1120: refactor(server): collapse duplicated spawn-and-read-stdout into one helper

### DIFF
--- a/src/server/cliUpdates.mjs
+++ b/src/server/cliUpdates.mjs
@@ -96,23 +96,24 @@ export async function resolveBinary(bin, { access, env }) {
 const VERSION_RE = /\d+\.\d+\.\d+(?:[-.\w]*)?/;
 
 /**
- * Spawn `<absPath> --version` and read the first dotted version out of stdout.
+ * Spawn a command and resolve its stdout, or null on ANY failure.
  *
- * Every CLI in the catalog prints something like `2.1.233 (Claude Code)` or
- * `codex-cli 0.147.0`; the regex covers both. Any throw, non-zero exit, or
- * 10s timeout → returns null (never propagates).
+ * The single spawn-and-read code path in this module. Resolves null — never
+ * rejects — on a spawn throw, a child `error`, a non-zero exit, or the
+ * timeout. Callers treat null as "couldn't tell", never as a value.
  *
- * @param {string} absPath
+ * @param {string} cmd
+ * @param {string[]} args
  * @param {object} deps
  * @param {(cmd:string, args:string[], opts:any) => import("node:child_process").ChildProcess} deps.spawn
- * @param {number} [deps.timeoutMs=10000]
- * @returns {Promise<string|null>}
+ * @param {number} deps.timeoutMs
+ * @returns {Promise<string|null>} raw stdout on exit 0, else null
  */
-export function readVersion(absPath, { spawn, timeoutMs = 10_000 }) {
+function spawnStdout(cmd, args, { spawn, timeoutMs }) {
   return new Promise((resolve) => {
     let child;
     try {
-      child = spawn(absPath, ["--version"], { timeout: timeoutMs });
+      child = spawn(cmd, args, { timeout: timeoutMs });
     } catch {
       resolve(null);
       return;
@@ -139,14 +140,29 @@ export function readVersion(absPath, { spawn, timeoutMs = 10_000 }) {
 
     child.on("close", (code) => {
       clearTimeout(timer);
-      if (code !== 0) {
-        resolve(null);
-        return;
-      }
-      const m = out.match(VERSION_RE);
-      resolve(m ? m[0] : null);
+      resolve(code === 0 ? out : null);
     });
   });
+}
+
+/**
+ * Spawn `<absPath> --version` and read the first dotted version out of stdout.
+ *
+ * Every CLI in the catalog prints something like `2.1.233 (Claude Code)` or
+ * `codex-cli 0.147.0`; the regex covers both. Any throw, non-zero exit, or
+ * 10s timeout → returns null (never propagates).
+ *
+ * @param {string} absPath
+ * @param {object} deps
+ * @param {(cmd:string, args:string[], opts:any) => import("node:child_process").ChildProcess} deps.spawn
+ * @param {number} [deps.timeoutMs=10000]
+ * @returns {Promise<string|null>}
+ */
+export async function readVersion(absPath, { spawn, timeoutMs = 10_000 }) {
+  const out = await spawnStdout(absPath, ["--version"], { spawn, timeoutMs });
+  if (out == null) return null;
+  const m = out.match(VERSION_RE);
+  return m ? m[0] : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -195,44 +211,9 @@ export async function fetchLatest(entry, { fetchJson }) {
  * `npm install -g` over a vendor installer that would shadow it.
  */
 function defaultGetNpmGlobalRoot({ spawn }) {
-  return new Promise((resolve) => {
-    let child;
-    try {
-      child = spawn("npm", ["root", "-g"], { timeout: 5000 });
-    } catch {
-      resolve(null);
-      return;
-    }
-
-    let out = "";
-    child.stdout?.on("data", (d) => {
-      out += String(d);
-    });
-
-    const timer = setTimeout(() => {
-      try {
-        child.kill();
-      } catch {
-        /* already dead */
-      }
-      resolve(null);
-    }, 5000);
-
-    child.on("error", () => {
-      clearTimeout(timer);
-      resolve(null);
-    });
-
-    child.on("close", (code) => {
-      clearTimeout(timer);
-      if (code !== 0) {
-        resolve(null);
-        return;
-      }
-      const trimmed = out.trim();
-      resolve(trimmed || null);
-    });
-  });
+  return spawnStdout("npm", ["root", "-g"], { spawn, timeoutMs: 5000 }).then(
+    (out) => (out == null ? null : out.trim() || null),
+  );
 }
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
Refactors `src/server/cliUpdates.mjs` to collapse the two character-identical
spawn-and-read-stdout routines (`readVersion`, `defaultGetNpmGlobalRoot`) into
one module-private helper `spawnStdout`. Net deletion: no behaviour change —
all 18+ existing tests pass completely unmodified.

**Files changed:** 1 file.
```
 src/server/cliUpdates.mjs | 87 ++++++++++++++++++-----------------------------
 1 file changed, 34 insertions(+), 53 deletions(-)
```
Net **−19 lines**. `src/server/cliUpdates.test.mjs` is untouched (`git diff`
shows zero changes to it).

**Verification results:**
- PR branch (`multica/BET-1120-collapse-spawn-stdout` @ `71a2cbd`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2354 pass / 0 fail / 0 skip. Failures: none. log sha256: `fc79aa2fdff8018ef10b143da0068172d1668772814f85fbfe7da8b232fb6ec8`
- Base (`main` @ `a312820e`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2354 pass / 0 fail / 0 skip. Failures: none. log sha256: `1098e6a37af100401d7497302878d1fabd3b8e5fec8a3890bc1ca82bfebf8fa6`
- **Conclusion:** 0 new failures; the two branches produce identical results (the sha256 difference between the two test logs is only invocation noise — both report 2354 pass / 0 fail).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ `a312820e`**
