### PR TITLE
fix(routing): deck-a reads live usage snapshots from the running server (BET-1299)

### DIFF
--- a/scripts/routing/deck-a.mjs
+++ b/scripts/routing/deck-a.mjs
@@ -25,7 +25,7 @@
 // prompt difficulty — see docs/routing-scenarios.md.
 
 import { configGet } from "../../src/server/local.mjs";
-import { listSnapshots } from "../../src/server/usage.mjs";
+import { listSnapshots, listLiveSnapshots } from "../../src/server/usage.mjs";
 import { listRoutableModels } from "../../src/server/opencode.mjs";
 import { buildRoutingServices } from "../../src/server/routingServices.mjs";
 import { lookupModel, matchModel, allModels } from "../../src/server/modelCatalog.mjs";
@@ -58,6 +58,26 @@ const catalogIndex = { lookupModel, matchModel, allModels };
 const providerHealth = createProviderHealth({});
 const providerHealthState = (pid) => providerHealth.state(pid);
 
+// The deck runs in its own process with NO usage poller of its own, so the
+// in-process `listSnapshots()` is always [] — production truth lives in the
+// RUNNING manta-server's poller. Read that poller's cache over the `usage:list`
+// RPC so the §12d cost checks reflect production (BET-1299); fall back to the
+// local in-process read for the (currently unused) embedded case.
+async function getLiveSnapshots() {
+  try {
+    const live = await listLiveSnapshots();
+    if (Array.isArray(live) && live.length > 0) return live;
+  } catch {
+    /* fall through to the in-process read */
+  }
+  try {
+    const local = listSnapshots();
+    return Array.isArray(local) ? local : [];
+  } catch {
+    return [];
+  }
+}
+
 async function buildBoxContext() {
   const cfg = (await configGet()) ?? {};
   const policy = isObj(cfg?.modelRouting) ? { ...cfg.modelRouting } : {};
@@ -77,14 +97,7 @@ async function runDecision({ cfg, policy, scenario, nowMs }) {
   }
   let services = null;
   try {
-    const snapshotList = (() => {
-      try {
-        const s = listSnapshots();
-        return Array.isArray(s) ? s : [];
-      } catch {
-        return [];
-      }
-    })();
+    const snapshotList = await getLiveSnapshots();
     services = await buildRoutingServices(
       cfg,
       {
@@ -442,14 +455,7 @@ async function inertSignalFindings({ cfg, policy, rows }) {
   let catalog = [];
   let services = {};
   try {
-    const snapshotList = (() => {
-      try {
-        const s = listSnapshots();
-        return Array.isArray(s) ? s : [];
-      } catch {
-        return [];
-      }
-    })();
+    const snapshotList = await getLiveSnapshots();
     catalog = await listRoutableModels("main", cfg);
     services = await buildRoutingServices(
       cfg,

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -90,6 +90,7 @@ import { codexAdapter } from "./usageAdapters/codex.mjs";
 import { kimiAdapter } from "./usageAdapters/kimi.mjs";
 import { isUsageAtLimit } from "./usageStopper.mjs";
 import { loadAccountReaders } from "./accountReaders.mjs";
+import { loadAuthFile, DEFAULT_AUTH_PATH } from "./gatewayRegister.mjs";
 
 export { normalizeWindow };
 
@@ -436,4 +437,55 @@ export function startUsagePoller(bus, { intervalMs = POLL_MS } = {}) {
 /** @returns {UsageSnapshot[]} */
 export function listSnapshots() {
   return activePoller ? activePoller.snapshots : [];
+}
+
+// ---------------------------------------------------------------------------
+// Live read for the deck harness (BET-1299) — the running server's poller
+// ---------------------------------------------------------------------------
+//
+// `listSnapshots()` reads the ONE poller instance `startUsagePoller` creates in
+// the running manta-server process. A separate process — the routing replay
+// harness (scripts/routing/deck-a.mjs) — has no poller of its own, so its
+// `listSnapshots()` is always `[]` and every priced endpoint would report a
+// false `cost.basis: unknown` even though production routing prices correctly.
+// This function fetches the SAME in-process cache from the live server over its
+// `usage:list` RPC, so deck checks reflect production truth. Never throws and
+// returns `[]` on any failure — the services contract (a missing account bag
+// must never break a decision) applies identically here.
+
+// The local binding is the direct server process (no Caddy/DNS/TLS hop) — the
+// same box the deck runs on. Same default + env override as index.mjs.
+function localServerBaseUrl() {
+  const port = Number(process.env.MANTA_MOBILE_PORT ?? 8787);
+  return `http://127.0.0.1:${port}`;
+}
+
+/**
+ * Read the live server's polled usage snapshots over its `usage:list` RPC.
+ * @param {{ fetchImpl?: typeof fetch, authPath?: string, baseUrl?: string }} [opts]
+ * @returns {Promise<UsageSnapshot[]>}
+ */
+export async function listLiveSnapshots({
+  fetchImpl = fetch,
+  authPath = DEFAULT_AUTH_PATH,
+  baseUrl = localServerBaseUrl(),
+} = {}) {
+  try {
+    const token = loadAuthFile(authPath)?.box_token;
+    if (!token) return [];
+    const res = await fetchImpl(`${baseUrl}/rpc/${encodeURIComponent("usage:list")}`, {
+      method: "POST",
+      headers: {
+        "content-type": "application/json",
+        authorization: `Bearer ${token}`,
+      },
+      body: JSON.stringify({ args: [] }),
+    });
+    if (!res.ok) return [];
+    const json = await res.json().catch(() => null);
+    const snapshots = json?.result;
+    return Array.isArray(snapshots) ? snapshots : [];
+  } catch {
+    return [];
+  }
 }

--- a/src/server/usage.test.mjs
+++ b/src/server/usage.test.mjs
@@ -1,6 +1,6 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { normalizeWindow, createUsagePoller, ADAPTERS, rateLimitBackoffMs, carryForward } from "./usage.mjs";
+import { normalizeWindow, createUsagePoller, ADAPTERS, rateLimitBackoffMs, carryForward, listLiveSnapshots } from "./usage.mjs";
 import { usageWindowLabel } from "./usageAdapters/normalizeWindow.mjs";
 import { claudeAdapter } from "./usageAdapters/claude.mjs";
 import { codexAdapter } from "./usageAdapters/codex.mjs";
@@ -1000,4 +1000,109 @@ test("poller: the retry budget re-arms once the window stops waiting", async () 
   await poller.tick();
   await sleep(60);
   assert.ok(fetchCalls > afterFresh + 1, "a fresh boundary gets a fresh retry budget");
+});
+
+// ----------------------------------------------------------------------------
+// listLiveSnapshots — read the RUNNING server's poller cache over usage:list
+// ----------------------------------------------------------------------------
+
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+function fakeAuthFile({ box_token = "tok123" } = {}) {
+  const dir = mkdtempSync(join(tmpdir(), "usage-live-"));
+  const path = join(dir, "auth.json");
+  writeFileSync(path, JSON.stringify({ box_id: "box1", ...(box_token ? { box_token } : {}) }));
+  return { dir, path };
+}
+
+function snap(overrides = {}) {
+  return {
+    provider: "claude",
+    providerIDs: ["anthropic"],
+    kind: "subscription",
+    windows: [{ kind: "weekly", label: "5h", pct: 42 }],
+    fetchedAt: 1000,
+    ...overrides,
+  };
+}
+
+test("listLiveSnapshots: returns the server's polled snapshots from usage:list", async () => {
+  const { dir, path } = fakeAuthFile();
+  try {
+    const expected = [snap()];
+    const out = await listLiveSnapshots({
+      authPath: path,
+      baseUrl: "http://127.0.0.1:8787",
+      fetchImpl: async (url, init) => {
+        assert.match(url, /\/rpc\/usage%3Alist$/);
+        assert.equal(init.method, "POST");
+        assert.equal(init.headers.authorization, "Bearer tok123");
+        return fakeResponse(200, { result: expected });
+      },
+    });
+    assert.deepEqual(out, expected);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("listLiveSnapshots: returns [] when no box_token is present", async () => {
+  const { dir, path } = fakeAuthFile({ box_token: null });
+  try {
+    let called = false;
+    const out = await listLiveSnapshots({
+      authPath: path,
+      fetchImpl: async () => {
+        called = true;
+        return fakeResponse(200, { result: [] });
+      },
+    });
+    assert.deepEqual(out, []);
+    assert.equal(called, false, "no fetch when there is no token");
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("listLiveSnapshots: returns [] on a non-2xx response", async () => {
+  const { dir, path } = fakeAuthFile();
+  try {
+    const out = await listLiveSnapshots({
+      authPath: path,
+      fetchImpl: async () => fakeResponse(401, { error: "nope" }),
+    });
+    assert.deepEqual(out, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("listLiveSnapshots: returns [] when the result is not an array", async () => {
+  const { dir, path } = fakeAuthFile();
+  try {
+    const out = await listLiveSnapshots({
+      authPath: path,
+      fetchImpl: async () => fakeResponse(200, { result: { not: "an array" } }),
+    });
+    assert.deepEqual(out, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("listLiveSnapshots: never throws — a rejected fetch returns []", async () => {
+  const { dir, path } = fakeAuthFile();
+  try {
+    const out = await listLiveSnapshots({
+      authPath: path,
+      fetchImpl: async () => {
+        throw new Error("server down");
+      },
+    });
+    assert.deepEqual(out, []);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
 });


### PR DESCRIPTION
## BET-1299 — Deck A reads live usage snapshots from the running server

**Problem.** The routing replay harness (`scripts/routing/deck-a.mjs`) called
`listSnapshots()` in its own process. That function reads the **in-process
poller cache owned by the running manta-server**, so in the deck process it
always returned `[]`. `buildRoutingServices` therefore got an empty
`snapshots` bag → `services.accounts` was empty → every priced endpoint
reported a false `cost.basis: unknown`, and the §12d inert-signal check #5
("endpoint priced basis=unknown while the provider reports a cost") fired on
every priced endpoint. This was the entire origin of BET-1297 finding #2.
Production routing (`rpc:routing:choose`, `delegate:startJob`) was correct
all along — it passes the server-side cache.

**Fix.** Add `listLiveSnapshots()` to `src/server/usage.mjs` — it reads the
**running** server's polled snapshots over its `usage:list` RPC
(`POST /rpc/usage:list` with the box token from `~/.manta/auth.json` against
the local server binding `http://127.0.0.1:8787`), which is the SAME cache
production routing reads. Injectable `{ fetchImpl, authPath, baseUrl }` for
tests; never throws; returns `[]` on any failure (the services contract: a
missing account bag must never break a decision).

The deck now draws snapshots through a single `getLiveSnapshots()` helper
(used by both `runDecision` and the §12d scan) that prefers the live-server
read and falls back to the local in-process read.

**Verified on the live box.** Deck "basis" column now shows
`subscription-pac` (real Anthropic subscription snapshot, `providerIDs:
["anthropic"]`) instead of `unknown`, and the false
`cost.basis=unknown` finding is gone. It is replaced by the *genuine* inert
signals §12d exists to surface: all 9 routable endpoints share one marginal
cost ($0 — a pure-subscription box with no cash-priced alternative prices at
marginal zero, per `marginalCost.mjs`), so the price-dependent scenarios
(`cheaperThan`, `sensitivity on preset/context`) can no longer distinguish
endpoints. That is production truth, not a harness defect.

**Follow-up note (filed inline, not a blocker):** the deck's price-dependent
scenario expectations (A02/A05 cheaperThan, A30 sensitivity, A17/A20/A21
deprecation/exhaustion/out-of-credit) assume per-endpoint price/quality
differentiation. On a subscription-only box they cannot pass. Whether those
scenarios need subscription-aware expectations is a separate tuning question
out of scope here — this PR delivers the snapshot-reading fix so the §12d
cost checks reflect production.

**Files changed:** 3 files. `scripts/routing/deck-a.mjs`,
`src/server/usage.mjs`, `src/server/usage.test.mjs`.

**Verification results:**
- PR branch (`multica/BET-1299-deck-live-usage-snapshots` @ `bfeb0060`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit 0, 3538 pass / 7 skip (vitest) + 2692 pass server tests. Failures: none. log sha256: `01c12a903f0d9e28b4a1279f0d04f97778f591259e50ba35c3759388a5f0f7aa`
- **Conclusion:** 0 failures. No base-branch re-run needed — the change is additive (new exported function + two localized deck call sites) and does not alter any existing test's expectations (all 5 new tests target the new `listLiveSnapshots` path).

**Base:** `origin/main` @ `c98ae791`

**Functional check (deck, live box):**
```
basis now: subscription-pac  (was: unknown)
fake cost.basis=unknown finding: GONE
```
