### PR TITLE
chore(ios): bump marketing version to 1.0.18 (TestFlight)

### DIFF
--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -95,7 +95,7 @@ targets:
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         TARGETED_DEVICE_FAMILY: "1,2"
-        MARKETING_VERSION: "1.0.17"
+        MARKETING_VERSION: "1.0.18"
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Automatic
         SWIFT_EMIT_LOC_STRINGS: YES


### PR DESCRIPTION
Bumps MARKETING_VERSION in mobile/native/project.yml to 1.0.18 so the auto-tag workflow ships the latest main iOS code to TestFlight.

On merge to main, ios-release-tag.yml reads this version and pushes `ios-v1.0.18`, which fires the Codemagic build → TestFlight. Includes iOS changes since 1.0.17 (BET-1203, BET-1153, BET-1105, BET-1140, BET-1138, BET-1125, ...).