### PR TITLE
feat(router): wire main-conversation routing into the routed pill (BET-1225)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -822,7 +822,7 @@ describe("ChatPanel main-conversation routing (BET-1225)", () => {
     // The routed model is threaded through the existing prompt's modelOverride.
     const promptCall = api.calls["opencodePrompt"]?.[0];
     expect(promptCall?.[0]).toBe("ses_test");
-    expect(promptCall?.[2]?.modelID).toBe("claude-sonnet-4-6");
+    expect((promptCall?.[2] as { modelID?: string } | undefined)?.modelID).toBe("claude-sonnet-4-6");
   });
 
   it("leaves the prompt's model untouched when the decision is a no-op (BET-1225)", async () => {

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -761,6 +761,102 @@ describe("ChatPanel composer submit", () => {
   });
 });
 
+// ===== Main-conversation routing populates the routed pill (BET-1225) =====
+//
+// The server's routing decision for the session is fetched once on mount. When
+// it actually changed the model, ChatPanel applies the routed model as the
+// active override (so the next prompt runs on it) and populates `routed` so the
+// composer renders the undoable pill. A null / no-op decision leaves routing
+// silent and the prompt's model untouched.
+describe("ChatPanel main-conversation routing (BET-1225)", () => {
+  let api: MockApi;
+  let h: Harness | null = null;
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function typeInto(el: HTMLTextAreaElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  it("applies a changed routing decision as the active model for the next prompt (BET-1225)", async () => {
+    ({ api } = installMockApi({
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+      opencodeModelRoute: () =>
+        Promise.resolve({
+          model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+          reason: "build → balanced tier: anthropic quota ample",
+          incumbent: { providerID: "anthropic", modelID: "claude-opus-4-5" },
+          changed: true,
+        }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    // The routing RPC ran once per session start with the session-scoped agent.
+    const routeCalls = api.calls["opencodeModelRoute"] ?? [];
+    expect(routeCalls.length).toBeGreaterThan(0);
+    // No persisted per-session model / config default in the test harness →
+    // the incumbent (the model the session would otherwise use) is null.
+    expect(routeCalls[0][0]).toBeNull();
+
+    const textarea = h.container.querySelector("textarea");
+    await act(async () => {
+      typeInto(textarea as HTMLTextAreaElement, "hello");
+    });
+    await act(async () => {
+      (textarea as HTMLTextAreaElement).dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await h.flush();
+
+    // The routed model is threaded through the existing prompt's modelOverride.
+    const promptCall = api.calls["opencodePrompt"]?.[0];
+    expect(promptCall?.[0]).toBe("ses_test");
+    expect(promptCall?.[2]?.modelID).toBe("claude-sonnet-4-6");
+  });
+
+  it("leaves the prompt's model untouched when the decision is a no-op (BET-1225)", async () => {
+    ({ api } = installMockApi({
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+      opencodeModelRoute: () =>
+        Promise.resolve({
+          model: null,
+          reason: "routing is off",
+          incumbent: null,
+          changed: false,
+        }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const textarea = h.container.querySelector("textarea");
+    await act(async () => {
+      typeInto(textarea as HTMLTextAreaElement, "hi");
+    });
+    await act(async () => {
+      (textarea as HTMLTextAreaElement).dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await h.flush();
+
+    const promptCall = api.calls["opencodePrompt"]?.[0];
+    expect(promptCall?.[0]).toBe("ses_test");
+    expect(promptCall?.[2]).toBeUndefined();
+  });
+});
+
 // ===== Re-activation re-pin defers the tail scroll until the scroller
 // re-measures (BET-1003) =====
 //

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -446,6 +446,38 @@ export function ChatPanel({
     [modelOverride, configDefaultModel],
   );
 
+  // BET-1225: main-conversation routing, the honesty half of the routing epic.
+  // On session start, ask the server for the router's "build" decision. When it
+  // actually changed the model (routing enabled AND picked a different winner),
+  // apply the routed model as the active override — so the next prompt actually
+  // runs on it — and populate `routed` with the reason + incumbent so the
+  // composer renders the undoable routed pill. The incumbent is the model the
+  // session would run on without routing (the user's per-session pick or the
+  // persisted default); undo reverts to exactly that. Best-effort: a null or
+  // failed decision (routing off / demo transport) leaves routing silent, and
+  // never breaks the session. Re-runs on session change; the user's own
+  // selectModel clears the pill.
+  useEffect(() => {
+    let cancelled = false;
+    const incumbent = readSavedModel(sessionId) ?? configDefaultModel ?? null;
+    window.api
+      .opencodeModelRoute(incumbent, "build")
+      .then((d) => {
+        if (cancelled || !d || !d.changed || !d.model) return;
+        setModelOverride(d.model);
+        // The pill (which offers undo back to a prior model) renders only when
+        // there is an incumbent to revert to; with no prior model there is
+        // nothing to undo, so the decision applies silently.
+        if (d.incumbent) setRouted({ reason: d.reason, incumbent: d.incumbent });
+      })
+      .catch(() => {
+        /* routing is best-effort — never break the session over it */
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
   // ===== Per-session plan mode (BET-949) =====
   // Local on/off, seeded from the per-session storage key (the `Session.agent`
   // seed falls back to this). The honesty handlers in useSseBus sync this from
@@ -1513,6 +1545,9 @@ export function ChatPanel({
     (m: ModelSelection | null) => {
       setModelOverride(m);
       writeSavedModel(sessionId, m);
+      // A manual model choice ends any routed state: once the user picks the
+      // model themselves, the pill must not claim the router chose it (BET-1225).
+      setRouted(null);
     },
     [sessionId],
   );

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -108,6 +108,7 @@ export const DEMO_UNIMPLEMENTED = [
   "opencodeGenerateTitle",
   "opencodeGetProviders",
   "opencodeGetSubagents",
+  "opencodeModelRoute",
   "opencodePermissionReply",
   "opencodePrompt",
   "opencodeQuestionReject",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1055,6 +1055,8 @@ export const httpApi: Api = {
 
   // -- model picker --
   opencodeModels: () => rpc(IPC.opencodeModels),
+  opencodeModelRoute: (incumbent, agent) =>
+    rpc(IPC.opencodeModelRoute, { incumbent, agent }),
   opencodeGetProviders: () => rpc(IPC.opencodeGetProviders),
   opencodeSetProviders: (ops) => rpc(IPC.opencodeSetProviders, ops),
   opencodeDiscoverModels: (baseURL, apiKey) => rpc(IPC.opencodeDiscoverModels, baseURL, apiKey),

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -516,6 +516,23 @@ export function resolveRequestedModel(model, models) {
  * @param {number} [input.nowMs]
  * @returns {object|null} the model to run on (incumbent on off-path / failure)
  */
+// The model deliver()/sendPrompt() accept is the structured shape
+// {providerID, modelID} (opencode's sendPrompt reads `model.modelID`). A
+// catalog winner carries `.id`, not `.modelID` — so a routed winner has to be
+// normalised into the deliver shape or the model override is silently dropped.
+// This is a no-op for the requested-model incumbent (which is already
+// {providerID, modelID}). Shared by both routing wrappers below so the two
+// decision points normalise identically.
+function toDeliverModel(m) {
+  if (!m) return null;
+  const providerID = m?.providerID ?? "";
+  const modelID = m?.modelID ?? m?.id ?? "";
+  if (!providerID || !modelID) return null;
+  const out = { providerID, modelID };
+  if (typeof m?.variant === "string" && m.variant) out.variant = m.variant;
+  return out;
+}
+
 export function chooseSubagentModel({
   incumbent = null,
   catalog = [],
@@ -524,22 +541,6 @@ export function chooseSubagentModel({
   agent = "general",
   nowMs = Date.now(),
 } = {}) {
-  // The model deliver()/sendPrompt() accept is the structured shape
-  // {providerID, modelID} (opencode's sendPrompt reads `model.modelID`). A
-  // catalog winner carries `.id`, not `.modelID` — so a routed winner has to
-  // be normalised into the deliver shape or the model override is silently
-  // dropped. This is a no-op for the requested-model incumbent (which is
-  // already {providerID, modelID}).
-  function toDeliverModel(m) {
-    if (!m) return null;
-    const providerID = m?.providerID ?? "";
-    const modelID = m?.modelID ?? m?.id ?? "";
-    if (!providerID || !modelID) return null;
-    const out = { providerID, modelID };
-    if (typeof m?.variant === "string" && m.variant) out.variant = m.variant;
-    return out;
-  }
-
   // Normalise the incumbent into catalog shape ({providerID, id}) for the
   // comparison inside chooseModel, so its `changed` flag / modelKey() treat a
   // requested model and a catalog entry of the same model as equal. The ORIGINAL
@@ -573,6 +574,77 @@ export function chooseSubagentModel({
     // Routing must never break a spawn — fall back to the incumbent model.
     console.warn("[router] subagent routing failed, using incumbent:", e?.message ?? e);
     return incumbent;
+  }
+}
+
+/**
+ * THE other single routing decision point: the user-facing MAIN conversation
+ * ("build" agent). Sat beside chooseSubagentModel so `chooseModel` is still
+ * called from exactly one module — the one place a model is decided.
+ *
+ * Unlike the subagent wrapper, which returns only the model the spawn should
+ * run on (the spawn is opaque to the user), this returns the FULL decision —
+ * the routed `model`, the human-readable `reason`, the `incumbent` it would
+ * otherwise have used, and a `changed` flag — so the renderer can (a) apply
+ * the routed model to the next prompt's `modelOverride` AND (b) render the
+ * routed pill (`ChatPanel.routed`) exposing the reason and offering undo back
+ * to the incumbent. That is the honesty contract of the routing epic: a main
+ * conversation's model is never switched without a visible, undoable reason.
+ *
+ * Same safety contract as chooseSubagentModel: policy off / throw / no
+ * survivors all fall back to `incumbent` with `changed: false`, so enabling
+ * routing can never substitute a model the user was not shown and can undo.
+ *
+ * @param {object} [input]
+ * @param {object|null} [input.incumbent]  the model the session would use without routing
+ * @param {Array<object>} [input.catalog]  opencode model list
+ * @param {{ enabled?: boolean, preset?: string, perAgent?: Record<string,string> }} [input.policy]
+ * @param {Array<object>} [input.quota]    usage snapshots
+ * @param {string} [input.agent]           main-conversation agent (default "build")
+ * @param {number} [input.nowMs]
+ * @returns {{ model: object|null, reason: string, incumbent: object|null, changed: boolean }}
+ */
+export function chooseMainModel({
+  incumbent = null,
+  catalog = [],
+  policy = { enabled: false },
+  quota = [],
+  agent = "build",
+  nowMs = Date.now(),
+} = {}) {
+  const incumbentShape = incumbent
+    ? { providerID: incumbent.providerID, modelID: incumbent.modelID ?? incumbent.id ?? "" }
+    : null;
+  // Normalise the incumbent into catalog shape ({providerID, id}) so the
+  // `changed` comparison inside chooseModel treats a requested model and a
+  // catalog entry of the same model as equal (mirrors chooseSubagentModel).
+  const catalogIncumbent = incumbent
+    ? { providerID: incumbent.providerID, id: incumbent.modelID ?? incumbent.id }
+    : null;
+  try {
+    const decision = chooseModel({
+      intent: { kind: "main", agent, needs: { tools: true }, contextTokens: 0, incumbent: catalogIncumbent },
+      catalog,
+      telemetry: {},
+      quota,
+      policy,
+      nowMs,
+    });
+    const model =
+      decision?.model === catalogIncumbent
+        ? incumbent
+        : toDeliverModel(decision?.model ?? incumbent);
+    return {
+      model,
+      reason: decision?.reason ?? "",
+      incumbent: incumbentShape,
+      changed: decision?.changed === true,
+    };
+  } catch (e) {
+    // Routing must never change a main conversation invisibly — and must never
+    // break the send — so any failure falls back to the incumbent.
+    console.warn("[router] main routing failed, using incumbent:", e?.message ?? e);
+    return { model: incumbent, reason: "routing failed", incumbent: incumbentShape, changed: false };
   }
 }
 

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -22,6 +22,7 @@ import {
   effectiveModelFromMessages,
   tickActivity,
   chooseSubagentModel,
+  chooseMainModel,
 } from "./delegate.mjs";
 
 // ----------------------------------------------------------------------------
@@ -624,6 +625,78 @@ test("chooseSubagentModel returns the incumbent on an off-path and is load-beari
     }),
     incumbent,
   );
+});
+
+// ----------------------------------------------------------------------------
+// BET-1225 — main-conversation ("build") routing decision
+// ----------------------------------------------------------------------------
+
+test("chooseMainModel returns the FULL decision — model, reason, incumbent — and normalises the winner to {providerID, modelID} (BET-1225)", () => {
+  const catalog = [
+    { providerID: "anthropic", id: "claude-opus-4", status: "active" },     // deep
+    { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },   // balanced
+    { providerID: "anthropic", id: "claude-haiku-4", status: "active" },    // fast
+  ];
+  const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
+  const decision = chooseMainModel({
+    incumbent,
+    catalog,
+    policy: { enabled: true, preset: "economy" }, // economy + build → balanced floor
+    quota: [],
+    agent: "build",
+    nowMs: 1_700_000_000_000,
+  });
+  // The main-conversation decision is richer than the subagent wrapper: the
+  // renderer needs the model, a reason, and the incumbent for the undo pill.
+  assert.equal(decision.changed, true);
+  assert.equal(decision.model?.providerID, "anthropic");
+  assert.equal(decision.model?.modelID, "claude-sonnet-4", "build under economy must land on the balanced-tier floor");
+  assert.equal("id" in decision.model, false, "the routed model must carry modelID, not the catalog's id");
+  assert.match(decision.reason, /build → balanced tier/, "reason names the build agent and tier");
+  assert.deepEqual(decision.incumbent, incumbent, "incumbent is preserved for the undo pill");
+});
+
+test("chooseMainModel on the off-path returns the incumbent with changed:false, never a hidden switch (BET-1225)", () => {
+  const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
+  const catalog = [
+    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
+    { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
+  ];
+  // routing disabled → no switch, even though a cheaper fast model exists
+  const off = chooseMainModel({ incumbent, catalog, policy: { enabled: false }, agent: "build", nowMs: 0 });
+  assert.equal(off.changed, false);
+  assert.deepEqual(off.model, incumbent);
+  assert.equal(off.reason, "routing is off");
+  // an enabled router with no survivors (all dead) still falls back to incumbent
+  const noSurvivors = chooseMainModel({
+    incumbent,
+    catalog: [{ providerID: "anthropic", id: "claude-opus-4", status: "retired" }],
+    policy: { enabled: true, preset: "economy" },
+    agent: "build",
+    nowMs: 0,
+  });
+  assert.equal(noSurvivors.changed, false);
+  assert.deepEqual(noSurvivors.model, incumbent);
+});
+
+test("chooseMainModel when the router picks the same model reports changed:false (BET-1225)", () => {
+  // deep incumbent + performance preset → build stays deep → same model, no pill.
+  const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
+  const catalog = [
+    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
+    { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },
+  ];
+  const decision = chooseMainModel({
+    incumbent,
+    catalog,
+    policy: { enabled: true, preset: "performance" },
+    quota: [],
+    agent: "build",
+    nowMs: 0,
+  });
+  assert.equal(decision.changed, false, "no model was substituted → the pill must not render");
+  assert.deepEqual(decision.model, incumbent);
+  assert.deepEqual(decision.incumbent, incumbent);
 });
 
 test("requestedModel survives a tickActivity that rewrites job.model (BET-947)", async () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -33,6 +33,7 @@ import { resolveWorkspace } from "./peers.mjs";
 import * as providers from "./providers.mjs";
 import * as launchers from "./launchers.mjs";
 import * as subscriptionProviders from "./subscriptionProviders.mjs";
+import { chooseMainModel } from "./delegate.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { pollClaudeLogin, claudeCliStatus } from "./opencode.mjs";
 import { backupClaudeCredentials, CREDENTIALS_PATH } from "./claudeAuth.mjs";
@@ -792,6 +793,41 @@ export function buildHandlers({
     "opencode:models": async () => {
       const cfg = await local.configGet();
       return oc.listModels(cfg.modelOverrides ?? {});
+    },
+
+    // BET-1225: main-conversation ("build" agent) routing decision. ChatPanel
+    // asks once at session start; the server is the ONE place chooseModel runs
+    // (chooseMainModel in delegate.mjs, sat beside chooseSubagentModel), so
+    // the routed pill reflects the same decision the send path would apply.
+    // Returns the full decision { model, reason, incumbent, changed } so the
+    // renderer can apply the routed model AND surface the undoable pill. Every
+    // input is guarded — missing policy / quota / catalog must never throw and
+    // falls back to the incumbent (routing off by default).
+    "routing:main": async (input) => {
+      const incumbent = input?.incumbent ?? null;
+      const agent = input?.agent ?? "build";
+      let policy = { enabled: false };
+      let quota = [];
+      let catalog = [];
+      try {
+        const cfg = await local.configGet();
+        policy = cfg?.modelRouter ?? { enabled: false };
+      } catch {
+        policy = { enabled: false };
+      }
+      try {
+        quota = usageListSnapshots();
+        if (!Array.isArray(quota)) quota = [];
+      } catch {
+        quota = [];
+      }
+      try {
+        catalog = await oc.listModels();
+        if (!Array.isArray(catalog)) catalog = [];
+      } catch {
+        catalog = [];
+      }
+      return chooseMainModel({ incumbent, catalog, policy, quota, agent, nowMs: Date.now() });
     },
 
     // Provider management — now served from the server (BET-82.3).

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -88,6 +88,17 @@ import type {
 import type { ClaimOutcome } from "./claim.mjs";
 
 type PromptModel = { providerID: string; modelID: string; variant?: string };
+// BET-1225: the server-side main-conversation routing decision, returned by
+// opencodeModelRoute. `model` is the router's chosen model to apply to the
+// next prompt; `reason` is why (shown on the routed pill); `incumbent` is the
+// model it replaced (what undo reverts to); `changed` is whether a substitution
+// actually happened (false on routing-off / failure / no-op).
+type ModelRouteDecision = {
+  model: PromptModel | null;
+  reason: string;
+  incumbent: PromptModel | null;
+  changed: boolean;
+};
 type PromptAttachment = { remotePath: string; mime: string; filename?: string };
 type PromptAgentMention = {
   name: string;
@@ -399,6 +410,15 @@ export interface Api {
 
   // Model picker.
   opencodeModels(): Promise<OpencodeModel[]>;
+  // BET-1225: fetch the server's main-conversation routing decision for the
+  // session at start, so the renderer can apply the routed model and render
+  // the undoable routed pill. `incumbent` is the model the session would use
+  // without routing (the user's per-session pick or the persisted default).
+  // Returns null on the demo/no-op transport (routing is never exercised).
+  opencodeModelRoute(
+    incumbent: PromptModel | null,
+    agent?: string,
+  ): Promise<ModelRouteDecision | null>;
   opencodeDefaultModel(): Promise<{ providerID: string; modelID: string } | null>;
   opencodeGetProviders(): Promise<ProviderEndpoint[]>;
   opencodeSetProviders(ops: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1350,6 +1350,8 @@ export const IPC = {
   // Model picker: list available models on the remote opencode server (with
   // provider secrets stripped before forwarding).
   opencodeModels: "opencode:models",
+  // BET-1225: main-conversation routing decision at session start.
+  opencodeModelRoute: "routing:main",
   // Provider management: list/set custom providers + discover models.
   opencodeGetProviders: "opencode:get-providers",
   opencodeSetProviders: "opencode:set-providers",


### PR DESCRIPTION
Opened automatically for `multica/BET-1225-wire-main-routing`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1225.