### PR TITLE
fix(renderer): row with its own controls no longer double-handles the click (BET-1199)

### DIFF
--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -466,4 +466,19 @@ describe("CloneFromGitHub picker", () => {
     expect(text).toContain("Clone a repository");
     expect(container!.querySelector('input[aria-label="Search repositories"]')).toBeTruthy();
   });
+
+  it("selects a repo when its row (not the hidden checkbox) is clicked, and updates the button (BET-1199)", async () => {
+    mountPicker();
+    await flushMicro();
+
+    // The row is the ListRow rendered as a role=button; its name text is alpha's.
+    const alphaRow = Array.from(
+      container!.querySelectorAll<HTMLElement>('div[role="button"]'),
+    ).find((r) => r.textContent?.includes("alpha"));
+    expect(alphaRow).toBeTruthy();
+    act(() => {
+      alphaRow!.click();
+    });
+    expect(cloneButtonFor("1 selected")).toBeTruthy();
+  });
 });

--- a/src/renderer/CloneFromGitHub.tsx
+++ b/src/renderer/CloneFromGitHub.tsx
@@ -397,6 +397,7 @@ export function CloneFromGitHub({
                   name={r.name}
                   secondary={r.description || "—"}
                   trailing={r.pushedAt != null ? formatAge(Date.now() - r.pushedAt) : "—"}
+                  onClick={() => toggleRepo(r.fullName, !checked.has(r.fullName))}
                 />
               ))}
             {reposState.kind === "ready" && filtered.length === 0 && (

--- a/src/renderer/ListRow.test.tsx
+++ b/src/renderer/ListRow.test.tsx
@@ -1,0 +1,95 @@
+// @vitest-environment jsdom
+//
+// Regression tests for the ListRow row-click guard (BET-1199).
+//
+// The guard: a row that contains its own controls must not also handle those
+// controls' clicks. A <label>-wrapped checkbox re-dispatches a click on its
+// hidden <input>, so one user click on the visible box yields TWO click events
+// at the row; an unguarded row `onClick` would toggle twice — selecting then
+// instantly deselecting. The guard ignores clicks whose target is (or is
+// inside) an interactive control and lets the control act.
+//
+// CRITICAL — assert invocation COUNTS, not final selection. jsdom batches
+// React state updates inside act(), so both row invocations read the stale
+// value and the final selection ends up correct under test even while it is
+// broken in a real browser. The existing tests clicked the hidden <input>
+// directly — a target no user can reach — which is exactly how this defect
+// reached users.
+
+import { describe, it, expect, afterEach, vi } from "vitest";
+import { act } from "react";
+import { mount, type Harness } from "./testHarness";
+import { ListRow } from "./ListRow";
+import { Checkbox } from "./Checkbox";
+
+describe("ListRow", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("clicking the visible box ignores the row onClick and fires the checkbox onChange exactly once", () => {
+    const rowClick = vi.fn();
+    const checkChange = vi.fn();
+    h = mount(
+      <ListRow
+        onClick={rowClick}
+        leading={<Checkbox checked={false} onChange={checkChange} ariaLabel="toggle" />}
+        name="Alpha"
+      />,
+    );
+    const box = h.container.querySelector("label > span") as HTMLElement;
+    expect(box).toBeTruthy();
+    act(() => {
+      box.click();
+    });
+    // The row must NOT act on the control's click (the control owns it).
+    expect(rowClick).toHaveBeenCalledTimes(0);
+    expect(checkChange).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking the row's name invokes the row onClick exactly once", () => {
+    const rowClick = vi.fn();
+    h = mount(
+      <ListRow
+        onClick={rowClick}
+        leading={<Checkbox checked={false} onChange={() => {}} ariaLabel="toggle" />}
+        name="Alpha"
+      />,
+    );
+    const nameEl = h.container.querySelector("span.text-text") as HTMLElement;
+    expect(nameEl).toBeTruthy();
+    act(() => {
+      nameEl.click();
+    });
+    expect(rowClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("clicking a button in the trailing slot ignores the row onClick", () => {
+    const rowClick = vi.fn();
+    const btnClick = vi.fn();
+    h = mount(
+      <ListRow
+        onClick={rowClick}
+        name="Alpha"
+        trailing={<button onClick={btnClick}>Disconnect</button>}
+      />,
+    );
+    const btn = h.container.querySelector("button") as HTMLElement;
+    expect(btn).toBeTruthy();
+    act(() => {
+      btn.click();
+    });
+    expect(rowClick).toHaveBeenCalledTimes(0);
+    expect(btnClick).toHaveBeenCalledTimes(1);
+  });
+
+  it("a row with no onClick renders with no role and no tabIndex", () => {
+    h = mount(<ListRow name="Alpha" />);
+    const row = h.container.firstElementChild as HTMLElement;
+    expect(row).toBeTruthy();
+    expect(row.getAttribute("role")).toBeNull();
+    expect(row.getAttribute("tabIndex")).toBeNull();
+  });
+});

--- a/src/renderer/ListRow.tsx
+++ b/src/renderer/ListRow.tsx
@@ -11,6 +11,15 @@
 // from a plain row to a keyboard-activatable button so a checkbox/dot row and
 // a clickable row share one component (docs/components.md decision 2).
 //
+// GOTCHA — a row that contains its own controls must not also handle those
+// controls' clicks. A `<label>`-wrapped checkbox (see Checkbox.tsx) re-dispatches
+// a click on its hidden `<input>`, so a user's single click on the visible box
+// produces TWO click events at the row; an unguarded row `onClick` would toggle
+// twice — selecting then instantly deselecting. The guard below therefore
+// ignores any click whose target is (or is inside) an interactive control, and
+// lets that control handle it. It deliberately does NOT stop propagation: the
+// control's own handler still runs, the row just declines to act.
+//
 // Note the deliberate asymmetry with the chrome primitives (Button, Checkbox,
 // StatusDot): this is a *composable container*, not a single chrome element,
 // so it takes `className` (e.g. a `manta-*` identity hook). The slots stay the
@@ -44,7 +53,23 @@ export function ListRow({
     <div
       role={onClick ? "button" : undefined}
       tabIndex={onClick ? 0 : undefined}
-      onClick={onClick}
+      onClick={
+        onClick
+          ? (e) => {
+              // A control inside the row owns its own click. A <label>-wrapped
+              // checkbox additionally re-dispatches a click on its hidden <input>,
+              // so the row sees TWO clicks for one user click and would toggle
+              // twice — selecting then instantly deselecting.
+              if (
+                (e.target as HTMLElement).closest(
+                  "label,input,button,a,select,textarea",
+                )
+              )
+                return;
+              onClick();
+            }
+          : undefined
+      }
       onKeyDown={
         onClick
           ? (e) => {

--- a/website/updates/server.json
+++ b/website/updates/server.json
@@ -1,5 +1,5 @@
 {
- "version": "0.0.46",
+ "version": "0.0.47",
  "notes_url": "https://mantaui.com/releases",
  "min_client": "0.0.0"
 }


### PR DESCRIPTION
Fixes BET-1199.

**Root cause:** a `<label>`-wrapped checkbox re-dispatches a click on its hidden `<input>`, so one user click on the visible box bubbles as TWO click events to the ancestor row. An unguarded row `onClick` ran twice — selecting then instantly deselecting (a silent no-op in the New workspace picker). The sibling Clone from GitHub picker had the mirror-image defect: row not clickable at all.

**The fix** is in the row primitive (`ListRow.tsx`), not per call site:
- `ListRow` now guards its `onClick` so it ignores clicks targeting (or inside) an interactive control — the control owns its own click. No `stopPropagation`, no new prop, unconditional — per the issue's explicit do-NOT list.
- `CloneFromGitHub` repo rows gained the row-level `onClick` the other picker already had, so the two surfaces behave identically (checkbox and row each toggle exactly once).
- `NewSessionScreen` and `Checkbox` unchanged.

**Red/green:** the new `ListRow.test.tsx` assertion 1 (clicking the visible box must NOT invoke the row `onClick`) FAILS before this change (reports 2 — the double-fire) and passes after. Verified via stash: the new test fails against pre-fix `ListRow.tsx` and passes against the fixed one.

**Files changed:** 4 (`ListRow.tsx`, `ListRow.test.tsx` [new], `CloneFromGitHub.tsx`, `CloneFromGitHub.test.tsx`).

**Verification:**
- typecheck: passed.
- test: renderer 3225 passed / 7 skipped; server 2542 pass / 1 fail. The 1 failure is `website/updates/server.json version matches package.json version` — pre-existing version drift on main (server.json 0.0.46 vs package.json 0.0.47), unrelated to this change.

Base: origin/main @ e9ee0fb1