### PR TITLE
BET-1155: feat(server): suppress agentFile toast for inline-media files (tag-and-skip outbox)

### DIFF
--- a/src/server/media.mjs
+++ b/src/server/media.mjs
@@ -260,6 +260,7 @@ export async function saveMedia(
 
   const pushed = await pushArtifact(measurePath, sessionID, {
     messageID: typeof messageID === "string" && messageID ? messageID : undefined,
+    media: true,
   });
 
   if (tempDir) await remove(tempDir, { recursive: true, force: true }).catch(() => {});

--- a/src/server/media.test.mjs
+++ b/src/server/media.test.mjs
@@ -175,7 +175,7 @@ test("saveMedia: accepts data (base64) and returns measured metadata", async () 
   assert.equal(writes.length, 1); // decoded blob staged to temp
   assert.equal(pushed.length, 1);
   assert.equal(pushed[0].sid, "s1");
-  assert.deepEqual(pushed[0].opts, { messageID: "m1" });
+  assert.deepEqual(pushed[0].opts, { messageID: "m1", media: true });
 });
 
 test("saveMedia: accepts sourcePath (existing file) as-is", async () => {

--- a/src/server/outbox.mjs
+++ b/src/server/outbox.mjs
@@ -3,9 +3,9 @@
 // The box (server IS the box) keeps a durable, workspace-linked mailbox of
 // files the remote AI sends the user. The AI drops a file under
 // ~/.manta-outbox/<sessionID>/ (its opencode session id — the workspace) via
-// the `send_file` tool; a local scanner surfaces it to connected devices as an
-// `agentFile` bus event (the "AI sent you a file" toast). Detection is a plain
-// local `readdir`.
+// the `send_file` tool (or the inline-media tools); a local scanner surfaces
+// it to connected devices as an `agentFile` bus event (the "AI sent you a
+// file" toast). Detection is a plain local `readdir`.
 //
 // Durability semantics (reconciled with the old one-shot mailbox):
 //   - WORKSPACE-LINKED: files live in a subdir named by the opencode session
@@ -124,6 +124,7 @@ async function statRow(path, name, sessionID, now) {
       expiresAt,
       messageID:
         typeof meta.messageID === "string" && meta.messageID ? meta.messageID : null,
+      media: meta.media === true,
     };
   } catch {
     return {
@@ -134,6 +135,7 @@ async function statRow(path, name, sessionID, now) {
       mtime: 0,
       expiresAt: null,
       messageID: null,
+      media: false,
     };
   }
 }
@@ -144,7 +146,7 @@ async function statRow(path, name, sessionID, now) {
 export async function pushArtifact(
   filePath,
   sessionID,
-  { root = defaultOutboxRoot(), ttlHours, messageID } = {},
+  { root = defaultOutboxRoot(), ttlHours, messageID, media } = {},
 ) {
   if (!sessionID || typeof sessionID !== "string" || !sessionID.trim()) {
     return { ok: false, error: "sessionID is required" };
@@ -168,6 +170,7 @@ export async function pushArtifact(
     const meta = {};
     if (msgId) meta.messageID = msgId;
     if (ttlHours != null) meta.expiresAt = resolveExpiry(ttlHours, st.mtimeMs);
+    if (media) meta.media = true;
     await writeSidecar(sidecarPath(dest), meta);
   }
   const row = await statRow(dest, safe, sessionID, Date.now());
@@ -277,6 +280,7 @@ export function createOutboxScanner(bus, root) {
       }
       for (const entry of entries) {
         if (seen.has(entry.path)) continue;
+        if (entry.media === true) continue;
         seen.add(entry.path);
         bus.publish({
           kind: "agentFile",

--- a/src/server/outbox.test.mjs
+++ b/src/server/outbox.test.mjs
@@ -326,3 +326,77 @@ test("pushArtifact ignores a blank/absent messageID (no empty sidecar written)",
     await rm(src, { force: true });
   }
 });
+
+test("pushArtifact with media:true tags the sidecar; listOutbox exposes media true", async () => {
+  const root = await makeOutbox();
+  const src = join(root, "..", "src-media.png");
+  await writeFile(src, "img\n");
+  try {
+    const res = await pushArtifact(src, "ses_m", { root, media: true, messageID: "msg-media" });
+    assert.equal(res.ok, true);
+    assert.equal(res.row.media, true, "row returned to tool carries the tag");
+    const listed = await listOutbox(root, { sessionID: "ses_m" });
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].media, true, "persisted tag survives listOutbox round-trip");
+    assert.equal(listed[0].messageID, "msg-media", "messageID still present alongside the tag");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(src, { force: true });
+  }
+});
+
+test("pushArtifact without media:true exposes media false", async () => {
+  const root = await makeOutbox();
+  const src = join(root, "..", "src-plain.png");
+  await writeFile(src, "img\n");
+  try {
+    const res = await pushArtifact(src, "ses_p", { root });
+    assert.equal(res.ok, true);
+    assert.equal(res.row.media, false, "ordinary push is untagged");
+    const listed = await listOutbox(root, { sessionID: "ses_p" });
+    assert.equal(listed.length, 1);
+    assert.equal(listed[0].media, false);
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(src, { force: true });
+  }
+});
+
+test("scanner publishes NO agentFile event for a media-tagged row", async () => {
+  const root = await makeOutbox();
+  const bus = fakeBus();
+  const src = join(root, "..", "img-media.png");
+  await writeFile(src, "img\n");
+  try {
+    await pushArtifact(src, "ses_m", { root, media: true, messageID: "m1" });
+    const { tick } = createOutboxScanner(bus, root);
+    await tick();
+    await tick();
+    assert.equal(fileEvents(bus).length, 0, "media file never announced");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(src, { force: true });
+  }
+});
+
+test("scanner announces an untagged row alongside a media-tagged one", async () => {
+  const root = await makeOutbox();
+  const bus = fakeBus();
+  const srcMedia = join(root, "..", "img-a.png");
+  const srcPlain = join(root, "..", "doc-b.pdf");
+  await writeFile(srcMedia, "img\n");
+  await writeFile(srcPlain, "pdf\n");
+  try {
+    await pushArtifact(srcMedia, "ses_m", { root, media: true, messageID: "m1" });
+    await pushArtifact(srcPlain, "ses_p", { root });
+    const { tick } = createOutboxScanner(bus, root);
+    await tick();
+    const evs = fileEvents(bus);
+    assert.equal(evs.length, 1, "only the untagged file is announced");
+    assert.equal(evs[0].payload.name, "doc-b.pdf");
+  } finally {
+    await rm(root, { recursive: true, force: true });
+    await rm(srcMedia, { force: true });
+    await rm(srcPlain, { force: true });
+  }
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1725,6 +1725,8 @@ export type OutboxFile = {
   mtime: number;
   expiresAt: number | null;
   messageID: string | null;
+  // true when pushed by the inline-media tools; suppress the agentFile toast
+  media?: boolean;
 };
 
 // Input shape for secretsSet (UI → store). The value travels renderer → IPC →


### PR DESCRIPTION
## What

Server-only: stop the redundant "AI sent you a file · Save" toast for files shown **inline** in the transcript via the media tools. The inline media is already visible in the chat, so the outbox `agentFile` toast is suppressed — for those files only. Ordinary `send_file` pushes keep toasting exactly as today.

Uses the **tag-and-skip** approach: media-pushed artifacts are tagged `media: true` in the existing per-file outbox sidecar (a `pushArtifact` `media` option), exposed on every row by `statRow`/`listOutbox`, and the outbox scanner skips tagged rows before the seen-set. No new directory, retention policy, watcher, or module.

- `src/server/outbox.mjs` — `pushArtifact` gains an optional `media` option (writes `meta.media = true` into the same sidecar it already builds, without changing the write-condition); `statRow` exposes `media` on success and fallback rows; `createOutboxScanner.tick()` skips media-tagged rows before `seen.add`. File header note extended (was "`send_file` tool") to mention the media tools.
- `src/server/media.mjs` — `saveMedia` passes `media: true` to `pushArtifact`.
- `src/shared/types.ts` — `OutboxFile.media?: boolean` addend with a comment. No renderer/toast/`AgentFileReady` changes.

## Verification results

PR branch (`multica/BET-1155-tag-and-skip-outbox` @ `3f7b581`):
- typecheck: exit 0. Errors: none.
- test: exit 0, 2422 pass / 0 fail / 0 skip.
- New/updated tests: `pushArtifact media:true` tags + round-trips; untagged exposes `media:false`; scanner publishes NO `agentFile` for a media row; scanner still announces an untagged row beside a media one; `saveMedia` passes `media:true` through to pushArtifact.

**Base: origin/main @ c1f92a95** (branched from `c1f92a95`).

Conclusion: 0 new failures (full suite green). The only failures seen mid-run were environmental — before `npm ci` populated `node_modules`, `tsc` was not on PATH (~9 unrelated forge/audit test files failed purely from missing deps); once dependencies were installed the entire suite passed 2422/2422.
