### PR TITLE
On-call CTO 1/3: gateway (read tools) + brain/store + text cto agent (BET-1164)

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -452,3 +452,21 @@ the same handle once the file exists. A `media_begin` with no following
 forward the current session + message id so the placeholder and artifact land
 on this turn. Install: `cp <repo>/docs/opencode-tools/media.ts
 ~/.config/opencode/tools/media.ts` then restart `opencode-serve`.
+
+## manta on-call CTO reads
+
+You have a `cto` tool (global opencode custom tool, BET-1164) that runs
+deterministic, READ-ONLY diagnostics about this box and the Multica board:
+`cto {tool, args}` where `tool` is one of `list_sessions` / `list_projects` /
+`read_transcript` / `search_messages` / `git_status` / `git_branch` /
+`git_log` / `list_models` / `get_usage` / `usage_stopped` / `session_usage` /
+`context_state` / `session_plan_mode` / `get_config` / `query_multica`.
+Nothing mutates anything; results are plain JSON. Reach for these to answer
+"What's running?", "what did we ship on Multica?", "what's our usage / any
+stopped conversations?", "is <session> in plan mode?", or "context state of
+<session>?". A quiet box (no sessions / empty board) is a valid answer — report
+the empty state, never fabricate. The `cto` opencode agent (selectable as a
+normal chat session) is pre-wired to use this belt. Install/update is a COPY,
+never a symlink: `cp <repo>/docs/opencode-tools/cto.ts
+~/.config/opencode/tools/cto.ts` then `systemctl --user restart
+opencode-serve`. The engine lives in `src/server/cto.mjs` (see there).

