### PR TITLE
chore(release): bump version to 0.0.43 (server-v40, no-op)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "manta-ui",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "manta-ui",
-      "version": "0.0.42",
+      "version": "0.0.43",
       "hasInstallScript": true,
       "dependencies": {
         "@fontsource-variable/inter": "^5.3.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.42",
+  "version": "0.0.43",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.42",
+ "version": "0.0.43",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
No-op version bump to exercise the reliable self-update path end-to-end on boxes (0.0.42 shipped the fix). server.json bumped in lockstep. Then tag server-v40 + web-v39.