### PR TITLE
fix(server): subscription disconnect reads auth store + restarts opencode (BET-1319)

### DIFF
--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -1618,6 +1618,65 @@ export async function readProviderOAuthToken(providerId, { readFile = readFileSy
   return parseProviderOAuthToken(raw, providerId);
 }
 
+/**
+ * Pure: return the top-level provider ids present in opencode's auth store
+ * from the ALREADY-READ text of the file. Mirrors `parseProviderApiKey`
+ * above exactly — never throws, returns `[]` for invalid JSON or an
+ * unparseable store.
+ *
+ * This is the truth the subscription status reads: BOTH connect
+ * (`PUT /auth/{id}`) and disconnect (`DELETE /auth/{id}`) write this store,
+ * so its top-level keys reflect a completed disconnect immediately — unlike
+ * opencode's process-lifetime `GET /provider` `connected[]`, which only a
+ * restart clears (BET-1319). The `opencode-claude-auth` plugin DOES re-sync
+ * the `anthropic` entry back in within seconds of a restart, so `anthropic`
+ * is never a reliable subject for this check.
+ *
+ * Separated from the file read below so it's directly unit-testable without
+ * touching a real auth store, the same split `parseProviderApiKey` /
+ * `readProviderApiKey` uses.
+ *
+ * @param {string} rawFileText
+ * @returns {string[]}
+ */
+export function parseAuthedProviderIds(rawFileText) {
+  try {
+    const parsed = JSON.parse(rawFileText);
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed)
+      ? Object.keys(parsed)
+      : [];
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Read opencode's own auth store and return the provider ids it currently
+ * holds. This is the reader the subscription status uses: both connect and
+ * disconnect write it, so it updates immediately — see
+ * `parseAuthedProviderIds` above for why `GET /provider` cannot be trusted
+ * here.
+ *
+ * Mirrors `readProviderApiKey` above exactly: tolerates a missing file by
+ * returning `[]` — NEVER throws, so a caller can `await` this
+ * unconditionally. The file-read function is injectable (`readFile`),
+ * defaulting to the real `readFileSync`, so tests can drive the
+ * missing-file / unparseable cases with a fake reader and never touch a real
+ * auth store. Reuses `opencodeAuthPath()` — do not compute the path again.
+ *
+ * @param {{ readFile?: (file: string, encoding: string) => string }} [opts]
+ * @returns {Promise<string[]>}
+ */
+export async function readAuthedProviderIds({ readFile = readFileSync } = {}) {
+  let raw;
+  try {
+    raw = readFile(opencodeAuthPath(), "utf-8");
+  } catch {
+    return [];
+  }
+  return parseAuthedProviderIds(raw);
+}
+
 // ---------------------------------------------------------------------------
 // VCS
 // ---------------------------------------------------------------------------

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -47,6 +47,8 @@ import {
   readProviderApiKey,
   parseProviderOAuthToken,
   readProviderOAuthToken,
+  parseAuthedProviderIds,
+  readAuthedProviderIds,
   opencodeAuthPath,
   completeProviderOauth,
 } from "./opencode.mjs";
@@ -241,6 +243,53 @@ test("readProviderOAuthToken returns \"\" for an api-type entry", async () => {
 
 test("readProviderOAuthToken returns the access token for a valid oauth-type entry", async () => {
   assert.equal(await readOauthVia(OPENAI_OAUTH), "mom-access-token");
+});
+
+// ---------------------------------------------------------------------------
+// parseAuthedProviderIds / readAuthedProviderIds (BET-1319) — the
+// subscription-status reader. Returns the top-level provider ids of
+// opencode's auth store, which is what both connect (PUT /auth/{id}) and
+// disconnect (DELETE /auth/{id}) write — so it reflects a completed
+// disconnect immediately, unlike GET /provider's process-lifetime connected[].
+// Pure parse + injectable-reader IO, never touches a real file.
+// ---------------------------------------------------------------------------
+
+test("parseAuthedProviderIds returns the top-level provider ids of a valid store", () => {
+  const raw = JSON.stringify({ anthropic: { type: "oauth" }, openai: { type: "oauth" } });
+  assert.deepEqual(parseAuthedProviderIds(raw), ["anthropic", "openai"]);
+});
+
+test("parseAuthedProviderIds returns [] for an empty store", () => {
+  assert.deepEqual(parseAuthedProviderIds("{}"), []);
+});
+
+test("parseAuthedProviderIds returns [] for malformed JSON", () => {
+  assert.deepEqual(parseAuthedProviderIds("not json{"), []);
+});
+
+test("parseAuthedProviderIds never echoes any values — returns [] for non-object roots", () => {
+  assert.deepEqual(parseAuthedProviderIds("null"), []);
+  assert.deepEqual(parseAuthedProviderIds("[]"), []);
+  assert.deepEqual(parseAuthedProviderIds('"just a string"'), []);
+});
+
+test("readAuthedProviderIds returns [] when the auth store file is missing (reader throws)", async () => {
+  assert.deepEqual(
+    await readAuthedProviderIds({ readFile: () => { throw new Error("ENOENT"); } }),
+    [],
+  );
+});
+
+test("readAuthedProviderIds returns the provider ids from a populated store", async () => {
+  const raw = JSON.stringify({ openai: { type: "oauth" }, "kimi-for-coding": { type: "api" } });
+  assert.deepEqual(
+    await readAuthedProviderIds({ readFile: () => raw }),
+    ["openai", "kimi-for-coding"],
+  );
+});
+
+test("readAuthedProviderIds returns [] for unparseable JSON", async () => {
+  assert.deepEqual(await readAuthedProviderIds({ readFile: () => "not json{" }), []);
 });
 
 // opencodeAuthPath (review cycle 2 Nit): mirrors messageSearch.mjs's

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -316,6 +316,12 @@ export function buildHandlers({
   serverVersion,
   opencodeVersion,
   runServerSelfUpdate,
+  // BET-1319: injectable so the disconnect restart is testable without a live
+  // systemd unit. Defaults to the real module import (the `opencode:restart`
+  // channel and claude-login path use the import directly; this is DISCONNECT
+  // only). Production index.mjs does not pass it → the default is used,
+  // identical to before.
+  restartOpencode: restartOpencodeImpl = restartOpencode,
   checkServerUpdate = () => Promise.resolve({ available: false }),
   // Box-side CLI update detector (BET-1096). Null when not wired — the
   // `server:update-check` handler then returns the box verdict WITHOUT
@@ -1316,7 +1322,13 @@ export function buildHandlers({
     "opencode:provider-auth": async (req) => {
       const action = req?.action;
       if (action === "status") {
-        const { connected } = await oc.getProviders();
+        // BET-1319: read connected-state from opencode's OWN auth store, not
+        // from GET /provider. opencode keeps `connected[]` for the process
+        // lifetime, so a completed DELETE /auth/{id} did not show up until a
+        // restart — the disconnect reported success yet the row stayed
+        // "Connected" forever. The auth store is what both connect and
+        // disconnect write, so it reflects the truth immediately.
+        const connected = await oc.readAuthedProviderIds();
         return {
           action: "status",
           providers: subscriptionProviders.subscriptionStatuses(connected),
@@ -1435,11 +1447,30 @@ export function buildHandlers({
       if (action === "disconnect") {
         const id = String(req?.id ?? "");
         const r = await oc.removeProviderAuth(id);
-        return {
-          action: "disconnect",
-          ok: !!r?.ok,
-          error: r?.ok ? undefined : r?.error,
-        };
+        if (!r?.ok) {
+          return {
+            action: "disconnect",
+            ok: false,
+            error: r?.error,
+          };
+        }
+        // BET-1319: the DELETE removed the credential from opencode's auth
+        // store, but opencode keeps the provider loaded in-process until a
+        // restart — its models still appear in the picker. "Disconnected"
+        // must not be reported while opencode still holds the credential, so
+        // bounce opencode and fold the result into the response. This mirrors
+        // the connect side (ConnectProvider restarts opencode and polls to
+        // verify). The /rpc response still returns to the caller because
+        // restartOpencode() restarts the opencode-serve unit, not manta-server.
+        const restart = await restartOpencodeImpl();
+        if (!restart?.ok) {
+          return {
+            action: "disconnect",
+            ok: false,
+            error: restart?.error,
+          };
+        }
+        return { action: "disconnect", ok: true };
       }
       // BET-354: Claude login status check. The renderer's connect card
       // polls this on its 1s tick while in the claude-login phase; the

--- a/src/server/rpc.test.mjs
+++ b/src/server/rpc.test.mjs
@@ -408,36 +408,83 @@ test("tmux:new-window surfaces the created window's sessionId + windowIndex", as
 // These tests assert the end-to-end shape the renderer sees from the rpc
 // channel, with the underlying opencode call stubbed via the `oc` dep.
 
-test("opencode:provider-auth status returns subscriptionStatuses for the connected set", async () => {
+test("opencode:provider-auth status reports connected from the AUTH STORE, not /provider (BET-1319)", async () => {
   const { deps } = makeDeps([]);
-  deps.oc.getProviders = async () => ({
-    connected: ["anthropic", "openai"],
-  });
+  // GET /provider still (incorrectly) reports openai as connected until a
+  // restart — that is exactly the stale-cache bug. The status branch must
+  // read opencode's auth store instead.
+  deps.oc.getProviders = async () => ({ connected: ["anthropic", "openai"] });
+  deps.oc.readAuthedProviderIds = async () => ["anthropic"];
   const handlers = buildHandlers(deps);
   const result = await handlers["opencode:provider-auth"]({ action: "status" });
   assert.equal(result.action, "status");
   assert.ok(Array.isArray(result.providers));
-  // anthropic + openai show as connected; kimi-for-coding is the third
-  // SUBSCRIPTION_PROVIDERS entry — must NOT be connected.
+  // anthropic is in the auth store → connected. openai is in /provider but
+  // NOT in the auth store (a completed DELETE /auth/openai) → disconnected.
   const byId = Object.fromEntries(result.providers.map((p) => [p.id, p.connected]));
   assert.equal(byId.anthropic, true);
-  assert.equal(byId.openai, true);
+  assert.equal(byId.openai, false);
   assert.equal(byId["kimi-for-coding"], false);
 });
 
 test("opencode:provider-auth status rejects with the upstream error (no try/catch in handler)", async () => {
   const { deps } = makeDeps([]);
-  deps.oc.getProviders = async () => { throw new Error("upstream gone"); };
+  deps.oc.readAuthedProviderIds = async () => { throw new Error("upstream gone"); };
   const handlers = buildHandlers(deps);
-  // The status branch awaits `oc.getProviders()` directly (no try/catch in
-  // the handler) — a thrown upstream surfaces as a rejected promise that
-  // the renderer's typed result would treat as an error. Pin the
-  // current behavior so a future "wrap with try/catch" change is a
+  // The status branch awaits `oc.readAuthedProviderIds()` directly (no
+  // try/catch in the handler) — a thrown upstream surfaces as a rejected
+  // promise that the renderer's typed result would treat as an error. Pin
+  // the current behavior so a future "wrap with try/catch" change is a
   // conscious one.
   await assert.rejects(
     () => handlers["opencode:provider-auth"]({ action: "status" }),
     /upstream gone/,
   );
+});
+
+// ---- BET-1319: opencode:provider-auth `disconnect` finishes the job -------
+//
+// A DELETE /auth/{id} removes the credential from opencode's auth store, but
+// opencode keeps the provider loaded in-process (its models still appear in
+// the picker) until a restart. The disconnect branch must bounce opencode and
+// never report success while it still holds the credential. restartOpencode is
+// injected via buildHandlers deps so no systemd unit is touched here.
+
+test("opencode:provider-auth disconnect restarts opencode exactly once on success (BET-1319)", async () => {
+  const { deps } = makeDeps([]);
+  let restarts = 0;
+  deps.oc.removeProviderAuth = async () => ({ ok: true });
+  deps.restartOpencode = async () => { restarts += 1; return { ok: true }; };
+  const handlers = buildHandlers(deps);
+  const result = await handlers["opencode:provider-auth"]({ action: "disconnect", id: "openai" });
+  assert.equal(result.action, "disconnect");
+  assert.equal(result.ok, true);
+  assert.equal(restarts, 1, "restart called exactly once on a successful delete");
+});
+
+test("opencode:provider-auth disconnect does NOT restart when the delete failed (BET-1319)", async () => {
+  const { deps } = makeDeps([]);
+  let restarts = 0;
+  deps.oc.removeProviderAuth = async () => ({ ok: false, error: "upstream rejected" });
+  deps.restartOpencode = async () => { restarts += 1; return { ok: true }; };
+  const handlers = buildHandlers(deps);
+  const result = await handlers["opencode:provider-auth"]({ action: "disconnect", id: "openai" });
+  assert.equal(result.action, "disconnect");
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "upstream rejected");
+  assert.equal(restarts, 0, "no restart when the delete did not succeed");
+});
+
+test("opencode:provider-auth disconnect returns ok:false when the restart fails (BET-1319)", async () => {
+  const { deps } = makeDeps([]);
+  deps.oc.removeProviderAuth = async () => ({ ok: true });
+  deps.restartOpencode = async () => ({ ok: false, error: "unit restart failed" });
+  const handlers = buildHandlers(deps);
+  const result = await handlers["opencode:provider-auth"]({ action: "disconnect", id: "openai" });
+  // Success must NEVER be reported while opencode still holds the credential.
+  assert.equal(result.action, "disconnect");
+  assert.equal(result.ok, false);
+  assert.equal(result.error, "unit restart failed");
 });
 
 // ---- BET-348: pty:spawn forwards tmuxTarget through the rpc envelope -------


### PR DESCRIPTION
## BET-1319 — Subscription disconnect reports success but never takes effect

Fixes the stale `/provider` connected-list bug: the Subscriptions card read connected-state from opencode's process-lifetime `GET /provider`, which only a restart clears — so a completed `DELETE /auth/{id}` showed "Connected" forever.

**Part 1 — read the truth, not opencode's cache.** Added two exported readers beside `readProviderApiKey`, reusing `opencodeAuthPath()` (not recomputed):
- `parseAuthedProviderIds(rawFileText)` — pure, returns top-level keys of the parsed auth store, `[]` on bad JSON.
- `readAuthedProviderIds({ readFile })` — never-throwing reader, `[]` on a missing file, injectable readFile for tests.

The `status` branch now calls `oc.readAuthedProviderIds()` instead of `oc.getProviders()`. `subscriptionStatuses(connected)` is unchanged. `getProviders()` and its other callers (`getDefaultModel`, `listModels`) are untouched — they legitimately keep opencode's live loaded-provider view.

**Part 2 — finish the disconnect.** The `disconnect` branch now awaits `restartOpencode()` after a successful delete, and returns `{ ok:false, error }` if the restart fails — success is never reported while opencode still holds the credential. Mirrors the connect side. `restartOpencode` bounces the `opencode-serve` unit, not manta-server, so the `/rpc` response still returns.

**Base: origin/main @ `9fe02dee`**

**Verification results:**
- PR branch (`multica/BET-1319-subscription-disconnect` @ `5afe8c8a`):
  - typecheck: exit 0, errors none
  - test: exit 0, 2712 pass / 0 fail / 0 skip. log sha256: `50d86d354f9e78443b735bab74ba9acc4a22b6560431761e1ac1f7ab2024ae88`
- Base (`main` @ `9fe02dee`): branched from this commit, no subsequent main drift; both branches run the same installed deps.
- **Conclusion:** 0 new failures. (A pre-existing stale `node_modules` missing the `jsonc-parser` dep from the merged BET-1318 was fixed by `npm install` — not part of this diff.)
