### PR TITLE
feat(renderer): update-affordance loading/result state (BET-1160)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -225,6 +225,10 @@ function Shell() {
   const setServerUpdatePrompt = useStore((s) => s.setServerUpdatePrompt);
   const serverUpdateProgress = useStore((s) => s.serverUpdateProgress);
   const updateTargets = useStore((s) => s.updateTargets);
+  // BET-1160: the single target mid-update (null = none). With the App-local
+  // `boxUpgrading` it makes up the aggregate `busy` that disables the banner
+  // / Settings rows while ANY update runs.
+  const updatingTargetId = useStore((s) => s.updatingTargetId);
   const connectionState = useStore((s) => s.connectionState);
   const launcherFlags = useStore((s) => s.launcherFlags);
   const createDraft = useStore((s) => s.createDraft);
@@ -1688,7 +1692,11 @@ function Shell() {
             onDismiss={onUpdateBannerDismiss}
             dismissible={updateBanner.dismissible}
             tone={updateBanner.tone}
-            busy={boxUpgrading}
+            // BET-1160: treat ANY in-flight update (a per-CLI run sets
+            // updatingTargetId; the box leg sets boxUpgrading) as busy — the
+            // action is disabled and the bar shows its in-flight progress. The
+            // boxUpgrading determinate/indeterminate surface is unchanged.
+            busy={boxUpgrading || updatingTargetId != null}
             progress={boxUpgrading && !boxRestarting ? serverUpdateProgress ?? undefined : undefined}
             busyLabel={boxRestarting ? "Restarting the server…" : "Updating the server…"}
           />
@@ -1897,6 +1905,11 @@ function Shell() {
           // handling). Settings deliberately does not call serverUpdateApply()
           // itself; a second call site would be a second copy of all of that.
           onRequestServerUpdate={() => setConfirmServerUpdate(true)}
+          // BET-1160: Settings needs the aggregate busy to disable its rows
+          // while a box update runs (boxUpgrading is App-local, not in the
+          // store); the per-target in-flight/error state it reads from the
+          // store itself.
+          busy={boxUpgrading || updatingTargetId != null}
         />
       )}
       {searchOpen && activeChatSessionId != null && (

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -36,6 +36,7 @@ import { BANNER_BTN } from "./Toast";
 import { errorDisclosure } from "./settingsError";
 import { describeUpdateTarget } from "./chatUtils";
 import { refreshUpdateTargets } from "./updateCheck";
+import { rowUpdateState } from "../shared/updateTargets.mjs";
 import { forgeCredentialSecondary } from "./chatUtils";
 import { useCachedResource } from "./useCachedResource";
 import { MantaLoader } from "./MantaLoader";
@@ -294,6 +295,14 @@ function GroupCard({ title, danger = false, children }: {
  * pinned "Update ready" strip is up) the desktop row's own Update button is
  * suppressed — the strip IS that single-click action, and a second one for
  * the same target would re-download an already-downloaded update.
+ *
+ * BET-1160: `rowState` + `error` are the in-flight/result presentation, read
+ * from the shared store (via the parent) so this row and the banner can never
+ * disagree. `rowState.kind === "updating"` means THIS target is mid-update →
+ * its own spinner + "Updating…" (every other row is just disabled);
+ * `rowState.kind === "busy"` means some OTHER update is in flight → the button
+ * is disabled. `error` is this target's transient result error → the row flips
+ * to the shared error tone and the button is re-enabled for retry.
  */
 function UpdateTargetRow({
   target,
@@ -301,23 +310,32 @@ function UpdateTargetRow({
   downloadPercent,
   installReady,
   onUpdate,
+  rowState,
+  error,
 }: {
   target: UpdateTarget;
   downloading: boolean;
   downloadPercent: number | null;
   installReady: boolean;
   onUpdate: (t: UpdateTarget) => void;
+  rowState: { kind: "updating" } | { kind: "busy" } | { kind: "idle" };
+  error: string | null;
 }) {
   const row = describeUpdateTarget(target);
   const hasUpdate = target.latest != null && target.latest !== target.current;
+  const updating = rowState.kind === "updating";
+  const busy = rowState.kind === "busy";
 
   // Today's UpdateResultRow dot tones, kept as-is (BET-1099 design contract).
+  // A transient update error flips the dot to the error tone (reuses the
+  // existing error presentation — no new markup).
+  const dotTone = error != null ? "error" : row.tone;
   const dot =
-    row.tone === "ok"
+    dotTone === "ok"
       ? "bg-ok"
-      : row.tone === "action"
+      : dotTone === "action"
         ? "bg-accent"
-        : row.tone === "error"
+        : dotTone === "error"
           ? "bg-danger"
           : "bg-[var(--tx4)]";
 
@@ -325,10 +343,23 @@ function UpdateTargetRow({
   // rest are quiet text (ok / error) or a manual link (muted, when there is a
   // URL to offer).
   let action: ReactNode = null;
-  if (row.tone === "action") {
-    // A finished desktop download is marked by the pinned "Update ready" strip
-    // (installReady); suppress the desktop row's own Update button then, since
-    // a second one would re-download an already-downloaded update.
+  if (updating) {
+    // THIS target is the one being updated — its own spinner + label. No other
+    // row shows a spinner; those are just disabled via `busy`.
+    action = (
+      <span className="shrink-0 text-meta text-text-faint inline-flex items-center gap-2">
+        <span
+          aria-hidden
+          className="inline-block h-3 w-3 rounded-full border-2 border-current border-t-transparent animate-spin"
+        />
+        Updating…
+      </span>
+    );
+  } else if (row.tone === "action") {
+    // An update is available (or a failed one to retry). A finished desktop
+    // download is marked by the pinned "Update ready" strip (installReady);
+    // suppress the desktop row's own Update button then, since a second one
+    // would re-download an already-downloaded update.
     if (!(target.id === "desktop" && installReady)) {
       if (target.id === "desktop" && downloading) {
         action = (
@@ -337,8 +368,10 @@ function UpdateTargetRow({
           </span>
         );
       } else {
+        // Disabled while any update is in flight (`busy`); re-enabled (with the
+        // inline error above) so the user can retry a failed row.
         action = (
-          <button className={BANNER_BTN} onClick={() => onUpdate(target)}>
+          <button className={BANNER_BTN} disabled={busy} onClick={() => onUpdate(target)}>
             Update
           </button>
         );
@@ -370,8 +403,10 @@ function UpdateTargetRow({
     <div className="flex items-center gap-2 text-[length:var(--font-size-2xs)]">
       <span aria-hidden className={`inline-block shrink-0 w-[length:var(--step-dot)] h-[length:var(--step-dot)] rounded-full ${dot}`} />
       <span className="text-text">{target.label}</span>
-      <span className="flex-1 min-w-0 truncate font-mono text-text-quiet">
-        {hasUpdate ? (
+      <span className={`flex-1 min-w-0 truncate font-mono ${error != null ? "text-danger" : "text-text-quiet"}`}>
+        {error != null ? (
+          error
+        ) : hasUpdate ? (
           <>
             {target.current ?? ""} →{" "}
             <span className="text-text-muted font-medium">{target.latest}</span>
@@ -389,6 +424,7 @@ export function Settings({
   onClose,
   initialSection,
   onRequestServerUpdate,
+  busy = false,
 }: {
   onClose: () => void;
   /** Section to land on when the modal mounts (e.g. the `manta-open-settings`
@@ -402,6 +438,11 @@ export function Settings({
    *  a successful restart stop looking like a failure. A second call site here
    *  would be a second, subtly different version of all of that. */
   onRequestServerUpdate?: () => void;
+  /** Aggregate "an update is in flight" (`updatingTargetId != null ||
+   *  boxUpgrading`). Passed DOWN from App because `boxUpgrading` is App-local;
+   *  the per-target in-flight + error state itself is read from the shared
+   *  store so Settings and the banner can never disagree. */
+  busy?: boolean;
 }) {
   // BET-730: per-field selectors, never a bare useStore() — a no-selector
   // destructure re-renders the whole Settings tree on every store write.
@@ -421,6 +462,14 @@ export function Settings({
   const launcherFlags = useStore((s) => s.launcherFlags);
   const updatePrompt = useStore((s) => s.updatePrompt);
   const updateTargets = useStore((s) => s.updateTargets);
+  // BET-1160: in-flight/result update state, read from the shared store so
+  // Settings and the update banner never disagree. `updatingTargetId` is the
+  // single target mid-update (null = none); `targetUpdateErrors[id]` carries a
+  // target's last transient error (null = none).
+  const updatingTargetId = useStore((s) => s.updatingTargetId);
+  const targetUpdateErrors = useStore((s) => s.targetUpdateErrors);
+  const setUpdatingTarget = useStore((s) => s.setUpdatingTarget);
+  const setTargetUpdateError = useStore((s) => s.setTargetUpdateError);
   // Terminal auto-update failure (integrity / permission / unusable feed).
   // Read here only to end About's "Downloading…" state — the banner owns
   // reporting it.
@@ -498,6 +547,20 @@ export function Settings({
   const [checkedAt, setCheckedAt] = useState<number | null>(null);
   const [downloading, setDownloading] = useState(false);
   const [downloadPercent, setDownloadPercent] = useState<number | null>(null);
+
+  // BET-1160 never-stuck invariant: a fresh Settings open (re)mount resets the
+  // transient in-flight update state to idle — no stale spinner, no button left
+  // permanently disabled from a previous session. Durable truth (what is
+  // available / up to date) comes from `updateTargets`, not from the transient
+  // `updatingTargetId` / `targetUpdateErrors`, so discarding them here is safe.
+  useEffect(() => {
+    setUpdatingTarget(null);
+    const errs = useStore.getState().targetUpdateErrors;
+    for (const id of Object.keys(errs)) {
+      if (errs[id] != null) setTargetUpdateError(id, null);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   const runUpdateCheck = async () => {
     if (checking) return;
@@ -925,6 +988,8 @@ export function Settings({
                   downloadPercent={downloadPercent}
                   installReady={Boolean(updatePrompt)}
                   onUpdate={handleRowUpdate}
+                  rowState={rowUpdateState(t.id, { updatingTargetId, busy })}
+                  error={targetUpdateErrors[t.id] ?? null}
                 />
               ))}
             </div>

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -503,6 +503,14 @@ type State = {
   // to drive the single `updates` banner (via describeUpdateBanner /
   // planUpdateAll) and by Settings → About. Empty [] until the first refresh.
   updateTargets: UpdateTarget[];
+  // Update in-flight/result state, OWNED here (BET-1160). BET-1159 sets the
+  // lifecycle (one target mid-update, cleared in every terminal path via
+  // `setUpdatingTarget(null)`); BET-1161 clears a row's transient error on a
+  // successful re-check. Only `updatingTargetId` + `targetUpdateErrors` live
+  // here; the aggregate `busy` (`updatingTargetId != null || boxUpgrading`)
+  // is derived where boxUpgrading (App-local) is known, never stored twice.
+  updatingTargetId: string | null;
+  targetUpdateErrors: Record<string, string | null>;
   // A TERMINAL auto-update failure (integrity / permission). Set from main's
   // autoUpdate:error IPC, which only fires for failures the user must act on
   // — transient network errors are filtered server-side of the bridge.
@@ -726,6 +734,14 @@ type State = {
   setAgentFileToast: (t: AgentFileReady | null) => void;
   setUpdatePrompt: (p: { version: string; releaseName?: string } | null) => void;
   setUpdateTargets: (t: UpdateTarget[]) => void;
+  // BET-1160: in-flight/result update state (see the field block above). Exactly
+  // one target may be mid-update at a time (`setUpdatingTarget(id)` starts it,
+  // `setUpdatingTarget(null)` ends it); a per-target error message rides
+  // `targetUpdateErrors` (null = no error for that id). Idempotence/ordering:
+  // BET-1159's finally clears `updatingTargetId` on RPC ok + reject, and a
+  // box reconnect / Settings-close resets it — the store never selfers.
+  setUpdatingTarget: (id: string | null) => void;
+  setTargetUpdateError: (id: string, error: string | null) => void;
   setUpdateError: (p: { message: string; raw: string } | null) => void;
   setBoxIncompatible: (b: boolean) => void;
   setServerUpdatePrompt: (
@@ -797,6 +813,8 @@ export const useStore = create<State>((set, get) => ({
   systemNotice: null,
   updatePrompt: null,
   updateTargets: [],
+  updatingTargetId: null,
+  targetUpdateErrors: {},
   updateError: null,
   boxIncompatible: false,
   serverUpdatePrompt: null,
@@ -1132,6 +1150,9 @@ export const useStore = create<State>((set, get) => ({
   setSystemNotice: (t) => set({ systemNotice: t }),
   setUpdatePrompt: (p) => set({ updatePrompt: p }),
   setUpdateTargets: (t) => set({ updateTargets: t }),
+  setUpdatingTarget: (id) => set({ updatingTargetId: id }),
+  setTargetUpdateError: (id, error) =>
+    set((prev) => ({ targetUpdateErrors: { ...prev.targetUpdateErrors, [id]: error } })),
   setUpdateError: (p) => set({ updateError: p }),
   setBoxIncompatible: (b) => set({ boxIncompatible: b }),
   setServerUpdatePrompt: (p) => set({ serverUpdatePrompt: p }),

--- a/src/shared/updateTargets.d.mts
+++ b/src/shared/updateTargets.d.mts
@@ -61,3 +61,19 @@ export interface UpdateAllPlan {
  * Plan a single "Update all" run over the target list.
  */
 export function planUpdateAll(targets: UpdateTarget[]): UpdateAllPlan;
+
+export type RowUpdateState =
+  | { kind: "updating" }
+  | { kind: "busy" }
+  | { kind: "idle" };
+
+/**
+ * Decide a per-target update row's in-flight presentation (BET-1160):
+ * `updating` = THIS target is mid-update (spinner + its own label), `busy` =
+ * some OTHER update is in flight (this row's button disabled), `idle` =
+ * nothing in flight (normal presentation).
+ */
+export function rowUpdateState(
+  id: string,
+  state?: { updatingTargetId?: string | null; busy?: boolean },
+): RowUpdateState;

--- a/src/shared/updateTargets.mjs
+++ b/src/shared/updateTargets.mjs
@@ -221,3 +221,36 @@ export function planUpdateAll(targets) {
     confirmBody,
   };
 }
+
+/**
+ * Decide a per-target update row's in-flight presentation (BET-1160).
+ *
+ * Pure, so Settings (and any future consumer) and the banner never disagree
+ * about which row is busy / disabled / the one actually updating. Given the
+ * target id and the shared in-flight snapshot (`updatingTargetId` from the
+ * store, plus the aggregate `busy` that folds in the App-local box upgrade),
+ * returns exactly one of:
+ *
+ *   - `{ kind: "updating" }` — THIS target is the one being updated (`id`
+ *     equals `updatingTargetId`): its own button shows a spinner + "Updating…"
+ *     and is disabled; no other row shows a spinner.
+ *   - `{ kind: "busy" }`      — some OTHER update is in flight (`busy` is true
+ *     via a different `updatingTargetId` or the box leg): this row's button is
+ *     disabled, with no spinner of its own.
+ *   - `{ kind: "idle" }`      — nothing in flight: the row keeps its normal
+ *     action presentation.
+ *
+ * `id` is the row's target id; `updatingTargetId` is the store's in-flight
+ * target (null = none); `busy` is the aggregate busy flag. A row with a
+ * transient error is handled by the caller (it re-presents the button for
+ * retry regardless of this result).
+ *
+ * @param {string} id the target id of the row being considered
+ * @param {{ updatingTargetId: string|null, busy: boolean }} state
+ * @returns {{ kind: "updating" } | { kind: "busy" } | { kind: "idle" }}
+ */
+export function rowUpdateState(id, { updatingTargetId = null, busy = false } = {}) {
+  if (updatingTargetId != null && updatingTargetId === id) return { kind: "updating" };
+  if (updatingTargetId != null || busy) return { kind: "busy" };
+  return { kind: "idle" };
+}

--- a/src/shared/updateTargets.test.ts
+++ b/src/shared/updateTargets.test.ts
@@ -6,6 +6,7 @@ import {
   summarizeUpdates,
   describeUpdateBanner,
   planUpdateAll,
+  rowUpdateState,
 } from "./updateTargets.mjs";
 
 const cli = (
@@ -421,5 +422,25 @@ describe("planUpdateAll", () => {
   it("app-restart alone does NOT suppress the reconnect sentence (no ends-turns)", () => {
     const plan = planUpdateAll([t("server", true, false, "reconnect")]);
     expect(plan.confirmBody).toEqual(["The server will restart briefly and reconnect on its own."]);
+  });
+});
+
+describe("rowUpdateState", () => {
+  it("reports `updating` only for the exact target that is mid-update", () => {
+    const state = { updatingTargetId: "server", busy: true };
+    expect(rowUpdateState("server", state)).toEqual({ kind: "updating" });
+    expect(rowUpdateState("desktop", state)).toEqual({ kind: "busy" });
+    expect(rowUpdateState("opencode", state)).toEqual({ kind: "busy" });
+  });
+
+  it("reports `busy` when another update or the box leg is in flight", () => {
+    expect(rowUpdateState("desktop", { updatingTargetId: "server", busy: true })).toEqual({ kind: "busy" });
+    // busy can be true from the App-local box upgrade alone (updatingTargetId null).
+    expect(rowUpdateState("desktop", { updatingTargetId: null, busy: true })).toEqual({ kind: "busy" });
+  });
+
+  it("reports `idle` when nothing is in flight", () => {
+    expect(rowUpdateState("desktop", { updatingTargetId: null, busy: false })).toEqual({ kind: "idle" });
+    expect(rowUpdateState("server", {})).toEqual({ kind: "idle" });
   });
 });


### PR DESCRIPTION
**BET-1160 — Update buttons (banner + Settings rows) have no loading/in-progress state**

Adds the shared update-state contract (OWNED here; consumed by BET-1159 routing and BET-1161 refresh) and renders loading/in-progress + result feedback on every update affordance, desktop only.

## What changed

**STEP 1 — store contract** (`src/renderer/store.ts`): `updatingTargetId` (the single target mid-update, null = none) + `targetUpdateErrors: Record<id, string|null>` with `setUpdatingTarget(id)` / `setTargetUpdateError(id, err)`. Initial `updatingTargetId: null`, `targetUpdateErrors: {}`.

**Design decision (stated per the issue):** the aggregate `busy = updatingTargetId != null || boxUpgrading` is NOT stored — `boxUpgrading` stays App-local and `busy` is passed DOWN from App to Settings as a prop. Settings/App read the per-target in-flight + error state from the shared store so the banner and rows never disagree.

**STEP 2 — Settings rows** (`UpdateTargetRow`): renders from the store via the new pure `rowUpdateState()` — spinner + "Updating…" (its own label) when `updatingTargetId === target.id`; every other row is just disabled while busy; a per-target `targetUpdateErrors[id]` sets the row to the shared error tone (dot + inline message, reusing existing danger styling — no new markup) and re-enables the button for retry. Success is NOT hand-rendered — it flows from describeUpdateTarget via the refresh (BET-1161). The "Check for updates" button already disables on its existing `checking` state.

**STEP 3 — App banner:** the UpdateBar treats any in-flight update as busy (`busy = boxUpgrading || updatingTargetId != null`), so a per-CLI run gets a disabled/busy action too. The existing boxUpgrading determinate/indeterminate progress surface is unchanged.

**STEP 4 — pure helper + tests:** `rowUpdateState(id, {updatingTargetId, busy})` in `src/shared/updateTargets.mjs` (+ `.d.mts` decl), unit-tested in `updateTargets.test.ts` (updating / busy / idle). No status decisions live inline in components.

**Never-stuck invariant:** Settings remount resets `updatingTargetId` → null and clears transient `targetUpdateErrors` (durable truth comes from `updateTargets`). RPC ok/reject finallys and box reconnect are BET-1159's cleanup — the store just exposes the setters.

## Files changed
6 files, +180/−11: `src/renderer/store.ts`, `src/renderer/Settings.tsx`, `src/renderer/App.tsx`, `src/shared/updateTargets.mjs`, `src/shared/updateTargets.d.mts`, `src/shared/updateTargets.test.ts`.

**Verification results:**
- PR branch (`multica/BET-1160-update-affordance-state` @ `eca5e76b`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, all pass (vitest 3148 pass + server 2422 pass), 0 fail. log sha256: `847799b677733ebda9d576349a63bb83c6bd6b5f5de99bff1ce79d07a68d0110`
- Base (`main` @ `e461eb75`):
  - typecheck: exit 0. Errors: none. log sha256: `b3e043f9cf03e405d51dbe05ecf0b311f738ab572192d72a50f6b28221a92f13`
  - test: exit 0, all pass, 0 fail. log sha256: `7b6aa50a535fc57f7f9342577d3beecacfee29fb0635acae8fb99f2316e42e51`
- **Conclusion:** 0 new failures; the only delta is the added `rowUpdateState` tests on the PR branch.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ `e461eb75`**
