### PR TITLE
fix(mobile): keep in-flight prompt send alive across backgrounding (BET-1264)

### DIFF
--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -1,5 +1,6 @@
 import Foundation
 import Combine
+import UIKit
 
 // ===========================================================================
 // S4 — chat session store (BET-596).
@@ -990,6 +991,18 @@ final class ChatSessionStore: ObservableObject {
         await deliver(prompt)
     }
 
+    /// Run `work` inside a background-task assertion so an in-flight send is not
+    /// frozen the instant the app is backgrounded. The assertion is ALWAYS ended,
+    /// including on the expiration handler — an unbalanced one is a watchdog kill.
+    private func withBackgroundAssertion<T>(_ name: String, _ work: () async throws -> T) async rethrows -> T {
+        var id: UIBackgroundTaskIdentifier = .invalid
+        id = UIApplication.shared.beginBackgroundTask(withName: name) {
+            if id != .invalid { UIApplication.shared.endBackgroundTask(id); id = .invalid }
+        }
+        defer { if id != .invalid { UIApplication.shared.endBackgroundTask(id); id = .invalid } }
+        return try await work()
+    }
+
     /// POST one pending prompt now. Keyed on the prompt's stable id (minted
     /// once at submit and reused across a retry), so the row's identity never
     /// changes across `waiting → sending → failed → waiting` — TiledView
@@ -1012,14 +1025,16 @@ final class ChatSessionStore: ObservableObject {
             liveTailRowID = streamingTailID
         }
         do {
-            try await api.sendPrompt(SendPromptInput(
-                sessionId: sessionId,
-                text: prompt.text,
-                model: prompt.model,
-                attachments: prompt.attachments.isEmpty ? nil : prompt.attachments,
-                mentions: prompt.mentions,
-                agent: prompt.agent
-            ))
+            try await withBackgroundAssertion("send-prompt") {
+                try await api.sendPrompt(SendPromptInput(
+                    sessionId: sessionId,
+                    text: prompt.text,
+                    model: prompt.model,
+                    attachments: prompt.attachments.isEmpty ? nil : prompt.attachments,
+                    mentions: prompt.mentions,
+                    agent: prompt.agent
+                ))
+            }
             // Success: nothing is outstanding any more. Drop the pending row;
             // the canonical refetch already carries the real user message.
             remove(prompt.id)


### PR DESCRIPTION
## BET-1264 — iOS: keep an in-flight prompt send alive across backgrounding

Lands on top of BET-1263 (durable outbox), which introduced `ChatSessionStore.deliver(_:)`.

Wraps **only** the network attempt inside `deliver(_:)` in a UIKit background-task assertion, so a send already in flight gets the system's discretionary grace window when the app is backgrounded instead of being frozen instantly.

### Changes

- `mobile/native/MantaUI/ChatSessionStore.swift`:
  - Add `import UIKit`.
  - Add one small private `withBackgroundAssertion(_:_:)` helper. The assertion is **always** balanced — ended in both the expiration handler and a `defer`, each guarded by `.invalid`, so double-ending is impossible.
  - In `deliver(_:)`, wrap **only** the `try await api.sendPrompt(...)` call. The `.sending` transition, optimistic turn state, success removal, and failure `.failed` transition/rollback stay exactly where they are, outside the assertion.

### Scope respected

- Exactly one call site — no other RPC wrapped.
- No background `URLSession`, no `BGTaskScheduler`, no `URLSessionConfiguration.background`. The app's RPC client keeps using `URLSession.shared`.
- No automatic resend on relaunch — a prompt that still fails comes back `.failed` and waits for the user's tap.
- No background mode added to `Info.plist` or `project.yml`.
- `MantaAPIClient`, the event store, and the reconnect controller are untouched.
- Swift 6: `ChatSessionStore` is `@MainActor` and `UIApplication.shared` is main-actor-isolated, so the helper needs no extra annotation; no `Task.detached`, no `@unchecked Sendable`.

This is a mitigation, not a guarantee — the outbox remains the correctness story.

### Verification (iOS merge gate)

- `ios-mantaui` `test-unit` on `multica/BET-1264-ios-bg-prompt-send` (branch `7f7635a4`): **PASS**. Job status `done`; unit test log `/tmp/manta-ios-unit-7f7635a4.log` (2875 lines) shows tests passing.
- No new unit test added — `UIApplication` is not testable from the unit bundle; a mock of it would test the mock.

Base: `origin/main @ fae5172a`
