### PR TITLE
fix(server): derive usage window label from provider's real window length (BET-1129)

### DIFF
--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -28,7 +28,7 @@
  * @typedef {Object} UsageWindow
  * @property {"session"|"weekly"|string} kind  Open set — a provider with a
  *   daily window works with no engine change.
- * @property {string} label      Human label, e.g. "Session (5h)".
+ * @property {string} label      Human label, e.g. "5h".
  * @property {number} pct        0-100, ALWAYS present. Derived when the
  *                               provider reports only absolutes.
  * @property {number} [used]     Absolute count when the provider exposes one.

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -1,6 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { normalizeWindow, createUsagePoller, ADAPTERS, rateLimitBackoffMs, carryForward } from "./usage.mjs";
+import { usageWindowLabel } from "./usageAdapters/normalizeWindow.mjs";
 import { claudeAdapter } from "./usageAdapters/claude.mjs";
 import { codexAdapter } from "./usageAdapters/codex.mjs";
 import { kimiAdapter } from "./usageAdapters/kimi.mjs";
@@ -117,6 +118,25 @@ test("normalizeWindow: kind/label/binding pass through", () => {
   // binding omitted entirely when not explicitly true.
   const w2 = normalizeWindow({ pct: 41 });
   assert.equal("binding" in w2, false);
+});
+
+// ----------------------------------------------------------------------------
+// usageWindowLabel — pure
+// ----------------------------------------------------------------------------
+
+test("usageWindowLabel: unusable durations yield an empty label", () => {
+  assert.equal(usageWindowLabel(0), "");
+  assert.equal(usageWindowLabel(-1), "");
+  assert.equal(usageWindowLabel(undefined), "");
+  assert.equal(usageWindowLabel(null), "");
+  assert.equal(usageWindowLabel("abc"), "");
+});
+
+test("usageWindowLabel: derives m/h/d from the window length in seconds", () => {
+  assert.equal(usageWindowLabel(1800), "30m");
+  assert.equal(usageWindowLabel(18000), "5h");
+  assert.equal(usageWindowLabel(604800), "7d");
+  assert.equal(usageWindowLabel(2592000), "30d");
 });
 
 // ----------------------------------------------------------------------------
@@ -653,6 +673,37 @@ test("codex adapter: no credits, no plan_type — extras/planLabel omitted, not 
   });
   assert.equal("planLabel" in snap, false);
   assert.equal("extras" in snap, false);
