### PR TITLE
fix(renderer): stop the hover-marquee doubling every truncated row's height

### DIFF
--- a/src/renderer/MarqueeLabel.test.tsx
+++ b/src/renderer/MarqueeLabel.test.tsx
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+//
+// MarqueeLabel — the invariant under test is GEOMETRY, not motion: a label must
+// occupy exactly the same box whether or not its text is truncated and whether
+// or not the pointer is over it. BET-1172 shipped the resting copy and the
+// sliding copy as two in-flow siblings (the sliding one merely
+// `visibility:hidden`), which reserves a second line and made every truncated
+// sidebar row double height. These tests pin the fix: the sliding copy is
+// absolutely positioned (out of flow), and the hover swap is a visibility flip
+// on both copies — never `display`, which would collapse the box on hover.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { mount, type Harness } from "./testHarness";
+import { MarqueeLabel } from "./MarqueeLabel";
+
+// jsdom performs no layout, so `over` can never become true on its own. Stub
+// the two metrics `measure` reads so a test can choose "truncated" or not.
+function stubLayout(scrollWidth: number, clientWidth: number): () => void {
+  const proto = HTMLElement.prototype;
+  const prev = {
+    scrollWidth: Object.getOwnPropertyDescriptor(proto, "scrollWidth"),
+    clientWidth: Object.getOwnPropertyDescriptor(proto, "clientWidth"),
+  };
+  Object.defineProperty(proto, "scrollWidth", { configurable: true, get: () => scrollWidth });
+  Object.defineProperty(proto, "clientWidth", { configurable: true, get: () => clientWidth });
+  return () => {
+    for (const k of ["scrollWidth", "clientWidth"] as const) {
+      const d = prev[k];
+      if (d) Object.defineProperty(proto, k, d);
+      else delete (proto as unknown as Record<string, unknown>)[k];
+    }
+  };
+}
+
+describe("MarqueeLabel — the box never changes", () => {
+  let h: Harness | null = null;
+  let restore: (() => void) | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    restore?.();
+    restore = null;
+  });
+
+  it("not truncated: one in-flow ellipsized copy, no marquee, no overlay", () => {
+    restore = stubLayout(100, 100);
+    h = mount(<MarqueeLabel>Add CSV export</MarqueeLabel>);
+    const clip = h.container.firstElementChild as HTMLElement;
+    expect(clip.className).not.toContain("manta-marquee ");
+    expect(clip.children).toHaveLength(1);
+    const rest = clip.firstElementChild as HTMLElement;
+    expect(rest.className).toContain("manta-marquee-rest");
+    expect(rest.className).toContain("truncate");
+    expect(clip.textContent).toBe("Add CSV export");
+  });
+
+  it("truncated: the sliding copy is OUT OF FLOW so the label keeps one line", () => {
+    restore = stubLayout(300, 200);
+    h = mount(<MarqueeLabel>Add CSV export</MarqueeLabel>);
+    const clip = h.container.firstElementChild as HTMLElement;
+    expect(clip.className).toContain("manta-marquee");
+    expect(clip.className).toContain("relative"); // containing block for the overlay
+    expect(clip.getAttribute("style")).toContain("--marquee-shift: 100px");
+
+    // Exactly two copies, and only the resting one is in flow.
+    expect(clip.children).toHaveLength(2);
+    const rest = clip.children[0] as HTMLElement;
+    const inner = clip.children[1] as HTMLElement;
+    expect(rest.className).toContain("manta-marquee-rest");
+    expect(rest.className).not.toContain("absolute");
+    expect(inner.className).toContain("manta-marquee-inner");
+    // THE regression guard: an in-flow second copy is what doubled row height.
+    expect(inner.className).toContain("absolute");
+    expect(inner.className).toContain("whitespace-nowrap");
+    // ...and it must not re-introduce the BET-1154 width mutation either.
+    expect(inner.className).not.toContain("max-w-full");
+    expect(inner.className).not.toContain("text-ellipsis");
+  });
+
+  it("measures the resting copy, so hovering the overlay cannot re-trigger it", () => {
+    restore = stubLayout(260, 200);
+    h = mount(<MarqueeLabel title="Add CSV export">Add CSV export</MarqueeLabel>);
+    const clip = h.container.firstElementChild as HTMLElement;
+    expect(clip.getAttribute("title")).toBe("Add CSV export");
+    expect(clip.getAttribute("style")).toContain("--marquee-shift: 60px");
+  });
+
+  it("the hover swap is visibility-only — `display:none` would collapse the box", () => {
+    const css = readFileSync(resolve(process.cwd(), "src/renderer/index.css"), "utf8");
+    const hoverRest = css.match(/\.manta-marquee:hover \.manta-marquee-rest \{([^}]*)\}/);
+    expect(hoverRest).not.toBeNull();
+    expect(hoverRest![1]).toContain("visibility");
+    // With the sliding copy out of flow, `display:none` on the resting copy
+    // leaves the label with no in-flow content — it collapses to zero height
+    // the instant the pointer arrives.
+    expect(hoverRest![1]).not.toContain("display");
+  });
+});

