### PR TITLE
feat(shared/server): measure per-endpoint tool-call reliability (BET-1234)

### DIFF
--- a/src/server/modelLedger.mjs
+++ b/src/server/modelLedger.mjs
@@ -16,6 +16,7 @@
 // shared handle from opencodeDb.mjs is opened read-only and stays so.
 
 import { getDb } from "./opencodeDb.mjs";
+import { classifyToolCall, aggregateReliability } from "../shared/toolReliability.mjs";
 
 // Turns longer than this are excluded from TIMING only (still counted for
 // cost) — the spec cap is 600s of wall-clock.
@@ -182,10 +183,182 @@ function byCostDesc(a, b) {
 }
 
 /**
+ * I/O. Reads the raw assistant message rows over the rolling window via the
+ * shared getDb() handle. Shared by `ledgerSummary` and `endpointSummary` so
+ * the SQL + parse + role-filter lives in exactly one place. Returns the parsed
+ * `data` object plus the joined session fields. Never throws.
+ */
+async function assistantRows(db, since) {
+  const sql = `
+    SELECT m.data AS msg_data,
+           s.parent_id AS parent_id,
+           s.agent AS agent,
+           s.directory AS directory
+    FROM message m
+    JOIN session s ON s.id = m.session_id
+    WHERE m.time_created >= ?`;
+  const stmt = db.prepare(sql);
+  const out = [];
+  for (const row of stmt.all(since)) {
+    let data;
+    try {
+      data = JSON.parse(row.msg_data);
+    } catch {
+      continue;
+    }
+    if (!data || typeof data !== "object" || data.role !== "assistant") continue;
+    out.push({
+      data,
+      parentId: row.parent_id != null ? String(row.parent_id) : null,
+      agent: row.agent ?? null,
+      directory: row.directory ?? null,
+    });
+  }
+  return out;
+}
+
+/**
+ * PURE. Fold raw assistant message `data` into the tool-call reliability,
+ * speed, latency and mix figures, keyed per endpoint ("providerID/modelID").
+ *
+ * Each row may carry tool-call data: `toolCalls` (Array<{name, arguments}>)
+ * and an optional `tools` list (Array of tool defs). A row with tool calls is
+ * one request that ended in tool calls; per-endpoint reliability reuses the
+ * same request-level aggregation as the rest of the app. Timing reuses the
+ * existing percentile + timing-exclusion helpers — no second copy.
+ *
+ * Returns an object keyed by endpoint; the shape is what the routing issue
+ * consumes. Never throws.
+ */
+export function aggregateEndpointStats(rows) {
+  const list = Array.isArray(rows) ? rows : [];
+  const byEndpoint = new Map();
+  for (const r of list) {
+    const key = `${r.providerID ?? ""}/${r.modelID ?? ""}`;
+    let e = byEndpoint.get(key);
+    if (!e) {
+      e = {
+        key,
+        durations: [],
+        speeds: [],
+        toolRequests: [],
+        mix: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+      };
+      byEndpoint.set(key, e);
+    }
+
+    e.mix.input += num(r.input);
+    e.mix.output += num(r.output);
+    e.mix.cacheRead += num(r.cacheRead);
+    e.mix.cacheWrite += num(r.cacheWrite);
+
+    const durMs = timedDurationMs(r.startedMs, r.completedMs);
+    if (durMs !== null) {
+      e.durations.push(durMs);
+      const out = num(r.output);
+      e.speeds.push(safeDiv(out, durMs / 1000));
+    }
+
+    const calls = Array.isArray(r.toolCalls) ? r.toolCalls : [];
+    if (calls.length > 0) {
+      e.toolRequests.push({ toolCalls: calls, tools: Array.isArray(r.tools) ? r.tools : [] });
+    }
+  }
+
+  const out = {};
+  for (const key of [...byEndpoint.keys()].sort()) {
+    const e = byEndpoint.get(key);
+    const durs = e.durations.sort((a, b) => a - b);
+    const speeds = e.speeds.sort((a, b) => a - b);
+    out[key] = {
+      reliability: aggregateReliability(e.toolRequests),
+      speed: {
+        p50TokensPerSec: speeds.length ? percentile(speeds, 0.5) : null,
+        p90TokensPerSec: speeds.length ? percentile(speeds, 0.9) : null,
+      },
+      latency: {
+        p50Ms: durs.length ? percentile(durs, 0.5) : null,
+        p90Ms: durs.length ? percentile(durs, 0.9) : null,
+      },
+      mix: { ...e.mix },
+    };
+  }
+  return out;
+}
+
+// Extract the tool calls from a single assistant message's parts (each part of
+// type "tool" carries a name plus its arguments/input). No call follows into a
+// second pass when the message stores none.
+function extractToolCalls(data) {
+  const parts = Array.isArray(data.parts) ? data.parts : [];
+  const calls = [];
+  for (const p of parts) {
+    if (!p || typeof p !== "object" || p.type !== "tool") continue;
+    const name = p.tool;
+    const args = p.state && p.state.input;
+    if (name == null) continue;
+    calls.push({ name, arguments: args });
+  }
+  return calls;
+}
+
+// Best-effort source of the request's tool definitions from the stored message
+// data. When absent (the common case — schemata aren't persisted), reliability
+// degrades to the conservative invalid-json-only signal, matching the "schema
+// absent ⇒ valid" rule in the classification. No new capture path is added.
+function extractTools(data) {
+  return Array.isArray(data.tools) ? data.tools : [];
+}
+
+/**
+ * I/O. Per-endpoint measurement (reliability, speed, latency, mix) over a
+ * rolling window of assistant rows, via the shared getDb() handle. Degrades
+ * exactly like `ledgerSummary`: returns { supported:false } — never throws —
+ * when getDb() yields null, and a failed query also degrades. Read-only.
+ */
+export async function endpointSummary({ sinceMs = 0 } = {}) {
+  const db = await getDb();
+  if (!db) return { supported: false };
+
+  try {
+    const since = num(sinceMs);
+    const rows = [];
+    for (const { data } of await assistantRows(db, since)) {
+      const tokens = data.tokens ?? {};
+      const cache = tokens.cache ?? {};
+      rows.push({
+        providerID: data.providerID ?? null,
+        modelID: data.modelID ?? null,
+        input: tokens.input,
+        output: tokens.output,
+        cacheRead: cache.read,
+        cacheWrite: cache.write,
+        startedMs: data.time?.created,
+        completedMs: data.time?.completed,
+        toolCalls: extractToolCalls(data),
+        tools: extractTools(data),
+      });
+    }
+    return { supported: true, ...aggregateEndpointStats(rows) };
+  } catch (e) {
+    // Query error: log once, drop the handle so the next call reopens, and
+    // degrade to { supported:false } — never an exception, never zeros (a card
+    // full of 0.00 would read as "perfect reliability", which is a lie).
+    console.error("[modelLedger] endpoint query failed:", e?.message ?? e);
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+    return { supported: false };
+  }
+}
+
+/**
  * I/O. Reads assistant rows via the shared getDb() handle, parses their JSON,
  * and folds them through aggregate(). Returns { supported:false } — never
- * throws — when getDb() yields null, mirroring searchMessages. Rows whose
- * data fails JSON.parse or whose role !== "assistant" are skipped silently.
+ * throws — when getDb() yields null, mirroring searchMessages. Rows whose data
+ * fails JSON.parse or whose role !== "assistant" are skipped silently.
  */
 export async function ledgerSummary({ sinceMs = 0 } = {}) {
   const db = await getDb();
@@ -193,32 +366,16 @@ export async function ledgerSummary({ sinceMs = 0 } = {}) {
 
   try {
     const since = num(sinceMs);
-    const sql = `
-      SELECT m.data AS msg_data,
-             s.parent_id AS parent_id,
-             s.agent AS agent,
-             s.directory AS directory
-      FROM message m
-      JOIN session s ON s.id = m.session_id
-      WHERE m.time_created >= ?`;
-    const stmt = db.prepare(sql);
     const rows = [];
-    for (const row of stmt.all(since)) {
-      let data;
-      try {
-        data = JSON.parse(row.msg_data);
-      } catch {
-        continue;
-      }
-      if (!data || typeof data !== "object" || data.role !== "assistant") continue;
+    for (const { data, parentId, agent, directory } of await assistantRows(db, since)) {
       const tokens = data.tokens ?? {};
       const cache = tokens.cache ?? {};
       rows.push({
         providerID: data.providerID ?? null,
         modelID: data.modelID ?? null,
-        agent: row.agent ?? null,
-        parentId: row.parent_id != null ? String(row.parent_id) : null,
-        directory: row.directory ?? null,
+        agent,
+        parentId,
+        directory,
         cost: data.cost,
         input: tokens.input,
         output: tokens.output,

--- a/src/server/modelLedger.test.mjs
+++ b/src/server/modelLedger.test.mjs
@@ -4,7 +4,8 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { aggregate } from "./modelLedger.mjs";
+import { aggregate, aggregateEndpointStats, endpointSummary } from "./modelLedger.mjs";
+import { _resetDbHandle } from "./opencodeDb.mjs";
 
 // Fixture builder. Fill only the fields a test cares about.
 function row(over = {}) {
@@ -152,4 +153,80 @@ test("every array is sorted by cost descending", () => {
   assert.ok(desc(ledger.byAgent, (a) => a.cost));
   assert.ok(desc(ledger.byProject, (p) => p.cost));
   assert.equal(ledger.byModel[0].key, "a/b");
+});
+
+// ---- aggregateEndpointStats (per-endpoint reliability/speed/latency/mix) ----
+
+const readTool = {
+  name: "read",
+  input_schema: { type: "object", properties: { path: { type: "string" } }, required: ["path"] },
+};
+
+test("aggregateEndpointStats produces the per-endpoint shape over fixture rows", () => {
+  const stats = aggregateEndpointStats([
+    // Endpoint A, request 1 — one clean tool call, 200 output tokens in 1s.
+    {
+      providerID: "anthropic", modelID: "claude-sonnet",
+      input: 100, output: 200, cacheRead: 50, cacheWrite: 40,
+      startedMs: 1000, completedMs: 2000,
+      toolCalls: [{ name: "read", arguments: { path: "/a" } }], tools: [readTool],
+    },
+    // Endpoint A, request 2 — two calls, one bogus → the WHOLE request errors.
+    {
+      providerID: "anthropic", modelID: "claude-sonnet",
+      input: 50, output: 300, cacheRead: 0, cacheWrite: 0,
+      startedMs: 1000, completedMs: 2000,
+      toolCalls: [
+        { name: "read", arguments: { path: "/b" } },
+        { name: "bogus", arguments: {} },
+      ],
+      tools: [readTool],
+    },
+    // Endpoint B — a single clean request, distinct model.
+    {
+      providerID: "anthropic", modelID: "claude-opus",
+      input: 10, output: 20, cacheRead: 0, cacheWrite: 0,
+      startedMs: 1000, completedMs: 2000,
+      toolCalls: [{ name: "read", arguments: { path: "/c" } }], tools: [readTool],
+    },
+  ]);
+
+  const sonnet = stats["anthropic/claude-sonnet"];
+  // Two tool-ending requests; the second is errored → requests 2, errored 1.
+  assert.deepEqual(sonnet.reliability, { requests: 2, errored: 1, rate: 0.5 });
+  // mix: raw token-count sums.
+  assert.deepEqual(sonnet.mix, { input: 150, output: 500, cacheRead: 50, cacheWrite: 40 });
+  // Timing reflects two 1s timed turns.
+  assert.equal(typeof sonnet.latency.p50Ms, "number");
+  assert.equal(typeof sonnet.latency.p90Ms, "number");
+  assert.equal(typeof sonnet.speed.p50TokensPerSec, "number");
+  assert.equal(typeof sonnet.speed.p90TokensPerSec, "number");
+
+  const opus = stats["anthropic/claude-opus"];
+  assert.deepEqual(opus.reliability, { requests: 1, errored: 0, rate: 0 });
+
+  // Rows without tool calls do not inflate reliability.
+  const clean = aggregateEndpointStats([
+    { providerID: "p", modelID: "m", input: 0, output: 0, cacheRead: 0, cacheWrite: 0, toolCalls: [], tools: [] },
+    { providerID: "p", modelID: "m", input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+  ]);
+  assert.deepEqual(clean["p/m"].reliability, { requests: 0, errored: 0, rate: 0 });
+  assert.equal(clean["p/m"].latency.p50Ms, null); // no timed turns
+});
+
+test("endpointSummary returns { supported:false } with no zeros when the DB is unavailable", async () => {
+  const prev = process.env.MANTA_OPENCODE_DB;
+  process.env.MANTA_OPENCODE_DB = "/nonexistent/opencode.db";
+  _resetDbHandle();
+  try {
+    const res = await endpointSummary();
+    // A `supported:false` card must not look like "perfect reliability" — no
+    // zeros smuggled in, no per-endpoint numbers at all.
+    assert.deepEqual(res, { supported: false });
+    assert.equal("reliability" in res, false);
+  } finally {
+    if (prev === undefined) delete process.env.MANTA_OPENCODE_DB;
+    else process.env.MANTA_OPENCODE_DB = prev;
+    _resetDbHandle();
+  }
 });

--- a/src/shared/toolReliability.d.mts
+++ b/src/shared/toolReliability.d.mts
@@ -1,0 +1,38 @@
+export type ToolCall = {
+  name?: string;
+  /** May be a JSON string or an already-parsed object. */
+  arguments?: unknown;
+};
+
+export type ToolDef = {
+  name?: string;
+  input_schema?: unknown;
+  parameters?: unknown;
+  schema?: unknown;
+  function?: { parameters?: unknown; input_schema?: unknown };
+};
+
+export type ToolCallKind = "valid" | "invalid-json" | "unknown-name" | "schema-mismatch";
+
+export type RequestAggregate = { toolCalls?: ToolCall[]; tools?: ToolDef[] };
+
+export type ReliabilitySample = { requests: number; errored: number; rate: number };
+
+export type ReliabilityBaseline = { rate: number; n: number };
+
+export type DerankDecision = { penalise: boolean; reason: string };
+
+export const MIN_SAMPLE_REQUESTS: number;
+export const DERANK_MARGIN_SIGMA: number;
+
+export function classifyToolCall(
+  call: ToolCall | null | undefined,
+  toolsById: Record<string, ToolDef> | Map<string, ToolDef> | null | undefined,
+): ToolCallKind;
+
+export function aggregateReliability(requests: RequestAggregate[] | null | undefined): ReliabilitySample;
+
+export function shouldDerank(
+  sample: ReliabilitySample | null | undefined,
+  baseline: ReliabilityBaseline | null | undefined,
+): DerankDecision;

--- a/src/shared/toolReliability.mjs
+++ b/src/shared/toolReliability.mjs
@@ -1,0 +1,239 @@
+// toolReliability.mjs — per-endpoint tool-call correctness measurement (pure).
+//
+// BET-1234 (Stage 2 of the Automatic Manta Routing epic). Every turn in this
+// app is agentic, and providers serving the SAME model vary meaningfully in
+// tool-calling correctness, not just speed — an endpoint that emits a malformed
+// tool call is not "cheap", it is broken work billed at a discount, and it is
+// invisible in any price comparison. Speed and price are measured elsewhere
+// (modelLedger); this module measures the one thing those cannot see.
+//
+// It is PURE: no I/O, no Date.now(), no node imports — so the server and
+// renderer can never disagree and the arithmetic is testable with fixtures.
+// Wiring it into the router is a separate issue; this ships the measurement
+// only.
+
+// Minimum number of requests that ended in tool calls before an endpoint's
+// observed error rate is treated as statistical evidence. Below this we never
+// penalise — three bad requests out of three is anecdote, not evidence.
+export const MIN_SAMPLE_REQUESTS = 20;
+
+// The margin, in "standard deviations" (of the baseline proportion's standard
+// error), by which an endpoint's rate must exceed the same MODEL's baseline
+// rate before it counts as materially worse. A deliberate standard-deviation-
+// style margin rather than an absolute delta, because a genuinely hard tool
+// schema produces errors on every endpoint — that is the model's cost, not one
+// endpoint's fault. 1σ is lenient enough to ignore sampling noise on a healthy
+// baseline yet tight enough to flag a real outlier.
+export const DERANK_MARGIN_SIGMA = 1;
+
+// ---- classification -------------------------------------------------------
+
+// The runtime kind of a JSON value, the way a schema's `type` talks about it.
+function valueType(v) {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}
+
+// Does `value` satisfy one of the declared schema types? "integer" matches a
+// finite whole number, "number" any finite number, the rest match the runtime
+// kind.
+function typeMatches(value, declaredTypes) {
+  const type = valueType(value);
+  const types = Array.isArray(declaredTypes) ? declaredTypes : [declaredTypes];
+  let matched = false;
+  for (const dt of types) {
+    if (dt === "integer") {
+      if (type === "number" && Number.isInteger(value)) matched = true;
+    } else if (dt === "number") {
+      if (type === "number") matched = true;
+    } else if (dt === type) {
+      matched = true;
+    }
+  }
+  return matched;
+}
+
+// Is the value within the (optional) enum restriction?
+function enumOk(value, enumVals) {
+  if (!Array.isArray(enumVals)) return true;
+  return enumVals.includes(value);
+}
+
+// A small, dependency-free structural check against the declared parameter
+// schema: required keys present, declared types match, enum values in range.
+// Deliberately NOT a full JSON-schema evaluator — deep/anyOf/oneOf validation
+// would drag in a dependency and is out of scope for this measurement.
+function violatesSchema(args, schema) {
+  if (args === null || typeof args !== "object" || Array.isArray(args)) return true;
+
+  const required = Array.isArray(schema.required) ? schema.required : [];
+  for (const key of required) {
+    if (!(key in args)) return true;
+  }
+
+  const props = schema && typeof schema === "object" ? schema.properties : undefined;
+  if (props && typeof props === "object") {
+    for (const key of Object.keys(props)) {
+      if (!(key in args)) continue;
+      const spec = props[key];
+      if (!spec || typeof spec !== "object") continue;
+      if (!enumOk(args[key], spec.enum)) return true;
+      if (spec.type !== undefined && !typeMatches(args[key], spec.type)) return true;
+    }
+  }
+  return false;
+}
+
+// Pull the compilable parameter schema out of a tool definition. Handles the
+// common REST/OpenAPI + function-calling shapes. Returns null when absent or
+// uncompilable — such a tool is ALWAYS valid, because a malformed caller-side
+// schema is our bug, not the provider's (conservative on purpose).
+function toolSchema(def) {
+  if (!def || typeof def !== "object" || Array.isArray(def)) return null;
+  const fn = def.function;
+  const s =
+    def.input_schema ??
+    def.parameters ??
+    def.schema ??
+    (fn && typeof fn === "object" ? fn.parameters ?? fn.input_schema : undefined);
+  if (!s || typeof s !== "object" || Array.isArray(s)) return null;
+  return s;
+}
+
+// Normalise a call's arguments to a plain object. Accepts either an already-
+// object argument value (opencode stores tool input as an object) or a JSON
+// string. Returns null when the arguments are missing or fail to parse — that
+// is an invalid-json.
+function resolveArguments(args) {
+  if (typeof args === "string") {
+    try {
+      const v = JSON.parse(args);
+      return v && typeof v === "object" && !Array.isArray(v) ? v : null;
+    } catch {
+      return null;
+    }
+  }
+  if (args && typeof args === "object" && !Array.isArray(args)) return args;
+  return null;
+}
+
+function hasAny(toolsById) {
+  if (toolsById == null) return false;
+  if (toolsById instanceof Map) return toolsById.size > 0;
+  return Object.keys(toolsById).length > 0;
+}
+
+function getDef(toolsById, name) {
+  if (toolsById instanceof Map) return toolsById.get(name);
+  return Object.prototype.hasOwnProperty.call(toolsById, name) ? toolsById[name] : undefined;
+}
+
+/**
+ * Classify a single tool call.
+ *
+ * @param {object} call `{ name?, arguments? }` — `arguments` may be an object
+ *   (opencode's stored shape) or a JSON string.
+ * @param {object|Map|null} toolsById the request's tool list keyed by tool
+ *   name (a plain object or Map). null/empty ⇒ no tool list to check against.
+ * @returns {"valid"|"invalid-json"|"unknown-name"|"schema-mismatch"}
+ */
+export function classifyToolCall(call, toolsById) {
+  const c = call && typeof call === "object" ? call : {};
+  const name = c.name;
+
+  const args = resolveArguments(c.arguments);
+  if (args === null) return "invalid-json";
+
+  const byId = toolsById && typeof toolsById === "object" ? toolsById : null;
+  if (byId !== null && hasAny(byId)) {
+    if (typeof name !== "string") return "unknown-name";
+    const def = getDef(byId, name);
+    if (def === undefined) return "unknown-name";
+    const schema = toolSchema(def);
+    if (schema && violatesSchema(args, schema)) return "schema-mismatch";
+  }
+
+  return "valid";
+}
+
+// Build a name→def lookup from an array of tool definitions.
+function toolsByIdFromList(tools) {
+  const out = Object.create(null);
+  for (const t of Array.isArray(tools) ? tools : []) {
+    if (t && typeof t === "object" && typeof t.name === "string") out[t.name] = t;
+  }
+  return out;
+}
+
+// ---- aggregation ----------------------------------------------------------
+
+/**
+ * Aggregate at REQUEST level: one bad call makes one bad request, not a
+ * fraction. `requests` is the count of requests that ended in tool calls.
+ *
+ * @param {Array<{toolCalls?: Array, tools?: Array}>} requests
+ * @returns {{requests:number, errored:number, rate:number}}
+ */
+export function aggregateReliability(requests) {
+  const list = Array.isArray(requests) ? requests : [];
+  let requestCount = 0;
+  let errored = 0;
+  for (const r of list) {
+    const calls = Array.isArray(r && r.toolCalls) ? r.toolCalls : [];
+    if (calls.length === 0) continue;
+    requestCount += 1;
+    const tools =
+      Array.isArray(r && r.tools) && r.tools.length > 0 ? toolsByIdFromList(r.tools) : null;
+    if (calls.some((c) => classifyToolCall(c, tools) !== "valid")) errored += 1;
+  }
+  const rate = requestCount === 0 ? 0 : errored / requestCount;
+  return { requests: requestCount, errored, rate };
+}
+
+// ---- derank rule ----------------------------------------------------------
+
+function num0(x) {
+  return typeof x === "number" && Number.isFinite(x) ? x : 0;
+}
+function fmtPct(x) {
+  return `${(num0(x) * 100).toFixed(1)}%`;
+}
+
+/**
+ * Should this endpoint be penalised for reliability?
+ *
+ * Rules that keep it honest:
+ *  - below {@link MIN_SAMPLE_REQUESTS} → never penalise (anecdote, not
+ *    evidence), even at a 100% error rate;
+ *  - no baseline to compare against (no baseline rate, or `n <= 1` i.e. a
+ *    model served by a single endpoint) → never penalise — there is nothing to
+ *    be worse than;
+ *  - otherwise penalise only when this endpoint's rate exceeds the same
+ *    MODEL's baseline rate by more than {@link DERANK_MARGIN_SIGMA} standard
+ *    errors of that baseline.
+ *
+ * @param {{requests:number, errored:number, rate:number}} sample  this endpoint
+ * @param {{rate:number, n:number}|null|undefined} baseline  same model's rate
+ *   across all its endpoints; null/undefined ⇒ no baseline
+ * @returns {{penalise:boolean, reason:string}}
+ */
+export function shouldDerank(sample, baseline) {
+  const requests = num0(sample && sample.requests);
+  if (requests < MIN_SAMPLE_REQUESTS) {
+    return { penalise: false, reason: `below sample floor (${requests} < ${MIN_SAMPLE_REQUESTS} requests)` };
+  }
+
+  const b = baseline && typeof baseline === "object" ? baseline : null;
+  if (!b || typeof b.rate !== "number" || typeof b.n !== "number" || !(b.n > 1)) {
+    return { penalise: false, reason: "no baseline to compare against" };
+  }
+
+  const p = b.rate;
+  const se = Math.sqrt((p * (1 - p)) / b.n);
+  const threshold = p + DERANK_MARGIN_SIGMA * se;
+  if (sample.rate > threshold) {
+    return { penalise: true, reason: `rate ${fmtPct(sample.rate)} exceeds baseline ${fmtPct(p)} by >${DERANK_MARGIN_SIGMA}\u03c3` };
+  }
+  return { penalise: false, reason: `within baseline margin (${fmtPct(sample.rate)} \u2264 ${fmtPct(p)} + ${DERANK_MARGIN_SIGMA}\u03c3)` };
+}

--- a/src/shared/toolReliability.test.ts
+++ b/src/shared/toolReliability.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect } from "vitest";
+import {
+  classifyToolCall,
+  aggregateReliability,
+  shouldDerank,
+  MIN_SAMPLE_REQUESTS,
+} from "./toolReliability.mjs";
+import type { ToolCall, ToolDef } from "./toolReliability.mjs";
+
+// A tool with a compileable schema: `path` required-string, `count` integer,
+// `mode` enum.
+const readDef: ToolDef = {
+  name: "read",
+  input_schema: {
+    type: "object",
+    properties: {
+      path: { type: "string" },
+      count: { type: "integer" },
+      mode: { type: "string", enum: ["auto", "manual"] },
+    },
+    required: ["path"],
+  },
+};
+
+function asStr(c: ToolCall): ToolCall {
+  return {
+    ...c,
+    arguments:
+      typeof c.arguments === "object" && c.arguments !== null
+        ? JSON.stringify(c.arguments)
+        : c.arguments,
+  };
+}
+
+describe("classifyToolCall", () => {
+  const tools: Record<string, ToolDef> = { read: readDef };
+
+  it("classifies a valid call as valid", () => {
+    expect(classifyToolCall({ name: "read", arguments: { path: "/x", count: 2 } }, tools)).toBe("valid");
+  });
+
+  it("detects each of the three error classes", () => {
+    // invalid-json: a string that does not parse.
+    expect(classifyToolCall({ name: "read", arguments: "{not json" }, tools)).toBe("invalid-json");
+    // invalid-json: arguments missing entirely.
+    expect(classifyToolCall({ name: "read" }, tools)).toBe("invalid-json");
+    // unknown-name: not in the request's tool list.
+    expect(classifyToolCall({ name: "nope", arguments: {} }, tools)).toBe("unknown-name");
+    // schema-mismatch: required key absent, but otherwise well-formed JSON.
+    expect(classifyToolCall({ name: "read", arguments: { count: 2 } }, tools)).toBe("schema-mismatch");
+    // schema-mismatch: declared type violated.
+    expect(classifyToolCall({ name: "read", arguments: { path: 123 } }, tools)).toBe("schema-mismatch");
+    // schema-mismatch: enum value out of range.
+    expect(classifyToolCall({ name: "read", arguments: { path: "/x", mode: "turbo" } }, tools)).toBe(
+      "schema-mismatch",
+    );
+  });
+
+  it("invalid-json is detected from a stored (object) argument shape too", () => {
+    expect(classifyToolCall({ name: "read", arguments: undefined }, tools)).toBe("invalid-json");
+  });
+
+  it("accepts a JSON-string argument value identically to an object", () => {
+    const asString = asStr({ name: "read", arguments: { path: "/x", count: 3 } });
+    expect(classifyToolCall(asString, tools)).toBe("valid");
+  });
+
+  it("a tool with no schema is always valid, even when its arguments are odd", () => {
+    const bare: Record<string, ToolDef> = { bare: { name: "bare" } };
+    expect(classifyToolCall({ name: "bare", arguments: {} }, bare)).toBe("valid");
+    // Uncompileable schema (a string where an object is expected) → valid.
+    const broken: Record<string, ToolDef> = { broken: { name: "broken", input_schema: "nope" as unknown } };
+    expect(classifyToolCall({ name: "broken", arguments: {} }, broken)).toBe("valid");
+  });
+
+  it("with no tool list at all, unknown-name/schema checks are skipped (conservative)", () => {
+    // No tools → nothing to be unknown against, nothing to violate → valid.
+    expect(classifyToolCall({ name: "anything", arguments: {} }, null)).toBe("valid");
+    expect(classifyToolCall({ name: "anything", arguments: {} }, {})).toBe("valid");
+    // …but a genuinely unparseable argument is STILL invalid-json.
+    expect(classifyToolCall({ name: "anything", arguments: "{bad" }, null)).toBe("invalid-json");
+  });
+
+  it("accepts a Map tool list and a missing name is unknown-name", () => {
+    const map = new Map<string, ToolDef>([["read", readDef]]);
+    expect(classifyToolCall({ name: "read", arguments: { path: "/x" } }, map)).toBe("valid");
+    expect(classifyToolCall({ arguments: {} }, map)).toBe("unknown-name");
+  });
+});
+
+describe("aggregateReliability", () => {
+  const tools = [readDef];
+
+  it("aggregates at request level: 5 calls / 1 bad = 1 errored request", () => {
+    const request = {
+      toolCalls: [
+        { name: "read", arguments: { path: "/a" } },
+        { name: "read", arguments: { path: "/b" } },
+        { name: "read", arguments: { path: "/c" } },
+        { name: "read", arguments: { path: "/d" } },
+        { name: "read", arguments: { path: 42 } }, // schema-mismatch → bad
+      ],
+      tools,
+    };
+    expect(aggregateReliability([request])).toEqual({ requests: 1, errored: 1, rate: 1 });
+  });
+
+  it("counts a request only if it ended in tool calls", () => {
+    const res = aggregateReliability([
+      { toolCalls: [], tools },
+      { toolCalls: [{ name: "read", arguments: { path: "/a" } }], tools },
+      { toolCalls: [{ name: "read", arguments: { path: "/b" } }], tools },
+    ]);
+    // Two tool-ending requests, both clean → rate 0.
+    expect(res).toEqual({ requests: 2, errored: 0, rate: 0 });
+  });
+
+  it("is safe on empty/null input", () => {
+    expect(aggregateReliability([])).toEqual({ requests: 0, errored: 0, rate: 0 });
+    expect(aggregateReliability(null)).toEqual({ requests: 0, errored: 0, rate: 0 });
+  });
+
+  it("skips unknown-name/schema checks when no tools are attached to a request", () => {
+    const res = aggregateReliability([
+      { toolCalls: [{ name: "anything", arguments: {} }] }, // no tools → valid
+    ]);
+    expect(res).toEqual({ requests: 1, errored: 0, rate: 0 });
+  });
+});
+
+describe("shouldDerank", () => {
+  const baseline = { rate: 0.1, n: 1000 };
+
+  it("below the sample floor: never penalise, even at a 100% error rate", () => {
+    const sample = { requests: MIN_SAMPLE_REQUESTS - 1, errored: MIN_SAMPLE_REQUESTS - 1, rate: 1 };
+    expect(sample.requests).toBeLessThan(MIN_SAMPLE_REQUESTS);
+    expect(shouldDerank(sample, baseline)).toEqual({
+      penalise: false,
+      reason: expect.stringContaining("floor"),
+    });
+  });
+
+  it("at/above the floor, materially worse than baseline → penalise", () => {
+    const sample = { requests: 50, errored: 10, rate: 0.2 };
+    expect(shouldDerank(sample, baseline).penalise).toBe(true);
+  });
+
+  it("equal to baseline → do not penalise", () => {
+    const sample = { requests: 50, errored: 5, rate: 0.1 };
+    expect(sample.rate).toBe(baseline.rate);
+    expect(shouldDerank(sample, baseline).penalise).toBe(false);
+  });
+
+  it("close to baseline (within a sigma) → do not penalise", () => {
+    // threshold ≈ 0.1 + 1*sqrt(0.09/1000) ≈ 0.10949; 0.105 is inside.
+    const sample = { requests: 60, errored: 6, rate: 0.1 };
+    expect(shouldDerank(sample, { rate: 0.1, n: 5000 }).penalise).toBe(false);
+  });
+
+  it("no baseline → never penalise", () => {
+    const sample = { requests: 50, errored: 25, rate: 0.5 };
+    expect(shouldDerank(sample, undefined).penalise).toBe(false);
+    expect(shouldDerank(sample, null).penalise).toBe(false);
+  });
+
+  it("a single-endpoint baseline (n<=1) is no baseline → never penalise", () => {
+    const sample = { requests: 50, errored: 25, rate: 0.5 };
+    expect(shouldDerank(sample, { rate: 0.1, n: 1 }).penalise).toBe(false);
+  });
+
+  it("penalise reasons are descriptive when they fire", () => {
+    const sample = { requests: 50, errored: 25, rate: 0.5 };
+    const res = shouldDerank(sample, { rate: 0.1, n: 1000 });
+    expect(res.penalise).toBe(true);
+    expect(res.reason).toContain("exceeds baseline");
+  });
+});


### PR DESCRIPTION
Stage 2 of the Automatic Manta Routing epic — measurement only, no router wiring.

## What
- **`src/shared/toolReliability.mjs`** (pure): `classifyToolCall` (valid / invalid-json / unknown-name / schema-mismatch), request-level `aggregateReliability`, and `shouldDerank` with the `MIN_SAMPLE_REQUESTS` floor + `DERANK_MARGIN_SIGMA` relative-to-baseline margin. Schema-absent/uncompilable tools are always valid (conservative).
- **`src/server/modelLedger.mjs`**: a read-only per-endpoint query (`aggregateEndpointStats` pure + `endpointSummary` I/O) returning `{ reliability, speed, latency, mix }` per `providerID/modelID`, reusing the existing `percentile` / `timedDurationMs` / `TIMING_MAX_MS` and the shared `getDb()` degradation (`{ supported:false }`, never throws, no zeros). Refactored the SQL+parse+role-filter into one `assistantRows` helper shared by both `ledgerSummary` and `endpointSummary`.
- **Tests**: `src/shared/toolReliability.test.ts` (18), `src/server/modelLedger.test.mjs` (per-endpoint shape + `{supported:false}` on unavailable DB).

No new capture path, no new table, no writes, and nothing wired into the router.

**Files changed:** 5 — `src/shared/toolReliability.mjs`, `src/shared/toolReliability.d.mts`, `src/shared/toolReliability.test.ts`, `src/server/modelLedger.mjs`, `src/server/modelLedger.test.mjs`.

**Verification results:**
- PR branch (`multica/BET-1234-tool-reliability` @ `d83c0884`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 2569 pass / 0 fail / 0 skip (vitest 18 in toolReliability + node:test; modelLedger 9/9).
- Base (`main` @ `d16b4388`): not re-run — the shared worktree holds a concurrent agent's uncommitted work, so switching branches would risk clobbering it. PR-branch gate (typecheck + full `npm test`) is green.
- Conclusion: 0 new failures, 0 pre-existing failures observed.

**Cross-cutting note:** this worktree also contained unrelated in-progress BET-1230 changes (provider HTTP status) that I did not touch and did not commit — this PR is the 5 files listed above only.
