### PR TITLE
BET-1306 fix(ios): drop glass background from session-list header buttons

### DIFF
--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -104,11 +104,6 @@ struct SessionListView: View {
                         Image(systemName: "gearshape")
                             .foregroundColor(tokens.tx2)
                     }
-                    // Hidden shared background: iOS 26 paints an automatic
-                    // glass capsule behind image bar buttons; suppressing it
-                    // keeps these as bare icons while leaving standard
-                    // toolbar hit-testing untouched.
-                    .sharedBackgroundVisibility(.hidden)
                     .accessibilityLabel("Settings")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
@@ -119,7 +114,6 @@ struct SessionListView: View {
                         Image(systemName: "plus")
                             .foregroundColor(tokens.tx2)
                     }
-                    .sharedBackgroundVisibility(.hidden)
                     .accessibilityLabel("New session")
                 }
             }

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -104,12 +104,11 @@ struct SessionListView: View {
                         Image(systemName: "gearshape")
                             .foregroundColor(tokens.tx2)
                     }
-                    // The system's own glass BUTTON style, not a plain button
-                    // with a glass effect layered over it: the layered version
-                    // renders correctly but eats the touch, so the button looks
-                    // dead. Both header buttons use the same style so they read
-                    // as a matched pair.
-                    .buttonStyle(.glass)
+                    // Hidden shared background: iOS 26 paints an automatic
+                    // glass capsule behind image bar buttons; suppressing it
+                    // keeps these as bare icons while leaving standard
+                    // toolbar hit-testing untouched.
+                    .sharedBackgroundVisibility(.hidden)
                     .accessibilityLabel("Settings")
                 }
                 ToolbarItem(placement: .topBarTrailing) {
@@ -120,7 +119,7 @@ struct SessionListView: View {
                         Image(systemName: "plus")
                             .foregroundColor(tokens.tx2)
                     }
-                    .buttonStyle(.glass)
+                    .sharedBackgroundVisibility(.hidden)
                     .accessibilityLabel("New session")
                 }
             }


### PR DESCRIPTION
Fixes BET-1306 — remove the white glass capsule behind the session-list header buttons (settings gear + new-session plus) on iOS.

## Change

One file, `mobile/native/MantaUI/SessionListView.swift`, header toolbar only. Both header buttons drop `.buttonStyle(.glass)` (the iOS 26 Liquid Glass white capsule). This is a pure modifier removal — no API/behavior change, both buttons stay a matched pair, tap targets unchanged.

Per the issue's fallback rule: the primary approach (`.sharedBackgroundVisibility(.hidden)`) was tried, but the Swift compiler failed to type-check the toolbar expression (`unable to type-check this expression in reasonable time`), so per instructions I removed both `.buttonStyle(.glass)` lines and added nothing in their place — the fallback. Verified compiling (compile-only: COMPILE PASS) on commit `9dadf261`.

No other glass usage touched (ComposerView, floating bottom search bar intentionally unchanged). No tests — pure view-style removal.

**Base: origin/main @ e410c6b7**
