### PR TITLE
BET-1323: feat(widgets): box spine — widget store, widget_show tool, /widgets/<id> route, the one CSP

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -494,3 +494,26 @@ Install/update each tool as a COPY (`cp docs/opencode-tools/{send-to-cto,cto}.ts
 ~/.config/opencode/tools/`) then `systemctl --user restart opencode-serve`. The
 engine + routers live in `src/server/cto.mjs` (createCtoEngine / createCtoInbound /
 createWatcherPoller).
+
+## MantaUI inline widgets
+
+You have a `widget_show` tool to store a self-contained inline HTML widget in
+the chat transcript — a chart, a mini-app, an interactive visual — authored
+entirely by you. The widget is a FULL standalone HTML document stored on the
+box and rendered by the client inside a sandboxed frame:
+
+- **Author everything inline.** The widget has **no network access**
+  (`connect-src 'none'`) and lives in an opaque, same-origin-less sandbox. Any
+  CSS, JS, or chart/library code must be embedded directly in the HTML you
+  write — nothing can be fetched, and the widget can never read the user's box
+  token or exfiltrate data. This is deliberate; do not ask for an exception.
+- **Declare `width`/`height` (or `aspectRatio`)** so the client can reserve
+  that box before the widget loads.
+- `widget_show(html, width?/height?/aspectRatio?, title?, ttlHours?)` ->
+  "Widget registered at <url>". Returns promptly; the widget expires after 24h
+  by default (`ttlHours: 0` = never).
+
+Install: `cp <repo>/docs/opencode-tools/widget.ts`
+`~/.config/opencode/tools/widget.ts` then `systemctl --user restart
+opencode-serve`. **Install/update is a COPY, never a symlink** (a symlink
+fails to resolve `@opencode-ai/plugin` and the tool silently never registers).

--- a/docs/opencode-tools/widget.ts
+++ b/docs/opencode-tools/widget.ts
@@ -1,0 +1,131 @@
+// manta-native `widget_show` tool — global opencode custom tool.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/widget.ts ~/.config/opencode/tools/widget.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+//
+// This tool is a THIN registrar. It validates the request and POSTs it to
+// manta-server (127.0.0.1:8787, same box — no SSH hop), which stores the HTML
+// under ~/.manta/widgets/<id>/ and serves it from /widgets/<id> under the
+// box's own hostname, then announces it to the clients on the bus. The tool
+// does NOT sleep, poll, or do any work — execute() returns promptly.
+//
+// See docs/manta-tools-scheduler.md for the general "manta tools" pattern.
+
+import { tool } from "@opencode-ai/plugin";
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api route
+// (M1 auth gate — src/server/auth.mjs). These tools run on the SAME box as the
+// same user as manta-server, so they read the token straight from the server's
+// own auth store (~/.manta/auth.json, 0600). Re-read on every call (one tiny
+// local file) so a token rotation never requires an opencode-serve restart.
+// MANTA_BOX_TOKEN env overrides for tests/dev.
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}
+
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+export const widget_show = tool({
+  description: [
+    "Store and display an inline widget in the chat: you author a FULL, ",
+    "self-contained standalone HTML document (a single <html> document with ",
+    "everything it needs inline — CSS, JS, chart libraries all embedded, ",
+    "because the widget has NO network access and cannot fetch anything). ",
+    "Declare width/height (or aspectRatio) so the client can reserve that box ",
+    "before the widget loads. The widget runs sandboxed in an opaque origin ",
+    "with no network (connect-src 'none') and no same-origin, so it can never ",
+    "read the user's box token or exfiltrate data — keep all rendering logic ",
+    "inside the authored HTML. A widget_show call returns promptly; the widget ",
+    "is stored on the box (default 24h TTL, or ttlHours:0 for no expiry).",
+  ].join(" "),
+  args: {
+    html: z
+      .string()
+      .describe(
+        "The full standalone HTML document for the widget (its own <html> " +
+          "document). Everything must be inline — CSS in <style>, JS in " +
+          "<script>, and any chart/library code embedded directly, because " +
+          "the widget has no network access and nothing external can be " +
+          "fetched or loaded.",
+      ),
+    title: z.string().optional().describe("Optional short label for the widget."),
+    width: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Desired width in px for the reserved box."),
+    height: z
+      .number()
+      .int()
+      .positive()
+      .optional()
+      .describe("Desired height in px for the reserved box."),
+    aspectRatio: z
+      .number()
+      .positive()
+      .optional()
+      .describe("Desired aspect ratio (width/height) when exact px are unknown."),
+    ttlHours: z
+      .number()
+      .optional()
+      .describe(
+        "Hours until the widget expires (default 24). Set to 0 to disable expiry.",
+      ),
+  },
+  async execute(args, context) {
+    const result = await call("POST", "/api/widgets", {
+      html: args.html,
+      title: args.title,
+      width: args.width,
+      height: args.height,
+      aspectRatio: args.aspectRatio,
+      ttlHours: args.ttlHours,
+      sessionID: context.sessionID,
+      messageID: context.messageID,
+    });
+    return `Widget registered at ${result.url}.`;
+  },
+});

