### PR TITLE
feat(shared): add autoEligibility completeness gate (BET-1235)

### DIFF
--- a/src/shared/autoEligibility.d.mts
+++ b/src/shared/autoEligibility.d.mts
@@ -1,0 +1,39 @@
+export const MISSING: {
+  IDENTITY: "identity";
+  PRICE: "price";
+  CACHING: "caching";
+  QUALITY: "quality";
+};
+
+export interface OpencodeModel {
+  providerID?: string;
+  id?: string;
+  cost?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+  capabilities?: Record<string, unknown>;
+  limit?: { context?: number | null; output?: number };
+}
+
+export interface AutoEligibilityInput {
+  model: OpencodeModel;
+  identity?: { catalogId?: string; known?: boolean };
+  quality?: { score?: number; known?: boolean };
+  declared?: {
+    catalogId?: string;
+    price?: { input?: number; output?: number } | "free";
+    caches?: boolean | { read?: boolean; write?: boolean };
+    tierOverride?: string;
+  };
+  providerClass: "supported" | "custom";
+}
+
+export interface AutoEligibilityResult {
+  eligible: boolean;
+  missing: string[];
+}
+
+export function autoEligibility(input: AutoEligibilityInput): AutoEligibilityResult;

--- a/src/shared/autoEligibility.mjs
+++ b/src/shared/autoEligibility.mjs
@@ -1,0 +1,64 @@
+// autoEligibility.mjs — the ONE completeness gate shared by the router and the
+// Accounts UI.
+//
+// Auto must only choose endpoints it can fully describe. An endpoint becomes
+// describable two ways — we filled the information in (a *supported* provider
+// from the catalogue + the provider's own model list) or the user did (a
+// *custom* provider, or an override on a supported one). There is exactly one
+// gate, asked once, so those two classes cannot drift into two behaviours.
+//
+// The Accounts UI reads this same function, so "what the UI says is missing"
+// is exactly "what the router is waiting for". Pure + framework-free (no I/O,
+// no time, no imports) so the server, renderer and tests share one answer.
+//
+// This function is ONLY about description completeness. It deliberately does
+// NOT consider account state/balance (a custom provider legitimately has
+// none), whether the user ticked the model (that is consent, checked by
+// listRoutableModels), per-turn capability/context fit (the per-turn
+// constraint stage), or provider health (the per-turn availability stage).
+
+/** Stable machine keys for each thing Auto cannot yet describe. The renderer
+ *  owns the human sentence for each key — never put user-facing copy here. */
+export const MISSING = {
+  IDENTITY: "identity", // which model is this?
+  PRICE: "price", // what does a token cost here?
+  CACHING: "caching", // does it cache, and at what rate?
+  QUALITY: "quality", // we cannot place it in the field
+};
+
+export function autoEligibility(input) {
+  const model = input?.model;
+  const identity = input?.identity;
+  const quality = input?.quality;
+  const declared = input?.declared;
+
+  const missing = [];
+
+  // IDENTITY — which model is this? Resolved by identity.known (the catalogue
+  // recognised it) or by the user declaring a catalogId for it.
+  const identityKnown = Boolean(identity?.known) || Boolean(declared?.catalogId);
+  if (!identityKnown) missing.push(MISSING.IDENTITY);
+
+  // PRICE — what does a token cost here? Satisfied by the provider's own cost
+  // figures or by an explicit declaration (incl. "free", a complete answer).
+  const hasModelPrice =
+    Number.isFinite(model?.cost?.input) || Number.isFinite(model?.cost?.output);
+  const hasDeclaredPrice = declared?.price !== undefined;
+  if (!hasModelPrice && !hasDeclaredPrice) missing.push(MISSING.PRICE);
+
+  // CACHING — does it cache, and at what rate? Satisfied by cache rates on the
+  // provider's cost or by an explicit declaration (incl. false = "no caching",
+  // the safe assumption).
+  const hasCacheRates =
+    model?.cost?.cacheRead !== undefined || model?.cost?.cacheWrite !== undefined;
+  const hasDeclaredCaches = declared?.caches !== undefined;
+  if (!hasCacheRates && !hasDeclaredCaches) missing.push(MISSING.CACHING);
+
+  // QUALITY — can we place it in the field to honour a tier floor? Missing
+  // when quality is known-false; an explicit tierOverride satisfies it.
+  const qualityKnown = quality?.known !== false;
+  const hasTierOverride = Boolean(declared?.tierOverride);
+  if (!qualityKnown && !hasTierOverride) missing.push(MISSING.QUALITY);
+
+  return { eligible: missing.length === 0, missing };
+}

