### PR TITLE
fix(renderer): remove dead Settings→Accounts controls (BET-1273 9a–9f)

### DIFF
--- a/src/renderer/AccountsCard.test.ts
+++ b/src/renderer/AccountsCard.test.ts
@@ -200,6 +200,41 @@ describe("endpointEligibility (multi-model union — reviewer Question)", () => 
     const { missing } = endpointEligibility(ep([]), {}, null);
     expect(missing).toEqual(expect.arrayContaining([MISSING.IDENTITY]));
   });
+
+  it("an endpoint that reports a price + caching lists only the identity gap, not 'what it costs' (9d)", () => {
+    // The endpoint "told us" its price (free) and caching (none) — the row must
+    // NOT say "Auto needs: what it costs". This is the case the empty-model
+    // eligibility bug (BET-1273 9d) got wrong: it always reported PRICE/CACHING/
+    // QUALITY missing because it judged `{}` instead of the resolved endpoint.
+    const declared = {
+      "voska/m1": { price: "free" as const, caches: false as const },
+    };
+    const { missing } = endpointEligibility(ep(["m1"]), declared, null);
+    expect(missing).toEqual([MISSING.IDENTITY]);
+    expect(missing).not.toContain(MISSING.PRICE);
+    expect(missing).not.toContain(MISSING.CACHING);
+    expect(missing).not.toContain(MISSING.QUALITY);
+  });
+
+  it("a custom endpoint with a declared price does not say 'Auto needs: what it costs'", () => {
+    const declared = {
+      "voska/m1": { price: { input: 0.02, output: 0.08 }, caches: false },
+    };
+    const { missing } = endpointEligibility(ep(["m1"]), declared, null);
+    expect(missing).not.toContain(MISSING.PRICE);
+    const row: AccountRowModel = {
+      id: "voska",
+      className: "Custom",
+      kind: "declared",
+      name: "VoskaAI",
+      connected: true,
+      reading: null,
+      balance: null,
+      health: "unknown",
+      eligibilityMissing: missing,
+    };
+    expect(helpText(row)).not.toContain("what it costs");
+  });
 });
 
 describe("usagePace", () => {
@@ -216,8 +251,55 @@ describe("usagePace", () => {
     expect(usagePace(w(90), now)).toBe("over pace");
   });
 
-  it("falls back to a pct heuristic when no timing is present", () => {
-    expect(usagePace({ pct: 20 } as never, 0)).toBe("on pace");
-    expect(usagePace({ pct: 85 } as never, 0)).toBe("over pace");
+  it("falls back to no pace when no timing is present (9e)", () => {
+    expect(usagePace({ pct: 20 } as never, 0)).toBeNull();
+    expect(usagePace({ pct: 85 } as never, 0)).toBeNull();
+  });
+});
+
+describe("AccountsCard pace clause (9e)", () => {
+  it("a reading with no timing renders the percentage with no pace clause", () => {
+    const st = describeAccountState(
+      subscription({ reading: { label: "Weekly", pct: 85, pace: null } }),
+    );
+    expect(st.text).toBe("Weekly 85%");
+    expect(st.text).not.toContain("pace");
+  });
+
+  it("a reading with timing still renders the pace clause", () => {
+    const st = describeAccountState(
+      subscription({ reading: { label: "5h", pct: 41, pace: "under pace" } }),
+    );
+    expect(st.text).toBe("5h 41% · under pace");
+  });
+});
+
+describe("health unknown is not healthy (9f)", () => {
+  it("an unknown health entry renders the usage state, never 'ok'/'healthy'", () => {
+    const withReading = describeAccountState(
+      subscription({ health: "unknown", reading: { label: "5h", pct: 41, pace: "under pace" } }),
+    );
+    expect(withReading.text).toContain("5h 41%");
+    expect(withReading.text).not.toMatch(/healthy|ok/i);
+
+    const byBalance = describeAccountState(subscription({ health: "unknown", reading: null, balance: 12.5 }));
+    expect(byBalance.text).toBe("$12.50 remaining");
+  });
+
+  it("an unknown health custom row with no data reads 'No usage data', not healthy", () => {
+    const row: AccountRowModel = {
+      id: "voska",
+      className: "Custom",
+      kind: "declared",
+      name: "VoskaAI",
+      connected: true,
+      reading: null,
+      balance: null,
+      health: "unknown",
+      eligibilityMissing: [],
+    };
+    const st = describeAccountState(row);
+    expect(st.text).toBe("No usage data");
+    expect(st.tone).toBe("quiet");
   });
 });

--- a/src/renderer/AccountsCard.test.tsx
+++ b/src/renderer/AccountsCard.test.tsx
@@ -7,7 +7,7 @@
 // covered in AccountsCard.test.ts.
 
 import { describe, it, expect, afterEach, vi } from "vitest";
-import { mount, installMockApi, type Harness, type MockApi } from "./testHarness";
+import { mount, installMockApi, clickCheckbox, type Harness, type MockApi } from "./testHarness";
 import { AccountsCard } from "./AccountsCard";
 
 function statusProvider() {
@@ -40,6 +40,48 @@ function buttonByText(h: Harness, text: string): HTMLButtonElement | null {
     if ((b.textContent ?? "").trim() === text) return b;
   }
   return null;
+}
+
+function checkboxByLabel(h: Harness, label: string): HTMLInputElement | null {
+  return (
+    (Array.from(h.container.querySelectorAll('input[type="checkbox"]')).find(
+      (i) => i.getAttribute("aria-label") === label,
+    ) as HTMLInputElement | null) ?? null
+  );
+}
+
+// Mount the card with ONE custom endpoint ("voska", enabled blend "alpha") whose
+// discovery reports ["alpha","beta"]. `opencodeGetProviders`/`setProviders` are
+// stateful so a re-tick actually sticks for the next read.
+function customProviderSetup(overrides: Record<string, unknown> = {}) {
+  let providerState: {
+    id: string;
+    name: string;
+    baseURL: string;
+    hasApiKey: boolean;
+    enabledModels: string[];
+  }[] = [
+    { id: "voska", name: "VoskaAI", baseURL: "https://api.voska.org/v1", hasApiKey: true, enabledModels: ["alpha"] },
+  ];
+  const { api } = installMockApi({
+    opencodeProviderAuth: () => Promise.resolve({ action: "status" as const, providers: [] }),
+    opencodeGetProviders: () => Promise.resolve(providerState),
+    accountHealth: () => Promise.resolve({}),
+    configGet: () => Promise.resolve({}),
+    opencodeSetProviders: (input: {
+      upsert?: { id: string; name?: string; baseURL?: string; enabledModels: string[] }[];
+    }) => {
+      const u = input?.upsert?.[0];
+      if (u) providerState = providerState.map((p) => (p.id === u.id ? { ...p, ...u } : p));
+      return Promise.resolve({ ok: true });
+    },
+    opencodeDiscoverModels: () =>
+      Promise.resolve({ ok: true, models: [{ id: "alpha" }, { id: "beta" }] }),
+    accountsRetry: () => Promise.resolve({ ok: true, state: "ok", message: "x" }),
+    ...overrides,
+  });
+  const h = mount(<AccountsCard />);
+  return { h, api, getEnv: () => providerState };
 }
 
 describe("AccountsCard Try again (out-of-credit)", () => {
@@ -98,5 +140,102 @@ describe("AccountsCard Try again (out-of-credit)", () => {
     await h.flush();
     expect(h.container.textContent).toContain("Rate limited · retry in 12m");
     expect(buttonByText(h, "Try again")).toBeNull();
+  });
+});
+
+describe("AccountsCard Refresh on a custom endpoint (9a/9b)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("Refresh on a reachable endpoint renders the discovered models and a confirmation", async () => {
+    const s = customProviderSetup();
+    h = s.h;
+    await h.flush();
+    expect(h.container.textContent).toContain("VoskaAI");
+    const btn = buttonByText(h, "Refresh");
+    expect(btn).toBeTruthy();
+    btn!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await h.flush();
+    // discovered model that was NOT enabled renders
+    expect(checkboxByLabel(h, "beta")).toBeTruthy();
+    // confirmation naming how many were found
+    expect(h.container.textContent).toContain("Discovered 2 models");
+  });
+
+  it("Refresh on an unreachable endpoint renders the error in text-danger and does not reject", async () => {
+    const s = customProviderSetup({
+      opencodeDiscoverModels: () =>
+        Promise.resolve({ ok: false, error: "unauthorized", detail: "bad key" }),
+    });
+    h = s.h;
+    await h.flush();
+    const btn = buttonByText(h, "Refresh");
+    expect(btn).toBeTruthy();
+    // must not throw / leave an unhandled rejection
+    btn!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await h.flush();
+    const alert = h.container.querySelector('[role="alert"]');
+    expect(alert).toBeTruthy();
+    expect(alert!.textContent).toContain("unauthorized");
+    expect((alert as HTMLElement).className).toContain("text-danger");
+    // no false success confirmation
+    expect(h.container.textContent).not.toContain("Discovered");
+  });
+
+  it("an unticked discovered model renders unchecked and can be re-ticked", async () => {
+    const s = customProviderSetup();
+    h = s.h;
+    await h.flush();
+    buttonByText(h, "Refresh")!.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await h.flush();
+    const beta = checkboxByLabel(h, "beta");
+    expect(beta).toBeTruthy();
+    expect(beta!.checked).toBe(false);
+    expect(checkboxByLabel(h, "alpha")!.checked).toBe(true);
+    // re-tick it — the mutation must reach the box and stick on refetch
+    clickCheckbox(h, "beta");
+    await h.flush();
+    expect(JSON.stringify(s.api.calls.opencodeSetProviders ?? [])).not.toBe("[]");
+    expect(s.getEnv()[0].enabledModels).toContain("beta");
+    expect(checkboxByLabel(h, "beta")!.checked).toBe(true);
+  });
+});
+
+describe("AccountsCard Try-again tone by outcome (9c)", () => {
+  it("failure renders in text-danger, success in text-ok", async () => {
+    let h = await underOutOfCredit(() =>
+      Promise.resolve({
+        ok: false,
+        state: "out-of-credit",
+        message: "anthropic still reports out of credit — check the account.",
+      }),
+    );
+    buttonByText(h, "Try again")!.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await h.flush();
+    let status = h.container.querySelector('[role="status"]');
+    expect(status).toBeTruthy();
+    expect(status!.textContent).toContain("still reports out of credit");
+    expect((status as HTMLElement).className).toContain("text-danger");
+    h.unmount();
+
+    h = await underOutOfCredit(() =>
+      Promise.resolve({ ok: true, state: "ok", message: "anthropic is back in the pool" }),
+    );
+    buttonByText(h, "Try again")!.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await h.flush();
+    status = h.container.querySelector('[role="status"]');
+    expect(status).toBeTruthy();
+    expect(status!.textContent).toContain("back in the pool");
+    expect((status as HTMLElement).className).toContain("text-ok");
+    h.unmount();
   });
 });

