### PR TITLE
Settings accounts: shared inline confirm, hide unreachable Disconnect (BET-1320)

### DIFF
--- a/src/renderer/AccountsCard.test.ts
+++ b/src/renderer/AccountsCard.test.ts
@@ -88,6 +88,23 @@ describe("describeAccountState", () => {
     expect(st.tone).toBe("quiet");
   });
 
+  it("externally-managed connected row names the owner instead of usage (9g BET-1320)", () => {
+    const st = describeAccountState(
+      subscription({
+        managedExternally: true,
+        managedBy: "the Claude CLI on this box",
+        reading: { label: "5h window", pct: 41, pace: "under pace" },
+      }),
+    );
+    expect(st.text).toBe("connected · signed in with the Claude CLI on this box");
+    expect(st.tone).toBe("ok");
+  });
+
+  it("an externally-managed row without a managedBy owner falls back to today's text", () => {
+    const st = describeAccountState(subscription({ managedExternally: true }));
+    expect(st.text).toBe("No usage data");
+  });
+
   it("out-of-credit shows 'Out of credit' (danger)", () => {
     const st = describeAccountState(subscription({ health: "out-of-credit", balance: 0 }));
     expect(st.text).toBe("Out of credit");

--- a/src/renderer/AccountsCard.test.tsx
+++ b/src/renderer/AccountsCard.test.tsx
@@ -241,6 +241,98 @@ describe("AccountsCard Try-again tone by outcome (9c)", () => {
   });
 });
 
