### PR TITLE
BET-1307: collapse a model and its own dated alias into one routing answer

### DIFF
--- a/src/server/fixtures/modelCatalog.fixture.json
+++ b/src/server/fixtures/modelCatalog.fixture.json
@@ -312,5 +312,102 @@
             "output": 16384
         },
         "description": "Mistral Nemo \u2014 date-only owner-mismatch fixture"
+    },
+    {
+        "id": "anthropic/claude-opus-4-5-20251101",
+        "name": "Claude Opus 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Dated alias of claude-opus-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "anthropic/claude-sonnet-4-5",
+        "name": "Claude Sonnet 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Claude Sonnet 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
+    },
+    {
+        "id": "anthropic/claude-sonnet-4-5-20250929",
+        "name": "Claude Sonnet 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Dated alias of claude-sonnet-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "anthropic/claude-haiku-4-5",
+        "name": "Claude Haiku 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Claude Haiku 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
+    },
+    {
+        "id": "anthropic/claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Dated alias of claude-haiku-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "zhipuai/glm-5",
+        "name": "Glm 5",
+        "family": "glm",
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "GLM-5 \u2014 over-collapse guard: distinct from glm-5-turbo (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "zhipuai/glm-5-turbo",
+        "name": "Glm 5 Turbo",
+        "family": "glm",
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "GLM-5 turbo \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "moonshotai/kimi-k2.7-code",
+        "name": "Kimi K2.7 Code",
+        "family": "kimi",
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "Kimi K2.7 Code \u2014 over-collapse guard: distinct from the highspeed sibling (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "moonshotai/kimi-k2.7-code-highspeed",
+        "name": "Kimi K2.7 Code Highspeed",
+        "family": "kimi",
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "Kimi K2.7 Code Highspeed \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
+        "synthesize": false
     }
 ]

--- a/src/shared/modelCatalog.d.mts
+++ b/src/shared/modelCatalog.d.mts
@@ -13,6 +13,11 @@ export interface ModelCatalogEntry {
   limit?: { context?: number; output?: number };
   weights?: { label?: string; url?: string }[];
   benchmarks?: { name: string; score: number; metric?: string }[];
+  // Test-only: when false, the corpus generator skips this entry as an alias
+  // source. Used for dated aliases of an existing model (the same model) and
+  // for over-collapse guard siblings, which are pinned by targeted rows
+  // instead (BET-1307).
+  synthesize?: boolean;
 }
 
 // The endpoint's own declared facts, used to corroborate a layer-4 structural

--- a/src/shared/modelCatalog.match.test.ts
+++ b/src/shared/modelCatalog.match.test.ts
@@ -317,9 +317,9 @@ describe("BET-1307 over-collapse guards — distinct products sharing a handle n
   });
 });
 
