### PR TITLE
fix(main): harden windows against navigation and external launch (BET-1324)

### DIFF
--- a/src/main/callWindow.test.ts
+++ b/src/main/callWindow.test.ts
@@ -79,7 +79,7 @@ const bwState = vi.hoisted(() => {
       for (const fn of this.listeners.get(event) ?? []) fn();
     }
     get webContents() {
-      return { setWindowOpenHandler() {}, loadURL() {}, loadFile() {} };
+      return { on() {}, setWindowOpenHandler() {}, loadURL() {}, loadFile() {} };
     }
   }
   return { BrowserWindow };

--- a/src/main/callWindow.ts
+++ b/src/main/callWindow.ts
@@ -15,6 +15,10 @@
 
 import { BrowserWindow, shell } from "electron";
 import { join } from "node:path";
+import {
+  shouldAllowNavigation,
+  externalUrlOrNull,
+} from "./windowSecurity.js";
 
 // A short-lived "opening" size if we have no saved bounds.
 const DEFAULT_BOUNDS = { x: undefined, y: undefined, width: 380, height: 560 };
@@ -66,8 +70,16 @@ export function createCallWindowController(deps: Deps): CallWindowController {
       },
     });
 
+    // BET-1324: same window-hardening as the main window (see windowSecurity.ts)
+    // — deny navigation away from the app's own page and only openExternal http/https.
+    callWindow.webContents.on("will-navigate", (event, url) => {
+      if (!shouldAllowNavigation(callWindow!.webContents.getURL(), url)) {
+        event.preventDefault();
+      }
+    });
     callWindow.webContents.setWindowOpenHandler(({ url }) => {
-      shell.openExternal(url);
+      const external = externalUrlOrNull(url);
+      if (external) shell.openExternal(external.href);
       return { action: "deny" };
     });
 

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -38,6 +38,10 @@ import {
 } from "./screenshotDetector.js";
 import { checkForUpdates } from "./autoUpdate.js";
 import { titleBarOptions } from "./windowChrome.js";
+import {
+  shouldAllowNavigation,
+  externalUrlOrNull,
+} from "./windowSecurity.js";
 import { downloadFileToDownloads } from "./download.js";
 import { createCallWindowController } from "./callWindow.js";
 import { registerInstallerHandlers } from "./installer/handlers.js";
@@ -92,8 +96,18 @@ function createWindow(): void {
     },
   });
 
+  // BET-1324: deny any top-level navigation that leaves the app's own page
+  // (a foreign URL replacing the whole window), and only hand http:/https:
+  // URLs to the OS via openExternal. Shared with the call window — see
+  // windowSecurity.ts.
+  mainWindow.webContents.on("will-navigate", (event, url) => {
+    if (!shouldAllowNavigation(mainWindow!.webContents.getURL(), url)) {
+      event.preventDefault();
+    }
+  });
   mainWindow.webContents.setWindowOpenHandler(({ url }) => {
-    shell.openExternal(url);
+    const external = externalUrlOrNull(url);
+    if (external) shell.openExternal(external.href);
     return { action: "deny" };
   });
 

