### PR TITLE
feat(renderer): enable attaching files before starting a session (BET-1124)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -13,6 +13,8 @@ import { act } from "react";
 import { ChatPanel } from "./ChatPanel";
 import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
 import { useStore } from "./store";
+import { refreshModelCatalog } from "./modelCatalog";
+import type { Attachment } from "./chatShared";
 import {
   installMockApi,
   resetStore,
@@ -1296,5 +1298,98 @@ describe("ChatPanel auto-rename first-turn fallback (BET-1100 follow-up)", () =>
       windowIndex: 1,
       newName: "Manta setup check",
     });
+  });
+});
+
+// BET-1124: the new-session auto-submit carries staged attachments. The draft
+// hands the panel attachments (already status:"ready" with remotePath); the
+// panel seeds its composer strip from them and submit() sends path-ref chips
+// folded into the text (@<path>) and media chips as FileParts (never in text).
+describe("ChatPanel attachment auto-submit (BET-1124)", () => {
+  let api: MockApi;
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    ({ api } = installMockApi({
+      opencodeModels: () =>
+        Promise.resolve([
+          {
+            id: "claude-x",
+            providerID: "anthropic",
+            name: "Claude X",
+            limit: { context: 200000 },
+            capabilities: { input: { image: true, text: true } },
+          },
+        ]),
+      opencodeDefaultModel: () =>
+        Promise.resolve({ providerID: "anthropic", modelID: "claude-x" }),
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+    }));
+    // The model catalog is module-cached; force a fresh fetch so activeModel
+    // resolves to the image-capable model above (otherwise the media chip's
+    // capability guard would refuse the send).
+    refreshModelCatalog();
+    resetStore();
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("seeds the composer strip and carries attachments through the first prompt", async () => {
+    const attachments: Attachment[] = [
+      {
+        id: "a1",
+        filename: "notes.md",
+        mime: "text/markdown",
+        remotePath: "/remote/notes.md",
+        status: "ready",
+        source: "drop",
+        asPathRef: true,
+      },
+      {
+        id: "a2",
+        filename: "img.png",
+        mime: "image/png",
+        remotePath: "/remote/img.png",
+        status: "ready",
+        source: "drop",
+        asPathRef: false,
+      },
+    ];
+    h = mount(
+      <ChatPanel
+        {...PROPS}
+        autoSubmit={{
+          text: "review these",
+          model: { providerID: "anthropic", modelID: "claude-x" },
+          attachments,
+        }}
+      />,
+    );
+    // submit() clears the composer strip after a successful send, so the
+    // seeding is asserted through its effects: only a panel whose strip was
+    // seeded (attachments in composer state) can fold the path-ref chip into
+    // the text or send the media chip as a FilePart.
+    await h.flush();
+
+    const calls = api.calls["opencodePrompt"] ?? [];
+    expect(calls.length).toBe(1);
+    const sentText = calls[0]?.[1] as string;
+    // Path-ref chip folded into the text as @<path> for the AI's Read tool.
+    expect(sentText).toContain("@/remote/notes.md");
+    // Media chip is NOT folded into the text.
+    expect(sentText).not.toContain("@/remote/img.png");
+    // Media chip travels as a FilePart attachment.
+    expect(calls[0]?.[3]).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          remotePath: "/remote/img.png",
+          mime: "image/png",
+          filename: "img.png",
+        }),
+      ]),
+    );
   });
 });

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -169,7 +169,7 @@ type Props = {
   // used by the optimistic "new session" flow so the first prompt + running
   // indicator appear immediately in the real chat view. Optional; present
   // only on the transient panel rendered while the tmux window is created.
-  autoSubmit?: { text: string; model?: ModelSelection; plan?: boolean };
+  autoSubmit?: { text: string; model?: ModelSelection; plan?: boolean; attachments?: Attachment[] };
   // App-control (BET-840/841): App owns the single `appControl` bus listener
   // and reaches the open panel for a `switch-model` action through these.
   // `selectModel` is registered so a model-switch applies the override through
@@ -1281,7 +1281,7 @@ export function ChatPanel({
   useEffect(() => {
     if (!autoSubmit || autoSubmitted.current) return;
     autoSubmitted.current = true;
-    const { text, model, plan } = autoSubmit;
+    const { text, model, plan, attachments } = autoSubmit;
     setModelOverride(model ?? null);
     // The draft's plan mode rides the same one-shot channel as the model
     // (the new panel can mount before the draft finishes handing off, and its
@@ -1292,6 +1292,11 @@ export function ChatPanel({
     // runs as the chosen agent.
     syncPlan(plan ?? false);
     setInput(text);
+    // (BET-1124) The draft staged files before the session existed — hand them
+    // to the composer so submit()'s normal path uploads path-ref chips into
+    // the text (@<path>) and media chips into FileParts. Already status:"ready"
+    // with a remotePath, so no per-chip upload spinner/shake here.
+    if (attachments?.length) setAttachments(attachments);
     // Clear the one-shot INSIDE the fired timeout, never in the effect body.
     // Clearing the store flips autoSubmit → undefined, which re-runs this
     // effect's cleanup (clearTimeout) and would cancel the deferred submit
@@ -1313,7 +1318,7 @@ export function ChatPanel({
       // cleanup, so there is still exactly one submission per autoSubmit value.
       autoSubmitted.current = false;
     };
-  }, [autoSubmit, setModelOverride, setInput, syncPlan]);
+  }, [autoSubmit, setModelOverride, setInput, syncPlan, setAttachments]);
 
   // BET-795: inbox "Start a session" — seed the composer (setInput) but do NOT
   // submit. One-shot via the same ref guard idiom as autoSubmit. Clearing the

--- a/src/renderer/NewSessionScreen.harness.test.tsx
+++ b/src/renderer/NewSessionScreen.harness.test.tsx
@@ -49,6 +49,7 @@ function draft(overrides: Partial<NewSessionDraft> = {}): NewSessionDraft {
     scratch: false,
     projectName: "",
     scratchRoot: "",
+    attachments: [],
     ...overrides,
   };
 }
@@ -473,5 +474,157 @@ describe("NewSessionScreen scratch mode (BET-1093)", () => {
 
     const asp = useStore.getState().autoSubmitPrompt;
     expect(asp?.text).toBe("wire it up");
+  });
+});
+
+// BET-1124: attach files before starting a session. The attach icon opens a
+// hidden file input; selected files are staged into the draft's attachments
+// and rendered as removable chips; on submit they upload and ride the first
+// prompt's autoSubmit channel.
+describe("NewSessionScreen attach-before-start (BET-1124)", () => {
+  let h: Harness | null = null;
+
+  const GIT_WT: WorktreeInfo[] = [
+    { path: "/x", head: "abc", branch: "main", bare: false, detached: false },
+  ];
+
+  function mountComposer(
+    d: NewSessionDraft,
+    apiOverrides: Record<string, unknown> = {},
+    storeOverrides: Partial<ReturnType<typeof useStore.getState>> = {},
+  ): MockApi {
+    const { api } = installMockApi({
+      gitListWorktrees: () => Promise.resolve(GIT_WT),
+      ...apiOverrides,
+    });
+    refreshModelCatalog();
+    refreshAgentCatalog();
+    resetStore({
+      projects: [],
+      activeDraftId: d.id,
+      drafts: [d],
+      ...storeOverrides,
+    });
+    h = mount(<NewSessionScreen draftId={d.id} />);
+    return api;
+  }
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  // jsdom can't open a native picker; drive the hidden input directly the way
+  // a selection would (files + change event → onFiles).
+  function stageFile(input: HTMLInputElement, file: File) {
+    Object.defineProperty(input, "files", {
+      value: [file] as unknown as FileList,
+      configurable: true,
+    });
+    act(() => input.dispatchEvent(new Event("change", { bubbles: true })));
+  }
+
+  it("selecting a file through the hidden input stages a removable chip", async () => {
+    const d = draft({ mode: { projectName: "proj" }, cwd: "/x", input: "build it" });
+    mountComposer(d);
+    await h!.flush();
+
+    // The attach control is enabled (it was hard-coded disabled before) and
+    // its title no longer says the feature is unavailable.
+    const attach = [...h!.container.querySelectorAll("button")].find(
+      (b) => b.getAttribute("aria-label") === "Attach a file",
+    ) as HTMLButtonElement | undefined;
+    expect(attach).toBeTruthy();
+    expect(attach!.disabled).toBe(false);
+    expect(attach!.getAttribute("title")).toBe("Attach a file");
+
+    const input = h!.container.querySelector('input[type="file"]') as HTMLInputElement;
+    expect(input, "expected the hidden file input").toBeTruthy();
+
+    const file = new File(["content"], "note.md", { type: "text/markdown" });
+    stageFile(input, file);
+    await h!.flush();
+
+    // The chip renders with the filename.
+    expect(h!.text()).toContain("note.md");
+    const staged = useStore.getState().drafts.find((x) => x.id === d.id)!.attachments;
+    expect(staged).toHaveLength(1);
+    expect(staged[0].filename).toBe("note.md");
+    // text/markdown is not FilePart-safe → path ref.
+    expect(staged[0].asPathRef).toBe(true);
+
+    // Clicking the chip's remove splices it out of the draft.
+    const remove = h!.container.querySelector(
+      'button[aria-label="Remove attachment"]',
+    ) as HTMLButtonElement;
+    expect(remove, "expected a remove button on the chip").toBeTruthy();
+    act(() => remove.click());
+    await h!.flush();
+
+    expect(h!.text()).not.toContain("note.md");
+    expect(useStore.getState().drafts.find((x) => x.id === d.id)!.attachments).toHaveLength(0);
+  });
+
+  it("submit uploads staged files and carries them on the first prompt", async () => {
+    const d = draft({ mode: { projectName: "proj" }, cwd: "/x", input: "summarize" });
+    const api = mountComposer(
+      d,
+      {
+        uploadBuffer: () => Promise.resolve("/remote/note.md"),
+        tmuxNewWindow: () =>
+          Promise.resolve({ sessionId: "ses-1", windowIndex: 0, projects: [] }),
+      },
+      {
+        projects: [
+          {
+            tmuxSession: "proj",
+            defaultCwd: "/x",
+            attached: false,
+            windows: [
+              {
+                index: 0,
+                name: "w",
+                active: true,
+                paneCurrentPath: "/x",
+                opencodeSessionId: "ses-1",
+              },
+            ],
+          },
+        ],
+        // Neutralize dismissDraft (see the composer-parity tests — submit()
+        // closes over the store binding from the render).
+        dismissDraft: () => {},
+      },
+    );
+    await h!.flush();
+
+    const file = new File(["content"], "note.md", { type: "text/markdown" });
+    // jsdom's File lacks arrayBuffer(); submit() reads bytes this way.
+    (file as File & { arrayBuffer: () => Promise<ArrayBuffer> }).arrayBuffer =
+      () => Promise.resolve(new ArrayBuffer(1));
+    stageFile(h!.container.querySelector('input[type="file"]') as HTMLInputElement, file);
+    await h!.flush();
+
+    const start = h!.container.querySelector(
+      'button[aria-label="Start a session"]',
+    ) as HTMLButtonElement;
+    act(() => start.click());
+    await h!.flush();
+
+    const ups = api.calls.uploadBuffer ?? [];
+    expect(ups.length).toBe(1);
+    expect(ups[0]?.[0]).toMatchObject({ projectName: "proj", filename: "note.md" });
+
+    const asp = useStore.getState().autoSubmitPrompt;
+    expect(asp?.text).toBe("summarize");
+    expect(asp?.attachments).toHaveLength(1);
+    expect(asp?.attachments![0]).toMatchObject({
+      filename: "note.md",
+      mime: "text/markdown",
+      remotePath: "/remote/note.md",
+      status: "ready",
+      source: "drop",
+      asPathRef: true,
+    });
   });
 });

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -40,7 +40,7 @@ import { Tag } from "./Tag";
 import { ModelPicker } from "./ModelPicker";
 import { useModelCatalog } from "./modelCatalog";
 import { useAgentCatalog } from "./agentCatalog";
-import { MicButton, PlanChip, TrustRow } from "./ComposerParts";
+import { MicButton, PlanChip, TrustRow, AttachmentStrip } from "./ComposerParts";
 import { UsageDial } from "./UsageDial";
 import { IconButton } from "./IconButton";
 import { Button } from "./Button";
@@ -76,7 +76,13 @@ import type {
   TmuxCreateResult,
   WorktreeInfo,
 } from "../shared/types";
-import { type ModelSelection, resolveActiveModel } from "./chatShared";
+import {
+  type Attachment,
+  type ModelSelection,
+  guessMime,
+  mimeToInputMode,
+  resolveActiveModel,
+} from "./chatShared";
 
 // Normalise the tmux:new-session / new-window response. The (merged) server
 // returns { sessionId, windowIndex, projects }; tolerate an older server that
@@ -162,6 +168,30 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   const [sending, setSending] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const inputRef = useRef<HTMLTextAreaElement>(null);
+  // Hidden picker backing the attach button (BET-1124). The draft has no
+  // sessionId yet, so it uses its own input rather than the manta-attach-files
+  // bridge (which targets a live session's composer).
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  // Stage files a user picks into the draft's attachments. Upload is deferred
+  // to submit() — once the destination session/window name exists.
+  const onFiles = (files: FileList | null) => {
+    if (!files?.length) return;
+    const newAttachments = Array.from(files).map((f) => {
+      const mime = f.type || guessMime(f.name);
+      return {
+        id: `att-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 6)}`,
+        filename: f.name,
+        mime,
+        asPathRef: mimeToInputMode(mime) === "other",
+        file: f,
+      };
+    });
+    updateDraft(draftId, {
+      attachments: [...draft.attachments, ...newAttachments],
+    });
+    if (fileInputRef.current) fileInputRef.current.value = "";
+  };
 
   // ---- repo probe (BET-787): the new-project zero state ----
   // Probe the box for git repos + the gh CLI. The scan is purely additive: if
@@ -639,11 +669,40 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
       // lands on the session's FIRST turn (see ChatPanel's autoSubmit effect).
       // Only queue when there IS a prompt — scratch mode may submit empty.
       if (sessionId && text) {
+        // BET-1124: upload staged files into the new project's uploads dir,
+        // then pass them to the panel's auto-submit so the first prompt carries
+        // them (media → FileParts; non-media → @<path> appended). A failed
+        // upload aborts the whole send — no session left without its files.
+        const attachments: Attachment[] = [];
+        for (const a of draft.attachments) {
+          const buffer = await a.file.arrayBuffer();
+          const rp = await window.api.uploadBuffer({
+            projectName: sessionName,
+            filename: a.filename,
+            buffer,
+          });
+          if (rp) {
+            attachments.push({
+              id: a.id,
+              filename: a.filename,
+              mime: a.mime,
+              remotePath: rp,
+              status: "ready",
+              source: "drop",
+              asPathRef: a.asPathRef,
+            });
+          } else {
+            setError("Failed to upload " + a.filename);
+            setSending(false);
+            return;
+          }
+        }
         setAutoSubmitPrompt({
           sid: sessionId,
           text,
           model: draft.model ?? undefined,
           plan: draft.plan,
+          attachments,
         });
       }
       // Navigate to the new session (setActive + box-side select-window so the
@@ -727,11 +786,29 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
         // 6th param is the agent. Fan-out can't use the autoSubmit channel (it
         // sends directly), so resolve the plan agent here exactly as ChatPanel
         // does (plan.available && plan.on) so the two paths cannot diverge.
+        // BET-1124: upload staged files against the new session and pass them
+        // as attachments so fan-out doesn't silently drop them.
+        const attachments: { remotePath: string; mime: string; filename?: string }[] = [];
+        for (const a of draft.attachments) {
+          const buffer = await a.file.arrayBuffer();
+          const rp = await window.api.uploadBuffer({
+            projectName: sessionName,
+            filename: a.filename,
+            buffer,
+          });
+          if (rp) {
+            attachments.push({ remotePath: rp, mime: a.mime, filename: a.filename });
+          } else {
+            setError("Failed to upload " + a.filename);
+            setSending(false);
+            return;
+          }
+        }
         await window.api.opencodePrompt(
           sessionId,
           text,
           draft.model ?? undefined,
-          undefined,
+          attachments,
           undefined,
           plan.available && plan.on ? plan.agent : undefined,
         );
@@ -914,7 +991,35 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
             (voiceRecording ? "manta-recording" : "border-border-subtle")
           }
         >
