### PR TITLE
BET-1152: Hover-marquee for truncated session names

### DIFF
--- a/src/renderer/MarqueeLabel.tsx
+++ b/src/renderer/MarqueeLabel.tsx
@@ -1,0 +1,69 @@
+// MarqueeLabel — a reusable hover-marquee text label for truncated names.
+//
+// Renders an overflow-clipping outer span (the clip) containing one nowrap
+// inner span (the text). When the inner text is wider than the clip (i.e. it
+// WOULD truncate), hovering the clip slides the text on a loop with a dwell at
+// each end. When not hovered — or not truncated, or reduced-motion — the inner
+// span has transform:none, so the title ALWAYS reads from the start (R1). The
+// animation is applied only under :hover in index.css, so lifting the pointer
+// snaps the text back to the start by construction; there is no scroll offset
+// to remember or reset.
+
+import {
+  useLayoutEffect,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ReactNode,
+} from "react";
+
+const CLIP = "overflow-hidden";
+const INNER = "manta-marquee-inner inline-block whitespace-nowrap";
+
+export function MarqueeLabel({
+  children,
+  className = "",
+  title,
+}: {
+  /** The text (or a ReactNode) to show. */
+  children: ReactNode;
+  /** Applied to the OUTER clip span — carries the caller's flex/sizing/typography. */
+  className?: string;
+  /** Full-text tooltip, forwarded to the clip span (omit when the row already has one). */
+  title?: string;
+}) {
+  const clipRef = useRef<HTMLSpanElement>(null);
+  const innerRef = useRef<HTMLSpanElement>(null);
+  const [shift, setShift] = useState(0);
+  const [over, setOver] = useState(false);
+
+  useLayoutEffect(() => {
+    const clip = clipRef.current;
+    const inner = innerRef.current;
+    if (!clip || !inner) return;
+    const measure = () => {
+      const w = inner.scrollWidth - clip.clientWidth;
+      setShift(Math.max(0, w));
+      setOver(w > 0);
+    };
+    measure();
+    if (typeof ResizeObserver === "undefined") return; // jsdom / environments without RO
+    const ro = new ResizeObserver(measure);
+    ro.observe(clip);
+    ro.observe(inner);
+    return () => ro.disconnect();
+  }, [children]);
+
+  return (
+    <span
+      ref={clipRef}
+      title={title}
+      className={`${CLIP}${over ? " manta-marquee" : ""} ${className}`}
+      style={over ? ({ "--marquee-shift": `${shift}px` } as CSSProperties) : undefined}
+    >
+      <span ref={innerRef} className={INNER}>
+        {children}
+      </span>
+    </span>
+  );
+}

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -50,6 +50,7 @@ import { Callout } from "./Callout";
 import { ForgeMark, hasForgeMark } from "./ForgeMark";
 import { Dropdown, MenuItem } from "./MenuItem";
 import { Popover } from "./Popover";
+import { MarqueeLabel } from "./MarqueeLabel";
 import { ConfirmModal } from "./ConfirmModal";
 
 // Cache-segment colors for the header pill.