--- a/src/shared/autoEligibility.test.ts
+++ b/src/shared/autoEligibility.test.ts
@@ -1,0 +1,129 @@
+import { describe, it, expect } from "vitest";
+import { autoEligibility, MISSING } from "./autoEligibility.mjs";
+import type { AutoEligibilityInput } from "./autoEligibility.mjs";
+
+// A fully-described endpoint — every requirement is satisfied by either the
+// catalogue/provider data or the user declaration.
+function complete(over: Partial<AutoEligibilityInput> = {}): AutoEligibilityInput {
+  return {
+    providerClass: "custom",
+    model: { providerID: "custom", id: "m1", cost: { input: 1, output: 3 } },
+    identity: { known: false },
+    quality: { known: true, score: 0.8 },
+    declared: {
+      catalogId: "some-catalog-model",
+      price: { input: 1, output: 3 },
+      caches: { read: true, write: true },
+      tierOverride: "balanced",
+    },
+    ...over,
+  };
+}
+
+describe("autoEligibility", () => {
+  it("fully described custom endpoint is eligible with no penalty vs a supported one", () => {
+    const custom = autoEligibility(complete({ providerClass: "custom" }));
+    const supported = autoEligibility(complete({ providerClass: "supported" }));
+    expect(custom.eligible).toBe(true);
+    expect(custom.missing).toEqual([]);
+    expect(supported.eligible).toBe(true);
+    expect(supported.missing).toEqual([]);
+    // Same data → same shape for both classes; class never changes the verdict.
+    expect(supported).toEqual(custom);
+  });
+
+  it("nothing declared → missing identity, price and caching", () => {
+    const res = autoEligibility({
+      providerClass: "custom",
+      model: { providerID: "custom", id: "m1" },
+    });
+    expect(res.eligible).toBe(false);
+    expect(res.missing).toContain(MISSING.IDENTITY);
+    expect(res.missing).toContain(MISSING.PRICE);
+    expect(res.missing).toContain(MISSING.CACHING);
+  });
+
+  it("identity declared only → still ineligible, but identity no longer missing", () => {
+    const res = autoEligibility({
+      providerClass: "custom",
+      model: { providerID: "custom", id: "m1" },
+      declared: { catalogId: "catalog-alpha" },
+    });
+    expect(res.eligible).toBe(false);
+    expect(res.missing).not.toContain(MISSING.IDENTITY);
+    expect(res.missing).toContain(MISSING.PRICE);
+    expect(res.missing).toContain(MISSING.CACHING);
+  });
+
+  it("price: 'free' satisfies PRICE; caches: false satisfies CACHING", () => {
+    const res = autoEligibility({
+      providerClass: "custom",
+      model: { providerID: "custom", id: "m1" },
+      identity: { known: true },
+      quality: { known: true, score: 0.9 },
+      declared: { price: "free", caches: false },
+    });
+    expect(res.eligible).toBe(true);
+    expect(res.missing).toEqual([]);
+  });
+
+  it("quality.known === false and no tierOverride → QUALITY missing", () => {
+    const { tierOverride, ...declaredNoTier } = complete().declared!;
+    const res = autoEligibility(
+      complete({
+        quality: { known: false, score: undefined },
+        declared: declaredNoTier,
+      }),
+    );
+    expect(res.eligible).toBe(false);
+    expect(res.missing).toContain(MISSING.QUALITY);
+  });
+
+  it("quality.known === false, tierOverride present → QUALITY satisfied", () => {
+    const res = autoEligibility(
+      complete({
+        quality: { known: false, score: undefined },
+        declared: { tierOverride: "fast" },
+      }),
+    );
+    expect(res.missing).not.toContain(MISSING.QUALITY);
+  });
+
+  it("declared identity (catalogId) satisfies IDENTITY even when identity.known is false", () => {
+    const res = autoEligibility(
+      complete({ identity: { known: false }, quality: { known: true, score: 0.8 } }),
+    );
+    expect(res.missing).not.toContain(MISSING.IDENTITY);
+    expect(res.eligible).toBe(true);
+  });
+
+  it("provider cost figures satisfy PRICE and CACHING without declarations", () => {
+    const res = autoEligibility(
+      complete({
+        model: {
+          providerID: "anthropic",
+          id: "claude-sonnet-4-6",
+          cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+        },
+        declared: undefined,
+      }),
+    );
+    expect(res.missing).not.toContain(MISSING.PRICE);
+    expect(res.missing).not.toContain(MISSING.CACHING);
+  });
+
+  it("a supported provider with a gap reports it rather than being waved through", () => {
+    // A supported provider that is missing its cost figures is a bug we own —
+    // the gate must report it, not short-circuit on class.
+    const res = autoEligibility({
+      providerClass: "supported",
+      model: { providerID: "anthropic", id: "claude-sonnet-4-6" },
+      identity: { known: true },
+      quality: { known: true, score: 0.9 },
+      declared: undefined,
+    });
+    expect(res.eligible).toBe(false);
+    expect(res.missing).toContain(MISSING.PRICE);
+    expect(res.missing).toContain(MISSING.CACHING);
+  });
+});


