### PR TITLE
fix(self-update): route install.sh boxes to the prebuilt tarball path (no on-box npm)

### DIFF
--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -74,6 +74,31 @@ verify_sha256() {
       (corrupt download or stale manifest — re-run; if it persists, report it)"
 }
 
+# detect_install_kind <has_release_json> <has_git>
+#
+# Decide which update path a box takes: `packaged` (release tarball -> prebuilt
+# node_modules, no on-box build) or `git` (a live dev checkout -> git reset +
+# on-box npm).
+#
+# RELEASE.json is the ground truth for a RELEASE-DEPLOYED box and therefore
+# WINS over an incidental .git/. install.sh makes every box it creates a git
+# checkout (deploy_git_checkout) so the box can self-update, but such a box's
+# source+deps come from the release tarball and it has no toolchain — misreading
+# it as a dev git box sends it down the git path, which rebuilds node_modules on
+# the box and fails with no compiler (the "re-run install.sh to get a matching
+# prebuilt tree" brick). Only a checkout with NO RELEASE.json is a true dev box.
+#
+# Pure: both inputs are caller-computed booleans, so this is unit-testable.
+detect_install_kind() { # $1=has_release_json $2=has_git
+  if [ "$1" = "1" ]; then
+    printf 'packaged'
+  elif [ "$2" = "1" ]; then
+    printf 'git'
+  else
+    printf 'none'
+  fi
+}
+
 # replace_release_payload <pkg-dir> <dest-dir> <node-bin>
 #
 # Replace every path the incoming release owns in <dest-dir> with the copy from

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -440,6 +440,46 @@ test("release_is_current: an unreadable installed stamp is never 'current'", () 
   assert.equal(isCurrent("", "", "0.0.29", "def456"), false);
 });
 
+// --- detect_install_kind: packaged-vs-git routing ------------------------------
+//
+// RELEASE.json (true for every install.sh box) MUST win over .git/, because
+// install.sh git-inits the dir it creates — so .git alone does NOT mean "dev
+// checkout". If .git were checked first (the pre-fix bug), every install.sh
+// box would route to the on-box `npm ci` path and brick on a toolchain-less
+// box. Only a checkout with no RELEASE.json is a real dev box.
+
+function detectKind(hasReleaseJson, hasGit) {
+  const script = `
+    log() { :; }; ok() { :; }; warn() { :; }; die() { echo "$*" >&2; exit 1; }
+    . "${RELEASE_LIB}"
+    detect_install_kind "$1" "$2"
+  `;
+  const out = execFileSync(
+    "bash",
+    ["-c", script, "bash", String(hasReleaseJson), String(hasGit)],
+    { encoding: "utf-8" },
+  );
+  return out.trim();
+}
+
+test("detect_install_kind: an install.sh box (RELEASE.json + .git) is packaged, not git", () => {
+  // The regression: install.sh boxes carry BOTH a RELEASE.json stamp AND an
+  // incidental .git/ (install.sh git-inits the dir). RELEASE.json must win.
+  assert.equal(detectKind(1, 1), "packaged");
+});
+
+test("detect_install_kind: a dev clone (no RELEASE.json, has .git) stays git", () => {
+  assert.equal(detectKind(0, 1), "git");
+});
+
+test("detect_install_kind: a bare extracted tarball (RELEASE.json only) is packaged", () => {
+  assert.equal(detectKind(1, 0), "packaged");
+});
+
+test("detect_install_kind: neither → none", () => {
+  assert.equal(detectKind(0, 0), "none");
+});
+
 // --- should_skip_self_update: the early-exit decision -------------------------
 //
 // The updater's early exit must skip the whole update ONLY when the box is

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -7,18 +7,23 @@
 #
 # Two kinds of box are supported (BET-640):
 #
-#   * git checkout (the maintainer's dev box): update = `git fetch origin main`
-#     + `git reset --hard origin/main`.
-#   * packaged install (every box created by `curl mantaui.com/install.sh`):
-#     a plain directory with RELEASE.json (no .git). Update = download the
+#   * packaged install (EVERY box created by `curl mantaui.com/install.sh`):
+#     identified by RELEASE.json (install.sh also git-inits the dir, but that
+#     incidental .git/ never determines the path). Update = download the
 #     release tarball for this arch, verify it, extract it, and replace the
 #     payload paths the incoming release owns (`includes` in RELEASE.json) —
-#     which DOES include `runtime/` (the vendored Node, so a runtime version
-#     bump can reach an installed box) but NOT `node_modules/` (which is
-#     reinstalled by the `npm ci --omit=dev` step that runs immediately after).
+#     which includes `runtime/` (the vendored Node) AND `node_modules/` (the
+#     PREBUILT, arch-/ABI-verified tree, so an update never rebuilds deps and
+#     needs no toolchain). install_prod_deps skips its network-fallback `npm ci`
+#     entirely when the payload supplied node_modules.
+#   * git checkout (a live DEV box — a clone with NO RELEASE.json): update =
+#     `git fetch origin main` + `git reset --hard origin/main`. Dev boxes have
+#     a toolchain and may run arbitrary source, so they keep the on-box npm
+#     path.
 #
