### PR TITLE
feat(server): cache provider-agnostic model catalogue on the box (BET-1241)

### DIFF
--- a/src/server/fixtures/modelCatalog.fixture.json
+++ b/src/server/fixtures/modelCatalog.fixture.json
@@ -1,0 +1,82 @@
+[
+  {
+    "id": "qwen/qwen3.6-27b",
+    "name": "Qwen3.6-27B",
+    "family": "qwen",
+    "description": "Qwen3.6 tuned for long-context coding (exact-match fixture)",
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": { "input": ["text"], "output": ["text"] },
+    "open_weights": true,
+    "limit": { "context": 131072, "output": 8192 },
+    "benchmarks": [{ "name": "SWE-Bench Verified", "score": 58.4, "metric": "resolved" }]
+  },
+  {
+    "id": "chutes/Ornith-9B",
+    "name": "Ornith 9B",
+    "family": "ornith",
+    "description": "Ornith family, 9B variant",
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": { "input": ["text"], "output": ["text"] },
+    "open_weights": true,
+    "limit": { "context": 32768, "output": 4096 }
+  },
+  {
+    "id": "chutes/Ornith-31B",
+    "name": "Ornith 31B",
+    "family": "ornith",
+    "description": "Ornith family, 31B variant",
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": { "input": ["text"], "output": ["text"] },
+    "open_weights": true,
+    "limit": { "context": 65536, "output": 8192 }
+  },
+  {
+    "id": "chutes/Ornith-35B",
+    "name": "Ornith 35B",
+    "family": "ornith",
+    "description": "Ornith family, 35B variant",
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": { "input": ["text"], "output": ["text"] },
+    "open_weights": true,
+    "limit": { "context": 65536, "output": 8192 }
+  },
+  {
+    "id": "chutes/Ornith-397B",
+    "name": "Ornith 397B",
+    "family": "ornith",
+    "description": "Ornith family, 397B variant",
+    "reasoning": false,
+    "tool_call": true,
+    "modalities": { "input": ["text"], "output": ["text"] },
+    "open_weights": true,
+    "limit": { "context": 262144, "output": 32768 }
+  },
+  {
+    "id": "minimax/MiniMax-M3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": { "input": ["text", "image", "video"], "output": ["text"] },
+    "open_weights": true,
+    "limit": { "context": 512000, "output": 128000 },
+    "benchmarks": [{ "name": "SWE-Bench Verified", "score": 80.5, "metric": "resolved" }]
+  },
+  {
+    "id": "deepseek/deepseek-chat",
+    "name": "DeepSeek Chat",
+    "family": "deepseek",
+    "description": "DeepSeek general chat model",
+    "reasoning": false,
+    "tool_call": true,
+    "modalities": { "input": ["text"], "output": ["text"] },
+    "open_weights": true,
+    "limit": { "context": 65536, "output": 8192 }
+  }
+]

