### PR TITLE
BET-1233: routing marginalCost — price a subscription by pace, not its sunk list price

### DIFF
--- a/src/shared/marginalCost.d.mts
+++ b/src/shared/marginalCost.d.mts
@@ -1,0 +1,45 @@
+export const CREDIT_PREMIUM: number;
+export const CREDIT_DEPLETION_FLOOR: number;
+export const CREDIT_DEPLETION_SLOPE: number;
+export const CREDIT_DEPLETION_EPSILON: number;
+export const RESET_RAMP_MS: number;
+export const SUBSCRIPTION_PACE_EXPONENT: number;
+export const PACING_EPSILON: number;
+
+export interface WindowState {
+  kind?: string;
+  pct?: number;
+  startedAt?: number;
+  resetsAt?: number;
+  binding?: boolean;
+}
+
+export interface AccountState {
+  kind?: "subscription" | "credit" | "none" | string;
+  windows?: WindowState[];
+  balance?: number;
+  overagePrice?: number;
+  exhausted?: boolean;
+}
+
+export interface MargCostModel {
+  cost?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+}
+
+export interface MarginalCostResult {
+  cost: number;
+  exhausted: boolean;
+  basis: string;
+  reason: string;
+}
+
+export function depletionFactor(balance: number | undefined): number;
+
+export function marginalCost(input: {
+  model?: MargCostModel | null;
+  account?: AccountState | null;
+  nowMs?: number;
+  mix?: unknown;
+  reference?: unknown;
+  replacementCost?: number;
+}): MarginalCostResult;

