### PR TITLE
feat(shared): modelIdentity — resolve what an opaque endpoint serves (BET-1242)

### DIFF
--- a/src/shared/modelIdentity.d.mts
+++ b/src/shared/modelIdentity.d.mts
@@ -1,0 +1,68 @@
+export type IdentityState = "resolved" | "ambiguous" | "unknown";
+export type IdentitySource = "provider" | "matched" | "declared" | null;
+
+export interface OpencodeModel {
+  providerID?: string;
+  id?: string;
+  family?: string;
+  capabilities?: {
+    reasoning?: boolean;
+    tool_call?: boolean;
+    modalities?: { input?: string[]; output?: string[] };
+    input?: { image?: boolean; pdf?: boolean };
+  };
+  limit?: { context?: number | null; output?: number };
+  cost?: {
+    input?: number;
+    output?: number;
+    cacheRead?: number;
+    cacheWrite?: number;
+  };
+}
+
+export interface ModelDeclaration {
+  catalogId?: string;
+  price?: { input?: number; output?: number } | "free";
+  caches?: false | { read?: boolean; write?: boolean };
+  tierOverride?: string;
+}
+
+export interface CatalogueEntry {
+  id?: string;
+  name?: string;
+  family?: string;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  modalities?: { input?: string[]; output?: string[] };
+  limit?: { context?: number; output?: number };
+  benchmarks?: { name: string; score: number; metric?: string }[];
+}
+
+export interface ModelCatalog {
+  lookupModel(catalogId: string): CatalogueEntry | null;
+  matchModel(localModelId: string): {
+    kind: "exact" | "ambiguous" | "none";
+    candidates: CatalogueEntry[];
+  };
+}
+
+export interface IdentityResult {
+  state: IdentityState;
+  catalogId: string | null;
+  candidates: string[];
+  source: IdentitySource;
+  effective: EffectiveModel;
+}
+
+export interface EffectiveModel extends OpencodeModel {
+  catalogId?: string;
+  benchmarks?: CatalogueEntry["benchmarks"];
+  caches?: false | { read?: boolean; write?: boolean };
+  tierOverride?: string;
+}
+
+export function resolveIdentity(
+  model: OpencodeModel | null | undefined,
+  declared: ModelDeclaration | null | undefined,
+  catalog: ModelCatalog | null | undefined
+): IdentityResult;

