### PR TITLE
BET-1185: fix(call): single live call + StrictMode-safe connect + shared AudioContext

### DIFF
--- a/src/renderer/call/CallApp.tsx
+++ b/src/renderer/call/CallApp.tsx
@@ -59,8 +59,17 @@ export function CallApp() {
   const initialSetRef = useRef(false);
 
   // ----- connect the /call WS + mic + audio-out -----
+  //
+  // StrictMode safety (BET-1185): the async body awaits BEFORE it creates the
+  // socket, so a StrictMode unmount (cleanup sets `cancelled`) during that
+  // await would otherwise leave the body to run to completion and open a
+  // socket the cleanup never sees — leaking a second Realtime session that
+  // talks over the live one. We check `cancelled` after EVERY await and bail
+  // (closing anything this run created), for the socket, the mic stream, and
+  // the audio context alike.
   useEffect(() => {
     let cancelled = false;
+    const isCancelled = () => cancelled;
     (async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
       const pre = (window as any).__mantaPreload?.call;
@@ -69,6 +78,7 @@ export function CallApp() {
         return;
       }
       const cfg = await pre.getConfig();
+      if (isCancelled()) return; // cleanup ran during the await — create nothing
       if (!cfg?.serverUrl || !cfg?.boxToken) {
         setStatus("dropped");
         setError("Not connected to a box.");
@@ -91,14 +101,29 @@ export function CallApp() {
         }
         handleServerMessage(msg);
       };
-      startMic(ws);
-      setupAudioOut();
+      if (isCancelled()) {
+        ws.close();
+        return;
+      }
+
+      // Capture and playback run on ONE shared AudioContext so the browser's
+      // echo canceller has a reference to what is being played (BET-1185).
+      await startMic(ws, isCancelled);
+      if (isCancelled()) {
+        ws.close();
+        return;
+      }
+      await setupAudioOut(isCancelled);
+      if (isCancelled()) {
+        ws.close();
+        return;
+      }
     })();
     return () => {
       cancelled = true;
       wsRef.current?.close();
-      micStreamRef.current?.getTracks().forEach((t) => t.stop());
-      audioCtxRef.current?.close().catch(() => {});
+      cleanupMic();
+      cleanupAudio();
     };
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
@@ -186,15 +211,26 @@ export function CallApp() {
     }
   }
 
-  async function startMic(ws: WebSocket) {
+  async function startMic(ws: WebSocket, isCancelled: () => boolean = () => false) {
     if (!listening) return;
     if (micStreamRef.current) return;
+    let stream: MediaStream | null = null;
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({
+      stream = await navigator.mediaDevices.getUserMedia({
         audio: { channelCount: 1, sampleRate: 24000, echoCancellation: true, noiseSuppression: true },
       });
+      if (isCancelled()) {
+        stopStream(stream);
+        return;
+      }
       micStreamRef.current = stream;
-      const ctx = new AudioContext({ sampleRate: 24000 });
+      // Same shared AudioContext as playback, so echo cancellation works.
+      const ctx = getOrCreateAudioCtx();
+      if (!ctx) {
+        stopStream(stream);
+        micStreamRef.current = null;
+        return;
+      }
       const src = ctx.createMediaStreamSource(stream);
       // Keep the graph pulling (src + worklet must stay connected to the
       // destination to process) but emit no sound: route both capture nodes
@@ -208,6 +244,11 @@ export function CallApp() {
           ws.send(JSON.stringify({ type: "audio", delta: pcm16ToBase64(samples) }));
         }
       });
+      if (isCancelled()) {
+        stopStream(stream);
+        micStreamRef.current = null;
+        return;
+      }
       src.connect(worklet);
       worklet.connect(monitor);
     } catch {
@@ -215,9 +256,9 @@ export function CallApp() {
     }
   }
 
-  function setupAudioOut() {
-    const ctx = new AudioContext({ sampleRate: 24000 });
-    audioCtxRef.current = ctx;
+  function setupAudioOut(isCancelled: () => boolean = () => false) {
+    const ctx = getOrCreateAudioCtx();
+    if (!ctx) return;
     const workletSrc = `
       class Out extends AudioWorkletProcessor {
         constructor(){ super(); this.buf = new Float32Array(0); this.port.onmessage=(e)=>{ const d=e.data; if(d.kind==='push'){ const a=new Float32Array(d.samples); const n=new Float32Array(this.buf.length+a.length); n.set(this.buf); n.set(a,this.buf.length); this.buf=n; } if(d.kind==='clear'){ this.buf=new Float32Array(0); } }; }
@@ -232,11 +273,49 @@ export function CallApp() {
     const blob = new Blob([workletSrc], { type: "application/javascript" });
     const url = URL.createObjectURL(blob);
     ctx.audioWorklet.addModule(url).then(() => {
+      if (isCancelled()) {
+        cleanupAudio();
+        return;
+      }
       const node = new AudioWorkletNode(ctx, "pcm-out");
       node.connect(ctx.destination);
       outNodeRef.current = node;
       URL.revokeObjectURL(url);
-    }).catch(() => {});
+    }).catch(() => {
+      URL.revokeObjectURL(url);
+    });
+  }
+
+  // A single shared AudioContext for both mic capture and playback, so the
+  // browser's echo canceller sees what is being played (BET-1185).
+  function getOrCreateAudioCtx(): AudioContext | null {
+    if (audioCtxRef.current) return audioCtxRef.current;
+    try {
+      const ctx = new AudioContext({ sampleRate: 24000 });
+      audioCtxRef.current = ctx;
+      return ctx;
+    } catch {
+      return null;
+    }
+  }
+
+  function cleanupMic() {
+    if (micStreamRef.current) {
+      micStreamRef.current.getTracks().forEach((t) => t.stop());
+      micStreamRef.current = null;
+    }
+  }
+
+  function cleanupAudio() {
+    outNodeRef.current = null;
+    if (audioCtxRef.current) {
+      audioCtxRef.current.close().catch(() => {});
+      audioCtxRef.current = null;
+    }
+  }
+
+  function stopStream(stream: MediaStream) {
+    stream.getTracks().forEach((t) => t.stop());
   }
 
   function playPcm(base64: string) {
@@ -254,22 +333,15 @@ export function CallApp() {
   // with Groq Orpheus. Decode + play it through the shared AudioContext.
   function playNarration(base64: string, _mime: string) {
     if (!base64) return;
-    let ctx = audioCtxRef.current;
-    if (!ctx) {
-      try {
-        ctx = new AudioContext();
-        audioCtxRef.current = ctx;
-      } catch {
-        return;
-      }
-    }
+    const ctx = getOrCreateAudioCtx();
+    if (!ctx) return;
     const bytes = base64ToBytes(base64);
     if (!bytes) return;
     ctx.decodeAudioData(bytes.buffer as ArrayBuffer).then(
       (buffer) => {
-        const src = ctx!.createBufferSource();
+        const src = ctx.createBufferSource();
         src.buffer = buffer;
-        src.connect(ctx!.destination);
+        src.connect(ctx.destination);
         src.start();
       },
       () => {

--- a/src/server/callWs.mjs
+++ b/src/server/callWs.mjs
@@ -19,13 +19,50 @@
 import { createVcCallEngine } from "./vccall.mjs";
 
 /**
+ * The single-call registry (BET-1185, Cause 2). Owns the "exactly one live
+ * call" invariant across every /call socket: `begin` registers a new call and
+ * returns whatever was active before it (the displaced call the caller must
+ * tear down); `end` clears the active call ONLY if that exact engine is still
+ * the current one — so a displaced call's own teardown can never clear the flag
+ * for the call that replaced it.
+ */
+export function createCallRegistry() {
+  let active = null; // { id, engine, ws }
+  let seq = 0;
+  return {
+    /** Register a new call as active; returns the displaced call or null. */
+    begin(engine, ws) {
+      const displaced = active;
+      active = { id: ++seq, engine, ws };
+      return displaced;
+    },
+    /** Clear the active call if (and only if) it is this engine. Returns true if cleared. */
+    end(engine) {
+      if (active && active.engine === engine) {
+        active = null;
+        return true;
+      }
+      return false;
+    },
+    current() {
+      return active;
+    },
+    isActive() {
+      return active !== null;
+    },
+  };
+}
+
+/**
  * Attach a /call WS to a fresh vccall engine. Auth + path matching happen at
  * the upgrade layer (src/server/index.mjs). `opts` supplies the engine deps
- * and the live-routing hooks (the "call active" flag that issue 2's inbound
- * funnel reads):
+ *  and the live-routing hooks (the "call active" flag that issue 2's inbound
+ *  funnel reads):
  *   { dispatchCto, approveConfirm, rejectConfirm, configGet,
  *     synthesizeSpeech, onNarrate,
- *     setCallActive:(active, engine|null)=>void }
+ *     setCallActive:(active, engine|null)=>void,
+ *     registry,          // a shared createCallRegistry() — the single-call guard
+ *     log:(msg)=>void }  // default console.log; the box logs nothing for calls
  *
  * @param {object} ws   a `ws` WebSocket instance
  * @param {URL}    url  the parsed upgrade URL
@@ -41,6 +78,8 @@ export function attachCallWs(ws, url, opts = {}) {
     realtimeConnect,
     onNarrate = () => {},
     setCallActive = () => {},
+    registry = null,
+    log = (msg) => console.log(msg),
   } = opts;
 
   let open = true;
@@ -100,6 +139,52 @@ export function attachCallWs(ws, url, opts = {}) {
     publish: sendJson,
   });
 
+  // ----- single-call guard (BET-1185, Cause 2) -----
+  // The box permits ONE live call. Register this socket+engine as the active
+  // call at attach time (synchronously, BEFORE the async boot). If another
+  // call is already active it is displaced — a reconnecting window must be
+  // able to take over a dead session, so we close its socket rather than
+  // reject it. The displaced socket's own `close` handler hangs its engine and
+  // clears the flag in an identity-guarded way (registry.end only clears the
+  // active call if that engine is still the current one), so the displaced
+  // call can never clobber the flag for the call that replaced it.
+  let displaced = null;
+  if (registry) {
+    displaced = registry.begin(engine, ws);
+  }
+  markActive(displaced ? "takeover" : "new");
+  if (displaced) {
+    log(`[call] takeover: closing the ${displacedCause(displaced)} on new /call`);
+    if (typeof displaced.ws?.close === "function") {
+      displaced.ws.close();
+    } else {
+      try {
+        displaced.engine.hangup();
+      } catch {
+        /* ignore */
+      }
+    }
+  }
+
+  function markActive(reason) {
+    setCallActive(true, engine);
+    log(`[call] attach: ${reason}`);
+  }
+
+  function clearActive(reason) {
+    if (registry) {
+      // Identity guard: only clear if THIS engine is still the active call.
+      // If it was already displaced by a takeover, leaving the new call's flag
+      // alone is the point.
+      const cleared = registry.end(engine);
+      if (!cleared) return;
+      setCallActive(false, null);
+    } else {
+      setCallActive(false, null);
+    }
+    log(`[call] detach: ${reason}`);
+  }
+
   // Boot the call on connect (open a Realtime session). The keys live on the
   // box; the engine reads them via configGet — nothing reaches the renderer.
   engine.setTools(opts.listTools ? opts.listTools() : []);
@@ -110,7 +195,6 @@ export function attachCallWs(ws, url, opts = {}) {
     } catch {
       cfg = {};
     }
-    setCallActive(true, engine);
     // Push the cto profile to the renderer so it honours the config (e.g. the
     // push-to-barge default reads cto.alwaysListening; never hardcodes it).
     sendJson({
@@ -151,10 +235,10 @@ export function attachCallWs(ws, url, opts = {}) {
         return;
       case "control":
         if (msg.action === "park") {
-          setCallActive(false, null);
+          clearActive("park");
           engine.park();
         } else if (msg.action === "hangup") {
-          setCallActive(false, null);
+          clearActive("hangup");
           engine.hangup();
         }
         return;
@@ -165,12 +249,22 @@ export function attachCallWs(ws, url, opts = {}) {
 
   ws.on("close", () => {
     open = false;
-    setCallActive(false, null);
+    // A socket close (normal hangup, the renderer window vanishing, or a
+    // takeover displacing this call) tears the engine down and clears the
+    // active flag — identity-guarded so a displaced call can't clear a newer
+    // call's flag.
+    clearActive(`socket close${displaced ? " (displaced by takeover)" : ""}`);
     engine.hangup();
   });
   ws.on("error", () => {
     /* cleanup runs in close */
   });
+}
+
+// human label for which call was displaced, for the takeover log line
+function displacedCause(d) {
+  if (d?.ws?.id) return `socket ${d.ws.id}`;
+  return "active call";
 }
 
 // Narration text from cto.dispatch arrives as terse `[cto] <tool>` / ` ok` /

--- a/src/server/callWs.test.mjs
+++ b/src/server/callWs.test.mjs
@@ -1,7 +1,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { EventEmitter } from "node:events";
-import { attachCallWs } from "./callWs.mjs";
+import { attachCallWs, createCallRegistry } from "./callWs.mjs";
 
 function makeClientWs() {
   const ws = new EventEmitter();
@@ -179,4 +179,89 @@ test("a rejected engine.start pushes an error frame and is not an unhandled reje
   } finally {
     process.removeListener("unhandledRejection", onUnhandled);
   }
+});
+
+test("createCallRegistry begins/ends identity-guarded: a displaced call can't clear a newer call", () => {
+  const r = createCallRegistry();
+  const e1 = { engine: 1 };
+  const e2 = { engine: 2 };
+  const s1 = { id: "s1" };
+  const s2 = { id: "s2" };
+
+  assert.equal(r.isActive(), false);
+  const displaced1 = r.begin(e1, s1);
+  assert.equal(displaced1, null, "first begin displaces nothing");
+  assert.equal(r.isActive(), true);
+
+  // Second call displaces the first.
+  const displaced2 = r.begin(e2, s2);
+  assert.equal(displaced2.engine, e1, "second begin displaces the first call");
+  assert.equal(displaced2.ws, s1);
+
+  // The DISPLACED call (engine 1) trying to end must NOT clear the active flag.
+  assert.equal(r.end(e1), false, "displaced engine end is a no-op");
+  assert.equal(r.isActive(), true, "active call survives the displaced call's teardown");
+
+  // The actual active call (engine 2) clears it.
+  assert.equal(r.end(e2), true, "active engine end clears the call");
+  assert.equal(r.isActive(), false);
+});
+
+test("a second /call attach while one is active tears down the first (takeover)", async () => {
+  const registry = createCallRegistry();
+  const activeState = [];
+  const makeOpts = (configGet) => ({
+    realtimeConnect: async () => ({}), // realtime ws shape is mocked below via engine deps
+    configGet,
+    listTools: () => [],
+    setCallActive: (a) => activeState.push(a),
+    registry,
+    log: () => {},
+  });
+
+  // First call: real, open realtime session.
+  const firstClient = makeClientWs();
+  const firstRt = makeFakeRealtime();
+  attachCallWs(firstClient, new URL("/call", "http://x"), {
+    ...makeOpts(async () => ({ openaiApiKey: "sk-test", cto: {} })),
+    realtimeConnect: async () => firstRt,
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(activeState[0], true, "first call active on connect");
+  assert.equal(firstRt.closed, false, "first realtime open before takeover");
+  assert.notEqual(firstClient.closed, true, "first socket open before takeover");
+
+  // Second call attaches while the first is live → displaces it.
+  const secondClient = makeClientWs();
+  const secondRt = makeFakeRealtime();
+  attachCallWs(secondClient, new URL("/call", "http://x"), {
+    ...makeOpts(async () => ({ openaiApiKey: "sk-test", cto: {} })),
+    realtimeConnect: async () => secondRt,
+  });
+  await new Promise((r) => setTimeout(r, 10));
+
+  // The first engine was hung up and its socket closed.
+  assert.equal(firstRt.closed, true, "first engine hung up on takeover");
+  assert.equal(firstClient.closed, true, "first socket closed on takeover");
+
+  // Let the second call's Realtime session come up.
+  secondRt.emit("message", Buffer.from(JSON.stringify({ type: "session.created", session: { id: "s2" } })));
+  await new Promise((r) => setTimeout(r, 10));
+
+  // The second call is the live one.
+  assert.ok(
+    secondClient.clientSent.some((m) => {
+      try {
+        return JSON.parse(m).type === "state" && JSON.parse(m).state === "live";
+      } catch {
+        return false;
+      }
+    }),
+    "second call becomes live",
+  );
+  assert.equal(secondRt.closed, false, "second realtime stays open");
+
+  // The first call's teardown must NOT have cleared the active flag.
+  assert.equal(activeState[activeState.length - 1], true, "takeover leaves the new call active");
+  assert.equal(registry.isActive(), true, "registry still points at the new call");
 });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -40,7 +40,7 @@ import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/
 }
 import { createBus, handleEventsRequest, attachEventsWs } from "./events.mjs";
 import { attachPtyWs } from "./ptyWs.mjs";
-import { attachCallWs } from "./callWs.mjs";
+import { attachCallWs, createCallRegistry } from "./callWs.mjs";
 import { buildHandlers, handleRpcRequest } from "./rpc.mjs";
 import { startStatusPoller } from "./status.mjs";
 import { createSyncState } from "./syncState.mjs";
@@ -976,6 +976,11 @@ function setCallActive(active, engine) {
   callActive = !!active;
   activeCallEngine = active && engine ? engine : null;
 }
+// Single-call guard (BET-1185, Cause 2): exactly one live /call at a time. A
+// new /call while one is active displaces (tears down) the previous one; the
+// registry is passed to every attach so the takeover logic runs inside
+// callWs.mjs where it is unit-testable.
+const callRegistry = createCallRegistry();
 
 // Which read a watcher's surface maps to. NATIVE surfaces (schedule, delegate)
 // go through the box's own stores. `session` needs no poller read — session
@@ -3018,6 +3023,7 @@ const handleUpgrade = (req, socket, head) => {
         configGet: () => local.configGet(),
         listTools: () => getCtoEngine().listTools(),
         setCallActive,
+        registry: callRegistry,
         // Narration (spec #6): the box synthesizes tool-boundary narration with
         // Groq Orpheus (key server-side) and streams it down /call as audio.
         synthesizeSpeech,

--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -108,6 +108,7 @@ export function createVcCallEngine(deps = {}) {
 
   const state = {
     active: false, // a live call is open (set true on session.created)
+    deactivated: false, // hangup/park ran — no further connect/reconnect (BET-1185)
     status: "idle", // idle | connecting | live | parked | dropped | reconnecting
     openai: null, // ws-like to OpenAI
     tools: [], // [{name,description,params}]
@@ -213,6 +214,14 @@ export function createVcCallEngine(deps = {}) {
       });
     } catch (e) {
       scheduleReconnect("connect_error");
+      return null;
+    }
+    // BET-1185 (Cause 2): a takeover / hangup / close can deactivate this
+    // engine while the connect is in flight (the Realtime socket opened after
+    // hangup). Don't leave a live, unbilled-but-fatal orphan session behind —
+    // close the socket and bow out; the active call owns the conversation.
+    if (state.deactivated) {
+      try { ws.close(); } catch { /* ignore */ }
       return null;
     }
     state.reconnectAttempts = 0;
@@ -355,6 +364,7 @@ export function createVcCallEngine(deps = {}) {
 
   function hangup() {
     state.active = false;
+    state.deactivated = true;
     clearIdleTimer();
     clearReconnectTimer();
     if (state.openai) {
@@ -367,6 +377,7 @@ export function createVcCallEngine(deps = {}) {
 
   function park() {
     state.active = false;
+    state.deactivated = true;
     clearIdleTimer();
     clearReconnectTimer();
     if (state.openai) {

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -584,3 +584,25 @@ test("spend parses the GA usage shape (evt.response.usage, *_details) — BET-11
   assert.ok(Math.abs(costs[0].usd - 0.215) < 1e-9, "GA usage priced identically to beta usage");
   assert.equal(ws.closed, true, "spend cap trips on GA-shaped usage too");
 });
+
+test("a hangup during connect closes the socket once it opens (no orphan session, BET-1185)", async () => {
+  const ws = makeFakeWs();
+  let resolveConnect;
+  const pending = new Promise((resolve) => {
+    resolveConnect = resolve;
+  });
+  const engine = createVcCallEngine({
+    realtimeConnect: () => pending,
+    configGet: async () => ({ openaiApiKey: "sk-test", cto: {} }),
+    dispatchCto: async () => ({ ok: true }),
+    publish: () => {},
+    onState: () => {},
+  });
+  engine.setTools([]);
+  const startPromise = engine.start({ openaiApiKey: "sk-test", cto: {} });
+  // Hang up while the realtime connect is still in flight, then let it open.
+  engine.hangup();
+  resolveConnect(ws);
+  await startPromise;
+  assert.equal(ws.closed, true, "post-hangup connect does not leave a live orphan session");
+});


### PR DESCRIPTION
## P0 — call window opens two OpenAI sessions that talk over each other

Fixes all three causes of the self-interrupting CTO (`hey there… hey there…`).

**Files changed:** `6` files.
```
src/renderer/call/CallApp.tsx    (Cause 1 + Cause 3)
src/server/callWs.mjs            (Cause 2: single-call guard + call logging)
src/server/callWs.test.mjs       (new takeover + registry tests)
src/server/index.mjs             (wire shared registry into /call)
src/server/vccall.mjs            (Cause 2b: deactivated-mid-boot orphan guard)
src/server/vccall.test.mjs       (new orphan-guard test)
```

### Cause 1 — StrictMode socket leak
The connect effect's async body awaited `pre.getConfig()` before creating the socket, so StrictMode's unmount (cleanup sets `cancelled`) ran during that await and the body still opened a socket the cleanup never saw — two sockets, two Realtime sessions. Now it checks `cancelled` after **every** await and bails (closing anything this run created) for the socket, the mic stream, and the audio context alike. The cleanups split into `cleanupMic()` / `cleanupAudio()` / `stopStream()` reused by the effect teardown and mid-await bails. StrictMode untouched — it surfaced a real leak.

### Cause 2 — server accepts unlimited concurrent calls
`callWs.mjs` gains `createCallRegistry()` (identity-guarded single-call registry) and `attachCallWs` registers at attach time. A new `/call` while one is active **displaces** the active call: it closes the previous socket and hangs its engine before the new one proceeds (a reconnecting window takes over the dead session — the newcomer is never rejected). The displaced call's own `close` handler is identity-guarded (`registry.end` only clears if that engine is still current), so it can't clobber the flag for the call that replaced it. `index.mjs` passes the shared registry into every `/call` attach. The box now logs a reason on attach (`new` / `takeover`) and detach (`park` / `hangup` / `socket close`), plus the takeover.

### Cause 2b (supporting) — orphan session mid-boot
`vccall.mjs`: hangup/park set a `deactivated` flag, and `openTransport` checks it after the Realtime connect resolves — a connect that completes after a takeover/hangup closes the socket instead of leaving a live unbilled-but-fatal orphan session. (The existing `state.active` flag is only true after `session.created`, so it couldn't be used for this.)

### Cause 3 — microphone hears the model
- Capture and playback now share **one** `AudioContext` (`getOrCreateAudioCtx()`), so the browser's echo canceller has a playback reference. Previously two separate contexts meant AEC largely couldn't work.
- The renderer's automatic barge on `input_audio_buffer.speech_started` did **not** exist in the current code — the Realtime session's own interrupt already owns interruption. Nothing to delete. The manual Barge button and the server-driven playback "barge" clear remain.

### Verification
- `npm run typecheck`: exit 0, no errors.
- `npm test`: **2527 pass / 0 fail** (2524 on `main` + 3 new: `callWs` takeover, `createCallRegistry`, `vccall` orphan-guard).
- New test pinned as requested: a second `/call` attach while one is active tears down the first (first engine hung up + socket closed), and the takeover leaves the new call active.
- Manual (dev, done by user): open call window → exactly one greeting, no self-interruption, one call attach in the box logs; speaking over the CTO makes it yield.

**Base:** `origin/main` @ `9fad8975`
