### PR TITLE
fix(update): classify gateway 5xx on the box-update RPC as the benign restart-drop

### DIFF
--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -1573,6 +1573,20 @@ describe("isTransientUpdateNetworkError", () => {
     expect(isTransientUpdateNetworkError(new Error("Load failed"))).toBe(true);
   });
 
+  it("treats a gateway 5xx on the update RPC as the same transient restart-drop", () => {
+    // Over HTTPS a reverse proxy answers the in-flight update RPC with a bare
+    // gateway 5xx while the box restarts itself — the same benign success-path
+    // drop as `Failed to fetch`, just a different spelling. Must NOT abort the
+    // graceful boxUpgrading flow.
+    expect(isTransientUpdateNetworkError(new Error("HTTP 502 Bad Gateway"))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("HTTP 502"))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("HTTP 503"))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("HTTP 504 Gateway Timeout"))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("Bad Gateway"))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("HTTP 521"))).toBe(true);
+    expect(isTransientUpdateNetworkError(new Error("HTTP 524 origin is unreachable"))).toBe(true);
+  });
+
   it("does NOT treat a real server-reported early failure as transient", () => {
     // Genuine failures come back as structured strings from the RPC result,
     // not as connection errors — these must still raise the update-failed banner.
@@ -1580,6 +1594,16 @@ describe("isTransientUpdateNetworkError", () => {
     expect(isTransientUpdateNetworkError(new Error("self-update: manifest is malformed"))).toBe(false);
     expect(isTransientUpdateNetworkError(new Error("self-update: bad tarball — missing src/server/index.mjs"))).toBe(false);
     expect(isTransientUpdateNetworkError(new Error("spawn /abs/scripts/self-update.sh EACCES"))).toBe(false);
+    // Even a structured failure whose text mentions the download URL (which can
+    // contain "502") must stay real — the box is UP and reported it couldn't
+    // fetch the tarball. The `self-update:` guard wins over the gateway match.
+    expect(isTransientUpdateNetworkError(new Error("self-update: download failed: https://mantaui.com/releases/manta-x.tar.gz"))).toBe(false);
+  });
+
+  it("does NOT treat a bare HTTP 500 (server up but errored) as transient", () => {
+    // 500 means the box answered — it is NOT restarting, so this is a real
+    // failure, not the benign origin-unreachable family.
+    expect(isTransientUpdateNetworkError(new Error("HTTP 500 Internal Server Error"))).toBe(false);
   });
 
   it("is tolerant of null/undefined and arbitrary input", () => {

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1180,6 +1180,17 @@ export function isTransientUpdateNetworkError(err: unknown): boolean {
   // failures and must never be classified transient — the banner-relevant
   // resolver's `res.ok === false` branch surfaces them for real.
   if (msg.includes("self-update:")) return false;
+  // When a reverse proxy (Cloudflare/Caddy) sits between the app and the box,
+  // the SAME benign "box is restarting itself mid-update" drop that a direct
+  // socket surfaces as `Failed to fetch` arrives as a gateway 5xx — the proxy
+  // answers the in-flight update RPC with origin-unreachable while the box is
+  // briefly down. That is the success path's side-effect, not a real failure:
+  // the reconnect + version re-check resolve it, so it must not flip the
+  // update-failed banner (which would abort the graceful boxUpgrading flow).
+  // 502 bad-gateway / 503 / 504 gateway-timeout, plus Cloudflare's
+  // origin-down codes (521/522/524). A bare 500 ("Internal Server Error") is
+  // NOT in the set — the box is up, so that is a genuine failure.
+  if (/http (502|503|504|521|522|524)\b|bad gateway|gateway timeout|origin is unreachable/.test(msg)) return true;
   return (
     msg.includes("failed to fetch") ||
     msg.includes("fetch failed") ||


### PR DESCRIPTION
## The bug you hit
A successful box update restarts manta-server **before** the update RPC resolves. Over HTTPS the reverse proxy answers that in-flight request with **`HTTP 502`** while the box is briefly restarting — the same benign success-path drop that a direct socket reports as `Failed to fetch`.

`isTransientUpdateNetworkError` only recognized the connection-drop spellings, so `HTTP 502` fell to the **real-failure** branch: it raised the "Update failed: HTTP 502" banner **and called `setBoxUpgrading(false)`**, aborting the in-flight/reconnect/reconcile flow. That's the whole symptom: false failure + no loading state.

## The fix
Teach the predicate to treat the gateway **origin-unreachable** family — `502/503/504`, Cloudflare `521/522/524`, "bad gateway", "gateway timeout" — as the same transient drop. Then the existing BET-713 flow runs: `boxUpgrading` in-flight state → indeterminate "Restarting the box…" on drop → reconnect → version re-check → clears on match.

Guards kept correct:
- **`HTTP 500` stays a real failure** — the box is up, just errored.
- **`self-update:` structured errors still win** — a genuine download failure the box reports is never swallowed.

## Tests
- Gateway codes (502/503/504/521/522/524, "Bad Gateway") → transient.
- `self-update:` (incl. a URL containing 5xx) → not transient.
- bare `HTTP 500` → not transient.
- 643 renderer tests pass; typecheck clean.