### PR TITLE
fix(renderer): hide ModelLedgerCard on fetch error instead of upgrade sentence (BET-1224)

### DIFF
--- a/src/renderer/ModelLedgerCard.test.tsx
+++ b/src/renderer/ModelLedgerCard.test.tsx
@@ -59,6 +59,15 @@ describe("ModelLedgerCard", () => {
     expect(text).not.toContain("$");
   });
 
+  it("hides the card entirely when the fetch rejects (network error)", async () => {
+    installMockApi({
+      ledgerSummary: () => Promise.reject(new Error("network down")),
+    });
+    h = mount(<ModelLedgerCard />);
+    await h.flush();
+    expect(h.text()).toBe("");
+  });
+
   it("renders the four legend entries and the top-model row from a fixture summary", async () => {
     installMockApi({ ledgerSummary: () => Promise.resolve(fixture()) });
     h = mount(<ModelLedgerCard />);

--- a/src/renderer/ModelLedgerCard.tsx
+++ b/src/renderer/ModelLedgerCard.tsx
@@ -5,8 +5,11 @@
 // user can finally SEE that most of their bill is prompt cache, and which
 // model / agent runs on what. No routing, no controls that mutate anything.
 //
-// Three states, each honest:
+// Four states, each honest:
 //   - loading  → "Reading your history…"
+//   - fetch rejected (network error) → render nothing (hide the card entirely)
+//     — no card, no numbers, no sentence. A transient network glitch must not
+//     read as "your runtime is outdated".
 //   - { supported:false } → "Spend history needs a newer box runtime." — NO
 //     zeros. A card full of $0.00 would read "you spent nothing", which is a
 //     lie.
@@ -46,23 +49,25 @@ function Numeric({
 
 export function ModelLedgerCard() {
   // loading=true until the first resolution below; data is null until then.
-  const [state, setState] = useState<{ loading: boolean; data: LedgerData | null }>({
-    loading: true,
-    data: null,
-  });
+  const [state, setState] = useState<{
+    loading: boolean;
+    data: LedgerData | null;
+    fetchError: boolean;
+  }>({ loading: true, data: null, fetchError: false });
 
   useEffect(() => {
     let alive = true;
     window.api
       .ledgerSummary()
       .then((r: LedgerData) => {
-        if (alive) setState({ loading: false, data: r });
+        if (alive) setState({ loading: false, data: r, fetchError: false });
       })
       .catch(() => {
         // Fetch failed (not "unsupported" — that comes back as a resolved
         // { supported:false }). Don't show the upgrade sentence for a network
-        // error; hide the card rather than fabricate a bill.
-        if (alive) setState({ loading: false, data: null });
+        // error; hide the card entirely rather than fabricate a bill or mislead
+        // the user into thinking their runtime is outdated.
+        if (alive) setState({ loading: false, data: null, fetchError: true });
       });
     return () => {
       alive = false;
@@ -79,6 +84,10 @@ export function ModelLedgerCard() {
         <div className="text-meta text-text-faint">Reading your history…</div>
       </Card>
     );
+  }
+
+  if (state.fetchError) {
+    return null;
   }
 
   const data = state.data;


### PR DESCRIPTION
## BET-1224 — ModelLedgerCard: hide card on fetch error instead of the upgrade sentence

**Files changed:** 2 files.
```
src/renderer/ModelLedgerCard.tsx
src/renderer/ModelLedgerCard.test.tsx
```

**Base: origin/main @ `854c6c2c`**

### What changed
The fetch `catch` path set `data: null`, and the render's `if (!data || !data.supported)` then showed the **upgrade sentence** ("Spend history needs a newer box runtime.") — so a transient network error misled the user into thinking their box runtime was outdated, contradicting the code's own documented intent.

Added a distinct `fetchError` state. Now:
- Fetch **rejection** (network error) → render `null` (hide the card entirely — no card, no numbers, no sentence).
- Resolved `{ supported:false }` → keeps the upgrade sentence (the genuine unsupported-runtime case).
- `loading` and loaded states unchanged.

### Anti-spaghetti
Single component, single call site of the fetch; no duplicated logic. The `!data || !data.supported` guard is still a type-safety net but the `null` path (fetch error) is now unreachable past the `fetchError` early return.

### New test
`renders nothing when the fetch rejects` — installs a rejecting `ledgerSummary` mock and asserts the container is empty.

**Verification results:**
- PR branch (`multica/BET-1224-hide-ledger-card-on-error` @ `55a98f34`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2563 pass / 0 fail / 0 skip. Failures: none. log sha256: `89d41879d649eb0c2bb7aa4b39d07c5c0f58ac59ad37f86d146e86ccb6852868`
- Base (`main` @ `854c6c2c`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, pass/fail green. Failures: none. log sha256: `a865610fd895c1aae97b29f92ce54edc911f955f49c9003d5cad7544d4364f71`
- **Conclusion:** 0 new failures; 0 pre-existing failures; 0 resolved.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
