### PR TITLE
BET-1193: fix(renderer): end update in-flight on landed version edge, not compatibility level

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -24,7 +24,7 @@ import {
   resolveLauncherFlags,
 } from "./chatShared";
 import type { SyncPayload } from "../shared/api";
-import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, pruneVisitedSessions, registerMountedTerminal, shouldResyncWindowsForJobs, dispatchAppControl, dispatchMedia, applyMediaEvent, formatResetAt, voiceUi, type AppControlHandlers, type MountedTerminal } from "./chatUtils";
+import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, pruneVisitedSessions, registerMountedTerminal, shouldResyncWindowsForJobs, dispatchAppControl, dispatchMedia, applyMediaEvent, formatResetAt, voiceUi, boxUpgradeLanded, type AppControlHandlers, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
 import { UpdateBar } from "./UpdateBar";
 import { ConfirmModal } from "./ConfirmModal";
@@ -64,6 +64,13 @@ import { providerLabel } from "./UsageDial";
 // link can never be misclaimed by a `manta://`-registered app, and a
 // `manta://` link can never silently pass through a staging build.
 const PAIR_PARSE_SCHEME = channelConfig(__MANTA_CHANNEL__).urlScheme;
+
+// How long the in-flight upgrade state may persist before it is force-cleared
+// so the user can retry. A real observed box update (opencode upgrade +
+// download + dependency swap + two service restarts) took ~95s end to end, so
+// the old 120s left almost no headroom and would flip the bar back to a
+// clickable state while the box was still updating.
+const BOX_UPGRADE_MAX_MS = 600_000;
 
 // BET-659: Artifacts panel open/closed — device-local, default CLOSED. Lazy
 // read with try/catch (repo convention — localStorage can throw).
@@ -1475,6 +1482,12 @@ function Shell() {
   const updateAllRunRef = useRef(false);
   const updateAllBoxConfirmed = useRef(false);
   const updateAllResolvers = useRef<{ resolve: (ok: boolean) => void } | null>(null);
+
+  // The box version at the moment the upgrade was started. The in-flight state
+  // ends when the box comes back reporting a DIFFERENT one — see
+  // boxUpgradeLanded. A ref, not state: it is click-scoped, must not trigger a
+  // render, and must be readable in the effect without being a dependency.
+  const upgradeFromVersionRef = useRef<string | null>(null);
   const [updateAllConfirmBody, setUpdateAllConfirmBody] = useState<string | null>(null);
 
   // Step 4 of runUpdateAll: once the desktop download has landed (updatePrompt
@@ -1498,25 +1511,25 @@ function Shell() {
     setUpdateRefreshKey((k) => k + 1);
   }, [connectionState.state, boxUpgrading]);
 
-  // Once the box has advanced (variant is no longer "behind"), end the in-flight
-  // state and clear any stale update-failed banner + frozen progress — the upgrade
-  // landed. A REAL early failure leaves the box behind, so `compatibilityVariant`
-  // stays "behind", `boxUpgrading` is cleared directly in applyServerUpdate, and
-  // the actionable banner persists for retry.
+  // Once the box restarts onto a DIFFERENT build than the one the upgrade was
+  // started from (see boxUpgradeLanded — an edge, never the version-relationship
+  // level), end the in-flight state and clear any stale update-failed banner +
+  // frozen progress: the upgrade landed. A REAL early failure leaves the box on
+  // the same build, so the state is instead cleared directly in applyServerUpdate
+  // and the actionable banner persists for retry.
   useEffect(() => {
     if (!boxUpgrading) return;
-    if (compatibilityVariant === "match" || compatibilityVariant === "unknown") {
-      setBoxUpgrading(false);
-      useStore.getState().setUpdatingTarget(null);
-      useStore.getState().setServerUpdateProgress(null);
-      setUpdateError(null);
-      // The box run has completed and the connection is confirmed back (the
-      // reconnect refetch advanced the version). If runUpdateAll has a desktop
-      // install waiting on the box leg, fire it now.
-      updateAllBoxConfirmed.current = true;
-      finishUpdateAllOnce();
-    }
-  }, [boxUpgrading, compatibilityVariant]);
+    if (!boxUpgradeLanded(upgradeFromVersionRef.current, serverVersion)) return;
+    setBoxUpgrading(false);
+    useStore.getState().setUpdatingTarget(null);
+    useStore.getState().setServerUpdateProgress(null);
+    setUpdateError(null);
+    // The box run has completed and the connection is confirmed back (the
+    // reconnect refetch advanced the version). If runUpdateAll has a desktop
+    // install waiting on the box leg, fire it now.
+    updateAllBoxConfirmed.current = true;
+    finishUpdateAllOnce();
+  }, [boxUpgrading, serverVersion]);
 
   // Safety net: never leave the banner stuck in the in-flight state (e.g. the box
   // reconnected but somehow never advanced). Cap it; the user can then retry.
