### PR TITLE
feat(routing): delete global routing toggle; settings keeps Balance (BET-1243)

### DIFF
--- a/src/main/config.ts
+++ b/src/main/config.ts
@@ -9,7 +9,7 @@ const DEFAULT_CONFIG: AppConfig = {
   // Model routing (BET-1215). Off by default (opt-in — routing acts on the
   // user's behalf). The live server default lives in src/server/local.mjs;
   // this mirrors it for desktop-side config reads.
-  modelRouting: { enabled: false, preset: "balanced" },
+  modelRouting: { preset: "balanced" },
 };
 
 function configPath(): string {

--- a/src/renderer/ModelRoutingCard.test.tsx
+++ b/src/renderer/ModelRoutingCard.test.tsx
@@ -2,8 +2,9 @@
 //
 // ModelRoutingCard — the Routing card in Settings → Models (BET-1222). Tiers
 // must be read from the router module (never a literal), plan usage comes from
-// the shared store (the same source the composer dial uses), and the card must
-// stay visible — greyed — when routing is off.
+// the shared store (the same source the composer dial uses), and the card shows
+// what routing *would* do — there is no global off-state (BET-1243 removed the
+// toggle; routing is activated per conversation from the model picker).
 
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mount, type Harness } from "./testHarness";
@@ -35,7 +36,7 @@ describe("ModelRoutingCard", () => {
   let h: Harness | null = null;
 
   beforeEach(() => {
-    useStore.setState({ usage: [], modelRouting: { enabled: true, preset: "balanced" } });
+    useStore.setState({ usage: [], modelRouting: { preset: "balanced" } });
   });
 
   afterEach(() => {
@@ -70,17 +71,17 @@ describe("ModelRoutingCard", () => {
     expect(c.html()).toContain("border-warn bg-warn-bg");
   });
 
-  it("renders the 'Routing is off' chip and keeps the card present when disabled", () => {
-    useStore.setState({ modelRouting: { enabled: false, preset: "balanced" } });
+  it("renders the preset caption chip when no window is near-spent", () => {
+    useStore.setState({ modelRouting: { preset: "balanced" } });
     const c = render();
-    expect(c.text()).toContain("Routing is off — you choose the model.");
-    // Card still present (the whole point) — agent rows still render, greyed.
-    expect(c.text()).toContain("build");
-    expect(c.html()).toContain("opacity-60");
+    // With no global off-state (routing is per-conversation now), the card
+    // always shows the active preset caption and never the greyed-out state.
+    expect(c.text()).toContain("Balanced — cheapest model");
+    expect(c.html()).not.toContain("opacity-60");
   });
 
   it("shows tiers matching AGENT_TIER imported from modelRouter.mjs", () => {
-    useStore.setState({ modelRouting: { enabled: true, preset: "balanced" } });
+    useStore.setState({ modelRouting: { preset: "balanced" } });
     const c = render();
     const text = c.text();
     // Assert against the module import, never a literal — so the card and the

--- a/src/renderer/ModelRoutingCard.tsx
+++ b/src/renderer/ModelRoutingCard.tsx
@@ -10,9 +10,6 @@
 // never hardcoded here, so the card and the router cannot drift. Plan usage is
 // the SAME state the composer's usage dial reads (`store.usage`) — no second
 // fetch, no second percentage bar (the bar IS `UsageWindowRow`, reused).
-//
-// When routing is OFF the card is still rendered (greyed) — showing what
-// *would* happen is the point, and the "Routing is off" chip explains the state.
 
 import { useState } from "react";
 import { AGENT_FLOOR, AGENT_TIER } from "../shared/modelRouter.mjs";
@@ -54,7 +51,6 @@ export function ModelRoutingCard() {
   // lines don't re-render constantly inside Settings.
   const [nowMs] = useState(() => Date.now());
 
-  const enabled = modelRouting?.enabled === true;
   const preset = modelRouting?.preset ?? "balanced";
   const perAgent = modelRouting?.perAgent;
 
@@ -73,10 +69,7 @@ export function ModelRoutingCard() {
 
   let chipClass: string;
   let chipText: string;
-  if (!enabled) {
-    chipClass = CHIP_NEUTRAL;
-    chipText = "Routing is off — you choose the model.";
-  } else if (nearlySpent) {
+  if (nearlySpent) {
     chipClass = CHIP_WARN;
     chipText = `${nearlySpent.provider} ${nearlySpent.label} is nearly spent — new subagents are routing to cheaper models until it resets.`;
   } else {
@@ -87,7 +80,7 @@ export function ModelRoutingCard() {
 
   return (
     <Card header={<span className="text-micro uppercase text-text-faint">Routing</span>}>
-      <div className={enabled ? "" : "opacity-60"}>
+      <div>
         {/* Block A — per-agent pills */}
         <div>
           {AGENT_ROWS.map((row, i) => {

--- a/src/renderer/Settings.tsx
+++ b/src/renderer/Settings.tsx
@@ -536,7 +536,6 @@ export function Settings({
       "cto.model": cto?.model ?? "",
       "cto.voice": cto?.voice ?? "",
       "cto.alwaysListening": cto?.alwaysListening ?? false,
-      "modelRouting.enabled": modelRouting?.enabled ?? false,
       "modelRouting.preset": modelRouting?.preset ?? "balanced",
     }),
     [cacheTtl, groqApiKey, voiceTranscriptionModel, openaiApiKey, allowAgentPush, downloadsDir, worktreePerSession, worktreeCleanOnClose, uploadCleanupHours, voiceNoteTtlHours, theme, autoRenameSessions, alwaysShowUsage, cto, modelRouting],
@@ -1097,10 +1096,9 @@ export function Settings({
     if (section === "models") {
       return (
         <>
-          {/* Routing card mounts under the schema-driven "Routing" group (the
-              toggle + preset). The card shows what routing *would* do — the
-              per-agent tiers + plan windows — so it stays visible even when
-              routing is off. */}
+          {/* Routing card — the per-agent tiers + plan windows. Renders what
+              routing would do, alongside the schema-driven "Automatic Manta
+              Routing" Balance card. There is no global toggle (BET-1243). */}
           <ModelRoutingCard />
           <GroupCard title="Models">
             <ModelsCard />

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -79,7 +79,6 @@ const DEFAULT_CONFIG = {
   // it is opt-in, matching chatAutoAllow / pluginsEnabled). Config-only in
   // this issue; no behaviour change until the router wiring issue reads it.
   modelRouting: {
-    enabled: false,
     preset: "balanced",
   },
 };

--- a/src/shared/settingsSchema.test.ts
+++ b/src/shared/settingsSchema.test.ts
@@ -128,28 +128,31 @@ describe("uploadCleanupHours (BET-427)", () => {
 });
 
 describe("model routing entries (BET-1218)", () => {
-  const enabled = ALL.find((e) => e.id === "modelRoutingEnabled");
   const preset = ALL.find((e) => e.id === "modelRoutingPreset");
 
-  it("are present in the models section for desktop", () => {
+  it("the enabled toggle no longer exists (routing is per-conversation only)", () => {
+    // The global toggle was deleted: routing is activated per conversation from
+    // the composer's model picker, so a global consent switch would be a second
+    // control for one decision (and a stub — its config key was never read).
+    expect(ALL.find((e) => e.id === "modelRoutingEnabled")).toBeUndefined();
+  });
+
+  it("the preset is present in the models section for desktop", () => {
     const desktop = settingsForSection(ALL, "models", "desktop");
-    expect(enabled).toBeDefined();
     expect(preset).toBeDefined();
-    expect(desktop.some((e) => e.id === "modelRoutingEnabled")).toBe(true);
     expect(desktop.some((e) => e.id === "modelRoutingPreset")).toBe(true);
   });
 
-  it("are desktop-only (never rendered on mobile)", () => {
+  it("the preset is desktop-only (never rendered on mobile)", () => {
     const mobile = settingsForPlatform(ALL, "mobile");
-    expect(mobile.some((e) => e.id === "modelRoutingEnabled")).toBe(false);
     expect(mobile.some((e) => e.id === "modelRoutingPreset")).toBe(false);
   });
 
-  it("the enabled toggle defaults to FALSE (the consent boundary)", () => {
-    // Routing acts on the user's behalf, so it is strictly opt-in.
-    expect(enabled!.control).toBe("toggle");
-    expect(enabled!.configKey).toBe("modelRouting.enabled");
-    expect(enabled!.default).toBe(false);
+  it("the preset renders in the Automatic Manta Routing group", () => {
+    expect(preset!.control).toBe("segmented");
+    expect(preset!.configKey).toBe("modelRouting.preset");
+    expect(preset!.default).toBe("balanced");
+    expect(preset!.group).toBe("Automatic Manta Routing");
   });
 
   it("the preset uses the exact PRESETS values from modelRouter (no drift)", () => {

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -178,17 +178,6 @@ export const SETTINGS: SettingEntry[] = [
     group: "Plan usage",
   },
   {
-    id: "modelRoutingEnabled",
-    section: "models",
-    label: "Let Manta pick the model",
-    help: "Chooses a model per task when a session or subagent starts, and when a plan usage limit would otherwise stop the work. Never changes model in the middle of an exchange. Every choice shows why, and can be undone.",
-    control: "toggle",
-    configKey: "modelRouting.enabled",
-    platform: "desktop",
-    default: false,
-    group: "Routing",
-  },
-  {
     id: "modelRoutingPreset",
     section: "models",
     label: "Balance",
@@ -197,7 +186,7 @@ export const SETTINGS: SettingEntry[] = [
     configKey: "modelRouting.preset",
     platform: "desktop",
     default: "balanced",
-    group: "Routing",
+    group: "Automatic Manta Routing",
     options: [
       { value: "economy", label: "Economy" },
       { value: "balanced", label: "Balanced" },

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -289,13 +289,21 @@ export type AppConfig = {
   // matching chatAutoAllow / pluginsEnabled). Config-only in this issue; the
   // router wiring issue reads this into the router's `policy` argument.
   modelRouting?: {
-    // Master switch. False (the default) until the user opts in.
-    enabled: boolean;
     // Three-way balance dial. Default "balanced".
     preset: "economy" | "balanced" | "performance";
     // Per-agent tier override (config-only — no UI builds this). Absent /
     // partial = fall back to the preset's tier table.
     perAgent?: Record<string, "fast" | "balanced" | "deep">;
+    // Per-endpoint identity + price declared by the user. Key: "providerID/modelID".
+    declaredModels?: Record<
+      string,
+      {
+        catalogId?: string;
+        price?: { input: number; output: number } | "free";
+        caches?: false | { read: number; write?: number };
+        tierOverride?: "fast" | "balanced" | "deep";
+      }
+    >;
   };
   // Position/size of the floating on-call CTO window (BET-1166). Persisted so
   // the window remembers where the user parked it across runs.


### PR DESCRIPTION
## What
Stage 6 of the Automatic Manta Routing epic — routing is activated **per conversation** from the composer's model picker, so the global enable toggle (a second control for one decision, and a stub — its config key was never read) is deleted.

### Changes
- **`src/shared/settingsSchema.ts`** — deleted the `modelRoutingEnabled` entry; renamed the preset's `group` from `Routing` → `Automatic Manta Routing` (the Models section now renders **one** Balance card, via the existing `renderSection` grouping).
- **`src/shared/types.ts`** — removed `modelRouting.enabled`; added the user-declared `declaredModels` block per the spec.
- **`src/main/config.ts` / `src/server/local.mjs`** — dropped `enabled` from `DEFAULT_CONFIG.modelRouting`; kept `preset: "balanced"`.
- **`src/renderer/Settings.tsx`** — removed `modelRouting.enabled` from the values map.
- **`src/renderer/ModelRoutingCard.tsx` (+ test)** — the BET-1222 card no longer depends on the deleted global `enabled` flag (there is no global off-state; routing is per-conversation). Removed the greyed "Routing is off" branch; it now always shows the active preset caption / near-spent warn.
- **`src/shared/settingsSchema.test.ts`** — replaced the "toggle defaults to FALSE" test with an assertion that the entry no longer exists; updated group + platform assertions; kept the preset↔`PRESETS` no-drift check.

Migration: none — an old config carrying `modelRouting.enabled` is simply ignored.

## Verification
- `npm run typecheck` — green
- `npm test` — 2597 pass, 0 fail
- `grep -rn 'modelRoutingEnabled|modelRouting.enabled' src/` — only the deliberate test assertion remains

## Note for review
The richer `ModelRoutingCard` (BET-1222) already lands in the Models section and shows what routing *would* do (per-agent tiers + plan windows). It is a separate, informative card from the sibling ticket — I kept it, removing its dependence on the now-deleted global `enabled` flag (there is no longer a global off-state, since routing is activated per conversation). "Balance alone" refers to the schema-driven Balance group card.