### PR TITLE
feat(optimizer): observe-mode masking counterfactual store + ingest (BET-1335)

### DIFF
--- a/docs/opencode-tools/manta-optimizer-plugin.ts
+++ b/docs/opencode-tools/manta-optimizer-plugin.ts
@@ -1,0 +1,87 @@
+/**
+ * manta-optimizer plugin — Phase 1: OBSERVE ONLY.
+ * Computes the masking counterfactual (what the optimizer WOULD trim) and
+ * reports it to manta-server. It never mutates the message history.
+ *
+ * INSTALL (maintainer, post-merge — NOT during an agent run):
+ *   cp docs/opencode-tools/manta-optimizer-plugin.ts ~/.config/opencode/plugins/manta-optimizer.ts
+ *   systemctl --user restart opencode-serve
+ * COPY, never symlink (same @opencode-ai/plugin resolution gotcha as the tools).
+ */
+import type { Plugin } from "@opencode-ai/plugin"
+
+const PROTECT_TAIL_TOKENS = 40_000
+const PROTECT_LAST_TOOL_USES = 12
+const MIN_BATCH_TOKENS = 20_000
+const SERVER = "http://127.0.0.1:8787"
+
+// copied from the shared manta-auth helper (BET-1330) — the plugins dir cannot resolve the tools dir at runtime
+import { readFileSync } from "node:fs"
+import { homedir } from "node:os"
+import { join } from "node:path"
+
+function boxToken(): string | null {
+  const fromEnv = process.env.MANTA_BOX_TOKEN
+  if (fromEnv) return fromEnv
+  try {
+    const raw = readFileSync(join(homedir(), ".manta", "auth.json"), "utf-8")
+    const tok = JSON.parse(raw)?.box_token
+    return typeof tok === "string" && /^[0-9a-f]{32}$/.test(tok) ? tok : null
+  } catch {
+    return null // no store yet (auth disabled / first run) → send no header
+  }
+}
+
+function authHeaders(body?: unknown): Record<string, string> {
+  const headers: Record<string, string> = {}
+  if (body) headers["content-type"] = "application/json"
+  const tok = boxToken()
+  if (tok) headers["authorization"] = `Bearer ${tok}`
+  return headers
+}
+
+const estTokens = (s: unknown): number =>
+  typeof s === "string" ? Math.ceil(s.length / 4) : 0
+
+export const MantaOptimizerObserve: Plugin = async () => {
+  return {
+    "experimental.chat.messages.transform": async (_input: any, output: any) => {
+      try {
+        const messages: any[] = output?.messages ?? []
+        const sessionID: string = messages[0]?.info?.sessionID ?? ""
+        if (!sessionID) return
+        // Walk parts newest-first, accumulating estimated tokens and tool-use count.
+        let tailTokens = 0
+        let toolUses = 0
+        let maskedTokens = 0
+        let maskedParts = 0
+        for (let m = messages.length - 1; m >= 0; m--) {
+          for (const part of [...(messages[m]?.parts ?? [])].reverse()) {
+            const isTool = part?.type === "tool"
+            const done = part?.state?.status === "completed"
+            const out = part?.state?.output ?? ""
+            const t = estTokens(out) + estTokens(part?.text)
+            tailTokens += t
+            if (isTool && done) toolUses++
+            const protectedByTail = tailTokens <= PROTECT_TAIL_TOKENS
+            const protectedByRecency = toolUses <= PROTECT_LAST_TOOL_USES
+            const isSkill = typeof part?.tool === "string" && part.tool.startsWith("skill")
+            if (isTool && done && !isSkill && !protectedByTail && !protectedByRecency) {
+              maskedTokens += estTokens(out)
+              maskedParts++
+            }
+          }
+        }
+        if (maskedTokens < MIN_BATCH_TOKENS) return
+        await fetch(`${SERVER}/api/optimizer/counterfactual`, {
+          method: "POST",
+          headers: { "content-type": "application/json", ...authHeaders() },
+          body: JSON.stringify({ sessionID, maskedTokens, maskedParts, ts: Date.now() }),
+          signal: AbortSignal.timeout(1500),
+        }).catch(() => {})
+      } catch {
+        /* fail open — observation must never affect a turn */
+      }
+    },
+  }
+}

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -13,9 +13,11 @@ import { fileURLToPath } from "node:url";
 import { dirname, join, extname, normalize, resolve, basename } from "node:path";
 import { homedir, hostname } from "node:os";
 import { pipeline } from "node:stream/promises";
-import { uploadRoot } from "../shared/paths.mjs";
+import { uploadRoot, statePath } from "../shared/paths.mjs";
 import { synthesizeSpeech } from "../shared/groq.mjs";
 import { WebSocketServer } from "ws";
+import { createCounterfactualStore, validateCounterfactualReport } from "./optimizer/counterfactual.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import * as tmux from "./tmux.mjs";
 import * as oc from "./opencode.mjs";
 import * as pty from "./pty.mjs";
