### PR TITLE
BET-1133: refactor(renderer): rename user-facing 'the box' to 'the server' in setup wording

### DIFF
--- a/src/renderer/AddPhonePanel.tsx
+++ b/src/renderer/AddPhonePanel.tsx
@@ -104,7 +104,7 @@ export function AddPhonePanel() {
                 <span className="font-mono text-text">{pairing.pairingCode}</span>
               </div>
               <div className="text-body">
-                <span className="text-text-muted">Box ID:</span>{" "}
+                <span className="text-text-muted">Server ID:</span>{" "}
                 <span className="font-mono text-text break-all">{pairing.boxId}</span>
               </div>
               <PairingCountdown expiry={new Date(pairing.expiresAt)} />
@@ -124,7 +124,7 @@ export function AddPhonePanel() {
 
       <div className="text-body text-text-faint">
         {pairing?.ok
-          ? "Prefer to type it? Enter the six digits and the box ID above on your phone instead of scanning."
+          ? "Prefer to type it? Enter the six digits and the Server ID above on your phone instead of scanning."
           : "Prefer to type it? Enter the six-digit code on your phone instead of scanning."}
       </div>
     </div>

--- a/src/renderer/CloneFromGitHub.tsx
+++ b/src/renderer/CloneFromGitHub.tsx
@@ -176,7 +176,7 @@ export function CloneFromGitHub({
         res = await window.api.forgeCloneStart({ url: repo.cloneUrl, dest, name: repo.name });
       } catch {
         if (!cancelled) {
-          setPhase({ kind: "failed", repo, message: "Couldn't reach the box.", errorKind: "unknown" });
+          setPhase({ kind: "failed", repo, message: "Couldn't reach the server.", errorKind: "unknown" });
         }
         return;
       }

--- a/src/renderer/ConnectGithub.test.tsx
+++ b/src/renderer/ConnectGithub.test.tsx
@@ -204,6 +204,6 @@ describe("ConnectGithubPanel poll loop", () => {
       start: () => Promise.resolve({ connected: false, notConfigured: true, grant: null }),
     });
     await flushMicro();
-    expect(text()).toContain("GitHub sign-in isn't configured on this box yet");
+    expect(text()).toContain("GitHub sign-in isn't configured on this server yet");
   });
 });

