### PR TITLE
fix(server): consume configured cache TTL in device staleness fallback (BET-1338)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -118,7 +118,7 @@ import {
 } from "./media.mjs";
 import { setSecret, deleteSecret, listSecrets, provideSecret } from "./secrets.mjs";
 import { createPromptDelivery } from "./promptDelivery.mjs";
-import { ensureMantaPlanAgent, ensureCtoAgent } from "./providers.mjs";
+import { ensureMantaPlanAgent, ensureCtoAgent, readCacheTtl as readProvidersCacheTtl } from "./providers.mjs";
 import {
   createWebhookEngine,
   createHook,
@@ -218,6 +218,10 @@ function contextLimitFor(providerID, modelID) {
 const streamInterp = createStreamInterpreter({
   publish: (evt) => bus.publish(evt),
   contextLimitFor,
+  // The device stream predicts cache staleness against the SAME TTL opencode
+  // actually sends (providers.readCacheTtl) that the desktop pill reads, so
+  // the device cache pill matches on a 1h box instead of always assuming 5m.
+  readCacheTtl: () => readProvidersCacheTtl({ listProviders: oc.getProviders }),
 });
 // BET-913 + BET-916 + BET-922: when a client (re)connects mid-state, replay the
 // current edge-only state so frames that only fire on an edge aren't lost —

--- a/src/server/streamInterp.mjs
+++ b/src/server/streamInterp.mjs
@@ -47,33 +47,10 @@ import { createSeenIdFilter } from "./seenIds.mjs";
 
 // opencode stamps its cache breakpoints with no `ttl`, so Anthropic applies
 // its default 5-minute TTL — measured on the wire, see AppConfig.cacheTtl.
-// This is the fallback the device stream predicts staleness against.
+// This is the fallback the device stream predicts staleness against, used only
+// while/unless the interpreter resolves the TTL opencode is actually
+// configured to send (see `readCacheTtl` in createStreamInterpreter below).
 const TTL_DEFAULT = "5m";
-
-// Recompute the cached-prefix size from a usage payload and publish the
-// staleness verdict for a session.
-//
-// Two call sites need this: the transcript-derived context emit and the
-// step-ended usage emit. They must agree byte-for-byte — including WHICH TTL
-// is predicted — or the device's cache pill flickers between two verdicts
-// depending on which event arrived last. Keeping it in one function is also
-// what stops the TTL constant being read in two places and drifting, which is
-// the shape of the bug this fallback exists to fix.
-//
-// The `|| st.cachedTokens` fallback is deliberate: a usage payload with no
-// cache buckets (0 + 0) means "this event carries no cache information",
-// not "the cache is now empty" — so the last known size is retained.
-function emitCacheStaleness(emit, sid, st, tokens, nowMs) {
-  st.cachedTokens =
-    (tokens?.cache?.read ?? 0) + (tokens?.cache?.write ?? 0) || st.cachedTokens;
-  emit(sid, "cache", computeStaleCache({
-    lastCompleted: st.lastCompleted,
-    now: nowMs,
-    ttlMs: selectCacheTtlMs(TTL_DEFAULT),
-    cachedTokens: st.cachedTokens,
-    running: st.running,
-  }));
-}
 
 // Per-tool cap for the live tool-output tail (server half, BET-745). Once a
 // single tool has streamed this many characters to the device, further output
@@ -264,6 +241,13 @@ export function createStreamInterpreter({
   publish,
   now = () => Date.now(),
   contextLimitFor = () => null,
+  // Resolves the cache TTL opencode is actually configured to send ("5m" |
+  // "1h"), or null when nothing is set / it can't be read (non-fatal). Injected
+  // like contextLimitFor so the interpreter stays pure/testable; production
+  // wires providers.readCacheTtl. The device stream predicts staleness against
+  // this — the SAME value the desktop SessionHeader pill reads — so the two
+  // pills agree on a 1h box instead of the device always assuming 5m.
+  readCacheTtl = async () => null,
 }) {
   const sessions = new Map();
   // The same opencode event is delivered on BOTH the global stream and the
@@ -273,12 +257,50 @@ export function createStreamInterpreter({
   // Events carry a unique id; remember a bounded window of them (shared filter,
   // lifted from this inline block so push.mjs can reuse the same guard).
   const seenEventIds = createSeenIdFilter();
+  // Configured cache TTL resolved once, non-blocking. Fetching it is async I/O
+  // (providers.readCacheTtl reads opencode's config) while `interpret` is
+  // synchronous, so resolve it in the background and read the memoized label
+  // here; "5m" stays the fallback until/unless a configured value lands.
+  let cacheTtlLabel = null;
+  void (async () => {
+    try {
+      const label = await readCacheTtl();
+      if (typeof label === "string" && label.length > 0) cacheTtlLabel = label;
+    } catch {
+      /* non-fatal: fall back to the 5m default */
+    }
+  })();
   function state(sid) {
     if (!sessions.has(sid)) sessions.set(sid, newSessionState());
     return sessions.get(sid);
   }
   function emit(sid, sub, payload) {
     publish({ kind: "stream", sub, sessionId: sid, payload });
+  }
+
+  // Recompute the cached-prefix size from a usage payload and publish the
+  // staleness verdict for a session.
+  //
+  // Two call sites need this: the transcript-derived context emit and the
+  // step-ended usage emit. They must agree byte-for-byte — including WHICH TTL
+  // is predicted — or the device's cache pill flickers between two verdicts
+  // depending on which event arrived last. Keeping it in one function is also
+  // what stops the TTL constant being read in two places and drifting, which is
+  // the shape of the bug this fallback exists to fix.
+  //
+  // The `|| st.cachedTokens` fallback is deliberate: a usage payload with no
+  // cache buckets (0 + 0) means "this event carries no cache information",
+  // not "the cache is now empty" — so the last known size is retained.
+  function emitCacheStaleness(emit, sid, st, tokens, nowMs) {
+    st.cachedTokens =
+      (tokens?.cache?.read ?? 0) + (tokens?.cache?.write ?? 0) || st.cachedTokens;
+    emit(sid, "cache", computeStaleCache({
+      lastCompleted: st.lastCompleted,
+      now: nowMs,
+      ttlMs: selectCacheTtlMs(cacheTtlLabel ?? TTL_DEFAULT),
+      cachedTokens: st.cachedTokens,
+      running: st.running,
+    }));
   }
 
   // The single place `running` changes. Stamps the idle->busy EDGE only, so a

--- a/src/server/streamInterp.test.mjs
+++ b/src/server/streamInterp.test.mjs
@@ -969,6 +969,35 @@ test("the same event also emits a cache frame", () => {
   assert.equal(events.filter((e) => e.sub === "cache").length, 1);
 });
 
+test("cache staleness predicts against the configured TTL, falling back to 5m", async () => {
+  const flush = () => new Promise((r) => setTimeout(r, 0));
+  // opencode configured to send 1h -> the device pill uses 1h (matches the
+  // desktop SessionHeader pill) rather than always assuming opencode's 5m
+  // default.
+  const oneHour = [];
+  const interp1h = createStreamInterpreter({
+    publish: (e) => oneHour.push(e),
+    readCacheTtl: async () => "1h",
+  });
+  await flush(); // let the background TTL resolution land
+  interp1h.interpret(updatedWith(ASSISTANT_MSG));
+  const cache1h = oneHour.find((e) => e.sub === "cache");
+  assert.ok(cache1h, "a cache frame was emitted");
+  assert.equal(cache1h.payload.ttlMs, 3_600_000);
+
+  // no readCacheTtl / nothing readable -> 5m default fallback preserved
+  const fiveMin = [];
+  const interp5m = createStreamInterpreter({
+    publish: (e) => fiveMin.push(e),
+    readCacheTtl: async () => null,
+  });
+  await flush();
+  interp5m.interpret(updatedWith(ASSISTANT_MSG));
+  const cache5m = fiveMin.find((e) => e.sub === "cache");
+  assert.ok(cache5m, "a cache frame was emitted");
+  assert.equal(cache5m.payload.ttlMs, 5 * 60_000);
+});
+
 test("a completed plan_exit tool part emits one planMode {on:false} frame", () => {
   const { interp, events } = make();
   interp.interpret({


### PR DESCRIPTION
## What

The device stream's cache-staleness fallback (`emitCacheStaleness` in `src/server/streamInterp.mjs`) predicted the prompt-cache TTL from a hard-coded `5m`, even though the desktop SessionHeader pill reads the TTL opencode is actually configured to send. On a box whose measured/configured TTL is `1h`, the device cache pill could therefore disagree with the desktop pill.

Per the retarget note on BET-1338, the fallback now consumes the **configured** value via `providers.readCacheTtl` (what opencode actually sends), not a ledger-measured TTL. The `5m` default is kept as the fallback when nothing is configured/readable.

## Change

- `createStreamInterpreter` takes an injected `readCacheTtl` dep (defaults to `() => null`, so behavior is unchanged for existing callers/tests).
- The configured TTL label (`"5m"|"1h"|null`) is resolved once in the background (async I/O, while `interpret` is synchronous) and memoized; staleness predicts against `selectCacheTtlMs(cacheTtlLabel ?? "5m")` instead of a hard-coded `5m`.
- `src/server/index.mjs` wires `readCacheTtl: () => providers.readCacheTtl({ listProviders: oc.getProviders })` — the same read the desktop pill and the optimizer summary verifier use.

## Follow-ups

None.

Base: origin/main @ ffbc5f9c

## Verification

- `npm run typecheck` — pass
- `npm test` — 2802 pass, 0 fail
- New test: configured `1h` → device pill uses `3_600_000`; unreadable → `5m` fallback preserved.
