### PR TITLE
feat(routing): decision record — chooseModel reports what it used (BET-1265)

### DIFF
--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -942,6 +942,19 @@ export function buildHandlers({
           nowMs: Date.now(),
           services,
         });
+        // The box-side signal that routing ran (BET-1265). Always logged, no
+        // debug flag: a decision nobody watches is a decision not made. Names
+        // the winner, the cost basis and whether the mix was measured.
+        {
+          const t = decision?.trace;
+          const basis = t?.winner?.cost?.basis ?? "none";
+          const mix = t?.winner?.cost?.mixSource ?? "default";
+          const dropped = Array.isArray(t?.dropped) ? t.dropped.reduce((s, d) => s + d.n, 0) : 0;
+          const w = decision?.model;
+          console.log(
+            `[router] ${surface}/${agent} → ${w?.providerID ?? "-"}/${w?.id ?? "-"} · ${basis} · considered=${t?.considered ?? 0} dropped=${dropped} mix=${mix}`
+          );
+        }
         // On the off-path / no-survivors path chooseModel returns the very
         // catalogIncumbent reference it was handed; map that back to the
         // original structured incumbent so the decision stays byte-identical.

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -1360,6 +1360,49 @@ test("routing:main is handed the filtered catalogue for the main surface (not li
   assert.ok(typeof out.model?.modelID === "string" && out.model.modelID.length > 0);
 });
 
+// BET-1265: routing:choose emits exactly one `[router]` line (the box-side
+// signal that routing ran) whenever an activated routing decision is made.
+// Format: [router] <surface>/<agent> → <provider>/<model> · <basis> ·
+// considered=<n> dropped=<n> mix=<measured|default>. Gated on nothing.
+test("routing:choose logs exactly one well-formed [router] line on a routed decision", async () => {
+  const { deps } = makeDeps([]);
+  // Config that ACTIVATES routing so the decision core actually runs.
+  deps.local.configGet = async () => ({
+    projects: [],
+    modelRouting: { preset: "economy", declaredModels: { "anthropic/claude-sonnet-4": { catalogId: "claude-sonnet-4" } } },
+  });
+  deps.routingListRoutableModels = async () => [
+    { providerID: "anthropic", id: "claude-sonnet-4", status: "active", cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0.5 } },
+  ];
+  const fakeCatalog = {
+    matchModel: (id) => ({ kind: "exact", candidates: [{ id, name: id }] }),
+    lookupModel: (id) => ({ id }),
+    allModels: () => [{ id: "claude-sonnet-4", benchmarks: [{ name: "SWE-Bench Verified", score: 0.8 }] }],
+  };
+  const handlers = buildHandlers({ ...deps, routingCatalogIndex: fakeCatalog });
+  const lines = [];
+  const orig = console.log;
+  console.log = (...a) => lines.push(a.join(" "));
+  try {
+    await handlers["routing:choose"]({
+      sessionId: "ses_1",
+      directory: "/w",
+      agent: "build",
+      surface: "main",
+      contextTokens: 0,
+      needs: {},
+      incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
+    });
+  } finally {
+    console.log = orig;
+  }
+  assert.equal(lines.length, 1, "exactly one [router] line, no debug flag");
+  // Deterministic for this injected catalogue: a real winner (sonnet, no
+  // account → cost basis "unknown"), zero drops, mix=default (no measured
+  // ledger mix on today's wiring — the evidence BET-1265 exists to surface).
+  assert.equal(lines[0], "[router] main/build → anthropic/claude-sonnet-4 · unknown · considered=1 dropped=0 mix=default");
+});
+
 // accounts:retry always reports an outcome — a non-empty message in BOTH the
 // cleared and not-cleared cases (AGENTS.md: it does the thing and says so,
 // or fails and says why; a swallowed bare return is a dead button).

