### PR TITLE
feat(server): account-reader descriptors — grow the supported-provider list without code (BET-1239)

### DIFF
--- a/src/server/accountDescriptors/openrouter.json
+++ b/src/server/accountDescriptors/openrouter.json
@@ -1,0 +1,7 @@
+{
+  "id": "openrouter",
+  "providerIDs": ["openrouter"],
+  "url": "https://openrouter.ai/api/v1/credits",
+  "auth": "bearer",
+  "balance": { "path": "credits", "units": "dollars", "sign": "positive-is-credit" }
+}

--- a/src/server/accountDescriptors/openrouter.json
+++ b/src/server/accountDescriptors/openrouter.json
@@ -3,5 +3,13 @@
   "providerIDs": ["openrouter"],
   "url": "https://openrouter.ai/api/v1/credits",
   "auth": "bearer",
-  "balance": { "path": "credits", "units": "dollars", "sign": "positive-is-credit" }
+  "balance": { "path": "data.total_credits", "units": "dollars", "sign": "positive-is-credit" },
+  "windows": [
+    {
+      "kind": "credit-limit",
+      "label": "Credits",
+      "used": "data.total_usage",
+      "limit": "data.total_credits"
+    }
+  ]
 }

--- a/src/server/accountReaders.mjs
+++ b/src/server/accountReaders.mjs
@@ -1,0 +1,132 @@
+// accountReaders.mjs — load the SHIPPED account descriptors and present them as
+// ordinary usage readers (BET-1239).
+//
+// A descriptor is data that declares how to read a credit-based account: the
+// URL, the bearer key to send, and which dot-paths in the response become a
+// UsageSnapshot (balance, windows, plan label, overage price). Adding a
+// supported provider is authoring a JSON file in ./accountDescriptors/ — NOT
+// writing an adapter.
+//
+// The readers produced here are indistinguishable from the code adapters in
+// ./usageAdapters/: they expose the same `{id, providerIDs, detect, fetch}`
+// interface, so src/server/usage.mjs's ADAPTERS registry holds both and the
+// engine never branches on how a reader was made. The descriptor validation
+// and payload mapping live in the pure shared module
+// (../shared/accountDescriptor.mjs); this module is only the I/O + loading
+// half (read the directory, validate each on load, log an invalid one BY NAME,
+// never throw past an individual bad file).
+//
+// A descriptor that fails to fetch or validate leaves that provider with NO
+// account state — it must never make the router believe something false. There
+// is deliberately no fallback path, no probe of conventional URLs: a connected
+// provider with no reader and no descriptor simply has no account state.
+//
+// SECURITY: `readProviderApiKey` resolves a LIVE credential. It is used only
+// inside the reader's detect()/fetch() to build the Bearer header; it is never
+// logged and never folded into an error message.
+
+import { readdirSync, readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { readProviderApiKey } from "./opencode.mjs";
+import { readDescriptor, validateDescriptor } from "../shared/accountDescriptor.mjs";
+import { httpError } from "./usageAdapters/httpError.mjs";
+
+const DESCRIPTORS_DIR = join(dirname(fileURLToPath(import.meta.url)), "accountDescriptors");
+
+/**
+ * The opencode providerID whose key this descriptor's account is authenticated
+ * with. A descriptor may cover several opencode providerIDs that share one
+ * credit pool, but the credential opencode holds lives under ONE auth-store
+ * entry — the first providerID is that entry.
+ * @param {object} descriptor
+ * @returns {string}
+ */
+function authProviderID(descriptor) {
+  return descriptor.providerIDs[0];
+}
+
+/**
+ * Present one validated descriptor as an ordinary usage reader, exactly like a
+ * code adapter: `{id, providerIDs, detect, fetch}`.
+ *   - detect() = is the bearer key already held (reused from opencode.mjs)?
+ *   - fetch()  = one HTTPS GET with `Authorization: Bearer <key>`, then
+ *     readDescriptor. A non-2xx reuses the shared `httpError` shape so the
+ *     usage poller's existing quarantine/carry-forward handles it identically
+ *     to the code adapters (a 500 leaves the provider with NO account state).
+ * @param {object} descriptor a validated descriptor
+ * @returns {{ id: string, providerIDs: string[], detect: Function, fetch: Function }}
+ */
+export function readerFromDescriptor(descriptor) {
+  const providerId = authProviderID(descriptor);
+  const readKey = () => readProviderApiKey(providerId);
+  return {
+    id: descriptor.id,
+    providerIDs: descriptor.providerIDs,
+
+    async detect({ readKey: inject = readKey } = {}) {
+      const key = await inject();
+      return typeof key === "string" && key.length > 0;
+    },
+
+    async fetch({ readKey: inject = readKey, fetchImpl = fetch, now = () => Date.now() } = {}) {
+      const key = await inject();
+      if (!key) throw new Error(`no API key available for "${descriptor.id}"`);
+      const res = await fetchImpl(descriptor.url, {
+        headers: { Authorization: `Bearer ${key}` },
+      });
+      if (!res.ok) throw httpError(res, `${descriptor.id} usage`);
+      const payload = await res.json();
+      return readDescriptor(descriptor, payload, now());
+    },
+  };
+}
+
+/**
+ * Load every `*.json` descriptor from the shipped directory, validate each on
+ * load, log an invalid one BY NAME (never silently skip), and return one reader
+ * per valid descriptor. Best-effort and never-throwing: a missing directory, an
+ * unreadable file or an invalid descriptor is a logged skip, not a crash.
+ * I/O is injected so tests exercise the loader without touching the real dir.
+ * @param {object} [opts]
+ * @param {string} [opts.dir]
+ * @param {(d: string) => string[]} [opts.readDir]
+ * @param {(p: string) => unknown} [opts.readJson]
+ * @param {(m: string) => void} [opts.log]
+ * @returns {ReturnType<typeof readerFromDescriptor>[]}
+ */
+export function loadAccountReaders({
+  dir = DESCRIPTORS_DIR,
+  readDir = readdirSync,
+  readJson = (p) => JSON.parse(readFileSync(p, "utf-8")),
+  log = (m) => console.warn(m),
+} = {}) {
+  const readers = [];
+  let files;
+  try {
+    files = readDir(dir);
+  } catch {
+    return readers;
+  }
+  for (const file of files) {
+    if (typeof file !== "string" || !file.endsWith(".json")) continue;
+
+    let raw;
+    try {
+      raw = readJson(join(dir, file));
+    } catch (e) {
+      log(`[accountReaders] invalid descriptor "${file}": ${e?.message ?? String(e)}`);
+      continue;
+    }
+
+    const result = validateDescriptor(raw);
+    if (!result.valid) {
+      const name = typeof raw?.id === "string" && raw.id ? raw.id : file;
+      log(`[accountReaders] invalid descriptor "${name}": ${result.errors.join("; ")}`);
+      continue;
+    }
+
+    readers.push(readerFromDescriptor(result.descriptor));
+  }
+  return readers;
+}

--- a/src/server/accountReaders.test.mjs
+++ b/src/server/accountReaders.test.mjs
@@ -7,8 +7,12 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
 import { readerFromDescriptor, loadAccountReaders } from "./accountReaders.mjs";
 import { createUsagePoller } from "./usage.mjs";
+import { validateDescriptor, readDescriptor } from "../shared/accountDescriptor.mjs";
 
 const DESCRIPTOR = {
   id: "samplecredits",
@@ -70,6 +74,31 @@ test("reader.fetch reuses the shared httpError shape for a non-2xx", async () =>
       }),
     (err) => err.status === 500 && /HTTP 500/.test(err.message),
   );
