### PR TITLE
feat(ios-native): question/permission/plan cards move into the transcript tail with 44pt tap targets (BET-1214)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -185,6 +185,10 @@ private struct ChatScreenContent: View {
     /// row) should be shown. Driven purely by scroll geometry; it does not
     /// touch auto-follow, which stays constant so new messages pin smoothly.
     @State private var showScrollToBottom = false
+    /// Tracks whether a blocking card was present on the last render, so the
+    /// auto-scroll on card arrival fires ONCE per no-card → card transition
+    /// (never per rebuild) and re-arms when a card leaves (BET-1214).
+    @State private var wasBlockingCardPresent = false
 
     /// Measured height of the floating bottom bar (cards + composer), fed to
     /// the transcript's `additionalContentInset` bottom inset so the newest
@@ -299,6 +303,18 @@ private struct ChatScreenContent: View {
                 if running, BranchFreshnessPolicy.shouldRefresh(didSubmit: true, now: Date(), lastFetch: nil) {
                     Task { await refreshBranch() }
                 }
+            }
+            // BET-1214: a blocking card (permission / plan / question) can now be
+            // scrolled away — it is a transcript-tail row, not a pinned overlay.
+            // When a card ARRIVES while the user is following it is already in
+            // view; the auto-scroll matters when they are scrolled away, so the
+            // new ask is not silently missed. Fire ONCE on the no-card → card
+            // transition, never per rebuild; re-arm when the card leaves.
+            .onChange(of: isBlockingCardPresent) { _, nowPresent in
+                if nowPresent, !wasBlockingCardPresent {
+                    scrollPosition.scrollTo(edge: .bottom, animated: true)
+                }
+                wasBlockingCardPresent = nowPresent
             }
             // BET-673: fire one success haptic when a turn completes while the
             // user has scrolled up (scroll-to-bottom chip showing) and the scene
@@ -746,6 +762,7 @@ private struct ChatScreenContent: View {
             bottomInset: bottomBarHeight,
             scrollPosition: $scrollPosition,
             onPointsFromBottom: { showScrollToBottom = $0 > Self.scrollToBottomThreshold },
+            cards: cardActions,
             header: { sessionHeaderBlock }
         )
     }
@@ -1007,64 +1024,50 @@ private struct ChatScreenContent: View {
             }
             // Only things that BLOCK the turn and need a tap stay here. Live
             // running tools now render INSIDE the transcript (in the turn that
-            // spawned them); sessionError / truncation / queued prompts moved
-            // into the transcript tail too. Todos stay, collapsed to a single
+            // spawned them); sessionError / truncation / queued prompts AND the
+            // blocking cards (permission / plan / question) all moved into the
+            // transcript tail too (BET-1214). Todos stay, collapsed to a single
             // line while a turn runs.
             if let todos = store.todos, !(todos.visible?.visible ?? todos.active ?? []).isEmpty {
                 TodosCard(payload: todos, tokens: tokens, compact: store.running)
-            }
-            if let permission = newestPermission {
-                PermissionCard(permission: permission, tokens: tokens) { reply in
-                    store.replyPermission(permission, reply: reply)
-                }
-            }
-            // The plan_exit question upgrades into a dedicated PlanCard and is
-            // EXCLUDED from newestQuestion (below), exactly as desktop excludes
-            // it from its inline question stack (`ChatPanel.tsx:2896`) — so the
-            // plan card and the generic question card never render for the
-            // same question.
-            if let planQ = newestPlanQuestion {
-                PlanCard(
-                    question: planQ,
-                    messages: store.messages,
-                    buildModelName: buildModelName,
-                    planURL: planURL,
-                    tokens: tokens,
-                    onBuildHere: { feedback in
-                        handleBuildHere(planQ, feedback: feedback)
-                    },
-                    onKeepPlanning: { feedback in
-                        store.keepPlanning(question: planQ, feedback: feedback)
-                    },
-                    onOpenPage: { openPlanPage() }
-                )
-            }
-            if let question = newestQuestion {
-                QuestionCard(question: question, tokens: tokens) { answers in
-                    store.replyQuestion(question, answers: answers)
-                } onReject: {
-                    store.rejectQuestion(question)
-                }
             }
         }
         .padding(.horizontal, Metrics.spacing.sp3)
         .padding(.top, Metrics.spacing.sp2)
     }
 
