### PR TITLE
Routing: the composer chip says Auto, and which model Auto chose (BET-1247)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -75,6 +75,7 @@ import {
   modelInputModes,
   modelKey,
   modelSupportsAttachments,
+  readSavedChoice,
   readSavedModel,
   writeSavedModel,
   readPlanSaved,
@@ -425,8 +426,16 @@ export function ChatPanel({
   // it. Initialized from the per-session localStorage override for the session,
   // falling back to the persisted global default (the same seed useSseBus's
   // providerID used to recompute from readSavedModel on every render).
+  // BET-1247: whether the session's model choice is Auto (the three-state
+  // choice from BET-1245). Under Auto the override seeds to null rather than
+  // the server default — the default is not "the model Auto chose", and the
+  // chip must read "Auto" until the router actually resolves one (a turn
+  // running applies the routed pick to `modelOverride`).
+  const [autoActive, setAutoActive] = useState<boolean>(
+    () => readSavedChoice(sessionId).kind === "auto",
+  );
   const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
-    readSavedModel(sessionId) ?? configDefaultModel ?? null,
+    autoActive ? null : readSavedModel(sessionId) ?? configDefaultModel ?? null,
   );
   // BET-1222: routed state for the composer pill — set when the router chose
   // this session's model (fed by the main-conversation routing wiring). The
@@ -657,8 +666,10 @@ export function ChatPanel({
     setError(null);
     const planOnStart = readPlanSaved(sessionId);
     setPlanOn(planOnStart);
+    const autoNow = readSavedChoice(sessionId).kind === "auto";
+    setAutoActive(autoNow);
     setModelOverride(
-      readSavedModel(sessionId) ?? configDefaultModel ?? null,
+      autoNow ? null : readSavedModel(sessionId) ?? configDefaultModel ?? null,
     );
     // Seed plan mode from the session's own `agent` field when present (BET-949
     // §5): a session pre-set to plan OUTSIDE MantaUI would otherwise show the
@@ -3131,6 +3142,7 @@ export function ChatPanel({
         models={models}
         modelOverride={modelOverride}
         defaultModel={defaultModel}
+        auto={autoActive}
         routed={routed}
         onRoutedUndone={() => void undoRouted()}
         plan={plan}

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -151,6 +151,7 @@ export function InputArea({
   models,
   modelOverride,
   defaultModel,
+  auto,
   routed,
   onRoutedUndone,
   plan,
@@ -212,6 +213,9 @@ export function InputArea({
   models: OpencodeModel[] | null;
   modelOverride: ModelSelection | null;
   defaultModel: { providerID: string; modelID: string } | null;
+  // BET-1247: the session's model choice is `auto` — the composer chip must
+  // say "Auto" and, once the router has resolved a model, which one.
+  auto: boolean;
   // BET-1222 routed state — forwarded to ModelPicker: reason + incumbent shown
   // on the routed pill, and the caller-owned undo action.
   routed?: { reason: string; incumbent: { providerID: string; modelID: string } } | null;
@@ -555,6 +559,7 @@ export function InputArea({
             models={models}
             modelOverride={modelOverride}
             defaultModel={defaultModel}
+            auto={auto}
             routed={routed}
             onRoutedUndone={onRoutedUndone}
             deactivatedMainModels={deactivatedMainModels}

--- a/src/renderer/ModelPicker.test.tsx
+++ b/src/renderer/ModelPicker.test.tsx
@@ -17,6 +17,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import { act } from "react";
 import { mount, type Harness } from "./testHarness";
 import { ModelPicker } from "./ModelPicker";
+import type { ModelSelection } from "./chatShared";
 import type { OpencodeModel } from "../shared/types";
 
 const MODELS: OpencodeModel[] = [
@@ -152,5 +153,105 @@ describe("ModelPicker — routed pill (BET-1222)", () => {
     expect(btn).toBeTruthy();
     act(() => (btn as HTMLButtonElement).click());
     expect(undone).toBe(true);
+  });
+});
+
+describe("ModelPicker — Auto mode (BET-1247)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function render(props: {
+    models?: OpencodeModel[] | null;
+    modelOverride?: ModelSelection | null;
+    defaultModel?: { providerID: string; modelID: string } | null;
+    auto?: boolean;
+    labelOverride?: string | null;
+  }): HTMLElement {
+    h?.unmount();
+    h = mount(
+      <ModelPicker
+        modelLabel={null}
+        models={props.models === undefined ? MODELS : props.models}
+        modelOverride={props.modelOverride ?? null}
+        defaultModel={props.defaultModel ?? null}
+        auto={props.auto ?? false}
+        labelOverride={props.labelOverride ?? null}
+        onOpen={() => {}}
+        onSelect={() => {}}
+      />,
+    );
+    return h.container;
+  }
+
+  // The left segment button's text — the model part of the split chip. Its
+  // two icons (Sparkles, ChevronDown) are empty glyphs, so the textContent is
+  // exactly the label string under test.
+  function leftLabel(c: HTMLElement): string {
+    const btn = c.querySelector<HTMLElement>(".manta-model-picker-btn");
+    return btn?.textContent ?? "";
+  }
+
+  it("reads just 'Auto' when Auto is on and no model is resolved yet", () => {
+    const c = render({ auto: true, modelOverride: null, defaultModel: null });
+    const label = leftLabel(c);
+    expect(label).toContain("Auto");
+    // No specific model is claimed while Auto has not chosen one — a "·" would
+    // assert a model that nobody has resolved.
+    expect(label).not.toContain("·");
+  });
+
+  it("reads 'Auto · <model>' once Auto has resolved a model", () => {
+    const c = render({
+      auto: true,
+      modelOverride: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+      defaultModel: null,
+    });
+    expect(leftLabel(c)).toContain("Auto · Claude Opus 4.7");
+  });
+
+  it("leaves the label byte-identical when Auto is off", () => {
+    const c = render({
+      auto: false,
+      modelOverride: null,
+      defaultModel: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+    });
+    // Today's label, exactly: the resolved default model's friendly name.
+    expect(leftLabel(c)).toBe("Claude Opus 4.7");
+    expect(leftLabel(c)).not.toContain("Auto");
+  });
+
+  it("never renders the Auto label while the catalog is in flight", () => {
+    const c = render({ auto: true, models: null });
+    const text = c.textContent ?? "";
+    expect(text).not.toContain("Auto");
+    expect(c.querySelector(".manta-model-picker-btn")).toBeTruthy();
+  });
+
+  it("leaves the effort and fast-toggle segments unchanged under Auto", () => {
+    const c = render({
+      auto: true,
+      modelOverride: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+      defaultModel: null,
+    });
+    // Resolved model exposes variants → the effort segment stays interactive
+    // with its default label; the ⚡ fast toggle is still present.
+    expect(c.textContent ?? "").toContain("Default");
+    expect(c.querySelector(".manta-fast-toggle-btn")).toBeTruthy();
+  });
+
+  it("names the full resolved model + provider in the auto hover title", () => {
+    const c = render({
+      auto: true,
+      modelOverride: { providerID: "anthropic", modelID: "claude-opus-4-7" },
+      defaultModel: null,
+    });
+    const title = c
+      .querySelector<HTMLElement>(".manta-model-picker-btn")
+      ?.getAttribute("title") ?? "";
+    expect(title).toContain("Claude Opus 4.7");
+    expect(title).toContain("anthropic");
   });
 });

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -50,6 +50,11 @@ export function ModelPicker({
   onOpen,
   onSelect,
   labelOverride = null,
+  // BET-1247: when the session's model choice is `auto` (the three-state
+  // choice BET-1245), the chip MUST say so and, once the router has resolved a
+  // model (a turn has run and `modelOverride` carries the routed pick), which
+  // model Auto chose. Until a model is resolved there is nothing to claim.
+  auto = false,
   // BET-1222: when the router chose this session's model, the composer pill
   // explains WHY (reason) and offers one-click undo to the incumbent model.
   // `routed` is pure display state; the undo action itself (set override back
@@ -80,6 +85,8 @@ export function ModelPicker({
   // highest precedence — lets a caller display "Auto" until the user first
   // picks a model. A no-op for callers that don't pass it (ChatPanel).
   labelOverride?: string | null;
+  // BET-1247: session model choice is `auto` (see above).
+  auto?: boolean;
   // BET-1222 routed state (see above).
   routed?: { reason: string; incumbent: { providerID: string; modelID: string } } | null;
   onRoutedUndone?: () => void;
@@ -119,9 +126,16 @@ export function ModelPicker({
 
   // Resolve the active model object (for the friendly name + variant list).
   // Shared resolution path with ChatPanel (BET-415 duplication gate).
+  // Under Auto, the resolved model is the one the router CHOSE (it is applied
+  // to `modelOverride` the moment a turn runs), never the server default —
+  // falling back to the default would claim "Auto · <default>" for a model Auto
+  // had not actually picked. So under Auto we resolve from the override only.
   const activeModel = useMemo<OpencodeModel | null>(
-    () => resolveActiveModel(models, modelOverride, defaultModel),
-    [models, modelOverride, defaultModel],
+    () =>
+      auto
+        ? resolveActiveModel(models, modelOverride, null)
+        : resolveActiveModel(models, modelOverride, defaultModel),
+    [models, modelOverride, defaultModel, auto],
   );
 
   const variants = activeModel?.variants ?? [];
@@ -144,8 +158,13 @@ export function ModelPicker({
   // Friendly display name for the model button: the caller's labelOverride
   // (highest precedence), else the resolved active model name, else the
   // modelLabel prop, else the "opencode" stub.
-  const modelDisplayName =
-    labelOverride ?? activeModel?.name ?? modelLabel ?? "opencode";
+  // Under Auto this is replaced entirely: "Auto" until the router has resolved
+  // a model, then "Auto · <model>" so the chip never hides who is answering.
+  const modelDisplayName = auto
+    ? activeModel
+      ? `Auto · ${activeModel.name}`
+      : "Auto"
+    : labelOverride ?? activeModel?.name ?? modelLabel ?? "opencode";
 
   // ⚡ fast-mode toggle — the third segment. Flipping it swaps the active model
   // for its `-fast` twin (or back), carrying the selected effort across. It is
@@ -167,6 +186,15 @@ export function ModelPicker({
   // no fast twin. A user reading that gets three facts about a model nobody has
   // resolved. Placeholder bars say "not yet" instead.
   const loading = models === null;
+
+  // Native title on the left segment. Under Auto with a resolved model, name
+  // the full resolved model + provider so hovering answers "what exactly is
+  // this". Otherwise today's copy stands.
+  const leftTitle = loading
+    ? LOADING_TITLE
+    : auto && activeModel
+      ? `Auto · ${activeModel.name} (${activeModel.providerID})`
+      : "Pick model for next prompt";
 
   return (
     <div className="overflow-visible min-w-0">
@@ -256,13 +284,13 @@ export function ModelPicker({
         extraPressed={fast.on}
         extraDisabled={!fast.available}
         rightAccent
-        leftAccent={Boolean(routed)}
+        leftAccent={Boolean(routed) || auto}
         popup
         leftHook="manta-model-picker-btn"
         rightHook="manta-effort-picker-btn"
         leftExpanded={modelOpen}
         rightExpanded={variantOpen}
-        leftTitle={loading ? LOADING_TITLE : "Pick model for next prompt"}
+        leftTitle={leftTitle}
         rightTitle={
           loading
             ? LOADING_TITLE


### PR DESCRIPTION
## BET-1247 — the composer chip says Auto, and which model Auto chose

Stage 6 of the Automatic Manta Routing epic.

The composer split chip (the model half of `SplitChip`) now never hides who is
answering when the session's model choice is Auto (three-state choice, BET-1245):

- Auto on, no model resolved yet → `Auto`
- Auto on, model resolved → `Auto · <model>`
- Auto off → today's label, byte-identical
- `models === null` → the skeleton placeholder still wins, never the Auto label
- Reuses the existing `leftAccent` affordance (no second accent mechanism)
- Hover title names the full resolved model + provider under Auto

No restructuring of `SplitChip`. Only the left segment's string, the resolution
of `activeModel` (under Auto it resolves from the routed override only, never
the server default — the default is not "the model Auto chose"), the hover
title, and the accent flag change.

**Files changed:** 4
- `src/renderer/ModelPicker.tsx` — `auto` prop, activeModel resolution, label/title/accent
- `src/renderer/ModelPicker.test.tsx` — 6 new Auto-state tests
- `src/renderer/InputArea.tsx` — thread `auto` through to ModelPicker
- `src/renderer/ChatPanel.tsx` — derive `autoActive` from the session choice; seed the override to null under Auto

**Verification results:**
- PR branch (`multica/BET-1247-composer-chip-auto` @ `cf4999a7`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, `3374` pass / `7` skip / `0` fail. Failures: none. log sha256: `78b1574d619609e737d15b054d5567000c0d0127bcf575fa5833fae894b127d2`
- Base (`origin/main` @ `219e5217`): unchanged by this PR (branch is a clean descendant)
- **Conclusion:** `0` new failures; no pre-existing failures.

Base: origin/main @ `219e5217`