+});
+
+test("shipped openrouter descriptor reads the live /api/v1/credits payload (BET-1239 regression)", () => {
+  // The real OpenRouter endpoint returns { data: { total_credits, total_usage } }
+  // — NOT a top-level `credits` field. The shipped descriptor must resolve the
+  // balance at data.total_credits AND map the credit pool as a window so an
+  // overdrawn account (total_usage > total_credits, as captured live) trips
+  // `exhausted` instead of showing a healthy positive balance.
+  const dir = dirname(fileURLToPath(import.meta.url));
+  const raw = JSON.parse(readFileSync(join(dir, "accountDescriptors", "openrouter.json"), "utf-8"));
+  const v = validateDescriptor(raw);
+  assert.equal(v.valid, true);
+  if (!v.valid) return;
+
+  // Live capture 2026-08-20 with a real key: usage 20.0717 > credits 20.
+  const overdrawn = { data: { total_credits: 20, total_usage: 20.071752339 } };
+  const snap = readDescriptor(v.descriptor, overdrawn, 0);
+  assert.equal(snap.balance, 20);
+  assert.equal(snap.exhausted, true);
+  assert.equal(snap.windows[0].pct, 100);
+
+  const healthy = { data: { total_credits: 20, total_usage: 5 } };
+  const healthySnap = readDescriptor(v.descriptor, healthy, 0);
+  assert.equal(healthySnap.exhausted, undefined);
+  assert.equal(healthySnap.windows[0].pct, 25);
 });
 
 test("an invalid descriptor is reported by name and excluded; valid ones load", () => {

--- a/src/server/accountReaders.test.mjs
+++ b/src/server/accountReaders.test.mjs
@@ -1,0 +1,91 @@
+// Tests for src/server/accountReaders.mjs (BET-1239). All fetch I/O is injected
+// — never the network, never opencode's real auth store. Exercises the loader
+// (validate-on-load, invalid reported by name and excluded) and the reader
+// factory (same interface shape as a code adapter, fetch → readDescriptor,
+// non-2xx → the shared httpError shape which the usage poller quarantines so a
+// 500 leaves the provider with NO account state).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readerFromDescriptor, loadAccountReaders } from "./accountReaders.mjs";
+import { createUsagePoller } from "./usage.mjs";
+
+const DESCRIPTOR = {
+  id: "samplecredits",
+  providerIDs: ["samplecredits"],
+  url: "https://example.com/credits",
+  auth: "bearer",
+  balance: { path: "account.balance", units: "dollars", sign: "positive-is-credit" },
+};
+
+function fakeResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    headers: { get: () => null },
+    json: async () => body,
+  };
+}
+
+test("a descriptor-backed reader satisfies the same interface shape as a code adapter", () => {
+  const reader = readerFromDescriptor(DESCRIPTOR);
+  assert.equal(reader.id, "samplecredits");
+  assert.deepEqual(reader.providerIDs, ["samplecredits"]);
+  assert.equal(typeof reader.detect, "function");
+  assert.equal(typeof reader.fetch, "function");
+});
+
+test("reader.fetch maps a fetched payload through readDescriptor (balance + exhausted)", async () => {
+  const reader = readerFromDescriptor(DESCRIPTOR);
+  const out = await reader.fetch({
+    readKey: async () => "the-key",
+    fetchImpl: async () => fakeResponse(200, { account: { balance: -2 } }),
+    now: () => 1000,
+  });
+  assert.equal(out.provider, "samplecredits");
+  assert.equal(out.balance, -2);
+  assert.equal(out.exhausted, true);
+});
+
+test("a 500 leaves the provider with no account state and does not throw (poller)", async () => {
+  // detect forced true so the 500 path is what's exercised (the real detect()
+  // reads opencode's auth store, which the sandbox has no entry for).
+  const reader = { ...readerFromDescriptor(DESCRIPTOR), detect: async () => true };
+  const poller = createUsagePoller({
+    adapters: [reader],
+    fetchImpl: async () => fakeResponse(500, {}),
+    now: () => 1000,
+  });
+  await poller.tick(); // must not throw
+  assert.equal(poller.snapshots.length, 0);
+});
+
+test("reader.fetch reuses the shared httpError shape for a non-2xx", async () => {
+  const reader = readerFromDescriptor(DESCRIPTOR);
+  await assert.rejects(
+    () =>
+      reader.fetch({
+        readKey: async () => "k",
+        fetchImpl: async () => fakeResponse(500, {}),
+      }),
+    (err) => err.status === 500 && /HTTP 500/.test(err.message),
+  );
+});
+
+test("an invalid descriptor is reported by name and excluded; valid ones load", () => {
+  const logs = [];
+  const readers = loadAccountReaders({
+    dir: "DIR",
+    readDir: () => ["good.json", "bad.json", "notes.txt"],
+    readJson: (p) => {
+      if (p.includes("good.json")) return { ...DESCRIPTOR, id: "good", providerIDs: ["good"] };
+      if (p.includes("bad.json")) {
+        return { id: "baddesc", providerIDs: ["baddesc"], url: "x", auth: "bearer", oops: 1 };
+      }
+      throw new Error("boom");
+    },
+    log: (m) => logs.push(m),
+  });
+  assert.deepEqual(readers.map((r) => r.id), ["good"]);
+  assert.ok(logs.some((m) => m.includes("baddesc")), "invalid descriptor logged by name");
+});

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -85,12 +85,22 @@ import { claudeAdapter } from "./usageAdapters/claude.mjs";
 import { codexAdapter } from "./usageAdapters/codex.mjs";
 import { kimiAdapter } from "./usageAdapters/kimi.mjs";
 import { isUsageAtLimit } from "./usageStopper.mjs";
