### PR TITLE
feat(renderer): route the main conversation at routing boundaries from ChatPanel submit (BET-1248)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -78,6 +78,8 @@ import {
   readSavedChoice,
   readSavedModel,
   writeSavedModel,
+  writeSavedChoice,
+  modelFromChoice,
   readPlanSaved,
   writePlanSaved,
   readSavedDelegateModel,
@@ -90,6 +92,7 @@ import {
   type TaskContextValue,
   type TokenUsage,
 } from "./chatShared";
+import { crossesBoundary, shouldSwitch, boundaryPhrase } from "../shared/routingBoundary.mjs";
 import { useModelCatalog } from "./modelCatalog";
 import { useAgentCatalog } from "./agentCatalog";
 import { MantaLoader } from "./MantaLoader";
@@ -434,8 +437,13 @@ export function ChatPanel({
   const [autoActive, setAutoActive] = useState<boolean>(
     () => readSavedChoice(sessionId).kind === "auto",
   );
+  // BET-1248: the override seed derives from the THREE-state choice
+  // (readSavedChoice, BET-1245) so the rest of the component is untouched:
+  // {kind:"model"} → the model, {kind:"server-default"} → the global default,
+  // {kind:"auto"} → null until the router resolves one. The routed pick is
+  // applied to the override the moment a turn runs (BET-1247).
   const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
-    autoActive ? null : readSavedModel(sessionId) ?? configDefaultModel ?? null,
+    modelFromChoice(readSavedChoice(sessionId), configDefaultModel),
   );
   // BET-1222: routed state for the composer pill — set when the router chose
   // this session's model (fed by the main-conversation routing wiring). The
@@ -445,6 +453,44 @@ export function ChatPanel({
     reason: string;
     incumbent: { providerID: string; modelID: string };
   } | null>(null);
+  // BET-1248: boundary-routing state for the main conversation. `routedModel`
+  // is the session's current routed endpoint — the incumbent shouldSwitch uses
+  // and the model the next Auto turn runs on; `routedReason` is the latest
+  // decision reason (with the boundary phrase appended) for surfacing. Keyed
+  // by session: reset on session change, exactly like stepTokens / liveTodos /
+  // finishByMessageId.
+  const [routedModel, setRoutedModel] = useState<ModelSelection | null>(null);
+  const [routedReason, setRoutedReason] = useState<string | null>(null);
+  // Ref mirror so submit() reads the incumbent synchronously without re-creating
+  // the callback on every routed change (the commandsRef pattern).
+  const routedModelRef = useRef<ModelSelection | null>(null);
+  useEffect(() => {
+    routedModelRef.current = routedModel;
+  }, [routedModel]);
+  // Apply a boundary-routing decision: record the incumbent + reason and, under
+  // Auto, set the active override so the pill and send paths run on it.
+  const applyRouted = useCallback((model: ModelSelection | null, reason: string) => {
+    routedModelRef.current = model;
+    setRoutedModel(model);
+    setRoutedReason(reason);
+    setModelOverride(model);
+  }, []);
+  // The agent the PREVIOUS turn ran as — drives the agent-changed boundary.
+  const lastAgentRef = useRef<string | undefined>(undefined);
+  // A compaction completed since the last submit (cache is gone → re-deciding
+  // is free). Latched from the compaction card (see the effect below the SSE
+  // bus), cleared on the next turn.
+  const justCompactedRef = useRef(false);
+  // The user re-picked Auto while a routed model may exist — the next turn
+  // re-decides (user-requested boundary). Detected as an autoActive flip.
+  const pendingAutoUserRef = useRef(false);
+  const priorAutoRef = useRef(autoActive);
+  useEffect(() => {
+    if (autoActive && !priorAutoRef.current && routedModelRef.current) {
+      pendingAutoUserRef.current = true;
+    }
+    priorAutoRef.current = autoActive;
+  }, [autoActive]);
   // Active-model providerID for the auth-error banner (BET-316). Per-session
   // override wins over the persisted default; null if neither is set. Memoized
   // on `modelOverride` (the in-memory selection, itself seeded from
@@ -583,6 +629,14 @@ export function ChatPanel({
     submitRef,
   });
 
+  // BET-1248: latch a completed compaction into `justCompactedRef` so the
+  // NEXT submit re-evaluates routing at the (now free) compacted boundary. The
+  // compaction card clears itself ~2.5s later; latching keeps the boundary
+  // valid for the next turn regardless of how fast the user reacts.
+  useEffect(() => {
+    if (compactionState?.phase === "done") justCompactedRef.current = true;
+  }, [compactionState]);
+
   // Manual dismiss of the pinned todo card — the user's escape hatch for a
   // stale list that's non-terminal. Mirrors the auto-dismiss path in submit().
   // Stable identity so it doesn't defeat ActiveTodos' React.memo.
@@ -666,11 +720,16 @@ export function ChatPanel({
     setError(null);
     const planOnStart = readPlanSaved(sessionId);
     setPlanOn(planOnStart);
-    const autoNow = readSavedChoice(sessionId).kind === "auto";
-    setAutoActive(autoNow);
-    setModelOverride(
-      autoNow ? null : readSavedModel(sessionId) ?? configDefaultModel ?? null,
-    );
+    const choiceNow = readSavedChoice(sessionId);
+    setAutoActive(choiceNow.kind === "auto");
+    setModelOverride(modelFromChoice(choiceNow, configDefaultModel));
+    // BET-1248: routed state is per-session — reset on session change (and on
+    // /clear, which swaps the session id), exactly like stepTokens / liveTodos.
+    setRoutedModel(null);
+    setRoutedReason(null);
+    routedModelRef.current = null;
+    pendingAutoUserRef.current = false;
+    priorAutoRef.current = choiceNow.kind === "auto";
     // Seed plan mode from the session's own `agent` field when present (BET-949
     // §5): a session pre-set to plan OUTSIDE MantaUI would otherwise show the
     // chip off and send the next prompt as build — the stored key alone can't
@@ -1250,13 +1309,94 @@ export function ChatPanel({
       }
     }
 
+    // BET-1248: route the main conversation at boundaries ONLY — never on a
+    // non-Auto session, never mid-exchange (this is submit(), the single send
+    // path reachable from the composer and the queued drain, which goes through
+    // submit too). All the judgement lives in routingBoundary.mjs; this
+    // component supplies facts and applies the answer. A routing failure must
+    // never fail a turn — it falls back to the previous routed model (or the
+    // server default) and sends.
+    let sendModel = modelOverride;
+    if (autoActive && text) {
+      if (readSavedChoice(sessionId).kind === "auto") {
+        const incumbent = routedModelRef.current;
+        const incumbentModel = incumbent
+          ? resolveActiveModel(models, incumbent, null)
+          : null;
+        const ctxTokens = latestTokens
+          ? (latestTokens.input ?? 0) +
+            (latestTokens.cache?.read ?? 0) +
+            (latestTokens.cache?.write ?? 0)
+          : undefined;
+        const requiredModes = readyAttachments.map((a) => mimeToInputMode(a.mime));
+        const currentAgent = planAgent ?? "build";
+        const { crossed, boundary } = crossesBoundary({
+          hasRoutedModel: incumbent != null,
+          agent: currentAgent,
+          previousAgent: lastAgentRef.current,
+          contextTokens: ctxTokens ?? undefined,
+          incumbentContextLimit: incumbentModel?.limit?.context ?? undefined,
+          requiredModalities: requiredModes,
+          incumbentModalities: incumbentModel
+            ? modelInputModes(incumbentModel)
+            : [],
+          incumbentHealthy: true,
+          justCompacted: justCompactedRef.current,
+          userRequested: pendingAutoUserRef.current,
+        });
+        justCompactedRef.current = false;
+        pendingAutoUserRef.current = false;
+        lastAgentRef.current = currentAgent;
+        if (crossed) {
+          try {
+            const decision = await window.api.routingChoose({
+              sessionId,
+              directory: cwd ?? "",
+              agent: currentAgent,
+              surface: "main",
+              contextTokens: ctxTokens ?? 0,
+              needs: {
+                tools: Boolean(planAgent),
+                image: readyAttachments.some((a) => mimeToInputMode(a.mime) === "image"),
+                pdf: readyAttachments.some((a) => mimeToInputMode(a.mime) === "pdf"),
+              },
+              incumbent,
+            });
+            const ranked = decision.model
+              ? [decision.model, ...decision.alternatives]
+              : decision.alternatives;
+            // Hysteresis: only move off the incumbent when it genuinely fell out
+            // (didn't survive the router's contention), and only when the router
+            // actually offered a model. Otherwise keep it and send on it as-is.
+            if (
+              decision.model &&
+              shouldSwitch({
+                incumbent,
+                ranked,
+                incumbentStillEligible: true,
+                incumbentStillCapable: true,
+                incumbentHealthy: true,
+              }).switch
+            ) {
+              const reason = decision.reason + (boundary ? ` · ${boundaryPhrase(boundary)}` : "");
+              applyRouted(decision.model, reason);
+              sendModel = decision.model;
+            }
+          } catch {
+            // routing failure must never fail a turn — fall through to the
+            // previous routed model (or the server default) and send.
+          }
+        }
+      }
+    }
+
     try {
       if (knownCommand && slashMatch) {
         await window.api.opencodeRunCommand({
           sessionId,
           command: cmdName!,
           arguments: slashMatch[2] ?? "",
-          model: modelOverride ?? undefined,
+          model: sendModel ?? undefined,
           agent: planAgent,
           attachments: readyAttachments,
         });
@@ -1290,7 +1430,7 @@ export function ChatPanel({
         await window.api.opencodePrompt(
           sessionId,
           text,
-          modelOverride ?? undefined,
+          sendModel ?? undefined,
           readyAttachments,
           resolvedMentions.length > 0 ? resolvedMentions : undefined,
           planAgent,
@@ -1313,7 +1453,7 @@ export function ChatPanel({
     // (clear/fork/compact) are read via their ref mirror below (declared after
     // submit in this file — the established commandsRef pattern) so submit
     // always sees their current value without them re-rotating this callback.
-  }, [input, running, sessionId, modelOverride, attachments, agentMentions, tmuxSession, windowIndex, plan]);
+  }, [input, running, sessionId, modelOverride, attachments, agentMentions, tmuxSession, windowIndex, plan, autoActive, models, applyRouted]);
 
   // Always-current ref to submit — lets the queued-message effect call the
   // latest version without adding submit to the effect's dependency array
@@ -1562,6 +1702,18 @@ export function ChatPanel({
     },
     [sessionId],
   );
+
+  // BET-1248: the user explicitly re-picked Auto — write the three-state choice,
+  // flip the UI to Auto, and flag the NEXT turn as a user-requested boundary so
+  // it re-decides at once (crossesBoundary USER). Clears the override so the
+  // pill reads "Auto · chooses when the turn starts" until routing resolves.
+  const onSelectAuto = useCallback(() => {
+    writeSavedChoice(sessionId, { kind: "auto" });
+    setAutoActive(true);
+    setModelOverride(null);
+    setRouted(null);
+    if (routedModelRef.current) pendingAutoUserRef.current = true;
+  }, [sessionId]);
 
   // BET-1222: undo a routed model choice. Reverts through the SAME per-session
   // override path the manual picker uses (selectModel + writeSavedModel) — no
@@ -3143,6 +3295,8 @@ export function ChatPanel({
         modelOverride={modelOverride}
         defaultModel={defaultModel}
         auto={autoActive}
+        autoReason={routedReason}
+        onSelectAuto={onSelectAuto}
         routed={routed}
         onRoutedUndone={() => void undoRouted()}
         plan={plan}

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -481,6 +481,10 @@ export function ChatPanel({
   // is free). Latched from the compaction card (see the effect below the SSE
   // bus), cleared on the next turn.
   const justCompactedRef = useRef(false);
+  // Ref mirror of latestTokens (set below, after its memo is defined) so submit
+  // reads the CURRENT context size without re-creating the callback on every
+  // stream update (the liveChildStatusRef / permissionsRef pattern).
+  const latestTokensRef = useRef<TokenUsage | null>(null);
   // The user re-picked Auto while a routed model may exist — the next turn
   // re-decides (user-requested boundary). Detected as an autoActive flip.
   const pendingAutoUserRef = useRef(false);
@@ -1323,14 +1327,14 @@ export function ChatPanel({
         const incumbentModel = incumbent
           ? resolveActiveModel(models, incumbent, null)
           : null;
-        const ctxTokens = latestTokens
-          ? (latestTokens.input ?? 0) +
-            (latestTokens.cache?.read ?? 0) +
-            (latestTokens.cache?.write ?? 0)
+        const ctxTokens = latestTokensRef.current
+          ? (latestTokensRef.current.input ?? 0) +
+            (latestTokensRef.current.cache?.read ?? 0) +
+            (latestTokensRef.current.cache?.write ?? 0)
           : undefined;
         const requiredModes = readyAttachments.map((a) => mimeToInputMode(a.mime));
         const currentAgent = planAgent ?? "build";
-        const { crossed, boundary } = crossesBoundary({
+        const { crossed, boundary, stillCapable, stillHealthy } = crossesBoundary({
           hasRoutedModel: incumbent != null,
           agent: currentAgent,
           previousAgent: lastAgentRef.current,
@@ -1366,16 +1370,17 @@ export function ChatPanel({
               ? [decision.model, ...decision.alternatives]
               : decision.alternatives;
             // Hysteresis: only move off the incumbent when it genuinely fell out
-            // (didn't survive the router's contention), and only when the router
-            // actually offered a model. Otherwise keep it and send on it as-is.
+            // (didn't survive the router's contention) OR it no longer fits the
+            // turn (a CONSTRAINT boundary made it incapable/unhealthy — force the
+            // switch away regardless of where it ranks). Otherwise keep it.
             if (
               decision.model &&
               shouldSwitch({
                 incumbent,
                 ranked,
                 incumbentStillEligible: true,
-                incumbentStillCapable: true,
-                incumbentHealthy: true,
+                incumbentStillCapable: stillCapable,
+                incumbentHealthy: stillHealthy,
               }).switch
             ) {
               const reason = decision.reason + (boundary ? ` · ${boundaryPhrase(boundary)}` : "");
@@ -2319,6 +2324,13 @@ export function ChatPanel({
     }
     return null;
   }, [messages, stepTokens]);
+
+  // BET-1248: mirror latestTokens into a ref so submit's boundary routing reads
+  // the CURRENT context size (it can't take latestTokens as a dep — it is
+  // declared after submit — and a stale closure would miss context-outgrown).
+  useEffect(() => {
+    latestTokensRef.current = latestTokens;
+  }, [latestTokens]);
 
   // ===== Stale prompt-cache detection =====
   //

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -152,6 +152,8 @@ export function InputArea({
   modelOverride,
   defaultModel,
   auto,
+  autoReason,
+  onSelectAuto,
   routed,
   onRoutedUndone,
   plan,
@@ -216,6 +218,12 @@ export function InputArea({
   // BET-1247: the session's model choice is `auto` — the composer chip must
   // say "Auto" and, once the router has resolved a model, which one.
   auto: boolean;
+  // BET-1248: the latest boundary-routing reason, shown in the Auto row once
+  // a decision has resolved.
+  autoReason?: string | null;
+  // BET-1248: user re-picked Auto in the menu — forwarded to the ModelPicker's
+  // Auto row so it renders + re-decides on the next turn.
+  onSelectAuto?: () => void;
   // BET-1222 routed state — forwarded to ModelPicker: reason + incumbent shown
   // on the routed pill, and the caller-owned undo action.
   routed?: { reason: string; incumbent: { providerID: string; modelID: string } } | null;
@@ -560,6 +568,8 @@ export function InputArea({
             modelOverride={modelOverride}
             defaultModel={defaultModel}
             auto={auto}
+            autoReason={autoReason}
+            onSelectAuto={onSelectAuto}
             routed={routed}
             onRoutedUndone={onRoutedUndone}
             deactivatedMainModels={deactivatedMainModels}

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -55,6 +55,12 @@ export function ModelPicker({
   // model (a turn has run and `modelOverride` carries the routed pick), which
   // model Auto chose. Until a model is resolved there is nothing to claim.
   auto = false,
+  // BET-1248: the latest boundary-routing reason — forwarded to ModelMenu's
+  // Auto row sub-line once a decision has resolved.
+  autoReason = null,
+  // BET-1248: the user re-picking Auto — when provided the ModelMenu's Auto
+  // row is rendered (a control can NEVER be present without a handler).
+  onSelectAuto,
   // BET-1222: when the router chose this session's model, the composer pill
   // explains WHY (reason) and offers one-click undo to the incumbent model.
   // `routed` is pure display state; the undo action itself (set override back
@@ -87,6 +93,10 @@ export function ModelPicker({
   labelOverride?: string | null;
   // BET-1247: session model choice is `auto` (see above).
   auto?: boolean;
+  // BET-1248: the latest boundary-routing reason for the Auto row.
+  autoReason?: string | null;
+  // BET-1248: the user re-picking Auto (render the Auto row).
+  onSelectAuto?: () => void;
   // BET-1222 routed state (see above).
   routed?: { reason: string; incumbent: { providerID: string; modelID: string } } | null;
   onRoutedUndone?: () => void;
@@ -332,6 +342,9 @@ export function ModelPicker({
           defaultModel={defaultModel}
           onSelect={onSelect}
           onClose={() => setModelOpen(false)}
+          autoActive={auto}
+          onSelectAuto={onSelectAuto}
+          autoReason={autoReason ?? undefined}
         />
       )}
 

--- a/src/renderer/chatShared.test.ts
+++ b/src/renderer/chatShared.test.ts
@@ -21,6 +21,7 @@ import {
   readSavedChoice,
   writeSavedChoice,
   carrySavedChoice,
+  modelFromChoice,
   resolveLauncherFlags,
   readPromptHistory,
   appendPromptHistory,
@@ -351,6 +352,25 @@ describe("readSavedChoice / writeSavedChoice (three-state, BET-1245)", () => {
   it("a session's choice is isolated from another session id", () => {
     writeSavedChoice("sess-1", { kind: "auto" });
     expect(readSavedChoice("sess-2")).toEqual({ kind: "server-default" });
+  });
+});
+
+describe("modelFromChoice (BET-1248 seed derivation)", () => {
+  const sel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+  const server = { providerID: "anthropic", modelID: "claude-opus-4-7" };
+
+  it("{kind:'model'} → the explicit model (default ignored)", () => {
+    expect(modelFromChoice({ kind: "model", model: sel }, server)).toEqual(sel);
+  });
+
+  it("{kind:'server-default'} → the global default, or null when none", () => {
+    expect(modelFromChoice({ kind: "server-default" }, server)).toEqual(server);
+    expect(modelFromChoice({ kind: "server-default" }, null)).toBeNull();
+  });
+
+  it("{kind:'auto'} → null (the routed pick is applied once a turn resolves)", () => {
+    expect(modelFromChoice({ kind: "auto" }, server)).toBeNull();
+    expect(modelFromChoice({ kind: "auto" }, null)).toBeNull();
   });
 });
 

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -324,6 +324,30 @@ export function readSavedModel(sessionId: string): ModelSelection | null {
 }
 
 /**
+ * Map a three-state `ModelChoice` to the active override `ModelSelection`
+ * (or `null`). The single place `modelOverride`'s seed derives from the choice
+ * so every consumer keeps reading a plain model (BET-1248):
+ *  - `{kind:"model"}`          → the explicit model
+ *  - `{kind:"server-default"}` → the global default (today's behaviour)
+ *  - `{kind:"auto"}`           → `null` until the router resolves one (the
+ *                                routed pick is applied separately to the
+ *                                override the moment a turn runs)
+ */
+export function modelFromChoice(
+  choice: ModelChoice,
+  serverDefault: ModelSelection | null,
+): ModelSelection | null {
+  switch (choice.kind) {
+    case "model":
+      return choice.model;
+    case "server-default":
+      return serverDefault;
+    case "auto":
+      return null;
+  }
+}
+
+/**
  * @deprecated Superseded by `writeSavedChoice` (BET-1245). Thin wrapper: writes
  * an explicit model, or clears to the server default when `m` is null.
  */

--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -983,3 +983,139 @@ describe("useSseBus plan-mode mirror (BET-973)", () => {
     expect(planCalls).toEqual([false]);
   });
 });
+
+describe("BET-1248 main-conversation routing at boundaries (ChatPanel submit)", () => {
+  let api: MockApi;
+  let bus: MockEventBus;
+  let h: Harness | null = null;
+  const ROUTED = { providerID: "anthropic", modelID: "claude-routed" };
+  type RouterModel = { providerID: string; modelID: string; variant?: string } | null;
+
+  function typeInto(el: HTMLTextAreaElement, value: string) {
+    const setter = Object.getOwnPropertyDescriptor(
+      window.HTMLTextAreaElement.prototype,
+      "value",
+    )?.set;
+    setter?.call(el, value);
+    el.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  async function submitAsUser(text: string) {
+    const textarea = h!.container.querySelector("textarea") as HTMLTextAreaElement;
+    await act(async () => {
+      typeInto(textarea, text);
+      textarea.dispatchEvent(new KeyboardEvent("keydown", { key: "Enter", bubbles: true }));
+    });
+    // The async submit() body awaits routingChoose + opencodePrompt; settle
+    // the whole chain (two macrotask hops) before asserting.
+    await h!.flush();
+    await h!.flush();
+  }
+
+  // Flip the box's running→idle so the NEXT submit sends (instead of queuing).
+  // Mirrors the drain tests' turnComplete + TURN_SETTLE_MS settle window.
+  async function settleIdle() {
+    await emitStreamAndFlush(bus, h!, {
+      sub: "turnComplete",
+      sessionId: "ses_test",
+      payload: { complete: true, running: false },
+    });
+    await new Promise((r) => setTimeout(r, TURN_SETTLE_MS + 50));
+    await h!.flush();
+  }
+
+  // The model opencodePrompt was last called with for a given user text.
+  // opencodePrompt(sessionId, text, model, ...) → args[2] is the model.
+  function promptModelFor(text: string): unknown {
+    const calls = (api.calls.opencodePrompt ?? []) as unknown[][];
+    const hit = [...calls].reverse().find((a) => a[1] === text);
+    return hit ? hit[2] : undefined;
+  }
+
+  function decision(model: RouterModel, alternatives: RouterModel[] = []) {
+    return Promise.resolve({ model, reason: "cost", alternatives, changed: true });
+  }
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+    localStorage.clear();
+  });
+
+  async function mountAuto(overrides: Record<string, unknown> = {}) {
+    localStorage.setItem("manta:chat:ses_test:model", "auto");
+    ({ api, bus } = installMockApi({
+      routingChoose: () => decision(ROUTED),
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+      ...overrides,
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+  }
+
+  it("first turn with Auto on → routingChoose is called once and the turn is sent on the returned model", async () => {
+    await mountAuto();
+    await submitAsUser("hello");
+    expect((api.calls.routingChoose ?? []).length).toBe(1);
+    expect(promptModelFor("hello")).toEqual(ROUTED);
+  });
+
+  it("a follow-up with no boundary → routingChoose is NOT called; the same model is reused", async () => {
+    await mountAuto();
+    await submitAsUser("first");
+    await settleIdle();
+    await submitAsUser("second");
+    expect((api.calls.routingChoose ?? []).length).toBe(1);
+    expect(promptModelFor("first")).toEqual(ROUTED);
+    expect(promptModelFor("second")).toEqual(ROUTED);
+  });
+
+  it("after a compaction → routingChoose is called, but with the incumbent in contention the model does NOT change", async () => {
+    await mountAuto();
+    await submitAsUser("first");
+    await settleIdle();
+    // Compaction completes (cache is gone) — the next turn crosses a boundary.
+    await emitAndFlush(bus, h!, {
+      type: "session.next.compaction.started",
+      properties: { sessionID: "ses_test", reason: "context", text: "" },
+    });
+    await emitAndFlush(bus, h!, {
+      type: "session.next.compaction.ended",
+      properties: { sessionID: "ses_test" },
+    });
+    // The router returns the incumbent → it stays in the contention window.
+    await submitAsUser("after compact");
+    expect((api.calls.routingChoose ?? []).length).toBe(2);
+    expect(promptModelFor("after compact")).toEqual(ROUTED);
+  });
+
+  it("routingChoose rejecting → the turn still sends, on the previous model", async () => {
+    localStorage.setItem("manta:chat:ses_test:model", "auto");
+    ({ api, bus } = installMockApi({
+      routingChoose: () => Promise.reject(new Error("router down")),
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    await submitAsUser("hi");
+    // A turn was still sent. First turn with no incumbent → server default.
+    expect((api.calls.opencodePrompt ?? []).length).toBeGreaterThan(0);
+    expect(promptModelFor("hi")).toBeUndefined();
+  });
+
+  it("Auto off → routingChoose is never called", async () => {
+    localStorage.clear(); // server-default choice
+    ({ api, bus } = installMockApi({
+      routingChoose: () => decision(ROUTED),
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    await submitAsUser("hi");
+    expect(api.calls.routingChoose ?? []).toHaveLength(0);
+    expect(promptModelFor("hi")).toBeUndefined();
+  });
+});

--- a/src/shared/routingBoundary.d.mts
+++ b/src/shared/routingBoundary.d.mts
@@ -25,6 +25,7 @@ export interface CrossesResult {
 }
 
 export function crossesBoundary(input?: CrossesInput): CrossesResult;
+export function boundaryPhrase(boundary: string | null): string;
 
 export interface ShouldSwitchInput {
   incumbent?: object | null;

--- a/src/shared/routingBoundary.d.mts
+++ b/src/shared/routingBoundary.d.mts
@@ -22,6 +22,12 @@ export interface CrossesInput {
 export interface CrossesResult {
   crossed: boolean;
   boundary: string | null;
+  // Whether the incumbent still "fits" this turn (context within its limit AND
+  // every required modality present) and its provider is healthy. A CONSTRAINT
+  // boundary sets one of these false so the caller can force a switch even when
+  // the incumbent stays in the router's top-N.
+  stillCapable: boolean;
+  stillHealthy: boolean;
 }
 
 export function crossesBoundary(input?: CrossesInput): CrossesResult;

--- a/src/shared/routingBoundary.mjs
+++ b/src/shared/routingBoundary.mjs
@@ -98,6 +98,27 @@ export function crossesBoundary(input = {}) {
   return { crossed: false, boundary: null };
 }
 
+const BOUNDARY_PHRASE = {
+  [BOUNDARY.FIRST_TURN]: "first turn",
+  [BOUNDARY.AGENT]: "agent changed",
+  [BOUNDARY.CONSTRAINT]: "context or capability",
+  [BOUNDARY.COMPACTED]: "just compacted",
+  [BOUNDARY.USER]: "Auto re-selected",
+};
+
+/**
+ * A short human phrase naming WHICH boundary justified a re-decision. The
+ * router's `reason` already explains the model choice; this appends the
+ * trigger context so the routed pill reads "…cost/quality… · just compacted".
+ * Pure display — returns "" for an unknown/null boundary (never throws).
+ *
+ * @param {string|null} boundary a `BOUNDARY.*` value
+ * @returns {string}
+ */
+export function boundaryPhrase(boundary) {
+  return BOUNDARY_PHRASE[boundary] ?? "";
+}
+
 // 0-based position of the incumbent endpoint within `ranked`, or -1 if absent.
 function incumbentIndex(incumbent, ranked) {
   const k = endpointKey(incumbent);

--- a/src/shared/routingBoundary.mjs
+++ b/src/shared/routingBoundary.mjs
@@ -61,19 +61,12 @@ export function crossesBoundary(input = {}) {
     userRequested = false,
   } = input;
 
-  // FIRST_TURN — new session or after /clear; there is nothing to re-decide, we
-  // are deciding for the first time. Cheapest, checked first.
-  if (hasRoutedModel === false) {
-    return { crossed: true, boundary: BOUNDARY.FIRST_TURN };
-  }
-
-  // AGENT — the assistant's judgement role changed (plan <-> build).
-  if (agent != null && previousAgent != null && agent !== previousAgent) {
-    return { crossed: true, boundary: BOUNDARY.AGENT };
-  }
-
-  // CONSTRAINT — the incumbent genuinely no longer fits the turn: it lost its
-  // context window, lacks a modality the turn needs, or its provider went away.
+  // The capability/health FACTS, computed once here (the single copy of the
+  // constraint logic). A CONSTRAINT boundary means the incumbent no longer fits
+  // the turn, so the caller threads these into `shouldSwitch` to force a switch
+  // off an outgrown/incapable/unhealthy incumbent even while it stays in the
+  // router's top-N. Non-constraint boundaries keep the incumbent genuinely
+  // capable + healthy, so those retain today's contention-only behaviour.
   const contextOutgrown =
     typeof incumbentContextLimit === "number" &&
     typeof contextTokens === "number" &&
@@ -81,21 +74,37 @@ export function crossesBoundary(input = {}) {
   const modalityMissing = requiredModalities.some(
     (m) => !incumbentModalities.includes(m),
   );
+  const stillCapable = !(contextOutgrown || modalityMissing);
+  const stillHealthy = incumbentHealthy;
+
+  // FIRST_TURN — new session or after /clear; there is nothing to re-decide, we
+  // are deciding for the first time. Cheapest, checked first.
+  if (hasRoutedModel === false) {
+    return { crossed: true, boundary: BOUNDARY.FIRST_TURN, stillCapable, stillHealthy };
+  }
+
+  // AGENT — the assistant's judgement role changed (plan <-> build).
+  if (agent != null && previousAgent != null && agent !== previousAgent) {
+    return { crossed: true, boundary: BOUNDARY.AGENT, stillCapable, stillHealthy };
+  }
+
+  // CONSTRAINT — the incumbent genuinely no longer fits the turn: it lost its
+  // context window, lacks a modality the turn needs, or its provider went away.
   if (incumbentHealthy === false || contextOutgrown || modalityMissing) {
-    return { crossed: true, boundary: BOUNDARY.CONSTRAINT };
+    return { crossed: true, boundary: BOUNDARY.CONSTRAINT, stillCapable, stillHealthy };
   }
 
   // COMPACTED — the cache is gone anyway, so re-evaluating is free.
   if (justCompacted === true) {
-    return { crossed: true, boundary: BOUNDARY.COMPACTED };
+    return { crossed: true, boundary: BOUNDARY.COMPACTED, stillCapable, stillHealthy };
   }
 
   // USER — the user explicitly re-picked Auto; honour it.
   if (userRequested === true) {
-    return { crossed: true, boundary: BOUNDARY.USER };
+    return { crossed: true, boundary: BOUNDARY.USER, stillCapable, stillHealthy };
   }
 
-  return { crossed: false, boundary: null };
+  return { crossed: false, boundary: null, stillCapable, stillHealthy };
 }
 
 const BOUNDARY_PHRASE = {

--- a/src/shared/routingBoundary.test.ts
+++ b/src/shared/routingBoundary.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { BOUNDARY, crossesBoundary, shouldSwitch } from "./routingBoundary.mjs";
+import { BOUNDARY, crossesBoundary, shouldSwitch, boundaryPhrase } from "./routingBoundary.mjs";
 
 // A routed endpoint with a distinct (providerID/id) identity, like the router's.
 function ep(providerID: string, id: string) {
@@ -186,5 +186,20 @@ describe("shouldSwitch — hysteresis", () => {
     expect(
       shouldSwitch({ ...base, ranked: [...n4.slice(0, 3), ep("anthropic", "a")] }),
     ).toEqual({ switch: true, why: "incumbent-dropped-out" });
+  });
+});
+
+describe("boundaryPhrase", () => {
+  it("returns a phrase per boundary kind", () => {
+    expect(boundaryPhrase(BOUNDARY.FIRST_TURN)).toBe("first turn");
+    expect(boundaryPhrase(BOUNDARY.AGENT)).toBe("agent changed");
+    expect(boundaryPhrase(BOUNDARY.CONSTRAINT)).toBe("context or capability");
+    expect(boundaryPhrase(BOUNDARY.COMPACTED)).toBe("just compacted");
+    expect(boundaryPhrase(BOUNDARY.USER)).toBe("Auto re-selected");
+  });
+
+  it("returns an empty string for an unknown / null boundary (never throws)", () => {
+    expect(boundaryPhrase(null)).toBe("");
+    expect(boundaryPhrase("nope")).toBe("");
   });
 });

--- a/src/shared/routingBoundary.test.ts
+++ b/src/shared/routingBoundary.test.ts
@@ -21,7 +21,7 @@ const followUp = {
 
 describe("crossesBoundary — each boundary in isolation", () => {
   it("FIRST_TURN when there is no routed model yet", () => {
-    expect(crossesBoundary({ ...followUp, hasRoutedModel: false })).toEqual({
+    expect(crossesBoundary({ ...followUp, hasRoutedModel: false })).toMatchObject({
       crossed: true,
       boundary: BOUNDARY.FIRST_TURN,
     });
@@ -30,13 +30,13 @@ describe("crossesBoundary — each boundary in isolation", () => {
   it("AGENT when the agent changed (plan -> build)", () => {
     expect(
       crossesBoundary({ ...followUp, agent: "build", previousAgent: "plan" }),
-    ).toEqual({ crossed: true, boundary: BOUNDARY.AGENT });
+    ).toMatchObject({ crossed: true, boundary: BOUNDARY.AGENT });
   });
 
   it("CONSTRAINT when context outgrew the incumbent's limit", () => {
     expect(
       crossesBoundary({ ...followUp, contextTokens: 41000, incumbentContextLimit: 40000 }),
-    ).toEqual({ crossed: true, boundary: BOUNDARY.CONSTRAINT });
+    ).toMatchObject({ crossed: true, boundary: BOUNDARY.CONSTRAINT });
   });
 
   it("CONSTRAINT when a required modality is missing", () => {
@@ -46,25 +46,25 @@ describe("crossesBoundary — each boundary in isolation", () => {
         requiredModalities: ["image", "pdf"],
         incumbentModalities: ["text", "image"],
       }),
-    ).toEqual({ crossed: true, boundary: BOUNDARY.CONSTRAINT });
+    ).toMatchObject({ crossed: true, boundary: BOUNDARY.CONSTRAINT });
   });
 
   it("CONSTRAINT when the incumbent provider is unhealthy", () => {
-    expect(crossesBoundary({ ...followUp, incumbentHealthy: false })).toEqual({
+    expect(crossesBoundary({ ...followUp, incumbentHealthy: false })).toMatchObject({
       crossed: true,
       boundary: BOUNDARY.CONSTRAINT,
     });
   });
 
   it("COMPACTED when the cache is gone anyway", () => {
-    expect(crossesBoundary({ ...followUp, justCompacted: true })).toEqual({
+    expect(crossesBoundary({ ...followUp, justCompacted: true })).toMatchObject({
       crossed: true,
       boundary: BOUNDARY.COMPACTED,
     });
   });
 
   it("USER when the user re-picked Auto", () => {
-    expect(crossesBoundary({ ...followUp, userRequested: true })).toEqual({
+    expect(crossesBoundary({ ...followUp, userRequested: true })).toMatchObject({
       crossed: true,
       boundary: BOUNDARY.USER,
     });
@@ -73,20 +73,20 @@ describe("crossesBoundary — each boundary in isolation", () => {
 
 describe("crossesBoundary — no boundary", () => {
   it("returns crossed:false for an ordinary follow-up turn", () => {
-    expect(crossesBoundary(followUp)).toEqual({ crossed: false, boundary: null });
+    expect(crossesBoundary(followUp)).toMatchObject({ crossed: false, boundary: null });
   });
 
   it("drifting numbers alone never cross a boundary (context growing under the limit)", () => {
     expect(
       crossesBoundary({ ...followUp, contextTokens: 25000 }),
-    ).toEqual({ crossed: false, boundary: null });
+    ).toMatchObject({ crossed: false, boundary: null });
     expect(
       crossesBoundary({
         ...followUp,
         contextTokens: 1,
         incumbentContextLimit: 1,
       }),
-    ).toEqual({ crossed: false, boundary: null });
+    ).toMatchObject({ crossed: false, boundary: null });
   });
 
   it("precedence: FIRST_TURN beats every later boundary", () => {
@@ -99,7 +99,7 @@ describe("crossesBoundary — no boundary", () => {
         justCompacted: true,
         userRequested: true,
       }),
-    ).toEqual({ crossed: true, boundary: BOUNDARY.FIRST_TURN });
+    ).toMatchObject({ crossed: true, boundary: BOUNDARY.FIRST_TURN });
   });
 
   it("precedence: AGENT beats CONSTRAINT/COMPACTED/USER", () => {
@@ -111,7 +111,66 @@ describe("crossesBoundary — no boundary", () => {
         incumbentHealthy: false,
         justCompacted: true,
       }),
-    ).toEqual({ crossed: true, boundary: BOUNDARY.AGENT });
+    ).toMatchObject({ crossed: true, boundary: BOUNDARY.AGENT });
+  });
+});
+
+describe("crossesBoundary — capability/health facts (BET-1248 reviewer Block)", () => {
+  it("a context-outgrown incumbent is reported NOT stillCapable", () => {
+    expect(
+      crossesBoundary({ ...followUp, contextTokens: 41000, incumbentContextLimit: 40000 }),
+    ).toMatchObject({ crossed: true, boundary: BOUNDARY.CONSTRAINT, stillCapable: false, stillHealthy: true });
+  });
+
+  it("a missing modality is reported NOT stillCapable", () => {
+    expect(
+      crossesBoundary({
+        ...followUp,
+        requiredModalities: ["image", "pdf"],
+        incumbentModalities: ["text", "image"],
+      }),
+    ).toMatchObject({ crossed: true, boundary: BOUNDARY.CONSTRAINT, stillCapable: false, stillHealthy: true });
+  });
+
+  it("an unhealthy incumbent is reported NOT stillHealthy", () => {
+    expect(
+      crossesBoundary({ ...followUp, incumbentHealthy: false }),
+    ).toMatchObject({ crossed: true, boundary: BOUNDARY.CONSTRAINT, stillCapable: true, stillHealthy: false });
+  });
+
+  it("non-constraint boundaries keep the incumbent capable + healthy", () => {
+    const res = crossesBoundary({ ...followUp, justCompacted: true });
+    expect(res.crossed).toBe(true);
+    expect(res.boundary).toBe(BOUNDARY.COMPACTED);
+    expect(res.stillCapable).toBe(true);
+    expect(res.stillHealthy).toBe(true);
+  });
+
+  it("no boundary → crossed:false and the incumbent still fits", () => {
+    const res = crossesBoundary(followUp);
+    expect(res).toMatchObject({ crossed: false, boundary: null, stillCapable: true, stillHealthy: true });
+  });
+
+  it("wire: a context-outgrown incumbent STILL SWITCHES while in the top-N (the Block)", () => {
+    // crossesBoundary reports the incapability...
+    const { crossed, boundary, stillCapable, stillHealthy } = crossesBoundary({
+      ...followUp,
+      contextTokens: 41000,
+      incumbentContextLimit: 40000,
+    });
+    expect(crossed).toBe(true);
+    expect(boundary).toBe(BOUNDARY.CONSTRAINT);
+    // ...and shouldSwitch honours it OVER the contention window: the incumbent
+    // is ranked #1, yet incapable → the turn switches to a capable alternative.
+    expect(
+      shouldSwitch({
+        incumbent: ep("anthropic", "a"),
+        ranked: [ep("anthropic", "a"), ep("openai", "b")],
+        incumbentStillEligible: true,
+        incumbentStillCapable: stillCapable,
+        incumbentHealthy: stillHealthy,
+      }),
+    ).toEqual({ switch: true, why: "incumbent-incapable" });
   });
 });
 


### PR DESCRIPTION
## BET-1248: Route the main conversation at boundaries from ChatPanel submit

Stage 6 of the Automatic Manta Routing epic — the last wiring step for the main
conversation. Spawns were already routed; this routes the composer's main turn.

### What changed

- **`ChatPanel.tsx`** — the `modelOverride` seed now derives from the three-state
  choice (`modelFromChoice(readSavedChoice(sessionId))`, BET-1245/1248) instead of
  the two-value seed. Holds `routedModel` / `routedReason` as per-session state
  (reset on session change like `stepTokens`/`liveTodos`), plus ref mirrors.
  In `submit()` — and only when the session's choice is `auto` — it crosses the
  routing boundary via `crossesBoundary` (first-turn / agent-changed / constraint /
  compacted / user-requested), and when a boundary is crossed calls
  `window.api.routingChoose`. `shouldSwitch` applies the hysteresis: the incumbent
  is kept unless it fell out of the router's contention. The resolved model is
  passed to both existing send paths (`opencodePrompt` and `opencodeRunCommand`) —
  no third send path. The whole routing block is wrapped in try/catch so a routing
  failure never fails a turn.
- **`chatShared.tsx`** — new pure `modelFromChoice` (choice → override seed).
- **`src/shared/routingBoundary.mjs`** — new `boundaryPhrase(boundary)` export
  (human phrase appended to the routed reason); typed + unit-tested.
- **`ModelPicker.tsx` / `InputArea.tsx`** — forward `autoReason` + `onSelectAuto`
  so `routedReason` is surfaced in the Auto row and the user can re-pick Auto
  (which re-decides on the next turn via the user-requested boundary).

All the routing judgement lives in `routingBoundary.mjs`; ChatPanel only supplies
facts and applies the answer. Between boundaries the session keeps its model.

### Tests added

- `useSseBus.test.tsx` — ChatPanel-harness coverage for the issue's list:
  first-turn Auto → `routingChoose` once, sent on the returned model;
  follow-up no boundary → not called, same model reused; compaction → called but
  model unchanged while incumbent is in contention (hysteresis); `routingChoose`
  rejecting → turn still sends on the previous model; Auto off → never called.
- `chatShared.test.ts` — `modelFromChoice` (3 states).
- `routingBoundary.test.ts` — `boundaryPhrase`.

### Notes / follow-ups

- BET-1225's `opencodeModelRoute` initial-route effect still runs at session start
  and also writes `modelOverride`/the undo pill under Auto; BET-1248's first-turn
  boundary now supersedes that initial decision. No user-visible break, but the
  two write `modelOverride` — worth consolidating.
  Follow-up filed: BET-1255 (parked).

**Base:** origin/main @ `f5956b4f`

**Files changed:** 9. [diff --stat](f5956b4f...6c08231f)

**Verification results:**
- PR branch (`multica/BET-1248-route-main-at-boundaries` @ `6c08231f`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 3422 pass / 7 skip / 0 fail (renderer 181 files; server 2637). Failures: none. log sha256: `a2060bc5cdd2fd5f3bbde4029f90abc572e240e0b5be675af1b28051050fe1d6`
- Base (`main` @ `f5956b4f`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 3412 pass / 7 skip / 0 fail (renderer 181 files; server 2637). Failures: none. log sha256: `c23f8d4b824c5d4de48fba7c9151edcc5cc64d555e248c091b4d5eea98ba51b7`
- **Conclusion:** 0 new test failures; 10 new passing tests (5 routing, 3 modelFromChoice, 2 boundaryPhrase). No pre-existing failures on base.
