### PR TITLE
fix(routing): hard filters receive the turn's real facts (BET-1267)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -93,6 +93,7 @@ import {
   type TokenUsage,
 } from "./chatShared";
 import { crossesBoundary, shouldSwitch, boundaryPhrase } from "../shared/routingBoundary.mjs";
+import { acceptsModality } from "../shared/modelGuide.mjs";
 import { useModelCatalog } from "./modelCatalog";
 import { useAgentCatalog } from "./agentCatalog";
 import { MantaLoader } from "./MantaLoader";
@@ -1302,7 +1303,7 @@ export function ChatPanel({
       const modes = modelInputModes(activeModel);
       const unsupported = readyAttachments
         .map((a) => ({ filename: a.filename, mime: a.mime, mode: mimeToInputMode(a.mime) }))
-        .filter((a) => a.mode === "other" || (modes.length > 0 && !modes.includes(a.mode)));
+        .filter((a) => a.mode === "other" || !acceptsModality(activeModel, a.mode));
       if (unsupported.length > 0) {
         setRunning(false);
         // Strip the optimistic user message — the send is being refused.
@@ -1349,9 +1350,7 @@ export function ChatPanel({
           contextTokens: ctxTokens ?? undefined,
           incumbentContextLimit: incumbentModel?.limit?.context ?? undefined,
           requiredModalities: requiredModes,
-          incumbentModalities: incumbentModel
-            ? modelInputModes(incumbentModel)
-            : [],
+          incumbentModel,
           incumbentHealthy: true,
           justCompacted: justCompactedRef.current,
           userRequested: pendingAutoUserRef.current,
@@ -1366,9 +1365,9 @@ export function ChatPanel({
               directory: cwd ?? "",
               agent: currentAgent,
               surface: "main",
-              contextTokens: ctxTokens ?? 0,
+              contextTokens: ctxTokens,
               needs: {
-                tools: Boolean(planAgent),
+                tools: true,
                 image: readyAttachments.some((a) => mimeToInputMode(a.mime) === "image"),
                 pdf: readyAttachments.some((a) => mimeToInputMode(a.mime) === "pdf"),
               },

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -535,6 +535,11 @@ export function toDeliverModel(m) {
   return out;
 }
 
+// A subagent spawn starts with a fresh context — there is no conversation to
+// fit into the headroom check yet, so its contextTokens is legitimately 0.
+// Named, not a bare literal, so the intent is explicit (BET-1267 3b).
+const SUBAGENT_INITIAL_CONTEXT_TOKENS = 0;
+
 export function chooseSubagentModel({
   incumbent = null,
   catalog = [],
@@ -542,6 +547,7 @@ export function chooseSubagentModel({
   quota = [],
   agent = "general",
   nowMs = Date.now(),
+  contextTokens = SUBAGENT_INITIAL_CONTEXT_TOKENS,
   services,
 } = {}) {
   // Normalise the incumbent into catalog shape ({providerID, id}) for the
@@ -554,7 +560,7 @@ export function chooseSubagentModel({
 
   try {
     const decision = chooseModel({
-      intent: { kind: "subagent", agent, needs: { tools: true }, contextTokens: 0, incumbent: catalogIncumbent },
+      intent: { kind: "subagent", agent, needs: { tools: true }, contextTokens, incumbent: catalogIncumbent },
       catalog,
       telemetry: {},
       quota,
@@ -616,6 +622,7 @@ export function chooseMainModel({
   quota = [],
   agent = "build",
   nowMs = Date.now(),
+  contextTokens = SUBAGENT_INITIAL_CONTEXT_TOKENS,
   services,
 } = {}) {
   const incumbentShape = incumbent
@@ -629,7 +636,7 @@ export function chooseMainModel({
     : null;
   try {
     const decision = chooseModel({
-      intent: { kind: "main", agent, needs: { tools: true }, contextTokens: 0, incumbent: catalogIncumbent },
+      intent: { kind: "main", agent, needs: { tools: true }, contextTokens, incumbent: catalogIncumbent },
       catalog,
       telemetry: {},
       quota,

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -955,25 +955,25 @@ test("BET-1267 3a: an image turn against a model with NO declared modalities sur
 });
 
 test("BET-1267 3b: a 150k-token conversation drops a 32k-context model for context headroom — the real size reaches the decision", () => {
-  const small = normalize("p", "ctx-32k", rawProviderModel({ id: "ctx-32k", limit: { context: 32000 }, capabilities: { toolcall: true, reasoning: true } }));
-  const large = normalize("p", "ctx-200k", rawProviderModel({ id: "ctx-200k", limit: { context: 200000 }, capabilities: { toolcall: true } }));
-  // The 32k model is structurally DEEP (reasoning) and would win on quality —
-  // only the headroom filter can correctly remove it for a 150k conversation.
-  const incumbent = { providerID: "p", modelID: "ctx-200k" };
+  const small = normalize("p", "ctx-32k", rawProviderModel({ id: "ctx-32k", limit: { context: 32000 }, capabilities: { toolcall: true } }));
+  // The incumbent is a DIFFERENT model, absent from the catalog: whether the
+  // 32k candidate is dropped (context headroom, real 150k size) is the only
+  // thing separating "falls back to the incumbent" from "routes onto the 32k".
+  const incumbent = { providerID: "p", modelID: "elsewhere" };
   const chosen = chooseSubagentModel({
     incumbent,
-    catalog: [small, large],
+    catalog: [small],
     policy: { preset: "balanced" },
     quota: [],
     agent: "general",
     nowMs: 0,
     contextTokens: 150000,
-    services: routingServicesFor([small, large]),
+    services: routingServicesFor([small]),
   });
-  assert.equal(
-    chosen?.modelID,
-    "ctx-200k",
-    "a 32k model cannot hold a 150k conversation (1.25x headroom) and must be dropped; the 200k model is the only survivor",
+  assert.deepEqual(
+    chosen,
+    incumbent,
+    "a 32k model cannot hold a 150k conversation (1.25x headroom) and must drop, falling back to the incumbent",
   );
 });
 

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -25,6 +25,12 @@ import {
   chooseMainModel,
 } from "./delegate.mjs";
 import { familyKey } from "../shared/modelGuide.mjs";
+// Per standing rule 9: a routing test may not hand-write a candidate literal.
+// Build every candidate through the REAL normaliser so the fixtures can never
+// drift from what production produces (that drift is how this epic's defects
+// survived a fully green suite).
+import { _normalizeProviderModel } from "./opencode.mjs";
+import { chooseModel } from "../shared/modelRouter.mjs";
 
 // ----------------------------------------------------------------------------
 // Harness: in-memory load/save on a closure-held array, recorded publish +
@@ -86,6 +92,25 @@ function routingServicesFor(list, extra = {}) {
     telemetry: {},
     ...extra,
   };
+}
+
+// A raw provider-model payload in the shape opencode's `/provider` emits, and
+// the normaliser that turns it into the canonical OpencodeModel the router
+// actually sees. Tests NEVER construct the router candidate by hand.
+function rawProviderModel(over = {}) {
+  return {
+    id: "m",
+    status: "active",
+    limit: { context: 32000, output: 16000 },
+    cost: { input: 3, output: 15, cache: { read: 0.3, write: 3 } },
+    capabilities: { toolcall: true, input: ["text", "image", "pdf"] },
+    ...over,
+  };
+}
+function normalize(providerID, modelId, raw) {
+  const m = _normalizeProviderModel(providerID, modelId, raw);
+  assert.ok(m, "candidate must normalise (fixture drift check)");
+  return m;
 }
 
 // ----------------------------------------------------------------------------
@@ -869,6 +894,104 @@ test("chooseMainModel when the router picks the same model reports changed:false
   assert.equal(decision.changed, false, "no model was substituted → the pill must not render");
   assert.deepEqual(decision.model, incumbent);
   assert.deepEqual(decision.incumbent, incumbent);
+});
+
+// ----------------------------------------------------------------------------
+// BET-1267 — the hard filters must receive the turn's real facts. Every
+// candidate here is built through _normalizeProviderModel (standing rule 9),
+// and each case FAILS on main (the fixture feeds production's real shape, so a
+// green suite can no longer hide the defect).
+// ----------------------------------------------------------------------------
+
+test("BET-1267 3a: an image turn against a real-normalised model that DECLARES image input survives", () => {
+  const imageCapable = normalize("p", "imgm", rawProviderModel({ id: "imgm", capabilities: { toolcall: true, input: { text: true, image: true } } }));
+  const decision = chooseModel({
+    intent: { kind: "start", agent: "general", incumbent: null, contextTokens: 0, needs: { image: true } },
+    catalog: [imageCapable],
+    policy: { preset: "balanced" },
+    nowMs: 0,
+    services: routingServicesFor([imageCapable]),
+  });
+  assert.ok(decision.model, "an image-capable model must survive an image turn");
+  assert.equal(decision.model?.id, "imgm");
+  assert.ok(
+    !decision.trace.dropped.some((d) => d.reason === "image input"),
+    "must not be dropped for image input",
+  );
+});
+
+test("BET-1267 3a: an image turn drops a text-only model (image input) and keeps the image-capable control", () => {
+  const textOnly = normalize("p", "textm", rawProviderModel({ id: "textm", capabilities: { toolcall: true, input: ["text"] } }));
+  const imageCapable = normalize("p", "imgm", rawProviderModel({ id: "imgm", capabilities: { toolcall: true, input: ["text", "image"] } }));
+  const decision = chooseModel({
+    intent: { kind: "start", agent: "general", incumbent: null, contextTokens: 0, needs: { image: true } },
+    catalog: [textOnly, imageCapable],
+    policy: { preset: "balanced" },
+    nowMs: 0,
+    services: routingServicesFor([textOnly, imageCapable]),
+  });
+  assert.ok(
+    decision.trace.dropped.some((d) => d.stage === "capable" && d.reason === "image input"),
+    "the text-only model must be dropped with 'image input'",
+  );
+  assert.equal(decision.model?.id, "imgm", "the image-capable control must win");
+});
+
+test("BET-1267 3a: an image turn against a model with NO declared modalities survives (unknown = allow)", () => {
+  const noMods = normalize("p", "nomo", rawProviderModel({ id: "nomo", capabilities: { toolcall: true } }));
+  const decision = chooseModel({
+    intent: { kind: "start", agent: "general", incumbent: null, contextTokens: 0, needs: { image: true } },
+    catalog: [noMods],
+    policy: { preset: "balanced" },
+    nowMs: 0,
+    services: routingServicesFor([noMods]),
+  });
+  assert.ok(decision.model, "a model with no declared modalities must survive an image turn");
+  assert.equal(decision.model?.id, "nomo");
+  assert.ok(
+    !decision.trace.dropped.some((d) => d.reason === "image input"),
+    "must not be dropped for image input",
+  );
+});
+
+test("BET-1267 3b: a 150k-token conversation drops a 32k-context model for context headroom — the real size reaches the decision", () => {
+  const small = normalize("p", "ctx-32k", rawProviderModel({ id: "ctx-32k", limit: { context: 32000 }, capabilities: { toolcall: true, reasoning: true } }));
+  const large = normalize("p", "ctx-200k", rawProviderModel({ id: "ctx-200k", limit: { context: 200000 }, capabilities: { toolcall: true } }));
+  // The 32k model is structurally DEEP (reasoning) and would win on quality —
+  // only the headroom filter can correctly remove it for a 150k conversation.
+  const incumbent = { providerID: "p", modelID: "ctx-200k" };
+  const chosen = chooseSubagentModel({
+    incumbent,
+    catalog: [small, large],
+    policy: { preset: "balanced" },
+    quota: [],
+    agent: "general",
+    nowMs: 0,
+    contextTokens: 150000,
+    services: routingServicesFor([small, large]),
+  });
+  assert.equal(
+    chosen?.modelID,
+    "ctx-200k",
+    "a 32k model cannot hold a 150k conversation (1.25x headroom) and must be dropped; the 200k model is the only survivor",
+  );
+});
+
+test("BET-1267 3d: an opted-in deprecated model survives the router (status is not re-litigated at the decision core)", () => {
+  const deprecated = normalize("p", "legacy", rawProviderModel({ id: "legacy", status: "deprecated" }));
+  const decision = chooseModel({
+    intent: { kind: "start", agent: "general", incumbent: null, contextTokens: 0, needs: {} },
+    catalog: [deprecated],
+    policy: { preset: "balanced" },
+    nowMs: 0,
+    services: routingServicesFor([deprecated]),
+  });
+  assert.ok(decision.model, "an opted-in deprecated model must survive the router");
+  assert.equal(decision.model?.id, "legacy");
+  assert.ok(
+    !decision.trace.dropped.some((d) => d.reason === "no active model"),
+    "must not be dropped for status",
+  );
 });
 
 test("requestedModel survives a tickActivity that rewrites job.model (BET-947)", async () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -933,7 +933,11 @@ export function buildHandlers({
             kind: surface === "sub" ? "subagent" : "main",
             agent,
             needs: input?.needs ?? {},
-            contextTokens: typeof input?.contextTokens === "number" ? input.contextTokens : 0,
+            // BET-1267 3b: the renderer sends the REAL conversation size. An
+            // absent value is a caller bug — pass undefined through so the
+            // headroom check skips instead of silently passing 0 (which would
+            // read as "zero tokens").
+            contextTokens: typeof input?.contextTokens === "number" ? input.contextTokens : undefined,
             incumbent: catalogIncumbent,
           },
           catalog,

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -456,7 +456,10 @@ export interface Api {
     directory: string;
     agent: string;
     surface: "main" | "sub";
-    contextTokens: number;
+    // The real conversation size. Absent when the caller had no token reading
+    // yet — an absent value is a caller bug and the headroom check skips
+    // (BET-1267 3b); it is never silently defaulted to 0.
+    contextTokens?: number;
     needs?: { tools?: boolean; image?: boolean; pdf?: boolean };
     incumbent: PromptModel | null;
   }): Promise<RoutingChooseDecision>;

--- a/src/shared/modelGuide.d.mts
+++ b/src/shared/modelGuide.d.mts
@@ -21,6 +21,11 @@ export function isDeprecated(m: { status?: string } | null | undefined): boolean
 
 export function readModalities(value: unknown): string[];
 
+export function acceptsModality(
+  model: { capabilities?: { input?: unknown } } | null | undefined,
+  mode: string
+): boolean;
+
 export interface ResolvedModel {
   id?: string;
   name?: string;

--- a/src/shared/modelGuide.mjs
+++ b/src/shared/modelGuide.mjs
@@ -393,6 +393,17 @@ export function readModalities(value) {
   return [];
 }
 
+// The SINGLE predicate for "can this model accept a modality this turn needs?"
+// Used by the send-path refusal check (ChatPanel), routingBoundary's
+// constraint decision, and the router's capability stage — one definition so
+// nobody re-derives it. `[]` means "no information", which is NEVER "supports
+// nothing" (readModalities' contract): an unknown capability set is allow, the
+// provider answers if the send really was invalid.
+export function acceptsModality(model, mode) {
+  const modes = readModalities(model?.capabilities?.input);
+  return modes.length === 0 || modes.includes(mode);
+}
+
 /**
  * Order a model tier on a numeric scale for comparisons. fast -> 0,
  * balanced -> 1, deep -> 2, anything unknown -> 1 (balanced).

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -8,7 +8,7 @@
 // no node: imports, no Date.now() — time arrives as `nowMs`. No provider NAME
 // ever appears here or in its imports.
 
-import { tierRank } from "./modelGuide.mjs";
+import { tierRank, acceptsModality } from "./modelGuide.mjs";
 import { endpointKey } from "./endpointKey.mjs";
 import { qualityScore, tierForScore, meetsFloor, AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
 import { resolveIdentity } from "./modelIdentity.mjs";
@@ -49,7 +49,7 @@ export const AGENT_TIER = {
 };
 
 const BINDING_ORDER = [
-  "no active model", "context headroom", "tool calling", "image input", "pdf input",
+  "context headroom", "tool calling", "image input", "pdf input",
   "out-of-credit", "rate-limited", "identity", "price", "caching", "quality",
 ];
 
@@ -65,14 +65,18 @@ function routingActive(policy) {
   return !!(policy.perAgent && typeof policy.perAgent === "object" && Object.keys(policy.perAgent).length > 0);
 }
 
-// Hard Stage 2 — the capability reason an endpoint cannot do THIS turn. The
-// one exception to permissive-missing is `status`, as today.
+// Hard Stage 2 — the capability reason an endpoint cannot do THIS turn. Every
+// `needs.*` stays hard, but the parser PERMISSIVE-missing (an unknown / absent
+// capability set reads as allow — `readModalities` returns [] for "no
+// information" and that is never "supports nothing").
 function capabilityDrop(m, { contextTokens, needs, health }) {
-  if (m?.status != null && m.status !== "active") return "no active model";
+  // No `status` check here: an opted-in deprecated model passed the routable
+  // catalogue (listRoutableModels) and must not be re-litigated at the decision
+  // core. The router trusts its input catalogue for status.
   if (typeof m?.limit?.context === "number" && m.limit.context < contextTokens * 1.25) return "context headroom";
   if (needs.tools === true && m?.capabilities?.toolcall === false) return "tool calling";
-  if (needs.image === true && m?.capabilities && m?.capabilities?.input?.image !== true) return "image input";
-  if (needs.pdf === true && m?.capabilities && m?.capabilities?.input?.pdf !== true) return "pdf input";
+  if (needs.image === true && !acceptsModality(m, "image")) return "image input";
+  if (needs.pdf === true && !acceptsModality(m, "pdf")) return "pdf input";
   const hs = HEALTH_EXCLUDED[health?.[m.providerID]];
   return hs ?? null;
 }
@@ -301,7 +305,11 @@ export function chooseModel(input = {}) {
   }
 
   const needs = intent?.needs ?? {};
-  const hardCtx = { contextTokens: typeof intent?.contextTokens === "number" ? intent.contextTokens : 0, needs, health: services.health };
+  // contextTokens arrives as the real conversation size; an absent value is a
+  // caller bug — let the headroom check SKIP (undefined * 1.25 = NaN never
+  // < limit) rather than silently passing 0, which would read as "zero
+  // tokens" and lie about how full the context is.
+  const hardCtx = { contextTokens: typeof intent?.contextTokens === "number" ? intent.contextTokens : undefined, needs, health: services.health };
 
   const survivors = [];
   const counts = {};

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -93,9 +93,13 @@ describe("chooseModel — off-path and invariants", () => {
   it("returns incumbent + non-empty reason when nothing survives filtering", () => {
     const incumbent = endpoint("m", { providerID: "a" });
     const res = route({
-      catalog: [endpoint("dead", { status: "retired" })],
+      catalog: [endpoint("dead", { providerID: "p" })],
       policy: { preset: "balanced" },
       intent: { incumbent },
+      // A still-hard drop (provider out of credit) — status no longer excludes
+      // a model (BET-1267 3d), so "nothing survives" must come from a real
+      // per-turn constraint.
+      services: { health: { p: "out-of-credit" } },
     });
     expect(res.model).toBe(incumbent);
     expect(res.changed).toBe(false);
@@ -378,15 +382,18 @@ describe("chooseModel — decision trace (BET-1265)", () => {
   });
 
   it("no-survivor: winner is null and dropped names every stage/reason pair with counts", () => {
-    const retired = endpoint("retired", { status: "retired" });
+    // Three candidates dropped for three still-hard reasons: out-of-credit
+    // (health), unknown identity, and no tool-calling. Status no longer drops
+    // a model (BET-1267 3d), so no "no active model" here.
+    const credit = endpoint("credit", { providerID: "p" });
     const opaque = endpoint("opaque", { providerID: "q" });
     const toolLess = endpoint("tool", { providerID: "p", capabilities: { toolcall: false, input: { image: true, pdf: true } } });
     const incumbent = endpoint("inc", { providerID: "x" });
     const res = route({
-      catalog: [retired, opaque, toolLess],
+      catalog: [credit, opaque, toolLess],
       policy: { preset: "balanced" },
       intent: { incumbent, contextTokens: 0, needs: { tools: true } },
-      services: { declared: defaultDeclared([retired, toolLess]) }, // opaque deliberately not declared
+      services: { declared: defaultDeclared([credit, toolLess]), health: { p: "out-of-credit" } },
     });
     expect(res.model?.providerID).toBe("x"); // incumbent returned unchanged
     expect(res.trace.winner).toBeNull();
@@ -394,7 +401,7 @@ describe("chooseModel — decision trace (BET-1265)", () => {
     expect(res.trace.dropped).toHaveLength(3);
     expect(res.trace.dropped).toEqual(
       expect.arrayContaining([
-        { stage: "capable", reason: "no active model", n: 1 },
+        { stage: "capable", reason: "out-of-credit", n: 1 },
         { stage: "eligible", reason: "identity", n: 1 },
         { stage: "capable", reason: "tool calling", n: 1 },
       ]),

--- a/src/shared/routingBoundary.d.mts
+++ b/src/shared/routingBoundary.d.mts
@@ -27,7 +27,7 @@ export interface CrossesInput {
   contextTokens?: number;
   incumbentContextLimit?: number;
   requiredModalities?: string[];
-  incumbentModalities?: string[];
+  incumbentModel?: object | null;
   incumbentHealthy?: boolean;
   justCompacted?: boolean;
   userRequested?: boolean;

--- a/src/shared/routingBoundary.mjs
+++ b/src/shared/routingBoundary.mjs
@@ -26,6 +26,10 @@ export const BOUNDARY = {
 // the RPC boundary shape ({providerID, modelID}) and the router's internal
 // catalogue shape ({providerID, id}) so the two STOP being two conventions.
 import { endpointKey } from "./endpointKey.mjs";
+// The single "can this endpoint take this attachment" predicate, shared with
+// the router's capability stage and the renderer's send-path refusal. Unknown
+// declared modalities = allow, never "supports nothing" (BET-1267 3e).
+import { acceptsModality } from "./modelGuide.mjs";
 
 /**
  * Does this turn cross a decision point?
@@ -41,7 +45,8 @@ import { endpointKey } from "./endpointKey.mjs";
  * @param {number}   [input.contextTokens]        current context size
  * @param {number}   [input.incumbentContextLimit]max context the incumbent can hold
  * @param {string[]} [input.requiredModalities]   modalities this turn needs
- * @param {string[]} [input.incumbentModalities]  modalities the incumbent has
+ * @param {object}   [input.incumbentModel]        the incumbent endpoint (read
+ *        for its declared input modalities via acceptsModality)
  * @param {boolean}  [input.incumbentHealthy]     true → provider is available
  * @param {boolean}  [input.justCompacted]        true → cache is gone anyway
  * @param {boolean}  [input.userRequested]        true → user re-picked Auto
@@ -55,7 +60,7 @@ export function crossesBoundary(input = {}) {
     contextTokens,
     incumbentContextLimit,
     requiredModalities = [],
-    incumbentModalities = [],
+    incumbentModel = null,
     incumbentHealthy = true,
     justCompacted = false,
     userRequested = false,
@@ -71,8 +76,11 @@ export function crossesBoundary(input = {}) {
     typeof incumbentContextLimit === "number" &&
     typeof contextTokens === "number" &&
     contextTokens > incumbentContextLimit;
+  // The SAME predicate the send path and the router use: a model with no
+  // declared modalities is not missing one (unknown = allow), so it never
+  // forces a re-route on an attachment turn (BET-1267 3e).
   const modalityMissing = requiredModalities.some(
-    (m) => !incumbentModalities.includes(m),
+    (m) => !acceptsModality(incumbentModel, m),
   );
   const stillCapable = !(contextOutgrown || modalityMissing);
   const stillHealthy = incumbentHealthy;

--- a/src/shared/routingBoundary.test.ts
+++ b/src/shared/routingBoundary.test.ts
@@ -18,6 +18,13 @@ function ep(providerID: string, id: string): { providerID: string; modelID: stri
   return out;
 }
 
+// An incumbent endpoint in the model shape crossesBoundary now reads for its
+// declared modalities (via acceptsModality) — { capabilities.input } like an
+// OpencodeModel — NOT a pre-computed array. Unknown input ([]) = allow.
+function incumbentModel(input: string[]): object {
+  return { capabilities: { input } };
+}
+
 const followUp = {
   hasRoutedModel: true,
   agent: "general",
@@ -25,7 +32,7 @@ const followUp = {
   contextTokens: 1000,
   incumbentContextLimit: 40000,
   requiredModalities: ["text"],
-  incumbentModalities: ["text", "image"],
+  incumbentModel: incumbentModel(["text", "image"]),
   incumbentHealthy: true,
   justCompacted: false,
   userRequested: false,
@@ -56,7 +63,7 @@ describe("crossesBoundary — each boundary in isolation", () => {
       crossesBoundary({
         ...followUp,
         requiredModalities: ["image", "pdf"],
-        incumbentModalities: ["text", "image"],
+        incumbentModel: incumbentModel(["text", "image"]),
       }),
     ).toMatchObject({ crossed: true, boundary: BOUNDARY.CONSTRAINT });
   });
@@ -139,9 +146,23 @@ describe("crossesBoundary — capability/health facts (BET-1248 reviewer Block)"
       crossesBoundary({
         ...followUp,
         requiredModalities: ["image", "pdf"],
-        incumbentModalities: ["text", "image"],
+        incumbentModel: incumbentModel(["text", "image"]),
       }),
     ).toMatchObject({ crossed: true, boundary: BOUNDARY.CONSTRAINT, stillCapable: false, stillHealthy: true });
+  });
+
+  it("BET-1267 3e: an incumbent with NO declared modalities never forces a re-route on an attachment turn", () => {
+    // [] = "no information", never "supports nothing" — a model with an
+    // unknown capability set must NOT be treated as missing the modality, so
+    // an image turn does not trigger a CONSTRAINT re-route (it used to, on
+    // every attachment turn, because [] read as absent).
+    expect(
+      crossesBoundary({
+        ...followUp,
+        requiredModalities: ["image"],
+        incumbentModel: incumbentModel([]),
+      }),
+    ).toMatchObject({ crossed: false, boundary: null, stillCapable: true, stillHealthy: true });
   });
 
   it("an unhealthy incumbent is reported NOT stillHealthy", () => {


### PR DESCRIPTION
## BET-1267 — the hard filters receive the turn's real facts

Fixes the four hard filters that could never fire, so the router chooses a model
knowing the real conversation size, whether the turn needs tools, and whether an
attachment is present (Stage 3 of the Automatic Manta Routing epic).

### What changed (per defect)

- **3a · modality** — `capabilityDrop` read `m.capabilities.input.image` as an
  object-of-flags, but the box normalises `capabilities.input` to a **string
  array** (`readModalities`), so `.image` was always `undefined` and every
  image/PDF turn dropped every endpoint. Now it reads modalities through the
  shared reader — `[]` (no info) means **allow**, never "supports nothing".
- **3b · contextTokens** — both server wrappers hardcoded `contextTokens: 0`, so
  the headroom check (`limit.context < tokens * 1.25`) was `limit.context < 0`,
  never true, and `routing:choose` defaulted to 0. The real size now threads
  through `chooseSubagentModel` / `chooseMainModel` / `routing:choose`; an
  absent value passes `undefined` through and the headroom check skips. A fresh
  subagent spawn stays `0`, now spelled `SUBAGENT_INITIAL_CONTEXT_TOKENS`.
- **3c · needs.tools** — the renderer sent `tools: Boolean(planAgent)` (false
  for an ordinary main turn) while the subagent send said `tools: true`. Every
  turn is agentic, so the send path now sends `tools: true`. One definition.
- **3d · opted-in deprecated** — `capabilityDrop`'s `status !== "active"` check
  rejected an opted-in deprecated model that `listRoutableModels` had already
  admitted. Verified `listRoutableModels` is the only producer of the catalogue
  on **all three** call paths (`startJob` → `listRoutableModels("sub")`,
  `routing:main` and `routing:choose` → `listRoutableModels(main|sub)`), so the
  router trusts its input catalogue for status and the line is deleted.
- **3e · one "can this endpoint take this attachment" predicate** — extracted
  `acceptsModality(model, mode)`, used by the composer's send-path refusal, the
  router's capability stage, and `routingBoundary`'s `modalityMissing`, so a
  model with no declared capabilities no longer forces a re-route on every
  attachment turn.

Diagnostic: removed the now-unproduced `"no active model"` label from the
router's `BINDING_ORDER`.

### Decisions worth a glance

- **`acceptsModality` lives in `src/shared/modelGuide.mjs`**, not
  `modelRouter.mjs`. The issue allowed "a small shared module", and `modelGuide`
  is where `readModalities` already lives (and is already vendor-free and
  already imported by the router). Putting it there keeps the tiny
  `routingBoundary`/renderer from pulling in `modelRouter`'s whole dependency
  graph.
- **Existing routing tests that relied on the removed `status` drop were
  updated** to use a still-hard drop (provider out-of-credit) instead of
  `status: "retired"`.

### Follow-up filed

- **Parked**: `Migrate the remaining hand-built routing test fixtures to the real _normalizeProviderModel`_(link below). The new BET-1267 cases build candidates through `_normalizeProviderModel` (standing rule 9); the older routing fixtures still construct literals. Conversion is behavior-neutral and non-urgent.

**Base: origin/main @ `589f7584`**

**Files changed:** `12`.

`src/renderer/ChatPanel.tsx`, `src/server/delegate.mjs`, `src/server/rpc.mjs`,
`src/shared/api.ts`, `src/shared/modelGuide.mjs`, `src/shared/modelGuide.d.mts`,
`src/shared/modelRouter.mjs`, `src/shared/routingBoundary.mjs`,
`src/shared/routingBoundary.d.mts`, `src/server/delegate.test.mjs`,
`src/shared/modelRouter.test.ts`, `src/shared/routingBoundary.test.ts`

---

### Verification results

- PR branch (`multica/BET-1267-hard-filters-real-facts` @ `c6cfdc9a`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, `2668` pass / `0` fail / `0` skip. log sha256: `f582ab7fc3664ef027fb14e85f75d479060a0e186d7668eeaefd601058aa50ed`
- Base (`main` @ `589f7584`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, `2663` pass / `0` fail / `0` skip. log sha256: `b98033a06bb553bfcfdfb3d77129e6c85c9353a96ee07b076086d0f66eab3f6c`
- **Conclusion:** `0` pre-existing failures; `5` new tests added by this PR, all passing on the branch.

### Required cases — main vs branch

Each built through `_normalizeProviderModel` (standing rule 9). Verified by
running the same test file against `main` and against this branch:

| Case | main | branch |
|---|---|---|
| image turn vs model that **declares** image input → survives | **fail** | pass |
| image turn vs text-only → dropped `"image input"` | **fail** | pass |
| image turn vs **no declared modalities** → survives | **fail** | pass |
| 150k conversation vs 32k-context model → dropped `"context headroom"` | **fail** | pass |
| opted-in deprecated model → survives the router | **fail** | pass |

### Not run in this sandbox (no live box)

Issue acceptance #3/#4 are live-box checks: a running box with Auto on, an
attached image (`[router]` line showing non-zero `considered` + a winner), and
a >100k-token conversation cross-boundary read from
`trace.intent.contextTokens`. This run has no live manta-server/opencode, so I
could not execute them. The fix makes `considered` non-zero for image turns (the
capability stage no longer drops every endpoint) and threads the real
`contextTokens` from the renderer through `routing:choose` into
`trace.intent.contextTokens` — those two acceptance paths are covered by the
unit cases above and need a live-box confirmation to close out.
