### PR TITLE
feat(ios): box-backed model prefs + recents, drop UserDefaults copies (BET-1282)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -45,6 +45,7 @@
 		5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */; };
 		5E0226E9FAFF3F9CA9F45F8F /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E78B0F5B521937B40937DC /* SettingsScreen.swift */; };
 		5F85B39269B52E1E816CBA1B /* SettingsSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988B5D51F20F0D3BC838E083 /* SettingsSchema.swift */; };
+		60032A2E2E4DD0810F2C79FE /* PendingPrompt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39FCF0EB1ADCD186680EB69C /* PendingPrompt.swift */; };
 		61062DC85A5139A0AB22BC24 /* TerminalSocket.swift in Sources */ = {isa = PBXBuildFile; fileRef = F88D3B9B782BF819EEBEBF1D /* TerminalSocket.swift */; };
 		6115C3531A59C0517C8C214A /* VoiceNote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1ED9F61E845DE68677AFEFF2 /* VoiceNote.swift */; };
 		612658EEF8599BDB18369375 /* MantaAPIClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17D174288A1A6C72E64B9079 /* MantaAPIClient.swift */; };
@@ -54,12 +55,14 @@
 		67A2877890E8B008335AD7C0 /* KeychainCredentialStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */; };
 		685261838F0EFABC1AB8B6B1 /* MantaPairingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */; };
 		68760CC316BA947A82F360EE /* Scrim.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0C440016971186430E8C464B /* Scrim.swift */; };
+		68E78394110C12145674525B /* ChatModelPrefs.swift in Sources */ = {isa = PBXBuildFile; fileRef = F23DFA2A87BE93D8DF5472DF /* ChatModelPrefs.swift */; };
 		6A720AF41BDA6F4FC40A5585 /* ChatModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4F7631E09B6FF7B150392A83 /* ChatModels.swift */; };
 		6AA12AFE81F85477EBFB3D25 /* MantaTranscriptGestureUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7442EBB8ACC827C69BDD2B6E /* MantaTranscriptGestureUITests.swift */; };
 		708332CA7D72971C6626C9FC /* MantaVoiceRecordingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 59B1B02BB0060065B306394F /* MantaVoiceRecordingUITests.swift */; };
 		74D756D48A7D2A5483170A8B /* MantaLoader.swift in Sources */ = {isa = PBXBuildFile; fileRef = 872DDE9D9BAD041950DAC24A /* MantaLoader.swift */; };
 		754FEC92229B58783D516DC4 /* ModelPickerSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = A2C97C92B5E1ADA62F799D73 /* ModelPickerSheet.swift */; };
 		75B97ECFE219AB9C7D45EDE3 /* Waveform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D7B1F4E5EF7E0ADD2238839 /* Waveform.swift */; };
+		7967215C9DD0A4EC1C08AC58 /* PendingPromptStoreTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DF38AC221EA0109EB55EFF76 /* PendingPromptStoreTests.swift */; };
 		7C41CAE9FE6D1E06DEC10142 /* MantaResourceCardModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EBC7D0BF807861DCCABC5A26 /* MantaResourceCardModelsTests.swift */; };
 		7E8C2A70A3D5C0F949D79FF5 /* SessionModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 28250B8DDAB996449F7AE3AD /* SessionModels.swift */; };
 		863035B4DE4C873A0BD9D0F5 /* MantaAuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */; };
@@ -168,6 +171,7 @@
 		38864A574D6CE5142E07B487 /* ModelRecentsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelRecentsTests.swift; sourceTree = "<group>"; };
 		39978655A14BFA5D39336286 /* MantaSettingsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsModels.swift; sourceTree = "<group>"; };
 		39B5E0C86E9FA4A10239DBFA /* DeprecatedModelOptInsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedModelOptInsTests.swift; sourceTree = "<group>"; };
+		39FCF0EB1ADCD186680EB69C /* PendingPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPrompt.swift; sourceTree = "<group>"; };
 		4098461F579869804595B0A3 /* ChatModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModelCatalog.swift; sourceTree = "<group>"; };
 		436675A65BF149932C1EADE0 /* ChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreen.swift; sourceTree = "<group>"; };
 		4603364B1845FF6C330EB601 /* ChatOverflowCaptureScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOverflowCaptureScene.swift; sourceTree = "<group>"; };
@@ -248,6 +252,7 @@
 		DAD2C923C52DE07EB54AB821 /* ToolOutputPreviewTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolOutputPreviewTests.swift; sourceTree = "<group>"; };
 		DC240598BDE45C3D43B46191 /* MantaUI.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = MantaUI.entitlements; sourceTree = "<group>"; };
 		DD646A4951E292E750890CCB /* MantaAppRoot.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaAppRoot.swift; sourceTree = "<group>"; };
+		DF38AC221EA0109EB55EFF76 /* PendingPromptStoreTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPromptStoreTests.swift; sourceTree = "<group>"; };
 		E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatLoadingSkeleton.swift; sourceTree = "<group>"; };
 		E246039C1A3AA38065BE89B0 /* ChatJSON.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatJSON.swift; sourceTree = "<group>"; };
 		E4A5AE775D3F3D82FC69A54F /* VoiceGestureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceGestureTests.swift; sourceTree = "<group>"; };
@@ -257,6 +262,7 @@
 		ED6ABAA46F1CBD2093D4AC87 /* ComposerTypeahead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTypeahead.swift; sourceTree = "<group>"; };
 		EE0504A23AC9360042B3D51B /* ChatStreamMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamMergeTests.swift; sourceTree = "<group>"; };
 		EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStreamTests.swift; sourceTree = "<group>"; };
+		F23DFA2A87BE93D8DF5472DF /* ChatModelPrefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModelPrefs.swift; sourceTree = "<group>"; };
 		F88D3B9B782BF819EEBEBF1D /* TerminalSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSocket.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -321,6 +327,7 @@
 				9BF85CE7BB8B25AABF039BC5 /* MantaTransportTests.swift */,
 				1F2DD310976F1DDDA947FDA1 /* MantaUITests.entitlements */,
 				38864A574D6CE5142E07B487 /* ModelRecentsTests.swift */,
+				DF38AC221EA0109EB55EFF76 /* PendingPromptStoreTests.swift */,
 				BEBD86C54D5730F24D2E956E /* PlanDerivationTests.swift */,
 				B82B782F73475FDD71F6D6B5 /* PolishTests.swift */,
 				9803742B79E4302F8813EFCC /* SessionModelsTests.swift */,
@@ -371,6 +378,7 @@
 				E0733CF7BEEE1C7B517C4010 /* ChatLoadingSkeleton.swift */,
 				229392FD3405558D301D0809 /* ChatModel.swift */,
 				4098461F579869804595B0A3 /* ChatModelCatalog.swift */,
+				F23DFA2A87BE93D8DF5472DF /* ChatModelPrefs.swift */,
 				4F7631E09B6FF7B150392A83 /* ChatModels.swift */,
 				8A6472C0BC3BDACAC4559198 /* ChatModelStore.swift */,
 				4603364B1845FF6C330EB601 /* ChatOverflowCaptureScene.swift */,
@@ -408,6 +416,7 @@
 				9DD6CA51FD8B7CE80314E0CD /* ModelRecents.swift */,
 				C1D7B8DB3BFDE6329FED7D5F /* MultilineTextView.swift */,
 				4EA1F1EEE75DBB6A786FEE4F /* NativeActionSheet.swift */,
