### PR TITLE
fix(ios): subagent drill-in transcript scrolls (BET-1211)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -50,6 +50,7 @@
 		6115C3531A59C0517C8C214A /* VoiceNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED9F61E845DE68677AFEFF2 /* VoiceNote.swift */; };
 		612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */; };
 		61441105C65E4D7385DAF363 /* TerminalWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BDC7F6FA94631DA4C55A948 /* TerminalWebView.swift */; };
+		6386FDB578224149980B97DE /* MantaSubagentScrollDiagUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3CB28CCDC78C4C48410D03 /* MantaSubagentScrollDiagUITests.swift */; };
 		650862947C7F0D6C393C94BB /* ChatTranscriptTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C25DFE9E1AD1E939DBF7101D /* ChatTranscriptTests.swift */; };
 		6545C305B308C5D49D581CFC /* MantaOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4B1B39AEF93CAAB814A6DBD7 /* MantaOnboarding.swift */; };
 		67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */; };
@@ -254,6 +255,7 @@
 		E246039C1A3AA38065BE89B0 /* ChatJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatJSON.swift; sourceTree = "<group>"; };
 		E4A5AE775D3F3D82FC69A54F /* VoiceGestureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceGestureTests.swift; sourceTree = "<group>"; };
 		E4FA4CCB9740565057F26D31 /* MantaLiveArtifactsUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaLiveArtifactsUITests.swift; sourceTree = "<group>"; };
+		EA3CB28CCDC78C4C48410D03 /* MantaSubagentScrollDiagUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSubagentScrollDiagUITests.swift; sourceTree = "<group>"; };
 		EAA20AACFCE7D2BA897AE130 /* VoiceNotePlayer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceNotePlayer.swift; sourceTree = "<group>"; };
 		EBC7D0BF807861DCCABC5A26 /* MantaResourceCardModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaResourceCardModelsTests.swift; sourceTree = "<group>"; };
 		ED6ABAA46F1CBD2093D4AC87 /* ComposerTypeahead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTypeahead.swift; sourceTree = "<group>"; };
@@ -465,6 +467,7 @@
 				17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */,
 				39217C665D64CEFA1C5F5C79 /* MantaScrollTraceUITests.swift */,
 				12A39FBE813A8B20F7F00055 /* MantaSubagentDrillInUITests.swift */,
+				EA3CB28CCDC78C4C48410D03 /* MantaSubagentScrollDiagUITests.swift */,
 				7442EBB8ACC827C69BDD2B6E /* MantaTranscriptGestureUITests.swift */,
 				714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */,
 				5EF0199856D7E4C0B0D2595C /* MantaUIOverflowCaptureUITests.swift */,
@@ -640,6 +643,7 @@
 				51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */,
 				12BF6CF95679710C484807E9 /* MantaScrollTraceUITests.swift in Sources */,
 				DE5E17651AB0E9C750C4D712 /* MantaSubagentDrillInUITests.swift in Sources */,
+				6386FDB578224149980B97DE /* MantaSubagentScrollDiagUITests.swift in Sources */,
 				6AA12AFE81F85477EBFB3D25 /* MantaTranscriptGestureUITests.swift in Sources */,
 				4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */,
 				ECB0360A8A26279B6EEF955F /* MantaUIOverflowCaptureUITests.swift in Sources */,

--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		058E2179669599C216446E7C /* ToolOutputPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD2C923C52DE07EB54AB821 /* ToolOutputPreviewTests.swift */; };
 		0DA0C1C92C06A3BED780494E /* UsageMeters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A81D1BB24FB02E4DFFA04FE /* UsageMeters.swift */; };
 		12070C130BD9D1CD9EA0603F /* WaveformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF7554D798247FECA6BFF84 /* WaveformTests.swift */; };
+		12BF6CF95679710C484807E9 /* MantaScrollTraceUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39217C665D64CEFA1C5F5C79 /* MantaScrollTraceUITests.swift */; };
 		12C1D08D7311357D1872FA18 /* ChatJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = E246039C1A3AA38065BE89B0 /* ChatJSON.swift */; };
 		1888AC1DE5A98EFBE6DDEA51 /* DeprecatedModelOptIns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6169B72F37CC138729DDD22E /* DeprecatedModelOptIns.swift */; };
 		1A55CBC343898856735AF0F8 /* MantaChatSurfaceCaptureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 570E190164DB3AB83DC14283 /* MantaChatSurfaceCaptureUITests.swift */; };
