### PR TITLE
fix(call): unmute actually restarts the mic (BET-1187)

### DIFF
--- a/src/renderer/call/CallApp.tsx
+++ b/src/renderer/call/CallApp.tsx
@@ -212,7 +212,6 @@ export function CallApp() {
   }
 
   async function startMic(ws: WebSocket, isCancelled: () => boolean = () => false) {
-    if (!listening) return;
     if (micStreamRef.current) return;
     let stream: MediaStream | null = null;
     try {


### PR DESCRIPTION
## BET-1187 — Call window: muting then unmuting never restarts the mic

### Bug
In `CallApp.tsx`, pressing unmute (`toggleMic`) calls `startMic(ws)` to
restart the mic, but `startMic` began with `if (!listening) return;`. That
`listening` is the render-closure value at the time the current render's
`toggleMic` ran — which, after the user muted, is `false`. So unmute left the
mic dead until the window was reopened.

### Fix
Remove the stale `listening` gate from `startMic` (now
`startMic(ws, isCancelled = () => false)` after the BET-1185 rework). Both
callers want the mic **on**, and the `micStreamRef.current` guard already
prevents a duplicate stream, so the gate was both wrong (stale closure) and
redundant. The mount path is unchanged — the mic still starts on connect
(`await startMic(ws, isCancelled)`). The unmute path (`void startMic(ws)` uses
the default `isCancelled`) now proceeds past the guard and restarts the stream.

Rebased onto current `origin/main` (post-BET-1185 reworked `CallApp.tsx`);
the single-line fix was re-applied in the new `startMic` shape.

### Verification
- `npm run typecheck` — clean (exit 0)
- `npm test` — 2527 pass, 0 fail
- Base: `origin/main @ 2f823dca`

Logs: typecheck sha256 `29e6dab56ead28fa401d3f6f9030441a68dae592703bef3cc7db9ac4aed334d0`, test sha256 `96c02e787bb3eda4a0e80310fc7fdf9b54f8ca1e3b331b1cdb92b962b68e8ce3`.
