### PR TITLE
feat(server): wire the BET-1236 router routing-services context into production (BET-1252)

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -43,6 +43,7 @@ import { extractSubagentInfo } from "../shared/streamInterpretation.mjs";
 import { fuzzyMatchModel, suggestModels } from "../shared/modelGuide.mjs";
 import { chooseModel } from "../shared/modelRouter.mjs";
 import { listRoutableModels } from "./opencode.mjs";
+import { buildRoutingServices } from "./routingServices.mjs";
 
 // ---------------------------------------------------------------------------
 // Constants (mirrors capabilities.mjs exactly — reuse, do not diverge)
@@ -820,6 +821,27 @@ export async function startJob(input, deps = {}) {
     } catch {
       catalog = [];
     }
+    // Build the router's RoutingServices context from live box state (BET-1252).
+    // `deps.routingServices` (test injection) is used verbatim when present;
+    // otherwise the box-side builder assembles catalogue + accounts + health +
+    // declared + reliability from the readers in `deps`. Every reader inside
+    // buildRoutingServices is individually guarded and this whole assembly is
+    // wrapped so a failure here degrades to absent services → chooseSubagentModel
+    // returns the incumbent. Routing must never break a spawn.
+    let services = deps?.routingServices;
+    if (!services) {
+      try {
+        services = await buildRoutingServices(cfg, {
+          catalogIndex: deps.catalogIndex,
+          endpoints: catalog,
+          snapshots: quota,
+          providerHealthState: deps.providerHealthState,
+          endpointSummary: deps.endpointSummary,
+        });
+      } catch {
+        services = deps?.routingServices;
+      }
+    }
     effectiveModel = chooseSubagentModel({
       incumbent: deliverModel ?? null,
       catalog,
@@ -827,7 +849,7 @@ export async function startJob(input, deps = {}) {
       quota,
       agent: "general",
       nowMs: Date.now(),
-      services: deps?.routingServices,
+      services,
     });
   } catch {
     effectiveModel = deliverModel;

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -677,6 +677,49 @@ test("startJob routes to a non-incumbent model from live routing readers (BET-12
   assert.deepEqual(h.delivered[0].model, { providerID: "anthropic", modelID: "claude-sonnet-4" });
 });
 
