### PR TITLE
MarqueeLabel follow-up: RTL loop, ellipsis at rest, fade cutoff (BET-1154)

### DIFF
--- a/src/renderer/MarqueeLabel.tsx
+++ b/src/renderer/MarqueeLabel.tsx
@@ -18,7 +18,7 @@ import {
 } from "react";
 
 const CLIP = "overflow-hidden";
-const INNER = "manta-marquee-inner inline-block whitespace-nowrap";
+const INNER = "manta-marquee-inner inline-block whitespace-nowrap max-w-full overflow-hidden text-ellipsis";
 
 export function MarqueeLabel({
   children,

--- a/src/renderer/SessionRow.test.tsx
+++ b/src/renderer/SessionRow.test.tsx
@@ -248,4 +248,14 @@ describe("SessionRow — one line: dot · name · age", () => {
     expect(name.className).toContain("overflow-hidden");
     expect(name.textContent).toBe("Add CSV export");
   });
+
+  it("marquee: true ellipsizes the inner text at rest", () => {
+    h = mount(<SessionRow status="idle" name="Add CSV export" marquee />);
+    const el = h.container.firstElementChild as HTMLElement;
+    const clip = el.firstElementChild!.nextElementSibling as HTMLElement;
+    const inner = clip.firstElementChild as HTMLElement;
+    expect(inner.className).toContain("text-ellipsis");
+    expect(inner.className).toContain("overflow-hidden");
+    expect(inner.className).toContain("max-w-full");
+  });
 });

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -360,21 +360,39 @@ html, body, #root {
   }
 }
 
-/* MarqueeLabel — hover-slide for truncated names (see MarqueeLabel.tsx).
-   The animation runs ONLY while the clip is hovered. Its absence when not
-   hovered is what snaps the text back to the start (the element reverts to
-   translateX(0) = the title from the beginning). --marquee-shift is set inline
-   by the component to the overflow width in px. Reduced-motion: static. */
+/* MarqueeLabel — RTL hover-loop for truncated names (see MarqueeLabel.tsx).
+   The animation runs ONLY while the clip is hovered, so lifting the pointer
+   reverts to transform:none = the title reads from the start (no scroll state
+   to remember). --marquee-shift is the overflow width in px (set inline by the
+   component); --marquee-gap adds breathing room so the tail fully clears the
+   clip instead of stopping flush against it. At rest the inner caps at 100% of
+   the clip and ellipsizes (...); both are removed while animating so the whole
+   name scrolls. Reduced-motion: a static ellipsized label. */
 @keyframes manta-marquee {
   0%   { transform: translateX(0); }
-  28%  { transform: translateX(var(--marquee-shift, 0px)); }
-  62%  { transform: translateX(var(--marquee-shift, 0px)); }
-  80%  { transform: translateX(0); }
+  35%  { transform: translateX(calc(-1 * (var(--marquee-shift, 0px) + var(--marquee-gap, 24px)))); }
+  65%  { transform: translateX(calc(-1 * (var(--marquee-shift, 0px) + var(--marquee-gap, 24px)))); }
+  90%  { transform: translateX(0); }
   100% { transform: translateX(0); }
 }
 .manta-marquee:hover .manta-marquee-inner {
+  max-width: none;
+  overflow: visible;
+  text-overflow: clip;
   animation: manta-marquee 9s linear infinite;
 }
+/* Slight fade at the right (cutoff) edge while animating — scoped to :hover
+   so the resting label never fades. */
+.manta-marquee:hover {
+  -webkit-mask-image: linear-gradient(to left, transparent 0, #000 18px);
+  mask-image: linear-gradient(to left, transparent 0, #000 18px);
+}
 @media (prefers-reduced-motion: reduce) {
-  .manta-marquee:hover .manta-marquee-inner { animation: none; }
+  .manta-marquee:hover .manta-marquee-inner {
+    max-width: 100%;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    animation: none;
+  }
+  .manta-marquee:hover { mask-image: none; }
 }


### PR DESCRIPTION
RTL hover-marquee loop, ellipsis at rest, and fade-cutoff for the MarqueeLabel (follow-up to PR #1154).

**Requirement E finding:** the session-header breadcrumb (`SessionHeader.tsx`) already marquees when wider than the 200px cap — its `MarqueeLabel` clip carries `overflow-hidden` + `shrink-0` + `max-w-[200px]`, and an `overflow:hidden` flex item computes its automatic minimum to zero with `max-w` capping the used width at 200px, so `inner.scrollWidth > clip.clientWidth` fires correctly. **No `min-w-0` change was needed** and per the issue I did not alter `SessionHeader.tsx` (only permitted when it fails to trigger).

**Files changed:** 3
- `src/renderer/MarqueeLabel.tsx` — `INNER` gains `max-w-full overflow-hidden text-ellipsis` (only change; measurement/`over`/`shift` untouched).
- `src/renderer/index.css` — single replacement block: RTL keyframes (`--marquee-shift` + `--marquee-gap`), `:hover` uncaps the inner + gradient mask, reduced-motion static-ellipsized label.
- `src/renderer/SessionRow.test.tsx` — new structural test `marquee: true ellipsizes the inner text at rest`.

Non-goals respected: no second marquee impl, no `className` prop on `SessionRow`, no ⌘K/group-header/DraftRow/Sidebar/rename changes, no server/iOS changes.

Base: origin/main @ cf6ce69b
