### PR TITLE
refactor(server): installer + CLI output 'the box' -> 'the server' (BET-1135)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -193,11 +193,11 @@ sudo_priv() {
     nopasswd) sudo -n "$@" ;;
     tty)      sudo "$@" ;;
     none)
-      die "Cannot run commands as root on this box — giving it a public HTTPS address is impossible without root.
+      die "Cannot run commands as root on this server — giving it a public HTTPS address is impossible without root.
         Choose one of these and run the installer again:
         * Install as root  — ssh root@$(hostname) then run the same install command
         * Use Tailscale    — curl -fsSL https://tailscale.com/install.sh | sh; sudo tailscale up; then run the installer again
-        * Grant this user sudo access on the box, then run the installer again."
+        * Grant this user sudo access on the server, then run the installer again."
       ;;
   esac
 }
@@ -450,7 +450,7 @@ public_ingress_preflight() {
   fi
 
   if [ "$root_usable" != "1" ]; then
-    die "Cannot complete the install: giving this box a public HTTPS address needs to run
+    die "Cannot complete the install: giving this server a public HTTPS address needs to run
       three commands as root (install Caddy, write its site config, reload it), and
       this user cannot run commands as root without a password.
 
@@ -464,7 +464,7 @@ public_ingress_preflight() {
             sudo tailscale up
             then run the same install command
 
-        * Grant this user sudo access on the box, then run the installer again."
+        * Grant this user sudo access on the server, then run the installer again."
   fi
 }
 
@@ -1466,7 +1466,7 @@ main() {
     # requires Tailscale (a Mac that's never logged in is unsupported —
     # Issue C will wire that up via LaunchAgents). B/C (gateway register
     # + merge-gateway) still run below for the APNs push token.
-    log "macOS detected — skipping Caddy/apt/DNS/vhost; box is loopback-only. Use Tailscale to reach this box off-network."
+    log "macOS detected — skipping Caddy/apt/DNS/vhost; server is loopback-only. Use Tailscale to reach this server off-network."
   else
     log "Configuring public TLS via Caddy + gateway registration (privileged)…"
   fi
@@ -1491,7 +1491,7 @@ main() {
 
   if [ -z "$BOX_ID_FOR_GATEWAY" ]; then
     if [ "$DRY_RUN" != "1" ] && [ "$SKIP_PUBLIC_TLS" != "1" ]; then
-      die "no box_id in $MANTA_AUTH_FILE after waiting — cannot register the gateway, so this box would have no public HTTPS.
+      die "no box_id in $MANTA_AUTH_FILE after waiting — cannot register the gateway, so this server would have no public HTTPS.
         Start the manta-server at least once ($(supervisor_hint restart server)), then run the installer again.
 
         Fix the above and run the installer again — re-running is safe and preserves your box identity."
@@ -1529,7 +1529,7 @@ main() {
           ok "gateway registration complete."
         else
           if [ "$SKIP_PUBLIC_TLS" != "1" ]; then
-            die "merge-gateway failed — the gateway token/host could not be persisted, so this box would advertise a hostname whose config is incomplete (see /tmp/manta-gateway-merge.err).
+            die "merge-gateway failed — the gateway token/host could not be persisted, so this server would advertise a hostname whose config is incomplete (see /tmp/manta-gateway-merge.err).
               Fix the gateway registration issue and run the installer again.
 
               Fix the above and run the installer again — re-running is safe and preserves your box identity."
@@ -1538,12 +1538,12 @@ main() {
         fi
       else
         if [ "$SKIP_PUBLIC_TLS" != "1" ]; then
-          die "gateway registration POST failed — this box would have no public HTTPS without it.
+          die "gateway registration POST failed — this server would have no public HTTPS without it.
             ${MANTA_GATEWAY_BASE:+($MANTA_GATEWAY_BASE) }Fix the gateway/network issue and run the installer again.
 
             Fix the above and run the installer again — re-running is safe and preserves your box identity."
         fi
-        warn "gateway registration POST failed — the box will retry on every server restart."
+        warn "gateway registration POST failed — the server will retry on every server restart."
       fi
     fi
   fi
@@ -1631,7 +1631,7 @@ main() {
   # as failed, not dressed as success). Dry-run just shows the plan.
   if [ "$SKIP_PUBLIC_TLS" != "1" ]; then
     if [ "$DRY_RUN" = "1" ]; then
-      dry_log "would determine the box's public IP and poll DNS for $GATEWAY_HOST (up to 90s)"
+      dry_log "would determine the server's public IP and poll DNS for $GATEWAY_HOST (up to 90s)"
       dry_log "would render + install the Caddy vhost (box_id=$BOX_ID_FOR_GATEWAY, port=$MANTA_PORT)"
       dry_log "would run: systemctl reload caddy"
     else
@@ -1666,7 +1666,7 @@ main() {
         BOX_PUBLIC_IP="$(hostname -I 2>/dev/null | awk '{print $1}' || true)"
       fi
       if [ -z "$BOX_PUBLIC_IP" ]; then
-        die "could not determine the box's public IP — cannot complete the public path.
+        die "could not determine the server's public IP — cannot complete the public path.
           Fix your network/egress so api.ipify.org (or hostname -I) reports a public address, then run the installer again.
 
           Fix the above and run the installer again — re-running is safe and preserves your box identity."
@@ -1869,7 +1869,7 @@ EOF
   if [ "$INGRESS_MODE" = "tailscale" ]; then
     cat <<EOF
 
-Tailscale detected ($TAILNET_IP) — your box is reachable over the tailnet at
+Tailscale detected ($TAILNET_IP) — your server is reachable over the tailnet at
 http://$TAILNET_IP:$MANTA_PORT (plain HTTP; WireGuard encrypts the hop). No public
 DNS, no Caddy, no Let's Encrypt on this path. Devices on the same tailnet can
 connect directly; off-tailnet devices need Tailscale access first.
@@ -1877,8 +1877,8 @@ EOF
   else
     cat <<EOF
 
-Your box serves its own public hostname — https://<box_id>.boxes.mantaui.com
-(Caddy on this box terminates TLS and reverse-proxies 127.0.0.1:8787). The
+Your server serves its own public hostname — https://<box_id>.boxes.mantaui.com
+(Caddy on this server terminates TLS and reverse-proxies 127.0.0.1:8787). The
 desktop / mobile app discovers it directly via the box_id below; no relay,
 no tunnel, no dial-out.
 EOF

--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -3113,7 +3113,7 @@ public_ingress_preflight public 0 yes ubuntu
 echo "SHOULD_NOT_REACH=yes"
 `,
   });
-  assert.match(out, /Cannot complete the install: giving this box a public HTTPS address/);
+  assert.match(out, /Cannot complete the install: giving this server a public HTTPS address/);
   assert.match(out, /Nothing has been installed\./);
   // All three recovery alternatives must be named (D3).
   assert.match(out, /Install as root/);
@@ -3181,7 +3181,7 @@ public_ingress_preflight "$_PRE_INGRESS" 0 yes ubuntu
 echo "SHOULD_NOT_REACH=yes"
 `,
   });
-  assert.match(out, /Cannot complete the install: giving this box a public HTTPS address/);
+  assert.match(out, /Cannot complete the install: giving this server a public HTTPS address/);
   assert.match(out, /Nothing has been installed\./);
   assert.doesNotMatch(out, /SHOULD_NOT_REACH=yes/);
 });

--- a/src/main/installer/handlers.test.ts
+++ b/src/main/installer/handlers.test.ts
@@ -573,7 +573,7 @@ describe("registerInstallerHandlers — passphrase pause/resume (BET-360)", () =
         {
           cause: "SSH key authentication was rejected.",
           action:
-            "Make sure your key is loaded (ssh-add) and listed in the box's ~/.ssh/authorized_keys.",
+            "Make sure your key is loaded (ssh-add) and listed in the server's ~/.ssh/authorized_keys.",
         },
       ],
       unknownHost: null,

--- a/src/main/installer/preflight.ts
+++ b/src/main/installer/preflight.ts
@@ -240,13 +240,13 @@ export function classifyPreflight(probes: PreflightProbes): PreflightResult {
     failures.push({
       cause: "Could not connect to the host over SSH.",
       action:
-        "Check the alias resolves, the box is reachable, and SSH is running on the expected port.",
+        "Check the alias resolves, the server is reachable, and SSH is running on the expected port.",
     });
   } else if (probes.reachability === "auth-failed") {
     failures.push({
       cause: "SSH key authentication was rejected.",
       action:
-        "Make sure your key is loaded (ssh-add) and listed in the box's ~/.ssh/authorized_keys.",
+        "Make sure your key is loaded (ssh-add) and listed in the server's ~/.ssh/authorized_keys.",
     });
   }
 
@@ -255,7 +255,7 @@ export function classifyPreflight(probes: PreflightProbes): PreflightResult {
     if (label === null) {
       const why =
         probes.os.id === "darwin"
-          ? "Intel Macs are not supported as a MantaUI box."
+          ? "Intel Macs are not supported as a MantaUI server."
           : probes.os.id === "linux"
           ? `Linux ${probes.os.arch} is not on the supported list (the installer ships x86_64 and aarch64).`
           : "The installer does not support this operating system.";
@@ -269,9 +269,9 @@ export function classifyPreflight(probes: PreflightProbes): PreflightResult {
   const skew = Math.abs(probes.clockSkewSeconds);
   if (skew > CLOCK_SKEW_FAIL_SECONDS) {
     failures.push({
-      cause: `Box clock is off by ${skew}s.`,
+      cause: `Server clock is off by ${skew}s.`,
       action:
-        "Certificate issuance and OAuth will fail. Sync the box's time, then try again.",
+        "Certificate issuance and OAuth will fail. Sync the server's time, then try again.",
     });
   }
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -754,7 +754,7 @@ const authRateLimit = createRateLimiter({
 });
 if (!authEnforced) {
   console.warn(
-    "[auth] ⚠️  MANTA_AUTH_DISABLED=1 — the box server is UNAUTHENTICATED. " +
+    "[auth] ⚠️  MANTA_AUTH_DISABLED=1 — the server is UNAUTHENTICATED. " +
       "Anyone who can reach this port has full access. Unset it and pair a device.",
   );
 } else {
@@ -1424,7 +1424,7 @@ const handleRequest = async (req, res) => {
           !requireLoopback(
             req,
             res,
-            "pairing codes can only be minted from the box itself (run `manta pair` locally)",
+            "pairing codes can only be minted from the server itself (run `manta pair` locally)",
           )
         ) {
           return;


### PR DESCRIPTION
Renames user-facing installer + server CLI output: "the box" -> "the server" (BET-1135).

**Files changed:** 5
- `scripts/install.sh` — user-facing `die`/`printf`/`log`/`warn`/`dry_log` strings
- `src/server/index.mjs` — auth warning + pairing-code-local-only message
- `src/main/installer/preflight.ts` — preflight error strings (+ `Server clock` cause for consistency with the renamed `Sync the server's time` action)
- `scripts/install.test.mjs` — lockstep: two assertions on the renamed `giving this server a public HTTPS address` die message
- `src/main/installer/handlers.test.ts` — lockstep: authorized_keys string

**Notes / intentional non-changes:**
- `box identity` and `box_id` / `<box_id>.boxes.mantaui.com` kept (per issue).
- Brand `MantaUI` kept.
- Product self-names kept: "MantaUI box installer", "manta box self-install".
- `scripts/lib/release.sh` (out of scope; its block is synced byte-identical into install.sh) still prints "Intel Macs are not supported as a box." — filed as follow-up.
- `src/renderer/preloadAccess.test.ts:80` holds a test-local mock "manta pair exited 1 on the box" that does not assert any source string changed here — left.

**Verification:**
- typecheck: exit 0, no errors
- test: 2371 pass / 0 fail / 0 skip
- `bash -n scripts/install.sh`: OK
- Grepped owned files for `\b[Bb]ox\b` non-comment lines: only legit non-server terms remain (box identity, product self-names, box_id/URL fields).

**Base: origin/main @ b3156b96**
