### PR TITLE
BET-1311: refactor(renderer): remove compact/full fork in CustomProviderForm

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -91,7 +91,7 @@ SessionHeader's session menu moved with it.
 
 | Primitive | File | Adopters | Variants |
 | --- | --- | --- | --- |
-| Button | `src/renderer/Button.tsx` | 2 — `Settings.tsx`, `FolderPickerModal.tsx` | `tone: default\|primary\|ghost\|danger` (required, no default — the bare base is abstract, C4); `disabled`; `type`; `title`; `children`; `hook`. No `size` prop — one size only (the spec has no `.btn.sm` rule). |
+| Button | `src/renderer/Button.tsx` | 3 — `Settings.tsx`, `FolderPickerModal.tsx`, `CustomProviderForm.tsx` | `tone: default\|primary\|ghost\|danger` (required, no default — the bare base is abstract, C4); `disabled`; `type`; `title`; `children`; `hook`. No `size` prop — one size only (the spec has no `.btn.sm` rule). |
 | Chip | `src/renderer/Chip.tsx` | 2 — `NewSessionScreen.tsx` (folder chip + branch chip); `ModelPicker.tsx` (via the shared module) | `on` (the accent "active" state); `onClick`; `title`; `children`; `hook`. No `size` prop — one size only (29px hit area) |
 | SplitChip | `src/renderer/Chip.tsx` | 2 — `ModelPicker.tsx` (model ▸ effort split); `NewSessionScreen.tsx` (via the shared module) | `left`/`right` (ReactNode); `onLeftClick`/`onRightClick`; `rightAccent` (accent-tx + semibold on the right — replaces the composer's old inline `var(--accent-tx)`); `leftTitle`/`rightTitle`; `popup` (OPT-IN `aria-haspopup="listbox"` on both segments — a generic split control does not assume popup semantics, so a non-popup adopter omits it); `hook`. Both co-reside in `Chip.tsx` because they share the shell and must not diverge |
 | Card | `src/renderer/Card.tsx` | 3 — `Cards.tsx`, `Settings.tsx`, `NewSessionScreen.tsx` | `danger` (optional); `header`/`actions` slots |

--- a/src/renderer/AccountsCard.tsx
+++ b/src/renderer/AccountsCard.tsx
@@ -723,7 +723,7 @@ export function AccountsCard() {
         </div>
       )}
 
-      <CustomProviderForm compact onSaved={() => void refresh()} />
+      <CustomProviderForm onSaved={() => void refresh()} />
 
       <div className="text-meta text-text-quiet pt-3 border-t border-border-subtle">
         One list: subscriptions and custom endpoints are both a way to reach a

--- a/src/renderer/CustomProviderForm.tsx
+++ b/src/renderer/CustomProviderForm.tsx
@@ -19,6 +19,7 @@
 // caller share one source of truth.
 
 import { useState } from "react";
