### PR TITLE
feat(server): on-call CTO inbound feed — send_to_cto, watch, routing, gate (BET-1165)

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -470,3 +470,27 @@ normal chat session) is pre-wired to use this belt. Install/update is a COPY,
 never a symlink: `cp <repo>/docs/opencode-tools/cto.ts
 ~/.config/opencode/tools/cto.ts` then `systemctl --user restart
 opencode-serve`. The engine lives in `src/server/cto.mjs` (see there).
+
+## manta on-call CTO inbound — `send_to_cto` + watchers (BET-1165)
+
+Two companion capabilities to the `cto` read belt, both global opencode tools.
+
+- **`send_to_cto(message, opts?)`** (global tool, `docs/opencode-tools/send-to-cto.ts`):
+  report a note up to the CTO from ANY session. With no live call it is surfaced
+  to the user as a notification; once the call-window feature ships it is injected
+  into the CTO conversation as a turn. Use it to flag something the CTO should know
+  (a new P0, a blocker, a call-back request). Thin registrar → `POST /api/cto/inbound`.
+- **`watch(surface, condition)`** + `unwatch` / `list_watches` (via the `cto` tool,
+  `docs/opencode-tools/cto.ts`): register a recurring probe against a surface
+  (`multica`, `schedule`, `delegate`, ...). The box runs the watch's condition
+  against that surface's existing read and surfaces a notification when it matches
+  AND something new appeared. `watch` is a **confirm-mode** action: it needs the
+  user's go-ahead before it takes effect. When the `cto` tool returns
+  `needConfirmation: { id, preview }`, surface "I need your go-ahead: <preview>"
+  and re-dispatch the SAME tool+args with `approve: <id>` on "go ahead" (or abort
+  on "no").
+
+Install/update each tool as a COPY (`cp docs/opencode-tools/{send-to-cto,cto}.ts
+~/.config/opencode/tools/`) then `systemctl --user restart opencode-serve`. The
+engine + routers live in `src/server/cto.mjs` (createCtoEngine / createCtoInbound /
+createWatcherPoller).

--- a/docs/opencode-tools/cto.ts
+++ b/docs/opencode-tools/cto.ts
@@ -27,7 +27,8 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 const CTO_TOOLS =
   "list_sessions, list_projects, read_transcript, search_messages, git_status, " +
   "git_branch, git_log, list_models, get_usage, usage_stopped, session_usage, " +
