### PR TITLE
fix(server): claude usage reads 0-100 percentage verbatim (BET-1126)

### DIFF
--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -526,34 +526,8 @@ test("poller: in-flight guard prevents overlapping ticks", async () => {
 // Adapter: claude — captured sample payloads, fed inline (no fixture files)
 // ----------------------------------------------------------------------------
 
-test("claude adapter: utilization fraction (0-1) is converted to a percentage", async () => {
-  const sample = {
-    rate_limits: {
-      five_hour: { utilization: 0.78, resets_at: 1735689600 },
-      seven_day: { utilization: 0.41, resets_at: "2025-01-07T09:00:00.000Z" },
-      seven_day_opus: { utilization: 0.64 },
-      seven_day_sonnet: { used_percentage: 18 },
-    },
-  };
-  const snap = await claudeAdapter.fetch({
-    fetchImpl: async () => fakeResponse(200, sample),
-    readCredentials: async () => ({ accessToken: "tok" }),
-  });
-  assert.equal(snap.provider, "claude");
-  assert.equal(snap.windows.length, 2);
-  const session = snap.windows.find((w) => w.kind === "session");
-  assert.equal(session.label, "Session (5h)");
-  assert.equal(session.pct, 78);
-  assert.equal(session.resetsAt, 1735689600000);
-  const weekly = snap.windows.find((w) => w.kind === "weekly");
-  assert.equal(weekly.pct, 41);
-  assert.equal(weekly.resetsAt, Date.parse("2025-01-07T09:00:00.000Z"));
-  assert.equal(snap.extras.find((e) => e.label === "Opus (7d)").value, "64%");
-  assert.equal(snap.extras.find((e) => e.label === "Sonnet (7d)").value, "18%");
-});
-
 test("claude adapter: used_percentage is preferred over utilization when both are present", async () => {
-  const sample = { rate_limits: { five_hour: { utilization: 0.5, used_percentage: 93 } } };
+  const sample = { rate_limits: { five_hour: { utilization: 50, used_percentage: 93 } } };
   const snap = await claudeAdapter.fetch({
     fetchImpl: async () => fakeResponse(200, sample),
     readCredentials: async () => ({ accessToken: "tok" }),
@@ -603,7 +577,7 @@ test("claude adapter: still honours a rate_limits wrapper if a future build rein
 });
 
 test("claude adapter: no absolutes, no planLabel — never fabricated", async () => {
-  const sample = { rate_limits: { five_hour: { utilization: 0.1 } } };
+  const sample = { rate_limits: { five_hour: { utilization: 10 } } };
   const snap = await claudeAdapter.fetch({
     fetchImpl: async () => fakeResponse(200, sample),
     readCredentials: async () => ({ accessToken: "tok" }),
@@ -611,6 +585,15 @@ test("claude adapter: no absolutes, no planLabel — never fabricated", async ()
   assert.equal("planLabel" in snap, false);
   assert.equal("used" in snap.windows[0], false);
   assert.equal("limit" in snap.windows[0], false);
+});
+
+test("claude adapter: a 1% reading is 1%, not 100% (reset-time regression)", async () => {
+  const sample = { five_hour: { utilization: 1, resets_at: "2026-08-18T19:20:00.000Z" } };
+  const snap = await claudeAdapter.fetch({
+    fetchImpl: async () => fakeResponse(200, sample),
+    readCredentials: async () => ({ accessToken: "tok" }),
+  });
+  assert.equal(snap.windows.find((w) => w.kind === "session").pct, 1);
 });
 
 test("claude adapter: detect() requires a non-empty accessToken", async () => {

--- a/src/server/usageAdapters/claude.mjs
+++ b/src/server/usageAdapters/claude.mjs
@@ -26,19 +26,11 @@ async function defaultReadCredentials() {
   }
 }
 
-// Anthropic sometimes sends `used_percentage` (0-100) directly and always
-// sends `utilization` too — prefer `used_percentage` when both are present.
-// `utilization` has been observed BOTH as a 0-1 fraction (the documented
-// shape) and, live against api.anthropic.com/api/oauth/usage as of 2026-08,
-// already as a 0-100 percentage (e.g. `"utilization":58.0`) — a fraction can
-// never exceed 1.0, so treat anything > 1 as already a percentage rather than
-// re-scaling it into the 5800% range.
+// The provider reports a 0-100 percentage (used_percentage or utilization)
+// and it is used verbatim, never rescaled.
 function pctOf(pool) {
-  if (typeof pool?.used_percentage === "number") return pool.used_percentage;
-  if (typeof pool?.utilization === "number") {
-    return pool.utilization > 1 ? pool.utilization : pool.utilization * 100;
-  }
-  return undefined;
+  const v = pool?.used_percentage ?? pool?.utilization;
+  return typeof v === "number" ? v : undefined;
 }
 
 // Per-model 7d pools ride under either `seven_day_opus`/`seven_day_sonnet` or


### PR DESCRIPTION
Fixes BET-1126: Claude usage adapter reports a 1% reading as 100%.

**Root cause:** `pctOf` in `src/server/usageAdapters/claude.mjs` guessed whether
`utilization` was a 0-1 fraction or a 0-100 percentage, rescaling anything ≤ 1
(including exactly 1, i.e. 1% used) by ×100 → 100%, painting a full red dial and
firing a false "limit reached" toast right after a quota reset.

**Fix (net deletion):** `pctOf` now reads whatever percentage the provider
supplied (`used_percentage` ?? `utilization`) verbatim, with no rescaling; the
stale fraction-heuristic comment block is replaced with a one-liner.

Per the issue's explicit guardrail, no other behavior was touched: the `stale`
flag / reset-instant handling (BET-1039/1041/1048), `normalizeWindow` clamp,
`extraFor`, the `rate_limits` wrapper reading, and the 429 handling are all
unchanged.

**Tests:** deleted the old fraction-conversion test (asserted the buggy 0.78→78),
changed two samples to percentage values (`0.5`→`50`, `0.1`→`10`), left the
live-shape and rate_limits-wrapper tests untouched, and added a regression test
pinning `utilization: 1` → `pct === 1`.

Base: origin/main @ `ae087dd5`