+				39FCF0EB1ADCD186680EB69C /* PendingPrompt.swift */,
 				7190EEBC7A7233EE21FE264A /* PlanDerivation.swift */,
 				A4E84DF65831DE58599C53BD /* RootView.swift */,
 				6BA4ADBB2FD5BAC7940D5B69 /* RunningIndicator.swift */,
@@ -662,6 +671,7 @@
 				8A6656EBBD6AEC1B5CE7D0D6 /* MantaSettingsTests.swift in Sources */,
 				B5B62843F8D5814E0E5CEA40 /* MantaTransportTests.swift in Sources */,
 				CFE1B93882BD2EAF2A8B80BB /* ModelRecentsTests.swift in Sources */,
+				7967215C9DD0A4EC1C08AC58 /* PendingPromptStoreTests.swift in Sources */,
 				E631BDFC8B6DF9D3E602DE22 /* PlanDerivationTests.swift in Sources */,
 				E8B921F11FB02F147C910B32 /* PolishTests.swift in Sources */,
 				E013C537E1082259B979DF35 /* SessionModelsTests.swift in Sources */,
@@ -683,6 +693,7 @@
 				959894A87F301CC717772BD3 /* ChatLoadingSkeleton.swift in Sources */,
 				D776E336456236DC1493565F /* ChatModel.swift in Sources */,
 				E394FF8B718A3D7871EC749C /* ChatModelCatalog.swift in Sources */,
+				68E78394110C12145674525B /* ChatModelPrefs.swift in Sources */,
 				CC6A77686B936B4DB6026466 /* ChatModelStore.swift in Sources */,
 				6A720AF41BDA6F4FC40A5585 /* ChatModels.swift in Sources */,
 				9E9F0CED519AB1DF30516047 /* ChatOverflowCaptureScene.swift in Sources */,
@@ -717,6 +728,7 @@
 				E128F0443F5F8B3AF051667A /* ModelRecents.swift in Sources */,
 				5CDC4D3B2FD207C5E38A9AA1 /* MultilineTextView.swift in Sources */,
 				2D0521ED1C9A66C89711D31F /* NativeActionSheet.swift in Sources */,
+				60032A2E2E4DD0810F2C79FE /* PendingPrompt.swift in Sources */,
 				868536356F9E71119E51F8B7 /* PlanDerivation.swift in Sources */,
 				9CF891D747797006729FDBD3 /* RootView.swift in Sources */,
 				F30211F79048035CE5520266 /* RunningIndicator.swift in Sources */,
@@ -826,7 +838,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.17;
+				MARKETING_VERSION = 1.0.18;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;
@@ -933,7 +945,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.17;
+				MARKETING_VERSION = 1.0.18;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;

