### PR TITLE
feat(renderer): drag-and-drop file attach on the new-session draft screen (BET-1204)

### DIFF
--- a/src/renderer/NewSessionScreen.harness.test.tsx
+++ b/src/renderer/NewSessionScreen.harness.test.tsx
@@ -627,6 +627,74 @@ describe("NewSessionScreen attach-before-start (BET-1124)", () => {
       asPathRef: true,
     });
   });
+
+  // BET-1204: drag-and-drop on the new-session draft screen stages through the
+  // identical onFiles path as the paperclip button (onFiles → draft.attachments
+  // → upload on submit). A synthetic drop must produce the same chip + upload.
+  it("a drop on the screen root stages the file and uploads it on submit", async () => {
+    const d = draft({ mode: { projectName: "proj" }, cwd: "/x", input: "summarize" });
+    const api = mountComposer(
+      d,
+      {
+        uploadBuffer: () => Promise.resolve("/remote/note.md"),
+        tmuxNewWindow: () =>
+          Promise.resolve({ sessionId: "ses-1", windowIndex: 0, projects: [] }),
+      },
+      {
+        projects: [
+          {
+            tmuxSession: "proj",
+            defaultCwd: "/x",
+            attached: false,
+            windows: [
+              {
+                index: 0,
+                name: "w",
+                active: true,
+                paneCurrentPath: "/x",
+                opencodeSessionId: "ses-1",
+              },
+            ],
+          },
+        ],
+        dismissDraft: () => {},
+      },
+    );
+    await h!.flush();
+
+    const root = h!.container.querySelector('[data-screen="welcome"]') as HTMLElement;
+    expect(root, "expected the screen root").toBeTruthy();
+
+    const file = new File(["content"], "note.md", { type: "text/markdown" });
+    // jsdom's File lacks arrayBuffer(); submit() reads bytes this way.
+    (file as File & { arrayBuffer: () => Promise<ArrayBuffer> }).arrayBuffer =
+      () => Promise.resolve(new ArrayBuffer(1));
+
+    // jsdom has no DataTransfer; hand the drop event a minimal stub whose
+    // types/files the handlers read (Array.from(types) + onFiles(files)).
+    const drop = new Event("drop", { bubbles: true, cancelable: true });
+    Object.defineProperty(drop, "dataTransfer", {
+      value: { types: ["Files"], files: [file] as unknown as FileList, dropEffect: "none" },
+    });
+    act(() => root.dispatchEvent(drop));
+    await h!.flush();
+
+    // The chip appears, staged through the same onFiles path as the button.
+    expect(h!.text()).toContain("note.md");
+    const staged = useStore.getState().drafts.find((x) => x.id === d.id)!.attachments;
+    expect(staged).toHaveLength(1);
+    expect(staged[0].filename).toBe("note.md");
+
+    const start = h!.container.querySelector(
+      'button[aria-label="Start a session"]',
+    ) as HTMLButtonElement;
+    act(() => start.click());
+    await h!.flush();
+
+    const ups = api.calls.uploadBuffer ?? [];
+    expect(ups.length).toBe(1);
+    expect(ups[0]?.[0]).toMatchObject({ projectName: "proj", filename: "note.md" });
+  });
 });
 
 // BET-1127 follow-up: the fan-out submit path (submitFanOut — one session, one

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -174,6 +174,11 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
   // sessionId yet, so it uses its own input rather than the manta-attach-files
   // bridge (which targets a live session's composer).
   const fileInputRef = useRef<HTMLInputElement>(null);
+  // Drop-to-attach state (BET-1204): a dotted "Drop to attach" overlay shows
+  // while files are dragged over the screen. dragDepth unwinds nested-element
+  // crossings so the overlay only clears when the pointer leaves the screen.
+  const [dragHover, setDragHover] = useState(false);
+  const dragDepth = useRef(0);
 
   // Stage files a user picks into the draft's attachments. Upload is deferred
   // to submit() — once the destination session/window name exists.
@@ -193,6 +198,37 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
       attachments: [...draft.attachments, ...newAttachments],
     });
     if (fileInputRef.current) fileInputRef.current.value = "";
