### PR TITLE
feat(renderer): box-backed per-session model prefs, drop localStorage copy (BET-1281)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -20,9 +20,9 @@ import {
   type ModelSelection,
   readSavedMode,
   writeSavedMode,
-  writeSavedModel,
   resolveLauncherFlags,
 } from "./chatShared";
+import { setSessionChoice } from "./modelPrefs";
 import type { SyncPayload } from "../shared/api";
 import { chooseUpdateSkewVariant, isTransientUpdateNetworkError, isUnknownChannelError, pruneVisitedSessions, registerMountedTerminal, shouldResyncWindowsForJobs, dispatchAppControl, dispatchMedia, applyMediaEvent, formatResetAt, voiceUi, boxUpgradeLanded, type AppControlHandlers, type MountedTerminal } from "./chatUtils";
 import { useCompatibilityCard } from "./hooks/useCompatibilityCard";
@@ -1170,8 +1170,11 @@ function Shell() {
         switchModel: ({ sessionId, providerID, modelID }) => {
           const sel: ModelSelection = { providerID, modelID };
           const apply = panelModelControl.current.get(sessionId);
+          // With a panel mounted, drive its override through selectModel (the
+          // picker path); with none, route through the shared box-backed setter
+          // (BET-1281) so the write still lands — the panel reads it on mount.
           if (apply) apply(sel);
-          else writeSavedModel(sessionId, sel);
+          else setSessionChoice(sessionId, { kind: "model", model: sel });
         },
         renameSession: () => {
           // tmux is the source of truth; the existing refresh re-reads it.

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -15,7 +15,7 @@ import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
 import { useStore } from "./store";
 import { refreshModelCatalog } from "./modelCatalog";
 import type { Attachment } from "./chatShared";
-import { writeSavedChoice } from "./chatShared";
+import { sessionAutoKey } from "./modelPrefs";
 import {
   installMockApi,
   resetStore,
@@ -781,10 +781,11 @@ describe("ChatPanel composer submit", () => {
    beforeEach(() => {
      // jsdom localStorage is shared across tests in this file, and the suite
      // mounts the same ses_test session every time. Reset the per-session model
-     // choice to server-default so a prior test's "auto" write can't leak into
-     // a later non-Auto test (and vice versa). BET-1255 relies on this to
-     // switch cleanly between Auto and non-Auto sessions.
-     writeSavedChoice("ses_test", { kind: "server-default" });
+     // choice to server-default by clearing the device-local Auto flag (the box
+     // mirror's `modelPrefsGet` returns empty in the harness) so a prior test's
+     // "auto" write can't leak into a later non-Auto test (and vice versa).
+     // BET-1255 relies on this to switch cleanly between Auto and non-Auto.
+     localStorage.removeItem(sessionAutoKey("ses_test"));
    });
 
   function typeInto(el: HTMLTextAreaElement, value: string) {
@@ -867,7 +868,7 @@ describe("ChatPanel composer submit", () => {
   });
 
   it("makes no opencodeModelRoute mount call for an Auto session (BET-1255)", async () => {
-    writeSavedChoice("ses_test", { kind: "auto" });
+    localStorage.setItem(sessionAutoKey("ses_test"), "1");
     ({ api } = installMockApi({
       opencodeModelRoute: () =>
         Promise.resolve({
@@ -887,7 +888,7 @@ describe("ChatPanel composer submit", () => {
   });
 
   it("still routes an Auto session's first turn via the boundary router (BET-1255)", async () => {
-    writeSavedChoice("ses_test", { kind: "auto" });
+    localStorage.setItem(sessionAutoKey("ses_test"), "1");
     const routedModel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
     ({ api } = installMockApi({
       opencodePrompt: () => Promise.resolve({ ok: true }),

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -69,16 +69,10 @@ import { isPlanAgent, planPageUrl } from "../shared/planMode.mjs";
 import { serverBase } from "./api/httpApi";
 import {
   appendPromptHistory,
-  carrySavedChoice,
   guessMime,
   mimeToInputMode,
   modelInputModes,
-  modelKey,
   modelSupportsAttachments,
-  readSavedChoice,
-  readSavedModel,
-  writeSavedModel,
-  writeSavedChoice,
   modelFromChoice,
   readPlanSaved,
   writePlanSaved,
@@ -95,6 +89,12 @@ import {
 import { crossesBoundary, shouldSwitch, boundaryPhrase } from "../shared/routingBoundary.mjs";
 import { acceptsModality } from "../shared/modelGuide.mjs";
 import { useModelCatalog } from "./modelCatalog";
+import {
+  readSessionAuto,
+  sessionBoxSelection,
+  setSessionChoice,
+  useSessionModelChoice,
+} from "./modelPrefs";
 import { useAgentCatalog } from "./agentCatalog";
 import { MantaLoader } from "./MantaLoader";
 import { MeasureColumn } from "./MeasureColumn";
@@ -427,24 +427,26 @@ export function ChatPanel({
 
   // ===== Per-session model override =====
   // Declared before useSseBus: the auth-banner providerID below derives from
-  // it. Initialized from the per-session localStorage override for the session,
-  // falling back to the persisted global default (the same seed useSseBus's
-  // providerID used to recompute from readSavedModel on every render).
+  // it. Seeded from the box-backed per-session choice (modelPrefs.ts, BET-1281),
+  // falling back to the persisted global default.
   // BET-1247: whether the session's model choice is Auto (the three-state
   // choice from BET-1245). Under Auto the override seeds to null rather than
   // the server default — the default is not "the model Auto chose", and the
   // chip must read "Auto" until the router actually resolves one (a turn
   // running applies the routed pick to `modelOverride`).
+  // BET-1281: the box-backed per-session choice (the model-prefs box store +
+  // the device-local Auto flag). Single source for every seed below.
+  const sessionChoice = useSessionModelChoice(sessionId);
   const [autoActive, setAutoActive] = useState<boolean>(
-    () => readSavedChoice(sessionId).kind === "auto",
+    () => sessionChoice.kind === "auto",
   );
-  // BET-1248: the override seed derives from the THREE-state choice
-  // (readSavedChoice, BET-1245) so the rest of the component is untouched:
-  // {kind:"model"} → the model, {kind:"server-default"} → the global default,
-  // {kind:"auto"} → null until the router resolves one. The routed pick is
-  // applied to the override the moment a turn runs (BET-1247).
+  // BET-1248: the override seed derives from the THREE-state choice so the
+  // rest of the component is untouched: {kind:"model"} → the model,
+  // {kind:"server-default"} → the global default, {kind:"auto"} → null until
+  // the router resolves one. The routed pick is applied to the override the
+  // moment a turn runs (BET-1247).
   const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
-    modelFromChoice(readSavedChoice(sessionId), configDefaultModel),
+    modelFromChoice(sessionChoice, configDefaultModel),
   );
   // BET-1222: routed state for the composer pill — set when the router chose
   // this session's model (fed by the main-conversation routing wiring). The
@@ -496,6 +498,18 @@ export function ChatPanel({
     }
     priorAutoRef.current = autoActive;
   }, [autoActive]);
+  // BET-1281: keep the panel's local override + Auto flag in sync with the
+  // box-backed choice. Runs on mount and whenever the choice changes — e.g. the
+  // box mirror first loads, an `model-prefs.updated` refetch lands (including a
+  // refetch of this client's own write, a harmless reseed of the same value), or
+  // /clear swaps the session id. `sessionChoice` is memoized, so this does not
+  // re-run on keystroke renders.
+  useEffect(() => {
+    setAutoActive(sessionChoice.kind === "auto");
+    setModelOverride(modelFromChoice(sessionChoice, configDefaultModel));
+    priorAutoRef.current = sessionChoice.kind === "auto";
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [sessionChoice, configDefaultModel]);
   // Active-model providerID for the auth-error banner (BET-316). Per-session
   // override wins over the persisted default; null if neither is set. Memoized
   // on `modelOverride` (the in-memory selection, itself seeded from
@@ -525,9 +539,9 @@ export function ChatPanel({
     // co-existence of its undo pill with the Auto-row reason). The gate reads
     // the same session key the effect already reads, so the [sessionId]
     // dependency stays correct on session change.
-    if (readSavedChoice(sessionId).kind === "auto") return;
+    if (readSessionAuto(sessionId)) return;
     let cancelled = false;
-    const incumbent = readSavedModel(sessionId) ?? configDefaultModel ?? null;
+    const incumbent = sessionBoxSelection(sessionId) ?? configDefaultModel ?? null;
     window.api
       .opencodeModelRoute(incumbent, "build")
       .then((d) => {
@@ -733,16 +747,12 @@ export function ChatPanel({
     setError(null);
     const planOnStart = readPlanSaved(sessionId);
     setPlanOn(planOnStart);
-    const choiceNow = readSavedChoice(sessionId);
-    setAutoActive(choiceNow.kind === "auto");
-    setModelOverride(modelFromChoice(choiceNow, configDefaultModel));
     // BET-1248: routed state is per-session — reset on session change (and on
     // /clear, which swaps the session id), exactly like stepTokens / liveTodos.
     setRoutedModel(null);
     setRoutedReason(null);
     routedModelRef.current = null;
     pendingAutoUserRef.current = false;
-    priorAutoRef.current = choiceNow.kind === "auto";
     // Seed plan mode from the session's own `agent` field when present (BET-949
     // §5): a session pre-set to plan OUTSIDE MantaUI would otherwise show the
     // chip off and send the next prompt as build — the stored key alone can't
@@ -1331,7 +1341,7 @@ export function ChatPanel({
     // server default) and sends.
     let sendModel = modelOverride;
     if (autoActive && text) {
-      if (readSavedChoice(sessionId).kind === "auto") {
+      if (readSessionAuto(sessionId)) {
         const incumbent = routedModelRef.current;
         const incumbentModel = incumbent
           ? resolveActiveModel(models, incumbent, null)
@@ -1684,30 +1694,21 @@ export function ChatPanel({
   // If the saved model references one that isn't in the current list of
   // connected models (common after switching providers or fixing listModels'
   // source endpoint), clear it. Otherwise the server rejects the prompt with a
-  // not-found error and nothing reaches the transcript.
+  // not-found error and nothing reaches the transcript. Reads the BOX-backed
+  // selection (BET-1281); re-runs when models or the session choice change.
   useEffect(() => {
     if (!models) return;
-    let saved: ModelSelection | null = null;
-    try {
-      const raw = localStorage.getItem(modelKey(sessionId));
-      if (raw) {
-        const p = JSON.parse(raw);
-        if (p && typeof p.providerID === "string" && typeof p.modelID === "string") {
-          saved = p as ModelSelection;
-        }
-      }
-    } catch { /* non-JSON / disabled storage — nothing to heal */ }
-    if (!saved) return;
-    const sel = saved;
+    const sel = sessionBoxSelection(sessionId);
+    if (!sel) return;
     if (models.some((m) => m.providerID === sel.providerID && m.id === sel.modelID)) return;
-    writeSavedModel(sessionId, null);
+    setSessionChoice(sessionId, { kind: "server-default" });
     setModelOverride(null);
-  }, [models, sessionId]);
+  }, [models, sessionId, sessionChoice]);
 
   const selectModel = useCallback(
     (m: ModelSelection | null) => {
       setModelOverride(m);
-      writeSavedModel(sessionId, m);
+      setSessionChoice(sessionId, m ? { kind: "model", model: m } : { kind: "server-default" });
       // A manual model choice ends any routed state: once the user picks the
       // model themselves, the pill must not claim the router chose it (BET-1225).
       setRouted(null);
@@ -1720,7 +1721,7 @@ export function ChatPanel({
   // it re-decides at once (crossesBoundary USER). Clears the override so the
   // pill reads "Auto · chooses when the turn starts" until routing resolves.
   const onSelectAuto = useCallback(() => {
-    writeSavedChoice(sessionId, { kind: "auto" });
+    setSessionChoice(sessionId, { kind: "auto" });
     setAutoActive(true);
     setModelOverride(null);
     setRouted(null);
@@ -1728,7 +1729,7 @@ export function ChatPanel({
   }, [sessionId]);
 
   // BET-1222: undo a routed model choice. Reverts through the SAME per-session
-  // override path the manual picker uses (selectModel + writeSavedModel) — no
+  // override path the manual picker uses (selectModel) — no
   // second persistence path — then clears the routed state so the pill reverts.
   // Awaited: a failure surfaces on the existing sendError banner rather than
   // being swallowed.
@@ -1747,7 +1748,7 @@ export function ChatPanel({
 
   // App-control (BET-840/841): expose this panel's `selectModel` to App so the
   // box's `switch-model` app-control event drives the override through the same
-  // path the picker uses (setModelOverride + writeSavedModel). Re-registers on
+  // path the picker uses (setModelOverride + setSessionChoice). Re-registers on
   // session change; unregisters on unmount so a closed panel can't be reached.
   useEffect(() => {
     registerModelControl?.(sessionId, selectModel);
@@ -1814,7 +1815,7 @@ export function ChatPanel({
       // /clear carries the session's model choice forward so the user doesn't
       // re-pick after every clear (including Auto); plan mode state on top.
       if (cleared?.newSessionId) {
-        carrySavedChoice(sessionId, cleared.newSessionId);
+        setSessionChoice(cleared.newSessionId, sessionChoice);
         if (planOn) {
           writePlanSaved(cleared.newSessionId, true);
         }
@@ -1823,7 +1824,7 @@ export function ChatPanel({
     } catch (e) {
       setSendError(String((e as Error)?.message ?? e));
     }
-  }, [tmuxSession, windowIndex, cwd, planOn, refresh]);
+  }, [tmuxSession, windowIndex, cwd, planOn, refresh, sessionChoice]);
 
   // Current-value ref mirrors for `submit` — declared AFTER submit in this file
   // (the established commandsRef pattern), so submit reads these instead of

--- a/src/renderer/chatShared.test.ts
+++ b/src/renderer/chatShared.test.ts
@@ -16,11 +16,6 @@ import {
   findLast,
   readSavedMode,
   writeSavedMode,
-  readSavedModel,
-  writeSavedModel,
-  readSavedChoice,
-  writeSavedChoice,
-  carrySavedChoice,
   modelFromChoice,
   resolveLauncherFlags,
   readPromptHistory,
@@ -30,6 +25,12 @@ import {
   readSavedActiveSession,
   writeSavedActiveSession,
 } from "./chatShared";
+import {
+  parseOldModelPrefs,
+  collectOldModelPrefs,
+  resolveSessionChoice,
+  sessionSelectionFromRecord,
+} from "./modelPrefs";
 import type { OpencodeModel } from "../shared/types";
 
 // Minimal OpencodeModel factory — only the `capabilities` field matters for
@@ -268,90 +269,107 @@ describe("readSavedMode / writeSavedMode (BET-138)", () => {
    });
  });
 
-describe("readSavedModel / writeSavedModel", () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-  const sel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
-
-  it("writes then reads back the same selection", () => {
-    writeSavedModel("sess-1", sel);
-    expect(readSavedModel("sess-1")).toEqual(sel);
+describe("sessionSelectionFromRecord (BET-1281) — box record → ModelSelection", () => {
+  it("maps a full record (with variant) to a ModelSelection", () => {
+    expect(
+      sessionSelectionFromRecord({ providerID: "anthropic", modelID: "claude-sonnet-4-6", variant: "high", updatedAt: 1 }),
+    ).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4-6", variant: "high" });
   });
 
-  it("writeSavedModel(sid, null) clears it; read returns null", () => {
-    writeSavedModel("sess-1", sel);
-    writeSavedModel("sess-1", null);
-    expect(readSavedModel("sess-1")).toBeNull();
-    expect(localStorage.getItem("manta:chat:sess-1:model")).toBeNull();
+  it("omits variant when absent", () => {
+    expect(
+      sessionSelectionFromRecord({ providerID: "anthropic", modelID: "claude-sonnet-4-6", updatedAt: 1 }),
+    ).toEqual({ providerID: "anthropic", modelID: "claude-sonnet-4-6" });
   });
 
-  it("unset session reads null", () => {
-    expect(readSavedModel("sess-1")).toBeNull();
-  });
-
-  it("a session's model is isolated from another session id", () => {
-    writeSavedModel("sess-1", sel);
-    expect(readSavedModel("sess-2")).toBeNull();
-  });
-
-  it("malformed (non-JSON) stored value reads null and does not throw", () => {
-    localStorage.setItem("manta:chat:sess-1:model", "{not json");
-    expect(() => readSavedModel("sess-1")).not.toThrow();
-    expect(readSavedModel("sess-1")).toBeNull();
+  it("returns null for a missing or malformed record", () => {
+    expect(sessionSelectionFromRecord(undefined)).toBeNull();
+    expect(sessionSelectionFromRecord({ providerID: "", modelID: "x", updatedAt: 1 })).toBeNull();
+    expect(sessionSelectionFromRecord({ providerID: "x", modelID: "", updatedAt: 1 })).toBeNull();
   });
 });
 
-describe("readSavedChoice / writeSavedChoice (three-state, BET-1245)", () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-  const sel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+describe("resolveSessionChoice (BET-1281) — box sessions + Auto flag → three-state choice", () => {
+  const sessions = {
+    s1: { providerID: "anthropic", modelID: "claude-sonnet-4-6", updatedAt: 1 },
+  };
 
-  it("round-trips the auto state", () => {
-    writeSavedChoice("sess-1", { kind: "auto" });
-    expect(readSavedChoice("sess-1")).toEqual({ kind: "auto" });
+  it("Auto flag wins → { kind: 'auto' } even with a box record present", () => {
+    expect(resolveSessionChoice(sessions, "s1", true)).toEqual({ kind: "auto" });
   });
 
-  it("round-trips an explicit model", () => {
-    writeSavedChoice("sess-1", { kind: "model", model: sel });
-    expect(readSavedChoice("sess-1")).toEqual({ kind: "model", model: sel });
+  it("a present + valid record → { kind: 'model' }", () => {
+    expect(resolveSessionChoice(sessions, "s1", false)).toEqual({
+      kind: "model",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    });
   });
 
-  it("round-trips the server-default state (key absent)", () => {
-    writeSavedChoice("sess-1", { kind: "server-default" });
-    expect(readSavedChoice("sess-1")).toEqual({ kind: "server-default" });
-    expect(localStorage.getItem("manta:chat:sess-1:model")).toBeNull();
+  it("absence (no record) → { kind: 'server-default' }", () => {
+    expect(resolveSessionChoice(sessions, "s2", false)).toEqual({ kind: "server-default" });
+  });
+});
+
+describe("parseOldModelPrefs / collectOldModelPrefs (BET-1281 migration)", () => {
+  it("parses a concrete model key", () => {
+    expect(parseOldModelPrefs("manta:chat:sess-1:model", JSON.stringify({ providerID: "anthropic", modelID: "claude-sonnet-4-6" }))).toEqual({
+      sessionId: "sess-1",
+      kind: "model",
+      model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
+    });
   });
 
-  it("an existing stored ModelSelection still reads as { kind: 'model' }", () => {
-    localStorage.setItem("manta:chat:sess-1:model", JSON.stringify(sel));
-    expect(readSavedChoice("sess-1")).toEqual({ kind: "model", model: sel });
+  it("parses a variant-bearing model key", () => {
+    expect(parseOldModelPrefs("manta:chat:sess-1:model", JSON.stringify({ providerID: "p", modelID: "m", variant: "low" }))).toEqual({
+      sessionId: "sess-1",
+      kind: "model",
+      model: { providerID: "p", modelID: "m", variant: "low" },
+    });
   });
 
-  it("an absent key reads server-default", () => {
-    expect(readSavedChoice("sess-1")).toEqual({ kind: "server-default" });
+  it("parses the bare 'auto' literal as the auto marker", () => {
+    expect(parseOldModelPrefs("manta:chat:sess-1:model", "auto")).toEqual({ sessionId: "sess-1", kind: "auto" });
   });
 
-  it("the bare string 'auto' reads as auto", () => {
-    localStorage.setItem("manta:chat:sess-1:model", "auto");
-    expect(readSavedChoice("sess-1")).toEqual({ kind: "auto" });
+  it("ignores plan keys", () => {
+    expect(parseOldModelPrefs("manta:chat:sess-1:plan", "1")).toBeNull();
   });
 
-  it("malformed JSON reads server-default and does not throw", () => {
-    localStorage.setItem("manta:chat:sess-1:model", "{not json");
-    expect(() => readSavedChoice("sess-1")).not.toThrow();
-    expect(readSavedChoice("sess-1")).toEqual({ kind: "server-default" });
+  it("ignores non-model keys and non-matching keys", () => {
+    expect(parseOldModelPrefs("manta:foo", "x")).toBeNull();
+    expect(parseOldModelPrefs("other", null)).toBeNull();
   });
 
-  it("writes auto as the bare string, not a JSON object", () => {
-    writeSavedChoice("sess-1", { kind: "auto" });
-    expect(localStorage.getItem("manta:chat:sess-1:model")).toBe("auto");
+  it("skips malformed values (bad JSON, missing fields, empty session id)", () => {
+    expect(parseOldModelPrefs("manta:chat:sess-1:model", "{not json")).toBeNull();
+    expect(parseOldModelPrefs("manta:chat:sess-1:model", JSON.stringify({ modelID: "m" }))).toBeNull();
+    expect(parseOldModelPrefs("manta:chat:sess-1:model", JSON.stringify({ providerID: "p" }))).toBeNull();
+    expect(parseOldModelPrefs("manta:chat::model", JSON.stringify({ providerID: "p", modelID: "m" }))).toBeNull();
+    expect(parseOldModelPrefs("manta:chat:sess-1:model", null)).toBeNull();
   });
 
-  it("a session's choice is isolated from another session id", () => {
-    writeSavedChoice("sess-1", { kind: "auto" });
-    expect(readSavedChoice("sess-2")).toEqual({ kind: "server-default" });
+  it("collectOldModelPrefs builds sessions + auto lists, skipping malformed", () => {
+    const getEntry = (k: string): string | null =>
+      ({
+        "manta:chat:s1:model": JSON.stringify({ providerID: "anthropic", modelID: "claude-sonnet-4-6" }),
+        "manta:chat:s2:model": "auto",
+        "manta:chat:s3:model": "garbage",
+        "manta:chat:s4:plan": "1",
+      })[k] ?? null;
+    const collected = collectOldModelPrefs(getEntry, [
+      "manta:chat:s1:model",
+      "manta:chat:s2:model",
+      "manta:chat:s3:model",
+      "manta:chat:s4:plan",
+    ]);
+    expect(collected).not.toBeNull();
+    expect(collected!.sessions).toEqual({ s1: { providerID: "anthropic", modelID: "claude-sonnet-4-6" } });
+    expect(collected!.auto).toEqual(["s2"]);
+  });
+
+  it("collectOldModelPrefs returns null when nothing parseable was found", () => {
+    const collected = collectOldModelPrefs((k) => (k === "manta:chat:s1:model" ? "garbage" : null), ["manta:chat:s1:model", "manta:chat:s1:plan"]);
+    expect(collected).toBeNull();
   });
 });
 
@@ -371,30 +389,6 @@ describe("modelFromChoice (BET-1248 seed derivation)", () => {
   it("{kind:'auto'} → null (the routed pick is applied once a turn resolves)", () => {
     expect(modelFromChoice({ kind: "auto" }, server)).toBeNull();
     expect(modelFromChoice({ kind: "auto" }, null)).toBeNull();
-  });
-});
-
-describe("carrySavedChoice /clear carry-forward", () => {
-  beforeEach(() => {
-    localStorage.clear();
-  });
-  const sel = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
-
-  it("carries an explicit model to the destination session id", () => {
-    writeSavedChoice("sess-1", { kind: "model", model: sel });
-    carrySavedChoice("sess-1", "sess-2");
-    expect(readSavedChoice("sess-2")).toEqual({ kind: "model", model: sel });
-  });
-
-  it("carries the auto state to the destination session id", () => {
-    writeSavedChoice("sess-1", { kind: "auto" });
-    carrySavedChoice("sess-1", "sess-2");
-    expect(readSavedChoice("sess-2")).toEqual({ kind: "auto" });
-  });
-
-  it("is a no-op when the source has no stored choice (destination stays default)", () => {
-    carrySavedChoice("sess-1", "sess-2");
-    expect(readSavedChoice("sess-2")).toEqual({ kind: "server-default" });
   });
 });
 

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -281,9 +281,9 @@ export function modelFromChoice(
   }
 }
 
-// Per-session plan-mode override (BET-949). Deliberately its OWN storage key —
-// NOT folded into the `manta:chat:<sid>:model` JSON blob (that blob is a model
-// selection and the native iOS client stores it in an incompatible format).
+// Per-session plan-mode override (BET-949). Deliberately its OWN storage key,
+// kept apart from the box-backed model choice (BET-1281) — the plan flag is a
+// per-session local toggle (agent change), not a model selection.
 // Value is the literal "1" when on, absent otherwise.
 export function planKey(sessionId: string): string {
   return `manta:chat:${sessionId}:plan`;

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -236,14 +236,11 @@ export function guessMime(filename: string): string {
   return map[ext] ?? "application/octet-stream";
 }
 
-// Per-session model override. Stored in localStorage keyed by sessionId so the
-// picker remembers the user's choice across panel mounts. `null` (or missing)
-// means "let opencode pick its default" — matches the prompt_async fallback.
+// A single per-session model override: provider + model (+ optional reasoning
+// effort variant). Lives in the box model-prefs store (src/renderer/modelPrefs.ts,
+// BET-1281) so the same conversation shows the same choice on another device.
+// `null` (or missing) means "let opencode pick its default".
 export type ModelSelection = { providerID: string; modelID: string; variant?: string };
-
-export function modelKey(sessionId: string): string {
-  return `manta:chat:${sessionId}:model`;
-}
 
 /**
  * What the session's model picker is set to. Three states (BET-1245):
@@ -259,69 +256,6 @@ export type ModelChoice =
   | { kind: "auto" }
   | { kind: "model"; model: ModelSelection }
   | { kind: "server-default" };
-
-/**
- * Read the per-session model choice. One storage key (`modelKey`), three states.
- * The stored value is either absent (`server-default`), a `ModelSelection` JSON
- * object (`{ kind: "model" }`), or the bare literal string `"auto"`
- * (`{ kind: "auto" }`). A malformed or unparseable value falls back to
- * `server-default`; never throws out of a storage read.
- */
-export function readSavedChoice(sessionId: string): ModelChoice {
-  try {
-    const raw = localStorage.getItem(modelKey(sessionId));
-    if (raw === null) return { kind: "server-default" };
-    if (raw === "auto") return { kind: "auto" };
-    const parsed = JSON.parse(raw);
-    if (parsed && typeof parsed.providerID === "string" && typeof parsed.modelID === "string") {
-      return { kind: "model", model: parsed as ModelSelection };
-    }
-    return { kind: "server-default" };
-  } catch {
-    return { kind: "server-default" };
-  }
-}
-
-/**
- * Persist the per-session model choice under the SAME key as the historical
- * `ModelSelection` JSON (so existing sessions keep their stored model, and a
- * later variant is a compatible read). `auto` is written as the bare string
- * `"auto"`; `server-default` removes the key (an absent value means default).
- */
-export function writeSavedChoice(sessionId: string, c: ModelChoice): void {
-  try {
-    switch (c.kind) {
-      case "auto":
-        localStorage.setItem(modelKey(sessionId), "auto");
-        break;
-      case "model":
-        localStorage.setItem(modelKey(sessionId), JSON.stringify(c.model));
-        break;
-      case "server-default":
-        localStorage.removeItem(modelKey(sessionId));
-        break;
-    }
-  } catch { /* quota / disabled storage */ }
-}
-
-/**
- * /clear carry-forward: copy the session's model choice to the new session id
- * so the user doesn't have to re-pick after every clear. Carry the FULL choice
- * (including `auto`) — clearing a conversation must not silently drop Auto.
- */
-export function carrySavedChoice(fromSessionId: string, toSessionId: string): void {
-  writeSavedChoice(toSessionId, readSavedChoice(fromSessionId));
-}
-
-/**
- * @deprecated Superseded by `readSavedChoice` (BET-1245). Thin wrapper over the
- * three-state reader: returns the explicit `ModelSelection`, or `null` for the
- * auto / server-default states. Prefer `readSavedChoice` and narrow yourself.
- */
-export function readSavedModel(sessionId: string): ModelSelection | null {
-  const c = readSavedChoice(sessionId);
-  return c.kind === "model" ? c.model : null;
-}
 
 /**
  * Map a three-state `ModelChoice` to the active override `ModelSelection`
@@ -345,14 +279,6 @@ export function modelFromChoice(
     case "auto":
       return null;
   }
-}
-
-/**
- * @deprecated Superseded by `writeSavedChoice` (BET-1245). Thin wrapper: writes
- * an explicit model, or clears to the server default when `m` is null.
- */
-export function writeSavedModel(sessionId: string, m: ModelSelection | null): void {
-  writeSavedChoice(sessionId, m ? { kind: "model", model: m } : { kind: "server-default" });
 }
 
 // Per-session plan-mode override (BET-949). Deliberately its OWN storage key —

--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -9,6 +9,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { act, useRef, useState } from "react";
 import { ChatPanel } from "../ChatPanel";
+import { sessionAutoKey } from "../modelPrefs";
 import { useSseBus, TURN_SETTLE_MS, type SseBus } from "./useSseBus";
 import type { OpencodeMessage } from "../../shared/types";
 import {
@@ -1043,7 +1044,7 @@ describe("BET-1248 main-conversation routing at boundaries (ChatPanel submit)", 
   });
 
   async function mountAuto(overrides: Record<string, unknown> = {}) {
-    localStorage.setItem("manta:chat:ses_test:model", "auto");
+    localStorage.setItem(sessionAutoKey("ses_test"), "1");
     ({ api, bus } = installMockApi({
       routingChoose: () => decision(ROUTED),
       opencodePrompt: () => Promise.resolve({ ok: true }),
@@ -1091,7 +1092,7 @@ describe("BET-1248 main-conversation routing at boundaries (ChatPanel submit)", 
   });
 
   it("routingChoose rejecting → the turn still sends, on the previous model", async () => {
-    localStorage.setItem("manta:chat:ses_test:model", "auto");
+    localStorage.setItem(sessionAutoKey("ses_test"), "1");
     ({ api, bus } = installMockApi({
       routingChoose: () => Promise.reject(new Error("router down")),
       opencodePrompt: () => Promise.resolve({ ok: true }),

--- a/src/renderer/main.tsx
+++ b/src/renderer/main.tsx
@@ -15,6 +15,7 @@ import { installHttpTransport, setWindowApi } from "./transportInstall";
 import { applyTheme } from "./theme";
 import { pinDemoClock } from "./clock";
 import { loadPersistedSnapshot } from "./store";
+import { migrateModelPrefs } from "./modelPrefs";
 
 // Demo mode (BET-302): `?demo` in the URL swaps the real httpApi for a
 // fixture-backed transport and skips pairing / config / credential logic
@@ -126,6 +127,10 @@ async function chooseDesktopTransport(realPreload: PreloadApi): Promise<void> {
       // the cache so a re-pair to another box never replays the old box's
       // sessions/config.
       loadPersistedSnapshot(config.boxId);
+      // BET-1281: one-shot migration of the old per-session model keys
+      // (`manta:chat:*:model`) into the box store, right after the httpApi
+      // transport is live so modelPrefsSeed / setSessionChoice can reach it.
+      migrateModelPrefs();
     }
   } catch (e) {
     console.warn("[bui] configGet failed at entry:", e);

--- a/src/renderer/modelPrefs.ts
+++ b/src/renderer/modelPrefs.ts
@@ -1,22 +1,18 @@
 // Shared per-session model choice, box-backed (BET-1281).
 //
-// WHY THIS EXISTS. The per-conversation model choice used to live in
-// localStorage (`manta:chat:<sid>:model`), so it never left the Mac. It now
-// lives in the box store (~/.manta/model-prefs.json, src/server/modelPrefs.mjs,
-// BET-1279) so the same conversation opened on another device shows the same
-// choice. This module is the SINGLE renderer cache for that store — one
-// `model-prefs:get` for the whole box, cached at module scope, refetched on the
-// `model-prefs.updated` bus event. ChatPanel never fetches per-session (there is
-// deliberately no per-session RPC channel, and none should be added).
-//
-// Modeled on modelCatalog.ts: module-level cache + a hook for consumers.
+// The per-conversation model choice used to live in localStorage
+// (`manta:chat:<sid>:model`); it now lives in the box store
+// (src/server/modelPrefs.mjs, BET-1279) so the same conversation opened on
+// another device shows the same choice. This module is the SINGLE renderer
+// cache for that store — one `model-prefs:get` for the whole box, cached at
+// module scope, refetched on the `model-prefs.updated` bus event. ChatPanel
+// never fetches per-session (no per-session RPC channel exists or should be
+// added). Modeled on modelCatalog.ts: module-level cache + a hook.
 //
 // The box store holds a CONCRETE per-session `ModelSelection` or ABSENCE
-// (absence = server default). It has no slot for the desktop's "Auto" routing
-// mode (BET-1245): Auto is a desktop-routing concept that can't run on a second
-// device, so its flag is kept device-locally OUTSIDE the `manta:chat:` namespace
-// (that namespace is now box-backed; the DoD grep only admits the plan key
-// there). Everything else is box-backed.
+// (absence = server default). It has no slot for the desktop "Auto" routing mode
+// (BET-1245), so Auto's flag stays device-local OUTSIDE `manta:chat:` (that
+// namespace is now box-backed; the DoD grep only admits the plan key there).
 
 import { useEffect, useMemo, useState } from "react";
 import type { ModelPrefsSessionRecord, ModelPrefsState } from "../shared/types";
@@ -115,7 +111,14 @@ export function sessionSelectionFromRecord(
   rec: ModelPrefsSessionRecord | undefined,
 ): ModelSelection | null {
   if (!rec) return null;
-  if (typeof rec.providerID !== "string" || typeof rec.modelID !== "string") return null;
+  if (
+    typeof rec.providerID !== "string" ||
+    rec.providerID === "" ||
+    typeof rec.modelID !== "string" ||
+    rec.modelID === ""
+  ) {
+    return null;
+  }
   const model: ModelSelection = { providerID: rec.providerID, modelID: rec.modelID };
   if (typeof rec.variant === "string" && rec.variant !== "") model.variant = rec.variant;
   return model;
@@ -143,13 +146,33 @@ export function resolveSessionChoice(
 export function useSessionModelChoice(sessionId: string): ModelChoice {
   const { sessions } = useModelPrefs();
   const isAuto = readSessionAuto(sessionId);
-  // useMemo gives the choice a stable identity unless the box mirror or the
-  // Auto flag actually changed, so consumers can depend on it without re-running
-  // on every render.
-  return useMemo(
-    () => resolveSessionChoice(sessions, sessionId, isAuto),
-    [sessions, sessionId, isAuto],
-  );
+  const rec = sessions[sessionId];
+  // Resolve to primitive fields so the memo is STABLE across a no-op box
+  // refetch (the mirror hands back a new object with the same contents). A
+  // consumer depends on `sessionChoice` identity to reseed its local override;
+  // making it stable means a routing-applied override is not clobbered by an
+  // empty initial/refetch that resolves to the same stored choice.
+  const providerID =
+    typeof rec?.providerID === "string" && rec.providerID !== "" ? rec.providerID : null;
+  const modelID =
+    typeof rec?.modelID === "string" && rec.modelID !== "" ? rec.modelID : null;
+  const variant =
+    typeof rec?.variant === "string" && rec.variant !== "" ? rec.variant : undefined;
+  const kind: ModelChoice["kind"] =
+    isAuto ? "auto" : providerID && modelID ? "model" : "server-default";
+  return useMemo(() => {
+    switch (kind) {
+      case "auto":
+        return { kind: "auto" as const };
+      case "model":
+        return {
+          kind: "model" as const,
+          model: { providerID: providerID!, modelID: modelID!, ...(variant ? { variant } : {}) },
+        };
+      default:
+        return { kind: "server-default" as const };
+    }
+  }, [kind, providerID, modelID, variant]);
 }
 
 /**
@@ -174,10 +197,15 @@ export function setSessionChoice(sessionId: string, choice: ModelChoice): void {
   if (choice.kind === "auto") return;
   const api = window.api as Partial<typeof window.api>;
   if (!api.modelPrefsSet) return; // pre-pairing subset
-  void window.api.modelPrefsSet({
-    sessionId,
-    selection: choice.kind === "model" ? choice.model : null,
-  });
+  // Fire-and-forget: the local override already updated optimistically. A failed
+  // write just means the box isn't synced yet — swallow it (no toast on every
+  // pick); the next update event refetch reconciles.
+  void window.api
+    .modelPrefsSet({
+      sessionId,
+      selection: choice.kind === "model" ? choice.model : null,
+    })
+    .catch(() => {});
 }
 
 // ---- one-shot migration (BET-1281 step 4) ----
@@ -268,7 +296,7 @@ export function migrateModelPrefs(): void {
     if (collected) {
       const api = window.api as Partial<typeof window.api>;
       if (collected.sessions && Object.keys(collected.sessions).length > 0 && api.modelPrefsSeed) {
-        void window.api.modelPrefsSeed({ sessions: collected.sessions });
+        void window.api.modelPrefsSeed({ sessions: collected.sessions }).catch(() => {});
       }
       for (const sid of collected.auto) setSessionChoice(sid, { kind: "auto" });
     }

--- a/src/renderer/modelPrefs.ts
+++ b/src/renderer/modelPrefs.ts
@@ -1,0 +1,284 @@
+// Shared per-session model choice, box-backed (BET-1281).
+//
+// WHY THIS EXISTS. The per-conversation model choice used to live in
+// localStorage (`manta:chat:<sid>:model`), so it never left the Mac. It now
+// lives in the box store (~/.manta/model-prefs.json, src/server/modelPrefs.mjs,
+// BET-1279) so the same conversation opened on another device shows the same
+// choice. This module is the SINGLE renderer cache for that store — one
+// `model-prefs:get` for the whole box, cached at module scope, refetched on the
+// `model-prefs.updated` bus event. ChatPanel never fetches per-session (there is
+// deliberately no per-session RPC channel, and none should be added).
+//
+// Modeled on modelCatalog.ts: module-level cache + a hook for consumers.
+//
+// The box store holds a CONCRETE per-session `ModelSelection` or ABSENCE
+// (absence = server default). It has no slot for the desktop's "Auto" routing
+// mode (BET-1245): Auto is a desktop-routing concept that can't run on a second
+// device, so its flag is kept device-locally OUTSIDE the `manta:chat:` namespace
+// (that namespace is now box-backed; the DoD grep only admits the plan key
+// there). Everything else is box-backed.
+
+import { useEffect, useMemo, useState } from "react";
+import type { ModelPrefsSessionRecord, ModelPrefsState } from "../shared/types";
+import type { ModelChoice, ModelSelection } from "./chatShared";
+
+// ---- module-level cache of the whole box store ----
+let cache: ModelPrefsState = { sessions: {}, recents: [] };
+let inFlight: Promise<void> | null = null;
+let subscribed = false;
+const listeners = new Set<() => void>();
+
+function emit(): void {
+  for (const l of listeners) l();
+}
+
+// Fetch once, deduped (concurrent callers share one round trip), and re-fetch on
+// the box's `model-prefs.updated` bus event. GUARD (same as modelCatalog): the
+// pre-pairing preload subset has no modelPrefsGet / onModelPrefsUpdated, so we
+// check before touching them — calling an absent method would throw from the
+// commit phase where `.catch` cannot see it.
+function load(): void {
+  if (inFlight) return;
+  const api = window.api as Partial<typeof window.api>;
+  if (!api.modelPrefsGet) return;
+  if (!subscribed && api.onModelPrefsUpdated) {
+    subscribed = true;
+    api.onModelPrefsUpdated(() => load());
+  }
+  inFlight = window.api
+    .modelPrefsGet()
+    .then((next) => {
+      // Keep the previous value on a failed/empty fetch rather than blanking.
+      if (next) cache = next;
+      emit();
+    })
+    .catch(() => {
+      /* transient — keep last known state */
+    })
+    .finally(() => {
+      inFlight = null;
+    });
+}
+
+/**
+ * The shared box mirror. Returns the cached value synchronously on the first
+ * render (so a remount — e.g. after `/clear` — never flashes an empty choice)
+ * and re-renders when a refetch brings something new.
+ */
+export function useModelPrefs(): ModelPrefsState {
+  const [snapshot, setSnapshot] = useState<ModelPrefsState>(cache);
+  useEffect(() => {
+    const onChange = () => setSnapshot(cache);
+    listeners.add(onChange);
+    if (inFlight === null) load();
+    // Adopt anything that landed between render and effect (e.g. an update
+    // event refetch resolving before this effect runs).
+    if (cache !== snapshot) onChange();
+    return () => {
+      listeners.delete(onChange);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+  return snapshot;
+}
+
+// ---- device-local Auto flag ----
+// The box cannot represent Auto, so it lives in a short device-local key.
+// Deliberately NOT `manta:chat:`: that namespace is box-backed now, and the
+// one-shot migration scans it for concrete models only. See the header comment.
+export function sessionAutoKey(sessionId: string): string {
+  return `manta:model-auto:${sessionId}`;
+}
+
+export function readSessionAuto(sessionId: string): boolean {
+  try {
+    return localStorage.getItem(sessionAutoKey(sessionId)) === "1";
+  } catch {
+    /* disabled storage */
+    return false;
+  }
+}
+
+export function writeSessionAuto(sessionId: string, on: boolean): void {
+  try {
+    if (on) localStorage.setItem(sessionAutoKey(sessionId), "1");
+    else localStorage.removeItem(sessionAutoKey(sessionId));
+  } catch {
+    /* quota / disabled storage */
+  }
+}
+
+// ---- pure resolution helpers (unit-tested) ----
+
+/** A box session record → the renderer's `ModelSelection` (or null if malformed). */
+export function sessionSelectionFromRecord(
+  rec: ModelPrefsSessionRecord | undefined,
+): ModelSelection | null {
+  if (!rec) return null;
+  if (typeof rec.providerID !== "string" || typeof rec.modelID !== "string") return null;
+  const model: ModelSelection = { providerID: rec.providerID, modelID: rec.modelID };
+  if (typeof rec.variant === "string" && rec.variant !== "") model.variant = rec.variant;
+  return model;
+}
+
+/**
+ * Resolve the box `sessions` map + the device-local Auto flag into the
+ * three-state choice (auto / model / server-default). Auto wins; then a present
+ * box record → an explicit model; absence → server default.
+ */
+export function resolveSessionChoice(
+  sessions: Record<string, ModelPrefsSessionRecord>,
+  sessionId: string,
+  isAuto: boolean,
+): ModelChoice {
+  if (isAuto) return { kind: "auto" };
+  const model = sessionSelectionFromRecord(sessions[sessionId]);
+  return model ? { kind: "model", model } : { kind: "server-default" };
+}
+
+/**
+ * The current session's choice, live: re-resolved whenever the box mirror
+ * refreshes and when the device-local Auto flag changes (reads it per render).
+ */
+export function useSessionModelChoice(sessionId: string): ModelChoice {
+  const { sessions } = useModelPrefs();
+  const isAuto = readSessionAuto(sessionId);
+  // useMemo gives the choice a stable identity unless the box mirror or the
+  // Auto flag actually changed, so consumers can depend on it without re-running
+  // on every render.
+  return useMemo(
+    () => resolveSessionChoice(sessions, sessionId, isAuto),
+    [sessions, sessionId, isAuto],
+  );
+}
+
+/**
+ * The concrete model the box currently holds for `sessionId` (from the cached
+ * mirror), or null. Synchronous — used by non-hook call sites (e.g. the routing
+ * effect's incumbent read) that can't subscribe to the cache.
+ */
+export function sessionBoxSelection(sessionId: string): ModelSelection | null {
+  return sessionSelectionFromRecord(cache.sessions[sessionId]);
+}
+
+/**
+ * Persist a user pick: update the device-local Auto flag immediately and write
+ * the box. auto → local flag only (the box has no Auto slot); model → the box
+ * session record; server-default → delete the box session record. This is the
+ * single write path — the same setter powers selectModel, auto, /clear carry
+ * and the app-control switch-model fallback. Fire-and-forget; a client
+ * refetching its own write is a harmless no-op (no echo suppression).
+ */
+export function setSessionChoice(sessionId: string, choice: ModelChoice): void {
+  writeSessionAuto(sessionId, choice.kind === "auto");
+  if (choice.kind === "auto") return;
+  const api = window.api as Partial<typeof window.api>;
+  if (!api.modelPrefsSet) return; // pre-pairing subset
+  void window.api.modelPrefsSet({
+    sessionId,
+    selection: choice.kind === "model" ? choice.model : null,
+  });
+}
+
+// ---- one-shot migration (BET-1281 step 4) ----
+// The old localStorage keys were `manta:chat:<sessionId>:model`, holding either
+// a `ModelSelection` JSON object, the bare literal `"auto"`, or (badly) something
+// else. Scan them into the box, then remove the keys, then set the flag. Do NOT
+// touch `manta:chat:*:plan` (plan mode is out of scope).
+
+const OLD_PREFIX = "manta:chat:";
+const OLD_SUFFIX = ":model";
+
+export type OldModelValue =
+  | { sessionId: string; kind: "model"; model: ModelSelection }
+  | { sessionId: string; kind: "auto" };
+
+/**
+ * Parse one legacy storage key/value into a concrete model or an Auto marker.
+ * Returns null for non-model keys, an empty session id, a missing value, an
+ * unrecognised/malformed value, or the literal "auto"-only forms that carry no
+ * model (those are handled by the Auto marker). Malformed values are skipped
+ * (returned null) — a broken value must never break the migration.
+ */
+export function parseOldModelPrefs(key: string, raw: string | null): OldModelValue | null {
+  if (!key.startsWith(OLD_PREFIX) || !key.endsWith(OLD_SUFFIX)) return null;
+  const sessionId = key.slice(OLD_PREFIX.length, key.length - OLD_SUFFIX.length);
+  if (sessionId === "") return null;
+  if (raw === null) return null;
+  if (raw === "auto") return { sessionId, kind: "auto" };
+  try {
+    const p = JSON.parse(raw);
+    if (
+      p &&
+      typeof p.providerID === "string" &&
+      p.providerID !== "" &&
+      typeof p.modelID === "string" &&
+      p.modelID !== ""
+    ) {
+      const model: ModelSelection = { providerID: p.providerID, modelID: p.modelID };
+      if (typeof p.variant === "string" && p.variant !== "") model.variant = p.variant;
+      return { sessionId, kind: "model", model };
+    }
+  } catch {
+    /* malformed JSON — skip */
+  }
+  return null;
+}
+
+/**
+ * Scan a caller-supplied bag of keys via `getEntry` (injectable so the function
+ * is pure/unit-testable; the real caller passes localStorage). Builds the
+ * `{ sessions }` map + the Auto session ids, skipping malformed values. Returns
+ * null when nothing parseable was found (caller then skips the seed + flag).
+ */
+export function collectOldModelPrefs(
+  getEntry: (key: string) => string | null,
+  keys: string[],
+): { sessions: Record<string, ModelSelection>; auto: string[] } | null {
+  let found = false;
+  const sessions: Record<string, ModelSelection> = {};
+  const auto: string[] = [];
+  for (const key of keys) {
+    const parsed = parseOldModelPrefs(key, getEntry(key));
+    if (!parsed) continue;
+    found = true;
+    if (parsed.kind === "auto") auto.push(parsed.sessionId);
+    else sessions[parsed.sessionId] = parsed.model;
+  }
+  return found ? { sessions, auto } : null;
+}
+
+/**
+ * One-shot migration. Called once after pairing (next to loadPersistedSnapshot)
+ * when the flag is absent: scan `manta:chat:*:model` keys, seed the concrete
+ * models to the box (`model-prefs:seed`) + the Auto flags locally, remove the
+ * scanned keys, and set the flag. Best-effort; never throws out of boot.
+ */
+export function migrateModelPrefs(): void {
+  const FLAG = "manta:model-prefs:migrated";
+  try {
+    if (localStorage.getItem(FLAG) !== null) return;
+    const keys: string[] = [];
+    for (let i = 0; i < localStorage.length; i++) {
+      const k = localStorage.key(i);
+      if (k) keys.push(k);
+    }
+    const getEntry = (k: string) => localStorage.getItem(k);
+    const collected = collectOldModelPrefs(getEntry, keys);
+    if (collected) {
+      const api = window.api as Partial<typeof window.api>;
+      if (collected.sessions && Object.keys(collected.sessions).length > 0 && api.modelPrefsSeed) {
+        void window.api.modelPrefsSeed({ sessions: collected.sessions });
+      }
+      for (const sid of collected.auto) setSessionChoice(sid, { kind: "auto" });
+    }
+    // Remove every scanned model key (Auto segments of the keys are removed
+    // here too; the Auto flag migration wrote a NEW key, so no conflict).
+    for (const key of keys) {
+      if (parseOldModelPrefs(key, getEntry(key))) localStorage.removeItem(key);
+    }
+    localStorage.setItem(FLAG, "1");
+  } catch {
+    /* best-effort — never break boot over a migration */
+  }
+}

--- a/src/renderer/modelPrefs.ts
+++ b/src/renderer/modelPrefs.ts
@@ -15,7 +15,11 @@
 // namespace is now box-backed; the DoD grep only admits the plan key there).
 
 import { useEffect, useMemo, useState } from "react";
-import type { ModelPrefsSessionRecord, ModelPrefsState } from "../shared/types";
+import type {
+  ModelPrefsSelection,
+  ModelPrefsSessionRecord,
+  ModelPrefsState,
+} from "../shared/types";
 import type { ModelChoice, ModelSelection } from "./chatShared";
 
 // ---- module-level cache of the whole box store ----
@@ -186,25 +190,27 @@ export function sessionBoxSelection(sessionId: string): ModelSelection | null {
 
 /**
  * Persist a user pick: update the device-local Auto flag immediately and write
- * the box. auto → local flag only (the box has no Auto slot); model → the box
- * session record; server-default → delete the box session record. This is the
- * single write path — the same setter powers selectModel, auto, /clear carry
- * and the app-control switch-model fallback. Fire-and-forget; a client
- * refetching its own write is a harmless no-op (no echo suppression).
+ * the box. auto → local flag (the box has no Auto slot); model → the box session
+ * record; server-default → delete the box session record. This is the single
+ * write path — the same setter powers selectModel, auto, /clear carry and the
+ * app-control switch-model fallback. Fire-and-forget; a client refetching its
+ * own write is a harmless no-op (no echo suppression).
  */
 export function setSessionChoice(sessionId: string, choice: ModelChoice): void {
   writeSessionAuto(sessionId, choice.kind === "auto");
-  if (choice.kind === "auto") return;
   const api = window.api as Partial<typeof window.api>;
   if (!api.modelPrefsSet) return; // pre-pairing subset
+  // Auto wins in selection resolution, but clear any lingering box record for
+  // the session so turning Auto off later can't resurface a stale model (reviewer
+  // nit). /clear carry of an Auto choice rides this same path and clears the
+  // destination id's record too.
+  const selection: ModelPrefsSelection | null =
+    choice.kind === "model" ? choice.model : null;
   // Fire-and-forget: the local override already updated optimistically. A failed
   // write just means the box isn't synced yet — swallow it (no toast on every
   // pick); the next update event refetch reconciles.
   void window.api
-    .modelPrefsSet({
-      sessionId,
-      selection: choice.kind === "model" ? choice.model : null,
-    })
+    .modelPrefsSet({ sessionId, selection })
     .catch(() => {});
 }
 

--- a/src/renderer/testHarness.tsx
+++ b/src/renderer/testHarness.tsx
@@ -137,6 +137,10 @@ function defaultApiImpl(): Record<string, unknown> {
     webhookList: () => Promise.resolve([]),
     webhookDelete: () => Promise.resolve(),
     progressGet: () => Promise.resolve(null),
+    // Per-session model prefs (BET-1281): ChatPanel reads the box mirror through
+    // the shared modelPrefs module. Empty by default unless a test overrides it.
+    modelPrefsGet: () => Promise.resolve({ sessions: {}, recents: [] }),
+    onModelPrefsUpdated: () => () => {},
     // Voice / files — component may probe these on mount.
     getPathForFile: () => "",
     clipboardReadImage: () => Promise.resolve(null),


### PR DESCRIPTION
## BET-1281 — Desktop: model selection from the box store, delete the localStorage copy

Swaps the per-conversation model choice from `localStorage` (`manta:chat:<sid>:model`)
to the box model-prefs store (BET-1279), so the same conversation opened on
another device shows the same choice. **Storage swap — desktop semantics unchanged.**

### What changed

- **New `src/renderer/modelPrefs.ts`** — the single renderer cache for the box store.
  Modeled on `modelCatalog.ts`: one module-level `model-prefs:get`, cached, refetched
  on the `model-prefs.updated` bus event, exposed through a hook (`useSessionModelChoice`)
  + a write path (`setSessionChoice`). No per-session RPC, no second cache, no
  per-ChatPanel fetch.
- **`chatShared.tsx`** — deleted the localStorage helpers (`modelKey`, `readSavedModel`,
  `writeSavedModel`, and the three-state `readSavedChoice`/`writeSavedChoice`/
  `carrySavedChoice`). Kept `ModelSelection`, `ModelChoice`, and the pure
  `modelFromChoice`. **Plan mode untouched** (`planKey`/`readPlanSaved`/`writePlanSaved` stay).
- **`ChatPanel.tsx`** — rewired every call site through the module: seeding,
  `selectModel` (the single chokepoint), the Auto flag, `/clear` carry-forward, the
  catalogue self-heal, and the routing-gate reads. A narrow effect keeps local
  `modelOverride`/`autoActive` in sync when the box choice for the session actually
  changes (its identity is stable across no-op refetches so a routing-applied
  override is never clobbered).
- **`App.tsx`** — the `switch-model` app-control no-panel fallback now routes through
  the module's `setSessionChoice` (deleted the direct `writeSavedModel` branch).
- **`main.tsx`** — one-shot migration after pairing: scans `manta:chat:*:model`,
  seeds concrete models to the box + migrates the device-local Auto flag, removes
  the scanned keys, sets the flag.

### Note on scope vs the ticket

The ticket was written against the pre-routing-epic two-state choice (`ModelSelection`
or null). The code in `main` is now **three-state** (BET-1245/1248): `auto` /
`model` / `server-default`. To honor "storage swap, not a behaviour change", the
module resolves and persists all three states:

- `model` → the box session record (cross-device).
- `server-default` → delete the box record.
- `auto` → the **device-local** Auto flag. The box store has no slot for Auto (Auto
  is a desktop-only routing mode that can't run on another device), so it lives in a
  `manta:model-auto:<sid>` key outside the `manta:chat:` namespace rather than
  touching/converting the merged BET-1279 store shape. Concrete models are fully
  box-synced; Auto's flag is device-local by design (a second device has no router).

**Definition-of-done grep:** `grep -r "manta:chat:" src/renderer/` now matches only
(a) the plan-mode key (`planKey`) and (b) the migration scanner's `OLD_PREFIX`
constant + its test fixtures — there are **no** live per-session *model* storage
reads/writes under `manta:chat:` any more.

`Base: origin/main @ 0d6ffab5` (rebased; base advanced with BET-1267)

**Files changed:** 9 files (all `src/renderer/`): `App.tsx`, `ChatPanel.harness.test.tsx`,
`ChatPanel.tsx`, `chatShared.test.ts`, `chatShared.tsx`, `hooks/useSseBus.test.tsx`,
`main.tsx`, `modelPrefs.ts` (new), `testHarness.tsx`.

**Verification results:**

- **PR branch** (`multica/BET-1281-model-prefs` @ `10c69b7e`):
  - typecheck: exit 0. Errors: none. log sha256: `6b4397a7b8e898b1f30f061c4cf5410bcb179c8df99b1048ee870bd613df0e6d`
  - test: exit 0, renderer `3477 pass / 0 fail / 7 skip`, server `2156 pass / 0 fail`. Failures: none. log sha256: `947146bb7cb387021138d5080dc031bc17de1f5caf1fc35b70a153c1a543c5e3`
- **Base** (`main` @ `589f7584`):
  - typecheck: exit 0. Errors: none. log sha256: `6b4397a7b8e898b1f30f061c4cf5410bcb179c8df99b1048ee870bd613df0e6d`
  - test: exit 0, renderer `3479 pass / 0 fail / 7 skip`, server `2663 pass / 0 fail`. Failures: none. log sha256: `f3f062483fdd5790a1fc081b492b12377338c8bcf667b2911c43b176d0fa68d7`
- **Conclusion:** 0 new failures. The PR's renderer suite is 3 tests smaller
  (dead tests for the removed localStorage helpers were deleted; those are replaced
  by tests for the new module's pure resolution + migration parsing). No failures on
  either branch; the single earlier `CloneFromGitHub` unhandled rejection did not
  reproduce on rerun and is unrelated to this change.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`,
`/tmp/test-main.log`.

