### PR TITLE
fix(shared): one shared modality reader that tolerates both wire shapes (BET-1201)

### DIFF
--- a/src/renderer/chatShared.test.ts
+++ b/src/renderer/chatShared.test.ts
@@ -129,13 +129,19 @@ describe("modelInputModes", () => {
     ]);
   });
 
-  it("returns [] for an object-map input (normalization owns that shape now)", () => {
-    // The raw /provider object-map (input: {image: true, ...}) is canonicalized
-    // to an array at the normalization chokepoint; the renderer no longer
-    // special-cases it, so an un-normalized map reads as "unknown".
+  it("reads an object-of-flags input, keeping only the true keys (/provider shape)", () => {
     expect(
       modelInputModes(model({ input: { text: true, image: true, pdf: false } })),
-    ).toEqual([]);
+    ).toEqual(["text", "image"]);
+  });
+
+  it("REGRESSION: tolerates the object-of-flags shape from an older box (BET-1201)", () => {
+    // A client can be NEWER than the box it talks to, so it may receive the
+    // provider's raw object-of-flags form rather than the normalized array.
+    // This is the incident guard: it must NOT read as "no input modalities".
+    expect(
+      modelInputModes(model({ input: { text: true, image: true, pdf: true } })),
+    ).toEqual(["text", "image", "pdf"]);
   });
 });
 

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -12,6 +12,7 @@
 
 import { createContext, type ReactNode } from "react";
 import type { OpencodeMessage, OpencodeModel } from "../shared/types";
+import { readModalities } from "../shared/modelGuide.mjs";
 // TokenUsage now lives in src/shared/types.ts (the single source — it also
 // types OpencodeMessageInfo.tokens, which killed the renderer's
 // `as unknown as { tokens?: TokenUsage }` casts, BET-733/L10). Re-exported here
@@ -155,23 +156,21 @@ export function pastVerbFor(messageId: string): string {
   return SPINNER_VERBS_PAST[verbIndexFor(messageId)];
 }
 
-// Detect whether a model can accept file attachments. Normalization guarantees
-// `capabilities.input` is a canonical array of string modalities (never the
-// raw object-map shape) — treat "supports attachments" as any non-"text"
-// modality.
+// Detect whether a model can accept file attachments. Reads the input
+// modalities via the shared `readModalities` (both wire shapes tolerated) —
+// treat "supports attachments" as any non-"text" modality.
 export function modelSupportsAttachments(m: OpencodeModel | null): boolean {
   const modes = modelInputModes(m);
   return modes.some((v) => v !== "text");
 }
 
 // Return the set of input modalities the model accepts (text, image, pdf,
