### PR TITLE
refactor(server): single source for home AI CLI install dirs (BET-1163)

### DIFF
--- a/scripts/install.test.mjs
+++ b/scripts/install.test.mjs
@@ -4950,11 +4950,21 @@ test("self-update.sh NODE_CMD: no-runtime box resolves node to an absolute path 
 
 test("self-update.sh prepends AI CLI install dirs to PATH for the upgrade step (BET-1158)", () => {
   const src = scriptFile("self-update.sh");
-  const start = src.indexOf('if [ -n "${HOME:-}" ]; then');
+  const start = src.indexOf('if [ -n "${HOME:-}" ] &&');
   assert.ok(start !== -1, "self-update.sh must prepend CLI install dirs to PATH");
   const end = src.indexOf("\n\n", start);
   assert.ok(end !== -1, "CLI-dirs PATH block must be followed by a blank line");
   const block = src.slice(start, end);
+
+  // The dir list is NOT hardcoded in the shell (BET-1163): it must come from
+  // the single source, HOME_CLI_INSTALL_DIRS, emitted by
+  // scripts/list-cli-bin-dirs.mjs, which the block shells out to via NODE_CMD.
+  // The "must not hardcode" assertion pins the drift-trap fix at the source.
+  assert.match(
+    block,
+    /list-cli-bin-dirs\.mjs/,
+    "the CLI-dirs PATH block must consume scripts/list-cli-bin-dirs.mjs, not repeat the dirs",
+  );
 
   const fakeHome = mkdtempSync(join(tmpdir(), "manta-cli-home-"));
   try {
@@ -4962,7 +4972,7 @@ test("self-update.sh prepends AI CLI install dirs to PATH for the upgrade step (
     mkdirSync(join(fakeHome, ".opencode", "bin"), { recursive: true });
     const out = runSelfUpdateSnippet(
       block,
-      `HOME="${fakeHome}"`,
+      `HOME="${fakeHome}"\nNODE_CMD="$(command -v node)"\nMANTA_HOME="${join(__dirname, "..")}"`,
       [
         'case ":$PATH:" in *":$HOME/.local/bin:"*) echo "LOCAL_BIN=1";; *) echo "LOCAL_BIN=0";; esac',
         'case ":$PATH:" in *":$HOME/.opencode/bin:"*) echo "OPENCODE_BIN=1";; *) echo "OPENCODE_BIN=0";; esac',

--- a/scripts/list-cli-bin-dirs.mjs
+++ b/scripts/list-cli-bin-dirs.mjs
@@ -1,0 +1,18 @@
+// list-cli-bin-dirs.mjs — emit the HOME-relative AI CLI install dirs to
+// stdout, one per line.
+//
+// Single source: HOME_CLI_INSTALL_DIRS in src/shared/cliCatalog.mjs — the
+// SAME constant resolveBinary() in src/server/cliUpdates.mjs pins. It is kept
+// as a separate small script so scripts/self-update.sh (a POSIX-ish bash
+// updater that has NODE_CMD in scope) can consume the machine-readable list
+// without duplicating the dirs in shell (BET-1163).
+//
+// Emitted paths are RELATIVE to $HOME (e.g. `.local/bin`); the caller prepends
+// `$HOME/` when building an absolute dir. This mirrors how resolveBinary()
+// resolves each entry against its own env.HOME.
+
+import { HOME_CLI_INSTALL_DIRS } from "../src/shared/cliCatalog.mjs";
+
+for (const rel of HOME_CLI_INSTALL_DIRS) {
+  process.stdout.write(rel + "\n");
+}

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -121,18 +121,26 @@ fi
 
 # --- Put the AI CLIs on PATH for the upgrade step (BET-1158) ------------------
 # upgrade-clis.mjs spawns each installed CLI's upgrade command BY NAME
-# (`opencode upgrade`, `claude update`, …) and those binaries live in
-# ~/.local/bin (claude), ~/.opencode/bin (opencode) and ~/.bun/bin — dirs that
-# a ~/.bashrc adds but a systemd/launchd service's minimal PATH never carries.
-# Prepend the same home-relative set resolveBinary() in
-# src/server/cliUpdates.mjs searches so the upgrade commands resolve. A
-# packaged box already got its vendored runtime/node/bin above; these are the
-# user-level dirs that apply to every box kind.
-if [ -n "${HOME:-}" ]; then
-  for _cli_dir in "$HOME/.local/bin" "$HOME/.opencode/bin" "$HOME/.bun/bin"; do
+# (`opencode upgrade`, `claude update`, …) and those binaries live in dirs
+# that a ~/.bashrc adds but a systemd/launchd service's minimal PATH never
+# carries. Prepend the same home-relative set resolveBinary() in
+# src/server/cliUpdates.mjs searches so the upgrade commands resolve.
+#
+# The list is NOT hardcoded here (BET-1163): it comes from the SINGLE source,
+# HOME_CLI_INSTALL_DIRS in src/shared/cliCatalog.mjs — emitted by
+# scripts/list-cli-bin-dirs.mjs (RELATIVE to $HOME, one per line). Only
+# existing dirs are added, so a box missing some is unaffected. Guarded on
+# node + the script being present; if node can't run, the CLI upgrade step
+# below is skipped anyway, so skipping the prepend is consistent. A packaged
+# box already got its vendored runtime/node/bin above; these are the user-level
+# dirs that apply to every box kind.
+if [ -n "${HOME:-}" ] && [ -x "$NODE_CMD" ] && [ -f "$MANTA_HOME/scripts/list-cli-bin-dirs.mjs" ]; then
+  while IFS= read -r _rel_dir; do
+    [ -n "$_rel_dir" ] || continue
+    _cli_dir="$HOME/$_rel_dir"
     [ -d "$_cli_dir" ] || continue
     PATH="$_cli_dir:$PATH"
-  done
+  done < <("$NODE_CMD" "$MANTA_HOME/scripts/list-cli-bin-dirs.mjs")
   export PATH
 fi
 

--- a/src/server/cliUpdates.mjs
+++ b/src/server/cliUpdates.mjs
@@ -15,7 +15,11 @@ import { join } from "node:path";
 import { constants } from "node:fs";
 import { access as fsAccess } from "node:fs/promises";
 import { spawn as nodeSpawn } from "node:child_process";
-import { CLI_CATALOG, resolveUpgradeCommand } from "../shared/cliCatalog.mjs";
+import {
+  CLI_CATALOG,
+  HOME_CLI_INSTALL_DIRS,
+  resolveUpgradeCommand,
+} from "../shared/cliCatalog.mjs";
 import { isUpdateAvailable } from "../shared/versionCompare.mjs";
 import { createJsonFetcher } from "./conditionalFetch.mjs";
 
@@ -68,10 +72,13 @@ function defaultFetchJsonFor(entryId) {
  */
 export async function resolveBinary(bin, { access, env }) {
   const home = env?.HOME ?? "";
+  // The home CLI install dirs come from the single shared source
+  // (HOME_CLI_INSTALL_DIRS in src/shared/cliCatalog.mjs) — the same list
+  // scripts/self-update.sh prepends to PATH for its by-name upgrade commands
+  // (BET-1163). /opt/homebrew/bin and /usr/local/bin are system-level dirs
+  // (not home-relative) and are pinned additionally.
   const pinned = [
-    join(home, ".local", "bin"),
-    join(home, ".opencode", "bin"),
-    join(home, ".bun", "bin"),
+    ...HOME_CLI_INSTALL_DIRS.map((rel) => join(home, rel)),
     "/opt/homebrew/bin",
     "/usr/local/bin",
   ];

--- a/src/server/cliUpdates.test.mjs
+++ b/src/server/cliUpdates.test.mjs
@@ -18,6 +18,7 @@ import {
   detectClis,
   createCliDetector,
 } from "./cliUpdates.mjs";
+import { HOME_CLI_INSTALL_DIRS } from "../shared/cliCatalog.mjs";
 
 // ---------------------------------------------------------------------------
 // resolveBinary — THE PATH TRAP regression
@@ -56,6 +57,25 @@ test("resolveBinary: falls back to a PATH-visible binary not in a pinned dir", a
   const env = { HOME: "/home/user", PATH: "/usr/bin:/home/user/.opencode/bin" };
   const access = makeAccess(["/home/user/.opencode/bin/opencode"]);
   assert.equal(await resolveBinary("opencode", { access, env }), "/home/user/.opencode/bin/opencode");
+});
+
+test("resolveBinary: searches EVERY home CLI install dir from the single shared source (BET-1163)", async () => {
+  // The home CLI dirs are no longer hardcoded here — they come from
+  // HOME_CLI_INSTALL_DIRS (src/shared/cliCatalog.mjs), the SAME constant
+  // scripts/self-update.sh consumes (via scripts/list-cli-bin-dirs.mjs). This
+  // pins that the detector really consumes the whole shared list: a binary
+  // placed ONLY in each listed home dir must be found. If someone adds a dir
+  // to the shared source, this test forces resolveBinary to search it too —
+  // the drift-trap is structural, not remembered.
+  const home = "/home/user";
+  const env = { HOME: home, PATH: "/usr/bin:/bin" };
+  assert.ok(Array.isArray(HOME_CLI_INSTALL_DIRS) && HOME_CLI_INSTALL_DIRS.length > 0);
+  for (const rel of HOME_CLI_INSTALL_DIRS) {
+    const abs = `${home}/${rel}/somecli`;
+    const access = makeAccess([abs]);
+    const found = await resolveBinary("somecli", { access, env });
+    assert.equal(found, abs, `must search home CLI dir ${home}/${rel}`);
+  }
 });
 
 // ---------------------------------------------------------------------------

--- a/src/shared/cliCatalog.d.mts
+++ b/src/shared/cliCatalog.d.mts
@@ -16,6 +16,15 @@ export interface CliCatalogEntry {
 export const CLI_CATALOG: CliCatalogEntry[];
 
 /**
+ * HOME-relative dirs where the AI CLIs install their binaries
+ * (claude → ~/.local/bin, opencode → ~/.opencode/bin, bun-installed CLIs →
+ * ~/.bun/bin). Resolved against $HOME by each consumer (resolveBinary's
+ * pinning, self-update.sh's PATH prepend). Adding a home CLI dir here reaches
+ * both — never hardcode it in a single consumer (BET-1163).
+ */
+export const HOME_CLI_INSTALL_DIRS: string[];
+
+/**
  * Which command upgrades this CLI, given where its binary actually is.
  * Returns null = "we cannot upgrade this safely" → the UI shows a manual link.
  * Precedence: npm-managed → `npm install -g <pkg>@latest`; Homebrew-managed →

--- a/src/shared/cliCatalog.mjs
+++ b/src/shared/cliCatalog.mjs
@@ -61,6 +61,20 @@ export const CLI_CATALOG = [
   },
 ];
 
+// The HOME-RELATIVE dirs where the AI CLIs install their binaries: claude →
+// ~/.local/bin, opencode → ~/.opencode/bin, bun-installed CLIs → ~/.bun/bin.
+//
+// This is the SINGLE source for the home CLI install-dir list (BET-1163). Two
+// consumers must never drift apart:
+//   * resolveBinary() in src/server/cliUpdates.mjs pins these (resolved against
+//     $HOME) before PATH so a spawned manta-server can find the CLIs.
+//   * scripts/list-cli-bin-dirs.mjs emits them so scripts/self-update.sh can
+//     prepend each existing one to PATH for its by-name upgrade commands.
+// They are RELATIVE to $HOME on purpose — each consumer resolves against its
+// own notion of the box's home. If you add a home CLI dir, add it here and it
+// reaches both.
+export const HOME_CLI_INSTALL_DIRS = [".local/bin", ".opencode/bin", ".bun/bin"];
+
 // Homebrew-managed install prefixes. Re-running a vendor installer over a
 // brew-managed binary installs a shadowing second copy — the upgrade must
 // refuse rather than do that.

--- a/src/shared/cliCatalog.test.ts
+++ b/src/shared/cliCatalog.test.ts
@@ -1,5 +1,26 @@
 import { describe, it, expect } from "vitest";
-import { CLI_CATALOG, resolveUpgradeCommand } from "./cliCatalog.mjs";
+import { CLI_CATALOG, HOME_CLI_INSTALL_DIRS, resolveUpgradeCommand } from "./cliCatalog.mjs";
+
+describe("HOME_CLI_INSTALL_DIRS", () => {
+  it("lists the three home-relative AI CLI install dirs, in resolution order", () => {
+    // Single source of truth for the home CLI install-dir list (BET-1163): the
+    // value resolveBinary() pins AND self-update.sh emits. Keep in sync with
+    // resolveBinary/src/server/cliUpdates.mjs and scripts/list-cli-bin-dirs.mjs.
+    expect(HOME_CLI_INSTALL_DIRS).toEqual([
+      ".local/bin", // claude
+      ".opencode/bin", // opencode
+      ".bun/bin", // bun-installed CLIs
+    ]);
+  });
+
+  it("entries are HOME-relative (no leading slash, no $HOME baked in)", () => {
+    for (const rel of HOME_CLI_INSTALL_DIRS) {
+      expect(rel).toBeTruthy();
+      expect(rel.startsWith("/")).toBe(false);
+      expect(rel.startsWith("./")).toBe(false);
+    }
+  });
+});
 
 describe("CLI_CATALOG", () => {
   it("has the four expected CLIs with their manual URLs", () => {


### PR DESCRIPTION
## BET-1163 — single source of truth for the home AI CLI install dirs

Centralizes the home-relative AI CLI install-dir list (`~/.local/bin`,
`~/.opencode/bin`, `~/.bun/bin`) into ONE module so the detector and the shell
self-update can never silently drift (the BET-1158 follow-up).

### What changed

- **`src/shared/cliCatalog.mjs`** — new export `HOME_CLI_INSTALL_DIRS =
  [".local/bin", ".opencode/bin", ".bun/bin"]` (HOME-relative on purpose).
  This is the single source of truth.
- **`src/server/cliUpdates.mjs`** — `resolveBinary()` now derives its pinned
  home dirs from `HOME_CLI_INSTALL_DIRS` (mapped against `$HOME`) instead of
  hardcoding them; the system-level dirs `/opt/homebrew/bin` and
  `/usr/local/bin` stay pinned as-is (they are not home-relative and were not
  part of the duplicated set).
- **`scripts/list-cli-bin-dirs.mjs`** (new) — emits `HOME_CLI_INSTALL_DIRS`
  one-per-line (HOME-relative), the machine-readable list the shell consumes.
- **`scripts/self-update.sh`** — the `for _cli_dir in "$HOME/.local/bin" …`
  hardcoded PATH-prepend loop is replaced with a loop fed from
  `scripts/list-cli-bin-dirs.mjs` via `NODE_CMD` (which is already in scope at
  that point). Existing dirs are still prepended; absent ones are skipped —
  identical resulting PATH. Guarded on node + the script being present; if
  node is unavailable the CLI-upgrade step is skipped anyway, so skipping the
  prepend is consistent.
- **Tests** — both consumers' tests updated/pinned to the single source:
  - `scripts/install.test.mjs` "self-update.sh prepends AI CLI install dirs…"
    now asserts the block consumes `list-cli-bin-dirs.mjs` (not a hardcoded
    list) and still verifies existing dirs are on PATH / absent dir is not.
  - `src/server/cliUpdates.test.mjs` new test: `resolveBinary` searches EVERY
    dir in `HOME_CLI_INSTALL_DIRS` — a structural pin so any addition to the
    shared source is searched by the detector.
  - `src/shared/cliCatalog.test.ts` new describe pins the constant's contents
    and HOME-relativeness.

### Drift trap closed

Adding a new home CLI install dir now requires touching one place
(`HOME_CLI_INSTALL_DIRS`); both the detector's pinning and the shell's PATH
prepend follow automatically. The old failure mode — detector finds a CLI but
the by-name upgrade command can't resolve (`spawn ENOENT`, update silently not
applied) — is structurally unreachable.

### Verification results

**Files changed:** 8 files (`scripts/install.test.mjs`, `scripts/list-cli-bin-dirs.mjs` (new), `scripts/self-update.sh`, `src/server/cliUpdates.mjs`, `src/server/cliUpdates.test.mjs`, `src/shared/cliCatalog.d.mts`, `src/shared/cliCatalog.mjs`, `src/shared/cliCatalog.test.ts`). Diff stat: `124 insertions(+), 17 deletions(-)`.

- PR branch (`multica/BET-1163-cli-install-dir-single-source` @ `d5df7773`):
  - typecheck: exit 0. Errors: none. log sha256: `3d4bc0be89b28c0a51064f0f739e86bf359f9b52ad80b17275e2301a47d5026c`
  - test: exit 0, 3151 pass / 0 fail / 7 skip (vitest), node:test clean including 264 `install.test.mjs` + 20 `cliUpdates.test.mjs`. Failures: none. log sha256: `8c3658b6016ab1bb83c48c4e1de0a4f15b9b160648336624fb28d2dbf9406915`
- Base (`main` @ `b6cff5eb`):
  - typecheck: exit 0. Errors: none. log sha256: `3d4bc0be89b28c0a51064f0f739e86bf359f9b52ad80b17275e2301a47d5026c`
  - test: exit 0, 3149 pass / 0 fail / 7 skip (vitest), node:test clean. Failures: none. log sha256: `f51dbf4a44f10562c6b2fd05270bf0075bdb48d95acce562000095c7dfaddf91`
- **Conclusion:** 0 test failures (identical pass counts; +2 vitest tests and +1 node:test test are the new tests this PR adds).

**Base: origin/main @ `b6cff5eb`**

No cross-cutting follow-ups; this PR IS the consolidation.
