### PR TITLE
fix(mobile): derive session-list needs-you dot from the box's pending questions/permissions (BET-1348)

### DIFF
--- a/mobile/native/MantaUI/MantaEventStore.swift
+++ b/mobile/native/MantaUI/MantaEventStore.swift
@@ -278,10 +278,12 @@ enum MantaStreamRouter {
 
     /// Replace running state across ALL known sessions from the box's
     /// authoritative set. A session absent from the set is not running.
-    /// Only `running` / `runningSince` are touched — `turnComplete`, `chunks`
-    /// and `tools` are deliberately left alone (turn retirement + tool rows are
-    /// owned by the reconnect transcript refetch; synthesising `turnComplete`
-    /// here would double-fire the completion haptic).
+    /// `running` / `runningSince` are reconciled as authoritative, AND
+    /// `questions` / `permissions` are cleared so the snapshot (which only
+    /// re-emits non-empty lists) can reconcile pending cards (BET-1348).
+    /// `turnComplete`, `chunks` and `tools` are deliberately left alone (turn
+    /// retirement + tool rows are owned by the reconnect transcript refetch;
+    /// synthesising `turnComplete` here would double-fire the completion haptic).
     static func applyingRunningSet(
         _ payload: StreamRunningSetPayload,
         to states: [String: MantaSessionStreamState]
@@ -292,6 +294,15 @@ enum MantaStreamRouter {
             let entry = bySession[sid]
             s.running = entry != nil
             s.runningSince = resolveRunningSetSince(entry, current: s.runningSince)
+            // An authoritative replay starts here (BET-1348): the box's connect
+            // snapshot only emits a `questions` / `permissions` frame for
+            // sessions whose list is NON-empty, so a card answered while the
+            // device was disconnected would otherwise stay latched forever.
+            // Clearing both makes the snapshot authoritative for pending cards,
+            // exactly as `running` is — the snapshot's own frames repopulate
+            // whatever is still pending. Same-path, correctly-ordered marker.
+            s.questions = nil
+            s.permissions = nil
             next[sid] = s
         }
         // A session the device has never seen a frame for can still be running.

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -148,7 +148,13 @@ struct MantaStreamFrame: Equatable, Sendable {
             return [:]
         }()
         // sessionId: envelope key first; when absent or empty, fall back to
-        // `payload.sessionID`, then `payload.sessionId`. First non-empty wins.
+        // `payload.sessionID`, then `payload.sessionId`, then the same two keys
+        // under `payload.properties` (the box nests it there for raw opencode
+        // events). First non-empty wins.
+        let properties: [String: JSONValue] = {
+            if case .object(let p)? = rawPayload["properties"] { return p }
+            return [:]
+        }()
         let envelopeSession = string("sessionId")
         let sessionId: String?
         if let envelopeSession, !envelopeSession.isEmpty {
@@ -156,6 +162,8 @@ struct MantaStreamFrame: Equatable, Sendable {
         } else {
             sessionId = nonEmpty("sessionID", in: rawPayload)
                 ?? nonEmpty("sessionId", in: rawPayload)
+                ?? nonEmpty("sessionID", in: properties)
+                ?? nonEmpty("sessionId", in: properties)
         }
         // eventType: `payload.type` if a non-empty string, else `payload.kind`.
         // The envelope `kind` is intentionally LEFT untouched (it stays the

--- a/mobile/native/MantaUI/MantaStreamModels.swift
+++ b/mobile/native/MantaUI/MantaStreamModels.swift
@@ -109,6 +109,13 @@ struct MantaStreamFrame: Equatable, Sendable {
     var sub: String?
     var sessionId: String?
     var payload: JSONValue?
+    /// The event's TYPE, resolved once at parse time so consumers never
+    /// re-derive it. For RAW opencode events it is `payload.type` (with a
+    /// `payload.kind` fallback for older boxes); typed `stream` frames carry
+    /// no payload-level type, so it is nil there and the `sub` drives
+    /// interpretation. This is the SINGLE place the app resolves an event's
+    /// type (BET-1348).
+    var eventType: String?
 
     var isHeartbeat: Bool { kind == "heartbeat" }
 
@@ -132,11 +139,34 @@ struct MantaStreamFrame: Equatable, Sendable {
         guard let kind = string("kind") else {
             throw MantaError.transport("event frame missing kind")
         }
+        func nonEmpty(_ key: String, in dict: [String: JSONValue]) -> String? {
+            if case .string(let s)? = dict[key], !s.isEmpty { return s }
+            return nil
+        }
+        let rawPayload: [String: JSONValue] = {
+            if case .object(let p)? = obj["payload"] { return p }
+            return [:]
+        }()
+        // sessionId: envelope key first; when absent or empty, fall back to
+        // `payload.sessionID`, then `payload.sessionId`. First non-empty wins.
+        let envelopeSession = string("sessionId")
+        let sessionId: String?
+        if let envelopeSession, !envelopeSession.isEmpty {
+            sessionId = envelopeSession
+        } else {
+            sessionId = nonEmpty("sessionID", in: rawPayload)
+                ?? nonEmpty("sessionId", in: rawPayload)
+        }
+        // eventType: `payload.type` if a non-empty string, else `payload.kind`.
+        // The envelope `kind` is intentionally LEFT untouched (it stays the
+        // box's frame kind).
+        let eventType = nonEmpty("type", in: rawPayload) ?? nonEmpty("kind", in: rawPayload)
         return MantaStreamFrame(
             kind: kind,
             sub: string("sub"),
-            sessionId: string("sessionId"),
-            payload: obj["payload"]
+            sessionId: sessionId,
+            payload: obj["payload"],
+            eventType: eventType
         )
     }
 }

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -282,7 +282,7 @@ final class SessionListStore: ObservableObject {
     /// so the row subtitle can show it. Published only when the label actually
     /// differs (mirrors the old trackAttention's BET-672 re-render guard).
     private func trackProgress(frame: MantaStreamFrame) {
-        guard let kind = frame.eventType ?? frame.kind, kind == "progress.updated", let sid = frame.sessionId else { return }
+        guard (frame.eventType ?? frame.kind) == "progress.updated", let sid = frame.sessionId else { return }
         Task { [weak self] in
             let label = await self?.workingProgressLabel(sessionID: sid)
             guard let self else { return }

--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -81,7 +81,6 @@ final class SessionListStore: ObservableObject {
     private let api: MantaAPIClient
     private let mutations: SessionListMutationAPI
     private let eventStore: MantaEventStore
-    private var attentionSessions: Set<String> = []
     /// opencodeSessionID → lightweight per-session metadata resolved from the
     /// opencode session list (BET-897). One dictionary replaces the old separate
     /// `modelLabels` map and feeds both the running subtitle and the new idle
@@ -108,7 +107,6 @@ final class SessionListStore: ObservableObject {
         self.eventStore = eventStore
         self.loadConfig()
         self.eventStore.addRawFrameHandler { [weak self] frame in
-            self?.trackAttention(frame: frame)
             self?.trackProgress(frame: frame)
         }
     }
@@ -251,14 +249,17 @@ final class SessionListStore: ObservableObject {
     // MARK: - Row status (reads the S1b store)
 
     /// The window's live status, merging the box's stream state with the
-    /// attention set. Pure inputs; presentation decided in SessionModels.
+    /// attention derived from its pending questions/permissions. Pure inputs;
+    /// presentation decided in SessionModels.
     func rowStatus(for window: MantaWindow) -> SessionRowStatus {
         let sid = window.opencodeSessionId ?? ""
         let stream = eventStore.sessionStates[sid]
         let running = stream?.running == true
+        let attention = !(stream?.questions?.questions.isEmpty ?? true)
+            || !(stream?.permissions?.permissions.isEmpty ?? true)
         return SessionRowStatus(
             running: running,
-            attention: attentionSessions.contains(sid),
+            attention: attention,
             backgroundJobs: backgroundJobsBySession[sid] ?? 0,
             modelLabel: sessionMeta[sid]?.modelLabel,
             progressLabel: progressBySession[sid],
@@ -274,48 +275,14 @@ final class SessionListStore: ObservableObject {
         visibleWindows(in: project).filter { rowStatus(for: $0).running }.count
     }
 
-    // MARK: - Attention (needs-you dot / subtitle)
-
-    /// Track `question.*` / `permission.*` request/response frames as a per-
-    /// session "needs you" signal for the §7.1 warn dot + §7.1a subtitle.
-    private func trackAttention(frame: MantaStreamFrame) {
-        guard let kind = kind(frame), let sid = frame.sessionId else { return }
-        // Compute the new value first and publish ONLY when it actually differs
-        // from the stored one (BET-672): the raw frame surface carries a row
-        // for every raw event, so an unconditional `objectWillChange.send()`
-        // re-rendered the whole session list per frame even when the attention
-        // set did not change.
-        var changed = false
-        if kind == "question.asked" || kind == "permission.asked" {
-            if !attentionSessions.contains(sid) {
-                attentionSessions.insert(sid)
-                changed = true
-            }
-        } else if kind == "question.replied" || kind == "question.rejected"
-            || kind == "permission.replied" || kind == "permission.rejected" {
-            changed = attentionSessions.remove(sid) != nil
-        }
-        if changed { objectWillChange.send() }
-    }
-
-    private func kind(_ frame: MantaStreamFrame) -> String? {
-        guard case .object(let obj) = frame.payload ?? .object([:]) else {
-            return frame.kind
-        }
-        // Raw opencode events carry `kind` at the top frame level; fall back
-        // to the envelope kind.
-        if case .string(let s)? = obj["kind"] { return s }
-        return frame.kind
-    }
-
     // MARK: - Progress (BET-791)
 
     /// Track `progress.updated` frames: refetch that session's progress record
     /// (the frame carries only a {sessionID} hint) and stash the working label
     /// so the row subtitle can show it. Published only when the label actually
-    /// differs (mirrors trackAttention's BET-672 re-render guard).
+    /// differs (mirrors the old trackAttention's BET-672 re-render guard).
     private func trackProgress(frame: MantaStreamFrame) {
-        guard kind(frame) == "progress.updated", let sid = frame.sessionId else { return }
+        guard let kind = frame.eventType ?? frame.kind, kind == "progress.updated", let sid = frame.sessionId else { return }
         Task { [weak self] in
             let label = await self?.workingProgressLabel(sessionID: sid)
             guard let self else { return }
@@ -492,7 +459,6 @@ final class SessionListStore: ObservableObject {
         loadError = nil
         loadedOnce = false
         pendingDeletes = [:]
-        attentionSessions = []
         sessionMeta = [:]
         progressBySession = [:]
         delegateJobs = [:]

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -122,9 +122,16 @@ final class MantaEventStreamModelTests: XCTestCase {
     /// Raw opencode events carry the session id inside the payload (the box
     /// envelope has none). The parser must fall back to it.
     func testParseTakesSessionIDFromPayloadWhenEnvelopeHasNone() throws {
-        let f = try frame(#"{"kind":"opencode","payload":{"type":"question.asked","sessionID":"ses_payload"}}"#)
+        let f = try frame(#"{"kind":"opencode","payload":{"sessionID":"ses_payload"}}"#)
         XCTAssertEqual(f.sessionId, "ses_payload")
         XCTAssertNil(f.eventType)
+    }
+
+    /// The session id can also sit under payload.properties (the box nests it
+    /// there for raw opencode events). The parser must descend into it.
+    func testParseTakesSessionIDFromPayloadProperties() throws {
+        let f = try frame(#"{"kind":"opencode","payload":{"properties":{"sessionID":"ses_1"}}}"#)
+        XCTAssertEqual(f.sessionId, "ses_1")
     }
 
     /// The envelope key wins when both are present.

--- a/mobile/native/MantaUITests/MantaEventStreamTests.swift
+++ b/mobile/native/MantaUITests/MantaEventStreamTests.swift
@@ -117,6 +117,56 @@ final class MantaEventStreamModelTests: XCTestCase {
         XCTAssertNil(f.payload)
     }
 
+    // MARK: - sessionId / eventType resolution (BET-1348)
+
+    /// Raw opencode events carry the session id inside the payload (the box
+    /// envelope has none). The parser must fall back to it.
+    func testParseTakesSessionIDFromPayloadWhenEnvelopeHasNone() throws {
+        let f = try frame(#"{"kind":"opencode","payload":{"type":"question.asked","sessionID":"ses_payload"}}"#)
+        XCTAssertEqual(f.sessionId, "ses_payload")
+        XCTAssertNil(f.eventType)
+    }
+
+    /// The envelope key wins when both are present.
+    func testParsePrefersEnvelopeSessionIDOverPayload() throws {
+        let f = try frame(#"{"kind":"stream","sessionId":"ses_env","payload":{"sessionID":"ses_payload"}}"#)
+        XCTAssertEqual(f.sessionId, "ses_env")
+    }
+
+    /// No session id anywhere -> nil, not a crash.
+    func testParseReturnsNilSessionIDWhenNeitherExists() throws {
+        let f = try frame(#"{"kind":"opencode","payload":{"type":"question.asked"}}"#)
+        XCTAssertNil(f.sessionId)
+    }
+
+    /// The event type lives at payload.type for raw opencode frames.
+    func testParseResolvesEventTypeFromPayloadType() throws {
+        let f = try frame(#"{"kind":"opencode","payload":{"type":"question.asked"}}"#)
+        XCTAssertEqual(f.eventType, "question.asked")
+    }
+
+    /// Older boxes put the type at payload.kind; that is the fallback.
+    func testParseFallsBackEventTypeToPayloadKind() throws {
+        let f = try frame(#"{"kind":"opencode","payload":{"kind":"permission.asked"}}"#)
+        XCTAssertEqual(f.eventType, "permission.asked")
+    }
+
+    /// No type anywhere -> eventType nil.
+    func testParseReturnsNilEventTypeWhenNeitherExists() throws {
+        let f = try frame(#"{"kind":"opencode","payload":{"properties":{"foo":"bar"}}}"#)
+        XCTAssertNil(f.eventType)
+    }
+
+    /// REGRESSION — the literal frame that ships the needs-you dot. Both the
+    /// session id (from payload.sessionID) and the type (from payload.type)
+    /// must resolve, because the box envelope carries neither.
+    func testParseQuestionAskedFrameResolvesSessionAndType() throws {
+        let f = try frame(#"{"kind":"opencode","payload":{"type":"question.asked","properties":{"sessionID":"ses_1"}}}"#)
+        XCTAssertEqual(f.sessionId, "ses_1")
+        XCTAssertEqual(f.eventType, "question.asked")
+        XCTAssertEqual(f.kind, "opencode")
+    }
+
     func testParsesRunningPayload() throws {
         let f = try frame(#"{"kind":"stream","sub":"running","sessionId":"ses_1","payload":{"running":true}}"#)
         let p = try XCTUnwrap(f.decodedPayload(StreamRunningPayload.self))
@@ -521,6 +571,36 @@ final class MantaEventStreamRouterTests: XCTestCase {
         )
         XCTAssertEqual(next["ses_1"]?.running, true)
         XCTAssertEqual(next["ses_1"]?.runningSince, Date(timeIntervalSince1970: 1234))
+    }
+
+    /// REGRESSION (BET-1348): the connect snapshot re-emits a `questions` /
+    /// `permissions` frame only for sessions whose list is NON-empty, so a
+    /// card answered while the device was disconnected would otherwise stay
+    /// latched forever. The running set must clear both so the snapshot is
+    /// authoritative for pending cards — on a session absent from the set.
+    func testRunningSetClearsQuestionsAndPermissionsAbsentFromTheSet() {
+        var s = MantaSessionStreamState(sessionId: "ses_1")
+        s.questions = StreamQuestionsPayload(questions: [])
+        s.permissions = StreamPermissionsPayload(permissions: [])
+        let next = MantaStreamRouter.applyingRunningSet(
+            StreamRunningSetPayload(sessions: []), to: ["ses_1": s]
+        )
+        XCTAssertNil(next["ses_1"]?.questions)
+        XCTAssertNil(next["ses_1"]?.permissions)
+    }
+
+    /// ... and on a session PRESENT in the running set (its still-pending
+    /// cards are restored by the snapshot's own frames that follow).
+    func testRunningSetClearsQuestionsAndPermissionsPresentInTheSet() {
+        var s = MantaSessionStreamState(sessionId: "ses_1")
+        s.questions = StreamQuestionsPayload(questions: [])
+        s.permissions = StreamPermissionsPayload(permissions: [])
+        let next = MantaStreamRouter.applyingRunningSet(
+            StreamRunningSetPayload(sessions: [.init(sessionId: "ses_1", since: nil, type: nil)]),
+            to: ["ses_1": s]
+        )
+        XCTAssertNil(next["ses_1"]?.questions)
+        XCTAssertNil(next["ses_1"]?.permissions)
     }
 
     // MARK: - Subagent upsert (BET-672)


### PR DESCRIPTION
## What

The iOS session list's "needs-you" dot never rendered: `SessionListStore` watched raw `question.asked` / `permission.asked` frames and required an envelope-level `sessionId` + the type at `payload.kind`, but the box publishes these as `{"kind":"opencode","payload":{"type":"question.asked","properties":{"sessionID":"ses_…"}}}` — no envelope `sessionId`, type at `payload.type`. Both guards failed on every frame, so `attentionSessions` stayed empty and (same root cause) `trackProgress` filtered out live `progress.updated` frames too.

Fixed by deriving attention from state the box already maintains, clears on answer, and replays on reconnect — with less code.

## Changes (all under `mobile/native/`)

1. **`MantaStreamModels.swift` — resolve once, in the frame parser.** `MantaStreamFrame` now resolves `sessionId` (envelope key first, then `payload.sessionID`, then `payload.sessionId`) and a new `eventType` (`payload.type`, else `payload.kind`) in `parse`. Deleted the store's private `kind(_:)` helper and its call sites; `trackProgress` reads `frame.eventType ?? frame.kind`. Exactly one place in the app resolves an event's type now.
2. **`SessionListStore.swift` — delete the attention set; derive instead.** Removed `attentionSessions`, `trackAttention(frame:)`, its handler registration, and the reset line. `rowStatus(for:)` computes attention as "any pending questions **or** permissions" from `eventStore.sessionStates[sid]`.
3. **`MantaEventStore.swift` — connect snapshot authoritative for pending cards.** `applyingRunningSet` clears `questions` and `permissions` on every session so a card answered while disconnected can't stay latched (the snapshot re-emits frames only for non-empty lists). Race-free by construction: the `runningSet` frame is index 0 of every connect snapshot on the same frame path.

## Risks / notes

- Expected correct side effect (deliberately not hidden): a question pending in an *open* chat screen when the socket reconnects may blank for one render before the snapshot's `questions` frame restores it.
- No "clear attention when the session is opened" rule was added — the derived value is the truth (dot goes out when answered, not when glanced at). No latch/cache/override on top.

## Verification

No Swift toolchain on the Linux box — cannot build or run here. Handing to `macos` to run the `ios-mantaui` plugin `action: "test-unit"` on this branch. Tests added in `mobile/native/MantaUITests/MantaEventStreamTests.swift`:
- `parse` sessionId from `payload.sessionID`, envelope precedence, nil when neither.
- `parse` eventType from `payload.type`, `payload.kind` fallback, nil when neither.
- Regression: the literal `{"kind":"opencode","payload":{"type":"question.asked","properties":{"sessionID":"ses_1"}}}` parses to `sessionId == "ses_1"`, `eventType == "question.asked"`.
- `applyingRunningSet` clears `questions`/`permissions` both for a session absent from and present in the running set.

Base: origin/main @ `533fad26`