### PR TITLE
feat(shared): routing boundary + switch hysteresis (BET-1237)

### DIFF
--- a/src/shared/routingBoundary.d.mts
+++ b/src/shared/routingBoundary.d.mts
@@ -1,0 +1,43 @@
+export const BOUNDARY: {
+  FIRST_TURN: string;
+  AGENT: string;
+  CONSTRAINT: string;
+  COMPACTED: string;
+  USER: string;
+};
+
+export interface CrossesInput {
+  hasRoutedModel?: boolean;
+  agent?: string;
+  previousAgent?: string;
+  contextTokens?: number;
+  incumbentContextLimit?: number;
+  requiredModalities?: string[];
+  incumbentModalities?: string[];
+  incumbentHealthy?: boolean;
+  justCompacted?: boolean;
+  userRequested?: boolean;
+}
+
+export interface CrossesResult {
+  crossed: boolean;
+  boundary: string | null;
+}
+
+export function crossesBoundary(input?: CrossesInput): CrossesResult;
+
+export interface ShouldSwitchInput {
+  incumbent?: object | null;
+  ranked?: object[];
+  incumbentStillEligible: boolean;
+  incumbentStillCapable: boolean;
+  incumbentHealthy: boolean;
+  topN?: number;
+}
+
+export interface ShouldSwitchResult {
+  switch: boolean;
+  why: string;
+}
+
+export function shouldSwitch(input?: ShouldSwitchInput): ShouldSwitchResult;

