### PR TITLE
feat(mobile/ios): deprecated models disabled by default + on-device opt-in (BET-1140)

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -65,7 +65,7 @@ enum ChatModel {
             $0.providerID == active.providerID &&
             $0.id == counterpartID &&
             $0.enabled != false &&
-            $0.status?.lowercased() != "deprecated"
+            !isDeprecated($0)
         }
         guard let counterpart else {
             if isFast {
@@ -169,12 +169,53 @@ enum ChatModel {
         }
     }
 
-    /// A model is pickable when it is not explicitly disabled and not
-    /// deprecated. Absent `enabled`/`status` (common) → pickable.
+    // MARK: - Deprecation (BET-1140)
+
+    /// A model the provider still serves but flags as deprecated. THE single
+    /// predicate: the ONLY place the literal "deprecated" is compared on iOS —
+    /// the Swift mirror of `isDeprecated` in `src/shared/modelGuide.mjs`
+    /// (BET-1139). Consumers must call this, never re-compare the literal.
+    /// Mirrors the desktop exactly (byte-for-byte status match) so the two stay
+    /// in lockstep.
+    static func isDeprecated(_ model: OpencodeModel) -> Bool {
+        model.status == "deprecated"
+    }
+
+    /// A model is pickable (selectable) when it is not explicitly disabled and
+    /// not deprecated. Absent `enabled`/`status` (common) → pickable. A
+    /// deprecated model that has NOT been opted in stays non-pickable here; it
+    /// remains VISIBLE in the catalogue as a disabled row (see
+    /// `catalogueGroups` / `isCatalogueRowDisabled`) until the user opts in.
     static func isPickable(_ m: OpencodeModel) -> Bool {
         if m.enabled == false { return false }
-        if m.status?.lowercased() == "deprecated" { return false }
+        if isDeprecated(m) { return false }
         return true
+    }
+
+    /// The catalogue's ("All models") candidate groups. Same alphabetical /
+    /// enabled / `-fast`-sibling-folding gates as `groups(_:)`, EXCEPT a
+    /// deprecated model is KEPT in the list so it stays visible + importable
+    /// (rendered as a greyed, non-selectable row until opted in). Mirror of the
+    /// desktop `mainPickerGroups` keep-deprecated behaviour (BET-1139).
+    static func catalogueGroups(_ models: [OpencodeModel]) -> [(provider: String, models: [OpencodeModel])] {
+        var map: [String: [OpencodeModel]] = [:]
+        for m in models where m.enabled != false {
+            map[m.providerID, default: []].append(m)
+        }
+        return map.keys.sorted().compactMap { provider in
+            guard let all = map[provider] else { return nil }
+            let ids = Set(all.map(\.id))
+            let kept = all.filter { !(isFastModelID($0.id) && ids.contains(baseModelID($0.id))) }
+            return kept.isEmpty ? nil : (provider, kept)
+        }
+    }
+
+    /// Whether a catalogue row renders disabled — the model is deprecated AND
+    /// its "providerID/modelID" has not been opted in. The single row-disabled
+    /// decision for the catalogue; mirrors the desktop `disabledKeys` set from
+    /// `mainPickerGroups` (BET-1139).
+    static func isCatalogueRowDisabled(_ m: OpencodeModel, optIn deprecatedOptIns: Set<String>) -> Bool {
+        isDeprecated(m) && !deprecatedOptIns.contains("\(m.providerID)/\(m.id)")
     }
 
     /// The effective selection: override wins, else the configured default.
@@ -377,12 +418,12 @@ enum ChatModel {
         return parts.joined(separator: " · ")
     }
 
-    /// How many models the catalogue will actually show in its "All models · N"
-    /// count — the total across `groups(_:)`, so the count can never disagree
-    /// with the list beneath it (which likewise excludes disabled/deprecated
-    /// models and `-fast` twins whose base twin survives).
-    static func pickableCount(_ models: [OpencodeModel]) -> Int {
-        groups(models).reduce(0) { $0 + $1.models.count }
+    /// How many rows the catalogue will actually show in its "All models · N"
+    /// count — the total across `catalogueGroups(_:)`, so the count can never
+    /// disagree with the list beneath it (which now includes deprecated rows,
+    /// greyed/disabled until opted in).
+    static func catalogueCount(_ models: [OpencodeModel]) -> Int {
+        catalogueGroups(models).reduce(0) { $0 + $1.models.count }
     }
 
     /// Encode a selection as the persisted `providerID/modelID` string.

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -35,6 +35,12 @@ final class ChatModelStore: ObservableObject {
     /// first. Persisted PER BOX (a habit, not a conversation), unlike the
     /// override/variant above which are per-session.
     @Published private(set) var recents: [ModelChoice] = []
+    /// "providerID/modelID" keys of deprecated models the user has explicitly
+    /// opted back in to (BET-1140). Per box (UserDefaults), like recents — not
+    /// per session, so the choice follows the user across sessions. A
+    /// deprecated model NOT in this set renders greyed/disabled in the
+    /// catalogue list until opted in.
+    @Published private(set) var deprecatedOptIns: Set<String> = []
     /// Plan mode is ON for this session (the per-session `manta:chat:<sid>:plan`
     /// boolean — BET-952). A plain Bool, deliberately NOT folded into the model
     /// blob: iOS stores that as a distinct "providerID/modelID" string.
@@ -67,6 +73,7 @@ final class ChatModelStore: ObservableObject {
         self.defaultModel = catalog.defaultModel
         self.loaded = catalog.loaded
         self.recents = ModelRecents.load()
+        self.deprecatedOptIns = DeprecatedModelOptIns.load()
         catalog.objectWillChange
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.mirrorCatalog() }
@@ -260,6 +267,18 @@ final class ChatModelStore: ObservableObject {
         let currentVariant = variant
         setOverride(OpencodeModelID(providerID: target.providerID, modelID: target.modelID))
         if let currentVariant { setVariant(currentVariant) }
+    }
+
+    // MARK: - Deprecated-model opt-in (BET-1140)
+
+    /// Persist the user's opt-in for a deprecated model, flipping its catalogue
+    /// row from disabled to selectable. Idempotent — a second opt-in for the
+    /// same model is a no-op.
+    func optIn(_ model: OpencodeModel) {
+        let key = "\(model.providerID)/\(model.id)"
+        guard !deprecatedOptIns.contains(key) else { return }
+        deprecatedOptIns.insert(key)
+        DeprecatedModelOptIns.save(deprecatedOptIns)
     }
 
     // MARK: - Plan mode (BET-952)

--- a/mobile/native/MantaUI/DeprecatedModelOptIns.swift
+++ b/mobile/native/MantaUI/DeprecatedModelOptIns.swift
@@ -1,0 +1,34 @@
+import Foundation
+
+// ===========================================================================
+// BET-1140 — deprecated-model opt-ins.
+//
+// A model the provider still serves but flags as deprecated is shown
+// GREYED/DISABLED in the model list by default; the user explicitly opts it
+// back in and that choice persists on-device, at which point it becomes a
+// normal selectable row.
+//
+// The opt-in is a HABIT (which deprecated models this user will keep using),
+// not tied to one conversation, so it persists PER BOX under a single
+// UserDefaults key — the same storage idiom as ModelRecents. Keys are
+// "providerID/modelID". One predicate (`ChatModel.isDeprecated`) and one
+// storage idiom; nothing here diverges from the desktop (BET-1139).
+// ===========================================================================
+
+enum DeprecatedModelOptIns {
+    /// Per-box storage key (an opt-in is not tied to one session).
+    static let storageKey = "manta:deprecated-model-opt-ins"
+
+    static func load(_ defaults: UserDefaults = .standard) -> Set<String> {
+        guard let data = defaults.data(forKey: storageKey),
+              let set = try? JSONDecoder().decode(Set<String>.self, from: data)
+        else { return [] }
+        return set
+    }
+
+    static func save(_ set: Set<String>, _ defaults: UserDefaults = .standard) {
+        if let data = try? JSONEncoder().encode(set) {
+            defaults.set(data, forKey: storageKey)
+        }
+    }
+}

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -257,7 +257,7 @@ struct ModelPickerSheet: View {
                     .font(.manta(size: Metrics.type.small, weight: .semibold))
                     .foregroundColor(tokens.tx1)
                 Spacer(minLength: 0)
-                Text("\(ChatModel.pickableCount(modelStore.models))")
+                Text("\(ChatModel.catalogueCount(modelStore.models))")
                     .font(.manta(size: Metrics.type.small))
                     .foregroundColor(tokens.tx4)
                 Image(systemName: "chevron.right")
@@ -303,7 +303,7 @@ struct ModelCatalogueView: View {
     private var groups: [(provider: String, models: [OpencodeModel])] {
         let all = modelStore.models
         let filtered = all.filter { ChatModel.matches($0, filter: filter, in: all) }
-        return ChatModel.filteredGroups(ChatModel.groups(filtered), query: query)
+        return ChatModel.filteredGroups(ChatModel.catalogueGroups(filtered), query: query)
     }
 
     private func isSelected(_ m: OpencodeModel) -> Bool {
@@ -312,7 +312,11 @@ struct ModelCatalogueView: View {
     }
 
     /// Pick a model from the catalogue and record it as a recently-used triple.
+    /// A disabled (deprecated, not opted-in) row can never reach here — its
+    /// Button is disabled — but the guard keeps the store from ever setting a
+    /// deprecated override it wasn't meant to allow.
     private func select(_ m: OpencodeModel) {
+        guard !ChatModel.isCatalogueRowDisabled(m, optIn: modelStore.deprecatedOptIns) else { return }
         modelStore.setOverride(OpencodeModelID(providerID: m.providerID, modelID: m.id))
         modelStore.recordCurrentChoice()
     }
@@ -327,7 +331,7 @@ struct ModelCatalogueView: View {
                 .searchable(
                     text: $query,
                     placement: .navigationBarDrawer(displayMode: .always),
-                    prompt: "Search \(ChatModel.pickableCount(modelStore.models)) models"
+                    prompt: "Search \(ChatModel.catalogueCount(modelStore.models)) models"
                 )
             } else {
                 ProgressView("Loading models…")
@@ -366,7 +370,9 @@ struct ModelCatalogueView: View {
     /// The model list, grouped into a Section per provider. Empty-query misses
     /// AND a capability filter with no matches both render the platform search
     /// empty state — a user who filters to Vision on a box with no vision model
-    /// gets the platform state, not a blank list.
+    /// gets the platform state, not a blank list. A deprecated model not yet
+    /// opted in renders a greyed, non-selectable row with an "Enable" action
+    /// (BET-1140); once opted in it becomes an ordinary selectable row.
     @ViewBuilder
     private var providerSections: some View {
         if groups.isEmpty {
@@ -375,20 +381,11 @@ struct ModelCatalogueView: View {
             ForEach(groups, id: \.provider) { group in
                 Section {
                     ForEach(group.models, id: \.id) { m in
-                        Button { select(m); onPick() } label: {
-                            HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
-                                VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
-                                    Text(m.name)
-                                        .lineLimit(1)
-                                    let badge = ChatModel.catalogueBadge(m)
-                                    if !badge.isEmpty {
-                                        Text(badge)
-                                            .font(.manta(size: Metrics.type.xs))
-                                            .foregroundColor(tokens.tx3)
-                                    }
-                                }
-                                Spacer()
-                                if isSelected(m) { checkmark }
+                        if ChatModel.isCatalogueRowDisabled(m, optIn: modelStore.deprecatedOptIns) {
+                            disabledRow(for: m)
+                        } else {
+                            Button { select(m); onPick() } label: {
+                                modelRow(for: m)
                             }
                         }
                     }
@@ -397,6 +394,54 @@ struct ModelCatalogueView: View {
                 }
             }
         }
+    }
+
+    /// The ordinary selectable catalogue row: name + capability/context badge,
+    /// and the checkmark when it's the active model.
+    private func modelRow(for m: OpencodeModel) -> some View {
+        HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
+            VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
+                Text(m.name)
+                    .lineLimit(1)
+                let badge = ChatModel.catalogueBadge(m)
+                if !badge.isEmpty {
+                    Text(badge)
+                        .font(.manta(size: Metrics.type.xs))
+                        .foregroundColor(tokens.tx3)
+                }
+            }
+            Spacer()
+            if isSelected(m) { checkmark }
+        }
+    }
+
+    /// A deprecated model the user hasn't opted in to: greyed, NOT a tappable
+    /// Button, with a small "Enable" action that persists the opt-in — the
+    /// minimal disabled-row affordance BET-1140 asks for. Mirrors the desktop's
+    /// `Enable deprecated` row in ModelMenu.tsx.
+    private func disabledRow(for m: OpencodeModel) -> some View {
+        HStack(alignment: .center, spacing: Metrics.spacing.sp2) {
+            VStack(alignment: .leading, spacing: Metrics.spacing.spPx) {
+                Text(m.name)
+                    .lineLimit(1)
+                    .foregroundColor(tokens.tx3)
+                let badge = ChatModel.catalogueBadge(m)
+                if !badge.isEmpty {
+                    Text(badge)
+                        .font(.manta(size: Metrics.type.xs))
+                        .foregroundColor(tokens.tx4)
+                }
+            }
+            Spacer()
+            Text("deprecated")
+                .font(.manta(size: Metrics.type.twoXS, weight: .semibold))
+                .foregroundColor(tokens.tx4)
+            Button("Enable") { modelStore.optIn(m) }
+                .font(.manta(size: Metrics.type.xs, weight: .semibold))
+                .foregroundColor(tokens.accentTx)
+                .accessibilityIdentifier("model-enable-deprecated")
+        }
+        .accessibilityIdentifier("model-deprecated-disabled-\(m.id)")
     }
 
     private var checkmark: some View {

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -246,6 +246,50 @@ final class ComposerTests: XCTestCase {
         XCTAssertEqual(ChatModel.shortName("Gemini Claude Weird"), "Claude Weird")
     }
 
+    // MARK: - ChatModel deprecation + catalogue (BET-1140)
+
+    func testIsDeprecatedMatchesExactStatus() {
+        XCTAssertTrue(ChatModel.isDeprecated(model("anthropic", "opus", status: "deprecated")))
+        XCTAssertFalse(ChatModel.isDeprecated(model("anthropic", "opus", status: "live")))
+        XCTAssertFalse(ChatModel.isDeprecated(model("anthropic", "opus")))
+    }
+
+    func testIsPickableExcludesDeprecated() {
+        XCTAssertTrue(ChatModel.isPickable(model("anthropic", "sonnet")))
+        XCTAssertFalse(ChatModel.isPickable(model("anthropic", "deprecated", status: "deprecated")))
+        XCTAssertFalse(ChatModel.isPickable(model("anthropic", "disabled", enabled: false)))
+    }
+
+    func testCatalogueGroupsKeepsDeprecatedButNotDisabled() {
+        let models = [
+            model("anthropic", "haiku"),
+            model("anthropic", "deprecated", status: "deprecated"),
+            model("anthropic", "disabled", enabled: false),
+            model("zebra", "z1"),
+        ]
+        let groups = ChatModel.catalogueGroups(models)
+        XCTAssertEqual(groups.map(\.provider), ["anthropic", "zebra"])
+        // Deprecated stays visible; explicitly-disabled is dropped.
+        XCTAssertEqual(groups[0].models.map(\.id), ["haiku", "deprecated"])
+    }
+
+    func testCatalogueGroupsFoldsDeprecatedFastTwins() {
+        let models = [
+            model("openai", "gpt-5.6"),
+            model("openai", "gpt-5.6-fast", status: "deprecated"),
+        ]
+        let groups = ChatModel.catalogueGroups(models)
+        // The -fast twin of a visible base is a mode — folded even when deprecated.
+        XCTAssertEqual(groups[0].models.map(\.id), ["gpt-5.6"])
+    }
+
+    func testCatalogueRowDisabledUntilOptedIn() {
+        let deprecated = model("anthropic", "opus", status: "deprecated")
+        XCTAssertTrue(ChatModel.isCatalogueRowDisabled(deprecated, optIn: []))
+        XCTAssertFalse(ChatModel.isCatalogueRowDisabled(deprecated, optIn: ["anthropic/opus"]))
+        XCTAssertFalse(ChatModel.isCatalogueRowDisabled(model("anthropic", "haiku"), optIn: []))
+    }
+
     // MARK: - ChatVoice.mime
 
     func testMimeFromFilenameExtension() {

--- a/mobile/native/MantaUITests/DeprecatedModelOptInsTests.swift
+++ b/mobile/native/MantaUITests/DeprecatedModelOptInsTests.swift
@@ -1,0 +1,42 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// BET-1140 — deprecated-model opt-in persistence. The opt-in set lives under a
+// PER-BOX UserDefaults key (same storage idiom as ModelRecents) and round-trips
+// on-device: a deprecated model the user enabled stays selectable across
+// launches.
+// ===========================================================================
+
+final class DeprecatedModelOptInsTests: XCTestCase {
+
+    private var suiteName = ""
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        suiteName = "DeprecatedModelOptInsTests-\(UUID().uuidString)"
+        defaults = UserDefaults(suiteName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        super.tearDown()
+    }
+
+    func testRoundTripPersistsAcrossLoads() {
+        let set: Set<String> = ["anthropic/opus", "openai/gpt-4o"]
+        DeprecatedModelOptIns.save(set, defaults)
+        XCTAssertEqual(DeprecatedModelOptIns.load(defaults), set)
+    }
+
+    func testLoadEmptyWhenNothingStored() {
+        XCTAssertEqual(DeprecatedModelOptIns.load(defaults), [])
+    }
+
+    func testSaveReplacesPreviousSet() {
+        DeprecatedModelOptIns.save(["anthropic/opus"], defaults)
+        DeprecatedModelOptIns.save(["anthropic/opus", "openai/gpt-4o"], defaults)
+        XCTAssertEqual(DeprecatedModelOptIns.load(defaults), ["anthropic/opus", "openai/gpt-4o"])
+    }
+}

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -263,7 +263,7 @@ final class ModelRecentsTests: XCTestCase {
         XCTAssertFalse(label.contains("Xhigh"))
     }
 
-    // MARK: - Cockpit + catalogue copy (BET-894): catalogueBadge / cardSubtitle / pickableCount
+    // MARK: - Cockpit + catalogue copy (BET-894/BET-1140): catalogueBadge / cardSubtitle / catalogueCount
 
     /// A bare model for the badge/subtitle tests, with the context limit and
     /// capability flags explicit the way the wire object carries them.
@@ -314,26 +314,27 @@ final class ModelRecentsTests: XCTestCase {
         XCTAssertEqual(ChatModel.cardSubtitle(m), "anthropic · 1M context")
     }
 
-    // MARK: - ChatModel.pickableCount
+    // MARK: - ChatModel.catalogueCount (BET-1140)
 
-    func testPickableCountExcludesDisabledDeprecatedAndFastTwins() {
+    func testCatalogueCountIncludesDeprecatedExcludesDisabledAndFastTwins() {
         let base = OpencodeModel(id: "gpt-5.6", providerID: "openai", name: "GPT-5.6")
         // The -fast twin of a visible base is a MODE, not a choice — excluded.
         let fast = OpencodeModel(id: "gpt-5.6-fast", providerID: "openai", name: "GPT-5.6 Fast")
         let disabled = OpencodeModel(id: "disabled", providerID: "openai", name: "Disabled", enabled: false)
+        // A deprecated model is KEPT in the list (visible, greyed) — counted.
         let deprecated = OpencodeModel(id: "deprecated", providerID: "openai", name: "Deprecated", status: "deprecated")
         let regular = OpencodeModel(id: "gpt-4o", providerID: "openai", name: "GPT-4o")
         let models = [base, fast, disabled, deprecated, regular]
 
-        XCTAssertEqual(ChatModel.pickableCount(models), 2)
-        // Must equal the sum of the sections `groups(_:)` actually renders.
-        let groupsSum = ChatModel.groups(models).reduce(0) { $0 + $1.models.count }
-        XCTAssertEqual(ChatModel.pickableCount(models), groupsSum)
+        XCTAssertEqual(ChatModel.catalogueCount(models), 3)
+        // Must equal the sum of the sections `catalogueGroups(_:)` actually renders.
+        let groupsSum = ChatModel.catalogueGroups(models).reduce(0) { $0 + $1.models.count }
+        XCTAssertEqual(ChatModel.catalogueCount(models), groupsSum)
     }
 
-    func testPickableCountSingleModel() {
+    func testCatalogueCountSingleModel() {
         let models = [OpencodeModel(id: "opus", providerID: "anthropic", name: "Claude Opus 4.7")]
-        XCTAssertEqual(ChatModel.pickableCount(models), 1)
+        XCTAssertEqual(ChatModel.catalogueCount(models), 1)
     }
 
     // MARK: - ChatModel.ModelCapabilityFilter.matches (BET-895)


### PR DESCRIPTION
## BET-1140 — Deprecated models: disabled by default + opt-in (iOS model list)

Mirror the desktop BET-1139 behaviour in the native iOS model list. No TypeScript / server code touched — this PR is Swift-under `mobile/native/` only.

**Files changed (6):**
- `mobile/native/MantaUI/ChatModel.swift` — single `isDeprecated` predicate (the ONLY place the literal is compared on iOS, mirroring `src/shared/modelGuide.mjs`); `isPickable` and the fast-toggle counterpart check now call it; new `catalogueGroups` (keeps deprecated rows), `isCatalogueRowDisabled(_:optIn:)`, `catalogueCount` (replaces the old `pickableCount`).
- `mobile/native/MantaUI/DeprecatedModelOptIns.swift` (new) — per-box UserDefaults persistence of the opt-in set, same idiom as `ModelRecents`.
- `mobile/native/MantaUI/ChatModelStore.swift` — `deprecatedOptIns` published set + `optIn(_:)`.
- `mobile/native/MantaUI/ModelPickerSheet.swift` — catalogue renders deprecated rows greyed + non-selectable with an "Enable" action; select/count/search use the catalogue path.
- Tests: `ComposerTests.swift`, `ModelRecentsTests.swift`, new `DeprecatedModelOptInsTests.swift`.

**Base: origin/main @ `d132c7ac`**

**Verification results** (native Swift — the Linux box has no Swift toolchain, so verification comes from GitHub CI + the Mac plugin, not npm):
- `swift-core-test` (GitHub CI, **runs the MantaUITests unit bundle** on a macos runner): **pass** ✓
- `swiftlint`: **pass** ✓
- `typecheck-test` (npm renderer+server): **pass** ✓ (untouched by this PR)
- `ios-build` (compile-only, macos-26): pending at snapshot
- `ios-mantaui` plugin `test-unit` (deterministic native gate, run on the Mac): job completed `done` after gating commit `2c252d72` on the MantaUITests bundle
