### PR TITLE
fix(shared): pick the repo-mate a weights-repo id names (BET-1313)

### DIFF
--- a/src/server/fixtures/modelCatalog.fixture.json
+++ b/src/server/fixtures/modelCatalog.fixture.json
@@ -1,413 +1,527 @@
 [
-    {
-        "id": "qwen/qwen3.6-27b",
-        "name": "Qwen3.6-27B",
-        "family": "qwen",
-        "description": "Qwen3.6 tuned for long-context coding (exact-match fixture)",
-        "reasoning": true,
-        "tool_call": true,
-        "modalities": {
-            "input": [
-                "text"
-            ],
-            "output": [
-                "text"
-            ]
-        },
-        "open_weights": true,
-        "limit": {
-            "context": 131072,
-            "output": 8192
-        },
-        "benchmarks": [
-            {
-                "name": "SWE-Bench Verified",
-                "score": 58.4,
-                "metric": "resolved"
-            }
-        ]
+  {
+    "id": "qwen/qwen3.6-27b",
+    "name": "Qwen3.6-27B",
+    "family": "qwen",
+    "description": "Qwen3.6 tuned for long-context coding (exact-match fixture)",
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
     },
-    {
-        "id": "chutes/Ornith-9B",
-        "name": "Ornith 9B",
-        "family": "ornith",
-        "description": "Ornith family, 9B variant",
-        "reasoning": true,
-        "tool_call": true,
-        "modalities": {
-            "input": [
-                "text"
-            ],
-            "output": [
-                "text"
-            ]
-        },
-        "open_weights": true,
-        "limit": {
-            "context": 32768,
-            "output": 4096
-        }
+    "open_weights": true,
+    "limit": {
+      "context": 131072,
+      "output": 8192
     },
-    {
-        "id": "chutes/Ornith-31B",
-        "name": "Ornith 31B",
-        "family": "ornith",
-        "description": "Ornith family, 31B variant",
-        "reasoning": true,
-        "tool_call": true,
-        "modalities": {
-            "input": [
-                "text"
-            ],
-            "output": [
-                "text"
-            ]
-        },
-        "open_weights": true,
-        "limit": {
-            "context": 65536,
-            "output": 8192
-        }
+    "benchmarks": [
+      {
+        "name": "SWE-Bench Verified",
+        "score": 58.4,
+        "metric": "resolved"
+      }
+    ]
+  },
+  {
+    "id": "chutes/Ornith-9B",
+    "name": "Ornith 9B",
+    "family": "ornith",
+    "description": "Ornith family, 9B variant",
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
     },
-    {
-        "id": "chutes/Ornith-35B",
-        "name": "Ornith 35B",
-        "family": "ornith",
-        "description": "Ornith family, 35B variant",
-        "reasoning": true,
-        "tool_call": true,
-        "modalities": {
-            "input": [
-                "text"
-            ],
-            "output": [
-                "text"
-            ]
-        },
-        "open_weights": true,
-        "limit": {
-            "context": 65536,
-            "output": 8192
-        }
-    },
-    {
-        "id": "chutes/Ornith-397B",
-        "name": "Ornith 397B",
-        "family": "ornith",
-        "description": "Ornith family, 397B variant",
-        "reasoning": false,
-        "tool_call": true,
-        "modalities": {
-            "input": [
-                "text"
-            ],
-            "output": [
-                "text"
-            ]
-        },
-        "open_weights": true,
-        "limit": {
-            "context": 262144,
-            "output": 32768
-        }
-    },
-    {
-        "id": "minimax/MiniMax-M3",
-        "name": "MiniMax-M3",
-        "family": "minimax",
-        "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
-        "attachment": true,
-        "reasoning": true,
-        "tool_call": true,
-        "modalities": {
-            "input": [
-                "text",
-                "image",
-                "video"
-            ],
-            "output": [
-                "text"
-            ]
-        },
-        "open_weights": true,
-        "limit": {
-            "context": 512000,
-            "output": 128000
-        },
-        "benchmarks": [
-            {
-                "name": "SWE-Bench Verified",
-                "score": 80.5,
-                "metric": "resolved"
-            }
-        ]
-    },
-    {
-        "id": "deepseek/deepseek-chat",
-        "name": "DeepSeek Chat",
-        "family": "deepseek",
-        "description": "DeepSeek general chat model",
-        "reasoning": false,
-        "tool_call": true,
-        "modalities": {
-            "input": [
-                "text"
-            ],
-            "output": [
-                "text"
-            ]
-        },
-        "open_weights": true,
-        "limit": {
-            "context": 65536,
-            "output": 8192
-        }
-    },
-    {
-        "id": "alibaba/qwen3-32b",
-        "name": "Qwen3 32B",
-        "family": "qwen",
-        "weights": [
-            {
-                "label": "Hugging Face",
-                "url": "https://huggingface.co/Qwen/Qwen3-32B"
-            }
-        ],
-        "limit": {
-            "context": 131072,
-            "output": 16384
-        },
-        "description": "Qwen3 32B, open-weight (exact fixture for release weights repo)"
-    },
-    {
-        "id": "alibaba/qwen3-30b-a3b",
-        "name": "Qwen3 30B A3B",
-        "family": "qwen",
-        "weights": [
-            {
-                "label": "Hugging Face",
-                "url": "https://huggingface.co/Qwen/Qwen3-30B-A3B"
-            }
-        ],
-        "limit": {
-            "context": 65536,
-            "output": 8192
-        },
-        "description": "Qwen3 30B-A3B \u2014 a sibling size that must NOT be conflated with qwen3-32b"
-    },
-    {
-        "id": "zhipuai/glm-5.2",
-        "name": "Glm 5.2",
-        "family": "glm",
-        "weights": [
-            {
-                "label": "Hugging Face",
-                "url": "https://huggingface.co/zai-org/GLM-5.2"
-            }
-        ],
-        "limit": {
-            "context": 131072,
-            "output": 16384
-        },
-        "description": "GLM-5.2; reseller vendor disagrees with the catalogue"
-    },
-    {
-        "id": "zhipuai/glm-5.1",
-        "name": "Glm 5.1",
-        "family": "glm",
-        "weights": [
-            {
-                "label": "Hugging Face",
-                "url": "https://huggingface.co/zai-org/GLM-5.1"
-            }
-        ],
-        "limit": {
-            "context": 131072,
-            "output": 16384
-        },
-        "description": "GLM-5.1 \u2014 must not be conflated with GLM-5.2"
-    },
-    {
-        "id": "moonshotai/kimi-k3",
-        "name": "Kimi K3",
-        "family": "kimi",
-        "weights": [
-            {
-                "label": "Hugging Face",
-                "url": "https://huggingface.co/moonshotai/Kimi-K3"
-            }
-        ],
-        "limit": {
-            "context": 131072,
-            "output": 16384
-        },
-        "description": "Kimi K3, weights repo"
-    },
-    {
-        "id": "openai/gpt-5.5",
-        "name": "Gpt 5.5",
-        "family": "gpt",
-        "limit": {
-            "context": 128000,
-            "output": 16000
-        },
-        "description": "GPT-5.5 \u2014 tier-decoration corroboration fixture"
-    },
-    {
-        "id": "openai/gpt-5.5-pro",
-        "name": "Gpt 5.5 Pro",
-        "family": "gpt",
-        "limit": {
-            "context": 128000,
-            "output": 40000
-        },
-        "description": "GPT-5.5 Pro \u2014 the richer sibling gpt-5.5-fast must NOT hit"
-    },
-    {
-        "id": "anthropic/claude-opus-5",
-        "name": "Claude Opus 5",
-        "family": "claude",
-        "limit": {
-            "context": 200000,
-            "output": 64000
-        },
-        "description": "Claude Opus 5 \u2014 claude-opus-5-fast must resolve here, not 4-5"
-    },
-    {
-        "id": "anthropic/claude-opus-4-5",
-        "name": "Claude Opus 4 5",
-        "family": "claude",
-        "limit": {
-            "context": 200000,
-            "output": 64000
-        },
-        "description": "Claude Opus 4-5 \u2014 version inequality must reject it"
-    },
-    {
-        "id": "nvidia/nemotron-3-ultra-550b-a55b",
-        "name": "Nemotron 3 Ultra 550B A55B",
-        "family": "nemotron",
-        "limit": {
-            "context": 131072,
-            "output": 16384
-        },
-        "description": "Nemotron 3 Ultra 550B-A55B \u2014 size present on one side only"
-    },
-    {
-        "id": "meta/muse-spark-1.2",
-        "name": "Muse Spark 1.2",
-        "family": "muse",
-        "limit": {
-            "context": 32768,
-            "output": 4096
-        },
-        "description": "Muse Spark 1.2 \u2014 multi-token decoration fixture"
-    },
-    {
-        "id": "mistral/mistral-nemo",
-        "name": "Mistral Nemo",
-        "family": "mistral",
-        "limit": {
-            "context": 128000,
-            "output": 16384
-        },
-        "description": "Mistral Nemo \u2014 date-only owner-mismatch fixture"
-    },
-    {
-        "id": "anthropic/claude-opus-4-5-20251101",
-        "name": "Claude Opus 4 5",
-        "family": "claude",
-        "limit": {
-            "context": 200000,
-            "output": 64000
-        },
-        "description": "Dated alias of claude-opus-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
-        "synthesize": false
-    },
-    {
-        "id": "anthropic/claude-sonnet-4-5",
-        "name": "Claude Sonnet 4 5",
-        "family": "claude",
-        "limit": {
-            "context": 200000,
-            "output": 64000
-        },
-        "description": "Claude Sonnet 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
-    },
-    {
-        "id": "anthropic/claude-sonnet-4-5-20250929",
-        "name": "Claude Sonnet 4 5",
-        "family": "claude",
-        "limit": {
-            "context": 200000,
-            "output": 64000
-        },
-        "description": "Dated alias of claude-sonnet-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
-        "synthesize": false
-    },
-    {
-        "id": "anthropic/claude-haiku-4-5",
-        "name": "Claude Haiku 4 5",
-        "family": "claude",
-        "limit": {
-            "context": 200000,
-            "output": 64000
-        },
-        "description": "Claude Haiku 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
-    },
-    {
-        "id": "anthropic/claude-haiku-4-5-20251001",
-        "name": "Claude Haiku 4 5",
-        "family": "claude",
-        "limit": {
-            "context": 200000,
-            "output": 64000
-        },
-        "description": "Dated alias of claude-haiku-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
-        "synthesize": false
-    },
-    {
-        "id": "zhipuai/glm-5",
-        "name": "Glm 5",
-        "family": "glm",
-        "limit": {
-            "context": 131072,
-            "output": 16384
-        },
-        "description": "GLM-5 \u2014 over-collapse guard: distinct from glm-5-turbo (BET-1307)",
-        "synthesize": false
-    },
-    {
-        "id": "zhipuai/glm-5-turbo",
-        "name": "Glm 5 Turbo",
-        "family": "glm",
-        "limit": {
-            "context": 131072,
-            "output": 16384
-        },
-        "description": "GLM-5 turbo \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
-        "synthesize": false
-    },
-    {
-        "id": "moonshotai/kimi-k2.7-code",
-        "name": "Kimi K2.7 Code",
-        "family": "kimi",
-        "limit": {
-            "context": 131072,
-            "output": 16384
-        },
-        "description": "Kimi K2.7 Code \u2014 over-collapse guard: distinct from the highspeed sibling (BET-1307)",
-        "synthesize": false
-    },
-    {
-        "id": "moonshotai/kimi-k2.7-code-highspeed",
-        "name": "Kimi K2.7 Code Highspeed",
-        "family": "kimi",
-        "limit": {
-            "context": 131072,
-            "output": 16384
-        },
-        "description": "Kimi K2.7 Code Highspeed \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
-        "synthesize": false
+    "open_weights": true,
+    "limit": {
+      "context": 32768,
+      "output": 4096
     }
+  },
+  {
+    "id": "chutes/Ornith-31B",
+    "name": "Ornith 31B",
+    "family": "ornith",
+    "description": "Ornith family, 31B variant",
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "limit": {
+      "context": 65536,
+      "output": 8192
+    }
+  },
+  {
+    "id": "chutes/Ornith-35B",
+    "name": "Ornith 35B",
+    "family": "ornith",
+    "description": "Ornith family, 35B variant",
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "limit": {
+      "context": 65536,
+      "output": 8192
+    }
+  },
+  {
+    "id": "chutes/Ornith-397B",
+    "name": "Ornith 397B",
+    "family": "ornith",
+    "description": "Ornith family, 397B variant",
+    "reasoning": false,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "limit": {
+      "context": 262144,
+      "output": 32768
+    }
+  },
+  {
+    "id": "minimax/MiniMax-M3",
+    "name": "MiniMax-M3",
+    "family": "minimax",
+    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+    "attachment": true,
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text",
+        "image",
+        "video"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "limit": {
+      "context": 512000,
+      "output": 128000
+    },
+    "benchmarks": [
+      {
+        "name": "SWE-Bench Verified",
+        "score": 80.5,
+        "metric": "resolved"
+      }
+    ]
+  },
+  {
+    "id": "deepseek/deepseek-chat",
+    "name": "DeepSeek Chat",
+    "family": "deepseek",
+    "description": "DeepSeek general chat model",
+    "reasoning": false,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "limit": {
+      "context": 65536,
+      "output": 8192
+    },
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
+      }
+    ]
+  },
+  {
+    "id": "alibaba/qwen3-32b",
+    "name": "Qwen3 32B",
+    "family": "qwen",
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/Qwen/Qwen3-32B"
+      }
+    ],
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    },
+    "description": "Qwen3 32B, open-weight (exact fixture for release weights repo)"
+  },
+  {
+    "id": "alibaba/qwen3-30b-a3b",
+    "name": "Qwen3 30B A3B",
+    "family": "qwen",
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/Qwen/Qwen3-30B-A3B"
+      }
+    ],
+    "limit": {
+      "context": 65536,
+      "output": 8192
+    },
+    "description": "Qwen3 30B-A3B \u2014 a sibling size that must NOT be conflated with qwen3-32b"
+  },
+  {
+    "id": "zhipuai/glm-5.2",
+    "name": "Glm 5.2",
+    "family": "glm",
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/zai-org/GLM-5.2"
+      }
+    ],
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    },
+    "description": "GLM-5.2; reseller vendor disagrees with the catalogue"
+  },
+  {
+    "id": "zhipuai/glm-5.1",
+    "name": "Glm 5.1",
+    "family": "glm",
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/zai-org/GLM-5.1"
+      }
+    ],
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    },
+    "description": "GLM-5.1 \u2014 must not be conflated with GLM-5.2"
+  },
+  {
+    "id": "moonshotai/kimi-k3",
+    "name": "Kimi K3",
+    "family": "kimi",
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/moonshotai/Kimi-K3"
+      }
+    ],
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    },
+    "description": "Kimi K3, weights repo"
+  },
+  {
+    "id": "openai/gpt-5.5",
+    "name": "Gpt 5.5",
+    "family": "gpt",
+    "limit": {
+      "context": 128000,
+      "output": 16000
+    },
+    "description": "GPT-5.5 \u2014 tier-decoration corroboration fixture"
+  },
+  {
+    "id": "openai/gpt-5.5-pro",
+    "name": "Gpt 5.5 Pro",
+    "family": "gpt",
+    "limit": {
+      "context": 128000,
+      "output": 40000
+    },
+    "description": "GPT-5.5 Pro \u2014 the richer sibling gpt-5.5-fast must NOT hit"
+  },
+  {
+    "id": "anthropic/claude-opus-5",
+    "name": "Claude Opus 5",
+    "family": "claude",
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    },
+    "description": "Claude Opus 5 \u2014 claude-opus-5-fast must resolve here, not 4-5"
+  },
+  {
+    "id": "anthropic/claude-opus-4-5",
+    "name": "Claude Opus 4 5",
+    "family": "claude",
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    },
+    "description": "Claude Opus 4-5 \u2014 version inequality must reject it"
+  },
+  {
+    "id": "nvidia/nemotron-3-ultra-550b-a55b",
+    "name": "Nemotron 3 Ultra 550B A55B",
+    "family": "nemotron",
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    },
+    "description": "Nemotron 3 Ultra 550B-A55B \u2014 size present on one side only"
+  },
+  {
+    "id": "meta/muse-spark-1.2",
+    "name": "Muse Spark 1.2",
+    "family": "muse",
+    "limit": {
+      "context": 32768,
+      "output": 4096
+    },
+    "description": "Muse Spark 1.2 \u2014 multi-token decoration fixture"
+  },
+  {
+    "id": "mistral/mistral-nemo",
+    "name": "Mistral Nemo",
+    "family": "mistral",
+    "limit": {
+      "context": 128000,
+      "output": 16384
+    },
+    "description": "Mistral Nemo \u2014 date-only owner-mismatch fixture"
+  },
+  {
+    "id": "anthropic/claude-opus-4-5-20251101",
+    "name": "Claude Opus 4 5",
+    "family": "claude",
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    },
+    "description": "Dated alias of claude-opus-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
+    "synthesize": false
+  },
+  {
+    "id": "anthropic/claude-sonnet-4-5",
+    "name": "Claude Sonnet 4 5",
+    "family": "claude",
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    },
+    "description": "Claude Sonnet 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
+  },
+  {
+    "id": "anthropic/claude-sonnet-4-5-20250929",
+    "name": "Claude Sonnet 4 5",
+    "family": "claude",
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    },
+    "description": "Dated alias of claude-sonnet-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
+    "synthesize": false
+  },
+  {
+    "id": "anthropic/claude-haiku-4-5",
+    "name": "Claude Haiku 4 5",
+    "family": "claude",
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    },
+    "description": "Claude Haiku 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
+  },
+  {
+    "id": "anthropic/claude-haiku-4-5-20251001",
+    "name": "Claude Haiku 4 5",
+    "family": "claude",
+    "limit": {
+      "context": 200000,
+      "output": 64000
+    },
+    "description": "Dated alias of claude-haiku-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
+    "synthesize": false
+  },
+  {
+    "id": "zhipuai/glm-5",
+    "name": "Glm 5",
+    "family": "glm",
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    },
+    "description": "GLM-5 \u2014 over-collapse guard: distinct from glm-5-turbo (BET-1307)",
+    "synthesize": false
+  },
+  {
+    "id": "zhipuai/glm-5-turbo",
+    "name": "Glm 5 Turbo",
+    "family": "glm",
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    },
+    "description": "GLM-5 turbo \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
+    "synthesize": false
+  },
+  {
+    "id": "moonshotai/kimi-k2.7-code",
+    "name": "Kimi K2.7 Code",
+    "family": "kimi",
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    },
+    "description": "Kimi K2.7 Code \u2014 over-collapse guard: distinct from the highspeed sibling (BET-1307)",
+    "synthesize": false
+  },
+  {
+    "id": "moonshotai/kimi-k2.7-code-highspeed",
+    "name": "Kimi K2.7 Code Highspeed",
+    "family": "kimi",
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    },
+    "description": "Kimi K2.7 Code Highspeed \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
+    "synthesize": false
+  },
+  {
+    "id": "deepseek/deepseek-v3.2",
+    "name": "DeepSeek V3.2",
+    "family": "deepseek",
+    "description": "DeepSeek V3.2 general model",
+    "reasoning": false,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
+      }
+    ],
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "deepseek/deepseek-reasoner",
+    "name": "DeepSeek Reasoner",
+    "family": "deepseek",
+    "description": "DeepSeek reasoning model",
+    "reasoning": true,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
+      }
+    ],
+    "limit": {
+      "context": 131072,
+      "output": 16384
+    }
+  },
+  {
+    "id": "acme/synth-alpha-1.0",
+    "name": "Synth Alpha 1.0",
+    "family": "synth",
+    "description": "Synthetic repo-mate for the BET-1313 over-collapse guard",
+    "reasoning": false,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/acme/Synth-1.0"
+      }
+    ],
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  },
+  {
+    "id": "acme/synth-beta-1.0",
+    "name": "Synth Beta 1.0",
+    "family": "synth",
+    "description": "Synthetic repo-mate for the BET-1313 over-collapse guard",
+    "reasoning": false,
+    "tool_call": true,
+    "modalities": {
+      "input": [
+        "text"
+      ],
+      "output": [
+        "text"
+      ]
+    },
+    "open_weights": true,
+    "weights": [
+      {
+        "label": "Hugging Face",
+        "url": "https://huggingface.co/acme/Synth-1.0"
+      }
+    ],
+    "limit": {
+      "context": 32768,
+      "output": 8192
+    }
+  }
 ]

