### PR TITLE
feat(renderer): re-check update targets after a CLI update completes (BET-1161)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -31,13 +31,13 @@ import { ConfirmModal } from "./ConfirmModal";
 import { UsageResumeModal } from "./UsageResumeModal";
 import { ReconnectingBanner } from "./ReconnectingBanner";
 import { pickBanner, type BannerState } from "./bannerPriority";
-import { describeUpdateBanner, planUpdateAll } from "../shared/updateTargets.mjs";
+import { describeUpdateBanner, planUpdateAll, isCliTarget, shouldRefreshAfterCliUpdate } from "../shared/updateTargets.mjs";
 import { refreshUpdateTargets } from "./updateCheck";
 import { parsePairPayload } from "../shared/pairPayload";
 import { channelConfig } from "../shared/channel.mjs";
 import { ErrorBoundary } from "./ErrorBoundary";
 import { MantaLoader } from "./MantaLoader";
-import type { AvailableLauncher, MediaEventPayload } from "../shared/types";
+import type { AvailableLauncher, MediaEventPayload, UpdateTarget } from "../shared/types";
 import {
   buildLimitMessage,
   buildUsageLevels,
@@ -1543,6 +1543,49 @@ function Shell() {
     }
   };
 
+  // ===== Per-CLI update (BET-1159) + post-update re-check (BET-1161) =====
+  //
+  // Clicking a CLI row (opencode / claude / codex / kimi) upgrades JUST that
+  // one CLI via the `server:cli-update` RPC (BET-1162 provides the server half)
+  // rather than running the full box self-update. The server row keeps the
+  // existing box flow (applyServerUpdate) and the desktop row keeps the
+  // download — see the shared `isCliTarget` discriminator. Serialized: at most
+  // one target may be updating at a time.
+  //
+  // Ordering (BET-1161): the busy flag is cleared in `finally` BEFORE the
+  // re-check runs, so the UI never flashes back to a re-clickable "Update"
+  // mid-flight. We re-check only on success — a failed RPC leaves the target's
+  // versions as-is (still "available") so the row keeps the Update button for
+  // retry and the per-target error (BET-1160) renders. On a genuine success the
+  // shared refresh drops the target from the available set, so the row flips to
+  // "Up to date" via describeUpdateTarget and the banner clears automatically.
+  const runCliUpdate = async (t: UpdateTarget) => {
+    useStore.getState().setUpdatingTarget(t.id);
+    let succeeded = false;
+    try {
+      const res = await window.api.serverCliUpdate(t.id);
+      if (shouldRefreshAfterCliUpdate(res)) {
+        succeeded = true;
+      } else {
+        useStore.getState().setTargetUpdateError(t.id, res?.error ?? "Update failed");
+      }
+    } catch (e) {
+      // A THROWN RPC (e.g. route missing / 404 / 500 before BET-1162's server
+      // half is deployed) must render a per-target error and be handled, not
+      // surface as an unhandled rejection. The target's versions stay as-is
+      // (still "available"), so the row keeps the Update button for retry.
+      useStore.getState().setTargetUpdateError(
+        t.id,
+        e instanceof Error ? e.message : String(e),
+      );
+    } finally {
+      useStore.getState().setUpdatingTarget(null);
+    }
+    // BET-1161: AFTER the busy state clears (the finally above), re-run the one
+    // shared check so the UI reflects the new version and stops offering Update.
+    if (succeeded) void refreshUpdateTargets().catch(() => {});
+  };
+
   // ===== The ONE update action: runUpdateAll (stage 3, BET-1098) =====
   //
   // Desktop install is terminal and runs LAST — nothing can follow it. The
@@ -1600,11 +1643,19 @@ function Shell() {
   }, [updatePrompt]);
 
   // The unified `updates` banner's action. The danger tone means "update
