### PR TITLE
Routing: drop global policy.enabled; route per conversation via preset (BET-1251)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -831,7 +831,7 @@ describe("ChatPanel main-conversation routing (BET-1225)", () => {
       opencodeModelRoute: () =>
         Promise.resolve({
           model: null,
-          reason: "routing is off",
+          reason: "routing not activated for this conversation",
           incumbent: null,
           changed: false,
         }),

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -502,8 +502,8 @@ export function resolveRequestedModel(model, models) {
  * `incumbent` = whatever model the caller would have used today) and returns
  * the model to actually run on.
  *
- * Provably safe on the off-path: when `policy` is disabled (no modelRouting
- * config on a box that has never seen this feature), `chooseModel` returns
+ * Provably safe on the off-path: when the policy has no routing directive (no
+ * preset — a conversation that has not asked to route), `chooseModel` returns
  * `incumbent` exactly — so a spawn is byte-identical to today's. And any
  * throw inside the routing is swallowed, falling back to `incumbent`, so a
  * routing failure can never fail a spawn.
@@ -511,7 +511,7 @@ export function resolveRequestedModel(model, models) {
  * @param {object} [input]
  * @param {object|null} [input.incumbent]  the model the code would have used today
  * @param {Array<object>} [input.catalog]  opencode model list
- * @param {{ enabled?: boolean, preset?: string, perAgent?: Record<string,string> }} [input.policy]
+ * @param {{ preset?: string, perAgent?: Record<string,string> }} [input.policy]
  * @param {Array<object>} [input.quota]    usage snapshots
  * @param {string} [input.agent]           subagent type (default "general")
  * @param {number} [input.nowMs]
@@ -537,7 +537,7 @@ function toDeliverModel(m) {
 export function chooseSubagentModel({
   incumbent = null,
   catalog = [],
-  policy = { enabled: false },
+  policy = {},
   quota = [],
   agent = "general",
   nowMs = Date.now(),
@@ -592,14 +592,15 @@ export function chooseSubagentModel({
  * to the incumbent. That is the honesty contract of the routing epic: a main
  * conversation's model is never switched without a visible, undoable reason.
  *
- * Same safety contract as chooseSubagentModel: policy off / throw / no
- * survivors all fall back to `incumbent` with `changed: false`, so enabling
- * routing can never substitute a model the user was not shown and can undo.
+ * Same safety contract as chooseSubagentModel: a policy with no routing
+ * directive / any throw / no survivors all fall back to `incumbent` with
+ * `changed: false`, so enabling routing can never substitute a model the user
+ * was not shown and can undo.
  *
  * @param {object} [input]
  * @param {object|null} [input.incumbent]  the model the session would use without routing
  * @param {Array<object>} [input.catalog]  opencode model list
- * @param {{ enabled?: boolean, preset?: string, perAgent?: Record<string,string> }} [input.policy]
+ * @param {{ preset?: string, perAgent?: Record<string,string> }} [input.policy]
  * @param {Array<object>} [input.quota]    usage snapshots
  * @param {string} [input.agent]           main-conversation agent (default "build")
  * @param {number} [input.nowMs]
@@ -608,7 +609,7 @@ export function chooseSubagentModel({
 export function chooseMainModel({
   incumbent = null,
   catalog = [],
-  policy = { enabled: false },
+  policy = {},
   quota = [],
   agent = "build",
   nowMs = Date.now(),
@@ -779,7 +780,7 @@ export async function startJob(input, deps = {}) {
   //    asked for a specific model actually runs on it; omitted → the default.
   //
   //    BET-1220: the effective model passes through the subagent router
-  //    (chooseSubagentModel). With routing off (no modelRouting config) it
+  //    (chooseSubagentModel). With no routing directive in the policy it
   //    returns `incumbent` = the requested model / null, byte-identical to
   //    today. Routing must never break a spawn, so every input read (policy,
   //    quota, catalog) is individually guarded and the whole decision falls
@@ -795,11 +796,11 @@ export async function startJob(input, deps = {}) {
     } catch {
       cfg = {};
     }
-    let policy = { enabled: false };
+    let policy = {};
     try {
-      policy = cfg.modelRouting ?? { enabled: false };
+      policy = cfg.modelRouting ?? {};
     } catch {
-      policy = { enabled: false };
+      policy = {};
     }
     let quota = [];
     try {

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -528,7 +528,7 @@ test("startJob with no model calls deliver without a model key (BET-947 regressi
 
 test("startJob with routing off delivers the incumbent model byte-identical (BET-1220)", async () => {
   const h = startHarness("child_route_off");
-  h.deps.configGet = async () => ({}); // no modelRouter key → routing off
+  h.deps.configGet = async () => ({}); // no routing config → not activated
   h.deps.listSnapshots = () => [];
   h.deps.listModels = async () => mockModels();
   const res = await startJob(
@@ -555,7 +555,7 @@ test("startJob survives a throwing listSnapshots and delivers the incumbent (BET
   assert.deepEqual(h.delivered[0].model, { providerID: "anthropic", modelID: "claude-opus-4-5" });
 });
 
-test("chooseSubagentModel routes an explore agent to a fast-tier model when enabled (BET-1220)", () => {
+test("chooseSubagentModel routes an explore agent to a fast-tier model when the conversation activates routing (BET-1220)", () => {
   const catalog = [
     { providerID: "anthropic", id: "claude-opus-4", status: "active" },   // deep
     { providerID: "anthropic", id: "claude-haiku-4", status: "active" }, // fast
@@ -563,7 +563,7 @@ test("chooseSubagentModel routes an explore agent to a fast-tier model when enab
   const chosen = chooseSubagentModel({
     incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
     catalog,
-    policy: { enabled: true, preset: "economy" }, // economy + explore → fast tier
+    policy: { preset: "economy" }, // economy + explore → fast tier
     quota: [],
     agent: "explore",
     nowMs: 1_700_000_000_000,
@@ -585,7 +585,7 @@ test("startJob with routing on normalises the catalog winner to a {providerID, m
   // PINS THE CONFIG KEY BY NAME (BET-1227): routing reads `modelRouting`, the
   // key Settings writes. A rename here fails by construction, so this asserts
   // the key, not just the behaviour.
-  h.deps.configGet = async () => ({ modelRouting: { enabled: true, preset: "economy" } });
+  h.deps.configGet = async () => ({ modelRouting: { preset: "economy" } });
   h.deps.listSnapshots = () => [];
   h.deps.listModels = async () => [
     { providerID: "anthropic", id: "claude-opus-4", status: "active" },   // deep
@@ -608,9 +608,10 @@ test("startJob with routing on normalises the catalog winner to a {providerID, m
 
 test("startJob ignores the stale modelRouter key and delivers the incumbent (BET-1227)", async () => {
   const h = startHarness("child_stale_key");
-  // The wrong, never-written key must NOT enable routing — an enabled flag under
-  // `modelRouter` is inert, exactly as it has been on every box since shipping.
-  h.deps.configGet = async () => ({ modelRouter: { enabled: true, preset: "economy" } });
+  // The wrong, never-written key must NOT activate routing — a preset under
+  // `modelRouter` is inert (the wire key is `modelRouting`), exactly as it has
+  // been on every box since shipping.
+  h.deps.configGet = async () => ({ modelRouter: { preset: "economy" } });
   const res = await startJob(
     { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo",
       model: { providerID: "anthropic", modelID: "claude-opus-4" } },
@@ -618,7 +619,7 @@ test("startJob ignores the stale modelRouter key and delivers the incumbent (BET
   );
   assert.equal(res.ok, true);
   assert.equal(h.delivered.length, 1);
-  // routing stayed off → the requested model passes through byte-identical,
+  // routing not activated → the requested model passes through byte-identical,
   // proving we are NOT reading the stale `modelRouter` name.
   assert.deepEqual(h.delivered[0].model, { providerID: "anthropic", modelID: "claude-opus-4" });
 });
@@ -632,7 +633,7 @@ test("startJob routes only within the consent (sub) catalogue (BET-1229)", async
   // Routing on, and the user has deactivated every subagent model except
   // claude-opus-4 and gpt-5 (the "ticked" set).
   h.deps.configGet = async () => ({
-    modelRouting: { enabled: true, preset: "economy" },
+    modelRouting: { preset: "economy" },
     deactivatedSubagents: ["anthropic/claude-sonnet-4", "anthropic/claude-haiku-4"],
   });
   h.deps.listSnapshots = () => [];
@@ -663,17 +664,17 @@ test("chooseSubagentModel returns the incumbent on an off-path and is load-beari
     { providerID: "anthropic", id: "claude-opus-4", status: "active" },
     { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
   ];
-  // routing disabled → incumbent unchanged even though a cheaper fast model exists
+  // routing not activated (no preset) → incumbent unchanged even though a cheaper fast model exists
   assert.deepEqual(
-    chooseSubagentModel({ incumbent, catalog, policy: { enabled: false }, agent: "explore", nowMs: 0 }),
+    chooseSubagentModel({ incumbent, catalog, policy: {}, agent: "explore", nowMs: 0 }),
     incumbent,
   );
-  // an enabled router with no survivors (all dead) still falls back to incumbent
+  // an activated router with no survivors (all dead) still falls back to incumbent
   assert.deepEqual(
     chooseSubagentModel({
       incumbent,
       catalog: [{ providerID: "anthropic", id: "claude-opus-4", status: "retired" }],
-      policy: { enabled: true, preset: "economy" },
+      policy: { preset: "economy" },
       agent: "explore",
       nowMs: 0,
     }),
@@ -695,7 +696,7 @@ test("chooseMainModel returns the FULL decision — model, reason, incumbent —
   const decision = chooseMainModel({
     incumbent,
     catalog,
-    policy: { enabled: true, preset: "economy" }, // economy + build → balanced floor
+    policy: { preset: "economy" }, // economy + build → balanced floor
     quota: [],
     agent: "build",
     nowMs: 1_700_000_000_000,
@@ -716,16 +717,16 @@ test("chooseMainModel on the off-path returns the incumbent with changed:false, 
     { providerID: "anthropic", id: "claude-opus-4", status: "active" },
     { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
   ];
-  // routing disabled → no switch, even though a cheaper fast model exists
-  const off = chooseMainModel({ incumbent, catalog, policy: { enabled: false }, agent: "build", nowMs: 0 });
+  // routing not activated (no preset) → no switch, even though a cheaper fast model exists
+  const off = chooseMainModel({ incumbent, catalog, policy: {}, agent: "build", nowMs: 0 });
   assert.equal(off.changed, false);
   assert.deepEqual(off.model, incumbent);
-  assert.equal(off.reason, "routing is off");
-  // an enabled router with no survivors (all dead) still falls back to incumbent
+  assert.equal(off.reason, "routing not activated for this conversation");
+  // an activated router with no survivors (all dead) still falls back to incumbent
   const noSurvivors = chooseMainModel({
     incumbent,
     catalog: [{ providerID: "anthropic", id: "claude-opus-4", status: "retired" }],
-    policy: { enabled: true, preset: "economy" },
+    policy: { preset: "economy" },
     agent: "build",
     nowMs: 0,
   });
@@ -743,7 +744,7 @@ test("chooseMainModel when the router picks the same model reports changed:false
   const decision = chooseMainModel({
     incumbent,
     catalog,
-    policy: { enabled: true, preset: "performance" },
+    policy: { preset: "performance" },
     quota: [],
     agent: "build",
     nowMs: 0,

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -489,9 +489,10 @@ const delegateEngine = createDelegateEngine({
   listMessages: (sid) => oc.listMessages(sid),
   listModels: (overrides) => oc.listModels(overrides),
   // BET-1220: routing inputs for the subagent model decision in startJob.
-  // configGet supplies the modelRouter policy (absent on a box that has never
-  // seen the feature → routing stays off); listSnapshots supplies quota, and
-  // startJob guards both so they can never break a spawn.
+  // configGet supplies the modelRouting policy (absent on a conversation that
+  // has not asked to route → the spawn passes the incumbent through);
+  // listSnapshots supplies quota, and startJob guards both so they can never
+  // break a spawn.
   configGet: () => local.configGet(),
   listSnapshots,
   abortSession: (sid) => oc.abortSession(sid),

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -802,18 +802,18 @@ export function buildHandlers({
     // Returns the full decision { model, reason, incumbent, changed } so the
     // renderer can apply the routed model AND surface the undoable pill. Every
     // input is guarded — missing policy / quota / catalog must never throw and
-    // falls back to the incumbent (routing off by default).
+    // falls back to the incumbent (a conversation that did not ask to route).
     "routing:main": async (input) => {
       const incumbent = input?.incumbent ?? null;
       const agent = input?.agent ?? "build";
-      let policy = { enabled: false };
+      let policy = {};
       let quota = [];
       let catalog = [];
       try {
         const cfg = await local.configGet();
-        policy = cfg?.modelRouter ?? { enabled: false };
+        policy = cfg?.modelRouting ?? {};
       } catch {
-        policy = { enabled: false };
+        policy = {};
       }
       try {
         quota = usageListSnapshots();

--- a/src/shared/modelRouter.d.mts
+++ b/src/shared/modelRouter.d.mts
@@ -49,7 +49,7 @@ export interface ChooseInput {
   catalog?: Model[];
   telemetry?: Record<string, { tokensPerSec?: number; p50Ms?: number }>;
   quota?: QuotaWindow[];
-  policy?: { enabled?: boolean; preset?: string; perAgent?: Record<string, string> };
+  policy?: { preset?: string; perAgent?: Record<string, string> };
   nowMs?: number;
 }
 

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -187,6 +187,19 @@ function bindingReason(counts) {
   return CONSTRAINT_LABELS[best] ?? "constraints";
 }
 
+// Whether a policy asks the router to run at all. Routing is activated per
+// conversation, not by a global switch: the composer's model picker activates
+// it for a conversation by supplying a preset, and a per-agent override map can
+// pin specific tiers on top. The former global `enabled` field is gone
+// (BET-1243) — there is no box-wide off switch. An absent/empty policy (no
+// preset, no per-agent override) means the conversation did not ask to route.
+function routingActive(policy) {
+  if (typeof policy !== "object" || policy === null) return false;
+  if (typeof policy.preset === "string" && policy.preset.length > 0) return true;
+  const perAgent = policy.perAgent;
+  return !!perAgent && typeof perAgent === "object" && Object.keys(perAgent).length > 0;
+}
+
 // A single sentence naming the agent, the tier, and the binding factor.
 function explain({ agent, tierName, winner, quota, nowMs }) {
   const window = pickWindow(winner?.providerID, quota, nowMs);
@@ -207,7 +220,7 @@ function explain({ agent, tierName, winner, quota, nowMs }) {
  * @param {Array<object>} [input.catalog] - Model[] from opencode
  * @param {Record<string, { tokensPerSec?: number, p50Ms?: number }>} [input.telemetry]
  * @param {Array<object>} [input.quota] - UsageSnapshot[]
- * @param {{ enabled?: boolean, preset?: string, perAgent?: Record<string,string> }} [input.policy]
+ * @param {{ preset?: string, perAgent?: Record<string,string> }} [input.policy]
  * @param {number} [input.nowMs]
  * @returns {{ model: object|null, reason: string, alternatives: object[], changed: boolean }}
  */
@@ -226,8 +239,13 @@ export function chooseModel(input = {}) {
     };
   }
 
-  if (policy?.enabled !== true) {
-    return { model: incumbent, reason: "routing is off", alternatives: [], changed: false };
+  // Activation is per-conversation: routing runs only when this conversation
+  // supplied a routing directive — a preset the composer picker set, or a
+  // per-agent override. The former global on/off (`enabled`) is gone
+  // (BET-1243); "no preset" is a conversation that did not ask to route, not a
+  // box-wide off switch, so an empty policy returns the incumbent unchanged.
+  if (!routingActive(policy)) {
+    return { model: incumbent, reason: "routing not activated for this conversation", alternatives: [], changed: false };
   }
 
   const needs = intent?.needs ?? {};

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -140,7 +140,7 @@ describe("chooseModel", () => {
     const res = chooseModel({
       intent: { kind: "start", agent: "general" },
       catalog: [balanced, fast],
-      policy: { enabled: true, preset: "economy" },
+      policy: { preset: "economy" },
       nowMs: 0,
     });
     expect(AGENT_FLOOR.general).toBe("balanced");
@@ -160,7 +160,7 @@ describe("chooseModel", () => {
     const base = chooseModel({
       intent: { kind: "start", agent: "general", incumbent: m("claude-sonnet-4") },
       catalog,
-      policy: { enabled: true, preset: "balanced" },
+      policy: { preset: "balanced" },
       nowMs: 0,
     });
     for (let i = 0; i < 100; i++) {
@@ -168,7 +168,7 @@ describe("chooseModel", () => {
       const res = chooseModel({
         intent: { kind: "start", agent: "general", incumbent: m("claude-sonnet-4") },
         catalog: shuffled,
-        policy: { enabled: true, preset: "balanced" },
+        policy: { preset: "balanced" },
         nowMs: 0,
       });
       expect(res.model?.id).toBe(base.model?.id);
@@ -181,25 +181,25 @@ describe("chooseModel", () => {
       chooseModel({
         intent: { kind: "mid-exchange", agent: "general", incumbent },
         catalog: [m("claude-haiku-4")],
-        policy: { enabled: true, preset: "balanced" },
+        policy: { preset: "balanced" },
         nowMs: 0,
       }),
       chooseModel({
         intent: { kind: "start", agent: "general", incumbent },
         catalog: [m("claude-sonnet-4")],
-        policy: { enabled: false, preset: "balanced" },
+        policy: {},
         nowMs: 0,
       }),
       chooseModel({
         intent: { kind: "start", agent: "general", incumbent },
         catalog: [m("dead", { status: "retired" })],
-        policy: { enabled: true, preset: "balanced" },
+        policy: { preset: "balanced" },
         nowMs: 0,
       }),
       chooseModel({
         intent: { kind: "start", agent: "general" },
         catalog: [m("claude-sonnet-4")],
-        policy: { enabled: true, preset: "balanced" },
+        policy: { preset: "balanced" },
         nowMs: 0,
       }),
     ];
@@ -209,17 +209,33 @@ describe("chooseModel", () => {
     }
   });
 
-  it("returns the incumbent unchanged when routing is disabled", () => {
+  it("returns the incumbent unchanged when the conversation did not activate routing", () => {
     const incumbent = m("claude-sonnet-4");
     const res = chooseModel({
       intent: { kind: "start", agent: "general", incumbent },
       catalog: [m("claude-haiku-4")],
-      policy: { enabled: false },
+      policy: {},
       nowMs: 0,
     });
     expect(res.model).toBe(incumbent);
     expect(res.changed).toBe(false);
-    expect(res.reason).toBe("routing is off");
+    expect(res.reason).toBe("routing not activated for this conversation");
+  });
+
+  it("REGRESSION: routing activates from a preset alone, without any enabled flag (BET-1251)", () => {
+    // BET-1243 deleted the global `enabled` toggle; activation is per
+    // conversation via the composer's preset pick. A preset in the policy must
+    // be sufficient — no `enabled` field is consulted.
+    const cheap = m("claude-haiku-4"); // tier fast
+    const balanced = m("claude-sonnet-4"); // tier balanced
+    const res = chooseModel({
+      intent: { kind: "start", agent: "general", incumbent: m("claude-opus-4") },
+      catalog: [cheap, balanced],
+      policy: { preset: "economy" }, // no enabled key at all
+      nowMs: 0,
+    });
+    expect(res.model?.id).toBe("claude-sonnet-4");
+    expect(res.changed).toBe(true);
   });
 
   it("returns the incumbent when nothing survives filtering", () => {
@@ -227,7 +243,7 @@ describe("chooseModel", () => {
     const res = chooseModel({
       intent: { kind: "start", agent: "general", incumbent },
       catalog: [m("dead", { status: "retired" })],
-      policy: { enabled: true, preset: "balanced" },
+      policy: { preset: "balanced" },
       nowMs: 0,
     });
     expect(res.model).toBe(incumbent);
@@ -245,7 +261,7 @@ describe("chooseModel", () => {
     const res = chooseModel({
       intent: { kind: "mid-exchange", agent: "general", incumbent },
       catalog: [incumbent, cheap],
-      policy: { enabled: true, preset: "performance" },
+      policy: { preset: "performance" },
       nowMs: 0,
     });
     expect(res.model).toBe(incumbent);


### PR DESCRIPTION
## What & why

BET-1243 deleted the global `modelRouting.enabled` toggle from the config/UI/types, but the router still gated on `policy?.enabled === true` and `delegate.mjs` still hardcoded `{ enabled: false }` fallbacks. That left a dual source of truth: Settings can no longer express "routing off", yet the router/consumers still modeled a box-wide off switch — so a box with `modelRouting: { preset: "balanced" }` silently ignored the preset.

**Decision: `policy` no longer carries an `enabled` concept at all.** Routing is per-conversation; a policy activates routing by the presence of a routing directive — the `preset` the composer picker sets for a conversation, or a `perAgent` override. An absent/empty policy (no preset, no override) means the conversation did not ask to route → the router returns the incumbent unchanged, byte-identical to today. This is the "policy absent = per-conversation, not off" branch the epic left open.

- `modelRouter.mjs` — replaced the `enabled !== true` guard with `routingActive(policy)` (preset or non-empty perAgent present). Reason becomes "routing not activated for this conversation".
- `delegate.mjs` / `rpc.mjs` — dropped the `{ enabled: false }` fallbacks (`?? {}`). Also fixed a latent typo in the `routing:main` RPC which read `cfg?.modelRouter` (never-written key) instead of `cfg?.modelRouting` — that RPC never saw real config.
- `modelRouter.d.mts` — removed `enabled` from the `policy` type.
- Tests — updated all `{ enabled: true/false, ... }` policy fixtures to preset-based activation, plus a regression test asserting a preset alone (no `enabled` key) activates routing.

**Subagent spawns:** `delegate.mjs startJob` still builds policy from `cfg.modelRouting` (the box config) — deliberate, unchanged. A background delegate spawn is not a user conversation with its own picker, so the config preset is its routing signal; the per-session "Auto" activation for the *main* conversation is handled by sibling epic issues (BET-1245/46/48).

**Files changed:** 8
```
 src/renderer/ChatPanel.harness.test.tsx |  2 +-
 src/server/delegate.mjs                 | 27 +++----
 src/server/delegate.test.mjs            | 41 +++++++++----------
 src/server/index.mjs                    |  7 +--
 src/server/rpc.mjs                      |  8 +--
 src/shared/modelRouter.d.mts            |  2 +-
 src/shared/modelRouter.mjs              | 24 ++++++---
 src/shared/modelRouter.test.ts          | 40 ++++++++++----------
```

**Base: origin/main @ `afb2ad67`**

## Verification results
- PR branch (`multica/BET-1251-reconcile-policy-enabled` @ `807a518e`):
  - typecheck: exit 0, errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2602 pass / 0 fail / 0 skip. log sha256: `dabd52705fcb578735e2e69aa3c0a70b34abca31b8d8ce831ad61ce174be5a88`
- Base (`main` @ `afb2ad67`):
  - typecheck: exit 0, errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2602 pass / 0 fail / 0 skip. log sha256: `5837e2a72d2608f6d33905c642e1e48890618643001476f9e1f7e6b6bd20a1e1`
- **Conclusion:** 0 new failures, 0 pre-existing; both branches at 2602 pass. Logs cached at `/tmp/typecheck-{pr,main}.log`, `/tmp/test-{pr,main}.log`.
