### PR TITLE
fix(renderer): 'the box' -> 'the server', app-leg 'Manta UI' -> 'Desktop app' in update wording (BET-1150)

### DIFF
--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -1506,7 +1506,7 @@ describe("chooseUpdateSkewVariant", () => {
 describe("describeUpdateTarget", () => {
   const target = (over: Partial<UpdateTarget>): UpdateTarget => ({
     id: "desktop",
-    label: "Manta UI",
+    label: "Desktop app",
     current: null,
     latest: null,
     available: false,

--- a/src/shared/updateTargets.mjs
+++ b/src/shared/updateTargets.mjs
@@ -11,8 +11,8 @@
 
 // Fixed labels and disruption values for the two non-CLI targets. The CLI ones
 // come from the catalog and ride through `serverCheck.targets` unchanged.
-const DESKTOP_FIXED = { label: "Manta UI", disruption: "app-restart" };
-const SERVER_FIXED = { label: "The box", disruption: "reconnect" };
+const DESKTOP_FIXED = { label: "Desktop app", disruption: "app-restart" };
+const SERVER_FIXED = { label: "The server", disruption: "reconnect" };
 
 /**
  * Build the canonical UpdateTarget[] from the two update-check results.
@@ -139,7 +139,7 @@ export function describeUpdateBanner(targets, { mandatory = false, failure = nul
 
   if (mandatory) {
     return {
-      text: "Manta UI must be updated to keep working with this box",
+      text: "Desktop app must be updated to keep working with this server",
       actionLabel: "Update",
       tone: "accent",
       dismissible: false,
@@ -207,10 +207,10 @@ export function planUpdateAll(targets) {
       "Updating opencode restarts it, which ends every agent turn currently running. Any unsaved work in a running turn is lost.",
     );
   } else if (hasReconnect) {
-    confirmBody.push("The box will restart briefly and reconnect on its own.");
+    confirmBody.push("The server will restart briefly and reconnect on its own.");
   }
   if (hasAppRestart) {
-    confirmBody.push("Manta UI will restart itself once the box is done.");
+    confirmBody.push("Desktop app will restart itself once the server is done.");
   }
 
   return {

--- a/src/shared/updateTargets.test.ts
+++ b/src/shared/updateTargets.test.ts
@@ -42,7 +42,7 @@ describe("buildUpdateTargets", () => {
     const desktop = result[0];
     expect(desktop).toMatchObject({
       id: "desktop",
-      label: "Manta UI",
+      label: "Desktop app",
       latest: "0.0.37",
       available: true,
       ok: true,
@@ -88,7 +88,7 @@ describe("buildUpdateTargets", () => {
     const server = result[1];
     expect(server).toMatchObject({
       id: "server",
-      label: "The box",
+      label: "The server",
       current: "0.0.36",
       latest: "0.0.37",
       available: true,
@@ -240,7 +240,7 @@ describe("describeUpdateBanner", () => {
 
   it("failure outranks mandatory and every count", () => {
     const banner = describeUpdateBanner(
-      [t("desktop", "Manta UI", true)],
+      [t("desktop", "Desktop app", true)],
       { mandatory: true, failure: "permission denied" },
     );
     expect(banner?.tone).toBe("danger");
@@ -250,7 +250,7 @@ describe("describeUpdateBanner", () => {
   it("mandatory → accent, NON-dismissible, must-update copy", () => {
     const banner = describeUpdateBanner([], { mandatory: true, failure: null });
     expect(banner).toEqual({
-      text: "Manta UI must be updated to keep working with this box",
+      text: "Desktop app must be updated to keep working with this server",
       actionLabel: "Update",
       tone: "accent",
       dismissible: false,
@@ -258,7 +258,7 @@ describe("describeUpdateBanner", () => {
   });
 
   it("mandatory renders even with no targets available", () => {
-    const banner = describeUpdateBanner([t("desktop", "Manta UI", false)], {
+    const banner = describeUpdateBanner([t("desktop", "Desktop app", false)], {
       mandatory: true,
       failure: null,
     });
@@ -266,7 +266,7 @@ describe("describeUpdateBanner", () => {
   });
 
   it("exactly one available → '<label> has an update available' for every target", () => {
-    for (const label of ["Manta UI", "The box", "opencode", "Claude Code", "Codex", "Kimi Code"]) {
+    for (const label of ["Desktop app", "The server", "opencode", "Claude Code", "Codex", "Kimi Code"]) {
       const banner = describeUpdateBanner([t("claude", label, true)], {
         mandatory: false,
         failure: null,
@@ -282,11 +282,11 @@ describe("describeUpdateBanner", () => {
 
   it("two available → 'N updates available · names' in display order", () => {
     const banner = describeUpdateBanner(
-      [t("desktop", "Manta UI", true), t("server", "The box", true, false, "reconnect")],
+      [t("desktop", "Desktop app", true), t("server", "The server", true, false, "reconnect")],
       { mandatory: false, failure: null },
     );
     expect(banner).toEqual({
-      text: "2 updates available · Manta UI, The box",
+      text: "2 updates available · Desktop app, The server",
       actionLabel: "Update all",
       tone: "accent",
       dismissible: true,
@@ -296,31 +296,31 @@ describe("describeUpdateBanner", () => {
   it("three available → all three names", () => {
     const banner = describeUpdateBanner(
       [
-        t("desktop", "Manta UI", true),
-        t("server", "The box", true, false, "reconnect"),
+        t("desktop", "Desktop app", true),
+        t("server", "The server", true, false, "reconnect"),
         t("opencode", "opencode", true, false, "ends-turns"),
       ],
       { mandatory: false, failure: null },
     );
-    expect(banner?.text).toBe("3 updates available · Manta UI, The box, opencode");
+    expect(banner?.text).toBe("3 updates available · Desktop app, The server, opencode");
   });
 
   it("past three names → keep first three and append '+N more'", () => {
     const banner = describeUpdateBanner(
       [
-        t("desktop", "Manta UI", true),
-        t("server", "The box", true, false, "reconnect"),
+        t("desktop", "Desktop app", true),
+        t("server", "The server", true, false, "reconnect"),
         t("opencode", "opencode", true, false, "ends-turns"),
         t("claude", "Claude Code", true),
       ],
       { mandatory: false, failure: null },
     );
-    expect(banner?.text).toBe("4 updates available · Manta UI, The box, opencode +1 more");
+    expect(banner?.text).toBe("4 updates available · Desktop app, The server, opencode +1 more");
   });
 
   it("zero available → null (no banner)", () => {
     const banner = describeUpdateBanner(
-      [t("desktop", "Manta UI", false), t("server", "The box", false)],
+      [t("desktop", "Desktop app", false), t("server", "The server", false)],
       { mandatory: false, failure: null },
     );
     expect(banner).toBeNull();
@@ -328,7 +328,7 @@ describe("describeUpdateBanner", () => {
 
   it("manual targets never count as available", () => {
     const banner = describeUpdateBanner(
-      [t("desktop", "Manta UI", true, true), t("server", "The box", false)],
+      [t("desktop", "Desktop app", true, true), t("server", "The server", false)],
       { mandatory: false, failure: null },
     );
     expect(banner).toBeNull();
@@ -364,8 +364,8 @@ describe("planUpdateAll", () => {
       needsConfirm: true,
     });
     expect(plan.confirmBody).toEqual([
-      "The box will restart briefly and reconnect on its own.",
-      "Manta UI will restart itself once the box is done.",
+      "The server will restart briefly and reconnect on its own.",
+      "Desktop app will restart itself once the server is done.",
     ]);
   });
 
@@ -387,7 +387,7 @@ describe("planUpdateAll", () => {
     // restart), but app-restart still appears.
     expect(plan.confirmBody).toEqual([
       "Updating opencode restarts it, which ends every agent turn currently running. Any unsaved work in a running turn is lost.",
-      "Manta UI will restart itself once the box is done.",
+      "Desktop app will restart itself once the server is done.",
     ]);
   });
 
@@ -404,7 +404,7 @@ describe("planUpdateAll", () => {
     expect(plan.desktopDownload).toBe(true);
     expect(plan.box).toBe(false);
     expect(plan.needsConfirm).toBe(true);
-    expect(plan.confirmBody).toEqual(["Manta UI will restart itself once the box is done."]);
+    expect(plan.confirmBody).toEqual(["Desktop app will restart itself once the server is done."]);
   });
 
   it("manual targets never count toward any leg", () => {
@@ -420,6 +420,6 @@ describe("planUpdateAll", () => {
 
   it("app-restart alone does NOT suppress the reconnect sentence (no ends-turns)", () => {
     const plan = planUpdateAll([t("server", true, false, "reconnect")]);
-    expect(plan.confirmBody).toEqual(["The box will restart briefly and reconnect on its own."]);
+    expect(plan.confirmBody).toEqual(["The server will restart briefly and reconnect on its own."]);
   });
 });


### PR DESCRIPTION
BET-1150 — Wording (desktop Settings → About): "the box" → "the server" + app-leg "Manta UI" → "Desktop app"

## What changed

Renamed the user-facing update strings in the desktop Settings → About update
surface per the issue glossary:

- Server leg: "The box" → "The server" (the About update-list row label, plus
  the confirm copy "The box will restart briefly…" → "The server will restart
  briefly…").
- App leg: "Manta UI" → "Desktop app" (the desktop update-target row label,
  the mandatory banner "Manta UI must be updated…" → "Desktop app must be
  updated…", and "Manta UI will restart itself once the box is done." →
  "Desktop app will restart itself once the server is done.").

The product brand is kept where it is not the update target (e.g. the macOS
permission prompt, the notification title in `App.tsx`).

## Scope note (important — read before reviewing)

The issue's "Known literal strings" point at `describeDesktopUpdate` /
`describeServerUpdate` in `src/renderer/chatUtils.ts`. Those functions no
longer exist on `main`: the unified-update epic (BET-1096/1098, already merged
before this issue ran) replaced them with `describeUpdateTarget` and relocated
the per-target labels + confirm/banner copy into **`src/shared/updateTargets.mjs`**
(`DESKTOP_FIXED`/`SERVER_FIXED` labels, `describeUpdateBanner`, `planUpdateAll`).

So the strings this issue owns physically live in `src/shared/updateTargets.mjs`
+ its test now, not in the three files the issue listed. I edited those two, plus
the desktop fixture label in `src/renderer/chatUtils.test.ts` (the only update
wording left in the scoped files). This is the only way to actually change what
the About surface displays — a change confined to the listed three files would
have been a no-op. The `App.tsx` strings the issue lists (busyLabel, "This server
(v…)", "Update the server?") were already converted to "server" on `main` by
prior bonded wording work, so no `App.tsx` change was needed.

`_verify_ note_:` the `src/shared/types.ts` type comment enumerating allowed
labels (`// "Manta UI" | "The box" …`) is a code comment and was left untouched
per the issue's do-not-touch-comments rule.

**Files changed:** `3` files. `src/renderer/chatUtils.test.ts`, `src/shared/updateTargets.mjs`, `src/shared/updateTargets.test.ts`.

**Base: origin/main @ `7057bd60`**

**Verification results:**
- PR branch (`multica/BET-1150-about-box-wording` @ `0b689334`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 2393 pass / 0 fail / 0 skip across 71 suites (incl. `updateTargets.test.ts` 30/30).
- Base (`main` @ `7057bd60`):
  - Not re-run: this PR is pure string-literal edits (no logic, no types), and the PR branch is green with zero failures, so a base re-run would be byte-identical.
- **Conclusion:** 0 failures; change is output-text only.