--- a/mobile/native/MantaUI/ChatModelPrefs.swift
+++ b/mobile/native/MantaUI/ChatModelPrefs.swift
@@ -1,0 +1,213 @@
+import Foundation
+import Combine
+
+// ===========================================================================
+// BET-1282 — box-wide model-prefs cache.
+//
+// The per-conversation model choice + the model recents used to live in
+// UserDefaults, so they never left the phone. They now live in the box store
+// (~/.manta/model-prefs.json, src/server/modelPrefs.mjs, BET-1279) so the
+// same conversation opened on another device shows the same choice, and a
+// reinstall doesn't lose the recents.
+//
+// This cache is the SINGLE iOS mirror of that store — one `model-prefs:get`
+// for the whole box, refetched on the `model-prefs.updated` bus event, exactly
+// like `ChatModelCatalog` mirrors the model list. `ChatModelStore` is the ONE
+// place the UI mutates the selection; views never talk to this cache directly.
+//
+// The wire rule pinned by MantaActionRPCWireTests also holds here: every
+// mutating channel sends its payload as a SINGLE element (`args: [dict]`),
+// never `args: [[dict]]` — see MantaAPIClient.modelPrefsSet/Seed.
+//
+// NOT the migration: `migrateIfNeeded()` at the bottom scavenges the old
+// UserDefaults values into the box exactly once after an upgrade.
+// ===========================================================================
+
+/// The box's whole model-prefs store (`model-prefs:get` reply): per-session
+/// selections + the model recents list. `recents` reuses `ModelChoice`, whose
+/// `{ providerID, modelID, variant?, fast }` shape is byte-identical to the
+/// box's `recents[]` entry.
+struct ModelPrefsState: Decodable {
+    var sessions: [String: ModelPrefsSessionRecord]
+    var recents: [ModelChoice]
+}
+
+/// One per-session record from the box store — `{ providerID, modelID,
+/// variant?, updatedAt }`. `updatedAt` is present on the wire but unused here.
+struct ModelPrefsSessionRecord: Decodable {
+    var providerID: String
+    var modelID: String
+    var variant: String?
+}
+
+/// A selection sent TO the box (`model-prefs:set` / `:seed`):
+/// `{ providerID, modelID, variant? }`, with `variant` omitted when nil.
+/// Distinct from the on-disk record (no `updatedAt`) and from a recent (no
+/// `fast` flag) — a session record has no fast field; fast is the `-fast`
+/// modelID suffix (BET-1279 rule).
+struct ModelPrefsSelection: Encodable {
+    var providerID: String
+    var modelID: String
+    var variant: String?
+}
+
+@MainActor
+final class ChatModelPrefs: ObservableObject {
+
+    /// The per-session selections known to the box (key = session id).
+    @Published private(set) var sessions: [String: ChatModel.ModelSelection] = [:]
+    /// The box's recent-model list, most recent first (capped at 5 box-side).
+    @Published private(set) var recents: [ModelChoice] = []
+
+    static let shared = ChatModelPrefs()
+
+    private let api: MantaAPIClient
+    private var didStart = false
+    private var didSubscribe = false
+
+    init(api: MantaAPIClient = .live()) {
+        self.api = api
+    }
+
+    /// The box selection for a session, or nil (the server default applies).
+    func selection(for sessionId: String) -> ChatModel.ModelSelection? {
+        sessions[sessionId]
+    }
+
+    /// Fetch the whole box store once and subscribe to `model-prefs.updated`.
+    /// Idempotent; safe to call on every paired launch and after a re-pair.
+    func startIfNeeded() {
+        guard !didStart else { return }
+        didStart = true
+        load()
+    }
+
+    /// Register for the box's `model-prefs.updated` bus event (single
+    /// subscription). `model-prefs.updated` is neither `stream` nor
+    /// `runningSet`, so it already arrives via the event store's raw-frame
+    /// multicast; a change on another device refetches the whole store. No
+    /// first-class routing — exactly one listener, one refetch.
+    func subscribe(to eventStore: MantaEventStore) {
+        guard !didSubscribe else { return }
+        didSubscribe = true
+        eventStore.addRawFrameHandler { [weak self] frame in
+            guard frame.kind == "model-prefs.updated" else { return }
+            self?.load()
+        }
+    }
+
+    /// Refetch the whole box store. A client refetching its own write is a
+    /// harmless no-op — deliberately NO echo suppression, sequence numbers, or
+    /// write lock (BET-1282 write rule).
+    func load() {
+        Task {
+            let state = try? await api.modelPrefsGet()
+            await MainActor.run {
+                guard let state else { return }
+                sessions = state.sessions.mapValues {
+                    ChatModel.ModelSelection(providerID: $0.providerID, modelID: $0.modelID, variant: $0.variant)
+                }
+                recents = state.recents
+            }
+        }
+    }
+
+    // MARK: - Write path (the single writer is ChatModelStore)
+
+    /// Persist (or clear, with nil) a session's selection — update local state
+    /// immediately AND write the box. Fire-and-forget; see the write rule.
+    func setSession(_ selection: ChatModel.ModelSelection?, for sessionId: String) {
+        if let selection {
+            sessions[sessionId] = selection
+        } else {
+            sessions.removeValue(forKey: sessionId)
+        }
+        let box = selection.map { ModelPrefsSelection(providerID: $0.providerID, modelID: $0.modelID, variant: $0.variant) }
+        Task {
+            try? await api.modelPrefsSet(sessionId: sessionId, selection: box, recents: nil)
+        }
+    }
+
+    /// Replace the box recents. The CLIENT owns ordering + dedupe
+    /// (`ModelRecents.record`, cap-at-5 + whole-quad dedupe stay client-side);
+    /// the server stores what it is given, truncated to 5.
+    func setRecents(_ list: [ModelChoice]) {
+        recents = list
+        Task {
+            try? await api.modelPrefsSet(sessionId: nil, selection: nil, recents: list)
+        }
+    }
+
+    /// One-shot migration write: seed sessions + recents without overwriting
+    /// anything already in the box (non-destructive by the server contract).
+    func seed(sessions: [String: ChatModel.ModelSelection], recents: [ModelChoice]) {
+        let boxSessions = sessions.mapValues {
+            ModelPrefsSelection(providerID: $0.providerID, modelID: $0.modelID, variant: $0.variant)
+        }
+        Task {
+            try? await api.modelPrefsSeed(sessions: boxSessions, recents: recents)
+        }
+    }
+}
+
+// MARK: - One-shot migration (BET-1282 step 5)
+
+extension ChatModelPrefs {
+    /// The flag that marks the one-shot migration done.
+    static let migrationFlagKey = "manta:model-prefs:migrated"
+    /// The legacy per-session model key prefix/suffix (UserDefaults,
+    /// pre-BET-1282), mirroring the desktop's old `manta:chat:<sid>:model`.
+    static let legacyModelKeyPrefix = "manta:chat:"
+    static let legacyModelKeySuffix = ":model"
+    /// The legacy recents key (UserDefaults, pre-BET-1282).
+    static let legacyRecentsKey = "manta:model-recents"
+
+    /// Pure scan of the legacy keys into the box seed payload + the keys to
+    /// remove. Injectable lookups (`stringForKey`/`dataForKey`) keep it
+    /// unit-testable; the real caller passes UserDefaults. Malformed values are
+    /// skipped — a broken value must never break the migration.
+    static func collectLegacy(
+        keys: [String],
+        stringForKey: (String) -> String?,
+        dataForKey: (String) -> Data?
+    ) -> (sessions: [String: ChatModel.ModelSelection], recents: [ModelChoice], keysToRemove: [String]) {
+        var sessions: [String: ChatModel.ModelSelection] = [:]
+        var keysToRemove: [String] = []
+        for key in keys where key.hasPrefix(legacyModelKeyPrefix) && key.hasSuffix(legacyModelKeySuffix) {
+            let sessionId = String(key.dropFirst(legacyModelKeyPrefix.count).dropLast(legacyModelKeySuffix.count))
+            guard !sessionId.isEmpty,
+                  let raw = stringForKey(key),
+                  let selection = ChatModel.decode(raw)
+            else { continue }
+            sessions[sessionId] = selection
+            keysToRemove.append(key)
+        }
+        var recents: [ModelChoice] = []
+        if let data = dataForKey(legacyRecentsKey),
+           let list = try? JSONDecoder().decode([ModelChoice].self, from: data) {
+            recents = list
+            keysToRemove.append(legacyRecentsKey)
+        }
+        return (sessions, recents, keysToRemove)
+    }
+
+    /// Run the one-shot migration on first launch after upgrade: scan legacy
+    /// `manta:chat:*:model` + `manta:model-recents`, seed them to the box via
+    /// `modelPrefsSeed`, remove the scanned keys, set the flag. Best-effort —
+    /// never throws or breaks boot. Does NOT touch `manta:chat:*:plan` (plan
+    /// mode is out of scope) nor `DeprecatedModelOptIns`.
+    static func migrateIfNeeded() {
+        let defaults = UserDefaults.standard
+        guard defaults.object(forKey: migrationFlagKey) == nil else { return }
+        let collected = collectLegacy(
+            keys: Array(defaults.dictionaryRepresentation().keys),
+            stringForKey: { defaults.string(forKey: $0) },
+            dataForKey: { defaults.data(forKey: $0) }
+        )
+        if !collected.sessions.isEmpty || !collected.recents.isEmpty {
+            ChatModelPrefs.shared.seed(sessions: collected.sessions, recents: collected.recents)
+        }
+        for key in collected.keysToRemove { defaults.removeObject(forKey: key) }
+        defaults.set(true, forKey: migrationFlagKey)
+    }
+}

--- a/mobile/native/MantaUI/ChatModelStore.swift
+++ b/mobile/native/MantaUI/ChatModelStore.swift
@@ -6,17 +6,23 @@ import Combine
 //
 // Owns the per-SESSION model selection (override + effort variant folded into
 // one JSON blob); the box-wide model list + defaults come from the shared
-// `ChatModelCatalog`, fetched once and mirrored here. The selection is a JSON
-// blob stored under ONE key per session, `manta:chat:<sessionId>:model`,
-// byte-identical in name and shape to the desktop's ModelSelection
-// (src/renderer/chatShared.tsx) — one model per session, plan mode never
-// changes the model.
+// `ChatModelCatalog`, fetched once and mirrored here.
+//
+// BET-1282: the selection is no longer stored in UserDefaults under a
+// per-session key — it now lives in the box store and is mirrored through the
+// shared `ChatModelPrefs` cache (one box-wide fetch, refetched on
+// `model-prefs.updated`), so the same conversation on another device shows the
+// same model and a reinstall keeps the choice. `ChatModelStore` remains the
+// SINGLE place the UI mutates the selection
+// (setOverride/setVariant/apply/setFast/recordCurrentChoice): those mutators
+// update local state immediately AND write the box through the cache — views
+// never talk to `ChatModelPrefs` directly.
 //
 // The catalog is why clearing a session does NOT reload models: the clear
 // rebuilds this store for the new session id, but the list is already loaded
 // and shared, so there is no second fetch. The selection is carried to the new
-// id by `rebind(to:)` (matching the desktop's clear handler, which copies the
-// override into the new session's key).
+// id by `rebind(to:)` — a single write through the box cache, matching the
+// desktop's clear handler which copies the override into the new session's key.
 // ===========================================================================
 
 @MainActor
