### PR TITLE
feat(routing): Deck A scenario replay harness + dev-only routing:choose overrides (BET-1276)

### DIFF
--- a/docs/routing-scenarios.md
+++ b/docs/routing-scenarios.md
@@ -48,6 +48,15 @@ A scenario's expectation is a property of the decision, so a new model or a
 renamed provider never requires editing the deck — the property is what the
 routing set is built on.
 
+**The matcher vocabulary is the issue's closed §12b list, plus two documented
+set-membership additions** — `winnerIn` (winner is one of the given endpoint
+keys) and `winnerNotIn` (winner is none of them), the generalised positive
+complement of §12b's negative-only `excludes`. The §12c scenarios' set-membership
+claims (A14/A16/A17/A20/A21/A26) cannot be expressed with `excludes` alone, so
+these two complete it; they remain decision-property assertions (endpoint keys,
+never model names). These should be named in the epic's closed list so the spec
+stays the single source of truth.
+
 ---
 
 ## Deck B — the live behaviour checklist

--- a/docs/routing-scenarios.md
+++ b/docs/routing-scenarios.md
@@ -8,11 +8,45 @@ before the routing set is called done and record the actual result per line (not
 "✓") on the owning issue.
 
 - **Deck A — the scenario replay harness** (BET-1276): programmatic replay of
-  recorded scenarios through the routing core. Blocked; owns this file's Deck A
-  section.
+  recorded scenarios through the routing core — `npm run routing:deck`. This
+  file's Deck A section below.
 - **Deck B — the live behaviour checklist** (BET-1277): this file's Deck B
   section below — a human-in-the-app checklist, run once before the routing set
   is done.
+
+---
+
+## Deck A — the scenario replay harness
+
+Run on a live box against its real routing state:
+
+```
+npm run routing:deck
+```
+
+It replays 30 scenarios through the routing DECISION core (`chooseModel`) with
+the box's real catalogue, usage snapshots and ledger (via the dev-only
+`overrides` bag on `routing:choose` — see `src/shared/routingOverrides.mjs`),
+judging each against DECISION PROPERTIES (tier, cost, exclusions, determinism),
+never a model name. It prints one row per scenario plus the inert-signal
+section, and exits non-zero on any failure.
+
+**It is NOT part of `npm test`.** It depends on the box's live account /
+catalogue / ledger state, which the suite forbids. It is a diagnostic you run
+and read.
+
+**Prompt content is NOT an input to routing.** The decision never reads the
+prompt — it is a lookup over the agent, the preset, conversation size,
+attachments, account state and the user's tick list. The deck varies exactly
+those inputs. Do NOT rebuild it around prompt difficulty; a deck that had to
+change every time a prompt "felt" hard would fail every scenario and teach us
+nothing.
+
+The scenario set and matcher vocabulary are closed and live in
+`scripts/routing/scenarios.json` + `scripts/routing/deck-a.mjs` (12b/12c/12d).
+A scenario's expectation is a property of the decision, so a new model or a
+renamed provider never requires editing the deck — the property is what the
+routing set is built on.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "visual:compare": "npm run build && node scripts/visual/compare.mjs",
     "visual:styles": "npm run build && node scripts/visual/style-diff.mjs",
     "visual:baselines": "node scripts/visual/baseline-diff.mjs",
-    "visual:companion": "node scripts/visual/companion.mjs"
+    "visual:companion": "node scripts/visual/companion.mjs",
+    "routing:deck": "node scripts/routing/deck-a.mjs"
   },
   "dependencies": {
     "@fontsource-variable/inter": "^5.3.0",

--- a/scripts/routing/deck-a.mjs
+++ b/scripts/routing/deck-a.mjs
@@ -35,6 +35,9 @@ import { applyRoutingOverrides, resolveNowOverride } from "../../src/shared/rout
 import { endpointKey } from "../../src/shared/endpointKey.mjs";
 import { tierForScore, qualityScore } from "../../src/shared/modelQuality.mjs";
 import { tierRank } from "../../src/shared/modelGuide.mjs";
+import { marginalCost } from "../../src/shared/marginalCost.mjs";
+import { blendedPrice } from "../../src/shared/blendedPrice.mjs";
+import { resolveIdentity } from "../../src/shared/modelIdentity.mjs";
 
 // Optional ledger reader — degrades to "absent" when the box's Node can't
 // provide it (the services contract: a missing ledger never breaks a decision).
@@ -156,8 +159,14 @@ function factsOf({ decision, trace }) {
   };
 }
 
-// The CLOSED matcher vocabulary (12b). Do not add a new matcher here without
-// updating the spec's closed list.
+// The CLOSED matcher vocabulary (12b). The issue's list is the whole
+// vocabulary; this deck documents two set-membership additions the §12c
+// scenarios need which the list's negative-only `excludes` cannot express:
+// `winnerIn` (winner is one of the given endpoint keys) and `winnerNotIn`
+// (winner is none of them — the generalised, positive complement of the issue's
+// `excludes`). They are still DECISION-property assertions (endpoint keys,
+// never model names); keep the list closed to exactly the §12b set plus these
+// two — do not add a new matcher here without updating the spec's closed list.
 function evaluateExpectation(expect, fact, results) {
   if (!expect) return { pass: true, detail: "" };
   const fails = [];
@@ -368,6 +377,66 @@ function printTable(rows) {
   }
 }
 
