### PR TITLE
chore(release): bump iOS marketing version to 1.0.19

### DIFF
--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -95,7 +95,7 @@ targets:
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         TARGETED_DEVICE_FAMILY: "1,2"
-        MARKETING_VERSION: "1.0.18"
+        MARKETING_VERSION: "1.0.19"
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Automatic
         SWIFT_EMIT_LOC_STRINGS: YES


### PR DESCRIPTION
Ships the merged iOS work to TestFlight: BET-1306 (session-list header glass fix) + BET-1305 (composer keyboard toolbar). Version-only change; ios-release-tag.yml will auto-tag ios-v1.0.19 and trigger the Codemagic TestFlight build on merge.