### PR TITLE
test(ios): gesture-driving XCUITest for transcript tap/swipe behaviours (BET-1118)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -10,7 +10,6 @@
 		0129D15936E52427A46702E7 /* MantaAuthClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */; };
 		01871023D47544D64443194D /* MantaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8240F1954861B4846E279D /* MantaModels.swift */; };
 		0488B71F794FC6E64CDC0B23 /* TerminalKeyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7BC8920829E8847057C8DA /* TerminalKeyRow.swift */; };
-		058E2179669599C216446E7C /* ToolOutputPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD2C923C52DE07EB54AB821 /* ToolOutputPreviewTests.swift */; };
 		0DA0C1C92C06A3BED780494E /* UsageMeters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A81D1BB24FB02E4DFFA04FE /* UsageMeters.swift */; };
 		12070C130BD9D1CD9EA0603F /* WaveformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF7554D798247FECA6BFF84 /* WaveformTests.swift */; };
 		1A55CBC343898856735AF0F8 /* MantaChatSurfaceCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570E190164DB3AB83DC14283 /* MantaChatSurfaceCaptureUITests.swift */; };
@@ -237,7 +236,6 @@
 		D178D08102AB83BF93B82D16 /* SessionResourceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionResourceCards.swift; sourceTree = "<group>"; };
 		D687A8F5AD2BEEAC0D728C3C /* UsageMetersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageMetersTests.swift; sourceTree = "<group>"; };
 		DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalModelsTests.swift; sourceTree = "<group>"; };
-		DAD2C923C52DE07EB54AB821 /* ToolOutputPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolOutputPreviewTests.swift; sourceTree = "<group>"; };
 		DC240598BDE45C3D43B46191 /* MantaUI.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MantaUI.entitlements; sourceTree = "<group>"; };
 		DD646A4951E292E750890CCB /* MantaAppRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppRoot.swift; sourceTree = "<group>"; };
 		E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLoadingSkeleton.swift; sourceTree = "<group>"; };
@@ -314,7 +312,6 @@
 				B82B782F73475FDD71F6D6B5 /* PolishTests.swift */,
 				9803742B79E4302F8813EFCC /* SessionModelsTests.swift */,
 				DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */,
-				DAD2C923C52DE07EB54AB821 /* ToolOutputPreviewTests.swift */,
 				D687A8F5AD2BEEAC0D728C3C /* UsageMetersTests.swift */,
 				E4A5AE775D3F3D82FC69A54F /* VoiceGestureTests.swift */,
 				AE01D00B6A031E239CC12EAD /* VoiceNoteTests.swift */,
@@ -651,7 +648,6 @@
 				E8B921F11FB02F147C910B32 /* PolishTests.swift in Sources */,
 				E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */,
 				C414F36E83344076CE4F1ACD /* TerminalModelsTests.swift in Sources */,
-				058E2179669599C216446E7C /* ToolOutputPreviewTests.swift in Sources */,
 				97CCE1CDDEF2E81BF57B52D1 /* UsageMetersTests.swift in Sources */,
 				B7D2A1C0F9EC29C5B0002C8F /* VoiceGestureTests.swift in Sources */,
 				49F13D74AD1B942D3313970B /* VoiceNoteTests.swift in Sources */,

--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		0129D15936E52427A46702E7 /* MantaAuthClientTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 989AB507C4722A4CF012C3B8 /* MantaAuthClientTests.swift */; };
 		01871023D47544D64443194D /* MantaModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8C8240F1954861B4846E279D /* MantaModels.swift */; };
 		0488B71F794FC6E64CDC0B23 /* TerminalKeyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7BC8920829E8847057C8DA /* TerminalKeyRow.swift */; };
+		058E2179669599C216446E7C /* ToolOutputPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD2C923C52DE07EB54AB821 /* ToolOutputPreviewTests.swift */; };
 		0DA0C1C92C06A3BED780494E /* UsageMeters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A81D1BB24FB02E4DFFA04FE /* UsageMeters.swift */; };
 		12070C130BD9D1CD9EA0603F /* WaveformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF7554D798247FECA6BFF84 /* WaveformTests.swift */; };
 		1A55CBC343898856735AF0F8 /* MantaChatSurfaceCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570E190164DB3AB83DC14283 /* MantaChatSurfaceCaptureUITests.swift */; };
