### PR TITLE
fix(server): codex usage adapter reads opencode's own OpenAI sign-in (BET-1128)

### DIFF
--- a/src/renderer/UsageDial.tsx
+++ b/src/renderer/UsageDial.tsx
@@ -42,7 +42,7 @@ import { mbtn } from "./ComposerParts";
 // the same single lookup instead of duplicating it.
 const PROVIDER_LABELS: Record<string, string> = {
   claude: "Claude",
-  codex: "Codex",
+  codex: "OpenAI",
   kimi: "Kimi",
 };
 

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1414,6 +1414,63 @@ export async function readProviderApiKey(providerId, { readFile = readFileSync }
   return parseProviderApiKey(raw, providerId);
 }
 
+/**
+ * Pure: extract a provider's OAuth access token from the ALREADY-READ text of
+ * opencode's auth store. Mirrors `parseProviderApiKey` above exactly — never
+ * throws, returns `""` (this value is used directly as a Bearer header) for
+ * invalid JSON, a missing provider entry, or an entry that isn't an oauth
+ * token. Discriminating on `type === "oauth"` matters for the same reason the
+ * api-key reader discriminates on `type === "api"`: the value goes straight
+ * into a `Bearer` header, so an entry of the wrong type must never supply it.
+ *
+ * opencode persists an oauth sign-in as
+ * `{"<providerId>": {"type":"oauth", "access":"…", "refresh":"…", …}}` — e.g.
+ * the `openai` entry this box writes for an OpenAI sign-in.
+ *
+ * @param {string} rawFileText
+ * @param {string} providerId
+ * @returns {string}
+ */
+export function parseProviderOAuthToken(rawFileText, providerId) {
+  try {
+    const entry = JSON.parse(rawFileText)?.[providerId];
+    return entry?.type === "oauth" && typeof entry?.access === "string" && entry.access.length > 0
+      ? entry.access
+      : "";
+  } catch {
+    return "";
+  }
+}
+
+/**
+ * Read a provider's OAuth access token straight off opencode's own auth store.
+ * The sibling of `readProviderApiKey` above for the oauth entry shape — a
+ * READER only, never a writer: opencode owns the token's lifecycle (including
+ * refreshing it), and an expired token simply 401s at the usage endpoint.
+ *
+ * Tolerates a missing file by returning `""` — NEVER throws, so a caller can
+ * `await` this unconditionally. The file-read function is injectable
+ * (`readFile`), defaulting to the real `readFileSync`, so tests never touch a
+ * real auth store. Reuses `opencodeAuthPath()` — do not compute the path again.
+ *
+ * SECURITY: this resolves a LIVE credential. It must never log, echo, or
+ * return the token anywhere but to its direct caller, and a caller must never
+ * fold it into an error message.
+ *
+ * @param {string} providerId
+ * @param {{ readFile?: (file: string, encoding: string) => string }} [opts]
+ * @returns {Promise<string>}
+ */
+export async function readProviderOAuthToken(providerId, { readFile = readFileSync } = {}) {
+  let raw;
+  try {
+    raw = readFile(opencodeAuthPath(), "utf-8");
+  } catch {
+    return "";
+  }
+  return parseProviderOAuthToken(raw, providerId);
+}
+
 // ---------------------------------------------------------------------------
 // VCS
 // ---------------------------------------------------------------------------

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -42,6 +42,8 @@ import {
   claudeCliStatus,
   parseProviderApiKey,
   readProviderApiKey,
+  parseProviderOAuthToken,
+  readProviderOAuthToken,
   opencodeAuthPath,
   completeProviderOauth,
 } from "./opencode.mjs";
@@ -154,6 +156,88 @@ test("readProviderApiKey returns the key for a valid api-type entry", async () =
     await readVia(JSON.stringify({ "kimi-for-coding": { type: "api", key: "kimi-provider-key" } })),
     "kimi-provider-key",
   );
