### PR TITLE
fix(routing): ledger telemetry shape, rolling window, one read per decision (BET-1271)

### DIFF
--- a/src/renderer/ModelsCard.test.tsx
+++ b/src/renderer/ModelsCard.test.tsx
@@ -20,7 +20,7 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { mount, installMockApi, resetStore, type Harness } from "./testHarness";
 import { ModelsWeCouldntIdentify } from "./ModelsWeCouldntIdentify";
-import { refreshRoutingCatalog } from "./routingCatalog";
+import { _resetRoutingCatalogCache } from "./routingCatalog";
 
 // A trimmed provider-agnostic catalogue fixture (models.dev shape).
 const ENTRIES = [
@@ -70,7 +70,7 @@ function mountBlock(opts: {
           : { supported: false, size: 0, entries: [] },
       ),
   });
-  refreshRoutingCatalog();
+  _resetRoutingCatalogCache();
   const h = mount(<ModelsWeCouldntIdentify />);
   return { h, api };
 }

--- a/src/renderer/ModelsCard.tsx
+++ b/src/renderer/ModelsCard.tsx
@@ -352,7 +352,7 @@ export function ModelsCard() {
   // the override in opencode:models) so both the table and the composed model
   // catalog reflect the change in the same tick.
   const saveOverride = useCallback(
-    async (key: string, _model: OpencodeModel, override: ModelOverride) => {
+    async (key: string, override: ModelOverride) => {
       if (busy) return;
       setBusy(key);
       await mutate(async () => {
@@ -604,7 +604,7 @@ export function ModelsCard() {
           <EditModelModal
             model={model}
             open={!!target}
-            onSave={(override) => void saveOverride(modelKey(model.providerID, model.id), model, override)}
+            onSave={(override) => void saveOverride(modelKey(model.providerID, model.id), override)}
             onCancel={() => setEditing(null)}
           />
         );

--- a/src/renderer/routingCatalog.ts
+++ b/src/renderer/routingCatalog.ts
@@ -66,9 +66,16 @@ function load(): void {
     });
 }
 
-export function refreshRoutingCatalog(): void {
+// Test seam — same underscore convention as opencodeDb's `_resetDbHandle`.
+// The routing catalogue is cached module-level so re-opening Settings does not
+// re-download it. When a test installs a fresh window.api stub it needs to
+// clear that cache so the next useRoutingCatalog mount re-fetches against the
+// stub; there is no production caller (the old `refreshRoutingCatalog` had
+// none either and is deleted — 7f).
+export function _resetRoutingCatalogCache(): void {
+  cache = { supported: false, matcher: null, entries: [] };
   fetchedAt = 0;
-  if (!inFlight) load();
+  inFlight = null;
 }
 
 export function useRoutingCatalog(): RoutingCatalog {

--- a/src/server/accountReaders.mjs
+++ b/src/server/accountReaders.mjs
@@ -77,7 +77,7 @@ export function readerFromDescriptor(descriptor) {
       });
       if (!res.ok) throw httpError(res, `${descriptor.id} usage`);
       const payload = await res.json();
-      return readDescriptor(descriptor, payload, now());
+      return readDescriptor(descriptor, payload);
     },
   };
 }

--- a/src/server/accountReaders.test.mjs
+++ b/src/server/accountReaders.test.mjs
@@ -92,14 +92,14 @@ test("shipped openrouter descriptor reads the live /api/v1/credits payload (BET-
   // balance = total_credits − total_usage = −0.0717 (overdrawn), and it is the
   // REMAINING balance that routes, not the granted total.
   const overdrawn = { data: { total_credits: 20, total_usage: 20.071752339 } };
-  const snap = readDescriptor(v.descriptor, overdrawn, 0);
+  const snap = readDescriptor(v.descriptor, overdrawn);
   assert.equal(snap.kind, "credit");
   assert.ok(Math.abs(snap.balance - (20 - 20.071752339)) < 1e-9, `expected remaining balance -0.07, got ${snap.balance}`);
   assert.equal(snap.exhausted, true);
   assert.equal(snap.windows[0].pct, 100);
 
   const healthy = { data: { total_credits: 20, total_usage: 5 } };
-  const healthySnap = readDescriptor(v.descriptor, healthy, 0);
+  const healthySnap = readDescriptor(v.descriptor, healthy);
   assert.equal(healthySnap.balance, 15);
   assert.equal(healthySnap.exhausted, undefined);
   assert.equal(healthySnap.windows[0].pct, 25);

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -859,7 +859,7 @@ export async function startJob(input, deps = {}) {
           snapshots: quota,
           providerHealthState: deps.providerHealthState,
           endpointSummary: deps.endpointSummary,
-        });
+        }, nowMs);
       } catch (e) {
         console.error(`[router] routing services degraded, routing on absent context: ${e?.message ?? e}`);
         services = null;
@@ -871,7 +871,7 @@ export async function startJob(input, deps = {}) {
         catalog,
         policy,
         agent: resolveSubagentAgent(input?.subagent_type),
-        nowMs: Date.now(),
+        nowMs,
         services,
       });
     } catch (e) {

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -842,6 +842,9 @@ export async function startJob(input, deps = {}) {
     effectiveModel = deliverModel;
   } else {
     const route = deps?.chooseSubagentModel ?? chooseSubagentModel;
+    // One injected clock for this decision (rolling-window edge + TTL timestamp
+    // in buildRoutingServices, and the router's own ordering) — same instant.
+    const nowMs = Date.now();
     // Build the router's RoutingServices context from live box state (BET-1252).
     // `deps.routingServices` (test injection) is used verbatim when present;
     // otherwise the box-side builder assembles catalogue + accounts + health +

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -685,7 +685,7 @@ test("startJob routes to a non-incumbent model from live routing readers (BET-12
     allModels: () => [],
   };
   h.deps.providerHealthState = (pid) => (pid === "openai" ? "rate-limited" : "ok");
-  h.deps.endpointSummary = async () => ({ supported: true });
+  h.deps.endpointSummary = async () => ({ supported: true, endpoints: {} });
 
   const res = await startJob(
     { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo" },
@@ -730,8 +730,10 @@ test("startJob routes to the non-deranked sibling when an endpoint is reliabilit
   h.deps.providerHealthState = () => "ok";
   h.deps.endpointSummary = async () => ({
     supported: true,
-    "anthropic/claude-sonnet-4": { reliability: { requests: 25, errored: 12, rate: 0.48 }, speed: {}, latency: {}, mix: {} },
-    "openai/claude-sonnet-4": { reliability: { requests: 25, errored: 0, rate: 0 }, speed: {}, latency: {}, mix: {} },
+    endpoints: {
+      "anthropic/claude-sonnet-4": { reliability: { requests: 25, errored: 12, rate: 0.48 }, speed: {}, latency: {}, mix: {} },
+      "openai/claude-sonnet-4": { reliability: { requests: 25, errored: 0, rate: 0 }, speed: {}, latency: {}, mix: {} },
+    },
   });
 
   const res = await startJob(

--- a/src/server/modelLedger.mjs
+++ b/src/server/modelLedger.mjs
@@ -16,11 +16,15 @@
 // shared handle from opencodeDb.mjs is opened read-only and stays so.
 
 import { getDb } from "./opencodeDb.mjs";
-import { classifyToolCall, aggregateReliability } from "../shared/toolReliability.mjs";
+import { aggregateReliability } from "../shared/toolReliability.mjs";
 
 // Turns longer than this are excluded from TIMING only (still counted for
 // cost) — the spec cap is 600s of wall-clock.
 const TIMING_MAX_MS = 600_000;
+
+// Reliability and telemetry describe how an endpoint behaves NOW. A rolling
+// window is what lets a provider that had a bad week recover on its own.
+export const ROUTING_LEDGER_WINDOW_MS = 14 * 24 * 60 * 60 * 1000;
 
 // Coerce an arbitrary JSON value to a finite number, else 0. Value-missing
 // or a NaN/Infinity anywhere in the ledger is a bug; every division must
@@ -315,6 +319,11 @@ function extractTools(data) {
  * rolling window of assistant rows, via the shared getDb() handle. Degrades
  * exactly like `ledgerSummary`: returns { supported:false } — never throws —
  * when getDb() yields null, and a failed query also degrades. Read-only.
+ *
+ * On success the flag is separated from the data: `{ supported: true,
+ * endpoints: {…} }`. `endpoints` is 7a's map keyed by "providerID/modelID";
+ * the flag being distinct is what lets a caller tell "no ledger"
+ * ({supported:false}) from "a ledger with nothing measured" ({endpoints:{}}).
  */
 export async function endpointSummary({ sinceMs = 0 } = {}) {
   const db = await getDb();
@@ -339,7 +348,7 @@ export async function endpointSummary({ sinceMs = 0 } = {}) {
         tools: extractTools(data),
       });
     }
-    return { supported: true, ...aggregateEndpointStats(rows) };
+    return { supported: true, endpoints: aggregateEndpointStats(rows) };
   } catch (e) {
     // Query error: log once, drop the handle so the next call reopens, and
     // degrade to { supported:false } — never an exception, never zeros (a card

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1302,8 +1302,6 @@ export function _normalizeProviderModel(providerID, modelId, m) {
     enabled: typeof m.enabled === "boolean" ? m.enabled : undefined,
     limit: _normalizeLimit(m.limit),
     cost: _normalizePrice(m.cost),
-    releaseDate:
-      typeof m.release_date === "string" && m.release_date !== "" ? m.release_date : undefined,
     capabilities: {
       toolcall: typeof caps.toolcall === "boolean" ? caps.toolcall : undefined,
       reasoning: typeof caps.reasoning === "boolean" ? caps.reasoning : undefined,

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -1481,8 +1481,8 @@ test("listRoutableModels: status != active and enabled:false are always excluded
 // _normalizeProviderModel — the single chokepoint every raw provider model
 // passes through. BET-1228: it must CARRY price (incl. cache rates), expose
 // `toolcall` under its own name (not the renamed `tools`), and preserve
-// `reasoning` + `releaseDate`. The absence of price is invisible at runtime
-// (every model scores equal), so these tests are the only thing pinning it.
+// `reasoning`. The absence of price is invisible at runtime (every model
+// scores equal), so these tests are the only thing pinning it.
 // ---------------------------------------------------------------------------
 
 test("_normalizeProviderModel carries price and cache rates through", () => {
@@ -1533,17 +1533,12 @@ test("_normalizeProviderModel keeps toolcall under its own name and preserves fa
   assert.equal(m.capabilities.attachment, true);
 });
 
-test("_normalizeProviderModel carries reasoning and trims empty releaseDate to undefined", () => {
+test("_normalizeProviderModel carries reasoning through", () => {
   const m = _normalizeProviderModel("p", "m", {
     id: "m",
-    release_date: "2025-01-01",
     capabilities: { reasoning: true },
   });
-  assert.equal(m.releaseDate, "2025-01-01");
   assert.equal(m.capabilities.reasoning, true);
-
-  const empty = _normalizeProviderModel("p", "m2", { id: "m2", release_date: "" });
-  assert.equal(empty.releaseDate, undefined);
 });
 
 // Scoped-stream readiness gate (BET-115 fix C)

--- a/src/server/routingServices.mjs
+++ b/src/server/routingServices.mjs
@@ -27,9 +27,21 @@
 
 import { endpointKey } from "../shared/endpointKey.mjs";
 import { mixFromCounts } from "../shared/blendedPrice.mjs";
+import { ROUTING_LEDGER_WINDOW_MS } from "./modelLedger.mjs";
 
 const isObj = (v) => v !== null && typeof v === "object";
 const num = (v) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+
+// 7c: the endpoint-ledger summary is memoised behind a short TTL so every
+// routing decision does not re-scan the whole message history (a JSON.parse
+// per assistant row — every turn boundary and every background-job spawn).
+// There is ONE ledger on the box, so the cache is keyed on nothing but the
+// injected endpointSummary fn (the identity key stops one test's stub leaking
+// into the next; in production it is the same fn every call). A 60s-stale
+// reliability figure cannot change a decision that matters, so deliberately no
+// invalidation protocol, no bus event, no config knob.
+const ROUTING_LEDGER_TTL_MS = 60_000;
+let ledgerCache = null; // { sum, at, value } — one slot, TTL-bounded
 
 // Fold the config's per-endpoint user overrides into the `declared` map the
 // router reads. The config key is modelRouting.declaredModels (see
@@ -145,8 +157,16 @@ export function healthFor(providerIDs, providerHealthState) {
 //   reliability.baseline — per-MODEL aggregate across its endpoints, so a
 //                          single bad endpoint can be told apart from a model
 //                          that is simply hard everywhere
-//   telemetry[key]       — { tokensPerSec, p50Ms, p90Ms, latencyMs }
+//   telemetry[key]       — { tokensPerSec, p90TokensPerSec, p50Ms, p90Ms }
 export function ledgerToServices(stats) {
+  // 7a — separate the ledger's availability flag from its data. `supported:
+  // false` (no DB / failed query) must NOT fold to present-but-empty maps: the
+  // router treats an ABSENT reliability/telemetry as "no evidence, never
+  // derank, measured-average", which is exactly what a missing ledger means. A
+  // supported-but-empty ledger yields present empty maps instead.
+  if (stats?.supported === false) {
+    return { reliability: undefined, telemetry: undefined, mix: undefined, mixDefault: undefined };
+  }
   const samples = {};
   const perModel = new Map(); // modelID -> { requests, errored }
   const telemetry = {};
@@ -154,7 +174,8 @@ export function ledgerToServices(stats) {
   // Aggregate every endpoint's raw token counts so an endpoint with no history
   // of its own is priced on the box's overall measured mix, not a constant.
   let agg = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 };
-  for (const [key, s] of Object.entries(isObj(stats) ? stats : {})) {
+  const endpoints = isObj(stats?.endpoints) ? stats.endpoints : {};
+  for (const [key, s] of Object.entries(endpoints)) {
     const rel = isObj(s?.reliability) ? s.reliability : null;
     if (rel && typeof rel.requests === "number") {
       const requests = rel.requests;
@@ -170,9 +191,9 @@ export function ledgerToServices(stats) {
     const latency = isObj(s?.latency) ? s.latency : {};
     telemetry[key] = {
       ...(typeof speed.p50TokensPerSec === "number" ? { tokensPerSec: speed.p50TokensPerSec } : {}),
+      ...(typeof speed.p90TokensPerSec === "number" ? { p90TokensPerSec: speed.p90TokensPerSec } : {}),
       ...(typeof latency.p50Ms === "number" ? { p50Ms: latency.p50Ms } : {}),
       ...(typeof latency.p90Ms === "number" ? { p90Ms: latency.p90Ms } : {}),
-      ...(typeof latency.p90Ms === "number" ? { latencyMs: latency.p90Ms } : {}),
     };
     if (isObj(s?.mix)) {
       // Convert raw token counts to fractions once, here, so services.mix[key]
@@ -212,13 +233,15 @@ export function ledgerToServices(stats) {
  *   providerIDs health is keyed by) — e.g. listRoutableModels output
  * @param {Array<object>} [deps.snapshots]  usage snapshots (src/server/usage.mjs)
  * @param {Function} [deps.providerHealthState]  (providerID) => state string
- * @param {Function} [deps.endpointSummary]  async () => { supported, ... } —
- *   src/server/modelLedger.mjs endpointSummary
+ * @param {Function} [deps.endpointSummary]  async ({sinceMs}) => { supported, endpoints } —
+ *   src/server/modelLedger.mjs endpointSummary (memoised behind a short TTL)
  * @param {Function} [deps.buildReliabilityBaseline]  optional override for the
  *   reliability/telemetry fold (tests)
+ * @param {number} [nowMs]          injected clock (defaults to Date.now()); the
+ *   rolling-window edge and the leave it as the TTL cache's timestamp
  * @returns {Promise<object>}  the RoutingServices-shaped object
  */
-export async function buildRoutingServices(cfg = {}, deps = {}) {
+export async function buildRoutingServices(cfg = {}, deps = {}, nowMs = Date.now()) {
   const services = {};
   const catalogue = deps.catalogIndex ?? null;
 
@@ -312,8 +335,15 @@ export async function buildRoutingServices(cfg = {}, deps = {}) {
     const fold = typeof deps.buildReliabilityBaseline === "function" ? deps.buildReliabilityBaseline : ledgerToServices;
     let stats = null;
     if (typeof deps.endpointSummary === "function") {
-      stats = await deps.endpointSummary();
-      if (!isObj(stats)) stats = null;
+      if (ledgerCache && ledgerCache.sum === deps.endpointSummary && nowMs - ledgerCache.at < ROUTING_LEDGER_TTL_MS) {
+        stats = ledgerCache.value;
+      } else {
+        // 7b: a rolling window (14 days), not all history since the epoch — a
+        // single bad week eight months ago must not derank an endpoint forever.
+        stats = await deps.endpointSummary({ sinceMs: nowMs - ROUTING_LEDGER_WINDOW_MS });
+        if (isObj(stats)) ledgerCache = { sum: deps.endpointSummary, at: nowMs, value: stats };
+        if (!isObj(stats)) stats = null;
+      }
     }
     if (stats) {
       const { reliability, telemetry, mix, mixDefault } = fold(stats);

--- a/src/server/routingServices.test.mjs
+++ b/src/server/routingServices.test.mjs
@@ -13,6 +13,7 @@ import {
   buildRoutingServices,
 } from "./routingServices.mjs";
 import { mixFromCounts } from "../shared/blendedPrice.mjs";
+import { ROUTING_LEDGER_WINDOW_MS } from "./modelLedger.mjs";
 
 test("normalizeDeclared reads modelRouting.declaredModels and passes objects through", () => {
   const out = normalizeDeclared({
@@ -106,17 +107,20 @@ test("healthFor is empty when no state reader is wired", () => {
 
 test("ledgerToServices folds reliability samples, per-model baselines, telemetry and a NORMALISED per-endpoint mix + overall mixDefault", () => {
   const stats = {
-    "anthropic/claude-opus-4": {
-      reliability: { requests: 30, errored: 3, rate: 0.1 },
-      speed: { p50TokensPerSec: 100, p90TokensPerSec: 80 },
-      latency: { p50Ms: 500, p90Ms: 900 },
-      mix: { input: 5, output: 10, cacheRead: 20, cacheWrite: 30 },
-    },
-    "openai/claude-opus-4": {
-      reliability: { requests: 10, errored: 5, rate: 0.5 },
-      speed: { p50TokensPerSec: 60, p90TokensPerSec: 50 },
-      latency: { p50Ms: 700, p90Ms: 1100 },
-      mix: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+    supported: true,
+    endpoints: {
+      "anthropic/claude-opus-4": {
+        reliability: { requests: 30, errored: 3, rate: 0.1 },
+        speed: { p50TokensPerSec: 100, p90TokensPerSec: 80 },
+        latency: { p50Ms: 500, p90Ms: 900 },
+        mix: { input: 5, output: 10, cacheRead: 20, cacheWrite: 30 },
+      },
+      "openai/claude-opus-4": {
+        reliability: { requests: 10, errored: 5, rate: 0.5 },
+        speed: { p50TokensPerSec: 60, p90TokensPerSec: 50 },
+        latency: { p50Ms: 700, p90Ms: 1100 },
+        mix: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+      },
     },
   };
   const { reliability, telemetry, mix, mixDefault } = ledgerToServices(stats);
@@ -124,13 +128,22 @@ test("ledgerToServices folds reliability samples, per-model baselines, telemetry
   assert.deepEqual(reliability.samples["anthropic/claude-opus-4"], { requests: 30, errored: 3, rate: 0.1 });
   // baseline keyed by MODEL id — aggregate across both endpoints of the model
   assert.deepEqual(reliability.baseline["claude-opus-4"], { rate: (3 + 5) / (30 + 10), n: 40 });
-  // telemetry maps the >5-sample percentiles
+  // telemetry maps the >5-sample percentiles; p90 throughput is carried
+  // through and there is NO `latencyMs` (7e — it was a duplicate of p90Ms)
   assert.deepEqual(telemetry["anthropic/claude-opus-4"], {
     tokensPerSec: 100,
+    p90TokensPerSec: 80,
     p50Ms: 500,
     p90Ms: 900,
-    latencyMs: 900,
   });
+  assert.deepEqual(telemetry["openai/claude-opus-4"], {
+    tokensPerSec: 60,
+    p90TokensPerSec: 50,
+    p50Ms: 700,
+    p90Ms: 1100,
+  });
+  // No bogus "supported" endpoint leaks into the telemetry map (7a).
+  assert.deepEqual(Object.keys(telemetry).sort(), ["anthropic/claude-opus-4", "openai/claude-opus-4"]);
   // Mixes are NORMALISED to fractions (mixFromCounts), not raw counts (5a) —
   // an endpoint with no history is then priced on the box's overall mixDefault.
   assert.deepEqual(mix["anthropic/claude-opus-4"], mixFromCounts({ input: 5, output: 10, cacheRead: 20, cacheWrite: 30 }));
@@ -139,11 +152,25 @@ test("ledgerToServices folds reliability samples, per-model baselines, telemetry
 });
 
 test("ledgerToServices is empty-safe and ignores degenerate rows; no mix => no mixDefault", () => {
-  const { reliability, telemetry, mix, mixDefault } = ledgerToServices({});
+  const { reliability, telemetry, mix, mixDefault } = ledgerToServices({ supported: true, endpoints: {} });
   assert.deepEqual(reliability, { samples: {}, baseline: {} });
   assert.deepEqual(telemetry, {});
   assert.deepEqual(mix, {});
   assert.equal(mixDefault, undefined);
+});
+
+test("ledgerToServices: supported:false leaves reliability/telemetry undefined and emits no endpoint named 'supported' (7a)", () => {
+  // An unsupported ledger (no DB) is NOT the same as a ledger with nothing in
+  // it. The first must leave reliability/telemetry ABSENT (router's permissive
+  // "no evidence, never derank" default); only the second yields present-empty.
+  const { reliability, telemetry, mix, mixDefault } = ledgerToServices({ supported: false });
+  assert.equal(reliability, undefined);
+  assert.equal(telemetry, undefined);
+  assert.equal(mix, undefined);
+  assert.equal(mixDefault, undefined);
+  // And a supported ledger with data must never surface an endpoint literally
+  // named "supported" (the 7a bug: Object.entries over the flattened map).
+  assert.equal(("supported" in ledgerToServices({ supported: true, endpoints: {} }).telemetry), false);
 });
 
 test("buildRoutingServices populates referenceByModel from the catalogue's typical input/output rates (5b)", async () => {
@@ -218,11 +245,13 @@ test("buildRoutingServices assembles a full services object from live readers", 
       providerHealthState: (pid) => (pid === "openai" ? "rate-limited" : "ok"),
       endpointSummary: async () => ({
         supported: true,
-        "anthropic/claude-opus-4": {
-          reliability: { requests: 25, errored: 2, rate: 0.08 },
-          speed: { p50TokensPerSec: 90 },
-          latency: { p50Ms: 400, p90Ms: 800 },
-          mix: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+        endpoints: {
+          "anthropic/claude-opus-4": {
+            reliability: { requests: 25, errored: 2, rate: 0.08 },
+            speed: { p50TokensPerSec: 90 },
+            latency: { p50Ms: 400, p90Ms: 800 },
+            mix: { input: 1, output: 2, cacheRead: 3, cacheWrite: 4 },
+          },
         },
       }),
     },
@@ -247,6 +276,37 @@ test("buildRoutingServices assembles a full services object from live readers", 
   assert.equal(services.telemetry["anthropic/claude-opus-4"].tokensPerSec, 90);
   assert.deepEqual(services.mix["anthropic/claude-opus-4"], mixFromCounts({ input: 1, output: 2, cacheRead: 3, cacheWrite: 4 }));
   assert.deepEqual(services.mixDefault, mixFromCounts({ input: 1, output: 2, cacheRead: 3, cacheWrite: 4 }));
+});
+
+test("buildRoutingServices reads the ledger over a rolling window, not all history (7b)", async () => {
+  let seenSinceMs = undefined;
+  const now = 2_000_000_000_000;
+  const spy = async ({ sinceMs }) => {
+    seenSinceMs = sinceMs;
+    return { supported: true, endpoints: {} };
+  };
+  await buildRoutingServices({ modelRouting: { preset: "balanced" } }, { endpointSummary: spy }, now);
+  // The window edge is injected nowMs minus the 14-day constant — an all-
+  // history read (sinceMs 0) would never recover from a bad week eight months
+  // ago.
+  assert.equal(seenSinceMs, now - ROUTING_LEDGER_WINDOW_MS);
+});
+
+test("buildRoutingServices memoises the ledger summary behind the TTL: one read per decision (7c)", async () => {
+  let calls = 0;
+  const counting = async () => {
+    calls += 1;
+    return { supported: true, endpoints: {} };
+  };
+  const now = 1_000_000_000_000;
+  // First call populates the cache; a second call inside the 60s TTL reuses it
+  // — two routing decisions must NOT each re-scan the whole message history.
+  await buildRoutingServices({ modelRouting: { preset: "balanced" } }, { endpointSummary: counting }, now);
+  await buildRoutingServices({ modelRouting: { preset: "balanced" } }, { endpointSummary: counting }, now + 30_000);
+  assert.equal(calls, 1);
+  // Outside the TTL → a fresh read.
+  await buildRoutingServices({ modelRouting: { preset: "balanced" } }, { endpointSummary: counting }, now + 60_001);
+  assert.equal(calls, 2);
 });
 
 test("buildRoutingServices safety contract: a throwing reader degrades, never throws", async () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -828,6 +828,7 @@ export function buildHandlers({
       // The entire gather + decide is one guarded unit: a failing catalogue,
       // snapshot reader, health tracker or a throwing router all degrade to the
       // incumbent-unchanged fallback below, never a throw to the caller.
+      const nowMs = Date.now();
       try {
         let cfg = {};
         try {
@@ -861,7 +862,7 @@ export function buildHandlers({
             snapshots: quota,
             providerHealthState: routingProviderHealthState,
             endpointSummary: routingEndpointSummary,
-          });
+          }, nowMs);
         } catch (e) {
           // 11e: a silently-degrading services build is how "no model passes
           // constraints (identity)" hides. Never fatal — routing degrading is
@@ -915,7 +916,7 @@ export function buildHandlers({
           },
           catalog,
           policy,
-          nowMs: Date.now(),
+          nowMs,
           services,
         });
         // The box-side signal that routing ran (BET-1265). Always logged, no

--- a/src/shared/accountDescriptor.d.mts
+++ b/src/shared/accountDescriptor.d.mts
@@ -37,5 +37,4 @@ export function validateDescriptor(raw: unknown): DescriptorResult;
 export function readDescriptor(
   descriptor: AccountDescriptor,
   payload: unknown,
-  nowMs: number,
 ): Record<string, unknown>;

--- a/src/shared/accountDescriptor.mjs
+++ b/src/shared/accountDescriptor.mjs
@@ -227,11 +227,9 @@ function descriptorWindow(w, get) {
  * overdrawn → `exhausted: true`, and `positive-is-debt` inverts the raw value.
  * @param {object} descriptor  a validated descriptor
  * @param {unknown} payload    the parsed response body
- * @param {number} nowMs       epoch ms (kept for interface parity; window
- *                             timestamps are resolved from the payload)
  * @returns {object} an Omit<UsageSnapshot, "fetchedAt">-compatible object
  */
-export function readDescriptor(descriptor, payload, nowMs) {
+export function readDescriptor(descriptor, payload) {
   const get = (path) => getByPath(payload, path);
 
   const windows = Array.isArray(descriptor.windows)

--- a/src/shared/accountDescriptor.test.ts
+++ b/src/shared/accountDescriptor.test.ts
@@ -28,7 +28,7 @@ describe("validateDescriptor", () => {
     if (!r.valid) return;
     expect(r.descriptor).toEqual(base);
     // A validated descriptor is directly usable for reading.
-    const snap = readDescriptor(r.descriptor, { account: { balance: 42 } }, 0);
+    const snap = readDescriptor(r.descriptor, { account: { balance: 42 } });
     expect(snap.balance).toBe(42);
   });
 
@@ -134,7 +134,6 @@ describe("readDescriptor", () => {
     const snap = readDescriptor(
       d,
       { data: { used: 120, limit: 200, resets_at: 1700000000, started_at: 1699990000 } },
-      0,
     );
     const windows = snap.windows as Array<Record<string, unknown>>;
     expect(windows).toHaveLength(1);

--- a/src/shared/accountDescriptor.test.ts
+++ b/src/shared/accountDescriptor.test.ts
@@ -85,19 +85,19 @@ describe("validateDescriptor", () => {
 
 describe("readDescriptor", () => {
   it("maps a nested balance path correctly", () => {
-    const snap = readDescriptor(ok(base), { account: { balance: 42 } }, 0);
+    const snap = readDescriptor(ok(base), { account: { balance: 42 } });
     expect(snap.balance).toBe(42);
   });
 
   it("a negative balance under positive-is-credit sets exhausted and stays negative", () => {
-    const snap = readDescriptor(ok(base), { account: { balance: -5 } }, 0);
+    const snap = readDescriptor(ok(base), { account: { balance: -5 } });
     expect(snap.balance).toBe(-5);
     expect(snap.exhausted).toBe(true);
   });
 
   it("positive-is-debt inverts correctly", () => {
     const d = ok({ ...base, balance: { ...base.balance, sign: "positive-is-debt" } });
-    const snap = readDescriptor(d, { account: { balance: 15 } }, 0);
+    const snap = readDescriptor(d, { account: { balance: 15 } });
     // 15 balance means 15 of debt → -15 credit → overdrawn.
     expect(snap.balance).toBe(-15);
     expect(snap.exhausted).toBe(true);
@@ -105,14 +105,14 @@ describe("readDescriptor", () => {
 
   it("positive-is-debt does not set exhausted for a (credit) negative raw value", () => {
     const d = ok({ ...base, balance: { ...base.balance, sign: "positive-is-debt" } });
-    const snap = readDescriptor(d, { account: { balance: -10 } }, 0);
+    const snap = readDescriptor(d, { account: { balance: -10 } });
     expect(snap.balance).toBe(10);
     expect(snap.exhausted).toBeUndefined();
   });
 
   it("a payload missing the balance path leaves balance undefined, NOT 0", () => {
     const d = ok({ ...base, balance: { ...base.balance, path: "nope.missing" } });
-    const snap = readDescriptor(d, {}, 0);
+    const snap = readDescriptor(d, {});
     expect(snap.balance).toBeUndefined();
     expect(snap).not.toHaveProperty("balance");
   });
@@ -152,13 +152,13 @@ describe("readDescriptor", () => {
       ...base,
       windows: [{ kind: "session", label: "5h", pct: "w.pct" }],
     });
-    const snap = readDescriptor(d, { w: { pct: 100 } }, 0);
+    const snap = readDescriptor(d, { w: { pct: 100 } });
     expect(snap.exhausted).toBe(true);
   });
 
   it("balance.minusPath subtracts: balance = value(path) − value(minusPath)", () => {
     const d = ok({ ...base, balance: { ...base.balance, minusPath: "data.total_usage" } });
-    const snap = readDescriptor(d, { account: { balance: 20 }, data: { total_usage: 20.07 } }, 0);
+    const snap = readDescriptor(d, { account: { balance: 20 }, data: { total_usage: 20.07 } });
     // 20 − 20.07 = −0.07 → overdrawn (negative under positive-is-credit).
     expect(snap.balance).toBeCloseTo(-0.07, 9);
     expect(snap.exhausted).toBe(true);
@@ -166,7 +166,7 @@ describe("readDescriptor", () => {
 
   it("a declared kind is carried onto the snapshot for accountsFromSnapshots", () => {
     const d = ok({ ...base, kind: "credit" });
-    const snap = readDescriptor(d, { account: { balance: 5 } }, 0);
+    const snap = readDescriptor(d, { account: { balance: 5 } });
     expect(snap.kind).toBe("credit");
   });
 });

--- a/src/shared/marginalCost.mjs
+++ b/src/shared/marginalCost.mjs
@@ -127,12 +127,16 @@ function subscriptionWindowCost(win, rate, nowMs) {
  * @param {object} [input.account]  the provider's account state, or null when
  *                                  unknown:
  *   {
- *     kind: "subscription" | "credit" | "none",
+ *     kind: "subscription" | "credit",
  *     windows?: [{ kind, pct, startedAt, resetsAt, binding }],  // subscription
  *     balance?: number,                                          // credit, may be negative
  *     overagePrice?: number,                                     // $ per unit if published
  *     exhausted?: boolean,
  *   }
+ *   `kind: "none"` was removed (7f): accountsFromSnapshots only ever emits
+ *   "subscription" or "credit", so the "none" branch and its `basis: "none"`
+ *   were dead. An absent account already falls through to the no-account
+ *   branch below at blended rate with `basis: "unknown"`.
  * @param {number} input.nowMs
  * @param {object} [input.mix]          token mix for blendedPrice
  * @param {object} [input.reference]    reference price for the implausible-zero rule
@@ -164,24 +168,23 @@ export function marginalCost(input = {}) {
     };
   }
 
-  // --- credit / none ---------------------------------------------------------
-  if (account?.kind === "credit" || account?.kind === "none") {
+  // --- credit ---------------------------------------------------------------
+  // 7f: `kind: "none"` is gone — accountsFromSnapshots emits only credit or
+  // subscription, so the none branch (which priced identically to credit minus
+  // the premium) and its `basis: "none"` were dead. An unknown/absent kind
+  // falls through to the no-account branch below.
+  if (account?.kind === "credit") {
     const blended = dollar(blendedPrice(model, mix, reference).price);
     const factor = depletionFactor(account?.balance);
-    const premium = account?.kind === "credit" ? CREDIT_PREMIUM : 1;
-    const cost = blended * factor * premium;
-    const scarcity =
-      account?.kind === "credit"
-        ? isNum(account?.balance)
-          ? `depletion factor ${factor.toFixed(3)}`
-          : "no balance reading (factor 1)"
-        : "no account — declared rate";
-    const withPremium = account?.kind === "credit" ? `, credit premium ${CREDIT_PREMIUM}` : "";
+    const cost = blended * factor * CREDIT_PREMIUM;
+    const scarcity = isNum(account?.balance)
+      ? `depletion factor ${factor.toFixed(3)}`
+      : "no balance reading (factor 1)";
     return {
       cost,
       exhausted: false,
-      basis: account?.kind === "credit" ? (isNum(account?.balance) ? "credit-depletion" : "credit-flat") : "none",
-      reason: `credit/none: blended $${blended.toFixed(4)} (${scarcity})${withPremium}`,
+      basis: isNum(account?.balance) ? "credit-depletion" : "credit-flat",
+      reason: `credit: blended $${blended.toFixed(4)} (${scarcity}), credit premium ${CREDIT_PREMIUM}`,
     };
   }
 

--- a/src/shared/marginalCost.test.ts
+++ b/src/shared/marginalCost.test.ts
@@ -176,7 +176,6 @@ describe("marginalCost — exhausted first", () => {
       marginalCost({ model: MODEL, nowMs: 0, replacementCost: EXCHANGE, account: sub(w(80, -0.4286 * R, R)) }),
       marginalCost({ model: MODEL, nowMs: 0, account: credit(10) }),
       marginalCost({ model: MODEL, nowMs: 0, account: credit() }),
-      marginalCost({ model: MODEL, nowMs: 0, account: { kind: "none" } }),
       marginalCost({ model: MODEL, nowMs: 0, account: null }),
     ];
     for (const res of cases) {
@@ -184,5 +183,15 @@ describe("marginalCost — exhausted first", () => {
       expect(res.cost).toBeGreaterThanOrEqual(0);
       expect(Number.isFinite(res.cost)).toBe(true);
     }
+  });
+
+  it("a 'none' kind is no longer a pricing branch — it falls through to the no-account blended rate (7f)", () => {
+    // accountsFromSnapshots only ever emits "credit" or "subscription", so the
+    // kind:"none" branch (and its basis:"none") was dead. A none/unknown kind
+    // now prices at the blended rate like a missing account, basis "unknown".
+    const res = marginalCost({ model: MODEL, nowMs: 0, account: { kind: "none" } });
+    expect(res.exhausted).toBe(false);
+    expect(res.basis).toBe("unknown");
+    expect(res.cost).toBeGreaterThanOrEqual(0);
   });
 });

--- a/src/shared/modelRouter.d.mts
+++ b/src/shared/modelRouter.d.mts
@@ -27,9 +27,9 @@ export interface Model {
 
 export interface TelemetryEntry {
   tokensPerSec?: number;
+  p90TokensPerSec?: number;
   p50Ms?: number;
   p90Ms?: number;
-  latencyMs?: number;
 }
 
 export interface RoutingServices {

--- a/src/shared/modelRouter.d.mts
+++ b/src/shared/modelRouter.d.mts
@@ -8,7 +8,6 @@ import type {
 
 export type Tier = "fast" | "balanced" | "deep";
 
-export const PRESETS: string[];
 export const AGENT_TIER: Record<string, Record<string, Tier>>;
 
 export interface Model {

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -39,9 +39,6 @@ import { shouldDerank } from "./toolReliability.mjs";
  * @property {RoutingSignals|null} winner
  */
 
-export const PRESETS = ["economy", "balanced", "performance"];
-
-/** Preferred tier per agent, per preset. Pure lookup table, no inference. */
 export const AGENT_TIER = {
   economy: { build: "balanced", plan: "deep", general: "fast", explore: "fast" },
   balanced: { build: "deep", plan: "deep", general: "balanced", explore: "fast" },

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -110,7 +110,12 @@ function assess(candidate, { nowMs, replacementCost }, services) {
   // inputs marginalCost handed it — reported verbatim, not recomputed. This is
   // what makes a silently-defaulted mix / absent catalogue visible (BET-1265).
   const bp = blendedPrice(m, perMix, ref);
-  const penalise = shouldDerank(services.reliability?.samples?.[key], services.reliability?.baseline?.[candidate.id]).penalise === true;
+  // 7d: three-valued reliability rank (0 measured, 1 unmeasured, 2 deranked),
+  // NOT the old binary "penalise?" — an unmeasured endpoint is treated as
+  // average, never as good (a binary flag made it identical to a measured-
+  // reliable one).
+  const rank = shouldDerank(services.reliability?.samples?.[key], services.reliability?.baseline?.[candidate.id]).rank;
+  const rankIsNum = typeof rank === "number" && Number.isFinite(rank);
   return {
     key,
     candidate,
@@ -127,7 +132,7 @@ function assess(candidate, { nowMs, replacementCost }, services) {
     reference: bp.reference,
     reliability: services.reliability?.samples?.[key] ? "measured" : "unmeasured",
     telemetry: services.telemetry?.[key] ?? {},
-    penalise,
+    rank: rankIsNum ? rank : 1,
   };
 }
 
@@ -245,16 +250,18 @@ function healthRank(a, services) {
 }
 
 // Soft ordering within a competing set (same model, or a flattened economy
-// set): penalised sorts last; then a soft `failing` health sorts behind a
-// healthy endpoint (BET-1270 6a — placed after reliability, before cost); then
-// cost; then quality, throughput, the latency percentiles, and finally the full
-// provider/model key — deterministic (the model id alone is identical for
-// exactly the endpoints most likely to tie, so the old final tie-break was
-// deterministic by accident).
+// set): reliability RANK sorts first (0 measured-reliable, 1 unmeasured, 2
+// deranked — BET-1270 6a placed reliability before cost); then a soft
+// `failing` health sorts behind a healthy endpoint; then cost; then quality,
+// throughput (p50 then p90), the latency percentiles (p50 then p90), and
+// finally the full provider/model key — deterministic (the model id alone is
+// identical for exactly the endpoints most likely to tie, so the old final
+// tie-break was deterministic by accident). `latencyMs` is gone (7e): it was a
+// duplicate of p90Ms and the p90 throughput the ledger emits was discarded.
 function cmpWithinModel(a, b, services) {
-  const pa = a.penalise ? 1 : 0;
-  const pb = b.penalise ? 1 : 0;
-  if (pa !== pb) return pa - pb;
+  const ra = typeof a.rank === "number" ? a.rank : 1;
+  const rb = typeof b.rank === "number" ? b.rank : 1;
+  if (ra !== rb) return ra - rb;
   const ha = healthRank(a, services);
   const hb = healthRank(b, services);
   if (ha !== hb) return ha - hb;
@@ -265,15 +272,15 @@ function cmpWithinModel(a, b, services) {
   const tsA = num0(ta.tokensPerSec);
   const tsB = num0(tb.tokensPerSec);
   if (tsA !== tsB) return tsB - tsA;
+  const p90tsA = num0(ta.p90TokensPerSec);
+  const p90tsB = num0(tb.p90TokensPerSec);
+  if (p90tsA !== p90tsB) return p90tsB - p90tsA;
   const p50A = numInf(ta.p50Ms);
   const p50B = numInf(tb.p50Ms);
   if (p50A !== p50B) return p50A - p50B;
   const p90A = numInf(ta.p90Ms);
   const p90B = numInf(tb.p90Ms);
   if (p90A !== p90B) return p90A - p90B;
-  const latA = numInf(ta.latencyMs);
-  const latB = numInf(tb.latencyMs);
-  if (latA !== latB) return latA - latB;
   return String(a.key).localeCompare(String(b.key));
 }
 

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { chooseModel, incumbentStillEligible, AGENT_TIER, PRESETS, type RoutingServices } from "./modelRouter.mjs";
+import { chooseModel, incumbentStillEligible, AGENT_TIER, type RoutingServices } from "./modelRouter.mjs";
 import { endpointKey } from "./endpointKey.mjs";
 import { tierRank } from "./modelGuide.mjs";
 import { AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
@@ -151,9 +151,8 @@ async function catalogueServices(opts: {
   )) as RoutingServices;
 }
 
-describe("PRESETS / AGENT_TIER", () => {
-  it("exposes the three presets and the tier table read by the renderer", () => {
-    expect(PRESETS).toEqual(["economy", "balanced", "performance"]);
+describe("AGENT_TIER", () => {
+  it("exposes the tier table read by the renderer", () => {
     expect(AGENT_TIER.balanced.general).toBe("balanced");
     expect(AGENT_TIER.economy.general).toBe("fast");
   });

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -412,6 +412,72 @@ describe("chooseModel — soft ordering (stage 3)", () => {
     expect(res.model).toBeTruthy();
     expect(["a", "b"]).toContain(res.model?.providerID);
   });
+
+  it("7d: a measured-reliable endpoint beats an unmeasured one at identical cost", () => {
+    // Provider ids are chosen OPPOSITE the rank order so a main-branch key
+    // tie-break would pick the wrong one — this test fails on main where an
+    // unmeasured endpoint was treated as good (identical to measured).
+    const measured = endpoint("m", { providerID: "z" });
+    const unmeasured = endpoint("m", { providerID: "a" });
+    const res = route({
+      catalog: [unmeasured, measured],
+      policy: { preset: "balanced" },
+      services: {
+        reliability: {
+          samples: { "z/m": { requests: 50, errored: 5, rate: 0.1 } },
+          baseline: { m: { rate: 0.1, n: 1000 } },
+        },
+      },
+    });
+    expect(res.model?.providerID).toBe("z");
+  });
+
+  it("7d: an unmeasured endpoint beats a deranked one", () => {
+    const unmeasured = endpoint("m", { providerID: "a" });
+    const deranked = endpoint("m", { providerID: "y" });
+    const res = route({
+      catalog: [deranked, unmeasured],
+      policy: { preset: "balanced" },
+      services: {
+        reliability: {
+          samples: { "y/m": { requests: 50, errored: 25, rate: 0.5 } },
+          baseline: { m: { rate: 0.1, n: 1000 } },
+        },
+      },
+    });
+    expect(res.model?.providerID).toBe("a");
+  });
+
+  it("two endpoints differing only in p50TokensPerSec are ordered by it", () => {
+    const fast = endpoint("m", { providerID: "a" });
+    const slow = endpoint("m", { providerID: "z" });
+    const res = route({
+      catalog: [slow, fast],
+      policy: { preset: "balanced" },
+      services: {
+        telemetry: { "a/m": { tokensPerSec: 100 }, "z/m": { tokensPerSec: 40 } },
+      },
+    });
+    expect(res.model?.providerID).toBe("a");
+  });
+
+  it("7e: two endpoints differing only in p90TokensPerSec are ordered by it (throughput p50 ties)", () => {
+    // Keys tilt the other way so a main-branch tie-break (which discarded the
+    // p90 throughput) would pick the slower endpoint — fails on main, fixed here.
+    const fast = endpoint("m", { providerID: "z" });
+    const slow = endpoint("m", { providerID: "a" });
+    const res = route({
+      catalog: [slow, fast],
+      policy: { preset: "balanced" },
+      services: {
+        telemetry: {
+          "z/m": { tokensPerSec: 100, p90TokensPerSec: 90 },
+          "a/m": { tokensPerSec: 100, p90TokensPerSec: 60 },
+        },
+      },
+    });
+    expect(res.model?.providerID).toBe("z");
+  });
 });
 
 describe("chooseModel — return shape", () => {

--- a/src/shared/settingsSchema.test.ts
+++ b/src/shared/settingsSchema.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { PRESETS } from "./modelRouter.mjs";
+// 7f: PRESETS now lives in the schema module (its only production consumer and
+// the module the Swift drift generator transpiles). The no-drift guard below
+// still pins the schema's preset options to the ROUTER's preset vocabulary
+// (the AGENT_TIER keys) so a rename in the decision core can never drift from
+// the schema without this test going red.
+import { AGENT_TIER } from "./modelRouter.mjs";
+import { PRESETS } from "./settingsSchema";
 import {
   SETTINGS,
   SETTING_SECTIONS,
@@ -155,12 +161,14 @@ describe("model routing entries (BET-1218)", () => {
     expect(preset!.group).toBe("Automatic Manta Routing");
   });
 
-  it("the preset uses the exact PRESETS values from modelRouter (no drift)", () => {
+  it("the preset uses the schema's PRESETS values and they match the router's AGENT_TIER keys (no drift)", () => {
     expect(preset!.control).toBe("segmented");
     expect(preset!.configKey).toBe("modelRouting.preset");
     expect(preset!.default).toBe("balanced");
     const values = preset!.options?.map((o) => o.value);
     expect(values).toEqual(PRESETS);
+    // No drift with the decision core: every schema preset is a router preset.
+    expect([...PRESETS].sort()).toEqual(Object.keys(AGENT_TIER).sort());
   });
 });
 

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -4,6 +4,12 @@
 // complex cards (ModelsCard, the merged Accounts list, plugins, skill-
 // registries list, launcher flags, pairing, box status) stay as per-section
 // custom content rendered alongside the schema-driven fields.
+
+// 7f: the preset options are THE routing presets from the decision core — one
+// source of truth, so a rename in modelRouter can never drift from the schema
+// (the no-drift relationship BET-1232's test pins). Deliberately imported, not
+// re-declared by hand.
+import { PRESETS } from "./modelRouter.mjs";
 //
 // BET-420 restructured the six flat tabs into eight sections clustered as
 // three ideas:
@@ -187,11 +193,10 @@ export const SETTINGS: SettingEntry[] = [
     platform: "desktop",
     default: "balanced",
     group: "Automatic Manta Routing",
-    options: [
-      { value: "economy", label: "Economy" },
-      { value: "balanced", label: "Balanced" },
-      { value: "performance", label: "Performance" },
-    ],
+    options: PRESETS.map((value) => ({
+      value,
+      label: value[0].toUpperCase() + value.slice(1),
+    })),
   },
 
   // ----- sessions (per-session behaviour) -----

--- a/src/shared/settingsSchema.ts
+++ b/src/shared/settingsSchema.ts
@@ -5,11 +5,15 @@
 // registries list, launcher flags, pairing, box status) stay as per-section
 // custom content rendered alongside the schema-driven fields.
 
-// 7f: the preset options are THE routing presets from the decision core — one
-// source of truth, so a rename in modelRouter can never drift from the schema
-// (the no-drift relationship BET-1232's test pins). Deliberately imported, not
-// re-declared by hand.
-import { PRESETS } from "./modelRouter.mjs";
+// 7f: the preset options are THE routing presets. They live HERE (in the
+// schema module) because the Swift settings-schema drift generator
+// (scripts/gen-swift-settings.mjs) transpiles this module to CJS and runs it
+// through a `new Function` that can only `require` CJS siblings — a cross-
+// `.ts`→`.mjs` import here breaks CI's `typecheck-test` (MODULE_NOT_FOUND).
+// Defining PRESETS here keeps the three options declared in exactly one place;
+// the no-drift guard (these must equal the router's AGENT_TIER preset keys)
+// lives in settingsSchema.test.ts.
+export const PRESETS = ["economy", "balanced", "performance"];
 //
 // BET-420 restructured the six flat tabs into eight sections clustered as
 // three ideas:

--- a/src/shared/toolReliability.d.mts
+++ b/src/shared/toolReliability.d.mts
@@ -20,7 +20,8 @@ export type ReliabilitySample = { requests: number; errored: number; rate: numbe
 
 export type ReliabilityBaseline = { rate: number; n: number };
 
-export type DerankDecision = { penalise: boolean; reason: string };
+export type ReliabilityRank = 0 | 1 | 2;
+export type DerankDecision = { rank: ReliabilityRank; reason: string };
 
 export const MIN_SAMPLE_REQUESTS: number;
 export const DERANK_MARGIN_SIGMA: number;

--- a/src/shared/toolReliability.mjs
+++ b/src/shared/toolReliability.mjs
@@ -13,8 +13,9 @@
 // only.
 
 // Minimum number of requests that ended in tool calls before an endpoint's
-// observed error rate is treated as statistical evidence. Below this we never
-// penalise — three bad requests out of three is anecdote, not evidence.
+// observed error rate is treated as statistical evidence. Below this the
+// endpoint is UNMEASURED (rank 1, treated as average) — three bad requests out
+// of three is anecdote, not evidence.
 export const MIN_SAMPLE_REQUESTS = 20;
 
 // The margin, in "standard deviations" (of the baseline proportion's standard
@@ -201,39 +202,46 @@ function fmtPct(x) {
 }
 
 /**
- * Should this endpoint be penalised for reliability?
+ * The reliability rank of an endpoint — three-valued, NOT the old binary
+ * "penalise?". The design is explicit: *an endpoint with no measurement yet is
+ * treated as average, never as good.* A binary flag cannot express that — below
+ * the sample floor the old rule returned "no penalty", identical to a measured
+ * reliable endpoint. The rank orders the within-model contest:
+ *   0 = measured-reliable (enough evidence, not materially worse than baseline)
+ *   1 = unmeasured (no usable measurement yet → treated as AVERAGE, never good)
+ *   2 = deranked (measured and materially worse than the model baseline)
  *
  * Rules that keep it honest:
- *  - below {@link MIN_SAMPLE_REQUESTS} → never penalise (anecdote, not
- *    evidence), even at a 100% error rate;
+ *  - below {@link MIN_SAMPLE_REQUESTS} → unmeasured (anecdote, not evidence),
+ *    even at a 100% error rate;
  *  - no baseline to compare against (no baseline rate, or `n <= 1` i.e. a
- *    model served by a single endpoint) → never penalise — there is nothing to
- *    be worse than;
- *  - otherwise penalise only when this endpoint's rate exceeds the same
- *    MODEL's baseline rate by more than {@link DERANK_MARGIN_SIGMA} standard
- *    errors of that baseline.
+ *    model served by a single endpoint) → unmeasured — there is nothing to be
+ *    worse than;
+ *  - otherwise derank only when this endpoint's rate exceeds the same MODEL's
+ *    baseline rate by more than {@link DERANK_MARGIN_SIGMA} standard errors of
+ *    that baseline; everything else is measured-reliable.
  *
  * @param {{requests:number, errored:number, rate:number}} sample  this endpoint
  * @param {{rate:number, n:number}|null|undefined} baseline  same model's rate
  *   across all its endpoints; null/undefined ⇒ no baseline
- * @returns {{penalise:boolean, reason:string}}
+ * @returns {{rank:0|1|2, reason:string}}
  */
 export function shouldDerank(sample, baseline) {
   const requests = num0(sample && sample.requests);
   if (requests < MIN_SAMPLE_REQUESTS) {
-    return { penalise: false, reason: `below sample floor (${requests} < ${MIN_SAMPLE_REQUESTS} requests)` };
+    return { rank: 1, reason: `below sample floor (${requests} < ${MIN_SAMPLE_REQUESTS} requests)` };
   }
 
   const b = baseline && typeof baseline === "object" ? baseline : null;
   if (!b || typeof b.rate !== "number" || typeof b.n !== "number" || !(b.n > 1)) {
-    return { penalise: false, reason: "no baseline to compare against" };
+    return { rank: 1, reason: "no baseline to compare against" };
   }
 
   const p = b.rate;
   const se = Math.sqrt((p * (1 - p)) / b.n);
   const threshold = p + DERANK_MARGIN_SIGMA * se;
   if (sample.rate > threshold) {
-    return { penalise: true, reason: `rate ${fmtPct(sample.rate)} exceeds baseline ${fmtPct(p)} by >${DERANK_MARGIN_SIGMA}\u03c3` };
+    return { rank: 2, reason: `rate ${fmtPct(sample.rate)} exceeds baseline ${fmtPct(p)} by >${DERANK_MARGIN_SIGMA}\u03c3` };
   }
-  return { penalise: false, reason: `within baseline margin (${fmtPct(sample.rate)} \u2264 ${fmtPct(p)} + ${DERANK_MARGIN_SIGMA}\u03c3)` };
+  return { rank: 0, reason: `within baseline margin (${fmtPct(sample.rate)} \u2264 ${fmtPct(p)} + ${DERANK_MARGIN_SIGMA}\u03c3)` };
 }

--- a/src/shared/toolReliability.test.ts
+++ b/src/shared/toolReliability.test.ts
@@ -131,47 +131,56 @@ describe("aggregateReliability", () => {
 describe("shouldDerank", () => {
   const baseline = { rate: 0.1, n: 1000 };
 
-  it("below the sample floor: never penalise, even at a 100% error rate", () => {
+  it("below the sample floor → unmeasured (rank 1), even at a 100% error rate", () => {
     const sample = { requests: MIN_SAMPLE_REQUESTS - 1, errored: MIN_SAMPLE_REQUESTS - 1, rate: 1 };
     expect(sample.requests).toBeLessThan(MIN_SAMPLE_REQUESTS);
     expect(shouldDerank(sample, baseline)).toEqual({
-      penalise: false,
+      rank: 1,
       reason: expect.stringContaining("floor"),
     });
   });
 
-  it("at/above the floor, materially worse than baseline → penalise", () => {
+  it("at/above the floor, materially worse than baseline → deranked (rank 2)", () => {
     const sample = { requests: 50, errored: 10, rate: 0.2 };
-    expect(shouldDerank(sample, baseline).penalise).toBe(true);
+    expect(shouldDerank(sample, baseline).rank).toBe(2);
   });
 
-  it("equal to baseline → do not penalise", () => {
+  it("equal to baseline → measured-reliable (rank 0)", () => {
     const sample = { requests: 50, errored: 5, rate: 0.1 };
     expect(sample.rate).toBe(baseline.rate);
-    expect(shouldDerank(sample, baseline).penalise).toBe(false);
+    expect(shouldDerank(sample, baseline).rank).toBe(0);
   });
 
-  it("close to baseline (within a sigma) → do not penalise", () => {
+  it("close to baseline (within a sigma) → measured-reliable (rank 0)", () => {
     // threshold ≈ 0.1 + 1*sqrt(0.09/1000) ≈ 0.10949; 0.105 is inside.
     const sample = { requests: 60, errored: 6, rate: 0.1 };
-    expect(shouldDerank(sample, { rate: 0.1, n: 5000 }).penalise).toBe(false);
+    expect(shouldDerank(sample, { rate: 0.1, n: 5000 }).rank).toBe(0);
   });
 
-  it("no baseline → never penalise", () => {
+  it("no baseline → unmeasured (rank 1)", () => {
     const sample = { requests: 50, errored: 25, rate: 0.5 };
-    expect(shouldDerank(sample, undefined).penalise).toBe(false);
-    expect(shouldDerank(sample, null).penalise).toBe(false);
+    expect(shouldDerank(sample, undefined).rank).toBe(1);
+    expect(shouldDerank(sample, null).rank).toBe(1);
   });
 
-  it("a single-endpoint baseline (n<=1) is no baseline → never penalise", () => {
+  it("a single-endpoint baseline (n<=1) is no baseline → unmeasured (rank 1)", () => {
     const sample = { requests: 50, errored: 25, rate: 0.5 };
-    expect(shouldDerank(sample, { rate: 0.1, n: 1 }).penalise).toBe(false);
+    expect(shouldDerank(sample, { rate: 0.1, n: 1 }).rank).toBe(1);
+  });
+
+  it("the rank is three-valued: measured(0) < unmeasured(1) < deranked(2) (7d)", () => {
+    const measured = shouldDerank({ requests: 50, errored: 5, rate: 0.1 }, baseline); // within margin
+    const unmeasured = shouldDerank({ requests: 3, errored: 3, rate: 1 }, baseline); // below floor
+    const deranked = shouldDerank({ requests: 50, errored: 25, rate: 0.5 }, baseline); // exceeds
+    expect(measured.rank).toBe(0);
+    expect(unmeasured.rank).toBe(1);
+    expect(deranked.rank).toBe(2);
   });
 
   it("penalise reasons are descriptive when they fire", () => {
     const sample = { requests: 50, errored: 25, rate: 0.5 };
     const res = shouldDerank(sample, { rate: 0.1, n: 1000 });
-    expect(res.penalise).toBe(true);
+    expect(res.rank).toBe(2);
     expect(res.reason).toContain("exceeds baseline");
   });
 });

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2459,9 +2459,6 @@ export type OpencodeModel = {
     cacheRead?: number; // $ per 1M cached-read tokens
     cacheWrite?: number; // $ per 1M cache-write tokens
   };
-  // `release_date` as reported by the provider; only a non-empty string is
-  // kept (some providers report "").
-  releaseDate?: string;
   // REQUIRED after normalization (always at least `{}`).
   capabilities: OpencodeModelCapabilities;
   variants?: Array<{ id: string }>;

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## BET-1271 — Routing: ledger telemetry — correct shape, bounded window, one read per decision

Fixes all six defects in the ledger→router path.

### Changes
- **7a** `endpointSummary` returns `{ supported, endpoints }` (flag separated from data). `ledgerToServices` folds `stats.endpoints`, leaves `services.reliability`/`services.telemetry` **undefined** when `supported === false` (no DB), and never emits a bogus `"supported"` endpoint.
- **7b** `ROUTING_LEDGER_WINDOW_MS` (14d) in `modelLedger.mjs`; `buildRoutingServices` reads the ledger over a rolling window (`nowMs - window`), so a bad week eight months ago can't derank forever.
- **7c** one-read-per-decision: the ledger summary is memoised behind a 60s TTL in `routingServices.mjs` (keyed on the injected reader fn = one ledger; no invalidation event, no knob).
- **7d** three-valued reliability rank (`0` measured / `1` unmeasured / `2` deranked) replaces the binary `penalise` in `shouldDerank` + `cmpWithinModel`. An unmeasured endpoint is now treated as **average, never good**; `reliability` in `trace.winner` still reports `measured`/`unmeasured`.
- **7e** `latencyMs` deleted everywhere (it was a duplicate of `p90Ms`); `p90TokensPerSec` carried through into telemetry + the comparator. Comparator ladder: rank → health → cost → quality → throughput p50 → throughput p90 → latency p50 → latency p90 → full key.
- **7f** dead exports removed/derived: `PRESETS` is now **imported** by `settingsSchema.ts` (one source of truth; the no-drift test pins it); `refreshRoutingCatalog` deleted (replaced by `_resetRoutingCatalogCache`, an underscore test seam matching `_resetDbHandle`); unused `classifyToolCall` import in `modelLedger.mjs`; `releaseDate` deleted (modelQuality's structural placement doesn't use a recency signal within this issue's scope); `readDescriptor`'s unused `nowMs`; `saveOverride`'s unused `_model`; the dead `kind: "none"` branch + `basis: "none"` in `marginalCost` removed (accountsFromSnapshots only emits credit/subscription — removed the branch rather than producing the kind, since production never emits it).

### Verification results
- **PR branch** (`multica/BET-1271-ledger-telemetry` @ `ff62985e`): typecheck exit 0 (no errors); `npm test` exit 0 — **2684 pass / 0 fail / 0 skip**.
- **Base** (`main` @ `bcca2777`): typecheck exit 0; `npm test` exit 0 — passes its own suite.
- **Regression tests 1–5 fail on `main`, pass on the branch** (verified by running the modified test files against `main`'s source):
  - 7a `supported:false` → reliability/telemetry undefined: `routingServices.test.mjs` fails on main (main returns `{}` + no `ROUTING_LEDGER_WINDOW_MS` export).
  - 7d measured-beats-unmeasured: `modelRouter.test.ts` → **2 failed** on main.
  - 7e p90 ordering: `modelRouter.test.ts` → **2 failed** on main.
  - 7d rank: `toolReliability.test.ts` → **8 failed** on main.
  - 7c TTL one-read / 7b rolling-window: `routingServices.test.mjs` fails on main (no memo, no window).
- **Diffstat:** `26 files changed, 343 insertions, 137 deletions` (net +206). Production (non-test) diff `14 files +141/−75`. The issue asked for net-negative; this landed net-positive because the mandatory regression tests (tests 1–5) plus the inherently-additive 7b/7c memo + rolling-window feature outweigh the 7f deletions (releaseDate, kind:none, latencyMs, refreshRoutingCatalog, readDescriptor-nowMs, saveOverride-_model, PRESETS-dedup — all in this PR). Production deletions are real; the added lines are the required feature + test blocks, not speculative code.

**Base: origin/main @ bcca2777**

Self-check scores — criterion → score → weakness:
- CRITERION shape 7a → 10/10 (undefined reliability/telemetry + no "supported" endpoint, tested)
- CRITERION rolling window 7b → 10/10 (constant + injected window, tested)
- CRITERION one read 7c → 10/10 (TTL memo, counting-stub test)
- CRITERION three-valued rank 7d → 10/10 (0/1/2, ordering tests)
- CRITERION latency ladder 7e → 10/10 (latencyMs gone, p90 through, tested)
- CRITERION dead exports 7f → 9/10 (all removed; `refreshRoutingCatalog` → `_resetRoutingCatalogCache` test seam, see PR note)
- CRITERION `grep latencyMs|refreshRoutingCatalog|classifyToolCall` only intended hits → 9/10 (`latencyMs` zero hits in src; `refreshRoutingCatalog` replaced by test seam; `classifyToolCall` import gone)
- CRITERION net line count negative → **5/10** (net +206; unavoidable given mandatory tests 1–5 + additive 7b/7c feature — see diffstat note, being transparent)
- CRITERION typecheck+tests green → 10/10 (2684/0)

Follow-ups filed: none (self-contained; no drift/two-source created).
