### PR TITLE
BET-1175: Guard desktop Settings SECTION_GROUPS against silently dropping schema fields

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -57,6 +57,7 @@ import type {
 import {
   SETTINGS,
   SETTING_SECTIONS,
+  SECTION_GROUPS,
   settingsForSection,
   searchSettings,
   sectionIsModified,
@@ -234,31 +235,9 @@ const SECTION_ICONS: Record<SettingSectionId, typeof SettingsIcon> = {
   cto: PhoneCall,
 };
 
-// Card groupings for the schema-driven sections. Each { title, entryIds }
-// becomes one --card surface with a micro-caps group heading, mirroring the
-// mockup's group labels. Sections with per-section custom content (general,
-// box, accounts, extensions) are rendered by renderCustom instead.
-const SECTION_GROUPS: Partial<Record<SettingSectionId, { title: string; entryIds: string[] }[]>> = {
-  models: [
-    { title: "Requests", entryIds: ["cacheTtl"] },
-    { title: "Plan usage", entryIds: ["alwaysShowUsage"] },
-  ],
-  sessions: [
-    { title: "Naming", entryIds: ["autoRenameSessions"] },
-    { title: "Git worktrees", entryIds: ["worktreePerSession", "worktreeCleanOnClose"] },
-  ],
-  files: [
-    { title: "Files the agent sends you", entryIds: ["allowAgentPush", "downloadsDir"] },
-    { title: "Files you send the agent", entryIds: ["uploadCleanupHours"] },
-    { title: "Voice note audio retention", entryIds: ["voiceNoteTtlHours"] },
-  ],
-  voice: [
-    { title: "Speech to text (Groq)", entryIds: ["groqApiKey", "voiceTranscriptionModel"] },
-  ],
-  cto: [
-    { title: "Setup", entryIds: ["openaiApiKey", "ctoEnabled", "ctoModel", "ctoVoice", "ctoAlwaysListening", "ctoParkedBehavior"] },
-  ],
-};
+// Card groupings for the schema-driven sections live in SECTION_GROUPS
+// (src/shared/settingsSchema.ts). Sections with per-section custom content
+// (general, box, accounts, extensions) are rendered by renderCustom instead.
 
 // A --card surface with a micro-caps group heading (BET-461 §4). The chrome
 // (--card bg, --border edge, --r-lg radius, 12px v / 16px h padding) lives on

--- a/src/shared/settingsSchema.test.ts
+++ b/src/shared/settingsSchema.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "vitest";
 import {
   SETTINGS,
   SETTING_SECTIONS,
+  SECTION_GROUPS,
   settingsForPlatform,
   settingsForSection,
   searchSettings,
@@ -86,6 +87,55 @@ describe("settingsForSection", () => {
     );
     const ctoDesktop = settingsForSection(ALL, "cto", "desktop");
     expect(ctoDesktop.map((e) => e.id)).toContain("openaiApiKey");
+  });
+});
+
+describe("SECTION_GROUPS desktop coverage (BET-1175)", () => {
+  // The desktop Settings window renders each section's simple fields from
+  // SECTION_GROUPS — a separate hand list from SETTINGS. A desktop-visible,
+  // non-`custom` entry missing from it (or whose section isn't grouped at
+  // all) renders NOWHERE on desktop while still showing in Search + on
+  // mobile. These two are drawn by explicit dedicated cards in Settings.tsx
+  // rather than a SECTION_GROUPS group.
+  const DESKTOP_SPECIAL_CARDS = new Set(["theme", "pluginsEnabled"]);
+
+  it("every desktop-visible schema field renders on desktop", () => {
+    const desktop = settingsForPlatform(ALL, "desktop");
+    const uncovered: string[] = [];
+
+    for (const e of desktop) {
+      if (e.control === "custom") continue; // drawn by bespoke custom content
+      if (DESKTOP_SPECIAL_CARDS.has(e.id)) continue; // theme (General), pluginsEnabled (Extensions)
+
+      const groups = SECTION_GROUPS[e.section] ?? [];
+      const idsInSection = groups.flatMap((g) => g.entryIds);
+      if (!idsInSection.includes(e.id)) {
+        uncovered.push(`${e.id} (${e.section})`);
+      }
+    }
+
+    expect(uncovered, "desktop-visible schema fields with no SECTION_GROUPS card").toEqual([]);
+  });
+
+  it("every SECTION_GROUPS entry id resolves to a real, desktop-visible schema entry", () => {
+    const desktopIds = new Set(settingsForPlatform(ALL, "desktop").map((e) => e.id));
+    const stale: string[] = [];
+    for (const section of Object.keys(SECTION_GROUPS)) {
+      for (const group of SECTION_GROUPS[section as keyof typeof SECTION_GROUPS]!) {
+        for (const id of group.entryIds) {
+          if (!desktopIds.has(id)) stale.push(`${section}.${id}`);
+        }
+      }
+    }
+    expect(stale, "SECTION_GROUPS entry ids that don't exist in SETTINGS on desktop").toEqual([]);
+  });
+
+  it("throws when a group id list has no entries (a group is never empty)", () => {
+    for (const section of Object.keys(SECTION_GROUPS)) {
+      for (const group of SECTION_GROUPS[section as keyof typeof SECTION_GROUPS]!) {
+        expect(group.entryIds.length, `${section}/${group.title}`).toBeGreaterThan(0);
+      }
+    }
   });
 });
 

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -375,6 +375,41 @@ export const SETTINGS: SettingEntry[] = [
   },
 ];
 
