### PR TITLE
fix(renderer): attachment gate sends on unknown model capabilities (BET-1202)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1170,15 +1170,16 @@ export function ChatPanel({
         filename: a.filename,
       }));
 
-    // Refuse to submit if the user has attachments but the active model
-    // can't accept them — opencode would error mid-stream with a vague
-    // "media type X functionality not supported" message. Block here with
-    // a clearer reason instead.
+    // Refuse only what the model positively declares it cannot take. A file
+    // that maps to no media mode ("other") is refused on its own — that is a
+    // property of the file, not the model. But a modality check requires
+    // capability information to exist: when we know nothing, we send and let
+    // the provider answer, rather than asserting "accepted: none".
     if (readyAttachments.length > 0) {
       const modes = modelInputModes(activeModel);
       const unsupported = readyAttachments
         .map((a) => ({ filename: a.filename, mime: a.mime, mode: mimeToInputMode(a.mime) }))
-        .filter((a) => a.mode === "other" || !modes.includes(a.mode));
+        .filter((a) => a.mode === "other" || (modes.length > 0 && !modes.includes(a.mode)));
       if (unsupported.length > 0) {
         setRunning(false);
         // Strip the optimistic user message — the send is being refused.

--- a/src/renderer/chatShared.test.ts
+++ b/src/renderer/chatShared.test.ts
@@ -156,9 +156,10 @@ describe("modelSupportsAttachments", () => {
     expect(modelSupportsAttachments(model({ input: ["image"] }))).toBe(true);
   });
 
-  it("is false for null / unknown capabilities", () => {
-    expect(modelSupportsAttachments(null)).toBe(false);
-    expect(modelSupportsAttachments(model(undefined))).toBe(false);
+  it("is true when capabilities are unknown (absence of info is not a denial)", () => {
+    expect(modelSupportsAttachments(null)).toBe(true);
+    expect(modelSupportsAttachments(model(undefined))).toBe(true);
+    expect(modelSupportsAttachments(model({ input: [] }))).toBe(true);
   });
 });
 

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -158,10 +158,12 @@ export function pastVerbFor(messageId: string): string {
 
 // Detect whether a model can accept file attachments. Reads the input
 // modalities via the shared `readModalities` (both wire shapes tolerated) —
-// treat "supports attachments" as any non-"text" modality.
+// treat "supports attachments" as any non-"text" modality. Unknown
+// capabilities mean "no reason to warn": an empty modality list is allow,
+// not deny — the provider answers if the send really was invalid.
 export function modelSupportsAttachments(m: OpencodeModel | null): boolean {
   const modes = modelInputModes(m);
-  return modes.some((v) => v !== "text");
+  return modes.length === 0 || modes.some((v) => v !== "text");
 }
 
 // Return the set of input modalities the model accepts (text, image, pdf,


### PR DESCRIPTION
**Base: origin/main @ 5569a3ef**

## Change

Fixes BET-1202. Two predicate changes so the attachment gate treats **unknown** model capabilities as "no reason to refuse/warn", while still refusing on a model that **positively** declares it can't take the file's type.

1. `src/renderer/ChatPanel.tsx` — submit gate: the capability-based filter now requires `modes.length > 0` before a mode-mismatch can refuse. `a.mode === "other"` (a property of the file) still refuses on its own regardless of capability knowledge. Comment rewritten to state the rule.
2. `src/renderer/chatShared.tsx` — `modelSupportsAttachments`: empty modality list → allow (unknown means no warning), so the `@`-mention typeahead no longer warns on unknown capabilities. Same notion as the submit gate, one reader.

**Files changed:** `3`.
```
 src/renderer/ChatPanel.tsx      | 11 ++++++-----
 src/renderer/chatShared.test.ts |  7 ++++---
 src/renderer/chatShared.tsx     |  6 ++++--
 3 files changed, 14 insertions(+), 10 deletions(-)
```

## Verification results

- PR branch (`multica/BET-1202-attachment-gate-unknown-capabilities` @ `51e76d91`):
  - typecheck: exit 0, no errors.
  - test: exit 0, 2543 pass / 0 fail / 0 skip.

Ran on the PR branch after rebasing onto current `origin/main` (which added only iOS-native BET-1203 files, no overlap).

## Tests

`chatShared.test.ts` `modelSupportsAttachments`:
- unknown capabilities (`null`, missing caps) → `true`
- empty modality list → `true`
- exactly `["text"]` → `false` (kept)
- `["text","text"]` → `false` (kept)
- `["text","image"]` / `["image"]` → `true` (kept)

No new test file; the harness does not currently mount the refusal-gate wiring and the ticket's two unit-level cases plus reasoning are explicitly deemed sufficient there.
