### PR TITLE
Routing: migrate remaining hand-built test fixtures to the real _normalizeProviderModel (BET-1284)

### DIFF
--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -607,8 +607,8 @@ test("startJob survives a throwing listSnapshots and delivers the incumbent (BET
 
 test("chooseSubagentModel routes an explore agent to a fast-tier model when the conversation activates routing (BET-1220)", () => {
   const catalog = [
-    { providerID: "anthropic", id: "claude-opus-4", status: "active" },   // deep
-    { providerID: "anthropic", id: "claude-haiku-4", status: "active" }, // fast
+    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),   // deep
+    normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4" })), // fast
   ];
   const chosen = chooseSubagentModel({
     incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
@@ -639,9 +639,9 @@ test("startJob with routing on normalises the catalog winner to a {providerID, m
   h.deps.configGet = async () => ({ modelRouting: { preset: "economy" } });
   h.deps.listSnapshots = () => [];
   const models = [
-    { providerID: "anthropic", id: "claude-opus-4", status: "active" },   // deep
-    { providerID: "anthropic", id: "claude-sonnet-4", status: "active" }, // balanced
-    { providerID: "anthropic", id: "claude-haiku-4", status: "active" },  // fast
+    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),   // deep
+    normalize("anthropic", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4" })), // balanced
+    normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4" })),  // fast
   ];
   h.deps.listModels = async () => models;
   h.deps.routingServices = routingServicesFor(models);
@@ -671,10 +671,10 @@ test("startJob routes to a non-incumbent model from live routing readers (BET-12
   const models = [
     // openai/gpt-5 is the CHEAPEST — but the health reader reports it
     // rate-limited, so it must be excluded from the decision.
-    { providerID: "openai", id: "gpt-5", status: "active", cost: { input: 0.1, output: 0.4, cacheRead: 0.05, cacheWrite: 0.15 }, capabilities: { toolcall: true } },
-    { providerID: "anthropic", id: "claude-opus-4", status: "active", cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 22.5 }, capabilities: { reasoning: true, toolcall: true } },
-    { providerID: "anthropic", id: "claude-sonnet-4", status: "active", cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 4.5 }, capabilities: { reasoning: true, toolcall: true } },
-    { providerID: "anthropic", id: "claude-haiku-4", status: "active", cost: { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1.5 }, capabilities: { toolcall: true } },
+    normalize("openai", "gpt-5", rawProviderModel({ id: "gpt-5", cost: { input: 0.1, output: 0.4, cache: { read: 0.05, write: 0.15 } }, capabilities: { toolcall: true } })),
+    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4", cost: { input: 15, output: 75, cache: { read: 1.5, write: 22.5 } }, capabilities: { reasoning: true, toolcall: true } })),
+    normalize("anthropic", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4", cost: { input: 3, output: 15, cache: { read: 0.3, write: 4.5 } }, capabilities: { reasoning: true, toolcall: true } })),
+    normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4", cost: { input: 1, output: 5, cache: { read: 0.1, write: 1.5 } }, capabilities: { toolcall: true } })),
   ];
   h.deps.listModels = async () => models;
   // Live-style readers (NOT a pre-built routingServices).
@@ -717,8 +717,8 @@ test("startJob routes to the non-deranked sibling when an endpoint is reliabilit
     // tie-break winner, but its endpoint has a bad tool-call rate → it must be
     // reliability-penalised and lose to openai's clean copy. This pins that the
     // ledger's derank actually swings the outcome, not the model-id tie-break.
-    { providerID: "anthropic", id: "claude-sonnet-4", status: "active", cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 4.5 }, capabilities: { reasoning: true, toolcall: true } },
-    { providerID: "openai", id: "claude-sonnet-4", status: "active", cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 4.5 }, capabilities: { reasoning: true, toolcall: true } },
+    normalize("anthropic", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4", cost: { input: 3, output: 15, cache: { read: 0.3, write: 4.5 } }, capabilities: { reasoning: true, toolcall: true } })),
+    normalize("openai", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4", cost: { input: 3, output: 15, cache: { read: 0.3, write: 4.5 } }, capabilities: { reasoning: true, toolcall: true } })),
   ];
   h.deps.listModels = async () => models;
   const cat = (id) => ({ id, family: "sonnet" });
@@ -777,10 +777,10 @@ test("startJob routes only within the consent (sub) catalogue (BET-1229)", async
   });
   h.deps.listSnapshots = () => [];
   const models = [
-    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
-    { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },
-    { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
-    { providerID: "openai", id: "gpt-5", status: "active" },
+    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),
+    normalize("anthropic", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4" })),
+    normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4" })),
+    normalize("openai", "gpt-5", rawProviderModel({ id: "gpt-5" })),
   ];
   h.deps.listModels = async () => models;
   h.deps.routingServices = routingServicesFor(models);
@@ -802,8 +802,8 @@ test("startJob routes only within the consent (sub) catalogue (BET-1229)", async
 test("chooseSubagentModel returns the incumbent on an off-path and is load-bearing (BET-1220)", () => {
   const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
   const catalog = [
-    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
-    { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
+    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),
+    normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4" })),
   ];
   // routing not activated (no preset) → incumbent unchanged even though a cheaper fast model exists
   assert.deepEqual(
@@ -814,7 +814,7 @@ test("chooseSubagentModel returns the incumbent on an off-path and is load-beari
   assert.deepEqual(
     chooseSubagentModel({
       incumbent,
-      catalog: [{ providerID: "anthropic", id: "claude-opus-4", status: "retired" }],
+      catalog: [normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4", status: "retired" }))],
       policy: { preset: "economy" },
       agent: "explore",
       nowMs: 0,
@@ -829,9 +829,9 @@ test("chooseSubagentModel returns the incumbent on an off-path and is load-beari
 
 test("chooseMainModel returns the FULL decision — model, reason, incumbent — and normalises the winner to {providerID, modelID} (BET-1225)", () => {
   const catalog = [
-    { providerID: "anthropic", id: "claude-opus-4", status: "active" },     // deep
-    { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },   // balanced
-    { providerID: "anthropic", id: "claude-haiku-4", status: "active" },    // fast
+    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),     // deep
+    normalize("anthropic", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4" })),   // balanced
+    normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4" })),    // fast
   ];
   const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
   const decision = chooseMainModel({
@@ -856,8 +856,8 @@ test("chooseMainModel returns the FULL decision — model, reason, incumbent —
 test("chooseMainModel on the off-path returns the incumbent with changed:false, never a hidden switch (BET-1225)", () => {
   const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
   const catalog = [
-    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
-    { providerID: "anthropic", id: "claude-haiku-4", status: "active" },
+    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),
+    normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4" })),
   ];
   // routing not activated (no preset) → no switch, even though a cheaper fast model exists
   const off = chooseMainModel({ incumbent, catalog, policy: {}, agent: "build", nowMs: 0 });
@@ -867,7 +867,7 @@ test("chooseMainModel on the off-path returns the incumbent with changed:false, 
   // an activated router with no survivors (all dead) still falls back to incumbent
   const noSurvivors = chooseMainModel({
     incumbent,
-    catalog: [{ providerID: "anthropic", id: "claude-opus-4", status: "retired" }],
+    catalog: [normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4", status: "retired" }))],
     policy: { preset: "economy" },
     agent: "build",
     nowMs: 0,
@@ -880,8 +880,8 @@ test("chooseMainModel when the router picks the same model reports changed:false
   // deep incumbent + performance preset → build stays deep → same model, no pill.
   const incumbent = { providerID: "anthropic", modelID: "claude-opus-4" };
   const catalog = [
-    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
-    { providerID: "anthropic", id: "claude-sonnet-4", status: "active" },
+    normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4" })),
+    normalize("anthropic", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4" })),
   ];
   const decision = chooseMainModel({
     incumbent,

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -3,6 +3,13 @@ import { chooseModel, AGENT_TIER, PRESETS, type RoutingServices } from "./modelR
 import { endpointKey } from "./endpointKey.mjs";
 import { tierRank } from "./modelGuide.mjs";
 import { AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
+// Standing rule 9: a routing test may not hand-write a candidate literal.
+// Build every candidate through the REAL normaliser (the same seam the
+// BET-1267 cases use) so the fixtures can never drift from what production
+// actually produces.
+// @ts-expect-error — server module has no .d.mts; _normalizeProviderModel is
+// the canonical OpencodeModel producer every routed test builds through.
+import { _normalizeProviderModel } from "../server/opencode.mjs";
 
 // A catalogue entry field that forces a precise, known quality score so tests
 // control the tier band deterministically. qualityScore's benchmark path wins
@@ -11,20 +18,40 @@ const CHECK = { name: "SWE-Bench Verified", score: 0.5 };
 
 const TIER_SCORE: Record<string, number> = { fast: 0.25, balanced: 0.55, deep: 0.85 };
 
-type EndpointOver = Record<string, unknown> & { providerID?: string; tier?: string; score?: number };
+type EndpointOver = Record<string, unknown> & {
+  providerID?: string;
+  tier?: string;
+  score?: number;
+  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  capabilities?: { toolcall?: boolean; input?: Array<string> | Record<string, boolean> };
+};
 type Endpoint = Record<string, unknown>;
 
+// The intended benchmark quality per endpoint, keyed by endpointKey. Quality
+// is a catalogue SERVICE input (the benchmark a given model posts), never a
+// field on the candidate — so it lives here, looked up from the normalised
+// candidate's providerID/id exactly as production's catalogue lookup does,
+// instead of being hand-stamped onto the candidate object.
+const SCORES = new Map<string, number>();
+
+// Build one candidate through the real normaliser fed a raw `/provider`
+// payload, so a fixture can never quietly disagree with what the box produces.
 function endpoint(id: string, over: EndpointOver = {}): Endpoint {
-  const { providerID = "p", tier = "balanced", score, ...rest } = over;
-  return {
-    providerID,
+  const { providerID = "p", tier = "balanced", score, cost, capabilities, ...rest } = over;
+  const key = `${providerID}/${id}`;
+  SCORES.set(key, score ?? TIER_SCORE[tier]);
+  const raw = {
     id,
     status: "active",
-    cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0.5 },
-    capabilities: { toolcall: true, input: { image: true, pdf: true } },
-    _score: score ?? TIER_SCORE[tier],
+    cost: cost
+      ? { input: cost.input, output: cost.output, cache: { read: cost.cacheRead, write: cost.cacheWrite } }
+      : { input: 1, output: 2, cache: { read: 0.5, write: 0.5 } },
+    capabilities: { toolcall: true, input: ["image", "pdf"], ...capabilities },
     ...rest,
   };
+  const m = _normalizeProviderModel(providerID, id, raw);
+  if (!m) throw new Error(`candidate ${providerID}/${id} failed to normalise`);
+  return m;
 }
 
 function defaultDeclared(catalog: Endpoint[]): Record<string, { catalogId: string }> {
@@ -41,7 +68,7 @@ type RouteOpts = {
 
 function route({ catalog, policy, intent = {}, services: extra = {}, nowMs = 0 }: RouteOpts) {
   const services: RoutingServices = {
-    catalogEntryFor: (c: any) => ({ benchmarks: [{ ...CHECK, score: c?._score }] }),
+    catalogEntryFor: (c: any) => ({ benchmarks: [{ ...CHECK, score: SCORES.get(endpointKey(c)) ?? CHECK.score }] }),
     qualityField: { benchmarkPercentile: (_n: string, s: any) => s },
     declared: defaultDeclared(catalog),
     accounts: {},

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -22,7 +22,7 @@ type EndpointOver = Record<string, unknown> & {
   providerID?: string;
   tier?: string;
   score?: number;
-  cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+  cost?: { input: number; output: number; cacheRead?: number; cacheWrite?: number };
   capabilities?: { toolcall?: boolean; input?: Array<string> | Record<string, boolean> };
 };
 type Endpoint = Record<string, unknown>;

--- a/src/shared/routingBoundary.test.ts
+++ b/src/shared/routingBoundary.test.ts
@@ -5,6 +5,11 @@ import { endpointKey } from "./endpointKey.mjs";
 // boundary normaliser whose OUTPUT shape is exactly what the renderer hands
 // shouldSwitch on both sides (the bug this file pins).
 import { toDeliverModel } from "../server/delegate.mjs";
+// Standing rule 9: build the incumbent in the real canonical model shape, not
+// a hand-written literal — cross the boundary with what production produces.
+// @ts-expect-error — server module has no .d.mts; _normalizeProviderModel is
+// the canonical OpencodeModel producer.
+import { _normalizeProviderModel } from "../server/opencode.mjs";
 
 /**
  * A routed endpoint in the shape PRODUCTION actually produces across the RPC
@@ -18,11 +23,20 @@ function ep(providerID: string, id: string): { providerID: string; modelID: stri
   return out;
 }
 
-// An incumbent endpoint in the model shape crossesBoundary now reads for its
-// declared modalities (via acceptsModality) — { capabilities.input } like an
-// OpencodeModel — NOT a pre-computed array. Unknown input ([]) = allow.
+// An incumbent endpoint in the model shape crossesBoundary reads for its
+// declared modalities (via acceptsModality) — { capabilities.input } on the
+// canonical OpencodeModel, built through the REAL normaliser. Unknown input
+// ([]) = allow.
 function incumbentModel(input: string[]): object {
-  return { capabilities: { input } };
+  const raw = {
+    id: "m",
+    status: "active",
+    cost: { input: 1, output: 2, cache: { read: 0.5, write: 0.5 } },
+    capabilities: { toolcall: true, input },
+  };
+  const m = _normalizeProviderModel("p", "m", raw);
+  if (!m) throw new Error("incumbent model failed to normalise");
+  return m;
 }
 
 const followUp = {


### PR DESCRIPTION
Migrate the remaining hand-built routing test fixtures to the real `_normalizeProviderModel` (epic standing rule 9).

**Files changed:** 3 files. `[src/shared/modelRouter.test.ts, src/server/delegate.test.mjs, src/shared/routingBoundary.test.ts]`

- **`src/shared/modelRouter.test.ts`**: the `endpoint()` fixture helper now builds every candidate through `_normalizeProviderModel` fed a raw `/provider` payload, instead of a hand-written literal. The intended quality score (which used to be hand-stamped on the candidate as `_score`) moves to a catalogue benchmark keyed by `endpointKey` — a service input, looked up exactly as production's catalogue lookup does, never a field on the candidate.
- **`src/server/delegate.test.mjs`**: all `chooseSubagentModel` / `chooseMainModel` / `startJob` routing catalog entries now build through `rawProviderModel` + `normalize` (the same pattern the BET-1267 cases already used). This covers the BET-1220/1225/1229/1252 routing tests.
- **`src/shared/routingBoundary.test.ts`**: `ep()` keeps `toDeliverModel` (a real producer). The `incumbentModel` modality fixtures are now full canonical `OpencodeModel`s built through `_normalizeProviderModel` (their `capabilities.input` array preserved, so `[]` still reads as "unknown = allow").

Behavior-neutral test hygiene: no production code changed.

**Base: origin/main @ `0d6ffab5`**

**Verification results:**
- PR branch (`multica/BET-1284-normalize-model-fixtures` @ `75d513ea`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`. Vitest `3480` pass / `7` skip / `0` fail (184 files); node:test `2668` pass / `0` fail (71 suites). Failures: none. log sha256: `6c67e6118ba504ecca2d2335fa55bec51f848a2d1ecb2cc0c5301c460c5fed80`
- Base (`main` @ `0d6ffab5`): no production code changed by this PR, so behaviorally equivalent to main (which was green before this change; the change is confined to test files).
- **Conclusion:** `0` new failures. This is a test-fixture-only, behavior-neutral migration; the full suite and typecheck are green on the PR branch.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log` for reviewer spot-check.
