### PR TITLE
fix(scripts): keep tmux sessions across server restarts (KillMode=process)

### DIFF
--- a/.github/workflows/macos-install-smoke.yml
+++ b/.github/workflows/macos-install-smoke.yml
@@ -356,6 +356,36 @@ jobs:
           tmux -V
           echo "ok — server-side tmux works."
 
+      - name: Assert — tmux sessions survive a server restart (BET-1192)
+        run: |
+          set -euo pipefail
+          # Linux kills tmux on every restart because it lives in the service's
+          # systemd cgroup. macOS launchd kills by PROCESS GROUP, which tmux
+          # daemonizes itself out of at startup — so sessions SHOULD survive a
+          # `launchctl kickstart -k`. This assertion proves that expectation: if
+          # it fails, BET-1192's macOS side needs its own (separate) fix, not a
+          # guessed plist edit.
+          name="survival"
+          curl -fsS -X POST http://127.0.0.1:8787/rpc/tmux:new-session \
+            -H "authorization: Bearer $MANTA_TOKEN" \
+            -H 'content-type: application/json' \
+            --data "{\"args\":[{\"name\":\"$name\",\"cwd\":\"$HOME\"}]}" \
+            -o /dev/null \
+            || { echo "FAIL: could not create survival session"; exit 1; }
+          tmux has-session -t "$name" || { echo "FAIL: session not present before restart"; exit 1; }
+          launchctl kickstart -k "gui/$(id -u)/com.mantaui.server"
+          for i in $(seq 1 30); do
+            # Any status (incl. the unpaired 401) = the listener is back.
+            if [ "$(curl -s -o /dev/null -w '%{http_code}' http://127.0.0.1:8787/auth/status || true)" != "000" ]; then
+              break
+            fi
+            sleep 1
+          done
+          tmux has-session -t "$name" \
+            || { echo "FAIL: tmux session '$name' was killed by the server restart"; exit 1; }
+          echo "ok — session '$name' survived the server restart (macOS launchd kills by process group)"
+          tmux kill-session -t "$name" || true
+
       - name: Assert — re-running the installer preserves box identity
         run: |
           set -euo pipefail

--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -347,3 +347,66 @@ should_skip_self_update() {
   fi
   return 1
 }
