### PR TITLE
chore(release): 0.0.38 — desktop + server, unblock the secret scan

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -66,6 +66,7 @@ paths = [
   '''src/main/installer/knownHosts\.test\.ts''',
   '''src/main/installer/installer\.test\.ts''',
   '''src/main/auth\.test\.ts''',
+  '''src/main/download\.test\.ts''',
   '''src/server/local\.test\.mjs''',
   '''src/server/push\.test\.mjs''',
   '''src/server/devices\.test\.mjs''',

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.36",
+  "version": "0.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.36",
+      "version": "0.0.38",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.36",
+  "version": "0.0.38",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.36",
+ "version": "0.0.38",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Cuts the 0.0.38 release line and unblocks CI.

## Version bump 0.0.36 -> 0.0.38

`mac-v0.0.37` was pushed **without** a version bump, so it rebuilt and republished `0.0.36` — the version electron-updater compares was unchanged, so no desktop ever saw that release. Prod's feed and the prod server manifest are both still `0.0.36`.

Going to **0.0.38** skips the burnt number rather than deleting a tag that already ran a build, and puts tag == `package.json` version back in sync (the convention every release before `mac-v0.0.37` followed).

`website/updates/server.json` moves with it: that is the box-update **detect** manifest and it ships via the *web* workflow, so leaving it at 0.0.36 would mean boxes are never told 0.0.38 exists. Consequence for release ordering: `server-v*` must be published **before** `web-v*`.

## Secret-scan allowlist

Separately, `main` and every open PR went red together on a gitleaks finding: `boxToken: "0123456789abcdef0123456789abcdef"` in `src/main/download.test.ts`. It is a literal placeholder — the same hex run is also the fake box id in the fixture's `serverUrl` — with no key material.

The scan covers full git history across every fetched ref, so a fixture on an **unmerged** branch (#1160) was enough to block everything. #1160 does not touch `.gitleaks.toml`, so the fix lands here. Listed as an explicit path, per that file's stated convention (no blanket `*.test.ts` rule).

## Verification

- `npm run typecheck` clean
- `npm test` — 2421/2422; the one failure (`usage.test.mjs` poller re-poll count, 3 !== 4) reproduces on **unmodified main** and is environment-dependent timing on this box; CI passes it
- gitleaks 8.24.3 (the pinned CI version) full-history scan: **clean**