### PR TITLE
fix: restore config remove ops via surgical JSONC edit + mandatory opencode restart (BET-1318)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1557,22 +1557,19 @@ picks its own default. `skillRegistryUrls: string[]` — extra opencode skill
 registry URLs (Settings UI), persisted to `~/.manta/config.json` via the generic
 `configUpdate` channel.
 
-**All opencode.jsonc writes go through opencode's own `PATCH /global/config`
-endpoint — never a hand-rolled read/merge/write (BET-1019).** The writer lives
-in `src/server/providers.mjs` (`patchGlobalConfig` → `setProviders` /
+**opencode.jsonc writes go through exactly two writers (BET-1318).** Upserts go
+through opencode's own `PATCH /global/config` (BET-1019) — the writer lives in
+`src/server/providers.mjs` (`patchGlobalConfig` → `setProviders` /
 `setSubagents`). The endpoint owns both the in-memory config and the file, edits
-the `.jsonc` surgically, and **preserves `//` comments** (verified live). The old
-behavior — comment-stripping the file before `JSON.parse` and starting from `{}`
-when unparseable, silently discarding comments and other keys — is deleted. Note
-**`PATCH /config` is INERT on 1.18.x** (returns 200 but changes nothing): only
-`PATCH /global/config` works, and it is the ONLY config writer — never write
-opencode.jsonc directly. `remove` ops (deactivating a subagent / deleting a
-provider endpoint) are NOT supported: opencode's PATCH endpoint has no delete
-semantics over HTTP (it deep-merges and rejects `null`), so `setProviders` /
-`setSubagents` REJECT a `remove` with an explicit error and never touch the file.
-Writing the file behind the endpoint's back is forbidden — memory and disk would
-diverge and a removed key would resurrect on the next upsert PATCH. Restoring
-deactivation is tracked in BET-1033. The default
+the `.jsonc` surgically, and **preserves `//` comments** (verified live). Note
+`PATCH /config` is INERT on 1.18.x (returns 200 but changes nothing): only
+`PATCH /global/config` works. Deletions go through `removeConfigKeys` (surgical
+jsonc-parser edit + mandatory opencode restart) — the PATCH endpoint has no
+delete semantics over HTTP (it deep-merges and rejects `null`), so a `remove`
+op (deactivating a subagent / deleting a provider endpoint / removing a
+reference) cannot be expressed through it; the restart is what stops a removed
+key resurrecting from opencode's stale in-memory config. There is no third
+writer. The default
 registry
 (`https://antoinedc.github.io/manta-skills`) ships in the opencode binary once
 the upstream PR (anomalyco/opencode#28068) lands; these are user-added extras.
@@ -2176,12 +2173,11 @@ agent blocks — so a not-yet-registered model still shows up.
   known model is NEVER touched (a user's hand-made agent survives). The I/O
   wrapper `syncSubagents({models, deactivated})` in `src/server/providers.mjs`
   reads `opencode.jsonc`, reconciles, and applies via the EXISTING
-  `setSubagents` writer (no second config writer — the ONLY config writer is
-  `PATCH /global/config`, see the AppConfig section above). Because the
-  endpoint can't express `remove` ops, a deactivated-but-registered model's
-  block is currently LEFT IN PLACE — `setSubagents` rejects the remove and
-  `syncSubagents` degrades to the pre-sync list, so deactivation is a no-op
-  until BET-1033 restores it through a vetted mechanism. No-op diffs skip
+  `setSubagents` writer (the two config writers: upserts through
+  `PATCH /global/config`, deletions through `removeConfigKeys` + mandatory
+  opencode restart, see the AppConfig section above). A deactivated model's
+  block is removed from opencode.jsonc by that deletion path — the remove is
+  no longer a no-op. No-op diffs skip
   the write
   entirely, so it's safe to call on every card open AND every activation
   toggle (`opencode:sync-subagents` RPC channel — mirrors `get`/`set-subagents`

--- a/src/server/providers.mjs
+++ b/src/server/providers.mjs
@@ -10,12 +10,12 @@
 // This slice only adds the HTTP path. The RPC layer serves both (SSH + HTTP)
 // until SSH is removed.
 
-import { readFile } from "node:fs/promises";
+import { readFile, writeFile, rename } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join } from "node:path";
 import { fileURLToPath } from "node:url";
-import { parse } from "jsonc-parser";
+import { parse, modify, applyEdits } from "jsonc-parser";
 import { reconcileSubagents } from "../shared/subagentSync.mjs";
 import { restartOpencode } from "./opencodeAdmin.mjs";
 
@@ -86,17 +86,51 @@ const normBaseURL = (u) => stripUrlUserinfo(u).replace(/\/$/, "");
 const OPENCODE_JSONC = join(homedir(), ".config", "opencode", "opencode.jsonc");
 const OPENCODE_API = "http://127.0.0.1:4096/global/config";
 
-// opencode's PATCH /global/config has no HTTP delete semantics (it deep-merges
-// objects and rejects `null`), so a `remove` op can't be expressed through the
-// single endpoint. Re-scoped out of BET-1019: setProviders/setSubagents REJECT
-// removes with this message rather than writing the file directly (a direct
-// write behind the endpoint's back is what made memory and disk diverge — a
-// removed key resurrects on the next upsert PATCH). See BET-1033 for restoring
-// deactivation through a vetted mechanism.
-const REMOVE_UNSUPPORTED_MSG =
-  "remove ops are not supported through the config endpoint (PATCH /global/config " +
-  "has no delete semantics). Deactivation is pending a vetted mechanism — " +
-  "nothing was changed.";
+/**
+ * THE single direct-write path for opencode.jsonc, used ONLY for deletions
+ * (opencode's PATCH /global/config cannot express one — it deep-merges and
+ * rejects null). Surgical jsonc-parser edits preserve comments; the mandatory
+ * opencode restart is what stops opencode's in-memory config from diverging
+ * from a file it no longer owns. NEVER use this for an upsert — upserts go
+ * through patchGlobalConfig.
+ *
+ * @param {Array<Array<string>>} paths  e.g. [["provider","voska"],["agent","fast"]]
+ * @param {object} deps  injectable readText/writeText/restart (defaults hit the real box)
+ * @returns {Promise<{ ok: boolean, changed?: boolean, error?: string }>}
+ */
+export async function removeConfigKeys(paths, deps = {}) {
+  const readText = deps.readText ?? (async () => readFile(OPENCODE_JSONC, "utf-8"));
+  const writeText = deps.writeText ?? (async (text) => {
+    await writeFile(`${OPENCODE_JSONC}.tmp`, text, "utf-8");
+    await rename(`${OPENCODE_JSONC}.tmp`, OPENCODE_JSONC);
+  });
+  const restart = deps.restart ?? restartOpencode;
+
+  try {
+    const input = await readText();
+
+    let text = input;
+    for (const path of paths ?? []) {
+      text = applyEdits(text, modify(text, path, undefined, {}));
+    }
+
+    // Nothing matched — deleting something that is not there is a success, not
+    // a reason to interrupt every running session.
+    if (text === input) return { ok: true, changed: false };
+
+    await writeText(text);
+
+    // Never report success when a live opencode still holds the deleted key.
+    const restartResult = await restart();
+    if (!restartResult.ok) {
+      return { ok: false, error: restartResult.error };
+    }
+
+    return { ok: true, changed: true };
+  } catch (e) {
+    return { ok: false, error: e instanceof Error ? e.message : String(e) };
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Provider block manipulation (pure)
@@ -365,38 +399,45 @@ export async function patchGlobalConfig(patch) {
 }
 
 /**
- * Shared core for setProviders / setSubagents — both are the same write-through
- * PATCH shape (reject `remove`, upsert each block via a builder, PATCH one
- * config key) with no HTTP delete semantics. `configKey` is "provider" or
+ * Shared core for setProviders / setSubagents. Upserts go through PATCH
+ * /global/config (patchGlobalConfig); removes go through removeConfigKeys (the
+ * surgical JSONC write + mandatory opencode restart). Fixed, deterministic
+ * order: upsert FIRST (and stop if it fails — never delete when the upsert
+ * failed), then remove (stop if it fails). `configKey` is "provider" or
  * "agent"; `keyFor(input)` and `build(input)` produce the per-entry key + block.
  */
 async function patchBlocks(ops, deps, configKey, keyFor, build) {
   const patch = deps?.patch ?? patchGlobalConfig;
+  const remove = deps?.remove ?? removeConfigKeys;
   const upserts = ops?.upsert ?? [];
   const removes = ops?.remove ?? [];
 
-  if (removes.length > 0) {
-    return { ok: false, error: REMOVE_UNSUPPORTED_MSG };
+  if (upserts.length > 0) {
+    const collected = {};
+    for (const input of upserts) {
+      collected[keyFor(input)] = build(input);
+    }
+    const patchResult = await patch({ [configKey]: collected });
+    if (!patchResult.ok) return patchResult;
   }
 
-  if (upserts.length === 0) return { ok: true };
-  const collected = {};
-  for (const input of upserts) {
-    collected[keyFor(input)] = build(input);
+  if (removes.length > 0) {
+    const removeResult = await remove(removes.map((k) => [configKey, k]));
+    if (!removeResult.ok) return removeResult;
   }
-  return patch({ [configKey]: collected });
+
+  return { ok: true };
 }
 
 /**
  * Apply a set of provider mutations through opencode's config endpoint.
  * Upserts go through PATCH /global/config — the single authority that owns
- * both the in-memory config and the file. `remove` ops are NOT supported
- * (the endpoint has no delete semantics over HTTP: it deep-merges objects and
- * rejects `null`, so a key can't be removed through it) and are REJECTED with
- * an explicit error rather than written directly — writing the file behind the
- * endpoint's back would let memory and disk diverge (a removed key resurrects
- * on the next upsert PATCH). Restoring deactivation is tracked as follow-up
- * work. Does NOT restart opencode; the caller decides (prompt-before-restart).
+ * both the in-memory config and the file. `remove` ops (deleting an endpoint)
+ * go through removeConfigKeys: a surgical jsonc-parser edit of opencode.jsonc
+ * followed by a mandatory opencode restart, because the PATCH endpoint has no
+ * HTTP delete semantics (it deep-merges objects and rejects `null`). The
+ * restart is what stops the removed key from resurrecting on a stale
+ * in-memory config / the next upsert PATCH.
  */
 export async function setProviders(ops, deps = {}) {
   return patchBlocks(
@@ -431,12 +472,12 @@ export async function getSubagents(readConfig = readRemoteConfig) {
 /**
  * Apply a set of subagent mutations through opencode's config endpoint.
  * Upserts go through PATCH /global/config — the single authority that owns
- * both the in-memory config and the file. `remove` ops are NOT supported (the
- * endpoint has no delete semantics over HTTP) and are REJECTED with an
- * explicit error rather than written directly — writing the file behind the
- * endpoint's back would let memory and disk diverge (a removed block
- * resurrects on the next upsert PATCH). Restoring deactivation is tracked as
- * follow-up work. Does NOT restart opencode; the caller must do that manually.
+ * both the in-memory config and the file. `remove` ops (deactivating a
+ * subagent) go through removeConfigKeys: a surgical jsonc-parser edit of
+ * opencode.jsonc followed by a mandatory opencode restart, because the PATCH
+ * endpoint has no HTTP delete semantics (it deep-merges objects and rejects
+ * `null`). The restart is what stops the removed block from resurrecting on a
+ * stale in-memory config / the next upsert PATCH.
  */
 export async function setSubagents(ops, deps = {}) {
   return patchBlocks(
@@ -466,9 +507,13 @@ export async function setSkillRegistryUrls(urls = [], deps = {}) {
 }
 
 /**
- * Upsert opencode references (BET-1023) through THE single opencode.jsonc
- * write path — PATCH /global/config (the same `patchGlobalConfig` used by
- * setProviders/setSubagents; never a second writer).
+ * Upsert or remove opencode references (BET-1023). Upserts go through THE
+ * single opencode.jsonc upsert writer — PATCH /global/config (the same
+ * `patchGlobalConfig` used by setProviders/setSubagents; never a second
+ * writer). `remove` ops (deleting a reference alias) go through
+ * removeConfigKeys against the `references` key — a surgical jsonc-parser edit
+ * + mandatory opencode restart — because opencode's PATCH /global/config has
+ * no HTTP delete semantics (it deep-merges objects and rejects `null`).
  *
  * A reference entry is written as an explicit object — either
  *   { path, description? }            for a local directory, or
@@ -476,41 +521,41 @@ export async function setSkillRegistryUrls(urls = [], deps = {}) {
  * — never as a bare shorthand string, so the config stays unambiguous and
  * keyed by the alias the user declared.
  *
- * `remove` ops are REJECTED with an explicit error, mirroring
- * REMOVE_UNSUPPORTED_MSG: opencode's PATCH /global/config has no HTTP delete
- * semantics (it deep-merges objects and rejects `null`), so a reference alias
- * can't be removed through the single endpoint. Restoring removal is tracked
- * as follow-up work alongside BET-1033.
- *
- * `patch` is injectable for unit tests; defaults to patchGlobalConfig.
+ * `patch`/`remove` are injectable for unit tests; defaults to the real writers.
  */
 export async function setReferences(ops, deps = {}) {
   const patch = deps.patch ?? patchGlobalConfig;
+  const remove = deps.remove ?? removeConfigKeys;
   const upserts = ops?.upsert ?? [];
   const removes = ops?.remove ?? [];
 
-  if (removes.length > 0) {
-    return { ok: false, error: REMOVE_UNSUPPORTED_MSG };
-  }
-
-  if (upserts.length === 0) return { ok: true };
-
-  const referencesPatch = {};
-  for (const input of upserts) {
-    const { alias } = input;
-    if (!alias) continue;
-    const entry = {};
-    if (input.repository) {
-      entry.repository = input.repository;
-      if (input.branch) entry.branch = input.branch;
-    } else {
-      entry.path = input.path;
+  if (upserts.length > 0) {
+    const referencesPatch = {};
+    for (const input of upserts) {
+      const { alias } = input;
+      if (!alias) continue;
+      const entry = {};
+      if (input.repository) {
+        entry.repository = input.repository;
+        if (input.branch) entry.branch = input.branch;
+      } else {
+        entry.path = input.path;
+      }
+      if (input.description) entry.description = input.description;
+      referencesPatch[alias] = entry;
     }
-    if (input.description) entry.description = input.description;
-    referencesPatch[alias] = entry;
+    if (Object.keys(referencesPatch).length > 0) {
+      const patchResult = await patch({ references: referencesPatch });
+      if (!patchResult.ok) return patchResult;
+    }
   }
-  if (Object.keys(referencesPatch).length === 0) return { ok: true };
-  return patch({ references: referencesPatch });
+
+  if (removes.length > 0) {
+    const removeResult = await remove(removes.map((alias) => ["references", alias]));
+    if (!removeResult.ok) return removeResult;
+  }
+
+  return { ok: true };
 }
 
 /**

--- a/src/server/providers.test.mjs
+++ b/src/server/providers.test.mjs
@@ -13,6 +13,7 @@ import {
   discoverModels,
   discoverModelsForEndpoint,
   setProviders,
+  removeConfigKeys,
   getProviderEndpoints,
   upsertAgentBlock,
   readAgentBlocks,
@@ -515,15 +516,46 @@ describe("setProviders", () => {
     assert.equal(patches[0].provider["other"], undefined, "only the changed provider is patched");
   });
 
-  it("rejects a remove (the endpoint has no delete) without writing the file", async () => {
+  it("routes a remove through removeConfigKeys (no longer rejects)", async () => {
+    let removedPaths = null;
     let patched = false;
     const result = await setProviders(
       { remove: ["voska"] },
-      { patch: async () => { patched = true; return { ok: true }; } },
+      {
+        patch: async () => { patched = true; return { ok: true }; },
+        remove: async (paths) => { removedPaths = paths; return { ok: true, changed: true }; },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.deepEqual(removedPaths, [["provider", "voska"]]);
+    assert.equal(patched, false, "a pure remove does not PATCH");
+  });
+
+  it("patches before deleting on a mixed upsert+remove batch", async () => {
+    const order = [];
+    const result = await setProviders(
+      { upsert: [{ id: "voska", name: "Voska", baseURL: "https://api.voska.org/v1", apiKey: "sk", enabledModels: [] }], remove: ["old"] },
+      {
+        patch: async () => { order.push("patch"); return { ok: true }; },
+        remove: async () => { order.push("remove"); return { ok: true }; },
+      },
+    );
+    assert.equal(result.ok, true);
+    assert.deepEqual(order, ["patch", "remove"]);
+  });
+
+  it("does not delete when the upsert patch fails", async () => {
+    let removed = false;
+    const result = await setProviders(
+      { upsert: [{ id: "voska", name: "Voska", baseURL: "https://api.voska.org/v1", apiKey: "sk", enabledModels: [] }], remove: ["old"] },
+      {
+        patch: async () => ({ ok: false, error: "boom" }),
+        remove: async () => { removed = true; return { ok: true }; },
+      },
     );
     assert.equal(result.ok, false);
-    assert.match(result.error, /remove/i);
-    assert.equal(patched, false, "no PATCH for a rejected remove op — no file write, no endpoint call");
+    assert.match(result.error, /boom/);
+    assert.equal(removed, false, "must not delete when the upsert patch failed");
   });
 
   it("surfaces an endpoint error to the caller (no file fallback)", async () => {
@@ -779,26 +811,43 @@ describe("setSubagents", () => {
     assert.equal(patches[0].agent["old"], undefined, "only the changed agent is patched");
   });
 
-  it("rejects a remove (the endpoint has no delete) without writing the file", async () => {
+  it("routes a remove through removeConfigKeys against the agent key (no longer rejects)", async () => {
+    let removedPaths = null;
     let patched = false;
     const result = await setSubagents(
       { remove: ["haiku"] },
-      { patch: async () => { patched = true; return { ok: true }; } },
+      {
+        patch: async () => { patched = true; return { ok: true }; },
+        remove: async (paths) => { removedPaths = paths; return { ok: true, changed: true }; },
+      },
     );
-    assert.equal(result.ok, false);
-    assert.match(result.error, /remove/i);
-    assert.equal(patched, false, "no PATCH for a rejected remove op — no file write, no endpoint call");
+    assert.equal(result.ok, true);
+    assert.deepEqual(removedPaths, [["agent", "haiku"]]);
+    assert.equal(patched, false);
   });
 
-  it("rejects a batch that includes a remove before patching (remove unsupported)", async () => {
-    let patched = false;
-    const result = await setSubagents(
+  it("patches before deleting on a mixed upsert+remove batch, and stops when the patch fails", async () => {
+    const order = [];
+    const okResult = await setSubagents(
       { upsert: [{ name: "fast", model: "anthropic/claude-haiku-4", description: "Fast" }], remove: ["haiku"] },
-      { patch: async () => { patched = true; return { ok: true }; } },
+      {
+        patch: async () => { order.push("patch"); return { ok: true }; },
+        remove: async () => { order.push("remove"); return { ok: true }; },
+      },
     );
-    assert.equal(result.ok, false);
-    assert.match(result.error, /remove/i);
-    assert.equal(patched, false, "rejects the batch before any upsert PATCH");
+    assert.equal(okResult.ok, true);
+    assert.deepEqual(order, ["patch", "remove"]);
+
+    let removed = false;
+    const failResult = await setSubagents(
+      { upsert: [{ name: "fast", model: "x", description: "F" }], remove: ["haiku"] },
+      {
+        patch: async () => ({ ok: false, error: "boom" }),
+        remove: async () => { removed = true; return { ok: true }; },
+      },
+    );
+    assert.equal(failResult.ok, false);
+    assert.equal(removed, false, "must not delete when the upsert patch failed");
   });
 });
 
@@ -1118,15 +1167,43 @@ describe("setReferences", () => {
     assert.equal(patches[0].references.docs.path, "../docs");
   });
 
-  it("rejects remove ops with no PATCH write", async () => {
+  it("routes a remove through removeConfigKeys against the references key (no longer rejects)", async () => {
+    let removedPaths = null;
     let patched = false;
     const result = await setReferences(
-      { upsert: [{ alias: "docs", path: "../docs" }], remove: ["docs"] },
-      { patch: async () => { patched = true; return { ok: true }; } },
+      { remove: ["docs"] },
+      {
+        patch: async () => { patched = true; return { ok: true }; },
+        remove: async (paths) => { removedPaths = paths; return { ok: true, changed: true }; },
+      },
     );
-    assert.equal(result.ok, false);
-    assert.match(result.error, /not supported|no delete/);
-    assert.equal(patched, false, "no PATCH for a rejected remove op");
+    assert.equal(result.ok, true);
+    assert.deepEqual(removedPaths, [["references", "docs"]]);
+    assert.equal(patched, false);
+  });
+
+  it("patches before deleting on a mixed batch, and stops when the patch fails", async () => {
+    const order = [];
+    const okResult = await setReferences(
+      { upsert: [{ alias: "docs", path: "../docs" }], remove: ["old"] },
+      {
+        patch: async () => { order.push("patch"); return { ok: true }; },
+        remove: async () => { order.push("remove"); return { ok: true }; },
+      },
+    );
+    assert.equal(okResult.ok, true);
+    assert.deepEqual(order, ["patch", "remove"]);
+
+    let removed = false;
+    const failResult = await setReferences(
+      { upsert: [{ alias: "docs", path: "../docs" }], remove: ["old"] },
+      {
+        patch: async () => ({ ok: false, error: "boom" }),
+        remove: async () => { removed = true; return { ok: true }; },
+      },
+    );
+    assert.equal(failResult.ok, false);
+    assert.equal(removed, false, "must not delete when the upsert patch failed");
   });
 
   it("no-ops when there is nothing to upsert", async () => {
@@ -1146,5 +1223,79 @@ describe("setReferences", () => {
     );
     assert.equal(result.ok, false);
     assert.match(result.error, /500/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// removeConfigKeys — THE single direct-write path (deletions only). Surgical
+// jsonc-parser edits preserve comments; the mandatory opencode restart is
+// what stops memory/disk divergence. All deps are injected — never touches
+// the real opencode.jsonc or systemctl.
+// ---------------------------------------------------------------------------
+
+describe("removeConfigKeys", () => {
+  const SRC = '{\n  // keep me\n  "provider": {\n    "a": {"x":1},\n    "b": {"y":2}\n  },\n  "model": "m"\n}';
+
+  it("deletes a key and leaves a // comment elsewhere intact", async () => {
+    let written = null;
+    let restarts = 0;
+    const result = await removeConfigKeys([["provider", "b"]], {
+      readText: async () => SRC,
+      writeText: async (t) => { written = t; },
+      restart: async () => { restarts++; return { ok: true }; },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, true);
+    assert.ok(written.includes("// keep me"), "comment preserved");
+    assert.ok(!written.includes('"b"'), "removed key is gone");
+    assert.equal(restarts, 1);
+  });
+
+  it("missing key → ok:true changed:false, writer NOT called, restart NOT called", async () => {
+    let written = false;
+    let restarts = 0;
+    const result = await removeConfigKeys([["provider", "zzz-does-not-exist"]], {
+      readText: async () => SRC,
+      writeText: async () => { written = true; },
+      restart: async () => { restarts++; return { ok: true }; },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, false);
+    assert.equal(written, false);
+    assert.equal(restarts, 0);
+  });
+
+  it("multi-path call removes all and restarts exactly once", async () => {
+    let written = null;
+    let restarts = 0;
+    const result = await removeConfigKeys([["provider", "a"], ["provider", "b"]], {
+      readText: async () => SRC,
+      writeText: async (t) => { written = t; },
+      restart: async () => { restarts++; return { ok: true }; },
+    });
+    assert.equal(result.ok, true);
+    assert.equal(result.changed, true);
+    assert.equal(restarts, 1);
+    assert.ok(!written.includes('"a"') && !written.includes('"b"'));
+    assert.ok(written.includes("// keep me"));
+  });
+
+  it("restart failure → ok:false (never reports success while a live opencode holds the key)", async () => {
+    const result = await removeConfigKeys([["provider", "a"]], {
+      readText: async () => SRC,
+      writeText: async () => {},
+      restart: async () => ({ ok: false, error: "systemctl failed" }),
+    });
+    assert.equal(result.ok, false);
+  });
+
+  it("never throws — a failing read surfaces as ok:false with an error", async () => {
+    const result = await removeConfigKeys([["provider", "a"]], {
+      readText: async () => { throw new Error("ENOENT"); },
+      writeText: async () => {},
+      restart: async () => ({ ok: true }),
+    });
+    assert.equal(result.ok, false);
+    assert.match(result.error, /ENOENT/);
   });
 });


### PR DESCRIPTION
Fixes BET-1318 — Config remove ops are dead.

## What was wrong
Every `remove` op (`setProviders` / `setSubagents` / `setReferences`) was rejected with `REMOVE_UNSUPPORTED_MSG` and wrote nothing, so deleting a custom endpoint in **Settings → Accounts → Custom endpoints**, deactivating a subagent, and removing a reference were dead controls that could never succeed. Deleting a config key genuinely can't be expressed through opencode's `PATCH /global/config` (it deep-merges and rejects `null`).

## The fix
Added **`removeConfigKeys(paths, deps)`** in `src/server/providers.mjs` — THE single direct-write path, used only for deletions. It:
- Reads opencode.jsonc and applies a surgical `jsonc-parser` `modify`/`applyEdits` per path (preserves `//` comments).
- If nothing matched → `{ ok:true, changed:false }` and does **not** write/restart (deleting something absent is a success, not a reason to drop every session).
- Otherwise writes atomically (`.tmp` + `rename`) then **restarts opencode** (`restartOpencode`) — the mandatory restart is what stops the removed key resurrecting from opencode's stale in-memory config. Restart failure → `{ ok:false }` (never reports success while a live opencode still holds the key). Never throws.

Rewired the three call sites to upsert-first-then-remove (stop if the upsert fails — never delete when an upsert failed), and deleted the `REMOVE_UNSUPPORTED_MSG` constant + its reject branches. The old `removeProviderBlock`/`removeAgentBlock` helpers were **not** restored — they re-serialize a parsed object and destroy comments (the BET-1019 regression). Docs in AGENTS.md updated.

Out of scope (per issue): renderer, subscription disconnect, confirm UI.

**Base: origin/main @ e244fbd8**

**Verification results:**
- PR branch (`multica/BET-1318-config-remove-ops` @ `b4503a92`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0 — 2702 pass / 0 fail / 0 skip (full server + renderer suite; no new failures possible on this branch).
