### PR TITLE
feat(shared): unwrap provider error bodies to the human sentence (BET-1131)

### DIFF
--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -92,6 +92,7 @@ export {
   describeTruncation,
   extractSubagentInfo,
   findFlushBoundary,
+  humanizeProviderError,
   hydrateQuestion,
   isAssistantTurnComplete,
   isAssistantTurnInProgress,

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -69,6 +69,7 @@ import {
   hydrateQuestion,
   authErrorAdvice,
   fetchTranscriptWithRetry,
+  humanizeProviderError,
 } from "../chatUtils";
 import { planModeFromToolPart, isPlanAgent } from "../../shared/planMode.mjs";
 import type { TokenUsage } from "../chatShared";
@@ -522,22 +523,27 @@ export function useSseBus(params: {
           setRunning(false);
           return;
         }
+        // Unwrap a provider rejection body (e.g. `Bad Request: {"detail":"…"}`)
+        // down to the human sentence for every branch below. `authErrorAdvice`
+        // above keeps reading the ORIGINAL `raw` — its regex matches on message
+        // content and its behaviour must not shift (BET-1131).
+        const human = humanizeProviderError(raw);
         let msg: string;
         switch (err?.name) {
           case "ContextOverflowError":
-            msg = `Context full — try /compact: ${raw}`;
+            msg = `Context full — try /compact: ${human}`;
             break;
           case "MessageOutputLengthError":
             msg = "Response truncated (hit output limit)";
             break;
           case "StructuredOutputError":
-            msg = `Structured output failed: ${raw}`;
+            msg = `Structured output failed: ${human}`;
             break;
           case "ApiError":
-            msg = `API error: ${raw}`;
+            msg = `API error: ${human}`;
             break;
           default:
-            msg = raw;
+            msg = human;
         }
         setSendError(msg);
         setAuthReconnect(null);

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -40,6 +40,7 @@ import {
   countUserTurns,
   buildTitlePromptInput,
   buildTitleInstruction,
+  humanizeProviderError,
   ASSUMED_CONTEXT_TOKENS,
 } from "../shared/streamInterpretation.mjs";
 import { planModeFromToolPart } from "../shared/planMode.mjs";
@@ -491,7 +492,10 @@ export function createStreamInterpreter({
         const message =
           typeof err?.data?.message === "string" ? err.data.message :
           typeof err?.message === "string" ? err.message : "The turn failed.";
-        emit(sid, "sessionError", { name, message });
+        // Unwrap a provider rejection body down to the human sentence so the
+        // native iOS transcript notice shows the same clean text desktop does
+        // (BET-1131). Lossless — unrecognised messages pass through unchanged.
+        emit(sid, "sessionError", { name, message: humanizeProviderError(message) });
         emitTurnComplete(sid, st, true);
         return;
       }

--- a/src/shared/streamInterpretation.d.mts
+++ b/src/shared/streamInterpretation.d.mts
@@ -21,6 +21,10 @@ export function describeTruncation(kind: TruncationKind): {
   hint: string;
 };
 
+/** Unwrap the human sentence from a provider rejection body
+ *  (`<reason phrase>: <JSON>`), or return the input unchanged. Lossless. */
+export function humanizeProviderError(raw: string): string;
+
 export function findFlushBoundary(buffer: string): number;
 
 /** Max time a chunk may be withheld before the caller flushes at the latest

--- a/src/shared/streamInterpretation.mjs
+++ b/src/shared/streamInterpretation.mjs
@@ -95,6 +95,64 @@ export function describeTruncation(kind) {
   }
 }
 
+// Pull the human sentence out of a provider rejection body, so an error banner
+// that currently reads `Bad Request: {"detail":"The 'gpt-5.6-sol' model is not
+// supported…"}` instead shows just the sentence inside. Pure, no I/O, no throw.
+//
+// The wire shape is always `<HTTP reason phrase>: <raw provider response body>`.
+// Only bodies we recognise are unwrapped; anything we don't understand is
+// returned byte-identical (lossless fallback — an unreadable error is far
+// better than a missing one).
+export function humanizeProviderError(raw) {
+  if (typeof raw !== "string") return raw;
+  let body = raw;
+  // Split an optional leading `<reason phrase>: ` off the front. Only treat the
+  // leading segment as a reason phrase when the remainder is itself JSON
+  // (starts with `{` or `[`); plain prose like `Bad Request: something happened`
+  // is NOT a JSON body and is left untouched.
+  const sep = raw.indexOf(": ");
+  if (sep > 0) {
+    const rest = raw.slice(sep + 2);
+    if (rest.startsWith("{") || rest.startsWith("[")) body = rest;
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(body);
+  } catch {
+    return raw;
+  }
+  const sentence = extractErrorSentence(parsed);
+  if (typeof sentence === "string" && sentence.length > 0) return sentence;
+  return raw;
+}
+
+// Recognise the four provider body shapes and return the human sentence, or
+// null when none match.
+//
+//   | Provider                    | Body                                    | Extract     |
+//   |-----------------------------|-----------------------------------------|-------------|
+//   | Codex / ChatGPT backend     | `{"detail":"…"}`                        | `detail`    |
+//   | OpenAI API                  | `{"error":{"message":"…",…}}`           | `error.message` |
+//   | Anthropic                   | `{"type":"error","error":{…,"message":"…"}}` | `error.message` |
+//   | Misc / OpenAI-compatible    | `{"message":"…"}`                       | `message`   |
+//
+// Order matters only in that `error.message` is checked before a top-level
+// `message`. `detail` may also arrive as an array of objects (FastAPI
+// validation errors) — if it is not a non-empty string, the shape is unmatched.
+function extractErrorSentence(parsed) {
+  if (!parsed || typeof parsed !== "object") return null;
+  const errObj = parsed.error;
+  if (errObj && typeof errObj === "object") {
+    const m = errObj.message;
+    if (typeof m === "string" && m.length > 0) return m;
+  }
+  const detail = parsed.detail;
+  if (typeof detail === "string" && detail.length > 0) return detail;
+  const message = parsed.message;
+  if (typeof message === "string" && message.length > 0) return message;
+  return null;
+}
+
 // ===== Streamed-text flush boundaries =====
 //
 // opencode streams text/reasoning content via `message.part.delta` events

--- a/src/shared/streamInterpretation.test.ts
+++ b/src/shared/streamInterpretation.test.ts
@@ -38,6 +38,7 @@ import {
   shouldAutoRename,
   shouldDropEventForSessionFilter,
   summarizeChildSession,
+  humanizeProviderError,
 } from "./streamInterpretation.mjs";
 
 
@@ -2044,5 +2045,113 @@ describe("isSafeCut", () => {
   it("ignores underscores — they are constant in paths and identifiers", () => {
     // Counting them would block almost every cut.
     expect(isSafeCut("see src/foo_bar.ts and _baz. ")).toBe(true);
+  });
+});
+
+describe("humanizeProviderError", () => {
+  const screenshot =
+    "Bad Request: {\"detail\":\"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.\"}";
+
+  it("unwraps the screenshot case end to end", () => {
+    expect(humanizeProviderError(screenshot)).toBe(
+      "The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account.",
+    );
+  });
+
+  it("unwraps the four body shapes WITH a leading reason phrase", () => {
+    expect(
+      humanizeProviderError(
+        `Bad Request: ${JSON.stringify({ detail: "detail sentence" })}`,
+      ),
+    ).toBe("detail sentence");
+    expect(
+      humanizeProviderError(
+        `Bad Request: ${JSON.stringify({
+          error: { message: "openai sentence", type: "invalid_request_error", code: "model_not_found", param: null },
+        })}`,
+      ),
+    ).toBe("openai sentence");
+    expect(
+      humanizeProviderError(
+        `Bad Request: ${JSON.stringify({
+          type: "error",
+          error: { type: "not_found_error", message: "anthropic sentence" },
+        })}`,
+      ),
+    ).toBe("anthropic sentence");
+    expect(
+      humanizeProviderError(
+        `Bad Request: ${JSON.stringify({ message: "misc sentence" })}`,
+      ),
+    ).toBe("misc sentence");
+  });
+
+  it("unwraps the four body shapes WITHOUT a leading reason phrase", () => {
+    expect(humanizeProviderError(JSON.stringify({ detail: "detail sentence" }))).toBe(
+      "detail sentence",
+    );
+    expect(
+      humanizeProviderError(JSON.stringify({ error: { message: "openai sentence" } })),
+    ).toBe("openai sentence");
+    expect(
+      humanizeProviderError(JSON.stringify({ type: "error", error: { type: "x", message: "anthropic sentence" } })),
+    ).toBe("anthropic sentence");
+    expect(humanizeProviderError(JSON.stringify({ message: "misc sentence" }))).toBe(
+      "misc sentence",
+    );
+  });
+
+  it("drops the reason phrase but keeps the extracted sentence", () => {
+    // The extracted sentence already says everything the reason phrase did.
+    expect(
+      humanizeProviderError(`Bad Request: ${JSON.stringify({ message: "Too many requests, retry later." })}`),
+    ).toBe("Too many requests, retry later.");
+  });
+
+  it("returns unrecognised input losslessly (fallback)", () => {
+    // Plain prose with no JSON.
+    expect(humanizeProviderError("The provider is down.")).toBe("The provider is down.");
+    // A reason-phrase prefix over non-JSON prose is NOT treated as a body split.
+    expect(humanizeProviderError("Bad Request: something happened.")).toBe(
+      "Bad Request: something happened.",
+    );
+    // Malformed JSON.
+    expect(humanizeProviderError("{nope")).toBe("{nope");
+    // Valid JSON of an unrecognised shape.
+    expect(humanizeProviderError(JSON.stringify({ foo: 1 }))).toBe(JSON.stringify({ foo: 1 }));
+    // Empty string.
+    expect(humanizeProviderError("")).toBe("");
+    // A body whose `detail` is an array (FastAPI validation errors).
+    expect(
+      humanizeProviderError(JSON.stringify({ detail: [{ loc: ["body"], msg: "field required" }] })),
+    ).toBe(JSON.stringify({ detail: [{ loc: ["body"], msg: "field required" }] }));
+    // A non-string detail.
+    expect(humanizeProviderError(JSON.stringify({ detail: 42 }))).toBe(JSON.stringify({ detail: 42 }));
+    // Non-object JSON (number/string/array without a recognised shape).
+    expect(humanizeProviderError("42")).toBe("42");
+    expect(humanizeProviderError(JSON.stringify(["a", "b"]))).toBe(JSON.stringify(["a", "b"]));
+  });
+
+  it("favours error.message over a top-level message", () => {
+    expect(
+      humanizeProviderError(
+        JSON.stringify({ error: { message: "nested wins" }, message: "top-level" }),
+      ),
+    ).toBe("nested wins");
+  });
+
+  it("is idempotent (humanize(humanize(x)) === humanize(x))", () => {
+    const inputs = [
+      screenshot,
+      `Bad Request: ${JSON.stringify({ detail: "detail sentence" })}`,
+      `Bad Request: ${JSON.stringify({ error: { message: "openai sentence" } })}`,
+      "plain prose",
+      JSON.stringify({ foo: 1 }),
+      "Bad Request: something happened.",
+    ];
+    for (const raw of inputs) {
+      const once = humanizeProviderError(raw);
+      expect(humanizeProviderError(once)).toBe(once);
+    }
   });
 });


### PR DESCRIPTION
## BET-1131 — Provider errors render as raw HTTP bodies: unwrap the human sentence (shared, desktop + iOS)

Adds a single pure helper `humanizeProviderError(raw)` to the shared stream-interpretation module and calls it from **both** consumers, so a provider rejection like:

```
Bad Request: {"detail":"The 'gpt-5.6-sol' model is not supported when using Codex with a ChatGPT account."}
```

now renders as just the human sentence on desktop **and** in the native iOS transcript notice.

**Files changed:** 6.

- `src/shared/streamInterpretation.mjs` — `humanizeProviderError` + `extractErrorSentence`. Splits an optional leading `<reason phrase>: ` iff the remainder is JSON, parses it, and pulls the sentence from the first matching shape (`error.message` before top-level `message`, then `detail`, then `message`). **Lossless fallback:** anything that doesn't parse or match is returned byte-identical.
- `src/shared/streamInterpretation.d.mts` — signature alongside `describeTruncation`.
- `src/renderer/chatUtils.ts` — re-export (renderer keeps one implementation through the shared module).
- `src/renderer/hooks/useSseBus.ts` — in the `session.error` block, `authErrorAdvice` still reads the **original** `raw`; the switch/default branches use `humanizeProviderError(raw)`.
- `src/server/streamInterp.mjs` — applies the same helper to `message` before `emit(sid, "sessionError", …)`, so iOS shows the same clean string. No Swift change needed.
- `src/shared/streamInterpretation.test.ts` — the four body shapes ± reason phrase, lossless fallback (prose / malformed JSON / unknown shape / empty / array `detail`), `error.message` precedence, screenshot case end-to-end, idempotence.

**Base: `origin/main` @ `fea29698`** (refreshed to HEAD before branching).

**Verification results:**
- PR branch (`multica/BET-1131-provider-error-humanize` @ `7a9f36e`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 3098 pass / 0 fail / 7 skip. log sha256: `837d3e844d1016246e6a86de287f21d6e832d5aaf92f98aadbb4c562acf242ac`
- Base (`main` @ `fea29698`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 3091 pass / 0 fail / 7 skip. log sha256: `751530ee6db7e9da1e95b6f183a8f81d06c2aea4f10b6982c3aaf3d44bf3c0a2`
- **Conclusion:** 0 new failures; 7 new passing tests (the `humanizeProviderError` suite). No pre-existing failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Out of scope (per ticket):** length capping, `authErrorAdvice` changes, Swift changes, per-provider actionable UI (model-switch offer) — filed as follow-ups separately if warranted.
