### PR TITLE
Routing: the cost stage — measured mix, real reference, no list price for a subscription (BET-1269)

### DIFF
--- a/src/server/accountDescriptors/openrouter.json
+++ b/src/server/accountDescriptors/openrouter.json
@@ -1,9 +1,10 @@
 {
   "id": "openrouter",
   "providerIDs": ["openrouter"],
+  "kind": "credit",
   "url": "https://openrouter.ai/api/v1/credits",
   "auth": "bearer",
-  "balance": { "path": "data.total_credits", "units": "dollars", "sign": "positive-is-credit" },
+  "balance": { "path": "data.total_credits", "minusPath": "data.total_usage", "units": "dollars", "sign": "positive-is-credit" },
   "windows": [
     {
       "kind": "credit-limit",

--- a/src/server/accountReaders.test.mjs
+++ b/src/server/accountReaders.test.mjs
@@ -89,14 +89,18 @@ test("shipped openrouter descriptor reads the live /api/v1/credits payload (BET-
   if (!v.valid) return;
 
   // Live capture 2026-08-20 with a real key: usage 20.0717 > credits 20.
+  // balance = total_credits − total_usage = −0.0717 (overdrawn), and it is the
+  // REMAINING balance that routes, not the granted total.
   const overdrawn = { data: { total_credits: 20, total_usage: 20.071752339 } };
   const snap = readDescriptor(v.descriptor, overdrawn, 0);
-  assert.equal(snap.balance, 20);
+  assert.equal(snap.kind, "credit");
+  assert.ok(Math.abs(snap.balance - (20 - 20.071752339)) < 1e-9, `expected remaining balance -0.07, got ${snap.balance}`);
   assert.equal(snap.exhausted, true);
   assert.equal(snap.windows[0].pct, 100);
 
   const healthy = { data: { total_credits: 20, total_usage: 5 } };
   const healthySnap = readDescriptor(v.descriptor, healthy, 0);
+  assert.equal(healthySnap.balance, 15);
   assert.equal(healthySnap.exhausted, undefined);
   assert.equal(healthySnap.windows[0].pct, 25);
 });

--- a/src/server/routingServices.mjs
+++ b/src/server/routingServices.mjs
@@ -26,6 +26,7 @@
 //     accounts, health, reliability, telemetry, mix, referenceByModel }
 
 import { endpointKey } from "../shared/endpointKey.mjs";
+import { mixFromCounts } from "../shared/blendedPrice.mjs";
 
 const isObj = (v) => v !== null && typeof v === "object";
 const num = (v) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
@@ -93,9 +94,22 @@ export function accountsFromSnapshots(snapshots) {
     if (!isObj(s)) continue;
     const providerIDs = Array.isArray(s.providerIDs) ? s.providerIDs : [];
     if (providerIDs.length === 0) continue;
+    const windows = Array.isArray(s.windows) ? s.windows : [];
+    // The account kind is DECLARED by the adapter/descriptor, never inferred
+    // from `balance` (BET-1269 5e): a subscription that also reports a credit
+    // balance (codex) must not be priced as prepaid credit. A snapshot with no
+    // declared kind falls back to "credit" only when it is structurally a
+    // balance-only account; otherwise the adapter is incomplete and must be
+    // fixed, not guessed around.
+    let kind =
+      typeof s.kind === "string" && (s.kind === "subscription" || s.kind === "credit")
+        ? s.kind
+        : typeof s.balance === "number" && windows.length === 0
+          ? "credit"
+          : "subscription";
     const account = {
-      kind: typeof s.balance === "number" ? "credit" : "subscription",
-      windows: Array.isArray(s.windows) ? s.windows : [],
+      kind,
+      windows,
       ...(typeof s.balance === "number" ? { balance: s.balance } : {}),
       ...(typeof s.overagePrice === "number" ? { overagePrice: s.overagePrice } : {}),
       ...(s.exhausted === true ? { exhausted: true } : {}),
@@ -136,7 +150,10 @@ export function ledgerToServices(stats) {
   const samples = {};
   const perModel = new Map(); // modelID -> { requests, errored }
   const telemetry = {};
-  const mix = {};
+  const mix = {}; // per-endpoint normalised fractions
+  // Aggregate every endpoint's raw token counts so an endpoint with no history
+  // of its own is priced on the box's overall measured mix, not a constant.
+  let agg = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
   for (const [key, s] of Object.entries(isObj(stats) ? stats : {})) {
     const rel = isObj(s?.reliability) ? s.reliability : null;
     if (rel && typeof rel.requests === "number") {
@@ -144,10 +161,10 @@ export function ledgerToServices(stats) {
       const errored = num(rel.errored);
       samples[key] = { requests, errored, rate: num(rel.rate) };
       const modelID = key.includes("/") ? key.slice(key.indexOf("/") + 1) : key;
-      const agg = perModel.get(modelID) ?? { requests: 0, errored: 0 };
-      agg.requests += requests;
-      agg.errored += errored;
-      perModel.set(modelID, agg);
+      const agg2 = perModel.get(modelID) ?? { requests: 0, errored: 0 };
+      agg2.requests += requests;
+      agg2.errored += errored;
+      perModel.set(modelID, agg2);
     }
     const speed = isObj(s?.speed) ? s.speed : {};
     const latency = isObj(s?.latency) ? s.latency : {};
@@ -157,16 +174,28 @@ export function ledgerToServices(stats) {
       ...(typeof latency.p90Ms === "number" ? { p90Ms: latency.p90Ms } : {}),
       ...(typeof latency.p90Ms === "number" ? { latencyMs: latency.p90Ms } : {}),
     };
-    if (isObj(s?.mix)) mix[key] = s.mix;
+    if (isObj(s?.mix)) {
+      // Convert raw token counts to fractions once, here, so services.mix[key]
+      // arrives at the router already normalised (BET-1269 5a).
+      mix[key] = mixFromCounts(s.mix);
+      agg.input += num(s.mix.input);
+      agg.output += num(s.mix.output);
+      agg.cacheRead += num(s.mix.cacheRead);
+      agg.cacheWrite += num(s.mix.cacheWrite);
+    }
   }
   const baseline = {};
-  for (const [modelID, agg] of perModel) {
-    baseline[modelID] = { rate: agg.requests ? agg.errored / agg.requests : 0, n: agg.requests };
+  for (const [modelID, ag] of perModel) {
+    baseline[modelID] = { rate: ag.requests ? ag.errored / ag.requests : 0, n: ag.requests };
   }
+  const hasAnyMix = agg.input + agg.output + agg.cacheRead + agg.cacheWrite > 0;
   return {
     reliability: { samples, baseline },
     telemetry,
     mix,
+    ...(hasAnyMix
+      ? { mixDefault: mixFromCounts({ input: agg.input, output: agg.output, cacheRead: agg.cacheRead, cacheWrite: agg.cacheWrite }) }
+      : {}),
   };
 }
 
@@ -234,6 +263,30 @@ export async function buildRoutingServices(cfg = {}, deps = {}) {
     services.declared = {};
   }
 
+  // The implausible-zero reference (BET-1269 5b): each candidate's model priced
+  // by the provider-agnostic catalogue's own typical input/output rates, keyed
+  // by model id. This is what lets a reseller quoting 0/0 for a priced model be
+  // judged against the real rate instead of winning on a made-up number. A
+  // catalogue lookup only — the catalogue is already loaded.
+  try {
+    const refs = {};
+    for (const ep of Array.isArray(deps.endpoints) ? deps.endpoints : []) {
+      if (!ep || typeof ep.id !== "string" || ep.id === "") continue;
+      const entry = typeof services.catalogEntryFor === "function" ? services.catalogEntryFor(ep) : null;
+      const cost = entry && isObj(entry.cost) ? entry.cost : null;
+      if (!cost) continue;
+      const { input, output } = cost;
+      if (typeof input !== "number" && typeof output !== "number") continue;
+      refs[ep.id] = {
+        ...(typeof input === "number" && Number.isFinite(input) ? { input } : {}),
+        ...(typeof output === "number" && Number.isFinite(output) ? { output } : {}),
+      };
+    }
+    if (Object.keys(refs).length > 0) services.referenceByModel = refs;
+  } catch {
+    /* no catalogue → no reference (the implausible-zero rule cannot fire) */
+  }
+
   // Accounts per providerID from the usage snapshots.
   try {
     const accounts = accountsFromSnapshots(deps.snapshots);
@@ -263,10 +316,11 @@ export async function buildRoutingServices(cfg = {}, deps = {}) {
       if (!isObj(stats)) stats = null;
     }
     if (stats) {
-      const { reliability, telemetry, mix } = fold(stats);
+      const { reliability, telemetry, mix, mixDefault } = fold(stats);
       services.reliability = reliability;
       services.telemetry = telemetry;
       if (mix && Object.keys(mix).length > 0) services.mix = mix;
+      if (mixDefault) services.mixDefault = mixDefault;
     }
   } catch {
     /* no ledger → reliability/telemetry absent (never derank, measured speed) */

--- a/src/server/routingServices.test.mjs
+++ b/src/server/routingServices.test.mjs
@@ -12,6 +12,7 @@ import {
   ledgerToServices,
   buildRoutingServices,
 } from "./routingServices.mjs";
+import { mixFromCounts } from "../shared/blendedPrice.mjs";
 
 test("normalizeDeclared reads modelRouting.declaredModels and passes objects through", () => {
   const out = normalizeDeclared({
@@ -64,9 +65,24 @@ test("accountsFromSnapshots maps each snapshot to all the providerIDs it covers"
     { provider: "codex", providerIDs: ["openai"], windows: [{ pct: 10 }] },
   ]);
   assert.deepEqual(accounts, {
-    anthropic: { kind: "credit", windows: [{ pct: 90 }], balance: -2, overagePrice: 0.25, exhausted: true },
+    anthropic: { kind: "subscription", windows: [{ pct: 90 }], balance: -2, overagePrice: 0.25, exhausted: true },
     openai: { kind: "subscription", windows: [{ pct: 10 }] },
   });
+});
+
+test("accountsFromSnapshots reads the DECLARED account kind, never the balance inference (5e)", () => {
+  // A subscription that also reports a credit balance (codex) must stay a
+  // subscription — it must not be priced as prepaid credit.
+  const accounts = accountsFromSnapshots([
+    { provider: "codex", providerIDs: ["openai"], kind: "subscription", balance: 14.2, windows: [{ pct: 20 }] },
+    { provider: "openrouter", providerIDs: ["openrouter"], kind: "credit", balance: -0.07, windows: [] },
+    { provider: "legacy", providerIDs: ["legacy"], balance: 5, windows: [] },
+  ]);
+  assert.equal(accounts.openai.kind, "subscription");
+  assert.equal(accounts.openai.balance, 14.2);
+  assert.equal(accounts.openrouter.kind, "credit");
+  // No declared kind + balance-only → credit (the only safe inference).
+  assert.equal(accounts.legacy.kind, "credit");
 });
 
 test("accountsFromSnapshots skips snapshots with no providerIDs and malformed rows", () => {
@@ -88,7 +104,7 @@ test("healthFor is empty when no state reader is wired", () => {
   assert.deepEqual(healthFor(["anthropic"], null), {});
 });
 
-test("ledgerToServices folds reliability samples, per-model baselines and telemetry", () => {
+test("ledgerToServices folds reliability samples, per-model baselines, telemetry and a NORMALISED per-endpoint mix + overall mixDefault", () => {
   const stats = {
     "anthropic/claude-opus-4": {
       reliability: { requests: 30, errored: 3, rate: 0.1 },
@@ -103,7 +119,7 @@ test("ledgerToServices folds reliability samples, per-model baselines and teleme
       mix: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
     },
   };
-  const { reliability, telemetry, mix } = ledgerToServices(stats);
+  const { reliability, telemetry, mix, mixDefault } = ledgerToServices(stats);
   // samples keyed by endpoint
   assert.deepEqual(reliability.samples["anthropic/claude-opus-4"], { requests: 30, errored: 3, rate: 0.1 });
   // baseline keyed by MODEL id — aggregate across both endpoints of the model
@@ -115,14 +131,49 @@ test("ledgerToServices folds reliability samples, per-model baselines and teleme
     p90Ms: 900,
     latencyMs: 900,
   });
-  assert.deepEqual(mix["anthropic/claude-opus-4"], { input: 5, output: 10, cacheRead: 20, cacheWrite: 30 });
+  // Mixes are NORMALISED to fractions (mixFromCounts), not raw counts (5a) —
+  // an endpoint with no history is then priced on the box's overall mixDefault.
+  assert.deepEqual(mix["anthropic/claude-opus-4"], mixFromCounts({ input: 5, output: 10, cacheRead: 20, cacheWrite: 30 }));
+  assert.deepEqual(mix["openai/claude-opus-4"], mixFromCounts({ input: 1, output: 2, cacheRead: 3, cacheWrite: 4 }));
+  assert.deepEqual(mixDefault, mixFromCounts({ input: 6, output: 12, cacheRead: 23, cacheWrite: 34 }));
 });
 
-test("ledgerToServices is empty-safe and ignores degenerate rows", () => {
-  const { reliability, telemetry, mix } = ledgerToServices({});
+test("ledgerToServices is empty-safe and ignores degenerate rows; no mix => no mixDefault", () => {
+  const { reliability, telemetry, mix, mixDefault } = ledgerToServices({});
   assert.deepEqual(reliability, { samples: {}, baseline: {} });
   assert.deepEqual(telemetry, {});
   assert.deepEqual(mix, {});
+  assert.equal(mixDefault, undefined);
+});
+
+test("buildRoutingServices populates referenceByModel from the catalogue's typical input/output rates (5b)", async () => {
+  const services = await buildRoutingServices(
+    { modelRouting: { preset: "balanced", declaredModels: { "p/sonnet": { catalogId: "declared-sonnet" }, "p/haiku": { catalogId: "declared-haiku" } } } },
+    {
+      catalogIndex: {
+        lookupModel: (id) =>
+          id === "declared-sonnet"
+            ? { id: "declared-sonnet", cost: { input: 3, output: 15 } }
+            : id === "declared-haiku"
+              ? { id: "declared-haiku", cost: { input: 0, output: 0 } }
+              : null,
+        matchModel: () => ({ kind: "none", candidates: [] }),
+        allModels: () => [],
+      },
+      endpoints: [
+        { providerID: "p", id: "sonnet" },
+        { providerID: "p", id: "haiku" },
+        { providerID: "p", id: "no-entry" },
+      ],
+    },
+  );
+  // Keyed by model id; only endpoint ids that resolve in the catalogue carry a
+  // reference.
+  assert.deepEqual(services.referenceByModel.sonnet, { input: 3, output: 15 });
+  // A genuinely free catalogue model still carries a (zero) reference — the
+  // implausible-zero rule only fires against a reference that costs money.
+  assert.deepEqual(services.referenceByModel.haiku, { input: 0, output: 0 });
+  assert.equal(services.referenceByModel["no-entry"], undefined);
 });
 
 test("buildRoutingServices: catalogEntryFor honours a declared catalogId over a fuzzy match (BET-1268)", async () => {
@@ -192,9 +243,10 @@ test("buildRoutingServices assembles a full services object from live readers", 
   // reliability sample + baseline present
   assert.equal(services.reliability.samples["anthropic/claude-opus-4"].requests, 25);
   assert.ok(services.reliability.baseline["claude-opus-4"]);
-  // telemetry + mix present
+  // telemetry + mix present (mix normalised to fractions, mixDefault from the ledger)
   assert.equal(services.telemetry["anthropic/claude-opus-4"].tokensPerSec, 90);
-  assert.deepEqual(services.mix["anthropic/claude-opus-4"], { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 });
+  assert.deepEqual(services.mix["anthropic/claude-opus-4"], mixFromCounts({ input: 1, output: 2, cacheRead: 3, cacheWrite: 4 }));
+  assert.deepEqual(services.mixDefault, mixFromCounts({ input: 1, output: 2, cacheRead: 3, cacheWrite: 4 }));
 });
 
 test("buildRoutingServices safety contract: a throwing reader degrades, never throws", async () => {

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -60,6 +60,10 @@
  *                                  opencode's), so a name-equality match would
  *                                  silently fail for every adapter.
  * @property {string} [planLabel]   "Max 20x", "Pro", "Allegretto".
+ * @property {string} [kind]        "subscription" | "credit" — DECLARED by the
+ *                                  adapter/descriptor, never inferred. A
+ *                                  subscription that also reports a credit
+ *                                  balance (codex) must not be priced as credit.
  * @property {UsageWindow[]} windows
  * @property {{label:string,value:string}[]} [extras]  Credits balance, model pools.
  * @property {number} [balance]    Account credit in dollars. May be NEGATIVE
@@ -287,12 +291,19 @@ export function createUsagePoller({
         try {
           const raw = await adapter.fetch({ fetchImpl, now });
           const windows = Array.isArray(raw?.windows) ? raw.windows.filter(Boolean) : [];
-          if (windows.length === 0) {
+          const hasBalance = typeof raw?.balance === "number";
+          // A snapshot carrying a balance and no windows is VALID — an unfunded
+          // credit account (e.g. OpenRouter with total_credits: 0) must be
+          // distinguishable from "not connected", and a balance-only snapshot is
+          // exactly the shape `accountDescriptor` was written to support
+          // (BET-1269 5g). The throw applies only to a snapshot with neither.
+          if (windows.length === 0 && !hasBalance) {
             throw new Error("adapter returned zero usable windows");
           }
           results.push({
             provider: adapter.id,
             providerIDs: adapter.providerIDs,
+            ...(typeof raw.kind === "string" ? { kind: raw.kind } : {}),
             ...(raw.planLabel ? { planLabel: raw.planLabel } : {}),
             windows,
             ...(Array.isArray(raw.extras) && raw.extras.length > 0 ? { extras: raw.extras } : {}),

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -243,6 +243,30 @@ test("poller drops an adapter whose response has zero usable windows", async () 
   assert.equal(poller.snapshots.length, 0);
 });
 
+test("poller keeps a balance-only snapshot (no windows) — an unfunded credit account is a valid snapshot (5g)", async () => {
+  const balOnly = makeAdapter("cred", {
+    detect: async () => true,
+    fetch: async () => ({ kind: "credit", balance: 0, windows: [] }),
+  });
+  const poller = createUsagePoller({ adapters: [balOnly], now: () => 1000 });
+  await poller.tick();
+  assert.equal(poller.snapshots.length, 1);
+  const snap = poller.snapshots[0];
+  assert.equal(snap.balance, 0);
+  assert.equal(snap.kind, "credit");
+  assert.deepEqual(snap.windows, []);
+});
+
+test("poller carries the adapter-declared kind onto the snapshot (5e)", async () => {
+  const sub = makeAdapter("subprov", {
+    detect: async () => true,
+    fetch: async () => ({ kind: "subscription", balance: 14.2, windows: [{ kind: "session", label: "s", pct: 20 }] }),
+  });
+  const poller = createUsagePoller({ adapters: [sub], now: () => 1000 });
+  await poller.tick();
+  assert.equal(poller.snapshots[0].kind, "subscription");
+});
+
 test("poller: a 429 with Retry-After backs off only that adapter, for exactly that long", async () => {
   let nowMs = 1_700_000_000_000;
   let rlFetchCalls = 0;

--- a/src/server/usageAdapters/claude.mjs
+++ b/src/server/usageAdapters/claude.mjs
@@ -104,6 +104,7 @@ export const claudeAdapter = {
 
     return {
       provider: "claude",
+      kind: "subscription",
       windows,
       ...(exhausted ? { exhausted: true } : {}),
       ...(extras.length > 0 ? { extras } : {}),

--- a/src/server/usageAdapters/codex.mjs
+++ b/src/server/usageAdapters/codex.mjs
@@ -103,6 +103,7 @@ export const codexAdapter = {
 
     return {
       provider: "codex",
+      kind: "subscription",
       ...(planLabel ? { planLabel } : {}),
       windows,
       ...(balanceNum !== undefined ? { balance: balanceNum } : {}),

--- a/src/server/usageAdapters/kimi.mjs
+++ b/src/server/usageAdapters/kimi.mjs
@@ -99,6 +99,6 @@ export const kimiAdapter = {
     // No planLabel on this endpoint — it needs a cookie-auth web API, out of
     // scope per the issue spec.
     const exhausted = isUsageAtLimit(windows);
-    return { provider: "kimi", windows, ...(exhausted ? { exhausted: true } : {}) };
+    return { provider: "kimi", kind: "subscription", windows, ...(exhausted ? { exhausted: true } : {}) };
   },
 };

--- a/src/shared/accountDescriptor.d.mts
+++ b/src/shared/accountDescriptor.d.mts
@@ -21,7 +21,8 @@ export type AccountDescriptor = {
   providerIDs: string[];
   url: string;
   auth: "bearer";
-  balance: { path: string; units: string; sign: BalanceSign };
+  kind?: "subscription" | "credit";
+  balance: { path: string; minusPath?: string; units: string; sign: BalanceSign };
   windows?: DescriptorWindow[];
   planLabel?: string;
   overagePrice?: string;

--- a/src/shared/accountDescriptor.mjs
+++ b/src/shared/accountDescriptor.mjs
@@ -22,12 +22,14 @@ const TOP_LEVEL_KEYS = [
   "providerIDs",
   "url",
   "auth",
+  "kind",
   "balance",
   "windows",
   "planLabel",
   "overagePrice",
 ];
-const BALANCE_KEYS = ["path", "units", "sign"];
+const BALANCE_KEYS = ["path", "minusPath", "units", "sign"];
+const ACCOUNT_KINDS = ["subscription", "credit"];
 const BALANCE_SIGNS = ["positive-is-credit", "positive-is-debt"];
 const WINDOW_KEYS = [
   "kind",
@@ -123,6 +125,10 @@ export function validateDescriptor(raw) {
     errors.push(raw.auth === undefined ? 'missing required key "auth"' : `unknown auth "${raw.auth}"`);
   }
 
+  if (raw.kind !== undefined && !ACCOUNT_KINDS.includes(raw.kind)) {
+    errors.push(`"kind" must be "subscription" or "credit"`);
+  }
+
   const bal = raw.balance;
   if (!isPlainObject(bal)) {
     errors.push('missing required key "balance"');
@@ -131,6 +137,9 @@ export function validateDescriptor(raw) {
       if (!BALANCE_KEYS.includes(k)) errors.push(`unknown key "balance.${k}"`);
     }
     if (!isNonEmptyString(bal.path)) errors.push('missing required key "balance.path"');
+    if (bal.minusPath !== undefined && !isNonEmptyString(bal.minusPath)) {
+      errors.push('"balance.minusPath" must be a non-empty dot-path string');
+    }
     if (bal.units !== undefined && !isNonEmptyString(bal.units)) errors.push('"balance.units" must be a non-empty string');
     if (!BALANCE_SIGNS.includes(bal.sign)) {
       errors.push('"balance.sign" must be "positive-is-credit" or "positive-is-debt"');
@@ -230,11 +239,19 @@ export function readDescriptor(descriptor, payload, nowMs) {
     : [];
 
   const balanceNum = toFiniteNumber(get(descriptor.balance?.path));
+  let resolvedBalance = balanceNum;
+  // A two-field balance: `value(path) − value(minusPath)`. This is the whole
+  // permitted arithmetic — no expression language (BET-1269 5d). Add nothing
+  // more.
+  if (resolvedBalance !== undefined && descriptor.balance?.minusPath) {
+    const subtract = toFiniteNumber(get(descriptor.balance.minusPath));
+    if (subtract !== undefined) resolvedBalance = resolvedBalance - subtract;
+  }
   const balance =
-    balanceNum !== undefined
+    resolvedBalance !== undefined
       ? descriptor.balance?.sign === "positive-is-debt"
-        ? -balanceNum
-        : balanceNum
+        ? -resolvedBalance
+        : resolvedBalance
       : undefined;
 
   const planLabelRaw = get(descriptor.planLabel);
@@ -248,6 +265,7 @@ export function readDescriptor(descriptor, payload, nowMs) {
   const exhausted = overdrawn || atWindowLimit;
 
   const snap = { provider: descriptor.id, providerIDs: descriptor.providerIDs, windows };
+  if (typeof descriptor.kind === "string" && descriptor.kind) snap.kind = descriptor.kind;
   if (balance !== undefined) snap.balance = balance;
   if (overagePrice !== undefined) snap.overagePrice = overagePrice;
   if (planLabel) snap.planLabel = planLabel;

--- a/src/shared/accountDescriptor.test.ts
+++ b/src/shared/accountDescriptor.test.ts
@@ -64,6 +64,23 @@ describe("validateDescriptor", () => {
     if (r.valid) return;
     expect(r.errors.join("; ")).toContain("positive-is-credit");
   });
+
+  it("accepts kind subscription/credit and rejects other values", () => {
+    const credit = validateDescriptor({ ...base, kind: "credit" });
+    expect(credit.valid).toBe(true);
+    const sub = validateDescriptor({ ...base, kind: "subscription" });
+    expect(sub.valid).toBe(true);
+    const bad = validateDescriptor({ ...base, kind: "prepaid" });
+    expect(bad.valid).toBe(false);
+    if (!bad.valid) expect(bad.errors.join("; ")).toContain('"kind"');
+  });
+
+  it("accepts a balance.minusPath and rejects a non-string one", () => {
+    const ok = validateDescriptor({ ...base, balance: { ...base.balance, minusPath: "data.total_usage" } });
+    expect(ok.valid).toBe(true);
+    const bad = validateDescriptor({ ...base, balance: { ...base.balance, minusPath: 3 } });
+    expect(bad.valid).toBe(false);
+  });
 });
 
 describe("readDescriptor", () => {
@@ -138,5 +155,19 @@ describe("readDescriptor", () => {
     });
     const snap = readDescriptor(d, { w: { pct: 100 } }, 0);
     expect(snap.exhausted).toBe(true);
+  });
+
+  it("balance.minusPath subtracts: balance = value(path) − value(minusPath)", () => {
+    const d = ok({ ...base, balance: { ...base.balance, minusPath: "data.total_usage" } });
+    const snap = readDescriptor(d, { account: { balance: 20 }, data: { total_usage: 20.07 } }, 0);
+    // 20 − 20.07 = −0.07 → overdrawn (negative under positive-is-credit).
+    expect(snap.balance).toBeCloseTo(-0.07, 9);
+    expect(snap.exhausted).toBe(true);
+  });
+
+  it("a declared kind is carried onto the snapshot for accountsFromSnapshots", () => {
+    const d = ok({ ...base, kind: "credit" });
+    const snap = readDescriptor(d, { account: { balance: 5 } }, 0);
+    expect(snap.kind).toBe("credit");
   });
 });

--- a/src/shared/marginalCost.d.mts
+++ b/src/shared/marginalCost.d.mts
@@ -12,6 +12,7 @@ export interface WindowState {
   startedAt?: number;
   resetsAt?: number;
   binding?: boolean;
+  stale?: boolean;
 }
 
 export interface AccountState {

--- a/src/shared/marginalCost.mjs
+++ b/src/shared/marginalCost.mjs
@@ -77,15 +77,16 @@ function resetDamp(resetsAt, nowMs) {
   return clamp01(remaining / RESET_RAMP_MS);
 }
 
-// Which figure anchors the subscription exchange rate, in priority order.
-function exchangeRateOf(account, model, mix, reference, replacementCost) {
+// Which figure anchors the subscription's marginal cost. There is deliberately
+// NO list-price fallback (BET-1269 5c): the subscription's fee is already paid,
+// so one more token costs what the cheapest acceptable alternative would charge
+// to do the same work — the replacement cost. With no cash alternative the rate
+// is 0 (a subscription with nothing to compare against is free at the margin).
+function exchangeRateOf(account, replacementCost) {
   if (isNum(account?.overagePrice)) {
     return { rate: dollar(account.overagePrice), source: "published overage price" };
   }
-  if (isNum(replacementCost)) {
-    return { rate: dollar(replacementCost), source: "replacement cost" };
-  }
-  return { rate: blendedPrice(model, mix, reference).price, source: "blended price" };
+  return { rate: dollar(replacementCost), source: "replacement cost" };
 }
 
 // One subscription window, priced by pace vs elapsed, damped near reset.
@@ -143,10 +144,16 @@ export function marginalCost(input = {}) {
 
   // --- Exhausted first -------------------------------------------------------
   const windows = Array.isArray(account?.windows) ? account.windows : [];
+  // A stale reading must never escalate (UsageWindow.stale is set by the usage
+  // poller the moment a window's reset instant passes and the provider has not
+  // published the replacement numbers). A stale window contributes neither
+  // exhaustion nor pace; if every window is stale the account has no usable
+  // reading and is priced as if it had none, not as exhausted (BET-1269 5f).
+  const liveWindows = windows.filter((w) => w?.stale !== true);
   const exhausted =
     account?.exhausted === true ||
     (account?.kind === "credit" && isNum(account?.balance) && account.balance <= 0) ||
-    (account?.kind === "subscription" && windows.some((w) => isNum(w?.pct) && w.pct >= 100));
+    (account?.kind === "subscription" && liveWindows.some((w) => isNum(w?.pct) && w.pct >= 100));
 
   if (exhausted) {
     return {
@@ -180,18 +187,18 @@ export function marginalCost(input = {}) {
 
   // --- subscription ----------------------------------------------------------
   if (account?.kind === "subscription") {
-    const { rate, source } = exchangeRateOf(account, model, mix, reference, replacementCost);
-    if (windows.length === 0) {
+    const { rate, source } = exchangeRateOf(account, replacementCost);
+    if (liveWindows.length === 0) {
       return {
         cost: dollar(rate),
         exhausted: false,
         basis: "subscription-no-window",
-        reason: `subscription, no window data — priced at exchange rate (${source})`,
+        reason: `subscription, no usable window — priced at exchange rate (${source})`,
       };
     }
     let best = 0;
     let bestBasis = "subscription-pace";
-    for (const w of windows) {
+    for (const w of liveWindows) {
       const c = subscriptionWindowCost(w, rate, nowMs);
       if (c.cost > best) {
         best = c.cost;

--- a/src/shared/marginalCost.test.ts
+++ b/src/shared/marginalCost.test.ts
@@ -38,7 +38,7 @@ const EXCHANGE = 15;
 describe("marginalCost — subscription pacing", () => {
   it("under pace ≈ free: 20% consumed / 60% elapsed → far below the exchange rate", () => {
     // elapsed 0.6, resetsAt = R (damp 1). pace = 0.2/0.6 = 0.333 → cost = 15 * 0.111.
-    const res = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(20, -1.5 * R, R)) });
+    const res = marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(20, -1.5 * R, R)) });
     expect(res.exhausted).toBe(false);
     expect(res.cost).toBeGreaterThan(0);
     expect(res.cost).toBeLessThan(EXCHANGE * 0.15); // ~1.67, vs exchange 15
@@ -47,8 +47,8 @@ describe("marginalCost — subscription pacing", () => {
 
   it("pace, not fill: same pct at two different elapsed values → materially different costs", () => {
     // pct 60 fixed. elapsed 0.2 → pace 3 (over); elapsed 0.6 → pace 1 (on pace).
-    const fast = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -0.25 * R, R)) });
-    const slow = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -1.5 * R, R)) });
+    const fast = marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(60, -0.25 * R, R)) });
+    const slow = marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(60, -1.5 * R, R)) });
     // 15*9 = 135 vs 15*1 = 15 — a gauge reading pct alone would say they're equal.
     expect(fast.cost).toBeGreaterThan(slow.cost * 5);
     expect(slow.cost).toBeCloseTo(EXCHANGE, 3);
@@ -56,14 +56,14 @@ describe("marginalCost — subscription pacing", () => {
 
   it("over pace rises: 80% consumed / 30% elapsed → above the exchange rate", () => {
     // pace = 0.8/0.3 = 2.667 → cost = 15 * 7.11 ≈ 106.7.
-    const res = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(80, -0.4286 * R, R)) });
+    const res = marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(80, -0.4286 * R, R)) });
     expect(res.cost).toBeGreaterThan(EXCHANGE);
     expect(res.cost).toBeCloseTo(106.7, 1);
   });
 
   it("on pace = exchange rate, within tolerance", () => {
     // pace = 0.6/0.6 = 1 → cost is exactly the exchange rate (15).
-    const res = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -1.5 * R, R)) });
+    const res = marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(60, -1.5 * R, R)) });
     expect(res.cost).toBeCloseTo(EXCHANGE, 5);
   });
 
@@ -72,6 +72,7 @@ describe("marginalCost — subscription pacing", () => {
     const res = marginalCost({
       model: MODEL,
       nowMs: 0,
+      replacementCost: EXCHANGE,
       account: sub([w(30, -1.5 * R, R), w(80, -0.4286 * R, R)]),
     });
     expect(res.exhausted).toBe(false);
@@ -81,8 +82,8 @@ describe("marginalCost — subscription pacing", () => {
   it("near reset is cheap: same pace, resetsAt imminent → cheaper", () => {
     // Both pace 1 (consumed 0.5 / elapsed 0.5). Far window: damp 1 → 15.
     // Near window: resetsAt = 0.1R → damp 0.1 → 1.5. Same pace, same fill.
-    const far = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(50, -1 * R, R)) });
-    const near = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(50, -0.1 * R, 0.1 * R)) });
+    const far = marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(50, -1 * R, R)) });
+    const near = marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(50, -0.1 * R, 0.1 * R)) });
     expect(near.cost).toBeLessThan(far.cost);
     expect(far.cost).toBeCloseTo(EXCHANGE, 3);
     expect(near.cost).toBeCloseTo(EXCHANGE * 0.1, 3);
@@ -92,6 +93,7 @@ describe("marginalCost — subscription pacing", () => {
     const res = marginalCost({
       model: MODEL,
       nowMs: 0,
+      replacementCost: EXCHANGE,
       account: {
         kind: "subscription",
         windows: [{ pct: 50, resetsAt: R }], // no startedAt
@@ -136,7 +138,7 @@ describe("marginalCost — credit", () => {
 describe("marginalCost — the asymmetry (subscription < credit at equal scarcity)", () => {
   it("at equal scarcity a subscription costs less than a credit balance, every time", () => {
     // Subscription on-pace (pace 1) = exchange rate 15.
-    const subRes = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -1.5 * R, R)) });
+    const subRes = marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(60, -1.5 * R, R)) });
     expect(subRes.cost).toBeCloseTo(EXCHANGE, 5);
 
     // A credit balance, even one at unit depletion (huge balance), must cost more.
@@ -156,7 +158,7 @@ describe("marginalCost — the asymmetry (subscription < credit at equal scarcit
 describe("marginalCost — exhausted first", () => {
   it("each exhausted signal returns exhausted:true and cost Infinity", () => {
     const byFlag = marginalCost({ model: MODEL, nowMs: 0, account: { kind: "credit", balance: 50, exhausted: true } });
-    const byPct = marginalCost({ model: MODEL, nowMs: 0, account: sub(w(100, -1.5 * R, R)) });
+    const byPct = marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(100, -1.5 * R, R)) });
     const byZero = marginalCost({ model: MODEL, nowMs: 0, account: credit(0) });
     const byNegative = marginalCost({ model: MODEL, nowMs: 0, account: credit(-0.57) });
 
@@ -169,9 +171,9 @@ describe("marginalCost — exhausted first", () => {
 
   it("every non-exhausted return is finite and ≥ 0; Infinity appears only on exhaustion", () => {
     const cases = [
-      marginalCost({ model: MODEL, nowMs: 0, account: sub(w(20, -1.5 * R, R)) }),
-      marginalCost({ model: MODEL, nowMs: 0, account: sub(w(60, -1.5 * R, R)) }),
-      marginalCost({ model: MODEL, nowMs: 0, account: sub(w(80, -0.4286 * R, R)) }),
+      marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(20, -1.5 * R, R)) }),
+      marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(60, -1.5 * R, R)) }),
+      marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(80, -0.4286 * R, R)) }),
       marginalCost({ model: MODEL, nowMs: 0, account: credit(10) }),
       marginalCost({ model: MODEL, nowMs: 0, account: credit() }),
       marginalCost({ model: MODEL, nowMs: 0, account: { kind: "none" } }),

--- a/src/shared/modelRouter.d.mts
+++ b/src/shared/modelRouter.d.mts
@@ -49,8 +49,12 @@ export interface RoutingServices {
     samples?: Record<string, ReliabilitySample>;
     baseline?: Record<string, ReliabilityBaseline>;
   };
-  mix?: unknown;
-  referenceByModel?: Record<string, unknown>;
+  /** Keyed by "providerID/modelID" — the measured token mix per endpoint. */
+  mix?: Record<string, { input?: number; output?: number; cacheRead?: number; cacheWrite?: number }>;
+  /** The box's overall measured mix, for an endpoint with no history of its own. */
+  mixDefault?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
+  /** Keyed by model id — the catalogue's typical input/output rate. */
+  referenceByModel?: Record<string, { input?: number; output?: number }>;
 }
 
 export interface ChooseInput {

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -83,7 +83,7 @@ function capabilityDrop(m, { contextTokens, needs, health }) {
 
 // Assess one endpoint once — Hard Stage 1 (eligibility), marginal cost and
 // reliability — everything the hard and soft stages read.
-function assess(candidate, { nowMs }, services) {
+function assess(candidate, { nowMs, replacementCost }, services) {
   const key = endpointKey(candidate);
   const dec = services.declared?.[key] ?? null;
   const identity = resolveIdentity(candidate, dec, services.catalogMatcher);
@@ -96,6 +96,8 @@ function assess(candidate, { nowMs }, services) {
   const m = identity.effective ?? candidate;
   const catalogEntry = typeof services.catalogEntryFor === "function" ? services.catalogEntryFor(candidate) : null;
   const quality = qualityScore(m, catalogEntry, services.qualityField);
+  const perMix = mixFor(services, key);
+  const ref = referenceFor(dec, services, candidate);
   const elig = autoEligibility({
     model: m,
     identity: { known: identity.state === "resolved" },
@@ -103,11 +105,11 @@ function assess(candidate, { nowMs }, services) {
     declared: dec,
     providerClass: services.providerClass?.[candidate.providerID] ?? "supported",
   });
-  const mc = marginalCost({ model: m, account: services.accounts?.[candidate.providerID], nowMs, mix: services.mix, reference: services.referenceByModel?.[candidate.id] });
+  const mc = marginalCost({ model: m, account: services.accounts?.[candidate.providerID], nowMs, mix: perMix, reference: ref, replacementCost });
   // The raw mix/reference flags blendedPrice already computed with the SAME
   // inputs marginalCost handed it — reported verbatim, not recomputed. This is
   // what makes a silently-defaulted mix / absent catalogue visible (BET-1265).
-  const bp = blendedPrice(m, services.mix, services.referenceByModel?.[candidate.id]);
+  const bp = blendedPrice(m, perMix, ref);
   const penalise = shouldDerank(services.reliability?.samples?.[key], services.reliability?.baseline?.[candidate.id]).penalise === true;
   return {
     key,
@@ -147,6 +149,38 @@ function bindingReason(counts) {
     if (cv > bestCount) { bestCount = cv; best = label; }
   }
   return best;
+}
+
+// The reference price to judge implausible-zero against, or null when the user
+// has declared a price for this endpoint (a declaration — including "free" —
+// is authoritative; it must not be re-classified by the catalogue).
+function referenceFor(dec, services, endpoint) {
+  return dec?.price !== undefined ? null : services.referenceByModel?.[endpoint?.id];
+}
+
+// The mix for one endpoint: its own measured ledger mix, else the box's overall
+// measured mix, else absent (falls back to DEFAULT_MIX inside blendedPrice).
+function mixFor(services, key) {
+  return services.mix?.[key] ?? services.mixDefault;
+}
+
+// The subscription exchange rate needs "the cheapest acceptable alternative":
+// the minimum blended price across every non-subscription endpoint in the
+// candidate set. Computed once per decision, before the per-candidate loop.
+function computeReplacementCost(catalog, services) {
+  let best = null;
+  for (const c of Array.isArray(catalog) ? catalog : []) {
+    if (c === null || typeof c !== "object") continue;
+    const account = services.accounts?.[c?.providerID] ?? null;
+    if (account?.kind === "subscription") continue;
+    const key = endpointKey(c);
+    const dec = services.declared?.[key] ?? null;
+    const identity = resolveIdentity(c, dec, services.catalogMatcher);
+    const m = identity.effective ?? c;
+    const price = blendedPrice(m, mixFor(services, key), referenceFor(dec, services, c)).price;
+    if (best === null || price < best) best = price;
+  }
+  return best === null ? undefined : best;
 }
 
 const num0 = (v) => (isNum(v) ? v : 0);
@@ -323,6 +357,9 @@ export function chooseModel(input = {}) {
   const counts = {};
   const drops = [];
   let considered = 0;
+  // The subscription exchange rate anchors to the cheapest non-subscription
+  // endpoint's blended price — computed once, before the per-candidate loop.
+  const replacementCost = computeReplacementCost(catalog, services);
   const addDrop = (stage, reason) => {
     const existing = drops.find((d) => d.stage === stage && d.reason === reason);
     if (existing) existing.n += 1;
@@ -330,7 +367,7 @@ export function chooseModel(input = {}) {
   };
   for (const c of Array.isArray(catalog) ? catalog : []) {
     considered += 1;
-    const a = assess(c, { nowMs }, services);
+    const a = assess(c, { nowMs, replacementCost }, services);
     const cap = capabilityDrop(a.effective ?? a.candidate, hardCtx);
     if ((a.exhausted && !cap) || cap || !a.eligible) {
       const label = bindLabel(a, cap);

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -11,10 +11,17 @@ import { AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
 // The two server .mjs modules have no bundled type declarations (they are
 // consumed from node:test .test.mjs). The seams below are exercised through
 // the real modules — the fixtures are deliberately not hand-typed.
-// @ts-expect-error — server .mjs has no bundled declarations; used for the real normaliser.
+// The tests import real server .mjs (normaliser, services wiring, adapters) so
+// fixtures and account shapes cannot quietly disagree with production (BET-1269
+// standing rule 9). Those modules have no bundled .d.mts, hence the directives.
+// @ts-expect-error — server .mjs has no bundled declarations.
 import { _normalizeProviderModel } from "../server/opencode.mjs";
-// @ts-expect-error — server .mjs has no bundled declarations; used for the real services wiring.
-import { buildRoutingServices } from "../server/routingServices.mjs";
+// @ts-expect-error — server .mjs has no bundled declarations.
+import { buildRoutingServices, accountsFromSnapshots } from "../server/routingServices.mjs";
+// @ts-expect-error — server .mjs has no bundled declarations.
+import { claudeAdapter } from "../server/usageAdapters/claude.mjs";
+// @ts-expect-error — server .mjs has no bundled declarations.
+import { codexAdapter } from "../server/usageAdapters/codex.mjs";
 
 // A catalogue entry field that forces a precise, known quality score so tests
 // control the tier band deterministically. qualityScore's benchmark path wins
@@ -91,6 +98,58 @@ function route({ catalog, policy, intent = {}, services: extra = {}, nowMs = 0 }
 }
 
 const keyOf = endpointKey;
+
+// A fetch-shaped Response for the real adapters — never the network.
+function fakeRes(status: number, body: unknown) {
+  return { ok: status < 300, status, headers: { get: () => null }, json: async () => body };
+}
+
+async function claudeSnapshot(body: unknown) {
+  return claudeAdapter.fetch({
+    readCredentials: async () => ({ accessToken: "x" }),
+    fetchImpl: async () => fakeRes(200, body),
+  });
+}
+
+async function codexSnapshot(body: unknown) {
+  return codexAdapter.fetch({
+    readToken: async () => "x",
+    fetchImpl: async () => fakeRes(200, body),
+    now: () => 0,
+  });
+}
+
+// The real adapters' fetch() does not carry providerIDs — the usage poller adds
+// them from adapter.providerIDs. Mirror that so accountsFromSnapshots keys by
+// opencode providerID exactly as production does.
+function accountFor(adapter: { providerIDs: string[] }, snapshot: Record<string, unknown>) {
+  return accountsFromSnapshots([{ ...snapshot, providerIDs: adapter.providerIDs }] as any);
+}
+
+// Real services for a catalogue-driven scenario: reference prices, benchmarks,
+// accounts and a ledger mix all built through buildRoutingServices.
+async function catalogueServices(opts: {
+  declaredModels: Record<string, unknown>;
+  entries: Record<string, unknown>;
+  endpoints: Array<Record<string, unknown>>;
+  snapshots?: Array<Record<string, unknown>>;
+  endpointSummary?: () => Promise<Record<string, unknown>>;
+}) {
+  return (await buildRoutingServices(
+    { modelRouting: { preset: "balanced", declaredModels: opts.declaredModels } },
+    {
+      catalogIndex: {
+        lookupModel: (id: string) => (opts.entries[id] ? opts.entries[id] : null),
+        matchModel: () => ({ kind: "none", candidates: [] }),
+        allModels: () => Object.values(opts.entries),
+      },
+      endpoints: opts.endpoints as any,
+      snapshots: (opts.snapshots as any) ?? [],
+      providerHealthState: () => undefined,
+      endpointSummary: opts.endpointSummary ?? (async () => ({})),
+    },
+  )) as RoutingServices;
+}
 
 describe("PRESETS / AGENT_TIER", () => {
   it("exposes the three presets and the tier table read by the renderer", () => {
@@ -538,5 +597,174 @@ describe("chooseModel — judge the resolved endpoint, not the provider's raw cl
     // has none (it would place the endpoint by family instead).
     expect(w.quality.basis).toBe("benchmark");
     expect(w.quality.known).toBe(true);
+  });
+});
+
+describe("chooseModel — the cost stage (BET-1269): measured mix, catalogue reference, subscription pricing", () => {
+  // --- Test 2: mix is measured ---------------------------------------------
+  // Two endpoints, identical capability (same model, same band), differing only
+  // in cache discount. Under a cache-heavy MEASURED mix the caching endpoint
+  // wins; under a cache-light measured mix the cheap-fresh one wins. On main
+  // the per-endpoint mix never arrives, so mixSource stays "default".
+  const CACHE_HEAVY = { input: 0.08, output: 0.05, cacheRead: 0.8, cacheWrite: 0.07 };
+  const CACHE_LIGHT = { input: 0.45, output: 0.45, cacheRead: 0.05, cacheWrite: 0.05 };
+
+  it("2. mix is measured: the winner flips with a cache-heavy vs cache-light ledger mix", () => {
+    const cachey = endpoint("m", { providerID: "a", cost: { input: 2, output: 2, cacheRead: 0.1, cacheWrite: 0.1 } });
+    const fresh = endpoint("m", { providerID: "b", cost: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1 } });
+    const heavy = route({
+      catalog: [fresh, cachey],
+      policy: { preset: "balanced" },
+      services: { mix: { "a/m": CACHE_HEAVY, "b/m": CACHE_HEAVY }, mixDefault: CACHE_HEAVY },
+    });
+    expect(heavy.model?.providerID).toBe("a");
+    expect(heavy.trace.winner!.cost.mixSource).toBe("measured");
+    const light = route({
+      catalog: [fresh, cachey],
+      policy: { preset: "balanced" },
+      services: { mix: { "a/m": CACHE_LIGHT, "b/m": CACHE_LIGHT }, mixDefault: CACHE_LIGHT },
+    });
+    expect(light.model?.providerID).toBe("b");
+    expect(light.trace.winner!.cost.mixSource).toBe("measured");
+  });
+
+  it("2b. an endpoint with no ledger history is priced on the box's overall mixDefault", () => {
+    // Both mixDefault entries are the same per-endpoint value in 2; here the
+    // winner's cost is computed with mixDefault alone (no per-endpoint mix).
+    const cachey = endpoint("m", { providerID: "a", cost: { input: 2, output: 2, cacheRead: 0.1, cacheWrite: 0.1 } });
+    const fresh = endpoint("m", { providerID: "b", cost: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1 } });
+    const res = route({
+      catalog: [fresh, cachey],
+      policy: { preset: "balanced" },
+      services: { mixDefault: CACHE_HEAVY },
+    });
+    expect(res.trace.winner!.cost.mixSource).toBe("measured");
+    expect(res.model?.providerID).toBe("a");
+  });
+
+  // --- Test 3: implausible zero loses (catalogue reference wired) ----------
+  const ORIG_SONNET = {
+    id: "declared-sonnet",
+    family: "sonnet",
+    limit: { context: 262000 },
+    benchmarks: [{ name: "SWE-Bench Verified", score: 0.85 }],
+    cost: { input: 3, output: 15 },
+  };
+
+  it("3. a reseller quoting 0/0 for a model the catalogue prices in dollars loses", async () => {
+    const services = await catalogueServices({
+      declaredModels: { "b/declared-sonnet": { catalogId: "declared-sonnet", caches: false }, "a/declared-sonnet": { catalogId: "declared-sonnet", caches: false } },
+      entries: { "declared-sonnet": ORIG_SONNET },
+      endpoints: [{ providerID: "b", id: "declared-sonnet" }, { providerID: "a", id: "declared-sonnet" }],
+    });
+    const reseller = _normalizeProviderModel("b", "declared-sonnet", { id: "declared-sonnet", status: "active", cost: { input: 0, output: 0 }, capabilities: { toolcall: true } })!;
+    const firstParty = _normalizeProviderModel("a", "declared-sonnet", { id: "declared-sonnet", status: "active", cost: { input: 3, output: 15 }, capabilities: { toolcall: true } })!;
+    const res = chooseModel({
+      intent: { kind: "start", agent: "general", needs: {}, contextTokens: 1000 },
+      catalog: [reseller, firstParty],
+      policy: { preset: "balanced" },
+      services,
+    });
+    // The reseller's 0/0 is judged against the catalogue's real rate (it is NOT
+    // a gift) — so the first party, quoting the real rate, wins within the
+    // model's own cost contest.
+    expect(res.model?.providerID).toBe("a");
+  });
+
+  it("3b. a declared-free endpoint still wins", async () => {
+    const services = await catalogueServices({
+      declaredModels: { "b/declared-sonnet": { catalogId: "declared-sonnet", price: "free", caches: false }, "a/declared-sonnet": { catalogId: "declared-sonnet", caches: false } },
+      entries: { "declared-sonnet": ORIG_SONNET },
+      endpoints: [{ providerID: "b", id: "declared-sonnet" }, { providerID: "a", id: "declared-sonnet" }],
+    });
+    const declaredFree = _normalizeProviderModel("b", "declared-sonnet", { id: "declared-sonnet", status: "active", cost: { input: 3, output: 15 }, capabilities: { toolcall: true } })!;
+    const firstParty = _normalizeProviderModel("a", "declared-sonnet", { id: "declared-sonnet", status: "active", cost: { input: 3, output: 15 }, capabilities: { toolcall: true } })!;
+    const res = chooseModel({
+      intent: { kind: "start", agent: "general", needs: {}, contextTokens: 1000 },
+      catalog: [declaredFree, firstParty],
+      policy: { preset: "balanced" },
+      services,
+    });
+    // A user-declared "free" is AUTHORITATIVE — the catalogue reference does not
+    // re-classify it as implausible zero. The free endpoint wins.
+    expect(res.model?.providerID).toBe("b");
+  });
+
+  // --- Test 5: subscription beats free (real codex subscription) -----------
+  it("5. a well-paced subscription outranks a free model of equal task capability (5e)", async () => {
+    // The real codex adapter: a *subscription* (kind) that also reports a credit
+    // balance. On main the balance inference misclassifies it as credit.
+    const snap: any = await codexSnapshot({
+      rate_limit: { primary_window: { used_percent: 60, limit_window_seconds: 18000, reset_at: 2000 } },
+      plan_type: "plus",
+      credits: { balance: 14.2 },
+    });
+    // Position the session window ON PACE (consumed 0.6 / elapsed 0.6) so the
+    // cost basis is the pace curve, not the gauge.
+    const win = snap.windows[0];
+    win.startedAt = 1000;
+    win.resetsAt = 2000;
+    const onPaceNow = 1000 + 0.6 * (2000 - 1000);
+    const accounts = accountFor(codexAdapter, snap as any); // { openai: { kind: "subscription", balance: 14.2, windows: [...] } }
+    const codexModel = endpoint("gpt", { providerID: "openai", tier: "balanced" });
+    const freeModel = endpoint("free", { providerID: "f", tier: "fast", cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } });
+    const res = route({
+      catalog: [freeModel, codexModel],
+      policy: { preset: "balanced" },
+      nowMs: onPaceNow,
+      services: {
+        accounts: { openai: (accounts as any).openai },
+        declared: { ...defaultDeclared([codexModel, freeModel]), "f/free": { catalogId: "free", price: "free" } },
+      },
+    });
+    expect(res.model?.providerID).toBe("openai");
+    expect(res.trace.winner!.cost.basis.startsWith("subscription")).toBe(true);
+    expect(res.trace.winner!.cost.basis).toBe("subscription-pace");
+  });
+
+  // --- Test 6: exhausted is excluded, not expensive -------------------------
+  it("6. an exhausted provider is unselectable even as the only candidate; the incumbent is kept", async () => {
+    // The real claude adapter reporting a 100% session window → exhausted.
+    const snap: any = await claudeSnapshot({
+      five_hour: { utilization: 100, resets_at: 2000 },
+      seven_day: { utilization: 30, resets_at: 2000 + 86400000 },
+    });
+    const accounts = accountFor(claudeAdapter, snap as any); // { anthropic: { kind: "subscription", windows: [pct 100], exhausted: true } }
+    const only = endpoint("m", { providerID: "anthropic" });
+    const incumbent = endpoint("inc", { providerID: "x" });
+    const res = route({
+      catalog: [only],
+      policy: { preset: "balanced" },
+      intent: { incumbent },
+      services: { accounts: { anthropic: (accounts as any).anthropic } },
+    });
+    expect(res.model?.providerID).toBe("x");
+    expect(res.changed).toBe(false);
+    expect(res.reason.toLowerCase()).toContain("no general model passes constraints");
+  });
+
+  // --- Test 7: stale never excludes -----------------------------------------
+  // A stale 100% window (set by the usage poller the moment a reset passes) must
+  // not escalate: it contributes neither exhaustion nor pace. On main the
+  // exhaustion check ignores `stale` and drops the provider.
+  it("7. a stale 100% window leaves the provider selectable", () => {
+    const a = endpoint("m", { providerID: "a" });
+    const res = route({
+      catalog: [a],
+      policy: { preset: "balanced" },
+      services: { accounts: { a: { kind: "subscription", windows: [{ pct: 100, stale: true }] } } },
+    });
+    expect(res.model?.providerID).toBe("a");
+  });
+
+  it("7b. if every window is stale the account is priced as if it had none (no-window), not exhausted", () => {
+    const a = endpoint("m", { providerID: "a" });
+    const res = route({
+      catalog: [a],
+      policy: { preset: "balanced" },
+      services: { accounts: { a: { kind: "subscription", windows: [{ pct: 100, stale: true }] } } },
+    });
+    expect(res.model?.providerID).toBe("a");
+    expect(res.trace.winner!.cost.basis).toBe("subscription-no-window");
   });
 });

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Routing: the cost stage — measured mix, real reference, no list price for a subscription (BET-1269)

Fixes the seven wiring defects that kept the cost stage of Automatic Manta Routing from operating at all. The router never used the box's actually-measured token mix, never had a catalogue reference to judge implausible prices against, priced subscriptions off their list price, misclassified the codex subscription as prepaid credit, let a stale reading exclude a provider, and treated an unfunded credit account as "not connected".

**Base:** `origin/main @ 3cbc8d20`

### Changes (5a–5g)

- **5a · measured mix arrives.** `ledgerToServices` normalises each endpoint's raw token counts with `mixFromCounts` and computes a `mixDefault` from the whole ledger; `assess()` prices an endpoint with `services.mix[key] ?? services.mixDefault`, so an endpoint with no history is priced on the box's overall mix, not the constant `DEFAULT_MIX`.
- **5b · implausible-zero can fire.** `buildRoutingServices` populates `referenceByModel` (keyed by model id) from the provider-agnostic catalogue's own input/output rates — a lookup, no new fetch. A reseller quoting 0/0 for a priced model is now judged against the real rate.
- **5c · no list price for a subscription.** Deleted the `blendedPrice` list-price fallback in `exchangeRateOf`. `chooseModel` computes the replacement cost — the cheapest **non-subscription** endpoint's blended price in the candidate set — once per call and threads it in; with no cash alternative the exchange rate is 0 (free at the margin).
- **5d · OpenRouter balance is what's left.** Added `balance.minusPath` (the whole permitted descriptor addition) and set the OpenRouter descriptor to `balance = total_credits − total_usage`, so the remaining balance (not the granted total) drives the depletion curve.
- **5e · declared account kind.** Each adapter (claude/codex/kimi = `subscription`) and descriptor (openrouter = `credit`) declares `kind` on the snapshot; `usage.mjs` carries it through; `accountsFromSnapshots` reads the declaration and never infers from `balance` — so codex is priced on the pace curve, not the credit premium + depletion.
- **5f · stale never excludes.** `marginalCost` drops `stale` windows from both the exhaustion check and the pace loop; if every window is stale the account is priced as if it had none, not as exhausted.
- **5g · an unfunded credit account is a valid snapshot.** `usage.mjs` only throws "zero usable windows" when a snapshot has **neither** windows **nor** a balance; a balance-only snapshot (e.g. OpenRouter with `total_credits: 0`) is valid and distinguishable from "not connected".

All decision-core files remain provider-name-free; no expression language, no config knobs.

### Verification results (acceptance 2 — per test, main vs branch)

The seven cost-stage tests (run on `main @ 3cbc8d20` and on this branch; full suite logs below):

| # | Test | on `main` | on branch |
|---|---|---|---|
| 1 | Cache is priced | pass (pre-existing) | pass |
| 2 | Mix is measured | **fail** (mixSource "default") | pass (`measured`) |
| 3 | Implausible zero loses (3) / declared-free wins (3b) | **fail** (3) / pass (3b) | pass / pass |
| 4 | Pace, not fill | pass (pre-existing) | pass |
| 5 | Subscription beats free | **fail** (codex misclassified as credit → `credit-*` basis) | pass (`subscription-pace`) |
| 6 | Exhausted is excluded | pass (already worked) | pass |
| 7 | Stale never excludes (7 / 7b) | **fail** (stale 100% drops the provider) | pass / pass |

Tests 1 and 4 already passed on `main` (they predate this issue) and test 6 correctly "may already pass" as the issue predicted — the new-toggle defects were 2, 3, 5 and 7, and each fails on `main` and passes here.

- PR branch (`multica/BET-1269-cost-stage` @ `e7f69b7e`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, vitest 3491 pass / 7 skip, node:test 2680 pass / 0 fail. log sha256: `1ee18b3928275311baf01d63b58671556b08e2b71a4ed0cbea173b89cf715f6c`
- Base (`origin/main @ ec336d7e`): cost-stage block run on a `3cbc8d20` worktree — the six/seven cost-stage tests behave as the table above (the branch's only diff from that base is this PR).
- **Conclusion:** 0 new failures, 0 pre-existing failures on the branch; full suite green.

### Note on test 5's basis

The real codex adapter reports a session window **without** a window start, so its live marginal cost basis is `subscription-consumed` (the pace-fallback the marginal cost module already defines); the test drives an on-pace window to assert `subscription-pace` to match the issue's wording. The pace-vs-fill property itself is pinned by the pre-existing "pace, not fill" test in `marginalCost.test.ts` (test 4 in the matrix).

### Account-shape provenance

The account tests use the **real** coders — `codexAdapter` / `claudeAdapter` fetched with injected I/O, and `accountsFromSnapshots` for the mapping — so the fixtures cannot quietly disagree with what production produces.
