### PR TITLE
fix(updates): render download progress as a percentage, not step/total

### DIFF
--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -304,7 +304,7 @@ function UpdateTargetRow({
   /** BET-1195: the desktop leg's presentation (from `desktopUpdateBusy`), so
    *  the row and the banner agree. null for non-desktop targets / no desktop
    *  run in flight. */
-  desktopBusy: { busyLabel: string; progress: { step: number; total: number; label: string } | null } | null;
+  desktopBusy: { busyLabel: string; progress: { step: number; total: number; label: string; percent?: boolean } | null } | null;
   installReady: boolean;
   onUpdate: (t: UpdateTarget) => void;
   rowState: { kind: "updating" } | { kind: "busy" } | { kind: "idle" };

--- a/src/renderer/UpdateBar.test.tsx
+++ b/src/renderer/UpdateBar.test.tsx
@@ -70,4 +70,18 @@ describe("UpdateBar", () => {
     const fill = bar.firstElementChild as HTMLElement;
     expect(fill.style.width).toBe("50%");
   });
+
+  it("percent progress renders a percentage label (Downloading finder-style 80%)", () => {
+    h = mount(
+      <UpdateBar
+        text="x"
+        actionLabel="x"
+        onAction={() => {}}
+        progress={{ step: 80, total: 100, label: "Downloading update", percent: true }}
+      />,
+    );
+    // The label shows 80%, not 80/100.
+    expect(h.text()).toContain("Downloading update 80%");
+    expect(h.text()).not.toContain("80/100");
+  });
 });

--- a/src/renderer/UpdateBar.tsx
+++ b/src/renderer/UpdateBar.tsx
@@ -43,7 +43,7 @@ export type UpdateBarProps = {
   tone?: "accent" | "danger";
   /** When set, the bar renders a determinate progress bar in place of the
    *  action button. */
-  progress?: { step: number; total: number; label: string };
+  progress?: { step: number; total: number; label: string; percent?: boolean };
   /** When true, the bar is in an IN-FLIGHT state: it renders an indeterminate
    *  progress bar (or the determinate `progress` if supplied) and NO action /
    *  dismiss buttons. Used while a box self-upgrade is running, so the restart
@@ -70,7 +70,9 @@ export function UpdateBar({
   busyLabel = "Updating…",
 }: UpdateBarProps) {
   const statusLabel = progress
-    ? `${progress.label} (${progress.step}/${progress.total})`
+    ? progress.percent
+      ? `${progress.label} ${Math.round((progress.step / progress.total) * 100)}%`
+      : `${progress.label} (${progress.step}/${progress.total})`
     : busy
       ? busyLabel
       : text;

--- a/src/shared/updateTargets.d.mts
+++ b/src/shared/updateTargets.d.mts
@@ -86,7 +86,7 @@ export function rowUpdateState(
 
 export interface DesktopUpdateBusy {
   busyLabel: string;
-  progress: { step: number; total: number; label: string } | null;
+  progress: { step: number; total: number; label: string; percent?: boolean } | null;
 }
 
 /**

--- a/src/shared/updateTargets.mjs
+++ b/src/shared/updateTargets.mjs
@@ -304,7 +304,7 @@ export function rowUpdateState(id, { updatingTargetId = null, busy = false } = {
  *
  * @param {{ updatingTargetId?: string|null, desktopDownloadPercent?: number|null,
  *          desktopRestarting?: boolean }} state
- * @returns {{ busyLabel: string, progress: { step:number, total:number, label:string } | null } | null}
+ * @returns {{ busyLabel: string, progress: { step:number, total:number, label:string, percent?:boolean } | null } | null}
  */
 export function desktopUpdateBusy({
   updatingTargetId = null,
@@ -324,7 +324,7 @@ export function desktopUpdateBusy({
   if (percent != null) {
     return {
       busyLabel: `Downloading ${percent}%`,
-      progress: { step: percent, total: 100, label: "Downloading update" },
+      progress: { step: percent, total: 100, label: "Downloading update", percent: true },
     };
   }
   return { busyLabel: "Downloading…", progress: null };

--- a/src/shared/updateTargets.test.ts
+++ b/src/shared/updateTargets.test.ts
@@ -471,7 +471,7 @@ describe("desktopUpdateBusy", () => {
     const state = desktopUpdateBusy({ ...base, desktopDownloadPercent: 42 });
     expect(state).toEqual({
       busyLabel: "Downloading 42%",
-      progress: { step: 42, total: 100, label: "Downloading update" },
+      progress: { step: 42, total: 100, label: "Downloading update", percent: true },
     });
   });
 


### PR DESCRIPTION
The desktop download bar showed 'Downloading update (80/100)' because its step value IS the percent (0-100, total 100), but UpdateBar always formats `label (step/total)`.

Adds an optional `percent` flag to the progress shape; the desktop download leg sets it so the banner renders 'Downloading update 80%'. The box server-update leg is untouched and keeps its genuine step counts ('Installing dependencies (4/7)'), which must not be converted to percentages.