@@ -52,6 +53,7 @@
 		685261838F0EFABC1AB8B6B1 /* MantaPairingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */; };
 		68760CC316BA947A82F360EE /* Scrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C440016971186430E8C464B /* Scrim.swift */; };
 		6A720AF41BDA6F4FC40A5585 /* ChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7631E09B6FF7B150392A83 /* ChatModels.swift */; };
+		6AA12AFE81F85477EBFB3D25 /* MantaTranscriptGestureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7442EBB8ACC827C69BDD2B6E /* MantaTranscriptGestureUITests.swift */; };
 		708332CA7D72971C6626C9FC /* MantaVoiceRecordingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B1B02BB0060065B306394F /* MantaVoiceRecordingUITests.swift */; };
 		74D756D48A7D2A5483170A8B /* MantaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872DDE9D9BAD041950DAC24A /* MantaLoader.swift */; };
 		754FEC92229B58783D516DC4 /* ModelPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C97C92B5E1ADA62F799D73 /* ModelPickerSheet.swift */; };
@@ -184,6 +186,7 @@
 		6E1D5B31C8FB29B23AB2A577 /* MantaLiveChatClearCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaLiveChatClearCaptureUITests.swift; sourceTree = "<group>"; };
 		714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIHierarchyCaptureUITests.swift; sourceTree = "<group>"; };
 		7190EEBC7A7233EE21FE264A /* PlanDerivation.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlanDerivation.swift; sourceTree = "<group>"; };
+		7442EBB8ACC827C69BDD2B6E /* MantaTranscriptGestureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaTranscriptGestureUITests.swift; sourceTree = "<group>"; };
 		74A048582549409FE0949053 /* TranscriptRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptRow.swift; sourceTree = "<group>"; };
 		7582E08CBBDCE70E242A6B18 /* UsageSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageSheets.swift; sourceTree = "<group>"; };
 		772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaReconnectController.swift; sourceTree = "<group>"; };
@@ -234,6 +237,7 @@
 		D178D08102AB83BF93B82D16 /* SessionResourceCards.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionResourceCards.swift; sourceTree = "<group>"; };
 		D687A8F5AD2BEEAC0D728C3C /* UsageMetersTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageMetersTests.swift; sourceTree = "<group>"; };
 		DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalModelsTests.swift; sourceTree = "<group>"; };
+		DAD2C923C52DE07EB54AB821 /* ToolOutputPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolOutputPreviewTests.swift; sourceTree = "<group>"; };
 		DC240598BDE45C3D43B46191 /* MantaUI.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MantaUI.entitlements; sourceTree = "<group>"; };
 		DD646A4951E292E750890CCB /* MantaAppRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppRoot.swift; sourceTree = "<group>"; };
 		E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLoadingSkeleton.swift; sourceTree = "<group>"; };
@@ -310,6 +314,7 @@
 				B82B782F73475FDD71F6D6B5 /* PolishTests.swift */,
 				9803742B79E4302F8813EFCC /* SessionModelsTests.swift */,
 				DA2C52DC49C55784D6EF2B65 /* TerminalModelsTests.swift */,
+				DAD2C923C52DE07EB54AB821 /* ToolOutputPreviewTests.swift */,
 				D687A8F5AD2BEEAC0D728C3C /* UsageMetersTests.swift */,
 				E4A5AE775D3F3D82FC69A54F /* VoiceGestureTests.swift */,
 				AE01D00B6A031E239CC12EAD /* VoiceNoteTests.swift */,
@@ -443,6 +448,7 @@
 				AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */,
 				17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */,
 				12A39FBE813A8B20F7F00055 /* MantaSubagentDrillInUITests.swift */,
+				7442EBB8ACC827C69BDD2B6E /* MantaTranscriptGestureUITests.swift */,
 				714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */,
 				5EF0199856D7E4C0B0D2595C /* MantaUIOverflowCaptureUITests.swift */,
 				59B1B02BB0060065B306394F /* MantaVoiceRecordingUITests.swift */,
@@ -616,6 +622,7 @@
 				D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */,
 				51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */,
 				DE5E17651AB0E9C750C4D712 /* MantaSubagentDrillInUITests.swift in Sources */,
