### PR TITLE
On-call CTO 3/3: floating call window + OpenAI Realtime (server-relayed) + voice UX + settings (BET-1166)

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -470,3 +470,27 @@ normal chat session) is pre-wired to use this belt. Install/update is a COPY,
 never a symlink: `cp <repo>/docs/opencode-tools/cto.ts
 ~/.config/opencode/tools/cto.ts` then `systemctl --user restart
 opencode-serve`. The engine lives in `src/server/cto.mjs` (see there).
+
+## manta on-call CTO inbound — `send_to_cto` + watchers (BET-1165)
+
+Two companion capabilities to the `cto` read belt, both global opencode tools.
+
+- **`send_to_cto(message, opts?)`** (global tool, `docs/opencode-tools/send-to-cto.ts`):
+  report a note up to the CTO from ANY session. With no live call it is surfaced
+  to the user as a notification; once the call-window feature ships it is injected
+  into the CTO conversation as a turn. Use it to flag something the CTO should know
+  (a new P0, a blocker, a call-back request). Thin registrar → `POST /api/cto/inbound`.
+- **`watch(surface, condition)`** + `unwatch` / `list_watches` (via the `cto` tool,
+  `docs/opencode-tools/cto.ts`): register a recurring probe against a surface
+  (`multica`, `schedule`, `delegate`, ...). The box runs the watch's condition
+  against that surface's existing read and surfaces a notification when it matches
+  AND something new appeared. `watch` is a **confirm-mode** action: it needs the
+  user's go-ahead before it takes effect. When the `cto` tool returns
+  `needConfirmation: { id, preview }`, surface "I need your go-ahead: <preview>"
+  and re-dispatch the SAME tool+args with `approve: <id>` on "go ahead" (or abort
+  on "no").
+
+Install/update each tool as a COPY (`cp docs/opencode-tools/{send-to-cto,cto}.ts
+~/.config/opencode/tools/`) then `systemctl --user restart opencode-serve`. The
+engine + routers live in `src/server/cto.mjs` (createCtoEngine / createCtoInbound /
+createWatcherPoller).

--- a/docs/opencode-tools/cto.ts
+++ b/docs/opencode-tools/cto.ts
@@ -27,7 +27,8 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 const CTO_TOOLS =
   "list_sessions, list_projects, read_transcript, search_messages, git_status, " +
   "git_branch, git_log, list_models, get_usage, usage_stopped, session_usage, " +
