### PR TITLE
fix(renderer): every download reports itself, naming the full destination folder

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -365,6 +365,26 @@ require-confirm toast the user hasn't answered isn't re-offered every 3s.
   `agentFileToast` in the store, App.tsx owns the one `onAgentFileReady`
   listener, the active ChatPanel renders it. De-dupe on collision via
   `uniqueLocalPath` (`report.pdf` → `report (1).pdf`).
+- **`/api/download` is scoped to the user's HOME dir, not to the outbox
+  (BET-1195).** Inline media shown via `media_show` can sit at ANY path inside
+  home — the tool never copies it into the mailbox — so an outbox-only guard
+  meant a file the transcript happily DISPLAYED (`/api/peek`, already
+  home-scoped, same bearer) could not be SAVED: the download 403'd, the desktop
+  bridge returned `""`, and the renderer threw a bare "download failed". The two
+  routes now share one rule. This does not widen what an authenticated client
+  can read; it only stops display and download from disagreeing.
+- **Every download REPORTS ITSELF (BET-1198) — `saveToDownloads` in
+  `src/renderer/downloadFeedback.ts` is the one non-toast call site.** The
+  inline-media hover/preview Download and the artifacts row were previously
+  fire-and-forget: a success showed nothing and a failure showed only an
+  "Uncaught (in promise)" in devtools, so the two were indistinguishable from a
+  dead button — a WORKING save was reported as broken more than once. Rules:
+  desktop success → a confirmation toast naming the **full destination folder**
+  (`Saved dog.mp4 to /Users/x/Downloads`) + Reveal; mobile/web (`agentPullFile`
+  returns `""`) → silent ON PURPOSE, the browser owns that chrome; failure → an
+  error toast saying the file is still on the server. The agent-file toast keeps
+  its own Save→Reveal lifecycle but shares the copy via `savedToastMessage`.
+  Name the folder, never just "Downloads": `downloadsDir` makes that ambiguous.
 - **The AI sends files via the `send_file` tool** (`docs/opencode-tools/send-file.ts`,
   a manta-native opencode tool like `serve_page`). It POSTs the file path + its
   `context.sessionID` to `POST /api/outbox/push`, which copies the file into

--- a/src/renderer/ArtifactsPanel.tsx
+++ b/src/renderer/ArtifactsPanel.tsx
@@ -43,6 +43,7 @@ import {
   type PlanStatus,
 } from "./artifacts";
 import { decodeDataUri, expiryLabel, formatBytes, resolvePreviewType } from "./chatUtils";
+import { saveToDownloads } from "./downloadFeedback";
 import { IconButton } from "./IconButton";
 import { ArtifactPreview } from "./ArtifactPreview";
 import { ReviewPane } from "./ReviewPane";