--- a/src/server/fixtures/modelCatalog.fixture.json
+++ b/src/server/fixtures/modelCatalog.fixture.json
@@ -1,527 +1,527 @@
 [
-  {
-    "id": "qwen/qwen3.6-27b",
-    "name": "Qwen3.6-27B",
-    "family": "qwen",
-    "description": "Qwen3.6 tuned for long-context coding (exact-match fixture)",
-    "reasoning": true,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+    {
+        "id": "qwen/qwen3.6-27b",
+        "name": "Qwen3.6-27B",
+        "family": "qwen",
+        "description": "Qwen3.6 tuned for long-context coding (exact-match fixture)",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "limit": {
+            "context": 131072,
+            "output": 8192
+        },
+        "benchmarks": [
+            {
+                "name": "SWE-Bench Verified",
+                "score": 58.4,
+                "metric": "resolved"
+            }
+        ]
     },
-    "open_weights": true,
-    "limit": {
-      "context": 131072,
-      "output": 8192
+    {
+        "id": "chutes/Ornith-9B",
+        "name": "Ornith 9B",
+        "family": "ornith",
+        "description": "Ornith family, 9B variant",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "limit": {
+            "context": 32768,
+            "output": 4096
+        }
     },
-    "benchmarks": [
-      {
-        "name": "SWE-Bench Verified",
-        "score": 58.4,
-        "metric": "resolved"
-      }
-    ]
-  },
-  {
-    "id": "chutes/Ornith-9B",
-    "name": "Ornith 9B",
-    "family": "ornith",
-    "description": "Ornith family, 9B variant",
-    "reasoning": true,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
+    {
+        "id": "chutes/Ornith-31B",
+        "name": "Ornith 31B",
+        "family": "ornith",
+        "description": "Ornith family, 31B variant",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "limit": {
+            "context": 65536,
+            "output": 8192
+        }
     },
-    "open_weights": true,
-    "limit": {
-      "context": 32768,
-      "output": 4096
+    {
+        "id": "chutes/Ornith-35B",
+        "name": "Ornith 35B",
+        "family": "ornith",
+        "description": "Ornith family, 35B variant",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "limit": {
+            "context": 65536,
+            "output": 8192
+        }
+    },
+    {
+        "id": "chutes/Ornith-397B",
+        "name": "Ornith 397B",
+        "family": "ornith",
+        "description": "Ornith family, 397B variant",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "limit": {
+            "context": 262144,
+            "output": 32768
+        }
+    },
+    {
+        "id": "minimax/MiniMax-M3",
+        "name": "MiniMax-M3",
+        "family": "minimax",
+        "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
+        "attachment": true,
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text",
+                "image",
+                "video"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "limit": {
+            "context": 512000,
+            "output": 128000
+        },
+        "benchmarks": [
+            {
+                "name": "SWE-Bench Verified",
+                "score": 80.5,
+                "metric": "resolved"
+            }
+        ]
+    },
+    {
+        "id": "deepseek/deepseek-chat",
+        "name": "DeepSeek Chat",
+        "family": "deepseek",
+        "description": "DeepSeek general chat model",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "limit": {
+            "context": 65536,
+            "output": 8192
+        },
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
+            }
+        ]
+    },
+    {
+        "id": "alibaba/qwen3-32b",
+        "name": "Qwen3 32B",
+        "family": "qwen",
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/Qwen/Qwen3-32B"
+            }
+        ],
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "Qwen3 32B, open-weight (exact fixture for release weights repo)"
+    },
+    {
+        "id": "alibaba/qwen3-30b-a3b",
+        "name": "Qwen3 30B A3B",
+        "family": "qwen",
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/Qwen/Qwen3-30B-A3B"
+            }
+        ],
+        "limit": {
+            "context": 65536,
+            "output": 8192
+        },
+        "description": "Qwen3 30B-A3B \u2014 a sibling size that must NOT be conflated with qwen3-32b"
+    },
+    {
+        "id": "zhipuai/glm-5.2",
+        "name": "Glm 5.2",
+        "family": "glm",
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/zai-org/GLM-5.2"
+            }
+        ],
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "GLM-5.2; reseller vendor disagrees with the catalogue"
+    },
+    {
+        "id": "zhipuai/glm-5.1",
+        "name": "Glm 5.1",
+        "family": "glm",
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/zai-org/GLM-5.1"
+            }
+        ],
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "GLM-5.1 \u2014 must not be conflated with GLM-5.2"
+    },
+    {
+        "id": "moonshotai/kimi-k3",
+        "name": "Kimi K3",
+        "family": "kimi",
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/moonshotai/Kimi-K3"
+            }
+        ],
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "Kimi K3, weights repo"
+    },
+    {
+        "id": "openai/gpt-5.5",
+        "name": "Gpt 5.5",
+        "family": "gpt",
+        "limit": {
+            "context": 128000,
+            "output": 16000
+        },
+        "description": "GPT-5.5 \u2014 tier-decoration corroboration fixture"
+    },
+    {
+        "id": "openai/gpt-5.5-pro",
+        "name": "Gpt 5.5 Pro",
+        "family": "gpt",
+        "limit": {
+            "context": 128000,
+            "output": 40000
+        },
+        "description": "GPT-5.5 Pro \u2014 the richer sibling gpt-5.5-fast must NOT hit"
+    },
+    {
+        "id": "anthropic/claude-opus-5",
+        "name": "Claude Opus 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Claude Opus 5 \u2014 claude-opus-5-fast must resolve here, not 4-5"
+    },
+    {
+        "id": "anthropic/claude-opus-4-5",
+        "name": "Claude Opus 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Claude Opus 4-5 \u2014 version inequality must reject it"
+    },
+    {
+        "id": "nvidia/nemotron-3-ultra-550b-a55b",
+        "name": "Nemotron 3 Ultra 550B A55B",
+        "family": "nemotron",
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "Nemotron 3 Ultra 550B-A55B \u2014 size present on one side only"
+    },
+    {
+        "id": "meta/muse-spark-1.2",
+        "name": "Muse Spark 1.2",
+        "family": "muse",
+        "limit": {
+            "context": 32768,
+            "output": 4096
+        },
+        "description": "Muse Spark 1.2 \u2014 multi-token decoration fixture"
+    },
+    {
+        "id": "mistral/mistral-nemo",
+        "name": "Mistral Nemo",
+        "family": "mistral",
+        "limit": {
+            "context": 128000,
+            "output": 16384
+        },
+        "description": "Mistral Nemo \u2014 date-only owner-mismatch fixture"
+    },
+    {
+        "id": "anthropic/claude-opus-4-5-20251101",
+        "name": "Claude Opus 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Dated alias of claude-opus-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "anthropic/claude-sonnet-4-5",
+        "name": "Claude Sonnet 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Claude Sonnet 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
+    },
+    {
+        "id": "anthropic/claude-sonnet-4-5-20250929",
+        "name": "Claude Sonnet 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Dated alias of claude-sonnet-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "anthropic/claude-haiku-4-5",
+        "name": "Claude Haiku 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Claude Haiku 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
+    },
+    {
+        "id": "anthropic/claude-haiku-4-5-20251001",
+        "name": "Claude Haiku 4 5",
+        "family": "claude",
+        "limit": {
+            "context": 200000,
+            "output": 64000
+        },
+        "description": "Dated alias of claude-haiku-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "zhipuai/glm-5",
+        "name": "Glm 5",
+        "family": "glm",
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "GLM-5 \u2014 over-collapse guard: distinct from glm-5-turbo (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "zhipuai/glm-5-turbo",
+        "name": "Glm 5 Turbo",
+        "family": "glm",
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "GLM-5 turbo \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "moonshotai/kimi-k2.7-code",
+        "name": "Kimi K2.7 Code",
+        "family": "kimi",
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "Kimi K2.7 Code \u2014 over-collapse guard: distinct from the highspeed sibling (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "moonshotai/kimi-k2.7-code-highspeed",
+        "name": "Kimi K2.7 Code Highspeed",
+        "family": "kimi",
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        },
+        "description": "Kimi K2.7 Code Highspeed \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
+        "synthesize": false
+    },
+    {
+        "id": "deepseek/deepseek-v3.2",
+        "name": "DeepSeek V3.2",
+        "family": "deepseek",
+        "description": "DeepSeek V3.2 general model",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
+            }
+        ],
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        }
+    },
+    {
+        "id": "deepseek/deepseek-reasoner",
+        "name": "DeepSeek Reasoner",
+        "family": "deepseek",
+        "description": "DeepSeek reasoning model",
+        "reasoning": true,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
+            }
+        ],
+        "limit": {
+            "context": 131072,
+            "output": 16384
+        }
+    },
+    {
+        "id": "acme/synth-alpha-1.0",
+        "name": "Synth Alpha 1.0",
+        "family": "synth",
+        "description": "Synthetic repo-mate for the BET-1313 over-collapse guard",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/acme/Synth-1.0"
+            }
+        ],
+        "limit": {
+            "context": 32768,
+            "output": 8192
+        }
+    },
+    {
+        "id": "acme/synth-beta-1.0",
+        "name": "Synth Beta 1.0",
+        "family": "synth",
+        "description": "Synthetic repo-mate for the BET-1313 over-collapse guard",
+        "reasoning": false,
+        "tool_call": true,
+        "modalities": {
+            "input": [
+                "text"
+            ],
+            "output": [
+                "text"
+            ]
+        },
+        "open_weights": true,
+        "weights": [
+            {
+                "label": "Hugging Face",
+                "url": "https://huggingface.co/acme/Synth-1.0"
+            }
+        ],
+        "limit": {
+            "context": 32768,
+            "output": 8192
+        }
     }
