### PR TITLE
fix(server): contain vccall socket failures — never take down manta-server (BET-1177)

### DIFF
--- a/src/server/callWs.mjs
+++ b/src/server/callWs.mjs
@@ -83,7 +83,10 @@ export function attachCallWs(ws, url, opts = {}) {
       } catch {
         /* narration is best-effort; never breaks the call */
       }
-    })();
+    })().catch((err) => {
+      console.error("[callWs] narration failed:", err);
+      sendJson({ type: "error", error: "narration_failed" });
+    });
   }
 
   const engine = createVcCallEngine({
@@ -120,7 +123,13 @@ export function attachCallWs(ws, url, opts = {}) {
       },
     });
     await engine.start(cfg);
-  })();
+  })().catch((err) => {
+    // One call window failing is a call-window problem, never a box-wide
+    // outage: never let a boot failure become an unhandled rejection (which
+    // exits the process).
+    console.error("[callWs] engine.start failed:", err);
+    sendJson({ type: "error", error: "call_boot_failed" });
+  });
 
   ws.on("message", (raw) => {
     let msg;

--- a/src/server/callWs.test.mjs
+++ b/src/server/callWs.test.mjs
@@ -128,3 +128,28 @@ test("socket close tears down and clears the call-active flag (no silent session
   assert.equal(rt.closed, true);
   assert.equal(activeState[activeState.length - 1], false);
 });
+
+test("a rejected engine.start pushes an error frame and is not an unhandled rejection", async () => {
+  const client = makeClientWs();
+  const unhandled = [];
+  const onUnhandled = (reason) => {
+    unhandled.push(reason);
+  };
+  process.on("unhandledRejection", onUnhandled);
+  try {
+    attachCallWs(client, new URL("/call", "http://x"), {
+      // Deliberately NOT a ws (no .on): openTransport's configureTransport
+      // throws after the connect call, so engine.start rejects. The boot
+      // IIFE's .catch must contain it.
+      realtimeConnect: async () => ({ send() {} }),
+      configGet: async () => ({ openaiApiKey: "sk-test", cto: {} }),
+      listTools: () => [],
+    });
+    await new Promise((r) => setTimeout(r, 10));
+    const frames = client.clientSent.map((m) => JSON.parse(m));
+    assert.ok(frames.some((m) => m.type === "error"), "error frame pushed to renderer");
+    assert.equal(unhandled.length, 0, "no unhandled rejection surfaced");
+  } finally {
+    process.removeListener("unhandledRejection", onUnhandled);
+  }
+});

--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -253,7 +253,16 @@ export function createVcCallEngine(deps = {}) {
 
   function send(msg) {
     if (state.openai && typeof state.openai.send === "function") {
-      state.openai.send(typeof msg === "string" ? msg : JSON.stringify(msg));
+      // A websocket can close between any two writes; a send on a CONNECTING /
+      // CLOSED socket throws, and that must never take the server down. Publish
+      // an error frame instead of propagating (openTransport keeps running and
+      // the reconnect/close handlers own the retry).
+      try {
+        state.openai.send(typeof msg === "string" ? msg : JSON.stringify(msg));
+      } catch {
+        publish({ type: "error", error: "realtime_send_failed" });
+        return;
+      }
     }
   }
 
@@ -504,6 +513,48 @@ export function createVcCallEngine(deps = {}) {
   };
 }
 
+/**
+ * Resolve once `ws` is open; reject if it errors or closes before open. The
+ * realtimeConnect contract is "resolves with an OPEN socket" — openTransport
+ * writes to it immediately, and a write on a CONNECTING socket throws. Takes a
+ * ws-like EventEmitter (never references NodeWebSocket) and removes its
+ * listeners once settled.
+ *
+ * @param {import("events").EventEmitter & object} ws a ws-like instance
+ * @returns {Promise<object>} resolves with the same `ws` once open
+ */
+export function awaitOpen(ws) {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const cleanup = () => {
+      ws.removeListener("open", onOpen);
+      ws.removeListener("error", onError);
+      ws.removeListener("close", onClose);
+    };
+    const onOpen = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      resolve(ws);
+    };
+    const onError = (err) => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(err instanceof Error ? err : new Error(String(err)));
+    };
+    const onClose = () => {
+      if (settled) return;
+      settled = true;
+      cleanup();
+      reject(new Error("websocket closed before open"));
+    };
+    ws.on("open", onOpen);
+    ws.on("error", onError);
+    ws.on("close", onClose);
+  });
+}
+
 async function defaultRealtimeConnect(url, headers) {
-  return new NodeWebSocket(url, { headers });
+  return awaitOpen(new NodeWebSocket(url, { headers }));
 }

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { createVcCallEngine } from "./vccall.mjs";
+import { createVcCallEngine, awaitOpen } from "./vccall.mjs";
 
 // A fake OpenAI Realtime WebSocket: an EventEmitter whose .send captures
 // client→OpenAI messages and .close flips a flag. Tests drive the connection
@@ -257,4 +257,53 @@ test("regression: the Realtime socket authenticates with the OpenAI key, not the
   });
   assert.ok(capturedHeaders, "realtimeConnect was called");
   assert.equal(capturedHeaders.authorization, "Bearer sk-openai");
