### PR TITLE
feat(shared): routing config key + schema entries (BET-1218)

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -6,6 +6,10 @@ import { migrateLegacyCapConfig } from "../shared/configMigration.mjs";
 
 const DEFAULT_CONFIG: AppConfig = {
   projects: [],
+  // Model routing (BET-1215). Off by default (opt-in — routing acts on the
+  // user's behalf). The live server default lives in src/server/local.mjs;
+  // this mirrors it for desktop-side config reads.
+  modelRouting: { enabled: false, preset: "balanced" },
 };
 
 function configPath(): string {

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -467,6 +467,7 @@ export function Settings({
   const alwaysShowUsage = useStore((s) => s.alwaysShowUsage);
   const theme = useStore((s) => s.theme);
   const cto = useStore((s) => s.cto);
+  const modelRouting = useStore((s) => s.modelRouting);
   const skillRegistryUrls = useStore((s) => s.skillRegistryUrls);
   const launcherFlags = useStore((s) => s.launcherFlags);
   const updatePrompt = useStore((s) => s.updatePrompt);
@@ -533,8 +534,10 @@ export function Settings({
       "cto.model": cto?.model ?? "",
       "cto.voice": cto?.voice ?? "",
       "cto.alwaysListening": cto?.alwaysListening ?? false,
+      "modelRouting.enabled": modelRouting?.enabled ?? false,
+      "modelRouting.preset": modelRouting?.preset ?? "balanced",
     }),
-    [cacheTtl, groqApiKey, voiceTranscriptionModel, openaiApiKey, allowAgentPush, downloadsDir, worktreePerSession, worktreeCleanOnClose, uploadCleanupHours, voiceNoteTtlHours, theme, autoRenameSessions, alwaysShowUsage, cto],
+    [cacheTtl, groqApiKey, voiceTranscriptionModel, openaiApiKey, allowAgentPush, downloadsDir, worktreePerSession, worktreeCleanOnClose, uploadCleanupHours, voiceNoteTtlHours, theme, autoRenameSessions, alwaysShowUsage, cto, modelRouting],
   );
 
   const commitKey = async (entry: SettingEntry, nextValue: unknown) => {

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -409,6 +409,9 @@ type State = {
   // On-call CTO feature (BET-1166). Nested block mirrors AppConfig#cto; the
   // call window + settings read it off the store.
   cto: AppConfig["cto"];
+  // Model routing (BET-1215). Nested block mirrors AppConfig#modelRouting;
+  // Settings reads it off the store (config-only — no wiring yet).
+  modelRouting: AppConfig["modelRouting"];
   // Analytics opt-out (BET-217). Default true; false = this instance ships
   // nothing to Axiom (desktop renderer + server). Mobile always ships
   // regardless. Mirror of AppConfig.shareAnalytics.
@@ -803,6 +806,7 @@ export const useStore = create<State>((set, get) => ({
   voiceTranscriptionModel: "",
   openaiApiKey: "",
   cto: undefined,
+  modelRouting: undefined,
   shareAnalytics: true,
   theme: "system",
   pinnedWindows: [],
@@ -1082,6 +1086,7 @@ export const useStore = create<State>((set, get) => ({
       voiceTranscriptionModel: c.voiceTranscriptionModel ?? "",
       openaiApiKey: c.openaiApiKey ?? "",
       cto: c.cto ? { ...c.cto } : undefined,
+      modelRouting: c.modelRouting ? { ...c.modelRouting } : undefined,
       shareAnalytics: c.shareAnalytics ?? true,
       pinnedWindows: Array.isArray(c.pinnedWindows) ? c.pinnedWindows : [],
       theme:

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -74,6 +74,14 @@ const DEFAULT_CONFIG = {
   // Lets a self-hosted GitHub/GitLab instance (which `detectForge` deliberately
   // rejects) resolve to its forge + API root. `kind` is "github" | "gitlab".
   forgeHosts: [],
+  // Model routing (BET-1215): pick the cheapest model that clears the floor.
+  // Off by default (hard requirement — routing acts on the user's behalf, so
+  // it is opt-in, matching chatAutoAllow / pluginsEnabled). Config-only in
+  // this issue; no behaviour change until the router wiring issue reads it.
+  modelRouting: {
+    enabled: false,
+    preset: "balanced",
+  },
 };
 
 let _config = null;

--- a/src/shared/settingsSchema.test.ts
+++ b/src/shared/settingsSchema.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from "vitest";
+import { PRESETS } from "./modelRouter.mjs";
 import {
   SETTINGS,
   SETTING_SECTIONS,
@@ -123,6 +124,40 @@ describe("uploadCleanupHours (BET-427)", () => {
   });
   it("carries a 0-disables option", () => {
     expect(entry!.options?.some((o) => o.value === "0")).toBe(true);
+  });
+});
+
+describe("model routing entries (BET-1218)", () => {
+  const enabled = ALL.find((e) => e.id === "modelRoutingEnabled");
+  const preset = ALL.find((e) => e.id === "modelRoutingPreset");
+
+  it("are present in the models section for desktop", () => {
+    const desktop = settingsForSection(ALL, "models", "desktop");
+    expect(enabled).toBeDefined();
+    expect(preset).toBeDefined();
+    expect(desktop.some((e) => e.id === "modelRoutingEnabled")).toBe(true);
+    expect(desktop.some((e) => e.id === "modelRoutingPreset")).toBe(true);
+  });
+
+  it("are desktop-only (never rendered on mobile)", () => {
+    const mobile = settingsForPlatform(ALL, "mobile");
+    expect(mobile.some((e) => e.id === "modelRoutingEnabled")).toBe(false);
+    expect(mobile.some((e) => e.id === "modelRoutingPreset")).toBe(false);
+  });
+
+  it("the enabled toggle defaults to FALSE (the consent boundary)", () => {
+    // Routing acts on the user's behalf, so it is strictly opt-in.
+    expect(enabled!.control).toBe("toggle");
+    expect(enabled!.configKey).toBe("modelRouting.enabled");
+    expect(enabled!.default).toBe(false);
+  });
+
+  it("the preset uses the exact PRESETS values from modelRouter (no drift)", () => {
+    expect(preset!.control).toBe("segmented");
+    expect(preset!.configKey).toBe("modelRouting.preset");
+    expect(preset!.default).toBe("balanced");
+    const values = preset!.options?.map((o) => o.value);
+    expect(values).toEqual(PRESETS);
   });
 });
 

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -177,6 +177,33 @@ export const SETTINGS: SettingEntry[] = [
     default: false,
     group: "Plan usage",
   },
+  {
+    id: "modelRoutingEnabled",
+    section: "models",
+    label: "Let Manta pick the model",
+    help: "Chooses a model per task when a session or subagent starts, and when a plan usage limit would otherwise stop the work. Never changes model in the middle of an exchange. Every choice shows why, and can be undone.",
+    control: "toggle",
+    configKey: "modelRouting.enabled",
+    platform: "desktop",
+    default: false,
+    group: "Routing",
+  },
+  {
+    id: "modelRoutingPreset",
+    section: "models",
+    label: "Balance",
+    help: "Economy favours the cheapest model that still clears the quality floor for each kind of work. Performance favours the strongest. Each kind of work has a floor that Economy will not go below.",
+    control: "segmented",
+    configKey: "modelRouting.preset",
+    platform: "desktop",
+    default: "balanced",
+    group: "Routing",
+    options: [
+      { value: "economy", label: "Economy" },
+      { value: "balanced", label: "Balanced" },
+      { value: "performance", label: "Performance" },
+    ],
+  },
 
   // ----- sessions (per-session behaviour) -----
   {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -282,6 +282,21 @@ export type AppConfig = {
     // Whether the call window listens continuously (Issue 3). Default false.
     alwaysListening?: boolean;
   };
+  // ----- Model routing (BET-1215) -----
+  // Manta picks the cheapest model that still clears the quality floor for a
+  // given kind of work, instead of always using the default. Off by default
+  // (hard requirement — routing acts on the user's behalf, so it is opt-in,
+  // matching chatAutoAllow / pluginsEnabled). Config-only in this issue; the
+  // router wiring issue reads this into the router's `policy` argument.
+  modelRouting?: {
+    // Master switch. False (the default) until the user opts in.
+    enabled: boolean;
+    // Three-way balance dial. Default "balanced".
+    preset: "economy" | "balanced" | "performance";
+    // Per-agent tier override (config-only — no UI builds this). Absent /
+    // partial = fall back to the preset's tier table.
+    perAgent?: Record<string, "fast" | "balanced" | "deep">;
+  };
   // Position/size of the floating on-call CTO window (BET-1166). Persisted so
   // the window remembers where the user parked it across runs.
   callWindowBounds?: { x?: number; y?: number; width: number; height: number };


### PR DESCRIPTION
## Summary
Adds the `modelRouting` config block (off by default) plus two schema-driven Settings entries under **Models → Routing** — a `toggle` ("Let Manta pick the model") and a `segmented` ("Balance"). No new component, no new `.tsx`, no new dependency, no behaviour change to routing itself (the router wiring issue reads this into `policy`).

**Files changed:** 7 — `src/shared/settingsSchema.ts`, `src/shared/types.ts`, `src/server/local.mjs`, `src/main/config.ts`, `src/renderer/store.ts`, `src/renderer/Settings.tsx`, `src/shared/settingsSchema.test.ts`.

## Dotted vs flat keys — decision
Took the **dotted** branch (`modelRouting.enabled` / `modelRouting.preset`). Verified first: `configUpdate` in `src/server/local.mjs` already handles **any** dotted key generically (splits on `.`, writes nested) — the `cto.*` feature already relies on this, and the existing settings plumbing (`resetAllPayload`, `sectionIsModified`, the store + Settings values map) all address dotted keys. Adding flat keys would have duplicated a working code path for no benefit, which the issue explicitly forbids.

## Why Settings.tsx + store.ts are touched (issue listed 4 files)
The issue lists only `settingsSchema.ts` / `main/config.ts` / `types.ts` / the test file, but the Settings **values map is explicit per-key, not schema-derived** — `settingsForSection` renders controls from `values[entry.configKey]`, and the dotted `cto.*` entries are sourced from the nested config through the store. Without wiring the same two lines for `modelRouting`, the toggle/segmented would not reflect saved state (they'd snap back to default on every open). This mirrors exactly how `cto.*` was wired (BET-1166): `store.cto` field + `applyConfig` mapping + two values-map lines. No component or render code changed.

The live runtime default lives in `src/server/local.mjs` `DEFAULT_CONFIG` (where every other schema config key already lives — `chatAutoAllow`, `worktreePerSession`, `cto.*`); `src/main/config.ts` gets the desktop default mirror as the issue requested.

## Defaults (consent boundary)
- `enabled: false` — hard requirement. Routing is opt-in, matching `chatAutoAllow` / `pluginsEnabled`.
- `preset: "balanced"`.

## Tests
- New `model routing entries (BET-1218)` block in `settingsSchema.test.ts`:
  - both entries present in the `models` section for desktop;
  - both excluded from mobile;
  - the toggle's default asserted `false` explicitly (the consent boundary);
  - the segmented options `economy | balanced | performance` imported and compared against `PRESETS` from `src/shared/modelRouter.mjs` so the two can never drift.

**Verification results:**
- PR branch (`multica/BET-1218-routing-config-schema` @ `39f97ec2`):
  - typecheck: exit 0, no errors. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2548 pass / 0 fail / 0 skip (node:test), plus vitest `.ts` suites green (settingsSchema: 39/39, incl. 4 new). log sha256: `09d90a0d597f5dd76ce911c59116a2799be9d06801cb8fc3fcaf90027006a28b`
- Base (`main` @ `828d87a4`):
  - typecheck: exit 0, no errors. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2548 pass / 0 fail / 0 skip. log sha256: `e5d688e0c757afa00a518db605005932778ad63867c3e9bd5917e30c69cbc199`
- **Conclusion:** 0 new failures. (The 2548 node:test count is identical on both branches — my new tests are vitest `.ts`, counted separately.)

Base: origin/main @ `828d87a4`