-// video, audio, ...). Empty array if unknown. Normalization owns the canonical
-// array shape; this only defensively filters to strings.
+// video, audio, ...). Both wire shapes are tolerated — the box normalizes to an
+// array, but a client can talk to an older box that emits the object-of-flags
+// form — so this delegates to the shared `readModalities`
+// (src/shared/modelGuide.mjs), the ONLY supported reader for these fields.
 export function modelInputModes(m: OpencodeModel | null): string[] {
-  if (!m) return [];
-  const input = m.capabilities?.input;
-  if (!Array.isArray(input)) return [];
-  return input.filter((v): v is string => typeof v === "string");
+  return readModalities(m?.capabilities?.input);
 }
 
 // Group a mime type into one of opencode's input modality buckets so we can

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -13,6 +13,7 @@ import { readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import http from "node:http";
 import { expandTilde, patchPath } from "../shared/paths.mjs";
+import { readModalities } from "../shared/modelGuide.mjs";
 import { startPoller } from "./startPoller.mjs";
 import {
   CREDENTIALS_PATH,
@@ -1143,23 +1144,6 @@ export function applyModelOverride(m, override) {
   return next;
 }
 
-// Canonicalize a providerInput-backed modality field to the single canonical
-// array-of-strings shape. Handles both raw shapes seen in the wild:
-//   /provider source:  input: {image, pdf, ...}  (object map, true = enabled)
-//   /api/model source: input: ["text", "image"]  (array)
-// Anything else → `[]`.
-function _normalizeModalities(input) {
-  if (Array.isArray(input)) {
-    return input.filter((v) => typeof v === "string");
-  }
-  if (input && typeof input === "object") {
-    return Object.entries(input)
-      .filter(([, v]) => v === true)
-      .map(([k]) => String(k));
-  }
-  return [];
-}
-
 // Canonicalize a model's `limit`. `context` is `number | null`; `null` means
 // "the provider gave no usable limit — never fabricate one". `0`, negative,
 // NaN, Infinity and missing all map to `null`. `output` is kept only when a
@@ -1207,8 +1191,8 @@ function _normalizeProviderModel(providerID, modelId, m) {
     capabilities: {
       tools: typeof caps.tools === "boolean" ? caps.tools : undefined,
       attachment: typeof caps.attachment === "boolean" ? caps.attachment : undefined,
-      input: _normalizeModalities(caps.input),
-      output: _normalizeModalities(caps.output),
+      input: readModalities(caps.input),
+      output: readModalities(caps.output),
     },
     variants: variants && variants.length > 0 ? variants : undefined,
   };

--- a/src/shared/modelGuide.d.mts
+++ b/src/shared/modelGuide.d.mts
@@ -15,6 +15,8 @@ export function familyKey(modelID: string): string | null;
 
 export function isDeprecated(m: { status?: string } | null | undefined): boolean;
 
+export function readModalities(value: unknown): string[];
+
 export interface ResolvedModel {
   id?: string;
   name?: string;

--- a/src/shared/modelGuide.mjs
+++ b/src/shared/modelGuide.mjs
@@ -366,3 +366,21 @@ export function isDeprecated(m) {
   return !!m && m.status === "deprecated";
 }
 
+// Read a model's declared modalities from EITHER wire shape.
+//
+// The box normalizes `capabilities.input` / `.output` to an array of strings,
+// but a client can be NEWER than the box it talks to — the desktop app and the
+// box update on separate tracks — so a client may still receive the provider's
+// raw object-of-flags form. Both are accepted here. Anything else reads as
+// "unknown" and returns [], which callers must treat as "no information",
+// NEVER as "this model supports nothing".
+export function readModalities(value) {
+  if (Array.isArray(value)) return value.filter((v) => typeof v === "string");
+  if (value && typeof value === "object") {
+    return Object.entries(value)
+      .filter(([, v]) => v === true)
+      .map(([k]) => String(k));
+  }
+  return [];
+}
+

--- a/src/shared/modelGuide.test.ts
+++ b/src/shared/modelGuide.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { describeModel, familyKey, fuzzyMatchModel, suggestModels, isDeprecated } from "./modelGuide.mjs";
+import { describeModel, familyKey, fuzzyMatchModel, suggestModels, isDeprecated, readModalities } from "./modelGuide.mjs";
 
 describe("describeModel", () => {
   it("matches haiku family", () => {
@@ -285,5 +285,26 @@ describe("isDeprecated", () => {
     expect(isDeprecated({})).toBe(false);
     expect(isDeprecated(null)).toBe(false);
     expect(isDeprecated(undefined)).toBe(false);
+  });
+});
+
+describe("readModalities", () => {
+  it("passes an array of strings through unchanged", () => {
+    expect(readModalities(["text", "image", "pdf"])).toEqual(["text", "image", "pdf"]);
+  });
+
+  it("reads the object-of-flags form, keeping only the true keys in key order", () => {
+    expect(readModalities({ image: true, text: true, pdf: false })).toEqual(["image", "text"]);
+  });
+
+  it("drops non-string members of an array", () => {
+    expect(readModalities(["text", 5, null, "image"])).toEqual(["text", "image"]);
+  });
+
+  it("returns [] for undefined, null, a string, or a number", () => {
+    expect(readModalities(undefined)).toEqual([]);
+    expect(readModalities(null)).toEqual([]);
+    expect(readModalities("text")).toEqual([]);
+    expect(readModalities(42)).toEqual([]);
   });
 });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2313,15 +2313,17 @@ export type SubagentInput = {
 // "pdf" | "video" | "audio" | any provider-specific or custom value.
 export type InputModality = string;
 
-// Canonical model capabilities. After normalization at the chokepoint
-// (_normalizeProviderModel in src/server/opencode.mjs), `input`/`output` are
-// ALWAYS arrays of strings — the renderer must never handle the raw provider
-// object-map shape. `tools`/`attachment` pass through as booleans.
+// Model capabilities. The box normalizes `capabilities.input` / `.output` to
+// arrays of strings, but a client may be talking to an OLDER box (the desktop
+// app and the box update on separate tracks), so both shapes reach clients —
+// the provider's raw object-of-flags form and the canonical array form.
+// `readModalities` (src/shared/modelGuide.mjs) is the ONLY supported way to
+// read these two fields. `tools`/`attachment` pass through as booleans.
 export type OpencodeModelCapabilities = {
   tools?: boolean;
   attachment?: boolean;
-  input?: InputModality[];   // CANONICAL: array of strings after normalization
-  output?: InputModality[];
+  input?: InputModality[] | Record<string, boolean>;
+  output?: InputModality[] | Record<string, boolean>;
 };
 
 export type OpencodeModel = {


### PR DESCRIPTION
Collapses model input-modality parsing into ONE shared reader that tolerates both wire shapes, so no client can ever be stricter than the box it talks to (the desktop and box update on separate tracks).

**Root cause fixed:** commit `e31ccd17` normalized modalities to arrays server-side and, in the same commit, made the renderer read ONLY the array form. A newer desktop against an older box received the object-of-flags form, read it as "[] modalities", and refused every attachment — a false "doesn't accept" refusal for image-capable models.

**Changes:**
- `src/shared/modelGuide.mjs` — new `readModalities(value)` pure reader, shared by server + renderer.
- `src/server/opencode.mjs` — deleted private `_normalizeModalities`; uses `readModalities`. Server behaviour unchanged (still emits arrays).
- `src/renderer/chatShared.tsx` — `modelInputModes` now delegates to `readModalities`; removed the strict `Array.isArray` path and the false "never the object map" comment.
- `src/shared/types.ts` — `input`/`output` typed `InputModality[] | Record<string, boolean>`; comment now says `readModalities` is the only supported reader.
- Tests: `readModalities` block in `modelGuide.test.ts`; object-of-flags regression guard in `chatShared.test.ts`.

Some minor doc/comment cleanup of the same false assumption caught during review.

**Files changed:** 7 files (73 insertions, 41 deletions).

**Verification results:**
- PR branch (`multica/BET-1201-shared-modalities-reader` @ `448a67aa`):
  - typecheck: exit 0. Errors: none. log sha256: `736863a6a32276c2ff4ddee349a89c3f086c868bed727c331ded11892800d9dd`
  - test: server node:test exit 0 (2543 pass / 0 fail); vitest 3230 passed / 7 skipped / 0 failed. Failures: none. log sha256 (`test-pr.log`): `8b93e190542b1e571f5229a365e032efdc687b6cd71913ef9e681573c3400dee`. (vitest summary re-verified separately: 3230 passed.)
- Base (`main` @ `229e6c12`):
  - typecheck: exit 0. Errors: none. log sha256: `736863a6a32276c2ff4ddee349a89c3f086c868bed727c331ded11892800d9dd`
  - test: server node:test exit 0 (2543 pass / 0 fail); vitest 3225 passed / 7 skipped / 0 failed. Failures: none. log sha256 (`test-main.log`): `187fe4c6998b0a8b184938d085ffddfedd6b92fb97679857d7d10eb302a72959`
- **Conclusion:** 0 test failures are pre-existing or new. This PR adds 5 new passing tests (4 `readModalities`, 1 object-of-flags regression guard) and updates 1 stale assertion (the old "object-map reads as []" case) to the corrected behavior.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ `229e6c12`**