--- a/src/shared/modelIdentity.mjs
+++ b/src/shared/modelIdentity.mjs
@@ -1,0 +1,191 @@
+// modelIdentity.mjs — what model is this opaque endpoint actually serving?
+//
+// Pure, injected inputs only. There is no I/O and nothing is fetched: the
+// catalogue matcher (`{ lookupModel, matchModel }`, the same pair the
+// box-side model catalogue exposes) arrives as an argument. This is the
+// design opportunity of Automatic Manta Routing: not every opaque id is
+// equally opaque. A provider can expose three model ids — `qwen3.6-27b`,
+// `ornith`, `default` — where every fact a router needs is missing or
+// present-and-wrong (a context limit of 0 and a price of 0 are not
+// "unknown", they are claims, and both are false). But the ids are not
+// equally hopeless:
+//
+//   • `qwen3.6-27b` resolves exactly in the catalogue → we know what it is;
+//   • `ornith` is ambiguous (four same-family sizes) → we must NOT guess;
+//   • `default` is meaningless → genuinely unknown, stays hand-pickable and
+//     is simply never chosen automatically (supported, not an error).
+//
+// The hallucinated `limit.context: 0` and `cost: 0` are the credibility trap
+// this module exists for: a provider reporting `0` / `""` / `undefined` is
+// reporting *nothing*, and the catalogue's real value must win; but a
+// positive provider value is a real property of that endpoint and wins over
+// the catalogue. Price is always the endpoint's, never the catalogue's — the
+// same model is free on one host and expensive on another.
+
+// A value is "credible" for the limit/context rule: any positive finite
+// number is a real claim about this endpoint; `0`/`""`/`undefined`/`NaN` are
+// silence and must fall back to the catalogue. Returns the credible value or
+// null.
+function credibleNumber(v) {
+  return typeof v === "number" && Number.isFinite(v) && v > 0 ? v : null;
+}
+
+// Generic "provider value overrides the catalogue base when credible" —
+// `credible(v)` decides whether the provider's value is a real signal.
+function pickCredible(providerVal, catalogueVal, credible) {
+  return credible(providerVal) ? providerVal : catalogueVal;
+}
+
+// Copy only the finite, non-negative payload of a cost object (a declared 0
+// is real, missing/NaN/negative is junk and dropped — never emitted as a
+// made-up figure).
+function copyCost(cost) {
+  if (!cost || typeof cost !== "object") return {};
+  const out = {};
+  for (const key of ["input", "output", "cacheRead", "cacheWrite"]) {
+    const v = cost[key];
+    if (typeof v === "number" && Number.isFinite(v) && v >= 0) out[key] = v;
+  }
+  return out;
+}
+
+// Merge catalogue capabilities (reasoning, tool_call, modalities) under the
+// provider's own where the provider's are credible; otherwise the catalogue
+// fact stands. Provider capability fields that are absent are untouched.
+function mergeCapabilities(providerCaps, catalogueEntry) {
+  const base =
+    providerCaps && typeof providerCaps === "object" ? { ...providerCaps } : {};
+  const e = catalogueEntry && typeof catalogueEntry === "object" ? catalogueEntry : {};
+  return {
+    ...base,
+    reasoning: pickCredible(base.reasoning, e.reasoning, (v) => typeof v === "boolean"),
+    tool_call: pickCredible(base.tool_call, e.tool_call, (v) => typeof v === "boolean"),
+    modalities: pickCredible(
+      base.modalities,
+      e.modalities,
+      (v) => Array.isArray(v) && v.length > 0,
+    ),
+  };
+}
+
+// Resolve the provider's own id/family against the catalogue. id is the
+// more specific signal and is tried first; family is the fallback that lets
+// a bare family name surface every size of it (ambiguously).
+function matchProvider(cat, id, family) {
+  for (const localId of [id, family]) {
+    if (typeof localId !== "string" || localId === "") continue;
+    // A provider that literally names a full catalogue id is self-identifying
+    // — no fuzzy matching needed.
+    if (typeof cat?.lookupModel === "function") {
+      const direct = cat.lookupModel(localId);
+      if (direct) return { kind: "provider", candidates: [direct] };
+    }
+    if (typeof cat?.matchModel === "function") {
+      const r = cat.matchModel(localId);
+      if (r?.kind === "exact") return { kind: "exact", candidates: r.candidates };
+      if (r?.kind === "ambiguous") return { kind: "ambiguous", candidates: r.candidates };
+    }
+  }
+  return { kind: "none", candidates: [] };
+}
+
+// Merge the catalogue entry, then the provider's own credible values, then
+// the user's declaration, into one `effective` endpoint description. Later
+// wins.
+function buildEffective(m, dec, entry, catalogId) {
+  const e = entry && typeof entry === "object" ? entry : {};
+
+  // Price is always the endpoint's — never the catalogue's. Start from the
+  // provider's own cost, then the user's declared price (incl. "free", which
+  // is an explicit zero, distinguishable from the silence of an absent price).
+  let cost = copyCost(m.cost);
+  if (dec.price === "free") {
+    cost = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
+  } else if (dec.price && typeof dec.price === "object") {
+    cost = { ...cost, ...copyCost(dec.price) };
+  }
+
+  // Context/output: catalogue is the base; the provider's positive value wins
+  // (it is a real property of its own endpoint); `0`/absent falls back.
+  const context =
+    credibleNumber(m?.limit?.context) ?? credibleNumber(e?.limit?.context) ?? undefined;
+  const output =
+    credibleNumber(m?.limit?.output) ?? credibleNumber(e?.limit?.output) ?? undefined;
+
+  const effective = {
+    providerID: m?.providerID,
+    id: m?.id,
+    family:
+      typeof e?.family === "string" && e.family !== "" ? e.family : m?.family,
+    capabilities: mergeCapabilities(m?.capabilities, e),
+    limit: { context, output },
+    cost,
+  };
+  for (const key of ["catalogId", "benchmarks", "caches", "tierOverride"]) {
+    const val =
+      key === "catalogId"
+        ? catalogId
+        : key === "benchmarks"
+          ? e.benchmarks
+          : dec[key];
+    if (key === "benchmarks" ? Array.isArray(val) : val !== undefined) {
+      effective[key] = val;
+    }
+  }
+  return effective;
+}
+
+/**
+ * What model is this endpoint actually serving, and what do we therefore know?
+ *
+ * @param {object} model      OpencodeModel as normalised from the provider
+ * @param {object} declared   the user's declaration for this endpoint key, or null:
+ *                            { catalogId?, price?: {input,output}|"free",
+ *                              caches?: false|{read,write}, tierOverride? }
+ * @param {object} catalog    { lookupModel, matchModel } — injected
+ * @returns {{
+ *   state: "resolved"|"ambiguous"|"unknown",
+ *   catalogId: string|null,
+ *   candidates: string[],          // populated only when ambiguous
+ *   source: "provider"|"matched"|"declared"|null,
+ *   effective: object,             // the model merged with catalogue + declared facts
+ * }}
+ */
+export function resolveIdentity(model, declared, catalog) {
+  const m = model && typeof model === "object" ? model : {};
+  const dec = declared && typeof declared === "object" ? declared : {};
+
+  let catalogId = null;
+  let source = null;
+  let state = "unknown";
+  let entry = null;
+  let candidates = [];
+
+  if (typeof dec.catalogId === "string" && dec.catalogId !== "") {
+    // The user told us. Always wins — even over an exact catalogue match.
+    catalogId = dec.catalogId;
+    source = "declared";
+    state = "resolved";
+    if (typeof catalog?.lookupModel === "function") {
+      entry = catalog.lookupModel(catalogId);
+    } else {
+      entry = null;
+    }
+  } else {
+    const res = matchProvider(catalog, m.id, m.family);
+    if (res.kind === "provider" || res.kind === "exact") {
+      // candidate[0] is the single resolved entry for both kinds.
+      entry = res.candidates[0];
+      catalogId = entry?.id;
+      source = res.kind === "provider" ? "provider" : "matched";
+      state = "resolved";
+    } else if (res.kind === "ambiguous") {
+      state = "ambiguous";
+      candidates = res.candidates.map((x) => x?.id).filter(Boolean);
+    }
+    // kind === "none" → state stays "unknown".
+  }
+
+  const effective = buildEffective(m, dec, entry, catalogId);
+  return { state, catalogId, candidates, source, effective };
+}

