### PR TITLE
Routing: provider health must influence routing and reach the user (BET-1270)

### DIFF
--- a/src/renderer/AccountsCard.tsx
+++ b/src/renderer/AccountsCard.tsx
@@ -31,6 +31,7 @@ import { useCallback, useMemo, useState, type ReactNode } from "react";
 import { X } from "lucide-react";
 import type { ProviderEndpoint, SubscriptionStatus, UsageSnapshot, UsageWindow } from "../shared/types";
 import { autoEligibility, MISSING } from "../shared/autoEligibility.mjs";
+import { providerStateLabel } from "../shared/providerHealthLabel.mjs";
 import { resolveIdentity } from "../shared/modelIdentity.mjs";
 import { ConnectProvider } from "./ConnectProvider";
 import { CustomProviderForm } from "./CustomProviderForm";
@@ -87,14 +88,15 @@ const formatDollars = (n: number) => (Number.isFinite(n) ? n.toFixed(2) : String
  * credential absence; then "no usage data".
  */
 export function describeAccountState(r: AccountRowModel): AccountState {
-  if (r.health === "out-of-credit") return { text: "Out of credit", tone: "danger" };
+  if (r.health === "out-of-credit") return { text: providerStateLabel("out-of-credit") ?? "Out of credit", tone: "danger" };
   if (r.health === "rate-limited") {
+    const base = providerStateLabel("rate-limited") ?? "Rate limited";
     return {
-      text: r.retryInMinutes ? `Rate limited · retry in ${r.retryInMinutes}m` : "Rate limited",
+      text: r.retryInMinutes ? `${base} · retry in ${r.retryInMinutes}m` : base,
       tone: "warn",
     };
   }
-  if (r.health === "failing") return { text: "Not responding", tone: "warn" };
+  if (r.health === "failing") return { text: providerStateLabel("failing") ?? "Not responding", tone: "warn" };
   if (r.reading) {
     const pct = r.reading.pct;
     const tone: AccountStatus = pct >= 90 ? "danger" : pct >= 70 ? "warn" : "ok";

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -481,6 +481,11 @@ export function ChatPanel({
   // — never silently. The model is applied to the override, carrying forward
   // the user's current in-memory effort (BET-1274 10c) so a just-chosen effort
   // is not dropped by a route.
+  // The incumbent provider's health as LAST REPORTED BY THE BOX (routing:choose
+  // returns it — see 6e). Kept as a ref so crossesBoundary can read whether the
+  // incumbent is still available BEFORE the next routing:choose round trip, while
+  // the renderer itself holds no independent health state. Defaults healthy.
+  const incumbentHealthRef = useRef<boolean>(true);
   const applyRouted = useCallback((model: ModelSelection | null, reason: string) => {
     const incumbent = routedModelRef.current;
     setRouted({
@@ -731,6 +736,7 @@ export function ChatPanel({
     setRoutedModel(null);
     setRoutedReason(null);
     routedModelRef.current = null;
+    incumbentHealthRef.current = true;
     pendingAutoUserRef.current = false;
     // Seed plan mode from the session's own `agent` field when present (BET-949
     // §5): a session pre-set to plan OUTSIDE MantaUI would otherwise show the
@@ -1331,7 +1337,7 @@ export function ChatPanel({
         : undefined;
       const requiredModes = readyAttachments.map((a) => mimeToInputMode(a.mime));
       const currentAgent = planAgent ?? "build";
-      const { crossed, boundary, stillCapable, stillHealthy } = crossesBoundary({
+      const { crossed, boundary, stillCapable } = crossesBoundary({
         hasRoutedModel: incumbent != null,
         agent: currentAgent,
         previousAgent: lastAgentRef.current,
@@ -1339,7 +1345,7 @@ export function ChatPanel({
         incumbentContextLimit: incumbentModel?.limit?.context ?? undefined,
         requiredModalities: requiredModes,
         incumbentModel,
-        incumbentHealthy: true,
+        incumbentHealthy: incumbentHealthRef.current,
         justCompacted: justCompactedRef.current,
         userRequested: pendingAutoUserRef.current,
       });
@@ -1361,6 +1367,10 @@ export function ChatPanel({
             },
             incumbent,
           });
+          // Remember the box's answer about the incumbent for the NEXT turn's
+          // crossesBoundary (so an outage fires a CONSTRAINT boundary even before
+          // this turn switches). Defaults healthy when the box didn't report.
+          incumbentHealthRef.current = decision.incumbentHealthy !== false;
           const ranked = decision.model
             ? [decision.model, ...decision.alternatives]
             : decision.alternatives;
@@ -1373,9 +1383,9 @@ export function ChatPanel({
             shouldSwitch({
               incumbent,
               ranked,
-              incumbentStillEligible: true,
+              incumbentStillEligible: decision.incumbentStillEligible !== false,
               incumbentStillCapable: stillCapable,
-              incumbentHealthy: stillHealthy,
+              incumbentHealthy: decision.incumbentHealthy !== false,
             }).switch
           ) {
             const reason = decision.reason + (boundary ? ` · ${boundaryPhrase(boundary)}` : "");

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -46,6 +46,7 @@ import { startStatusPoller } from "./status.mjs";
 import { createSyncState } from "./syncState.mjs";
 import { createStreamInterpreter } from "./streamInterp.mjs";
 import { enrichProviderError } from "../shared/streamInterpretation.mjs";
+import { providerStateLabel } from "../shared/providerHealthLabel.mjs";
 import { startOutboxPoller, pushArtifact, createArtifactSweep } from "./outbox.mjs";
 import { startUploadCleanupPoller } from "./uploads.mjs";
 import {
@@ -433,11 +434,63 @@ const usageStopEngine = createUsageStopEngine({
 // OWN per-session provider cache (getSessionModel — no second cache is built
 // here); observeEvent is fed the opencode pump below alongside the others.
 const providerHealth = createProviderHealth({
-  publish: (evt) => bus.publish(evt),
+  // BET-1270 6d: a provider going out of credit / rate-limited / failing must
+  // SURFACE, not sit unpublished (nobody subscribes to a bus kind that was never
+  // wired to the renderer). Route the ONE transition event through the EXISTING
+  // notification router (fireNotify — informational tier) instead of adding a
+  // second delivery mechanism. The body names the provider + state in the same
+  // words as the Accounts row (shared providerStateLabel), so the two surfaces
+  // cannot disagree.
+  publish: (evt) => {
+    if (evt?.kind === "provider-health.needs-attention") {
+      const { providerID, state } = evt.payload ?? {};
+      const label = providerStateLabel(state);
+      if (providerID && label) {
+        void push.fireNotify({
+          title: "Provider needs attention",
+          message: `${providerID}: ${label}`,
+          urgent: false,
+        });
+        return;
+      }
+    }
+    bus.publish(evt);
+  },
   getSessionModel: (sessionId) => usageStopEngine.getSessionModel(sessionId),
   providerIDForAdapter,
+  // BET-1270 6b: attribute adapter-less (custom / pay-as-you-go) providers by
+  // their failing model's endpoint identity. The map below is the synchronous
+  // modelID -> providerID the health pump reads; refreshed from the opencode
+  // model list (the SAME source the adapters are keyed by).
+  providerForModel: (modelID) => modelProviderIndex.get(modelID) ?? null,
   recheckAtLimit: (adapterId) => recheckAdapterAtLimit(adapterId),
 });
+
+// BET-1270 6b: modelID -> providerID for providers with NO usage adapter. The
+// box cannot ask an adapter-less provider its identity, but it answers "which
+// connected provider exposes this model?" from the opencode model list — first
+// writer wins (stable), refreshed at startup (provider sets change rarely).
+const modelProviderIndex = new Map();
+async function refreshModelProviderIndex() {
+  try {
+    const models = await oc.listModels();
+    for (const m of Array.isArray(models) ? models : []) {
+      const providerID = m?.providerID;
+      const id = m?.id ?? m?.modelID;
+      if (
+        typeof providerID === "string" &&
+        typeof id === "string" &&
+        id !== "" &&
+        !modelProviderIndex.has(id)
+      ) {
+        modelProviderIndex.set(id, providerID);
+      }
+    }
+  } catch {
+    // non-fatal: attribution degrades to the supported-provider path
+  }
+}
+void refreshModelProviderIndex();
 // Recovery path #3 (issue §Three ways the flag clears): a supported provider's
 // reader reporting funds on a normal poll clears its evidence-only
 // out-of-credit flag. Reuses the EXISTING usage poller's `usage.updated`
@@ -1169,7 +1222,15 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
   // existing consumer (renderer banner, push classification, the usage-stop
   // enroller) keeps working unchanged.
   if (evt && evt.type === "session.error" && evt.properties?.error) {
-    evt.properties.error = enrichProviderError(evt.properties.error);
+    // BET-1270 6c: a transport-level 429 (prompt_async POST) carries the
+    // provider's Retry-After but is NOT a session.error on the stream — the
+    // pump bridges it here so the enrichment hands a real retryAfterMs to
+    // providerHealth instead of clamping every rate-limit to the 2-min floor.
+    const refusal = oc.getAndClearSessionRefusal(evt.properties?.sessionID);
+    evt.properties.error = enrichProviderError(
+      evt.properties.error,
+      refusal?.retryAfterMs,
+    );
   }
   // Box-side stream interpretation (BET-551 / §17): derive interpreted events
   // from the raw opencode stream and publish them on the SAME bus (no second

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -617,6 +617,31 @@ export async function getMessage(sessionId, messageId) {
   }
 }
 
+// BET-1270 6c: transport-level refusals (a non-2xx on the prompt_async POST
+// itself) carry the provider's Retry-After, but surface to the box as a THROWN
+// error rather than a `session.error` SSE event — so the Retry-After never
+// reaches providerHealth and every rate-limit clamps to the 2-min floor. Record
+// the transport refusal per-session at the point it is read, so the opencode
+// pump's session.error enrichment can attach its retryAfterMs when the matching
+// session.error arrives (a model-level 429 that streams via SSE carries no
+// header). Best-effort bridge; nothing here is awaited.
+const _transportRefusalBySession = new Map(); // sessionId -> { httpStatus, retryAfterMs? }
+
+/**
+ * Read + clear a session's most recent transport-level refusal. The pump calls
+ * this while enriching a `session.error` for the same session, so the
+ * Retry-After read at the prompt boundary reaches providerHealth / the Accounts
+ * row. Returns undefined when there is no (or no more) recorded refusal.
+ * @param {string} [sessionId]
+ * @returns {{ httpStatus?: number, retryAfterMs?: number }|undefined}
+ */
+export function getAndClearSessionRefusal(sessionId) {
+  if (!sessionId) return undefined;
+  const r = _transportRefusalBySession.get(sessionId);
+  if (r) _transportRefusalBySession.delete(sessionId);
+  return r;
+}
+
 /**
  * Send a user message (prompt_async — returns 204 immediately; response
  * streams via SSE). Model is per-prompt; omit to use opencode's default.
@@ -668,6 +693,12 @@ export async function sendPrompt({ sessionId, text, model, agent, attachments, m
     err.status = res.status;
     const retryAfterMs = parseRetryAfterMs(res.headers?.get?.("retry-after"));
     if (retryAfterMs !== undefined) err.retryAfterMs = retryAfterMs;
+    // BET-1270 6c: stash the transport Retry-After for the session so the pump
+    // can attach it to the matching session.error (see getAndClearSessionRefusal).
+    _transportRefusalBySession.set(sessionId, {
+      httpStatus: res.status,
+      ...(retryAfterMs !== undefined ? { retryAfterMs } : {}),
+    });
     throw err;
   }
 }

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -5,6 +5,7 @@ import {
   parseSseFrame,
   createSession,
   sendPrompt,
+  getAndClearSessionRefusal,
   getSessionAgent,
   listMessages,
   getMessage,
@@ -394,6 +395,37 @@ test("sendPrompt non-2xx carries status + Retry-After (BET-1230)", async () => {
       assert.equal(thrown.status, 429);
       assert.equal(thrown.retryAfterMs, 30_000);
       assert.match(thrown.message, /429/);
+    },
+  );
+});
+
+test("transport refusal records Retry-After per-session for the pump to bridge (BET-1270 6c)", async () => {
+  // The prompt_async POST carries Retry-After but is a THROWN error, not a
+  // session.error SSE event — getAndClearSessionRefusal is how the pump attaches
+  // it to the matching session.error so providerHealth gets a real cooldown.
+  _resetSessionDirectoryCache();
+  await withMockFetch(
+    async (url) => {
+      if (String(url).startsWith("http://127.0.0.1:4096/session?directory=")) {
+        return new Response(
+          JSON.stringify({ id: "ses_rl", title: "t", directory: "/w", projectID: "p" }),
+          { status: 200, headers: { "content-type": "application/json" } },
+        );
+      }
+      return new Response("slow down", {
+        status: 429,
+        headers: { "retry-after": "900" },
+      });
+    },
+    async () => {
+      await assert.rejects(() => sendPrompt({ sessionId: "ses_rl", text: "hi" }));
+      const refusal = getAndClearSessionRefusal("ses_rl");
+      // Retry-After: 900 seconds -> 900_000 ms, carried to the pump.
+      assert.deepEqual(refusal, { httpStatus: 429, retryAfterMs: 900_000 });
+      // Read-once: a second read returns undefined (the pump must not re-apply it).
+      assert.equal(getAndClearSessionRefusal("ses_rl"), undefined);
+      // A session with no refusal returns undefined.
+      assert.equal(getAndClearSessionRefusal("ses_other"), undefined);
     },
   );
 });

--- a/src/server/providerHealth.mjs
+++ b/src/server/providerHealth.mjs
@@ -37,8 +37,13 @@
 // per-session {adapterId, model} cache built from `session.next.step.ended` in
 // usageStopEnroll.mjs (exposed as getSessionModel) — it does NOT write a
 // second cache. The adapter id is mapped back to an opencode providerID via
-// providerIDForAdapter; a session whose provider was never observed (or a
-// pay-as-you-go key) cannot be attributed and is skipped.
+// providerIDForAdapter. A custom / pay-as-you-go provider has NO usage adapter,
+// so providerIDForAdapter returns null for exactly the case this module exists
+// for (BET-1270 6b): a provider with no meter can still be attributed. Fall
+// back to the failing MODEL's endpoint identity — the session cache carries the
+// model id and a `providerForModel` reader maps it to the connected provider
+// that exposes it. The usage adapter is an unrelated concern and must not gate
+// attribution.
 //
 // Surfacing: per the `NEVER STUB A CONTROL TO DO NOTHING` rule in AGENTS.md an
 // excluded provider must surface, not silently disappear. A needs-attention
@@ -85,6 +90,10 @@ function clampRetryAfterMs(retryAfterMs) {
  *   usageStopEnroll.mjs (BET-1230 exposes it) — reused, never duplicated
  * @param {(adapterId: string) => string|null} [deps.providerIDForAdapter]
  *   adapter id -> opencode providerID (usage.mjs)
+ * @param {(modelID: string) => string|null} [deps.providerForModel]
+ *   model id -> opencode providerID, for a provider with NO usage adapter
+ *   (custom / pay-as-you-go). The failing model's identity is the attribution
+ *   the usage adapter cannot give (BET-1270 6b).
  * @param {(adapterId: string) => Promise<boolean>|boolean} [deps.recheckAtLimit]
  *   wire to recheckAdapterAtLimit — a cheap metadata fetch, ZERO model calls
  * @param {number} [deps.minFailuresToDeprioritize]
@@ -101,6 +110,7 @@ export function createProviderHealth({
   publish = () => {},
   getSessionModel = () => null,
   providerIDForAdapter = () => null,
+  providerForModel = () => null,
   recheckAtLimit = async () => false,
   minFailuresToDeprioritize = MIN_FAILURES_TO_DEPRIORITIZE,
 } = {}) {
@@ -158,9 +168,17 @@ export function createProviderHealth({
 
   function attributedProvider(sessionId) {
     const m = getSessionModel(sessionId);
-    const adapterId = m?.adapterId;
-    if (!adapterId) return null;
-    return providerIDForAdapter(adapterId);
+    if (!m) return null;
+    // A supported provider: the usage adapter IS its identity reader.
+    const viaAdapter = m.adapterId ? providerIDForAdapter(m.adapterId) : null;
+    if (viaAdapter) return viaAdapter;
+    // A custom / pay-as-you-go provider has no usage adapter — attribute by the
+    // failing MODEL's endpoint identity instead. The adapter is unrelated to
+    // which provider refused the turn and must not gate attribution (6b).
+    if (typeof m.model === "string" && m.model !== "") {
+      return providerForModel(m.model);
+    }
+    return null;
   }
 
   function applyFailure(providerID, error) {

--- a/src/server/providerHealth.test.mjs
+++ b/src/server/providerHealth.test.mjs
@@ -248,6 +248,45 @@ test("unattributable failures (no session / unknown provider) are ignored", () =
   assert.equal(published.filter((e) => e.kind === "provider-health.needs-attention").length, 0);
 });
 
+test("a provider with NO usage adapter is attributed by its failing model (BET-1270 6b)", () => {
+  // A custom / pay-as-you-go provider has no usage adapter, so
+  // providerIDForAdapter returns null for exactly the case the module exists
+  // for. The failing MODEL's endpoint identity is the attribution — the adapter
+  // is an unrelated concern and must not gate it.
+  const clock = { t: 1000 };
+  const published = [];
+  const engine = createProviderHealth({
+    now: () => clock.t,
+    publish: (evt) => published.push(evt),
+    // The session's provider was never observed via a step event (adapterId null)
+    // — only the model id is known.
+    getSessionModel: (sid) => (sid === "s-payg" ? { adapterId: null, model: "deepseek-chat" } : null),
+    providerIDForAdapter: () => null, // no adapter anywhere
+    providerForModel: (model) => ({ "deepseek-chat": "deepseek" }[model] ?? null),
+    recheckAtLimit: async () => false,
+  });
+  engine.observeEvent({
+    type: "session.error",
+    properties: { sessionID: "s-payg", error: { httpStatus: 402 } },
+  });
+  assert.equal(engine.state("deepseek"), PROVIDER_HEALTH_STATE.OUT_OF_CREDIT);
+  const attention = published.filter((e) => e.kind === "provider-health.needs-attention");
+  assert.equal(attention.length, 1);
+  assert.equal(attention[0].payload.providerID, "deepseek");
+
+  // A provider NOT reachable via adapter OR model stays unattributable.
+  const engine2 = createProviderHealth({
+    now: () => clock.t,
+    publish: () => {},
+    getSessionModel: () => ({ adapterId: null, model: "mystery-model" }),
+    providerIDForAdapter: () => null,
+    providerForModel: () => null,
+    recheckAtLimit: async () => false,
+  });
+  engine2.observeEvent({ type: "session.error", properties: { sessionID: "s-x", error: { httpStatus: 402 } } });
+  assert.deepEqual(engine2.all(), {});
+});
+
 test("retryIn() reports the remaining rate-limit cooldown, then null once it expires (BET-1250)", () => {
   const { engine, error, clock, providerID } = make();
   assert.equal(engine.retryIn(providerID), null, "no cooldown before a 429");

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -869,12 +869,26 @@ export function buildHandlers({
           console.error(`[router] routing services degraded, routing on absent context: ${e?.message ?? e}`);
           services = null;
         }
-        // Normalise the incumbent into catalog shape ({providerID, id}) so the
-        // `changed` comparison inside chooseModel treats a requested model and
-        // a catalog entry of the same model as equal.
-        const catalogIncumbent = incumbent
-          ? { providerID: incumbent.providerID, id: incumbent.modelID ?? incumbent.id }
+        // Resolve the incumbent's FULL catalog endpoint (the normalized
+        // OpencodeModel with cost/capabilities) so the eligibility gate sees the
+        // real endpoint, not a price-less stub. BET-1270 6e reviewer Block: a
+        // stripped {providerID, id} fails autoEligibility's Price/Caching gates,
+        // forcing `incumbent-ineligible` off a perfectly describable incumbent on
+        // every boundary-crossing turn. Fall back to the stripped stub only when
+        // the incumbent is absent from the routable catalog (genuinely not
+        // routable → honestly ineligible).
+        const fullIncumbent = incumbent
+          ? (Array.isArray(catalog) ? catalog : []).find(
+              (c) =>
+                c?.providerID === incumbent.providerID &&
+                String(c?.id ?? c?.modelID ?? "") === String(incumbent.modelID ?? incumbent.id ?? ""),
+            ) ?? null
           : null;
+        const catalogIncumbent =
+          fullIncumbent ??
+          (incumbent
+            ? { providerID: incumbent.providerID, id: incumbent.modelID ?? incumbent.id }
+            : null);
         // BET-1270 6e: the box-side facts about the incumbent the renderer
         // sent, reported back on the SAME round trip (no second fetch, no
         // renderer-held health/eligibility state). `incumbentHealthy` is false

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -38,7 +38,7 @@ import { toDeliverModel } from "./delegate.mjs";
 import { buildRoutingServices } from "./routingServices.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { pollClaudeLogin, claudeCliStatus, listRoutableModels } from "./opencode.mjs";
-import { chooseModel } from "../shared/modelRouter.mjs";
+import { chooseModel, incumbentStillEligible } from "../shared/modelRouter.mjs";
 import { backupClaudeCredentials, CREDENTIALS_PATH } from "./claudeAuth.mjs";
 import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
@@ -875,6 +875,18 @@ export function buildHandlers({
         const catalogIncumbent = incumbent
           ? { providerID: incumbent.providerID, id: incumbent.modelID ?? incumbent.id }
           : null;
+        // BET-1270 6e: the box-side facts about the incumbent the renderer
+        // sent, reported back on the SAME round trip (no second fetch, no
+        // renderer-held health/eligibility state). `incumbentHealthy` is false
+        // when the incumbent's provider is excluded or failing; `incumbentStillEligible`
+        // is the SAME completeness gate the router uses (autoEligibility), so the
+        // renderer's shouldSwitch can force an ineligible/unhealthy incumbent out.
+        const incumbentHealthy = !["out-of-credit", "rate-limited", "failing"].includes(
+          routingProviderHealthState(incumbent?.providerID) ?? "ok",
+        );
+        const stillEligible = catalogIncumbent
+          ? incumbentStillEligible(catalogIncumbent, services)
+          : true;
         const decision = chooseModel({
           intent: {
             kind: surface === "sub" ? "subagent" : "main",
@@ -919,10 +931,19 @@ export function buildHandlers({
             ? decision.alternatives.map(toDeliverModel).filter(Boolean)
             : [],
           changed: decision?.changed === true,
+          incumbentHealthy,
+          incumbentStillEligible: stillEligible,
         };
       } catch (e) {
         console.warn("[router] routing:choose failed, using incumbent:", e?.message ?? e);
-        return { model: incumbent, reason: "routing unavailable", alternatives: [], changed: false };
+        return {
+          model: incumbent,
+          reason: "routing unavailable",
+          alternatives: [],
+          changed: false,
+          incumbentHealthy: true,
+          incumbentStillEligible: true,
+        };
       }
     },
 

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -1367,6 +1367,56 @@ test("routing:choose logs exactly one well-formed [router] line on a routed deci
   assert.equal(lines[0], "[router] main/build → anthropic/claude-sonnet-4 · unknown · considered=1 dropped=0 mix=default");
 });
 
+// BET-1270 6e: routing:choose reports the box's facts about the incumbent it
+// was handed — `incumbentHealthy` (its provider not excluded/failing) and
+// `incumbentStillEligible` (the same autoEligibility gate the router uses) — so
+// the renderer's shouldSwitch can force an ineligible/unhealthy incumbent out
+// on the SAME round trip, without holding health state of its own.
+test("routing:choose reports incumbentHealthy=false when the incumbent's provider is failing (6e)", async () => {
+  const { deps } = makeDeps([]);
+  deps.local.configGet = async () => ({ projects: [], modelRouting: { preset: "economy" } });
+  deps.routingListRoutableModels = async () => [
+    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
+  ];
+  deps.routingProviderHealthState = (pid) => (pid === "anthropic" ? "failing" : null);
+  const handlers = buildHandlers(deps);
+  const out = await handlers["routing:choose"]({
+    sessionId: "ses_1",
+    directory: "/w",
+    agent: "build",
+    surface: "main",
+    contextTokens: 0,
+    needs: {},
+    incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
+  });
+  assert.equal(out.incumbentHealthy, false, "failing provider ⇒ incumbent unhealthy");
+  assert.equal(
+    typeof out.incumbentStillEligible,
+    "boolean",
+    "incumbentStillEligible is reported as a boolean",
+  );
+});
+
+test("routing:choose reports incumbentHealthy=true for a healthy incumbent (6e)", async () => {
+  const { deps } = makeDeps([]);
+  deps.local.configGet = async () => ({ projects: [], modelRouting: { preset: "economy" } });
+  deps.routingListRoutableModels = async () => [
+    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
+  ];
+  deps.routingProviderHealthState = () => null; // provider healthy (absent state)
+  const handlers = buildHandlers(deps);
+  const out = await handlers["routing:choose"]({
+    sessionId: "ses_1",
+    directory: "/w",
+    agent: "build",
+    surface: "main",
+    contextTokens: 0,
+    needs: {},
+    incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
+  });
+  assert.equal(out.incumbentHealthy, true);
+});
+
 // accounts:retry always reports an outcome — a non-empty message in BOTH the
 // cleared and not-cleared cases (AGENTS.md: it does the thing and says so,
 // or fails and says why; a swallowed bare return is a dead button).

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -1417,6 +1417,47 @@ test("routing:choose reports incumbentHealthy=true for a healthy incumbent (6e)"
   assert.equal(out.incumbentHealthy, true);
 });
 
+// 6e reviewer Block regression: incumbentStillEligible must be computed from the
+// incumbent's FULL catalog endpoint (cost/capabilities/catalogue identity), not
+// a price-less {providerID,id} stub — otherwise a perfectly describable incumbent
+// reads ineligible and shouldSwitch force-switches every boundary-crossing turn.
+test("routing:choose reports incumbentStillEligible=true for a describable incumbent (6e Block regression)", async () => {
+  const { deps } = makeDeps([]);
+  deps.local.configGet = async () => ({
+    projects: [],
+    modelRouting: {
+      preset: "economy",
+      declaredModels: { "anthropic/claude-sonnet-4": { catalogId: "claude-sonnet-4" } },
+    },
+  });
+  deps.routingListRoutableModels = async () => [
+    {
+      providerID: "anthropic",
+      id: "claude-sonnet-4",
+      status: "active",
+      cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0.5 },
+    },
+  ];
+  // A catalogue index so buildRoutingServices resolves identity + quality (the
+  // SAME seam the BET-1265 log test uses).
+  const fakeCatalog = {
+    matchModel: (id) => ({ kind: "exact", candidates: [{ id, name: id }] }),
+    lookupModel: (id) => ({ id }),
+    allModels: () => [{ id: "claude-sonnet-4", benchmarks: [{ name: "SWE-Bench Verified", score: 0.8 }] }],
+  };
+  const handlers = buildHandlers({ ...deps, routingCatalogIndex: fakeCatalog });
+  const out = await handlers["routing:choose"]({
+    sessionId: "ses_1",
+    directory: "/w",
+    agent: "build",
+    surface: "main",
+    contextTokens: 0,
+    needs: {},
+    incumbent: { providerID: "anthropic", modelID: "claude-sonnet-4" },
+  });
+  assert.equal(out.incumbentStillEligible, true, "a describable incumbent must read eligible");
+});
+
 // accounts:retry always reports an outcome — a non-empty message in BOTH the
 // cleared and not-cleared cases (AGENTS.md: it does the thing and says so,
 // or fails and says why; a swallowed bare return is a dead button).

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -102,6 +102,13 @@ type RoutingChooseDecision = {
   reason: string;
   alternatives: PromptModel[];
   changed: boolean;
+  // BET-1270 6e: the box's facts about the incumbent the caller sent, returned
+  // on the SAME round trip so the renderer holds no health/eligibility state of
+  // its own. `incumbentHealthy` is false when the incumbent's provider is
+  // excluded or failing; `incumbentStillEligible` is the router's completeness
+  // gate (autoEligibility).
+  incumbentHealthy: boolean;
+  incumbentStillEligible: boolean;
 };
 // BET-1249: a provider-agnostic catalogue entry as served by
 // `opencode:model-catalog` (models.dev view). Consumed by the renderer's

--- a/src/shared/modelRouter.d.mts
+++ b/src/shared/modelRouter.d.mts
@@ -99,3 +99,8 @@ export interface ChooseResult {
 }
 
 export function chooseModel(input?: ChooseInput): ChooseResult;
+
+export function incumbentStillEligible(
+  candidate: Model | null | undefined,
+  services?: RoutingServices,
+): boolean;

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -211,15 +211,53 @@ function signalsOf(a) {
   };
 }
 
+// BET-1270 6e: is the incumbent still describable by Auto (the completeness
+// gate)? The renderer's hysteresis (shouldSwitch) needs this to force a switch
+// off an incumbent Auto can no longer describe — computed here, server-side,
+// from the SAME assess machinery, so the renderer keeps no eligibility state of
+// its own (one round trip, one source of truth).
+export function incumbentStillEligible(candidate, services) {
+  if (!candidate || typeof candidate !== "object") return true;
+  const key = endpointKey(candidate);
+  const dec = services?.declared?.[key] ?? null;
+  const identity = resolveIdentity(candidate, dec, services?.catalogMatcher);
+  const m = identity.effective ?? candidate;
+  const catalogEntry =
+    typeof services?.catalogEntryFor === "function" ? services.catalogEntryFor(candidate) : null;
+  const quality = qualityScore(m, catalogEntry, services?.qualityField);
+  const elig = autoEligibility({
+    model: m,
+    identity: { known: identity.state === "resolved" },
+    quality,
+    declared: dec,
+    providerClass: services?.providerClass?.[candidate.providerID] ?? "supported",
+  });
+  return elig.eligible;
+}
+
+function healthRank(a, services) {
+  const providerID = a?.candidate?.providerID ?? a?.effective?.providerID;
+  const st = services?.health?.[providerID];
+  // Only `failing` is a soft/deprioritised signal here. `out-of-credit` and
+  // `rate-limited` never reach the ordering — they are EXCLUDED (hard) in
+  // capabilityDrop, so a survivor's health is either ok or failing.
+  return st === "failing" ? 1 : 0;
+}
+
 // Soft ordering within a competing set (same model, or a flattened economy
-// set): penalised sorts last; then cost; then quality, throughput, the
-// latency percentiles, and finally the full provider/model key — deterministic
-// (the model id alone is identical for exactly the endpoints most likely to
-// tie, so the old final tie-break was deterministic by accident).
+// set): penalised sorts last; then a soft `failing` health sorts behind a
+// healthy endpoint (BET-1270 6a — placed after reliability, before cost); then
+// cost; then quality, throughput, the latency percentiles, and finally the full
+// provider/model key — deterministic (the model id alone is identical for
+// exactly the endpoints most likely to tie, so the old final tie-break was
+// deterministic by accident).
 function cmpWithinModel(a, b, services) {
   const pa = a.penalise ? 1 : 0;
   const pb = b.penalise ? 1 : 0;
   if (pa !== pb) return pa - pb;
+  const ha = healthRank(a, services);
+  const hb = healthRank(b, services);
+  if (ha !== hb) return ha - hb;
   if (a.marginalCost !== b.marginalCost) return a.marginalCost - b.marginalCost;
   if (a.qualityScore !== b.qualityScore) return b.qualityScore - a.qualityScore;
   const ta = telemetryOf(a, services);
@@ -399,7 +437,7 @@ export function chooseModel(input = {}) {
     };
   }
 
-  const explored = stage3Order(survivors, { preset: policy?.preset, telemetry: services.telemetry });
+  const explored = stage3Order(survivors, { preset: policy?.preset, telemetry: services.telemetry, health: services.health });
   const band = selectBand(explored, targetRank, agent);
   if (band.length === 0) {
     return {

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { chooseModel, AGENT_TIER, PRESETS, type RoutingServices } from "./modelRouter.mjs";
+import { chooseModel, incumbentStillEligible, AGENT_TIER, PRESETS, type RoutingServices } from "./modelRouter.mjs";
 import { endpointKey } from "./endpointKey.mjs";
 import { tierRank } from "./modelGuide.mjs";
 import { AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
@@ -766,5 +766,73 @@ describe("chooseModel — the cost stage (BET-1269): measured mix, catalogue ref
     });
     expect(res.model?.providerID).toBe("a");
     expect(res.trace.winner!.cost.basis).toBe("subscription-no-window");
+  });
+});
+
+describe("provider health in routing (BET-1270 6a)", () => {
+  // Two endpoints of the SAME model with IDENTICAL cost/quality — the only
+  // differing signal is provider health. Under economy the set is flattened and
+  // ordered by cmpWithinModel, so a soft `failing` health must sort the failing
+  // endpoint BEHIND the healthy one (placed after reliability, before cost).
+  it("softly deprioritises a failing provider behind a healthy one", () => {
+    const healthy = endpoint("claude-sonnet-4", { providerID: "healthy", tier: "deep", cost: { input: 3, output: 15, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const failing = endpoint("claude-sonnet-4", { providerID: "failing", tier: "deep", cost: { input: 3, output: 15, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const res = route({
+      catalog: [failing, healthy],
+      policy: { preset: "economy" },
+      services: { health: { failing: "failing", healthy: "ok" } },
+    });
+    expect(res.model?.providerID).toBe("healthy");
+    expect(res.alternatives.map((a: any) => a.providerID)).toContain("failing");
+    expect(res.trace.considered).toBe(2);
+  });
+
+  it("NEVER drops a failing provider — only failing candidates still route", () => {
+    const a = endpoint("claude-haiku", { providerID: "x", tier: "deep", cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const b = endpoint("claude-haiku", { providerID: "y", tier: "deep", cost: { input: 1, output: 2, cacheRead: 0.5, cacheWrite: 0.5 } });
+    const res = route({
+      catalog: [a, b],
+      policy: { preset: "economy" },
+      services: { health: { x: "failing", y: "failing" } },
+    });
+    expect(res.model).toBeTruthy();
+    expect(res.trace.dropped.length).toBe(0);
+  });
+
+  it("out-of-credit and rate-limited still EXCLUDE (hard), not deprioritise", () => {
+    for (const state of ["out-of-credit", "rate-limited"]) {
+      const res = route({
+        catalog: [endpoint("m", { providerID: "p" })],
+        policy: { preset: "balanced" },
+        services: { health: { p: state } },
+      });
+      expect(res.model).toBeNull();
+      expect(res.reason).toContain("no general model passes constraints");
+    }
+  });
+});
+
+describe("incumbentStillEligible (BET-1270 6e)", () => {
+  it("returns true for a describable incumbent (declared catalogue identity)", () => {
+    const incumbent = endpoint("claude-sonnet-4", { providerID: "anthropic", tier: "deep" });
+    const services = {
+      declared: { "anthropic/claude-sonnet-4": { catalogId: "claude-sonnet-4" } },
+    };
+    expect(incumbentStillEligible(incumbent, services)).toBe(true);
+  });
+
+  it("returns false for an incumbent Auto can no longer describe", () => {
+    const incumbent = endpoint("opaque", { providerID: "custom" });
+    expect(
+      incumbentStillEligible(incumbent, {
+        declared: {},
+        catalogMatcher: { lookupModel: () => null, matchModel: () => ({ kind: "none", candidates: [] }) },
+        catalogEntryFor: () => null,
+      }),
+    ).toBe(false);
+  });
+
+  it("returns true for a null / absent incumbent", () => {
+    expect(incumbentStillEligible(null, undefined)).toBe(true);
   });
 });

--- a/src/shared/providerHealthLabel.d.mts
+++ b/src/shared/providerHealthLabel.d.mts
@@ -1,0 +1,2 @@
+export const PROVIDER_STATE_LABEL: Readonly<Record<string, string>>;
+export function providerStateLabel(state: string): string | null;

--- a/src/shared/providerHealthLabel.mjs
+++ b/src/shared/providerHealthLabel.mjs
@@ -1,0 +1,20 @@
+// providerHealthLabel.mjs — the human words for a provider-health state.
+//
+// ONE source of truth for the words the two surfaces that show them must not
+// disagree on (BET-1270 6d): the Accounts row (renderer) and the needs-attention
+// notification body (server). If the wording drifts, a user reads "Out of
+// credit" in Settings and "Not responding" in the push for the same provider.
+//
+// Only the non-ok states have words; `ok` is the default and needs no label.
+// Pure, no I/O, no imports.
+
+export const PROVIDER_STATE_LABEL = Object.freeze({
+  "out-of-credit": "Out of credit",
+  "rate-limited": "Rate limited",
+  failing: "Not responding",
+});
+
+/** The human label for a provider-health state, or null when unknown/ok. */
+export function providerStateLabel(state) {
+  return PROVIDER_STATE_LABEL[state] ?? null;
+}

--- a/src/shared/providerHealthLabel.test.ts
+++ b/src/shared/providerHealthLabel.test.ts
@@ -1,0 +1,25 @@
+import { describe, it, expect } from "vitest";
+// Single source of truth for the words the Accounts row and the needs-attention
+// notification must agree on (BET-1270 6d). If these drift, a user reads one
+// phrase in Settings and another in the push for the same provider.
+import { PROVIDER_STATE_LABEL, providerStateLabel } from "./providerHealthLabel.mjs";
+
+describe("providerStateLabel", () => {
+  it("maps the three non-ok states to the words the Accounts row shows", () => {
+    expect(providerStateLabel("out-of-credit")).toBe("Out of credit");
+    expect(providerStateLabel("rate-limited")).toBe("Rate limited");
+    expect(providerStateLabel("failing")).toBe("Not responding");
+  });
+
+  it("returns null for the ok/default state and unknown states", () => {
+    expect(providerStateLabel("ok")).toBeNull();
+    expect(providerStateLabel("nope")).toBeNull();
+    expect(providerStateLabel(undefined as unknown as string)).toBeNull();
+  });
+
+  it("exposes the frozen table for direct reads", () => {
+    expect(PROVIDER_STATE_LABEL["out-of-credit"]).toBe("Out of credit");
+    expect(PROVIDER_STATE_LABEL["rate-limited"]).toBe("Rate limited");
+    expect(PROVIDER_STATE_LABEL["failing"]).toBe("Not responding");
+  });
+});


### PR DESCRIPTION
**Closes BET-1270** — Routing: provider health must influence routing and reach the user.

Fixes the five Stage-6 wiring defects. `Base: origin/main @ a75a35f4`.

## What changed

**6a — `src/shared/modelRouter.mjs`** — `cmpWithinModel` gains one soft comparison, placed after reliability (penalise) and before cost: a provider in the soft `failing` state sorts behind a healthy endpoint. It can never remove a candidate — `out-of-credit`/`rate-limited` remain the only hard exclusions (in `capabilityDrop`), a `failing` survivor still routes even as the only option.

**6b — `src/server/providerHealth.mjs` + `index.mjs`** — attribution no longer gated by the usage adapter. `attributedProvider` keeps the adapter path for supported providers, and falls back to the failing **model's** endpoint identity via a new injected `providerForModel` (wired to a modelID→providerID index refreshed from the opencode model list). A custom / pay-as-you-go provider can now be marked unhealthy.

**6c — `src/server/opencode.mjs` + `index.mjs`** — the transport-level Retry-After (on the `prompt_async` POST) is recorded per-session at the point it is read and bridged onto the `session.error` event; `index.mjs` passes it as the second argument to `enrichProviderError`. A 429 with `Retry-After: 900` now drives a 15-minute cooldown (the Accounts "retry in Nm") instead of a constant 2 minutes — the MAX clamp in `clampRetryAfterMs` is no longer dead code.

**6d — `src/server/index.mjs` + `src/shared/providerHealthLabel.mjs`** — `provider-health.needs-attention` is no longer published to zero subscribers. It is routed through the **existing** `fireNotify` notification router as an informational-tier notification (device selection/deduping/deferral all from the one router; no new bus kind, no second delivery path). The body names the provider + state in the shared words (`Out of credit` / `Rate limited` / `Not responding`) — `providerStateLabel` is now the one source both the Accounts row and the push read.

**6e — `src/server/rpc.mjs` + `src/shared/api.ts` + `src/renderer/ChatPanel.tsx` + `modelRouter.mjs`** — `routing:choose` now returns `incumbentHealthy` (its provider not excluded/failing) and `incumbentStillEligible` (the router's `autoEligibility` gate, via a new exported `incumbentStillEligible` helper) for the incumbent the caller sent — same round trip, one source of truth. ChatPanel deletes both hardcoded literals and drives `crossesBoundary` / `shouldSwitch` from the box's answer, so the `incumbent-ineligible` and `incumbent-unhealthy` forced-switch reasons are reachable.

## Verification results

- PR branch (`multica/BET-1270-provider-health-routing` @ `4509d3df`):
  - typecheck: exit 0 (node + web tsconfig), no errors.
  - test: server `# pass 2684 / # fail 0`; renderer `3500 passed | 7 skipped`.
- Base (`main` @ `a75a35f4`):
  - The five new tests **fail on main** and **pass on the branch** (ran each by applying the new tests onto a clean `main` checkout):
    - **Test 3** (`a provider with NO usage adapter is attributed by its failing model`): FAIL on main (adapter-less provider never attributed → no `providerForModel`). PASS on branch.
    - **Test 4** (`transport refusal records Retry-After per-session`): FAIL on main (module import error — `getAndClearSessionRefusal` not exported). PASS on branch.
    - **Test 5** (`routing:choose reports incumbentHealthy=…`): FAIL on main (field absent → `undefined !== false`). PASS on branch.
    - **Test 1/6a** (`softly deprioritises a failing provider`): FAIL on main (health ignored in ordering). PASS on branch.

## Acceptance notes

- Acceptance #3 (live box: bad key → notification + matching Accounts row + provider excluded) is **not performed** — it needs a real box with a custom endpoint pointed at a bad key, which I cannot drive from this environment. The routing `_EXCLUDED`/deprioritise behavior it exercises is covered by unit tests 1/2/5.

## Follow-ups

- None filed: the only deviation a reviewer might flag (whether `fireNotify` could express a non-session-scoped notification) resolved cleanly — `fireNotify` accepts an omitted `sessionID` and falls back to the supplied title, so no new bus kind was needed, per 6d's branch instruction.
