### PR TITLE
BET-1203: iOS model capabilities decode both input shapes without emptying the catalogue

### DIFF
--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -313,10 +313,36 @@ struct OpencodeModel: Codable, Equatable, Sendable {
 /// present with the wrong TYPE throws and takes the whole model list with it,
 /// which is exactly how the catalogue silently came up empty.
 struct ModelCapabilities: Codable, Equatable, Sendable {
-    /// Input modalities, an OBJECT of flags on the wire (`{"text":true,
-    /// "image":true,…}`) — never a list of strings.
+    /// Input modalities. TWO shapes reach this client and both are valid:
+    /// a list of names (`["text","image"]`, what the box sends after it
+    /// normalizes) and the provider's raw object of flags
+    /// (`{"text":true,"image":true}`, what an older box forwards untouched).
+    /// The app and the box update on separate tracks, so neither shape can be
+    /// assumed. Anything else decodes to empty — "unknown", never a claim that
+    /// the model supports nothing — and never throws, because a throw here
+    /// takes the whole model list with it.
     struct Modalities: Codable, Equatable, Sendable {
-        var image: Bool?
+        var names: [String] = []
+
+        var image: Bool { names.contains("image") }
+
+        init(names: [String] = []) { self.names = names }
+
+        init(from decoder: Decoder) throws {
+            let container = try decoder.singleValueContainer()
+            if let list = try? container.decode([String].self) {
+                names = list
+            } else if let flags = try? container.decode([String: Bool].self) {
+                names = flags.filter { $0.value }.map(\.key).sorted()
+            } else {
+                names = []
+            }
+        }
+
+        func encode(to encoder: Encoder) throws {
+            var container = encoder.singleValueContainer()
+            try container.encode(names)
+        }
     }
     var reasoning: Bool?
     var input: Modalities?

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -119,7 +119,7 @@ final class ModelRecentsTests: XCTestCase {
             name: "m",
             capabilities: ModelCapabilities(
                 reasoning: reasoning,
-                input: image.map { ModelCapabilities.Modalities(image: $0) }
+                input: image.map { ModelCapabilities.Modalities(names: $0 ? ["image"] : []) }
             )
         )
     }
@@ -275,7 +275,7 @@ final class ModelRecentsTests: XCTestCase {
             limit: context.map { ModelLimit(context: $0) },
             capabilities: ModelCapabilities(
                 reasoning: reasoning,
-                input: image.map { ModelCapabilities.Modalities(image: $0) }
+                input: image.map { ModelCapabilities.Modalities(names: $0 ? ["image"] : []) }
             )
         )
     }
@@ -351,7 +351,7 @@ final class ModelRecentsTests: XCTestCase {
             enabled: enabled,
             capabilities: ModelCapabilities(
                 reasoning: reasoning,
-                input: image.map { ModelCapabilities.Modalities(image: $0) }
+                input: image.map { ModelCapabilities.Modalities(names: $0 ? ["image"] : []) }
             )
         )
     }

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -334,6 +334,64 @@ final class SessionModelsTests: XCTestCase {
         XCTAssertFalse(shouldFireTurnCompleteHaptic(
             turnCompleteEdge: true, showScrollToBottom: true, isActive: true, hapticsEnabled: false))
     }
+
+    // MARK: - BET-1203 model capabilities decode both input shapes
+
+    private func decodeModels(_ json: String) -> [OpencodeModel]? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONDecoder().decode([OpencodeModel].self, from: data)
+    }
+
+    func testCapabilitiesInputListShapeDecodesImage() {
+        let models = decodeModels("""
+        [{"id":"m","providerID":"anthropic","name":"M","capabilities":{"input":["text","image","pdf"]}}]
+        """)
+        XCTAssertEqual(models?.count, 1)
+        XCTAssertTrue(models?.first?.capabilities?.input?.image == true)
+    }
+
+    func testCapabilitiesInputObjectShapeDecodesImageAndOmitsFalseFlag() {
+        let models = decodeModels("""
+        [{"id":"m","providerID":"anthropic","name":"M","capabilities":{"input":{"text":true,"image":true,"pdf":false}}}]
+        """)
+        XCTAssertEqual(models?.count, 1)
+        let input = models?.first?.capabilities?.input
+        XCTAssertTrue(input?.image == true)
+        XCTAssertFalse(input?.names.contains("pdf") == true)
+    }
+
+    func testCapabilitiesInputObjectImageFalseDecodesAsFalse() {
+        let models = decodeModels("""
+        [{"id":"m","providerID":"anthropic","name":"M","capabilities":{"input":{"text":true,"image":false}}}]
+        """)
+        XCTAssertEqual(models?.count, 1)
+        XCTAssertTrue(models?.first?.capabilities?.input?.image == false)
+    }
+
+    func testCapabilitiesInputGarbageShapeStillDecodesModel() {
+        let models = decodeModels("""
+        [{"id":"m","providerID":"anthropic","name":"M","capabilities":{"input":42}}]
+        """)
+        XCTAssertEqual(models?.count, 1)
+        XCTAssertTrue(models?.first?.capabilities?.input?.image == false)
+    }
+
+    /// The actual production failure: one model in the new (list) shape must not
+    /// empty the whole catalogue. A list of two models — first list shape,
+    /// second object shape — must return both.
+    func testCapabilitiesInputMixedShapesDoNotEmptyTheCatalogue() {
+        let models = decodeModels("""
+        [
+          {"id":"a","providerID":"anthropic","name":"A","capabilities":{"input":["text","image","pdf"]}},
+          {"id":"b","providerID":"anthropic","name":"B","capabilities":{"input":{"text":true,"image":true,"pdf":false}}}
+        ]
+        """)
+        XCTAssertEqual(models?.count, 2)
+        XCTAssertEqual(models?.first?.id, "a")
+        XCTAssertEqual(models?.last?.id, "b")
+        XCTAssertTrue(models?.first?.capabilities?.input?.image == true)
+        XCTAssertTrue(models?.last?.capabilities?.input?.image == true)
+    }
 }
 
 // MARK: - BET-746 rename/fork failure feedback


### PR DESCRIPTION
Opened automatically for `agent/macos/7ad4a580`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1203.