### PR TITLE
BET-1330: dedupe boxToken()/authHeaders() across docs/opencode-tools/*.ts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -442,6 +442,8 @@ require-confirm toast the user hasn't answered isn't re-offered every 3s.
   `~/.manta-outbox/<sessionID>/` (workspace-linked) and hands it a TTL (default
   7 days, or `ttlHours:0` for never). Install on the remote opencode host:
   `cp <repo>/docs/opencode-tools/send-file.ts ~/.config/opencode/tools/send-file.ts`
+  plus the shared `manta-auth.ts` module it imports
+  (`cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts`),
   then restart `opencode-serve`. The legacy `/send-file` markdown command
   (`docs/opencode-commands/send-file.md`) still works for a bare `cp` to the
   root, but that path is NOT workspace-linked.
@@ -713,7 +715,10 @@ the reusable "MantaUI tools" pattern (for future tools like `ping`) is in
 
 - **The AI's awareness comes from a GLOBAL opencode custom tool**, not MantaUI code.
   `docs/opencode-tools/schedule.ts` is **COPIED** (not symlinked) into
-  `~/.config/opencode/tools/schedule.ts` on the box; opencode auto-loads it for
+  `~/.config/opencode/tools/schedule.ts` on the box — **alongside the shared
+  `manta-auth.ts` module** it imports
+  (`docs/opencode-tools/manta-auth.ts` → `~/.config/opencode/tools/manta-auth.ts`);
+  opencode auto-loads it for
   EVERY project/session/model. Multiple named exports → tools `schedule_create`,
   `schedule_list`, `schedule_cancel`. A guidance blurb appended to
   `~/.config/opencode/AGENTS.md` (from `docs/opencode-tools/AGENTS.md`) tells the
@@ -773,7 +778,8 @@ generates on the box. Follows the same "MantaUI tools" pattern as the scheduler
 
 - **Global opencode tool**, `docs/opencode-tools/serve-page.ts`, **COPIED** (not
   symlinked — same `@opencode-ai/plugin` import-resolution gotcha as schedule)
-  to `~/.config/opencode/tools/serve-page.ts`. Three named exports → tools
+  to `~/.config/opencode/tools/serve-page.ts`, **plus the shared `manta-auth.ts`
+  module it imports** (`→ ~/.config/opencode/tools/manta-auth.ts`). Three named exports → tools
   `serve_page`, `stop_page`, `list_pages`. Guidance appended to
   `~/.config/opencode/AGENTS.md` from `docs/opencode-tools/AGENTS.md`.
   **Install/update = `systemctl --user restart opencode-serve`.**
@@ -850,7 +856,8 @@ schedule/serve-page (`docs/manta-tools-scheduler.md`). Key facts:
   whose window isn't stamped). `selectPeers` returns the sibling windows.
 - **Global opencode tool**, `docs/opencode-tools/peers.ts`, **COPIED** (not
   symlinked — same `@opencode-ai/plugin` gotcha) to
-  `~/.config/opencode/tools/peers.ts`. Three exports → `peers_list`,
+  `~/.config/opencode/tools/peers.ts`, **plus the shared `manta-auth.ts` module
+  it imports** (`→ ~/.config/opencode/tools/manta-auth.ts`). Three exports → `peers_list`,
   `peers_inspect`, `peers_message`. Guidance appended to
   `~/.config/opencode/AGENTS.md`.
   **Install/update = `systemctl --user restart opencode-serve`.**
@@ -953,7 +960,8 @@ routing matrix + scenarios in `docs/manta-tools-notify.md`. Key facts:
 - **Blocking tier is unchanged:** both devices immediately, mobile suppressed
   only when the phone is foregrounded on that same session.
 - **The `notify` tool** (`docs/opencode-tools/notify.ts`, COPIED to
-  `~/.config/opencode/tools/`, restart `opencode-serve`) is a thin registrar →
+  `~/.config/opencode/tools/` plus the shared `manta-auth.ts` module it imports,
+  restart `opencode-serve`) is a thin registrar →
   `POST /api/notify {message, title?, urgent?, sessionID}` → `fireNotify`.
   Session-tied: carries `context.sessionID` so it deep-links + dedupes
   (`tag:"notify-<sid>"`). The model does NOT pick the device — the router does.
@@ -985,7 +993,8 @@ peers/notify. Key facts:
   implement the resolution; session wins over shared.
 - **Global opencode tool**, `docs/opencode-tools/secrets.ts`, **COPIED** (not
   symlinked — same `@opencode-ai/plugin` gotcha) to
-  `~/.config/opencode/tools/secrets.ts`. Two exports → `secret_list`,
+  `~/.config/opencode/tools/secrets.ts`, **plus the shared `manta-auth.ts` module
+  it imports** (`→ ~/.config/opencode/tools/manta-auth.ts`). Two exports → `secret_list`,
   `secret_provide`. Guidance appended to `~/.config/opencode/AGENTS.md` from
   `docs/opencode-tools/AGENTS.md` (## MantaUI secrets). **Install/update =
   `systemctl --user restart opencode-serve`.**
@@ -1051,7 +1060,8 @@ and worktree all belong to it.
 
 - **Global opencode tool**, `docs/opencode-tools/delegate.ts`, **COPIED** (not
   symlinked — same `@opencode-ai/plugin` gotcha) to
-  `~/.config/opencode/tools/delegate.ts`. Three exports → `delegate`,
+  `~/.config/opencode/tools/delegate.ts`, **plus the shared `manta-auth.ts` module
+  it imports** (`→ ~/.config/opencode/tools/manta-auth.ts`). Three exports → `delegate`,
   `delegate_list`, `delegate_stop`. Guidance appended to
   `~/.config/opencode/AGENTS.md` from `docs/opencode-tools/AGENTS.md`
   (## MantaUI background delegation). **Install/update =
@@ -1112,7 +1122,8 @@ consumes the bus envelopes in the renderer.
 
 - **Global opencode tool**, `docs/opencode-tools/manta-app.ts`, **COPIED** (not
   symlinked — same `@opencode-ai/plugin` gotcha) to
-  `~/.config/opencode/tools/manta-app.ts`. Four exports → `manta_compact_session`,
+  `~/.config/opencode/tools/manta-app.ts`, **plus the shared `manta-auth.ts` module
+  it imports** (`→ ~/.config/opencode/tools/manta-auth.ts`). Four exports → `manta_compact_session`,
   `manta_switch_model`, `manta_rename_session`, `manta_list_sessions`. Guidance
   appended to `~/.config/opencode/AGENTS.md`. **Install/update =
   `systemctl --user restart opencode-serve`.**

--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -8,6 +8,26 @@
   (Strip this HTML comment if you like; opencode reads the file as plain text.)
 -->
 
+## Shared auth module — `manta-auth.ts`
+
+Every MantaUI tool (`docs/opencode-tools/*.ts`) reaches manta-server's
+`/api/*` routes with `Authorization: Bearer <box_token>` (M1 auth gate). The
+`boxToken()` / `authHeaders()` helpers are **one shared source**,
+`docs/opencode-tools/manta-auth.ts` (BET-1330). Tools import them:
+
+```ts
+import { boxToken, authHeaders } from "./manta-auth";
+```
+
+Do NOT hand-copy these helpers into a new tool. Because opencode resolves a
+tool's imports relative to the file's REAL path under
+`~/.config/opencode/tools/` (which has no `node_modules`), `manta-auth.ts`
+must be **copied alongside** as a sibling of every tool that imports it —
+each tool's install instructions include the extra
+`cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts`.
+Forgetting it makes the tool silently fail to register with
+`Cannot find module './manta-auth'`.
+
 ## manta scheduled tasks
 
 You have a `schedule_create` tool that runs a prompt later in this same chat
@@ -350,6 +370,8 @@ create a PR, only the human-facing app is confirmed by the human's click.)
 
 **Install/update is a COPY, never a symlink.** Copy
 `docs/opencode-tools/delegate.ts` to `~/.config/opencode/tools/delegate.ts`
+**and** `docs/opencode-tools/manta-auth.ts` to
+`~/.config/opencode/tools/manta-auth.ts` (the shared `./manta-auth` import)
 and run `systemctl --user restart opencode-serve`. A symlinked tool fails
 to resolve `@opencode-ai/plugin` and silently never registers.
 
@@ -382,6 +404,8 @@ try to route around them with the other tools.
 
 Install/update is a COPY, never a symlink: copy
 `docs/opencode-tools/manta-app.ts` to `~/.config/opencode/tools/manta-app.ts`
+and `docs/opencode-tools/manta-auth.ts` to
+`~/.config/opencode/tools/manta-auth.ts` (the shared `./manta-auth` import)
 then `systemctl --user restart opencode-serve`. A symlink fails to resolve
 `@opencode-ai/plugin` and the tool silently never registers.
 
@@ -401,7 +425,10 @@ It is NOT a one-shot mailbox:
   it, so users can re-download any time before then.
 
 Install: `cp <repo>/docs/opencode-tools/send-file.ts
-~/.config/opencode/tools/send-file.ts` and restart `opencode-serve`.
+~/.config/opencode/tools/send-file.ts` and `cp
+<repo>/docs/opencode-tools/manta-auth.ts
+~/.config/opencode/tools/manta-auth.ts` (the shared `./manta-auth` import),
+then restart `opencode-serve`.
 **Install/update is a COPY, never a symlink** (same `@opencode-ai/plugin`
 resolution gotcha as the other manta tools).
 
@@ -451,7 +478,10 @@ the same handle once the file exists. A `media_begin` with no following
 `media_show` fails after 10 minutes (the placeholder is dropped). All three
 forward the current session + message id so the placeholder and artifact land
 on this turn. Install: `cp <repo>/docs/opencode-tools/media.ts
-~/.config/opencode/tools/media.ts` then restart `opencode-serve`.
+~/.config/opencode/tools/media.ts` and `cp
+<repo>/docs/opencode-tools/manta-auth.ts
+~/.config/opencode/tools/manta-auth.ts` (the shared `./manta-auth` import),
+then restart `opencode-serve`.
 
 ## manta on-call CTO reads
 
@@ -468,7 +498,10 @@ stopped conversations?", "is <session> in plan mode?", or "context state of
 the empty state, never fabricate. The `cto` opencode agent (selectable as a
 normal chat session) is pre-wired to use this belt. Install/update is a COPY,
 never a symlink: `cp <repo>/docs/opencode-tools/cto.ts
-~/.config/opencode/tools/cto.ts` then `systemctl --user restart
+~/.config/opencode/tools/cto.ts` and `cp
+<repo>/docs/opencode-tools/manta-auth.ts
+~/.config/opencode/tools/manta-auth.ts` (the shared `./manta-auth` import)
+then `systemctl --user restart
 opencode-serve`. The engine lives in `src/server/cto.mjs` (see there).
 
 ## manta on-call CTO inbound — `send_to_cto` + watchers (BET-1165)
@@ -491,7 +524,9 @@ Two companion capabilities to the `cto` read belt, both global opencode tools.
   on "no").
 
 Install/update each tool as a COPY (`cp docs/opencode-tools/{send-to-cto,cto}.ts
-~/.config/opencode/tools/`) then `systemctl --user restart opencode-serve`. The
+~/.config/opencode/tools/` **plus** `cp docs/opencode-tools/manta-auth.ts
+~/.config/opencode/tools/manta-auth.ts` — the shared `./manta-auth` import)
+then `systemctl --user restart opencode-serve`. The
 engine + routers live in `src/server/cto.mjs` (createCtoEngine / createCtoInbound /
 createWatcherPoller).
 
@@ -514,7 +549,10 @@ box and rendered by the client inside a sandboxed frame:
   by default (`ttlHours: 0` = never).
 
 Install: `cp <repo>/docs/opencode-tools/widget.ts`
-`~/.config/opencode/tools/widget.ts` then `systemctl --user restart
+`~/.config/opencode/tools/widget.ts` and `cp
+<repo>/docs/opencode-tools/manta-auth.ts
+~/.config/opencode/tools/manta-auth.ts` (the shared `./manta-auth` import),
+then `systemctl --user restart
 opencode-serve`. **Install/update is a COPY, never a symlink** (a symlink
 fails to resolve `@opencode-ai/plugin` and the tool silently never registers).
 
@@ -547,6 +585,9 @@ inline here; there is deliberately no measurement script in the repo.
 
 Install/update is a COPY, never a symlink:
 `cp <repo>/docs/opencode-tools/widget.ts
-~/.config/opencode/tools/widget.ts` then `systemctl --user restart
+~/.config/opencode/tools/widget.ts` and `cp
+<repo>/docs/opencode-tools/manta-auth.ts
+~/.config/opencode/tools/manta-auth.ts` (the shared `./manta-auth` import),
+then `systemctl --user restart
 opencode-serve` (see the section above for the `@opencode-ai/plugin`
 resolution gotcha).

--- a/docs/opencode-tools/cto.ts
+++ b/docs/opencode-tools/cto.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/cto.ts ~/.config/opencode/tools/cto.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 // A copy, never a symlink — opencode resolves a tool's imports relative to the
 // file's REAL path, so a symlink back into the repo (no node_modules) fails
@@ -16,9 +17,7 @@
 // stoppedStore; nothing is reimplemented).
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -29,26 +28,6 @@ const CTO_TOOLS =
   "git_branch, git_log, list_models, get_usage, usage_stopped, session_usage, " +
   "context_state, session_plan_mode, get_config, watch, unwatch, " +
   "list_watches";
-
-function boxToken() {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null;
-  }
-}
-
-function authHeaders(body) {
-  const headers = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 export const cto = tool({
   description: [

--- a/docs/opencode-tools/delegate.ts
+++ b/docs/opencode-tools/delegate.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/delegate.ts ~/.config/opencode/tools/delegate.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 //
 // This tool is a THIN registrar. It POSTs the request to manta-server
@@ -23,9 +24,8 @@
 // (docs/manta-tools-scheduler.md).
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -35,25 +35,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/forge-rules.ts
+++ b/docs/opencode-tools/forge-rules.ts
@@ -4,6 +4,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/forge-rules.ts ~/.config/opencode/tools/forge-rules.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 // (COPY, never symlink — the `@opencode-ai/plugin` import-resolution gotcha in
 // docs/manta-tools-scheduler.md §"DO NOT symlink".)
@@ -23,9 +24,8 @@
 // rewriting the plumbing.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -35,25 +35,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/manta-app.ts
+++ b/docs/opencode-tools/manta-app.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/manta-app.ts ~/.config/opencode/tools/manta-app.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 // A copy, never a symlink — opencode resolves a tool's imports relative to the
 // file's REAL path, so a symlink back into the repo (no node_modules) fails
@@ -18,9 +19,8 @@
 // next turn on). See src/server/appControl.mjs.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -30,25 +30,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 async function appControl<T>(action: string, args: Record<string, unknown>, context: any): Promise<T> {
   const res = await fetch(`${MANTA_SERVER}/api/app-control`, {

--- a/docs/opencode-tools/manta-auth.ts
+++ b/docs/opencode-tools/manta-auth.ts
@@ -1,0 +1,43 @@
+// Shared boxToken() / authHeaders() helpers for the MantaUI opencode tools
+// (docs/opencode-tools/*.ts). One source of truth — every tool imports these
+// by relative path (`./manta-auth`) instead of re-declaring box-identical
+// copies (BET-1330).
+//
+// Install constraint: opencode resolves a tool's imports relative to the
+// file's REAL path under ~/.config/opencode/tools/ (which has no
+// node_modules). So this module is COPIED alongside each tool that imports
+// it:
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
+// It must be installed as a sibling of the tool importing it or that tool
+// silently fails to register with `Cannot find module './manta-auth'`.
+//
+// manta-server enforces `Authorization: Bearer <box_token>` on every /api
+// route (M1 auth gate — src/server/auth.mjs). These tools run on the SAME
+// box as the same user as manta-server, so they read the token straight from
+// the server's own auth store (~/.manta/auth.json, 0600). Re-read on every
+// call (one tiny local file) so a token rotation never requires an
+// opencode-serve restart. MANTA_BOX_TOKEN env overrides for tests/dev.
+
+import { readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+
+export function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN;
+  if (fromEnv) return fromEnv;
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
+    const tok = JSON.parse(raw)?.box_token;
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
+  } catch {
+    return null; // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+export function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {};
+  if (body) headers["content-type"] = "application/json";
+  const tok = boxToken();
+  if (tok) headers["authorization"] = `Bearer ${tok}`;
+  return headers;
+}

--- a/docs/opencode-tools/media.ts
+++ b/docs/opencode-tools/media.ts
@@ -4,6 +4,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/media.ts ~/.config/opencode/tools/media.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 //
 // These tools are THIN registrars: validate, POST to manta-server
@@ -15,9 +16,8 @@
 // the inline-media design in the BET-1147 epic.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -27,25 +27,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one tiny
 // local file) so a token rotation never requires an opencode-serve restart.
 // MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/notify.ts
+++ b/docs/opencode-tools/notify.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/notify.ts ~/.config/opencode/tools/notify.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 //
 // This tool is a THIN registrar. It POSTs the notification to manta-server
@@ -15,9 +16,7 @@
 // docs/manta-tools-scheduler.md for the general "manta tools" pattern.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -27,25 +26,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/peers.ts
+++ b/docs/opencode-tools/peers.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/peers.ts ~/.config/opencode/tools/peers.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 //
 // These tools let THIS session see what OTHER sessions in the same workspace
@@ -20,9 +21,8 @@
 // peers_message if appropriate.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -32,25 +32,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/plan-render.ts
+++ b/docs/opencode-tools/plan-render.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/plan-render.ts ~/.config/opencode/tools/plan-render.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 //
 // This tool is a THIN registrar (same contract as the other MantaUI tools). It
@@ -12,9 +13,7 @@
 // promptly — no long-running work.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -24,25 +23,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/plugins.ts
+++ b/docs/opencode-tools/plugins.ts
@@ -5,6 +5,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/plugins.ts ~/.config/opencode/tools/plugins.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 // (COPY, never symlink — the `@opencode-ai/plugin` import-resolution gotcha in
 // docs/manta-tools-scheduler.md §"DO NOT symlink".)
@@ -31,9 +32,8 @@
 // against an authored ios-capacitor manifest instead.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -43,25 +43,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/progress.ts
+++ b/docs/opencode-tools/progress.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/progress.ts ~/.config/opencode/tools/progress.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 //
 // This tool is a THIN registrar. It POSTs a durable, session-scoped progress
@@ -16,9 +17,7 @@
 // deliberately forbids that. Do not soften it.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -28,25 +27,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/schedule.ts
+++ b/docs/opencode-tools/schedule.ts
@@ -2,7 +2,8 @@
 //
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
-//   ln -sf <repo>/docs/opencode-tools/schedule.ts ~/.config/opencode/tools/schedule.ts
+//   cp <repo>/docs/opencode-tools/schedule.ts ~/.config/opencode/tools/schedule.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/
 // (NOT a `manta-opencode` tmux session — that reference elsewhere is stale).
 //
@@ -16,9 +17,8 @@
 // a new turn. See docs/manta-tools-scheduler.md for the full design.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -28,25 +28,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/secrets.ts
+++ b/docs/opencode-tools/secrets.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/secrets.ts ~/.config/opencode/tools/secrets.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 // DO NOT symlink — opencode resolves a tool's imports relative to the file's
 // REAL path, so a symlink back into the repo fails to find @opencode-ai/plugin.
@@ -26,9 +27,8 @@
 //   into a message — that would defeat the entire point and leak the secret.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -38,25 +38,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/send-file.ts
+++ b/docs/opencode-tools/send-file.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/send-file.ts ~/.config/opencode/tools/send-file.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 //
 // This tool is a THIN registrar. It validates the request and POSTs it to
@@ -22,9 +23,7 @@
 // See docs/manta-tools-scheduler.md for the general "manta tools" pattern.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -34,25 +33,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one tiny
 // local file) so a token rotation never requires an opencode-serve restart.
 // MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/send-to-cto.ts
+++ b/docs/opencode-tools/send-to-cto.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/send-to-cto.ts ~/.config/opencode/tools/send-to-cto.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 // A copy, never a symlink — opencode resolves a tool's imports relative to the
 // file's REAL path, so a symlink back into the repo (no node_modules) fails
@@ -20,9 +21,7 @@
 // flag, the message is injected into the CTO session as a turn instead.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -32,25 +31,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/serve-page.ts
+++ b/docs/opencode-tools/serve-page.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/serve-page.ts ~/.config/opencode/tools/serve-page.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 //
 // This tool is a THIN registrar. It validates the request and POSTs it to
@@ -14,9 +15,8 @@
 // See docs/manta-tools-scheduler.md for the general "manta tools" pattern.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -26,25 +26,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/webhook.ts
+++ b/docs/opencode-tools/webhook.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/webhook.ts ~/.config/opencode/tools/webhook.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then: systemctl --user restart opencode-serve   (re-scans tools/).
 // COPIED, not symlinked (the @opencode-ai/plugin import-resolution gotcha).
 //
@@ -17,9 +18,8 @@
 // session as a new turn. See docs/manta-tools-webhook.md for the full design.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
 import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -29,25 +29,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one
 // tiny local file) so a token rotation never requires an opencode-serve
 // restart. MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 

--- a/docs/opencode-tools/widget.ts
+++ b/docs/opencode-tools/widget.ts
@@ -3,6 +3,7 @@
 // Install on the opencode host (the Linux box that runs manta-server + opencode):
 //   mkdir -p ~/.config/opencode/tools
 //   cp <repo>/docs/opencode-tools/widget.ts ~/.config/opencode/tools/widget.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
 // then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
 //
 // This tool is a THIN registrar. It validates the request and POSTs it to
@@ -14,9 +15,7 @@
 // See docs/manta-tools-scheduler.md for the general "manta tools" pattern.
 
 import { tool } from "@opencode-ai/plugin";
-import { readFileSync } from "node:fs";
-import { homedir } from "node:os";
-import { join } from "node:path";
+import { boxToken, authHeaders } from "./manta-auth";
 
 const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 
@@ -26,25 +25,6 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 // own auth store (~/.manta/auth.json, 0600). Re-read on every call (one tiny
 // local file) so a token rotation never requires an opencode-serve restart.
 // MANTA_BOX_TOKEN env overrides for tests/dev.
-function boxToken(): string | null {
-  const fromEnv = process.env.MANTA_BOX_TOKEN;
-  if (fromEnv) return fromEnv;
-  try {
-    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8");
-    const tok = JSON.parse(raw)?.box_token;
-    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null;
-  } catch {
-    return null; // no store yet (auth disabled / first run) → send no header
-  }
-}
-
-function authHeaders(body?: unknown): Record<string, string> {
-  const headers: Record<string, string> = {};
-  if (body) headers["content-type"] = "application/json";
-  const tok = boxToken();
-  if (tok) headers["authorization"] = `Bearer ${tok}`;
-  return headers;
-}
 
 const z = tool.schema;
 


### PR DESCRIPTION
## What

Consolidate the box-identical `boxToken()` / `authHeaders()` helpers copy-pasted across **all 17** manta opencode tools (`docs/opencode-tools/*.ts`) into **one shared source**: `docs/opencode-tools/manta-auth.ts`. Every tool now does:

```ts
import { boxToken, authHeaders } from "./manta-auth";
```

(17 tool files share the duplication — the issue said 16; `docs/opencode-tools/` actually contains 17 tool files, all of which carried the helpers.)

## Import-resolution constraint (the BET-1329 blocker)

opencode resolves a tool's imports relative to the file's **real path** under `~/.config/opencode/tools/`, which has **no `node_modules`**. So `manta-auth.ts` must be **COPIED alongside** every tool that imports it — the documented `cp` install now includes the extra `cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts` line. Install instructions were updated in **every** tool header, plus `docs/opencode-tools/AGENTS.md` and the root `AGENTS.md`, and a shared-auth note was added so future tools import rather than re-copy (the exact regression this prevents).

## Registration verification (the correctness gate)

Verified through **opencode's real loader** (Bun resolver, `opencode 1.18.21`), not just typecheck:

- Copied all 17 modified tools + `manta-auth.ts` into an isolated `~/.config/opencode/tools/` dir (the exact documented install) and booted a fresh opencode in isolation.
- A probe tool using the extensionless `./manta-auth` import **resolved and executed** at module load (`authHeaders({a:1})` returned `{"content-type":"application/json",…}`).
- A broken-import control (`./does-not-exist-xyz`) produced the documented failure signature `Cannot find module './does-not-exist-xyz'` — the "tool silently never registers" mode this issue is about.
- **None of the 17 tools hit `Cannot find module './manta-auth'`** — the only resolution error in the run was the deliberate control. All 17 load cleanly.

## Self-check

- CRITERION 1: all duplicated `boxToken()`/`authHeaders()` consolidated into one shared source → **10/10**. `grep -rn "function boxToken\|function authHeaders" docs/opencode-tools/*.ts` now returns only `manta-auth.ts`; all 17 tools import `./manta-auth`.
- CRITERION 2: shared helper resolves exactly the way the per-tool copy does today (copied alongside) → **9/10** — verified end-to-end through the real opencode loader above.
- CRITERION 3: all 17 tools still register → **9/10** — verified: no module-resolution failure for any tool in the real-loader run; good/negative control confirmed the mechanism.
- CRITERION 4: install instructions updated so fresh installs don't break → **9/10** — every tool header + both AGENTS.md files now carry the `manta-auth.ts` copy line.
- CRITERION 5: every actionable follow-up filed, none narrated → **10/10** — none surfaced (the related `schedule.ts` stale `ln -sf` instruction was corrected in-pass).

**Base: origin/main @ 70e308ad**

**Files changed:** 20 files (17 tool `.ts` + new `manta-auth.ts` + `docs/opencode-tools/AGENTS.md` + `AGENTS.md`). 100 insertions(+), 379 deletions(-) once the new file counts.

**Verification results:**
- PR branch (`multica/BET-1330-dedupe-auth-helpers` @ `aa88197d`):
  - typecheck: exit `0`. Errors: none. (`npm run typecheck`)
  - test: exit `0`, 2733 pass / 0 fail / 0 skip. Failures: none. (`npm test`)
  - registration: exit `0` — all 17 tools loaded cleanly through opencode 1.18.21's real loader (see above).
- Base (`main` @ `70e308ad`): not separately re-run — this diff touches only files outside `tsconfig.node.json`/`tsconfig.web.json` include globs (`docs/opencode-tools/*.ts` + `AGENTS.md`), so the typecheck/test result is definitionally identical between branches. The registration check is the gate that matters here and it passed on the PR branch.
- **Conclusion:** 0 new failures. No source (`src/`) or test files were touched.
