### PR TITLE
test(ios): lock in claimGeneration staleness guard (BET-1309)

### DIFF
--- a/mobile/native/MantaUI/MantaOnboarding.swift
+++ b/mobile/native/MantaUI/MantaOnboarding.swift
@@ -210,7 +210,11 @@ final class MantaOnboardingFlow: ObservableObject {
         Task { await runClaim(payload, generation: generation) }
     }
 
-    private func runClaim(_ payload: MantaPairing.PairPayload, generation: Int) async {
+    /// Runs a claim for `payload` at `generation`. Internal (not private) so
+    /// the staleness-guard unit test can drive a stale generation's result and
+    /// assert its `phase`/`savedCredentials` writes are dropped. In production
+    /// it is only ever invoked by `startLinking` with the current generation.
+    func runClaim(_ payload: MantaPairing.PairPayload, generation: Int) async {
         defer { finishClaim(generation) }
         // The volunteer device-registry name is surfaced server-side so a
         // linked device is identifiable (§6.3).

--- a/mobile/native/MantaUITests/MantaOnboardingFlowTests.swift
+++ b/mobile/native/MantaUITests/MantaOnboardingFlowTests.swift
@@ -85,6 +85,45 @@ final class MantaOnboardingFlowTests: XCTestCase {
         XCTAssertEqual(requestCount, 1, "the in-flight guard drops the duplicate, so its 403 is never sent")
     }
 
+    /// BET-1309 — lock in the `claimGeneration` staleness guard directly. The
+    /// `claimInFlight` guard serialises claims, so the genuine out-of-order
+    /// interleave is unreachable through `receive` alone; drain it by driving
+    /// `runClaim` with a stale generation and asserting its write is dropped.
+    func testStaleClaimResultDoesNotOverwriteNewerClaim() async throws {
+        var requestCount = 0
+        let success: ([String: Any]) -> (HTTPURLResponse, Data) = { body in
+            let response = HTTPURLResponse(url: URL(string: "https://claim")!, statusCode: 200, httpVersion: nil, headerFields: nil)!
+            return (response, try! JSONSerialization.data(withJSONObject: body))
+        }
+        MockURLProtocol.handler = { request in
+            requestCount += 1
+            return success(["box_token": self.box, "box_id": self.box, "device_id": "dev_1"])
+        }
+        let flow = makeFlow()
+        let payload = payload()
+
+        // Two sequential claims advance `claimGeneration` to 2; the newest wins.
+        flow.receive(payload: payload)
+        _ = await awaitSettled(flow)
+        flow.receive(payload: payload)
+        _ = await awaitSettled(flow)
+        XCTAssertEqual(flow.phase, .notifications, "the newest claim succeeded")
+
+        // A stale result for the ORIGINAL (generation 1) claim arrives now. It
+        // reaches the network and classifies as .wrongCode, but because its
+        // generation is no longer current it must NOT write .failure(.rejected).
+        MockURLProtocol.handler = { request in
+            requestCount += 1
+            let response = HTTPURLResponse(url: request.url!, statusCode: 403, httpVersion: nil, headerFields: nil)!
+            return (response, Data("{\"error\":\"no\"}".utf8))
+        }
+        await flow.runClaim(payload, generation: 1)
+
+        XCTAssertEqual(requestCount, 3, "the stale claim's request really ran — only its write was suppressed")
+        XCTAssertEqual(flow.phase, .notifications, "a stale claim result must not overwrite a newer claim")
+        XCTAssertFalse(isRejected(flow))
+    }
+
     private func isRejected(_ flow: MantaOnboardingFlow) -> Bool {
         if case .failure(.rejected) = flow.phase { return true }
         return false


### PR DESCRIPTION
## BET-1309 — iOS: unit test for the claimGeneration staleness guard

Follow-up to BET-1308 (PR #1310). Adds the standalone unit test the
implementer disclosed was missing: the out-of-order interleave the
`claimGeneration` guard protects against is not reachable through the
public `receive` API because `claimInFlight` serialises claims.

### Change

- `mobile/native/MantaUITests/MantaOnboardingFlowTests.swift` —
  `testStaleClaimResultDoesNotOverwriteNewerClaim`: advances
  `claimGeneration` to 2 via two genuine claims, then drives
  `runClaim(payload, generation: 1)` with a stale generation whose result
  would classify as `.wrongCode`. Asserts the stale write to `phase` is
  suppressed (stays `.notifications`, never `.rejected`), and that the
  request really ran (`requestCount == 3`) — proving the suppression
  happens at the generation guard, not because the call was skipped.
- `mobile/native/MantaUI/MantaOnboarding.swift` — demotes `runClaim` from
  `private` to internal (the minimal test seam; it was previously only
  reachable via `startLinking`, which the in-flight guard serialises). No
  behavior change — production still only ever invokes it from
  `startLinking` with the current generation.

Reuses the existing `MockURLProtocol` harness; no second HTTP stub.

### Verification

- **iOS `ios-mantaui test-unit`** (full `MantaUITests` suite): this requires
  the Mac toolchain and is being run via `macos` against this branch (the
  implementation agent has no Xcode). Result to be reported before review.
- **typecheck / test**: change is Swift-only under `mobile/native/`; no
  TypeScript or server test files touched.

Base: origin/main @ `cf06845a`
