### PR TITLE
fix(routing): one endpoint identity across every seam (BET-1266)

### DIFF
--- a/src/shared/endpointKey.d.mts
+++ b/src/shared/endpointKey.d.mts
@@ -1,0 +1,12 @@
+export interface EndpointLike {
+  providerID?: string;
+  modelID?: string;
+  id?: string;
+}
+
+/**
+ * The stable machine identity of a routed endpoint: `providerID/modelID`.
+ * Returns `""` when either side is missing — an empty key is "no identity"
+ * and must never match another empty key at a comparison site.
+ */
+export function endpointKey(m: EndpointLike | null | undefined): string;

--- a/src/shared/endpointKey.mjs
+++ b/src/shared/endpointKey.mjs
@@ -1,0 +1,17 @@
+/**
+ * The stable machine identity of a routed endpoint: `providerID/modelID`.
+ *
+ * The SINGLE definition. Two conventions for a model id are in circulation —
+ * the router's internal catalogue shape uses `id`, everything crossing the RPC
+ * boundary uses `modelID` (see toDeliverModel). Accepting both here is what
+ * makes them one identity rather than two that silently disagree.
+ *
+ * An empty key means "no identity": a routing comparison must never treat two
+ * empty keys as matching (see routingBoundary's incumbentIndex guard).
+ */
+export function endpointKey(m) {
+  if (!m) return "";
+  const provider = m.providerID ?? "";
+  const model = m.modelID ?? m.id ?? "";
+  return provider && model ? `${provider}/${model}` : "";
+}

--- a/src/shared/endpointKey.test.ts
+++ b/src/shared/endpointKey.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { endpointKey } from "./endpointKey.mjs";
+
+describe("endpointKey — the single identity definition", () => {
+  it("renders providerID/modelID for the RPC (deliver) shape", () => {
+    expect(endpointKey({ providerID: "anthropic", modelID: "claude-sonnet-4-6" })).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
+  });
+
+  it("renders providerID/id for the router catalogue shape", () => {
+    expect(endpointKey({ providerID: "anthropic", id: "claude-sonnet-4-6" })).toBe(
+      "anthropic/claude-sonnet-4-6",
+    );
+  });
+
+  it("the two shapes resolve to the SAME identity — one convention, not two", () => {
+    expect(endpointKey({ providerID: "anthropic", modelID: "claude-opus-4-7" })).toBe(
+      endpointKey({ providerID: "anthropic", id: "claude-opus-4-7" }),
+    );
+  });
+
+  it("distinguishes different models of the same provider", () => {
+    expect(endpointKey({ providerID: "anthropic", modelID: "a" })).not.toBe(
+      endpointKey({ providerID: "anthropic", modelID: "z" }),
+    );
+  });
+
+  it("returns '' for null / undefined / missing provider / missing model", () => {
+    expect(endpointKey(null)).toBe("");
+    expect(endpointKey(undefined)).toBe("");
+    expect(endpointKey({})).toBe("");
+    expect(endpointKey({ providerID: "anthropic" })).toBe("");
+    expect(endpointKey({ modelID: "x" })).toBe("");
+  });
+
+  it("an empty key is never an identity — it never equals a real key", () => {
+    expect(endpointKey({ providerID: "anthropic" })).not.toBe(
+      endpointKey({ providerID: "anthropic", modelID: "x" }),
+    );
+    expect(endpointKey({ modelID: "x" })).not.toBe(
+      endpointKey({ providerID: "p", modelID: "x" }),
+    );
+  });
+
+  it("every missing-identity endpoint collapses to the same empty key — so comparison SITES must guard, not the key", () => {
+    // Two endpoints with no identity BOTH produce "" — that is exactly why a
+    // comparison must never pair two empty keys as "the same endpoint". The
+    // key returns "" for all of these; the guard lives at the comparison site
+    // (routingBoundary's incumbentIndex early-returns -1 on an empty incumbent).
+    expect(endpointKey({})).toBe("");
+    expect(endpointKey({ providerID: "p" })).toBe("");
+    expect(endpointKey({ modelID: "x" })).toBe("");
+  });
+});

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -9,6 +9,7 @@
 // ever appears here or in its imports.
 
 import { tierRank } from "./modelGuide.mjs";