+
+# ensure_kill_policy_text — echo unit text with `KillMode=process` present in
+# [Service] exactly once. Idempotent, and NEVER overrides an existing
+# KillMode= line whatever its value (an operator's explicit choice wins).
+# $1 = full unit file text. Behaviour, exhaustively:
+#   * text already containing any line matching `^KillMode=` -> echo unchanged,
+#     byte for byte
+#   * otherwise -> insert `KillMode=process` on the line immediately after
+#     [Service]
+#   * no [Service] section at all -> echo unchanged (nothing safe to do)
+ensure_kill_policy_text() {
+  local text="$1" line
+  # Already carries a KillMode line (whatever its value) -> leave byte-for-byte.
+  if printf '%s\n' "$text" | grep -q '^KillMode='; then
+    printf '%s' "$text"
+    return 0
+  fi
+  # No [Service] section -> nothing safe to anchor the insert on.
+  if ! printf '%s\n' "$text" | grep -q '^\[Service\]'; then
+    printf '%s' "$text"
+    return 0
+  fi
+  # Insert KillMode=process on the line immediately after [Service]. sed keeps
+  # every other byte (and trailing newline) untouched, so the insert is exact
+  # and re-applying is a no-op (the next run sees ^KillMode= and returns early).
+  printf '%s' "$text" | sed '/^\[Service\]$/a KillMode=process'
+  return 0
+}
+
+# ensure_server_kill_policy — patch the INSTALLED systemd unit in place if
+# needed and daemon-reload so the NEXT restart uses it. Never fatal: the worst
+# case on any failure is the pre-existing behaviour (sessions destroyed by the
+# restart), which is no worse than not running this at all.
+# $1 = unit path, default $HOME/.config/systemd/user/manta-server.service.
+# Behaviour, exhaustively:
+#   * unit file missing (macOS, nohup fallback) -> return 0, write nothing
+#   * patched text identical to current text -> return 0, do NOT write, do NOT
+#     daemon-reload
+#   * text changed -> write it back, `systemctl --user daemon-reload`, log once
+#   * any failure (unwritable file, daemon-reload non-zero) -> warn, return 0
+ensure_server_kill_policy() {
+  local unit="${1:-$HOME/.config/systemd/user/manta-server.service}"
+  local current patched
+  [ -f "$unit" ] || return 0
+  if ! current="$(cat "$unit")"; then
+    warn "ensure_server_kill_policy: could not read $unit"
+    return 0
+  fi
+  patched="$(ensure_kill_policy_text "$current")" || return 0
+  if [ "$patched" = "$current" ]; then
+    return 0
+  fi
+  if ! printf '%s' "$patched" > "$unit"; then
+    warn "ensure_server_kill_policy: could not write $unit"
+    return 0
+  fi
+  if ! systemctl --user daemon-reload; then
+    warn "ensure_server_kill_policy: daemon-reload failed for $unit"
+    return 0
+  fi
+  log "manta-server unit patched with KillMode=process ($unit)"
+  return 0
+}

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -521,3 +521,134 @@ test("should_skip_self_update: box stale + no CLI changed → do NOT skip", () =
 test("should_skip_self_update: box stale + a CLI changed → do NOT skip", () => {
   assert.equal(shouldSkip("0.0.29", "abc123", "0.0.30", "def456", "1"), false);
 });
+
+// --- KillMode policy (BET-1192): the systemd unit patch -----------------------
+//
+// The systemd default KillMode=control-group SIGTERMs every process in the
+// service's cgroup on stop/restart, and manta-server's tmux + pane shells live
+// in that cgroup — so every restart destroyed every session. The fix narrows
+// the kill to the main process with KillMode=process. `ensure_kill_policy_text`
+// is the pure text transform (unit-tested directly); `ensure_server_kill_policy`
+// patches the INSTALLED unit in place and daemon-reloads. The patcher must be
+// idempotent and NEVER override an operator's explicit KillMode= line.
+
+// The shipped systemd template — used by the drift guard below. The test file
+// lives in scripts/lib/, so the template is one dir up under scripts/systemd/.
+const MANTA_SERVICE_TEMPLATE = join(__dirname, "../systemd/manta-server.service");
+
+const SERVICE_TEXT = `[Unit]
+Description=manta box server
+[Service]
+Type=simple
+Restart=on-failure
+[Install]
+WantedBy=default.target
+`;
+
+/** Source release.sh and echo the result of ensure_kill_policy_text "$KILL_TEXT". */
+function killPolicyText(text) {
+  // Pass the text via an env var (not argv) so arbitrary content survives
+  // shell quoting; the function echoes the (possibly transformed) text.
+  return execFileSync(
+    "bash",
+    ["-c", `log(){ :;}; ok(){ :;}; warn(){ :;}; die(){ echo "$*" >&2; exit 1; }\n. '${RELEASE_LIB}'\nensure_kill_policy_text "$KILL_TEXT"`],
+    { env: { ...process.env, KILL_TEXT: text }, encoding: "utf-8" },
+  );
+}
+
+test("ensure_kill_policy_text: text with no KillMode gains ONE KillMode=process right after [Service]", () => {
+  const out = killPolicyText(SERVICE_TEXT);
+  assert.equal(out, `[Unit]\nDescription=manta box server\n[Service]\nKillMode=process\nType=simple\nRestart=on-failure\n[Install]\nWantedBy=default.target\n`);
+  assert.equal((out.match(/^KillMode=process$/gm) ?? []).length, 1, "exactly one KillMode=process");
+});
+
+test("ensure_kill_policy_text: already containing KillMode=process comes back byte-identical", () => {
+  const text = `[Service]\nKillMode=process\nRestart=on-failure\n`;
+  assert.equal(killPolicyText(text), text);
+});
+
+test("ensure_kill_policy_text: containing KillMode=mixed is never overridden", () => {
+  const text = `[Service]\nKillMode=mixed\nRestart=on-failure\n`;
+  assert.equal(killPolicyText(text), text);
+});
+
+test("ensure_kill_policy_text: applying twice equals applying once (idempotent)", () => {
+  const once = killPolicyText(SERVICE_TEXT);
+  assert.equal(killPolicyText(once), once);
+});
+
+test("ensure_kill_policy_text: a unit with no [Service] section is left unchanged", () => {
+  const text = `[Unit]\nDescription=no service section\n`;
+  assert.equal(killPolicyText(text), text);
+});
+
+/**
+ * Source release.sh and run ensure_server_kill_policy against a real temp unit
+ * path, with `systemctl` stubbed on PATH to a recorder so the test can assert
+ * whether daemon-reload actually ran. Returns { status, stdout, reloaded }.
+ */
+function runServerKillPolicy(unitPath) {
+  const dir = mkdtempSync(join(tmpdir(), "manta-kill-"));
+  const binDir = join(dir, "bin");
+  mkdirSync(binDir, { recursive: true });
+  const calls = join(dir, "systemctl.calls");
+  // Stub systemctl on PATH to a recorder so the test can assert whether
+  // daemon-reload actually ran (the function must only reload when it wrote).
+  writeFileSync(
+    join(binDir, "systemctl"),
+    `#!/bin/sh\nprintf '%s\\n' "$*" >> '${calls}'\nexit 0\n`,
+    { mode: 0o755 },
+  );
+  const r = sourceAndRun(`ensure_server_kill_policy '${unitPath}'`, {
+    preamble: `export PATH='${binDir}':"$PATH"`,
+  });
+  let reloaded = false;
+  if (existsSync(calls)) {
+    reloaded = readFileSync(calls, "utf8").split("\n").some((l) => l.includes("daemon-reload"));
+  }
+  rmSync(dir, { recursive: true, force: true });
+  return { status: r.status, stdout: r.stdout, reloaded };
+}
+
+test("ensure_server_kill_policy: a missing unit path returns 0 and creates nothing", () => {
+  const missing = join(mkdtempSync(join(tmpdir(), "manta-kill-missing-")), "nope.service");
+  const r = runServerKillPolicy(missing);
+  assert.equal(r.status, 0);
+  assert.equal(existsSync(missing), false, "must not create the unit");
+  assert.equal(r.reloaded, false, "must not daemon-reload for a missing unit");
+});
+
+test("ensure_server_kill_policy: patches a unit that lacks KillMode and daemon-reloads", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-kill-"));
+  const unitPath = join(dir, "manta-server.service");
+  writeFileSync(unitPath, SERVICE_TEXT);
+  try {
+    const r = runServerKillPolicy(unitPath);
+    assert.equal(r.status, 0);
+    assert.match(readFileSync(unitPath, "utf8"), /^KillMode=process$/m);
+    assert.equal(r.reloaded, true, "a changed unit must trigger daemon-reload");
+    assert.match(r.stdout, /patched with KillMode=process/);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("ensure_server_kill_policy: an already-patched unit is not rewritten and not daemon-reloaded", () => {
+  const dir = mkdtempSync(join(tmpdir(), "manta-kill-"));
+  const unitPath = join(dir, "manta-server.service");
+  const text = `[Service]\nKillMode=process\nRestart=on-failure\n`;
+  writeFileSync(unitPath, text);
+  try {
+    const r = runServerKillPolicy(unitPath);
+    assert.equal(r.status, 0);
+    assert.equal(readFileSync(unitPath, "utf8"), text, "file must be byte-identical");
+    assert.equal(r.reloaded, false, "no-op patch must not daemon-reload");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("drift guard: the shipped systemd template is already unchanged by ensure_kill_policy_text", () => {
+  const template = readFileSync(MANTA_SERVICE_TEMPLATE, "utf8");
+  assert.equal(killPolicyText(template), template);
+});

--- a/scripts/self-update.sh
+++ b/scripts/self-update.sh
@@ -460,6 +460,12 @@ restart_server() {
   # supervisor and the user is expected to restart by hand.
   if command -v systemctl >/dev/null 2>&1; then
     echo "▸ self-update: restarting manta-server.service"
+    # BET-1192: patch the installed unit with KillMode=process (and
+    # daemon-reload) BEFORE the restart. systemd stops the unit using the
+    # currently-loaded config, so the patch must complete first — done this
+    # way the FIRST upgrade to the fixed version already saves the user's
+    # sessions instead of being the last update to destroy them.
+    ensure_server_kill_policy
     systemctl --user restart manta-server.service
   elif [ "$(uname -s)" = "Darwin" ]; then
     echo "▸ self-update: kickstarting com.mantaui.server LaunchAgent"

--- a/scripts/systemd/manta-server.service
+++ b/scripts/systemd/manta-server.service
@@ -47,6 +47,12 @@ Environment=MANTA_CHANNEL=@@MANTA_CHANNEL@@
 # hop, so the box is reachable WITHOUT TLS on this listener.
 Environment=MANTA_TAILNET_HOST=@@MANTA_TAILNET_HOST@@
 Environment=PATH=@@AGENT_PATH@@
+# tmux and every pane shell are children of this service and therefore live in
+# its cgroup. The systemd default (KillMode=control-group) SIGTERMs the whole
+# cgroup on stop/restart, which destroyed every session on the box on every
+# restart — including the one the self-update performs on itself. Narrow the
+# kill to the main process so sessions (and the update script) survive.
+KillMode=process
 Restart=on-failure
 RestartSec=2
 # Give the server a moment to flush on stop before SIGKILL.


### PR DESCRIPTION
## BET-1192 — Server restart destroys every tmux session

Every restart of `manta-server` SIGTERMed the whole systemd cgroup, tmux + pane
shells included, destroying every session (sidebars empty, "no projects").
Fix: narrow the kill to the main process with `KillMode=process`.

### What changed
- `scripts/systemd/manta-server.service` — add `KillMode=process` with a comment
  (install.sh picks it up for free via its `@@…@@` sed render; no install.sh edit).
- `scripts/lib/release.sh` — `ensure_kill_policy_text` (pure text transform, inserts
  `KillMode=process` right after `[Service]`, idempotent, never overrides an existing
  `KillMode=` line) + `ensure_server_kill_policy` (patches the installed unit in place,
  daemon-reloads only when it wrote, never fatal).
- `scripts/self-update.sh` — one call site: `ensure_server_kill_policy` before
  `systemctl --user restart` inside `restart_server()`'s systemctl branch.
- `scripts/lib/release.test.mjs` — new tests incl. the template drift guard.
- `.github/workflows/macos-install-smoke.yml` — assertion that a tmux session
  survives a `launchctl kickstart -k` (launchd kills by process group, so macOS
  should be unaffected; if it fails the macOS side is a separate fix).

Did NOT touch install.sh, opencode-serve.service, src/server/tmux.mjs,
src/server/pty.mjs, or any renderer code (per issue "Do NOT" list).

**Files changed:** `5` files, `236` insertions. `[.github/workflows/macos-install-smoke.yml, scripts/lib/release.sh, scripts/lib/release.test.mjs, scripts/self-update.sh, scripts/systemd/manta-server.service]`

**Base: origin/main @ `db4ef2de`**

**Verification results:**
- PR branch (`multica/BET-1192-narrow-systemd-kill-policy` @ `ec3b18d6`):
  - typecheck: exit `0`. Errors: `none`. log sha256: `120d3f59e1265ffc20a1c7aa5db5276ee3d326f5a5e6bfccc9e3550d9662c86c`
  - test: exit `0`, `2543` pass / `0` fail / `0` skip. Failures: `none`. log sha256: `32d80b344eb5c2952010a7f77ac1a976db7ede91f1caff14c714d72f6ec08e50`
- Base (`main` @ `db4ef2de`):
  - typecheck: exit `0`. Errors: `none`. log sha256: `120d3f59e1265ffc20a1c7aa5db5276ee3d326f5a5e6bfccc9e3550d9662c86c`
  - test: exit `0`, `2534` pass / `0` fail / `0` skip. Failures: `none`. log sha256: `f0bbeae1532b68ebd135813e969d23a61190963f3dd2016f001a5bc6dc3b7a52`
- **Conclusion:** `0` test failures are pre-existing, `0` failures are new. The PR adds `9` passing tests.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

> Note: live staging-box verification (`root@135.181.255.249`) was not run from this
> run — the code path is covered by unit tests (patcher text transform, idempotency,
> drift guard) and the Linux mechanism is exactly the `KillMode=process` verified in
> the issue's own write-up. The issue's expected side effects (stray pty shells orphaned
> rather than killed) could not be confirmed live here.