--- a/src/renderer/ConnectGithub.tsx
+++ b/src/renderer/ConnectGithub.tsx
@@ -131,7 +131,7 @@ export function ConnectGithubPanel({
       } catch {
         if (cancelled) return;
         // A connection-level failure surfaces here, not in a caller phase.
-        setStage({ kind: "error", message: "Couldn't reach the box. Try again." });
+        setStage({ kind: "error", message: "Couldn't reach the server. Try again." });
       }
     })();
     return () => {
@@ -183,7 +183,7 @@ export function ConnectGithubPanel({
         inFlight = false;
         if (cancelled) return;
         if (consecutiveErrors >= MAX_CONSECUTIVE_ERRORS) {
-          fail("Couldn't reach the box. Try again.");
+          fail("Couldn't reach the server. Try again.");
           return;
         }
         scheduleNext();
@@ -282,7 +282,7 @@ export function ConnectGithubPanel({
           <PanelHeader title="Connect GitHub" />
           <div className="p-4">
             <Callout tone="warn">
-              GitHub sign-in isn't configured on this box yet.
+              GitHub sign-in isn't configured on this server yet.
             </Callout>
             <div className="flex gap-2 mt-3">
               <Button tone="ghost" onClick={cancel}>

--- a/src/renderer/ConnectProvider.tsx
+++ b/src/renderer/ConnectProvider.tsx
@@ -189,12 +189,12 @@ export function ConnectProvider({
       try {
         res = await window.api.opencodeProviderAuth(req);
       } catch {
-        if (!cancelled) safeSetPhase({ kind: "failed", message: "Couldn't reach the box. Try again." });
+        if (!cancelled) safeSetPhase({ kind: "failed", message: "Couldn't reach the server. Try again." });
         return;
       }
       if (cancelled) return;
       if (res.action !== "start") {
-        safeSetPhase({ kind: "failed", message: "Unexpected response from the box." });
+        safeSetPhase({ kind: "failed", message: "Unexpected response from the server." });
         return;
       }
       // BET-354: claude-login shape carries a sessionKey for the live
@@ -395,7 +395,7 @@ export function ConnectProvider({
           kind: "failed",
           reason: "claude-cli-install",
           message:
-            "The Claude CLI didn't install in time. The box itself is fine — try again, use a different model, or install it manually.",
+            "The Claude CLI didn't install in time. The server itself is fine — try again, use a different model, or install it manually.",
         });
         return;
       }
@@ -427,7 +427,7 @@ export function ConnectProvider({
             kind: "failed",
             reason: "claude-cli-install",
             message:
-              "The Claude CLI installer exited without installing the binary. The box itself is fine — try again, use a different model, or install it manually from https://claude.ai.",
+              "The Claude CLI installer exited without installing the binary. The server itself is fine — try again, use a different model, or install it manually from https://claude.ai.",
           });
           return;
         }
@@ -618,7 +618,7 @@ export function ConnectProvider({
                 url: phase.url,
                 instructions: phase.instructions,
                 methodIndex: phase.methodIndex,
-                inputError: "Couldn't reach the box. Try again.",
+                inputError: "Couldn't reach the server. Try again.",
               });
               return;
             }
@@ -671,7 +671,7 @@ export function ConnectProvider({
                 safeSetPhase({
                   kind: "needsKey",
                   consoleUrl: phase.consoleUrl,
-                  inputError: "Couldn't reach the box. Try again.",
+                  inputError: "Couldn't reach the server. Try again.",
                 });
                 return;
               }
@@ -722,7 +722,7 @@ export function ConnectProvider({
             } catch {
               safeSetPhase({
                 ...phase,
-                inputError: "Couldn't reach the box. Try again.",
+                inputError: "Couldn't reach the server. Try again.",
               });
               return;
             }
@@ -748,12 +748,12 @@ export function ConnectProvider({
         >
           <div className="space-y-2">
             <p className="text-text-muted">
-              The <b className="text-text">claude</b> CLI isn't on this box yet.
+              The <b className="text-text">claude</b> CLI isn't on this server yet.
               Installing it now via the official installer — no action needed.
             </p>
             <details className="text-meta">
               <summary className="text-text-faint cursor-pointer hover:text-text-muted">
-                Show what's happening on the box
+                Show what's happening on the server
               </summary>
               <div className="rounded-xs border border-border overflow-hidden h-40 bg-[var(--inset)] mt-1">
                 <Terminal
@@ -1037,7 +1037,7 @@ function ClaudeLoginBlock({
     <div className="space-y-2">
       {preExisting ? (
         <div className="text-text-muted">
-          {inputError ?? "Claude is already signed in on this box."}
+          {inputError ?? "Claude is already signed in on this server."}
         </div>
       ) : (
         <>
@@ -1074,7 +1074,7 @@ function ClaudeLoginBlock({
               still render through xterm for users who want to watch. */}
           <details className="text-meta">
             <summary className="text-text-faint cursor-pointer hover:text-text-muted">
-              Show what's happening on the box
+              Show what's happening on the server
             </summary>
             <div className="rounded-xs border border-border overflow-hidden h-40 bg-[var(--inset)] mt-1">
               <Terminal

--- a/src/renderer/NewSessionScreen.harness.test.tsx
+++ b/src/renderer/NewSessionScreen.harness.test.tsx
@@ -103,7 +103,7 @@ describe("NewSessionScreen mount against an unpaired window.api", () => {
     await h.flush();
 
     // Fresh-box heading (probe succeeded, zero repos found).
-    expect(h.container.textContent).toContain("Let's get some code on this box");
+    expect(h.container.textContent).toContain("Let's get some code on this server");
     // No worktree chip in the repo-probe zero state.
     const checkbox = h.container.querySelector(
       'input[aria-label="Create in a fresh git worktree"]',

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -897,7 +897,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
             <>
               <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
               <p className="text-body text-text-faint">
-                Start a session on any folder your box can see.
+                Start a session on any folder your server can see.
               </p>
             </>
           )}
@@ -1121,7 +1121,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
               <>
                 <div className="text-center space-y-1 mb-4">
                   <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
-                  <p className="text-body text-text-faint">Looking for repositories on your box…</p>
+                  <p className="text-body text-text-faint">Looking for repositories on your server…</p>
                 </div>
                 <div className="space-y-2" aria-hidden="true">
                   <Skeleton width={38} />
@@ -1156,7 +1156,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
               <>
                 <div className="text-center space-y-1 mb-4">
                   <h1 className="text-display font-bold tracking-tight text-text">
-                    Let's get some code on this box
+                    Let's get some code on this server
                   </h1>
                   <p className="text-body text-text-faint">
                     No repositories found. Clone one from GitHub, or point Manta at a folder.
@@ -1178,7 +1178,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
                     <div className="text-center space-y-1 mb-4">
                       <h1 className="text-display font-bold tracking-tight text-text">What's up next?</h1>
                       <p className="text-body text-text-faint">
-                        Found {probeRepos.length} {probeRepos.length === 1 ? "repository" : "repositories"} on your box.
+                        Found {probeRepos.length} {probeRepos.length === 1 ? "repository" : "repositories"} on your server.
                       </p>
                     </div>
 

--- a/src/renderer/PairStep.test.tsx
+++ b/src/renderer/PairStep.test.tsx
@@ -74,12 +74,12 @@ describe("PairStep render harness (BET-382 / BET-962)", () => {
     h = mount(<PairStep onPaired={noopOnPaired} />);
     const headings = h.container.querySelectorAll("h2");
     expect(headings).toHaveLength(1);
-    expect(headings[0].textContent).toBe("Connect your box");
+    expect(headings[0].textContent).toBe("Connect your server");
     expect(h.text()).toContain(
       "Pick the machine you want to run Manta on.",
     );
-    expect(h.text()).not.toContain("Connect to your box");
-    expect(h.text()).not.toContain("Set up your box via SSH");
+    expect(h.text()).not.toContain("Connect to your server");
+    expect(h.text()).not.toContain("Set up your server via SSH");
     expect(h.text()).not.toContain("Skip setup");
     expect(h.text()).not.toContain("Pair manually with a code");
     expect(h.text()).not.toContain("Advanced");
@@ -93,7 +93,7 @@ describe("PairStep render harness (BET-382 / BET-962)", () => {
     expect(h.container.querySelector("#pair-code")).not.toBeNull();
     expect(h.container.querySelector("#pair-host")).not.toBeNull();
     // Zone B shows the idle manual status; zone A carries the mode-switch link.
-    expect(h.text()).toContain("Enter the 6-digit code from the box");
+    expect(h.text()).toContain("Enter the 6-digit code from the server");
     expect(h.text()).toContain("Back to the host picker");
   });
 

--- a/src/renderer/PairStep.tsx
+++ b/src/renderer/PairStep.tsx
@@ -122,7 +122,7 @@ export function PairStep({ onPaired }: { onPaired: () => void }) {
   return (
     <div>
       <h2 className="text-display font-semibold tracking-tight text-text mb-2">
-        Connect your box
+        Connect your server
       </h2>
       <p className="text-body text-text-muted leading-relaxed mb-8 max-w-md">
         Pick the machine you want to run Manta on. It installs itself over SSH
@@ -269,7 +269,7 @@ function ManualPairPanel({
   // `targetSummary` replaces it, so there are no `disabled` copies of these
   // fields. The host label for the summary is the address the user paired
   // against (or the pending deep-link's server).
-  const hostLabel = serverUrlTrimmed || prefill?.serverUrl || "your box";
+  const hostLabel = serverUrlTrimmed || prefill?.serverUrl || "your server";
   const targetSummary = (
     <div className="flex items-center gap-2 min-w-0">
       {paired ? (
@@ -309,7 +309,7 @@ function ManualPairPanel({
             inputMode="url"
             autoComplete="off"
             spellCheck={false}
-            placeholder="https://box.mantaui.com"
+            placeholder="https://server.mantaui.com"
             value={serverUrl}
             onChange={(e) => {
               setServerUrl(e.target.value);
@@ -338,7 +338,7 @@ function ManualPairPanel({
             htmlFor="pair-box-id"
             className="text-label font-medium text-text-muted"
           >
-            Box ID{" "}
+            Server ID{" "}
             <span className="font-normal text-text-faint">
               (optional if Host set)
             </span>

--- a/src/renderer/ProvidersStep.tsx
+++ b/src/renderer/ProvidersStep.tsx
@@ -70,7 +70,7 @@ export function ProvidersStep({
     setRefreshing(true);
     setLoadError(null);
     if (typeof window.api.opencodeProviderAuth !== "function") {
-      setLoadError("Couldn't reach the box to check providers.");
+      setLoadError("Couldn't reach the server to check providers.");
       setStatuses([]);
       setRefreshing(false);
       return;
@@ -78,7 +78,7 @@ export function ProvidersStep({
     try {
       const res = await window.api.opencodeProviderAuth({ action: "status" });
       if (res.action !== "status") {
-        setLoadError("Unexpected response from the box.");
+        setLoadError("Unexpected response from the server.");
         setStatuses([]);
         return;
       }

--- a/src/renderer/SshInstallStep.tsx
+++ b/src/renderer/SshInstallStep.tsx
@@ -86,7 +86,7 @@ function SecretPrompt({
   onCancel: () => void;
 }) {
   const isSudo = kind === "sudo-password";
-  const hostLabel = host || "this box";
+  const hostLabel = host || "this server";
   const heading = isSudo
     ? `Administrator password needed on ${hostLabel}`
     : "Unlock your SSH key";
@@ -99,16 +99,16 @@ function SecretPrompt({
       <p className="text-meta text-text-muted">
         {isSudo ? (
           <>
-            MantaUI needs to run three commands as root to give this box a
+            The desktop app needs to run three commands as root to give this server a
             public HTTPS address: install Caddy from the official
             Debian/Ubuntu package repository, write the Caddy site config for
-            your box's hostname, and reload the Caddy service. Nothing else on
+            your server's hostname, and reload the Caddy service. Nothing else on
             this install needs root.
             <br />
             <br />
-            Your password is sent to the box over the SSH connection you are
+            Your password is sent to the server over the SSH connection you are
             already using, stored in a file only your user can read, used for
-            this install only, and deleted when it finishes. MantaUI never
+            this install only, and deleted when it finishes. It never
             saves it.
           </>
         ) : (
@@ -155,8 +155,8 @@ function SecretPrompt({
               and run the installer again. No password needed.
             </li>
             <li>
-              <span className="font-medium">Use Tailscale</span> — MantaUI
-              then needs no root at all. On the box, run:{" "}
+              <span className="font-medium">Use Tailscale</span> — the desktop app
+              then needs no root at all. On the server, run:{" "}
               <code className="font-mono text-code bg-bg rounded-sm px-2 py-1 text-text-muted">
                 curl -fsSL https://tailscale.com/install.sh | sh
               </code>{" "}
@@ -168,7 +168,7 @@ function SecretPrompt({
             </li>
             <li>
               <span className="font-medium">Grant this user sudo access</span>{" "}
-              on the box, then run the installer again.
+              on the server, then run the installer again.
             </li>
           </ul>
         </div>
@@ -401,7 +401,7 @@ export function SshInstallStep({
           secretKind: kind,
           prompt:
             kind === "sudo-password"
-              ? `Administrator password needed on ${installHostLabel || "this box"}`
+              ? `Administrator password needed on ${installHostLabel || "this server"}`
               : "Enter the passphrase for your SSH key:",
         });
         setSecretInput("");
@@ -807,7 +807,7 @@ export function SshInstallStep({
           className="text-label font-medium text-text-muted"
           htmlFor="ssh-host"
         >
-          Box address
+          Server address
         </label>
         <span className="text-meta text-text-quiet">{hostCountLabel}</span>
       </div>
@@ -866,7 +866,7 @@ export function SshInstallStep({
                 <input
                   id="ssh-custom-host"
                   type="text"
-                  placeholder="box.example.com"
+                  placeholder="server.example.com"
                   value={customHost}
                   onChange={(e) => {
                     setCustomHost(e.target.value);
@@ -953,7 +953,7 @@ export function SshInstallStep({
             </div>
             <p className="text-meta text-text-faint">
               Leave a field empty to let OpenSSH decide. These are used for
-              this box only — your ~/.ssh/config is never written to.
+              this server only — your ~/.ssh/config is never written to.
             </p>
           </div>
         </>
@@ -982,7 +982,7 @@ export function SshInstallStep({
   // `installHostLabel` is captured at install start from the resolved
   // SshTarget, so a custom host reads "root@54.73.231.25" and an alias reads
   // its own label.
-  const hostLabel = installHostLabel || "your box";
+  const hostLabel = installHostLabel || "your server";
   const targetSummary = (
     <div className="flex items-center gap-2 min-w-0">
       {paired ? (

--- a/src/renderer/connectPanelLogic.test.ts
+++ b/src/renderer/connectPanelLogic.test.ts
@@ -57,7 +57,7 @@ describe("deriveConnectPanel — no row carries a `hint` (BET-1007)", () => {
 });
 
 describe("deriveConnectPanel — precedence table (BET-961)", () => {
-  it("row 1 — paired: 'Your box is ready' + progress 1 + next", () => {
+  it("row 1 — paired: 'Your server is ready' + progress 1 + next", () => {
     const s = deriveConnectPanel({
       ...base,
       paired: true,
@@ -66,7 +66,7 @@ describe("deriveConnectPanel — precedence table (BET-961)", () => {
     });
     expect(status({ paired: true, elapsedSeconds: 72 })).toEqual({
       tone: "ok",
-      text: "Your box is ready",
+      text: "Your server is ready",
       meta: "6 of 6 · 1:12",
     });
     expect(s.status?.progress).toBe(1);
@@ -75,7 +75,7 @@ describe("deriveConnectPanel — precedence table (BET-961)", () => {
     expect(s.actions).toEqual(["next"]);
   });
 
-  it("row 2 — preflight failure: 'Couldn't reach the box' + failures, log null", () => {
+  it("row 2 — preflight failure: 'Couldn't reach the server' + failures, log null", () => {
     const s = deriveConnectPanel({
       ...base,
       stage: "preflight",
@@ -85,7 +85,7 @@ describe("deriveConnectPanel — precedence table (BET-961)", () => {
     });
     expect(status({ stage: "preflight", preflightFailure: { failures: [] } })).toEqual({
       tone: "error",
-      text: "Couldn't reach the box",
+      text: "Couldn't reach the server",
       meta: "1 of 6",
     });
     expect(s.status?.progress).toBe(1 / 6);
@@ -259,7 +259,7 @@ describe("deriveConnectPanel — precedence table (BET-961)", () => {
 
   it("higher precedence beats lower — paired beats an install error", () => {
     const s = deriveConnectPanel({ ...base, paired: true, installError: "boom" });
-    expect(s.status?.text).toBe("Your box is ready");
+    expect(s.status?.text).toBe("Your server is ready");
     expect(s.status?.tone).toBe("ok");
     expect(s.actions).toEqual(["next"]);
   });
@@ -297,18 +297,18 @@ describe("deriveConnectPanel — manual mode rows (BET-962)", () => {
     expect(s.targetCollapsed).toBe(false);
   });
 
-  it("M2 — idle manual: 'Enter the 6-digit code from the box' + hint; Connect disabled until canConnect", () => {
+  it("M2 — idle manual: 'Enter the 6-digit code from the server' + hint; Connect disabled until canConnect", () => {
     const idle = deriveConnectPanel(manual({}));
     expect(idle.status).toEqual({
       tone: "idle",
-      text: "Enter the 6-digit code from the box",
+      text: "Enter the 6-digit code from the server",
       meta: null,
       progress: null,
       sub: null,
     });
     expect(idle.details).toEqual({
       kind: "hint",
-      text: "Run `manta pair` on the box to get a code.",
+      text: "Run `manta pair` on the server to get a code.",
     });
     expect(idle.log).toBeNull();
     expect(idle.actions).toEqual(["connect"]);
@@ -349,11 +349,11 @@ describe("deriveConnectPanel — manual mode rows (BET-962)", () => {
     expect(s.targetCollapsed).toBe(false);
   });
 
-  it("M5 — claim succeeded: 'Your box is ready' + Next →, zone A collapsed", () => {
+  it("M5 — claim succeeded: 'Your server is ready' + Next →, zone A collapsed", () => {
     const s = deriveConnectPanel(manual({ paired: true }));
     expect(s.status).toEqual({
       tone: "ok",
-      text: "Your box is ready",
+      text: "Your server is ready",
       meta: null,
       progress: null,
       sub: null,
@@ -366,7 +366,7 @@ describe("deriveConnectPanel — manual mode rows (BET-962)", () => {
 
   it("precedence — paired beats a claim error in manual mode", () => {
     const s = deriveConnectPanel(manual({ paired: true, claimError: "x" }));
-    expect(s.status?.text).toBe("Your box is ready");
+    expect(s.status?.text).toBe("Your server is ready");
     expect(s.actions).toEqual(["next"]);
   });
 

--- a/src/renderer/connectPanelLogic.ts
+++ b/src/renderer/connectPanelLogic.ts
@@ -139,7 +139,7 @@ export function deriveConnectPanel(input: ConnectInput): ConnectPanelState {
       return {
         status: {
           tone: "ok",
-          text: "Your box is ready",
+          text: "Your server is ready",
           meta: null,
           progress: null,
           sub: null,
@@ -196,12 +196,12 @@ export function deriveConnectPanel(input: ConnectInput): ConnectPanelState {
     return {
       status: {
         tone: "idle",
-        text: "Enter the 6-digit code from the box",
+        text: "Enter the 6-digit code from the server",
         meta: null,
         progress: null,
         sub: null,
       },
-      details: { kind: "hint", text: "Run `manta pair` on the box to get a code." },
+      details: { kind: "hint", text: "Run `manta pair` on the server to get a code." },
       log: null,
       actions: ["connect"],
       disabledActions: input.canConnect ? undefined : ["connect"],
@@ -219,7 +219,7 @@ export function deriveConnectPanel(input: ConnectInput): ConnectPanelState {
     return {
       status: {
         tone: "ok",
-        text: "Your box is ready",
+        text: "Your server is ready",
         meta: `${total} of ${total} · ${formatElapsed(input.elapsedSeconds)}`,
         progress: 1,
         sub: null,
@@ -236,7 +236,7 @@ export function deriveConnectPanel(input: ConnectInput): ConnectPanelState {
     return {
       status: {
         tone: "error",
-        text: "Couldn't reach the box",
+        text: "Couldn't reach the server",
         meta: stageMeta(input),
         progress,
         sub: null,


### PR DESCRIPTION
Renames the user-facing "the box" → "the server" wording across the onboarding/setup screens owned by BET-1133. String literals only — no logic, no new abstractions.

**Files changed:** 13 (9 source + 4 test files), per the issue glossary. MantaUI self-references in `SshInstallStep.tsx` rewritten to "the desktop app" / "It".

Not touched (per scope): code comments, `boxId` / `pair-box-id` / deep-link `?box=` scheme, `mobile/www/`, files owned by sibling wording issues.

**Verification results:**
- PR branch (`multica/BET-1133-box-to-server` @ `7603519`):
  - typecheck: exit 0, no errors. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2371 pass / 0 fail / 0 skip. log sha256: `91d2b9090fbf9c1bc3c8d1b42ddc9ccd4974b3e7bcc50cfc3eeaa66d6921864c`
- Base (`main` @ `f3d6498`, the SHA branched from): not independently re-run — no checkout of that exact SHA on this box (the `main` worktree is at a stale older version). Changes are pure string renames; PR branch has 0 failures.
- **Conclusion:** 0 new test failures caused by this PR.

Base: origin/main @ f3d6498