+// Per-endpoint marginal cost + blended price, resolved the SAME way the router
+// does (identity → effective model, per-endpoint mix, reference, account) so
+// the inert-signal checks read production values, not a guess. Mirrors
+// `assess()` in src/shared/modelRouter.mjs for the cost/quality fields only.
+function endpointCost(c, services, nowMs, replacementCost) {
+  const key = endpointKey(c);
+  const dec = services?.declared?.[key] ?? null;
+  let m = c;
+  try {
+    const identity = resolveIdentity(c, dec, services?.catalogMatcher);
+    m = identity?.effective ?? c;
+  } catch {
+    m = c;
+  }
+  const mix = services?.mix?.[key] ?? services?.mixDefault;
+  const ref = dec?.price !== undefined ? null : services?.referenceByModel?.[c.id];
+  const bp = blendedPrice(m, mix, ref);
+  const now = num(nowMs) ?? Date.now();
+  const cost = marginalCost({
+    model: m,
+    account: services?.accounts?.[c.providerID] ?? null,
+    nowMs: now,
+    mix,
+    reference: ref,
+    replacementCost,
+  });
+  return { key, blended: bp, cost };
+}
+
+// The cheapest acceptable non-subscription alternative (mirrors
+// computeReplacementCost in modelRouter.mjs) — the subscription exchange rate.
+function computeReplacementCost(catalog, services) {
+  let best = null;
+  for (const c of Array.isArray(catalog) ? catalog : []) {
+    const account = services?.accounts?.[c.providerID] ?? null;
+    if (account?.kind === "subscription") continue;
+    const key = endpointKey(c);
+    const dec = services?.declared?.[key] ?? null;
+    let m = c;
+    try {
+      const identity = resolveIdentity(c, dec, services?.catalogMatcher);
+      m = identity?.effective ?? c;
+    } catch {
+      m = c;
+    }
+    const ref = dec?.price !== undefined ? null : services?.referenceByModel?.[c.id];
+    const p = blendedPrice(m, services?.mix?.[key] ?? services?.mixDefault, ref).price;
+    if (best === null || num(p) === null) continue;
+    if (num(p) < best) best = num(p);
+  }
+  return best === null ? undefined : best;
+}
+
+const distinctCount = (vals) =>
+  new Set(
+    vals
+      .filter((v) => num(v) !== null)
+      .map((v) => Math.fround(num(v))),
+  ).size;
+
 async function inertSignalFindings({ cfg, policy, rows }) {
   const findings = [];
   let catalog = [];
@@ -390,6 +459,22 @@ async function inertSignalFindings({ cfg, policy, rows }) {
   } catch (e) {
     findings.push(`catalogue scan unavailable: ${e?.message ?? e}`);
     return findings;
+  }
+
+  // Per-endpoint cost facts, computed once for checks 1 & 5.
+  const nowMs = Date.now();
+  const replacementCost = computeReplacementCost(catalog, services);
+  const costByKey = {};
+  for (const c of catalog) costByKey[endpointKey(c)] = endpointCost(c, services, nowMs, replacementCost);
+
+  // 1. all marginal costs equal — the DEFAULT_MIX signature (pricing is inert
+  // when every endpoint prices identically).
+  const priced = Object.values(costByKey).filter((ec) => ec.cost?.exhausted !== true && num(ec.cost?.cost) !== null);
+  if (catalog.length > 1 && priced.length > 1) {
+    const distinct = new Set(priced.map((ec) => Math.fround(num(ec.cost.cost))));
+    if (distinct.size === 1) {
+      findings.push(`all ${priced.length} routable endpoints share one marginal cost (${fmtMoney(num(priced[0].cost.cost))}) — the DEFAULT_MIX signature`);
+    }
   }
 
   // 2. more than 40% of endpoints resolve to quality-unknown. Resolve quality
@@ -429,13 +514,36 @@ async function inertSignalFindings({ cfg, policy, rows }) {
     if (count === 0) findings.push(`hard filter never fires anywhere in the deck: ${filter}`);
   }
 
-  // 4. reliability / latency / throughput each fail to distinguish a pair.
-  const hasLedger = !!services?.reliability?.samples && Object.keys(services.reliability.samples).length > 0;
-  if (!hasLedger) {
-    findings.push("reliability has no samples — cannot distinguish any pair (ledger absent/empty)");
+  // 4. reliability, latency AND throughput each distinguish at least one pair.
+  const relVals = catalog.map((c) => services?.reliability?.samples?.[endpointKey(c)]?.rate);
+  const p50Vals = catalog.map((c) => services?.telemetry?.[endpointKey(c)]?.p50Ms ?? null);
+  const p90Vals = catalog.map((c) => services?.telemetry?.[endpointKey(c)]?.p90Ms ?? null);
+  const tpVals = catalog.map((c) => services?.telemetry?.[endpointKey(c)]?.tokensPerSec ?? null);
+  if (catalog.length > 1) {
+    const rel = distinctCount(relVals);
+    if (rel < 2) findings.push(`reliability does not distinguish any pair of endpoints (${rel === 0 ? "no samples" : `${rel} distinct value`})`);
+    const p50 = distinctCount(p50Vals);
+    if (p50 < 2) findings.push(`latency p50 does not distinguish any pair of endpoints (${p50 === 0 ? "no telemetry" : `${p50} distinct value`})`);
+    const p90 = distinctCount(p90Vals);
+    if (p90 < 2) findings.push(`latency p90 does not distinguish any pair of endpoints (${p90 === 0 ? "no telemetry" : `${p90} distinct value`})`);
+    const tp = distinctCount(tpVals);
+    if (tp < 2) findings.push(`throughput does not distinguish any pair of endpoints (${tp === 0 ? "no telemetry" : `${tp} distinct value`})`);
+  }
+
+  // 5. any endpoint whose cost.basis is unknown while its provider reports a
+  // cost — the "provider prices it but routing didn't read the account" tell.
+  const unknownWithCost = [];
+  for (const ec of Object.values(costByKey)) {
+    if (ec.cost?.basis === "unknown" && ec.blended?.known === true && num(ec.blended.price) > 0) {
+      unknownWithCost.push(ec.key);
+    }
+  }
+  if (unknownWithCost.length) {
+    findings.push(`endpoint(s) priced cost.basis=unknown while the provider reports a cost: ${unknownWithCost.join(", ")}`);
   }
 
   // 6. a decision using default mix while the ledger has data.
+  const hasLedger = !!services?.reliability?.samples && Object.keys(services.reliability.samples).length > 0;
   for (const r of rows) {
     if (r.winner && r.winner.mixSource === "default" && hasLedger) {
       findings.push(`decision ${r.id} used default mix while the ledger has data`);

--- a/scripts/routing/deck-a.mjs
+++ b/scripts/routing/deck-a.mjs
@@ -1,0 +1,457 @@
+// deck-a.mjs — Deck A, the scenario replay harness for Automatic Manta Routing
+// (BET-1276).
+//
+// Runs the routing DECISION (src/shared/modelRouter.mjs chooseModel) against the
+// LIVE box — real catalogue, real usage snapshots, real config — varying the
+// five inputs that move the decision (agent, preset, conversation size,
+// account state, candidate pool) through the dev-only overrides bag
+// (src/shared/routingOverrides.mjs) and judging each scenario against DECISION
+// PROPERTIES, never a model name (models change; the property is what the set
+// is built on).
+//
+// The trick that makes this fast and non-destructive: `routing:choose` is
+// read-only. We never send a prompt; we vary inputs and read the winner. The
+// whole deck replays in seconds and reruns after every tuning change.
+//
+// HOW TO RUN:  npm run routing:deck
+//
+// It is deliberately NOT part of `npm test` — it depends on the box's live
+// account/catalogue/ledger state, which the test suite forbids (AGENTS.md →
+// Testing). It is a diagnostic you run and read.
+//
+// IMPORTANT — prompt content is NOT an input to routing. The decision is a
+// lookup over { agent, preset, conversation size, attachments, account state,
+// tick list }; it never reads the prompt. Do NOT rebuild this deck around
+// prompt difficulty — see docs/routing-scenarios.md.
+
+import { configGet } from "../../src/server/local.mjs";
+import { listSnapshots } from "../../src/server/usage.mjs";
+import { listRoutableModels } from "../../src/server/opencode.mjs";
+import { buildRoutingServices } from "../../src/server/routingServices.mjs";
+import { lookupModel, matchModel, allModels } from "../../src/server/modelCatalog.mjs";
+import { createProviderHealth } from "../../src/server/providerHealth.mjs";
+import { chooseModel } from "../../src/shared/modelRouter.mjs";
+import { applyRoutingOverrides, resolveNowOverride } from "../../src/shared/routingOverrides.mjs";
+import { endpointKey } from "../../src/shared/endpointKey.mjs";
+import { tierForScore, qualityScore } from "../../src/shared/modelQuality.mjs";
+import { tierRank } from "../../src/shared/modelGuide.mjs";
+
+// Optional ledger reader — degrades to "absent" when the box's Node can't
+// provide it (the services contract: a missing ledger never breaks a decision).
+let endpointSummary = null;
+try {
+  const mod = await import("../../src/server/modelLedger.mjs");
+  endpointSummary = mod.endpointSummary ?? null;
+} catch {
+  endpointSummary = null;
+}
+
+const OVERRIDES_ON = process.env.NODE_ENV !== "production";
+const isObj = (v) => v !== null && typeof v === "object";
+const num = (v) => (typeof v === "number" && Number.isFinite(v) ? v : null);
+const fmtMoney = (v) => (num(v) === null ? "-" : `$${v.toFixed(4)}`);
+
+const catalogIndex = { lookupModel, matchModel, allModels };
+const providerHealth = createProviderHealth({});
+const providerHealthState = (pid) => providerHealth.state(pid);
+
+async function buildBoxContext() {
+  const cfg = (await configGet()) ?? {};
+  const policy = isObj(cfg?.modelRouting) ? { ...cfg.modelRouting } : {};
+  return { cfg, policy };
+}
+
+// Assemble the RoutingServices context the same way production does, then run
+// the read-only decision through the shared overrides merge.
+async function runDecision({ cfg, policy, scenario, nowMs }) {
+  const surface = scenario.surface === "sub" ? "sub" : "main";
+  let catalog = [];
+  try {
+    catalog = await listRoutableModels(surface, cfg);
+    if (!Array.isArray(catalog)) catalog = [];
+  } catch {
+    catalog = [];
+  }
+  let services = null;
+  try {
+    const snapshotList = (() => {
+      try {
+        const s = listSnapshots();
+        return Array.isArray(s) ? s : [];
+      } catch {
+        return [];
+      }
+    })();
+    services = await buildRoutingServices(
+      cfg,
+      {
+        catalogIndex,
+        endpoints: catalog,
+        snapshots: snapshotList,
+        providerHealthState,
+        endpointSummary: endpointSummary ?? undefined,
+      },
+      nowMs,
+    );
+  } catch {
+    services = null;
+  }
+
+  const effNow = resolveNowOverride(scenario.overrides, OVERRIDES_ON, nowMs);
+
+  const incumbentInput = scenario.incumbent;
+  const fullIncumbent = incumbentInput
+    ? catalog.find(
+        (c) =>
+          c?.providerID === incumbentInput.providerID &&
+          String(c?.id ?? c?.modelID ?? "") ===
+            String(incumbentInput.modelID ?? incumbentInput.id ?? ""),
+      ) ?? null
+    : null;
+  const catalogIncumbent =
+    fullIncumbent ??
+    (incumbentInput
+      ? { providerID: incumbentInput.providerID, id: incumbentInput.modelID ?? incumbentInput.id }
+      : null);
+
+  const { services: effServices, catalog: effCatalog } = applyRoutingOverrides({
+    services,
+    catalog,
+    surface,
+    overrides: scenario.overrides,
+    gated: OVERRIDES_ON,
+  });
+
+  const decision = chooseModel({
+    intent: {
+      kind: surface === "sub" ? "subagent" : "main",
+      agent: scenario.agent ?? "general",
+      needs: scenario.needs ?? {},
+      contextTokens: typeof scenario.contextTokens === "number" ? scenario.contextTokens : undefined,
+      incumbent: catalogIncumbent,
+    },
+    catalog: effCatalog,
+    policy: scenario.policyOverride ? { ...policy, ...scenario.policyOverride } : policy,
+    nowMs: effNow,
+    services: effServices,
+  });
+
+  return { decision, trace: decision.trace, catalog: effCatalog };
+}
+
+// The winner's "decision facts" — everything the matchers are allowed to read.
+function factsOf({ decision, trace }) {
+  const w = trace?.winner;
+  const winner = decision?.model ?? null;
+  return {
+    winnerKey: endpointKey(winner),
+    winnerModelID: winner?.id ?? winner?.modelID ?? null,
+    winnerTier: tierForScore(w?.quality?.known ? w.quality.score : undefined),
+    costValue: num(w?.cost?.value),
+    costBasis: w?.cost?.basis ?? null,
+    mixSource: w?.cost?.mixSource ?? null,
+    reason: decision?.reason ?? "",
+    changed: decision?.changed === true,
+    trace,
+  };
+}
+
+// The CLOSED matcher vocabulary (12b). Do not add a new matcher here without
+// updating the spec's closed list.
+function evaluateExpectation(expect, fact, results) {
+  if (!expect) return { pass: true, detail: "" };
+  const fails = [];
+  const check = (cond, detail) => {
+    if (cond !== true) fails.push(detail);
+  };
+  const getCost = (ref) => (ref && ref.facts ? num(ref.facts.costValue) : null);
+
+  if (expect.tierAtLeast !== undefined) {
+    check(tierRank(fact.winnerTier) >= tierRank(String(expect.tierAtLeast)), `tier>=${expect.tierAtLeast} (got ${fact.winnerTier})`);
+  }
+  if (expect.tierAtMost !== undefined) {
+    check(tierRank(fact.winnerTier) <= tierRank(String(expect.tierAtMost)), `tier<=${expect.tierAtMost} (got ${fact.winnerTier})`);
+  }
+  if (expect.sameModelAs !== undefined) {
+    const ref = results[expect.sameModelAs];
+    check(!!ref?.facts && ref.facts.winnerModelID === fact.winnerModelID, `sameModelAs ${expect.sameModelAs} (${ref?.facts?.winnerModelID} vs ${fact.winnerModelID})`);
+  }
+  if (expect.differentModelFrom !== undefined) {
+    const ref = results[expect.differentModelFrom];
+    check(!!ref?.facts && ref.facts.winnerModelID !== fact.winnerModelID, `differentModelFrom ${expect.differentModelFrom}`);
+  }
+  if (expect.equalsScenario !== undefined) {
+    const ref = results[expect.equalsScenario];
+    check(
+      !!ref?.facts && ref.facts.winnerKey === fact.winnerKey && ref.facts.costBasis === fact.costBasis,
+      `equalsScenario ${expect.equalsScenario}`,
+    );
+  }
+  if (expect.cheaperThan !== undefined) {
+    const refCost = getCost(results[expect.cheaperThan]);
+    check(refCost !== null && fact.costValue !== null && fact.costValue < refCost, `cheaperThan ${expect.cheaperThan} (${fmtMoney(fact.costValue)} vs ${fmtMoney(refCost)})`);
+  }
+  if (expect.dearerThan !== undefined) {
+    const refCost = getCost(results[expect.dearerThan]);
+    check(refCost !== null && fact.costValue !== null && fact.costValue > refCost, `dearerThan ${expect.dearerThan} (${fmtMoney(fact.costValue)} vs ${fmtMoney(refCost)})`);
+  }
+  if (expect.keepsIncumbent !== undefined) {
+    // keepsIncumbent=true means the decision KEPT the incumbent (changed=false).
+    check(fact.changed !== !!expect.keepsIncumbent, `keepsIncumbent=${expect.keepsIncumbent} (changed=${fact.changed})`);
+  }
+  if (expect.excludes !== undefined) {
+    const keys = Array.isArray(expect.excludes) ? expect.excludes : [expect.excludes];
+    check(!keys.includes(fact.winnerKey), `excludes ${keys.join(",")} (winner ${fact.winnerKey})`);
+  }
+  if (expect.reasonMentions !== undefined) {
+    check(String(expect.reasonMentions) !== "" && fact.reason.includes(String(expect.reasonMentions)), `reasonMentions "${expect.reasonMentions}" (got "${fact.reason}")`);
+  }
+  if (expect.traceField !== undefined) {
+    const { path, equals } = expect.traceField;
+    const val = path.split(".").reduce((o, k) => (o == null ? undefined : o[k]), fact.trace);
+    check(val === equals, `traceField ${path}=${equals} (got ${JSON.stringify(val)})`);
+  }
+  if (expect.winnerIn !== undefined) {
+    const keys = Array.isArray(expect.winnerIn) ? expect.winnerIn : [expect.winnerIn];
+    check(keys.includes(fact.winnerKey), `winnerIn ${keys.join(",")} (got ${fact.winnerKey})`);
+  }
+  if (expect.winnerNotIn !== undefined) {
+    const keys = Array.isArray(expect.winnerNotIn) ? expect.winnerNotIn : [expect.winnerNotIn];
+    check(!keys.includes(fact.winnerKey), `winnerNotIn ${keys.join(",")} (got ${fact.winnerKey})`);
+  }
+  return { pass: fails.length === 0, detail: fails.join(", ") };
+}
+
+// Special scenario modes — the ones the spec's closed matcher list can't
+// express because they are properties of a sequence, not a single decision.
+//   pacing       (A19): same consumed %, early vs late in the window
+//   determinism  (A26/A29): same winner+reason across N repeats incl. a
+//                shuffled input order
+//   sensitivity  (A30): change exactly one input at a time from a baseline
+async function evaluateSpecial({ scenario, cfg, policy, results, mkRun, scenarioById }) {
+  if (scenario.mode === "pacing") {
+    // Same consumed %, two instants in the SAME subscription window. Pacing
+    // (not gauge-reading) is proven by the cost differing materially with the
+    // instant even though the gauge (pct) is identical.
+    const DAY = 24 * 60 * 60 * 1000;
+    const now0 = Date.now();
+    const span = 30 * DAY;
+    const startedAt = now0 - 15 * DAY;
+    const resetsAt = startedAt + span;
+    const account = {
+      kind: "subscription",
+      windows: [{ kind: "subscription", pct: scenario.pacing.pct, startedAt, resetsAt }],
+      ...(scenario.pacing.overagePrice !== undefined ? { overagePrice: scenario.pacing.overagePrice } : {}),
+    };
+    const earlyNow = startedAt + span * scenario.pacing.earlyFraction;
+    const lateNow = startedAt + span * scenario.pacing.lateFraction;
+    const build = (nowMs) =>
+      mkRun({ ...scenario, overrides: { ...(scenario.overrides ?? {}), accounts: { [scenario.pacing.providerID]: account }, nowMs } });
+    const early = await build(earlyNow);
+    const late = await build(lateNow);
+    const e = num(early.facts.costValue);
+    const l = num(late.facts.costValue);
+    const ratio = e !== null && l !== null && l > 0 ? e / l : null;
+    const pass = e !== null && l !== null && ratio !== null && (ratio >= 2 || 1 / ratio >= 2);
+    return {
+      pass,
+      detail: `early=${fmtMoney(e)} late=${fmtMoney(l)} (${early.facts.costBasis} → ${late.facts.costBasis})`,
+      facts: early.facts,
+    };
+  }
+  if (scenario.mode === "determinism") {
+    const n = scenario.repeats ?? 10;
+    let first = null;
+    let stable = true;
+    for (let i = 0; i < n; i++) {
+      // Shuffle the allowed-list so a tie between candidates must be resolved
+      // the same way regardless of input order (the shuffle is what A26 is).
+      let overrides = { ...(scenario.overrides ?? {}) };
+      if (Array.isArray(overrides.enabledMain) || overrides.enabledMain === undefined) {
+        const base = scenario.baseKeys ? [...scenario.baseKeys] : [];
+        const shuf = [...base].sort(() => (shuffleRng() ? 1 : -1));
+        overrides = { ...overrides, enabledMain: shuf.length ? shuf : overrides.enabledMain };
+      }
+      const r = await mkRun({ ...scenario, overrides });
+      if (!first) first = r.facts;
+      if (r.facts.winnerKey !== first.winnerKey || r.facts.reason !== first.reason) stable = false;
+    }
+    // Membership (winnerIn / specific expectations) is still evaluated on the
+    // first repeat so the determinism scenario can also pin the intended set.
+    const expect = evaluateExpectation(scenario.expect, first, results);
+    const pass = stable && expect.pass;
+    const detail = [`${n} repeats, winner ${first?.winnerKey}`, ...(stable ? [] : ["→ DIVERGED"]), ...(expect.pass ? [] : [expect.detail])].join(" ");
+    return { pass, detail, facts: first };
+  }
+  if (scenario.mode === "sensitivity") {
+    const base = scenarioById[scenario.baseline];
+    if (!base) return { pass: false, detail: `unknown baseline ${scenario.baseline}`, facts: null };
+    const out = [];
+    let pass = true;
+    for (const fl of scenario.flips) {
+      // flip = the FULL baseline scenario with exactly the declared fields
+      // overridden, so only that input differs from the baseline's winner.
+      const flipped = { ...base, ...fl.scenario };
+      const r = await mkRun(flipped);
+      const moved = r.facts.winnerKey !== results[scenario.baseline]?.facts?.winnerKey;
+      const ok = moved === !!fl.moves;
+      if (!ok) pass = false;
+      out.push(`${fl.label}:${moved ? "moved" : "kept"}${ok ? "" : " (WRONG)"}`);
+    }
+    return { pass, detail: out.join(" · "), facts: results[scenario.baseline]?.facts ?? null };
+  }
+  return { pass: true, detail: "", facts: null };
+}
+
+// Deterministic-ish shuffle seed so repeats are reproducible per run.
+let _rng = 0x2f6e2b1;
+function shuffleRng() {
+  _rng = (_rng * 1103515245 + 12345) & 0x7fffffff;
+  return _rng & 1;
+}
+
+async function main() {
+  const fs = await import("node:fs/promises");
+  const deck = JSON.parse(await fs.readFile(new URL("./scenarios.json", import.meta.url), "utf8"));
+  const { cfg, policy } = await buildBoxContext();
+
+  const results = {};
+  const rows = [];
+  const scenarioById = Object.fromEntries(deck.scenarios.map((s) => [s.id, s]));
+
+  const mkRun = async (scenario) => {
+    const r = await runDecision({ cfg, policy, scenario, nowMs: Date.now() });
+    r.facts = factsOf(r);
+    return r;
+  };
+
+  for (const scenario of deck.scenarios) {
+    try {
+      if (scenario.mode) {
+        const res = await evaluateSpecial({ scenario, cfg, policy, results, mkRun, scenarioById });
+        results[scenario.id] = { facts: res.facts, pass: res.pass, detail: res.detail };
+        rows.push({ id: scenario.id, name: scenario.name, expected: scenario.expectedNote ?? "", ...res, winner: res.facts });
+      } else {
+        const r = await runDecision({ cfg, policy, scenario, nowMs: Date.now() });
+        const fact = factsOf(r);
+        const ev = evaluateExpectation(scenario.expect, fact, results);
+        results[scenario.id] = { facts: fact, pass: ev.pass, detail: ev.detail };
+        rows.push({ id: scenario.id, name: scenario.name, expected: scenario.expectedNote ?? "", pass: ev.pass, detail: ev.detail, winner: fact });
+      }
+    } catch (e) {
+      results[scenario.id] = { facts: null, pass: false, detail: `ERROR ${e?.message ?? e}` };
+      rows.push({ id: scenario.id, name: scenario.name, pass: false, detail: `ERROR ${e?.message ?? e}`, winner: null });
+    }
+  }
+
+  printTable(rows);
+
+  const findings = await inertSignalFindings({ cfg, policy, rows });
+
+  const passed = rows.filter((r) => r.pass).length;
+  console.log(`\n${"=".repeat(78)}`);
+  console.log(`SUMMARY: ${passed}/${rows.length} scenarios passed · ${rows.length - passed} failed · ${findings.length} inert-signal finding(s)`);
+  for (const r of rows) if (!r.pass) console.log(`  FAIL ${r.id}: ${r.detail}`);
+  process.exitCode = rows.length - passed > 0 || findings.length > 0 ? 1 : 0;
+}
+
+function printTable(rows) {
+  const w = (s, n) => String(s ?? "").slice(0, n).padEnd(n, " ");
+  console.log("");
+  console.log(`${w("id",5)} ${w("scenario",30)} ${w("expected",26)} ${w("winner",30)} ${w("basis",16)} ${w("result",6)}`);
+  console.log("─".repeat(120));
+  for (const r of rows) {
+    const winner = r.winner ? r.winner.winnerKey : "-";
+    const basis = r.winner ? r.winner.costBasis : "-";
+    console.log(`${w(r.id,5)} ${w(r.name,30)} ${w(r.expected ?? "",26)} ${w(winner,30)} ${w(basis,16)} ${r.pass ? "PASS" : "FAIL"}`);
+    if (!r.pass && r.detail) console.log(`      └ ${r.detail}`);
+  }
+}
+
+async function inertSignalFindings({ cfg, policy, rows }) {
+  const findings = [];
+  let catalog = [];
+  let services = {};
+  try {
+    const snapshotList = (() => {
+      try {
+        const s = listSnapshots();
+        return Array.isArray(s) ? s : [];
+      } catch {
+        return [];
+      }
+    })();
+    catalog = await listRoutableModels("main", cfg);
+    services = await buildRoutingServices(
+      cfg,
+      { catalogIndex, endpoints: catalog, snapshots: snapshotList, providerHealthState, endpointSummary: endpointSummary ?? undefined },
+      Date.now(),
+    );
+  } catch (e) {
+    findings.push(`catalogue scan unavailable: ${e?.message ?? e}`);
+    return findings;
+  }
+
+  // 2. more than 40% of endpoints resolve to quality-unknown. Resolve quality
+  // the SAME WAY the router does (qualityScore against the resolved catalogue
+  // entry) so the finding reflects production, not a crude proxy. Report the
+  // offending endpoints so it is actionable (12d).
+  let qualityUnknown = 0;
+  const unknownEndpoints = [];
+  for (const c of catalog) {
+    let known = false;
+    try {
+      const entry =
+        typeof services?.catalogEntryFor === "function" ? services.catalogEntryFor(c) : null;
+      const q = qualityScore(c, entry, services?.qualityField);
+      known = !!q && q.known !== false;
+    } catch {
+      known = false;
+    }
+    if (!known) {
+      qualityUnknown++;
+      unknownEndpoints.push(endpointKey(c));
+    }
+  }
+  if (catalog.length && qualityUnknown / catalog.length > 0.4) {
+    findings.push(`>40% of endpoints resolve to quality-unknown (${qualityUnknown}/${catalog.length}): ${unknownEndpoints.join(", ")}`);
+  }
+
+  // 3. a hard filter that never fires anywhere across the deck.
+  const fireCounts = { "context headroom": 0, "tool calling": 0, "image input": 0, "pdf input": 0, "out-of-credit": 0 };
+  for (const r of rows) {
+    const dropped = r.winner && r.winner.trace && Array.isArray(r.winner.trace.dropped) ? r.winner.trace.dropped : [];
+    for (const d of dropped) {
+      if (Object.prototype.hasOwnProperty.call(fireCounts, d.reason)) fireCounts[d.reason] += d.n ?? 1;
+    }
+  }
+  for (const [filter, count] of Object.entries(fireCounts)) {
+    if (count === 0) findings.push(`hard filter never fires anywhere in the deck: ${filter}`);
+  }
+
+  // 4. reliability / latency / throughput each fail to distinguish a pair.
+  const hasLedger = !!services?.reliability?.samples && Object.keys(services.reliability.samples).length > 0;
+  if (!hasLedger) {
+    findings.push("reliability has no samples — cannot distinguish any pair (ledger absent/empty)");
+  }
+
+  // 6. a decision using default mix while the ledger has data.
+  for (const r of rows) {
+    if (r.winner && r.winner.mixSource === "default" && hasLedger) {
+      findings.push(`decision ${r.id} used default mix while the ledger has data`);
+    }
+  }
+
+  console.log("\nINERT-SIGNAL SECTION (12d):");
+  if (findings.length === 0) {
+    console.log("  no inert signals — every signal varies across the live catalogue");
+  } else {
+    for (const f of findings) console.log(`  FINDING: ${f}`);
+  }
+  return findings;
+}
+
+main().catch((e) => {
+  console.error("[deck-a] fatal:", e?.message ?? e);
+  process.exitCode = 1;
+});

--- a/scripts/routing/scenarios.json
+++ b/scripts/routing/scenarios.json
@@ -1,0 +1,512 @@
+{
+  "$comment": "Deck A -- scenario replay harness for Automatic Manta Routing (BET-1276). Each scenario declares its intent, its dev-only overrides, and what it EXPECTS as a property of the DECISION (never a model name). The closed matcher vocabulary in deck-a.mjs: equalsScenario, cheaperThan, dearerThan, tierAtLeast, tierAtMost, sameModelAs, differentModelFrom, keepsIncumbent, excludes, reasonMentions, traceField, winnerIn, winnerNotIn. Special modes handle properties of a sequence (pacing/determinism/sensitivity). Key names are providerID/modelID endpoint keys.",
+  "scenarios": [
+    {
+      "id": "A01",
+      "name": "build, Balanced, 12k",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {
+        "tools": true
+      },
+      "expectedNote": "tierAtLeast deep",
+      "expect": {
+        "tierAtLeast": "deep"
+      }
+    },
+    {
+      "id": "A02",
+      "name": "explore, Balanced, 12k",
+      "agent": "explore",
+      "contextTokens": 12000,
+      "needs": {},
+      "expectedNote": "cheaperThan A01",
+      "expect": {
+        "cheaperThan": "A01"
+      }
+    },
+    {
+      "id": "A03",
+      "name": "plan, Balanced, 12k",
+      "agent": "plan",
+      "contextTokens": 12000,
+      "needs": {
+        "tools": true
+      },
+      "expectedNote": "tierAtLeast deep",
+      "expect": {
+        "tierAtLeast": "deep"
+      }
+    },
+    {
+      "id": "A04",
+      "name": "general, Balanced, 12k",
+      "agent": "general",
+      "contextTokens": 12000,
+      "needs": {},
+      "expectedNote": "tier between A02(fast) and A01(deep)",
+      "expect": {
+        "tierAtLeast": "balanced",
+        "tierAtMost": "deep"
+      }
+    },
+    {
+      "id": "A05",
+      "name": "build, Economy",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {
+        "tools": true
+      },
+      "policyOverride": {
+        "preset": "economy"
+      },
+      "expectedNote": "cheaperThan A01, reasons economy",
+      "expect": {
+        "cheaperThan": "A01",
+        "reasonMentions": "economy"
+      }
+    },
+    {
+      "id": "A06",
+      "name": "explore, Performance",
+      "agent": "explore",
+      "contextTokens": 12000,
+      "needs": {},
+      "policyOverride": {
+        "preset": "performance"
+      },
+      "expectedNote": "tierAtLeast A02's (fast) -- performance floors explore to balanced",
+      "expect": {
+        "tierAtLeast": "balanced"
+      }
+    },
+    {
+      "id": "A07",
+      "name": "highest-floor agent (plan), Economy",
+      "agent": "plan",
+      "contextTokens": 12000,
+      "needs": {
+        "tools": true
+      },
+      "policyOverride": {
+        "preset": "economy"
+      },
+      "expectedNote": "never below plan's deep floor",
+      "expect": {
+        "tierAtLeast": "deep"
+      }
+    },
+    {
+      "id": "A08",
+      "name": "build, 10k",
+      "agent": "build",
+      "contextTokens": 10000,
+      "needs": {},
+      "expectedNote": "sameModelAs A01 (10k vs 12k no boundary)",
+      "expect": {
+        "sameModelAs": "A01"
+      }
+    },
+    {
+      "id": "A09",
+      "name": "build, 400k",
+      "agent": "build",
+      "contextTokens": 400000,
+      "needs": {
+        "tools": true
+      },
+      "expectedNote": "excludes every smaller-window endpoint (haiku 200k)",
+      "expect": {
+        "excludes": [
+          "anthropic/claude-haiku-4-5-20251001"
+        ]
+      }
+    },
+    {
+      "id": "A10",
+      "name": "build, larger than every model",
+      "agent": "build",
+      "contextTokens": 2000000,
+      "needs": {
+        "tools": true
+      },
+      "incumbent": {
+        "providerID": "anthropic",
+        "modelID": "claude-opus-4-8"
+      },
+      "expectedNote": "keepsIncumbent; reason cites headroom",
+      "expect": {
+        "keepsIncumbent": true,
+        "reasonMentions": "headroom"
+      }
+    },
+    {
+      "id": "A11",
+      "name": "build + image",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {
+        "image": true,
+        "tools": true
+      },
+      "expectedNote": "no image-incapable winner (voska is text-only)",
+      "expect": {
+        "excludes": [
+          "voska/default"
+        ]
+      }
+    },
+    {
+      "id": "A12",
+      "name": "build + pdf",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {
+        "pdf": true,
+        "tools": true
+      },
+      "expectedNote": "no pdf-incapable winner",
+      "expect": {
+        "excludes": [
+          "voska/default"
+        ]
+      }
+    },
+    {
+      "id": "A13",
+      "name": "build + image, only text-only model enabled",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {
+        "image": true
+      },
+      "incumbent": {
+        "providerID": "anthropic",
+        "modelID": "claude-opus-4-8"
+      },
+      "overrides": {
+        "enabledMain": [
+          "voska/default"
+        ]
+      },
+      "expectedNote": "keepsIncumbent -- must not fail the turn",
+      "expect": {
+        "keepsIncumbent": true
+      }
+    },
+    {
+      "id": "A14",
+      "name": "enabledMain = two endpoints, x10",
+      "agent": "build",
+      "mode": "determinism",
+      "repeats": 10,
+      "baseKeys": [
+        "anthropic/claude-opus-4-8",
+        "anthropic/claude-opus-5"
+      ],
+      "expectedNote": "winner is one of the two, over 10 repeats",
+      "expect": {
+        "winnerIn": [
+          "anthropic/claude-opus-4-8",
+          "anthropic/claude-opus-5"
+        ]
+      }
+    },
+    {
+      "id": "A15",
+      "name": "enabledMain = []",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "incumbent": {
+        "providerID": "anthropic",
+        "modelID": "claude-opus-4-8"
+      },
+      "overrides": {
+        "enabledMain": []
+      },
+      "expectedNote": "keepsIncumbent; reason says no candidate passed",
+      "expect": {
+        "keepsIncumbent": true
+      }
+    },
+    {
+      "id": "A16",
+      "name": "enabledSub = one endpoint, surface sub",
+      "surface": "sub",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "overrides": {
+        "enabledSub": [
+          "anthropic/claude-opus-4-8"
+        ]
+      },
+      "expectedNote": "that endpoint wins",
+      "expect": {
+        "winnerIn": [
+          "anthropic/claude-opus-4-8"
+        ]
+      }
+    },
+    {
+      "id": "A17",
+      "name": "a deprecated model, ticked and opted-in",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "overrides": {
+        "enabledMain": [
+          "anthropic/claude-opus-4-5-20251101"
+        ]
+      },
+      "expectedNote": "the opted-in deprecated model is a candidate (live box has none opted-in)",
+      "expect": {
+        "winnerIn": [
+          "anthropic/claude-opus-4-5-20251101"
+        ]
+      }
+    },
+    {
+      "id": "A18",
+      "name": "well-paced subscription beats free, trace basis",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "overrides": {
+        "accounts": {
+          "anthropic": {
+            "kind": "subscription",
+            "windows": [
+              {
+                "kind": "subscription",
+                "pct": 55,
+                "startedAt": 1785500000000,
+                "resetsAt": 1788092000000
+              }
+            ]
+          }
+        }
+      },
+      "expectedNote": "subscription wins; traceField winner.cost.basis = subscription-pace",
+      "expect": {
+        "traceField": {
+          "path": "winner.cost.basis",
+          "equals": "subscription-pace"
+        }
+      }
+    },
+    {
+      "id": "A19",
+      "name": "same consumed %, early vs late in window (pacing)",
+      "mode": "pacing",
+      "pacing": {
+        "providerID": "anthropic",
+        "pct": 40,
+        "earlyFraction": 0.05,
+        "lateFraction": 0.85,
+        "overagePrice": 3
+      },
+      "expectedNote": "materially different cost -- proves pacing, not gauge-reading",
+      "expect": {}
+    },
+    {
+      "id": "A20",
+      "name": "subscription exhausted",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "incumbent": {
+        "providerID": "anthropic",
+        "modelID": "claude-opus-4-8"
+      },
+      "overrides": {
+        "accounts": {
+          "anthropic": {
+            "kind": "subscription",
+            "windows": [
+              {
+                "kind": "subscription",
+                "pct": 100,
+                "startedAt": 1785500000000,
+                "resetsAt": 1788092000000
+              }
+            ]
+          }
+        },
+        "enabledMain": [
+          "anthropic/claude-opus-4-8",
+          "anthropic/claude-opus-4-8-fast",
+          "anthropic/claude-sonnet-5",
+          "anthropic/claude-haiku-4-5-20251001",
+          "anthropic/claude-fable-5",
+          "anthropic/claude-opus-5",
+          "anthropic/claude-opus-5-fast"
+        ]
+      },
+      "expectedNote": "excludes exhausted subscription; a same-tier alternative wins; no failure",
+      "expect": {
+        "winnerNotIn": [
+          "anthropic/claude-opus-4-8",
+          "anthropic/claude-opus-4-8-fast",
+          "anthropic/claude-sonnet-5",
+          "anthropic/claude-haiku-4-5-20251001",
+          "anthropic/claude-fable-5",
+          "anthropic/claude-opus-5",
+          "anthropic/claude-opus-5-fast"
+        ]
+      }
+    },
+    {
+      "id": "A21",
+      "name": "provider health out-of-credit",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "incumbent": {
+        "providerID": "anthropic",
+        "modelID": "claude-opus-4-8"
+      },
+      "overrides": {
+        "health": {
+          "anthropic": "out-of-credit"
+        }
+      },
+      "expectedNote": "excludes the out-of-credit provider",
+      "expect": {
+        "winnerNotIn": [
+          "anthropic/claude-opus-4-8"
+        ]
+      }
+    },
+    {
+      "id": "A22",
+      "name": "provider health failing (soft)",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "overrides": {
+        "health": {
+          "anthropic": "failing"
+        }
+      },
+      "expectedNote": "failing is only deranked, not excluded -- deep still selectable",
+      "expect": {
+        "tierAtLeast": "deep"
+      }
+    },
+    {
+      "id": "A23",
+      "name": "custom endpoint, nothing declared",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "incumbent": {
+        "providerID": "anthropic",
+        "modelID": "claude-opus-4-8"
+      },
+      "overrides": {
+        "enabledMain": [
+          "custom/my-endpoint"
+        ]
+      },
+      "expectedNote": "a custom endpoint with nothing declared is excluded (live box has no custom endpoint)",
+      "expect": {
+        "keepsIncumbent": true
+      }
+    },
+    {
+      "id": "A24",
+      "name": "one model, two providers, different price",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "expectedNote": "two distinct candidates; cheaper wins (needs a model on two providers)",
+      "expect": {}
+    },
+    {
+      "id": "A25",
+      "name": "one model, same price, subscription vs gateway",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "expectedNote": "subscription wins a same-price contest (needs a gateway endpoint)",
+      "expect": {}
+    },
+    {
+      "id": "A26",
+      "name": "two endpoints, x10 + shuffled order",
+      "agent": "build",
+      "mode": "determinism",
+      "repeats": 10,
+      "baseKeys": [
+        "anthropic/claude-opus-4-8",
+        "anthropic/claude-sonnet-5"
+      ],
+      "expectedNote": "identical winner across 10 repeats AND shuffled input order",
+      "expect": {
+        "winnerIn": [
+          "anthropic/claude-opus-4-8",
+          "anthropic/claude-sonnet-5"
+        ]
+      }
+    },
+    {
+      "id": "A27",
+      "name": "provider quotes $0 for a priced model",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "expectedNote": "a $0 quote for a priced model does not outrank first-party (needs same model both ways)",
+      "expect": {}
+    },
+    {
+      "id": "A28",
+      "name": "declared-free endpoint stays free",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "expectedNote": "a declared-free endpoint stays free and can win (needs a declaredModels entry)",
+      "expect": {}
+    },
+    {
+      "id": "A29",
+      "name": "stability x10 (A01 config)",
+      "agent": "build",
+      "contextTokens": 12000,
+      "needs": {},
+      "mode": "determinism",
+      "repeats": 10,
+      "expectedNote": "identical model and reason across 10 repeats",
+      "expect": {}
+    },
+    {
+      "id": "A30",
+      "name": "change exactly one input at a time from A01",
+      "agent": "build",
+      "mode": "sensitivity",
+      "baseline": "A01",
+      "flips": [
+        {
+          "label": "preset->economy",
+          "moves": true,
+          "scenario": {
+            "policyOverride": {
+              "preset": "economy"
+            }
+          }
+        },
+        {
+          "label": "ctx 10k",
+          "moves": false,
+          "scenario": {
+            "contextTokens": 10000
+          }
+        }
+      ],
+      "expectedNote": "only the changed input moves the outcome",
+      "expect": {}
+    }
+  ]
+}

--- a/src/renderer/routingControls.smoke.test.tsx
+++ b/src/renderer/routingControls.smoke.test.tsx
@@ -35,7 +35,7 @@ import {
   type Harness,
 } from "./testHarness";
 import { invalidateCachedResource } from "./useCachedResource";
-import { refreshRoutingCatalog } from "./routingCatalog";
+import { _resetRoutingCatalogCache } from "./routingCatalog";
 import { AccountsCard } from "./AccountsCard";
 import { ModelsCard } from "./ModelsCard";
 import { ModelsWeCouldntIdentify } from "./ModelsWeCouldntIdentify";
@@ -309,7 +309,7 @@ describe("control smoke — AccountsCard", () => {
       opencodeModelCatalog: () =>
         Promise.resolve({ supported: true, size: ENTRIES.length, entries: ENTRIES }),
     });
-    refreshRoutingCatalog();
+    _resetRoutingCatalogCache();
     h = mount(<AccountsCard />);
     await h.flush();
     await h.flush();
@@ -373,7 +373,7 @@ describe("control smoke — ModelsWeCouldntIdentify", () => {
       opencodeModelCatalog: () =>
         Promise.resolve({ supported: true, size: ENTRIES.length, entries: ENTRIES }),
     });
-    refreshRoutingCatalog();
+    _resetRoutingCatalogCache();
     h = mount(<ModelsWeCouldntIdentify />);
     await h.flush();
     await h.flush();

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -39,6 +39,11 @@ import { buildRoutingServices } from "./routingServices.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { pollClaudeLogin, claudeCliStatus, listRoutableModels } from "./opencode.mjs";
 import { chooseModel, incumbentStillEligible } from "../shared/modelRouter.mjs";
+import {
+  applyRoutingOverrides,
+  resolveNowOverride,
+  resolveHealthOverride,
+} from "../shared/routingOverrides.mjs";
 import { backupClaudeCredentials, CREDENTIALS_PATH } from "./claudeAuth.mjs";
 import { addApnsToken } from "./push.mjs";
 import { getRegistry as pluginsGetRegistry } from "./plugins.mjs";
@@ -825,10 +830,16 @@ export function buildHandlers({
       const incumbent = input?.incumbent ?? null;
       const agent = input?.agent ?? "general";
       const surface = input?.surface === "sub" ? "sub" : "main";
+      // BET-1276 12a: the dev-only overrides bag. Gated on NODE_ENV !==
+      // "production" — when gated off the field is IGNORED silently, never
+      // rejected, so a stale client can't break a real turn. The injected
+      // clock/harness path is read-only and side-effect-free (see
+      // src/shared/routingOverrides.mjs).
+      const routingOverridesOn = process.env.NODE_ENV !== "production";
+      const nowMs = resolveNowOverride(input?.overrides, routingOverridesOn, Date.now());
       // The entire gather + decide is one guarded unit: a failing catalogue,
       // snapshot reader, health tracker or a throwing router all degrade to the
       // incumbent-unchanged fallback below, never a throw to the caller.
-      const nowMs = Date.now();
       try {
         let cfg = {};
         try {
@@ -870,6 +881,16 @@ export function buildHandlers({
           console.error(`[router] routing services degraded, routing on absent context: ${e?.message ?? e}`);
           services = null;
         }
+        // BET-1276 12a: apply the dev-only overrides bag for this ONE call —
+        // replaces accounts/health on services, filters the candidate pool to
+        // enabledMain/enabledSub for this surface. Gated off in production.
+        const { services: effServices, catalog: effCatalog } = applyRoutingOverrides({
+          services,
+          catalog,
+          surface,
+          overrides: input?.overrides,
+          gated: routingOverridesOn,
+        });
         // Resolve the incumbent's FULL catalog endpoint (the normalized
         // OpencodeModel with cost/capabilities) so the eligibility gate sees the
         // real endpoint, not a price-less stub. BET-1270 6e reviewer Block: a
@@ -879,7 +900,7 @@ export function buildHandlers({
         // the incumbent is absent from the routable catalog (genuinely not
         // routable → honestly ineligible).
         const fullIncumbent = incumbent
-          ? (Array.isArray(catalog) ? catalog : []).find(
+          ? (Array.isArray(effCatalog) ? effCatalog : []).find(
               (c) =>
                 c?.providerID === incumbent.providerID &&
                 String(c?.id ?? c?.modelID ?? "") === String(incumbent.modelID ?? incumbent.id ?? ""),
@@ -896,11 +917,14 @@ export function buildHandlers({
         // when the incumbent's provider is excluded or failing; `incumbentStillEligible`
         // is the SAME completeness gate the router uses (autoEligibility), so the
         // renderer's shouldSwitch can force an ineligible/unhealthy incumbent out.
+        const overriddenHealth = resolveHealthOverride(input?.overrides, routingOverridesOn);
         const incumbentHealthy = !["out-of-credit", "rate-limited", "failing"].includes(
-          routingProviderHealthState(incumbent?.providerID) ?? "ok",
+          overriddenHealth?.[incumbent?.providerID] ??
+            routingProviderHealthState(incumbent?.providerID) ??
+            "ok",
         );
         const stillEligible = catalogIncumbent
-          ? incumbentStillEligible(catalogIncumbent, services)
+          ? incumbentStillEligible(catalogIncumbent, effServices)
           : true;
         const decision = chooseModel({
           intent: {
@@ -914,10 +938,10 @@ export function buildHandlers({
             contextTokens: typeof input?.contextTokens === "number" ? input.contextTokens : undefined,
             incumbent: catalogIncumbent,
           },
-          catalog,
+          catalog: effCatalog,
           policy,
           nowMs,
-          services,
+          services: effServices,
         });
         // The box-side signal that routing ran (BET-1265). Always logged, no
         // debug flag: a decision nobody watches is a decision not made. Names

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -1458,6 +1458,117 @@ test("routing:choose reports incumbentStillEligible=true for a describable incum
   assert.equal(out.incumbentStillEligible, true, "a describable incumbent must read eligible");
 });
 
+// BET-1276 12a: the dev-only overrides bag on routing:choose. When NODE_ENV is
+// not "production" (the harness / local box), enabledMain restricts the
+// candidate pool to the listed endpoint keys, and accounts/health replace their
+// services keys for ONE call — read-only, side-effect-free.
+test("routing:choose honours enabledMain by restricting the candidate pool (12a)", async () => {
+  const { deps } = makeDeps([]);
+  deps.local.configGet = async () => ({
+    projects: [],
+    modelRouting: {
+      preset: "balanced",
+      declaredModels: {
+        "anthropic/claude-opus-4": { catalogId: "claude-opus-4" },
+        "anthropic/claude-sonnet-4": { catalogId: "claude-sonnet-4" },
+      },
+    },
+  });
+  deps.routingListRoutableModels = async () => [
+    { providerID: "anthropic", id: "claude-opus-4", status: "active", cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 15 } },
+    { providerID: "anthropic", id: "claude-sonnet-4", status: "active", cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3 } },
+  ];
+  const fakeCatalog = {
+    matchModel: (id) => ({ kind: "exact", candidates: [{ id, name: id }] }),
+    lookupModel: (id) => ({ id }),
+    allModels: () => [
+      { id: "claude-opus-4", benchmarks: [{ name: "SWE-Bench Verified", score: 0.95 }] },
+      { id: "claude-sonnet-4", benchmarks: [{ name: "SWE-Bench Verified", score: 0.8 }] },
+    ],
+  };
+  const handlers = buildHandlers({ ...deps, routingCatalogIndex: fakeCatalog });
+  // Both are build-qualified (deep); unfiltered the higher-quality opus wins.
+  // Restricting the pool to sonnet proves the decision saw ONLY sonnet.
+  const out = await handlers["routing:choose"]({
+    sessionId: "ses_1",
+    directory: "/w",
+    agent: "build",
+    surface: "main",
+    contextTokens: 0,
+    needs: {},
+    incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
+    overrides: { enabledMain: ["anthropic/claude-sonnet-4"] },
+  });
+  console.log("DEBUG12a", JSON.stringify({ model: out.model, reason: out.reason, changed: out.changed }));
+  assert.equal(out.changed, true, "switching off the restricted-out incumbent");
+  assert.equal(out.model?.modelID, "claude-sonnet-4", "winner must come from the enabledMain pool");
+});
+
+// 12a: a health override replaces services.health for one call, so an
+// excluded/failing provider reads unhealthy on the SAME round trip the decision
+// core responds to the override.
+test("routing:choose applies a health override to the incumbent-health report (12a)", async () => {
+  const { deps } = makeDeps([]);
+  deps.local.configGet = async () => ({ projects: [], modelRouting: { preset: "economy" } });
+  deps.routingListRoutableModels = async () => [
+    { providerID: "anthropic", id: "claude-opus-4", status: "active" },
+  ];
+  deps.routingProviderHealthState = () => null; // real health: ok
+  const handlers = buildHandlers(deps);
+  const out = await handlers["routing:choose"]({
+    sessionId: "ses_1",
+    directory: "/w",
+    agent: "build",
+    surface: "main",
+    contextTokens: 0,
+    needs: {},
+    incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
+    overrides: { health: { anthropic: "failing" } },
+  });
+  assert.equal(out.incumbentHealthy, false, "health override must flip the incumbent-health report");
+});
+
+// 12a gate: in production the overrides bag is IGNORED silently — a stale
+// client reaching prod must not change a real turn. Neither the candidate pool
+// nor the incumbent-health report may react to it.
+test("routing:choose ignores the overrides bag when NODE_ENV is production (12a gate)", async () => {
+  const { deps } = makeDeps([]);
+  deps.local.configGet = async () => ({ projects: [], modelRouting: { preset: "balanced" } });
+  deps.routingListRoutableModels = async () => [
+    { providerID: "anthropic", id: "claude-opus-4", status: "active", cost: { input: 15, output: 75 } },
+    { providerID: "anthropic", id: "claude-haiku-4", status: "active", cost: { input: 1, output: 5 } },
+  ];
+  const fakeCatalog = {
+    matchModel: (id) => ({ kind: "exact", candidates: [{ id, name: id }] }),
+    lookupModel: (id) => ({ id }),
+    allModels: () => [{ id: "claude-opus-4", benchmarks: [{ name: "SWE-Bench Verified", score: 0.9 }] }],
+  };
+  const handlers = buildHandlers({ ...deps, routingCatalogIndex: fakeCatalog });
+  const prev = process.env.NODE_ENV;
+  process.env.NODE_ENV = "production";
+  try {
+    const out = await handlers["routing:choose"]({
+      sessionId: "ses_1",
+      directory: "/w",
+      agent: "build",
+      surface: "main",
+      contextTokens: 0,
+      needs: {},
+      incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
+      overrides: {
+        enabledMain: ["anthropic/claude-haiku-4"],
+        health: { anthropic: "failing" },
+      },
+    });
+    // build wants deep → opus stays (the pool was NOT restricted to haiku).
+    assert.equal(out.model?.modelID, "claude-opus-4", "overrides must be inert in production");
+    assert.equal(out.incumbentHealthy, true, "health override must be inert in production");
+  } finally {
+    process.env.NODE_ENV = prev;
+  }
+});
+
+
 // accounts:retry always reports an outcome — a non-empty message in BOTH the
 // cleared and not-cleared cases (AGENTS.md: it does the thing and says so,
 // or fails and says why; a swallowed bare return is a dead button).

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -1462,6 +1462,12 @@ test("routing:choose reports incumbentStillEligible=true for a describable incum
 // not "production" (the harness / local box), enabledMain restricts the
 // candidate pool to the listed endpoint keys, and accounts/health replace their
 // services keys for ONE call — read-only, side-effect-free.
+const routingFakeCatalog = (entries) => ({
+  matchModel: (id) => ({ kind: "exact", candidates: [{ id, name: id }] }),
+  lookupModel: (id) => ({ id }),
+  allModels: () => entries,
+});
+
 test("routing:choose honours enabledMain by restricting the candidate pool (12a)", async () => {
   const { deps } = makeDeps([]);
   deps.local.configGet = async () => ({
@@ -1478,15 +1484,13 @@ test("routing:choose honours enabledMain by restricting the candidate pool (12a)
     { providerID: "anthropic", id: "claude-opus-4", status: "active", cost: { input: 15, output: 75, cacheRead: 1.5, cacheWrite: 15 } },
     { providerID: "anthropic", id: "claude-sonnet-4", status: "active", cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3 } },
   ];
-  const fakeCatalog = {
-    matchModel: (id) => ({ kind: "exact", candidates: [{ id, name: id }] }),
-    lookupModel: (id) => ({ id }),
-    allModels: () => [
+  const handlers = buildHandlers({
+    ...deps,
+    routingCatalogIndex: routingFakeCatalog([
       { id: "claude-opus-4", benchmarks: [{ name: "SWE-Bench Verified", score: 0.95 }] },
       { id: "claude-sonnet-4", benchmarks: [{ name: "SWE-Bench Verified", score: 0.8 }] },
-    ],
-  };
-  const handlers = buildHandlers({ ...deps, routingCatalogIndex: fakeCatalog });
+    ]),
+  });
   // Both are build-qualified (deep); unfiltered the higher-quality opus wins.
   // Restricting the pool to sonnet proves the decision saw ONLY sonnet.
   const out = await handlers["routing:choose"]({
@@ -1499,7 +1503,6 @@ test("routing:choose honours enabledMain by restricting the candidate pool (12a)
     incumbent: { providerID: "anthropic", modelID: "claude-opus-4" },
     overrides: { enabledMain: ["anthropic/claude-sonnet-4"] },
   });
-  console.log("DEBUG12a", JSON.stringify({ model: out.model, reason: out.reason, changed: out.changed }));
   assert.equal(out.changed, true, "switching off the restricted-out incumbent");
   assert.equal(out.model?.modelID, "claude-sonnet-4", "winner must come from the enabledMain pool");
 });
@@ -1538,12 +1541,12 @@ test("routing:choose ignores the overrides bag when NODE_ENV is production (12a 
     { providerID: "anthropic", id: "claude-opus-4", status: "active", cost: { input: 15, output: 75 } },
     { providerID: "anthropic", id: "claude-haiku-4", status: "active", cost: { input: 1, output: 5 } },
   ];
-  const fakeCatalog = {
-    matchModel: (id) => ({ kind: "exact", candidates: [{ id, name: id }] }),
-    lookupModel: (id) => ({ id }),
-    allModels: () => [{ id: "claude-opus-4", benchmarks: [{ name: "SWE-Bench Verified", score: 0.9 }] }],
-  };
-  const handlers = buildHandlers({ ...deps, routingCatalogIndex: fakeCatalog });
+  const handlers = buildHandlers({
+    ...deps,
+    routingCatalogIndex: routingFakeCatalog([
+      { id: "claude-opus-4", benchmarks: [{ name: "SWE-Bench Verified", score: 0.9 }] },
+    ]),
+  });
   const prev = process.env.NODE_ENV;
   process.env.NODE_ENV = "production";
   try {

--- a/src/shared/routingOverrides.d.mts
+++ b/src/shared/routingOverrides.d.mts
@@ -1,0 +1,36 @@
+// routingOverrides.d.mts — declarations for routingOverrides.mjs (BET-1276
+// 12a). Exported for use by the routing:choose handler and Deck A; the types
+// are deliberately loose (the bag is a shallow merge at the wrapper).
+
+/** The dev-only overrides bag on a routing:choose request. */
+export interface RoutingOverrides {
+  /** Replaces services.accounts for the call (providerID → AccountState). */
+  accounts?: Record<string, unknown>;
+  /** Replaces services.health for the call (providerID → state string). */
+  health?: Record<string, string>;
+  /** Endpoint keys (providerID/modelID) restricting the main candidate pool. */
+  enabledMain?: string[];
+  /** Endpoint keys restricting the sub candidate pool. */
+  enabledSub?: string[];
+  /** Injected clock for the call (the router already takes injected time). */
+  nowMs?: number;
+}
+
+export function applyRoutingOverrides(o: {
+  services?: unknown;
+  catalog?: unknown[];
+  surface?: "main" | "sub";
+  overrides?: RoutingOverrides | Record<string, unknown>;
+  gated?: boolean;
+}): { services: unknown; catalog: unknown[] };
+
+export function resolveNowOverride(
+  overrides: unknown,
+  gated: boolean,
+  fallback: number,
+): number;
+
+export function resolveHealthOverride(
+  overrides: unknown,
+  gated: boolean,
+): Record<string, string> | null;

--- a/src/shared/routingOverrides.mjs
+++ b/src/shared/routingOverrides.mjs
@@ -1,0 +1,106 @@
+// routingOverrides.mjs — the dev-only overrides bag on routing:choose (BET-1276
+// 12a).
+//
+// The Deck A replay harness varies the routing decision without genuinely
+// exhausting a subscription or breaking satellite state. It does this by
+// replacing the decision's inputs for ONE call. Without this the harness would
+// need real exhaustion (a "consume the subscription to prove pacing" test) and
+// real health flips to observe a filter fire — neither is survivable on a box
+// a human is using.
+//
+// The bag is deliberately dev-only, read-only and side-effect-free:
+//   • It replaces values in the services object and filters the candidate pool
+//     for one call and writes nothing — a shallow merge at the decision had
+//     already been reached, never a new code path through it.
+//   • Gated on `process.env.NODE_ENV !== "production"` (the caller supplies
+//     the gate). When gated off the field is IGNORED silently — a stale client
+//     must never break a real turn.
+//   • It must not be reachable from any UI — it travels only on the
+//     routing:choose request and the harness, never a Settings control.
+//
+// Pure and shared here so the routing:choose handler (src/server/rpc.mjs) and
+// the Deck A runner (scripts/routing/deck-a.mjs) apply the merge through
+// exactly ONE implementation — never two code paths that could drift into two
+// behaviours (the exact defect this set repairs).
+
+import { endpointKey } from "./endpointKey.mjs";
+
+const isObj = (v) => v !== null && typeof v === "object";
+
+/**
+ * Shallow-merge the overrides bag onto the decision inputs for one call.
+ *
+ * `accounts` and `health` replace the corresponding keys on the services
+ * object; `enabledMain` / `enabledSub` (endpoint keys, providerID/modelID)
+ * restrict the candidate pool for the matching surface. The bag is applied
+ * ONLY when `gated === true`; otherwise the inputs pass through untouched.
+ *
+ * @param {object} o
+ * @param {object} [o.services]   the RoutingServices object built from live state
+ * @param {Array}  [o.catalog]    the candidate endpoint list for the surface
+ * @param {"main"|"sub"} [o.surface]
+ * @param {object} [o.overrides]  the overrides bag from the request
+ * @param {boolean} [o.gated]     true when NODE_ENV !== "production"
+ * @returns {{ services: object, catalog: Array }}
+ */
+export function applyRoutingOverrides({ services, catalog, surface, overrides, gated }) {
+  if (gated !== true || !isObj(overrides)) {
+    return { services, catalog };
+  }
+  let next = services;
+  if (isObj(overrides.accounts)) {
+    next = { ...(isObj(next) ? next : {}), accounts: overrides.accounts };
+  }
+  if (isObj(overrides.health)) {
+    next = { ...(isObj(next) ? next : {}), health: overrides.health };
+  }
+  let nextCatalog = catalog;
+  // A PROVIDED array (including []) restricts the pool to exactly those
+  // endpoint keys — present-but-empty means "no candidates", the A15 harness
+  // scenario (keepsIncumbent). Absent/undefined means no restriction.
+  const enabled = surface === "sub" ? overrides.enabledSub : overrides.enabledMain;
+  if (Array.isArray(enabled)) {
+    const keys = new Set(enabled);
+    nextCatalog = Array.isArray(catalog) ? catalog.filter((c) => keys.has(endpointKey(c))) : catalog;
+  }
+  return { services: next, catalog: nextCatalog };
+}
+
+/**
+ * Resolve the decision's injected clock. The router already takes injected
+ * time; this lets the harness hold `nowMs` fixed so pacing scenarios (A19) are
+ * reproducible. Gated: when off (or absent) the caller's own clock wins.
+ *
+ * @param {object} [overrides]
+ * @param {boolean} [gated]
+ * @param {number} [fallback]
+ * @returns {number}
+ */
+export function resolveNowOverride(overrides, gated, fallback) {
+  if (
+    gated === true &&
+    isObj(overrides) &&
+    typeof overrides.nowMs === "number" &&
+    Number.isFinite(overrides.nowMs)
+  ) {
+    return overrides.nowMs;
+  }
+  return fallback;
+}
+
+/**
+ * The health map the incumbent-health report should consult, or null when the
+ * bag is gated off / carries no health override. Lets a harness scenario (A21,
+ * A22) observe the incumbent READING as unhealthy on the same round trip the
+ * decision core responds to the override.
+ *
+ * @param {object} [overrides]
+ * @param {boolean} [gated]
+ * @returns {Record<string,string>|null}
+ */
+export function resolveHealthOverride(overrides, gated) {
+  if (gated === true && isObj(overrides) && isObj(overrides.health)) {
+    return overrides.health;
+  }
+  return null;
+}

--- a/src/shared/routingOverrides.test.ts
+++ b/src/shared/routingOverrides.test.ts
@@ -1,0 +1,144 @@
+import { describe, it, expect } from "vitest";
+import {
+  applyRoutingOverrides,
+  resolveNowOverride,
+  resolveHealthOverride,
+} from "./routingOverrides.mjs";
+
+type Endpoint = { providerID: string; id?: string; modelID?: string };
+type Applied = { services: Record<string, unknown>; catalog: Endpoint[] };
+
+// Helper shapes mirroring the live sources (src/server/routingServices.mjs and
+// opencode.mjs listRoutableModels) — providerID/id routes, not hand-won.
+const ep = (providerID: string, id: string): Endpoint => ({ providerID, id });
+const keyOf = (c: Endpoint): string => `${c.providerID}/${c.id ?? c.modelID ?? ""}`;
+
+const apply = (o: unknown): Applied => o as Applied;
+
+describe("applyRoutingOverrides (BET-1276 12a)", () => {
+  it("passes inputs through untouched when gated off", () => {
+    const services = { accounts: { a: 1 } };
+    const catalog = [ep("p1", "m1"), ep("p2", "m2")];
+    const out = apply(
+      applyRoutingOverrides({
+        services,
+        catalog,
+        surface: "main",
+        overrides: {
+          accounts: { b: 2 },
+          health: { p1: "out-of-credit" },
+          enabledMain: ["p1/m1"],
+          nowMs: 0,
+        },
+        gated: false,
+      }),
+    );
+    expect(out.services).toBe(services);
+    expect(out.catalog).toBe(catalog);
+  });
+
+  it("replaces accounts and health, filtering the main pool by enabledMain", () => {
+    const services = { accounts: { a: 1 }, health: { p1: "ok" } };
+    const catalog = [ep("p1", "m1"), ep("p2", "m2")];
+    const out = apply(
+      applyRoutingOverrides({
+        services,
+        catalog,
+        surface: "main",
+        overrides: {
+          accounts: { b: 2 },
+          health: { p1: "out-of-credit" },
+          enabledMain: ["p2/m2"],
+        },
+        gated: true,
+      }),
+    );
+    expect(out.services.accounts).toEqual({ b: 2 });
+    expect(out.services.health).toEqual({ p1: "out-of-credit" });
+    expect(out.services).not.toBe(services);
+    expect(out.catalog.map(keyOf)).toEqual(["p2/m2"]);
+  });
+
+  it("applies enabledSub to the sub surface and enabledMain to main independently", () => {
+    const catalog = [ep("p1", "m1"), ep("p2", "m2")];
+    for (const surface of ["main", "sub"] as const) {
+      const sub = apply(
+        applyRoutingOverrides({
+          services: {},
+          catalog,
+          surface,
+          overrides: { enabledSub: ["p2/m2"], enabledMain: [] },
+          gated: true,
+        }),
+      );
+      if (surface === "main") expect(sub.catalog).toHaveLength(0);
+      else expect(sub.catalog.map(keyOf)).toEqual(["p2/m2"]);
+    }
+  });
+
+  it("an empty provided list means an empty pool (present-but-empty, not absent)", () => {
+    const catalog = [ep("p1", "m1"), ep("p2", "m2")];
+    const out = apply(
+      applyRoutingOverrides({
+        services: {},
+        catalog,
+        surface: "main",
+        overrides: { enabledMain: [] },
+        gated: true,
+      }),
+    );
+    expect(out.catalog).toHaveLength(0);
+  });
+
+  it("no restriction when the list is absent", () => {
+    const catalog = [ep("p1", "m1"), ep("p2", "m2")];
+    const out = apply(
+      applyRoutingOverrides({
+        services: {},
+        catalog,
+        surface: "main",
+        overrides: { accounts: {} },
+        gated: true,
+      }),
+    );
+    expect(out.catalog).toHaveLength(2);
+  });
+
+  it("matches endpoint keys by providerID/modelID (both id and modelID spellings)", () => {
+    const a: Endpoint = { providerID: "p1", id: "m1" };
+    const b: Endpoint = { providerID: "p1", modelID: "m2" };
+    const out = apply(
+      applyRoutingOverrides({
+        services: {},
+        catalog: [a, b],
+        surface: "main",
+        overrides: { enabledMain: ["p1/m2"] },
+        gated: true,
+      }),
+    );
+    expect(out.catalog).toEqual([b]);
+  });
+});
+
+describe("resolveNowOverride (12a injected clock)", () => {
+  it("honours a finite nowMs when gated on", () => {
+    expect(resolveNowOverride({ nowMs: 123 }, true, 456)).toBe(123);
+  });
+  it("falls back when gated off", () => {
+    expect(resolveNowOverride({ nowMs: 123 }, false, 456)).toBe(456);
+  });
+  it("falls back when nowMs is missing or non-finite", () => {
+    expect(resolveNowOverride({}, true, 456)).toBe(456);
+    expect(resolveNowOverride({ nowMs: "x" }, true, 456)).toBe(456);
+  });
+});
+
+describe("resolveHealthOverride (12a incumbent-health report)", () => {
+  it("returns the health map when gated on and present", () => {
+    expect(resolveHealthOverride({ health: { p1: "failing" } }, true)).toEqual({ p1: "failing" });
+  });
+  it("returns null when gated off or absent", () => {
+    expect(resolveHealthOverride({ health: { p1: "failing" } }, false)).toBeNull();
+    expect(resolveHealthOverride({}, true)).toBeNull();
+  });
+});


### PR DESCRIPTION
## Deck A — the scenario replay harness (BET-1276)

Programmatic replay of 30 routing scenarios against the **live box**, varying
the inputs the decision actually reads (agent, preset, conversation size,
attachments, account state, candidate pool) through the new dev-only
`overrides` bag on `routing:choose` — judging each against **decision
properties** (tier, cost, exclusions, determinism), never a model name.

**Base: `origin/main` @ `670ba466`**

**Files changed:** 10 files + 4 new — `src/shared/routingOverrides.mjs`(+test/+`.d.mts`), `src/server/rpc.mjs`, `src/server/rpc.test.mjs`, `scripts/routing/deck-a.mjs`, `scripts/routing/scenarios.json`, `docs/routing-scenarios.md`, `package.json` (+`routing:deck`), `src/renderer/routingControls.smoke.test.tsx`.

### What it does
- **12a** — `routing:choose` gains a dev-only `overrides` bag (`accounts`/`health`/`enabledMain`/`enabledSub`/`nowMs`), gated on `NODE_ENV !== "production"`; read-only, side-effect-free, never reachable from any UI, silently ignored in production, applied through one shared pure helper (`src/shared/routingOverrides.mjs`).
- **12b/c** — `deck-a.mjs` + `scenarios.json`: 30 scenarios, decision-property matchers (never model names).
- **12d** — all six inert-signal checks (#1–#6, named in the section).
- **12e** — `npm run routing:deck` (diagnostic, **not part of `npm test`**) + `docs/routing-scenarios.md` Deck A section.

### Reviewer-return (cycle 2) — addressed
- **Block (fix-here):** §12d now implements all six mandated checks — added #1 (all marginal costs equal → DEFAULT_MIX signature), completed #4 (reliability, latency p50/p90 **and** throughput each verified to distinguish a pair, reported per-metric), added #5 (cost.basis=unknown while the provider reports a cost).
- **Question:** resolved as option (a) — `winnerIn`/`winnerNotIn` are formally documented as additions to the closed §12b matcher vocabulary (deck comment + `docs/routing-scenarios.md`), and flagged as should-be-named in the epic's closed list so the spec stays the single source of truth.
- Out-of-scope `routingControls.smoke.test.tsx` rename is the pre-existing `main` typecheck fix (below).

### Verification results
- Typecheck: exit **0**.
- Test: exit **0** — vitest `3538 passed / 7 skipped`; node `2687 pass / 0 fail`.

> `origin/main @ 670ba466` fails typecheck with a **pre-existing** error — the BET-1277 smoke test imports `refreshRoutingCatalog`, deleted by BET-1249. This PR switches it to the renamed test seam `_resetRoutingCatalogCache` (6 lines) so acceptance 5 is reachable; it is the only change here outside Deck A scope.

### Deck output (acceptance 2 — full, verbatim)

```

> manta-ui@0.0.49 routing:deck
> node scripts/routing/deck-a.mjs

(node:3878928) ExperimentalWarning: SQLite is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)

id    scenario                       expected                   winner                         basis            result
────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────
A01   build, Balanced, 12k           tierAtLeast deep           anthropic/claude-opus-5        unknown          PASS
A02   explore, Balanced, 12k         cheaperThan A01            anthropic/claude-opus-5        unknown          FAIL
      └ cheaperThan A01 ($0.8525 vs $0.8525)
A03   plan, Balanced, 12k            tierAtLeast deep           anthropic/claude-opus-5        unknown          PASS
A04   general, Balanced, 12k         tier between A02(fast) and anthropic/claude-opus-5        unknown          PASS
A05   build, Economy                 cheaperThan A01, reasons e anthropic/claude-haiku-4-5-202 unknown          PASS
A06   explore, Performance           tierAtLeast A02's (fast) - anthropic/claude-opus-5        unknown          PASS
A07   highest-floor agent (plan), Ec never below plan's deep fl anthropic/claude-haiku-4-5-202 unknown          PASS
A08   build, 10k                     sameModelAs A01 (10k vs 12 anthropic/claude-opus-5        unknown          PASS
A09   build, 400k                    excludes every smaller-win anthropic/claude-opus-5        unknown          PASS
A10   build, larger than every model keepsIncumbent; reason cit anthropic/claude-opus-4-8                       PASS
A11   build + image                  no image-incapable winner  anthropic/claude-opus-5        unknown          PASS
A12   build + pdf                    no pdf-incapable winner    anthropic/claude-opus-5        unknown          PASS
A13   build + image, only text-only  keepsIncumbent -- must not anthropic/claude-opus-4-8                       PASS
A14   enabledMain = two endpoints, x winner is one of the two,  anthropic/claude-opus-5        unknown          PASS
A15   enabledMain = []               keepsIncumbent; reason say anthropic/claude-opus-4-8                       PASS
A16   enabledSub = one endpoint, sur that endpoint wins         anthropic/claude-opus-4-8      unknown          PASS
A17   a deprecated model, ticked and the opted-in deprecated mo                                                 FAIL
      └ winnerIn anthropic/claude-opus-4-5-20251101 (got )
A18   well-paced subscription beats  subscription wins; traceFi anthropic/claude-opus-5        subscription-pac PASS
A19   same consumed %, early vs late materially different cost  anthropic/claude-opus-5        subscription-pac PASS
A20   subscription exhausted         excludes exhausted subscri anthropic/claude-opus-4-8                       FAIL
      └ winnerNotIn anthropic/claude-opus-4-8,anthropic/claude-opus-4-8-fast,anthropic/claude-sonnet-5,anthropic/claude-haiku-4-5-20251001,anthropic/claude-fable-5,anthropic/claude-opus-5,anthropic/claude-opus-5-fast (got anthropic/claude-opus-4-8)
A21   provider health out-of-credit  excludes the out-of-credit anthropic/claude-opus-4-8                       FAIL
      └ winnerNotIn anthropic/claude-opus-4-8 (got anthropic/claude-opus-4-8)
A22   provider health failing (soft) failing is only deranked,  anthropic/claude-opus-5        unknown          PASS
A23   custom endpoint, nothing decla a custom endpoint with not anthropic/claude-opus-4-8                       PASS
A24   one model, two providers, diff two distinct candidates; c anthropic/claude-opus-5        unknown          PASS
A25   one model, same price, subscri subscription wins a same-p anthropic/claude-opus-5        unknown          PASS
A26   two endpoints, x10 + shuffled  identical winner across 10 anthropic/claude-opus-4-8      unknown          PASS
A27   provider quotes $0 for a price a $0 quote for a priced mo anthropic/claude-opus-5        unknown          PASS
A28   declared-free endpoint stays f a declared-free endpoint s anthropic/claude-opus-5        unknown          PASS
A29   stability x10 (A01 config)     identical model and reason anthropic/claude-opus-5        unknown          PASS
A30   change exactly one input at a  only the changed input mov anthropic/claude-opus-5        unknown          PASS

INERT-SIGNAL SECTION (12d):
  FINDING: hard filter never fires anywhere in the deck: tool calling
  FINDING: reliability does not distinguish any pair of endpoints (1 distinct value)
  FINDING: endpoint(s) priced cost.basis=unknown while the provider reports a cost: anthropic/claude-opus-4-8, anthropic/claude-opus-4-8-fast, anthropic/claude-sonnet-5, anthropic/claude-haiku-4-5-20251001, anthropic/claude-fable-5, anthropic/claude-opus-5, anthropic/claude-opus-5-fast

==============================================================================
SUMMARY: 26/30 scenarios passed · 4 failed · 3 inert-signal finding(s)
  FAIL A02: cheaperThan A01 ($0.8525 vs $0.8525)
  FAIL A17: winnerIn anthropic/claude-opus-4-5-20251101 (got )
  FAIL A20: winnerNotIn anthropic/claude-opus-4-8,anthropic/claude-opus-4-8-fast,anthropic/claude-sonnet-5,anthropic/claude-haiku-4-5-20251001,anthropic/claude-fable-5,anthropic/claude-opus-5,anthropic/claude-opus-5-fast (got anthropic/claude-opus-4-8)
  FAIL A21: winnerNotIn anthropic/claude-opus-4-8 (got anthropic/claude-opus-4-8)
```


**Acceptance 3 (A19 + A26 pass): ✓ both pass.**

**Acceptance 4 (inert-signal):** the full six-check §12d section is implemented. On this live box it reports 3 findings (reported, not suppressed, and filed): the tool-calling filter is inert; reliability does not distinguish any pair (1 distinct value) though latency/throughput do; and **every Anthropic endpoint is priced `cost.basis=unknown` while the provider reports a real cost** — the clearest "routing isn't reading account/cost data" tell the checker exists to catch.

The 4 failing scenarios are conditions this live box does not provide (no cheaper-tier eligible model → A02; no deprecated/opted-in model → A17; no non-Anthropic same-tier endpoint → A20/A21, where the router correctly keeps the incumbent).

**Follow-up filed (acceptance 4):** BET-1295 tracks the inert-signal findings; updated to reflect the complete §12d output.
