### PR TITLE
fix(ios): decode object reply on create channels + surface real failure (BET-1259)

### DIFF
--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -177,6 +177,9 @@ final class MantaAPIClient: Sendable {
     }
 
     /// `tmux:new-session` — create a new project (tmux session).
+    /// The reply is normalised through `TmuxCreateResult`, which absorbs both
+    /// the box's `{sessionId, windowIndex, projects}` object and the legacy
+    /// bare `Project[]`.
     func newSession(_ input: NewSessionInput) async throws -> [MantaProject] {
         let dict: [String: Any] = [
             "name": input.name,
@@ -185,12 +188,14 @@ final class MantaAPIClient: Sendable {
             "createDir": input.createDir,
             "chatMode": input.chatMode,
         ]
-        return try await callRequired("tmux:new-session", args: [dict], as: [MantaProject].self)
+        return try await callRequired("tmux:new-session", args: [dict], as: TmuxCreateResult.self).projects
     }
 
     /// `tmux:new-window` — create a new session (window) in an existing project.
     /// A chat-mode window becomes a live opencode session the moment its first
-    /// message is sent.
+    /// message is sent. The reply is normalised through `TmuxCreateResult`,
+    /// which absorbs both the box's `{sessionId, windowIndex, projects}` object
+    /// and the legacy bare `Project[]`.
     func newWindow(_ input: NewWindowInput) async throws -> [MantaProject] {
         var dict: [String: Any] = [
             "sessionName": input.sessionName,
@@ -198,7 +203,7 @@ final class MantaAPIClient: Sendable {
             "chatMode": input.chatMode,
         ]
         if let cwd = input.cwd { dict["cwd"] = cwd }
-        return try await callRequired("tmux:new-window", args: [dict], as: [MantaProject].self)
+        return try await callRequired("tmux:new-window", args: [dict], as: TmuxCreateResult.self).projects
     }
 
     /// `tmux:kill-window` — delete a session (a row in the list).

--- a/mobile/native/MantaUI/SessionCreateSheet.swift
+++ b/mobile/native/MantaUI/SessionCreateSheet.swift
@@ -173,7 +173,7 @@ struct SessionCreateSheet: View {
                 }
             } catch {
                 await MainActor.run {
-                    self.error = "Couldn't create the session"
+                    self.error = SessionCreateFailure.message(for: error)
                     self.creating = false
                 }
             }

--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -157,6 +157,29 @@ struct NewWindowInput: Sendable {
     var chatMode: Bool
 }
 
+/// The reply from `tmux:new-session` / `tmux:new-window`.
+///
+/// The box answers `{sessionId, windowIndex, projects}` (since 2026-08-06); a
+/// box that predates that answers with a bare `Project[]`. ONE type absorbs
+/// both so the two call sites stay a single code path and neither has to know
+/// which box it is talking to. Only `projects` is consumed — the caller finds
+/// the created window by name — so the other two fields are deliberately
+/// dropped rather than plumbed through to nothing.
+struct TmuxCreateResult: Decodable, Equatable, Sendable {
+    let projects: [MantaProject]
+
+    private enum CodingKeys: String, CodingKey { case projects }
+
+    init(from decoder: Decoder) throws {
+        if let list = try? [MantaProject](from: decoder) {
+            projects = list
+            return
+        }
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        projects = try container.decode([MantaProject].self, forKey: .projects)
+    }
+}
+
 /// Delete-input payload for `tmux:kill-window`.
 struct KillWindowInput: Sendable {
     var sessionName: String
@@ -505,4 +528,27 @@ func shouldFireTurnCompleteHaptic(
     hapticsEnabled: Bool
 ) -> Bool {
     turnCompleteEdge && showScrollToBottom && isActive && hapticsEnabled
+}
+
+/// User-facing text for a failed create. The box sends a specific, actionable
+/// reason (a missing directory, a name clash); the sheet used to replace all of
+/// it with one generic line, which is why a create failure was undiagnosable
+/// from the phone. Anything that is NOT a message written for a human — a
+/// decoding failure, a URLError — still falls back to the generic line, because
+/// its text would mean nothing to the user.
+enum SessionCreateFailure {
+    static let generic = "Couldn't create the session."
+
+    static func message(for error: Error) -> String {
+        switch error {
+        case MantaError.authRequired:
+            return "Not signed in to this box."
+        case MantaError.server(let text) where !text.isEmpty:
+            return text
+        case MantaError.transport(let text) where !text.isEmpty:
+            return text
+        default:
+            return generic
+        }
+    }
 }

--- a/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
+++ b/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
@@ -47,13 +47,11 @@ final class MantaActionRPCWireTests: XCTestCase {
 
     func testNewSessionSingleWraps() async throws {
         let client = makeClient()
-        // The create channels return the project LIST, and a reply carrying no
-        // result is now an error rather than an empty list (that laundering is
-        // what let an unanswered `tmux:list` blank the session list). These
-        // tests only assert the REQUEST shape, so they need a reply the method
-        // can actually return — the class-wide `{"result": null}` default is
-        // not one for these three.
-        CapturingURLProtocol.result = #"{"result": []}"#
+        // These tests only assert the REQUEST shape, so they need a reply the
+        // method can return, and it must be the shape the box actually sends —
+        // the `{sessionId, windowIndex, projects}` object, not the legacy
+        // bare `Project[]`.
+        CapturingURLProtocol.result = #"{"result": {"sessionId": null, "windowIndex": 0, "projects": []}}"#
         try await client.newSession(NewSessionInput(name: "p", cwd: "/d", windowName: "w", createDir: true, chatMode: true))
         assertSingleWrapped()
         XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/tmux:new-session")
@@ -61,10 +59,33 @@ final class MantaActionRPCWireTests: XCTestCase {
 
     func testNewWindowSingleWraps() async throws {
         let client = makeClient()
-        CapturingURLProtocol.result = #"{"result": []}"#
+        CapturingURLProtocol.result = #"{"result": {"sessionId": null, "windowIndex": 0, "projects": []}}"#
         try await client.newWindow(NewWindowInput(sessionName: "p", windowName: "w", cwd: nil, chatMode: true))
         assertSingleWrapped()
         XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/tmux:new-window")
+    }
+
+    // MARK: - create-channel reply decode (BET-1259)
+
+    /// The box's `tmux:new-session` reply is `{sessionId, windowIndex,
+    /// projects}` (since 2026-08-06). `newSession` must decode that object and
+    /// return its `projects` array without throwing.
+    func testNewSessionDecodesObjectReply() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": {"sessionId": "ses_1", "windowIndex": 2, "projects": []}}"#
+        let projects = try await client.newSession(NewSessionInput(name: "p", cwd: "/d", windowName: "w", createDir: true, chatMode: true))
+        XCTAssertTrue(projects.isEmpty)
+    }
+
+    /// A box that predates 2026-08-06 answers with a bare `Project[]`.
+    /// `newSession` must decode that legacy shape and return it without
+    /// throwing — this is the regression that used to surface as a
+    /// `DecodingError.typeMismatch`.
+    func testNewSessionDecodesLegacyArrayReply() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": []}"#
+        let projects = try await client.newSession(NewSessionInput(name: "p", cwd: "/d", windowName: "w", createDir: true, chatMode: true))
+        XCTAssertTrue(projects.isEmpty)
     }
 
     func testKillWindowSingleWraps() async throws {

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -456,6 +456,24 @@ final class SessionModelsTests: XCTestCase {
         XCTAssertTrue(models?.first?.capabilities?.input?.image == true)
         XCTAssertTrue(models?.last?.capabilities?.input?.image == true)
     }
+
+    // MARK: - BET-1259 create-failure messaging
+
+    func testCreateFailureSurfacesServerReason() {
+        XCTAssertEqual(SessionCreateFailure.message(for: MantaError.server("boom")), "boom")
+    }
+
+    func testCreateFailureEmptyServerMessageFallsBackToGeneric() {
+        XCTAssertEqual(SessionCreateFailure.message(for: MantaError.server("")), SessionCreateFailure.generic)
+    }
+
+    func testCreateFailureAuthRequired() {
+        XCTAssertEqual(SessionCreateFailure.message(for: MantaError.authRequired), "Not signed in to this box.")
+    }
+
+    func testCreateFailureUnrelatedErrorFallsBackToGeneric() {
+        XCTAssertEqual(SessionCreateFailure.message(for: URLError(.timedOut)), SessionCreateFailure.generic)
+    }
 }
 
 // MARK: - BET-746 rename/fork failure feedback


### PR DESCRIPTION
Opened automatically for `multica/BET-1259-ios-create-session-decode`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1259.