+				6AA12AFE81F85477EBFB3D25 /* MantaTranscriptGestureUITests.swift in Sources */,
 				4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */,
 				ECB0360A8A26279B6EEF955F /* MantaUIOverflowCaptureUITests.swift in Sources */,
 				708332CA7D72971C6626C9FC /* MantaVoiceRecordingUITests.swift in Sources */,
@@ -644,6 +651,7 @@
 				E8B921F11FB02F147C910B32 /* PolishTests.swift in Sources */,
 				E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */,
 				C414F36E83344076CE4F1ACD /* TerminalModelsTests.swift in Sources */,
+				058E2179669599C216446E7C /* ToolOutputPreviewTests.swift in Sources */,
 				97CCE1CDDEF2E81BF57B52D1 /* UsageMetersTests.swift in Sources */,
 				B7D2A1C0F9EC29C5B0002C8F /* VoiceGestureTests.swift in Sources */,
 				49F13D74AD1B942D3313970B /* VoiceNoteTests.swift in Sources */,

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -168,6 +168,13 @@ private struct TranscriptCellReveal: View {
                 .offset(x: TranscriptGutter.gutterWidth - reveal)
                 .allowsHitTesting(false)
             }
+            // A stable per-row accessibility handle so a UI test can drive the
+            // reveal gesture on ONE specific row (and observe the timestamp
+            // strip). This only groups the row for accessibility — it does not
+            // add, disable or otherwise alter MessagingUI's reveal recogniser
+            // and does not change TranscriptGutter.gutterWidth.
+            .accessibilityElement(children: .contain)
+            .accessibilityIdentifier(TranscriptGutter.rowAccessibilityID)
     }
 
     @ViewBuilder
@@ -266,4 +273,7 @@ enum TranscriptGutter {
     /// Finger travel needed for a full reveal. Longer than the strip itself,
     /// so the strip arrives damped instead of slamming open on a flick.
     static let gutterTravel: CGFloat = 96
+    /// Accessibility id on every transcript row, exposed so a gesture-driving
+    /// UI test can target one row (and read its timestamp strip) deterministically.
+    static let rowAccessibilityID = "transcript-row"
 }

