### PR TITLE
fix(ios): render server usage window labels instead of hardcoded 5h/7d/Claude (BET-1130)

### DIFF
--- a/mobile/native/MantaUI/UsageMeters.swift
+++ b/mobile/native/MantaUI/UsageMeters.swift
@@ -139,6 +139,22 @@ enum UsageMeters {
         return "\(Int((tokens / 1_000_000).rounded()))M"
     }
 
+    /// The desktop's `providerLabel` lookup (`providerLabel` in
+    /// src/renderer/UsageDial.tsx), shared verbatim so the iOS usage sheet and
+    /// the desktop dial/popover never disagree about a provider's name: claude
+    /// → "Claude", codex → "OpenAI", kimi → "Kimi", otherwise the adapter id
+    /// capitalised (first character upper, rest unchanged — a 4th adapter needs
+    /// no client change). Empty/missing → "".
+    static func providerLabel(_ provider: String?) -> String {
+        guard let provider, !provider.isEmpty else { return "" }
+        switch provider {
+        case "claude": return "Claude"
+        case "codex": return "OpenAI"
+        case "kimi": return "Kimi"
+        default: return provider.prefix(1).uppercased() + provider.dropFirst()
+        }
+    }
+
     /// "344k cold" when the box has flagged the prompt cache stale, nil
     /// otherwise. Pure, so the label is unit-testable and the view renders
     /// whatever comes back — the staleness DECISION belongs to the box

--- a/mobile/native/MantaUI/UsageSheets.swift
+++ b/mobile/native/MantaUI/UsageSheets.swift
@@ -233,17 +233,17 @@ struct UsageSheet: View {
         // below the content.
         NavigationStack {
             List {
-                Section(footer: Text("Updated \(updatedAgo) · the dot tracks the 5-hour window.")) {
+                Section(footer: footer) {
                     if let session = UsageMeters.sessionWindow(snapshots) {
-                        UsageWindowRow(window: session, name: "Session", caption: "5-hour window", tokens: tokens)
+                        UsageWindowRow(window: session, tokens: tokens)
                     }
                     if let weekly = UsageMeters.weeklyWindow(snapshots) {
-                        UsageWindowRow(window: weekly, name: "Weekly", caption: "7-day window", tokens: tokens)
+                        UsageWindowRow(window: weekly, tokens: tokens)
                     }
                 }
             }
             .listStyle(.insetGrouped)
-            .navigationTitle("Claude plan")
+            .navigationTitle(planTitle)
             .navigationBarTitleDisplayMode(.inline)
             .toolbar {
                 ToolbarItem(placement: .confirmationAction) {
@@ -262,15 +262,34 @@ struct UsageSheet: View {
         if minutes < 1 { return "just now" }
         return "\(minutes)m ago"
     }
+
+    /// The sheet's title — the provider whose snapshot the sheet shows,
+    /// mapped the same way the desktop dial names providers (claude →
+    /// "Claude", codex → "OpenAI", kimi → "Kimi", else capitalised id).
+    private var planTitle: String {
+        UsageMeters.providerLabel(primarySnapshot?.provider)
+    }
+
+    /// The snapshot that drives the sheet — the one holding the primary (dot)
+    /// window, falling back to the first snapshot when none does.
+    private var primarySnapshot: UsageSnapshot? {
+        snapshots.first { $0.windows.contains { $0.kind == "session" } } ?? snapshots.first
+    }
+
+    /// "Updated 2m ago · the dot tracks 5h." The window the dot actually tracks
+    /// is the session (primary, first) window — named from its own `label`, so
+    /// the footer never asserts a fixed 5-hour window.
+    private var footer: Text {
+        let windowLabel = UsageMeters.sessionWindow(snapshots)?.label ?? ""
+        return Text("Updated \(updatedAgo) · the dot tracks \(windowLabel).")
+    }
 }
 
-/// One window row in the usage sheet: band ring, name, window-length caption,
+/// One window row in the usage sheet: band ring, the server's window `label`,
 /// percentage, meter, and the reset countdown/date. The list draws the row's
 /// surface, so there is no hand-rolled card here.
 private struct UsageWindowRow: View {
     let window: UsageWindow
-    let name: String
-    let caption: String
     let tokens: Tokens
 
     var body: some View {
@@ -279,11 +298,8 @@ private struct UsageWindowRow: View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
             HStack(spacing: Metrics.spacing.sp1) {
                 MeterRing(pct: window.pct, color: tint, diameter: 11, lineWidth: 2.5, track: tokens.borderSubtle)
-                Text(name)
+                Text(window.label ?? "")
                     .font(.body)
-                Text(caption)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
                 Spacer(minLength: 0)
                 Text("\(Int(window.pct.rounded()))%")
                     .font(.body.weight(.semibold))

--- a/mobile/native/MantaUITests/UsageMetersTests.swift
+++ b/mobile/native/MantaUITests/UsageMetersTests.swift
@@ -165,6 +165,29 @@ final class UsageMetersTests: XCTestCase {
         XCTAssertEqual(UsageMeters.formatTokens(nil), "0")
     }
 
+    // MARK: - providerLabel (BET-1130 — mirrors the desktop dial lookup)
+
+    /// The three known adapters map to their spoken names, matching
+    /// `providerLabel` in src/renderer/UsageDial.tsx exactly.
+    func testProviderLabelKnownAdapters() {
+        XCTAssertEqual(UsageMeters.providerLabel("claude"), "Claude")
+        XCTAssertEqual(UsageMeters.providerLabel("codex"), "OpenAI")
+        XCTAssertEqual(UsageMeters.providerLabel("kimi"), "Kimi")
+    }
+
+    /// An unknown adapter id is capitalised (first char upper, rest unchanged)
+    /// so a 4th adapter needs no client change — same fallback as the desktop.
+    func testProviderLabelUnknownCapitalised() {
+        XCTAssertEqual(UsageMeters.providerLabel("openai"), "Openai")
+        XCTAssertEqual(UsageMeters.providerLabel("deepseek"), "Deepseek")
+    }
+
+    /// A missing/empty provider yields "" — never a crash or "null".
+    func testProviderLabelMissingIsEmpty() {
+        XCTAssertEqual(UsageMeters.providerLabel(nil), "")
+        XCTAssertEqual(UsageMeters.providerLabel(""), "")
+    }
+
     // MARK: - staleChipLabel (BET-969)
 
     private func cache(_ isStale: Bool, staleTokens: Double) -> StreamCachePayload {


### PR DESCRIPTION
Opened automatically for `multica/BET-1130-ios-usage-labels`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1130.