### PR TITLE
feat(server): inline media tools (media_save/begin/show) + /api/media route (BET-1147)

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -426,3 +426,29 @@ scratch space.
 - **Don't over-create.** Reserve todos for genuinely multi-step work (≈3+
   distinct actions). A single-step request doesn't need a checklist, and a
   wall of noise makes the real items easier to miss.
+
+## manta inline media
+
+You have three `media_*` tools to put a generated image or video INTO the
+transcript, with a correctly-sized placeholder while it is still being
+produced:
+
+- `media_save` — you have media in *some* form (raw base64 bytes, or a file you
+  downloaded with curl). Writes it into the artifact mailbox and measures it,
+  returning the real path + dimensions. Does NOT display it.
+- `media_begin` — call BEFORE a slow generation. Declares the *intended*
+  dimensions so the UI can reserve the exact final space. Returns a handle.
+- `media_show` — call AFTER the media exists, with a local path (+ the handle),
+  to swap the real media in.
+
+**`media_show` takes a LOCAL PATH ONLY.** It never fetches a URL and never
+accepts raw bytes — if you got media as bytes or from a URL, turn it into a
+file first (via `media_save`, or your own `curl`), then pass that file's path.
+The path must be inside the user's home directory.
+
+When generating something slow, call `media_begin` first, then `media_show` with
+the same handle once the file exists. A `media_begin` with no following
+`media_show` fails after 10 minutes (the placeholder is dropped). All three
+forward the current session + message id so the placeholder and artifact land
+on this turn. Install: `cp <repo>/docs/opencode-tools/media.ts
+~/.config/opencode/tools/media.ts` then restart `opencode-serve`.