--- a/src/main/windowSecurity.test.ts
+++ b/src/main/windowSecurity.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from "vitest";
+import {
+  shouldAllowNavigation,
+  externalUrlOrNull,
+} from "./windowSecurity";
+
+describe("shouldAllowNavigation", () => {
+  it("allows navigating to the app's own URL (reload)", () => {
+    expect(shouldAllowNavigation("file:///app/index.html", "file:///app/index.html")).toBe(true);
+  });
+
+  it("allows a same-URL reload in dev (http origin)", () => {
+    expect(shouldAllowNavigation("http://localhost:5173/", "http://localhost:5173/")).toBe(true);
+  });
+
+  it("denies navigation to a foreign https origin", () => {
+    expect(shouldAllowNavigation("file:///app/index.html", "https://evil.example")).toBe(false);
+  });
+
+  it("denies navigation to a file path", () => {
+    expect(shouldAllowNavigation("file:///app/index.html", "file:///etc/passwd")).toBe(false);
+  });
+
+  it("denies a different same-origin path", () => {
+    expect(shouldAllowNavigation("file:///app/index.html", "file:///app/other.html")).toBe(false);
+  });
+
+  it("denies when either side is unparseable (fail closed)", () => {
+    expect(shouldAllowNavigation("file:///app/index.html", "not a url")).toBe(false);
+    expect(shouldAllowNavigation("not a url", "file:///app/index.html")).toBe(false);
+  });
+});
+
+describe("externalUrlOrNull", () => {
+  it("returns the URL for http", () => {
+    const url = externalUrlOrNull("http://example.com/path");
+    expect(url).toBeInstanceOf(URL);
+    expect(url?.href).toBe("http://example.com/path");
+  });
+
+  it("returns the URL for https", () => {
+    const url = externalUrlOrNull("https://example.com/path");
+    expect(url).toBeInstanceOf(URL);
+    expect(url?.href).toBe("https://example.com/path");
+  });
+
+  it("returns null for file:", () => {
+    expect(externalUrlOrNull("file:///etc/passwd")).toBeNull();
+  });
+
+  it("returns null for smb:", () => {
+    expect(externalUrlOrNull("smb://server/share")).toBeNull();
+  });
+
+  it("returns null for javascript:", () => {
+    expect(externalUrlOrNull("javascript:alert(1)")).toBeNull();
+  });
+
+  it("returns null for a custom scheme", () => {
+    expect(externalUrlOrNull("manta://pair?box=abc&code=123456")).toBeNull();
+  });
+
+  it("returns null for unparseable garbage", () => {
+    expect(externalUrlOrNull("not a url at all")).toBeNull();
+  });
+
+  it("returns null for a non-string", () => {
+    expect(externalUrlOrNull(undefined as unknown as string)).toBeNull();
+  });
+});

--- a/src/main/windowSecurity.ts
+++ b/src/main/windowSecurity.ts
@@ -1,0 +1,61 @@
+// windowSecurity.ts — shared window-hardening helpers for the Electron main
+// process (BET-1324).
+//
+// Both BrowserWindows (the main one in index.ts and the call window in
+// callWindow.ts) apply the same two guards, so the logic lives here once
+// instead of being duplicated across two files:
+//
+//   • will-navigate   — deny any top-level navigation away from the app's own
+//                       URL, so embedded/foreign content can't replace the
+//                       whole window with a page of its choosing.
+//   • setWindowOpenHandler — only hand http:/https: URLs to the OS; drop
+//                       everything else (file:, smb:, javascript:, custom
+//                       schemes, unparseable strings) instead of launching it.
+//
+// Both helpers are pure (no Electron import) so they can be unit-tested in
+// isolation.
+
+/**
+ * Whether a `will-navigate` target is the app's own URL and may be allowed.
+ *
+ * The renderer is a single-page app that never initiates a top-level
+ * navigation, so the only URL it legitimately navigates to is the page it
+ * already holds. Returning true only for an exact match of the current URL
+ * (allowing reloads) denies everything else — https://evil.example, a
+ * file:///etc/passwd path, a differing same-origin path — while still
+ * permitting the app to reload its own page.
+ *
+ * An unparseable current or target string is denied (fail closed), never
+ * passed through.
+ */
+export function shouldAllowNavigation(currentUrl: string, targetUrl: string): boolean {
+  let current: URL;
+  let target: URL;
+  try {
+    current = new URL(currentUrl);
+    target = new URL(targetUrl);
+  } catch {
+    return false;
+  }
+  return target.href === current.href;
+}
+
+/**
+ * Returns the parsed URL when `raw` is an http: or https: URL, else null.
+ *
+ * `shell.openExternal` hands an arbitrary string to the operating system, so
+ * it must only ever receive user-meaningful web URLs. A file:, smb:,
+ * javascript:, registered-custom-scheme URL, or an unparseable string must be
+ * dropped (return null), never launched.
+ */
+export function externalUrlOrNull(raw: string): URL | null {
+  if (typeof raw !== "string") return null;
+  let url: URL;
+  try {
+    url = new URL(raw);
+  } catch {
+    return null;
+  }
+  if (url.protocol !== "http:" && url.protocol !== "https:") return null;
+  return url;
+}

--- a/src/renderer/call.html
+++ b/src/renderer/call.html
@@ -7,6 +7,10 @@
       content="width=device-width, initial-scale=1.0"
     />
     <title>On-call CTO</title>
