### PR TITLE
Per-row CLI update (renderer half) — BET-1159

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -31,13 +31,21 @@ import { ConfirmModal } from "./ConfirmModal";
 import { UsageResumeModal } from "./UsageResumeModal";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
-import { describeUpdateBanner, planUpdateAll } from "../shared/updateTargets.mjs";
+import {
+  describeUpdateBanner,
+  planUpdateAll,
+  isCliTarget,
+} from "../shared/updateTargets.mjs";
 import { refreshUpdateTargets } from "./updateCheck";
 import { parsePairPayload } from "../shared/pairPayload";
 import { channelConfig } from "../shared/channel.mjs";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { MantaLoader } from "./MantaLoader";
-import type { AvailableLauncher, MediaEventPayload } from "../shared/types";
+import type {
+  AvailableLauncher,
+  MediaEventPayload,
+  UpdateTarget,
+} from "../shared/types";
 import {
   buildLimitMessage,
   buildUsageLevels,
@@ -1543,6 +1551,59 @@ function Shell() {
     }
   };
 
+  // ===== Per-row CLI update (BET-1159) =====
+  //
+  // The renderer half of "click one CLI row, upgrade just that CLI". Exactly
+  // one target updates at a time — the busy gate (any update in flight,
+  // including a box upgrade) serializes against overlap. `updatingTargetId`
+  // (set via the shared store) drives the row's spinner + disabled state while
+  // the RPC is in flight; the server RPC (BET-1162) never rejects, so a
+  // failure is read off `res.ok`. BET-1160/1161 already own the store slice
+  // (`updatingTargetId`/`targetUpdateErrors`) and the per-row loading states;
+  // this is only the CLI routing.
+  const runCliUpdate = async (t: UpdateTarget) => {
+    if (updatingTargetId != null || boxUpgrading) return;
+    useStore.getState().setUpdatingTarget(t.id);
+    try {
+      const res = await window.api.serverCliUpdate(t.id);
+      if (res && res.ok === false) {
+        useStore.getState().setTargetUpdateError(t.id, res.error ?? "Update failed");
+      }
+    } catch (e) {
+      // Defensive: the RPC's contract is to never reject, but a bare
+      // connection error would strand the spinner forever. Record it as the
+      // per-row error and let the row recover, never leave `updatingTargetId`
+      // stuck.
+      useStore.getState().setTargetUpdateError(
+        t.id,
+        e instanceof Error ? e.message : "Update failed",
+      );
+    } finally {
+      useStore.getState().setUpdatingTarget(null);
+    }
+    // BET-1161: after busy clears, re-check so the row/node reflects the new
+    // version instead of the stale pre-upgrade one.
+    void refreshUpdateTargets().catch(() => {});
+  };
+
+  // The ONE per-target update router, shared by the Settings rows and the
+  // banner's single-target path (BET-1159). Routes by target id — the only
+  // discriminator (`isCliTarget`, never label or disruption). `desktop` keeps
+  // its download, `server` keeps the box flow unchanged; every CLI id runs the
+  // per-CLI upgrade above.
+  const handleTargetUpdate = (t: UpdateTarget) => {
+    if (isCliTarget(t)) {
+      void runCliUpdate(t);
+      return;
+    }
+    if (t.id === "desktop") {
+      void window.api.autoUpdateDownload().catch(() => {});
+      return;
+    }
+    // server — the box's own self-update flow (confirm → applyServerUpdate).
+    setConfirmServerUpdate(true);
+  };
+
   // ===== The ONE update action: runUpdateAll (stage 3, BET-1098) =====
   //
   // Desktop install is terminal and runs LAST — nothing can follow it. The
@@ -1600,11 +1661,18 @@ function Shell() {
   }, [updatePrompt]);
 
   // The unified `updates` banner's action. The danger tone means "update
