### PR TITLE
Optimizer P1.4 — quota-window usage history + forecast-at-reset (BET-1336)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -62,7 +62,7 @@ import { startServerUpdatePoller, createOpencodeUpdateForwarder } from "./server
 import { createCliDetector, upgradeCli } from "./cliUpdates.mjs";
 import { runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { startSchedulePoller, createJob, listJobs, deleteJob } from "./schedule.mjs";
-import { startUsagePoller, recheckAdapterAtLimit, providerIDForAdapter, listSnapshots } from "./usage.mjs";
+import { startUsagePoller, recheckAdapterAtLimit, providerIDForAdapter, listSnapshots, getUsageHistory } from "./usage.mjs";
 import {
   createCapJob,
   getJob,
@@ -945,6 +945,11 @@ rpcHandlers = buildHandlers({
   // BET-1335: the observe-mode counterfactual store for the optimizer:summary
   // read model.
   counterfactualStore: optimizerCounterfactual,
+  // BET-1336: quota-window forecast-at-reset read sources for the
+  // optimizer:summary `windows` slice — the live polled snapshots + the
+  // persisted observation history.
+  usageSnapshots: listSnapshots,
+  usageHistory: getUsageHistory,
   // BET-790: renderer read channel for a session's progress record (the
   // server store from src/server/progress.mjs). The write side is the AI's
   // progress_report tool → POST /api/progress.

--- a/src/server/optimizer/forecast.mjs
+++ b/src/server/optimizer/forecast.mjs
@@ -1,0 +1,122 @@
+// optimizer/forecast.mjs — quota-window usage history + forecast-at-reset
+// (Optimizer P1.4, BET-1336).
+//
+// The dashboard's fuel gauges show, as a tick mark, the forecasted usage at
+// the current window's reset instant: "if today's burn rate holds, this window
+// lands at ~78%." Pure OBSERVATION — nothing here paces or routes work; pacing
+// is phase 2.
+//
+// Two pure functions, injected I/O only, no fs access:
+//   • appendObservation — the single tap on the usage poller's publish point
+//     (wired in usage.mjs). Records one {ts, pct} per key at most every
+//     `minIntervalMs`, prunes observations older than `maxAgeDays`.
+//   • forecastAtReset — derate the window's recent positive burn into a
+//     per-hour rate, take its median, and extrapolate it out to `resetsAt`.
+//     Returns null when there is not enough history to trust the forecast
+//     (the UI then hides the tick) or when a reset time is missing.
+//
+// Key = "<provider>:<window.kind>", e.g. "claude:session". History shape:
+// `{[key]: [{ts, pct}]}` with ts ascending.
+
+export const MAX_AGE_DAYS = 28;
+export const MIN_INTERVAL_MS = 900_000; // 15 minutes — no finer than one obs per key per 15m
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
+// Any delta below this is a window RESET boundary — pct jumped back down to
+// ~0 because a fresh window opened, not because usage fell. The pair straddling
+// that boundary describes two different windows and must never feed a rate.
+const RESET_DELTA = -10;
+
+/**
+ * PURE. Median of `numbers` (does not mutate the input). Odd → middle element;
+ * even → mean of the two middle elements. Returns null for an empty array so
+ * callers can treat "no median" like "no forecast".
+ */
+export function median(numbers) {
+  if (!Array.isArray(numbers) || numbers.length === 0) return null;
+  const sorted = [...numbers].sort((a, b) => a - b);
+  const mid = Math.floor(sorted.length / 2);
+  return sorted.length % 2 === 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+}
+
+/**
+ * PURE. Record one observation for `obs.key`. `history` is mutated in place and
+ * returned (the caller holds the only reference — usage.mjs's module state).
+ *   obs = { ts, key, pct }
+ *   opts = { maxAgeDays: 28, minIntervalMs: 900000 }
+ * Skips (returns history unchanged) when the key's NEWEST observation is
+ * younger than `minIntervalMs` — the key has already been recorded recently.
+ * Appends, then prunes entries older than `maxAgeDays` (referenced from the
+ * new observation's own timestamp).
+ */
+export function appendObservation(
+  history,
+  obs,
+  { maxAgeDays = MAX_AGE_DAYS, minIntervalMs = MIN_INTERVAL_MS } = {},
+) {
+  if (!history || typeof history !== "object" || !obs) return history;
+  const key = obs.key;
+  const ts = Number(obs.ts);
+  const pct = Number(obs.pct);
+  if (typeof key !== "string" || key.length === 0 || !Number.isFinite(ts) || !Number.isFinite(pct)) {
+    return history;
+  }
+
+  let arr = Array.isArray(history[key]) ? history[key] : [];
+
+  // Skip when the newest observation for this key is younger than minIntervalMs.
+  if (arr.length > 0) {
+    const newest = arr[arr.length - 1];
+    if (Number.isFinite(newest.ts) && ts - newest.ts < minIntervalMs) return history;
+  }
+
+  arr = [...arr, { ts, pct }];
+  history[key] = arr;
+
+  // Prune entries older than maxAgeDays (referenced from the new observation).
+  const cutoff = ts - maxAgeDays * DAY_MS;
+  history[key] = arr.filter((e) => Number.isFinite(e.ts) && e.ts >= cutoff);
+  return history;
+}
+
+/**
+ * PURE. Forecast the window's pct at its reset instant, extrapolating the
+ * median recent per-hour burn rate forward. Returns an integer (rounded) or
+ * null when there is no forecast.
+ *
+ * Consecutive deltas for `key`; any delta < -10 is a window reset boundary —
+ * that PAIR is excluded. The remaining POSITIVE deltas become per-hour rates
+ * (`delta / hoursBetween`). Fewer than 8 rates → null (the UI hides the tick).
+ * Else forecast = clamp(currentPct + median(rates) * hoursUntil(resetsAt),
+ * currentPct, 100), rounded to integer. Lower-bound clamped at currentPct —
+ * a forecast never goes below the already-burned pct — and capped at 100.
+ */
+export function forecastAtReset(history, key, { now, resetsAt, currentPct } = {}) {
+  const nowMs = Number(now);
+  const resetMs = Number(resetsAt);
+  const cur = Number(currentPct);
+  if (!Number.isFinite(nowMs) || !Number.isFinite(resetMs) || !Number.isFinite(cur)) return null;
+
+  const arr = history && Array.isArray(history[key]) ? history[key] : [];
+
+  const rates = [];
+  for (let i = 1; i < arr.length; i++) {
+    const prev = arr[i - 1];
+    const curr = arr[i];
+    if (!Number.isFinite(prev?.ts) || !Number.isFinite(curr?.ts)) continue;
+    const delta = curr.pct - prev.pct;
+    if (delta < RESET_DELTA) continue; // window reset boundary — exclude the pair
+    if (delta <= 0) continue; // only positive deltas become rates
+    const hoursBetween = (curr.ts - prev.ts) / HOUR_MS;
+    if (hoursBetween <= 0) continue;
+    rates.push(delta / hoursBetween);
+  }
+
+  if (rates.length < 8) return null;
+
+  const medianRate = median(rates);
+  const hoursUntil = (resetMs - nowMs) / HOUR_MS;
+  const raw = cur + medianRate * hoursUntil;
+  return Math.round(Math.min(Math.max(raw, cur), 100));
+}

--- a/src/server/optimizer/forecast.test.mjs
+++ b/src/server/optimizer/forecast.test.mjs
@@ -1,0 +1,113 @@
+// Tests for optimizer/forecast.mjs — quota-window usage history + forecast-at-
+// reset (Optimizer P1.4, BET-1336). Pure functions, no I/O. Run via `npm run
+// test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { appendObservation, forecastAtReset, median } from "./forecast.mjs";
+
+const H = 3_600_000; // one hour, ms
+const D = 86_400_000; // one day, ms
+
+function hist(points) {
+  return { k: points.map(([ts, pct]) => ({ ts, pct })) };
+}
+
+test("median: odd length returns the middle element", () => {
+  assert.equal(median([3, 1, 2]), 2);
+  assert.equal(median([7]), 7);
+});
+
+test("median: even length returns the mean of the two middle elements", () => {
+  assert.equal(median([1, 4, 2, 3]), 2.5);
+  assert.equal(median([10, 20]), 15);
+});
+
+test("median: empty array returns null", () => {
+  assert.equal(median([]), null);
+});
+
+test("appendObservation: skips when the newest observation is younger than minIntervalMs", () => {
+  const history = {};
+  appendObservation(history, { ts: 0, key: "c:s", pct: 10 }, { minIntervalMs: 900_000 });
+  assert.equal(history["c:s"].length, 1);
+  // 5 minutes later — still inside the 15m min interval → skipped.
+  appendObservation(history, { ts: 5 * 60_000, key: "c:s", pct: 12 }, { minIntervalMs: 900_000 });
+  assert.equal(history["c:s"].length, 1);
+  // At exactly minIntervalMs the observation is no longer "younger" → appended.
+  appendObservation(history, { ts: 900_000, key: "c:s", pct: 12 }, { minIntervalMs: 900_000 });
+  assert.equal(history["c:s"].length, 2);
+});
+
+test("appendObservation: keys are independent", () => {
+  const history = {};
+  appendObservation(history, { ts: 0, key: "c:s", pct: 10 });
+  appendObservation(history, { ts: 1, key: "c:w", pct: 20 });
+  assert.equal(history["c:s"].length, 1);
+  assert.equal(history["c:w"].length, 1);
+});
+
+test("appendObservation: prunes entries older than maxAgeDays", () => {
+  const history = {};
+  appendObservation(history, { ts: 0, key: "c:s", pct: 10 }, { maxAgeDays: 28 });
+  appendObservation(history, { ts: 1 * D, key: "c:s", pct: 11 }, { maxAgeDays: 28 });
+  // New obs 29 days after the first: cutoff = 29d - 28d = 1d → the t=0 entry
+  // (0 < 1d) is pruned, the day-1 entry survives.
+  appendObservation(history, { ts: 29 * D, key: "c:s", pct: 12 }, { maxAgeDays: 28 });
+  assert.equal(history["c:s"].length, 2);
+  assert.equal(history["c:s"][0].ts, 1 * D);
+});
+
+test("forecastAtReset: excludes the reset-boundary pair and clamps correctly", () => {
+  // 100→0 is a reset (delta -100 < -10): that pair must NOT feed a rate.
+  // The 0→1…7→8 deltas are +1/hr → 8 positive rates, median 1.
+  const now = 0;
+  const history = hist([100, 0, 1, 2, 3, 4, 5, 6, 7, 8].map((pct, i) => [i * H, pct]));
+  const resetsAt = now + 50 * H; // 50h away
+  // forecast = clamp(8 + 1*50, 8, 100) = 58
+  assert.equal(forecastAtReset(history, "k", { now, resetsAt, currentPct: 8 }), 58);
+});
+
+test("forecastAtReset: a reset pair that WOULD count as a rate keeps <8 → null", () => {
+  // 7 positive +1/hr deltas plus one reset pair (100→0). Counting the reset
+  // would give 8 "rates" → non-null; correctly excluding it leaves 7 → null.
+  const now = 0;
+  const history = hist([100, 0, 1, 2, 3, 4, 5, 6, 7].map((pct, i) => [i * H, pct]));
+  assert.equal(
+    forecastAtReset(history, "k", { now, resetsAt: now + 50 * H, currentPct: 7 }),
+    null,
+  );
+});
+
+test("forecastAtReset: fewer than 8 rates returns null", () => {
+  const now = 0;
+  const history = hist([1, 2, 3, 4, 5, 6].map((pct, i) => [i * H, pct])); // 5 deltas
+  assert.equal(forecastAtReset(history, "k", { now, resetsAt: now + H, currentPct: 6 }), null);
+});
+
+test("forecastAtReset: clamps at 100", () => {
+  const now = 0;
+  const history = hist([1, 2, 3, 4, 5, 6, 7, 8, 9].map((pct, i) => [i * H, pct])); // 8 deltas +1/hr
+  // median 1, hoursUntil 200h → 5 + 200 = 205 → clamped to 100.
+  assert.equal(forecastAtReset(history, "k", { now, resetsAt: now + 200 * H, currentPct: 5 }), 100);
+});
+
+test("forecastAtReset: clamps at currentPct when the window already reset", () => {
+  const now = 0;
+  const history = hist([1, 2, 3, 4, 5, 6, 7, 8, 9].map((pct, i) => [i * H, pct])); // median 1
+  // resetsAt in the past → hoursUntil negative → raw < currentPct → clamped up to currentPct.
+  assert.equal(forecastAtReset(history, "k", { now, resetsAt: now - 5 * H, currentPct: 60 }), 60);
+});
+
+test("forecastAtReset: rounds to integer", () => {
+  const now = 0;
+  const history = hist([1, 2, 3, 4, 5, 6, 7, 8, 9].map((pct, i) => [i * H, pct])); // median 1
+  // hoursUntil = 1.5h → raw = 10 + 1.5 = 11.5 → rounds to 12.
+  assert.equal(forecastAtReset(history, "k", { now, resetsAt: now + 1.5 * H, currentPct: 10 }), 12);
+});
+
+test("forecastAtReset: null when currentPct/resetsAt is not a finite number", () => {
+  const history = hist([1, 2, 3, 4, 5, 6, 7, 8, 9].map((pct, i) => [i * H, pct]));
+  assert.equal(forecastAtReset(history, "k", { now: 0, resetsAt: undefined, currentPct: 5 }), null);
+  assert.equal(forecastAtReset(history, "k", { now: 0, resetsAt: 100, currentPct: Number.NaN }), null);
+});

--- a/src/server/optimizer/summary.mjs
+++ b/src/server/optimizer/summary.mjs
@@ -19,6 +19,7 @@
 
 import { aggregate, aggregateBySession, aggregateDailySeries, fetchLedgerRows } from "../modelLedger.mjs";
 import { summaryFields } from "./counterfactual.mjs";
+import { forecastAtReset } from "./forecast.mjs";
 
 const WINDOW_DAYS = 30;
 const TTL_MS = 60_000;
@@ -36,7 +37,18 @@ export { WINDOW_DAYS };
  * no counterfactual), and by populating the `counterfactual` key itself with
  * the raw store fields.
  */
-export async function buildOptimizerSummary({ fetchRows, now = Date.now(), counterfactualStore = null }) {
+export async function buildOptimizerSummary({
+  fetchRows,
+  now = Date.now(),
+  counterfactualStore = null,
+  // BET-1336: the quota-window forecast-at-reset lives here. Injected, like
+  // fetchRows/counterfactualStore, so the arithmetic stays pure. `usageSnapshots`
+  // returns the CURRENT stored UsageSnapshot[] (production wires usage.mjs
+  // listSnapshots); `usageHistory` returns the observation history
+  // `{[key]: [{ts,pct}]}` (production wires usage.mjs getUsageHistory).
+  usageSnapshots = () => [],
+  usageHistory = () => ({}),
+} = {}) {
   const nowMs = num(now);
   const raw = await fetchRows(nowMs - WINDOW_DAYS * 86_400_000);
   const rows = Array.isArray(raw) ? raw : [];
@@ -62,8 +74,35 @@ export async function buildOptimizerSummary({ fetchRows, now = Date.now(), count
     bySession,
     ttl: null,
     counterfactual: cf ? { dailySeries: cf.dailySeries, bySession: cf.bySession } : null,
-    windows: null,
+    windows: windowsFor(usageSnapshots(), usageHistory(), nowMs),
   };
+}
+
+// Map the current stored usage snapshots to the summary's `windows` slice —
+// one entry per quota window, in the same order the UsageDial popover lists
+// them (each snapshot's `windows` array is already shortest-first, and
+// snapshots are iterated in provider order). `forecastPct` is the forecast-at-
+// reset from history, or null when there isn't enough history to trust it (the
+// UI then hides the tick).
+function windowsFor(snapshots, history, nowMs) {
+  const out = [];
+  for (const snap of snapshots ?? []) {
+    for (const w of snap.windows ?? []) {
+      out.push({
+        provider: snap.provider,
+        planLabel: typeof snap.planLabel === "string" ? snap.planLabel : undefined,
+        windowLabel: w.label,
+        pct: w.pct,
+        resetsAt: Number.isFinite(w.resetsAt) ? w.resetsAt : null,
+        forecastPct: forecastAtReset(history, `${snap.provider}:${w.kind}`, {
+          now: nowMs,
+          resetsAt: Number.isFinite(w.resetsAt) ? w.resetsAt : undefined,
+          currentPct: w.pct,
+        }),
+      });
+    }
+  }
+  return out;
 }
 
 // savedPct = maskedTokens / (maskedTokens + tokensSent), 0 when there is no
@@ -92,7 +131,7 @@ let inflight = null;
  * summary then degrades to empty counterfactual). The returned async
  * function memoizes the built summary for TTL_MS with an in-flight guard.
  */
-export function createOptimizerSummary({ getDb, now, counterfactualStore = null }) {
+export function createOptimizerSummary({ getDb, now, counterfactualStore = null, usageSnapshots, usageHistory }) {
   const nowMs = () => (typeof now === "function" ? num(now()) : num(now ?? Date.now()));
   return async function optimizerSummary() {
     const t = nowMs();
@@ -106,6 +145,8 @@ export function createOptimizerSummary({ getDb, now, counterfactualStore = null 
           fetchRows: (since) => fetchLedgerRows(db, since),
           now: t,
           counterfactualStore,
+          usageSnapshots,
+          usageHistory,
         });
         cache = { at: t, value };
         return value;

--- a/src/server/optimizer/summary.test.mjs
+++ b/src/server/optimizer/summary.test.mjs
@@ -52,7 +52,8 @@ test("buildOptimizerSummary returns the full shape with empty counterfactual, re
   // every day, savedPct 0 on every session, the counterfactual key null.
   assert.equal(s.ttl, null);
   assert.equal(s.counterfactual, null);
-  assert.equal(s.windows, null);
+  // No usage snapshots wired → windows is empty (P1.4: the quota-window slice).
+  assert.deepEqual(s.windows, []);
   assert.ok(s.dailySeries.every((d) => d.maskedTokens === 0));
   assert.ok(s.bySession.every((e) => e.savedPct === 0));
 });
@@ -144,4 +145,53 @@ test("createOptimizerSummary in-flight guard shares one build across concurrent 
 
   assert.equal(r1, r2);
   assert.equal(resolves, 1, "concurrent calls must share a single in-flight build");
+});
+
+test("buildOptimizerSummary: windows slice maps stored snapshots + forecast-at-reset (BET-1336)", async () => {
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const rows = [row({ cost: 1, input: 1, cacheRead: 1, cacheWrite: 1, output: 1, startedMs: now })];
+  const fetchRows = async () => rows;
+
+  const H = 3_600_000;
+  // Two snapshots, each with a session+weekly window (shortest-first order).
+  const snapshots = [
+    {
+      provider: "claude",
+      planLabel: "Max 20x",
+      fetchedAt: now,
+      windows: [
+        { kind: "session", label: "5h", pct: 30, resetsAt: now + 50 * H },
+        { kind: "weekly", label: "week", pct: 40, resetsAt: now + 100 * H },
+      ],
+    },
+    { provider: "codex", fetchedAt: now, windows: [{ kind: "session", label: "5h", pct: 20, resetsAt: now + 50 * H }] },
+  ];
+  // History: enough +1/hr observations for the first snapshot's session window
+  // to produce a forecast; nothing for the others → their forecastPct is null.
+  const history = {
+    "claude:session": [0, 1, 2, 3, 4, 5, 6, 7, 8].map((pct, i) => ({ ts: now - (8 - i) * H, pct })),
+  };
+
+  const s = await buildOptimizerSummary({ fetchRows, now, usageSnapshots: () => snapshots, usageHistory: () => history });
+
+  assert.equal(s.windows.length, 3);
+  // The popover order: snapshot order, each snapshot's windows shortest-first.
+  assert.deepEqual(
+    s.windows.map((w) => [w.provider, w.windowLabel]),
+    [
+      ["claude", "5h"],
+      ["claude", "week"],
+      ["codex", "5h"],
+    ],
+  );
+  // First window: 9 observations of +1/hr → median 1; resetsAt 50h away from
+  // now, currentPct 30 → 30 + 1*50 = 80.
+  assert.equal(s.windows[0].forecastPct, 80);
+  assert.equal(s.windows[0].pct, 30);
+  assert.equal(s.windows[0].resetsAt, now + 50 * H);
+  assert.equal(s.windows[0].planLabel, "Max 20x");
+  // No history for the others → forecastPct null, resetsAt preserved.
+  assert.equal(s.windows[1].forecastPct, null);
+  assert.equal(s.windows[1].resetsAt, now + 100 * H);
+  assert.equal(s.windows[2].forecastPct, null);
 });

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -360,6 +360,13 @@ export function buildHandlers({
   // counterfactual.mjs), created + wired in index.mjs. Null when not wired →
   // the optimizer:summary degrades to empty counterfactual fields.
   counterfactualStore = null,
+  // BET-1336: the quota-window forecast-at-reset read sources. `usageSnapshots`
+  // returns the current usage snapshot set (index.mjs wires usage.mjs
+  // listSnapshots); `usageHistory` returns the observation history (index.mjs
+  // wires usage.mjs getUsageHistory). Null/none when not wired → the summary's
+  // `windows` is empty, matching the pre-P1.4 placeholder.
+  usageSnapshots = () => [],
+  usageHistory = () => ({}),
 }) {
   // The sole resolver for project cwd — no longer mirrored to a desktop-main
   // copy (the src/main/index.ts duplicate was retired in the HTTP-only
@@ -413,7 +420,7 @@ export function buildHandlers({
   // routingServices.mjs. `getDb` is the module-scope handle from
   // opencodeDb.mjs; `counterfactualStore` is injected (BET-1335) so the
   // summary merges the observe-mode counterfactual when one is wired.
-  const optimizerSummary = createOptimizerSummary({ getDb, counterfactualStore });
+  const optimizerSummary = createOptimizerSummary({ getDb, counterfactualStore, usageSnapshots, usageHistory });
 
   return {
     // ---- local channels (config/git/fs/clipboard/transport/tmux-config) ----

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -91,6 +91,9 @@ import { kimiAdapter } from "./usageAdapters/kimi.mjs";
 import { isUsageAtLimit } from "./usageStopper.mjs";
 import { loadAccountReaders } from "./accountReaders.mjs";
 import { loadAuthFile, DEFAULT_AUTH_PATH } from "./gatewayRegister.mjs";
+import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { appendObservation } from "./optimizer/forecast.mjs";
 
 export { normalizeWindow };
 
@@ -234,6 +237,10 @@ export function createUsagePoller({
   fetchImpl = fetch,
   now = () => Date.now(),
   publish,
+  // BET-1336: observation tap at the publish point — called with the published
+  // UsageSnapshot[] whenever the content actually changes. Null in tests /
+  // direct users → no history recording.
+  observe = null,
   staleRetryMs = STALE_RETRY_MS,
 } = {}) {
   let snapshots = [];
@@ -379,6 +386,7 @@ export function createUsagePoller({
       const key = contentKey(results);
       if (key !== lastContentKey) {
         lastContentKey = key;
+        observe?.(results);
         publish?.({ kind: "usage.updated", payload: { snapshots: results } });
       }
     } finally {
@@ -417,7 +425,10 @@ let activePoller = null;
  * @returns {{ stop: () => void }}
  */
 export function startUsagePoller(bus, { intervalMs = POLL_MS } = {}) {
-  const poller = createUsagePoller({ publish: (evt) => bus.publish(evt) });
+  const poller = createUsagePoller({
+    publish: (evt) => bus.publish(evt),
+    observe: recordWindowObservations,
+  });
   activePoller = poller;
   const p = startPoller(() => poller.tick(), { intervalMs, label: "usage" });
   return {
@@ -437,6 +448,68 @@ export function startUsagePoller(bus, { intervalMs = POLL_MS } = {}) {
 /** @returns {UsageSnapshot[]} */
 export function listSnapshots() {
   return activePoller ? activePoller.snapshots : [];
+}
+
+// ---------------------------------------------------------------------------
+// Quota-window observation history + forecast-at-reset (BET-1336, P1.4)
+// ---------------------------------------------------------------------------
+//
+// Pure OBSERVATION — the dashboard's fuel gauges show a tick at the forecasted
+// pct at the current window's reset. Nothing here paces or routes work (that
+// is phase 2). The single observation tap is at the poller's publish point
+// (createUsagePoller's `observe` hook — wired to `recordWindowObservations` in
+// startUsagePoller below), so there is no second poller and no adapter change.
+// History is persisted at `statePath("usage-history.json")` via the shared
+// jsonStore atomic writer; loaded once lazily and saved on a single debounced
+// 30s timer so the poll loop never hammers the disk.
+const HISTORY_PATH = statePath("usage-history.json");
+const HISTORY_SAVE_DEBOUNCE_MS = 30_000;
+
+// Lazily loaded `{[key]: [{ts, pct}]}` (key = "<provider>:<window.kind>").
+let usageHistory = null;
+let historySaveTimer = null;
+
+/** @returns {Record<string, Array<{ts:number, pct:number}>>} */
+export function getUsageHistory() {
+  if (usageHistory === null) usageHistory = readJsonSync(HISTORY_PATH, {});
+  return usageHistory;
+}
+
+// One debounced 30s save timer (single timer, unref'd so it never holds the
+// process open). Writing the current in-memory state is idempotent and tiny.
+function scheduleHistorySave() {
+  if (historySaveTimer) return;
+  historySaveTimer = setTimeout(() => {
+    historySaveTimer = null;
+    const snapshot = usageHistory;
+    if (snapshot == null) return;
+    writeJsonAtomic(HISTORY_PATH, JSON.stringify(snapshot, null, 2)).catch((e) =>
+      console.warn("[usage] history save failed:", e?.message ?? e),
+    );
+  }, HISTORY_SAVE_DEBOUNCE_MS);
+  historySaveTimer?.unref?.();
+}
+
+/**
+ * Tap the poller's publish point: record one observation per snapshot window
+ * with `key = "<provider>:<window.kind>"`. Pure appendObservation handles the
+ * min-interval dedupe + max-age prune; this is only the iteration + persistence
+ * glue. `snapshots` is the published UsageSnapshot[].
+ * @param {UsageSnapshot[]} snapshots
+ */
+export function recordWindowObservations(snapshots) {
+  if (!Array.isArray(snapshots) || snapshots.length === 0) return;
+  const history = getUsageHistory();
+  for (const snap of snapshots) {
+    for (const w of snap.windows ?? []) {
+      appendObservation(history, {
+        ts: snap.fetchedAt,
+        key: `${snap.provider}:${w.kind}`,
+        pct: w.pct,
+      });
+    }
+  }
+  scheduleHistorySave();
 }
 
 // ---------------------------------------------------------------------------

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1875,10 +1875,11 @@ export type LedgerSummary = {
 // `dailySeries` day gains a `maskedTokens` (0 where no counterfactual) = the
 // observe-mode "what manta WOULD trim" line; each top-20 `bySession` entry
 // gains `savedPct`; and the `counterfactual` key itself holds the raw store
-// fields. `windows` stays a `null` placeholder child 4 fills. `ttl` stays null
-// in phase 1 — the hotfix (#1339) made the cacheTtl setting WRITE the real
-// opencode TTL, so measurement returns later as its verifier.
-// `supported:false` = the box can't read opencode.db.
+// fields. BET-1336 fills the `windows` placeholder: the quota-window usage
+// list with a per-window `forecastPct` (the forecast-at-reset tick; null when
+// history is too thin). `ttl` stays null in phase 1 — the hotfix (#1339) made
+// the cacheTtl setting WRITE the real opencode TTL, so measurement returns
+// later as its verifier. `supported:false` = the box can't read opencode.db.
 export type OptimizerSummary = {
   supported: boolean;
   windowDays: number;
@@ -1891,7 +1892,14 @@ export type OptimizerSummary = {
     dailySeries: { day: string; maskedTokens: number }[];
     bySession: Record<string, { maskedTokens: number }>;
   } | null;
-  windows: null;
+  windows: {
+    provider: string;
+    planLabel?: string;
+    windowLabel: string;
+    pct: number;
+    resetsAt: number | null;
+    forecastPct: number | null;
+  }[];
 };
 
 // A secret's METADATA — what the UI and `secret_list` see. NEVER carries the


### PR DESCRIPTION
## Summary
Fills the `optimizer:summary` `windows` placeholder (P1.4 of the Manta Optimizer epic) and records the quota-window usage observations driving it. Pure observation — no pacing, no routing effect (phase 2).

**Deliverables:**
1. **`src/server/optimizer/forecast.mjs`** (new, pure): `appendObservation` (min-interval dedupe + max-age prune) and `forecastAtReset` (median per-hour burn rate extrapolated to reset; null when <8 rates). Tests in `forecast.test.mjs`.
2. **Capture wiring** in `src/server/usage.mjs`: an `observe` hook at the poller's single publish point (no second poller, no adapter change) records one observation per window with `key = "<provider>:<window.kind>"`. History persisted at `statePath("usage-history.json")` via the shared `jsonStore` atomic writer, loaded lazily, saved on a single debounced 30s timer (`unref()`).
3. **Summary placeholder filled** in `buildOptimizerSummary`: `windows` mapped from the current stored snapshots (injected `usageSnapshots` = `listSnapshots`) + `forecastAtReset` per window (`forecastPct` null when too little history). Ordered exactly as the UsageDial popover lists them — each snapshot's `windows` array is already shortest-first and snapshots iterate in provider order; grepped `chatUtils` and there is no separate ordering helper to reuse, so the snapshot's native order is used.

**Wiring:** `usageSnapshots`/`usageHistory` injected through `buildHandlers` (rpc.mjs) ← `index.mjs` (`listSnapshots`, new `getUsageHistory`). `OptimizerSummary.windows` type updated in `src/shared/types.ts`.

**Hygiene:** one observation tap at the existing publish point; history persists through `statePath` (sandboxed under the test seam); `createUsagePoller` keeps `observe = null` as the default so existing direct/test users record nothing.

**Base: origin/main @ `fd65f680`**

**Files changed:** 8 files
```
src/server/optimizer/forecast.mjs       (new)
src/server/optimizer/forecast.test.mjs  (new)
src/server/optimizer/summary.mjs
src/server/optimizer/summary.test.mjs
src/server/usage.mjs
src/server/rpc.mjs
src/server/index.mjs
src/shared/types.ts
```

## Verification results
- PR branch (`multica/BET-1336-usage-history-forecast` @ `0c29e707`):
  - typecheck: exit 0. Errors: none. log sha256: `2352696e…`
  - test: exit 0, 2772 pass / 0 fail / 0 skip. Failures: none. log sha256: `c35ae49e…`
- Base (`main` @ `fd65f680`):
  - typecheck: exit 0. Errors: none. log sha256: `2352696e…`
  - test: exit 0, 2758 pass / 0 fail / 0 skip. Failures: none. log sha256: `adc2a625…`
- **Conclusion:** 0 new failures, 0 pre-existing. 14 new tests added (13 forecast + 1 summary windows).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

> Auto-opened by the push-sweep; body replaced with the implementer's summary + verification results.