-    private var newestPermission: PermissionRequest? {
-        store.permissions.last
+    /// The callbacks + context the blocking cards need now that they render in
+    /// the transcript tail via `transcriptBlockView`, not the pinned bottom
+    /// stack. Same closures the cards always took — only their delivery route
+    /// changed (BET-1214).
+    private var cardActions: TranscriptCardActions {
+        TranscriptCardActions(
+            messages: store.messages,
+            buildModelName: buildModelName,
+            planURL: planURL,
+            onPermissionReply: { permission, reply in
+                store.replyPermission(permission, reply: reply)
+            },
+            onQuestionSubmit: { question, answers in
+                store.replyQuestion(question, answers: answers)
+            },
+            onQuestionReject: { question in
+                store.rejectQuestion(question)
+            },
+            onBuildHere: { question, feedback in
+                handleBuildHere(question, feedback: feedback)
+            },
+            onKeepPlanning: { question, feedback in
+                store.keepPlanning(question: question, feedback: feedback)
+            },
+            onOpenPage: { openPlanPage() }
+        )
     }
 
-    /// The newest pending question EXCLUDING the plan_exit question (which is
-    /// rendered by the dedicated PlanCard). Matching the exact tool callID via
-    /// `PlanDerivation.isPlanExitQuestion` — never the question text — so the
-    /// plan card and the generic question card can never appear simultaneously.
-    private var newestQuestion: QuestionRequest? {
-        store.questions.last(where: { !PlanDerivation.isPlanExitQuestion($0, in: store.messages) })
-    }
-
-    private var newestPlanQuestion: QuestionRequest? {
-        store.questions.last(where: { PlanDerivation.isPlanExitQuestion($0, in: store.messages) })
+    /// True while a blocking card is present, driving the one-time scroll to
+    /// its arrival (BET-1214).
+    private var isBlockingCardPresent: Bool {
+        store.hasBlockingCard
     }
 
     /// The deterministic plan-page URL for this session (`<base>/pages/plan-…`,
@@ -1238,11 +1241,15 @@ struct TranscriptListView<Header: View>: View {
     let bottomInset: CGFloat
     @Binding var scrollPosition: TiledScrollPosition
     var onPointsFromBottom: ((CGFloat) -> Void)? = nil
+    /// The blocking-card callbacks, threaded to the cells so cards render in
+    /// the transcript tail. Read-only surfaces (subagent drill-in) leave it
+    /// nil and render inert cards (BET-1214).
+    var cards: TranscriptCardActions? = nil
     @ViewBuilder var header: () -> Header
 
     var body: some View {
         TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
-            TranscriptBlockCell(item: row, tokens: tokens)
+            TranscriptBlockCell(item: row, tokens: tokens, cards: cards)
         }
         .prependLoader(.loader(
             perform: { store.loadEarlier() },
@@ -1414,7 +1421,7 @@ private struct TodosCard: View {
 
 // MARK: - Permission card (answerable, §7.5)
 
-private struct PermissionCard: View {
+struct PermissionCard: View {
     let permission: PermissionRequest
     let tokens: Tokens
     let onReply: (PermissionReply) -> Void
@@ -1432,13 +1439,7 @@ private struct PermissionCard: View {
                 replyButton("Allow once", reply: .once, filled: true)
                 replyButton("Allow always", reply: .always, filled: false)
                 Spacer()
-                Button {
-                    onReply(.reject)
-                } label: {
-                    Text("Reject")
-                        .font(.manta(size: Metrics.type.small, weight: .medium))
-                        .foregroundColor(tokens.danger)
-                }
+                rejectButton
             }
         }
         .padding(Metrics.spacing.sp3)
@@ -1468,6 +1469,23 @@ private struct PermissionCard: View {
                 .padding(.horizontal, Metrics.spacing.sp3)
                 .padding(.vertical, Metrics.spacing.sp2)
                 .background(filled ? tokens.accentSolid : tokens.accentSoft, in: Capsule())
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+    }
+
+    private var rejectButton: some View {
+        Button {
+            onReply(.reject)
+        } label: {
+            Text("Reject")
+                .font(.manta(size: Metrics.type.small, weight: .medium))
+                .foregroundColor(tokens.danger)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp2)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }
@@ -1475,7 +1493,7 @@ private struct PermissionCard: View {
 
 // MARK: - Question card (answerable, §7.5)
 
-private struct QuestionCard: View {
+struct QuestionCard: View {
     let question: QuestionRequest
     let tokens: Tokens
     let onSubmit: ([[String]]) -> Void
@@ -1500,8 +1518,12 @@ private struct QuestionCard: View {
                     Text(q.question)
                         .font(.manta(size: Metrics.type.body))
                         .foregroundColor(tokens.tx1)
-                    ForEach(Array(q.options.enumerated()), id: \.offset) { oi, option in
-                        optionButton(questionIndex: index, optionIndex: oi, label: option.label, multi: q.multiple == true)
+                    // Options are spaced sp2 apart (BET-1214) so each 44pt row
+                    // reads as its own target.
+                    VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+                        ForEach(Array(q.options.enumerated()), id: \.offset) { oi, option in
+                            optionButton(questionIndex: index, optionIndex: oi, label: option.label, multi: q.multiple == true)
+                        }
                     }
                 }
             }
@@ -1520,6 +1542,10 @@ private struct QuestionCard: View {
                 Button("Reject", action: onReject)
                     .font(.manta(size: Metrics.type.small, weight: .medium))
                     .foregroundColor(tokens.danger)
+                    .padding(.horizontal, Metrics.spacing.sp3)
+                    .padding(.vertical, Metrics.spacing.sp2)
+                    .frame(minHeight: 44)
+                    .contentShape(Rectangle())
                 Spacer()
                 Button { submit() } label: {
                     Text("Send")
@@ -1528,6 +1554,8 @@ private struct QuestionCard: View {
                         .padding(.horizontal, Metrics.spacing.sp3)
                         .padding(.vertical, Metrics.spacing.sp2)
                         .background(canSubmit ? AnyShapeStyle(tokens.accentSolid) : AnyShapeStyle(tokens.inset), in: Capsule())
+                        .frame(minHeight: 44)
+                        .contentShape(Rectangle())
                 }
                 .buttonStyle(.plain)
                 .disabled(!canSubmit)
@@ -1560,7 +1588,7 @@ private struct QuestionCard: View {
         } label: {
             HStack(spacing: Metrics.spacing.sp2) {
                 Image(systemName: isOn ? "checkmark.square.fill" : "square")
-                    .font(.system(size: Metrics.type.xs))
+                    .font(.system(size: Metrics.type.body))
                     .foregroundColor(isOn ? tokens.accent : tokens.tx4)
                 Text(label)
                     .font(.manta(size: Metrics.type.small))
@@ -1568,7 +1596,16 @@ private struct QuestionCard: View {
                     .multilineTextAlignment(.leading)
                 Spacer(minLength: 0)
             }
-            .padding(.vertical, Metrics.spacing.sp1)
+            // The FULL row width is the tap target — 44pt minimum (Apple's
+            // minimum hit size) and a visible surface so the target is legible,
+            // not merely present (BET-1214).
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .frame(maxWidth: .infinity, minHeight: 44, alignment: .leading)
+            .contentShape(Rectangle())
+            .background(
+                isOn ? AnyShapeStyle(tokens.accentSoft) : AnyShapeStyle(tokens.inset),
+                in: RoundedRectangle(cornerRadius: Metrics.radius.md)
+            )
         }
         .buttonStyle(.plain)
     }
@@ -1609,7 +1646,7 @@ private struct QuestionCard: View {
 /// bare text button in `tx3` (not `danger` — keeping planning is not
 /// destructive). All colours/spacing/radii/type resolve through the existing
 /// generated tokens — no new token.
-private struct PlanCard: View {
+struct PlanCard: View {
     let question: QuestionRequest
     let messages: [OpencodeMessage]
     /// The session's BUILD-model name for "Ready to build · <model>".
@@ -1696,6 +1733,8 @@ private struct PlanCard: View {
                 .padding(.horizontal, Metrics.spacing.sp3)
                 .padding(.vertical, Metrics.spacing.sp2)
                 .background(tokens.accentSolid, in: Capsule())
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }
@@ -1714,6 +1753,8 @@ private struct PlanCard: View {
             .padding(.horizontal, Metrics.spacing.sp3)
             .padding(.vertical, Metrics.spacing.sp2)
             .background(tokens.accentSoft, in: Capsule())
+            .frame(minHeight: 44)
+            .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }
@@ -1725,6 +1766,10 @@ private struct PlanCard: View {
             Text("Keep planning")
                 .font(.manta(size: Metrics.type.small, weight: .medium))
                 .foregroundColor(tokens.tx3)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.vertical, Metrics.spacing.sp2)
+                .frame(minHeight: 44)
+                .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
     }

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -311,10 +311,11 @@ private struct ChatScreenContent: View {
             // new ask is not silently missed. Fire ONCE on the no-card → card
             // transition, never per rebuild; re-arm when the card leaves.
             .onChange(of: isBlockingCardPresent) { _, nowPresent in
-                if nowPresent, !wasBlockingCardPresent {
+                let decision = ChatSessionStore.shouldScrollForCardArrival(nowPresent, wasPresent: wasBlockingCardPresent)
+                if decision.scroll {
                     scrollPosition.scrollTo(edge: .bottom, animated: true)
                 }
-                wasBlockingCardPresent = nowPresent
+                wasBlockingCardPresent = decision.present
             }
             // BET-673: fire one success haptic when a turn completes while the
             // user has scrolled up (scroll-to-bottom chip showing) and the scene
@@ -1241,16 +1242,21 @@ struct TranscriptListView<Header: View>: View {
     let bottomInset: CGFloat
     @Binding var scrollPosition: TiledScrollPosition
     var onPointsFromBottom: ((CGFloat) -> Void)? = nil
-    /// The blocking-card callbacks, threaded to the cells so cards render in
-    /// the transcript tail. Read-only surfaces (subagent drill-in) leave it
-    /// nil and render inert cards (BET-1214).
+    /// The blocking-card callbacks, threaded down to the transcript cells.
+    /// Read-only surfaces (subagent drill-in) leave the environment unset and
+    /// cards render inert (BET-1214).
     var cards: TranscriptCardActions? = nil
     @ViewBuilder var header: () -> Header
 
     var body: some View {
+        // Deliver the blocking-card actions to the cells via the environment —
+        // the cell's `body(context:)` is nonisolated, and a closure-carrying
+        // value cannot be threaded through it (Swift 6). The cells read
+        // `\.transcriptCardActions` back inside their `@MainActor` bodies.
         TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
-            TranscriptBlockCell(item: row, tokens: tokens, cards: cards)
+            TranscriptBlockCell(item: row, tokens: tokens)
         }
+        .environment(\.transcriptCardActions, cards)
         .prependLoader(.loader(
             perform: { store.loadEarlier() },
             isProcessing: store.loadingEarlier

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -763,9 +763,11 @@ private struct ChatScreenContent: View {
             bottomInset: bottomBarHeight,
             scrollPosition: $scrollPosition,
             onPointsFromBottom: { showScrollToBottom = $0 > Self.scrollToBottomThreshold },
-            cards: cardActions,
             header: { sessionHeaderBlock }
         )
+        // Deliver the blocking-card actions to the transcript cells via the
+        // SwiftUI environment (BET-1214). The subagent drill-in keeps `nil`.
+        .environment(\.transcriptCardActions, cardActions)
     }
     /// How far above the bottom the user must scroll for the down-arrow to
     /// appear. Same magnitude MessagingUI uses internally for its own "near
@@ -1242,21 +1244,17 @@ struct TranscriptListView<Header: View>: View {
     let bottomInset: CGFloat
     @Binding var scrollPosition: TiledScrollPosition
     var onPointsFromBottom: ((CGFloat) -> Void)? = nil
-    /// The blocking-card callbacks, threaded down to the transcript cells.
-    /// Read-only surfaces (subagent drill-in) leave the environment unset and
-    /// cards render inert (BET-1214).
-    var cards: TranscriptCardActions? = nil
     @ViewBuilder var header: () -> Header
 
     var body: some View {
-        // Deliver the blocking-card actions to the cells via the environment —
-        // the cell's `body(context:)` is nonisolated, and a closure-carrying
-        // value cannot be threaded through it (Swift 6). The cells read
-        // `\.transcriptCardActions` back inside their `@MainActor` bodies.
+        // The blocking-card actions are delivered to the cells through the
+        // SwiftUI environment (a closure-carrying `@MainActor` reference can't
+        // be threaded through the cell's nonisolated `body`); the enclosing chat
+        // screen injects `\.transcriptCardActions` at its call site. Read-only
+        // surfaces (subagent drill-in) leave it unset → cards render inert.
         TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
             TranscriptBlockCell(item: row, tokens: tokens)
         }
-        .environment(\.transcriptCardActions, cards)
         .prependLoader(.loader(
             perform: { store.loadEarlier() },
             isProcessing: store.loadingEarlier

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -639,17 +639,20 @@ final class ChatSessionStore: ObservableObject {
         // Terminal state of the current turn, MOVED out of the pinned area into
         // the transcript, at the end of the turn it belongs to: session errors
         // and truncations scroll WITH their turn rather than hovering over the
-        // composer.
-        var trailing: [TranscriptBlock] = []
-        if let err = sessionError {
-            trailing.append(.notice(err.message, .error))
-        }
-        if let trunc = truncation, !running {
-            trailing.append(.notice(trunc.label ?? "Response truncated", .warn))
-        }
-        // Prompts accepted mid-turn render as dim ghost bubbles at the very
-        // tail — where they will actually land once the current turn finishes.
-        trailing.append(contentsOf: queuedPrompts.map { .queuedPrompt($0.text) })
+        // composer. The blocking cards (permission / plan / question) join the
+        // tail here too, in the agreed fixed order — notices first, then
+        // permission, plan-exit, generic question, and the queued prompts LAST
+        // (they represent what happens next). See `trailingBlocks` for the
+        // pinned order.
+        let trailing = Self.trailingBlocks(
+            sessionError: sessionError,
+            truncation: truncation,
+            running: running,
+            permission: newestPermission,
+            planExitQuestion: newestPlanQuestion,
+            question: newestQuestion,
+            queuedPrompts: queuedPrompts
+        )
 
         let newRows: [TranscriptRow]
         if inProgressText.isEmpty {
@@ -685,6 +688,43 @@ final class ChatSessionStore: ObservableObject {
                 + uniqueTranscriptRows(trailing)
         }
         rows = newRows
+    }
+
+    /// Build the transcript-TAIL block array in the ONE fixed order: system
+    /// notices (session error, then truncation), the blocking cards (permission
+    /// → plan-exit → generic question), then the queued prompts LAST — they
+    /// represent what happens next and must stay at the very end. Pure and
+    /// unit-tested so the ordering cannot drift between the two rebuild
+    /// branches (BET-1214).
+    static func trailingBlocks(
+        sessionError: StreamSessionErrorPayload?,
+        truncation: StreamTruncationPayload?,
+        running: Bool,
+        permission: PermissionRequest?,
+        planExitQuestion: QuestionRequest?,
+        question: QuestionRequest?,
+        queuedPrompts: [QueuedPrompt]
+    ) -> [TranscriptBlock] {
+        var trailing: [TranscriptBlock] = []
+        if let err = sessionError {
+            trailing.append(.notice(err.message, .error))
+        }
+        if let trunc = truncation, !running {
+            trailing.append(.notice(trunc.label ?? "Response truncated", .warn))
+        }
+        if let permission {
+            trailing.append(.permission(permission))
+        }
+        if let planQ = planExitQuestion {
+            trailing.append(.planExit(planQ))
+        }
+        if let question {
+            trailing.append(.question(question))
+        }
+        // Prompts accepted mid-turn render as dim ghost bubbles at the very
+        // tail — where they will actually land once the current turn finishes.
+        trailing.append(contentsOf: queuedPrompts.map { .queuedPrompt($0.text) })
+        return trailing
     }
 
     // MARK: - Refetch
@@ -1101,11 +1141,39 @@ final class ChatSessionStore: ObservableObject {
 
     // MARK: - Header
 
-    /// The newest pending permission, if any (used by the bottom cards).
+    /// The newest pending permission, if any (rendered as a tail card).
     var newestPermission: PermissionRequest? { permissions.last }
 
-    /// The newest pending question request, if any.
-    var newestQuestion: QuestionRequest? { questions.last }
+    /// Partition the pending questions into the plan-exit one and the generic
+    /// remaining one. Pure and unit-tested so the plan card and the generic
+    /// question card can never render for the same question — the split is by
+    /// the exact tool callID (`PlanDerivation.isPlanExitQuestion`), never by
+    /// wording.
+    static func splitQuestions(
+        _ questions: [QuestionRequest],
+        messages: [OpencodeMessage]
+    ) -> (planExit: QuestionRequest?, generic: QuestionRequest?) {
+        let planExit = questions.last(where: { PlanDerivation.isPlanExitQuestion($0, in: messages) })
+        let generic = questions.last(where: { !PlanDerivation.isPlanExitQuestion($0, in: messages) })
+        return (planExit, generic)
+    }
+
+    /// The newest pending question EXCLUDING the plan_exit question (which is
+    /// rendered by the dedicated plan card).
+    var newestQuestion: QuestionRequest? {
+        Self.splitQuestions(questions, messages: messages).generic
+    }
+
+    /// The newest plan_exit question, when one is pending.
+    var newestPlanQuestion: QuestionRequest? {
+        Self.splitQuestions(questions, messages: messages).planExit
+    }
+
+    /// True when at least one blocking card (permission / plan / question) is
+    /// present, driving the one-time scroll-to-bottom on arrival (BET-1214).
+    var hasBlockingCard: Bool {
+        newestPermission != nil || newestPlanQuestion != nil || newestQuestion != nil
+    }
 
     /// When the current turn started (nil when idle). The running row measures
     /// live elapsed against its own 1s tick rather than stream-state changes

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -1175,6 +1175,16 @@ final class ChatSessionStore: ObservableObject {
         newestPermission != nil || newestPlanQuestion != nil || newestQuestion != nil
     }
 
+    /// The pure transition rule for the one-time auto-scroll when a blocking
+    /// card arrives: scroll exactly on the no-card → card edge, never on a
+    /// present→present rebuild or a card-leaving transition, and re-arm the
+    /// guard the moment a card is present (so a later card re-arrival fires
+    /// again). Unit-tested so "once per transition, not per rebuild" cannot
+    /// drift (BET-1214).
+    static func shouldScrollForCardArrival(_ nowPresent: Bool, wasPresent: Bool) -> (scroll: Bool, present: Bool) {
+        (scroll: nowPresent && !wasPresent, present: nowPresent)
+    }
+
     /// When the current turn started (nil when idle). The running row measures
     /// live elapsed against its own 1s tick rather than stream-state changes
     /// (BET-630, D1).

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -696,7 +696,9 @@ final class ChatSessionStore: ObservableObject {
     /// represent what happens next and must stay at the very end. Pure and
     /// unit-tested so the ordering cannot drift between the two rebuild
     /// branches (BET-1214).
-    static func trailingBlocks(
+    /// `nonisolated`: pure (value-in, value-out, no main-actor state), so it is
+    /// directly unit-testable from a nonisolated XCTest body.
+    nonisolated static func trailingBlocks(
         sessionError: StreamSessionErrorPayload?,
         truncation: StreamTruncationPayload?,
         running: Bool,
@@ -1149,7 +1151,9 @@ final class ChatSessionStore: ObservableObject {
     /// question card can never render for the same question — the split is by
     /// the exact tool callID (`PlanDerivation.isPlanExitQuestion`), never by
     /// wording.
-    static func splitQuestions(
+    /// `nonisolated`: pure (value-in, value-out), so it is directly
+    /// unit-testable from a nonisolated XCTest body.
+    nonisolated static func splitQuestions(
         _ questions: [QuestionRequest],
         messages: [OpencodeMessage]
     ) -> (planExit: QuestionRequest?, generic: QuestionRequest?) {
@@ -1181,7 +1185,9 @@ final class ChatSessionStore: ObservableObject {
     /// guard the moment a card is present (so a later card re-arrival fires
     /// again). Unit-tested so "once per transition, not per rebuild" cannot
     /// drift (BET-1214).
-    static func shouldScrollForCardArrival(_ nowPresent: Bool, wasPresent: Bool) -> (scroll: Bool, present: Bool) {
+    /// `nonisolated`: pure (value-in, value-out), so it is directly
+    /// unit-testable from a nonisolated XCTest body.
+    nonisolated static func shouldScrollForCardArrival(_ nowPresent: Bool, wasPresent: Bool) -> (scroll: Bool, present: Bool) {
         (scroll: nowPresent && !wasPresent, present: nowPresent)
     }
 

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -792,12 +792,24 @@ enum TranscriptBlock: Equatable {
     /// A prompt accepted mid-turn, waiting for the session to go idle. Rendered
     /// as a DIM ghost user bubble where the message will actually land.
     case queuedPrompt(String)
+    /// A pending permission request rendered as a blocking card in the
+    /// transcript tail (BET-1214). The card's callbacks come from the
+    /// surface's `TranscriptCardActions`, never from the block — a block stays
+    /// pure Equatable data so its identity survives a rebuild unchanged.
+    case permission(PermissionRequest)
+    /// The plan_exit question, upgraded into the dedicated plan card and
+    /// rendered in the transcript tail (BET-1214). Excluded from `.question`
+    /// — the two cards never coexist for the same question.
+    case planExit(QuestionRequest)
+    /// A generic pending question rendered as a card in the transcript tail
+    /// (BET-1214).
+    case question(QuestionRequest)
 
     /// The time shown in the gutter; nil for blocks that have none.
     var timestamp: Date? {
         switch self {
         case .user(_, let at), .prose(_, let at): return at
-        case .steps, .file, .notice, .queuedPrompt: return nil
+        case .steps, .file, .notice, .queuedPrompt, .permission, .planExit, .question: return nil
         }
     }
 }

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -119,8 +119,14 @@ extension StepGroupContent {
 /// unchanged from the pinned-above-composer era — only their LOCATION moved, so
 /// this struct carries the same closures ChatScreen used to hand the cards
 /// directly. It is an in-property value type with no `static` storage (see the
-/// "no static var" rule); a read-only surface just leaves `cards` nil and
-/// `transcriptBlockView` supplies inert callbacks (see `transcriptBlockView`).
+/// "no static var" rule).
+///
+/// Delivered through the SwiftUI ENVIRONMENT, not stored on the transcript cell:
+/// the `TiledCellContent` cell's `body(context:)` is required to be
+/// `nonisolated` (Swift 6), so a closure-carrying value can't be threaded as a
+/// stored cell property across that boundary. The parent injects it via
+/// `.environment(\.transcriptCardActions, …)` and only a `@MainActor`
+/// `View.body` ever reads it.
 struct TranscriptCardActions {
     /// The raw transcript the plan card's exact derivation reads.
     var messages: [OpencodeMessage]
@@ -134,6 +140,21 @@ struct TranscriptCardActions {
     var onBuildHere: (QuestionRequest, String) -> Void
     var onKeepPlanning: (QuestionRequest, String) -> Void
     var onOpenPage: () -> Void
+}
+
+/// The environment key carrying the blocking-card actions into transcript cells.
+private struct TranscriptCardActionsKey: EnvironmentKey {
+    static let defaultValue: TranscriptCardActions? = nil
+}
+
+extension EnvironmentValues {
+    /// The blocking-card callbacks for the current transcript surface, or nil
+    /// on read-only surfaces (subagent drill-in, capture fixture) where cards
+    /// render inert.
+    var transcriptCardActions: TranscriptCardActions? {
+        get { self[TranscriptCardActionsKey.self] }
+        set { self[TranscriptCardActionsKey.self] = newValue }
+    }
 }
 
 // MARK: - Cell
@@ -153,7 +174,6 @@ struct TranscriptBlockCell: TiledCellContent {
 
     let item: TranscriptRow
     let tokens: Tokens
-    var cards: TranscriptCardActions?
 
     func body(context: CellContext<Void>) -> some View {
         // The reveal offset now comes from MessagingUI's OWN pan recogniser, which
@@ -167,11 +187,15 @@ struct TranscriptBlockCell: TiledCellContent {
         // protocol conformance as a data-race), so the main-actor reveal state is
         // passed down to `TranscriptCellReveal`, whose own `View.body` runs on the
         // main actor and can read `rubberbandedOffset(max:)`.
+        //
+        // The blocking-card actions are NOT threaded through this nonisolated
+        // body — a closure-carrying value can't cross it. They arrive via the
+        // SwiftUI environment and are read inside `TranscriptCellReveal.body`
+        // (main actor) (BET-1214).
         TranscriptCellReveal(
             cellReveal: context.cellReveal,
             item: item,
-            tokens: tokens,
-            cards: cards
+            tokens: tokens
         )
     }
 }
@@ -184,7 +208,11 @@ private struct TranscriptCellReveal: View {
     let cellReveal: CellReveal?
     let item: TranscriptRow
     let tokens: Tokens
-    let cards: TranscriptCardActions?
+    /// The blocking-card callbacks, injected by the enclosing chat screen via
+    /// `.environment(\.transcriptCardActions, …)` — read only on the main actor
+    /// here, so it never crosses the nonisolated cell boundary. Nil on
+    /// read-only surfaces (subagent drill-in, capture fixture).
+    @Environment(\.transcriptCardActions) private var cardActions
 
     var body: some View {
         let reveal = cellReveal?.rubberbandedOffset(max: TranscriptGutter.gutterWidth) ?? 0
@@ -209,12 +237,13 @@ private struct TranscriptCellReveal: View {
             .accessibilityIdentifier(TranscriptGutter.rowAccessibilityID)
     }
 
+    @MainActor
     @ViewBuilder
     private var cellContent: some View {
         if case .prose(let text, nil) = item.block {
             LiveProseTail(text: text, tokens: tokens)
         } else {
-            transcriptBlockView(item.block, tokens: tokens, cards: cards)
+            transcriptBlockView(item.block, tokens: tokens, cards: cardActions)
         }
     }
 }
@@ -222,9 +251,13 @@ private struct TranscriptCellReveal: View {
 /// The ONE transcript block renderer, shared by every surface — the live
 /// TiledView cell (`TranscriptBlockCell`) and the legacy `TranscriptView` the
 /// capture fixture still uses. There is deliberately no second switch anywhere.
-/// The blocking cards take their callbacks from `cards`; a read-only surface
-/// passes nil and the cards render inert (a no-op, never wiring to a live
-/// store). A block itself never carries closures.
+///
+/// `@MainActor`: the blocking cards are main-actor views whose callbacks touch a
+/// `@MainActor` store, and the cards' closures are not `Sendable` — so this
+/// function must run on the main actor (both callers are `@MainActor`
+/// `View.body`s). The card actions come from `cards` (nil on read-only
+/// surfaces → the cards render inert, never wiring to a live store).
+@MainActor
 @ViewBuilder
 func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: TranscriptCardActions? = nil) -> some View {
     // The inert action set a read-only surface falls back to: every card

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -117,29 +117,52 @@ extension StepGroupContent {
 /// The callbacks + context the blocking cards need when they render inside the
 /// transcript tail (BET-1214). The cards' behaviour, copy and callbacks are
 /// unchanged from the pinned-above-composer era — only their LOCATION moved, so
-/// this struct carries the same closures ChatScreen used to hand the cards
-/// directly. It is an in-property value type with no `static` storage (see the
-/// "no static var" rule).
+/// this type carries the same closures ChatScreen used to hand the cards
+/// directly.
 ///
-/// Delivered through the SwiftUI ENVIRONMENT, not stored on the transcript cell:
-/// the `TiledCellContent` cell's `body(context:)` is required to be
-/// `nonisolated` (Swift 6), so a closure-carrying value can't be threaded as a
-/// stored cell property across that boundary. The parent injects it via
-/// `.environment(\.transcriptCardActions, …)` and only a `@MainActor`
-/// `View.body` ever reads it.
-struct TranscriptCardActions {
+/// A `@MainActor final class` (not a struct): it holds main-actor-bound closures
+/// that touch a `@MainActor` store, and the transcript cell's `body(context:)`
+/// is required by `TiledCellContent` to be `nonisolated`, so the card actions
+/// are delivered through the SwiftUI environment — an actor-isolated reference
+/// type is implicitly `Sendable`, which is exactly what an `EnvironmentKey`
+/// `static` default and a cross-view round-trip need, while everything reads the
+/// closures on the main actor only.
+@MainActor
+final class TranscriptCardActions {
     /// The raw transcript the plan card's exact derivation reads.
-    var messages: [OpencodeMessage]
+    let messages: [OpencodeMessage]
     /// The session's BUILD-model name for the plan card's subtitle.
-    var buildModelName: String
+    let buildModelName: String
     /// The deterministic plan-page URL (nil when no usable slug can be formed).
-    var planURL: String?
-    var onPermissionReply: (PermissionRequest, PermissionReply) -> Void
-    var onQuestionSubmit: (QuestionRequest, [[String]]) -> Void
-    var onQuestionReject: (QuestionRequest) -> Void
-    var onBuildHere: (QuestionRequest, String) -> Void
-    var onKeepPlanning: (QuestionRequest, String) -> Void
-    var onOpenPage: () -> Void
+    let planURL: String?
+    let onPermissionReply: (PermissionRequest, PermissionReply) -> Void
+    let onQuestionSubmit: (QuestionRequest, [[String]]) -> Void
+    let onQuestionReject: (QuestionRequest) -> Void
+    let onBuildHere: (QuestionRequest, String) -> Void
+    let onKeepPlanning: (QuestionRequest, String) -> Void
+    let onOpenPage: () -> Void
+
+    init(
+        messages: [OpencodeMessage],
+        buildModelName: String,
+        planURL: String?,
+        onPermissionReply: @escaping (PermissionRequest, PermissionReply) -> Void,
+        onQuestionSubmit: @escaping (QuestionRequest, [[String]]) -> Void,
+        onQuestionReject: @escaping (QuestionRequest) -> Void,
+        onBuildHere: @escaping (QuestionRequest, String) -> Void,
+        onKeepPlanning: @escaping (QuestionRequest, String) -> Void,
+        onOpenPage: @escaping () -> Void
+    ) {
+        self.messages = messages
+        self.buildModelName = buildModelName
+        self.planURL = planURL
+        self.onPermissionReply = onPermissionReply
+        self.onQuestionSubmit = onQuestionSubmit
+        self.onQuestionReject = onQuestionReject
+        self.onBuildHere = onBuildHere
+        self.onKeepPlanning = onKeepPlanning
+        self.onOpenPage = onOpenPage
+    }
 }
 
 /// The environment key carrying the blocking-card actions into transcript cells.

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -58,6 +58,13 @@ extension TranscriptBlock {
         case .steps(let content): return "s" + (content.rows.first?.id ?? "empty")
         case .notice(let text, let kind): return "n\(kind)\(text.hashValue)"
         case .queuedPrompt(let text): return "q\(text.hashValue)"
+        // Cards key on the REQUEST id — stable and unique. Do NOT hash content:
+        // a card whose text is edited mid-flight would change identity and cause
+        // a delete+insert in the list. The prefixes are distinct so a question
+        // and a plan-exit question carrying the same id never collide (BET-1214).
+        case .permission(let p): return "pm" + p.id
+        case .planExit(let q): return "px" + q.id
+        case .question(let q): return "qq" + q.id
         }
     }
 }
@@ -107,6 +114,28 @@ extension StepGroupContent {
     }
 }
 
+/// The callbacks + context the blocking cards need when they render inside the
+/// transcript tail (BET-1214). The cards' behaviour, copy and callbacks are
+/// unchanged from the pinned-above-composer era — only their LOCATION moved, so
+/// this struct carries the same closures ChatScreen used to hand the cards
+/// directly. It is an in-property value type with no `static` storage (see the
+/// "no static var" rule); a read-only surface just leaves `cards` nil and
+/// `transcriptBlockView` supplies inert callbacks (see `transcriptBlockView`).
+struct TranscriptCardActions {
+    /// The raw transcript the plan card's exact derivation reads.
+    var messages: [OpencodeMessage]
+    /// The session's BUILD-model name for the plan card's subtitle.
+    var buildModelName: String
+    /// The deterministic plan-page URL (nil when no usable slug can be formed).
+    var planURL: String?
+    var onPermissionReply: (PermissionRequest, PermissionReply) -> Void
+    var onQuestionSubmit: (QuestionRequest, [[String]]) -> Void
+    var onQuestionReject: (QuestionRequest) -> Void
+    var onBuildHere: (QuestionRequest, String) -> Void
+    var onKeepPlanning: (QuestionRequest, String) -> Void
+    var onOpenPage: () -> Void
+}
+
 // MARK: - Cell
 
 /// Renders ONE transcript block inside `TiledView`, reusing the same
@@ -124,6 +153,7 @@ struct TranscriptBlockCell: TiledCellContent {
 
     let item: TranscriptRow
     let tokens: Tokens
+    var cards: TranscriptCardActions?
 
     func body(context: CellContext<Void>) -> some View {
         // The reveal offset now comes from MessagingUI's OWN pan recogniser, which
@@ -140,7 +170,8 @@ struct TranscriptBlockCell: TiledCellContent {
         TranscriptCellReveal(
             cellReveal: context.cellReveal,
             item: item,
-            tokens: tokens
+            tokens: tokens,
+            cards: cards
         )
     }
 }
@@ -153,6 +184,7 @@ private struct TranscriptCellReveal: View {
     let cellReveal: CellReveal?
     let item: TranscriptRow
     let tokens: Tokens
+    let cards: TranscriptCardActions?
 
     var body: some View {
         let reveal = cellReveal?.rubberbandedOffset(max: TranscriptGutter.gutterWidth) ?? 0
@@ -182,7 +214,7 @@ private struct TranscriptCellReveal: View {
         if case .prose(let text, nil) = item.block {
             LiveProseTail(text: text, tokens: tokens)
         } else {
-            transcriptBlockView(item.block, tokens: tokens)
+            transcriptBlockView(item.block, tokens: tokens, cards: cards)
         }
     }
 }
@@ -190,8 +222,24 @@ private struct TranscriptCellReveal: View {
 /// The ONE transcript block renderer, shared by every surface — the live
 /// TiledView cell (`TranscriptBlockCell`) and the legacy `TranscriptView` the
 /// capture fixture still uses. There is deliberately no second switch anywhere.
+/// The blocking cards take their callbacks from `cards`; a read-only surface
+/// passes nil and the cards render inert (a no-op, never wiring to a live
+/// store). A block itself never carries closures.
 @ViewBuilder
-func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens) -> some View {
+func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: TranscriptCardActions? = nil) -> some View {
+    // The inert action set a read-only surface falls back to: every card
+    // renders harmlessly but no closure reaches a live store.
+    let actions = cards ?? TranscriptCardActions(
+        messages: [],
+        buildModelName: "",
+        planURL: nil,
+        onPermissionReply: { _, _ in },
+        onQuestionSubmit: { _, _ in },
+        onQuestionReject: { _ in },
+        onBuildHere: { _, _ in },
+        onKeepPlanning: { _, _ in },
+        onOpenPage: {}
+    )
     switch block {
     case .user(let text, _):
         UserBand(text: text, tokens: tokens)
@@ -222,6 +270,33 @@ func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens) -> some View 
         UserBand(text: text, tokens: tokens)
             .opacity(0.45)
             .padding(.bottom, Metrics.spacing.sp4)
+    case .permission(let permission):
+        PermissionCard(permission: permission, tokens: tokens) { reply in
+            actions.onPermissionReply(permission, reply)
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.bottom, Metrics.spacing.sp3)
+    case .planExit(let question):
+        PlanCard(
+            question: question,
+            messages: actions.messages,
+            buildModelName: actions.buildModelName,
+            planURL: actions.planURL,
+            tokens: tokens,
+            onBuildHere: { feedback in actions.onBuildHere(question, feedback) },
+            onKeepPlanning: { feedback in actions.onKeepPlanning(question, feedback) },
+            onOpenPage: actions.onOpenPage
+        )
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.bottom, Metrics.spacing.sp3)
+    case .question(let question):
+        QuestionCard(question: question, tokens: tokens) { answers in
+            actions.onQuestionSubmit(question, answers)
+        } onReject: {
+            actions.onQuestionReject(question)
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.bottom, Metrics.spacing.sp3)
     }
 }
 

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -821,3 +821,114 @@ final class CompactConfirmGateTests: XCTestCase {
                       "a compact proceeds only after the confirm sheet's destructive action")
     }
 }
+
+// MARK: - Blocking-card tail ordering + question split (BET-1214)
+
+final class TrailingCardsTests: XCTestCase {
+
+    private func cardPermission(_ id: String) -> PermissionRequest {
+        PermissionRequest(id: id, sessionID: "ses", permission: "Shell", patterns: nil, always: nil, metadata: nil, tool: nil)
+    }
+
+    private func cardQuestion(_ id: String) -> QuestionRequest {
+        QuestionRequest(id: id, sessionID: "ses", questions: [], tool: nil, requestId: nil)
+    }
+
+    private func queued(_ text: String) -> QueuedPrompt {
+        QueuedPrompt(text: text, attachments: [], model: nil, mentions: nil, agent: nil)
+    }
+
+    private func kind(_ block: TranscriptBlock) -> String {
+        switch block {
+        case .notice: return "notice"
+        case .permission: return "permission"
+        case .planExit: return "planExit"
+        case .question: return "question"
+        case .queuedPrompt: return "queuedPrompt"
+        default: return "other"
+        }
+    }
+
+    func testTrailingOrderIsNoticesThenPermissionThenPlanThenQuestionThenQueued() {
+        let blocks = ChatSessionStore.trailingBlocks(
+            sessionError: StreamSessionErrorPayload(name: nil, message: "boom"),
+            truncation: StreamTruncationPayload(kind: "", label: "trunc", messageID: nil),
+            running: false,
+            permission: cardPermission("p"),
+            planExitQuestion: cardQuestion("pe"),
+            question: cardQuestion("q"),
+            queuedPrompts: [queued("next")]
+        )
+        XCTAssertEqual(blocks.map(kind),
+                       ["notice", "notice", "permission", "planExit", "question", "queuedPrompt"],
+                       "tail order is fixed: notices → permission → planExit → question → queuedPrompts")
+    }
+
+    func testTruncationNoticeSuppressedWhileRunning() {
+        let blocks = ChatSessionStore.trailingBlocks(
+            sessionError: nil,
+            truncation: StreamTruncationPayload(kind: "", label: "trunc", messageID: nil),
+            running: true,
+            permission: nil, planExitQuestion: nil, question: nil, queuedPrompts: [])
+        XCTAssertEqual(blocks.map(kind), [],
+                       "a truncation notice must not render while the turn is still running")
+    }
+
+    func testOmittedCardsProduceNoBlocks() {
+        let blocks = ChatSessionStore.trailingBlocks(
+            sessionError: nil, truncation: nil, running: false,
+            permission: nil, planExitQuestion: nil, question: nil, queuedPrompts: [])
+        XCTAssertEqual(blocks, [])
+    }
+
+    func testQueuedPromptsStayLastBehindEveryCard() {
+        let blocks = ChatSessionStore.trailingBlocks(
+            sessionError: nil, truncation: nil, running: false,
+            permission: cardPermission("p"), planExitQuestion: cardQuestion("pe"), question: cardQuestion("q"),
+            queuedPrompts: [queued("a"), queued("b")])
+        let kinds = blocks.map(kind)
+        XCTAssertEqual(kinds.last, "queuedPrompt",
+                       "queued prompts represent what happens next and must stay at the very end")
+        XCTAssertEqual(kinds.filter { $0 == "queuedPrompt" }.count, 2)
+    }
+
+    // MARK: - splitQuestions (plan card never coexists with generic question card)
+
+    private func planExitQuestion(_ id: String, callID: String) -> QuestionRequest {
+        QuestionRequest(id: id, sessionID: "ses", questions: [],
+                        tool: PermissionTool(messageID: "m1", callID: callID), requestId: nil)
+    }
+
+    private func planMessage(callID: String) -> OpencodeMessage {
+        OpencodeMessage(
+            info: OpencodeMessageInfo(id: "m1", sessionID: "ses", role: .assistant,
+                                      time: OpencodeTime(created: 0)),
+            parts: [OpencodePart(type: "tool", id: "p1", messageID: "m1",
+                                 extra: ["tool": .string("plan_exit"), "callID": .string(callID)])]
+        )
+    }
+
+    func testSplitQuestionsPutsPlanExitApartFromGeneric() {
+        let pe = planExitQuestion("pe", callID: "call-exit")
+        let plain = cardQuestion("plain")
+        let split = ChatSessionStore.splitQuestions([pe, plain], messages: [planMessage(callID: "call-exit")])
+        XCTAssertEqual(split.planExit?.id, "pe")
+        XCTAssertEqual(split.generic?.id, "plain",
+                       "the plan-exit and the generic question card must render different questions")
+    }
+
+    func testSplitQuestionsNeverReturnsTheSameQuestionAsBoth() {
+        let pe = planExitQuestion("pe", callID: "call-exit")
+        let split = ChatSessionStore.splitQuestions([pe], messages: [planMessage(callID: "call-exit")])
+        XCTAssertEqual(split.planExit?.id, "pe")
+        XCTAssertNil(split.generic,
+                     "a plan-exit question must never also surface as a generic question card")
+    }
+
+    func testSplitQuestionsOfAPlainQuestionHasNoPlanExit() {
+        let plain = cardQuestion("plain")
+        let split = ChatSessionStore.splitQuestions([plain], messages: [planMessage(callID: "call-exit")])
+        XCTAssertNil(split.planExit)
+        XCTAssertEqual(split.generic?.id, "plain")
+    }
+}

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -932,3 +932,29 @@ final class TrailingCardsTests: XCTestCase {
         XCTAssertEqual(split.generic?.id, "plain")
     }
 }
+
+final class CardScrollTriggerTests: XCTestCase {
+    func testScrollsOnNoCardToCardTransitionOnly() {
+        let noToCard = ChatSessionStore.shouldScrollForCardArrival(true, wasPresent: false)
+        XCTAssertTrue(noToCard.scroll, "entering a card from no-card must scroll once")
+        XCTAssertTrue(noToCard.present, "the guard re-arms to present after the edge")
+    }
+
+    func testDoesNotScrollOnPresentToPresentRebuild() {
+        let rebuild = ChatSessionStore.shouldScrollForCardArrival(true, wasPresent: true)
+        XCTAssertFalse(rebuild.scroll, "a card that stays present across rebuilds must not re-scroll")
+        XCTAssertTrue(rebuild.present)
+    }
+
+    func testDoesNotScrollWhenCardLeaves() {
+        let leaving = ChatSessionStore.shouldScrollForCardArrival(false, wasPresent: true)
+        XCTAssertFalse(leaving.scroll, "a card leaving must not scroll")
+        XCTAssertFalse(leaving.present, "the guard clears so a later arrival fires again")
+    }
+
+    func testDoesNotScrollWhenNeither() {
+        let neither = ChatSessionStore.shouldScrollForCardArrival(false, wasPresent: false)
+        XCTAssertFalse(neither.scroll)
+        XCTAssertFalse(neither.present)
+    }
+}

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -933,28 +933,36 @@ final class TrailingCardsTests: XCTestCase {
     }
 }
 
-final class CardScrollTriggerTests: XCTestCase {
-    func testScrollsOnNoCardToCardTransitionOnly() {
-        let noToCard = ChatSessionStore.shouldScrollForCardArrival(true, wasPresent: false)
-        XCTAssertTrue(noToCard.scroll, "entering a card from no-card must scroll once")
-        XCTAssertTrue(noToCard.present, "the guard re-arms to present after the edge")
+// MARK: - Blocking-card arrival scroll trigger (BET-1214)
+
+final class CardArrivalScrollTriggerTests: XCTestCase {
+
+    func testScrollFiresOnceOnNoCardToCardTransition() {
+        // absent → present: scroll, and re-arm (present = true).
+        let edge = ChatSessionStore.shouldScrollForCardArrival(true, wasPresent: false)
+        XCTAssertTrue(edge.scroll, "the no-card → card transition must auto-scroll")
+        XCTAssertTrue(edge.present, "the guard re-arms once a card is present")
     }
 
-    func testDoesNotScrollOnPresentToPresentRebuild() {
-        let rebuild = ChatSessionStore.shouldScrollForCardArrival(true, wasPresent: true)
-        XCTAssertFalse(rebuild.scroll, "a card that stays present across rebuilds must not re-scroll")
-        XCTAssertTrue(rebuild.present)
+    func testNoScrollOnPresentToPresentRebuilds() {
+        let steady = ChatSessionStore.shouldScrollForCardArrival(true, wasPresent: true)
+        XCTAssertFalse(steady.scroll, "a present→present rebuild must NOT re-scroll (once per transition, not per rebuild)")
+        XCTAssertTrue(steady.present)
     }
 
-    func testDoesNotScrollWhenCardLeaves() {
+    func testNoScrollWhenCardLeaves() {
         let leaving = ChatSessionStore.shouldScrollForCardArrival(false, wasPresent: true)
         XCTAssertFalse(leaving.scroll, "a card leaving must not scroll")
-        XCTAssertFalse(leaving.present, "the guard clears so a later arrival fires again")
+        XCTAssertFalse(leaving.present, "the guard disarms so the NEXT arrival re-arms")
     }
 
-    func testDoesNotScrollWhenNeither() {
-        let neither = ChatSessionStore.shouldScrollForCardArrival(false, wasPresent: false)
-        XCTAssertFalse(neither.scroll)
-        XCTAssertFalse(neither.present)
+    func testCardReArrivalScrollsAgain() {
+        // absent → present (scroll, arm) → absent (disarm) → present (scroll).
+        let first = ChatSessionStore.shouldScrollForCardArrival(true, wasPresent: false)
+        let leaving = ChatSessionStore.shouldScrollForCardArrival(false, wasPresent: first.present)
+        let second = ChatSessionStore.shouldScrollForCardArrival(true, wasPresent: leaving.present)
+        XCTAssertTrue(first.scroll, "first arrival scrolls")
+        XCTAssertFalse(leaving.scroll)
+        XCTAssertTrue(second.scroll, "a later re-arrival after a leave scrolls again")
     }
 }

--- a/mobile/native/MantaUITests/ChatTranscriptTests.swift
+++ b/mobile/native/MantaUITests/ChatTranscriptTests.swift
@@ -597,6 +597,61 @@ final class ChatTranscriptTests: XCTestCase {
                        "non-colliding blocks must keep their content-stable ids unchanged")
     }
 
+    // MARK: - Blocking-card row identity (BET-1214)
+    //
+    // Permission / plan / question cards now live in the transcript tail. They
+    // key their row id on the REQUEST id (stable + unique) rather than hashing
+    // content, so an edited card text mid-flight never changes the row's
+    // identity (which would delete+insert the card in the list).
+
+    private func cardPermission(_ id: String) -> PermissionRequest {
+        PermissionRequest(id: id, sessionID: "ses", permission: "Shell", patterns: nil, always: nil, metadata: nil, tool: nil)
+    }
+
+    private func cardQuestion(_ id: String) -> QuestionRequest {
+        QuestionRequest(id: id, sessionID: "ses", questions: [], tool: nil, requestId: nil)
+    }
+
+    func testCardStableScrollIDsAreStableAcrossRebuilds() {
+        let blocks: [TranscriptBlock] = [
+            .permission(cardPermission("p1")),
+            .planExit(cardQuestion("q1")),
+            .question(cardQuestion("q2")),
+        ]
+        let first = uniqueTranscriptRows(blocks).map(\.id)
+        let second = uniqueTranscriptRows(blocks).map(\.id)
+        XCTAssertEqual(first, second,
+                       "card ids must be stable across rebuilds so the diff stays stable")
+    }
+
+    func testPlanExitAndQuestionCardsDifferForSameRequestId() {
+        let q = cardQuestion("shared")
+        XCTAssertNotEqual(
+            TranscriptBlock.planExit(q).stableScrollID,
+            TranscriptBlock.question(q).stableScrollID,
+            "a plan-exit card and a generic question card must never share a row id"
+        )
+    }
+
+    func testCardKindsDoNotCollideOnAnIdenticalId() {
+        let rows = uniqueTranscriptRows([
+            .permission(cardPermission("x")),
+            .planExit(cardQuestion("x")),
+            .question(cardQuestion("x")),
+        ])
+        XCTAssertEqual(Set(rows.map(\.id)).count, 3,
+                       "three card kinds sharing an id string must still be distinct rows")
+    }
+
+    func testPermissionCardIDsAreStableAndUniquePerRequest() {
+        let rows = uniqueTranscriptRows([
+            .permission(cardPermission("a")),
+            .permission(cardPermission("b")),
+        ])
+        XCTAssertEqual(rows.map(\.id), ["pma", "pmb"],
+                       "permission row ids key on the request id")
+    }
+
     // MARK: - Step-group identity (BET-1103)
     //
     // A step group grows by appending rows. Its id must therefore be fixed for the


### PR DESCRIPTION
## What

Move the three blocking cards (permission / plan / question) out of the pinned bottom stack and into the transcript tail as normal `TranscriptBlock` rows, and bring every control in the three cards up to Apple's 44pt minimum tap target.

**Part 1 — cards in the tail**
- New `TranscriptBlock` cases `.permission`, `.planExit`, `.question` (TranscriptComponents.swift).
- `stableScrollID` keys on the request id (`pm`, `px`, `qq` prefixes) — not hashed content, so an edited card text never deletes+inserts the row.
- `transcriptBlockView` routes each case to the existing `PermissionCard`/`PlanCard`/`QuestionCard` (behaviour, copy, callbacks unchanged).
- `rebuildBlocks` appends tail order `notices → permission → planExit → question → queuedPrompts`; queued prompts stay last.
- Selectors moved into the store (`newestPermission`, `newestPlanQuestion`, `newestQuestion` excluding plan-exit) with a pure `splitQuestions` split; `hasBlockingCard` drives the scroll trigger.
- `bottomCards` keeps only the weekly banner + `TodosCard` (ambient, not blocking).
- Auto-scroll: `hasBlockingCard` no-card→card edge fires `scrollTo(bottom)` **once per transition** via pure `shouldScrollForCardArrival`, never per rebuild.

**Concurrency note (Swift 6).** The card actions are delivered to the cells through the SwiftUI environment (`TranscriptCardActions` is a `@MainActor` reference type, implicitly `Sendable`) and read only inside the cell's `@MainActor` `View.body` — the `TiledCellContent` cell `body(context:)` is protocol-required nonisolated, so a closure-carrying value can't be threaded through it. Built against a clean clone; only the pure store helpers were made `nonisolated` for testability.

**Part 2 — 44pt tap targets** in all three cards: every option row / button `.frame(minHeight: 44)` + `.contentShape(Rectangle())`, visible option surfaces (inset / accentSoft, radius md, sp3 hpad), sp2 option spacing, checkbox glyph raised to `Metrics.type.body` (15). No new token, no copy change, answer semantics untouched.

## Verification results

- **Base**: `origin/main` @ `193caee4`.
- **iOS native unit suite** (`ios-mantaui` `test-unit`, iPhone 17 Pro, MantaUITests only — the deterministic merge gate): **PASS**. Both bundles compiled; app + the new BET-1214 tests all green (vs the prior 577-test baseline). Earlier failing runs on this branch were Swift 6 concurrency/compile errors, fixed in later commits — the end state builds clean.
- Visual simulator check + hand-off to BET-1208 follows in a comment.
- JS typecheck/test: not re-run (diff is Swift-only under `mobile/native/`; no JS/TS surface touched — `typecheck-test` CI gate unaffected by path filter).
