### PR TITLE
BET-1121: Drop the now-stale duplication-gate exemption for src/server/cliUpdates.mjs

### DIFF
--- a/scripts/duplication-gate-ignore.txt
+++ b/scripts/duplication-gate-ignore.txt
@@ -28,11 +28,3 @@ src/main/installer/handlers.test.ts
 # scans changed files). Same rationale as the handlers.test.ts exemption above;
 # my BET-1008 additions introduced no new clones.
 src/main/installer/installer.test.ts
-# BET-1119: the CLI latest-version probe suite. jscpd flags an INTRA-file,
-# pre-existing self-clone — the spawn-with-timeout scaffolding shared by
-# readVersion and defaultGetNpmGlobalRoot (19 lines) — which exists on
-# origin/main and surfaces ONLY because this file is in a diff (the gate scans
-# changed files). Same rationale as the installer.test.ts exemption above; the
-# BET-1119 fix (default fetchJson for the probe) introduced no new clones, and
-# de-duplicating those two helpers is out of this tightly-scoped fix's remit.
-src/server/cliUpdates.mjs

--- a/src/server/cliUpdates.mjs
+++ b/src/server/cliUpdates.mjs
@@ -98,7 +98,9 @@ const VERSION_RE = /\d+\.\d+\.\d+(?:[-.\w]*)?/;
 /**
  * Spawn a command and resolve its stdout, or null on ANY failure.
  *
- * The single spawn-and-read code path in this module. Resolves null — never
+ * The single spawn-and-read code path in this module. This shared helper is
+ * why the file needs no duplication-gate exemption — reuse it for a third
+ * spawn call rather than re-copying the scaffolding. Resolves null — never
  * rejects — on a spawn throw, a child `error`, a non-zero exit, or the
  * timeout. Callers treat null as "couldn't tell", never as a value.
  *


### PR DESCRIPTION
## BET-1121 — Drop the stale duplication-gate exemption for `src/server/cliUpdates.mjs`

The dedupe the original ticket requested already landed in BET-1120 (`spawnStdout` helper). This PR drops the now-stale exemption.

**Changes:**
- Removed the `src/server/cliUpdates.mjs` entry + its whole `# BET-1119` comment block from `scripts/duplication-gate-ignore.txt`.
- Added a one-line note to `spawnStdout`'s doc comment in `src/server/cliUpdates.mjs` recording that the shared helper exists so the file needs no duplication-gate exemption.

No behavior change to `spawnStdout` / `readVersion` / `defaultGetNpmGlobalRoot` — timeouts, stdout parsing and null-on-any-failure contract untouched.

**Duplication gate:** `scripts/check-duplication-gate.sh` scans `cliUpdates.mjs` (in the diff) and **PASS — no clones** with the exemption gone, proving it was genuinely unnecessary.

**Verification results:**
- PR branch (`multica/BET-1121-drop-cliupdates-exemption` @ `a82499c8`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2354 pass / 0 fail / 0 skip. Failures: none. log sha256: `a41bec40911384fac6dc4cba9175c0ac4832f7b5e83f3926a2324f8d04cde02e`
- Base (`main` @ `97455f0a`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2354 pass / 0 fail / 0 skip. Failures: none. log sha256: `8590edffc9eab8e9822221a90036cb6750d3348c034e1e586d17adaba508b675`
- **Conclusion:** 0 failures on both branches (identical pass counts). This is a non-behavioral change (doc comment + ignore-list gate config only), so no new or resolved failures.

**Base:** origin/main @ `97455f0a`

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
