### PR TITLE
routing:choose + accounts:retry RPC channels (BET-1244)

### DIFF
--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -33,6 +33,7 @@ import { explicitMethods } from "./demoApi.js";
 //   - a key removed → someone added a demo stub (or deleted the Api method).
 //     Delete the name from this list.
 export const DEMO_UNIMPLEMENTED = [
+  "accountsRetry",
   "agentPullFile",
   "authClaim",
   "authPair",
@@ -133,6 +134,7 @@ export const DEMO_UNIMPLEMENTED = [
   "ptyWrite",
   "pushRegisterApns",
   "revealInFolder",
+  "routingChoose",
   "scheduleCreate",
   "scheduleDelete",
   "scheduleList",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1057,6 +1057,8 @@ export const httpApi: Api = {
   opencodeModels: () => rpc(IPC.opencodeModels),
   opencodeModelRoute: (incumbent, agent) =>
     rpc(IPC.opencodeModelRoute, { incumbent, agent }),
+  routingChoose: (input) => rpc(IPC.routingChoose, input),
+  accountsRetry: (providerID) => rpc(IPC.accountsRetry, { providerID }),
   opencodeModelCatalog: () => rpc(IPC.opencodeModelCatalog),
   opencodeGetProviders: () => rpc(IPC.opencodeGetProviders),
   opencodeSetProviders: (ops) => rpc(IPC.opencodeSetProviders, ops),

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -525,7 +525,7 @@ export function resolveRequestedModel(model, models) {
 // This is a no-op for the requested-model incumbent (which is already
 // {providerID, modelID}). Shared by both routing wrappers below so the two
 // decision points normalise identically.
-function toDeliverModel(m) {
+export function toDeliverModel(m) {
   if (!m) return null;
   const providerID = m?.providerID ?? "";
   const modelID = m?.modelID ?? m?.id ?? "";

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -863,6 +863,9 @@ rpcHandlers = buildHandlers({
   routingCatalogIndex,
   routingProviderHealthState: (providerID) => providerHealth.state(providerID),
   routingEndpointSummary,
+  // BET-1244: the provider-health engine itself, for the Accounts "Try again"
+  // action (accounts:retry delegates to providerHealth.retry).
+  providerHealth,
   // BET-790: renderer read channel for a session's progress record (the
   // server store from src/server/progress.mjs). The write side is the AI's
   // progress_report tool → POST /api/progress.

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -33,10 +33,11 @@ import { resolveWorkspace } from "./peers.mjs";
 import * as providers from "./providers.mjs";
 import * as launchers from "./launchers.mjs";
 import * as subscriptionProviders from "./subscriptionProviders.mjs";
-import { chooseMainModel } from "./delegate.mjs";
+import { chooseMainModel, toDeliverModel } from "./delegate.mjs";
 import { buildRoutingServices } from "./routingServices.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
-import { pollClaudeLogin, claudeCliStatus } from "./opencode.mjs";
+import { pollClaudeLogin, claudeCliStatus, listRoutableModels } from "./opencode.mjs";
+import { chooseModel } from "../shared/modelRouter.mjs";
 import { backupClaudeCredentials, CREDENTIALS_PATH } from "./claudeAuth.mjs";
 import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
@@ -332,6 +333,14 @@ export function buildHandlers({
   routingCatalogIndex = null,
   routingProviderHealthState = () => null,
   routingEndpointSummary = () => null,
+  // BET-1244: the filtered catalogue for routing:choose — listRoutableModels
+  // (S1c) is the ONE place routing consent is computed; routing:choose gets the
+  // filtered catalogue from it, never a second filter. Injectable for tests.
+  routingListRoutableModels = listRoutableModels,
+  // BET-1244: the provider-health engine (createProviderHealth) exposing
+  // `retry` for the Accounts "Try again" action. Null when not wired → the
+  // accounts:retry channel answers a non-empty failure message, never a throw.
+  providerHealth = null,
 }) {
   // The sole resolver for project cwd — no longer mirrored to a desktop-main
   // copy (the src/main/index.ts duplicate was retired in the HTTP-only
@@ -851,6 +860,136 @@ export function buildHandlers({
         services = null;
       }
       return chooseMainModel({ incumbent, catalog, policy, quota, agent, nowMs: Date.now(), services });
+    },
+
+    // BET-1244: the read-only, side-effect-free routing decision — the generic
+    // sibling of routing:main (which decides the main conversation's model at
+    // session start). Unlike routing:main it takes the SURFACE explicitly
+    // ("main" | "sub"), so the same single decision core (chooseModel — the one
+    // the subagent path calls) can answer for either, and returns the decision
+    // VERBATIM: { model, reason, alternatives, changed }. No state is written,
+    // no prompt is sent. It never throws — on any internal failure it returns
+    // the incumbent unchanged with reason "routing unavailable", so a routing
+    // failure can never fail a turn (the same guarantee chooseSubagentModel
+    // makes).
+    "routing:choose": async (input) => {
+      const incumbent = input?.incumbent ?? null;
+      const agent = input?.agent ?? "general";
+      const surface = input?.surface === "sub" ? "sub" : "main";
+      // The entire gather + decide is one guarded unit: a failing catalogue,
+      // snapshot reader, health tracker or a throwing router all degrade to the
+      // incumbent-unchanged fallback below, never a throw to the caller.
+      try {
+        let cfg = {};
+        try {
+          cfg = (await local.configGet()) ?? {};
+        } catch {
+          cfg = {};
+        }
+        const policy = cfg?.modelRouting ?? {};
+        let quota = [];
+        try {
+          quota = usageListSnapshots();
+          if (!Array.isArray(quota)) quota = [];
+        } catch {
+          quota = [];
+        }
+        // BET-1244/S1c: the FILTERED catalogue. listRoutableModels is the one
+        // place routing consent is computed — do not build a second filter here
+        // (use routingListRoutableModels, never raw listModels / oc.listModels).
+        let catalog = [];
+        try {
+          catalog = await routingListRoutableModels(surface, cfg);
+          if (!Array.isArray(catalog)) catalog = [];
+        } catch {
+          catalog = [];
+        }
+        let services = null;
+        try {
+          services = await buildRoutingServices(cfg, {
+            catalogIndex: routingCatalogIndex,
+            endpoints: catalog,
+            snapshots: quota,
+            providerHealthState: routingProviderHealthState,
+            endpointSummary: routingEndpointSummary,
+          });
+        } catch {
+          services = null;
+        }
+        // Normalise the incumbent into catalog shape ({providerID, id}) so the
+        // `changed` comparison inside chooseModel treats a requested model and
+        // a catalog entry of the same model as equal (mirrors chooseMainModel).
+        const catalogIncumbent = incumbent
+          ? { providerID: incumbent.providerID, id: incumbent.modelID ?? incumbent.id }
+          : null;
+        const decision = chooseModel({
+          intent: {
+            kind: surface === "sub" ? "subagent" : "main",
+            agent,
+            needs: input?.needs ?? {},
+            contextTokens: typeof input?.contextTokens === "number" ? input.contextTokens : 0,
+            incumbent: catalogIncumbent,
+          },
+          catalog,
+          telemetry: {},
+          quota,
+          policy,
+          nowMs: Date.now(),
+          services,
+        });
+        // On the off-path / no-survivors path chooseModel returns the very
+        // catalogIncumbent reference it was handed; map that back to the
+        // original structured incumbent so the decision stays byte-identical.
+        // A real winner / alternative is normalised into {providerID, modelID}.
+        return {
+          model:
+            decision?.model === catalogIncumbent
+              ? incumbent
+              : toDeliverModel(decision?.model ?? incumbent),
+          reason: decision?.reason ?? "",
+          alternatives: Array.isArray(decision?.alternatives)
+            ? decision.alternatives.map(toDeliverModel).filter(Boolean)
+            : [],
+          changed: decision?.changed === true,
+        };
+      } catch (e) {
+        console.warn("[router] routing:choose failed, using incumbent:", e?.message ?? e);
+        return { model: incumbent, reason: "routing unavailable", alternatives: [], changed: false };
+      }
+    },
+
+    // BET-1244: the Accounts "Try again" action. Delegates straight to
+    // providerHealth.retry (S4c), which already encodes the supported-vs-custom
+    // behaviour — supported read the meter and clear only on funds; custom clear
+    // optimistically with no traffic. `message` is a short factual sentence the
+    // row can display and is NEVER empty: the button reports both outcomes
+    // (AGENTS.md: it does the thing and says so / fails and says why).
+    "accounts:retry": async (input) => {
+      const providerID = typeof input?.providerID === "string" ? input.providerID.trim() : "";
+      if (!providerID) {
+        return { ok: false, state: "unknown", message: "No provider id given to retry." };
+      }
+      if (!providerHealth || typeof providerHealth.retry !== "function") {
+        return {
+          ok: false,
+          state: "unknown",
+          message: "Provider health isn't wired on this box — can't retry.",
+        };
+      }
+      try {
+        const r = await providerHealth.retry(providerID);
+        const cleared = r?.cleared === true;
+        const state = typeof r?.state === "string" && r.state ? r.state : "unknown";
+        return {
+          ok: cleared,
+          state,
+          message: cleared
+            ? `${providerID} is back in the pool (out-of-credit flag cleared).`
+            : `${providerID} still reports out of credit — check the account.`,
+        };
+      } catch (e) {
+        return { ok: false, state: "error", message: `Retry failed: ${e?.message ?? "unknown error"}` };
+      }
     },
 
     // BET-1249: the provider-agnostic model catalogue for the renderer's

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -1232,3 +1232,115 @@ test("opencode:provider-auth start does NOT fire the detached callback for claud
   await handlers["opencode:provider-auth"]({ action: "start", id: "kimi-for-coding" });
   assert.equal(called, 0, "api-key (kimi) must NOT fire the callback");
 });
+
+// ---- BET-1244: routing:choose / accounts:retry channels ----
+
+// routing:choose is read-only and never throws. A policy with no routing
+// directive (no preset / no perAgent) resolves to routing being unusable, and
+// the decision returns the incumbent unchanged — never a hidden switch and
+// never a throw.
+test("routing:choose returns the incumbent unchanged when routing is not activated", async () => {
+  const { deps } = makeDeps([]);
+  // local.configGet returns { projects } only — no modelRouting → routing off.
+  deps.routingListRoutableModels = async (surface, cfg) => [
+    { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },
+  ];
+  const handlers = buildHandlers(deps);
+  const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
+  const out = await handlers["routing:choose"]({
+    sessionId: "ses_1",
+    directory: "/w",
+    agent: "build",
+    surface: "main",
+    contextTokens: 0,
+    needs: {},
+    incumbent,
+  });
+  assert.deepEqual(out.model, incumbent, "off-path keeps the incumbent");
+  assert.equal(out.changed, false);
+  assert.deepEqual(out.alternatives, []);
+  assert.equal(out.reason, "routing not activated for this conversation");
+});
+
+// routing:choose must NEVER throw — even when every dependency rejects. It
+// degrades to the incumbent unchanged rather than propagating the failure.
+test("routing:choose never throws when its dependencies reject", async () => {
+  const { deps } = makeDeps([]);
+  deps.local.configGet = async () => { throw new Error("config down"); };
+  deps.routingListRoutableModels = async () => { throw new Error("catalogue down"); };
+  const handlers = buildHandlers(deps);
+  const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
+  // Must RESOLVE (not reject) with the incumbent unchanged, never a throw.
+  const out = await handlers["routing:choose"]({
+    sessionId: "ses_1",
+    directory: "/w",
+    agent: "build",
+    surface: "main",
+    contextTokens: 0,
+    needs: {},
+    incumbent,
+  });
+  assert.deepEqual(out.model, incumbent);
+  assert.equal(out.changed, false);
+  assert.deepEqual(out.alternatives, []);
+  assert.ok(typeof out.reason === "string" && out.reason.length > 0);
+});
+
+// routing:choose must be handed the FILTERED catalogue — listRoutableModels
+// with the right surface — never a second filter and never raw listModels.
+test("routing:choose is handed the filtered catalogue for the requested surface (not listModels)", async () => {
+  const { deps } = makeDeps([]);
+  // Config that ACTIVATES routing so the decision core actually runs against
+  // the returned catalogue.
+  deps.local.configGet = async () => ({ projects: [], modelRouting: { preset: "economy" } });
+  let surfaceSeen = null;
+  let calls = 0;
+  deps.routingListRoutableModels = async (surface) => {
+    surfaceSeen = surface;
+    calls++;
+    return [
+      { providerID: "anthropic", id: "claude-opus-4", status: "active" },
+      { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },
+      { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
+    ];
+  };
+  const handlers = buildHandlers(deps);
+  const out = await handlers["routing:choose"]({
+    sessionId: "ses_1",
+    directory: "/w",
+    agent: "build",
+    surface: "sub",
+    contextTokens: 0,
+    needs: {},
+    incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
+  });
+  assert.equal(calls, 1);
+  assert.equal(surfaceSeen, "sub", "listRoutableModels must be called with the requested surface");
+  // A real decision was produced from the injected (filtered) catalogue — a
+  // selected model normalised into {providerID, modelID}.
+  assert.equal(out.model?.providerID, "anthropic");
+  assert.ok(typeof out.model?.modelID === "string" && out.model.modelID.length > 0);
+  assert.equal("id" in (out.model ?? {}), false, "the routed model carries modelID, not the catalog's id");
+  assert.deepEqual(out.alternatives, out.alternatives.filter((a) => a && a.modelID), "alternatives are well-formed {providerID, modelID}");
+});
+
+// accounts:retry always reports an outcome — a non-empty message in BOTH the
+// cleared and not-cleared cases (AGENTS.md: it does the thing and says so,
+// or fails and says why; a swallowed bare return is a dead button).
+test("accounts:retry returns a non-empty message in both cleared and not-cleared cases", async () => {
+  const { deps } = makeDeps([]);
+  deps.providerHealth = { retry: async () => ({ cleared: true, state: "working" }) };
+  const handlers = buildHandlers(deps);
+
+  const cleared = await handlers["accounts:retry"]({ providerID: "anthropic" });
+  assert.equal(cleared.ok, true);
+  assert.equal(cleared.state, "working");
+  assert.ok(typeof cleared.message === "string" && cleared.message.length > 0, "cleared case needs a message");
+
+  deps.providerHealth = { retry: async () => ({ cleared: false, state: "out_of_credit" }) };
+  const handlers2 = buildHandlers(deps);
+  const notCleared = await handlers2["accounts:retry"]({ providerID: "anthropic" });
+  assert.equal(notCleared.ok, false);
+  assert.equal(notCleared.state, "out_of_credit");
+  assert.ok(typeof notCleared.message === "string" && notCleared.message.length > 0, "not-cleared case needs a message");
+});

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -99,6 +99,18 @@ type ModelRouteDecision = {
   incumbent: PromptModel | null;
   changed: boolean;
 };
+// BET-1244: the generic, read-only routing decision (`routing:choose`) — the
+// sibling of ModelRouteDecision that carries no `incumbent` but adds
+// `alternatives` (the next-best candidates a surface can offer). `model` stays
+// null on routing-off / no-survivors / failure; `changed` is false whenever no
+// substitution is offered. Never throws: on an internal failure the server
+// returns the incumbent unchanged with reason "routing unavailable".
+type RoutingChooseDecision = {
+  model: PromptModel | null;
+  reason: string;
+  alternatives: PromptModel[];
+  changed: boolean;
+};
 // BET-1249: a provider-agnostic catalogue entry as served by
 // `opencode:model-catalog` (models.dev view). Consumed by the renderer's
 // "Models we couldn't identify" block for identity + typeahead.
@@ -431,6 +443,30 @@ export interface Api {
     incumbent: PromptModel | null,
     agent?: string,
   ): Promise<ModelRouteDecision | null>;
+  // BET-1244: the read-only, side-effect-free routing decision for either
+  // surface ("main" | "sub"), resolved by the SAME decision core the subagent
+  // path uses. No state is written and no prompt is sent. Never throws — on
+  // any internal failure it returns the incumbent unchanged with reason
+  // "routing unavailable", alternatives empty, changed false.
+  routingChoose(input: {
+    sessionId: string;
+    directory: string;
+    agent: string;
+    surface: "main" | "sub";
+    contextTokens: number;
+    needs?: { tools?: boolean; image?: boolean; pdf?: boolean };
+    incumbent: PromptModel | null;
+  }): Promise<RoutingChooseDecision>;
+  // BET-1244: the Accounts "Try again" action — clears the out-of-credit
+  // evidence-only flag for a provider, delegated to server-side provider
+  // health (supported providers re-read their meter; custom providers clear
+  // optimistically with no traffic). `message` is a factual row string and is
+  // NEVER empty — the button reports both outcomes.
+  accountsRetry(providerID: string): Promise<{
+    ok: boolean;
+    state: string;
+    message: string;
+  }>;
   // BET-1249: the provider-agnostic model catalogue for the "Models we
   // couldn't identify" block — resolve opaque endpoint ids and typeahead over
   // every known model. `supported:false` when the box has no catalogue yet

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1360,6 +1360,10 @@ export const IPC = {
   opencodeModels: "opencode:models",
   // BET-1225: main-conversation routing decision at session start.
   opencodeModelRoute: "routing:main",
+  // BET-1244: generic read-only routing decision for either surface (main|sub).
+  routingChoose: "routing:choose",
+  // BET-1244: Accounts "Try again" — clear a provider's out-of-credit flag.
+  accountsRetry: "accounts:retry",
   // BET-1249: the provider-agnostic model catalogue (models.dev) for the
   // renderer's "Models we couldn't identify" block — resolve opaque endpoint
   // ids and typeahead over every known model. Read-only; entry-level data.


### PR DESCRIPTION
Wires the box side of the Automatic Routing surface — two RPC channels, no UI.

## routing:choose
Read-only, side-effect-free generic routing decision for either surface (`main`|`sub`). Uses the SAME decision core the subagent path calls (`chooseModel`, the shared router in `src/shared/modelRouter.mjs` — no second ordering logic), consumes BET-1252's shared `buildRoutingServices` builder (never an inline services assembly), and is handed the **filtered** catalogue from `listRoutableModels(surface, cfg)` (S1c) — no second filter, no `listModels`. Returns `{model, reason, alternatives, changed}` verbatim. Never throws: any internal failure returns `{model: incumbent, reason: "routing unavailable", alternatives: [], changed: false}`.

## accounts:retry
The Accounts "Try again" action, delegating straight to `providerHealth.retry(providerID)` (S4c) — supported providers re-read the meter and clear only on funds; custom providers clear optimistically with no traffic. `message` is non-empty in both the cleared and not-cleared cases.

## Wiring (all in this diff)
- `src/shared/api.ts` — `routingChoose` + `accountsRetry` signatures on `Api` + `RoutingChooseDecision` type
- `src/server/rpc.mjs` — channel dispatch (both handlers)
- `src/shared/types.ts` — `IPC.routingChoose` / `IPC.accountsRetry` channel names
- `src/renderer/api/httpApi.ts` — `/rpc` implementations
- `src/renderer/api/demoCoverage.test.ts` — demo/unimplemented coverlist (both added)
- `src/server/index.mjs` — inject `providerHealth` into buildHandlers for `accounts:retry`
- `src/server/delegate.mjs` — export `toDeliverModel` (shared shape mapping, so routing:choose and the two existing wrappers normalise the decision identically)
- `src/server/rpc.test.mjs` — 4 tests (off-path incumbent, deps-reject never-throws, filtered-catalogue surface, accounts:retry messages)

Note: `src/preload/index.ts` is intentionally untouched — per the current tree the preload carries only OS bridges + pairing and the `Api` data surface is httpApi-only (same as the existing `schedule:*`/`secrets:*` channels, which have no preload entries). The `Api` type now lives in `src/shared/api.ts`.

Base: origin/main @ b00d2957

**Files changed:** 8 files. `src/server/rpc.mjs (+143)` `src/server/rpc.test.mjs (+112)` `src/shared/api.ts (+36)` `src/server/index.mjs (+3)` `src/shared/types.ts (+4)` `src/server/delegate.mjs (+2-1)` `src/renderer/api/httpApi.ts (+2)` `src/renderer/api/demoCoverage.test.ts (+2)`

**Verification results:**
- PR branch (`multica/BET-1244-routing-rpc` @ `104ff0e1`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, `2637` pass / `0` fail / `0` skip. Failures: none. log sha256: `53c879eeb7b00454b50bdbdfd26097f8c991d98d41cc839a00400fec65d2b5ad`
- Base (`main` @ `b00d2957`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, `2633` pass / `0` fail / `0` skip. Failures: none. log sha256: `cf83467db6aee8d2375b0d8fa65a68b2e8a1e940154c5a2b524554bd92ebe29c`
- **Conclusion:** 0 new failures; the 4 extra tests on the PR branch are this PR's own (routing:choose ×3, accounts:retry ×1). 0 pre-existing failures.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