--- a/mobile/native/MantaUIUITests/MantaTranscriptGestureUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaTranscriptGestureUITests.swift
@@ -1,0 +1,302 @@
+import XCTest
+
+// ===========================================================================
+// Gesture-driving XCUITest for the native transcript (BET-1104 follow-up).
+//
+// BET-1104 replaced the two hand-rolled transcript gestures — tap-to-dismiss-
+// keyboard and swipe-to-reveal-timestamp — with MessagingUI's own recognisers,
+// fixing "the transcript needs a second swipe before it scrolls". The three
+// runtime behaviours were never verified hands-on in the simulator; this driver
+// does exactly that. It does NOT disable the library's reveal recogniser or
+// alter `TranscriptGutter.gutterWidth` — the shipped mechanism is exercised
+// as-is.
+//
+// It pairs against the capture fixture box (`capture-fixture/fixture-box.mjs`,
+// which serves a TALL transcript so the list overflows) and opens the chat
+// screen, then drives three gestures and records what it observes:
+//
+//   1. Keyboard dismiss on transcript tap  (composer focused, keyboard up)
+//   2. Left-swipe reveals the timestamp strip from the trailing edge, which
+//      springs back on release
+//   3. A single up/down swipe begins scrolling immediately (no second swipe)
+//
+// The pair credential comes from `MantaPairFixture` (the driver overwrites it
+// before `xcodebuild test`, exactly as MantaPairingDriverUITests documents) or
+// the `MANTA_PAIR_CODE`/`MANTA_PAIR_SERVER` env fallback; empty → skip, so an
+// ordinary test run with no fixture box is unaffected.
+//
+// A note on how the three are judged here: #1 has a hard, queryable assertion
+// (the keyboard element disappears). #2 is visual (the timestamp gutter is
+// `accessibilityHidden`), so frames are captured for a human rather than
+// gate-asserted. #3 is observed via the transcript's scroll position (the
+// vertical scroll bar value + an on-screen message frame) before and after a
+// single swipe; a "Scroll to bottom" chip, shown only once the list has moved
+// off the tail, is the corroborating signal.
+// ===========================================================================
+
+private enum TranscriptGesture {
+
+    /// Drop a PNG in the runner's own container and print its path, so the
+    /// driver can glob it from the host (mirrors MantaChatSurfaceCapture).
+    @MainActor
+    static func capture(_ name: String, after delay: TimeInterval = 0) {
+        if delay > 0 { usleep(useconds_t(delay * 1_000_000)) }
+        let shot = XCUIScreen.main.screenshot()
+        let out = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent(name)
+        try? shot.pngRepresentation.write(to: out)
+        print("GESTURE shot=\(out.path)")
+    }
+
+    /// Answer any system notification alert Springboard is holding, so it
+    /// cannot obscure the chat after pairing (mirrors MantaSystemAlertUITests).
+    static func dismissSystemAlerts() {
+        let springboard = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        for label in ["Allow", "Don't Allow", "OK"] {
+            let button = springboard.buttons[label]
+            if button.waitForExistence(timeout: 2) {
+                button.tap()
+                print("GESTURE alert-answered=\(label)")
+                return
+            }
+        }
+    }
+
+    /// Pair the app against the fixture box if it isn't paired already, and
+    /// land on the session list. Idempotent across test methods within one
+    /// install (keychain persists).
+    @MainActor
+    static func pairIfNeeded(_ app: XCUIApplication) throws {
+        let code = ProcessInfo.processInfo.environment["MANTA_PAIR_CODE"] ?? MantaPairFixture.code
+        let server = ProcessInfo.processInfo.environment["MANTA_PAIR_SERVER"] ?? MantaPairFixture.server
+
+        if app.staticTexts["Sessions"].waitForExistence(timeout: 3) {
+            print("GESTURE already-paired")
+            return
+        }
+
+        let otp = app.textFields["onboarding-otp"]
+        guard otp.waitForExistence(timeout: 15) else {
+            XCTFail("neither the session list nor the onboarding entry appeared")
+            return
+        }
+
+        if code.isEmpty || server.isEmpty {
+            throw XCTSkip("GESTURE SKIP: no pairing code/server (MantaPairFixture empty, no env)")
+        }
+
+        print("GESTURE pair code-digits=\(code.count) server=\(server)")
+        otp.tap()
+        otp.typeText(code)
+
+        let advanced = app.buttons["My box isn't reachable from the internet"]
+        if advanced.waitForExistence(timeout: 3) { advanced.tap() }
+        let serverField = app.textFields["onboarding-server-url"]
+        XCTAssertTrue(serverField.waitForExistence(timeout: 5), "server URL field never appeared")
+        serverField.tap()
+        serverField.typeText(server)
+
+        app.buttons["Continue"].firstMatch.tap()
+
+        let notifications = app.staticTexts["Know when it needs you"]
+        let failure = app.staticTexts["onboarding-failure-subtitle"]
+        let deadline = Date().addingTimeInterval(45)
+        while Date() < deadline, !notifications.exists, !failure.exists {
+            usleep(300_000)
+        }
+        if failure.exists {
+            XCTFail("pairing failed: \(failure.label)")
+            return
+        }
+        XCTAssertTrue(notifications.exists, "neither the notifications primer nor a failure card appeared")
+
+        app.buttons["Continue"].firstMatch.tap()
+        dismissSystemAlerts()
+        print("GESTURE paired")
+    }
+
+    /// Wait for the session list, then open the first session row so the app
+    /// lands on the real chat surface (TiledView transcript + composer). Uses
+    /// the same normalized-coordinate tap as the proven capture drivers
+    /// (MantaChatSurfaceCapture / MantaOpenSessionUITests) — a session row
+    /// combines its children for accessibility, so a coordinate hit is the
+    /// reliable way to open it rather than a fragile label match.
+    @MainActor
+    static func openChat(_ app: XCUIApplication) {
+        _ = app.staticTexts["Sessions"].waitForExistence(timeout: 15)
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        print("GESTURE opened-chat")
+    }
+
+    /// Resolve a visible message-row element to drive the reveal gesture on.
+    /// Prefers the per-row accessibility handle, falling back to the tail
+    /// assistant text; waits for one to appear.
+    @MainActor
+    static func rowToSwipe(_ app: XCUIApplication) -> XCUIElement {
+        let byID = app.descendants(matching: .any)["transcript-row"].firstMatch
+        if byID.waitForExistence(timeout: 8) {
+            return byID
+        }
+        let prose = NSPredicate(format: "label BEGINSWITH %@", "Yes — tap the ellipsis")
+        return app.staticTexts.matching(prose).firstMatch
+    }
+
+    /// Where a transcript tap should land to count as "background": the middle
+    /// of the transcript region, away from the composer.
+    @MainActor
+    static func transcriptBackground(_ app: XCUIApplication) -> XCUICoordinate {
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28))
+    }
+
+    /// Current vertical scroll offset of the transcript, read from the scroll
+    /// indicator's percent value ("" when not present). Position-independent.
+    @MainActor
+    static func scrollPercent(_ app: XCUIApplication) -> String {
+        let scrollBar = app.descendants(matching: .other)
+            .matching(NSPredicate(format: "label BEGINSWITH %@", "Vertical scroll bar"))
+            .firstMatch
+        guard scrollBar.exists, let v = scrollBar.value as? String else { return "n/a" }
+        return v
+    }
+}
+
+// 1. Composer focused + keyboard shown → tapping the transcript background
+// dismisses the keyboard. (MessagingUI `.onTapBackground`.)
+@MainActor
+final class MantaKeyboardDismissGestureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testTappingTranscriptBackgroundDismissesKeyboard() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        try TranscriptGesture.pairIfNeeded(app)
+        TranscriptGesture.openChat(app)
+
+        let input = app.textViews["composer-input"]
+        XCTAssertTrue(input.waitForExistence(timeout: 10), "no composer input")
+        input.tap()
+        XCTAssertTrue(app.keyboards.firstMatch.waitForExistence(timeout: 5),
+                      "keyboard did not appear after tapping the composer")
+        print("GESTURE keyboard-shown")
+
+        TranscriptGesture.capture("gesture-keyboard-up.png")
+
+        // Tap the transcript background (NOT the composer, NOT a message row).
+        TranscriptGesture.transcriptBackground(app).tap()
+
+        // The keyboard should disappear as a result of the tap-dismiss gesture.
+        let keyboardGone = NSPredicate(format: "exists == false")
+        let expectation = XCTNSPredicateExpectation(
+            predicate: keyboardGone,
+            object: app.keyboards.firstMatch
+        )
+        let result = XCTWaiter().wait(for: [expectation], timeout: 5)
+        TranscriptGesture.capture("gesture-keyboard-dismissed.png")
+        XCTAssertEqual(result, .completed,
+                       "keyboard was not dismissed by a tap on the transcript background")
+        print("GESTURE keyboard-dismissed")
+    }
+}
+
+// 2. Swiping LEFT on a message row slides the timestamp strip in from the
+// trailing edge, and it springs back on release. (MessagingUI's reveal offset,
+// driven off the cell's `context.cellReveal`.) The gutter label is
+// `accessibilityHidden`, so the observation is visual: frames are captured and
+// reported, not gate-asserted.
+@MainActor
+final class MantaSwipeRevealGestureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testSwipeLeftRevealsTimestampStripAndSpringsBack() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        try TranscriptGesture.pairIfNeeded(app)
+        TranscriptGesture.openChat(app)
+
+        let row = TranscriptGesture.rowToSwipe(app)
+        XCTAssertTrue(row.waitForExistence(timeout: 10), "no transcript row to swipe")
+
+        TranscriptGesture.capture("gesture-reveal-before.png")
+
+        // A leftward flick on the row: the whole row slides left to reveal the
+        // timestamp strip from the trailing edge.
+        row.swipeLeft()
+        // Capture as close to the gesture as possible (spring-back is fast).
+        TranscriptGesture.capture("gesture-reveal-swipe.png")
+
+        // After release the strip springs back (the row restores).
+        TranscriptGesture.capture("gesture-reveal-settled.png", after: 1.2)
+        print("GESTURE reveal-swiped-and-settled row.exists=\(row.exists)")
+    }
+}
+
+// 3. A single up-swipe begins scrolling immediately — the BET-1104 fix for the
+// "second swipe before the transcript scrolls" bug. Observed by anchoring at
+// the tail, then performing ONE upward swipe and reading the scroll position
+// before and after. The "Scroll to bottom" chip (shown only once the list moves
+// off the tail) corroborates.
+//
+// Deliberately an observation test: it records the scroll-position delta and
+// screenshots rather than hard-asserting motion, because an XCUITest synthetic
+// swipe can legitimately fail to move a custom collection view where a real
+// finger would. The report on PR #1111 interprets what this test records.
+@MainActor
+final class MantaFirstSwipeScrollGestureUITests: XCTestCase {
+
+    override func setUpWithError() throws {
+        continueAfterFailure = false
+    }
+
+    func testSingleSwipeScrollsTranscriptImmediately() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        try TranscriptGesture.pairIfNeeded(app)
+        TranscriptGesture.openChat(app)
+
+        let composer = app.textViews["composer-input"]
+        XCTAssertTrue(composer.waitForExistence(timeout: 10), "no composer input")
+
+        // Anchor at the transcript tail (newest message): the tall fixture can
+        // open scrolled up, so settle to the bottom via the scroll-to-bottom
+        // chip, which is exactly the signal for "away from the tail".
+        let chip = app.buttons["Scroll to bottom"]
+        var guardLoop = 0
+        while chip.exists, guardLoop < 10 {
+            if chip.isHittable {
+                chip.tap()
+            } else {
+                app.swipeDown()
+            }
+            guardLoop += 1
+            usleep(400_000)
+        }
+        let atTail = !chip.exists
+        print("GESTURE at-tail=\(atTail) scroll=\(TranscriptGesture.scrollPercent(app))")
+
+        TranscriptGesture.capture("gesture-scroll-before.png")
+        let beforeScroll = TranscriptGesture.scrollPercent(app)
+
+        // ONE upward drag — the gesture under test.
+        app.swipeUp()
+
+        TranscriptGesture.capture("gesture-scroll-after.png")
+        let afterScroll = TranscriptGesture.scrollPercent(app)
+        let chipAfter = chip.waitForExistence(timeout: 2)
+
+        print("GESTURE SCROLL-OBSERVATION anchoredAtTail=\(atTail) scrollBefore=\(beforeScroll) scrollAfter=\(afterScroll) chipAppearedAfterOneSwipe=\(chipAfter)")
+        print("GESTURE reveal-drive-complete")
+
+        // The gesture itself must be drivable on the shipped transcript; whether
+        // a single synthetic swipe moves the custom list is the observed outcome
+        // (reported on PR #1111), not a gate.
+    }
+}

