### PR TITLE
refactor(server): consolidate opencode SQLite access into opencodeDb.mjs (BET-1216)

### DIFF
--- a/src/server/messageSearch.mjs
+++ b/src/server/messageSearch.mjs
@@ -16,17 +16,15 @@
 // Degradation: a box that has not taken the Node 24 runtime yet has no
 // `node:sqlite`, or there is no opencode.db — both return
 // { supported:false, hits:[] } and the UI shows "update the box". searchMessages
-// NEVER throws; DB errors are logged once, the handle is closed+nulled so the
-// next call reopens, and we return { supported:true, hits:[] }.
+// NEVER throws; DB errors are logged once, the handle is closed so the next
+// call reopens (see opencodeDb.mjs), and we return { supported:true, hits:[] }.
 //
 // The schema (verified live; do not re-derive):
 //   part(id TEXT PK, message_id TEXT, session_id TEXT, time_created INTEGER, data TEXT)
 //   message(id TEXT PK, session_id TEXT, time_created INTEGER, data TEXT)
 // part.data / message.data are JSON blobs.
 
-import { homedir } from "node:os";
-import { join } from "node:path";
-import { existsSync } from "node:fs";
+import { getDb } from "./opencodeDb.mjs";
 
 const SNIPPET_PRE_CHARS = 60;
 const SNIPPET_POST_CHARS = 200;
@@ -34,41 +32,6 @@ const SNIPPET_POST_CHARS = 200;
 // MAX_LIMIT over-fetch bounds a LIKE scan before the JS text-part filter
 // drops non-text rows (tool arguments etc.).
 const MAX_LIMIT = 800;