--- a/src/shared/marginalCost.mjs
+++ b/src/shared/marginalCost.mjs
@@ -1,0 +1,217 @@
+// marginalCost.mjs — the expected $ cost of running one turn on an endpoint,
+// given the account that backs it, right now.
+//
+// Pure. No node:* imports, no Date.now(), no I/O. Time arrives as `nowMs`.
+// Provider-neutral: zero vendor names in the decision core.
+//
+// The frame is budget pacing, not a fill gauge. `effectivePrice` in
+// modelRouter.mjs takes a model's list price and *adds* a quota penalty — wrong
+// for both a subscription (the fee is already sunk; one more token costs a
+// marginal *zero*) and for credit (the cost is the opportunity cost of spending
+// it now, which is about consumed-vs-elapsed, not pct alone).
+
+import { blendedPrice } from "./blendedPrice.mjs";
+
+// --- Asymmetry: subscription < credit at equal scarcity ---------------------
+// A subscription's unused quota expires worthless; unused credit carries over
+// to the next billing period. So at equal scarcity a credit balance must cost
+// MORE than a subscription — otherwise routing drains the subscription first
+// and then still has the carried-over credit it could have spent later. This is
+// an explicit named constant, not an accident of curve shape: a test pins it.
+export const CREDIT_PREMIUM = 1.5;
+
+// --- Credit depletion curve -------------------------------------------------
+// `cost = blended * depletionFactor(balance)`. The factor rises as balance
+// approaches 0 (a nearly-empty credit balance is scarce — spending it now may
+// force a top-up). No balance reading → factor is exactly 1: no scarcity
+// signal, priced at its declared rate. "No reading" is never treated as plenty.
+export const CREDIT_DEPLETION_FLOOR = 1; // never below the declared rate
+export const CREDIT_DEPLETION_SLOPE = 5; // how fast cost climbs as balance drops
+export const CREDIT_DEPLETION_EPSILON = 1e-6; // keep the factor finite at balance → 0
+
+// --- Near-reset damping -----------------------------------------------------
+// A window whose remainder is about to expire is cheap — hoarding a balance
+// that resets in a few hours is pointless. `RESET_RAMP_MS` is the horizon over
+// which cost damps linearly to 0 as `resetsAt` approaches `nowMs`.
+export const RESET_RAMP_MS = 24 * 60 * 60 * 1000;
+
+// --- Subscription pace curve ------------------------------------------------
+// `subscriptionCost = exchangeRate * pace^k * resetDamp`. On pace (pace === 1)
+// the cost IS the exchange rate — that is the anchor. k > 1 makes over-pacing
+// climb steeply past the exchange rate while under-pacing falls toward 0.
+export const SUBSCRIPTION_PACE_EXPONENT = 2;
+
+export const PACING_EPSILON = 1e-9;
+
+function isNum(v) {
+  return typeof v === "number" && Number.isFinite(v);
+}
+
+function dollar(v) {
+  return isNum(v) ? Math.max(0, v) : 0;
+}
+
+function clamp01(v) {
+  return Math.min(1, Math.max(0, v));
+}
+
+/**
+ * The depletion multiplier for a credit balance. 1 when there is no reading —
+ * no scarcity signal, priced at the declared rate. Otherwise rises toward
+ * infinity as `balance` approaches 0 (see CREDIT_DEPLETION_SLOPE). Exported so
+ * the "no reading → factor 1" rule is usable and testable.
+ *
+ * @param {number|undefined} balance
+ * @returns {number}
+ */
+export function depletionFactor(balance) {
+  if (!isNum(balance)) return 1;
+  return CREDIT_DEPLETION_FLOOR + CREDIT_DEPLETION_SLOPE / Math.max(balance, CREDIT_DEPLETION_EPSILON);
+}
+
+// The low, exported fallback used when a window lacks elapsed data.
+function resetDamp(resetsAt, nowMs) {
+  if (!isNum(resetsAt) || !isNum(nowMs)) return 1;
+  const remaining = resetsAt - nowMs;
+  if (remaining <= 0) return 0;
+  return clamp01(remaining / RESET_RAMP_MS);
+}
+
+// Which figure anchors the subscription exchange rate, in priority order.
+function exchangeRateOf(account, model, mix, reference, replacementCost) {
+  if (isNum(account?.overagePrice)) {
+    return { rate: dollar(account.overagePrice), source: "published overage price" };
+  }
+  if (isNum(replacementCost)) {
+    return { rate: dollar(replacementCost), source: "replacement cost" };
+  }
+  return { rate: blendedPrice(model, mix, reference).price, source: "blended price" };
+}
+
+// One subscription window, priced by pace vs elapsed, damped near reset.
+function subscriptionWindowCost(win, rate, nowMs) {
+  const pct = isNum(win?.pct) ? Math.max(0, win.pct) : 0;
+  const consumed = pct / 100;
+  const startedAt = win?.startedAt;
+  const resetsAt = win?.resetsAt;
+
+  let pace;
+  let basis;
+  if (isNum(startedAt) && isNum(resetsAt) && resetsAt > startedAt) {
+    const span = resetsAt - startedAt || PACING_EPSILON;
+    const elapsed = clamp01((nowMs - startedAt) / span);
+    pace = consumed / Math.max(elapsed, PACING_EPSILON);
+    basis = "subscription-pace";
+  } else {
+    // No start time → cannot compute elapsed. Fall back to consumed alone
+    // (today's behaviour): a higher fill is scarcer. Do not guess a start time.
+    pace = consumed;
+    basis = "subscription-consumed";
+  }
+
+  const damp = resetDamp(resetsAt, nowMs);
+  const cost = dollar(rate) * Math.pow(pace, SUBSCRIPTION_PACE_EXPONENT) * damp;
+  return { cost, basis };
+}
+
+/**
+ * The expected $ cost of running one turn on this endpoint, right now.
+ *
+ * Exhausted endpoints are flagged `exhausted: true` (cost set to Infinity so a
+ * caller that forgets to check is still safe) — the caller EXCLUDES them; it
+ * does not price them high.
+ *
+ * @param {object} input
+ * @param {object} input.model      OpencodeModel (cost, providerID)
+ * @param {object} [input.account]  the provider's account state, or null when
+ *                                  unknown:
+ *   {
+ *     kind: "subscription" | "credit" | "none",
+ *     windows?: [{ kind, pct, startedAt, resetsAt, binding }],  // subscription
+ *     balance?: number,                                          // credit, may be negative
+ *     overagePrice?: number,                                     // $ per unit if published
+ *     exhausted?: boolean,
+ *   }
+ * @param {number} input.nowMs
+ * @param {object} [input.mix]          token mix for blendedPrice
+ * @param {object} [input.reference]    reference price for the implausible-zero rule
+ * @param {number} [input.replacementCost]  $ of the cheapest acceptable alternative
+ * @returns {{ cost: number, exhausted: boolean, basis: string, reason: string }}
+ */
+export function marginalCost(input = {}) {
+  const { model, account, nowMs = 0, mix, reference, replacementCost } = input || {};
+
+  // --- Exhausted first -------------------------------------------------------
+  const windows = Array.isArray(account?.windows) ? account.windows : [];
+  const exhausted =
+    account?.exhausted === true ||
+    (account?.kind === "credit" && isNum(account?.balance) && account.balance <= 0) ||
+    (account?.kind === "subscription" && windows.some((w) => isNum(w?.pct) && w.pct >= 100));
+
+  if (exhausted) {
+    return {
+      cost: Infinity,
+      exhausted: true,
+      basis: "exhausted",
+      reason: "endpoint is exhausted — excluded, not priced high",
+    };
+  }
+
+  // --- credit / none ---------------------------------------------------------
+  if (account?.kind === "credit" || account?.kind === "none") {
+    const blended = dollar(blendedPrice(model, mix, reference).price);
+    const factor = depletionFactor(account?.balance);
+    const premium = account?.kind === "credit" ? CREDIT_PREMIUM : 1;
+    const cost = blended * factor * premium;
+    const scarcity =
+      account?.kind === "credit"
+        ? isNum(account?.balance)
+          ? `depletion factor ${factor.toFixed(3)}`
+          : "no balance reading (factor 1)"
+        : "no account — declared rate";
+    const withPremium = account?.kind === "credit" ? `, credit premium ${CREDIT_PREMIUM}` : "";
+    return {
+      cost,
+      exhausted: false,
+      basis: account?.kind === "credit" ? (isNum(account?.balance) ? "credit-depletion" : "credit-flat") : "none",
+      reason: `credit/none: blended $${blended.toFixed(4)} (${scarcity})${withPremium}`,
+    };
+  }
+
+  // --- subscription ----------------------------------------------------------
+  if (account?.kind === "subscription") {
+    const { rate, source } = exchangeRateOf(account, model, mix, reference, replacementCost);
+    if (windows.length === 0) {
+      return {
+        cost: dollar(rate),
+        exhausted: false,
+        basis: "subscription-no-window",
+        reason: `subscription, no window data — priced at exchange rate (${source})`,
+      };
+    }
+    let best = 0;
+    let bestBasis = "subscription-pace";
+    for (const w of windows) {
+      const c = subscriptionWindowCost(w, rate, nowMs);
+      if (c.cost > best) {
+        best = c.cost;
+        bestBasis = c.basis;
+      }
+    }
+    return {
+      cost: dollar(best),
+      exhausted: false,
+      basis: bestBasis,
+      reason: `subscription priced by pace at exchange rate ${source}`,
+    };
+  }
+
+  // --- unknown / no account --------------------------------------------------
+  const blended = dollar(blendedPrice(model, mix, reference).price);
+  return {
+    cost: blended,
+    exhausted: false,
+    basis: "unknown",
+    reason: `no account state — priced at blended rate $${blended.toFixed(4)}`,
+  };
+}

