### PR TITLE
feat(renderer): OptimizerCard TTL detail + consume cache tokens (BET-1341)

### DIFF
--- a/src/renderer/OptimizerCard.tsx
+++ b/src/renderer/OptimizerCard.tsx
@@ -27,6 +27,15 @@ type OptimizerData = OptimizerSummary | { supported: false };
 
 const wholePct = (v: number): string => `${Math.round(v)}%`;
 
+// Anthropic prompt-cache TTL label for the Cache-hit detail line — matches the
+// BET-1337 spec's "5m" / "1h" wording (a default confidence still shows the
+// 5-minute baseline, e.g. "TTL 5m default").
+function ttlLabel(ms: number): string {
+  if (ms === 3_600_000) return "1h";
+  if (ms === 300_000) return "5m";
+  return `${Math.round(ms / 60_000)}m`;
+}
+
 // Gauge fill colour thresholds (BET-1337): <60 ok, 60–84 warn, ≥85 danger.
 function gaugeColor(pct: number): string {
   if (pct >= 85) return "var(--danger)";
@@ -248,10 +257,12 @@ export function OptimizerCard() {
         <div className="opt-stat">
           <div className="opt-stat-l">Cache hit</div>
           <div className="opt-stat-v">{wholePct(cacheHitPct)}</div>
-          {/* TTL detail is intentionally absent: optimizer:summary.ttl is a
-              DIAGNOSTIC value (measured effective TTL + verifier comparison,
-              BET-1340), never user-facing in P1. Render nothing. */}
-          <div className="opt-stat-d" />
+          {/* TTL detail (BET-1341) drawn from the measured effective TTL's
+              label + confidence — "TTL 5m measured" / "TTL 1h measured" /
+              "TTL 5m default" per the BET-1337 spec. */}
+          <div className="opt-stat-d">
+            {d.ttl ? `TTL ${ttlLabel(d.ttl.measuredMs)} ${d.ttl.confidence}` : ""}
+          </div>
         </div>
         <div className="opt-stat">
           <div className="opt-stat-l">Cost / turn</div>

--- a/src/renderer/SessionHeader.tsx
+++ b/src/renderer/SessionHeader.tsx
@@ -53,9 +53,11 @@ import { Popover } from "./Popover";
 import { MarqueeLabel } from "./MarqueeLabel";
 import { ConfirmModal } from "./ConfirmModal";
 
-// Cache-segment colors for the header pill.
-const CACHE_WRITE_COLOR = cssVar("--warn");
-const CACHE_READ_COLOR = cssVar("--info");
+// Cache-segment colors for the header pill. Consumed from the semantic tokens
+// (BET-408 / BET-1337 D2) so the header bar and the OptimizerCard share one
+// source of truth for the read/write cache hues.
+const CACHE_WRITE_COLOR = cssVar("--cache-write");
+const CACHE_READ_COLOR = cssVar("--cache-read");
 
 function formatTokensCompact(n: number): string {
   if (n < 1000) return String(n);
@@ -648,7 +650,7 @@ function ContextPill({
               />
               <span
                 className="tabular-nums font-mono font-semibold"
-                style={{ color: stale ? CACHE_WRITE_COLOR : fill }}
+                style={{ color: stale ? cssVar("--warn") : fill }}
               >
                 {pct}%
               </span>

--- a/src/server/optimizer/summary.mjs
+++ b/src/server/optimizer/summary.mjs
@@ -72,12 +72,14 @@ export async function buildOptimizerSummary({
     savedPct: savedPctFor(e, cf?.bySession),
   }));
 
-  // BET-1340: `ttl` is a DIAGNOSTIC, never user-facing in P1 (the renderer
-  // deliberately does not render it — see OptimizerCard). It carries the
-  // measured effective TTL plus, when the measurement is conclusive and a
-  // configured TTL is readable, whether it matches what opencode is set to
-  // send. A mismatch is logged once as an [optimizer] line: config and
-  // measured reality have drifted apart.
+  // BET-1340: `ttl` carries the measured effective TTL plus, when the
+  // measurement is conclusive and a configured TTL is readable, whether it
+  // matches what opencode is set to send. A mismatch is logged once as an
+  // [optimizer] line: config and measured reality have drifted apart. The
+  // renderer consumes `measuredMs` + `confidence` to draw the OptimizerCard
+  // Cache-hit TTL detail ("TTL 5m measured" / "TTL 1h measured" / "TTL 5m
+  // default", BET-1341); `observations`/`configuredMs`/`matched` stay as
+  // diagnostic surface for the verifier.
   const measured = measureEffectiveTtl(rows, nowMs);
   let configuredTtl = null;
   try {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1877,9 +1877,16 @@ export type LedgerSummary = {
 // gains `savedPct`; and the `counterfactual` key itself holds the raw store
 // fields. BET-1336 fills the `windows` placeholder: the quota-window usage
 // list with a per-window `forecastPct` (the forecast-at-reset tick; null when
-// history is too thin). `ttl` stays null in phase 1 — the hotfix (#1339) made
-// the cacheTtl setting WRITE the real opencode TTL, so measurement returns
-// later as its verifier. `supported:false` = the box can't read opencode.db.
+// history is too thin). `ttl` is the measured effective Anthropic prompt-cache
+// TTL (BET-1340): `measuredMs` is what the ledger shows actually happened,
+// `confidence` is "measured" when enough idle-gap observations exist and
+// "default" otherwise, `observations` is how many pairs the measurement used,
+// and `configuredMs`/`matched` compare it against what opencode is set to
+// send (null when there is no readable configured TTL). The renderer shows the
+// Cache-hit detail ("TTL 5m measured" / "TTL 1h measured" / "TTL 5m default")
+// from `measuredMs` + `confidence` (BET-1341). `ttl` is null only when the
+// summary builder has no measurement at all.
+// `supported:false` = the box can't read opencode.db.
 export type OptimizerSummary = {
   supported: boolean;
   windowDays: number;
@@ -1887,7 +1894,13 @@ export type OptimizerSummary = {
   cacheShare: { output: number; cacheRead: number; cacheWrite: number; input: number };
   dailySeries: { day: string; tokensSent: number; maskedTokens: number }[]; // "YYYY-MM-DD", oldest→newest
   bySession: { sessionID: string | null; turns: number; cost: number; tokensSent: number; savedPct: number }[];
-  ttl: null;
+  ttl: {
+    measuredMs: number;
+    confidence: "default" | "measured";
+    observations: number;
+    configuredMs: number | null;
+    matched: boolean | null;
+  } | null;
   counterfactual: {
     dailySeries: { day: string; maskedTokens: number }[];
     bySession: Record<string, { maskedTokens: number }>;


### PR DESCRIPTION
Un-gates the OptimizerCard Cache-hit TTL detail now that the measured-TTL source (BET-1340) has landed, and consumes the orphaned `--cache-read`/`--cache-write` tokens.

**Changes**
- `src/renderer/OptimizerCard.tsx` — renders the Cache-hit detail line from `optimizer:summary.ttl` (`measuredMs` + `confidence`) per the BET-1337 spec: `TTL 5m measured` / `TTL 1h measured` / `TTL 5m default`.
- `src/shared/types.ts` — un-nulls `OptimizerSummary.ttl` to the shape BET-1340 actually emits (`{ measuredMs, confidence, observations, configuredMs, matched } | null`); renders from `measuredMs` + `confidence`. Deliberately the richer emitted shape rather than the bare `{ ms, confidence }` sketched in the issue, so BET-1340's verifier diagnostics aren't regressed.
- `src/server/optimizer/summary.mjs` — comment-only: `ttl` is now consumed by the renderer, no longer "never user-facing".
- `src/renderer/SessionHeader.tsx` — consumes `--cache-read`/`--cache-write` tokens for the context bar's cache segment/legend fill colors (was `--info`/`--warn`). Kept the stale-% text on `--warn` since that's a staleness signal (the light-theme `--warn` is #6E6200, contrast-verified; amber `--cache-write` as text would fail light mode).

**Note on #2 (cache tokens):** chose *consume* over *remove* — the tokens are the BET-1337 D2 deliverable and are the on-theme source of truth for the read/write cache hues.

**Base:** `origin/main @ 3385c224`

**Verification results:**
- PR branch (`multica/BET-1341-optimizercard-ttl` @ `HEAD`): typecheck exit 0, no errors. test exit 0, 2801 pass / 0 fail / 0 skip.
- Base (`main @ 3385c224`): typecheck exit 0, no errors. test exit 0, 2801 pass / 0 fail / 0 skip.
- Conclusion: 0 new failures; no pre-existing failures; no resolved failures.

Cross-cutting follow-ups: none.

Follow-up filed: none (see self-check).
