### PR TITLE
fix(call): send conversation.item.truncate on interruption; tune server VAD (BET-1186)

### DIFF
--- a/src/renderer/call/CallApp.tsx
+++ b/src/renderer/call/CallApp.tsx
@@ -188,6 +188,11 @@ export function CallApp() {
       case "barge":
         outNodeRef.current?.port.postMessage({ kind: "clear" });
         return;
+      case "response-start":
+        // A new response's audio is starting → reset the played counter so an
+        // interruption truncates only THIS response (BET-1186).
+        outNodeRef.current?.port.postMessage({ kind: "reset" });
+        return;
       case NARRATE_KIND:
         // Narration (spec #6): the box synthesized (Groq Orpheus) + streamed
         // this as audio; decode + play it. The working line stays visible.
@@ -259,12 +264,23 @@ export function CallApp() {
   function setupAudioOut(isCancelled: () => boolean = () => false) {
     const ctx = getOrCreateAudioCtx();
     if (!ctx) return;
+    // BET-1186: the worklet is the one place that knows how many samples it
+    // has ACTUALLY written to the output (played), vs what is still queued in
+    // `buf`. It reports ms-played to the renderer on every push so the box can
+    // `conversation.item.truncate` the in-flight reply at exactly the point
+    // the user heard. 24000 Hz → ms = samples / 24.
     const workletSrc = `
       class Out extends AudioWorkletProcessor {
-        constructor(){ super(); this.buf = new Float32Array(0); this.port.onmessage=(e)=>{ const d=e.data; if(d.kind==='push'){ const a=new Float32Array(d.samples); const n=new Float32Array(this.buf.length+a.length); n.set(this.buf); n.set(a,this.buf.length); this.buf=n; } if(d.kind==='clear'){ this.buf=new Float32Array(0); } }; }
+        constructor(){ super(); this.buf = new Float32Array(0); this.played = 0;
+          this.port.onmessage=(e)=>{ const d=e.data;
+            if(d.kind==='push'){ const a=new Float32Array(d.samples); const n=new Float32Array(this.buf.length+a.length); n.set(this.buf); n.set(a,this.buf.length); this.buf=n; this.port.postMessage({kind:'played', ms: Math.round(this.played/24)}); }
+            if(d.kind==='reset'){ this.buf=new Float32Array(0); this.played=0; this.port.postMessage({kind:'played', ms:0}); }
+            if(d.kind==='clear'){ this.buf=new Float32Array(0); }
+          };
+        }
         process(inputs, outputs){
           const out = outputs[0][0]; if(!out) return true;
-          if(this.buf.length>0){ const n=Math.min(out.length,this.buf.length); out.set(this.buf.subarray(0,n)); this.buf=this.buf.subarray(n); }
+          if(this.buf.length>0){ const n=Math.min(out.length,this.buf.length); out.set(this.buf.subarray(0,n)); this.buf=this.buf.subarray(n); this.played+=n; }
           return true;
         }
       }
@@ -278,6 +294,16 @@ export function CallApp() {
         return;
       }
       const node = new AudioWorkletNode(ctx, "pcm-out");
+      // Forward the worklet's played-ms up to the box (the renderer can't read
+      // the audio thread synchronously — the worklet pushes it on each batch).
+      node.port.onmessage = (ev) => {
+        const d = ev.data as { kind?: string; ms?: number };
+        if (d?.kind === "played" && typeof d.ms === "number") {
+          if (wsRef.current?.readyState === WebSocket.OPEN) {
+            wsRef.current.send(JSON.stringify({ type: "played", ms: d.ms }));
+          }
+        }
+      };
       node.connect(ctx.destination);
       outNodeRef.current = node;
       URL.revokeObjectURL(url);

--- a/src/server/callWs.mjs
+++ b/src/server/callWs.mjs
@@ -12,6 +12,7 @@
 //   { type:"audio", delta:<base64 opus> }  → engine.handleUserAudio
 //   { type:"commit" }                       → engine.commitAndRespond
 //   { type:"barge" }                        → engine.barge
+//   { type:"played", ms }                   → engine.setPlayedMs (truncate pt)
 //   { type:"control", action:"park"|"hangup" } → lifecycle
 // Server→client (JSON text): every engine.publish(msg) forwarded verbatim
 //   ({ type:"state"|"audio"|"transcript"|"stt"|"working"|"confirm"|… }).
@@ -232,6 +233,11 @@ export function attachCallWs(ws, url, opts = {}) {
         return;
       case "barge":
         engine.barge();
+        return;
+      case "played":
+        // BET-1186: renderer reports ms it has actually played of the current
+        // response, so an interruption can truncate the conversation there.
+        if (typeof msg.ms === "number") engine.setPlayedMs(msg.ms);
         return;
       case "control":
         if (msg.action === "park") {

--- a/src/server/callWs.test.mjs
+++ b/src/server/callWs.test.mjs
@@ -95,6 +95,29 @@ test("client audio/commit/barge bridge into the Realtime session", async () => {
   assert.ok(sent.some((m) => m.type === "response.cancel"), "barge reaches realtime");
 });
 
+test("client played-ms drives the truncate on interrupt (BET-1186)", async () => {
+  const client = makeClientWs();
+  const rt = makeFakeRealtime();
+  attachCallWs(client, new URL("/call", "http://x"), {
+    realtimeConnect: async () => rt,
+    configGet: async () => ({ openaiApiKey: "sk-test", cto: {} }),
+    listTools: () => [],
+  });
+  await new Promise((r) => setTimeout(r, 10));
+  // The model's audio item is added (tracked server-side)…
+  rt.emit("message", Buffer.from(JSON.stringify({ type: "response.output_item.added", item: { id: "item-9", type: "message", role: "assistant" } })));
+  // …the renderer reports it has played 2000ms…
+  deliver(client, { type: "played", ms: 2000 });
+  // …then the server VAD fires an interruption.
+  rt.emit("message", Buffer.from(JSON.stringify({ type: "input_audio_buffer.speech_started" })));
+  await new Promise((r) => setTimeout(r, 10));
+  const sent = rt.sent.map((s) => JSON.parse(s));
+  assert.ok(
+    sent.some((m) => m.type === "conversation.item.truncate" && m.item_id === "item-9" && m.audio_end_ms === 2000),
+    "truncate sent at the reported played point",
+  );
+});
+
 test("park / hangup clear the call-active flag and hangup the engine", async () => {
   const client = makeClientWs();
   const rt = makeFakeRealtime();

--- a/src/server/vccall.mjs
+++ b/src/server/vccall.mjs
@@ -29,6 +29,31 @@ const REALTIME_BASE = "wss://api.openai.com/v1/realtime";
 const DEFAULT_REALTIME_MODEL = "gpt-realtime-2.1";
 const DEFAULT_VOICE = "alloy";
 
+// Server VAD (voice-activity detection) tuning for a desktop room (BET-1186).
+// `turn_detection.server_vad` is what makes the model consider the user to be
+// speaking — and therefore when it interrupts the in-flight answer (barge) or
+// responds. The API's defaults (threshold 0.5, 300ms prefix padding, 500ms
+// silence) are tuned for a quiet mic, so with a laptop mic and audible
+// speakers the model gets "interrupted" by room noise and by its own voice.
+// What raising/lowering each knob does:
+//   - threshold:         minimum onset loudness to count as speech. Raise
+//                        (->0.7-0.8) to reject room noise / speaker bleed; raise
+//                        too far and quiet-but-real speech is missed.
+//   - prefix_padding_ms: silence appended BEFORE detected speech so no leading
+//                        syllables are swallowed. Raise if word onsets get
+//                        clipped; it is NOT an anti-noise knob.
+//   - silence_duration_ms: how long the user must stay quiet before speech is
+//                        declared finished. Longer suits slow talkers but makes
+//                        the model slow to barge; shorter cuts off sooner.
+// The ecosystem's usual starting point for noisy input is threshold ~0.7 with
+// a tighter silence window (kept here). Tune these from one place after a real
+// call; do NOT add config keys until we have measured values.
+const SERVER_VAD = {
+  threshold: 0.7,
+  prefix_padding_ms: 300,
+  silence_duration_ms: 400,
+};
+
 // Per-1M-token cost of the Realtime model, used to turn a response.done
 // `usage` object into a dollar figure for the per-call spend cap (cost guard).
 // These ratios come from OpenAI's realtime pricing page
@@ -113,6 +138,8 @@ export function createVcCallEngine(deps = {}) {
     openai: null, // ws-like to OpenAI
     tools: [], // [{name,description,params}]
     session: null,
+    responseItemId: null, // in-flight assistant audio item id (for truncate, BET-1186)
+    playedMs: 0, // ms of the current response the renderer has played (BET-1186)
     pendingConfirm: null, // {id, tool, preview, at}
     ongoingSpend: 0, // per-call USD spent
     idleTimer: null,
@@ -233,10 +260,10 @@ export function createVcCallEngine(deps = {}) {
       model,
       instructions: SESSION_INSTRUCTIONS,
       output_modalities: ["audio"],
-      audio: {
-        input: {
-          format: { type: "audio/pcm", rate: 24000 },
-          turn_detection: { type: "server_vad", create_response: true },
+        audio: {
+          input: {
+            format: { type: "audio/pcm", rate: 24000 },
+            turn_detection: { type: "server_vad", create_response: true, ...SERVER_VAD },
           // Input transcription turns the user's speech into text so that a
           // pending confirm can be approved by their actual words (BET-1181).
           transcription: { model: "whisper-1" },
@@ -347,10 +374,27 @@ export function createVcCallEngine(deps = {}) {
   }
 
   function barge() {
+    // BET-1186 correctness half: the renderer owns speaker playback, so the
+    // model cannot know how much of its reply actually reached the user. The
+    // renderer continuously reports ms-played for the current response; on an
+    // interruption truncate the in-flight item at that point so the unplayed
+    // remainder is removed from the model's history — otherwise its next turn
+    // builds on sentences the user never heard. Only when a response item is
+    // tracked AND some audio actually played (nothing playing → no truncate).
+    if (state.responseItemId && state.playedMs > 0) {
+      send({
+        type: "conversation.item.truncate",
+        item_id: state.responseItemId,
+        content_index: 0,
+        audio_end_ms: Math.round(state.playedMs),
+      });
+    }
     // Stop playback + cancel the in-flight model response so the new user
     // input wins. Realtime handles turn-taking natively.
     emit({ type: "barge" });
     send({ type: "response.cancel" });
+    state.responseItemId = null;
+    state.playedMs = 0;
     clearIdleTimer();
   }
 
@@ -392,6 +436,8 @@ export function createVcCallEngine(deps = {}) {
     return {
       status: state.status,
       tools: state.tools.map((t) => t.name),
+      responseItemId: state.responseItemId,
+      playedMs: state.playedMs,
       pendingConfirm: state.pendingConfirm
         ? { id: state.pendingConfirm.id, tool: state.pendingConfirm.tool, preview: state.pendingConfirm.preview }
         : null,
@@ -423,6 +469,20 @@ export function createVcCallEngine(deps = {}) {
       }
       case "response.output_audio.done":
         return armIdleTimer();
+      case "response.output_item.added": {
+        // Track the in-flight assistant (audio) response item id so an
+        // interruption can truncate the conversation at the played point
+        // (BET-1186). A new output item starts a fresh response → reset the
+        // per-response played figure and tell the renderer to reset its
+        // playback counter too.
+        const item = evt?.item;
+        if (item && item.type === "message" && item.role === "assistant") {
+          state.responseItemId = item.id ?? null;
+          state.playedMs = 0;
+          emit({ type: "response-start" });
+        }
+        return;
+      }
       case "response.done": {
         // GA's `response.done` carries complete function-call items in
         // `response.output`; dispatch each one (the only function-call path).
@@ -432,6 +492,8 @@ export function createVcCallEngine(deps = {}) {
         }
         // Feed the completed response's usage into the spend cap (cost guard).
         chargeUsage(evt);
+        // The response finished — nothing left to truncate.
+        state.responseItemId = null;
         return armIdleTimer();
       }
       case "input_audio_buffer.speech_started":
@@ -647,6 +709,13 @@ export function createVcCallEngine(deps = {}) {
     handleUserAudio,
     commitAndRespond,
     barge,
+    // BET-1186: the renderer reports how much of the current response it has
+    // actually played, so an interruption can truncate at the right point.
+    setPlayedMs: (ms) => {
+      if (typeof ms === "number" && Number.isFinite(ms) && ms >= 0) {
+        state.playedMs = ms;
+      }
+    },
     injectTurn,
     hangup,
     park,

--- a/src/server/vccall.test.mjs
+++ b/src/server/vccall.test.mjs
@@ -269,6 +269,89 @@ test("barge: speech_started cancels the in-flight response and notifies the rend
   assert.ok(published.some((m) => m.type === "barge"));
 });
 
+test("interrupt: truncates the in-flight item at the played point (BET-1186)", async () => {
+  const { engine, ws } = makeEngine();
+  await startLive(engine);
+  // The model's audio item is added → tracked, and the renderer is told to
+  // reset its played counter. Then the renderer reports it has played 1500ms.
+  engine.receiveRealtime({
+    type: "response.output_item.added",
+    item: { id: "item-7", type: "message", role: "assistant" },
+  });
+  engine.setPlayedMs(1500);
+  // The user interrupts (server VAD barge path).
+  engine.receiveRealtime({ type: "input_audio_buffer.speech_started" });
+  const sent = json(ws);
+  const trunc = sent.find((m) => m.type === "conversation.item.truncate");
+  assert.ok(trunc, "conversation.item.truncate sent on interrupt");
+  assert.equal(trunc.item_id, "item-7", "carries the tracked response item id");
+  assert.equal(trunc.content_index, 0);
+  assert.equal(trunc.audio_end_ms, 1500, "truncates at the non-zero played point");
+  const truncIdx = sent.findIndex((m) => m.type === "conversation.item.truncate");
+  const cancelIdx = sent.findIndex((m) => m.type === "response.cancel");
+  assert.ok(truncIdx >= 0 && cancelIdx >= 0 && truncIdx < cancelIdx, "truncate precedes response.cancel");
+});
+
+test("interrupt: no truncate is sent when nothing is playing (BET-1186)", async () => {
+  const { engine, ws } = makeEngine();
+  await startLive(engine);
+  engine.receiveRealtime({ type: "input_audio_buffer.speech_started" });
+  const sent = json(ws);
+  assert.equal(sent.some((m) => m.type === "conversation.item.truncate"), false, "no truncate when nothing played");
+  assert.ok(sent.some((m) => m.type === "response.cancel"), "still cancels the response");
+});
+
+test("a completed response clears the tracked item; it is not truncated later (BET-1186)", async () => {
+  const { engine, ws } = makeEngine();
+  await startLive(engine);
+  engine.receiveRealtime({
+    type: "response.output_item.added",
+    item: { id: "item-A", type: "message", role: "assistant" },
+  });
+  engine.setPlayedMs(900);
+  engine.receiveRealtime({ type: "response.done", response: {} });
+  // A later interrupt must NOT truncate the already-completed item.
+  engine.receiveRealtime({ type: "input_audio_buffer.speech_started" });
+  const sent = json(ws);
+  assert.equal(sent.some((m) => m.type === "conversation.item.truncate"), false, "completed item not truncated");
+});
+
+test("a new response output item resets the per-response played figure (BET-1186)", async () => {
+  const { engine, ws } = makeEngine();
+  await startLive(engine);
+  engine.receiveRealtime({
+    type: "response.output_item.added",
+    item: { id: "item-1", type: "message", role: "assistant" },
+  });
+  engine.setPlayedMs(800);
+  // A second response starts → the newest item is tracked and played resets.
+  engine.receiveRealtime({
+    type: "response.output_item.added",
+    item: { id: "item-2", type: "message", role: "assistant" },
+  });
+  assert.equal(engine.listState().responseItemId, "item-2", "tracks the newest response item");
+  assert.equal(engine.listState().playedMs, 0, "played reset to 0 for the new response");
+  const before = json(ws).length;
+  engine.receiveRealtime({ type: "input_audio_buffer.speech_started" });
+  const sent = json(ws).slice(before);
+  assert.equal(
+    sent.some((m) => m.type === "conversation.item.truncate"),
+    false,
+    "no truncate: the new response hasn't played yet",
+  );
+});
+
+test("session.update carries the tuned server_vad named constants (BET-1186)", async () => {
+  const { engine, ws } = makeEngine();
+  await engine.start({ openaiApiKey: "sk-test", cto: {} });
+  const su = json(ws).find((m) => m.type === "session.update");
+  const td = su.session.audio.input.turn_detection;
+  assert.equal(td.type, "server_vad");
+  assert.equal(td.threshold, 0.7);
+  assert.equal(td.prefix_padding_ms, 300);
+  assert.equal(td.silence_duration_ms, 400);
+});
+
 test("narration seam: onNarrate is threaded into the dispatch ctx", async () => {
   let narrated = null;
   const { engine, calls } = makeEngine({


### PR DESCRIPTION
**Base: origin/main @ 2f823dca**

## BET-1186 — send `conversation.item.truncate` on interruption; tune VAD thresholds

Correctness half of interruption handling for the voice call. The renderer owns speaker playback over the WS transport, so the model can't know how much of its reply reached the speakers. This change truncates the in-flight response at the actually-played point on an interruption, so the model's next turn no longer builds on sentences the user never heard.

### What changed

- **Renderer — track played audio** (`src/renderer/call/CallApp.tsx`): the audio-out worklet now counts the samples it has *actually written to the output* (vs what remains queued in its buffer) and reports `ms` played to the box on each push. A new downstream `response-start` event resets the per-response played counter (and clears the buffer).
- **Engine — truncate on barge** (`src/server/vccall.mjs`): `barge()` now sends `conversation.item.truncate` (`item_id`, `content_index: 0`, `audio_end_ms: playedMs`) *before* `response.cancel` when a response item is in flight **and** some audio actually played. Nothing playing → no truncate.
- **Engine — track the in-flight response item** (`src/server/vccall.mjs`): `response.output_item.added` (assistant message) records `responseItemId` and resets `playedMs`/emits `response-start`; `response.done` clears it. `setPlayedMs()` is wired from the `/call` WS `played` message (`src/server/callWs.mjs`).
- **VAD thresholds** (`src/server/vccall.mjs`): `threshold`/`prefix_padding_ms`/`silence_duration_ms` become named `SERVER_VAD` constants beside the model default, documented for what raising/lowering each does, starting at threshold 0.7 with a tighter silence window (400ms). No config keys added — deliberate, per the issue.

Both interrupt paths (manual Barge button and server-VAD `speech_started`) route through the same `barge()`, so both truncate. Anti-spaghetti: this reuses the existing single barge path that BET-1185 left intact — no second code path added.

### Verification results

**Files changed:** 4 files. `src/server/vccall.mjs`, `src/server/callWs.mjs`, `src/server/vccall.test.mjs`, `src/server/callWs.test.mjs`, `src/renderer/call/CallApp.tsx`

- PR branch (`multica/BET-1186-vccall-truncate` @ `6fbea8b0`):
  - typecheck: exit 0. Errors: none. log sha256: `29e6dab56ead28fa401d3f6f9030441a68dae592703bef3cc7db9ac4aed334d0`
  - test: exit 0, 2533 pass / 0 fail / 0 skip. Failures: none. log sha256: `171c0ed2e02803933152e8eea2bb8ad9b095060a3bc39291fcbc643f53472b92`
- Base (`main` @ `2f823dca`): the base checkout lives in a sibling worktree, so a full base-branch re-run wasn't produced; the PR-branch suite is fully green (0 failures), so there are no new test failures introduced.
- **Conclusion:** 0 new test failures; the added BET-1186 regression tests (truncate on interrupt with played-ms, no-truncate-when-silent, clear-on-complete, per-response reset, VAD constants, WS played wiring) all pass.

**Manual verification (the point of the change) — NOT yet performed.** The required physical test is: interrupt the CTO mid-sentence, then ask "what did you just say?" and confirm it references only what was actually heard. That needs a live desktop call window with a working mic/speakers, which is not available on this implementer's box. The engine/decision logic is covered by unit tests; the audio-path manual check on a real device is left for human/`macos` verification.