--- a/docs/opencode-tools/media.ts
+++ b/docs/opencode-tools/media.ts
@@ -1,0 +1,179 @@
+// manta-native `media_save` / `media_begin` / `media_show` tools — global
+// opencode custom tools.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/media.ts ~/.config/opencode/tools/media.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+//
+// These tools are THIN registrars: validate, POST to manta-server
+// (127.0.0.1:8787, same box — no SSH hop), and return promptly. The server
+// owns the write (into the artifact mailbox), the measurement, and the bus
+// events the renderer consumes.
+//
+// See docs/manta-tools-scheduler.md for the general "manta tools" pattern and
+// the inline-media design in the BET-1147 epic.
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one tiny
+// local file) so a token rotation never requires an opencode-serve restart.
+// MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+// POST /api/media and forward the calling session + message id so the server
+// can scope the placeholder + artifact sidecar to this turn.
+async function mediaCall(action: string, args: Record<string, unknown>, context: any): Promise<any> {
+  return call("POST", "/api/media", {
+    ...args,
+    action,
+    sessionID: context.sessionID,
+    messageID: context.messageID,
+  });
+}
+
+export const media_save = tool({
+  description: [
+    "Put an image or video into the transcript as an inline media artifact.",
+    "The model has media in SOME form — either raw base64 bytes it generated,",
+    "or a file it already downloaded with curl (pass its local path as",
+    "sourcePath). The file is written into the artifact mailbox, measured, and",
+    "returned with its real path + dimensions. Exactly one of data or",
+    "sourcePath must be supplied. This does NOT display the media itself —",
+    "call media_show with the returned path to place it in the transcript.",
+  ].join(" "),
+  args: {
+    data: z
+      .string()
+      .optional()
+      .describe(
+        "Base64-encoded bytes of the media (e.g. a generated image). " +
+          "Provide exactly one of data or sourcePath, never both.",
+      ),
+    sourcePath: z
+      .string()
+      .optional()
+      .describe(
+        "Local absolute path to an existing media file on this box (e.g. one " +
+          "you downloaded with curl). Provide exactly one of data or sourcePath.",
+      ),
+    filename: z
+      .string()
+      .optional()
+      .describe(
+        "A filename (with extension) so the mime/type is known. Required when " +
+          "using data; defaulted from sourcePath otherwise.",
+      ),
+  },
+  async execute(args, context) {
+    const result = await mediaCall("save", args, context);
+    const dims = result.width && result.height ? ` ${result.width}x${result.height}` : "";
+    return `Saved media to ${result.path} (${result.mime}${dims}, ${result.size} bytes). Call media_show with that path to put it in the transcript.`;
+  },
+});
+
+export const media_begin = tool({
+  description: [
+    "Declare the INTENDED metadata of an image or video BEFORE a slow ",
+    "generation completes, so the UI can reserve the exact final space for a ",
+    "placeholder. Returns a handle you must keep. After the media is actually ",
+    "produced, call media_show with the handle and the file's local path to ",
+    "swap the real media in. A media_begin with no following media_show fails ",
+    "after 10 minutes.",
+  ].join(" "),
+  args: {
+    kind: z.enum(["image", "video"]).describe("The kind of media being produced."),
+    width: z.number().int().positive().optional().describe("Intended width in px (images)."),
+    height: z.number().int().positive().optional().describe("Intended height in px (images)."),
+    aspectRatio: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Intended aspect ratio (width/height) when exact px are unknown."),
+    count: z.number().int().positive().optional().describe("Number of items (e.g. a carousel)."),
+    title: z.string().optional().describe("Optional short label for the placeholder."),
+  },
+  async execute(args, context) {
+    const result = await mediaCall("begin", args, context);
+    return `Placeholder reserved. Handle: ${result.handle}. Keep it and pass it to media_show once the media file exists.`;
+  },
+});
+
+export const media_show = tool({
+  description: [
+    "Display an existing image or video file in the transcript, swapping it in ",
+    "for a placeholder reserved with media_begin (pass the handle). Accepts a ",
+    "LOCAL PATH ONLY — it never fetches a URL and never accepts raw bytes. If ",
+    "you have media in another form (base64 or a URL), turn it into a file ",
+    "first via media_save or your own curl, then pass that file's path here. ",
+    "The path must be inside the user's home directory.",
+  ].join(" "),
+  args: {
+    path: z
+      .string()
+      .describe(
+        "Local absolute (or ~-prefixed) path to the existing file to display, " +
+          "e.g. the path returned by media_save.",
+      ),
+    handle: z
+      .string()
+      .optional()
+      .describe(
+        "The handle returned by media_begin, when this media had a reserved " +
+          "placeholder. Omit to display a standalone file.",
+      ),
+    title: z.string().optional().describe("Optional short label."),
+  },
+  async execute(args, context) {
+    const result = await mediaCall("show", args, context);
+    const dims = result.width && result.height ? ` ${result.width}x${result.height}` : "";
+    return `Displayed ${result.path} (${result.mime}${dims}, ${result.size} bytes) in the transcript.`;
+  },
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -90,6 +90,11 @@ import { upsertStopped, markStoppedRan, bumpStoppedAttempts } from "./stoppedSto
 import { createUsageStopEngine } from "./usageStopEnroll.mjs";
 import { createUsageResumeEngine } from "./usageResume.mjs";
 import * as appControl from "./appControl.mjs";
+import {
+  dispatch as mediaDispatch,
+  createPendingMediaStore,
+  createMediaSweep,
+} from "./media.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
 import { createPromptDelivery } from "./promptDelivery.mjs";
 import { ensureMantaPlanAgent } from "./providers.mjs";
@@ -887,6 +892,17 @@ void ensureMantaPlanAgent().catch((e) => console.error("[manta-plan] ensure fail
 // eslint-disable-next-line no-unused-vars
 const artifactSweep = createArtifactSweep();
 artifactSweep.start();
+
+// Inline-media orphan poller (BET-1147): in-memory pending placeholders for
+// `media_begin`. A `begin` with no matching `show` after 10 minutes publishes
+// `action:"fail"` and is dropped. Same sweep shape as createArtifactSweep
+// (inFlight guard + timer.unref()). See src/server/media.mjs.
+const mediaPending = createPendingMediaStore();
+const mediaSweep = createMediaSweep({
+  pending: mediaPending,
+  publish: (payload) => bus.publish({ kind: "media", payload }),
+});
+mediaSweep.start();
 
 // Voice-note audio TTL sweep (BET-834): deletes EXPIRED audio files every 5
 // min but KEEPS the records (transcript + waveform outlive the clip), flipping
@@ -2525,6 +2541,38 @@ const handleRequest = async (req, res) => {
         if (result?.ok && body?.action === "rename-session") {
           await syncState.refreshNow();
         }
+        respondJson(res, result.ok ? 200 : 400, result);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      // Errors return a message the model can act on, never a bare 500.
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Inline media ----------
+  // POST /api/media  body {action, sessionID, messageID, ...action-specific}
+  //   → {ok, ...} on success, or {ok:false, error} (400) on a bad request.
+  // Three AI-facing tools with ONE route + an `action` discriminator (save |
+  // begin | show), mirroring /api/app-control:
+  //   save  — write media (base64 blob or existing file) into the artifact
+  //           mailbox and measure it.
+  //   begin — declare INTENDED metadata before a slow generation (returns a
+  //           handle; the orphan poller fails it after 10 min).
+  //   show  — swap in an existing local file (home-only path, measured).
+  // Client-visible placeholder events publish on the bus as ONE kind, `media`,
+  // with the matching `action` discriminator. See src/server/media.mjs.
+  if (path === "/api/media") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const deps = {
+          publish: (payload) => bus.publish({ kind: "media", payload }),
+          pending: mediaPending,
+        };
+        const result = await mediaDispatch(body?.action, body || {}, deps);
         respondJson(res, result.ok ? 200 : 400, result);
         return;
       }

--- a/src/server/media.mjs
+++ b/src/server/media.mjs
@@ -1,0 +1,435 @@
+// media.mjs — inline media server tools (media_save / media_begin / media_show).
+//
+// Lets the AI put a generated image or video INTO the transcript, with a
+// correctly-sized placeholder while it is still being produced. Mirrors
+// src/server/appControl.mjs: pure logic with injected I/O, one `dispatch`
+// switch, client-visible effects published on the bus as ONE kind, `media`,
+// with an `action` discriminator (`begin` | `show` | `fail`). The bus envelope
+// ({ kind:"media", payload }) is added by index.mjs; each function here calls
+// its injected `publish` with the bare payload.
+//
+// Three tools, locked (do not redesign):
+//   - media_save  — the model has media in *some* form (base64 blob, or a file
+//                   it downloaded with curl). Writes it into the artifact
+//                   mailbox (~/.manta-outbox/<sessionID>/) via pushArtifact and
+//                   measures it, returning the real path + metadata.
+//   - media_begin — called BEFORE a slow generation. Declares *intended*
+//                   metadata so the UI can reserve the exact final space.
+//                   Returns a handle.
+//   - media_show  — called AFTER, with a local path (+ the handle). Swaps the
+//                   real media in.
+//
+// media_show accepts ONLY a local path — it never fetches a URL and never
+// accepts raw bytes. The model is responsible for turning whatever it received
+// into a file first (via media_save, or its own curl). This is deliberate: it
+// keeps the display path total and removes any outbound-request decision from
+// the box.
+
+import { readFile, writeFile, rm, mkdtemp } from "node:fs/promises";
+import { homedir as osHomedir, tmpdir } from "node:os";
+import { join, basename, resolve, extname } from "node:path";
+import { randomBytes } from "node:crypto";
+import { pushArtifact as defaultPushArtifact } from "./outbox.mjs";
+
+// A `begin` with no matching `show` publishes `action:"fail"` and is dropped
+// after this long. In-memory only — a placeholder need not survive a restart.
+export const ORPHAN_TIMEOUT_MS = 10 * 60 * 1000;
+export const MEDIA_SWEEP_MS = 30 * 1000;
+
+// Small extension → MIME map for the tools' returns. Video is never measured
+// (see readImageSize) — its mime is still reported from the extension.
+const MIME_BY_EXT = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".avif": "image/avif",
+  ".svg": "image/svg+xml",
+  ".mp4": "video/mp4",
+  ".mov": "video/quicktime",
+  ".webm": "video/webm",
+  ".m4v": "video/x-m4v",
+};
+
+export function guessMime(name) {
+  return MIME_BY_EXT[(extname(name || "") || "").toLowerCase()] ?? "application/octet-stream";
+}
+
+// Opaque 128-bit handle id (matches the box_id token pattern: 32 hex chars).
+export function randomHex() {
+  return randomBytes(16).toString("hex");
+}
+
+// In-memory pending-placeholder store. Handles survival is not required, so an
+// in-memory Map is the whole durability story — no durable store, no JSON file.
+export function createPendingMediaStore() {
+  const map = new Map();
+  return {
+    set(handle, meta) {
+      map.set(handle, { createdAt: Date.now(), ...meta });
+    },
+    get(handle) {
+      return map.get(handle);
+    },
+    delete(handle) {
+      map.delete(handle);
+    },
+    entries() {
+      return [...map.entries()];
+    },
+    size() {
+      return map.size;
+    },
+  };
+}
+
+// Header-only image dimension reader — no new dependency. PNG / JPEG / GIF /
+// WebP → { width, height }; anything else (or truncated/unknown bytes) →
+// null. This is a supported outcome, never a throw. Video is deliberately NOT
+// measured (ffprobe/ffmpeg may not exist on the box); video relies on the
+// metadata declared in media_begin.
+export function readImageSize(buffer) {
+  try {
+    if (!Buffer.isBuffer(buffer) || buffer.length < 8) return null;
+    const b = buffer;
+    // PNG: 8-byte signature, then IHDR width/height as 4-byte BE at 16/20.
+    if (
+      b[0] === 0x89 && b[1] === 0x50 && b[2] === 0x4e && b[3] === 0x47 &&
+      b[4] === 0x0d && b[5] === 0x0a && b[6] === 0x1a && b[7] === 0x0a
+    ) {
+      if (b.length < 24) return null;
+      return { width: b.readUInt32BE(16), height: b.readUInt32BE(20) };
+    }
+    // GIF87a / GIF89a: logical screen descriptor width/height as 2-byte LE at 6/8.
+    if (
+      b[0] === 0x47 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x38 &&
+      (b[4] === 0x37 || b[4] === 0x39) && b[5] === 0x61
+    ) {
+      if (b.length < 10) return null;
+      return { width: b.readUInt16LE(6), height: b.readUInt16LE(8) };
+    }
+    // JPEG: walk markers to the first SOFn segment; height/width as 2-byte BE
+    // right after the 1-byte precision field.
+    if (b[0] === 0xff && b[1] === 0xd8 && b[2] === 0xff) {
+      let i = 2;
+      while (i + 9 <= b.length) {
+        if (b[i] !== 0xff) {
+          i++;
+          continue;
+        }
+        const marker = b[i + 1];
+        // Standalone markers carry no length field.
+        if (marker === 0xd8 || marker === 0xd9 || (marker >= 0xd0 && marker <= 0xd7)) {
+          i += 2;
+          continue;
+        }
+        if (marker === 0xff) {
+          i++;
+          continue;
+        }
+        if (i + 4 > b.length) return null;
+        const segLen = b.readUInt16BE(i + 2);
+        // SOF0..SOF15 except DHT (C4), JPG (C8), DAC (CC).
+        if (
+          marker >= 0xc0 && marker <= 0xcf &&
+          marker !== 0xc4 && marker !== 0xc8 && marker !== 0xcc
+        ) {
+          if (i + 9 > b.length) return null;
+          return { height: b.readUInt16BE(i + 5), width: b.readUInt16BE(i + 7) };
+        }
+        i += 2 + segLen;
+      }
+      return null;
+    }
+    // WebP (RIFF container): branch on the first chunk type.
+    if (
+      b[0] === 0x52 && b[1] === 0x49 && b[2] === 0x46 && b[3] === 0x46 &&
+      b[8] === 0x57 && b[9] === 0x45 && b[10] === 0x42 && b[11] === 0x50
+    ) {
+      const signature = Buffer.from(b.subarray(12, 16)).toString("latin1");
+      if (signature === "VP8X") {
+        if (b.length < 30) return null;
+        return {
+          width: readLE24(b, 24) + 1,
+          height: readLE24(b, 27) + 1,
+        };
+      }
+      if (signature === "VP8L") {
+        if (b.length < 25 || b[20] !== 0x2f) return null;
+        const width = b[21] | ((b[22] & 0x3f) << 8);
+        const height = ((b[22] >> 6) & 0x3) | (b[23] << 2) | ((b[24] & 0x0f) << 10);
+        return { width: width + 1, height: height + 1 };
+      }
+      if (signature === "VP8 ") {
+        if (b.length < 30 || !(b[20] === 0x9d && b[21] === 0x01 && b[22] === 0x2a)) return null;
+        return { width: b.readUInt16LE(26), height: b.readUInt16LE(28) };
+      }
+      return null;
+    }
+    return null;
+  } catch {
+    return null; // truncated / malformed → unsupported, not a throw
+  }
+}
+
+function readLE24(b, offset) {
+  return b[offset] | (b[offset + 1] << 8) | (b[offset + 2] << 16);
+}
+
+// The SAME path rule /api/peek applies (see src/server/peek.mjs): expand a
+// leading `~` / lone `~`, resolve, and require the result to stay inside the
+// user's home directory. Returns the resolved absolute path, or null when the
+// path is outside home (callers reject that with a clear error).
+export function resolvePathWithinHome(raw, home) {
+  if (typeof raw !== "string" || !raw) return null;
+  const base = home.endsWith("/") ? home : home + "/";
+  let resolved;
+  if (raw === "~") resolved = base;
+  else if (raw.startsWith("~/")) resolved = base + raw.slice(2);
+  else resolved = resolve(raw);
+  if (resolved !== base && !resolved.startsWith(base)) return null;
+  return resolved;
+}
+
+async function readForMeasure(filePath, deps) {
+  const read = deps.readFile || readFile;
+  return read(filePath);
+}
+
+// media_save — write media (base64 blob OR an existing local file) into the
+// artifact mailbox and measure it. Exactly one of `data` / `sourcePath` must
+// be supplied. Returns { path, mime, width, height, size } (width/height null
+// when unmeasurable). The write goes through the existing pushArtifact (the
+// artifact mailbox is ~/.manta-outbox/<sessionID>/, swept by the existing
+// expireArtifacts sweep — no new retention, no new folder).
+export async function saveMedia(
+  { data, sourcePath, filename, sessionID, messageID },
+  deps = {},
+) {
+  const write = deps.writeFile || writeFile;
+  const remove = deps.rm || rm;
+  const mkTemp = deps.mkdtemp || mkdtemp;
+  const pushArtifact = deps.pushArtifact || defaultPushArtifact;
+
+  if (!sessionID || typeof sessionID !== "string" || !sessionID.trim()) {
+    return { ok: false, error: "sessionID is required." };
+  }
+  const hasData = typeof data === "string" && data !== "";
+  const hasSource = typeof sourcePath === "string" && sourcePath !== "";
+  if (hasData === hasSource) {
+    return {
+      ok: false,
+      error: hasData
+        ? 'Pass exactly one of "data" (base64) or "sourcePath", not both.'
+        : 'One of "data" (base64) or "sourcePath" is required.',
+    };
+  }
+
+  const displayName =
+    typeof filename === "string" && filename.trim()
+      ? basename(filename)
+      : hasSource
+        ? basename(sourcePath)
+        : "media";
+
+  let measurePath = sourcePath;
+  let tempDir = null;
+  if (hasData) {
+    let buf;
+    try {
+      buf = Buffer.from(data, "base64");
+    } catch {
+      return { ok: false, error: '"data" is not a valid base64 string.' };
+    }
+    if (buf.length === 0) return { ok: false, error: '"data" is empty.' };
+    tempDir = await mkTemp(join(tmpdir(), "manta-media-"));
+    const safeName = displayName.replace(/[^A-Za-z0-9._-]/g, "_") || "media";
+    measurePath = join(tempDir, safeName);
+    await write(measurePath, buf);
+  }
+
+  let measureBuf;
+  try {
+    measureBuf = await readForMeasure(measurePath, deps);
+  } catch (err) {
+    if (tempDir) await remove(tempDir, { recursive: true, force: true }).catch(() => {});
+    return { ok: false, error: srcReadError(hasSource ? sourcePath : measurePath, err) };
+  }
+  const size = measureBuf.length;
+
+  const pushed = await pushArtifact(measurePath, sessionID, {
+    messageID: typeof messageID === "string" && messageID ? messageID : undefined,
+  });
+
+  if (tempDir) await remove(tempDir, { recursive: true, force: true }).catch(() => {});
+
+  if (!pushed?.ok) {
+    return { ok: false, error: pushed?.error ?? "Failed to write into the artifact mailbox." };
+  }
+
+  const dim = readImageSize(measureBuf);
+  const mime = guessMime(displayName);
+  return {
+    ok: true,
+    path: pushed?.row?.path ?? measurePath,
+    mime,
+    width: dim?.width ?? null,
+    height: dim?.height ?? null,
+    size,
+  };
+}
+
+function srcReadError(target, err) {
+  return `Could not read "${target}": ${err?.message ?? err}`;
+}
+
+// media_begin — declare INTENDED metadata before a slow generation so the UI
+// can reserve the exact final space. `kind` is "image" | "video". Returns
+// { handle }; publishes { action:"begin", handle, ... }.
+export async function beginMedia(
+  { kind, width, height, aspectRatio, count, title, sessionID, messageID },
+  deps = {},
+) {
+  const pending = deps.pending;
+  const publish = deps.publish || (() => {});
+  if (kind !== "image" && kind !== "video") {
+    return { ok: false, error: 'kind must be "image" or "video".' };
+  }
+  if (!sessionID || typeof sessionID !== "string" || !sessionID.trim()) {
+    return { ok: false, error: "sessionID is required." };
+  }
+  const handle = randomHex();
+  if (pending) pending.set(handle, { sessionID, messageID: messageID ?? null, kind });
+  publish({
+    action: "begin",
+    handle,
+    sessionID,
+    messageID: messageID ?? null,
+    kind,
+    width: typeof width === "number" ? width : null,
+    height: typeof height === "number" ? height : null,
+    aspectRatio: typeof aspectRatio === "number" ? aspectRatio : null,
+    count: typeof count === "number" ? count : null,
+    title: typeof title === "string" && title ? title : null,
+  });
+  return { ok: true, handle };
+}
+
+// media_show — display an EXISTING local file (the model turned whatever it
+// received into a file first). Validates the path (home-only rule), measures
+// it, publishes { action:"show", ... }; clears the pending entry when a handle
+// is supplied. Works with no handle — the standalone case.
+export async function showMedia(
+  { path, handle, title, sessionID, messageID },
+  deps = {},
+) {
+  const homedir = deps.homedir || osHomedir;
+  const pending = deps.pending;
+  const publish = deps.publish || (() => {});
+  if (typeof path !== "string" || !path.trim()) {
+    return { ok: false, error: 'path is required — pass a local path to an existing file.' };
+  }
+  const resolved = resolvePathWithinHome(path, deps.home ?? homedir());
+  if (!resolved) {
+    return { ok: false, error: "path must be inside the user's home directory." };
+  }
+  let buf;
+  try {
+    buf = await readForMeasure(resolved, deps);
+  } catch (err) {
+    return { ok: false, error: srcReadError(path, err) };
+  }
+  if (handle && pending) pending.delete(handle);
+  const dim = readImageSize(buf);
+  const mime = guessMime(resolved);
+  const payload = {
+    action: "show",
+    path: resolved,
+    handle: handle ?? null,
+    title: typeof title === "string" && title ? title : null,
+    sessionID,
+    messageID: messageID ?? null,
+    mime,
+    width: dim?.width ?? null,
+    height: dim?.height ?? null,
+    size: buf.length,
+  };
+  publish(payload);
+  return { ok: true, ...payload };
+}
+
+// Pure: given the pending store's entries, return the handles whose begin has
+// not been followed by a show within ORPHAN_TIMEOUT_MS. The poller publishes
+// `action:"fail"` and deletes each.
+export function sweepPendingMedia(now, pending, timeoutMs = ORPHAN_TIMEOUT_MS) {
+  const out = [];
+  for (const [handle, entry] of pending.entries()) {
+    if (entry && now - entry.createdAt > timeoutMs) out.push(handle);
+  }
+  return out;
+}
+
+// Thin poller wiring for the box (mirrors createArtifactSweep's shape):
+// inFlight guard + timer.unref(). Publishes `action:"fail"` for each orphaned
+// placeholder and clears it.
+export function createMediaSweep({
+  pending,
+  publish = () => {},
+  intervalMs = MEDIA_SWEEP_MS,
+  now = Date.now,
+} = {}) {
+  let timer = null;
+  let running = false;
+  const sweep = () => {
+    if (running) return;
+    running = true;
+    try {
+      const t = now();
+      for (const handle of sweepPendingMedia(t, pending, ORPHAN_TIMEOUT_MS)) {
+        const entry = pending.get(handle);
+        publish({
+          action: "fail",
+          handle,
+          sessionID: entry?.sessionID ?? null,
+          messageID: entry?.messageID ?? null,
+        });
+        pending.delete(handle);
+      }
+    } finally {
+      running = false;
+    }
+  };
+  return {
+    start() {
+      void sweep();
+      timer = setInterval(() => void sweep(), intervalMs);
+      if (timer.unref) timer.unref();
+    },
+    stop() {
+      if (timer) clearInterval(timer);
+      timer = null;
+    },
+    sweep,
+  };
+}
+
+// Dispatch an /api/media request on its `action` (`save` | `begin` | `show`),
+// mirroring /api/app-control. One switch — action handling never scatters
+// across the route and the module. Returns `{ ok: true, ... }` or `{ ok:
+// false, error }`.
+export async function dispatch(action, body = {}, deps = {}) {
+  switch (action) {
+    case "save":
+      return saveMedia(body, deps);
+    case "begin":
+      return beginMedia(body, deps);
+    case "show":
+      return showMedia(body, deps);
+    default:
+      return {
+        ok: false,
+        error: `unknown action "${action}". Supported actions: save, begin, show.`,
+      };
+  }
+}

--- a/src/server/media.test.mjs
+++ b/src/server/media.test.mjs
@@ -1,0 +1,387 @@
+// Tests for media.mjs pure logic + injected I/O — no live fs, HTTP, or crypto
+// randomness beyond the handle generator. Run via `npm run test:server`.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  readImageSize,
+  guessMime,
+  resolvePathWithinHome,
+  createPendingMediaStore,
+  saveMedia,
+  beginMedia,
+  showMedia,
+  sweepPendingMedia,
+  createMediaSweep,
+  dispatch,
+} from "./media.mjs";
+
+// ---------------------------------------------------------------------------
+// Header builders — hand-crafted valid headers for the four supported formats
+// ---------------------------------------------------------------------------
+
+function pngHdr(width, height) {
+  const b = Buffer.alloc(24);
+  b.write("\x89PNG\r\n\x1a\n", 0, "latin1");
+  b.writeUInt32BE(13, 8);
+  b.write("IHDR", 12, "ascii");
+  b.writeUInt32BE(width, 16);
+  b.writeUInt32BE(height, 20);
+  return b;
+}
+
+function gifHdr(width, height) {
+  const b = Buffer.alloc(10);
+  b.write("GIF89a", 0, "ascii");
+  b.writeUInt16LE(width, 6);
+  b.writeUInt16LE(height, 8);
+  return b;
+}
+
+function jpegHdr(width, height) {
+  const b = Buffer.alloc(11);
+  b[0] = 0xff;
+  b[1] = 0xd8;
+  b[2] = 0xff;
+  b[3] = 0xc0; // SOF0
+  b.writeUInt16BE(8, 4); // segment length
+  b[6] = 8; // precision
+  b.writeUInt16BE(height, 7);
+  b.writeUInt16BE(width, 9);
+  return b;
+}
+
+function webpLossyHdr(width, height) {
+  const b = Buffer.alloc(30);
+  b.write("RIFF", 0, "ascii");
+  b.writeUInt32LE(26, 4);
+  b.write("WEBP", 8, "ascii");
+  b.write("VP8 ", 12, "ascii");
+  b.writeUInt32LE(10, 16);
+  b[20] = 0x9d;
+  b[21] = 0x01;
+  b[22] = 0x2a;
+  b.writeUInt16LE(width, 26);
+  b.writeUInt16LE(height, 28);
+  return b;
+}
+
+// ---------------------------------------------------------------------------
+// readImageSize
+// ---------------------------------------------------------------------------
+
+test("readImageSize: valid PNG/JPEG/GIF/WebP headers → correct dimensions", () => {
+  assert.deepEqual(readImageSize(pngHdr(640, 480)), { width: 640, height: 480 });
+  assert.deepEqual(readImageSize(jpegHdr(800, 600)), { width: 800, height: 600 });
+  assert.deepEqual(readImageSize(gifHdr(320, 200)), { width: 320, height: 200 });
+  assert.deepEqual(readImageSize(webpLossyHdr(1024, 768)), { width: 1024, height: 768 });
+});
+
+test("readImageSize: unknown bytes → null", () => {
+  assert.equal(readImageSize(Buffer.from("totally not an image", "latin1")), null);
+  assert.equal(readImageSize(Buffer.from([0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c])), null);
+});
+
+test("readImageSize: truncated input → null, never a throw", () => {
+  assert.equal(readImageSize(Buffer.alloc(0)), null);
+  assert.equal(readImageSize(Buffer.alloc(3)), null);
+  // PNG signature but no IHDR body.
+  assert.equal(readImageSize(Buffer.from("\x89PNG\r\n\x1a\n", "latin1")), null);
+  // GIF signature but no screen descriptor.
+  assert.equal(readImageSize(Buffer.from("GIF89a", "latin1")), null);
+  // JPEG with SOI only.
+  assert.equal(readImageSize(Buffer.from([0xff, 0xd8, 0xff])), null);
+  // WebP lossy with start code but truncated dims.
+  assert.equal(readImageSize(webpLossyHdr(100, 100).subarray(0, 25)), null);
+});
+
+test("readImageSize: non-buffer input → null", () => {
+  assert.equal(readImageSize("not a buffer"), null);
+  assert.equal(readImageSize(null), null);
+  assert.equal(readImageSize(undefined), null);
+});
+
+// ---------------------------------------------------------------------------
+// guessMime
+// ---------------------------------------------------------------------------
+
+test("guessMime maps known extensions and falls back to octet-stream", () => {
+  assert.equal(guessMime("photo.png"), "image/png");
+  assert.equal(guessMime("clip.MP4"), "video/mp4");
+  assert.equal(guessMime("a.webm"), "video/webm");
+  assert.equal(guessMime("unknown.xyz"), "application/octet-stream");
+  assert.equal(guessMime(""), "application/octet-stream");
+});
+
+// ---------------------------------------------------------------------------
+// resolvePathWithinHome (the /api/peek home-only rule)
+// ---------------------------------------------------------------------------
+
+const HOME = "/home/alice";
+
+test("resolvePathWithinHome: accepts a path inside home", () => {
+  assert.equal(resolvePathWithinHome("/home/alice/img.png", HOME), "/home/alice/img.png");
+  assert.equal(resolvePathWithinHome("/home/alice/dir/img.png", HOME), "/home/alice/dir/img.png");
+});
+
+test("resolvePathWithinHome: accepts a leading ~ (lone and prefixed)", () => {
+  assert.equal(resolvePathWithinHome("~/img.png", HOME), "/home/alice/img.png");
+  assert.equal(resolvePathWithinHome("~", HOME), "/home/alice/");
+});
+
+test("resolvePathWithinHome: rejects a path outside home", () => {
+  assert.equal(resolvePathWithinHome("/etc/passwd", HOME), null);
+  assert.equal(resolvePathWithinHome("/home/alicex/stuff", HOME), null);
+  assert.equal(resolvePathWithinHome("/", HOME), null);
+});
+
+test("resolvePathWithinHome: rejects empty / non-string input", () => {
+  assert.equal(resolvePathWithinHome("", HOME), null);
+  assert.equal(resolvePathWithinHome(null, HOME), null);
+  assert.equal(resolvePathWithinHome(undefined, HOME), null);
+});
+
+// ---------------------------------------------------------------------------
+// saveMedia
+// ---------------------------------------------------------------------------
+
+function saveHarness({ file = jpegHdr(200, 100) } = {}) {
+  const pushed = [];
+  const writes = [];
+  const deps = {
+    readFile: async () => file,
+    writeFile: async (p, buf) => writes.push([p, buf]),
+    rm: async () => {},
+    mkdtemp: async () => "/tmp/fake-media-dir",
+    tmpdir: () => "/tmp",
+    pushArtifact: async (path, sid, opts) => {
+      pushed.push({ path, sid, opts });
+      return { ok: true, row: { path: `/home/alice/.manta-outbox/${sid}/img.jpeg`, name: "img.jpeg", size: file.length } };
+    },
+  };
+  return { pushed, writes, deps };
+}
+
+test("saveMedia: accepts data (base64) and returns measured metadata", async () => {
+  const { pushed, writes, deps } = saveHarness({ file: pngHdr(300, 200) });
+  const r = await saveMedia(
+    { data: pngHdr(300, 200).toString("base64"), filename: "gen.png", sessionID: "s1", messageID: "m1" },
+    deps,
+  );
+  assert.equal(r.ok, true);
+  assert.equal(r.mime, "image/png");
+  assert.equal(r.width, 300);
+  assert.equal(r.height, 200);
+  assert.equal(writes.length, 1); // decoded blob staged to temp
+  assert.equal(pushed.length, 1);
+  assert.equal(pushed[0].sid, "s1");
+  assert.deepEqual(pushed[0].opts, { messageID: "m1" });
+});
+
+test("saveMedia: accepts sourcePath (existing file) as-is", async () => {
+  const { pushed, deps } = saveHarness({ file: gifHdr(50, 25) });
+  const r = await saveMedia({ sourcePath: "/home/alice/gif.gif", sessionID: "s2" }, deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.mime, "image/gif");
+  assert.equal(r.width, 50);
+  assert.equal(r.height, 25);
+  assert.equal(pushed[0].path, "/home/alice/gif.gif");
+});
+
+test("saveMedia: unmeasurable data returns null dimensions (video), not an error", async () => {
+  const { deps } = saveHarness({ file: Buffer.from("plain videobytes", "latin1") });
+  const r = await saveMedia({ data: Buffer.from("plain videobytes", "latin1").toString("base64"), filename: "clip.mp4", sessionID: "s3" }, deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.mime, "video/mp4");
+  assert.equal(r.width, null);
+  assert.equal(r.height, null);
+});
+
+test("saveMedia: rejects when both data AND sourcePath are given", async () => {
+  const { deps } = saveHarness();
+  const r = await saveMedia({ data: "abc", sourcePath: "/x", sessionID: "s" }, deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /not both/);
+});
+
+test("saveMedia: rejects when neither data nor sourcePath is given", async () => {
+  const { deps } = saveHarness();
+  const r = await saveMedia({ sessionID: "s" }, deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /data.*sourcePath.*is required/);
+});
+
+test("saveMedia: requires sessionID", async () => {
+  const { deps } = saveHarness();
+  const r = await saveMedia({ data: "aGVsbG8=" }, deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /sessionID is required/);
+});
+
+// ---------------------------------------------------------------------------
+// showMedia — path validation + publish
+// ---------------------------------------------------------------------------
+
+function showHarness({ home = "/home/alice", file = jpegHdr(120, 80) } = {}) {
+  const published = [];
+  const pending = createPendingMediaStore();
+  const deps = {
+    home,
+    readFile: async () => file,
+    pending,
+    publish: (payload) => published.push(payload),
+  };
+  return { published, pending, deps };
+}
+
+test("showMedia: rejects a path outside home", async () => {
+  const { published, deps } = showHarness();
+  const r = await showMedia({ path: "/etc/passwd", sessionID: "s" }, deps);
+  assert.equal(r.ok, false);
+  assert.match(r.error, /inside the user's home/);
+  assert.equal(published.length, 0);
+});
+
+test("showMedia: accepts a path inside home and measures it", async () => {
+  const { published, deps } = showHarness();
+  const r = await showMedia({ path: "/home/alice/img.jpeg", sessionID: "s" }, deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.width, 120);
+  assert.equal(r.height, 80);
+  assert.equal(published[0].action, "show");
+  assert.equal(published[0].width, 120);
+  assert.equal(published[0].height, 80);
+});
+
+test("showMedia: accepts a leading ~", async () => {
+  const { published, deps } = showHarness();
+  const r = await showMedia({ path: "~/img.jpeg", sessionID: "s" }, deps);
+  assert.equal(r.ok, true);
+  assert.equal(r.path, "/home/alice/img.jpeg");
+  assert.equal(r.width, 120);
+  assert.equal(published[0].path, "/home/alice/img.jpeg");
+});
+
+test("showMedia: with no handle still publishes a show payload", async () => {
+  const { published, pending, deps } = showHarness();
+  const r = await showMedia({ path: "/home/alice/img.jpeg", sessionID: "s" }, deps);
+  assert.equal(r.ok, true);
+  assert.equal(published.length, 1);
+  assert.equal(published[0].action, "show");
+  assert.equal(published[0].handle, null);
+  assert.equal(pending.size(), 0); // nothing to clear, no throw
+});
+
+// ---------------------------------------------------------------------------
+// beginMedia → showMedia with handle clears the pending entry
+// ---------------------------------------------------------------------------
+
+test("beginMedia → showMedia with handle clears the pending entry", async () => {
+  const pending = createPendingMediaStore();
+  const published = [];
+  const deps = { pending, publish: (p) => published.push(p) };
+  const begin = await beginMedia({ kind: "image", width: 800, height: 600, title: "hero", sessionID: "s", messageID: "m" }, deps);
+  assert.equal(begin.ok, true);
+  assert.match(begin.handle, /^[0-9a-f]{32}$/);
+  assert.equal(pending.size(), 1);
+
+  const seen = published.filter((p) => p.action === "begin");
+  assert.equal(seen.length, 1);
+  assert.equal(seen[0].handle, begin.handle);
+  assert.equal(seen[0].action, "begin");
+  assert.equal(seen[0].kind, "image");
+  assert.equal(seen[0].width, 800);
+  assert.equal(seen[0].title, "hero");
+
+  const showDeps = { pending, publish: (p) => published.push(p), home: "/home/alice", readFile: async () => pngHdr(800, 600) };
+  const show = await showMedia({ path: "/home/alice/img.png", handle: begin.handle, sessionID: "s" }, showDeps);
+  assert.equal(show.ok, true);
+  assert.equal(pending.size(), 0); // cleared
+  const shows = published.filter((p) => p.action === "show");
+  assert.equal(shows.length, 1);
+  assert.equal(shows[0].handle, begin.handle);
+});
+
+test("beginMedia: rejects a non image/video kind", async () => {
+  const pending = createPendingMediaStore();
+  const r = await beginMedia({ kind: "audio", sessionID: "s" }, { pending });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /image.*video/);
+  assert.equal(pending.size(), 0);
+});
+
+// ---------------------------------------------------------------------------
+// sweepPendingMedia / createMediaSweep — 10-minute orphan rule
+// ---------------------------------------------------------------------------
+
+test("sweepPendingMedia: returns only entries older than 10 minutes", () => {
+  const pending = createPendingMediaStore();
+  const age = (ms) => ({ createdAt: ms, sessionID: "s" });
+  pending.set("old", age(Date.now() - 11 * 60 * 1000));
+  pending.set("border", age(Date.now() - 10 * 60 * 1000));
+  pending.set("fresh", age(Date.now() - 1000));
+
+  const expired = sweepPendingMedia(Date.now(), pending);
+  assert.deepEqual([...expired].sort(), ["old"]);
+});
+
+test("createMediaSweep: publishes fail for orphans and clears them", () => {
+  const pending = createPendingMediaStore();
+  const published = [];
+  let fakeNow = Date.now();
+  const sweep = createMediaSweep({
+    pending,
+    publish: (p) => published.push(p),
+    now: () => fakeNow,
+    intervalMs: 1000,
+  });
+  const handle = "a".repeat(32);
+  pending.set(handle, { createdAt: fakeNow - 11 * 60 * 1000, sessionID: "s", messageID: "m" });
+
+  sweep.sweep();
+  assert.equal(published.length, 1);
+  assert.equal(published[0].action, "fail");
+  assert.equal(published[0].handle, handle);
+  assert.equal(published[0].sessionID, "s");
+  assert.equal(pending.size(), 0);
+
+  // Fresh entry survives a sweep.
+  pending.set("fresh", { createdAt: fakeNow, sessionID: "s" });
+  sweep.sweep();
+  assert.equal(pending.get("fresh") !== undefined, true);
+});
+
+// ---------------------------------------------------------------------------
+// dispatch — one switch, unknown action rejected by name
+// ---------------------------------------------------------------------------
+
+test("dispatch: rejects an unknown action by name", async () => {
+  const r = await dispatch("explode", {}, {});
+  assert.equal(r.ok, false);
+  assert.match(r.error, /unknown action "explode"/);
+  assert.match(r.error, /save, begin, show/);
+});
+
+test("dispatch: routes the three known actions", async () => {
+  const pending = createPendingMediaStore();
+  const published = [];
+  const deps = {
+    pending,
+    publish: (p) => published.push(p),
+    home: "/home/alice",
+    readFile: async () => pngHdr(10, 10),
+    writeFile: async () => {},
+    rm: async () => {},
+    mkdtemp: async () => "/tmp/fd",
+    pushArtifact: async (p, sid) => ({ ok: true, row: { path: p, name: "x.png", size: 1 } }),
+  };
+  const begin = await dispatch("begin", { kind: "image", sessionID: "s" }, deps);
+  assert.equal(begin.ok, true);
+  const show = await dispatch("show", { path: "/home/alice/x.png", handle: begin.handle, sessionID: "s" }, deps);
+  assert.equal(show.ok, true);
+  const save = await dispatch("save", { data: pngHdr(10, 10).toString("base64"), filename: "x.png", sessionID: "s" }, deps);
+  assert.equal(save.ok, true);
+
+  const actions = published.map((p) => p.action);
+  assert.deepEqual(actions, ["begin", "show"]);
+});


### PR DESCRIPTION
## What

Server half of inline media: three AI-facing tools let a model put a generated image/video into the transcript, with a correctly-sized placeholder while it is still being produced.

- **`src/server/media.mjs`** (new) — pure module + injected I/O, mirroring `appControl.mjs`. One `dispatch(action,...)` switch over `save | begin | show`; `readImageSize` (PNG/JPEG/GIF/WebP from headers, no new dep); `resolvePathWithinHome` (the same home-only rule `/api/peek` applies); `createPendingMediaStore` (in-memory only) + `sweepPendingMedia`/`createMediaSweep` (10-min orphan timeout, `action:"fail"`, inFlight guard + `timer.unref()`).
- **`src/server/index.mjs`** — ONE `POST /api/media` route with an `action` discriminator (mirrors `/api/app-control`), wired to `media.dispatch` with `{ publish: (p) => bus.publish({kind:"media", payload:p}) }`; orphan poller started next to the other pollers. Unknown action → 400 naming the valid actions.
- **`docs/opencode-tools/media.ts`** (new) — `media_save` / `media_begin` / `media_show`, boxToken()/authHeaders() copied verbatim, forwards `context.sessionID` + `context.messageID`.
- **`docs/opencode-tools/AGENTS.md`** — short "manta inline media" section.

## Locked design honored

- `media_save` writes into the existing artifact mailbox `~/.manta-outbox/<sessionID>/` via the existing `pushArtifact`; no new retention, no new folder, no durable store.
- `media_show` accepts only a local path (home-only); never fetches a URL, never accepts raw bytes.
- Image dimensions measured by a header reader; unknown → `null` (supported outcome). Video deliberately NOT measured (relies on `media_begin` metadata).
- Pending placeholders in-memory only; 10-min orphan timeout publishes `fail`.
- No renderer changes (that's the sibling issue).

## Tests — `src/server/media.test.mjs` (25, pure/injected only)

readImageSize (PNG/JPEG/GIF/WebP, unknown→null, truncated→null-no-throw), saveMedia (accepts data / accepts sourcePath / rejects both / rejects neither / requires sessionID), showMedia (rejects outside home, accepts inside, accepts `~`, no-handle publishes), begin→show clears pending, sweepPendingMedia >10min only, createMediaSweep publishes fail, dispatch (unknown action + all three routed). Bus payload shape asserted for `begin` and `show` (`save` correctly produces no bus event).

**Verification results:**
- `npm run typecheck` — exit 0, no errors.
- `npm test` — 2418 pass / 0 fail.
- `npm run test:server` — 1908 pass / 0 fail.

Note: `auditJobsConcurrency`, `capabilities`, `forge/*`, `forgeRules`, `pairPage`, `providers`, `pty`, `rpc` test suites are timing-flaky on this box — they fail intermittently on clean `origin/main` too (verified in a detached worktree) and are not related to this change.

**Base:** origin/main @ `7057bd60`