+});
+
+// ---------------------------------------------------------------------------
+// parseProviderOAuthToken (BET-1128) — the oauth sibling of
+// parseProviderApiKey. Reads the `access` token of an `oauth`-type entry in
+// opencode's own auth store (e.g. the `openai` entry for an OpenAI sign-in).
+// Never touches a real file.
+// ---------------------------------------------------------------------------
+
+const OPENAI_OAUTH = JSON.stringify({
+  openai: { type: "oauth", access: "mom-access-token", refresh: "mom-refresh", accountId: "acc-1", expires: 1788 },
+});
+
+test("parseProviderOAuthToken extracts the access token from an oauth-type entry", () => {
+  assert.equal(parseProviderOAuthToken(OPENAI_OAUTH, "openai"), "mom-access-token");
+});
+
+test("parseProviderOAuthToken returns \"\" for an api-type entry (no `access` field)", () => {
+  const raw = JSON.stringify({ openai: { type: "api", key: "some-key" } });
+  assert.equal(parseProviderOAuthToken(raw, "openai"), "");
+});
+
+test("parseProviderOAuthToken returns \"\" for a provider with no entry", () => {
+  const raw = JSON.stringify({ anthropic: { type: "oauth", access: "x", refresh: "y" } });
+  assert.equal(parseProviderOAuthToken(raw, "openai"), "");
+});
+
+test("parseProviderOAuthToken returns \"\" for a non-oauth entry even when it carries a non-empty `access` (type gate)", () => {
+  // type === "oauth" is the discriminant — a stray `access` on an api/common
+  // entry must never be trusted as a Bearer credential.
+  const raw = JSON.stringify({ openai: { type: "api", access: "should-not-leak", key: "x" } });
+  assert.equal(parseProviderOAuthToken(raw, "openai"), "");
+  const rawNoType = JSON.stringify({ openai: { access: "still-no-type" } });
+  assert.equal(parseProviderOAuthToken(rawNoType, "openai"), "");
+});
+
+test("parseProviderOAuthToken returns \"\" for an empty-string access token", () => {
+  const raw = JSON.stringify({ openai: { type: "oauth", access: "" } });
+  assert.equal(parseProviderOAuthToken(raw, "openai"), "");
+});
+
+test("parseProviderOAuthToken returns \"\" for unparseable JSON", () => {
+  assert.equal(parseProviderOAuthToken("not json{", "openai"), "");
+});
+
+test("parseProviderOAuthToken returns \"\" for an empty auth store", () => {
+  assert.equal(parseProviderOAuthToken("{}", "openai"), "");
+});
+
+test("parseProviderOAuthToken never echoes the token into an exception (it doesn't throw at all)", () => {
+  assert.equal(parseProviderOAuthToken("null", "openai"), "");
+  assert.equal(parseProviderOAuthToken("[]", "openai"), "");
+  assert.equal(parseProviderOAuthToken('"just a string"', "openai"), "");
+});
+
+// readProviderOAuthToken (BET-1128) — the IO wrapper around
+// parseProviderOAuthToken, mirroring readProviderApiKey exactly: injectable
+// readFile, "" (never a throw) on missing file / unparseable / wrong type.
+const readOauthVia = (text) =>
+  readProviderOAuthToken("openai", { readFile: () => text });
+
+test("readProviderOAuthToken returns \"\" when the auth store file is missing (reader throws)", async () => {
+  assert.equal(
+    await readProviderOAuthToken("openai", { readFile: () => { throw new Error("ENOENT"); } }),
+    "",
+  );
+});
+
+test("readProviderOAuthToken returns \"\" for unparseable JSON", async () => {
+  assert.equal(await readOauthVia("not json{"), "");
+});
+
+test("readProviderOAuthToken returns \"\" for a provider with no entry", async () => {
+  assert.equal(await readOauthVia(JSON.stringify({ anthropic: { type: "oauth", access: "x" } })), "");
+});
+
+test("readProviderOAuthToken returns \"\" for an api-type entry", async () => {
+  assert.equal(await readOauthVia(JSON.stringify({ openai: { type: "api", key: "k" } })), "");
+});
+
+test("readProviderOAuthToken returns the access token for a valid oauth-type entry", async () => {
+  assert.equal(await readOauthVia(OPENAI_OAUTH), "mom-access-token");
 });
 
 // opencodeAuthPath (review cycle 2 Nit): mirrors messageSearch.mjs's

--- a/src/server/usageAdapters/codex.mjs
+++ b/src/server/usageAdapters/codex.mjs
@@ -1,36 +1,32 @@
 // codex.mjs — usage adapter for Codex / ChatGPT Plus-Pro (BET-737).
 //
