### PR TITLE
BET-1205: dedupe staged-attachment upload into one helper

### DIFF
--- a/src/renderer/NewSessionScreen.test.tsx
+++ b/src/renderer/NewSessionScreen.test.tsx
@@ -1,0 +1,51 @@
+// @vitest-environment jsdom
+//
+// Unit tests for the shared staged-attachment upload round-trip
+// (uploadDraftAttachment). Both submit() and submitFanOut() route through it,
+// so its contract — return the remote path on success, null when uploadBuffer
+// returns an empty/falsy path — is what every creation path relies on.
+
+import { describe, it, expect, afterEach } from "vitest";
+import { uploadDraftAttachment } from "./NewSessionScreen";
+
+function stagedFile(): { filename: string; file: File } {
+  const file = new File(["content"], "note.md", { type: "text/markdown" });
+  // jsdom's File lacks arrayBuffer(); uploadDraftAttachment() reads bytes this
+  // way — same polyfill the harness applies to staged files.
+  (file as File & { arrayBuffer: () => Promise<ArrayBuffer> }).arrayBuffer = () =>
+    Promise.resolve(new ArrayBuffer(1));
+  return { filename: "note.md", file };
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function setUploadBuffer(impl: (args: unknown) => unknown): void {
+  (window as any).api = { uploadBuffer: impl };
+}
+
+afterEach(() => {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  delete (window as any).api;
+});
+
+describe("uploadDraftAttachment", () => {
+  it("returns the remote path when uploadBuffer succeeds", async () => {
+    let received: unknown = null;
+    setUploadBuffer((args) => {
+      received = args;
+      return Promise.resolve("/remote/note.md");
+    });
+
+    const rp = await uploadDraftAttachment("proj", stagedFile());
+
+    expect(rp).toBe("/remote/note.md");
+    expect(received).toMatchObject({ projectName: "proj", filename: "note.md" });
+  });
+
+  it("returns null when uploadBuffer returns an empty/falsy path", async () => {
+    setUploadBuffer(() => Promise.resolve(""));
+    expect(await uploadDraftAttachment("proj", stagedFile())).toBeNull();
+
+    setUploadBuffer(() => Promise.resolve(undefined));
+    expect(await uploadDraftAttachment("proj", stagedFile())).toBeNull();
+  });
+});

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -101,6 +101,22 @@ function normalizeCreate(
   };
 }
 
+// Upload one staged draft attachment and return its remote path, or null on
+// failure. Shared by submit() and submitFanOut() so both creation paths run
+// the exact same read+upload round-trip. The caller decides the abort.
+export async function uploadDraftAttachment(
+  projectName: string,
+  a: { filename: string; file: File },
+): Promise<string | null> {
+  const buffer = await a.file.arrayBuffer();
+  const rp = await window.api.uploadBuffer({
+    projectName,
+    filename: a.filename,
+    buffer,
+  });
+  return rp ? rp : null;
+}
+
 type Props = {
   // The id of the store draft this composer edits (see NewSessionDraft). The
   // draft holds the persisted composer workspace; the active view renders this
@@ -677,12 +693,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
         // upload aborts the whole send — no session left without its files.
         const attachments: Attachment[] = [];
         for (const a of draft.attachments) {
-          const buffer = await a.file.arrayBuffer();
-          const rp = await window.api.uploadBuffer({
-            projectName: sessionName,
-            filename: a.filename,
-            buffer,
-          });
+          const rp = await uploadDraftAttachment(sessionName, a);
           if (rp) {
             attachments.push({
               id: a.id,
@@ -792,12 +803,7 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
         // as attachments so fan-out doesn't silently drop them.
         const attachments: { remotePath: string; mime: string; filename?: string }[] = [];
         for (const a of draft.attachments) {
-          const buffer = await a.file.arrayBuffer();
-          const rp = await window.api.uploadBuffer({
-            projectName: sessionName,
-            filename: a.filename,
-            buffer,
-          });
+          const rp = await uploadDraftAttachment(sessionName, a);
           if (rp) {
             attachments.push({ remotePath: rp, mime: a.mime, filename: a.filename });
           } else {


### PR DESCRIPTION
## Summary
Extracted the duplicated "read staged attachment bytes + upload" round-trip that existed in both `submit()` and `submitFanOut()` of `NewSessionScreen.tsx` into one shared module-level helper, `uploadDraftAttachment(projectName, a)`.

Both creation paths now call the single helper; each keeps its own result-shape and per-path abort handling unchanged (per the issue's intentional-duplication note).

## Changes
- `src/renderer/NewSessionScreen.tsx`: added `uploadDraftAttachment` (exported, pure-adjacent, testable); replaced the inner read+upload loop in both `submit()` and `submitFanOut()` with `const rp = await uploadDraftAttachment(sessionName, a)`. Result shapes and `if (!rp) { setError(...); setSending(false); return; }` aborts left exactly as-is.
- `src/renderer/NewSessionScreen.test.tsx` (new): unit tests for `uploadDraftAttachment` — returns the remote path on success, returns `null` when `uploadBuffer` returns an empty/falsy path.

No behavior change; the `uploadBuffer` surface, drag-drop, `ChatPanel.tsx`, `App.tsx`, and `Api` are untouched.

## Verification
- `npm run typecheck` — pass
- `npm test` — 2543/2543 pass (includes the existing submit + submitFanOut attachment-parity tests and the new helper unit tests)