--- a/src/shared/modelIdentity.test.ts
+++ b/src/shared/modelIdentity.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { resolveIdentity } from "./modelIdentity.mjs";
+import type { ModelCatalog } from "./modelIdentity.mjs";
 
 // A minimal catalogue matcher mirroring the box-side model catalogue's
 // semantics (normalise + family-grouped handles → exact/ambiguous/none). The
@@ -13,7 +14,7 @@ function normalize(modelsId: string): string {
     .replace(/^-+|-+$/g, "");
 }
 
-function index(entries: any[]) {
+function index(entries: any[]): ModelCatalog {
   const byHandle = new Map<string, any[]>();
   const add = (keys: Set<string>, v: unknown) => {
     if (typeof v === "string" && v !== "") keys.add(normalize(v));
@@ -84,9 +85,9 @@ describe("resolveIdentity — the three real cases", () => {
     expect(r.catalogId).toBe("qwen/qwen3.6-27b");
     expect(r.candidates).toEqual([]);
     // 0 is absent, not zero → the catalogue's real 131072 stands.
-    expect(r.effective.limit.context).toBe(131072);
+    expect(r.effective.limit!.context).toBe(131072);
     expect(r.effective.family).toBe("qwen");
-    expect(r.effective.capabilities.reasoning).toBe(true);
+    expect(r.effective.capabilities!.reasoning).toBe(true);
   });
 
   it("ornith is ambiguous — all four same-family sizes, no guessing", () => {
@@ -134,7 +135,7 @@ describe("resolveIdentity — credibility rule for limit.context", () => {
   it("a provider limit.context of 0 is absent → catalogue value is used", () => {
     const model = { providerID: "chutes", id: "qwen3.6-27b", family: "", limit: { context: 0 } };
     const r = resolveIdentity(model, null, CATALOG);
-    expect(r.effective.limit.context).toBe(131072);
+    expect(r.effective.limit!.context).toBe(131072);
   });
 
   it("a provider limit.context of 262144 against a catalogue 1048576 → provider wins", () => {
@@ -142,7 +143,7 @@ describe("resolveIdentity — credibility rule for limit.context", () => {
     // endpoint property of 262144, which is a fact about ITS endpoint.
     const model = { providerID: "chutes", id: "qwen-1m", family: "", limit: { context: 262144 } };
     const r = resolveIdentity(model, null, CATALOG);
-    expect(r.effective.limit.context).toBe(262144);
+    expect(r.effective.limit!.context).toBe(262144);
   });
 });
 

--- a/src/shared/modelIdentity.test.ts
+++ b/src/shared/modelIdentity.test.ts
@@ -1,0 +1,168 @@
+import { describe, it, expect } from "vitest";
+import { resolveIdentity } from "./modelIdentity.mjs";
+
+// A minimal catalogue matcher mirroring the box-side model catalogue's
+// semantics (normalise + family-grouped handles → exact/ambiguous/none). The
+// real matching logic is covered by its own suite; here we need a faithful
+// injected stand-in for the three real cases the issue drives from.
+function normalize(modelsId: string): string {
+  return String(modelsId)
+    .toLowerCase()
+    .replace(/[\s_./]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+function index(entries: any[]) {
+  const byHandle = new Map<string, any[]>();
+  const add = (keys: Set<string>, v: unknown) => {
+    if (typeof v === "string" && v !== "") keys.add(normalize(v));
+  };
+  const handles = (e: any) => {
+    const keys = new Set<string>();
+    add(keys, e?.id);
+    if (typeof e?.id === "string") add(keys, String(e.id).split("/").pop());
+    add(keys, e?.name);
+    add(keys, e?.family);
+    return keys;
+  };
+  for (const e of entries) {
+    for (const k of handles(e)) {
+      if (!byHandle.has(k)) byHandle.set(k, []);
+      byHandle.get(k)!.push(e);
+    }
+  }
+  return {
+    lookupModel(id: string) {
+      const n = normalize(id);
+      return entries.find((e) => typeof e?.id === "string" && normalize(e.id) === n) ?? null;
+    },
+    matchModel(localId: string) {
+      const raw = byHandle.get(normalize(localId)) ?? [];
+      const candidates = [...new Set(raw)];
+      if (candidates.length === 0) return { kind: "none", candidates: [] };
+      if (candidates.length === 1) return { kind: "exact", candidates };
+      return { kind: "ambiguous", candidates };
+    },
+  };
+}
+
+// Trimmed catalogue fixture — the three real cases from the issue.
+const QWEN = {
+  id: "qwen/qwen3.6-27b",
+  name: "Qwen3.6-27B",
+  family: "qwen",
+  reasoning: true,
+  tool_call: true,
+  modalities: { input: ["text"], output: ["text"] },
+  limit: { context: 131072, output: 8192 },
+  benchmarks: [{ name: "SWE-Bench Verified", score: 58.4, metric: "resolved" }],
+};
+
+const ORNITH_SIZES = [
+  { id: "chutes/Ornith-9B", name: "Ornith 9B", family: "ornith", limit: { context: 32768, output: 4096 } },
+  { id: "chutes/Ornith-31B", name: "Ornith 31B", family: "ornith", limit: { context: 65536, output: 8192 } },
+  { id: "chutes/Ornith-35B", name: "Ornith 35B", family: "ornith", limit: { context: 65536, output: 8192 } },
+  { id: "chutes/Ornith-397B", name: "Ornith 397B", family: "ornith", limit: { context: 262144, output: 32768 } },
+];
+
+// A catalogue whose qwen entry reports a 1M context (for the credibility test
+// where the provider's smaller-but-plausible 262144 is a real endpoint fact).
+const CATALOG = index([
+  QWEN,
+  { ...QWEN, id: "qwen/qwen-1m", name: "Qwen-1M", family: "qwen", limit: { context: 1048576, output: 8192 } },
+  ...ORNITH_SIZES,
+]);
+
+describe("resolveIdentity — the three real cases", () => {
+  it("qwen3.6-27b resolves exactly; effective context comes from the catalogue", () => {
+    // The provider reports a context limit of 0 — a claim, and a false one.
+    const model = { providerID: "chutes", id: "qwen3.6-27b", family: "", limit: { context: 0 }, cost: { input: 0, output: 0 } };
+    const r = resolveIdentity(model, null, CATALOG);
+    expect(r.state).toBe("resolved");
+    expect(r.source).toBe("matched");
+    expect(r.catalogId).toBe("qwen/qwen3.6-27b");
+    expect(r.candidates).toEqual([]);
+    // 0 is absent, not zero → the catalogue's real 131072 stands.
+    expect(r.effective.limit.context).toBe(131072);
+    expect(r.effective.family).toBe("qwen");
+    expect(r.effective.capabilities.reasoning).toBe(true);
+  });
+
+  it("ornith is ambiguous — all four same-family sizes, no guessing", () => {
+    const model = { providerID: "chutes", id: "ornith", family: "ornith", limit: { context: 0 } };
+    const r = resolveIdentity(model, null, CATALOG);
+    expect(r.state).toBe("ambiguous");
+    expect(r.catalogId).toBeNull();
+    expect(r.candidates.sort()).toEqual(
+      ["chutes/Ornith-9B", "chutes/Ornith-31B", "chutes/Ornith-35B", "chutes/Ornith-397B"].sort(),
+    );
+    expect(r.source).toBeNull();
+  });
+
+  it("default is unknown — supported, never chosen automatically", () => {
+    const model = { providerID: "chutes", id: "default", family: "", limit: { context: 0 }, cost: { input: 0, output: 0 } };
+    const r = resolveIdentity(model, null, CATALOG);
+    expect(r.state).toBe("unknown");
+    expect(r.catalogId).toBeNull();
+    expect(r.candidates).toEqual([]);
+    expect(r.source).toBeNull();
+  });
+});
+
+describe("resolveIdentity — declared identity", () => {
+  it("declared.catalogId overrides an exact match", () => {
+    // qwen3.6-27b would otherwise resolve exactly.
+    const model = { providerID: "chutes", id: "qwen3.6-27b", family: "" };
+    const r = resolveIdentity(model, { catalogId: "some-other-model" }, CATALOG);
+    expect(r.state).toBe("resolved");
+    expect(r.source).toBe("declared");
+    expect(r.catalogId).toBe("some-other-model");
+    expect(r.effective.catalogId).toBe("some-other-model");
+  });
+
+  it("provider that names a full catalogue id self-identifies (source provider)", () => {
+    const model = { providerID: "chutes", id: "qwen/qwen3.6-27b", family: "" };
+    const r = resolveIdentity(model, null, CATALOG);
+    expect(r.state).toBe("resolved");
+    expect(r.source).toBe("provider");
+    expect(r.catalogId).toBe("qwen/qwen3.6-27b");
+  });
+});
+
+describe("resolveIdentity — credibility rule for limit.context", () => {
+  it("a provider limit.context of 0 is absent → catalogue value is used", () => {
+    const model = { providerID: "chutes", id: "qwen3.6-27b", family: "", limit: { context: 0 } };
+    const r = resolveIdentity(model, null, CATALOG);
+    expect(r.effective.limit.context).toBe(131072);
+  });
+
+  it("a provider limit.context of 262144 against a catalogue 1048576 → provider wins", () => {
+    // id qwen-1m matches the 1M-entry; the provider reports a smaller-but-real
+    // endpoint property of 262144, which is a fact about ITS endpoint.
+    const model = { providerID: "chutes", id: "qwen-1m", family: "", limit: { context: 262144 } };
+    const r = resolveIdentity(model, null, CATALOG);
+    expect(r.effective.limit.context).toBe(262144);
+  });
+});
+
+describe("resolveIdentity — price is always the endpoint's", () => {
+  it("declared.price 'free' yields explicit zero rates, distinguishable from absent", () => {
+    const model = { providerID: "chutes", id: "qwen3.6-27b", family: "" };
+    const free = resolveIdentity(model, { price: "free" }, CATALOG);
+    // Explicit zeros across every rate — a declared free endpoint.
+    expect(free.effective.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+
+    // Absent price is silence — no made-up zeroes.
+    const silent = resolveIdentity(model, null, CATALOG);
+    expect(silent.effective.cost).toEqual({});
+  });
+
+  it("the catalogue's own price is never adopted as the endpoint's price", () => {
+    // Even though the catalogue entry carries no cost here, a provider price
+    // must be able to win outright.
+    const model = { providerID: "chutes", id: "qwen3.6-27b", family: "", cost: { input: 3, output: 15, cacheRead: 0.3 } };
+    const r = resolveIdentity(model, null, CATALOG);
+    expect(r.effective.cost).toEqual({ input: 3, output: 15, cacheRead: 0.3 });
+  });
+});


### PR DESCRIPTION
**Stage 5 of Automatic Manta Routing (S5b).** Depends on S5a (BET-1241, catalogue — already on `main`). Pure module + tests only; no wiring.

## What

`src/shared/modelIdentity.mjs` — resolve what an opaque endpoint is actually serving, given the provider's model, the user's declaration, and the injected catalogue matcher (`{ lookupModel, matchModel }`, the same pair the box-side catalogue exposes).

- Precedence: `declared.catalogId` (always wins) → provider's own id/family exact in catalogue → ambiguous → unknown. Returns `{ state, catalogId, candidates, source, effective }`.
- `source`: **matched** (catalogue matched the opaque id), **provider** (provider literally named a full catalogue id / self-identifies), **declared** (user overrode).
- `effective`: catalogue entry merged with the provider's *credible* values (positive wins; `0`/`""`/`undefined` are silence → catalogue's real value stands) then the user's declared facts.
- **Credibility rule**: `limit.context: 0` is absent; a real positive value is a genuine endpoint property and wins over the catalogue.
- **Price is always the endpoint's**: never taken from the catalogue; `declared.price === "free"` yields explicit zero rates distinguishable from an absent price.

Driven by the three real cases: `qwen3.6-27b` → resolved/matched (catalogue context), `ornith` → ambiguous (four same-family sizes, no guessing), `default` → unknown (supported, hand-pickable).

## Why here / anti-spaghetti notes

- Pure + injected inputs, mirrors siblings (`modelQuality`, `blendedPrice`). No fetch, no probing, no `node:` imports.
- Feeds the existing `autoEligibility` gate (its `identity.known`/`catalogId` and `declared` shape) — no duplication; the `declared` type reuses that contract.
- Catalogue matching semantics (normalise + family-grouped handles) already live + tested in `modelCatalog.mjs` (BET-1241); not re-implemented here. The identity test injects a small faithful stand-in rather than pulling the server module into a shared test.

## What I deliberately did NOT do

- No wiring into the router / Accounts UI — that is a separate issue (state that the issue itself scopes this as "Pure module + tests; the UI that drives it is a separate issue").
- No endpoint probing or network in the module.

**Base: `origin/main` @ `219e5217`**

**Files changed:** 3 files (all new).
- `src/shared/modelIdentity.mjs`
- `src/shared/modelIdentity.d.mts`
- `src/shared/modelIdentity.test.ts`

**Verification results:**
- PR branch (`multica/BET-1242-model-identity` @ `dcf0bce2`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, vitest `3377` pass / `7` skip / `0` fail (179 files); node:test `2597` pass / `0` fail. log sha256: `d0cf5730057ceadef56810e2e088a94ddad6b9b6fb9cefb4814dfb3e7b24866f`
- Base (`main` @ `219e5217`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, node:test `2597` pass / `0` fail (178 vitest files). log sha256: `0bd418e750b9fb8790e829a5b0cce9986014f3f0c0c92cd8c2cf62b11498500b`
- **Conclusion:** `0` new failures; the change adds a pure module + its tests and touches no existing files, so all pre-existing suites are identical between branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Note: this box's root disk was briefly full (env), causing transient `ENOSPC` failures on the first full-suite run; after freeing stale temp space both branches run green. Not a code issue.
