### PR TITLE
BET-1213: feat(ios): hide background-job rows and show count on parent

### DIFF
--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -158,6 +158,24 @@ final class MantaAPIClient: Sendable {
         try await callRequired("tmux:list", args: [], as: [MantaProject].self)
     }
 
+    /// `delegate:list` — the box's background-delegation jobs (BET-1213).
+    /// No-arg returns ALL jobs, so a single fetch covers a `delegate` job and a
+    /// `task` subagent the job store adopted. The engine returns a bare
+    /// `DelegateJob[]`; a no-engine fallback returns `{jobs: []}`, which we
+    /// normalize (mirrors desktop httpApi.delegateList). A box that predates
+    /// delegation answers with an unknown-channel error — that THROWS, and the
+    /// caller decides whether it is fatal (it is not for the session list).
+    func delegateList() async throws -> [DelegateJob] {
+        let data = try await transport(channel: "delegate:list", args: [])
+        if let jobs = try? Self.decode(data, as: [DelegateJob].self) {
+            return jobs
+        }
+        if let envelope = try Self.decode(data, as: DelegateJobsEnvelope.self) {
+            return envelope.jobs
+        }
+        return []
+    }
+
     /// `tmux:new-session` — create a new project (tmux session).
     func newSession(_ input: NewSessionInput) async throws -> [MantaProject] {
         let dict: [String: Any] = [
@@ -716,6 +734,12 @@ final class MantaAPIClient: Sendable {
 }
 
 private struct VoidResult: Decodable {}
+
+/// `delegate:list` can answer `{jobs: [...]}` on a no-engine fallback; the
+/// normalize path in `delegateList()` decodes that shape.
+private struct DelegateJobsEnvelope: Decodable {
+    let jobs: [DelegateJob]
+}
 
 /// The `opencode:fork-session` reply is `{ newSessionId, projects }`; only the
 /// new session id is consumed by callers (to navigate to the fork). The extra

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -8,9 +8,10 @@ import SwiftUI
 // Owns the live data behind the §7.1 list:
 //   - the grouped project/window list from `tmux:list` (refreshed on demand
 //     and on every healthy stream reconnect via `resyncHandler`);
-//   - per-row live status (running / attention / subagents / model) merged
-//     from the S1b event store (`sessionStates` keyed by the window's
-//     `opencodeSessionId`) plus attention tracking on the raw frame surface;
+//   - per-row live status (running / attention / background jobs / model)
+//     merged from the S1b event store (`sessionStates` keyed by the window's
+//     `opencodeSessionId`) plus the `delegate:list` jobs fetch and attention
+//     tracking on the raw frame surface;
 //   - pinned windows (`pinnedWindows`) and the haptics enable flag, both
 //     persisted through `config:update`;
 //   - §7.3 delete-with-undo: an idle delete is held 5 s, the RPC fires only
@@ -70,6 +71,12 @@ final class SessionListStore: ObservableObject {
     @Published private(set) var hapticsEnabled = true
     /// pinID -> pending delete being held within its 5 s undo window.
     @Published private(set) var pendingDeletes: [String: PendingDelete] = [:]
+    /// Background-delegation jobs keyed by the job's child opencode session id
+    /// (BET-1213). Decoration ONLY: fetched on the same cadence as `projects`
+    /// but tolerated — a box that predates delegation errors on `delegate:list`,
+    /// and that must leave the list fully visible with no counts (a missing job
+    /// list is missing decoration, never missing sessions).
+    @Published private(set) var delegateJobs: [String: DelegateJob] = [:]
 
     private let api: MantaAPIClient
     private let mutations: SessionListMutationAPI
@@ -84,6 +91,11 @@ final class SessionListStore: ObservableObject {
     /// (BET-791). Fed from `progress:get` on `progress.updated` frames + a
     /// backfill on refresh; drives the row subtitle via `rowStatus`.
     private var progressBySession: [String: String] = [:]
+    /// Parent opencodeSessionID → count of non-terminal jobs nested under it
+    /// (BET-1213). Drives the background-job subtitle via `rowStatus`.
+    private var backgroundJobsBySession: [String: Int] = [:]
+    /// Project tmuxSession → child window indices hidden because they're jobs.
+    private var hiddenByProject: [String: Set<Int>] = [:]
     /// A refresh asked for while one was already in flight. The request used to
     /// be DROPPED (`guard !loading else { return }`) and never rescheduled, so
     /// the foreground/reconnect refresh that raced the launch fetch simply
@@ -131,6 +143,16 @@ final class SessionListStore: ObservableObject {
             loadedOnce = true
             loadError = nil
             await refreshSessionMeta()
+            // The job list is decoration: if `delegate:list` fails (an older
+            // box errors on the unknown channel), every window stays visible
+            // and no count shows — never a blank list. On success adopt it; on
+            // failure keep whatever we had (stale jobs still resolve to real
+            // windows) and just re-derive nesting against the new projects.
+            if let jobs = try? await api.delegateList() {
+                applyJobs(jobs)
+            } else {
+                recomputeNesting()
+            }
         } catch {
             // Keep whatever was already on screen — a failed fetch must never
             // blank a list we successfully loaded before.
@@ -160,6 +182,46 @@ final class SessionListStore: ObservableObject {
         projects = list
         loadedOnce = true
         loadError = nil
+        recomputeNesting()
+    }
+
+    /// The windows that actually render for a project — its top-level rows with
+    /// background-job child windows filtered out (BET-1213).
+    func visibleWindows(in project: MantaProject) -> [MantaWindow] {
+        let hidden = hiddenByProject[project.tmuxSession] ?? []
+        return project.windows.filter { !hidden.contains($0.index) }
+    }
+
+    /// Adopt the fetched job list, keyed by childSessionID, and re-derive
+    /// nesting (hidden windows + per-parent counts) against the current
+    /// projects.
+    private func applyJobs(_ list: [DelegateJob]) {
+        var jobs: [String: DelegateJob] = [:]
+        for j in list {
+            if let child = j.childSessionID, !child.isEmpty { jobs[child] = j }
+        }
+        delegateJobs = jobs
+        recomputeNesting()
+    }
+
+    /// Re-run the pure nesting computation over the current projects+jobs and
+    /// publish the derived maps. Called whenever either input changes.
+    private func recomputeNesting() {
+        var hidden: [String: Set<Int>] = [:]
+        var counts: [String: Int] = [:]
+        let jobs = Array(delegateJobs.values)
+        for p in projects {
+            let nesting = SessionJobNesting.compute(project: p, jobs: jobs)
+            hidden[p.tmuxSession] = nesting.hidden
+            for (index, count) in nesting.activeChildCounts {
+                if let w = p.windows.first(where: { $0.index == index }),
+                   let sid = w.opencodeSessionId, !sid.isEmpty {
+                    counts[sid] = count
+                }
+            }
+        }
+        hiddenByProject = hidden
+        backgroundJobsBySession = counts
     }
 
     private func refreshSessionMeta() async {
@@ -194,11 +256,10 @@ final class SessionListStore: ObservableObject {
         let sid = window.opencodeSessionId ?? ""
         let stream = eventStore.sessionStates[sid]
         let running = stream?.running == true
-        let subagents = runningSubagents(stream?.subagents ?? [])
         return SessionRowStatus(
             running: running,
             attention: attentionSessions.contains(sid),
-            subagentsRunning: subagents,
+            backgroundJobs: backgroundJobsBySession[sid] ?? 0,
             modelLabel: sessionMeta[sid]?.modelLabel,
             progressLabel: progressBySession[sid],
             lastActivity: sessionMeta[sid]?.lastActivity,
@@ -206,20 +267,11 @@ final class SessionListStore: ObservableObject {
         )
     }
 
-    /// How many of a project's windows are mid-turn (drives the group header
-    /// chip).
+    /// How many of a project's visible windows are mid-turn (drives the group
+    /// header chip). Hidden background-job windows are excluded — a job is
+    /// represented by its parent's count, not by a running row of its own.
     func runningCount(in project: MantaProject) -> Int {
-        project.windows.filter { rowStatus(for: $0).running }.count
-    }
-
-    /// Number of live child subagents for a session (box-published).
-    private func runningSubagents(_ subagents: [StreamSubagentPayload]) -> Int {
-        let counted = subagents.filter { $0.status == "running" }.count
-        if counted > 0 { return counted }
-        if let last = subagents.last, let count = last.runningCount {
-            return Int(count)
-        }
-        return 0
+        visibleWindows(in: project).filter { rowStatus(for: $0).running }.count
     }
 
     // MARK: - Attention (needs-you dot / subtitle)
@@ -443,6 +495,9 @@ final class SessionListStore: ObservableObject {
         attentionSessions = []
         sessionMeta = [:]
         progressBySession = [:]
+        delegateJobs = [:]
+        backgroundJobsBySession = [:]
+        hiddenByProject = [:]
         pinnedWindows = []
         hapticsEnabled = true
     }

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -7,7 +7,7 @@ import UIKit
 //   §7.1   grouped list: project group headers (Title Case, 15px/600 tx2),
 //          rows = windows with [dot][name+subtitle][timer], min-height 62,
 //          radius 20, no dividers, most-recently-active row gets `fill`.
-//   §7.1a  subtitle table (subagents / running · model / needs you / absent).
+//   §7.1a  subtitle table (background jobs / running · model / needs you / absent).
 //   §7.2   tap opens; swipe-left delete (full-swipe commit); swipe-right pin;
 //          long-press context menu (Rename · Pin · Fork, sep, Delete).
 //   §7.3   idle delete → immediate + 5 s undo (RPC held); running → confirm
@@ -248,8 +248,13 @@ struct SessionListView: View {
     }
 
     private func rowEntries(_ project: MantaProject) -> [SessionRowEntry] {
-        let count = project.windows.count
-        return project.windows.enumerated().map { idx, window in
+        // BET-1213: a background job's child window gets no row of its own on
+        // mobile — it is hidden here and represented by the count on its
+        // parent row. Positions are computed over the VISIBLE windows so the
+        // first rendered row still rounds the card's top corner.
+        let visible = store.visibleWindows(in: project)
+        let count = visible.count
+        return visible.enumerated().map { idx, window in
             SessionRowEntry(project: project.tmuxSession, window: window,
                             position: .at(index: idx, count: count))
         }
@@ -285,6 +290,9 @@ struct SessionListView: View {
     @ViewBuilder
     private func groupHeader(_ project: MantaProject) -> some View {
         let running = store.runningCount(in: project)
+        // The total chip counts VISIBLE windows: hidden background-job rows are
+        // no longer counted, matching the running chip (BET-1213).
+        let visibleCount = store.visibleWindows(in: project).count
         HStack(spacing: Metrics.spacing.sp2) {
             Text(titleCased(project.tmuxSession))
                 .font(.manta(size: Metrics.type.body, weight: .semibold))
@@ -294,7 +302,7 @@ struct SessionListView: View {
             if running > 0 {
                 chip("\(running) running", fg: tokens.accentTx, bg: tokens.accentSoft)
             }
-            chip("\(project.windows.count)", fg: tokens.tx4, bg: tokens.fill)
+            chip("\(visibleCount)", fg: tokens.tx4, bg: tokens.fill)
         }
         .padding(.top, Metrics.type.listGroupAbove)
         .padding(.bottom, Metrics.type.listGroupBelow)

--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -59,6 +59,67 @@ struct MantaWorktree: Codable, Equatable, Sendable {
     var detached: Bool
 }
 
+// MARK: - Background jobs (BET-1213)
+
+/// A background-delegation job record, mirrored from the box's `delegate:list`
+/// channel. One fetch covers BOTH kinds the box's job store adopts: a `delegate`
+/// job, and a `task` subagent launched with `background: true`
+/// (src/server/delegate.mjs). `parentSessionID` is the session that started the
+/// job; `childSessionID` is the job's own opencode session (null until created).
+/// Unknown fields are ignored by Codable.
+struct DelegateJob: Codable, Equatable, Sendable {
+    var id: String
+    var parentSessionID: String?
+    var childSessionID: String?
+    var status: String
+
+    /// Whether the job is still live. `done`/`failed`/`stopped` are terminal;
+    /// anything else (a running job, or a status a newer box added) counts as
+    /// active so the count never under-reports a live job.
+    var isActive: Bool {
+        status != "done" && status != "failed" && status != "stopped"
+    }
+}
+
+/// Result of nesting a project's windows against its jobs (BET-1213).
+struct DelegateNesting: Equatable, Sendable {
+    /// Child window indices to REMOVE from the project's top-level rows.
+    var hidden: Set<Int>
+    /// Parent window index -> count of non-terminal jobs nested under it.
+    var activeChildCounts: [Int: Int]
+}
+
+/// Pure port of the desktop `computeJobNesting` (src/renderer/chatUtils.ts).
+/// For each job whose child window AND parent window both exist in the project,
+/// the child window is hidden — on mobile it renders as NO row of its own; the
+/// parent row carries the background-job count instead (no nested row, no
+/// disclosure). A job whose parent window is gone leaves the child VISIBLE at
+/// top level (never orphan a reachable session). A job whose child window is
+/// absent is ignored.
+enum SessionJobNesting {
+    static func compute(project: MantaProject, jobs: [DelegateJob]) -> DelegateNesting {
+        var hidden = Set<Int>()
+        var counts: [Int: Int] = [:]
+        var byOpencodeId: [String: MantaWindow] = [:]
+        for w in project.windows {
+            if let sid = w.opencodeSessionId, !sid.isEmpty {
+                byOpencodeId[sid] = w
+            }
+        }
+        for job in jobs {
+            guard let child = job.childSessionID, !child.isEmpty,
+                  let childWin = byOpencodeId[child] else { continue }
+            guard let parent = job.parentSessionID, !parent.isEmpty,
+                  let parentWin = byOpencodeId[parent] else { continue }
+            hidden.insert(childWin.index)
+            if job.isActive {
+                counts[parentWin.index, default: 0] += 1
+            }
+        }
+        return DelegateNesting(hidden: hidden, activeChildCounts: counts)
+    }
+}
+
 /// The durable, session-scoped "where is this turn right now" record (BET-790,
 /// mirroring src/server/progress.mjs). One record per session; `step` is
 /// monotonic and clamped server-side. The list surface reads only the model's
@@ -110,7 +171,10 @@ struct KillWindowInput: Sendable {
 struct SessionRowStatus: Equatable, Sendable {
     var running: Bool
     var attention: Bool
-    var subagentsRunning: Int
+    /// Number of non-terminal background jobs nested under this window
+    /// (BET-1213). Missing delegation (an older box) is just 0 — a missing job
+    /// list is missing decoration, never a missing session.
+    var backgroundJobs: Int
     var modelLabel: String?
     /// BET-791: the model-authored progress label for a working turn (e.g.
     /// "Running integration tests"). Absent when the turn has no record, or
@@ -124,17 +188,19 @@ struct SessionRowStatus: Equatable, Sendable {
 }
 
 enum SessionRowSubtitle {
-    /// §7.1a subtitle table — precedence: subagents, then the working progress
-    /// label, then running, then blocked, then (idle) model. The
-    /// subagent case REPLACES the line. A model-authored progress label
-    /// (BET-791) is more informative than a bare "running" / "running · model",
-    /// so it replaces both when a working turn names its step. The first four
-    /// branches are unchanged from the original table; only the idle tail is
-    /// new (BET-897): a terminal row says "terminal", otherwise the idle line
-    /// is the model label alone; recency lives in the age chip (BET-1084).
+    /// §7.1a subtitle table — precedence: background jobs, then the working
+    /// progress label, then running, then blocked, then (idle) model. The
+    /// background-job case REPLACES the line (the count is the number of
+    /// non-terminal jobs nested under the window). A model-authored progress
+    /// label (BET-791) is more informative than a bare "running" /
+    /// "running · model", so it replaces both when a working turn names its
+    /// step. The first four branches are unchanged from the original table;
+    /// only the idle tail is new (BET-897): a terminal row says "terminal",
+    /// otherwise the idle line is the model label alone; recency lives in the
+    /// age chip (BET-1084).
     static func text(for s: SessionRowStatus) -> String? {
-        if s.subagentsRunning > 0 {
-            return "\(s.subagentsRunning) subagent" + (s.subagentsRunning == 1 ? "" : "s")
+        if s.backgroundJobs > 0 {
+            return "\(s.backgroundJobs) background job" + (s.backgroundJobs == 1 ? "" : "s")
         }
         if s.running {
             if let label = s.progressLabel, !label.isEmpty {

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -8,66 +8,130 @@ final class SessionModelsTests: XCTestCase {
 
     // MARK: - §7.1a subtitle table
 
-    func testSubtitleSubagentsReplacesRunningAndModel() {
-        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 3, modelLabel: "opus 4.8")
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "3 subagents")
+    func testSubtitleBackgroundJobsReplaceRunningAndModel() {
+        let s = SessionRowStatus(running: true, attention: false, backgroundJobs: 3, modelLabel: "opus 4.8")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s), "3 background jobs")
     }
 
-    func testSubtitleSubagentsSingular() {
-        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 1, modelLabel: nil)
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "1 subagent")
+    func testSubtitleBackgroundJobsSingular() {
+        let s = SessionRowStatus(running: true, attention: false, backgroundJobs: 1, modelLabel: nil)
+        XCTAssertEqual(SessionRowSubtitle.text(for: s), "1 background job")
     }
 
     func testSubtitleRunningShowsModel() {
-        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: "opus 4.8")
+        let s = SessionRowStatus(running: true, attention: false, backgroundJobs: 0, modelLabel: "opus 4.8")
         XCTAssertEqual(SessionRowSubtitle.text(for: s), "running · opus 4.8")
     }
 
     func testSubtitleRunningWithoutModelFallsBackToRunning() {
-        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: nil)
+        let s = SessionRowStatus(running: true, attention: false, backgroundJobs: 0, modelLabel: nil)
         XCTAssertEqual(SessionRowSubtitle.text(for: s), "running")
     }
 
     func testSubtitleNeedsYouWhenBlocked() {
-        let s = SessionRowStatus(running: false, attention: true, subagentsRunning: 0, modelLabel: nil)
+        let s = SessionRowStatus(running: false, attention: true, backgroundJobs: 0, modelLabel: nil)
         XCTAssertEqual(SessionRowSubtitle.text(for: s), "needs you")
     }
 
     // MARK: - §7.1a progress label (BET-791)
 
     func testSubtitleWorkingProgressLabelReplacesRunningAndModel() {
-        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: "opus 4.8", progressLabel: "Running integration tests")
+        let s = SessionRowStatus(running: true, attention: false, backgroundJobs: 0, modelLabel: "opus 4.8", progressLabel: "Running integration tests")
         XCTAssertEqual(SessionRowSubtitle.text(for: s), "Running integration tests")
     }
 
     func testSubtitleWorkingProgressLabelEmptyFallsBackToRunning() {
-        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: nil, progressLabel: "")
+        let s = SessionRowStatus(running: true, attention: false, backgroundJobs: 0, modelLabel: nil, progressLabel: "")
         XCTAssertEqual(SessionRowSubtitle.text(for: s), "running")
     }
 
-    func testSubtitleProgressLabelStillLosesToSubagents() {
-        let s = SessionRowStatus(running: true, attention: false, subagentsRunning: 2, modelLabel: nil, progressLabel: "Running integration tests")
-        XCTAssertEqual(SessionRowSubtitle.text(for: s), "2 subagents")
+    func testSubtitleBackgroundJobsStillBeatProgressLabel() {
+        let s = SessionRowStatus(running: true, attention: false, backgroundJobs: 2, modelLabel: nil, progressLabel: "Running integration tests")
+        XCTAssertEqual(SessionRowSubtitle.text(for: s), "2 background jobs")
     }
 
     func testSubtitleIdleIsNil() {
-        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0, modelLabel: nil)
+        let s = SessionRowStatus(running: false, attention: false, backgroundJobs: 0, modelLabel: nil)
         XCTAssertNil(SessionRowSubtitle.text(for: s))
     }
 
-    // MARK: - §7.1 status dot
+    // MARK: - BET-1213 background-job nesting
 
+    private func win(_ index: Int, _ sid: String?) -> MantaWindow {
+        MantaWindow(index: index, name: "w\(index)", active: false, paneCurrentPath: "", opencodeSessionId: sid, worktreePath: nil)
+    }
+
+    private func job(_ id: String, parent: String?, child: String?, status: String = "running") -> DelegateJob {
+        DelegateJob(id: id, parentSessionID: parent, childSessionID: child, status: status)
+    }
+
+    private func proj(_ windows: [MantaWindow]) -> MantaProject {
+        MantaProject(tmuxSession: "proj", defaultCwd: "/tmp", windows: windows, attached: false, mantaOwned: nil)
+    }
+
+    func testNestingHidesChildUnderPresentParent() {
+        let p = proj([win(0, "ses_parent"), win(1, "ses_child")])
+        let nesting = SessionJobNesting.compute(project: p, jobs: [job("j1", parent: "ses_parent", child: "ses_child")])
+        XCTAssertEqual(nesting.hidden, [1])
+        XCTAssertEqual(nesting.activeChildCounts, [0: 1])
+    }
+
+    func testNestingChildStaysVisibleWhenParentWindowAbsent() {
+        // The child window exists but its parent session has no window in the
+        // project — the child must NOT be orphaned or hidden.
+        let p = proj([win(0, "ses_child")])
+        let nesting = SessionJobNesting.compute(project: p, jobs: [job("j1", parent: "ses_gone", child: "ses_child")])
+        XCTAssertTrue(nesting.hidden.isEmpty)
+        XCTAssertTrue(nesting.activeChildCounts.isEmpty)
+    }
+
+    func testNestingIgnoresJobWhoseChildWindowIsAbsent() {
+        let p = proj([win(0, "ses_parent")])
+        let nesting = SessionJobNesting.compute(project: p, jobs: [job("j1", parent: "ses_parent", child: "ses_no_window")])
+        XCTAssertTrue(nesting.hidden.isEmpty)
+        XCTAssertTrue(nesting.activeChildCounts.isEmpty)
+    }
+
+    func testNestingNoJobsIsANoop() {
+        let p = proj([win(0, "ses_a"), win(1, "ses_b")])
+        let nesting = SessionJobNesting.compute(project: p, jobs: [])
+        XCTAssertTrue(nesting.hidden.isEmpty)
+        XCTAssertTrue(nesting.activeChildCounts.isEmpty)
+    }
+
+    func testNestingCountsOnlyNonTerminalJobs() {
+        // Both children are hidden (any job whose child+parent windows exist),
+        // but only the RUNNING one counts toward the parent's background-job
+        // subtitle.
+        let p = proj([win(0, "ses_parent"), win(1, "ses_run"), win(2, "ses_done")])
+        let nesting = SessionJobNesting.compute(project: p, jobs: [
+            job("a", parent: "ses_parent", child: "ses_run", status: "running"),
+            job("b", parent: "ses_parent", child: "ses_done", status: "done"),
+        ])
+        XCTAssertEqual(nesting.hidden, [1, 2])
+        XCTAssertEqual(nesting.activeChildCounts, [0: 1])
+    }
+
+    func testNestingChildOfTerminalJobIsStillHidden() {
+        // Desktop hides a nested child window regardless of job status.
+        let p = proj([win(0, "ses_parent"), win(1, "ses_done")])
+        let nesting = SessionJobNesting.compute(project: p, jobs: [job("a", parent: "ses_parent", child: "ses_done", status: "done")])
+        XCTAssertEqual(nesting.hidden, [1])
+        XCTAssertTrue(nesting.activeChildCounts.isEmpty)
+    }
+
+    // MARK: - §7.1 status dot
     func testDotNeedsYouTakesPrecedenceOverRunning() {
-        let s = SessionRowStatus(running: true, attention: true, subagentsRunning: 0, modelLabel: nil)
+        let s = SessionRowStatus(running: true, attention: true, backgroundJobs: 0, modelLabel: nil)
         XCTAssertEqual(SessionDotState.forRow(s), .needsYou)
     }
 
     func testDotRunning() {
-        XCTAssertEqual(SessionDotState.forRow(SessionRowStatus(running: true, attention: false, subagentsRunning: 0, modelLabel: nil)), .running)
+        XCTAssertEqual(SessionDotState.forRow(SessionRowStatus(running: true, attention: false, backgroundJobs: 0, modelLabel: nil)), .running)
     }
 
     func testDotIdle() {
-        XCTAssertEqual(SessionDotState.forRow(SessionRowStatus(running: false, attention: false, subagentsRunning: 0, modelLabel: nil)), .idle)
+        XCTAssertEqual(SessionDotState.forRow(SessionRowStatus(running: false, attention: false, backgroundJobs: 0, modelLabel: nil)), .idle)
     }
 
     // MARK: - Timer / duration
@@ -117,19 +181,19 @@ final class SessionModelsTests: XCTestCase {
     func testSessionRowAgeGate() {
         let activity = now.addingTimeInterval(-3600)
         // Running rows show no age even with activity known (the dot is the signal).
-        let running = SessionRowStatus(running: true, attention: false, subagentsRunning: 0,
+        let running = SessionRowStatus(running: true, attention: false, backgroundJobs: 0,
                                        modelLabel: nil, lastActivity: activity)
         XCTAssertNil(SessionRowAge.text(for: running, now: now))
         // Attention rows likewise.
-        let attention = SessionRowStatus(running: false, attention: true, subagentsRunning: 0,
+        let attention = SessionRowStatus(running: false, attention: true, backgroundJobs: 0,
                                          modelLabel: nil, lastActivity: activity)
         XCTAssertNil(SessionRowAge.text(for: attention, now: now))
         // No known activity → no age.
-        let none = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+        let none = SessionRowStatus(running: false, attention: false, backgroundJobs: 0,
                                     modelLabel: nil, lastActivity: nil)
         XCTAssertNil(SessionRowAge.text(for: none, now: now))
         // A plain idle row with activity → the formatted age.
-        let idle = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+        let idle = SessionRowStatus(running: false, attention: false, backgroundJobs: 0,
                                     modelLabel: "opus 4.8", lastActivity: activity)
         XCTAssertEqual(SessionRowAge.text(for: idle, now: now), "1h")
     }
@@ -137,14 +201,14 @@ final class SessionModelsTests: XCTestCase {
     // MARK: - BET-897 idle subtitle (model only)
 
     func testIdleSubtitleModelOnly() {
-        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0, modelLabel: "opus 4.8")
+        let s = SessionRowStatus(running: false, attention: false, backgroundJobs: 0, modelLabel: "opus 4.8")
         XCTAssertEqual(SessionRowSubtitle.text(for: s), "opus 4.8")
     }
 
     func testIdleSubtitleRecencyOnlyBecomesNil() {
         // Recency now lives in the age chip, not the subtitle — a row with
         // activity but no model shows nothing here.
-        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+        let s = SessionRowStatus(running: false, attention: false, backgroundJobs: 0,
                                  modelLabel: nil, lastActivity: now.addingTimeInterval(-3600))
         XCTAssertNil(SessionRowSubtitle.text(for: s))
     }
@@ -152,39 +216,39 @@ final class SessionModelsTests: XCTestCase {
     func testIdleSubtitleModelOnlyIgnoresRecency() {
         // Model alone; recency is carried by the trailing age chip, so it no
         // longer appears here (used to read "opus 4.8 · 1h ago").
-        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+        let s = SessionRowStatus(running: false, attention: false, backgroundJobs: 0,
                                  modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600))
         XCTAssertEqual(SessionRowSubtitle.text(for: s), "opus 4.8")
     }
 
     func testIdleSubtitleNothingKnownIsNil() {
-        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+        let s = SessionRowStatus(running: false, attention: false, backgroundJobs: 0,
                                  modelLabel: nil, lastActivity: nil)
         XCTAssertNil(SessionRowSubtitle.text(for: s))
     }
 
     func testIdleSubtitleTerminalWinsOverModelAndRecency() {
-        let s = SessionRowStatus(running: false, attention: false, subagentsRunning: 0,
+        let s = SessionRowStatus(running: false, attention: false, backgroundJobs: 0,
                                  modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600),
                                  isTerminal: true)
         XCTAssertEqual(SessionRowSubtitle.text(for: s), "terminal")
     }
 
-    func testIdleSubtitleRunningAttentionSubagentPrecedenceUnchanged() {
-        // Subagents win over an idle model/recency line.
-        let subagents = SessionRowStatus(running: true, attention: false, subagentsRunning: 2,
-                                         modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600))
-        XCTAssertEqual(SessionRowSubtitle.text(for: subagents), "2 subagents")
+    func testIdleSubtitleRunningAttentionBackgroundJobPrecedenceUnchanged() {
+        // Background jobs win over an idle model/recency line.
+        let bg = SessionRowStatus(running: true, attention: false, backgroundJobs: 2,
+                                  modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600))
+        XCTAssertEqual(SessionRowSubtitle.text(for: bg), "2 background jobs")
         // Running wins over the idle tail.
-        let running = SessionRowStatus(running: true, attention: false, subagentsRunning: 0,
+        let running = SessionRowStatus(running: true, attention: false, backgroundJobs: 0,
                                        modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600))
         XCTAssertEqual(SessionRowSubtitle.text(for: running), "running · opus 4.8")
         // Attention wins over the idle tail even with a recency present.
-        let attention = SessionRowStatus(running: false, attention: true, subagentsRunning: 0,
+        let attention = SessionRowStatus(running: false, attention: true, backgroundJobs: 0,
                                          modelLabel: "opus 4.8", lastActivity: now.addingTimeInterval(-3600))
         XCTAssertEqual(SessionRowSubtitle.text(for: attention), "needs you")
         // A terminal row whose running flag is somehow true still reports running.
-        let terminalRunning = SessionRowStatus(running: true, attention: false, subagentsRunning: 0,
+        let terminalRunning = SessionRowStatus(running: true, attention: false, backgroundJobs: 0,
                                                modelLabel: nil, isTerminal: true)
         XCTAssertEqual(SessionRowSubtitle.text(for: terminalRunning), "running")
     }
@@ -519,5 +583,86 @@ final class SessionListMutationTests: XCTestCase {
     func testPinOrderOtherProjectPinDoesNotAffect() {
         let ws = windows(["a", "b"])
         XCTAssertEqual(names(SessionOrder.sorted(ws, project: "proj", pinned: [SessionPinID.window("other", index: 0)])), ["a", "b"])
+    }
+}
+
+// MARK: - BET-1213 delegate:list failure tolerance
+//
+// A box that predates delegation answers `delegate:list` with an unknown-
+// channel error. That must leave the project list fully working: every window
+// visible, no count, no error banner, no empty state. This drives the real
+// store seam through a stubbed URLSession (same pattern as
+// MantaEventStreamTests' StubTranscriptURLProtocol), with the jobs channel
+// returning the server's `{error: "unknown rpc channel: …"}` envelope while
+// `tmux:list` succeeds.
+
+@MainActor
+final class SessionListJobToleranceTests: XCTestCase {
+
+    private final class StubChannelURLProtocol: URLProtocol {
+        nonisolated(unsafe) static var responseBySubstring: [String: String] = [:]
+
+        override class func canInit(with request: URLRequest) -> Bool { true }
+        override class func canonicalRequest(for request: URLRequest) -> URLRequest { request }
+
+        override func startLoading() {
+            let urlString = request.url?.absoluteString ?? ""
+            var body = Self.responseBySubstring["default"] ?? #"{"result": null}"#
+            for (key, value) in Self.responseBySubstring where urlString.contains(key) {
+                body = value
+                break
+            }
+            let data = Data(body.utf8)
+            let response = HTTPURLResponse(
+                url: request.url!,
+                statusCode: 200,
+                httpVersion: nil,
+                headerFields: ["Content-Type": "application/json"]
+            )!
+            client?.urlProtocol(self, didReceive: response, cacheStoragePolicy: .notAllowed)
+            client?.urlProtocol(self, didLoad: data)
+            client?.urlProtocolDidFinishLoading(self)
+        }
+
+        override func stopLoading() {}
+    }
+
+    private let projectJSON = #"""
+    {"result":[{"tmuxSession":"proj","defaultCwd":"/tmp","windows":[
+      {"index":0,"name":"a","active":false,"paneCurrentPath":"","opencodeSessionId":"ses_a"},
+      {"index":1,"name":"b","active":false,"paneCurrentPath":"","opencodeSessionId":"ses_b"}
+    ],"attached":false}]}
+    """#
+
+    private func makeAPI() -> MantaAPIClient {
+        let config = URLSessionConfiguration.ephemeral
+        config.protocolClasses = [StubChannelURLProtocol.self]
+        return MantaAPIClient(
+            serverURL: URL(string: "https://box.example")!,
+            tokenProvider: { "tok" },
+            session: URLSession(configuration: config)
+        )
+    }
+
+    func testUnknownDelegateChannelLeavesProjectListIntact() async {
+        StubChannelURLProtocol.responseBySubstring = [
+            "default": #"{"error":"unknown rpc channel: delegate:list"}"#,
+            "tmux:list": projectJSON,
+        ]
+        let store = SessionListStore(api: makeAPI(), eventStore: MantaEventStore())
+
+        await store.refresh()
+
+        // The project list loaded fully despite the failing jobs fetch.
+        XCTAssertEqual(store.projects.count, 1)
+        let project = store.projects[0]
+        XCTAssertEqual(project.windows.count, 2)
+        // Every window stays visible — a missing job list hides nothing.
+        XCTAssertEqual(store.visibleWindows(in: project).map(\.index), [0, 1])
+        // And no window carries a background-job count.
+        for w in project.windows {
+            XCTAssertEqual(store.rowStatus(for: w).backgroundJobs, 0)
+        }
+        XCTAssertNil(store.loadError)
     }
 }


### PR DESCRIPTION
## feat(ios): hide background-job rows and show count on parent

A background job (started by `delegate`, or by `task` with `background: true`) was appearing in the native iOS session list as an ordinary sibling row — swipe-deletable and renameable with no marker that deleting it kills a running job, and counted toward the group header's running/total chips.

This ports the desktop's `computeJobNesting` to the session list:

- **`MantaAPIClient`** — new `delegate:list` channel (`delegateList()`), decoded into a `DelegateJob` struct (`id`, `parentSessionID`, `childSessionID`, `status`; unknown fields ignored). Normalizes both the engine's bare array and the no-engine `{jobs: []}` envelope.
- **`SessionListStore`** — fetches jobs on the same refresh cadence as projects, keyed by `childSessionID`, and derives (a) the set of child windows to hide per project and (b) the per-parent count of **non-terminal** nested jobs.
- **`SessionModels`** — pure `SessionJobNesting.compute` (ported from desktop `chatUtils.computeJobNesting`): a job whose child **and** parent windows both exist hides the child; a job whose parent window is gone leaves the child **visible** (never orphan a reachable session); a job whose child window is absent is ignored; a missing job list is a no-op. `SessionRowSubtitle` replaces the old `subagentsRunning` branch (removed) with a background-job branch in the same first-precedence slot: `"1 background job"` / `"N background jobs"`.
- **`SessionListView`** — filters hidden windows out of `rowEntries`; group-header running/total chips count only visible windows. No new row type, no disclosure/chevron, no drill-in; swipe/pin/order/search unchanged.

**Failure tolerance:** a box that predates delegation errors on `delegate:list` (unknown channel). That leaves the list fully working — every window visible, no count, no error banner, no empty state (missing decoration, never missing sessions). Covered by a store test driving the real seam against a stubbed URLSession that returns the server's `{error: "unknown rpc channel: ..."}` envelope for the jobs channel while `tmux:list` succeeds.

### Visual verification (simulator) — NOT completed

I could not obtain a screenshot of the session list with a live job in this environment:
- The app **builds and launches** on the iPhone 17 Pro simulator from this branch (`ios-mantaui` action `simulator` → `SIMULATOR: PASS`).
- The **pairing UI test failed deterministically** (rc=65, 1 failure, both attempts) and I could not get the app past onboarding to the session list, so I could not start a real background job or screenshot its row state.
- A screenshot was captured but this model has no image input, so I could not visually read it.

Reported plainly per the ticket; the behavior is covered by the pure unit tests below, and a QA visual check is handed to BET-1208.

### Verification results (iOS merge gate)

- **`ios-mantaui` action `test-unit`** on `multica/BET-1213-ios-bgjob-rows` @ `d1666430`: **TEST SUCCEEDED — Executed 577 tests, with 0 failures** (`MantaUITests`, both bundles compiled). Includes new tests: nesting (child hidden / orphan stays visible / absent child ignored / no-jobs no-op / non-terminal counting / terminal-child still hidden), subtitle precedence + singular/plural copy, and the unknown-channel store tolerance test.

**Base:** `origin/main` @ `4745da7c`.

No open follow-ups.