-// Credential: ~/.codex/auth.json, `tokens.access_token` (falls back to a
-// top-level `access_token`). Path resolved via homedir() — never hardcode
-// `/home/...` (matches claudeAuth.mjs's own CREDENTIALS_PATH convention).
+// Credential: opencode's OWN OpenAI sign-in — `~/.local/share/opencode/
+// auth.json`, the `openai` entry, oauth `access` token. This adapter is a
+// READER of opencode's connection, not a second place to enter it — no config
+// field, no secrets-store entry, no new credentials file (`readProviderOAuthToken`
+// in opencode.mjs resolves the store path and returns "" on any read/parse
+// failure or a missing/wrong-type entry — never throws). opencode is the only
+// thing on the box that runs models, so an OpenAI session opencode does not
+// hold is not usage worth reporting; opencode also owns the token's refresh
+// lifecycle (an expired token simply 401s and the poller's carry-forward
+// handles it). If the user isn't signed into OpenAI through opencode,
+// `detect()` is simply false: a silent, correct inactive state, not an error.
 //
 // Endpoint schema is public in the codex repo — the most stable of the three
 // adapters — but every field read stays defensive anyway, for consistency
 // with its siblings and in case the box is running an older/newer codex CLI.
 
-import { readFile } from "node:fs/promises";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { readProviderOAuthToken } from "../opencode.mjs";
 import { normalizeWindow } from "./normalizeWindow.mjs";
 import { httpError } from "./httpError.mjs";
 
 const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
+const PROVIDER_ID = "openai";
 
-function authPath() {
-  return join(homedir(), ".codex", "auth.json");
-}
-
-// Default I/O — overridable per-call so tests never touch the real
-// credentials file or the network.
-async function defaultReadToken() {
-  try {
-    const raw = await readFile(authPath(), "utf-8");
-    const parsed = JSON.parse(raw);
-    const token = parsed?.tokens?.access_token ?? parsed?.access_token;
-    return typeof token === "string" ? token : null;
-  } catch {
-    return null;
-  }
+// Default I/O — overridable per-call so tests never touch opencode's real
+// auth store or the network.
+function defaultReadToken() {
+  return readProviderOAuthToken(PROVIDER_ID);
 }
 
 function titleCase(s) {


### PR DESCRIPTION
## BET-1128 — OpenAI plan usage never shows: codex adapter credential source

The codex usage adapter read its credential from the Codex CLI's own file
(`~/.codex/auth.json`). On a box that never installed the Codex CLI that file
doesn't exist, so `detect()` returned `false`, the adapter was skipped, and no
snapshot was produced — OpenAI plan usage silently never rendered in the usage
dial, even with "Always show plan usage" on. Claude and Kimi worked.

The box authenticates OpenAI through **opencode's own auth store**
(`~/.local/share/opencode/auth.json`, `openai` entry, `type: "oauth"`, `access`
token). Verified live: that `access` token alone (no `chatgpt-account-id` header
needed) returns a full `rate_limit` payload from
`https://chatgpt.com/backend-api/wham/usage`. Only the credential source was
wrong.

### Changes

1. **`src/server/opencode.mjs`** — added `parseProviderOAuthToken` /
   `readProviderOAuthToken`, the oauth siblings of the existing
   `parseProviderApiKey` / `readProviderApiKey` pair. Discriminate on
   `type === "oauth"` (the Bearer-header safety gate), reuse the existing
   `opencodeAuthPath()`, never throw, return `""` on any failure, injectable
   `readFile`.

2. **`src/server/usageAdapters/codex.mjs`** — REPLACED the credential source
   (deleted `authPath()`, `defaultReadToken()`'s body, and the now-unused
   `readFile`/`homedir`/`join` imports). It now reads opencode's own OpenAI
   sign-in via `readProviderOAuthToken("openai")`. `detect()`/`fetch()`
   signatures and their `{ readToken = defaultReadToken }` injection points are
   unchanged, so every existing codex test passes untouched. No fallback — one
   credential source, matching `kimi.mjs`.

3. **`src/renderer/UsageDial.tsx`** — `PROVIDER_LABELS` `codex: "OpenAI"` (adapter id stays `codex`; only the user-visible string changes).

### Tests

- `parseProviderOAuthToken` unit tests (opencode.test.mjs): oauth → access;
  api-type → `""`; missing provider → `""`; unparseable → `""`; empty access →
  `""`; type-gate + no-throw cases.
- `readProviderOAuthToken` IO-wrapper tests (missing file / unparseable /
  wrong type / valid).
- Existing codex `detect()` test (true for non-empty injected token, false for
  `""`/null) and all codex `fetch` tests pass **untouched**.
- No test reads a real credentials file or hits the network.

**Base: origin/main @ `ae087dd5`**
