### PR TITLE
Routing: the composer never lies about Auto, and the off switch actually works (BET-1274)

### DIFF
--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -15,7 +15,7 @@ import { TRANSCRIPT_TAIL_LIMIT } from "./hooks/useTranscriptState";
 import { useStore } from "./store";
 import { refreshModelCatalog } from "./modelCatalog";
 import type { Attachment } from "./chatShared";
-import { sessionAutoKey } from "./modelPrefs";
+import { sessionAutoKey, readSessionAuto } from "./modelPrefs";
 import {
   installMockApi,
   resetStore,
@@ -797,94 +797,26 @@ describe("ChatPanel composer submit", () => {
     el.dispatchEvent(new Event("input", { bubbles: true }));
   }
 
-  it("applies a changed routing decision as the active model for the next prompt (BET-1225)", async () => {
-    ({ api } = installMockApi({
-      opencodePrompt: () => Promise.resolve({ ok: true }),
-      opencodeModelRoute: () =>
-        Promise.resolve({
-          model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
-          reason: "build → balanced tier: anthropic quota ample",
-          incumbent: { providerID: "anthropic", modelID: "claude-opus-4-5" },
-          changed: true,
-        }),
-    }));
-    resetStore();
-    h = mount(<ChatPanel {...PROPS} />);
-    await h.flush();
-
-    // The routing RPC ran once per session start with the session-scoped agent.
-    const routeCalls = api.calls["opencodeModelRoute"] ?? [];
-    expect(routeCalls.length).toBeGreaterThan(0);
-    // No persisted per-session model / config default in the test harness →
-    // the incumbent (the model the session would otherwise use) is null.
-    expect(routeCalls[0][0]).toBeNull();
-
-    const textarea = h.container.querySelector("textarea");
-    await act(async () => {
-      typeInto(textarea as HTMLTextAreaElement, "hello");
-    });
-    await act(async () => {
-      (textarea as HTMLTextAreaElement).dispatchEvent(
-        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
-      );
-    });
-    await h.flush();
-
-    // The routed model is threaded through the existing prompt's modelOverride.
-    const promptCall = api.calls["opencodePrompt"]?.[0];
-    expect(promptCall?.[0]).toBe("ses_test");
-    expect((promptCall?.[2] as { modelID?: string } | undefined)?.modelID).toBe("claude-sonnet-4-6");
-  });
-
-  it("leaves the prompt's model untouched when the decision is a no-op (BET-1225)", async () => {
-    ({ api } = installMockApi({
-      opencodePrompt: () => Promise.resolve({ ok: true }),
-      opencodeModelRoute: () =>
-        Promise.resolve({
-          model: null,
-          reason: "routing not activated for this conversation",
-          incumbent: null,
-          changed: false,
-        }),
-    }));
-    resetStore();
-    h = mount(<ChatPanel {...PROPS} />);
-    await h.flush();
-
-    const textarea = h.container.querySelector("textarea");
-    await act(async () => {
-      typeInto(textarea as HTMLTextAreaElement, "hi");
-    });
-    await act(async () => {
-      (textarea as HTMLTextAreaElement).dispatchEvent(
-        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
-      );
-    });
-    await h.flush();
-
-    const promptCall = api.calls["opencodePrompt"]?.[0];
-    expect(promptCall?.[0]).toBe("ses_test");
-    expect(promptCall?.[2]).toBeUndefined();
-  });
-
-  it("makes no opencodeModelRoute mount call for an Auto session (BET-1255)", async () => {
-    localStorage.setItem(sessionAutoKey("ses_test"), "1");
-    ({ api } = installMockApi({
-      opencodeModelRoute: () =>
-        Promise.resolve({
-          model: { providerID: "anthropic", modelID: "claude-sonnet-4-6" },
-          reason: "build → balanced tier: anthropic quota ample",
-          incumbent: null,
-          changed: true,
-        }),
-    }));
-    resetStore();
-    h = mount(<ChatPanel {...PROPS} />);
-    await h.flush();
-
-    // Auto's model choice is owned by the boundary router (BET-1248), not this
-    // mount-time "build" route — the RPC must not fire for an Auto session.
-    expect(api.calls["opencodeModelRoute"] ?? []).toHaveLength(0);
+  it("issues no routing RPC on session mount (BET-1274 test 6)", async () => {
+    // Ranging over the choice kinds: Auto (device-local flag on) and
+    // server-default (flag off, no box record). The third kind — an explicit
+    // hand-picked model — is non-Auto by construction, so it can only route
+    // from the boundary router in submit() (never on mount); 10a deleted the
+    // mount-time channel outright. None of the kinds may issue a routing RPC on
+    // mount — that's the whole point of deleting the mount route.
+    for (const auto of [true, false]) {
+      if (auto) localStorage.setItem(sessionAutoKey("ses_test"), "1");
+      else localStorage.removeItem(sessionAutoKey("ses_test"));
+      ({ api } = installMockApi());
+      resetStore();
+      h = mount(<ChatPanel {...PROPS} />);
+      await h.flush();
+      await h.flush();
+      expect(api.calls["routingChoose"] ?? []).toHaveLength(0);
+      expect((api.calls["opencodePrompt"] ?? [])).toHaveLength(0);
+      h?.unmount();
+      h = null;
+    }
   });
 
   it("still routes an Auto session's first turn via the boundary router (BET-1255)", async () => {
@@ -921,6 +853,112 @@ describe("ChatPanel composer submit", () => {
     const promptCall = api.calls["opencodePrompt"]?.[0];
     expect(promptCall?.[0]).toBe("ses_test");
     expect((promptCall?.[2] as { modelID?: string } | undefined)?.modelID).toBe("claude-sonnet-4-6");
+  });
+
+  it("a first routed boundary renders the reason with no undo (no incumbent) (BET-1274 test 5)", async () => {
+    localStorage.setItem(sessionAutoKey("ses_test"), "1");
+    const movedTo = { providerID: "anthropic", modelID: "claude-sonnet-4-6" };
+    ({ api } = installMockApi({
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+      routingChoose: () =>
+        Promise.resolve({
+          model: movedTo,
+          alternatives: [movedTo],
+          reason: "balanced",
+        }),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    const textarea = h.container.querySelector("textarea");
+    await act(async () => {
+      typeInto(textarea as HTMLTextAreaElement, "first turn");
+    });
+    await act(async () => {
+      (textarea as HTMLTextAreaElement).dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await h.flush();
+    // The routed pill says why (the reason applyRouted recorded) — and, with no
+    // prior model to revert to, it renders NO undo action (BET-1274 10e).
+    const text = h?.container.textContent ?? "";
+    expect(text).toContain("balanced");
+    expect(text).not.toContain("undo");
+  });
+
+  it("a routing failure still sends the turn and raises the error banner (BET-1274 test 4)", async () => {
+    localStorage.setItem(sessionAutoKey("ses_test"), "1");
+    ({ api } = installMockApi({
+      opencodePrompt: () => Promise.resolve({ ok: true }),
+      routingChoose: () => Promise.reject(new Error("router unreachable")),
+    }));
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+
+    const textarea = h.container.querySelector("textarea");
+    await act(async () => {
+      typeInto(textarea as HTMLTextAreaElement, "hi");
+    });
+    await act(async () => {
+      (textarea as HTMLTextAreaElement).dispatchEvent(
+        new KeyboardEvent("keydown", { key: "Enter", bubbles: true }),
+      );
+    });
+    await h.flush();
+
+    // The turn STILL sends (routing never blocks a turn) …
+    const promptCall = api.calls["opencodePrompt"]?.[0];
+    expect(promptCall?.[0]).toBe("ses_test");
+    expect(promptCall?.[1]).toBe("hi");
+    // … and the banner says the router was unreachable instead of pretending it
+    // picked a model.
+    expect(h?.container.textContent ?? "").toContain("Couldn't pick a model");
+  });
+
+  it("picking a model while Auto is on stops the chip saying Auto in the same commit and clears the Auto flag (BET-1274 test 1)", async () => {
+    localStorage.setItem(sessionAutoKey("ses_test"), "1");
+    const model = {
+      id: "claude-opus-4-7",
+      providerID: "anthropic",
+      name: "Claude Opus 4.7",
+      variants: [{ id: "high" }, { id: "low" }],
+    };
+    ({ api } = installMockApi({
+      opencodeModels: () => Promise.resolve([model]),
+    }));
+    // The catalog is a module-level cache served past STALE_MS — force a
+    // refetch so THIS test sees the injected model, not a prior test's `[]`.
+    refreshModelCatalog();
+    resetStore();
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    await h.flush();
+
+    const pickerBtn = () =>
+      h!.container.querySelector<HTMLElement>(".manta-model-picker-btn");
+    // The catalog has landed (the mock returns a model) and the chip says Auto.
+    expect(pickerBtn()?.textContent).toContain("Auto");
+
+    // Open the dropdown; it portals to document.body.
+    act(() => (pickerBtn() as HTMLButtonElement).click());
+    await h.flush();
+    await h.flush();
+    expect(document.body.querySelector(".manta-model-dropdown")).toBeTruthy();
+    // Click the model row (a role=option whose label is the model's name).
+    const modelRow = [...document.body.querySelectorAll<HTMLElement>('[role="option"]')].find(
+      (o) => (o.textContent ?? "").includes("Claude Opus 4.7"),
+    );
+    expect(modelRow).toBeTruthy();
+    act(() => (modelRow as HTMLElement).click());
+    await h.flush();
+
+    // The chip stops saying Auto in this very commit — a manual model choice is
+    // the off switch for Auto (BET-1274 10b, selectModel → setAutoActive(false))
+    // — and the device-local Auto flag is cleared (the persisted off-switch).
+    expect(pickerBtn()?.textContent).not.toContain("Auto");
+    expect(readSessionAuto("ses_test")).toBe(false);
   });
 });
 

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -91,7 +91,6 @@ import { crossesBoundary, shouldSwitch, boundaryPhrase } from "../shared/routing
 import { acceptsModality } from "../shared/modelGuide.mjs";
 import { useModelCatalog } from "./modelCatalog";
 import {
-  readSessionAuto,
   sessionBoxSelection,
   setSessionChoice,
   useSessionModelChoice,

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -64,6 +64,7 @@ import {
   isPlanExitQuestion,
   extractPlanData,
   selectableModelGroups,
+  titleCase,
 } from "./chatUtils";
 import { isPlanAgent, planPageUrl } from "../shared/planMode.mjs";
 import { serverBase } from "./api/httpApi";
@@ -213,6 +214,9 @@ export function ChatPanel({
   const deactivatedMainModels = useStore((s) => s.deactivatedMainModels);
   const optInModels = useStore((s) => s.optInModels);
   const optInModel = useStore((s) => s.optInModel);
+  // BET-1274 10d: the routing preset drives the Auto row's display label; the
+  // value lives on the same store block Settings writes (modelRouting.preset).
+  const routingPreset = useStore((s) => s.modelRouting?.preset);
   const hiddenStatusItems = useStore((s) => s.hiddenStatusItems);
   // BET-789: the "Connect GitHub…" offer's per-box dismissal flag. Once set,
   // the offer never re-appears until the config flag is cleared.
@@ -448,13 +452,13 @@ export function ChatPanel({
   const [modelOverride, setModelOverride] = useState<ModelSelection | null>(() =>
     modelFromChoice(sessionChoice, configDefaultModel),
   );
-  // BET-1222: routed state for the composer pill — set when the router chose
-  // this session's model (fed by the main-conversation routing wiring). The
-  // pill renders ONLY while this is non-null; clearing it reverts the pill to
-  // its normal appearance.
+  // BET-1248: routed state for the composer pill — set when the router chose
+  // this session's model (fed by the main-conversation boundary routing in
+  // submit). The pill renders ONLY while this is non-null; clearing it reverts
+  // the pill to its normal appearance.
   const [routed, setRouted] = useState<{
     reason: string;
-    incumbent: { providerID: string; modelID: string };
+    incumbent: { providerID: string; modelID: string } | null;
   } | null>(null);
   // BET-1248: boundary-routing state for the main conversation. `routedModel`
   // is the session's current routed endpoint — the incumbent shouldSwitch uses
@@ -470,14 +474,30 @@ export function ChatPanel({
   useEffect(() => {
     routedModelRef.current = routedModel;
   }, [routedModel]);
-  // Apply a boundary-routing decision: record the incumbent + reason and, under
-  // Auto, set the active override so the pill and send paths run on it.
+  // The single producer of `routed`: apply a boundary-routing decision. With
+  // an incumbent (the model the session was on before the switch) surface the
+  // undoable pill — the reason and the model undo reverts to. With no
+  // incumbent (the first turn of a session) there is nothing to undo, so the
+  // reason still surfaces (the pill renders the reason without an undo action)
+  // — never silently. The model is applied to the override, carrying forward
+  // the user's current in-memory effort (BET-1274 10c) so a just-chosen effort
+  // is not dropped by a route.
   const applyRouted = useCallback((model: ModelSelection | null, reason: string) => {
+    const incumbent = routedModelRef.current;
+    setRouted({
+      reason,
+      incumbent: incumbent
+        ? { providerID: incumbent.providerID, modelID: incumbent.modelID }
+        : null,
+    });
     routedModelRef.current = model;
     setRoutedModel(model);
     setRoutedReason(reason);
-    setModelOverride(model);
-  }, []);
+    const override =
+      model && modelOverride?.variant ? { ...model, variant: modelOverride.variant } : model;
+    setModelOverride(override);
+    return override;
+  }, [modelOverride]);
   // The agent the PREVIOUS turn ran as — drives the agent-changed boundary.
   const lastAgentRef = useRef<string | undefined>(undefined);
   // A compaction completed since the last submit (cache is gone → re-deciding
@@ -519,46 +539,6 @@ export function ChatPanel({
     () => modelOverride?.providerID ?? configDefaultModel?.providerID ?? null,
     [modelOverride, configDefaultModel],
   );
-
-  // BET-1225: main-conversation routing, the honesty half of the routing epic.
-  // On session start, ask the server for the router's "build" decision. When it
-  // actually changed the model (routing enabled AND picked a different winner),
-  // apply the routed model as the active override — so the next prompt actually
-  // runs on it — and populate `routed` with the reason + incumbent so the
-  // composer renders the undoable routed pill. The incumbent is the model the
-  // session would run on without routing (the user's per-session pick or the
-  // persisted default); undo reverts to exactly that. Best-effort: a null or
-  // failed decision (routing off / demo transport) leaves routing silent, and
-  // never breaks the session. Re-runs on session change; the user's own
-  // selectModel clears the pill.
-  useEffect(() => {
-    // BET-1255: Auto-session model choice is owned SOLELY by the boundary
-    // routing in submit() (BET-1248) — it already re-decides on the first
-    // turn, which is itself a boundary. Returning early for Auto avoids a
-    // second, immediately-overwritten "build" RPC decision (and the confusing
-    // co-existence of its undo pill with the Auto-row reason). The gate reads
-    // the same session key the effect already reads, so the [sessionId]
-    // dependency stays correct on session change.
-    if (readSessionAuto(sessionId)) return;
-    let cancelled = false;
-    const incumbent = sessionBoxSelection(sessionId) ?? configDefaultModel ?? null;
-    window.api
-      .opencodeModelRoute(incumbent, "build")
-      .then((d) => {
-        if (cancelled || !d || !d.changed || !d.model) return;
-        setModelOverride(d.model);
-        // The pill (which offers undo back to a prior model) renders only when
-        // there is an incumbent to revert to; with no prior model there is
-        // nothing to undo, so the decision applies silently.
-        if (d.incumbent) setRouted({ reason: d.reason, incumbent: d.incumbent });
-      })
-      .catch(() => {
-        /* routing is best-effort — never break the session over it */
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [sessionId]);
 
   // ===== Per-session plan mode (BET-949) =====
   // Local on/off, seeded from the per-session storage key (the `Session.agent`
@@ -1341,73 +1321,73 @@ export function ChatPanel({
     // server default) and sends.
     let sendModel = modelOverride;
     if (autoActive && text) {
-      if (readSessionAuto(sessionId)) {
-        const incumbent = routedModelRef.current;
-        const incumbentModel = incumbent
-          ? resolveActiveModel(models, incumbent, null)
-          : null;
-        const ctxTokens = latestTokensRef.current
-          ? (latestTokensRef.current.input ?? 0) +
-            (latestTokensRef.current.cache?.read ?? 0) +
-            (latestTokensRef.current.cache?.write ?? 0)
-          : undefined;
-        const requiredModes = readyAttachments.map((a) => mimeToInputMode(a.mime));
-        const currentAgent = planAgent ?? "build";
-        const { crossed, boundary, stillCapable, stillHealthy } = crossesBoundary({
-          hasRoutedModel: incumbent != null,
-          agent: currentAgent,
-          previousAgent: lastAgentRef.current,
-          contextTokens: ctxTokens ?? undefined,
-          incumbentContextLimit: incumbentModel?.limit?.context ?? undefined,
-          requiredModalities: requiredModes,
-          incumbentModel,
-          incumbentHealthy: true,
-          justCompacted: justCompactedRef.current,
-          userRequested: pendingAutoUserRef.current,
-        });
-        justCompactedRef.current = false;
-        pendingAutoUserRef.current = false;
-        lastAgentRef.current = currentAgent;
-        if (crossed) {
-          try {
-            const decision = await window.api.routingChoose({
-              sessionId,
-              directory: cwd ?? "",
-              agent: currentAgent,
-              surface: "main",
-              contextTokens: ctxTokens,
-              needs: {
-                tools: true,
-                image: readyAttachments.some((a) => mimeToInputMode(a.mime) === "image"),
-                pdf: readyAttachments.some((a) => mimeToInputMode(a.mime) === "pdf"),
-              },
+      const incumbent = routedModelRef.current;
+      const incumbentModel = incumbent
+        ? resolveActiveModel(models, incumbent, null)
+        : null;
+      const ctxTokens = latestTokensRef.current
+        ? (latestTokensRef.current.input ?? 0) +
+          (latestTokensRef.current.cache?.read ?? 0) +
+          (latestTokensRef.current.cache?.write ?? 0)
+        : undefined;
+      const requiredModes = readyAttachments.map((a) => mimeToInputMode(a.mime));
+      const currentAgent = planAgent ?? "build";
+      const { crossed, boundary, stillCapable, stillHealthy } = crossesBoundary({
+        hasRoutedModel: incumbent != null,
+        agent: currentAgent,
+        previousAgent: lastAgentRef.current,
+        contextTokens: ctxTokens ?? undefined,
+        incumbentContextLimit: incumbentModel?.limit?.context ?? undefined,
+        requiredModalities: requiredModes,
+        incumbentModel,
+        incumbentHealthy: true,
+        justCompacted: justCompactedRef.current,
+        userRequested: pendingAutoUserRef.current,
+      });
+      justCompactedRef.current = false;
+      pendingAutoUserRef.current = false;
+      lastAgentRef.current = currentAgent;
+      if (crossed) {
+        try {
+          const decision = await window.api.routingChoose({
+            sessionId,
+            directory: cwd ?? "",
+            agent: currentAgent,
+            surface: "main",
+            contextTokens: ctxTokens,
+            needs: {
+              tools: true,
+              image: readyAttachments.some((a) => mimeToInputMode(a.mime) === "image"),
+              pdf: readyAttachments.some((a) => mimeToInputMode(a.mime) === "pdf"),
+            },
+            incumbent,
+          });
+          const ranked = decision.model
+            ? [decision.model, ...decision.alternatives]
+            : decision.alternatives;
+          // Hysteresis: only move off the incumbent when it genuinely fell out
+          // (didn't survive the router's contention) OR it no longer fits the
+          // turn (a CONSTRAINT boundary made it incapable/unhealthy — force the
+          // switch away regardless of where it ranks). Otherwise keep it.
+          if (
+            decision.model &&
+            shouldSwitch({
               incumbent,
-            });
-            const ranked = decision.model
-              ? [decision.model, ...decision.alternatives]
-              : decision.alternatives;
-            // Hysteresis: only move off the incumbent when it genuinely fell out
-            // (didn't survive the router's contention) OR it no longer fits the
-            // turn (a CONSTRAINT boundary made it incapable/unhealthy — force the
-            // switch away regardless of where it ranks). Otherwise keep it.
-            if (
-              decision.model &&
-              shouldSwitch({
-                incumbent,
-                ranked,
-                incumbentStillEligible: true,
-                incumbentStillCapable: stillCapable,
-                incumbentHealthy: stillHealthy,
-              }).switch
-            ) {
-              const reason = decision.reason + (boundary ? ` · ${boundaryPhrase(boundary)}` : "");
-              applyRouted(decision.model, reason);
-              sendModel = decision.model;
-            }
-          } catch {
-            // routing failure must never fail a turn — fall through to the
-            // previous routed model (or the server default) and send.
+              ranked,
+              incumbentStillEligible: true,
+              incumbentStillCapable: stillCapable,
+              incumbentHealthy: stillHealthy,
+            }).switch
+          ) {
+            const reason = decision.reason + (boundary ? ` · ${boundaryPhrase(boundary)}` : "");
+            sendModel = applyRouted(decision.model, reason);
           }
+        } catch {
+          // Routing failure must never fail a turn — the turn still sends on the
+          // previous routed model (or the server default). But it must not do so
+          // silently: the chip would keep claiming Auto picked a model the router
+          // never chose. Say so on the existing error banner.
+          setSendError("Couldn't pick a model — sent on the default. Auto will try again next turn.");
         }
       }
     }
@@ -1705,12 +1685,15 @@ export function ChatPanel({
     setModelOverride(null);
   }, [models, sessionId, sessionChoice]);
 
+  // BET-1247/BET-1274: a manual model choice is THE off switch for Auto — the
+  // design contract's only one. It writes the three-state choice, flips the UI
+  // off Auto (so the chip stops claiming Auto in this very commit), and ends
+  // any routed pill state (BET-1225).
   const selectModel = useCallback(
     (m: ModelSelection | null) => {
       setModelOverride(m);
       setSessionChoice(sessionId, m ? { kind: "model", model: m } : { kind: "server-default" });
-      // A manual model choice ends any routed state: once the user picks the
-      // model themselves, the pill must not claim the router chose it (BET-1225).
+      setAutoActive(false);
       setRouted(null);
     },
     [sessionId],
@@ -1728,22 +1711,49 @@ export function ChatPanel({
     if (routedModelRef.current) pendingAutoUserRef.current = true;
   }, [sessionId]);
 
+  // BET-1274 10c: effort (the variant dial) and the ⚡ fast toggle write a
+  // VARIANT, not a model choice — they must not change the ModelChoice kind and
+  // must not turn Auto off. Under a pinned model ("model") the value (possibly a
+  // `-fast` twin model) is merged into the box-backed record; under "auto" the
+  // box has no model/effort slot (BET-1287: Auto is a device-local boolean), so
+  // the effort is applied to the current in-memory routed model only and Auto is
+  // never exited; server-default falls back to pinning (same as before).
+  const onSelectEffort = useCallback(
+    (value: ModelSelection) => {
+      const choice = sessionChoice;
+      if (choice.kind === "model") {
+        const merged = { ...choice.model, ...value };
+        setSessionChoice(sessionId, { kind: "model", model: merged });
+        setModelOverride(merged);
+      } else if (choice.kind === "auto") {
+        // Auto has no model/effort slot to persist into — applying effort here
+        // only affects the current in-memory routed model (the next send runs at
+        // that effort) without exiting Auto. The fast-twin MODEL swap stays a
+        // model choice and is not expressible under Auto; Auto keeps picking.
+        setModelOverride((prev) => (prev ? { ...prev, variant: value.variant } : prev));
+      } else {
+        setSessionChoice(sessionId, {
+          kind: "model",
+          model: { providerID: value.providerID, modelID: value.modelID, variant: value.variant },
+        });
+        setModelOverride({ ...value });
+      }
+    },
+    [sessionId, sessionChoice],
+  );
+
   // BET-1222: undo a routed model choice. Reverts through the SAME per-session
   // override path the manual picker uses (selectModel) — no
   // second persistence path — then clears the routed state so the pill reverts.
-  // Awaited: a failure surfaces on the existing sendError banner rather than
-  // being swallowed.
-  const undoRouted = useCallback(async () => {
-    if (!routed) return;
-    try {
-      await selectModel({
-        providerID: routed.incumbent.providerID,
-        modelID: routed.incumbent.modelID,
-      });
-      setRouted(null);
-    } catch (e) {
-      setSendError(String((e as Error)?.message ?? e));
-    }
+  // selectModel is synchronous; a failure cannot occur here, so this needs no
+  // async wrapper or try/catch (BET-1274 10e).
+  const undoRouted = useCallback(() => {
+    if (!routed?.incumbent) return;
+    selectModel({
+      providerID: routed.incumbent.providerID,
+      modelID: routed.incumbent.modelID,
+    });
+    setRouted(null);
   }, [routed, selectModel]);
 
   // App-control (BET-840/841): expose this panel's `selectModel` to App so the
@@ -3327,6 +3337,8 @@ export function ChatPanel({
         onOptInModel={optInModel}
         onOpenModels={ensureModels}
         onSelectModel={selectModel}
+        onSelectEffort={onSelectEffort}
+        presetLabel={routingPreset ? titleCase(routingPreset) : undefined}
         scheduleCount={schedules.length}
         onSchedules={() => togglePanel("schedules")}
         onSecrets={() => togglePanel("secrets")}

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -164,6 +164,8 @@ export function InputArea({
   onOptInModel,
   onOpenModels,
   onSelectModel,
+  onSelectEffort,
+  presetLabel,
   scheduleCount,
   onSchedules,
   onSecrets,
@@ -224,9 +226,13 @@ export function InputArea({
   // BET-1248: user re-picked Auto in the menu — forwarded to the ModelPicker's
   // Auto row so it renders + re-decides on the next turn.
   onSelectAuto?: () => void;
-  // BET-1222 routed state — forwarded to ModelPicker: reason + incumbent shown
-  // on the routed pill, and the caller-owned undo action.
-  routed?: { reason: string; incumbent: { providerID: string; modelID: string } } | null;
+  // BET-1222/BET-1274 routed state — forwarded to ModelPicker: reason shown on
+  // the routed pill, and the (possibly null) incumbent drives the optional undo
+  // action (no incumbent = first turn, nothing to undo).
+  routed?: {
+    reason: string;
+    incumbent: { providerID: string; modelID: string } | null;
+  } | null;
   onRoutedUndone?: () => void;
   // BET-738: the active model's providerID, already resolved by ChatPanel
   // via resolveActiveModel (the same computation `shortLabel` above uses) —

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -240,6 +240,10 @@ export function InputArea({
   onOptInModel: (key: string) => void;
   onOpenModels: () => void;
   onSelectModel: (m: ModelSelection | null) => void;
+  // BET-1274 10c: kind-preserving effort/fast selection (never turns Auto off).
+  onSelectEffort: (m: ModelSelection) => void;
+  // BET-1274 10d: the routing preset's display label for the Auto row.
+  presetLabel?: string;
   // Plan-mode chip (BET-949): the resolved toggle state + the flip handler.
   plan: PlanToggleState;
   onTogglePlan: () => void;
@@ -577,6 +581,8 @@ export function InputArea({
             onOptInModel={onOptInModel}
             onOpen={onOpenModels}
             onSelect={onSelectModel}
+            onSelectEffort={onSelectEffort}
+            presetLabel={presetLabel}
             labelOverride={shortLabel}
           />
           {/* Plan mode chip (BET-949) — shared PlanChip, also used by the

--- a/src/renderer/ModelMenu.tsx
+++ b/src/renderer/ModelMenu.tsx
@@ -69,7 +69,7 @@ export function ModelMenu({
   presetLabel?: string;
   /**
    * BET-1246: the routing decision's human-readable reason (what `routing:choose`
-   * / `routing:main` returned). Shown in the Auto row's sub-line when Auto is
+   * returned). Shown in the Auto row's sub-line when Auto is
    * active and a decision exists.
    */
   autoReason?: string;

--- a/src/renderer/ModelPicker.test.tsx
+++ b/src/renderer/ModelPicker.test.tsx
@@ -294,16 +294,18 @@ describe("ModelPicker — effort/fast write effort, not a model choice (BET-1274
         onSelectEffort={(m) => effortCalls.push(m)}
       />,
     );
-    // Open the effort (right) segment menu.
+    // Open the effort (right) segment menu. The dropdown portals to document.body.
     const effortBtn = h.container.querySelector<HTMLElement>(".manta-effort-picker-btn");
     expect(effortBtn).toBeTruthy();
     act(() => (effortBtn as HTMLButtonElement).click());
+    const effortMenu = document.body.querySelector<HTMLElement>(".manta-effort-dropdown");
+    expect(effortMenu).toBeTruthy();
     // Select the "High" variant row.
-    const high = [...h.container.querySelectorAll("button")].find((b) =>
+    const high = [...(effortMenu?.querySelectorAll<HTMLElement>('[role="option"]') ?? [])].find((b) =>
       (b.textContent ?? "").includes("High"),
     );
     expect(high).toBeTruthy();
-    act(() => (high as HTMLButtonElement).click());
+    act(() => (high as HTMLElement).click());
     // The effort went to onSelectEffort (with the variant) — and NOT to the
     // model-choice onSelect, which is what used to pin the model + exit Auto.
     expect(effortCalls).toHaveLength(1);
@@ -330,6 +332,11 @@ describe("ModelPicker — effort/fast write effort, not a model choice (BET-1274
     // Open the model dropdown; the Auto pinned row is its first header row.
     const modelBtn = h.container.querySelector<HTMLElement>(".manta-model-picker-btn");
     act(() => (modelBtn as HTMLButtonElement).click());
-    expect((h.container.textContent ?? "")).toContain("Balanced · moved: the previous provider ran out");
+    const modelMenu = document.body.querySelector<HTMLElement>(".manta-model-dropdown");
+    const autoRow = [...(modelMenu?.querySelectorAll<HTMLElement>('[role="option"]') ?? [])].find((e) =>
+      (e.textContent ?? "").includes("Auto — Manta picks per task"),
+    );
+    expect(autoRow).toBeTruthy();
+    expect(autoRow?.textContent ?? "").toContain("Balanced · moved: the previous provider ran out");
   });
 });

--- a/src/renderer/ModelPicker.test.tsx
+++ b/src/renderer/ModelPicker.test.tsx
@@ -50,6 +50,7 @@ describe("ModelPicker — loading state (models === null)", () => {
         defaultModel={{ providerID: "anthropic", modelID: "claude-opus-4-7" }}
         onOpen={() => {}}
         onSelect={() => {}}
+        onSelectEffort={() => {}}
       />,
     );
     return h.container;
@@ -98,7 +99,9 @@ describe("ModelPicker — routed pill (BET-1222)", () => {
   });
 
   function render(
-    routed: { reason: string; incumbent: { providerID: string; modelID: string } } | null,
+    routed:
+      | { reason: string; incumbent: { providerID: string; modelID: string } | null }
+      | null,
     onRoutedUndone: () => void = () => {},
   ): HTMLElement {
     h?.unmount();
@@ -112,6 +115,7 @@ describe("ModelPicker — routed pill (BET-1222)", () => {
         onSelect={() => {}}
         routed={routed}
         onRoutedUndone={onRoutedUndone}
+        onSelectEffort={() => {}}
       />,
     );
     return h.container;
@@ -154,6 +158,18 @@ describe("ModelPicker — routed pill (BET-1222)", () => {
     act(() => (btn as HTMLButtonElement).click());
     expect(undone).toBe(true);
   });
+
+  it("renders the reason without an undo action when routed has no incumbent (BET-1274 10e)", () => {
+    // The first turn of a session has nothing to undo — the pill still says why
+    // the model is what it is, but offers no undo button.
+    const c = render({
+      reason: "first turn boundary",
+      incumbent: null,
+    });
+    const text = c.textContent ?? "";
+    expect(text).toContain("first turn boundary");
+    expect(text).not.toContain("undo");
+  });
 });
 
 describe("ModelPicker — Auto mode (BET-1247)", () => {
@@ -181,6 +197,7 @@ describe("ModelPicker — Auto mode (BET-1247)", () => {
         labelOverride={props.labelOverride ?? null}
         onOpen={() => {}}
         onSelect={() => {}}
+        onSelectEffort={() => {}}
       />,
     );
     return h.container;
@@ -253,5 +270,66 @@ describe("ModelPicker — Auto mode (BET-1247)", () => {
       ?.getAttribute("title") ?? "";
     expect(title).toContain("Claude Opus 4.7");
     expect(title).toContain("anthropic");
+  });
+});
+
+describe("ModelPicker — effort/fast write effort, not a model choice (BET-1274 10c)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("routes an effort-menu selection to onSelectEffort, never onSelect", () => {
+    const effortCalls: ModelSelection[] = [];
+    const modelCalls: ModelSelection[] = [];
+    h = mount(
+      <ModelPicker
+        modelLabel={null}
+        models={MODELS}
+        modelOverride={{ providerID: "anthropic", modelID: "claude-opus-4-7" }}
+        defaultModel={null}
+        onOpen={() => {}}
+        onSelect={(m) => { if (m) modelCalls.push(m); }}
+        onSelectEffort={(m) => effortCalls.push(m)}
+      />,
+    );
+    // Open the effort (right) segment menu.
+    const effortBtn = h.container.querySelector<HTMLElement>(".manta-effort-picker-btn");
+    expect(effortBtn).toBeTruthy();
+    act(() => (effortBtn as HTMLButtonElement).click());
+    // Select the "High" variant row.
+    const high = [...h.container.querySelectorAll("button")].find((b) =>
+      (b.textContent ?? "").includes("High"),
+    );
+    expect(high).toBeTruthy();
+    act(() => (high as HTMLButtonElement).click());
+    // The effort went to onSelectEffort (with the variant) — and NOT to the
+    // model-choice onSelect, which is what used to pin the model + exit Auto.
+    expect(effortCalls).toHaveLength(1);
+    expect(effortCalls[0].variant).toBe("high");
+    expect(modelCalls).toHaveLength(0);
+  });
+
+  it("names the capitalized balance preset in the Auto row sub-line (BET-1274 10d)", () => {
+    h = mount(
+      <ModelPicker
+        modelLabel={null}
+        models={MODELS}
+        modelOverride={null}
+        defaultModel={null}
+        auto
+        presetLabel="Balanced"
+        autoReason="moved: the previous provider ran out"
+        onSelectAuto={() => {}}
+        onOpen={() => {}}
+        onSelect={() => {}}
+        onSelectEffort={() => {}}
+      />,
+    );
+    // Open the model dropdown; the Auto pinned row is its first header row.
+    const modelBtn = h.container.querySelector<HTMLElement>(".manta-model-picker-btn");
+    act(() => (modelBtn as HTMLButtonElement).click());
+    expect((h.container.textContent ?? "")).toContain("Balanced · moved: the previous provider ran out");
   });
 });

--- a/src/renderer/ModelPicker.test.tsx
+++ b/src/renderer/ModelPicker.test.tsx
@@ -339,4 +339,32 @@ describe("ModelPicker — effort/fast write effort, not a model choice (BET-1274
     expect(autoRow).toBeTruthy();
     expect(autoRow?.textContent ?? "").toContain("Balanced · moved: the previous provider ran out");
   });
+
+  it("after a model choice Auto is off and the dropdown has exactly one selected row (BET-1274 test 1)", () => {
+    // The post-pick UI state (BET-1274 10b): non-Auto + an explicit override.
+    // Auto and Server-default rows are deselected; only the picked model row is.
+    h = mount(
+      <ModelPicker
+        modelLabel={null}
+        models={MODELS}
+        modelOverride={{ providerID: "anthropic", modelID: "claude-opus-4-7" }}
+        defaultModel={null}
+        auto={false}
+        onOpen={() => {}}
+        onSelect={() => {}}
+        onSelectEffort={() => {}}
+      />,
+    );
+    // The chip no longer claims Auto — a plain model name.
+    const btn = h.container.querySelector<HTMLElement>(".manta-model-picker-btn");
+    expect(btn?.textContent ?? "").not.toContain("Auto");
+    expect(btn?.textContent ?? "").toContain("Claude Opus 4.7");
+
+    // Open the dropdown: exactly one row is selected (the picked model).
+    act(() => (btn as HTMLButtonElement).click());
+    const menu = document.body.querySelector<HTMLElement>(".manta-model-dropdown");
+    const selected = [...(menu?.querySelectorAll<HTMLElement>('[role="option"][aria-selected="true"]') ?? [])];
+    expect(selected.length).toBe(1);
+    expect(selected[0].textContent ?? "").toContain("Claude Opus 4.7");
+  });
 });

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -69,6 +69,13 @@ export function ModelPicker({
   // mechanism the picker's own selects use — no second persistence path.
   routed = null,
   onRoutedUndone,
+  // BET-1274 10c: effort (variant) + the ⚡ fast toggle call THIS, not
+  // `onSelect` — writing a variant never changes the ModelChoice kind and
+  // never turns Auto off.
+  onSelectEffort,
+  // BET-1274 10d: the routing preset's display label ("Balanced"), threaded to
+  // the Auto row's sub-line so Auto can name the user's balance setting.
+  presetLabel,
 }: {
   modelLabel: string | null;
   models: OpencodeModel[] | null;
@@ -87,6 +94,10 @@ export function ModelPicker({
   onOptInModel?: (key: string) => void;
   onOpen: () => void;
   onSelect: (m: ModelSelection | null) => void;
+  // BET-1274 10c: kind-preserving effort/fast selection (see above).
+  onSelectEffort: (m: ModelSelection) => void;
+  // BET-1274 10d: the routing preset's display label for the Auto row.
+  presetLabel?: string;
   // Welcome-screen helper for the model button label: shown unconditionally,
   // highest precedence — lets a caller display "Auto" until the user first
   // picks a model. A no-op for callers that don't pass it (ChatPanel).
@@ -157,6 +168,12 @@ export function ModelPicker({
   // active model exposes no variant list the right segment is simply
   // non-interactive (nothing to select).
   const effortDisabled = variants.length === 0;
+  // BET-1274 10g: no resolved model yet (catalog in flight, OR Auto before its
+  // first turn resolved a model) ⇒ the right segment must not claim a value.
+  // "High" is the design's default only for a RESOLVED model that has no
+  // variant list; with no model at all the effort side says "not yet", reusing
+  // the loading treatment rather than inventing a third state.
+  const rightUnresolved = models === null || activeModel === null;
   // Label reflects the user's selected variant; with no selectable variants
   // (or no selection yet) it shows the design's default effort value.
   const effortLabel = activeVariant
@@ -232,7 +249,7 @@ export function ModelPicker({
           )
         }
         right={
-          loading ? (
+          rightUnresolved ? (
             <span className="flex items-center gap-1">
               <SkeletonBar width={30} />
               <ChevronDown size={13} aria-hidden="true" className="shrink-0 text-text-quiet" />
@@ -286,7 +303,7 @@ export function ModelPicker({
           if (!fast.available || !fast.target) return;
           setModelOpen(false);
           setVariantOpen(false);
-          onSelect(fast.target);
+          onSelectEffort(fast.target);
         }}
         extraTitle={loading ? LOADING_TITLE : fast.title}
         extraLabel="Fast mode"
@@ -302,7 +319,7 @@ export function ModelPicker({
         rightExpanded={variantOpen}
         leftTitle={leftTitle}
         rightTitle={
-          loading
+          rightUnresolved
             ? LOADING_TITLE
             : effortDisabled
               ? "This model has no effort / variant setting"
@@ -311,19 +328,23 @@ export function ModelPicker({
       />
 
       {/* Routed pill — the honesty mechanism (BET-1222). When the router set
-          this session's model, show WHY and a one-click undo back to the model
-          the user would have had. The reason never renders without routed: the
-          caller's `routed` state is the only thing that switches this on. */}
+          this session's model, show WHY and, when there is a model it moved
+          away from, a one-click undo back to it. The reason renders whenever
+          `routed` is set (including a first turn with no incumbent — nothing
+          to undo, so no undo action); the undo button renders only when an
+          incumbent exists (BET-1274 10e). */}
       {routed && !loading && (
         <span className="flex items-center gap-2 flex-wrap">
           <span className="text-meta text-text-faint">{routed.reason}</span>
-          <button
-            type="button"
-            onClick={onRoutedUndone}
-            className="font-mono text-meta rounded-full border border-border bg-raised px-3 py-1 text-text-muted hover:bg-fill-hover"
-          >
-            undo · keep {routed.incumbent.providerID}/{routed.incumbent.modelID} here
-          </button>
+          {routed.incumbent && (
+            <button
+              type="button"
+              onClick={onRoutedUndone}
+              className="font-mono text-meta rounded-full border border-border bg-raised px-3 py-1 text-text-muted hover:bg-fill-hover"
+            >
+              undo · keep {routed.incumbent.providerID}/{routed.incumbent.modelID} here
+            </button>
+          )}
         </span>
       )}
 
@@ -345,6 +366,7 @@ export function ModelPicker({
           autoActive={auto}
           onSelectAuto={onSelectAuto}
           autoReason={autoReason ?? undefined}
+          presetLabel={presetLabel}
         />
       )}
 
@@ -357,7 +379,7 @@ export function ModelPicker({
           variants={variants}
           activeModel={activeModel}
           activeVariantId={activeVariantId}
-          onSelect={onSelect}
+          onSelect={onSelectEffort}
           onClose={() => setVariantOpen(false)}
         />
       )}

--- a/src/renderer/ModelPicker.tsx
+++ b/src/renderer/ModelPicker.tsx
@@ -108,8 +108,12 @@ export function ModelPicker({
   autoReason?: string | null;
   // BET-1248: the user re-picking Auto (render the Auto row).
   onSelectAuto?: () => void;
-  // BET-1222 routed state (see above).
-  routed?: { reason: string; incumbent: { providerID: string; modelID: string } } | null;
+  // BET-1222/BET-1274 routed state (see above). `incumbent` null = a first turn
+  // with nothing to undo (the pill renders the reason only).
+  routed?: {
+    reason: string;
+    incumbent: { providerID: string; modelID: string } | null;
+  } | null;
   onRoutedUndone?: () => void;
 }) {
   const [modelOpen, setModelOpen] = useState(false);

--- a/src/renderer/NewSessionScreen.tsx
+++ b/src/renderer/NewSessionScreen.tsx
@@ -1144,6 +1144,11 @@ export function NewSessionScreen({ draftId, onDone }: Props) {
                 // null = clear back to the server default.
                 updateDraft(draftId, { model: m });
               }}
+              onSelectEffort={(m: ModelSelection) => {
+                // No Auto concept on the welcome composer: effort/fast pin the
+                // draft's model with the chosen variant (BET-1274 10c).
+                updateDraft(draftId, { model: m });
+              }}
             />
             <PlanChip
               plan={plan}

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -115,7 +115,6 @@ export const DEMO_UNIMPLEMENTED = [
   "opencodeGetProviders",
   "opencodeGetSubagents",
   "opencodeModelCatalog",
-  "opencodeModelRoute",
   "opencodePermissionReply",
   "opencodePrompt",
   "opencodeQuestionReject",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1060,8 +1060,6 @@ export const httpApi: Api = {
 
   // -- model picker --
   opencodeModels: () => rpc(IPC.opencodeModels),
-  opencodeModelRoute: (incumbent, agent) =>
-    rpc(IPC.opencodeModelRoute, { incumbent, agent }),
   routingChoose: (input) => rpc(IPC.routingChoose, input),
   accountsRetry: (providerID) => rpc(IPC.accountsRetry, { providerID }),
   accountHealth: () => rpc(IPC.accountsHealth),

--- a/src/renderer/chatShared.tsx
+++ b/src/renderer/chatShared.tsx
@@ -249,6 +249,11 @@ export type ModelSelection = { providerID: string; modelID: string; variant?: st
  *                               the stored value.
  * - `{ kind: "server-default" }` — today's `null`: let opencode pick its default.
  *
+ * The `variant` (effort dial) is stored separately from the model identity:
+ * on `model` it rides the `ModelSelection.variant, and the `auto` kind carries
+ * its own optional `variant` (BET-1274 10c — choosing an effort never turns
+ * Auto off, so Auto must be able to carry it).
+ *
  * Kept separate from `ModelSelection` on purpose: widening `ModelSelection` would force
  * every consumer that forwards a model to a provider to re-narrow it.
  */

--- a/src/renderer/hooks/useSseBus.test.tsx
+++ b/src/renderer/hooks/useSseBus.test.tsx
@@ -1091,7 +1091,7 @@ describe("BET-1248 main-conversation routing at boundaries (ChatPanel submit)", 
     expect(promptModelFor("after compact")).toEqual(ROUTED);
   });
 
-  it("routingChoose rejecting → the turn still sends, on the previous model", async () => {
+  it("routingChoose rejecting → the turn still sends, on the previous model, and the error banner says so (BET-1274 test 4)", async () => {
     localStorage.setItem(sessionAutoKey("ses_test"), "1");
     ({ api, bus } = installMockApi({
       routingChoose: () => Promise.reject(new Error("router down")),
@@ -1104,6 +1104,9 @@ describe("BET-1248 main-conversation routing at boundaries (ChatPanel submit)", 
     // A turn was still sent. First turn with no incumbent → server default.
     expect((api.calls.opencodePrompt ?? []).length).toBeGreaterThan(0);
     expect(promptModelFor("hi")).toBeUndefined();
+    // …and it is not silent: the banner tells the user the router was
+    // unreachable rather than letting the chip pretend Auto picked a model.
+    expect(h?.container.textContent ?? "").toContain("Couldn't pick a model");
   });
 
   it("Auto off → routingChoose is never called", async () => {

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -518,10 +518,10 @@ function unroutableError(structured, src) {
  * This wrapper hands `chooseModel` the subagent intent (agent + tool needs +
  * `incumbent` = whatever model the caller would have used today) and returns
  * the model to actually run on. It shares its `chooseModel` argument builder
- * with chooseMainModel below (see buildChooseModelInput) so the main and
- * subagent paths can never diverge again. Note: it is NOT the only module that
- * calls `chooseModel` — rpc.mjs's `routing:choose` calls it directly (it carries
- * a caller-supplied surface + needs). The wrappers share ONE builder; the RPC
+ * with the subagent path's other caller so they can never diverge. Note: it is
+ * NOT the only module that calls `chooseModel` — rpc.mjs's `routing:choose`
+ * calls it directly (it carries a caller-supplied surface + needs). The
+ * wrappers share ONE builder; the RPC
  * builds its own intent for its different surface.
  *
  * Provably safe on the off-path: when the policy has no routing directive (no
@@ -587,14 +587,13 @@ function catalogIncumbentOf(incumbent) {
   return incumbent ? { providerID: incumbent.providerID, id: incumbent.modelID ?? incumbent.id } : null;
 }
 
-// Shared argument-builder for the two routing wrappers (BET-1275 11d).
-// chooseSubagentModel and chooseMainModel MUST hand chooseModel the same intent
-// shape — this is what kept the main-conversation and subagent paths from
-// diverging (they disagreed on `needs.tools` in the real-facts issue). The main
-// path needs a couple of extra fields around the decision, but the chooseModel
-// ARGUMENT is identical. routing:choose in rpc.mjs builds its own intent because
-// it carries a caller-supplied surface + needs; these two server wrappers share
-// this one builder so they cannot diverge again.
+// Shared argument-builder for the subagent routing wrapper (BET-1275 11d).
+// chooseSubagentModel hands chooseModel the same intent shape as the main
+// path did before the mount-time main route was deleted — this is what kept the
+// main-conversation and subagent paths from diverging (they disagreed on
+// `needs.tools` in the real-facts issue). routing:choose in rpc.mjs builds its
+// own intent because it carries a caller-supplied surface + needs, but this
+// subagent wrapper uses this one builder so its own callers cannot diverge again.
 function buildChooseModelInput({ kind, agent, needs, contextTokens, incumbent, catalog, policy, nowMs, services }) {
   return {
     intent: { kind, agent, needs, contextTokens, incumbent: catalogIncumbentOf(incumbent) },
@@ -648,77 +647,6 @@ export function chooseSubagentModel({
     // Routing must never break a spawn — fall back to the incumbent model.
     console.warn("[router] subagent routing failed, using incumbent:", e?.message ?? e);
     return incumbent;
-  }
-}
-
-/**
- * THE other single routing decision point: the user-facing MAIN conversation
- * ("build" agent). Sat beside chooseSubagentModel, sharing its `chooseModel`
- * argument builder (buildChooseModelInput) so the two can never diverge.
- *
- * Unlike the subagent wrapper, which returns only the model the spawn should
- * run on (the spawn is opaque to the user), this returns the FULL decision —
- * the routed `model`, the human-readable `reason`, the `incumbent` it would
- * otherwise have used, and a `changed` flag — so the renderer can (a) apply
- * the routed model to the next prompt's `modelOverride` AND (b) render the
- * routed pill (`ChatPanel.routed`) exposing the reason and offering undo back
- * to the incumbent. That is the honesty contract of the routing epic: a main
- * conversation's model is never switched without a visible, undoable reason.
- *
- * Same safety contract as chooseSubagentModel: a policy with no routing
- * directive / any throw / no survivors all fall back to `incumbent` with
- * `changed: false`, so enabling routing can never substitute a model the user
- * was not shown and can undo.
- *
- * @param {object} [input]
- * @param {object|null} [input.incumbent]  the model the session would use without routing
- * @param {Array<object>} [input.catalog]  opencode model list
- * @param {{ preset?: string, perAgent?: Record<string,string> }} [input.policy]
- * @param {string} [input.agent]           main-conversation agent (default "build")
- * @param {number} [input.nowMs]
- * @returns {{ model: object|null, reason: string, incumbent: object|null, changed: boolean }}
- */
-export function chooseMainModel({
-  incumbent = null,
-  catalog = [],
-  policy = {},
-  agent = "build",
-  nowMs = Date.now(),
-  contextTokens = SUBAGENT_INITIAL_CONTEXT_TOKENS,
-  services,
-} = {}) {
-  const incumbentShape = incumbent
-    ? { providerID: incumbent.providerID, modelID: incumbent.modelID ?? incumbent.id ?? "" }
-    : null;
-  try {
-    const decision = chooseModel(
-      buildChooseModelInput({
-        kind: "main",
-        agent,
-        needs: { tools: true },
-        contextTokens,
-        incumbent,
-        catalog,
-        policy,
-        nowMs,
-        services,
-      }),
-    );
-    const model =
-      decision?.model === catalogIncumbentOf(incumbent)
-        ? incumbent
-        : toDeliverModel(decision?.model ?? incumbent);
-    return {
-      model,
-      reason: decision?.reason ?? "",
-      incumbent: incumbentShape,
-      changed: decision?.changed === true,
-    };
-  } catch (e) {
-    // Routing must never change a main conversation invisibly — and must never
-    // break the send — so any failure falls back to the incumbent.
-    console.warn("[router] main routing failed, using incumbent:", e?.message ?? e);
-    return { model: incumbent, reason: "routing failed", incumbent: incumbentShape, changed: false };
   }
 }
 

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -22,7 +22,6 @@ import {
   effectiveModelFromMessages,
   tickActivity,
   chooseSubagentModel,
-  chooseMainModel,
   resolveNamedModel,
 } from "./delegate.mjs";
 import { familyKey } from "../shared/modelGuide.mjs";
@@ -990,79 +989,6 @@ test("chooseSubagentModel returns the incumbent on an off-path and is load-beari
     }),
     incumbent,
   );
-});
-
-// ----------------------------------------------------------------------------
-// BET-1225 — main-conversation ("build") routing decision
-// ----------------------------------------------------------------------------
-
-test("chooseMainModel returns the FULL decision — model, reason, incumbent — and normalises the winner to {providerID, modelID} (BET-1225)", () => {
-  const catalog = [
-    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),     // deep
-    normalize("anthropic", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4" })),   // balanced
-    normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4" })),    // fast
-  ];
-  const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
-  const decision = chooseMainModel({
-    incumbent,
-    catalog,
-    policy: { preset: "economy" }, // economy + build → balanced floor
-    quota: [],
-    agent: "build",
-    nowMs: 1_700_000_000_000,
-    services: routingServicesFor(catalog),
-  });
-  // The main-conversation decision is richer than the subagent wrapper: the
-  // renderer needs the model, a reason, and the incumbent for the undo pill.
-  assert.equal(decision.changed, true);
-  assert.equal(decision.model?.providerID, "anthropic");
-  assert.equal(decision.model?.modelID, "claude-sonnet-4", "build under economy must land on the balanced-tier floor");
-  assert.equal("id" in decision.model, false, "the routed model must carry modelID, not the catalog's id");
-  assert.match(decision.reason, /build → balanced tier/, "reason names the build agent and tier");
-  assert.deepEqual(decision.incumbent, incumbent, "incumbent is preserved for the undo pill");
-});
-
-test("chooseMainModel on the off-path returns the incumbent with changed:false, never a hidden switch (BET-1225)", () => {
-  const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
-  const catalog = [
-    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),
-    normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4" })),
-  ];
-  // routing not activated (no preset) → no switch, even though a cheaper fast model exists
-  const off = chooseMainModel({ incumbent, catalog, policy: {}, agent: "build", nowMs: 0 });
-  assert.equal(off.changed, false);
-  assert.deepEqual(off.model, incumbent);
-  assert.equal(off.reason, "routing not activated for this conversation");
-  // an activated router with no survivors (all dead) still falls back to incumbent
-  const noSurvivors = chooseMainModel({
-    incumbent,
-    catalog: [normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4", status: "retired" }))],
-    policy: { preset: "economy" },
-    agent: "build",
-    nowMs: 0,
-  });
-  assert.equal(noSurvivors.changed, false);
-  assert.deepEqual(noSurvivors.model, incumbent);
-});
-
-test("chooseMainModel when the router picks the same model reports changed:false (BET-1225)", () => {
-  // deep incumbent + performance preset → build stays deep → same model, no pill.
-  const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
-  const catalog = [
-    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),
-    normalize("anthropic", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4" })),
-  ];
-  const decision = chooseMainModel({
-    incumbent,
-    catalog,
-    policy: { preset: "performance" },
-    quota: [],
-    agent: "build",
-    nowMs: 0,
-  });
-  assert.equal(decision.changed, false, "no model was substituted → the pill must not render");
-  assert.deepEqual(decision.model, incumbent);
-  assert.deepEqual(decision.incumbent, incumbent);
 });
 
 // ----------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -455,7 +455,7 @@ providerHealth.deliverSnapshots(listSnapshots());
 // BET-1252: the box's model catalogue (provider-agnostic, for routing
 // identity/quality). Starts the page poller (immediate first tick, inFlight
 // guard, timer.unref()) and exposes its controller as the routing catalogue
-// index both production callers (delegate startJob + rpc routing:main) build
+// index the production callers (delegate startJob + rpc routing:choose) build
 // their RoutingServices from. Degrades to an empty catalogue until the first
 // successful fetch — routing treats that as "models unidentifiable" and falls
 // back to the incumbent, never an error.
@@ -857,7 +857,7 @@ rpcHandlers = buildHandlers({
   serverVersion: SERVER_VERSION,
   opencodeVersion: OPENCODE_VERSION,
   delegate: delegateEngine,
-  // BET-1252: routing-services readers shared with delegate (the routing:main
+  // BET-1252: routing-services readers shared with delegate (the routing:choose
   // channel). Same degradation contract:
   // absent readers ⇒ absent services ⇒ the router returns the incumbent.
   routingCatalogIndex,

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -74,10 +74,9 @@ const DEFAULT_CONFIG = {
   // Lets a self-hosted GitHub/GitLab instance (which `detectForge` deliberately
   // rejects) resolve to its forge + API root. `kind` is "github" | "gitlab".
   forgeHosts: [],
-  // Model routing (BET-1215): pick the cheapest model that clears the floor.
-  // Off by default (hard requirement — routing acts on the user's behalf, so
-  // it is opt-in, matching chatAutoAllow / pluginsEnabled). Config-only in
-  // this issue; no behaviour change until the router wiring issue reads it.
+  // Model routing (BET-1215): the balance dial for Automatic Manta Routing.
+  // Auto's on/off switch is the composer's per-conversation model picker, not
+  // this block — there is no config gate that turns routing on/off globally.
   modelRouting: {
     preset: "balanced",
   },

--- a/src/server/routingServices.mjs
+++ b/src/server/routingServices.mjs
@@ -5,8 +5,8 @@
 // object that the WIRING must construct from live box readers — the model
 // catalogue, provider health, usage snapshots (accounts), and the endpoint
 // ledger (reliability / telemetry / mix). This is that assembly, and it is the
-// single source of truth for BOTH production callers (delegate startJob and
-// rpc routing:main) so the subagent and main-conversation paths share one
+// single source of truth for the production callers (delegate startJob and
+// rpc routing:choose) so the subagent and main-conversation paths share one
 // build ("one code path").
 //
 // Safety contract — every reader is OPTIONAL and individually guarded. The

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -34,7 +34,7 @@ import { resolveWorkspace } from "./peers.mjs";
 import * as providers from "./providers.mjs";
 import * as launchers from "./launchers.mjs";
 import * as subscriptionProviders from "./subscriptionProviders.mjs";
-import { chooseMainModel, toDeliverModel } from "./delegate.mjs";
+import { toDeliverModel } from "./delegate.mjs";
 import { buildRoutingServices } from "./routingServices.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { pollClaudeLogin, claudeCliStatus, listRoutableModels } from "./opencode.mjs";
@@ -812,69 +812,8 @@ export function buildHandlers({
       return oc.listModels(cfg.modelOverrides ?? {});
     },
 
-    // BET-1225: main-conversation ("build" agent) routing decision. ChatPanel
-    // asks once at session start; the decision runs through the shared
-    // chooseMainModel wrapper (delegate.mjs), so the routed pill reflects the
-    // same decision the send path would apply. Returns the full decision
-    // { model, reason, incumbent, changed } so the renderer can apply the
-    // routed model AND surface the undoable pill. Every input is guarded —
-    // missing policy / quota / catalog must never throw and falls back to the
-    // incumbent (a conversation that did not ask to route).
-    "routing:main": async (input) => {
-      const incumbent = input?.incumbent ?? null;
-      const agent = input?.agent ?? "build";
-      let cfg = {};
-      let quota = [];
-      let catalog = [];
-      try {
-        cfg = (await local.configGet()) ?? {};
-      } catch {
-        cfg = {};
-      }
-      const policy = cfg?.modelRouting ?? {};
-      try {
-        quota = usageListSnapshots();
-        if (!Array.isArray(quota)) quota = [];
-      } catch {
-        quota = [];
-      }
-      // BET-1253: the FILTERED catalogue for the "main" surface. Use the same
-      // routingListRoutableModels seam routing:choose does — the ONE place
-      // routing consent is computed — never a second filter, never raw
-      // listModels. Otherwise routing:main could route a main conversation onto
-      // a model the user deactivated/retired (which routing:choose excludes).
-      try {
-        catalog = await routingListRoutableModels("main", cfg);
-        if (!Array.isArray(catalog)) catalog = [];
-      } catch {
-        catalog = [];
-      }
-      // BET-1252: assemble the routing-services context from live box state.
-      // Build is guarded (every reader degrades to absent) and the whole wrap
-      // degrades to null services → the router returns the incumbent unchanged,
-      // so a routing failure can never change a conversation invisibly.
-      let services = null;
-      try {
-        services = await buildRoutingServices(cfg, {
-          catalogIndex: routingCatalogIndex,
-          endpoints: catalog,
-          snapshots: quota,
-          providerHealthState: routingProviderHealthState,
-          endpointSummary: routingEndpointSummary,
-        });
-      } catch (e) {
-        // 11e: a silently-degrading services build is how "no model passes
-        // constraints (identity)" hides. Never fatal — routing degrading is
-        // correct, degrading silently is not.
-        console.error(`[router] routing services degraded, routing on absent context: ${e?.message ?? e}`);
-        services = null;
-      }
-      return chooseMainModel({ incumbent, catalog, policy, agent, nowMs: Date.now(), services });
-    },
-
     // BET-1244: the read-only, side-effect-free routing decision — the generic
-    // sibling of routing:main (which decides the main conversation's model at
-    // session start). Unlike routing:main it takes the SURFACE explicitly
+    // routing decision for a surface. It takes the SURFACE explicitly
     // ("main" | "sub"), so the same single decision core (chooseModel — the one
     // the subagent path calls) can answer for either, and returns the decision
     // VERBATIM: { model, reason, alternatives, changed }. No state is written,
@@ -932,7 +871,7 @@ export function buildHandlers({
         }
         // Normalise the incumbent into catalog shape ({providerID, id}) so the
         // `changed` comparison inside chooseModel treats a requested model and
-        // a catalog entry of the same model as equal (mirrors chooseMainModel).
+        // a catalog entry of the same model as equal.
         const catalogIncumbent = incumbent
           ? { providerID: incumbent.providerID, id: incumbent.modelID ?? incumbent.id }
           : null;

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -1324,42 +1324,6 @@ test("routing:choose is handed the filtered catalogue for the requested surface 
   assert.deepEqual(out.alternatives, out.alternatives.filter((a) => a && a.modelID), "alternatives are well-formed {providerID, modelID}");
 });
 
-// BET-1253: routing:main must be handed the same FILTERED catalogue for the
-// "main" surface that routing:choose uses — not the raw connected listModels.
-// Two entry points for one surface must resolve the same routable set, or a
-// main conversation could be routed onto a model the user deactivated/retired.
-test("routing:main is handed the filtered catalogue for the main surface (not listModels)", async () => {
-  const { deps } = makeDeps([]);
-  // Config that ACTIVATES routing so the decision core runs against the
-  // returned catalogue.
-  deps.local.configGet = async () => ({ projects: [], modelRouting: { preset: "economy" } });
-  let surfaceSeen = null;
-  let cfgSeen = null;
-  let calls = 0;
-  deps.routingListRoutableModels = async (surface, cfg) => {
-    surfaceSeen = surface;
-    cfgSeen = cfg;
-    calls++;
-    return [
-      { providerID: "anthropic", id: "claude-opus-4", status: "active" },
-      { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },
-      { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
-    ];
-  };
-  const handlers = buildHandlers(deps);
-  const out = await handlers["routing:main"]({
-    incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
-    agent: "build",
-  });
-  assert.equal(calls, 1);
-  assert.equal(surfaceSeen, "main", "routing:main must request the filtered catalogue for the main surface");
-  assert.equal(cfgSeen?.modelRouting?.preset, "economy", "routing:main passes the config through to the seam");
-  // A real decision was produced from the injected (filtered) catalogue — a
-  // selected model normalised into {providerID, modelID}.
-  assert.equal(out.model?.providerID, "anthropic");
-  assert.ok(typeof out.model?.modelID === "string" && out.model.modelID.length > 0);
-});
-
 // BET-1265: routing:choose emits exactly one `[router]` line (the box-side
 // signal that routing ran) whenever an activated routing decision is made.
 // Format: [router] <surface>/<agent> → <provider>/<model> · <basis> ·

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -91,19 +91,8 @@ import type {
 import type { ClaimOutcome } from "./claim.mjs";
 
 type PromptModel = { providerID: string; modelID: string; variant?: string };
-// BET-1225: the server-side main-conversation routing decision, returned by
-// opencodeModelRoute. `model` is the router's chosen model to apply to the
-// next prompt; `reason` is why (shown on the routed pill); `incumbent` is the
-// model it replaced (what undo reverts to); `changed` is whether a substitution
-// actually happened (false on routing-off / failure / no-op).
-type ModelRouteDecision = {
-  model: PromptModel | null;
-  reason: string;
-  incumbent: PromptModel | null;
-  changed: boolean;
-};
 // BET-1244: the generic, read-only routing decision (`routing:choose`) — the
-// sibling of ModelRouteDecision that carries no `incumbent` but adds
+// routing decision carries no `incumbent` but adds
 // `alternatives` (the next-best candidates a surface can offer). `model` stays
 // null on routing-off / no-survivors / failure; `changed` is false whenever no
 // substitution is offered. Never throws: on an internal failure the server
@@ -437,15 +426,6 @@ export interface Api {
 
   // Model picker.
   opencodeModels(): Promise<OpencodeModel[]>;
-  // BET-1225: fetch the server's main-conversation routing decision for the
-  // session at start, so the renderer can apply the routed model and render
-  // the undoable routed pill. `incumbent` is the model the session would use
-  // without routing (the user's per-session pick or the persisted default).
-  // Returns null on the demo/no-op transport (routing is never exercised).
-  opencodeModelRoute(
-    incumbent: PromptModel | null,
-    agent?: string,
-  ): Promise<ModelRouteDecision | null>;
   // BET-1244: the read-only, side-effect-free routing decision for either
   // surface ("main" | "sub"), resolved by the SAME decision core the subagent
   // path uses. No state is written and no prompt is sent. Never throws — on

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -283,11 +283,9 @@ export type AppConfig = {
     alwaysListening?: boolean;
   };
   // ----- Model routing (BET-1215) -----
-  // Manta picks the cheapest model that still clears the quality floor for a
-  // given kind of work, instead of always using the default. Off by default
-  // (hard requirement — routing acts on the user's behalf, so it is opt-in,
-  // matching chatAutoAllow / pluginsEnabled). Config-only in this issue; the
-  // router wiring issue reads this into the router's `policy` argument.
+  // Manta picks the model for a conversation while Auto is on (the per-session
+  // gate). Config carries the balance dial; the Auto on/off switch is the
+  // composer's model picker, never this block.
   modelRouting?: {
     // Three-way balance dial. Default "balanced".
     preset: "economy" | "balanced" | "performance";
@@ -1357,8 +1355,6 @@ export const IPC = {
   // Model picker: list available models on the remote opencode server (with
   // provider secrets stripped before forwarding).
   opencodeModels: "opencode:models",
-  // BET-1225: main-conversation routing decision at session start.
-  opencodeModelRoute: "routing:main",
   // BET-1244: generic read-only routing decision for either surface (main|sub).
   routingChoose: "routing:choose",
   // BET-1244: Accounts "Try again" — clear a provider's out-of-credit flag.


### PR DESCRIPTION
## BET-1274 — Routing: the composer never lies about Auto, and the off switch actually works

Rebased onto `origin/main @ a75a35f` (was `0d6ffab`) and reconciled with **BET-1281** (box-backed model prefs) and **BET-1269** (server cost stage), which landed on main since the branch was cut. PR is now mergeable (reviewer stale-base Block resolved). Net for this branch: `+200 −390` across the same 7 sub-issues.

### What changed (10a–10g)

**10a — no mount-time route.** Deleted the mount `opencodeModelRoute`/`routing:main` RPC and `chooseMainModel` end to end (rpc.mjs, delegate.mjs, types.ts, api.ts, httpApi.ts, demo-coverage, comments). `grep -rn "routing:main\|opencodeModelRoute\|chooseMainModel" src/` is clean.

**10b — picking a model turns Auto off.** `selectModel` now also clears `autoActive` → the chip stops saying Auto in the same commit. Deleted the defensive storage re-read in `submit()`. **Storage now goes through BET-1281's box-backed path** (`setSessionChoice` → box model-prefs + device-local Auto flag), not a re-introduced localStorage copy.

**10c — effort/⚡ write effort, not a model choice.** New kind-preserving `onSelectEffort`: under a pinned model it merges the variant into the box record; server-default pins; **under Auto there is no effort slot** — BET-1287 (the doc landed on main) made Auto a device-local *boolean* with no model/effort value, so "Auto at high effort" is not representable. Per the issue's escape hatch I did not invent a slot: under Auto the effort applies to the current in-memory routed model only, and Auto is never exited.

**10d — Auto row names the Balance preset.** `presetLabel` (titleCased `modelRouting.preset` from the store) threaded through to the Auto row's sub-line.

**10e — the primary routing path has a reason pill + working undo.** `applyRouted` (sole producer of `routed`) records the incumbent; first turn renders the reason with no undo. `undoRouted` simplified.

**10f — routing failure says something.** The turn still sends; a rejected `routingChoose` raises `"Couldn't pick a model — sent on the default. Auto will try again next turn."`

**10g — effort no longer claims "High" for an unresolved model.** Reuses the loading treatment.

### Reconciliation with BET-1281 (what changed during the rebase)
- Dropped the renderer's `readSavedChoice`/`writeSavedChoice`/`writeSavedModel`/`modelKey` and the `{kind:"auto"; variant?}` slot from `chatShared.tsx` — BET-1281 removed those (box-backed). `selectModel`/`onSelectAuto`/`onSelectEffort` now call `setSessionChoice`.
- `applyRouted` carries the user's current in-memory effort instead of a stored auto-variant.
- Harness + useSseBus tests now drive the device-local Auto flag (`sessionAutoKey`) and live-mount real dropdowns.

### Verification results
- PR branch (`multica/BET-1274-routing-composer-auto` @ `fb237bed`): typecheck exit 0; vitest **3496** pass / 7 skip; server **2676** pass / 0 fail. **0 new failures** vs `main`.
- Acceptance #4 (grep `routing:main|opencodeModelRoute|chooseMainModel` → nothing) holds.
- All six requested test scenarios are present.

**Base: origin/main @ `a75a35f`** (rebase target; PR `mergeable`).
