### PR TITLE
fix(renderer): desktop update gets a proper in-flight state (BET-1195)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -35,6 +35,7 @@ import {
   describeUpdateBanner,
   planUpdateAll,
   isCliTarget,
+  desktopUpdateBusy,
 } from "../shared/updateTargets.mjs";
 import { refreshUpdateTargets } from "./updateCheck";
 import { parsePairPayload } from "../shared/pairPayload";
@@ -247,6 +248,11 @@ function Shell() {
   // `boxUpgrading` it makes up the aggregate `busy` that disables the banner
   // / Settings rows while ANY update runs.
   const updatingTargetId = useStore((s) => s.updatingTargetId);
+  // BET-1195: the desktop leg's in-flight state, owned in the shared store (not
+  // Settings) so the banner and the Settings row can never disagree. The
+  // percent is fed from IPC.autoUpdateProgress at App level; the restart beat is
+  // the App-local `desktopRestarting` below (the desktop analogue of boxRestarting).
+  const desktopDownloadPercent = useStore((s) => s.desktopDownloadPercent);
   const connectionState = useStore((s) => s.connectionState);
   const launcherFlags = useStore((s) => s.launcherFlags);
   const createDraft = useStore((s) => s.createDraft);
@@ -942,6 +948,21 @@ function Shell() {
     return off;
   }, []);
 
+  // BET-1195: the desktop leg's in-flight DOWNLOAD percent lives in the shared
+  // store, subscribed ONCE here at App level, so the banner AND Settings both
+  // read the SAME value and can never disagree (the old Settings-local copy is
+  // what made the banner path + runUpdateAll show nothing — the state never
+  // left that component). main emits this on every electron-updater
+  // `download-progress` tick; zero here only when no download is running.
+  useEffect(() => {
+    const off = window.api.onAutoUpdateProgress?.((p) => {
+      useStore.getState().setDesktopDownloadPercent(
+        typeof p.percent === "number" ? Math.max(0, Math.min(100, p.percent)) : null,
+      );
+    });
+    return off;
+  }, []);
+
   // Terminal auto-update failure. Main only forwards failures the user has to
   // ACT on (integrity / permission — see shared/updateError.mjs); transient
   // network errors never arrive here, so this banner can't nag about a flaky