@@ -906,6 +908,19 @@ const SERVER_VERSION = await readServerVersion(PROJECT_ROOT);
 // response + `/api/version` body as `version` + `minClient` — no new IPC
 // channel; Settings → About reads it in the single getServerVersion trip.
 const OPENCODE_VERSION = readOpencodeVersion();
+
+// BET-1335: the observe-mode masking counterfactual store. Reads/writes
+// `optimizer-counterfactual.json` through the shared jsonStore atomic writer
+// (the same temp-file-then-rename primitive schedule.mjs reuses — already a
+// single shared source, no duplicate to extract). Wired into buildHandlers so
+// the `optimizer:summary` read model merges the counterfactual, and used by
+// the POST /api/optimizer/counterfactual ingest route below.
+const optimizerCounterfactual = createCounterfactualStore({
+  load: () => readJsonSync(statePath("optimizer-counterfactual.json"), {}),
+  save: (s) => writeJsonAtomic(statePath("optimizer-counterfactual.json"), JSON.stringify(s, null, 2)),
+  now: Date.now,
+});
+
 rpcHandlers = buildHandlers({
   tmux,
   oc,
@@ -927,6 +942,9 @@ rpcHandlers = buildHandlers({
   // BET-1244: the provider-health engine itself, for the Accounts "Try again"
   // action (accounts:retry delegates to providerHealth.retry).
   providerHealth,
+  // BET-1335: the observe-mode counterfactual store for the optimizer:summary
+  // read model.
+  counterfactualStore: optimizerCounterfactual,
   // BET-790: renderer read channel for a session's progress record (the
   // server store from src/server/progress.mjs). The write side is the AI's
   // progress_report tool → POST /api/progress.
@@ -2717,6 +2735,34 @@ const handleRequest = async (req, res) => {
           urgent: !!body?.urgent,
           sessionID: body?.sessionID,
         });
+        respondJson(res, 200, { ok: true });
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Optimizer counterfactual ingest (OBSERVE-ONLY) ----------
+  // POST /api/optimizer/counterfactual  body {sessionID, maskedTokens,
+  //   maskedParts, ts} → {ok:true}  (400 {error:"invalid"} on bad shape)
+  // The manta-optimizer opencode plugin (docs/opencode-tools/
+  // manta-optimizer-plugin.ts) reports what manta WOULD trim — read + report
+  // only, it never mutates the message history. The store REPLACES the
+  // session's latest counterfactual (each report is a full would-mask, not an
+  // increment). Behind the /api/* Bearer gate (no exemption). The validator is
+  // the shared PURE one from counterfactual.mjs, so the route stays ~5 lines.
+  if (path === "/api/optimizer/counterfactual") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        if (validateCounterfactualReport(body)) {
+          respondJson(res, 400, { error: "invalid" });
+          return;
+        }
+        await optimizerCounterfactual.record(body);
         respondJson(res, 200, { ok: true });
         return;
       }

--- a/src/server/optimizer/counterfactual.mjs
+++ b/src/server/optimizer/counterfactual.mjs
@@ -1,0 +1,198 @@
+// optimizer/counterfactual.mjs — the OBSERVE-ONLY masking counterfactual store
+// (Optimizer P1.3, BET-1335).
+//
+// What the manta-optimizer opencode plugin reports (POST
+// /api/optimizer/counterfactual) is not spend — it is the "what manta WOULD
+// trim" counterfactual: for a session's current message history, how many
+// tokens/parts the masking policy would drop. The plugin is read + report
+// only; it never mutates the message history. This module stores those
+// reports so the dashboard's "raw vs optimized" graph has a real second line
+// before any actuation exists.
+//
+// Semantics (a report REPLACES, never increments): each session keeps only its
+// LATEST report's values, because each report is the full would-mask for that
+// session's current history. `days` stores, per local day, the sum over
+// sessions of each session's latest maskedTokens as of that day's last report.
+//
+// Split strictly into pure/store (createCounterfactualStore — injected I/O)
+// and a PURE validator + summaryFields. No real state dir is touched unless
+// index.mjs wires a load/save; tests inject in-memory load/save.
+
+import { statePath } from "../../shared/paths.mjs";
+
+// Persistence file for the store (wired by index.mjs via the shared
+// jsonStore atomic writer — see the hygiene note there). New store, new file:
+// `statePath()` keeps it sandboxed under the test seam.
+export const COUNTERFACTUAL_PATH = statePath("optimizer-counterfactual.json");
+
+export const MAX_SESSIONS = 500;
+export const RETAIN_DAYS = 90;
+export const SUMMARY_DAYS = 30;
+
+function num(v) {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+
+// Local-calendar day key "YYYY-MM-DD", matching how the dashboard graph is read.
+function dayKey(ms) {
+  const d = new Date(num(ms));
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+const DAY_MS = 86_400_000;
+
+function normalizeState(raw) {
+  const s = raw && typeof raw === "object" ? raw : {};
+  return {
+    days: s.days && typeof s.days === "object" ? s.days : {},
+    sessions: s.sessions && typeof s.sessions === "object" ? s.sessions : {},
+  };
+}
+
+/**
+ * PURE. Validates a counterfactual report. Returns `null` when valid, else an
+ * error string naming the offending field. Shared by the store's `record` and
+ * the `/api/optimizer/counterfactual` route (so the route stays ~5 lines):
+ *   sessionID — non-empty string, ≤128 chars
+ *   maskedTokens / maskedParts / ts — finite numbers ≥ 0
+ */
+export function validateCounterfactualReport(report) {
+  const r = report ?? {};
+  if (
+    typeof r.sessionID !== "string" ||
+    r.sessionID.length === 0 ||
+    r.sessionID.length > 128
+  ) {
+    return "sessionID";
+  }
+  for (const k of ["maskedTokens", "maskedParts", "ts"]) {
+    const v = r[k];
+    if (typeof v !== "number" || !Number.isFinite(v) || v < 0) return k;
+  }
+  return null;
+}
+
+// Recompute a day's entry: the sum of maskedTokens (and count of sessions)
+// over all sessions whose latest report falls on that local day.
+function computeDay(sessions, day) {
+  let maskedTokens = 0;
+  let reports = 0;
+  for (const sd of Object.values(sessions)) {
+    if (!sd || typeof sd.lastTs !== "number") continue;
+    if (dayKey(sd.lastTs) === day) {
+      maskedTokens += num(sd.maskedTokens);
+      reports++;
+    }
+  }
+  return { maskedTokens, reports };
+}
+
+// Evict sessions beyond MAX_SESSIONS, oldest `lastTs` first.
+function capSessions(sessions) {
+  const keys = Object.keys(sessions);
+  if (keys.length <= MAX_SESSIONS) return;
+  const withTs = keys
+    .filter((k) => typeof sessions[k]?.lastTs === "number")
+    .sort((a, b) => sessions[a].lastTs - sessions[b].lastTs);
+  let n = keys.length;
+  for (const k of withTs) {
+    if (n <= MAX_SESSIONS) break;
+    delete sessions[k];
+    n--;
+  }
+  // Sessions with no numeric lastTs (shouldn't happen after normalize + record,
+  // but be safe) are evicted last, arbitrarily, until under the cap.
+  if (Object.keys(sessions).length > MAX_SESSIONS) {
+    for (const k of Object.keys(sessions)) {
+      if (Object.keys(sessions).length <= MAX_SESSIONS) break;
+      delete sessions[k];
+    }
+  }
+}
+
+/**
+ * The counterfactual store. Injected I/O: `load()` returns the persisted
+ * `{days, sessions}` (or {}), `save(state)` persists it atomically, `now` is
+ * the clock (number or zero-arg fn, for tests). Pure logic — no fs access
+ * unless the injected load/save touch it.
+ *
+ * Returns { record, snapshot }:
+ *   record({sessionID, maskedTokens, maskedParts, ts}) → {ok, error?}. Validates;
+ *   replaces the session's latest report; prunes old day entries; caps sessions
+ *   at MAX_SESSIONS; recomputes today's day entry; persists; {ok:true}.
+ *   snapshot() → the current state ({days, sessions}), loading from load() on
+ *   first access. Backs summaryFields().
+ */
+export function createCounterfactualStore({ load, save, now }) {
+  let state = null;
+  const nowMs = () => (typeof now === "function" ? num(now()) : num(now ?? Date.now()));
+
+  async function ensureLoaded() {
+    if (!state) state = normalizeState(await load());
+    return state;
+  }
+
+  async function record(report) {
+    const err = validateCounterfactualReport(report);
+    if (err) return { ok: false, error: err };
+    const s = await ensureLoaded();
+    const t = nowMs();
+    const today = dayKey(t);
+    // REPLACE the session's counterfactual (each report is the full would-mask
+    // for that session's current history, not an increment).
+    s.sessions[report.sessionID] = {
+      maskedTokens: num(report.maskedTokens),
+      maskedParts: num(report.maskedParts),
+      lastTs: num(report.ts),
+    };
+    capSessions(s.sessions);
+    // Retention: drop day entries older than RETAIN_DAYS (ISO keys compare
+    // lexicographically).
+    const cutoff = dayKey(t - RETAIN_DAYS * DAY_MS);
+    for (const k of Object.keys(s.days)) {
+      if (k < cutoff) delete s.days[k];
+    }
+    // Day entries are snapshots "as of that day's last report" — only today's
+    // is recomputed.
+    s.days[today] = computeDay(s.sessions, today);
+    await save(s);
+    return { ok: true };
+  }
+
+  async function snapshot() {
+    return ensureLoaded();
+  }
+
+  return { record, snapshot };
+}
+
+/**
+ * PURE(over the store's snapshot). Shape consumed by buildOptimizerSummary:
+ *   dailySeries: [{day, maskedTokens}] — SUMMARY_DAYS days, oldest→newest,
+ *     ZERO-FILLED for days with no counterfactual report.
+ *   bySession: {[sessionID]: {maskedTokens}} — each session's latest
+ *     maskedTokens. `savedPct` is NOT computed here: it needs tokensSent,
+ *     which only summary.mjs has (it computes it against its own bySession).
+ */
+export async function summaryFields(store, { days = SUMMARY_DAYS, now = Date.now() } = {}) {
+  const s = await store.snapshot();
+  const n = Math.max(1, Math.floor(num(days)) || 1);
+  const bySession = {};
+  for (const [id, sd] of Object.entries(s.sessions ?? {})) {
+    if (sd && typeof sd.maskedTokens === "number") {
+      bySession[id] = { maskedTokens: sd.maskedTokens };
+    }
+  }
+  const t = typeof now === "function" ? num(now()) : num(now ?? Date.now());
+  const dailySeries = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const d = new Date(t);
+    d.setDate(d.getDate() - i);
+    const key = dayKey(d.getTime());
+    dailySeries.push({ day: key, maskedTokens: s.days?.[key]?.maskedTokens ?? 0 });
+  }
+  return { dailySeries, bySession };
+}

--- a/src/server/optimizer/counterfactual.test.mjs
+++ b/src/server/optimizer/counterfactual.test.mjs
@@ -1,0 +1,169 @@
+// Tests for optimizer/counterfactual.mjs — the observe-mode masking
+// counterfactual store (Optimizer P1.3, BET-1335). Pure/injected throughout:
+// no real state dir — `load`/`save` are in-memory and `now` is a controlled
+// clock. Run via `npm run test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createCounterfactualStore,
+  validateCounterfactualReport,
+  MAX_SESSIONS,
+  RETAIN_DAYS,
+} from "./counterfactual.mjs";
+
+const DAY_MS = 86_400_000;
+
+function dayKey(ms) {
+  const d = new Date(ms);
+  return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function makeStore({ initial = {}, now }) {
+  let state = initial;
+  const saves = [];
+  const store = createCounterfactualStore({
+    load: async () => state,
+    save: async (s) => {
+      state = s;
+      saves.push(JSON.parse(JSON.stringify(s)));
+    },
+    now: () => now(),
+  });
+  return { store, saves, get: () => state };
+}
+
+function fixed(ms) {
+  return () => ms;
+}
+
+test("validation: valid report passes, each bad field is rejected", () => {
+  assert.equal(
+    validateCounterfactualReport({ sessionID: "abc", maskedTokens: 1, maskedParts: 2, ts: 3 }),
+    null,
+  );
+  // sessionID
+  assert.ok(validateCounterfactualReport({ sessionID: "", maskedTokens: 1, maskedParts: 1, ts: 1 }));
+  assert.ok(validateCounterfactualReport({ sessionID: "x".repeat(129), maskedTokens: 1, maskedParts: 1, ts: 1 }));
+  assert.ok(validateCounterfactualReport({ sessionID: 42, maskedTokens: 1, maskedParts: 1, ts: 1 }));
+  assert.ok(validateCounterfactualReport({ maskedTokens: 1, maskedParts: 1, ts: 1 }));
+  // numeric fields
+  assert.ok(validateCounterfactualReport({ sessionID: "a", maskedTokens: -1, maskedParts: 1, ts: 1 }));
+  assert.ok(validateCounterfactualReport({ sessionID: "a", maskedTokens: NaN, maskedParts: 1, ts: 1 }));
+  assert.ok(validateCounterfactualReport({ sessionID: "a", maskedTokens: "1", maskedParts: 1, ts: 1 }));
+  assert.ok(validateCounterfactualReport({ sessionID: "a", maskedTokens: 1, maskedParts: -5, ts: 1 }));
+  assert.ok(validateCounterfactualReport({ sessionID: "a", maskedTokens: 1, maskedParts: 1, ts: NaN }));
+  assert.ok(validateCounterfactualReport(null));
+});
+
+test("store.record rejects invalid and leaves state untouched", async () => {
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const { store, get } = makeStore({ now: fixed(now) });
+  const res = await store.record({ sessionID: "", maskedTokens: 1, maskedParts: 1, ts: 1 });
+  assert.equal(res.ok, false);
+  assert.ok(res.error);
+  assert.deepEqual(get(), {}); // no load/normalize, no mutation on an invalid report
+});
+
+test("a report REPLACES the session's counterfactual, and today's day is the sum of sessions whose latest report is today", async () => {
+  const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const { store, get } = makeStore({ now: fixed(t) });
+  const today = dayKey(t);
+
+  await store.record({ sessionID: "s1", maskedTokens: 100, maskedParts: 3, ts: t });
+  await store.record({ sessionID: "s2", maskedTokens: 200, maskedParts: 2, ts: t });
+  assert.equal(get().days[today].maskedTokens, 300, "two sessions today sum");
+  assert.equal(get().days[today].reports, 2);
+
+  // s1's NEWER report replaces its old 100 → today becomes 200(s1) + 200(s2).
+  await store.record({ sessionID: "s1", maskedTokens: 1000, maskedParts: 4, ts: t });
+  assert.equal(get().days[today].maskedTokens, 1200);
+  assert.equal(get().sessions.s1.maskedTokens, 1000);
+});
+
+test("day entries are per-day snapshots: a session moving days updates today only", async () => {
+  // day0 t, day1 = next day.
+  const t0 = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const t1 = t0 + DAY_MS;
+  let current = t0;
+  const { store, get } = makeStore({ now: () => current });
+  const d0 = dayKey(t0);
+  const d1 = dayKey(t1);
+
+  await store.record({ sessionID: "s1", maskedTokens: 100, maskedParts: 1, ts: t0 });
+  await store.record({ sessionID: "s2", maskedTokens: 200, maskedParts: 1, ts: t0 });
+  // Move a full day forward (both the server clock and the report ts).
+  current = t1;
+  await store.record({ sessionID: "s1", maskedTokens: 50, maskedParts: 1, ts: t1 });
+
+  assert.equal(get().days[d0].maskedTokens, 300, "day0 keeps its snapshot (s1 100 + s2 200)");
+  assert.equal(get().days[d1].maskedTokens, 50, "day1 is just s1's latest");
+});
+
+test("retention prunes day entries older than RETAIN_DAYS; recent ones survive", async () => {
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const oldDay = dayKey(now - (RETAIN_DAYS + 1) * DAY_MS);
+  const recentDay = dayKey(now - 10 * DAY_MS);
+  const {
+    store,
+    get,
+  } = makeStore({
+    initial: {
+      days: {
+        [oldDay]: { maskedTokens: 999, reports: 1 },
+        [recentDay]: { maskedTokens: 7, reports: 1 },
+      },
+      sessions: {},
+    },
+    now: fixed(now),
+  });
+
+  await store.record({ sessionID: "s1", maskedTokens: 5, maskedParts: 1, ts: now });
+
+  const days = get().days;
+  assert.equal(days[oldDay], undefined, "entries older than 90 days are pruned");
+  assert.deepEqual(days[recentDay], { maskedTokens: 7, reports: 1 }, "recent entries survive");
+});
+
+test("sessions are capped at MAX_SESSIONS, evicting the oldest lastTs first", async () => {
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const { store, get } = makeStore({ now: fixed(now) });
+
+  // Fill to the cap with ascending timestamps.
+  for (let i = 0; i < MAX_SESSIONS; i++) {
+    await store.record({ sessionID: `s${i}`, maskedTokens: i, maskedParts: 1, ts: now + i });
+  }
+  assert.equal(Object.keys(get().sessions).length, MAX_SESSIONS);
+
+  // A new, newest session pushes the OLDEST (s0) out.
+  await store.record({ sessionID: "newest", maskedTokens: MAX_SESSIONS, maskedParts: 1, ts: now + 1_000_000 });
+  const sessions = get().sessions;
+  assert.equal(Object.keys(sessions).length, MAX_SESSIONS);
+  assert.equal(sessions.s0, undefined, "oldest lastTs is evicted first");
+  assert.ok(sessions.newest, "the newest report survives");
+});
+
+test("summaryFields returns a zero-filled 30d maskedTokens series and per-session maskedTokens", async () => {
+  const { store } = makeStore({ now: fixed(new Date(2026, 7, 24, 12, 0, 0).getTime()) });
+  const { summaryFields } = await import("./counterfactual.mjs");
+  const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  await store.record({ sessionID: "s1", maskedTokens: 123, maskedParts: 1, ts: t });
+
+  const f = await summaryFields(store);
+  assert.equal(f.dailySeries.length, 30);
+  const today = dayKey(t);
+  assert.equal(f.dailySeries.find((d) => d.day === today).maskedTokens, 123);
+  assert.ok(f.dailySeries.filter((d) => d.day !== today).every((d) => d.maskedTokens === 0));
+  assert.deepEqual(f.bySession, { s1: { maskedTokens: 123 } });
+});
+
+test("record is idempotent per report (same report twice → same state)", async () => {
+  const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const { store, get } = makeStore({ now: fixed(t) });
+  const today = dayKey(t);
+  await store.record({ sessionID: "s1", maskedTokens: 42, maskedParts: 2, ts: t });
+  const first = JSON.parse(JSON.stringify(get()));
+  await store.record({ sessionID: "s1", maskedTokens: 42, maskedParts: 2, ts: t });
+  assert.deepEqual(get(), first);
+  assert.equal(get().days[today].maskedTokens, 42);
+});

--- a/src/server/optimizer/summary.mjs
+++ b/src/server/optimizer/summary.mjs
@@ -19,6 +19,7 @@
 
 import { aggregate, aggregateBySession, aggregateDailySeries, fetchLedgerRows } from "../modelLedger.mjs";
 import { measureEffectiveTtl } from "./ttl.mjs";
+import { summaryFields } from "./counterfactual.mjs";
 
 const WINDOW_DAYS = 30;
 const TTL_MS = 60_000;
@@ -29,25 +30,49 @@ export { WINDOW_DAYS };
  * PURE. Build the optimizer summary over the last WINDOW_DAYS of ledger rows
  * (fetched via the injected `fetchRows(sinceMs)`). `totals`/`cacheShare` reuse
  * the existing `aggregate` — no re-derivation. `ttl` is measured from the same
- * rows (BET-1334); `counterfactual`/`windows` are `null` placeholders children
- * 3–4 fill.
+ * rows (BET-1334); `windows` stays a `null` placeholder child 4 fills;
+ * `counterfactual` (BET-1335) fills its placeholder by injecting the observe-
+ * only masking counterfactual into `dailySeries` (a `maskedTokens` per day,
+ * 0 where absent — the "raw vs optimized" graph's second line) and into
+ * `bySession` (a `savedPct` per top-20 session, 0 when no counterfactual), and
+ * by populating the `counterfactual` key itself with the raw store fields.
  */
-export async function buildOptimizerSummary({ fetchRows, now = Date.now() }) {
+export async function buildOptimizerSummary({ fetchRows, now = Date.now(), counterfactualStore = null }) {
   const nowMs = num(now);
   const raw = await fetchRows(nowMs - WINDOW_DAYS * 86_400_000);
   const rows = Array.isArray(raw) ? raw : [];
   const { totals, cacheShare } = aggregate(rows);
+  const cf = counterfactualStore
+    ? await summaryFields(counterfactualStore, { days: WINDOW_DAYS, now: nowMs })
+    : null;
+  const cfDaily = new Map((cf?.dailySeries ?? []).map((d) => [d.day, d.maskedTokens ?? 0]));
+  const dailySeries = aggregateDailySeries(rows, WINDOW_DAYS, nowMs).map((d) => ({
+    ...d,
+    maskedTokens: cfDaily.get(d.day) ?? 0,
+  }));
+  const bySession = aggregateBySession(rows).map((e) => ({
+    ...e,
+    savedPct: savedPctFor(e, cf?.bySession),
+  }));
   return {
     supported: true,
     windowDays: WINDOW_DAYS,
     totals,
     cacheShare,
-    dailySeries: aggregateDailySeries(rows, WINDOW_DAYS, nowMs),
-    bySession: aggregateBySession(rows),
-    counterfactual: null,
+    dailySeries,
+    bySession,
+    counterfactual: cf ? { dailySeries: cf.dailySeries, bySession: cf.bySession } : null,
     windows: null,
     ttl: measureEffectiveTtl(rows, nowMs),
   };
+}
+
+// savedPct = maskedTokens / (maskedTokens + tokensSent), 0 when there is no
+// counterfactual for the session or nothing to save against.
+function savedPctFor(entry, cfBySession) {
+  const m = cfBySession?.[entry.sessionID]?.maskedTokens ?? 0;
+  const denom = m + entry.tokensSent;
+  return denom > 0 ? m / denom : 0;
 }
 
 function num(v) {
@@ -63,10 +88,12 @@ let inflight = null;
 /**
  * I/O. Wrapper factory. `getDb` resolves the read-only opencode.db handle
  * (null → { supported:false }); `now` (a number or a zero-arg fn, for tests)
- * is the clock used for both the window and the TTL. The returned async
+ * is the clock used for both the window and the TTL; `counterfactualStore` is
+ * the observe-mode store from counterfactual.mjs (null when not wired — the
+ * summary then degrades to empty counterfactual). The returned async
  * function memoizes the built summary for TTL_MS with an in-flight guard.
  */
-export function createOptimizerSummary({ getDb, now }) {
+export function createOptimizerSummary({ getDb, now, counterfactualStore = null }) {
   const nowMs = () => (typeof now === "function" ? num(now()) : num(now ?? Date.now()));
   return async function optimizerSummary() {
     const t = nowMs();
@@ -79,6 +106,7 @@ export function createOptimizerSummary({ getDb, now }) {
         const value = await buildOptimizerSummary({
           fetchRows: (since) => fetchLedgerRows(db, since),
           now: t,
+          counterfactualStore,
         });
         cache = { at: t, value };
         return value;

--- a/src/server/optimizer/summary.test.mjs
+++ b/src/server/optimizer/summary.test.mjs
@@ -6,6 +6,7 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 import { buildOptimizerSummary, createOptimizerSummary, WINDOW_DAYS } from "./summary.mjs";
+import { createCounterfactualStore } from "./counterfactual.mjs";
 
 function row(over = {}) {
   return {
@@ -20,7 +21,18 @@ function row(over = {}) {
   };
 }
 
-test("buildOptimizerSummary returns the full shape with the three null placeholders, reusing aggregate totals/cacheShare", async () => {
+function memStore(now, seed = {}) {
+  let state = seed;
+  return createCounterfactualStore({
+    load: async () => state,
+    save: async (s) => {
+      state = s;
+    },
+    now,
+  });
+}
+
+test("buildOptimizerSummary returns the full shape with empty counterfactual, reusing aggregate totals/cacheShare", async () => {
   const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
   const rows = [row({ cost: 5, input: 1, cacheRead: 2, cacheWrite: 3, output: 4, startedMs: now })];
   const fetchRows = async () => rows;
@@ -36,11 +48,51 @@ test("buildOptimizerSummary returns the full shape with the three null placehold
   assert.equal(s.dailySeries.length, WINDOW_DAYS);
   assert.equal(s.bySession[0].sessionID, "s1");
   // ttl is measured from the same rows (BET-1334): a single row yields no
-  // consecutive pairs → the default prediction. counterfactual/windows remain
-  // blank placeholders for children 3–4.
+  // consecutive pairs → the default prediction.
   assert.deepEqual(s.ttl, { ms: 300_000, confidence: "default", observations: 0 });
+  // No counterfactualStore wired → counterfactual is empty: maskedTokens 0 on
+  // every day, savedPct 0 on every session, the counterfactual key null.
   assert.equal(s.counterfactual, null);
   assert.equal(s.windows, null);
+  assert.ok(s.dailySeries.every((d) => d.maskedTokens === 0));
+  assert.ok(s.bySession.every((e) => e.savedPct === 0));
+});
+
+test("buildOptimizerSummary merges the counterfactual into dailySeries + bySession and fills the counterfactual key", async () => {
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  // tokensSent = 1+2+3+4 = 10 for s1.
+  const rows = [row({ cost: 5, input: 1, cacheRead: 2, cacheWrite: 3, output: 4, startedMs: now })];
+  const fetchRows = async () => rows;
+  const store = memStore(now);
+  assert.equal((await store.record({ sessionID: "s1", maskedTokens: 5, maskedParts: 1, ts: now })).ok, true);
+
+  const s = await buildOptimizerSummary({ fetchRows, now, counterfactualStore: store });
+
+  // The day of `now` holds s1's maskedTokens (5); every other day is 0.
+  const today = new Date(now);
+  const key = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, "0")}-${String(today.getDate()).padStart(2, "0")}`;
+  const todayEntry = s.dailySeries.find((d) => d.day === key);
+  assert.equal(todayEntry.maskedTokens, 5);
+  assert.ok(s.dailySeries.filter((d) => d.day !== key).every((d) => d.maskedTokens === 0));
+  // savedPct = 5 / (5 + 10) = 1/3 on the s1 bySession entry.
+  assert.equal(s.bySession.length, 1);
+  assert.equal(s.bySession[0].savedPct, 5 / 15);
+  // The counterfactual placeholder is now populated with the raw store fields.
+  assert.deepEqual(s.counterfactual.bySession, { s1: { maskedTokens: 5 } });
+  assert.equal(s.counterfactual.dailySeries.find((d) => d.day === key).maskedTokens, 5);
+});
+
+test("buildOptimizerSummary: savedPct is 0 when a session has no counterfactual", async () => {
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const rows = [row({ sessionID: "s1", input: 1, cacheRead: 2, cacheWrite: 3, output: 4, startedMs: now })];
+  const fetchRows = async () => rows;
+  const store = memStore(now);
+  // A report for a DIFFERENT session — s1 has no counterfactual.
+  await store.record({ sessionID: "other", maskedTokens: 9, maskedParts: 1, ts: now });
+
+  const s = await buildOptimizerSummary({ fetchRows, now, counterfactualStore: store });
+  assert.equal(s.bySession[0].sessionID, "s1");
+  assert.equal(s.bySession[0].savedPct, 0);
 });
 
 test("createOptimizerSummary returns { supported:false } when getDb resolves null", async () => {

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -57,9 +57,10 @@ import { MIN_CLIENT } from "./version.mjs";
 import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, replyThreadForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
 
 // BET-1333: the Optimizer's memoized `optimizer:summary` read model. Created
-// once at module scope so the 60s memo + in-flight guard are shared across
-// RPC calls — the same single-slot cache pattern as routingServices.mjs.
-const optimizerSummary = createOptimizerSummary({ getDb });
+// once inside buildHandlers (below) so the 60s memo + in-flight guard are
+// shared across RPC calls — the same single-slot cache pattern as
+// routingServices.mjs — and so its injected `counterfactualStore` dep
+// (BET-1335) is wired from the server entry.
 import { listRules as forgeListRules, formatIssueRef, parseIssueRef } from "./forgeRules.mjs";
 import { clearStoredToken } from "./forge/auth.mjs";
 import { parseRules as parseForgeRules } from "../shared/forgeRules.mjs";
@@ -361,6 +362,10 @@ export function buildHandlers({
   // `retry` for the Accounts "Try again" action. Null when not wired → the
   // accounts:retry channel answers a non-empty failure message, never a throw.
   providerHealth = null,
+  // BET-1335: the observe-mode masking counterfactual store (optimizer/
+  // counterfactual.mjs), created + wired in index.mjs. Null when not wired →
+  // the optimizer:summary degrades to empty counterfactual fields.
+  counterfactualStore = null,
 }) {
   // The sole resolver for project cwd — no longer mirrored to a desktop-main
   // copy (the src/main/index.ts duplicate was retired in the HTTP-only
@@ -407,6 +412,13 @@ export function buildHandlers({
       return null;
     }
   }
+
+  // BET-1333: the memoized `optimizer:summary` read model. Built once per
+  // buildHandlers (single production instance) so the 60s memo + in-flight
+  // guard share across RPC calls. `getDb` is the module-scope handle from
+  // opencodeDb.mjs; `counterfactualStore` is injected (BET-1335) so the
+  // summary merges the observe-mode counterfactual when one is wired.
+  const optimizerSummary = createOptimizerSummary({ getDb, counterfactualStore });
 
   return {
     // ---- local channels (config/git/fs/clipboard/transport/tmux-config) ----

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1845,19 +1845,24 @@ export type LedgerSummary = {
 // the ledger `aggregate` shape; `dailySeries` is a zero-filled local-day
 // tokensSent graph over `windowDays`, oldest→newest; `bySession` is the top 20
 // sessions by cost. `ttl` is the measured effective prompt-cache TTL (BET-1334:
-// `{ms, confidence:"default"|"measured", observations}`), `counterfactual`/
-// `windows` are placeholders that Optimizer children 3–4 fill — they stay
-// present (null) so the renderer contract is stable. `supported:false` = the
-// box can't read opencode.db.
+// `{ms, confidence:"default"|"measured", observations}`. BET-1335 fills the
+// `counterfactual` placeholder: each `dailySeries` day gains a `maskedTokens`
+// (0 where no counterfactual) = the observe-mode "what manta WOULD trim" line;
+// each top-20 `bySession` entry gains `savedPct`; and the `counterfactual` key
+// itself holds the raw store fields. `windows` stays a `null` placeholder child
+// 4 fills. `supported:false` = the box can't read opencode.db.
 export type OptimizerSummary = {
   supported: boolean;
   windowDays: number;
   totals: { turns: number; cost: number; input: number; output: number; cacheRead: number; cacheWrite: number };
   cacheShare: { output: number; cacheRead: number; cacheWrite: number; input: number };
-  dailySeries: { day: string; tokensSent: number }[]; // "YYYY-MM-DD", oldest→newest
-  bySession: { sessionID: string | null; turns: number; cost: number; tokensSent: number }[];
+  dailySeries: { day: string; tokensSent: number; maskedTokens: number }[]; // "YYYY-MM-DD", oldest→newest
+  bySession: { sessionID: string | null; turns: number; cost: number; tokensSent: number; savedPct: number }[];
   ttl: { ms: number; confidence: "default" | "measured"; observations: number };
-  counterfactual: null;
+  counterfactual: {
+    dailySeries: { day: string; maskedTokens: number }[];
+    bySession: Record<string, { maskedTokens: number }>;
+  } | null;
   windows: null;
 };
 


### PR DESCRIPTION
**BET-1335 — Optimizer P1.3: observe-mode plugin + counterfactual store + ingest route**

**Base: origin/main @ `ea2f9603`**

Three deliverables:

1. **`docs/opencode-tools/manta-optimizer-plugin.ts`** (repo source of truth) — the OBSERVE-ONLY opencode plugin. Computes the masking counterfactual (what manta WOULD trim) and POSTs it to `/api/optimizer/counterfactual`. Never mutates `output.messages`; fails open (swallowed errors); not installed here (header documents install for the maintainer). `boxToken()`/`authHeaders()` are inlined verbatim from `docs/opencode-tools/manta-auth.ts` (BET-1330) with the required comment — the plugins dir can't resolve the tools dir at runtime.

2. **`src/server/optimizer/counterfactual.mjs`** — `createCounterfactualStore({load, save, now})` (injected I/O, pure logic) + exported `validateCounterfactualReport` (route stays ~5 lines) + `summaryFields(store)` (maskedTokens only; savedPct computed in summary.mjs). A report REPLACES a session's counterfactual; per-day entries are per-day snapshots; 90d day retention; 500-session cap evicting oldest lastTs. Reuses the already-shared atomic writer (`src/server/jsonStore.mjs` `writeJsonAtomic`) — no new duplicate, nothing to extract.

3. **Route + summary wiring** — `POST /api/optimizer/counterfactual` in `index.mjs` (behind the existing Bearer gate, mirroring `/api/notify`); store wired into `buildHandlers`; `buildOptimizerSummary` fills its counterfactual placeholder: `dailySeries` entries gain `maskedTokens` (0 where absent — the "raw vs optimized" graph's second line), `bySession` entries gain `savedPct` (0 when no counterfactual), and the `counterfactual` key is populated. `OptimizerSummary` type in `shared/types.ts` updated to match.

Cross-cutting note: `optimizer:summary` was created at module scope in `rpc.mjs`; moved into `buildHandlers` so its injected `counterfactualStore` dep is wired from the server entry (single production instance → same memo semantics).

**Verification:**
- typecheck: exit 0, no errors
- test: 2758 pass / 0 fail / 0 skip
- New tests: `counterfactual.test.mjs` (latest-report-replaces, day recompute, 90d prune, 500-session cap order, validator cases, summaryFields) + 3 summary merge tests.

No design decisions taken — the plugin code is the spec verbatim.
