### PR TITLE
fix(ios): solid Sessions nav bar via one shared mantaNavigationBarBackground modifier (BET-1258)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -249,8 +249,7 @@ private struct ChatScreenContent: View {
             .environmentObject(voicePlayer)
             .navigationTitle(title)
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackgroundVisibility(.visible, for: .navigationBar)
-            .toolbarBackground(tokens.canvas, for: .navigationBar)
+            .mantaNavigationBarBackground(tokens)
             .toolbar {
                 ToolbarItem(placement: .primaryAction) {
                     Button { showOverflow = true } label: {
@@ -1183,8 +1182,7 @@ struct ChatSubagentScreen: View {
         content
             .navigationTitle(subtitle.isEmpty ? title : "\(title) · \(subtitle)")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackgroundVisibility(.visible, for: .navigationBar)
-            .toolbarBackground(tokens.canvas, for: .navigationBar)
+            .mantaNavigationBarBackground(tokens)
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("subagent-scene")
     }

--- a/mobile/native/MantaUI/Scrim.swift
+++ b/mobile/native/MantaUI/Scrim.swift
@@ -1,6 +1,9 @@
 import SwiftUI
 
 // ===========================================================================
+// Shared screen chrome — this file holds the view chrome every full-screen
+// surface must match, of which the edge scrim is one piece.
+//
 // Edge scrim.
 //
 // The shared fade behind floating chrome — the chat composer, the session
@@ -160,5 +163,27 @@ struct Scrim: View {
                 .init(color: tokens.canvas.opacity(1.0), location: 1.0),
             ]
         }
+    }
+}
+
+// ===========================================================================
+// Navigation-bar background.
+//
+// Same reason the scrim above is one component: these must MATCH. Every
+// full-screen surface pins its nav bar to solid `canvas` so the bar, the
+// list background and a pinned section header read as one continuous
+// surface. Left to the platform, the bar is transparent at the scroll edge
+// and a system blur once scrolled, and content smears under it.
+//
+// It was written out by hand on the chat screen and the subagent screen and
+// simply forgotten on the session list, which is exactly the drift one
+// modifier prevents.
+// ===========================================================================
+
+extension View {
+    func mantaNavigationBarBackground(_ tokens: Tokens) -> some View {
+        self
+            .toolbarBackgroundVisibility(.visible, for: .navigationBar)
+            .toolbarBackground(tokens.canvas, for: .navigationBar)
     }
 }

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -92,6 +92,7 @@ struct SessionListView: View {
             }
             .navigationTitle("Sessions")
             .navigationBarTitleDisplayMode(.large)
+            .mantaNavigationBarBackground(tokens)
             .toolbar {
                 ToolbarItem(placement: .topBarTrailing) {
                     Button {


### PR DESCRIPTION
Opened automatically for `multica/BET-1258-ios-solid-nav-bar`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1258.