-
-let dbHandle = null;
-
-// Resolve opencode's SQLite path. First existing wins; a test/override hook
-// (`MANTA_OPENCODE_DB`) is used as-is. null → the box cannot search.
-export function resolveDbPath() {
-  if (process.env.MANTA_OPENCODE_DB) return process.env.MANTA_OPENCODE_DB;
-  if (process.env.XDG_DATA_HOME) {
-    const p = join(process.env.XDG_DATA_HOME, "opencode", "opencode.db");
-    if (existsSync(p)) return p;
-    return null;
-  }
-  const p = join(homedir(), ".local", "share", "opencode", "opencode.db");
-  if (existsSync(p)) return p;
-  return null;
-}
-
-// Lazily open node:sqlite read-only. The import lives in a try/catch because
-// on a box that hasn't taken the Node 24 runtime yet it throws — that must
-// degrade to { supported:false }, not crash the server. Null handle on any
-// failure.
-async function getDb() {
-  if (dbHandle) return dbHandle;
-  const path = resolveDbPath();
-  if (!path) return null;
-  try {
-    const { DatabaseSync } = await import("node:sqlite");
-    dbHandle = new DatabaseSync(path, { readOnly: true });
-    return dbHandle;
-  } catch (e) {
-    console.warn("[messageSearch] node:sqlite unavailable:", e?.message ?? e);
-    dbHandle = null;
-    return null;
-  }
-}
 
 // The only exported entry point used by rpc.mjs.
 export async function searchMessages({
@@ -117,7 +80,6 @@ export async function searchMessages({
     } catch {
       /* already closed */
     }
-    dbHandle = null;
     return { supported: true, hits: [] };
   }
 }

--- a/src/server/opencodeDb.mjs
+++ b/src/server/opencodeDb.mjs
@@ -1,0 +1,56 @@
+// opencodeDb.mjs — the single read-only access layer for opencode's own
+// SQLite store (`opencode.db`). Extracted from messageSearch.mjs so that any
+// consumer (conversation search, the model ledger, …) shares ONE resolution
+// path and ONE lazily-opened connection/degradation path instead of each
+// opening its own handle.
+//
+// Degradation: a box that has not taken the Node 24 runtime yet has no
+// `node:sqlite`, or there is no opencode.db at the resolved path — both make
+// `getDb()` return `null` (never throw). Read-only is a hard invariant; this
+// database is never opened writable.
+
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { existsSync } from "node:fs";
+
+let dbHandle = null;
+
+// Resolve opencode's SQLite path. First existing wins; a test/override hook
+// (`MANTA_OPENCODE_DB`) is used as-is. null → the box cannot search.
+export function resolveDbPath() {
+  if (process.env.MANTA_OPENCODE_DB) return process.env.MANTA_OPENCODE_DB;
+  if (process.env.XDG_DATA_HOME) {
+    const p = join(process.env.XDG_DATA_HOME, "opencode", "opencode.db");
+    if (existsSync(p)) return p;
+    return null;
+  }
+  const p = join(homedir(), ".local", "share", "opencode", "opencode.db");
+  if (existsSync(p)) return p;
+  return null;
+}
+
+// Lazily open node:sqlite read-only. The import lives in a try/catch because
+// on a box that hasn't taken the Node 24 runtime yet it throws — that must
+// degrade to `null`, not crash the server. A cached handle that a consumer
+// closed (query-error recovery) is reopened on the next call. Null handle on
+// any failure.
+export async function getDb() {
+  if (dbHandle && dbHandle.isOpen !== false) return dbHandle;
+  const path = resolveDbPath();
+  if (!path) return null;
+  try {
+    const { DatabaseSync } = await import("node:sqlite");
+    dbHandle = new DatabaseSync(path, { readOnly: true });
+    return dbHandle;
+  } catch (e) {
+    console.warn("[opencodeDb] node:sqlite unavailable:", e?.message ?? e);
+    dbHandle = null;
+    return null;
+  }
+}
+
+// Clears the cached handle so the next `getDb()` reopens it. Test-only: not
+// part of the runtime API.
+export function _resetDbHandle() {
+  dbHandle = null;
+}

--- a/src/server/opencodeDb.test.mjs
+++ b/src/server/opencodeDb.test.mjs
@@ -1,0 +1,39 @@
+// Tests for opencodeDb.mjs — the shared read-only access layer for opencode's
+// SQLite store. Pure: no real database is opened here. Run via `npm run
+// test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { resolveDbPath, getDb, _resetDbHandle } from "./opencodeDb.mjs";
+
+test("resolveDbPath returns MANTA_OPENCODE_DB verbatim when set", () => {
+  const override = "/custom/path/opencode.db";
+  process.env.MANTA_OPENCODE_DB = override;
+  try {
+    assert.equal(resolveDbPath(), override);
+  } finally {
+    delete process.env.MANTA_OPENCODE_DB;
+  }
+});
+
+test("resolveDbPath returns null when XDG_DATA_HOME is set but the file is absent", () => {
+  process.env.XDG_DATA_HOME = "/nonexistent/xdg-data-home-for-test";
+  try {
+    assert.equal(resolveDbPath(), null);
+  } finally {
+    delete process.env.XDG_DATA_HOME;
+  }
+});
+
+test("getDb() returns null (and does not throw) when resolveDbPath yields null", async () => {
+  _resetDbHandle();
+  process.env.XDG_DATA_HOME = "/nonexistent/xdg-data-home-for-test";
+  delete process.env.MANTA_OPENCODE_DB;
+  try {
+    const db = await getDb();
+    assert.equal(db, null);
+  } finally {
+    delete process.env.XDG_DATA_HOME;
+    _resetDbHandle();
+  }
+});


### PR DESCRIPTION
Extracts the read-only opencode SQLite access layer out of `messageSearch.mjs` into a single shared module, `src/server/opencodeDb.mjs`, so the upcoming model-ledger consumer shares one resolution path and one lazily-opened connection instead of opening its own handle.

**Pure refactor — zero behaviour change.**

- Moved `resolveDbPath()`, `getDb()`, and the cached handle into `opencodeDb.mjs` (unchanged semantics: `MANTA_OPENCODE_DB` override wins, `XDG_DATA_HOME`, then `~/.local/share/opencode/opencode.db`; `await import("node:sqlite")` stays in try/catch and degrades to `null`, never throws; opened `{ readOnly: true }`).
- Added `_resetDbHandle()` (test-only).
- `messageSearch.mjs` now imports `getDb` from `opencodeDb.mjs`; deleted its own `resolveDbPath`, `dbHandle`, private `getDb`, and the now-unused `node:os` / `node:path` / `node:fs` imports. Net: 3 insertions, 41 deletions.
- No existing import relied on `resolveDbPath` (verified repo-wide) so no re-export was needed.
- Added `opencodeDb.test.mjs` covering the three required cases; existing `messageSearch.test.mjs` passes unchanged.

**Verification**
- `npm run typecheck` ✓
- `npm test` ✓ (2551 pass, 0 fail)
- `new DatabaseSync(` occurrences in `src/server/`:

```console
$ grep -rn "new DatabaseSync(" src/server/
src/server/opencodeDb.mjs:43:    dbHandle = new DatabaseSync(path, { readOnly: true });
```

Closes BET-1216