--- a/src/renderer/MarqueeLabel.tsx
+++ b/src/renderer/MarqueeLabel.tsx
@@ -1,14 +1,20 @@
 // MarqueeLabel — a reusable hover-marquee text label for truncated names.
 //
-// Renders an overflow-clipping outer span (the clip) containing one nowrap
-// inner span (the text) plus an ellipsizing REST sibling. The inner span is
-// ALWAYS full-width and is animated with a pure transform, so its box never
-// changes on hover — lifting the pointer returns to the start with no reflow.
-// At rest an ellipsizing REST sibling is shown; on hover CSS swaps to the
-// animated inner. Because the inner keeps its layout size in both states
-// (visibility, not display, hides it at rest), its scrollWidth stays
-// measurable and the ResizeObserver (which observes only the clip) never
-// re-fires on hover.
+// The label box is defined by ONE in-flow child: the resting, ellipsized copy
+// (`manta-marquee-rest`). It is always present and always one line tall, so the
+// label's height and width are the same whether or not the text is truncated
+// and whether or not the pointer is over it.
+//
+// When the text WOULD truncate, a second copy (`manta-marquee-inner`) is
+// rendered ABSOLUTELY POSITIONED on top of it — out of flow, so it contributes
+// no height and no width. Hovering swaps which copy is visible and animates the
+// overlay with a pure transform; nothing about the box changes, so entering
+// hover reflows nothing and the ResizeObserver (which watches only the clip)
+// never re-fires from a hover.
+//
+// Note the overlay MUST stay out of flow. An in-flow hidden sibling — even
+// `visibility:hidden` — reserves a second line and makes every truncated row
+// double height (BET-1172's regression).
 
 import {
   useLayoutEffect,
@@ -18,9 +24,9 @@ import {
   type ReactNode,
 } from "react";
 
-const CLIP = "overflow-hidden";
-const INNER = "manta-marquee-inner inline-block whitespace-nowrap";
+const CLIP = "relative block overflow-hidden";
 const REST = "manta-marquee-rest block w-full truncate";
+const INNER = "manta-marquee-inner absolute left-0 top-0 inline-block whitespace-nowrap";
 
 export function MarqueeLabel({
   children,
@@ -35,16 +41,19 @@ export function MarqueeLabel({
   title?: string;
 }) {
   const clipRef = useRef<HTMLSpanElement>(null);
-  const innerRef = useRef<HTMLSpanElement>(null);
+  const restRef = useRef<HTMLSpanElement>(null);
   const [shift, setShift] = useState(0);
   const [over, setOver] = useState(false);
 
   useLayoutEffect(() => {
     const clip = clipRef.current;
-    const inner = innerRef.current;
-    if (!clip || !inner) return;
+    const rest = restRef.current;
+    if (!clip || !rest) return;
+    // The resting copy is `truncate` (nowrap + overflow hidden), so its
+    // scrollWidth is the FULL text width and its clientWidth is the visible
+    // width — their difference is exactly how far the overlay must travel.
     const measure = () => {
-      const w = inner.scrollWidth - clip.clientWidth;
+      const w = rest.scrollWidth - rest.clientWidth;
       setShift(Math.max(0, w));
       setOver(w > 0);
     };
@@ -62,14 +71,10 @@ export function MarqueeLabel({
       className={`${CLIP}${over ? " manta-marquee" : ""} ${className}`}
       style={over ? ({ "--marquee-shift": `${shift}px` } as CSSProperties) : undefined}
     >
-      {over && (
-        <span className={REST}>
-          {children}
-        </span>
-      )}
-      <span ref={innerRef} className={INNER}>
+      <span ref={restRef} className={REST}>
         {children}
       </span>
+      {over && <span className={INNER}>{children}</span>}
     </span>
   );
 }

--- a/src/renderer/SessionRow.test.tsx
+++ b/src/renderer/SessionRow.test.tsx
@@ -249,15 +249,17 @@ describe("SessionRow — one line: dot · name · age", () => {
     expect(name.textContent).toBe("Add CSV export");
   });
 
-  it("marquee: true keeps the inner span width-unconstrained (no width-mutation jitter)", () => {
+  it("marquee: true still renders exactly ONE in-flow, one-line name (no double-height row)", () => {
     h = mount(<SessionRow status="idle" name="Add CSV export" marquee />);
     const el = h.container.firstElementChild as HTMLElement;
     const clip = el.firstElementChild!.nextElementSibling as HTMLElement;
-    const inner = clip.firstElementChild as HTMLElement;
-    expect(inner.className).toContain("manta-marquee-inner");
-    expect(inner.className).toContain("whitespace-nowrap");
-    expect(inner.className).not.toContain("max-w-full");
-    expect(inner.className).not.toContain("overflow-hidden");
-    expect(inner.className).not.toContain("text-ellipsis");
+    // The label's box comes from one truncating child; the sliding copy (when
+    // the text overflows) is absolutely positioned on top of it and adds no
+    // height. A second in-flow copy is what made every truncated row two lines
+    // tall (BET-1172). Geometry itself is covered in MarqueeLabel.test.tsx.
+    expect(clip.children).toHaveLength(1);
+    const rest = clip.firstElementChild as HTMLElement;
+    expect(rest.className).toContain("manta-marquee-rest");
+    expect(rest.className).toContain("truncate");
   });
 });

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -361,17 +361,16 @@ html, body, #root {
 }
 
 /* MarqueeLabel — RTL hover-loop for truncated names (see MarqueeLabel.tsx).
-   The inner span is ALWAYS full-width (`inline-block whitespace-nowrap`) and is
-   animated with a pure transform, so its box NEVER changes on hover — lifting
-   the pointer reverts to transform:none = the title reads from the start. At
-   rest an ellipsizing sibling (`manta-marquee-rest`, width-constrained +
-   text-ellipsis) is shown; on hover CSS swaps to the animated inner. Because
-   the inner keeps its layout size in both states (visibility, not display,
-   hides it at rest), `inner.scrollWidth` stays measurable and the ResizeObserver
-   (which observes only the clip) never fires from hovering. My --marquee-shift
-   is the overflow width in px (set inline by the component); --marquee-gap adds
-   breathing room so the tail fully clears the clip. Reduced-motion: a static
-   ellipsized label. */
+   The label's box comes from ONE in-flow child: the resting, ellipsized copy
+   (`manta-marquee-rest`), always exactly one line tall. The sliding copy
+   (`manta-marquee-inner`) is ABSOLUTELY POSITIONED on top of it, so it adds no
+   height and no width and hovering cannot reflow anything — it is a pure
+   transform, and lifting the pointer reverts to transform:none = the title
+   reads from the start. Do NOT make the sliding copy an in-flow sibling: even
+   `visibility:hidden` reserves a second line and doubles every truncated row's
+   height (BET-1172). --marquee-shift is the overflow width in px (set inline by
+   the component); --marquee-gap adds breathing room so the tail fully clears
+   the clip. Reduced-motion: a static ellipsized label. */
 @keyframes manta-marquee {
   0%   { transform: translateX(0); }
   35%  { transform: translateX(calc(-1 * (var(--marquee-shift, 0px) + var(--marquee-gap, 24px)))); }
@@ -379,15 +378,15 @@ html, body, #root {
   90%  { transform: translateX(0); }
   100% { transform: translateX(0); }
 }
-/* At rest: show the ellipsized REST copy; hide the animated inner but keep it
-   laid out (visibility) so its width is still measurable. */
+/* At rest: the ellipsized REST copy is the visible one; the overlay is hidden. */
 .manta-marquee .manta-marquee-inner {
   visibility: hidden;
 }
-/* On hover: swap — hide the REST copy, reveal + animate the inner. No width or
-   overflow change, so entering hover reflows nothing and re-fires nothing. */
+/* On hover: swap which copy is visible and animate the overlay. Both are
+   visibility flips — no display, width or overflow change — so entering hover
+   changes no geometry and re-fires no measurement. */
 .manta-marquee:hover .manta-marquee-rest {
-  display: none;
+  visibility: hidden;
 }
 .manta-marquee:hover .manta-marquee-inner {
   visibility: visible;
@@ -406,7 +405,7 @@ html, body, #root {
     animation: none;
   }
   .manta-marquee:hover .manta-marquee-rest {
-    display: block;
+    visibility: visible;
   }
   .manta-marquee:hover {
     -webkit-mask-image: none;


### PR DESCRIPTION
## What broke

BET-1172 fixed the hover-entry jitter by rendering the label as **two in-flow copies** — an ellipsized resting copy and the sliding one, the latter hidden with `visibility:hidden` so it stayed measurable.

`visibility:hidden` keeps an element **in the layout**. So every truncated row reserved two lines of text height: sidebar rows rendered double height, with the age chip floating below the name's baseline (user-reported, screenshot).

## Fix

The sliding copy is now **absolutely positioned** over the resting one — out of flow, so it adds no height and no width. The hover swap is a visibility flip on both copies. Measurement moves to the resting copy (`scrollWidth - clientWidth`), the one element whose width is stable in both states, so the ResizeObserver still only watches the clip.

`display:none` on the resting copy is now forbidden too: with the overlay out of flow it would leave the label with no in-flow content and collapse it to zero height on hover. A test pins that.

BET-1172's actual property is preserved: no geometry changes on hover → no reflow, no re-measure feedback.

## Verification results

- `npm run typecheck` — pass
- `npm test` — pass (166 renderer files / 3185 tests, 2496 server tests)
- New `src/renderer/MarqueeLabel.test.tsx` (4): out-of-flow overlay, one-line at rest, shift measured off the resting copy, CSS visibility-not-display guard
- `SessionRow.test.tsx` marquee test now asserts the row keeps exactly one in-flow one-line name