### PR TITLE
docs(optimizer): phase-2 target mockup + AGENTS.md section (BET-1342)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1164,6 +1164,59 @@ consumes the bus envelopes in the renderer.
   validation accept/reject, unknown-action rejection, bus payload shape for
   both publishing actions — pure/injected only, no live HTTP/tmux).
 
+## Manta Optimizer (`src/server/optimizer/`) — phase 1 shipped, phase 2 in flight
+
+The optimizer makes a paid plan last longer: it trims dead weight out of a
+conversation's history, paces spending against the quota windows that actually
+reset, compacts long-idle conversations before the user comes back to them, and
+folds all of that into the model router's existing cost stage. **Phase 1
+(BET-1332, merged) is OBSERVE-ONLY and always on**; phase 2 (BET-1346) is what
+actuates, and it is gated behind ONE user-facing switch.
+
+**Metrics are always on; actuation is not.** With the switch off the box still
+measures everything — the ledger read model, the masking counterfactual, the
+quota-window forecast, the measured cache TTL — so the dashboard has real
+numbers to show BEFORE the user ever turns anything on. That asymmetry is
+deliberate: an optimizer that can only prove its value after you trust it never
+earns the trust.
+
+**Phase 1 surface (shipped):**
+- `optimizer:summary` (`src/server/optimizer/summary.mjs`) — a memoized (60s,
+  in-flight-guarded) read model over the opencode message ledger. Degrades to
+  `{supported:false}` on a box with no Node 24 / no `opencode.db`, exactly like
+  `modelLedger`.
+- `counterfactual.mjs` + `POST /api/optimizer/counterfactual` — the
+  observe-mode masking store. A report REPLACES a session's entry (each report
+  is the full would-mask for that history, never an increment).
+- `forecast.mjs` — quota-window observation history + forecast-at-reset, tapped
+  at the usage poller's single publish point.
+- `ttl.mjs` — the measured effective prompt-cache TTL, and the verifier that
+  compares it against what opencode is CONFIGURED to send.
+- `OptimizerCard` in Settings → Models; the visual spec is committed at
+  `docs/optimizer/mockup.html` and is the artifact the UI is implemented
+  against, not a screenshot taken afterwards.
+
+**The switch (phase 2): "Manta optimized token usage", Settings → Models,
+DEFAULT OFF.** It replaces the three-way routing-preset control, and it gates
+ONLY the phase-2 behaviours. **It does NOT gate Auto routing.** Routing
+activation is `modelRouting.preset`, which the server defaults to `"balanced"`
+(`src/server/local.mjs`), so every box has routing active today; wiring the new
+switch into `routingActive()` would silently turn Auto OFF for everyone the
+moment the default-off switch shipped. The preset config key is retained and
+pinned at `"balanced"` precisely so that cannot happen — what used to be the
+`economy` preset is now reached dynamically through the eco level below.
+
+**The one user override is the model pick.** The existing manual-pick-beats-Auto
+contract is the whole override surface: no per-knob editing, no reset buttons,
+no approval queue. Changes that could affect answer quality ship inside their
+own guardrails (constraint-retention checks, re-fetch-churn limits) rather than
+behind a human confirmation, and the activity log is the trust surface —
+including the entries where the optimizer rolled its own change back.
+
+**Nothing phones home.** There are no fleet priors and no shared telemetry of
+any kind; every parameter the tuner learns is learned from this box's own
+history and stays on it.
+
 ## Mouse mode — design decision, do not re-litigate
 
 **Mouse is ON through the whole pipeline (tmux + claude).** This matches what

--- a/docs/optimizer/mockup.html
+++ b/docs/optimizer/mockup.html
@@ -2,7 +2,7 @@
 <html lang="en" data-theme="dark">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Optimizer dashboard — phase 1 mockup</title>
+<title>Optimizer dashboard — phase 1 shipped + phase 2 target</title>
 <link rel="stylesheet" href="../../src/renderer/tokens.css">
 <style>
 body{margin:0;background:var(--canvas);color:var(--tx2);font-family:var(--font-sans);font-size:15px;line-height:1.55}
