### PR TITLE
fix(server): routing:main uses filtered listRoutableModels catalog (BET-1253)

### DIFF
--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -837,8 +837,13 @@ export function buildHandlers({
       } catch {
         quota = [];
       }
+      // BET-1253: the FILTERED catalogue for the "main" surface. Use the same
+      // routingListRoutableModels seam routing:choose does — the ONE place
+      // routing consent is computed — never a second filter, never raw
+      // listModels. Otherwise routing:main could route a main conversation onto
+      // a model the user deactivated/retired (which routing:choose excludes).
       try {
-        catalog = await oc.listModels();
+        catalog = await routingListRoutableModels("main", cfg);
         if (!Array.isArray(catalog)) catalog = [];
       } catch {
         catalog = [];

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -1324,6 +1324,42 @@ test("routing:choose is handed the filtered catalogue for the requested surface 
   assert.deepEqual(out.alternatives, out.alternatives.filter((a) => a && a.modelID), "alternatives are well-formed {providerID, modelID}");
 });
 
+// BET-1253: routing:main must be handed the same FILTERED catalogue for the
+// "main" surface that routing:choose uses — not the raw connected listModels.
+// Two entry points for one surface must resolve the same routable set, or a
+// main conversation could be routed onto a model the user deactivated/retired.
+test("routing:main is handed the filtered catalogue for the main surface (not listModels)", async () => {
+  const { deps } = makeDeps([]);
+  // Config that ACTIVATES routing so the decision core runs against the
+  // returned catalogue.
+  deps.local.configGet = async () => ({ projects: [], modelRouting: { preset: "economy" } });
+  let surfaceSeen = null;
+  let cfgSeen = null;
+  let calls = 0;
+  deps.routingListRoutableModels = async (surface, cfg) => {
+    surfaceSeen = surface;
+    cfgSeen = cfg;
+    calls++;
+    return [
+      { providerID: "anthropic", id: "claude-opus-4", status: "active" },
+      { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },
+      { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
+    ];
+  };
+  const handlers = buildHandlers(deps);
+  const out = await handlers["routing:main"]({
+    incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
+    agent: "build",
+  });
+  assert.equal(calls, 1);
+  assert.equal(surfaceSeen, "main", "routing:main must request the filtered catalogue for the main surface");
+  assert.equal(cfgSeen?.modelRouting?.preset, "economy", "routing:main passes the config through to the seam");
+  // A real decision was produced from the injected (filtered) catalogue — a
+  // selected model normalised into {providerID, modelID}.
+  assert.equal(out.model?.providerID, "anthropic");
+  assert.ok(typeof out.model?.modelID === "string" && out.model.modelID.length > 0);
+});
+
 // accounts:retry always reports an outcome — a non-empty message in BOTH the
 // cleared and not-cleared cases (AGENTS.md: it does the thing and says so,
 // or fails and says why; a swallowed bare return is a dead button).


### PR DESCRIPTION
## BET-1253 — routing:main uses the filtered routing catalogue (main-surface drift fix)

`routing:main` (the main-conversation session-start routing decision) was still reading the **raw** connected catalogue via `oc.listModels()`, while `routing:choose` used the filtered `listRoutableModels(surface, cfg)` — the one place routing consent is computed. For the same "main" surface two entry points resolved two different notions of "routable", so a main conversation could be routed onto a model the user deactivated/retired.

### Fix
Switched `routing:main`'s catalogue source from `oc.listModels()` to the same `routingListRoutableModels("main", cfg)` seam that `routing:choose` uses (the injected BET-1244 seam, defaulting to `listRoutableModels`). No second filter is built; the handler now resolves the same filtered set both channels use.

The handler's input contract (`{ incumbent, agent }`) and output shape (from `chooseMainModel`) are unchanged, so the BET-1225 ChatPanel caller is unaffected.

### Tests
Added `routing:main is handed the filtered catalogue for the main surface (not listModels)` in `src/server/rpc.test.mjs` — asserts the seam is invoked with surface `"main"`, the config is passed through, and a real decision is produced from the injected (filtered) catalogue.

**Files changed:** 2 (`src/server/rpc.mjs`, `src/server/rpc.test.mjs`)

**Base: `origin/main` @ `f5956b4f`**

**Verification results:**
- typecheck: exit 0. Errors: none.
- test (`npm test`): exit 0, 2638 pass / 0 fail / 0 skip.
- Including the new `routing:main` test (ok).

No cross-cutting follow-ups: this is purely the catalogue-source parity fix inside the existing `routing:main` handler; the `routing:main`/`routing:choose` divergence is now eliminated by construction (both read the same seam).
