### PR TITLE
docs: never stub a control to do nothing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,57 @@ bridges as dead.
 See `README.md` for user-facing intro and `HANDOFF.md` for the most recent
 session-state snapshot.
 
+## NEVER STUB A CONTROL TO DO NOTHING
+
+**If the user can press it, it MUST do something. Every time. No exceptions
+outside tests.** A control that silently does nothing is the single most
+expensive defect this codebase produces, because it is indistinguishable from a
+broken backend, a broken build, and a broken app — so it gets reported as
+"X is broken", debugged everywhere except the button, and the real answer turns
+out to be that someone shipped an empty function on purpose.
+
+The three legal outcomes of a press are:
+
+1. **It does the thing** — and SAYS SO. An action whose result isn't visible on
+   screen has not communicated anything; a save that shows no confirmation is
+   read as a save that didn't happen (that exact bug: a working download
+   reported as broken, twice).
+2. **It fails, and says why** — an error the user can act on. "Couldn't save —
+   the file is still on the server, try again" is a real outcome. A swallowed
+   `catch {}` is not.
+3. **It isn't there.** If the current platform / mode / state genuinely cannot
+   perform the action, DON'T RENDER THE CONTROL (or render it disabled with a
+   reason in the title). A hidden button is honest; a dead one lies.
+
+What is explicitly BANNED:
+
+- `foo: async () => {}` in ANY client shim, adapter, or platform layer, for
+  anything a control invokes. **This is not a mobile-vs-desktop question.** The
+  desktop swaps `window.api` to `httpApi` once paired, so every "mobile-only"
+  no-op there is what the DESKTOP calls too — that is precisely how the download
+  path (BET-1156) and then `revealInFolder` (#1215) both shipped as dead
+  buttons while the real OS bridge sat right there in the preload, fully
+  implemented. If a capability exists on the current platform, DELEGATE to it;
+  if it doesn't, see outcome 3.
+- Fire-and-forget calls for a user action (`void doThing()`), which turn a
+  failure into a devtools-only rejection and a success into nothing at all.
+  Await the result and report BOTH branches — `saveToDownloads`
+  (`src/renderer/downloadFeedback.ts`) is the reference shape.
+- `catch {}` with a "non-fatal" comment on a user-initiated action. Non-fatal to
+  the PROGRAM, maybe; to the user it is the whole point of the click.
+- A TODO-shaped placeholder handler on a shipped control. Ship the control when
+  it works, not before.
+
+The ONE legitimate no-op is an EVENT SUBSCRIPTION for a signal a transport never
+emits (e.g. `onScreenshotDetected` on a phone: nothing fires it, so nothing is
+missing and no control is dead). That is a listener, not an action. Do not
+generalise it into a licence to stub actions — that generalisation is the bug.
+
+**Known outstanding violation** (fix it, don't copy it): `peekRemoteFile` in
+`httpApi.ts` falls through to an RPC no-op because no `ipcMain` handler was ever
+registered, so clicking an absolute path in the terminal does nothing at all.
+The comment there explains why it was left; the explanation is not a defence.
+
 ## Layout
 
 - `src/server/` — **the core.** Node HTTP+WS server that runs **on the Linux


### PR DESCRIPTION
Two investigations in two days (#1195/#1210 download, #1215 Reveal) had the same root cause: **a button that was deliberately wired to an empty function.**

Both times the capability was fully implemented one layer down; both times a mobile-shaped no-op shadowed it; both times the symptom was reported as "the feature is broken" and the debugging went everywhere except the button. The "it's fine, it's only for phones" reasoning is what makes it dangerous — **the desktop runs that same client once paired**, so a mobile-only no-op is never mobile-only.

Adds a top-of-file rule to AGENTS.md. A press has exactly three legal outcomes:

1. it does the thing **and says so** (an invisible success reads as a failure);
2. it fails with a reason the user can act on;
3. the control isn't rendered at all (a hidden button is honest; a dead one lies).

Banned explicitly: empty implementations in client/platform shims, fire-and-forget calls for user actions, `catch {}` on a user-initiated action, placeholder handlers on shipped controls.

Carved out: an event *subscription* for a signal a transport never emits — a listener, not an action. That carve-out is stated precisely because over-generalising it is how the bug happened.

Also names the one known remaining violation (`peekRemoteFile` — clicking an absolute path in the terminal does nothing) so it gets fixed rather than discovered a third time.

Docs only.