### PR TITLE
fix(server): classify reasoning deltas by part type, not field (BET-1209)

### DIFF
--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -81,6 +81,7 @@ function newSessionState() {
   return {
     parts: new Map(),          // partID -> { messageID, field, text } (delta buffers)
     finalParts: new Set(),     // partIDs that got a message.part.updated snapshot
+    partTypes: new Map(),      // partID -> part type ("text"|"reasoning"|...) from message.part.updated (BET-1209)
     tools: new Map(),          // toolIdx(partID) -> { idx, name, status, sent, truncated, ended }
     childSessionIds: new Set(),
     liveChildStatus: new Map(),
@@ -282,15 +283,23 @@ export function createStreamInterpreter({
         // ever emitted and a streaming answer reached the phone as silence.
         const part = evt.properties?.part;
         const messageID = evt.properties?.messageID ?? part?.messageID;
+        const partID = evt.properties?.partID ?? part?.id;
+        // opencode never sets `field` to "reasoning": its ReasoningPart carries
+        // its content in a property literally named `text`, so a reasoning
+        // delta arrives byte-identical to a prose delta. The only reliable
+        // discriminator is the part's `type`, recorded from the
+        // `message.part.updated` snapshot that opencode emits BEFORE it starts
+        // streaming into the part (BET-1209). Fall back to the field/type when
+        // no snapshot was seen (classified "text", today's behaviour).
         const rawField = evt.properties?.field ?? part?.type;
-        const field = rawField === "reasoning" ? "reasoning" : "text";
+        const known = partID != null ? st.partTypes.get(partID) : null;
+        const field = known === "reasoning" || rawField === "reasoning" ? "reasoning" : "text";
         const chunk =
           typeof evt.properties?.delta === "string"
             ? evt.properties.delta
             : typeof part?.text === "string"
               ? part.text
               : "";
-        const partID = evt.properties?.partID ?? part?.id;
         if (!messageID || !partID || !chunk) return;
         const cur = st.parts.get(partID) ?? { messageID, field, text: "", firstAt: now() };
         if (cur.firstAt == null) cur.firstAt = now();
@@ -319,22 +328,32 @@ export function createStreamInterpreter({
         // subagent (task tool) + finalize part snapshot
         const part = evt.properties?.part;
         const partID = part?.id;
+        // Record the part's type BEFORE the flush-and-finalize block below, so
+        // a reasoning part that finalizes is withheld correctly (BET-1209).
+        // opencode creates the part via `message.part.updated` (type known)
+        // before streaming deltas into it, so this entry is present before the
+        // first `message.part.delta` ever lands.
+        if (partID != null && part?.type != null) st.partTypes.set(partID, part.type);
         if (partID && st.parts.has(partID)) {
           // Flush whatever is still buffered before dropping the part. A
           // boundary only fires at a paragraph break or a closed code fence,
           // so a short answer ends its whole life inside the buffer — without
-          // this it was streamed as nothing at all.
-          const pending = st.parts.get(partID);
-          if (pending?.text) {
-            emit(sid, "flush", {
-              messageID: pending.messageID,
-              partID,
-              field: pending.field,
-              text: pending.text,
-            });
+          // this it was streamed as nothing at all. A REASONING part is the
+          // one exception: its tail must NOT reach the device as prose, so it
+          // is dropped un-flushed (BET-1209).
+          if (st.partTypes.get(partID) !== "reasoning") {
+            const pending = st.parts.get(partID);
+            if (pending?.text) {
+              emit(sid, "flush", {
+                messageID: pending.messageID,
+                partID,
+                field: pending.field,
+                text: pending.text,
+              });
+            }
           }
           st.finalParts.add(partID);
-          st.parts.delete(partID);
+          if (st.parts.delete(partID)) st.partTypes.delete(partID);
         }
         const info = extractSubagentInfo(part);
         if (info) {

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -630,6 +630,93 @@ test("message.part.updated flushes the buffered tail of a short answer", () => {
   assert.equal(flushes[0].payload.text, "Hello");
 });
 
+// BET-1209: a reasoning part's content streams in a field literally named
+// `text`, byte-identical to a prose delta. The interpreter must classify it as
+// `reasoning` from the part's `type` snapshot so a thin client (iOS) can keep
+// it out of the conversation. opencode emits `message.part.updated` (type
+// known) BEFORE it starts streaming the deltas.
+test("reasoning deltas stream as reasoning, never as text (BET-1209)", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: { sessionID: SID, part: { id: "p1", type: "reasoning" } },
+  });
+  interp.interpret({
+    type: "message.part.delta",
+    properties: { sessionID: SID, messageID: "msg1", partID: "p1", field: "text", delta: "Let me think step by step.\n\n" },
+  });
+  const flushes = events.filter((e) => e.sub === "flush");
+  assert.equal(flushes.length, 1, "the reasoning delta flushed at the boundary");
+  assert.ok(
+    flushes.every((f) => f.payload.field !== "text"),
+    "no reasoning content leaks to the device as ordinary prose",
+  );
+  assert.equal(flushes[0].payload.field, "reasoning");
+});
+
+test("text deltas still flush as text (BET-1209)", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: { sessionID: SID, part: { id: "p1", type: "text" } },
+  });
+  interp.interpret({
+    type: "message.part.delta",
+    properties: { sessionID: SID, messageID: "msg1", partID: "p1", field: "text", delta: "Regular prose.\n\n" },
+  });
+  const flushes = events.filter((e) => e.sub === "flush");
+  assert.equal(flushes.length, 1);
+  assert.equal(flushes[0].payload.field, "text");
+});
+
+test("a delta whose part id was never announced is classified text (BET-1209)", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "message.part.delta",
+    properties: { sessionID: SID, messageID: "msg1", partID: "ghost", field: "text", delta: "Unknown part prose.\n\n" },
+  });
+  const flushes = events.filter((e) => e.sub === "flush");
+  assert.equal(flushes.length, 1);
+  assert.equal(flushes[0].payload.field, "text");
+});
+
+test("a reasoning part that finalizes with buffered text emits no flush (BET-1209)", () => {
+  const { interp, events } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: { sessionID: SID, part: { id: "p1", type: "reasoning" } },
+  });
+  interp.interpret({
+    type: "message.part.delta",
+    properties: { sessionID: SID, messageID: "msg1", partID: "p1", field: "text", delta: "end of thinking, no boundary" },
+  });
+  assert.equal(events.length, 0, "no boundary yet -> nothing flushed");
+  interp.interpret({
+    type: "message.part.updated",
+    properties: { sessionID: SID, part: { id: "p1", type: "reasoning", text: "end of thinking, no boundary" } },
+  });
+  const flushes = events.filter((e) => e.sub === "flush");
+  assert.equal(flushes.length, 0, "the reasoning tail is dropped, never flushed as prose");
+});
+
+test("partTypes does not retain entries for finalized parts (BET-1209)", () => {
+  const { interp } = make();
+  interp.interpret({
+    type: "message.part.updated",
+    properties: { sessionID: SID, part: { id: "p1", type: "reasoning" } },
+  });
+  interp.interpret({
+    type: "message.part.delta",
+    properties: { sessionID: SID, messageID: "msg1", partID: "p1", field: "text", delta: "x" },
+  });
+  interp.interpret({
+    type: "message.part.updated",
+    properties: { sessionID: SID, part: { id: "p1", type: "reasoning", text: "x" } },
+  });
+  const st = interp.getState(SID);
+  assert.equal(st.partTypes.has("p1"), false, "finalized part released from partTypes");
+});
+
 test("message.updated records the message from properties.info (no wrapper)", () => {
   const { interp, events } = make();
   interp.interpret({


### PR DESCRIPTION
## What
Fixes BET-1209: a reasoning model's thinking streamed to the phone as ordinary assistant prose (visible during streaming, vanished when the turn settled).

### Root cause
`message.part.delta` classified the field from `evt.properties.field ?? part.type`, but opencode never sets field to `"reasoning"` — its ReasoningPart carries content in a field literally named `text`. iOS was already correct on both its own paths (filters `field=="reasoning"` from the live tail, skips `type=="reasoning"` parts in the canonical transcript), so once the canonical transcript replaced the live tail the thinking vanished.

### Fix (box-side only, no Swift changes)
The only reliable discriminator is the part's `type`, which opencode emits on `message.part.updated` **before** it starts streaming deltas into the part:
- Track `partTypes` (partID → type) per session, recorded on `message.part.updated`.
- Classify deltas: `known === "reasoning" || rawField === "reasoning" ? "reasoning" : "text"` (partTypes authoritative, rawField kept as a forward-compat fallback).
- Do **not** flush a reasoning part's buffered tail on finalize (it must never reach the device as prose).
- Release `partTypes` entries on the same cleanups as `parts`/`finalParts` so it can't grow unbounded.
- Unknown part type → `"text"` (unchanged behaviour); no "show thinking" toggle added.
- No iOS changes.

## Verification
- `npm run test:server`: exit 0, 2036/2036 pass (5 new BET-1209 tests included).
- `npm run typecheck`: exit 0, no errors.
- `npm test` (full suite): 2548/2548 pass.
- User-visible effect only reaches a phone once the box is updated to this build.

**Base: origin/main @ 63b6ab81**
