### PR TITLE
docs(widgets): centralise bus routing-field casing contract (BET-1328)

### DIFF
--- a/src/renderer/App.tsx
+++ b/src/renderer/App.tsx
@@ -1194,7 +1194,9 @@ function Shell() {
   // state into the store keyed sessionId → messageID so the owning panel's
   // transcript draws the media card. The entries are derived by the pure
   // `applyMediaEvent` reducer (preserves prior reserved-box metadata across
-  // begin → show / begin → fail).
+  // begin → show / begin → fail). Routing fields are sessionID / messageID
+  // (upper `ID`), per the shared casing contract in src/shared/types.ts
+  // (BET-1328).
   useEffect(() => {
     if (!window.api.onMedia) return;
     const off = window.api.onMedia((payload) => {
@@ -1221,7 +1223,9 @@ function Shell() {
   // panels mount/unmount per session) and route the state into the store keyed
   // sessionId → messageId, exactly mirroring the `media` path above. The
   // entries are derived by the pure `applyWidgetEvent` reducer, so no logic
-  // lives in the subscription callback.
+  // lives in the subscription callback. Routing fields are sessionId /
+  // messageId (lowercase `d`, NOT the media kind's upper `ID`) per the shared
+  // casing contract in src/shared/types.ts (BET-1328).
   useEffect(() => {
     if (!window.api.onWidget) return;
     const off = window.api.onWidget((payload) => {

--- a/src/server/media.mjs
+++ b/src/server/media.mjs
@@ -8,6 +8,10 @@
 // ({ kind:"media", payload }) is added by index.mjs; each function here calls
 // its injected `publish` with the bare payload.
 //
+// Routing fields published here are sessionID / messageID (uppercase `ID`) —
+// see the shared bus routing-field casing contract in src/shared/types.ts
+// (BET-1328). The sibling `widget` kind deliberately uses lowercase `d`.
+//
 // Three tools, locked (do not redesign):
 //   - media_save  — the model has media in *some* form (base64 blob, or a file
 //                   it downloaded with curl). Writes it into the artifact

--- a/src/server/widgets.mjs
+++ b/src/server/widgets.mjs
@@ -140,6 +140,9 @@ function numOrNull(v) {
 // CRUD — injectable via {load, save, publish, baseUrl}
 // ---------------------------------------------------------------------------
 
+// Routing fields published here are sessionId / messageId (lowercase `d`) —
+// see the shared bus routing-field casing contract in src/shared/types.ts
+// (BET-1328). The sibling `media` kind deliberately uses uppercase `ID`.
 export async function registerWidget(
   { html, title, width, height, aspectRatio, ttlHours, sessionId, messageId },
   { load = loadWidgets, save = saveWidgets, publish, baseUrl } = {},

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -989,6 +989,26 @@ export type AppControlPayload = {
   name?: string;
 };
 
+// ── Bus routing-field casing contract (BET-1328) ─────────────────────────────
+// The `media` and `widget` bus kinds both carry routing fields that key
+// per-session placeholder state in the renderer: which session owns the box and
+// which message produced it. Those fields use DIFFERENT casing on the wire:
+//
+//   media   → sessionID / messageID   (uppercase `ID`), src/server/media.mjs
+//   widget  → sessionId / messageId   (lowercase `d`),  src/server/widgets.mjs
+//
+// The difference is real and deliberate per kind — the box spine publishes each
+// kind in its own casing and the renderer reads exactly that casing. It is
+// deliberately NOT normalised (a wire change would be breaking across server +
+// clients), so THIS comment is the single source of truth for the routing-field
+// names. Every payload type below, and every publisher / reader that emits or
+// consumes routing fields, REFERENCES this contract rather than restating the
+// naming. If you add a THIRD bus kind with routing fields, reference this
+// contract too and type it to EXACTLY the casing the publisher emits — never
+// copy the case off a sibling type, or you inherit that kind's casing by
+// accident.
+// ─────────────────────────────────────────────────────────────────────────────
+
 // BET-1148: inline media bus events (src/server/media.mjs). ONE `media` bus
 // kind with an `action` discriminator, published when the media tools land a
 // client-visible effect:
@@ -998,7 +1018,8 @@ export type AppControlPayload = {
 //           placeholder ends as a labelled failure.
 // The renderer routes by (sessionID, messageID) and keys its per-session
 // placeholder state on `messageID`. Client-agnostic so the native client can
-// adopt the same bus kind later.
+// adopt the same bus kind later. Routing-field casing: upper `ID` per the
+// shared contract above.
 export type MediaEventPayload = {
   action: string;
   handle?: string | null;
@@ -1022,10 +1043,9 @@ export type MediaEventPayload = {
 // dimension fields the media kind uses. The renderer routes by (sessionId,
 // messageId) and keys its per-session placeholder state on `messageId`.
 //
-// NOTE the field casing (sessionId / messageId, lowercase `d`) deliberately
-// differs from MediaEventPayload's uppercase `ID` — that is the actual wire
-// shape the box spine publishes, so this type mirrors reality; the renderer
-// reads the same casing here.
+// Routing-field casing: lowercase `d` (sessionId / messageId) — NOT the media
+// kind's uppercase `ID`. See the shared contract above (BET-1328); this type
+// mirrors exactly what src/server/widgets.mjs publishes.
 export type WidgetEventPayload = {
   action: string;
   id?: string | null;


### PR DESCRIPTION
Closes BET-1328.

## What

The `media` and `widget` bus kinds carry routing fields with different casing:
- `MediaEventPayload` (`src/shared/types.ts`): `sessionID` / `messageID` (uppercase `ID`)
- `WidgetEventPayload`: `sessionId` / `messageId` (lowercase `d`)

Both are read correctly today (no functional bug), but the mismatch is a silent drift trap for a future third bus kind. Normalising the wire is breaking, so the closed-scope fix is to centralise + cross-document the naming contract.

## Changes

- `src/shared/types.ts`: add a single centralised **bus routing-field casing contract** (BET-1328) that documents the real per-kind casing and instructs a future kind to reference it rather than copy a sibling type's case. Both `MediaEventPayload` and `WidgetEventPayload` now point at it (the widget kind's previously isolated `NOTE` is folded into the shared contract).
- `src/server/media.mjs` / `src/server/widgets.mjs` (publishers): reference the contract, not restate.
- `src/renderer/App.tsx` (subscriptions): reference the contract, not restate.

## Verification

`npm run typecheck` — clean. `npm test` — 2728 pass, 0 fail.