### PR TITLE
fix(renderer): Reveal opens Finder again — bridge revealInFolder in http mode

### DIFF
--- a/src/renderer/api/httpApi.test.ts
+++ b/src/renderer/api/httpApi.test.ts
@@ -583,3 +583,30 @@ describe("httpApi agentPullFile desktop bridge delegation", () => {
     expect(out).toBe("");
   });
 });
+
+// ---------------------------------------------------------------------------
+// revealInFolder — bridged, not a blanket no-op
+//
+// The desktop swaps window.api to THIS client once paired, so an unconditional
+// no-op here disabled every Reveal button on the only platform with a file
+// manager: the download toast saved the file correctly and then did nothing
+// when asked to show it.
+// ---------------------------------------------------------------------------
+
+describe("httpApi revealInFolder", () => {
+  it("delegates to the preload bridge on desktop", async () => {
+    const revealInFolder = vi.fn(async () => {});
+    vi.stubGlobal("window", {
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      __mantaPreload: { revealInFolder },
+    });
+    await httpApi.revealInFolder("/Users/a/Downloads/report.pdf");
+    expect(revealInFolder).toHaveBeenCalledWith("/Users/a/Downloads/report.pdf");
+  });
+
+  it("stays a no-op on a phone/browser (no preload, nothing to reveal into)", async () => {
+    vi.stubGlobal("window", { addEventListener: vi.fn(), removeEventListener: vi.fn() });
+    await expect(httpApi.revealInFolder("/Users/a/Downloads/report.pdf")).resolves.toBeUndefined();
+  });
+});

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -659,7 +659,8 @@ function on<T>(kind: Kind, cb: (p: T) => void): () => any {
 //     "no OS path" and fall back to uploadBuffer's byte path — that fallback
 //     is what makes drag-in work in http mode; don't remove it.
 //   • agentPullFile (outbox) → browser download via /api/download — WORKS;
-//     revealInFolder        → no-op (no OS file manager to reveal into).
+//     revealInFolder        → delegates to the preload when there IS one
+//     (desktop), no-op only on a phone/browser with no file manager.
 //   • openExternal (chat links) → window.open (the WebView is a browser) — WORKS.
 //   • clipboardWriteText / clipboardReadImage → routed to the server RPC no-ops;
 //     OSC52 desktop-clipboard sync is a preload-only affordance and silently
@@ -926,8 +927,18 @@ export const httpApi: Api = {
     if (preload?.downloadFileToDownloads) return await preload.downloadFileToDownloads(remotePath, filename);
     return "";
   },
-  // No OS file manager to reveal into on a phone/browser — no-op.
-  revealInFolder: async (_localPath) => {},
+  // Reveal a saved file in Finder / the OS file manager. BRIDGED, like
+  // peekRemoteFile / downloadFileToDownloads: on desktop `window.api` is
+  // swapped to THIS client once paired, so an unconditional no-op here means
+  // every Reveal button in the app silently does nothing on the very platform
+  // that has a file manager — which is exactly what happened to the download
+  // toast's Reveal (the file WAS saved; the button just never called Finder).
+  // The no-op survives only for a phone/browser, where there is nothing to
+  // reveal into.
+  revealInFolder: async (localPath) => {
+    const preload = getMantaPreload();
+    if (preload?.revealInFolder) await preload.revealInFolder(localPath);
+  },
 
   /**
    * Markdown links in ChatPanel always call `window.api.openExternal(href)`


### PR DESCRIPTION
Reported: the **Reveal** button in the download toast does nothing.

## Cause

`httpApi.revealInFolder` was an unconditional no-op:

```ts
// No OS file manager to reveal into on a phone/browser — no-op.
revealInFolder: async (_localPath) => {},
```

The reasoning holds for a phone — but the **desktop swaps `window.api` to this same client once paired**, so that no-op is what every desktop Reveal button has been calling. The file was saved correctly; the button just never reached Finder.

Exactly the shape of the bug #1156 fixed for the download itself: a mobile-shaped implementation shadowing an OS bridge that the preload already exposes and main already handles. The tell: Settings' "Open plugins folder" works, because it reaches for the preload *directly* rather than through `window.api`.

## Fix

Delegate to the preload when there is one (desktop), keep the no-op only where there is nothing to reveal into (phone/browser) — mirroring `peekRemoteFile` and `downloadFileToDownloads`.

Affected call sites, both now working: the agent-file toast's Reveal and the new download-confirmation toast's Reveal (#1210).

## Tests

- delegates to the preload bridge with the exact path
- stays a silent no-op with no preload present

`npm run typecheck` clean; full suite green (3217 renderer tests).