@@ -392,12 +393,12 @@ export function SessionHeader({
             many workspaces, and the branch alone does not identify one. It is
             not decoration, and nothing else in the desktop chrome carries it. */}
       {crumb && (
-        <span
-          className="text-label text-text-faint shrink-0 truncate max-w-[200px]"
+        <MarqueeLabel
+          className="text-label text-text-faint shrink-0 max-w-[200px]"
           title={crumb}
         >
           {crumb}
-        </span>
+        </MarqueeLabel>
       )}
 
       {/* Branch chip — session state, at the `sm` tag density so it reads as

--- a/src/renderer/SessionRow.test.tsx
+++ b/src/renderer/SessionRow.test.tsx
@@ -240,4 +240,12 @@ describe("SessionRow — one line: dot · name · age", () => {
     expect(el.className).toContain("relative");
     expect(el.className).toContain("z-[1]");
   });
+
+  it("marquee: true wraps the name in the MarqueeLabel clip and still renders the text", () => {
+    h = mount(<SessionRow status="idle" name="Add CSV export" marquee />);
+    const el = h.container.firstElementChild as HTMLElement;
+    const name = el.firstElementChild!.nextElementSibling as HTMLElement;
+    expect(name.className).toContain("overflow-hidden");
+    expect(name.textContent).toBe("Add CSV export");
+  });
 });

--- a/src/renderer/SessionRow.tsx
+++ b/src/renderer/SessionRow.tsx
@@ -40,6 +40,8 @@
 
 import type { ReactNode } from "react";
 
+import { MarqueeLabel } from "./MarqueeLabel";
+
 export type SessionStatus = "run" | "att" | "idle" | "ok" | "default" | "halted";
 
 // The row container. `group` is the identity hook for the call site's
@@ -107,6 +109,9 @@ const DOT: Record<SessionStatus, string> = {
 const NAME_REST = "flex-1 min-w-0 truncate text-label font-medium text-text-muted";
 const NAME_SELECTED = "flex-1 min-w-0 truncate text-label font-semibold text-text";
 
+const NAME_MARQUEE = "flex-1 min-w-0 text-label font-medium text-text-muted";
+const NAME_MARQUEE_SELECTED = "flex-1 min-w-0 text-label font-semibold text-text";
+
 // Age `.age`: mono tabular numerals, right-aligned, never shrinks. `ageStale`
 // hides the slot at rest and reveals it on row hover (visibility-preserving,
 // so revealing it shifts nothing).
@@ -115,6 +120,7 @@ const AGE_CHROME = "shrink-0 min-w-[20px] text-right font-mono tabular-nums text
 export function SessionRow({
   status,
   selected = false,
+  marquee = false,
   child = false,
   lastChild = false,
   name,
@@ -133,6 +139,8 @@ export function SessionRow({
   status: SessionStatus;
   /** `.on` — `--raised` surface + the C3 marker. */
   selected?: boolean;
+  /** marquee: true wraps the name in MarqueeLabel (hover-slide for truncated text). */
+  marquee?: boolean;
   /** `.child` — 26px indent + the `left:13px` tree connectors. */
   child?: boolean;
   /** Last child in its group — the trunk stops at the elbow instead of
@@ -178,7 +186,13 @@ export function SessionRow({
       className={row}
     >
       <span className={`${DOT_BASE} ${DOT[status]}`} title={statusTitle} aria-hidden="true" />
-      <span className={selected ? NAME_SELECTED : NAME_REST}>{name}</span>
+      {marquee ? (
+        <MarqueeLabel className={selected ? NAME_MARQUEE_SELECTED : NAME_MARQUEE}>
+          {name}
+        </MarqueeLabel>
+      ) : (
+        <span className={selected ? NAME_SELECTED : NAME_REST}>{name}</span>
+      )}
       <span className={AGE_CHROME + (ageStale ? " invisible group-hover:visible" : " visible")}>
         {age}
       </span>

--- a/src/renderer/Sidebar.tsx
+++ b/src/renderer/Sidebar.tsx
@@ -1253,6 +1253,7 @@ function WindowRow({
               </span>
             )
           }
+          marquee={!isRenaming}
           age={age.text}
           ageStale={age.stale}
           trailing={<PinSlot pinned={pinned} onToggle={onTogglePin} />}
@@ -1301,6 +1302,7 @@ function JobChildRow({
           child
           lastChild={lastChild}
           name={w.name}
+          marquee
           age={age.text}
           ageStale={age.stale}
           title={title}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -359,3 +359,22 @@ html, body, #root {
     background: var(--raised);
   }
 }
+
+/* MarqueeLabel — hover-slide for truncated names (see MarqueeLabel.tsx).
+   The animation runs ONLY while the clip is hovered. Its absence when not
+   hovered is what snaps the text back to the start (the element reverts to
+   translateX(0) = the title from the beginning). --marquee-shift is set inline
+   by the component to the overflow width in px. Reduced-motion: static. */
+@keyframes manta-marquee {
+  0%   { transform: translateX(0); }
+  28%  { transform: translateX(var(--marquee-shift, 0px)); }
+  62%  { transform: translateX(var(--marquee-shift, 0px)); }
+  80%  { transform: translateX(0); }
+  100% { transform: translateX(0); }
+}
+.manta-marquee:hover .manta-marquee-inner {
+  animation: manta-marquee 9s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .manta-marquee:hover .manta-marquee-inner { animation: none; }
+}


### PR DESCRIPTION
## Hover-marquee for truncated session names

Adds **one** shared `MarqueeLabel` component (CSS-only hover-slide for truncated text, snap-to-start on exit by construction) and wires it into:

1. Sidebar session rows (`SessionRow` via `marquee` prop — `WindowRow` and `JobChildRow` in `Sidebar.tsx`)
2. Chat-header breadcrumb (`SessionHeader.tsx`)

Short names never move (`over` gate in the component); reduced-motion yields a static label. While a window is being renamed the row shows the input, not the marquee (`marquee={!isRenaming}`). No new state, no IPC, no server changes; `marquee` defaults to `false` so existing rendering and tests are byte-identical.

Non-goals respected: the ⌘K palette `SessionRow`, project group headers, and `DraftRow` are untouched; `SessionRow` gets no `className` prop.

**Verification results:**
- PR branch (`multica/BET-1152-hover-marquee` @ `044448ae`):
  - typecheck: exit 0, no errors. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, vitest 3116 pass / 7 skip + node 2418 pass / 0 fail. log sha256: `6c3818b90387e81c994f36a99201c101a42c3db8642ca1918cc186ef6f70eb5f`
- Base (`main` @ `d08395d6`):
  - typecheck: exit 0, no errors. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, vitest 3144 pass / 7 skip + node 2418 pass / 0 fail. log sha256: `124cb5ffef98c2531711ea76adfd5ad1ada0a218be397905a7475f8ce65984b9`
- **Conclusion:** 0 new failures; the test-log hashes differ only because `main` has since gained tests from other merged PRs, not from this change. Both branches fully green.

**Base:** origin/main @ `ce59a2df`
