### PR TITLE
BET-1229: add listRoutableModels helper; route subagent spawn within consent set

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -42,6 +42,7 @@ import {
 import { extractSubagentInfo } from "../shared/streamInterpretation.mjs";
 import { fuzzyMatchModel, suggestModels } from "../shared/modelGuide.mjs";
 import { chooseModel } from "../shared/modelRouter.mjs";
+import { listRoutableModels } from "./opencode.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants (mirrors capabilities.mjs exactly — reuse, do not diverge)
@@ -785,9 +786,18 @@ export async function startJob(input, deps = {}) {
   //    back to `deliverModel` on any throw.
   let effectiveModel = deliverModel;
   try {
+    // configGet supplies BOTH the routing policy and the consent model list
+    // (deactivatedSubagents / optInModels). Read it once, guarded, so a throw
+    // here can never break a spawn.
+    let cfg = {};
+    try {
+      cfg = (await configGet()) ?? {};
+    } catch {
+      cfg = {};
+    }
     let policy = { enabled: false };
     try {
-      policy = (await configGet())?.modelRouting ?? { enabled: false };
+      policy = cfg.modelRouting ?? { enabled: false };
     } catch {
       policy = { enabled: false };
     }
@@ -800,7 +810,7 @@ export async function startJob(input, deps = {}) {
     }
     let catalog = [];
     try {
-      catalog = listModels ? await listModels() : [];
+      catalog = await listRoutableModels("sub", cfg, listModels);
       if (!Array.isArray(catalog)) catalog = [];
     } catch {
       catalog = [];

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -623,6 +623,40 @@ test("startJob ignores the stale modelRouter key and delivers the incumbent (BET
   assert.deepEqual(h.delivered[0].model, { providerID: "anthropic", modelID: "claude-opus-4" });
 });
 
+// BET-1229 — a routed subagent spawn can only ever produce one of the models
+// the user's ticks consent to. startJob hands the router listRoutableModels
+// ("sub", cfg) instead of the raw connected catalogue, so models the user
+// deactivated for subagents are excluded before the router ever sees them.
+test("startJob routes only within the consent (sub) catalogue (BET-1229)", async () => {
+  const h = startHarness("child_consent");
+  // Routing on, and the user has deactivated every subagent model except
+  // claude-opus-4 and gpt-5 (the "ticked" set).
+  h.deps.configGet = async () => ({
+    modelRouting: { enabled: true, preset: "economy" },
+    deactivatedSubagents: ["anthropic/claude-sonnet-4", "anthropic/claude-haiku-4"],
+  });
+  h.deps.listSnapshots = () => [];
+  h.deps.listModels = async () => [
+    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
+    { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },
+    { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
+    { providerID: "openai", id: "gpt-5", status: "active" },
+  ];
+  const res = await startJob(
+    { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.equal(h.delivered.length, 1);
+  assert.ok(h.delivered[0].model, "routing should decide a model");
+  const key = `${h.delivered[0].model.providerID}/${h.delivered[0].model.modelID}`;
+  // The winner must be within the consented set — never a deactivated model.
+  assert.ok(
+    key === "anthropic/claude-opus-4" || key === "openai/gpt-5",
+    `routed subagent landed on deactivated model ${key}`,
+  );
+});
+
 test("chooseSubagentModel returns the incumbent on an off-path and is load-bearing (BET-1220)", () => {
   const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
   const catalog = [

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -13,7 +13,7 @@ import { readFileSync, existsSync } from "node:fs";
 import path from "node:path";
 import http from "node:http";
 import { expandTilde, patchPath } from "../shared/paths.mjs";
-import { readModalities } from "../shared/modelGuide.mjs";
+import { readModalities, isDeprecated } from "../shared/modelGuide.mjs";
 import { startPoller } from "./startPoller.mjs";
 import { parseRetryAfterMs } from "./usageAdapters/httpError.mjs";
 import {
@@ -1128,6 +1128,63 @@ export async function listModels(overrides = {}) {
     }
   } catch {
     /* non-fatal */
+  }
+  return out;
+}
+
+/**
+ * The models Auto is allowed to choose from, for a given surface.
+ *
+ * A model is routable when ALL of these hold (checked in this order):
+ *   1. it is in `listModels()` (i.e. its provider is connected);
+ *   2. `status` is absent or `"active"`;
+ *   3. `enabled` is not `false`;
+ *   4. its "providerID/modelID" key is NOT in `deactivatedMainModels`
+ *      (surface `"main"`) or `deactivatedSubagents` (surface `"sub"`);
+ *   5. if it is deprecated (`isDeprecated` — BET-1139), its key IS in
+ *      `optInModels`.
+ *
+ * The user's ticks are the only expression of "models I consent to run", so
+ * routing must be a choice *within* this set — never over the raw connected
+ * catalogue (which includes every model the user unticked).
+ *
+ * NOTE for future main-conversation routing: use `listRoutableModels("main",
+ * cfg)` here too — the RPC issue in this epic will call it. Do NOT add a
+ * second filter; this is the one place routing consent is computed.
+ *
+ * @param {"main"|"sub"} surface
+ * @param {object} cfg  AppConfig (deactivatedMainModels, deactivatedSubagents, optInModels)
+ * @param {Function} [models]  model-source to list from; defaults to `listModels`
+ *        (the real one). Injectable so tests can pass a fake catalogue.
+ * @returns {Promise<Array<{id: string, providerID: string, ...}>>}
+ */
+export async function listRoutableModels(surface, cfg, models = listModels) {
+  const deactivated = new Set(
+    surface === "main"
+      ? cfg?.deactivatedMainModels ?? []
+      : cfg?.deactivatedSubagents ?? [],
+  );
+  const optIn = new Set(cfg?.optInModels ?? []);
+  const out = [];
+  let listed = [];
+  try {
+    listed = await models();
+    if (!Array.isArray(listed)) listed = [];
+  } catch {
+    /* non-fatal */
+  }
+  for (const m of listed) {
+    if (!m || typeof m !== "object") continue;
+    // A model the provider flags `status: "deprecated"` is decided by rule 5
+    // below (opt-in), NOT hard-blocked here — otherwise no deprecated model
+    // could ever be opted back in. Any other non-active status is excluded.
+    const deprecated = isDeprecated(m);
+    if (m.status && m.status !== "active" && !deprecated) continue;
+    if (m.enabled === false) continue;
+    const key = `${m.providerID}/${m.id}`;
+    if (deactivated.has(key)) continue;
+    if (deprecated && !optIn.has(key)) continue;
+    out.push(m);
   }
   return out;
 }

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -39,6 +39,7 @@ import {
   getDefaultModel,
   generateSessionTitle,
   listModels,
+  listRoutableModels,
   _normalizeProviderModel,
   claudeCliStatus,
   parseProviderApiKey,
@@ -1377,6 +1378,72 @@ test("listModels returns [] on a transport throw (never re-throws)", async () =>
       assert.deepEqual(out, []);
     },
   );
+});
+
+// listRoutableModels — the single routable-catalogue helper (BET-1229). Auto's
+// consent set: a model is routable only when it is connected AND active AND
+// enabled AND not deactivated for the surface AND opted-in if deprecated. The
+// user's ticks are the only consent expression, so this filters the raw
+// connected catalogue for whoever routes.
+// ---------------------------------------------------------------------------
+
+const routableCatalogue = [
+  // connected + active + enabled → routable everywhere
+  { providerID: "anthropic", id: "claude-opus-4", name: "Opus 4", status: "active", enabled: true },
+  // `status` absent → routable
+  { providerID: "anthropic", id: "claude-sonnet-4", name: "Sonnet 4" },
+  // `enabled: false` → never routable
+  { providerID: "anthropic", id: "claude-haiku-4", name: "Haiku 4", status: "active", enabled: false },
+  // `status: "deprecated"` → only with opt-in
+  { providerID: "anthropic", id: "claude-low-1", name: "Low 1", status: "deprecated" },
+  // `status` some other non-active value → never routable
+  { providerID: "openai", id: "gpt-5", name: "GPT-5", status: "retired" },
+];
+
+test("listRoutableModels: empty/absent config excludes nothing (fresh box)", async () => {
+  const out = await listRoutableModels("sub", undefined, async () => routableCatalogue);
+  const keys = out.map((m) => `${m.providerID}/${m.id}`).sort();
+  // openai/gpt-5 is retired and anthropic/claude-haiku-4 is disabled → still
+  // excluded by status/enabled; everything else survives an empty config.
+  assert.deepEqual(keys, ["anthropic/claude-opus-4", "anthropic/claude-sonnet-4"]);
+});
+
+test("listRoutableModels: main/surface deactivation are independent", async () => {
+  const cfg = {
+    deactivatedMainModels: ["anthropic/claude-opus-4"],
+    deactivatedSubagents: ["anthropic/claude-sonnet-4"],
+  };
+  const main = await listRoutableModels("main", cfg, async () => routableCatalogue);
+  const mainKeys = main.map((m) => `${m.providerID}/${m.id}`);
+  // opus-4 is deactivated for main (absent) but sonnet-4 (not in main's set) survives.
+  assert.ok(!mainKeys.includes("anthropic/claude-opus-4"), "main must drop main-deactivated opus-4");
+  assert.ok(mainKeys.includes("anthropic/claude-sonnet-4"), "main keeps sub-only-deactivated sonnet-4");
+
+  const sub = await listRoutableModels("sub", cfg, async () => routableCatalogue);
+  const subKeys = sub.map((m) => `${m.providerID}/${m.id}`);
+  // vice-versa: sub drops sub-deactivated sonnet-4, keeps opus-4.
+  assert.ok(!subKeys.includes("anthropic/claude-sonnet-4"), "sub must drop sub-deactivated sonnet-4");
+  assert.ok(subKeys.includes("anthropic/claude-opus-4"), "sub keeps main-only-deactivated opus-4");
+});
+
+test("listRoutableModels: deprecated model requires opt-in", async () => {
+  // claude-low-1 is deprecated; without opt-in it is dropped, with opt-in kept.
+  const noOptIn = await listRoutableModels("sub", {}, async () => routableCatalogue);
+  assert.ok(!noOptIn.some((m) => m.id === "claude-low-1"), "deprecated absent without opt-in");
+
+  const opted = await listRoutableModels(
+    "sub",
+    { optInModels: ["anthropic/claude-low-1"] },
+    async () => routableCatalogue,
+  );
+  assert.ok(opted.some((m) => m.id === "claude-low-1"), "deprecated present once opted-in");
+});
+
+test("listRoutableModels: status != active and enabled:false are always excluded", async () => {
+  const out = await listRoutableModels("main", {}, async () => routableCatalogue);
+  const keys = out.map((m) => `${m.providerID}/${m.id}`);
+  assert.ok(!keys.includes("anthropic/claude-haiku-4"), "enabled:false excluded");
+  assert.ok(!keys.includes("openai/gpt-5"), "status retired excluded");
 });
 
 // _normalizeProviderModel — the single chokepoint every raw provider model


### PR DESCRIPTION
**BET-1229 — Routing: one routable-catalogue helper so Auto respects the user's model ticks**

Stage 1 of the Automatic Manta Routing epic. Adds ONE shared helper and wires the subagent spawn to it.

**Files changed:** 4 files
- `src/server/opencode.mjs` — new `listRoutableModels(surface, cfg, models?)` next to `listModels` (which it wraps). A model is routable when ALL hold: (1) in `listModels()`; (2) status absent/"active" (or deprecated, decided by rule 5, not hard-blocked); (3) `enabled !== false`; (4) key not in `deactivatedMainModels`/`deactivatedSubagents` for the surface; (5) if deprecated (`isDeprecated` from `src/shared/modelGuide.mjs`, reused — not a new predicate), key in `optInModels`. Added a comment noting the RPC issue in this epic will call `listRoutableModels("main", cfg)` so nobody adds a second filter.
- `src/server/delegate.mjs` — `startJob` now passes `await listRoutableModels("sub", cfg, listModels)` as the router's `catalog` instead of the raw `listModels()` result. Config is read once, guarded (a throw can never break a spawn).
- `src/server/opencode.test.mjs` — 4 unit tests (fake listModels source + fake config): main/sub surface independence; deprecated requires opt-in; status non-active / enabled:false excluded; empty config excludes nothing.
- `src/server/delegate.test.mjs` — 1 integration test pinning the acceptance: a routed subagent spawn with all-but-two subagent models deactivated delivers only one of the consented two.

**Reuse, not reimplementation:** `isDeprecated` already lives in `src/shared/modelGuide.mjs` (BET-1139) — imported, not duplicated. Renderer's `selectableModelList`/`mainPickerGroups` left untouched (out of scope per issue). No price/tier/capability filtering added (that's the router's job).

**Verification results:**
- PR branch (`multica/BET-1229-routable-catalog-helper` @ `8b33ba24`):
  - typecheck: exit 0. Errors: none. log sha256: `32abac62ef889781e2cc1269d6eff02d4197bf639af099f8941e98c953ac3e7b`
  - test: exit 0, 2602 pass / 0 fail / 0 skip. Failures: none. log sha256: `13836736d2f2a8f0c56c896c38c59075682ec042048b4666dfb45698cb216b6c`
- Base (`main` @ `219e5217`):
  - typecheck: exit 0. Errors: none. log sha256: `32abac62ef889781e2cc1269d6eff02d4197bf639af099f8941e98c953ac3e7b`
  - test: exit 0, 2597 pass / 0 fail / 0 skip. Failures: none. log sha256: `516182bee2aeb91d74ad13692024cf39afaf97fe1bcfd0237d3ee1733e0408b1`
- **Conclusion:** 0 failures on both branches. PR adds 5 passing tests; 0 new failures.

Base: `origin/main` @ `219e5217`.
