### PR TITLE
Wording: 'the box' → 'the server' + desktop-app self-reference

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -870,7 +870,7 @@ function Shell() {
         // reason on the pair step, opening the flow if it isn't already up.
         const st = useStore.getState();
         st.setPairLinkError(
-          "That pairing link isn't valid. Generate a fresh one on your box (run `manta pair`) and open the new link.",
+          "That pairing link isn't valid. Generate a fresh one on your server (run `manta pair`) and open the new link.",
         );
         const onboardingOpen =
           st.onboardingForced ||
@@ -1631,7 +1631,7 @@ function Shell() {
           <UpdateBar
             text={
               <>
-                This box (v
+                This server (v
                 <span className="font-medium text-text">
                   {serverVersion ?? "?"}
                 </span>
@@ -1662,7 +1662,7 @@ function Shell() {
             tone={updateBanner.tone}
             busy={boxUpgrading}
             progress={boxUpgrading && !boxRestarting ? serverUpdateProgress ?? undefined : undefined}
-            busyLabel={boxRestarting ? "Restarting the box…" : "Updating the box…"}
+            busyLabel={boxRestarting ? "Restarting the server…" : "Updating the server…"}
           />
         )}
         {!isChatPaneActive && (
@@ -1698,7 +1698,7 @@ function Shell() {
             {boxStale && (
               <span
                 className="shrink-0 inline-flex items-center gap-1 text-text-faint"
-                title="The box's tmux is unreachable — showing the last known session list."
+                title="The server's tmux is unreachable — showing the last known session list."
               >
                 <span
                   className="inline-block w-1.5 h-1.5 rounded-full shrink-0 bg-warn"
@@ -1884,7 +1884,7 @@ function Shell() {
           the update starts. */}
       <ConfirmModal
         open={confirmServerUpdate}
-        title="Update the box?"
+        title="Update the server?"
         body="This restarts opencode, which will end every agent turn currently running in any session. Any unsaved work in a running turn is lost."
         confirmLabel="Update & restart"
         confirmTone="primary"

--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -460,7 +460,7 @@ describe("CloneFromGitHub picker", () => {
     const text = container!.textContent ?? "";
     // The network message renders inside the picker's error callout…
     expect(text).toContain(
-      "Couldn't reach GitHub from your box. Check its connection and try again.",
+      "Couldn't reach GitHub from your server. Check its connection and try again.",
     );
     // …and the picker stays up — a blip must not look like a sign-out.
     expect(text).toContain("Clone a repository");

--- a/src/renderer/InboxPalette.tsx
+++ b/src/renderer/InboxPalette.tsx
@@ -120,7 +120,7 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
         .then((res) => {
           if (cancelled) return;
           setItems(sortInbox(res?.items ?? []));
-          if (res?.error === "not_connected") setLoadError("GitHub isn't connected on this box.");
+          if (res?.error === "not_connected") setLoadError("GitHub isn't connected on this server.");
         })
         .catch(() => {
           if (cancelled) return;
@@ -161,7 +161,7 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
   const createSessionFromItem = async (item: ForgeInboxItem) => {
     const path = repos[item.repoKey];
     if (!path) {
-      setError(`No local checkout of ${repoName(item)} on this box to start a session in.`);
+      setError(`No local checkout of ${repoName(item)} on this server to start a session in.`);
       return;
     }
     setError(null);
@@ -209,7 +209,7 @@ export function InboxPalette({ onClose }: { onClose: () => void }) {
   const delegateInBackground = async (item: ForgeInboxItem) => {
     const path = repos[item.repoKey];
     if (!path) {
-      setError(`No local checkout of ${repoName(item)} on this box to delegate in.`);
+      setError(`No local checkout of ${repoName(item)} on this server to delegate in.`);
       return;
     }
     const active = useStore.getState().activeSession();

--- a/src/renderer/PanelCards.tsx
+++ b/src/renderer/PanelCards.tsx
@@ -327,7 +327,7 @@ export const SecretsCard = memo(function SecretsCard({
               submit();
             }
           }}
-          placeholder="value (stored on the box; never shown again)"
+          placeholder="value (stored on the server; never shown again)"
           type="password"
           spellCheck={false}
           autoCapitalize="off"
@@ -346,7 +346,7 @@ export const SecretsCard = memo(function SecretsCard({
             disabled={!canSave}
             className="shrink-0 px-2 py-1 rounded-xs border disabled:opacity-40"
             style={{ borderColor: "rgb(var(--accent-rgb) / 0.53)", color: "var(--accent)" }}
-            title="Store this secret on the box"
+            title="Store this secret on the server"
           >
             {saving ? "saving…" : "Save"}
           </button>

--- a/src/renderer/SearchPalette.tsx
+++ b/src/renderer/SearchPalette.tsx
@@ -195,7 +195,7 @@ export function SearchPalette({
         if (!supported) {
           return (
             <div className="px-3 py-3 text-label text-text-faint">
-              Search needs a newer box runtime — update the box.
+              Search needs a newer server runtime — update the server.
             </div>
           );
         }

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -464,7 +464,7 @@ export function SessionHeader({
       <ConfirmModal
         open={confirm === "delete"}
         title="Delete this session?"
-        body={`“${sessionName}” and its tmux window will be killed on the box. This can't be undone.`}
+        body={`“${sessionName}” and its tmux window will be killed on the server. This can't be undone.`}
         confirmLabel="Delete session"
         onConfirm={() => {
           setConfirm(null);

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -783,14 +783,14 @@ export function Settings({
     const preload = getMantaPreload();
     if (!preload?.authUnpair) {
       setRemovingBox(false);
-      setRemoveResult({ ok: false, message: "Removing a box is only supported in the desktop app." });
+      setRemoveResult({ ok: false, message: "Removing a server is only supported in the desktop app." });
       return;
     }
     try {
       const outcome = await preload.authUnpair();
       await useStore.getState().refresh().catch(() => {});
       if (outcome.ok) { setRemoveResult({ ok: true, message: "" }); onClose(); return; }
-      setRemoveResult({ ok: false, message: outcome.message || "The box's token could not be revoked remotely. Local credentials were cleared." });
+      setRemoveResult({ ok: false, message: outcome.message || "The server's token could not be revoked remotely. Local credentials were cleared." });
     } catch (e) {
       setRemoveResult({ ok: false, message: e instanceof Error ? e.message : String(e) });
     } finally {
@@ -931,7 +931,7 @@ export function Settings({
           </GroupCard>
           <GroupCard title="Danger zone" danger>
             <div className="space-y-3">
-              <div className="text-body text-text-faint">Restore every setting below to its default. This does not remove your box pairing or projects.</div>
+              <div className="text-body text-text-faint">Restore every setting below to its default. This does not remove your server pairing or projects.</div>
               <Button onClick={() => setConfirmReset(true)} tone="danger">Reset all settings…</Button>
             </div>
           </GroupCard>
@@ -987,7 +987,7 @@ export function Settings({
                   value={opencodePortDraft}
                   onChange={(e) => { setOpencodePortDraft(e.target.value); setOpencodePortSavedAt(null); }}
                   onBlur={commitOpencodePort}
-                  help="Local port forwarded to the box's opencode serve instance. Defaults to 14096 to avoid colliding with a local opencode on 4096."
+                  help="Local port forwarded to the server's opencode serve instance. Defaults to 14096 to avoid colliding with a local opencode on 4096."
                   footer={opencodePortSavedAt ? <div role="status" className="text-meta text-ok">Saved</div> : undefined}
                 />
               </div>
@@ -996,9 +996,9 @@ export function Settings({
 
           <GroupCard title="Danger zone" danger>
             <div className="space-y-3">
-              <div className="text-body text-text-faint">Forget this box on the desktop. If the box is reachable, its current token is revoked too.</div>
+              <div className="text-body text-text-faint">Forget this server on the desktop. If the server is reachable, its current token is revoked too.</div>
               <Button onClick={() => setConfirmRemove(true)} disabled={removingBox} tone="default">
-                {removingBox ? "Removing…" : "Remove box"}
+                {removingBox ? "Removing…" : "Remove server"}
               </Button>
             </div>
             {removeResult && !removeResult.ok && <div role="alert" className="text-body text-warn">{removeResult.message}</div>}
@@ -1095,8 +1095,8 @@ export function Settings({
                 not a switch). Gates dispatch, not the visibility of the list
                 below. */}
             <div className="flex items-center gap-2 py-1">
-              <Checkbox id="forge-rules-enabled" checked={forgeRulesOn} onChange={(v) => void toggleForgeRules(v)} ariaLabel="Let forge rules start agents on this box" />
-              <span className="text-body text-text-muted">Let forge rules start agents on this box</span>
+              <Checkbox id="forge-rules-enabled" checked={forgeRulesOn} onChange={(v) => void toggleForgeRules(v)} ariaLabel="Let forge rules start agents on this server" />
+              <span className="text-body text-text-muted">Let forge rules start agents on this server</span>
             </div>
             {forgeRulesError ? (
               <div role="alert" className="text-body text-danger">{errorDisclosure("Couldn't load the forge rules list.", forgeRulesError)}</div>
@@ -1105,7 +1105,7 @@ export function Settings({
                 <MantaLoader size="inline" label="Loading forge rules" />
               </div>
             ) : (forgeRules ?? []).length === 0 ? (
-              <div className="text-body text-text-faint">No forge rules yet. The AI authors them on the box with <code className="text-text-muted">forge_rules.save</code>; each is a YAML file at <code className="text-text-muted">~/.manta/forge-rules/</code>.</div>
+              <div className="text-body text-text-faint">No forge rules yet. The AI authors them on the server with <code className="text-text-muted">forge_rules.save</code>; each is a YAML file at <code className="text-text-muted">~/.manta/forge-rules/</code>.</div>
             ) : (
               <div className="space-y-1">
                 {(forgeRules ?? []).map((r) =>
@@ -1183,7 +1183,7 @@ export function Settings({
           </GroupCard>
           {availableLaunchers.some((l) => l.flags.length > 0) && (
             <GroupCard title="CLI launch options">
-              <div className="text-body text-text-faint">Flags used when launching an AI CLI (e.g. Claude Code) directly in a session's terminal. Only CLIs detected on this box are shown.</div>
+              <div className="text-body text-text-faint">Flags used when launching an AI CLI (e.g. Claude Code) directly in a session's terminal. Only CLIs detected on this server are shown.</div>
               <div className="space-y-4">
                 {availableLaunchers.filter((l) => l.flags.length > 0).map((l) => (
                   <div key={l.id} className="space-y-2">
@@ -1339,8 +1339,8 @@ export function Settings({
       {/* In-app confirm: Remove box (replaces window.confirm — BET-419 §D). */}
       <ConfirmModal
         open={confirmRemove}
-        title="Remove this box?"
-        body="The desktop will forget its pairing and saved projects. If the box is reachable, its current token is also revoked. If the box is offline, the local credentials are cleared and the box's token will be rotated the next time it starts."
+        title="Remove this server?"
+        body="The desktop will forget its pairing and saved projects. If the server is reachable, its current token is also revoked. If the server is offline, the local credentials are cleared and the server's token will be rotated the next time it starts."
         confirmLabel="Remove"
         onConfirm={() => void removeBox()}
         onCancel={() => setConfirmRemove(false)}
@@ -1350,7 +1350,7 @@ export function Settings({
       <ConfirmModal
         open={confirmReset}
         title="Reset all settings?"
-        body="Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after."
+        body="Every setting will return to its default. Your server pairing and projects are not affected. You can undo this right after."
         confirmLabel="Reset"
         onConfirm={() => void resetAll()}
         onCancel={() => setConfirmReset(false)}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -4843,7 +4843,7 @@ describe("repoListErrorMessage (BET-1011)", () => {
 
   it("explains a network failure", () => {
     expect(repoListErrorMessage("network")).toBe(
-      "Couldn't reach GitHub from your box. Check its connection and try again.",
+      "Couldn't reach GitHub from your server. Check its connection and try again.",
     );
   });
 

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -4859,13 +4859,13 @@ describe("repoListErrorMessage (BET-1011)", () => {
 describe("forgeCredentialSecondary (BET-1059)", () => {
   it("explains a rejected gh CLI credential", () => {
     expect(forgeCredentialSecondary({ login: "a", source: "cli", valid: false })).toBe(
-      "GitHub rejected the gh CLI sign-in on your box. Run `gh auth login` there, or Disconnect.",
+      "GitHub rejected the gh CLI sign-in on your server. Run `gh auth login` there, or Disconnect.",
     );
   });
 
   it("explains a rejected env-var credential", () => {
     expect(forgeCredentialSecondary({ login: "a", source: "env", valid: false })).toBe(
-      "GitHub rejected the MANTA_GITHUB_TOKEN environment variable on your box. Replace it there, or Disconnect.",
+      "GitHub rejected the MANTA_GITHUB_TOKEN environment variable on your server. Replace it there, or Disconnect.",
     );
   });
 
@@ -4880,13 +4880,13 @@ describe("forgeCredentialSecondary (BET-1059)", () => {
 
   it("valid with a login → @login · <where>", () => {
     expect(forgeCredentialSecondary({ login: "antoinedc", source: "cli", valid: true })).toBe(
-      "@antoinedc · from the gh CLI on your box",
+      "@antoinedc · from the gh CLI on your server",
     );
   });
 
   it("valid with no login → the bare <where>", () => {
     expect(forgeCredentialSecondary({ login: null, source: "stored", valid: true })).toBe(
-      "signed in on this box",
+      "signed in on this server",
     );
   });
 
@@ -5187,7 +5187,7 @@ describe("describeSessionClose", () => {
   it("idle + no worktree → exact single sentence", () => {
     expect(describeSessionClose({ name: "Deploy", running: false, worktreePath: null })).toEqual({
       title: 'Close “Deploy”?',
-      body: "Its tmux window will be killed on the box.",
+      body: "Its tmux window will be killed on the server.",
       confirmLabel: "Close session",
     });
   });
@@ -5213,7 +5213,7 @@ describe("describeSessionClose", () => {
       worktreePath: "/srv/manta/ethernal",
     });
     expect(r.body).toBe(
-      "Its tmux window will be killed on the box. " +
+      "Its tmux window will be killed on the server. " +
         "A turn is currently running and will be stopped. " +
         "Its worktree at /srv/manta/ethernal will be removed.",
     );
@@ -5234,7 +5234,7 @@ describe("describeProjectClose", () => {
       worktreeCount: 0,
     });
     expect(r.title).toBe("Close “orphan”?");
-    expect(r.body).toBe("Its tmux session will be killed on the box.");
+    expect(r.body).toBe("Its tmux session will be killed on the server.");
     expect(r.confirmLabel).toBe("Close project");
   });
 
@@ -5246,7 +5246,7 @@ describe("describeProjectClose", () => {
       worktreeCount: 0,
     });
     expect(r.title).toBe("Close “manta” and its 1 session?");
-    expect(r.body).toBe("All 1 tmux window will be killed on the box.");
+    expect(r.body).toBe("All 1 tmux window will be killed on the server.");
   });
 
   it("4 sessions, 2 running → plural mid-turn sentence", () => {

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -2194,7 +2194,7 @@ export function resolvePlanToggle(
   if (!plan)
     return on
       ? { available: false, on: true, title: "Plan mode on (plan agent unavailable)" }
-      : { available: false, on: false, title: "This box has no plan agent" };
+      : { available: false, on: false, title: "This server has no plan agent" };
   return {
     available: true,
     on,
@@ -3500,7 +3500,7 @@ export function repoListErrorMessage(code: string | null | undefined): string {
     return "GitHub refused this request. If the repositories belong to an organisation, it may require SSO authorisation for your sign-in.";
   }
   if (code === "network") {
-    return "Couldn't reach GitHub from your box. Check its connection and try again.";
+    return "Couldn't reach GitHub from your server. Check its connection and try again.";
   }
   return "Couldn't list your repositories from GitHub.";
 }
@@ -3514,17 +3514,17 @@ export function forgeCredentialSecondary(status: {
 }): string {
   if (status.valid === false) {
     if (status.source === "cli") {
-      return "GitHub rejected the gh CLI sign-in on your box. Run `gh auth login` there, or Disconnect.";
+      return "GitHub rejected the gh CLI sign-in on your server. Run `gh auth login` there, or Disconnect.";
     }
     if (status.source === "env") {
-      return "GitHub rejected the MANTA_GITHUB_TOKEN environment variable on your box. Replace it there, or Disconnect.";
+      return "GitHub rejected the MANTA_GITHUB_TOKEN environment variable on your server. Replace it there, or Disconnect.";
     }
     return "GitHub rejected this sign-in. Disconnect, then connect again.";
   }
   const where =
-    status.source === "cli" ? "from the gh CLI on your box"
+    status.source === "cli" ? "from the gh CLI on your server"
     : status.source === "env" ? "from the MANTA_GITHUB_TOKEN env var"
-    : status.source === "stored" ? "signed in on this box"
+    : status.source === "stored" ? "signed in on this server"
     : "connected";
   return status.login ? `@${status.login} · ${where}` : where;
 }
@@ -4007,7 +4007,7 @@ export function describeSessionClose(args: {
   /** The worktree that WILL be removed, or null when none will be. */
   worktreePath: string | null;
 }): CloseConfirmCopy {
-  const parts = ["Its tmux window will be killed on the box."];
+  const parts = ["Its tmux window will be killed on the server."];
   if (args.running) parts.push("A turn is currently running and will be stopped.");
   if (args.worktreePath) parts.push(`Its worktree at ${args.worktreePath} will be removed.`);
   return {
@@ -4032,8 +4032,8 @@ export function describeProjectClose(args: {
       : `Close “${name}” and its ${sessionCount} session${sessionCount === 1 ? "" : "s"}?`;
   const parts = [
     sessionCount === 0
-      ? "Its tmux session will be killed on the box."
-      : `All ${sessionCount} tmux window${sessionCount === 1 ? "" : "s"} will be killed on the box.`,
+      ? "Its tmux session will be killed on the server."
+      : `All ${sessionCount} tmux window${sessionCount === 1 ? "" : "s"} will be killed on the server.`,
   ];
   if (runningCount > 0) {
     parts.push(


### PR DESCRIPTION
**Files changed:** 9 (7 owned source files + 2 tests)

- `src/renderer/App.tsx`
- `src/renderer/InboxPalette.tsx`
- `src/renderer/PanelCards.tsx`
- `src/renderer/SearchPalette.tsx`
- `src/renderer/SessionHeader.tsx`
- `src/renderer/Settings.tsx`
- `src/renderer/chatUtils.ts`
- `src/renderer/chatUtils.test.ts`
- `src/renderer/CloneFromGitHub.test.tsx`

**What:** User-facing string renames in BET-1134's owned files: "the box" → "the server" (and "your box", "box's", "box runtime", etc.) in all user-facing strings; desktop-app self-references swapped to "the desktop app" where they existed.

Notes:
- The `describeDesktopUpdate`/`describeServerUpdate` strings the issue lists (`Manta UI ${r.version} is available.`, `Manta UI is up to date.`, `Box update ... is available.`, etc.) **do not exist in this codebase** (`grep` confirms no `describeDesktopUpdate`/`describeServerUpdate` function and none of those literals in the owned files). Nothing to change there.
- App.tsx's two "Manta UI" occurrences (macOS Files-and-Folders permission text, notification title fallback) are the product/OS app name — left untouched per the issue's NOTE.
- `CloneFromGitHub.test.tsx` is not an owned file, but its failure was caused by a string I own: it asserts `repoListErrorMessage`'s output (`chatUtils.ts`), so I updated the assertion in lockstep.
- "Remove box" button label and the "This server has no plan agent" tooltip were changed beyond the explicit list, per the issue's "grep for the rest" instruction (both user-facing "box" references to the server).

All remaining `\b[Bb]ox\b` hits in the 7 owned files were verified as comments or legit non-server terms (config keys `box:`, `section === "box"`, `plan.box`, "composer box" / "border-box" comments).

**Base:** `origin/main @ b3156b96`

**Verification results:**
- PR branch (`multica/BET-1134-box-to-server-wording` @ `a7c882bb`):
  - typecheck: exit 0. Errors: none.
  - test: renderer 161 files passed, 3098 pass / 0 fail / 7 skip; server 2371 pass / 0 fail.
- **Conclusion:** 0 failures on the PR branch (all previously-affected assertions updated in the same PR). Base re-run not needed since the branch itself is fully green and this is pure literal renames with lockstep test updates.