--- a/src/renderer/AccountsCard.test.tsx
+++ b/src/renderer/AccountsCard.test.tsx
@@ -8,6 +8,7 @@
 
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { mount, installMockApi, clickCheckbox, type Harness, type MockApi } from "./testHarness";
+import { invalidateCachedResource } from "./useCachedResource";
 import { AccountsCard } from "./AccountsCard";
 
 function statusProvider() {
@@ -236,6 +237,46 @@ describe("AccountsCard Try-again tone by outcome (9c)", () => {
     expect(status).toBeTruthy();
     expect(status!.textContent).toContain("back in the pool");
     expect((status as HTMLElement).className).toContain("text-ok");
+    h.unmount();
+  });
+});
+
+describe("AccountsCard Try-again verdict clears on recovery (9c)", () => {
+  it("drops the verdict once a refetch shows the row recovered", async () => {
+    // Cold-start the "accounts" cache so the mount fetch actually reads health.
+    invalidateCachedResource("accounts");
+    let calls = 0;
+    installMockApi({
+      opencodeProviderAuth: () => Promise.resolve(statusProvider()),
+      opencodeGetProviders: () => Promise.resolve([]),
+      accountHealth: () => {
+        calls++;
+        // First read (mount) is out-of-credit; every later read (retry's own
+        // refetch) shows the flag cleared — so the verdict must not linger.
+        return Promise.resolve(calls <= 1 ? { anthropic: { state: "out-of-credit" } } : { anthropic: { state: "ok" } });
+      },
+      configGet: () => Promise.resolve({}),
+      opencodeSetProviders: () => Promise.resolve({ ok: true }),
+      opencodeDiscoverModels: () => Promise.resolve({ ok: true, models: [] }),
+      accountsRetry: () =>
+        Promise.resolve({
+          ok: false,
+          state: "out-of-credit",
+          message: "still reports out of credit — check the account.",
+        }),
+    });
+    const h = mount(<AccountsCard />);
+    await h.flush();
+    // out-of-credit at mount → Try again is present
+    expect(buttonByText(h, "Try again")).toBeTruthy();
+    buttonByText(h, "Try again")!.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    // The retry's own refetch re-reads health (now ok) → row is healthy → the
+    // stale verdict is dropped rather than sitting under a healthy row.
+    await h.flush();
+    expect(h.container.textContent).not.toContain("still reports out of credit");
+    expect(buttonByText(h, "Try again")).toBeNull();
     h.unmount();
   });
 });

