### PR TITLE
Routing: preserve provider HTTP status + Retry-After on the model-turn path (BET-1230)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -45,6 +45,7 @@ import { buildHandlers, handleRpcRequest } from "./rpc.mjs";
 import { startStatusPoller } from "./status.mjs";
 import { createSyncState } from "./syncState.mjs";
 import { createStreamInterpreter } from "./streamInterp.mjs";
+import { enrichProviderError } from "../shared/streamInterpretation.mjs";
 import { startOutboxPoller, pushArtifact, createArtifactSweep } from "./outbox.mjs";
 import { startUploadCleanupPoller } from "./uploads.mjs";
 import {
@@ -1100,6 +1101,17 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
   const forwardedUpdate = forwardOpencodeUpdate(evt);
   if (forwardedUpdate) {
     bus.publish(forwardedUpdate);
+  }
+  // Preserve the provider HTTP status on a failed turn (BET-1230). The raw
+  // `session.error` message is "<reason phrase>: <body>" — parse the phrase
+  // back to a status so downstream (provider health, Stage 4) can tell 402
+  // (out of credit) from 429 (rate limited) from 5xx (broken) without
+  // substring-matching error text. Purely additive: `error` is replaced by an
+  // enriched copy whose `name` / `data.message` are byte-identical, so every
+  // existing consumer (renderer banner, push classification, the usage-stop
+  // enroller) keeps working unchanged.
+  if (evt && evt.type === "session.error" && evt.properties?.error) {
+    evt.properties.error = enrichProviderError(evt.properties.error);
   }
   // Box-side stream interpretation (BET-551 / §17): derive interpreted events
   // from the raw opencode stream and publish them on the SAME bus (no second

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -15,6 +15,7 @@ import http from "node:http";
 import { expandTilde, patchPath } from "../shared/paths.mjs";
 import { readModalities } from "../shared/modelGuide.mjs";
 import { startPoller } from "./startPoller.mjs";
+import { parseRetryAfterMs } from "./usageAdapters/httpError.mjs";
 import {
   CREDENTIALS_PATH,
   parseCredentials,
@@ -659,7 +660,15 @@ export async function sendPrompt({ sessionId, text, model, agent, attachments, m
     body: JSON.stringify(body),
   });
   if (!res.ok) {
-    throw new Error(`opencode sendPrompt ${res.status}: ${await res.text()}`);
+    const err = new Error(`opencode sendPrompt ${res.status}: ${await res.text()}`);
+    // Mirror the usage-meter HTTP error shape (usageAdapters/httpError.mjs):
+    // carry the real status + Retry-After so the provider-refusal path can
+    // tell 402 (out of credit) from 429 (rate limited) from 5xx (broken)
+    // without string-matching the body (BET-1230).
+    err.status = res.status;
+    const retryAfterMs = parseRetryAfterMs(res.headers?.get?.("retry-after"));
+    if (retryAfterMs !== undefined) err.retryAfterMs = retryAfterMs;
+    throw err;
   }
 }
 

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -365,6 +365,38 @@ test("createSession primes directory cache; sendPrompt then appends ?directory="
   );
 });
 
