### PR TITLE
routing: single [router] decision line carrying ctx and needs (BET-1301)

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -41,7 +41,7 @@ import {
 } from "./peers.mjs";
 import { extractSubagentInfo } from "../shared/streamInterpretation.mjs";
 import { fuzzyMatchModel, suggestModels } from "../shared/modelGuide.mjs";
-import { chooseModel } from "../shared/modelRouter.mjs";
+import { chooseModel, describeDecision } from "../shared/modelRouter.mjs";
 import { listRoutableModels } from "./opencode.mjs";
 import { buildRoutingServices } from "./routingServices.mjs";
 
@@ -640,8 +640,7 @@ export function chooseSubagentModel({
       decision?.model === catalogIncumbentOf(incumbent)
         ? incumbent
         : toDeliverModel(decision?.model ?? incumbent);
-    const label = model ? `${model.providerID}/${model.modelID ?? model.id}` : "";
-    console.log(`[router] subagent agent=${agent} → ${label} (${decision?.reason ?? ""})`);
+    console.log(describeDecision(decision, { surface: "sub", agent }));
     return model;
   } catch (e) {
     // Routing must never break a spawn — fall back to the incumbent model.

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -920,11 +920,16 @@ test("BET-1275 11a: delegate({}) with subagent_type 'explore' routes with agent=
   assert.equal(out.ok, true);
   assert.equal(h.delivered.length, 1);
   // The requested subagent type IS the intent — the [router] line names the
-  // agent the spawn routed as. Assert the intent, not which model won.
+  // agent the spawn routed as, in the BET-1301 format (sub surface, plus the
+  // decision's inputs: ctx + needs=tools). Assert the intent, not which model
+  // won.
+  const line = lines.find((l) => l.includes("[router]"));
+  assert.ok(line, `expected a [router] line; got: ${lines.join(" | ")}`);
   assert.ok(
-    lines.some((l) => l.includes("[router] subagent agent=explore")),
-    `expected agent=explore in [router] line; got: ${lines.join(" | ")}`,
+    line.startsWith("[router] sub/explore → "),
+    `expected the BET-1301 sub/explore format; got: ${line}`,
   );
+  assert.ok(line.includes("ctx=0 needs=tools"), `expected the turn's inputs; got: ${line}`);
 });
 
 test("BET-1275 11a: an absent/blank subagent_type routes with agent=general", async () => {
@@ -942,11 +947,16 @@ test("BET-1275 11a: an absent/blank subagent_type routes with agent=general", as
   });
   assert.equal(out.ok, true);
   // A blank subagent_type (unknown) must map to the general agent, not leak
-  // through as an empty agent and not crash.
+  // through as an empty agent and not crash. The line is the BET-1301 format
+  // (sub surface) and carries the turn's inputs.
+  assert.equal(h.delivered.length, 1);
+  const line = lines.find((l) => l.includes("[router]"));
+  assert.ok(line, `expected a [router] line; got: ${lines.join(" | ")}`);
   assert.ok(
-    lines.some((l) => l.includes("[router] subagent agent=general")),
-    `expected agent=general in [router] line; got: ${lines.join(" | ")}`,
+    line.startsWith("[router] sub/general → "),
+    `expected the BET-1301 sub/general format; got: ${line}`,
   );
+  assert.ok(line.includes("ctx=0 needs=tools"), `expected the turn's inputs; got: ${line}`);
 });
 
 test("BET-1275: a background job routes from the box config even with no parent-Auto input", async () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -38,7 +38,7 @@ import { toDeliverModel } from "./delegate.mjs";
 import { buildRoutingServices } from "./routingServices.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { pollClaudeLogin, claudeCliStatus, listRoutableModels } from "./opencode.mjs";
-import { chooseModel, incumbentStillEligible } from "../shared/modelRouter.mjs";
+import { chooseModel, incumbentStillEligible, describeDecision } from "../shared/modelRouter.mjs";
 import {
   applyRoutingOverrides,
   resolveNowOverride,
@@ -944,18 +944,10 @@ export function buildHandlers({
           services: effServices,
         });
         // The box-side signal that routing ran (BET-1265). Always logged, no
-        // debug flag: a decision nobody watches is a decision not made. Names
-        // the winner, the cost basis and whether the mix was measured.
-        {
-          const t = decision?.trace;
-          const basis = t?.winner?.cost?.basis ?? "none";
-          const mix = t?.winner?.cost?.mixSource ?? "default";
-          const dropped = Array.isArray(t?.dropped) ? t.dropped.reduce((s, d) => s + d.n, 0) : 0;
-          const w = decision?.model;
-          console.log(
-            `[router] ${surface}/${agent} → ${w?.providerID ?? "-"}/${w?.id ?? "-"} · ${basis} · considered=${t?.considered ?? 0} dropped=${dropped} mix=${mix}`
-          );
-        }
+        // debug flag: a decision nobody watches is a decision not made. One
+        // pure formatter (BET-1301) prints the decision's inputs — the real
+        // conversation size and what the turn needed — alongside its outputs.
+        console.log(describeDecision(decision, { surface, agent }));
         // On the off-path / no-survivors path chooseModel returns the very
         // catalogIncumbent reference it was handed; map that back to the
         // original structured incumbent so the decision stays byte-identical.

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -1361,10 +1361,19 @@ test("routing:choose logs exactly one well-formed [router] line on a routed deci
     console.log = orig;
   }
   assert.equal(lines.length, 1, "exactly one [router] line, no debug flag");
-  // Deterministic for this injected catalogue: a real winner (sonnet, no
-  // account → cost basis "unknown"), zero drops, mix=default (no measured
-  // ledger mix on today's wiring — the evidence BET-1265 exists to surface).
-  assert.equal(lines[0], "[router] main/build → anthropic/claude-sonnet-4 · unknown · considered=1 dropped=0 mix=default");
+  // BET-1301: the decision line now carries the decision's INPUTS — the real
+  // conversation size (ctx=0, verbatim — a caller bug stays visible) and what
+  // the turn needed (needs=none) — alongside its outputs. Deterministic for
+  // this injected catalogue: a real winner (sonnet, no account → cost basis
+  // "unknown"), zero drops, mix=default (no measured ledger mix on today's
+  // wiring — the evidence BET-1265 exists to surface).
+  assert.ok(
+    lines[0].startsWith(
+      "[router] main/build → anthropic/claude-sonnet-4 · ctx=0 needs=none · considered=1 dropped=0 · unknown mix=default ·",
+    ),
+    `expected the BET-1301 input-carrying format; got: ${lines[0]}`,
+  );
+  assert.ok(/ · [^·]+$/.test(lines[0]), "reason is present and the final field");
 });
 
 // BET-1270 6e: routing:choose reports the box's facts about the incumbent it

