### PR TITLE
fix(mobile): opaque composer keyboard bar band so keys aren't transparent (BET-1316)

### DIFF
--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -506,6 +506,18 @@ struct ComposerView: View {
                                   enabled: true) { showClearConfirm = true }
             }
             .frame(maxWidth: .infinity, alignment: .leading)
+            // BET-1316: an opaque background band so the keys read as solid
+            // instead of transparent over the transcript scrim. The composer's
+            // outer VStack pads by sp3 horizontally, so bleed past it (and the
+            // matching vertical margin) to make the band reach the composer's
+            // edges rather than float as an inset chip. Mirrors the session
+            // header's `.background(tokens.canvas)` + bottom hairline recipe.
+            .padding(.horizontal, -Metrics.spacing.sp3)
+            .padding(.vertical, -Metrics.spacing.sp2)
+            .background(tokens.canvas)
+            .overlay(alignment: .bottom) {
+                Rectangle().fill(tokens.borderSubtle).frame(height: 1)
+            }
         }
     }
 


### PR DESCRIPTION
iOS: give the composer keyboard bar a solid opaque background (BET-1316)

On-device follow-up to BET-1315. The relocated composer keyboard bar rendered its keys on `tokens.fill` (a ~4%-white tint) directly over the transcript scrim, so the keys read as transparent. This gives the bar a solid, opaque background band.

**Changes (one file):**
- `mobile/native/MantaUI/ComposerView.swift` — added an opaque `tokens.canvas` background band to `keyboardBarRow`, bled past the composer's outer `sp3` horizontal (and matching vertical) padding so it is contiguous and edge-to-edge within the composer rather than a floating inset chip, plus a 1pt `tokens.borderSubtle` bottom hairline — mirroring the existing `sessionHeaderBlock` recipe in `ChatScreen.swift`.
- The six controls, their order, identifiers, labels and actions are unchanged. Keys keep their `tokens.fill`. No new files, no literals, no new presentations.

**Verification:**
- `ios-mantaui` `test-unit` on `multica/BET-1316-composer-kb-opaque-band` @ `e3284e47`: **TEST SUCCEEDED — 642 tests, 0 failures** (both bundles compiled; only `MantaUITests` run).

Base: origin/main @ `556dfef3`
