### PR TITLE
chore(release): bump desktop version to 0.0.39

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.38",
+      "version": "0.0.39",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.38",
+  "version": "0.0.39",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.38",
+ "version": "0.0.39",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Cuts the version for the mac/win 0.0.39 release.

The desktop artifacts take their version from `package.json`, not from the release tag. `main` still carried 0.0.38 — the version `mac-v0.0.38` / `win-v0.0.38` already published — so tagging without this bump would build artifacts stamped 0.0.38 and publish an update feed advertising the version users already have. electron-updater would find no update and the release would reach nobody, with every workflow green.

No functional change.