+});
+
+test("codex adapter: a 30-day primary window is labelled 30d, not Session (5h)", async () => {
+  const sample = {
+    rate_limit: {
+      primary_window: { used_percent: 3, limit_window_seconds: 2592000, reset_at: 1735700000000 },
+      secondary_window: { used_percent: 91, reset_at: 1735700000000 },
+    },
+  };
+  const snap = await codexAdapter.fetch({
+    fetchImpl: async () => fakeResponse(200, sample),
+    readToken: async () => "tok",
+    now: () => 1_700_000_000_000,
+  });
+  const session = snap.windows.find((w) => w.kind === "session");
+  assert.equal(session.label, "30d");
+});
+
+test("codex adapter: a window with no limit_window_seconds still yields a usable window with empty label", async () => {
+  const sample = {
+    rate_limit: { primary_window: { used_percent: 5, reset_at: 1735700000000 } },
+  };
+  const snap = await codexAdapter.fetch({
+    fetchImpl: async () => fakeResponse(200, sample),
+    readToken: async () => "tok",
+    now: () => 1_700_000_000_000,
+  });
+  const session = snap.windows.find((w) => w.kind === "session");
+  assert.ok(session, "a pct with no duration still produces a window");
+  assert.equal(session.label, "");
+  assert.equal(session.pct, 5);
 });
 
 test("codex adapter: detect() requires a non-empty token", async () => {

--- a/src/server/usageAdapters/claude.mjs
+++ b/src/server/usageAdapters/claude.mjs
@@ -10,7 +10,7 @@
 
 import { readFile } from "node:fs/promises";
 import { CREDENTIALS_PATH, parseCredentials } from "../claudeAuth.mjs";
-import { normalizeWindow } from "./normalizeWindow.mjs";
+import { normalizeWindow, usageWindowLabel } from "./normalizeWindow.mjs";
 import { httpError } from "./httpError.mjs";
 
 const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
@@ -75,7 +75,7 @@ export const claudeAdapter = {
     const session = fiveHour
       ? normalizeWindow({
           kind: "session",
-          label: "Session (5h)",
+          label: usageWindowLabel(5 * 3600),
           pct: pctOf(fiveHour),
           resetsAt: fiveHour?.resets_at,
         })
@@ -86,7 +86,7 @@ export const claudeAdapter = {
     const weekly = sevenDay
       ? normalizeWindow({
           kind: "weekly",
-          label: "Weekly",
+          label: usageWindowLabel(7 * 86400),
           pct: pctOf(sevenDay),
           resetsAt: sevenDay?.resets_at,
         })

--- a/src/server/usageAdapters/codex.mjs
+++ b/src/server/usageAdapters/codex.mjs
@@ -17,7 +17,7 @@
 // with its siblings and in case the box is running an older/newer codex CLI.
 
 import { readProviderOAuthToken } from "../opencode.mjs";
-import { normalizeWindow } from "./normalizeWindow.mjs";
+import { normalizeWindow, usageWindowLabel } from "./normalizeWindow.mjs";
 import { httpError } from "./httpError.mjs";
 
 const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
@@ -69,7 +69,7 @@ export const codexAdapter = {
     const session = primary
       ? normalizeWindow({
           kind: "session",
-          label: "Session (5h)",
+          label: usageWindowLabel(primary?.limit_window_seconds),
           pct: primary?.used_percent,
           resetsAt: resolveResetsAt(primary, nowMs),
         })
@@ -80,7 +80,7 @@ export const codexAdapter = {
     const weekly = secondary
       ? normalizeWindow({
           kind: "weekly",
-          label: "Weekly",
+          label: usageWindowLabel(secondary?.limit_window_seconds),
           pct: secondary?.used_percent,
           resetsAt: resolveResetsAt(secondary, nowMs),
         })

--- a/src/server/usageAdapters/kimi.mjs
+++ b/src/server/usageAdapters/kimi.mjs
@@ -23,7 +23,7 @@
 // src/renderer/chatUtils.ts AUTH_PROVIDER_LABELS) — not "moonshot" / "kimi".
 
 import { readProviderApiKey } from "../opencode.mjs";
-import { normalizeWindow } from "./normalizeWindow.mjs";
+import { normalizeWindow, usageWindowLabel } from "./normalizeWindow.mjs";
 import { httpError } from "./httpError.mjs";
 
 const USAGE_URL = "https://api.kimi.com/coding/v1/usages";
@@ -88,11 +88,11 @@ export const kimiAdapter = {
     // is the session window.
     const limitsArr = Array.isArray(data?.limits) ? data.limits : [];
     const sessionEntry = limitsArr.find((l) => minutesOf(l?.window) === 300);
-    const session = windowFromDetail(sessionEntry?.detail, "session", "Session (5h)");
+    const session = windowFromDetail(sessionEntry?.detail, "session", usageWindowLabel(300 * 60));
     if (session) windows.push(session);
 
     // `usage` is the WEEKLY window.
-    const weekly = windowFromDetail(data?.usage, "weekly", "Weekly");
+    const weekly = windowFromDetail(data?.usage, "weekly", usageWindowLabel(7 * 86400));
     if (weekly) windows.push(weekly);
 
     // No planLabel on this endpoint — it needs a cookie-auth web API, out of

--- a/src/server/usageAdapters/normalizeWindow.mjs
+++ b/src/server/usageAdapters/normalizeWindow.mjs
@@ -22,6 +22,19 @@ function clampPct(n) {
   return Math.round(Math.max(0, Math.min(100, n)));
 }
 
+/** A window's human label, derived from its length in SECONDS: "45m", "5h",
+ *  "7d", "30d". Returns "" for a missing/unusable duration — callers pass the
+ *  result straight to normalizeWindow, whose `label` already defaults to "".
+ *  Never throws: `Number()` on a weird input yields NaN → "".
+ */
+export function usageWindowLabel(seconds) {
+  const s = Number(seconds);
+  if (!Number.isFinite(s) || s <= 0) return "";
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  if (s < 86400) return `${Math.round(s / 3600)}h`;
+  return `${Math.round(s / 86400)}d`;
+}
+
 /**
  * @param {object} raw
  * @param {"session"|"weekly"|string} [raw.kind]

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1747,7 +1747,7 @@ export type ScheduledJob = {
 // colour scale, or placement with the context pill.
 export type UsageWindow = {
   kind: "session" | "weekly" | string; // open set — a daily window just works
-  label: string; // "Session (5h)"
+  label: string; // "5h"
   pct: number; // 0-100, ALWAYS present (derived when the provider reports only absolutes)
   used?: number; // absolute count when the provider exposes one
   limit?: number; // absolute cap when the provider exposes one


### PR DESCRIPTION
## What & why

Every usage adapter hardcoded its window labels ("Session (5h)" / "Weekly" — six literals): wrong whenever a provider's real window differs from 5h/7d. The OpenAI account reports a **30-day** window and was labelled "Session (5h)".

The label is now derived from the window length the provider reports, through ONE shared helper.

- Added `usageWindowLabel(seconds)` to `src/server/usageAdapters/normalizeWindow.mjs` (co-located with the existing normalizer, no new module). "45m" / "5h" / "7d" / "30d"; `""` for a missing/unusable duration.
- **claude.mjs** — session `usageWindowLabel(5 * 3600)`, weekly `usageWindowLabel(7 * 86400)`.
- **codex.mjs** — session `usageWindowLabel(primary?.limit_window_seconds)`, weekly `usageWindowLabel(secondary?.limit_window_seconds)`. Live account now reads **"30d"**.
- **kimi.mjs** — session `usageWindowLabel(300 * 60)`, weekly `usageWindowLabel(7 * 86400)`. `windowFromDetail` signature unchanged.
- Updated the two doc comments that quoted the old label (`usage.mjs`, `types.ts`).

The `kind` field ("session" / "weekly") is unchanged — it stays the key for the fire-once alert, window ordering, and the client.

**Files changed:** 7.
- `src/server/usageAdapters/normalizeWindow.mjs`
- `src/server/usageAdapters/claude.mjs`
- `src/server/usageAdapters/codex.mjs`
- `src/server/usageAdapters/kimi.mjs`
- `src/server/usage.test.mjs` (+2 usageWindowLabel unit tests, +2 codex tests)
- `src/server/usage.mjs`
- `src/shared/types.ts`

**Verification results:**
- PR branch (`multica/BET-1129-usage-window-label` @ `1cd05126`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, **2371 pass / 0 fail / 0 skip**. Failures: none.
- Base (`origin/main` @ `fea29698`): full suite passes on the PR branch whose base is this commit; 0 new failures (the PR branch is clean).
- New tests green: `usageWindowLabel` (unusable durs → "", m/h/d derivation), codex 30-day → "30d", codex no-duration → usable window with "" label.

**Base:** origin/main @ `fea29698`