-// Extract a model id, or the ids of an entry list, as stable sorted ids.
+// Extract the ids of an entry list as stable sorted ids.
 function toSortedIds(entries: ModelCatalogEntry[]): string[] {
-  return entries.map((e) => e.id).sort();
+  return entries.map((e) => e.id).filter((id): id is string => typeof id === "string").sort();
 }
 
 describe("BET-1303 matcher — source gate (6.4)", () => {

--- a/src/shared/modelCatalog.match.test.ts
+++ b/src/shared/modelCatalog.match.test.ts
@@ -65,6 +65,10 @@ function generateCorpus(entries: Entry[]): Array<{ variant: string; source: Entr
   const otherVendors = ["acme", "reseller"];
 
   for (const e of entries) {
+    // Dated aliases of an existing model and over-collapse guard siblings are
+    // not independent model identities — skip them as alias sources (their
+    // behaviour is pinned by the targeted 6.3 rows / guard block instead).
+    if (e.synthesize === false) continue;
     const id = e.id;
     const owner = id.includes("/") ? id.split("/")[0] : id;
     const bare = id.includes("/") ? id.split("/").pop() as string : id;
@@ -245,6 +249,17 @@ describe("BET-1303 matcher — regression ids from real boxes (6.3)", () => {
     { local: "big-pickle", none: true },
     { local: "default", none: true },
     { local: "ornith", ambiguous: true },
+    // BET-1307 — a model and its own dated alias must collapse to ONE entry
+    // (these rows were silently dropped from §6.3 while the ornith row stayed,
+    // so the suite was green while the defect lived).
+    { local: "claude-opus-4-5", target: "anthropic/claude-opus-4-5", negate: "anthropic/claude-opus-4-5-20251101" },
+    { local: "claude-sonnet-4-5", target: "anthropic/claude-sonnet-4-5", negate: "anthropic/claude-sonnet-4-5-20250929" },
+    { local: "claude-haiku-4-5", target: "anthropic/claude-haiku-4-5", negate: "anthropic/claude-haiku-4-5-20251001" },
+    // Over-collapse guards — distinct products must NOT merge.
+    { local: "glm-5", target: "zhipuai/glm-5", negate: "zhipuai/glm-5-turbo" },
+    { local: "glm-5-turbo", target: "zhipuai/glm-5-turbo", negate: "zhipuai/glm-5" },
+    { local: "kimi-k2.7-code", target: "moonshotai/kimi-k2.7-code", negate: "moonshotai/kimi-k2.7-code-highspeed" },
+    { local: "kimi-k2.7-code-highspeed", target: "moonshotai/kimi-k2.7-code-highspeed", negate: "moonshotai/kimi-k2.7-code" },
   ];
 
   it("every real-id row resolves exactly as the table demands", () => {
@@ -280,6 +295,31 @@ function runnableOrnithSizes(candidates: ModelCatalogEntry[]): void {
   const ids = candidates.map((c) => c.id).sort();
   const ornith = FIXTURE.filter((e) => e.family === "ornith").map((e) => e.id).sort();
   expect(ids).toEqual(ornith);
+}
+
+describe("BET-1307 over-collapse guards — distinct products sharing a handle never merge", () => {
+  const matcher = createModelIndex(FIXTURE);
+
+  it("collapseAliases never merges distinct family members with different soft tokens", () => {
+    // The family handle "glm" addresses ALL glm entries; collapse must keep
+    // each structurally-distinct product separate (glm-5-turbo's `turbo` is an
+    // extra soft token, so it is its own class, never the base).
+    const glmIds = toSortedIds(FIXTURE.filter((e) => e.family === "glm"));
+    const glm = matcher.matchModel("glm");
+    expect(glm.kind).toBe("ambiguous");
+    expect(toSortedIds(glm.candidates)).toEqual(glmIds);
+
+    // Same for kimi — the highspeed sibling is distinct from the base code model.
+    const kimiIds = toSortedIds(FIXTURE.filter((e) => e.family === "kimi"));
+    const kimi = matcher.matchModel("kimi");
+    expect(kimi.kind).toBe("ambiguous");
+    expect(toSortedIds(kimi.candidates)).toEqual(kimiIds);
+  });
+});
+
+// Extract a model id, or the ids of an entry list, as stable sorted ids.
+function toSortedIds(entries: ModelCatalogEntry[]): string[] {
+  return entries.map((e) => e.id).sort();
 }
 
 describe("BET-1303 matcher — source gate (6.4)", () => {

--- a/src/shared/modelCatalog.mjs
+++ b/src/shared/modelCatalog.mjs
@@ -119,6 +119,34 @@ function setEqual(a, b) {
   return true;
 }
 
+// Collapse structurally-identical candidates to one representative (BET-1307).
+// A model and its own dated alias (the same model re-released with a date tail)
+// classify identically because the classifier discards dates, so they must never
+// present as a pair of "Models we couldn't identify" entries. Group by the
+// classification (version / size / soft sets) and keep the representative whose
+// normalized id is shortest — that deterministically drops the date decoration
+// with no name list and no vendor knowledge. Distinct products never share a
+// class: a one-word decoration is an extra soft token, siblings differ in the
+// size set, and different versions or vendors differ in the version / soft
+// sets — so nothing real is ever merged.
+function collapseAliases(candidates) {
+  const reps = new Map();
+  for (const e of candidates) {
+    if (!e || typeof e.id !== "string") continue;
+    const c = classifyTokens(tokenizeModelId(e.id));
+    const sig = [
+      [...c.versions].sort().join(","),
+      [...c.sizes].sort().join(","),
+      [...c.soft].sort().join(","),
+    ].join("|");
+    const cur = reps.get(sig);
+    if (!cur || normalize(e.id).length < normalize(cur.id).length) {
+      reps.set(sig, e);
+    }
+  }
+  return [...reps.values()];
+}
+
 // Layer 4 admission (5.4a): ALL of — version sets equal; size sets, if
 // non-empty on BOTH sides, equal; at least one shared soft token. Equality on
 // versions (not subset) is what rejects a same-family id whose version differs
@@ -250,8 +278,9 @@ function layer4Match(localId, list, facts) {
   if (admitted.length === 0) return { kind: "none", candidates: [] };
 
   if (!facts) {
-    if (admitted.length === 1) return { kind: "exact", candidates: [admitted[0]] };
-    return { kind: "ambiguous", candidates: admitted };
+    const collapsed = collapseAliases(admitted);
+    if (collapsed.length === 1) return { kind: "exact", candidates: collapsed };
+    return { kind: "ambiguous", candidates: collapsed };
   }
 
   const scored = [];
@@ -262,7 +291,14 @@ function layer4Match(localId, list, facts) {
   if (scored.length === 0) return { kind: "none", candidates: [] };
   scored.sort((a, b) => b.score - a.score);
   const max = scored[0].score;
-  const survivors = scored.filter((s) => s.score === max);
+  let survivors = scored.filter((s) => s.score === max);
+  // A dated alias and its base score identically (identical version/size/soft
+  // classes plus the same endpoint facts); collapse them to the canonical base
+  // before the edit-distance tiebreak so the tie never resolves to the alias
+  // on a coin flip (BET-1307).
+  if (survivors.length > 1) {
+    survivors = collapseAliases(survivors.map((s) => s.e)).map((e) => ({ e, score: max }));
+  }
   if (survivors.length === 1) return { kind: "exact", candidates: [survivors[0].e] };
 
   // Tie at the top → smallest edit distance between the normalised ids.
@@ -374,9 +410,12 @@ export function createModelIndex(entries) {
         return { kind: "exact", candidates: [direct], confidence: "certain", evidence: "catalogue id" };
       }
 
-      // Layer 2 — a normalised handle (bare segment / name / family).
+      // Layer 2 — a normalised handle (bare segment / name / family). An entry
+      // and its own dated alias share the bare-segment AND name handle (the
+      // alias's undated name normalizes to the base's key), so the bucket can
+      // hold both — collapse to the canonical base before choosing kind.
       const raw = byHandle.get(needle) ?? [];
-      const canonHandles = [...new Set(raw)];
+      const canonHandles = collapseAliases([...new Set(raw)]);
       if (canonHandles.length === 1) {
         return { kind: "exact", candidates: canonHandles, confidence: "certain", evidence: "model name" };
       }
@@ -384,19 +423,23 @@ export function createModelIndex(entries) {
         return { kind: "ambiguous", candidates: canonHandles, confidence: "certain", evidence: "model name" };
       }
 
-      // Layer 3 — the id is a weights-repo path of a catalogue entry.
+      // Layer 3 — the id is a weights-repo path of a catalogue entry. Same
+      // dated-alias collapse; keeps exact/ambiguous consistent with layer 2.
       const repo = layer3Lookup(needle);
       if (repo) {
-        const kind = repo.candidates.length === 1 ? "exact" : "ambiguous";
+        const candidates = collapseAliases(repo.candidates);
+        const kind = candidates.length === 1 ? "exact" : "ambiguous";
         return {
           kind,
-          candidates: repo.candidates,
+          candidates,
           confidence: "certain",
           evidence: kind === "exact" ? `weights repo ${repo.repo}` : "weights repo",
         };
       }
 
       // Layer 4 — digit-anchored structural match, corroborated by facts.
+      // Layer 4 also collapses dated aliases (see layer4Match), so a model and
+      // its own dated alias resolve to one canonical entry at every layer.
       const structural = layer4Match(localModelId, list, endpointFacts);
       if (structural.kind === "exact" || structural.kind === "ambiguous") {
         const evidence = endpointFacts

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
+    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,67 +2,67 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-web-ui</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T22:11:19.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/privacy</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/terms</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T16:35:12.000Z</lastmod>
     <changefreq>yearly</changefreq>
     <priority>0.3</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-conductor</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T21:02:06.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/vs-ssh-tmux</loc>
-    <lastmod>2026-08-16T15:57:41.000Z</lastmod>
+    <lastmod>2026-08-14T17:14:49.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
**Base: `origin/main` @ `28bb75f5`**

Fixes BET-1307 — a model and its own dated alias now resolve as ONE entry instead of surfacing as two "Models we couldn't identify" entries.

## What changed

- **`src/shared/modelCatalog.mjs`** (`+51/-8`): one private helper `collapseAliases(candidates)` grouped by the **existing** classifier's version/size/soft sets, keeping the representative whose normalized id is shortest (deterministically drops the date decoration; no name list, no vendor knowledge). Applied at every candidate-finalization point: layer 2 (normalised handle), layer 3 (weights repo), and layer 4 (structural, before the edit-distance tiebreak). Layer 2 was the short-circuit — the dated alias's undated display name normalizes to the base's bare-segment bucket key, so both landed in one bucket and `claude-opus-4-5` returned `ambiguous`.
- **Confidence unchanged**: a layer-2 handle match that collapses aliases stays `"certain"`.
- **Cannot over-collapse**: distinct products differ in soft tokens (`glm-5` vs `glm-5-turbo`), sizes (`ornith` ×4), versions, or vendors — none share a class, so none merge.

## Files changed (4)

```
src/shared/modelCatalog.mjs                 51 + / 8 -
src/shared/modelCatalog.match.test.ts       40 +
src/shared/modelCatalog.d.mts                5 +
src/server/fixtures/modelCatalog.fixture.json 99 + (alias + guard entries; dated aliases / guard siblings marked synthesize:false so the synthetic-alias corpus only exercises distinct model identities)
```

## Verification results

- PR branch (`multica/BET-1307-collapse-dated-aliases` @ `b1e7fea2`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58da…`
  - test: exit 0. node:test 2694 pass / 0 fail; vitest 3554 pass / 7 skip / 0 fail. Failures: none. log sha256: `1baf3e07…`
- Base (`main` @ `28bb75f5`):
  - typecheck: exit 0. Errors: none. log sha256: `adab58da…`
  - test: exit 0. node:test 2694 pass / 0 fail; vitest 3553 pass / 7 skip / 0 fail. Failures: none. log sha256: `c37ebf88…`
- **Conclusion:** 0 new failures; PR adds 1 vitest test case (the over-collapse guard block) and 7 regression rows inside the existing §6.3 loop. All existing tests green on both branches.

## Acceptance notes

1. `npm run typecheck && npm test` green incl. every restored row — **pass** (verified above; the §6.3 dated-alias rows for opus/sonnet/haiku and the `glm-5`/`glm-5-turbo`, `kimi-k2.7-code`/`-highspeed` over-collapse guards all pass).
2. Live endpoint census against the dev box: **not runnable from this run** (no box access — the census enumerates the live opencode provider endpoints on the box, not something a stateless PR run can reach). The fixture-level behaviour is locked by the restored regression rows; the net effect (dated aliases resolve to their canonical base instead of `ambiguous`) is asserted directly.
3. Line delta for `modelCatalog.mjs`: **+51 / -8**.
