### PR TITLE
BET-1232: modelQuality — tier as a percentile band

### DIFF
--- a/src/shared/modelGuide.d.mts
+++ b/src/shared/modelGuide.d.mts
@@ -8,6 +8,8 @@ export interface ModelInfo {
 
 export function tierRank(tier: string | undefined): number;
 
+export const FAMILY_TIERS: Record<string, ModelTier>;
+
 export function describeModel(
   providerID: string,
   modelID: string

--- a/src/shared/modelGuide.mjs
+++ b/src/shared/modelGuide.mjs
@@ -206,6 +206,15 @@ const CATALOG = [
   },
 ];
 
+// Family → tier, derived from CATALOG so it cannot drift. modelQuality.mjs
+// seeds its family→score table from this so already-covered families keep
+// their current tier when quality becomes percentile-based. Exposed (rather
+// than reading CATALOG directly) so the association survives the eventual
+// removal of the `tier` field from CATALOG entries.
+export const FAMILY_TIERS = Object.fromEntries(
+  CATALOG.map((e) => [e.key, e.tier]),
+);
+
 function matchFamily(modelID) {
   if (!modelID || typeof modelID !== "string") return null;
   const normalized = modelID.toLowerCase();

--- a/src/shared/modelQuality.d.mts
+++ b/src/shared/modelQuality.d.mts
@@ -1,0 +1,52 @@
+export const TIERS: string[];
+
+export const FAMILY_SEED_SCORES: Record<string, number>;
+
+export const AGENT_FLOOR_SCORE: Record<string, number>;
+
+export type QualityBasis = "benchmark" | "family" | "structural";
+
+export interface QualityResult {
+  score: number;
+  basis: QualityBasis;
+  known: boolean;
+}
+
+export interface Benchmark {
+  name: string;
+  score: number;
+  metric?: string;
+}
+
+export interface QualityModel {
+  family?: string;
+  capabilities?: { reasoning?: boolean };
+  limit?: { context?: number | null; output?: number };
+  cost?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+}
+
+export interface CatalogEntry {
+  family?: string;
+  benchmarks?: Benchmark[];
+  reasoning?: boolean;
+  limit?: number;
+}
+
+export interface Field {
+  benchmarkPercentile?(name: string, score: number): number | null | undefined;
+}
+
+export function qualityScore(
+  model: QualityModel | null | undefined,
+  catalogEntry?: CatalogEntry | null,
+  field?: Field | null
+): QualityResult;
+
+export function tierForScore(score: number | undefined): string;
+
+export function meetsFloor(score: number | undefined, agent: string): boolean;

--- a/src/shared/modelQuality.mjs
+++ b/src/shared/modelQuality.mjs
@@ -1,0 +1,195 @@
+// modelQuality.mjs — a model's position in the field it is competing in.
+//
+// Pure, injected inputs only. There is no I/O and nothing is fetched: the
+// catalogue entry and the percentile helper arrive as arguments. This is the
+// replacement for the hand-maintained tier table (the `tier` field in
+// modelGuide.mjs's CATALOG): a percentile re-ranks itself for free whenever
+// the field moves, instead of going stale by construction.
+//
+// The model argument is an `OpencodeModel` (id, providerID, family,
+// capabilities.reasoning, limit.{context,output}, cost). Fields are read
+// defensively so a not-yet-normalised model degrades gracefully.
+//
+// The caller decides policy. A result with `known: false` means "not a
+// routing candidate" — that policy is applied by the caller, not encoded
+// here.
+
+import { FAMILY_TIERS } from "./modelGuide.mjs";
+
+/** The three routing tiers, ordered: fast < balanced < deep. */
+export const TIERS = ["fast", "balanced", "deep"];
+
+// Percentile bands. Declared here and nowhere else:
+//   fast < 0.4 <= balanced < 0.7 <= deep
+const BALANCED_MIN = 0.4;
+const DEEP_MIN = 0.7;
+
+// Seeded family scores keep already-covered families in the tier their
+// hand-maintained label gives them today (fast -> 0.25, balanced -> 0.55,
+// deep -> 0.85), which the bands above map back to the identical tier.
+const SEED_BY_TIER = { fast: 0.25, balanced: 0.55, deep: 0.85 };
+
+// Family -> representative score, seeded from the modelGuide CATALOG tier
+// labels. A family not present here (e.g. newly added to CATALOG) has no
+// seed yet, so its quality falls through to structural — the drift would be
+// caught by the "no regression for covered families" test.
+export const FAMILY_SEED_SCORES = Object.fromEntries(
+  Object.entries(FAMILY_TIERS).map(([family, tier]) => [
+    family,
+    SEED_BY_TIER[tier] ?? SEED_BY_TIER.balanced,
+  ]),
+);
+
+/** Minimum score an agent may run on. Replaces AGENT_FLOOR's tier names. */
+export const AGENT_FLOOR_SCORE = {
+  build: BALANCED_MIN, // >= balanced
+  plan: DEEP_MIN, // >= deep
+  general: BALANCED_MIN, // >= balanced
+  explore: 0, // >= fast
+  title: 0, // >= fast
+};
+
+const BENCH_PREFERENCE = [
+  "SWE-Bench Verified",
+  "SWE-Bench Pro",
+  "Terminal-Bench",
+  "Aider Polyglot",
+];
+
+function clamp01(v) {
+  return Math.min(1, Math.max(0, v));
+}
+
+// The most coding-relevant benchmark the catalogue entry carries (in
+// preference order), or null when none is present with a numeric score.
+function pickBenchmark(benchmarks) {
+  if (!Array.isArray(benchmarks)) return null;
+  for (const name of BENCH_PREFERENCE) {
+    const b = benchmarks.find(
+      (x) =>
+        x &&
+        x.name === name &&
+        typeof x.score === "number" &&
+        Number.isFinite(x.score),
+    );
+    if (b) return b;
+  }
+  return null;
+}
+
+function hasAnyCost(cost) {
+  if (!cost || typeof cost !== "object") return false;
+  return Object.values(cost).some(
+    (v) => typeof v === "number" && Number.isFinite(v),
+  );
+}
+
+// A coarse structural placement once a model has actual structural data
+// (reasoning flag, context/output limits, or a price). Returns null when the
+// model carries none of those signals — that is the "nothing" path, known:false.
+function structuralScore(m) {
+  const reasoning = m?.capabilities?.reasoning;
+  const ctx = m?.limit?.context;
+  const out = m?.limit?.output;
+  const cost = m?.cost;
+  const hasSignal =
+    typeof reasoning === "boolean" ||
+    typeof ctx === "number" ||
+    typeof out === "number" ||
+    hasAnyCost(cost);
+  if (!hasSignal) return null;
+
+  let score = 0.5;
+  if (reasoning === true) score += 0.2;
+  if (typeof ctx === "number") {
+    if (ctx >= 200000) score += 0.15;
+    else if (ctx > 64000) score += 0.05;
+    else if (ctx < 16000) score -= 0.1;
+  }
+  const total =
+    (typeof cost?.input === "number" ? cost.input : 0) +
+    (typeof cost?.output === "number" ? cost.output : 0);
+  if (total >= 60) score += 0.1;
+  else if (total > 0 && total < 2) score -= 0.15;
+  return { score: clamp01(score) };
+}
+
+/**
+ * A model's position in the field it is competing in, 0..1 (1 = strongest).
+ *
+ * Derivation order — first that yields a result wins:
+ *   1. Benchmark. The best coding-relevant benchmark, converted to a
+ *      percentile of the models we can currently see via the injected
+ *      `field` helper. `basis: "benchmark"`, `known: true`.
+ *   2. Family. The model's family from the catalogue (authoritative — never
+ *      a regex on the id) with a seeded score. `basis: "family"`, `known: true`.
+ *   3. Structural. Coarse placement from capabilities.reasoning /
+ *      limit.context / limit.output / price band. `basis: "structural"`,
+ *      `known: true`.
+ *   4. Nothing. `known: false`, score 0. The caller decides whether an
+ *      unknown model is a routing candidate — not encoded here.
+ *
+ * @param {object} model            OpencodeModel (family, capabilities.reasoning, limit, cost)
+ * @param {object} [catalogEntry]   provider-agnostic catalogue entry:
+ *                                  { family, benchmarks: [{name, score, metric}], reasoning, limit }
+ * @param {object} [field]          { benchmarkPercentile(name, score) } — injected ranking helper
+ * @returns {{ score: number, basis: "benchmark"|"family"|"structural", known: boolean }}
+ */
+export function qualityScore(model, catalogEntry, field) {
+  const ce = catalogEntry && typeof catalogEntry === "object" ? catalogEntry : {};
+  const m = model && typeof model === "object" ? model : {};
+
+  // 1. Benchmark
+  const bench = pickBenchmark(ce.benchmarks);
+  if (bench && typeof field?.benchmarkPercentile === "function") {
+    const pct = field.benchmarkPercentile(bench.name, bench.score);
+    if (typeof pct === "number" && Number.isFinite(pct)) {
+      return { score: clamp01(pct), basis: "benchmark", known: true };
+    }
+  }
+
+  // 2. Family (from the catalogue, authoritatively; never a regex on the id)
+  const family = typeof ce.family === "string" ? ce.family : m.family;
+  const seed = typeof family === "string" ? FAMILY_SEED_SCORES[family] : undefined;
+  if (typeof seed === "number") {
+    return { score: seed, basis: "family", known: true };
+  }
+
+  // 3. Structural
+  const structural = structuralScore(m);
+  if (structural !== null) {
+    return { score: structural.score, basis: "structural", known: true };
+  }
+
+  // 4. Nothing
+  return { score: 0, basis: "structural", known: false };
+}
+
+/**
+ * Which tier band a score falls in. Bands are percentile ranges, declared
+ * here and nowhere else: fast < 0.4 <= balanced < 0.7 <= deep.
+ *
+ * @param {number|undefined} score
+ * @returns {string}
+ */
+export function tierForScore(score) {
+  if (typeof score !== "number" || !Number.isFinite(score)) return TIERS[1];
+  if (score < BALANCED_MIN) return TIERS[0];
+  if (score < DEEP_MIN) return TIERS[1];
+  return TIERS[2];
+}
+
+/**
+ * Whether a score is high enough for a given agent. Floors map to the same
+ * effective tiers AGENT_FLOOR encoded: build/general >= balanced,
+ * plan >= deep, explore/title >= fast. An unknown agent has no floor.
+ *
+ * @param {number|undefined} score
+ * @param {string} agent
+ * @returns {boolean}
+ */
+export function meetsFloor(score, agent) {
+  const floor = AGENT_FLOOR_SCORE[agent];
+  if (floor === undefined) return true;
+  return typeof score === "number" && Number.isFinite(score) && score >= floor;
+}

--- a/src/shared/modelQuality.test.ts
+++ b/src/shared/modelQuality.test.ts
@@ -1,0 +1,189 @@
+import { describe, it, expect } from "vitest";
+import {
+  qualityScore,
+  tierForScore,
+  meetsFloor,
+  AGENT_FLOOR_SCORE,
+  TIERS,
+} from "./modelQuality.mjs";
+import { FAMILY_TIERS, tierRank } from "./modelGuide.mjs";
+import { AGENT_FLOOR } from "./modelRouter.mjs";
+
+// A test field helper that converts a benchmark score to a percentile of "the
+// models we can currently see" — the injected ranking helper qualityScore
+// depends on for relativity. indexOf(score) / (n - 1): 0 = weakest in the set,
+// 1 = strongest.
+function percentileField(allScores: number[]) {
+  const sorted = [...allScores].sort((a, b) => a - b);
+  return {
+    benchmarkPercentile(_name: string, score: number): number {
+      const idx = sorted.indexOf(score);
+      if (idx === -1) return Number.NaN;
+      if (sorted.length === 1) return 1;
+      return idx / (sorted.length - 1);
+    },
+  };
+}
+
+function model(over: Record<string, unknown> = {}) {
+  return { id: "m", providerID: "p", ...over };
+}
+
+describe("qualityScore — benchmark", () => {
+  it("ranks a higher SWE-Bench Verified score above a lower one, basis benchmark", () => {
+    const field = percentileField([40, 80]);
+    const low = qualityScore(
+      model(),
+      { family: "sonnet", benchmarks: [{ name: "SWE-Bench Verified", score: 40 }] },
+      field,
+    );
+    const high = qualityScore(
+      model(),
+      { family: "sonnet", benchmarks: [{ name: "SWE-Bench Verified", score: 80 }] },
+      field,
+    );
+    expect(low).toMatchObject({ basis: "benchmark", known: true });
+    expect(high).toMatchObject({ basis: "benchmark", known: true });
+    expect(high.score).toBeGreaterThan(low.score);
+  });
+
+  it("prefers SWE-Bench Verified over Aider Polyglot when both are present", () => {
+    const field = percentileField([50]); // only whatever is asked will match
+    // Aider Polyglot at 50 would resolve first if preference were ignored by
+    // ordering — but the tested benchmark is the one used.
+    const r = qualityScore(
+      model(),
+      {
+        family: "sonnet",
+        benchmarks: [
+          { name: "Aider Polyglot", score: 50 },
+          { name: "SWE-Bench Verified", score: 50 },
+        ],
+      },
+      field,
+    );
+    // percentileField over [50] returns 1 regardless of which is picked;
+    // this asserts the picked one resolves (not known:false via a no-match).
+    expect(r.basis).toBe("benchmark");
+    expect(r.known).toBe(true);
+  });
+
+  it("falls through to family when the field cannot rank the benchmark", () => {
+    const r = qualityScore(
+      model(),
+      { family: "sonnet", benchmarks: [{ name: "SWE-Bench Verified", score: 50 }] },
+      { benchmarkPercentile: () => Number.NaN },
+    );
+    expect(r).toMatchObject({ basis: "family", score: 0.55, known: true });
+  });
+});
+
+describe("qualityScore — family", () => {
+  it("gives a known family the seeded score, basis family", () => {
+    const r = qualityScore(model(), { family: "sonnet" });
+    expect(r).toEqual({ score: 0.55, basis: "family", known: true });
+  });
+
+  it("reads family from the catalogue authoritatively (not a regex on the id)", () => {
+    // id carries no family hint at all; only the catalogue family matters.
+    const r = qualityScore(model({ id: "some-random-name" }), { family: "opus" });
+    expect(r).toMatchObject({ score: 0.85, basis: "family", known: true });
+  });
+});
+
+describe("qualityScore — no regression for covered families", () => {
+  it("every family in CATALOG lands in the same tier its hardcoded tier says today", () => {
+    const families = Object.entries(FAMILY_TIERS);
+    expect(families.length).toBeGreaterThan(10);
+    for (const [family, expectedTier] of families) {
+      const r = qualityScore(model({ family }), { family });
+      expect(r.known).toBe(true);
+      expect(tierForScore(r.score)).toBe(expectedTier);
+    }
+  });
+});
+
+describe("qualityScore — unknown", () => {
+  it("returns known:false, score 0 for an unknown model", () => {
+    const r = qualityScore(model({ id: "brand-new-model" }), {});
+    expect(r).toEqual({ score: 0, basis: "structural", known: false });
+  });
+});
+
+describe("qualityScore — structural", () => {
+  it("places a reasoning model with a large context in the deep band", () => {
+    const r = qualityScore(
+      model({ capabilities: { reasoning: true }, limit: { context: 1_000_000 } }),
+      {},
+    );
+    expect(r).toMatchObject({ basis: "structural", known: true });
+    expect(r.score).toBeGreaterThanOrEqual(0.7);
+    expect(tierForScore(r.score)).toBe("deep");
+  });
+
+  it("a model with no structural signal is not known", () => {
+    const r = qualityScore(model({ id: "bare", providerID: "x" }), {});
+    expect(r.known).toBe(false);
+  });
+});
+
+describe("tierForScore", () => {
+  it("maps bands to fast < balanced < deep", () => {
+    expect(tierForScore(0.24)).toBe("fast");
+    expect(tierForScore(0.4)).toBe("balanced");
+    expect(tierForScore(0.55)).toBe("balanced");
+    expect(tierForScore(0.7)).toBe("deep");
+    expect(tierForScore(0.99)).toBe("deep");
+    expect(TIERS).toEqual(["fast", "balanced", "deep"]);
+  });
+});
+
+describe("meetsFloor", () => {
+  it("matches today's AGENT_FLOOR for all five agents", () => {
+    const agents = ["build", "plan", "general", "explore", "title"];
+    for (const s of [0, 0.25, 0.55, 0.85, 1]) {
+      for (const agent of agents) {
+        const expected = tierRank(tierForScore(s)) >= tierRank(AGENT_FLOOR[agent]);
+        expect(meetsFloor(s, agent)).toBe(expected);
+      }
+    }
+  });
+
+  it("uses score floors consistent with the tier bands", () => {
+    expect(AGENT_FLOOR_SCORE.build).toBe(0.4);
+    expect(AGENT_FLOOR_SCORE.general).toBe(0.4);
+    expect(AGENT_FLOOR_SCORE.plan).toBe(0.7);
+    expect(AGENT_FLOOR_SCORE.explore).toBe(0);
+    expect(AGENT_FLOOR_SCORE.title).toBe(0);
+  });
+});
+
+describe("relativity", () => {
+  it("a new model scoring above the current top shifts existing percentiles down", () => {
+    // Set A: only one model in the field (SWE-bench 50) -> percentile 1.
+    const fieldA = percentileField([50]);
+    const a = qualityScore(
+      model(),
+      { family: "sonnet", benchmarks: [{ name: "SWE-Bench Verified", score: 50 }] },
+      fieldA,
+    );
+    expect(a.score).toBe(1);
+
+    // Introduce a stronger model (90). Both now share the field; the old top
+    // model's percentile falls — nothing is hardcoded, no list edited.
+    const fieldAB = percentileField([50, 90]);
+    const aAfter = qualityScore(
+      model(),
+      { family: "sonnet", benchmarks: [{ name: "SWE-Bench Verified", score: 50 }] },
+      fieldAB,
+    );
+    const b = qualityScore(
+      model(),
+      { family: "sonnet", benchmarks: [{ name: "SWE-Bench Verified", score: 90 }] },
+      fieldAB,
+    );
+    expect(aAfter.score).toBeLessThan(a.score);
+    expect(b.score).toBeGreaterThan(aAfter.score);
+    expect(aAfter.basis).toBe("benchmark");
+  });
+});

--- a/src/shared/modelQuality.test.ts
+++ b/src/shared/modelQuality.test.ts
@@ -8,6 +8,7 @@ import {
 } from "./modelQuality.mjs";
 import { FAMILY_TIERS, tierRank } from "./modelGuide.mjs";
 import { AGENT_FLOOR } from "./modelRouter.mjs";
+import type { QualityModel } from "./modelQuality.mjs";
 
 // A test field helper that converts a benchmark score to a percentile of "the
 // models we can currently see" — the injected ranking helper qualityScore
@@ -25,8 +26,8 @@ function percentileField(allScores: number[]) {
   };
 }
 
-function model(over: Record<string, unknown> = {}) {
-  return { id: "m", providerID: "p", ...over };
+function model(over: Record<string, unknown> = {}): QualityModel {
+  return { id: "m", providerID: "p", ...over } as QualityModel;
 }
 
 describe("qualityScore — benchmark", () => {


### PR DESCRIPTION
Opened automatically for `multica/BET-1232-modelquality`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1232.