### PR TITLE
fix(cto): OpenAI key invisible in Settings and unused by the Realtime call

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2032,6 +2032,13 @@ recorder and is not exported from `voice.ts`.)
   reintroduce a chunked-streaming spike; it under-delivered vs the
   added complexity in spike testing.
 
+## On-call CTO voice call (OpenAI Realtime)
+
+The OpenAI key lives in Settings → On-call CTO (`openaiApiKey`), stored in the
+box's config and never sent to the renderer. Narration uses the Groq key while
+the Realtime model authenticates with the OpenAI key — two deliberately separate
+credentials, each used where it belongs.
+
 ## File upload paths (chat-mode)
 
 Three upload paths all land in `~/.manta-uploads/<session>/<ts>/` on the remote:

--- a/generated/swift/SettingsSchema.swift
+++ b/generated/swift/SettingsSchema.swift
@@ -204,7 +204,7 @@ enum SettingsSchema {
         ),
         SettingEntry(
             id: "openaiApiKey",
-            section: "voice",
+            section: "cto",
             label: "OpenAI API key",
             help: "Enables the on-call CTO voice call window (OpenAI Realtime). Stored on the box; the renderer never sees it.",
             control: SettingControl.password,

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -256,7 +256,7 @@ const SECTION_GROUPS: Partial<Record<SettingSectionId, { title: string; entryIds
     { title: "Speech to text (Groq)", entryIds: ["groqApiKey", "voiceTranscriptionModel"] },
   ],
   cto: [
-    { title: "Setup", entryIds: ["ctoEnabled", "ctoModel", "ctoVoice", "ctoAlwaysListening", "ctoParkedBehavior"] },
+    { title: "Setup", entryIds: ["openaiApiKey", "ctoEnabled", "ctoModel", "ctoVoice", "ctoAlwaysListening", "ctoParkedBehavior"] },
   ],
 };
 

--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -138,7 +138,7 @@ export function createVcCallEngine(deps = {}) {
     if (state.status === "connecting" || state.status === "live") return;
     state.cfg = cfg;
     const conf = cfg?.cto ?? {};
-    const apiKey = cfg?.groqApiKey || cfg?.openaiApiKey;
+    const apiKey = cfg?.openaiApiKey;
     state.caps = {
       spendCapUsd: typeof cfg?.cto?.spendCapUsd === "number" ? cfg.cto.spendCapUsd : DEFAULT_SPEND_CAP_USD,
       idleParkMs: typeof cfg?.cto?.idleParkMs === "number" ? cfg.cto.idleParkMs : DEFAULT_IDLE_PARK_MS,

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -236,3 +236,25 @@ test("reconnect: giving up after maxAttempts surfaces a dropped state", async ()
   assert.equal(stateLog.includes("reconnecting"), true);
   assert.equal(stateLog[stateLog.length - 1], "dropped");
 });
+
+test("regression: the Realtime socket authenticates with the OpenAI key, not the Groq key (BET-1173)", async () => {
+  // With BOTH groqApiKey and openaiApiKey present, the bearer token must be
+  // the OpenAI key. A Groq key is required for chat dictation, so nearly every
+  // user has one — a groqApiKey fallback would open the OpenAI Realtime socket
+  // with a Groq credential, get rejected, and end in the dropped state.
+  let capturedHeaders = null;
+  const { engine } = makeEngine({
+    realtimeConnect: async (url, headers) => {
+      capturedHeaders = headers;
+      const ws = makeFakeWs();
+      return ws;
+    },
+  });
+  await engine.start({
+    groqApiKey: "gsk-groq",
+    openaiApiKey: "sk-openai",
+    cto: {},
+  });
+  assert.ok(capturedHeaders, "realtimeConnect was called");
+  assert.equal(capturedHeaders.authorization, "Bearer sk-openai");
+});

--- a/src/shared/settingsSchema.test.ts
+++ b/src/shared/settingsSchema.test.ts
@@ -82,8 +82,10 @@ describe("settingsForSection", () => {
   it("returns only entries in the given section for the platform", () => {
     const voiceDesktop = settingsForSection(ALL, "voice", "desktop");
     expect(voiceDesktop.map((e) => e.id).sort()).toEqual(
-      ["groqApiKey", "openaiApiKey", "voiceTranscriptionModel"],
+      ["groqApiKey", "voiceTranscriptionModel"],
     );
+    const ctoDesktop = settingsForSection(ALL, "cto", "desktop");
+    expect(ctoDesktop.map((e) => e.id)).toContain("openaiApiKey");
   });
 });
 

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -301,9 +301,13 @@ export const SETTINGS: SettingEntry[] = [
     default: "",
     placeholder: "whisper-large-v3-turbo",
   },
+
+  // ----- on-call CTO (BET-1166) -----
+  // Nested under `cto.*` in AppConfig. The surface renders these through the
+  // generic schema-driven fields (configUpdate handles the cto.* prefix).
   {
     id: "openaiApiKey",
-    section: "voice",
+    section: "cto",
     label: "OpenAI API key",
     help: "Enables the on-call CTO voice call window (OpenAI Realtime). Stored on the box; the renderer never sees it.",
     control: "password",
@@ -313,10 +317,6 @@ export const SETTINGS: SettingEntry[] = [
     commitOnBlur: true,
     placeholder: "sk-… (leave blank to disable the call window)",
   },
-
-  // ----- on-call CTO (BET-1166) -----
-  // Nested under `cto.*` in AppConfig. The surface renders these through the
-  // generic schema-driven fields (configUpdate handles the cto.* prefix).
   {
     id: "ctoEnabled",
     section: "cto",


### PR DESCRIPTION
## What

Two small defects that made the on-call CTO call window unusable (BET-1173):

1. **Realtime call used the wrong key.** `vccall.mjs` picked `groqApiKey || openaiApiKey` as the bearer token for the OpenAI Realtime socket. Since nearly every user has a Groq key (required for chat dictation), the OpenAI socket was being dialed with a Groq credential, rejected, and ending in `dropped` no matter what was in the OpenAI field. Now reads `openaiApiKey` only; the `openai_key_missing` branch is unchanged. Narration (`callWs.mjs` → Groq Orpheus TTS) is untouched.

2. **OpenAI key never rendered in desktop Settings.** `openaiApiKey` is a real schema entry (`section: "voice"`) honored everywhere, but desktop renders fields from the hand-maintained `SECTION_GROUPS` map, and its `voice` group listed only `groqApiKey` + `voiceTranscriptionModel` — so the field was silently dropped. Moved the entry to the on-call CTO block (section `cto`, immediately before `ctoEnabled`) and added it as the first id of the cto → Setup group.

## Files changed

`AGENTS.md`, `generated/swift/SettingsSchema.swift` (regenerated via `npm run gen:swift-settings`), `src/renderer/Settings.tsx`, `src/server/vccall.mjs`, `src/server/vccall.test.mjs`, `src/shared/settingsSchema.ts`, `src/shared/settingsSchema.test.ts`.

## Scope notes / deferrals

- The structural problem — `SECTION_GROUPS` is a hand list that can silently drop any field — is explicitly out of scope per the issue. Noted here for a future follow-up.
- `cto.transport: "realtime" | "groq"` remains an inert seam; not implementing a second transport.

**Base:** origin/main @ `c7e9abcf`
