### PR TITLE
chore(renderer): remove dead describeSubscriptionStatus helper (BET-1256)

### DIFF
--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -54,7 +54,6 @@ import {
   customProviderDraftError,
   connectPhaseLabel,
   isPollExpired,
-  describeSubscriptionStatus,
   arrangeCards,
   terminalShortcut,
   authErrorAdvice,
@@ -1902,41 +1901,6 @@ describe("isPollExpired", () => {
     expect(isPollExpired(NaN, 1000, 5000)).toBe(false);
     expect(isPollExpired(1000, NaN, 5000)).toBe(false);
     expect(isPollExpired(1000, 1000, NaN)).toBe(false);
-  });
-});
-
-// ===== describeSubscriptionStatus (BET-314) =====
-//
-// SubscriptionsCard renders "connected" / "not connected" next to each row.
-// The string is the entire UX (no badge, no chip), so a future copy tweak
-// should land here, not inline in the JSX. Two tests, both exhaustive over
-// the boolean — anything else (a third value, mixed casing) is a regression.
-
-describe("describeSubscriptionStatus", () => {
-  it("returns 'connected' when status.connected is true", () => {
-    expect(
-      describeSubscriptionStatus({
-        id: "anthropic",
-        label: "Claude",
-        plan: "Claude Pro / Max",
-        console: null,
-        docs: "https://claude.com/pricing",
-        connected: true,
-      }),
-    ).toBe("connected");
-  });
-
-  it("returns 'not connected' when status.connected is false", () => {
-    expect(
-      describeSubscriptionStatus({
-        id: "openai",
-        label: "Codex",
-        plan: "ChatGPT Plus / Pro",
-        console: null,
-        docs: "https://openai.com/chatgpt/pricing",
-        connected: false,
-      }),
-    ).toBe("not connected");
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -5,7 +5,7 @@
 // without DOM/Electron/network).
 import type { ReactNode } from "react";
 import type { ConnectionStateName } from "../shared/net/state.js";
-import type { AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, MediaEventPayload, OpencodeAgent, OpencodeMessage, OpencodeModel, OpencodePart, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, QuestionRequest, RepoHit, SubscriptionStatus, TmuxWindow, UpdateTarget, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { AppControlPayload, CheckRollup, DelegateApprovalTool, ForgeCheckRun, ForgeInboxItem, InboxReason, MediaEventPayload, OpencodeAgent, OpencodeMessage, OpencodeModel, OpencodePart, PermissionRequest, ProgressRecord, ProgressState, Project, PullRequest, QuestionRequest, RepoHit, TmuxWindow, UpdateTarget, UsageSnapshot, UsageWindow } from "../shared/types";
 import type { SessionMode } from "./chatShared";
 import type { VoiceNoteRecord } from "../shared/types";
 // Value import — `isClientTooOld` is the pure semver compare that drives
@@ -1571,18 +1571,6 @@ export function terminalShortcut(
   }
 }
 
-// ===== Subscription provider status (BET-314) =====
-//
-// Single source of truth for the connected/not-connected label the
-// SubscriptionsCard renders next to each row. The renderer never invents
-// its own copy here — the connect-card description ("● connected") is the
-// whole UX, and pinning the strings in chatUtils.ts keeps a future i18n /
-// copy pass touching one place. Returns "connected" / "not connected" with
-// no extra ornament (no leading dot, no uppercase — the row already draws
-// the dot separately and styles the casing).
-export function describeSubscriptionStatus(s: SubscriptionStatus): string {
-  return s.connected ? "connected" : "not connected";
-}
 // ===== Auth-error banner (BET-316) =====
 //
 // Opencode emits `session.error` whenever a turn fails. The legacy path in


### PR DESCRIPTION
Opened automatically for `multica/BET-1256-remove-dead-describesubscriptionstatus`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1256.