### PR TITLE
feat(server): usage snapshots carry balance, overagePrice, exhausted and window startedAt (BET-1238)

### DIFF
--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -34,6 +34,9 @@
  * @property {number} [used]     Absolute count when the provider exposes one.
  * @property {number} [limit]    Absolute cap when the provider exposes one.
  * @property {number} [resetsAt] Epoch MILLISECONDS.
+ * @property {number} [startedAt] Epoch ms when this window opened. Absent when
+ *   the provider does not report a window start — consumers must NOT guess a
+ *   start from `resetsAt` minus an assumed window length.
  * @property {boolean} [binding] The provider says this window bites first.
  * @property {boolean} [stale] True when this reading describes a window whose
  *   reset instant has already passed: the provider has not published the new
@@ -59,6 +62,11 @@
  * @property {string} [planLabel]   "Max 20x", "Pro", "Allegretto".
  * @property {UsageWindow[]} windows
  * @property {{label:string,value:string}[]} [extras]  Credits balance, model pools.
+ * @property {number} [balance]    Account credit in dollars. May be NEGATIVE
+ *                                 (overdrawn). Absent means *unknown*, never 0.
+ * @property {number} [overagePrice] $ per unit beyond the included allowance,
+ *                                 when the plan publishes one.
+ * @property {boolean} [exhausted] The provider will refuse work now.
  * @property {number} fetchedAt     Epoch ms of the successful fetch.
  */
 /**
@@ -278,6 +286,14 @@ export function createUsagePoller({
             ...(raw.planLabel ? { planLabel: raw.planLabel } : {}),
             windows,
             ...(Array.isArray(raw.extras) && raw.extras.length > 0 ? { extras: raw.extras } : {}),
+            // Carry the account-level fields through so a changed balance /
+            // overage / exhausted flag lands in contentKey and actually
+            // surfaces a usage.updated. (BET-1238: dropping these here would
+            // make the balance read as frozen — the dial never learns it
+            // moved because results is rebuilt each tick, not passed through.)
+            ...(raw.balance !== undefined ? { balance: raw.balance } : {}),
+            ...(raw.overagePrice !== undefined ? { overagePrice: raw.overagePrice } : {}),
+            ...(raw.exhausted === true ? { exhausted: true } : {}),
             fetchedAt: nowMs,
           });
           backoffUntil.delete(adapter.id);

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -100,6 +100,20 @@ test("normalizeWindow: resetsAt — epoch seconds vs epoch ms vs ISO string", ()
   assert.equal(bad.pct, 10);
 });
 
+test("normalizeWindow: startedAt survives — epoch seconds vs epoch ms vs ISO string", () => {
+  // < 1e12 → treated as epoch seconds, like resetsAt.
+  assert.equal(normalizeWindow({ pct: 10, startedAt: 1735689600 }).startedAt, 1735689600000);
+  // >= 1e12 → already ms.
+  assert.equal(normalizeWindow({ pct: 10, startedAt: 1735689600000 }).startedAt, 1735689600000);
+  // ISO string → Date.parse.
+  const iso = normalizeWindow({ pct: 10, startedAt: "2026-01-01T00:00:00.000Z" });
+  assert.equal(iso.startedAt, Date.parse("2026-01-01T00:00:00.000Z"));
+  // Unparseable string → field dropped, window still valid.
+  const bad = normalizeWindow({ pct: 10, startedAt: "not-a-date" });
+  assert.equal(bad.startedAt, undefined);
+  assert.equal(bad.pct, 10);
+});
+
 test("normalizeWindow: non-finite counts are dropped, not coerced to NaN/Infinity", () => {
   // used fails to coerce → falls through to "missing denominators" → null.
   assert.equal(normalizeWindow({ used: "abc", limit: 200 }), null);
@@ -519,6 +533,25 @@ test("poller: a genuine content change publishes again", async () => {
   assert.equal(published.length, 2);
 });
 
+test("poller: a snapshot whose ONLY change is balance publishes again (balance is in contentKey)", async () => {
+  let balance = 14.2;
+  const adapter = makeAdapter("a", {
+    detect: async () => true,
+    fetch: async () => ({ windows: [{ kind: "session", label: "s", pct: 20 }], balance }),
+  });
+  const published = [];
+  const poller = createUsagePoller({
+    adapters: [adapter],
+    now: () => 1000,
+    publish: (evt) => published.push(evt),
+  });
+  await poller.tick();
+  assert.equal(published.length, 1);
+  balance = 11.1; // windows unchanged — only the credit balance moved
+  await poller.tick();
+  assert.equal(published.length, 2, "a changed balance must surface a usage.updated");
+});
+
 test("poller: in-flight guard prevents overlapping ticks", async () => {
   let concurrent = 0;
   let maxConcurrent = 0;
@@ -616,6 +649,15 @@ test("claude adapter: a 1% reading is 1%, not 100% (reset-time regression)", asy
   assert.equal(snap.windows.find((w) => w.kind === "session").pct, 1);
 });
 
+test("claude adapter: a 100% window reports exhausted", async () => {
+  const sample = { rate_limits: { five_hour: { utilization: 100 } } };
+  const snap = await claudeAdapter.fetch({
+    fetchImpl: async () => fakeResponse(200, sample),
+    readCredentials: async () => ({ accessToken: "tok" }),
+  });
+  assert.equal(snap.exhausted, true);
+});
+
 test("claude adapter: detect() requires a non-empty accessToken", async () => {
   assert.equal(await claudeAdapter.detect({ readCredentials: async () => ({ accessToken: "x" }) }), true);
   assert.equal(await claudeAdapter.detect({ readCredentials: async () => null }), false);
@@ -662,6 +704,49 @@ test("codex adapter: prefers reset_at, falls back to now + reset_after_seconds",
   assert.equal(weekly.pct, 91);
   assert.equal(weekly.resetsAt, 1735700000000);
   assert.equal(snap.extras.find((e) => e.label === "Credits balance").value, "14.2");
+  assert.equal(snap.balance, 14.2, "credits balance promoted to the top-level balance field");
+  assert.equal("exhausted" in snap, false, "a positive balance with windows < 100% is not exhausted");
+});
+
+test("codex adapter: a negative balance is preserved as negative and reports exhausted", async () => {
+  const sample = {
+    rate_limit: { primary_window: { used_percent: 30, reset_after_seconds: 60 } },
+    credits: { balance: -4.5 },
+  };
+  const snap = await codexAdapter.fetch({
+    fetchImpl: async () => fakeResponse(200, sample),
+    readToken: async () => "tok",
+    now: () => 0,
+  });
+  assert.equal(snap.balance, -4.5, "negative (overdrawn) balance is not clamped");
+  assert.equal(snap.extras.find((e) => e.label === "Credits balance").value, "-4.5");
+  assert.equal(snap.exhausted, true, "a balance <= 0 means the account will refuse work");
+});
+
+test("codex adapter: a 100% window reports exhausted even with a positive balance", async () => {
+  const sample = {
+    rate_limit: { primary_window: { used_percent: 100, reset_after_seconds: 60 } },
+    credits: { balance: 10 },
+  };
+  const snap = await codexAdapter.fetch({
+    fetchImpl: async () => fakeResponse(200, sample),
+    readToken: async () => "tok",
+    now: () => 0,
+  });
+  assert.equal(snap.balance, 10);
+  assert.equal(snap.exhausted, true, "a window at 100% is exhausted regardless of balance");
+});
+
+test("codex adapter: absent credits balance stays undefined, never 0", async () => {
+  const sample = { rate_limit: { primary_window: { used_percent: 5, reset_after_seconds: 60 } } };
+  const snap = await codexAdapter.fetch({
+    fetchImpl: async () => fakeResponse(200, sample),
+    readToken: async () => "tok",
+    now: () => 0,
+  });
+  assert.equal("balance" in snap, false, "no credits field → no balance key at all");
+  assert.equal(snap.balance, undefined, "absent balance is undefined, not 0");
+  assert.equal("exhausted" in snap, false);
 });
 
 test("codex adapter: no credits, no plan_type — extras/planLabel omitted, not fabricated", async () => {
@@ -743,6 +828,18 @@ test("kimi adapter: weekly (string counts) + session (300-minute limits entry, r
   assert.equal(session.limit, 200);
   assert.equal(session.pct, 70);
   assert.equal(session.resetsAt, 1735700000000); // epoch seconds → ms
+});
+
+test("kimi adapter: a window at/over its limit reports exhausted", async () => {
+  const sample = {
+    usage: { limit: 200, used: 200 },
+    limits: [{ window: { duration: 300, timeUnit: "minute" }, detail: { limit: 200, used: 200 } }],
+  };
+  const snap = await kimiAdapter.fetch({
+    fetchImpl: async () => fakeResponse(200, sample),
+    readKey: async () => "key",
+  });
+  assert.equal(snap.exhausted, true);
 });
 
 test("kimi adapter: a 5h window given in hours (not minutes) still resolves", async () => {

--- a/src/server/usageAdapters/claude.mjs
+++ b/src/server/usageAdapters/claude.mjs
@@ -12,6 +12,7 @@ import { readFile } from "node:fs/promises";
 import { CREDENTIALS_PATH, parseCredentials } from "../claudeAuth.mjs";
 import { normalizeWindow, usageWindowLabel } from "./normalizeWindow.mjs";
 import { httpError } from "./httpError.mjs";
+import { isUsageAtLimit } from "../usageStopper.mjs";
 
 const USAGE_URL = "https://api.anthropic.com/api/oauth/usage";
 
@@ -99,9 +100,12 @@ export const claudeAdapter = {
     const sonnetExtra = extraFor(limits?.seven_day_sonnet ?? limits?.["7d_sonnet"], "Sonnet (7d)");
     if (sonnetExtra) extras.push(sonnetExtra);
 
+    const exhausted = isUsageAtLimit(windows);
+
     return {
       provider: "claude",
       windows,
+      ...(exhausted ? { exhausted: true } : {}),
       ...(extras.length > 0 ? { extras } : {}),
     };
   },

--- a/src/server/usageAdapters/codex.mjs
+++ b/src/server/usageAdapters/codex.mjs
@@ -19,6 +19,7 @@
 import { readProviderOAuthToken } from "../opencode.mjs";
 import { normalizeWindow, usageWindowLabel } from "./normalizeWindow.mjs";
 import { httpError } from "./httpError.mjs";
+import { isUsageAtLimit } from "../usageStopper.mjs";
 
 const USAGE_URL = "https://chatgpt.com/backend-api/wham/usage";
 const PROVIDER_ID = "openai";
@@ -92,13 +93,20 @@ export const codexAdapter = {
     if (balance !== undefined && balance !== null) {
       extras.push({ label: "Credits balance", value: String(balance) });
     }
+    const balanceNum = typeof balance === "number" && Number.isFinite(balance) ? balance : undefined;
 
     const planLabel = titleCase(data?.plan_type);
+
+    // The provider will refuse work now: any window is at/over its limit, or
+    // credits are spent/overdrawn (balance ≤ 0).
+    const exhausted = isUsageAtLimit(windows) || (balanceNum !== undefined && balanceNum <= 0);
 
     return {
       provider: "codex",
       ...(planLabel ? { planLabel } : {}),
       windows,
+      ...(balanceNum !== undefined ? { balance: balanceNum } : {}),
+      ...(exhausted ? { exhausted: true } : {}),
       ...(extras.length > 0 ? { extras } : {}),
     };
   },

--- a/src/server/usageAdapters/kimi.mjs
+++ b/src/server/usageAdapters/kimi.mjs
@@ -25,6 +25,7 @@
 import { readProviderApiKey } from "../opencode.mjs";
 import { normalizeWindow, usageWindowLabel } from "./normalizeWindow.mjs";
 import { httpError } from "./httpError.mjs";
+import { isUsageAtLimit } from "../usageStopper.mjs";
 
 const USAGE_URL = "https://api.kimi.com/coding/v1/usages";
 const PROVIDER_ID = "kimi-for-coding";
@@ -97,6 +98,7 @@ export const kimiAdapter = {
 
     // No planLabel on this endpoint — it needs a cookie-auth web API, out of
     // scope per the issue spec.
-    return { provider: "kimi", windows };
+    const exhausted = isUsageAtLimit(windows);
+    return { provider: "kimi", windows, ...(exhausted ? { exhausted: true } : {}) };
   },
 };

--- a/src/server/usageAdapters/normalizeWindow.mjs
+++ b/src/server/usageAdapters/normalizeWindow.mjs
@@ -91,6 +91,14 @@ export function normalizeWindow(raw) {
     if (Number.isFinite(parsed)) window.resetsAt = parsed;
   }
 
+  const rawStarted = raw.startedAt;
+  if (typeof rawStarted === "number" && Number.isFinite(rawStarted)) {
+    window.startedAt = rawStarted < 1e12 ? rawStarted * 1000 : rawStarted;
+  } else if (typeof rawStarted === "string" && rawStarted) {
+    const parsed = Date.parse(rawStarted);
+    if (Number.isFinite(parsed)) window.startedAt = parsed;
+  }
+
   if (raw.binding === true) window.binding = true;
 
   return window;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1892,6 +1892,8 @@ export type UsageWindow = {
   used?: number; // absolute count when the provider exposes one
   limit?: number; // absolute cap when the provider exposes one
   resetsAt?: number; // epoch ms
+  startedAt?: number; // epoch ms — when this window opened; absent when the
+  // provider does not report one (never guess it from resetsAt minus a window length)
   binding?: boolean; // the provider says this window bites first
   // True when this reading describes a window whose reset instant has already
   // passed: the provider has not published the new window's numbers yet, so
@@ -1914,6 +1916,10 @@ export type UsageSnapshot = {
   // src/server/usageAdapters/ upholds this.
   windows: UsageWindow[];
   extras?: { label: string; value: string }[]; // credits balance, model pools…
+  balance?: number; // account credit in dollars; may be NEGATIVE (overdrawn).
+  // Absent = unknown, never 0.
+  overagePrice?: number; // $ per unit beyond the included allowance, when published
+  exhausted?: boolean; // the provider will refuse work now
   fetchedAt: number; // epoch ms of the successful fetch
 };
 


### PR DESCRIPTION
Extends the usage snapshot shape (BET-1238, Stage 4 of Automatic Manta Routing) so `marginalCost` can compute elapsed time and account-level state:

- **`UsageWindow.startedAt?`** — epoch ms when the window opened, carried through `normalizeWindow` (the one place a raw window becomes a `UsageWindow`). Left `undefined` where a provider reports no start (never guessed from `resetsAt`).
- **`UsageSnapshot.balance?`** — account credit in dollars, may be negative; absent means *unknown*, never 0. Codex's credits row is promoted from `extras` to the top-level field (the `extras` row is kept so popover copy is unchanged).
- **`UsageSnapshot.overagePrice?`** — $/unit beyond the allowance, when a plan publishes one (type added; no adapter publishes one today).
- **`UsageSnapshot.exhausted?`** — explicitly true when the adapter can tell: any window at/over 100% (`isUsageAtLimit`, reused — not re-implemented) or, for codex, a balance ≤ 0.

**Root cause fixed (the easy-to-miss one):** the poller in `src/server/usage.mjs` rebuilds each snapshot object rather than passing the adapter object through, so the new account-level fields were silently dropped from `contentKey` — a changed balance would have read as frozen and never published `usage.updated`. The rebuild now carries `balance`/`overagePrice`/`exhausted` through.

Verification: typecheck clean; full suite 2595 pass / 0 fail (usage suite: 55 pass).

Base: origin/main @ b67d8c21
