### PR TITLE
chore(agents): manta-probe live-box tool + manta-live-session skill, and correct the stale transcript-crash note

### DIFF
--- a/.multica/skills/manta-live-session/SKILL.md
+++ b/.multica/skills/manta-live-session/SKILL.md
@@ -1,0 +1,189 @@
+---
+name: manta-live-session
+description: Talk to a real manta box from an agent session — create a chat session, send a prompt, read the reply, and mint a pairing code for a phone or Simulator. Use whenever a task needs live box data rather than a unit test. Always runs on voska/default.
+---
+
+# Live box access — `manta-probe`
+
+## What this is for
+
+Some work cannot be verified by a unit test: a screen that only renders with a
+real transcript, a card that only appears when a real turn blocks, a Simulator
+that has to be paired to a real box. Before this skill existed, agents wrote
+their own `curl` calls against the box and quietly got them wrong — the RPC body
+shape, the auth header, the fact that the prompt endpoint is **asynchronous**,
+and the fact that the pairing endpoint is **loopback-only** are each easy to miss,
+and a half-working request looks exactly like a broken feature.
+
+**`manta-probe` is the one supported way in.** Do not hand-roll `curl` against
+the box; if this tool cannot do what you need, say so on the issue rather than
+improvising.
+
+## The one rule you cannot break
+
+**Every prompt runs on `voska/default`.** There is no flag, no argument and no
+environment variable to change it — the model is a constant inside the tool. The
+other providers on this box are metered and are not yours to spend. If you find
+yourself wanting a different model, you are doing something this skill is not
+for.
+
+## Where it runs
+
+The box is the Linux machine **`alphaclaw`** — the same machine the Linux agents
+already run on.
+
+| You are | Command form |
+|---|---|
+| a Linux agent (`manta-dev`, and anything on the box) | `~/.local/bin/manta-probe <cmd>` |
+| the **macos** agent | `ssh dev@alphaclaw '~/.local/bin/manta-probe <cmd>'` |
+
+**Always use the absolute path `~/.local/bin/manta-probe`, never the bare name.**
+A non-interactive SSH shell has a minimal `PATH` that does **not** include
+`~/.local/bin`, so a bare `manta-probe` fails with "command not found" over SSH.
+This is verified, not theoretical — use the absolute form everywhere and the same
+line works from both machines.
+
+## Commands
+
+```bash
+# The one-shot most tasks want: fresh session, prompt, wait, print the reply.
+~/.local/bin/manta-probe ask "Reply with exactly one word: PONG"
+
+# Keep the session afterwards (to inspect it in the app, or prompt it again).
+~/.local/bin/manta-probe ask "Read AGENTS.md and summarise section 6" --keep
+
+# Long-form: drive a session across several turns.
+SID=$(~/.local/bin/manta-probe new my-label)
+~/.local/bin/manta-probe prompt "$SID" "first turn"
+~/.local/bin/manta-probe prompt "$SID" "second turn"
+~/.local/bin/manta-probe messages "$SID"     # dump the transcript
+
+# Pair an iOS Simulator in one step — the app auto-claims this link, no typing.
+~/.local/bin/manta-probe pair-url            # manta://pair?box=…&code=…
+~/.local/bin/manta-probe pair-url --simctl   # the full xcrun simctl command
+~/.local/bin/manta-probe pair                # raw code + URL (physical phone)
+~/.local/bin/manta-probe server              # just the server URL
+
+# Housekeeping — always finish with this.
+~/.local/bin/manta-probe list
+~/.local/bin/manta-probe clean
+```
+
+`ask` prints **the reply on stdout** and progress/diagnostics on stderr, so
+`REPLY=$(~/.local/bin/manta-probe ask "…" 2>/dev/null)` captures just the answer.
+
+## Pairing a Simulator — one command, no typing
+
+**Do not drive the pairing screen with XCUITest and do not type a code.** The app
+registers the `manta://` URL scheme and **auto-claims** a deep-linked payload —
+there is no "Continue" to tap. Opening the link on a booted Simulator pairs it
+outright.
+
+From the macos agent, the entire flow is two lines:
+
+```bash
+# 1. mint the link ON the box (pairing is loopback-only, so it must run there)
+LINK=$(ssh dev@alphaclaw '~/.local/bin/manta-probe pair-url' 2>/dev/null)
+
+# 2. open it on the booted Simulator
+xcrun simctl openurl booted "$LINK"
+```
+
+`pair-url --simctl` prints the whole `xcrun simctl openurl booted '…'` command
+ready to paste, if you prefer one copyable line.
+
+Facts that will otherwise waste your time:
+
+- **Codes expire in minutes.** Mint the link immediately before opening it, never
+  at the start of a long job. If pairing fails, mint a fresh one — do not reuse.
+- **`/auth/pair` is loopback-only, by design.** Against the public hostname it
+  answers `403`. That is why it is minted over SSH on the box. A 403 while
+  pairing means you called the public URL — the feature working, not a bug.
+- **The link carries no `server=` param, deliberately.** The app REFUSES a
+  non-private server URL, and this box is reached over its public gateway
+  hostname. With `box=` alone the app derives
+  `https://<boxId>.boxes.mantaui.com` itself, which is correct here. Adding
+  `server=` would make the payload be rejected outright.
+- **Already paired to another box?** The app treats a pairing link as a re-pair
+  and shows a "Switch box?" confirmation instead of silently switching — so on
+  an already-paired Simulator this needs one tap, or erase the Simulator first
+  (`manta-sim-drive action: reset`).
+
+`pair` (without `-url`) prints the raw 6-digit code and server URL. It is the
+**fallback for a physical phone**, where you cannot open a link from the host —
+type them into the pairing screen by hand.
+
+## How pairing is persisted (and why we do not write it directly)
+
+The claimed credentials live in the **iOS Keychain**
+(`KeychainCredentialStore`, a `kSecClassGenericPassword` item), not in a
+preferences file. There is no supported way to write another app's Keychain item
+from the host — `simctl keychain` only manages certificates — so "just write the
+token in" is not available, and any scheme that tried would be reaching into
+private app storage.
+
+The deep link is strictly better anyway: it exercises the **real** claim path
+(`/auth/claim`, device registration, the app's own error handling), so a
+successful pair proves the thing you actually care about works. Writing storage
+directly would bypass exactly the code most likely to be broken.
+
+## Cleaning up — not optional
+
+Every probe session is a real opencode session in a tmux project called
+`manta-probe`, kept apart from real work so it is trivially findable and
+trivially removable. `ask` deletes its session automatically unless you pass
+`--keep`.
+
+**Run `clean` when you finish.** Sessions you leave behind are live agent
+sessions on someone's machine: they show up in the app's sidebar, they hold
+context, and nobody else knows whether they matter.
+
+## Failure modes and what they actually mean
+
+| What you see | What it means |
+|---|---|
+| `cannot reach manta-server` | the server is down — `systemctl --user status manta-server` |
+| `unauthorized — the box token was rejected` | `~/.manta/auth.json` is stale or you are the wrong user; do **not** try to re-pair the box to fix this |
+| `command not found` over SSH | you used the bare name instead of `~/.local/bin/manta-probe` |
+| `403` from a pairing attempt | you called the public hostname; pairing is loopback-only |
+| `no completed reply within Ns` | the turn is still running — inspect with `messages <sid>`, do not retry blindly |
+
+Report a failure as a finding on the issue. **Never** substitute a plausible
+answer for one you could not obtain, and never claim you verified something live
+when the tool did not run.
+
+## Security — how the token is handled
+
+The box token lives in `~/.manta/auth.json` on `alphaclaw` and is read **inside**
+the tool. It is never printed, never logged, never placed in a command line, and
+never crosses to another machine. That is why the macos agent runs this over SSH
+instead of being handed a token: the value is substituted remotely and never
+enters the Mac's context.
+
+**Do not read, print or copy `~/.manta/auth.json` yourself.** If you think you
+need the raw token, you need a new subcommand on this tool instead — say so on
+the issue.
+
+## Installation
+
+The tool is versioned in this repo at **`scripts/manta-probe.cjs`** and is
+installed on `alphaclaw` at `~/.local/bin/manta-probe`. It is plain Node with no
+dependencies.
+
+If `~/.local/bin/manta-probe` is missing (a rebuilt box, a fresh machine),
+restore it from the repo rather than reconstructing it from memory:
+
+```bash
+install -D -m 755 scripts/manta-probe.cjs ~/.local/bin/manta-probe
+~/.local/bin/manta-probe server   # smoke test
+```
+
+The `.cjs` extension is load-bearing: this package is `"type": "module"`, so a
+`.mjs`/`.js` file here would be parsed as ESM and the script's `require` calls
+would fail with *"require is not defined in ES module scope"*. The installed
+copy is extensionless, which Node treats as CommonJS, so the same source runs
+in both places.
+
+It is **not** installed to `/usr/local/bin` because that needs sudo this box
+does not grant non-interactively — which is exactly why every invocation in this
+skill uses the absolute `~/.local/bin/manta-probe` path.

--- a/mobile/native/AGENTS.md
+++ b/mobile/native/AGENTS.md
@@ -222,14 +222,24 @@ deterministic and reproducible from the block alone, because a canonical
 refetch re-derives them (see `stableScrollID`/`uniqueTranscriptRows`).
 
 This area has been diagnosed and fixed **more than once** and has recurred
-each time. BET-1103, BET-1104 and BET-1105 have been rewriting exactly this:
-BET-1103 (stable identity for the `.steps` transcript block) **has merged**
-into `main`, while BET-1104 (replacing the hand-rolled transcript gestures
-with MessagingUI's own) and BET-1105 are **not merged** as of 2026-08-18.
-**Check which of these are on your base** (and whether they have merged/landed
-since) before touching row identity, row ordering, or the update path, and
-treat any new `TiledView`/batch-update crash as a likely regression of this
-family.
+each time. BET-1103, BET-1104 and BET-1105 rewrote exactly this, and **all
+three are now merged into `main`** (verified 2026-08-19):
+
+- **BET-1103** — stable identity for the `.steps` transcript block.
+- **BET-1104** — the hand-rolled transcript gestures are **gone**, replaced by
+  MessagingUI's own recognisers (`eda646e1`). The reveal is now horizontal-only
+  (`abs(x) > abs(y) && x < 0`) and runs *simultaneously* with the scroll pan, so
+  **it cannot swallow a vertical drag** — do not diagnose a scrolling fault as
+  the reveal gesture eating the pan. That mechanism no longer exists.
+- **BET-1105** — the list renders from a plain snapshot of the rows; the
+  hand-rolled `ListDataSource` and its append-only change log are gone, which
+  removed the mechanism behind the "invalid batch updates" crash.
+
+Row identity still matters, but the sharpest edge is gone. **Verify against the
+code on your base rather than trusting this paragraph** — an earlier version of
+it said BET-1104 was unmerged for a day after it landed, and that stale line
+sent an agent chasing a gesture that had already been deleted. Treat any new
+`TiledView`/batch-update crash as a likely regression of this family.
 
 ## 7. Networking and error handling
 

--- a/scripts/manta-probe.cjs
+++ b/scripts/manta-probe.cjs
@@ -1,0 +1,268 @@
+#!/usr/bin/env node
+// manta-probe — talk to the manta box on THIS machine (alphaclaw) from an agent
+// session: create a chat session, send a prompt, read the reply, mint a pairing
+// code for a phone/simulator.
+//
+// WHY THIS EXISTS
+// Implementer agents kept failing to verify anything live: the RPC body shape,
+// the auth header, the async prompt + poll loop and the loopback-only pairing
+// endpoint are each easy to get subtly wrong, and a half-working curl looks
+// exactly like a broken feature. This is the one supported way in.
+//
+// THE MODEL IS NOT A CHOICE. Every prompt runs on voska/default. There is no
+// flag to change it and no env var to override it — a constraint that is
+// enforced cannot be forgotten, and this box's other providers are metered.
+//
+// THE TOKEN NEVER LEAVES THE BOX. It is read from ~/.manta/auth.json inside
+// this process and used only as an Authorization header. It is never printed,
+// never logged, never placed in argv. Callers on other machines invoke this
+// over ssh so the value is substituted remotely:
+//     ssh dev@alphaclaw manta-probe ask "hello"
+
+"use strict";
+
+const fs = require("node:fs");
+const os = require("node:os");
+const path = require("node:path");
+
+const BOX = process.env.MANTA_PROBE_BOX || "http://127.0.0.1:8787";
+const MODEL = { providerID: "voska", modelID: "default" }; // deliberately const
+const AUTH = path.join(os.homedir(), ".manta", "auth.json");
+const SCRATCH = path.join(os.homedir(), ".manta-probe");
+const PROJECT = "manta-probe";
+
+function die(msg, code = 1) {
+  process.stderr.write(`manta-probe: ${msg}\n`);
+  process.exit(code);
+}
+
+function auth() {
+  let raw;
+  try {
+    raw = JSON.parse(fs.readFileSync(AUTH, "utf8"));
+  } catch (e) {
+    die(`cannot read ${AUTH} (${e.code || e.message}). Are you on the box, as the right user?`);
+  }
+  if (!raw.box_token) die(`${AUTH} has no box_token — this box is not paired/initialised.`);
+  return { token: raw.box_token, host: raw.gateway_host || null };
+}
+
+async function rpc(channel, args) {
+  const { token } = auth();
+  let res;
+  try {
+    res = await fetch(`${BOX}/rpc/${channel}`, {
+      method: "POST",
+      headers: { Authorization: `Bearer ${token}`, "Content-Type": "application/json" },
+      body: JSON.stringify({ args }),
+    });
+  } catch (e) {
+    die(`cannot reach manta-server at ${BOX} (${e.cause?.code || e.message}).\n` +
+        `  Check it is up:  systemctl --user status manta-server`);
+  }
+  if (res.status === 401) die("unauthorized — the box token was rejected. Is ~/.manta/auth.json current?");
+  const text = await res.text();
+  if (!res.ok) die(`${channel} failed: HTTP ${res.status} ${text.slice(0, 300)}`);
+  let body;
+  try {
+    body = JSON.parse(text);
+  } catch {
+    die(`${channel} returned non-JSON: ${text.slice(0, 200)}`);
+  }
+  if (body && body.error) die(`${channel} error: ${JSON.stringify(body.error).slice(0, 300)}`);
+  return body && "result" in body ? body.result : body;
+}
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+async function projects() {
+  return (await rpc("tmux:list", [])) || [];
+}
+
+// Every probe session is a window in ONE tmux project so they are trivially
+// findable and trivially cleaned up, and never pollute a real project.
+async function newSession(label) {
+  fs.mkdirSync(SCRATCH, { recursive: true });
+  const name = label || `probe-${new Date().toISOString().slice(11, 19).replace(/:/g, "")}`;
+  const existing = (await projects()).find((p) => p.tmuxSession === PROJECT);
+  const res = existing
+    ? await rpc("tmux:new-window", [
+        { sessionName: PROJECT, windowName: name, cwd: SCRATCH, chatMode: true },
+      ])
+    : await rpc("tmux:new-session", [
+        { name: PROJECT, windowName: name, cwd: SCRATCH, createDir: true, chatMode: true },
+      ]);
+  const sid = res && res.sessionId;
+  if (!sid) die(`session created but no opencode session id came back: ${JSON.stringify(res).slice(0, 200)}`);
+  return sid;
+}
+
+// The prompt endpoint is ASYNC: it returns null immediately and the answer
+// arrives on the transcript. Anything that "sends a prompt" must then poll.
+async function sendPrompt(sessionId, text) {
+  await rpc("opencode:prompt", [{ sessionId, text, model: MODEL }]);
+}
+
+async function readReply(sessionId, { timeoutMs = 180000, quiet = false } = {}) {
+  const started = Date.now();
+  let lastLen = -1;
+  while (Date.now() - started < timeoutMs) {
+    await sleep(2000);
+    const msgs = (await rpc("opencode:messages", [sessionId, {}])) || [];
+    const assistants = msgs.filter((m) => m.info && m.info.role === "assistant");
+    if (!assistants.length) continue;
+    const last = assistants[assistants.length - 1];
+    const text = (last.parts || [])
+      .filter((p) => p.type === "text" && !p.ignored && !p.synthetic)
+      .map((p) => p.text || "")
+      .join("")
+      .trim();
+    const done = Boolean(last.info.time && last.info.time.completed);
+    if (!quiet && text.length !== lastLen) {
+      process.stderr.write(`  … ${done ? "done" : "running"} (${text.length} chars)\n`);
+      lastLen = text.length;
+    }
+    if (done) return { text, model: `${last.info.providerID || "?"}/${last.info.modelID || "?"}` };
+  }
+  die(`no completed reply within ${Math.round(timeoutMs / 1000)}s — the turn may still be running. ` +
+      `Inspect with:  manta-probe messages ${sessionId}`);
+}
+
+async function main() {
+  const [cmd, ...rest] = process.argv.slice(2);
+
+  switch (cmd) {
+    // The one-shot most callers want: fresh session, prompt, wait, print reply.
+    case "ask": {
+      const text = rest.filter((a) => !a.startsWith("--")).join(" ");
+      if (!text) die('usage: manta-probe ask "your prompt"  [--keep]');
+      const keep = rest.includes("--keep");
+      const sid = await newSession();
+      process.stderr.write(`session ${sid}\n`);
+      await sendPrompt(sid, text);
+      const reply = await readReply(sid);
+      process.stdout.write(reply.text + "\n");
+      process.stderr.write(`model ${reply.model}\n`);
+      if (!keep) await rpc("tmux:kill-session", [PROJECT]).catch(() => {});
+      else process.stderr.write(`kept — clean up with:  manta-probe clean\n`);
+      return;
+    }
+
+    case "new": {
+      const sid = await newSession(rest[0]);
+      process.stdout.write(sid + "\n");
+      return;
+    }
+
+    case "prompt": {
+      const [sid, ...words] = rest;
+      const text = words.join(" ");
+      if (!sid || !text) die('usage: manta-probe prompt <sessionId> "your prompt"');
+      await sendPrompt(sid, text);
+      const reply = await readReply(sid);
+      process.stdout.write(reply.text + "\n");
+      return;
+    }
+
+    case "messages": {
+      const sid = rest[0];
+      if (!sid) die("usage: manta-probe messages <sessionId>");
+      const msgs = (await rpc("opencode:messages", [sid, {}])) || [];
+      for (const m of msgs) {
+        const role = m.info?.role || "?";
+        const body = (m.parts || [])
+          .map((p) => (p.type === "text" ? p.text : `[${p.type}${p.tool ? ":" + p.tool : ""}]`))
+          .join(" ")
+          .replace(/\s+/g, " ")
+          .trim();
+        process.stdout.write(`${role.padEnd(9)} ${body.slice(0, 300)}\n`);
+      }
+      return;
+    }
+
+    // Pair a phone or a Simulator. /auth/pair is loopback-only BY DESIGN, so
+    // this must run ON the box — over ssh from a Mac, never against the public
+    // hostname (which correctly answers 403).
+    case "pair": {
+      const { host } = auth();
+      const res = await fetch(`${BOX}/auth/pair`).catch((e) => die(`cannot reach ${BOX} (${e.message})`));
+      const body = await res.json().catch(() => die("pairing endpoint returned non-JSON"));
+      if (!body.pairing_code) die(`no pairing code in response: ${JSON.stringify(body).slice(0, 200)}`);
+      const url = host ? `https://${host}` : "(no gateway_host on this box)";
+      process.stdout.write(`code   ${body.pairing_code}\nserver ${url}\n`);
+      process.stderr.write("codes expire in minutes — use it immediately\n");
+      return;
+    }
+
+    // The ZERO-TYPING pairing path. The app registers the `manta://` scheme and
+    // auto-CLAIMS a deep-linked payload (MantaAppRoot.onOpenURL →
+    // MantaPairingRouter.route → flow.receive → startLinking) — there is no
+    // "Continue" to tap and no code to type. Opening this URL on a booted
+    // Simulator pairs it outright.
+    //
+    // NOTE the `server=` param is deliberately NOT emitted: the app REFUSES a
+    // non-private server URL (MantaPairing.isPrivateServerURL), and this box is
+    // reached over its public gateway hostname. With `box=` alone the app
+    // derives https://<boxId>.boxes.mantaui.com itself, which is what we want.
+    case "pair-url": {
+      const res = await fetch(`${BOX}/auth/pair`).catch((e) => die(`cannot reach ${BOX} (${e.message})`));
+      const body = await res.json().catch(() => die("pairing endpoint returned non-JSON"));
+      if (!body.pairing_code || !body.box_id) {
+        die(`unexpected pairing response: ${JSON.stringify(body).slice(0, 200)}`);
+      }
+      const url = `manta://pair?box=${body.box_id}&code=${body.pairing_code}`;
+      if (rest.includes("--simctl")) {
+        process.stdout.write(`xcrun simctl openurl booted '${url}'\n`);
+      } else {
+        process.stdout.write(url + "\n");
+      }
+      process.stderr.write("expires in minutes — open it now\n");
+      return;
+    }
+
+    case "server": {
+      const { host } = auth();
+      process.stdout.write((host ? `https://${host}` : "") + "\n");
+      return;
+    }
+
+    case "list": {
+      const p = (await projects()).find((x) => x.tmuxSession === PROJECT);
+      if (!p) return process.stdout.write("no probe sessions\n");
+      for (const w of p.windows) {
+        process.stdout.write(`${String(w.index).padEnd(4)} ${(w.name || "").padEnd(24)} ${w.opencodeSessionId || "-"}\n`);
+      }
+      return;
+    }
+
+    case "clean": {
+      const p = (await projects()).find((x) => x.tmuxSession === PROJECT);
+      if (!p) return process.stdout.write("nothing to clean\n");
+      await rpc("tmux:kill-session", [PROJECT]);
+      process.stdout.write(`removed ${p.windows.length} probe session(s)\n`);
+      return;
+    }
+
+    default:
+      process.stdout.write(
+        [
+          "manta-probe — live box access for agent verification. Model is always voska/default.",
+          "",
+          '  ask "<prompt>" [--keep]   fresh session, prompt, wait, print the reply',
+          "  new [label]               create a chat session, print its id",
+          '  prompt <sid> "<text>"     prompt an existing session, print the reply',
+          "  messages <sid>            dump a session transcript",
+          "  pair-url [--simctl]       ONE-STEP pairing: a manta:// link the app auto-claims",
+          "  pair                      mint a raw code + server URL (manual entry fallback)",
+          "  server                    print this box's public server URL",
+          "  list                      list probe sessions",
+          "  clean                     delete every probe session",
+          "",
+          "From a Mac:  ssh dev@alphaclaw manta-probe ask \"hello\"",
+        ].join("\n") + "\n",
+      );
+      process.exit(cmd ? 1 : 0);
+  }
+}
+
+main().catch((e) => die(e && e.stack ? e.stack.split("\n")[0] : String(e)));


### PR DESCRIPTION
## Why

Agents could not reliably reach a live box. "Verify this on a real session" kept degrading into hand-rolled `curl` that was subtly wrong — the RPC body shape, the bearer header, the fact that the prompt endpoint is **asynchronous** (returns `null`; the answer arrives on the transcript), and the fact that `/auth/pair` is **loopback-only**. Each of those fails in a way that looks exactly like a broken feature, so the gap got mis-reported rather than noticed.

Concretely: BET-1213 merged with **no** visual verification because its simulator step couldn't pair, and BET-1211 stalled on a diagnosis that needed live box access.

## What

**`scripts/manta-probe.cjs`** — the one supported way in. `ask` / `new` / `prompt` / `messages` / `pair-url` / `pair` / `server` / `list` / `clean`. Installed on `alphaclaw` at `~/.local/bin/manta-probe`.

**`.multica/skills/manta-live-session/SKILL.md`** — the skill agents load (registered in Multica as `manta-live-session`).

**`mobile/native/AGENTS.md`** — corrects a stale paragraph.

## Decisions worth reviewing

- **The model is a constant, not a flag.** Every prompt runs on `voska/default`; there is no argument or env var to change it. A rule an agent must remember is a rule an agent will forget, and the other providers on this box are metered.
- **The token never leaves the box.** Read inside the process, used only as a header — never printed, never in argv. The macos agent runs this over `ssh dev@alphaclaw`, so the value is substituted remotely and never enters the Mac's context. The skill forbids agents from reading `~/.manta/auth.json` themselves.
- **Pairing is one command, no typing.** The app registers `manta://` and **auto-claims** a deep-linked payload (`onOpenURL` → `route` → `receive` → `startLinking`), so `pair-url` + `xcrun simctl openurl booted` pairs a Simulator outright — no XCUITest driving the pairing screen. It deliberately omits `server=`, which the app refuses for a non-private host; with `box=` alone the app derives the public hostname itself.
- **Deep link over writing storage.** Credentials live in the iOS Keychain, and there is no supported way to write another app's Keychain item from the host. Even if there were, the link is better: it exercises the real `/auth/claim` path, so a successful pair proves the thing you actually care about works instead of bypassing it.
- **`.cjs` is load-bearing.** This package is `"type": "module"`, so a `.mjs` copy here parses as ESM and the script's `require` calls die. The installed copy is extensionless, which Node treats as CommonJS — one source, both places. (Caught by running the committed copy; it would otherwise have shipped broken.)

## The AGENTS.md correction

It still said BET-1104 and BET-1105 were unmerged. All three of BET-1103/1104/1105 are on `main`. That line cost real time: it produced a ticket instructing an agent to fix a scrolling fault by constraining a hand-rolled reveal gesture **that BET-1104 had already deleted**. The agent correctly refused to ship a fake fix. The paragraph now states what is true, explains why that diagnosis is no longer possible, and tells the reader to verify against the code rather than trust the paragraph.

## Verification

- `npm run typecheck` — clean
- `npm test` — 3233 renderer + 2543 server, 0 failures
- Tool exercised live end to end: create session → prompt → reply (`voska/default`), multi-turn, `messages`, `pair`, `pair-url`, `list`, `clean`
- Over SSH: `ssh dev@alphaclaw '~/.local/bin/manta-probe ask "…"'` → reply in 5.7s
- Non-interactive SSH `PATH` trap confirmed and documented (bare `manta-probe` is not on `PATH`; the absolute path is mandated everywhere)