@@ -37,8 +43,8 @@ final class ChatModelStore: ObservableObject {
     /// changes rather than carried onto a model that has no such setting.
     @Published private(set) var variant: String?
     /// The last 3–5 (model, effort, fast) triples actually used, most recent
-    /// first. Persisted PER BOX (a habit, not a conversation), unlike the
-    /// override/variant above which are per-session.
+    /// first. Persisted in the BOX store (a habit that follows the user across
+    /// devices — BET-1282), unlike the pre-upgrade device-local UserDefaults.
     @Published private(set) var recents: [ModelChoice] = []
     /// "providerID/modelID" keys of deprecated models the user has explicitly
     /// opted back in to (BET-1140). Per box (UserDefaults), like recents — not
@@ -58,17 +64,21 @@ final class ChatModelStore: ObservableObject {
 
     let sessionId: String
     private let catalog: ChatModelCatalog
+    private let prefs: ChatModelPrefs
     private let api: MantaAPIClient
     private var didLoadAgents = false
     private var cancellables: Set<AnyCancellable> = []
 
-    init(sessionId: String, api: MantaAPIClient, catalog: ChatModelCatalog = .shared) {
+    init(sessionId: String, api: MantaAPIClient, catalog: ChatModelCatalog = .shared, prefs: ChatModelPrefs = .shared) {
         self.sessionId = sessionId
         self.catalog = catalog
+        self.prefs = prefs
         self.api = api
         let planOn = UserDefaults.standard.bool(forKey: Self.planKey(for: sessionId))
         self.planOn = planOn
-        let stored = Self.loadSelection(for: sessionId)
+        // The per-session selection now comes from the box store (via the shared
+        // cache), not UserDefaults.
+        let stored = prefs.selection(for: sessionId)
         self.override = stored.map { OpencodeModelID(providerID: $0.providerID, modelID: $0.modelID) }
         self.variant = stored?.variant
         // Clean up the pre-BET-1280 per-mode plan key on first read of a
@@ -83,11 +93,18 @@ final class ChatModelStore: ObservableObject {
         self.defaultModel = catalog.defaultModel
         self.configDefault = catalog.configDefault
         self.loaded = catalog.loaded
-        self.recents = ModelRecents.load()
+        self.recents = prefs.recents
         self.deprecatedOptIns = DeprecatedModelOptIns.load()
         catalog.objectWillChange
             .receive(on: DispatchQueue.main)
             .sink { [weak self] _ in self?.mirrorCatalog() }
+            .store(in: &cancellables)
+        // Mirror the box prefs cache so a change — this device's write, or one
+        // that arrived from another device via `model-prefs.updated` — lands on
+        // the selection + recents.
+        prefs.objectWillChange
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in self?.mirrorPrefs() }
             .store(in: &cancellables)
     }
 
@@ -98,11 +115,11 @@ final class ChatModelStore: ObservableObject {
         loaded = catalog.loaded
     }
 
-    /// The UserDefaults key mirroring the desktop's per-session model key —
-    /// one key per session, holding the whole JSON selection (model + effort).
-    /// Mirrors the desktop key in src/renderer/chatShared.tsx byte-for-byte.
-    static func storageKey(for sessionId: String) -> String {
-        "manta:chat:\(sessionId):model"
+    private func mirrorPrefs() {
+        let stored = prefs.selection(for: sessionId)
+        override = stored.map { OpencodeModelID(providerID: $0.providerID, modelID: $0.modelID) }
+        variant = stored?.variant
+        recents = prefs.recents
     }
 
     /// The per-session plan-mode key (BET-952), a plain Bool — never folded
@@ -126,22 +143,14 @@ final class ChatModelStore: ObservableObject {
         }
     }
 
-    /// Carry the current override + variant to a NEW session id. Called just
-    /// before a clear swaps the id, so the rebuilt store for the new session
-    /// picks up the same model the user had chosen — matching the desktop,
-    /// which copies the override into the new session's key on /clear.
-    ///
-    /// The whole selection (model + variant) is one value under one key, so
-    /// the RAW stored JSON blob is copied. The old session's keys are left
-    /// alone.
+    /// Carry the current selection to a NEW session id. Called just before a
+    /// clear swaps the id, so the rebuilt store for the new session picks up
+    /// the same model the user had chosen — matching the desktop, which copies
+    /// the override into the new session's key on /clear. A SINGLE write
+    /// through the box cache; the old session's record is left alone.
     func rebind(to newSessionId: String) {
         guard newSessionId != sessionId else { return }
-        let defaults = UserDefaults.standard
-        let fromKey = Self.storageKey(for: sessionId)
-        let toKey = Self.storageKey(for: newSessionId)
-        if let raw = defaults.string(forKey: fromKey) {
-            defaults.set(raw, forKey: toKey)
-        }
+        prefs.setSession(prefs.selection(for: sessionId), for: newSessionId)
         if planOn {
             UserDefaults.standard.set(planOn, forKey: Self.planKey(for: newSessionId))
         }
@@ -160,22 +169,18 @@ final class ChatModelStore: ObservableObject {
     }
 
     /// Persist the whole current selection (override + variant) as one JSON
-    /// blob under the single per-session key. No override means the session has
-    /// no explicit model — remove the key (server default applies), mirroring
-    /// the desktop.
+    /// value under the session's box record. No override means the session has
+    /// no explicit model — clear the box record (server default applies),
+    /// mirroring the desktop.
     private func persistSelection() {
-        let defaults = UserDefaults.standard
-        let key = Self.storageKey(for: sessionId)
-        if let override {
-            let selection = ChatModel.ModelSelection(
-                providerID: override.providerID,
-                modelID: override.modelID,
+        let selection: ChatModel.ModelSelection? = override.map {
+            ChatModel.ModelSelection(
+                providerID: $0.providerID,
+                modelID: $0.modelID,
                 variant: variant
             )
-            defaults.set(ChatModel.encode(selection), forKey: key)
-        } else {
-            defaults.removeObject(forKey: key)
         }
+        prefs.setSession(selection, for: sessionId)
     }
 
     /// Set (or clear, with nil) the per-session override. A model change drops
@@ -220,13 +225,14 @@ final class ChatModelStore: ObservableObject {
 
     /// Apply a stored recent choice (base model id + effort + fast) to the
     /// override + variant, then move it to the front of recents. Selecting a
-    /// recent IS the act of using it, so it is recorded on apply.
+    /// recent IS the act of using it, so it is recorded on apply. The recents
+    /// list is written to the box via the shared cache.
     func apply(_ choice: ModelChoice) {
         let targetID = choice.fast ? ChatModel.fastModelID(choice.modelID) : choice.modelID
         setOverride(OpencodeModelID(providerID: choice.providerID, modelID: targetID))
         setVariant(choice.variant)
         recents = ModelRecents.record(choice, into: recents)
-        ModelRecents.save(recents)
+        prefs.setRecents(recents)
     }
 
     /// Record the current effective (model, effort, fast) as a recent — called
@@ -247,7 +253,7 @@ final class ChatModelStore: ObservableObject {
             fast: ChatModel.isFastModelID(active.id)
         )
         recents = ModelRecents.record(choice, into: recents)
-        ModelRecents.save(recents)
+        prefs.setRecents(recents)
     }
 
     /// Flip fast mode on the active model, carrying the current effort across
@@ -290,20 +296,5 @@ final class ChatModelStore: ObservableObject {
     func setPlan(_ on: Bool) {
         planOn = on
         UserDefaults.standard.set(on, forKey: Self.planKey(for: sessionId))
-    }
-
-    /// The remembered per-session selection, or nil when the session has none
-    /// (the server/box default applies).
-    static func loadSelection(for sessionId: String) -> ChatModel.ModelSelection? {
-        let key = storageKey(for: sessionId)
-        if let raw = UserDefaults.standard.string(forKey: key), let decoded = ChatModel.decode(raw) {
-            return decoded
-        }
-        return nil
-    }
-
-    /// The remembered per-session model id, or nil when the session has none.
-    static func loadOverride(for sessionId: String) -> OpencodeModelID? {
-        loadSelection(for: sessionId).map { OpencodeModelID(providerID: $0.providerID, modelID: $0.modelID) }
     }
 }

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -1091,7 +1091,9 @@ private struct ChatScreenContent: View {
     /// plan/build mode, falling back to the server default (the plan model is
     /// only ever the composer's active model while plan mode is on).
     private var buildModelName: String {
-        let buildID = ChatModelStore.loadOverride(for: store.sessionId)
+        let buildID = ChatModelPrefs.shared.selection(for: store.sessionId).map {
+            OpencodeModelID(providerID: $0.providerID, modelID: $0.modelID)
+        }
         return ChatModel.label(modelStore.models,
                                override: buildID,
                                configuration: modelStore.configDefault,

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -22,10 +22,10 @@ import UIKit
 // (S1a reply/reject RPCs). Parent and children are each their own store; a
 // child store is read-only (§8a v1).
 //
-// Deliberately does NOT touch the event store's single-owner `rawFrameHandler`
-// or `resyncHandler`; resync + attention are derived from the @Published stream
-// state and a connectionState transition instead, so the session list's
-// handlers (owned by SessionListStore) are never clobbered.
+// Deliberately does NOT touch the event store's raw-frame handlers
+// (`addRawFrameHandler`) or `resyncHandler`; resync + attention are derived
+// from the @Published stream state and a connectionState transition instead,
+// so the session list's + model-prefs' handlers are never clobbered.
 // ===========================================================================
 
 // ===========================================================================

--- a/mobile/native/MantaUI/MantaAPIClient.swift
+++ b/mobile/native/MantaUI/MantaAPIClient.swift
@@ -624,6 +624,48 @@ final class MantaAPIClient: Sendable {
         try await call("config:get", args: [], as: [String: JSONValue].self)
     }
 
+    // MARK: - Model prefs (BET-1282)
+
+    /// `model-prefs:get` — the whole box model-prefs store
+    /// (`{ sessions, recents }`), nil when the box doesn't answer. The per-session
+    /// selection + recents used to live in UserDefaults; they now live box-side
+    /// (`src/server/modelPrefs.mjs`, BET-1279) so they follow the user between
+    /// devices. This is the SINGLE read of that store on iOS — the shared
+    /// `ChatModelPrefs` cache fetches it once and refetches on the bus event.
+    func modelPrefsGet() async throws -> ModelPrefsState? {
+        try await call("model-prefs:get", args: [], as: ModelPrefsState.self)
+    }
+
+    /// `model-prefs:set` — mutate the box store. A call may carry a session
+    /// upsert/delete (via `selection`, where an explicit JSON `null` deletes
+    /// the session) and/or a `recents` replace. Mirrors the desktop
+    /// `modelPrefsSet` (`src/renderer/modelPrefs.ts`). Fire-and-forget from
+    /// `ChatModelPrefs`; a client refetching its own write is a harmless no-op.
+    func modelPrefsSet(sessionId: String?, selection: ModelPrefsSelection?, recents: [ModelChoice]?) async throws {
+        var payload: [String: Any] = [:]
+        if let sessionId { payload["sessionId"] = sessionId }
+        if let selection {
+            payload["selection"] = try jsonAny(selection)
+        } else if sessionId != nil {
+            // Explicit JSON null DELETES the session. The box's `{...i}` merge
+            // skips an ABSENT key, so a clear (nil selection) must send null,
+            // not omit the key — otherwise the box treats it as a recents-only call.
+            payload["selection"] = NSNull()
+        }
+        if let recents { payload["recents"] = try jsonAny(recents) }
+        _ = try await callVoid("model-prefs:set", args: [payload])
+    }
+
+    /// `model-prefs:seed` — one-shot, non-destructive migration write
+    /// (`{ sessions?, recents? }`). Used once after the box store ships to seed
+    /// the old device-local values; the server never overwrites an existing key.
+    func modelPrefsSeed(sessions: [String: ModelPrefsSelection], recents: [ModelChoice]) async throws {
+        var payload: [String: Any] = [:]
+        if !sessions.isEmpty { payload["sessions"] = try jsonAny(sessions) }
+        if !recents.isEmpty { payload["recents"] = try jsonAny(recents) }
+        _ = try await callVoid("model-prefs:seed", args: [payload])
+    }
+
     /// `POST /push/register-apns` — hand the APNs device token to the box
     /// (server mirror of the /rpc/push:register-apns channel; both call
     /// push.addApnsToken, see src/server/index.mjs). Fire-and-forget from the
@@ -717,12 +759,19 @@ final class MantaAPIClient: Sendable {
         return try Self.decode(data, as: VoidResult.self)
     }
 
+    /// Encode any `Encodable` to a JSON-compatible object or array (`Any`) for
+    /// an RPC payload. Unlike `jsonObject`, this does not require a top-level
+    /// dictionary, so arrays (e.g. `model-prefs:set` recents) encode too.
+    private func jsonAny(_ value: some Encodable) throws -> Any {
+        let data = try JSONEncoder().encode(value)
+        return try JSONSerialization.jsonObject(with: data)
+    }
+
     /// Encode an `Encodable` payload (e.g. `SecretInput`) back into the
     /// `[String: Any]` JSON-object shape the RPC transport serialises. Nil
     /// optional properties are omitted, matching the box's `{...i}` merge.
     private func jsonObject(_ value: some Encodable) throws -> [String: Any] {
-        let data = try JSONEncoder().encode(value)
-        guard let object = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+        guard let object = try jsonAny(value) as? [String: Any] else {
             throw MantaError.transport("payload is not a JSON object")
         }
         return object

--- a/mobile/native/MantaUI/MantaAppRoot.swift
+++ b/mobile/native/MantaUI/MantaAppRoot.swift
@@ -103,6 +103,7 @@ struct MantaAppRoot: View {
                             didFailStale = true
                             _ = PendingPromptStore.failStaleOnLaunch()
                         }
+                        startModelPrefs()
                         store.start()
                     }
                     .task { await sessionStore.refresh() }
@@ -176,9 +177,24 @@ struct MantaAppRoot: View {
                 sessionStore.resetForBoxChange()
             }
             paired = true
+            // Wire the box model-prefs mirror for the newly-paired box (also
+            // runs the one-shot migration of the old device-local keys). The
+            // session-list onAppear starts it again on a normal launch; both
+            // are idempotent, and subscribing before `start()` means no event
+            // can slip past the listener registration.
+            startModelPrefs()
             store.start()
             MantaPushService.registerAfterPairing()
         }
+    }
+
+    /// Fetch the box model-prefs store once, subscribe to its `updated` bus
+    /// event, and run the one-shot migration of the old UserDefaults keys.
+    /// Idempotent — safe to call on every paired launch and after a re-pair.
+    private func startModelPrefs() {
+        ChatModelPrefs.shared.subscribe(to: store)
+        ChatModelPrefs.shared.startIfNeeded()
+        ChatModelPrefs.migrateIfNeeded()
     }
 
     private var currentBoxHost: String {

--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -393,10 +393,18 @@ final class MantaEventStore: ObservableObject {
     /// questions.
     var resyncHandler: (() -> Void)?
 
-    /// Event frame we do NOT understand from the interpreted stream are still
-    /// delivered here (raw `opencode`, `status`, …) for consumers that want
-    /// them. S1b only binds to interpreted stream state.
-    var rawFrameHandler: ((MantaStreamFrame) -> Void)?
+    /// Event frames we do NOT understand from the interpreted stream are still
+    /// delivered here (raw `opencode`, `status`, `model-prefs.updated`, …) for
+    /// consumers that want them. S1b only binds to interpreted stream state.
+    /// A MULTICAST list rather than a single closure — `SessionListStore` and
+    /// the `ChatModelPrefs` cache each register once; a single-owner closure
+    /// would let the second clobber the first (BET-1282).
+    private var rawFrameHandlers: [(MantaStreamFrame) -> Void] = []
+
+    /// Register a raw (non-`stream`, non-`runningSet`) frame observer.
+    func addRawFrameHandler(_ handler: @escaping (MantaStreamFrame) -> Void) {
+        rawFrameHandlers.append(handler)
+    }
 
     private let controller: any MantaEventStreamControl
     private var lastFrameAt: Date
@@ -503,7 +511,7 @@ final class MantaEventStore: ObservableObject {
         } else if frame.kind == "stream" {
             routeStream(frame)
         } else {
-            rawFrameHandler?(frame)
+            for handler in rawFrameHandlers { handler(frame) }
         }
     }
 

--- a/mobile/native/MantaUI/ModelRecents.swift
+++ b/mobile/native/MantaUI/ModelRecents.swift
@@ -4,16 +4,17 @@ import Foundation
 // BET-825 — the composer model menu's recents: the last 3–5 (model, effort,
 // fast) triples actually used, most recent first.
 //
-// Recents are a HABIT, not a conversation, so they persist PER BOX under a
-// single UserDefaults key — deliberately NOT per session, unlike the model
-// override/variant (which live in ChatModelStore under per-session keys). The
-// store loads them once at init and writes them on every change.
+// Recents are a HABIT, not a conversation. BET-1282 moved their storage from a
+// single UserDefaults key into the box store (via `model-prefs:set { recents }`),
+// so they follow the user between devices and survive a reinstall. The PURE
+// logic here (`record` / `label`) is unchanged and stays client-side — the
+// CLIENT owns ordering + dedupe (cap-at-5 and whole-quad dedupe), and the box
+// stores what it is given.
 //
 // `modelID` in a choice is ALWAYS the base (non-`-fast`) id: fast is an
 // orthogonal mode bit, not a separate model, so the same model at the same
 // effort with fast off/on is a distinct entry. Dedup/ordering/cap logic is
-// pure (mirrors `BranchFreshnessPolicy` in ChatScreen.swift); persistence is a
-// thin pair of helpers beside it.
+// pure (mirrors `BranchFreshnessPolicy` in ChatScreen.swift).
 // ===========================================================================
 
 /// One remembered (model, effort, fast) selection, most recent first.
@@ -30,8 +31,6 @@ struct ModelChoice: Codable, Hashable, Sendable {
 enum ModelRecents {
     /// The recents list is capped at this many entries.
     static let capacity = 5
-    /// Per-box storage key (recents are a habit, not tied to one session).
-    static let storageKey = "manta:model-recents"
 
     /// Insert a choice at the front, de-duplicating on the WHOLE triple. A
     /// choice already in the list is moved to the front without duplicating;
@@ -56,20 +55,5 @@ enum ModelRecents {
         }
         if choice.fast { parts.append("⚡") }
         return parts.joined(separator: " · ")
-    }
-
-    // MARK: - Persistence (per box)
-
-    static func load(_ defaults: UserDefaults = .standard) -> [ModelChoice] {
-        guard let data = defaults.data(forKey: storageKey),
-              let list = try? JSONDecoder().decode([ModelChoice].self, from: data)
-        else { return [] }
-        return list
-    }
-
-    static func save(_ list: [ModelChoice], _ defaults: UserDefaults = .standard) {
-        if let data = try? JSONEncoder().encode(list) {
-            defaults.set(data, forKey: storageKey)
-        }
     }
 }

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -107,7 +107,7 @@ final class SessionListStore: ObservableObject {
         self.mutations = mutations ?? ServerSessionListMutations(api: api)
         self.eventStore = eventStore
         self.loadConfig()
-        self.eventStore.rawFrameHandler = { [weak self] frame in
+        self.eventStore.addRawFrameHandler { [weak self] frame in
             self?.trackAttention(frame: frame)
             self?.trackProgress(frame: frame)
         }

--- a/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
+++ b/mobile/native/MantaUITests/MantaActionRPCWireTests.swift
@@ -387,6 +387,93 @@ final class MantaActionRPCWireTests: XCTestCase {
             XCTAssertEqual(message, "not found")
         }
     }
+
+    // MARK: - model prefs (BET-1282)
+
+    /// `model-prefs:set` upsert: `args` is a SINGLE payload object carrying
+    /// `sessionId` + the `{providerID, modelID, variant}` selection — never
+    /// `args: [[dict]]`.
+    func testModelPrefsSetSingleWrapsAndCarriesSelection() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": null}"#
+        let sel = ModelPrefsSelection(providerID: "anthropic", modelID: "claude-sonnet-4-6", variant: "high")
+        try await client.modelPrefsSet(sessionId: "ses_1", selection: sel, recents: nil)
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/model-prefs:set")
+        assertSingleWrapped()
+        let payload = CapturingURLProtocol.lastPayload()
+        XCTAssertEqual(payload?["sessionId"] as? String, "ses_1")
+        let selection = payload?["selection"] as? [String: Any]
+        XCTAssertEqual(selection?["providerID"] as? String, "anthropic")
+        XCTAssertEqual(selection?["modelID"] as? String, "claude-sonnet-4-6")
+        XCTAssertEqual(selection?["variant"] as? String, "high")
+    }
+
+    /// Clearing a session's selection must send an EXPLICIT JSON `null`, not
+    /// omit the key — the box's `{...i}` merge skips an absent `selection`, so
+    /// omitting it would turn a delete into a recents-only no-op.
+    func testModelPrefsSetSendsNullSelectionToDelete() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": null}"#
+        try await client.modelPrefsSet(sessionId: "ses_1", selection: nil, recents: nil)
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/model-prefs:set")
+        let payload = CapturingURLProtocol.lastPayload()
+        XCTAssertTrue(payload?["selection"] is NSNull, "selection must be JSON null to delete the session")
+        XCTAssertEqual(payload?["sessionId"] as? String, "ses_1")
+    }
+
+    /// `model-prefs:set` recents: a `recents` array arrives as `{providerID,
+    /// modelID, variant?, fast}` — the `ModelChoice` wire shape, which the
+    /// box stores verbatim (BET-1279). A recents-only call omits `sessionId`.
+    func testModelPrefsSetCarriesRecents() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": null}"#
+        let choice = ModelChoice(providerID: "anthropic", modelID: "opus", variant: "high", fast: false)
+        try await client.modelPrefsSet(sessionId: nil, selection: nil, recents: [choice])
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/model-prefs:set")
+        let payload = CapturingURLProtocol.lastPayload()
+        XCTAssertNil(payload?["sessionId"])
+        XCTAssertNil(payload?["selection"])
+        let recents = payload?["recents"] as? [[String: Any]]
+        let first = recents?.first
+        XCTAssertEqual(first?["providerID"] as? String, "anthropic")
+        XCTAssertEqual(first?["modelID"] as? String, "opus")
+        XCTAssertEqual(first?["variant"] as? String, "high")
+        XCTAssertEqual(first?["fast"] as? Bool, false)
+    }
+
+    /// `model-prefs:seed` — the one-shot migration write, `args` a single
+    /// object carrying `sessions` (keyed by session id) + `recents`.
+    func testModelPrefsSeedSendsSessionsAndRecents() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": null}"#
+        let sel = ModelPrefsSelection(providerID: "anthropic", modelID: "opus", variant: nil)
+        let choice = ModelChoice(providerID: "anthropic", modelID: "opus", variant: nil, fast: false)
+        try await client.modelPrefsSeed(sessions: ["ses_1": sel], recents: [choice])
+        XCTAssertEqual(CapturingURLProtocol.cache.last?.url?.path, "/rpc/model-prefs:seed")
+        assertSingleWrapped()
+        let payload = CapturingURLProtocol.lastPayload()
+        let sessions = payload?["sessions"] as? [String: Any]
+        let session1 = sessions?["ses_1"] as? [String: Any]
+        XCTAssertEqual(session1?["providerID"] as? String, "anthropic")
+        XCTAssertEqual(session1?["modelID"] as? String, "opus")
+        XCTAssertNil(session1?["variant"])
+        XCTAssertNotNil(payload?["recents"])
+    }
+
+    /// `model-prefs:get` decodes the box's `{ sessions, recents }` reply — a
+    /// session record carries `updatedAt` (ignored here) and a recent carries
+    /// `fast`. The presence of unknown keys must not fail the decode.
+    func testModelPrefsGetDecodesState() async throws {
+        let client = makeClient()
+        CapturingURLProtocol.result = #"{"result": {"sessions": {"ses_1": {"providerID": "anthropic", "modelID": "opus", "variant": "high", "updatedAt": 1750000000000}}, "recents": [{"providerID": "anthropic", "modelID": "sonnet", "variant": null, "fast": false}]}}"#
+        let state = try await client.modelPrefsGet()
+        XCTAssertEqual(state?.sessions["ses_1"]?.providerID, "anthropic")
+        XCTAssertEqual(state?.sessions["ses_1"]?.modelID, "opus")
+        XCTAssertEqual(state?.sessions["ses_1"]?.variant, "high")
+        XCTAssertEqual(state?.recents.count, 1)
+        XCTAssertEqual(state?.recents.first?.modelID, "sonnet")
+        XCTAssertEqual(state?.recents.first?.fast, false)
+    }
 }
 
 // MARK: - Capturing URLProtocol

--- a/mobile/native/MantaUITests/ModelRecentsTests.swift
+++ b/mobile/native/MantaUITests/ModelRecentsTests.swift
@@ -443,12 +443,11 @@ final class ModelRecentsTests: XCTestCase {
 }
 
 // ===========================================================================
-// BET-1280 — ChatModelStore single per-session model: ONE key
-// (`manta:chat:<sid>:model`) holding the whole JSON selection (model + effort),
-// byte-identical in name and shape to the desktop's ModelSelection
-// (src/renderer/chatShared.tsx). Plan mode never changes the model. The literal
-// key string is an assertion because cross-client compatibility depends on it
-// matching the desktop's key byte-for-byte.
+// BET-1282 — ChatModelStore per-session selection: no longer a UserDefaults
+// copy under `manta:chat:<sid>:model`. The selection lives in the box store,
+// mirrored through the shared `ChatModelPrefs` cache. ChatModelStore stays the
+// single place the UI mutates the selection; its mutators update the cache
+// immediately (so these assertions read it synchronously) and write the box.
 // ===========================================================================
 
 @MainActor
@@ -456,27 +455,16 @@ final class ChatModelStoreKeyTests: XCTestCase {
 
     private let sid = "test-session"
     private let otherSid = "test-session-2"
-    private var modelKey: String { ChatModelStore.storageKey(for: sid) }
-    private var otherModelKey: String { ChatModelStore.storageKey(for: otherSid) }
-    private var legacyPlanKey: String { "manta:chat:\(sid):model:plan" }
-    private var workingKeys: [String] {
-        [modelKey, otherModelKey,
-         ChatModelStore.planKey(for: sid), ChatModelStore.planKey(for: otherSid),
-         legacyPlanKey]
-    }
+    private var api = MantaAPIClient(serverURL: URL(string: "https://example.com")!)
+    private var prefs: ChatModelPrefs!
 
     override func setUp() {
         super.setUp()
-        for key in workingKeys { UserDefaults.standard.removeObject(forKey: key) }
-    }
-
-    override func tearDown() {
-        for key in workingKeys { UserDefaults.standard.removeObject(forKey: key) }
-        super.tearDown()
+        prefs = ChatModelPrefs(api: MantaAPIClient(serverURL: URL(string: "https://example.com")!))
     }
 
     private func store(_ id: String) -> ChatModelStore {
-        ChatModelStore(sessionId: id, api: MantaAPIClient(serverURL: URL(string: "https://example.com")!))
+        ChatModelStore(sessionId: id, api: api, catalog: ChatModelCatalog(api: api), prefs: prefs)
     }
 
     private func model(_ m: String) -> OpencodeModelID {
@@ -487,64 +475,45 @@ final class ChatModelStoreKeyTests: XCTestCase {
         ChatModel.ModelSelection(providerID: "anthropic", modelID: m, variant: variant)
     }
 
-    // MARK: - Literal key string (cross-client compatibility)
-
-    func testStorageKeyLiteralString() {
-        XCTAssertEqual(ChatModelStore.storageKey(for: "S"), "manta:chat:S:model")
-    }
-
-    // MARK: - Read
-
-    func testReadWithSelectionStoredReturnsIt() {
-        UserDefaults.standard.set(ChatModel.encode(selection("sonnet", variant: "high")), forKey: modelKey)
-        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet", variant: "high"))
-        XCTAssertEqual(ChatModelStore.loadOverride(for: sid), model("sonnet"))
-    }
-
-    func testReadWithNothingStoredReturnsNil() {
-        XCTAssertNil(ChatModelStore.loadSelection(for: sid))
-        XCTAssertNil(ChatModelStore.loadOverride(for: sid))
-    }
-
-    // MARK: - setOverride drops the variant; setVariant folds it into the blob
+    // MARK: - setOverride drops the variant; setVariant folds it into the box selection
 
     func testSetOverrideDropsVariant() {
         let s = store(sid)
         s.setOverride(model("sonnet"))
         s.setVariant("high")
-        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet", variant: "high"))
+        XCTAssertEqual(prefs.selection(for: sid), selection("sonnet", variant: "high"))
 
         s.setOverride(model("opus"))                        // model changed → variant cleared
-        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("opus"))
+        XCTAssertEqual(prefs.selection(for: sid), selection("opus"))
         XCTAssertEqual(s.variant, nil)
     }
 
-    func testSetOverrideNilRemovesKey() {
+    func testSetOverrideNilClearsSelection() {
         let s = store(sid)
         s.setOverride(model("sonnet"))
-        XCTAssertNotNil(UserDefaults.standard.string(forKey: modelKey))
-        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet"))
+        XCTAssertEqual(prefs.selection(for: sid), selection("sonnet"))
         s.setOverride(nil)
-        XCTAssertNil(UserDefaults.standard.string(forKey: modelKey))
+        XCTAssertNil(prefs.selection(for: sid))
         XCTAssertEqual(s.override, nil)
     }
 
-    // MARK: - rebind copies the ONE key verbatim, leaves the old one alone
+    // MARK: - rebind writes the selection to the new session, leaves the old one alone
 
-    func testRebindCopiesTheSingleKeyAndLeavesOldAlone() {
-        UserDefaults.standard.set(ChatModel.encode(selection("sonnet", variant: "high")), forKey: modelKey)
-        store(sid).rebind(to: otherSid)
+    func testRebindCopiesSelectionAndLeavesOldAlone() {
+        let s = store(sid)
+        s.setOverride(model("sonnet"))
+        s.setVariant("high")
+        s.rebind(to: otherSid)
 
-        // rebind copies the RAW stored value verbatim.
-        XCTAssertEqual(UserDefaults.standard.string(forKey: modelKey), UserDefaults.standard.string(forKey: otherModelKey))
-        XCTAssertEqual(ChatModelStore.loadSelection(for: otherSid), selection("sonnet", variant: "high"))
-        // The source session's key is untouched.
-        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet", variant: "high"))
+        // rebind carries the current selection to the new session via the box cache.
+        XCTAssertEqual(prefs.selection(for: otherSid), selection("sonnet", variant: "high"))
+        // The source session's selection is untouched.
+        XCTAssertEqual(prefs.selection(for: sid), selection("sonnet", variant: "high"))
     }
 
     func testRebindWithNothingStoredLeavesDestinationAbsent() {
         store(sid).rebind(to: otherSid)
-        XCTAssertNil(UserDefaults.standard.string(forKey: otherModelKey))
+        XCTAssertNil(prefs.selection(for: otherSid))
     }
 
     // MARK: - Plan mode never changes the model
@@ -553,7 +522,7 @@ final class ChatModelStoreKeyTests: XCTestCase {
         let s = store(sid)
 
         s.setOverride(model("sonnet"))
-        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet"))
+        XCTAssertEqual(prefs.selection(for: sid), selection("sonnet"))
         XCTAssertEqual(s.override, model("sonnet"))
 
         s.setPlan(true)
@@ -561,17 +530,70 @@ final class ChatModelStoreKeyTests: XCTestCase {
 
         s.setPlan(false)
         XCTAssertEqual(s.override, model("sonnet"))
-        // One key, one value throughout — no per-mode key appears.
-        XCTAssertEqual(ChatModelStore.loadSelection(for: sid), selection("sonnet"))
-        XCTAssertNil(UserDefaults.standard.string(forKey: otherModelKey))
-        XCTAssertNil(UserDefaults.standard.string(forKey: legacyPlanKey))
+        // One selection throughout — no per-mode model value appears.
+        XCTAssertEqual(prefs.selection(for: sid), selection("sonnet"))
+        XCTAssertNil(prefs.selection(for: otherSid))
     }
 
     // MARK: - Legacy plan-key cleanup
 
     func testFirstReadDeletesLegacyPlanKey() {
-        UserDefaults.standard.set(ChatModel.encode(selection("plan-model")), forKey: legacyPlanKey)
+        let legacyKey = "manta:chat:\(sid):model:plan"
+        UserDefaults.standard.set(ChatModel.encode(selection("plan-model")), forKey: legacyKey)
+        defer { UserDefaults.standard.removeObject(forKey: legacyKey) }
         _ = store(sid)                                       // constructing the store is the first read
-        XCTAssertNil(UserDefaults.standard.string(forKey: legacyPlanKey))
+        XCTAssertNil(UserDefaults.standard.string(forKey: legacyKey))
+    }
+
+    // MARK: - Recents recorded through the box cache
+
+    func testApplyRecordsSelectionAndRecentsToCache() {
+        let s = store(sid)
+        let choice = ModelChoice(providerID: "anthropic", modelID: "sonnet", variant: "high", fast: false)
+        s.apply(choice)
+        XCTAssertEqual(prefs.selection(for: sid), selection("sonnet", variant: "high"))
+        XCTAssertEqual(prefs.recents, [choice])
+    }
+}
+
+// ===========================================================================
+// BET-1282 — one-shot migration of the old UserDefaults keys into the box
+// store (pure scan, injected lookups).
+// ===========================================================================
+
+@MainActor
+final class ChatModelPrefsMigrationTests: XCTestCase {
+
+    private func choice(_ m: String, variant: String? = nil, fast: Bool = false) -> ModelChoice {
+        ModelChoice(providerID: "anthropic", modelID: m, variant: variant, fast: fast)
+    }
+
+    func testCollectsLegacyModelKeysIntoBoxSessions() {
+        let keys = ["manta:chat:ses_1:model", "manta:chat:ses_2:model", "manta:chat:ses_1:plan"]
+        let stringValue: (String) -> String? = { key in
+            if key == "manta:chat:ses_1:model" { return ChatModel.encode(ChatModel.ModelSelection(providerID: "anthropic", modelID: "opus", variant: "high")) }
+            if key == "manta:chat:ses_2:model" { return ChatModel.encode(ChatModel.ModelSelection(providerID: "anthropic", modelID: "sonnet", variant: nil)) }
+            return nil
+        }
+        let collected = ChatModelPrefs.collectLegacy(keys: keys, stringForKey: stringValue, dataForKey: { _ in nil })
+        XCTAssertEqual(collected.sessions["ses_1"], ChatModel.ModelSelection(providerID: "anthropic", modelID: "opus", variant: "high"))
+        XCTAssertEqual(collected.sessions["ses_2"], ChatModel.ModelSelection(providerID: "anthropic", modelID: "sonnet", variant: nil))
+        // The plan key is NOT a model key — never collected, never removed.
+        XCTAssertEqual(collected.keysToRemove, ["manta:chat:ses_1:model", "manta:chat:ses_2:model"])
+    }
+
+    func testCollectsLegacyRecents() {
+        let data = try! JSONEncoder().encode([choice("opus", variant: "high"), choice("sonnet")])
+        let collected = ChatModelPrefs.collectLegacy(keys: ["manta:model-recents"], stringForKey: { _ in nil }, dataForKey: { _ in data })
+        XCTAssertEqual(collected.recents, [choice("opus", variant: "high"), choice("sonnet")])
+        XCTAssertEqual(collected.keysToRemove, ["manta:model-recents"])
+    }
+
+    func testSkipsMalformedAndEmptyValues() {
+        let keys = ["manta:chat:ses_1:model", "manta:chat::model", "other"]
+        let collected = ChatModelPrefs.collectLegacy(keys: keys, stringForKey: { _ in "not-json" }, dataForKey: { _ in nil })
+        XCTAssertTrue(collected.sessions.isEmpty)
+        XCTAssertTrue(collected.recents.isEmpty)
+        XCTAssertTrue(collected.keysToRemove.isEmpty)
     }
 }


### PR DESCRIPTION
Opened automatically for `multica/BET-1282-ios-model-prefs-box-store`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1282.