### PR TITLE
chore(release): bump version to 0.0.47

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.46",
+  "version": "0.0.47",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",


### PR DESCRIPTION
Desktop release for 0.0.47. Bumps package.json; tag mac-v0.0.47 cut at this commit.