### PR TITLE
docs(renderer): state Option-A end state for desktop-local Auto (BET-1287)

### DIFF
--- a/src/renderer/modelPrefs.ts
+++ b/src/renderer/modelPrefs.ts
@@ -13,6 +13,12 @@
 // (absence = server default). It has no slot for the desktop "Auto" routing mode
 // (BET-1245), so Auto's flag stays device-local OUTSIDE `manta:chat:` (that
 // namespace is now box-backed; the DoD grep only admits the plan key there).
+// DECIDED END STATE (BET-1287, Option A): Auto is desktop-local BY DESIGN, not a
+// transient split. `kind:"auto"` means the MantaUI ROUTER on this device picks
+// the model, and only the desktop runs that router — the box, iOS and any other
+// client have no router to run, so a box-side `auto` mode would be a value
+// nothing else honors. A second device showing SERVER-DEFAULT for an Auto
+// session is therefore correct, not a bug; do not reconcile it box-side.
 
 import { useEffect, useMemo, useState } from "react";
 import type {
@@ -86,6 +92,9 @@ export function useModelPrefs(): ModelPrefsState {
 // The box cannot represent Auto, so it lives in a short device-local key.
 // Deliberately NOT `manta:chat:`: that namespace is box-backed now, and the
 // one-shot migration scans it for concrete models only. See the header comment.
+// DECIDED END STATE (BET-1287, Option A): Auto is desktop-local by design — only
+// the desktop runs the MantaUI router; a second device showing server-default
+// for an Auto session is correct, not a bug. See the header comment.
 export function sessionAutoKey(sessionId: string): string {
   return `manta:model-auto:${sessionId}`;
 }


### PR DESCRIPTION
## What

Comment-only edit to `src/renderer/modelPrefs.ts` making the Option-A decision explicit so a future reader does not triangulate the two sinks (box store + device-local Auto flag) as a latent divergence and try to reconcile them box-side.

- **Header comment**: added a block stating Auto is desktop-local BY DESIGN (BET-1287, Option A) — only the desktop runs the MantaUI router; a box-side `auto` mode would be a wire value nothing else honors; a second device showing server-default for an Auto session is correct, not a bug.
- **`sessionAutoKey` block**: added the same one-liner cross-referencing the header.

## No changes

No behavior, no schema, no key shape, no box store (`src/server/modelPrefs.mjs`), no `src/shared/types.ts`, no iOS client.

Base: `origin/main` @ `af85bb3b`

**Files changed:** 1 file. `src/renderer/modelPrefs.ts`

**Verification results:**
- PR branch (`multica/BET-1287-model-auto-doc` @ `6a3b5596`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, `2675` pass / `0` fail / `0` skip. Failures: none. log sha256: `295c1669256529193ed8a75c0080284a9c8e1a8c61b012a07ebc5f731313307e`
- Base (`main` @ `af85bb3b`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, `2676` pass / `0` fail / `0` skip. Failures: none. log sha256: `acc3790526585590e2d1f6ea79800c52eae4c210b6651e2e3841efac0bcec470`
- **Conclusion:** 0 test failures, 0 new. The 1-count delta (2675 vs 2676) is test-enumeration noise — the diff is comment-only, no test code changed.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
