### PR TITLE
feat(mobile): one model per session, effort in the selection, honour box default (BET-1280)

### DIFF
--- a/mobile/native/MantaUI/ChatModel.swift
+++ b/mobile/native/MantaUI/ChatModel.swift
@@ -218,25 +218,27 @@ enum ChatModel {
         isDeprecated(m) && !deprecatedOptIns.contains("\(m.providerID)/\(m.id)")
     }
 
-    /// The effective selection: override wins, else the configured default.
-    static func effective(_ override: OpencodeModelID?, _ defaultModel: OpencodeModelID?) -> OpencodeModelID? {
-        override ?? defaultModel
+    /// The effective selection, identical to the desktop's precedence
+    /// (`src/renderer/ChatPanel.tsx`): the session override wins, else the box
+    /// config's `defaultModel`, else opencode's own provider default.
+    static func effective(_ override: OpencodeModelID?, _ configDefault: OpencodeModelID?, _ providerDefault: OpencodeModelID?) -> OpencodeModelID? {
+        override ?? configDefault ?? providerDefault
     }
 
     /// Resolve the active model object (for the pill's friendly name), or nil
-    /// when neither an override nor the default names a known pickable model.
-    static func activeModel(_ models: [OpencodeModel], override: OpencodeModelID?, default defaultModel: OpencodeModelID?) -> OpencodeModel? {
-        guard let selection = effective(override, defaultModel) else { return nil }
+    /// when no effective selection names a known pickable model.
+    static func activeModel(_ models: [OpencodeModel], override: OpencodeModelID?, configuration configDefault: OpencodeModelID?, provider providerDefault: OpencodeModelID?) -> OpencodeModel? {
+        guard let selection = effective(override, configDefault, providerDefault) else { return nil }
         return models.first { $0.providerID == selection.providerID && $0.id == selection.modelID }
     }
 
     /// The pill's short label: the active model's friendly name, else
     /// "Default" when no effective selection resolves.
-    static func label(_ models: [OpencodeModel], override: OpencodeModelID?, default defaultModel: OpencodeModelID?) -> String {
-        if let active = activeModel(models, override: override, default: defaultModel) {
+    static func label(_ models: [OpencodeModel], override: OpencodeModelID?, configuration configDefault: OpencodeModelID?, provider providerDefault: OpencodeModelID?) -> String {
+        if let active = activeModel(models, override: override, configuration: configDefault, provider: providerDefault) {
             return active.name
         }
-        if override != nil || defaultModel != nil { return "Default" }
+        if override != nil || configDefault != nil || providerDefault != nil { return "Default" }
         return "Default"
     }
 
@@ -426,15 +428,29 @@ enum ChatModel {
         catalogueGroups(models).reduce(0) { $0 + $1.models.count }
     }
 
-    /// Encode a selection as the persisted `providerID/modelID` string.
-    static func encode(_ id: OpencodeModelID) -> String {
-        "\(id.providerID)/\(id.modelID)"
+    /// The persisted selection — byte-identical in shape to the desktop's
+    /// `ModelSelection` (`{ providerID, modelID, variant? }`,
+    /// src/renderer/chatShared.tsx). `variant` is omitted (never null) when
+    /// absent, so the two clients store the same JSON blob under the same key.
+    struct ModelSelection: Codable, Equatable, Sendable {
+        var providerID: String
+        var modelID: String
+        var variant: String?
     }
 
-    /// Decode a persisted override string, or nil when malformed/empty.
-    static func decode(_ raw: String) -> OpencodeModelID? {
-        let parts = raw.split(separator: "/", maxSplits: 1).map(String.init)
-        guard parts.count == 2, !parts[0].isEmpty, !parts[1].isEmpty else { return nil }
-        return OpencodeModelID(providerID: parts[0], modelID: parts[1])
+    /// Encode a selection as the JSON blob stored under the single per-session
+    /// key, mirroring the desktop's `JSON.stringify`. A nil `variant` is
+    /// omitted by the synthesized Codable (encodeIfPresent), never `null`.
+    static func encode(_ selection: ModelSelection) -> String {
+        (try? JSONEncoder().encode(selection)).flatMap { String(data: $0, encoding: .utf8) } ?? ""
+    }
+
+    /// Decode a persisted selection JSON blob, or nil when malformed/empty.
+    static func decode(_ raw: String) -> ModelSelection? {
+        guard let data = raw.data(using: .utf8),
+              let s = try? JSONDecoder().decode(ModelSelection.self, from: data)
+        else { return nil }
+        guard !s.providerID.isEmpty, !s.modelID.isEmpty else { return nil }
+        return s
     }
 }

--- a/mobile/native/MantaUI/ChatModelCatalog.swift
+++ b/mobile/native/MantaUI/ChatModelCatalog.swift
@@ -18,7 +18,11 @@ import Combine
 final class ChatModelCatalog: ObservableObject {
 
     @Published private(set) var models: [OpencodeModel] = []
+    /// The opencode provider's own default (from `opencode:default-model`).
     @Published private(set) var defaultModel: OpencodeModelID?
+    /// The box config's `defaultModel` (`AppConfig.defaultModel` shape) read
+    /// from `config:get` — the middle tier of the per-session precedence.
+    @Published private(set) var configDefault: OpencodeModelID?
     /// True once the model list has arrived (or failed). Drives the composer
     /// pill's loading state and the picker's "Loading models…" placeholder.
     @Published private(set) var loaded = false
@@ -32,22 +36,36 @@ final class ChatModelCatalog: ObservableObject {
         self.api = api
     }
 
-    /// Fetch the box's model list + default exactly once. Idempotent: a second
-    /// call while a fetch is in flight, or after one has completed, does
-    /// nothing — which is what lets every ChatModelStore (including a freshly
-    /// rebuilt one after a clear) share the same loaded list. A failed/empty
-    /// fetch still flips `loaded` (so the pill leaves its loading state).
+    /// Fetch the box's model list + the two defaults exactly once. Idempotent:
+    /// a second call while a fetch is in flight, or after one has completed,
+    /// does nothing — which is what lets every ChatModelStore (including a
+    /// freshly rebuilt one after a clear) share the same loaded list. A
+    /// failed/empty fetch still flips `loaded` (so the pill leaves its loading
+    /// state). The box `defaultModel` is read through the EXISTING `config:get`
+    /// channel — no new RPC — at the same time the models load.
     func loadIfNeeded() {
         guard !didStart, !loaded else { return }
         didStart = true
         Task {
             let modelsResult = (try? await api.models()) ?? []
             let defaultResult = try? await api.defaultModel()
+            let configDefault = Self.configDefaultID((try? await api.configGet()) ?? nil)
             await MainActor.run {
                 self.models = modelsResult
                 self.defaultModel = defaultResult
+                self.configDefault = configDefault
                 self.loaded = true
             }
         }
+    }
+
+    /// Extract the box config's `defaultModel` (`{ providerID, modelID }`)
+    /// from a `config:get` envelope. Malformed/absent → nil.
+    private static func configDefaultID(_ config: [String: JSONValue]?) -> OpencodeModelID? {
+        guard case .object(let dm)? = config?["defaultModel"],
+              case .string(let providerID)? = dm["providerID"],
+              case .string(let modelID)? = dm["modelID"]
+        else { return nil }
+        return OpencodeModelID(providerID: providerID, modelID: modelID)
     }
 }

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -4,25 +4,30 @@ import Combine
 // ===========================================================================
 // S5 — model store for the composer (BET-597).
 //
-// Owns the per-SESSION model override + effort variant; the box-wide model
-// list + server default come from the shared `ChatModelCatalog`, fetched once
-// and mirrored here. The per-session override is a plain `providerID/modelID`
-// string in UserDefaults (NOT a credential — the raw string encodes
-// provider+model ids only), mirroring the desktop's
-// `manta:chat:<sessionId>:model` localStorage key.
+// Owns the per-SESSION model selection (override + effort variant folded into
+// one JSON blob); the box-wide model list + defaults come from the shared
+// `ChatModelCatalog`, fetched once and mirrored here. The selection is a JSON
+// blob stored under ONE key per session, `manta:chat:<sessionId>:model`,
+// byte-identical in name and shape to the desktop's ModelSelection
+// (src/renderer/chatShared.tsx) — one model per session, plan mode never
+// changes the model.
 //
 // The catalog is why clearing a session does NOT reload models: the clear
 // rebuilds this store for the new session id, but the list is already loaded
-// and shared, so there is no second fetch. The override/variant are carried to
-// the new id by `rebind(to:)` (matching the desktop's clear handler, which
-// copies the override into the new session's key).
+// and shared, so there is no second fetch. The selection is carried to the new
+// id by `rebind(to:)` (matching the desktop's clear handler, which copies the
+// override into the new session's key).
 // ===========================================================================
 
 @MainActor
 final class ChatModelStore: ObservableObject {
 
     @Published private(set) var models: [OpencodeModel] = []
+    /// The opencode provider's own default (from `opencode:default-model`).
     @Published private(set) var defaultModel: OpencodeModelID?
+    /// The box config's `defaultModel` entry (`AppConfig.defaultModel` from
+    /// `config:get`), the middle tier of the precedence.
+    @Published private(set) var configDefault: OpencodeModelID?
     @Published private(set) var override: OpencodeModelID?
     /// True once the shared catalog has its list (mirrored from the catalog).
     /// Drives the composer pill's loading state.
@@ -43,7 +48,8 @@ final class ChatModelStore: ObservableObject {
     @Published private(set) var deprecatedOptIns: Set<String> = []
     /// Plan mode is ON for this session (the per-session `manta:chat:<sid>:plan`
     /// boolean — BET-952). A plain Bool, deliberately NOT folded into the model
-    /// blob: iOS stores that as a distinct "providerID/modelID" string.
+    /// blob: plan mode changes the agent, never the model (one model per
+    /// session), so the flag stays separate from the JSON selection.
     @Published private(set) var planOn: Bool
     /// The box's agent list, once fetched (`opencode:agents`). Nil = not loaded
     /// yet (the plan chip shows a loading placeholder); a list with no `plan`
@@ -62,15 +68,20 @@ final class ChatModelStore: ObservableObject {
         self.api = api
         let planOn = UserDefaults.standard.bool(forKey: Self.planKey(for: sessionId))
         self.planOn = planOn
-        self.override = Self.loadOverride(for: sessionId, mode: planOn ? .plan : .build)
-        self.variant = UserDefaults.standard.string(forKey: Self.variantKey(for: sessionId))
+        let stored = Self.loadSelection(for: sessionId)
+        self.override = stored.map { OpencodeModelID(providerID: $0.providerID, modelID: $0.modelID) }
+        self.variant = stored?.variant
+        // Clean up the pre-BET-1280 per-mode plan key on first read of a
+        // session so an upgrading user leaves no litter in UserDefaults.
+        UserDefaults.standard.removeObject(forKey: "manta:chat:\(sessionId):model:plan")
 
-        // Seed + mirror the shared catalog so the box-wide list and default are
+        // Seed + mirror the shared catalog so the box-wide list and defaults are
         // published here (keeps every existing caller reading
         // `modelStore.models` unchanged). A clear rebuilds this store, but the
         // catalog is already loaded, so it seeds instantly — no refetch.
         self.models = catalog.models
         self.defaultModel = catalog.defaultModel
+        self.configDefault = catalog.configDefault
         self.loaded = catalog.loaded
         self.recents = ModelRecents.load()
         self.deprecatedOptIns = DeprecatedModelOptIns.load()
@@ -83,31 +94,15 @@ final class ChatModelStore: ObservableObject {
     private func mirrorCatalog() {
         models = catalog.models
         defaultModel = catalog.defaultModel
+        configDefault = catalog.configDefault
         loaded = catalog.loaded
     }
 
-    /// Which model a session remembers. Plan and build are remembered
-    /// separately so switching modes restores the model the user last chose
-    /// for that mode — and so "Build here" has a build model to return to.
-    /// Mirrors the desktop keys in src/renderer/chatShared.tsx exactly.
-    enum ModelMode: String {
-        case build
-        case plan
-    }
-
     /// The UserDefaults key mirroring the desktop's per-session model key —
-    /// one per mode. `build` uses the original `…:model` key so every
-    /// existing session keeps its model and nothing migrates; `plan` gets its
-    /// own key (`…:model:plan`), same stored shape.
-    static func storageKey(for sessionId: String, mode: ModelMode) -> String {
-        switch mode {
-        case .build: return "manta:chat:\(sessionId):model"
-        case .plan:  return "manta:chat:\(sessionId):model:plan"
-        }
-    }
-
-    static func variantKey(for sessionId: String) -> String {
-        "manta:chat:\(sessionId):variant"
+    /// one key per session, holding the whole JSON selection (model + effort).
+    /// Mirrors the desktop key in src/renderer/chatShared.tsx byte-for-byte.
+    static func storageKey(for sessionId: String) -> String {
+        "manta:chat:\(sessionId):model"
     }
 
     /// The per-session plan-mode key (BET-952), a plain Bool — never folded
@@ -136,33 +131,26 @@ final class ChatModelStore: ObservableObject {
     /// picks up the same model the user had chosen — matching the desktop,
     /// which copies the override into the new session's key on /clear.
     ///
-    /// Copies BOTH per-mode model keys (mirroring the desktop's
-    /// `copySavedModels`), preserving their independence: the RAW stored value
-    /// of each key is copied — not `loadOverride`, whose plan→build fallback
-    /// would stamp the build model into a plan key that was never explicitly
-    /// written — and a plan key absent on the source stays absent on the new
-    /// session. The old session's keys are left alone.
+    /// The whole selection (model + variant) is one value under one key, so
+    /// the RAW stored JSON blob is copied. The old session's keys are left
+    /// alone.
     func rebind(to newSessionId: String) {
         guard newSessionId != sessionId else { return }
         let defaults = UserDefaults.standard
-        for mode in [ModelMode.build, .plan] {
-            let fromKey = Self.storageKey(for: sessionId, mode: mode)
-            let toKey = Self.storageKey(for: newSessionId, mode: mode)
-            if let raw = defaults.string(forKey: fromKey) {
-                defaults.set(raw, forKey: toKey)
-            }
-        }
-        if let variant, !variant.isEmpty {
-            UserDefaults.standard.set(variant, forKey: Self.variantKey(for: newSessionId))
+        let fromKey = Self.storageKey(for: sessionId)
+        let toKey = Self.storageKey(for: newSessionId)
+        if let raw = defaults.string(forKey: fromKey) {
+            defaults.set(raw, forKey: toKey)
         }
         if planOn {
             UserDefaults.standard.set(planOn, forKey: Self.planKey(for: newSessionId))
         }
     }
 
-    /// The effective selection for the next turn: override wins, else default.
+    /// The effective selection for the next turn: override wins, else the box
+    /// config default, else the opencode provider default.
     var active: OpencodeModelID? {
-        ChatModel.effective(override, defaultModel)
+        ChatModel.effective(override, configDefault, defaultModel)
     }
 
     /// The selection to send on `opencode:prompt` (nil = let opencode pick).
@@ -171,40 +159,45 @@ final class ChatModelStore: ObservableObject {
         return SendPromptInput.Model(providerID: active.providerID, modelID: active.modelID, variant: variant)
     }
 
-    /// The mode the session is currently in — drives which per-mode key the
-    /// model selection reads and writes. Plan builds on the plan key; build
-    /// (and the default) use the build key.
-    var mode: ModelMode { planOn ? .plan : .build }
+    /// Persist the whole current selection (override + variant) as one JSON
+    /// blob under the single per-session key. No override means the session has
+    /// no explicit model — remove the key (server default applies), mirroring
+    /// the desktop.
+    private func persistSelection() {
+        let defaults = UserDefaults.standard
+        let key = Self.storageKey(for: sessionId)
+        if let override {
+            let selection = ChatModel.ModelSelection(
+                providerID: override.providerID,
+                modelID: override.modelID,
+                variant: variant
+            )
+            defaults.set(ChatModel.encode(selection), forKey: key)
+        } else {
+            defaults.removeObject(forKey: key)
+        }
+    }
 
-    /// Set (or clear, with nil) the per-session override, persisting it to the
-    /// CURRENT mode's key. A model change drops the effort variant: the levels
-    /// one model offers mean nothing on another, and most models offer none at
-    /// all.
+    /// Set (or clear, with nil) the per-session override. A model change drops
+    /// the effort variant: the levels one model offers mean nothing on another,
+    /// and most models offer none at all. Persisted as the whole selection.
     func setOverride(_ id: OpencodeModelID?) {
         let modelChanged = id != override
         override = id
-        let key = Self.storageKey(for: sessionId, mode: mode)
-        if let id {
-            UserDefaults.standard.set(ChatModel.encode(id), forKey: key)
-        } else {
-            UserDefaults.standard.removeObject(forKey: key)
-        }
-        if modelChanged { setVariant(nil) }
+        if modelChanged { variant = nil }
+        persistSelection()
     }
 
-    /// Set (or clear) the effort variant for the active model.
+    /// Set (or clear) the effort variant for the active model — a rewrite of
+    /// the whole selection (the variant lives inside the JSON blob now).
     func setVariant(_ id: String?) {
         variant = id
-        if let id, !id.isEmpty {
-            UserDefaults.standard.set(id, forKey: Self.variantKey(for: sessionId))
-        } else {
-            UserDefaults.standard.removeObject(forKey: Self.variantKey(for: sessionId))
-        }
+        persistSelection()
     }
 
     /// The effort variants the ACTIVE model offers (empty when it has none).
     var activeVariants: [OpencodeModel.Variant] {
-        ChatModel.activeModel(models, override: override, default: defaultModel)?.variants ?? []
+        ChatModel.activeModel(models, override: override, configuration: configDefault, provider: defaultModel)?.variants ?? []
     }
 
     // MARK: - Recents (BET-825)
@@ -214,7 +207,7 @@ final class ChatModelStore: ObservableObject {
     /// lands on Server default, not on a recent). `modelID` is always the
     /// base id; fast is expressed as the `fast` flag.
     var activeChoice: ModelChoice? {
-        guard let override, let active = ChatModel.activeModel(models, override: override, default: defaultModel) else {
+        guard let override, let active = ChatModel.activeModel(models, override: override, configuration: configDefault, provider: defaultModel) else {
             return nil
         }
         return ModelChoice(
@@ -245,7 +238,7 @@ final class ChatModelStore: ObservableObject {
     func recordCurrentChoice() {
         guard
             let override,
-            let active = ChatModel.activeModel(models, override: override, default: defaultModel)
+            let active = ChatModel.activeModel(models, override: override, configuration: configDefault, provider: defaultModel)
         else { return }
         let choice = ModelChoice(
             providerID: override.providerID,
@@ -261,7 +254,7 @@ final class ChatModelStore: ObservableObject {
     /// (the fast twin keeps the chosen effort, or fast is unavailable). Moved
     /// here from the sheet so the menu and the sheet share one implementation.
     func setFast(_ on: Bool) {
-        guard let active = ChatModel.activeModel(models, override: override, default: defaultModel) else { return }
+        guard let active = ChatModel.activeModel(models, override: override, configuration: configDefault, provider: defaultModel) else { return }
         let f = ChatModel.fastToggle(models: models, active: active, variantId: variant)
         guard let target = f.target else { return }
         let currentVariant = variant
@@ -290,39 +283,27 @@ final class ChatModelStore: ObservableObject {
         ChatModel.planToggle(agents: agents, on: planOn)
     }
 
-    /// Flip plan mode for this session, persisting the boolean. When the mode
-    /// actually changes, the composer's active model becomes the mode being
-    /// entered's remembered model (mirroring `ChatPanel.tsx`'s togglePlan):
-    /// reading plan pulls the plan key, falling back to build; reading build
-    /// never consults the plan key. The model key is NOT written here — only
-    /// on an explicit model pick.
+    /// Flip plan mode for this session, persisting the boolean. Plan mode
+    /// changes the agent, never the model (mirroring the desktop's togglePlan
+    /// at `src/renderer/ChatPanel.tsx`), so this ONLY sets the flag — the model
+    /// key is untouched, exactly as on desktop.
     func setPlan(_ on: Bool) {
-        let modeChanged = on != planOn
         planOn = on
         UserDefaults.standard.set(on, forKey: Self.planKey(for: sessionId))
-        guard modeChanged else { return }
-        let remembered = Self.loadOverride(for: sessionId, mode: mode)
-        if remembered != override {
-            override = remembered
-            setVariant(nil)
-        }
     }
 
-    /// The remembered per-session model for a mode, or nil when the session
-    /// has none (the server default applies). Plan reads the plan key first,
-    /// falling back to the build key when the plan key is absent — that is the
-    /// desktop's asymmetric rule and is what makes a first toggle to plan keep
-    /// the build model until the user picks one while in plan mode. Build never
-    /// falls back to plan. A present-but-malformed value counts as absent for
-    /// the purpose of the fallback.
-    static func loadOverride(for sessionId: String, mode: ModelMode) -> OpencodeModelID? {
-        let key = storageKey(for: sessionId, mode: mode)
+    /// The remembered per-session selection, or nil when the session has none
+    /// (the server/box default applies).
+    static func loadSelection(for sessionId: String) -> ChatModel.ModelSelection? {
+        let key = storageKey(for: sessionId)
         if let raw = UserDefaults.standard.string(forKey: key), let decoded = ChatModel.decode(raw) {
             return decoded
         }
-        if mode == .plan, let build = loadOverride(for: sessionId, mode: .build) {
-            return build
-        }
         return nil
+    }
+
+    /// The remembered per-session model id, or nil when the session has none.
+    static func loadOverride(for sessionId: String) -> OpencodeModelID? {
+        loadSelection(for: sessionId).map { OpencodeModelID(providerID: $0.providerID, modelID: $0.modelID) }
     }
 }

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -808,12 +808,16 @@ private struct ChatScreenContent: View {
     private var activeModelContextLimit: Double? {
         guard let model = ChatModel.activeModel(modelStore.models,
                                                 override: modelStore.override,
-                                                default: modelStore.defaultModel) else { return nil }
+                                                configuration: modelStore.configDefault,
+                                                provider: modelStore.defaultModel) else { return nil }
         return model.limit?.context
     }
 
     private var activeModelName: String {
-        ChatModel.label(modelStore.models, override: modelStore.override, default: modelStore.defaultModel)
+        ChatModel.label(modelStore.models,
+                        override: modelStore.override,
+                        configuration: modelStore.configDefault,
+                        provider: modelStore.defaultModel)
     }
 
     /// The band colour for the current context reading (strip + sheet).
@@ -1087,8 +1091,11 @@ private struct ChatScreenContent: View {
     /// plan/build mode, falling back to the server default (the plan model is
     /// only ever the composer's active model while plan mode is on).
     private var buildModelName: String {
-        let buildID = ChatModelStore.loadOverride(for: store.sessionId, mode: .build)
-        return ChatModel.label(modelStore.models, override: buildID, default: modelStore.defaultModel)
+        let buildID = ChatModelStore.loadOverride(for: store.sessionId)
+        return ChatModel.label(modelStore.models,
+                               override: buildID,
+                               configuration: modelStore.configDefault,
+                               provider: modelStore.defaultModel)
     }
 
     private func handleBuildHere(_ question: QuestionRequest, feedback: String) {

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -681,7 +681,7 @@ struct ComposerView: View {
     }
 
     private var activeModel: OpencodeModel? {
-        ChatModel.activeModel(modelStore.models, override: modelStore.override, default: modelStore.defaultModel)
+        ChatModel.activeModel(modelStore.models, override: modelStore.override, configuration: modelStore.configDefault, provider: modelStore.defaultModel)
     }
 
     private var isFastActive: Bool {

--- a/mobile/native/MantaUI/ModelPickerSheet.swift
+++ b/mobile/native/MantaUI/ModelPickerSheet.swift
@@ -36,7 +36,7 @@ struct ModelPickerSheet: View {
     private var tokens: Tokens { Tokens.scheme(colorScheme) }
 
     private var activeModel: OpencodeModel? {
-        ChatModel.activeModel(modelStore.models, override: modelStore.override, default: modelStore.defaultModel)
+        ChatModel.activeModel(modelStore.models, override: modelStore.override, configuration: modelStore.configDefault, provider: modelStore.defaultModel)
     }
 
     private var fastToggleState: ChatModel.FastToggle {

--- a/mobile/native/MantaUITests/ComposerTests.swift
+++ b/mobile/native/MantaUITests/ComposerTests.swift
@@ -44,35 +44,53 @@ final class ComposerTests: XCTestCase {
 
     // MARK: - ChatModel.effective
 
-    func testEffectiveOverrideWinsOverDefault() {
+    func testEffectiveOverrideWinsOverDefaults() {
         XCTAssertEqual(
-            ChatModel.effective(selection("anthropic", "sonnet"), selection("anthropic", "opus")),
+            ChatModel.effective(
+                selection("anthropic", "sonnet"),
+                selection("anthropic", "opus"),
+                selection("anthropic", "haiku")
+            ),
             selection("anthropic", "sonnet")
         )
-        XCTAssertEqual(ChatModel.effective(nil, selection("anthropic", "opus")), selection("anthropic", "opus"))
-        XCTAssertNil(ChatModel.effective(nil, nil))
+        XCTAssertEqual(
+            ChatModel.effective(nil, selection("anthropic", "opus"), selection("anthropic", "haiku")),
+            selection("anthropic", "opus")
+        )
+        XCTAssertEqual(
+            ChatModel.effective(nil, nil, selection("anthropic", "haiku")),
+            selection("anthropic", "haiku")
+        )
+        XCTAssertNil(ChatModel.effective(nil, nil, nil))
     }
 
     // MARK: - ChatModel.activeModel + label
 
-    func testActiveModelResolvesOverrideThenDefaultThenNil() {
+    func testActiveModelResolvesOverrideThenDefaultsThenNil() {
         let models = [model("anthropic", "sonnet"), model("anthropic", "opus")]
         XCTAssertEqual(
-            ChatModel.activeModel(models, override: selection("anthropic", "sonnet"), default: selection("anthropic", "opus"))?.id,
+            ChatModel.activeModel(models, override: selection("anthropic", "sonnet"), configuration: selection("anthropic", "opus"), provider: selection("anthropic", "haiku"))?.id,
             "sonnet"
         )
         XCTAssertEqual(
-            ChatModel.activeModel(models, override: nil, default: selection("anthropic", "opus"))?.id,
+            ChatModel.activeModel(models, override: nil, configuration: selection("anthropic", "opus"), provider: selection("anthropic", "haiku"))?.id,
             "opus"
         )
-        XCTAssertEqual(ChatModel.activeModel(models, override: nil, default: selection("other", "x"))?.id, nil)
-        XCTAssertEqual(ChatModel.activeModel(models, override: nil, default: nil), nil)
+        XCTAssertEqual(
+            ChatModel.activeModel(models, override: nil, configuration: nil, provider: selection("anthropic", "opus"))?.id,
+            "opus"
+        )
+        XCTAssertEqual(ChatModel.activeModel(models, override: nil, configuration: selection("other", "x"), provider: nil)?.id, nil)
+        XCTAssertEqual(ChatModel.activeModel(models, override: nil, configuration: nil, provider: nil), nil)
     }
 
     func testLabelUsesFriendlyNameAndDefaults() {
         let models = [model("anthropic", "sonnet", name: "Claude Sonnet 4.6")]
-        XCTAssertEqual(ChatModel.label(models, override: selection("anthropic", "sonnet"), default: nil), "Claude Sonnet 4.6")
-        XCTAssertEqual(ChatModel.label(models, override: nil, default: nil), "Default")
+        XCTAssertEqual(
+            ChatModel.label(models, override: selection("anthropic", "sonnet"), configuration: nil, provider: nil),
+            "Claude Sonnet 4.6"
+        )
+        XCTAssertEqual(ChatModel.label(models, override: nil, configuration: nil, provider: nil), "Default")
     }
 
     // MARK: - ChatModel.findByQuery
@@ -88,10 +106,32 @@ final class ComposerTests: XCTestCase {
     // MARK: - ChatModel.encode/decode
 
     func testOverrideEncodeDecodeRoundTrip() {
-        let id = selection("anthropic", "claude-sonnet-4-6")
-        XCTAssertEqual(ChatModel.decode(ChatModel.encode(id)), id)
+        let selection = ChatModel.ModelSelection(
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            variant: nil
+        )
+        XCTAssertEqual(ChatModel.decode(ChatModel.encode(selection)), selection)
         XCTAssertNil(ChatModel.decode(""))
         XCTAssertNil(ChatModel.decode("no-slash"))
+    }
+
+    func testOverrideEncodeOmitsNilVariant() {
+        let withVariant = ChatModel.ModelSelection(
+            providerID: "anthropic",
+            modelID: "claude-sonnet-4-6",
+            variant: "high"
+        )
+        let encoded = ChatModel.encode(withVariant)
+        XCTAssertTrue(encoded.contains("\"variant\":\"high\""))
+        XCTAssertEqual(ChatModel.decode(encoded)?.variant, "high")
+        // A nil variant is omitted (never "null"), matching the desktop JSON.
+        XCTAssertFalse(ChatModel.encode(ChatModel.ModelSelection(
+            providerID: "anthropic", modelID: "claude-sonnet-4-6", variant: nil
+        )).contains("variant"))
+        XCTAssertFalse(ChatModel.encode(ChatModel.ModelSelection(
+            providerID: "anthropic", modelID: "claude-sonnet-4-6", variant: nil
+        )).contains("null"))
     }
 
     // MARK: - Fast-mode helpers + grouped picker

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -443,12 +443,12 @@ final class ModelRecentsTests: XCTestCase {
 }
 
 // ===========================================================================
-// BET-1025 — ChatModelStore per-mode model keys. Plan and build are remembered
-// separately (desktop: `manta:chat:<sid>:model` / `…:model:plan`), plan falls
-// back to build when its own key is absent, build never falls back to plan, and
-// toggling modes restores each mode's remembered model with no cross-
-// contamination. The literal key strings are assertions, because cross-client
-// compatibility depends on them matching the desktop's keys byte-for-byte.
+// BET-1280 — ChatModelStore single per-session model: ONE key
+// (`manta:chat:<sid>:model`) holding the whole JSON selection (model + effort),
+// byte-identical in name and shape to the desktop's ModelSelection
+// (src/renderer/chatShared.tsx). Plan mode never changes the model. The literal
+// key string is an assertion because cross-client compatibility depends on it
+// matching the desktop's key byte-for-byte.
 // ===========================================================================
 
 @MainActor
@@ -456,14 +456,13 @@ final class ChatModelStoreKeyTests: XCTestCase {
 
     private let sid = "test-session"
     private let otherSid = "test-session-2"
-    private var buildKey: String { ChatModelStore.storageKey(for: sid, mode: .build) }
-    private var planKey: String { ChatModelStore.storageKey(for: sid, mode: .plan) }
-    private var otherBuildKey: String { ChatModelStore.storageKey(for: otherSid, mode: .build) }
-    private var otherPlanKey: String { ChatModelStore.storageKey(for: otherSid, mode: .plan) }
+    private var modelKey: String { ChatModelStore.storageKey(for: sid) }
+    private var otherModelKey: String { ChatModelStore.storageKey(for: otherSid) }
+    private var legacyPlanKey: String { "manta:chat:\(sid):model:plan" }
     private var workingKeys: [String] {
-        [buildKey, planKey, otherBuildKey, otherPlanKey,
-         ChatModelStore.planKey(for: sid), ChatModelStore.variantKey(for: sid),
-         ChatModelStore.planKey(for: otherSid), ChatModelStore.variantKey(for: otherSid)]
+        [modelKey, otherModelKey,
+         ChatModelStore.planKey(for: sid), ChatModelStore.planKey(for: otherSid),
+         legacyPlanKey]
     }
 
     override func setUp() {
@@ -484,87 +483,95 @@ final class ChatModelStoreKeyTests: XCTestCase {
         OpencodeModelID(providerID: "anthropic", modelID: m)
     }
 
-    // MARK: - Literal key strings (cross-client compatibility)
-
-    func testStorageKeyLiteralStrings() {
-        XCTAssertEqual(ChatModelStore.storageKey(for: "S", mode: .build), "manta:chat:S:model")
-        XCTAssertEqual(ChatModelStore.storageKey(for: "S", mode: .plan), "manta:chat:S:model:plan")
+    private func selection(_ m: String, variant: String? = nil) -> ChatModel.ModelSelection {
+        ChatModel.ModelSelection(providerID: "anthropic", modelID: m, variant: variant)
     }
 
-    // MARK: - Read with fallback
+    // MARK: - Literal key string (cross-client compatibility)
 
-    func testPlanReadWithPlanValueStoredReturnsIt() {
-        UserDefaults.standard.set(ChatModel.encode(model("plan-model")), forKey: planKey)
-        UserDefaults.standard.set(ChatModel.encode(model("build-model")), forKey: buildKey)
-        XCTAssertEqual(ChatModelStore.loadOverride(for: sid, mode: .plan), model("plan-model"))
+    func testStorageKeyLiteralString() {
+        XCTAssertEqual(ChatModelStore.storageKey(for: "S"), "manta:chat:S:model")
     }
 
-    func testPlanReadWithOnlyBuildValueReturnsBuild() {
-        UserDefaults.standard.set(ChatModel.encode(model("build-model")), forKey: buildKey)
-        XCTAssertEqual(ChatModelStore.loadOverride(for: sid, mode: .plan), model("build-model"))
+    // MARK: - Read
+
+    func testReadWithSelectionStoredReturnsIt() {
+        UserDefaults.standard.set(ChatModel.encode(selection("sonnet", variant: "high")), forKey: modelKey)
+        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet", variant: "high"))
+        XCTAssertEqual(ChatModelStore.loadOverride(for: sid), model("sonnet"))
     }
 
-    func testBuildReadWithOnlyPlanValueReturnsNil() {
-        UserDefaults.standard.set(ChatModel.encode(model("plan-model")), forKey: planKey)
-        XCTAssertNil(ChatModelStore.loadOverride(for: sid, mode: .build))
+    func testReadWithNothingStoredReturnsNil() {
+        XCTAssertNil(ChatModelStore.loadSelection(for: sid))
+        XCTAssertNil(ChatModelStore.loadOverride(for: sid))
     }
 
-    func testPlanReadWithNothingStoredReturnsNil() {
-        XCTAssertNil(ChatModelStore.loadOverride(for: sid, mode: .plan))
-        XCTAssertNil(ChatModelStore.loadOverride(for: sid, mode: .build))
+    // MARK: - setOverride drops the variant; setVariant folds it into the blob
+
+    func testSetOverrideDropsVariant() {
+        let s = store(sid)
+        s.setOverride(model("sonnet"))
+        s.setVariant("high")
+        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet", variant: "high"))
+
+        s.setOverride(model("opus"))                        // model changed → variant cleared
+        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("opus"))
+        XCTAssertEqual(s.variant, nil)
     }
 
-    // MARK: - rebind copies BOTH keys, leaves the old ones alone
+    func testSetOverrideNilRemovesKey() {
+        let s = store(sid)
+        s.setOverride(model("sonnet"))
+        XCTAssertNotNil(UserDefaults.standard.string(forKey: modelKey))
+        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet"))
+        s.setOverride(nil)
+        XCTAssertNil(UserDefaults.standard.string(forKey: modelKey))
+        XCTAssertEqual(s.override, nil)
+    }
 
-    func testRebindCopiesBothKeysAndLeavesOldAlone() {
-        UserDefaults.standard.set(ChatModel.encode(model("build-model")), forKey: buildKey)
-        UserDefaults.standard.set(ChatModel.encode(model("plan-model")), forKey: planKey)
+    // MARK: - rebind copies the ONE key verbatim, leaves the old one alone
+
+    func testRebindCopiesTheSingleKeyAndLeavesOldAlone() {
+        UserDefaults.standard.set(ChatModel.encode(selection("sonnet", variant: "high")), forKey: modelKey)
         store(sid).rebind(to: otherSid)
 
-        XCTAssertEqual(UserDefaults.standard.string(forKey: otherBuildKey), ChatModel.encode(model("build-model")))
-        XCTAssertEqual(UserDefaults.standard.string(forKey: otherPlanKey), ChatModel.encode(model("plan-model")))
-        // The source session's keys are untouched.
-        XCTAssertEqual(UserDefaults.standard.string(forKey: buildKey), ChatModel.encode(model("build-model")))
-        XCTAssertEqual(UserDefaults.standard.string(forKey: planKey), ChatModel.encode(model("plan-model")))
+        // rebind copies the RAW stored value verbatim.
+        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), UserDefaults.standard.string(forKey: otherModelKey))
+        XCTAssertEqual(ChatModelStore.loadSelection(for: otherSid), selection("sonnet", variant: "high"))
+        // The source session's key is untouched.
+        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet", variant: "high"))
     }
 
-    func testRebindLeavesAbsentPlanKeyAbsentOnDestination() {
-        // Only a build model stored — the destination must NOT get a plan key
-        // stamped with the build fallback (that would "activate" plan mode).
-        UserDefaults.standard.set(ChatModel.encode(model("build-model")), forKey: buildKey)
+    func testRebindWithNothingStoredLeavesDestinationAbsent() {
         store(sid).rebind(to: otherSid)
-
-        XCTAssertEqual(UserDefaults.standard.string(forKey: otherBuildKey), ChatModel.encode(model("build-model")))
-        XCTAssertNil(UserDefaults.standard.string(forKey: otherPlanKey))
+        XCTAssertNil(UserDefaults.standard.string(forKey: otherModelKey))
     }
 
-    // MARK: - Mode toggle restores each mode's model (no cross-contamination)
+    // MARK: - Plan mode never changes the model
 
-    func testTogglePlanTwiceReturnsOriginalModel() {
+    func testTogglePlanDoesNotChangeTheModel() {
         let s = store(sid)
 
-        s.setOverride(model("build-a"))                    // pick A in build mode
-        XCTAssertEqual(UserDefaults.standard.string(forKey: buildKey), ChatModel.encode(model("build-a")))
-        XCTAssertEqual(s.override, model("build-a"))
+        s.setOverride(model("sonnet"))
+        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet"))
+        XCTAssertEqual(s.override, model("sonnet"))
 
-        s.setPlan(true)                                    // plan on — plan key absent, falls back to build-a
-        XCTAssertEqual(s.override, model("build-a"))
+        s.setPlan(true)
+        XCTAssertEqual(s.override, model("sonnet"))
 
-        s.setOverride(model("plan-b"))                     // pick B in plan mode
-        XCTAssertEqual(UserDefaults.standard.string(forKey: planKey), ChatModel.encode(model("plan-b")))
-        XCTAssertEqual(s.override, model("plan-b"))
-
-        s.setPlan(false)                                   // plan off — build key holds A again
-        XCTAssertEqual(s.override, model("build-a"))
-
-        s.setPlan(true)                                    // plan on again — plan key holds B
-        XCTAssertEqual(s.override, model("plan-b"))
+        s.setPlan(false)
+        XCTAssertEqual(s.override, model("sonnet"))
+        // One key, one value throughout — no per-mode key appears.
+        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet"))
+        XCTAssertNil(UserDefaults.standard.string(forKey: otherModelKey))
+        XCTAssertNil(UserDefaults.standard.string(forKey: legacyPlanKey))
     }
 
-    func testModeDoesNotWriteWhenValueUnchanged() {
-        let s = store(sid)
-        s.setPlan(false)                                   // already build — no re-read, no write
-        XCTAssertNil(UserDefaults.standard.string(forKey: buildKey))
-        XCTAssertNil(UserDefaults.standard.string(forKey: planKey))
+    // MARK: - Legacy plan-key cleanup
+
+    func testFirstReadDeletesLegacyPlanKey() {
+        UserDefaults.standard.set(ChatModel.encode(selection("plan-model")), forKey: legacyPlanKey)
+        _ = store(sid)                                       // constructing the store is the first read
+        XCTAssertNil(UserDefaults.standard.string(forKey: legacyPlanKey))
     }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-1280-ios-one-model-per-session`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1280.