### PR TITLE
BET-1136: iOS native wording — 'the box' → 'the server'

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -119,7 +119,7 @@ enum ChatModel {
         guard let plan else {
             return on
                 ? PlanToggle(available: false, on: true, loading: false, agent: nil, title: "Plan mode on (plan agent unavailable)")
-                : PlanToggle(available: false, on: false, loading: false, agent: nil, title: "This box has no plan agent")
+                : PlanToggle(available: false, on: false, loading: false, agent: nil, title: "This server has no plan agent")
         }
         return PlanToggle(
             available: true,

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1085,7 +1085,7 @@ private struct ChatScreenContent: View {
             Image(systemName: "exclamationmark.triangle")
                 .font(.system(size: Metrics.type.display))
                 .foregroundColor(tokens.warn)
-            Text("Couldn't reach your box")
+            Text("Couldn't reach your server")
                 .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx1)
             Text("Tap to retry.")

--- a/mobile/native/MantaUI/MantaOnboarding.swift
+++ b/mobile/native/MantaUI/MantaOnboarding.swift
@@ -67,7 +67,7 @@ final class MantaOnboardingFlow: ObservableObject {
     // No hardcoded ring: the linking progress stages are all resolved through
     // the copy table; there is no positional/color literal anywhere in app code.
     let linkingStages: [String] = [
-        "Reached your box",
+        "Reached your server",
         "Verified the code",
         "Saving credentials",
     ]
@@ -123,7 +123,7 @@ final class MantaOnboardingFlow: ObservableObject {
                 serverUrl: derived.absoluteString
             )
         } else {
-            manualError = "Enter your Box ID (32 hex chars), or your server URL below."
+            manualError = "Enter your Server ID (32 hex chars), or your server URL below."
             showAdvanced = true
             return
         }
@@ -334,7 +334,7 @@ struct MantaManualEntryView: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp6) {
             header(title: "Enter the code",
-                   subtitle: "Read the six digits off your desktop, or run `manta pair` on the box.")
+                   subtitle: "Read the six digits off your desktop, or run `manta pair` on the server.")
             VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
                 // BET-702: in-app QR scan sits above the manual fields. A
                 // decoded Manta payload routes through the SAME `flow.receive`
@@ -356,7 +356,7 @@ struct MantaManualEntryView: View {
                 .accessibilityIdentifier("onboarding-scan-button")
                 OTPField(value: $flow.code, placeholder: "000000", tokens: tokens)
                     .accessibilityIdentifier("onboarding-otp")
-                TextField("Box ID (32 hex)", text: $flow.boxId)
+                TextField("Server ID (32 hex)", text: $flow.boxId)
                     .font(.manta(size: Metrics.type.body, design: .monospaced))
                     .textFieldStyle(.plain)
                     .padding(Metrics.spacing.sp3)
@@ -366,7 +366,7 @@ struct MantaManualEntryView: View {
                     .autocorrectionDisabled()
                     .accessibilityIdentifier("onboarding-box-id")
                 Button(action: { withAnimation { flow.showAdvanced.toggle() } }) {
-                    Text(flow.showAdvanced ? "Hide server URL" : "My box isn't reachable from the internet")
+                    Text(flow.showAdvanced ? "Hide server URL" : "My server isn't reachable from the internet")
                         .font(.manta(size: Metrics.type.small, weight: mantaFontWeight(Metrics.type.medium)))
                         .foregroundColor(tokens.accentTx)
                 }
@@ -456,7 +456,7 @@ struct MantaLinkingView: View {
                     .tint(tokens.accent)
                 Spacer()
             }
-            Text("Credentials stay on this phone and on your box.")
+            Text("Credentials stay on this phone and on your server.")
                 .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx4)
             Spacer(minLength: 0)
@@ -522,12 +522,12 @@ struct MantaFailureView: View {
             // Claim succeeded but the Keychain write failed. Retry re-attempts
             // ONLY the save — the code is already burned, never re-claim.
             return ("Paired, but couldn't save to this phone",
-                    "Your box accepted the code, but this phone couldn't store the connection yet.",
+                    "Your server accepted the code, but this phone couldn't store the connection yet.",
                     "Nothing is linked until the credentials save. Try saving again — don't enter a new code.",
                     "Try again", { flow.retrySave() },
                     ("Back", { flow.backToEntry() }))
         case .unreachable:
-            return ("Can't reach your box",
+            return ("Can't reach your server",
                     "The code is valid but nothing answered. Nothing was linked.",
                     "It may be asleep — check it's powered on and the server is running. Or this network blocks it — try cellular instead of Wi-Fi.",
                     "Try again", { flow.retry() },
@@ -535,7 +535,7 @@ struct MantaFailureView: View {
         case .rateLimited:
             return ("Too many attempts",
                     "Wait a moment and try again. Nothing was linked.",
-                    "Rate limiting protects your box. Give it a few seconds.",
+                    "Rate limiting protects your server. Give it a few seconds.",
                     "Try again", { flow.retry() },
                     ("Back", { flow.backToEntry() }))
         case .serverError:
@@ -661,7 +661,7 @@ struct MantaOnboardingRoot: View {
                 Text("Pair your phone")
                     .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.semibold)))
                     .foregroundColor(tokens.tx1)
-                Text("Connect this device to your box.")
+                Text("Connect this device to your server.")
                     .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx4)
             }
@@ -686,17 +686,17 @@ struct MantaSwitchBoxSheet: View {
     var body: some View {
         VStack(alignment: .leading, spacing: Metrics.spacing.sp6) {
             VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
-                Text("Switch box?")
+                Text("Switch server?")
                     .font(.manta(size: Metrics.type.display, weight: mantaFontWeight(Metrics.type.semibold)))
                     .foregroundColor(tokens.tx1)
-                Text("A Manta pairing link arrived while you're connected to another box. Switching re-pairs this phone to the new one.")
+                Text("A Manta pairing link arrived while you're connected to another server. Switching re-pairs this phone to the new one.")
                     .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
                     .foregroundColor(tokens.tx3)
             }
             MantaCard(tokens: tokens) {
                 VStack(alignment: .leading, spacing: Metrics.spacing.sp3) {
-                    hostRow(label: "Current box", host: currentHost)
-                    hostRow(label: "New box", host: newHost)
+                    hostRow(label: "Current server", host: currentHost)
+                    hostRow(label: "New server", host: newHost)
                 }
             }
             MantaPrimaryButton(title: "Switch", disabled: false,
@@ -727,7 +727,7 @@ struct MantaSwitchBoxSheet: View {
                 .lineLimit(2)
         }
         .accessibilityElement(children: .combine)
-        .accessibilityIdentifier(label == "Current box" ? "switch-box-current" : "switch-box-new")
+        .accessibilityIdentifier(label == "Current server" ? "switch-box-current" : "switch-box-new")
     }
 }
 

--- a/mobile/native/MantaUI/MantaSettingsStore.swift
+++ b/mobile/native/MantaUI/MantaSettingsStore.swift
@@ -103,7 +103,7 @@ final class MantaSettingsStore: ObservableObject {
             }
             lastError = nil
         } else {
-            lastError = "Couldn't load settings from the box."
+            lastError = "Couldn't load settings from the server."
         }
         loaded = true
     }

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -147,7 +147,7 @@ struct ModelPickerSheet: View {
 
     private var activeModelSubtitle: String {
         guard let model = activeModel else {
-            return "Using the model your box is configured to use."
+            return "Using the model your server is configured to use."
         }
         return ChatModel.cardSubtitle(model)
     }

--- a/mobile/native/MantaUI/NativeActionSheet.swift
+++ b/mobile/native/MantaUI/NativeActionSheet.swift
@@ -87,7 +87,7 @@ enum SessionConfirmCopy {
 
     static let clear = Copy(
         title: "Clear this session?",
-        message: "Starts a fresh session in this window. The transcript stays on the box.",
+        message: "Starts a fresh session in this window. The transcript stays on the server.",
         destructiveTitle: "Clear session"
     )
     static let delete = Copy(

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -140,9 +140,9 @@ final class SessionListStore: ObservableObject {
 
     private static func describe(_ error: Error) -> String {
         if let known = error as? MantaError, known == .authRequired {
-            return "Your box rejected this device — pair it again."
+            return "Your server rejected this device — pair it again."
         }
-        return "Couldn't reach your box"
+        return "Couldn't reach your server"
     }
 
     /// Adopt the project list a mutating RPC already returned (post-create),

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -665,7 +665,7 @@ struct SessionListView: View {
             Text("Can't load your sessions")
                 .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx3)
-            Text(store.loadError ?? "Couldn't reach your box")
+            Text(store.loadError ?? "Couldn't reach your server")
                 .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx4)
                 .multilineTextAlignment(.center)

--- a/mobile/native/MantaUI/SessionResourceCards.swift
+++ b/mobile/native/MantaUI/SessionResourceCards.swift
@@ -288,7 +288,7 @@ private struct SecretAddForm: View {
                     Text("1–64 chars: a letter or underscore, then letters/digits/underscores.")
                 }
                 Section {
-                    SecureField("Value (stored on the box; never shown again)", text: $value)
+                    SecureField("Value (stored on the server; never shown again)", text: $value)
                         .font(.system(.body, design: .monospaced))
                 }
                 Section {

--- a/mobile/native/MantaUI/SettingsScreen.swift
+++ b/mobile/native/MantaUI/SettingsScreen.swift
@@ -328,7 +328,7 @@ struct SettingsScreen: View {
                 .font(.manta(size: Metrics.type.twoXS, weight: .semibold))
                 .foregroundColor(tokens.tx2)
                 .textCase(.uppercase)
-            Text("Restore every setting to its default. This does not remove your box pairing or projects.")
+            Text("Restore every setting to its default. This does not remove your server pairing or projects.")
                 .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx3)
             Button {
@@ -359,7 +359,7 @@ struct SettingsScreen: View {
             Text("Reset all settings?")
                 .font(.manta(size: Metrics.type.body, weight: .semibold))
                 .foregroundColor(tokens.tx1)
-            Text("Every setting will return to its default. Your box pairing and projects are not affected. You can undo this right after.")
+            Text("Every setting will return to its default. Your server pairing and projects are not affected. You can undo this right after.")
                 .font(.manta(size: Metrics.type.small))
                 .foregroundColor(tokens.tx3)
                 .multilineTextAlignment(.center)

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -188,7 +188,7 @@ final class ComposerTests: XCTestCase {
         let r = ChatModel.planToggle(agents: [agent("build", mode: "primary")], on: false)
         XCTAssertFalse(r.available)
         XCTAssertFalse(r.on)
-        XCTAssertEqual(r.title, "This box has no plan agent")
+        XCTAssertEqual(r.title, "This server has no plan agent")
         XCTAssertNil(r.agent)
     }
 
@@ -202,7 +202,7 @@ final class ComposerTests: XCTestCase {
     func testPlanToggleSubagentNamedPlanDoesNotCount() {
         let r = ChatModel.planToggle(agents: [agent("plan", mode: "subagent")], on: false)
         XCTAssertFalse(r.available)
-        XCTAssertEqual(r.title, "This box has no plan agent")
+        XCTAssertEqual(r.title, "This server has no plan agent")
     }
 
     func testPlanToggleAvailableOffAndOn() {

--- a/mobile/native/MantaUIUITests/MantaLiveChatClearCaptureUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaLiveChatClearCaptureUITests.swift
@@ -61,7 +61,7 @@ final class MantaLiveChatClearCaptureUITests: XCTestCase {
 
         // 5. Tap Clear → native action sheet presents (message OR Cancel).
         clearRow.tap()
-        let presented = app.staticTexts["Starts a fresh session in this window. The transcript stays on the box."].waitForExistence(timeout: 8)
+        let presented = app.staticTexts["Starts a fresh session in this window. The transcript stays on the server."].waitForExistence(timeout: 8)
             || app.buttons["Cancel"].waitForExistence(timeout: 8)
             || app.alerts.firstMatch.waitForExistence(timeout: 4)
         print("RESULT actionSheetPresented=\(presented)")

--- a/mobile/native/MantaUIUITests/MantaUIOverflowCaptureUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaUIOverflowCaptureUITests.swift
@@ -47,7 +47,7 @@ final class MantaUIOverflowCaptureUITests: XCTestCase {
         // 3. The gate that proves the ACTION SHEET (not the overflow sheet) is
         //    up: the native action sheet's unique message text OR its Cancel
         //    button (UIAlertController may expose the two differently).
-        let message = app.staticTexts["Starts a fresh session in this window. The transcript stays on the box."]
+        let message = app.staticTexts["Starts a fresh session in this window. The transcript stays on the server."]
         let presented = message.waitForExistence(timeout: 8)
             || app.buttons["Cancel"].waitForExistence(timeout: 8)
         if !presented {


### PR DESCRIPTION
## What

BET-1136 — rename user-facing "box" → "server" in the native iOS client (`mobile/native`).

Pure find/replace of user-facing string literals across the 10 scoped source files + 3 lockstep test files. No new functions, no refactors; Swift string syntax preserved.

## Changes

- `ChatScreen.swift`, `SessionListStore.swift`, `SessionListView.swift`, `MantaSettingsStore.swift` — "Couldn't reach your box" / error copy → "server"
- `MantaOnboarding.swift` — onboarding/claim copy, "Box ID" field → "Server ID", switch-server sheet text (user-facing)
- `SettingsScreen.swift` — reset-settings copy ("box pairing" → "server pairing")
- `SessionResourceCards.swift`, `ModelPickerSheet.swift`, `NativeActionSheet.swift` — "stored on the box", "your box is configured", "transcript stays on the box"
- `ChatModel.swift` — plan-toggle title "This server has no plan agent"
- Tests (lockstep): `ComposerTests.swift`, `MantaUIOverflowCaptureUITests.swift`, `MantaLiveChatClearCaptureUITests.swift`

## Left alone (deliberately)

- Internal identifiers/accessibility ids: `boxId`, `isValidBoxId`, `boxDirectURL`, `onboarding-box-id`, `switch-box-*`, `MantaSwitchBoxSheet`, etc.
- Swift comments
- `MantaSettingsTests` `sectionResetValues("box")` (internal section key)

## Verification

- Linux SwiftPM gate (`mobile/native/verify.sh`, BET-1110): `swift build` + `swift test` — **65 tests, 0 failures, exit 0**
- XCUITest assertions (`MantaUIOverflowCaptureUITests`, `MantaLiveChatClearCaptureUITests`) require a Mac and are being handed off to the `macos` agent — not run here.

**Base: origin/main @ `b3156b96`**
