### PR TITLE
feat(shared): restructure modelRouter around endpoints with hard/soft stages (BET-1236)

### DIFF
--- a/src/renderer/ModelRoutingCard.tsx
+++ b/src/renderer/ModelRoutingCard.tsx
@@ -6,13 +6,15 @@
 // — a warn-toned notice when a window is nearly spent, a neutral one-liner
 // otherwise.
 //
-// Tiers are READ from the pure router module (`AGENT_TIER` / `AGENT_FLOOR`),
-// never hardcoded here, so the card and the router cannot drift. Plan usage is
-// the SAME state the composer's usage dial reads (`store.usage`) — no second
-// fetch, no second percentage bar (the bar IS `UsageWindowRow`, reused).
+// Tiers are READ from the pure router module (`AGENT_TIER`) and the quality
+// floors from `modelQuality` (`AGENT_FLOOR_SCORE`), never hardcoded here, so
+// the card and the router cannot drift. Plan usage is the SAME state the
+// composer's usage dial reads (`store.usage`) — no second fetch, no second
+// percentage bar (the bar IS `UsageWindowRow`, reused).
 
 import { useState } from "react";
-import { AGENT_FLOOR, AGENT_TIER } from "../shared/modelRouter.mjs";
+import { AGENT_TIER } from "../shared/modelRouter.mjs";
+import { AGENT_FLOOR_SCORE, tierForScore } from "../shared/modelQuality.mjs";
 import { tierRank } from "../shared/modelGuide.mjs";
 import { useStore } from "./store";
 import { Card } from "./Card";
