### PR TITLE
BET-1219: read-only spend/latency ledger over opencode's store

### DIFF
--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -75,6 +75,7 @@ export const DEMO_UNIMPLEMENTED = [
   "getPathForFile",
   "gitAddWorktree",
   "gitRemoveWorktree",
+  "ledgerSummary",
   "onAgentFileReady",
   "onAppControl",
   "onAutoUpdateAvailable",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1228,6 +1228,7 @@ export const httpApi: Api = {
   opencodeReferences: () => rpc(IPC.opencodeReferences),
   opencodeSetReferences: (ops) => rpc(IPC.opencodeSetReferences, ops),
   opencodeSearchMessages: (input) => rpc(IPC.opencodeSearchMessages, input),
+  ledgerSummary: (opts) => rpc(IPC.ledgerSummary, opts),
 
   // -- slash-command execution --
   opencodeRunCommand: (input) => rpc(IPC.opencodeRunCommand, input),

--- a/src/server/modelLedger.mjs
+++ b/src/server/modelLedger.mjs
@@ -1,0 +1,244 @@
+// modelLedger.mjs — read-only spend/latency ledger over opencode's store.
+//
+// BET-1219: the measurement half of model routing. Nobody can see where model
+// spend actually goes; on this box ~90% of it is prompt cache, not output
+// tokens, and subagents silently run on the most expensive model available.
+// This module adds the MEASUREMENT only — no routing, no behaviour change.
+// Later routing decisions are tuned from these numbers, so this ships first.
+//
+// Split strictly into pure (`aggregate`) and I/O (`ledgerSummary`):
+//   • aggregate — all arithmetic. Pure; no DB. Exported for tests.
+//   • ledgerSummary — SQL via getDb() + JSON.parse, then aggregate().
+//
+// Degradation: mirrors messageSearch.mjs — when getDb() yields null (no Node
+// 24 runtime, or no opencode.db at the resolved path) ledgerSummary returns
+// { supported:false } and never throws. Read-only is a hard invariant; the
+// shared handle from opencodeDb.mjs is opened read-only and stays so.
+
+import { getDb } from "./opencodeDb.mjs";
+
+// Turns longer than this are excluded from TIMING only (still counted for
+// cost) — the spec cap is 600s of wall-clock.
+const TIMING_MAX_MS = 600_000;
+
+// Coerce an arbitrary JSON value to a finite number, else 0. Value-missing
+// or a NaN/Infinity anywhere in the ledger is a bug; every division must
+// yield 0, never NaN/Infinity.
+function num(x) {
+  return typeof x === "number" && Number.isFinite(x) ? x : 0;
+}
+
+// Divide with a hard divide-by-zero guard: 0/0 and n/0 both yield 0.
+function safeDiv(n, d) {
+  const dd = num(d);
+  return dd === 0 ? 0 : num(n) / dd;
+}
+
+// Percentile of an ascending-sorted array (linear-approach index). Caller
+// gates on the minimum sample count; safe on empty input (returns 0).
+function percentile(sorted, p) {
+  if (sorted.length === 0) return 0;
+  const idx = Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * p));
+  return sorted[idx];
+}
+
+// Timing duration (ms) for a row, or null when the row is excluded from
+// timing: either boundary missing/zero, a zero/negative duration, or a
+// duration over TIMING_MAX_MS. Excluded rows still count toward cost.
+function timedDurationMs(startedMs, completedMs) {
+  const s = num(startedMs);
+  const c = num(completedMs);
+  if (s <= 0 || c <= 0) return null;
+  const d = c - s;
+  if (!(d > 0) || d > TIMING_MAX_MS) return null;
+  return d;
+}
+
+/**
+ * PURE. Fold raw (already-parsed) rows into the spend/latency ledger.
+ *
+ * `rows` is Array<{ providerID, modelID, agent, parentId, directory, cost,
+ * input, output, reasoning, cacheRead, cacheWrite, startedMs, completedMs }>.
+ * `ledgerSummary` builds that shape; `aggregate` does all arithmetic.
+ *
+ * Every array in the result is sorted by `cost` descending. Never throws and
+ * never emits NaN/Infinity — empty input yields all-zeros.
+ */
+export function aggregate(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+
+  const totals = { turns: 0, cost: 0, input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+
+  // Group accumulators, keyed so undefined/null collapse to one bucket each.
+  const modelMap = new Map(); // "providerID/modelID" -> { … }
+  const agentMap = new Map(); // agent string (or null marker) -> { … }
+  const projectMap = new Map(); // directory (or empty marker) -> { … }
+
+  for (const r of list) {
+    const cost = num(r.cost);
+    const input = num(r.input);
+    const output = num(r.output);
+    const cacheRead = num(r.cacheRead);
+    const cacheWrite = num(r.cacheWrite);
+
+    totals.turns += 1;
+    totals.cost += cost;
+    totals.input += input;
+    totals.output += output;
+    totals.cacheRead += cacheRead;
+    totals.cacheWrite += cacheWrite;
+
+    // ---- byModel ----
+    const modelKey = `${r.providerID ?? ""}/${r.modelID ?? ""}`;
+    let m = modelMap.get(modelKey);
+    if (!m) {
+      m = { key: modelKey, turns: 0, cost: 0, outTotal: 0, outTimed: 0, durSec: 0, durations: [] };
+      modelMap.set(modelKey, m);
+    }
+    m.turns += 1;
+    m.cost += cost;
+    m.outTotal += output;
+
+    const durMs = timedDurationMs(r.startedMs, r.completedMs);
+    if (durMs !== null) {
+      m.outTimed += output;
+      m.durSec += durMs / 1000;
+      m.durations.push(durMs);
+    }
+
+    // ---- byAgent ----
+    const agent = r.agent ?? null;
+    const agentKey = agent === null ? "__null__" : agent;
+    let a = agentMap.get(agentKey);
+    if (!a) {
+      a = { agent, isChild: false, turns: 0, cost: 0 };
+      agentMap.set(agentKey, a);
+    }
+    a.turns += 1;
+    a.cost += cost;
+    // A subagent/child session is one whose parentId is set. isChild is true
+    // if any contributing row came from a child session.
+    if (r.parentId != null) a.isChild = true;
+
+    // ---- byProject ----
+    const directory = r.directory ?? "";
+    const projectKey = directory === "" ? "__empty__" : directory;
+    let p = projectMap.get(projectKey);
+    if (!p) {
+      p = { directory, turns: 0, cost: 0 };
+      projectMap.set(projectKey, p);
+    }
+    p.turns += 1;
+    p.cost += cost;
+  }
+
+  // ---- byModel ----
+  const byModel = [];
+  for (const m of modelMap.values()) {
+    byModel.push({
+      key: m.key,
+      turns: m.turns,
+      cost: m.cost,
+      costPerTurn: safeDiv(m.cost, m.turns),
+      outPerTurn: safeDiv(m.outTotal, m.turns),
+      // Timing only: sum(output) / sum(durationSeconds) across timed turns.
+      tokensPerSec: safeDiv(m.outTimed, m.durSec),
+      p50Ms: m.durations.length >= 5 ? percentile(m.durations, 0.5) : null,
+      p90Ms: m.durations.length >= 5 ? percentile(m.durations, 0.9) : null,
+    });
+  }
+  byModel.sort(byCostDesc);
+
+  // ---- byAgent ----
+  const byAgent = [];
+  for (const a of agentMap.values()) {
+    byAgent.push({ agent: a.agent, isChild: a.isChild, turns: a.turns, cost: a.cost, costPerTurn: safeDiv(a.cost, a.turns) });
+  }
+  byAgent.sort(byCostDesc);
+
+  // ---- byProject ----
+  const byProject = [];
+  for (const p of projectMap.values()) {
+    byProject.push({ directory: p.directory, turns: p.turns, cost: p.cost });
+  }
+  byProject.sort(byCostDesc);
+
+  // ---- cacheShare ----
+  // Fractions of the summed billed token cost proxy
+  // (input + output + cacheRead + cacheWrite); the four sum to ~1.
+  const proxy = totals.input + totals.output + totals.cacheRead + totals.cacheWrite;
+  const cacheShare = {
+    output: safeDiv(totals.output, proxy),
+    cacheRead: safeDiv(totals.cacheRead, proxy),
+    cacheWrite: safeDiv(totals.cacheWrite, proxy),
+    input: safeDiv(totals.input, proxy),
+  };
+
+  return { totals, cacheShare, byModel, byAgent, byProject };
+}
+
+function byCostDesc(a, b) {
+  return num(b.cost) - num(a.cost);
+}
+
+/**
+ * I/O. Reads assistant rows via the shared getDb() handle, parses their JSON,
+ * and folds them through aggregate(). Returns { supported:false } — never
+ * throws — when getDb() yields null, mirroring searchMessages. Rows whose
+ * data fails JSON.parse or whose role !== "assistant" are skipped silently.
+ */
+export async function ledgerSummary({ sinceMs = 0 } = {}) {
+  const db = await getDb();
+  if (!db) return { supported: false };
+
+  try {
+    const since = num(sinceMs);
+    const sql = `
+      SELECT m.data AS msg_data,
+             s.parent_id AS parent_id,
+             s.agent AS agent,
+             s.directory AS directory
+      FROM message m
+      JOIN session s ON s.id = m.session_id
+      WHERE m.time_created >= ?`;
+    const stmt = db.prepare(sql);
+    const rows = [];
+    for (const row of stmt.all(since)) {
+      let data;
+      try {
+        data = JSON.parse(row.msg_data);
+      } catch {
+        continue;
+      }
+      if (!data || typeof data !== "object" || data.role !== "assistant") continue;
+      const tokens = data.tokens ?? {};
+      const cache = tokens.cache ?? {};
+      rows.push({
+        providerID: data.providerID ?? null,
+        modelID: data.modelID ?? null,
+        agent: row.agent ?? null,
+        parentId: row.parent_id != null ? String(row.parent_id) : null,
+        directory: row.directory ?? null,
+        cost: data.cost,
+        input: tokens.input,
+        output: tokens.output,
+        reasoning: tokens.reasoning,
+        cacheRead: cache.read,
+        cacheWrite: cache.write,
+        startedMs: data.time?.created,
+        completedMs: data.time?.completed,
+      });
+    }
+    return { supported: true, ...aggregate(rows) };
+  } catch (e) {
+    // Query error: log once, drop the handle so the next call reopens, and
+    // degrade to { supported:false } — never an exception.
+    console.error("[modelLedger] query failed:", e?.message ?? e);
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+    return { supported: false };
+  }
+}

--- a/src/server/modelLedger.test.mjs
+++ b/src/server/modelLedger.test.mjs
@@ -1,0 +1,155 @@
+// Tests for modelLedger.mjs — the read-only spend/latency ledger.
+// Pure: all fixtures run against `aggregate`, never a real database. Run via
+// `npm run test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { aggregate } from "./modelLedger.mjs";
+
+// Fixture builder. Fill only the fields a test cares about.
+function row(over = {}) {
+  return {
+    providerID: "anthropic",
+    modelID: "claude-sonnet-4-6",
+    agent: "build",
+    parentId: null,
+    directory: "/work/proj",
+    cost: 0,
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    startedMs: 0,
+    completedMs: 0,
+    ...over,
+  };
+}
+
+const closeTo = (actual, expected, tol, msg) =>
+  assert.ok(Math.abs(actual - expected) <= tol, `${msg}: ${actual} !≈ ${expected} (±${tol})`);
+
+// Assert every numeric field in the ledger is finite (no NaN/Infinity).
+function assertFinite(ledger) {
+  const nums = [ledger.totals, ledger.cacheShare, ...ledger.byModel, ...ledger.byAgent, ...ledger.byProject];
+  for (const obj of nums) {
+    for (const v of Object.values(obj)) {
+      if (typeof v === "number") assert.ok(Number.isFinite(v), `non-finite value: ${v}`);
+    }
+  }
+}
+
+test("cache-share fractions sum to 1 and match a hand-computed fixture", () => {
+  const ledger = aggregate([
+    row({ cost: 1, input: 100, output: 10, cacheRead: 50, cacheWrite: 40 }),
+  ]);
+  // proxy = 100 + 10 + 50 + 40 = 200
+  closeTo(ledger.cacheShare.output, 10 / 200, 1e-9, "output");
+  closeTo(ledger.cacheShare.cacheRead, 50 / 200, 1e-9, "cacheRead");
+  closeTo(ledger.cacheShare.cacheWrite, 40 / 200, 1e-9, "cacheWrite");
+  closeTo(ledger.cacheShare.input, 100 / 200, 1e-9, "input");
+  const sum =
+    ledger.cacheShare.output + ledger.cacheShare.cacheRead + ledger.cacheShare.cacheWrite + ledger.cacheShare.input;
+  closeTo(sum, 1, 1e-3, "sum");
+});
+
+test("costPerTurn and tokensPerSec correct on a 3-row fixture", () => {
+  const ledger = aggregate([
+    row({ providerID: "p", modelID: "m", cost: 6, output: 200, startedMs: 1000, completedMs: 3000 }),
+    row({ providerID: "p", modelID: "m", cost: 4, output: 100, startedMs: 2000, completedMs: 4000 }),
+    row({ providerID: "p", modelID: "m", cost: 2, output: 300, startedMs: 500, completedMs: 1500 }),
+  ]);
+  const model = ledger.byModel[0];
+  assert.equal(model.key, "p/m");
+  assert.equal(model.turns, 3);
+  // cost 6+4+2 = 12, / 3 turns
+  closeTo(model.costPerTurn, 4, 1e-9, "costPerTurn");
+  closeTo(model.outPerTurn, 200, 1e-9, "outPerTurn");
+  // output 200+100+300 = 600; durations 2000+2000+1000 ms = 5s → 600/5 = 120
+  closeTo(model.tokensPerSec, 120, 1e-9, "tokensPerSec");
+  assertFinite(ledger);
+});
+
+test("missing/zero/oversize durations are excluded from timing but included in cost", () => {
+  const validMs = 5000; // 5s, in budget
+  const ledger = aggregate([
+    row({ cost: 10, output: 100, startedMs: 100, completedMs: 100 + validMs }), // valid
+    row({ cost: 20, output: 100, startedMs: 1000, completedMs: undefined }), // completed missing
+    row({ cost: 30, output: 100, startedMs: 1000, completedMs: 1000 }), // zero-length
+    row({ cost: 40, output: 100, startedMs: 1000, completedMs: 1000 + 601_000 }), // > 600s
+  ]);
+  // All four still count for cost.
+  assert.equal(ledger.totals.turns, 4);
+  closeTo(ledger.totals.cost, 100, 1e-9, "cost");
+  const model = ledger.byModel[0];
+  closeTo(model.costPerTurn, 25, 1e-9, "costPerTurn");
+  // Timing uses only the single valid row: output 100, duration 5s → 20 tok/s.
+  closeTo(model.tokensPerSec, 100 / 5, 1e-9, "tokensPerSec");
+  // 1 timed turn < 5 → percentiles null.
+  assert.equal(model.p50Ms, null);
+  assert.equal(model.p90Ms, null);
+  assertFinite(ledger);
+});
+
+test("p50/p90 are null below 5 timed turns, finite above", () => {
+  const few = aggregate([
+    row({ startedMs: 0, completedMs: 100 }),
+    row({ startedMs: 0, completedMs: 200 }),
+  ]);
+  assert.equal(few.byModel[0].p50Ms, null);
+  assert.equal(few.byModel[0].p90Ms, null);
+
+  const five = aggregate([
+    row({ startedMs: 1000, completedMs: 1100 }),
+    row({ startedMs: 1000, completedMs: 1200 }),
+    row({ startedMs: 1000, completedMs: 1300 }),
+    row({ startedMs: 1000, completedMs: 1400 }),
+    row({ startedMs: 1000, completedMs: 1500 }),
+  ]);
+  assert.equal(typeof five.byModel[0].p50Ms, "number");
+  assert.equal(typeof five.byModel[0].p90Ms, "number");
+  assertFinite(five);
+});
+
+test("empty input yields all zeros and no NaN", () => {
+  const ledger = aggregate([]);
+  assert.equal(ledger.totals.turns, 0);
+  assert.equal(ledger.totals.cost, 0);
+  assert.equal(ledger.totals.input, 0);
+  assert.equal(ledger.totals.output, 0);
+  assert.equal(ledger.totals.cacheRead, 0);
+  assert.equal(ledger.totals.cacheWrite, 0);
+  assert.equal(ledger.byModel.length, 0);
+  assert.equal(ledger.byAgent.length, 0);
+  assert.equal(ledger.byProject.length, 0);
+  // Explicit NaN/Infinity assertion (test 5).
+  for (const v of Object.values(ledger.totals)) assert.ok(Number.isFinite(v));
+  for (const v of Object.values(ledger.cacheShare)) assert.ok(Number.isFinite(v));
+});
+
+test("byAgent marks isChild correctly from parentId", () => {
+  const ledger = aggregate([
+    row({ agent: "explore", parentId: "ses-child" }), // subagent session
+    row({ agent: "explore", parentId: "ses-child" }),
+    row({ agent: "build", parentId: null }), // top-level session
+    row({ agent: "general", providerID: "x", modelID: "y", parentId: "ses-2" }),
+  ]);
+  const byAgent = Object.fromEntries(ledger.byAgent.map((a) => [a.agent, a]));
+  assert.equal(byAgent.explore.isChild, true);
+  assert.equal(byAgent.build.isChild, false);
+  assert.equal(byAgent.general.isChild, true);
+  assertFinite(ledger);
+});
+
+test("every array is sorted by cost descending", () => {
+  const ledger = aggregate([
+    row({ providerID: "a", modelID: "a", cost: 5, agent: "one", directory: "/x", startedMs: 0, completedMs: 100 }),
+    row({ providerID: "a", modelID: "b", cost: 9, agent: "two", directory: "/y", startedMs: 0, completedMs: 100 }),
+    row({ providerID: "a", modelID: "c", cost: 2, agent: "three", directory: "/z", startedMs: 0, completedMs: 100 }),
+  ]);
+  const desc = (arr, get) => arr.every((v, i) => i === 0 || get(arr[i - 1]) >= get(v));
+  assert.ok(desc(ledger.byModel, (m) => m.cost));
+  assert.ok(desc(ledger.byAgent, (a) => a.cost));
+  assert.ok(desc(ledger.byProject, (p) => p.cost));
+  assert.equal(ledger.byModel[0].key, "a/b");
+});

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -39,6 +39,7 @@ import { backupClaudeCredentials, CREDENTIALS_PATH } from "./claudeAuth.mjs";
 import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import { searchMessages } from "./messageSearch.mjs";
+import { ledgerSummary } from "./modelLedger.mjs";
 import { MIN_CLIENT } from "./version.mjs";
 import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, replyThreadForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
 import { listRules as forgeListRules, formatIssueRef, parseIssueRef } from "./forgeRules.mjs";
@@ -949,6 +950,13 @@ export function buildHandlers({
     // hasn't taken the Node 24 runtime yet.
     // preload: ipcRenderer.invoke(IPC.opencodeSearchMessages, { query, sessionIds })
     "opencode:search-messages": (input) => searchMessages(input ?? {}),
+
+    // BET-1219: read-only spend/latency ledger over opencode's SQLite
+    // (modelLedger.mjs). Args { sinceMs } — filters assistant rows to
+    // time_created >= sinceMs (default 0 = all). Measurement only: no
+    // routing, no behaviour change. Degrades to { supported:false } on a
+    // box that hasn't taken the Node 24 runtime yet / has no opencode.db.
+    "ledger:summary": (opts) => ledgerSummary(opts ?? {}),
 
     // preload: ipcRenderer.invoke(IPC.opencodeRunCommand, { sessionId, command, arguments, model?, attachments? })
     // → args[0] = that object; opencode.mjs runCommand expects same shape

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -81,6 +81,7 @@ import type {
   SubagentInput,
   PluginRegistryRow,
   TranscriptHit,
+  LedgerSummary,
   AppControlPayload,
   MediaEventPayload,
 } from "./types.js";

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -637,6 +637,11 @@ export interface Api {
     query: string;
     sessionIds: string[];
   }): Promise<{ supported: boolean; hits: TranscriptHit[] }>;
+  // BET-1219: read-only spend/latency ledger over opencode's store.
+  // `sinceMs` filters assistant rows to time_created >= sinceMs (default 0 =
+  // all). Measurement only — no routing. `supported:false` = the box can't
+  // read opencode.db (needs the Node 24 runtime).
+  ledgerSummary(opts?: { sinceMs?: number }): Promise<LedgerSummary | { supported: false }>;
 
   // Slash-command execution.
   opencodeRunCommand(input: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1379,6 +1379,9 @@ export const IPC = {
   // BET-698: server-side conversation search over opencode's SQLite
   // (messageSearch.mjs). Returns { supported, hits }.
   opencodeSearchMessages: "opencode:search-messages",
+  // BET-1219: read-only spend/latency ledger over opencode's store.
+  // Returns { supported, ...LedgerSummary }.
+  ledgerSummary: "ledger:summary",
   // Slash-command execution: invokes POST /session/{id}/command. Distinct
   // from opencode:prompt — the server treats commands specially (templates,
   // configured agent/model, etc.).
@@ -1739,6 +1742,30 @@ export type TranscriptHit = {
   match: string;
   post: string;
   timeCreated: number | null;
+};
+
+// BET-1219: read-only spend/latency ledger over opencode's store
+// (`ledger:summary` RPC). Crosses the wire, so it lives in shared/types.
+// The four cacheShare fractions sum to ~1 (±0.001): each is that bucket's
+// share of the summed billed token cost proxy (input + output + cacheRead +
+// cacheWrite). Arrays are sorted by cost descending. p50Ms/p90Ms are null
+// below 5 timed turns. `supported:false` = the box can't read opencode.db.
+export type LedgerSummary = {
+  supported: boolean;
+  totals: { turns: number; cost: number; input: number; output: number; cacheRead: number; cacheWrite: number };
+  cacheShare: { output: number; cacheRead: number; cacheWrite: number; input: number };
+  byModel: {
+    key: string; // "providerID/modelID"
+    turns: number;
+    cost: number;
+    costPerTurn: number;
+    outPerTurn: number;
+    tokensPerSec: number;
+    p50Ms: number | null;
+    p90Ms: number | null;
+  }[];
+  byAgent: { agent: string | null; isChild: boolean; turns: number; cost: number; costPerTurn: number }[];
+  byProject: { directory: string; turns: number; cost: number }[];
 };
 
 // A secret's METADATA — what the UI and `secret_list` see. NEVER carries the


### PR DESCRIPTION
Opened automatically for `multica/BET-1219-model-ledger`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1219.