### PR TITLE
feat(server): providerHealth — working/not-working per provider (BET-1240)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -434,6 +434,19 @@ const providerHealth = createProviderHealth({
   providerIDForAdapter,
   recheckAtLimit: (adapterId) => recheckAdapterAtLimit(adapterId),
 });
+// Recovery path #3 (issue §Three ways the flag clears): a supported provider's
+// reader reporting funds on a normal poll clears its evidence-only
+// out-of-credit flag. Reuses the EXISTING usage poller's `usage.updated`
+// snapshots — no second poller — exactly as resumeEngine.deliverSnapshots does.
+// eslint-disable-next-line no-unused-vars
+const stopProviderHealthFunds = bus.subscribe((evt) => {
+  if (evt?.kind === "usage.updated" && Array.isArray(evt.payload?.snapshots)) {
+    providerHealth.deliverSnapshots(evt.payload.snapshots);
+  }
+});
+// Prime on startup with whatever the poller already has cached (same rationale
+// as resumeEngine's warmup; a provider marked exhausted stays excluded).
+providerHealth.deliverSnapshots(listSnapshots());
 
 // Capability-job sweeper: same shape as startSchedulePoller — fails out stale
 // `running` jobs (30 min) and expired `queued` jobs (24h), then prunes terminal

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -92,6 +92,7 @@ import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./pee
 import { upsertStopped, markStoppedRan, bumpStoppedAttempts, listStopped } from "./stoppedStore.mjs";
 import { createUsageStopEngine } from "./usageStopEnroll.mjs";
 import { createUsageResumeEngine } from "./usageResume.mjs";
+import { createProviderHealth } from "./providerHealth.mjs";
 import * as appControl from "./appControl.mjs";
 import * as cto from "./cto.mjs";
 import { searchMessages } from "./messageSearch.mjs";
@@ -419,6 +420,19 @@ const usageStopEngine = createUsageStopEngine({
       return "";
     }
   },
+});
+
+// Provider health (BET-1240, Automatic Routing Stage 4): tracks whether each
+// provider is WORKING or NOT from the HTTP status of its failed turns (402 =
+// out of credit, 429 = rate limited, other repeated failures = soft failing),
+// recovered by evidence only — never by a clock. Attribute via usageStopEngine's
+// OWN per-session provider cache (getSessionModel — no second cache is built
+// here); observeEvent is fed the opencode pump below alongside the others.
+const providerHealth = createProviderHealth({
+  publish: (evt) => bus.publish(evt),
+  getSessionModel: (sessionId) => usageStopEngine.getSessionModel(sessionId),
+  providerIDForAdapter,
+  recheckAtLimit: (adapterId) => recheckAdapterAtLimit(adapterId),
 });
 
 // Capability-job sweeper: same shape as startSchedulePoller — fails out stale
@@ -1150,6 +1164,13 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
     resumeEngine.observeEvent(evt);
   } catch (e) {
     console.warn("[usage-resume] observeEvent failed:", e?.message ?? e);
+  }
+  // Provider health (BET-1240): record whether the attributed provider is
+  // rate-limited / out-of-credit / failing from the preserved HTTP status.
+  try {
+    providerHealth.observeEvent(evt);
+  } catch (e) {
+    console.warn("[provider-health] observeEvent failed:", e?.message ?? e);
   }
   // Auto-recover expired Claude credentials (server-side; works with no client attached).
   oc.maybeRecoverCredentials(evt).catch(() => {});

--- a/src/server/providerHealth.mjs
+++ b/src/server/providerHealth.mjs
@@ -92,6 +92,7 @@ function clampRetryAfterMs(retryAfterMs) {
  *   observeEvent: (evt: object|null|undefined) => void,
  *   state: (providerID: string) => string,
  *   retry: (providerID: string) => Promise<{cleared: boolean, state: string}>,
+ *   deliverSnapshots: (snapshots: Array<object>|null|undefined) => void,
  *   all: () => Record<string, string>,
  * }}
  */
