### PR TITLE
fix(server): migrate vccall Realtime client from retired beta interface to GA (BET-1178)

### DIFF
--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -26,7 +26,7 @@
 import { WebSocket as NodeWebSocket } from "ws";
 
 const REALTIME_BASE = "wss://api.openai.com/v1/realtime";
-const DEFAULT_REALTIME_MODEL = "gpt-4o-realtime-preview";
+const DEFAULT_REALTIME_MODEL = "gpt-realtime-2.1";
 const DEFAULT_VOICE = "alloy";
 
 // Cost cap defaults (USD). Per-call cap disconnects + notifies; a generous
@@ -168,7 +168,6 @@ export function createVcCallEngine(deps = {}) {
       setStatus("connecting");
       ws = await realtimeConnect(`${REALTIME_BASE}?model=${encodeURIComponent(model)}`, {
         authorization: `Bearer ${apiKey}`,
-        "openai-beta": "realtime=v1",
       });
     } catch (e) {
       scheduleReconnect("connect_error");
@@ -179,13 +178,21 @@ export function createVcCallEngine(deps = {}) {
     if (!state.startedAt) state.startedAt = now();
     configureTransport(ws);
     send({ type: "session.update", session: {
+      type: "realtime",
+      model,
       instructions: SESSION_INSTRUCTIONS,
-      voice,
-      modalities: ["audio", "text"],
-      input_audio_format: "pcm16",
-      output_audio_format: "pcm16",
+      output_modalities: ["audio"],
+      audio: {
+        input: {
+          format: { type: "audio/pcm", rate: 24000 },
+          turn_detection: { type: "server_vad", create_response: true },
+        },
+        output: {
+          format: { type: "audio/pcm" },
+          voice,
+        },
+      },
       tools: state.tools.map((t) => ({ type: "function", name: t.name, description: t.description, parameters: t.params })),
-      turn_detection: { type: "server_vad", create_response: true },
     }});
     armIdleTimer();
     return ws;
@@ -342,26 +349,34 @@ export function createVcCallEngine(deps = {}) {
     switch (evt.type) {
       case "session.created":
         return handleSessionCreated(evt);
-      case "response.audio.delta":
+      case "response.output_audio.delta":
         return handleAudioDelta(evt);
-      case "response.audio_transcript.delta": {
+      case "response.output_audio_transcript.delta": {
         const d = evt.delta ?? "";
         if (d) emit({ type: "transcript", delta: d, role: "cto" });
         return;
       }
-      case "response.audio_transcript.done": {
+      case "response.output_audio_transcript.done": {
         const t = evt.transcript ?? "";
         if (t) emit({ type: "transcript-finished", text: t, role: "cto" });
         return;
       }
       case "response.output_audio.done":
-      case "response.done":
         return armIdleTimer();
+      case "response.done": {
+        // GA's `response.done` carries complete function-call items in
+        // `response.output`; dispatch each one (the only function-call path).
+        const items = evt?.response?.output ?? [];
+        for (const item of items) {
+          if (item?.type === "function_call") await handleFunctionCall(item);
+        }
+        return armIdleTimer();
+      }
       case "input_audio_buffer.speech_started":
         return barge();
       case "input_audio_buffer.speech_stopped":
         return armIdleTimer();
-      case "conversation.item.created": {
+      case "conversation.item.added": {
         // User speech item → push STT text when available.
         if (evt?.item?.type === "message" && evt.item.role === "user") {
           for (const c of evt.item.content ?? []) {
@@ -377,10 +392,6 @@ export function createVcCallEngine(deps = {}) {
         if (t) emit({ type: "stt", text: t });
         return;
       }
-      case "response.function_call_arguments.done":
-        return handleFunctionCall(evt);
-      case "response.function_call_arguments.delta":
-        return; // accumulate in openai's built-in buffer; done carries full args
       case "error":
         return handleError(evt);
       default:
@@ -397,7 +408,7 @@ export function createVcCallEngine(deps = {}) {
   }
 
   function handleAudioDelta(evt) {
-    // Forward raw delta audio to the renderer to play (base64 opus).
+    // Forward raw delta audio to the renderer to play (PCM audio).
     if (evt?.delta) emit({ type: "audio", delta: evt.delta });
     armIdleTimer();
   }

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -26,7 +26,7 @@ function makeEngine(overrides = {}) {
   const config = {
     openaiApiKey: "sk-test",
     cto: {
-      model: "gpt-4o-realtime-preview",
+      model: "gpt-realtime-2.1",
       voice: "alloy",
       trustedActions: ["trusted_list_sessions"],
     },
@@ -69,10 +69,11 @@ test("start connects and sends a session.update with the tools configured", asyn
   const sent = json(ws);
   assert.ok(sent.some((m) => m.type === "session.update"), "session.update sent");
   const su = sent.find((m) => m.type === "session.update");
-  assert.equal(su.session.voice, "nova");
-  assert.equal(su.session.modalities.join(","), "audio,text");
+  assert.equal(su.session.type, "realtime");
+  assert.equal(su.session.audio.output.voice, "nova");
+  assert.equal(su.session.audio.input.turn_detection.type, "server_vad");
+  assert.equal(su.session.output_modalities.join(","), "audio");
   assert.equal(su.session.tools.length, 2);
-  assert.equal(su.session.turn_detection.type, "server_vad");
   assert.equal(stateLog[0], "connecting");
 
   // Server → client: session.created flips the call live.
@@ -86,10 +87,12 @@ test("function-call round-trip: dispatches to cto, emits working + cost, complet
   engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
 
   await engine.receiveRealtime({
-    type: "response.function_call_arguments.done",
-    call_id: "call-1",
-    name: "trusted_list_sessions",
-    arguments: "{}",
+    type: "response.done",
+    response: {
+      output: [
+        { type: "function_call", call_id: "call-1", name: "trusted_list_sessions", arguments: "{}" },
+      ],
+    },
   });
 
   assert.equal(calls.length, 1);
@@ -110,10 +113,12 @@ test("voice confirm: gated tool pauses, re-issue (spoken go-ahead) approves and 
 
   // First call to a gated, untrusted action → pause for go-ahead.
   await engine.receiveRealtime({
-    type: "response.function_call_arguments.done",
-    call_id: "call-1",
-    name: "confirmable_action",
-    arguments: "{\"x\":1}",
+    type: "response.done",
+    response: {
+      output: [
+        { type: "function_call", call_id: "call-1", name: "confirmable_action", arguments: "{\"x\":1}" },
+      ],
+    },
   });
   assert.equal(published.some((m) => m.type === "confirm" && m.id === "cid-1"), true);
   assert.equal(await engine.listState().pendingConfirm?.tool, "confirmable_action");
@@ -125,10 +130,12 @@ test("voice confirm: gated tool pauses, re-issue (spoken go-ahead) approves and 
   calls.length = 0;
   const before = calls.length;
   await engine.receiveRealtime({
-    type: "response.function_call_arguments.done",
-    call_id: "call-2",
-    name: "confirmable_action",
-    arguments: "{\"x\":1}",
+    type: "response.done",
+    response: {
+      output: [
+        { type: "function_call", call_id: "call-2", name: "confirmable_action", arguments: "{\"x\":1}" },
+      ],
+    },
   });
   assert.ok(ws.approved?.includes("cid-1"), "approveConfirm called on the spoken go-ahead");
   // dispatchCto ran a second time (the approved re-dispatch).
@@ -136,6 +143,21 @@ test("voice confirm: gated tool pauses, re-issue (spoken go-ahead) approves and 
   assert.equal(published.some((m) => m.type === "confirm-resolved" && m.ok === true), true);
   assert.equal(await engine.listState().pendingConfirm, null);
   assert.equal(before, 0);
+});
+
+test("GA event names: output_audio delta + transcript deltas publish audio/transcript (BET-1178)", async () => {
+  const { engine, published } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+
+  engine.receiveRealtime({ type: "response.output_audio.delta", delta: "AAE=" });
+  assert.equal(published.some((m) => m.type === "audio" && m.delta === "AAE="), true);
+
+  engine.receiveRealtime({ type: "response.output_audio_transcript.delta", delta: "Hello" });
+  assert.equal(published.some((m) => m.type === "transcript" && m.delta === "Hello" && m.role === "cto"), true);
+
+  engine.receiveRealtime({ type: "response.output_audio_transcript.done", transcript: "Hello world" });
+  assert.equal(published.some((m) => m.type === "transcript-finished" && m.text === "Hello world"), true);
 });
 
 test("barge: speech_started cancels the in-flight response and notifies the renderer", async () => {
@@ -158,10 +180,12 @@ test("narration seam: onNarrate is threaded into the dispatch ctx", async () => 
   await engine.start({ openaiApiKey: "sk-test", cto: {} });
   engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
   await engine.receiveRealtime({
-    type: "response.function_call_arguments.done",
-    call_id: "c",
-    name: "trusted_list_sessions",
-    arguments: "{}",
+    type: "response.done",
+    response: {
+      output: [
+        { type: "function_call", call_id: "c", name: "trusted_list_sessions", arguments: "{}" },
+      ],
+    },
   });
   assert.equal(typeof calls[0].ctx.onNarrate, "function");
   // Call it and confirm the injected seam fires.
@@ -257,6 +281,20 @@ test("regression: the Realtime socket authenticates with the OpenAI key, not the
   });
   assert.ok(capturedHeaders, "realtimeConnect was called");
   assert.equal(capturedHeaders.authorization, "Bearer sk-openai");
+});
+
+test("regression: the connect headers carry no openai-beta key (GA, not the retired beta interface) (BET-1178)", async () => {
+  let capturedHeaders = null;
+  const { engine } = makeEngine({
+    realtimeConnect: async (url, headers) => {
+      capturedHeaders = headers;
+      return makeFakeWs();
+    },
+  });
+  await engine.start({ openaiApiKey: "sk-openai", cto: {} });
+  assert.ok(capturedHeaders, "realtimeConnect was called");
+  assert.equal(capturedHeaders.authorization, "Bearer sk-openai");
+  assert.ok(!Object.keys(capturedHeaders).some((k) => k.toLowerCase() === "openai-beta"), "no openai-beta header");
 });
 
 test("awaitOpen resolves once the socket emits open", async () => {


### PR DESCRIPTION
## What

Migrate the on-call CTO Realtime client (`src/server/vccall.mjs`) from the retired OpenAI Realtime **beta** interface to GA. URL and transport unchanged (still `wss://api.openai.com/v1/realtime?model=…` server-to-server, Bearer auth).

### Changes
- **Connection**: removed the `openai-beta: realtime=v1` header (its presence is what selected the retired interface → the reported rejection). Header set is now just `authorization`. URL untouched.
- **Model**: `DEFAULT_REALTIME_MODEL` `gpt-4o-realtime-preview` → `gpt-realtime-2.1`. `DEFAULT_VOICE` stays `alloy`.
- **`session.update`**: replaced the beta body with the GA shape — `session.type: "realtime"`, `model`, `output_modalities: ["audio"]`, nested `audio.input.format` (`audio/pcm`, 24000 Hz) + `audio.input.turn_detection`, `audio.output.format` + `audio.output.voice`. `tools` array unchanged (still `{type:"function",name,description,parameters}`).
- **Server-event names** (GA renames): `response.audio.delta` → `response.output_audio.delta`, `response.audio_transcript.delta` → `response.output_audio_transcript.delta`, `response.audio_transcript.done` → `response.output_audio_transcript.done`, `conversation.item.created` → `conversation.item.added`.
- **Function calls — one path**: deleted BOTH `response.function_call_arguments.{done,delta}` branches. Dispatch now happens from the existing `response.done` case: for each item in `evt.response.output` with `type === "function_call"`, call `handleFunctionCall(item)`, then arm the idle timer. `handleFunctionCall` is unchanged — a GA `function_call` output item carries `name`, `arguments` (JSON string), `call_id`, exactly what it already reads. Reply path (`conversation.item.create` with `function_call_output` + `response.create`) unchanged; confirm/gate logic untouched.
- **Comment**: `handleAudioDelta` said "base64 opus"; the audio is PCM, now corrected.

## Out of scope (noted per issue)
- **Input-audio transcription**: the `conversation.item.input_audio_transcription.completed` handler is unchanged. Nothing enables transcription in `session.update`, so it never fires — true before and after this change. Enabling it is a separate decision.
- WebRTC / ephemeral client secrets / `/v1/realtime/calls` / SIP / truncate-on-barge: untouched. `barge()` still sends `response.cancel` only.
- No new files, no new dependency, no renderer changes.

## Manual verification
This environment has no live OpenAI Realtime key to drive the call window, so I could not run the on-box manual step (open call window → speak → hear reply). Automated verification below is the honest signal I have. Signals a manual test should confirm on a keyed box: `session.created` received, `output_audio` deltas flowing, one `function_call` round-tripping via `response.done`.

<details>
<summary><b>Verification results</b></summary>

**Files changed:** 2 files. `src/server/vccall.mjs`, `src/server/vccall.test.mjs`

- PR branch (`multica/BET-1178-realtime-ga` @ `7af8c4a9`):
  - typecheck: exit 0. Errors: none. log sha256: `23c488aee7094d63f775bfa2d8f7b8aaab8573fb2b08b85c9fc77c7c42a26759`
  - test: exit 0, 2505 pass / 0 fail / 0 skip. Failures: none. log sha256: `15a4f713217af66164b937c510962f6bae860af932f8e1b51abc463f9766802b`
- Base (`main` @ `d0cdc581`):
  - typecheck: exit 0. Errors: none. log sha256: `23c488aee7094d63f775bfa2d8f7b8aaab8573fb2b08b85c9fc77c7c42a26759`
  - test: exit 0, 2503 pass / 0 fail / 0 skip. Failures: none. log sha256: `8f3e3c7ad99170bb98221790f17a68e9366bd9d1df7344ad589d934098bc1be1`
- **Base: origin/main @ `d0cdc581`**
- **Conclusion:** 2 test failures are new-ish — actually 0 pre-existing + 2 new passing tests added by this PR (connect-headers-no-beta, GA audio/transcript event names). 0 failures on either branch.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
</details>