@@ -166,6 +167,7 @@
 		35ECC10E3DB9A931F8EB5420 /* MantaUI.app */ = {isa = PBXFileReference; includeInIndex = 0; lastKnownFileType = wrapper.application; path = MantaUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		36E99A4154D594C6A36FB890 /* MantaLiveTypeaheadSlashUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaLiveTypeaheadSlashUITests.swift; sourceTree = "<group>"; };
 		38864A574D6CE5142E07B487 /* ModelRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelRecentsTests.swift; sourceTree = "<group>"; };
+		39217C665D64CEFA1C5F5C79 /* MantaScrollTraceUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaScrollTraceUITests.swift; sourceTree = "<group>"; };
 		39978655A14BFA5D39336286 /* MantaSettingsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsModels.swift; sourceTree = "<group>"; };
 		39B5E0C86E9FA4A10239DBFA /* DeprecatedModelOptInsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedModelOptInsTests.swift; sourceTree = "<group>"; };
 		4098461F579869804595B0A3 /* ChatModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModelCatalog.swift; sourceTree = "<group>"; };
@@ -461,6 +463,7 @@
 				8D8A1A5388E54F31462D616F /* MantaPairFixture.swift */,
 				AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */,
 				17673950838B843917DA660F /* MantaRunningStateCaptureUITests.swift */,
+				39217C665D64CEFA1C5F5C79 /* MantaScrollTraceUITests.swift */,
 				12A39FBE813A8B20F7F00055 /* MantaSubagentDrillInUITests.swift */,
 				7442EBB8ACC827C69BDD2B6E /* MantaTranscriptGestureUITests.swift */,
 				714E922397017504533FC4EE /* MantaUIHierarchyCaptureUITests.swift */,
@@ -635,6 +638,7 @@
 				EDFF1716E461980191B71C85 /* MantaPairFixture.swift in Sources */,
 				D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */,
 				51F9E82B1001E68644519724 /* MantaRunningStateCaptureUITests.swift in Sources */,
+				12BF6CF95679710C484807E9 /* MantaScrollTraceUITests.swift in Sources */,
 				DE5E17651AB0E9C750C4D712 /* MantaSubagentDrillInUITests.swift in Sources */,
 				6AA12AFE81F85477EBFB3D25 /* MantaTranscriptGestureUITests.swift in Sources */,
 				4DFA9582998C586AAC579F31 /* MantaUIHierarchyCaptureUITests.swift in Sources */,
@@ -826,7 +830,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.17;
+				MARKETING_VERSION = 1.0.18;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;
@@ -933,7 +937,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.17;
+				MARKETING_VERSION = 1.0.18;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;

--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -99,6 +99,7 @@
 		CE48AF05FEFD7446610C8B70 /* VoiceNotePlayer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAA20AACFCE7D2BA897AE130 /* VoiceNotePlayer.swift */; };
 		CFE1B93882BD2EAF2A8B80BB /* ModelRecentsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 38864A574D6CE5142E07B487 /* ModelRecentsTests.swift */; };
 		D3E89E0419EE12C59BEA62A9 /* MantaQRScanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5B4D07F9EBDCD8A693C141FF /* MantaQRScanner.swift */; };
+		D6A1F36C03E255C1480C7252 /* ScrollDiagnostic.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86B5B43E53479D0EB54F919F /* ScrollDiagnostic.swift */; };
 		D776E336456236DC1493565F /* ChatModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 229392FD3405558D301D0809 /* ChatModel.swift */; };
 		D8B312D02500D61F791EF275 /* MantaPairingDriverUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */; };
 		D9266F363BEB86F687C320FC /* ComposerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = C42691C89906181C99929354 /* ComposerView.swift */; };
@@ -206,6 +207,7 @@
 		7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaStreamModels.swift; sourceTree = "<group>"; };
 		81FE763828641B50BF496F4D /* TerminalSessionState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSessionState.swift; sourceTree = "<group>"; };
 		82EEBB3B72D8F63CF4D8CB7B /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		86B5B43E53479D0EB54F919F /* ScrollDiagnostic.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScrollDiagnostic.swift; sourceTree = "<group>"; };
 		872DDE9D9BAD041950DAC24A /* MantaLoader.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaLoader.swift; sourceTree = "<group>"; };
 		87CBDB00B3F0D138CB44A326 /* MantaUIApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaUIApp.swift; sourceTree = "<group>"; };
 		8879A94FE1BE824F438342AD /* MantaDeepLink.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaDeepLink.swift; sourceTree = "<group>"; };
@@ -416,6 +418,7 @@
 				A4E84DF65831DE58599C53BD /* RootView.swift */,
 				6BA4ADBB2FD5BAC7940D5B69 /* RunningIndicator.swift */,
 				0C440016971186430E8C464B /* Scrim.swift */,