-  },
-  {
-    "id": "chutes/Ornith-31B",
-    "name": "Ornith 31B",
-    "family": "ornith",
-    "description": "Ornith family, 31B variant",
-    "reasoning": true,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "limit": {
-      "context": 65536,
-      "output": 8192
-    }
-  },
-  {
-    "id": "chutes/Ornith-35B",
-    "name": "Ornith 35B",
-    "family": "ornith",
-    "description": "Ornith family, 35B variant",
-    "reasoning": true,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "limit": {
-      "context": 65536,
-      "output": 8192
-    }
-  },
-  {
-    "id": "chutes/Ornith-397B",
-    "name": "Ornith 397B",
-    "family": "ornith",
-    "description": "Ornith family, 397B variant",
-    "reasoning": false,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "limit": {
-      "context": 262144,
-      "output": 32768
-    }
-  },
-  {
-    "id": "minimax/MiniMax-M3",
-    "name": "MiniMax-M3",
-    "family": "minimax",
-    "description": "MiniMax multimodal model for long-context coding, perception, and agent planning",
-    "attachment": true,
-    "reasoning": true,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text",
-        "image",
-        "video"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "limit": {
-      "context": 512000,
-      "output": 128000
-    },
-    "benchmarks": [
-      {
-        "name": "SWE-Bench Verified",
-        "score": 80.5,
-        "metric": "resolved"
-      }
-    ]
-  },
-  {
-    "id": "deepseek/deepseek-chat",
-    "name": "DeepSeek Chat",
-    "family": "deepseek",
-    "description": "DeepSeek general chat model",
-    "reasoning": false,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "limit": {
-      "context": 65536,
-      "output": 8192
-    },
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
-      }
-    ]
-  },
-  {
-    "id": "alibaba/qwen3-32b",
-    "name": "Qwen3 32B",
-    "family": "qwen",
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/Qwen/Qwen3-32B"
-      }
-    ],
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    },
-    "description": "Qwen3 32B, open-weight (exact fixture for release weights repo)"
-  },
-  {
-    "id": "alibaba/qwen3-30b-a3b",
-    "name": "Qwen3 30B A3B",
-    "family": "qwen",
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/Qwen/Qwen3-30B-A3B"
-      }
-    ],
-    "limit": {
-      "context": 65536,
-      "output": 8192
-    },
-    "description": "Qwen3 30B-A3B \u2014 a sibling size that must NOT be conflated with qwen3-32b"
-  },
-  {
-    "id": "zhipuai/glm-5.2",
-    "name": "Glm 5.2",
-    "family": "glm",
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/zai-org/GLM-5.2"
-      }
-    ],
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    },
-    "description": "GLM-5.2; reseller vendor disagrees with the catalogue"
-  },
-  {
-    "id": "zhipuai/glm-5.1",
-    "name": "Glm 5.1",
-    "family": "glm",
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/zai-org/GLM-5.1"
-      }
-    ],
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    },
-    "description": "GLM-5.1 \u2014 must not be conflated with GLM-5.2"
-  },
-  {
-    "id": "moonshotai/kimi-k3",
-    "name": "Kimi K3",
-    "family": "kimi",
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/moonshotai/Kimi-K3"
-      }
-    ],
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    },
-    "description": "Kimi K3, weights repo"
-  },
-  {
-    "id": "openai/gpt-5.5",
-    "name": "Gpt 5.5",
-    "family": "gpt",
-    "limit": {
-      "context": 128000,
-      "output": 16000
-    },
-    "description": "GPT-5.5 \u2014 tier-decoration corroboration fixture"
-  },
-  {
-    "id": "openai/gpt-5.5-pro",
-    "name": "Gpt 5.5 Pro",
-    "family": "gpt",
-    "limit": {
-      "context": 128000,
-      "output": 40000
-    },
-    "description": "GPT-5.5 Pro \u2014 the richer sibling gpt-5.5-fast must NOT hit"
-  },
-  {
-    "id": "anthropic/claude-opus-5",
-    "name": "Claude Opus 5",
-    "family": "claude",
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    },
-    "description": "Claude Opus 5 \u2014 claude-opus-5-fast must resolve here, not 4-5"
-  },
-  {
-    "id": "anthropic/claude-opus-4-5",
-    "name": "Claude Opus 4 5",
-    "family": "claude",
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    },
-    "description": "Claude Opus 4-5 \u2014 version inequality must reject it"
-  },
-  {
-    "id": "nvidia/nemotron-3-ultra-550b-a55b",
-    "name": "Nemotron 3 Ultra 550B A55B",
-    "family": "nemotron",
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    },
-    "description": "Nemotron 3 Ultra 550B-A55B \u2014 size present on one side only"
-  },
-  {
-    "id": "meta/muse-spark-1.2",
-    "name": "Muse Spark 1.2",
-    "family": "muse",
-    "limit": {
-      "context": 32768,
-      "output": 4096
-    },
-    "description": "Muse Spark 1.2 \u2014 multi-token decoration fixture"
-  },
-  {
-    "id": "mistral/mistral-nemo",
-    "name": "Mistral Nemo",
-    "family": "mistral",
-    "limit": {
-      "context": 128000,
-      "output": 16384
-    },
-    "description": "Mistral Nemo \u2014 date-only owner-mismatch fixture"
-  },
-  {
-    "id": "anthropic/claude-opus-4-5-20251101",
-    "name": "Claude Opus 4 5",
-    "family": "claude",
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    },
-    "description": "Dated alias of claude-opus-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
-    "synthesize": false
-  },
-  {
-    "id": "anthropic/claude-sonnet-4-5",
-    "name": "Claude Sonnet 4 5",
-    "family": "claude",
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    },
-    "description": "Claude Sonnet 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
-  },
-  {
-    "id": "anthropic/claude-sonnet-4-5-20250929",
-    "name": "Claude Sonnet 4 5",
-    "family": "claude",
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    },
-    "description": "Dated alias of claude-sonnet-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
-    "synthesize": false
-  },
-  {
-    "id": "anthropic/claude-haiku-4-5",
-    "name": "Claude Haiku 4 5",
-    "family": "claude",
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    },
-    "description": "Claude Haiku 4.5 base \u2014 dated-alias collision fixture (BET-1307)"
-  },
-  {
-    "id": "anthropic/claude-haiku-4-5-20251001",
-    "name": "Claude Haiku 4 5",
-    "family": "claude",
-    "limit": {
-      "context": 200000,
-      "output": 64000
-    },
-    "description": "Dated alias of claude-haiku-4-5 (undated name) \u2014 must collapse onto the base (BET-1307)",
-    "synthesize": false
-  },
-  {
-    "id": "zhipuai/glm-5",
-    "name": "Glm 5",
-    "family": "glm",
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    },
-    "description": "GLM-5 \u2014 over-collapse guard: distinct from glm-5-turbo (BET-1307)",
-    "synthesize": false
-  },
-  {
-    "id": "zhipuai/glm-5-turbo",
-    "name": "Glm 5 Turbo",
-    "family": "glm",
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    },
-    "description": "GLM-5 turbo \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
-    "synthesize": false
-  },
-  {
-    "id": "moonshotai/kimi-k2.7-code",
-    "name": "Kimi K2.7 Code",
-    "family": "kimi",
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    },
-    "description": "Kimi K2.7 Code \u2014 over-collapse guard: distinct from the highspeed sibling (BET-1307)",
-    "synthesize": false
-  },
-  {
-    "id": "moonshotai/kimi-k2.7-code-highspeed",
-    "name": "Kimi K2.7 Code Highspeed",
-    "family": "kimi",
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    },
-    "description": "Kimi K2.7 Code Highspeed \u2014 over-collapse guard: one-word decoration is an extra soft token (BET-1307)",
-    "synthesize": false
-  },
-  {
-    "id": "deepseek/deepseek-v3.2",
-    "name": "DeepSeek V3.2",
-    "family": "deepseek",
-    "description": "DeepSeek V3.2 general model",
-    "reasoning": false,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
-      }
-    ],
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    }
-  },
-  {
-    "id": "deepseek/deepseek-reasoner",
-    "name": "DeepSeek Reasoner",
-    "family": "deepseek",
-    "description": "DeepSeek reasoning model",
-    "reasoning": true,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/deepseek-ai/DeepSeek-V3.2"
-      }
-    ],
-    "limit": {
-      "context": 131072,
-      "output": 16384
-    }
-  },
-  {
-    "id": "acme/synth-alpha-1.0",
-    "name": "Synth Alpha 1.0",
-    "family": "synth",
-    "description": "Synthetic repo-mate for the BET-1313 over-collapse guard",
-    "reasoning": false,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/acme/Synth-1.0"
-      }
-    ],
-    "limit": {
-      "context": 32768,
-      "output": 8192
-    }
-  },
-  {
-    "id": "acme/synth-beta-1.0",
-    "name": "Synth Beta 1.0",
-    "family": "synth",
-    "description": "Synthetic repo-mate for the BET-1313 over-collapse guard",
-    "reasoning": false,
-    "tool_call": true,
-    "modalities": {
-      "input": [
-        "text"
-      ],
-      "output": [
-        "text"
-      ]
-    },
-    "open_weights": true,
-    "weights": [
-      {
-        "label": "Hugging Face",
-        "url": "https://huggingface.co/acme/Synth-1.0"
-      }
-    ],
-    "limit": {
-      "context": 32768,
-      "output": 8192
-    }
-  }
 ]