@@ -27,21 +27,61 @@ body{margin:0;background:var(--canvas);color:var(--tx2);font-family:var(--font-s
 .stat .d{font-size:11px;color:var(--tx3);margin-top:2px}
 .legend{display:flex;gap:16px;font-size:11px;color:var(--tx3);margin-top:2px}
 .legend i{display:inline-block;width:8px;height:8px;border-radius:2px;margin-right:5px;vertical-align:1px}
+
+/* ---- phase 2 ---- */
+.phase{font-size:10.5px;letter-spacing:.06em;text-transform:uppercase;color:var(--tx4);margin:34px 0 10px;display:flex;align-items:center;gap:10px}
+.phase::after{content:"";flex:1;height:1px;background:var(--border-subtle)}
+.sw{display:flex;align-items:flex-start;gap:14px}
+.sw .txt{flex:1}
+.sw b{color:var(--tx1);font-size:13.5px}
+.sw p{font-size:11.5px;color:var(--tx4);margin:3px 0 0;max-width:60ch}
+.toggle{width:38px;height:22px;border-radius:var(--r-full);background:var(--accent-solid);position:relative;flex:none;margin-top:2px}
+.toggle.off{background:var(--inset)}
+.toggle i{position:absolute;top:3px;left:19px;width:16px;height:16px;border-radius:var(--r-full);background:var(--on-accent)}
+.toggle.off i{left:3px;background:var(--tx4)}
+.subrows{margin-top:14px;border-top:1px solid var(--border-subtle)}
+.subrow{display:flex;align-items:baseline;gap:12px;padding:9px 0;border-bottom:1px solid var(--border-subtle);font-size:12px}
+.subrow .n{color:var(--tx2);width:132px;flex:none}
+.subrow .v{color:var(--tx3);flex:1}
+.subrow .k{font-family:var(--font-mono);font-size:11px;color:var(--tx4)}
+.chip{display:inline-block;font-size:10.5px;padding:1px 7px;border-radius:var(--r-full);border:1px solid var(--border-subtle);color:var(--tx3);background:var(--inset)}
+.chip.warn{color:var(--warn);border-color:rgb(var(--warn-rgb) / 0.4);background:var(--warn-bg)}
+.chip.ok{color:var(--ok);border-color:rgb(var(--ok-rgb) / 0.4);background:var(--ok-bg)}
+.chip.accent{color:var(--accent);border-color:rgb(var(--accent-rgb) / 0.4);background:var(--accent-bg)}
+.meter{display:flex;align-items:center;gap:12px;padding:10px 0;border-bottom:1px solid var(--border-subtle);font-size:12px}
+.meter b{color:var(--tx1);font-size:12.5px;width:190px;flex:none;font-weight:var(--weight-medium)}
+.meter .role{color:var(--tx3);flex:1}
+.meter .px{font-family:var(--font-mono);font-size:11.5px;color:var(--tx4)}
+.feed{margin-top:8px}
+.ev{display:flex;gap:12px;padding:11px 0;border-bottom:1px solid var(--border-subtle)}
+.ev .when{font-family:var(--font-mono);font-size:10.5px;color:var(--tx4);width:74px;flex:none;padding-top:2px}
+.ev .body{flex:1}
+.ev .hd{color:var(--tx1);font-size:12.5px}
+.ev .why{color:var(--tx3);font-size:11.5px;margin-top:3px}
+.ev .why em{color:var(--tx4);font-style:normal;font-family:var(--font-mono);font-size:10.5px}
+.empty{color:var(--tx4);font-size:12px;padding:22px 0;text-align:center}
+.conv{background:var(--card);border:1px solid var(--border-subtle);border-radius:var(--r-lg);padding:16px 18px;margin-top:12px}
+.pill{display:inline-flex;align-items:center;gap:6px;font-size:11px;padding:2px 9px;border-radius:var(--r-full);background:var(--inset);color:var(--tx3);border:1px solid var(--border-subtle)}
+.away{font-size:11.5px;color:var(--tx4);font-family:var(--font-mono);padding:8px 0}
 </style>
 </head>
 <body><div class="wrap"><div class="frame">
   <b style="color:var(--tx1);font-size:13.5px">Subscription windows</b>
-  <p style="font-size:11.5px;color:var(--tx4);margin:2px 0 12px">Forecast from your recent usage. Tick = forecast at reset (hidden until enough history).</p>
+  <p style="font-size:11.5px;color:var(--tx4);margin:2px 0 12px">Forecast from your recent usage. Tick = forecast at reset (hidden until enough history).
+    <span style="color:var(--tx4)">Pressure chip = how far ahead of pace this window is right now (phase 2).</span></p>
   <div class="wins">
     <div class="win"><div class="t"><b>Claude Max — weekly</b><span>resets Sun 09:00</span></div>
       <div class="gauge"><span class="fill" style="width:71%;background:var(--warn)"></span><span class="fc warn" style="left:88%"></span></div>
-      <div class="meta"><span>71% used</span><span>forecast 88%</span></div></div>
+      <div class="meta"><span>71% used</span><span>forecast 88%</span></div>
+      <div style="margin-top:8px"><span class="chip warn">+23 pts ahead of pace</span></div></div>
     <div class="win"><div class="t"><b>Claude Max — 5h session</b><span>resets 17:40</span></div>
       <div class="gauge"><span class="fill" style="width:34%;background:var(--ok)"></span><span class="fc" style="left:52%"></span></div>
-      <div class="meta"><span>34% used</span><span>forecast 52%</span></div></div>
+      <div class="meta"><span>34% used</span><span>forecast 52%</span></div>
+      <div style="margin-top:8px"><span class="chip ok">on pace</span></div></div>
     <div class="win"><div class="t"><b>Kimi — weekly</b><span>resets Wed 00:00</span></div>
       <div class="gauge"><span class="fill" style="width:18%;background:var(--ok)"></span></div>
-      <div class="meta"><span>18% used</span><span>gathering history…</span></div></div>
+      <div class="meta"><span>18% used</span><span>gathering history…</span></div>
+      <div style="margin-top:8px"><span class="chip">no pressure signal yet</span></div></div>
   </div>
   <div style="height:22px"></div>
   <b style="color:var(--tx1);font-size:13.5px">Token consumption — with &amp; without optimization</b>
@@ -70,4 +110,69 @@ body{margin:0;background:var(--canvas);color:var(--tx2);font-family:var(--font-s
     <div class="stat"><div class="l">Cost / turn</div><div class="v">$0.31</div><div class="d">30d average</div></div>
     <div class="stat"><div class="l">Sessions</div><div class="v">63</div><div class="d">30d</div></div>
   </div>
-</div></div></body></html>
+
+  <!-- ===================== PHASE 2 ADDITIONS ===================== -->
+
+  <div class="phase">Metered endpoints</div>
+  <p style="font-size:11.5px;color:var(--tx4);margin:0 0 6px">Pay-per-token endpoints have no window and never reset, so there is nothing to fill —
+    only a role and the price at which they beat the subscription. Deliberately a slim row, not a gauge.</p>
+  <div class="meter"><b>OpenAI · gpt-5.2</b><span class="role">fallback when the weekly window is over pace</span><span class="px">$2.40 / Mtok blended · beats sub above 74% pace</span></div>
+  <div class="meter"><b>Groq · llama-4-70b</b><span class="role">explore + title work</span><span class="px">$0.31 / Mtok blended · always cheaper</span></div>
+  <div class="meter" style="border-bottom:none"><b>Local · qwen3-32b</b><span class="role">not routed — quality floor</span><span class="px">$0.00 / Mtok · below the build floor</span></div>
+</div>
+
+<div class="frame" style="margin-top:20px">
+  <div class="sw">
+    <div class="txt">
+      <b>Manta optimized token usage</b>
+      <p>Manta trims, paces and compacts your conversations to make a plan last longer. It never changes which model you picked by hand.
+        Everything it changes is listed below and in the activity log.</p>
+    </div>
+    <div class="toggle"><i></i></div>
+  </div>
+  <div class="subrows">
+    <div class="subrow"><span class="n">Trimming</span><span class="v">Old tool output is replaced by a one-line placeholder after 12 newer tool uses. Last 40k tokens are never touched.</span><span class="k">−18% sent</span></div>
+    <div class="subrow"><span class="n">Pacing</span><span class="v">Cheaper models while a plan window is ahead of pace. Build and plan work keeps its quality floor.</span><span class="k">eco · +23 pts</span></div>
+    <div class="subrow"><span class="n">Compacting</span><span class="v">Long idle conversations are summarized in the background, before you come back to them.</span><span class="k">6 of 7 in background</span></div>
+    <div class="subrow" style="border-bottom:none"><span class="n">Prompt cache</span><span class="v">1 hour, measured. Reads are billed at 0.1×.</span><span class="k">74% hit</span></div>
+  </div>
+  <p style="font-size:11px;color:var(--tx4);margin:12px 0 0">Rows appear only for subsystems that are actually shipped and running. A row is never rendered for something that does nothing.</p>
+</div>
+
+<div class="frame" style="margin-top:20px">
+  <b style="color:var(--tx1);font-size:13.5px">Activity</b>
+  <p style="font-size:11.5px;color:var(--tx4);margin:2px 0 0">Every parameter change the optimizer made on its own, with the evidence it used. Rolled-back entries stay — that is the point.</p>
+  <div class="feed">
+    <div class="ev"><span class="when">14:02</span><div class="body">
+      <div class="hd">Kept — trim threshold 16 → 12 tool uses</div>
+      <div class="why">Cache hit held at 74% over 62 turns and re-fetch churn stayed at 0.4%.
+        <em>evidence: 62 turns · hit 74.1% (was 74.6%) · churn 0.4% · cost/turn −6%</em></div></div></div>
+    <div class="ev"><span class="when">Mon 09:41</span><div class="body">
+      <div class="hd">Rolled back — protected tail 40k → 24k</div>
+      <div class="why">Re-fetch churn rose to 3.1% of masked parts, over the 2% guardrail. Reverted after 41 minutes; the old value is back.
+        <em>evidence: 38 turns · churn 3.1% (limit 2%) · 12 tools re-run · reverted 10:22</em></div></div></div>
+    <div class="ev" style="border-bottom:none"><span class="when">Sun 22:15</span><div class="body">
+      <div class="hd">Kept — eco level 0 → 2 while the weekly window is over pace</div>
+      <div class="why">Weekly window ran 23 points ahead of pace with 4 days left. Explore and general work moved down one tier; build and plan kept their floor.
+        <em>evidence: deficit +23 pts · forecast 88% at reset · build/plan floor unchanged</em></div></div></div>
+  </div>
+</div>
+
+<div class="frame" style="margin-top:20px">
+  <b style="color:var(--tx1);font-size:13.5px">Activity — empty state</b>
+  <div class="empty">Nothing changed yet. Manta needs a few days of your usage before it starts tuning anything.</div>
+</div>
+
+<div class="phase">In-conversation surfaces</div>
+<div class="conv">
+  <div style="font-size:11px;color:var(--tx4);margin-bottom:8px">Composer meta row — the saving pill sits next to the usage dial</div>
+  <span class="pill">↓ 18% <span style="color:var(--tx4)">this conversation</span></span>
+  <span class="pill accent" style="margin-left:8px">Auto <span style="color:var(--tx4)">· eco</span></span>
+  <p style="font-size:11px;color:var(--tx4);margin:10px 0 0">The <b style="color:var(--tx3)">· eco</b> suffix appears on the Auto chip only while a window is over pace, and disappears on its own when the window resets. It is not a mode the user sets.</p>
+</div>
+<div class="conv">
+  <div style="font-size:11px;color:var(--tx4);margin-bottom:6px">Transcript — one line, where the compaction happened</div>
+  <div class="away">⟳ Compacted while you were away · 128k → 31k</div>
+</div>
+
+</div></body></html>


### PR DESCRIPTION
Spec/docs only — no production code. Prepares the committed artifacts the BET-1342 phase-2 stages implement against.

## What

**`docs/optimizer/mockup.html`** — extended from the phase-1 dashboard to the v2 full-system layout, so stage 5 (BET-1347) implements against a committed artifact the same way BET-1337 did in phase 1:
- the switch card ("Manta optimized token usage") with read-only status sub-rows
- pressure chips on the subscription-window cards
- the metered-endpoints **slim row** — role + crossover price, deliberately no gauge (a metered endpoint has no window and never resets, so there is nothing to fill)
- the activity feed with evidence lines, rolled-back entries, and its empty state
- the in-conversation surfaces: the `↓ N%` saving pill, the `· eco` suffix on the Auto chip, and the `⟳ Compacted while you were away` transcript line

Tokens only — no hex outside `tokens.css`.

**`AGENTS.md`** — a "Manta Optimizer" section covering what phase 1 shipped, the metrics-always-on/actuation-gated split, and the load-bearing phase-2 rule:

> The switch does NOT gate Auto routing. `routingActive()` keys off `modelRouting.preset`, which `local.mjs` defaults to `"balanced"`, so Auto is active on every box today. The new switch is default OFF — wiring it into `routingActive()` would turn Auto off for every existing user on upgrade.

## Issues
Epic BET-1342, stages BET-1343 … BET-1347.