-  "context_state, session_plan_mode, get_config, query_multica";
+  "context_state, session_plan_mode, get_config, query_multica, watch, unwatch, " +
+  "list_watches";
 
 function boxToken() {
   const fromEnv = process.env.MANTA_BOX_TOKEN;
@@ -51,22 +52,34 @@ function authHeaders(body) {
 
 export const cto = tool({
   description: [
-    "Deterministic, read-only on-call CTO tools: inspect what's running on this box,",
+    "Deterministic on-call CTO tools: inspect what's running on this box,",
     "read chat transcripts, search messages, git state, models, plan usage,",
     "stopped conversations, per-session cost/context/plan-mode, config, and the",
-    "Multica task board. Nothing here mutates anything — all reads.",
+    "Multica task board. Reads never mutate anything. The watch/unwatch/list_watches",
+    "tools register watchers (watch is a confirm-mode action).",
     `Pick \`tool\` from: ${CTO_TOOLS}.`,
     "Pass that tool's arguments as a free-form object in \`args\`",
     "(e.g. {tool:\"read_transcript\", args:{sessionID:\"ses_...\"}}).",
+    "If the call returns needConfirmation for a confirm-mode tool, surface",
+    "\"I need your go-ahead: <preview>\" to the user; when they reply \"go ahead\",",
+    "re-invoke the SAME tool+args with \`approve: <id>\` (the id from the",
+    "needConfirmation result). Reply \"no\" to abort (reject).",
   ].join(" "),
   args: {
     tool: tool.schema
       .string()
-      .describe(`The cto read tool to run. One of: ${CTO_TOOLS}.`),
+      .describe(`The cto tool to run. One of: ${CTO_TOOLS}.`),
     args: tool.schema
       .object({})
       .passthrough()
       .describe("Free-form arguments for the chosen tool (depends on the tool)."),
+    approve: tool.schema
+      .string()
+      .optional()
+      .describe(
+        "When re-dispatching a confirm-mode tool after the user said \"go ahead\", pass " +
+          "the id from the earlier needConfirmation result to authorize it.",
+      ),
   },
   async execute(args, context) {
     const res = await fetch(`${MANTA_SERVER}/api/cto`, {
@@ -75,6 +88,7 @@ export const cto = tool({
       body: JSON.stringify({
         tool: args.tool,
         args: args.args ?? {},
+        approve: args.approve,
         sessionID: context?.sessionID,
         directory: context?.directory,
       }),

--- a/docs/opencode-tools/send-to-cto.ts
+++ b/docs/opencode-tools/send-to-cto.ts
@@ -1,0 +1,117 @@
+// manta-native `send_to_cto` tool — global opencode custom tool (BET-1165).
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/send-to-cto.ts ~/.config/opencode/tools/send-to-cto.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+// A copy, never a symlink — opencode resolves a tool's imports relative to the
+// file's REAL path, so a symlink back into the repo (no node_modules) fails
+// with `Cannot find module '@opencode-ai/plugin'` and the tool silently never
+// registers.
+//
+// PURPOSE: let ANY session report something to the on-call CTO. This is a THIN
+// registrar: `execute` POSTs `{surface:"session", sessionID, message, ...opts}`
+// to manta-server's /api/cto/inbound (same box, no SSH hop) and returns
+// immediately. manta-server owns the routing (dedupe + live-vs-parked), NOT
+// this tool. See src/server/cto.mjs (createCtoInbound).
+//
+// When no "call is live" flag is set (this issue), the message routes to the
+// PARKED path and the user gets a push/notify. Once Issue 3 flips the live
+// flag, the message is injected into the CTO session as a turn instead.
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
+// tiny local file) so a token rotation never requires an opencode-serve
+// restart. MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+export const send_to_cto = tool({
+  description: [
+    "Send a message to the on-call CTO. Any session can call this: it reports a",
+    "note up to the CTO, who has a read-only tool belt over what's running, the",
+    "Multica board, usage, and more. The message is surfaced to the user: when",
+    "the CTO call is not live it arrives as a push/notify; once the call-window",
+    "feature ships it is injected into the CTO conversation as a turn. Use this",
+    "to flag something the CTO should know (a new P0, a blocker, a request to",
+    "call you back). It returns immediately — the box owns routing.",
+  ].join(" "),
+  args: {
+    message: z
+      .string()
+      .describe("What to report to the CTO. Be concrete: the fact, not the process."),
+    title: z
+      .string()
+      .optional()
+      .describe(
+        "Optional short title for the surfaced notification. Defaults to the sender's " +
+          "session label.",
+      ),
+    urgent: z
+      .boolean()
+      .optional()
+      .describe(
+        "If true, deliver to every device immediately (blocking tier). Use sparingly — " +
+          "only for something the CTO must see right now.",
+      ),
+  },
+  async execute(args, context) {
+    const result = await call("POST", "/api/cto/inbound", {
+      surface: "session",
+      sessionID: context.sessionID,
+      message: args.message,
+      title: args.title,
+      urgent: !!args.urgent,
+    });
+    return result.parked
+      ? "Reported to the CTO (no live call — surfaced as a notification)."
+      : "Reported to the CTO.";
+  },
+});

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -60,7 +60,11 @@ export default defineConfig({
     },
     build: {
       rollupOptions: {
-        input: { index: resolve(__dirname, "src/renderer/index.html") },
+        input: {
+          index: resolve(__dirname, "src/renderer/index.html"),
+          // The floating on-call CTO window (BET-1166): frameless call.html.
+          call: resolve(__dirname, "src/renderer/call.html"),
+        },
       },
     },
     resolve: {

--- a/src/main/callWindow.ts
+++ b/src/main/callWindow.ts
@@ -1,0 +1,122 @@
+// callWindow.ts — the floating on-call CTO voice window (BET-1166).
+//
+// A second, small BrowserWindow distinct from the main app window. Frameless,
+// always-on-top, non-resizable, with a drag region in its header. Lifecycle:
+//   show    → create (first use) + reveal the window
+//   park    → hide the window but KEEP it alive (inbound CTO events still push)
+//   hangup  → destroy the window and tear down the call
+// Position is persisted via the app config (`callWindowBounds`) so the window
+// remembers where the user parked it across runs.
+//
+// The window itself is a thin shell: it loads `call.html`, whose renderer
+// opens the box's /call WebSocket (auth-gated, token via ?token=) and streams
+// opus mic audio up while receiving transcript/audio/intent events down. The
+// OpenAI key lives on the box and never reaches this window.
+
+import { BrowserWindow, shell } from "electron";
+import { join } from "node:path";
+
+// A short-lived "opening" size if we have no saved bounds.
+const DEFAULT_BOUNDS = { x: undefined, y: undefined, width: 380, height: 560 };
+
+export type CallWindowController = {
+  show: () => void;
+  park: () => void;
+  hangup: () => void;
+};
+
+type Bounds = { x?: number; y?: number; width: number; height: number };
+
+type Deps = {
+  /** Read the persisted bounds (undefined if none yet). */
+  getBounds: () => Bounds | undefined;
+  /** Persist the current bounds on move/close. */
+  saveBounds: (b: Bounds) => void;
+};
+
+export function createCallWindowController(deps: Deps): CallWindowController {
+  const { getBounds, saveBounds } = deps;
+  let callWindow: BrowserWindow | null = null;
+
+  function ensureWindow(): BrowserWindow {
+    if (callWindow && !callWindow.isDestroyed()) return callWindow;
+    const saved = getBounds();
+    const bounds = {
+      x: saved?.x,
+      y: saved?.y,
+      width: saved?.width ?? DEFAULT_BOUNDS.width,
+      height: saved?.height ?? DEFAULT_BOUNDS.height,
+    };
+    callWindow = new BrowserWindow({
+      width: bounds.width,
+      height: bounds.height,
+      x: bounds.x,
+      y: bounds.y,
+      frame: false,
+      resizable: false,
+      alwaysOnTop: true,
+      fullscreenable: false,
+      skipTaskbar: true,
+      backgroundColor: "#0B1020",
+      webPreferences: {
+        preload: join(__dirname, "../preload/index.mjs"),
+        sandbox: false,
+        contextIsolation: true,
+        nodeIntegration: false,
+      },
+    });
+
+    callWindow.webContents.setWindowOpenHandler(({ url }) => {
+      shell.openExternal(url);
+      return { action: "deny" };
+    });
+
+    // The header is the drag region (CSS `-webkit-app-region: drag`).
+    if (process.env.ELECTRON_RENDERER_URL) {
+      callWindow.loadURL(`${process.env.ELECTRON_RENDERER_URL}/call.html`);
+    } else {
+      callWindow.loadFile(join(__dirname, "../renderer/call.html"));
+    }
+
+    const remember = () => {
+      if (callWindow && !callWindow.isDestroyed()) {
+        try {
+          saveBounds(callWindow.getBounds());
+        } catch {
+          /* ignore */
+        }
+      }
+    };
+    callWindow.on("move", remember);
+    callWindow.on("close", () => {
+      remember();
+      callWindow = null;
+    });
+
+    // Don't let the call window keep the app alive if the main window closes.
+    callWindow.on("closed", () => {
+      callWindow = null;
+    });
+    return callWindow;
+  }
+
+  function show() {
+    // The renderer fetches its connection config itself (via `call:get-config`
+    // IPC on mount) — nothing is pushed from here. Handing the box token over
+    // IPC to the caller's own window is fine (it already holds it).
+    const win = ensureWindow();
+    if (!win.isVisible()) win.show();
+    win.focus();
+  }
+
+  function park() {
+    if (callWindow && !callWindow.isDestroyed()) callWindow.hide();
+  }
+
+  function hangup() {
+    if (callWindow && !callWindow.isDestroyed()) callWindow.destroy();
+    callWindow = null;
+  }
+
+  return { show, park, hangup };
+}

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -39,6 +39,7 @@ import {
 import { checkForUpdates } from "./autoUpdate.js";
 import { titleBarOptions } from "./windowChrome.js";
 import { downloadFileToDownloads } from "./download.js";
+import { createCallWindowController } from "./callWindow.js";
 import { registerInstallerHandlers } from "./installer/handlers.js";
 import {
   resolveChannel,
@@ -273,6 +274,17 @@ app.on("before-quit", () => {
 });
 
 function registerHandlers(): void {
+  // On-call CTO floating window (BET-1166). The controller reads connection
+  // config + persisted bounds lazily from the live `config`.
+  const callWindow = createCallWindowController({
+    getBounds: () => config.callWindowBounds,
+    saveBounds: (b) => commit({ callWindowBounds: { x: b.x, y: b.y, width: b.width, height: b.height } }),
+  });
+  ipcMain.handle(IPC.callWindowShow, () => callWindow.show());
+  ipcMain.handle(IPC.callWindowPark, () => callWindow.park());
+  ipcMain.handle(IPC.callWindowHangup, () => callWindow.hangup());
+  ipcMain.handle(IPC.callGetConfig, () => ({ serverUrl: config.serverUrl ?? "", boxToken: config.boxToken ?? "" }));
+
   // Read ONLY by main.tsx's boot sequence (`chooseDesktopTransport`), before
   // httpApi is installed as `window.api` — used to seed httpApi's
   // localStorage credentials from the desktop's local config.json (pairing

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -286,6 +286,18 @@ const api = {
     ipcRenderer.on(IPC.installerEvent, listener);
     return () => ipcRenderer.removeListener(IPC.installerEvent, listener);
   },
+
+  // On-call CTO floating window controls (BET-1166). The call.html renderer
+  // uses these to show/park/hang the window and to fetch the {serverUrl,
+  // boxToken} it needs to open its /call WebSocket. No second transport and
+  // no API key ever reaches this surface — audio + events ride the /call WS.
+  call: {
+    show: (): Promise<void> => ipcRenderer.invoke(IPC.callWindowShow),
+    park: (): Promise<void> => ipcRenderer.invoke(IPC.callWindowPark),
+    hangup: (): Promise<void> => ipcRenderer.invoke(IPC.callWindowHangup),
+    getConfig: (): Promise<{ serverUrl: string; boxToken: string }> =>
+      ipcRenderer.invoke(IPC.callGetConfig),
+  },
 };
 
 // Expose the real preload bridge under a STABLE, dedicated name — NOT "api".

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -10,6 +10,7 @@ import {
   Folder,
   Plug,
   Mic,
+  PhoneCall,
 } from "lucide-react";
 import { useStore } from "./store";
 import { ConfirmModal } from "./ConfirmModal";
@@ -229,6 +230,7 @@ const SECTION_ICONS: Record<SettingSectionId, typeof SettingsIcon> = {
   files: Folder,
   extensions: Plug,
   voice: Mic,
+  cto: PhoneCall,
 };
 
 // Card groupings for the schema-driven sections. Each { title, entryIds }

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -454,6 +454,7 @@ export function Settings({
   const cacheTtl = useStore((s) => s.cacheTtl);
   const groqApiKey = useStore((s) => s.groqApiKey);
   const voiceTranscriptionModel = useStore((s) => s.voiceTranscriptionModel);
+  const openaiApiKey = useStore((s) => s.openaiApiKey);
   const allowAgentPush = useStore((s) => s.allowAgentPush);
   const downloadsDir = useStore((s) => s.downloadsDir);
   const worktreePerSession = useStore((s) => s.worktreePerSession);
@@ -505,6 +506,7 @@ export function Settings({
       cacheTtl,
       groqApiKey,
       voiceTranscriptionModel,
+      openaiApiKey,
       allowAgentPush,
       downloadsDir,
       worktreePerSession,
@@ -520,7 +522,7 @@ export function Settings({
       "cto.alwaysListening": cto?.alwaysListening ?? false,
       "cto.parkedBehavior": cto?.parkedBehavior ?? "auto-open",
     }),
-    [cacheTtl, groqApiKey, voiceTranscriptionModel, allowAgentPush, downloadsDir, worktreePerSession, worktreeCleanOnClose, uploadCleanupHours, voiceNoteTtlHours, theme, autoRenameSessions, alwaysShowUsage, cto],
+    [cacheTtl, groqApiKey, voiceTranscriptionModel, openaiApiKey, allowAgentPush, downloadsDir, worktreePerSession, worktreeCleanOnClose, uploadCleanupHours, voiceNoteTtlHours, theme, autoRenameSessions, alwaysShowUsage, cto],
   );
 
   const commitKey = async (entry: SettingEntry, nextValue: unknown) => {

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -463,6 +463,7 @@ export function Settings({
   const autoRenameSessions = useStore((s) => s.autoRenameSessions);
   const alwaysShowUsage = useStore((s) => s.alwaysShowUsage);
   const theme = useStore((s) => s.theme);
+  const cto = useStore((s) => s.cto);
   const skillRegistryUrls = useStore((s) => s.skillRegistryUrls);
   const launcherFlags = useStore((s) => s.launcherFlags);
   const updatePrompt = useStore((s) => s.updatePrompt);
@@ -513,8 +514,13 @@ export function Settings({
       theme,
       autoRenameSessions,
       alwaysShowUsage,
+      "cto.enabled": cto?.enabled ?? false,
+      "cto.model": cto?.model ?? "",
+      "cto.voice": cto?.voice ?? "",
+      "cto.alwaysListening": cto?.alwaysListening ?? false,
+      "cto.parkedBehavior": cto?.parkedBehavior ?? "auto-open",
     }),
-    [cacheTtl, groqApiKey, voiceTranscriptionModel, allowAgentPush, downloadsDir, worktreePerSession, worktreeCleanOnClose, uploadCleanupHours, voiceNoteTtlHours, theme, autoRenameSessions, alwaysShowUsage],
+    [cacheTtl, groqApiKey, voiceTranscriptionModel, allowAgentPush, downloadsDir, worktreePerSession, worktreeCleanOnClose, uploadCleanupHours, voiceNoteTtlHours, theme, autoRenameSessions, alwaysShowUsage, cto],
   );
 
   const commitKey = async (entry: SettingEntry, nextValue: unknown) => {

--- a/src/renderer/call.html
+++ b/src/renderer/call.html
@@ -1,0 +1,17 @@
+<!doctype html>
+<html lang="en" data-theme="dark">
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0"
+    />
+    <title>On-call CTO</title>
+    <link rel="stylesheet" href="./tokens.css" />
+    <link rel="stylesheet" href="./call/call.css" />
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module" src="./call/main.tsx"></script>
+  </body>
+</html>

--- a/src/renderer/call/CallApp.tsx
+++ b/src/renderer/call/CallApp.tsx
@@ -1,0 +1,358 @@
+// CallApp.tsx — the on-call CTO voice window surface (BET-1166).
+//
+// A small, self-contained React root. The window is frameless + draggable via
+// the `.call-header` drag region; the surface renders the three states from
+// docs/call-window/mockup.html — listening / working-narration /
+// awaiting-voice-confirmation — plus parked-vs-listening dot states — using
+// ONLY design tokens (repo rule: never a hardcoded hex).
+//
+// Transport: a single /call WebSocket (auth-gated, `?token=` — browsers can't
+// set WS headers). Opus/PCM16 mic frames go up; transcript / audio / working /
+// confirm / intent events come down. The OpenAI key lives on the box — it is
+// never requested here. Window show/park/hang ride the preload `call` bridge.
+
+import { useEffect, useRef, useState } from "react";
+
+type CallState =
+  | "disconnected"
+  | "connecting"
+  | "listening"
+  | "working"
+  | "confirm"
+  | "parked"
+  | "dropped";
+
+type TranscriptLine = { role: "user" | "cto"; text: string };
+type ConfirmInfo = { id: string; tool: string; preview: string } | null;
+
+// pcm16 encode: Int16Array → base64 (browser btoa on a latin1 string).
+function pcm16ToBase64(samples: Int16Array): string {
+  const bytes = new Uint8Array(samples.length * 2);
+  const dv = new DataView(bytes.buffer);
+  for (let i = 0; i < samples.length; i++) dv.setInt16(i * 2, samples[i], true);
+  let bin = "";
+  const chunk = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunk) {
+    bin += String.fromCharCode(...bytes.subarray(i, i + chunk));
+  }
+  return btoa(bin);
+}
+
+// Dedicated low-latency TTS for narration is generated on the box (Groq
+// Orpheus). The renderer only plays the audio the server pushes down /call.
+const NARRATE_KIND = "cto.narrate";
+
+export function CallApp() {
+  const [status, setStatus] = useState<CallState>("connecting");
+  const [transcript, setTranscript] = useState<TranscriptLine[]>([]);
+  const [working, setWorking] = useState<string | null>(null);
+  const [confirm, setConfirm] = useState<ConfirmInfo>(null);
+  const [listening, setListening] = useState(true); // mic mute (push-to-barge default: user toggles)
+  const [spend, setSpend] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  const wsRef = useRef<WebSocket | null>(null);
+  const micStreamRef = useRef<MediaStream | null>(null);
+  const audioCtxRef = useRef<AudioContext | null>(null);
+  const outNodeRef = useRef<AudioWorkletNode | null>(null);
+
+  // ----- connect the /call WS + mic + audio-out -----
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const pre = (window as any).__mantaPreload?.call;
+      if (!pre) {
+        setStatus("dropped");
+        return;
+      }
+      const cfg = await pre.getConfig();
+      if (!cfg?.serverUrl || !cfg?.boxToken) {
+        setStatus("dropped");
+        setError("Not connected to a box.");
+        return;
+      }
+      const url = cfg.serverUrl.replace(/^http/, "ws") + "/call?token=" + encodeURIComponent(cfg.boxToken);
+      const ws = new WebSocket(url);
+      wsRef.current = ws;
+      ws.onopen = () => setStatus((s) => (s === "parked" || s === "disconnected" ? s : "listening"));
+      ws.onclose = () => {
+        if (!cancelled) setStatus("disconnected");
+      };
+      ws.onerror = () => setStatus("dropped");
+      ws.onmessage = (ev) => {
+        let msg: Record<string, unknown>;
+        try {
+          msg = JSON.parse(String(ev.data));
+        } catch {
+          return;
+        }
+        handleServerMessage(msg);
+      };
+      startMic(ws);
+      setupAudioOut();
+    })();
+    return () => {
+      cancelled = true;
+      wsRef.current?.close();
+      micStreamRef.current?.getTracks().forEach((t) => t.stop());
+      audioCtxRef.current?.close().catch(() => {});
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  function handleServerMessage(msg: Record<string, unknown>) {
+    const type = String(msg.type ?? "");
+    switch (type) {
+      case "state":
+        setStatus(mapState(String(msg.state ?? "disconnected")));
+        if (String(msg.state) === "parked") setWorking(null);
+        return;
+      case "transcript":
+        setTranscript((t) =>
+          appendTranscript(t, String(msg.role) === "user" ? "user" : "cto", String(msg.delta ?? "")),
+        );
+        return;
+      case "transcript-finished":
+      case "stt":
+        return; // handled via deltas / the user line above
+      case "working":
+        setWorking(String(msg.tool ?? ""));
+        setStatus("working");
+        return;
+      case "confirm":
+        setConfirm({ id: String(msg.id ?? ""), tool: String(msg.tool ?? ""), preview: String(msg.preview ?? "") });
+        setStatus("confirm");
+        return;
+      case "confirm-resolved":
+        setConfirm(null);
+        setStatus("listening");
+        return;
+      case "audio":
+        playPcm(String(msg.delta ?? ""));
+        return;
+      case "barge":
+        outNodeRef.current?.port.postMessage({ kind: "clear" });
+        return;
+      case NARRATE_KIND:
+        // Narration audio is generated on the box and streamed as `audio`
+        // separately; nothing to render beyond the working line it complements.
+        return;
+      case "cost":
+        setSpend(Number(msg.usd ?? 0));
+        return;
+      case "error":
+      case "dropped":
+        setError(String(msg.error ?? msg.reason ?? "Call dropped."));
+        setStatus("dropped");
+        return;
+      default:
+        return;
+    }
+  }
+
+  async function startMic(ws: WebSocket) {
+    if (!listening) return;
+    if (micStreamRef.current) return;
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: { channelCount: 1, sampleRate: 24000, echoCancellation: true, noiseSuppression: true },
+      });
+      micStreamRef.current = stream;
+      const ctx = new AudioContext({ sampleRate: 24000 });
+      const src = ctx.createMediaStreamSource(stream);
+      src.connect(ctx.destination); // monitor is muted; kept for liveness
+      const worklet = await makePcmWorklet(ctx, (samples) => {
+        if (ws.readyState === WebSocket.OPEN) {
+          ws.send(JSON.stringify({ type: "audio", delta: pcm16ToBase64(samples) }));
+        }
+      });
+      src.connect(worklet);
+      worklet.connect(ctx.destination);
+    } catch {
+      setError("Microphone unavailable.");
+    }
+  }
+
+  function setupAudioOut() {
+    const ctx = new AudioContext({ sampleRate: 24000 });
+    audioCtxRef.current = ctx;
+    const workletSrc = `
+      class Out extends AudioWorkletProcessor {
+        constructor(){ super(); this.buf = new Float32Array(0); this.port.onmessage=(e)=>{ const d=e.data; if(d.kind==='push'){ const a=new Float32Array(d.samples); const n=new Float32Array(this.buf.length+a.length); n.set(this.buf); n.set(a,this.buf.length); this.buf=n; } if(d.kind==='clear'){ this.buf=new Float32Array(0); } }; }
+        process(inputs, outputs){
+          const out = outputs[0][0]; if(!out) return true;
+          if(this.buf.length>0){ const n=Math.min(out.length,this.buf.length); out.set(this.buf.subarray(0,n)); this.buf=this.buf.subarray(n); }
+          return true;
+        }
+      }
+      registerProcessor('pcm-out', Out);
+    `;
+    const blob = new Blob([workletSrc], { type: "application/javascript" });
+    const url = URL.createObjectURL(blob);
+    ctx.audioWorklet.addModule(url).then(() => {
+      const node = new AudioWorkletNode(ctx, "pcm-out");
+      node.connect(ctx.destination);
+      outNodeRef.current = node;
+      URL.revokeObjectURL(url);
+    }).catch(() => {});
+  }
+
+  function playPcm(base64: string) {
+    const buf = base64ToInt16(base64);
+    if (!buf || buf.length === 0) return;
+    outNodeRef.current?.port.postMessage({ kind: "push", samples: Array.from(buf) });
+  }
+
+  function makePcmWorklet(ctx: AudioContext, onSamples: (s: Int16Array) => void): Promise<AudioWorkletNode> {
+    const src = `
+      class In extends AudioWorkletProcessor {
+        constructor(){ super(); this.frame=new Float32Array(0); }
+        process(inputs){
+          const ch=inputs[0] && inputs[0][0]; if(!ch) return true;
+          const a=new Float32Array(this.frame.length+ch.length); a.set(this.frame); a.set(ch,this.frame.length); this.frame=a;
+          const n=Math.floor(this.frame.length/480);
+          if(n>=1){ const use=n*480; this.port.postMessage(this.frame.subarray(0,use), [this.frame.buffer]); this.frame=this.frame.subarray(use); }
+          return true;
+        }
+      }
+      registerProcessor('pcm-in', In);
+    `;
+    const blob = new Blob([src], { type: "application/javascript" });
+    const url = URL.createObjectURL(blob);
+    return ctx.audioWorklet.addModule(url).then(() => {
+      const node = new AudioWorkletNode(ctx, "pcm-in", { numberOfInputs: 1, numberOfOutputs: 1, outputChannelCount: [1] });
+      node.port.onmessage = (ev) => {
+        const f = ev.data as Float32Array;
+        const i = new Int16Array(f.length);
+        for (let k = 0; k < f.length; k++) i[k] = Math.max(-32768, Math.min(32767, Math.round(f[k] * 32768)));
+        onSamples(i);
+      };
+      URL.revokeObjectURL(url);
+      return node;
+    });
+  }
+
+  // ----- controls -----
+  function toggleMic() {
+    setListening((on) => {
+      const next = !on;
+      if (!next) {
+        micStreamRef.current?.getTracks().forEach((t) => t.stop());
+        micStreamRef.current = null;
+      } else {
+        const ws = wsRef.current;
+        if (ws) void startMic(ws);
+      }
+      return next;
+    });
+  }
+
+  function barge() {
+    wsRef.current?.send(JSON.stringify({ type: "barge" }));
+  }
+
+  async function hangup() {
+    setStatus("disconnected");
+    wsRef.current?.close();
+    micStreamRef.current?.getTracks().forEach((t) => t.stop());
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__mantaPreload?.call?.hangup?.();
+  }
+
+  function park() {
+    setStatus("parked");
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    (window as any).__mantaPreload?.call?.park?.();
+  }
+
+  return (
+    <div className={"call " + statusClass(status)}>
+      <div className="call-header">
+        <span className={"call-dot " + (status === "parked" ? "parked" : status === "listening" ? "listening" : "busy")} />
+        <span className="call-title">On-call CTO</span>
+        <span className="call-spend">{spend > 0 ? `$${spend.toFixed(2)}` : ""}</span>
+      </div>
+
+      <div className="call-body">
+        {error ? (
+          <div className="call-error">{error}</div>
+        ) : status === "confirm" && confirm ? (
+          <div className="confirm-banner">
+            <div className="confirm-preview">{confirm.preview}</div>
+            <div className="confirm-hint">Go ahead, or say "no".</div>
+          </div>
+        ) : status === "working" && working ? (
+          <div className="working-line">Working… {working}</div>
+        ) : (
+          <div className="listening-line">{status === "listening" ? "Listening" : "Connect…"}</div>
+        )}
+
+        <div className="transcript">
+          {transcript.map((l, i) => (
+            <div key={i} className={"tline " + (l.role === "user" ? "user" : "cto")}>
+              <span className="trole">{l.role === "user" ? "You" : "CTO"}</span>
+              <span className="ttext">{l.text}</span>
+            </div>
+          ))}
+        </div>
+      </div>
+
+      <div className="call-controls">
+        <button
+          className={"ctl " + (listening ? "on" : "off")}
+          onClick={toggleMic}
+          title={listening ? "Mute" : "Unmute"}
+        >
+          {listening ? "Mute" : "Talk"}
+        </button>
+        <button className="ctl" onClick={barge} title="Barge in">
+          Barge
+        </button>
+        <button className="ctl park" onClick={park} title="Park">
+          Park
+        </button>
+        <button className="ctl danger" onClick={hangup} title="Hang up">
+          Hang up
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function mapState(s: string): CallState {
+  if (s === "live") return "listening";
+  if (s === "parked") return "parked";
+  if (s === "idle") return "disconnected";
+  if (s === "connecting") return "connecting";
+  if (s === "dropped") return "dropped";
+  return "disconnected";
+}
+
+function statusClass(s: CallState): string {
+  return `call--${s}`;
+}
+
+function appendTranscript(list: TranscriptLine[], role: "user" | "cto", delta: string): TranscriptLine[] {
+  const last = list[list.length - 1];
+  if (last && last.role === role) {
+    const copy = [...list];
+    copy[copy.length - 1] = { role, text: last.text + delta };
+    return copy;
+  }
+  return [...list, { role, text: delta }];
+}
+
+function base64ToInt16(b64: string): Int16Array | null {
+  try {
+    const bin = atob(b64);
+    const bytes = new Uint8Array(bin.length);
+    for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
+    const samples = new Int16Array(bytes.length / 2);
+    const dv = new DataView(bytes.buffer);
+    for (let i = 0; i < samples.length; i++) samples[i] = dv.getInt16(i * 2, true);
+    return samples;
+  } catch {
+    return null;
+  }
+}

--- a/src/renderer/call/call.css
+++ b/src/renderer/call/call.css
@@ -1,0 +1,207 @@
+/* call/call.css — the on-call CTO floating window (BET-1166). Tokens only. */
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  height: 100%;
+  background: transparent;
+  overflow: hidden;
+  font-family: var(--font-sans);
+  color: var(--tx1);
+}
+
+.call {
+  display: flex;
+  flex-direction: column;
+  height: 100vh;
+  background: var(--canvas);
+  border: 1px solid var(--border);
+  border-radius: var(--r-lg);
+  box-shadow: var(--shadow-lg);
+  overflow: hidden;
+  transition: background 0.15s var(--ease-out);
+}
+
+.call--connecting,
+.call--disconnected {
+  border-color: var(--border-subtle);
+}
+.call--dropped {
+  border-color: var(--danger);
+}
+
+/* The header is the drag region for the frameless window. */
+.call-header {
+  -webkit-app-region: drag;
+  display: flex;
+  align-items: center;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--panel);
+  border-bottom: 1px solid var(--border-subtle);
+  user-select: none;
+}
+
+.call-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: var(--r-full);
+  transition: background 0.15s var(--ease-out);
+}
+.call-dot.listening {
+  background: var(--ok);
+  box-shadow: 0 0 0 4px var(--ok-bg);
+  animation: pulse 1.6s var(--ease-out) infinite;
+}
+.call-dot.parked {
+  background: var(--warn);
+  box-shadow: 0 0 0 4px var(--warn-bg);
+}
+.call-dot.busy {
+  background: var(--accent-solid);
+  box-shadow: 0 0 0 4px var(--accent-bg);
+}
+
+@keyframes pulse {
+  0% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.4;
+  }
+  100% {
+    opacity: 1;
+  }
+}
+
+.call-title {
+  font-size: var(--font-size-small);
+  font-weight: 600;
+  color: var(--tx1);
+}
+
+.call-spend {
+  margin-left: auto;
+  font-size: var(--font-size-2xs);
+  color: var(--tx3);
+  font-variant-numeric: tabular-nums;
+}
+
+.call-body {
+  flex: 1 1 auto;
+  padding: var(--sp-3);
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-3);
+  min-height: 0;
+  overflow: hidden;
+}
+
+.listening-line {
+  color: var(--tx2);
+  font-size: var(--font-size-small);
+}
+.working-line {
+  color: var(--accent-tx);
+  background: var(--accent-bg);
+  border: 1px solid var(--accent-solid);
+  border-radius: var(--r-md);
+  padding: var(--sp-2) var(--sp-3);
+  font-size: var(--font-size-small);
+}
+.confirm-banner {
+  border: 1px solid var(--warn);
+  background: var(--warn-bg);
+  border-radius: var(--r-md);
+  padding: var(--sp-3);
+}
+.confirm-preview {
+  color: var(--tx1);
+  font-size: var(--font-size-body);
+}
+.confirm-hint {
+  margin-top: var(--sp-1);
+  color: var(--tx2);
+  font-size: var(--font-size-2xs);
+}
+.call-error {
+  color: var(--danger);
+  border: 1px solid var(--danger);
+  background: var(--danger-bg);
+  border-radius: var(--r-md);
+  padding: var(--sp-3);
+  font-size: var(--font-size-small);
+}
+
+.transcript {
+  flex: 1 1 auto;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: var(--sp-2);
+  min-height: 0;
+  border-top: 1px solid var(--border-subtle);
+  padding-top: var(--sp-2);
+}
+
+.tline {
+  display: flex;
+  gap: var(--sp-2);
+  font-size: var(--font-size-small);
+  line-height: 1.4;
+}
+.tline.user .ttext {
+  color: var(--tx2);
+}
+.tline.cto .ttext {
+  color: var(--tx1);
+}
+.trole {
+  flex: 0 0 auto;
+  color: var(--tx3);
+  font-weight: 600;
+}
+
+.call-controls {
+  display: flex;
+  gap: var(--sp-2);
+  padding: var(--sp-2) var(--sp-3);
+  background: var(--panel);
+  border-top: 1px solid var(--border-subtle);
+  -webkit-app-region: no-drag;
+}
+
+.ctl {
+  -webkit-app-region: no-drag;
+  flex: 1 1 auto;
+  border: 1px solid var(--border);
+  background: var(--raised);
+  color: var(--tx1);
+  border-radius: var(--r-sm);
+  padding: var(--sp-2);
+  font-size: var(--font-size-2xs);
+  font-family: var(--font-sans);
+  cursor: pointer;
+  transition: background 0.12s var(--ease-out), border-color 0.12s var(--ease-out);
+}
+.ctl:hover {
+  border-color: var(--accent-solid);
+}
+.ctl.on {
+  border-color: var(--ok);
+  color: var(--ok);
+}
+.ctl.off {
+  border-color: var(--warn);
+  color: var(--warn);
+}
+.ctl.danger {
+  color: var(--danger);
+  border-color: var(--danger);
+}
+.ctl.park {
+  color: var(--tx2);
+}

--- a/src/renderer/call/main.tsx
+++ b/src/renderer/call/main.tsx
@@ -1,0 +1,17 @@
+// call/main.tsx — entry for the floating on-call CTO window (BET-1166).
+//
+// A deliberately small, self-contained React root distinct from the main app
+// (src/renderer/main.tsx). It does NOT pull in the app-wide store or httpApi:
+// it only needs window.__mantaPreload.call to fetch its {serverUrl, boxToken}
+// (to open the /call WS) and to show/park/hang the window. Audio + events ride
+// the /call WS; the OpenAI key never reaches this window.
+
+import React from "react";
+import ReactDOM from "react-dom/client";
+import { CallApp } from "./CallApp";
+
+ReactDOM.createRoot(document.getElementById("root")!).render(
+  <React.StrictMode>
+    <CallApp />
+  </React.StrictMode>,
+);

--- a/src/renderer/settingsApply.ts
+++ b/src/renderer/settingsApply.ts
@@ -41,15 +41,54 @@ export function useApplySetting(pushToast: (t: ToastItem) => void) {
     const key = entry.configKey;
     value = coerceSettingValue(entry, value);
     if (key === "theme") applyTheme(value as ThemePref);
-    useStore.setState({ [key]: value });
+    setStorePath(key, value);
     try {
       const next = await window.api.configUpdate({ [key]: value });
-      const reconciled = (next as Record<string, unknown>)[key];
-      useStore.setState({ [key]: reconciled ?? value });
+      const reconciled = readStorePath(next as Record<string, unknown>, key);
+      setStorePath(key, reconciled ?? value);
     } catch (e) {
-      useStore.setState({ [key]: prevValue });
+      setStorePath(key, prevValue);
       if (key === "theme") applyTheme(prevValue as ThemePref);
       pushToast({ id: `err-${key}-${Date.now()}`, message: errorDisclosure(`Couldn't set ${entry.label.toLowerCase()}.`, e) });
     }
   };
+}
+
+/**
+ * Read a possibly-dotted path (e.g. "cto.enabled") from an object. Flat keys
+ * return the value directly.
+ */
+function readStorePath(root: Record<string, unknown>, key: string): unknown {
+  if (!key.includes(".")) return root[key];
+  const parts = key.split(".");
+  let cur: unknown = root;
+  for (const part of parts) {
+    if (cur == null || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[part];
+  }
+  return cur;
+}
+
+/**
+ * Write a possibly-dotted path into the zustand store as a nested object. The
+ * store is shallow-merged by setState, so a nested path must be written as a
+ * whole parent object built from the current store state (no stomping others).
+ */
+function setStorePath(key: string, value: unknown): void {
+  if (!key.includes(".")) {
+    useStore.setState({ [key]: value });
+    return;
+  }
+  const parts = key.split(".");
+  const head = parts[0];
+  const current = {
+    ...(((useStore.getState() as Record<string, unknown>)[head] as object) ?? {}),
+  };
+  let cur = current as Record<string, unknown>;
+  for (let i = 1; i < parts.length - 1; i++) {
+    cur[parts[i]] = { ...((cur[parts[i]] as Record<string, unknown>) ?? {}) };
+    cur = cur[parts[i]] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]] = value;
+  useStore.setState({ [head]: current });
 }

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -405,6 +405,9 @@ type State = {
   // built-in default (whisper-large-v3-turbo).
   groqApiKey: string;
   voiceTranscriptionModel: string;
+  // On-call CTO feature (BET-1166). Nested block mirrors AppConfig#cto; the
+  // call window + settings read it off the store.
+  cto: AppConfig["cto"];
   // Analytics opt-out (BET-217). Default true; false = this instance ships
   // nothing to Axiom (desktop renderer + server). Mobile always ships
   // regardless. Mirror of AppConfig.shareAnalytics.
@@ -789,6 +792,7 @@ export const useStore = create<State>((set, get) => ({
   launcherFlags: {},
   groqApiKey: "",
   voiceTranscriptionModel: "",
+  cto: undefined,
   shareAnalytics: true,
   theme: "system",
   pinnedWindows: [],
@@ -1065,6 +1069,7 @@ export const useStore = create<State>((set, get) => ({
       launcherFlags: c.launcherFlags ?? {},
       groqApiKey: c.groqApiKey ?? "",
       voiceTranscriptionModel: c.voiceTranscriptionModel ?? "",
+      cto: c.cto ? { ...c.cto } : undefined,
       shareAnalytics: c.shareAnalytics ?? true,
       pinnedWindows: Array.isArray(c.pinnedWindows) ? c.pinnedWindows : [],
       theme:

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -405,6 +405,7 @@ type State = {
   // built-in default (whisper-large-v3-turbo).
   groqApiKey: string;
   voiceTranscriptionModel: string;
+  openaiApiKey: string;
   // On-call CTO feature (BET-1166). Nested block mirrors AppConfig#cto; the
   // call window + settings read it off the store.
   cto: AppConfig["cto"];
@@ -792,6 +793,7 @@ export const useStore = create<State>((set, get) => ({
   launcherFlags: {},
   groqApiKey: "",
   voiceTranscriptionModel: "",
+  openaiApiKey: "",
   cto: undefined,
   shareAnalytics: true,
   theme: "system",
@@ -1069,6 +1071,7 @@ export const useStore = create<State>((set, get) => ({
       launcherFlags: c.launcherFlags ?? {},
       groqApiKey: c.groqApiKey ?? "",
       voiceTranscriptionModel: c.voiceTranscriptionModel ?? "",
+      openaiApiKey: c.openaiApiKey ?? "",
       cto: c.cto ? { ...c.cto } : undefined,
       shareAnalytics: c.shareAnalytics ?? true,
       pinnedWindows: Array.isArray(c.pinnedWindows) ? c.pinnedWindows : [],

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -219,7 +219,7 @@ export function isPublicAssetPath(path) {
 // authorize(). The header always wins when present (non-browser clients keep
 // using it); the query token is honored only as a fallback and only on the
 // allowlisted stream paths (/events, /pty).
-export const QUERY_TOKEN_PATHS = new Set(["/events", "/pty"]);
+export const QUERY_TOKEN_PATHS = new Set(["/events", "/pty", "/call"]);
 
 export function queryTokenAllowedForPath(path) {
   return QUERY_TOKEN_PATHS.has(path);

--- a/src/server/auth.test.mjs
+++ b/src/server/auth.test.mjs
@@ -138,18 +138,21 @@ test("isPublicAssetPath only exempts the favicon (web/PWA client retired, BET-55
 // query-param token fallback — /events + /pty (BET-51; /pty re-added in BET-158)
 // ----------------------------------------------------------------------------
 
-test("queryTokenAllowedForPath allows /events AND /pty", () => {
+test("queryTokenAllowedForPath allows /events, /pty and /call", () => {
   assert.equal(queryTokenAllowedForPath("/events"), true);
   // BET-158: /pty is back (binary-safe terminal WS that the relay bridges).
   assert.equal(queryTokenAllowedForPath("/pty"), true);
+  // BET-1166: /call is the on-call CTO voice window WS (browser WS cannot set an
+  // Authorization header, so it uses the ?token= fallback like /events + /pty).
+  assert.equal(queryTokenAllowedForPath("/call"), true);
   // every other route must present a real Bearer header
   assert.equal(queryTokenAllowedForPath("/api/projects"), false);
   assert.equal(queryTokenAllowedForPath("/rpc/tmux"), false);
   assert.equal(queryTokenAllowedForPath("/auth/status"), false);
   assert.equal(queryTokenAllowedForPath("/"), false);
   assert.equal(queryTokenAllowedForPath("/events/../api/projects"), false);
-  // exactly the two paths, nothing more
-  assert.deepEqual([...QUERY_TOKEN_PATHS].sort(), ["/events", "/pty"]);
+  // exactly the three paths, nothing more
+  assert.deepEqual([...QUERY_TOKEN_PATHS].sort(), ["/call", "/events", "/pty"]);
 });
 
 test("authorizationForRequest: header always wins on any route", () => {

--- a/src/server/callWs.mjs
+++ b/src/server/callWs.mjs
@@ -1,0 +1,121 @@
+// callWs.mjs — the /call WebSocket handler (BET-1166, issue 3/3).
+//
+// The renderer's call window connects here (auth-gated at the upgrade layer,
+// mirroring /pty) and streams opus mic frames up while receiving transcript /
+// audio / intent events down. One vccall engine per socket; the engine owns
+// the OpenAI Realtime session (whose key lives on the box, never in the
+// renderer). Lives in its own module so the WS↔engine wiring is unit-testable
+// without standing up the HTTP server — attachCallWs(ws, url, opts) is called
+// only after the upgrade is authorized and the path is /call.
+//
+// Client→server (JSON text):
+//   { type:"audio", delta:<base64 opus> }  → engine.handleUserAudio
+//   { type:"commit" }                       → engine.commitAndRespond
+//   { type:"barge" }                        → engine.barge
+//   { type:"control", action:"park"|"hangup" } → lifecycle
+// Server→client (JSON text): every engine.publish(msg) forwarded verbatim
+//   ({ type:"state"|"audio"|"transcript"|"stt"|"working"|"confirm"|… }).
+
+import { createVcCallEngine } from "./vccall.mjs";
+
+/**
+ * Attach a /call WS to a fresh vccall engine. Auth + path matching happen at
+ * the upgrade layer (src/server/index.mjs). `opts` supplies the engine deps
+ * and the live-routing hooks (the "call active" flag that issue 2's inbound
+ * funnel reads):
+ *   { dispatchCto, approveConfirm, rejectConfirm, configGet,
+ *     synthesizeSpeech, onNarrate,
+ *     setCallActive:(active, engine|null)=>void }
+ *
+ * @param {object} ws   a `ws` WebSocket instance
+ * @param {URL}    url  the parsed upgrade URL
+ * @param {object} [opts]
+ */
+export function attachCallWs(ws, url, opts = {}) {
+  const {
+    dispatchCto,
+    approveConfirm,
+    rejectConfirm,
+    configGet,
+    synthesizeSpeech,
+    realtimeConnect,
+    onNarrate = () => {},
+    setCallActive = () => {},
+  } = opts;
+
+  let open = true;
+  function sendJson(obj) {
+    if (!open) return;
+    try {
+      ws.send(JSON.stringify(obj));
+    } catch {
+      /* socket closing */
+    }
+  }
+
+  const engine = createVcCallEngine({
+    dispatchCto,
+    approveConfirm,
+    rejectConfirm,
+    configGet,
+    synthesizeSpeech,
+    realtimeConnect,
+    onNarrate,
+    publish: sendJson,
+  });
+
+  // Boot the call on connect (open a Realtime session). The keys live on the
+  // box; the engine reads them via configGet — nothing reaches the renderer.
+  engine.setTools(opts.listTools ? opts.listTools() : []);
+  (async () => {
+    let cfg = {};
+    try {
+      cfg = (await configGet()) ?? {};
+    } catch {
+      cfg = {};
+    }
+    setCallActive(true, engine);
+    await engine.start(cfg);
+  })();
+
+  ws.on("message", (raw) => {
+    let msg;
+    try {
+      msg = JSON.parse(typeof raw === "string" ? raw : raw.toString("utf8"));
+    } catch {
+      return;
+    }
+    if (!msg || typeof msg !== "object") return;
+    switch (msg.type) {
+      case "audio":
+        if (typeof msg.delta === "string") engine.handleUserAudio(msg.delta);
+        return;
+      case "commit":
+        engine.commitAndRespond();
+        return;
+      case "barge":
+        engine.barge();
+        return;
+      case "control":
+        if (msg.action === "park") {
+          setCallActive(false, null);
+          engine.park();
+        } else if (msg.action === "hangup") {
+          setCallActive(false, null);
+          engine.hangup();
+        }
+        return;
+      default:
+        return;
+    }
+  });
+
+  ws.on("close", () => {
+    open = false;
+    setCallActive(false, null);
+    engine.hangup();
+  });
+  ws.on("error", () => {
+    /* cleanup runs in close */
+  });
+}

--- a/src/server/callWs.test.mjs
+++ b/src/server/callWs.test.mjs
@@ -1,0 +1,130 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { attachCallWs } from "./callWs.mjs";
+
+function makeClientWs() {
+  const ws = new EventEmitter();
+  ws.clientSent = [];
+  ws.send = (msg) => ws.clientSent.push(msg);
+  ws.close = () => {
+    ws.closed = true;
+    ws.emit("close");
+  };
+  return ws;
+}
+
+function makeFakeRealtime() {
+  const ws = new EventEmitter();
+  ws.sent = [];
+  ws.closed = false;
+  ws.send = (msg) => ws.sent.push(typeof msg === "string" ? msg : JSON.stringify(msg));
+  ws.close = () => {
+    ws.closed = true;
+  };
+  return ws;
+}
+
+// A tiny async helper so the WS message callback (JSON text) can be driven.
+function deliver(ws, obj) {
+  ws.emit("message", Buffer.from(JSON.stringify(obj)));
+}
+
+test("connect boots the engine, calls setCallActive(true), and streams session to live", async () => {
+  const client = makeClientWs();
+  const rt = makeFakeRealtime();
+  const activeState = [];
+  const dispatchCalls = [];
+  attachCallWs(client, new URL("/call", "http://x"), {
+    realtimeConnect: async () => rt,
+    configGet: async () => ({ openaiApiKey: "sk-test", cto: {} }),
+    dispatchCto: async (name, args, ctx) => {
+      dispatchCalls.push(name);
+      return { ok: true };
+    },
+    listTools: () => [{ name: "t1", description: "d", params: {} }],
+    setCallActive: (a, e) => activeState.push(a ? "active" : "inactive"),
+  });
+  // The engine's start() is async; let it open the fake realtime socket.
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(activeState.includes("active"), true, "call active flagged on connect");
+  assert.ok(
+    rt.sent.some((s) => {
+      try {
+        return JSON.parse(s).type === "session.update";
+      } catch {
+        return false;
+      }
+    }),
+    "session.update sent to realtime",
+  );
+
+  // session.created → renderer receives `state: live`.
+  rt.emit("message", Buffer.from(JSON.stringify({ type: "session.created", session: { id: "s1" } })));
+  await new Promise((r) => setTimeout(r, 10));
+  assert.ok(
+    client.clientSent.some((m) => {
+      try {
+        return JSON.parse(m).type === "state" && JSON.parse(m).state === "live";
+      } catch {
+        return false;
+      }
+    }),
+    "renderer told the call is live",
+  );
+});
+
+test("client audio/commit/barge bridge into the Realtime session", async () => {
+  const client = makeClientWs();
+  const rt = makeFakeRealtime();
+  attachCallWs(client, new URL("/call", "http://x"), {
+    realtimeConnect: async () => rt,
+    configGet: async () => ({ openaiApiKey: "sk-test", cto: {} }),
+    listTools: () => [],
+  });
+  await new Promise((r) => setTimeout(r, 10));
+
+  deliver(client, { type: "audio", delta: "B64" });
+  deliver(client, { type: "commit" });
+  deliver(client, { type: "barge" });
+  await new Promise((r) => setTimeout(r, 10));
+
+  const sent = rt.sent.map((s) => JSON.parse(s));
+  assert.ok(sent.some((m) => m.type === "input_audio_buffer.append" && m.audio === "B64"));
+  assert.ok(sent.some((m) => m.type === "input_audio_buffer.commit"));
+  assert.ok(sent.some((m) => m.type === "response.cancel"), "barge reaches realtime");
+});
+
+test("park / hangup clear the call-active flag and hangup the engine", async () => {
+  const client = makeClientWs();
+  const rt = makeFakeRealtime();
+  const activeState = [];
+  attachCallWs(client, new URL("/call", "http://x"), {
+    realtimeConnect: async () => rt,
+    configGet: async () => ({ openaiApiKey: "sk-test", cto: {} }),
+    listTools: () => [],
+    setCallActive: (a) => activeState.push(a),
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  deliver(client, { type: "control", action: "hangup" });
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(rt.closed, true, "realtime session torn down on hangup");
+  assert.equal(activeState[activeState.length - 1], false, "call-active cleared");
+});
+
+test("socket close tears down and clears the call-active flag (no silent session)", async () => {
+  const client = makeClientWs();
+  const rt = makeFakeRealtime();
+  const activeState = [];
+  attachCallWs(client, new URL("/call", "http://x"), {
+    realtimeConnect: async () => rt,
+    configGet: async () => ({ openaiApiKey: "sk-test", cto: {} }),
+    listTools: () => [],
+    setCallActive: (a) => activeState.push(a),
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  client.close();
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(rt.closed, true);
+  assert.equal(activeState[activeState.length - 1], false);
+});

--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -27,9 +27,12 @@
 //     engine-level failures, and the tools guard empty inputs.
 
 import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { describeModel } from "../shared/modelGuide.mjs";
+import { createSeenIdFilter } from "./seenIds.mjs";
+import { startPoller } from "./startPoller.mjs";
 
 export const CTO_STORE_PATH = statePath("cto.json");
 
@@ -115,6 +118,12 @@ export function createCtoEngine(deps = {}) {
     gitLog = remoteGitLog,
     queryMultica = async () => ({ ok: true, data: {} }),
     isPlanAgent = (name) => name === "plan" || name === "manta-plan",
+    loadWatches = async () => Array.isArray(loadCtoStore()?.watches) ? loadCtoStore().watches : [],
+    saveWatches = async (watches) => {
+      const store = loadCtoStore();
+      store.watches = Array.isArray(watches) ? watches : [];
+      await saveCtoStore(store);
+    },
     now = () => Date.now(),
   } = deps;
 
@@ -638,9 +647,84 @@ export function createCtoEngine(deps = {}) {
   });
 
   // -------------------------------------------------------------------------
+  // Watchers (Issue 2) — watch / unwatch / list_watches
+  // -------------------------------------------------------------------------
+  // A watch registers a recurring probe against a SURFACE (multica, schedule,
+  // delegate, session…). The watcher poller (createWatcherPoller below) runs
+  // each active watch's query against the surface's existing read and, when
+  // its condition matches AND its seenId is new, calls cto.inbound with that
+  // surface. `watch` is a CONFIRM-mode tool: registering a repeat probe is a
+  // side effect, so it needs the user's go-ahead (see the gate dispatch below).
+  register({
+    name: "watch",
+    description:
+      "Register a watcher that probes a surface and surfaces a notification when its " +
+      "condition matches. `surface` is one of: multica (the task board), schedule, " +
+      "delegate, or session. `query` names what to read on that surface (for multica, " +
+      "e.g. the issue key or 'read from the board'); `condition` is a natural-language " +
+      "phrase describing the trigger (e.g. 'a P0 opens'). The watcher poller runs it " +
+      "periodically via the surface's existing read. NOTE: this is a confirm-mode " +
+      "action — it registers a recurring probe, so it needs your go-ahead before it takes " +
+      "effect.",
+    params: {
+      surface: { type: "string", description: "The surface to watch: multica, schedule, delegate, or session." },
+      query: { type: "string", description: "What to query on that surface (informational)." },
+      condition: { type: "string", description: "Natural-language condition for when to trigger." },
+    },
+    mode: "confirm",
+    run: async (ctx, args) => {
+      const surface = String(args?.surface ?? "").trim();
+      if (!surface) return { ok: false, error: "surface is required (multica, schedule, delegate, session)" };
+      const watch = {
+        id: randomBytes(4).toString("hex"),
+        surface,
+        query: String(args?.query ?? "").trim(),
+        condition: String(args?.condition ?? "").trim(),
+        active: true,
+        lastFiredAt: null,
+        createdAt: now(),
+      };
+      const watches = await loadWatches();
+      await saveWatches([...watches, watch]);
+      return { ok: true, data: { watch } };
+    },
+  });
+
+  register({
+    name: "unwatch",
+    description: "Remove a watcher by its id (from list_watches). Read what is registered," +
+      " then stop the probe.",
+    params: { id: { type: "string", description: "The watcher id to remove." } },
+    run: async (ctx, args) => {
+      const id = String(args?.id ?? "");
+      const watches = await loadWatches();
+      const next = (watches ?? []).filter((w) => w?.id !== id);
+      if (next.length === (watches ?? []).length) return { ok: true, data: { removed: false } };
+      await saveWatches(next);
+      return { ok: true, data: { removed: true } };
+    },
+  });
+
+  register({
+    name: "list_watches",
+    description: "List every registered watcher: id, surface, query, condition, active," +
+      " and when it last fired. Read-only.",
+    params: {},
+    run: async () => ({ ok: true, data: { watches: await loadWatches() } }),
+  });
+
+  // -------------------------------------------------------------------------
   // Dispatch
   // -------------------------------------------------------------------------
   const byName = new Map(tools.map((t) => [t.name, t]));
+
+  // The in-conversation confirmation loop (Issue 2's gate wiring). When a
+  // confirm-mode tool is not in `trustedActions`, dispatch returns
+  // `{ needConfirmation: true, id, preview }` WITHOUT running. The cto text
+  // agent surfaces "I need your go-ahead: <preview>"; the user's "go ahead"
+  // calls approveConfirm(id) and the re-dispatch runs; "no" calls
+  // rejectConfirm(id) to abort. Issue 3 replaces this text loop with voice.
+  const pendingConfirms = new Map(); // id -> { tool, args, approved }
 
   async function dispatch(name, args, ctx = {}) {
     const def = byName.get(String(name ?? ""));
@@ -658,10 +742,27 @@ export function createCtoEngine(deps = {}) {
       return { ok: false, error: `tool ${def.name} denied` };
     }
     if (decision === "confirm") {
-      // Issue 1 ships only "auto" tools and wires no confirm/deny surface.
-      // The seam exists so Issue 3 can gate before run; until then a confirm
-      // request fails closed with a clear message rather than running.
-      return { ok: false, error: `tool ${def.name} requires confirmation (not wired yet)` };
+      // A trusted action runs without asking; anything else pauses for the
+      // user's go-ahead (returns needConfirmation and does NOT act yet).
+      const trusted = Array.isArray(ctx?.trustedActions) ? ctx.trustedActions : [];
+      if (!trusted.includes(def.name)) {
+        const id = computeConfirmId(def.name, args ?? {});
+        const prior = pendingConfirms.get(id);
+        if (prior?.approved) {
+          // The user said "go ahead" → this exact (tool, args) is authorized;
+          // consume the approval and run.
+          pendingConfirms.delete(id);
+        } else {
+          if (!prior) pendingConfirms.set(id, { tool: def.name, args: args ?? {}, approved: false });
+          return {
+            ok: true,
+            needConfirmation: true,
+            id,
+            tool: def.name,
+            preview: buildPreview(def, args ?? {}),
+          };
+        }
+      }
     }
     const narrate = typeof ctx?.onNarrate === "function" ? ctx.onNarrate : NOOP_NARRATE;
     try {
@@ -679,6 +780,18 @@ export function createCtoEngine(deps = {}) {
     tools,
     listTools: () => tools.map((t) => ({ ...t })),
     dispatch,
+    // In-conversation gate loop (Issue 2): the cto text agent surfaces a
+    // needConfirmation preview; the user's "go ahead"/"no" drives these.
+    approveConfirm: (id) => {
+      const p = pendingConfirms.get(id);
+      if (!p) return false;
+      p.approved = true;
+      pendingConfirms.set(id, p);
+      return true;
+    },
+    rejectConfirm: (id) => pendingConfirms.delete(id),
+    listPendingConfirms: () =>
+      [...pendingConfirms.entries()].map(([id, p]) => ({ id, tool: p.tool, approved: p.approved })),
   };
 }
 
@@ -741,4 +854,221 @@ async function remoteGitLog(cwd, { n = 10, oneline = true } = {}) {
   const args = ["-C", cwd, "log", `--max-count=${n}`];
   if (oneline) args.push("--oneline");
   return runGit(args, cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Inbound funnel (Issue 2) — createCtoInbound
+// ---------------------------------------------------------------------------
+// The single place a CTO-bound event enters the box. Producers (the
+// send_to_cto tool, the watcher poller, a scheduled prompt, a webhook) all
+// call `inbound({ surface, payload, seenId })`. Live vs parked is decided by
+// the server-side "call active" flag (Issue 3 sets it; this issue it is
+// always false, so every event takes the parked route). Parked events are
+// de-duped by seenId and surfaced through the EXISTING notification router
+// (push.mjs fireNotify) — no second notify path.
+export function createCtoInbound({
+  seenFilter = createSeenIdFilter(),
+  isCallActive = () => false,
+  ctoSessionID = null,
+  fireNotify = async () => {},
+  sendPrompt = async () => {},
+} = {}) {
+  async function inbound({ surface = "session", payload = {}, seenId } = {}) {
+    // De-dupe: an event whose seenId was already handled is a re-delivery
+    // (the same opencode event arrives on multiple streams; a watcher may
+    // re-poll). An event with no seenId is never swallowed.
+    if (typeof seenId === "string" && seenId && seenFilter.seen(seenId)) {
+      return { ok: true, deduped: true };
+    }
+    if (isCallActive()) {
+      // LIVE route (stub — Issue 3 sets the "call active" flag and injects
+      // the event as a turn into the CTO session). Until then this never runs.
+      if (sendPrompt && ctoSessionID && typeof payload?.message === "string" && payload.message) {
+        await sendPrompt({ sessionId: ctoSessionID, text: payload.message }).catch((e) =>
+          console.warn("[cto] live inject failed:", e?.message ?? e),
+        );
+      }
+      return { ok: true, live: true };
+    }
+    // PARKED route: surface via the existing notification router.
+    const message = typeof payload?.message === "string" ? payload.message.trim() : "";
+    if (message) {
+      try {
+        await fireNotify({
+          message,
+          title: typeof payload?.title === "string" && payload.title ? payload.title : undefined,
+          urgent: !!payload?.urgent,
+          sessionID: typeof payload?.sessionID === "string" ? payload.sessionID : undefined,
+        });
+      } catch (e) {
+        console.warn("[cto] inbound notify failed:", e?.message ?? e);
+      }
+    }
+    return { ok: true, parked: true };
+  }
+  return { inbound };
+}
+
+// ---------------------------------------------------------------------------
+// Watcher poller (Issue 2) — createWatcherPoller
+// ---------------------------------------------------------------------------
+// For each ACTIVE watch it runs the surface's existing read, computes a stable
+// seenId, and when the seenId is new AND the condition matches it calls the
+// inbound funnel with that surface. In-flight-guarded + timer.unref(), mirroring
+// the schedule/delegate pollers. The read + the seenId + the condition matcher
+// are all injected so the tick is unit-testable with no live engines.
+//
+// A watch whose surface read fails is skipped (logged, never wedges the loop);
+// a watch is only re-armed once its seenId moves, so a constantly-matching
+// read doesn't re-fire every tick.
+export function createWatcherPoller({
+  loadWatches,
+  saveWatches,
+  readSurface,
+  seenFilter = createSeenIdFilter(),
+  sendToInbound,
+  conditionMatches = defaultConditionMatches,
+  computeSeenId = defaultComputeSurfaceSeenId,
+  messageFor = defaultWatchMessage,
+  now = () => Date.now(),
+} = {}) {
+  let inFlight = false;
+
+  async function tick() {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      const watches = await loadWatches();
+      let mutated = false;
+      const snapshot = Array.isArray(watches) ? watches : [];
+      for (const watch of snapshot) {
+        if (!watch || watch.active === false || watch.disabled) continue;
+        if (!watch.surface) continue;
+        let read;
+        try {
+          read = await readSurface(watch.surface, watch.query);
+        } catch (e) {
+          console.warn(`[cto] watch ${watch.id} surface "${watch.surface}" read failed:`, e?.message ?? e);
+          continue;
+        }
+        const seenId = computeSeenId(read);
+        if (seenFilter.seen(seenId)) continue; // no new content since last tick
+        if (!conditionMatches(watch.condition, read)) continue; // not a trigger
+        await sendToInbound({ surface: watch.surface, payload: { message: messageFor(watch, read) }, seenId });
+        watch.lastFiredAt = now();
+        mutated = true;
+      }
+      if (mutated) await saveWatches(snapshot);
+    } catch (e) {
+      console.warn("[cto] watcher tick failed:", e?.message ?? e);
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  return {
+    tick,
+    start: ({ intervalMs = 15_000 } = {}) => startPoller(tick, { intervalMs, label: "cto-watcher", immediate: true }),
+  };
+}
+
+// Build the notification message for a fired watch. Falls back to a clear
+// "condition matched on <surface>" line when the read carries no snippet.
+export function defaultWatchMessage(watch, read) {
+  const condition =
+    typeof watch?.condition === "string" && watch.condition ? ` (${watch.condition})` : "";
+  const snippet = firstSnippet(read?.data ?? read);
+  const base = `CTO watch on ${watch?.surface ?? "?"}${condition} matched`;
+  return snippet ? `${base}: ${snippet}` : base;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (injectable wires, unit-tested)
+// ---------------------------------------------------------------------------
+
+// Stable short hash of a string (used for confirm ids and surface seen ids).
+export function stableHash(str) {
+  let h = 2166136261;
+  const s = String(str ?? "");
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(36);
+}
+
+// Deterministic id for a pending confirmation of a (tool, args) pair, so the
+// user's "go ahead" re-dispatch of the SAME tool+args resolves to the pending
+// record.
+export function computeConfirmId(toolName, args) {
+  return stableHash(`${toolName}:${JSON.stringify(args ?? {})}`);
+}
+
+// A short human summary of a tool call for the "I need your go-ahead: …"
+// surface. Used in the needConfirmation preview.
+export function buildPreview(def, args) {
+  const header = [def?.name ?? "?"];
+  if (args && typeof args === "object") {
+    const entries = Object.entries(args).filter(([, v]) => v !== undefined && v !== null && v !== "");
+    if (entries.length) {
+      header.push(entries.map(([k, v]) => `${k}=${typeof v === "object" ? JSON.stringify(v) : String(v)}`).join(", "));
+    }
+  }
+  const firstLine = (String(def?.description ?? "").split("\n")[0] ?? "").slice(0, 120);
+  if (firstLine) header.push(`— ${firstLine}`);
+  return header.join(" ");
+}
+
+const CONDITION_STOPWORDS = new Set([
+  "a", "an", "the", "of", "to", "in", "on", "for", "and", "or", "with",
+  "when", "if", "is", "are", "was", "were", "new", "opens", "open", "appears",
+  "shows", "changes", "has", "have", "any", "that", "this", "there", "it",
+]);
+
+// Keywords of a natural-language condition (lowercased tokens minus stopwords) —
+// the deterministic v1 condition evaluator. Issue 3 may replace this with an
+// LLM/narration judgement; until then a keyword hit is the honest seam.
+export function conditionKeywords(condition) {
+  if (typeof condition !== "string") return [];
+  return condition
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 0 && !CONDITION_STOPWORDS.has(t));
+}
+
+// Default condition evaluator: matches when any keyword from the condition is
+// present in the serialized read, or when the condition is empty/no keywords
+// (treat any new content as a trigger). Lowercased case-insensitive match.
+export function defaultConditionMatches(condition, read) {
+  const keywords = conditionKeywords(condition);
+  if (keywords.length === 0) return true;
+  const haystack = JSON.stringify(read ?? {}).toLowerCase();
+  return keywords.some((k) => haystack.includes(k));
+}
+
+// A stable seenId for a surface read. Prefers an explicit `seenId` on the read
+// (readers may stamp one, e.g. the newest issue id), else hashes a stable
+// serialization of the whole read. Two identical reads hash identically, so
+// the poller does not re-fire until content actually changes.
+export function defaultComputeSurfaceSeenId(read) {
+  if (read && typeof read === "object" && typeof read.seenId === "string" && read.seenId) {
+    return read.seenId;
+  }
+  return stableHash(JSON.stringify(read ?? {}));
+}
+
+// First short text snippet from a read for the watch notification message.
+function firstSnippet(data) {
+  if (!data) return null;
+  if (typeof data === "string") return data.slice(0, 140);
+  const issues = Array.isArray(data?.issues) ? data.issues : null;
+  if (issues) {
+    const first = issues.find((i) => i && (i.identifier || i.title));
+    if (first) {
+      const label = [first.identifier, first.status, first.title].filter(Boolean).join(" · ");
+      return label.slice(0, 140);
+    }
+  }
+  const text = JSON.stringify(data);
+  return text && text !== "{}" && text !== "[]" ? text.slice(0, 140) : null;
 }

--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -34,7 +34,7 @@ function makeEngine(overrides = {}) {
   return engine;
 }
 
-const TOOL_COUNT = 15;
+const TOOL_COUNT = 18; // 15 reads (BET-1164) + 3 watcher tools watch/unwatch/list_watches (BET-1165)
 
 // ---------------------------------------------------------------------------
 // Registry integrity
@@ -63,6 +63,9 @@ test("registry exposes every cto read tool with a complete shape, all mode auto"
       "session_plan_mode",
       "get_config",
       "query_multica",
+      "watch",
+      "unwatch",
+      "list_watches",
     ].sort(),
   );
   for (const t of tools) {
@@ -71,7 +74,9 @@ test("registry exposes every cto read tool with a complete shape, all mode auto"
     assert.equal(typeof t.description, "string");
     assert.ok(t.description.length > 0);
     assert.ok(t.params && typeof t.params === "object");
-    assert.equal(t.mode, "auto");
+    // Reads are auto; the watcher tools are auto/confirm (watch registers a
+    // recurring probe, so it is confirm-gated).
+    assert.ok(t.mode === "auto" || t.mode === "confirm");
     assert.equal(typeof t.run, "function");
   }
 });
@@ -108,12 +113,15 @@ test("dispatch honors a gate returning deny (fails closed)", async () => {
   assert.match(result.error, /denied/);
 });
 
-test("dispatch fails closed when the gate requests confirm (not wired yet)", async () => {
+test("dispatch requires confirmation for a confirm-gated tool and does NOT act", async () => {
   const engine = makeEngine();
   const gate = () => "confirm";
+  // A confirm-gated tool that is not trusted pauses with needConfirmation
+  // (Issue 2 gate wiring) instead of failing closed.
   const result = await engine.dispatch("list_models", {}, { gate });
-  assert.equal(result.ok, false);
-  assert.match(result.error, /requires confirmation/);
+  assert.equal(result.ok, true);
+  assert.equal(result.needConfirmation, true);
+  assert.equal(typeof result.preview, "string");
 });
 
 test("default gate returns allow for every tool (Issue 1 ships auto)", async () => {

--- a/src/server/ctoInbound.test.mjs
+++ b/src/server/ctoInbound.test.mjs
@@ -1,0 +1,336 @@
+// ctoInbound.test.mjs — On-call CTO inbound feed (BET-1165, issue 2/3).
+// Pure logic + injected I/O, no live tmux / opencode / multica / push:
+//   - inbound routing (live flag off → park; live on → inject; dedupe via seenId)
+//   - watcher tick with injected reads (fires on new + matching, no re-fire)
+//   - watch registry CRUD (engine confirm-gated, cto.json atomic store round-trip)
+//   - gate: confirm → allow via trustedActions; untrusted → needConfirmation;
+//     text-loop approve / reject re-dispatch
+//   - pure helpers (conditionKeywords / defaultConditionMatches / seenId / preview)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createCtoInbound,
+  createWatcherPoller,
+  createCtoEngine,
+  loadCtoStore,
+  saveCtoStore,
+  conditionKeywords,
+  defaultConditionMatches,
+  defaultComputeSurfaceSeenId,
+  computeConfirmId,
+  buildPreview,
+  stableHash,
+} from "./cto.mjs";
+
+// ---------------------------------------------------------------------------
+// Inbound routing + dedupe
+// ---------------------------------------------------------------------------
+
+test("inbound parks when the call flag is off and surfaces via fireNotify", async () => {
+  const notified = [];
+  const inbound = createCtoInbound({ fireNotify: async (a) => notified.push(a) });
+  const res = await inbound.inbound({ surface: "session", payload: { message: "hey", urgent: true } });
+  assert.equal(res.ok, true);
+  assert.equal(res.parked, true);
+  assert.equal(res.live, undefined);
+  assert.equal(notified.length, 1);
+  assert.equal(notified[0].message, "hey");
+  assert.equal(notified[0].urgent, true);
+});
+
+test("inbound drops a re-delivered event with an already-seen seenId (dedupe)", async () => {
+  const notified = [];
+  const inbound = createCtoInbound({ fireNotify: async (a) => notified.push(a) });
+  await inbound.inbound({ surface: "session", payload: { message: "a" }, seenId: "evt-1" });
+  const second = await inbound.inbound({ surface: "session", payload: { message: "b" }, seenId: "evt-1" });
+  assert.equal(second.deduped, true);
+  assert.equal(notified.length, 1); // only the first surfaced
+  // An event with no seenId is never swallowed.
+  await inbound.inbound({ surface: "session", payload: { message: "c" } });
+  assert.equal(notified.length, 2);
+});
+
+test("inbound live route injects into the CTO session when the flag is on (stub seam)", async () => {
+  const sent = [];
+  const inbound = createCtoInbound({
+    isCallActive: () => true,
+    ctoSessionID: "cto-ses",
+    sendPrompt: async (a) => sent.push(a),
+    fireNotify: async () => {},
+  });
+  const res = await inbound.inbound({ surface: "session", payload: { message: "live" } });
+  assert.equal(res.live, true);
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].sessionId, "cto-ses");
+  assert.equal(sent[0].text, "live");
+});
+
+test("inbound with no message and no live call surfaces nothing but resolves ok", async () => {
+  const notified = [];
+  const inbound = createCtoInbound({ fireNotify: async (a) => notified.push(a) });
+  const res = await inbound.inbound({ surface: "multica", payload: {} });
+  assert.equal(res.ok, true);
+  assert.equal(res.parked, true);
+  assert.equal(notified.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Gate: confirm → allow via trustedActions; text-loop approve / reject
+// ---------------------------------------------------------------------------
+
+function makeEngine(overrides = {}) {
+  return createCtoEngine({
+    listProjects: async () => [],
+    listSessions: async () => [],
+    listMessages: async () => [],
+    listModels: async () => [],
+    getSessionAgent: async () => null,
+    listSnapshots: () => [],
+    listStopped: async () => ({ records: [], lastLooked: null }),
+    searchMessages: async () => ({ supported: true, hits: [] }),
+    configGet: async () => ({}),
+    gitStatus: async () => "",
+    gitBranch: async () => null,
+    gitLog: async () => "",
+    queryMultica: async () => ({ ok: true }),
+    ...overrides,
+  });
+}
+
+// Gate that reports confirm only for `watch` (the confirm-mode tool).
+const gate = (name) => (name === "watch" ? "confirm" : "allow");
+
+test("untrusted confirm-mode tool returns needConfirmation + preview and does NOT act", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const res = await engine.dispatch("watch", { surface: "multica", query: "q", condition: "a P0 opens" }, { gate });
+  assert.equal(res.ok, true);
+  assert.equal(res.needConfirmation, true);
+  assert.equal(res.tool, "watch");
+  assert.equal(typeof res.id, "string");
+  assert.ok(res.preview.length > 0);
+  assert.equal(watchers.length, 0); // NOT registered yet
+});
+
+test("a trusted action in trustedActions runs without confirmation", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const res = await engine.dispatch(
+    "watch",
+    { surface: "multica", query: "q", condition: "a P0 opens" },
+    { gate, trustedActions: ["watch"] },
+  );
+  assert.equal(res.ok, true);
+  assert.equal(res.needConfirmation, undefined);
+  assert.equal(watchers.length, 1);
+  assert.equal(watchers[0].surface, "multica");
+});
+
+test("text loop: approveConfirm(id) then re-dispatch of the same tool+args runs it", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const args = { surface: "multica", query: "q", condition: "a P0 opens" };
+  const first = await engine.dispatch("watch", args, { gate });
+  assert.equal(first.needConfirmation, true);
+  assert.equal(watchers.length, 0);
+  // user says "go ahead"
+  assert.equal(engine.approveConfirm(first.id), true);
+  const second = await engine.dispatch("watch", args, { gate });
+  assert.equal(second.needConfirmation, undefined);
+  assert.equal(watchers.length, 1);
+});
+
+test("text loop: rejectConfirm(id) aborts and the tool stays blocked until approved again", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const args = { surface: "multica", query: "q", condition: "a P0 opens" };
+  const first = await engine.dispatch("watch", args, { gate });
+  // user says "no"
+  assert.equal(engine.rejectConfirm(first.id), true);
+  const second = await engine.dispatch("watch", args, { gate });
+  assert.equal(second.needConfirmation, true); // still blocked
+  assert.equal(watchers.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Watch registry CRUD (engine + cto.json atomic store round-trip)
+// ---------------------------------------------------------------------------
+
+test("watch registry CRUD through the engine (watch / list_watches / unwatch)", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const gated = { gate, trustedActions: ["watch"] };
+  const added = await engine.dispatch("watch", { surface: "multica", query: "q", condition: "a P0 opens" }, gated);
+  assert.equal(added.ok, true);
+  const id = added.data.watch.id;
+  assert.equal(watchers.length, 1);
+  assert.equal(watchers[0].active, true);
+  assert.equal(watchers[0].lastFiredAt, null);
+
+  const list = await engine.dispatch("list_watches", {});
+  assert.equal(list.data.watches.length, 1);
+
+  const removed = await engine.dispatch("unwatch", { id }, {});
+  assert.equal(removed.data.removed, true);
+  assert.equal(watchers.length, 0);
+});
+
+test("cto.json store load/save round-trips watches atomically", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "cto-store-"));
+  const path = join(dir, "cto.json");
+  const init = loadCtoStore(path);
+  assert.deepEqual(init.watches, []);
+  const store = loadCtoStore(path);
+  store.watches = [
+    { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null, createdAt: 1 },
+  ];
+  await saveCtoStore(store, path);
+  const reloaded = loadCtoStore(path);
+  assert.equal(reloaded.watches.length, 1);
+  assert.equal(reloaded.watches[0].surface, "multica");
+});
+
+// ---------------------------------------------------------------------------
+// Watcher poller with injected reads
+// ---------------------------------------------------------------------------
+
+test("watcher tick fires inbound when condition matches and seenId is new; no re-fire on the same read", async () => {
+  const readOnce = { ok: true, data: { issues: [{ identifier: "BET-1", status: "critical", title: "P0 outage" }] } };
+  const fired = [];
+  const poller = createWatcherPoller({
+    loadWatches: async () => [
+      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null },
+    ],
+    saveWatches: async () => {},
+    readSurface: async () => readOnce,
+    sendToInbound: async (input) => fired.push(input),
+  });
+  await poller.tick();
+  assert.equal(fired.length, 1);
+  assert.equal(fired[0].surface, "multica");
+  assert.equal(typeof fired[0].seenId, "string");
+  assert.ok(fired[0].payload.message.includes("P0"), "message carries the matching snippet");
+  // Same (unchanged) read on the next tick → seenId unchanged → no re-fire.
+  await poller.tick();
+  assert.equal(fired.length, 1);
+});
+
+test("watcher tick respects an inactive/disabled watch", async () => {
+  const fired = [];
+  const poller = createWatcherPoller({
+    loadWatches: async () => [
+      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: false, lastFiredAt: null },
+    ],
+    saveWatches: async () => {},
+    readSurface: async () => ({ ok: true, data: { issues: [{ identifier: "BET-1", status: "critical", title: "P0 outage" }] } }),
+    sendToInbound: async (input) => fired.push(input),
+  });
+  await poller.tick();
+  assert.equal(fired.length, 0);
+});
+
+test("watcher tick does not fire when the condition does not match", async () => {
+  const fired = [];
+  // read has no P0 and no keyword from the condition ("P0")
+  const poller = createWatcherPoller({
+    loadWatches: async () => [
+      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null },
+    ],
+    saveWatches: async () => {},
+    readSurface: async () => ({ ok: true, data: { issues: [{ identifier: "BET-2", status: "todo", title: "chore" }] } }),
+    sendToInbound: async (input) => fired.push(input),
+  });
+  await poller.tick();
+  assert.equal(fired.length, 0);
+});
+
+test("watcher tick survives a failed surface read (skips the watch, keeps going)", async () => {
+  const fired = [];
+  let calls = 0;
+  const poller = createWatcherPoller({
+    loadWatches: async () => [
+      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null },
+      { id: "w2", surface: "multica", query: "q2", condition: "a P0 opens", active: true, lastFiredAt: null },
+    ],
+    saveWatches: async () => {},
+    readSurface: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("surface down");
+      return { ok: true, data: { issues: [{ identifier: "BET-1", status: "critical", title: "P0 outage" }] } };
+    },
+    sendToInbound: async (input) => fired.push(input),
+  });
+  await poller.tick();
+  // w1's read threw (skipped, no throw out of the tick); w2's read succeeded.
+  assert.equal(fired.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+test("conditionKeywords strips stopwords and normalizes case", () => {
+  assert.deepEqual(conditionKeywords("a P0 opens"), ["p0"]);
+  assert.deepEqual(conditionKeywords("deploy failed"), ["deploy", "failed"]);
+  assert.deepEqual(conditionKeywords(""), []);
+});
+
+test("defaultConditionMatches is a keyword hit (case-insensitive) or true on empty condition", () => {
+  const read = { data: { issues: [{ identifier: "BET-1", title: "P0 Outage" }] } };
+  assert.equal(defaultConditionMatches("a P0 opens", read), true);
+  assert.equal(defaultConditionMatches("deploy failed", read), false);
+  assert.equal(defaultConditionMatches("", read), true);
+});
+
+test("defaultComputeSurfaceSeenId is stable for identical reads, differs for changed ones", () => {
+  const readA = { data: { issues: [{ identifier: "BET-1" }] } };
+  const readB = { data: { issues: [{ identifier: "BET-1" }, { identifier: "BET-2" }] } };
+  assert.equal(defaultComputeSurfaceSeenId(readA), defaultComputeSurfaceSeenId(readA));
+  assert.notEqual(defaultComputeSurfaceSeenId(readA), defaultComputeSurfaceSeenId(readB));
+  // An explicit seenId on the read always wins.
+  assert.equal(defaultComputeSurfaceSeenId({ seenId: "abc" }), "abc");
+});
+
+test("computeConfirmId is deterministic per (tool, args) and buildPreview summarizes", () => {
+  assert.equal(computeConfirmId("watch", { surface: "multica" }), computeConfirmId("watch", { surface: "multica" }));
+  assert.notEqual(computeConfirmId("watch", { surface: "multica" }), computeConfirmId("watch", { surface: "delegate" }));
+  const preview = buildPreview({ name: "watch", description: "Register a watcher\nover two lines" }, { surface: "multica", condition: "a P0 opens" });
+  assert.ok(preview.includes("watch"));
+  assert.ok(preview.includes("surface=multica"));
+  assert.ok(preview.length > 0);
+});
+
+test("stableHash is a short stable hash", () => {
+  assert.equal(stableHash("x"), stableHash("x"));
+  assert.ok(stableHash("x").length >= 1);
+  assert.notEqual(stableHash("x"), stableHash("y"));
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -39,6 +39,7 @@ import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/
 }
 import { createBus, handleEventsRequest, attachEventsWs } from "./events.mjs";
 import { attachPtyWs } from "./ptyWs.mjs";
+import { attachCallWs } from "./callWs.mjs";
 import { buildHandlers, handleRpcRequest } from "./rpc.mjs";
 import { startStatusPoller } from "./status.mjs";
 import { createSyncState } from "./syncState.mjs";
@@ -943,11 +944,34 @@ void maybeEnsureCtoAgent();
 // sets it), so every event takes the PARKED route → dedupe → the existing
 // notification router (fireNotify). No parallel notify path.
 const ctoInbound = cto.createCtoInbound({
-  isCallActive: () => false, // Issue 3 sets the live flag; until then always parked
-  ctoSessionID: null, // resolved in Issue 3 when the live route flips on
+  isCallActive: () => callActive,
+  ctoSessionID: null, // issue 3 wires the live route below via the active call engine
   fireNotify: (args) => push.fireNotify(args),
-  sendPrompt: (args) => promptDelivery.deliver(args),
+  sendPrompt: async ({ text }) => {
+    // LIVE route (issue 3): while a call is open, inject the inbound event as
+    // a turn into the active Realtime session so the CTO speaks it. Parked
+    // events never reach here (isCallActive guards the branch).
+    const engine = activeCallEngine;
+    if (engine && text) {
+      try {
+        engine.injectTurn(typeof text === "string" ? text : String(text ?? ""));
+      } catch (e) {
+        console.warn("[cto] live inject failed:", e?.message ?? e);
+      }
+    }
+  },
 });
+
+// The server-side "call active" flag issue 2's inbound funnel reads. Set by
+// the /call WS handler (issue 3): true while a call window is connected, with
+// a reference to its engine so live inbound events can be spoken. Parked state
+// (window hidden) keeps the flag false → events take the existing push route.
+let callActive = false;
+let activeCallEngine = null;
+function setCallActive(active, engine) {
+  callActive = !!active;
+  activeCallEngine = active && engine ? engine : null;
+}
 
 // Which read a watcher's surface maps to. EXTERNAL surfaces (multica) go
 // through multica.mjs; NATIVE surfaces (schedule, delegate) through the box's
@@ -2983,6 +3007,25 @@ const handleUpgrade = (req, socket, head) => {
     // or ?token=<box_token>) connect here for a low-latency raw-byte
     // terminal stream.
     wss.handleUpgrade(req, socket, head, (ws) => attachPtyWs(ws, url));
+    return;
+  }
+  if (url.pathname === "/call") {
+    // On-call CTO voice window (BET-1166). The renderer's call window streams
+    // opus mic frames here; the box relays to OpenAI Realtime (key server-side).
+    wss.handleUpgrade(req, socket, head, (ws) =>
+      attachCallWs(ws, url, {
+        dispatchCto: (name, args, ctx) => getCtoEngine().dispatch(name, args, {
+          ...ctx,
+          gate: ctx?.gate ?? (() => "confirm"),
+        }),
+        approveConfirm: (id) => getCtoEngine().approveConfirm(id),
+        rejectConfirm: (id) => getCtoEngine().rejectConfirm(id),
+        configGet: () => local.configGet(),
+        listTools: () => getCtoEngine().listTools(),
+        setCallActive,
+        onNarrate: () => {}, // narration events flow out via engine.publish
+      }),
+    );
     return;
   }
   socket.destroy();

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -67,7 +67,7 @@ import {
   startCapSweeper,
 } from "./capabilities.mjs";
 import { notifyCapSession } from "./capNotifier.mjs";
-import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset, resolveForgeOwner } from "./delegate.mjs";
+import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset, resolveForgeOwner, loadJobs as loadDelegateJobs } from "./delegate.mjs";
 import {
   reportProgress,
   readProgressRecord,
@@ -935,6 +935,56 @@ async function maybeEnsureCtoAgent() {
   }
 }
 void maybeEnsureCtoAgent();
+
+// On-call CTO inbound funnel (Issue 2): the single place a CTO-bound event
+// enters the box. Producers (the send_to_cto tool, the watcher poller, a
+// scheduled prompt targeting the CTO, a webhook routed to the CTO) all call
+// `inbound()`. The server-side "call active" flag is FALSE this issue (Issue 3
+// sets it), so every event takes the PARKED route → dedupe → the existing
+// notification router (fireNotify). No parallel notify path.
+const ctoInbound = cto.createCtoInbound({
+  isCallActive: () => false, // Issue 3 sets the live flag; until then always parked
+  ctoSessionID: null, // resolved in Issue 3 when the live route flips on
+  fireNotify: (args) => push.fireNotify(args),
+  sendPrompt: (args) => promptDelivery.deliver(args),
+});
+
+// Which read a watcher's surface maps to. EXTERNAL surfaces (multica) go
+// through multica.mjs; NATIVE surfaces (schedule, delegate) through the box's
+// own stores. `session` needs no poller read — session events arrive directly
+// via send_to_cto. `crashlytics` is an external MCP read with no server-side
+// engine yet (stretch), so it never matches until that read lands (Issue 3).
+async function ctoSurfaceRead(surface, query) {
+  switch (surface) {
+    case "multica":
+      return queryMultica({ query: query ?? "" });
+    case "schedule":
+      return { ok: true, data: { jobs: await listJobs() } };
+    case "delegate":
+      return { ok: true, data: { jobs: await loadDelegateJobs() } };
+    case "crashlytics":
+      return { ok: true, data: { issues: [] } };
+    case "session":
+    default:
+      return { ok: true, data: {} };
+  }
+}
+
+// Watcher poller (Issue 2): probes each active watch against its surface's
+// existing read and routes a matching + unseen event into the inbound funnel.
+// In-flight-guarded + timer.unref(), mirroring the schedule/delegate pollers.
+const watcherPoller = cto.createWatcherPoller({
+  loadWatches: async () => Array.isArray(cto.loadCtoStore()?.watches) ? cto.loadCtoStore().watches : [],
+  saveWatches: async (watches) => {
+    const store = cto.loadCtoStore();
+    store.watches = Array.isArray(watches) ? watches : [];
+    await cto.saveCtoStore(store);
+  },
+  readSurface: ctoSurfaceRead,
+  sendToInbound: (input) => ctoInbound.inbound(input),
+});
+// eslint-disable-next-line no-unused-vars
+const stopWatcherPoller = watcherPoller.start({ intervalMs: 15_000 });
 
 // Sweep expired artifact-mailbox files (TTL past) every 5 min — non-destructive
 // otherwise: downloads do not delete, the sweep is what reclaims disk.
@@ -2609,13 +2659,58 @@ const handleRequest = async (req, res) => {
   // on-call CTO agent. dispatch wraps every tool so a quiet box / bad engine
   // returns a structured error, never a throw. `ctx.onNarrate` is a server-side
   // seam (wired by issue 3's voice window), never read off the HTTP body.
+  // ---------- On-call CTO inbound (Issue 2) ----------
+  // POST /api/cto/inbound  body {surface?, payload, seenId?} → {ok:true, ...}
+  // The single entry point for CTO-bound events. Producers: the global
+  // send_to_cto tool, the watcher poller, a scheduled prompt targeting the
+  // CTO, or a webhook routed to the CTO. With no live call (this issue) events
+  // are deduped + surfaced via the existing notification router; Issue 3 flips
+  // the live route on. See src/server/cto.mjs (createCtoInbound).
+  if (path === "/api/cto/inbound") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const result = await ctoInbound.inbound({
+          surface: body?.surface,
+          payload: body?.payload ?? {},
+          seenId: body?.seenId,
+        });
+        respondJson(res, result.ok ? 200 : 400, result);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
   if (path === "/api/cto") {
     try {
       if (req.method === "POST") {
         const body = await readJsonBody(req);
-        const result = await getCtoEngine().dispatch(body?.tool, body?.args ?? {}, {
+        const engine = getCtoEngine();
+        // Text-loop gate (Issue 2): an `approve` id re-authorizes the previously
+        // needConfirmation'd (tool, args) — the user said "go ahead". "no" is
+        // rejectConfirm; both drive the in-conversation loop (Issue 3 replaces it
+        // with voice).
+        if (typeof body?.approve === "string" && body.approve) engine.approveConfirm(body.approve);
+        let cfg = {};
+        try {
+          cfg = (await local.configGet()) ?? {};
+        } catch {
+          cfg = {};
+        }
+        // The gate reports each tool's declared mode: read-only auto tools run
+        // freely; confirm-mode tools (watch) pause for the user's go-ahead
+        // (handled inside dispatch via trustedActions / the approve loop).
+        const toolModes = new Map(engine.listTools().map((t) => [t.name, t.mode]));
+        const gate = (toolName) => (toolModes.get(toolName) === "confirm" ? "confirm" : "allow");
+        const result = await engine.dispatch(body?.tool, body?.args ?? {}, {
           sessionID: body?.sessionID,
           cwd: body?.directory,
+          trustedActions: Array.isArray(cfg?.cto?.trustedActions) ? cfg.cto.trustedActions : [],
+          gate,
         });
         respondJson(res, result.ok ? 200 : 400, result);
         return;

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -56,6 +56,18 @@ const DEFAULT_CONFIG = {
   // sweep deletes the file (transcript + waveform are kept forever). 0 = keep
   // forever. Default 168 (7 days).
   voiceNoteTtlHours: 168,
+  // "On-call CTO" feature (BET-1164..1166). Server-side defaults mirror
+  // src/shared/types.ts AppConfig#cto. `enabled` off (false) until shipped;
+  // with it off the box never registers the cto agent nor wires the engine.
+  cto: {
+    enabled: false,
+    transport: "realtime",
+    model: "",
+    voice: "",
+    trustedActions: [],
+    parkedBehavior: "auto-open",
+    alwaysListening: false,
+  },
   // BET-799: user-configured self-hosted forge hosts — `[{ host, kind, apiBase? }]`.
   // Lets a self-hosted GitHub/GitLab instance (which `detectForge` deliberately
   // rejects) resolve to its forge + API root. `kind` is "github" | "gitlab".
@@ -91,11 +103,29 @@ export async function configGet() {
   return getConfig();
 }
 
-// configUpdate(patch) — merge patch, persist, return full config.
+// configUpdate(patch) — merge patch, persist, return full config. Dotted keys
+// (e.g. "cto.enabled") are written as nested paths so the schemas that address
+// nested config (`cto.*`) land where the server reads them. Flat keys merge as
+// before. Deep objects are merged one level (enough for the cto block).
 // preload: ipcRenderer.invoke(IPC.configUpdate, patch) → args[0] = patch
 export async function configUpdate(patch) {
   const current = await getConfig();
-  const next = { ...current, ...patch };
+  const next = { ...current };
+  for (const [key, value] of Object.entries(patch ?? {})) {
+    if (typeof key === "string" && key.includes(".")) {
+      const [head, ...rest] = key.split(".");
+      const target = { ...(next[head] ?? {}) };
+      let cur = target;
+      for (let i = 0; i < rest.length - 1; i++) {
+        cur[rest[i]] = { ...(cur[rest[i]] ?? {}) };
+        cur = cur[rest[i]];
+      }
+      cur[rest[rest.length - 1]] = value;
+      next[head] = target;
+    } else {
+      next[key] = value;
+    }
+  }
   await saveConfig(next);
   return next;
 }

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -56,6 +56,9 @@ const DEFAULT_CONFIG = {
   // sweep deletes the file (transcript + waveform are kept forever). 0 = keep
   // forever. Default 168 (7 days).
   voiceNoteTtlHours: 168,
+  // OpenAI API key for the on-call CTO voice transport (BET-1166). Stored on
+  // the box like groqApiKey; the renderer never sees it.
+  openaiApiKey: "",
   // "On-call CTO" feature (BET-1164..1166). Server-side defaults mirror
   // src/shared/types.ts AppConfig#cto. `enabled` off (false) until shipped;
   // with it off the box never registers the cto agent nor wires the engine.

--- a/src/server/localCtoConfig.test.mjs
+++ b/src/server/localCtoConfig.test.mjs
@@ -1,0 +1,25 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { configUpdate, configGet } from "./local.mjs";
+
+// The settings schema addresses the on-call CTO block through nested keys
+// ("cto.enabled", "cto.model", …). configUpdate must write those to the nested
+// `cto.*` path the server reads — not as a flat top-level key. Runs in the
+// sandboxed state dir (testSandbox.mjs), never production config.
+
+test("configUpdate writes dotted cto.* keys into the nested cto block", async () => {
+  await configUpdate({ "cto.enabled": true, "cto.model": "gpt-4o-realtime-preview", "cto.trustedActions": ["a", "b"] });
+  const cfg = await configGet();
+  assert.equal(cfg.cto.enabled, true);
+  assert.equal(cfg.cto.model, "gpt-4o-realtime-preview");
+  assert.deepEqual(cfg.cto.trustedActions, ["a", "b"]);
+  // No flat dotted key leaked to the top level.
+  assert.equal(cfg["cto.enabled"], undefined);
+});
+
+test("configUpdate flat keys still merge at the top level", async () => {
+  await configUpdate({ voiceNoteTtlHours: 5 });
+  const cfg = await configGet();
+  assert.equal(cfg.voiceNoteTtlHours, 5);
+  assert.equal(typeof cfg.cto.enabled, "boolean");
+});

--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -1,0 +1,434 @@
+// vccall.mjs — the on-call CTO voice-call engine (BET-1166, issue 3/3).
+//
+// Owns the OpenAI Realtime WebSocket session (server-relayed transport). The
+// renderer's call window never talks to OpenAI directly and never sees the
+// API key: it streams opus mic frames up a local, auth-gated /call WS and
+// receives audio + transcript + intent events back down it. THIS module is
+// the brain between the two — a pure, injectable state machine so the whole
+// Realtime protocol (barge, function-call loop → cto.dispatch, voice
+// confirmation, narration injection, lifecycle) is unit-testable against a
+// MOCKED OpenAI Realtime WS with no live socket.
+//
+// Design rules (mirror cto.mjs / delegate.mjs): pure decision logic with
+// injected I/O. `deps` supplies every I/O:
+//   - realtimeConnect(url, headers) → a ws-like (EventEmitter with .send)
+//   - dispatchCto(name, args, ctx)   → cto.dispatch from issue 1
+//   - approveConfirm / rejectConfirm → cto engine's voice-confirm handlers
+//   - configGet()                    → AppConfig (model/voice/trustedActions/…)
+//   - synthesizeSpeech({text,apiKey})→ Groq Orpheus TTS (narration)
+//   - publish(msg)                   → emit a message down the /call WS
+//   - now()                          → clock (for idle/cost accounting)
+//   - onState(state)                 → state-change hook (tests observe)
+//
+// The Realtime session is torn down on park and hangup so there is no silent
+// per-minute OpenAI spend (cost guard).
+
+import { WebSocket as NodeWebSocket } from "ws";
+
+const REALTIME_BASE = "wss://api.openai.com/v1/realtime";
+const DEFAULT_REALTIME_MODEL = "gpt-4o-realtime-preview";
+const DEFAULT_VOICE = "alloy";
+
+// Cost cap defaults (USD). Per-call cap disconnects + notifies; a generous
+// auto-idle park leaves the model no silent spend.
+export const DEFAULT_SPEND_CAP_USD = 5;
+export const DEFAULT_IDLE_PARK_MS = 60_000;
+
+// The Realtime session is instructed to ask for go-ahead before acting on a
+// confirm-mode tool. This is the contract the model follows (issue 2's text
+// confirm loop, issued 3's voice loop).
+const SESSION_INSTRUCTIONS = [
+  "You are the on-call CTO voice assistant. You have deterministic read tools.",
+  "When a tool needs the user's go-ahead, you MUST pause and state exactly",
+  "what you are about to do, then WAIT for a spoken yes/no. Do not act until",
+  "the user answers. If the user says no or cancels, explain and replan.",
+].join(" ");
+
+export function clampModel(v, dflt) {
+  return typeof v === "string" && v.trim() ? v.trim() : dflt;
+}
+
+/**
+ * Build the vccall engine. Returns a control surface plus the low-level
+ * `receiveRealtime(evt, send)` dispatcher so tests can drive a fake WS.
+ */
+export function createVcCallEngine(deps = {}) {
+  const {
+    realtimeConnect = defaultRealtimeConnect,
+    dispatchCto = async () => ({ ok: true }),
+    approveConfirm = () => true,
+    rejectConfirm = () => true,
+    configGet = async () => ({}),
+    synthesizeSpeech = async () => ({ buffer: new Uint8Array(0), mime: "audio/mpeg" }),
+    publish = () => {},
+    onNarrate = () => {},
+    onState = () => {},
+    now = () => Date.now(),
+  } = deps;
+
+  const state = {
+    status: "idle", // idle | connecting | live | parked | dropped
+    openai: null, // ws-like to OpenAI
+    tools: [], // [{name,description,params}]
+    session: null,
+    pendingConfirm: null, // {id, tool, preview, at}
+    ongoingSpend: 0, // per-call USD spent
+    idleTimer: null,
+    startedAt: null,
+    caps: { spendCapUsd: DEFAULT_SPEND_CAP_USD, idleParkMs: DEFAULT_IDLE_PARK_MS },
+  };
+
+  function setStatus(s) {
+    state.status = s;
+    onState(s);
+    publish({ type: "state", state: s });
+  }
+
+  function clearIdleTimer() {
+    if (state.idleTimer) {
+      clearTimeout(state.idleTimer);
+      state.idleTimer = null;
+    }
+  }
+
+  function armIdleTimer() {
+    clearIdleTimer();
+    if (!state.caps.idleParkMs) return;
+    state.idleTimer = setTimeout(() => {
+      // Auto-idle → park: tear down the Realtime session (no silent spend).
+      if (state.status === "live") {
+        publish({ type: "notify", message: "Calls idle — closed the session." });
+        park();
+      }
+    }, state.caps.idleParkMs);
+    if (state.idleTimer?.unref) state.idleTimer.unref();
+  }
+
+  function spend(usd) {
+    state.ongoingSpend += usd;
+    publish({ type: "cost", usd: state.ongoingSpend });
+    if (state.ongoingSpend >= state.caps.spendCapUsd) {
+      publish({ type: "notify", message: "Call spend cap reached — disconnected." });
+      hangup();
+    }
+  }
+
+  // Emit a message down the /call WS to the renderer.
+  function emit(msg) {
+    publish(msg);
+  }
+
+  // -------------------------------------------------------------------------
+  // Starting a call
+  // -------------------------------------------------------------------------
+
+  async function start(cfg = {}) {
+    if (state.status === "connecting" || state.status === "live") return;
+    const conf = cfg?.cto ?? {};
+    const apiKey = cfg?.groqApiKey || cfg?.openaiApiKey;
+    state.caps = {
+      spendCapUsd: typeof cfg?.cto?.spendCapUsd === "number" ? cfg.cto.spendCapUsd : DEFAULT_SPEND_CAP_USD,
+      idleParkMs: typeof cfg?.cto?.idleParkMs === "number" ? cfg.cto.idleParkMs : DEFAULT_IDLE_PARK_MS,
+    };
+    if (!apiKey) {
+      setStatus("dropped");
+      emit({ type: "error", error: "openai_key_missing" });
+      return;
+    }
+    const model = clampModel(conf.model, DEFAULT_REALTIME_MODEL);
+    const voice = typeof conf.voice === "string" && conf.voice ? conf.voice : DEFAULT_VOICE;
+    let ws;
+    try {
+      setStatus("connecting");
+      ws = await realtimeConnect(`${REALTIME_BASE}?model=${encodeURIComponent(model)}`, {
+        authorization: `Bearer ${apiKey}`,
+        "openai-beta": "realtime=v1",
+      });
+    } catch (e) {
+      setStatus("dropped");
+      emit({ type: "dropped", reason: String(e?.message ?? e) });
+      return;
+    }
+    state.openai = ws;
+    state.startedAt = now();
+    state.ongoingSpend = 0;
+    ws.on("message", (raw) => {
+      let evt;
+      try {
+        evt = JSON.parse(typeof raw === "string" ? raw : raw.toString("utf8"));
+      } catch {
+        return;
+      }
+      receiveRealtime(evt);
+    });
+    ws.on("close", () => {
+      if (state.status === "live" || state.status === "connecting") {
+        setStatus("dropped");
+        emit({ type: "dropped", reason: "realtime_closed" });
+      }
+    });
+    ws.on("error", () => {
+      /* close handler does teardown */
+    });
+    // Send the session config.
+    send({ type: "session.update", session: {
+      instructions: SESSION_INSTRUCTIONS,
+      voice,
+      modalities: ["audio", "text"],
+      tools: state.tools.map((t) => ({ type: "function", name: t.name, description: t.description, parameters: t.params })),
+      turn_detection: { type: "server_vad", create_response: true },
+    }});
+    armIdleTimer();
+    return ws;
+  }
+
+  function send(msg) {
+    if (state.openai && typeof state.openai.send === "function") {
+      state.openai.send(typeof msg === "string" ? msg : JSON.stringify(msg));
+    }
+  }
+
+  // -------------------------------------------------------------------------
+  // Renderer → engine (audio + controls)
+  // -------------------------------------------------------------------------
+
+  function handleUserAudio(b64) {
+    armIdleTimer();
+    send({ type: "input_audio_buffer.append", audio: b64 });
+  }
+
+  function commitAndRespond() {
+    armIdleTimer();
+    send({ type: "input_audio_buffer.commit" });
+    send({ type: "response.create" });
+  }
+
+  function barge() {
+    // Stop playback + cancel the in-flight model response so the new user
+    // input wins. Realtime handles turn-taking natively.
+    emit({ type: "barge" });
+    send({ type: "response.cancel" });
+    clearIdleTimer();
+  }
+
+  function injectTurn(text) {
+    // Live inbound routing (issue 2): make the CTO speak an inbound event.
+    const item = { type: "message", role: "user", content: [{ type: "input_text", text }] };
+    send({ type: "conversation.item.create", item });
+    send({ type: "response.create" });
+    armIdleTimer();
+  }
+
+  function hangup() {
+    clearIdleTimer();
+    if (state.openai) {
+      try { state.openai.close(); } catch { /* ignore */ }
+    }
+    state.openai = null;
+    state.pendingConfirm = null;
+    setStatus("idle");
+  }
+
+  function park() {
+    clearIdleTimer();
+    if (state.openai) {
+      try { state.openai.close(); } catch { /* ignore */ }
+    }
+    state.openai = null;
+    state.pendingConfirm = null;
+    setStatus("parked");
+  }
+
+  function listState() {
+    return {
+      status: state.status,
+      tools: state.tools.map((t) => t.name),
+      pendingConfirm: state.pendingConfirm
+        ? { id: state.pendingConfirm.id, tool: state.pendingConfirm.tool, preview: state.pendingConfirm.preview }
+        : null,
+      spend: state.ongoingSpend,
+      caps: { ...state.caps },
+    };
+  }
+
+  // -------------------------------------------------------------------------
+  // OpenAI Realtime event dispatch
+  // -------------------------------------------------------------------------
+
+  async function receiveRealtime(evt) {
+    if (!evt || typeof evt !== "object") return;
+    switch (evt.type) {
+      case "session.created":
+        return handleSessionCreated(evt);
+      case "response.audio.delta":
+        return handleAudioDelta(evt);
+      case "response.audio_transcript.delta": {
+        const d = evt.delta ?? "";
+        if (d) emit({ type: "transcript", delta: d, role: "cto" });
+        return;
+      }
+      case "response.audio_transcript.done": {
+        const t = evt.transcript ?? "";
+        if (t) emit({ type: "transcript-finished", text: t, role: "cto" });
+        return;
+      }
+      case "response.output_audio.done":
+      case "response.done":
+        return armIdleTimer();
+      case "input_audio_buffer.speech_started":
+        return barge();
+      case "input_audio_buffer.speech_stopped":
+        return armIdleTimer();
+      case "conversation.item.created": {
+        // User speech item → push STT text when available.
+        if (evt?.item?.type === "message" && evt.item.role === "user") {
+          for (const c of evt.item.content ?? []) {
+            if (c?.type === "input_text" && c.text) {
+              emit({ type: "transcript", delta: c.text, role: "user" });
+            }
+          }
+        }
+        return;
+      }
+      case "conversation.item.input_audio_transcription.completed": {
+        const t = evt?.transcript ?? "";
+        if (t) emit({ type: "stt", text: t });
+        return;
+      }
+      case "response.function_call_arguments.done":
+        return handleFunctionCall(evt);
+      case "response.function_call_arguments.delta":
+        return; // accumulate in openai's built-in buffer; done carries full args
+      case "error":
+        return handleError(evt);
+      default:
+        return;
+    }
+  }
+
+  function handleSessionCreated(evt) {
+    state.session = evt?.session ?? null;
+    setStatus("live");
+    emit({ type: "ready", sessionId: state.session?.id ?? null });
+  }
+
+  function handleAudioDelta(evt) {
+    // Forward raw delta audio to the renderer to play (base64 opus).
+    if (evt?.delta) emit({ type: "audio", delta: evt.delta });
+    armIdleTimer();
+  }
+
+  async function handleFunctionCall(evt) {
+    const name = evt?.name;
+    const rawArgs = evt?.arguments ?? "{}";
+    let args = {};
+    try {
+      args = JSON.parse(rawArgs || "{}");
+    } catch {
+      args = {};
+    }
+    emit({ type: "working", tool: name });
+
+    // Voice-confirm resolution: if there is a pending confirm for the SAME
+    // (tool,args), the model re-issuing it IS the user's spoken "go ahead"…
+    const pc = state.pendingConfirm;
+    if (pc && pc.tool === name && sameArgs(pc.args, args)) {
+      approveConfirm(pc.id);
+      state.pendingConfirm = null;
+      emit({ type: "confirm-resolved", id: pc.id, ok: true });
+    }
+
+    const conf = (await configGet().catch(() => ({}))) ?? {};
+    const result = await dispatchCto(name, args, {
+      gate: () => "confirm",
+      trustedActions: Array.isArray(conf?.cto?.trustedActions) ? conf.cto.trustedActions : [],
+      onNarrate,
+    });
+
+    if (result?.needConfirmation && !pc) {
+      // Gated tool, user hasn't spoken yet → pause for go-ahead.
+      const id = result.id;
+      emit({ type: "confirm", id, tool: name, preview: result.preview });
+      state.pendingConfirm = { id, tool: name, args, preview: result.preview, at: now() };
+      armConfirmTimeout(id);
+      // Tell the model to ask, then complete the function call so it can speak.
+      send({
+        type: "conversation.item.create",
+        item: {
+          type: "function_call_output",
+          call_id: evt?.call_id,
+          output: JSON.stringify({ ok: true, awaiting_confirmation: true, preview: result.preview }),
+        },
+      });
+      send({ type: "response.create" });
+      return;
+    }
+
+    // Normal (or just-approved) path: complete the function call with the result.
+    const output = result?.ok === false || !result ? JSON.stringify({ ok: false, error: result?.error ?? "failed" })
+      : result?.needConfirmation
+        ? JSON.stringify({ ok: true, error: "cancelled" })
+        : JSON.stringify({ ok: true, ...result });
+    send({
+      type: "conversation.item.create",
+      item: { type: "function_call_output", call_id: evt?.call_id, output },
+    });
+    send({ type: "response.create" });
+    armIdleTimer();
+  }
+
+  function handleError(evt) {
+    const message = evt?.error?.message ?? "";
+    emit({ type: "error", error: message || "realtime_error" });
+  }
+
+  // A pending confirm with no re-issue times out → abort + re-plan.
+  function armConfirmTimeout(id) {
+    const ms = state.caps.confirmTimeoutMs ?? 30_000;
+    const t = setTimeout(() => {
+      const pc = state.pendingConfirm;
+      if (pc && pc.id === id) {
+        rejectConfirm(id);
+        state.pendingConfirm = null;
+        emit({ type: "confirm-resolved", id, ok: false });
+        // Ask the model to re-plan since no go-ahead came.
+        send({
+          type: "conversation.item.create",
+          item: { type: "message", role: "user", content: [{ type: "input_text", text: "No answer. Abort and replan, do not act." }] },
+        });
+        send({ type: "response.create" });
+      }
+    }, ms);
+    if (t?.unref) t.unref();
+  }
+
+  function sameArgs(a, b) {
+    try {
+      return JSON.stringify(a ?? {}) === JSON.stringify(b ?? {});
+    } catch {
+      return false;
+    }
+  }
+
+  // Exposed for tests + index wiring to snapshot the working tool/confirm
+  // timers. (Confirm timeout is armed in the confirm branch; see below.)
+  return {
+    start,
+    handleUserAudio,
+    commitAndRespond,
+    barge,
+    injectTurn,
+    hangup,
+    park,
+    receiveRealtime,
+    listState,
+    // Set the tool registry before starting a call (from ctoEngine.listTools).
+    setTools: (tools) => {
+      state.tools = Array.isArray(tools) ? tools : [];
+    },
+  };
+}
+
+async function defaultRealtimeConnect(url, headers) {
+  return new NodeWebSocket(url, { headers });
+}

--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -170,11 +170,15 @@ export function createVcCallEngine(deps = {}) {
     ws.on("error", () => {
       /* close handler does teardown */
     });
-    // Send the session config.
+    // Send the session config. pcm16 in/out: the call renderer encodes mic
+    // frames as raw 16-bit PCM (decodable with a plain AudioBuffer, no opus
+    // wasm dependency) and decodes the model's pcm16 deltas the same way.
     send({ type: "session.update", session: {
       instructions: SESSION_INSTRUCTIONS,
       voice,
       modalities: ["audio", "text"],
+      input_audio_format: "pcm16",
+      output_audio_format: "pcm16",
       tools: state.tools.map((t) => ({ type: "function", name: t.name, description: t.description, parameters: t.params })),
       turn_detection: { type: "server_vad", create_response: true },
     }});

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -1,0 +1,210 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { EventEmitter } from "node:events";
+import { createVcCallEngine } from "./vccall.mjs";
+
+// A fake OpenAI Realtime WebSocket: an EventEmitter whose .send captures
+// client→OpenAI messages and .close flips a flag. Tests drive the connection
+// (server→client events) via receiveRealtime, the same path the real socket's
+// on("message") dispatches through.
+function makeFakeWs() {
+  const ws = new EventEmitter();
+  ws.sent = [];
+  ws.closed = false;
+  ws.send = (msg) => ws.sent.push(typeof msg === "string" ? msg : JSON.stringify(msg));
+  ws.close = () => {
+    ws.closed = true;
+  };
+  return ws;
+}
+
+function makeEngine(overrides = {}) {
+  const ws = makeFakeWs();
+  const published = [];
+  const calls = [];
+  const stateLog = [];
+  const config = {
+    openaiApiKey: "sk-test",
+    cto: {
+      model: "gpt-4o-realtime-preview",
+      voice: "alloy",
+      trustedActions: ["trusted_list_sessions"],
+    },
+  };
+  const engine = createVcCallEngine({
+    realtimeConnect: async () => ws,
+    configGet: async () => config,
+    dispatchCto: async (name, args, ctx) => {
+      calls.push({ name, args, ctx });
+      if (name === "confirmable_action") return { ok: true, needConfirmation: true, id: "cid-1", preview: "send the report" };
+      if (name === "trusted_list_sessions") return { ok: true, sessions: [] };
+      return { ok: true };
+    },
+    approveConfirm: (id) => {
+      ws.approved = [...(ws.approved ?? []), id];
+      return true;
+    },
+    rejectConfirm: (id) => {
+      ws.rejected = [...(ws.rejected ?? []), id];
+      return true;
+    },
+    publish: (m) => published.push(m),
+    onState: (s) => stateLog.push(s),
+    ...overrides,
+  });
+  engine.setTools([
+    { name: "trusted_list_sessions", description: "list sessions", params: {} },
+    { name: "confirmable_action", description: "an action", params: {} },
+  ]);
+  return { engine, ws, published, calls, stateLog, config };
+}
+
+function json(ws) {
+  return ws.sent.map((s) => JSON.parse(s));
+}
+
+test("start connects and sends a session.update with the tools configured", async () => {
+  const { engine, ws, stateLog } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: { model: "m1", voice: "nova" } });
+  const sent = json(ws);
+  assert.ok(sent.some((m) => m.type === "session.update"), "session.update sent");
+  const su = sent.find((m) => m.type === "session.update");
+  assert.equal(su.session.voice, "nova");
+  assert.equal(su.session.modalities.join(","), "audio,text");
+  assert.equal(su.session.tools.length, 2);
+  assert.equal(su.session.turn_detection.type, "server_vad");
+  assert.equal(stateLog[0], "connecting");
+
+  // Server → client: session.created flips the call live.
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  assert.equal(stateLog.includes("live"), true);
+});
+
+test("function-call round-trip: dispatches to cto, emits working + cost, completes the call", async () => {
+  const { engine, ws, published, calls } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+
+  await engine.receiveRealtime({
+    type: "response.function_call_arguments.done",
+    call_id: "call-1",
+    name: "trusted_list_sessions",
+    arguments: "{}",
+  });
+
+  assert.equal(calls.length, 1);
+  assert.equal(calls[0].name, "trusted_list_sessions");
+  // The trusted action runs without a confirm pause.
+  assert.equal(published.some((m) => m.type === "working" && m.tool === "trusted_list_sessions"), true);
+  const sent = json(ws);
+  const output = sent.find((m) => m.type === "conversation.item.create" && m.item.type === "function_call_output");
+  assert.ok(output, "function_call_output sent");
+  assert.ok(output.item.output.includes('"ok":true'));
+  assert.ok(sent.some((m) => m.type === "response.create"));
+});
+
+test("voice confirm: gated tool pauses, re-issue (spoken go-ahead) approves and runs", async () => {
+  const { engine, ws, published, calls } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: { trustedActions: [] } });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+
+  // First call to a gated, untrusted action → pause for go-ahead.
+  await engine.receiveRealtime({
+    type: "response.function_call_arguments.done",
+    call_id: "call-1",
+    name: "confirmable_action",
+    arguments: "{\"x\":1}",
+  });
+  assert.equal(published.some((m) => m.type === "confirm" && m.id === "cid-1"), true);
+  assert.equal(await engine.listState().pendingConfirm?.tool, "confirmable_action");
+  const sent = json(ws);
+  const out = sent.find((m) => m.type === "conversation.item.create" && m.item.type === "function_call_output");
+  assert.ok(out.item.output.includes("awaiting_confirmation"), "pauses for go-ahead");
+
+  // The model re-issues the SAME tool+args (user said "go ahead") → approves + runs.
+  calls.length = 0;
+  const before = calls.length;
+  await engine.receiveRealtime({
+    type: "response.function_call_arguments.done",
+    call_id: "call-2",
+    name: "confirmable_action",
+    arguments: "{\"x\":1}",
+  });
+  assert.ok(ws.approved?.includes("cid-1"), "approveConfirm called on the spoken go-ahead");
+  // dispatchCto ran a second time (the approved re-dispatch).
+  assert.equal(calls.length, 1);
+  assert.equal(published.some((m) => m.type === "confirm-resolved" && m.ok === true), true);
+  assert.equal(await engine.listState().pendingConfirm, null);
+  assert.equal(before, 0);
+});
+
+test("barge: speech_started cancels the in-flight response and notifies the renderer", async () => {
+  const { engine, ws, published } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  engine.receiveRealtime({ type: "input_audio_buffer.speech_started" });
+  const sent = json(ws);
+  assert.ok(sent.some((m) => m.type === "response.cancel"), "response.cancel sent on barge");
+  assert.ok(published.some((m) => m.type === "barge"));
+});
+
+test("narration seam: onNarrate is threaded into the dispatch ctx", async () => {
+  let narrated = null;
+  const { engine, calls } = makeEngine({
+    onNarrate: (t) => {
+      narrated = t;
+    },
+  });
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  await engine.receiveRealtime({
+    type: "response.function_call_arguments.done",
+    call_id: "c",
+    name: "trusted_list_sessions",
+    arguments: "{}",
+  });
+  assert.equal(typeof calls[0].ctx.onNarrate, "function");
+  // Call it and confirm the injected seam fires.
+  calls[0].ctx.onNarrate("hello narration");
+  assert.equal(narrated, "hello narration");
+});
+
+test("injectTurn: live inbound events are injected into the Realtime session", async () => {
+  const { engine, ws } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  engine.injectTurn("deploy finished");
+  const sent = json(ws);
+  const item = sent.find((m) => m.type === "conversation.item.create" && m.item.type === "message");
+  assert.ok(item, "injected conversation item");
+  assert.equal(item.item.content[0].text, "deploy finished");
+  assert.ok(sent.some((m) => m.type === "response.create"));
+});
+
+test("user audio + commit stream to the Realtime session", async () => {
+  const { engine, ws } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  engine.handleUserAudio("AAAA");
+  engine.commitAndRespond();
+  const sent = json(ws);
+  assert.ok(sent.some((m) => m.type === "input_audio_buffer.append" && m.audio === "AAAA"));
+  assert.ok(sent.some((m) => m.type === "input_audio_buffer.commit"));
+  assert.ok(sent.some((m) => m.type === "response.create"));
+});
+
+test("hangup tears down the Realtime session and returns to idle", async () => {
+  const { engine, ws, stateLog } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  engine.hangup();
+  assert.equal(ws.closed, true);
+  assert.equal(stateLog[stateLog.length - 1], "idle");
+});
+
+test("park closes the session without silent spend and sets parked", async () => {
+  const { engine, ws, stateLog } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  engine.park();
+  assert.equal(ws.closed, true);
+  assert.equal(stateLog[stateLog.length - 1], "parked");
+});

--- a/src/shared/groq.mjs
+++ b/src/shared/groq.mjs
@@ -101,3 +101,53 @@ export async function transcribeAudio({ buffer, mime, apiKey, model }) {
   const json = /** @type {{ text?: string }} */ (await res.json());
   return { text: typeof json.text === "string" ? json.text : "" };
 }
+
+// ---------------------------------------------------------------------------
+// Orpheus TTS (narration)
+// ---------------------------------------------------------------------------
+// The on-call CTO (BET-1166) narrates tool boundaries with a fast, light
+// voice distinct from the Realtime model. Groq serves canopylabs/orpheus over
+// its OpenAI-compatible /audio/speech endpoint. Runs in main / the server only
+// — the API key never leaves the trusted process. Returns raw audio bytes +
+// mime so the renderer can play them through WebAudio/HTMLMediaElement.
+
+const GROQ_ORPHEUS_MODEL = "canopylabs/orpheus-v1-english";
+const GROQ_ORPHEUS_VOICE = "tara";
+
+/**
+ * Synthesize short narration audio via Groq Orpheus.
+ *
+ * @param {object} args
+ * @param {string}           args.text    — the text to speak
+ * @param {string}           args.apiKey  — required; throws if empty
+ * @param {string}           [args.model] — defaults to canopylabs/orpheus-v1-english
+ * @param {string}           [args.voice] — defaults to "tara"
+ * @param {"mp3"|"wav"|"opus"} [args.format] — audio response format, default "mp3"
+ * @returns {Promise<{ buffer: Uint8Array, mime: string }>}
+ */
+export async function synthesizeSpeech({ text, apiKey, model, voice, format = "mp3" }) {
+  if (!apiKey || typeof apiKey !== "string") {
+    throw new Error("Groq API key not configured. Add it in Settings.");
+  }
+  if (!text || !text.trim()) throw new Error("Nothing to say.");
+  const mime = format === "wav" ? "audio/wav" : format === "opus" ? "audio/opus" : "audio/mpeg";
+  const res = await fetch(`${GROQ_BASE}/audio/speech`, {
+    method: "POST",
+    headers: {
+      authorization: `Bearer ${apiKey}`,
+      "content-type": "application/json",
+    },
+    body: JSON.stringify({
+      model: model || GROQ_ORPHEUS_MODEL,
+      voice: voice || GROQ_ORPHEUS_VOICE,
+      input: text.trim(),
+      response_format: format,
+    }),
+  });
+  if (!res.ok) {
+    const body = await res.text().catch(() => "");
+    throw new Error(`Groq speech ${res.status}: ${body.slice(0, 200)}`);
+  }
+  const buf = Buffer.from(await res.arrayBuffer());
+  return { buffer: new Uint8Array(buf), mime };
+}

--- a/src/shared/settingsSchema.test.ts
+++ b/src/shared/settingsSchema.test.ts
@@ -82,7 +82,7 @@ describe("settingsForSection", () => {
   it("returns only entries in the given section for the platform", () => {
     const voiceDesktop = settingsForSection(ALL, "voice", "desktop");
     expect(voiceDesktop.map((e) => e.id).sort()).toEqual(
-      ["groqApiKey", "voiceTranscriptionModel"],
+      ["groqApiKey", "openaiApiKey", "voiceTranscriptionModel"],
     );
   });
 });

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -301,6 +301,18 @@ export const SETTINGS: SettingEntry[] = [
     default: "",
     placeholder: "whisper-large-v3-turbo",
   },
+  {
+    id: "openaiApiKey",
+    section: "voice",
+    label: "OpenAI API key",
+    help: "Enables the on-call CTO voice call window (OpenAI Realtime). Stored on the box; the renderer never sees it.",
+    control: "password",
+    configKey: "openaiApiKey",
+    platform: "both",
+    default: "",
+    commitOnBlur: true,
+    placeholder: "sk-… (leave blank to disable the call window)",
+  },
 
   // ----- on-call CTO (BET-1166) -----
   // Nested under `cto.*` in AppConfig. The surface renders these through the

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -43,7 +43,8 @@ export type SettingSectionId =
   | "sessions"
   | "files"
   | "extensions"
-  | "voice";
+  | "voice"
+  | "cto";
 
 export type SettingSection = {
   id: SettingSectionId;
@@ -85,6 +86,7 @@ export const SETTING_SECTIONS: SettingSection[] = [
   { id: "files", label: "Files", group: "AGENT" },
   { id: "extensions", label: "Extensions", group: "AGENT" },
   { id: "voice", label: "Voice", group: "AGENT" },
+  { id: "cto", label: "On-call CTO", group: "AGENT" },
 ];
 
 // The schema. `custom` entries are placeholders so search/section listing
@@ -298,6 +300,66 @@ export const SETTINGS: SettingEntry[] = [
     platform: "both",
     default: "",
     placeholder: "whisper-large-v3-turbo",
+  },
+
+  // ----- on-call CTO (BET-1166) -----
+  // Nested under `cto.*` in AppConfig. The surface renders these through the
+  // generic schema-driven fields (configUpdate handles the cto.* prefix).
+  {
+    id: "ctoEnabled",
+    section: "cto",
+    label: "On-call CTO enabled",
+    help: "Registers the cto agent and enables the call window. Off by default until the feature ships.",
+    control: "toggle",
+    configKey: "cto.enabled",
+    platform: "both",
+    default: false,
+  },
+  {
+    id: "ctoModel",
+    section: "cto",
+    label: "CTO model",
+    help: "The model the on-call CTO answers through.",
+    control: "text",
+    configKey: "cto.model",
+    platform: "both",
+    default: "",
+    placeholder: "gpt-4o-realtime-preview",
+  },
+  {
+    id: "ctoVoice",
+    section: "cto",
+    label: "CTO voice",
+    help: "Voice/narration model id for the call window.",
+    control: "text",
+    configKey: "cto.voice",
+    platform: "both",
+    default: "",
+    placeholder: "alloy",
+  },
+  {
+    id: "ctoAlwaysListening",
+    section: "cto",
+    label: "Always listening",
+    help: "When off, the call window is push-to-barge: the mic opens only while you hold/click to talk.",
+    control: "toggle",
+    configKey: "cto.alwaysListening",
+    platform: "both",
+    default: false,
+  },
+  {
+    id: "ctoParkedBehavior",
+    section: "cto",
+    label: "When parked",
+    help: "What the box does with an inbound CTO event while no call is open.",
+    control: "segmented",
+    configKey: "cto.parkedBehavior",
+    platform: "both",
+    default: "auto-open",
+    options: [
+      { value: "auto-open", label: "Auto-open" },
+      { value: "push", label: "Notify only" },
+    ],
   },
 ];
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -210,6 +210,11 @@ export type AppConfig = {
   // manta credentials (ssh identity path, opencode auth). Settings UI shows
   // a masked password input. Absent → mic button is hidden in the UI.
   groqApiKey?: string;
+  // ----- On-call CTO (BET-1166) -----
+  // OpenAI API key for the Realtime voice transport. Stored on the box (like
+  // groqApiKey) and never reaches the renderer — the call window relays audio
+  // through the box's /call WS. Absent → the call window can't start a call.
+  openaiApiKey?: string;
   // ----- Analytics (BET-217) -----
   // When true (the default), this instance ships console.* output + a handful
   // of structured events to Axiom for remote debugging. When false, the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -285,6 +285,9 @@ export type AppConfig = {
     // Whether the call window listens continuously (Issue 3). Default false.
     alwaysListening?: boolean;
   };
+  // Position/size of the floating on-call CTO window (BET-1166). Persisted so
+  // the window remembers where the user parked it across runs.
+  callWindowBounds?: { x?: number; y?: number; width: number; height: number };
 };
 
 // ----- Live tmux state -----
@@ -1285,6 +1288,17 @@ export const IPC = {
   // DesktopNotifyPayload. The renderer suppresses it if it's already viewing
   // that session, else shows it via the Notification API + deep-links on click.
   desktopNotify: "desktop:notify",
+
+  // ---- on-call CTO voice window (BET-1166) ----
+  // Renderer → main controls for the floating call window. `show` reveals it
+  // (creating it on first use), `park` hides it while keeping the window
+  // alive, `hangup` destroys it. `callGetConfig` returns the {serverUrl,
+  // boxToken} the call renderer needs to open its /call WS (no second
+  // transport, no API key — audio + events ride the /call WS).
+  callWindowShow: "call:window-show",
+  callWindowPark: "call:window-park",
+  callWindowHangup: "call:window-hangup",
+  callGetConfig: "call:get-config",
 
   // ---- opencode chat-mode ----
   // Fetch a session's transcript (one-shot HTTP call on the remote).


### PR DESCRIPTION
Builds on the BET-1164 (gateway) + BET-1165 (inbound feed) branch (stacks on PRs #1168/#1169).

Implements the flagship on-call CTO call surface:

- Server: `vccall.mjs` OpenAI Realtime client (server-side key, pcm16 audio), barge, function-call loop → `cto.dispatch`, voice confirmation, narration seam; `/call` WS relay mirroring /pty; live inbound routing (flips the `isCallActive` flag issue 2 reads + `injectTurn`); cost guard + auto-idle park.
- Desktop: frameless always-on-top non-resizable call window with drag region + position persistence (park/hang); `call.html` renderer entry (CallApp) with the three states + parked/listening dot, mic (pcm16 via AudioWorklet), barge, hang-up — all over the /call WS, no second transport.
- Config/settings: nested `cto.*` keys + `openaiApiKey`, settings schema section, store/plumbing for nested keys.
- Tests: `vccall.test.mjs` + `callWs.test.mjs` against a mocked Realtime WS.

Verification: `npm run typecheck` ✅, `npm test` ✅ (3149 vitest + 2482 node), Electron e2e smoke ✅ (app launches, no console errors; sidebar/terminal N/A in fresh unpaired onboarding state).

Known follow-ups: first-call onboarding flow + trustedActions allowlist editor UI (config + server support present); hardware audio (mic/speaker, <1.5s first word, barge mid-narration) needs laptop verification.