### PR TITLE
feat(server): stamp calling messageID on pushed outbox files (BET-1145)

### DIFF
--- a/docs/opencode-tools/send-file.ts
+++ b/docs/opencode-tools/send-file.ts
@@ -16,6 +16,8 @@
 //   - Workspace-linked under the caller's opencode sessionID.
 //   - TTL (default 7 days) — NOT deleted on download; swept when it expires.
 //   - Re-downloadable until then.
+//   - Stamps the calling opencode `context.messageID` on the artifact so the
+//     Artifacts panel's "Jump to message" scrolls to the turn that sent it.
 //
 // See docs/manta-tools-scheduler.md for the general "manta tools" pattern.
 
@@ -106,6 +108,7 @@ export const send_file = tool({
       filePath: args.path,
       sessionID: context.sessionID,
       ttlHours: args.ttlHours,
+      messageID: context.messageID,
     });
     const ttl =
       result.row?.expiresAt == null

--- a/src/renderer/artifacts.test.ts
+++ b/src/renderer/artifacts.test.ts
@@ -170,7 +170,7 @@ describe("deriveArtifacts", () => {
 
   it("outbox file → file artifact (origin agent, scoped to its session)", () => {
     const got = deriveArtifacts([], [], "ses_a", [
-      { path: "/home/dev/.manta-outbox/q3-revenue.csv", name: "q3-revenue.csv", size: 1204, sessionID: "ses_a", mtime: 5000, expiresAt: 5000 + 604800000 },
+      { path: "/home/dev/.manta-outbox/q3-revenue.csv", name: "q3-revenue.csv", size: 1204, sessionID: "ses_a", mtime: 5000, expiresAt: 5000 + 604800000, messageID: "msg-abc" },
     ]);
     expect(got).toHaveLength(1);
     expect(got[0]).toMatchObject({
@@ -181,7 +181,7 @@ describe("deriveArtifacts", () => {
       mime: "text/csv",
       size: 1204,
       at: 5000,
-      messageId: null,
+      messageId: "msg-abc",
       context: null,
       expiresAt: 5000 + 604800000,
     });
@@ -189,14 +189,14 @@ describe("deriveArtifacts", () => {
 
   it("outbox files from another session are excluded (workspace-linked)", () => {
     const got = deriveArtifacts([], [], "ses_a", [
-      { path: "/home/dev/.manta-outbox/x.csv", name: "x.csv", size: 1, sessionID: "ses_OTHER", mtime: 1000, expiresAt: null },
+      { path: "/home/dev/.manta-outbox/x.csv", name: "x.csv", size: 1, sessionID: "ses_OTHER", mtime: 1000, expiresAt: null, messageID: null },
     ]);
     expect(got).toEqual([]);
   });
 
   it("outbox image file → image artifact with its mime", () => {
     const got = deriveArtifacts([], [], "ses_a", [
-      { path: "/home/dev/.manta-outbox/shot.png", name: "shot.png", size: 2048, sessionID: "ses_a", mtime: 1000, expiresAt: null },
+      { path: "/home/dev/.manta-outbox/shot.png", name: "shot.png", size: 2048, sessionID: "ses_a", mtime: 1000, expiresAt: null, messageID: null },
     ]);
     expect(got).toHaveLength(1);
     expect(got[0].kind).toBe("image");
@@ -205,7 +205,7 @@ describe("deriveArtifacts", () => {
 
   it("outbox file with an unknown extension keeps a null mime (file kind)", () => {
     const got = deriveArtifacts([], [], "ses_a", [
-      { path: "/home/dev/.manta-outbox/archive.bin", name: "archive.bin", size: 99, sessionID: "ses_a", mtime: 1000, expiresAt: null },
+      { path: "/home/dev/.manta-outbox/archive.bin", name: "archive.bin", size: 99, sessionID: "ses_a", mtime: 1000, expiresAt: null, messageID: null },
     ]);
     expect(got).toHaveLength(1);
     expect(got[0].kind).toBe("file");
@@ -217,7 +217,7 @@ describe("deriveArtifacts", () => {
       msg("u", "user", [filePart({ filename: "mine.csv", url: "file:///home/dev/.manta-uploads/mine.csv" })]),
     ];
     const got = deriveArtifacts(messages, [], "ses_a", [
-      { path: "/home/dev/.manta-outbox/pushed.pdf", name: "pushed.pdf", size: 100, sessionID: "ses_a", mtime: 2000, expiresAt: null },
+      { path: "/home/dev/.manta-outbox/pushed.pdf", name: "pushed.pdf", size: 100, sessionID: "ses_a", mtime: 2000, expiresAt: null, messageID: null },
     ]);
     expect(got.length).toBe(2);
     expect(got.map((a) => a.origin).sort()).toEqual(["agent", "user"]);

--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -159,7 +159,7 @@ function deriveOutboxArtifact(row: OutboxFile): Artifact {
     mime,
     size: row.size,
     at: row.mtime || 0,
-    messageId: null,
+    messageId: row.messageID ?? null,
     context: null,
     expiresAt: row.expiresAt,
   };

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1660,10 +1660,12 @@ const handleRequest = async (req, res) => {
   }
 
   // ---------- Push a file as a workspace artifact (send_file tool) ----------
-  // POST /api/outbox/push { filePath, sessionID, ttlHours? }
+  // POST /api/outbox/push { filePath, sessionID, ttlHours?, messageID? }
   // Copies the AI-generated file into ~/.manta-outbox/<sessionID>/ so it shows
   // in the artifacts panel's Files tab (workspace-linked, TTL'd, not deleted
   // on download) and announces it via the outbox scanner's agentFile toast.
+  // `messageID` stamps the calling opencode turn on the file so the Artifacts
+  // panel's "Jump to message" works; absent/non-string values are ignored.
   if (req.method === "POST" && path === "/api/outbox/push") {
     let body;
     try {
@@ -1673,6 +1675,10 @@ const handleRequest = async (req, res) => {
     }
     const result = await pushArtifact(body?.filePath, body?.sessionID, {
       ttlHours: body?.ttlHours,
+      messageID:
+        typeof body?.messageID === "string" && body.messageID.trim()
+          ? body.messageID
+          : undefined,
     });
     return result.ok
       ? respondJson(res, 200, { ok: true, row: result.row })

--- a/src/server/outbox.mjs
+++ b/src/server/outbox.mjs
@@ -16,7 +16,7 @@
 //     download (/api/peek) and /api/download leave the source in place.
 //   - The arrival toast (`agentFile`) still fires on new files.
 
-import { readdir, stat, copyFile, mkdir, rm } from "node:fs/promises";
+import { readdir, stat, copyFile, mkdir, rm, readFile, writeFile } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { outboxRoot as defaultOutboxRoot } from "../shared/paths.mjs";
 import { startPoller } from "./startPoller.mjs";
@@ -34,6 +34,42 @@ function resolveExpiry(ttlHours, mtime) {
       ? ttlHours * 3600 * 1000
       : DEFAULT_TTL_MS;
   return mtime + ttl;
+}
+
+// Per-file metadata sidecar. `send_file` stamps the calling opencode message id
+// (and any per-push TTL override) here so `listOutbox` can surface it without
+// nesting the file (nesting would make it invisible to the panel and immune to
+// the sweep). The sidecar is always beside the file it describes.
+export function sidecarPath(filePath) {
+  return `${filePath}.manta.json`;
+}
+
+// "Is this a sidecar file?" — used by BOTH listOutbox and expireArtifacts so
+// sidecars never surface as artifacts and never survive the deletion of their
+// file. The single source of truth for the suffix.
+export function isSidecar(name) {
+  return typeof name === "string" && name.endsWith(".manta.json");
+}
+
+// Best-effort, never throws. Missing / empty / corrupt → "no metadata",
+// identical to a file that predates the sidecar.
+async function readSidecar(path) {
+  try {
+    const raw = await readFile(path, "utf-8");
+    const meta = raw ? JSON.parse(raw) : null;
+    return meta && typeof meta === "object" ? meta : {};
+  } catch {
+    return {};
+  }
+}
+
+// Best-effort, never throws.
+async function writeSidecar(path, meta) {
+  try {
+    await writeFile(path, JSON.stringify(meta));
+  } catch {
+    /* non-fatal — the push still succeeds, metadata is lost */
+  }
 }
 
 // List the artifact mailbox. Each row is { path, name, size, sessionID, mtime,
@@ -54,6 +90,7 @@ export async function listOutbox(root = defaultOutboxRoot(), { sessionID } = {})
     const full = join(root, ent.name);
     if (ent.isFile()) {
       if (sessionID != null && sessionID !== "") continue;
+      if (isSidecar(ent.name)) continue;
       out.push(await statRow(full, ent.name, null, now));
     } else if (ent.isDirectory()) {
       if (sessionID != null && ent.name !== sessionID) continue;
@@ -65,6 +102,7 @@ export async function listOutbox(root = defaultOutboxRoot(), { sessionID } = {})
       }
       for (const sub of subEntries) {
         if (!sub.isFile()) continue;
+        if (isSidecar(sub.name)) continue;
         out.push(await statRow(join(full, sub.name), sub.name, ent.name, now));
       }
     }
@@ -75,16 +113,28 @@ export async function listOutbox(root = defaultOutboxRoot(), { sessionID } = {})
 async function statRow(path, name, sessionID, now) {
   try {
     const st = await stat(path);
+    const meta = await readSidecar(sidecarPath(path));
+    const expiresAt = "expiresAt" in meta ? meta.expiresAt : resolveExpiry(null, st.mtimeMs, now);
     return {
       path,
       name,
       size: st.size,
       sessionID,
       mtime: st.mtimeMs,
-      expiresAt: resolveExpiry(null, st.mtimeMs, now),
+      expiresAt,
+      messageID:
+        typeof meta.messageID === "string" && meta.messageID ? meta.messageID : null,
     };
   } catch {
-    return { path, name, size: 0, sessionID, mtime: 0, expiresAt: null };
+    return {
+      path,
+      name,
+      size: 0,
+      sessionID,
+      mtime: 0,
+      expiresAt: null,
+      messageID: null,
+    };
   }
 }
 
@@ -94,7 +144,7 @@ async function statRow(path, name, sessionID, now) {
 export async function pushArtifact(
   filePath,
   sessionID,
-  { root = defaultOutboxRoot(), ttlHours } = {},
+  { root = defaultOutboxRoot(), ttlHours, messageID } = {},
 ) {
   if (!sessionID || typeof sessionID !== "string" || !sessionID.trim()) {
     return { ok: false, error: "sessionID is required" };
@@ -111,8 +161,16 @@ export async function pushArtifact(
   await mkdir(destDir, { recursive: true });
   const dest = join(destDir, safe);
   await copyFile(filePath, dest);
+  const msgId =
+    typeof messageID === "string" && messageID.trim() ? messageID : null;
+  if (msgId || ttlHours != null) {
+    const st = await stat(dest);
+    const meta = {};
+    if (msgId) meta.messageID = msgId;
+    if (ttlHours != null) meta.expiresAt = resolveExpiry(ttlHours, st.mtimeMs);
+    await writeSidecar(sidecarPath(dest), meta);
+  }
   const row = await statRow(dest, safe, sessionID, Date.now());
-  if (ttlHours != null) row.expiresAt = resolveExpiry(ttlHours, row.mtime);
   return { ok: true, row };
 }
 
@@ -136,6 +194,7 @@ export async function expireArtifacts(
       const subs = await readdir(full, { withFileTypes: true });
       for (const sub of subs) {
         if (!sub.isFile()) continue;
+        if (isSidecar(sub.name)) continue;
         const subFull = join(full, sub.name);
         let st;
         try {
@@ -145,6 +204,7 @@ export async function expireArtifacts(
         }
         if (now - st.mtimeMs > ttlMs) {
           await rm(subFull, { force: true });
+          await rm(sidecarPath(subFull), { force: true });
           removed++;
         }
       }

--- a/src/server/outbox.test.mjs
+++ b/src/server/outbox.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { mkdtemp, mkdir, writeFile, rm, utimes } from "node:fs/promises";
+import { mkdtemp, mkdir, writeFile, rm, utimes, readdir } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { listOutbox, createOutboxScanner, pushArtifact, expireArtifacts } from "./outbox.mjs";
@@ -207,3 +207,122 @@ test("expireArtifacts removes files past TTL and prunes empty session dirs", asy
 async function touchMtime(p, ms) {
   await utimes(p, new Date(ms), new Date(ms));
 }
+
+// ----------------------------------------------------------------------------
+// Sidecar metadata — messageID stamping + TTL persistence
+// ----------------------------------------------------------------------------
+
+test("pushArtifact writes a sidecar carrying the messageID; listOutbox returns it", async () => {
+  const root = await makeOutbox();
+  const src = join(root, "..", "src-msg.csv");
+  await writeFile(src, "a\n");
+  try {
+    const res = await pushArtifact(src, "ses_m", { root, messageID: "msg-123" });
+    assert.equal(res.ok, true);
+    assert.equal(res.row.messageID, "msg-123");
+    const listed = await listOutbox(root, { sessionID: "ses_m" });
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].messageID, "msg-123");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(src, { force: true });
+  }
+});
+
+test("a file with no sidecar returns messageID null", async () => {
+  const root = await makeOutbox();
+  try {
+    await mkdir(join(root, "ses_x"));
+    await writeFile(join(root, "ses_x", "plain.txt"), "x");
+    const listed = await listOutbox(root, { sessionID: "ses_x" });
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].messageID, null);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("sidecars never appear as their own rows in listOutbox", async () => {
+  const root = await makeOutbox();
+  try {
+    await mkdir(join(root, "ses_s"));
+    await writeFile(join(root, "ses_s", "doc.txt"), "y");
+    await writeFile(join(root, "ses_s", "doc.txt.manta.json"), '{"messageID":"m-s"}');
+    const listed = await listOutbox(root, { sessionID: "ses_s" });
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].name, "doc.txt");
+    assert.equal(listed[0].messageID, "m-s");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("regression: ttlHours 0 (never expire) survives a listOutbox round-trip", async () => {
+  const root = await makeOutbox();
+  const src = join(root, "..", "src-never.csv");
+  await writeFile(src, "z\n");
+  try {
+    const res = await pushArtifact(src, "ses_t", { root, ttlHours: 0 });
+    assert.equal(res.ok, true);
+    assert.equal(res.row.expiresAt, null, "row returned to tool says never expires");
+    const listed = await listOutbox(root, { sessionID: "ses_t" });
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].expiresAt, null, "persisted via sidecar, not recomputed to 7d");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(src, { force: true });
+  }
+});
+
+test("expireArtifacts removes a sidecar with its file and still prunes the dir", async () => {
+  const root = await makeOutbox();
+  const ttl = 1000;
+  try {
+    await mkdir(join(root, "ses_e"));
+    await writeFile(join(root, "ses_e", "old.txt"), "x");
+    await writeFile(join(root, "ses_e", "old.txt.manta.json"), '{"messageID":"m-e"}');
+    const now = Date.now();
+    await touchMtime(join(root, "ses_e", "old.txt"), now - ttl - 1000);
+    const removed = await expireArtifacts(root, { ttlMs: ttl, now });
+    assert.equal(removed, 1);
+    const remaining = await listOutbox(root, { sessionID: "ses_e" });
+    assert.equal(remaining.length, 0, "file gone");
+    const dirs = await readdir(root);
+    assert.deepEqual(dirs, [], "session dir pruned");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("a corrupt sidecar degrades to null rather than throwing", async () => {
+  const root = await makeOutbox();
+  try {
+    await mkdir(join(root, "ses_c"));
+    await writeFile(join(root, "ses_c", "bad.txt"), "x");
+    await writeFile(join(root, "ses_c", "bad.txt.manta.json"), "{not json");
+    const listed = await listOutbox(root, { sessionID: "ses_c" });
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].name, "bad.txt");
+    assert.equal(listed[0].messageID, null);
+    assert.equal(typeof listed[0].expiresAt, "number", "falls back to default TTL");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("pushArtifact ignores a blank/absent messageID (no empty sidecar written)", async () => {
+  const root = await makeOutbox();
+  const src = join(root, "..", "src-blank.csv");
+  await writeFile(src, "b\n");
+  try {
+    const res = await pushArtifact(src, "ses_b", { root, messageID: "   " });
+    assert.equal(res.ok, true);
+    assert.equal(res.row.messageID, null);
+    const listed = await listOutbox(root, { sessionID: "ses_b" });
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].messageID, null);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(src, { force: true });
+  }
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1698,6 +1698,7 @@ export type OutboxFile = {
   sessionID: string | null;
   mtime: number;
   expiresAt: number | null;
+  messageID: string | null;
 };
 
 // Input shape for secretsSet (UI → store). The value travels renderer → IPC →


### PR DESCRIPTION
Base: origin/main @ d132c7ac

## What & why
`send_file` files landed in the artifact mailbox with no message id, so the
Artifacts panel's "Jump to message" button was permanently disabled. This
stamps the calling opencode turn on each pushed file so jump works — no new
feature, just populating the one missing field.

## Changes
- `docs/opencode-tools/send-file.ts` — forward `context.messageID` in the POST body.
- `src/server/index.mjs` — accept `messageID` on `/api/outbox/push`; non-empty string or treated as absent; never throws.
- `src/server/outbox.mjs` — persist `{ messageID, expiresAt }` in a per-file `.manta.json` sidecar (`sidecarPath` single helper, `isSidecar` single predicate). `statRow` reads it back (messageID, and prefers the sidecar `expiresAt` — this also fixes the pre-existing bug where `ttlHours: 0` was honored in the tool reply but recomputed to 7d on the next list). `listOutbox` and `expireArtifacts` skip/clean sidecars; the TTL-persist change let me delete the `pushArtifact` post-hoc `row.expiresAt` branch.
- `src/shared/types.ts` — `OutboxFile.messageID: string | null`.
- `src/renderer/artifacts.ts` — `messageId: row.messageID ?? null`.
- Tests: 7 new server cases (sidecar write/read, null fallback, sidecars never listed, ttlHours:0 regression, expire+prune together, corrupt sidecar, blank messageID) + renderer fixture/mapping updates.

Out of scope per BET-1145: no UI change, no new endpoint/event/config, `handleDownload` untouched, no sidecar migration.

## Verification results
**Files changed:** 7. `docs/opencode-tools/send-file.ts`, `src/renderer/artifacts.test.ts`, `src/renderer/artifacts.ts`, `src/server/index.mjs`, `src/server/outbox.mjs`, `src/server/outbox.test.mjs`, `src/shared/types.ts`

- PR branch (`multica/BET-1145-artifact-messageid` @ `c6154fab`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2378 pass / 0 fail / 0 skip. Failures: none. log sha256: `b8190826b70610d2b3657a9e636256b56e5f0d936c1edb044ab72fbfdae874aa`
- Base (`main` @ `d132c7ac`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2371 pass / 0 fail / 0 skip. Failures: none. log sha256: `da2d019de09fa72a25614b1726a4de84ce024f1423f5ea4ac73282d743524972`
- **Conclusion:** 0 failures are new (PR adds 7 passing tests; both branches 0 failures).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
