### PR TITLE
test(renderer): drive checkboxes through the visible box, not the sr-only input (BET-1200)

### DIFF
--- a/src/renderer/CloneFromGitHub.test.tsx
+++ b/src/renderer/CloneFromGitHub.test.tsx
@@ -22,7 +22,7 @@ import { describe, it, expect, afterEach, vi } from "vitest";
 import { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { CloneFromGitHub } from "./CloneFromGitHub";
-import { installMockApi, type MockApi } from "./testHarness";
+import { installMockApi, mount, clickCheckbox, type Harness, type MockApi } from "./testHarness";
 import type { ForgeCloneStatus } from "../shared/types";
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -61,6 +61,9 @@ const CLONE_IN_PROGRESS = {
 let container: HTMLElement | null = null;
 let root: Root | null = null;
 let api: MockApi;
+// The shared harness handle, used to drive checkboxes the way a user does
+// (clickCheckbox) rather than poking the sr-only input.
+let h: Harness | null = null;
 
 type MountOverrides = {
   forgeCloneStart?: () => Promise<{ id?: string; error?: string; message?: string }>;
@@ -78,18 +81,14 @@ function mountPicker(overrides: MountOverrides = {}): void {
     forgeCloneStatus:
       overrides.forgeCloneStatus ?? (() => Promise.resolve(CLONE_IN_PROGRESS)),
   }));
-  container = document.createElement("div");
-  document.body.appendChild(container);
-  root = createRoot(container);
-  act(() => {
-    root!.render(
-      <CloneFromGitHub
-        defaultRoot="/root"
-        onCancel={() => {}}
-        onCloned={overrides.onCloned ?? (() => {})}
-      />,
-    );
-  });
+  h = mount(
+    <CloneFromGitHub
+      defaultRoot="/root"
+      onCancel={() => {}}
+      onCloned={overrides.onCloned ?? (() => {})}
+    />,
+  );
+  container = h.container;
 }
 
 async function flushMicro(): Promise<void> {
@@ -115,6 +114,7 @@ function unmount(): void {
     root?.unmount();
   });
   root = null;
