### PR TITLE
Desktop: quote a transcript selection into the composer (BET-1351)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -105,11 +105,13 @@ import { CardStack, type PinnedCardRender } from "./components/CardStack";
 import { useSessionResources } from "./hooks/useSessionResources";
 import { useInputHistory } from "./hooks/useInputHistory";
 import { useTranscriptState } from "./hooks/useTranscriptState";
+import { useTranscriptSelection } from "./hooks/useTranscriptSelection";
 import { useSseBus } from "./hooks/useSseBus";
 import { useVoice } from "./hooks/useVoice";
 import { useTypeahead } from "./hooks/useTypeahead";
 import { VoicePlaybackProvider } from "./hooks/useVoicePlayback";
 import { Transcript } from "./Transcript";
+import { QuoteToolbar } from "./QuoteToolbar";
 import { Composer } from "./Composer";
 import { SessionHeader } from "./SessionHeader";
 import { Modal } from "./Modal";
@@ -301,6 +303,7 @@ export function ChatPanel({
 
   const projects = useStore((s) => s.projects);
   const setActive = useStore((s) => s.setActive);
+  const activateWindow = useStore((s) => s.activateWindow);
 
   const inputRef = useRef<HTMLTextAreaElement>(null);
   // Per-child debounce timers for refetching child transcripts when their
@@ -1780,25 +1783,39 @@ export function ChatPanel({
   // project list automatically via the next refresh / sync delta call.
   const refresh = useStore((s) => s.refresh);
 
-  const forkSession = useCallback(async () => {
-    if (!tmuxSession) return;
-    setSendError(null);
-    try {
-      const baseName = windowIndex != null ? `fork-${windowIndex}` : "fork";
-      const windowName = `${baseName}-${Date.now().toString(36).slice(-4)}`;
-      await window.api.opencodeForkSession({
-        sessionId,
-        sessionName: tmuxSession,
-        windowName,
-        // Empty string signals the main handler to resolve from the project's
-        // stored defaultCwd (see resolveProjectCwd in src/main/index.ts).
-        cwd: cwd ?? "",
-      });
-      await refresh();
-    } catch (e) {
-      setSendError(String((e as Error)?.message ?? e));
-    }
-  }, [sessionId, tmuxSession, windowIndex, cwd, refresh]);
+  const forkSession = useCallback(
+    async (seedText?: string) => {
+      if (!tmuxSession) return;
+      setSendError(null);
+      try {
+        const baseName = windowIndex != null ? `fork-${windowIndex}` : "fork";
+        const windowName = `${baseName}-${Date.now().toString(36).slice(-4)}`;
+        const { newSessionId, projects } = await window.api.opencodeForkSession({
+          sessionId,
+          sessionName: tmuxSession,
+          windowName,
+          // Empty string signals the main handler to resolve from the project's
+          // stored defaultCwd (see resolveProjectCwd in src/main/index.ts).
+          cwd: cwd ?? "",
+        });
+        await refresh();
+        // BET-1351 "Quote in new session": seed the fork's composer with the
+        // quote (a truncated pointer only resolvable in a session that carries
+        // the transcript it points into) and land the user in the fork. Same
+        // activate-then-seed pattern as InboxPalette's "Start a session".
+        if (seedText) {
+          useStore.getState().setSeedPrompt({ sid: newSessionId, text: seedText });
+          const win = projects
+            .flatMap((p) => p.windows)
+            .find((w) => w.opencodeSessionId === newSessionId);
+          if (win) await activateWindow(tmuxSession, win.index);
+        }
+      } catch (e) {
+        setSendError(String((e as Error)?.message ?? e));
+      }
+    },
+    [sessionId, tmuxSession, windowIndex, cwd, refresh, activateWindow],
+  );
 
   const compactSession = useCallback(async () => {
     setSendError(null);
@@ -2298,6 +2315,37 @@ export function ChatPanel({
     tmuxSession,
     windowIndex,
     historyEpoch,
+  });
+
+  // BET-1351 — transcript quote bar. The hook is event-driven/one-shot: it
+  // shows on pointerup / shift-arrow keyup, captures the selection position
+  // once, and hides on the next scroll / pointerdown / Escape / action / session
+  // change (see useTranscriptSelection). "Quote" prepends the blockquote line
+  // to the composer; "Quote in new session" forks and seeds the fork's composer.
+  const quoteToolbarRef = useRef<HTMLDivElement | null>(null);
+  const { quote, quoteNow, quoteNewSessionNow } = useTranscriptSelection({
+    scrollerRef: scrollerElRef,
+    toolbarRef: quoteToolbarRef,
+    sessionId,
+    onQuote: useCallback(
+      (block: string) => {
+        updateInputWithHistoryReset(block + input);
+        requestAnimationFrame(() => {
+          const el = inputRef.current;
+          if (!el) return;
+          el.focus();
+          const end = (block + input).length;
+          el.setSelectionRange(end, end);
+        });
+      },
+      [updateInputWithHistoryReset, input],
+    ),
+    onQuoteNewSession: useCallback(
+      (block: string) => {
+        void forkSession(block);
+      },
+      [forkSession],
+    ),
   });
 
   // Model line: last assistant message's modelID (provider/model).
@@ -3216,6 +3264,12 @@ export function ChatPanel({
           jump-to-latest button floats at the BOTTOM OF THE TRANSCRIPT — above
           the card stack and the composer, both of which change height. */}
       <div className="relative flex-1 min-h-0 flex flex-col">
+        <QuoteToolbar
+          quote={quote}
+          toolbarRef={quoteToolbarRef}
+          onQuote={quoteNow}
+          onQuoteNewSession={quoteNewSessionNow}
+        />
         <VoicePlaybackProvider active={isActive}>
           <Transcript
             messages={messages}

--- a/src/renderer/QuoteToolbar.tsx
+++ b/src/renderer/QuoteToolbar.tsx
@@ -7,7 +7,7 @@
 // whose overflow-x-hidden would clip it. It is deliberately NOT built on
 // Popover: Popover needs a real anchorRef element and a selection only has a
 // rectangle.
-import { useLayoutEffect, useRef, useState } from "react";
+import { useLayoutEffect, useState } from "react";
 import type { QuoteSelection } from "./hooks/useTranscriptSelection";
 
 export function QuoteToolbar(props: {
@@ -39,7 +39,7 @@ export function QuoteToolbar(props: {
 
   return (
     <div
-      ref={toolbarRef}
+      ref={toolbarRef as React.RefObject<HTMLDivElement>}
       className="manta-quote-toolbar"
       style={pos ? { top: pos.top, left: pos.left } : { top: -9999, left: -9999 }}
       role="toolbar"

--- a/src/renderer/QuoteToolbar.tsx
+++ b/src/renderer/QuoteToolbar.tsx
@@ -1,0 +1,56 @@
+// QuoteToolbar (BET-1351) — the floating action bar shown once the user
+// finishes selecting text in the transcript. "Quote" seeds the current
+// composer; "Quote in new session" forks the session with the quote seeded.
+//
+// position:fixed + clamped into the viewport (same arithmetic as Popover) and
+// rendered from ChatPanel's transcript wrapper — NOT inside the Virtuoso root,
+// whose overflow-x-hidden would clip it. It is deliberately NOT built on
+// Popover: Popover needs a real anchorRef element and a selection only has a
+// rectangle.
+import { useLayoutEffect, useRef, useState } from "react";
+import type { QuoteSelection } from "./hooks/useTranscriptSelection";
+
+export function QuoteToolbar(props: {
+  quote: QuoteSelection | null;
+  toolbarRef: React.RefObject<HTMLDivElement | null>;
+  onQuote: () => void;
+  onQuoteNewSession: () => void;
+}) {
+  const { quote, toolbarRef, onQuote, onQuoteNewSession } = props;
+  const [pos, setPos] = useState<{ top: number; left: number } | null>(null);
+
+  useLayoutEffect(() => {
+    if (!quote) {
+      setPos(null);
+      return;
+    }
+    const el = toolbarRef.current;
+    if (!el) return;
+    const w = el.offsetWidth || 0;
+    const h = el.offsetHeight || 0;
+    const top = Math.max(8, Math.min(quote.top - h - 4, window.innerHeight - h - 8));
+    const left = Math.max(8, Math.min(quote.left, window.innerWidth - w - 8));
+    setPos((prev) =>
+      prev && prev.top === top && prev.left === left ? prev : { top, left },
+    );
+  }, [quote, toolbarRef]);
+
+  if (!quote) return null;
+
+  return (
+    <div
+      ref={toolbarRef}
+      className="manta-quote-toolbar"
+      style={pos ? { top: pos.top, left: pos.left } : { top: -9999, left: -9999 }}
+      role="toolbar"
+      aria-label="Quote selection"
+    >
+      <button type="button" className="text-label" onClick={onQuote}>
+        Quote
+      </button>
+      <button type="button" className="text-label" onClick={onQuoteNewSession}>
+        Quote in new session
+      </button>
+    </div>
+  );
+}

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -696,8 +696,8 @@ describe("truncateMiddle", () => {
     const text = "a".repeat(QUOTE_MAX + 10);
     const out = truncateMiddle(text, QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL);
     expect(out).toContain(" \u2026 ");
-    expect(out).not.toContain("… ");
-    expect(out).not.toContain(" …");
+    expect(out.split("\u2026")).toHaveLength(2);
+    expect(out).not.toContain("...");
   });
 });
 

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -29,6 +29,11 @@ import {
   detectCommandFromText,
   MIN_COMMAND_PREFIX_LEN,
   formatAge,
+  QUOTE_MAX,
+  QUOTE_HEAD,
+  QUOTE_TAIL,
+  truncateMiddle,
+  buildQuoteBlock,
   shouldAbortForQueuedDrain,
   isToolStepBoundary,
   isDrainAbortError,
@@ -667,6 +672,58 @@ describe("formatAge", () => {
   it("treats negative/NaN input as 'now'", () => {
     expect(formatAge(-1000)).toBe("now");
     expect(formatAge(NaN)).toBe("now");
+  });
+});
+
+// ===== truncateMiddle / buildQuoteBlock (BET-1351) =====
+
+describe("truncateMiddle", () => {
+  it("returns text unchanged at and below max", () => {
+    const text = "a".repeat(QUOTE_MAX);
+    expect(truncateMiddle(text, QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL)).toBe(text);
+    expect(truncateMiddle("short", QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL)).toBe("short");
+  });
+
+  it("produces `head … tail` above max and is shorter than the input", () => {
+    const text = "x".repeat(QUOTE_MAX + 50);
+    const out = truncateMiddle(text, QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL);
+    expect(out).toBe(`${"x".repeat(QUOTE_HEAD)} … ${"x".repeat(QUOTE_TAIL)}`);
+    expect(out.length).toBeLessThan(text.length);
+    expect(out.length).toBeLessThanOrEqual(QUOTE_MAX);
+  });
+
+  it("uses a single U+2026 with one space each side", () => {
+    const text = "a".repeat(QUOTE_MAX + 10);
+    const out = truncateMiddle(text, QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL);
+    expect(out).toContain(" \u2026 ");
+    expect(out).not.toContain("… ");
+    expect(out).not.toContain(" …");
+  });
+});
+
+describe("buildQuoteBlock", () => {
+  it("collapses newlines and runs of spaces to single spaces and trims", () => {
+    const out = buildQuoteBlock("  hello   world\n\nsecond  line  ", QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL);
+    expect(out).toBe("> hello world second line\n\n");
+  });
+
+  it("returns null for empty and whitespace-only input", () => {
+    expect(buildQuoteBlock("", QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL)).toBeNull();
+    expect(buildQuoteBlock("   \n\t  ", QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL)).toBeNull();
+  });
+
+  it("prefixes exactly '> ' and ends with exactly '\\n\\n'", () => {
+    const out = buildQuoteBlock("hello", QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL);
+    expect(out).toMatch(/^> /);
+    expect(out!.endsWith("\n\n")).toBe(true);
+  });
+
+  it("reduces a long multi-paragraph selection to one line with exactly one ellipsis", () => {
+    const paragraph = "word ".repeat(120).trim();
+    const multi = `${paragraph}\n\n${paragraph}`;
+    const out = buildQuoteBlock(multi, QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL)!;
+    expect(out.trim().split("\n")).toHaveLength(1);
+    expect(out.split(" \u2026 ")).toHaveLength(2);
   });
 });
 

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -419,6 +419,42 @@ export function formatAge(elapsedMs: number): string {
   return `${days}d`;
 }
 
+// ===== Quote selection → composer (BET-1351) =====
+//
+// Normalises a transcript selection into ONE middle-truncated blockquote line
+// (`"> ...\n\n"`) that gets PREPENDED to whatever is already in the composer.
+// There is deliberately no hidden payload / chip / extra composer state: the
+// model already holds the full transcript in its context, so the quote only
+// has to be a locatable pointer. Collapsing to a single line also kills the
+// class of bug where a selection spanning several flex-laid-out paragraph
+// blocks serialises without its newlines.
+
+/** Longest quoted line, in chars. */
+export const QUOTE_MAX = 240;
+/** Chars kept from the head of a quote that exceeds `QUOTE_MAX`. */
+export const QUOTE_HEAD = 140;
+/** Chars kept from the tail of a quote that exceeds `QUOTE_MAX`. */
+export const QUOTE_TAIL = 80;
+
+/** "beginning … end". Returns `text` unchanged when it fits within `max`. */
+export function truncateMiddle(text: string, max: number, head: number, tail: number): string {
+  if (text.length <= max) return text;
+  return text.slice(0, head).trimEnd() + " \u2026 " + text.slice(text.length - tail).trimStart();
+}
+
+/**
+ * Selection → the exact string to prepend to the composer, or null when the
+ * selection has no usable text. Whitespace runs collapse to a single space,
+ * the result is trimmed, truncated, then prefixed with `"> "` and suffixed
+ * with a blank line (`"\n\n"`).
+ */
+export function buildQuoteBlock(selection: string, max: number, head: number, tail: number): string | null {
+  const collapsed = selection.replace(/\s+/g, " ").trim();
+  if (!collapsed) return null;
+  const truncated = truncateMiddle(collapsed, max, head, tail);
+  return "> " + truncated + "\n\n";
+}
+
 export type TypeaheadCommandRow = {
   name: string;
   description?: string;

--- a/src/renderer/hooks/useTranscriptSelection.ts
+++ b/src/renderer/hooks/useTranscriptSelection.ts
@@ -1,0 +1,155 @@
+// useTranscriptSelection (BET-1351) — one-shot transcript quote detection.
+//
+// Event-driven, NOT a live tracker: it shows the quote bar the moment the
+// user FINISHES selecting text (pointerup / shift-arrow keyup) and hides on
+// the next gesture, scroll, Escape, an action firing, or a session change.
+//
+// Why not a `selectionchange` live tracker: the transcript is virtualised
+// (react-virtuoso unmounts rows outside its viewport window), so a range whose
+// row has been recycled reports a zero rect — keeping the bar "live" over a
+// selection would paint a ghost bar over unrelated content. Instead we capture
+// the position ONCE, from the selection's rect at the pointerup/keyup moment,
+// and hide deterministically on any subsequent scroll (which is what would
+// otherwise make that frozen position lie).
+//
+// Deliberately NOT solved here: press-and-hold drag already detaches the
+// transcript's auto-scroll-to-bottom (see the note in chatUtils.ts on
+// createUserScrollIntent), so this hook adds no follow-suppression of its own.
+import { useCallback, useEffect, useRef, useState } from "react";
+import { QUOTE_HEAD, QUOTE_MAX, QUOTE_TAIL, buildQuoteBlock } from "../chatUtils";
+
+export type QuoteSelection = {
+  /** The built `"> ...\n\n"` block, ready to prepend to the composer. */
+  block: string;
+  /** Viewport-space top of the selection rect (fixed positioning). */
+  top: number;
+  /** Viewport-space left of the selection rect. */
+  left: number;
+};
+
+export function useTranscriptSelection(params: {
+  scrollerRef: React.RefObject<HTMLElement | null>;
+  /** Root of the quote bar, so pointer/selection events ON the bar don't
+   *  collapse it (which would unmount the buttons before their click lands). */
+  toolbarRef: React.RefObject<HTMLDivElement | null>;
+  sessionId: string;
+  /** Fired with the quote block for the "Quote" action. */
+  onQuote: (block: string) => void;
+  /** Fired with the quote block for the "Quote in new session" action. */
+  onQuoteNewSession: (block: string) => void;
+}): {
+  quote: QuoteSelection | null;
+  quoteNow: () => void;
+  quoteNewSessionNow: () => void;
+} {
+  const { scrollerRef, toolbarRef, sessionId, onQuote, onQuoteNewSession } = params;
+
+  const [quote, setQuote] = useState<QuoteSelection | null>(null);
+  const hide = useCallback(() => setQuote(null), []);
+
+  // Always-fresh accessors so the document-level listeners and the action
+  // wrappers never close over a stale callback / session / quote value.
+  const sessionIdRef = useRef(sessionId);
+  sessionIdRef.current = sessionId;
+  const onQuoteRef = useRef(onQuote);
+  onQuoteRef.current = onQuote;
+  const onQuoteNewSessionRef = useRef(onQuoteNewSession);
+  onQuoteNewSessionRef.current = onQuoteNewSession;
+  const quoteRef = useRef(quote);
+  quoteRef.current = quote;
+
+  const insideToolbar = useCallback(
+    (node: Node | null): boolean => !!toolbarRef.current && !!node && toolbarRef.current.contains(node),
+    [toolbarRef],
+  );
+
+  const maybeShow = useCallback(() => {
+    const scroller = scrollerRef.current;
+    const sel = window.getSelection();
+    if (!sel || sel.isCollapsed || !scroller) {
+      setQuote(null);
+      return;
+    }
+    if (!sel.anchorNode || !scroller.contains(sel.anchorNode)) {
+      setQuote(null);
+      return;
+    }
+    const text = sel.toString();
+    const block = buildQuoteBlock(text, QUOTE_MAX, QUOTE_HEAD, QUOTE_TAIL);
+    if (!block) {
+      setQuote(null);
+      return;
+    }
+    if (sel.rangeCount === 0) return;
+    const rect = sel.getRangeAt(0).getBoundingClientRect();
+    if (rect.width === 0 && rect.height === 0) {
+      setQuote(null);
+      return;
+    }
+    setQuote({ block, top: rect.top, left: rect.left });
+  }, [scrollerRef]);
+
+  // Clear on session change so a bar from the previous session can't linger.
+  useEffect(() => {
+    setQuote(null);
+  }, [sessionId]);
+
+  useEffect(() => {
+    const onPointerDown = (e: PointerEvent) => {
+      if (insideToolbar(e.target as Node)) return;
+      setQuote(null);
+    };
+    const onPointerUp = (e: PointerEvent) => {
+      if (insideToolbar(e.target as Node)) return;
+      maybeShow();
+    };
+    const onKeyUp = (e: KeyboardEvent) => {
+      if (insideToolbar(e.target as Node)) return;
+      if (e.key === "Escape") {
+        setQuote(null);
+        return;
+      }
+      maybeShow();
+    };
+    const onScroll = () => setQuote(null);
+    // "the selection becoming empty" — keyboard deselect / click that clears
+    // the selection without the pointerdown above. Ignored while focus is on
+    // the bar itself (clicking a button collapses the selection; that must
+    // surface as the button's action, not an instant hide).
+    const onSelectionChange = () => {
+      if (insideToolbar(document.activeElement)) return;
+      const sel = window.getSelection();
+      if (!sel || sel.isCollapsed) setQuote(null);
+    };
+
+    const scroller = scrollerRef.current;
+    document.addEventListener("pointerdown", onPointerDown, true);
+    document.addEventListener("pointerup", onPointerUp, true);
+    document.addEventListener("keyup", onKeyUp, true);
+    document.addEventListener("selectionchange", onSelectionChange);
+    scroller?.addEventListener("scroll", onScroll, { passive: true });
+    return () => {
+      document.removeEventListener("pointerdown", onPointerDown, true);
+      document.removeEventListener("pointerup", onPointerUp, true);
+      document.removeEventListener("keyup", onKeyUp, true);
+      document.removeEventListener("selectionchange", onSelectionChange);
+      scroller?.removeEventListener("scroll", onScroll);
+    };
+  }, [insideToolbar, maybeShow, scrollerRef]);
+
+  const quoteNow = useCallback(() => {
+    const current = quoteRef.current;
+    if (!current) return;
+    hide();
+    onQuoteRef.current(current.block);
+  }, [hide]);
+
+  const quoteNewSessionNow = useCallback(() => {
+    const current = quoteRef.current;
+    if (!current) return;
+    hide();
+    onQuoteNewSessionRef.current(current.block);
+  }, [hide]);
+
+  return { quote, quoteNow, quoteNewSessionNow };
+}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -177,6 +177,50 @@ html, body, #root {
   .manta-jump-latest { transition: none; }
 }
 
+/* Quote toolbar (BET-1351). Floating action bar shown when the user finishes
+   selecting text in the transcript — "Quote" seeds the composer, "Quote in
+   new session" forks with the quote. `position: fixed`, clamped into the
+   viewport (Popover arithmetic), and rendered in ChatPanel's transcript
+   wrapper, NOT the Virtuoso root (whose overflow-x-hidden would clip it).
+
+   Tokens only — the same floating-surface trio .manta-jump-latest uses
+   (--card / --border / --shadow-md), --r-md radius, --sp-* padding. Button
+   text is text-label in --tx2 with the --accent-tx hover and the --accent
+   focus ring pair. No new custom property, no new Tailwind token. */
+.manta-quote-toolbar {
+  position: fixed;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  gap: var(--sp-1);
+  padding: var(--sp-1);
+  border: 1px solid var(--border);
+  border-radius: var(--r-md);
+  background: var(--card);
+  color: var(--tx2);
+  box-shadow: var(--shadow-md);
+}
+.manta-quote-toolbar button {
+  padding: var(--sp-2) var(--sp-3);
+  border: none;
+  border-radius: var(--r-md);
+  background: transparent;
+  color: var(--tx2);
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color var(--motion-fast) var(--ease-out);
+}
+.manta-quote-toolbar button:hover {
+  color: var(--accent-tx);
+}
+.manta-quote-toolbar button:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 1px;
+}
+@media (prefers-reduced-motion: reduce) {
+  .manta-quote-toolbar button { transition: none; }
+}
+
 /* MantaLoader — the two counter-rotating arcs (src/renderer/MantaLoader.tsx).
    Speeds are the native client's, verbatim: 0.9s clockwise outer, 1.4s
    anticlockwise inner. The mismatched periods are what stop the pair reading


### PR DESCRIPTION
## BET-1351 — Desktop: quote a transcript selection into the composer

Adds a floating action bar when the user finishes selecting text in the chat
transcript, offering **Quote** (prepend the selection to this session's
composer) and **Quote in new session** (fork, seed the fork's composer, and
open it).

### What shipped

- **Pure helpers** in `src/renderer/chatUtils.ts` (next to `formatAge` /
  `formatTokens`):
  - `truncateMiddle(text, max, head, tail)` — `"beginning … end"`, single
    U+2026 ellipsis with one space each side; unchanged input when it fits.
  - `buildQuoteBlock(selection, …)` — collapses whitespace runs to single
    spaces, trims, middle-truncates, returns `"> …\n\n"` (or `null` for
    empty/whitespace). No hidden payload / chip / composer state: the model
    already holds the full transcript, so the quote is a locatable pointer.
- **Selection detection** — `src/renderer/hooks/useTranscriptSelection.ts`.
  Event-driven and one-shot (no `selectionchange` live tracker): shows on
  `pointerup` / `keyup` (shift-arrow) when the selection is non-collapsed, its
  anchor is inside the transcript scroller, and `buildQuoteBlock` is non-null;
  captures the position once from the selection rect; hides on scroller scroll,
  a new pointerdown, Escape, the selection clearing, an action firing, or the
  session id changing. No reposition-on-scroll (the virtualised transcript
  would report a zero rect after Virtuoso recycles the row).
- **The bar** — `src/renderer/QuoteToolbar.tsx`, rendered inside ChatPanel's
  existing transcript wrapper (not the Virtuoso root, whose `overflow-x-hidden`
  would clip it). `position: fixed`, `z-index: 40`, clamped into the viewport
  (Popover arithmetic). Two buttons, labels exactly `Quote` and `Quote in new
  session`. One new CSS class `.manta-quote-toolbar` in `index.css` next to
  `.manta-jump-latest`, tokens only (the `--card`/`--border`/`--shadow-md`
  floating-surface trio, `--r-md`, `--sp-*`, text-label in `--tx2`,
  `--accent-tx` hover, `--accent` focus ring, reduced-motion honoured). No new
  CSS custom property, no new Tailwind token, no `aria-haspopup`.
- **Wiring** in `src/renderer/ChatPanel.tsx` only:
  - **Quote**: `updateInputWithHistoryReset(block + input)`, then focus and put
    the caret at the end of the whole input.
  - **Quote in new session**: the existing `forkSession` now takes an optional
    `seedText?`; it captures the already-returned `{ newSessionId, projects }`,
    seeds the fork's composer via the existing `setSeedPrompt` mechanism, and
    activates the fork window (InboxPalette's activate-then-seed pattern). The
    existing `onFork` caller is unchanged.
  - Errors go to the existing `setSendError` surface — no swallowed catches.

### Scope respected

No new props on `MessageRow` / `AssistantPart` / `MarkdownBody` / `CodeBlock` /
`ToolCall` (selection is read from the DOM). No change to `Transcript.tsx`,
follow/pin-to-bottom, virtualisation, `AttachmentStrip`, or `user-select`.

### Tests

`src/renderer/chatUtils.test.ts` — `truncateMiddle` (unchanged ≤ max, `head …
tail` above, shorter result, single U+2026 with one space each side) and
`buildQuoteBlock` (whitespace collapse + trim, `null` for empty/whitespace,
`"> "` prefix, `"\n\n"` suffix, multi-paragraph → one line with exactly one
ellipsis).

**Files changed:** 6.

**Verification results:**
- PR branch (`multica/BET-1351-quote-toolbar` @ `697878ff`):
  - typecheck: exit 0, errors none
  - test: vitest 3637 pass / 7 skip; node:test 2802 pass / 0 fail / 0 skip
- Base (`main` @ `b6a77149`):
  - typecheck: exit 0, errors none
  - test: vitest 3630 pass / 7 skip; node:test 2802 pass / 0 fail / 0 skip
- **Conclusion:** 0 new failures; the branch adds quote-toolbar tests (3630 →
  3637) and all pass. `npm run typecheck && npm test` green on the branch.

Base: origin/main @ b6a77149.