--- a/src/shared/modelRouter.d.mts
+++ b/src/shared/modelRouter.d.mts
@@ -103,3 +103,19 @@ export function incumbentStillEligible(
   candidate: Model | null | undefined,
   services?: RoutingServices,
 ): boolean;
+
+export interface RoutedDecisionInput {
+  model?: Model | null;
+  reason?: string;
+  trace?: {
+    considered?: number;
+    dropped?: { n?: number }[];
+    intent?: { contextTokens?: number; needs?: Record<string, boolean> };
+    winner?: { cost?: { basis?: string; mixSource?: string } } | null;
+  };
+}
+
+export function describeDecision(
+  decision: RoutedDecisionInput | null | undefined,
+  ctx: { surface: "main" | "sub"; agent: string },
+): string;

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -469,3 +469,45 @@ export function chooseModel(input = {}) {
     },
   };
 }
+
+/**
+ * The single [router] decision line (BET-1301). Prints the decision's INPUTS
+ * (conversation size + what the turn needed) alongside its outputs, so a
+ * decision is auditable from the log alone. Pure: takes data, returns a
+ * string, no I/O / clock / console. Every field falls back independently —
+ * a partial or null decision yields a well-formed line, never a throw.
+ *
+ * @param {object|null} decision the chooseModel result (or null)
+ * @param {{ surface: "main"|"sub", agent: string }} ctx
+ * @returns {string} the complete line, `[router] ` prefix included
+ */
+export function describeDecision(decision, { surface, agent }) {
+  const trace = decision?.trace;
+  const w = endpointKey(decision?.model) || "-";
+
+  // ctx: print the real conversation size verbatim when it is a number (0
+  // included — a caller bug must stay visible). Never coerce absent to 0.
+  const ctxTokens = trace?.intent?.contextTokens;
+  const ctx = typeof ctxTokens === "number" ? String(ctxTokens) : "absent";
+
+  // needs: the keys whose value is true, sorted alphabetically (deterministic
+  // and testable), comma-joined with no spaces.
+  const needs = trace?.intent?.needs;
+  const needKeys =
+    needs && typeof needs === "object"
+      ? Object.keys(needs)
+          .filter((k) => needs[k] === true)
+          .sort()
+      : [];
+  const needsStr = needKeys.length > 0 ? needKeys.join(",") : "none";
+
+  const considered = trace?.considered ?? 0;
+  const dropped = Array.isArray(trace?.dropped)
+    ? trace.dropped.reduce((sum, d) => sum + (d?.n ?? 0), 0)
+    : 0;
+  const basis = trace?.winner?.cost?.basis ?? "none";
+  const mix = trace?.winner?.cost?.mixSource ?? "default";
+  const reason = decision?.reason || "-";
+
+  return `[router] ${surface}/${agent} → ${w} · ctx=${ctx} needs=${needsStr} · considered=${considered} dropped=${dropped} · ${basis} mix=${mix} · ${reason}`;
+}

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { chooseModel, incumbentStillEligible, AGENT_TIER, type RoutingServices } from "./modelRouter.mjs";
+import { chooseModel, incumbentStillEligible, describeDecision, AGENT_TIER, type RoutingServices } from "./modelRouter.mjs";
 import { endpointKey } from "./endpointKey.mjs";
 import { tierRank } from "./modelGuide.mjs";
 import { AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
@@ -899,5 +899,128 @@ describe("incumbentStillEligible (BET-1270 6e)", () => {
 
   it("returns true for a null / absent incumbent", () => {
     expect(incumbentStillEligible(null, undefined)).toBe(true);
+  });
+});
+
+describe("describeDecision", () => {
+  it("formats a full decision with every field, asserted whole", () => {
+    const decision = {
+      model: { providerID: "anthropic", modelID: "claude-opus-5" },
+      reason: "build → deep tier: anthropic/claude-opus-5",
+      trace: {
+        considered: 10,
+        dropped: [
+          { stage: "capable", reason: "subscription-pace", n: 3 },
+          { stage: "eligible", reason: "no-tools", n: 2 },
+        ],
+        intent: { contextTokens: 142000, needs: { image: true, tools: true } },
+        winner: { cost: { basis: "subscription-pace", mixSource: "measured" } },
+      },
+    };
+    expect(describeDecision(decision, { surface: "main", agent: "build" })).toBe(
+      "[router] main/build → anthropic/claude-opus-5 · ctx=142000 needs=image,tools · considered=10 dropped=5 · subscription-pace mix=measured · build → deep tier: anthropic/claude-opus-5",
+    );
+  });
+
+  it("prints ctx=absent for an undefined context size, never ctx=0", () => {
+    const decision = {
+      model: { providerID: "anthropic", id: "claude-opus-5" },
+      reason: "build → deep tier",
+      trace: {
+        considered: 1,
+        dropped: [],
+        intent: { needs: {} },
+        winner: { cost: {} },
+      },
+    };
+    const line = describeDecision(decision, { surface: "main", agent: "build" });
+    expect(line).toContain("ctx=absent");
+    expect(line).not.toContain("ctx=0");
+  });
+
+  it("keeps a caller's 0 visible as ctx=0", () => {
+    const decision = {
+      model: { providerID: "anthropic", id: "claude-opus-5" },
+      reason: "build → deep tier",
+      trace: {
+        considered: 1,
+        dropped: [],
+        intent: { contextTokens: 0, needs: {} },
+        winner: { cost: {} },
+      },
+    };
+    expect(describeDecision(decision, { surface: "main", agent: "build" })).toContain("ctx=0");
+  });
+
+  it("lists true needs sorted alphabetically, comma-joined without spaces", () => {
+    const decision = {
+      model: { providerID: "anthropic", id: "claude-opus-5" },
+      reason: "x",
+      trace: {
+        considered: 1,
+        dropped: [],
+        intent: { needs: { tools: true, image: true } },
+        winner: { cost: {} },
+      },
+    };
+    expect(describeDecision(decision, { surface: "main", agent: "build" })).toContain("needs=image,tools");
+  });
+
+  it("prints needs=none for empty and absent needs", () => {
+    const empty = {
+      model: { providerID: "anthropic", id: "claude-opus-5" },
+      reason: "x",
+      trace: { considered: 1, dropped: [], intent: { needs: {} }, winner: { cost: {} } },
+    };
+    const absent = {
+      model: { providerID: "anthropic", id: "claude-opus-5" },
+      reason: "x",
+      trace: { considered: 1, dropped: [], intent: {}, winner: { cost: {} } },
+    };
+    expect(describeDecision(empty, { surface: "main", agent: "build" })).toContain("needs=none");
+    expect(describeDecision(absent, { surface: "main", agent: "build" })).toContain("needs=none");
+  });
+
+  it("excludes false-valued needs", () => {
+    const decision = {
+      model: { providerID: "anthropic", id: "claude-opus-5" },
+      reason: "x",
+      trace: {
+        considered: 1,
+        dropped: [],
+        intent: { needs: { image: false, tools: true } },
+        winner: { cost: {} },
+      },
+    };
+    expect(describeDecision(decision, { surface: "main", agent: "build" })).toContain("needs=tools");
+    expect(describeDecision(decision, { surface: "main", agent: "build" })).not.toContain("image");
+  });
+
+  it("prints a dash winner and does not throw when there is no winner", () => {
+    const decision = {
+      model: null,
+      reason: "no build model passes constraints",
+      trace: { considered: 0, dropped: [], intent: { needs: {} }, winner: null },
+    };
+    const line = describeDecision(decision, { surface: "main", agent: "build" });
+    expect(line).toContain("→ -");
+    // no throw
+    expect(line).toContain("· none mix=default · no build model passes constraints");
+  });
+
+  it("formats a null decision as a well-formed line, no throw", () => {
+    const line = describeDecision(null, { surface: "main", agent: "general" });
+    expect(line).toBe(
+      "[router] main/general → - · ctx=absent needs=none · considered=0 dropped=0 · none mix=default · -",
+    );
+  });
+
+  it("uses the sub surface for the subagent call site", () => {
+    const decision = {
+      model: { providerID: "anthropic", id: "claude-sonnet-4" },
+      reason: "explore → fast tier",
+      trace: { considered: 1, dropped: [], intent: { needs: { tools: true } }, winner: { cost: {} } },
+    };
+    expect(describeDecision(decision, { surface: "sub", agent: "explore" })).toMatch(/^\[router\] sub\/explore /);
   });
 });

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
Base: `origin/main` @ `30efab26`

## What

BET-1301: collapse the two divergent `[router]` decision lines into one pure formatter — `describeDecision` exported from `src/shared/modelRouter.mjs` — that prints the decision's **inputs** (real conversation size `ctx`, and what the turn needed `needs`) alongside its outputs. Both call sites now call it; the line is buildable in exactly one place.

**No change to routing behaviour.** `chooseModel` is untouched. This only makes the existing decision legible.

## Files changed (7)

```
src/shared/modelRouter.mjs     |  42 ++++   (new describeDecision export)
src/shared/modelRouter.d.mts   |  16 ++    (types for the formatter)
src/shared/modelRouter.test.ts | 125 ++    (9 unit cases for the formatter)
src/server/rpc.mjs             |  18 +-     (call site → formatter; net −8)
src/server/delegate.mjs        |   5 +-     (call site → formatter; net −1)
src/server/rpc.test.mjs        |  17 +-     (pin new fields)
src/server/delegate.test.mjs   |  22 +-     (pin new fields)
```

## Acceptance evidence

**§4.2 — single build site.** Repo-wide search for the decision-line template finds **only** `describeDecision` (`src/shared/modelRouter.mjs:512`). The remaining `[router]` strings are the unchanged failure signals (`routing failed…` warn, `routing services degraded` / `subagent routing threw` error) and JSDoc/comments — none builds a decision line.

**§4.3 — both sites smaller.** `rpc.mjs` net −8 lines, `delegate.mjs` net −1 line (both net-negative, as required).

**§4.4 — both surfaces, same format:**
```
[router] main/build → anthropic/claude-opus-5 · ctx=142000 needs=image,tools · considered=10 dropped=5 · subscription-pace mix=measured · build → deep tier: anthropic/claude-opus-5
[router] sub/explore → anthropic/claude-sonnet-4 · ctx=0 needs=tools · considered=6 dropped=0 · catalogue mix=default · explore → fast tier: anthropic/claude-sonnet-4
```

**§4.5 — live check.** This is the one criterion I cannot run as the implementer: it requires deploying to the dev box and driving a routing decision with an attachment. What is now true *by construction*: every `[router]` decision line, main or sub, names `ctx=<size>` and the turn's `needs` (so an image-bearing turn logs `needs=image,…`) with **no probe script** — the fields come straight from `trace.intent`, which BET-1267 already echoes. BET-1288's criterion 4 ("the real conversation size reached the decision") is now answerable from `journalctl` alone. Live paste pending deploy.

## Verification results

- PR branch (`multica/BET-1301-routing-decision-line` @ `b9785844`):
  - typecheck: exit 0, errors none — sha256 `adab58da…260402`
  - test: exit 0, 2694 pass / 0 fail / 0 skip — sha256 `c20ab767…5e06c`
- Base (`main` @ `30efab26`):
  - typecheck: exit 0, errors none — sha256 `adab58da…260402`
  - test: exit 0, 2694 pass / 0 fail / 0 skip — sha256 `e01a7a8c…2db9d3`
- **Conclusion:** 0 new failures, 0 resolved, identical between branches.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

## Self-check (all criteria ≥ 8)

- **§4.1 typecheck+test green** → 10/10. Verified both.
- **§4.2 single `[router]` build site** → 9/10. One template; remaining matches are failure signals + comments. Weakness: a couple of the comments we scan over are other `[router]` strings — greppable but not decision-line bytes.
- **§4.3 both sites smaller (net-negative)** → 10/10. rpc −8, delegate −1.
- **§4.4 both surfaces same format** → 10/10. Pinned by call-site tests asserting `<surface>`/`<agent>`, `ctx=`, `needs=`; formatter is the single renderer.
- **§4.5 live check** → not scorable by implementer (needs deploy + live attachment decision); made answerable-from-logs by construction. Flaged as pending deploy.
- **Every actionable follow-up filed** → n/a (no cross-cutting follow-ups surfaced).

## Follow-ups

None. (No dual source of truth introduced — the formatter is the single definition; `endpointKey` reused for the winner per constraint 4.)