@@ -1473,6 +1494,14 @@ function Shell() {
   // error/progress clear.
   const [boxUpgrading, setBoxUpgrading] = useState(false);
 
+  // BET-1195: the DESKTOP leg's terminal INSTALL / app-restart beat — the
+  // analogue of `boxRestarting`. Set right before `autoUpdateInstall()` (which
+  // quits + reinstalls), it puts the bar into a non-dismissible, indeterminate
+  // "Restarting Manta Desktop…" state. quitAndInstall gives no progress events,
+  // so it is intentionally never cleared — the app dies a moment later, and
+  // this is deliberately the last thing the user sees.
+  const [desktopRestarting, setDesktopRestarting] = useState(false);
+
   // runUpdateAll state (stage 3, BET-1098). `updateAllRunRef` is true while a
   // run's DESKTOP install is pending; `updateAllBoxConfirmed` is true once the
   // box leg (if any) has completed AND the connection is confirmed back. A
@@ -1498,6 +1527,11 @@ function Shell() {
     if (!useStore.getState().updatePrompt) return;
     if (!updateAllBoxConfirmed.current) return;
     updateAllRunRef.current = false;
+    // BET-1195: the install/restart beat. Set BEFORE autoUpdateInstall — the
+    // bar flips to the indeterminate "Restarting Manta Desktop…" state (the
+    // desktop analogue of boxRestarting) as the last thing the user sees; the
+    // window quits a moment later, so this state is never cleared by design.
+    setDesktopRestarting(true);
     void window.api.autoUpdateInstall();
   };
 
@@ -1547,6 +1581,16 @@ function Shell() {
   // indeterminate "Restarting the box…" presentation instead of a frozen step.
   const boxRestarting =
     boxUpgrading && connectionState.state !== "connected" && connectionState.state !== "idle";
+
+  // BET-1195: the DESKTOP leg's presentation, decided by the pure shared helper
+  // (`desktopUpdateBusy`) so the banner and Settings can never disagree. null
+  // while no desktop update is running; otherwise the download label/progress
+  // or the terminal "Restarting Manta Desktop…" beat.
+  const desktopBusy = desktopUpdateBusy({
+    updatingTargetId,
+    desktopDownloadPercent,
+    desktopRestarting,
+  });
 
   const applyServerUpdate = async () => {
     upgradeFromVersionRef.current = serverVersion;
@@ -1615,6 +1659,40 @@ function Shell() {
     }
   };
 
+  // ===== Desktop download (BET-1195) =====
+  //
+  // The ONE shared runner for the desktop download leg, used by BOTH call sites
+  // (runUpdateAll's desktop leg and handleTargetUpdate's `desktop` branch — a
+  // desktop update applied once through a second, subtly different copy is how
+  // this feature lost its loading state the first time). It sets the shared
+  // in-flight state (`updatingTargetId = "desktop"` + a 0% seed), runs the
+  // download, and clears that state on EVERY terminal path as the never-stuck
+  // invariant demands:
+  //   - download resolves   → the `update-downloaded` event set updatePrompt;
+  //                           the row/banner recover to the "restart" state.
+  //   - download rejects    → clear + surface via the per-row error so the
+  //                           row/banner recover to a retryable button (a bare
+  //                           `.catch(()=>{})` would otherwise WEDGE the busy
+  //                           state we just introduced).
+  // The install/restart beat is NOT this function's job (it is App-level
+  // finishUpdateAllOnce / the caller's), so it needs no knowledge of it.
+  const runDesktopDownload = async () => {
+    useStore.getState().setUpdatingTarget("desktop");
+    useStore.getState().setDesktopDownloadPercent(0);
+    try {
+      await window.api.autoUpdateDownload();
+      useStore.getState().setUpdatingTarget(null);
+      useStore.getState().setDesktopDownloadPercent(null);
+    } catch (e) {
+      useStore.getState().setUpdatingTarget(null);
+      useStore.getState().setDesktopDownloadPercent(null);
+      useStore.getState().setTargetUpdateError(
+        "desktop",
+        e instanceof Error ? e.message : "Update download failed",
+      );
+    }
+  };
+
   // The ONE per-target update router, shared by the Settings rows and the
   // banner's single-target path (BET-1159). Routes by target id — the only
   // discriminator (`isCliTarget`, never label or disruption). `desktop` keeps
@@ -1626,7 +1704,7 @@ function Shell() {
       return;
     }
     if (t.id === "desktop") {
-      void window.api.autoUpdateDownload().catch(() => {});
+      void runDesktopDownload();
       return;
     }
     // server — the box's own self-update flow (confirm → applyServerUpdate).
@@ -1642,17 +1720,12 @@ function Shell() {
   const runUpdateAll = async () => {
     const plan = planUpdateAll(updateTargets);
 
-    // 1. Desktop download in flight CONCURRENTLY with the box work — free
-    //    wall-clock time. A rejection here degrades to "no desktop install at
-    //    the end"; it must not abort the box leg.
-    if (plan.desktopDownload) {
-      window.api.autoUpdateDownload().catch(() => {});
-    }
-
-    // 2. One confirm if anything disruptive is about to happen. Cancelling
-    //    cancels the WHOLE run — the download already in flight simply is
-    //    never installed. A CLI-only update (needsConfirm false) shows NO
-    //    dialog at all: nothing disruptive happens, so nothing interrupts.
+    // 1. One confirm if anything disruptive is about to happen. Cancelling
+    //    cancels the WHOLE run — and because the desktop leg only STARTS after
+    //    this point, a cancelled run has started nothing, so no desktop
+    //    in-flight state is ever set (the never-stuck invariant). A CLI-only
+    //    update (needsConfirm false) shows NO dialog at all: nothing disruptive
+    //    happens, so nothing interrupts.
     if (plan.needsConfirm) {
       const ok = await new Promise<boolean>((resolve) => {
         updateAllResolvers.current = { resolve };
@@ -1662,6 +1735,14 @@ function Shell() {
     }
 
     if (plan.desktopInstall) updateAllRunRef.current = true;
+
+    // 2. Desktop download in flight CONCURRENTLY with the box work — free
+    //    wall-clock time. runDesktopDownload owns the desktop in-flight state
+    //    and clears it on every terminal path. A rejection here degrades to "no
+    //    desktop install at the end"; it must not abort the box leg.
+    if (plan.desktopDownload) {
+      void runDesktopDownload();
+    }
 
     // 3. Box leg. `applyServerUpdate` owns boxUpgrading / serverUpdateProgress /
     //    boxRestarting / the 120s cap / isTransientUpdateNetworkError — reused
@@ -1790,7 +1871,7 @@ function Shell() {
             state matters most. `boxUpgrading` stays true until the version
             re-check confirms the box advanced (or the 120s cap / a real early
             failure). */}
-        {!showOnboarding && (boxUpgrading || updatingTargetId != null) && (
+        {!showOnboarding && (boxUpgrading || updatingTargetId != null || desktopRestarting) && (
           <UpdateBar
             text={updateBanner?.text ?? "Updating…"}
             actionLabel={updateBanner?.actionLabel ?? "Update"}
@@ -1798,8 +1879,26 @@ function Shell() {
             dismissible={false}
             tone={updateBanner?.tone}
             busy
-            progress={boxUpgrading && !boxRestarting ? serverUpdateProgress ?? undefined : undefined}
-            busyLabel={boxRestarting ? "Restarting the server…" : "Updating…"}
+            // BET-1195: each in-flight leg presents its own bar. The box leg
+            // keeps its determinate step progress / "Restarting the server…";
+            // the DESKTOP leg (the gap BET-1160 left) shows its download percent
+            // while downloading and the terminal "Restarting Manta Desktop…"
+            // beat before install — both from the shared `desktopUpdateBusy`
+            // helper so this bar and Settings always agree.
+            progress={
+              boxUpgrading
+                ? !boxRestarting
+                  ? serverUpdateProgress ?? undefined
+                  : undefined
+                : desktopBusy?.progress ?? undefined
+            }
+            busyLabel={
+              boxUpgrading
+                ? boxRestarting
+                  ? "Restarting the server…"
+                  : "Updating…"
+                : desktopBusy?.busyLabel ?? "Updating…"
+            }
           />
         )}
         {!showOnboarding && activeBanner === "updates" && updateBanner &&
@@ -2054,6 +2153,13 @@ function Shell() {
           // discriminator (`isCliTarget`) and the per-CLI run; Settings only
           // needs to delegate a CLI row to it.
           onCliUpdate={(t) => void runCliUpdate(t)}
+          // BET-1195: the desktop row delegates to App's single desktop
+          // download runner (runs through the shared store so Settings and the
+          // banner can never disagree), and receives the App-local restart beat
+          // so the row can't present a download that the banner says is
+          // restarting.
+          onDesktopUpdate={() => void runDesktopDownload()}
+          desktopRestarting={desktopRestarting}
         />
       )}
       {searchOpen && activeChatSessionId != null && (

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -38,7 +38,7 @@ import { BANNER_BTN } from "./Toast";
 import { errorDisclosure } from "./settingsError";
 import { describeUpdateTarget, voiceUi } from "./chatUtils";
 import { refreshUpdateTargets } from "./updateCheck";
-import { rowUpdateState, isCliTarget } from "../shared/updateTargets.mjs";
+import { rowUpdateState, isCliTarget, desktopUpdateBusy } from "../shared/updateTargets.mjs";
 import { forgeCredentialSecondary } from "./chatUtils";
 import { useCachedResource } from "./useCachedResource";
 import { MantaLoader } from "./MantaLoader";
@@ -294,16 +294,17 @@ function GroupCard({ title, danger = false, children }: {
  */
 function UpdateTargetRow({
   target,
-  downloading,
-  downloadPercent,
+  desktopBusy,
   installReady,
   onUpdate,
   rowState,
   error,
 }: {
   target: UpdateTarget;
-  downloading: boolean;
-  downloadPercent: number | null;
+  /** BET-1195: the desktop leg's presentation (from `desktopUpdateBusy`), so
+   *  the row and the banner agree. null for non-desktop targets / no desktop
+   *  run in flight. */
+  desktopBusy: { busyLabel: string; progress: { step: number; total: number; label: string } | null } | null;
   installReady: boolean;
   onUpdate: (t: UpdateTarget) => void;
   rowState: { kind: "updating" } | { kind: "busy" } | { kind: "idle" };
@@ -331,7 +332,15 @@ function UpdateTargetRow({
   // rest are quiet text (ok / error) or a manual link (muted, when there is a
   // URL to offer).
   let action: ReactNode = null;
-  if (updating) {
+  if (target.id === "desktop" && desktopBusy) {
+    // BET-1195: the desktop row shows its REAL in-flight state — the download
+    // percent, or the terminal "Restarting Manta Desktop…" beat — from the
+    // shared helper, instead of the generic "Updating…" spinner. Same label the
+    // banner shows; they can never diverge.
+    action = (
+      <span className="shrink-0 text-meta text-text-faint">{desktopBusy.busyLabel}</span>
+    );
+  } else if (updating) {
     // THIS target is the one being updated — its own spinner + label. No other
     // row shows a spinner; those are just disabled via `busy`.
     action = (
@@ -349,21 +358,13 @@ function UpdateTargetRow({
     // suppress the desktop row's own Update button then, since a second one
     // would re-download an already-downloaded update.
     if (!(target.id === "desktop" && installReady)) {
-      if (target.id === "desktop" && downloading) {
-        action = (
-          <span className="shrink-0 text-meta text-text-faint">
-            {downloadPercent == null ? "Downloading…" : `Downloading ${Math.round(downloadPercent)}%`}
-          </span>
-        );
-      } else {
-        // Disabled while any update is in flight (`busy`); re-enabled (with the
-        // inline error above) so the user can retry a failed row.
-        action = (
-          <button className={BANNER_BTN} disabled={busy} onClick={() => onUpdate(target)}>
-            Update
-          </button>
-        );
-      }
+      // Disabled while any update is in flight (`busy`); re-enabled (with the
+      // inline error above) so the user can retry a failed row.
+      action = (
+        <button className={BANNER_BTN} disabled={busy} onClick={() => onUpdate(target)}>
+          Update
+        </button>
+      );
     }
   } else if (row.tone === "muted") {
     if (target.manualUrl) {
@@ -414,6 +415,8 @@ export function Settings({
   onRequestServerUpdate,
   busy = false,
   onCliUpdate,
+  onDesktopUpdate,
+  desktopRestarting = false,
 }: {
   onClose: () => void;
   /** Section to land on when the modal mounts (e.g. the `manta-open-settings`
@@ -436,6 +439,17 @@ export function Settings({
    *  (decided by the shared `isCliTarget` discriminator) so the Settings rows
    *  and App's banner route through the SAME path — no second discriminator. */
   onCliUpdate?: (t: UpdateTarget) => void;
+  /** BET-1195: App's single desktop download runner. Settings delegates the
+   *  desktop row here (mirroring the CLI story) so the desktop leg's in-flight
+   *  state lives in the shared store — the banner and the row can never
+   *  disagree. The row's download percent + restart beat come from the store /
+   *  this prop, not a Settings-local copy. */
+  onDesktopUpdate?: () => void;
+  /** BET-1195: App-local flag set right before quit-and-install (the desktop
+   *  analogue of boxRestarting). Passed down so the row can show "Restarting
+   *  Manta Desktop…" instead of a download percent the download no longer talks
+   *  about. */
+  desktopRestarting?: boolean;
 }) {
   // BET-730: per-field selectors, never a bare useStore() — a no-selector
   // destructure re-renders the whole Settings tree on every store write.
@@ -463,12 +477,21 @@ export function Settings({
   // target's last transient error (null = none).
   const updatingTargetId = useStore((s) => s.updatingTargetId);
   const targetUpdateErrors = useStore((s) => s.targetUpdateErrors);
+  // BET-1195: the desktop download's live percent, owned in the SHARED store
+  // (fed at App level from IPC.autoUpdateProgress) so this row and the banner
+  // can never disagree. The old Settings-local copy is what left the banner
+  // path and runUpdateAll with no loading state.
+  const desktopDownloadPercent = useStore((s) => s.desktopDownloadPercent);
   const setUpdatingTarget = useStore((s) => s.setUpdatingTarget);
   const setTargetUpdateError = useStore((s) => s.setTargetUpdateError);
-  // Terminal auto-update failure (integrity / permission / unusable feed).
-  // Read here only to end About's "Downloading…" state — the banner owns
-  // reporting it.
-  const updateError = useStore((s) => s.updateError);
+  // BET-1195: the desktop leg's presentation, decided by the SAME pure shared
+  // helper the banner uses, so the row and the banner can never disagree about
+  // whether the desktop is downloading (with what percent) or restarting.
+  const desktopBusy = desktopUpdateBusy({
+    updatingTargetId,
+    desktopDownloadPercent,
+    desktopRestarting,
+  });
   const boxToken = useStore((s) => s.boxToken);
   const serverUrl = useStore((s) => s.serverUrl);
   const push = useStore((s) => s.pushAppToast);
@@ -547,16 +570,17 @@ export function Settings({
   // inside it: a failure of one leg still reports the other.
   const [checking, setChecking] = useState(false);
   const [checkedAt, setCheckedAt] = useState<number | null>(null);
-  const [downloading, setDownloading] = useState(false);
-  const [downloadPercent, setDownloadPercent] = useState<number | null>(null);
 
   // BET-1160 never-stuck invariant: a fresh Settings open (re)mount resets the
   // transient in-flight update state to idle — no stale spinner, no button left
   // permanently disabled from a previous session. Durable truth (what is
   // available / up to date) comes from `updateTargets`, not from the transient
   // `updatingTargetId` / `targetUpdateErrors`, so discarding them here is safe.
+  // The desktop download percent is also cleared here (BET-1195): a re-opened
+  // Settings must not present a stale percent for a download that ended.
   useEffect(() => {
     setUpdatingTarget(null);
+    useStore.getState().setDesktopDownloadPercent(null);
     const errs = useStore.getState().targetUpdateErrors;
     for (const id of Object.keys(errs)) {
       if (errs[id] != null) setTargetUpdateError(id, null);
@@ -575,64 +599,24 @@ export function Settings({
     }
   };
 
-  // Percent for a manual desktop download. Subscribed unconditionally (the
-  // no-op unsubscribe on mobile makes this safe) so a download started here
-  // renders progress instead of a button that looks stuck for minutes on a
-  // 100MB artifact.
-  useEffect(() => {
-    const off = window.api.onAutoUpdateProgress?.((p) => {
-      setDownloadPercent(typeof p.percent === "number" ? p.percent : null);
-    });
-    return off;
-  }, []);
-
-  // A download ends in exactly one of three ways, and ALL of them must clear
-  // the local in-flight state — otherwise the row sits on "Downloading…"
-  // forever, which is the same "looks busy, is actually dead" impression this
-  // feature exists to remove.
-  //
-  //  - success: the store's `updatePrompt` appears (App.tsx sets it from the
-  //    `update-downloaded` event) and the row becomes "Restart to update".
-  //  - terminal failure: the store's `updateError` appears (main forwards only
-  //    non-transient failures). The failure is reported by the banner; About
-  //    just stops claiming to be busy.
-  //  - transient failure: main neither raises `updatePrompt` nor `updateError`
-  //    (a drop mid-download is deliberately not surfaced as a terminal error),
-  //    but the IPC now rejects, so the click handler's `.catch` below resets
-  //    the state and the "Download" button comes back — the user can retry.
-  useEffect(() => {
-    if (updatePrompt || updateError) {
-      setDownloading(false);
-      setDownloadPercent(null);
-    }
-  }, [updatePrompt, updateError]);
-
   // One row per target (BET-1099): the list below maps over the canonical
   // `updateTargets` in its fixed display order, so Settings and the banner
   // always describe the same state. The two bespoke per-leg blocks they
   // replace were deleted in stage 4.
   //
   // The action routes by target id through the shared `isCliTarget`
-  // discriminator (BET-1159): desktop keeps its download; every CLI row
-  // delegates to App's per-CLI router (`onCliUpdate` — the SAME path the
-  // banner uses), so a CLI row upgrades JUST that CLI, never the whole box;
-  // the server row keeps the box self-update flow (`onRequestServerUpdate`),
-  // which App's confirm → applyServerUpdate path owns unchanged. The row's
-  // disabled/spinner presentation (busy + updatingTargetId) is BET-1160's
-  // `rowUpdateState`, already read from the store — nothing to add here.
+  // discriminator (BET-1159): desktop delegates to App's single desktop runner
+  // (`onDesktopUpdate` — the SAME path the banner uses, so Settings never keeps
+  // a second copy of the download/in-flight state; BET-1195); every CLI row
+  // delegates to App's per-CLI router (`onCliUpdate`), so a CLI row upgrades
+  // JUST that CLI, never the whole box; the server row keeps the box
+  // self-update flow (`onRequestServerUpdate`), which App's confirm →
+  // applyServerUpdate path owns unchanged. The row's disabled/spinner
+  // presentation (busy + updatingTargetId) is BET-1160's `rowUpdateState`,
+  // already read from the store — nothing to add here.
   const handleRowUpdate = (t: UpdateTarget) => {
     if (t.id === "desktop") {
-      setDownloading(true);
-      setDownloadPercent(0);
-      // The IPC rejects on ANY failure (main now returns the download
-      // promise), so a transient drop recovers to the button instead of
-      // wedging "Downloading…".
-      void window.api
-        .autoUpdateDownload()
-        .catch(() => {
-          setDownloading(false);
-          setDownloadPercent(null);
-        });
+      onDesktopUpdate?.();
     } else if (isCliTarget(t)) {
       onCliUpdate?.(t);
     } else {
@@ -1002,8 +986,7 @@ export function Settings({
                 <UpdateTargetRow
                   key={t.id}
                   target={t}
-                  downloading={downloading}
-                  downloadPercent={downloadPercent}
+                  desktopBusy={desktopBusy}
                   installReady={Boolean(updatePrompt)}
                   onUpdate={handleRowUpdate}
                   rowState={rowUpdateState(t.id, { updatingTargetId, busy })}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -515,6 +515,13 @@ type State = {
   // is derived where boxUpgrading (App-local) is known, never stored twice.
   updatingTargetId: string | null;
   targetUpdateErrors: Record<string, string | null>;
+  // BET-1195: live download percent of a desktop auto-update in flight, owned
+  // here (NOT in Settings) so the banner and the Settings row can never
+  // disagree — the exact failure mode BET-1160's store contract exists to
+  // prevent. Fed from `IPC.autoUpdateProgress` at App level; cleared on every
+  // terminal path exactly like `updatingTargetId`. No percent represented as a
+  // percent means a download started but hasn't ticked yet.
+  desktopDownloadPercent: number | null;
   // A TERMINAL auto-update failure (integrity / permission). Set from main's
   // autoUpdate:error IPC, which only fires for failures the user must act on
   // — transient network errors are filtered server-side of the bridge.
@@ -745,6 +752,7 @@ type State = {
   // BET-1159's finally clears `updatingTargetId` on RPC ok + reject, and a
   // box reconnect / Settings-close resets it — the store never selfers.
   setUpdatingTarget: (id: string | null) => void;
+  setDesktopDownloadPercent: (p: number | null) => void;
   setTargetUpdateError: (id: string, error: string | null) => void;
   setUpdateError: (p: { message: string; raw: string } | null) => void;
   setBoxIncompatible: (b: boolean) => void;
@@ -821,6 +829,7 @@ export const useStore = create<State>((set, get) => ({
   updateTargets: [],
   updatingTargetId: null,
   targetUpdateErrors: {},
+  desktopDownloadPercent: null,
   updateError: null,
   boxIncompatible: false,
   serverUpdatePrompt: null,
@@ -1159,6 +1168,7 @@ export const useStore = create<State>((set, get) => ({
   setUpdatePrompt: (p) => set({ updatePrompt: p }),
   setUpdateTargets: (t) => set({ updateTargets: t }),
   setUpdatingTarget: (id) => set({ updatingTargetId: id }),
+  setDesktopDownloadPercent: (p) => set({ desktopDownloadPercent: p }),
   setTargetUpdateError: (id, error) =>
     set((prev) => ({ targetUpdateErrors: { ...prev.targetUpdateErrors, [id]: error } })),
   setUpdateError: (p) => set({ updateError: p }),

--- a/src/shared/updateTargets.d.mts
+++ b/src/shared/updateTargets.d.mts
@@ -83,3 +83,21 @@ export function rowUpdateState(
   id: string,
   state?: { updatingTargetId?: string | null; busy?: boolean },
 ): RowUpdateState;
+
+export interface DesktopUpdateBusy {
+  busyLabel: string;
+  progress: { step: number; total: number; label: string } | null;
+}
+
+/**
+ * Decide the desktop leg's in-flight presentation (BET-1195): `null` when no
+ * desktop update is running; otherwise the label + (possible) determinate
+ * progress for download-vs-restart. See rowUpdateState for the "desktop marks
+ * OTHER rows disabled" relationship — the desktop leg reuses `updatingTargetId`
+ * so a desktop run disables other rows exactly as a CLI run does.
+ */
+export function desktopUpdateBusy(state?: {
+  updatingTargetId?: string | null;
+  desktopDownloadPercent?: number | null;
+  desktopRestarting?: boolean;
+}): DesktopUpdateBusy | null;

--- a/src/shared/updateTargets.mjs
+++ b/src/shared/updateTargets.mjs
@@ -270,3 +270,62 @@ export function rowUpdateState(id, { updatingTargetId = null, busy = false } = {
   if (updatingTargetId != null || busy) return { kind: "busy" };
   return { kind: "idle" };
 }
+
+/**
+ * Decide the DESKTOP leg's in-flight presentation (BET-1195).
+ *
+ * The desktop leg was the ONE unified-update surface with no loading state: the
+ * banner rendered the idle, clickable "Update" button through the whole
+ * download, then the app quit with no "restarting" beat (BET-1160 wired the
+ * server leg and the per-CLI legs but never the desktop leg). This is the
+ * desktop analogue of the box leg's `boxUpgrading` / `serverUpdateProgress` /
+ * `boxRestarting` trio, kept in ONE pure function so the banner and Settings
+ * can never disagree about which surface is busy or what it says.
+ *
+ * Returns `null` when no desktop update is running, or the presentation for the
+ * one that is:
+ *
+ *   - `{ busyLabel: "Restarting Manta Desktop…", progress: null }` — the
+ *     terminal INSTALL / app-restart beat drives `desktopRestarting`. There is
+ *     no percent to report and quitAndInstall emits no progress events, so the
+ *     bar is indeterminate. Never cleared by design — the app quits a moment
+ *     later, and this is the last thing the user sees.
+ *   - `{ busyLabel: "Downloading N%", progress: { step, total: 100, label } }` —
+ *     a DOWNLOAD in progress with a live percent from `desktopDownloadPercent`.
+ *   - `{ busyLabel: "Downloading…", progress: null }` — a download that has
+ *     started but not yet reported a percent (determinate is impossible yet).
+ *
+ * `updatingTargetId` is the store's single in-flight target (BET-1160): the
+ * desktop leg sets it to `"desktop"` when its download starts, exactly as a CLI
+ * leg sets its own id, so `rowUpdateState` marks OTHER rows `busy`/disabled the
+ * same way a CLI run does. The restart beat keeps the id (it is the one
+ * intentionally-permanent state), so `desktopUpdateBusy` answers for it even
+ * after the download leg cleared the id.
+ *
+ * @param {{ updatingTargetId?: string|null, desktopDownloadPercent?: number|null,
+ *          desktopRestarting?: boolean }} state
+ * @returns {{ busyLabel: string, progress: { step:number, total:number, label:string } | null } | null}
+ */
+export function desktopUpdateBusy({
+  updatingTargetId = null,
+  desktopDownloadPercent = null,
+  desktopRestarting = false,
+} = {}) {
+  if (desktopRestarting) {
+    return { busyLabel: "Restarting Manta Desktop…", progress: null };
+  }
+  if (updatingTargetId !== "desktop") return null;
+
+  const raw = Number(desktopDownloadPercent);
+  const percent =
+    typeof desktopDownloadPercent === "number" && Number.isFinite(raw)
+      ? Math.max(0, Math.min(100, Math.round(raw)))
+      : null;
+  if (percent != null) {
+    return {
+      busyLabel: `Downloading ${percent}%`,
+      progress: { step: percent, total: 100, label: "Downloading update" },
+    };
+  }
+  return { busyLabel: "Downloading…", progress: null };
+}

--- a/src/shared/updateTargets.test.ts
+++ b/src/shared/updateTargets.test.ts
@@ -7,6 +7,7 @@ import {
   describeUpdateBanner,
   planUpdateAll,
   rowUpdateState,
+  desktopUpdateBusy,
   isCliTarget,
 } from "./updateTargets.mjs";
 
@@ -443,6 +444,60 @@ describe("rowUpdateState", () => {
   it("reports `idle` when nothing is in flight", () => {
     expect(rowUpdateState("desktop", { updatingTargetId: null, busy: false })).toEqual({ kind: "idle" });
     expect(rowUpdateState("server", {})).toEqual({ kind: "idle" });
+  });
+
+  it("a DESKTOP run marks other rows disabled exactly as a CLI run does", () => {
+    // BET-1195: the desktop leg reuses the same `updatingTargetId` the per-CLI
+    // legs use, so a desktop run disables every other row just like a CLI run.
+    const state = { updatingTargetId: "desktop", busy: true };
+    expect(rowUpdateState("desktop", state)).toEqual({ kind: "updating" });
+    expect(rowUpdateState("server", state)).toEqual({ kind: "busy" });
+    expect(rowUpdateState("claude", state)).toEqual({ kind: "busy" });
+  });
+});
+
+describe("desktopUpdateBusy", () => {
+  const base = { updatingTargetId: "desktop", desktopDownloadPercent: null, desktopRestarting: false };
+
+  it("returns null when no desktop update is in flight", () => {
+    expect(desktopUpdateBusy({ ...base, updatingTargetId: null })).toBeNull();
+    // A CLI run (updatingTargetId = the CLI id) is NOT a desktop run.
+    expect(desktopUpdateBusy({ ...base, updatingTargetId: "claude" })).toBeNull();
+    // Nothing at all.
+    expect(desktopUpdateBusy({})).toBeNull();
+  });
+
+  it("desktop downloading with a percent → determinate progress + label", () => {
+    const state = desktopUpdateBusy({ ...base, desktopDownloadPercent: 42 });
+    expect(state).toEqual({
+      busyLabel: "Downloading 42%",
+      progress: { step: 42, total: 100, label: "Downloading update" },
+    });
+  });
+
+  it("clamps out-of-range percents and rounds", () => {
+    expect(desktopUpdateBusy({ ...base, desktopDownloadPercent: 99.6 })?.progress?.step).toBe(100);
+    expect(desktopUpdateBusy({ ...base, desktopDownloadPercent: -3 })?.progress?.step).toBe(0);
+    expect(desktopUpdateBusy({ ...base, desktopDownloadPercent: 42.4 })?.busyLabel).toBe("Downloading 42%");
+  });
+
+  it("desktop downloading with NO percent yet → indeterminate 'Downloading…'", () => {
+    expect(desktopUpdateBusy({ ...base, desktopDownloadPercent: null })).toEqual({
+      busyLabel: "Downloading…",
+      progress: null,
+    });
+  });
+
+  it("desktop restarting → indeterminate 'Restarting Manta Desktop…' with no percent", () => {
+    const state = desktopUpdateBusy({ ...base, desktopRestarting: true, desktopDownloadPercent: 42 });
+    expect(state).toEqual({ busyLabel: "Restarting Manta Desktop…", progress: null });
+  });
+
+  it("the restart beat answers even after the download leg cleared the id", () => {
+    // finishUpdateAllOnce sets desktopRestarting AFTER runDesktopDownload clears
+    // updatingTargetId — the beat must still present.
+    const state = desktopUpdateBusy({ updatingTargetId: null, desktopDownloadPercent: null, desktopRestarting: true });
+    expect(state?.busyLabel).toBe("Restarting Manta Desktop…");
   });
 });
 


### PR DESCRIPTION
**Base:** `origin/main` @ `d008183c`

## What & why
BET-1160 wired an in-flight presentation for the server leg and the per-CLI legs of the unified update, but never the DESKTOP leg. So a desktop-only run through `runUpdateAll` gave zero feedback — the banner stayed on the idle "Update" button through the whole download, then the app quit with no transition. This closes the gap with the two missing states:

**A. DOWNLOAD (determinate).** The desktop download percent now lives in the **shared store** (`desktopDownloadPercent` + `setDesktopDownloadPercent`), fed ONCE at App level from `IPC.autoUpdateProgress`. Settings' local `downloading`/`downloadPercent` copy is deleted — both surfaces read the same value and can never disagree (the exact failure BET-1160's store contract exists to prevent).

**B. INSTALL / app restart (indeterminate).** A `desktopRestarting` flag (the desktop analogue of `boxRestarting`) is set right before `autoUpdateInstall()` and drives a terminal, non-dismissible "Restarting Manta Desktop…" beat. Never cleared by design — the app quits a moment later.

**Both call sites** (`runUpdateAll` and `handleTargetUpdate`'s `desktop` branch) share ONE `runDesktopDownload` runner that sets `updatingTargetId="desktop"` (so other rows disable exactly as a CLI run does) and clears it on download resolve/reject/user-cancel — rejections surface via the existing `setTargetUpdateError` path instead of the old wedging `.catch(()=>{})`.

**Never-stuck:** every terminal path clears the desktop in-flight state; the only intentionally-permanent state is the restart beat. The confirm is now shown BEFORE the desktop download starts, so a cancelled run has started nothing.

## Files changed
`6` files.
- `src/shared/updateTargets.mjs` — new pure `desktopUpdateBusy()` helper (+ `updateTargets.d.mts` types)
- `src/shared/updateTargets.test.ts` — helper tests (download w/ percent, restart no percent, clamp, desktop-run-disables-other-rows)
- `src/renderer/store.ts` — `desktopDownloadPercent` field + setter
- `src/renderer/App.tsx` — App-level `onAutoUpdateProgress` subscribe, `desktopRestarting`, `runDesktopDownload`, both call sites, bar rendering
- `src/renderer/Settings.tsx` — deleted local download state; desktop row delegates to App's runner and reads the store

No changes to `src/main/autoUpdate.ts` — it already emits everything needed.

Follow-up filed: **BET-1197** (parked) — Settings' "Update ready → Restart to update" strip is a separate direct `autoUpdateInstall()` call site that bypasses the restart-beat beat; a second quit-and-install path worth wiring to the same flag.

## Verification results
- PR branch (`multica/BET-1195-desktop-update-loading-state` @ `1603f67a`):
  - typecheck: exit `0`. Errors: none. log sha256: `4b9cb3e5b4a3b7f1ec44f92bc690d50b750cc055aec7162c15c3c3f375c19d90`
  - test: exit `0`. vitest `3215 passed / 7 skipped`, node:test `2543 pass / 0 fail`. log sha256: `e61c159b4b34528ee0d9523871ba106dfe763884c4373b224685d90856b43c86`
- Base (`main` @ `d008183c`):
  - typecheck: exit `0`. Errors: none. log sha256: `4b9cb3e5b4a3b7f1ec44f92bc690d50b750cc055aec7162c15c3c3f375c19d90`
  - test: exit `0`. log sha256: `b765be02a8dd7e237594702c714fce16c18c417c8f29cf694f465ad1b5494ab4`
- **Conclusion:** `0` test failures pre-existing, `0` new, `0` resolved (typecheck logs byte-identical; test log differs only by the new desktopUpdateBusy/rowUpdateState tests added in this PR).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
