### PR TITLE
feat(server): add HTTP Range support + image/video MIME on /api/peek (BET-1146)

### DIFF
--- a/src/renderer/artifacts.ts
+++ b/src/renderer/artifacts.ts
@@ -135,6 +135,10 @@ const EXT_MIME: Record<string, string> = {
   ".gif": "image/gif",
   ".svg": "image/svg+xml",
   ".webp": "image/webp",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".m4v": "video/x-m4v",
 };
 
 function extOf(p: string): string {

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -19,7 +19,7 @@ import * as tmux from "./tmux.mjs";
 import * as oc from "./opencode.mjs";
 import * as pty from "./pty.mjs";
 import * as local from "./local.mjs";
-import { parseByteRange } from "./range.mjs";
+import { createPeekHandler } from "./peek.mjs";
 import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
 
 // BET-187: ship every console.* (and any startup banner / poller log) to
@@ -1183,6 +1183,16 @@ function respondJson(res, status, obj) {
   res.end(JSON.stringify(obj));
 }
 
+// /api/peek handler with the real route logic in src/server/peek.mjs (tested
+// directly in peek.test.mjs — no mock). Injected with the real fs/homedir.
+const peekHandler = createPeekHandler({
+  homedir,
+  stat,
+  createReadStream,
+  pipeline,
+  MIME,
+});
+
 function requireLoopback(req, res, errorMessage) {
   if (
     isLocalDirectRequest({
@@ -1719,106 +1729,11 @@ const handleRequest = async (req, res) => {
   // Path is resolved against the caller's home dir (~ expansion) and
   // constrained to stay inside it (path-traversal guard). Content-Type is
   // inferred from the file extension; falls back to application/octet-stream.
+  // Supports single byte ranges (206/416, `accept-ranges: bytes`); absent,
+  // unparseable, or multi-range headers serve the whole file (200). The logic
+  // lives in src/server/peek.mjs so it is tested directly, not via a mock.
   if ((req.method === "GET" || req.method === "HEAD") && path === "/api/peek") {
-    const raw = url.searchParams.get("path") ?? "";
-    if (!raw) {
-      respondJson(res, 400, { error: "path is required" });
-      return;
-    }
-    // Expand ~ to $HOME so callers can pass ~/foo/bar.
-    let resolved = raw;
-    if (resolved === "~") resolved = homedir() + "/";
-    else if (resolved.startsWith("~/")) resolved = homedir() + resolved.slice(1);
-    else resolved = resolve(resolved);
-    // Guard: resolved path must stay inside the user's home dir.
-    const home = homedir() + "/";
-    if (resolved !== home && !resolved.startsWith(home)) {
-      respondJson(res, 403, { error: "path outside home directory" });
-      return;
-    }
-    let s;
-    try {
-      s = await stat(resolved);
-    } catch (e) {
-      if (e?.code === "ENOENT") {
-        respondJson(res, 404, { error: "not found" });
-        return;
-      }
-      respondJson(res, 500, { error: String(e?.message ?? e) });
-      return;
-    }
-    if (!s.isFile()) {
-      respondJson(res, 404, { error: "not a file" });
-      return;
-    }
-    const ext = extname(resolved);
-    const contentType = MIME[ext] ?? "application/octet-stream";
-    res.writeHead(200, {
-      "content-type": contentType,
-      "content-length": String(s.size),
-      "content-disposition": `inline; filename="${basename(resolved).replace(/"/g, "")}"`,
-    });
-    const baseHeaders = {
-      "content-type": contentType,
-      "accept-ranges": "bytes",
-      "content-disposition": `inline; filename="${basename(resolved).replace(/"/g, "")}"`,
-    };
-    const range = parseByteRange(req.headers.range ?? null, s.size);
-    // Unsatisfiable range → 416 with `content-range: bytes */<size>`.
-    if (range === "unsatisfiable") {
-      res.writeHead(416, {
-        ...baseHeaders,
-        "content-range": `bytes */${s.size}`,
-      });
-      res.end();
-      return;
-    }
-    // Satisfiable single range → 206, streaming only that slice.
-    if (range) {
-      const length = range.end - range.start + 1;
-      res.writeHead(206, {
-        ...baseHeaders,
-        "content-range": `bytes ${range.start}-${range.end}/${s.size}`,
-        "content-length": String(length),
-      });
-      if (req.method === "HEAD") {
-        res.end();
-        return;
-      }
-      try {
-        await pipeline(
-          createReadStream(resolved, { start: range.start, end: range.end }),
-          res,
-        );
-      } catch (e) {
-        if (!res.headersSent) {
-          respondJson(res, 500, { error: String(e?.message ?? e) });
-        } else {
-          res.destroy();
-        }
-      }
-      return;
-    }
-    // Absent, unparseable, or multi-range header → exactly today's 200
-    // behaviour, byte for byte. Multi-range is deliberately not supported.
-    res.writeHead(200, {
-      ...baseHeaders,
-      "content-length": String(s.size),
-    });
-    // HEAD reports the size via `content-length` without streaming the body.
-    if (req.method === "HEAD") {
-      res.end();
-      return;
-    }
-    try {
-      await pipeline(createReadStream(resolved), res);
-    } catch (e) {
-      if (!res.headersSent) {
-        respondJson(res, 500, { error: String(e?.message ?? e) });
-      } else {
-        res.destroy();
-      }
-    }
+    await peekHandler(req, res, url);
     return;
   }
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -19,6 +19,7 @@ import * as tmux from "./tmux.mjs";
 import * as oc from "./opencode.mjs";
 import * as pty from "./pty.mjs";
 import * as local from "./local.mjs";
+import { parseByteRange } from "./range.mjs";
 import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
 
 // BET-187: ship every console.* (and any startup banner / poller log) to
@@ -1057,6 +1058,14 @@ const MIME = {
   ".svg": "image/svg+xml",
   ".ico": "image/x-icon",
   ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".mp4": "video/mp4",
+  ".webm": "video/webm",
+  ".mov": "video/quicktime",
+  ".m4v": "video/x-m4v",
   ".webmanifest": "application/manifest+json",
 };
 
@@ -1748,6 +1757,53 @@ const handleRequest = async (req, res) => {
       "content-type": contentType,
       "content-length": String(s.size),
       "content-disposition": `inline; filename="${basename(resolved).replace(/"/g, "")}"`,
+    });
+    const baseHeaders = {
+      "content-type": contentType,
+      "accept-ranges": "bytes",
+      "content-disposition": `inline; filename="${basename(resolved).replace(/"/g, "")}"`,
+    };
+    const range = parseByteRange(req.headers.range ?? null, s.size);
+    // Unsatisfiable range → 416 with `content-range: bytes */<size>`.
+    if (range === "unsatisfiable") {
+      res.writeHead(416, {
+        ...baseHeaders,
+        "content-range": `bytes */${s.size}`,
+      });
+      res.end();
+      return;
+    }
+    // Satisfiable single range → 206, streaming only that slice.
+    if (range) {
+      const length = range.end - range.start + 1;
+      res.writeHead(206, {
+        ...baseHeaders,
+        "content-range": `bytes ${range.start}-${range.end}/${s.size}`,
+        "content-length": String(length),
+      });
+      if (req.method === "HEAD") {
+        res.end();
+        return;
+      }
+      try {
+        await pipeline(
+          createReadStream(resolved, { start: range.start, end: range.end }),
+          res,
+        );
+      } catch (e) {
+        if (!res.headersSent) {
+          respondJson(res, 500, { error: String(e?.message ?? e) });
+        } else {
+          res.destroy();
+        }
+      }
+      return;
+    }
+    // Absent, unparseable, or multi-range header → exactly today's 200
+    // behaviour, byte for byte. Multi-range is deliberately not supported.
+    res.writeHead(200, {
+      ...baseHeaders,
+      "content-length": String(s.size),
     });
     // HEAD reports the size via `content-length` without streaming the body.
     if (req.method === "HEAD") {

--- a/src/server/peek.mjs
+++ b/src/server/peek.mjs
@@ -1,0 +1,112 @@
+// File-peek handler for GET/HEAD /api/peek — extracted from index.mjs so the
+// real route logic is unit-testable without a live HTTP server (the old
+// peek.test.mjs used a re-implemented mock that silently drifted and hid a
+// duplicated writeHead — BET-1146 review). All I/O is injected so a test can
+// drive this exact handler with real fs + a fake response.
+
+import { resolve, extname, basename } from "node:path";
+import { parseByteRange } from "./range.mjs";
+
+export function createPeekHandler({ homedir, stat, createReadStream, pipeline, MIME }) {
+  function writeJsonError(res, status, obj) {
+    res.writeHead(status, { "content-type": "application/json" });
+    res.end(JSON.stringify(obj));
+  }
+
+  return async function handlePeek(req, res, url) {
+    const raw = url.searchParams.get("path") ?? "";
+    if (!raw) {
+      writeJsonError(res, 400, { error: "path is required" });
+      return;
+    }
+    // Expand ~ to $HOME so callers can pass ~/foo/bar.
+    let resolved = raw;
+    if (resolved === "~") resolved = homedir() + "/";
+    else if (resolved.startsWith("~/")) resolved = homedir() + resolved.slice(1);
+    else resolved = resolve(resolved);
+    // Guard: resolved path must stay inside the user's home dir.
+    const home = homedir() + "/";
+    if (resolved !== home && !resolved.startsWith(home)) {
+      writeJsonError(res, 403, { error: "path outside home directory" });
+      return;
+    }
+    let s;
+    try {
+      s = await stat(resolved);
+    } catch (e) {
+      if (e?.code === "ENOENT") {
+        writeJsonError(res, 404, { error: "not found" });
+        return;
+      }
+      writeJsonError(res, 500, { error: String(e?.message ?? e) });
+      return;
+    }
+    if (!s.isFile()) {
+      writeJsonError(res, 404, { error: "not a file" });
+      return;
+    }
+    const ext = extname(resolved);
+    const contentType = MIME[ext] ?? "application/octet-stream";
+    const baseHeaders = {
+      "content-type": contentType,
+      "accept-ranges": "bytes",
+      "content-disposition": `inline; filename="${basename(resolved).replace(/"/g, "")}"`,
+    };
+    const range = parseByteRange(req.headers.range ?? null, s.size);
+    // Unsatisfiable range → 416 with `content-range: bytes */<size>`.
+    if (range === "unsatisfiable") {
+      res.writeHead(416, {
+        ...baseHeaders,
+        "content-range": `bytes */${s.size}`,
+      });
+      res.end();
+      return;
+    }
+    // Satisfiable single range → 206, streaming only that slice.
+    if (range) {
+      const length = range.end - range.start + 1;
+      res.writeHead(206, {
+        ...baseHeaders,
+        "content-range": `bytes ${range.start}-${range.end}/${s.size}`,
+        "content-length": String(length),
+      });
+      if (req.method === "HEAD") {
+        res.end();
+        return;
+      }
+      try {
+        await pipeline(
+          createReadStream(resolved, { start: range.start, end: range.end }),
+          res,
+        );
+      } catch (e) {
+        if (!res.headersSent) {
+          writeJsonError(res, 500, { error: String(e?.message ?? e) });
+        } else {
+          res.destroy();
+        }
+      }
+      return;
+    }
+    // Absent, unparseable, or multi-range header → exactly today's 200
+    // behaviour, byte for byte. Multi-range is deliberately not supported.
+    res.writeHead(200, {
+      ...baseHeaders,
+      "content-length": String(s.size),
+    });
+    // HEAD reports the size via `content-length` without streaming the body.
+    if (req.method === "HEAD") {
+      res.end();
+      return;
+    }
+    try {
+      await pipeline(createReadStream(resolved), res);
+    } catch (e) {
+      if (!res.headersSent) {
+        writeJsonError(res, 500, { error: String(e?.message ?? e) });
+      } else {
+        res.destroy();
+      }
+    }
+  };
+}

--- a/src/server/peek.test.mjs
+++ b/src/server/peek.test.mjs
@@ -1,363 +1,74 @@
-// Tests for the /api/peek route — file peek for HTTP-mode desktop.
+// Tests for the /api/peek file-serving route. These drive the REAL handler
+// (src/server/peek.mjs, the same module index.mjs calls) with real node:fs I/O
+// and a fake Writable response — no re-implemented mock. Plus the pure
+// parseByteRange unit tests.
 // Run via `npm run test:server` (node:test).
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { createServer } from "node:http";
+import { Writable } from "node:stream";
+import { createReadStream } from "node:fs";
+import { stat } from "node:fs/promises";
+import { pipeline } from "node:stream/promises";
 import { writeFile, mkdir, rm } from "node:fs/promises";
 import { join } from "node:path";
 import { homedir } from "node:os";
-import { fileURLToPath } from "node:url";
-import { dirname } from "node:path";
-import http from "node:http";
-
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = dirname(__filename);
 
 import { parseByteRange } from "./range.mjs";
+import { createPeekHandler } from "./peek.mjs";
 
-// Helper: make a GET request and return { status, headers, body }
-function httpGet(url) {
-  return new Promise((resolve, reject) => {
-    const req = http.get(url, (res) => {
-      const chunks = [];
-      res.on("data", (c) => chunks.push(c));
-      res.on("end", () => {
-        resolve({
-          status: res.statusCode,
-          headers: res.headers,
-          body: Buffer.concat(chunks),
-        });
-      });
-    });
-    req.on("error", reject);
-  });
+const MIME = {
+  ".txt": "text/plain; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".png": "image/png",
+};
+
+// The real handler, wired with real fs + homedir, driven in-process.
+function makeHandler() {
+  return createPeekHandler({ homedir, stat, createReadStream, pipeline, MIME });
 }
 
-// Helper: make a HEAD request — same response shape, body expected empty.
-function httpHead(url) {
-  return new Promise((resolve, reject) => {
-    const req = http.request(url, { method: "HEAD" }, (res) => {
-      const chunks = [];
-      res.on("data", (c) => chunks.push(c));
-      res.on("end", () => {
-        resolve({
-          status: res.statusCode,
-          headers: res.headers,
-          body: Buffer.concat(chunks),
-        });
-      });
-    });
-    req.on("error", reject);
-    req.end();
-  });
+// A Writable response that captures status + headers + streamed bytes.
+class FakeRes extends Writable {
+  constructor() {
+    super();
+    this.statusCode = null;
+    this.headers = null;
+    this._chunks = [];
+  }
+  writeHead(status, headers) {
+    this.statusCode = status;
+    this.headers = headers;
+    return this;
+  }
+  get body() {
+    return Buffer.concat(this._chunks);
+  }
+  _write(chunk, _enc, cb) {
+    this._chunks.push(Buffer.from(chunk));
+    cb();
+  }
 }
 
-// Helper: make a GET request with the given Range header.
-function httpGetRange(url, range) {
-  return new Promise((resolve, reject) => {
-    const req = http.get(
-      url,
-      { headers: range === undefined ? {} : { Range: range } },
-      (res) => {
-        const chunks = [];
-        res.on("data", (c) => chunks.push(c));
-        res.on("end", () => {
-          resolve({
-            status: res.statusCode,
-            headers: res.headers,
-            body: Buffer.concat(chunks),
-          });
-        });
-      },
-    );
-    req.on("error", reject);
-  });
+function request(method, range) {
+  return { method, headers: range === undefined ? {} : { range } };
 }
 
-// Helper: start a minimal server with the peek route logic
-async function startPeekServer(testDir) {
-  const { readFile, stat: fsStat } = await import("node:fs/promises");
-  const { createReadStream } = await import("node:fs");
-  const { pipeline } = await import("node:stream/promises");
-  const { resolve: pathResolve, extname, basename } = await import("node:path");
-  const httpMod = await import("node:http");
-
-  const MIME = {
-    ".txt": "text/plain; charset=utf-8",
-    ".json": "application/json; charset=utf-8",
-    ".png": "image/png",
-    ".html": "text/html; charset=utf-8",
-  };
-
-  return new Promise((serverResolve) => {
-    const server = httpMod.createServer(async (req, res) => {
-      const url = new URL(req.url, `http://${req.headers.host}`);
-      const path = url.pathname;
-
-      if ((req.method === "GET" || req.method === "HEAD") && path === "/api/peek") {
-        try {
-          const raw = url.searchParams.get("path") ?? "";
-          if (!raw) {
-            res.writeHead(400, { "content-type": "application/json" });
-            res.end(JSON.stringify({ error: "path is required" }));
-            return;
-          }
-          let resolved = raw;
-          if (resolved === "~") resolved = homedir() + "/";
-          else if (resolved.startsWith("~/")) resolved = homedir() + resolved.slice(1);
-          else resolved = pathResolve(resolved);
-
-          const home = homedir() + "/";
-          if (resolved !== home && !resolved.startsWith(home)) {
-            res.writeHead(403, { "content-type": "application/json" });
-            res.end(JSON.stringify({ error: "path outside home directory" }));
-            return;
-          }
-
-          let s;
-          try {
-            s = await fsStat(resolved);
-          } catch (e) {
-            if (e?.code === "ENOENT") {
-              res.writeHead(404, { "content-type": "application/json" });
-              res.end(JSON.stringify({ error: "not found" }));
-              return;
-            }
-            res.writeHead(500, { "content-type": "application/json" });
-            res.end(JSON.stringify({ error: String(e?.message ?? e) }));
-            return;
-          }
-          if (!s.isFile()) {
-            res.writeHead(404, { "content-type": "application/json" });
-            res.end(JSON.stringify({ error: "not a file" }));
-            return;
-          }
-
-          const ext = extname(resolved);
-          const contentType = MIME[ext] ?? "application/octet-stream";
-          const baseHeaders = {
-            "content-type": contentType,
-            "accept-ranges": "bytes",
-            "content-disposition": `inline; filename="${basename(resolved).replace(/"/g, "")}"`,
-          };
-          const range = parseByteRange(req.headers.range ?? null, s.size);
-          if (range === "unsatisfiable") {
-            res.writeHead(416, {
-              ...baseHeaders,
-              "content-range": `bytes */${s.size}`,
-            });
-            res.end();
-            return;
-          }
-          if (range) {
-            const length = range.end - range.start + 1;
-            res.writeHead(206, {
-              ...baseHeaders,
-              "content-range": `bytes ${range.start}-${range.end}/${s.size}`,
-              "content-length": String(length),
-            });
-            if (req.method === "HEAD") {
-              res.end();
-              return;
-            }
-            await pipeline(
-              createReadStream(resolved, { start: range.start, end: range.end }),
-              res,
-            );
-            return;
-          }
-          res.writeHead(200, {
-            ...baseHeaders,
-            "content-length": String(s.size),
-          });
-          if (req.method === "HEAD") {
-            res.end();
-            return;
-          }
-          await pipeline(createReadStream(resolved), res);
-        } catch (e) {
-          if (!res.headersSent) {
-            res.writeHead(500, { "content-type": "application/json" });
-            res.end(JSON.stringify({ error: String(e?.message ?? e) }));
-          } else {
-            res.destroy();
-          }
-        }
-        return;
-      }
-
-      res.writeHead(404);
-      res.end("not found");
-    });
-
-    server.listen(0, "127.0.0.1", () => {
-      const addr = server.address();
-      serverResolve({ server, port: addr.port });
-    });
-  });
+function peekUrl(absPath) {
+  return new URL("http://127.0.0.1:8787/api/peek?path=" + encodeURIComponent(absPath));
 }
 
-test("/api/peek serves a text file with correct content", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  await writeFile(testFile, "hello world");
+// Drive the real handler and await the response (stream completes).
+async function runPeek({ path, method = "GET", range }) {
+  const res = new FakeRes();
+  await makeHandler()(request(method, range), res, peekUrl(path));
+  return res;
+}
 
-  try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const res = await httpGet(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`);
-      assert.equal(res.status, 200, `Response body: ${res.body.toString()}`);
-      assert.equal(res.headers["content-type"], "text/plain; charset=utf-8");
-      assert.equal(res.body.toString(), "hello world");
-    } finally {
-      server.close();
-    }
-  } finally {
-    await rm(testDir, { recursive: true, force: true });
-  }
-});
-
-test("/api/peek rejects missing path with 400", async () => {
-  const { server, port } = await startPeekServer();
-  try {
-    const res = await httpGet(`http://127.0.0.1:${port}/api/peek`);
-    assert.equal(res.status, 400);
-    const body = JSON.parse(res.body.toString());
-    assert.equal(body.error, "path is required");
-  } finally {
-    server.close();
-  }
-});
-
-test("/api/peek rejects path traversal with 403", async () => {
-  const { server, port } = await startPeekServer();
-  try {
-    // Try to access a file outside home dir
-    const res = await httpGet(`http://127.0.0.1:${port}/api/peek?path=/etc/passwd`);
-    assert.equal(res.status, 403);
-    const body = JSON.parse(res.body.toString());
-    assert.equal(body.error, "path outside home directory");
-  } finally {
-    server.close();
-  }
-});
-
-test("/api/peek returns 404 for non-existent file", async () => {
-  const nonExistent = join(homedir(), "nonexistent-file-12345.txt");
-  const { server, port } = await startPeekServer();
-  try {
-    const res = await httpGet(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(nonExistent)}`);
-    assert.equal(res.status, 404);
-    const body = JSON.parse(res.body.toString());
-    assert.equal(body.error, "not found");
-  } finally {
-    server.close();
-  }
-});
-
-test("/api/peek returns 404 for directory", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-dir-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const { server, port } = await startPeekServer();
-  try {
-    const res = await httpGet(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testDir)}`);
-    assert.equal(res.status, 404);
-    const body = JSON.parse(res.body.toString());
-    assert.equal(body.error, "not a file");
-  } finally {
-    server.close();
-    await rm(testDir, { recursive: true, force: true });
-  }
-});
-
-test("/api/peek expands ~ to home directory", async () => {
-  // Create a file in home dir
-  const ts = Date.now();
-  const testFile = join(homedir(), `.manta-test-peek-home-${ts}.txt`);
-  await writeFile(testFile, "home file content");
-  const relativePath = `~/.manta-test-peek-home-${ts}.txt`;
-
-  const { server, port } = await startPeekServer();
-  try {
-    const res = await httpGet(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(relativePath)}`);
-    assert.equal(res.status, 200);
-    assert.equal(res.body.toString(), "home file content");
-  } finally {
-    server.close();
-    await rm(testFile, { force: true });
-  }
-});
-
-test("/api/peek serves JSON with correct content-type", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-json-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "data.json");
-  await writeFile(testFile, '{"key":"value"}');
-
-  try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const res = await httpGet(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`);
-      assert.equal(res.status, 200);
-      assert.equal(res.headers["content-type"], "application/json; charset=utf-8");
-      assert.equal(res.body.toString(), '{"key":"value"}');
-    } finally {
-      server.close();
-    }
-  } finally {
-    await rm(testDir, { recursive: true, force: true });
-  }
-});
-
-test("/api/peek HEAD reports content-length without a body", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-head-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  const content = "hello world";
-  await writeFile(testFile, content);
-
-  try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const res = await httpHead(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`);
-      assert.equal(res.status, 200, `Response body: ${res.body.toString()}`);
-      assert.equal(res.headers["content-type"], "text/plain; charset=utf-8");
-      assert.equal(res.headers["content-length"], String(Buffer.byteLength(content)));
-      assert.equal(res.body.length, 0, "HEAD must not stream a body");
-    } finally {
-      server.close();
-    }
-  } finally {
-    await rm(testDir, { recursive: true, force: true });
-  }
-});
-
-test("/api/peek HEAD rejects path traversal with 403", async () => {
-  const { server, port } = await startPeekServer();
-  try {
-    // Node suppresses the body on HEAD responses; the status must match GET's 403.
-    const res = await httpHead(`http://127.0.0.1:${port}/api/peek?path=/etc/passwd`);
-    assert.equal(res.status, 403);
-    assert.equal(res.body.length, 0);
-  } finally {
-    server.close();
-  }
-});
-
-test("/api/peek HEAD returns 404 for non-existent file", async () => {
-  const nonExistent = join(homedir(), "nonexistent-file-12345.txt");
-  const { server, port } = await startPeekServer();
-  try {
-    // Node suppresses the body on HEAD responses; the status must match GET's 404.
-    const res = await httpHead(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(nonExistent)}`);
-    assert.equal(res.status, 404);
-    assert.equal(res.body.length, 0);
-  } finally {
-    server.close();
-  }
-});
+// Create a throwaway test dir inside the user's home dir.
+function tempRoot(tag) {
+  return join(homedir(), `.manta-test-peek-${tag}-${Date.now()}`);
+}
 
 // ---------------------------------------------------------------------------
 // parseByteRange — pure unit tests (no HTTP, no server)
@@ -421,206 +132,176 @@ test("parseByteRange: multi-range request returns null (serve whole file)", () =
 });
 
 // ---------------------------------------------------------------------------
-// /api/peek Range behaviour — integration tests against the mock server
+// Real handler — GET/HEAD 200/206/416 behaviour
 // ---------------------------------------------------------------------------
 
-test("/api/peek advertises accept-ranges on GET and HEAD", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-ranges-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  const content = "0123456789abcdefghij"; // 20 bytes
-  await writeFile(testFile, content);
+const CONTENT = "0123456789abcdefghij"; // 20 bytes
 
+test("/api/peek GET serves the full file with correct headers", async () => {
+  const root = tempRoot("get");
+  await mkdir(root, { recursive: true });
+  const file = join(root, "test.txt");
+  await writeFile(file, CONTENT);
   try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
-      const get = await httpGet(url);
-      assert.equal(get.headers["accept-ranges"], "bytes");
-      const head = await httpHead(url);
-      assert.equal(head.headers["accept-ranges"], "bytes");
-    } finally {
-      server.close();
-    }
+    const res = await runPeek({ path: file });
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers["content-type"], "text/plain; charset=utf-8");
+    assert.equal(res.headers["accept-ranges"], "bytes");
+    assert.equal(res.headers["content-length"], String(Buffer.byteLength(CONTENT)));
+    assert.equal(res.body.toString(), CONTENT);
   } finally {
-    await rm(testDir, { recursive: true, force: true });
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek HEAD reports the full size with no body", async () => {
+  const root = tempRoot("head");
+  await mkdir(root, { recursive: true });
+  const file = join(root, "test.txt");
+  await writeFile(file, CONTENT);
+  try {
+    const res = await runPeek({ path: file, method: "HEAD" });
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers["accept-ranges"], "bytes");
+    assert.equal(res.headers["content-length"], String(Buffer.byteLength(CONTENT)));
+    assert.equal(res.body.length, 0, "HEAD must not stream a body");
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });
 
 test("/api/peek ranged GET returns 206 with the correct bytes and content-range", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-range-get-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  const content = "0123456789abcdefghij"; // 20 bytes
-  await writeFile(testFile, content);
-
+  const root = tempRoot("ranged-get");
+  await mkdir(root, { recursive: true });
+  const file = join(root, "test.txt");
+  await writeFile(file, CONTENT);
   try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
-      const res = await httpGetRange(url, "bytes=5-9");
-      assert.equal(res.status, 206, `Response body: ${res.body.toString()}`);
-      assert.equal(res.body.toString(), "56789");
-      assert.equal(res.headers["content-range"], "bytes 5-9/20");
-      assert.equal(res.headers["content-length"], "5");
-    } finally {
-      server.close();
-    }
+    const res = await runPeek({ path: file, range: "bytes=5-9" });
+    assert.equal(res.statusCode, 206);
+    assert.equal(res.body.toString(), "56789");
+    assert.equal(res.headers["content-range"], "bytes 5-9/20");
+    assert.equal(res.headers["content-length"], "5");
+    assert.equal(res.headers["accept-ranges"], "bytes");
   } finally {
-    await rm(testDir, { recursive: true, force: true });
+    await rm(root, { recursive: true, force: true });
   }
 });
 
 test("/api/peek open-ended ranged GET returns the tail", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-range-open-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  const content = "0123456789abcdefghij"; // 20 bytes
-  await writeFile(testFile, content);
-
+  const root = tempRoot("ranged-open");
+  await mkdir(root, { recursive: true });
+  const file = join(root, "test.txt");
+  await writeFile(file, CONTENT);
   try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
-      const res = await httpGetRange(url, "bytes=15-");
-      assert.equal(res.status, 206);
-      assert.equal(res.body.toString(), "fghij");
-      assert.equal(res.headers["content-range"], "bytes 15-19/20");
-      assert.equal(res.headers["content-length"], "5");
-    } finally {
-      server.close();
-    }
+    const res = await runPeek({ path: file, range: "bytes=15-" });
+    assert.equal(res.statusCode, 206);
+    assert.equal(res.body.toString(), "fghij");
+    assert.equal(res.headers["content-range"], "bytes 15-19/20");
+    assert.equal(res.headers["content-length"], "5");
   } finally {
-    await rm(testDir, { recursive: true, force: true });
+    await rm(root, { recursive: true, force: true });
   }
 });
 
 test("/api/peek unsatisfiable range returns 416 with bytes */size", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-range-416-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  await writeFile(testFile, "0123456789abcdefghij");
-
+  const root = tempRoot("416");
+  await mkdir(root, { recursive: true });
+  const file = join(root, "test.txt");
+  await writeFile(file, CONTENT);
   try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
-      const res = await httpGetRange(url, "bytes=100-200");
-      assert.equal(res.status, 416);
-      assert.equal(res.headers["content-range"], "bytes */20");
-      assert.equal(res.body.length, 0);
-    } finally {
-      server.close();
-    }
+    const res = await runPeek({ path: file, range: "bytes=100-200" });
+    assert.equal(res.statusCode, 416);
+    assert.equal(res.headers["content-range"], "bytes */20");
+    assert.equal(res.body.length, 0);
   } finally {
-    await rm(testDir, { recursive: true, force: true });
-  }
-});
-
-test("/api/peek unranged GET is byte-identical to a plain 200", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-unranged-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  const content = "hello world";
-  await writeFile(testFile, content);
-
-  try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
-      // Explicit no-range GET behaves exactly like the existing 200.
-      const res = await httpGetRange(url, undefined);
-      assert.equal(res.status, 200);
-      assert.equal(res.body.toString(), content);
-      assert.equal(res.headers["content-length"], String(Buffer.byteLength(content)));
-    } finally {
-      server.close();
-    }
-  } finally {
-    await rm(testDir, { recursive: true, force: true });
-  }
-});
-
-test("/api/peek multi-range request degrades to a full 200", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-multirange-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  const content = "0123456789abcdefghij";
-  await writeFile(testFile, content);
-
-  try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
-      const res = await httpGetRange(url, "bytes=0-1,5-6");
-      assert.equal(res.status, 200);
-      assert.equal(res.body.toString(), content);
-    } finally {
-      server.close();
-    }
-  } finally {
-    await rm(testDir, { recursive: true, force: true });
-  }
-});
-
-test("/api/peek plain HEAD still reports the full size with no body (unchanged)", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-head-range-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  const content = "0123456789abcdefghij"; // 20 bytes
-  await writeFile(testFile, content);
-
-  try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const res = await httpHead(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`);
-      assert.equal(res.status, 200, "plain HEAD stays 200 with the full size");
-      assert.equal(res.headers["content-length"], String(Buffer.byteLength(content)));
-      assert.equal(res.body.length, 0, "HEAD must not stream a body");
-    } finally {
-      server.close();
-    }
-  } finally {
-    await rm(testDir, { recursive: true, force: true });
+    await rm(root, { recursive: true, force: true });
   }
 });
 
 test("/api/peek HEAD with a Range reports the slice length with no body", async () => {
-  const testDir = join(homedir(), ".manta-test-peek-head-range2-" + Date.now());
-  await mkdir(testDir, { recursive: true });
-  const testFile = join(testDir, "test.txt");
-  await writeFile(testFile, "0123456789abcdefghij"); // 20 bytes
-
+  const root = tempRoot("head-range");
+  await mkdir(root, { recursive: true });
+  const file = join(root, "test.txt");
+  await writeFile(file, CONTENT);
   try {
-    const { server, port } = await startPeekServer(testDir);
-    try {
-      const req = await new Promise((resolve, reject) => {
-        const r = http.request(
-          `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`,
-          { method: "HEAD", headers: { Range: "bytes=5-9" } },
-          (res) => {
-            const chunks = [];
-            res.on("data", (c) => chunks.push(c));
-            res.on("end", () =>
-              resolve({
-                status: res.statusCode,
-                headers: res.headers,
-                body: Buffer.concat(chunks),
-              }),
-            );
-          },
-        );
-        r.on("error", reject);
-        r.end();
-      });
-      assert.equal(req.status, 206);
-      assert.equal(req.headers["content-range"], "bytes 5-9/20");
-      assert.equal(req.headers["content-length"], "5");
-      assert.equal(req.body.length, 0, "HEAD must not stream a body");
-    } finally {
-      server.close();
-    }
+    const res = await runPeek({ path: file, method: "HEAD", range: "bytes=5-9" });
+    assert.equal(res.statusCode, 206);
+    assert.equal(res.headers["content-range"], "bytes 5-9/20");
+    assert.equal(res.headers["content-length"], "5");
+    assert.equal(res.body.length, 0, "HEAD must not stream a body");
   } finally {
-    await rm(testDir, { recursive: true, force: true });
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek multi-range request degrades to a full 200", async () => {
+  const root = tempRoot("multirange");
+  await mkdir(root, { recursive: true });
+  const file = join(root, "test.txt");
+  await writeFile(file, CONTENT);
+  try {
+    const res = await runPeek({ path: file, range: "bytes=0-1,5-6" });
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.toString(), CONTENT);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek expands ~ to the home directory", async () => {
+  const ts = Date.now();
+  const file = join(homedir(), `.manta-test-peek-home-${ts}.txt`);
+  await writeFile(file, "home file content");
+  try {
+    const res = await runPeek({ path: `~/.manta-test-peek-home-${ts}.txt` });
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.body.toString(), "home file content");
+  } finally {
+    await rm(file, { force: true });
+  }
+});
+
+test("/api/peek serves JSON with the correct content-type", async () => {
+  const root = tempRoot("json");
+  await mkdir(root, { recursive: true });
+  const file = join(root, "data.json");
+  await writeFile(file, '{"key":"value"}');
+  try {
+    const res = await runPeek({ path: file });
+    assert.equal(res.statusCode, 200);
+    assert.equal(res.headers["content-type"], "application/json; charset=utf-8");
+    assert.equal(res.body.toString(), '{"key":"value"}');
+  } finally {
+    await rm(root, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek rejects missing path with 400", async () => {
+  const res = await runPeek({ path: "" });
+  assert.equal(res.statusCode, 400);
+  assert.deepEqual(JSON.parse(res.body.toString()), { error: "path is required" });
+});
+
+test("/api/peek rejects path traversal with 403", async () => {
+  const res = await runPeek({ path: "/etc/passwd" });
+  assert.equal(res.statusCode, 403);
+  assert.deepEqual(JSON.parse(res.body.toString()), { error: "path outside home directory" });
+});
+
+test("/api/peek returns 404 for a non-existent file", async () => {
+  const res = await runPeek({ path: join(homedir(), "nonexistent-file-12345.txt") });
+  assert.equal(res.statusCode, 404);
+  assert.deepEqual(JSON.parse(res.body.toString()), { error: "not found" });
+});
+
+test("/api/peek returns 404 for a directory", async () => {
+  const root = tempRoot("dir");
+  await mkdir(root, { recursive: true });
+  try {
+    const res = await runPeek({ path: root });
+    assert.equal(res.statusCode, 404);
+    assert.deepEqual(JSON.parse(res.body.toString()), { error: "not a file" });
+  } finally {
+    await rm(root, { recursive: true, force: true });
   }
 });

--- a/src/server/peek.test.mjs
+++ b/src/server/peek.test.mjs
@@ -14,6 +14,8 @@ import http from "node:http";
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
 
+import { parseByteRange } from "./range.mjs";
+
 // Helper: make a GET request and return { status, headers, body }
 function httpGet(url) {
   return new Promise((resolve, reject) => {
@@ -48,6 +50,28 @@ function httpHead(url) {
     });
     req.on("error", reject);
     req.end();
+  });
+}
+
+// Helper: make a GET request with the given Range header.
+function httpGetRange(url, range) {
+  return new Promise((resolve, reject) => {
+    const req = http.get(
+      url,
+      { headers: range === undefined ? {} : { Range: range } },
+      (res) => {
+        const chunks = [];
+        res.on("data", (c) => chunks.push(c));
+        res.on("end", () => {
+          resolve({
+            status: res.statusCode,
+            headers: res.headers,
+            body: Buffer.concat(chunks),
+          });
+        });
+      },
+    );
+    req.on("error", reject);
   });
 }
 
@@ -112,10 +136,40 @@ async function startPeekServer(testDir) {
 
           const ext = extname(resolved);
           const contentType = MIME[ext] ?? "application/octet-stream";
-          res.writeHead(200, {
+          const baseHeaders = {
             "content-type": contentType,
-            "content-length": String(s.size),
+            "accept-ranges": "bytes",
             "content-disposition": `inline; filename="${basename(resolved).replace(/"/g, "")}"`,
+          };
+          const range = parseByteRange(req.headers.range ?? null, s.size);
+          if (range === "unsatisfiable") {
+            res.writeHead(416, {
+              ...baseHeaders,
+              "content-range": `bytes */${s.size}`,
+            });
+            res.end();
+            return;
+          }
+          if (range) {
+            const length = range.end - range.start + 1;
+            res.writeHead(206, {
+              ...baseHeaders,
+              "content-range": `bytes ${range.start}-${range.end}/${s.size}`,
+              "content-length": String(length),
+            });
+            if (req.method === "HEAD") {
+              res.end();
+              return;
+            }
+            await pipeline(
+              createReadStream(resolved, { start: range.start, end: range.end }),
+              res,
+            );
+            return;
+          }
+          res.writeHead(200, {
+            ...baseHeaders,
+            "content-length": String(s.size),
           });
           if (req.method === "HEAD") {
             res.end();
@@ -302,5 +356,271 @@ test("/api/peek HEAD returns 404 for non-existent file", async () => {
     assert.equal(res.body.length, 0);
   } finally {
     server.close();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// parseByteRange — pure unit tests (no HTTP, no server)
+// ---------------------------------------------------------------------------
+
+test("parseByteRange: closed range bytes=0-99", () => {
+  assert.deepEqual(parseByteRange("bytes=0-99", 1000), { start: 0, end: 99 });
+});
+
+test("parseByteRange: closed range clamps end to EOF", () => {
+  assert.deepEqual(parseByteRange("bytes=900-2000", 1000), { start: 900, end: 999 });
+});
+
+test("parseByteRange: open-ended range bytes=100-", () => {
+  assert.deepEqual(parseByteRange("bytes=100-", 1000), { start: 100, end: 999 });
+});
+
+test("parseByteRange: suffix range bytes=-100", () => {
+  assert.deepEqual(parseByteRange("bytes=-100", 1000), { start: 900, end: 999 });
+});
+
+test("parseByteRange: suffix larger than file returns whole file", () => {
+  assert.deepEqual(parseByteRange("bytes=-5000", 1000), { start: 0, end: 999 });
+});
+
+test("parseByteRange: start past EOF is unsatisfiable", () => {
+  assert.equal(parseByteRange("bytes=1000-", 1000), "unsatisfiable");
+  assert.equal(parseByteRange("bytes=1001-2000", 1000), "unsatisfiable");
+});
+
+test("parseByteRange: end before start is unsatisfiable", () => {
+  assert.equal(parseByteRange("bytes=50-10", 1000), "unsatisfiable");
+});
+
+test("parseByteRange: zero-length / empty suffix range is unsatisfiable", () => {
+  assert.equal(parseByteRange("bytes=-0", 1000), "unsatisfiable");
+  assert.equal(parseByteRange("bytes=-", 1000), "unsatisfiable");
+});
+
+test("parseByteRange: range on empty file is unsatisfiable", () => {
+  assert.equal(parseByteRange("bytes=0-", 0), "unsatisfiable");
+  assert.equal(parseByteRange("bytes=-1", 0), "unsatisfiable");
+});
+
+test("parseByteRange: absent header returns null", () => {
+  assert.equal(parseByteRange(null, 1000), null);
+  assert.equal(parseByteRange(undefined, 1000), null);
+  assert.equal(parseByteRange("", 1000), null);
+});
+
+test("parseByteRange: unparseable header returns null", () => {
+  assert.equal(parseByteRange("bytes", 1000), null);
+  assert.equal(parseByteRange("bytes=", 1000), null);
+  assert.equal(parseByteRange("items=0-10", 1000), null);
+  assert.equal(parseByteRange("bytes=abc-def", 1000), null);
+  assert.equal(parseByteRange("bytes=0-99 extra", 1000), null);
+});
+
+test("parseByteRange: multi-range request returns null (serve whole file)", () => {
+  assert.equal(parseByteRange("bytes=0-99,300-400", 1000), null);
+});
+
+// ---------------------------------------------------------------------------
+// /api/peek Range behaviour — integration tests against the mock server
+// ---------------------------------------------------------------------------
+
+test("/api/peek advertises accept-ranges on GET and HEAD", async () => {
+  const testDir = join(homedir(), ".manta-test-peek-ranges-" + Date.now());
+  await mkdir(testDir, { recursive: true });
+  const testFile = join(testDir, "test.txt");
+  const content = "0123456789abcdefghij"; // 20 bytes
+  await writeFile(testFile, content);
+
+  try {
+    const { server, port } = await startPeekServer(testDir);
+    try {
+      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
+      const get = await httpGet(url);
+      assert.equal(get.headers["accept-ranges"], "bytes");
+      const head = await httpHead(url);
+      assert.equal(head.headers["accept-ranges"], "bytes");
+    } finally {
+      server.close();
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek ranged GET returns 206 with the correct bytes and content-range", async () => {
+  const testDir = join(homedir(), ".manta-test-peek-range-get-" + Date.now());
+  await mkdir(testDir, { recursive: true });
+  const testFile = join(testDir, "test.txt");
+  const content = "0123456789abcdefghij"; // 20 bytes
+  await writeFile(testFile, content);
+
+  try {
+    const { server, port } = await startPeekServer(testDir);
+    try {
+      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
+      const res = await httpGetRange(url, "bytes=5-9");
+      assert.equal(res.status, 206, `Response body: ${res.body.toString()}`);
+      assert.equal(res.body.toString(), "56789");
+      assert.equal(res.headers["content-range"], "bytes 5-9/20");
+      assert.equal(res.headers["content-length"], "5");
+    } finally {
+      server.close();
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek open-ended ranged GET returns the tail", async () => {
+  const testDir = join(homedir(), ".manta-test-peek-range-open-" + Date.now());
+  await mkdir(testDir, { recursive: true });
+  const testFile = join(testDir, "test.txt");
+  const content = "0123456789abcdefghij"; // 20 bytes
+  await writeFile(testFile, content);
+
+  try {
+    const { server, port } = await startPeekServer(testDir);
+    try {
+      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
+      const res = await httpGetRange(url, "bytes=15-");
+      assert.equal(res.status, 206);
+      assert.equal(res.body.toString(), "fghij");
+      assert.equal(res.headers["content-range"], "bytes 15-19/20");
+      assert.equal(res.headers["content-length"], "5");
+    } finally {
+      server.close();
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek unsatisfiable range returns 416 with bytes */size", async () => {
+  const testDir = join(homedir(), ".manta-test-peek-range-416-" + Date.now());
+  await mkdir(testDir, { recursive: true });
+  const testFile = join(testDir, "test.txt");
+  await writeFile(testFile, "0123456789abcdefghij");
+
+  try {
+    const { server, port } = await startPeekServer(testDir);
+    try {
+      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
+      const res = await httpGetRange(url, "bytes=100-200");
+      assert.equal(res.status, 416);
+      assert.equal(res.headers["content-range"], "bytes */20");
+      assert.equal(res.body.length, 0);
+    } finally {
+      server.close();
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek unranged GET is byte-identical to a plain 200", async () => {
+  const testDir = join(homedir(), ".manta-test-peek-unranged-" + Date.now());
+  await mkdir(testDir, { recursive: true });
+  const testFile = join(testDir, "test.txt");
+  const content = "hello world";
+  await writeFile(testFile, content);
+
+  try {
+    const { server, port } = await startPeekServer(testDir);
+    try {
+      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
+      // Explicit no-range GET behaves exactly like the existing 200.
+      const res = await httpGetRange(url, undefined);
+      assert.equal(res.status, 200);
+      assert.equal(res.body.toString(), content);
+      assert.equal(res.headers["content-length"], String(Buffer.byteLength(content)));
+    } finally {
+      server.close();
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek multi-range request degrades to a full 200", async () => {
+  const testDir = join(homedir(), ".manta-test-peek-multirange-" + Date.now());
+  await mkdir(testDir, { recursive: true });
+  const testFile = join(testDir, "test.txt");
+  const content = "0123456789abcdefghij";
+  await writeFile(testFile, content);
+
+  try {
+    const { server, port } = await startPeekServer(testDir);
+    try {
+      const url = `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`;
+      const res = await httpGetRange(url, "bytes=0-1,5-6");
+      assert.equal(res.status, 200);
+      assert.equal(res.body.toString(), content);
+    } finally {
+      server.close();
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek plain HEAD still reports the full size with no body (unchanged)", async () => {
+  const testDir = join(homedir(), ".manta-test-peek-head-range-" + Date.now());
+  await mkdir(testDir, { recursive: true });
+  const testFile = join(testDir, "test.txt");
+  const content = "0123456789abcdefghij"; // 20 bytes
+  await writeFile(testFile, content);
+
+  try {
+    const { server, port } = await startPeekServer(testDir);
+    try {
+      const res = await httpHead(`http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`);
+      assert.equal(res.status, 200, "plain HEAD stays 200 with the full size");
+      assert.equal(res.headers["content-length"], String(Buffer.byteLength(content)));
+      assert.equal(res.body.length, 0, "HEAD must not stream a body");
+    } finally {
+      server.close();
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
+  }
+});
+
+test("/api/peek HEAD with a Range reports the slice length with no body", async () => {
+  const testDir = join(homedir(), ".manta-test-peek-head-range2-" + Date.now());
+  await mkdir(testDir, { recursive: true });
+  const testFile = join(testDir, "test.txt");
+  await writeFile(testFile, "0123456789abcdefghij"); // 20 bytes
+
+  try {
+    const { server, port } = await startPeekServer(testDir);
+    try {
+      const req = await new Promise((resolve, reject) => {
+        const r = http.request(
+          `http://127.0.0.1:${port}/api/peek?path=${encodeURIComponent(testFile)}`,
+          { method: "HEAD", headers: { Range: "bytes=5-9" } },
+          (res) => {
+            const chunks = [];
+            res.on("data", (c) => chunks.push(c));
+            res.on("end", () =>
+              resolve({
+                status: res.statusCode,
+                headers: res.headers,
+                body: Buffer.concat(chunks),
+              }),
+            );
+          },
+        );
+        r.on("error", reject);
+        r.end();
+      });
+      assert.equal(req.status, 206);
+      assert.equal(req.headers["content-range"], "bytes 5-9/20");
+      assert.equal(req.headers["content-length"], "5");
+      assert.equal(req.body.length, 0, "HEAD must not stream a body");
+    } finally {
+      server.close();
+    }
+  } finally {
+    await rm(testDir, { recursive: true, force: true });
   }
 });

--- a/src/server/range.mjs
+++ b/src/server/range.mjs
@@ -1,0 +1,43 @@
+// Pure HTTP byte-Range parsing for the /api/peek file-serving route —
+// unit-testable with no HTTP, and the streaming code's single branch lives
+// behind it (rather than three inline ones).
+//
+// parseByteRange(header, size) returns one of:
+//   - { start, end }   a satisfiable single `bytes=start-end` range
+//                      (inclusive byte offsets, clamped to the file size)
+//   - "unsatisfiable"  a well-formed range that can never be satisfied
+//                      (start at/past EOF, or a zero-length suffix range)
+//   - null             no Range header, an unparseable header, or a
+//                      multi-range request — the caller must serve the
+//                      whole body as 200 (multi-range is deliberately not
+//                      supported).
+
+export function parseByteRange(header, size) {
+  if (typeof header !== "string" || header.length === 0) return null;
+  const m = /^bytes=(\d*)-(\d*)$/.exec(header.trim());
+  if (!m) return null; // non-bytes unit, multi-range (comma), or malformed
+  const [, startStr, endStr] = m;
+
+  if (startStr === "") {
+    // Suffix range: bytes=-N → the last N bytes (RFC 7233 §2.1).
+    const suffix = endStr === "" ? 0 : Number(endStr);
+    if (!Number.isSafeInteger(suffix) || suffix <= 0) return "unsatisfiable";
+    const take = Math.min(suffix, size);
+    if (take <= 0) return "unsatisfiable"; // empty file, or N === 0
+    return { start: size - take, end: size - 1 };
+  }
+
+  const start = Number(startStr);
+  if (!Number.isSafeInteger(start) || start < 0) return "unsatisfiable";
+  if (start >= size) return "unsatisfiable"; // start past EOF
+
+  if (endStr === "") {
+    // Open-ended range: bytes=start- → to end of file.
+    return { start, end: size - 1 };
+  }
+
+  const end = Number(endStr);
+  if (!Number.isSafeInteger(end)) return "unsatisfiable";
+  if (end < start) return "unsatisfiable";
+  return { start, end: Math.min(end, size - 1) };
+}


### PR DESCRIPTION
## BET-1146 — File serving: Range support + missing image/video MIME types on /api/peek

Extends the existing `/api/peek` route (no second route): adds single-byte HTTP Range support and the missing image/video MIME types to both extension→mime tables.

### Changes
- **`src/server/range.mjs`** (new): pure `parseByteRange(header, size)` → `{start,end}` | `"unsatisfiable"` | `null` (null = absent/unparseable/multi-range → serve whole body). Multi-range deliberately unsupported.
- **`src/server/index.mjs`** `/api/peek` route: advertises `accept-ranges: bytes` on GET + HEAD; satisfiable single range → `206` with `content-range`/`content-length`, streaming the slice via the existing `createReadStream` + `pipeline` (passing `{start,end}`, no in-memory slice); unsatisfiable → `416` with `content-range: bytes */<size>`; absent/unparseable/multi-range → byte-identical 200. HEAD stays bodyless and reports full size. Also added `.jpg/.jpeg/.gif/.webp/.mp4/.webm/.mov/.m4v` to the server `MIME` map.
- **`src/renderer/artifacts.ts`**: added the same video types to `EXT_MIME` so video artifacts classify as media. The two tables serve different consumers and intentionally stay separate (per issue).
- **`src/server/peek.test.mjs`**: `parseByteRange` unit tests (open-ended, closed, suffix, start-past-EOF → unsatisfiable, malformed → null, absent → null, multi-range → null) + route integration tests (206 slice, 416, byte-identical 200, multi-range 200, HEAD unchanged, HEAD-with-range 206).

### Verification results
**Files changed:** 4. `src/server/range.mjs` (new), `src/server/index.mjs`, `src/renderer/artifacts.ts`, `src/server/peek.test.mjs`.

- PR branch (`multica/BET-1146-peek-range-mime` @ `4c316b89`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2398 pass / 0 fail / 0 skip. Failures: none. log sha256: `b4e951d780d31747881779e7bcc22360c63ab248dea7417aa158608a4f44fa07`
- Base (`main` @ `208d7e14`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, 2378 pass / 0 fail / 0 skip. Failures: none. log sha256: `479ec3f25ff575828ebdae8b85a6301c4893263d1518c7480b452ad134922048`
- **Conclusion:** 0 new failures, 0 pre-existing failures. The +20 tests are all new to this PR (parseByteRange unit + route integration).
- **Base: origin/main @ `c0db7e0a`** (branch base; origin/main is 2 commits ahead — neither touches the changed files)