+    <!-- BET-1324: identical CSP to index.html — an identical string in both
+         files is worth more than a bespoke one ("why do these differ?" is a
+         question nobody will answer correctly later). -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' data:; connect-src 'self' ws: http: https:; frame-src https:;" />
     <link rel="stylesheet" href="./tokens.css" />
     <link rel="stylesheet" href="./call/call.css" />
   </head>

--- a/src/renderer/index.html
+++ b/src/renderer/index.html
@@ -18,7 +18,12 @@
          channel (httpApi `voiceFetchNote`) and handed to the player as an
          object URL, so blob: here is our own already-authorised bytes — never a
          remote origin, and never a `?token=` URL. -->
-    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' data:; connect-src 'self' ws: http: https:;" />
+    <!-- BET-1324: `frame-src https:` is added so the desktop widget renderer can
+         frame a URL served by the box (https://<box_id>.boxes.mantaui.com). The
+         box origin is per-install and cannot be enumerated in a static CSP, so we
+         permit https: for frame-src ONLY — default-src, script-src and
+         connect-src are deliberately not widened. -->
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self'; img-src 'self' data: blob:; media-src 'self' blob:; font-src 'self' data:; connect-src 'self' ws: http: https:; frame-src https:;" />
     <!-- BET-559: the PWA (manifest, apple-touch-icon, install meta, home-screen
          decoration) was the web-mobile-client surface and is retired with it.
          The renderer is the desktop Electron app — none of these PWA bits apply. -->


### PR DESCRIPTION
## BET-1324 — Desktop hardening: will-navigate deny, openExternal allowlist, call.html CSP, frame-src

**Base: origin/main @ `fe27b4eb`**

Four independent security gaps in the desktop app's window layer, fixed ahead of inline widgets shipping:

1. **will-navigate deny** — both windows (`src/main/index.ts`, `src/main/callWindow.ts`) now deny any top-level navigation away from the app's own URL via a shared `shouldAllowNavigation(currentUrl, targetUrl)` helper. The renderer is a single-page app that never top-level-navigates, so only an exact match of the current URL (i.e. reload) is allowed; `https://evil.example`, `file:///etc/passwd`, and differing same-origin paths are all denied (fail closed on unparseable strings).
2. **openExternal allowlist** — `shell.openExternal` is only invoked for `http:`/`https:` URLs via shared `externalUrlOrNull(raw)`; `file:`, `smb:`, `javascript:`, custom schemes and unparseable garbage are dropped (return null) instead of being handed to the OS.
3. **call.html CSP** — `src/renderer/call.html` now carries the identical CSP string as `index.html` (continuation of the existing `frame-src` addition). Both share one `<meta http-equiv="Content-Security-Policy">` content value.
4. **frame-src** — `frame-src https:` added to the renderer CSP so the desktop widget renderer can frame the box-served URL. The box origin (`https://<box_id>.boxes.mantaui.com`) is per-install and can't be enumerated in a static CSP, so we permit `https:` for `frame-src` **only** — `default-src`, `script-src`, `connect-src` are deliberately not widened. Documented in a comment in `index.html`.

The helper lives in one module (`src/main/windowSecurity.ts`) used by both windows rather than a third copy of the duplicated `webPreferences`/`setWindowOpenHandler` blocks. Both helpers are pure — no Electron import — and unit-tested in `src/main/windowSecurity.test.ts`.

Out of scope per the issue, left untouched: `sandbox: false` on both windows, `webviewTag`, and the dead Swift `TerminalWebView` method.

**Files changed:** 7 files.
- `src/main/windowSecurity.ts` (new) — shared pure helpers
- `src/main/windowSecurity.test.ts` (new) — 14 tests
- `src/main/index.ts` — wire will-navigate denial + openExternal allowlist
- `src/main/callWindow.ts` — same wiring for the call window
- `src/main/callWindow.test.ts` — add `on()` to the fake `webContents` (real `webContents.on` supports it)
- `src/renderer/index.html` — add `frame-src https:`
- `src/renderer/call.html` — add identical CSP

**Verification results:**
- PR branch (`multica/BET-1324-windows-security`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0. vitest 3581 passed / 0 failed (includes 14 new windowSecurity tests + updated callWindow tests); node:test 2712 passed / 0 failed.
- Base (`main` @ `fe27b4eb`):
  - not separately re-run (PR branch is based directly on origin/main; no pre-existing failures were observed on the full run).
- **Conclusion:** 0 new failures. All suites green.