@@ -35,7 +37,7 @@ const AGENT_ROWS: { agent: string; sub: string }[] = [
 // target computation (modelRouter.mjs) so the card never lies about a floor.
 function effectiveTier(preset: string | undefined, agent: string): string {
   const presetTier = AGENT_TIER?.[preset ?? ""]?.[agent] ?? "balanced";
-  const floor = AGENT_FLOOR?.[agent] ?? "balanced";
+  const floor = tierForScore(AGENT_FLOOR_SCORE?.[agent] ?? 0);
   return tierRank(presetTier) >= tierRank(floor) ? presetTier : floor;
 }
 

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -541,6 +541,7 @@ export function chooseSubagentModel({
   quota = [],
   agent = "general",
   nowMs = Date.now(),
+  services,
 } = {}) {
   // Normalise the incumbent into catalog shape ({providerID, id}) for the
   // comparison inside chooseModel, so its `changed` flag / modelKey() treat a
@@ -558,6 +559,7 @@ export function chooseSubagentModel({
       quota,
       policy,
       nowMs,
+      services,
     });
     // On the off-path / no-survivors path chooseModel returns the very
     // catalogIncumbent reference it was handed; map that back to the original
@@ -613,6 +615,7 @@ export function chooseMainModel({
   quota = [],
   agent = "build",
   nowMs = Date.now(),
+  services,
 } = {}) {
   const incumbentShape = incumbent
     ? { providerID: incumbent.providerID, modelID: incumbent.modelID ?? incumbent.id ?? "" }
@@ -631,6 +634,7 @@ export function chooseMainModel({
       quota,
       policy,
       nowMs,
+      services,
     });
     const model =
       decision?.model === catalogIncumbent
@@ -823,6 +827,7 @@ export async function startJob(input, deps = {}) {
       quota,
       agent: "general",
       nowMs: Date.now(),
+      services: deps?.routingServices,
     });
   } catch {
     effectiveModel = deliverModel;

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -24,6 +24,7 @@ import {
   chooseSubagentModel,
   chooseMainModel,
 } from "./delegate.mjs";
+import { familyKey } from "../shared/modelGuide.mjs";
 
 // ----------------------------------------------------------------------------
 // Harness: in-memory load/save on a closure-held array, recorded publish +
@@ -62,6 +63,30 @@ function harness(initialJobs = [], fixedNow = 1_700_000_000_000) {
 
 const CAP_ERROR =
   "too many background jobs running (5). Do not retry — either wait for one to finish, or do this work yourself.";
+
+// BET-1236: the router gated a candidate on description completeness
+// (autoEligibility). The routing-era tests must feed it the routing context
+// (identity matcher + quality entry + declared price/caching) so the bare
+// {providerID, id, status} fixtures are eligible, exactly as the box's wiring
+// will when it lands. Without these the router honestly reports "no usable
+// endpoint" and returns the incumbent.
+function routingServicesFor(list, extra = {}) {
+  const declared = {};
+  for (const m of list ?? []) {
+    if (!m || typeof m !== "object") continue;
+    declared[`${m.providerID}/${m.id}`] = { catalogId: m.id, price: {}, caches: true };
+  }
+  return {
+    catalogMatcher: { lookupModel: (id) => ({ id }), matchModel: (id) => ({ kind: "exact", candidates: [{ id }] }) },
+    catalogEntryFor: (c) => ({ family: familyKey(c?.id) ?? undefined }),
+    qualityField: {},
+    declared,
+    accounts: {},
+    health: {},
+    telemetry: {},
+    ...extra,
+  };
+}
 
 // ----------------------------------------------------------------------------
 // 1. buildJobPrompt — with and without a worktree
@@ -567,6 +592,7 @@ test("chooseSubagentModel routes an explore agent to a fast-tier model when the 
     quota: [],
     agent: "explore",
     nowMs: 1_700_000_000_000,
+    services: routingServicesFor(catalog),
   });
   // NOTE: this asserts the ROUTER WRAPPER's per-agent contract (the reusable
   // chooseSubagentModel — what any future explore-routing spawn would call).
@@ -587,11 +613,13 @@ test("startJob with routing on normalises the catalog winner to a {providerID, m
   // the key, not just the behaviour.
   h.deps.configGet = async () => ({ modelRouting: { preset: "economy" } });
   h.deps.listSnapshots = () => [];
-  h.deps.listModels = async () => [
+  const models = [
     { providerID: "anthropic", id: "claude-opus-4", status: "active" },   // deep
     { providerID: "anthropic", id: "claude-sonnet-4", status: "active" }, // balanced
     { providerID: "anthropic", id: "claude-haiku-4", status: "active" },  // fast
   ];
+  h.deps.listModels = async () => models;
+  h.deps.routingServices = routingServicesFor(models);
   const res = await startJob(
     { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo" },
     h.deps,
@@ -637,12 +665,14 @@ test("startJob routes only within the consent (sub) catalogue (BET-1229)", async
     deactivatedSubagents: ["anthropic/claude-sonnet-4", "anthropic/claude-haiku-4"],
   });
   h.deps.listSnapshots = () => [];
-  h.deps.listModels = async () => [
+  const models = [
     { providerID: "anthropic", id: "claude-opus-4", status: "active" },
     { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },
     { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
     { providerID: "openai", id: "gpt-5", status: "active" },
   ];
+  h.deps.listModels = async () => models;
+  h.deps.routingServices = routingServicesFor(models);
   const res = await startJob(
     { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo" },
     h.deps,
@@ -700,6 +730,7 @@ test("chooseMainModel returns the FULL decision — model, reason, incumbent —
     quota: [],
     agent: "build",
     nowMs: 1_700_000_000_000,
+    services: routingServicesFor(catalog),
   });
   // The main-conversation decision is richer than the subagent wrapper: the
   // renderer needs the model, a reason, and the incumbent for the undo pill.

--- a/src/shared/modelQuality.test.ts
+++ b/src/shared/modelQuality.test.ts
@@ -6,8 +6,7 @@ import {
   AGENT_FLOOR_SCORE,
   TIERS,
 } from "./modelQuality.mjs";
-import { FAMILY_TIERS, tierRank } from "./modelGuide.mjs";
-import { AGENT_FLOOR } from "./modelRouter.mjs";
+import { FAMILY_TIERS } from "./modelGuide.mjs";
 import type { QualityModel } from "./modelQuality.mjs";
 
 // A test field helper that converts a benchmark score to a percentile of "the
@@ -140,11 +139,12 @@ describe("tierForScore", () => {
 });
 
 describe("meetsFloor", () => {
-  it("matches today's AGENT_FLOOR for all five agents", () => {
+  it("matches the score floors for all five agents", () => {
     const agents = ["build", "plan", "general", "explore", "title"];
     for (const s of [0, 0.25, 0.55, 0.85, 1]) {
       for (const agent of agents) {
-        const expected = tierRank(tierForScore(s)) >= tierRank(AGENT_FLOOR[agent]);
+        const floor = AGENT_FLOOR_SCORE[agent] ?? 0;
+        const expected = s >= floor;
         expect(meetsFloor(s, agent)).toBe(expected);
       }
     }

--- a/src/shared/modelRouter.d.mts
+++ b/src/shared/modelRouter.d.mts
@@ -1,42 +1,57 @@
+import type { AccountState } from "./marginalCost.d.mts";
+import type { ModelDeclaration, ModelCatalog, CatalogEntry } from "./modelIdentity.d.mts";
+import type { Field as QualityField } from "./modelQuality.d.mts";
+import type {
+  ReliabilityBaseline,
+  ReliabilitySample,
+} from "./toolReliability.d.mts";
+
 export type Tier = "fast" | "balanced" | "deep";
 
 export const PRESETS: string[];
-export const AGENT_FLOOR: Record<string, Tier>;
 export const AGENT_TIER: Record<string, Record<string, Tier>>;
-export const REFERENCE_PRICE: number;
-export const FREE_FLOOR: number;
 
 export interface Model {
   providerID?: string;
   id?: string;
+  family?: string;
   status?: string;
-  cost?: { input?: number; output?: number };
-  limit?: { context?: number };
+  cost?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+  limit?: { context?: number; output?: number };
   capabilities?: {
     toolcall?: boolean;
+    reasoning?: boolean;
     input?: { image?: boolean; pdf?: boolean };
   };
 }
 
-export interface QuotaWindow {
-  providerIDs?: string[];
-  pct?: number;
-  stale?: boolean;
-  resetsAt?: number;
-  period?: string;
+export interface TelemetryEntry {
+  tokensPerSec?: number;
+  p50Ms?: number;
+  p90Ms?: number;
+  latencyMs?: number;
 }
 
-export function filterByConstraints(
-  models: Model[],
-  opts?: {
-    contextTokens?: number;
-    needs?: { tools?: boolean; image?: boolean; pdf?: boolean };
-  }
-): Model[];
-
-export function scarcity(window: unknown, nowMs: number): number;
-
-export function effectivePrice(model: Model, quota: QuotaWindow[], nowMs: number): number;
+export interface RoutingServices {
+  catalogMatcher?: ModelCatalog;
+  catalogEntryFor?: (endpoint: Model) => CatalogEntry | null | undefined;
+  qualityField?: QualityField;
+  /** Keyed by "providerID/modelID". */
+  declared?: Record<string, ModelDeclaration>;
+  providerClass?: Record<string, "supported" | "custom">;
+  /** Keyed by providerID. */
+  accounts?: Record<string, AccountState>;
+  /** Keyed by providerID — the provider-health state string. */
+  health?: Record<string, string>;
+  /** Keyed by "providerID/modelID". */
+  telemetry?: Record<string, TelemetryEntry>;
+  reliability?: {
+    samples?: Record<string, ReliabilitySample>;
+    baseline?: Record<string, ReliabilityBaseline>;
+  };
+  mix?: unknown;
+  referenceByModel?: Record<string, unknown>;
+}
 
 export interface ChooseInput {
   intent?: {
@@ -47,10 +62,9 @@ export interface ChooseInput {
     incumbent?: Model | null;
   };
   catalog?: Model[];
-  telemetry?: Record<string, { tokensPerSec?: number; p50Ms?: number }>;
-  quota?: QuotaWindow[];
   policy?: { preset?: string; perAgent?: Record<string, string> };
   nowMs?: number;
+  services?: RoutingServices;
 }
 
 export interface ChooseResult {

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -1,23 +1,21 @@
 // modelRouter.mjs — the pure routing decision core (no wiring).
 //
-// All model-routing intelligence lives here in ONE pure, fully-tested module
-// with no I/O, so the server and renderer can never disagree and the logic is
-// testable without a live provider. It changes no behaviour on its own; the
-// caller (a separate issue) wires it in. Pure + framework-free (no node:)
-// imports, no fetch, no Date.now() — time arrives as `nowMs`.
+// BET-1236 restructured this around ENDPOINTS (a `(model, provider)` pair)
+// with an explicit hard/soft filter split. Cost, quality, identity,
+// eligibility, reliability and health all live OUT of this file in the
+// Stage-2 modules it consumes (marginalCost ~> blendedPrice, modelQuality,
+// modelIdentity, autoEligibility, toolReliability + injected health). Pure,
+// no node: imports, no Date.now() — time arrives as `nowMs`. No provider NAME
+// ever appears here or in its imports.
 
-import { describeModel, tierRank } from "./modelGuide.mjs";
+import { tierRank } from "./modelGuide.mjs";
+import { qualityScore, tierForScore, meetsFloor, AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
+import { resolveIdentity } from "./modelIdentity.mjs";
+import { autoEligibility, MISSING } from "./autoEligibility.mjs";
+import { marginalCost } from "./marginalCost.mjs";
+import { shouldDerank } from "./toolReliability.mjs";
 
 export const PRESETS = ["economy", "balanced", "performance"];
-
-/** Tier a given agent must never drop below. */
-export const AGENT_FLOOR = {
-  build: "balanced",
-  plan: "deep",
-  general: "balanced",
-  explore: "fast",
-  title: "fast",
-};
 
 /** Preferred tier per agent, per preset. Pure lookup table, no inference. */
 export const AGENT_TIER = {
@@ -26,282 +24,242 @@ export const AGENT_TIER = {
   performance: { build: "deep", plan: "deep", general: "deep", explore: "balanced" },
 };
 
-/** Comparable price baseline, in dollars, used to blend quota scarcity in. */
-export const REFERENCE_PRICE = 30;
+const endpointKey = (c) => `${c?.providerID ?? ""}/${c?.id ?? ""}`;
 
-/** Floor price for a genuinely free model with no quota window. */
-export const FREE_FLOOR = 0.5;
+const BINDING_ORDER = [
+  "no active model", "context headroom", "tool calling", "image input", "pdf input",
+  "out-of-credit", "rate-limited", "identity", "price", "caching", "quality",
+];
 
-const DAY_MS = 24 * 60 * 60 * 1000;
-const TIER_NAMES = ["fast", "balanced", "deep"];
+const HEALTH_EXCLUDED = { "out-of-credit": "out-of-credit", "rate-limited": "rate-limited" };
 
-// "providerID/modelID" — the identity used for telemetry lookups.
-function modelKey(m) {
-  return m ? `${m?.providerID ?? ""}/${m?.id ?? ""}` : "";
+const isNum = (v) => typeof v === "number" && Number.isFinite(v);
+
+// BET-1251: routing is activated per conversation (a preset or per-agent
+// override), not by a global switch. An empty policy means "did not ask".
+function routingActive(policy) {
+  if (typeof policy !== "object" || policy === null) return false;
+  if (typeof policy.preset === "string" && policy.preset.length > 0) return true;
+  return !!(policy.perAgent && typeof policy.perAgent === "object" && Object.keys(policy.perAgent).length > 0);
 }
 
-// The effective tier of a model; unrecognized families default to "balanced".
-function tierOf(m) {
-  const info = describeModel(m?.providerID, m?.id);
-  return info && info.tier ? info.tier : "balanced";
+// Hard Stage 2 — the capability reason an endpoint cannot do THIS turn. The
+// one exception to permissive-missing is `status`, as today.
+function capabilityDrop(m, { contextTokens, needs, health }) {
+  if (m?.status != null && m.status !== "active") return "no active model";
+  if (typeof m?.limit?.context === "number" && m.limit.context < contextTokens * 1.25) return "context headroom";
+  if (needs.tools === true && m?.capabilities?.toolcall === false) return "tool calling";
+  if (needs.image === true && m?.capabilities && m?.capabilities?.input?.image !== true) return "image input";
+  if (needs.pdf === true && m?.capabilities && m?.capabilities?.input?.pdf !== true) return "pdf input";
+  const hs = HEALTH_EXCLUDED[health?.[m.providerID]];
+  return hs ?? null;
 }
 
-// Which quota windows belong to a provider, choosing the highest-scarcity one
-// when several exist.
-function pickWindow(providerID, quota, nowMs) {
-  const windows = (quota ?? []).filter(
-    (w) => Array.isArray(w?.providerIDs) && w.providerIDs.includes(providerID),
-  );
-  if (windows.length === 0) return null;
-  let best = windows[0];
-  let bestS = scarcity(best, nowMs);
-  for (let i = 1; i < windows.length; i++) {
-    const s = scarcity(windows[i], nowMs);
-    if (s > bestS) {
-      best = windows[i];
-      bestS = s;
-    }
+// Assess one endpoint once — Hard Stage 1 (eligibility), marginal cost and
+// reliability — everything the hard and soft stages read.
+function assess(candidate, { nowMs }, services) {
+  const key = endpointKey(candidate);
+  const dec = services.declared?.[key] ?? null;
+  const identity = resolveIdentity(candidate, dec, services.catalogMatcher);
+  const catalogEntry = typeof services.catalogEntryFor === "function" ? services.catalogEntryFor(candidate) : null;
+  const quality = qualityScore(candidate, catalogEntry, services.qualityField);
+  const elig = autoEligibility({
+    model: candidate,
+    identity: { known: identity.state === "resolved" },
+    quality,
+    declared: dec,
+    providerClass: services.providerClass?.[candidate.providerID] ?? "supported",
+  });
+  const mc = marginalCost({ model: candidate, account: services.accounts?.[candidate.providerID], nowMs, mix: services.mix, reference: services.referenceByModel?.[candidate.id] });
+  const penalise = shouldDerank(services.reliability?.samples?.[key], services.reliability?.baseline?.[candidate.id]).penalise === true;
+  return {
+    key,
+    candidate,
+    qualityScore: quality.known ? quality.score : 0,
+    tier: tierForScore(quality.known ? quality.score : undefined),
+    eligible: elig.eligible,
+    missing: elig.missing,
+    marginalCost: mc.exhausted ? Infinity : mc.cost,
+    exhausted: mc.exhausted,
+    penalise,
+  };
+}
+
+// One binding label per dropped endpoint: its capability reason, else the
+// first missing completeness fact.
+function bindLabel(a, cap) {
+  if (cap) return cap;
+  for (const m of [MISSING.IDENTITY, MISSING.PRICE, MISSING.CACHING, MISSING.QUALITY]) {
+    if (a.missing.includes(m)) return m;
+  }
+  return "eligibility";
+}
+
+function bindingReason(counts) {
+  let best = BINDING_ORDER[0];
+  let bestCount = -1;
+  for (const label of BINDING_ORDER) {
+    const cv = counts?.[label] ?? 0;
+    if (cv > bestCount) { bestCount = cv; best = label; }
   }
   return best;
 }
 
-/**
- * Drop models that cannot do the job. Pure.
- *
- * A model is dropped when any constraint is violated:
- *   - `model.status` is present and !== "active"
- *   - `model.limit?.context` is a number and < contextTokens * 1.25
- *   - `needs.tools === true` and `model.capabilities?.toolcall === false`
- *   - `needs.image === true` and `model.capabilities?.input?.image !== true`
- *   - `needs.pdf === true` and `model.capabilities?.input?.pdf !== true`
- *
- * Missing/undefined metadata is permissive (never drops) — except `status`,
- * handled above.
- *
- * @param {Array<object>} models
- * @param {{ contextTokens?: number, needs?: { tools?: boolean, image?: boolean, pdf?: boolean } }} [opts]
- * @returns {Array<object>}
- */
-export function filterByConstraints(models, { contextTokens = 0, needs = {} } = {}) {
-  const list = Array.isArray(models) ? models : [];
-  if (list.length === 0) return [];
-  const headroom = contextTokens * 1.25;
-  return list.filter((m) => {
-    if (m?.status != null && m.status !== "active") return false;
-    if (typeof m?.limit?.context === "number" && m.limit.context < headroom) return false;
-    if (needs.tools === true && m?.capabilities?.toolcall === false) return false;
-    // Image/pdf gates only apply when the model declares capabilities at all;
-    // absent capabilities are permissive (unknown).
-    if (needs.image === true && m?.capabilities && m?.capabilities?.input?.image !== true) return false;
-    if (needs.pdf === true && m?.capabilities && m?.capabilities?.input?.pdf !== true) return false;
-    return true;
-  });
+const num0 = (v) => (isNum(v) ? v : 0);
+const numInf = (v) => (isNum(v) ? v : Infinity);
+const telemetryOf = (a, services) => services.telemetry?.[a.key] ?? {};
+
+// Soft ordering within a competing set (same model, or a flattened economy
+// set): penalised sorts last; then cost; then quality, throughput, the
+// latency percentiles, and finally the full provider/model key — deterministic
+// (the model id alone is identical for exactly the endpoints most likely to
+// tie, so the old final tie-break was deterministic by accident).
+function cmpWithinModel(a, b, services) {
+  const pa = a.penalise ? 1 : 0;
+  const pb = b.penalise ? 1 : 0;
+  if (pa !== pb) return pa - pb;
+  if (a.marginalCost !== b.marginalCost) return a.marginalCost - b.marginalCost;
+  if (a.qualityScore !== b.qualityScore) return b.qualityScore - a.qualityScore;
+  const ta = telemetryOf(a, services);
+  const tb = telemetryOf(b, services);
+  const tsA = num0(ta.tokensPerSec);
+  const tsB = num0(tb.tokensPerSec);
+  if (tsA !== tsB) return tsB - tsA;
+  const p50A = numInf(ta.p50Ms);
+  const p50B = numInf(tb.p50Ms);
+  if (p50A !== p50B) return p50A - p50B;
+  const p90A = numInf(ta.p90Ms);
+  const p90B = numInf(tb.p90Ms);
+  if (p90A !== p90B) return p90A - p90B;
+  const latA = numInf(ta.latencyMs);
+  const latB = numInf(tb.latencyMs);
+  if (latA !== latB) return latA - latB;
+  return String(a.key).localeCompare(String(b.key));
 }
 
-/**
- * 0 when a window is comfortable, ramping to 1 as it fills. Pure.
- *
- * No window, `pct < 50`, or `stale === true` → 0. Otherwise `(pct - 50) / 50`
- * clamped to [0,1], scaled by an urgency factor: 1 when `resetsAt` is missing
- * or more than 24h away, scaling linearly down to 0.25 as `resetsAt`
- * approaches `nowMs` (a window about to reset is less scarce). Always returns
- * a finite number in [0,1].
- *
- * @param {object|null|undefined} window
- * @param {number} nowMs
- * @returns {number}
- */
-export function scarcity(window, nowMs) {
-  if (!window || typeof window !== "object") return 0;
-  if (window.stale === true) return 0;
-  const pct = window.pct;
-  if (typeof pct !== "number" || pct < 50) return 0;
-  let ramped = (pct - 50) / 50;
-  if (ramped < 0) ramped = 0;
-  if (ramped > 1) ramped = 1;
-  const resetsAt = window.resetsAt;
-  if (resetsAt == null || typeof nowMs !== "number") return ramped;
-  let f = (resetsAt - nowMs) / DAY_MS;
-  if (f < 0) f = 0;
-  if (f > 1) f = 1;
-  return ramped * (0.25 + 0.75 * f);
-}
-
-/**
- * Comparable price for one model, blending dollars and quota scarcity. Pure.
- *
- * `dollars + scarcity(window) * REFERENCE_PRICE`, where `dollars` sums
- * `cost.input` + `cost.output`. The window is the one from `quota` whose
- * `providerIDs` includes the model's `providerID` (highest scarcity when
- * several). A genuinely free model (`dollars === 0` and no matching quota
- * window) gets `FREE_FLOOR` — so a free-but-weak model is not chosen over a
- * good one while quota is abundant.
- *
- * @param {object} model
- * @param {Array<object>} [quota]
- * @param {number} [nowMs]
- * @returns {number}
- */
-export function effectivePrice(model, quota = [], nowMs = 0) {
-  const dollars = (model?.cost?.input ?? 0) + (model?.cost?.output ?? 0);
-  const window = pickWindow(model?.providerID, quota, nowMs);
-  if (window) return dollars + scarcity(window, nowMs) * REFERENCE_PRICE;
-  return dollars === 0 ? FREE_FLOOR : dollars;
-}
-
-const CONSTRAINT_LABELS = {
-  status: "no active model",
-  context: "context headroom",
-  tools: "tool calling",
-  image: "image input",
-  pdf: "pdf input",
-};
-
-// Filter while tracking which constraint eliminated what, for reasons.
-function applyConstraints(models, contextTokens, needs) {
-  const kept = [];
-  const counts = { status: 0, context: 0, tools: 0, image: 0, pdf: 0 };
-  const headroom = contextTokens * 1.25;
-  for (const m of models) {
-    let drop = null;
-    if (m?.status != null && m.status !== "active") drop = "status";
-    else if (typeof m?.limit?.context === "number" && m.limit.context < headroom) drop = "context";
-    else     if (needs.tools === true && m?.capabilities?.toolcall === false) drop = "tools";
-    else if (needs.image === true && m?.capabilities && m?.capabilities?.input?.image !== true) drop = "image";
-    else if (needs.pdf === true && m?.capabilities && m?.capabilities?.input?.pdf !== true) drop = "pdf";
-    if (drop) counts[drop] += 1;
-    else kept.push(m);
+// The full soft ordering. Under `economy` the model partition is flattened
+// (trading quality for cost is exactly what that preset asks for); otherwise
+// group by model, order the groups by quality, run the within-model contest
+// inside each.
+function stage3Order(assessed, services) {
+  if (services.preset === "economy") {
+    return [...assessed].sort((a, b) => cmpWithinModel(a, b, services));
   }
-  return { kept, counts };
-}
-
-function bindingReason(counts) {
-  let best = "status";
-  let bestCount = -1;
-  for (const key of Object.keys(CONSTRAINT_LABELS)) {
-    if (counts[key] > bestCount) {
-      bestCount = counts[key];
-      best = key;
+  const byModel = new Map();
+  for (const a of assessed) {
+    let g = byModel.get(a.candidate?.id);
+    if (!g) {
+      g = { quality: a.qualityScore, minKey: a.key, items: [] };
+      byModel.set(a.candidate?.id, g);
     }
+    if (a.qualityScore > g.quality) g.quality = a.qualityScore;
+    if (a.key < g.minKey) g.minKey = a.key;
+    g.items.push(a);
   }
-  return CONSTRAINT_LABELS[best] ?? "constraints";
+  const groups = [...byModel.values()].sort((x, y) => y.quality - x.quality || String(x.minKey).localeCompare(String(y.minKey)));
+  const ordered = [];
+  for (const g of groups) {
+    g.items.sort((a, b) => cmpWithinModel(a, b, services));
+    ordered.push(...g.items);
+  }
+  return ordered;
 }
 
-// Whether a policy asks the router to run at all. Routing is activated per
-// conversation, not by a global switch: the composer's model picker activates
-// it for a conversation by supplying a preset, and a per-agent override map can
-// pin specific tiers on top. The former global `enabled` field is gone
-// (BET-1243) — there is no box-wide off switch. An absent/empty policy (no
-// preset, no per-agent override) means the conversation did not ask to route.
-function routingActive(policy) {
-  if (typeof policy !== "object" || policy === null) return false;
-  if (typeof policy.preset === "string" && policy.preset.length > 0) return true;
-  const perAgent = policy.perAgent;
-  return !!perAgent && typeof perAgent === "object" && Object.keys(perAgent).length > 0;
+const TIER_BY_RANK = ["fast", "balanced", "deep"];
+
+// The candidates considered for the winner: the target tier (never below the
+// agent's floor), widening one neighbouring band when the target is empty.
+function selectBand(ordered, targetRank, agent) {
+  const byRank = {};
+  for (const a of ordered) {
+    if (!meetsFloor(a.qualityScore, agent)) continue;
+    const r = tierRank(a.tier);
+    (byRank[r] = byRank[r] || []).push(a);
+  }
+  const ranks = Object.keys(byRank).map(Number);
+  if (ranks.length === 0) return [];
+  if (byRank[targetRank]?.length) return byRank[targetRank];
+  let bestRank = ranks[0];
+  let bestDist = Math.abs(ranks[0] - targetRank);
+  for (const r of ranks) {
+    const d = Math.abs(r - targetRank);
+    if (d < bestDist || (d === bestDist && r > bestRank)) { bestDist = d; bestRank = r; }
+  }
+  return byRank[bestRank];
 }
 
-// A single sentence naming the agent, the tier, and the binding factor.
-function explain({ agent, tierName, winner, quota, nowMs }) {
-  const window = pickWindow(winner?.providerID, quota, nowMs);
-  const s = window ? scarcity(window, nowMs) : 0;
-  if (s > 0) {
-    const label = window.period ? `${window.period}` : "quota";
-    return `${agent} → ${tierName} tier: ${winner.providerID} ${label} at ${Math.round(s * 100)}%`;
+function explain({ agent, tierName, preset, winner, cost }) {
+  if (preset === "economy") {
+    return `${agent} → ${tierName} tier (economy): ${winner.providerID}/${winner.id} cheapest at $${cost.toFixed(4)}`;
   }
-  return `${agent} → ${tierName} tier: ${winner.providerID} quota ample`;
+  return `${agent} → ${tierName} tier: ${winner.providerID}/${winner.id}`;
 }
 
 /**
  * THE entry point. Always returns a model and a non-empty reason; never
- * throws.
+ * throws. Candidate = one (model, provider) endpoint; the set never merges.
  *
  * @param {object} [input]
- * @param {object} [input.intent] - { kind, agent, needs, contextTokens, incumbent }
- * @param {Array<object>} [input.catalog] - Model[] from opencode
- * @param {Record<string, { tokensPerSec?: number, p50Ms?: number }>} [input.telemetry]
- * @param {Array<object>} [input.quota] - UsageSnapshot[]
+ * @param {object} [input.intent]   - { kind, agent, needs, contextTokens, incumbent }
+ * @param {Array<object>} [input.catalog] - endpoints[] — one per (model, provider)
  * @param {{ preset?: string, perAgent?: Record<string,string> }} [input.policy]
  * @param {number} [input.nowMs]
+ * @param {object} [input.services] - the routing context the wiring issue injects
+ *   (all optional; absent is permissive / measured-average, never false):
+ *   { catalogMatcher, catalogEntryFor, qualityField, declared, providerClass,
+ *     accounts, health, telemetry, reliability, mix, referenceByModel }
  * @returns {{ model: object|null, reason: string, alternatives: object[], changed: boolean }}
  */
 export function chooseModel(input = {}) {
-  const { intent = {}, catalog = [], telemetry = {}, quota = [], policy = {}, nowMs = 0 } = input;
+  const { intent = {}, catalog = [], policy = {}, nowMs = 0 } = input;
+  const services = input.services && typeof input.services === "object" ? input.services : {};
   const agent = intent?.agent ?? "general";
   const incumbent = intent?.incumbent ?? null;
 
-  // Permanent invariant: never route mid-exchange.
   if (intent?.kind === "mid-exchange") {
-    return {
-      model: incumbent,
-      reason: "mid-exchange switching is disabled",
-      alternatives: [],
-      changed: false,
-    };
+    return { model: incumbent, reason: "mid-exchange switching is disabled", alternatives: [], changed: false };
   }
-
-  // Activation is per-conversation: routing runs only when this conversation
-  // supplied a routing directive — a preset the composer picker set, or a
-  // per-agent override. The former global on/off (`enabled`) is gone
-  // (BET-1243); "no preset" is a conversation that did not ask to route, not a
-  // box-wide off switch, so an empty policy returns the incumbent unchanged.
+  // Off-path (no routing directive): return the incumbent BY REFERENCE,
+  // byte-identical so a box without routing behaves exactly as before.
   if (!routingActive(policy)) {
     return { model: incumbent, reason: "routing not activated for this conversation", alternatives: [], changed: false };
   }
 
   const needs = intent?.needs ?? {};
-  const contextTokens = typeof intent?.contextTokens === "number" ? intent.contextTokens : 0;
-  const { kept: survivors, counts } = applyConstraints(catalog, contextTokens, needs);
+  const hardCtx = { contextTokens: typeof intent?.contextTokens === "number" ? intent.contextTokens : 0, needs, health: services.health };
+
+  const survivors = [];
+  const counts = {};
+  for (const c of Array.isArray(catalog) ? catalog : []) {
+    const a = assess(c, { nowMs }, services);
+    const cap = capabilityDrop(c, hardCtx);
+    if ((a.exhausted && !cap) || cap || !a.eligible) {
+      counts[bindLabel(a, cap)] = (counts[bindLabel(a, cap)] ?? 0) + 1;
+      continue;
+    }
+    survivors.push(a);
+  }
 
   if (survivors.length === 0) {
-    return {
-      model: incumbent,
-      reason: `no ${agent} model passes constraints (${bindingReason(counts)})`,
-      alternatives: [],
-      changed: false,
-    };
+    return { model: incumbent, reason: `no ${agent} model passes constraints (${bindingReason(counts)})`, alternatives: [], changed: false };
   }
 
-  const floor = AGENT_FLOOR[agent] ?? "balanced";
-  const floorRank = tierRank(floor);
-  const target = policy?.perAgent?.[agent] ?? AGENT_TIER?.[policy?.preset]?.[agent] ?? "balanced";
-  let targetRank = tierRank(target);
-  if (targetRank < floorRank) targetRank = floorRank;
+  const targetRaw = policy?.perAgent?.[agent] ?? AGENT_TIER?.[policy?.preset]?.[agent] ?? "balanced";
+  const floorScore = AGENT_FLOOR_SCORE[agent] ?? 0;
+  const targetRank = Math.max(tierRank(targetRaw), tierRank(tierForScore(floorScore)));
 
-  // Keep candidates whose tier equals the target; if none, widen to the
-  // nearest tier at or above the floor.
-  const ranked = survivors.map((m) => ({ m, rank: tierRank(tierOf(m)) }));
-  let chosen = ranked.filter((x) => x.rank === targetRank);
-  if (chosen.length === 0) {
-    const eligible = ranked.filter((x) => x.rank >= floorRank);
-    const nearest = Math.min(...eligible.map((x) => Math.abs(x.rank - targetRank)));
-    chosen = eligible.filter((x) => Math.abs(x.rank - targetRank) === nearest);
+  const explored = stage3Order(survivors, { preset: policy?.preset, telemetry: services.telemetry });
+  const band = selectBand(explored, targetRank, agent);
+  if (band.length === 0) {
+    return { model: incumbent, reason: `no ${agent} model meets the ${TIER_BY_RANK[targetRank]} target above the ${floorScore} floor`, alternatives: [], changed: false };
   }
 
-  // Sort by effectivePrice ascending; ties by higher telemetry tokensPerSec,
-  // then lower p50Ms, then modelID alphabetically (deterministic).
-  chosen.sort((a, b) => {
-    const pa = effectivePrice(a.m, quota, nowMs);
-    const pb = effectivePrice(b.m, quota, nowMs);
-    if (pa !== pb) return pa - pb;
-    const ta = telemetry?.[modelKey(a.m)]?.tokensPerSec ?? 0;
-    const tb = telemetry?.[modelKey(b.m)]?.tokensPerSec ?? 0;
-    if (ta !== tb) return tb - ta;
-    const la = telemetry?.[modelKey(a.m)]?.p50Ms ?? Infinity;
-    const lb = telemetry?.[modelKey(b.m)]?.p50Ms ?? Infinity;
-    if (la !== lb) return la - lb;
-    return String(a.m?.id ?? "").localeCompare(String(b.m?.id ?? ""));
-  });
-
-  const winner = chosen[0].m;
-  const winnerRank = chosen[0].rank;
-  const tierName = TIER_NAMES[winnerRank] ?? "balanced";
-  const alternatives = chosen.slice(1, 4).map((x) => x.m);
-  const changed = !incumbent || modelKey(incumbent) !== modelKey(winner);
-
+  const winner = band[0].candidate;
+  const winnerKey = band[0].key;
   return {
     model: winner,
-    reason: explain({ agent, tierName, winner, quota, nowMs }),
-    alternatives,
-    changed,
+    reason: explain({ agent, tierName: TIER_BY_RANK[tierRank(band[0].tier)], preset: policy?.preset, winner, cost: band[0].marginalCost }),
+    alternatives: band.slice(1, 4).map((a) => a.candidate),
+    changed: !incumbent || endpointKey(incumbent) !== winnerKey,
   };
 }

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -1,271 +1,333 @@
 import { describe, it, expect } from "vitest";
-import {
-  filterByConstraints,
-  scarcity,
-  effectivePrice,
-  chooseModel,
-  REFERENCE_PRICE,
-  FREE_FLOOR,
-  AGENT_FLOOR,
-  AGENT_TIER,
-} from "./modelRouter.mjs";
+import { chooseModel, AGENT_TIER, PRESETS, type RoutingServices } from "./modelRouter.mjs";
 import { tierRank } from "./modelGuide.mjs";
-import type { Model } from "./modelRouter.mjs";
+import { AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
 
-function m(id: string, over: Partial<Model> = {}): Model {
-  return { providerID: "anthropic", id, status: "active", cost: { input: 0, output: 0 }, ...over };
+// A catalogue entry field that forces a precise, known quality score so tests
+// control the tier band deterministically. qualityScore's benchmark path wins
+// over the family seed; the identity percentile is the score itself.
+const CHECK = { name: "SWE-Bench Verified", score: 0.5 };
+
+const TIER_SCORE: Record<string, number> = { fast: 0.25, balanced: 0.55, deep: 0.85 };
+
+type EndpointOver = Record<string, unknown> & { providerID?: string; tier?: string; score?: number };
+type Endpoint = Record<string, unknown>;
+
+function endpoint(id: string, over: EndpointOver = {}): Endpoint {
+  const { providerID = "p", tier = "balanced", score, ...rest } = over;
+  return {
+    providerID,
+    id,
+    status: "active",
+    cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0.5 },
+    capabilities: { toolcall: true, input: { image: true, pdf: true } },
+    _score: score ?? TIER_SCORE[tier],
+    ...rest,
+  };
 }
 
-describe("tierRank", () => {
-  it("orders fast < balanced < deep, unknown to balanced", () => {
-    expect(tierRank("fast")).toBe(0);
-    expect(tierRank("balanced")).toBe(1);
-    expect(tierRank("deep")).toBe(2);
-    expect(tierRank("unknown")).toBe(1);
-    expect(tierRank(undefined)).toBe(1);
-  });
-});
+function defaultDeclared(catalog: Endpoint[]): Record<string, { catalogId: string }> {
+  return Object.fromEntries(catalog.map((c) => [`${c.providerID}/${c.id}`, { catalogId: String(c.id) }]));
+}
 
-describe("filterByConstraints", () => {
-  it("drops a model whose context limit leaves no headroom", () => {
-    const ok = m("ok", { limit: { context: 125 } });
-    const bad = m("bad", { limit: { context: 124 } });
-    const res = filterByConstraints([ok, bad], { contextTokens: 100 });
-    expect(res.map((x) => x.id)).toEqual(["ok"]);
-  });
+type RouteOpts = {
+  catalog: Endpoint[];
+  policy?: Record<string, unknown>;
+  intent?: Record<string, unknown>;
+  services?: Record<string, unknown>;
+  nowMs?: number;
+};
 
-  it("drops on toolcall:false when tools are needed, keeps missing metadata", () => {
-    const good = m("good", { capabilities: { toolcall: true } });
-    const bad = m("bad", { capabilities: { toolcall: false } });
-    const missing = m("missing"); // no capabilities at all
-    const res = filterByConstraints([good, bad, missing], { needs: { tools: true } });
-    expect(res.map((x) => x.id)).toEqual(["good", "missing"]);
+function route({ catalog, policy, intent = {}, services: extra = {}, nowMs = 0 }: RouteOpts) {
+  const services: RoutingServices = {
+    catalogEntryFor: (c: any) => ({ benchmarks: [{ ...CHECK, score: c?._score }] }),
+    qualityField: { benchmarkPercentile: (_n: string, s: any) => s },
+    declared: defaultDeclared(catalog),
+    accounts: {},
+    health: {},
+    telemetry: {},
+    ...(extra as RoutingServices),
+  };
+  return chooseModel({
+    intent: { kind: "start", agent: "general", ...intent },
+    catalog,
+    policy,
+    nowMs,
+    services,
   });
+}
 
-  it("drops on missing image input when images are needed", () => {
-    const good = m("good", { capabilities: { input: { image: true } } });
-    const bad = m("bad", { capabilities: { input: { image: false } } });
-    const missing = m("missing");
-    const res = filterByConstraints([good, bad, missing], { needs: { image: true } });
-    expect(res.map((x) => x.id)).toEqual(["good", "missing"]);
-  });
+const keyOf = (m: { providerID?: string; id?: string } | null | undefined) =>
+  m ? `${m.providerID}/${m.id}` : "";
 
-  it("drops on missing pdf input when pdfs are needed", () => {
-    const good = m("good", { capabilities: { input: { pdf: true } } });
-    const hasImageButNoPdf = m("img", { capabilities: { input: { image: true } } });
-    const missing = m("missing");
-    const res = filterByConstraints([good, hasImageButNoPdf, missing], { needs: { pdf: true } });
-    expect(res.map((x) => x.id)).toEqual(["good", "missing"]);
-  });
-
-  it("drops on non-active status, keeps missing status", () => {
-    const active = m("active", { status: "active" });
-    const retired = m("retired", { status: "retired" });
-    const deprecated = m("deprecated", { status: "deprecated" });
-    const noStatus = m("noStatus");
-    const res = filterByConstraints([active, retired, deprecated, noStatus]);
-    expect(res.map((x) => x.id)).toEqual(["active", "noStatus"]);
-  });
-
-  it("keeps models with missing metadata (permissive) on every gate", () => {
-    const bare = m("bare");
-    const res = filterByConstraints([bare], {
-      contextTokens: 100,
-      needs: { tools: true, image: true, pdf: true },
-    });
-    expect(res.map((x) => x.id)).toEqual(["bare"]);
-  });
-});
-
-describe("scarcity", () => {
-  it("returns 0 with no window or pct below 50", () => {
-    expect(scarcity(undefined, 0)).toBe(0);
-    expect(scarcity(null, 0)).toBe(0);
-    expect(scarcity({}, 0)).toBe(0);
-    expect(scarcity({ pct: 49 }, 0)).toBe(0);
-  });
-
-  it("ramps at 50/75/89/100", () => {
-    expect(scarcity({ pct: 50 }, 0)).toBe(0);
-    expect(scarcity({ pct: 75 }, 0)).toBe(0.5);
-    expect(scarcity({ pct: 89 }, 0)).toBeCloseTo(0.78, 5);
-    expect(scarcity({ pct: 100 }, 0)).toBe(1);
-  });
-
-  it("returns 0 on a stale reading", () => {
-    expect(scarcity({ pct: 100, stale: true }, 0)).toBe(0);
-  });
-
-  it("is lower near a reset", () => {
-    const now = 1_000_000;
-    const far = scarcity({ pct: 89, resetsAt: now + 25 * 60 * 60 * 1000 }, now);
-    const near = scarcity({ pct: 89, resetsAt: now }, now);
-    expect(far).toBeCloseTo(0.78, 5);
-    expect(near).toBeCloseTo(0.78 * 0.25, 5);
-    expect(near).toBeLessThan(far);
-  });
-
-  it("always returns a finite number in [0,1]", () => {
-    for (const w of [{ pct: -5 }, { pct: 200 }, { pct: 75, resetsAt: 0 }, { pct: 40 }]) {
-      const v = scarcity(w, 1e6);
-      expect(Number.isFinite(v)).toBe(true);
-      expect(v).toBeGreaterThanOrEqual(0);
-      expect(v).toBeLessThanOrEqual(1);
-    }
-  });
-});
-
-describe("effectivePrice", () => {
-  it("prices a dollar model by cost with no quota window", () => {
-    const model = m("paid", { cost: { input: 2, output: 3 } });
-    expect(effectivePrice(model, [], 0)).toBe(5);
-  });
-
-  it("blends quota scarcity into a subscription model at 89%", () => {
-    const model = m("sub", { providerID: "anthropic", cost: { input: 0, output: 0 } });
-    const quota = [{ providerIDs: ["anthropic"], pct: 89 }];
-    expect(effectivePrice(model, quota, 0)).toBeCloseTo(0.78 * REFERENCE_PRICE, 5);
-  });
-
-  it("gives a free model with no window the FREE_FLOOR", () => {
-    const model = m("free", { cost: { input: 0, output: 0 } });
-    expect(effectivePrice(model, [], 0)).toBe(FREE_FLOOR);
-  });
-});
-
-describe("chooseModel", () => {
-  it("honours the agent floor under economy (general raised fast -> balanced)", () => {
-    const fast = m("claude-haiku-4"); // tier fast
-    const balanced = m("claude-sonnet-4"); // tier balanced
-    const res = chooseModel({
-      intent: { kind: "start", agent: "general" },
-      catalog: [balanced, fast],
-      policy: { preset: "economy" },
-      nowMs: 0,
-    });
-    expect(AGENT_FLOOR.general).toBe("balanced");
+describe("PRESETS / AGENT_TIER", () => {
+  it("exposes the three presets and the tier table read by the renderer", () => {
+    expect(PRESETS).toEqual(["economy", "balanced", "performance"]);
+    expect(AGENT_TIER.balanced.general).toBe("balanced");
     expect(AGENT_TIER.economy.general).toBe("fast");
-    // floor must win: a fast model exists but the lower bound is balanced
-    expect(res.model?.id).toBe("claude-sonnet-4");
-    expect(res.reason).toBeTruthy();
   });
+});
 
-  it("is deterministic across 100 shuffles of the catalog", () => {
-    const catalog = [
-      m("claude-sonnet-4"),
-      m("gpt-4o"),
-      m("gpt-5"),
-      m("claude-haiku-4"),
-    ];
-    const base = chooseModel({
-      intent: { kind: "start", agent: "general", incumbent: m("claude-sonnet-4") },
-      catalog,
-      policy: { preset: "balanced" },
-      nowMs: 0,
-    });
-    for (let i = 0; i < 100; i++) {
-      const shuffled = [...catalog].sort(() => Math.random() - 0.5);
-      const res = chooseModel({
-        intent: { kind: "start", agent: "general", incumbent: m("claude-sonnet-4") },
-        catalog: shuffled,
-        policy: { preset: "balanced" },
-        nowMs: 0,
-      });
-      expect(res.model?.id).toBe(base.model?.id);
-    }
-  });
-
-  it("returns the incumbent and non-empty reason on every path", () => {
-    const incumbent = m("claude-sonnet-4");
-    const paths = [
-      chooseModel({
-        intent: { kind: "mid-exchange", agent: "general", incumbent },
-        catalog: [m("claude-haiku-4")],
-        policy: { preset: "balanced" },
-        nowMs: 0,
-      }),
-      chooseModel({
-        intent: { kind: "start", agent: "general", incumbent },
-        catalog: [m("claude-sonnet-4")],
-        policy: {},
-        nowMs: 0,
-      }),
-      chooseModel({
-        intent: { kind: "start", agent: "general", incumbent },
-        catalog: [m("dead", { status: "retired" })],
-        policy: { preset: "balanced" },
-        nowMs: 0,
-      }),
-      chooseModel({
-        intent: { kind: "start", agent: "general" },
-        catalog: [m("claude-sonnet-4")],
-        policy: { preset: "balanced" },
-        nowMs: 0,
-      }),
-    ];
-    for (const p of paths) {
-      expect(typeof p.reason).toBe("string");
-      expect(p.reason.length).toBeGreaterThan(0);
-    }
-  });
-
-  it("returns the incumbent unchanged when the conversation did not activate routing", () => {
-    const incumbent = m("claude-sonnet-4");
-    const res = chooseModel({
-      intent: { kind: "start", agent: "general", incumbent },
-      catalog: [m("claude-haiku-4")],
-      policy: {},
-      nowMs: 0,
-    });
+describe("chooseModel — off-path and invariants", () => {
+  it("returns the incumbent by reference when routing is not activated", () => {
+    const incumbent = endpoint("m", { providerID: "a" });
+    const res = route({ catalog: [endpoint("other")], policy: {}, intent: { incumbent } });
     expect(res.model).toBe(incumbent);
     expect(res.changed).toBe(false);
     expect(res.reason).toBe("routing not activated for this conversation");
   });
 
-  it("REGRESSION: routing activates from a preset alone, without any enabled flag (BET-1251)", () => {
-    // BET-1243 deleted the global `enabled` toggle; activation is per
-    // conversation via the composer's preset pick. A preset in the policy must
-    // be sufficient — no `enabled` field is consulted.
-    const cheap = m("claude-haiku-4"); // tier fast
-    const balanced = m("claude-sonnet-4"); // tier balanced
-    const res = chooseModel({
-      intent: { kind: "start", agent: "general", incumbent: m("claude-opus-4") },
-      catalog: [cheap, balanced],
-      policy: { preset: "economy" }, // no enabled key at all
-      nowMs: 0,
+  it("never routes mid-exchange", () => {
+    const incumbent = endpoint("m", { providerID: "a" });
+    const cheap = endpoint("other", { tier: "fast" });
+    const res = route({
+      catalog: [incumbent, cheap],
+      policy: { preset: "performance" },
+      intent: { kind: "mid-exchange", incumbent },
     });
-    expect(res.model?.id).toBe("claude-sonnet-4");
-    expect(res.changed).toBe(true);
+    expect(res.model).toBe(incumbent);
+    expect(res.changed).toBe(false);
+    expect(res.reason).toBe("mid-exchange switching is disabled");
   });
 
-  it("returns the incumbent when nothing survives filtering", () => {
-    const incumbent = m("claude-sonnet-4");
-    const res = chooseModel({
-      intent: { kind: "start", agent: "general", incumbent },
-      catalog: [m("dead", { status: "retired" })],
+  it("returns incumbent + non-empty reason when nothing survives filtering", () => {
+    const incumbent = endpoint("m", { providerID: "a" });
+    const res = route({
+      catalog: [endpoint("dead", { status: "retired" })],
       policy: { preset: "balanced" },
-      nowMs: 0,
+      intent: { incumbent },
     });
     expect(res.model).toBe(incumbent);
     expect(res.changed).toBe(false);
     expect(res.reason).toContain("no general model passes constraints");
   });
 
-  it("REGRESSION: mid-exchange never switches", () => {
-    const incumbent = m("claude-opus-4");
-    // A far cheaper, perfectly valid candidate exists — switching must still
-    // be refused: replaying one model's thinking blocks to another is a
-    // documented source of provider errors, and the cold cache write costs
-    // more than it saves.
-    const cheap = m("claude-haiku-4");
-    const res = chooseModel({
-      intent: { kind: "mid-exchange", agent: "general", incumbent },
-      catalog: [incumbent, cheap],
-      policy: { preset: "performance" },
-      nowMs: 0,
+  it("REGRESSION: routing activates from a preset alone (BET-1251)", () => {
+    const cheap = endpoint("haiku-4", { tier: "fast" });
+    const balanced = endpoint("sonnet-4", { tier: "balanced" });
+    const res = route({
+      catalog: [cheap, balanced],
+      policy: { preset: "economy" },
+      intent: { incumbent: endpoint("opus-4", { providerID: "a" }) },
+    });
+    expect(res.model?.id).toBe("sonnet-4");
+    expect(res.changed).toBe(true);
+  });
+});
+
+describe("chooseModel — hard stages (eligibility, capability, health)", () => {
+  it("honours the agent floor under economy (general raised fast -> balanced)", () => {
+    expect(AGENT_FLOOR_SCORE.general).toBe(0.4);
+    expect(AGENT_TIER.economy.general).toBe("fast");
+    const fast = endpoint("haiku-4", { tier: "fast" });
+    const balanced = endpoint("sonnet-4", { tier: "balanced" });
+    const res = route({ catalog: [balanced, fast], policy: { preset: "economy" } });
+    if (tierRank(AGENT_TIER.economy.general) < tierRank("balanced")) {
+      // floor must win: a fast model exists but the lower bound is balanced
+      expect(res.model?.id).toBe("sonnet-4");
+    }
+    expect(res.model).toBeTruthy();
+  });
+
+  it("endpoints do not merge — two providers of one model are two candidates", () => {
+    const dear = endpoint("m", { providerID: "a" });
+    const cheap = endpoint("m", { providerID: "b", cost: { input: 0.1, output: 0.1, cacheRead: 0.05, cacheWrite: 0.05 } });
+    const res = route({ catalog: [dear, cheap], policy: { preset: "balanced" } });
+    expect(res.model?.providerID).toBe("b");
+    expect(res.alternatives.some((x) => keyOf(x) === keyOf(dear))).toBe(true);
+  });
+
+  it("cheaper blended price wins between two endpoints of the same model", () => {
+    const a = endpoint("m", { providerID: "a", cost: { input: 1, output: 1, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const b = endpoint("m", { providerID: "b", cost: { input: 5, output: 5, cacheRead: 2.5, cacheWrite: 2.5 } });
+    const res = route({ catalog: [b, a], policy: { preset: "balanced" } });
+    expect(res.model?.providerID).toBe("a");
+  });
+
+  it("the cache case: identical input/output, the caching endpoint wins", () => {
+    const caching = endpoint("m", { providerID: "a", cost: { input: 1, output: 1, cacheRead: 0, cacheWrite: 0 } });
+    const noCache = endpoint("m", { providerID: "b", cost: { input: 1, output: 1 } });
+    const res = route({
+      catalog: [noCache, caching],
+      policy: { preset: "balanced" },
+      services: { declared: { ...defaultDeclared([caching, noCache]), "b/m": { catalogId: "m", caches: true } } },
+    });
+    expect(res.model?.providerID).toBe("a");
+  });
+
+  it("tool filter fires: a tool-requiring intent drops toolcall:false", () => {
+    const good = endpoint("m", { providerID: "a", capabilities: { toolcall: true, input: { image: true, pdf: true } } });
+    const bad = endpoint("m", { providerID: "b", capabilities: { toolcall: false, input: { image: true, pdf: true } } });
+    const res = route({
+      catalog: [bad, good],
+      policy: { preset: "balanced" },
+      intent: { needs: { tools: true } },
+    });
+    expect(res.model?.providerID).toBe("a");
+    expect(res.alternatives.find((x) => keyOf(x) === keyOf(bad))).toBeUndefined();
+  });
+
+  it("modality: an image-carrying turn drops an endpoint that cannot take images", () => {
+    const good = endpoint("m", { providerID: "a" });
+    const noImg = endpoint("m", { providerID: "b", capabilities: { toolcall: true, input: { image: false, pdf: true } } });
+    const res = route({
+      catalog: [noImg, good],
+      policy: { preset: "balanced" },
+      intent: { needs: { image: true } },
+    });
+    expect(res.model?.providerID).toBe("a");
+  });
+
+  it("unidentifiable excluded: autoEligibility false is never chosen", () => {
+    const known = endpoint("known");
+    const opaque = endpoint("opaque", { providerID: "q" });
+    // `opaque` is deliberately NOT declared, so its identity is unknown.
+    const res = route({
+      catalog: [opaque, known],
+      policy: { preset: "balanced" },
+      services: { declared: defaultDeclared([known]) },
+    });
+    expect(res.model?.id).toBe("known");
+  });
+
+  it("unhealthy excluded: an out-of-credit provider is unselectable even when sole candidate", () => {
+    const only = endpoint("m", { providerID: "a" });
+    const incumbent = endpoint("inc", { providerID: "x" });
+    const res = route({
+      catalog: [only],
+      policy: { preset: "balanced" },
+      services: { health: { a: "out-of-credit" } },
+      intent: { incumbent },
     });
     expect(res.model).toBe(incumbent);
     expect(res.changed).toBe(false);
-    expect(res.reason).toBe("mid-exchange switching is disabled");
+    expect(res.reason).toContain("out-of-credit");
+  });
+
+  it("rate-limited is also excluded as a hard constraint", () => {
+    const only = endpoint("m", { providerID: "a" });
+    const incumbent = endpoint("inc", { providerID: "x" });
+    const res = route({
+      catalog: [only],
+      policy: { preset: "balanced" },
+      services: { health: { a: "rate-limited" } },
+      intent: { incumbent },
+    });
+    expect(res.model).toBe(incumbent);
+    expect(res.reason).toContain("rate-limited");
+  });
+});
+
+describe("chooseModel — soft ordering (stage 3)", () => {
+  it("reliability outranks price within a model: a penalised endpoint loses to a dearer reliable one", () => {
+    const reliable = endpoint("m", { providerID: "a", cost: { input: 10, output: 10, cacheRead: 5, cacheWrite: 5 } });
+    const unreliable = endpoint("m", { providerID: "b", cost: { input: 1, output: 1, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const res = route({
+      catalog: [unreliable, reliable],
+      policy: { preset: "balanced" },
+      services: {
+        reliability: {
+          samples: { "b/m": { requests: 30, errored: 15, rate: 0.5 } },
+          baseline: { m: { rate: 0.1, n: 100 } },
+        },
+      },
+    });
+    expect(res.model?.providerID).toBe("a");
+  });
+
+  it("below the sample floor no penalty applies and cost decides", () => {
+    const reliable = endpoint("m", { providerID: "a", cost: { input: 10, output: 10, cacheRead: 5, cacheWrite: 5 } });
+    const cheap = endpoint("m", { providerID: "b", cost: { input: 1, output: 1, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const res = route({
+      catalog: [cheap, reliable],
+      policy: { preset: "balanced" },
+      services: {
+        reliability: {
+          samples: { "b/m": { requests: 3, errored: 3, rate: 1 } },
+          baseline: { m: { rate: 0.1, n: 100 } },
+        },
+      },
+    });
+    expect(res.model?.providerID).toBe("b");
+  });
+
+  it("ties are defined: identical cost yields the same winner across runs and shuffles", () => {
+    const a = endpoint("m", { providerID: "a" });
+    const b = endpoint("m", { providerID: "b" });
+    const base = route({ catalog: [a, b], policy: { preset: "balanced" } });
+    for (let i = 0; i < 40; i++) {
+      const shuffled = [a, b].sort(() => Math.random() - 0.5);
+      const res = route({ catalog: shuffled, policy: { preset: "balanced" } });
+      expect(keyOf(res.model)).toBe(keyOf(base.model));
+    }
+    expect(keyOf(base.model)).toBe("a/m"); // full key is the last, deterministic tiebreak
+  });
+
+  it("is deterministic across 100 shuffles of the catalog", () => {
+    const catalog = [
+      endpoint("sonnet-4", { tier: "balanced" }),
+      endpoint("gpt-4o", { tier: "balanced" }),
+      endpoint("gpt-5", { tier: "balanced" }),
+      endpoint("haiku-4", { tier: "fast" }),
+    ];
+    const incumbent = endpoint("sonnet-4", { providerID: "a" });
+    const base = route({ catalog, policy: { preset: "balanced" }, intent: { incumbent } });
+    for (let i = 0; i < 100; i++) {
+      const shuffled = [...catalog].sort(() => Math.random() - 0.5);
+      const res = route({ catalog: shuffled, policy: { preset: "balanced" }, intent: { incumbent } });
+      expect(keyOf(res.model)).toBe(keyOf(base.model));
+    }
+  });
+
+  it("partitions by model: a cheaper weaker model never displaces a stronger one under balanced", () => {
+    const strong = endpoint("strong", { tier: "balanced", score: 0.6, providerID: "a", cost: { input: 100, output: 100, cacheRead: 50, cacheWrite: 50 } });
+    const weak = endpoint("weak", { tier: "balanced", score: 0.45, providerID: "b", cost: { input: 1, output: 1, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const res = route({ catalog: [weak, strong], policy: { preset: "balanced" } });
+    expect(res.model?.id).toBe("strong");
+  });
+
+  it("under economy the partition is flattened: the cheaper weaker model wins, and the reason says so", () => {
+    const strong = endpoint("strong", { tier: "balanced", score: 0.6, providerID: "a", cost: { input: 100, output: 100, cacheRead: 50, cacheWrite: 50 } });
+    const weak = endpoint("weak", { tier: "balanced", score: 0.45, providerID: "b", cost: { input: 1, output: 1, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const res = route({ catalog: [weak, strong], policy: { preset: "economy" } });
+    expect(res.model?.id).toBe("weak");
+    expect(res.reason.toLowerCase()).toContain("economy");
+  });
+
+  it("widening: an empty target band widens one band, never below the floor", () => {
+    // general's floor is balanced; only a deep model is available -> widen up to deep.
+    const deep = endpoint("deep", { tier: "deep", providerID: "a" });
+    const res = route({ catalog: [deep], policy: { preset: "balanced" } });
+    expect(res.model?.id).toBe("deep");
+  });
+
+  it("soft never empties: even when every endpoint is penalised, a winner is still returned", () => {
+    const a = endpoint("m", { providerID: "a" });
+    const b = endpoint("m", { providerID: "b" });
+    const res = route({
+      catalog: [a, b],
+      policy: { preset: "balanced" },
+      services: {
+        reliability: {
+          samples: { "a/m": { requests: 30, errored: 30, rate: 1 }, "b/m": { requests: 30, errored: 30, rate: 1 } },
+          baseline: { m: { rate: 0.1, n: 100 } },
+        },
+      },
+    });
+    expect(res.model).toBeTruthy();
+    expect(["a", "b"]).toContain(res.model?.providerID);
+  });
+});
+
+describe("chooseModel — return shape", () => {
+  it("alternatives are capped at 3 same-tier runners-up, ordered", () => {
+    const a = endpoint("m", { providerID: "a", cost: { input: 1, output: 1, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const b = endpoint("m", { providerID: "b", cost: { input: 2, output: 2, cacheRead: 1, cacheWrite: 1 } });
+    const c = endpoint("m", { providerID: "c", cost: { input: 3, output: 3, cacheRead: 1.5, cacheWrite: 1.5 } });
+    const d = endpoint("m", { providerID: "d", cost: { input: 4, output: 4, cacheRead: 2, cacheWrite: 2 } });
+    const e = endpoint("m", { providerID: "e", cost: { input: 5, output: 5, cacheRead: 2.5, cacheWrite: 2.5 } });
+    const res = route({ catalog: [a, b, c, d, e], policy: { preset: "balanced" } });
+    expect(res.model?.providerID).toBe("a");
+    expect(res.alternatives.map((x) => x.providerID)).toEqual(["b", "c", "d"]);
   });
 });


### PR DESCRIPTION
**BET-1236 — Routing: restructure modelRouter around endpoints with hard/soft filter stages**

Rewrites `src/shared/modelRouter.mjs` around **endpoints** (a `(model, provider)` pair that never merges) with an explicit hard/soft filter split, and moves every notion of cost and quality out into the Stage-2 modules it consumes. The router is smaller (net-negative on lines: 307 -> 265) and knows less.

- **Hard Stage 1 — Eligible**: `autoEligibility(...).eligible === true` (identity/price/caching/quality completeness).
- **Hard Stage 2 — Capable**: context headroom, tool-call/modality gates, provider health (`out-of-credit` / `rate-limited` excluded hard). Missing metadata stays permissive except `status`.
- **Soft Stage 3 — Ordered (never empties)**: partition by model (flattened under `economy`) → within-model reliability (`shouldDerank` penalised sorts last; unmeasured = average) → lowest `marginalCost`. Ties: quality → throughput p50 → p90 → latency → **full `providerID/modelID` key** (fixes the old accident where the model-id-only final tiebreak was equal for exactly the endpoints most likely to tie).
- **Tier targeting**: `policy.perAgent?.[agent] ?? AGENT_TIER[preset][agent]`, clamped up to the `modelQuality` score floor; empty target band widens one band, never below the floor; nothing survives → incumbent + binding-constraint reason.
- Return shape unchanged (`model`, `reason`, `alternatives` (≤3 same-tier), `changed`). Invariants intact: mid-exchange never routes; off-path returns the incumbent **by reference** (byte-identical, BET-1251 activation preserved); pure, `nowMs` injected, no `Date.now()`, no provider NAME in the file or its imports.

**Deleted from modelRouter.mjs**: `effectivePrice`, `scarcity`, `pickWindow`, `REFERENCE_PRICE`, `FREE_FLOOR`, `DAY_MS`, `tierOf`, `TIER_NAMES`, `AGENT_FLOOR` (tier-name form) and the duplicate `filterByConstraints`. `AGENT_TIER` / `PRESETS` kept (still consumed by the router, `ModelRoutingCard`, `settingsSchema`).

**Callers threading**: `delegate.mjs` wrappers (`chooseSubagentModel` / `chooseMainModel`, and `startJob`) thread an injected optional routing `services` through to `chooseModel`; absent services → safe incumbent fallback (routing honestly reports no usable endpoint until the wiring issue feeds the context). `ModelRoutingCard` reads the floor from `modelQuality` (`AGENT_FLOOR_SCORE`) now that `AGENT_FLOOR` is gone.

**Files changed (7):**
- `src/shared/modelRouter.mjs` (rewrite)
- `src/shared/modelRouter.d.mts` (new endpoint/services contract)
- `src/shared/modelRouter.test.ts` (rewrite — all new required cases)
- `src/shared/modelQuality.test.ts` (drop AGENT_FLOOR dep; assert score floors)
- `src/server/delegate.mjs` (thread `services`)
- `src/server/delegate.test.mjs` (feed routing context to routing tests)
- `src/renderer/ModelRoutingCard.tsx` (floor from `modelQuality`)

**Verification results:**
- typecheck: exit 0. Errors: none.
- test (vitest): `180` files, `3406` passed / `7` skipped. Failures: none.
- test (node:test server): `2619` pass / `0` fail. Failures: none.
- Conclusion: 0 new failures.

Base: origin/main @ `a7a82f50`