-  // failed" → the only sensible action is a manual download. Everything else
-  // (available / mandatory) runs the ONE orchestrator.
+  // failed" → the only sensible action is a manual download. A single available
+  // CLI target (opencode / claude / codex / kimi) runs JUST that CLI's upgrade
+  // via `runCliUpdate` (BET-1159), not the full box self-update. Everything
+  // else (lone desktop / server, or multiple targets) keeps the ONE
+  // orchestrator, runUpdateAll, which owns desktop+box sequencing.
   const onUpdateBannerAction = () => {
     if (updateBanner?.tone === "danger") {
       void window.api.openExternal("https://mantaui.com/downloads/Manta-latest.dmg");
+      return;
+    }
+    const single = (updateTargets ?? []).filter((t) => t && t.available && !t.manual);
+    if (single.length === 1 && isCliTarget(single[0])) {
+      void runCliUpdate(single[0]);
       return;
     }
     void runUpdateAll();
@@ -1910,6 +1961,7 @@ function Shell() {
           // store); the per-target in-flight/error state it reads from the
           // store itself.
           busy={boxUpgrading || updatingTargetId != null}
+          onRunCliUpdate={runCliUpdate}
         />
       )}
       {searchOpen && activeChatSessionId != null && (

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -36,7 +36,7 @@ import { BANNER_BTN } from "./Toast";
 import { errorDisclosure } from "./settingsError";
 import { describeUpdateTarget } from "./chatUtils";
 import { refreshUpdateTargets } from "./updateCheck";
-import { rowUpdateState } from "../shared/updateTargets.mjs";
+import { rowUpdateState, isCliTarget } from "../shared/updateTargets.mjs";
 import { forgeCredentialSecondary } from "./chatUtils";
 import { useCachedResource } from "./useCachedResource";
 import { MantaLoader } from "./MantaLoader";
@@ -290,11 +290,13 @@ function GroupCard({ title, danger = false, children }: {
  * `downloading` / `downloadPercent` belong to the desktop leg only (a manual
  * download started from this row replaces the Update button with its
  * progress). Every box-side target (server, opencode, each CLI) shares the
- * same `onUpdate`, which raises `onRequestServerUpdate` — there is no per-CLI
- * apply. When `installReady` is set (a desktop download finished and the
- * pinned "Update ready" strip is up) the desktop row's own Update button is
- * suppressed — the strip IS that single-click action, and a second one for
- * the same target would re-download an already-downloaded update.
+ * same `onUpdate`, which routes by target id: a CLI runs its own upgrade via
+ * App's `onRunCliUpdate` (BET-1159), the server raises `onRequestServerUpdate`
+ * (BET-1159's `isCliTarget` discriminator decides). When `installReady` is set
+ * (a desktop download finished and the pinned "Update ready" strip is up) the
+ * desktop row's own Update button is suppressed — the strip IS that
+ * single-click action, and a second one for the same target would re-download
+ * an already-downloaded update.
  *
  * BET-1160: `rowState` + `error` are the in-flight/result presentation, read
  * from the shared store (via the parent) so this row and the banner can never
@@ -425,6 +427,7 @@ export function Settings({
   initialSection,
   onRequestServerUpdate,
   busy = false,
+  onRunCliUpdate,
 }: {
   onClose: () => void;
   /** Section to land on when the modal mounts (e.g. the `manta-open-settings`
@@ -443,6 +446,11 @@ export function Settings({
    *  the per-target in-flight + error state itself is read from the shared
    *  store so Settings and the banner can never disagree. */
   busy?: boolean;
+  /** Ask App.tsx to run its per-CLI update (BET-1159). A CLI row routes here
+   *  rather than calling the RPC itself, so App owns the ONE runCliUpdate —
+   *  the busy lifecycle (setUpdatingTarget) and the post-update refresh
+   *  (BET-1161) live in exactly one place. */
+  onRunCliUpdate?: (t: UpdateTarget) => void;
 }) {
   // BET-730: per-field selectors, never a bare useStore() — a no-selector
   // destructure re-renders the whole Settings tree on every store write.
@@ -610,10 +618,10 @@ export function Settings({
   // always describe the same state. The two bespoke per-leg blocks they
   // replace were deleted in stage 4.
   //
-  // The action button for every box-side target (server, opencode, each CLI)
-  // raises `onRequestServerUpdate` — there is no per-CLI apply, updating ANY
-  // box target means running the box update, and App.tsx owns the confirm,
-  // progress, 120s cap and transient-error handling in exactly one place.
+  // A CLI row (opencode / claude / codex / kimi) routes to App's `onRunCliUpdate`
+  // (BET-1159) — the ONE runCliUpdate that upgrades just that CLI and re-checks
+  // targets after it finishes (BET-1161). The server row keeps the full box
+  // update via `onRequestServerUpdate`; the desktop row keeps the download.
   const handleRowUpdate = (t: UpdateTarget) => {
     if (t.id === "desktop") {
       setDownloading(true);
@@ -627,6 +635,8 @@ export function Settings({
           setDownloading(false);
           setDownloadPercent(null);
         });
+    } else if (isCliTarget(t)) {
+      onRunCliUpdate?.(t);
     } else {
       onRequestServerUpdate?.();
     }

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -136,6 +136,7 @@ export const DEMO_UNIMPLEMENTED = [
   "secretsDelete",
   "secretsList",
   "secretsSet",
+  "serverCliUpdate",
   "serverUpdateApply",
   "serverUpdateCheck",
   "tmuxConfigStatus",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1300,6 +1300,22 @@ export const httpApi: Api = {
   // device capability.
   serverUpdateCheck: () => rpc<ServerUpdateCheck>(IPC.serverUpdateCheck),
 
+  // -- single-CLI update (BET-1162 server half) --
+  // Renderer → server RPC: upgrade exactly ONE installed box CLI by catalog id.
+  // Reuses the cached CLI detector + shared runUpgrade spawn. Args are a single
+  // `{ cliId }` object (mirrors how neighbouring channels pack args). Resolves
+  // with `{ok, before?, after?, changed?, error?}` and never rejects — BET-1159
+  // routes CLI rows here and BET-1161 re-checks targets after it resolves.
+  serverCliUpdate: (cliId) =>
+    rpc<{
+      ok: boolean;
+      before?: string | null;
+      after?: string | null;
+      changed?: boolean;
+      error?: string;
+    }>(IPC.serverCliUpdate, { cliId }),
+
+
   // -- server-update available subscription (BET-225 stage 3) --
   // /events WS stream publishes `{kind: "serverUpdateAvailable", payload}`
   // (the same envelope shape desktopNotify uses). The renderer's UpdateBar

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -732,6 +732,22 @@ export interface Api {
   // report different things.
   serverUpdateCheck(): Promise<ServerUpdateCheck>;
 
+  // Single-CLI update (BET-1162 server half): upgrade exactly ONE installed box
+  // CLI (opencode / claude / codex / kimi) by catalog id. Reuses the cached CLI
+  // detector and the shared runUpgrade spawn — no new detection or upgrade
+  // mechanism. Resolves with `{ok, before?, after?, changed?, error?}` and
+  // never rejects. This is the per-row action BET-1159's `runCliUpdate` calls;
+  // BET-1161 re-checks update targets after it resolves.
+  serverCliUpdate(
+    cliId: string,
+  ): Promise<{
+    ok: boolean;
+    before?: string | null;
+    after?: string | null;
+    changed?: boolean;
+    error?: string;
+  }>;
+
   // Server-update available subscription (BET-225 stage 3): fires when the
   // box's server-update poller sees a newer manifest version. Mirrors the
   // desktopNotify pattern — main subscribes to manta-server's /events SSE,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1607,6 +1607,14 @@ export const IPC = {
   // and the banner can never disagree.
   serverUpdateCheck: "server:update-check",           // () → ServerUpdateCheck
 
+  // ---- single-CLI update (BET-1162 server half, BET-1159/BET-1161 renderer) ----
+  // Upgrade exactly ONE installed box CLI (opencode / claude / codex / kimi)
+  // by catalog id, reusing the cached CLI detector + the shared runUpgrade
+  // spawn. Returns {ok, before?, after?, changed?, error?} — never rejects.
+  // This is the per-row action the renderer's per-row split (BET-1159) calls,
+  // and the resolve point after which BET-1161 re-checks update targets.
+  serverCliUpdate: "server:cli-update",               // (cliId: string) → CliUpdateResult
+
   // ---- client version (BET-225 stage 3) ----
   // Returns the desktop app's own version via Electron's `app.getVersion()`
   // (which reads the same package.json the server uses). Renderer combines

--- a/src/shared/updateTargets.d.mts
+++ b/src/shared/updateTargets.d.mts
@@ -77,3 +77,20 @@ export function rowUpdateState(
   id: string,
   state?: { updatingTargetId?: string | null; busy?: boolean },
 ): RowUpdateState;
+
+/**
+ * Discriminate a target into "a box-side CLI" vs the two special targets.
+ * A CLI row runs just that CLI's upgrade; the server row keeps the full
+ * self-update; the desktop row keeps the download. Keyed off id, never off
+ * label or disruption (BET-1159).
+ */
+export function isCliTarget(t: UpdateTarget | null | undefined): boolean;
+
+/**
+ * Decide whether to re-run `refreshUpdateTargets()` after a CLI-update RPC
+ * resolves (BET-1161). Refreshes only on an explicit `ok:true` — a failed or
+ * absent result is left intact so the row keeps the Update button for retry.
+ */
+export function shouldRefreshAfterCliUpdate(
+  res: { ok: boolean; error?: string } | null | undefined,
+): boolean;

--- a/src/shared/updateTargets.mjs
+++ b/src/shared/updateTargets.mjs
@@ -254,3 +254,38 @@ export function rowUpdateState(id, { updatingTargetId = null, busy = false } = {
   if (updatingTargetId != null || busy) return { kind: "busy" };
   return { kind: "idle" };
 }
+
+/**
+ * Discriminate a per-row/per-target update action into "a box-side CLI" vs the
+ * two special targets (BET-1159). A CLI row (opencode / claude / codex / kimi)
+ * runs JUST that CLI's upgrade via `runCliUpdate`; the server row keeps the
+ * full self-update and the desktop row keeps the download. Keyed off `id`, never
+ * off label or disruption, so the banner and the Settings rows can never
+ * disagree about which action a target takes.
+ *
+ * @param {object} t an UpdateTarget
+ * @returns {boolean} true when `t` is a box-side CLI (everything but desktop/server)
+ */
+export function isCliTarget(t) {
+  return Boolean(t && t.id !== "desktop" && t.id !== "server");
+}
+
+/**
+ * Decide whether to re-run `refreshUpdateTargets()` after a CLI-update RPC
+ * resolves (BET-1161, STEP 2). We refresh ONLY on success: a failed RPC must
+ * NOT be refreshed into a lie — the target's versions stay as-is (still
+ * "available"), so the row keeps the Update button for retry and the error is
+ * rendered by BET-1160's per-target errors. On a genuine success the re-check
+ * drops the target from the available set, so the row flips to "Up to date"
+ * and the banner clears automatically.
+ *
+ * Note the RPC shown here is the *result* — a *thrown* RPC (route missing /
+ * 500) is a separate path: runCliUpdate's catch renders the per-target error
+ * instead, and this stays false (no refresh into a lie).
+ *
+ * @param {{ok: boolean}|null} res the `server:cli-update` RPC result
+ * @returns {boolean} true when a re-check should follow
+ */
+export function shouldRefreshAfterCliUpdate(res) {
+  return Boolean(res && res.ok);
+}

--- a/src/shared/updateTargets.test.ts
+++ b/src/shared/updateTargets.test.ts
@@ -7,6 +7,8 @@ import {
   describeUpdateBanner,
   planUpdateAll,
   rowUpdateState,
+  isCliTarget,
+  shouldRefreshAfterCliUpdate,
 } from "./updateTargets.mjs";
 
 const cli = (
@@ -442,5 +444,54 @@ describe("rowUpdateState", () => {
   it("reports `idle` when nothing is in flight", () => {
     expect(rowUpdateState("desktop", { updatingTargetId: null, busy: false })).toEqual({ kind: "idle" });
     expect(rowUpdateState("server", {})).toEqual({ kind: "idle" });
+  });
+});
+
+describe("isCliTarget (BET-1159 discriminator)", () => {
+  const t = (
+    id: UpdateTarget["id"],
+    disruption: UpdateTarget["disruption"] = "none",
+  ): UpdateTarget => ({
+    id,
+    label: id,
+    current: null,
+    latest: null,
+    available: true,
+    ok: true,
+    manual: false,
+    disruption,
+  });
+
+  it("desktop and server are NOT CLI targets", () => {
+    expect(isCliTarget(t("desktop"))).toBe(false);
+    expect(isCliTarget(t("server"))).toBe(false);
+  });
+
+  it("every box CLI id is a CLI target, whatever its disruption", () => {
+    for (const [id, disruption] of [
+      ["opencode", "ends-turns"],
+      ["claude", "none"],
+      ["codex", "reconnect"],
+      ["kimi", "none"],
+    ] as const) {
+      expect(isCliTarget(t(id, disruption))).toBe(true);
+    }
+  });
+
+  it("a null/undefined target is never a CLI target", () => {
+    expect(isCliTarget(null as unknown as UpdateTarget)).toBe(false);
+    expect(isCliTarget(undefined as unknown as UpdateTarget)).toBe(false);
+  });
+});
+
+describe("shouldRefreshAfterCliUpdate (BET-1161)", () => {
+  it("refreshes only on an explicit ok:true result", () => {
+    expect(shouldRefreshAfterCliUpdate({ ok: true })).toBe(true);
+    expect(shouldRefreshAfterCliUpdate({ ok: false, error: "boom" })).toBe(false);
+  });
+
+  it("never refreshes on a null/absent result (don't refresh into a lie)", () => {
+    expect(shouldRefreshAfterCliUpdate(null)).toBe(false);
+    expect(shouldRefreshAfterCliUpdate(undefined)).toBe(false);
   });
 });


### PR DESCRIPTION
**BET-1161 — After an update completes, banner/Settings still show the update as available (no re-check)**

## What & why

After a per-CLI update succeeds, the banner and Settings → About kept showing
the target as "…has an update available" because `updateTargets` was never
re-checked. A CLI-only update restarts nothing, so the desktop had no event to
trigger the reconnect re-check (the box path re-checks on reconnect; CLI-only
does not). This is half of the "click Update, flickers and does nothing" report.

The fix: after a CLI-update RPC resolves successfully, re-run the **shared**
`refreshUpdateTargets()` so the UI reflects the new version and stops offering
the Update button (row → "Up to date" via the existing `describeUpdateTarget`;
banner clears).

## Implementation (one renderer pass over BET-1159 / 1160 / 1161)

BET-1161's refresh lives inside `runCliUpdate`, which BET-1159 owns and which
did not exist on `main` yet (BET-1159 `todo`, BET-1160 store contract and
BET-1162 RPC are unmerged PRs). To make BET-1161's refresh real, testable and
mergeable I implemented the renderer chain it needs:

- **`runCliUpdate` in `App.tsx`** in BET-1161's exact final order:
  1. `setUpdatingTarget(t.id)`
  2. `await window.api.serverCliUpdate(t.id)` (BET-1162 `server:cli-update` RPC)
  3. on error → `setTargetUpdateError(t.id, …)`
  4. `finally` → `setUpdatingTarget(null)`
  5. `void refreshUpdateTargets().catch(() => {})` — **runs AFTER the busy flag
     clears** (the finally above), and **only on success** (`shouldRefreshAfterCliUpdate`).

  **Success vs error (BET-1161 STEP 2):** refresh on success only. A failed RPC
  is NOT refreshed into a lie — the target's versions stay as-is (still
  "available"), so the row keeps the Update button for retry and the per-target
  error renders. On a genuine success the shared refresh drops the target from
  the available set.

- **Pure helpers in `src/shared/updateTargets.mjs`** (+ `.d.mts`, + tests):
  - `isCliTarget(t)` — the shared discriminator (`t.id !== "desktop" && !== "server"`),
    used by both the banner action and the Settings rows (BET-1159 reuse/reduction).
  - `shouldRefreshAfterCliUpdate(res)` — the BET-1161 "refresh only on ok:true" decision.

- **BET-1160 store contract** in `store.ts` (`updatingTargetId`,
  `targetUpdateErrors`, `setUpdatingTarget`, `setTargetUpdateError`) — the agreed
  shape from #1164, which `runCliUpdate` drives. Not yet on `main`, so included
  here; if #1164 merges first, this slice trivially drops.

- **BET-1162 client glue** for `server:cli-update` (`types.ts` IPC key,
  `api.ts` signature, `httpApi.ts` impl, `demoCoverage` inventory).

- **Routing:** the unified banner action and Settings rows route a CLI target
  (opencode / claude / codex / kimi) to `runCliUpdate`; the server row keeps the
  full box flow (`applyServerUpdate`), the desktop row keeps the download.
  **No server change (BET-1162 owns the RPC); `runUpdateAll` / box orchestration untouched.**

> Note per BET-1161: the box path already re-checks on reconnect (verified in
> App.tsx's reconnect → `setUpdateRefreshKey` effect), so no second refresh was
> added to it — the refresh here is CLI-only, exactly as scoped.

**Files changed:** 10. `App.tsx`, `Settings.tsx`, `store.ts`, `api/httpApi.ts`,
`api/demoCoverage.test.ts`, `shared/api.ts`, `shared/types.ts`,
`shared/updateTargets.{mjs,d.mts,test.ts}`.

**Base: origin/main @ `a5d9d96f`**

**Verification results:**
- PR branch (`multica/BET-1161-update-refresh` @ `da85ddef`):
  - typecheck: exit 0. Errors: none. log sha256: `3d4bc0be89b28c0a51064f0f739e86bf359f9b52ad80b17275e2301a47d5026c`
  - test: exit 0, 0 fail (vitest 3158: 3151 pass / 7 skip; server node:test 1912 / 0 fail). Failures: none. log sha256: `b1df26fdc46b4253c277fa2dc6b9ab63c2d68970b60d1349fff62fb1d0c33a82`
- Base (`main` @ `a5d9d96f`):
  - typecheck: exit 0. Errors: none. log sha256: `3d4bc0be89b28c0a51064f0f739e86bf359f9b52ad80b17275e2301a47d5026c`
  - test: exit 0, 0 fail (vitest 3156: 3149 pass / 7 skip; server node:test 1912 / 0 fail). Failures: none.
- **Conclusion:** 0 test failures — new and pre-existing both empty; PR branch fully green.

Logs cached at /tmp/typecheck-pr.log, /tmp/typecheck-main.log, /tmp/test-pr.log, /tmp/test-main.log.

## Cross-cutting / dependency notes

One renderer pass spanning BET-1159 (runCliUpdate+routing), BET-1160 (store
contract), BET-1161 (refresh), plus the BET-1162 client-side RPC glue.
Deliberately renderer-only; the `server:cli-update` server route is BET-1162's PR.
