### PR TITLE
BET-1228: Routing — carry price, cache rates, reasoning and release date through model normalisation

### DIFF
--- a/src/renderer/api/demoFixture.ts
+++ b/src/renderer/api/demoFixture.ts
@@ -832,7 +832,7 @@ export const demoModels: OpencodeModel[] = [
     status: "active",
     enabled: true,
     limit: { context: 1_000_000, output: 32_000 },
-    capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+    capabilities: { toolcall: true, input: ["text", "image"], output: ["text"] },
   },
   {
     id: "claude-sonnet-4-6",
@@ -841,7 +841,7 @@ export const demoModels: OpencodeModel[] = [
     status: "active",
     enabled: true,
     limit: { context: 200_000, output: 16_000 },
-    capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+    capabilities: { toolcall: true, input: ["text", "image"], output: ["text"] },
   },
   // Third model exists so the visual gate can capture the effort picker's
   // OPEN state (BET-511): the two default models expose no `variants`, which
@@ -857,7 +857,7 @@ export const demoModels: OpencodeModel[] = [
     status: "active",
     enabled: true,
     limit: { context: 1_000_000, output: 32_000 },
-    capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+    capabilities: { toolcall: true, input: ["text", "image"], output: ["text"] },
     variants: [{ id: "balanced" }, { id: "maximum" }],
   },
   // The `-fast` twin of the model above, so the composer's ⚡ fast-mode toggle
@@ -873,7 +873,7 @@ export const demoModels: OpencodeModel[] = [
     status: "active",
     enabled: true,
     limit: { context: 1_000_000, output: 32_000 },
-    capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+    capabilities: { toolcall: true, input: ["text", "image"], output: ["text"] },
     variants: [{ id: "balanced" }],
   },
   // A model with NO reported context window — exercises the "no max context"
@@ -886,7 +886,7 @@ export const demoModels: OpencodeModel[] = [
     status: "active",
     enabled: true,
     limit: { context: null },
-    capabilities: { tools: true, input: ["text", "image"], output: ["text"] },
+    capabilities: { toolcall: true, input: ["text", "image"], output: ["text"] },
   },
 ];
 

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -523,7 +523,7 @@ function model(id: string, providerID: string): OpencodeModel {
     providerID,
     name: id,
     limit: { context: 200_000 },
-    capabilities: { tools: true, input: ["text"], output: ["text"] },
+    capabilities: { toolcall: true, input: ["text"], output: ["text"] },
   };
 }
 

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1144,6 +1144,22 @@ export function applyModelOverride(m, override) {
   return next;
 }
 
+// Canonicalize a model's `cost` (opencode reports `cost: { input, output,
+// cache: { read, write } }`). Keep only finite, non-negative numbers; a
+// missing/NaN/negative value becomes `undefined`, NEVER `0` — the difference
+// between "free" and "unknown" is load-bearing for the router (BET-1228).
+// opencode's `cost.tiers`/`experimentalOver200K` are context-tiered pricing,
+// deliberately not modelled here.
+function _normalizePrice(raw) {
+  const p = (v) => (typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : undefined);
+  return {
+    input: p(raw?.input),
+    output: p(raw?.output),
+    cacheRead: p(raw?.cache?.read),
+    cacheWrite: p(raw?.cache?.write),
+  };
+}
+
 // Canonicalize a model's `limit`. `context` is `number | null`; `null` means
 // "the provider gave no usable limit — never fabricate one". `0`, negative,
 // NaN, Infinity and missing all map to `null`. `output` is kept only when a