@@ -100,11 +101,10 @@ export async function downloadArtifact(artifact: Artifact): Promise<void> {
     artifact.href &&
     !artifact.href.startsWith("data:")
   ) {
-    try {
-      await window.api.agentPullFile(artifact.href);
-    } catch {
-      /* download failed on desktop — non-fatal; the source stays on the box */
-    }
+    // BET-1198: `saveToDownloads` reports the outcome (confirmation naming the
+    // full folder, or an error toast). The old swallow-and-return-silently made
+    // a real save and a real failure look identical — like nothing happened.
+    await saveToDownloads(artifact.href);
     return;
   }
   try {

--- a/src/renderer/GlobalToasts.test.tsx
+++ b/src/renderer/GlobalToasts.test.tsx
@@ -1,0 +1,88 @@
+// @vitest-environment jsdom
+//
+// Render tests for the agent-file toast's save lifecycle (BET-1198).
+//
+// The regression this locks: a COMPLETED save has to read as a completed save.
+// The pre-BET-1198 copy ("· saved to Downloads", same ↓ glyph as before the
+// save) was faint enough — and ambiguous enough once a custom downloads folder
+// is configured — that a working save was reported as "nothing happened".
+
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { mount, installMockApi, type Harness } from "./testHarness";
+import { GlobalToasts } from "./GlobalToasts";
+import { useStore } from "./store";
+
+describe("agent-file toast", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    useStore.setState({ appToasts: [], agentFileToast: null, systemNotice: null });
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    useStore.setState({ appToasts: [], agentFileToast: null });
+  });
+
+  function toastText() {
+    return h!.container.textContent ?? "";
+  }
+
+  it("offers Save before the pull, with no claim about where anything landed", () => {
+    installMockApi({});
+    useStore.setState({
+      agentFileToast: {
+        remotePath: "/home/dev/.manta-outbox/ses_x/dog-running.mp4",
+        name: "dog-running.mp4",
+        size: 983374,
+        sessionName: "ses_x",
+        autoPulled: false,
+      },
+    });
+    h = mount(<GlobalToasts />);
+
+    expect(toastText()).toContain("AI sent you a file");
+    expect(toastText()).not.toContain("saved to");
+    const labels = [...h.container.querySelectorAll("button")].map((b) => b.textContent);
+    expect(labels).toContain("Save");
+  });
+
+  it("confirms the save by naming the FULL folder, and offers Reveal", () => {
+    installMockApi({});
+    useStore.setState({
+      agentFileToast: {
+        remotePath: "/home/dev/.manta-outbox/ses_x/dog-running.mp4",
+        name: "dog-running.mp4",
+        size: 983374,
+        sessionName: "ses_x",
+        autoPulled: true,
+        localPath: "/Users/antoine/Downloads/dog-running.mp4",
+      },
+    });
+    h = mount(<GlobalToasts />);
+
+    expect(toastText()).toContain("saved to /Users/antoine/Downloads");
+    expect(toastText()).toContain("✓");
+    const labels = [...h.container.querySelectorAll("button")].map((b) => b.textContent);
+    expect(labels).toContain("Reveal");
+  });
+
+  it("falls back to the generic wording when there is no OS path (mobile/web)", () => {
+    installMockApi({});
+    useStore.setState({
+      agentFileToast: {
+        remotePath: "/home/dev/.manta-outbox/ses_x/dog-running.mp4",
+        name: "dog-running.mp4",
+        size: 983374,
+        sessionName: "ses_x",
+        autoPulled: true,
+      },
+    });
+    h = mount(<GlobalToasts />);
+
+    // No path is claimed, because none exists on that transport.
+    expect(toastText()).toContain("saved to Downloads");
+    expect(toastText()).not.toContain("saved to /");
+  });
+});

--- a/src/renderer/GlobalToasts.tsx
+++ b/src/renderer/GlobalToasts.tsx
@@ -18,7 +18,7 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { useStore } from "./store";
 import { ToastStack, type ToastItem } from "./Toast";