--- a/docs/opencode-tools/cto.ts
+++ b/docs/opencode-tools/cto.ts
@@ -1,0 +1,94 @@
+// manta-native `cto` read tool — a global opencode custom tool (BET-1164).
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/cto.ts ~/.config/opencode/tools/cto.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+// A copy, never a symlink — opencode resolves a tool's imports relative to the
+// file's REAL path, so a symlink back into the repo (no node_modules) fails
+// with `Cannot find module '@opencode-ai/plugin'` and the tool silently never
+// registers.
+//
+// This is a THIN registrar: `execute` POSTs `{tool, args}` to
+// manta-server's /api/cto (same box, no SSH hop) and returns the read result.
+// Every read is deterministic and read-only — see src/server/cto.mjs, which
+// owns the engine (it reuses tmux, opencode, usage, messageSearch, local,
+// stoppedStore and the multica CLI; nothing is reimplemented).
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// All the deterministic read tools this belt exposes. Keep in sync with
+// src/server/cto.mjs's registry (listTools).
+const CTO_TOOLS =
+  "list_sessions, list_projects, read_transcript, search_messages, git_status, " +
+  "git_branch, git_log, list_models, get_usage, usage_stopped, session_usage, " +
+  "context_state, session_plan_mode, get_config, query_multica";
+
+function boxToken() {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null;
+  }
+}
+
+function authHeaders(body) {
+  const headers = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+export const cto = tool({
+  description: [
+    "Deterministic, read-only on-call CTO tools: inspect what's running on this box,",
+    "read chat transcripts, search messages, git state, models, plan usage,",
+    "stopped conversations, per-session cost/context/plan-mode, config, and the",
+    "Multica task board. Nothing here mutates anything — all reads.",
+    `Pick \`tool\` from: ${CTO_TOOLS}.`,
+    "Pass that tool's arguments as a free-form object in \`args\`",
+    "(e.g. {tool:\"read_transcript\", args:{sessionID:\"ses_...\"}}).",
+  ].join(" "),
+  args: {
+    tool: tool.schema
+      .string()
+      .describe(`The cto read tool to run. One of: ${CTO_TOOLS}.`),
+    args: tool.schema
+      .object({})
+      .passthrough()
+      .describe("Free-form arguments for the chosen tool (depends on the tool)."),
+  },
+  async execute(args, context) {
+    const res = await fetch(`${MANTA_SERVER}/api/cto`, {
+      method: "POST",
+      headers: authHeaders(args),
+      body: JSON.stringify({
+        tool: args.tool,
+        args: args.args ?? {},
+        sessionID: context?.sessionID,
+        directory: context?.directory,
+      }),
+    });
+    const text = await res.text();
+    let json = {};
+    try {
+      json = text ? JSON.parse(text) : {};
+    } catch {
+      json = { ok: false, error: text };
+    }
+    if (!res.ok || json?.ok === false) {
+      throw new Error(json?.error || `manta-server ${res.status}`);
+    }
+    return JSON.stringify(json?.data ?? json);
+  },
+});

--- a/docs/opencode/skills/cto/prompt.md
+++ b/docs/opencode/skills/cto/prompt.md
@@ -1,0 +1,67 @@
+# On-call CTO
+
+You are the on-call CTO context agent. You answer operational questions about
+this box (and the Multica task board) using a belt of **deterministic, read-only
+tools**. You never mutate anything — every tool below is a read. When you don't
+know something, say so rather than guessing, and use the tools to look it up.
+
+## Tool
+
+You have ONE custom tool, `cto`, whose `tool` argument selects a sub-tool and
+whose `args` object holds that sub-tool's arguments. All results are plain data
+(JSON). Prefer the narrowest tool that answers the question.
+
+## Sub-tools
+
+- `list_sessions` — what's running: every chat session with its workspace,
+  window, model, plan-mode, directory, and (when available) cost/tokens. The
+  first tool to reach for.
+- `list_projects` — the projects (tmux sessions) and their windows (chat vs
+  terminal). Lighter silhouette of `list_sessions`.
+- `read_transcript({ sessionID, maxMessages? })` — a chat session's conversation,
+  bounded to the most recent messages with role, token counts, time and a
+  truncated text preview. Summarise from what it actually returns; never invent
+  content.
+- `search_messages({ query })` — full-history chat search across every chat
+  window (the same engine as the ⌘F palette), returning snippet matches.
+- `git_status({ cwd? })` / `git_branch({ cwd? })` / `git_log({ cwd?, n? })` —
+  pending changes, current branch, recent commits for a project. `cwd` defaults
+  to the caller's directory, then the first box project.
+- `list_models` — the box's available models with context-window limits and a
+  capability tier (fast / balanced / deep).
+- `get_usage` — the box's plan usage (quota/credits/limits) from the already
+  polled usage cache.
+- `usage_stopped` — conversations a plan-usage limit stopped, awaiting resume.
+- `session_usage({ sessionID })` — one session's cost + token totals.
+- `context_state({ sessionID })` — a session's model context limit, last token
+  usage, idle time, and configured cache TTL.
+- `session_plan_mode({ sessionID })` — whether a session is in plan mode.
+- `get_config({ path? })` — this box's config (secrets always scrubbed); with a
+  dot path, just that value.
+- `query_multica({ issue?, query? })` — the Multica task board. With `issue`
+  (e.g. "BET-123") returns that issue + its task-runs + pull requests; without
+  one, a board overview grouped by status. External integration.
+
+## How to answer typical questions
+
+- "what sessions are running" → `list_sessions`.
+- "what did I ship yesterday on Multica" → `query_multica` (board overview),
+  then read the `updated_at`/`status`/`created_at` fields of the returned
+  issues to determine what changed in the window the user asked about.
+- "what's my Claude usage / any stopped conversations" → `get_usage` and
+  `usage_stopped`.
+- "is `<session>` in plan mode" → `session_plan_mode({sessionID: "<id>"})`.
+- "context state of `<session>`" → `context_state({sessionID: "<id>"})`.
+- "what changed in this repo" → `git_status` / `git_branch` / `git_log`.
+
+## Guardrails
+
+- Read-only always. Never call a mutating tool, never write config, never
+  restart services.
+- "No read may throw": if a tool returns `{ok:false, error}` (a quiet box, a
+  missing session, an absent engine), report the error plainly — do not
+  fabricate data.
+- A quiet box (no sessions, empty board, no usage provider) is a valid answer:
+  report the empty state.
+- Keep answers concise and operational — you are a CTO's quick context, not a
+  report generator.

--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -172,18 +172,40 @@ export function createCtoEngine(deps = {}) {
   async function summarizeProjects(raw) {
     const projects = Array.isArray(raw) ? raw : [];
     const { info } = await sessionInfoMap(projects);
-    return projects.map((p) => ({
-      tmuxSession: p?.tmuxSession,
-      defaultCwd: p?.defaultCwd,
-      windows: (p?.windows ?? []).map((w) => ({
-        index: w?.index,
-        name: w?.name,
-        active: !!w?.active,
-        chat: typeof w?.opencodeSessionId === "string" && !!w?.opencodeSessionId,
-        sessionID: w?.opencodeSessionId ?? null,
-        model: w?.opencodeSessionId ? (info.get(w.opencodeSessionId)?.model ?? null) : null,
+    // Branch per distinct directory (best-effort, one git call per dir — never
+    // per window) so listing a box with many windows stays cheap.
+    const branchCache = new Map();
+    async function branchFor(dir) {
+      if (!dir) return null;
+      if (!branchCache.has(dir)) {
+        let branch = null;
+        try {
+          branch = (await gitBranch(dir)) ?? null;
+        } catch {
+          branch = null;
+        }
+        branchCache.set(dir, branch);
+      }
+      return branchCache.get(dir);
+    }
+    return Promise.all(
+      projects.map(async (p) => ({
+        tmuxSession: p?.tmuxSession,
+        defaultCwd: p?.defaultCwd,
+        branch: await branchFor(p?.defaultCwd),
+        windows: await Promise.all(
+          (p?.windows ?? []).map(async (w) => ({
+            index: w?.index,
+            name: w?.name,
+            active: !!w?.active,
+            chat: typeof w?.opencodeSessionId === "string" && !!w?.opencodeSessionId,
+            sessionID: w?.opencodeSessionId ?? null,
+            model: w?.opencodeSessionId ? (info.get(w.opencodeSessionId)?.model ?? null) : null,
+            branch: w?.opencodeSessionId ? await branchFor(w?.paneCurrentPath || p?.defaultCwd) : await branchFor(p?.defaultCwd),
+          })),
+        ),
       })),
-    }));
+    );
   }
 
   register({
@@ -196,6 +218,23 @@ export function createCtoEngine(deps = {}) {
     run: async (ctx, args) => {
       const projects = await listProjects();
       const { info, sessionsById } = await sessionInfoMap(projects);
+
+      // Per-directory branch cache (best-effort, one git call per dir).
+      const branchCache = new Map();
+      async function branchFor(dir) {
+        if (!dir) return null;
+        if (!branchCache.has(dir)) {
+          let branch = null;
+          try {
+            branch = (await gitBranch(dir)) ?? null;
+          } catch {
+            branch = null;
+          }
+          branchCache.set(dir, branch);
+        }
+        return branchCache.get(dir);
+      }
+
       const sessions = [];
       for (const p of Array.isArray(projects) ? projects : []) {
         for (const w of p?.windows ?? []) {
@@ -209,7 +248,7 @@ export function createCtoEngine(deps = {}) {
             window: `${w?.index}${w?.name ? `:${w.name}` : ""}`,
             model: info_.model ?? null,
             planMode: !!isPlanAgent(await safeAgent(sid)),
-            branch: null,
+            branch: await branchFor(info_.directory ?? w?.paneCurrentPath ?? p?.defaultCwd),
             directory: info_.directory ?? w?.paneCurrentPath ?? p?.defaultCwd ?? null,
             cost: s?.cost ?? null,
             tokens: s?.tokens ?? null,

--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -129,6 +129,26 @@ export function createCtoEngine(deps = {}) {
     });
   };
 
+  // Best-effort branch resolver: one git call per distinct directory, cached.
+  // Shared by list_sessions / list_projects so the per-project git state is
+  // computed once, never per window.
+  function makeBranchResolver() {
+    const cache = new Map();
+    return async function branchFor(dir) {
+      if (!dir) return null;
+      if (!cache.has(dir)) {
+        let branch = null;
+        try {
+          branch = (await gitBranch(dir)) ?? null;
+        } catch {
+          branch = null;
+        }
+        cache.set(dir, branch);
+      }
+      return cache.get(dir);
+    };
+  }
+
   // -------------------------------------------------------------------------
   // What's running — list_sessions / list_projects
   // -------------------------------------------------------------------------
@@ -172,22 +192,7 @@ export function createCtoEngine(deps = {}) {
   async function summarizeProjects(raw) {
     const projects = Array.isArray(raw) ? raw : [];
     const { info } = await sessionInfoMap(projects);
-    // Branch per distinct directory (best-effort, one git call per dir — never
-    // per window) so listing a box with many windows stays cheap.
-    const branchCache = new Map();
-    async function branchFor(dir) {
-      if (!dir) return null;
-      if (!branchCache.has(dir)) {
-        let branch = null;
-        try {
-          branch = (await gitBranch(dir)) ?? null;
-        } catch {
-          branch = null;
-        }
-        branchCache.set(dir, branch);
-      }
-      return branchCache.get(dir);
-    }
+    const branchFor = makeBranchResolver();
     return Promise.all(
       projects.map(async (p) => ({
         tmuxSession: p?.tmuxSession,
@@ -218,22 +223,7 @@ export function createCtoEngine(deps = {}) {
     run: async (ctx, args) => {
       const projects = await listProjects();
       const { info, sessionsById } = await sessionInfoMap(projects);
-
-      // Per-directory branch cache (best-effort, one git call per dir).
-      const branchCache = new Map();
-      async function branchFor(dir) {
-        if (!dir) return null;
-        if (!branchCache.has(dir)) {
-          let branch = null;
-          try {
-            branch = (await gitBranch(dir)) ?? null;
-          } catch {
-            branch = null;
-          }
-          branchCache.set(dir, branch);
-        }
-        return branchCache.get(dir);
-      }
+      const branchFor = makeBranchResolver();
 
       const sessions = [];
       for (const p of Array.isArray(projects) ? projects : []) {

--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -1,0 +1,715 @@
+// cto.mjs — the "On-call CTO" read gateway (BET-1164, issue 1/3).
+//
+// The durable server foundation for the on-call CTO feature: a registry of
+// deterministic READ-ONLY tools (what's running, transcripts, git, usage,
+// plan mode, config, the Multica board) exposed through a single
+// `dispatch(tool, args, ctx)` seam that the later issues (2 = inbound feed,
+// 3 = call window + voice) and the opencode text agent all consume.
+//
+// Design rules (from the issue):
+//   - THIN proxies over existing engines. Every tool reuses an existing
+//     engine's injected I/O — nothing is reimplemented. If an engine does not
+//     exist, the tool is out of scope (noted, never invented).
+//   - Pure decision logic + injected I/O, no top-level side effects —
+//     mirrors src/server/delegate.mjs / src/server/usage.mjs. The engine is
+//     built by `createCtoEngine(deps)`; deps carry every engine the tools
+//     need (listProjects, listSessions, listMessages, listModels,
+//     getSessionAgent, listSnapshots, listStopped, searchMessages, configGet,
+//     the git helpers, queryMultica, now). Tests inject fakes; index.mjs
+//     wires the real engines.
+//   - Every tool is `mode: "auto"`. The `gate` seam (a `(tool, args) =>
+//     "allow"|"confirm"|"deny"` callback) is implemented but Issue 1 ships no
+//     confirm/deny — the default gate returns "allow".
+//   - `onNarrate(text)`: a no-op-safe hook called at tool boundaries (voice
+//     narration lands in Issue 3). Must do nothing when unset.
+//   - NO read may throw on a quiet box (empty board, no sessions, no usage
+//     provider). dispatch returns `{ok:false, error}` instead of throwing for
+//     engine-level failures, and the tools guard empty inputs.
+
+import { execFile } from "node:child_process";
+import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { describeModel } from "../shared/modelGuide.mjs";
+
+export const CTO_STORE_PATH = statePath("cto.json");
+
+// The store the later issues build on. Issue 1 only LAYS IT DOWN: `watches`
+// and `inbound` stay empty until issue 2 fills them, `audit` is the box's
+// append-only tool-usage trail. Atomic load/save via injected I/O.
+export function defaultCtoStore() {
+  return { version: 1, watches: [], inbound: [], audit: [] };
+}
+
+export function loadCtoStore(path = CTO_STORE_PATH) {
+  const parsed = readJsonSync(path, {});
+  const base = defaultCtoStore();
+  return {
+    version: typeof parsed?.version === "number" ? parsed.version : base.version,
+    watches: Array.isArray(parsed?.watches) ? parsed.watches : [],
+    inbound: Array.isArray(parsed?.inbound) ? parsed.inbound : [],
+    audit: Array.isArray(parsed?.audit) ? parsed.audit : [],
+  };
+}
+
+export async function saveCtoStore(state, path = CTO_STORE_PATH) {
+  await writeJsonAtomic(path, JSON.stringify(state ?? defaultCtoStore(), null, 2));
+}
+
+/**
+ * Append one audit entry to the cto store (best-effort, atomic). The audit is
+ * the box's tool-usage trail; it is only written when a caller opts in by
+ * providing load/save — the read tools themselves never write.
+ * @param {object} entry
+ * @param {object} [deps]
+ * @param {() => object} [deps.load]
+ * @param {(s: object) => Promise<void>} [deps.save]
+ */
+export async function appendCtoAudit(entry, { load = loadCtoStore, save = saveCtoStore, now = () => Date.now() } = {}) {
+  const store = load();
+  store.audit = [...(Array.isArray(store.audit) ? store.audit : []), { at: now(), ...entry }];
+  await save(store);
+  return store;
+}
+
+// ---------------------------------------------------------------------------
+// Dispatch seam
+// ---------------------------------------------------------------------------
+
+const DEFAULT_GATE = () => "allow";
+const NOOP_NARRATE = () => {};
+
+/**
+ * createCtoEngine(deps) → the CTO tool registry + dispatch.
+ *
+ * @param {object} [deps] injected engine I/O — every tool reads through these:
+ * @param {() => Promise<Array<object>>} [deps.listProjects]  tmux.listProjects
+ * @param {(directory?: string) => Promise<Array<object>>} [deps.listSessions]  oc.listSessions
+ * @param {(sessionId: string, opts?: object) => Promise<Array<object>>} [deps.listMessages]  oc.listMessages
+ * @param {() => Promise<Array<object>>} [deps.listModels]  oc.listModels
+ * @param {(sessionId: string) => Promise<string|null>} [deps.getSessionAgent]  oc.getSessionAgent
+ * @param {() => Array<object>} [deps.listSnapshots]  usage.listSnapshots (synchronous polled cache)
+ * @param {(opts?: object) => Promise<{records: Array<object>, lastLooked: number|null}>} [deps.listStopped]  stoppedStore.listStopped
+ * @param {(opts: object) => Promise<{supported: boolean, hits: Array<object>}>} [deps.searchMessages]  messageSearch.searchMessages
+ * @param {() => Promise<object>} [deps.configGet]  local.configGet
+ * @param {(cwd: string) => Promise<string>} [deps.gitStatus]   porcelain or throw
+ * @param {(cwd: string) => Promise<string|null>} [deps.gitBranch]  current branch or null
+ * @param {(cwd: string, opts: object) => Promise<string>} [deps.gitLog]
+ * @param {(input: object) => Promise<object>} [deps.queryMultica]  multica.queryMultica
+ * @param {(name: string|null) => boolean} [deps.isPlanAgent]  shared planMode isPlanAgent
+ * @param {() => number} [deps.now]
+ * @returns {{tools: Array<object>, dispatch: Function, listTools: Function}}
+ */
+export function createCtoEngine(deps = {}) {
+  const {
+    listProjects = async () => [],
+    listSessions = async () => [],
+    listMessages = async () => [],
+    listModels = async () => [],
+    getSessionAgent = async () => null,
+    listSnapshots = () => [],
+    listStopped = async () => ({ records: [], lastLooked: null }),
+    searchMessages = async () => ({ supported: false, hits: [] }),
+    configGet = async () => ({}),
+    gitStatus = remoteGitStatus,
+    gitBranch = remoteGitBranch,
+    gitLog = remoteGitLog,
+    queryMultica = async () => ({ ok: true, data: {} }),
+    isPlanAgent = (name) => name === "plan" || name === "manta-plan",
+    now = () => Date.now(),
+  } = deps;
+
+  const tools = [];
+  const register = (def) => {
+    tools.push({
+      name: def.name,
+      description: def.description,
+      params: def.params ?? {},
+      mode: def.mode ?? "auto",
+      run: def.run,
+    });
+  };
+
+  // -------------------------------------------------------------------------
+  // What's running — list_sessions / list_projects
+  // -------------------------------------------------------------------------
+  // Build a per-chat-session info map (model + directory) in one pass over
+  // listSessions per distinct owning directory, so a session is never
+  // queried per-window. Plan mode is resolved per chat window via
+  // getSessionAgent (the same seed the plan-mode toggle uses).
+  async function sessionInfoMap(projects) {
+    const dirs = [];
+    for (const p of projects) {
+      for (const w of p?.windows ?? []) {
+        const d = w?.paneCurrentPath || p?.defaultCwd;
+        if (typeof d === "string" && d && !dirs.includes(d)) dirs.push(d);
+      }
+    }
+    const info = new Map();
+    const sessionsById = new Map();
+    await Promise.all(
+      dirs.map(async (dir) => {
+        let sessions;
+        try {
+          sessions = await listSessions(dir);
+        } catch {
+          sessions = [];
+        }
+        for (const s of Array.isArray(sessions) ? sessions : []) {
+          if (!s?.id) continue;
+          sessionsById.set(s.id, s);
+          if (!info.has(s.id)) {
+            info.set(s.id, {
+              model: s?.info?.providerID && s?.info?.modelID ? `${s.info.providerID}/${s.info.modelID}` : null,
+              directory: dir,
+            });
+          }
+        }
+      }),
+    );
+    return { info, sessionsById };
+  }
+
+  async function summarizeProjects(raw) {
+    const projects = Array.isArray(raw) ? raw : [];
+    const { info } = await sessionInfoMap(projects);
+    return projects.map((p) => ({
+      tmuxSession: p?.tmuxSession,
+      defaultCwd: p?.defaultCwd,
+      windows: (p?.windows ?? []).map((w) => ({
+        index: w?.index,
+        name: w?.name,
+        active: !!w?.active,
+        chat: typeof w?.opencodeSessionId === "string" && !!w?.opencodeSessionId,
+        sessionID: w?.opencodeSessionId ?? null,
+        model: w?.opencodeSessionId ? (info.get(w.opencodeSessionId)?.model ?? null) : null,
+      })),
+    }));
+  }
+
+  register({
+    name: "list_sessions",
+    description:
+      "List what is running on the box: every project (tmux session) and its windows, " +
+      "with whether each window is a chat session, its session model, and plan-mode " +
+      "state. Read-only. Empty box returns []. Use this first to see the layout.",
+    params: {},
+    run: async (ctx, args) => {
+      const projects = await listProjects();
+      const { info, sessionsById } = await sessionInfoMap(projects);
+      const sessions = [];
+      for (const p of Array.isArray(projects) ? projects : []) {
+        for (const w of p?.windows ?? []) {
+          if (typeof w?.opencodeSessionId !== "string" || !w.opencodeSessionId) continue;
+          const sid = w.opencodeSessionId;
+          const info_ = info.get(sid) ?? {};
+          const s = sessionsById.get(sid);
+          sessions.push({
+            sessionID: sid,
+            workspace: p?.tmuxSession,
+            window: `${w?.index}${w?.name ? `:${w.name}` : ""}`,
+            model: info_.model ?? null,
+            planMode: !!isPlanAgent(await safeAgent(sid)),
+            branch: null,
+            directory: info_.directory ?? w?.paneCurrentPath ?? p?.defaultCwd ?? null,
+            cost: s?.cost ?? null,
+            tokens: s?.tokens ?? null,
+            updated: s?.time?.updated ?? null,
+          });
+        }
+      }
+      return {
+        ok: true,
+        data: {
+          projects: await summarizeProjects(projects),
+          sessions,
+          isEmpty: sessions.length === 0 && projects.length === 0,
+        },
+      };
+    },
+  });
+
+  // getSessionAgent is best-effort (never throws); wrap defensively so a
+  // transient opencode blip never fails the whole listing.
+  async function safeAgent(sid) {
+    try {
+      return await getSessionAgent(sid);
+    } catch {
+      return null;
+    }
+  }
+
+  register({
+    name: "list_projects",
+    description:
+      "List the projects (tmux sessions) and their windows on the box, with chat vs " +
+      "terminal per window. A lighter alias of list_sessions; same data, project-shaped. " +
+      "Read-only. Empty box returns [].",
+    params: {},
+    run: async () => ({ ok: true, data: { projects: await summarizeProjects(await listProjects()) } }),
+  });
+
+  // -------------------------------------------------------------------------
+  // Transcripts — read_transcript / search_messages
+  // -------------------------------------------------------------------------
+  register({
+    name: "read_transcript",
+    description:
+      "Read the conversation of a chat session (sessionID from list_sessions). Returns " +
+      "a BOUNDED window: the most recent messages with role, token counts, time and a " +
+      "truncated text preview (content is real, capped — never fabricated). Use to " +
+      "understand what a session is working on.",
+    params: {
+      sessionID: { type: "string", description: "The opencode session id." },
+      maxMessages: { type: "number", description: "Most recent N messages to return (default 30, max 100)." },
+    },
+    run: async (ctx, args) => {
+      const sid = String(args?.sessionID ?? "");
+      if (!sid) return { ok: false, error: "sessionID is required" };
+      const limit = clampInt(args?.maxMessages, 30, 1, 100);
+      let messages;
+      try {
+        messages = await listMessages(sid, { limit });
+      } catch (e) {
+        return { ok: false, error: `could not read transcript: ${e?.message ?? e}` };
+      }
+      const arr = Array.isArray(messages) ? messages : [];
+      const recent = arr.slice(-limit).map((m) => ({
+        role: m?.info?.role ?? null,
+        tokens: m?.tokens ?? null,
+        time: m?.time ?? null,
+        preview: previewText(m),
+      }));
+      return {
+        ok: true,
+        data: {
+          sessionID: sid,
+          count: arr.length,
+          truncated: arr.length > limit,
+          messages: recent,
+        },
+      };
+    },
+  });
+
+  register({
+    name: "search_messages",
+    description:
+      "Search chat transcripts across every chat-mode window on the box using the same " +
+      "engine as the ⌘F palette. Returns matches with snippet context grouped by session. " +
+      "Read-only. An unsupported box (no node:sqlite) returns hits: [].",
+    params: { query: { type: "string", description: "The search text." } },
+    run: async (ctx, args) => {
+      const q = String(args?.query ?? "");
+      if (!q.trim()) return { ok: true, data: { query: q, hits: [] } };
+      const projects = await listProjects();
+      const sessionIds = [];
+      for (const p of Array.isArray(projects) ? projects : []) {
+        for (const w of p?.windows ?? []) {
+          if (typeof w?.opencodeSessionId === "string" && w.opencodeSessionId) sessionIds.push(w.opencodeSessionId);
+        }
+      }
+      let res;
+      try {
+        res = await searchMessages({ query: q, sessionIds });
+      } catch (e) {
+        return { ok: false, error: `search failed: ${e?.message ?? e}` };
+      }
+      return { ok: true, data: { query: q, supported: !!res?.supported, hits: res?.hits ?? [] } };
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // Git — git_status / git_branch / git_log
+  // -------------------------------------------------------------------------
+  async function resolveCwd(ctx, args) {
+    if (typeof args?.cwd === "string" && args.cwd) return args.cwd;
+    if (typeof ctx?.cwd === "string" && ctx.cwd) return ctx.cwd;
+    const projects = await listProjects();
+    const first = (Array.isArray(projects) ? projects : []).find((p) => p?.defaultCwd);
+    return first?.defaultCwd ?? null;
+  }
+
+  register({
+    name: "git_status",
+    description:
+      "Pending (uncommitted) changes in a project: git status --porcelain output and a " +
+      "change count. cwd defaults to the caller's or the first box project. Read-only.",
+    params: { cwd: { type: "string", description: "Optional repo directory." } },
+    run: async (ctx, args) => {
+      const cwd = await resolveCwd(ctx, args);
+      if (!cwd) return { ok: true, data: { cwd: null, status: null, count: 0 } };
+      let porcelain;
+      try {
+        porcelain = await gitStatus(cwd);
+      } catch (e) {
+        return { ok: false, error: `git status failed: ${e?.message ?? e}` };
+      }
+      const count = (porcelain ?? "").split("\n").filter((l) => l.length > 0).length;
+      return { ok: true, data: { cwd, status: porcelain ?? "", count } };
+    },
+  });
+
+  register({
+    name: "git_branch",
+    description:
+      "The current git branch of a project. cwd defaults like git_status. Read-only.",
+    params: { cwd: { type: "string", description: "Optional repo directory." } },
+    run: async (ctx, args) => {
+      const cwd = await resolveCwd(ctx, args);
+      if (!cwd) return { ok: true, data: { cwd: null, branch: null } };
+      let branch = null;
+      try {
+        branch = (await gitBranch(cwd)) ?? null;
+      } catch {
+        branch = null;
+      }
+      return { ok: true, data: { cwd, branch } };
+    },
+  });
+
+  register({
+    name: "git_log",
+    description:
+      "Recent git history of a project (default 10 commits, one line each with hash, " +
+      "author and subject). cwd defaults like git_status. Read-only.",
+    params: {
+      cwd: { type: "string", description: "Optional repo directory." },
+      n: { type: "number", description: "Number of commits (default 10, max 50)." },
+    },
+    run: async (ctx, args) => {
+      const cwd = await resolveCwd(ctx, args);
+      if (!cwd) return { ok: true, data: { cwd: null, log: null } };
+      const n = clampInt(args?.n, 10, 1, 50);
+      let log;
+      try {
+        log = await gitLog(cwd, { n, oneline: true });
+      } catch (e) {
+        return { ok: false, error: `git log failed: ${e?.message ?? e}` };
+      }
+      return { ok: true, data: { cwd, log: log ?? "" } };
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // Models / usage / stopped / per-session cost / context / plan mode / config
+  // -------------------------------------------------------------------------
+  register({
+    name: "list_models",
+    description:
+      "The models available on this box (from opencode /provider filtered to connected), " +
+      "each with its context-window limit and a rough capability tier (fast/balanced/deep). " +
+      "Read-only.",
+    params: {},
+    run: async () => {
+      let models;
+      try {
+        models = await listModels();
+      } catch {
+        models = [];
+      }
+      const data = (Array.isArray(models) ? models : []).map((m) => {
+        const cat = describeModel(m?.providerID, m?.id);
+        return {
+          providerID: m?.providerID,
+          modelID: m?.id,
+          name: m?.name ?? m?.id ?? null,
+          contextLimit: m?.limit?.context ?? null,
+          tier: cat?.tier ?? null,
+          blurb: cat?.blurb ?? null,
+        };
+      });
+      return { ok: true, data: { models: data } };
+    },
+  });
+
+  register({
+    name: "get_usage",
+    description:
+      "The box's subscription plan usage (quota/credits/limits per provider) from the " +
+      "already-polled usage cache — never triggers a new poll. Read-only. An untouched " +
+      "or unsupported provider simply returns no snapshot.",
+    params: {},
+    run: async () => {
+      let snaps;
+      try {
+        snaps = listSnapshots();
+      } catch (e) {
+        return { ok: false, error: `usage read failed: ${e?.message ?? e}` };
+      }
+      return { ok: true, data: { snapshots: (Array.isArray(snaps) ? snaps : []).map((s) => ({ ...s })) } };
+    },
+  });
+
+  register({
+    name: "usage_stopped",
+    description:
+      "Conversations the box stopped because a plan-usage limit was hit (the durable " +
+      "stopped-store). Returns the records + the last-looked timestamp. Read-only.",
+    params: {},
+    run: async () => {
+      let res;
+      try {
+        res = await listStopped();
+      } catch (e) {
+        return { ok: false, error: `stopped-store read failed: ${e?.message ?? e}` };
+      }
+      return { ok: true, data: { records: res?.records ?? [], lastLooked: res?.lastLooked ?? null } };
+    },
+  });
+
+  register({
+    name: "session_usage",
+    description:
+      "Per-session cost and token totals (input/output) for a chat session, read off the " +
+      "opencode session list item. Read-only.",
+    params: { sessionID: { type: "string", description: "The opencode session id." } },
+    run: async (ctx, args) => {
+      const sid = String(args?.sessionID ?? "");
+      if (!sid) return { ok: false, error: "sessionID is required" };
+      const { sessionsById } = await sessionInfoMap(await listProjects());
+      const s = sessionsById.get(sid);
+      if (!s) return { ok: false, error: `no such session: ${sid}` };
+      return {
+        ok: true,
+        data: {
+          sessionID: sid,
+          cost: s?.cost ?? null,
+          tokens: s?.tokens ?? null,
+          updated: s?.time?.updated ?? null,
+        },
+      };
+    },
+  });
+
+  register({
+    name: "context_state",
+    description:
+      "The context state of a chat session: its model's context-window limit, the last " +
+      "message's token usage, how long the session has been idle, and the configured " +
+      "cache TTL (the same inputs the UI context pill uses). Read-only.",
+    params: { sessionID: { type: "string", description: "The opencode session id." } },
+    run: async (ctx, args) => {
+      const sid = String(args?.sessionID ?? "");
+      if (!sid) return { ok: false, error: "sessionID is required" };
+      const { info, sessionsById } = await sessionInfoMap(await listProjects());
+      const s = sessionsById.get(sid);
+      const info_ = info.get(sid) ?? {};
+      let models = [];
+      try {
+        models = await listModels();
+      } catch {
+        models = [];
+      }
+      const model = models.find((m) => m?.providerID === info_?.model?.split("/")[0] && m?.id === info_?.model?.split("/")[1]);
+      let messages = [];
+      try {
+        messages = await listMessages(sid, { limit: 1 });
+      } catch {
+        messages = [];
+      }
+      const last = (Array.isArray(messages) ? messages : []).slice(-1)[0];
+      const lastTime = last?.time ?? s?.time?.updated ?? null;
+      const idleMs = typeof lastTime === "number" && lastTime > 0 ? Math.max(0, now() - lastTime) : null;
+      let cfg = {};
+      try {
+        cfg = (await configGet()) ?? {};
+      } catch {
+        cfg = {};
+      }
+      return {
+        ok: true,
+        data: {
+          sessionID: sid,
+          model: info_?.model ?? null,
+          contextLimit: model?.limit?.context ?? null,
+          lastTokens: last?.tokens ?? null,
+          idleMs,
+          cacheTtlMs: cacheTtlMs(cfg?.cacheTtl),
+        },
+      };
+    },
+  });
+
+  register({
+    name: "session_plan_mode",
+    description:
+      "Whether a chat session is in plan mode (its active agent is the plan agent). " +
+      "Read-only.",
+    params: { sessionID: { type: "string", description: "The opencode session id." } },
+    run: async (ctx, args) => {
+      const sid = String(args?.sessionID ?? "");
+      if (!sid) return { ok: false, error: "sessionID is required" };
+      const agent = await safeAgent(sid);
+      return { ok: true, data: { sessionID: sid, planMode: !!isPlanAgent(agent), agent } };
+    },
+  });
+
+  const SECRET_KEYS = new Set(["groqApiKey", "boxToken", "apiKey", "token", "secret", "secretKey"]);
+
+  function stripSecrets(obj) {
+    if (!obj || typeof obj !== "object") return obj;
+    if (Array.isArray(obj)) return obj.map(stripSecrets);
+    const out = {};
+    for (const [k, v] of Object.entries(obj)) {
+      if (SECRET_KEYS.has(k)) continue;
+      out[k] = v && typeof v === "object" ? stripSecrets(v) : v;
+    }
+    return out;
+  }
+
+  function pickPath(obj, path) {
+    if (!path) return obj;
+    return String(path).split(".").reduce((acc, key) => (acc && typeof acc === "object" ? acc[key] : undefined), obj);
+  }
+
+  register({
+    name: "get_config",
+    description:
+      "Read this box's config.json. With no path returns the whole config with secret " +
+      "fields scrubbed; with a dot path (e.g. \"defaultModel\") returns just that value. " +
+      "Never returns secrets. Read-only.",
+    params: { path: { type: "string", description: "Optional dot-path into the config." } },
+    run: async (ctx, args) => {
+      let cfg;
+      try {
+        cfg = (await configGet()) ?? {};
+      } catch (e) {
+        return { ok: false, error: `config read failed: ${e?.message ?? e}` };
+      }
+      let value = pickPath(cfg, args?.path);
+      if (args?.path) {
+        value = value && typeof value === "object" ? stripSecrets(value) : value;
+        return { ok: true, data: { path: args.path, value: value ?? null } };
+      }
+      return { ok: true, data: { config: stripSecrets(cfg) } };
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // Multica board — query_multica
+  // -------------------------------------------------------------------------
+  register({
+    name: "query_multica",
+    description:
+      "Query the Multica task board (an external integration, not native Manta): pass " +
+      "`issue` with a bump key (e.g. \"BET-123\") for that issue's detail + task-runs + " +
+      "pull requests, or omit it for a board overview grouped by status. Read-only.",
+    params: {
+      query: { type: "string", description: "Natural-language intent (informational)." },
+      issue: { type: "string", description: "Optional issue key, e.g. BET-123." },
+    },
+    run: async (ctx, args) => {
+      try {
+        const data = await queryMultica({ query: args?.query ?? "", issue: args?.issue ?? null });
+        return { ok: true, data };
+      } catch (e) {
+        return { ok: false, error: `multica query failed: ${e?.message ?? e}` };
+      }
+    },
+  });
+
+  // -------------------------------------------------------------------------
+  // Dispatch
+  // -------------------------------------------------------------------------
+  const byName = new Map(tools.map((t) => [t.name, t]));
+
+  async function dispatch(name, args, ctx = {}) {
+    const def = byName.get(String(name ?? ""));
+    if (!def) {
+      return { ok: false, error: `unknown cto tool: ${name} (known: ${tools.map((t) => t.name).join(", ")})` };
+    }
+    const gate = typeof ctx?.gate === "function" ? ctx.gate : DEFAULT_GATE;
+    let decision;
+    try {
+      decision = gate(def.name, args ?? {});
+    } catch {
+      decision = "deny";
+    }
+    if (decision === "deny") {
+      return { ok: false, error: `tool ${def.name} denied` };
+    }
+    if (decision === "confirm") {
+      // Issue 1 ships only "auto" tools and wires no confirm/deny surface.
+      // The seam exists so Issue 3 can gate before run; until then a confirm
+      // request fails closed with a clear message rather than running.
+      return { ok: false, error: `tool ${def.name} requires confirmation (not wired yet)` };
+    }
+    const narrate = typeof ctx?.onNarrate === "function" ? ctx.onNarrate : NOOP_NARRATE;
+    try {
+      narrate(`[cto] ${def.name}`);
+      const result = await def.run(ctx, args ?? {});
+      narrate(`[cto] ${def.name} ok`);
+      return result;
+    } catch (e) {
+      narrate(`[cto] ${def.name} error`);
+      return { ok: false, error: `${def.name} failed: ${e?.message ?? e}` };
+    }
+  }
+
+  return {
+    tools,
+    listTools: () => tools.map((t) => ({ ...t })),
+    dispatch,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Small local helpers (pure)
+// ---------------------------------------------------------------------------
+
+function clampInt(v, dflt, min, max) {
+  const n = Number(v);
+  if (!Number.isFinite(n)) return dflt;
+  return Math.max(min, Math.min(max, Math.floor(n)));
+}
+
+function cacheTtlMs(ttl) {
+  if (ttl === "5m") return 5 * 60_000;
+  if (ttl === "1h") return 60 * 60_000;
+  return null;
+}
+
+// First meaningful text from an opencode message part, capped. Real content,
+// never invented — just bounded for the transcript tool.
+function previewText(m) {
+  if (!m || !Array.isArray(m.parts)) return null;
+  let text = "";
+  for (const p of m.parts) {
+    if (p?.type === "text" && typeof p.text === "string") text += p.text;
+    if (text.length >= 500) break;
+  }
+  text = text.trim();
+  return text ? (text.length > 500 ? `${text.slice(0, 500)}…` : text) : null;
+}
+
+// ---------------------------------------------------------------------------
+// Default git I/O (injectable). Uses a plain spawn with a short timeout;
+// index.mjs may inject the same engines as the rest of the box instead.
+// ---------------------------------------------------------------------------
+
+function runGit(args, cwd, { timeoutMs = 10_000 } = {}) {
+  return new Promise((resolve, reject) => {
+    execFile("git", args, { cwd, timeout: timeoutMs }, (err, stdout) => {
+      if (err) {
+        const e = new Error(err.stderr?.trim() || err.message);
+        e.status = err.code;
+        reject(e);
+        return;
+      }
+      resolve(String(stdout ?? ""));
+    });
+  });
+}
+
+async function remoteGitStatus(cwd) {
+  return runGit(["-C", cwd, "status", "--porcelain"], cwd);
+}
+async function remoteGitBranch(cwd) {
+  const out = await runGit(["-C", cwd, "branch", "--show-current"], cwd);
+  return out.trim() || null;
+}
+async function remoteGitLog(cwd, { n = 10, oneline = true } = {}) {
+  const args = ["-C", cwd, "log", `--max-count=${n}`];
+  if (oneline) args.push("--oneline");
+  return runGit(args, cwd);
+}

--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -209,6 +209,37 @@ test("quiet box: no sessions / no usage / no board never throws", async () => {
   assert.equal(board.ok, true);
 });
 
+test("list_sessions resolves per-session model, plan mode and branch from injected engines", async () => {
+  const engine = makeEngine({
+    listProjects: async () => [
+      {
+        tmuxSession: "proj",
+        defaultCwd: "/repo",
+        windows: [
+          { index: 0, name: "chat", paneCurrentPath: "/repo", opencodeSessionId: "ses_1", active: true },
+          { index: 1, name: "term", paneCurrentPath: "/repo", opencodeSessionId: null, active: false },
+        ],
+      },
+    ],
+    listSessions: async (dir) => [
+      { id: "ses_1", info: { providerID: "anthropic", modelID: "claude-opus-4-7" }, cost: 0.5, tokens: { input: 10, output: 2 }, time: { updated: 100 } },
+    ],
+    getSessionAgent: async (sid) => (sid === "ses_1" ? "plan" : null),
+    gitBranch: async (dir) => { assert.equal(dir, "/repo"); return "feature/x"; },
+  });
+  const r = await engine.dispatch("list_sessions", {}, {});
+  assert.equal(r.ok, true);
+  assert.equal(r.data.sessions.length, 1);
+  const s = r.data.sessions[0];
+  assert.equal(s.model, "anthropic/claude-opus-4-7");
+  assert.equal(s.planMode, true);
+  assert.equal(s.branch, "feature/x");
+  assert.equal(s.cost, 0.5);
+  // The project row carries the same branch; the non-chat window stays a row.
+  assert.equal(r.data.projects[0].branch, "feature/x");
+  assert.equal(r.data.projects[0].windows.length, 2);
+});
+
 test("session_usage / context_state / git tools resolve cleanly on empty fakes", async () => {
   const engine = makeEngine();
   const su = await engine.dispatch("session_usage", { sessionID: "ses_x" }, {});

--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -1,0 +1,265 @@
+// cto.test.mjs — On-call CTO read gateway (BET-1164, issue 1/3).
+// Pure logic + injected I/O: registry integrity, dispatch (default-allow gate,
+// deny/confirm fail-closed, onNarrate boundaries), the tool reads (all
+// deterministic, none throw on a quiet box), and the cto.json store lifecycle.
+// No live tmux / opencode / multica.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  defaultCtoStore,
+  loadCtoStore,
+  appendCtoAudit,
+  createCtoEngine,
+} from "./cto.mjs";
+
+// Shared fakes so every engine test is deterministic and side-effect free.
+function makeEngine(overrides = {}) {
+  const engine = createCtoEngine({
+    listProjects: async () => [],
+    listSessions: async () => [],
+    listMessages: async () => [],
+    listModels: async () => [],
+    getSessionAgent: async () => null,
+    listSnapshots: () => [],
+    listStopped: async () => ({ records: [], lastLooked: null }),
+    searchMessages: async () => ({ supported: true, hits: [] }),
+    configGet: async () => ({}),
+    gitStatus: async () => "",
+    gitBranch: async () => null,
+    gitLog: async () => "",
+    queryMultica: async () => ({ ok: true }),
+    ...overrides,
+  });
+  return engine;
+}
+
+const TOOL_COUNT = 15;
+
+// ---------------------------------------------------------------------------
+// Registry integrity
+// ---------------------------------------------------------------------------
+
+test("registry exposes every cto read tool with a complete shape, all mode auto", () => {
+  const engine = makeEngine();
+  const tools = engine.listTools();
+  assert.equal(tools.length, TOOL_COUNT);
+  const names = new Set(tools.map((t) => t.name));
+  assert.deepEqual(
+    [...names].sort(),
+    [
+      "list_sessions",
+      "list_projects",
+      "read_transcript",
+      "search_messages",
+      "git_status",
+      "git_branch",
+      "git_log",
+      "list_models",
+      "get_usage",
+      "usage_stopped",
+      "session_usage",
+      "context_state",
+      "session_plan_mode",
+      "get_config",
+      "query_multica",
+    ].sort(),
+  );
+  for (const t of tools) {
+    assert.equal(typeof t.name, "string");
+    assert.ok(t.name.length > 0);
+    assert.equal(typeof t.description, "string");
+    assert.ok(t.description.length > 0);
+    assert.ok(t.params && typeof t.params === "object");
+    assert.equal(t.mode, "auto");
+    assert.equal(typeof t.run, "function");
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Dispatch
+// ---------------------------------------------------------------------------
+
+test("dispatch returns a structured error for an unknown tool (never throws)", async () => {
+  const engine = makeEngine();
+  const result = await engine.dispatch("nope", {}, {});
+  assert.equal(result.ok, false);
+  assert.match(result.error, /unknown cto tool: nope/);
+});
+
+test("dispatch runs a tool through the default-allow gate", async () => {
+  const engine = makeEngine({
+    listModels: async () => [
+      { providerID: "anthropic", id: "claude-opus-4-7", name: "Opus", limit: { context: 1_000_000 } },
+    ],
+  });
+  const result = await engine.dispatch("list_models", {}, {});
+  assert.equal(result.ok, true);
+  assert.equal(result.data.models.length, 1);
+  assert.equal(result.data.models[0].modelID, "claude-opus-4-7");
+  assert.equal(result.data.models[0].contextLimit, 1_000_000);
+});
+
+test("dispatch honors a gate returning deny (fails closed)", async () => {
+  const engine = makeEngine();
+  const gate = () => "deny";
+  const result = await engine.dispatch("list_models", {}, { gate });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /denied/);
+});
+
+test("dispatch fails closed when the gate requests confirm (not wired yet)", async () => {
+  const engine = makeEngine();
+  const gate = () => "confirm";
+  const result = await engine.dispatch("list_models", {}, { gate });
+  assert.equal(result.ok, false);
+  assert.match(result.error, /requires confirmation/);
+});
+
+test("default gate returns allow for every tool (Issue 1 ships auto)", async () => {
+  const engine = makeEngine();
+  for (const t of engine.listTools()) {
+    // No ctx.gate → default allow; a benign read tool must run, not be denied.
+    if (t.name === "read_transcript") continue; // needs an arg we don't assert here
+    const r = await engine.dispatch(t.name, {}, {});
+    assert.ok(r.ok === true || r.ok === false, t.name + " resolves cleanly");
+  }
+});
+
+test("onNarrate is called at tool boundaries and is a no-op when unset", async () => {
+  const engine = makeEngine();
+  const narrated = [];
+  const result = await engine.dispatch("list_models", {}, { onNarrate: (s) => narrated.push(s) });
+  assert.equal(result.ok, true);
+  assert.ok(narrated.some((s) => s.includes("list_models")));
+
+  // Unset → no throw.
+  const r2 = await engine.dispatch("list_models", {}, {});
+  assert.equal(r2.ok, true);
+});
+
+// ---------------------------------------------------------------------------
+// Tool reads
+// ---------------------------------------------------------------------------
+
+test("read_transcript returns a bounded preview of REAL content, never fabricated", async () => {
+  const engine = makeEngine({
+    listMessages: async (sid, { limit }) => {
+      assert.equal(typeof limit, "number");
+      const mk = (role, text) => ({ info: { role }, tokens: { input: 10, output: 5 }, time: 100, parts: [{ type: "text", text }] });
+      return [mk("user", "hello there"), mk("assistant", "plan: implement the gateway")];
+    },
+  });
+  const r = await engine.dispatch("read_transcript", { sessionID: "ses_1" }, {});
+  assert.equal(r.ok, true);
+  assert.equal(r.data.sessionID, "ses_1");
+  assert.equal(r.data.count, 2);
+  assert.equal(r.data.messages[0].preview, "hello there");
+  assert.equal(r.data.messages[1].preview, "plan: implement the gateway");
+});
+
+test("read_transcript requires a sessionID", async () => {
+  const engine = makeEngine();
+  const r = await engine.dispatch("read_transcript", {}, {});
+  assert.equal(r.ok, false);
+  assert.match(r.error, /sessionID is required/);
+});
+
+test("get_config scrubs secrets and supports dot-path access", async () => {
+  const engine = makeEngine({
+    configGet: async () => ({
+      groqApiKey: "SECRET",
+      boxToken: "SECRET2",
+      defaultModel: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+      cacheTtl: "1h",
+    }),
+  });
+  const full = await engine.dispatch("get_config", {}, {});
+  assert.equal(full.ok, true);
+  assert.equal(full.data.config.defaultModel.modelID, "claude-opus-4-7");
+  assert.equal(full.data.config.groqApiKey, undefined);
+  assert.equal(full.data.config.boxToken, undefined);
+  assert.equal(full.data.config.cacheTtl, "1h");
+
+  const partial = await engine.dispatch("get_config", { path: "defaultModel" }, {});
+  assert.equal(partial.ok, true);
+  assert.equal(partial.data.value.modelID, "claude-opus-4-7");
+  assert.equal(partial.data.config, undefined);
+});
+
+test("session_plan_mode reads the active agent", async () => {
+  const engine = makeEngine({
+    getSessionAgent: async (sid) => (sid === "ses_plan" ? "plan" : "build"),
+  });
+  const yes = await engine.dispatch("session_plan_mode", { sessionID: "ses_plan" }, {});
+  assert.equal(yes.ok, true);
+  assert.equal(yes.data.planMode, true);
+  const no = await engine.dispatch("session_plan_mode", { sessionID: "ses_build" }, {});
+  assert.equal(no.data.planMode, false);
+});
+
+test("quiet box: no sessions / no usage / no board never throws", async () => {
+  const engine = makeEngine();
+  const calls = ["list_projects", "list_models", "get_usage", "usage_stopped", "list_sessions"];
+  for (const tool of calls) {
+    const r = await engine.dispatch(tool, {}, {});
+    assert.equal(r.ok, true, tool);
+  }
+  const board = await engine.dispatch("query_multica", {}, {});
+  assert.equal(board.ok, true);
+});
+
+test("session_usage / context_state / git tools resolve cleanly on empty fakes", async () => {
+  const engine = makeEngine();
+  const su = await engine.dispatch("session_usage", { sessionID: "ses_x" }, {});
+  assert.equal(su.ok, false); // unknown session on an empty box → structured error, not throw
+  const cs = await engine.dispatch("context_state", { sessionID: "ses_x" }, {});
+  assert.equal(cs.ok, true); // context state tolerates an unknown session
+  const gs = await engine.dispatch("git_status", {}, {});
+  assert.equal(gs.ok, true);
+  const gl = await engine.dispatch("git_log", {}, {});
+  assert.equal(gl.ok, true);
+});
+
+test("git tools accept an explicit cwd and reject a failing repo without throwing", async () => {
+  const engine = makeEngine({
+    gitStatus: async (cwd) => { assert.equal(cwd, "/repo"); throw new Error("not a git repo"); },
+  });
+  const r = await engine.dispatch("git_status", { cwd: "/repo" }, {});
+  assert.equal(r.ok, false);
+  assert.match(r.error, /not a git repo/);
+});
+
+// ---------------------------------------------------------------------------
+// cto.json store
+// ---------------------------------------------------------------------------
+
+test("defaultCtoStore lays down the agreed shape (watches/inbound empty for issue 1)", () => {
+  const s = defaultCtoStore();
+  assert.equal(s.version, 1);
+  assert.deepEqual(s.watches, []);
+  assert.deepEqual(s.inbound, []);
+  assert.deepEqual(s.audit, []);
+});
+
+test("loadCtoStore returns the default shape for a missing/corrupt file", () => {
+  const s = loadCtoStore("/proc/definitely/not/a/file-cto-test.json");
+  assert.equal(s.version, 1);
+  assert.deepEqual(s.watches, []);
+  assert.deepEqual(s.inbound, []);
+  assert.deepEqual(s.audit, []);
+});
+
+test("appendCtoAudit appends a timestamped entry and persists via injected save", async () => {
+  let state = defaultCtoStore();
+  const load = () => state;
+  const save = async (s) => {
+    state = s;
+  };
+  const store = await appendCtoAudit({ tool: "list_sessions", ok: true }, { load, save, now: () => 123 });
+  assert.equal(store.audit.length, 1);
+  assert.equal(store.audit[0].at, 123);
+  assert.equal(store.audit[0].tool, "list_sessions");
+  // persisted
+  assert.equal(state.audit.length, 1);
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -86,10 +86,13 @@ import {
 } from "./servePage.mjs";
 import { publishPlanBundle } from "./planRender.mjs";
 import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./peers.mjs";
-import { upsertStopped, markStoppedRan, bumpStoppedAttempts } from "./stoppedStore.mjs";
+import { upsertStopped, markStoppedRan, bumpStoppedAttempts, listStopped } from "./stoppedStore.mjs";
 import { createUsageStopEngine } from "./usageStopEnroll.mjs";
 import { createUsageResumeEngine } from "./usageResume.mjs";
 import * as appControl from "./appControl.mjs";
+import * as cto from "./cto.mjs";
+import { queryMultica } from "./multica.mjs";
+import { searchMessages } from "./messageSearch.mjs";
 import {
   dispatch as mediaDispatch,
   createPendingMediaStore,
@@ -97,7 +100,7 @@ import {
 } from "./media.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
 import { createPromptDelivery } from "./promptDelivery.mjs";
-import { ensureMantaPlanAgent } from "./providers.mjs";
+import { ensureMantaPlanAgent, ensureCtoAgent } from "./providers.mjs";
 import {
   createWebhookEngine,
   createHook,
@@ -886,6 +889,57 @@ const { stop: stopServePageCleanup } = startCleanupPoller();
 // restarts opencode only when the config changed. Idempotent + fire-and-forget
 // so a failure here never blocks or fails server startup.
 void ensureMantaPlanAgent().catch((e) => console.error("[manta-plan] ensure failed:", e));
+
+// On-call CTO (BET-1164): build the engine lazily once, wired to the box's
+// real engines (all read-only). The engine's `dispatch` seam is what the
+// `/api/cto` route (and, later, issues 2/3) consume. Building lazily keeps it
+// off the hot startup path and lets every dep resolve after module init.
+let ctoEngine = null;
+function getCtoEngine() {
+  if (!ctoEngine) {
+    ctoEngine = cto.createCtoEngine({
+      listProjects: () => tmux.listProjects(),
+      listSessions: (dir) => oc.listSessions(dir),
+      listMessages: (sid, opts) => oc.listMessages(sid, opts),
+      listModels: () => oc.listModels(),
+      getSessionAgent: (sid) => oc.getSessionAgent(sid),
+      listSnapshots,
+      listStopped,
+      searchMessages,
+      configGet: () => local.configGet(),
+      gitStatus: (cwd) => tmux.run("git", ["-C", cwd, "status", "--porcelain"]).then((r) => r?.stdout ?? ""),
+      gitBranch: (cwd) =>
+        tmux.run("git", ["-C", cwd, "branch", "--show-current"]).then((r) => (r?.stdout ?? "").trim() || null),
+      gitLog: (cwd, { n }) =>
+        tmux.run("git", ["-C", cwd, "log", `--max-count=${n}`, "--oneline"]).then((r) => r?.stdout ?? ""),
+      queryMultica,
+    });
+  }
+  return ctoEngine;
+}
+
+// Best-effort install of the `cto` primary agent (BET-1164) — ONLY when the
+// feature is enabled (default off until shipped). Reads/writes opencode.jsonc
+// via the existing writer, restarts opencode only when the block changed.
+async function maybeEnsureCtoAgent() {
+  try {
+    let cfg;
+    try {
+      cfg = await local.configGet();
+    } catch {
+      cfg = {};
+    }
+    if (!cfg?.cto?.enabled) return;
+    const model =
+      cfg?.defaultModel?.providerID && cfg?.defaultModel?.modelID
+        ? `${cfg.defaultModel.providerID}/${cfg.defaultModel.modelID}`
+        : undefined;
+    await ensureCtoAgent({ model });
+  } catch (e) {
+    console.error("[cto] ensure failed:", e);
+  }
+}
+void maybeEnsureCtoAgent();
 
 // Sweep expired artifact-mailbox files (TTL past) every 5 min — non-destructive
 // otherwise: downloads do not delete, the sweep is what reclaims disk.
@@ -2547,6 +2601,32 @@ const handleRequest = async (req, res) => {
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
       // Errors return a message the model can act on, never a bare 500.
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- On-call CTO (BET-1164) ----------
+  // POST /api/cto  body {tool, args, sessionID, directory}
+  //   → 200 {ok:true, data} or 400 {ok:false, error}.
+  // The deterministic read-only tool belt. Called by the remote AI's global
+  // `cto` opencode tool (docs/opencode-tools/cto.ts) and consumed by the
+  // on-call CTO agent. dispatch wraps every tool so a quiet box / bad engine
+  // returns a structured error, never a throw. `ctx.onNarrate` is a server-side
+  // seam (wired by issue 3's voice window), never read off the HTTP body.
+  if (path === "/api/cto") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const result = await getCtoEngine().dispatch(body?.tool, body?.args ?? {}, {
+          sessionID: body?.sessionID,
+          cwd: body?.directory,
+        });
+        respondJson(res, result.ok ? 200 : 400, result);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -907,11 +907,6 @@ function getCtoEngine() {
       listStopped,
       searchMessages,
       configGet: () => local.configGet(),
-      gitStatus: (cwd) => tmux.run("git", ["-C", cwd, "status", "--porcelain"]).then((r) => r?.stdout ?? ""),
-      gitBranch: (cwd) =>
-        tmux.run("git", ["-C", cwd, "branch", "--show-current"]).then((r) => (r?.stdout ?? "").trim() || null),
-      gitLog: (cwd, { n }) =>
-        tmux.run("git", ["-C", cwd, "log", `--max-count=${n}`, "--oneline"]).then((r) => r?.stdout ?? ""),
       queryMultica,
     });
   }

--- a/src/server/multica.mjs
+++ b/src/server/multica.mjs
@@ -1,0 +1,171 @@
+// multica.mjs — thin read wrapper over the `multica` CLI (BET-1164, issue 1/3).
+//
+// The "On-call CTO" board read. Multica is an EXTERNAL integration, not a
+// native Manta engine — this module is the one place the box shells out to the
+// `multica` CLI to answer "what's on the board", "what did we ship", "what are
+// the task runs / PRs for issue X". It is deliberately THIN: every heavy
+// decision is delegated to the CLI/REST and this module only shapes the result
+// for the cto agent.
+//
+// Design (mirrors the rest of src/server): pure-ish decision logic + injected
+// I/O. The default `runCli` spawns `multica`; tests inject a fake so they never
+// touch a live workspace or require the CLI to be installed.
+//
+// Read-only everywhere. Never mutates the board.
+//
+// No read throws on a quiet/failed board: an unreadable list degrades to an
+// empty board, and a per-issue helper that fails returns null for that part —
+// the cto agent still gets what loaded.
+
+import { spawn } from "node:child_process";
+
+const RUN_TIMEOUT_MS = 20_000;
+
+export function workspaceEnv(workspaceId, baseEnv = process.env) {
+  const env = { ...baseEnv };
+  if (typeof workspaceId === "string" && workspaceId) env.MULTICA_WORKSPACE_ID = workspaceId;
+  return env;
+}
+
+/**
+ * Default CLI runner. Spawns `multica` with the workspace env injected, a
+ * bounded timeout, and streams stdout back. Rejects with a trimmed error on a
+ * non-zero exit or a spawn failure — callers wrap this best-effort.
+ * @param {string[]} args
+ * @param {object} [opts]
+ * @param {string} [opts.workspaceId]
+ * @param {string} [opts.bin]
+ * @returns {Promise<string>} stdout
+ */
+export function defaultRunCli(args, { workspaceId, bin = "multica", timeoutMs = RUN_TIMEOUT_MS } = {}) {
+  return new Promise((resolve, reject) => {
+    let out = "";
+    let err = "";
+    let p;
+    try {
+      p = spawn(bin, args, { env: workspaceEnv(workspaceId), stdio: ["ignore", "pipe", "pipe"] });
+    } catch (e) {
+      reject(e);
+      return;
+    }
+    const timer = setTimeout(() => {
+      try {
+        p.kill("SIGKILL");
+      } catch {
+        /* already gone */
+      }
+      reject(new Error(`multica timed out after ${Math.round(timeoutMs / 1000)}s`));
+    }, timeoutMs);
+    timer.unref();
+    p.stdout.on("data", (b) => (out += b.toString()));
+    p.stderr.on("data", (b) => (err += b.toString()));
+    p.on("error", (e) => {
+      clearTimeout(timer);
+      reject(e);
+    });
+    p.on("close", (code) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        resolve(out);
+      } else {
+        reject(new Error(err.trim() || `multica exited ${code}`));
+      }
+    });
+  });
+}
+
+function parseJson(stdout, fallback) {
+  if (!stdout) return fallback;
+  try {
+    const v = JSON.parse(stdout);
+    return v ?? fallback;
+  } catch {
+    return fallback;
+  }
+}
+
+async function runBestEffort(runCli, args) {
+  try {
+    const stdout = await runCli(args);
+    return parseJson(stdout, null);
+  } catch {
+    return null; // per-part failure never fails the whole read
+  }
+}
+
+/**
+ * The board read, shaped for the cto agent.
+ *
+ * With an `issue` key (e.g. "BET-123") returns that issue's detail plus its
+ * task-runs and linked pull requests (each best-effort — a failure yields null
+ * for that part). Without one returns a board overview: the open issues
+ * grouped by status. Always resolves; failures degrade to empty data.
+ *
+ * @param {object} [input]
+ * @param {string} [input.query]   informational intent (the cto agent's framing)
+ * @param {string|null} [input.issue]  optional issue key
+ * @param {number} [input.limit]   how many issues the overview reads (default 50)
+ * @param {object} [deps]
+ * @param {(args: string[], opts?: object) => Promise<string>} [deps.runCli]
+ * @param {string} [deps.workspaceId]
+ * @returns {Promise<object>}
+ */
+export async function queryMultica({ query, issue, limit = 50 } = {}, deps = {}) {
+  const runCli = deps.runCli ?? defaultRunCli;
+  const workspaceId = deps.workspaceId ?? process.env.MULTICA_WORKSPACE_ID;
+
+  if (issue) {
+    const [detail, runs, prs, children] = await Promise.all([
+      runBestEffort(runCli, ["issue", "get", issue, "--output", "json"]),
+      runBestEffort(runCli, ["issue", "runs", issue, "--output", "json"]),
+      runBestEffort(runCli, ["issue", "pull-requests", issue, "--output", "json"]),
+      runBestEffort(runCli, ["issue", "children", issue, "--output", "json"]),
+    ]);
+    return {
+      ok: true,
+      issue: issue,
+      query: query ?? "",
+      detail: summarizeIssue(detail),
+      taskRuns: Array.isArray(runs) ? runs : null,
+      pullRequests: Array.isArray(prs) ? prs : null,
+      children: Array.isArray(children) ? children : null,
+    };
+  }
+
+  const list = await runBestEffort(runCli, [
+    "issue", "list", "--output", "json", "--limit", String(limit),
+  ]);
+  const issues = Array.isArray(list?.issues) ? list.issues : Array.isArray(list) ? list : [];
+  const grouped = {};
+  for (const it of issues) {
+    const key = it?.status_category ?? it?.status ?? "unknown";
+    grouped[key] = grouped[key] ?? [];
+    grouped[key].push(summarizeIssue(it));
+  }
+  return {
+    ok: true,
+    issues: issues.map(summarizeIssue),
+    byStatus: grouped,
+    count: issues.length,
+  };
+}
+
+// Reduce an issue to the fields the cto agent needs; drop anything heavy or
+// secret-laden. Pure.
+export function summarizeIssue(issue) {
+  if (!issue || typeof issue !== "object") return null;
+  return {
+    identifier: issue.identifier ?? null,
+    title: issue.title ?? null,
+    status: issue.status ?? null,
+    status_category: issue.status_category ?? null,
+    priority: issue.priority ?? null,
+    assignee: issue.assignee_id ?? null,
+    assignee_type: issue.assignee_type ?? null,
+    updated_at: issue.updated_at ?? null,
+    created_at: issue.created_at ?? null,
+    labels: Array.isArray(issue.labels) ? issue.labels : null,
+    description: typeof issue.description === "string" ? issue.description.slice(0, 400) : null,
+    pr_url: issue.pr_url ?? null,
+  };
+}

--- a/src/server/multica.test.mjs
+++ b/src/server/multica.test.mjs
@@ -1,0 +1,117 @@
+// multica.test.mjs — thin read wrapper over the `multica` CLI (BET-1164).
+// Pure logic + injected runCli; no live workspace, no CLI required.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { queryMultica, summarizeIssue, workspaceEnv } from "./multica.mjs";
+
+// A fake CLI runner mapping an argv-joined key to a canned JSON stdout. Any
+// invocation not in the map throws, so we can pin that a failed subcommand
+// degrades rather than failing the whole read.
+function fakeCli(map) {
+  return async (args) => {
+    const key = args.join(" ");
+    if (!(key in map)) throw new Error(`no canned response for: ${key}`);
+    return map[key];
+  };
+}
+
+test("queryMultica returns a board overview grouped by status", async () => {
+  const runCli = fakeCli({
+    "issue list --output json --limit 50": JSON.stringify({
+      issues: [
+        { identifier: "BET-1", title: "one", status: "todo", status_category: "todo", priority: "high", updated_at: "2026-08-18T00:00:00Z" },
+        { identifier: "BET-2", title: "two", status: "done", status_category: "done", priority: "medium" },
+        { identifier: "BET-3", title: "three", status: "todo", status_category: "todo" },
+      ],
+    }),
+  });
+  const res = await queryMultica({}, { runCli });
+  assert.equal(res.ok, true);
+  assert.equal(res.count, 3);
+  assert.equal(res.issues.length, 3);
+  assert.equal(res.byStatus.todo.length, 2);
+  assert.equal(res.byStatus.done.length, 1);
+  assert.equal(res.issues[0].identifier, "BET-1");
+  assert.equal(res.issues[0].title, "one");
+});
+
+test("queryMultica tolerates a plain-array list and a failing CLI (quiet board)", async () => {
+  const runCli = fakeCli({
+    "issue list --output json --limit 50": JSON.stringify([
+      { identifier: "BET-9", status: "todo" },
+    ]),
+  });
+  const res = await queryMultica({}, { runCli });
+  assert.equal(res.count, 1);
+
+  // A completely failing CLI → empty board, never throws.
+  const failing = async () => {
+    throw new Error("multica not installed");
+  };
+  const res2 = await queryMultica({}, { runCli: failing });
+  assert.equal(res2.ok, true);
+  assert.equal(res2.count, 0);
+  assert.deepEqual(res2.byStatus, {});
+});
+
+test("queryMultica with an issue key resolves detail + runs + PRs + children", async () => {
+  const runCli = fakeCli({
+    "issue get BET-42 --output json": JSON.stringify({ identifier: "BET-42", title: "the thing", status: "in_progress" }),
+    "issue runs BET-42 --output json": JSON.stringify([{ id: "run-1", status: "done" }]),
+    "issue pull-requests BET-42 --output json": JSON.stringify([{ number: 12, state: "open" }]),
+    "issue children BET-42 --output json": JSON.stringify([{ identifier: "BET-43" }]),
+  });
+  const res = await queryMultica({ issue: "BET-42", query: "what's this" }, { runCli });
+  assert.equal(res.ok, true);
+  assert.equal(res.issue, "BET-42");
+  assert.equal(res.detail.identifier, "BET-42");
+  assert.equal(res.detail.title, "the thing");
+  assert.equal(res.taskRuns.length, 1);
+  assert.equal(res.pullRequests.length, 1);
+  assert.equal(res.children.length, 1);
+});
+
+test("a failing per-issue subcommand degrades to null, not a failure", async () => {
+  // Only `issue get` succeeds; runs/PRs/children throw.
+  const runCli = fakeCli({
+    "issue get BET-7 --output json": JSON.stringify({ identifier: "BET-7" }),
+  });
+  const res = await queryMultica({ issue: "BET-7" }, { runCli });
+  assert.equal(res.ok, true);
+  assert.equal(res.detail.identifier, "BET-7");
+  assert.equal(res.taskRuns, null);
+  assert.equal(res.pullRequests, null);
+  assert.equal(res.children, null);
+});
+
+test("summarizeIssue caps description and keeps only safe fields", () => {
+  const issue = {
+    identifier: "BET-1",
+    title: "t",
+    status: "done",
+    status_category: "done",
+    priority: "high",
+    assignee_id: "agent-1",
+    updated_at: "z",
+    labels: ["a"],
+    description: "x".repeat(2000),
+    pr_url: "https://pr",
+    secretKey: "should-be-dropped",
+  };
+  const s = summarizeIssue(issue);
+  assert.equal(s.identifier, "BET-1");
+  assert.equal(s.secretKey, undefined);
+  assert.equal(s.pr_url, "https://pr");
+  assert.equal(s.description.length, 400);
+  assert.equal(summarizeIssue(null), null);
+});
+
+test("workspaceEnv injects MULTICA_WORKSPACE_ID and preserves the base env", () => {
+  const env = workspaceEnv("ws-123", { PATH: "/bin" });
+  assert.equal(env.MULTICA_WORKSPACE_ID, "ws-123");
+  assert.equal(env.PATH, "/bin");
+  // No workspace id → env unchanged.
+  const env2 = workspaceEnv(undefined, { PATH: "/bin" });
+  assert.equal(env2.MULTICA_WORKSPACE_ID, undefined);
+});

--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -365,6 +365,29 @@ export async function patchGlobalConfig(patch) {
 }
 
 /**
+ * Shared core for setProviders / setSubagents — both are the same write-through
+ * PATCH shape (reject `remove`, upsert each block via a builder, PATCH one
+ * config key) with no HTTP delete semantics. `configKey` is "provider" or
+ * "agent"; `keyFor(input)` and `build(input)` produce the per-entry key + block.
+ */
+async function patchBlocks(ops, deps, configKey, keyFor, build) {
+  const patch = deps?.patch ?? patchGlobalConfig;
+  const upserts = ops?.upsert ?? [];
+  const removes = ops?.remove ?? [];
+
+  if (removes.length > 0) {
+    return { ok: false, error: REMOVE_UNSUPPORTED_MSG };
+  }
+
+  if (upserts.length === 0) return { ok: true };
+  const collected = {};
+  for (const input of upserts) {
+    collected[keyFor(input)] = build(input);
+  }
+  return patch({ [configKey]: collected });
+}
+
+/**
  * Apply a set of provider mutations through opencode's config endpoint.
  * Upserts go through PATCH /global/config — the single authority that owns
  * both the in-memory config and the file. `remove` ops are NOT supported
@@ -376,20 +399,13 @@ export async function patchGlobalConfig(patch) {
  * work. Does NOT restart opencode; the caller decides (prompt-before-restart).
  */
 export async function setProviders(ops, deps = {}) {
-  const patch = deps.patch ?? patchGlobalConfig;
-  const upserts = ops.upsert ?? [];
-  const removes = ops.remove ?? [];
-
-  if (removes.length > 0) {
-    return { ok: false, error: REMOVE_UNSUPPORTED_MSG };
-  }
-
-  if (upserts.length === 0) return { ok: true };
-  const providerPatch = {};
-  for (const input of upserts) {
-    providerPatch[input.id] = upsertProviderBlock({}, input).provider[input.id];
-  }
-  return patch({ provider: providerPatch });
+  return patchBlocks(
+    ops,
+    deps,
+    "provider",
+    (input) => input.id,
+    (input) => upsertProviderBlock({}, input).provider[input.id],
+  );
 }
 
 /**
@@ -423,20 +439,13 @@ export async function getSubagents(readConfig = readRemoteConfig) {
  * follow-up work. Does NOT restart opencode; the caller must do that manually.
  */
 export async function setSubagents(ops, deps = {}) {
-  const patch = deps.patch ?? patchGlobalConfig;
-  const upserts = ops.upsert ?? [];
-  const removes = ops.remove ?? [];
-
-  if (removes.length > 0) {
-    return { ok: false, error: REMOVE_UNSUPPORTED_MSG };
-  }
-
-  if (upserts.length === 0) return { ok: true };
-  const agentPatch = {};
-  for (const input of upserts) {
-    agentPatch[input.name] = upsertAgentBlock({}, input).agent[input.name];
-  }
-  return patch({ agent: agentPatch });
+  return patchBlocks(
+    ops,
+    deps,
+    "agent",
+    (input) => input.name,
+    (input) => upsertAgentBlock({}, input).agent[input.name],
+  );
 }
 
 /**
@@ -571,12 +580,27 @@ export function mantaPlanPromptPath(fromMetaUrl = import.meta.url) {
   return fileURLToPath(new URL(MANTA_PLAN_PROMPT_REL, fromMetaUrl));
 }
 
+// Assemble a primary-agent block object. Shared by the manta-plan and cto
+// agents — both are the same "a selectable primary agent with a file-based
+// prompt + permission block" shape; only the content differs. `model` is left
+// unset (inherit the session default) unless provided.
+function agentBlock({ name, description, permission, promptPath, model }) {
+  const block = {
+    name,
+    mode: "primary",
+    description,
+    permission,
+    prompt: `{file:${promptPath}}`,
+  };
+  if (typeof model === "string" && model) block.model = model;
+  return block;
+}
+
 export function mantaPlanAgentBlock(promptPath) {
-  return {
+  return agentBlock({
     name: MANTA_PLAN_AGENT_NAME,
     // mode primary (NOT subagent) — BET-983 only offers `mode !== "subagent"`
     // agents in the composer's Plan target selection.
-    mode: "primary",
     description: "Research a request and produce a structured, buildable plan.",
     // opencode merges each agent's permission block AFTER its shared defaults
     // (which deny plan_enter/plan_exit for every agent); these allows are what
@@ -587,20 +611,58 @@ export function mantaPlanAgentBlock(promptPath) {
       edit: { "*": "ask", ".opencode/plans/**": "allow" },
       bash: "ask",
     },
-    // model deliberately unset → inherit the session default.
-    prompt: `{file:${promptPath}}`,
-  };
+    promptPath,
+  });
+}
+
+/**
+ * Shared installer/ensurer core for a box-side opencode agent block.
+ * Idempotent (a no-op diff when the named block already exists) and never
+ * throws — I/O/restart failures log and return `{ ok:false }` so the startup
+ * wire-in can fire-and-forget. Both ensureMantaPlanAgent and ensureCtoAgent
+ * delegate here; keep them thin wrappers.
+ *
+ * @param {object} o
+ * @param {string} o.agentName
+ * @param {() => object} o.buildBlock
+ * @param {() => Promise<object>} o.readConfig
+ * @param {(ops) => Promise<{ok: boolean, error?: string}>} o.applySubagents
+ * @param {() => Promise<{ok: boolean, error?: string}>} o.restart
+ * @param {string} o.logPrefix
+ * @param {{warn?: Function, error?: Function}} o.log
+ * @returns {Promise<{ok: boolean, changed: boolean, reason?: string, error?: string}>}
+ */
+async function runEnsureAgent({ agentName, buildBlock, readConfig, applySubagents, restart, logPrefix, log }) {
+  try {
+    let cfg;
+    try {
+      cfg = await readConfig();
+    } catch (e) {
+      log.warn?.(`[providers] ${logPrefix}: config unreadable, skipping install:`, e);
+      return { ok: false, changed: false, reason: "unreadable" };
+    }
+    if (cfg?.agent?.[agentName]) {
+      return { ok: true, changed: false };
+    }
+    const result = await applySubagents({ upsert: [buildBlock()] });
+    if (!result.ok) {
+      log.warn?.(`[providers] ${logPrefix}: write failed:`, result.error);
+      return { ok: false, changed: false, error: result.error };
+    }
+    const restartResult = await restart();
+    if (!restartResult.ok) {
+      log.warn?.(`[providers] ${logPrefix}: restart after install failed:`, restartResult.error);
+    }
+    return { ok: true, changed: true };
+  } catch (e) {
+    log.error?.(`[providers] ${logPrefix}:`, e);
+    return { ok: false, changed: false, error: e instanceof Error ? e.message : String(e) };
+  }
 }
 
 /**
  * Best-effort installer/ensurer for the box-side `manta-plan` primary agent
- * block in opencode.jsonc. Idempotent:
- *  - If a `manta-plan` block already exists, does nothing (no write, no
- *    restart) — a no-op diff against the existing config.
- *  - Otherwise upserts the block via the EXISTING setSubagents writer and
- *    restarts opencode ONLY because the config changed.
- * Never throws — any I/O or restart failure logs and returns
- * `{ ok: false, ... }` so the startup wire-in can fire-and-forget.
+ * block in opencode.jsonc.
  *
  * `readConfig`/`applySubagents`/`restart`/`promptPath` are injectable for
  * tests; defaults hit the real box (readRemoteConfig, setSubagents,
@@ -622,31 +684,15 @@ export async function ensureMantaPlanAgent(deps = {}) {
     promptPath = mantaPlanPromptPath(),
     log = console,
   } = deps;
-  try {
-    let cfg;
-    try {
-      cfg = await readConfig();
-    } catch (e) {
-      log.warn?.("[providers] manta-plan: config unreadable, skipping install:", e);
-      return { ok: false, changed: false, reason: "unreadable" };
-    }
-    if (cfg?.agent?.[MANTA_PLAN_AGENT_NAME]) {
-      return { ok: true, changed: false };
-    }
-    const result = await applySubagents({ upsert: [mantaPlanAgentBlock(promptPath)] });
-    if (!result.ok) {
-      log.warn?.("[providers] manta-plan: write failed:", result.error);
-      return { ok: false, changed: false, error: result.error };
-    }
-    const restartResult = await restart();
-    if (!restartResult.ok) {
-      log.warn?.("[providers] manta-plan: restart after install failed:", restartResult.error);
-    }
-    return { ok: true, changed: true };
-  } catch (e) {
-    log.error?.("[providers] ensureMantaPlanAgent failed:", e);
-    return { ok: false, changed: false, error: e instanceof Error ? e.message : String(e) };
-  }
+  return runEnsureAgent({
+    agentName: MANTA_PLAN_AGENT_NAME,
+    buildBlock: () => mantaPlanAgentBlock(promptPath),
+    readConfig,
+    applySubagents,
+    restart,
+    logPrefix: "ensureMantaPlanAgent",
+    log,
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -667,20 +713,18 @@ export function ctoPromptPath(fromMetaUrl = import.meta.url) {
 }
 
 export function ctoAgentBlock(promptPath, model) {
-  const block = {
+  return agentBlock({
     name: CTO_AGENT_NAME,
     // mode primary (NOT subagent) — the cto agent is selectable as a normal
     // chat session ("ask the on-call CTO what's running"), and modify access
     // is bounded below to the read-only `cto` tool.
-    mode: "primary",
     description:
       "On-call CTO: answer what's running, git state, usage/stopped conversations, " +
       "plan mode, context state and the Multica board via deterministic read-only tools.",
     permission: { cto: "allow" },
-    prompt: `{file:${promptPath}}`,
-  };
-  if (typeof model === "string" && model) block.model = model;
-  return block;
+    promptPath,
+    model,
+  });
 }
 
 /**
@@ -712,29 +756,13 @@ export async function ensureCtoAgent(deps = {}) {
     model,
     log = console,
   } = deps;
-  try {
-    let cfg;
-    try {
-      cfg = await readConfig();
-    } catch (e) {
-      log.warn?.("[providers] cto: config unreadable, skipping install:", e);
-      return { ok: false, changed: false, reason: "unreadable" };
-    }
-    if (cfg?.agent?.[CTO_AGENT_NAME]) {
-      return { ok: true, changed: false };
-    }
-    const result = await applySubagents({ upsert: [ctoAgentBlock(promptPath, model)] });
-    if (!result.ok) {
-      log.warn?.("[providers] cto: write failed:", result.error);
-      return { ok: false, changed: false, error: result.error };
-    }
-    const restartResult = await restart();
-    if (!restartResult.ok) {
-      log.warn?.("[providers] cto: restart after install failed:", restartResult.error);
-    }
-    return { ok: true, changed: true };
-  } catch (e) {
-    log.error?.("[providers] ensureCtoAgent failed:", e);
-    return { ok: false, changed: false, error: e instanceof Error ? e.message : String(e) };
-  }
+  return runEnsureAgent({
+    agentName: CTO_AGENT_NAME,
+    buildBlock: () => ctoAgentBlock(promptPath, model),
+    readConfig,
+    applySubagents,
+    restart,
+    logPrefix: "ensureCtoAgent",
+    log,
+  });
 }

--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -648,3 +648,93 @@ export async function ensureMantaPlanAgent(deps = {}) {
     return { ok: false, changed: false, error: e instanceof Error ? e.message : String(e) };
   }
 }
+
+// ---------------------------------------------------------------------------
+// On-call CTO agent (BET-1164, issue 1/3)
+// ---------------------------------------------------------------------------
+// A `cto` primary agent carrying the deterministic read tool belt (exposed to
+// opencode as the global `cto` custom tool — see docs/opencode-tools/cto.ts);
+// this block just gives the agent a prompt + makes it selectable as a normal
+// chat session. Mirrors the manta-plan block/ensurer below.
+export const CTO_AGENT_NAME = "cto";
+
+// Committed under docs/ so it exists at the same relative location in a dev
+// checkout and a release tarball (both re-materialize the full source tree).
+const CTO_PROMPT_REL = "../../docs/opencode/skills/cto/prompt.md";
+
+export function ctoPromptPath(fromMetaUrl = import.meta.url) {
+  return fileURLToPath(new URL(CTO_PROMPT_REL, fromMetaUrl));
+}
+
+export function ctoAgentBlock(promptPath, model) {
+  const block = {
+    name: CTO_AGENT_NAME,
+    // mode primary (NOT subagent) — the cto agent is selectable as a normal
+    // chat session ("ask the on-call CTO what's running"), and modify access
+    // is bounded below to the read-only `cto` tool.
+    mode: "primary",
+    description:
+      "On-call CTO: answer what's running, git state, usage/stopped conversations, " +
+      "plan mode, context state and the Multica board via deterministic read-only tools.",
+    permission: { cto: "allow" },
+    prompt: `{file:${promptPath}}`,
+  };
+  if (typeof model === "string" && model) block.model = model;
+  return block;
+}
+
+/**
+ * Best-effort installer/ensurer for the box-side `cto` primary agent block in
+ * opencode.jsonc. Idempotent (a no-op diff when the block already exists) and
+ * never throws — I/O/restart failures log and return `{ ok:false }` so the
+ * startup wire-in can fire-and-forget. Injected deps default to the real box
+ * (readRemoteConfig / setSubagents / restartOpencode) exactly like
+ * ensureMantaPlanAgent.
+ *
+ * Gated by `cto.enabled`: with the feature off (the default until shipped)
+ * the caller simply does not invoke this.
+ *
+ * @param {object} [deps]
+ * @param {() => Promise<object>} [deps.readConfig]
+ * @param {(ops) => Promise<{ok: boolean, error?: string}>} [deps.applySubagents]
+ * @param {() => Promise<{ok: boolean, error?: string}>} [deps.restart]
+ * @param {string} [deps.promptPath]
+ * @param {string} [deps.model]
+ * @param {{warn?: Function, error?: Function}} [deps.log]
+ * @returns {Promise<{ok: boolean, changed: boolean, reason?: string, error?: string}>}
+ */
+export async function ensureCtoAgent(deps = {}) {
+  const {
+    readConfig = readRemoteConfig,
+    applySubagents = setSubagents,
+    restart = restartOpencode,
+    promptPath = ctoPromptPath(),
+    model,
+    log = console,
+  } = deps;
+  try {
+    let cfg;
+    try {
+      cfg = await readConfig();
+    } catch (e) {
+      log.warn?.("[providers] cto: config unreadable, skipping install:", e);
+      return { ok: false, changed: false, reason: "unreadable" };
+    }
+    if (cfg?.agent?.[CTO_AGENT_NAME]) {
+      return { ok: true, changed: false };
+    }
+    const result = await applySubagents({ upsert: [ctoAgentBlock(promptPath, model)] });
+    if (!result.ok) {
+      log.warn?.("[providers] cto: write failed:", result.error);
+      return { ok: false, changed: false, error: result.error };
+    }
+    const restartResult = await restart();
+    if (!restartResult.ok) {
+      log.warn?.("[providers] cto: restart after install failed:", restartResult.error);
+    }
+    return { ok: true, changed: true };
+  } catch (e) {
+    log.error?.("[providers] ensureCtoAgent failed:", e);
+    return { ok: false, changed: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -252,6 +252,33 @@ export type AppConfig = {
   // render. Rides the generic configGet/configUpdate path — no dedicated IPC
   // channel. Absent/empty = no pins.
   pinnedWindows?: string[];
+  // ----- On-call CTO (BET-1164) -----
+  // The "on-call CTO" feature: a deterministic read-only tool belt (the `cto`
+  // engine's dispatch surface) surfaced as an opencode agent + voice window.
+  // This issue (1/3) wires ONLY `enabled`; the rest of the shape is defined
+  // now (with the engine/store) so the later issues (2 = inbound feed, 3 =
+  // call window + voice) just plumb through fields already agreed. Absent =
+  // the whole feature off.
+  cto?: {
+    // Master switch. False (the default) until the feature is shipped — with
+    // it off the box never registers the `cto` agent nor wires the engine.
+    enabled?: boolean;
+    // Transport for voice narration of tool boundaries (Issue 3). "realtime"
+    // (default) = the eventual walkie-talkie transport; "groq" = TTS via Groq.
+    transport?: "realtime" | "groq";
+    // The model the `cto` agent runs on (Issue 3). Absent → opencode default.
+    model?: string;
+    // Voice/narration model id (Issue 3).
+    voice?: string;
+    // Tool names the user has allowed to run without narration/confirm
+    // (Issue 2, the inbound feed's trusted set). Absent/empty = none trusted.
+    trustedActions?: string[];
+    // What the box does when a call window is left parked (Issue 3).
+    // "push" (default) = notify the user; "auto-open" = open the window.
+    parkedBehavior?: "auto-open" | "push";
+    // Whether the call window listens continuously (Issue 3). Default false.
+    alwaysListening?: boolean;
+  };
 };
 
 // ----- Live tmux state -----


### PR DESCRIPTION
## On-call CTO 1/3 — gateway (deterministic read tools) + brain/store + text cto agent

Builds only Issue 1/3 of the on-call CTO feature: the durable server
foundation, fully usable as a text agent. No voice, no audio, no new window, no
CI/CD, no Confirm/Deny UI, no issue-2/3 work.

### What's here

- **`src/server/cto.mjs`** — `createCtoEngine(deps)` → a **registry + single
  `dispatch(tool, args, ctx)` seam**. Every tool is a THIN read-only proxy over
  an existing engine (tmux, opencode, usage, messageSearch, local, stoppedStore,
  modelGuide) — nothing reimplemented. 15 tools: `list_sessions`,
  `list_projects`, `read_transcript`, `search_messages`, `git_status`,
  `git_branch`, `git_log`, `list_models`, `get_usage`, `usage_stopped`,
  `session_usage`, `context_state`, `session_plan_mode`, `get_config`,
  `query_multica`. All `mode: "auto"`; the `gate` seam is implemented but Issue
  1 defaults to allow; `onNarrate` is a no-op-safe boundary hook (Issue 3's
  voice arrives later).
- **`~/.manta/cto.json` store** — `{ version: 1, watches: [], inbound: [],
  audit: [] }`, atomic load/save via `statePath` + `jsonStore`. Issue 1 only lays
  it down; watches/inbound stay empty until Issue 2.
- **Config block** — full `cto` shape in `src/shared/types.ts` (`enabled`
  default false, plus transport/model/voice/trustedActions/parkedBehavior/
  alwaysListening defined now so later issues don't re-design).
- **`src/server/multica.mjs`** — thin read wrapper over the `multica` CLI
  (board overview grouped by status, or per-issue detail + task-runs + PRs).
  External integration, best-effort, never throws on a quiet/failed board.
- **A `cto` opencode agent** — `ctoAgentBlock` + `ensureCtoAgent` in
  `providers.mjs` (mirrors the proven `manta-plan` pattern), a `/api/cto` route
  wiring the engine in `index.mjs`, the global `cto` custom tool
  (`docs/opencode-tools/cto.ts`) and the agent prompt
  (`docs/opencode/skills/cto/prompt.md`). Registered at startup only when
  `cto.enabled` is on (default off). Mode `primary` → selectable as a normal
  chat session.
- **Tests** — `src/server/cto.test.mjs` (registry integrity, dispatch +
  default-allow gate, deny/confirm fail-closed, onNarrate boundaries, tool
  reads on a quiet box, cto.json store lifecycle) and `src/server/multica.test.mjs`
  (injected-I/O wrapper). Sandboxed state dir / injected I/O only.

### Reuse notes (anti-spaghetti)

- Every tool proxies an existing engine via injected I/O — no second resolver,
  no duplicated ContextBar, no reinvented search/usage/plan-mode logic.
- `/api/cto` mirrors the established `/api/app-control` route shape; the agent
  `ensureCtoAgent` mirrors `ensureMantaPlanAgent`; the `cto` opencode tool
  mirrors the other `docs/opencode-tools/*` registrars.
- `git` helpers live in `cto.mjs` and are the single transport for these tools
  (index.mjs does not override them) — no drifting dual git path.
- **Consolidated pre-existing duplication surfaced by the gate:** the strict
  duplication gate flagged the PRE-EXISTING setProviders/setSubagents clone in
  providers.mjs once that file became "changed". Both are the same write-through
  PATCH shape, so they now share a `patchBlocks` core (behavior identical,
  injected I/O preserved). Also deduped the manta-plan/cto agent blocks and the
  cto branch resolver onto shared helpers. Duplication gate: PASS.

**Base: origin/main @ `b6cff5eb`**

**Verification results:**
- PR branch (`multica/BET-1164-cto-gateway` @ `602c60c3`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, **2448 pass / 0 fail** (23 new tests).
- Base (`main` @ `b6cff5eb`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 2425 pass / 0 fail.
- **Conclusion:** 0 new failures; 23 tests added by this PR. No pre-existing
  failures.

### Noted / deferred (no follow-up filed)
- Live registration of the `cto` agent to the running box is only reachable when
  `cto.enabled` flips on (default off until shipped) and is gated on the manual
  text-session verification step — not automatable against a live opencode in
  the sandboxed test suite.
