### PR TITLE
fix(renderer): pass draft attachments through autoSubmit first prompt (BET-1206)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -310,7 +310,7 @@ export function ChatPanel({
   }, []);
   // Forward declaration: submitRef is defined later (depends on submit), but
   // useSseBus needs it now for the drain effect.
-  const submitRef = useRef<(textOverride?: string) => void>(() => {});
+  const submitRef = useRef<(textOverride?: string, attachmentsOverride?: Attachment[]) => void>(() => {});
   // Input state must be declared before useSseBus (which needs setInput).
   const [input, setInput] = useState("");
   // Bumped after each submit so useInputHistory re-reads localStorage and the

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -1053,15 +1053,16 @@ export function ChatPanel({
     refreshPermissions();
   }, [isActive, scheduleRefetch, refreshQuestions, refreshPermissions]);
 
-  const submit = useCallback(async (textOverride?: string) => {
+  const submit = useCallback(async (textOverride?: string, attachmentsOverride?: Attachment[]) => {
+    const submitAttachments = attachmentsOverride ?? attachments;
     // Block submit while any attachment is still uploading.
-    if (attachments.some((a) => a.status === "uploading")) {
+    if (submitAttachments.some((a) => a.status === "uploading")) {
       setSendError("Wait for attachments to finish uploading.");
       return;
     }
     // Non-media chips ride along as `@<remote-path>` tokens appended to the
     // message text — the AI reads them with its Read tool.
-    const pathRefAttachments = attachments.filter(
+    const pathRefAttachments = submitAttachments.filter(
       (a) => a.status === "ready" && !!a.remotePath && a.asPathRef,
     );
     const pathRefText = pathRefAttachments.map((a) => `@${a.remotePath}`).join(" ");
@@ -1162,7 +1163,7 @@ export function ChatPanel({
 
     // Only media chips become multimodal FileParts; path-ref chips were
     // already folded into `text` above.
-    const readyAttachments = attachments
+    const readyAttachments = submitAttachments
       .filter((a) => a.status === "ready" && a.remotePath && !a.asPathRef)
       .map((a) => ({
         remotePath: a.remotePath!,
@@ -1315,7 +1316,11 @@ export function ChatPanel({
     // on the setInput re-render having committed before the timer fires.
     const t = setTimeout(() => {
       useStore.getState().setAutoSubmitPrompt(null);
-      submitRef.current?.(text);
+      // Attachments ride the same explicit-override channel as the text: like
+      // textOverride, this deferred first-turn submit must not depend on the
+      // setAttachments re-render having committed a fresh closure before the
+      // timer fires, or the staged draft file is silently dropped.
+      submitRef.current?.(text, attachments);
     }, 0);
     return () => {
       clearTimeout(t);


### PR DESCRIPTION
## Summary

Fixes BET-1206: a file attached to the new-session/new-project draft screen (drag-and-drop BET-1204 or the paperclip button) was silently dropped from the model's **first** prompt, even though it uploaded and staged correctly.

### Root cause
The first prompt is delivered through ChatPanel's `autoSubmit` handoff → a deferred `submit()`. The text is passed to `submit` explicitly via `textOverride` (to survive the stale-closure race), but attachments were read from the render closure with **no** override. When the deferred submit fired before the re-render reassigned a closure holding the new attachments, it ran with an empty set → text sent, file dropped.

### Fix (exactly as specified in the issue — `ChatPanel.tsx` only)
- `submit(textOverride?, attachmentsOverride?)` — the effective set is derived once: `submitAttachments = attachmentsOverride ?? attachments`.
- Both attachment consumers (path-ref fold and media FilePart derivation) now use `submitAttachments`.
- The `autoSubmit` deferred call passes `(text, attachments)` explicitly, mirroring `textOverride`; a comment notes why.
- Widened `submitRef`'s declared type to accept the second optional param (required for typecheck — it's the ref's type declaration, not a caller).

No other `submit` callers changed (`attachmentsOverride` is `undefined` for all of them → byte-identical behavior). `submitFanOut` and the fan-out path are untouched and still pass.

**Files changed:** 1 — `src/renderer/ChatPanel.tsx`

**Base: origin/main @ 1274a49**

## Verification results
- PR branch (`multica/BET-1206-draft-attachments-first-prompt` @ `0163c0c`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0 — vitest 3233 pass / 7 skip / 0 fail; node:test 2543 pass / 0 fail. The BET-1124 attachment auto-submit harness test passes (41 tests in `ChatPanel.harness.test.tsx`).
- Base (`main` @ `1274a49`): typecheck exit 0; vitest identical 3233 pass / 7 skip / 0 fail. The node:test portion reports 2 failures in server test files (`providers.test.mjs`, `rpc.test.mjs`) — **environmental, not this PR**: the linked main worktree is missing the `jsonc-parser` dependency (`ERR_MODULE_NOT_FOUND` on import). The same two files pass 136/136 on the PR worktree, which has a complete install. These are server-side; this PR touches renderer code only.
- **Conclusion:** 0 new failures. The change is renderer-only and adds an explicit-attachments override path that is behavior-neutral when the closure is already fresh.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-main.log`.