-  "context_state, session_plan_mode, get_config, query_multica";
+  "context_state, session_plan_mode, get_config, query_multica, watch, unwatch, " +
+  "list_watches";
 
 function boxToken() {
   const fromEnv = process.env.MANTA_BOX_TOKEN;
@@ -51,22 +52,34 @@ function authHeaders(body) {
 
 export const cto = tool({
   description: [
-    "Deterministic, read-only on-call CTO tools: inspect what's running on this box,",
+    "Deterministic on-call CTO tools: inspect what's running on this box,",
     "read chat transcripts, search messages, git state, models, plan usage,",
     "stopped conversations, per-session cost/context/plan-mode, config, and the",
-    "Multica task board. Nothing here mutates anything — all reads.",
+    "Multica task board. Reads never mutate anything. The watch/unwatch/list_watches",
+    "tools register watchers (watch is a confirm-mode action).",
     `Pick \`tool\` from: ${CTO_TOOLS}.`,
     "Pass that tool's arguments as a free-form object in \`args\`",
     "(e.g. {tool:\"read_transcript\", args:{sessionID:\"ses_...\"}}).",
+    "If the call returns needConfirmation for a confirm-mode tool, surface",
+    "\"I need your go-ahead: <preview>\" to the user; when they reply \"go ahead\",",
+    "re-invoke the SAME tool+args with \`approve: <id>\` (the id from the",
+    "needConfirmation result). Reply \"no\" to abort (reject).",
   ].join(" "),
   args: {
     tool: tool.schema
       .string()
-      .describe(`The cto read tool to run. One of: ${CTO_TOOLS}.`),
+      .describe(`The cto tool to run. One of: ${CTO_TOOLS}.`),
     args: tool.schema
       .object({})
       .passthrough()
       .describe("Free-form arguments for the chosen tool (depends on the tool)."),
+    approve: tool.schema
+      .string()
+      .optional()
+      .describe(
+        "When re-dispatching a confirm-mode tool after the user said \"go ahead\", pass " +
+          "the id from the earlier needConfirmation result to authorize it.",
+      ),
   },
   async execute(args, context) {
     const res = await fetch(`${MANTA_SERVER}/api/cto`, {
@@ -75,6 +88,7 @@ export const cto = tool({
       body: JSON.stringify({
         tool: args.tool,
         args: args.args ?? {},
+        approve: args.approve,
         sessionID: context?.sessionID,
         directory: context?.directory,
       }),

--- a/docs/opencode-tools/send-to-cto.ts
+++ b/docs/opencode-tools/send-to-cto.ts
@@ -1,0 +1,117 @@
+// manta-native `send_to_cto` tool — global opencode custom tool (BET-1165).
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/send-to-cto.ts ~/.config/opencode/tools/send-to-cto.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+// A copy, never a symlink — opencode resolves a tool's imports relative to the
+// file's REAL path, so a symlink back into the repo (no node_modules) fails
+// with `Cannot find module '@opencode-ai/plugin'` and the tool silently never
+// registers.
+//
+// PURPOSE: let ANY session report something to the on-call CTO. This is a THIN
+// registrar: `execute` POSTs `{surface:"session", sessionID, message, ...opts}`
+// to manta-server's /api/cto/inbound (same box, no SSH hop) and returns
+// immediately. manta-server owns the routing (dedupe + live-vs-parked), NOT
+// this tool. See src/server/cto.mjs (createCtoInbound).
+//
+// When no "call is live" flag is set (this issue), the message routes to the
+// PARKED path and the user gets a push/notify. Once Issue 3 flips the live
+// flag, the message is injected into the CTO session as a turn instead.
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
+// tiny local file) so a token rotation never requires an opencode-serve
+// restart. MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+export const send_to_cto = tool({
+  description: [
+    "Send a message to the on-call CTO. Any session can call this: it reports a",
+    "note up to the CTO, who has a read-only tool belt over what's running, the",
+    "Multica board, usage, and more. The message is surfaced to the user: when",
+    "the CTO call is not live it arrives as a push/notify; once the call-window",
+    "feature ships it is injected into the CTO conversation as a turn. Use this",
+    "to flag something the CTO should know (a new P0, a blocker, a request to",
+    "call you back). It returns immediately — the box owns routing.",
+  ].join(" "),
+  args: {
+    message: z
+      .string()
+      .describe("What to report to the CTO. Be concrete: the fact, not the process."),
+    title: z
+      .string()
+      .optional()
+      .describe(
+        "Optional short title for the surfaced notification. Defaults to the sender's " +
+          "session label.",
+      ),
+    urgent: z
+      .boolean()
+      .optional()
+      .describe(
+        "If true, deliver to every device immediately (blocking tier). Use sparingly — " +
+          "only for something the CTO must see right now.",
+      ),
+  },
+  async execute(args, context) {
+    const result = await call("POST", "/api/cto/inbound", {
+      surface: "session",
+      sessionID: context.sessionID,
+      message: args.message,
+      title: args.title,
+      urgent: !!args.urgent,
+    });
+    return result.parked
+      ? "Reported to the CTO (no live call — surfaced as a notification)."
+      : "Reported to the CTO.";
+  },
+});

--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -27,9 +27,12 @@
 //     engine-level failures, and the tools guard empty inputs.
 
 import { execFile } from "node:child_process";
+import { randomBytes } from "node:crypto";
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { describeModel } from "../shared/modelGuide.mjs";
+import { createSeenIdFilter } from "./seenIds.mjs";
+import { startPoller } from "./startPoller.mjs";
 
 export const CTO_STORE_PATH = statePath("cto.json");
 
@@ -115,6 +118,12 @@ export function createCtoEngine(deps = {}) {
     gitLog = remoteGitLog,
     queryMultica = async () => ({ ok: true, data: {} }),
     isPlanAgent = (name) => name === "plan" || name === "manta-plan",
+    loadWatches = async () => Array.isArray(loadCtoStore()?.watches) ? loadCtoStore().watches : [],
+    saveWatches = async (watches) => {
+      const store = loadCtoStore();
+      store.watches = Array.isArray(watches) ? watches : [];
+      await saveCtoStore(store);
+    },
     now = () => Date.now(),
   } = deps;
 
@@ -638,9 +647,84 @@ export function createCtoEngine(deps = {}) {
   });
 
   // -------------------------------------------------------------------------
+  // Watchers (Issue 2) — watch / unwatch / list_watches
+  // -------------------------------------------------------------------------
+  // A watch registers a recurring probe against a SURFACE (multica, schedule,
+  // delegate, session…). The watcher poller (createWatcherPoller below) runs
+  // each active watch's query against the surface's existing read and, when
+  // its condition matches AND its seenId is new, calls cto.inbound with that
+  // surface. `watch` is a CONFIRM-mode tool: registering a repeat probe is a
+  // side effect, so it needs the user's go-ahead (see the gate dispatch below).
+  register({
+    name: "watch",
+    description:
+      "Register a watcher that probes a surface and surfaces a notification when its " +
+      "condition matches. `surface` is one of: multica (the task board), schedule, " +
+      "delegate, or session. `query` names what to read on that surface (for multica, " +
+      "e.g. the issue key or 'read from the board'); `condition` is a natural-language " +
+      "phrase describing the trigger (e.g. 'a P0 opens'). The watcher poller runs it " +
+      "periodically via the surface's existing read. NOTE: this is a confirm-mode " +
+      "action — it registers a recurring probe, so it needs your go-ahead before it takes " +
+      "effect.",
+    params: {
+      surface: { type: "string", description: "The surface to watch: multica, schedule, delegate, or session." },
+      query: { type: "string", description: "What to query on that surface (informational)." },
+      condition: { type: "string", description: "Natural-language condition for when to trigger." },
+    },
+    mode: "confirm",
+    run: async (ctx, args) => {
+      const surface = String(args?.surface ?? "").trim();
+      if (!surface) return { ok: false, error: "surface is required (multica, schedule, delegate, session)" };
+      const watch = {
+        id: randomBytes(4).toString("hex"),
+        surface,
+        query: String(args?.query ?? "").trim(),
+        condition: String(args?.condition ?? "").trim(),
+        active: true,
+        lastFiredAt: null,
+        createdAt: now(),
+      };
+      const watches = await loadWatches();
+      await saveWatches([...watches, watch]);
+      return { ok: true, data: { watch } };
+    },
+  });
+
+  register({
+    name: "unwatch",
+    description: "Remove a watcher by its id (from list_watches). Read what is registered," +
+      " then stop the probe.",
+    params: { id: { type: "string", description: "The watcher id to remove." } },
+    run: async (ctx, args) => {
+      const id = String(args?.id ?? "");
+      const watches = await loadWatches();
+      const next = (watches ?? []).filter((w) => w?.id !== id);
+      if (next.length === (watches ?? []).length) return { ok: true, data: { removed: false } };
+      await saveWatches(next);
+      return { ok: true, data: { removed: true } };
+    },
+  });
+
+  register({
+    name: "list_watches",
+    description: "List every registered watcher: id, surface, query, condition, active," +
+      " and when it last fired. Read-only.",
+    params: {},
+    run: async () => ({ ok: true, data: { watches: await loadWatches() } }),
+  });
+
+  // -------------------------------------------------------------------------
   // Dispatch
   // -------------------------------------------------------------------------
   const byName = new Map(tools.map((t) => [t.name, t]));
+
+  // The in-conversation confirmation loop (Issue 2's gate wiring). When a
+  // confirm-mode tool is not in `trustedActions`, dispatch returns
+  // `{ needConfirmation: true, id, preview }` WITHOUT running. The cto text
+  // agent surfaces "I need your go-ahead: <preview>"; the user's "go ahead"
+  // calls approveConfirm(id) and the re-dispatch runs; "no" calls
+  // rejectConfirm(id) to abort. Issue 3 replaces this text loop with voice.
+  const pendingConfirms = new Map(); // id -> { tool, args, approved }
 
   async function dispatch(name, args, ctx = {}) {
     const def = byName.get(String(name ?? ""));
@@ -658,10 +742,27 @@ export function createCtoEngine(deps = {}) {
       return { ok: false, error: `tool ${def.name} denied` };
     }
     if (decision === "confirm") {
-      // Issue 1 ships only "auto" tools and wires no confirm/deny surface.
-      // The seam exists so Issue 3 can gate before run; until then a confirm
-      // request fails closed with a clear message rather than running.
-      return { ok: false, error: `tool ${def.name} requires confirmation (not wired yet)` };
+      // A trusted action runs without asking; anything else pauses for the
+      // user's go-ahead (returns needConfirmation and does NOT act yet).
+      const trusted = Array.isArray(ctx?.trustedActions) ? ctx.trustedActions : [];
+      if (!trusted.includes(def.name)) {
+        const id = computeConfirmId(def.name, args ?? {});
+        const prior = pendingConfirms.get(id);
+        if (prior?.approved) {
+          // The user said "go ahead" → this exact (tool, args) is authorized;
+          // consume the approval and run.
+          pendingConfirms.delete(id);
+        } else {
+          if (!prior) pendingConfirms.set(id, { tool: def.name, args: args ?? {}, approved: false });
+          return {
+            ok: true,
+            needConfirmation: true,
+            id,
+            tool: def.name,
+            preview: buildPreview(def, args ?? {}),
+          };
+        }
+      }
     }
     const narrate = typeof ctx?.onNarrate === "function" ? ctx.onNarrate : NOOP_NARRATE;
     try {
@@ -679,6 +780,18 @@ export function createCtoEngine(deps = {}) {
     tools,
     listTools: () => tools.map((t) => ({ ...t })),
     dispatch,
+    // In-conversation gate loop (Issue 2): the cto text agent surfaces a
+    // needConfirmation preview; the user's "go ahead"/"no" drives these.
+    approveConfirm: (id) => {
+      const p = pendingConfirms.get(id);
+      if (!p) return false;
+      p.approved = true;
+      pendingConfirms.set(id, p);
+      return true;
+    },
+    rejectConfirm: (id) => pendingConfirms.delete(id),
+    listPendingConfirms: () =>
+      [...pendingConfirms.entries()].map(([id, p]) => ({ id, tool: p.tool, approved: p.approved })),
   };
 }
 
@@ -741,4 +854,221 @@ async function remoteGitLog(cwd, { n = 10, oneline = true } = {}) {
   const args = ["-C", cwd, "log", `--max-count=${n}`];
   if (oneline) args.push("--oneline");
   return runGit(args, cwd);
+}
+
+// ---------------------------------------------------------------------------
+// Inbound funnel (Issue 2) — createCtoInbound
+// ---------------------------------------------------------------------------
+// The single place a CTO-bound event enters the box. Producers (the
+// send_to_cto tool, the watcher poller, a scheduled prompt, a webhook) all
+// call `inbound({ surface, payload, seenId })`. Live vs parked is decided by
+// the server-side "call active" flag (Issue 3 sets it; this issue it is
+// always false, so every event takes the parked route). Parked events are
+// de-duped by seenId and surfaced through the EXISTING notification router
+// (push.mjs fireNotify) — no second notify path.
+export function createCtoInbound({
+  seenFilter = createSeenIdFilter(),
+  isCallActive = () => false,
+  ctoSessionID = null,
+  fireNotify = async () => {},
+  sendPrompt = async () => {},
+} = {}) {
+  async function inbound({ surface = "session", payload = {}, seenId } = {}) {
+    // De-dupe: an event whose seenId was already handled is a re-delivery
+    // (the same opencode event arrives on multiple streams; a watcher may
+    // re-poll). An event with no seenId is never swallowed.
+    if (typeof seenId === "string" && seenId && seenFilter.seen(seenId)) {
+      return { ok: true, deduped: true };
+    }
+    if (isCallActive()) {
+      // LIVE route (stub — Issue 3 sets the "call active" flag and injects
+      // the event as a turn into the CTO session). Until then this never runs.
+      if (sendPrompt && ctoSessionID && typeof payload?.message === "string" && payload.message) {
+        await sendPrompt({ sessionId: ctoSessionID, text: payload.message }).catch((e) =>
+          console.warn("[cto] live inject failed:", e?.message ?? e),
+        );
+      }
+      return { ok: true, live: true };
+    }
+    // PARKED route: surface via the existing notification router.
+    const message = typeof payload?.message === "string" ? payload.message.trim() : "";
+    if (message) {
+      try {
+        await fireNotify({
+          message,
+          title: typeof payload?.title === "string" && payload.title ? payload.title : undefined,
+          urgent: !!payload?.urgent,
+          sessionID: typeof payload?.sessionID === "string" ? payload.sessionID : undefined,
+        });
+      } catch (e) {
+        console.warn("[cto] inbound notify failed:", e?.message ?? e);
+      }
+    }
+    return { ok: true, parked: true };
+  }
+  return { inbound };
+}
+
+// ---------------------------------------------------------------------------
+// Watcher poller (Issue 2) — createWatcherPoller
+// ---------------------------------------------------------------------------
+// For each ACTIVE watch it runs the surface's existing read, computes a stable
+// seenId, and when the seenId is new AND the condition matches it calls the
+// inbound funnel with that surface. In-flight-guarded + timer.unref(), mirroring
+// the schedule/delegate pollers. The read + the seenId + the condition matcher
+// are all injected so the tick is unit-testable with no live engines.
+//
+// A watch whose surface read fails is skipped (logged, never wedges the loop);
+// a watch is only re-armed once its seenId moves, so a constantly-matching
+// read doesn't re-fire every tick.
+export function createWatcherPoller({
+  loadWatches,
+  saveWatches,
+  readSurface,
+  seenFilter = createSeenIdFilter(),
+  sendToInbound,
+  conditionMatches = defaultConditionMatches,
+  computeSeenId = defaultComputeSurfaceSeenId,
+  messageFor = defaultWatchMessage,
+  now = () => Date.now(),
+} = {}) {
+  let inFlight = false;
+
+  async function tick() {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      const watches = await loadWatches();
+      let mutated = false;
+      const snapshot = Array.isArray(watches) ? watches : [];
+      for (const watch of snapshot) {
+        if (!watch || watch.active === false || watch.disabled) continue;
+        if (!watch.surface) continue;
+        let read;
+        try {
+          read = await readSurface(watch.surface, watch.query);
+        } catch (e) {
+          console.warn(`[cto] watch ${watch.id} surface "${watch.surface}" read failed:`, e?.message ?? e);
+          continue;
+        }
+        const seenId = computeSeenId(read);
+        if (seenFilter.seen(seenId)) continue; // no new content since last tick
+        if (!conditionMatches(watch.condition, read)) continue; // not a trigger
+        await sendToInbound({ surface: watch.surface, payload: { message: messageFor(watch, read) }, seenId });
+        watch.lastFiredAt = now();
+        mutated = true;
+      }
+      if (mutated) await saveWatches(snapshot);
+    } catch (e) {
+      console.warn("[cto] watcher tick failed:", e?.message ?? e);
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  return {
+    tick,
+    start: ({ intervalMs = 15_000 } = {}) => startPoller(tick, { intervalMs, label: "cto-watcher", immediate: true }),
+  };
+}
+
+// Build the notification message for a fired watch. Falls back to a clear
+// "condition matched on <surface>" line when the read carries no snippet.
+export function defaultWatchMessage(watch, read) {
+  const condition =
+    typeof watch?.condition === "string" && watch.condition ? ` (${watch.condition})` : "";
+  const snippet = firstSnippet(read?.data ?? read);
+  const base = `CTO watch on ${watch?.surface ?? "?"}${condition} matched`;
+  return snippet ? `${base}: ${snippet}` : base;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers (injectable wires, unit-tested)
+// ---------------------------------------------------------------------------
+
+// Stable short hash of a string (used for confirm ids and surface seen ids).
+export function stableHash(str) {
+  let h = 2166136261;
+  const s = String(str ?? "");
+  for (let i = 0; i < s.length; i++) {
+    h ^= s.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(36);
+}
+
+// Deterministic id for a pending confirmation of a (tool, args) pair, so the
+// user's "go ahead" re-dispatch of the SAME tool+args resolves to the pending
+// record.
+export function computeConfirmId(toolName, args) {
+  return stableHash(`${toolName}:${JSON.stringify(args ?? {})}`);
+}
+
+// A short human summary of a tool call for the "I need your go-ahead: …"
+// surface. Used in the needConfirmation preview.
+export function buildPreview(def, args) {
+  const header = [def?.name ?? "?"];
+  if (args && typeof args === "object") {
+    const entries = Object.entries(args).filter(([, v]) => v !== undefined && v !== null && v !== "");
+    if (entries.length) {
+      header.push(entries.map(([k, v]) => `${k}=${typeof v === "object" ? JSON.stringify(v) : String(v)}`).join(", "));
+    }
+  }
+  const firstLine = (String(def?.description ?? "").split("\n")[0] ?? "").slice(0, 120);
+  if (firstLine) header.push(`— ${firstLine}`);
+  return header.join(" ");
+}
+
+const CONDITION_STOPWORDS = new Set([
+  "a", "an", "the", "of", "to", "in", "on", "for", "and", "or", "with",
+  "when", "if", "is", "are", "was", "were", "new", "opens", "open", "appears",
+  "shows", "changes", "has", "have", "any", "that", "this", "there", "it",
+]);
+
+// Keywords of a natural-language condition (lowercased tokens minus stopwords) —
+// the deterministic v1 condition evaluator. Issue 3 may replace this with an
+// LLM/narration judgement; until then a keyword hit is the honest seam.
+export function conditionKeywords(condition) {
+  if (typeof condition !== "string") return [];
+  return condition
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((t) => t.length > 0 && !CONDITION_STOPWORDS.has(t));
+}
+
+// Default condition evaluator: matches when any keyword from the condition is
+// present in the serialized read, or when the condition is empty/no keywords
+// (treat any new content as a trigger). Lowercased case-insensitive match.
+export function defaultConditionMatches(condition, read) {
+  const keywords = conditionKeywords(condition);
+  if (keywords.length === 0) return true;
+  const haystack = JSON.stringify(read ?? {}).toLowerCase();
+  return keywords.some((k) => haystack.includes(k));
+}
+
+// A stable seenId for a surface read. Prefers an explicit `seenId` on the read
+// (readers may stamp one, e.g. the newest issue id), else hashes a stable
+// serialization of the whole read. Two identical reads hash identically, so
+// the poller does not re-fire until content actually changes.
+export function defaultComputeSurfaceSeenId(read) {
+  if (read && typeof read === "object" && typeof read.seenId === "string" && read.seenId) {
+    return read.seenId;
+  }
+  return stableHash(JSON.stringify(read ?? {}));
+}
+
+// First short text snippet from a read for the watch notification message.
+function firstSnippet(data) {
+  if (!data) return null;
+  if (typeof data === "string") return data.slice(0, 140);
+  const issues = Array.isArray(data?.issues) ? data.issues : null;
+  if (issues) {
+    const first = issues.find((i) => i && (i.identifier || i.title));
+    if (first) {
+      const label = [first.identifier, first.status, first.title].filter(Boolean).join(" · ");
+      return label.slice(0, 140);
+    }
+  }
+  const text = JSON.stringify(data);
+  return text && text !== "{}" && text !== "[]" ? text.slice(0, 140) : null;
 }

--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -34,7 +34,7 @@ function makeEngine(overrides = {}) {
   return engine;
 }
 
-const TOOL_COUNT = 15;
+const TOOL_COUNT = 18; // 15 reads (BET-1164) + 3 watcher tools watch/unwatch/list_watches (BET-1165)
 
 // ---------------------------------------------------------------------------
 // Registry integrity
@@ -63,6 +63,9 @@ test("registry exposes every cto read tool with a complete shape, all mode auto"
       "session_plan_mode",
       "get_config",
       "query_multica",
+      "watch",
+      "unwatch",
+      "list_watches",
     ].sort(),
   );
   for (const t of tools) {
@@ -71,7 +74,9 @@ test("registry exposes every cto read tool with a complete shape, all mode auto"
     assert.equal(typeof t.description, "string");
     assert.ok(t.description.length > 0);
     assert.ok(t.params && typeof t.params === "object");
-    assert.equal(t.mode, "auto");
+    // Reads are auto; the watcher tools are auto/confirm (watch registers a
+    // recurring probe, so it is confirm-gated).
+    assert.ok(t.mode === "auto" || t.mode === "confirm");
     assert.equal(typeof t.run, "function");
   }
 });
@@ -108,12 +113,15 @@ test("dispatch honors a gate returning deny (fails closed)", async () => {
   assert.match(result.error, /denied/);
 });
 
-test("dispatch fails closed when the gate requests confirm (not wired yet)", async () => {
+test("dispatch requires confirmation for a confirm-gated tool and does NOT act", async () => {
   const engine = makeEngine();
   const gate = () => "confirm";
+  // A confirm-gated tool that is not trusted pauses with needConfirmation
+  // (Issue 2 gate wiring) instead of failing closed.
   const result = await engine.dispatch("list_models", {}, { gate });
-  assert.equal(result.ok, false);
-  assert.match(result.error, /requires confirmation/);
+  assert.equal(result.ok, true);
+  assert.equal(result.needConfirmation, true);
+  assert.equal(typeof result.preview, "string");
 });
 
 test("default gate returns allow for every tool (Issue 1 ships auto)", async () => {

--- a/src/server/ctoInbound.test.mjs
+++ b/src/server/ctoInbound.test.mjs
@@ -1,0 +1,336 @@
+// ctoInbound.test.mjs — On-call CTO inbound feed (BET-1165, issue 2/3).
+// Pure logic + injected I/O, no live tmux / opencode / multica / push:
+//   - inbound routing (live flag off → park; live on → inject; dedupe via seenId)
+//   - watcher tick with injected reads (fires on new + matching, no re-fire)
+//   - watch registry CRUD (engine confirm-gated, cto.json atomic store round-trip)
+//   - gate: confirm → allow via trustedActions; untrusted → needConfirmation;
+//     text-loop approve / reject re-dispatch
+//   - pure helpers (conditionKeywords / defaultConditionMatches / seenId / preview)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  createCtoInbound,
+  createWatcherPoller,
+  createCtoEngine,
+  loadCtoStore,
+  saveCtoStore,
+  conditionKeywords,
+  defaultConditionMatches,
+  defaultComputeSurfaceSeenId,
+  computeConfirmId,
+  buildPreview,
+  stableHash,
+} from "./cto.mjs";
+
+// ---------------------------------------------------------------------------
+// Inbound routing + dedupe
+// ---------------------------------------------------------------------------
+
+test("inbound parks when the call flag is off and surfaces via fireNotify", async () => {
+  const notified = [];
+  const inbound = createCtoInbound({ fireNotify: async (a) => notified.push(a) });
+  const res = await inbound.inbound({ surface: "session", payload: { message: "hey", urgent: true } });
+  assert.equal(res.ok, true);
+  assert.equal(res.parked, true);
+  assert.equal(res.live, undefined);
+  assert.equal(notified.length, 1);
+  assert.equal(notified[0].message, "hey");
+  assert.equal(notified[0].urgent, true);
+});
+
+test("inbound drops a re-delivered event with an already-seen seenId (dedupe)", async () => {
+  const notified = [];
+  const inbound = createCtoInbound({ fireNotify: async (a) => notified.push(a) });
+  await inbound.inbound({ surface: "session", payload: { message: "a" }, seenId: "evt-1" });
+  const second = await inbound.inbound({ surface: "session", payload: { message: "b" }, seenId: "evt-1" });
+  assert.equal(second.deduped, true);
+  assert.equal(notified.length, 1); // only the first surfaced
+  // An event with no seenId is never swallowed.
+  await inbound.inbound({ surface: "session", payload: { message: "c" } });
+  assert.equal(notified.length, 2);
+});
+
+test("inbound live route injects into the CTO session when the flag is on (stub seam)", async () => {
+  const sent = [];
+  const inbound = createCtoInbound({
+    isCallActive: () => true,
+    ctoSessionID: "cto-ses",
+    sendPrompt: async (a) => sent.push(a),
+    fireNotify: async () => {},
+  });
+  const res = await inbound.inbound({ surface: "session", payload: { message: "live" } });
+  assert.equal(res.live, true);
+  assert.equal(sent.length, 1);
+  assert.equal(sent[0].sessionId, "cto-ses");
+  assert.equal(sent[0].text, "live");
+});
+
+test("inbound with no message and no live call surfaces nothing but resolves ok", async () => {
+  const notified = [];
+  const inbound = createCtoInbound({ fireNotify: async (a) => notified.push(a) });
+  const res = await inbound.inbound({ surface: "multica", payload: {} });
+  assert.equal(res.ok, true);
+  assert.equal(res.parked, true);
+  assert.equal(notified.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Gate: confirm → allow via trustedActions; text-loop approve / reject
+// ---------------------------------------------------------------------------
+
+function makeEngine(overrides = {}) {
+  return createCtoEngine({
+    listProjects: async () => [],
+    listSessions: async () => [],
+    listMessages: async () => [],
+    listModels: async () => [],
+    getSessionAgent: async () => null,
+    listSnapshots: () => [],
+    listStopped: async () => ({ records: [], lastLooked: null }),
+    searchMessages: async () => ({ supported: true, hits: [] }),
+    configGet: async () => ({}),
+    gitStatus: async () => "",
+    gitBranch: async () => null,
+    gitLog: async () => "",
+    queryMultica: async () => ({ ok: true }),
+    ...overrides,
+  });
+}
+
+// Gate that reports confirm only for `watch` (the confirm-mode tool).
+const gate = (name) => (name === "watch" ? "confirm" : "allow");
+
+test("untrusted confirm-mode tool returns needConfirmation + preview and does NOT act", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const res = await engine.dispatch("watch", { surface: "multica", query: "q", condition: "a P0 opens" }, { gate });
+  assert.equal(res.ok, true);
+  assert.equal(res.needConfirmation, true);
+  assert.equal(res.tool, "watch");
+  assert.equal(typeof res.id, "string");
+  assert.ok(res.preview.length > 0);
+  assert.equal(watchers.length, 0); // NOT registered yet
+});
+
+test("a trusted action in trustedActions runs without confirmation", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const res = await engine.dispatch(
+    "watch",
+    { surface: "multica", query: "q", condition: "a P0 opens" },
+    { gate, trustedActions: ["watch"] },
+  );
+  assert.equal(res.ok, true);
+  assert.equal(res.needConfirmation, undefined);
+  assert.equal(watchers.length, 1);
+  assert.equal(watchers[0].surface, "multica");
+});
+
+test("text loop: approveConfirm(id) then re-dispatch of the same tool+args runs it", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const args = { surface: "multica", query: "q", condition: "a P0 opens" };
+  const first = await engine.dispatch("watch", args, { gate });
+  assert.equal(first.needConfirmation, true);
+  assert.equal(watchers.length, 0);
+  // user says "go ahead"
+  assert.equal(engine.approveConfirm(first.id), true);
+  const second = await engine.dispatch("watch", args, { gate });
+  assert.equal(second.needConfirmation, undefined);
+  assert.equal(watchers.length, 1);
+});
+
+test("text loop: rejectConfirm(id) aborts and the tool stays blocked until approved again", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const args = { surface: "multica", query: "q", condition: "a P0 opens" };
+  const first = await engine.dispatch("watch", args, { gate });
+  // user says "no"
+  assert.equal(engine.rejectConfirm(first.id), true);
+  const second = await engine.dispatch("watch", args, { gate });
+  assert.equal(second.needConfirmation, true); // still blocked
+  assert.equal(watchers.length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Watch registry CRUD (engine + cto.json atomic store round-trip)
+// ---------------------------------------------------------------------------
+
+test("watch registry CRUD through the engine (watch / list_watches / unwatch)", async () => {
+  const watchers = [];
+  const engine = makeEngine({
+    loadWatches: async () => watchers,
+    saveWatches: async (w) => {
+      watchers.splice(0, watchers.length, ...w);
+    },
+  });
+  const gated = { gate, trustedActions: ["watch"] };
+  const added = await engine.dispatch("watch", { surface: "multica", query: "q", condition: "a P0 opens" }, gated);
+  assert.equal(added.ok, true);
+  const id = added.data.watch.id;
+  assert.equal(watchers.length, 1);
+  assert.equal(watchers[0].active, true);
+  assert.equal(watchers[0].lastFiredAt, null);
+
+  const list = await engine.dispatch("list_watches", {});
+  assert.equal(list.data.watches.length, 1);
+
+  const removed = await engine.dispatch("unwatch", { id }, {});
+  assert.equal(removed.data.removed, true);
+  assert.equal(watchers.length, 0);
+});
+
+test("cto.json store load/save round-trips watches atomically", async () => {
+  const dir = mkdtempSync(join(tmpdir(), "cto-store-"));
+  const path = join(dir, "cto.json");
+  const init = loadCtoStore(path);
+  assert.deepEqual(init.watches, []);
+  const store = loadCtoStore(path);
+  store.watches = [
+    { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null, createdAt: 1 },
+  ];
+  await saveCtoStore(store, path);
+  const reloaded = loadCtoStore(path);
+  assert.equal(reloaded.watches.length, 1);
+  assert.equal(reloaded.watches[0].surface, "multica");
+});
+
+// ---------------------------------------------------------------------------
+// Watcher poller with injected reads
+// ---------------------------------------------------------------------------
+
+test("watcher tick fires inbound when condition matches and seenId is new; no re-fire on the same read", async () => {
+  const readOnce = { ok: true, data: { issues: [{ identifier: "BET-1", status: "critical", title: "P0 outage" }] } };
+  const fired = [];
+  const poller = createWatcherPoller({
+    loadWatches: async () => [
+      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null },
+    ],
+    saveWatches: async () => {},
+    readSurface: async () => readOnce,
+    sendToInbound: async (input) => fired.push(input),
+  });
+  await poller.tick();
+  assert.equal(fired.length, 1);
+  assert.equal(fired[0].surface, "multica");
+  assert.equal(typeof fired[0].seenId, "string");
+  assert.ok(fired[0].payload.message.includes("P0"), "message carries the matching snippet");
+  // Same (unchanged) read on the next tick → seenId unchanged → no re-fire.
+  await poller.tick();
+  assert.equal(fired.length, 1);
+});
+
+test("watcher tick respects an inactive/disabled watch", async () => {
+  const fired = [];
+  const poller = createWatcherPoller({
+    loadWatches: async () => [
+      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: false, lastFiredAt: null },
+    ],
+    saveWatches: async () => {},
+    readSurface: async () => ({ ok: true, data: { issues: [{ identifier: "BET-1", status: "critical", title: "P0 outage" }] } }),
+    sendToInbound: async (input) => fired.push(input),
+  });
+  await poller.tick();
+  assert.equal(fired.length, 0);
+});
+
+test("watcher tick does not fire when the condition does not match", async () => {
+  const fired = [];
+  // read has no P0 and no keyword from the condition ("P0")
+  const poller = createWatcherPoller({
+    loadWatches: async () => [
+      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null },
+    ],
+    saveWatches: async () => {},
+    readSurface: async () => ({ ok: true, data: { issues: [{ identifier: "BET-2", status: "todo", title: "chore" }] } }),
+    sendToInbound: async (input) => fired.push(input),
+  });
+  await poller.tick();
+  assert.equal(fired.length, 0);
+});
+
+test("watcher tick survives a failed surface read (skips the watch, keeps going)", async () => {
+  const fired = [];
+  let calls = 0;
+  const poller = createWatcherPoller({
+    loadWatches: async () => [
+      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null },
+      { id: "w2", surface: "multica", query: "q2", condition: "a P0 opens", active: true, lastFiredAt: null },
+    ],
+    saveWatches: async () => {},
+    readSurface: async () => {
+      calls += 1;
+      if (calls === 1) throw new Error("surface down");
+      return { ok: true, data: { issues: [{ identifier: "BET-1", status: "critical", title: "P0 outage" }] } };
+    },
+    sendToInbound: async (input) => fired.push(input),
+  });
+  await poller.tick();
+  // w1's read threw (skipped, no throw out of the tick); w2's read succeeded.
+  assert.equal(fired.length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+test("conditionKeywords strips stopwords and normalizes case", () => {
+  assert.deepEqual(conditionKeywords("a P0 opens"), ["p0"]);
+  assert.deepEqual(conditionKeywords("deploy failed"), ["deploy", "failed"]);
+  assert.deepEqual(conditionKeywords(""), []);
+});
+
+test("defaultConditionMatches is a keyword hit (case-insensitive) or true on empty condition", () => {
+  const read = { data: { issues: [{ identifier: "BET-1", title: "P0 Outage" }] } };
+  assert.equal(defaultConditionMatches("a P0 opens", read), true);
+  assert.equal(defaultConditionMatches("deploy failed", read), false);
+  assert.equal(defaultConditionMatches("", read), true);
+});
+
+test("defaultComputeSurfaceSeenId is stable for identical reads, differs for changed ones", () => {
+  const readA = { data: { issues: [{ identifier: "BET-1" }] } };
+  const readB = { data: { issues: [{ identifier: "BET-1" }, { identifier: "BET-2" }] } };
+  assert.equal(defaultComputeSurfaceSeenId(readA), defaultComputeSurfaceSeenId(readA));
+  assert.notEqual(defaultComputeSurfaceSeenId(readA), defaultComputeSurfaceSeenId(readB));
+  // An explicit seenId on the read always wins.
+  assert.equal(defaultComputeSurfaceSeenId({ seenId: "abc" }), "abc");
+});
+
+test("computeConfirmId is deterministic per (tool, args) and buildPreview summarizes", () => {
+  assert.equal(computeConfirmId("watch", { surface: "multica" }), computeConfirmId("watch", { surface: "multica" }));
+  assert.notEqual(computeConfirmId("watch", { surface: "multica" }), computeConfirmId("watch", { surface: "delegate" }));
+  const preview = buildPreview({ name: "watch", description: "Register a watcher\nover two lines" }, { surface: "multica", condition: "a P0 opens" });
+  assert.ok(preview.includes("watch"));
+  assert.ok(preview.includes("surface=multica"));
+  assert.ok(preview.length > 0);
+});
+
+test("stableHash is a short stable hash", () => {
+  assert.equal(stableHash("x"), stableHash("x"));
+  assert.ok(stableHash("x").length >= 1);
+  assert.notEqual(stableHash("x"), stableHash("y"));
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -67,7 +67,7 @@ import {
   startCapSweeper,
 } from "./capabilities.mjs";
 import { notifyCapSession } from "./capNotifier.mjs";
-import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset, resolveForgeOwner } from "./delegate.mjs";
+import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset, resolveForgeOwner, loadJobs as loadDelegateJobs } from "./delegate.mjs";
 import {
   reportProgress,
   readProgressRecord,
@@ -935,6 +935,56 @@ async function maybeEnsureCtoAgent() {
   }
 }
 void maybeEnsureCtoAgent();
+
+// On-call CTO inbound funnel (Issue 2): the single place a CTO-bound event
+// enters the box. Producers (the send_to_cto tool, the watcher poller, a
+// scheduled prompt targeting the CTO, a webhook routed to the CTO) all call
+// `inbound()`. The server-side "call active" flag is FALSE this issue (Issue 3
+// sets it), so every event takes the PARKED route → dedupe → the existing
+// notification router (fireNotify). No parallel notify path.
+const ctoInbound = cto.createCtoInbound({
+  isCallActive: () => false, // Issue 3 sets the live flag; until then always parked
+  ctoSessionID: null, // resolved in Issue 3 when the live route flips on
+  fireNotify: (args) => push.fireNotify(args),
+  sendPrompt: (args) => promptDelivery.deliver(args),
+});
+
+// Which read a watcher's surface maps to. EXTERNAL surfaces (multica) go
+// through multica.mjs; NATIVE surfaces (schedule, delegate) through the box's
+// own stores. `session` needs no poller read — session events arrive directly
+// via send_to_cto. `crashlytics` is an external MCP read with no server-side
+// engine yet (stretch), so it never matches until that read lands (Issue 3).
+async function ctoSurfaceRead(surface, query) {
+  switch (surface) {
+    case "multica":
+      return queryMultica({ query: query ?? "" });
+    case "schedule":
+      return { ok: true, data: { jobs: await listJobs() } };
+    case "delegate":
+      return { ok: true, data: { jobs: await loadDelegateJobs() } };
+    case "crashlytics":
+      return { ok: true, data: { issues: [] } };
+    case "session":
+    default:
+      return { ok: true, data: {} };
+  }
+}
+
+// Watcher poller (Issue 2): probes each active watch against its surface's
+// existing read and routes a matching + unseen event into the inbound funnel.
+// In-flight-guarded + timer.unref(), mirroring the schedule/delegate pollers.
+const watcherPoller = cto.createWatcherPoller({
+  loadWatches: async () => Array.isArray(cto.loadCtoStore()?.watches) ? cto.loadCtoStore().watches : [],
+  saveWatches: async (watches) => {
+    const store = cto.loadCtoStore();
+    store.watches = Array.isArray(watches) ? watches : [];
+    await cto.saveCtoStore(store);
+  },
+  readSurface: ctoSurfaceRead,
+  sendToInbound: (input) => ctoInbound.inbound(input),
+});
+// eslint-disable-next-line no-unused-vars
+const stopWatcherPoller = watcherPoller.start({ intervalMs: 15_000 });
 
 // Sweep expired artifact-mailbox files (TTL past) every 5 min — non-destructive
 // otherwise: downloads do not delete, the sweep is what reclaims disk.
@@ -2609,13 +2659,58 @@ const handleRequest = async (req, res) => {
   // on-call CTO agent. dispatch wraps every tool so a quiet box / bad engine
   // returns a structured error, never a throw. `ctx.onNarrate` is a server-side
   // seam (wired by issue 3's voice window), never read off the HTTP body.
+  // ---------- On-call CTO inbound (Issue 2) ----------
+  // POST /api/cto/inbound  body {surface?, payload, seenId?} → {ok:true, ...}
+  // The single entry point for CTO-bound events. Producers: the global
+  // send_to_cto tool, the watcher poller, a scheduled prompt targeting the
+  // CTO, or a webhook routed to the CTO. With no live call (this issue) events
+  // are deduped + surfaced via the existing notification router; Issue 3 flips
+  // the live route on. See src/server/cto.mjs (createCtoInbound).
+  if (path === "/api/cto/inbound") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const result = await ctoInbound.inbound({
+          surface: body?.surface,
+          payload: body?.payload ?? {},
+          seenId: body?.seenId,
+        });
+        respondJson(res, result.ok ? 200 : 400, result);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
   if (path === "/api/cto") {
     try {
       if (req.method === "POST") {
         const body = await readJsonBody(req);
-        const result = await getCtoEngine().dispatch(body?.tool, body?.args ?? {}, {
+        const engine = getCtoEngine();
+        // Text-loop gate (Issue 2): an `approve` id re-authorizes the previously
+        // needConfirmation'd (tool, args) — the user said "go ahead". "no" is
+        // rejectConfirm; both drive the in-conversation loop (Issue 3 replaces it
+        // with voice).
+        if (typeof body?.approve === "string" && body.approve) engine.approveConfirm(body.approve);
+        let cfg = {};
+        try {
+          cfg = (await local.configGet()) ?? {};
+        } catch {
+          cfg = {};
+        }
+        // The gate reports each tool's declared mode: read-only auto tools run
+        // freely; confirm-mode tools (watch) pause for the user's go-ahead
+        // (handled inside dispatch via trustedActions / the approve loop).
+        const toolModes = new Map(engine.listTools().map((t) => [t.name, t.mode]));
+        const gate = (toolName) => (toolModes.get(toolName) === "confirm" ? "confirm" : "allow");
+        const result = await engine.dispatch(body?.tool, body?.args ?? {}, {
           sessionID: body?.sessionID,
           cwd: body?.directory,
+          trustedActions: Array.isArray(cfg?.cto?.trustedActions) ? cfg.cto.trustedActions : [],
+          gate,
         });
         respondJson(res, result.ok ? 200 : 400, result);
         return;


### PR DESCRIPTION
## On-call CTO 2/3 — inbound feed (`send_to_cto` + `watch` + routing), parked→push

Fresh PR targeting **main** (BET-1164 / Issue 1 is now merged, so the branches stack cleanly here). This replaces the closed main-targeted PR and the departed stacked PR #1171. Diff vs `main` = exactly this issue's 7 files.

### What's here
- **`docs/opencode-tools/send-to-cto.ts`** — global opencode tool `send_to_cto(message, {title?, urgent?})` → `POST /api/cto/inbound` `{surface:"session", sessionID, message}`. Thin registrar (copies `boxToken()`/`authHeaders()`/`call()` from notify.ts). Any session can call it.
- **`src/server/cto.mjs` — `createCtoInbound`**: the single inbound funnel. `isCallActive()` is **false this issue** (Issue 3 sets it) → every event takes the **parked** route: dedupe via `seenIds.mjs`, then surface through the **existing** `push.mjs fireNotify` (shared cross-device router). No parallel notify path. Live route is a clean stub.
- **Watchers**: `watch` (confirm-mode) + `unwatch`/`list_watches`, `Watch={id,surface,query,condition,active,lastFiredAt,createdAt}` in **cto.json** (atomic). `createWatcherPoller` (in-flight guard + `timer.unref()` via `startPoller`) probes each active watch against its surface's existing read — `multica.mjs`, `schedule.mjs` (`listJobs`), `delegate.mjs` (`loadJobs`) — and calls `inbound(surface=…)` when `conditionMatches && seenId is new`.
- **Gate wiring (in-conversation text loop)**: an untrusted confirm-mode tool returns `{needConfirmation, id, preview}` and does NOT act; `cto.trustedActions` → allow; `approveConfirm(id)` + re-dispatch runs it ("go ahead"), `rejectConfirm(id)` aborts ("no"). `send_prompt` into a non-busy session stays `auto` (existing `promptDelivery` defers when busy).
- **`src/server/index.mjs`**: `/api/cto/inbound` route; `/api/cto` passes `trustedActions` + a mode-based gate and supports an `approve` field; watcher poller started (15s). `docs/opencode-tools/cto.ts` + `AGENTS.md` updated.

### Answers to the reviewer's two questions (0 blocks)
- **Q1 — gate scope**: only `watch` (of the four named confirm actions) is a cto-ENGINE tool, so only it is confirm-gated here. `use_secret`/`set_config` are not cto-engine tools in this codebase (they live on other surfaces), and `send_prompt`-into-busy is the existing promptDelivery deferral, not a cto dispatch. The confirm gate is generic (any `mode:"confirm"` tool); `watch` is the one this issue adds. Kept the mechanism general; scope noted here and in code.
- **Q2 — crashlytics watcher read `{issues:[]}`**: correct for this issue. The Crashlytics read is an external MCP integration with no server-side engine, so `ctoSurfaceRead("crashlytics")` returns `{issues:[]}` and a crashlytics watch stays silent rather than misleadingly firing. A server-side read is filed as **BET-1168** (parked).

### Deferred (filed)
- Webhook→CTO routing: optional/low-stakes per the issue → **BET-1167** (parked).
- Crashlytics watcher read surface → **BET-1168** (parked).

### Verification
- typecheck: exit 0.
- test: **2468 pass / 0 fail** (on the rebased branch against current `main`).
- `src/server/ctoInbound.test.mjs` (15 tests): inbound routing (live off → park, dedupe via seenIdFilter), live stub, gate trustedActions + approve/reject text loop, watch registry CRUD + cto.json atomic round-trip, watcher tick with injected reads, pure helpers. `cto.test.mjs` updated (18 tools, confirm-gated dispatch).