--- a/src/shared/marginalCost.test.ts
+++ b/src/shared/marginalCost.test.ts
@@ -1,0 +1,186 @@
+import { describe, it, expect } from "vitest";
+import {
+  marginalCost,
+  depletionFactor,
+  CREDIT_PREMIUM,
+  RESET_RAMP_MS,
+} from "./marginalCost.mjs";
+import type { AccountState, MargCostModel } from "./marginalCost.mjs";
+
+// Every cost input/output rate here is 15, so the blended price is exactly
+// $15 / 1M regardless of mix (missing cache rates bill at the input rate).
+// That gives tests a clean, legible exchange-rate anchor.
+const MODEL: MargCostModel = { cost: { input: 15, output: 15 } };
+
+type Window = NonNullable<NonNullable<AccountState["windows"]>[number]>;
+
+function sub(win: Window | Window[]): AccountState {
+  const windows = Array.isArray(win) ? win : [win];
+  return { kind: "subscription", windows };
+}
+
+function w(pct: number, startedAt: number, resetsAt: number): Window {
+  return { pct, startedAt, resetsAt };
+}
+
+function credit(balance?: number): AccountState {
+  return balance === undefined ? { kind: "credit" } : { kind: "credit", balance };
+}
+
+// A window that is comfortably far from reset: `resetsAt - nowMs === RESET_RAMP_MS`,
+// so the near-reset damp is exactly 1 and does not interfere with pacing tests.
+const R = RESET_RAMP_MS;
+// nowMs is fixed at 0 for every pacing test; windows are positioned by their
+// start/reset times.
+
+const EXCHANGE = 15;
+
+describe("marginalCost — subscription pacing", () => {
+  it("under pace ≈ free: 20% consumed / 60% elapsed → far below the exchange rate", () => {
+    // elapsed 0.6, resetsAt = R (damp 1). pace = 0.2/0.6 = 0.333 → cost = 15 * 0.111.
+    const res = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(20, -1.5 * R, R)) });
+    expect(res.exhausted).toBe(false);
+    expect(res.cost).toBeGreaterThan(0);
+    expect(res.cost).toBeLessThan(EXCHANGE * 0.15); // ~1.67, vs exchange 15
+    expect(Number.isFinite(res.cost)).toBe(true);
+  });
+
+  it("pace, not fill: same pct at two different elapsed values → materially different costs", () => {
+    // pct 60 fixed. elapsed 0.2 → pace 3 (over); elapsed 0.6 → pace 1 (on pace).
+    const fast = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -0.25 * R, R)) });
+    const slow = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -1.5 * R, R)) });
+    // 15*9 = 135 vs 15*1 = 15 — a gauge reading pct alone would say they're equal.
+    expect(fast.cost).toBeGreaterThan(slow.cost * 5);
+    expect(slow.cost).toBeCloseTo(EXCHANGE, 3);
+  });
+
+  it("over pace rises: 80% consumed / 30% elapsed → above the exchange rate", () => {
+    // pace = 0.8/0.3 = 2.667 → cost = 15 * 7.11 ≈ 106.7.
+    const res = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(80, -0.4286 * R, R)) });
+    expect(res.cost).toBeGreaterThan(EXCHANGE);
+    expect(res.cost).toBeCloseTo(106.7, 1);
+  });
+
+  it("on pace = exchange rate, within tolerance", () => {
+    // pace = 0.6/0.6 = 1 → cost is exactly the exchange rate (15).
+    const res = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -1.5 * R, R)) });
+    expect(res.cost).toBeCloseTo(EXCHANGE, 5);
+  });
+
+  it("binding window wins: the scarcer of two windows determines the result", () => {
+    // Window 1: pace 0.5 → 3.75. Window 2: pace 2.667 → 106.7 (the binding one).
+    const res = marginalCost({
+      model: MODEL,
+      nowMs: 0,
+      account: sub([w(30, -1.5 * R, R), w(80, -0.4286 * R, R)]),
+    });
+    expect(res.exhausted).toBe(false);
+    expect(res.cost).toBeCloseTo(106.7, 1);
+  });
+
+  it("near reset is cheap: same pace, resetsAt imminent → cheaper", () => {
+    // Both pace 1 (consumed 0.5 / elapsed 0.5). Far window: damp 1 → 15.
+    // Near window: resetsAt = 0.1R → damp 0.1 → 1.5. Same pace, same fill.
+    const far = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(50, -1 * R, R)) });
+    const near = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(50, -0.1 * R, 0.1 * R)) });
+    expect(near.cost).toBeLessThan(far.cost);
+    expect(far.cost).toBeCloseTo(EXCHANGE, 3);
+    expect(near.cost).toBeCloseTo(EXCHANGE * 0.1, 3);
+  });
+
+  it("startedAt missing → falls back to consumed alone and says so in basis", () => {
+    const res = marginalCost({
+      model: MODEL,
+      nowMs: 0,
+      account: {
+        kind: "subscription",
+        windows: [{ pct: 50, resetsAt: R }], // no startedAt
+      },
+    });
+    expect(res.basis).toBe("subscription-consumed");
+    // consumed 0.5, treated as pace → 15 * 0.25 = 3.75 (damp 1).
+    expect(res.cost).toBeCloseTo(EXCHANGE * 0.25, 3);
+  });
+});
+
+describe("marginalCost — credit", () => {
+  it("depleting credit rises: balance 100 → 10 → 1 is monotonically more expensive", () => {
+    const c100 = marginalCost({ model: MODEL, nowMs: 0, account: credit(100) });
+    const c10 = marginalCost({ model: MODEL, nowMs: 0, account: credit(10) });
+    const c1 = marginalCost({ model: MODEL, nowMs: 0, account: credit(1) });
+    expect(c1.cost).toBeGreaterThan(c10.cost);
+    expect(c10.cost).toBeGreaterThan(c100.cost);
+    expect(Number.isFinite(c1.cost)).toBe(true);
+  });
+
+  it("no balance reading → factor 1, priced at its declared rate", () => {
+    expect(depletionFactor(undefined)).toBe(1);
+    const res = marginalCost({ model: MODEL, nowMs: 0, account: credit() });
+    expect(res.cost).toBeCloseTo(EXCHANGE * CREDIT_PREMIUM, 5); // blended × premium, no depletion
+    // rank independence: unrelated inputs (replacementCost is subscription-only)
+    // must not move the credit cost.
+    const withUnrelated = marginalCost({ model: MODEL, nowMs: 0, account: credit(), replacementCost: 999 });
+    expect(withUnrelated.cost).toBeCloseTo(res.cost, 10);
+  });
+
+  it("a negative balance is overdrawn, not a small positive number", () => {
+    const negative = marginalCost({ model: MODEL, nowMs: 0, account: credit(-0.57) });
+    const tinyPositive = marginalCost({ model: MODEL, nowMs: 0, account: credit(0.01) });
+    expect(negative.exhausted).toBe(true);
+    expect(negative.cost).toBe(Infinity);
+    expect(tinyPositive.exhausted).toBe(false);
+    expect(tinyPositive.cost).toBeLessThan(Infinity);
+  });
+});
+
+describe("marginalCost — the asymmetry (subscription < credit at equal scarcity)", () => {
+  it("at equal scarcity a subscription costs less than a credit balance, every time", () => {
+    // Subscription on-pace (pace 1) = exchange rate 15.
+    const subRes = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -1.5 * R, R)) });
+    expect(subRes.cost).toBeCloseTo(EXCHANGE, 5);
+
+    // A credit balance, even one at unit depletion (huge balance), must cost more.
+    for (const balance of [1e9, 100, 10, 1, 0.5]) {
+      const creditRes = marginalCost({ model: MODEL, nowMs: 0, account: credit(balance) });
+      expect(creditRes.exhausted).toBe(false);
+      expect(subRes.cost).toBeLessThan(creditRes.cost);
+    }
+
+    // At matching neutral scarcity the gap is exactly the named premium — this
+    // pins CREDIT_PREMIUM as the mechanism, not an accident of curve shape.
+    const neutralCredit = marginalCost({ model: MODEL, nowMs: 0, account: credit(1e9) });
+    expect(neutralCredit.cost / subRes.cost).toBeCloseTo(CREDIT_PREMIUM, 5);
+  });
+});
+
+describe("marginalCost — exhausted first", () => {
+  it("each exhausted signal returns exhausted:true and cost Infinity", () => {
+    const byFlag = marginalCost({ model: MODEL, nowMs: 0, account: { kind: "credit", balance: 50, exhausted: true } });
+    const byPct = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(100, -1.5 * R, R)) });
+    const byZero = marginalCost({ model: MODEL, nowMs: 0, account: credit(0) });
+    const byNegative = marginalCost({ model: MODEL, nowMs: 0, account: credit(-0.57) });
+
+    for (const res of [byFlag, byPct, byZero, byNegative]) {
+      expect(res.exhausted).toBe(true);
+      expect(res.cost).toBe(Infinity);
+      expect(res.basis).toBe("exhausted");
+    }
+  });
+
+  it("every non-exhausted return is finite and ≥ 0; Infinity appears only on exhaustion", () => {
+    const cases = [
+      marginalCost({ model: MODEL, nowMs: 0, account: sub(w(20, -1.5 * R, R)) }),
+      marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -1.5 * R, R)) }),
+      marginalCost({ model: MODEL, nowMs: 0, account: sub(w(80, -0.4286 * R, R)) }),
+      marginalCost({ model: MODEL, nowMs: 0, account: credit(10) }),
+      marginalCost({ model: MODEL, nowMs: 0, account: credit() }),
+      marginalCost({ model: MODEL, nowMs: 0, account: { kind: "none" } }),
+      marginalCost({ model: MODEL, nowMs: 0, account: null }),
+    ];
+    for (const res of cases) {
+      expect(res.exhausted).toBe(false);
+      expect(res.cost).toBeGreaterThanOrEqual(0);
+      expect(Number.isFinite(res.cost)).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## BET-1233 — marginalCost: price a subscription by pace, not its sunk list price

Stage 2 of Automatic Manta Routing. Pure module + tests only — no wiring.

### What

Adds `src/shared/marginalCost.mjs` (+ `.d.mts`) — the expected **$ cost of running one
turn on an endpoint right now**, given the account that backs it. Pure, time injected
(`nowMs`), no `node:` / no `Date.now()`, no provider names in the decision core.

- **Exhausted first** → `exhausted: true`, `cost: Infinity` (caller excludes, never prices
  high). Triggered by `exhausted: true`, a subscription window at `pct >= 100`, or a credit
  `balance <= 0`.
- **credit / none** → the `blendedPrice` (reused from BET-1231), × an exported credit
  depletion factor (`CREDIT_DEPLETION_*`) that rises as balance → 0. No balance reading →
  factor exactly `1` (declared rate, never "plenty").
- **subscription** → the list price is **not** used. Per window: `consumed = pct/100`,
  `elapsed`, `pace = consumed / elapsed`. On pace (`pace === 1`) the cost **is** the
  exchange rate (the anchor). Under pace ramps toward 0, over pace rises steeply past it
  (`SUBSCRIPTION_PACE_EXPONENT`). The most scarce (max cost) window binds. Near `resetsAt`
  the cost dams toward 0 over a principled `RESET_RAMP_MS` horizon. Missing `startedAt` →
  falls back to consumed alone, flagged in `basis`.
- Exchange rate = `overagePrice` → `replacementCost` → blended price, commented in `reason`.
- **Asymmetry** (`CREDIT_PREMIUM`): unused subscription quota expires worthless, unused
  credit carries over — so at equal scarcity credit is explicitly more expensive than
  subscription, via a named constant (tested), not an accident of curve shape.

Does **not** touch `modelRouter.mjs` (the router restructure issue deletes `scarcity` /
`effectivePrice` there). Imports only `blendedPrice`.

### Tests — `src/shared/marginalCost.test.ts` (13 new, all load-bearing)

Under pace ≈ free · **pace-not-fill (same pct, different elapsed ⇒ materially different)** ·
over pace rises · on pace = exchange rate · binding window wins · near reset cheap ·
startedAt-missing fallback · depleting credit rises · no reading → factor 1 (rank-independent)
· negative balance is overdrawn, not small-positive · asymmetry pinned to `CREDIT_PREMIUM` ·
exhausted-first (4 signals) · finite/≥0 meta-check.

### Verification results

**Files changed:** 3 (`src/shared/marginalCost.mjs`, `.d.mts`, `marginalCost.test.ts`), +448.

- PR branch (`multica/BET-1233-marginal-cost` @ `8944d0a5`):
  - typecheck: exit 0, errors none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 3396 pass / 0 fail / 7 skip. log sha256: `9c0479a13c2c4ab0e49e7621044d9b117cd8051f295bf0c30902b38b6216c95a`
- Base (`main` @ `afb2ad67`):
  - typecheck: exit 0, errors none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 3383 pass / 0 fail / 7 skip. log sha256: `450d36f71734b117907f64679bec5b593cab843a6c8a7dfff9b3abdd44638711`
- **Conclusion:** 0 new failures; +13 passing tests added by this PR. Base and PR typecheck logs are byte-identical.

**Base:** origin/main @ `afb2ad67`

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
