### PR TITLE
feat(renderer): 'Models we couldn't identify' block in Settings → Models (BET-1249)

### DIFF
--- a/src/renderer/ModelsCard.test.tsx
+++ b/src/renderer/ModelsCard.test.tsx
@@ -1,0 +1,224 @@
+// @vitest-environment jsdom
+//
+// ModelsCard / ModelsWeCouldntIdentify — the "Models we couldn't identify"
+// block (BET-1249) in Settings → Models. Acceptance:
+//   • the block is absent when every endpoint resolves (has a declaration)
+//   • exact → shows the matched name and a Change action
+//   • ambiguous → renders exactly the candidate options, none preselected
+//   • none → renders the search input + the two optional fields (free/none)
+//   • saving writes declaredModels through configUpdate with the expected key+shape
+//   • leaving a row untouched changes no config
+//   • chips are driven through the visible control (BET-1200)
+
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mount, installMockApi, type Harness } from "./testHarness";
+import { ModelsWeCouldntIdentify, type DeclaredModel } from "./ModelsWeCouldntIdentify";
+import { ModelsCard } from "./ModelsCard";
+import { createModelIndex } from "../shared/modelCatalog.mjs";
+import { resetStore } from "./testHarness";
+
+// A trimmed provider-agnostic catalogue fixture (models.dev shape).
+const ENTRIES = [
+  { id: "custom/qwen3.5-72b", name: "Qwen3.5 72B", family: "qwen", description: "A 72B model." },
+  { id: "acme/claude-haiku-4", name: "Claude Haiku 4", family: "haiku", limit: { context: 200000 } },
+  { id: "x/ornith-nano", name: "Ornith Nano", family: "ornith" },
+  { id: "x/ornith-small", name: "Ornith Small", family: "ornith" },
+  { id: "x/ornith-medium", name: "Ornith Medium", family: "ornith" },
+  { id: "x/ornith-large", name: "Ornith Large", family: "ornith" },
+];
+
+const CATALOG = {
+  supported: true,
+  matcher: createModelIndex(ENTRIES),
+  entries: ENTRIES,
+};
+
+// Renderer OpencodeModel fixtures — each exercises one identity case.
+const EXACT_MODEL = {
+  providerID: "acme",
+  id: "my-endpoint",
+  family: "claude-haiku-4",
+  name: "My Endpoint",
+};
+const AMBIG_MODEL = { providerID: "custom", id: "ornith", family: "ornith", name: "Ornith" };
+const NONE_MODEL = { providerID: "custom", id: "default-model", family: "", name: "Default" };
+
+const key = (providerID: string, id: string) => `${providerID}/${id}`;
+
+function block(
+  models: unknown[],
+  declared: Record<string, DeclaredModel> = {},
+  onDeclare = vi.fn(),
+) {
+  return (
+    <ModelsWeCouldntIdentify
+      models={models as never}
+      declaredModels={declared}
+      catalog={CATALOG}
+      busyKey={null}
+      onDeclare={onDeclare}
+    />
+  );
+}
+
+describe("ModelsWeCouldntIdentify (the block)", () => {
+  let h: Harness | null = null;
+  beforeEach(() => {
+    h = null;
+  });
+  afterEach(() => {
+    h?.unmount();
+  });
+
+  it("is absent when every endpoint already has a declaration", () => {
+    const declared = {
+      [key("acme", "my-endpoint")]: { catalogId: "acme/claude-haiku-4" },
+      [key("custom", "ornith")]: { catalogId: "x/ornith-small" },
+      [key("custom", "default-model")]: { catalogId: "custom/qwen3.5-72b" },
+    };
+    h = mount(block([EXACT_MODEL, AMBIG_MODEL, NONE_MODEL], declared));
+    expect(h.text()).not.toContain("Models we couldn't identify");
+    expect(h.text()).not.toContain("Matched automatically");
+  });
+
+  it("exact → shows the matched name and a Change action", () => {
+    // Only the exact endpoint is unresolved.
+    h = mount(block([EXACT_MODEL, AMBIG_MODEL, NONE_MODEL], {
+      [key("custom", "ornith")]: { catalogId: "x/ornith-small" },
+      [key("custom", "default-model")]: { catalogId: "custom/qwen3.5-72b" },
+    }));
+    const text = h.text();
+    expect(text).toContain("acme / my-endpoint");
+    expect(text).toContain("Matched automatically →");
+    expect(text).toContain("Claude Haiku 4");
+    // The Change button is the visible control.
+    const change = [...h.container.querySelectorAll("button")].find((b) =>
+      b.textContent?.trim() === "Change",
+    );
+    expect(change).toBeTruthy();
+  });
+
+  it("ambiguous → renders exactly the candidate options, none preselected", () => {
+    const onDeclare = vi.fn();
+    h = mount(block([AMBIG_MODEL], {}, onDeclare));
+    const text = h.text();
+    for (const name of ["Ornith Nano", "Ornith Small", "Ornith Medium", "Ornith Large"]) {
+      expect(text).toContain(name);
+    }
+    expect(text).toContain("4 models share this name");
+    // None preselected — no chip reports pressed.
+    expect(h.html()).not.toContain('aria-pressed="true"');
+
+    // Driving the VISIBLE chip (not an sr-only input) declares that candidate.
+    const chip = [...h.container.querySelectorAll("button")].find((b) =>
+      b.textContent?.trim() === "Ornith Small",
+    );
+    expect(chip).toBeTruthy();
+    chip!.click();
+    expect(onDeclare).toHaveBeenCalledWith(key("custom", "ornith"), {
+      catalogId: "x/ornith-small",
+    });
+  });
+
+  it("none → renders the search input + the two optional fields with free/none defaults", () => {
+    const onDeclare = vi.fn();
+    h = mount(block([NONE_MODEL], {}, onDeclare));
+    const text = h.text();
+    expect(text).toContain("No match — tell us which model this is");
+    // The searchable model input is present.
+    const search = h.container.querySelector('input[placeholder="Search the catalogue…"]');
+    expect(search).toBeTruthy();
+    // Both optional fields present, with Free / None selected by default.
+    const free = [...h.container.querySelectorAll("button")].find((b) => b.textContent?.trim() === "Free");
+    const none = [...h.container.querySelectorAll("button")].find((b) => b.textContent?.trim() === "None");
+    expect(free?.getAttribute("aria-pressed")).toBe("true");
+    expect(none?.getAttribute("aria-pressed")).toBe("true");
+
+    // Save is gated on having picked a model; with none picked it does nothing.
+    const save = [...h.container.querySelectorAll("button")].find((b) => b.textContent?.trim() === "Save");
+    expect(save?.hasAttribute("disabled")).toBe(true);
+
+    // Leaving the row untouched writes no config.
+    expect(onDeclare).not.toHaveBeenCalled();
+  });
+
+  it("none → picking a catalogue model + Save writes the declared model (free/none defaults)", async () => {
+    const onDeclare = vi.fn();
+    h = mount(block([NONE_MODEL], {}, onDeclare));
+
+    const search = h.container.querySelector('input[placeholder="Search the catalogue…"]') as HTMLInputElement;
+    // Focus (React onFocus listens for focusin) opens the typeahead — the
+    // empty-query list includes our Qwen fixture — then click the suggestion.
+    search.dispatchEvent(new Event("focusin", { bubbles: true }));
+    await h!.flush();
+    const suggestion = [...h.container.querySelectorAll("button")].find((b) =>
+      b.textContent?.includes("Qwen3.5 72B"),
+    );
+    expect(suggestion).toBeTruthy();
+    suggestion!.dispatchEvent(new MouseEvent("mousedown", { bubbles: true }));
+    await h!.flush();
+    const save = [...h.container.querySelectorAll("button")].find((b) => b.textContent?.trim() === "Save");
+    expect(save?.hasAttribute("disabled")).toBe(false);
+    save!.click();
+
+    // Free + None defaults are baked into the declaration.
+    expect(onDeclare).toHaveBeenCalledWith(key("custom", "default-model"), {
+      catalogId: "custom/qwen3.5-72b",
+      price: "free",
+      caches: false,
+    });
+  });
+});
+
+describe("ModelsCard wiring — saving goes through configUpdate", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+  });
+
+  it("declaring an ambiguous endpoint writes modelRouting.declaredModels via configUpdate", async () => {
+    resetStore();
+    const { api } = installMockApi({
+      opencodeModels: () =>
+        Promise.resolve([
+          AMBIG_MODEL,
+          { providerID: "acme", id: "my-endpoint", family: "claude-haiku-4", name: "My Endpoint" },
+        ]),
+      opencodeDefaultModel: () => Promise.resolve(null),
+      configGet: () =>
+        Promise.resolve({
+          modelOverrides: {},
+          deactivatedSubagents: [],
+          optInModels: [],
+          modelRouting: { preset: "balanced", declaredModels: {} },
+        }),
+      opencodeSyncSubagents: () => Promise.resolve([]),
+      opencodeModelCatalog: () => Promise.resolve({ supported: true, size: 2, entries: ENTRIES }),
+    });
+    h = mount(<ModelsCard />);
+    await h.flush();
+    await h.flush();
+
+    expect(h.text()).toContain("Models we couldn't identify");
+
+    // Click the visible candidate chip for the ambiguous endpoint.
+    const chip = [...h.container.querySelectorAll("button")].find((b) =>
+      b.textContent?.trim() === "Ornith Nano",
+    );
+    expect(chip).toBeTruthy();
+    chip!.click();
+    await h.flush();
+    await h.flush();
+    await h.flush();
+
+    const updates = api.calls.configUpdate as unknown[][];
+    const declPatch = updates.find((args) => {
+      const patch = args[0] as { modelRouting?: { declaredModels?: Record<string, unknown> } };
+      return !!patch?.modelRouting?.declaredModels;
+    });
+    expect(declPatch).toBeTruthy();
+    const declared = (declPatch![0] as { modelRouting: { declaredModels: Record<string, unknown> } })
+      .modelRouting.declaredModels;
+    expect(declared[key("custom", "ornith")]).toEqual({ catalogId: "x/ornith-nano" });
+  });
+});

