### PR TITLE
feat(mobile): iOS durable prompt outbox (BET-1263)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1265,7 +1265,7 @@ struct TranscriptListView<Header: View>: View {
         // screen injects `\.transcriptCardActions` at its call site. Read-only
         // surfaces (subagent drill-in) leave it unset → cards render inert.
         TiledView(items: store.rows, scrollPosition: $scrollPosition) { row in
-            TranscriptBlockCell(item: row, tokens: tokens)
+            TranscriptBlockCell(item: row, tokens: tokens, onRetry: { store.retry(promptID: $0) })
         }
         .prependLoader(.loader(
             perform: { store.loadEarlier() },

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -134,16 +134,6 @@ enum ChatStreamDelta {
     }
 }
 
-/// A prompt accepted while a turn was running, held until the session goes
-/// idle. Carries everything `send()` needs so the drain replays it verbatim.
-struct QueuedPrompt: Equatable {
-    let text: String
-    let attachments: [SendPromptInput.Attachment]
-    let model: SendPromptInput.Model?
-    let mentions: [SendPromptInput.Mention]?
-    let agent: String?
-}
-
 @MainActor
 final class ChatSessionStore: ObservableObject {
 
@@ -182,10 +172,13 @@ final class ChatSessionStore: ObservableObject {
     @Published private(set) var permissions: [PermissionRequest] = []
     @Published private(set) var planOn: Bool?
     @Published private(set) var subagents: [StreamSubagentPayload] = []
-    /// Prompts accepted mid-turn, FIFO. Drained one per idle edge — never
-    /// POSTed while `running`, which is what used to implicitly abort the
-    /// in-flight turn.
-    @Published private(set) var queuedPrompts: [QueuedPrompt] = []
+    /// The session's durable outbox rows, FIFO in submit order. A prompt a
+    /// user committed but the box has not acknowledged — `waiting` while a turn
+    /// runs (or after a relaunch), `sending` while its POST is in flight, and
+    /// `failed` (tap-to-retry) when the POST did not land. Persisted through
+    /// `PendingPromptStore`; drained one per idle edge — never POSTed while
+    /// `running`, which is what used to implicitly abort the in-flight turn.
+    @Published private(set) var pendingPrompts: [PendingPrompt] = []
     @Published private(set) var loading = false
     @Published private(set) var loadFailed = false
     /// True while the box was connected and the stream dropped (mirrors
@@ -375,14 +368,17 @@ final class ChatSessionStore: ObservableObject {
         // subagent screen owns ITS OWN store (BET-1024), so nothing here
         // touches any child; this releases the parent's own resources only.
         eventStore.unregisterSession(sessionId)
-        // A queued prompt must never fire into a session the user has left.
-        queuedPrompts.removeAll()
     }
 
     func load() {
         guard !loading else { return }
         loading = true
         refreshing = true
+        // Surface any prompts this session still has outstanding (a failed or
+        // waiting send from a previous visit). The rows render from the outbox;
+        // a relaunch has already migrated stale `waiting`/`sending` rows to
+        // `.failed` via `PendingPromptStore.failStaleOnLaunch`.
+        pendingPrompts = PendingPromptStore.prompts(for: sessionId, in: PendingPromptStore.load())
         Task {
             await fetchTranscript(isFirstLoad: true)
             // Cleared HERE, not inside the fetch: the fetch can return early
@@ -559,10 +555,10 @@ final class ChatSessionStore: ObservableObject {
         runningSince = running ? (s.runningSince ?? runningSince) : nil
 
         // The session just went idle (stream fold set `running = false`): any
-        // queued prompt may now be sent. Guard-based, so firing on whichever
+        // pending prompt may now be sent. Guard-based, so firing on whichever
         // path folded running down is harmless — a second call is a no-op while
-        // running (the drain's send sets it optimistically) or an empty queue.
-        drainQueuedPromptIfIdle()
+        // running (the drain's deliver sets it optimistically) or an empty box.
+        drainPendingPromptIfIdle()
 
         // Refetch the canonical transcript at turn boundaries so a finished
         // turn's blocks (steps/prose/subagents) land as real content. The fetch
@@ -651,7 +647,7 @@ final class ChatSessionStore: ObservableObject {
             permission: newestPermission,
             planExitQuestion: newestPlanQuestion,
             question: newestQuestion,
-            queuedPrompts: queuedPrompts
+            pendingPrompts: pendingPrompts
         )
 
         let newRows: [TranscriptRow]
@@ -705,7 +701,7 @@ final class ChatSessionStore: ObservableObject {
         permission: PermissionRequest?,
         planExitQuestion: QuestionRequest?,
         question: QuestionRequest?,
-        queuedPrompts: [QueuedPrompt]
+        pendingPrompts: [PendingPrompt]
     ) -> [TranscriptBlock] {
         var trailing: [TranscriptBlock] = []
         if let err = sessionError {
@@ -725,7 +721,7 @@ final class ChatSessionStore: ObservableObject {
         }
         // Prompts accepted mid-turn render as dim ghost bubbles at the very
         // tail — where they will actually land once the current turn finishes.
-        trailing.append(contentsOf: queuedPrompts.map { .queuedPrompt($0.text) })
+        trailing.append(contentsOf: pendingPrompts.map { .queuedPrompt($0) })
         return trailing
     }
 
@@ -971,61 +967,70 @@ final class ChatSessionStore: ObservableObject {
     /// composer trims); attachments + model are optional and flow through the
     /// unchanged `opencode:prompt` surface.
     ///
-    /// Returns `true` when the box accepted the prompt, `false` when the RPC
-    /// failed. On failure the optimistic running/tail state is rolled back so
-    /// the UI doesn't sit on a forever-spinner, and the caller is told so it
-    /// can restore the user's typed text.
-    @discardableResult
-    func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?, mentions: [SendPromptInput.Mention]? = nil, agent: String? = nil) async -> Bool {
+    /// The prompt first enters the durable outbox as a `.waiting` row, then is
+    /// delivered immediately if the session is idle (or picked up by the idle
+    /// drain if a turn is running). Failure is surfaced by the pending row in
+    /// the transcript with its own tap-to-retry — never retried automatically.
+    func send(text: String, attachments: [SendPromptInput.Attachment], model: SendPromptInput.Model?, mentions: [SendPromptInput.Mention]? = nil, agent: String? = nil) async {
+        let prompt = PendingPrompt(
+            id: UUID().uuidString,
+            sessionId: sessionId,
+            text: text,
+            attachments: attachments,
+            model: model,
+            mentions: mentions,
+            agent: agent,
+            state: .waiting
+        )
+        pendingPrompts = PendingPromptStore.upsert(prompt, into: pendingPrompts)
+        PendingPromptStore.save(pendingPrompts)
         // A send while the turn runs must not reach opencode — it would abort
-        // the in-flight turn implicitly. Queue it; the idle edge drains FIFO.
-        if running {
-            queuedPrompts.append(QueuedPrompt(text: text, attachments: attachments, model: model, mentions: mentions, agent: agent))
-            return true
-        }
-        // Echo the message straight into the transcript and assume the turn is
-        // running. The box confirms both within a second (running frame, then
-        // the canonical refetch replaces this block), but without the echo the
-        // screen sits completely unchanged after a send, which reads as "the
-        // send did nothing".
-        var optimisticUserIndex: Int?
-        if !text.isEmpty {
-            optimisticUserIndex = transcript.count
-            transcript.append(.user(text, at: Date()))
-            rebuildBlocks()
-        }
+        // the in-flight turn implicitly. The idle drain picks it up.
+        if running { return }
+        await deliver(prompt)
+    }
+
+    /// POST one pending prompt now. Keyed on the prompt's stable id (minted
+    /// once at submit and reused across a retry), so the row's identity never
+    /// changes across `waiting → sending → failed → waiting` — TiledView
+    /// updates it in place instead of remove+insert.
+    private func deliver(_ prompt: PendingPrompt) async {
+        mark(prompt, .sending)
+        // Set up the optimistic turn state `send()` used to set inline. A user
+        // submit is a genuinely new turn: re-arm the one-per-turn completion
+        // latch, mint the streaming tail's stable id, and assume the turn is
+        // running until the box confirms (the running frame, then the canonical
+        // refetch of the real user message, land within a second).
         running = true
         optimisticRunning = true
         turnComplete = false
-        // A user submit is a genuinely new turn: re-arm the one-per-turn
-        // completion latch so this turn's completion is counted once (BET-752
-        // task 5).
         completionArmed = true
         sessionError = nil
         if runningSince == nil {
             runningSince = Date()
-            // A send starts a turn directly (no stream running transition to
-            // mint this from), so mint the streaming tail's stable id here too.
             streamingTailID = "live-\(sessionId)-\(UUID().uuidString)"
             liveTailRowID = streamingTailID
         }
         do {
             try await api.sendPrompt(SendPromptInput(
                 sessionId: sessionId,
-                text: text,
-                model: model,
-                attachments: attachments.isEmpty ? nil : attachments,
-                mentions: mentions,
-                agent: agent
+                text: prompt.text,
+                model: prompt.model,
+                attachments: prompt.attachments.isEmpty ? nil : prompt.attachments,
+                mentions: prompt.mentions,
+                agent: prompt.agent
             ))
+            // Success: nothing is outstanding any more. Drop the pending row;
+            // the canonical refetch already carries the real user message.
+            remove(prompt.id)
             // A dictated note's user message now exists on the box; refetch the
             // notes so its player bubble attaches under it (BET-1029).
             Task { await refreshVoiceNotes() }
-            return true
         } catch {
             // Surface the failure instead of swallowing it: stop the running
             // state and clear the optimistic tail so the spinner doesn't stay
-            // on forever, and let the caller restore the lost message.
+            // on forever. The failed row in the transcript is the error
+            // surface — no separate `actionHint` for this flow.
             optimisticRunning = false
             let rolledBack = ChatStreamMerge.afterSendFailure(to: ChatStreamTurnState(
                 running: running,
@@ -1037,35 +1042,47 @@ final class ChatSessionStore: ObservableObject {
             running = rolledBack.running
             turnComplete = rolledBack.turnComplete
             streamingTailID = rolledBack.streamingTailID
-            // Remove THIS send's optimistic echo: the box never received the
-            // message, so it belongs back in the composer input (which the
-            // caller restores), not standing in the transcript as if sent.
-            // `fetchTranscript` can replace the whole array, so guard on the
-            // captured index still holding our echo before removing it.
-            if let idx = optimisticUserIndex, idx < transcript.count,
-               case .user(let echoed, _) = transcript[idx], echoed == text {
-                transcript.remove(at: idx)
-                rebuildBlocks()
-            }
-            return false
+            mark(prompt, .failed)
         }
     }
 
-    /// Drain ONE queued prompt now that the session is idle. One per edge: the
-    /// send() below sets `running = true` optimistically, so a second queued
-    /// item waits for the next idle. Strict FIFO.
-    private func drainQueuedPromptIfIdle() {
-        guard !running, !queuedPrompts.isEmpty else { return }
-        let next = queuedPrompts.removeFirst()
-        Task { @MainActor in
-            let ok = await send(text: next.text, attachments: next.attachments, model: next.model, mentions: next.mentions, agent: next.agent)
-            if !ok {
-                // The send failed after the box accepted going idle — don't lose
-                // the prompt silently. Put it back at the FRONT and tell the user.
-                queuedPrompts.insert(next, at: 0)
-                actionHint = "Queued message failed to send — will retry on next turn"
-            }
+    /// Drain ONE pending prompt now that the session is idle. One per idle
+    /// edge: `deliver` sets `running = true` optimistically, so a second
+    /// pending prompt waits for the next idle. Strict FIFO over `.waiting`
+    /// rows (a `.failed`/`.sending` row is never auto-delivered).
+    private func drainPendingPromptIfIdle() {
+        guard !running else { return }
+        guard let next = pendingPrompts.first(where: { $0.state == .waiting }) else { return }
+        Task { @MainActor in await deliver(next) }
+    }
+
+    /// User-initiated retry of a failed prompt. The ONLY path out of `.failed`.
+    /// Reuses the prompt's id — row identity survives the retry.
+    func retry(promptID: String) {
+        guard let index = pendingPrompts.firstIndex(where: { $0.id == promptID }),
+              pendingPrompts[index].state == .failed else { return }
+        var prompt = pendingPrompts[index]
+        prompt.state = .waiting
+        pendingPrompts[index] = prompt
+        PendingPromptStore.save(pendingPrompts)
+        if !running {
+            Task { @MainActor in await deliver(prompt) }
         }
+    }
+
+    /// Set a pending row's state, persisting and publishing it.
+    private func mark(_ prompt: PendingPrompt, _ state: PendingPrompt.State) {
+        guard let index = pendingPrompts.firstIndex(where: { $0.id == prompt.id }) else { return }
+        var updated = pendingPrompts[index]
+        updated.state = state
+        pendingPrompts[index] = updated
+        PendingPromptStore.save(pendingPrompts)
+    }
+
+    /// Remove a pending row, persisting and publishing the result.
+    private func remove(_ id: String) {
+        pendingPrompts = PendingPromptStore.remove(id: id, from: pendingPrompts)
+        PendingPromptStore.save(pendingPrompts)
     }
 
     /// Interrupt the running turn.

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -1148,18 +1148,14 @@ struct ComposerView: View {
             guard let remotePath = attachment.remotePath else { return nil }
             return SendPromptInput.Attachment(remotePath: remotePath, mime: attachment.mime, filename: attachment.filename)
         }
-        let sentText = trimmed
         let mentions = draftMentions.isEmpty ? nil : draftMentions
         // Send the resolved plan agent only while plan mode is actually on.
         let agent = modelStore.planToggle.on ? modelStore.planToggle.agent : nil
         Task { @MainActor in
-            // On a failed send the store rolled its running state back; restore
-            // the user's message so it is never silently lost, and surface why.
-            let ok = await store.send(text: sentText, attachments: sendAttachments, model: model, mentions: mentions, agent: agent)
-            if !ok {
-                text = sentText
-                surfaceHint("Send failed — message restored")
-            }
+            // Failure is surfaced by the failed pending-prompt row in the
+            // transcript with its own tap-to-retry — the composer is not a
+            // second recovery path (BET-1263).
+            await store.send(text: trimmed, attachments: sendAttachments, model: model, mentions: mentions, agent: agent)
         }
         text = ""
         attachments = []

--- a/mobile/native/MantaUI/MantaAppRoot.swift
+++ b/mobile/native/MantaUI/MantaAppRoot.swift
@@ -21,6 +21,10 @@ struct MantaAppRoot: View {
     /// A pairing payload that arrived while already paired — pending the
     /// "Switch box?" confirmation (BET-702).
     @State private var switchRequest: MantaPairing.PairPayload?
+    /// Guards the once-per-launch outbox migration: prompts left `waiting`/
+    /// `sending` when the process died become `.failed`. Must run exactly once,
+    /// before any session screen reads the outbox (BET-1263).
+    @State private var didFailStale = false
 
     init() {
         // UI-test / verification seam (BET-702): `MANTA_UI_FORCE_PAIRED` makes
@@ -94,7 +98,13 @@ struct MantaAppRoot: View {
                 // tap-open's chat to live data; S3 delivers the list, its
                 // actions, and creation.
                 SessionListView(store: sessionStore)
-                    .onAppear { store.start() }
+                    .onAppear {
+                        if !didFailStale {
+                            didFailStale = true
+                            _ = PendingPromptStore.failStaleOnLaunch()
+                        }
+                        store.start()
+                    }
                     .task { await sessionStore.refresh() }
             } else {
                 MantaOnboardingRoot(flow: flow, tokens: tokens)

--- a/mobile/native/MantaUI/MantaModels.swift
+++ b/mobile/native/MantaUI/MantaModels.swift
@@ -209,25 +209,25 @@ struct QuestionRequest: Codable, Equatable, Sendable {
 }
 
 struct SendPromptInput: Sendable {
-    struct Model: Sendable, Equatable {
+    struct Model: Sendable, Equatable, Codable {
         var providerID: String
         var modelID: String
         var variant: String?
     }
 
-    struct Attachment: Sendable, Equatable {
+    struct Attachment: Sendable, Equatable, Codable {
         var remotePath: String
         var mime: String
         var filename: String?
     }
 
-    struct MentionSource: Sendable, Equatable {
+    struct MentionSource: Sendable, Equatable, Codable {
         var value: String
         var start: Int
         var end: Int
     }
 
-    struct Mention: Sendable, Equatable {
+    struct Mention: Sendable, Equatable, Codable {
         var name: String
         var source: MentionSource
     }

--- a/mobile/native/MantaUI/PendingPrompt.swift
+++ b/mobile/native/MantaUI/PendingPrompt.swift
@@ -1,0 +1,75 @@
+import Foundation
+
+/// A prompt the user has committed but the box has not yet acknowledged.
+/// Durable: it outlives the session screen, backgrounding and app termination.
+struct PendingPrompt: Equatable, Codable, Identifiable {
+    enum State: String, Codable {
+        /// Accepted, not yet POSTed — a turn is running, or the app relaunched.
+        case waiting
+        /// The POST is in flight right now.
+        case sending
+        /// The POST failed, or the process died while it was in flight.
+        /// Terminal until the user taps retry. NEVER retried automatically.
+        case failed
+    }
+
+    let id: String
+    let sessionId: String
+    let text: String
+    let attachments: [SendPromptInput.Attachment]
+    let model: SendPromptInput.Model?
+    let mentions: [SendPromptInput.Mention]?
+    let agent: String?
+    var state: State
+}
+
+/// The durable outbox. Pure over an injected `UserDefaults` so it is unit
+/// testable; mirrors the existing `ModelRecents.load(_:)` seam.
+enum PendingPromptStore {
+    static let defaultsKey = "manta.pendingPrompts"
+
+    static func load(_ defaults: UserDefaults = .standard) -> [PendingPrompt] {
+        guard let data = defaults.data(forKey: defaultsKey),
+              let list = try? JSONDecoder().decode([PendingPrompt].self, from: data)
+        else { return [] }
+        return list
+    }
+
+    static func save(_ prompts: [PendingPrompt], to defaults: UserDefaults = .standard) {
+        if let data = try? JSONEncoder().encode(prompts) {
+            defaults.set(data, forKey: defaultsKey)
+        }
+    }
+
+    /// Called ONCE per app launch, before any session screen reads the outbox.
+    /// Every prompt that was `waiting` or `sending` when the process died
+    /// becomes `failed` — the user decides whether it is still wanted.
+    /// Returns the migrated list AND writes it back.
+    static func failStaleOnLaunch(_ defaults: UserDefaults = .standard) -> [PendingPrompt] {
+        let migrated = load(defaults).map { prompt -> PendingPrompt in
+            guard prompt.state == .waiting || prompt.state == .sending else { return prompt }
+            var p = prompt
+            p.state = .failed
+            return p
+        }
+        save(migrated, to: defaults)
+        return migrated
+    }
+
+    static func prompts(for sessionId: String, in all: [PendingPrompt]) -> [PendingPrompt] {
+        all.filter { $0.sessionId == sessionId }
+    }
+
+    static func upsert(_ prompt: PendingPrompt, into all: [PendingPrompt]) -> [PendingPrompt] {
+        if let index = all.firstIndex(where: { $0.id == prompt.id }) {
+            var out = all
+            out[index] = prompt
+            return out
+        }
+        return all + [prompt]
+    }
+
+    static func remove(id: String, from all: [PendingPrompt]) -> [PendingPrompt] {
+        all.filter { $0.id != id }
+    }
+}

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -789,9 +789,10 @@ enum TranscriptBlock: Equatable {
     /// A terminal system notice (session error / truncation) at the end of the
     /// turn it belongs to.
     case notice(String, SystemNotice)
-    /// A prompt accepted mid-turn, waiting for the session to go idle. Rendered
-    /// as a DIM ghost user bubble where the message will actually land.
-    case queuedPrompt(String)
+    /// A prompt the user committed that the box has not acknowledged. Renders as a
+    /// dim ghost user bubble while waiting/sending, and as a retryable failure row
+    /// once the send has failed.
+    case queuedPrompt(PendingPrompt)
     /// A pending permission request rendered as a blocking card in the
     /// transcript tail (BET-1214). The card's callbacks come from the
     /// surface's `TranscriptCardActions`, never from the block — a block stays

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -57,7 +57,7 @@ extension TranscriptBlock {
         // `uniqueTranscriptRows` suffixes any duplicate anyway.
         case .steps(let content): return "s" + (content.rows.first?.id ?? "empty")
         case .notice(let text, let kind): return "n\(kind)\(text.hashValue)"
-        case .queuedPrompt(let text): return "q\(text.hashValue)"
+        case .queuedPrompt(let prompt): return "pending-\(prompt.id)"
         // Cards key on the REQUEST id — stable and unique. Do NOT hash content:
         // a card whose text is edited mid-flight would change identity and cause
         // a delete+insert in the list. The prefixes are distinct so a question
@@ -197,6 +197,10 @@ struct TranscriptBlockCell: TiledCellContent {
 
     let item: TranscriptRow
     let tokens: Tokens
+    /// User-initiated retry of a failed pending prompt, threaded down from the
+    /// store-owning transcript surface. Invoked only on the main actor (inside
+    /// `TranscriptCellReveal.body`).
+    let onRetry: (String) -> Void
 
     func body(context: CellContext<Void>) -> some View {
         // The reveal offset now comes from MessagingUI's OWN pan recogniser, which
@@ -218,7 +222,8 @@ struct TranscriptBlockCell: TiledCellContent {
         TranscriptCellReveal(
             cellReveal: context.cellReveal,
             item: item,
-            tokens: tokens
+            tokens: tokens,
+            onRetry: onRetry
         )
     }
 }
@@ -231,6 +236,9 @@ private struct TranscriptCellReveal: View {
     let cellReveal: CellReveal?
     let item: TranscriptRow
     let tokens: Tokens
+    /// User-initiated retry of a failed pending prompt; read only on the main
+    /// actor here, so it never crosses the nonisolated cell boundary.
+    let onRetry: (String) -> Void
     /// The blocking-card callbacks, injected by the enclosing chat screen via
     /// `.environment(\.transcriptCardActions, …)` — read only on the main actor
     /// here, so it never crosses the nonisolated cell boundary. Nil on
@@ -266,7 +274,7 @@ private struct TranscriptCellReveal: View {
         if case .prose(let text, nil) = item.block {
             LiveProseTail(text: text, tokens: tokens)
         } else {
-            transcriptBlockView(item.block, tokens: tokens, cards: cardActions)
+            transcriptBlockView(item.block, tokens: tokens, cards: cardActions, onRetry: onRetry)
         }
     }
 }
@@ -282,7 +290,7 @@ private struct TranscriptCellReveal: View {
 /// surfaces → the cards render inert, never wiring to a live store).
 @MainActor
 @ViewBuilder
-func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: TranscriptCardActions? = nil) -> some View {
+func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: TranscriptCardActions? = nil, onRetry: (String) -> Void = { _ in }) -> some View {
     // The inert action set a read-only surface falls back to: every card
     // renders harmlessly but no closure reaches a live store.
     let actions = cards ?? TranscriptCardActions(
@@ -320,12 +328,34 @@ func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: Transc
         SystemNoticeView(text: text, kind: kind, tokens: tokens)
             .padding(.horizontal, Metrics.spacing.sp3)
             .padding(.bottom, Metrics.spacing.sp3)
-    case .queuedPrompt(let text):
-        // A ghost, dimmed user bubble — the message will land here once the
-        // current turn ends, so it renders a preview of where that will be.
-        UserBand(text: text, tokens: tokens)
-            .opacity(0.45)
-            .padding(.bottom, Metrics.spacing.sp4)
+    case .queuedPrompt(let prompt):
+        // A dim ghost user bubble while the send is waiting/sending (the
+        // message will land here once delivered) — flipped to a full-strength
+        // bubble with a tap-to-retry beneath once the send has failed.
+        switch prompt.state {
+        case .waiting, .sending:
+            UserBand(text: prompt.text, tokens: tokens)
+                .opacity(0.45)
+                .padding(.bottom, Metrics.spacing.sp4)
+        case .failed:
+            VStack(alignment: .leading, spacing: 0) {
+                UserBand(text: prompt.text, tokens: tokens)
+                Button {
+                    onRetry(prompt.id)
+                } label: {
+                    HStack(spacing: Metrics.spacing.sp2) {
+                        Image(systemName: "arrow.clockwise")
+                        Text("Couldn't send — tap to retry")
+                    }
+                    .font(.manta(size: Metrics.type.twoXS))
+                    .foregroundColor(tokens.danger)
+                }
+                .buttonStyle(.plain)
+                .padding(.horizontal, Metrics.spacing.sp3)
+                .padding(.bottom, Metrics.spacing.sp4)
+                .accessibilityIdentifier("pending-prompt-retry")
+            }
+        }
     case .permission(let permission):
         PermissionCard(permission: permission, tokens: tokens) { reply in
             actions.onPermissionReply(permission, reply)

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -198,9 +198,10 @@ struct TranscriptBlockCell: TiledCellContent {
     let item: TranscriptRow
     let tokens: Tokens
     /// User-initiated retry of a failed pending prompt, threaded down from the
-    /// store-owning transcript surface. Invoked only on the main actor (inside
-    /// `TranscriptCellReveal.body`).
-    let onRetry: (String) -> Void
+    /// store-owning transcript surface. `@MainActor` (hence Sendable) so it can
+    /// cross the cell's nonisolated `body` legally; invoked only on the main
+    /// actor (inside `TranscriptCellReveal.body`).
+    let onRetry: @MainActor (String) -> Void
 
     func body(context: CellContext<Void>) -> some View {
         // The reveal offset now comes from MessagingUI's OWN pan recogniser, which
@@ -236,9 +237,10 @@ private struct TranscriptCellReveal: View {
     let cellReveal: CellReveal?
     let item: TranscriptRow
     let tokens: Tokens
-    /// User-initiated retry of a failed pending prompt; read only on the main
-    /// actor here, so it never crosses the nonisolated cell boundary.
-    let onRetry: (String) -> Void
+    /// User-initiated retry of a failed pending prompt; `@MainActor` (Sendable)
+    /// so it crosses the nonisolated cell boundary, read only on the main actor
+    /// here.
+    let onRetry: @MainActor (String) -> Void
     /// The blocking-card callbacks, injected by the enclosing chat screen via
     /// `.environment(\.transcriptCardActions, …)` — read only on the main actor
     /// here, so it never crosses the nonisolated cell boundary. Nil on
@@ -290,7 +292,7 @@ private struct TranscriptCellReveal: View {
 /// surfaces → the cards render inert, never wiring to a live store).
 @MainActor
 @ViewBuilder
-func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: TranscriptCardActions? = nil, onRetry: (String) -> Void = { _ in }) -> some View {
+func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: TranscriptCardActions? = nil, onRetry: @escaping @MainActor (String) -> Void = { _ in }) -> some View {
     // The inert action set a read-only surface falls back to: every card
     // renders harmlessly but no closure reaches a live store.
     let actions = cards ?? TranscriptCardActions(

--- a/mobile/native/MantaUITests/ChatStreamMergeTests.swift
+++ b/mobile/native/MantaUITests/ChatStreamMergeTests.swift
@@ -129,8 +129,7 @@ final class ChatStreamMergeTests: XCTestCase {
         )
         await Task.yield()
 
-        let ok = await store.send(text: "hello", attachments: [], model: nil)
-        XCTAssertTrue(ok)
+        await store.send(text: "hello", attachments: [], model: nil)
         XCTAssertTrue(store.running, "a send reports running optimistically")
 
         // Unrelated context frame while the box hasn't confirmed → keep running.
@@ -170,8 +169,7 @@ final class ChatStreamMergeTests: XCTestCase {
         stream.inject(#"{"kind":"stream","sub":"context","sessionId":"ses","payload":{"freshInput":0,"cacheRead":0,"cacheWrite":0,"totalInput":0,"pct":0,"segments":[]}}"#)
         await Task.yield()
 
-        let ok = await store.send(text: "hello", attachments: [], model: nil)
-        XCTAssertTrue(ok)
+        await store.send(text: "hello", attachments: [], model: nil)
         XCTAssertTrue(store.running, "a send reports running optimistically")
 
         // The box reconnects and states the authoritative running set: this
@@ -203,8 +201,7 @@ final class ChatStreamMergeTests: XCTestCase {
         XCTAssertEqual(store.streamingTailID, "")
 
         // User sends the next message before the refetch lands.
-        let ok = await store.send(text: "next", attachments: [], model: nil)
-        XCTAssertTrue(ok)
+        await store.send(text: "next", attachments: [], model: nil)
         XCTAssertTrue(store.running)
         let mintedTail = store.streamingTailID
         XCTAssertFalse(mintedTail.isEmpty, "send() mints the streaming tail")
@@ -231,8 +228,7 @@ final class ChatStreamMergeTests: XCTestCase {
             eventStore: MantaEventStore(stream: TestStreamControl(), tokenProvider: { nil }, serverProvider: { nil }),
             api: api
         )
-        let ok = await store.send(text: "hello", attachments: [], model: nil)
-        XCTAssertFalse(ok, "a failed send must be reported as failed")
+        await store.send(text: "hello", attachments: [], model: nil)
         XCTAssertFalse(store.running, "a failed send must stop the running state (no forever-spinner)")
 
         let userBlocks = store.transcript.filter {
@@ -240,6 +236,8 @@ final class ChatStreamMergeTests: XCTestCase {
             return false
         }
         XCTAssertEqual(userBlocks.count, 0, "a failed send must not leave the message in the transcript")
+        XCTAssertEqual(store.pendingPrompts.filter { $0.state == .failed }.count, 1,
+                       "a failed send must leave a failed pending row with tap-to-retry")
     }
 
     // MARK: - Permissions routing (BET-715)
@@ -363,9 +361,9 @@ final class ChatStreamMergeTests: XCTestCase {
         await Task.yield()
         XCTAssertTrue(store.running)
 
-        let ok = await store.send(text: "queued", attachments: [], model: nil)
-        XCTAssertTrue(ok, "a mid-turn send is accepted (queued), not rejected")
-        XCTAssertEqual(store.queuedPrompts.count, 1, "the send must be queued")
+        await store.send(text: "queued", attachments: [], model: nil)
+        XCTAssertEqual(store.pendingPrompts.filter { $0.state == .waiting }.count, 1,
+                       "a mid-turn send is accepted and queued, not rejected")
         XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, [],
                        "no prompt may be POSTed while a turn runs")
     }
@@ -384,15 +382,15 @@ final class ChatStreamMergeTests: XCTestCase {
         await Task.yield()
         stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
         await Task.yield()
-        _ = await store.send(text: "q1", attachments: [], model: nil)
-        XCTAssertEqual(store.queuedPrompts.count, 1)
+        await store.send(text: "q1", attachments: [], model: nil)
+        XCTAssertEqual(store.pendingPrompts.filter { $0.state == .waiting }.count, 1)
         XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, [])
 
         // Turn finishes → idle edge drains exactly one.
         stream.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses","payload":{"complete":true,"running":false}}"#)
         await waitUntil { RecordingPromptURLProtocol.sentTexts == ["q1"] }
 
-        XCTAssertEqual(store.queuedPrompts.count, 0, "the queue must empty after the idle drain")
+        XCTAssertEqual(store.pendingPrompts.count, 0, "the outbox must empty after the idle drain")
         XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, ["q1"],
                        "the queued prompt must be sent exactly once on idle")
         XCTAssertTrue(store.running, "the drained send sets running optimistically")
@@ -411,16 +409,16 @@ final class ChatStreamMergeTests: XCTestCase {
         await Task.yield()
         stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
         await Task.yield()
-        _ = await store.send(text: "q1", attachments: [], model: nil)
-        _ = await store.send(text: "q2", attachments: [], model: nil)
-        XCTAssertEqual(store.queuedPrompts.count, 2)
+        await store.send(text: "q1", attachments: [], model: nil)
+        await store.send(text: "q2", attachments: [], model: nil)
+        XCTAssertEqual(store.pendingPrompts.filter { $0.state == .waiting }.count, 2)
 
         // First idle edge → only q1.
         stream.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses","payload":{"complete":true,"running":false}}"#)
         await waitUntil { RecordingPromptURLProtocol.sentTexts == ["q1"] }
         XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, ["q1"],
                        "the first idle edge must send only the FIRST queued prompt")
-        XCTAssertEqual(store.queuedPrompts.count, 1)
+        XCTAssertEqual(store.pendingPrompts.filter { $0.state == .waiting }.count, 1)
 
         // Drain's send is running; box confirms, then that turn finishes →
         // second drains.
@@ -430,12 +428,14 @@ final class ChatStreamMergeTests: XCTestCase {
         await waitUntil { RecordingPromptURLProtocol.sentTexts == ["q1", "q2"] }
         XCTAssertEqual(RecordingPromptURLProtocol.sentTexts, ["q1", "q2"],
                        "the second idle edge must send the second queued prompt (FIFO)")
-        XCTAssertEqual(store.queuedPrompts.count, 0)
+        XCTAssertEqual(store.pendingPrompts.count, 0)
     }
 
-    /// Leaving the session (stop) clears the queue so a queued prompt never
-    /// fires into a session the user has left.
-    func testStopClearsQueuedPrompts() async {
+    /// Leaving the session must NOT discard an outstanding prompt: the outbox
+    /// is durable (BET-1263), so `stop()` preserves it and a later `load()`
+    /// re-hydrates it. The old "clear the queue on leave" behaviour was
+    /// precisely the silent-loss bug this ticket removes.
+    func testStopPreservesPendingPrompts() async {
         let stream = TestStreamControl()
         let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
         let store = ChatSessionStore(
@@ -446,12 +446,12 @@ final class ChatStreamMergeTests: XCTestCase {
         await Task.yield()
         stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
         await Task.yield()
-        _ = await store.send(text: "q1", attachments: [], model: nil)
-        XCTAssertEqual(store.queuedPrompts.count, 1)
+        await store.send(text: "q1", attachments: [], model: nil)
+        XCTAssertEqual(store.pendingPrompts.filter { $0.state == .waiting }.count, 1)
 
         store.stop()
-        XCTAssertEqual(store.queuedPrompts.count, 0,
-                       "leaving the session must clear the queue")
+        XCTAssertEqual(store.pendingPrompts.filter { $0.state == .waiting }.count, 1,
+                       "leaving the session must NOT clear the durable outbox")
     }
 
     // MARK: - Once-per-turn completion signal (BET-752 task 5)
@@ -472,8 +472,7 @@ final class ChatStreamMergeTests: XCTestCase {
 
         // A genuine user turn starts via `send()` (re-arms the once-per-turn
         // latch).
-        let ok = await store.send(text: "hello", attachments: [], model: nil)
-        XCTAssertTrue(ok)
+        await store.send(text: "hello", attachments: [], model: nil)
 
         // Message A streams and completes.
         stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
@@ -494,7 +493,7 @@ final class ChatStreamMergeTests: XCTestCase {
                        "a second message completion of the SAME turn must not emit another haptic")
 
         // A NEW user turn re-arms and counts its own completion once.
-        _ = await store.send(text: "again", attachments: [], model: nil)
+        await store.send(text: "again", attachments: [], model: nil)
         stream.inject(#"{"kind":"stream","sub":"running","sessionId":"ses","payload":{"running":true}}"#)
         await Task.yield()
         stream.inject(#"{"kind":"stream","sub":"turnComplete","sessionId":"ses","payload":{"complete":true,"running":false}}"#)
@@ -834,8 +833,9 @@ final class TrailingCardsTests: XCTestCase {
         QuestionRequest(id: id, sessionID: "ses", questions: [], tool: nil, requestId: nil)
     }
 
-    private func queued(_ text: String) -> QueuedPrompt {
-        QueuedPrompt(text: text, attachments: [], model: nil, mentions: nil, agent: nil)
+    private func queued(_ text: String) -> PendingPrompt {
+        PendingPrompt(id: UUID().uuidString, sessionId: "ses", text: text,
+                      attachments: [], model: nil, mentions: nil, agent: nil, state: .waiting)
     }
 
     private func kind(_ block: TranscriptBlock) -> String {
@@ -857,7 +857,7 @@ final class TrailingCardsTests: XCTestCase {
             permission: cardPermission("p"),
             planExitQuestion: cardQuestion("pe"),
             question: cardQuestion("q"),
-            queuedPrompts: [queued("next")]
+            pendingPrompts: [queued("next")]
         )
         XCTAssertEqual(blocks.map(kind),
                        ["notice", "notice", "permission", "planExit", "question", "queuedPrompt"],
@@ -869,7 +869,7 @@ final class TrailingCardsTests: XCTestCase {
             sessionError: nil,
             truncation: StreamTruncationPayload(kind: "", label: "trunc", messageID: nil),
             running: true,
-            permission: nil, planExitQuestion: nil, question: nil, queuedPrompts: [])
+            permission: nil, planExitQuestion: nil, question: nil, pendingPrompts: [])
         XCTAssertEqual(blocks.map(kind), [],
                        "a truncation notice must not render while the turn is still running")
     }
@@ -877,7 +877,7 @@ final class TrailingCardsTests: XCTestCase {
     func testOmittedCardsProduceNoBlocks() {
         let blocks = ChatSessionStore.trailingBlocks(
             sessionError: nil, truncation: nil, running: false,
-            permission: nil, planExitQuestion: nil, question: nil, queuedPrompts: [])
+            permission: nil, planExitQuestion: nil, question: nil, pendingPrompts: [])
         XCTAssertEqual(blocks, [])
     }
 
@@ -885,7 +885,7 @@ final class TrailingCardsTests: XCTestCase {
         let blocks = ChatSessionStore.trailingBlocks(
             sessionError: nil, truncation: nil, running: false,
             permission: cardPermission("p"), planExitQuestion: cardQuestion("pe"), question: cardQuestion("q"),
-            queuedPrompts: [queued("a"), queued("b")])
+            pendingPrompts: [queued("a"), queued("b")])
         let kinds = blocks.map(kind)
         XCTAssertEqual(kinds.last, "queuedPrompt",
                        "queued prompts represent what happens next and must stay at the very end")

--- a/mobile/native/MantaUITests/PendingPromptStoreTests.swift
+++ b/mobile/native/MantaUITests/PendingPromptStoreTests.swift
@@ -1,0 +1,161 @@
+import XCTest
+@testable import MantaUI
+
+// ===========================================================================
+// BET-1263 — the durable prompt outbox's pure layer: `PendingPromptStore`.
+// Round-trips through an injected UserDefaults, migrates stale rows on launch,
+// preserves FIFO submit order through upsert, filters per session, and removes
+// by id. No view, no HTTP, no box — and never touches `.standard`.
+// ===========================================================================
+
+final class PendingPromptStoreTests: XCTestCase {
+
+    private let suiteName = "PendingPromptStoreTests"
+
+    private var defaults: UserDefaults!
+
+    override func setUp() {
+        super.setUp()
+        defaults = UserDefaults(suiteName: suiteName)
+        defaults.removePersistentDomain(forName: suiteName)
+    }
+
+    override func tearDown() {
+        defaults.removePersistentDomain(forName: suiteName)
+        defaults = nil
+        super.tearDown()
+    }
+
+    private func prompt(
+        _ id: String = UUID().uuidString,
+        sessionId: String = "ses",
+        text: String = "hi",
+        state: PendingPrompt.State = .waiting
+    ) -> PendingPrompt {
+        PendingPrompt(
+            id: id, sessionId: sessionId, text: text,
+            attachments: [], model: nil, mentions: nil, agent: nil, state: state
+        )
+    }
+
+    private func pendingState(_ p: PendingPrompt) -> PendingPrompt.State { p.state }
+
+    // MARK: - Load / save round-trip
+
+    func testRoundTripPreservesAllFields() {
+        let attachment = SendPromptInput.Attachment(remotePath: "/tmp/a.png", mime: "image/png", filename: "a.png")
+        let model = SendPromptInput.Model(providerID: "anthropic", modelID: "opus")
+        let mention = SendPromptInput.Mention(
+            name: "file.txt",
+            source: SendPromptInput.MentionSource(value: "file.txt", start: 0, end: 8)
+        )
+        let original = PendingPrompt(
+            id: "id-1", sessionId: "ses",
+            text: "write it",
+            attachments: [attachment], model: model,
+            mentions: [mention], agent: "plan",
+            state: .sending
+        )
+        PendingPromptStore.save([original], to: defaults)
+        let loaded = PendingPromptStore.load(defaults)
+        XCTAssertEqual(loaded, [original])
+    }
+
+    func testLoadMissingKeyReturnsEmpty() {
+        XCTAssertEqual(PendingPromptStore.load(defaults), [])
+    }
+
+    func testLoadCorruptDataReturnsEmptyWithoutThrowing() {
+        defaults.set(Data("not json".utf8), forKey: PendingPromptStore.defaultsKey)
+        XCTAssertEqual(PendingPromptStore.load(defaults), [], "a decode failure must return [], never throw or trap")
+    }
+
+    // MARK: - failStaleOnLaunch
+
+    func testFailStaleMapsWaitingToFailed() {
+        PendingPromptStore.save([prompt("w", state: .waiting)], to: defaults)
+        let migrated = PendingPromptStore.failStaleOnLaunch(defaults)
+        XCTAssertEqual(migrated.map(pendingState), [.failed])
+        XCTAssertEqual(PendingPromptStore.load(defaults).map(pendingState), [.failed],
+                       "failStaleOnLaunch must also WRITE the migrated list back")
+    }
+
+    func testFailStaleMapsSendingToFailed() {
+        PendingPromptStore.save([prompt("s", state: .sending)], to: defaults)
+        let migrated = PendingPromptStore.failStaleOnLaunch(defaults)
+        XCTAssertEqual(migrated.map(pendingState), [.failed])
+    }
+
+    func testFailStaleLeavesFailedAlone() {
+        PendingPromptStore.save([prompt("f", state: .failed)], to: defaults)
+        let migrated = PendingPromptStore.failStaleOnLaunch(defaults)
+        XCTAssertEqual(migrated.map(pendingState), [.failed], "an already-failed row stays failed (no state change)")
+    }
+
+    func testFailStalePreservesContentAndOrder() {
+        let waiting = prompt("w", text: "first", state: .waiting)
+        let sending = prompt("s", text: "second", state: .sending)
+        let failed = prompt("f", text: "third", state: .failed)
+        PendingPromptStore.save([waiting, sending, failed], to: defaults)
+
+        let migrated = PendingPromptStore.failStaleOnLaunch(defaults)
+        XCTAssertEqual(migrated.map(pendingState), [.failed, .failed, .failed])
+        XCTAssertEqual(migrated.map(\.text), ["first", "second", "third"],
+                       "migration must not reorder or mutate the carried text")
+    }
+
+    // MARK: - upsert (FIFO + in-place replace)
+
+    func testUpsertAppendsNewToEnd() {
+        let a = prompt("a", text: "A")
+        let b = prompt("b", text: "B")
+        let both = PendingPromptStore.upsert(b, into: PendingPromptStore.upsert(a, into: []))
+        XCTAssertEqual(both.map(\.id), ["a", "b"], "FIFO submit order: new items append to the end")
+    }
+
+    func testUpsertExistingReplacesInPlaceWithoutMoving() {
+        let a = prompt("a", text: "A")
+        let b = prompt("b", text: "B")
+        let c = prompt("c", text: "C")
+        let all = [a, b, c]
+
+        // Re-submit the FIRST row with a new state: it updates in place and does
+        // NOT move to the end.
+        let updatedA = PendingPrompt(id: a.id, sessionId: a.sessionId, text: a.text,
+                                     attachments: a.attachments, model: a.model,
+                                     mentions: a.mentions, agent: a.agent, state: .failed)
+        let result = PendingPromptStore.upsert(updatedA, into: all)
+        XCTAssertEqual(result.map(\.id), ["a", "b", "c"], "an upsert of an existing id replaces in place, not at the end")
+        XCTAssertEqual(result.map(pendingState), [.failed, .waiting, .waiting])
+    }
+
+    // MARK: - prompts(for:in:)
+
+    func testPromptsForSessionFilters() {
+        let mineA = prompt("a", sessionId: "ses")
+        let mineB = prompt("b", sessionId: "ses")
+        let other = prompt("c", sessionId: "ses-2")
+        let out = PendingPromptStore.prompts(for: "ses", in: [mineA, other, mineB])
+        XCTAssertEqual(out.map(\.id), ["a", "b"],
+                       "only this session's prompts, in FIFO order")
+    }
+
+    func testPromptsForSessionEmptyWhenNone() {
+        let other = prompt("c", sessionId: "ses-2")
+        XCTAssertEqual(PendingPromptStore.prompts(for: "ses", in: [other]), [])
+    }
+
+    // MARK: - remove(id:from:)
+
+    func testRemoveDeletesById() {
+        let a = prompt("a")
+        let b = prompt("b")
+        let out = PendingPromptStore.remove(id: "a", from: [a, b])
+        XCTAssertEqual(out.map(\.id), ["b"])
+    }
+
+    func testRemoveUnknownIdIsNoOp() {
+        let a = prompt("a")
+        XCTAssertEqual(PendingPromptStore.remove(id: "nope", from: [a]).map(\.id), ["a"])
+    }
+}


### PR DESCRIPTION
## Summary

Replaces the four inconsistent "unsent prompt" representations in the native iOS app with **one durable outbox**, so a submitted prompt survives backgrounding and fails visibly with tap-to-retry.

- **`PendingPrompt` / `PendingPromptStore`** (new, pure, unit-tested): a prompt the user committed that the box has not acked, in `waiting` / `sending` / `failed` states, persisted to `UserDefaults` under `manta.pendingPrompts`.
- **`send()`** now writes a `.waiting` row (durable, survives session leave + app termination) before anything else; delivers immediately if idle, else the idle drain picks it up. The optimistic echo and the in-memory `queuedPrompts` queue are deleted. Removes the `@discardableResult`/`Bool` return — no caller has a decision left.
- **`deliver()`** marks `.sending`, sets the optimistic turn state verbatim, POSTs; on success removes the row, on failure marks `.failed` (rollback verbatim). No `actionHint`, no auto-retry.
- **`retry(promptID:)`** is the only path out of `.failed`; reuses the row's id.
- **`failStaleOnLaunch()`** runs once per launch (guarded in `MantaAppRoot`), migrating leftover `waiting`/`sending` rows to `.failed`.
- **Rendering:** `TranscriptBlock.queuedPrompt` now carries a `PendingPrompt`; row identity is `pending-<id>` (fixes the duplicate-row-id crash); `.failed` renders a tap-to-retry button under a full-strength user bubble.
- **`ComposerView`** stops restoring text on failure — the failed row is the error surface.

## Files changed

- `mobile/native/MantaUI/PendingPrompt.swift` (new)
- `mobile/native/MantaUI/MantaModels.swift` — `Codable` on the four `SendPromptInput` payload types
- `mobile/native/MantaUI/ChatSessionStore.swift`
- `mobile/native/MantaUI/MantaAppRoot.swift`
- `mobile/native/MantaUI/TranscriptComponents.swift`
- `mobile/native/MantaUI/TranscriptRow.swift`
- `mobile/native/MantaUI/ComposerView.swift`
- `mobile/native/MantaUI/ChatScreen.swift` (thread `onRetry` into the cell)
- `mobile/native/MantaUITests/PendingPromptStoreTests.swift` (new)
- `mobile/native/MantaUITests/ChatStreamMergeTests.swift` (ported)

## Verification

iOS merge gate `ios-mantaui` plugin `test-unit` on `multica/BET-1263-durable-prompt-outbox`:

- **TEST SUCCEEDED — Executed 611 tests, 0 failures (0 unexpected)** (both bundles compiled; UI bundle not run — capture harness)
- Baseline `main`: 598 tests, 0 failures. +13 new tests.

Note: repo `npm run typecheck` / `npm test` were not re-run — this diff is Swift-only under `mobile/native/` and the TypeScript/desktop surface is untouched. The iOS merge gate is the relevant verification for this change and it passes.

**Base:** `origin/main` @ `cc8d05a9`