--- a/src/shared/modelCatalog.match.test.ts
+++ b/src/shared/modelCatalog.match.test.ts
@@ -290,6 +290,56 @@ describe("BET-1303 matcher — regression ids from real boxes (6.3)", () => {
   });
 });
 
+// BET-1313 — a weights repo shared by several catalogue entries must pick the
+// one the endpoint id names instead of short-circuiting to ambiguous. The
+// deepseek trio below all point at the same Hugging Face weights repo; the id
+// carries a `3.2` version token only `deepseek/deepseek-v3.2` has, so the
+// structural step (re-run over just the repo-mates) resolves it exactly. The
+// synthetic `synth` pair is the load-bearing over-collapse guard: two
+// repo-mates with the SAME version and size cannot be told apart, so they must
+// stay ambiguous rather than guessing.
+describe("BET-1313 — repo-mates of one weights repo resolve to the entry the id names", () => {
+  const matcher = createModelIndex(FIXTURE);
+
+  it("deepseek-ai/DeepSeek-V3.2-TEE → exact deepseek/deepseek-v3.2, not chat/reasoner", () => {
+    const res = matcher.matchModel("deepseek-ai/DeepSeek-V3.2-TEE");
+    expect(res.kind).toBe("exact");
+    expect(res.candidates[0]?.id).toBe("deepseek/deepseek-v3.2");
+    // Confidence stays "certain": the repo identity was a certain match and the
+    // structural step only chose which repo-mate the id names.
+    expect(res.confidence).toBe("certain");
+    const ids = res.candidates.map((c) => c.id);
+    expect(ids).not.toContain("deepseek/deepseek-chat");
+    expect(ids).not.toContain("deepseek/deepseek-reasoner");
+  });
+
+  it("repo-mates the id cannot distinguish (same version+size) stay ambiguous — no over-collapse", () => {
+    const res = matcher.matchModel("acme/Synth-1.0-TEE");
+    expect(res.kind).toBe("ambiguous");
+    expect(toSortedIds(res.candidates)).toEqual(["acme/synth-alpha-1.0", "acme/synth-beta-1.0"]);
+  });
+
+  it("ornith — a sibling-size family, NOT repo-mates — stays ambiguous x4", () => {
+    const res = matcher.matchModel("ornith");
+    expect(res.kind).toBe("ambiguous");
+    runnableOrnithSizes(res.candidates);
+  });
+
+  it("the single-repo path and the other layers are undisturbed", () => {
+    const rows = [
+      { local: "Qwen/Qwen3-32B-TEE", target: "alibaba/qwen3-32b" },
+      { local: "zai-org/GLM-5.2-TEE", target: "zhipuai/glm-5.2" },
+      { local: "claude-opus-5-fast", target: "anthropic/claude-opus-5" },
+    ];
+    for (const r of rows) {
+      const target = matcher.lookupModel(r.target);
+      const res = matcher.matchModel(r.local, target ? factsFrom(target) : undefined);
+      expect(res.kind, `${r.local} → ${res.candidates.map((c) => c.id).join(",")}`).toBe("exact");
+      expect(res.candidates[0]?.id, r.local).toBe(r.target);
+    }
+  });
+});
+
 // Assert an ambiguous result surfaces every sibling size of the family.
 function runnableOrnithSizes(candidates: ModelCatalogEntry[]): void {
   const ids = candidates.map((c) => c.id).sort();

--- a/src/shared/modelCatalog.mjs
+++ b/src/shared/modelCatalog.mjs
@@ -425,9 +425,30 @@ export function createModelIndex(entries) {
 
       // Layer 3 — the id is a weights-repo path of a catalogue entry. Same
       // dated-alias collapse; keeps exact/ambiguous consistent with layer 2.
+      //
+      // When several catalogue entries share the same weights repo (base +
+      // serving-name variants like chat/reasoner, or several sizes), the repo
+      // lookup cannot by itself tell which one the id names — but the endpoint
+      // id usually does: re-run the digit-anchored structural admission
+      // (layer 4) over JUST these repo-mates. The repo identity was a certain
+      // match, so the structural step only picks which repo-mate the id names;
+      // confidence stays "certain". If the id does not distinguish the
+      // repo-mates (same version AND size), layer 4 stays ambiguous and we keep
+      // the honest repo-ambiguous result rather than guessing (BET-1313).
       const repo = layer3Lookup(needle);
       if (repo) {
         const candidates = collapseAliases(repo.candidates);
+        if (candidates.length > 1) {
+          const structural = layer4Match(localModelId, candidates, endpointFacts);
+          if (structural.kind === "exact") {
+            return {
+              kind: "exact",
+              candidates: structural.candidates,
+              confidence: "certain",
+              evidence: structural.evidence ?? `weights repo ${repo.repo}`,
+            };
+          }
+        }
         const kind = candidates.length === 1 ? "exact" : "ambiguous";
         return {
           kind,


### PR DESCRIPTION
## BET-1313 — a weights-repo with several entries must pick the one the id names

When a weights-repo is shared by several catalogue entries (base + serving-name
variants like `chat`/`reasoner`, or several sizes under one repo), layer 3's repo
lookup returned ALL of them as `ambiguous ("certain")` and never applied the
digit-anchored structural logic that would notice the endpoint id itself names
one. Now, when the repo yields more than one candidate, we re-run the existing
`layer4Match` over just those repo-mates; if one survives uniquely, we return it
as `exact ("certain")` — the repo identity was a certain match, the structural
step only picks which repo-mate the id names. If the id can't distinguish the
repo-mates (same version AND size), it stays honestly `ambiguous`.

**Fix** — one branch in the layer-3 path, reusing the existing `layer4Match`
(no new module, no new parsing, no vendor/model names). `modelCatalog.mjs`
delta: +21 lines.

**Concrete case fixed:** `deepseek-ai/DeepSeek-V3.2-TEE` → exact
`deepseek/deepseek-v3.2` (was: ambiguous among v3.2/chat/reasoner, all on the
same HF repo).

**Fixture:** added the deepseek `v3.2` + `reasoner` entries (and the shared
weights URL on `chat`) plus a synthetic `synth-alpha/beta-1.0` pair that share a
repo with the SAME version+size — the load-bearing over-collapse guard.

**Over-collapse guard (state explicitly):** the synthetic fixture pair
`acme/Synth-1.0-TEE` stays `ambiguous` (``acme/synth-alpha-1.0`,
`acme/synth-beta-1.0``) — the id cannot tell them apart.

**Base:** `origin/main @ cf06845a`.

## Verification results

PR branch `multica/BET-1313-weights-repo-disambiguate` @ `d57679d4`:
- typecheck: exit 0, no errors. log sha256: `adab58dae4714563b5c28b02e93cd8054856ee78b37737d7648d5d5b62660402`
- test: exit 0, vitest `3569 passed | 7 skipped` (189 files), node:test `2694 pass / 0 fail`. log sha256: `4bfda0b1a2a327f22fe57d2c9ed7b77aca2c0a74124138fcff91b91ba3355b2f`

New tests: BET-1313 block covers (1) deepseek exact + negate chat/reasoner,
(2) over-collapse stay-ambiguous guard, (3) ornith stays ambiguous x4,
(4) `Qwen/Qwen3-32B-TEE` / `zai-org/GLM-5.2-TEE` / `claude-opus-5-fast` regression.
Source gate (6.4) passes (no vendor/model names in modelCatalog.mjs).

Base `main` is untouched by this additive change (0 failures on the PR branch =
0 new failures).