-# The install kind is detected, not assumed, so a box installed before the
-# updater understood packaged installs (or whose git fetch fails) self-heals.
+# The install kind is detected from RELEASE.json-first (never .git-first), so
+# every install.sh box routes to the prebuilt tarball path and self-heals even
+# when its dir carries a .git/.
 #
 # Two-hop note (do not "fix"): an installed box runs the copy of this script
 # it already has on disk, so the FIRST update after a payload-swap change ships
@@ -73,12 +78,17 @@ exec >>"$LOG_FILE" 2>&1
 . "$MANTA_HOME/scripts/lib/release.sh"
 
 # --- Detect install kind ------------------------------------------------------
+# RELEASE.json identifies a RELEASE-DEPLOYED box and WINS over .git/: install.sh
+# makes every box it creates a git checkout, so checking .git first misreads an
+# install.sh box (which carries RELEASE.json AND .git) as a dev checkout and
+# sends it down the on-box `npm ci` path — which fails without a toolchain.
+# Only a checkout with no RELEASE.json is a true dev box; it keeps the git path.
+# See detect_install_kind in scripts/lib/release.sh (unit-tested).
 echo "MANTA_PROGRESS 1/7 Checking for updates"
-if [ -d "$MANTA_HOME/.git" ]; then
-  INSTALL_KIND=git
-elif [ -f "$MANTA_HOME/RELEASE.json" ]; then
-  INSTALL_KIND=packaged
-else
+HAS_RELEASE_JSON=0; [ -f "$MANTA_HOME/RELEASE.json" ] && HAS_RELEASE_JSON=1
+HAS_GIT=0;           [ -d "$MANTA_HOME/.git" ]          && HAS_GIT=1
+INSTALL_KIND="$(detect_install_kind "$HAS_RELEASE_JSON" "$HAS_GIT")"
+if [ "$INSTALL_KIND" = "none" ]; then
   die "self-update: $MANTA_HOME is neither a git checkout nor a packaged install"
 fi
 
@@ -459,11 +469,35 @@ restart_server() {
   fi
 }
 
+# wait_server_healthy — after a payload swap + restart, confirm the box actually
+# comes back up before we report the update as complete. Without this a release
+# that won't boot would report "self-update: complete" on a dead box. This is a
+# LOUD failure (die with guidance), not a rollback: rolling the payload back in
+# place fights a self-replacing updater's two-hop hazard, so auto-restore is
+# deliberately out of scope here (see the header's "Two-hop note").
+wait_server_healthy() {
+  local url="${MANTA_HEALTH_URL:-http://127.0.0.1:${MANTA_PORT:-8787}/auth/status}"
+  local attempts="${SELF_UPDATE_HEALTH_ATTEMPTS:-40}"
+  local i=1
+  while [ "$i" -le "$attempts" ]; do
+    if curl -fsS --max-time 3 "$url" >/dev/null 2>&1; then
+      ok "self-update: server healthy at $url (attempt $i)"
+      return 0
+    fi
+    sleep 1
+    i=$((i + 1))
+  done
+  warn "self-update: server did not become healthy at $url after ${attempts}s"
+  die "server did not become healthy after the update — re-run install.sh to restore a matching prebuilt tree"
+}
+
 if [ "$PAYLOAD_REPLACED" = "1" ]; then
   echo "MANTA_PROGRESS 6/7 Restarting opencode"
   restart_opencode
   echo "MANTA_PROGRESS 7/7 Restarting box server"
   restart_server
+  # Confirm the new payload actually boots before reporting success.
+  wait_server_healthy
 elif [ "$OPENCODE_CHANGED" = "1" ]; then
   echo "MANTA_PROGRESS 6/7 Restarting opencode"
   restart_opencode


### PR DESCRIPTION
## The bug
install.sh git-inits every box it creates, so a released box carries both a `.git/` **and** a `RELEASE.json`. `self-update.sh` detected install kind `.git`-first, so every install.sh box was misclassified as a **dev git checkout** and took the git path:

- `git reset --hard origin/main` + a real `npm ci` **on the box**
- no toolchain on a fresh VPS → the rebuild fails → box left on new source with older deps → **"re-run install.sh to get a matching prebuilt tree"**

The release tarball's prebuilt, arch-/ABI-verified `node_modules` was ignored entirely. This is exactly the brick a fresh prod box hit on the 0.0.41 update.

## The fix
`RELEASE.json` is now the discriminator and **wins over `.git/`** (`detect_install_kind`, pure + unit-tested). A release-deployed box is identified by its stamp; only a clone with no `RELEASE.json` is a true dev box and keeps the git path. Released boxes take the packaged path — swap the tarball's prebuilt `node_modules`, skip the on-box fallback, no compiler needed.

Also: after a payload swap + restart, wait for the box to come up healthy and **fail loudly** if it doesn't — an update is never reported "complete" on a dead box.

## Scope notes
- **Auto-rollback of the payload is out of scope here** (self-replacing updater two-hop hazard) and is a follow-up.
- The live-box integration test (fresh install → update → assert node_modules came from tarball) needs a reachable box + a new release to validate against — I couldn't run it from here (no box access) and it can't run against the already-deployed 0.0.41. Unit test covers the routing decision.

## Tests
- 4 new `detect_install_kind` cases (RELEASE.json-wins-over-git is the regression).
- `bash -n` clean on self-update.sh + release.sh; release + install + sync-release test files pass.