--- a/src/shared/blendedPrice.d.mts
+++ b/src/shared/blendedPrice.d.mts
@@ -16,9 +16,14 @@ export type Mix = {
   cacheWrite: number;
 };
 
+export type MixSource = "measured" | "default";
+export type ReferenceFlag = "catalogue" | "absent";
+
 export interface PriceBits {
   price: number;
   known: boolean;
+  mixSource: MixSource;
+  reference: ReferenceFlag;
 }
 
 export const DEFAULT_MIX: Mix;

--- a/src/shared/blendedPrice.mjs
+++ b/src/shared/blendedPrice.mjs
@@ -41,8 +41,12 @@ function dollar(v) {
 // Normalise a caller-supplied mix so the four fractions sum to 1. A mix that
 // does not sum to 1 is rescaled, not rejected. A missing / empty / all-zero
 // mix falls back to DEFAULT_MIX (a box with no ledger history).
+//
+// Module-private. Reports which branch it took: "measured" when the caller
+// supplied a usable mix, "default" when it fell back to DEFAULT_MIX. This is
+// how a box that never fed it ledger counts becomes visible (the trace).
 function normalizeMix(mix) {
-  if (!mix || typeof mix !== "object") return { ...DEFAULT_MIX };
+  if (!mix || typeof mix !== "object") return { mix: { ...DEFAULT_MIX }, source: "default" };
   const raw = {
     input: dollar(mix.input),
     output: dollar(mix.output),
@@ -50,12 +54,15 @@ function normalizeMix(mix) {
     cacheWrite: dollar(mix.cacheWrite),
   };
   const total = raw.input + raw.output + raw.cacheRead + raw.cacheWrite;
-  if (!(total > 0)) return { ...DEFAULT_MIX };
+  if (!(total > 0)) return { mix: { ...DEFAULT_MIX }, source: "default" };
   return {
-    input: raw.input / total,
-    output: raw.output / total,
-    cacheRead: raw.cacheRead / total,
-    cacheWrite: raw.cacheWrite / total,
+    mix: {
+      input: raw.input / total,
+      output: raw.output / total,
+      cacheRead: raw.cacheRead / total,
+      cacheWrite: raw.cacheWrite / total,
+    },
+    source: "measured",
   };
 }
 
@@ -77,13 +84,14 @@ function normalizeMix(mix) {
  * @param {object} [mix]            {input, output, cacheRead, cacheWrite} fractions summing to 1
  * @param {object} [reference]      {input, output} typical price for this model from the
  *                                  provider-agnostic catalogue, used for the implausible-zero rule
- * @returns {{ price: number, known: boolean }}
+ * @returns {{ price: number, known: boolean, mixSource: "measured"|"default", reference: "catalogue"|"absent" }}
  */
 export function blendedPrice(model, mix, reference) {
-  const useMix = normalizeMix(mix);
+  const { mix: useMix, source: mixSource } = normalizeMix(mix);
   const cost = model && typeof model.cost === "object" && model.cost !== null ? model.cost : null;
 
   const hasReference = reference !== null && typeof reference === "object";
+  const referenceFlag = hasReference ? "catalogue" : "absent";
 
   // --- known ---------------------------------------------------------------
   // A missing cost bag, or a missing (non-numeric) input/output rate, leaves
@@ -110,7 +118,7 @@ export function blendedPrice(model, mix, reference) {
   // no reference we return 0 rather than inventing a number anyone could trust.
   if (!known) {
     const price = hasReference ? dollar(reference.input) + dollar(reference.output) : 0;
-    return { price, known: false };
+    return { price, known: false, mixSource, reference: referenceFlag };
   }
 
   // Missing cache rates bill at the full input rate; declared 0 stays 0.
@@ -125,7 +133,7 @@ export function blendedPrice(model, mix, reference) {
     cacheRead * useMix.cacheRead +
     cacheWrite * useMix.cacheWrite;
 
-  return { price: dollar(price), known: true };
+  return { price: dollar(price), known: true, mixSource, reference: referenceFlag };
 }
 
 /**

--- a/src/shared/blendedPrice.test.ts
+++ b/src/shared/blendedPrice.test.ts
@@ -30,7 +30,7 @@ describe("blendedPrice — the headline case", () => {
 describe("blendedPrice — declared free vs implausible zero", () => {
   it("a declared-free model with no reference is price 0, known true", () => {
     const res = blendedPrice(model({ input: 0, output: 0 }));
-    expect(res).toEqual({ price: 0, known: true });
+    expect(res).toEqual({ price: 0, known: true, mixSource: "default", reference: "absent" });
   });
 
   it("implausible zero (input 0, output 0) with a priced reference is known false and returns the reference price", () => {
@@ -88,6 +88,32 @@ describe("blendedPrice — degenerate input is finite and non-negative", () => {
     expect(typeof res.price).toBe("number");
     expect(Number.isFinite(res.price)).toBe(true);
     expect(res.price).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe("blendedPrice — source flags (BET-1265)", () => {
+  it("reports a default mix and absent reference when neither is supplied", () => {
+    const res = blendedPrice(model({ input: 5, output: 25 }));
+    expect(res.mixSource).toBe("default");
+    expect(res.reference).toBe("absent");
+  });
+
+  it("reports measured + catalogue when a usable mix and a reference are supplied", () => {
+    const res = blendedPrice(model({ input: 5, output: 25 }), { input: 0.5, output: 0.1, cacheRead: 0.3, cacheWrite: 0.1 }, { input: 5, output: 25 });
+    expect(res.mixSource).toBe("measured");
+    expect(res.reference).toBe("catalogue");
+  });
+
+  it("an all-zero mix falls back to default and reports it", () => {
+    const res = blendedPrice(model({ input: 5, output: 25 }), { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    expect(res.mixSource).toBe("default");
+  });
+
+  it("the unknown-price early return carries both flags too", () => {
+    const res = blendedPrice(model({ input: 5 }), undefined, { input: 5, output: 25 });
+    expect(res.known).toBe(false);
+    expect(res.mixSource).toBe("default");
+    expect(res.reference).toBe("catalogue");
   });
 });
 

--- a/src/shared/modelRouter.d.mts
+++ b/src/shared/modelRouter.d.mts
@@ -67,11 +67,31 @@ export interface ChooseInput {
   services?: RoutingServices;
 }
 
+export type QualityBasis = "benchmark" | "family" | "structural";
+export type MixSource = "measured" | "default";
+export type ReferenceFlag = "catalogue" | "absent";
+
+export interface RoutingSignals {
+  quality: { score: number; basis: QualityBasis; known: boolean };
+  cost: { value: number; basis: string; mixSource: MixSource; reference: ReferenceFlag };
+  reliability: "measured" | "unmeasured";
+  telemetry: { p50Ms: number | null; p90Ms: number | null; tokensPerSec: number | null };
+}
+
+export interface RoutingTrace {
+  considered: number;
+  dropped: { stage: "eligible" | "capable"; reason: string; n: number }[];
+  intent: { contextTokens: number; needs: { tools: boolean; image: boolean; pdf: boolean } };
+  target: { tier: string; floorTier: string; widened: boolean };
+  winner: RoutingSignals | null;
+}
+
 export interface ChooseResult {
   model: Model | null;
   reason: string;
   alternatives: Model[];
   changed: boolean;
+  trace: RoutingTrace;
 }
 
 export function chooseModel(input?: ChooseInput): ChooseResult;

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -13,7 +13,30 @@ import { qualityScore, tierForScore, meetsFloor, AGENT_FLOOR_SCORE } from "./mod
 import { resolveIdentity } from "./modelIdentity.mjs";
 import { autoEligibility, MISSING } from "./autoEligibility.mjs";
 import { marginalCost } from "./marginalCost.mjs";
+import { blendedPrice } from "./blendedPrice.mjs";
 import { shouldDerank } from "./toolReliability.mjs";
+
+// The inspectable decision record (BET-1265). `quality.basis` and `cost.basis`
+// are passed through VERBATIM from qualityScore / marginalCost — never
+// re-mapped or prettified. `reliability` is "measured" when a sample exists on
+// the box, "unmeasured" otherwise.
+/**
+ * @typedef {object} RoutingSignals
+ * @property {{ score: number, basis: "benchmark"|"family"|"structural", known: boolean }} quality
+ * @property {{ value: number, basis: string, mixSource: "measured"|"default",
+ *              reference: "catalogue"|"absent" }} cost
+ * @property {"measured"|"unmeasured"} reliability
+ * @property {{ p50Ms: number|null, p90Ms: number|null, tokensPerSec: number|null }} telemetry
+ */
+
+/**
+ * @typedef {object} RoutingTrace
+ * @property {number} considered
+ * @property {{ stage: "eligible"|"capable", reason: string, n: number }[]} dropped
+ * @property {{ contextTokens: number, needs: { tools: boolean, image: boolean, pdf: boolean } }} intent
+ * @property {{ tier: string, floorTier: string, widened: boolean }} target
+ * @property {RoutingSignals|null} winner
+ */
 
 export const PRESETS = ["economy", "balanced", "performance"];
 
@@ -71,16 +94,26 @@ function assess(candidate, { nowMs }, services) {
     providerClass: services.providerClass?.[candidate.providerID] ?? "supported",
   });
   const mc = marginalCost({ model: candidate, account: services.accounts?.[candidate.providerID], nowMs, mix: services.mix, reference: services.referenceByModel?.[candidate.id] });
+  // The raw mix/reference flags blendedPrice already computed with the SAME
+  // inputs marginalCost handed it — reported verbatim, not recomputed. This is
+  // what makes a silently-defaulted mix / absent catalogue visible (BET-1265).
+  const bp = blendedPrice(candidate, services.mix, services.referenceByModel?.[candidate.id]);
   const penalise = shouldDerank(services.reliability?.samples?.[key], services.reliability?.baseline?.[candidate.id]).penalise === true;
   return {
     key,
     candidate,
+    quality,
     qualityScore: quality.known ? quality.score : 0,
     tier: tierForScore(quality.known ? quality.score : undefined),
     eligible: elig.eligible,
     missing: elig.missing,
     marginalCost: mc.exhausted ? Infinity : mc.cost,
     exhausted: mc.exhausted,
+    costBasis: mc.basis,
+    mixSource: bp.mixSource,
+    reference: bp.reference,
+    reliability: services.reliability?.samples?.[key] ? "measured" : "unmeasured",
+    telemetry: services.telemetry?.[key] ?? {},
     penalise,
   };
 }
@@ -108,6 +141,30 @@ function bindingReason(counts) {
 const num0 = (v) => (isNum(v) ? v : 0);
 const numInf = (v) => (isNum(v) ? v : Infinity);
 const telemetryOf = (a, services) => services.telemetry?.[a.key] ?? {};
+
+// The winner's inspectable signals, read off the assessed entry — every value
+// was already computed during assess(); nothing new is derived here.
+function signalsOf(a) {
+  return {
+    quality: {
+      score: a.quality.score,
+      basis: a.quality.basis,
+      known: a.quality.known,
+    },
+    cost: {
+      value: a.marginalCost,
+      basis: a.costBasis,
+      mixSource: a.mixSource,
+      reference: a.reference,
+    },
+    reliability: a.reliability,
+    telemetry: {
+      p50Ms: typeof a.telemetry?.p50Ms === "number" ? a.telemetry.p50Ms : null,
+      p90Ms: typeof a.telemetry?.p90Ms === "number" ? a.telemetry.p90Ms : null,
+      tokensPerSec: typeof a.telemetry?.tokensPerSec === "number" ? a.telemetry.tokensPerSec : null,
+    },
+  };
+}
 
 // Soft ordering within a competing set (same model, or a flattened economy
 // set): penalised sorts last; then cost; then quality, throughput, the
@@ -208,21 +265,40 @@ function explain({ agent, tierName, preset, winner, cost }) {
  *   (all optional; absent is permissive / measured-average, never false):
  *   { catalogMatcher, catalogEntryFor, qualityField, declared, providerClass,
  *     accounts, health, telemetry, reliability, mix, referenceByModel }
- * @returns {{ model: object|null, reason: string, alternatives: object[], changed: boolean }}
+ * @returns {{ model: object|null, reason: string, alternatives: object[], changed: boolean, trace: object }}
  */
 export function chooseModel(input = {}) {
   const { intent = {}, catalog = [], policy = {}, nowMs = 0 } = input;
   const services = input.services && typeof input.services === "object" ? input.services : {};
   const agent = intent?.agent ?? "general";
   const incumbent = intent?.incumbent ?? null;
+  // Echoes back EXACTLY what the caller passed — unmodified, never the
+  // normalised `contextTokens`. A caller hardcoding contextTokens: 0 becomes
+  // visible here (BET-1265) without reading the caller.
+  const traceIntent = {
+    contextTokens: intent?.contextTokens,
+    needs: intent?.needs ?? {},
+  };
 
   if (intent?.kind === "mid-exchange") {
-    return { model: incumbent, reason: "mid-exchange switching is disabled", alternatives: [], changed: false };
+    return {
+      model: incumbent,
+      reason: "mid-exchange switching is disabled",
+      alternatives: [],
+      changed: false,
+      trace: { considered: 0, dropped: [], intent: traceIntent, target: { tier: "", floorTier: "", widened: false }, winner: null },
+    };
   }
   // Off-path (no routing directive): return the incumbent BY REFERENCE,
   // byte-identical so a box without routing behaves exactly as before.
   if (!routingActive(policy)) {
-    return { model: incumbent, reason: "routing not activated for this conversation", alternatives: [], changed: false };
+    return {
+      model: incumbent,
+      reason: "routing not activated for this conversation",
+      alternatives: [],
+      changed: false,
+      trace: { considered: 0, dropped: [], intent: traceIntent, target: { tier: "", floorTier: "", widened: false }, winner: null },
+    };
   }
 
   const needs = intent?.needs ?? {};
@@ -230,28 +306,57 @@ export function chooseModel(input = {}) {
 
   const survivors = [];
   const counts = {};
+  const drops = [];
+  let considered = 0;
+  const addDrop = (stage, reason) => {
+    const existing = drops.find((d) => d.stage === stage && d.reason === reason);
+    if (existing) existing.n += 1;
+    else drops.push({ stage, reason, n: 1 });
+  };
   for (const c of Array.isArray(catalog) ? catalog : []) {
+    considered += 1;
     const a = assess(c, { nowMs }, services);
     const cap = capabilityDrop(c, hardCtx);
     if ((a.exhausted && !cap) || cap || !a.eligible) {
-      counts[bindLabel(a, cap)] = (counts[bindLabel(a, cap)] ?? 0) + 1;
+      const label = bindLabel(a, cap);
+      counts[label] = (counts[label] ?? 0) + 1;
+      // "capable" = can't do THIS turn (missing capability / exhausted);
+      // "eligible" = not admissible by the completeness rules at all.
+      addDrop(cap || a.exhausted ? "capable" : "eligible", label);
       continue;
     }
     survivors.push(a);
   }
 
-  if (survivors.length === 0) {
-    return { model: incumbent, reason: `no ${agent} model passes constraints (${bindingReason(counts)})`, alternatives: [], changed: false };
-  }
-
   const targetRaw = policy?.perAgent?.[agent] ?? AGENT_TIER?.[policy?.preset]?.[agent] ?? "balanced";
   const floorScore = AGENT_FLOOR_SCORE[agent] ?? 0;
   const targetRank = Math.max(tierRank(targetRaw), tierRank(tierForScore(floorScore)));
+  const targetTrace = {
+    tier: TIER_BY_RANK[targetRank],
+    floorTier: tierForScore(floorScore),
+    widened: false,
+  };
+
+  if (survivors.length === 0) {
+    return {
+      model: incumbent,
+      reason: `no ${agent} model passes constraints (${bindingReason(counts)})`,
+      alternatives: [],
+      changed: false,
+      trace: { considered, dropped: drops, intent: traceIntent, target: targetTrace, winner: null },
+    };
+  }
 
   const explored = stage3Order(survivors, { preset: policy?.preset, telemetry: services.telemetry });
   const band = selectBand(explored, targetRank, agent);
   if (band.length === 0) {
-    return { model: incumbent, reason: `no ${agent} model meets the ${TIER_BY_RANK[targetRank]} target above the ${floorScore} floor`, alternatives: [], changed: false };
+    return {
+      model: incumbent,
+      reason: `no ${agent} model meets the ${TIER_BY_RANK[targetRank]} target above the ${floorScore} floor`,
+      alternatives: [],
+      changed: false,
+      trace: { considered, dropped: drops, intent: traceIntent, target: targetTrace, winner: null },
+    };
   }
 
   const winner = band[0].candidate;
@@ -261,5 +366,12 @@ export function chooseModel(input = {}) {
     reason: explain({ agent, tierName: TIER_BY_RANK[tierRank(band[0].tier)], preset: policy?.preset, winner, cost: band[0].marginalCost }),
     alternatives: band.slice(1, 4).map((a) => a.candidate),
     changed: !incumbent || endpointKey(incumbent) !== winnerKey,
+    trace: {
+      considered,
+      dropped: drops,
+      intent: traceIntent,
+      target: { ...targetTrace, widened: tierRank(band[0].tier) !== targetRank },
+      winner: signalsOf(band[0]),
+    },
   };
 }

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -331,3 +331,74 @@ describe("chooseModel — return shape", () => {
     expect(res.alternatives.map((x) => x.providerID)).toEqual(["b", "c", "d"]);
   });
 });
+
+describe("chooseModel — decision trace (BET-1265)", () => {
+  it("on a winner, reports what it actually used: quality basis, cost, mix, reliability, telemetry", () => {
+    const a = endpoint("sonnet", { providerID: "p", tier: "balanced" });
+    const b = endpoint("haiku", { providerID: "p", tier: "fast" });
+    const res = route({
+      catalog: [a, b],
+      policy: { preset: "balanced" },
+      intent: { incumbent: endpoint("opus", { providerID: "p" }), contextTokens: 0, needs: { tools: true } },
+      services: { telemetry: { "p/sonnet": { p50Ms: 120, p90Ms: 300, tokensPerSec: 80 } } },
+    });
+    expect(res.model?.id).toBe("sonnet");
+    expect(res.trace.considered).toBe(2);
+    expect(res.trace.dropped).toEqual([]);
+    expect(res.trace.intent).toEqual({ contextTokens: 0, needs: { tools: true } });
+    expect(res.trace.target.widened).toBe(false);
+    const w = res.trace.winner!;
+    expect(typeof w.quality.score).toBe("number");
+    expect(["benchmark", "family", "structural"]).toContain(w.quality.basis);
+    expect(w.quality.known).toBe(true);
+    expect(typeof w.cost.value).toBe("number");
+    expect(w.cost.mixSource).toBe("default");
+    expect(w.cost.reference).toBe("absent");
+    expect(w.reliability).toBe("unmeasured");
+    expect(w.telemetry).toEqual({ p50Ms: 120, p90Ms: 300, tokensPerSec: 80 });
+  });
+
+  it("measured telemetry is read, with per-field null fallback when absent", () => {
+    const res = route({
+      catalog: [endpoint("m", { tier: "balanced" })],
+      policy: { preset: "balanced" },
+      services: { telemetry: { "p/m": { tokensPerSec: 40 } } },
+    });
+    const w = res.trace.winner!;
+    expect(w.telemetry).toEqual({ p50Ms: null, p90Ms: null, tokensPerSec: 40 });
+  });
+
+  it("intent echoes the caller's contextTokens and needs verbatim", () => {
+    const res = route({
+      catalog: [endpoint("m", { tier: "balanced" })],
+      policy: { preset: "balanced" },
+      intent: { contextTokens: 0, needs: {} },
+    });
+    expect(res.trace.intent).toEqual({ contextTokens: 0, needs: {} });
+  });
+
+  it("no-survivor: winner is null and dropped names every stage/reason pair with counts", () => {
+    const retired = endpoint("retired", { status: "retired" });
+    const opaque = endpoint("opaque", { providerID: "q" });
+    const toolLess = endpoint("tool", { providerID: "p", capabilities: { toolcall: false, input: { image: true, pdf: true } } });
+    const incumbent = endpoint("inc", { providerID: "x" });
+    const res = route({
+      catalog: [retired, opaque, toolLess],
+      policy: { preset: "balanced" },
+      intent: { incumbent, contextTokens: 0, needs: { tools: true } },
+      services: { declared: defaultDeclared([retired, toolLess]) }, // opaque deliberately not declared
+    });
+    expect(res.model?.providerID).toBe("x"); // incumbent returned unchanged
+    expect(res.trace.winner).toBeNull();
+    expect(res.trace.considered).toBe(3);
+    expect(res.trace.dropped).toHaveLength(3);
+    expect(res.trace.dropped).toEqual(
+      expect.arrayContaining([
+        { stage: "capable", reason: "no active model", n: 1 },
+        { stage: "eligible", reason: "identity", n: 1 },
+        { stage: "capable", reason: "tool calling", n: 1 },
+      ]),
+    );
+    expect(res.trace.intent).toEqual({ contextTokens: 0, needs: { tools: true } });
+  });
+});


### PR DESCRIPTION
## BET-1265 — Routing: the decision record — make `chooseModel` report what it actually used

**Outcome-neutral.** For identical inputs the same model wins with the same reason string, before and after. The only behavioural change is that `chooseModel` now returns `trace`, and `routing:choose` logs one `[router]` line on the box. No routing decision logic was touched — the `counts`/`bindLabel`/`bindingReason`/ordering paths are byte-identical.

### What changed
- **`blendedPrice`** now returns `mixSource` (`"measured"|"default"`) and `reference` (`"catalogue"|"absent"`) on all return paths. Private `normalizeMix` reports whether it fell back to `DEFAULT_MIX`. Pinned in `blendedPrice.test.ts` including the fallback and unknown-price early-return cases.
- **`chooseModel`** returns `trace` on every exit (both no-survivor paths, the off-path returns, and the winner). `trace` echoes the caller's `intent` verbatim, reports `considered`/`dropped` (stage/reason/count), `target` (tier/floorTier/widened), and for a winner the full `RoutingSignals` (`quality` basis/score/known, `cost` value/basis/mixSource/reference, `reliability`, `telemetry`). `quality.basis` and `cost.basis` are passed through verbatim from `qualityScore`/`marginalCost` — not re-mapped. No new computation: every trace field reads a value `assess()` already produced (the one addition, reading `mixSource`/`reference` off a `blendedPrice` call with exactly the args `marginalCost` uses, is a report of an existing value, not a new decision input).
- **`routing:choose`** in `rpc.mjs` logs exactly one line, gated on nothing:
  ```
  [router] <surface>/<agent> → <providerID>/<modelID> · <basis> · considered=<n> dropped=<n> mix=<measured|default>
  ```
- Types added to `modelRouter.d.mts` (`RoutingSignals`, `RoutingTrace`, `ChooseResult.trace`) and `blendedPrice.d.mts`.

### Acceptance evidence
1. `npm run typecheck && npm test` green (details below).
2. `modelRouter.test.ts` asserts a no-survivor decision has `trace.winner === null` and `trace.dropped` naming every stage/reason pair with counts.
3. `modelRouter.test.ts` asserts `trace.intent` echoes the caller's `contextTokens` and `needs` verbatim.
4. `rpc.test.mjs` "routing:choose logs exactly one well-formed [router] line..." — runnable without a live box (injected deps only, no live tmux/opencode/network). Captured line:
   ```
   [router] main/build → anthropic/claude-sonnet-4 · unknown · considered=1 dropped=0 mix=default
   ```
5. Trace for one decision (from same harness — a real routed decision core over the injected catalogue). On today's wiring this shows `mix=default` and (implicitly) `reference=absent` — **the evidence BET-1265 exists to surface; not fixed here**, per the issue.

   ```json
   {
     "considered": 1,
     "dropped": [],
     "intent": { "contextTokens": 0, "needs": {} },
     "target": { "tier": "fast", "floorTier": "balanced", "widened": false },
     "winner": {
       "quality": { "score": 0.5, "basis": "structural", "known": true },
       "cost": { "value": 0.84, "basis": "unknown", "mixSource": "default", "reference": "absent" },
       "reliability": "unmeasured",
       "telemetry": { "p50Ms": null, "p90Ms": null, "tokensPerSec": null }
     }
   }
   ```

   > I could not run a **live** box here (no live opencode/tmux in this environment), so the box-side items 4/5 are verified through the injected-dep RPC harness above rather than a live session. The values match what the issue predicts for today's `main` (`mix=default`, `reference=absent`).

### Do-nots honoured
- No behaviour change; no debug/verbose flag, env var or config key; nothing computed new for the trace; `trace` is separate from the user-facing `reason` string. No provider names in the decision core (`modelRouter.mjs`/`blendedPrice.mjs`/`marginalCost.mjs` untouched for vendor terms).

**Follow-ups:** none filed — the `mix=default`/`reference=absent` on today's wiring is the known starting state the downstream issues in this repair set (which depend on this `trace`) are built to fix; not a defect of this issue.

**Base:** `origin/main @ a8a105cab` (branch was cut from `cc8d05a9`; rebased base recorded at PR time).

---

**Files changed (8):**
- `src/shared/blendedPrice.mjs` — `normalizeMix` reports source; `blendedPrice` returns `mixSource` + `reference` on all paths
- `src/shared/blendedPrice.d.mts` — `PriceBits` gains both fields
- `src/shared/blendedPrice.test.ts` — pins both flags incl. fallback + unknown-price early return
- `src/shared/modelRouter.mjs` — assemble + return `trace` from all exits
- `src/shared/modelRouter.d.mts` — `RoutingSignals` / `RoutingTrace` typedefs, `ChooseResult.trace`
- `src/shared/modelRouter.test.ts` — winner trace, no-survivor dropped/winner-null, intent echo
- `src/server/rpc.mjs` — the one `[router]` log line in `routing:choose`
- `src/server/rpc.test.mjs` — asserts exactly one well-formed `[router]` line

**Verification results:**
- PR branch (`multica/BET-1265-decision-record` @ `aaab4f58`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2646 pass / 0 fail / 0 skip. Failures: none. log sha256: `75c4ce3c098fb8cdbab8537fa53473f02a0d754b37527d55e3cbb56af483bdbc`
- Base (`main` @ `a8a105cab`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 2645 pass / 0 fail / 0 skip. Failures: none. log sha256: `a02e2ff93d0c06b82c1005d027806a09281a1213f09cb9a6f936508fefac0b1c`
- **Conclusion:** 0 new failures; the PR adds exactly one test (2646 vs 2645).