--- a/src/shared/routingBoundary.mjs
+++ b/src/shared/routingBoundary.mjs
@@ -1,0 +1,151 @@
+// routingBoundary.mjs — when to re-decide routing, and whether to actually switch.
+//
+// Two separate questions, both answered here so they cannot drift between call
+// sites:
+//
+//  - WHEN do we re-evaluate? Not every turn. Switching model mid-conversation
+//    discards the prompt cache and re-bills the whole prefix, and it changes the
+//    assistant's judgement under the user mid-thread. A boundary is a moment
+//    where re-evaluating is cheap or forced.
+//  - HAVING re-evaluated, do we actually switch? Not just because a rival edged
+//    ahead on price. We keep the incumbent unless it genuinely fell out.
+//
+// Pure + framework-free: no I/O, no Date.now() — everything arrives as an
+// argument. The caller decides what a "turn" looks like.
+
+/** The kinds of decision point. Order here is the precedence in `crossesBoundary`. */
+export const BOUNDARY = {
+  FIRST_TURN: "first-turn", // new session, or after /clear
+  AGENT: "agent-changed", // plan <-> build
+  CONSTRAINT: "constraint", // context outgrown / modality missing / provider unavailable
+  COMPACTED: "compacted", // cache is gone anyway — a free moment
+  USER: "user-requested", // the user re-picked Auto
+};
+
+// Stable machine identity of a routed endpoint. Same convention as modelRouter.
+function endpointKey(m) {
+  return m ? `${m?.providerID ?? ""}/${m?.id ?? ""}` : "";
+}
+
+/**
+ * Does this turn cross a decision point?
+ *
+ * Returns the FIRST matching boundary in `BOUNDARY` precedence, or
+ * `{ crossed: false, boundary: null }` when none match — that is the common
+ * case and it must be cheap.
+ *
+ * @param {object} [input]
+ * @param {boolean}  [input.hasRoutedModel]       false → new session / after /clear
+ * @param {string}   [input.agent]                the agent of this turn
+ * @param {string}   [input.previousAgent]        the agent of the previous turn
+ * @param {number}   [input.contextTokens]        current context size
+ * @param {number}   [input.incumbentContextLimit]max context the incumbent can hold
+ * @param {string[]} [input.requiredModalities]   modalities this turn needs
+ * @param {string[]} [input.incumbentModalities]  modalities the incumbent has
+ * @param {boolean}  [input.incumbentHealthy]     true → provider is available
+ * @param {boolean}  [input.justCompacted]        true → cache is gone anyway
+ * @param {boolean}  [input.userRequested]        true → user re-picked Auto
+ * @returns {{ crossed: boolean, boundary: string|null }}
+ */
+export function crossesBoundary(input = {}) {
+  const {
+    hasRoutedModel,
+    agent,
+    previousAgent,
+    contextTokens,
+    incumbentContextLimit,
+    requiredModalities = [],
+    incumbentModalities = [],
+    incumbentHealthy = true,
+    justCompacted = false,
+    userRequested = false,
+  } = input;
+
+  // FIRST_TURN — new session or after /clear; there is nothing to re-decide, we
+  // are deciding for the first time. Cheapest, checked first.
+  if (hasRoutedModel === false) {
+    return { crossed: true, boundary: BOUNDARY.FIRST_TURN };
+  }
+
+  // AGENT — the assistant's judgement role changed (plan <-> build).
+  if (agent != null && previousAgent != null && agent !== previousAgent) {
+    return { crossed: true, boundary: BOUNDARY.AGENT };
+  }
+
+  // CONSTRAINT — the incumbent genuinely no longer fits the turn: it lost its
+  // context window, lacks a modality the turn needs, or its provider went away.
+  const contextOutgrown =
+    typeof incumbentContextLimit === "number" &&
+    typeof contextTokens === "number" &&
+    contextTokens > incumbentContextLimit;
+  const modalityMissing = requiredModalities.some(
+    (m) => !incumbentModalities.includes(m),
+  );
+  if (incumbentHealthy === false || contextOutgrown || modalityMissing) {
+    return { crossed: true, boundary: BOUNDARY.CONSTRAINT };
+  }
+
+  // COMPACTED — the cache is gone anyway, so re-evaluating is free.
+  if (justCompacted === true) {
+    return { crossed: true, boundary: BOUNDARY.COMPACTED };
+  }
+
+  // USER — the user explicitly re-picked Auto; honour it.
+  if (userRequested === true) {
+    return { crossed: true, boundary: BOUNDARY.USER };
+  }
+
+  return { crossed: false, boundary: null };
+}
+
+// 0-based position of the incumbent endpoint within `ranked`, or -1 if absent.
+function incumbentIndex(incumbent, ranked) {
+  const k = endpointKey(incumbent);
+  if (!k) return -1;
+  return ranked.findIndex((m) => endpointKey(m) === k);
+}
+
+/**
+ * Having re-evaluated, should we move off the incumbent? Hysteresis.
+ *
+ * A boundary re-evaluates; it does NOT automatically switch. We switch only
+ * when the incumbent genuinely fell out: it is no longer eligible, capable, or
+ * healthy, or it dropped out of the top `topN` of `ranked`. Otherwise we keep
+ * it, even if something now ranks above it — being edged out on price is not
+ * enough.
+ *
+ * @param {object} input
+ * @param {object|null} input.incumbent          the session's current routed endpoint
+ * @param {object[]}    input.ranked             ordered candidates from the router
+ * @param {boolean}     input.incumbentStillEligible  can Auto still describe it
+ * @param {boolean}     input.incumbentStillCapable   does it still fit the turn
+ * @param {boolean}     input.incumbentHealthy        is its provider available
+ * @param {number}      [input.topN]             contention window (default 3)
+ * @returns {{ switch: boolean, why: string }}
+ */
+export function shouldSwitch(input = {}) {
+  const {
+    incumbent,
+    ranked = [],
+    incumbentStillEligible = true,
+    incumbentStillCapable = true,
+    incumbentHealthy = true,
+    topN = 3,
+  } = input;
+
+  if (incumbentStillEligible === false) {
+    return { switch: true, why: "incumbent-ineligible" };
+  }
+  if (incumbentStillCapable === false) {
+    return { switch: true, why: "incumbent-incapable" };
+  }
+  if (incumbentHealthy === false) {
+    return { switch: true, why: "incumbent-unhealthy" };
+  }
+
+  const pos = incumbentIndex(incumbent, ranked);
+  if (pos === -1 || pos >= topN) {
+    return { switch: true, why: "incumbent-dropped-out" };
+  }
+  return { switch: false, why: "incumbent-retained" };
+}

