### PR TITLE
fix(server): park stops the CTO call; idle + spend caps now fire (BET-1180)

### DIFF
--- a/generated/swift/SettingsSchema.swift
+++ b/generated/swift/SettingsSchema.swift
@@ -272,20 +272,6 @@ enum SettingsSchema {
             commitOnBlur: false,
             placeholder: nil,
         ),
-        SettingEntry(
-            id: "ctoParkedBehavior",
-            section: "cto",
-            label: "When parked",
-            help: "What the box does with an inbound CTO event while no call is open.",
-            control: SettingControl.segmented,
-            configKey: "cto.parkedBehavior",
-            defaultString: "auto-open",
-            defaultBool: nil,
-            defaultNumber: nil,
-            options: [SettingOption(value: "auto-open", label: "Auto-open"), SettingOption(value: "push", label: "Notify only")],
-            commitOnBlur: false,
-            placeholder: nil,
-        ),
     ]
 
     static func entries(in sectionID: String) -> [SettingEntry] {

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -500,7 +500,6 @@ export function Settings({
       "cto.model": cto?.model ?? "",
       "cto.voice": cto?.voice ?? "",
       "cto.alwaysListening": cto?.alwaysListening ?? false,
-      "cto.parkedBehavior": cto?.parkedBehavior ?? "auto-open",
     }),
     [cacheTtl, groqApiKey, voiceTranscriptionModel, openaiApiKey, allowAgentPush, downloadsDir, worktreePerSession, worktreeCleanOnClose, uploadCleanupHours, voiceNoteTtlHours, theme, autoRenameSessions, alwaysShowUsage, cto],
   );

--- a/src/renderer/call/CallApp.tsx
+++ b/src/renderer/call/CallApp.tsx
@@ -348,8 +348,11 @@ export function CallApp() {
     wsRef.current?.send(JSON.stringify({ type: "control", action: "park" }));
     micStreamRef.current?.getTracks().forEach((t) => t.stop());
     micStreamRef.current = null;
+    // Mic is off once parked, so the indicator reads "off" (the manual spec:
+    // "the mic indicator is off"). A parked call's engine is torn down anyway;
+    // if the window is later re-shown the user toggles Talk to restart the mic.
+    setListening(false);
     setStatus("parked");
-    setListening(true);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__mantaPreload?.call?.park?.();
   }

--- a/src/renderer/call/CallApp.tsx
+++ b/src/renderer/call/CallApp.tsx
@@ -327,15 +327,29 @@ export function CallApp() {
   }
 
   async function hangup() {
+    // Tell the box to tear the call down BEFORE closing the socket: the
+    // server's control:hangup path hangs up the engine, and the ws.on("close")
+    // teardown remains as the backstop for a window that vanishes without
+    // warning.
+    wsRef.current?.send(JSON.stringify({ type: "control", action: "hangup" }));
     setStatus("disconnected");
     wsRef.current?.close();
     micStreamRef.current?.getTracks().forEach((t) => t.stop());
+    micStreamRef.current = null;
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__mantaPreload?.call?.hangup?.();
   }
 
   function park() {
+    // Park must actually stop the call from the box's perspective: send the
+    // control:park frame (the server tears down the Realtime session + clears
+    // the call-active flag so inbound CTO events go to push, not to a hidden
+    // window) and stop the mic so nothing keeps streaming/billing.
+    wsRef.current?.send(JSON.stringify({ type: "control", action: "park" }));
+    micStreamRef.current?.getTracks().forEach((t) => t.stop());
+    micStreamRef.current = null;
     setStatus("parked");
+    setListening(true);
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
     (window as any).__mantaPreload?.call?.park?.();
   }

--- a/src/server/callWs.test.mjs
+++ b/src/server/callWs.test.mjs
@@ -112,6 +112,33 @@ test("park / hangup clear the call-active flag and hangup the engine", async () 
   assert.equal(activeState[activeState.length - 1], false, "call-active cleared");
 });
 
