### PR TITLE
refactor(scripts): release.sh user-facing 'box' -> 'server' wording (BET-1141)

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -268,12 +268,12 @@ resolve_arch() {
     Darwin)
       case "$m" in
         arm64)  ARCH_KEY="darwin_arm64" ;;
-        *) die "unsupported Mac: $m — the MantaUI box installer supports Apple Silicon (arm64) Macs only.
-      Intel Macs are not supported as a box. If you just want to USE MantaUI on this Mac,
+        *) die "unsupported Mac: $m — the MantaUI server installer supports Apple Silicon (arm64) Macs only.
+      Intel Macs are not supported as a server. If you just want to USE MantaUI on this Mac,
       install the desktop app instead: https://mantaui.com/downloads/Manta-latest.dmg" ;;
       esac
       ;;
-    *) die "unsupported OS: $s (the MantaUI box installer supports Linux and macOS/Apple Silicon)" ;;
+    *) die "unsupported OS: $s (the MantaUI server installer supports Linux and macOS/Apple Silicon)" ;;
   esac
 }
 

--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -44,12 +44,12 @@ resolve_arch() {
     Darwin)
       case "$m" in
         arm64)  ARCH_KEY="darwin_arm64" ;;
-        *) die "unsupported Mac: $m — the MantaUI box installer supports Apple Silicon (arm64) Macs only.
-      Intel Macs are not supported as a box. If you just want to USE MantaUI on this Mac,
+        *) die "unsupported Mac: $m — the MantaUI server installer supports Apple Silicon (arm64) Macs only.
+      Intel Macs are not supported as a server. If you just want to USE MantaUI on this Mac,
       install the desktop app instead: https://mantaui.com/downloads/Manta-latest.dmg" ;;
       esac
       ;;
-    *) die "unsupported OS: $s (the MantaUI box installer supports Linux and macOS/Apple Silicon)" ;;
+    *) die "unsupported OS: $s (the MantaUI server installer supports Linux and macOS/Apple Silicon)" ;;
   esac
 }
 
@@ -245,9 +245,9 @@ install_prod_deps() {
   warn "self-update: npm ci failed — restoring the previous node_modules"
   rm -rf "$dest/node_modules"
   if [ -d "$backup" ]; then
-    mv "$backup" "$dest/node_modules" || die "self-update: could not restore node_modules — box may not start; re-run install.sh"
+    mv "$backup" "$dest/node_modules" || die "self-update: could not restore node_modules — server may not start; re-run install.sh"
     die "self-update: dependency install failed; previous node_modules restored.
-      The box still runs, but it is now on new source with older deps — re-run
+      The server still runs, but it is now on new source with older deps — re-run
       install.sh to get a matching prebuilt tree."
   fi
   die "self-update: dependency install failed and there was no previous node_modules to restore — re-run install.sh"


### PR DESCRIPTION
Closes BET-1141. Renames remaining user-facing box-as-server wording in `scripts/lib/release.sh` die/warn output to server wording, following BET-1135's rename. Regenerates the synced fallback in `scripts/install.sh` via `node scripts/sync-release-fallback.mjs` so the byte-identity sync test stays green.

Changes (all user-facing output only; `box_id`/identity terms and `MantaUI` brand unchanged):
- `scripts/lib/release.sh`: `MantaUI box installer` -> `MantaUI server installer` (unsupported-Mac and unsupported-OS die blocks), `not supported as a box` -> `not supported as a server`, and self-update restore die/warn `box may not start` -> `server may not start` / `The box still runs` -> `The server still runs`.
- `scripts/install.sh`: regenerated byte-identical fallback from the script.

The only other `box` occurrences in the file are internal comments and `box_id`/identity terms, untouched.

**Files changed:** `2` files. `scripts/lib/release.sh`, `scripts/install.sh` (regenerated fallback).

**Verification results:**
- PR branch (`multica/BET-1141-release-box-wording` @ `a1179518`):
  - typecheck: exit `0`. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit `0` on re-run, `2370 pass / 1 fail / 0 skip`. Failures: `src/server/usage.test.mjs:824` (`poller: a waiting window re-polls…`) — a 5ms-timer timing flake unrelated to this PR (shell-script-only diff): passes in isolation (`48/0` on `src/server/usage.test.mjs`) and on full-suite re-run (`2371/0`). log sha256: `e809666cb13a21e3ead4575b375b396692a64785ec3be5c8a0cb915363e77942`
- Base (`main` @ `f819f6cc`):
  - typecheck: exit `0`. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit `0`, `2371 pass / 0 fail / 0 skip`. Failures: none. log sha256: `377e19eaff1ce3a9679ea2c7db6c6b11699d96a9cb1f1c4662378d1ba9dcd173`
- **Conclusion:** `1` test failure is a pre-existing timing flake in a test file this PR does not touch; it passes in isolation and on re-run. `0` new failures caused by this PR.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

Base: origin/main @ f819f6cc