+});
+
+test("awaitOpen resolves once the socket emits open", async () => {
+  const ws = makeFakeWs();
+  const p = awaitOpen(ws);
+  ws.emit("open");
+  assert.equal(await p, ws);
+});
+
+test("awaitOpen rejects when the socket errors before open", async () => {
+  const ws = makeFakeWs();
+  const p = awaitOpen(ws);
+  ws.emit("error", new Error("connect refused"));
+  await assert.rejects(p);
+});
+
+test("awaitOpen rejects when the socket closes before open", async () => {
+  const ws = makeFakeWs();
+  const p = awaitOpen(ws);
+  ws.emit("close");
+  await assert.rejects(p);
+});
+
+test("awaitOpen removes all listeners once settled", async () => {
+  const ws = makeFakeWs();
+  const settled = awaitOpen(ws);
+  ws.emit("open");
+  await settled;
+  assert.equal(ws.listenerCount("open"), 0);
+  assert.equal(ws.listenerCount("error"), 0);
+  assert.equal(ws.listenerCount("close"), 0);
+});
+
+test("a socket whose send throws publishes an error frame and does not propagate (start resolves)", async () => {
+  const { engine, published } = makeEngine({
+    realtimeConnect: async () => {
+      const ws = makeFakeWs();
+      ws.send = () => {
+        throw new Error("socket dead");
+      };
+      return ws;
+    },
+  });
+  // start() must resolve (not reject) — the write failure is contained.
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  assert.ok(
+    published.some((m) => m.type === "error" && m.error === "realtime_send_failed"),
+    "error frame published on failed send",
+  );
 });


### PR DESCRIPTION
Fixes **BET-1177 (P0)**: opening the CTO call window could crash the whole `manta-server` process — a `session.update` sent synchronously after `realtimeConnect` resolves is thrown on a socket still in `CONNECTING` state, the rejection escapes the boot IIFE as an unhandled rejection, and Node exits. systemd restarts it, every session on the box loses its stream, and it can loop. Remotely triggerable by any paired client.

Three changes, all in `src/server/vccall.mjs` + `src/server/callWs.mjs`:

1. **`awaitOpen` (exported)** — the realtime connect contract is now "resolves with an OPEN socket". `defaultRealtimeConnect` awaits `awaitOpen(...)`, which resolves on `open` and rejects on `error` or `close`-before-open, removing its listeners once settled, and never references `NodeWebSocket`. `openTransport` is unchanged — a failed connect still lands in the existing `catch` → `scheduleReconnect("connect_error")` path.
2. **`send()` never throws** — the socket write is wrapped in try/catch; on failure it publishes `{type:"error", error:"realtime_send_failed"}` and returns. A websocket can close between any two writes, so this whole class of crash is closed, not just the one instance. `send()` is the single write path for the Realtime socket, so every write is covered.
3. **The call can never take the server down** — both floating IIFEs in `callWs.mjs` (boot + narration) now end with `.catch(...)` that logs and pushes an error frame to the renderer. One failing call window is a call-window problem, never a box-wide outage.

**Tests (node:test, sandboxed state dir):**
- `vccall.test.mjs`: `awaitOpen` resolves on `open`, rejects on `error`, rejects on `close`-before-open, and leaves no listeners after settling; a fake ws whose `send` throws does NOT propagate (start resolves, and an `error` frame is published).
- `callWs.test.mjs`: an `engine.start` that rejects pushes an error frame to the renderer and produces no unhandled rejection (asserted via `process.on("unhandledRejection")` — `attachCallWs` is not restructured).

**Do-not list honored:** no pre-open frame queue/buffer; reconnect/backoff, cost guard, and confirm flow untouched; OpenAI key resolution and Groq narration key untouched; no new dependency (`ws` was already a direct dep).

**Note — state after a successful connect:** the call window should read `connecting` → `live` on `session.created`. Manual box verification (server restart count unchanged, no `WebSocket is not open` in journalctl; invalid-key path shows a dropped/error state) requires a live box with `cto.enabled` true and an OpenAI key, which is out of reach for CI here.

**Verification results:**
- PR branch (`multica/BET-1177-cto-call-window-crash-fix` @ `264372b0`):
  - typecheck: exit 0. Errors: none. log sha256: `ae8e0b7ac4895ee3b75f134aaea70f6e6501c0306e995419eed26fe181391a88`
  - test: exit 0, 2503 pass / 0 fail / 0 skip. Failures: none. log sha256: `72a0beb0cff2aca0c6ab82d0f8745b53bc0ab8f1757cef5b5b49a6a3393532fe`
- Base (`main` @ `4bf9b923`):
  - typecheck: exit 0. Errors: none. log sha256: `ae8e0b7ac4895ee3b75f134aaea70f6e6501c0306e995419eed26fe181391a88`
  - test: exit 0, 2497 pass / 0 fail / 0 skip. Failures: none. log sha256: `5ae346bf521764b23fa740fddeacc78a1d9b11ffc77cae8afce7227234fcd048`
- **Conclusion:** 0 failures on either branch; 6 new tests (all passing) added by this PR. No pre-existing failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ `4bf9b923`**