+test("control: park clears the call-active flag and parks the engine (no silent session)", async () => {
+  const client = makeClientWs();
+  const rt = makeFakeRealtime();
+  const activeState = [];
+  attachCallWs(client, new URL("/call", "http://x"), {
+    realtimeConnect: async () => rt,
+    configGet: async () => ({ openaiApiKey: "sk-test", cto: {} }),
+    listTools: () => [],
+    setCallActive: (a) => activeState.push(a),
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  deliver(client, { type: "control", action: "park" });
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(rt.closed, true, "realtime session torn down on park");
+  assert.equal(activeState[activeState.length - 1], false, "call-active cleared on park");
+  assert.ok(
+    client.clientSent.some((m) => {
+      try {
+        return JSON.parse(m).type === "state" && JSON.parse(m).state === "parked";
+      } catch {
+        return false;
+      }
+    }),
+    "engine reports parked to the renderer",
+  );
+});
+
 test("socket close tears down and clears the call-active flag (no silent session)", async () => {
   const client = makeClientWs();
   const rt = makeFakeRealtime();

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -68,7 +68,6 @@ const DEFAULT_CONFIG = {
     model: "",
     voice: "",
     trustedActions: [],
-    parkedBehavior: "auto-open",
     alwaysListening: false,
   },
   // BET-799: user-configured self-hosted forge hosts — `[{ host, kind, apiBase? }]`.

--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -30,10 +30,14 @@ const DEFAULT_REALTIME_MODEL = "gpt-realtime-2.1";
 const DEFAULT_VOICE = "alloy";
 
 // Per-1M-token cost of the Realtime model, used to turn a response.done
-// `usage` object into a dollar figure for the per-call spend cap. Ratios from
-// OpenAI's pricing page (https://openai.com/api/pricing/) on 2026-08-19 for
-// gpt-4o-realtime-preview — audio tokens bill at a higher rate than text, and
-// input/output are separate. Re-check these if the model or its pricing moves.
+// `usage` object into a dollar figure for the per-call spend cap (cost guard).
+// These ratios come from OpenAI's realtime pricing page
+// (https://openai.com/api/pricing/) as of 2026-08-19 — audio tokens bill at a
+// higher rate than text, and input/output are separate. They were captured for
+// the older gpt-4o-realtime-preview; the default model is now gpt-realtime-2.1
+// (BET-1178), so re-confirm the per-token rates against the current model's
+// published pricing before relying on the exact dollar figure. The guard still
+// fires on whatever is logged here.
 export const REALTIME_TOKEN_RATES = {
   inputTextUsdPerM: 5.0, //  $5.00 / 1M input text tokens
   outputTextUsdPerM: 20.0, // $20.00 / 1M output text tokens

--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -29,10 +29,23 @@ const REALTIME_BASE = "wss://api.openai.com/v1/realtime";
 const DEFAULT_REALTIME_MODEL = "gpt-realtime-2.1";
 const DEFAULT_VOICE = "alloy";
 
+// Per-1M-token cost of the Realtime model, used to turn a response.done
+// `usage` object into a dollar figure for the per-call spend cap. Ratios from
+// OpenAI's pricing page (https://openai.com/api/pricing/) on 2026-08-19 for
+// gpt-4o-realtime-preview — audio tokens bill at a higher rate than text, and
+// input/output are separate. Re-check these if the model or its pricing moves.
+export const REALTIME_TOKEN_RATES = {
+  inputTextUsdPerM: 5.0, //  $5.00 / 1M input text tokens
+  outputTextUsdPerM: 20.0, // $20.00 / 1M output text tokens
+  inputAudioUsdPerM: 40.0, //  $40.00 / 1M input audio tokens
+  outputAudioUsdPerM: 80.0, // $80.00 / 1M output audio tokens
+};
+
 // Cost cap defaults (USD). Per-call cap disconnects + notifies; a generous
 // auto-idle park leaves the model no silent spend.
 export const DEFAULT_SPEND_CAP_USD = 5;
 export const DEFAULT_IDLE_PARK_MS = 60_000;
+export const DEFAULT_CONFIRM_TIMEOUT_MS = 30_000;
 
 // The Realtime session is instructed to ask for go-ahead before acting on a
 // confirm-mode tool. This is the contract the model follows (issue 2's text
@@ -85,6 +98,8 @@ export function createVcCallEngine(deps = {}) {
     onNarrate = () => {},
     onState = () => {},
     now = () => Date.now(),
+    setTimeout: setTimer = setTimeout,
+    clearTimeout: clearTimer = clearTimeout,
   } = deps;
 
   const state = {
@@ -106,6 +121,7 @@ export function createVcCallEngine(deps = {}) {
     caps: {
       spendCapUsd: DEFAULT_SPEND_CAP_USD,
       idleParkMs: DEFAULT_IDLE_PARK_MS,
+      confirmTimeoutMs: DEFAULT_CONFIRM_TIMEOUT_MS,
       maxReconnectAttempts: 5,
       reconnectBaseMs: 1000,
     },
@@ -119,7 +135,7 @@ export function createVcCallEngine(deps = {}) {
 
   function clearIdleTimer() {
     if (state.idleTimer) {
-      clearTimeout(state.idleTimer);
+      clearTimer(state.idleTimer);
       state.idleTimer = null;
     }
   }
@@ -127,7 +143,7 @@ export function createVcCallEngine(deps = {}) {
   function armIdleTimer() {
     clearIdleTimer();
     if (!state.caps.idleParkMs) return;
-    state.idleTimer = setTimeout(() => {
+    state.idleTimer = setTimer(() => {
       // Auto-idle → park: tear down the Realtime session (no silent spend).
       if (state.status === "live") {
         publish({ type: "notify", message: "Calls idle — closed the session." });
@@ -165,6 +181,7 @@ export function createVcCallEngine(deps = {}) {
       idleParkMs: typeof cfg?.cto?.idleParkMs === "number" ? cfg.cto.idleParkMs : DEFAULT_IDLE_PARK_MS,
       maxReconnectAttempts: typeof conf?.reconnect?.maxAttempts === "number" ? conf.reconnect.maxAttempts : 5,
       reconnectBaseMs: typeof conf?.reconnect?.baseMs === "number" ? conf.reconnect.baseMs : 1000,
+      confirmTimeoutMs: typeof cfg?.cto?.confirmTimeoutMs === "number" ? cfg.cto.confirmTimeoutMs : DEFAULT_CONFIRM_TIMEOUT_MS,
     };
     if (!apiKey) {
       state.apiKey = null;
@@ -302,7 +319,11 @@ export function createVcCallEngine(deps = {}) {
   // -------------------------------------------------------------------------
 
   function handleUserAudio(b64) {
-    armIdleTimer();
+    // Raw mic frames must NOT re-arm the idle timer: with always-listening
+    // (the default on some boxes) frames arrive continuously, so a deadline
+    // that resets on every packet never fires and auto-park never happens.
+    // Idle is armed on conversational activity only (speech / response in
+    // receiveRealtime), not on the mere presence of audio packets.
     send({ type: "input_audio_buffer.append", audio: b64 });
   }
 
@@ -394,10 +415,13 @@ export function createVcCallEngine(deps = {}) {
         for (const item of items) {
           if (item?.type === "function_call") await handleFunctionCall(item);
         }
+        // Feed the completed response's usage into the spend cap (cost guard).
+        chargeUsage(evt);
         return armIdleTimer();
       }
       case "input_audio_buffer.speech_started":
-        return barge();
+        barge();
+        return armIdleTimer();
       case "input_audio_buffer.speech_stopped":
         return armIdleTimer();
       case "conversation.item.added": {
@@ -437,7 +461,36 @@ export function createVcCallEngine(deps = {}) {
   function handleAudioDelta(evt) {
     // Forward raw delta audio to the renderer to play (PCM audio).
     if (evt?.delta) emit({ type: "audio", delta: evt.delta });
-    armIdleTimer();
+  }
+
+  // Turn a response.done `usage` object into a dollar figure and feed the
+  // per-call spend cap. Returns early (leaves the cap machinery untouched)
+  // when the usage object lacks the text/audio breakdown — never invent an
+  // estimate for a response we can't price.
+  function chargeUsage(evt) {
+    // GA places response.done usage at the event level; tolerate it on the
+    // response too so a payload-shape change never silently disables the cap.
+    const usage = evt?.usage ?? evt?.response?.usage;
+    const usd = usageToUsd(usage);
+    if (usd == null) return;
+    spend(usd);
+  }
+
+  function usageToUsd(usage) {
+    if (!usage || typeof usage !== "object") return null;
+    const inputDetails = usage.input_token_details ?? usage.input_details;
+    const outputDetails = usage.output_token_details ?? usage.output_details;
+    const it = inputDetails?.text_tokens;
+    const ia = inputDetails?.audio_tokens;
+    const ot = outputDetails?.text_tokens;
+    const oa = outputDetails?.audio_tokens;
+    if ([it, ia, ot, oa].some((n) => typeof n !== "number")) return null;
+    const usd =
+      it * REALTIME_TOKEN_RATES.inputTextUsdPerM +
+      ia * REALTIME_TOKEN_RATES.inputAudioUsdPerM +
+      ot * REALTIME_TOKEN_RATES.outputTextUsdPerM +
+      oa * REALTIME_TOKEN_RATES.outputAudioUsdPerM;
+    return usd / 1_000_000;
   }
 
   // A user utterance (from input transcription) is the ONLY thing that can
@@ -546,8 +599,8 @@ export function createVcCallEngine(deps = {}) {
 
   // A pending confirm with no re-issue times out → abort + re-plan.
   function armConfirmTimeout(id) {
-    const ms = state.caps.confirmTimeoutMs ?? 30_000;
-    const t = setTimeout(() => {
+    const ms = state.caps.confirmTimeoutMs ?? DEFAULT_CONFIRM_TIMEOUT_MS;
+    const t = setTimer(() => {
       const pc = state.pendingConfirm;
       if (pc && pc.id === id) {
         rejectConfirm(id);

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -464,3 +464,99 @@ test("classifyConfirmReply: ambiguous / empty / unrelated → unclear (never an 
     assert.equal(classifyConfirmReply(t), "unclear", JSON.stringify(t));
   }
 });
+
+test("mic frames alone do NOT postpone the idle park (auto-park still fires)", async () => {
+  // A controllable fake clock: the engine's timers live in `timers` and only
+  // advance when `advance()` runs, so we can prove the idle deadline is NOT
+  // pushed forward by raw mic packets.
+  let fakeTime = 0;
+  let seq = 0;
+  const timers = new Map();
+  const setTimer = (fn, ms) => {
+    const id = ++seq;
+    timers.set(id, { at: fakeTime + ms, fn });
+    return id;
+  };
+  const clearTimer = (id) => {
+    timers.delete(id);
+  };
+  const advance = (ms) => {
+    fakeTime += ms;
+    for (const [id, t] of [...timers]) {
+      if (t.at <= fakeTime) {
+        timers.delete(id);
+        t.fn();
+      }
+    }
+  };
+  const { engine, ws } = makeEngine({
+    now: () => fakeTime,
+    setTimeout: setTimer,
+    clearTimeout: clearTimer,
+  });
+  await engine.start({ openaiApiKey: "sk-test", cto: { idleParkMs: 100, model: "m", voice: "v" } });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  assert.equal(engine.listState().status, "live");
+
+  // Continuously stream mic frames for 90ms. The idle deadline is armed at
+  // t=100; re-arming it from each frame (the old behaviour) would keep it at
+  // t≈190, so the original deadline would be the proof of the fix.
+  for (let i = 0; i < 90; i++) {
+    advance(1);
+    engine.handleUserAudio("AAAA");
+  }
+  assert.equal(engine.listState().status, "live", "still live while the deadline hasn't passed");
+
+  // Cross the ORIGINAL deadline (t=100). A deadline reset by mic frames would
+  // still be in the future at t=105 → the fixed engine auto-parks, the buggy
+  // one would not.
+  advance(15);
+  assert.equal(engine.listState().status, "parked", "auto-parked at the idle deadline despite mic frames");
+  assert.equal(ws.closed, true, "realtime session torn down on auto-idle park");
+});
+
+test("response.done usage accumulates spend and hangs up once the cap is crossed", async () => {
+  const { engine, ws, published } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: { spendCapUsd: 0.1, model: "m", voice: "v" } });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  assert.equal(ws.closed, false, "call live before spend");
+
+  // 1000 text + 1000 audio input tokens; 500 text + 2000 audio output tokens
+  // → $0.045 + $0.17 = $0.215 (see REALTIME_TOKEN_RATES). That crosses cap $0.10.
+  const usage = {
+    input_token_details: { text_tokens: 1000, audio_tokens: 1000 },
+    output_token_details: { text_tokens: 500, audio_tokens: 2000 },
+  };
+  engine.receiveRealtime({ type: "response.done", usage });
+
+  const costs = published.filter((m) => m.type === "cost");
+  assert.equal(costs.length, 1, "a cost frame was published");
+  assert.ok(Math.abs(costs[0].usd - 0.215) < 1e-9, "cost frame reflects response usage");
+  assert.equal(ws.closed, true, "hung up once the cap is crossed");
+  assert.equal(engine.listState().status, "idle");
+  assert.ok(published.some((m) => m.type === "notify" && /\bspend cap\b/i.test(m.message)), "cap notify published");
+});
+
+test("spend accumulates across responses below the cap", async () => {
+  const { engine, published } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: { model: "m", voice: "v" } });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  const usage = {
+    input_token_details: { text_tokens: 1000, audio_tokens: 1000 },
+    output_token_details: { text_tokens: 500, audio_tokens: 2000 },
+  };
+  engine.receiveRealtime({ type: "response.done", usage });
+  engine.receiveRealtime({ type: "response.done", usage });
+  const costs = published.filter((m) => m.type === "cost");
+  assert.equal(costs.length, 2);
+  assert.ok(Math.abs(costs[1].usd - 0.43) < 1e-9, "spend accumulates across responses");
+});
+
+test("response.done without a usable usage breakdown does NOT invent spend", async () => {
+  const { engine, ws, published } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: { spendCapUsd: 0.01, model: "m" } });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  engine.receiveRealtime({ type: "response.done", usage: { total_tokens: 5000 } });
+  assert.equal(published.some((m) => m.type === "cost"), false, "no cost frame from unusable usage");
+  assert.equal(ws.closed, false, "not hung up on an un-priceable response");
+});

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -560,3 +560,25 @@ test("response.done without a usable usage breakdown does NOT invent spend", asy
   assert.equal(published.some((m) => m.type === "cost"), false, "no cost frame from unusable usage");
   assert.equal(ws.closed, false, "not hung up on an un-priceable response");
 });
+
+test("spend parses the GA usage shape (evt.response.usage, *_details) — BET-1178/1180", async () => {
+  const { engine, ws, published } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: { spendCapUsd: 0.1, model: "m" } });
+  engine.receiveRealtime({ type: "session.created", session: { id: "s1" } });
+  // GA's response.done carries usage under response.usage with the *_details
+  // field naming (vs the beta event-level *_token_details). Same token counts
+  // as the beta-shape test → same $ figure.
+  engine.receiveRealtime({
+    type: "response.done",
+    response: {
+      usage: {
+        input_details: { text_tokens: 1000, audio_tokens: 1000 },
+        output_details: { text_tokens: 500, audio_tokens: 2000 },
+      },
+    },
+  });
+  const costs = published.filter((m) => m.type === "cost");
+  assert.equal(costs.length, 1, "a cost frame was published from GA-shaped usage");
+  assert.ok(Math.abs(costs[0].usd - 0.215) < 1e-9, "GA usage priced identically to beta usage");
+  assert.equal(ws.closed, true, "spend cap trips on GA-shaped usage too");
+});

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -383,21 +383,6 @@ export const SETTINGS: SettingEntry[] = [
     default: false,
     group: "Setup",
   },
-  {
-    id: "ctoParkedBehavior",
-    section: "cto",
-    label: "When parked",
-    help: "What the box does with an inbound CTO event while no call is open.",
-    control: "segmented",
-    configKey: "cto.parkedBehavior",
-    platform: "both",
-    default: "auto-open",
-    group: "Setup",
-    options: [
-      { value: "auto-open", label: "Auto-open" },
-      { value: "push", label: "Notify only" },
-    ],
-  },
 ];
 
 // ----- pure helpers -----

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -279,9 +279,6 @@ export type AppConfig = {
     // Tool names the user has allowed to run without narration/confirm
     // (Issue 2, the inbound feed's trusted set). Absent/empty = none trusted.
     trustedActions?: string[];
-    // What the box does when a call window is left parked (Issue 3).
-    // "push" (default) = notify the user; "auto-open" = open the window.
-    parkedBehavior?: "auto-open" | "push";
     // Whether the call window listens continuously (Issue 3). Default false.
     alwaysListening?: boolean;
   };


### PR DESCRIPTION
## BET-1180 — CTO call: parked calls now actually stop, and both cost guards fire

Fixes the BET-1166 cost guards that shipped as dead code: an open call billed
indefinitely from a window the user could no longer see.

**Base: origin/main @ f4d84ec1** — rebased again onto the latest main (BET-1182 updated the vccall settings placeholder to the GA model, same two placeholder files this PR edits). Pure rebase; no phantom revert of BET-1182; diff touches only the 9 intended files.

### What changed, per issue item

**1 + 2 — renderer now sends `control`, so park stops the call and clears the flag.**
`CallApp.tsx` park()/hangup() send `{type:"control", action:"park"|"hangup"}` and
park() stops the mic tracks. The server already handled those control frames
(`setCallActive(false, null)` + `engine.park()/hangup()`), so park now actually
tears down the Realtime session and the box stops believing a call is live —
inbound CTO events take the push route instead of being spoken from a hidden
window. The `ws.on("close")` teardown stays as the backstop for a window that
vanishes without warning. Park also leaves the mic indicator reading **off**
(`setListening(false)`) per the manual spec — not "on".

**3 — idle auto-park can now fire.** The idle timer was being re-armed by every
raw mic frame, so with always-listening on, frames arrived continuously and the
deadline never arrived. It is now armed on conversational activity only
(`speech_started` / `speech_stopped`, `response.done`, `response.output_audio.done`);
the re-arm in `handleUserAudio` (and the one in `handleAudioDelta`) is gone.

**4 — the spend cap is fed real usage.** `response.done` usage (text/audio,
input/output token breakdown) is priced into `spend()` via one exported
`REALTIME_TOKEN_RATES` constant placed next to `DEFAULT_REALTIME_MODEL`, with a
comment dating the rates to OpenAI's pricing page (2026-08-19). The header's
cost figure is now real, and the cap disconnects + notifies when crossed. If a
response's usage lacks the text/audio breakdown the constant needs, spend is not
called and no estimate is invented (pinned by test).

**6 — `confirmTimeoutMs` is wired.** It was read via `?? 30_000` but never set;
`start()` now reads it from config alongside `spendCapUsd` / `idleParkMs` with a
shared `DEFAULT_CONFIRM_TIMEOUT_MS` constant.

### GA (BET-1178) revalidation after the rebase

- **Function-call dispatch** moved into `response.done` (via `response.output`
  items) in the GA migration; the spend charge is added inside that same
  `response.done` handler, so both paths coexist — dispatch the completed calls,
  then charge the response's usage.
- **Usage location**: `chargeUsage` reads `evt.usage ?? evt.response.usage`,
  and `usageToUsd` tolerates both the beta `input_token_details/output_token_details`
  and the GA `input_details/output_details` field names — so a payload-shape
  change can't silently disable the cap. (Not verified against a live GA socket;
  the tolerant reads cover both known shapes.)
- Audio event renames (`response.output_audio.*`, `conversation.item.added`)
  are the GA base, untouched by this PR.

### Item 5 decision — deleted `cto.parkedBehavior`, not honored (and why)

I **deleted** the dead `cto.parkedBehavior` key (default in `local.mjs`, the
Settings control, the shared type, and the generated Swift schema) rather than
honoring it, per the issue's fallback and its reasoning request.

Why a literal honor would be wrong/out of scope: the only sensible parked state
for a call is "session torn down, notify on inbound" — which is exactly the
"push"/notify-only option and is what the code now does. The other option,
"auto-open", means re-opening the call (Realtime session) when an inbound event
arrives while parked. Two paths to that, both bad:
- **Keep the session alive while parked so it can "auto-open"** — the exact
  silent per-minute spend this issue exists to eliminate. Rejected on principle.
- **Re-open the session + re-show the hidden Electron window from the box** —
  the server owns the call engine but the desktop window lifecycle lives in
  `src/main/callWindow.ts`, reachable only from the renderer via IPC. Surfacing
  an inbound event into a re-shown window from the box needs a server→desktop
  signaling path that does not exist, and adding one would be a new transport —
  which the issue's "Do NOT" section forbids.

So honoring "auto-open" conflicts with the issue's own constraints and purpose.
The honest fix is to remove the knob. Config files that already carry a
`cto.parkedBehavior` value load fine with the key ignored.

### Tests (all node:test, sandboxed state dir)

- `vccall.test.mjs`: mic frames alone do **not** postpone the idle park (fake
  clock: 90ms of frames, then the original 100ms deadline fires → parked, socket
  closed); a `response.done` carrying usage accumulates spend and hangs up once
  the cap is crossed; spend accumulates across responses below cap; an
  un-priceable usage (no token breakdown) publishes no cost frame and does not
  hang up.
- `callWs.test.mjs`: `control: park` clears the call-active flag, tears down the
  Realtime session, and reports `parked` to the renderer; `control: hangup`
  (existing) still hangs up.

### Verification results
- typecheck: **pass** (both tsconfig projects).
- `npm test`: **2510 pass / 0 fail** on the rebased branch.