### PR DESCRIPTION
**Base: origin/main @ f58b7df6**

## What

Adds `src/shared/autoEligibility.mjs` — the single description-completeness gate shared by the router and the Accounts UI, plus `autoEligibility.d.mts` types and `autoEligibility.test.ts`.

- One function, one gate: exactly what the UI reports as "missing" is exactly what the router waits for, because both read the same pure module.
- Exported `MISSING` const (identity / price / caching / quality) with stable machine keys; the module ships **no user-facing copy** (renderer owns the sentences).
- Rules implemented exactly as specced:
  - IDENTITY: missing when neither `identity.known` nor `declared.catalogId` resolves it.
  - PRICE: missing when `model.cost` has no input/output **and** `declared.price` absent; `"free"` is a complete answer.
  - CACHING: missing when cache rates absent from `model.cost` **and** `declared.caches` absent; `false` (safe assumption) satisfies it.
  - QUALITY: missing when `quality.known === false`; `declared.tierOverride` satisfies it.
- `providerClass` never short-circuits — a supported provider with a gap reports it (a bug we own), verified by test.
- Deliberately NOT in the gate: account/balance, model-tick consent, per-turn capability fit, provider health.

`model.cost` uses the canonical field names from BET-1228 normalisation (`input`/`output`/`cacheRead`/`cacheWrite`).

**Files changed:** 3 files, all new (`autoEligibility.mjs`, `autoEligibility.d.mts`, `autoEligibility.test.ts`).

**Verification results:**
- PR branch (`multica/BET-1235-auto-eligibility` @ `24b7cdc4`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2572 pass / 0 fail / 0 skip. Failures: none. log sha256: `c7ff5677fc5cce112faf09bd19f6a75c52145e5098dd5978e27f7fb737248efa`
- Base (`main` @ `f58b7df6`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 1, 2565 pass / 1 fail / 0 skip. Failure: `src/server/usage.test.mjs:824` "poller: a waiting window re-polls a bounded number of times, then stops" (3 !== 4 — a timing-flaky count, unrelated to this change; it passed on the PR branch). log sha256: `4101348a8d36d0b2d06d771f54203c48fdbd96701b7e979b2d871637ca268d71`
- **Conclusion:** 1 test failure is pre-existing/flaky on main (timing-dependent poller count), 0 failures are new and caused by this PR.

Logs at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