-  // failed" → the only sensible action is a manual download. Everything else
-  // (available / mandatory) runs the ONE orchestrator.
+  // failed" → the only sensible action is a manual download. A SINGLE available
+  // CLI target is precisely that CLI's per-row upgrade (BET-1159) — route it
+  // through the per-target router instead of the whole-box run. Everything else
+  // (mandatory, or 2+ available / mixed) runs the ONE orchestrator.
   const onUpdateBannerAction = () => {
     if (updateBanner?.tone === "danger") {
       void window.api.openExternal("https://mantaui.com/downloads/Manta-latest.dmg");
+      return;
+    }
+    const avail = updateTargets.filter((t) => t.available && !t.manual);
+    if (avail.length === 1 && isCliTarget(avail[0])) {
+      handleTargetUpdate(avail[0]);
       return;
     }
     void runUpdateAll();
@@ -1910,6 +1978,10 @@ function Shell() {
           // store); the per-target in-flight/error state it reads from the
           // store itself.
           busy={boxUpgrading || updatingTargetId != null}
+          // BET-1159: per-row CLI updates. App owns the single-router
+          // discriminator (`isCliTarget`) and the per-CLI run; Settings only
+          // needs to delegate a CLI row to it.
+          onCliUpdate={(t) => void runCliUpdate(t)}
         />
       )}
       {searchOpen && activeChatSessionId != null && (

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -36,7 +36,7 @@ import { BANNER_BTN } from "./Toast";
 import { errorDisclosure } from "./settingsError";
 import { describeUpdateTarget } from "./chatUtils";
 import { refreshUpdateTargets } from "./updateCheck";
-import { rowUpdateState } from "../shared/updateTargets.mjs";
+import { rowUpdateState, isCliTarget } from "../shared/updateTargets.mjs";
 import { forgeCredentialSecondary } from "./chatUtils";
 import { useCachedResource } from "./useCachedResource";
 import { MantaLoader } from "./MantaLoader";
@@ -425,6 +425,7 @@ export function Settings({
   initialSection,
   onRequestServerUpdate,
   busy = false,
+  onCliUpdate,
 }: {
   onClose: () => void;
   /** Section to land on when the modal mounts (e.g. the `manta-open-settings`
@@ -443,6 +444,10 @@ export function Settings({
    *  the per-target in-flight + error state itself is read from the shared
    *  store so Settings and the banner can never disagree. */
   busy?: boolean;
+  /** BET-1159: App's per-CLI update router. Settings delegates a CLI row here
+   *  (decided by the shared `isCliTarget` discriminator) so the Settings rows
+   *  and App's banner route through the SAME path — no second discriminator. */
+  onCliUpdate?: (t: UpdateTarget) => void;
 }) {
   // BET-730: per-field selectors, never a bare useStore() — a no-selector
   // destructure re-renders the whole Settings tree on every store write.
@@ -610,10 +615,14 @@ export function Settings({
   // always describe the same state. The two bespoke per-leg blocks they
   // replace were deleted in stage 4.
   //
-  // The action button for every box-side target (server, opencode, each CLI)
-  // raises `onRequestServerUpdate` — there is no per-CLI apply, updating ANY
-  // box target means running the box update, and App.tsx owns the confirm,
-  // progress, 120s cap and transient-error handling in exactly one place.
+  // The action routes by target id through the shared `isCliTarget`
+  // discriminator (BET-1159): desktop keeps its download; every CLI row
+  // delegates to App's per-CLI router (`onCliUpdate` — the SAME path the
+  // banner uses), so a CLI row upgrades JUST that CLI, never the whole box;
+  // the server row keeps the box self-update flow (`onRequestServerUpdate`),
+  // which App's confirm → applyServerUpdate path owns unchanged. The row's
+  // disabled/spinner presentation (busy + updatingTargetId) is BET-1160's
+  // `rowUpdateState`, already read from the store — nothing to add here.
   const handleRowUpdate = (t: UpdateTarget) => {
     if (t.id === "desktop") {
       setDownloading(true);
@@ -627,6 +636,8 @@ export function Settings({
           setDownloading(false);
           setDownloadPercent(null);
         });
+    } else if (isCliTarget(t)) {
+      onCliUpdate?.(t);
     } else {
       onRequestServerUpdate?.();
     }

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -136,6 +136,7 @@ export const DEMO_UNIMPLEMENTED = [
   "secretsDelete",
   "secretsList",
   "secretsSet",
+  "serverCliUpdate",
   "serverUpdateApply",
   "serverUpdateCheck",
   "tmuxConfigStatus",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1300,6 +1300,20 @@ export const httpApi: Api = {
   // device capability.
   serverUpdateCheck: () => rpc<ServerUpdateCheck>(IPC.serverUpdateCheck),
 
+  // -- single-CLI update (BET-1162, server half; consumed by BET-1159) --
+  // Renderer → server RPC: upgrade exactly ONE installed box CLI by catalog id.
+  // Reuses the cached CLI detector + shared runUpgrade spawn. This is the
+  // per-row action behind the renderer's per-row split (BET-1159). Args are a
+  // single `{ cliId }` object (mirrors how neighbouring channels pack args).
+  serverCliUpdate: (cliId) =>
+    rpc<{
+      ok: boolean;
+      before?: string | null;
+      after?: string | null;
+      changed?: boolean;
+      error?: string;
+    }>(IPC.serverCliUpdate, { cliId }),
+
   // -- server-update available subscription (BET-225 stage 3) --
   // /events WS stream publishes `{kind: "serverUpdateAvailable", payload}`
   // (the same envelope shape desktopNotify uses). The renderer's UpdateBar

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -732,6 +732,22 @@ export interface Api {
   // report different things.
   serverUpdateCheck(): Promise<ServerUpdateCheck>;
 
+  // Single-CLI update (BET-1162, server half; consumed by BET-1159): upgrade
+  // exactly ONE installed box CLI (opencode / claude / codex / kimi) by catalog
+  // id. Reuses the cached CLI detector and the shared runUpgrade spawn — no new
+  // detection or upgrade mechanism. Resolves with `{ok, before?, after?,
+  // changed?, error?}` and never rejects. This is the per-row action the
+  // renderer's per-row split (BET-1159) calls.
+  serverCliUpdate(
+    cliId: string,
+  ): Promise<{
+    ok: boolean;
+    before?: string | null;
+    after?: string | null;
+    changed?: boolean;
+    error?: string;
+  }>;
+
   // Server-update available subscription (BET-225 stage 3): fires when the
   // box's server-update poller sees a newer manifest version. Mirrors the
   // desktopNotify pattern — main subscribes to manta-server's /events SSE,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1607,6 +1607,13 @@ export const IPC = {
   // and the banner can never disagree.
   serverUpdateCheck: "server:update-check",           // () → ServerUpdateCheck
 
+  // ---- single-CLI update (BET-1162, server half; consumed by BET-1159) ----
+  // Upgrade exactly ONE installed box CLI (opencode / claude / codex / kimi) by
+  // catalog id, reusing the cached CLI detector + the shared runUpgrade spawn.
+  // Returns {ok, before?, after?, changed?, error?} — never rejects. This is
+  // the per-row action behind BET-1159 (renderer per-row split).
+  serverCliUpdate: "server:cli-update",               // (cliId: string) → CliUpdateResult
+
   // ---- client version (BET-225 stage 3) ----
   // Returns the desktop app's own version via Electron's `app.getVersion()`
   // (which reads the same package.json the server uses). Renderer combines

--- a/src/shared/updateTargets.d.mts
+++ b/src/shared/updateTargets.d.mts
@@ -30,6 +30,12 @@ export function buildUpdateTargets(args: {
  * `names` in display order, and the deduped set of their `disruptions`.
  * `manual` targets never count.
  */
+/**
+ * The ONE target-identity discriminator for per-row updates (BET-1159): true
+ * iff the target is a per-CLI update (id is none of "desktop" / "server").
+ */
+export function isCliTarget(t: UpdateTarget | null | undefined): boolean;
+
 export function summarizeUpdates(targets: UpdateTarget[]): UpdateTargetSummary;
 
 export interface UpdateBanner {

--- a/src/shared/updateTargets.mjs
+++ b/src/shared/updateTargets.mjs
@@ -37,6 +37,22 @@ const SERVER_FIXED = { label: "The server", disruption: "reconnect" };
  * @param {string|null} [args.serverVersion] the running box version
  * @returns {Array<object>} UpdateTarget[] in fixed display order
  */
+/**
+ * The ONE target-identity discriminator for per-row updates (BET-1159).
+ *
+ * "Is this a CLI row?" is used by BOTH the Settings rows and the banner's
+ * routing (App.tsx) to decide which update path a single target takes. The
+ * only source of truth for "CLI" is the id — never the label or disruption.
+ * `desktop` and `server` are the two non-CLI targets; anything else in the
+ * UpdateTargetId union (opencode / claude / codex / kimi) is a CLI.
+ *
+ * @param {object} t an UpdateTarget
+ * @returns {boolean} true iff `t` is a per-CLI update target
+ */
+export function isCliTarget(t) {
+  return Boolean(t) && t.id !== "desktop" && t.id !== "server";
+}
+
 export function buildUpdateTargets({
   desktopCheck = null,
   serverCheck = null,

--- a/src/shared/updateTargets.test.ts
+++ b/src/shared/updateTargets.test.ts
@@ -7,6 +7,7 @@ import {
   describeUpdateBanner,
   planUpdateAll,
   rowUpdateState,
+  isCliTarget,
 } from "./updateTargets.mjs";
 
 const cli = (
@@ -442,5 +443,26 @@ describe("rowUpdateState", () => {
   it("reports `idle` when nothing is in flight", () => {
     expect(rowUpdateState("desktop", { updatingTargetId: null, busy: false })).toEqual({ kind: "idle" });
     expect(rowUpdateState("server", {})).toEqual({ kind: "idle" });
+  });
+});
+
+describe("isCliTarget", () => {
+  // The two non-CLI targets must NEVER be treated as per-CLI rows — the whole
+  // per-row feature keys off this tri-state identity, not the label.
+  it("desktop and server are NOT cli targets", () => {
+    expect(isCliTarget(cli("desktop", "Manta UI"))).toBe(false);
+    expect(isCliTarget(cli("server", "The box"))).toBe(false);
+  });
+
+  it("every catalog CLI id IS a cli target", () => {
+    expect(isCliTarget(cli("opencode", "opencode"))).toBe(true);
+    expect(isCliTarget(cli("claude", "Claude Code"))).toBe(true);
+    expect(isCliTarget(cli("codex", "Codex"))).toBe(true);
+    expect(isCliTarget(cli("kimi", "Kimi Code"))).toBe(true);
+  });
+
+  it("null/undefined is never a cli target", () => {
+    expect(isCliTarget(null)).toBe(false);
+    expect(isCliTarget(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
## BET-1159 — Per-row CLI update (renderer half)

Clicking a CLI row (opencode / Claude Code / codex / kimi) now runs **just that CLI's** upgrade via `server:cli-update`, instead of the full box self-update. The box row and desktop row keep their existing paths unchanged.

**Rebased onto `origin/main @ 15b1c073`.** This branch was cut before BET-1160/1161 merged; main now owns the shared store slice (`updatingTargetId`/`targetUpdateErrors`), the aggregate `busy` gate, and the per-row `rowUpdateState` loading/disable wiring. Per the review, this delta keeps **only the CLI-routing half** — the store slice and busy/disable/spinner wiring are dropped (they ship on main from BET-1160/1161).

### What this delta adds

- **Shared discriminator** (`src/shared/updateTargets.mjs`): pure `isCliTarget(t)` (`t.id !== "desktop" && t.id !== "server"`) — the single source of truth for "is this a CLI row", used by BOTH the Settings rows and the banner (App.tsx). `.d.mts` + unit tests.
- **App.tsx**: `runCliUpdate(t)` (serialize via the busy gate, set `updatingTargetId` in the shared store, `window.api.serverCliUpdate(t.id)`, record the error on `ok === false` + a defensive catch, clear, re-check via `refreshUpdateTargets` — BET-1161). A single per-target router `handleTargetUpdate` routes desktop / server / CLI by id; the banner routes a single available CLI through it.
- **Settings.tsx**: `handleRowUpdate` uses `isCliTarget` to delegate CLI rows to App's `onCliUpdate` (new prop) instead of the box flow; desktop and server paths unchanged. Loading/disable/spinner for rows comes from main's `rowUpdateState` (BET-1160) — nothing duplicated here.
- **Client RPC contract** for the BET-1162 dependency (`IPC.serverCliUpdate`, `Api.serverCliUpdate`, `httpApi.serverCliUpdate` + demo coverage entry) so the renderer compiles against the stable 1162 contract. Client side only — **no server changes.** If BET-1162 merges this will be identical content and trivially mergeable.

### Non-goals honored
No `src/server/*` changes; `runUpdateAll` / box flow untouched; mobile out of scope.

**Files changed:** `9`. src/renderer/App.tsx, src/renderer/Settings.tsx, src/renderer/api/httpApi.ts, src/renderer/api/demoCoverage.test.ts, src/shared/api.ts, src/shared/types.ts, src/shared/updateTargets.mjs, src/shared/updateTargets.d.mts, src/shared/updateTargets.test.ts

**Verification results:**
- PR branch (`multica/BET-1159-per-row-cli-update` @ `c6ef813f`):
  - typecheck: exit 0. Errors: none. log sha256: `3d4bc0be89b28c0a51064f0f739e86bf359f9b52ad80b17275e2301a47d5026c`
  - test: exit 0, 3176 pass / 0 fail / 7 skip. Failures: none. log sha256: `483b80f7136bb7b73b86dc5136da8ae50a477c7d2bc355cdd42837ea8ca146cd`
- Base (`main` @ `15b1c073`):
  - typecheck: exit 0. Errors: none. log sha256: `3d4bc0be89b28c0a51064f0f739e86bf359f9b52ad80b17275e2301a47d5026c`
  - test: exit 0, 3173 pass / 0 fail / 7 skip. Failures: none. log sha256: `6aff11830f0156a65c8c49df9fb143046ec24ff08a84ac1d20e8fa119e9cc51c`
- **Conclusion:** 0 failures on both branches; PR adds 3 tests (`isCliTarget`).

Base: `origin/main @ 15b1c073`