--- a/src/server/auth.mjs
+++ b/src/server/auth.mjs
@@ -134,6 +134,14 @@ export function isExemptPath(path) {
   if (path === "/pair" || path === "/pair/qr.png" || path === "/pair/logo.png") return true;
   if (path === "/hook/" || path.startsWith("/hook/")) return true;
   if (path === "/pages/" || path.startsWith("/pages/")) return true;
+  // /widgets/<id> — inline widget (AI `widget_show` tool). AUTH-EXEMPT by
+  // design: an iframe/webview that renders the widget cannot send an
+  // `Authorization` header, and the id is 256 bits of unguessable entropy, so
+  // a visitor by definition holds no token and cannot guess one. The widget's
+  // own CSP (WIDGET_CSP) keeps it in an opaque origin with no network, so it
+  // can never reach the box_token (which is why the box token must NEVER go in
+  // the widget URL either). The management API /api/widgets is NOT exempt.
+  if (path === "/widgets/" || path.startsWith("/widgets/")) return true;
   return false;
 }
 

--- a/src/server/auth.test.mjs
+++ b/src/server/auth.test.mjs
@@ -103,15 +103,22 @@ test("isExemptPath exempts only /auth pairing + /pair onboarding + /hook deliver
   assert.equal(isExemptPath("/pages/foo"), true);
   assert.equal(isExemptPath("/pages/"), true);
   assert.equal(isExemptPath("/pages/my-design"), true);
+  // /widgets/<id> — inline widget (AI `widget_show` tool). Auth-exempt by
+  // design: an iframe/webview cannot send an Authorization header, and the id
+  // is 256 bits of unguessable entropy. The management API is NOT exempt.
+  assert.equal(isExemptPath("/widgets/" + "a".repeat(64)), true);
+  assert.equal(isExemptPath("/widgets/"), true);
   // NOT exempt — these must be gated
   assert.equal(isExemptPath("/auth/status"), false);
   assert.equal(isExemptPath("/api/projects"), false);
   assert.equal(isExemptPath("/api/serve-page"), false); // management API is gated
+  assert.equal(isExemptPath("/api/widgets"), false);    // management API is gated
   assert.equal(isExemptPath("/rpc/tmux"), false);
   assert.equal(isExemptPath("/events"), false);
   assert.equal(isExemptPath("/pair/other"), false); // narrow exemption: only the 3 exact paths
   assert.equal(isExemptPath("/pairx"), false);      // prefix attack guard
   assert.equal(isExemptPath("/pagesx"), false);     // prefix attack guard
+  assert.equal(isExemptPath("/widgetsx"), false);   // prefix attack guard
   assert.equal(isExemptPath("/"), false);
   assert.equal(isExemptPath(null), false);
 });
@@ -405,6 +412,7 @@ test("authorize allows exempt + preflight + public-asset paths without a token",
   assert.equal(eng.authorize({ method: "GET", path: "/pair/logo.png" }).ok, true);
   assert.equal(eng.authorize({ method: "POST", path: "/hook/abcd" }).ok, true);
   assert.equal(eng.authorize({ method: "GET", path: "/pages/foo" }).ok, true);
+  assert.equal(eng.authorize({ method: "GET", path: "/widgets/" + "a".repeat(64) }).ok, true);
   // BET-559: the web/PWA client is retired, so the SPA shell ("/") and its
   // Vite /assets/* bundle are no longer public assets — they are gated now.
   assert.equal(eng.authorize({ method: "GET", path: "/" }).ok, false);
@@ -415,6 +423,8 @@ test("authorize allows exempt + preflight + public-asset paths without a token",
   assert.equal(eng.authorize({ method: "GET", path: "/pair/other" }).ok, false);
   // /api/serve-page is NOT exempt — management API must be gated
   assert.equal(eng.authorize({ method: "GET", path: "/api/serve-page" }).ok, false);
+  // /api/widgets is NOT exempt — management API must be gated
+  assert.equal(eng.authorize({ method: "POST", path: "/api/widgets" }).ok, false);
   // a POST to an asset-looking path is still gated (assets are GET-only)
   assert.equal(eng.authorize({ method: "POST", path: "/assets/x.js" }).ok, false);
 });

--- a/src/server/htmlHeaders.mjs
+++ b/src/server/htmlHeaders.mjs
@@ -1,0 +1,22 @@
+// htmlHeaders.mjs — the ONE sandboxed-HTML response header builder.
+//
+// Both /pages/<sub> (servePage.mjs) and /widgets/<id> (widgets.mjs) serve a
+// model-authored standalone HTML document on the box's own origin. That origin
+// is shared with the real app (which holds the box_token), so every such
+// response must carry the same defensive header set: a sandbox CSP that keeps
+// the document in an opaque origin, `no-store`, `nosniff` and `no-referrer`.
+//
+// This is the single source of truth for those headers. The caller supplies
+// its own CSP policy — servePage uses its long-standing `sandbox
+// allow-scripts allow-forms allow-popups allow-modals` string (unchanged,
+// pinned by test), widgets uses WIDGET_CSP — so there is exactly one place a
+// header can be forgotten and no second HTML-serving code path.
+export function sandboxedHtmlHeaders(csp) {
+  return {
+    "Content-Type": "text/html; charset=utf-8",
+    "Content-Security-Policy": csp,
+    "Cache-Control": "no-store",
+    "X-Content-Type-Options": "nosniff",
+    "Referrer-Policy": "no-referrer",
+  };
+}

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -88,6 +88,14 @@ import {
   pageResponseHeaders,
   isValidSubdomain,
 } from "./servePage.mjs";