+import { endpointKey } from "./endpointKey.mjs";
 import { qualityScore, tierForScore, meetsFloor, AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
 import { resolveIdentity } from "./modelIdentity.mjs";
 import { autoEligibility, MISSING } from "./autoEligibility.mjs";
@@ -46,8 +47,6 @@ export const AGENT_TIER = {
   balanced: { build: "deep", plan: "deep", general: "balanced", explore: "fast" },
   performance: { build: "deep", plan: "deep", general: "deep", explore: "balanced" },
 };
-
-const endpointKey = (c) => `${c?.providerID ?? ""}/${c?.id ?? ""}`;
 
 const BINDING_ORDER = [
   "no active model", "context headroom", "tool calling", "image input", "pdf input",
@@ -247,9 +246,9 @@ function selectBand(ordered, targetRank, agent) {
 
 function explain({ agent, tierName, preset, winner, cost }) {
   if (preset === "economy") {
-    return `${agent} → ${tierName} tier (economy): ${winner.providerID}/${winner.id} cheapest at $${cost.toFixed(4)}`;
+    return `${agent} → ${tierName} tier (economy): ${endpointKey(winner)} cheapest at $${cost.toFixed(4)}`;
   }
-  return `${agent} → ${tierName} tier: ${winner.providerID}/${winner.id}`;
+  return `${agent} → ${tierName} tier: ${endpointKey(winner)}`;
 }
 
 /**

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { chooseModel, AGENT_TIER, PRESETS, type RoutingServices } from "./modelRouter.mjs";
+import { endpointKey } from "./endpointKey.mjs";
 import { tierRank } from "./modelGuide.mjs";
 import { AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
 
@@ -27,7 +28,7 @@ function endpoint(id: string, over: EndpointOver = {}): Endpoint {
 }
 
 function defaultDeclared(catalog: Endpoint[]): Record<string, { catalogId: string }> {
-  return Object.fromEntries(catalog.map((c) => [`${c.providerID}/${c.id}`, { catalogId: String(c.id) }]));
+  return Object.fromEntries(catalog.map((c) => [endpointKey(c), { catalogId: String(c.id) }]));
 }
 
 type RouteOpts = {
@@ -57,8 +58,7 @@ function route({ catalog, policy, intent = {}, services: extra = {}, nowMs = 0 }
   });
 }
 
-const keyOf = (m: { providerID?: string; id?: string } | null | undefined) =>
-  m ? `${m.providerID}/${m.id}` : "";
+const keyOf = endpointKey;
 
 describe("PRESETS / AGENT_TIER", () => {
   it("exposes the three presets and the tier table read by the renderer", () => {

--- a/src/shared/routingBoundary.d.mts
+++ b/src/shared/routingBoundary.d.mts
@@ -6,6 +6,20 @@ export const BOUNDARY: {
   USER: string;
 };
 
+/**
+ * A routed endpoint as it crosses the RPC boundary: the RPC/deliver shape uses
+ * `modelID`, the router's internal catalogue shape uses `id`. `endpointKey`
+ * accepts both sides so they resolve to one identity. At least one of
+ * `modelID` / `id` is normally present; an endpoint with neither has no
+ * identity and never matches another.
+ */
+export interface RoutedEndpoint {
+  providerID: string;
+  modelID?: string;
+  id?: string;
+  variant?: string;
+}
+
 export interface CrossesInput {
   hasRoutedModel?: boolean;
   agent?: string;
@@ -34,8 +48,8 @@ export function crossesBoundary(input?: CrossesInput): CrossesResult;
 export function boundaryPhrase(boundary: string | null): string;
 
 export interface ShouldSwitchInput {
-  incumbent?: object | null;
-  ranked?: object[];
+  incumbent?: RoutedEndpoint | null;
+  ranked?: RoutedEndpoint[];
   incumbentStillEligible: boolean;
   incumbentStillCapable: boolean;
   incumbentHealthy: boolean;

--- a/src/shared/routingBoundary.mjs
+++ b/src/shared/routingBoundary.mjs
@@ -22,10 +22,10 @@ export const BOUNDARY = {
   USER: "user-requested", // the user re-picked Auto
 };
 
-// Stable machine identity of a routed endpoint. Same convention as modelRouter.
-function endpointKey(m) {
-  return m ? `${m?.providerID ?? ""}/${m?.id ?? ""}` : "";
-}
+// The single endpoint-identity definition, shared with the router. Accepts both
+// the RPC boundary shape ({providerID, modelID}) and the router's internal
+// catalogue shape ({providerID, id}) so the two STOP being two conventions.
+import { endpointKey } from "./endpointKey.mjs";
 
 /**
  * Does this turn cross a decision point?

--- a/src/shared/routingBoundary.test.ts
+++ b/src/shared/routingBoundary.test.ts
@@ -1,9 +1,21 @@
 import { describe, it, expect } from "vitest";
 import { BOUNDARY, crossesBoundary, shouldSwitch, boundaryPhrase } from "./routingBoundary.mjs";
+import { endpointKey } from "./endpointKey.mjs";
+// @ts-expect-error — server module has no .d.mts; toDeliverModel is the RPC
+// boundary normaliser whose OUTPUT shape is exactly what the renderer hands
+// shouldSwitch on both sides (the bug this file pins).
+import { toDeliverModel } from "../server/delegate.mjs";
 
-// A routed endpoint with a distinct (providerID/id) identity, like the router's.
-function ep(providerID: string, id: string) {
-  return { providerID, id };
+/**
+ * A routed endpoint in the shape PRODUCTION actually produces across the RPC
+ * boundary: `{providerID, modelID}` (see toDeliverModel). NOT the router's
+ * catalogue shape — building fixtures by hand in the router shape is how this
+ * file's 26 cases all passed against a function production never calls.
+ */
+function ep(providerID: string, id: string): { providerID: string; modelID: string } {
+  const out = toDeliverModel({ providerID, id });
+  if (!out) throw new Error("toDeliverModel returned null for a well-formed endpoint");
+  return out;
 }
 
 const followUp = {
@@ -244,6 +256,48 @@ describe("shouldSwitch — hysteresis", () => {
     // default topN=3: position 3 (4th, 0-based index 3) is outside → switch
     expect(
       shouldSwitch({ ...base, ranked: [...n4.slice(0, 3), ep("anthropic", "a")] }),
+    ).toEqual({ switch: true, why: "incumbent-dropped-out" });
+  });
+
+  it("THE BUG: a different model of the SAME provider as the incumbent switches", () => {
+    // Both sides arrive in the RPC deliver shape {providerID, modelID}. Before
+    // the shared endpointKey, each collapsed to "anthropic/" (its `.id` was
+    // undefined), the incumbent "matched" the first same-provider candidate,
+    // and this returned incumbent-retained — routing never switched. The shared
+    // key sees anthropic/a !== anthropic/z, so the incumbent fell out → switch.
+    const incumbent = ep("anthropic", "a");
+    const differentModelSameProvider = ep("anthropic", "z");
+    expect(
+      shouldSwitch({
+        incumbent,
+        ranked: [differentModelSameProvider],
+        incumbentStillEligible: true,
+        incumbentStillCapable: true,
+        incumbentHealthy: true,
+      }),
+    ).toEqual({ switch: true, why: "incumbent-dropped-out" });
+  });
+
+  it("an incumbent with no identity never matches another with no identity (empty-key guard)", () => {
+    // An endpoint that lost its model id has key "" — "no identity". Two such
+    // keys must never be treated as the same endpoint. Build both from the real
+    // producer, then strip the model id (toDeliverModel refuses to emit them).
+    const noModel = { ...ep("anthropic", "a") } as { providerID: string; modelID?: string };
+    delete noModel.modelID;
+    const otherNoModel = { ...ep("openai", "b") } as { providerID: string; modelID?: string };
+    delete otherNoModel.modelID;
+    expect(endpointKey(noModel)).toBe("");
+    expect(endpointKey(otherNoModel)).toBe("");
+    // incumbentIndex treats an empty incumbent key as absent → NOT the same
+    // endpoint, so the empty-ranked neighbour does not retain the incumbent.
+    expect(
+      shouldSwitch({
+        incumbent: noModel,
+        ranked: [otherNoModel],
+        incumbentStillEligible: true,
+        incumbentStillCapable: true,
+        incumbentHealthy: true,
+      }),
     ).toEqual({ switch: true, why: "incumbent-dropped-out" });
   });
 });


### PR DESCRIPTION
**Files changed:** `8` files. `src/shared/endpointKey.{mjs,d.mts,test.ts}` (new), `src/shared/routingBoundary.mjs`, `src/shared/routingBoundary.d.mts`, `src/shared/routingBoundary.test.ts`, `src/shared/modelRouter.mjs`, `src/shared/modelRouter.test.ts`.

**What & why**

One `endpointKey` identity, used everywhere. The router's internal catalogue shape uses `id`; everything crossing the RPC boundary uses `modelID` (see `toDeliverModel`). The hysteresis check in `routingBoundary` keyed on `.id` only, so on the renderer's `{providerID, modelID}` shape **every** same-provider endpoint collapsed to `"anthropic/"` — the incumbent always "matched" the first same-provider candidate and `shouldSwitch` returned `incumbent-retained` no matter the model. Routing called the box, got a winner, and threw it away.

- New `src/shared/endpointKey.mjs` accepts both `modelID` and `id` — the single definition. Returns `""` for "no identity" (an empty key never matches another empty key; the comparison site guards).
- Deleted the local copies in `routingBoundary.mjs` and `modelRouter.mjs`; both now import the shared one. Also pointed the router's `explain` reason strings and the `modelRouter.test.ts` `keyOf`/`defaultDeclared` helpers at the shared function so no second identity convention survives anywhere in `src/shared`.
- `routingBoundary.d.mts` now types both sides of `shouldSwitch` as a named `RoutedEndpoint` (`providerID` required, `modelID?`/`id?`) instead of bare `object`.
- `routingBoundary.test.ts` replaces the hand-written router-shape `ep()` fixture with one that builds the **renderer's deliver shape** via `toDeliverModel` (the real producer of that seam), and adds the case that reproduces the bug.

**This is effectively deletion + consolidation.** Net +167/−16, three identity copies down to one.

**Base: origin/main @ `23c60b9a`**

**Verification results:**
- PR branch (`multica/BET-1266-endpoint-identity` @ `98996442`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 3479 pass / 0 fail / 7 skip (vitest) + 2646 pass / 0 fail (node:test). Failures: none. log sha256: `338ed91767f62825858bddbae5ace4c380347833978b0117566883c8f1c34e49`
- Base (`main` @ `23c60b9a`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402` (identical — clean on both)
  - test: exit 0, 3470 pass / 0 fail / 7 skip (vitest) + 2646 pass / 0 fail (node:test). Failures: none. log sha256: `5285840fec8c240a57aa123369ce8970b7b3c97848538b5d4c83900c39ec8e2e`
- **Conclusion:** 0 failures on either branch. The PR adds 9 tests (new `endpointKey.test.ts` ×7, plus the same-provider + empty-key guard in `routingBoundary.test.ts` ×2).

**Acceptance criterion 3 — same-provider-different-model, fails on `main`, passes on the branch (demonstrated):**
Ran `routingBoundary.test.ts` against **main's** production code (scratch worktree with only the new test + `endpointKey` module dropped in, so the test could resolve; main's `routingBoundary.mjs` kept its buggy local key). Result: **1 failed / 28 passed** — the new case returns `{switch:false, why:"incumbent-retained"}` on main. Same file on the branch: **all pass** (`switch:true, incumbent-dropped-out`).

**Grep acceptance (criterion 2):** `grep -rn "providerID.*}/\${.*\.id" src/shared/` returns **nothing** (exit 1) anywhere in `src/shared` — including outside `endpointKey.mjs`.

**Acceptance criterion 4 (manual, live-box) — NOT performed in this run.** Criterion 4 is an on-a-real-box check: Auto on, force a boundary (compact the session) where a different model of the same provider wins, and confirm the `[router]` log line + composer chip show the model actually changed. That requires a running box with Auto + accounts and a real semantic compaction; it cannot be reproduced by the automated suite on this CI box. The `[router]` log line only landed with BET-1265 (now merged). This is the manual runtime verification a human (or a follow-up on a live box) should confirm.