+				86B5B43E53479D0EB54F919F /* ScrollDiagnostic.swift */,
 				B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */,
 				24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */,
 				D06ECCB6D27DBD73D1FF3189 /* SessionListView.swift */,
@@ -729,6 +732,7 @@
 				9CF891D747797006729FDBD3 /* RootView.swift in Sources */,
 				F30211F79048035CE5520266 /* RunningIndicator.swift in Sources */,
 				68760CC316BA947A82F360EE /* Scrim.swift in Sources */,
+				D6A1F36C03E255C1480C7252 /* ScrollDiagnostic.swift in Sources */,
 				239BD2739F1F96A11F033259 /* SessionCreateSheet.swift in Sources */,
 				1F0E6031C0987AFF27CC3F47 /* SessionListStore.swift in Sources */,
 				94493F871005DA7F4DA19ED7 /* SessionListView.swift in Sources */,

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -259,6 +259,15 @@ private struct ChatScreenContent: View {
                     }
                     .accessibilityLabel("Session actions")
                 }
+#if DEBUG
+                // BET-1211 TEMPORARY probe trigger — removed before merge.
+                ToolbarItem(placement: .topBarLeading) {
+                    Button { ScrollDiagnostic.probe(tag: "parent") } label: {
+                        Image(systemName: "stethoscope")
+                    }
+                    .accessibilityIdentifier("diag-probe")
+                }
+#endif
             }
             .onAppear {
                 // Three independent fetches, all started together: the
@@ -1187,6 +1196,17 @@ struct ChatSubagentScreen: View {
             .navigationBarTitleDisplayMode(.inline)
             .toolbarBackgroundVisibility(.visible, for: .navigationBar)
             .toolbarBackground(tokens.canvas, for: .navigationBar)
+#if DEBUG
+            // BET-1211 TEMPORARY probe trigger — removed before merge.
+            .toolbar {
+                ToolbarItem(placement: .topBarTrailing) {
+                    Button { ScrollDiagnostic.probe(tag: "child") } label: {
+                        Image(systemName: "stethoscope")
+                    }
+                    .accessibilityIdentifier("diag-probe")
+                }
+            }
+#endif
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("subagent-scene")
     }

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -2,6 +2,7 @@ import SwiftUI
 import UIKit
 import UserNotifications
 import MessagingUI
+import OSLog
 
 // ===========================================================================
 // S4 — chat screen wired to live data (BET-596).
@@ -763,6 +764,7 @@ private struct ChatScreenContent: View {
             bottomInset: bottomBarHeight,
             scrollPosition: $scrollPosition,
             onPointsFromBottom: { showScrollToBottom = $0 > Self.scrollToBottomThreshold },
+            surface: "parent",
             header: { sessionHeaderBlock }
         )
         // Deliver the blocking-card actions to the transcript cells via the
@@ -1209,6 +1211,7 @@ struct ChatSubagentScreen: View {
             bottomInset: 0,
             scrollPosition: $scrollPosition,
             onPointsFromBottom: nil,
+            surface: "child",
             header: { EmptyView() }
         )
         .background(tokens.canvas.ignoresSafeArea())
@@ -1244,6 +1247,8 @@ struct TranscriptListView<Header: View>: View {
     let bottomInset: CGFloat
     @Binding var scrollPosition: TiledScrollPosition
     var onPointsFromBottom: ((CGFloat) -> Void)? = nil
+    /// BET-1211 TEMPORARY diagnostic label ("parent"/"child") — remove before merge.
+    var surface: String = "?"
     @ViewBuilder var header: () -> Header
 
     var body: some View {
@@ -1269,6 +1274,11 @@ struct TranscriptListView<Header: View>: View {
         )
         .onTiledScrollGeometryChange { geometry in
             onPointsFromBottom?(geometry.pointsFromBottom)
+            // BET-1211 TEMPORARY scroll probe — remove before merge.
+            os_log("[scroll] %{public}@ off=%.1f content=%.1f visible=%.1f insetT=%.1f insetB=%.1f",
+                   log: .default, type: .info,
+                   surface, geometry.contentOffset.y, geometry.contentSize.height,
+                   geometry.visibleSize.height, geometry.contentInset.top, geometry.contentInset.bottom)
         }
         .onTapBackground { resignKeyboard() }
         .safeAreaBar(edge: .top) {

--- a/mobile/native/MantaUI/ScrollDiagnostic.swift
+++ b/mobile/native/MantaUI/ScrollDiagnostic.swift
@@ -1,0 +1,88 @@
+import Foundation
+import UIKit
+
+/// BET-1211 — DEBUG-only scroll probe for the subagent drill-in bug.
+///
+/// The parent and child transcripts share one `TranscriptListView` / `TiledView`
+/// with byte-identical `TiledScrollPosition` config, yet the child has been
+/// reported "completely locked" while the parent scrolls. `probe(tag:)` answers
+/// WHICH view actually receives a touch in the middle of the transcript
+/// (win.hitTest), dumps every scroll view's live state (isScrollEnabled,
+/// contentSize vs frame, pan recogniser), and tests whether the biggest one can
+/// move when the code asks.
+///
+/// All output goes to `Documents/scroll-diagnostic.log` in the app sandbox, so
+/// a simulator run can be diagnosed without a screenshot or a held-open
+/// terminal:
+///   cat "$(xcrun simctl get_app_container booted <bundle> data)/Documents/scroll-diagnostic.log"
+///
+/// Stateless per call; compiled out entirely in Release (no mutable global
+/// state).
+#if DEBUG
+@MainActor
+enum ScrollDiagnostic {
+    private static var url: URL {
+        let docs = FileManager.default.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        return docs.appendingPathComponent("scroll-diagnostic.log")
+    }
+
+    private static func line(_ s: String) {
+        let text = s + "\n"
+        guard let data = text.data(using: .utf8) else { return }
+        if let h = try? FileHandle(forWritingTo: url) {
+            defer { try? h.close() }
+            try? h.seekToEnd()
+            try? h.write(contentsOf: data)
+        } else {
+            try? data.write(to: url)
+        }
+    }
+
+    private static func allScrollViews(_ v: UIView) -> [UIScrollView] {
+        var out: [UIScrollView] = []
+        if let s = v as? UIScrollView { out.append(s) }
+        for sub in v.subviews { out += allScrollViews(sub) }
+        return out
+    }
+
+    static func probe(tag: String) {
+        line("=== probe[\(tag)] \(Date()) ===")
+        guard let win = UIApplication.shared.connectedScenes
+            .compactMap({ $0 as? UIWindowScene }).flatMap({ $0.windows })
+            .first(where: { $0.isKeyWindow }) else {
+            line("[\(tag)] no key window")
+            return
+        }
+
+        // (a) WHO receives a touch in the middle of the transcript?
+        let p = CGPoint(x: win.bounds.midX, y: win.bounds.midY)
+        let hit = win.hitTest(p, with: nil)
+        line("[\(tag)] hit=\(hit.map { String(describing: type(of: $0)) } ?? "nil") at \(Int(p.x)),\(Int(p.y))")
+
+        var chain: [String] = []
+        var v: UIView? = hit
+        var depth = 0
+        while let cur = v, depth < 25 {
+            chain.append("\(type(of: cur))(ui=\(cur.isUserInteractionEnabled),a=\(cur.alpha),h=\(cur.isHidden),f=\(Int(cur.frame.width))x\(Int(cur.frame.height)))")
+            v = cur.superview
+            depth += 1
+        }
+        line("[\(tag)] chain=\(chain.joined(separator: " < "))")
+
+        // (b) every scroll view's live state
+        for s in allScrollViews(win) {
+            line("[\(tag)] sv=\(type(of: s)) enabled=\(s.isScrollEnabled) ui=\(s.isUserInteractionEnabled) frame=\(Int(s.frame.width))x\(Int(s.frame.height)) content=\(Int(s.contentSize.width))x\(Int(s.contentSize.height)) off=\(Int(s.contentOffset.y)) adj=\(s.adjustedContentInset) panEnabled=\(s.panGestureRecognizer.isEnabled) grs=\(s.gestureRecognizers?.map { String(describing: type(of: $0)) } ?? [])")
+        }
+
+        // (c) can the tallest scroll view move when the CODE asks?
+        if let s = allScrollViews(win).max(by: { $0.contentSize.height < $1.contentSize.height }) {
+            let before = s.contentOffset.y
+            s.setContentOffset(CGPoint(x: 0, y: max(0, before - 400)), animated: false)
+            let after = s.contentOffset.y
+            line("[\(tag)] setOffset \(before) -> \(after)")
+            // restore
+            s.setContentOffset(CGPoint(x: 0, y: before), animated: false)
+        }
+    }
+}
+#endif

--- a/mobile/native/MantaUIUITests/MantaScrollTraceUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaScrollTraceUITests.swift
@@ -1,0 +1,98 @@
+import XCTest
+
+/// BET-1211 trace capture against the REAL dev box. Baselines the parent, then
+/// opens the "Map iOS transcript rendering" subagent child, swiping each while
+/// the os_log `[scroll]` probe (off/content/visible) records parent/child.
+final class MantaScrollTraceUITests: XCTestCase {
+    override func setUpWithError() throws { continueAfterFailure = false }
+
+    func testReverseScrollTrace() throws {
+        let app = XCUIApplication()
+        app.launch()
+        pairIfNeeded(app)
+
+        // 1) Baseline: open the real parent session.
+        _ = openParentChat(app)
+        print("RESULT parent-ready"); usleep(1_000_000)
+        swipePattern(app)
+        print("RESULT parent-swiped"); usleep(500_000)
+
+        // 2) Open the real child.
+        _ = tapSubagentCard(app)
+        let scene = app.otherElements["subagent-scene"]
+        XCTAssertTrue(scene.waitForExistence(timeout: 25), "child scene never appeared")
+        usleep(2_000_000)
+        print("RESULT child-ready")
+        swipePattern(app)
+        print("RESULT child-swiped")
+    }
+
+    private func pairIfNeeded(_ app: XCUIApplication) {
+        let otp = app.textFields["onboarding-otp"]
+        guard otp.waitForExistence(timeout: 4) else { return }
+        let srv = "https://3655737043030f5927b6c531f05ea650.boxes.mantaui.com"
+        let code = ProcessInfo.processInfo.environment["MANTA_PAIR_CODE"] ?? ""
+        otp.tap()
+        otp.typeText(String(repeating: XCUIKeyboardKey.delete.rawValue, count: 6))
+        otp.typeText(code)
+        let adv = app.buttons["My server isn't reachable from the internet"].firstMatch
+        if adv.waitForExistence(timeout: 3) { adv.tap() }
+        let sf = app.textFields["onboarding-server-url"]
+        if sf.waitForExistence(timeout: 5) { sf.tap(); sf.typeText(srv) }
+        app.buttons["Continue"].firstMatch.tap()
+        let fail = app.staticTexts["onboarding-failure-subtitle"]
+        let dl = Date().addingTimeInterval(60)
+        while Date() < dl, !app.staticTexts["Know when it needs you"].exists, !fail.exists { usleep(300_000) }
+        if !fail.exists { app.buttons["Continue"].firstMatch.tap(); answerNotifications() }
+        usleep(3_000_000)
+    }
+
+    // Swipe on the app itself (avoids element-coordinate staleness): a slow
+    // upward drag, a fast flick, then a downward drag back.
+    private func swipePattern(_ app: XCUIApplication) {
+        let w = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.82))
+        let top = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.2))
+        w.press(forDuration: 0.3, thenDragTo: top)
+        usleep(900_000)
+        w.press(forDuration: 0.01, thenDragTo: top, withVelocity: .fast, thenHoldForDuration: 0.01)
+        usleep(900_000)
+        let bot = app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.9))
+        top.press(forDuration: 0.3, thenDragTo: bot)
+        usleep(900_000)
+    }
+
+    @discardableResult
+    private func openParentChat(_ app: XCUIApplication) -> XCUIElement {
+        let composer = app.textViews["composer-input"].firstMatch
+        _ = composer.waitForExistence(timeout: 15)
+        if !composer.exists {
+            // Session list → find the real session window.
+            let row = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Native iOS UI polish'")).firstMatch
+            if row.waitForExistence(timeout: 15) {
+                var s = 0; while !row.isHittable && s < 12 { app.swipeUp(); usleep(250_000); s += 1 }
+                if row.isHittable { row.tap() }
+                _ = composer.waitForExistence(timeout: 15)
+                usleep(2_000_000)
+            }
+        }
+        return composer
+    }
+
+    @discardableResult
+    private func tapSubagentCard(_ app: XCUIApplication) -> XCUIElement {
+        var sc = 0
+        let probe = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Map iOS transcript rendering'")).firstMatch
+        while !probe.exists && sc < 60 { app.swipeDown(); usleep(300_000); sc += 1 }
+        let e = app.buttons.matching(NSPredicate(format: "label CONTAINS 'Map iOS transcript rendering'")).firstMatch
+        XCTAssertTrue(e.waitForExistence(timeout: 12), "subagent card never found")
+        var h = 0; while !e.isHittable && h < 40 { app.swipeDown(); usleep(250_000); h += 1 }
+        XCTAssertTrue(e.isHittable, "card not hittable")
+        e.tap()
+        return e
+    }
+
+    private func answerNotifications() {
+        let sb = XCUIApplication(bundleIdentifier: "com.apple.springboard")
+        for l in ["Allow", "Don't Allow", "OK"] { let b = sb.buttons[l]; if b.waitForExistence(timeout: 3) { b.tap(); return } }
+    }
+}