+import { sandboxedHtmlHeaders } from "./htmlHeaders.mjs";
+import {
+  WIDGET_CSP,
+  isValidWidgetId,
+  registerWidget,
+  readWidget,
+  startCleanupPoller as startWidgetCleanupPoller,
+} from "./widgets.mjs";
 import { publishPlanBundle } from "./planRender.mjs";
 import { listPeers, inspectPeer, sendPeerMessage, resolveWorkspace } from "./peers.mjs";
 import { upsertStopped, markStoppedRan, bumpStoppedAttempts, listStopped } from "./stoppedStore.mjs";
@@ -1007,6 +1015,11 @@ const { stop: stopServerUpdatePoller, check: checkServerUpdate } =
 // eslint-disable-next-line no-unused-vars
 const { stop: stopServePageCleanup } = startCleanupPoller();
 
+// Cleanup sweep for expired widgets (runs every 5 min). Same startPoller
+// shape as servePage's — immediate first tick, inFlight guard, timer.unref().
+// eslint-disable-next-line no-unused-vars
+const { stop: stopWidgetCleanup } = startWidgetCleanupPoller();
+
 // Best-effort install of the MantaUI-owned `manta-plan` primary agent (BET-984).
 // Reads ~/.config/opencode/opencode.jsonc; writes the manta-plan agent block
 // (mode "primary", plan_enter/plan_exit allow) via the existing writer and
@@ -1873,6 +1886,35 @@ const handleRequest = async (req, res) => {
       return;
     }
     res.writeHead(200, pageResponseHeaders());
+    res.end(result.html);
+    return;
+  }
+
+  // ---------- Inline widgets (PUBLIC, sandboxed) ----------
+  // GET /widgets/<id>  or  GET /widgets/<id>/  — one index.html per widget.
+  // The widget's CSP (WIDGET_CSP) sandboxes the document into an opaque
+  // origin with no network (`connect-src 'none'`) and no same-origin, so a
+  // malicious widget cannot read the box_token nor exfiltrate anything. The
+  // route is auth-EXEMPT (see isExemptPath): an iframe/webview cannot send an
+  // `Authorization` header, and the id is 256 bits of unguessable entropy, so
+  // a visitor by definition holds no token and cannot guess one. NEVER put the
+  // box token in the widget URL — a widget's own scripts can read
+  // `document.location`, which would hand the model's HTML the user's box
+  // credentials. See src/server/widgets.mjs.
+  if (req.method === "GET" && path.startsWith("/widgets/")) {
+    const id = path.slice("/widgets/".length).replace(/\/+$/, "");
+    // Sub-paths (/widgets/a/b) → 404 JSON. isValidWidgetId concurrently guards
+    // the registry key and the filesystem traversal.
+    if (!id || id.includes("/") || !isValidWidgetId(id)) {
+      respondJson(res, 404, { error: "not found" });
+      return;
+    }
+    const result = await readWidget(id);
+    if (!result.ok) {
+      respondJson(res, 404, { error: `widget "${id}" not found` });
+      return;
+    }
+    res.writeHead(200, sandboxedHtmlHeaders(WIDGET_CSP));
     res.end(result.html);
     return;
   }
@@ -2929,6 +2971,53 @@ const handleRequest = async (req, res) => {
     } catch (e) {
       // Errors return a message the model can act on, never a bare 500.
       respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Inline widgets ----------
+  // POST /api/widgets  body {html, title, width, height, aspectRatio, ttlHours,
+  //                         sessionID, messageID}
+  //   → {ok:true, id, url}  (400 {ok:false, error} on a bad request)
+  // Created by the remote AI's global opencode `widget_show` tool. The model
+  // authors a full standalone HTML document (the widget's code is all inline —
+  // it has NO network access, WIDGET_CSP's `connect-src 'none'` is the whole
+  // exfiltration defence). The HTML is stored under ~/.manta/widgets/<id>/
+  // and served from GET /widgets/<id> under the box's own hostname. Clients
+  // are told about it on the bus as ONE kind, `widget`, with an `action`
+  // discriminator — mirroring media.mjs's announcement. Behind the /api/* gate
+  // (no exemption; pinned by test). See src/server/widgets.mjs.
+  if (path === "/api/widgets") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const baseUrl = publicBaseUrl();
+        const result = await registerWidget(
+          {
+            html: body?.html,
+            title: body?.title,
+            width: body?.width,
+            height: body?.height,
+            aspectRatio: body?.aspectRatio,
+            ttlHours: body?.ttlHours,
+            sessionId: body?.sessionID,
+            messageId: body?.messageID,
+          },
+          {
+            publish: (payload) => bus.publish({ kind: "widget", payload }),
+            baseUrl,
+          },
+        );
+        if (!result.ok) {
+          respondJson(res, 400, { ok: false, error: result.error });
+          return;
+        }
+        respondJson(res, 200, { ok: true, id: result.id, url: result.url });
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { ok: false, error: String(e?.message ?? e) });
     }
     return;
   }