+// ----- desktop card groupings (BET-1175) -----
+//
+// The desktop Settings window (src/renderer/Settings.tsx) renders each
+// section's simple fields as one or more GroupCards. SECTION_GROUPS is the
+// desktop's map of section → card title → ordered entry ids. It must stay a
+// complete mirror of SETTINGS for the desktop platform: any non-`custom`
+// desktop-visible entry that is missing here (and not drawn by a dedicated
+// card) renders NOWHERE on desktop, while still appearing in Search and on
+// mobile — the exact drift that hid `openaiApiKey` (BET-1173). The guard in
+// settingsSchema.test.ts ("every desktop-visible schema field renders on
+// desktop") asserts every such entry is covered, so none can silently drop.
+export const SECTION_GROUPS: Partial<
+  Record<SettingSectionId, { title: string; entryIds: string[] }[]>
+> = {
+  models: [
+    { title: "Requests", entryIds: ["cacheTtl"] },
+    { title: "Plan usage", entryIds: ["alwaysShowUsage"] },
+  ],
+  sessions: [
+    { title: "Naming", entryIds: ["autoRenameSessions"] },
+    { title: "Git worktrees", entryIds: ["worktreePerSession", "worktreeCleanOnClose"] },
+  ],
+  files: [
+    { title: "Files the agent sends you", entryIds: ["allowAgentPush", "downloadsDir"] },
+    { title: "Files you send the agent", entryIds: ["uploadCleanupHours"] },
+    { title: "Voice note audio retention", entryIds: ["voiceNoteTtlHours"] },
+  ],
+  voice: [
+    { title: "Speech to text (Groq)", entryIds: ["groqApiKey", "voiceTranscriptionModel"] },
+  ],
+  cto: [
+    { title: "Setup", entryIds: ["openaiApiKey", "ctoEnabled", "ctoModel", "ctoVoice", "ctoAlwaysListening", "ctoParkedBehavior"] },
+  ],
+};
+
 // ----- pure helpers -----
 
 /** Entries visible on a given platform (both + that platform). */


### PR DESCRIPTION
## Context

Fixes BET-1175. `src/renderer/Settings.tsx` rendered the desktop Settings window's grouped fields from a hand-maintained `SECTION_GROUPS` map, separate from the canonical schema (`SETTINGS[]` in `src/shared/settingsSchema.ts`). Search + mobile render straight from the schema; desktop rendering depended on the second list. An entry added to the schema but forgotten in `SECTION_GROUPS` rendered **nowhere** on desktop, silently — exactly how `openaiApiKey` shipped invisible (BET-1173).

The structural fix deferred out of BET-1173, now that BET-1173's PR (#1180) has merged to `main` and unblocked this issue.

## Change

- **`src/shared/settingsSchema.ts`** — moved the desktop card-grouping map into the schema module as an exported `SECTION_GROUPS` (pure data keyed by `SettingSectionId`). Keeping the hand list next to the canonical schema makes drift visible; it lives in the module that already owns section types.
- **`src/renderer/Settings.tsx`** — removed the local `SECTION_GROUPS` definition and imports the shared one. Net line count of the file **goes down** (the constant + its local comment removed).
- **`src/shared/settingsSchema.test.ts`** — new `SECTION_GROUPS desktop coverage (BET-1175)` block with three guards:
  - **forward**: every desktop-visible, non-`custom` schema entry must render somewhere on desktop — in a `SECTION_GROUPS` group for its section, or via one of the two dedicated cards (`theme` in General, `pluginsEnabled` in Extensions). Any schema field missing from the map (including one in a brand-new section with no group) fails loudly instead of silently vanishing.
  - **reverse**: every id listed in `SECTION_GROUPS` resolves to a real, desktop-visible schema entry (catches stale/renamed ids in the map).
  - a group's `entryIds` is never empty.

No config-key/schema/store or behavior changes — the Settings window looks identical. This is the small "coverage guard" direction named in the issue; the fuller "delete the map and derive from a `group` field on each entry" refactor is tracked separately as BET-1174.

## Verification

- `npm run typecheck` — clean.
- `npm test` — 2497 tests, 0 fail (includes the new guard block).
- Guard proven by negative test: temporarily removing `ctoModel` from `SECTION_GROUPS` makes "every desktop-visible schema field renders on desktop" fail with `['ctoModel (cto)']` (reverted before committing). This is precisely the silent-drop class BET-1175 targets.
- `src/renderer/Settings.tsx` line count decreases (no addition of unrequested code).