@@ -1526,7 +1539,7 @@ function Shell() {
       setBoxUpgrading(false);
       useStore.getState().setUpdatingTarget(null);
       useStore.getState().setServerUpdateProgress(null);
-    }, 120_000);
+    }, BOX_UPGRADE_MAX_MS);
     return () => clearTimeout(t);
   }, [boxUpgrading]);
 
@@ -1536,32 +1549,25 @@ function Shell() {
     boxUpgrading && connectionState.state !== "connected" && connectionState.state !== "idle";
 
   const applyServerUpdate = async () => {
-    // DIAG: capture the banner server-update lifecycle so a "no loading state"
-    // report can be traced against runtime truth instead of assumptions.
-    console.debug("[update] applyServerUpdate start, boxUpgrading was", boxUpgrading);
+    upgradeFromVersionRef.current = serverVersion;
     setBoxUpgrading(true);
     // Mark the server row as the in-flight target so Settings' per-target
     // spinner actually renders ("updating"). boxUpgrading alone only made the
     // row "busy" (disabled, NO spinner), which is exactly the missing server
     // loading state. Cleared on the reconcile / cap / early-failure paths below.
     useStore.getState().setUpdatingTarget("server");
-    console.debug("[update] applyServerUpdate boxUpgrading now TRUE, updatingTarget=server");
     try {
       const res = await window.api.serverUpdateApply();
-      console.debug("[update] serverUpdateApply resolved", res);
       if (res && res.ok === false) {
-        console.debug("[update] serverUpdateApply ok:false → clearing in-flight", res.error);
         useStore.getState().setUpdatingTarget(null);
         setBoxUpgrading(false);
         setUpdateError({ message: res.error || "Server update failed", raw: res.error ?? "" });
       }
     } catch (e) {
-      const transient = isTransientUpdateNetworkError(e);
-      console.debug("[update] serverUpdateApply rejected, transient?", transient, "err:", String(e));
       // A bare connection error is the box restarting itself mid-update (the
       // success path) — swallow it; the reconnect + version re-check above
       // resolves the real outcome. Structured failures still raise the banner.
-      if (transient) return;
+      if (isTransientUpdateNetworkError(e)) return;
       useStore.getState().setUpdatingTarget(null);
       setBoxUpgrading(false);
       setUpdateError({

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -42,6 +42,7 @@ import {
   runWithConcurrency,
   chooseUpdateSkewVariant,
   isTransientUpdateNetworkError,
+  boxUpgradeLanded,
   describeUpdateTarget,
   arrowUpNavigatesHistory,
   arrowDownNavigatesHistory,
@@ -1625,6 +1626,19 @@ describe("isTransientUpdateNetworkError", () => {
     expect(isTransientUpdateNetworkError(undefined)).toBe(false);
     expect(isTransientUpdateNetworkError("")).toBe(false);
     expect(isTransientUpdateNetworkError(42)).toBe(false);
+  });
+});
+
+// ===== boxUpgradeLanded =====
+describe("boxUpgradeLanded", () => {
+  it("returns true only when both versions are present and differ", () => {
+    expect(boxUpgradeLanded(null, "1.0.1")).toBe(false);
+    expect(boxUpgradeLanded("1.0.0", null)).toBe(false);
+    expect(boxUpgradeLanded("", "1.0.1")).toBe(false);
+    expect(boxUpgradeLanded("1.0.0", "")).toBe(false);
+    expect(boxUpgradeLanded("1.0.0", "1.0.0")).toBe(false);
+    expect(boxUpgradeLanded("1.0.0", "1.0.1")).toBe(true);
+    expect(boxUpgradeLanded("1.0.1", "1.0.0")).toBe(true);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -1202,6 +1202,31 @@ export function isTransientUpdateNetworkError(err: unknown): boolean {
   );
 }
 
+/**
+ * Has the box restarted onto a different build than the one it was running
+ * when the upgrade was started?
+ *
+ * This is the ONLY signal that ends the in-flight upgrade state. It is an
+ * edge (the version CHANGED), never a level — the previous implementation
+ * asked "is the box currently not behind the desktop", which is already true
+ * when the user clicks and so cancelled the in-flight state instantly.
+ *
+ * Any change counts, not just a newer version: a different build means the
+ * box restarted, which is what the state is waiting for. Deliberately no
+ * version comparison — that would drag in ordering rules for no benefit.
+ *
+ * A missing value on either side can never satisfy this. That is intentional:
+ * "we don't know" must not read as "it worked". Those cases fall through to
+ * the caller's timeout.
+ */
+export function boxUpgradeLanded(
+  fromVersion: string | null | undefined,
+  currentVersion: string | null | undefined,
+): boolean {
+  if (!fromVersion || !currentVersion) return false;
+  return fromVersion !== currentVersion;
+}
+
 // ===== Composer arrow-key: history vs caret navigation =====
 //
 // The OLD logic scanned for `\n` before/after the caret to decide "first/last


### PR DESCRIPTION
Fixes BET-1193.

## Problem
Clicking the server-update banner's action produced no visible change. Root
cause: the reconcile effect that ends the in-flight upgrade state read
`compatibilityVariant` (a LEVEL: "is the box behind right now"), which is
already `"match"`/`"unknown"` at click time when desktop and server are on the
same released version — so the effect cleared `boxUpgrading` in the very same
commit `applyServerUpdate` set it. The busy bar never mounted and the seven
MANTA_PROGRESS steps were discarded. The 120s cap was dead code.

## Fix
- `chatUtils.ts`: new pure `boxUpgradeLanded(from, current)` — true iff both
  versions are present and differ (an EDGE: the box restarted onto a different
  build). No version comparison; a missing value never reads as "worked".
- `App.tsx`: capture the pre-upgrade server version in `upgradeFromVersionRef`
  as the first statement of `applyServerUpdate`; the reconcile effect now keys
  off `boxUpgradeLanded(upgradeFromVersionRef.current, serverVersion)`.
  `compatibilityVariant` no longer appears in that effect or its deps (it stays
  for the incompatible banner). Reuses the existing `serverVersion` from
  `useCompatibilityCard(updateRefreshKey)` — no new fetch/RPC/endpoint.
- Safety cap raised `120_000` inline → `BOX_UPGRADE_MAX_MS = 600_000`
  (observed real update ≈95s, old cap left ~no headroom).
- Removed all `console.debug("[update] …")` diagnostics from `db4ef2d`.
- `chatUtils.test.ts`: table test for `boxUpgradeLanded`.

## Do-not touched (per issue)
- Reconnect effect that bumps `updateRefreshKey` (what makes `serverVersion`
  advance) — untouched.
- No `boxUpgrading` flag added to `bannerPriority.ts`; in-flight bar stays
  rendered unconditionally.
- `updateTargets` / `refreshUpdateTargets` / `describeUpdateBanner` untouched.
- No App-level mounted regression test (pure test only, per issue).

**Base: origin/main @ db4ef2de**

**Files changed:** 3 — `src/renderer/App.tsx`, `src/renderer/chatUtils.ts`, `src/renderer/chatUtils.test.ts`.