-import { formatBytes } from "./chatUtils";
+import { describeSavedFile, formatBytes } from "./chatUtils";
 
 export function GlobalToasts() {
   const agentFileToast = useStore((s) => s.agentFileToast);
@@ -97,14 +97,27 @@ export function GlobalToasts() {
     for (const id of toastOrder) {
       if (id === "agent-file" && agentFileToast) {
         const size = formatBytes(agentFileToast.size);
+        const savedFolder = describeSavedFile(agentFileToast.localPath)?.dir ?? null;
         items.push({
           id: "agent-file",
+          // Post-save the toast becomes a CONFIRMATION naming the full folder
+          // (BET-1198). The old "· saved to Downloads" was both too faint to
+          // notice and ambiguous once a custom downloads folder is configured,
+          // so a completed save was routinely read as "nothing happened".
+          // `savedFolder` is null on mobile/web (no OS path), which keeps the
+          // old generic wording there rather than claiming a path we don't have.
           message: (
             <>
-              <span className="text-text">↓ {agentFileToast.name}</span>
+              <span className="text-text">
+                {agentFileToast.autoPulled ? "✓" : "↓"} {agentFileToast.name}
+              </span>
               {size && <span className="text-text-faint"> · {size}</span>}
               <span className="text-text-faint">
-                {agentFileToast.autoPulled ? " · saved to Downloads" : " — AI sent you a file"}
+                {!agentFileToast.autoPulled
+                  ? " — AI sent you a file"
+                  : savedFolder
+                    ? ` · saved to ${savedFolder}`
+                    : " · saved to Downloads"}
               </span>
             </>
           ),

--- a/src/renderer/MediaBody.tsx
+++ b/src/renderer/MediaBody.tsx
@@ -38,6 +38,7 @@ import {
   mediaKindFromMime,
   resolveMediaAspect,
 } from "./chatUtils";
+import { saveToDownloads } from "./downloadFeedback";
 import { useClockTick, WORKING_TICK_MS, nowMs } from "./clock";
 
 // The reserved box is capped at a sane reading width so a huge aspect never
@@ -199,8 +200,13 @@ function ReadyMedia({ entry }: { entry: MediaEntry }) {
   // through the preload bridge → main writes a real file to downloadsDir;
   // on mobile/web it falls back to a browser download. Used by both the hover
   // overlay and the preview overlay's Download.
+  //
+  // Goes through `saveToDownloads` so the save REPORTS ITSELF (BET-1198): this
+  // used to be a bare fire-and-forget call, so a successful download showed the
+  // user nothing at all and a failed one showed only an unhandled rejection in
+  // devtools — indistinguishable from each other, and from a broken button.
   const handleDownload = () => {
-    if (meta.path) void window.api.agentPullFile(meta.path);
+    if (meta.path) void saveToDownloads(meta.path);
   };
 
   return (

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -8,6 +8,7 @@ import {
   computeLiveTurn,
   formatTokens,
   formatBytes,
+  describeSavedFile,
   voiceUiEnabled,
   expiryLabel,
   formatDuration,
@@ -294,6 +295,45 @@ describe("formatBytes", () => {
     expect(formatBytes(1024 * 1024)).toBe("1 MB");
     expect(formatBytes(5.5 * 1024 * 1024)).toBe("5.5 MB");
     expect(formatBytes(3 * 1024 * 1024 * 1024)).toBe("3 GB");
+  });
+});
+
+// ===== describeSavedFile =====
+
+describe("describeSavedFile", () => {
+  it("splits an absolute POSIX path into folder + name", () => {
+    expect(describeSavedFile("/Users/antoine/Downloads/dog-running.mp4")).toEqual({
+      dir: "/Users/antoine/Downloads",
+      name: "dog-running.mp4",
+    });
+  });
+
+  it("splits a Windows path on backslashes", () => {
+    expect(describeSavedFile("C:\\Users\\antoine\\Downloads\\report.pdf")).toEqual({
+      dir: "C:\\Users\\antoine\\Downloads",
+      name: "report.pdf",
+    });
+  });
+
+  it("keeps the root slash rather than reporting an empty folder", () => {
+    expect(describeSavedFile("/dog.png")).toEqual({ dir: "/", name: "dog.png" });
+  });
+
+  it("returns null when there is no OS path to describe (mobile/web)", () => {
+    // agentPullFile returns "" on mobile — the browser owns the download
+    // chrome there, so the toast must not claim a path we don't have.
+    expect(describeSavedFile("")).toBeNull();
+    expect(describeSavedFile("   ")).toBeNull();
+    expect(describeSavedFile(undefined)).toBeNull();
+    expect(describeSavedFile(null)).toBeNull();
+  });
+
+  it("returns null for a bare directory (no file name)", () => {
+    expect(describeSavedFile("/Users/antoine/Downloads/")).toBeNull();
+  });
+
+  it("treats a bare filename as having no folder", () => {
+    expect(describeSavedFile("dog.png")).toEqual({ dir: "", name: "dog.png" });
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -234,6 +234,38 @@ export function formatBytes(n: number): string {
   return `${val < 10 ? val.toFixed(1).replace(/\.0$/, "") : Math.round(val)} ${units[i]}`;
 }
 
+// ===== Download confirmation (BET-1198) =====
+//
+// Every desktop download (outbox toast Save, inline-media hover/preview
+// Download, artifacts row) ends by writing a REAL file to the downloads
+// folder — but the only feedback used to be a faint "· saved to Downloads"
+// on one of the three, and nothing at all on the other two. A save the user
+// can't see reads as a save that didn't happen (that is exactly how a working
+// inline-media download got reported as broken). The confirmation names the
+// FULL folder so the file is findable without guessing which folder "Downloads"
+// meant — a custom `downloadsDir` in Settings makes that genuinely ambiguous.
+//
+// Pure: split a saved absolute path into the folder that holds it and the file
+// name. Returns null when there is no OS path to describe — mobile/web, where
+// agentPullFile hands the bytes to the browser and returns "" (the browser owns
+// the "downloaded" chrome there, so we must not claim a path we don't have).
+export function describeSavedFile(
+  localPath: string | undefined | null,
+): { dir: string; name: string } | null {
+  if (typeof localPath !== "string") return null;
+  const trimmed = localPath.trim();
+  if (!trimmed) return null;
+  // Windows separators too — the desktop app ships on Windows and main hands
+  // back whatever `path.join` produced there.
+  const cut = Math.max(trimmed.lastIndexOf("/"), trimmed.lastIndexOf("\\"));
+  if (cut < 0) return { dir: "", name: trimmed };
+  const name = trimmed.slice(cut + 1);
+  if (!name) return null; // a bare directory ("/a/b/") is not a saved file
+  // Keep the root slash: dirname("/x.png") is "/", not "".
+  const dir = cut === 0 ? trimmed.slice(0, 1) : trimmed.slice(0, cut);
+  return { dir, name };
+}
+
 // Decode a `data:<mime>;base64,<payload>` (or url-encoded) URI into its MIME
 // type and raw bytes. Used by the artifacts panel so a self-contained inline
 // image (href is a data URI, not a box path) can be downloaded/attached

--- a/src/renderer/downloadFeedback.test.ts
+++ b/src/renderer/downloadFeedback.test.ts
@@ -1,0 +1,92 @@
+// @vitest-environment jsdom
+//
+// Tests for the download-confirmation helper (BET-1198).
+//
+// The property under test is the one the bug was about: EVERY outcome of a
+// download is visible. A silent success is a bug (it reads as "nothing
+// happened"), and so is a silent failure.
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { saveToDownloads, savedToastMessage } from "./downloadFeedback";
+import { useStore } from "./store";
+
+function toasts() {
+  return useStore.getState().appToasts;
+}
+
+describe("savedToastMessage", () => {
+  it("names the file and its FULL folder", () => {
+    expect(savedToastMessage("/Users/antoine/Downloads/dog-running.mp4")).toBe(
+      "Saved dog-running.mp4 to /Users/antoine/Downloads",
+    );
+  });
+
+  it("is null when there is no local path (mobile/web browser download)", () => {
+    expect(savedToastMessage("")).toBeNull();
+  });
+});
+
+describe("saveToDownloads", () => {
+  const realApi = (globalThis as { window?: { api?: unknown } }).window?.api;
+
+  beforeEach(() => {
+    useStore.setState({ appToasts: [] });
+  });
+
+  afterEach(() => {
+    (window as unknown as { api?: unknown }).api = realApi;
+    vi.restoreAllMocks();
+  });
+
+  function installApi(api: Record<string, unknown>) {
+    (window as unknown as { api: Record<string, unknown> }).api = api;
+  }
+
+  it("confirms a desktop save with the full folder and offers Reveal", async () => {
+    const revealInFolder = vi.fn(async () => {});
+    installApi({
+      agentPullFile: vi.fn(async () => "/Users/antoine/Downloads/dog-running.mp4"),
+      revealInFolder,
+    });
+
+    await saveToDownloads("/home/dev/dog-running.mp4");
+
+    expect(toasts()).toHaveLength(1);
+    expect(String(toasts()[0].message)).toBe(
+      "Saved dog-running.mp4 to /Users/antoine/Downloads",
+    );
+    // The confirmation is actionable: Reveal opens the containing folder.
+    toasts()[0].actions?.[0].onClick();
+    expect(revealInFolder).toHaveBeenCalledWith("/Users/antoine/Downloads/dog-running.mp4");
+  });
+
+  it("stays silent on mobile/web, where the browser shows its own download UI", async () => {
+    installApi({ agentPullFile: vi.fn(async () => ""), revealInFolder: vi.fn() });
+    await saveToDownloads("/home/dev/dog-running.mp4");
+    expect(toasts()).toHaveLength(0);
+  });
+
+  it("reports a failure instead of throwing an unhandled rejection", async () => {
+    installApi({
+      agentPullFile: vi.fn(async () => {
+        throw new Error("download failed");
+      }),
+      revealInFolder: vi.fn(),
+    });
+
+    // Must not reject — the old fire-and-forget call site surfaced failures
+    // only as "Uncaught (in promise)" in devtools.
+    await expect(saveToDownloads("/home/dev/dog-running.mp4")).resolves.toBeUndefined();
+    expect(toasts()).toHaveLength(1);
+    expect(toasts()[0].tone).toBe("error");
+    expect(String(toasts()[0].message)).toContain("still on the server");
+  });
+
+  it("no-ops on an empty path", async () => {
+    const agentPullFile = vi.fn(async () => "/x/y");
+    installApi({ agentPullFile, revealInFolder: vi.fn() });
+    await saveToDownloads("");
+    expect(agentPullFile).not.toHaveBeenCalled();
+    expect(toasts()).toHaveLength(0);
+  });
+});

--- a/src/renderer/downloadFeedback.ts
+++ b/src/renderer/downloadFeedback.ts
@@ -1,0 +1,68 @@
+// ===== Download confirmation — the ONE place a save reports itself =====
+//
+// Every desktop download funnels through `window.api.agentPullFile` (BET-1156:
+// preload bridge → main writes a real file to the downloads folder and returns
+// its absolute path). What it did NOT have was feedback: the inline-media
+// hover/preview Download and the artifacts row were fire-and-forget — success
+// showed nothing, and a rejection surfaced only as an "Uncaught (in promise)"
+// in devtools. A save the user cannot see reads as a save that did not happen,
+// which is exactly how a WORKING inline-media download got reported as broken.
+//
+// So: one helper, used by every non-toast download call site, that always ends
+// in a visible outcome —
+//   desktop success → "Saved <name> to <full folder>" + Reveal
+//   mobile/web      → nothing (agentPullFile returns "": the browser owns the
+//                     download chrome there; a toast would duplicate it)
+//   failure         → an error toast that says the file was NOT saved
+//
+// The agent-file toast (GlobalToasts) keeps its own Save/Reveal lifecycle — it
+// mutates a toast that already exists rather than pushing a new one — but shares
+// the same copy via `savedToastMessage` so the two can't drift.
+
+import { describeSavedFile } from "./chatUtils";
+import { useStore } from "./store";
+
+/** Confirmation copy for a saved file. Exported so the agent-file toast and
+ *  this helper render the SAME sentence. `dir` is the full folder path: with a
+ *  custom downloads folder configured, "saved to Downloads" is ambiguous and
+ *  the user has to go hunting. */
+export function savedToastMessage(localPath: string): string | null {
+  const saved = describeSavedFile(localPath);
+  if (!saved) return null;
+  return saved.dir ? `Saved ${saved.name} to ${saved.dir}` : `Saved ${saved.name}`;
+}
+
+/**
+ * Pull a box file to the user's machine and report the outcome.
+ *
+ * Never throws — a download is an incidental action, so a failure is a toast,
+ * not an exception the caller has to remember to catch (forgetting is what put
+ * the "Uncaught (in promise)" in the console).
+ */
+export async function saveToDownloads(remotePath: string): Promise<void> {
+  if (!remotePath) return;
+  const { pushAppToast } = useStore.getState();
+  try {
+    const localPath = await window.api.agentPullFile(remotePath);
+    const message = savedToastMessage(localPath);
+    // No local path → mobile/web, where the browser already shows its own
+    // download UI. Staying silent there is deliberate, not a missing case.
+    if (!message) return;
+    pushAppToast({
+      message,
+      actions: [
+        {
+          label: "Reveal",
+          onClick: () => void window.api.revealInFolder(localPath),
+        },
+      ],
+    });
+  } catch {
+    // The source file stays on the box (downloads are non-destructive), so a
+    // retry is always safe — say so instead of failing silently.
+    pushAppToast({
+      tone: "error",
+      message: "Couldn’t save the file — it’s still on the server, try again.",
+    });
+  }
+}


### PR DESCRIPTION
Follow-up to #1195. That fixed the server refusing to serve inline media for download; this fixes the other half the user actually hit — **the save worked and looked like it hadn't**.

## The problem

- The inline-media hover/preview Download and the artifacts row called `agentPullFile` fire-and-forget. A successful save showed **nothing**; a failed one showed only `Uncaught (in promise) Error: download failed` in devtools. Success, failure and "the button is dead" were indistinguishable from the UI.
- The outbox toast did report, but as a faint `· saved to Downloads` behind the **same ↓ glyph it showed before the save**. And "Downloads" is ambiguous the moment a custom `downloadsDir` is configured, so the file isn't findable from the message.

Reported as "the download button is broken" and "the toast Save button doesn't work" — both were saving correctly the whole time.

## The change

One helper, `saveToDownloads` (`src/renderer/downloadFeedback.ts`), owns the outcome for every non-toast download call site:

| outcome | what the user sees |
|---|---|
| desktop success | `Saved dog-running.mp4 to /Users/x/Downloads` + **Reveal** |
| mobile/web (`agentPullFile` → `""`) | nothing, deliberately — the browser owns that chrome |
| failure | error toast: the file is still on the server, retry is safe |

It never throws (forgetting a `catch` at a call site is exactly what produced the console rejection). The agent-file toast keeps its own Save→Reveal lifecycle but shares the copy via `savedToastMessage` and flips to a ✓, so the two can't drift.

Call sites routed through it: `MediaBody` (hover overlay + preview Download), `ArtifactsPanel.downloadArtifact` (desktop branch).

## Tests

- `describeSavedFile` — POSIX / Windows / root-slash / no-path / bare-directory / bare-filename
- `saveToDownloads` — confirmation copy + Reveal wiring, mobile silence, failure resolves with an error toast instead of rejecting, empty-path no-op
- `GlobalToasts` — render coverage for the three agent-file states (pre-save Save, post-save full folder + Reveal, mobile fallback wording)

`npm run typecheck` clean; full suite green (168 renderer files / 3208 tests, server 2543).