--- a/mobile/native/MantaUIUITests/MantaSubagentScrollDiagUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaSubagentScrollDiagUITests.swift
@@ -1,0 +1,48 @@
+import XCTest
+
+// BET-1211 fixture-driven diagnostic (author: macos). Against the subagent
+// fixture box (FIXTURE_SUBAGENT=1), open the parent chat, drill into the child
+// subagent screen, and record whether the CHILD transcript scrolls under a
+// synthetic swipe (with the PARENT as control).
+//
+// NOTE (verified 2026-08-20): synthetic XCUITest swipes do NOT move this custom
+// TiledView at all — the parent (which scrolls by hand) also does not move
+// under scrollView.swipeUp/app.swipeUp/press-drag. So this automated check can
+// never be a pass/fail verdict for the scroll bug; the authoritative read is a
+// HUMAN drag while `log stream --predicate 'eventMessage CONTAINS "[scroll]"'`
+// runs. This file is kept as the fixture driver reference, not a gate.
+final class MantaSubagentScrollDiagUITests: XCTestCase {
+    override func setUpWithError() throws { continueAfterFailure = false }
+
+    @MainActor
+    func testSubagentChildScrollDiag() throws {
+        let app = XCUIApplication()
+        app.launch()
+
+        XCTAssertTrue(app.staticTexts["Sessions"].waitForExistence(timeout: 20),
+                      "no session list — is the app paired to the fixture box?")
+
+        // Open the fixture chat (parent), drill into the child.
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        usleep(4_000_000)
+
+        let agentByLabel = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label BEGINSWITH %@", "fixture subagent"))
+            .firstMatch
+        let agentRow = app.descendants(matching: .any)["agent-row"].firstMatch
+        let target = agentByLabel.exists ? agentByLabel : agentRow
+        XCTAssertTrue(target.exists, "no subagent task row in the fixture parent chat")
+        target.tap()
+        print("DIAG child pushed")
+
+        let scene = app.descendants(matching: .any)["subagent-scene"].firstMatch
+        XCTAssertTrue(scene.waitForExistence(timeout: 10), "child scene never appeared")
+        usleep(3_000_000)
+
+        // Observe only; the verdict comes from a human drag + the [scroll] probe.
+        let childBar = app.descendants(matching: .any)
+            .matching(NSPredicate(format: "label BEGINSWITH %@", "Vertical scroll bar"))
+            .firstMatch
+        print("DIAG child-scene-present scrollBar=\(childBar.exists ? childBar.label : "absent")")
+    }
+}