--- a/mobile/native/capture-fixture/fixture-box.mjs
+++ b/mobile/native/capture-fixture/fixture-box.mjs
@@ -61,7 +61,46 @@ const PROJECTS = [
   },
 ];
 
+// Gesture-fixture filler: the chat opens auto-scrolled to the tail, so the
+// newest message is the LAST element of the array. To make the transcript tall
+// enough to actually scroll (the BET-1104 "scrolls on the first swipe" check
+// needs overflow), older filler messages are PREPENDED before the two anchor
+// messages below. The anchors (m1/m2) stay at the tail so the chat opens with
+// them on screen, exactly as the overflow capture harness expects.
+function buildTallTranscript() {
+  const filler = [];
+  const FILLER_PAIRS = 22; // 44 messages -> many screens of long prose
+  let id = 1000;
+  for (let i = 0; i < FILLER_PAIRS; i++) {
+    const uid = "f" + (id++);
+    const aid = "f" + (id++);
+    const pid = id;
+    // A several-line paragraph so each assistant row owns real height and the
+    // whole transcript overflows the viewport many times over.
+    const prose = (
+      "This is fixture paragraph " + i + ", part of the taller transcript the " +
+      "gesture tests need so there is something to scroll. It is intentionally " +
+      "a few sentences long so the row owns measurable height on screen. " +
+      "Repeating the filler across the array gives the transcript enough " +
+      "vertical extent that a single upward drag must begin scrolling " +
+      "immediately, which is the point of the exercise. ".repeat(2)
+    );
+    filler.push(
+      {
+        info: { id: uid, sessionID: SESSION_ID, role: "user", time: { created: now - 1000000 } },
+        parts: [{ type: "text", id: "p" + (pid - 1), messageID: uid, text: "Filler question " + i }],
+      },
+      {
+        info: { id: aid, sessionID: SESSION_ID, role: "assistant", time: { created: now - 900000, completed: now - 899000 } },
+        parts: [{ type: "text", id: "p" + pid, messageID: aid, text: prose }],
+      }
+    );
+  }
+  return filler;
+}
+
 const MESSAGES = [
+  ...buildTallTranscript(),
   {
     info: {
       id: "m1",


### PR DESCRIPTION
Opened automatically for `multica/BET-1118-transcript-gesture-xctest`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1118.