--- a/src/server/servePage.mjs
+++ b/src/server/servePage.mjs
@@ -19,6 +19,14 @@ import { join, dirname } from "node:path";
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { startPoller } from "./startPoller.mjs";
+import { sandboxedHtmlHeaders } from "./htmlHeaders.mjs";
+
+// servePage's long-standing sandbox policy. Kept as its own exact string —
+// without `allow-same-origin`, so the page lives in an opaque origin and its
+// scripts cannot read the box_token out of the app's localStorage on this
+// shared origin. Pinned by test (the absence of `allow-same-origin` is the
+// point); do not retune it here.
+const SERVE_PAGE_CSP = "sandbox allow-scripts allow-forms allow-popups allow-modals";
 
 const STORE_PATH = statePath("serve-page.json");
 const PAGES_DIR = statePath("pages");
@@ -246,17 +254,14 @@ export async function readPage(
 // ---------------------------------------------------------------------------
 // Response headers — sandboxed + opaque-origin so a hosted page can't read
 // the box_token out of the app's localStorage (which lives on the SAME
-// origin now that pages share the hostname with the SPA).
+// origin now that pages share the hostname with the SPA). The header set is
+// built once in htmlHeaders.mjs (sandboxedHtmlHeaders); servePage keeps its
+// exact long-standing CSP and delegates the whitelist to that shared helper.
+// widgets.mjs is the other caller. There is exactly one header builder.
 // ---------------------------------------------------------------------------
 
 export function pageResponseHeaders() {
-  return {
-    "Content-Type": "text/html; charset=utf-8",
-    "Cache-Control": "no-store",
-    "X-Content-Type-Options": "nosniff",
-    "Referrer-Policy": "no-referrer",
-    "Content-Security-Policy": "sandbox allow-scripts allow-forms allow-popups allow-modals",
-  };
+  return sandboxedHtmlHeaders(SERVE_PAGE_CSP);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/widgets.mjs
+++ b/src/server/widgets.mjs
@@ -1,0 +1,280 @@
+// widgets.mjs — inline widget store + read for manta-server.
+//
+// The remote AI authors a full standalone HTML document (an inline widget —
+// e.g. a chart, a mini-app) and calls the global opencode `widget_show` tool
+// (docs/opencode-tools/widget.ts), which POSTs to manta-server's /api/widgets.
+// The HTML is stored under ~/.manta/widgets/<id>/index.html and served from
+// manta-server itself at GET /widgets/<id> under the box's own published
+// hostname. Registration announces the widget to the clients on the bus as
+// ONE kind, `widget`, with an `action` discriminator — mirroring media.mjs's
+// announcement pattern. servePage.mjs is the storage sibling; this module is
+// servePage's storage + media's announcement.
+//
+// The widget id is a security boundary: 32 crypto-random bytes, hex (64
+// chars). It is both the registry key and the path-traversal guard before any
+// filesystem touch, mirroring servePage's isValidSubdomain.
+//
+// Widgets expire after a configurable TTL (default 24h); a cleanup sweep
+// removes expired entries every 5 minutes (the same startPoller shape the
+// neighbouring stores use).
+
+import { readFile, mkdir, writeFile, rm } from "node:fs/promises";
+import { existsSync } from "node:fs";
+import { randomBytes } from "node:crypto";
+import { join, dirname } from "node:path";
+import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { startPoller } from "./startPoller.mjs";
+
+const STORE_PATH = statePath("widgets.json");
+const WIDGETS_DIR = statePath("widgets");
+const DEFAULT_TTL_HOURS = 24;
+
+// Cleanup sweep interval — 5 min, matching servePage. Coarse enough to be
+// cheap, fine enough that expired widgets don't linger.
+const CLEANUP_MS = 5 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// The widget CSP — defined ONCE here and exported. The clients do not restate
+// it, do not parse it, and do not carry their own copy.
+// ---------------------------------------------------------------------------
+//
+// Three things here are load-bearing. Do not "tidy" any of them (see issue):
+//   - `sandbox` WITHOUT `allow-same-origin`. `allow-scripts allow-same-origin`
+//     together is a documented sandbox escape — the frame becomes same-origin
+//     with its embedder and can rewrite its own sandbox attribute. Never add it.
+//   - `connect-src 'none'` is the whole exfiltration defence. A widget that can
+//     draw but cannot open a socket has a tiny blast radius. Never relax it,
+//     and never add a "just for charts" exception — chart libraries must be
+//     inlined into the widget HTML by the model, not fetched.
+//   - `'unsafe-inline'` for script/style is deliberate and safe here precisely
+//     because there is no network and no same-origin. Do not replace it with a
+//     nonce scheme; that buys nothing and adds a code path.
+export const WIDGET_CSP = [
+  "sandbox allow-scripts",
+  "default-src 'none'",
+  "script-src 'unsafe-inline'",
+  "style-src 'unsafe-inline'",
+  "img-src data: blob:",
+  "font-src data:",
+  "connect-src 'none'",
+  "form-action 'none'",
+  "frame-src 'none'",
+].join("; ");
+
+// Strict widget-id validator — 32 bytes of hex = 64 hex chars. Used both as
+// the registry key and as the path-traversal guard before touching the
+// filesystem, so a crafted `/widgets/../../etc/passwd` can never escape
+// ~/.manta/widgets/.
+export function isValidWidgetId(id) {
+  return typeof id === "string" && /^[0-9a-f]{64}$/.test(id);
+}
+
+export function genWidgetId() {
+  return randomBytes(32).toString("hex");
+}
+
+// Pure URL builder. Centralises the path shape so callers don't reconstruct
+// it independently. The URL is served from manta-server itself under the box's
+// own hostname (/widgets/<id>), like /pages/<sub>.
+export function widgetUrl(baseUrl, id) {
+  return `${baseUrl}/widgets/${id}`;
+}
+
+function resolveWidgetFile(id) {
+  return join(WIDGETS_DIR, id, "index.html");
+}
+
+function resolveWidgetDir(id) {
+  return join(WIDGETS_DIR, id);
+}
+
+// ---------------------------------------------------------------------------
+// Store — durable registry in ~/.manta/widgets.json
+// ---------------------------------------------------------------------------
+
+export function loadWidgets(path = STORE_PATH) {
+  const parsed = readJsonSync(path, {});
+  return Array.isArray(parsed.widgets) ? parsed.widgets : [];
+}
+
+export function saveWidgets(widgets, path = STORE_PATH) {
+  return writeJsonAtomic(path, JSON.stringify({ widgets }, null, 2));
+}
+
+// Resolve the registry's `expiresAt` from the caller-provided `ttlHours`,
+// mirroring servePage's resolveExpiresAt:
+//   - undefined/null → DEFAULT_TTL_HOURS from `now`
+//   - 0              → null (never expires; sweep filter skips falsy)
+//   - any other number → now + ttlHours * 3600 * 1000
+//   - non-number / negative / non-finite → {ok:false, error}
+export function resolveExpiresAt(ttlHours, now = Date.now()) {
+  if (ttlHours === undefined || ttlHours === null) {
+    return { ok: true, expiresAt: now + DEFAULT_TTL_HOURS * 3600 * 1000 };
+  }
+  if (ttlHours === 0) {
+    return { ok: true, expiresAt: null };
+  }
+  if (
+    typeof ttlHours !== "number" ||
+    !Number.isFinite(ttlHours) ||
+    ttlHours < 0
+  ) {
+    return {
+      ok: false,
+      error: "ttlHours must be a non-negative number (0 = never expires)",
+    };
+  }
+  return { ok: true, expiresAt: now + ttlHours * 3600 * 1000 };
+}
+
+// Normalise a dimensions field for storage + bus publication: any non-number
+// becomes null. A widget that declares neither width/height nor aspectRatio is
+// legal (the client falls back to its own default box); the tool description
+// pushes the model to declare them so the client can reserve the box up front.
+function numOrNull(v) {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+// ---------------------------------------------------------------------------
+// CRUD — injectable via {load, save, publish, baseUrl}
+// ---------------------------------------------------------------------------
+
+export async function registerWidget(
+  { html, title, width, height, aspectRatio, ttlHours, sessionId, messageId },
+  { load = loadWidgets, save = saveWidgets, publish, baseUrl } = {},
+) {
+  if (typeof html !== "string" || html.trim() === "") {
+    return { ok: false, error: "html is required" };
+  }
+  // An unregistered box has no published hostname, so any URL we returned
+  // would be unreachable — the same failure servePage guards against. There is
+  // no stable widget URL without a base.
+  if (!baseUrl) {
+    return {
+      ok: false,
+      error:
+        "This box has no published public hostname, so a widget URL would not " +
+        "be reachable from anywhere. Inline widgets are unavailable on this box.",
+    };
+  }
+
+  // Validate ttlHours before anything is written.
+  const ttlResult = resolveExpiresAt(ttlHours);
+  if (!ttlResult.ok) {
+    return { ok: false, error: ttlResult.error };
+  }
+  const expiresAt = ttlResult.expiresAt;
+
+  const id = genWidgetId();
+  const widgetFile = resolveWidgetFile(id);
+
+  // Write the HTML as a stable snapshot (exactly as servePage copies the
+  // source file at register time).
+  await mkdir(dirname(widgetFile), { recursive: true });
+  await writeFile(widgetFile, html);
+
+  const entry = {
+    id,
+    sessionId: sessionId ?? null,
+    title: typeof title === "string" && title ? title : null,
+    width: numOrNull(width),
+    height: numOrNull(height),
+    aspectRatio: numOrNull(aspectRatio),
+    createdAt: Date.now(),
+    expiresAt,
+  };
+  const widgets = load();
+  widgets.push(entry);
+  await save(widgets);
+
+  const url = widgetUrl(baseUrl, id);
+  if (publish) {
+    publish({
+      action: "show",
+      id,
+      url,
+      title: entry.title,
+      width: entry.width,
+      height: entry.height,
+      aspectRatio: entry.aspectRatio,
+      sessionId: entry.sessionId,
+      messageId: messageId ?? null,
+    });
+  }
+
+  return { ok: true, id, url };
+}
+
+// Read a served widget from disk. Returns {ok:true, html:Buffer} on success,
+// or {ok:false} when the widget is missing — in which case the matching
+// registry entry is also pruned (the file may have been removed externally or
+// swept), matching readPage. I/O is injectable so tests don't need a real
+// filesystem.
+export async function readWidget(id, { load = loadWidgets, save = saveWidgets } = {}) {
+  const widgetFile = resolveWidgetFile(id);
+  if (!existsSync(widgetFile)) {
+    // Best-effort prune — a missing widget file is treated as "gone".
+    try {
+      const widgets = load();
+      const filtered = widgets.filter((w) => w.id !== id);
+      if (filtered.length < widgets.length) {
+        await save(filtered);
+      }
+    } catch {
+      // best-effort
+    }
+    return { ok: false };
+  }
+  try {
+    const html = await readFile(widgetFile);
+    return { ok: true, html };
+  } catch {
+    return { ok: false };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Cleanup sweep — removes expired widgets every 5 min
+// ---------------------------------------------------------------------------
+
+export function createCleanupSweep({
+  load = loadWidgets,
+  save = saveWidgets,
+  now = () => new Date(),
+} = {}) {
+  let inFlight = false;
+
+  async function sweep() {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      const widgets = load();
+      const expired = widgets.filter((w) => w.expiresAt && now().getTime() > w.expiresAt);
+      if (expired.length === 0) return;
+
+      for (const entry of expired) {
+        try {
+          const dir = resolveWidgetDir(entry.id);
+          if (existsSync(dir)) {
+            await rm(dir, { recursive: true });
+          }
+        } catch {
+          // best-effort per-widget cleanup
+        }
+      }
+
+      const remaining = widgets.filter((w) => !(w.expiresAt && now().getTime() > w.expiresAt));
+      await save(remaining);
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  return { sweep };
+}
+
+export function startCleanupPoller({ intervalMs = CLEANUP_MS } = {}) {
+  const { sweep } = createCleanupSweep();
+  return startPoller(sweep, { intervalMs, label: "widgets" });
+}

--- a/src/server/widgets.test.mjs
+++ b/src/server/widgets.test.mjs
@@ -1,0 +1,239 @@
+// Tests for widgets.mjs pure logic + injected-I/O paths — no live HTTP, no
+// real disk outside the sandbox (MANTA_STATE_HOME). Run via `npm run
+// test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import { rm } from "node:fs/promises";
+import {
+  isValidWidgetId,
+  WIDGET_CSP,
+  genWidgetId,
+  widgetUrl,
+  registerWidget,
+  readWidget,
+  createCleanupSweep,
+} from "./widgets.mjs";
+import { sandboxedHtmlHeaders } from "./htmlHeaders.mjs";
+import { pageResponseHeaders } from "./servePage.mjs";
+import { STATE_DIRNAME } from "../shared/paths.mjs";
+
+// ---------------------------------------------------------------------------
+// isValidWidgetId — the id is a security boundary (registry key AND
+// path-traversal guard). 32 bytes = 64 hex chars.
+// ---------------------------------------------------------------------------
+
+test("isValidWidgetId accepts a real 64-hex id", () => {
+  const id = genWidgetId();
+  assert.match(id, /^[0-9a-f]{64}$/);
+  assert.equal(isValidWidgetId(id), true);
+  assert.equal(isValidWidgetId("a".repeat(64)), true);
+});
+
+test("isValidWidgetId rejects traversal, uppercase, wrong length, empty", () => {
+  // A path-traversal attempt must be rejected by the same validator used
+  // before touching the filesystem.
+  assert.equal(isValidWidgetId("../"), false);
+  assert.equal(isValidWidgetId(".."), false);
+  assert.equal(isValidWidgetId("../../etc/passwd"), false);
+  assert.equal(isValidWidgetId("a/bc"), false);
+  // Uppercase is not a valid hex widget id (lowercase only).
+  assert.equal(isValidWidgetId("A".repeat(64)), false);
+  // Wrong length.
+  assert.equal(isValidWidgetId("a".repeat(63)), false);
+  assert.equal(isValidWidgetId("a".repeat(65)), false);
+  // Empty / non-string.
+  assert.equal(isValidWidgetId(""), false);
+  assert.equal(isValidWidgetId(null), false);
+  assert.equal(isValidWidgetId(123), false);
+});
+
+// ---------------------------------------------------------------------------
+// WIDGET_CSP — the load-bearing security invariants. The one that matters
+// most: `connect-src 'none'` (the whole exfiltration defence) is present and
+// `allow-same-origin` is ABSENT (a sandbox escape).
+// ---------------------------------------------------------------------------
+
+test("WIDGET_CSP has connect-src 'none' and NEVER allow-same-origin", () => {
+  assert.match(WIDGET_CSP, /connect-src 'none'/);
+  // The sandbox-same-origin escape: `allow-scripts allow-same-origin` makes a
+  // sandboxed frame same-origin with its embedder, so it could rewrite its own
+  // sandbox attribute. It must never appear.
+  assert.equal(WIDGET_CSP.includes("allow-same-origin"), false);
+  assert.match(WIDGET_CSP, /^sandbox allow-scripts/);
+});
+
+// ---------------------------------------------------------------------------
+// sandboxedHtmlHeaders — the ONE header builder. servePage's policy must pass
+// through it unchanged (pure refactor).
+// ---------------------------------------------------------------------------
+
+test("sandboxedHtmlHeaders returns all five defensive headers", () => {
+  const h = sandboxedHtmlHeaders(WIDGET_CSP);
+  assert.equal(h["Content-Type"], "text/html; charset=utf-8");
+  assert.equal(h["Content-Security-Policy"], WIDGET_CSP);
+  assert.equal(h["Cache-Control"], "no-store");
+  assert.equal(h["X-Content-Type-Options"], "nosniff");
+  assert.equal(h["Referrer-Policy"], "no-referrer");
+});
+
+test("servePage policy is unchanged through the refactor", () => {
+  // servePage keeps its exact long-standing CSP (pinned by servePage.test.mjs).
+  const h = pageResponseHeaders();
+  assert.equal(h["Content-Security-Policy"], "sandbox allow-scripts allow-forms allow-popups allow-modals");
+  assert.equal(h["Content-Type"], "text/html; charset=utf-8");
+  assert.equal(h["Cache-Control"], "no-store");
+  assert.equal(h["X-Content-Type-Options"], "nosniff");
+  assert.equal(h["Referrer-Policy"], "no-referrer");
+  assert.equal(h["Content-Security-Policy"].includes("allow-same-origin"), false);
+});
+
+// ---------------------------------------------------------------------------
+// register / read round trip + the no-baseUrl guard
+// ---------------------------------------------------------------------------
+
+async function cleanup(id) {
+  try {
+    await rm(join(homedir(), STATE_DIRNAME, "widgets", id), { recursive: true, force: true });
+  } catch {
+    // best-effort — widget dir may not have been created
+  }
+}
+
+test("registerWidget stores a widget, publishes the bus event, and reads back", async () => {
+  const source = "<html><body>chart</body></html>";
+  let saved = null;
+  let published = null;
+  const r = await registerWidget(
+    {
+      html: source,
+      title: "Chart",
+      width: 800,
+      height: 400,
+      aspectRatio: 2,
+      ttlHours: 1,
+      sessionId: "ses_a",
+      messageId: "msg_1",
+    },
+    {
+      baseUrl: "https://0123abc.boxes.mantaui.com",
+      load: () => [],
+      save: async (w) => {
+        saved = w;
+      },
+      publish: (p) => {
+        published = p;
+      },
+    },
+  );
+  assert.equal(r.ok, true);
+  assert.match(r.id, /^[0-9a-f]{64}$/);
+  assert.equal(r.url, `https://0123abc.boxes.mantaui.com/widgets/${r.id}`);
+
+  assert.ok(saved && saved.length === 1);
+  assert.equal(saved[0].id, r.id);
+  assert.equal(saved[0].sessionId, "ses_a");
+  assert.equal(saved[0].title, "Chart");
+  assert.equal(saved[0].width, 800);
+  assert.equal(saved[0].height, 400);
+  assert.equal(saved[0].aspectRatio, 2);
+  assert.ok(saved[0].createdAt > 0);
+  assert.ok(saved[0].expiresAt > saved[0].createdAt);
+
+  // The announcement mirrors media: one kind, `widget`, with an action
+  // discriminator. The publish callback here receives the bare payload (index
+  // wraps it in { kind: "widget", payload }).
+  assert.equal(published.action, "show");
+  assert.equal(published.id, r.id);
+  assert.equal(published.url, r.url);
+  assert.equal(published.sessionId, "ses_a");
+  assert.equal(published.messageId, "msg_1");
+  assert.equal(published.title, "Chart");
+  assert.equal(published.width, 800);
+  assert.equal(published.aspectRatio, 2);
+
+  // Round trip: the HTML was written to ~/.manta/widgets/<id>/index.html on
+  // the (sandboxed) real filesystem, so readWidget with default I/O reads it
+  // back byte-for-byte.
+  const read = await readWidget(r.id);
+  assert.equal(read.ok, true);
+  assert.equal(read.html.toString("utf-8"), source);
+  await cleanup(r.id);
+});
+
+test("registerWidget rejects empty baseUrl without writing", async () => {
+  let saveCalled = false;
+  const r = await registerWidget(
+    { html: "<html></html>", ttlHours: 1 },
+    {
+      baseUrl: "",
+      load: () => [],
+      save: async () => {
+        saveCalled = true;
+      },
+    },
+  );
+  assert.equal(r.ok, false);
+  assert.match(r.error, /hostname/i);
+  assert.equal(saveCalled, false);
+});
+
+test("registerWidget requires html", async () => {
+  const r = await registerWidget({}, { baseUrl: "https://x.test" });
+  assert.equal(r.ok, false);
+  assert.match(r.error, /html is required/);
+});
+
+// ---------------------------------------------------------------------------
+// readWidget — prunes a registry entry whose file is missing (may have been
+// swept or removed externally), matching readPage.
+// ---------------------------------------------------------------------------
+
+test("readWidget returns ok:false and prunes the entry when the file is missing", async () => {
+  const id = genWidgetId(); // no on-disk file
+  const widgets = [{ id, expiresAt: Date.now() + 60_000 }];
+  let saved = null;
+  const result = await readWidget(id, {
+    load: () => widgets,
+    save: async (next) => {
+      saved = next;
+    },
+  });
+  assert.equal(result.ok, false);
+  assert.deepEqual(saved, [], "the missing widget's registry entry must be pruned");
+});
+
+// ---------------------------------------------------------------------------
+// createCleanupSweep — expiry filtering (injected load/save, no real FS)
+// ---------------------------------------------------------------------------
+
+test("cleanup sweep removes expired entries and leaves live / never-expiry ones", async () => {
+  const NOW = 1_000_000;
+  const widgets = [
+    { id: "a".repeat(64), expiresAt: NOW + 10_000 },
+    { id: "b".repeat(64), expiresAt: NOW - 10_000 },
+    { id: "c".repeat(64), expiresAt: null }, // 0 = never expires
+  ];
+  let saved = null;
+  const { sweep } = createCleanupSweep({
+    load: () => widgets,
+    save: async (next) => {
+      saved = next;
+    },
+    now: () => new Date(NOW),
+  });
+  await sweep();
+  assert.deepEqual(
+    saved.map((w) => w.id),
+    ["a".repeat(64), "c".repeat(64)],
+  );
+});
+
+test("widgetUrl builds the widget URL under the box's base URL", () => {
+  assert.equal(
+    widgetUrl("https://0123abc.boxes.mantaui.com", "a".repeat(64)),
+    `https://0123abc.boxes.mantaui.com/widgets/${"a".repeat(64)}`,
+  );
+});


### PR DESCRIPTION
## Summary

Box spine for inline widgets, built as servePage's storage + media's announcement. The AI's `widget_show` tool POSTs standalone HTML to `/api/widgets`; the box stores it under `~/.manta/widgets/<id>/index.html`, serves it at `GET /widgets/<id>` with the one security header set, and announces it to clients on the bus as a single `widget` kind with an `action: "show"` discriminator.

**Files changed:** 9. `src/server/widgets.mjs` (+280), `src/server/widgets.test.mjs` (+239), `docs/opencode-tools/widget.ts` (+131), `src/server/index.mjs` (+89), `src/server/htmlHeaders.mjs` (+22), `src/server/servePage.mjs` (refactor), `src/server/auth.mjs` (+8), `src/server/auth.test.mjs` (+10), `docs/opencode-tools/AGENTS.md` (+23).

Key points:
- **One header builder:** extracted `pageResponseHeaders()` into a shared `sandboxedHtmlHeaders(csp)` (`src/server/htmlHeaders.mjs`); both `servePage` and `widgets` use it. servePage keeps its **exact** long-standing CSP (`servePage.test.mjs` untouched).
- **The widget CSP is defined once** (`WIDGET_CSP`): `sandbox` **without** `allow-same-origin` (the sandbox escape), `connect-src 'none'` (the whole exfiltration defence), `'unsafe-inline'` script/style (safe precisely because there's no network / no same-origin). Load-bearing — not tidied.
- **Id is a security boundary:** 32 bytes of hex, validated by `isValidWidgetId` (`/^[0-9a-f]{64}$/`) used as both the registry key and the path-traversal guard before touching the filesystem.
- **`GET /widgets/<id>` is auth-exempt** (in `isExemptPath`): an iframe/webview cannot send an `Authorization` header, and the id is 256 bits of unguessable entropy. **No box token ever appears in the widget URL.**
- **`POST /api/widgets` is gated** (test asserts NOT exempt), returns `{ok:true, id, url}`.
- **Bus:** `{ kind: "widget", payload: { action:"show", id, url, title, width, height, aspectRatio, sessionId, messageId } }`.

This is the box half only. Renderers (desktop/iOS) that draw the widget are the sibling tickets in the widgets epic (the design contract is `docs/screens/widgets/mockup.html`).

**Install note (from the issue):** `cp docs/opencode-tools/widget.ts ~/.config/opencode/tools/` + `systemctl --user restart opencode-serve` — **a copy, never a symlink** (a symlink fails to resolve `@opencode-ai/plugin` and the tool silently never registers).

**Base:** `origin/main @ fe27b4eb`

**Verification results:**
- PR branch (`multica/BET-1323-widgets-spine` @ `cae5b2b1`):
  - typecheck: exit 0. Errors: none. log sha256: `97d0a1ceeef3a9424aaae155bdaea9a08ecda2d86c137f94dd6e191b5bf48b23`
  - test: exit 0, 2723 pass / 0 fail / 0 skip. log sha256: `4e68e2f558b9ace95cc3094130fb11b1e359c980286a02e957a2cef15193c67d`
- Base (`main` @ `fe27b4eb`):
  - typecheck: exit 0. Errors: none. log sha256: `97d0a1ceeef3a9424aaae155bdaea9a08ecda2d86c137f94dd6e191b5bf48b23`
  - test: exit 0, 2712 pass / 0 fail / 0 skip. log sha256: `106f5a54d440cd33768c622b715a1030202d757fddb3491f0c83ecece5cbfc12`
- **Conclusion:** 0 new failures. PR adds 11 tests (widgets + auth exemption pins).

Logs cached at `/tmp/typecheck-pr.log` / `/tmp/test-pr.log` / `/tmp/typecheck-main.log` / `/tmp/test-main.log`.