@@ -1167,7 +1183,7 @@ function _normalizeLimit(raw) {
 // `input`/`output`; `limit.context` never fabricated). Returns null when the
 // model is unaddressable (an empty/absent providerID would silently break
 // grouping/auth/usage), in which case the caller must SKIP it.
-function _normalizeProviderModel(providerID, modelId, m) {
+export function _normalizeProviderModel(providerID, modelId, m) {
   if (typeof providerID !== "string" || providerID.length === 0) return null;
   let variants;
   const vRaw = m.variants;
@@ -1188,8 +1204,12 @@ function _normalizeProviderModel(providerID, modelId, m) {
     status: typeof m.status === "string" ? m.status : undefined,
     enabled: typeof m.enabled === "boolean" ? m.enabled : undefined,
     limit: _normalizeLimit(m.limit),
+    cost: _normalizePrice(m.cost),
+    releaseDate:
+      typeof m.release_date === "string" && m.release_date !== "" ? m.release_date : undefined,
     capabilities: {
-      tools: typeof caps.tools === "boolean" ? caps.tools : undefined,
+      toolcall: typeof caps.toolcall === "boolean" ? caps.toolcall : undefined,
+      reasoning: typeof caps.reasoning === "boolean" ? caps.reasoning : undefined,
       attachment: typeof caps.attachment === "boolean" ? caps.attachment : undefined,
       input: readModalities(caps.input),
       output: readModalities(caps.output),

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -39,6 +39,7 @@ import {
   getDefaultModel,
   generateSessionTitle,
   listModels,
+  _normalizeProviderModel,
   claudeCliStatus,
   parseProviderApiKey,
   readProviderApiKey,
@@ -1344,6 +1345,74 @@ test("listModels returns [] on a transport throw (never re-throws)", async () =>
       assert.deepEqual(out, []);
     },
   );
+});
+
+// _normalizeProviderModel — the single chokepoint every raw provider model
+// passes through. BET-1228: it must CARRY price (incl. cache rates), expose
+// `toolcall` under its own name (not the renamed `tools`), and preserve
+// `reasoning` + `releaseDate`. The absence of price is invisible at runtime
+// (every model scores equal), so these tests are the only thing pinning it.
+// ---------------------------------------------------------------------------
+
+test("_normalizeProviderModel carries price and cache rates through", () => {
+  const m = _normalizeProviderModel("anthropic", "claude-opus-4-7", {
+    id: "claude-opus-4-7",
+    cost: { input: 5, output: 25, cache: { read: 0.5, write: 6.25 } },
+  });
+  assert.deepEqual(m.cost, {
+    input: 5,
+    output: 25,
+    cacheRead: 0.5,
+    cacheWrite: 6.25,
+  });
+});
+
+test("_normalizeProviderModel distinguishes 0 from missing cost (never 0 for unknown)", () => {
+  const zero = _normalizeProviderModel("p", "m0", { id: "m0", cost: { input: 0 } });
+  assert.equal(zero.cost.input, 0);
+  assert.equal(zero.cost.output, undefined);
+
+  const missing = _normalizeProviderModel("p", "m1", { id: "m1", cost: {} });
+  assert.equal(missing.cost.input, undefined);
+  assert.equal(missing.cost.output, undefined);
+
+  const absent = _normalizeProviderModel("p", "m2", { id: "m2" });
+  assert.equal(absent.cost.input, undefined);
+  assert.equal(absent.cost.output, undefined);
+});
+
+test("_normalizeProviderModel drops NaN and negative cost values (to undefined)", () => {
+  const m = _normalizeProviderModel("p", "m", {
+    id: "m",
+    cost: { input: NaN, output: -3, cache: { read: Infinity } },
+  });
+  assert.equal(m.cost.input, undefined);
+  assert.equal(m.cost.output, undefined);
+  assert.equal(m.cost.cacheRead, undefined);
+  assert.equal(m.cost.cacheWrite, undefined);
+});
+
+test("_normalizeProviderModel keeps toolcall under its own name and preserves false", () => {
+  const m = _normalizeProviderModel("p", "m", {
+    id: "m",
+    capabilities: { toolcall: false, attachment: true },
+  });
+  assert.equal(m.capabilities.toolcall, false);
+  assert.equal(m.capabilities.tools, undefined);
+  assert.equal(m.capabilities.attachment, true);
+});
+
+test("_normalizeProviderModel carries reasoning and trims empty releaseDate to undefined", () => {
+  const m = _normalizeProviderModel("p", "m", {
+    id: "m",
+    release_date: "2025-01-01",
+    capabilities: { reasoning: true },
+  });
+  assert.equal(m.releaseDate, "2025-01-01");
+  assert.equal(m.capabilities.reasoning, true);
+
+  const empty = _normalizeProviderModel("p", "m2", { id: "m2", release_date: "" });
+  assert.equal(empty.releaseDate, undefined);
 });
 
 // Scoped-stream readiness gate (BET-115 fix C)

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2362,9 +2362,13 @@ export type InputModality = string;
 // app and the box update on separate tracks), so both shapes reach clients —
 // the provider's raw object-of-flags form and the canonical array form.
 // `readModalities` (src/shared/modelGuide.mjs) is the ONLY supported way to
-// read these two fields. `tools`/`attachment` pass through as booleans.
+// read these two fields. `toolcall`/`reasoning`/`attachment` pass through as
+// booleans. `toolcall` matches the upstream opencode capability name (the
+// router's filterByConstraints checks `capabilities.toolcall`), so the box
+// must NOT rename it to `tools` (BET-1228).
 export type OpencodeModelCapabilities = {
-  tools?: boolean;
+  toolcall?: boolean;
+  reasoning?: boolean;
   attachment?: boolean;
   input?: InputModality[] | Record<string, boolean>;
   output?: InputModality[] | Record<string, boolean>;
@@ -2381,6 +2385,20 @@ export type OpencodeModel = {
   // limit; do NOT fabricate one". `output` is only present when the provider
   // reported a positive finite value.
   limit?: { context: number | null; output?: number };
+  // Price in $ per 1M tokens, as reported by the provider. Each field is
+  // `number | undefined`: undefined (or a field absent from `cost`) means the
+  // price is UNKNOWN, which is deliberately distinct from 0 (free) — the
+  // router treats unknown as free but the distinction is load-bearing for a
+  // later issue in the routing epic (BET-1228).
+  cost?: {
+    input?: number; // $ per 1M input tokens
+    output?: number; // $ per 1M output tokens
+    cacheRead?: number; // $ per 1M cached-read tokens
+    cacheWrite?: number; // $ per 1M cache-write tokens
+  };
+  // `release_date` as reported by the provider; only a non-empty string is
+  // kept (some providers report "").
+  releaseDate?: string;
   // REQUIRED after normalization (always at least `{}`).
   capabilities: OpencodeModelCapabilities;
   variants?: Array<{ id: string }>;


### PR DESCRIPTION
## BET-1228: Routing — carry price, cache rates, reasoning and release date through model normalisation

Stage 1 of the Automatic Manta Routing epic.

Every raw provider model passes through `_normalizeProviderModel` in `src/server/opencode.mjs`. It used to **discard** price (so every model scored as free and the "cheapest model" tie-break fell through to `localeCompare` on the id), **rename** the tool-calling flag (`tools` → so the router's `capabilities.toolcall === false` filter never fired), and **drop** `reasoning` + `release_date`.

This PR makes the data arrive:

1. **Price + cache rates** are carried through (mapped from opencode's `cost.input` / `cost.output` / `cost.cache.read` / `cost.cache.write`). Normalised the same way `_normalizeLimit` is: only finite, non-negative numbers kept; missing/NaN/negative → `undefined`, **never 0**. The "free" vs "unknown" distinction is load-bearing for a later issue in this epic.
2. **`tools` → `toolcall`** rename stopped: the normalised capability now ships under its own name matching upstream + the router's read. `modelRouter.mjs` was **not** changed (it already reads `cost` and `toolcall` correctly — that restructuring is a separate issue).
3. **`reasoning`** (capabilities) and **`releaseDate`** (from `release_date`, empty string → `undefined`) now pass through.

**Files changed:** 5
- `src/server/opencode.mjs` — `_normalizePrice` helper + normalisation in `_normalizeProviderModel` (now exported for tests); `tools`→`toolcall`.
- `src/shared/types.ts` — `OpencodeModelCapabilities.toolcall`/`reasoning`, `OpencodeModel.cost`/`releaseDate`.
- `src/server/opencode.test.mjs` — 5 new unit tests.
- `src/renderer/api/demoFixture.ts`, `src/renderer/chatUtils.test.ts` — fixture cleanup: `tools` → `toolcall` in normalized-model fixtures (grep `capabilities?.tools\|capabilities.tools` `src/` finds no other consumers; the renderer's `capabilities?.attachment`/`.input` reads are unaffected).

**Tests added** (all pass): price survives normalisation (all four rates), 0 vs missing distinguishable, NaN/negative → undefined, `toolcall` under its own name + `false` preserved, `reasoning` carried + `release_date: ""` → undefined.

**Verification results** (branch `multica/BET-1228-model-normalization` @ `91120573`):
- typecheck: exit 0, errors none
- test: exit 0, **2572 pass / 0 fail** (full `npm test`; isolated runs: `opencode.test.mjs` 120 pass incl. the 5 new, renderer chatUtils+demo 653 pass)
- **Base: origin/main @ `d16b4388`**

Note: this PR's diff is exactly the 5 files above. (Unrelated, uncommitted edits to `src/server/delegate.*` living in this shared worktree are a sibling issue's work and are NOT part of this PR.)

Cross-cutting follow-ups: none — scope is strictly the chokepoint. The router restructure and the quality-score consumption of `reasoning`/`releaseDate` are already tracked as other issues in this epic.