--- a/src/server/modelCatalog.mjs
+++ b/src/server/modelCatalog.mjs
@@ -1,0 +1,261 @@
+// modelCatalog.mjs — cache the provider-agnostic model catalogue on the box.
+//
+// BET-1241 (Automatic Manta Routing, stage 5). models.dev is opencode's own
+// internal catalogue — the model list Manta already receives via `/provider`
+// IS that data — but opencode exposes only the per-provider view. The
+// provider-agnostic view (`https://models.dev/models.json`) answers "what *is*
+// this model, wherever it is served", which is what makes an opaque provider
+// alias resolvable. This module fetches and caches that view so the decision
+// core can answer three questions without touching the network:
+//
+//   • lookupModel(catalogId) — is this exact catalogue id present?
+//   • matchModel(localModelId) — which catalogue entries could this opaque
+//     local id be? (exact / ambiguous / none)
+//   • allModels() — the full set, for modelQuality's percentile ranking.
+//
+// Split deliberately: the pure matching lives in `createModelIndex` (no I/O,
+// unit-testable with a fixture); `createModelCatalogController` owns the
+// fetch → cache → degrade dance. The degradation contract matches the sibling
+// measurement modules (modelLedger.mjs, messageSearch.mjs): a missing or
+// failing catalogue NEVER throws and NEVER blanks a working cache — it serves
+// the last good copy, or reports `{ supported:false }` when there has never
+// been one. An absent catalogue means models are unidentifiable, which the
+// eligibility gate already handles honestly; it must not fail a routing
+// decision.
+//
+// CACHE PATH — `statePath("model-catalog.json")` resolves through
+// `stateHome()`, so the test sandbox (`MANTA_STATE_HOME`) redirects writes
+// away from the live box. Never build a path with `join(homedir(), …)`
+// directly (see AGENTS.md "THE SUITE RUNS ON A LIVE BOX").
+
+import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { startPoller } from "./startPoller.mjs";
+
+// The provider-agnostic view of models.dev. The per-provider view is already
+// consumed indirectly via opencode's `/provider`; this one is not.
+export const CATALOG_URL = "https://models.dev/models.json";
+
+// Cache last-good copy to state – `statePath` lands inside the box's state
+// dir (or the test sandbox when MANTA_STATE_HOME is set).
+export const CACHE_PATH = statePath("model-catalog.json");
+
+// Refresh cadence. The catalogue is opencode's own, changes rarely, and is a
+// large-ish download (hundreds of models), so we poll slowly and fall back to
+// the cached copy between refreshes. startPoller gives us the immediate first
+// tick, the inFlight re-entrancy guard and `timer.unref()` for free.
+const DEFAULT_POLL_MS = 6 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Pure normalisation + matching
+// ---------------------------------------------------------------------------
+
+// Normalise a model identifier for comparison: case-insensitive, collapsing
+// `.`, `_`, `/`, whitespace and runs of `-` onto a single `-`. So `Qwen3.6-27B`,
+// `qwen3.6_27b` and `qwen3.6-27b` all compare equal.
+export function normalize(modelsId) {
+  return String(modelsId)
+    .toLowerCase()
+    .replace(/[\s_./]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// Every distinct normalised "handle" an entry can be addressed by: its full
+// catalogue id, the bare model segment of that id (after the provider prefix),
+// its display name, and its family. Grouping by family is what lets an opaque
+// local id like `ornith` resolve to all four sibling sizes instead of guessing
+// between them.
+export function entryHandles(entry) {
+  const keys = new Set();
+  const id = entry?.id;
+  const name = entry?.name;
+  const family = entry?.family;
+  if (typeof id === "string" && id !== "") {
+    keys.add(normalize(id));
+    const seg = id.split("/").pop();
+    if (typeof seg === "string" && seg !== "") keys.add(normalize(seg));
+  }
+  if (typeof name === "string" && name !== "") keys.add(normalize(name));
+  if (typeof family === "string" && family !== "") keys.add(normalize(family));
+  return keys;
+}
+
+/**
+ * PURE. Build a read-only matcher over a list of catalogue entries.
+ *
+ * `lookupModel(catalogId)` — exact match on the catalogue id (case-insensitive
+ * and separator-normalised). Returns the entry or null.
+ *
+ * `matchModel(localModelId)` — resolves an opaque local id to the catalogue
+ * entries it could be, on the model id and name (case-insensitive, separators
+ * normalised), with family-grouping so a bare family name surfaces every size.
+ * Returns `{ kind, candidates }` where `kind` is:
+ *   "exact"      — exactly one entry matches;
+ *   "ambiguous"  — several entries match (e.g. one family at different sizes);
+ *                  the caller must NOT guess between them — never pick between
+ *                  candidates of materially different size;
+ *   "none"       — meaningless / unidentifiable (e.g. `default`).
+ *
+ * `allModels()` — the full entry list (for modelQuality's percentile field).
+ *
+ * @param {Array<object>} entries
+ */
+export function createModelIndex(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  const byHandle = new Map();
+  for (const e of list) {
+    for (const k of entryHandles(e)) {
+      let bucket = byHandle.get(k);
+      if (!bucket) {
+        bucket = [];
+        byHandle.set(k, bucket);
+      }
+      bucket.push(e);
+    }
+  }
+
+  return {
+    get size() {
+      return list.length;
+    },
+    lookupModel(catalogId) {
+      const needle = normalize(catalogId);
+      for (const e of list) {
+        if (typeof e?.id === "string" && normalize(e.id) === needle) return e;
+      }
+      return null;
+    },
+    matchModel(localModelId) {
+      const needle = normalize(localModelId);
+      const raw = byHandle.get(needle) ?? [];
+      // An entry can appear under several handles; dedupe before classifying.
+      const candidates = [...new Set(raw)];
+      if (candidates.length === 0) return { kind: "none", candidates: [] };
+      if (candidates.length === 1) return { kind: "exact", candidates };
+      return { kind: "ambiguous", candidates };
+    },
+    allModels() {
+      return list.slice();
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Coercing the raw network payload to a list of entries
+// ---------------------------------------------------------------------------
+
+// models.json ships as either an array of entries (each with an `id`) or an
+// object keyed by catalogue id. Handle both so an upstream format change
+// doesn't silently empty the catalogue.
+export function normalizePayload(payload) {
+  if (Array.isArray(payload)) {
+    return payload.filter(
+      (e) => e !== null && typeof e === "object",
+    );
+  }
+  if (payload !== null && typeof payload === "object") {
+    return Object.entries(payload)
+      .map(([id, v]) =>
+        v !== null && typeof v === "object"
+          ? { ...v, id: typeof v.id === "string" && v.id !== "" ? v.id : id }
+          : null,
+      )
+      .filter((e) => e !== null);
+  }
+  return [];
+}
+
+// ---------------------------------------------------------------------------
+// I/O: fetch → cache → degrade
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a model-catalogue controller: loads the last-good copy from `cachePath`
+ * (empty when there is none), can `refresh()` from the network, and exposes the
+ * matcher against the current catalogue.
+ *
+ * Degradation (never throws, never blanks a working cache):
+ *   • fetch fails but a cache exists (in-memory or on disk) → serve the cache;
+ *   • no cache AND fetch fails → `{ supported:false }` (empty catalogue), which
+ *     `matchModel` reports as `{ kind:"none" }` and `allModels` as `[]`.
+ *
+ * @param {object} [opts]
+ * @param {typeof globalThis.fetch} [opts.fetchImpl]
+ * @param {string} [opts.cachePath] defaults to `CACHE_PATH`
+ * @param {number} [opts.intervalMs]
+ */
+export function createModelCatalogController({
+  fetchImpl,
+  cachePath = CACHE_PATH,
+  intervalMs = DEFAULT_POLL_MS,
+} = {}) {
+  const cached = readJsonSync(cachePath, null);
+  let catalog = createModelIndex(normalizePayload(cached));
+
+  async function refresh() {
+    const doFetch = fetchImpl ?? globalThis.fetch;
+    try {
+      const res = await doFetch(CATALOG_URL);
+      if (!res || !res.ok) {
+        throw new Error(`model catalog fetch failed: ${res?.status ?? "no response"}`);
+      }
+      const payload = await res.json();
+      const next = normalizePayload(payload);
+      if (next.length === 0) throw new Error("model catalog empty");
+      catalog = createModelIndex(next);
+      await writeJsonAtomic(cachePath, JSON.stringify(payload), { mode: 0o600 });
+      return { ok: true, size: next.length };
+    } catch (e) {
+      return { ok: false, error: e?.message ?? String(e) };
+    }
+  }
+
+  return {
+    refresh,
+    start() {
+      return startPoller(refresh, { intervalMs, label: "modelCatalog" });
+    },
+    lookupModel: (id) => catalog.lookupModel(id),
+    matchModel: (id) => catalog.matchModel(id),
+    allModels: () => catalog.allModels(),
+    status: () => ({ supported: catalog.size > 0, size: catalog.size }),
+  };
+}
+
+// The box's own singleton. `startModelCatalogPoller` loads the cached copy and
+// arms the periodic refresh; before it is called the matcher is empty
+// (`{supported:false}`) — safe, honest, non-blocking.
+const boxCatalog = createModelCatalogController({});
+
+/**
+ * Load the box's model catalogue and keep it fresh. Reuses `startPoller.mjs`
+ * (immediate first tick, inFlight guard, `timer.unref()`). Returns `{ stop }`
+ * plus the same lookup/match/allModels/status as the controller, so a caller
+ * (later routing stages) can read the catalogue through one object while the
+ * module-level `lookupModel`/`matchModel`/`allModels` stay in sync.
+ */
+export function startModelCatalogPoller(opts = {}) {
+  const controller = createModelCatalogController(opts);
+  const handle = controller.start();
+  return {
+    stop: handle.stop,
+    refresh: controller.refresh,
+    lookupModel: controller.lookupModel,
+    matchModel: controller.matchModel,
+    allModels: controller.allModels,
+    status: controller.status,
+  };
+}
+
+export function lookupModel(catalogId) {
+  return boxCatalog.lookupModel(catalogId);
+}
+
+export function matchModel(localModelId) {
+  return boxCatalog.matchModel(localModelId);
+}
+
+export function allModels() {
+  return boxCatalog.allModels();
+}

--- a/src/server/modelCatalog.test.mjs
+++ b/src/server/modelCatalog.test.mjs
@@ -1,0 +1,210 @@
+// modelCatalog.test.mjs — unit tests for the box-side model catalogue.
+//
+// Pure matching runs against a checked-in fixture (a trimmed subset of
+// models.json), never the network. The I/O tests stub `fetchImpl` and point
+// each controller at its own `cachePath` inside MANTA_STATE_HOME, so a fetch
+// failure / cache-hit exercise writes nothing outside the sandbox.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { sep } from "node:path";
+import { stateHome, statePath } from "../shared/paths.mjs";
+import {
+  CACHE_PATH,
+  normalize,
+  normalizePayload,
+  createModelIndex,
+  createModelCatalogController,
+  startModelCatalogPoller,
+} from "./modelCatalog.mjs";
+
+const FIXTURE = JSON.parse(
+  readFileSync(new URL("./fixtures/modelCatalog.fixture.json", import.meta.url), "utf-8"),
+);
+
+// A minimal fetch stub: `ok`/`status` control the response contract, `json`
+// the body. Enough for refresh() without a network connection.
+function stubFetch({ ok = true, status = 200, body = FIXTURE } = {}) {
+  return async () => ({ ok, status, json: async () => body });
+}
+
+function failingFetch(message = "boom") {
+  return async () => {
+    throw new Error(message);
+  };
+}
+
+const ORNITH_SIZES = ["9B", "31B", "35B", "397B"];
+
+// ---------------------------------------------------------------------------
+// Pure matching — driven by the three real cases from the issue
+// ---------------------------------------------------------------------------
+
+test("matchModel resolves an opaque local id to its exact catalogue entry", () => {
+  const index = createModelIndex(FIXTURE);
+  const res = index.matchModel("qwen3.6-27b");
+  assert.equal(res.kind, "exact");
+  assert.equal(res.candidates.length, 1);
+  assert.equal(res.candidates[0].id, "qwen/qwen3.6-27b");
+});
+
+test("matchModel returns every same-family size rather than guessing (ambiguous)", () => {
+  const index = createModelIndex(FIXTURE);
+  const res = index.matchModel("ornith");
+  assert.equal(res.kind, "ambiguous");
+  const ids = res.candidates.map((e) => e.id).sort();
+  assert.equal(ids.length, ORNITH_SIZES.length);
+  for (const size of ORNITH_SIZES) {
+    assert.ok(res.candidates.some((e) => e.name === `Ornith ${size}`), `missing Ornith ${size}`);
+  }
+  // Deliberately not collapsed to one candidate despite the size gap.
+  assert.deepEqual(
+    res.candidates.map((e) => e.family),
+    Array(ORNITH_SIZES.length).fill("ornith"),
+  );
+});
+
+test("matchModel reports none for a meaningless identifier", () => {
+  const index = createModelIndex(FIXTURE);
+  assert.deepEqual(index.matchModel("default"), { kind: "none", candidates: [] });
+  // An unmatchable id behaves the same as the unsupported-catalogue case.
+  assert.deepEqual(index.matchModel("not-a-real-model"), { kind: "none", candidates: [] });
+});
+
+test("matchModel is case-insensitive and normalises separators", () => {
+  const index = createModelIndex(FIXTURE);
+  assert.equal(index.matchModel("Qwen3.6-27B").kind, "exact");
+  assert.equal(index.matchModel("qwen3-6_27b").kind, "exact");
+  assert.equal(index.matchModel("qwen3.6 27b").kind, "exact");
+  assert.equal(index.matchModel("ORNITH").kind, "ambiguous");
+});
+
+test("lookupModel finds a catalogue id, exact and normalised", () => {
+  const index = createModelIndex(FIXTURE);
+  assert.equal(index.lookupModel("minimax/MiniMax-M3")?.id, "minimax/MiniMax-M3");
+  // Case/separator differences still resolve to the same entry.
+  assert.equal(index.lookupModel("Minimax/minimax-m3")?.id, "minimax/MiniMax-M3");
+  assert.equal(index.lookupModel("deepseek/deepseek-chat")?.id, "deepseek/deepseek-chat");
+  assert.equal(index.lookupModel("does/not-exist"), null);
+});
+
+test("allModels returns the full catalogue and does not hand out the internal list", () => {
+  const index = createModelIndex(FIXTURE);
+  const all = index.allModels();
+  assert.equal(all.length, FIXTURE.length);
+  all.push({ id: "mutated" });
+  assert.equal(index.allModels().length, FIXTURE.length, "mutation must not leak");
+});
+
+test("normalize collapses separators and case", () => {
+  assert.equal(normalize("Qwen3.6-27B"), "qwen3-6-27b");
+  assert.equal(normalize("qwen3.6_27b"), "qwen3-6-27b");
+  assert.equal(normalize("minimax/MiniMax-M3"), "minimax-minimax-m3");
+  assert.equal(normalize(" default "), "default");
+});
+
+test("normalizePayload accepts both the array and the id-keyed-object shape", () => {
+  assert.equal(normalizePayload(FIXTURE).length, FIXTURE.length);
+  const asObject = Object.fromEntries(FIXTURE.map((e) => [e.id, e]));
+  const fromObject = normalizePayload(asObject);
+  assert.equal(fromObject.length, FIXTURE.length);
+  assert.ok(fromObject.every((e) => typeof e.id === "string"));
+  // Preserves the id when the object value already carries one.
+  assert.equal(normalizePayload({ "x/y": { ...FIXTURE[0], id: "override/id" } })[0].id, "override/id");
+  // Garbage → empty, never throws.
+  assert.deepEqual(normalizePayload(null), []);
+  assert.deepEqual(normalizePayload("nope"), []);
+});
+
+// ---------------------------------------------------------------------------
+// I/O: refresh → cache → degrade
+// ---------------------------------------------------------------------------
+
+test("a successful refresh serves the catalogue and writes a cache copy", async () => {
+  const cachePath = statePath("model-catalog.test-success.json");
+  const ctl = createModelCatalogController({ fetchImpl: stubFetch(), cachePath });
+  const res = await ctl.refresh();
+  assert.equal(res.ok, true);
+  assert.equal(res.size, FIXTURE.length);
+  assert.equal(ctl.status().supported, true);
+  assert.equal(ctl.matchModel("ornith").kind, "ambiguous");
+  // The last-good copy is on disk for the next boot.
+  const onDisk = JSON.parse(readFileSync(cachePath, "utf-8"));
+  assert.equal(onDisk.length, FIXTURE.length);
+});
+
+test("a failed fetch degrades to the last good cached copy", async () => {
+  const cachePath = statePath("model-catalog.test-cache.json");
+  // Seed the cache the way a prior successful boot would have.
+  const { writeJsonAtomic } = await import("./jsonStore.mjs");
+  await writeJsonAtomic(cachePath, JSON.stringify(FIXTURE), { mode: 0o600 });
+
+  const ctl = createModelCatalogController({ fetchImpl: failingFetch(), cachePath });
+  assert.equal(ctl.status().supported, true, "cache is served before any refresh");
+  const res = await ctl.refresh();
+  assert.equal(res.ok, false);
+  // The cache is intact and the matcher still answers.
+  assert.equal(ctl.status().supported, true);
+  assert.equal(ctl.matchModel("qwen3.6-27b").kind, "exact");
+  assert.equal(ctl.matchModel("ornith").kind, "ambiguous");
+});
+
+test("no cache + failed fetch → { supported:false }, never throws", async () => {
+  const cachePath = statePath("model-catalog.test-none.json"); // does not exist
+  const ctl = createModelCatalogController({ fetchImpl: failingFetch(), cachePath });
+  assert.equal(ctl.status().supported, false);
+  const res = await ctl.refresh();
+  assert.equal(res.ok, false);
+  assert.equal(ctl.status().supported, false);
+  assert.deepEqual(ctl.allModels(), []);
+  assert.deepEqual(ctl.matchModel("anything"), { kind: "none", candidates: [] });
+});
+
+test("a failed refresh never blanks a catalogue already held in memory", async () => {
+  const cachePath = statePath("model-catalog.test-blank.json");
+  const ok = createModelCatalogController({ fetchImpl: stubFetch(), cachePath });
+  await ok.refresh();
+  assert.equal(ok.status().supported, true);
+  // Flip the catalogue's source to a failing fetch on the SAME cache path:
+  // the in-memory catalogue must survive a later failed refresh.
+  const ctl = createModelCatalogController({ fetchImpl: failingFetch(), cachePath });
+  assert.equal(ctl.status().supported, true, "booted from the on-disk copy");
+  const res = await ctl.refresh();
+  assert.equal(res.ok, false);
+  assert.equal(ctl.status().supported, true, "failed refresh keeps the good copy");
+  assert.equal(ctl.matchModel("ornith").kind, "ambiguous");
+});
+
+test("startModelCatalogPoller reuses startPoller: immediate tick populates the catalogue", async () => {
+  const cachePath = statePath("model-catalog.test-poller.json");
+  const poller = startModelCatalogPoller({ fetchImpl: stubFetch(), cachePath });
+  try {
+    // Immediate first tick is async; bounded-wait until it has landed.
+    const deadline = Date.now() + 2000;
+    while (Date.now() < deadline) {
+      if (poller.status().supported) break;
+      await new Promise((r) => setTimeout(r, 10));
+    }
+    assert.equal(poller.status().supported, true);
+    assert.equal(poller.matchModel("qwen3.6-27b").kind, "exact");
+    assert.equal(poller.lookupModel("minimax/MiniMax-M3")?.id, "minimax/MiniMax-M3");
+  } finally {
+    poller.stop();
+  }
+});
+
+// ---------------------------------------------------------------------------
+// Sandbox canary — the cache path must resolve INSIDE MANTA_STATE_HOME
+// ---------------------------------------------------------------------------
+
+test("the catalogue cache path resolves inside the state sandbox", () => {
+  const sandbox = process.env.MANTA_STATE_HOME;
+  assert.ok(sandbox && sandbox.trim() !== "", "MANTA_STATE_HOME must be set");
+  assert.equal(stateHome(), sandbox);
+  assert.ok(
+    CACHE_PATH.startsWith(sandbox + sep),
+    `cache path resolved to ${CACHE_PATH}, outside the sandbox ${sandbox}`,
+  );
+  assert.ok(statePath("model-catalog.json").startsWith(sandbox + sep));
+});


### PR DESCRIPTION
## Summary

Stage 5 of Automatic Manta Routing (BET-1226): cache the **provider-agnostic** model catalogue (`https://models.dev/models.json`) on the box. This is opencode's own catalogue — the `/provider` list Manta already receives IS this data — we were simply not reading the provider-agnostic view, which is what makes an opaque provider alias resolvable.

New module `src/server/modelCatalog.mjs` with three exports:

- **`lookupModel(catalogId)`** — exact, case-insensitive / separator-normalised lookup by catalogue id.
- **`matchModel(localModelId)`** — resolves an opaque local id to `{ kind: "exact" | "ambiguous" | "none", candidates }`, matched on the model id + name (+ family), normalising separators. Never guesses between candidates of materially different size — an `ambiguous` result returns all of them for the caller to ask.
- **`allModels()`** — the full entry list, for modelQuality's percentile field (owned downstream; this module only supplies the field).

Architecture (matching what `AGENTS.md` and the sibling `modelLedger.mjs` prescribe):

- **Pure matching** in `createModelIndex` (no I/O, unit-tested against a checked-in fixture). I/O lives in `createModelCatalogController` (fetch → cache → degrade).
- Uses `statePath()` from `src/shared/paths.mjs` for the cache path — under the test sandbox (`MANTA_STATE_HOME`) it resolves off the sandbox, never the live box (there is a dedicated canary test).
- Reuses **`startPoller.mjs`** (immediate first tick, inFlight guard, `timer.unref()`); never hand-rolls a timer. Default cadence 6h (large-ish download, changes rarely).
- **Degradation contract**: a fetch failure never throws and never blanks a working cache — it serves the last good copy from disk/memory, or reports `{ supported:false }` (empty catalogue → `matchModel` returns `{kind:"none"}`, `allModels` returns `[]`) when there has never been one. An absent catalogue means models are unidentifiable, which the eligibility gate already handles honestly — it must not fail a routing decision.
- `normalizePayload` accepts both the array and the id-keyed-object shapes of `models.json` so an upstream format change doesn't silently empty the catalogue.

Not wired into `index.mjs` boot yet — this stage is the cache + matcher module. `startModelCatalogPoller({...})` is exported for a later stage to arm at boot (modelQuality/routing).

**Standing-rule compliance:** no vendor names in the module; pure logic split from I/O; pure matching is unit-tested with a fixture only (no live network, no live tmux/opencode). Anti-spaghetti: reused `statePath`/`jsonStore`/`startPoller` rather than adding parallel copies.

## Files changed (3, +553/−0, on top of `origin/main`)

- `src/server/modelCatalog.mjs`
- `src/server/modelCatalog.test.mjs`
- `src/server/fixtures/modelCatalog.fixture.json`

## Verification results

- **typecheck:** exit 0, no errors. (`npm run typecheck`)
- **`src/server/modelCatalog.test.mjs`:** 14/14 pass (exact/ambiguous/none driven by the three real cases; cached copy served on fetch failure; `{supported:false}` with no cache+no network; failed refresh never blanks an in-memory copy; `startModelCatalogPoller` populates via the immediate startPoller tick; cache path resolves inside `MANTA_STATE_HOME`).
- **Full `npm test`:** the broader server suite cannot run to completion in this sandbox — `node_modules` is missing the third-party packages `node-pty` and `yaml`, producing 11 pre-existing `ERR_MODULE_NOT_FOUND` failures in files this PR does not touch (`pty.mjs`, `forgeRules.mjs`, `pluginManifest.mjs` and their dependents). These are environmental here and unrelated to this change; the real suite runs on CI.

**Base: `origin/main` @ `ffee9d05`**
