### PR TITLE
feat(renderer): three-state per-session model choice (auto/model/default) BET-1245

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -69,7 +69,7 @@ import { isPlanAgent, planPageUrl } from "../shared/planMode.mjs";
 import { serverBase } from "./api/httpApi";
 import {
   appendPromptHistory,
-  copySavedModel,
+  carrySavedChoice,
   guessMime,
   mimeToInputMode,
   modelInputModes,
@@ -1636,10 +1636,10 @@ export function ChatPanel({
         // auto-rename first-name path and stamp a workspace-prefixed name (BET-1100).
         title: "",
       });
-      // /clear carries the session's model forward so the user doesn't re-pick
-      // after every clear; plan mode state is carried on top.
+      // /clear carries the session's model choice forward so the user doesn't
+      // re-pick after every clear (including Auto); plan mode state on top.
       if (cleared?.newSessionId) {
-        copySavedModel(sessionId, cleared.newSessionId);
+        carrySavedChoice(sessionId, cleared.newSessionId);
         if (planOn) {
           writePlanSaved(cleared.newSessionId, true);
         }

--- a/src/renderer/chatShared.test.ts
+++ b/src/renderer/chatShared.test.ts
@@ -18,7 +18,9 @@ import {
   writeSavedMode,
   readSavedModel,
   writeSavedModel,
-  copySavedModel,
+  readSavedChoice,
+  writeSavedChoice,
+  carrySavedChoice,
   resolveLauncherFlags,
   readPromptHistory,
   appendPromptHistory,
@@ -299,21 +301,80 @@ describe("readSavedModel / writeSavedModel", () => {
   });
 });
 
-describe("copySavedModel /clear carry-forward", () => {
+describe("readSavedChoice / writeSavedChoice (three-state, BET-1245)", () => {
   beforeEach(() => {
     localStorage.clear();
   });
   const sel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
 
-  it("copies the source session's model to the destination session id", () => {
-    writeSavedModel("sess-1", sel);
-    copySavedModel("sess-1", "sess-2");
-    expect(readSavedModel("sess-2")).toEqual(sel);
+  it("round-trips the auto state", () => {
+    writeSavedChoice("sess-1", { kind: "auto" });
+    expect(readSavedChoice("sess-1")).toEqual({ kind: "auto" });
   });
 
-  it("is a no-op when the source has no stored model (destination stays null)", () => {
-    copySavedModel("sess-1", "sess-2");
-    expect(readSavedModel("sess-2")).toBeNull();
+  it("round-trips an explicit model", () => {
+    writeSavedChoice("sess-1", { kind: "model", model: sel });
+    expect(readSavedChoice("sess-1")).toEqual({ kind: "model", model: sel });
+  });
+
+  it("round-trips the server-default state (key absent)", () => {
+    writeSavedChoice("sess-1", { kind: "server-default" });
+    expect(readSavedChoice("sess-1")).toEqual({ kind: "server-default" });
+    expect(localStorage.getItem("manta:chat:sess-1:model")).toBeNull();
+  });
+
+  it("an existing stored ModelSelection still reads as { kind: 'model' }", () => {
+    localStorage.setItem("manta:chat:sess-1:model", JSON.stringify(sel));
+    expect(readSavedChoice("sess-1")).toEqual({ kind: "model", model: sel });
+  });
+
+  it("an absent key reads server-default", () => {
+    expect(readSavedChoice("sess-1")).toEqual({ kind: "server-default" });
+  });
+
+  it("the bare string 'auto' reads as auto", () => {
+    localStorage.setItem("manta:chat:sess-1:model", "auto");
+    expect(readSavedChoice("sess-1")).toEqual({ kind: "auto" });
+  });
+
+  it("malformed JSON reads server-default and does not throw", () => {
+    localStorage.setItem("manta:chat:sess-1:model", "{not json");
+    expect(() => readSavedChoice("sess-1")).not.toThrow();
+    expect(readSavedChoice("sess-1")).toEqual({ kind: "server-default" });
+  });
+
+  it("writes auto as the bare string, not a JSON object", () => {
+    writeSavedChoice("sess-1", { kind: "auto" });
+    expect(localStorage.getItem("manta:chat:sess-1:model")).toBe("auto");
+  });
+
+  it("a session's choice is isolated from another session id", () => {
+    writeSavedChoice("sess-1", { kind: "auto" });
+    expect(readSavedChoice("sess-2")).toEqual({ kind: "server-default" });
+  });
+});
+
+describe("carrySavedChoice /clear carry-forward", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+  const sel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+
+  it("carries an explicit model to the destination session id", () => {
+    writeSavedChoice("sess-1", { kind: "model", model: sel });
+    carrySavedChoice("sess-1", "sess-2");
+    expect(readSavedChoice("sess-2")).toEqual({ kind: "model", model: sel });
+  });
+
+  it("carries the auto state to the destination session id", () => {
+    writeSavedChoice("sess-1", { kind: "auto" });
+    carrySavedChoice("sess-1", "sess-2");
+    expect(readSavedChoice("sess-2")).toEqual({ kind: "auto" });
+  });
+
+  it("is a no-op when the source has no stored choice (destination stays default)", () => {
+    carrySavedChoice("sess-1", "sess-2");
+    expect(readSavedChoice("sess-2")).toEqual({ kind: "server-default" });
   });
 });
 

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -245,35 +245,90 @@ export function modelKey(sessionId: string): string {
   return `manta:chat:${sessionId}:model`;
 }
 
-export function readSavedModel(sessionId: string): ModelSelection | null {
+/**
+ * What the session's model picker is set to. Three states (BET-1245):
+ * - `{ kind: "auto" }`        — automatic routing picks the model for this conversation.
+ * - `{ kind: "model" }`       — an explicit `ModelSelection`, the historical meaning of
+ *                               the stored value.
+ * - `{ kind: "server-default" }` — today's `null`: let opencode pick its default.
+ *
+ * Kept separate from `ModelSelection` on purpose: widening `ModelSelection` would force
+ * every consumer that forwards a model to a provider to re-narrow it.
+ */
+export type ModelChoice =
+  | { kind: "auto" }
+  | { kind: "model"; model: ModelSelection }
+  | { kind: "server-default" };
+
+/**
+ * Read the per-session model choice. One storage key (`modelKey`), three states.
+ * The stored value is either absent (`server-default`), a `ModelSelection` JSON
+ * object (`{ kind: "model" }`), or the bare literal string `"auto"`
+ * (`{ kind: "auto" }`). A malformed or unparseable value falls back to
+ * `server-default`; never throws out of a storage read.
+ */
+export function readSavedChoice(sessionId: string): ModelChoice {
   try {
     const raw = localStorage.getItem(modelKey(sessionId));
-    if (!raw) return null;
+    if (raw === null) return { kind: "server-default" };
+    if (raw === "auto") return { kind: "auto" };
     const parsed = JSON.parse(raw);
     if (parsed && typeof parsed.providerID === "string" && typeof parsed.modelID === "string") {
-      return parsed as ModelSelection;
+      return { kind: "model", model: parsed as ModelSelection };
     }
-    return null;
+    return { kind: "server-default" };
   } catch {
-    return null;
+    return { kind: "server-default" };
   }
 }
 
-export function writeSavedModel(sessionId: string, m: ModelSelection | null): void {
+/**
+ * Persist the per-session model choice under the SAME key as the historical
+ * `ModelSelection` JSON (so existing sessions keep their stored model, and a
+ * later variant is a compatible read). `auto` is written as the bare string
+ * `"auto"`; `server-default` removes the key (an absent value means default).
+ */
+export function writeSavedChoice(sessionId: string, c: ModelChoice): void {
   try {
-    if (m) localStorage.setItem(modelKey(sessionId), JSON.stringify(m));
-    else localStorage.removeItem(modelKey(sessionId));
+    switch (c.kind) {
+      case "auto":
+        localStorage.setItem(modelKey(sessionId), "auto");
+        break;
+      case "model":
+        localStorage.setItem(modelKey(sessionId), JSON.stringify(c.model));
+        break;
+      case "server-default":
+        localStorage.removeItem(modelKey(sessionId));
+        break;
+    }
   } catch { /* quota / disabled storage */ }
 }
 
-// /clear carry-forward: copy the session's model to the new session id so the
-// user doesn't have to re-pick after every clear. Copies the RAW stored value.
-export function copySavedModel(fromSessionId: string, toSessionId: string): void {
-  try {
-    const raw = localStorage.getItem(modelKey(fromSessionId));
-    if (raw === null) return;
-    localStorage.setItem(modelKey(toSessionId), raw);
-  } catch { /* quota / disabled storage */ }
+/**
+ * /clear carry-forward: copy the session's model choice to the new session id
+ * so the user doesn't have to re-pick after every clear. Carry the FULL choice
+ * (including `auto`) — clearing a conversation must not silently drop Auto.
+ */
+export function carrySavedChoice(fromSessionId: string, toSessionId: string): void {
+  writeSavedChoice(toSessionId, readSavedChoice(fromSessionId));
+}
+
+/**
+ * @deprecated Superseded by `readSavedChoice` (BET-1245). Thin wrapper over the
+ * three-state reader: returns the explicit `ModelSelection`, or `null` for the
+ * auto / server-default states. Prefer `readSavedChoice` and narrow yourself.
+ */
+export function readSavedModel(sessionId: string): ModelSelection | null {
+  const c = readSavedChoice(sessionId);
+  return c.kind === "model" ? c.model : null;
+}
+
+/**
+ * @deprecated Superseded by `writeSavedChoice` (BET-1245). Thin wrapper: writes
+ * an explicit model, or clears to the server default when `m` is null.
+ */
+export function writeSavedModel(sessionId: string, m: ModelSelection | null): void {
+  writeSavedChoice(sessionId, m ? { kind: "model", model: m } : { kind: "server-default" });
 }
 
 // Per-session plan-mode override (BET-949). Deliberately its OWN storage key —


### PR DESCRIPTION
## Summary

Stage 6 of the Automatic Manta Routing epic. Extends the persisted per-session model
selection to a **three-state** choice without widening `ModelSelection` (which would force
every provider-forwarding consumer to re-narrow it).

Adds to `src/renderer/chatShared.tsx`:

- `ModelChoice = { kind: "auto" } | { kind: "model", model } | { kind: "server-default" }`
- `readSavedChoice` / `writeSavedChoice` / `carrySavedChoice`

**Storage compatibility** — same single key (`manta:chat:<sid>:model`), one key three states:
- absent → `server-default`
- a `ModelSelection`-shaped JSON object → `{ kind: "model", model }`
- bare literal string `"auto"` → `{ kind: "auto" }` (written as a bare string, not JSON)
- malformed → `server-default`, never throws out of a storage read

**Replace, don't duplicate.** `readSavedModel`/`writeSavedModel` are reimplemented as thin
`@deprecated` wrappers over the new pair (the ~6 call sites are model-view consumers in
ChatPanel/App that the later ChatPanel/ModelPicker issues migrate). No second independent
reader of the key. The `/clear` carry-forward was renamed `carrySavedChoice` and now carries
the FULL choice including `Auto` — clearing a conversation no longer silently drops Auto.

**Tests** — `chatShared.test.ts`: round-trip for each of the three states, existing stored
`ModelSelection` reads as `{ kind: "model" }`, absent → `server-default`, malformed →
`server-default` (no throw), `"auto"` written/read as bare string, and `carrySavedChoice`
carries `auto` across session ids (plus explicit-model and no-op cases).

**Verification results:**
- PR branch (`multica/BET-1245-model-choice-three-state` @ `a427e824`): typecheck exit 0, none. test exit 0, 2576 pass / 0 fail / 0 skip.
- Base (`main` @ `ffee9d05`).
- Conclusion: 0 new failures.

Base: `origin/main` @ `ffee9d05`
