### PR TITLE
chore(release): bump version to 0.0.48

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "manta-ui",
-  "version": "0.0.47",
+  "version": "0.0.48",
   "description": "Desktop client for remote Claude Code sessions",
   "main": "out/main/index.js",
   "type": "module",


### PR DESCRIPTION
No-op desktop release to test the pipeline. Tag mac-v0.0.48 cut at this commit.