+describe("AccountsCard Disconnect gating (9g BET-1320)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  function setupManaged(statuses: Record<string, unknown>[]) {
+    return installMockApi({
+      opencodeProviderAuth: () =>
+        Promise.resolve({ action: "status" as const, providers: statuses }),
+      opencodeGetProviders: () => Promise.resolve([]),
+      accountHealth: () => Promise.resolve({}),
+      configGet: () => Promise.resolve({}),
+      opencodeSetProviders: () => Promise.resolve({ ok: true }),
+      opencodeDiscoverModels: () => Promise.resolve({ ok: true, models: [] }),
+      accountsRetry: () => Promise.resolve({ ok: true, state: "ok", message: "x" }),
+    });
+  }
+
+  it("a plain connected row keeps a Disconnect button", async () => {
+    setupManaged([{ id: "anthropic", label: "Claude", plan: "Max 20x", console: null, docs: "", connected: true }]);
+    h = mount(<AccountsCard />);
+    await h.flush();
+    expect(buttonByText(h, "Disconnect")).toBeTruthy();
+  });
+
+  it("a connected + managedExternally row shows no Disconnect and names the owner", async () => {
+    setupManaged([
+      {
+        id: "anthropic",
+        label: "Claude",
+        plan: "Max 20x",
+        console: null,
+        docs: "",
+        connected: true,
+        managedExternally: true,
+        managedBy: "the Claude CLI on this box",
+      },
+    ]);
+    h = mount(<AccountsCard />);
+    await h.flush();
+    expect(buttonByText(h, "Disconnect")).toBeNull();
+    expect(h.container.textContent).toContain("connected · signed in with the Claude CLI on this box");
+  });
+});
+
+describe("AccountsCard remove confirm (BET-1320)", () => {
+  let h: Harness | null = null;
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("the ✕ does not call opencodeSetProviders until the confirm is pressed", async () => {
+    const s = customProviderSetup();
+    h = s.h;
+    await h.flush();
+
+    const removeBtn = h.container.querySelector('button[aria-label="Remove VoskaAI"]');
+    expect(removeBtn).toBeTruthy();
+    // The confirm button must not exist yet — and nothing has been written.
+    expect(buttonByText(h, "Remove")).toBeNull();
+    expect(JSON.stringify(s.api.calls.opencodeSetProviders ?? [])).toBe("[]");
+
+    removeBtn!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await h.flush();
+    // Confirm + Cancel now render; still nothing written.
+    expect(buttonByText(h, "Remove")).toBeTruthy();
+    expect(buttonByText(h, "Cancel")).toBeTruthy();
+    expect(JSON.stringify(s.api.calls.opencodeSetProviders ?? [])).toBe("[]");
+
+    // Cancel abandons without writing.
+    buttonByText(h, "Cancel")!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await h.flush();
+    expect(buttonByText(h, "Remove")).toBeNull();
+    expect(JSON.stringify(s.api.calls.opencodeSetProviders ?? [])).toBe("[]");
+
+    // Re-open and press the confirm → the remove op reaches the box once.
+    h.container.querySelector('button[aria-label="Remove VoskaAI"]')!.dispatchEvent(
+      new MouseEvent("click", { bubbles: true, cancelable: true }),
+    );
+    await h.flush();
+    buttonByText(h, "Remove")!.dispatchEvent(new MouseEvent("click", { bubbles: true, cancelable: true }));
+    await h.flush();
+    expect(s.api.calls.opencodeSetProviders ?? []).toHaveLength(1);
+    expect(s.api.calls.opencodeSetProviders![0][0]).toEqual({ remove: ["voska"] });
+    h.unmount();
+    h = null;
+  });
+});
+
 describe("AccountsCard Try-again verdict clears on recovery (9c)", () => {
   it("drops the verdict once a refetch shows the row recovered", async () => {
     // Cold-start the "accounts" cache so the mount fetch actually reads health.

--- a/src/renderer/AccountsCard.tsx
+++ b/src/renderer/AccountsCard.tsx
@@ -34,6 +34,7 @@ import { autoEligibility, MISSING } from "../shared/autoEligibility.mjs";
 import { providerStateLabel } from "../shared/providerHealthLabel.mjs";
 import { resolveIdentity, type ModelDeclaration } from "../shared/modelIdentity.mjs";
 import { qualityScore } from "../shared/modelQuality.mjs";
+import { ConfirmInline } from "./ConfirmInline";
 import { ConnectProvider } from "./ConnectProvider";
 import { CustomProviderForm } from "./CustomProviderForm";
 import { ModelChecklist } from "./ModelChecklist";
@@ -64,6 +65,11 @@ export type AccountRowModel = {
   plan?: string;
   /** credential present (subscription connected / custom has an api key). */
   connected: boolean;
+  /** The credential is owned outside Manta (e.g. the Claude CLI) — Manta
+   *  cannot deliver a Disconnect for it, so the row says so instead. */
+  managedExternally?: boolean;
+  /** Who owns the credential, e.g. "the Claude CLI on this box". */
+  managedBy?: string | null;
   /** A usage reading (window label / pct / pace) when one exists. `pace` is
    *  null when the window carries no timing — never a fabricated pace. */
   reading: { label: string; pct: number; pace: string | null } | null;
@@ -100,6 +106,12 @@ export function describeAccountState(r: AccountRowModel): AccountState {
     };
   }
   if (r.health === "failing") return { text: providerStateLabel("failing") ?? "Not responding", tone: "warn" };
+  // BET-1320: a connected row whose credential Manta does not own (e.g. the
+  // Claude CLI) can't show a Disconnect — say who owns it instead of offering
+  // a button that can never succeed.
+  if (r.connected && r.managedExternally && r.managedBy) {
+    return { text: `connected · signed in with ${r.managedBy}`, tone: "ok" };
+  }
   if (r.reading) {
     const pct = r.reading.pct;
     const tone: AccountStatus = pct >= 90 ? "danger" : pct >= 70 ? "warn" : "ok";
@@ -296,8 +308,10 @@ function AccountRow({
   connectState: {
     connectingId: string | null;
     disconnectConfirmId: string | null;
+    removeConfirmId: string | null;
     setConnectingId: (id: string | null) => void;
     setDisconnectConfirmId: (id: string | null) => void;
+    setRemoveConfirmId: (id: string | null) => void;
   };
   onConnectChange: (id: string, label: string) => void;
   onDisconnect: (id: string) => void;
@@ -307,7 +321,33 @@ function AccountRow({
 }) {
   const state = describeAccountState(row);
   const isBusy = busy === row.id;
-  const { connectingId, disconnectConfirmId, setConnectingId, setDisconnectConfirmId } = connectState;
+  const {
+    connectingId,
+    disconnectConfirmId,
+    removeConfirmId,
+    setConnectingId,
+    setDisconnectConfirmId,
+    setRemoveConfirmId,
+  } = connectState;
+
+  // Server-owned destructive action (remove / disconnect) now restarts
+  // opencode on the box, interrupting every running session — the confirm
+  // spells that consequence out (BET-1320). Rendered inline, not a modal.
+  const confirmBlock = (label: string, confirm: () => void, cancel: () => void) => (
+    <div className="space-y-1">
+      <div className="inline-flex items-center gap-2">
+        <ConfirmInline
+          label={label}
+          busy={isBusy}
+          onConfirm={confirm}
+          onCancel={cancel}
+        />
+      </div>
+      <div className="text-meta text-text-muted">
+        This restarts opencode and interrupts every running session.
+      </div>
+    </div>
+  );
 
   let control: ReactNode;
 
@@ -334,42 +374,46 @@ function AccountRow({
       <>
         <span className={STATE_TONE_CLASS[state.tone]}>{state.text}</span>
         {row.className === "Custom" ? (
-          <>
-            <button
-              onClick={() => onDiscover(row.id)}
-              disabled={isBusy}
-              className="px-2 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
-            >
-              {isBusy ? "…" : "Refresh"}
-            </button>
-            <button
-              onClick={() => onRemove(row.id)}
-              disabled={isBusy}
-              className="text-meta text-text-faint hover:text-text px-1 inline-flex items-center"
-              title="Remove endpoint"
-              aria-label={`Remove ${row.name}`}
-            >
-              <X size={14} aria-hidden="true" />
-            </button>
-          </>
-        ) : row.connected ? (
-          disconnectConfirmId === row.id ? (
+          removeConfirmId === row.id ? (
+            confirmBlock(
+              "Remove",
+              () => onRemove(row.id),
+              () => setRemoveConfirmId(null),
+            )
+          ) : (
             <>
               <button
-                onClick={() => onDisconnect(row.id)}
-                disabled={busy !== null}
-                className="px-2 py-1 text-meta bg-danger-bg border border-danger rounded-xs text-danger hover:text-danger disabled:opacity-40"
+                onClick={() => onDiscover(row.id)}
+                disabled={isBusy}
+                className="px-2 py-1 text-meta bg-bg-soft border border-border rounded-xs text-text-muted hover:text-text disabled:opacity-40"
               >
-                {busy === row.id ? "…" : "Disconnect"}
+                {isBusy ? "…" : "Refresh"}
               </button>
               <button
-                onClick={() => setDisconnectConfirmId(null)}
+                onClick={() => {
+                  if (busy !== null) return;
+                  setRemoveConfirmId(row.id);
+                }}
                 disabled={busy !== null}
-                className="px-2 py-1 text-meta text-text-faint hover:text-text disabled:opacity-40"
+                className="text-meta text-text-faint hover:text-text px-1 inline-flex items-center"
+                title="Remove endpoint"
+                aria-label={`Remove ${row.name}`}
               >
-                Cancel
+                <X size={14} aria-hidden="true" />
               </button>
             </>
+          )
+        ) : row.connected && row.managedExternally ? (
+          // Credential owned by the Claude CLI — no Disconnect Manta can
+          // deliver; the state text already says who owns it (BET-1320).
+          null
+        ) : row.connected ? (
+          disconnectConfirmId === row.id ? (
+            confirmBlock(
+              "Disconnect",
+              () => onDisconnect(row.id),
+              () => setDisconnectConfirmId(null),
+            )
           ) : (
             <button
               onClick={() => setDisconnectConfirmId(row.id)}
@@ -429,6 +473,7 @@ export function AccountsCard() {
   const [busy, setBusy] = useState<string | null>(null);
   const [connectingId, setConnectingId] = useState<string | null>(null);
   const [disconnectConfirmId, setDisconnectConfirmId] = useState<string | null>(null);
+  const [removeConfirmId, setRemoveConfirmId] = useState<string | null>(null);
   // Per-endpoint retry verdict: `ok:true` = flag cleared (text-ok), `ok:false` = still refused (text-danger).
   const [retryResult, setRetryResult] = useState<Record<string, { ok: boolean; message: string }>>({});
   // Per-endpoint discovery result (BET-1273 9a/9b): the discovered model list
@@ -476,6 +521,8 @@ export function AccountsCard() {
         name: s.label,
         plan: s.plan,
         connected: s.connected,
+        managedExternally: s.managedExternally,
+        managedBy: s.managedBy,
         reading,
         balance,
         health: effectiveHealth,
@@ -627,7 +674,10 @@ export function AccountsCard() {
       await mutate(async () => {
         const res = await window.api.opencodeSetProviders({ remove: [ep.id] });
         if (!res.ok) throw new Error(res.error ?? "Remove failed");
-        useStore.getState().setOpencodeRestartNeeded(true);
+        // BET-1318: the server restarts opencode itself as part of the remove
+        // op — do NOT raise the shared restart banner here (it would ask the
+        // user to do something already done). Keep the removed endpoint's
+        // discovery state cleared.
         setDiscovered((d) => {
           const { [ep.id]: _drop, ...rest } = d;
           return rest;
@@ -639,6 +689,7 @@ export function AccountsCard() {
         void refresh();
       });
       setBusy(null);
+      setRemoveConfirmId(null);
     },
     [busy, mutate, refresh],
   );
@@ -673,8 +724,10 @@ export function AccountsCard() {
                   connectState={{
                     connectingId,
                     disconnectConfirmId,
+                    removeConfirmId,
                     setConnectingId,
                     setDisconnectConfirmId,
+                    setRemoveConfirmId,
                   }}
                   onConnectChange={onConnectChange}
                   onDisconnect={(id) => void disconnect(id)}

--- a/src/renderer/ConfirmInline.tsx
+++ b/src/renderer/ConfirmInline.tsx
@@ -1,0 +1,34 @@
+// ===== ConfirmInline (BET-1320) =====
+//
+// Shared inline destructive-confirm: the danger-toned confirm button ("…"
+// while busy) plus the ghost Cancel, used by every account-row action whose
+// server-side effect is destructive (disconnect, remove). Extracted from the
+// account row's inline copy so the two confirm flows render identically —
+// the exact markup that used to live inline in AccountsCard's disconnect
+// branch. No styling beyond the moved classes, no new tokens.
+
+export function ConfirmInline({ label, busy, onConfirm, onCancel }: {
+  label: string;
+  busy: boolean;
+  onConfirm: () => void;
+  onCancel: () => void;
+}) {
+  return (
+    <>
+      <button
+        onClick={onConfirm}
+        disabled={busy}
+        className="px-2 py-1 text-meta bg-danger-bg border border-danger rounded-xs text-danger hover:text-danger disabled:opacity-40"
+      >
+        {busy ? "…" : label}
+      </button>
+      <button
+        onClick={onCancel}
+        disabled={busy}
+        className="px-2 py-1 text-meta text-text-faint hover:text-text disabled:opacity-40"
+      >
+        Cancel
+      </button>
+    </>
+  );
+}

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -6,6 +6,7 @@ import { fileURLToPath } from "node:url";
 import { randomUUID } from "node:crypto";
 import { gzipSync } from "node:zlib";
 import { homedir } from "node:os";
+import { existsSync } from "node:fs";
 import { transcribeAudio } from "../shared/groq.mjs";
 import { expandTilde } from "../shared/paths.mjs";
 import {
@@ -1329,9 +1330,19 @@ export function buildHandlers({
         // "Connected" forever. The auth store is what both connect and
         // disconnect write, so it reflects the truth immediately.
         const connected = await oc.readAuthedProviderIds();
+        // BET-1320: a provider whose detect path exists on disk has its
+        // credential owned outside Manta (e.g. the Claude CLI) — flag it so
+        // the renderer shows the owner instead of a Disconnect it can't
+        // deliver. Expand a leading `~` via the shared expandTilde (the one
+        // place that knows how).
+        const externallyManaged = new Set(
+          subscriptionProviders.SUBSCRIPTION_PROVIDERS.filter((p) =>
+            (p.detect ?? []).some((d) => existsSync(expandTilde(d))),
+          ).map((p) => p.id),
+        );
         return {
           action: "status",
-          providers: subscriptionProviders.subscriptionStatuses(connected),
+          providers: subscriptionProviders.subscriptionStatuses(connected, externallyManaged),
         };
       }
       if (action === "start") {

--- a/src/server/subscriptionProviders.mjs
+++ b/src/server/subscriptionProviders.mjs
@@ -42,6 +42,13 @@ export const SUBSCRIPTION_PROVIDERS = [
     plan: "Claude Pro / Max",
     prefer: [{ type: "oauth", match: "claude code account" }],
     detect: ["~/.claude/.credentials.json"],
+    // BET-1320: the opencode-claude-auth plugin re-syncs
+    // ~/.claude/.credentials.json into opencode's auth store at startup and
+    // every 5 minutes, so deleting the anthropic credential is undone within
+    // minutes — Manta cannot deliver a Disconnect for this row. When this
+    // detect path is present, the status branch flags the row as externally
+    // managed and the renderer shows the owner instead of a dead button.
+    managedBy: "the Claude CLI on this box",
     console: null,
     docs: "https://claude.com/pricing",
     // BET-354: tag that flags this row for the claude-login connect shape
@@ -231,14 +238,21 @@ export function describeConnectShape(resolvedMethod, authorizeResponse, id) {
  * @property {string|null} console  where to mint a key, or null
  * @property {string} docs       canonical setup doc URL
  * @property {boolean} connected  true iff id ∈ connected
+ * @property {boolean} managedExternally  true iff id ∈ externallyManaged — the
+ *                             credential is owned outside Manta and a
+ *                             Disconnect cannot be delivered
+ * @property {string|null} managedBy  who owns the credential (registry value,
+ *                             null when not externally managed)
  */
 
 /**
  * @param {string[]} connected  the `connected[]` array from opencode's GET /provider
+ * @param {Set<string>} [externallyManaged]  provider ids whose credential Manta does not own
  * @returns {SubscriptionStatus[]}
  */
-export function subscriptionStatuses(connected) {
+export function subscriptionStatuses(connected, externallyManaged = new Set()) {
   const set = new Set(Array.isArray(connected) ? connected : []);
+  const managed = externallyManaged instanceof Set ? externallyManaged : new Set();
   return SUBSCRIPTION_PROVIDERS.map((p) => ({
     id: p.id,
     label: p.label,
@@ -246,6 +260,8 @@ export function subscriptionStatuses(connected) {
     console: p.console,
     docs: p.docs,
     connected: set.has(p.id),
+    managedExternally: managed.has(p.id),
+    managedBy: p.managedBy ?? null,
   }));
 }
 

--- a/src/server/subscriptionProviders.test.mjs
+++ b/src/server/subscriptionProviders.test.mjs
@@ -273,6 +273,44 @@ describe("subscriptionStatuses", () => {
     assert.equal(kimi.plan, "Kimi For Coding");
     assert.equal(kimi.console, "https://www.kimi.com/code/console");
   });
+
+  it("omitting the second argument leaves every row managedExternally false", () => {
+    const rows = subscriptionStatuses(["anthropic", "openai", "kimi-for-coding"]);
+    // Not externally managed → the renderer must not treat the row specially,
+    // even though the anthropic entry still carries its registry managedBy.
+    assert.equal(rows.every((r) => r.managedExternally === false), true);
+  });
+
+  it("a non-flagged row still reports its registry managedBy value", () => {
+    const [anthropic, openai] = subscriptionStatuses([]);
+    assert.equal(anthropic.managedExternally, false);
+    assert.equal(anthropic.managedBy, "the Claude CLI on this box");
+    // Providers with no registry managedBy → null.
+    assert.equal(openai.managedBy, null);
+  });
+
+  it("flags a row from the externallyManaged set and names its owner from the registry", () => {
+    const rows = subscriptionStatuses(["anthropic"], new Set(["anthropic"]));
+    const anthropic = rows.find((r) => r.id === "anthropic");
+    assert.equal(anthropic.managedExternally, true);
+    assert.equal(anthropic.managedBy, "the Claude CLI on this box");
+
+    // Openai/Kimi carry no registry managedBy → null, and are NOT flagged.
+    const openai = rows.find((r) => r.id === "openai");
+    assert.equal(openai.managedExternally, false);
+    assert.equal(openai.managedBy, null);
+  });
+
+  it("a connected-but-externally-managed row is both connected and flagged", () => {
+    const [anthropic] = subscriptionStatuses(["anthropic"], new Set(["anthropic"]));
+    assert.equal(anthropic.connected, true);
+    assert.equal(anthropic.managedExternally, true);
+  });
+
+  it("tolerates a non-Set second argument (defensive)", () => {
+    const rows = subscriptionStatuses(["anthropic"], []);
+    assert.equal(rows.every((r) => r.managedExternally === false), true);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2625,6 +2625,10 @@ export type SubscriptionStatus = {
   console: string | null;  // where to mint a key (Kimi), or null
   docs: string;           // canonical setup doc URL
   connected: boolean;     // true iff opencode reports this provider connected
+  // BET-1320: the credential is owned outside Manta (e.g. the Claude CLI), so
+  // a Disconnect cannot be delivered — the UI shows `managedBy` instead.
+  managedExternally: boolean;
+  managedBy: string | null;
 };
 
 export type SubscriptionConnectShape =


### PR DESCRIPTION
## BET-1320 — Settings accounts: shared inline confirm, drop dead restart call, hide the Disconnect Manta can't deliver

Implements the renderer half of the BET-1318/1319 server behaviour. **Base: origin/main @ `299c387f`**.

### What changed

1. **`ConfirmInline.tsx` (new)** — the shared destructive inline confirm (danger-toned `busy ? "…" : label` + ghost Cancel), extracted verbatim from the account row's disconnect branch. Used for **both** the subscription Disconnect and the custom-endpoint Remove (which previously had no confirm at all — and now restarts opencode on the box, so it must ask first). Each confirm row additionally spells out the consequence inline: *"This restarts opencode and interrupts every running session."*
2. **Dropped the dead restart call** from `removeEndpoint` only (the server restarts opencode itself as part of the remove op — raising the shared restart banner would ask the user to do something already done). **Kept** it in `toggleModel` (upsert, server does not restart).
3. **Claude's Disconnect is no longer rendered.** The `opencode-claude-auth` plugin re-syncs `~/.claude/.credentials.json` every 5 min, so a delete would be undone — Manta can't deliver it. Data-driven: registry `managedBy` on the anthropic entry, pure `subscriptionStatuses(connected, externallyManaged)` second argument, an rpc status-branch detect-path probe (via the shared `expandTilde`), new `SubscriptionStatus` fields, and the row shows *connected · signed in with the Claude CLI on this box* with no Disconnect button.

### Adaptation note

The issue references `describeSubscriptionStatus` in `chatUtils.ts`, but that function was removed during the BET-1250 `SubscriptionsCard`→`AccountsCard` consolidation. I put the new copy in the existing pure describer for this row, `describeAccountState` in `AccountsCard.tsx` (unit-tested alongside its other branches) rather than resurrecting a dead function.

### Verification results

- PR branch (`multica/BET-1320-shared-inline-confirm` @ `ac2ad741`):
  - typecheck: exit 0. Errors: none.
  - test: vitest 3577 pass / 7 skip (189 files), server 2717 pass / 0 fail. Failures: none.
- Base (`main` @ `299c387f`): not re-run separately (PR branch is branched from `origin/main` and carries zero unrelated changes).

Follow-up filed: none.