--- a/src/renderer/AccountsCard.tsx
+++ b/src/renderer/AccountsCard.tsx
@@ -27,12 +27,13 @@
 // helpers here (describeAccountState, describeMissing, usagePace, helpText)
 // are unit-tested.
 
-import { useCallback, useMemo, useState, type ReactNode } from "react";
+import { useCallback, useEffect, useMemo, useState, type ReactNode } from "react";
 import { X } from "lucide-react";
-import type { ProviderEndpoint, SubscriptionStatus, UsageSnapshot, UsageWindow } from "../shared/types";
+import type { DiscoverResult, ProviderEndpoint, SubscriptionStatus, UsageSnapshot, UsageWindow } from "../shared/types";
 import { autoEligibility, MISSING } from "../shared/autoEligibility.mjs";
 import { providerStateLabel } from "../shared/providerHealthLabel.mjs";
-import { resolveIdentity } from "../shared/modelIdentity.mjs";
+import { resolveIdentity, type ModelDeclaration } from "../shared/modelIdentity.mjs";
+import { qualityScore } from "../shared/modelQuality.mjs";
 import { ConnectProvider } from "./ConnectProvider";
 import { CustomProviderForm } from "./CustomProviderForm";
 import { Checkbox } from "./Checkbox";
@@ -63,11 +64,13 @@ export type AccountRowModel = {
   plan?: string;
   /** credential present (subscription connected / custom has an api key). */
   connected: boolean;
-  /** A usage reading (window label / pct / pace) when one exists. */
-  reading: { label: string; pct: number; pace: string } | null;
+  /** A usage reading (window label / pct / pace) when one exists. `pace` is
+   *  null when the window carries no timing — never a fabricated pace. */
+  reading: { label: string; pct: number; pace: string | null } | null;
   /** Credit balance in dollars, or null when unknown. */
   balance: number | null;
-  health: "ok" | "out-of-credit" | "rate-limited" | "failing";
+  /** `unknown` when no health engine/entry exists — rendered as no state, never as healthy. */
+  health: "ok" | "unknown" | "out-of-credit" | "rate-limited" | "failing";
   /** Remaining rate-limit cooldown, whole minutes (health === "rate-limited"). */
   retryInMinutes?: number;
   /** Machine keys (autoEligibility MISSING) Auto still needs for a custom row. */
@@ -100,7 +103,12 @@ export function describeAccountState(r: AccountRowModel): AccountState {
   if (r.reading) {
     const pct = r.reading.pct;
     const tone: AccountStatus = pct >= 90 ? "danger" : pct >= 70 ? "warn" : "ok";
-    return { text: `${r.reading.label} ${pct}% · ${r.reading.pace}`, tone };
+    // No timing data ⇒ no pace clause: a pace is real or absent, never a guess
+    // (BET-1273 9e).
+    const text = r.reading.pace
+      ? `${r.reading.label} ${pct}% · ${r.reading.pace}`
+      : `${r.reading.label} ${pct}%`;
+    return { text, tone };
   }
   if (typeof r.balance === "number" && Number.isFinite(r.balance)) {
     return {
@@ -122,10 +130,10 @@ export const STATE_TONE_CLASS: Record<AccountStatus, string> = {
 /**
  * Classify a subscription window's pace ("under" / "on" / "over") from how fast
  * it is being consumed against how far through the window we are. Deterministic
- * on (nowMs, window). Falls back to a pct-based heuristic when the window
- * carries no timing.
+ * on (nowMs, window). A window with NO timing carries no pace — a pace invented
+ * from a percentage alone is a false claim (BET-1273 9e), so it returns null.
  */
-export function usagePace(w: UsageWindow, nowMs: number): string {
+export function usagePace(w: UsageWindow, nowMs: number): string | null {
   if (typeof w.startedAt === "number" && typeof w.resetsAt === "number" && w.resetsAt > w.startedAt) {
     const elapsed = (nowMs - w.startedAt) / (w.resetsAt - w.startedAt);
     if (elapsed > 0) {
@@ -135,7 +143,7 @@ export function usagePace(w: UsageWindow, nowMs: number): string {
       return "on pace";
     }
   }
-  return w.pct >= 80 ? "over pace" : "on pace";
+  return null;
 }
 
 // The machine-key → phrase map lives HERE, in the renderer, once. autoEligibility
@@ -189,7 +197,9 @@ function normalizeHealth(h: HealthMap | null | undefined, id: string): {
         : undefined;
     return { health: st, retryInMinutes };
   }
-  return { health: "ok" };
+  // No health entry / engine is UNKNOWN, not healthy — "we have no health data"
+  // must never render as "this provider is fine" (BET-1273 9f).
+  return { health: "unknown" };
 }
 
 function subscriptionReading(snap: UsageSnapshot | undefined, nowMs: number) {
@@ -221,22 +231,36 @@ export function endpointEligibility(
 
   for (const modelId of modelIds) {
     const key = modelId ? `${ep.id}/${modelId}` : null;
-    const decl: DeclaredModel | undefined = key ? declared?.[key] : undefined;
+    const decl = key ? declared?.[key] : undefined;
 
-    let identityKnown = false;
-    if (key) {
-      if (decl?.catalogId) {
-        identityKnown = true;
-      } else if (matcher && modelId) {
-        const id = resolveIdentity({ providerID: ep.id, id: modelId }, undefined, matcher);
-        identityKnown = id.state === "resolved";
-      }
-    }
+    // The candidate — the SAME (provider, model) pair the router judges
+    // (modelRouter assess / incumbentStillEligible). Eligibility is computed
+    // against the RESOLVED endpoint (identity.effective — declaration merged
+    // over the catalogue over the provider's own claims), never an empty
+    // model, so PRICE/CACHING/QUALITY reflect what the endpoint actually told
+    // us (BET-1273 9d). The card and the router answer the same question about
+    // the same object — that is the whole point of sharing the gate.
+    const candidate = { providerID: ep.id, id: modelId ?? "" };
+    const identity = resolveIdentity(
+      candidate,
+      // The renderer's DeclaredModel permits `caches: true`; modelIdentity's
+      // ModelDeclaration types a declaration-noted absence only. Cast (runtime
+      // shape agrees) for reuse of the shared resolver (BET-1273 9d).
+      (decl ?? null) as ModelDeclaration | null,
+      matcher ?? null,
+    );
+    const model = identity.effective ?? candidate;
+    const catalogEntry = (
+      identity.catalogId && matcher ? matcher.lookupModel(identity.catalogId) : null
+      // CatalogEntry.limit is typed `number` in modelQuality but the catalogue
+      // entry carries {context, output}; runtime shape is compatible.
+    ) as unknown as Parameters<typeof qualityScore>[1];
+    const quality = qualityScore(model, catalogEntry, undefined);
 
     const result = autoEligibility({
-      model: {},
-      identity: { known: identityKnown },
-      quality: { known: identityKnown },
+      model,
+      identity: { known: identity.state === "resolved" },
+      quality,
       declared: decl,
       providerClass: "custom",
     });
@@ -405,7 +429,13 @@ export function AccountsCard() {
   const [busy, setBusy] = useState<string | null>(null);
   const [connectingId, setConnectingId] = useState<string | null>(null);
   const [disconnectConfirmId, setDisconnectConfirmId] = useState<string | null>(null);
-  const [retryResult, setRetryResult] = useState<Record<string, string>>({});
+  // Per-endpoint retry verdict: `ok:true` = flag cleared (text-ok), `ok:false` = still refused (text-danger).
+  const [retryResult, setRetryResult] = useState<Record<string, { ok: boolean; message: string }>>({});
+  // Per-endpoint discovery result (BET-1273 9a/9b): the discovered model list
+  // persists so an unticked model stays visible and re-tickable, and the error
+  // string renders in text-danger — both branches reported, never discard.
+  const [discovered, setDiscovered] = useState<Record<string, { id: string }[]>>({});
+  const [discoverError, setDiscoverError] = useState<Record<string, string>>({});
 
   const {
     data,
@@ -505,12 +535,16 @@ export function AccountsCard() {
       setBusy(id);
       try {
         const res = await window.api.accountsRetry(id);
-        setRetryResult((r) => ({ ...r, [id]: res?.message ?? "Retry done." }));
+        const ok = res?.ok === true;
+        setRetryResult((r) => ({
+          ...r,
+          [id]: { ok, message: res?.message ?? (ok ? "Retry done." : "Retry failed — try again.") },
+        }));
         void refresh();
       } catch (e) {
         setRetryResult((r) => ({
           ...r,
-          [id]: e instanceof Error ? e.message : "Retry failed — try again.",
+          [id]: { ok: false, message: e instanceof Error ? e.message : "Retry failed — try again." },
         }));
       } finally {
         setBusy(null);
@@ -518,6 +552,25 @@ export function AccountsCard() {
     },
     [busy, refresh],
   );
+
+  // A retry verdict only explains an out-of-credit row. The moment the row's
+  // health stops being out-of-credit (the retry cleared the flag, or a refetch
+  // shows the meter recovered), the verdict is stale — drop it (BET-1273 9c),
+  // so a lingering "still reports out of credit" can't sit under a healthy row.
+  useEffect(() => {
+    setRetryResult((prev) => {
+      let changed = false;
+      const next: typeof prev = {};
+      for (const [id, v] of Object.entries(prev)) {
+        if (rows.some((r) => r.id === id && r.health === "out-of-credit")) {
+          next[id] = v;
+        } else {
+          changed = true;
+        }
+      }
+      return changed ? next : prev;
+    });
+  }, [rows]);
 
   const toggleModel = useCallback(
     async (ep: ProviderEndpoint, modelId: string) => {
@@ -539,18 +592,32 @@ export function AccountsCard() {
     [busy, mutate, refresh],
   );
 
+  // Refresh on a custom endpoint — a read-only probe that reports BOTH
+  // branches (BET-1273 9a): success stores the discovered models (which drives
+  // the real membership test in 9b) + a confirmation naming the count; failure
+  // renders the error in text-danger. Never fire-and-forget, never discard.
   const discover = useCallback(
     async (ep: ProviderEndpoint) => {
       if (busy) return;
       setBusy(ep.id);
+      setDiscoverError((e) => ({ ...e, [ep.id]: "" }));
       try {
-        await window.api.opencodeDiscoverModels(ep.baseURL, "");
-        void refresh();
+        const r: DiscoverResult = await window.api.opencodeDiscoverModels(ep.baseURL, "");
+        if (r.ok) {
+          setDiscovered((d) => ({ ...d, [ep.id]: r.models }));
+        } else {
+          setDiscoverError((e) => ({
+            ...e,
+            [ep.id]: `${r.error}${r.detail ? `: ${r.detail}` : ""}`,
+          }));
+        }
+      } catch (e) {
+        setDiscoverError((er) => ({ ...er, [ep.id]: e instanceof Error ? e.message : String(e) }));
       } finally {
         setBusy(null);
       }
     },
-    [busy, refresh],
+    [busy],
   );
 
   const removeEndpoint = useCallback(
@@ -561,6 +628,14 @@ export function AccountsCard() {
         const res = await window.api.opencodeSetProviders({ remove: [ep.id] });
         if (!res.ok) throw new Error(res.error ?? "Remove failed");
         useStore.getState().setOpencodeRestartNeeded(true);
+        setDiscovered((d) => {
+          const { [ep.id]: _drop, ...rest } = d;
+          return rest;
+        });
+        setDiscoverError((er) => {
+          const { [ep.id]: _drop, ...rest } = er;
+          return rest;
+        });
         void refresh();
       });
       setBusy(null);
@@ -608,22 +683,36 @@ export function AccountsCard() {
                   onRemove={() => ep && void removeEndpoint(ep)}
                 />
                 {retryResult[row.id] && (
-                  <div role="status" className="text-meta text-text-faint pl-[6px] -mt-1">
-                    {retryResult[row.id]}
+                  <div
+                    role="status"
+                    className={`text-meta ${retryResult[row.id].ok ? "text-ok" : "text-danger"} pl-[6px] -mt-1`}
+                  >
+                    {retryResult[row.id].message}
                   </div>
                 )}
                 {ep && (
                   <div className="pl-4 space-y-1">
                     <code className="text-meta text-text-faint truncate block">{ep.baseURL}</code>
-                    {ep.enabledModels.map((m) => (
-                      <div key={m} className="flex items-center gap-2 text-meta">
+                    {discoverError[ep.id] && (
+                      <div role="alert" className="text-meta text-danger break-words">
+                        {discoverError[ep.id]}
+                      </div>
+                    )}
+                    {discovered[ep.id] && discovered[ep.id].length > 0 && (
+                      <div role="status" className="text-meta text-ok">
+                        Discovered {discovered[ep.id].length} model
+                        {discovered[ep.id].length === 1 ? "" : "s"}
+                      </div>
+                    )}
+                    {(discovered[ep.id] ?? ep.enabledModels.map((id) => ({ id }))).map((m) => (
+                      <div key={m.id} className="flex items-center gap-2 text-meta">
                         <Checkbox
-                          checked={ep.enabledModels.includes(m)}
-                          onChange={() => void toggleModel(ep, m)}
-                          ariaLabel={m}
+                          checked={ep.enabledModels.includes(m.id)}
+                          onChange={() => void toggleModel(ep, m.id)}
+                          ariaLabel={m.id}
                           disabled={busy === row.id}
                         />
-                        <span className="text-text-muted">{m}</span>
+                        <span className="text-text-muted">{m.id}</span>
                       </div>
                     ))}
                   </div>


### PR DESCRIPTION
## BET-1273 — Settings → Accounts: remove the dead controls

Stage 4 renderer branch. Fixes the six silent-defect controls in the merged Accounts card, per the design contract in `docs/screens/routing/mockup.html` section 4.

**Files changed:** 3. `src/renderer/AccountsCard.tsx`, `src/renderer/AccountsCard.test.ts`, `src/renderer/AccountsCard.test.tsx`

### 9a · Refresh on a custom endpoint now reports BOTH branches
`discover` awaits `opencodeDiscoverModels` (a read-only probe), stores the result, and:
- success → the discovered models render in the row (this is what makes 9b fixable) plus an inline confirmation "Discovered N models" (`text-ok`);
- failure → the error string renders in `text-danger` in the row. There is no fire-and-forget `void`; a rejected key is caught and shown, not an unhandled rejection.

Reuses the deleted `ProvidersCard` shape (discovered / discoverError state), no toast system.

### 9b · Per-model checkbox is a real membership test
The row renders `discovered[ep.id] ?? ep.enabledModels` (exactly the old card) with `checked = ep.enabledModels.includes(m.id)`. An unticked model stays visible and re-tickable.

### 9c · Try-again tones by outcome and clears
`retryResult` stores `{ ok, message }`; the verdict renders `text-ok` on success, `text-danger` on failure. The verdict is dropped once the row's health leaves `out-of-credit` (a refetch reflecting recovery, or the flag clearing), so a stale verdict can't sit under a healthy row.

### 9d · Eligibility judges the real resolved endpoint
`endpointEligibility` no longer passes `model: {}`. Per enabled model it resolves the candidate (`{providerID, id}`) via the shared `resolveIdentity`, judges `identity.effective`, and computes `quality` via the shared `qualityScore` (not an asserted `{ known: identityKnown }`). The card and the router answer the same question about the same object through the one `autoEligibility` gate.

### 9e · No timing ⇒ no pace
`usagePace` returns `null` when the window carries no `startedAt`/`resetsAt`; `describeAccountState` renders the percentage alone ("Weekly 85%") instead of inventing "over/on pace" from a percentage.

### 9f · Health-unknown ≠ healthy
`normalizeHealth` returns `"unknown"` for a missing health entry instead of coercing it to `"ok"`. `describeAccountState` gives `unknown` no state string, so the row falls through to its usage/balance/`No usage data` state — never rendered as healthy.

`src/server/rpc.mjs` needed no change: its `accounts:health` already degrades to `{}` (the absence signal); the bug was purely the renderer mapping absence → `ok`.

**Base: origin/main @ `bcca2777`**

**Verification results:**
- PR branch (`multica/BET-1273-remove-dead-accounts-controls` @ `f1d485bb`):
  - typecheck: exit 0, no errors.
  - test: exit 0. Vitest 3515 passed / 7 skipped / 0 fail (185 files); node:test 2681 pass / 0 fail.
- Base: `origin/main` @ `bcca2777` (this branch was cut from it; PR adds 3 renderer files only).
- Conclusion: typecheck + full test green on the PR branch; 0 failing tests. All new tests for 9d/9e/9f are pure-logic (AccountsCard.test.ts); the 9a/9b/9c component tests are in AccountsCard.test.tsx.

### Test coverage mapped to the issue's tests
1. Refresh on a reachable endpoint renders the discovered list + confirmation — `AccountsCard.test.tsx` (9a).
2. Refresh on an unreachable endpoint renders `text-danger`, no reject — `AccountsCard.test.tsx`.
3. An unticked model renders unchecked and re-ticks — `AccountsCard.test.tsx` (9b).
4. Try-again failure `text-danger`, success `text-ok`, verdict clears on refetch — `AccountsCard.test.tsx` + pure cases (9c).
5. A custom endpoint reporting a real price does not say "Auto needs: what it costs" — `AccountsCard.test.ts` (9d).
6. A window with no timing renders no pace clause — `AccountsCard.test.ts` (9e).
7. An unknown health entry renders the usage/balance state, not "healthy" — `AccountsCard.test.ts` (9f).

**Note on live-box acceptance (items 2 & 4 of Acceptance):** the "click every element on a real box" and "bad key → error visible in the UI" checks require the running Electron app with a paired box. This Linux agent box can't drive the live desktop UI; they are covered by the component tests above and should be confirmed on the dev box. Called out rather than faked.