+import type { ReactNode } from "react";
 import { Loader2 } from "lucide-react";
 import type { DiscoverResult } from "../shared/types";
 import {
@@ -29,17 +30,12 @@ import { Field } from "./Field";
 import { Checkbox } from "./Checkbox";
 import { Button } from "./Button";
 
-const DANGER = "var(--danger)";
-
 type Phase = "editing" | "probing" | "ready";
 
 export function CustomProviderForm({
   onSaved,
-  compact = false,
 }: {
   onSaved: () => Promise<void> | void;
-  /** compact: Settings card styling (tighter padding, smaller labels). */
-  compact?: boolean;
 }) {
   const [name, setName] = useState("");
   const [baseURL, setBaseURL] = useState("");
@@ -160,76 +156,10 @@ export function CustomProviderForm({
   const busy = phase === "probing";
   const inSave = saveStep !== null;
 
-  if (compact) {
-    return (
-      <div className="border border-dashed border-border rounded-xs p-2 space-y-1">
-        <div className="text-micro font-semibold uppercase text-text-faint">
-          Add endpoint
-        </div>
-        <CustomInput
-          placeholder="name (e.g. VoskaAI)"
-          value={name}
-          disabled={busy}
-          onChange={setName}
-          onReset={phase !== "editing" ? reset : undefined}
-        />
-        <CustomInput
-          placeholder="baseURL (https://api.voska.org/v1)"
-          value={baseURL}
-          disabled={busy}
-          onChange={setBaseURL}
-        />
-        <input
-          type="password"
-          autoComplete="off"
-          spellCheck={false}
-          placeholder="API key (optional)"
-          value={apiKey}
-          disabled={busy}
-          onChange={(e) => setApiKey(e.target.value)}
-          className="w-full bg-bg-soft border border-border px-2 py-1 text-meta rounded-xs"
-        />
-        {derivedId && (
-          <div className="text-micro text-text-faint">
-            id: <code>{derivedId}</code>
-          </div>
-        )}
-        {error && <div className="text-meta text-danger">{error}</div>}
-        {phase === "ready" && models && (
-          <ModelList
-            models={models}
-            checked={checked}
-            onToggle={toggle}
-            disabled={busy}
-          />
-        )}
-        <div className="flex gap-2 pt-1">
-          {inSave || phase === "ready" ? (
-            <button
-              onClick={() => void save()}
-              disabled={busy || checked.size === 0}
-              className="px-3 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
-            >
-              {saveStep === "save" ? "Saving…" : saveStep === "restart" ? "Restarting opencode…" : `Save ${checked.size} model${checked.size === 1 ? "" : "s"}`}
-            </button>
-          ) : (
-            <button
-              onClick={() => void probe()}
-              disabled={busy || draftErr !== null}
-              className="px-3 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
-            >
-              {busy ? "Probing…" : "Probe"}
-            </button>
-          )}
-        </div>
-      </div>
-    );
-  }
-
   return (
-    <div className="rounded-sm border border-border bg-bg-soft p-3 space-y-3">
+    <div className="rounded-md border border-dashed border-border p-4 space-y-3">
       <div className="text-micro font-semibold uppercase text-text-faint">
-        Add a custom provider
+        Add endpoint
       </div>
       <CustomInput
         label="Name"
@@ -238,12 +168,14 @@ export function CustomProviderForm({
         disabled={busy}
         onChange={setName}
         onReset={phase !== "editing" ? reset : undefined}
+        help={
+          derivedId ? (
+            <>
+              Provider id: <code className="text-text-muted">{derivedId}</code>
+            </>
+          ) : undefined
+        }
       />
-      {derivedId && (
-        <div className="text-meta text-text-faint -mt-1">
-          Provider id: <code className="text-text-muted">{derivedId}</code>
-        </div>
-      )}
       <CustomInput
         label="Base URL"
         placeholder="https://api.voska.org/v1"
@@ -253,14 +185,15 @@ export function CustomProviderForm({
       />
       <CustomInput
         label="API key (optional)"
-        placeholder="key"
+        placeholder="sk-…"
         value={apiKey}
         type="password"
+        autoComplete="off"
         disabled={busy}
         onChange={setApiKey}
       />
       {error && (
-        <div role="alert" className="text-meta" style={{ color: DANGER }}>
+        <div role="alert" className="text-meta text-danger">
           {error}
         </div>
       )}
@@ -343,6 +276,8 @@ function CustomInput(props: {
   disabled: boolean;
   onChange: (v: string) => void;
   onReset?: () => void;
+  autoComplete?: string;
+  help?: ReactNode;
 }) {
   return (
     <Field
@@ -354,6 +289,8 @@ function CustomInput(props: {
       mono={false}
       disabled={props.disabled}
       onChange={(e) => props.onChange(e.target.value)}
+      autoComplete={props.autoComplete}
+      help={props.help}
       footer={
         props.onReset ? (
           <button

--- a/src/renderer/routingControls.smoke.test.tsx
+++ b/src/renderer/routingControls.smoke.test.tsx
@@ -152,7 +152,7 @@ async function smokeDrive(opts: {
   const enqueue = () => {
     const root = scope === "container" ? h.container : document.body;
     for (const el of Array.from(root.querySelectorAll<Element>(INTERACTIVE))) {
-      const id = controlId(el);
+    const id = controlId(el);
       if (seen.has(id)) continue;
       seen.add(id);
       queue.push(el);
@@ -282,7 +282,7 @@ describe("control smoke — AccountsCard", () => {
   });
 
   const ACCOUNTS_INERT: Record<string, string> = {
-    "button|||||Add endpoint Probe": "Add-endpoint Probe is disabled until name + baseURL are entered (draftErr gate)",
+    "button|button|Probe endpoint": "Add-endpoint Probe is disabled until name + baseURL are entered (draftErr gate)",
   };
 
   it("every control it renders does something observable", async () => {


### PR DESCRIPTION
Refactor BET-1311: remove the compact/full fork in `CustomProviderForm`.

`CustomProviderForm` previously forked on a `compact` prop into two full render
branches (`70` lines of duplication) that had drifted: the compact branch
hand-rolled a raw `<input type="password">` and two raw `<button>`s, so the
API-key box and the primary action were visibly different controls in Settings
vs onboarding.

This deletes the fork:
- Removed the `compact` prop, its type, JSDoc, and the whole `if (compact)` branch.
- One render tree using the shared `CustomInput` (→ `Field`) for all three fields
  (Name, Base URL, API key) and the shared `Button` primitive for the action.
- Added `autoComplete` + `help` passthroughs to `CustomInput`; derived provider
  id now renders in `Field`'s existing `help` slot.
- Single heading ("Add endpoint"), single wrapper
  (`rounded-md border border-dashed border-border p-4 space-y-3`), single error
  element using the `text-danger` token (deleted the `DANGER` inline-style const).
- Updated `AccountsCard.tsx:726` call site (dropped `compact`).
- Updated the `ACCOUNTS_INERT` smoke allowlist key to the new control id
  (`button|button|Probe endpoint` — read verbatim from the harness, the button
  label single-sourced to "Probe endpoint").
- docs/components.md: added `CustomProviderForm.tsx` to the Button adopters cell.

Net deletion: 84 deletions / 21 insertions.

`ModelList` is untouched (its search + All/None rework is a separate issue).

**Files changed:** 4
- `src/renderer/CustomProviderForm.tsx`
- `src/renderer/AccountsCard.tsx`
- `src/renderer/routingControls.smoke.test.tsx`
- `docs/components.md`

**Verification results:**
- PR branch (`multica/BET-1311-one-render-tree` @ `6de27d26`):
  - typecheck: exit `0`. Errors: none. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
  - test: exit `0`, vitest `3554` pass / `7` skip / `0` fail (188 files); server `2694` pass / `0` fail. Failures: none. test log sha256: `f7d2ae4cdc3975f07ff21fbc90095d81fd29fa04fe564bfe01ada19a3b659ec3`
- Base (`main` @ `8f58daff`): unchanged base this PR was branched from; verified green historically.
- **Conclusion:** 0 pre-existing failures, 0 new failures on this PR.

**Base: origin/main @ `8f58daff`**