--- a/src/shared/routingBoundary.test.ts
+++ b/src/shared/routingBoundary.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect } from "vitest";
+import { BOUNDARY, crossesBoundary, shouldSwitch } from "./routingBoundary.mjs";
+
+// A routed endpoint with a distinct (providerID/id) identity, like the router's.
+function ep(providerID: string, id: string) {
+  return { providerID, id };
+}
+
+const followUp = {
+  hasRoutedModel: true,
+  agent: "general",
+  previousAgent: "general",
+  contextTokens: 1000,
+  incumbentContextLimit: 40000,
+  requiredModalities: ["text"],
+  incumbentModalities: ["text", "image"],
+  incumbentHealthy: true,
+  justCompacted: false,
+  userRequested: false,
+};
+
+describe("crossesBoundary — each boundary in isolation", () => {
+  it("FIRST_TURN when there is no routed model yet", () => {
+    expect(crossesBoundary({ ...followUp, hasRoutedModel: false })).toEqual({
+      crossed: true,
+      boundary: BOUNDARY.FIRST_TURN,
+    });
+  });
+
+  it("AGENT when the agent changed (plan -> build)", () => {
+    expect(
+      crossesBoundary({ ...followUp, agent: "build", previousAgent: "plan" }),
+    ).toEqual({ crossed: true, boundary: BOUNDARY.AGENT });
+  });
+
+  it("CONSTRAINT when context outgrew the incumbent's limit", () => {
+    expect(
+      crossesBoundary({ ...followUp, contextTokens: 41000, incumbentContextLimit: 40000 }),
+    ).toEqual({ crossed: true, boundary: BOUNDARY.CONSTRAINT });
+  });
+
+  it("CONSTRAINT when a required modality is missing", () => {
+    expect(
+      crossesBoundary({
+        ...followUp,
+        requiredModalities: ["image", "pdf"],
+        incumbentModalities: ["text", "image"],
+      }),
+    ).toEqual({ crossed: true, boundary: BOUNDARY.CONSTRAINT });
+  });
+
+  it("CONSTRAINT when the incumbent provider is unhealthy", () => {
+    expect(crossesBoundary({ ...followUp, incumbentHealthy: false })).toEqual({
+      crossed: true,
+      boundary: BOUNDARY.CONSTRAINT,
+    });
+  });
+
+  it("COMPACTED when the cache is gone anyway", () => {
+    expect(crossesBoundary({ ...followUp, justCompacted: true })).toEqual({
+      crossed: true,
+      boundary: BOUNDARY.COMPACTED,
+    });
+  });
+
+  it("USER when the user re-picked Auto", () => {
+    expect(crossesBoundary({ ...followUp, userRequested: true })).toEqual({
+      crossed: true,
+      boundary: BOUNDARY.USER,
+    });
+  });
+});
+
+describe("crossesBoundary — no boundary", () => {
+  it("returns crossed:false for an ordinary follow-up turn", () => {
+    expect(crossesBoundary(followUp)).toEqual({ crossed: false, boundary: null });
+  });
+
+  it("drifting numbers alone never cross a boundary (context growing under the limit)", () => {
+    expect(
+      crossesBoundary({ ...followUp, contextTokens: 25000 }),
+    ).toEqual({ crossed: false, boundary: null });
+    expect(
+      crossesBoundary({
+        ...followUp,
+        contextTokens: 1,
+        incumbentContextLimit: 1,
+      }),
+    ).toEqual({ crossed: false, boundary: null });
+  });
+
+  it("precedence: FIRST_TURN beats every later boundary", () => {
+    expect(
+      crossesBoundary({
+        ...followUp,
+        hasRoutedModel: false,
+        agent: "build",
+        previousAgent: "plan",
+        justCompacted: true,
+        userRequested: true,
+      }),
+    ).toEqual({ crossed: true, boundary: BOUNDARY.FIRST_TURN });
+  });
+
+  it("precedence: AGENT beats CONSTRAINT/COMPACTED/USER", () => {
+    expect(
+      crossesBoundary({
+        ...followUp,
+        agent: "plan",
+        previousAgent: "build",
+        incumbentHealthy: false,
+        justCompacted: true,
+      }),
+    ).toEqual({ crossed: true, boundary: BOUNDARY.AGENT });
+  });
+});
+
+describe("shouldSwitch — hysteresis", () => {
+  const base = {
+    incumbent: ep("anthropic", "a"),
+    ranked: [ep("anthropic", "a"), ep("openai", "b"), ep("deepseek", "c")],
+    incumbentStillEligible: true,
+    incumbentStillCapable: true,
+    incumbentHealthy: true,
+  };
+
+  it("keeps the incumbent when a rival is marginally ahead but it is still in the top N", () => {
+    // incumbent still #1 in ranked; nothing about anything else matters
+    expect(shouldSwitch(base)).toEqual({ switch: false, why: "incumbent-retained" });
+  });
+
+  it("keeps the incumbent at position N (contention boundary), even when beaten", () => {
+    // topN=3: positions 0,1,2 (i.e. 1st..3rd) keep the incumbent. Put it 3rd.
+    expect(
+      shouldSwitch({
+        ...base,
+        topN: 3,
+        ranked: [ep("openai", "b"), ep("deepseek", "c"), ep("anthropic", "a")],
+      }),
+    ).toEqual({ switch: false, why: "incumbent-retained" });
+  });
+
+  it("switches when the incumbent is at position N+1 (outside the contention window)", () => {
+    expect(
+      shouldSwitch({
+        ...base,
+        topN: 3,
+        ranked: [ep("openai", "b"), ep("deepseek", "c"), ep("groq", "d"), ep("anthropic", "a")],
+      }),
+    ).toEqual({ switch: true, why: "incumbent-dropped-out" });
+  });
+
+  it("switches when the incumbent is absent from ranked entirely", () => {
+    expect(
+      shouldSwitch({
+        ...base,
+        ranked: [ep("openai", "b"), ep("deepseek", "c"), ep("groq", "d")],
+      }),
+    ).toEqual({ switch: true, why: "incumbent-dropped-out" });
+  });
+
+  it("switches, incumbent-ineligible, when Auto can no longer describe it", () => {
+    expect(shouldSwitch({ ...base, incumbentStillEligible: false })).toEqual({
+      switch: true,
+      why: "incumbent-ineligible",
+    });
+  });
+
+  it("switches, incumbent-incapable, when it no longer fits the turn", () => {
+    expect(shouldSwitch({ ...base, incumbentStillCapable: false })).toEqual({
+      switch: true,
+      why: "incumbent-incapable",
+    });
+  });
+
+  it("switches, incumbent-unhealthy, when its provider went away", () => {
+    expect(shouldSwitch({ ...base, incumbentHealthy: false })).toEqual({
+      switch: true,
+      why: "incumbent-unhealthy",
+    });
+  });
+
+  it("topN defaults to 3", () => {
+    const n4 = [ep("a", "1"), ep("a", "2"), ep("a", "3"), ep("a", "4")];
+    // default topN=3: position 3 (4th, 0-based index 3) is outside → switch
+    expect(
+      shouldSwitch({ ...base, ranked: [...n4.slice(0, 3), ep("anthropic", "a")] }),
+    ).toEqual({ switch: true, why: "incumbent-dropped-out" });
+  });
+});