+test("sendPrompt non-2xx carries status + Retry-After (BET-1230)", async () => {
+  // The model-turn path must mirror the usage meter's HTTP error shape so a
+  // refusal can be told apart by status (402/429/5xx) without string-matching.
+  _resetSessionDirectoryCache();
+  await withMockFetch(
+    async (url) => {
+      if (String(url).startsWith("http://127.0.0.1:4096/session?directory=")) {
+        return new Response(
+          JSON.stringify({ id: "ses_rl", title: "t", directory: "/w", projectID: "p" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("slow down", {
+        status: 429,
+        headers: { "retry-after": "30" },
+      });
+    },
+    async () => {
+      let thrown = null;
+      try {
+        await sendPrompt({ sessionId: "ses_rl", text: "hi" });
+      } catch (e) {
+        thrown = e;
+      }
+      assert.ok(thrown, "expected sendPrompt to throw on a non-2xx");
+      assert.equal(thrown.status, 429);
+      assert.equal(thrown.retryAfterMs, 30_000);
+      assert.match(thrown.message, /429/);
+    },
+  );
+});
+
 test("sendPrompt includes agent when passed and omits it when not", async () => {
   // BET-949: the plan-mode chip must drive `agent:"plan"` on the prompt_async
   // body; an omitted agent keeps today's body byte-identical.

--- a/src/server/usageAdapters/httpError.mjs
+++ b/src/server/usageAdapters/httpError.mjs
@@ -8,6 +8,23 @@
 // regardless of status — only usage.mjs's 429 branch reads it.
 
 /**
+ * Parse a `Retry-After` header value (seconds) into milliseconds, or
+ * undefined when there's no usable value. `>= 0`, NOT `> 0`: Anthropic's
+ * usage endpoint answers a 429 with a literal `retry-after: 0`, and treating
+ * that as "no header" is what sent the poller into its long default backoff
+ * and blanked the dial for 15 minutes at a time. A falsy raw header (absent
+ * or "") stays undefined. Shared so the model-turn path (BET-1230) parses it
+ * the same way the usage meter does.
+ * @param {string|undefined|null} raw
+ * @returns {number|undefined}
+ */
+export function parseRetryAfterMs(raw) {
+  const secs = raw ? Number(raw) : NaN;
+  if (Number.isFinite(secs) && secs >= 0) return secs * 1000;
+  return undefined;
+}
+
+/**
  * @param {{status:number, headers?:{get?:(name:string)=>string|null|undefined}}} res
  * @param {string} label  short adapter-provided context for the message, e.g. "claude usage"
  * @returns {Error & {status:number, retryAfterMs?:number}}
@@ -17,12 +34,8 @@ export function httpError(res, label) {
   err.status = res.status;
   // Parsed regardless of status: only usage.mjs's 429 branch reads
   // `retryAfterMs`, so a status guard here would gate a field nobody else
-  // touches. `>= 0`, NOT `> 0`: Anthropic's usage endpoint answers a 429 with
-  // a literal `retry-after: 0`, and treating that as "no header" is what sent
-  // the poller into its long default backoff and blanked the dial for 15
-  // minutes at a time. A falsy raw header (absent or "") stays undefined.
-  const raw = res.headers?.get?.("retry-after");
-  const secs = raw ? Number(raw) : NaN;
-  if (Number.isFinite(secs) && secs >= 0) err.retryAfterMs = secs * 1000;
+  // touches.
+  const retryAfterMs = parseRetryAfterMs(res.headers?.get?.("retry-after"));
+  if (retryAfterMs !== undefined) err.retryAfterMs = retryAfterMs;
   return err;
 }

--- a/src/server/usageStopEnroll.mjs
+++ b/src/server/usageStopEnroll.mjs
@@ -53,7 +53,7 @@ function freshModel(sessionId) {
  * @param {(adapterId: string) => Promise<boolean>|boolean} deps.recheckAtLimit  wire to recheckAdapterAtLimit
  * @param {(sessionId: string) => Promise<string|undefined>|string|undefined} [deps.resolveWorkspace]  best-effort project label
  * @param {() => number} [deps.now]
- * @returns {{ observeEvent: (evt: object) => void }}
+ * @returns {{ observeEvent: (evt: object) => void, getSessionModel: (sessionId: string) => {adapterId:string|null, model?:string, cachedTokens:number}|null }}
  */
 export function createUsageStopEngine({ upsert, recheckAtLimit, resolveWorkspace = () => "", now = () => Date.now() } = {}) {
   const sessionModel = new Map(); // sessionId -> {conversation, adapterId, model?, cachedTokens}
@@ -147,5 +147,16 @@ export function createUsageStopEngine({ upsert, recheckAtLimit, resolveWorkspace
     }
   }
 
-  return { observeEvent };
+  // Read-only view of the per-session provider record this engine already
+  // keeps (fed by `session.next.step.ended` — the ONLY event that carries the
+  // provider). Stage 4's provider-health record reads the SAME cache rather
+  // than building a second one (BET-1230). Returns null for a session whose
+  // provider was never observed.
+  function getSessionModel(sessionId) {
+    const m = sessionModel.get(sessionId);
+    if (!m) return null;
+    return { adapterId: m.adapterId, model: m.model, cachedTokens: m.cachedTokens };
+  }
+
+  return { observeEvent, getSessionModel };
 }

--- a/src/server/usageStopEnroll.test.mjs
+++ b/src/server/usageStopEnroll.test.mjs
@@ -138,3 +138,17 @@ test("non-error and non-step events are ignored", async () => {
   engine.observeEvent({ type: "message.part.updated", properties: {} });
   assert.equal(upserts.length, 0);
 });
+
+test("getSessionModel exposes the cached provider record (BET-1230)", () => {
+  const { engine } = harness();
+  // Before any step event: no record.
+  assert.equal(engine.getSessionModel("s1"), null);
+  // A step event seeds the per-session provider cache.
+  engine.observeEvent(stepEvent("s1", "openai", "gpt-5", { read: 2, write: 3 }));
+  const m = engine.getSessionModel("s1");
+  assert.equal(m.adapterId, "codex"); // openai -> adapter id "codex"
+  assert.equal(m.model, "gpt-5");
+  assert.equal(m.cachedTokens, 5);
+  // An unknown session stays null.
+  assert.equal(engine.getSessionModel("nobody"), null);
+});

--- a/src/shared/streamInterpretation.d.mts
+++ b/src/shared/streamInterpretation.d.mts
@@ -25,6 +25,18 @@ export function describeTruncation(kind: TruncationKind): {
  *  (`<reason phrase>: <JSON>`), or return the input unchanged. Lossless. */
 export function humanizeProviderError(raw: string): string;
 
+/** Map a provider error message's leading HTTP reason phrase to a status
+ *  code, or null when the phrase isn't in the closed table (BET-1230). */
+export function providerErrorStatus(message: string | null | undefined): number | null;
+
+/** Enrich a `session.error` `properties.error` with `httpStatus` /
+ *  `retryAfterMs`, preserving `name` / `data.message`. Returns the same
+ *  reference when nothing is resolvable. */
+export function enrichProviderError(
+  error: Record<string, any> | null | undefined,
+  retryAfterMs?: number,
+): Record<string, any>;
+
 export function findFlushBoundary(buffer: string): number;
 
 /** Max time a chunk may be withheld before the caller flushes at the latest

--- a/src/shared/streamInterpretation.mjs
+++ b/src/shared/streamInterpretation.mjs
@@ -154,6 +154,85 @@ function extractErrorSentence(parsed) {
   return null;
 }
 
+// ===== Provider HTTP status (BET-1230) =====
+// The provider's HTTP status does not survive on the model-turn path: a
+// refusal arrives as a `session.error` whose message is
+// "<HTTP reason phrase>: <raw provider body>", e.g.
+//   'Payment Required: {"detail":{"message":"Quota exceeded…"}}'.
+// `humanizeProviderError` (above) discards the leading phrase in favour of
+// the inner sentence; these helpers are a SECOND, additive reader of the
+// same string that maps the phrase back to a status code so downstream
+// (provider health, Stage 4) can distinguish 402 (out of credit) from 429
+// (rate limited) from 5xx (broken) without substring-matching error text.
+
+// Closed table of HTTP reason phrases → status codes. CLOSED by design —
+// only phrases listed here map; anything else yields null, so a wording that
+// fails to match fails VISIBLY (null) instead of being silently misread.
+// Greppable: to add a phrase, edit the table, not a regex.
+// Keys are lowercase; opencode reports the provider's raw reason phrase.
+const REASON_PHRASE_STATUS = new Map([
+  // 4xx — client / auth / capability refusals
+  ["bad request", 400],
+  ["unauthorized", 401],
+  ["payment required", 402],
+  ["forbidden", 403],
+  ["not found", 404],
+  ["method not allowed", 405],
+  ["not acceptable", 406],
+  ["request timeout", 408],
+  ["conflict", 409],
+  ["gone", 410],
+  ["unprocessable entity", 422],
+  ["too many requests", 429],
+  // 5xx — provider side / upstream broken
+  ["internal server error", 500],
+  ["not implemented", 501],
+  ["bad gateway", 502],
+  ["service unavailable", 503],
+  ["gateway timeout", 504],
+  ["http version not supported", 505],
+]);
+
+/**
+ * Map a provider error message's leading HTTP reason phrase to a status code,
+ * or null when the leading segment isn't a known phrase. Returns null for
+ * anything that isn't a non-empty `<phrase>: `-prefixed string. Does not
+ * mutate or affect `humanizeProviderError` — it is an additive reader of the
+ * same string. Pure, no I/O, no throw.
+ * @param {string} message
+ * @returns {number | null}
+ */
+export function providerErrorStatus(message) {
+  if (typeof message !== "string") return null;
+  const sep = message.indexOf(": ");
+  if (sep <= 0) return null;
+  return REASON_PHRASE_STATUS.get(message.slice(0, sep).toLowerCase()) ?? null;
+}
+
+/**
+ * Enrich a `session.error` event's `properties.error` object with the
+ * provider's `httpStatus` (parsed from the message's leading reason phrase)
+ * and, when supplied, `retryAfterMs`. Purely additive: `name` and
+ * `data.message` are copied through untouched, so every existing consumer
+ * (renderer banner, push classification, the usage-stop enroller) keeps
+ * working unchanged. Returns the SAME reference when nothing is resolvable.
+ *
+ * @param {object} error  `evt.properties.error` of a `session.error` event
+ * @param {number} [retryAfterMs]  ms from a Retry-After header, when in hand
+ * @returns {object}
+ */
+export function enrichProviderError(error, retryAfterMs) {
+  const message =
+    typeof error?.data?.message === "string" ? error.data.message : "";
+  const httpStatus = providerErrorStatus(message);
+  if (httpStatus == null && retryAfterMs == null) return error;
+  return {
+    ...error,
+    ...(httpStatus != null ? { httpStatus } : {}),
+    ...(retryAfterMs != null ? { retryAfterMs } : {}),
+  };
+}
+
 // ===== Streamed-text flush boundaries =====
 //
 // opencode streams text/reasoning content via `message.part.delta` events

--- a/src/shared/streamInterpretation.test.ts
+++ b/src/shared/streamInterpretation.test.ts
@@ -39,6 +39,8 @@ import {
   shouldDropEventForSessionFilter,
   summarizeChildSession,
   humanizeProviderError,
+  providerErrorStatus,
+  enrichProviderError,
 } from "./streamInterpretation.mjs";
 
 
@@ -2153,5 +2155,80 @@ describe("humanizeProviderError", () => {
       const once = humanizeProviderError(raw);
       expect(humanizeProviderError(once)).toBe(once);
     }
+  });
+
+  // BET-1230 pin: the new status reader must NOT move the banner copy. These are
+  // the same reason-phrase messages providerErrorStatus maps; the sentence the
+  // renderer shows is unchanged from before providerErrorStatus existed.
+  it("is unchanged for status-carrying messages (BET-1230 pin)", () => {
+    expect(humanizeProviderError('Payment Required: {"detail":"Balance $0"}')).toBe("Balance $0");
+    expect(humanizeProviderError('Too Many Requests: {"message":"slow down"}')).toBe("slow down");
+    expect(humanizeProviderError('Unauthorized: {"error":{"message":"bad key"}}')).toBe("bad key");
+  });
+});
+
+describe("providerErrorStatus", () => {
+  it("maps the leading HTTP reason phrase to its code", () => {
+    expect(providerErrorStatus('Payment Required: {"detail":"Quota exceeded"}')).toBe(402);
+    expect(providerErrorStatus('Too Many Requests: {"message":"slow down"}')).toBe(429);
+    expect(providerErrorStatus('Unauthorized: {"error":{"message":"bad key"}}')).toBe(401);
+    expect(providerErrorStatus('Bad Request: {"message":"nope"}}')).toBe(400);
+    expect(providerErrorStatus('Service Unavailable: {"detail":"down"}}')).toBe(503);
+    expect(providerErrorStatus('Internal Server Error: {"detail":"boom"}}')).toBe(500);
+  });
+
+  it("is case-insensitive on the phrase", () => {
+    expect(providerErrorStatus("payment required: {}")).toBe(402);
+    expect(providerErrorStatus("TOO MANY REQUESTS: {}")).toBe(429);
+  });
+
+  it("returns null when there is no leading reason phrase", () => {
+    expect(providerErrorStatus("some provider was unhappy")).toBe(null);
+  });
+
+  it("returns null for an unknown phrase — never a guess", () => {
+    expect(providerErrorStatus("Coffee Machine is Angry: {}")).toBe(null);
+  });
+
+  it("returns null for non-string or empty input", () => {
+    expect(providerErrorStatus(null)).toBe(null);
+    expect(providerErrorStatus(undefined)).toBe(null);
+    expect(providerErrorStatus("")).toBe(null);
+    // No ": " separator.
+    expect(providerErrorStatus("Payment Required")).toBe(null);
+  });
+});
+
+describe("enrichProviderError", () => {
+  it("attaches httpStatus parsed from the message, preserving name + data", () => {
+    const err = {
+      name: "ApiError",
+      data: { message: 'Payment Required: {"detail":"Balance $0"}' },
+    };
+    const out = enrichProviderError(err);
+    expect(out.httpStatus).toBe(402);
+    expect(out.name).toBe("ApiError");
+    expect(out.data.message).toBe('Payment Required: {"detail":"Balance $0"}');
+    expect(out.retryAfterMs).toBeUndefined();
+  });
+
+  it("attaches retryAfterMs when supplied", () => {
+    const err = { name: "ApiError", data: { message: "Too Many Requests: {}" } };
+    const out = enrichProviderError(err, 30_000);
+    expect(out.httpStatus).toBe(429);
+    expect(out.retryAfterMs).toBe(30_000);
+  });
+
+  it("returns the same reference when nothing is resolvable", () => {
+    const err = { name: "ApiError", data: { message: "some provider was unhappy" } };
+    expect(enrichProviderError(err)).toBe(err);
+  });
+
+  it("is additive — leaves unknown fields intact", () => {
+    const err = { name: "ApiError", extra: 1, data: { message: "Bad Request: {}" } };
+    const out = enrichProviderError(err);
+    expect(out.httpStatus).toBe(400);
+    expect(out.extra).toBe(1);
+    expect(out.data.message).toBe("Bad Request: {}");
   });
 });


### PR DESCRIPTION
## BET-1230 — Routing: preserve the provider HTTP status and Retry-After on the model-turn path

Stage 1 of the Automatic Manta Routing epic — the enabling piece for provider health (Stage 4), so it can distinguish *out of credit* (402) from *rate limited* (429) from *broken* (5xx) without substring-matching error text.

**What changed** (9 files, +269/−10):

1. **Pure status parser** (`src/shared/streamInterpretation.mjs`) — `providerErrorStatus(message)` maps a `session.error` message's leading HTTP reason phrase to a code via a **closed** reason-phrase→status table (unknown phrase → `null`, never a guess). `enrichProviderError(error, retryAfterMs?)` is a second, purely-additive reader that copies `name`/`data.message` through untouched, so existing consumers are byte-identical. Surfaces `httpStatus` and, when supplied, `retryAfterMs`.
2. **Enrich at the bus** (`src/server/index.mjs` opencode pump) — a `session.error` event gets `properties.error.httpStatus` (and `retryAfterMs` when in hand) before republish. This is what carries the 402 on the wire.
3. **Real-Response capture** (`src/server/opencode.mjs` `sendPrompt`) — on a non-2xx it now throws an Error shaped like the usage meter's `httpError` (`.status` + `.retryAfterMs` from a `Retry-After` header), mirroring `httpError.mjs` rather than inventing a second shape.
4. **DRY the Retry-After parse** (`src/server/usageAdapters/httpError.mjs`) — extracted the `>= 0` (not `> 0`) retry-after parsing into an exported `parseRetryAfterMs`, reused by both `httpError` and `sendPrompt`. Behaviour unchanged.
5. **Stage-4 cache** (`src/server/usageStopEnroll.mjs`) — exposed the per-session `{adapterId, model, cachedTokens}` record (fed by `session.next.step.ended`, the only event carrying the provider) as `getSessionModel(sessionId)`, so provider health reads the same cache instead of building a second one.

**Tests**: `providerErrorStatus` (mapping, case-insensitivity, nulls, unknown-phrase → null), `enrichProviderError` (status preservation, retryAfterMs, same-reference no-op, additivity), a BET-1230 pin that `humanizeProviderError` output for status-carrying messages is **unchanged**, `sendPrompt` non-2xx carrying status + Retry-After, and `getSessionModel` exposing the provider record.

**Do-nots honoured**: no credit-refusal routing into plan-limit machinery (`usageStopper.mjs` untouched); `humanizeProviderError` output unchanged (pinned); no retry/failover behavior added — this only makes the status visible.

**Cross-cutting**: none. This change is purely additive on the model-turn path.

---
**Base: origin/main @ `f58b7df6`** (the SHA this branch was cut from).

**Files changed:** 9 files (see diff stat above).

**Verification results:**
- PR branch (`multica/BET-1230-provider-http-status` @ `b1bbdd96`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, `2574` pass / `0` fail / `0` skip (node:test) + `3281` pass / `7` skip (vitest). Failures: none. log sha256: `79a70e0ae51286042b996784dbd0abeb9c4c73307f3d26879c591ea6ee6fd44b`
- Base (`main` @ `f58b7df6`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, `2572` pass / `0` fail / `0` skip (node:test) + `3271` pass / `7` skip (vitest). Failures: none. log sha256: `834b228a826cd8af8cc47605f7c89ef4fe2d4323823ec38cd9552eed2c7723cb`
- **Conclusion:** `0` new failures. The PR adds 10 renderer tests + 2 server tests, all green; the branch typecheck output is byte-identical to main.

Logs cached at `/tmp/typecheck-branch.log`, `/tmp/test-branch2.log`, `/tmp/typecheck-main.log`, `/tmp/test-main.log` for reviewer spot-check.