+  };
+
+  // ---- drop-to-attach (BET-1204) ----
+  // A drop feeds the EXACT same path as the paperclip button: onFiles →
+  // draft.attachments → deferred upload by submit()/submitFanOut(). Zero new
+  // upload, zero new staging, zero new data path — a pure drag affordance
+  // layered on the existing attach code.
+  const onDragEnter = (e: React.DragEvent) => {
+    if (!Array.from(e.dataTransfer?.types ?? []).includes("Files")) return;
+    e.preventDefault();
+    dragDepth.current++;
+    setDragHover(true);
+  };
+  const onDragOver = (e: React.DragEvent) => {
+    if (!Array.from(e.dataTransfer?.types ?? []).includes("Files")) return;
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+  };
+  const onDragLeave = (e: React.DragEvent) => {
+    if (!Array.from(e.dataTransfer?.types ?? []).includes("Files")) return;
+    e.preventDefault();
+    // Nested-element crossing: only clear once the depth unwinds to zero.
+    dragDepth.current = Math.max(0, dragDepth.current - 1);
+    if (dragDepth.current === 0) setDragHover(false);
+  };
+  const onDrop = (e: React.DragEvent) => {
+    if (!Array.from(e.dataTransfer?.types ?? []).includes("Files")) return;
+    e.preventDefault();
+    dragDepth.current = 0;
+    setDragHover(false);
+    onFiles(e.dataTransfer.files);
   };
 
   // ---- repo probe (BET-787): the new-project zero state ----
@@ -876,7 +912,30 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
     // data-screen is the visual harness's handle on this screen (see
     // scripts/visual/screens.mjs). One stable attribute per screen root, so
     // the harness never depends on a class name or DOM position.
-    <div data-screen="welcome" className="h-full flex flex-col items-center justify-center px-8">
+    <div
+      data-screen="welcome"
+      className="h-full flex flex-col items-center justify-center px-8 relative"
+      onDragEnter={onDragEnter}
+      onDragOver={onDragOver}
+      onDragLeave={onDragLeave}
+      onDrop={onDrop}
+    >
+      {/* Drop-to-attach overlay (BET-1204): dotted border + tinted bg only
+          while files are over the screen. pointer-events-none so the inner
+          DOM still receives the drop (the overlay never intercepts it). */}
+      {dragHover && (
+        <div
+          className="absolute inset-0 z-30 pointer-events-none rounded-md border-2 border-dashed flex items-center justify-center"
+          style={{
+            borderColor: "var(--accent)",
+            backgroundColor: "var(--accent-bg)",
+          }}
+        >
+          <span className="text-body text-text" style={{ color: "var(--accent)" }}>
+            Drop to attach
+          </span>
+        </div>
+      )}
       {cloneOpen ? (
         <CloneFromGitHub
           defaultRoot={proposedWorkspaceRoot}


### PR DESCRIPTION
## BET-1204: Enable drag-and-drop file attach on the new-session draft screen

**Files changed:** `2` files.
- `src/renderer/NewSessionScreen.tsx` (+61/-1)
- `src/renderer/NewSessionScreen.harness.test.tsx` (+68)

### What
Drag-drop on the new-session / new-project draft screen now stages dropped files as attachments, reusing the **exact** existing path: `onFiles` → `draft.attachments` → deferred upload by `submit()`/`submitFanOut()`. Zero new upload, staging, or data path — a pure drag affordance on top of the existing attach code (documented in a code comment next to the drop handler).

- Drag state + handlers (`onDragEnter`/`onDragOver`/`onDragLeave`/`onDrop`) mirror the `ChatPanel.tsx` pattern (Files-type guard, `dragDepth` unwind, `dropEffect: "copy"`).
- Handlers wired to the screen root `<div data-screen="welcome">`, which covers both new-session and new-project draft modes (they render the same screen) — no branching.
- A dotted "Drop to attach" overlay with `pointer-events-none` renders while `dragHover` is true (mirrors ChatPanel's overlay).
- Paperclip button + hidden `<input type="file">` untouched.

### Verification
Done nothing to `submit()`/`submitFanOut()`, no `uploadBuffer`/`window.api`/server change, and `ChatPanel.tsx`/`App.tsx` untouched.

**Verification results:**
- PR branch (`multica/BET-1204-drag-drop-attach` @ `b3be1ba5`):
  - typecheck: exit 0. Errors: none. log sha256: `736863a6a3...0d9dd`
  - test: exit 0, 2543 pass / 0 fail / 0 skip. Failures: none. log sha256: `241b36bde4...a1f253`
- Base (`origin/main` @ `229e6c12`):
  - typecheck: exit 0. Errors: none. log sha256: `736863a6a3...0d9dd`
  - test: exit 0, 2543 pass / 0 fail / 0 skip. Failures: none. log sha256: `0360fb8d7a...43bef`
- **Conclusion:** 0 new failures, 0 pre-existing, 0 resolved. Identical test counts between branches; the only change is the added file's drag-drop test.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.