### PR DESCRIPTION
Stage 3 of the Automatic Manta Routing epic. Pure module + tests, no renderer wiring.

Adds `src/shared/routingBoundary.mjs` (+ `.d.mts` types + Vitest tests) — one tested predicate answering two questions:
- **When do we re-evaluate?** `crossesBoundary` returns the first matching boundary (first-turn → agent-changed → constraint → compacted → user-requested) in `BOUNDARY` precedence, or `crossed:false` for ordinary follow-ups.
- **Having re-evaluated, do we switch?** `shouldSwitch` applies hysteresis: keep the incumbent unless it fell out (ineligible / incapable / unhealthy) or dropped out of the top `topN` of `ranked`. Being edged out on price is not enough.

Pure, framework-free: no I/O, no `Date.now()`, everything arrives as an argument (matches `modelRouter.mjs` convention). Rules of the epic honored: no provider names in the decision core.

**Note on `why` keys:** the issue lists four (`incumbent-ineligible`, `incumbent-unhealthy`, `incumbent-dropped-out`, `incumbent-retained`) but also requires a test asserting "ineligible / incapable / unhealthy → switch with the right why". The two inputs `incumbentStillEligible` (auto-eligibility: can we describe it) and `incumbentStillCapable` (per-turn constraint fit) are distinct failure modes, so I added a fifth key `incumbent-incapable` to keep the reason readable rather than folding capability collapse into eligibility. Five keys total.

**Files changed:** 3. `[src/shared/routingBoundary.mjs, src/shared/routingBoundary.d.mts, src/shared/routingBoundary.test.ts]`

**Verification results:**
- PR branch (`multica/BET-1237-routing-boundary` @ `383be30a`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, 2572 pass / 0 fail / 0 skip. Failures: none.
- Base (`origin/main` @ `f58b7df6` when branched; main now `b67d8c21`):
  - Diff vs current `origin/main` is purely additive — 3 new files, zero modifications, zero deletions. No regression possible from the change; branch is compatible with current main.
- **Conclusion:** 0 new failures. Change is net-new pure module + tests.

Base: origin/main @ f58b7df6