### PR TITLE
BET-1262: ios: keep Sessions title visible on scroll (inline nav bar, opaque canvas background)

### DIFF
--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -91,7 +91,9 @@ struct SessionListView: View {
                 }
             }
             .navigationTitle("Sessions")
-            .navigationBarTitleDisplayMode(.large)
+            .navigationBarTitleDisplayMode(.inline)
+            .toolbarBackgroundVisibility(.visible, for: .navigationBar)
+            .toolbarBackground(tokens.canvas, for: .navigationBar)
             .mantaNavigationBarBackground(tokens)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {


### PR DESCRIPTION
Opened automatically for `multica/BET-1262-sessions-title-inline`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1262.