### PR TITLE
BET-1329: widget_show — hard-constraint sizing guidance

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -517,3 +517,36 @@ Install: `cp <repo>/docs/opencode-tools/widget.ts`
 `~/.config/opencode/tools/widget.ts` then `systemctl --user restart
 opencode-serve`. **Install/update is a COPY, never a symlink** (a symlink
 fails to resolve `@opencode-ai/plugin` and the tool silently never registers).
+
+## MantaUI inline widgets — sizing is a hard constraint
+
+`widget_show` (thin registrar → `POST /api/widgets`) stores a self-contained
+inline HTML widget in the chat and returns promptly; the store + serving +
+TTL expiry all live server-side (`~/.manta/widgets/<id>/`, served at
+`/widgets/<id>`). Before you author one, decide: **you are designing a
+fixed-size card, not a web page.** The `width`/`height` (or `aspectRatio`)
+you declare is a HARD CONSTRAINT — the host reserves exactly those pixels,
+never measures your HTML, and never resizes to fit. Content taller than the
+box is clipped or scrolls inside it; content shorter leaves dead space. So
+pick the box first, then design to fill it exactly.
+
+Two invariance rules keep any declared box correct. **Height must not vary
+with state** — reserve space for elements that appear later with
+`visibility:hidden`, never `display:none`. **Height must not vary with
+width** — chrome that could wrap must be `nowrap` with ellipsis or horizontal
+scroll, never wrapping. If the height changes with either, no declared box
+can be right. Give the document `html,body{height:100%;overflow:hidden}` and
+a flex column with exactly one region at `flex:1 1 auto` to absorb slack.
+
+Measure the height, don't estimate it. Playwright is already a devDependency
+(1.61.1). Load the document, neutralise the fill rules with an injected style
+(`html,body{height:auto!important;overflow:visible!important}`), read
+`document.body.scrollHeight`, and sweep the widths and states the widget will
+actually render at — declare the largest stable number. The recipe belongs
+inline here; there is deliberately no measurement script in the repo.
+
+Install/update is a COPY, never a symlink:
+`cp <repo>/docs/opencode-tools/widget.ts
+~/.config/opencode/tools/widget.ts` then `systemctl --user restart
+opencode-serve` (see the section above for the `@opencode-ai/plugin`
+resolution gotcha).

--- a/docs/opencode-tools/widget.ts
+++ b/docs/opencode-tools/widget.ts
@@ -69,16 +69,26 @@ async function call(method: string, path: string, body?: unknown): Promise<any> 
 
 export const widget_show = tool({
   description: [
-    "Store and display an inline widget in the chat: you author a FULL, ",
+    "Store and display an inline widget in the chat. You author a FULL, ",
     "self-contained standalone HTML document (a single <html> document with ",
     "everything it needs inline — CSS, JS, chart libraries all embedded, ",
     "because the widget has NO network access and cannot fetch anything). ",
-    "Declare width/height (or aspectRatio) so the client can reserve that box ",
-    "before the widget loads. The widget runs sandboxed in an opaque origin ",
-    "with no network (connect-src 'none') and no same-origin, so it can never ",
-    "read the user's box token or exfiltrate data — keep all rendering logic ",
-    "inside the authored HTML. A widget_show call returns promptly; the widget ",
-    "is stored on the box (default 24h TTL, or ttlHours:0 for no expiry).",
+    "YOU ARE DESIGNING A FIXED-SIZE SURFACE — a card, not a web page. The ",
+    "box you declare is a HARD CONSTRAINT: the host reserves exactly those ",
+    "pixels and NEVER measures your HTML or resizes to fit it. Content taller ",
+    "than the box is clipped or scrolls inside it; content shorter leaves dead ",
+    "space. Decide the box first, then design to fit it: give the document ",
+    "html,body{height:100%;overflow:hidden} and a flex column with exactly one ",
+    "region at flex:1 1 auto to absorb slack. The content height must be a ",
+    "SINGLE number — it must not change with state (reserve space with ",
+    "visibility:hidden, never display:none) nor with width (chrome must be ",
+    "nowrap with ellipsis or horizontal scroll, never wrapping). If the height ",
+    "varies, no declared box can be correct. The widget runs sandboxed in an ",
+    "opaque origin with no network (connect-src 'none') and no same-origin, so ",
+    "it can never read the user's box token or exfiltrate data — keep all ",
+    "rendering logic inside the authored HTML. A widget_show call returns ",
+    "promptly; the widget is stored on the box (default 24h TTL, or ",
+    "ttlHours:0 for no expiry).",
   ].join(" "),
   args: {
     html: z
@@ -96,18 +106,24 @@ export const widget_show = tool({
       .int()
       .positive()
       .optional()
-      .describe("Desired width in px for the reserved box."),
+      .describe(
+        "Width in px of the reserved box. A HARD constraint, not a hint — the host reserves exactly this and never measures your HTML.",
+      ),
     height: z
       .number()
       .int()
       .positive()
       .optional()
-      .describe("Desired height in px for the reserved box."),
+      .describe(
+        "Height in px of the reserved box. A HARD constraint, not a hint: content taller than this is clipped or scrolls, content shorter leaves dead space. Measure the document's real height rather than estimating it.",
+      ),
     aspectRatio: z
       .number()
       .positive()
       .optional()
-      .describe("Desired aspect ratio (width/height) when exact px are unknown."),
+      .describe(
+        "Aspect ratio (width/height) for when exact px are unknown. Same hard-constraint semantics as width/height — the host never measures your HTML.",
+      ),
     ttlHours: z
       .number()
       .optional()


### PR DESCRIPTION
docs(widget): rewrite widget_show sizing guidance as a hard constraint

BET-1329. Two defects, one root cause — hit live while an agent authored a
widget mockup.

1. **`widget.ts` was not in the repo.** It existed only at
   `~/.config/opencode/tools/widget.ts`; there was no
   `docs/opencode-tools/widget.ts` source of truth, so the tool description
   governing how models author widgets was unversioned and un-reviewable.
   (Concurrently, BET-1323's widgets-spine landed the vendored file in the
   repo — verified byte-identical to the installed copy at branch time, so
   D1 is satisfied.)
2. **The size guidance actively misled** — it framed the declared box as
   placeholder bookkeeping and never stated that the host reserves exactly
   those pixels and never measures the HTML. A mockup declared at 780x560
   whose content was 374px is the observed symptom.

**Changes:**
- `docs/opencode-tools/widget.ts`: rewrote the tool description to state
  the fixed-surface rule (host reserves exactly the declared pixels, never
  measures/resizes), the design-to-fit guidance, and the two invariance
  rules; tightened the three size arg descriptions to "HARD constraint".
- `docs/opencode-tools/AGENTS.md`: one new section (after the CTO inbound
  section) covering the fixed-surface rule, the two invariance rules, and
  the Playwright measurement recipe.

No executable code changed. No new files beyond the vendored tool.

Base: origin/main @ `ed77d37a`