--- a/mobile/native/MantaUIUITests/MantaSubagentScrollDiagUITests.swift
+++ b/mobile/native/MantaUIUITests/MantaSubagentScrollDiagUITests.swift
@@ -1,48 +1,42 @@
 import XCTest
 
-// BET-1211 fixture-driven diagnostic (author: macos). Against the subagent
-// fixture box (FIXTURE_SUBAGENT=1), open the parent chat, drill into the child
-// subagent screen, and record whether the CHILD transcript scrolls under a
-// synthetic swipe (with the PARENT as control).
-//
-// NOTE (verified 2026-08-20): synthetic XCUITest swipes do NOT move this custom
-// TiledView at all — the parent (which scrolls by hand) also does not move
-// under scrollView.swipeUp/app.swipeUp/press-drag. So this automated check can
-// never be a pass/fail verdict for the scroll bug; the authoritative read is a
-// HUMAN drag while `log stream --predicate 'eventMessage CONTAINS "[scroll]"'`
-// runs. This file is kept as the fixture driver reference, not a gate.
+// BET-1211 real-HID drag harness (author: macos). XCUITest synthetic swipes
+// cannot drive TiledView's scroll; real macOS-mouse input over the Simulator
+// window becomes real device touches that can. These tests navigate the app to
+// a surface and HOLD it in place while a host-side CGEvent drag runs. Verdict is
+// read from the os_log "[scroll]" probe (off= changes on a real pan).
+// Hold tests are not gates; they are the touch-injection window.
 final class MantaSubagentScrollDiagUITests: XCTestCase {
     override func setUpWithError() throws { continueAfterFailure = false }
 
     @MainActor
-    func testSubagentChildScrollDiag() throws {
+    func testHoldParent() throws {
         let app = XCUIApplication()
         app.launch()
-
-        XCTAssertTrue(app.staticTexts["Sessions"].waitForExistence(timeout: 20),
-                      "no session list — is the app paired to the fixture box?")
-
-        // Open the fixture chat (parent), drill into the child.
+        XCTAssertTrue(app.staticTexts["Sessions"].waitForExistence(timeout: 20))
         app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
         usleep(4_000_000)
+        print("DIAG parent held")
+        // Hold ~95s: reveal a window for the host-side drag.
+        sleep(95)
+    }
 
+    @MainActor
+    func testHoldChild() throws {
+        let app = XCUIApplication()
+        app.launch()
+        XCTAssertTrue(app.staticTexts["Sessions"].waitForExistence(timeout: 20))
+        app.coordinate(withNormalizedOffset: CGVector(dx: 0.5, dy: 0.28)).tap()
+        usleep(4_000_000)
         let agentByLabel = app.descendants(matching: .any)
             .matching(NSPredicate(format: "label BEGINSWITH %@", "fixture subagent"))
             .firstMatch
         let agentRow = app.descendants(matching: .any)["agent-row"].firstMatch
         let target = agentByLabel.exists ? agentByLabel : agentRow
-        XCTAssertTrue(target.exists, "no subagent task row in the fixture parent chat")
+        XCTAssertTrue(target.exists, "no subagent task row")
         target.tap()
-        print("DIAG child pushed")
-
-        let scene = app.descendants(matching: .any)["subagent-scene"].firstMatch
-        XCTAssertTrue(scene.waitForExistence(timeout: 10), "child scene never appeared")
-        usleep(3_000_000)
-
-        // Observe only; the verdict comes from a human drag + the [scroll] probe.
-        let childBar = app.descendants(matching: .any)
-            .matching(NSPredicate(format: "label BEGINSWITH %@", "Vertical scroll bar"))
-            .firstMatch
-        print("DIAG child-scene-present scrollBar=\(childBar.exists ? childBar.label : "absent")")
+        usleep(4_000_000)
+        print("DIAG child held")
+        sleep(95)
     }
 }

--- a/mobile/native/capture-fixture/fixture-box.mjs
+++ b/mobile/native/capture-fixture/fixture-box.mjs
@@ -226,6 +226,19 @@ if (SUBAGENT) {
 const CHILD_MESSAGES = [
   ...buildChildTranscript(),
   {
+    info: { id: "cm_giant", sessionID: CHILD_SESSION_ID, role: "assistant", time: { created: now, completed: now + 2 } },
+    parts: [{ type: "text", id: "cp_giant", messageID: "cm_giant",
+      // BET-1211 (hypothesis #2): ONE giant prose row (~10k+ pt, like a real
+      // subagent's enormous output). A single row orders of magnitude taller
+      // than the viewport is the exact content shape that can break MessagingUI
+      // tiling / anchor arithmetic. Default OFF (FIXTURE_GIANT_ROW=1) so the
+      // baseline healthy-child probe stays comparable.
+      text: process.env.FIXTURE_GIANT_ROW === "1"
+        ? ("This is a deliberately GIANT child row to test hypothesis #2 — a single prose block tall enough to span many viewports, mirroring a real subagent's enormous output. ".repeat(700))
+        : "" },
+    ],
+  },
+  {
     info: { id: "cm1", sessionID: CHILD_SESSION_ID, role: "user", time: { created: now } },
     parts: [{ type: "text", id: "cp1", messageID: "cm1", text: "Run the Scroll diagnostic." }],
   },

--- a/mobile/native/capture-fixture/fixture-box.mjs
+++ b/mobile/native/capture-fixture/fixture-box.mjs
@@ -43,7 +43,18 @@ const MSGS_DELAY_MS = Number(process.env.FIXTURE_MSGS_DELAY_MS || 0);
 //   FIXTURE_EARLY_HISTORY=1 node mobile/native/capture-fixture/fixture-box.mjs
 const EARLY_HISTORY = process.env.FIXTURE_EARLY_HISTORY === "1";
 
+// BET-1211 diagnostic: when set, the parent transcript ends with a subagent
+// `task` tool part (drill-in agent-row) and `opencode:messages` serves a LONG
+// child transcript for the child session id, so the subagent drill-in screen
+// (with many screens of child content) is reproducible on the simulator via
+// this fixture — no real subagent session needed. Default OFF so the existing
+// fixture-driven capture suites (which assert the current tail shape) are
+// unaffected.
+//   FIXTURE_SUBAGENT=1 node mobile/native/capture-fixture/fixture-box.mjs
+const SUBAGENT = process.env.FIXTURE_SUBAGENT === "1";
+
 const SESSION_ID = "session-1";
+const CHILD_SESSION_ID = "session-child-1";
 const PROJECT = "Demo";
 const CWD = `/Users/${process.env.USER || "demo"}/demo`;
 
@@ -112,6 +123,38 @@ function buildTallTranscript() {
   return filler;
 }
 
+// BET-1211: a LONG child transcript (many screens) served when the app asks for
+// the subagent's child session. Mirror of `buildTallTranscript` scoped to the
+// child session id, so the drill-in screen has real overflow to scroll.
+function buildChildTranscript() {
+  const filler = [];
+  const FILLER_PAIRS = 20; // 40 messages -> many screens of long child prose
+  let id = 2000;
+  for (let i = 0; i < FILLER_PAIRS; i++) {
+    const uid = "c" + (id++);
+    const aid = "c" + (id++);
+    const pid = id;
+    const prose = (
+      "This is CHILD fixture paragraph " + i + ", part of the subagent's long " +
+      "transcript. It is intentionally a few sentences long so the row owns " +
+      "measurable height on screen, giving the drill-in screen enough vertical " +
+      "extent that a single upward drag must begin scrolling — which is exactly " +
+      "the point of the BET-1211 scroll diagnostic. ".repeat(2)
+    );
+    filler.push(
+      {
+        info: { id: uid, sessionID: CHILD_SESSION_ID, role: "user", time: { created: now - 1000000 } },
+        parts: [{ type: "text", id: "p" + (pid - 1), messageID: uid, text: "Child question " + i }],
+      },
+      {
+        info: { id: aid, sessionID: CHILD_SESSION_ID, role: "assistant", time: { created: now - 900000, completed: now - 899000 } },
+        parts: [{ type: "text", id: "p" + pid, messageID: aid, text: prose }],
+      }
+    );
+  }
+  return filler;
+}
+
 const MESSAGES = [
   ...buildTallTranscript(),
   {
@@ -145,6 +188,50 @@ const MESSAGES = [
         text: "Yes — tap the ellipsis in the header. Scheduled tasks carries a live count, and secrets lists names without ever sending a value to the phone.",
       },
     ],
+  },
+];
+
+// BET-1211: a subagent `task` tool part appended at the tail, so the parent
+// transcript carries a drill-in agent-row. Status "running" mirrors the real
+// steer session; `metadata.sessionId` is what lets the app open the child.
+const TASK_MESSAGE = {
+  info: {
+    id: "m_task",
+    sessionID: SESSION_ID,
+    role: "assistant",
+    time: { created: now + 3, completed: now + 3 },
+  },
+  parts: [
+    {
+      type: "tool",
+      id: "prt_task",
+      messageID: "m_task",
+      tool: "task",
+      callID: "call_task_1",
+      state: {
+        status: "running",
+        title: "fixture subagent",
+        metadata: { sessionId: CHILD_SESSION_ID },
+        time: { start: (now - 5) * 1000, end: now * 1000 },
+      },
+    },
+  ],
+};
+
+if (SUBAGENT) {
+  MESSAGES.push(TASK_MESSAGE);
+}
+
+// The LONG child transcript served when the app drills into the subagent.
+const CHILD_MESSAGES = [
+  ...buildChildTranscript(),
+  {
+    info: { id: "cm1", sessionID: CHILD_SESSION_ID, role: "user", time: { created: now } },
+    parts: [{ type: "text", id: "cp1", messageID: "cm1", text: "Run the Scroll diagnostic." }],
+  },
+  {
+    info: { id: "cm2", sessionID: CHILD_SESSION_ID, role: "assistant", time: { created: now, completed: now + 2 } },
+    parts: [{ type: "text", id: "cp2", messageID: "cm2", text: "Diagnostic complete — this is the final child message." }],
   },
 ];
 
@@ -194,6 +281,14 @@ function rpc(channel, args) {
     case "tmux:list":
       return PROJECTS;
     case "opencode:messages":
+      // BET-1211: the subagent child's own transcript is served when the app
+      // requests the child session id (the fixture's parent tail carries a
+      // `task` tool part whose metadata.sessionId points here).
+      if (SUBAGENT && args[0] === CHILD_SESSION_ID) {
+        return new Promise((resolve) => {
+          setTimeout(() => resolve(CHILD_MESSAGES), 0);
+        });
+      }
       // BET-1151 C4: in early-history mode, return just the tail `limit` window
       // so the app sees a real "more history exists above" page. `hasEarlier`
       // in the store is `loaded.count >= limit`, so returning a full page makes


### PR DESCRIPTION
Opened automatically for `multica/BET-1211-subagent-scroll`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1211.