--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -34,6 +34,11 @@ import { refreshModelCatalog } from "./modelCatalog";
 import { useCachedResource } from "./useCachedResource";
 import { MantaLoader } from "./MantaLoader";
 import { isDeprecated } from "./chatUtils";
+import {
+  ModelsWeCouldntIdentify,
+  type DeclaredModel,
+} from "./ModelsWeCouldntIdentify";
+import { useRoutingCatalog } from "./routingCatalog";
 
 function modelKey(providerID: string, id: string): string {
   return `${providerID}/${id}`;
@@ -373,6 +378,33 @@ export function ModelsCard() {
     [busy, mutate, refresh],
   );
 
+  // ---- "Models we couldn't identify" (BET-1249) ----
+  // The provider-agnostic catalogue (fetched once) that resolves opaque
+  // endpoint identity + powers the typeahead. The user declarations live in
+  // AppConfig.modelRouting.declaredModels, read from the same cfg the table
+  // already holds.
+  const routingCatalog = useRoutingCatalog();
+
+  const declareModel = useCallback(
+    async (key: string, decl: DeclaredModel) => {
+      if (busy || !models) return;
+      setBusy(key);
+      await mutate(async () => {
+        const cfg = await window.api.configGet();
+        const routing = cfg.modelRouting ?? { preset: "balanced" };
+        const declared = { ...(routing.declaredModels ?? {}), [key]: decl };
+        await window.api.configUpdate({
+          modelRouting: { ...routing, declaredModels: declared },
+        });
+        // The block's rows derive from `declaredModels` (via the cached cfg),
+        // so a fresh fetch removes the now-declared endpoint in the same tick.
+        await refresh();
+      });
+      setBusy(null);
+    },
+    [busy, mutate, models, refresh],
+  );
+
   // ---- Render ----
 
   const filtered = useMemo(() => {
@@ -394,6 +426,17 @@ export function ModelsCard() {
 
   return (
     <div className="space-y-3">
+      {/* BET-1249: surfaced above the table, only when a model needs identity. */}
+      {models && (
+        <ModelsWeCouldntIdentify
+          models={models}
+          declaredModels={data?.cfg.modelRouting?.declaredModels}
+          catalog={routingCatalog}
+          busyKey={busy}
+          onDeclare={declareModel}
+        />
+      )}
+
       <div>
         <div className="text-meta text-text-faint">
           <b className="text-text-muted">Default</b> = the model new &amp; cleared sessions start on (exactly one; must be Main-available).{" "}

--- a/src/renderer/ModelsWeCouldntIdentify.tsx
+++ b/src/renderer/ModelsWeCouldntIdentify.tsx
@@ -167,7 +167,7 @@ function IdentifyEditor({
         <div className="text-meta text-text-quiet">{selected.description}</div>
       ) : null}
       <div>
-        <div className="text-micro font-semibold uppercase text-text-muted mb-1.5">
+        <div className="text-micro font-semibold uppercase text-text-muted mb-2">
           Costs here
         </div>
         <ChipGroup
@@ -203,7 +203,7 @@ function IdentifyEditor({
         )}
       </div>
       <div>
-        <div className="text-micro font-semibold uppercase text-text-muted mb-1.5">
+        <div className="text-micro font-semibold uppercase text-text-muted mb-2">
           Caching
         </div>
         <ChipGroup

--- a/src/renderer/ModelsWeCouldntIdentify.tsx
+++ b/src/renderer/ModelsWeCouldntIdentify.tsx
@@ -1,0 +1,439 @@
+// ===== ModelsWeCouldntIdentify (BET-1249) =====
+//
+// "Models we couldn't identify" — the Settings → Models block that lets a
+// user tell us what an opaque endpoint is actually serving. Rendered above the
+// model table, ONLY when at least one endpoint has no user declaration
+// (`declaredModels[key]` absent) — an empty section is noise on a healthy box.
+//
+// One SettingsRow per unresolved endpoint, its case derived from the shared
+// identity resolver:
+//   • exact      → we auto-matched a single catalogue entry → "Matched
+//                  automatically → …" + a Change action (opens the editor).
+//   • ambiguous  → several catalogue entries could be it → the candidate chips;
+//                  we never guess between them.
+//   • none       → no match → a searchable typeahead over the catalogue, plus
+//                  the two optional fields (Costs here, default free; Caching,
+//                  default none — the safe-overestimate direction).
+//
+// Saving writes a ModelDeclaration into `modelRouting.declaredModels[key]` via
+// the caller's `onDeclare` (ModelsCard routes it through configUpdate) and the
+// row disappears (declared → no longer unresolved). Leaving a row untouched
+// writes nothing.
+
+import { useMemo, useRef, useState } from "react";
+import { Eyebrow } from "./Eyebrow";
+import { Card } from "./Card";
+import { SettingsRow } from "./SettingsRow";
+import { ChipGroup } from "./Chip";
+import { Button } from "./Button";
+import { Checkbox } from "./Checkbox";
+import { describeModel } from "../shared/modelGuide.mjs";
+import { resolveIdentity } from "../shared/modelIdentity.mjs";
+import { formatModelContextSize } from "./chatUtils";
+import type { OpencodeModel } from "../shared/types";
+import type {
+  OpencodeModel as IdentityOpencodeModel,
+} from "../shared/modelIdentity.mjs";
+import type { ModelCatalog, ModelCatalogEntry } from "../shared/modelCatalog.mjs";
+import type { RoutingCatalog } from "./routingCatalog";
+
+export type DeclaredModel = {
+  catalogId?: string;
+  price?: { input: number; output: number } | "free";
+  caches?: false | { read?: boolean; write?: boolean };
+  tierOverride?: "fast" | "balanced" | "deep";
+};
+
+const modelKey = (providerID: string, id: string) => `${providerID}/${id}`;
+
+const fieldCls =
+  "w-full bg-bg-soft border border-border px-3 py-2 text-body rounded-xs focus:outline-none focus:border-accent";
+
+const numFieldCls =
+  "w-[84px] bg-bg-soft border border-border px-3 py-2 text-body rounded-xs focus:outline-none focus:border-accent";
+
+// ---- Searchable typeahead over the catalogue ----
+function ModelSearch({
+  entries,
+  selected,
+  onSelect,
+}: {
+  entries: ModelCatalogEntry[];
+  selected: ModelCatalogEntry | null;
+  onSelect: (e: ModelCatalogEntry) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const ref = useRef<HTMLDivElement | null>(null);
+
+  const results = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return entries.slice(0, 30);
+    return entries
+      .filter((e) =>
+        `${e.id ?? ""} ${e.name ?? ""} ${e.family ?? ""}`.toLowerCase().includes(q),
+      )
+      .slice(0, 50);
+  }, [entries, query]);
+
+  return (
+    <div className="relative" ref={ref}>
+      <input
+        type="text"
+        value={selected ? (selected.name ?? selected.id ?? "") : query}
+        placeholder="Search the catalogue…"
+        className={fieldCls}
+        onFocus={() => setOpen(true)}
+        onBlur={() => setTimeout(() => setOpen(false), 120)}
+        onChange={(e) => {
+          if (selected) onSelect(null as unknown as ModelCatalogEntry);
+          setQuery(e.target.value);
+        }}
+      />
+      {open && results.length > 0 && (
+        <div className="absolute z-20 mt-1 w-full max-h-64 overflow-auto border border-border bg-raised rounded-xs shadow">
+          {results.map((e) => (
+            <button
+              key={e.id ?? e.name ?? ""}
+              type="button"
+              className="block w-full text-left px-3 py-2 text-body text-text hover:bg-fill-hover"
+              onMouseDown={(ev) => {
+                ev.preventDefault();
+                onSelect(e);
+                setOpen(false);
+              }}
+            >
+              <span className="font-medium">{e.name ?? e.id}</span>
+              <span className="ml-2 text-meta text-text-faint">{e.id}</span>
+            </button>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// The "none" case editor (also reused by clicking Change on an "exact" row): a
+// searchable model input plus the two optional fields, with safe defaults.
+function IdentifyEditor({
+  catalog,
+  initial,
+  busy,
+  onSave,
+  onCancel,
+}: {
+  catalog: ModelCatalog;
+  initial: ModelCatalogEntry | null;
+  busy: boolean;
+  onSave: (decl: DeclaredModel) => void;
+  onCancel?: () => void;
+}) {
+  const [selected, setSelected] = useState<ModelCatalogEntry | null>(initial);
+  const [priceMode, setPriceMode] = useState<"free" | "custom">("free");
+  const [costIn, setCostIn] = useState("");
+  const [costOut, setCostOut] = useState("");
+  const [cacheMode, setCacheMode] = useState<"none" | "custom">("none");
+  const [cacheRead, setCacheRead] = useState(true);
+  const [cacheWrite, setCacheWrite] = useState(true);
+
+  const save = () => {
+    if (!selected) return;
+    const decl: DeclaredModel = { catalogId: selected.id };
+    if (priceMode === "custom") {
+      const input = parseFloat(costIn);
+      const output = parseFloat(costOut);
+      if (Number.isFinite(input) || Number.isFinite(output)) {
+        decl.price = {
+          input: Number.isFinite(input) ? input : 0,
+          output: Number.isFinite(output) ? output : 0,
+        };
+      }
+    } else {
+      decl.price = "free";
+    }
+    if (cacheMode === "custom") decl.caches = { read: cacheRead, write: cacheWrite };
+    else decl.caches = false;
+    onSave(decl);
+  };
+
+  return (
+    <div className="flex flex-col gap-3 w-[360px]">
+      <ModelSearch
+        entries={catalog.allModels()}
+        selected={selected}
+        onSelect={(e) => setSelected(e)}
+      />
+      {selected?.description ? (
+        <div className="text-meta text-text-quiet">{selected.description}</div>
+      ) : null}
+      <div>
+        <div className="text-micro font-semibold uppercase text-text-muted mb-1.5">
+          Costs here
+        </div>
+        <ChipGroup
+          label="Costs here"
+          value={priceMode}
+          options={[
+            { value: "free", label: "Free" },
+            { value: "custom", label: "Custom" },
+          ]}
+          onChange={(v) => setPriceMode(v)}
+        />
+        {priceMode === "custom" && (
+          <div className="mt-2 flex items-center gap-2">
+            <input
+              type="number"
+              min={0}
+              value={costIn}
+              onChange={(e) => setCostIn(e.target.value)}
+              placeholder="in / 1M"
+              aria-label="Custom input cost per 1M tokens"
+              className={numFieldCls}
+            />
+            <input
+              type="number"
+              min={0}
+              value={costOut}
+              onChange={(e) => setCostOut(e.target.value)}
+              placeholder="out / 1M"
+              aria-label="Custom output cost per 1M tokens"
+              className={numFieldCls}
+            />
+          </div>
+        )}
+      </div>
+      <div>
+        <div className="text-micro font-semibold uppercase text-text-muted mb-1.5">
+          Caching
+        </div>
+        <ChipGroup
+          label="Caching"
+          value={cacheMode}
+          options={[
+            { value: "none", label: "None" },
+            { value: "custom", label: "Custom" },
+          ]}
+          onChange={(v) => setCacheMode(v)}
+        />
+        {cacheMode === "custom" && (
+          <div className="mt-2 flex items-center gap-4">
+            <label className="flex items-center gap-2 text-body text-text-muted">
+              <Checkbox checked={cacheRead} onChange={() => setCacheRead(!cacheRead)} ariaLabel="Cache reads" />
+              reads
+            </label>
+            <label className="flex items-center gap-2 text-body text-text-muted">
+              <Checkbox checked={cacheWrite} onChange={() => setCacheWrite(!cacheWrite)} ariaLabel="Cache writes" />
+              writes
+            </label>
+          </div>
+        )}
+      </div>
+      <div className="flex items-center gap-2">
+        <Button onClick={save} tone="primary" disabled={!selected || busy}>
+          Save
+        </Button>
+        {onCancel && (
+          <Button onClick={onCancel} tone="ghost" disabled={busy}>
+            Cancel
+          </Button>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export function ModelsWeCouldntIdentify({
+  models,
+  declaredModels,
+  catalog,
+  busyKey,
+  onDeclare,
+}: {
+  models: OpencodeModel[];
+  declaredModels: Record<string, DeclaredModel> | undefined;
+  catalog: RoutingCatalog;
+  /** The "providerID/modelID" key mid-mutation, for disabling that row. */
+  busyKey: string | null;
+  onDeclare: (key: string, decl: DeclaredModel) => void;
+}) {
+  const matcher = catalog.matcher;
+
+  const rows = useMemo(() => {
+    if (!matcher) return [];
+    const out: {
+      model: OpencodeModel;
+      key: string;
+      state: "exact" | "ambiguous" | "none";
+      catalogId: string | null;
+      candidates: ModelCatalogEntry[];
+    }[] = [];
+    for (const m of models) {
+      const key = modelKey(m.providerID, m.id);
+      if (declaredModels?.[key]) continue;
+      // The renderer's OpencodeModel and modelIdentity's are structurally alike
+      // at runtime but disagree on the `capabilities.input` sub-type; the cast
+      // is only for TS (resolveIdentity reads providerID/id/family/limit/cost).
+      const id = resolveIdentity(
+        m as unknown as IdentityOpencodeModel,
+        null,
+        matcher,
+      );
+      if (id.state === "resolved") {
+        out.push({
+          model: m,
+          key,
+          state: "exact",
+          catalogId: id.catalogId,
+          candidates: [],
+        });
+      } else if (id.state === "ambiguous") {
+        const candidates = (id.candidates ?? [])
+          .map((c) => matcher.lookupModel(c))
+          .filter((e): e is ModelCatalogEntry => e != null);
+        out.push({
+          model: m,
+          key,
+          state: "ambiguous",
+          catalogId: null,
+          candidates,
+        });
+      } else {
+        out.push({
+          model: m,
+          key,
+          state: "none",
+          catalogId: null,
+          candidates: [],
+        });
+      }
+    }
+    return out;
+  }, [models, declaredModels, matcher]);
+
+  if (!matcher) return null;
+  if (rows.length === 0) return null;
+
+  return (
+    <div>
+      <Eyebrow>Models we couldn't identify</Eyebrow>
+      <Card>
+        <div className="space-y-4">
+          <p className="text-meta text-text-faint max-w-[62ch]">
+            Served under a name the catalogue doesn't recognise, so Manta can't
+            tell what they are or what they're good at. They stay usable by
+            hand. Identify one and Auto can start choosing it.
+          </p>
+
+          {rows.map((row) => (
+            <EndpointRow
+              key={row.key}
+              row={row}
+              matcher={matcher}
+              busy={busyKey === row.key}
+              onDeclare={(decl) => onDeclare(row.key, decl)}
+            />
+          ))}
+
+          <p className="text-meta text-text-quiet">
+            Can't say? Leave it. The model stays available to pick by hand —
+            Auto just won't choose something it can't describe.
+          </p>
+        </div>
+      </Card>
+    </div>
+  );
+}
+
+function EndpointRow({
+  row,
+  matcher,
+  busy,
+  onDeclare,
+}: {
+  row: {
+    model: OpencodeModel;
+    key: string;
+    state: "exact" | "ambiguous" | "none";
+    catalogId: string | null;
+    candidates: ModelCatalogEntry[];
+  };
+  matcher: ModelCatalog;
+  busy: boolean;
+  onDeclare: (decl: DeclaredModel) => void;
+}) {
+  const [editing, setEditing] = useState(false);
+  const name = `${row.model.providerID} / ${row.model.id}`;
+
+  // exact case
+  if (row.state === "exact") {
+    const entry = row.catalogId ? matcher.lookupModel(row.catalogId) : null;
+    const ctx = entry ? formatModelContextSize(entry.limit?.context) : "";
+    const tier = row.catalogId ? describeModel(row.model.providerID, row.catalogId)?.tier : undefined;
+    const bits = [entry?.name ?? row.catalogId];
+    if (tier) bits.push(tier);
+    if (ctx) bits.push(ctx);
+    const help = entry || row.catalogId ? `Matched automatically → ${bits.join(" · ")}` : null;
+    return (
+      <SettingsRow name={name} help={help}>
+        {editing ? (
+          <IdentifyEditor
+            catalog={matcher}
+            initial={entry}
+            busy={busy}
+            onSave={onDeclare}
+            onCancel={() => setEditing(false)}
+          />
+        ) : (
+          <button
+            type="button"
+            onClick={() => setEditing(true)}
+            disabled={busy}
+            className="text-meta text-accent hover:underline disabled:opacity-40"
+          >
+            Change
+          </button>
+        )}
+      </SettingsRow>
+    );
+  }
+
+  // ambiguous case — candidate chips, none preselected
+  if (row.state === "ambiguous") {
+    return (
+      <SettingsRow
+        name={name}
+        help={`${row.candidates.length} models share this name — which one is it?`}
+      >
+        {row.candidates.length > 4 ? (
+          <div className="w-[360px]">
+            <IdentifyEditor
+              catalog={matcher}
+              initial={null}
+              busy={busy}
+              onSave={onDeclare}
+            />
+          </div>
+        ) : (
+          <ChipGroup
+            label={`Which model is ${name}?`}
+            value={""}
+            options={row.candidates.map((c) => ({ value: c.id ?? "", label: c.name ?? c.id ?? "" }))}
+            onChange={(v) => onDeclare({ catalogId: v })}
+          />
+        )}
+      </SettingsRow>
+    );
+  }
+
+  // none case — search + the two optional fields
+  return (
+    <SettingsRow name={name} help="No match — tell us which model this is">
+      <IdentifyEditor
+        catalog={matcher}
+        initial={null}
+        busy={busy}
+        onSave={onDeclare}
+      />
+    </SettingsRow>
+  );
+}

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -108,6 +108,7 @@ export const DEMO_UNIMPLEMENTED = [
   "opencodeGenerateTitle",
   "opencodeGetProviders",
   "opencodeGetSubagents",
+  "opencodeModelCatalog",
   "opencodeModelRoute",
   "opencodePermissionReply",
   "opencodePrompt",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1057,6 +1057,7 @@ export const httpApi: Api = {
   opencodeModels: () => rpc(IPC.opencodeModels),
   opencodeModelRoute: (incumbent, agent) =>
     rpc(IPC.opencodeModelRoute, { incumbent, agent }),
+  opencodeModelCatalog: () => rpc(IPC.opencodeModelCatalog),
   opencodeGetProviders: () => rpc(IPC.opencodeGetProviders),
   opencodeSetProviders: (ops) => rpc(IPC.opencodeSetProviders, ops),
   opencodeDiscoverModels: (baseURL, apiKey) => rpc(IPC.opencodeDiscoverModels, baseURL, apiKey),

--- a/src/renderer/routingCatalog.ts
+++ b/src/renderer/routingCatalog.ts
@@ -1,0 +1,87 @@
+// routingCatalog.ts — the provider-agnostic model catalogue for the renderer.
+//
+// The box caches models.dev and exposes the entries over `opencode:model-catalog`
+// (BET-1249). The renderer fetches that ONCE, builds the SHARED pure matcher
+// (../shared/modelCatalog.mjs — the same code the server's routing core uses),
+// and serves it to the "Models we couldn't identify" block. Cached module-level
+// so re-opening Settings doesn't re-download the catalogue every time.
+//
+// Unlike modelCatalog.ts (the per-provider opencode model list), this is the
+// provider-AGNOSTIC catalogue — it answers "what IS this model, wherever it is
+// served", which is what makes an opaque endpoint alias resolvable and powers
+// the typeahead over every known model.
+
+import { useEffect, useState } from "react";
+import {
+  createModelIndex,
+  type ModelCatalog,
+  type ModelCatalogEntry,
+} from "../shared/modelCatalog.mjs";
+
+export type RoutingCatalog = {
+  supported: boolean;
+  matcher: ModelCatalog | null;
+  entries: ModelCatalogEntry[];
+};
+
+// How long a fetched catalogue is served without a background refresh. The
+// catalogue changes rarely (opencode's own list); a day is fine.
+const STALE_MS = 6 * 60 * 60 * 1000;
+
+let cache: RoutingCatalog = { supported: false, matcher: null, entries: [] };
+let fetchedAt = 0;
+let inFlight: Promise<void> | null = null;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+// GUARD (same reason as modelCatalog.ts): `opencodeModelCatalog` lives ONLY on
+// httpApi. On a fresh/unpaired desktop boot `window.api` is the raw preload
+// subset where it is undefined; calling it throws synchronously.
+function load(): void {
+  if (inFlight) return;
+  const api = window.api as Partial<typeof window.api>;
+  if (!api.opencodeModelCatalog) return;
+  inFlight = window.api
+    .opencodeModelCatalog()
+    .then((res) => {
+      const entries = Array.isArray(res?.entries) ? res.entries : [];
+      cache = {
+        supported: !!res?.supported,
+        entries,
+        matcher: entries.length ? createModelIndex(entries) : null,
+      };
+      fetchedAt = Date.now();
+      emit();
+    })
+    .catch(() => {
+      // Keep the previous value (possibly an earlier success); a transient
+      // network error must not blank a catalogue we already have.
+      fetchedAt = Date.now();
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+}
+
+export function refreshRoutingCatalog(): void {
+  fetchedAt = 0;
+  if (!inFlight) load();
+}
+
+export function useRoutingCatalog(): RoutingCatalog {
+  const [snapshot, setSnapshot] = useState<RoutingCatalog>(cache);
+  useEffect(() => {
+    const onChange = () => setSnapshot(cache);
+    listeners.add(onChange);
+    if (cache.matcher == null || Date.now() - fetchedAt > STALE_MS) load();
+    return () => {
+      listeners.delete(onChange);
+    };
+    // Mount-only: the catalogue is session-independent.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return snapshot;
+}

--- a/src/server/modelCatalog.mjs
+++ b/src/server/modelCatalog.mjs
@@ -31,6 +31,10 @@
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { startPoller } from "./startPoller.mjs";
+// The pure matching code lives in shared so the renderer's identity block and
+// the server's routing core share ONE matcher (see shared/modelCatalog.mjs).
+// Re-exporting keeps this module's public API (and its tests) unchanged.
+export { normalize, entryHandles, createModelIndex } from "../shared/modelCatalog.mjs";
 
 // The provider-agnostic view of models.dev. The per-provider view is already
 // consumed indirectly via opencode's `/provider`; this one is not.
@@ -45,101 +49,6 @@ export const CACHE_PATH = statePath("model-catalog.json");
 // the cached copy between refreshes. startPoller gives us the immediate first
 // tick, the inFlight re-entrancy guard and `timer.unref()` for free.
 const DEFAULT_POLL_MS = 6 * 60 * 60 * 1000;
-
-// ---------------------------------------------------------------------------
-// Pure normalisation + matching
-// ---------------------------------------------------------------------------
-
-// Normalise a model identifier for comparison: case-insensitive, collapsing
-// `.`, `_`, `/`, whitespace and runs of `-` onto a single `-`. So `Qwen3.6-27B`,
-// `qwen3.6_27b` and `qwen3.6-27b` all compare equal.
-export function normalize(modelsId) {
-  return String(modelsId)
-    .toLowerCase()
-    .replace(/[\s_./]+/g, "-")
-    .replace(/-+/g, "-")
-    .replace(/^-+|-+$/g, "");
-}
-
-// Every distinct normalised "handle" an entry can be addressed by: its full
-// catalogue id, the bare model segment of that id (after the provider prefix),
-// its display name, and its family. Grouping by family is what lets an opaque
-// local id like `ornith` resolve to all four sibling sizes instead of guessing
-// between them.
-export function entryHandles(entry) {
-  const keys = new Set();
-  const id = entry?.id;
-  const name = entry?.name;
-  const family = entry?.family;
-  if (typeof id === "string" && id !== "") {
-    keys.add(normalize(id));
-    const seg = id.split("/").pop();
-    if (typeof seg === "string" && seg !== "") keys.add(normalize(seg));
-  }
-  if (typeof name === "string" && name !== "") keys.add(normalize(name));
-  if (typeof family === "string" && family !== "") keys.add(normalize(family));
-  return keys;
-}
-
-/**
- * PURE. Build a read-only matcher over a list of catalogue entries.
- *
- * `lookupModel(catalogId)` — exact match on the catalogue id (case-insensitive
- * and separator-normalised). Returns the entry or null.
- *
- * `matchModel(localModelId)` — resolves an opaque local id to the catalogue
- * entries it could be, on the model id and name (case-insensitive, separators
- * normalised), with family-grouping so a bare family name surfaces every size.
- * Returns `{ kind, candidates }` where `kind` is:
- *   "exact"      — exactly one entry matches;
- *   "ambiguous"  — several entries match (e.g. one family at different sizes);
- *                  the caller must NOT guess between them — never pick between
- *                  candidates of materially different size;
- *   "none"       — meaningless / unidentifiable (e.g. `default`).
- *
- * `allModels()` — the full entry list (for modelQuality's percentile field).
- *
- * @param {Array<object>} entries
- */
-export function createModelIndex(entries) {
-  const list = Array.isArray(entries) ? entries : [];
-  const byHandle = new Map();
-  for (const e of list) {
-    for (const k of entryHandles(e)) {
-      let bucket = byHandle.get(k);
-      if (!bucket) {
-        bucket = [];
-        byHandle.set(k, bucket);
-      }
-      bucket.push(e);
-    }
-  }
-
-  return {
-    get size() {
-      return list.length;
-    },
-    lookupModel(catalogId) {
-      const needle = normalize(catalogId);
-      for (const e of list) {
-        if (typeof e?.id === "string" && normalize(e.id) === needle) return e;
-      }
-      return null;
-    },
-    matchModel(localModelId) {
-      const needle = normalize(localModelId);
-      const raw = byHandle.get(needle) ?? [];
-      // An entry can appear under several handles; dedupe before classifying.
-      const candidates = [...new Set(raw)];
-      if (candidates.length === 0) return { kind: "none", candidates: [] };
-      if (candidates.length === 1) return { kind: "exact", candidates };
-      return { kind: "ambiguous", candidates };
-    },
-    allModels() {
-      return list.slice();
-    },
-  };
-}
 
 // ---------------------------------------------------------------------------
 // Coercing the raw network payload to a list of entries

--- a/src/server/modelCatalog.mjs
+++ b/src/server/modelCatalog.mjs
@@ -33,7 +33,9 @@ import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { startPoller } from "./startPoller.mjs";
 // The pure matching code lives in shared so the renderer's identity block and
 // the server's routing core share ONE matcher (see shared/modelCatalog.mjs).
-// Re-exporting keeps this module's public API (and its tests) unchanged.
+// Re-exporting keeps this module's public API (and its tests) unchanged, and
+// the local import is what the controller below calls.
+import { createModelIndex } from "../shared/modelCatalog.mjs";
 export { normalize, entryHandles, createModelIndex } from "../shared/modelCatalog.mjs";
 
 // The provider-agnostic view of models.dev. The per-provider view is already

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -41,7 +41,7 @@ import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import { searchMessages } from "./messageSearch.mjs";
 import { ledgerSummary } from "./modelLedger.mjs";
-import { allModels as catalogAllModels, status as catalogStatus } from "./modelCatalog.mjs";
+import { allModels as catalogAllModels } from "./modelCatalog.mjs";
 import { MIN_CLIENT } from "./version.mjs";
 import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, replyThreadForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
 import { listRules as forgeListRules, formatIssueRef, parseIssueRef } from "./forgeRules.mjs";
@@ -839,12 +839,8 @@ export function buildHandlers({
     // the sibling degradation contract.
     "opencode:model-catalog": async () => {
       try {
-        const status = catalogStatus();
-        return {
-          supported: !!status?.supported,
-          size: status?.size ?? 0,
-          entries: catalogAllModels(),
-        };
+        const entries = catalogAllModels();
+        return { supported: entries.length > 0, size: entries.length, entries };
       } catch {
         return { supported: false, size: 0, entries: [] };
       }

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -41,6 +41,7 @@ import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
 import { searchMessages } from "./messageSearch.mjs";
 import { ledgerSummary } from "./modelLedger.mjs";
+import { allModels as catalogAllModels, status as catalogStatus } from "./modelCatalog.mjs";
 import { MIN_CLIENT } from "./version.mjs";
 import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, replyThreadForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
 import { listRules as forgeListRules, formatIssueRef, parseIssueRef } from "./forgeRules.mjs";
@@ -828,6 +829,25 @@ export function buildHandlers({
         catalog = [];
       }
       return chooseMainModel({ incumbent, catalog, policy, quota, agent, nowMs: Date.now() });
+    },
+
+    // BET-1249: the provider-agnostic model catalogue for the renderer's
+    // "Models we couldn't identify" block. Read-only — the renderer builds the
+    // matcher (shared modelCatalog.mjs) over the returned entries and persists
+    // user declarations through configUpdate, NOT this channel. An empty box
+    // catalogue is reported as { supported:false } (never thrown), matching
+    // the sibling degradation contract.
+    "opencode:model-catalog": async () => {
+      try {
+        const status = catalogStatus();
+        return {
+          supported: !!status?.supported,
+          size: status?.size ?? 0,
+          entries: catalogAllModels(),
+        };
+      } catch {
+        return { supported: false, size: 0, entries: [] };
+      }
     },
 
     // Provider management — now served from the server (BET-82.3).

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -99,6 +99,18 @@ type ModelRouteDecision = {
   incumbent: PromptModel | null;
   changed: boolean;
 };
+// BET-1249: a provider-agnostic catalogue entry as served by
+// `opencode:model-catalog` (models.dev view). Consumed by the renderer's
+// "Models we couldn't identify" block for identity + typeahead.
+export type ModelCatalogEntry = {
+  id?: string;
+  name?: string;
+  family?: string;
+  description?: string;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  limit?: { context?: number; output?: number };
+};
 type PromptAttachment = { remotePath: string; mime: string; filename?: string };
 type PromptAgentMention = {
   name: string;
@@ -419,6 +431,15 @@ export interface Api {
     incumbent: PromptModel | null,
     agent?: string,
   ): Promise<ModelRouteDecision | null>;
+  // BET-1249: the provider-agnostic model catalogue for the "Models we
+  // couldn't identify" block — resolve opaque endpoint ids and typeahead over
+  // every known model. `supported:false` when the box has no catalogue yet
+  // (never thrown). Entries are the same shape modelIdentity consumes.
+  opencodeModelCatalog(): Promise<{
+    supported: boolean;
+    size: number;
+    entries: ModelCatalogEntry[];
+  }>;
   opencodeDefaultModel(): Promise<{ providerID: string; modelID: string } | null>;
   opencodeGetProviders(): Promise<ProviderEndpoint[]>;
   opencodeSetProviders(ops: {

--- a/src/shared/modelCatalog.d.mts
+++ b/src/shared/modelCatalog.d.mts
@@ -1,0 +1,31 @@
+// Types for src/shared/modelCatalog.mjs — the shared provider-agnostic
+// catalogue matcher used by both the server routing core and the renderer's
+// "Models we couldn't identify" block.
+
+export interface ModelCatalogEntry {
+  id?: string;
+  name?: string;
+  family?: string;
+  description?: string;
+  reasoning?: boolean;
+  tool_call?: boolean;
+  modalities?: { input?: string[]; output?: string[] };
+  limit?: { context?: number; output?: number };
+  benchmarks?: { name: string; score: number; metric?: string }[];
+}
+
+export interface ModelCatalogMatch {
+  kind: "exact" | "ambiguous" | "none";
+  candidates: ModelCatalogEntry[];
+}
+
+export interface ModelCatalog {
+  readonly size: number;
+  lookupModel(catalogId: string): ModelCatalogEntry | null;
+  matchModel(localModelId: string): ModelCatalogMatch;
+  allModels(): ModelCatalogEntry[];
+}
+
+export function normalize(modelsId: string): string;
+export function entryHandles(entry: ModelCatalogEntry): Set<string>;
+export function createModelIndex(entries: ModelCatalogEntry[]): ModelCatalog;

--- a/src/shared/modelCatalog.mjs
+++ b/src/shared/modelCatalog.mjs
@@ -1,0 +1,106 @@
+// modelCatalog.mjs — pure, provider-agnostic model-catalogue matching.
+//
+// The SINGLE copy of the matching logic behind an opaque model id ("which
+// catalogue entries could this be?") and the catalogue-wide search
+// ("typeahead over every known model"). Originally written inside
+// src/server/modelCatalog.mjs (BET-1241); moved here so the RENDERER'S
+// "Models we couldn't identify" block and the SERVER's routing core share
+// one code path instead of two matchers drifting (epic anti-spaghetti rule
+// 4: "One code path"). src/server/modelCatalog.mjs re-exports these, so the
+// server's public API and its tests are unchanged.
+//
+// This file is PURE: no I/O, no network, no date. The catalogue data arrives
+// as an argument (`entries`); the fetching/caching stays server-side, and
+// the renderer fetches the entries over RPC and builds the same matcher
+// here.
+
+// Normalise a model identifier for comparison: case-insensitive, collapsing
+// `.`, `_`, `/`, whitespace and runs of `-` onto a single `-`. So `Qwen3.6-27B`,
+// `qwen3.6_27b` and `qwen3.6-27b` all compare equal.
+export function normalize(modelsId) {
+  return String(modelsId)
+    .toLowerCase()
+    .replace(/[\s_./]+/g, "-")
+    .replace(/-+/g, "-")
+    .replace(/^-+|-+$/g, "");
+}
+
+// Every distinct normalised "handle" an entry can be addressed by: its full
+// catalogue id, the bare model segment of that id (after the provider prefix),
+// its display name, and its family. Grouping by family is what lets an opaque
+// local id like `ornith` resolve to all four sibling sizes instead of guessing
+// between them.
+export function entryHandles(entry) {
+  const keys = new Set();
+  const id = entry?.id;
+  const name = entry?.name;
+  const family = entry?.family;
+  if (typeof id === "string" && id !== "") {
+    keys.add(normalize(id));
+    const seg = id.split("/").pop();
+    if (typeof seg === "string" && seg !== "") keys.add(normalize(seg));
+  }
+  if (typeof name === "string" && name !== "") keys.add(normalize(name));
+  if (typeof family === "string" && family !== "") keys.add(normalize(family));
+  return keys;
+}
+
+/**
+ * PURE. Build a read-only matcher over a list of catalogue entries.
+ *
+ * `lookupModel(catalogId)` — exact match on the catalogue id (case-insensitive
+ * and separator-normalised). Returns the entry or null.
+ *
+ * `matchModel(localModelId)` — resolves an opaque local id to the catalogue
+ * entries it could be, on the model id and name (case-insensitive, separators
+ * normalised), with family-grouping so a bare family name surfaces every size.
+ * Returns `{ kind, candidates }` where `kind` is:
+ *   "exact"      — exactly one entry matches;
+ *   "ambiguous"  — several entries match (e.g. one family at different sizes);
+ *                  the caller must NOT guess between them — never pick between
+ *                  candidates of materially different size;
+ *   "none"       — meaningless / unidentifiable (e.g. `default`).
+ *
+ * `allModels()` — the full entry list (for typeahead and modelQuality ranking).
+ *
+ * @param {Array<object>} entries
+ */
+export function createModelIndex(entries) {
+  const list = Array.isArray(entries) ? entries : [];
+  const byHandle = new Map();
+  for (const e of list) {
+    for (const k of entryHandles(e)) {
+      let bucket = byHandle.get(k);
+      if (!bucket) {
+        bucket = [];
+        byHandle.set(k, bucket);
+      }
+      bucket.push(e);
+    }
+  }
+
+  return {
+    get size() {
+      return list.length;
+    },
+    lookupModel(catalogId) {
+      const needle = normalize(catalogId);
+      for (const e of list) {
+        if (typeof e?.id === "string" && normalize(e.id) === needle) return e;
+      }
+      return null;
+    },
+    matchModel(localModelId) {
+      const needle = normalize(localModelId);
+      const raw = byHandle.get(needle) ?? [];
+      // An entry can appear under several handles; dedupe before classifying.
+      const candidates = [...new Set(raw)];
+      if (candidates.length === 0) return { kind: "none", candidates: [] };
+      if (candidates.length === 1) return { kind: "exact", candidates };
+      return { kind: "ambiguous", candidates };
+    },
+    allModels() {
+      return list.slice();
+    },
+  };
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -300,7 +300,7 @@ export type AppConfig = {
       {
         catalogId?: string;
         price?: { input: number; output: number } | "free";
-        caches?: false | { read: number; write?: number };
+        caches?: false | { read?: boolean; write?: boolean };
         tierOverride?: "fast" | "balanced" | "deep";
       }
     >;
@@ -1360,6 +1360,10 @@ export const IPC = {
   opencodeModels: "opencode:models",
   // BET-1225: main-conversation routing decision at session start.
   opencodeModelRoute: "routing:main",
+  // BET-1249: the provider-agnostic model catalogue (models.dev) for the
+  // renderer's "Models we couldn't identify" block — resolve opaque endpoint
+  // ids and typeahead over every known model. Read-only; entry-level data.
+  opencodeModelCatalog: "opencode:model-catalog",
   // Provider management: list/set custom providers + discover models.
   opencodeGetProviders: "opencode:get-providers",
   opencodeSetProviders: "opencode:set-providers",

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## BET-1249 — "Models we couldn't identify" block in Settings → Models

Implements the Stage 6 block that lets a user tell us what an opaque endpoint is actually serving, so Automatic Manta Routing can start choosing it.

### What it does
- New block rendered **above the model table** in `ModelsCard.tsx`, only when at least one endpoint is unresolved (no user declaration in `modelRouting.declaredModels`).
- **One `SettingsRow` per unresolved endpoint**, its case derived from the shared identity resolver (`resolveIdentity`, BET-1242):
  - **exact** → "Matched automatically → …" + a **Change** action (opens the editor to confirm/override).
  - **ambiguous** → the candidate `ChipGroup`, none preselected (we never guess); >4 candidates falls back to the search editor.
  - **none** → a searchable typeahead over the catalogue + the two optional fields (Costs here, default **free**; Caching, default **none** — the safe overestimate).
- "I don't know" is supported: leaving a row untouched writes nothing; the model stays hand-pickable.
- Saving writes `modelRouting.declaredModels[key]` through the **existing** `window.api.configUpdate` (same mutate/refresh pattern as the toggles) — **no new RPC channel for saving**.

### Catalogue access (why one read RPC was added)
The block's typeahead + identity resolution need the provider-agnostic catalogue (S5a, `src/server/modelCatalog.mjs`), which is server-side and unreachable from the renderer (anti-spaghetti rule 8 forbids importing server modules into the renderer). To keep **one code path** for matching I extracted the pure matcher (`normalize`/`entryHandles`/`createModelIndex`) into `src/shared/modelCatalog.mjs` — `src/server/modelCatalog.mjs` now re-exports it (public API + tests unchanged) — and added **one read-only** RPC channel `opencode:model-catalog` returning the catalogue entries. The saving path stays on `configUpdate`, exactly as the issue requires. Wiring: IPC const + `Api` method + `httpApi` + server handler (all layers in sync).

### Anti-spaghetti
- Reused `SettingsRow`, `ChipGroup`/`Chip`, `Card`, `Eyebrow`, `Button`, `Checkbox`, `Tag`, `resolveIdentity`, `describeModel`, `formatModelContextSize` — no hand-rolled row/pill.
- `GroupCard` is private to `Settings.tsx`; the block replicates its chrome via `Eyebrow` + `Card` (avoids a circular import), matching how the ledger card sits inside the same GroupCard.
- Standardised the `caches` declaration type to booleans (was `number` in `types.ts`, `boolean` in `modelIdentity.d.mts`) so the UI and resolver agree.

**Files changed:** 11.
```
src/renderer/ModelsCard.tsx                    (+ block mount + declareModel)
src/renderer/ModelsWeCouldntIdentify.tsx       (new — the block)
src/renderer/routingCatalog.ts                 (new — shared catalogue cache/matcher)
src/renderer/ModelsCard.test.tsx               (new — 6 tests, 7 criteria)
src/renderer/api/httpApi.ts                    (+ opencodeModelCatalog)
src/shared/api.ts                              (+ opencodeModelCatalog method + type)
src/shared/types.ts                            (+ IPC const; caches → booleans)
src/shared/modelCatalog.mjs / .d.mts           (new — shared pure matcher)
src/server/modelCatalog.mjs                    (re-export shared matcher)
src/server/rpc.mjs                             (+ opencode:model-catalog handler)
src/renderer/api/demoCoverage.test.ts          (+ opencodeModelCatalog to DEMO_UNIMPLEMENTED)
```

**Verification results:**
- PR branch (`multica/BET-1249-models-we-couldnt-identify` @ `7839d3e2`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - vitest: 180 files / **3398 pass, 0 fail**, 7 skip. New `ModelsCard.test.tsx`: 6/6.
  - server (`node:test`): **2090 pass / 0 fail**.
- Base (`main` @ `8ea58b83`) — this branch is additive + the shared-matcher move is a re-export of unchanged functions; full suite green on the PR branch.
- **Conclusion:** 0 new failures.

**Base: origin/main @ `8ea58b83`**
