### PR TITLE
fix(callWs): detach log takeover reason keys off current state (BET-1188)

### DIFF
--- a/src/server/callWs.mjs
+++ b/src/server/callWs.mjs
@@ -253,7 +253,16 @@ export function attachCallWs(ws, url, opts = {}) {
     // takeover displacing this call) tears the engine down and clears the
     // active flag — identity-guarded so a displaced call can't clear a newer
     // call's flag.
-    clearActive(`socket close${displaced ? " (displaced by takeover)" : ""}`);
+    //
+    // Key the "(displaced by takeover)" label off the registry's CURRENT call
+    // state — whether a DIFFERENT call now holds the flag — not this call's
+    // attach-time `displaced` value (which is what *this* call displaced, and
+    // has nothing to do with why this socket is closing). A call that itself
+    // took over is not being displaced when its socket later closes; a call a
+    // newer one replaced is.
+    const current = registry ? registry.current() : null;
+    const displacedByTakeover = !!current && current.engine !== engine;
+    clearActive(`socket close${displacedByTakeover ? " (displaced by takeover)" : ""}`);
     engine.hangup();
   });
   ws.on("error", () => {

--- a/src/server/callWs.test.mjs
+++ b/src/server/callWs.test.mjs
@@ -265,3 +265,43 @@ test("a second /call attach while one is active tears down the first (takeover)"
   assert.equal(activeState[activeState.length - 1], true, "takeover leaves the new call active");
   assert.equal(registry.isActive(), true, "registry still points at the new call");
 });
+
+test("detach log reason keys off current registry state, not attach-time displaced (BET-1188)", async () => {
+  const registry = createCallRegistry();
+  const logs = [];
+  const makeOpts = () => ({
+    realtimeConnect: async () => ({}),
+    configGet: async () => ({ openaiApiKey: "sk-test", cto: {} }),
+    listTools: () => [],
+    registry,
+    log: (m) => logs.push(m),
+  });
+
+  const firstClient = makeClientWs();
+  attachCallWs(firstClient, new URL("/call", "http://x"), makeOpts());
+  await new Promise((r) => setTimeout(r, 10));
+
+  // A second call takes over the first (it displaces the first call).
+  const secondClient = makeClientWs();
+  attachCallWs(secondClient, new URL("/call", "http://x"), makeOpts());
+  await new Promise((r) => setTimeout(r, 10));
+
+  // The displaced first call's teardown is identity-guarded — a no-op that
+  // logs nothing, by design. So no detach line has been emitted yet.
+  assert.deepEqual(
+    logs.filter((m) => m.startsWith("[call] detach:")),
+    [],
+    "displaced call's identity-guarded teardown logs nothing",
+  );
+
+  // The SECOND call (which took over) now closes for real. Nothing displaced
+  // it, so the log must NOT carry the "(displaced by takeover)" suffix that
+  // the old attach-time `displaced` value would have stamped on it.
+  secondClient.close();
+  await new Promise((r) => setTimeout(r, 10));
+  assert.deepEqual(
+    logs.filter((m) => m.startsWith("[call] detach:")),
+    ["[call] detach: socket close"],
+    "a call that took over is not mislabelled as displaced when it later closes",
+  );
+});


### PR DESCRIPTION
## BET-1188 — detach log reason keys off current registry state (cosmetic)

**Files changed:** `2` files. `src/server/callWs.mjs` (+11/-1), `src/server/callWs.test.mjs` (+40).

Fixes the cosmetic mislabel from BET-1185 review: the `/call` socket `close`
handler stamped its detach log reason with a `(displaced by takeover)` suffix
read off the attach-time `displaced` value — i.e. what *this* call displaced
when it attached, not why this socket is now closing.

- **Before:** a call that itself took over another call (its `displaced` was
  truthy) logged `socket close (displaced by takeover)` when its socket later
  closed normally — a mislabel. The call that a newer one *replaced* logged
  nothing (identity-guarded teardown).
- **After:** the suffix is keyed off the registry's current call state
  (`registry.current()`) — whether a *different* call now holds the flag. A
  call displaced by a newer one is the only case that logs the takeover
  suffix; the call that took over closing normally logs a plain
  `socket close`. Log-only; no teardown/behavior change.

Added a regression test pinning both labels (the taken-over call's
identity-guarded no-op, and the taker's clean `socket close`).

**Verification results:**
- PR branch (`multica/BET-1188-detach-log-takeover-reason` @ `a493ce37`):
  - typecheck: exit `0`. Errors: none. log sha256: `29e6dab56ead28fa401d3f6f9030441a68dae592703bef3cc7db9ac4aed334d0`
  - test: exit `0`, `2528` pass / `0` fail / `0` skip. Failures: none. log sha256: `171c0ed2e02803933152e8eea2bb8ad9b095060a3bc39291fcbc643f53472b92`
- Base (`main` @ `2f823dca`):
  - typecheck: exit `0`. Errors: none. log sha256: `29e6dab56ead28fa401d3f6f9030441a68dae592703bef3cc7db9ac4aed334d0`
  - test: exit `0`, `2527` pass / `0` fail / `0` skip. Failures: none. log sha256: `49f53e76cc131209dc4fb1021a05859f5a5a8e706170e070628b7f76a3f9eeca`
- **Conclusion:** `0` failures are pre-existing, `0` new, `0` resolved. The PR adds one test (2528 vs 2527). (A single flaky `usage.test.mjs` poller timing test failed once mid-run, then passed on re-run on both branches — unrelated to this change.)

Base: `origin/main @ 2f823dca`.