-          <textarea
+          <input
+            ref={fileInputRef}
+            type="file"
+            multiple
+            className="hidden"
+            tabIndex={-1}
+            aria-hidden="true"
+            onChange={(e) => onFiles(e.target.files)}
+          />
+          <div className="flex-1">
+            {draft.attachments.length > 0 && (
+              <AttachmentStrip
+                attachments={draft.attachments.map((a) => ({
+                  id: a.id,
+                  filename: a.filename,
+                  mime: a.mime,
+                  status: "ready" as const,
+                  source: "drop" as const,
+                  asPathRef: a.asPathRef,
+                  remotePath: undefined,
+                }))}
+                onRemove={(id) =>
+                  updateDraft(draftId, {
+                    attachments: draft.attachments.filter((a) => a.id !== id),
+                  })
+                }
+              />
+            )}
+            <textarea
             ref={inputRef}
             autoFocus
             value={draft.input}
@@ -926,9 +1031,10 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
                 : "Describe a task or ask a question"
             }
             rows={3}
-            className="flex-1 w-full bg-transparent border-0 text-prose text-text outline-none resize-none placeholder:text-text-faint"
+            className="w-full bg-transparent border-0 text-prose text-text outline-none resize-none placeholder:text-text-faint"
             spellCheck={false}
           />
