### PR TITLE
BET-1158: fix(scripts): resolve NODE_CMD + CLI PATH so self-update upgrades AI CLIs on no-runtime boxes

### DIFF
--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -4900,6 +4900,83 @@ test("self-update.sh does NOT restart opencode — that would kill in-flight age
   );
 });
 
+// ----------------------------------------------------------------------------
+// scripts/self-update.sh — NODE_CMD / CLI-PATH resolution (BET-1158).
+// ----------------------------------------------------------------------------
+//
+// A git-checkout box has no $MANTA_HOME/runtime/node/bin, so NODE_CMD falls
+// back to whatever node is on PATH. BET-1158: the old fallback was the bare
+// literal `node`, and the `[ -x "$NODE_CMD" ]` guard then ran `-x node` — a
+// CWD-relative filesystem test that is false even when node is on PATH — so
+// every CLI upgrade was silently skipped ("node unavailable"). The fallback
+// must resolve to an ABSOLUTE path via `command -v node`, and the CLI install
+// dirs (~/.local/bin, ~/.opencode/bin, ~/.bun/bin) must be prepended to PATH
+// so upgrade-clis.mjs's by-name upgrade commands resolve. Both tests run the
+// REAL shipped block out of the actual script against a fake box layout, so a
+// regression in the shipped source is what goes red.
+function runSelfUpdateSnippet(block, pre = "", extra = "") {
+  const dir = mkdtempSync(join(tmpdir(), "manta-selfupd-snip-"));
+  const path = join(dir, "snippet.sh");
+  writeFileSync(path, `set -euo pipefail\n${pre}\n${block}\n${extra}\n`, { mode: 0o755 });
+  try {
+    const res = spawnSync("bash", [path], { encoding: "utf8", env: process.env });
+    return `${res.stdout ?? ""}${res.stderr ?? ""}EXIT=${res.status}`;
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
+test("self-update.sh NODE_CMD: no-runtime box resolves node to an absolute path so the CLI-upgrade guard passes (BET-1158)", () => {
+  const src = scriptFile("self-update.sh");
+  const start = src.indexOf('if [ -x "$MANTA_HOME/runtime/node/bin/node" ]; then');
+  assert.ok(start !== -1, "self-update.sh must resolve NODE_CMD against the vendored runtime first");
+  const end = src.indexOf("\n\n", start);
+  assert.ok(end !== -1, "NODE_CMD resolution block must be followed by a blank line");
+  const block = src.slice(start, end);
+
+  const fakeHome = mkdtempSync(join(tmpdir(), "manta-no-runtime-")); // no runtime/node/bin
+  try {
+    const out = runSelfUpdateSnippet(
+      block,
+      `MANTA_HOME="${fakeHome}"`,
+      'if [ -n "$NODE_CMD" ] && [ -x "$NODE_CMD" ]; then echo "GUARD_OK"; else echo "GUARD_SKIP"; fi',
+    );
+    assert.match(out, /GUARD_OK/, "the -x guard must pass when node is on PATH but not vendored");
+    assert.doesNotMatch(out, /GUARD_SKIP/);
+  } finally {
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
+test("self-update.sh prepends AI CLI install dirs to PATH for the upgrade step (BET-1158)", () => {
+  const src = scriptFile("self-update.sh");
+  const start = src.indexOf('if [ -n "${HOME:-}" ]; then');
+  assert.ok(start !== -1, "self-update.sh must prepend CLI install dirs to PATH");
+  const end = src.indexOf("\n\n", start);
+  assert.ok(end !== -1, "CLI-dirs PATH block must be followed by a blank line");
+  const block = src.slice(start, end);
+
+  const fakeHome = mkdtempSync(join(tmpdir(), "manta-cli-home-"));
+  try {
+    mkdirSync(join(fakeHome, ".local", "bin"), { recursive: true });
+    mkdirSync(join(fakeHome, ".opencode", "bin"), { recursive: true });
+    const out = runSelfUpdateSnippet(
+      block,
+      `HOME="${fakeHome}"`,
+      [
+        'case ":$PATH:" in *":$HOME/.local/bin:"*) echo "LOCAL_BIN=1";; *) echo "LOCAL_BIN=0";; esac',
+        'case ":$PATH:" in *":$HOME/.opencode/bin:"*) echo "OPENCODE_BIN=1";; *) echo "OPENCODE_BIN=0";; esac',
+        'case ":$PATH:" in *":$HOME/.bun/bin:"*) echo "BUN_BIN=1";; *) echo "BUN_BIN=0";; esac',
+      ].join("\n"),
+    );
+    assert.match(out, /LOCAL_BIN=1/, "~/.local/bin (claude) must be on PATH for the upgrade step");
+    assert.match(out, /OPENCODE_BIN=1/, "~/.opencode/bin (opencode) must be on PATH for the upgrade step");
+    assert.match(out, /BUN_BIN=0/, "an absent dir (~/.bun/bin here) must NOT be added to PATH");
+  } finally {
+    rmSync(fakeHome, { recursive: true, force: true });
+  }
+});
+
 test("install.sh writes service-read config files via install_root_file, never `sudo -n mv` (BET-440)", () => {
   // BET-440 outage: the marker-replace branch staged the new Caddyfile in a
   // mktemp file then moved it into place with `sudo -n mv`. mktemp(1) makes

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -88,7 +88,13 @@ fi
 if [ -x "$MANTA_HOME/runtime/node/bin/node" ]; then
   NODE_CMD="$MANTA_HOME/runtime/node/bin/node"
 else
-  NODE_CMD="node"
+  # No vendored runtime (a git-checkout box runs whatever Node is on PATH).
+  # Resolve to an ABSOLUTE path: the `[ -x "$NODE_CMD" ]` guard below is a real
+  # filesystem test, and with the bare `node` fallback that guard ran `-x node`
+  # against CWD — false even when node is on PATH, so every CLI upgrade was
+  # silently skipped (BET-1158). `|| true` yields empty on a genuinely missing
+  # node, which the guard correctly treats as "not available".
+  NODE_CMD="$(command -v node || true)"
 fi
 
 # Put the box's OWN vendored runtime FIRST on PATH (BET-829). install.sh does
@@ -110,6 +116,23 @@ fi
 # vendored runtime (it runs whatever Node is on PATH, by design).
 if [ -d "$MANTA_HOME/runtime/node/bin" ]; then
   PATH="$MANTA_HOME/runtime/node/bin:$PATH"
+  export PATH
+fi
+
+# --- Put the AI CLIs on PATH for the upgrade step (BET-1158) ------------------
+# upgrade-clis.mjs spawns each installed CLI's upgrade command BY NAME
+# (`opencode upgrade`, `claude update`, …) and those binaries live in
+# ~/.local/bin (claude), ~/.opencode/bin (opencode) and ~/.bun/bin — dirs that
+# a ~/.bashrc adds but a systemd/launchd service's minimal PATH never carries.
+# Prepend the same home-relative set resolveBinary() in
+# src/server/cliUpdates.mjs searches so the upgrade commands resolve. A
+# packaged box already got its vendored runtime/node/bin above; these are the
+# user-level dirs that apply to every box kind.
+if [ -n "${HOME:-}" ]; then
+  for _cli_dir in "$HOME/.local/bin" "$HOME/.opencode/bin" "$HOME/.bun/bin"; do
+    [ -d "$_cli_dir" ] || continue
+    PATH="$_cli_dir:$PATH"
+  done
   export PATH
 fi
 


### PR DESCRIPTION
## What

Fixes `scripts/self-update.sh` silently skipping every AI CLI upgrade on boxes whose runtime isn't vendored under `$MANTA_HOME/runtime/node/bin` (any git-checkout box).

**Root cause (BET-1158):** with no vendored runtime, `NODE_CMD` fell back to the bare literal `node`, and the `[ -x "$NODE_CMD" ]` guard ran `-x node` — a CWD-relative filesystem test, NOT a PATH lookup. It was false even when node was on PATH, so every CLI upgrade was skipped (the box's self-update log showed `⚠ self-update: node unavailable — skipping CLI upgrades` while `npm ci` ran fine moments later).

**Fix (shell-only):**
1. Resolve the fallback to an absolute path via `command -v node` (`NODE_CMD="$(command -v node || true)"`) so the `-x` guard and the invocation agree. `|| true` yields empty on a genuinely missing node, which the guard already treats as "not available".
2. Prepend the CLI install dirs (`~/.local/bin`, `~/.opencode/bin`, `~/.bun/bin`) to `PATH` for the upgrade step — `upgrade-clis.mjs` spawns each CLI's upgrade command **by name** and a systemd/launchd service's minimal PATH never carries those dirs. Same home-relative set `resolveBinary()` in `src/server/cliUpdates.mjs` searches.

Verified with `bash -n`. node-pty/build unrelated.

## Anti-spaghetti

Single root-cause site: the `NODE_CMD` fallback + the upgrade step's PATH. Fixed at the source; no call-site band-aid. Relation to the existing vendored-runtime PATH pinning (BET-829): kept separate/adjacent, both guard on dir existence.

## Tests

Two new regression tests in `scripts/install.test.mjs` that run the **real shipped block** out of `self-update.sh` against a fake box layout:
- `NODE_CMD`: a no-runtime box (node on PATH) now passes the `-x` guard → CLI upgrades run (old bare-`node` fallback made it skip).
- CLI dirs: `~/.local/bin` + `~/.opencode/bin` are prepended to PATH; an absent dir (`~/.bun/bin`) is correctly skipped.

**Files changed:** 2. `scripts/self-update.sh`, `scripts/install.test.mjs`

**Verification results:**
- PR branch (`multica/BET-1158-self-update-node-fallback` @ `677bea64`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9…`
  - test: exit 0, 2424 pass / 0 fail / 0 skip. Failures: none. log sha256: `2f7a28bc…`
- Base (`main` @ `e461eb75`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9…`
  - test: exit 0, 2422 pass / 0 fail / 0 skip. Failures: none. log sha256: `13a01937…`
- **Conclusion:** `+2` tests (the new BET-1158 regression tests), `0` new failures, `0` pre-existing failures. Both suites green.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

Base: origin/main @ `e461eb75`