+import { loadAccountReaders } from "./accountReaders.mjs";
 
 export { normalizeWindow };
 
-// The registry of built-in adapters. Registry only — the engine below never
-// branches on a provider name.
-export const ADAPTERS = [claudeAdapter, codexAdapter, kimiAdapter];
+// The registry of built-in readers. Registry only — the engine below never
+// branches on a provider name. Holds the code adapters AND the descriptor-
+// backed readers (BET-1239): each descriptor in ./accountDescriptors/ becomes
+// an ordinary reader with the SAME `{id, providerIDs, detect, fetch}` shape as
+// the code adapters, so the engine cannot tell them apart. Growing the
+// supported list is authoring one JSON file — no change here, no branch.
+export const ADAPTERS = [
+  claudeAdapter,
+  codexAdapter,
+  kimiAdapter,
+  ...loadAccountReaders(),
+];
 
 // Map an opencode providerID ("anthropic" | "openai" | "kimi-for-coding") to
 // its usage adapter id ("claude" | "codex" | "kimi"). The two namespaces differ

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -157,9 +157,13 @@ test("usageWindowLabel: derives m/h/d from the window length in seconds", () => 
 // ADAPTERS registry
 // ----------------------------------------------------------------------------
 
-test("ADAPTERS registers exactly the three built-in providers", () => {
+test("ADAPTERS registers the three code adapters plus each shipped descriptor reader", () => {
   const ids = ADAPTERS.map((a) => a.id).sort();
-  assert.deepEqual(ids, ["claude", "codex", "kimi"]);
+  // BET-1239: the descriptor-backed readers load from ./accountDescriptors/ and
+  // land in the same registry as the code adapters. The three adapters are the
+  // fixed base; the shipped descriptor set is the current worked example
+  // ("openrouter") — adding another descriptor later widens this list.
+  assert.deepEqual(ids, ["claude", "codex", "kimi", "openrouter"]);
   for (const a of ADAPTERS) {
     assert.equal(typeof a.detect, "function");
     assert.equal(typeof a.fetch, "function");

--- a/src/shared/accountDescriptor.d.mts
+++ b/src/shared/accountDescriptor.d.mts
@@ -1,0 +1,40 @@
+// Hand-written type declarations for accountDescriptor.mjs. The implementation
+// is plain JS so it can be imported by both Node-side modules (.mjs natively,
+// .ts via Bundler resolution) and the renderer/test suites. Keep this in sync
+// with src/shared/accountDescriptor.mjs.
+
+export type BalanceSign = "positive-is-credit" | "positive-is-debt";
+
+export type DescriptorWindow = {
+  kind: string;
+  label: string;
+  pct?: string;
+  used?: string;
+  limit?: string;
+  remaining?: string;
+  resetsAt?: string;
+  startedAt?: string;
+};
+
+export type AccountDescriptor = {
+  id: string;
+  providerIDs: string[];
+  url: string;
+  auth: "bearer";
+  balance: { path: string; units: string; sign: BalanceSign };
+  windows?: DescriptorWindow[];
+  planLabel?: string;
+  overagePrice?: string;
+};
+
+export type DescriptorResult =
+  | { valid: true; descriptor: AccountDescriptor }
+  | { valid: false; errors: string[] };
+
+export function validateDescriptor(raw: unknown): DescriptorResult;
+
+export function readDescriptor(
+  descriptor: AccountDescriptor,
+  payload: unknown,
+  nowMs: number,
+): Record<string, unknown>;

--- a/src/shared/accountDescriptor.mjs
+++ b/src/shared/accountDescriptor.mjs
@@ -1,0 +1,256 @@
+// accountDescriptor.mjs — the account-reader descriptor (BET-1239).
+//
+// A descriptor is a pure, declarative description of how to read a
+// credit-based account: "call this URL with the bearer key we already hold,
+// read these dot-paths, interpret the balance this way." It is data, not a
+// program, so growing the set of supported account readers is authoring a JSON
+// file — not writing an adapter (which stays reserved for provider shapes too
+// irregular to describe).
+//
+// Mirrors the two declarative-authoring patterns already in the repo — YAML
+// plugin manifests (src/shared/pluginManifest.mjs) and forge rules — for the
+// same reasons: a shared pure validator that fails by NAME (typo protection
+// matters more than flexibility in a file that decides routing), and a reader
+// that maps a fetched payload onto the UsageSnapshot shape.
+//
+// This module is pure (no fs, no network, no opencode imports) so it is shared
+// verbatim between the server loader (src/server/accountReaders.mjs) and the
+// renderer. Types are mirrored in accountDescriptor.d.mts.
+
+const TOP_LEVEL_KEYS = [
+  "id",
+  "providerIDs",
+  "url",
+  "auth",
+  "balance",
+  "windows",
+  "planLabel",
+  "overagePrice",
+];
+const BALANCE_KEYS = ["path", "units", "sign"];
+const BALANCE_SIGNS = ["positive-is-credit", "positive-is-debt"];
+const WINDOW_KEYS = [
+  "kind",
+  "label",
+  "pct",
+  "used",
+  "limit",
+  "remaining",
+  "resetsAt",
+  "startedAt",
+];
+
+function isNonEmptyString(v) {
+  return typeof v === "string" && v.length > 0;
+}
+
+function isPlainObject(v) {
+  return v != null && typeof v === "object" && !Array.isArray(v);
+}
+
+/**
+ * Coerce a possibly-string, possibly-nullish number to a finite number, or
+ * `undefined` when it can't. `Number("")` is 0 (not NaN) so empty strings are
+ * rejected explicitly.
+ */
+function toFiniteNumber(v) {
+  if (v === undefined || v === null) return undefined;
+  if (typeof v === "string" && v.trim() === "") return undefined;
+  const n = typeof v === "number" ? v : Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+function clampPct(n) {
+  return Math.round(Math.max(0, Math.min(100, n)));
+}
+
+/** Epoch seconds, epoch ms, or an ISO string → epoch ms. */
+function readEpochMs(v) {
+  if (typeof v === "number" && Number.isFinite(v)) {
+    return v < 1e12 ? v * 1000 : v;
+  }
+  if (typeof v === "string" && v) {
+    const parsed = Date.parse(v);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return undefined;
+}
+
+/** Resolve a dot-path ("a.b.0.c") against a payload. Returns undefined on any
+ *  missing segment or a non-object traversal step. */
+function getByPath(payload, path) {
+  if (path == null) return undefined;
+  let cur = payload;
+  for (const seg of String(path).split(".")) {
+    if (cur == null) return undefined;
+    cur = cur[seg];
+  }
+  return cur;
+}
+
+/**
+ * Validate a raw (parsed-JSON) descriptor. Never throws — a malformed input
+ * returns `{ valid: false, errors: string[] }` with each error naming the key
+ * it concerns (typo protection over flexibility). Unknown top-level keys fail
+ * by name; a missing required key fails by name.
+ * @param {unknown} raw
+ * @returns {{ valid: true, descriptor: object } | { valid: false, errors: string[] }}
+ */
+export function validateDescriptor(raw) {
+  if (!isPlainObject(raw)) {
+    return { valid: false, errors: ["descriptor must be an object"] };
+  }
+  const errors = [];
+
+  for (const k of Object.keys(raw)) {
+    if (!TOP_LEVEL_KEYS.includes(k)) errors.push(`unknown key "${k}"`);
+  }
+
+  if (!isNonEmptyString(raw.id)) errors.push('missing required key "id"');
+
+  if (!Array.isArray(raw.providerIDs)) {
+    errors.push('missing required key "providerIDs"');
+  } else {
+    if (raw.providerIDs.length === 0) errors.push('"providerIDs" must not be empty');
+    for (const p of raw.providerIDs) {
+      if (!isNonEmptyString(p)) errors.push('"providerIDs" must contain only non-empty strings');
+    }
+  }
+
+  if (!isNonEmptyString(raw.url)) errors.push('missing required key "url"');
+
+  if (raw.auth !== "bearer") {
+    errors.push(raw.auth === undefined ? 'missing required key "auth"' : `unknown auth "${raw.auth}"`);
+  }
+
+  const bal = raw.balance;
+  if (!isPlainObject(bal)) {
+    errors.push('missing required key "balance"');
+  } else {
+    for (const k of Object.keys(bal)) {
+      if (!BALANCE_KEYS.includes(k)) errors.push(`unknown key "balance.${k}"`);
+    }
+    if (!isNonEmptyString(bal.path)) errors.push('missing required key "balance.path"');
+    if (bal.units !== undefined && !isNonEmptyString(bal.units)) errors.push('"balance.units" must be a non-empty string');
+    if (!BALANCE_SIGNS.includes(bal.sign)) {
+      errors.push('"balance.sign" must be "positive-is-credit" or "positive-is-debt"');
+    }
+  }
+
+  if (raw.windows !== undefined) {
+    if (!Array.isArray(raw.windows)) {
+      errors.push('"windows" must be an array');
+    } else {
+      raw.windows.forEach((w, i) => {
+        const idx = `windows[${i}]`;
+        if (!isPlainObject(w)) {
+          errors.push(`${idx} must be an object`);
+          return;
+        }
+        for (const k of Object.keys(w)) {
+          if (!WINDOW_KEYS.includes(k)) errors.push(`unknown key "${idx}.${k}"`);
+        }
+        for (const lit of ["kind", "label"]) {
+          if (!isNonEmptyString(w[lit])) errors.push(`missing required key "${idx}.${lit}"`);
+        }
+        for (const f of ["pct", "used", "limit", "remaining", "resetsAt", "startedAt"]) {
+          if (w[f] !== undefined && !isNonEmptyString(w[f])) errors.push(`"${idx}.${f}" must be a dot-path string`);
+        }
+      });
+    }
+  }
+
+  if (raw.planLabel !== undefined && !isNonEmptyString(raw.planLabel)) {
+    errors.push('"planLabel" must be a dot-path string');
+  }
+  if (raw.overagePrice !== undefined && !isNonEmptyString(raw.overagePrice)) {
+    errors.push('"overagePrice" must be a dot-path string');
+  }
+
+  if (errors.length > 0) return { valid: false, errors };
+  return { valid: true, descriptor: raw };
+}
+
+/**
+ * Turn one descriptor window's dot-path spec into a UsageWindow by resolving
+ * each path against the payload. Normalizes the same way the code adapters'
+ * normalizeWindow does (pct from used/limit when absent, always clamped, epoch
+ * ms timestamps); returns null when there is nothing usable to show.
+ * @param {object} w
+ * @param {(path: string) => unknown} get
+ * @returns {object | null}
+ */
+function descriptorWindow(w, get) {
+  const limit = toFiniteNumber(get(w.limit));
+  let used = toFiniteNumber(get(w.used));
+  if (used === undefined && limit !== undefined) {
+    const remaining = toFiniteNumber(get(w.remaining));
+    if (remaining !== undefined) used = limit - remaining;
+  }
+
+  let pct = toFiniteNumber(get(w.pct));
+  if (pct !== undefined) {
+    pct = clampPct(pct);
+  } else if (limit !== undefined && limit !== 0 && used !== undefined) {
+    pct = clampPct((used / limit) * 100);
+  } else {
+    pct = undefined;
+  }
+  if (pct === undefined || !Number.isFinite(pct)) return null;
+
+  const out = { kind: w.kind, label: w.label, pct };
+  if (used !== undefined) out.used = used;
+  if (limit !== undefined && limit !== 0) out.limit = limit;
+
+  const resetsAt = readEpochMs(get(w.resetsAt));
+  if (resetsAt !== undefined) out.resetsAt = resetsAt;
+  const startedAt = readEpochMs(get(w.startedAt));
+  if (startedAt !== undefined) out.startedAt = startedAt;
+
+  return out;
+}
+
+/**
+ * Map a fetched payload onto the UsageSnapshot shape for this descriptor.
+ * Pure. A missing balance resolves to `undefined`, NEVER 0 (absent balance and
+ * a zero balance are meaningfully different: absent means *unknown*). Sign
+ * conventions are the point: a negative balance under `positive-is-credit` is
+ * overdrawn → `exhausted: true`, and `positive-is-debt` inverts the raw value.
+ * @param {object} descriptor  a validated descriptor
+ * @param {unknown} payload    the parsed response body
+ * @param {number} nowMs       epoch ms (kept for interface parity; window
+ *                             timestamps are resolved from the payload)
+ * @returns {object} an Omit<UsageSnapshot, "fetchedAt">-compatible object
+ */
+export function readDescriptor(descriptor, payload, nowMs) {
+  const get = (path) => getByPath(payload, path);
+
+  const windows = Array.isArray(descriptor.windows)
+    ? descriptor.windows.map((w) => descriptorWindow(w, get)).filter(Boolean)
+    : [];
+
+  const balanceNum = toFiniteNumber(get(descriptor.balance?.path));
+  const balance =
+    balanceNum !== undefined
+      ? descriptor.balance?.sign === "positive-is-debt"
+        ? -balanceNum
+        : balanceNum
+      : undefined;
+
+  const planLabelRaw = get(descriptor.planLabel);
+  const planLabel = typeof planLabelRaw === "string" && planLabelRaw ? planLabelRaw : undefined;
+
+  const overagePriceNum = toFiniteNumber(get(descriptor.overagePrice));
+  const overagePrice = overagePriceNum !== undefined ? overagePriceNum : undefined;
+
+  const overdrawn = balance !== undefined && balance < 0;
+  const atWindowLimit = windows.some((w) => w.pct >= 100);
+  const exhausted = overdrawn || atWindowLimit;
+
+  const snap = { provider: descriptor.id, providerIDs: descriptor.providerIDs, windows };
+  if (balance !== undefined) snap.balance = balance;
+  if (overagePrice !== undefined) snap.overagePrice = overagePrice;
+  if (planLabel) snap.planLabel = planLabel;
+  if (exhausted) snap.exhausted = true;
+  return snap;
+}

--- a/src/shared/accountDescriptor.test.ts
+++ b/src/shared/accountDescriptor.test.ts
@@ -1,0 +1,141 @@
+// Tests for src/shared/accountDescriptor.mjs — the pure descriptor validator
+// and payload mapper at the heart of BET-1239. Mirrors pluginManifest.test.ts
+// (vitest, no live fs / network / opencode). The sign conventions are the
+// load-bearing part: a wrong balance sign silently turns a dead account into a
+// cheap one, which is the exact failure this design guards against.
+
+import { describe, it, expect } from "vitest";
+import { validateDescriptor, readDescriptor } from "./accountDescriptor.mjs";
+
+const base = {
+  id: "samplecredits",
+  providerIDs: ["samplecredits"],
+  url: "https://example.com/credits",
+  auth: "bearer",
+  balance: { path: "account.balance", units: "dollars", sign: "positive-is-credit" },
+};
+
+const ok = (raw) => {
+  const r = validateDescriptor(raw);
+  if (!r.valid) throw new Error(`expected valid descriptor, got: ${r.errors.join("; ")}`);
+  return r.descriptor;
+};
+
+describe("validateDescriptor", () => {
+  it("accepts a well-formed descriptor and round-trips it", () => {
+    const r = validateDescriptor(base);
+    expect(r.valid).toBe(true);
+    if (!r.valid) return;
+    expect(r.descriptor).toEqual(base);
+    // A validated descriptor is directly usable for reading.
+    const snap = readDescriptor(r.descriptor, { account: { balance: 42 } }, 0);
+    expect(snap.balance).toBe(42);
+  });
+
+  it("rejects an unknown top-level key and names it", () => {
+    const r = validateDescriptor({ ...base, oops: 1 });
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors.join("; ")).toContain('"oops"');
+  });
+
+  it("rejects a missing required key and names it", () => {
+    const { id, ...withoutId } = base;
+    const r = validateDescriptor(withoutId);
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors.join("; ")).toContain('"id"');
+  });
+
+  it("rejects a missing balance object and names it", () => {
+    const { balance, ...withoutBalance } = base;
+    const r = validateDescriptor(withoutBalance);
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors.join("; ")).toContain('"balance"');
+  });
+
+  it("rejects an unknown balance.sign value", () => {
+    const r = validateDescriptor({
+      ...base,
+      balance: { ...base.balance, sign: "positive-means-money" },
+    });
+    expect(r.valid).toBe(false);
+    if (r.valid) return;
+    expect(r.errors.join("; ")).toContain("positive-is-credit");
+  });
+});
+
+describe("readDescriptor", () => {
+  it("maps a nested balance path correctly", () => {
+    const snap = readDescriptor(ok(base), { account: { balance: 42 } }, 0);
+    expect(snap.balance).toBe(42);
+  });
+
+  it("a negative balance under positive-is-credit sets exhausted and stays negative", () => {
+    const snap = readDescriptor(ok(base), { account: { balance: -5 } }, 0);
+    expect(snap.balance).toBe(-5);
+    expect(snap.exhausted).toBe(true);
+  });
+
+  it("positive-is-debt inverts correctly", () => {
+    const d = ok({ ...base, balance: { ...base.balance, sign: "positive-is-debt" } });
+    const snap = readDescriptor(d, { account: { balance: 15 } }, 0);
+    // 15 balance means 15 of debt → -15 credit → overdrawn.
+    expect(snap.balance).toBe(-15);
+    expect(snap.exhausted).toBe(true);
+  });
+
+  it("positive-is-debt does not set exhausted for a (credit) negative raw value", () => {
+    const d = ok({ ...base, balance: { ...base.balance, sign: "positive-is-debt" } });
+    const snap = readDescriptor(d, { account: { balance: -10 } }, 0);
+    expect(snap.balance).toBe(10);
+    expect(snap.exhausted).toBeUndefined();
+  });
+
+  it("a payload missing the balance path leaves balance undefined, NOT 0", () => {
+    const d = ok({ ...base, balance: { ...base.balance, path: "nope.missing" } });
+    const snap = readDescriptor(d, {}, 0);
+    expect(snap.balance).toBeUndefined();
+    expect(snap).not.toHaveProperty("balance");
+  });
+
+  it("window paths produce a UsageWindow with startedAt carried through", () => {
+    const d = ok({
+      ...base,
+      windows: [
+        {
+          kind: "weekly",
+          label: "7d",
+          used: "data.used",
+          limit: "data.limit",
+          resetsAt: "data.resets_at",
+          startedAt: "data.started_at",
+        },
+      ],
+    });
+    const snap = readDescriptor(
+      d,
+      { data: { used: 120, limit: 200, resets_at: 1700000000, started_at: 1699990000 } },
+      0,
+    );
+    expect(snap.windows).toHaveLength(1);
+    const w = snap.windows[0];
+    expect(w.kind).toBe("weekly");
+    expect(w.label).toBe("7d");
+    expect(w.used).toBe(120);
+    expect(w.limit).toBe(200);
+    expect(w.pct).toBe(60);
+    expect(w.startedAt).toBe(1699990000 * 1000);
+    expect(w.resetsAt).toBe(1700000000 * 1000);
+  });
+
+  it("a window at 100% sets exhausted even with no balance", () => {
+    const d = ok({
+      ...base,
+      windows: [{ kind: "session", label: "5h", pct: "w.pct" }],
+    });
+    const snap = readDescriptor(d, { w: { pct: 100 } }, 0);
+    expect(snap.exhausted).toBe(true);
+  });
+});

--- a/src/shared/accountDescriptor.test.ts
+++ b/src/shared/accountDescriptor.test.ts
@@ -15,7 +15,7 @@ const base = {
   balance: { path: "account.balance", units: "dollars", sign: "positive-is-credit" },
 };
 
-const ok = (raw) => {
+const ok = (raw: Record<string, unknown>) => {
   const r = validateDescriptor(raw);
   if (!r.valid) throw new Error(`expected valid descriptor, got: ${r.errors.join("; ")}`);
   return r.descriptor;
@@ -119,8 +119,9 @@ describe("readDescriptor", () => {
       { data: { used: 120, limit: 200, resets_at: 1700000000, started_at: 1699990000 } },
       0,
     );
-    expect(snap.windows).toHaveLength(1);
-    const w = snap.windows[0];
+    const windows = snap.windows as Array<Record<string, unknown>>;
+    expect(windows).toHaveLength(1);
+    const w = windows[0];
     expect(w.kind).toBe("weekly");
     expect(w.label).toBe("7d");
     expect(w.used).toBe(120);


### PR DESCRIPTION
Opened automatically for `multica/BET-1239-account-descriptors`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1239.