+  h = null;
   if (container) {
     container.remove();
     container = null;
@@ -154,13 +154,7 @@ describe("CloneFromGitHub picker", () => {
     mountPicker();
     await flushMicro();
 
-    const alphaBox = container!.querySelector(
-      'input[aria-label="Clone alpha"]',
-    ) as HTMLInputElement;
-    expect(alphaBox).toBeTruthy();
-    act(() => {
-      alphaBox.click();
-    });
+    clickCheckbox(h!, "Clone alpha");
     expect(cloneButtonFor("1 selected")).toBeTruthy();
 
     // Search for something that no longer matches alpha.
@@ -216,13 +210,7 @@ describe("CloneFromGitHub picker", () => {
     });
     await flushMicro();
 
-    const alphaBox = container!.querySelector(
-      'input[aria-label="Clone alpha"]',
-    ) as HTMLInputElement;
-    expect(alphaBox).toBeTruthy();
-    act(() => {
-      alphaBox.click();
-    });
+    clickCheckbox(h!, "Clone alpha");
     act(() => {
       cloneButtonFor("1 selected").click();
     });
@@ -249,13 +237,7 @@ describe("CloneFromGitHub picker", () => {
     });
     await flushMicro();
 
-    const alphaBox = container!.querySelector(
-      'input[aria-label="Clone alpha"]',
-    ) as HTMLElement;
-    expect(alphaBox).toBeTruthy();
-    act(() => {
-      alphaBox.click();
-    });
+    clickCheckbox(h!, "Clone alpha");
     act(() => {
       cloneButtonFor("1 selected").click();
     });
@@ -272,13 +254,7 @@ describe("CloneFromGitHub picker", () => {
     });
     await flushMicro();
 
-    const alphaBox = container!.querySelector(
-      'input[aria-label="Clone alpha"]',
-    ) as HTMLElement;
-    expect(alphaBox).toBeTruthy();
-    act(() => {
-      alphaBox.click();
-    });
+    clickCheckbox(h!, "Clone alpha");
     act(() => {
       cloneButtonFor("1 selected").click();
     });

--- a/src/renderer/Settings.test.tsx
+++ b/src/renderer/Settings.test.tsx
@@ -18,7 +18,7 @@
 import { describe, it, expect, afterEach } from "vitest";
 import { act } from "react";
 import { renderToStaticMarkup } from "react-dom/server";
-import { mount, installMockApi, type Harness } from "./testHarness";
+import { mount, installMockApi, clickCheckbox, type Harness } from "./testHarness";
 import { Settings } from "./Settings";
 import { useStore } from "./store";
 
@@ -272,11 +272,6 @@ describe("Settings — schema-driven toasts are error-only (BET-1055)", () => {
   // "Auto-rename sessions" is a schema toggle (platform "both",
   // configKey "autoRenameSessions"), committed through applySetting →
   // configUpdate, and lives on the Sessions tab.
-  const autoRenameInput = () =>
-    h!.container.querySelector<HTMLInputElement>(
-      'input[aria-label="Auto-rename sessions"]',
-    );
-
   const stubApi = (configUpdate?: () => Promise<unknown>) =>
     installMockApi({
       configGet: () => Promise.resolve({}),
@@ -289,11 +284,7 @@ describe("Settings — schema-driven toasts are error-only (BET-1055)", () => {
     });
 
   const toggleAutoRename = () => {
-    const input = autoRenameInput();
-    expect(input, "Auto-rename sessions checkbox").toBeTruthy();
-    act(() => {
-      (input as HTMLInputElement).click();
-    });
+    clickCheckbox(h!, "Auto-rename sessions");
   };
 
   afterEach(() => {

--- a/src/renderer/UsageResumeModal.test.tsx
+++ b/src/renderer/UsageResumeModal.test.tsx
@@ -14,7 +14,7 @@
 // (unarmedStoppedCount), covered by the pure-helper tests in usageResume.test.ts.
 
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { installMockApi, mount, resetStore, type Harness } from "./testHarness";
+import { installMockApi, mount, resetStore, clickCheckbox, type Harness } from "./testHarness";
 import { UsageResumeModal } from "./UsageResumeModal";
 import type { StoppedRecord } from "../shared/types";
 
@@ -31,16 +31,11 @@ const rec = (p: Partial<StoppedRecord> = {}): StoppedRecord => ({
   ...p,
 });
 
-function checkBox(harness: Harness, conversation: string): HTMLInputElement {
-  const input = harness.docQuery(`input[aria-label="Resume ${conversation}"]`) as HTMLInputElement | null;
-  if (!input) throw new Error(`no checkbox for ${conversation}`);
-  return input;
-}
-
 function toggle(harness: Harness, conversation: string): void {
-  // A real `.click()` on the native checkbox — React wires checkbox onChange
-  // to the native click event (a manual `change` event is not observed).
-  checkBox(harness, conversation).click();
+  // Drive the checkbox the way a user does — on the visible box, not the
+  // sr-only input. React wires checkbox onChange to the browser's
+  // label-activation click, which is exactly the path this exercises.
+  clickCheckbox(harness, `Resume ${conversation}`);
 }
 
 function primary(harness: Harness): HTMLButtonElement | null {

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -302,6 +302,47 @@ export function mount(el: React.ReactElement, opts: MountOptions = {}): Harness 
   };
 }
 
+// Click a Checkbox the way a user does: on the visible box, not the sr-only
+// input. The M527 Checkbox primitive renders a real `<input type="checkbox">`
+// as `sr-only` (1px, clipped, invisible) inside a `<label>` next to a styled
+// `span[aria-hidden]` box. A user clicks that box, and the real browser path is
+// label-activation → the input's click — exactly where checkbox defects live.
+// Driving the hidden input directly exercises a path no user can reach, so it
+// reports green on a control nobody could operate (BET-1199).
+//
+// Locates the input by its accessible name (container first, then
+// document.body for controls rendered through a Modal portal), climbs to the
+// wrapping `<label>`, and dispatches a bubbling, cancelable click on the
+// visible box inside act(). Throws if any step fails so a renamed ariaLabel
+// fails loudly instead of silently doing nothing.
+export function clickCheckbox(h: Harness, ariaLabel: string): void {
+  const sel = `input[aria-label="${ariaLabel}"]`;
+  const input =
+    h.container.querySelector<HTMLElement>(sel) ?? h.docQuery<HTMLElement>(sel);
+  if (!input) {
+    throw new Error(
+      `clickCheckbox: no checkbox with aria-label "${ariaLabel}" found`,
+    );
+  }
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  if (input.getAttribute("type") !== "checkbox") {
+    throw new Error(
+      `clickCheckbox: input "${ariaLabel}" is type "${input.getAttribute("type") ?? "?"}", not a checkbox`,
+    );
+  }
+  const label = input.closest("label");
+  if (!label) {
+    throw new Error(`clickCheckbox: checkbox "${ariaLabel}" is not inside a <label>`);
+  }
+  const box = label.querySelector<HTMLElement>('span[aria-hidden="true"]');
+  if (!box) {
+    throw new Error(`clickCheckbox: checkbox "${ariaLabel}" has no visible box`);
+  }
+  act(() => {
+    box.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+  });
+}
+
 // Convenience: emit an event through the bus and flush.
 export async function emitAndFlush(
   bus: MockEventBus,


### PR DESCRIPTION
## What

Test-only change (BET-1200). Removes the habit of driving checkboxes by
clicking the hidden `sr-only` `<input>` directly. Adds one shared helper that
clicks the **visible** box the way a user does — dispatching a bubbling,
cancelable `MouseEvent("click")` on the `span[aria-hidden]` inside the
checkbox's `<label>` (the browser label-activation path where the BET-1199
defect actually lived) — and converts the genuine checkbox call sites to it.

**Files changed: 4.** `src/renderer/testHarness.tsx`, `src/renderer/CloneFromGitHub.test.tsx`, `src/renderer/Settings.test.tsx`, `src/renderer/UsageResumeModal.test.tsx`.

## The helper

`clickCheckbox(h: Harness, ariaLabel)` in `src/renderer/testHarness.tsx`:

- finds the checkbox by its accessible name (container first, then
  `document.body` for controls rendered through a Modal portal — e.g.
  UsageResumeModal),
- climbs from the `input` to its wrapping `<label>`, disinfects the visible
  `span[aria-hidden="true"]` box,
- dispatches a `MouseEvent("click", { bubbles: true, cancelable: true })` on
  that box inside `act()`,
- throws a clear error if the checkbox / label / visible box isn't found, so a
  renamed `ariaLabel` fails loudly.

## Converted call sites (genuine checkboxes only)

- `CloneFromGitHub.test.tsx` — 4 × clicking `Clone alpha` (the M527 `<Checkbox>`)
- `Settings.test.tsx` — `Auto-rename sessions` toggle
- `UsageResumeModal.test.tsx` — `Resume <conversation>` toggles

The other files named in the issue had **no genuine checkbox drive** and are
correctly left untouched per the "skip non-checkbox inputs" rule:
`Card.test.tsx` (single-select **radio**, `input[type=radio]`), `MenuItem.test.tsx`
(text `Search models` input only), `NewSessionScreen.harness.test.tsx`
(the worktree checkbox is only ever asserted null / queried, never clicked).

## Line counts — net deletion in the test files

| file | before | after | delta |
|---|---|---|---|
| `CloneFromGitHub.test.tsx` | 484 | 460 | −24 |
| `Settings.test.tsx` | 334 | 325 | −9 |
| `UsageResumeModal.test.tsx` | 130 | 125 | −5 |
| `testHarness.tsx` (shared helper) | 368 | 409 | +41 |

Net in test files: **−38 lines** (the hard deletions were the ad-hoc
`querySelector(...)` + `.click()` pairs; the shared helper lives once in
`testHarness.tsx`).

**Base: `origin/main` @ `229e6c12`**

## Verification results

- PR branch (`multica/BET-1200-checkbox-click-helper` @ `655bf8f4`):
  - typecheck: exit 0. Errors: none.
  - test (`npm test`): exit 0, 2543 pass / 0 fail / 0 skip. Failures: none.
- Base (`main` @ `229e6c12`): unchanged test surface for these files; the
  renderer suite is green on the PR branch.
- **Conclusion:** 0 new failures; the only tolerance-checked behavior is the
  same toggling now driven through the user's path. All three affected test
  files ran green (`CloneFromGitHub`, `Settings`, `UsageResumeModal`).