@@ -143,11 +144,12 @@ export function createProviderHealth({
     publish({ kind: "provider-health.needs-attention", payload: { providerID, state: newState } });
   }
 
-  // A successful turn on the provider is evidence of life: it clears the
-  // evidence-only out-of-credit flag and the soft failure streak. The
-  // rate-limited flag is deliberately NOT touched here — it recovers by its
-  // own cooldown expiry, not by success.
-  function clearForSuccess(providerID) {
+  // Clear the evidence-only out-of-credit flag (and the soft failure streak) —
+  // the shared act behind all of the flag's recovery paths: a successful turn,
+  // `retry()`, and a supported provider's reader reporting funds on a normal
+  // poll. The rate-limited flag is deliberately NOT touched here — it recovers
+  // by its own cooldown expiry, not by any of these.
+  function reset(providerID) {
     known.add(providerID);
     outOfCredit.delete(providerID);
     consecutiveFailures.delete(providerID);
@@ -213,7 +215,7 @@ export function createProviderHealth({
 
     if (evt.type === "session.next.step.ended") {
       // The model produced a step → the provider is demonstrably working.
-      clearForSuccess(providerID);
+      reset(providerID);
       return;
     }
     if (evt.type === "session.error") {
@@ -233,9 +235,7 @@ export function createProviderHealth({
     if (!adapterId) {
       // Custom provider: no meter exists to re-read. Clear optimistically and
       // send no traffic; the next routed turn is the real test.
-      outOfCredit.delete(providerID);
-      consecutiveFailures.delete(providerID);
-      published.delete(providerID);
+      reset(providerID);
       return { cleared: true, state: state(providerID) };
     }
     let atLimit = false;
@@ -245,11 +245,29 @@ export function createProviderHealth({
       atLimit = false; // a failed re-check must never clear on an absent reading
     }
     if (!atLimit) {
-      outOfCredit.delete(providerID);
-      consecutiveFailures.delete(providerID);
-      published.delete(providerID);
+      reset(providerID);
     }
     return { cleared: !atLimit, state: state(providerID) };
+  }
+
+  /**
+   * Recovery path #3 on a normal poll (issue §Three ways the flag clears): a
+   * SUPPORTED provider's reader reporting funds. Driven by the EXISTING usage
+   * poller's `usage.updated` snapshots — no second poller. The poller only
+   * emits `exhausted` when true (usage.mjs: `...(raw.exhausted === true ? …
+   * : {})`), so a snapshot for the adapter that is NOT marked exhausted IS the
+   * affirmative "reader reporting funds" evidence that clears the evidence-only
+   * out-of-credit flag. A snapshot marked `exhausted: true`, or no snapshot at
+   * all, is no evidence — the flag stays (never clear on an absent reading).
+   * @param {Array<{provider:string, exhausted?:boolean}|null|undefined>|null|undefined} snapshots
+   */
+  function deliverSnapshots(snapshots) {
+    for (const s of snapshots ?? []) {
+      if (!s || typeof s?.provider !== "string") continue;
+      if (s.exhausted === true) continue; // still refusing work — no funds
+      const providerID = providerIDForAdapter(s.provider);
+      if (providerID && outOfCredit.has(providerID)) reset(providerID);
+    }
   }
 
   /** Every attributed provider mapped to its current state. */
@@ -259,5 +277,5 @@ export function createProviderHealth({
     return out;
   }
 
-  return { observeEvent, state, retry, all };
+  return { observeEvent, state, retry, deliverSnapshots, all };
 }

--- a/src/server/providerHealth.mjs
+++ b/src/server/providerHealth.mjs
@@ -1,0 +1,263 @@
+// providerHealth.mjs — Automatic Manta Routing, Stage 4 (BET-1240), box-side.
+//
+// Tracks whether each AI provider is currently WORKING or NOT, from the ONE
+// signal every provider emits without being asked: the HTTP status of a failed
+// turn. A custom provider has no account state by design, so it cannot be
+// asked "are you usable?" — but every provider still answers it: requests
+// either succeed or they do not. That is a fact, not an inference, and it
+// needs no balance endpoint and no knowledge of the provider.
+//
+// Four states per provider (issue §Three states):
+//   rate-limited   HTTP 429  excluded for the cooldown; AUTO-RECOVERS on expiry
+//   out-of-credit  HTTP 402  excluded from Auto (never from manual); recovers
+//                            ONLY by evidence — never by a clock
+//   failing        repeated non-402/429 failures — deprioritised (soft);
+//                            cleared on the next success
+//   ok             default
+//
+// Why out-of-credit must NOT recover by a clock: a credit exhaustion does not
+// reset on a window boundary, so there is nothing for a timer to observe. The
+// previous usage-resume implementation fired at a fixed reset+60s and was
+// deleted for exactly that reason — see the rationale comment at the top of
+// usageResume.mjs. Three free ways it clears, all evidence:
+//   1. a successful turn on that provider (Auto-exclusion only; manual always
+//      works, and a manual success is itself the clearing evidence);
+//   2. `retry(providerID)` — supported providers re-read the meter (zero model
+//      calls) and clear only if it reports funds; custom providers clear
+//      optimistically with NO traffic — the user is the evidence, the next
+//      routed turn is the real test, and a repeat refusal re-flags it;
+//   3. a supported provider's reader reporting funds on a normal poll.
+//   No background polling, no liveness pings, no timer re-admission.
+//
+// Shape: the same per-resource epoch-deadline-in-a-Map the repo already uses
+// twice for "unhealthy resource" — `backoffUntil` in usage.mjs and
+// `coolingUntil` in forge/index.mjs. Flat deadlines, no exponential back-off.
+//
+// Attribution: `session.error` carries no providerID. This module REUSES the
+// per-session {adapterId, model} cache built from `session.next.step.ended` in
+// usageStopEnroll.mjs (exposed as getSessionModel) — it does NOT write a
+// second cache. The adapter id is mapped back to an opencode providerID via
+// providerIDForAdapter; a session whose provider was never observed (or a
+// pay-as-you-go key) cannot be attributed and is skipped.
+//
+// Surfacing: per the `NEVER STUB A CONTROL TO DO NOTHING` rule in AGENTS.md an
+// excluded provider must surface, not silently disappear. A needs-attention
+// bus event fires ON the transition only, never on every check — precedent and
+// rationale at usageResume.mjs (~line 326 and ~344-346).
+
+import {
+  adapterForProviderID,
+  MIN_RATE_LIMIT_BACKOFF_MS,
+  MAX_RATE_LIMIT_BACKOFF_MS,
+} from "./usage.mjs";
+
+export const PROVIDER_HEALTH_STATE = Object.freeze({
+  OK: "ok",
+  RATE_LIMITED: "rate-limited",
+  OUT_OF_CREDIT: "out-of-credit",
+  FAILING: "failing",
+});
+
+// A provider is only deprioritised after this many CONSECUTIVE non-402/429
+// failures. Deliberately >1 so a single transient network blip does not
+// down-rank a healthy provider; small so a genuinely broken one surfaces fast.
+export const MIN_FAILURES_TO_DEPRIORITIZE = 2;
+
+// Clamp a provider's requested Retry-After into the band the usage engine
+// already uses for the same case (a real provider answers 429 with
+// `retry-after: 0`; honouring it hot-loops; a provider asking for an hour must
+// not take a resource dark for an hour). Reuses the named constants from
+// usage.mjs — the numbers have one home, with their rationale, there.
+function clampRetryAfterMs(retryAfterMs) {
+  const ms = Number.isFinite(retryAfterMs) ? retryAfterMs : 0;
+  return Math.min(MAX_RATE_LIMIT_BACKOFF_MS, Math.max(MIN_RATE_LIMIT_BACKOFF_MS, ms));
+}
+
+/**
+ * The working/not-working tracker for AI providers.
+ *
+ * @param {object} deps
+ * @param {() => number} [deps.now]
+ * @param {(evt: {kind:string, payload:object}) => void} [deps.publish]  bus publish
+ *   (a `provider-health.needs-attention` event fires ONCE per transition)
+ * @param {(sessionId: string) => ({adapterId:string|null, model?:string}|null)|null}
+ *   [deps.getSessionModel]  the per-session provider cache from
+ *   usageStopEnroll.mjs (BET-1230 exposes it) — reused, never duplicated
+ * @param {(adapterId: string) => string|null} [deps.providerIDForAdapter]
+ *   adapter id -> opencode providerID (usage.mjs)
+ * @param {(adapterId: string) => Promise<boolean>|boolean} [deps.recheckAtLimit]
+ *   wire to recheckAdapterAtLimit — a cheap metadata fetch, ZERO model calls
+ * @param {number} [deps.minFailuresToDeprioritize]
+ * @returns {{
+ *   observeEvent: (evt: object|null|undefined) => void,
+ *   state: (providerID: string) => string,
+ *   retry: (providerID: string) => Promise<{cleared: boolean, state: string}>,
+ *   all: () => Record<string, string>,
+ * }}
+ */
+export function createProviderHealth({
+  now = Date.now,
+  publish = () => {},
+  getSessionModel = () => null,
+  providerIDForAdapter = () => null,
+  recheckAtLimit = async () => false,
+  minFailuresToDeprioritize = MIN_FAILURES_TO_DEPRIORITIZE,
+} = {}) {
+  // Flat cooldown deadline per provider — auto-recovers on expiry.
+  const rateLimitedUntil = new Map(); // providerID -> epoch ms
+  // Evidence-only exclusion — NEVER cleared by a clock.
+  const outOfCredit = new Set(); // providerID
+  // Soft failure streak per provider; cleared on the next success.
+  const consecutiveFailures = new Map(); // providerID -> count
+  // Every provider we have attributed, so all() can enumerate the live picture.
+  const known = new Set();
+  // The last non-ok state published per provider, so the needs-attention event
+  // fires ONCE at the transition and never re-fires per observation.
+  const published = new Map(); // providerID -> state
+
+  function failuresOf(providerID) {
+    return consecutiveFailures.get(providerID) ?? 0;
+  }
+
+  /** The effective state of a provider RIGHT NOW (rate-limit expiry resolved). */
+  function state(providerID) {
+    if (outOfCredit.has(providerID)) return PROVIDER_HEALTH_STATE.OUT_OF_CREDIT;
+    const until = rateLimitedUntil.get(providerID);
+    if (until != null && until > now()) return PROVIDER_HEALTH_STATE.RATE_LIMITED;
+    if (failuresOf(providerID) >= minFailuresToDeprioritize) {
+      return PROVIDER_HEALTH_STATE.FAILING;
+    }
+    return PROVIDER_HEALTH_STATE.OK;
+  }
+
+  // Surface a non-ok state ONCE per transition into that state. Moving back to
+  // ok clears the marker so a later relapse re-publishes.
+  function mark(providerID, newState) {
+    known.add(providerID);
+    if (newState === PROVIDER_HEALTH_STATE.OK) {
+      published.delete(providerID);
+      return;
+    }
+    if (published.get(providerID) === newState) return;
+    published.set(providerID, newState);
+    publish({ kind: "provider-health.needs-attention", payload: { providerID, state: newState } });
+  }
+
+  // A successful turn on the provider is evidence of life: it clears the
+  // evidence-only out-of-credit flag and the soft failure streak. The
+  // rate-limited flag is deliberately NOT touched here — it recovers by its
+  // own cooldown expiry, not by success.
+  function clearForSuccess(providerID) {
+    known.add(providerID);
+    outOfCredit.delete(providerID);
+    consecutiveFailures.delete(providerID);
+    published.delete(providerID);
+  }
+
+  function attributedProvider(sessionId) {
+    const m = getSessionModel(sessionId);
+    const adapterId = m?.adapterId;
+    if (!adapterId) return null;
+    return providerIDForAdapter(adapterId);
+  }
+
+  function applyFailure(providerID, error) {
+    const httpStatus = Number.isFinite(error?.httpStatus) ? error.httpStatus : null;
+    const retryAfterMs = Number.isFinite(error?.retryAfterMs) ? error.retryAfterMs : undefined;
+
+    if (httpStatus === 402) {
+      // Out of credit: excluded until evidence (never a clock). A 402 is not a
+      // soft-failure streak — re-failing for the same reason must not also
+      // accrue `failing`.
+      consecutiveFailures.delete(providerID);
+      if (!outOfCredit.has(providerID)) {
+        outOfCredit.add(providerID);
+        mark(providerID, PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+      }
+      return;
+    }
+
+    if (httpStatus === 429) {
+      // Rate limited: flat cooldown, clamped, auto-recovers on expiry.
+      consecutiveFailures.delete(providerID);
+      rateLimitedUntil.set(providerID, now() + clampRetryAfterMs(retryAfterMs));
+      // Resolve the effective state — a lingering out-of-credit outranks a new
+      // rate-limit, and the transition surfacing must reflect that.
+      mark(providerID, state(providerID));
+      return;
+    }
+
+    // Any other failure (including an unscoped HTTP status): a soft-failure
+    // streak — deprioritised once it repeats, cleared on the next success.
+    known.add(providerID);
+    consecutiveFailures.set(providerID, failuresOf(providerID) + 1);
+    if (failuresOf(providerID) >= minFailuresToDeprioritize) {
+      mark(providerID, PROVIDER_HEALTH_STATE.FAILING);
+    }
+  }
+
+  /**
+   * Feed the opencode event stream (from the pump in index.mjs, alongside the
+   * other observers). Step events carry the provider via the shared session
+   * cache and are the success signal; error events carry the preserved HTTP
+   * status (BET-1230 enriches them before this runs).
+   * @param {object|null|undefined} evt
+   */
+  function observeEvent(evt) {
+    if (!evt || typeof evt !== "object") return;
+    const props = evt.properties ?? {};
+    const sessionId = props.sessionID;
+    if (typeof sessionId !== "string" || !sessionId) return;
+    const providerID = attributedProvider(sessionId);
+    if (!providerID) return;
+
+    if (evt.type === "session.next.step.ended") {
+      // The model produced a step → the provider is demonstrably working.
+      clearForSuccess(providerID);
+      return;
+    }
+    if (evt.type === "session.error") {
+      applyFailure(providerID, props.error ?? {});
+    }
+  }
+
+  /**
+   * The Accounts "Try again" action. Supported providers re-read their meter
+   * (zero model calls) and clear only if it reports funds; custom providers
+   * clear optimistically with NO traffic — the user is the evidence.
+   * @param {string} providerID
+   * @returns {Promise<{cleared: boolean, state: string}>}
+   */
+  async function retry(providerID) {
+    const adapterId = adapterForProviderID(providerID);
+    if (!adapterId) {
+      // Custom provider: no meter exists to re-read. Clear optimistically and
+      // send no traffic; the next routed turn is the real test.
+      outOfCredit.delete(providerID);
+      consecutiveFailures.delete(providerID);
+      published.delete(providerID);
+      return { cleared: true, state: state(providerID) };
+    }
+    let atLimit = false;
+    try {
+      atLimit = !!(await recheckAtLimit(adapterId));
+    } catch {
+      atLimit = false; // a failed re-check must never clear on an absent reading
+    }
+    if (!atLimit) {
+      outOfCredit.delete(providerID);
+      consecutiveFailures.delete(providerID);
+      published.delete(providerID);
+    }
+    return { cleared: !atLimit, state: state(providerID) };
+  }
+
+  /** Every attributed provider mapped to its current state. */
+  function all() {
+    const out = {};
+    for (const providerID of known) out[providerID] = state(providerID);
+    return out;
+  }
+
+  return { observeEvent, state, retry, all };
+}

--- a/src/server/providerHealth.test.mjs
+++ b/src/server/providerHealth.test.mjs
@@ -183,6 +183,31 @@ test("out-of-credit outranks a concurrent rate-limit in state()", () => {
   assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
 });
 
+test("a supported provider's reader reporting funds on a normal poll clears out-of-credit", () => {
+  const { engine, error, providerID } = make();
+  error(402);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+  // A normal poll snapshot for the adapter NOT marked exhausted = funds.
+  engine.deliverSnapshots([{ provider: "claude", exhausted: false, windows: [] }]);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OK);
+});
+
+test("a poll snapshot still marked exhausted does NOT clear out-of-credit", () => {
+  const { engine, error, providerID } = make();
+  error(402);
+  engine.deliverSnapshots([{ provider: "claude", exhausted: true }]);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+  // And no snapshot / a non-matching provider is no evidence either.
+  engine.deliverSnapshots([]);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+});
+
+test("deliverSnapshots is inert for a provider that is not out-of-credit", () => {
+  const { engine, providerID } = make();
+  engine.deliverSnapshots([{ provider: "claude", exhausted: false }]);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OK);
+});
+
 test("needs-attention publishes ONCE at the transition, not per observation", () => {
   const { engine, error, published } = make();
   error(429, 0);

--- a/src/server/providerHealth.test.mjs
+++ b/src/server/providerHealth.test.mjs
@@ -1,0 +1,224 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createProviderHealth, PROVIDER_HEALTH_STATE, MIN_FAILURES_TO_DEPRIORITIZE } from "./providerHealth.mjs";
+import { MIN_RATE_LIMIT_BACKOFF_MS, MAX_RATE_LIMIT_BACKOFF_MS } from "./usage.mjs";
+
+// Attribution helper shared by every test: a session "s1" (one per test) maps
+// to adapter "claude" -> opencode providerID "anthropic" (a SUPPORTED
+// provider, so retry's supported branch is exercised with the real
+// adapterForProviderID from usage.mjs). A separate non-adapter providerID,
+// "deepseek", is treated as CUSTOM by the real adapter lookup.
+const PROVIDER = "anthropic";
+const CUSTOM = "deepseek";
+
+function make({ sess = "s1", adapter = "claude", providerID = PROVIDER } = {}) {
+  const clock = { t: 1000 };
+  const published = [];
+  const sessionOf = new Map([[sess, adapter]]);
+  let recheckResult = false;
+  let recheckCalls = 0;
+
+  const engine = createProviderHealth({
+    now: () => clock.t,
+    publish: (evt) => published.push(evt),
+    getSessionModel: (sid) => {
+      const a = sessionOf.get(sid);
+      return a == null ? null : { adapterId: a, model: "m" };
+    },
+    providerIDForAdapter: (a) => ({ claude: "anthropic", codex: "openai", kimi: "kimi-for-coding" }[a] ?? null),
+    recheckAtLimit: async () => {
+      recheckCalls += 1;
+      return recheckResult;
+    },
+  });
+
+  return {
+    clock,
+    engine,
+    published,
+    providerID,
+    setRecheck: (v) => {
+      recheckResult = v;
+    },
+    recheckCalls: () => recheckCalls,
+    error: (httpStatus, retryAfterMs, sid = sess) =>
+      engine.observeEvent({
+        type: "session.error",
+        properties: {
+          sessionID: sid,
+          error: {
+            ...(httpStatus != null ? { httpStatus } : {}),
+            ...(retryAfterMs != null ? { retryAfterMs } : {}),
+          },
+        },
+      }),
+    step(sid = sess) {
+      engine.observeEvent({
+        type: "session.next.step.ended",
+        properties: { sessionID: sid, providerID, modelID: "m" },
+      });
+    },
+  };
+}
+
+test("402 -> out-of-credit; NO elapsed time re-admits it (anti-clock regression)", () => {
+  const { engine, error, clock, providerID } = make();
+  error(402);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+  // Hours later the flag is STILL set — the deleted clock-based resume must not
+  // sneak back in.
+  clock.t += 6 * 60 * 60 * 1000;
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+  clock.t += 30 * 24 * 60 * 60 * 1000;
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+});
+
+test("a successful step for that provider clears out-of-credit", () => {
+  const { engine, error, step, providerID } = make();
+  error(402);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+  step();
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OK);
+});
+
+test("a successful step clears a failing streak", () => {
+  const { engine, error, step, providerID } = make();
+  error(); // generic failure 1
+  error(); // generic failure 2 -> failing
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.FAILING);
+  step();
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OK);
+});
+
+test("retry() on a CUSTOM provider clears the flag and performs NO fetch", async () => {
+  // Seed an out-of-credit flag on the custom provider id, then retry it and
+  // assert the meter (recheckAtLimit) is NEVER hit — a custom provider has no
+  // meter to re-read, so the user is the evidence and no traffic is sent.
+  const f = { calls: 0 };
+  const eng = createProviderHealth({
+    now: () => 0,
+    publish: () => {},
+    getSessionModel: () => null,
+    providerIDForAdapter: () => null,
+    recheckAtLimit: async () => {
+      f.calls += 1;
+      return true;
+    },
+  });
+  const res = await eng.retry(CUSTOM);
+  assert.equal(res.cleared, true, "custom retry clears optimistically");
+  assert.equal(res.state, PROVIDER_HEALTH_STATE.OK);
+  assert.equal(f.calls, 0, "custom retry must not hit the meter");
+});
+
+test("retry() on a SUPPORTED provider re-reads the meter and clears only when it reports funds", async () => {
+  const { engine, error, setRecheck, recheckCalls, providerID } = make();
+  error(402);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+
+  // Meter still at limit -> not cleared, and the meter WAS re-read.
+  setRecheck(true);
+  let res = await engine.retry(providerID);
+  assert.equal(res.cleared, false);
+  assert.equal(res.state, PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+  assert.equal(recheckCalls(), 1);
+
+  // Meter reports funds -> cleared.
+  setRecheck(false);
+  res = await engine.retry(providerID);
+  assert.equal(res.cleared, true);
+  assert.equal(res.state, PROVIDER_HEALTH_STATE.OK);
+  assert.equal(recheckCalls(), 2);
+});
+
+test("429 with retryAfterMs: 0 is clamped to the 2-min floor (does not hot-loop)", () => {
+  const { clock, engine, error, providerID } = make();
+  error(429, 0);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.RATE_LIMITED);
+  clock.t += MIN_RATE_LIMIT_BACKOFF_MS - 1;
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.RATE_LIMITED);
+  clock.t += 1;
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OK);
+});
+
+test("429 asking for one hour is clamped to the 15-min ceiling", () => {
+  const { clock, engine, error, providerID } = make();
+  error(429, 60 * 60 * 1000);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.RATE_LIMITED);
+  clock.t += MAX_RATE_LIMIT_BACKOFF_MS - 1;
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.RATE_LIMITED);
+  clock.t += 1;
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OK);
+});
+
+test("429 expiry re-admits with no user action", () => {
+  const { clock, engine, error, providerID } = make();
+  error(429, 0);
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.RATE_LIMITED);
+  clock.t += MIN_RATE_LIMIT_BACKOFF_MS;
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OK);
+});
+
+test("repeated non-402/429 failures -> failing (soft); CLEARED on next success", () => {
+  const { engine, error, step, providerID } = make();
+  // A single generic failure must NOT deprioritise yet.
+  error();
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OK);
+  error();
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.FAILING);
+  // A third failure keeps it failing (no flip-flop).
+  error();
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.FAILING);
+  step();
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OK);
+});
+
+test("out-of-credit outranks a concurrent rate-limit in state()", () => {
+  const { clock, engine, error, providerID } = make();
+  error(402);
+  error(429, 0); // both flags set
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+  // The 429 cooldown alone expiring must not clear out-of-credit.
+  clock.t += MAX_RATE_LIMIT_BACKOFF_MS + 1;
+  assert.equal(engine.state(providerID), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+});
+
+test("needs-attention publishes ONCE at the transition, not per observation", () => {
+  const { engine, error, published } = make();
+  error(429, 0);
+  error(429, 0);
+  error(429, 0);
+  const attention = published.filter((e) => e.kind === "provider-health.needs-attention");
+  assert.equal(attention.length, 1);
+  assert.equal(attention[0].payload.providerID, PROVIDER);
+  assert.equal(attention[0].payload.state, PROVIDER_HEALTH_STATE.RATE_LIMITED);
+});
+
+test("needs-attention publishes once for failing, once after recovery relapse", () => {
+  const { engine, error, step, published } = make();
+  error();
+  error();
+  error();
+  let attention = published.filter((e) => e.kind === "provider-health.needs-attention");
+  assert.equal(attention.length, 1);
+  assert.equal(attention[0].payload.state, PROVIDER_HEALTH_STATE.FAILING);
+  step();
+  error();
+  error();
+  attention = published.filter((e) => e.kind === "provider-health.needs-attention");
+  assert.equal(attention.length, 2, "a relapse after recovery is a NEW transition");
+});
+
+test("all() enumerates every attributed provider's current state", () => {
+  const { engine, error, providerID } = make();
+  assert.deepEqual(engine.all(), {});
+  error(402);
+  assert.deepEqual(engine.all(), { [providerID]: PROVIDER_HEALTH_STATE.OUT_OF_CREDIT });
+});
+
+test("unattributable failures (no session / unknown provider) are ignored", () => {
+  const { engine, published } = make({ sess: "s-unknown", adapter: "nope" });
+  engine.observeEvent({ type: "session.error", properties: { sessionID: "s-unknown", error: { httpStatus: 402 } } });
+  assert.deepEqual(engine.all(), {});
+  assert.equal(published.filter((e) => e.kind === "provider-health.needs-attention").length, 0);
+});

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -157,8 +157,8 @@ const MAX_STALE_RETRIES = 3;
 // provider asking for an hour still must not blank the dial for an hour.
 // Both ends collapse the old "header present / header absent" branch into one
 // expression.
-const MIN_RATE_LIMIT_BACKOFF_MS = 2 * 60_000;  // 2 minutes
-const MAX_RATE_LIMIT_BACKOFF_MS = 15 * 60_000; // 15 minutes
+export const MIN_RATE_LIMIT_BACKOFF_MS = 2 * 60_000;  // 2 minutes
+export const MAX_RATE_LIMIT_BACKOFF_MS = 15 * 60_000; // 15 minutes
 // How long a snapshot may be carried forward across failed/backed-off ticks
 // before it is dropped. Sits above the stale-warning threshold the popover
 // uses, so a carried reading visibly ages into a warning before it disappears.


### PR DESCRIPTION
## Summary
Stage 4 of Automatic Manta Routing (BET-1240): a per-provider **working/not-working** tracker driven by the one signal every provider emits without being asked — the HTTP status of a failed turn.

New `src/server/providerHealth.mjs` (`createProviderHealth`) with four states:
- `rate-limited` (429) — excluded for a flat cooldown, clamped into the existing 2–15 min band, **auto-recovers on expiry**
- `out-of-credit` (402) — excluded from Auto (never manual), **recovers by evidence only, never a clock** (anti-regression for the deleted reset+60s resume)
- `failing` (other repeated failures) — soft deprioritise, cleared on next success
- `ok`

All three evidence-based recovery paths for out-of-credit are implemented: (1) a successful turn (`session.next.step.ended`), (2) `retry()` — supported re-reads the meter, custom clears with no traffic, and (3) a supported provider's reader reporting funds on a normal poll (`deliverSnapshots`, driven by the existing `usage.updated` poller snapshots).

Wired with one extra `observeEvent(evt)` call in the opencode pump plus one `usage.updated` bus subscription (reusing the existing poller — no new stream, no new poller).

## Anti-spaghetti
- **Clamp constants imported** — `MIN/MAX_RATE_LIMIT_BACKOFF_MS` now exported from `usage.mjs` and reused here (numbers not retyped; rationale lives there).
- **No second attribution cache** — reuses `usageStopEngine.getSessionModel()` (the per-session `{adapterId, model}` cache fed by `session.next.step.ended`, exposed by BET-1230); maps adapter → opencode providerID via the existing `providerIDForAdapter`.
- **Same epoch-deadline-Map shape** the repo already uses twice for "unhealthy resource" (`backoffUntil` in `usage.mjs`, `coolingUntil` in `forge/index.mjs`) — no new idiom.
- **Does NOT touch the plan-limit machinery** — 402 is handled here, not via `usageStopper`'s never-enrol classification. No failover/retry of failed turns (out of epic scope).

## Tests
`src/server/providerHealth.test.mjs` — 17 tests, injected time, no network. Covers all issue acceptance criteria including the anti-clock 402 regression, the 429 `retry-after: 0` floor / 1h ceiling clamps, custom-vs-supported `retry()` no-fetch, the normal-poll funds clearing (mechanism #3), and once-per-transition needs-attention surfacing.

**Files changed:** 4 files (+566 −2). `src/server/index.mjs`, `src/server/providerHealth.mjs` (+281), `src/server/providerHealth.test.mjs` (+249), `src/server/usage.mjs` (2 exports).

**Verification results:**
- PR branch (`multica/BET-1240-provider-health` @ `5eee7c82`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2619 pass / 0 fail / 0 skip. log sha256: `d338d6d5b03eae982892e583074f043dc7f52d1c3d3f6013dfc5bb032a39845e`
- Base (`main` @ `afb2ad67`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2602 pass / 0 fail / 0 skip. log sha256: `aaaa4a3dab892c01699ead05f2fc2e10956fb3331133845d0a83376c7017ee34`
- **Conclusion:** 0 failures pre-existing, 0 new failures caused by this PR, +17 tests added (all pass). Typecheck logs identical hash; test delta is exactly the 17 new provider-health tests.

**Base: origin/main @ `afb2ad67`**
