### PR TITLE
fix(server): add audio output format rate to session.update (BET-1184)

### DIFF
--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -233,7 +233,7 @@ export function createVcCallEngine(deps = {}) {
           transcription: { model: "whisper-1" },
         },
         output: {
-          format: { type: "audio/pcm" },
+          format: { type: "audio/pcm", rate: 24000 },
           voice,
         },
       },

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -126,6 +126,8 @@ test("start connects and sends a session.update with the tools configured", asyn
   const su = sent.find((m) => m.type === "session.update");
   assert.equal(su.session.type, "realtime");
   assert.equal(su.session.audio.output.voice, "nova");
+  assert.equal(su.session.audio.output.format.type, "audio/pcm");
+  assert.equal(su.session.audio.output.format.rate, 24000);
   assert.equal(su.session.audio.input.turn_detection.type, "server_vad");
   assert.equal(su.session.output_modalities.join(","), "audio");
   assert.equal(su.session.tools.length, 2);


### PR DESCRIPTION
## BET-1184 — GA session payload rejected: `session.audio.output.format.rate` missing

OpenAI's GA Realtime API requires `rate` on the output audio format. The `session.update` payload sent `{ type: "audio/pcm" }` with no `rate`, so the API rejected it with `missing_required_parameter: 'session.audio.output.format.rate'`.

**Fix:** add `rate: 24000` to the output format (matches the input format and the call window's `AudioContext` at 24000 on both capture and playback sides). Nothing else in the payload changes.

**Files changed:** 2 files.
- `src/server/vccall.mjs` — add `rate: 24000` to `session.audio.output.format`
- `src/server/vccall.test.mjs` — assert `session.audio.output.format.rate === 24000` so the field can't be dropped again

**Live probe (verification, not committed):** throwaway `ws` script against `wss://api.openai.com/v1/realtime?model=gpt-realtime-2.1`:
- Without `rate`: `invalid_request_error` `missing_required_parameter: 'session.audio.output.format.rate'` (exact error from the issue)
- With `rate`: `session.created` then `session.updated`, echo line:
  `audio.output: {"format":{"type":"audio/pcm","rate":24000},"voice":"alloy","speed":1}`

**Base:** `origin/main` @ `876cb346`

**Verification results:**
- PR branch (`multica/BET-1184-session-output-rate` @ `3f6cfaa8`):
  - typecheck: exit `0`. Errors: none. log sha256: `b3207b577411fe240b07f4435867a154a7e07248f9255b4b976f4fb182c4fddd`
  - test: exit `0`, `2524` pass / `0` fail / `0` skip. Failures: none. log sha256: `6569609dedef58dc7901c9a148e8b777ab0e916ddbd7194b3a1c8cded3cb990f`
- Base (`main` @ `876cb346`):
  - typecheck: exit `0`. Errors: none. log sha256: `b3207b577411fe240b07f4435867a154a7e07248f9255b4b976f4fb182c4fddd`
  - test: exit `0`, `2524` pass / `0` fail / `0` skip. Failures: none. log sha256: `db39d3e4a4dd4ff74022de09fcb4bfa380c9d24d56e1a781c587d99de25be8eb`
- **Conclusion:** `0` new failures, `0` pre-existing. This PR resolves the issue.