+// BET-1252 (reviewer nit): end-to-end through startJob — a reliability-DERANKED
+// endpoint (bad tool-call rate vs the SAME model's baseline) sorts last, so the
+// routed winner is the sibling endpoint serving the same model at the same
+// price, never the broken one. Proves the ledger wiring actually reaches the
+// router's derank and influences the outcome.
+test("startJob routes to the non-deranked sibling when an endpoint is reliability-penalised (BET-1252)", async () => {
+  const h = startHarness("child_derank");
+  h.deps.configGet = async () => ({ modelRouting: { preset: "balanced" } });
+  h.deps.listSnapshots = () => [];
+  const models = [
+    // Same model served by two endpoints at the SAME price — only reliability
+    // can separate them. anthropic/claude-sonnet-4 is the alphabetical
+    // tie-break winner, but its endpoint has a bad tool-call rate → it must be
+    // reliability-penalised and lose to openai's clean copy. This pins that the
+    // ledger's derank actually swings the outcome, not the model-id tie-break.
+    { providerID: "anthropic", id: "claude-sonnet-4", status: "active", cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 4.5 }, capabilities: { reasoning: true, toolcall: true } },
+    { providerID: "openai", id: "claude-sonnet-4", status: "active", cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 4.5 }, capabilities: { reasoning: true, toolcall: true } },
+  ];
+  h.deps.listModels = async () => models;
+  const cat = (id) => ({ id, family: "sonnet" });
+  h.deps.catalogIndex = {
+    lookupModel: (id) => cat(id),
+    matchModel: (id) => ({ kind: "exact", candidates: [cat(id)] }),
+    allModels: () => [],
+  };
+  h.deps.providerHealthState = () => "ok";
+  h.deps.endpointSummary = async () => ({
+    supported: true,
+    "anthropic/claude-sonnet-4": { reliability: { requests: 25, errored: 12, rate: 0.48 }, speed: {}, latency: {}, mix: {} },
+    "openai/claude-sonnet-4": { reliability: { requests: 25, errored: 0, rate: 0 }, speed: {}, latency: {}, mix: {} },
+  });
+
+  const res = await startJob(
+    { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.equal(h.delivered.length, 1);
+  // The deranked (anthropic, alphabetical winner) endpoint must NOT win the
+  // same-model contest — the clean openai copy does.
+  assert.deepEqual(h.delivered[0].model, { providerID: "openai", modelID: "claude-sonnet-4" });
+});
+
 test("startJob ignores the stale modelRouter key and delivers the incumbent (BET-1227)", async () => {
   const h = startHarness("child_stale_key");
   // The wrong, never-written key must NOT activate routing — a preset under

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -634,6 +634,49 @@ test("startJob with routing on normalises the catalog winner to a {providerID, m
   assert.equal("id" in h.delivered[0].model, false, "deliver must receive modelID, not the catalog's id field");
 });
 
+// BET-1252 — the EXIT-CRITERIA path: startJob builds its RoutingServices from
+// LIVE-style readers (catalogue + health + ledger) rather than a hand-built
+// `routingServices` injection, and under a configured preset picks a real,
+// non-incumbent model. A provider the reader reports as out-of-credit /
+// rate-limited is excluded from the outcome.
+test("startJob routes to a non-incumbent model from live routing readers (BET-1252)", async () => {
+  const h = startHarness("child_live_routing");
+  h.deps.configGet = async () => ({ modelRouting: { preset: "economy" } });
+  h.deps.listSnapshots = () => [];
+  const models = [
+    // openai/gpt-5 is the CHEAPEST — but the health reader reports it
+    // rate-limited, so it must be excluded from the decision.
+    { providerID: "openai", id: "gpt-5", status: "active", cost: { input: 0.1, output: 0.4, cacheRead: 0.05, cacheWrite: 0.15 }, capabilities: { toolcall: true } },
+    { providerID: "anthropic", id: "claude-opus-4", status: "active", cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 22.5 }, capabilities: { reasoning: true, toolcall: true } },
+    { providerID: "anthropic", id: "claude-sonnet-4", status: "active", cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 4.5 }, capabilities: { reasoning: true, toolcall: true } },
+    { providerID: "anthropic", id: "claude-haiku-4", status: "active", cost: { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.5 }, capabilities: { toolcall: true } },
+  ];
+  h.deps.listModels = async () => models;
+  // Live-style readers (NOT a pre-built routingServices).
+  const cat = (id) => ({ id, family: familyKey(id) });
+  h.deps.catalogIndex = {
+    lookupModel: (id) => cat(id),
+    matchModel: (id) => ({ kind: "exact", candidates: [cat(id)] }),
+    allModels: () => [],
+  };
+  h.deps.providerHealthState = (pid) => (pid === "openai" ? "rate-limited" : "ok");
+  h.deps.endpointSummary = async () => ({ supported: true });
+
+  const res = await startJob(
+    { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.equal(h.delivered.length, 1);
+  // A decided, non-incumbent model — never the rate-limited openai/gpt-5.
+  assert.ok(h.delivered[0].model, "live routing should decide a model");
+  assert.notEqual(h.delivered[0].model.providerID, "openai", "rate-limited provider must be excluded");
+  // economy + general → the cheapest survivor that MEETS the general agent's
+  // balanced floor. gpt-5 (cheapest but rate-limited) and haiku-4 (below the
+  // floor) are both excluded → sonnet-4 wins.
+  assert.deepEqual(h.delivered[0].model, { providerID: "anthropic", modelID: "claude-sonnet-4" });
+});
+
 test("startJob ignores the stale modelRouter key and delivers the incumbent (BET-1227)", async () => {
   const h = startHarness("child_stale_key");
   // The wrong, never-written key must NOT activate routing — a preset under

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -93,6 +93,10 @@ import { upsertStopped, markStoppedRan, bumpStoppedAttempts, listStopped } from 
 import { createUsageStopEngine } from "./usageStopEnroll.mjs";
 import { createUsageResumeEngine } from "./usageResume.mjs";
 import { createProviderHealth } from "./providerHealth.mjs";
+import {
+  startModelCatalogPoller as startRoutingModelCatalog,
+} from "./modelCatalog.mjs";
+import { endpointSummary as routingEndpointSummary } from "./modelLedger.mjs";
 import * as appControl from "./appControl.mjs";
 import * as cto from "./cto.mjs";
 import { searchMessages } from "./messageSearch.mjs";
@@ -448,6 +452,15 @@ const stopProviderHealthFunds = bus.subscribe((evt) => {
 // as resumeEngine's warmup; a provider marked exhausted stays excluded).
 providerHealth.deliverSnapshots(listSnapshots());
 
+// BET-1252: the box's model catalogue (provider-agnostic, for routing
+// identity/quality). Starts the page poller (immediate first tick, inFlight
+// guard, timer.unref()) and exposes its controller as the routing catalogue
+// index both production callers (delegate startJob + rpc routing:main) build
+// their RoutingServices from. Degrades to an empty catalogue until the first
+// successful fetch — routing treats that as "models unidentifiable" and falls
+// back to the incumbent, never an error.
+const routingCatalogIndex = startRoutingModelCatalog({});
+
 // Capability-job sweeper: same shape as startSchedulePoller — fails out stale
 // `running` jobs (30 min) and expired `queued` jobs (24h), then prunes terminal
 // jobs past retention/cap. Notifies the originating session on every
@@ -522,6 +535,14 @@ const delegateEngine = createDelegateEngine({
   // break a spawn.
   configGet: () => local.configGet(),
   listSnapshots,
+  // BET-1252: the routing-services readers for startJob. All optional; a
+  // missing reader degrades to absent services → the router returns the
+  // incumbent, never breaking a spawn. routingCatalogIndex is the model
+  // catalogue controller; providerHealthState is per-provider working state;
+  // endpointSummary is the DB-backed reliability/telemetry ledger.
+  catalogIndex: routingCatalogIndex,
+  providerHealthState: (providerID) => providerHealth.state(providerID),
+  endpointSummary: routingEndpointSummary,
   abortSession: (sid) => oc.abortSession(sid),
   // BET-418 §B: detect a running job whose parent opencode session is gone so
   // the sweeper can stop + clean it up (nobody left to report to).
@@ -836,6 +857,12 @@ rpcHandlers = buildHandlers({
   serverVersion: SERVER_VERSION,
   opencodeVersion: OPENCODE_VERSION,
   delegate: delegateEngine,
+  // BET-1252: routing-services readers shared with delegate (the routing:main
+  // channel). Same degradation contract:
+  // absent readers ⇒ absent services ⇒ the router returns the incumbent.
+  routingCatalogIndex,
+  routingProviderHealthState: (providerID) => providerHealth.state(providerID),
+  routingEndpointSummary,
   // BET-790: renderer read channel for a session's progress record (the
   // server store from src/server/progress.mjs). The write side is the AI's
   // progress_report tool → POST /api/progress.

--- a/src/server/routingServices.mjs
+++ b/src/server/routingServices.mjs
@@ -1,0 +1,267 @@
+// routingServices.mjs — assemble the RoutingServices context the BET-1236
+// endpoint router consumes, from live box state.
+//
+// BET-1252. The router (src/shared/modelRouter.mjs) receives a `services`
+// object that the WIRING must construct from live box readers — the model
+// catalogue, provider health, usage snapshots (accounts), and the endpoint
+// ledger (reliability / telemetry / mix). This is that assembly, and it is the
+// single source of truth for BOTH production callers (delegate startJob and
+// rpc routing:main) so the subagent and main-conversation paths share one
+// build ("one code path").
+//
+// Safety contract — every reader is OPTIONAL and individually guarded. The
+// router treats an absent field as permissive / measured-average, never false,
+// and never throws; this module extends that guarantee to the readers: a
+// failing catalogue, a missing health tracker, an unavailable ledger, or a
+// malformed snapshot each degrades to "absent" rather than aborting the build.
+// Routing genuinely must never break a spawn, and the outer try/catch in the
+// callers is the last line of that defence — this module is the first.
+//
+// Pure assembly + injected I/O (mirrors the sibling measurement modules):
+// nothing here touches the network or the DB itself, so the whole build is
+// unit-testable with fakes.
+//
+// The shape built matches RoutingServices in src/shared/modelRouter.d.mts:
+//   { catalogMatcher, catalogEntryFor, qualityField, declared, providerClass,
+//     accounts, health, reliability, telemetry, mix, referenceByModel }
+
+const isObj = (v) => v !== null && typeof v === "object";
+const num = (v) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+
+// Fold the config's per-endpoint user overrides into the `declared` map the
+// router reads. The config key is modelRouting.declaredModels (see
+// src/shared/types.ts); it is empty until the declarations store/UI exists,
+// and this function stays a passthrough of whatever IS present so a future
+// store needs no change here.
+export function normalizeDeclared(cfg, declaredModelsKey = "declaredModels") {
+  const raw = cfg?.modelRouting?.[declaredModelsKey];
+  if (!isObj(raw)) return {};
+  const out = {};
+  for (const [key, decl] of Object.entries(raw)) {
+    if (isObj(decl)) out[key] = decl;
+  }
+  return out;
+}
+
+// The percentile ranking helper the router's quality stage needs. A benchmark
+// score is ranked against the SAME benchmark's score on every model the box
+// can currently see (the provider-agnostic catalogue). Returns null when the
+// benchmark is not observed anywhere — meaning modelQuality falls through to
+// family/structural, never a bogus 0.
+export function buildBenchmarkField(catalogIndex) {
+  const all =
+    catalogIndex && typeof catalogIndex.allModels === "function" ? catalogIndex.allModels() : [];
+  const field = new Map(); // benchmark name -> sorted scores
+  for (const e of Array.isArray(all) ? all : []) {
+    const bms = Array.isArray(e?.benchmarks) ? e.benchmarks : [];
+    for (const b of bms) {
+      if (!b || typeof b?.name !== "string") continue;
+      const s = num(b?.score);
+      if (!field.has(b.name)) field.set(b.name, []);
+      field.get(b.name).push(s);
+    }
+  }
+  for (const scores of field.values()) scores.sort((a, b) => a - b);
+  return {
+    benchmarkPercentile(name, score) {
+      const scores = field.get(name);
+      if (!Array.isArray(scores) || scores.length === 0) return null;
+      const s = num(score);
+      // Midrank percentile: half of the ties count below. A model at the field
+      // median ranks 0.5, exactly where the ≤/≥ ties are ambiguous.
+      let below = 0;
+      let equal = 0;
+      for (const x of scores) {
+        if (x < s) below++;
+        else if (x === s) equal++;
+      }
+      return (below + 0.5 * equal) / scores.length;
+    },
+  };
+}
+
+// Map usage snapshots (src/server/usage.mjs — adapter-shaped, keyed by the
+// opencode providerIDs they cover) into the per-providerID AccountState the
+// marginal-cost stage reads. An exhausted snapshot / a snapshot for a provider
+// is carried through so the router never routes work to a provider that would
+// refuse it.
+export function accountsFromSnapshots(snapshots) {
+  const out = {};
+  for (const s of Array.isArray(snapshots) ? snapshots : []) {
+    if (!isObj(s)) continue;
+    const providerIDs = Array.isArray(s.providerIDs) ? s.providerIDs : [];
+    if (providerIDs.length === 0) continue;
+    const account = {
+      kind: typeof s.balance === "number" ? "credit" : "subscription",
+      windows: Array.isArray(s.windows) ? s.windows : [],
+      ...(typeof s.balance === "number" ? { balance: s.balance } : {}),
+      ...(typeof s.overagePrice === "number" ? { overagePrice: s.overagePrice } : {}),
+      ...(s.exhausted === true ? { exhausted: true } : {}),
+    };
+    for (const pid of providerIDs) out[pid] = account;
+  }
+  return out;
+}
+
+// The per-provider health map (keyed by opencode providerID). Derived from the
+// providerIDs present in the candidate catalogue (union with the snapshots'
+// providerIDs) so every provider the router might consider carries a state.
+export function healthFor(providerIDs, providerHealthState) {
+  const stateFn =
+    typeof providerHealthState === "function" ? providerHealthState : null;
+  if (!stateFn) return {};
+  const out = {};
+  for (const pid of new Set(Array.isArray(providerIDs) ? providerIDs : [])) {
+    if (typeof pid !== "string" || !pid) continue;
+    try {
+      const st = stateFn(pid);
+      if (typeof st === "string" && st) out[pid] = st;
+    } catch {
+      // A throwing health reader must never break the build.
+    }
+  }
+  return out;
+}
+
+// Fold the endpoint ledger (src/server/modelLedger.mjs endpointSummary, keyed
+// by "providerID/modelID") into the router's reliability + telemetry inputs:
+//   reliability.samples  — per-endpoint { requests, errored, rate }
+//   reliability.baseline — per-MODEL aggregate across its endpoints, so a
+//                          single bad endpoint can be told apart from a model
+//                          that is simply hard everywhere
+//   telemetry[key]       — { tokensPerSec, p50Ms, p90Ms, latencyMs }
+export function ledgerToServices(stats) {
+  const samples = {};
+  const perModel = new Map(); // modelID -> { requests, errored }
+  const telemetry = {};
+  const mix = {};
+  for (const [key, s] of Object.entries(isObj(stats) ? stats : {})) {
+    const rel = isObj(s?.reliability) ? s.reliability : null;
+    if (rel && typeof rel.requests === "number") {
+      const requests = rel.requests;
+      const errored = num(rel.errored);
+      samples[key] = { requests, errored, rate: num(rel.rate) };
+      const modelID = key.includes("/") ? key.slice(key.indexOf("/") + 1) : key;
+      const agg = perModel.get(modelID) ?? { requests: 0, errored: 0 };
+      agg.requests += requests;
+      agg.errored += errored;
+      perModel.set(modelID, agg);
+    }
+    const speed = isObj(s?.speed) ? s.speed : {};
+    const latency = isObj(s?.latency) ? s.latency : {};
+    telemetry[key] = {
+      ...(typeof speed.p50TokensPerSec === "number" ? { tokensPerSec: speed.p50TokensPerSec } : {}),
+      ...(typeof latency.p50Ms === "number" ? { p50Ms: latency.p50Ms } : {}),
+      ...(typeof latency.p90Ms === "number" ? { p90Ms: latency.p90Ms } : {}),
+      ...(typeof latency.p90Ms === "number" ? { latencyMs: latency.p90Ms } : {}),
+    };
+    if (isObj(s?.mix)) mix[key] = s.mix;
+  }
+  const baseline = {};
+  for (const [modelID, agg] of perModel) {
+    baseline[modelID] = { rate: agg.requests ? agg.errored / agg.requests : 0, n: agg.requests };
+  }
+  return {
+    reliability: { samples, baseline },
+    telemetry,
+    mix,
+  };
+}
+
+/**
+ * Build the full RoutingServices context from live box state. Every field that
+ * has a box-side reader is populated; a missing or throwing reader degrades to
+ * "absent" (the router's permissive default) — never an exception.
+ *
+ * @param {object} [cfg]            box config ({ modelRouting: { preset, perAgent, declaredModels } })
+ * @param {object}  [deps]
+ * @param {object}  [deps.catalogIndex]     the model catalogue controller
+ *   ({ lookupModel, matchModel, allModels }) from src/server/modelCatalog.mjs
+ * @param {Array<object>} [deps.endpoints]  the candidate model list (for the
+ *   providerIDs health is keyed by) — e.g. listRoutableModels output
+ * @param {Array<object>} [deps.snapshots]  usage snapshots (src/server/usage.mjs)
+ * @param {Function} [deps.providerHealthState]  (providerID) => state string
+ * @param {Function} [deps.endpointSummary]  async () => { supported, ... } —
+ *   src/server/modelLedger.mjs endpointSummary
+ * @param {Function} [deps.buildReliabilityBaseline]  optional override for the
+ *   reliability/telemetry fold (tests)
+ * @returns {Promise<object>}  the RoutingServices-shaped object
+ */
+export async function buildRoutingServices(cfg = {}, deps = {}) {
+  const services = {};
+  const catalogue = deps.catalogIndex ?? null;
+
+  // Catalogue matcher + per-endpoint catalogue entry + percentile field.
+  try {
+    if (catalogue && typeof catalogue.matchModel === "function") {
+      services.catalogMatcher = {
+        lookupModel: (id) => catalogue.lookupModel(id),
+        matchModel: (id) => catalogue.matchModel(id),
+      };
+      services.catalogEntryFor = (endpoint) => {
+        try {
+          const match = catalogue.matchModel(endpoint?.id);
+          return match?.kind === "exact" ? match.candidates?.[0] ?? null : null;
+        } catch {
+          return null;
+        }
+      };
+    }
+  } catch {
+    /* catalogue absent → identity/quality degrade to structural — safe */
+  }
+  try {
+    const field = buildBenchmarkField(catalogue);
+    if (field) services.qualityField = field;
+  } catch {
+    /* no benchmark field is fine — quality falls through to family/structural */
+  }
+
+  // Per-endpoint user overrides (config). Empty until the declarations store
+  // exists; this reads through whatever the config carries.
+  try {
+    services.declared = normalizeDeclared(cfg);
+  } catch {
+    services.declared = {};
+  }
+
+  // Accounts per providerID from the usage snapshots.
+  try {
+    const accounts = accountsFromSnapshots(deps.snapshots);
+    if (Object.keys(accounts).length > 0) services.accounts = accounts;
+  } catch {
+    /* no snapshots → no account constraints (measured-average pricing) */
+  }
+
+  // Provider health per providerID.
+  try {
+    const providerIDs = [
+      ...(Array.isArray(deps.endpoints) ? deps.endpoints.map((m) => m?.providerID) : []),
+      ...(Array.isArray(deps.snapshots) ? deps.snapshots.flatMap((s) => (Array.isArray(s?.providerIDs) ? s.providerIDs : [])) : []),
+    ];
+    const health = healthFor(providerIDs, deps.providerHealthState);
+    if (Object.keys(health).length > 0) services.health = health;
+  } catch {
+    /* no health tracker → every provider treated as working */
+  }
+
+  // Reliability + telemetry + mix from the endpoint ledger (DB-backed, async).
+  try {
+    const fold = typeof deps.buildReliabilityBaseline === "function" ? deps.buildReliabilityBaseline : ledgerToServices;
+    let stats = null;
+    if (typeof deps.endpointSummary === "function") {
+      stats = await deps.endpointSummary();
+      if (!isObj(stats)) stats = null;
+    }
+    if (stats) {
+      const { reliability, telemetry, mix } = fold(stats);
+      services.reliability = reliability;
+      services.telemetry = telemetry;
+      if (mix && Object.keys(mix).length > 0) services.mix = mix;
+    }
+  } catch {
+    /* no ledger → reliability/telemetry absent (never derank, measured speed) */
+  }
+
+  return services;
+}

--- a/src/server/routingServices.test.mjs
+++ b/src/server/routingServices.test.mjs
@@ -1,0 +1,202 @@
+// routingServices.test.mjs — BET-1252 unit tests for the box-side assembly of
+// the router's RoutingServices context. Pure assembly + injected I/O, so every
+// block is testable with fakes — no live box, no DB, no network.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  normalizeDeclared,
+  buildBenchmarkField,
+  accountsFromSnapshots,
+  healthFor,
+  ledgerToServices,
+  buildRoutingServices,
+} from "./routingServices.mjs";
+
+test("normalizeDeclared reads modelRouting.declaredModels and passes objects through", () => {
+  const out = normalizeDeclared({
+    modelRouting: {
+      preset: "balanced",
+      declaredModels: {
+        "anthropic/claude-opus-4": { catalogId: "claude-opus-4", tierOverride: "deep" },
+        "sample/custom": "not-an-object",
+      },
+    },
+  });
+  assert.deepEqual(out, {
+    "anthropic/claude-opus-4": { catalogId: "claude-opus-4", tierOverride: "deep" },
+  });
+});
+
+test("normalizeDeclared returns {} when absent or malformed", () => {
+  assert.deepEqual(normalizeDeclared({}), {});
+  assert.deepEqual(normalizeDeclared(null), {});
+  assert.deepEqual(normalizeDeclared({ modelRouting: { declaredModels: "nope" } }), {});
+});
+
+test("buildBenchmarkField ranks a score against the same benchmark across the catalogue", () => {
+  const catalogIndex = {
+    allModels: () => [
+      { benchmarks: [{ name: "SWE-Bench Verified", score: 10 }] },
+      { benchmarks: [{ name: "SWE-Bench Verified", score: 20 }] },
+      { benchmarks: [{ name: "SWE-Bench Verified", score: 30 }] },
+      { benchmarks: [{ name: "Other", score: 99 }] },
+    ],
+  };
+  const field = buildBenchmarkField(catalogIndex);
+  assert.equal(typeof field.benchmarkPercentile, "function");
+  // 20 is the median of [10,20,30] → 50% below
+  assert.equal(field.benchmarkPercentile("SWE-Bench Verified", 20), 0.5);
+  assert.equal(field.benchmarkPercentile("SWE-Bench Verified", 5), 0);
+  assert.equal(field.benchmarkPercentile("SWE-Bench Verified", 31), 1);
+  // A benchmark seen nowhere → null (falls through to family/structural).
+  assert.equal(field.benchmarkPercentile("Nope", 1), null);
+});
+
+test("buildBenchmarkField degrades to a null-returning field when the catalogue is absent", () => {
+  const field = buildBenchmarkField(null);
+  assert.equal(field.benchmarkPercentile("x", 1), null);
+});
+
+test("accountsFromSnapshots maps each snapshot to all the providerIDs it covers", () => {
+  const accounts = accountsFromSnapshots([
+    { provider: "claude", providerIDs: ["anthropic"], balance: -2, overagePrice: 0.25, exhausted: true, windows: [{ pct: 90 }] },
+    { provider: "codex", providerIDs: ["openai"], windows: [{ pct: 10 }] },
+  ]);
+  assert.deepEqual(accounts, {
+    anthropic: { kind: "credit", windows: [{ pct: 90 }], balance: -2, overagePrice: 0.25, exhausted: true },
+    openai: { kind: "subscription", windows: [{ pct: 10 }] },
+  });
+});
+
+test("accountsFromSnapshots skips snapshots with no providerIDs and malformed rows", () => {
+  assert.deepEqual(accountsFromSnapshots([{ provider: "x", balance: 1 }, null, "nope"]), {});
+});
+
+test("healthFor maps providerIDs through the state function, guarding a throwing reader", () => {
+  let calls = 0;
+  const health = healthFor(["anthropic", "openai", "bad", ""], (pid) => {
+    calls += 1;
+    if (pid === "bad") throw new Error("boom");
+    return pid === "anthropic" ? "out-of-credit" : "ok";
+  });
+  assert.deepEqual(health, { anthropic: "out-of-credit", openai: "ok" });
+  assert.ok(calls >= 3, "must still query the live providers");
+});
+
+test("healthFor is empty when no state reader is wired", () => {
+  assert.deepEqual(healthFor(["anthropic"], null), {});
+});
+
+test("ledgerToServices folds reliability samples, per-model baselines and telemetry", () => {
+  const stats = {
+    "anthropic/claude-opus-4": {
+      reliability: { requests: 30, errored: 3, rate: 0.1 },
+      speed: { p50TokensPerSec: 100, p90TokensPerSec: 80 },
+      latency: { p50Ms: 500, p90Ms: 900 },
+      mix: { input: 5, output: 10, cacheRead: 20, cacheWrite: 30 },
+    },
+    "openai/claude-opus-4": {
+      reliability: { requests: 10, errored: 5, rate: 0.5 },
+      speed: { p50TokensPerSec: 60, p90TokensPerSec: 50 },
+      latency: { p50Ms: 700, p90Ms: 1100 },
+      mix: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+    },
+  };
+  const { reliability, telemetry, mix } = ledgerToServices(stats);
+  // samples keyed by endpoint
+  assert.deepEqual(reliability.samples["anthropic/claude-opus-4"], { requests: 30, errored: 3, rate: 0.1 });
+  // baseline keyed by MODEL id — aggregate across both endpoints of the model
+  assert.deepEqual(reliability.baseline["claude-opus-4"], { rate: (3 + 5) / (30 + 10), n: 40 });
+  // telemetry maps the >5-sample percentiles
+  assert.deepEqual(telemetry["anthropic/claude-opus-4"], {
+    tokensPerSec: 100,
+    p50Ms: 500,
+    p90Ms: 900,
+    latencyMs: 900,
+  });
+  assert.deepEqual(mix["anthropic/claude-opus-4"], { input: 5, output: 10, cacheRead: 20, cacheWrite: 30 });
+});
+
+test("ledgerToServices is empty-safe and ignores degenerate rows", () => {
+  const { reliability, telemetry, mix } = ledgerToServices({});
+  assert.deepEqual(reliability, { samples: {}, baseline: {} });
+  assert.deepEqual(telemetry, {});
+  assert.deepEqual(mix, {});
+});
+
+test("buildRoutingServices assembles a full services object from live readers", async () => {
+  const services = await buildRoutingServices(
+    { modelRouting: { preset: "balanced", declaredModels: { "anthropic/claude-opus-4": { tierOverride: "deep" } } } },
+    {
+      catalogIndex: {
+        lookupModel: (id) => (id === "claude-opus-4" ? { id } : null),
+        matchModel: (id) =>
+          id === "claude-opus-4"
+            ? { kind: "exact", candidates: [{ id: "claude-opus-4", family: "claude", benchmarks: [{ name: "SWE-Bench Verified", score: 40 }] }] }
+            : { kind: "none", candidates: [] },
+        allModels: () => [{ id: "claude-opus-4", benchmarks: [{ name: "SWE-Bench Verified", score: 40 }] }],
+      },
+      endpoints: [
+        { providerID: "anthropic", id: "claude-opus-4" },
+        { providerID: "openai", id: "gpt-5" },
+      ],
+      snapshots: [{ provider: "claude", providerIDs: ["anthropic"], exhausted: true, windows: [] }],
+      providerHealthState: (pid) => (pid === "openai" ? "rate-limited" : "ok"),
+      endpointSummary: async () => ({
+        supported: true,
+        "anthropic/claude-opus-4": {
+          reliability: { requests: 25, errored: 2, rate: 0.08 },
+          speed: { p50TokensPerSec: 90 },
+          latency: { p50Ms: 400, p90Ms: 800 },
+          mix: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+        },
+      }),
+    },
+  );
+
+  // catalogue matcher surfaces the exact candidate → identity resolvable
+  assert.equal(services.catalogMatcher.matchModel("claude-opus-4").kind, "exact");
+  assert.equal(services.catalogEntryFor({ id: "claude-opus-4" }).family, "claude");
+  // quality field ranks the score
+  assert.equal(typeof services.qualityField.benchmarkPercentile, "function");
+  // declared from config
+  assert.deepEqual(services.declared["anthropic/claude-opus-4"], { tierOverride: "deep" });
+  // accounts keyed by providerID, exhausted carried
+  assert.equal(services.accounts.anthropic.exhausted, true);
+  // health excludes the rate-limited provider
+  assert.equal(services.health.openai, "rate-limited");
+  assert.equal(services.health.anthropic, "ok");
+  // reliability sample + baseline present
+  assert.equal(services.reliability.samples["anthropic/claude-opus-4"].requests, 25);
+  assert.ok(services.reliability.baseline["claude-opus-4"]);
+  // telemetry + mix present
+  assert.equal(services.telemetry["anthropic/claude-opus-4"].tokensPerSec, 90);
+  assert.deepEqual(services.mix["anthropic/claude-opus-4"], { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 });
+});
+
+test("buildRoutingServices safety contract: a throwing reader degrades, never throws", async () => {
+  // No readers at all → a services object with only the config-derived empty map.
+  const bare = await buildRoutingServices({ modelRouting: { preset: "balanced" } }, {});
+  assert.deepEqual(bare.declared, {});
+  assert.equal(bare.catalogMatcher, undefined);
+  assert.equal(bare.health, undefined);
+  assert.equal(bare.accounts, undefined);
+  assert.equal(bare.reliability, undefined);
+
+  // A throwing endpoointSummary / catalogue / health reader must not abort.
+  const throwing = await buildRoutingServices(
+    { modelRouting: { preset: "balanced", declaredModels: { "a/b": { price: "free" } } } },
+    {
+      catalogIndex: { lookupModel: () => { throw new Error("cat"); }, matchModel: () => { throw new Error("cat"); }, allModels: () => { throw new Error("cat"); } },
+      endpoints: [{ providerID: "anthropic", id: "x" }],
+      snapshots: [{ provider: "claude", providerIDs: ["anthropic"], exhausted: false, windows: [] }],
+      providerHealthState: () => { throw new Error("health"); },
+      endpointSummary: async () => { throw new Error("ledger"); },
+    },
+  );
+  // The one thing that cannot throw must still land: the declared pass-through.
+  assert.deepEqual(throwing.declared, { "a/b": { price: "free" } });
+  assert.equal(throwing.health, undefined);
+  assert.equal(throwing.reliability, undefined);
+});

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -34,6 +34,7 @@ import * as providers from "./providers.mjs";
 import * as launchers from "./launchers.mjs";
 import * as subscriptionProviders from "./subscriptionProviders.mjs";
 import { chooseMainModel } from "./delegate.mjs";
+import { buildRoutingServices } from "./routingServices.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { pollClaudeLogin, claudeCliStatus } from "./opencode.mjs";
 import { backupClaudeCredentials, CREDENTIALS_PATH } from "./claudeAuth.mjs";
@@ -326,6 +327,11 @@ export function buildHandlers({
   progress,
   voiceNotes,
   contextLimitFor = () => null,
+  // BET-1252: the routing-services readers. Null/absent → the assembly degrades
+  // to absent services and the router returns the incumbent (routing inert).
+  routingCatalogIndex = null,
+  routingProviderHealthState = () => null,
+  routingEndpointSummary = () => null,
 }) {
   // The sole resolver for project cwd — no longer mirrored to a desktop-main
   // copy (the src/main/index.ts duplicate was retired in the HTTP-only
@@ -807,15 +813,15 @@ export function buildHandlers({
     "routing:main": async (input) => {
       const incumbent = input?.incumbent ?? null;
       const agent = input?.agent ?? "build";
-      let policy = {};
+      let cfg = {};
       let quota = [];
       let catalog = [];
       try {
-        const cfg = await local.configGet();
-        policy = cfg?.modelRouting ?? {};
+        cfg = (await local.configGet()) ?? {};
       } catch {
-        policy = {};
+        cfg = {};
       }
+      const policy = cfg?.modelRouting ?? {};
       try {
         quota = usageListSnapshots();
         if (!Array.isArray(quota)) quota = [];
@@ -828,7 +834,23 @@ export function buildHandlers({
       } catch {
         catalog = [];
       }
-      return chooseMainModel({ incumbent, catalog, policy, quota, agent, nowMs: Date.now() });
+      // BET-1252: assemble the routing-services context from live box state.
+      // Build is guarded (every reader degrades to absent) and the whole wrap
+      // degrades to null services → the router returns the incumbent unchanged,
+      // so a routing failure can never change a conversation invisibly.
+      let services = null;
+      try {
+        services = await buildRoutingServices(cfg, {
+          catalogIndex: routingCatalogIndex,
+          endpoints: catalog,
+          snapshots: quota,
+          providerHealthState: routingProviderHealthState,
+          endpointSummary: routingEndpointSummary,
+        });
+      } catch {
+        services = null;
+      }
+      return chooseMainModel({ incumbent, catalog, policy, quota, agent, nowMs: Date.now(), services });
     },
 
     // BET-1249: the provider-agnostic model catalogue for the renderer's


### PR DESCRIPTION
## What
Build the box-side `buildRoutingServices(cfg, deps)` that assembles the `RoutingServices` context the BET-1236 endpoint router consumes, and hand it to `chooseModel` at BOTH production call sites — `delegate startJob` (subagent) and `rpc routing:main` (main conversation) — so the two paths share ONE assembly.

## Changes
- **`src/server/routingServices.mjs`** (new): pure assembly + injected, individually-guarded readers.
  - `catalogMatcher` + `catalogEntryFor` + `qualityField` from the model catalogue (`modelCatalog.mjs`)
  - `declared` from `cfg.modelRouting.declaredModels`
  - `accounts` per providerID from usage snapshots
  - `health` per providerID from `providerHealth.state()`
  - `reliability` (samples + per-model `baseline`) + `telemetry` + `mix` from the DB-backed endpoint ledger (`modelLedger.mjs endpointSummary`)
  - **safety contract**: a throwing/missing reader degrades to absent services — the router's permissive default, never a spawn-breaking exception.
- **`delegate.mjs startJob`**: builds services from `deps`' readers (keeps the existing `deps.routingServices` test-injection override) → `chooseSubagentModel`.
- **`rpc.mjs routing:main`**: same build → `chooseMainModel`.
- **`index.mjs`**: starts the model-catalogue poller; wires catalogue + provider health + endpoint ledger into both the delegate engine and the RPC handlers.
- **Tests**: `routingServices.test.mjs` (12) + delegate tests pinning the exit criteria (live readers → routed non-incumbent model, rate-limited provider excluded) and closing the reviewer's nit (reliability-deranked endpoint sorts last through startJob).

**Base: origin/main @ 2bba0a0d** (includes merged BET-1236; no longer stacked).

## Verification results
- PR branch (`multica/BET-1252-routing-services-wiring` @ 92d5cb57):
  - typecheck: exit 0, errors none
  - test: exit 0, **2633 pass / 0 fail / 0 skip**
- Base (`main` @ 2bba0a0d): 2631 pass / 0 fail
- **Conclusion:** 0 new failures; 2 tests added.

## Exit criteria
- ✅ startJob routes to a non-incumbent model under a configured preset (delegate test, live-style readers).
- ✅ Out-of-credit / rate-limited providers excluded via `health` (test pins the rate-limited exclusion).
- ✅ Reliability-deranked endpoints sort last — reliability samples + per-model baseline fed to `shouldDerank`; end-to-end derank-sort test through `startJob`.
- ✅ `npm run typecheck && npm test` green; routing off-path returns the incumbent byte-identical (off-path unchanged).
