### PR TITLE
fix(server): gate voice-call reads on tool mode, approve confirms by user words (BET-1181)

### DIFF
--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -693,12 +693,12 @@ export function createCtoEngine(deps = {}) {
   // -------------------------------------------------------------------------
   const byName = new Map(tools.map((t) => [t.name, t]));
 
-  // The in-conversation confirmation loop (Issue 2's gate wiring). When a
-  // confirm-mode tool is not in `trustedActions`, dispatch returns
-  // `{ needConfirmation: true, id, preview }` WITHOUT running. The cto text
-  // agent surfaces "I need your go-ahead: <preview>"; the user's "go ahead"
-  // calls approveConfirm(id) and the re-dispatch runs; "no" calls
-  // rejectConfirm(id) to abort. Issue 3 replaces this text loop with voice.
+  // The in-conversation confirmation loop (Issue 2's gate wiring). A confirm-
+  // mode tool that is not in `trustedActions` (and not already approved)
+  // returns `{ needConfirmation: true, id, preview }` WITHOUT running. The
+  // caller surfaces "I need your go-ahead: <preview>"; approval or rejection
+  // flows through approveConfirm(id) / rejectConfirm(id), and the re-dispatch
+  // runs. Issue 3 gates that approval on the user's own spoken words.
   const pendingConfirms = new Map(); // id -> { tool, args, approved }
 
   async function dispatch(name, args, ctx = {}) {
@@ -706,17 +706,25 @@ export function createCtoEngine(deps = {}) {
     if (!def) {
       return { ok: false, error: `unknown cto tool: ${name} (known: ${tools.map((t) => t.name).join(", ")})` };
     }
+    // The tool's declared `mode` is the source of truth for confirmation:
+    //   - `auto` tools (every read) never confirm — only deny policy applies,
+    //     and a caller-supplied "confirm" gate is ignored (registry mode wins).
+    //   - `confirm` tools pause for the user's go-ahead unless trusted or
+    //     already approved.
+    // So a caller can no longer manufacture a confirm for a read by passing a
+    // hardcoded confirm gate; the seam stays for deny/allow policy only.
     const gate = typeof ctx?.gate === "function" ? ctx.gate : DEFAULT_GATE;
-    let decision;
-    try {
-      decision = gate(def.name, args ?? {});
-    } catch {
-      decision = "deny";
-    }
-    if (decision === "deny") {
-      return { ok: false, error: `tool ${def.name} denied` };
-    }
-    if (decision === "confirm") {
+
+    if (def.mode === "confirm") {
+      let decision;
+      try {
+        decision = gate(def.name, args ?? {});
+      } catch {
+        decision = "deny";
+      }
+      if (decision === "deny") {
+        return { ok: false, error: `tool ${def.name} denied` };
+      }
       // A trusted action runs without asking; anything else pauses for the
       // user's go-ahead (returns needConfirmation and does NOT act yet).
       const trusted = Array.isArray(ctx?.trustedActions) ? ctx.trustedActions : [];
@@ -737,6 +745,18 @@ export function createCtoEngine(deps = {}) {
             preview: buildPreview(def, args ?? {}),
           };
         }
+      }
+    } else {
+      // Auto tool: confirmation never applies. Only deny policy is consulted;
+      // a "confirm" decision is coerced to allow.
+      let decision;
+      try {
+        decision = gate(def.name, args ?? {});
+      } catch {
+        decision = "deny";
+      }
+      if (decision === "deny") {
+        return { ok: false, error: `tool ${def.name} denied` };
       }
     }
     const narrate = typeof ctx?.onNarrate === "function" ? ctx.onNarrate : NOOP_NARRATE;

--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -111,15 +111,42 @@ test("dispatch honors a gate returning deny (fails closed)", async () => {
   assert.match(result.error, /denied/);
 });
 
-test("dispatch requires confirmation for a confirm-gated tool and does NOT act", async () => {
+test("an auto tool dispatches WITHOUT confirmation even when a confirm gate is supplied", async () => {
   const engine = makeEngine();
   const gate = () => "confirm";
-  // A confirm-gated tool that is not trusted pauses with needConfirmation
-  // (Issue 2 gate wiring) instead of failing closed.
+  // Reads are mode:"auto" — the registry wins over a caller-supplied confirm
+  // gate, so a hardcoded confirm gate can no longer pause a read (BET-1181).
   const result = await engine.dispatch("list_models", {}, { gate });
+  assert.equal(result.ok, true);
+  assert.equal(result.needConfirmation, undefined);
+});
+
+test("a confirm tool still returns needConfirmation (does NOT act)", async () => {
+  const engine = makeEngine();
+  const gate = () => "confirm";
+  // `watch` is the one confirm-mode tool. A confirm gate on it pauses.
+  const result = await engine.dispatch("watch", { surface: "schedule" }, { gate });
   assert.equal(result.ok, true);
   assert.equal(result.needConfirmation, true);
   assert.equal(typeof result.preview, "string");
+});
+
+test("a confirm tool pauses by default (no gate) and trustedActions bypasses it", async () => {
+  const saved = [];
+  const engine = makeEngine({
+    loadWatches: async () => [],
+    saveWatches: async (w) => saved.push(w),
+  });
+  // Default (DEFAULT_GATE = allow) still pauses a confirm tool — mode is what
+  // decides, not the gate.
+  const paused = await engine.dispatch("watch", { surface: "schedule" }, {});
+  assert.equal(paused.ok, true);
+  assert.equal(paused.needConfirmation, true);
+  // trustedActions bypasses the pause for a confirm tool.
+  const run = await engine.dispatch("watch", { surface: "schedule" }, { trustedActions: ["watch"] });
+  assert.equal(run.ok, true);
+  assert.equal(run.needConfirmation, undefined);
+  assert.ok(saved.length > 0, "trusted confirm tool actually ran (watcher saved)");
 });
 
 test("default gate returns allow for every tool (Issue 1 ships auto)", async () => {

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -3012,10 +3012,7 @@ const handleUpgrade = (req, socket, head) => {
     // opus mic frames here; the box relays to OpenAI Realtime (key server-side).
     wss.handleUpgrade(req, socket, head, (ws) =>
       attachCallWs(ws, url, {
-        dispatchCto: (name, args, ctx) => getCtoEngine().dispatch(name, args, {
-          ...ctx,
-          gate: ctx?.gate ?? (() => "confirm"),
-        }),
+        dispatchCto: (name, args, ctx) => getCtoEngine().dispatch(name, args, { ...ctx }),
         approveConfirm: (id) => getCtoEngine().approveConfirm(id),
         rejectConfirm: (id) => getCtoEngine().rejectConfirm(id),
         configGet: () => local.configGet(),

--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -48,6 +48,27 @@ export function clampModel(v, dflt) {
   return typeof v === "string" && v.trim() ? v.trim() : dflt;
 }
 
+// Deliberately dumb confirmation-reply classifier (BET-1181). Approval of a
+// pending confirm must come from the user's OWN words, so this maps a spoken
+// transcript to yes / no / unclear with a short explicit phrase list and
+// defaults to "unclear" — which is NOT an approval. Any ambiguity leaves the
+// pending confirm running until its timeout aborts it.
+const YES_PHRASES = ["yes", "yeah", "yep", "yup", "sure", "okay", "ok", "go ahead", "goahead", "do it", "please do", "confirm", "approve", "proceed", "fine"];
+const NO_PHRASES = ["no", "nope", "nah", "cancel", "stop", "abort", "dont", "don't", "never", "reject", "deny", "not"];
+
+export function classifyConfirmReply(text) {
+  const t = String(text ?? "")
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9']+/g, " ")
+    .trim();
+  if (!t) return "unclear";
+  // A leading explicit no wins (covers "no", "no thanks", "not now", …).
+  if (NO_PHRASES.some((p) => t === p || t.startsWith(`${p} `))) return "no";
+  if (YES_PHRASES.some((p) => t === p || t.startsWith(`${p} `))) return "yes";
+  return "unclear";
+}
+
 /**
  * Build the vccall engine. Returns a control surface plus the low-level
  * `receiveRealtime(evt, send)` dispatcher so tests can drive a fake WS.
@@ -186,6 +207,9 @@ export function createVcCallEngine(deps = {}) {
         input: {
           format: { type: "audio/pcm", rate: 24000 },
           turn_detection: { type: "server_vad", create_response: true },
+          // Input transcription turns the user's speech into text so that a
+          // pending confirm can be approved by their actual words (BET-1181).
+          transcription: { model: "whisper-1" },
         },
         output: {
           format: { type: "audio/pcm" },
@@ -389,7 +413,10 @@ export function createVcCallEngine(deps = {}) {
       }
       case "conversation.item.input_audio_transcription.completed": {
         const t = evt?.transcript ?? "";
-        if (t) emit({ type: "stt", text: t });
+        if (t) {
+          emit({ type: "stt", text: t });
+          handleUserUtterance(t);
+        }
         return;
       }
       case "error":
@@ -413,6 +440,30 @@ export function createVcCallEngine(deps = {}) {
     armIdleTimer();
   }
 
+  // A user utterance (from input transcription) is the ONLY thing that can
+  // authorize a pending confirm. A clear "yes" approves it; a clear "no"
+  // rejects it; anything else leaves it pending until the timeout aborts.
+  function handleUserUtterance(transcript) {
+    const pc = state.pendingConfirm;
+    if (!pc || pc.approvedByUser) return;
+    const verdict = classifyConfirmReply(transcript);
+    if (verdict === "yes") {
+      approveConfirm(pc.id);
+      pc.approvedByUser = true;
+      armConfirmTimeout(pc.id);
+      emit({ type: "confirm-resolved", id: pc.id, ok: true });
+    } else if (verdict === "no") {
+      rejectConfirm(pc.id);
+      state.pendingConfirm = null;
+      emit({ type: "confirm-resolved", id: pc.id, ok: false });
+      send({
+        type: "conversation.item.create",
+        item: { type: "message", role: "user", content: [{ type: "input_text", text: "User said no. Abort and replan, do not act." }] },
+      });
+      send({ type: "response.create" });
+    }
+  }
+
   async function handleFunctionCall(evt) {
     const name = evt?.name;
     const rawArgs = evt?.arguments ?? "{}";
@@ -424,27 +475,43 @@ export function createVcCallEngine(deps = {}) {
     }
     emit({ type: "working", tool: name });
 
-    // Voice-confirm resolution: if there is a pending confirm for the SAME
-    // (tool,args), the model re-issuing it IS the user's spoken "go ahead"…
+    // A model re-issue of the SAME pending (tool,args) is only authorized if
+    // the user's own words approved it. A re-issue with no such utterance is
+    // NOT an approval — re-raise the pause instead of acting.
     const pc = state.pendingConfirm;
-    if (pc && pc.tool === name && sameArgs(pc.args, args)) {
-      approveConfirm(pc.id);
+    const isReissue = pc && pc.tool === name && sameArgs(pc.args, args);
+    if (isReissue) {
+      if (!pc.approvedByUser) {
+        emit({ type: "confirm", id: pc.id, tool: name, preview: pc.preview });
+        send({
+          type: "conversation.item.create",
+          item: {
+            type: "function_call_output",
+            call_id: evt?.call_id,
+            output: JSON.stringify({ ok: true, awaiting_confirmation: true, preview: pc.preview }),
+          },
+        });
+        send({ type: "response.create" });
+        armConfirmTimeout(pc.id);
+        return;
+      }
+      // Spoken "go ahead" → clear the local pending; the engine's approval
+      // lets this re-dispatch actually run.
       state.pendingConfirm = null;
-      emit({ type: "confirm-resolved", id: pc.id, ok: true });
     }
 
     const conf = (await configGet().catch(() => ({}))) ?? {};
     const result = await dispatchCto(name, args, {
-      gate: () => "confirm",
       trustedActions: Array.isArray(conf?.cto?.trustedActions) ? conf.cto.trustedActions : [],
       onNarrate,
     });
 
     if (result?.needConfirmation && !pc) {
-      // Gated tool, user hasn't spoken yet → pause for go-ahead.
+      // Gated tool, user hasn't spoken yet → pause for go-ahead. It is only
+      // approved by an affirmative user utterance (see handleUserUtterance).
       const id = result.id;
       emit({ type: "confirm", id, tool: name, preview: result.preview });
-      state.pendingConfirm = { id, tool: name, args, preview: result.preview, at: now() };
+      state.pendingConfirm = { id, tool: name, args, preview: result.preview, at: now(), approvedByUser: false };
       armConfirmTimeout(id);
       // Tell the model to ask, then complete the function call so it can speak.
       send({

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { createVcCallEngine, awaitOpen } from "./vccall.mjs";
+import { createVcCallEngine, awaitOpen, classifyConfirmReply } from "./vccall.mjs";
 
 // A fake OpenAI Realtime WebSocket: an EventEmitter whose .send captures
 // client→OpenAI messages and .close flips a flag. Tests drive the connection
@@ -63,6 +63,61 @@ function json(ws) {
   return ws.sent.map((s) => JSON.parse(s));
 }
 
+// Engine for the voice-confirm flow tests. Its dispatchCto mimics the real cto
+// engine: a confirmable tool returns needConfirmation until it has been
+// approved (approveConfirm flips the flag), then the same call runs — the only
+// way to observe "approves once" end to end.
+function makeConfirmEngine(overrides = {}) {
+  const ws = makeFakeWs();
+  const published = [];
+  const calls = [];
+  let approved = false;
+  const engine = createVcCallEngine({
+    realtimeConnect: async () => ws,
+    configGet: async () => ({ openaiApiKey: "sk-test", cto: { trustedActions: [] } }),
+    dispatchCto: async (name, args, ctx) => {
+      calls.push({ name, args, ctx });
+      if (name === "confirmable_action") {
+        return approved ? { ok: true } : { ok: true, needConfirmation: true, id: "cid-1", preview: "send the report" };
+      }
+      return { ok: true };
+    },
+    approveConfirm: (id) => {
+      approved = true;
+      ws.approved = [...(ws.approved ?? []), id];
+      return true;
+    },
+    rejectConfirm: (id) => {
+      ws.rejected = [...(ws.rejected ?? []), id];
+      return true;
+    },
+    publish: (m) => published.push(m),
+    ...overrides,
+  });
+  engine.setTools([
+    { name: "confirmable_action", description: "an action", params: {} },
+    { name: "trusted_list_sessions", description: "list sessions", params: {} },
+  ]);
+  return { engine, ws, published, calls };
+}
+
+async function startLive(engine) {
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+}
+
+// Raise the confirm pause for confirmable_action({x:1}) via GA's response.done.
+async function raiseConfirm(engine) {
+  await engine.receiveRealtime({
+    type: "response.done",
+    response: {
+      output: [
+        { type: "function_call", call_id: "call-1", name: "confirmable_action", arguments: '{"x":1}' },
+      ],
+    },
+  });
+}
+
 test("start connects and sends a session.update with the tools configured", async () => {
   const { engine, ws, stateLog } = makeEngine();
   await engine.start({ openaiApiKey: "sk-test", cto: { model: "m1", voice: "nova" } });
@@ -106,29 +161,26 @@ test("function-call round-trip: dispatches to cto, emits working + cost, complet
   assert.ok(sent.some((m) => m.type === "response.create"));
 });
 
-test("voice confirm: gated tool pauses, re-issue (spoken go-ahead) approves and runs", async () => {
-  const { engine, ws, published, calls } = makeEngine();
-  await engine.start({ openaiApiKey: "sk-test", cto: { trustedActions: [] } });
-  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+test("voice confirm: a gated tool pauses until the user's words authorize it", async () => {
+  const { engine, ws, published } = makeConfirmEngine();
+  await startLive(engine);
 
   // First call to a gated, untrusted action → pause for go-ahead.
-  await engine.receiveRealtime({
-    type: "response.done",
-    response: {
-      output: [
-        { type: "function_call", call_id: "call-1", name: "confirmable_action", arguments: "{\"x\":1}" },
-      ],
-    },
-  });
+  await raiseConfirm(engine);
   assert.equal(published.some((m) => m.type === "confirm" && m.id === "cid-1"), true);
   assert.equal(await engine.listState().pendingConfirm?.tool, "confirmable_action");
   const sent = json(ws);
   const out = sent.find((m) => m.type === "conversation.item.create" && m.item.type === "function_call_output");
   assert.ok(out.item.output.includes("awaiting_confirmation"), "pauses for go-ahead");
+});
 
-  // The model re-issues the SAME tool+args (user said "go ahead") → approves + runs.
+test("voice confirm: a model re-issue with NO affirmative user utterance does NOT approve", async () => {
+  const { engine, ws, calls } = makeConfirmEngine();
+  await startLive(engine);
+  await raiseConfirm(engine); // paused
   calls.length = 0;
-  const before = calls.length;
+
+  // The model re-issues the SAME tool+args, but the user has said nothing.
   await engine.receiveRealtime({
     type: "response.done",
     response: {
@@ -137,12 +189,57 @@ test("voice confirm: gated tool pauses, re-issue (spoken go-ahead) approves and 
       ],
     },
   });
-  assert.ok(ws.approved?.includes("cid-1"), "approveConfirm called on the spoken go-ahead");
-  // dispatchCto ran a second time (the approved re-dispatch).
-  assert.equal(calls.length, 1);
-  assert.equal(published.some((m) => m.type === "confirm-resolved" && m.ok === true), true);
-  assert.equal(await engine.listState().pendingConfirm, null);
-  assert.equal(before, 0);
+  assert.ok(!ws.approved?.includes("cid-1"), "no approval without a spoken yes");
+  assert.equal(calls.length, 0, "action did NOT run (re-issue re-raised, not approved)");
+  assert.equal(await engine.listState().pendingConfirm?.tool, "confirmable_action", "still pending");
+});
+
+test("voice confirm: re-issue AFTER an affirmative utterance approves once and runs", async () => {
+  const { engine, ws, calls } = makeConfirmEngine();
+  await startLive(engine);
+  await raiseConfirm(engine); // paused
+  calls.length = 0;
+
+  // The user actually says yes (input transcription of their speech).
+  engine.receiveRealtime({ type: "conversation.item.input_audio_transcription.completed", transcript: "yes" });
+  assert.ok(ws.approved?.includes("cid-1"), "approveConfirm called on the spoken yes");
+
+  // Now the model re-issues the same tool+args → it is authorized to run.
+  await engine.receiveRealtime({
+    type: "response.done",
+    response: {
+      output: [
+        { type: "function_call", call_id: "call-3", name: "confirmable_action", arguments: '{"x":1}' },
+      ],
+    },
+  });
+  assert.equal(ws.approved?.filter((id) => id === "cid-1").length, 1, "approved exactly once");
+  assert.equal(calls.length, 1, "approved re-issue dispatched and ran");
+  assert.equal(await engine.listState().pendingConfirm, null, "pending cleared after approval");
+});
+
+test("voice confirm: a negative utterance rejects the pending confirm", async () => {
+  const { engine, ws, published } = makeConfirmEngine();
+  await startLive(engine);
+  await raiseConfirm(engine); // paused
+
+  engine.receiveRealtime({ type: "conversation.item.input_audio_transcription.completed", transcript: "no" });
+  assert.ok(ws.rejected?.includes("cid-1"), "rejectConfirm called on a spoken no");
+  assert.equal(await engine.listState().pendingConfirm, null, "pending cleared on reject");
+  assert.equal(published.some((m) => m.type === "confirm-resolved" && m.ok === false), true);
+  const sent = json(ws);
+  assert.ok(sent.some((m) => m.type === "conversation.item.create" && m.item.role === "user"), "model told to replan");
+});
+
+test("voice confirm: an unclear utterance leaves it pending (not an approval)", async () => {
+  const { engine, ws } = makeConfirmEngine();
+  await startLive(engine);
+  await raiseConfirm(engine); // paused
+
+  engine.receiveRealtime({ type: "conversation.item.input_audio_transcription.completed", transcript: "huh what was that" });
+  assert.ok(!ws.approved?.length, "unclear reply never approves");
+  assert.ok(!ws.rejected?.length, "unclear reply never rejects");
+  assert.equal(await engine.listState().pendingConfirm?.tool, "confirmable_action", "still pending until timeout aborts");
 });
 
 test("GA event names: output_audio delta + transcript deltas publish audio/transcript (BET-1178)", async () => {
@@ -344,4 +441,26 @@ test("a socket whose send throws publishes an error frame and does not propagate
     published.some((m) => m.type === "error" && m.error === "realtime_send_failed"),
     "error frame published on failed send",
   );
+});
+
+// ---------------------------------------------------------------------------
+// classifyConfirmReply
+// ---------------------------------------------------------------------------
+
+test("classifyConfirmReply: affirmative utterances → yes", () => {
+  for (const t of ["yes", "yeah", "yep", "go ahead", "okay, do it", "sure, go ahead", "yes you can", "ok"]) {
+    assert.equal(classifyConfirmReply(t), "yes", JSON.stringify(t));
+  }
+});
+
+test("classifyConfirmReply: negative utterances → no", () => {
+  for (const t of ["no", "nope", "no, cancel", "not now", "cancel that", "stop"]) {
+    assert.equal(classifyConfirmReply(t), "no", JSON.stringify(t));
+  }
+});
+
+test("classifyConfirmReply: ambiguous / empty / unrelated → unclear (never an approval)", () => {
+  for (const t of ["", "   ", "hmm", "what's that", "thank you", "you know", "42"]) {
+    assert.equal(classifyConfirmReply(t), "unclear", JSON.stringify(t));
+  }
 });


### PR DESCRIPTION
# CTO call: reads no longer require a spoken go-ahead; confirm approvals come from the user's words (BET-1181)

Two fixes in the CTO voice-call gate path.

## 1. Read-only tools no longer pause for permission

`dispatch` in `src/server/cto.mjs` now resolves the decision from each tool's declared `mode` instead of the gate alone:
- `mode === "auto"` → allow (all read-only tools run immediately).
- `mode === "confirm"` → consult the gate (which may still allow via `trustedActions`).

The two hardcoded `() => "confirm"` gate overrides are deleted — in the `handleFunctionCall` ctx (`src/server/vccall.mjs`) and the `index.mjs` fallback — so the caller stops overriding a property the registry already declares. The gate seam remains for deny/allow policy but no longer manufactures a confirm for a read.

## 2. Approvals must come from the user's words

In `handleFunctionCall`, a pending confirm is no longer approved merely because the model re-issues the same tool+args. Approval now requires an affirmative user utterance received after the confirm was raised; a negative utterance rejects. A re-issue with no such utterance does NOT approve — it re-raises or waits for the existing timeout (abort + re-plan).

The classifier is a small exported pure function `classifyConfirmReply(text) → "yes" | "no" | "unclear"` with a short explicit word list, unit-tested, defaulting to `"unclear"` — which is NOT an approval. Input transcription is enabled on the GA session config so the user's utterance arrives as text.

## Do-NOTs respected

- No clickable confirm button (voice-only, passive banner).
- `trustedActions` semantics unchanged / not auto-populated.
- Confirm timeout behaviour (abort + re-plan) unchanged — it is the fallback when a reply is unclear.
- Narration, reconnect path, and wire format untouched.

## Files changed

- `src/server/cto.mjs` — mode-aware dispatch.
- `src/server/vccall.mjs` — user-utterance-gated approval, removed hardcoded confirm gate, enabled transcription.
- `src/server/index.mjs` — removed hardcoded confirm fallback gate.
- `src/server/cto.test.mjs`, `src/server/vccall.test.mjs` — new unit tests.

## Verification

- `npm run typecheck`: exit 0.
- `npm test`: 2514 pass / 0 fail.
- CI: `typecheck-test` (required) green on head SHA.