+          </div>
 
           <button
             onClick={() => void submit()}
@@ -978,9 +1084,9 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
             <IconButton
               icon={<Paperclip />}
               label="Attach a file"
-              title="Attaching files is not available when starting a session"
+              title="Attach a file"
               size="xl"
-              disabled
+              onClick={() => fileInputRef.current?.click()}
             />
 
             {voiceEnabled ? (

--- a/src/renderer/Sidebar.test.tsx
+++ b/src/renderer/Sidebar.test.tsx
@@ -453,6 +453,7 @@ describe("Sidebar — only the active draft is highlighted (BET-1088)", () => {
           scratch: false,
           projectName: "",
           scratchRoot: "",
+          attachments: [],
         },
       ],
       projects: [

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -18,6 +18,7 @@ import { isAssistantTurnInProgress, runWithConcurrency } from "./chatUtils";
 import { applyTheme, type ThemePref } from "./theme";
 import type { ToastItem } from "./Toast";
 import {
+  type Attachment,
   type ModelSelection,
   readSavedActiveSession,
   writeSavedActiveSession,
@@ -235,6 +236,22 @@ export type NewSessionDraft = {
   projectName: string;
   // The parent directory the new scratch folder goes in.
   scratchRoot: string;
+  // Staged files the user attached in the pre-session composer (BET-1124).
+  // Held in-memory (File refs) and uploaded lazily when the draft commits —
+  // same lifetime as the draft (lost on reload like everything else here).
+  attachments: DraftAttachment[];
+};
+
+// A file staged in a new-session draft before the session exists. `file` holds
+// the bytes in-memory; upload to ~/.manta-uploads happens at submit, once the
+// destination session/window name is known. `asPathRef` mirrors Attachment's
+// flag: false = multimodal FilePart, true = @<path> reference read by the AI.
+export type DraftAttachment = {
+  id: string;          // local id (keyed rendering/removal)
+  filename: string;
+  mime: string;
+  asPathRef: boolean;  // false = multimodal FilePart; true = @path ref
+  file: File;          // held in-memory; uploaded lazily at submit
 };
 
 // Per-window UI status: live `running`/`subagents` from the poller, plus an
@@ -419,7 +436,7 @@ type State = {
   // A one-shot prompt for a freshly-created chat session to auto-submit on its
   // first mount (draft → new-session flow). Consumed (cleared) by the panel
   // once it fires, so re-navigating to the session never re-sends it.
-  autoSubmitPrompt: { sid: string; text: string; model?: ModelSelection; plan?: boolean } | null;
+  autoSubmitPrompt: { sid: string; text: string; model?: ModelSelection; plan?: boolean; attachments?: Attachment[] } | null;
   // BET-795: a one-shot composer SEED — the inbox's "Start a session" lands in
   // a chat session with the prompt seeded into the composer but NOT submitted
   // (the user reviews + hits Enter). Delivered to the session's ChatPanel like
@@ -572,7 +589,7 @@ type State = {
   dismissDraft: (id: string) => void;
   setActiveDraft: (id: string) => void;
   setAutoSubmitPrompt: (
-    p: { sid: string; text: string; model?: ModelSelection; plan?: boolean } | null,
+    p: { sid: string; text: string; model?: ModelSelection; plan?: boolean; attachments?: Attachment[] } | null,
   ) => void;
   setSeedPrompt: (p: { sid: string; text: string } | null) => void;
   refresh: () => Promise<void>;
@@ -862,6 +879,7 @@ export const useStore = create<State>((set, get) => ({
           scratch: false,
           projectName: "",
           scratchRoot: "",
+          attachments: [],
         },
       ],
       activeDraftId: id,


### PR DESCRIPTION
## BET-1124 — New-session view: enable attaching files before starting a session

Wires attachments into the pre-session composer. A user can stage files in the new-session/new-workspace view and they ride into the first prompt of the created session.

### What changed
- **`store.ts`**: `NewSessionDraft` gains a required `attachments: DraftAttachment[]` (with exported `DraftAttachment` type). `createDraft` seeds it empty. The one-shot `autoSubmitPrompt` (and `setAutoSubmitPrompt`) carries `attachments?: Attachment[]`.
- **`NewSessionScreen.tsx`**: attach button enabled + title "Attach a file"; hidden `<input type="file" multiple>`; staged files → `DraftAttachment` (mime via `guessMime`, `asPathRef` via `mimeToInputMode`); staged chips rendered above the textarea via the shared `AttachmentStrip` (removable). `submit()` uploads staged files (`uploadBuffer` against `sessionName`) and passes them through `setAutoSubmitPrompt`; a failed upload aborts the whole send. `submitFanOut()` uploads the same way and passes `{remotePath, mime, filename}[]` to `opencodePrompt` so fan-out doesn't drop files.
- **`ChatPanel.tsx`**: auto-submit effect seeds the panel's `attachments` from `autoSubmit.attachments` (additive single line; did not restructure the defer/StrictMode guard). submit()'s existing logic then folds path-ref chips into `@<path>` and sends media chips as FileParts.
- **Tests**: `NewSessionScreen.harness.test.tsx` (stage → chip, remove, and submit carry), `ChatPanel.harness.test.tsx` (auto-submit seeds + folds path-ref into text + sends media as FilePart). `Sidebar.test.tsx` + the harness draft factory get `attachments: []` for the new required field.

Reused `Attachment`, `guessMime`, `mimeToInputMode` from `chatShared` and `AttachmentStrip` from `ComposerParts` — no duplicated logic.

**Base: origin/main @ `ae087dd`**

### Verification results
- PR branch (`multica/BET-1124-enable-pre-session-attach` @ `10a693a`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: vitest 3091 pass / 7 skip / 0 fail; node:test 2354 pass / 0 fail. log sha256: vitest `ab8cb22ee7ea159984a4d7893d0c2f07f90fbf2c2c711db241d61a79e7a5b4ce`, node `3ad34393f1a0a36dbe6b21daeac8aa5090eb77055a53de371e4e66039f1d5274`
- Base (`main` @ `ae087dd`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: vitest 3088 pass / 7 skip / 0 fail; node:test 2354 pass / 0 fail. log sha256: vitest `228918e2e824e0ae0c7f01483b7b3123dea19fab1ad2d549069a8d79194dffb3`, node `51f6c14f622938157ff130d205be76fc99f0f06c782bf905d510b7d6496c4df5`
- **Conclusion**: 0 pre-existing failures; 3 new tests added (all pass), no new failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-vitest-pr.log`, `/tmp/test-vitest-main.log`, `/tmp/test-node-pr.log`, `/tmp/test-node-main.log`.
