### PR TITLE
BET-1255: Gate BET-1225 mount-time route effect to non-Auto sessions

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -15,6 +15,7 @@ import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
 import { useStore } from "./store";
 import { refreshModelCatalog } from "./modelCatalog";
 import type { Attachment } from "./chatShared";
+import { writeSavedChoice } from "./chatShared";
 import {
   installMockApi,
   resetStore,
@@ -768,14 +769,23 @@ describe("ChatPanel composer submit", () => {
 // active override (so the next prompt runs on it) and populates `routed` so the
 // composer renders the undoable pill. A null / no-op decision leaves routing
 // silent and the prompt's model untouched.
-describe("ChatPanel main-conversation routing (BET-1225)", () => {
-  let api: MockApi;
-  let h: Harness | null = null;
+  describe("ChatPanel main-conversation routing (BET-1225)", () => {
+   let api: MockApi;
+   let h: Harness | null = null;
 
-  afterEach(() => {
-    h?.unmount();
-    h = null;
-  });
+   afterEach(() => {
+     h?.unmount();
+     h = null;
+   });
+
+   beforeEach(() => {
+     // jsdom localStorage is shared across tests in this file, and the suite
+     // mounts the same ses_test session every time. Reset the per-session model
+     // choice to server-default so a prior test's "auto" write can't leak into
+     // a later non-Auto test (and vice versa). BET-1255 relies on this to
+     // switch cleanly between Auto and non-Auto sessions.
+     writeSavedChoice("ses_test", { kind: "server-default" });
+   });
 
   function typeInto(el: HTMLTextAreaElement, value: string) {
     const setter = Object.getOwnPropertyDescriptor(
@@ -854,6 +864,62 @@ describe("ChatPanel main-conversation routing (BET-1225)", () => {
     const promptCall = api.calls["opencodePrompt"]?.[0];
     expect(promptCall?.[0]).toBe("ses_test");
     expect(promptCall?.[2]).toBeUndefined();
+  });
+
+  it("makes no opencodeModelRoute mount call for an Auto session (BET-1255)", async () => {
+    writeSavedChoice("ses_test", { kind: "auto" });
+    ({ api } = installMockApi({
+      opencodeModelRoute: () =>
+        Promise.resolve({
+          model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+          reason: "build → balanced tier: anthropic quota ample",
+          incumbent: null,
+          changed: true,
+        }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    // Auto's model choice is owned by the boundary router (BET-1248), not this
+    // mount-time "build" route — the RPC must not fire for an Auto session.
+    expect(api.calls["opencodeModelRoute"] ?? []).toHaveLength(0);
+  });
+
+  it("still routes an Auto session's first turn via the boundary router (BET-1255)", async () => {
+    writeSavedChoice("ses_test", { kind: "auto" });
+    const routedModel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+    ({ api } = installMockApi({
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+      routingChoose: () =>
+        Promise.resolve({
+          model: routedModel,
+          alternatives: [routedModel],
+          reason: "first turn boundary",
+        }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const textarea = h.container.querySelector("textarea");
+    await act(async () => {
+      typeInto(textarea as HTMLTextAreaElement, "hello");
+    });
+    await act(async () => {
+      (textarea as HTMLTextAreaElement).dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await h.flush();
+
+    // The first turn is a boundary, so Auto still re-decides via routingChoose
+    // (gating the mount RPC must NOT have removed Auto routing) and the prompt
+    // runs on the routed pick.
+    expect((api.calls["routingChoose"] ?? []).length).toBeGreaterThan(0);
+    const promptCall = api.calls["opencodePrompt"]?.[0];
+    expect(promptCall?.[0]).toBe("ses_test");
+    expect((promptCall?.[2] as { modelID?: string } | undefined)?.modelID).toBe("claude-sonnet-4-6");
   });
 });
 

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -517,6 +517,14 @@ export function ChatPanel({
   // never breaks the session. Re-runs on session change; the user's own
   // selectModel clears the pill.
   useEffect(() => {
+    // BET-1255: Auto-session model choice is owned SOLELY by the boundary
+    // routing in submit() (BET-1248) — it already re-decides on the first
+    // turn, which is itself a boundary. Returning early for Auto avoids a
+    // second, immediately-overwritten "build" RPC decision (and the confusing
+    // co-existence of its undo pill with the Auto-row reason). The gate reads
+    // the same session key the effect already reads, so the [sessionId]
+    // dependency stays correct on session change.
+    if (readSavedChoice(sessionId).kind === "auto") return;
     let cancelled = false;
     const incumbent = readSavedModel(sessionId) ?? configDefaultModel ?? null;
     window.api


### PR DESCRIPTION
## BET-1255 — Gate BET-1225 mount-time route effect to non-Auto sessions

**Base: origin/main @ `404c403c`**

### What
The BET-1225 effect (ChatPanel.tsx, "main-conversation routing, the honesty
half") runs `opencodeModelRoute(incumbent, "build")` on every session start,
applies the winner, and populates the `routed` undo pill. For an **Auto**
session that decision is owned **solely** by the BET-1248 boundary router in
`submit()` — which already re-decides on the first turn (the first turn is a
boundary, `messages.length === 0`). So Auto got a second, immediately-
overwritten RPC decision plus a `routed` pill that coexists confusingly with
the Auto-row `routedReason`.

This gates the effect to non-Auto sessions:

- At the top of the effect body, if `readSavedChoice(sessionId).kind === "auto"`,
  `return` early — no RPC, no `setModelOverride`, no `setRouted`. The
  dependency array `[sessionId]` is unchanged (the gate reads the same session
  key the effect already reads, so it stays correct on session change).
- Non-Auto sessions keep today's behaviour exactly.
- BET-1248's boundary-routing block in `submit()` is untouched — it remains the
  sole owner of Auto-session routing.

### Files changed (2)
- `src/renderer/ChatPanel.tsx` — the gate (8 lines).
- `src/renderer/ChatPanel.harness.test.tsx` — 2 new tests + a `beforeEach`
  that resets the per-session model choice (jsdom localStorage is shared across
  tests in the file, so an "auto" write from one test could otherwise leak into
  a later non-Auto test).

### Tests
- **Auto session: no `opencodeModelRoute` call on mount** — seeds the choice
  auto, mounts, asserts `api.calls["opencodeModelRoute"]` is empty. Fails
  without the gate.
- **Auto session still routes the first turn via BET-1248** — seeds auto,
  stubs `routingChoose`, submits a first turn, asserts `routingChoose` ran and
  the prompt's model is the routed pick. Proves we did NOT remove Auto routing,
  only the mount RPC.
- **Existing BET-1225 tests (changed decision applied / no-op leaves model
  untouched) unchanged and passing** — they run on a non-Auto
  (server-default) session, so the gate must not affect them.

**Verification results:**
- PR branch (`multica/BET-1255-gate-route-effect-to-non-auto` @ `f65a2783`):
  - typecheck: exit `0`. Errors: none.
  - test: exit `0`, `2638` pass / `0` fail / `0` skip. Failures: none.
- Base (`main` @ `404c403c`): no source diff beyond the 2 files above (see
  `git diff --stat origin/main...HEAD` in the PR).

No cross-cutting follow-ups: no server changes, no IPC/preload changes, no
Auto-row/model-picker changes.
