### PR TITLE
feat(server): optimizer pacing controller — deficit queue, shadow price, rewarm hysteresis, eco level (BET-1345)

### DIFF
--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -87,7 +87,7 @@ import {
   type TaskContextValue,
   type TokenUsage,
 } from "./chatShared";
-import { crossesBoundary, shouldSwitch, boundaryPhrase } from "../shared/routingBoundary.mjs";
+import { crossesBoundary, shouldSwitch, boundaryPhrase, BOUNDARY } from "../shared/routingBoundary.mjs";
 import { acceptsModality } from "../shared/modelGuide.mjs";
 import { useModelCatalog } from "./modelCatalog";
 import {
@@ -218,6 +218,11 @@ export function ChatPanel({
   // BET-1274 10d: the routing preset drives the Auto row's display label; the
   // value lives on the same store block Settings writes (modelRouting.preset).
   const routingPreset = useStore((s) => s.modelRouting?.preset);
+  // Optimizer P2.3 (BET-1345): the eco level the last routing decision
+  // reported (trace.target.eco). Drives the Auto-row label ("Eco") — the preset
+  // key itself stays pinned at "balanced" in config; eco is runtime routing
+  // state, never a config change.
+  const [routingEco, setRoutingEco] = useState<number>(0);
   const hiddenStatusItems = useStore((s) => s.hiddenStatusItems);
   // BET-789: the "Connect GitHub…" offer's per-box dismissal flag. Once set,
   // the offer never re-appears until the config flag is cleared.
@@ -1369,11 +1374,18 @@ export function ChatPanel({
               pdf: readyAttachments.some((a) => mimeToInputMode(a.mime) === "pdf"),
             },
             incumbent,
+            // Optimizer P2.3 (BET-1345): the renderer reports the cached prefix
+            // size it already has (latestTokensRef.cache.read) so the BOX can
+            // price the rewarm cost — all pricing stays server-side.
+            cachedPrefixTokens: latestTokensRef.current?.cache?.read ?? undefined,
           });
           // Remember the box's answer about the incumbent for the NEXT turn's
           // crossesBoundary (so an outage fires a CONSTRAINT boundary even before
           // this turn switches). Defaults healthy when the box didn't report.
           incumbentHealthRef.current = decision.incumbentHealthy !== false;
+          // Optimizer P2.3: the decision's eco level feeds the Auto-row label
+          // ("Eco" while the box moves the target tier under pressure).
+          setRoutingEco(decision?.trace?.target?.eco ?? 0);
           const ranked = decision.model
             ? [decision.model, ...decision.alternatives]
             : decision.alternatives;
@@ -1389,6 +1401,13 @@ export function ChatPanel({
               incumbentStillEligible: decision.incumbentStillEligible !== false,
               incumbentStillCapable: stillCapable,
               incumbentHealthy: decision.incumbentHealthy !== false,
+              // Optimizer P2.3: the rewarm hysteresis — server-priced savings vs
+              // the cost of re-warming the winner's cache prefix. Only prevents
+              // a switch; never forces one. freeSwitch (post-compaction) is a
+              // free moment with no prefix to re-warm.
+              savingsPerTurn: decision.savingsPerTurn ?? undefined,
+              rewarmCost: decision.rewarmCost ?? undefined,
+              freeSwitch: boundary === BOUNDARY.COMPACTED,
             }).switch
           ) {
             const reason = decision.reason + (boundary ? ` · ${boundaryPhrase(boundary)}` : "");
@@ -3413,7 +3432,7 @@ export function ChatPanel({
         onOpenModels={ensureModels}
         onSelectModel={selectModel}
         onSelectEffort={onSelectEffort}
-        presetLabel={routingPreset ? titleCase(routingPreset) : undefined}
+        presetLabel={routingEco >= 1 ? "Eco" : routingPreset ? titleCase(routingPreset) : undefined}
         scheduleCount={schedules.length}
         onSchedules={() => togglePanel("schedules")}
         onSecrets={() => togglePanel("secrets")}

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -18,6 +18,7 @@ import { synthesizeSpeech } from "../shared/groq.mjs";
 import { WebSocketServer } from "ws";
 import { createCounterfactualStore, validateCounterfactualReport } from "./optimizer/counterfactual.mjs";
 import { createOptimizerSummary } from "./optimizer/summary.mjs";
+import { createPacingState } from "./optimizer/pacing.mjs";
 import { getDb } from "./opencodeDb.mjs";
 import {
   resolvePolicy,
@@ -114,7 +115,7 @@ import { createProviderHealth } from "./providerHealth.mjs";
 import {
   startModelCatalogPoller as startRoutingModelCatalog,
 } from "./modelCatalog.mjs";
-import { endpointSummary as routingEndpointSummary } from "./modelLedger.mjs";
+import { endpointSummary as routingEndpointSummary, providerTokenTotals, ROUTING_LEDGER_WINDOW_MS } from "./modelLedger.mjs";
 import * as appControl from "./appControl.mjs";
 import * as cto from "./cto.mjs";
 import { searchMessages } from "./messageSearch.mjs";
@@ -388,7 +389,27 @@ const { stop: stopDeferredMobilePoller } = push.startDeferredMobilePoller();
 // (src/server/rpc.mjs → usage.mjs listSnapshots()). NOT the context-window
 // indicator — see src/server/usage.mjs for that boundary.
 // eslint-disable-next-line no-unused-vars
-const { stop: stopUsagePoller, tick: usagePollerTick } = startUsagePoller(bus);
+const { stop: stopUsagePoller, tick: usagePollerTick } = startUsagePoller(bus, {
+  // Optimizer P2.3 (BET-1345): the pacing controller observes the SAME publish
+  // point as recordWindowObservations — no second poller, no adapter change.
+  pacing: optimizerPacing,
+});
+
+// Optimizer P2.3 (BET-1345): the pacing state. Reads/writes
+// `optimizer-pacing.json` through the shared jsonStore atomic writer; observes
+// the usage poller's publish point (wired above) to accumulate a deficit queue
+// per quota window, and serves the per-provider shadow price the router folds
+// in. `ledgerTokens` is the MEASURED token total per provider (modelLedger),
+// memoised behind a short TTL inside the pacing state — a null ledger read
+// means NO pacing pressure (fail-open, never a guess). Created before the usage
+// poller and buildHandlers so both share one instance.
+const optimizerPacing = createPacingState({
+  load: () => readJsonSync(statePath("optimizer-pacing.json"), {}),
+  save: (s) => writeJsonAtomic(statePath("optimizer-pacing.json"), JSON.stringify(s, null, 2)),
+  now: Date.now,
+  ledgerTokens: async () =>
+    providerTokenTotals({ sinceMs: Date.now() - ROUTING_LEDGER_WINDOW_MS }),
+});
 
 // Usage-stop resume engine (BET-1048): watches the ARMED entries in the
 // usage-stopped record and resumes them once their provider's usage genuinely
@@ -964,6 +985,10 @@ rpcHandlers = buildHandlers({
   routingCatalogIndex,
   routingProviderHealthState: (providerID) => providerHealth.state(providerID),
   routingEndpointSummary,
+  // Optimizer P2.3 (BET-1345): the pacing state for the routing:choose round
+  // trip — the router's cost stage reads services.pressure from it when the
+  // optimizer switch is on. Absent → pressure absent → route exactly as today.
+  routingPacing: optimizerPacing,
   // BET-1244: the provider-health engine itself, for the Accounts "Try again"
   // action (accounts:retry delegates to providerHealth.retry).
   providerHealth,

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -388,27 +388,29 @@ const { stop: stopDeferredMobilePoller } = push.startDeferredMobilePoller();
 // interval IS the cache TTL); the read side is the `usage:list` RPC channel
 // (src/server/rpc.mjs → usage.mjs listSnapshots()). NOT the context-window
 // indicator — see src/server/usage.mjs for that boundary.
-// eslint-disable-next-line no-unused-vars
-const { stop: stopUsagePoller, tick: usagePollerTick } = startUsagePoller(bus, {
-  // Optimizer P2.3 (BET-1345): the pacing controller observes the SAME publish
-  // point as recordWindowObservations — no second poller, no adapter change.
-  pacing: optimizerPacing,
-});
-
 // Optimizer P2.3 (BET-1345): the pacing state. Reads/writes
 // `optimizer-pacing.json` through the shared jsonStore atomic writer; observes
-// the usage poller's publish point (wired above) to accumulate a deficit queue
-// per quota window, and serves the per-provider shadow price the router folds
-// in. `ledgerTokens` is the MEASURED token total per provider (modelLedger),
+// the usage poller's publish point to accumulate a deficit queue per quota
+// window, and serves the per-provider shadow price the router folds in.
+// `ledgerTokens` is the MEASURED token total per provider (modelLedger),
 // memoised behind a short TTL inside the pacing state — a null ledger read
-// means NO pacing pressure (fail-open, never a guess). Created before the usage
-// poller and buildHandlers so both share one instance.
+// means NO pacing pressure (fail-open, never a guess). Created BEFORE
+// startUsagePoller and buildHandlers so both share one instance — the const
+// must be initialised before it is referenced (a TDZ ReferenceError here
+// crashes the server on boot, and tests never load index.mjs to catch it).
 const optimizerPacing = createPacingState({
   load: () => readJsonSync(statePath("optimizer-pacing.json"), {}),
   save: (s) => writeJsonAtomic(statePath("optimizer-pacing.json"), JSON.stringify(s, null, 2)),
   now: Date.now,
   ledgerTokens: async () =>
     providerTokenTotals({ sinceMs: Date.now() - ROUTING_LEDGER_WINDOW_MS }),
+});
+
+// eslint-disable-next-line no-unused-vars
+const { stop: stopUsagePoller, tick: usagePollerTick } = startUsagePoller(bus, {
+  // Optimizer P2.3 (BET-1345): the pacing controller observes the SAME publish
+  // point as recordWindowObservations — no second poller, no adapter change.
+  pacing: optimizerPacing,
 });
 
 // Usage-stop resume engine (BET-1048): watches the ARMED entries in the

--- a/src/server/modelLedger.mjs
+++ b/src/server/modelLedger.mjs
@@ -536,3 +536,40 @@ export async function ledgerSummary({ sinceMs = 0 } = {}) {
     return { supported: false };
   }
 }
+
+/**
+ * I/O. The optimizer's MEASURED tokens-per-pct conversion (Optimizer P2.3,
+ * BET-1345) needs a token total per opencode providerID. This sums
+ * `tokensSent` (input + cacheRead + cacheWrite + output — all context that
+ * passed through the model) across ledger rows per providerID, over the same
+ * rolling-window rows the rest of the ledger reads. The pacing state reads the
+ * total for a window's providerIDs at its mark and again later, and derives
+ * tokens-per-pct from the delta — so the conversion is MEASURED on the box, not
+ * assumed, and self-corrects.
+ *
+ * Returns { byProvider: { "<providerID>": total } } or `null` when the ledger
+ * is unavailable (the caller then reports no pacing pressure — fail-open).
+ * Never throws.
+ */
+export async function providerTokenTotals({ sinceMs = 0 } = {}) {
+  const db = await getDb();
+  if (!db) return null;
+  try {
+    const rows = await fetchLedgerRows(db, num(sinceMs));
+    const byProvider = {};
+    for (const r of rows) {
+      if (!r.providerID) continue;
+      byProvider[r.providerID] = (byProvider[r.providerID] ?? 0) + tokensSent(r);
+    }
+    return { byProvider };
+  } catch (e) {
+    // Query error: same degrade contract as the rest of the ledger.
+    console.error("[modelLedger] provider token query failed:", e?.message ?? e);
+    try {
+      db.close();
+    } catch {
+      /* already closed */
+    }
+    return null;
+  }
+}

--- a/src/server/optimizer/pacing.mjs
+++ b/src/server/optimizer/pacing.mjs
@@ -1,0 +1,269 @@
+// optimizer/pacing.mjs — the pacing controller's stateful core (Optimizer
+// P2.3, BET-1345).
+//
+// The SHARED, deterministic math (deficit queue, shadow price, eco, protection)
+// lives in src/shared/quotaPressure.mjs. THIS module is the stateful
+// observation + persistence half: it observes the usage poller's publish point,
+// accumulates a deficit queue per quota window, and serves the per-provider
+// "pressure" the router's cost stage folds in.
+//
+// Pure logic + injected I/O, mirroring createCounterfactualStore: `load` /
+// `save` persist `{ windows: { "<provider>:<kind>": {...} } }` via the shared
+// jsonStore atomic writer (wired in index.mjs), `now` is the injected clock,
+// and `ledgerTokens` is the injected MEASURED token total per providerID
+// (src/server/modelLedger.mjs providerTokenTotals). Tokens are never assumed:
+// a null token read means NO pacing pressure (fail-open).
+//
+// NB — the persisted window entry carries a few fields beyond the deficit
+// queue itself (providerIDs, rates, tokensAtMark/pctAtMark, startedAt) because
+// pressureFor must map a window to the opencode providerIDs it covers, must
+// evaluate the newsvendor protection against its measured rate distribution,
+// and must compute tokens-per-pct against a mark. They are observation state,
+// not extra knobs.
+
+import {
+  seedDeficit,
+  advanceDeficit,
+  shadowPrice,
+  ecoLevel,
+  protectionActive,
+  MIN_TOKENS_PER_PCT_SAMPLE,
+} from "../../shared/quotaPressure.mjs";
+
+const HOUR_MS = 3_600_000;
+// A window reset boundary, matching forecast.mjs (RESET_DELTA).
+const RESET_DELTA = -10;
+const SAVE_DEBOUNCE_MS = 30_000;
+// Bounded retained per-hour rate samples per window — enough for the ≥8
+// confidence gate plus slack, without unbounded growth over a 28-day history.
+const MAX_RATES = 1000;
+const TOKEN_TTL_MS = 60_000;
+
+const isNum = (v) => typeof v === "number" && Number.isFinite(v);
+const num = (v) => (isNum(v) ? v : 0);
+
+function normalizeState(raw) {
+  const s = raw && typeof raw === "object" ? raw : {};
+  const windows = {};
+  for (const [key, win] of Object.entries(s.windows ?? {})) {
+    if (!win || typeof win !== "object") continue;
+    windows[key] = {
+      deficit: num(win.deficit),
+      pct: num(win.pct),
+      at: num(win.at),
+      tokensAtMark: win.tokensAtMark, // keep possible null
+      pctAtMark: num(win.pctAtMark),
+      rates: Array.isArray(win.rates) ? win.rates.map(num) : [],
+      providerIDs: Array.isArray(win.providerIDs) ? win.providerIDs.filter((p) => typeof p === "string") : [],
+      ...(win.startedAt != null ? { startedAt: num(win.startedAt) } : {}),
+      ...(win.resetsAt != null ? { resetsAt: num(win.resetsAt) } : {}),
+    };
+  }
+  return { windows };
+}
+
+/**
+ * PURE. The measured tokens-per-pct for one window: the tokens this window's
+ * providers consumed since the mark, divided by the pct movement since the
+ * mark. Returns `null` when the denominator is below
+ * MIN_TOKENS_PER_PCT_SAMPLE (5 pct-points) or when the numerator isn't a
+ * positive measured number — a `null` here means NO pacing pressure at all
+ * (fail-open, never a guess).
+ *
+ * @param {string} key the "<provider>:<kind>" window key
+ * @param {object} args
+ * @param {number|null} args.ledgerTokensSince current cumulative token total for
+ *   the window's providerIDs (from the injected ledger reader)
+ * @param {object} args.state the persisted pacing state ({ windows })
+ * @returns {number|null}
+ */
+export function tokensPerPct(key, { ledgerTokensSince, state } = {}) {
+  const win = state?.windows?.[key];
+  if (!win) return null;
+  const deltaPct = num(win.pct) - num(win.pctAtMark);
+  if (!(deltaPct >= MIN_TOKENS_PER_PCT_SAMPLE)) return null;
+  if (!isNum(ledgerTokensSince) || !isNum(win.tokensAtMark)) return null;
+  const tokensSinceMark = ledgerTokensSince - win.tokensAtMark;
+  if (!(tokensSinceMark > 0)) return null;
+  return tokensSinceMark / deltaPct;
+}
+
+/**
+ * The pacing state. Injected I/O: `load()` returns the persisted
+ * `{ windows }` (or {}), `save(state)` persists it atomically, `now` is the
+ * clock (number or zero-arg fn). `ledgerTokens` is an async loader returning
+ * `{ byProvider: { "<providerID>": total } }` or null, memoised behind a short
+ * TTL so routing decisions don't hammer the DB.
+ *
+ * Returns { observe, pressureFor, tokensPerPct, snapshot }:
+ *   observe(snapshots) — one window at a time: reset-detect, seed or advance,
+ *     refresh the tokens mark, then persist debounced 30s on ONE unref'd timer.
+ *   pressureFor(providerID) — the worst-deficit window for that provider →
+ *     { lambda, tokensPerPct, deficit, ecoLevel, protection }, or null.
+ */
+export function createPacingState({ load, save, now, ledgerTokens, tokenTtlMs = TOKEN_TTL_MS } = {}) {
+  let state = null;
+  let saveTimer = null;
+  let tokenCache = null; // { at, byProvider }
+
+  const nowMs = () => (typeof now === "function" ? num(now()) : num(now ?? Date.now()));
+
+  async function ensureLoaded() {
+    if (!state && typeof load === "function") state = normalizeState(await load());
+    return state ?? (state = { windows: {} });
+  }
+
+  async function tokenTotals() {
+    if (typeof ledgerTokens !== "function") return null;
+    const t = nowMs();
+    if (tokenCache && t - tokenCache.at < tokenTtlMs) return tokenCache.byProvider;
+    let map = null;
+    try {
+      const res = await ledgerTokens();
+      map = res && typeof res === "object" && res.byProvider ? res.byProvider : null;
+    } catch {
+      map = null;
+    }
+    tokenCache = { at: t, byProvider: map ?? {} };
+    return tokenCache.byProvider;
+  }
+
+  async function sumTokens(providerIDs) {
+    const totals = await tokenTotals();
+    if (!totals) return null;
+    let sum = 0;
+    for (const p of Array.isArray(providerIDs) ? providerIDs : []) sum += totals[p] ?? 0;
+    return sum;
+  }
+
+  function scheduleSave() {
+    if (saveTimer || typeof save !== "function") return;
+    saveTimer = setTimeout(() => {
+      saveTimer = null;
+      if (!state) return;
+      save(state).catch((e) => console.warn("[pacing] save failed:", e?.message ?? e));
+    }, SAVE_DEBOUNCE_MS);
+    saveTimer?.unref?.();
+  }
+
+  async function observeWindow(s, key, { pct, startedAt, resetsAt, at, providerIDs }) {
+    const pctNum = isNum(pct) ? pct : 0;
+    const prev = s.windows[key];
+    const hasPrev = prev && isNum(prev.pct);
+    const tokens = await sumTokens(providerIDs);
+
+    // Window RESET: pct dropped back to ~0 (the same -10 boundary rule
+    // forecast.mjs uses). Discard the accumulator and re-seed from the closed
+    // form so a box that restarts / a window that turns over does not carry a
+    // stale queue.
+    if (hasPrev && pctNum < prev.pct + RESET_DELTA) {
+      s.windows[key] = {
+        deficit: seedDeficit({ pct: pctNum, startedAt, resetsAt, now: at }),
+        pct: pctNum,
+        at,
+        tokensAtMark: tokens,
+        pctAtMark: pctNum,
+        rates: [],
+        providerIDs,
+        ...(startedAt != null ? { startedAt } : {}),
+        ...(resetsAt != null ? { resetsAt } : {}),
+      };
+      return;
+    }
+
+    // First sight of this window: seed from the closed form (never assume
+    // Q = 0 on a cold start).
+    if (!hasPrev) {
+      s.windows[key] = {
+        deficit: seedDeficit({ pct: pctNum, startedAt, resetsAt, now: at }),
+        pct: pctNum,
+        at,
+        tokensAtMark: tokens,
+        pctAtMark: pctNum,
+        rates: [],
+        providerIDs,
+        ...(startedAt != null ? { startedAt } : {}),
+        ...(resetsAt != null ? { resetsAt } : {}),
+      };
+      return;
+    }
+
+    // Advance the accumulator: Q += (pct growth) - drain over the interval.
+    // The measured per-hour burn rate (positive delta, not a reset pair) feeds
+    // the newsvendor protection distribution.
+    const deficit = advanceDeficit({
+      prev: prev.deficit,
+      pct: pctNum,
+      prevPct: prev.pct,
+      resetsAt,
+      now: at,
+      prevNow: prev.at,
+    });
+    const rates = Array.isArray(prev.rates) ? prev.rates.slice() : [];
+    const dpct = pctNum - prev.pct;
+    const hours = (at - prev.at) / HOUR_MS;
+    if (dpct > 0 && hours > 0) {
+      rates.push(dpct / hours);
+      if (rates.length > MAX_RATES) rates.splice(0, rates.length - MAX_RATES);
+    }
+    s.windows[key] = {
+      deficit,
+      pct: pctNum,
+      at,
+      tokensAtMark: tokens,
+      pctAtMark: pctNum,
+      rates,
+      providerIDs,
+      ...(startedAt != null ? { startedAt } : {}),
+      ...(resetsAt != null ? { resetsAt } : {}),
+    };
+  }
+
+  async function observe(snapshots) {
+    if (!Array.isArray(snapshots) || snapshots.length === 0) return;
+    const s = await ensureLoaded();
+    const t = nowMs();
+    for (const snap of snapshots) {
+      const providerIDs = Array.isArray(snap.providerIDs) ? snap.providerIDs.slice() : [];
+      for (const w of snap.windows ?? []) {
+        if (!w || typeof w !== "object") continue;
+        await observeWindow(s, `${snap.provider}:${w.kind}`, {
+          pct: w.pct,
+          startedAt: w.startedAt,
+          resetsAt: w.resetsAt,
+          at: isNum(snap.fetchedAt) ? snap.fetchedAt : t,
+          providerIDs,
+        });
+      }
+    }
+    scheduleSave();
+  }
+
+  async function pressureFor(providerID) {
+    if (typeof providerID !== "string" || providerID === "") return null;
+    const s = await ensureLoaded();
+    let best = null; // { key, deficit, win }
+    for (const [key, win] of Object.entries(s.windows ?? {})) {
+      if (!win || !(Array.isArray(win.providerIDs) && win.providerIDs.includes(providerID))) continue;
+      if (!best || num(win.deficit) > best.deficit) best = { key, deficit: num(win.deficit), win };
+    }
+    if (!best) return null;
+    const deficit = best.deficit;
+    const lambda = shadowPrice(deficit);
+    const ledgerTokensSince = await sumTokens(best.win.providerIDs);
+    const tpp = tokensPerPct(best.key, { ledgerTokensSince, state: s });
+    const hoursUntilReset = isNum(best.win.resetsAt) ? Math.max(0, (best.win.resetsAt - nowMs()) / HOUR_MS) : null;
+    const protection = protectionActive({
+      rates: best.win.rates,
+      hoursUntilReset,
+      remainingPct: 100 - num(best.win.pct),
+    });
+    return { lambda, tokensPerPct: tpp, deficit, ecoLevel: ecoLevel(deficit), protection };
+  }
+
+  async function snapshot() {
+    return ensureLoaded();
+  }
+
+  return { observe, pressureFor, tokensPerPct, snapshot };
+}

--- a/src/server/optimizer/pacing.test.mjs
+++ b/src/server/optimizer/pacing.test.mjs
@@ -1,0 +1,151 @@
+// Tests for optimizer/pacing.mjs — the pacing controller's stateful core
+// (Optimizer P2.3, BET-1345). Pure/injected throughout: no real state dir —
+// `load`/`save` are in-memory, `now` is a controlled clock, and the token
+// ledger is a stub. Run via `npm run test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createPacingState, tokensPerPct } from "./pacing.mjs";
+import { MIN_TOKENS_PER_PCT_SAMPLE } from "../../shared/quotaPressure.mjs";
+
+const HOUR_MS = 3_600_000;
+
+function fixed(ms) {
+  return () => ms;
+}
+
+function makeState({ initial = {}, now, totals = {} }) {
+  let state = initial;
+  const saves = [];
+  const st = createPacingState({
+    load: async () => state,
+    save: async (s) => {
+      state = s;
+      saves.push(JSON.parse(JSON.stringify(s)));
+    },
+    now,
+    ledgerTokens: async () => ({ byProvider: totals }),
+  });
+  return { st, saves, get: () => st.snapshot() };
+}
+
+function snap(provider, providerIDs, windows, fetchedAt) {
+  return { provider, providerIDs, windows, fetchedAt };
+}
+
+function window(pct, startedAt, resetsAt) {
+  return { kind: "session", pct, startedAt, resetsAt };
+}
+
+test("observe seeds on first sight from the closed form (not Q=0)", async () => {
+  const R = 100 * HOUR_MS;
+  const { st } = makeState({ now: fixed(R / 2) });
+  await st.observe([snap("claude", ["anthropic"], [window(80, 0, R)], R / 2)]);
+  const state = await st.snapshot();
+  const win = state.windows["claude:session"];
+  assert.equal(win.deficit, 30); // 80 - 100 * 0.5
+  assert.deepEqual(win.providerIDs, ["anthropic"]);
+});
+
+test("observe advances the accumulator over pace", async () => {
+  const R = 1000; // short window for easy math
+  const { st } = makeState({ now: fixed(0) });
+  await st.observe([snap("claude", ["anthropic"], [window(50, 0, R)], 0)]);
+  let state = await st.snapshot();
+  assert.equal(state.windows["claude:session"].deficit, 50); // seed at t=0: 50 - 0
+
+  // The 30s debounced save never fires in-test, so a second state created from
+  // the mutated state would be stale; drive the SAME state through a second
+  // observation instead. pct 50 → 90 over a 500ms step: rate=(100-50)/1000=.05/ms,
+  // drain=.05*500=25 → Q = 50 + (90-50) - 25 = 65.
+  const st2 = createPacingState({
+    load: () => Promise.resolve(state),
+    save: async () => {},
+    now: fixed(500),
+    ledgerTokens: async () => ({ byProvider: {} }),
+  });
+  await st2.observe([snap("claude", ["anthropic"], [window(90, 0, R)], 500)]);
+  const state2 = await st2.snapshot();
+  assert.equal(state2.windows["claude:session"].deficit, 65);
+});
+
+test("observe discards the accumulator and re-seeds on a -10 reset drop", async () => {
+  const R = 1000;
+  const { st } = makeState({ now: fixed(0) });
+  await st.observe([snap("claude", ["anthropic"], [window(50, 0, R)], 0)]);
+  let state = await st.snapshot();
+  // A fresh window opens: pct drops to 5 (new startedAt/resetsAt). 5 < 50-10 → reset.
+  const R2 = 10_000;
+  const st2 = createPacingState({
+    load: () => Promise.resolve(state),
+    save: async () => {},
+    now: fixed(2000),
+    ledgerTokens: async () => ({ byProvider: {} }),
+  });
+  await st2.observe([snap("claude", ["anthropic"], [window(5, 1000, R2)], 2000)]);
+  const state2 = await st2.snapshot();
+  const win = state2.windows["claude:session"];
+  // Re-seeded: elapsed=(2000-1000)/9000≈0.111 → deficit=5 - 100*0.111 → clamped 0.
+  assert.equal(win.deficit, 0);
+  assert.equal(win.pct, 5);
+});
+
+test("tokensPerPct is null below MIN_TOKENS_PER_PCT_SAMPLE of movement", () => {
+  const state = {
+    windows: {
+      "claude:session": { pct: 60, pctAtMark: 58, tokensAtMark: 1000 },
+    },
+  };
+  // delta 2 < 5 → null, even with a huge measured token delta.
+  assert.equal(tokensPerPct("claude:session", { ledgerTokensSince: 100_000, state }), null);
+  assert.equal(MIN_TOKENS_PER_PCT_SAMPLE, 5);
+});
+
+test("tokensPerPct returns the measured ratio when movement is sufficient", () => {
+  const state = {
+    windows: {
+      "claude:session": { pct: 80, pctAtMark: 40, tokensAtMark: 1000 },
+    },
+  };
+  // delta 40 → (5000-1000)/40 = 100.
+  assert.equal(tokensPerPct("claude:session", { ledgerTokensSince: 5000, state }), 100);
+});
+
+test("pressureFor picks the largest-deficit window for a provider", async () => {
+  const { st } = makeState({
+    now: fixed(0),
+    totals: { anthropic: 5000 },
+    initial: {
+      windows: {
+        "claude:session": { deficit: 10, pct: 60, at: 10, tokensAtMark: 1000, pctAtMark: 40, rates: [1, 2, 3, 4, 5, 6, 7, 8], providerIDs: ["anthropic"], startedAt: 0, resetsAt: 1e9 },
+        "claude:weekly": { deficit: 30, pct: 80, at: 10, tokensAtMark: 1000, pctAtMark: 40, rates: [1, 2, 3, 4, 5, 6, 7, 8], providerIDs: ["anthropic"], startedAt: 0, resetsAt: 1e9 },
+      },
+    },
+  });
+  const p = await st.pressureFor("anthropic");
+  assert.ok(p);
+  assert.equal(p.deficit, 30); // worst window wins
+  assert.equal(p.ecoLevel, 2); // 30 is in [25, 40)
+  assert.equal(p.tokensPerPct, 100); // (5000-1000)/(80-40)
+  assert.equal(p.lambda, 30 / 25);
+});
+
+test("pressureFor returns null for a provider with no window", async () => {
+  const { st } = makeState({
+    now: fixed(0),
+    initial: { windows: { "claude:session": { deficit: 5, pct: 50, providerIDs: ["anthropic"] } } },
+  });
+  assert.equal(await st.pressureFor("openai"), null);
+  assert.equal(await st.pressureFor(""), null);
+});
+
+test("pressureFor returns null when the ledger read fails (fail-open)", async () => {
+  // ledgerTokens loader returns null → sumTokens null → tokensPerPct null.
+  const { st } = makeState({
+    now: fixed(0),
+    totals: null,
+    initial: { windows: { "claude:session": { deficit: 20, pct: 70, pctAtMark: 40, tokensAtMark: 1000, providerIDs: ["anthropic"] } } },
+  });
+  const p = await st.pressureFor("anthropic");
+  assert.equal(p.tokensPerPct, null);
+});

--- a/src/server/routingServices.mjs
+++ b/src/server/routingServices.mjs
@@ -241,10 +241,14 @@ export function ledgerToServices(stats) {
  *   providerIDs health is keyed by) — e.g. listRoutableModels output
  * @param {Array<object>} [deps.snapshots]  usage snapshots (src/server/usage.mjs)
  * @param {Function} [deps.providerHealthState]  (providerID) => state string
- * @param {Function} [deps.endpointSummary]  async ({sinceMs}) => { supported, endpoints } —
+ * @param {object}  [deps.endpointSummary]  async ({sinceMs}) => { supported, endpoints } —
  *   src/server/modelLedger.mjs endpointSummary (memoised behind a short TTL)
  * @param {Function} [deps.buildReliabilityBaseline]  optional override for the
  *   reliability/telemetry fold (tests)
+ * @param {object}  [deps.pacing]  the optimizer pacing state
+ *   (src/server/optimizer/pacing.mjs) exposing `pressureFor(providerID)`.
+ *   Populates `services.pressure` + `services.ecoLevel` ONLY when
+ *   `cfg.optimizerEnabled === true`; absent/degraded → route exactly as today.
  * @param {number} [nowMs]          injected clock (defaults to Date.now()); the
  *   rolling-window edge and the leave it as the TTL cache's timestamp
  * @returns {Promise<object>}  the RoutingServices-shaped object
@@ -372,6 +376,45 @@ export async function buildRoutingServices(cfg = {}, deps = {}, nowMs = Date.now
     }
   } catch {
     /* no ledger → reliability/telemetry absent (never derank, measured speed) */
+  }
+
+  // Optimizer P2.3 (BET-1345): the pacing pressure + eco level. BOTH are gated
+  // on the optimizer switch — `optimizerEnabled === true` and nothing else. With
+  // the switch off this block contributes NOTHING (absent pressure / absent eco
+  // = route exactly as today), and it never touches routingActive or the
+  // modelRouting.preset default. Each field has its own guard so a failing
+  // pressure reader degrades to absent without breaking the build.
+  const pacingProviderIDs = [
+    ...(Array.isArray(deps.endpoints) ? deps.endpoints.map((m) => m?.providerID) : []),
+    ...(Array.isArray(deps.snapshots) ? deps.snapshots.flatMap((s) => (Array.isArray(s?.providerIDs) ? s.providerIDs : [])) : []),
+  ];
+  if (cfg?.optimizerEnabled === true) {
+    try {
+      if (deps.pacing && typeof deps.pacing.pressureFor === "function") {
+        const pressure = {};
+        for (const pid of new Set(pacingProviderIDs)) {
+          if (typeof pid !== "string" || !pid) continue;
+          try {
+            const p = await deps.pacing.pressureFor(pid);
+            if (p) pressure[pid] = p;
+          } catch {
+            // one provider's pressure must never break the build for the rest
+          }
+        }
+        if (Object.keys(pressure).length > 0) services.pressure = pressure;
+      }
+    } catch {
+      /* pressure absent → route exactly as today */
+    }
+    try {
+      let eco = 0;
+      for (const p of Object.values(services.pressure ?? {})) {
+        if (p && typeof p.ecoLevel === "number" && p.ecoLevel > eco) eco = p.ecoLevel;
+      }
+      services.ecoLevel = eco;
+    } catch {
+      /* eco absent → the configured preset is used verbatim */
+    }
   }
 
   return services;

--- a/src/server/routingServices.test.mjs
+++ b/src/server/routingServices.test.mjs
@@ -356,3 +356,33 @@ test("buildRoutingServices safety contract: a throwing reader degrades, never th
   assert.equal(throwing.health, undefined);
   assert.equal(throwing.reliability, undefined);
 });
+
+test("optimizerEnabled gates pacing pressure + eco: off → absent, on → populated (BET-1345)", async () => {
+  const pacing = {
+    pressureFor: async () => ({ lambda: 1, tokensPerPct: 100, deficit: 30, ecoLevel: 2, protection: false }),
+  };
+  const deps = {
+    endpoints: [{ providerID: "anthropic", id: "claude-opus-4" }],
+    snapshots: [{ provider: "claude", providerIDs: ["anthropic"], exhausted: false, windows: [] }],
+    pacing,
+  };
+  // Switch OFF → nothing reaches the services bag: route exactly as today.
+  const off = await buildRoutingServices({ modelRouting: { preset: "balanced" }, optimizerEnabled: false }, deps, 0);
+  assert.equal(off.pressure, undefined);
+  assert.equal(off.ecoLevel, undefined);
+  // Switch ON → per-provider pressure + the max eco level across providers.
+  const on = await buildRoutingServices({ modelRouting: { preset: "balanced" }, optimizerEnabled: true }, deps, 0);
+  assert.equal(on.pressure.anthropic.lambda, 1);
+  assert.equal(on.pressure.anthropic.ecoLevel, 2);
+  assert.equal(on.ecoLevel, 2);
+});
+
+test("optimizer on but no pacing reader → pressure absent, eco 0 (never a guess)", async () => {
+  const s = await buildRoutingServices(
+    { modelRouting: { preset: "balanced" }, optimizerEnabled: true },
+    { endpoints: [{ providerID: "anthropic", id: "x" }] },
+    0,
+  );
+  assert.equal(s.pressure, undefined);
+  assert.equal(s.ecoLevel, 0);
+});

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -40,6 +40,7 @@ import { buildRoutingServices } from "./routingServices.mjs";
 import { restartOpencode, runServerSelfUpdate } from "./opencodeAdmin.mjs";
 import { pollClaudeLogin, claudeCliStatus, listRoutableModels } from "./opencode.mjs";
 import { chooseModel, incumbentStillEligible, describeDecision } from "../shared/modelRouter.mjs";
+import { CACHE_WRITE_MULTIPLIER } from "../shared/routingBoundary.mjs";
 import {
   applyRoutingOverrides,
   resolveNowOverride,
@@ -348,6 +349,11 @@ export function buildHandlers({
   routingCatalogIndex = null,
   routingProviderHealthState = () => null,
   routingEndpointSummary = () => null,
+  // Optimizer P2.3 (BET-1345): the optimizer pacing state
+  // (src/server/optimizer/pacing.mjs). Plugged into buildRoutingServices so the
+  // router's cost stage sees the pacing shadow price when the optimizer switch
+  // is on. Null/absent → pressure absent → route exactly as today.
+  routingPacing = null,
   // BET-1244: the filtered catalogue for routing:choose — listRoutableModels
   // (S1c) is the ONE place routing consent is computed; routing:choose gets the
   // filtered catalogue from it, never a second filter. Injectable for tests.
@@ -974,6 +980,7 @@ export function buildHandlers({
             snapshots: quota,
             providerHealthState: routingProviderHealthState,
             endpointSummary: routingEndpointSummary,
+            pacing: routingPacing,
           }, nowMs);
         } catch (e) {
           // 11e: a silently-degrading services build is how "no model passes
@@ -1053,6 +1060,26 @@ export function buildHandlers({
         // catalogIncumbent reference it was handed; map that back to the
         // original structured incumbent so the decision stays byte-identical.
         // A real winner / alternative is normalised into {providerID, modelID}.
+        // Optimizer P2.3 (BET-1345): the two server-priced numbers the renderer
+        // feeds the rewarm hysteresis in shouldSwitch. `savingsPerTurn` is the
+        // winner's assessed cost saving over the incumbent in $ (null when the
+        // incumbent did not survive routing — shouldSwitch already forced that
+        // switch). `rewarmCost` is what re-writing the winner's cache prefix
+        // costs, from the SAME blended-price inputs assess used (never a second
+        // price computation here).
+        const costs = decision?.costs;
+        const cachedPrefixTokens =
+          typeof input?.cachedPrefixTokens === "number" && Number.isFinite(input.cachedPrefixTokens)
+            ? input.cachedPrefixTokens
+            : null;
+        const savingsPerTurn =
+          costs && typeof costs.incumbent === "number" && typeof costs.winner === "number"
+            ? costs.incumbent - costs.winner
+            : null;
+        const rewarmCost =
+          costs && typeof costs.winnerCacheWritePrice === "number" && cachedPrefixTokens !== null
+            ? cachedPrefixTokens * CACHE_WRITE_MULTIPLIER * costs.winnerCacheWritePrice
+            : null;
         return {
           model:
             decision?.model === catalogIncumbent
@@ -1065,6 +1092,9 @@ export function buildHandlers({
           changed: decision?.changed === true,
           incumbentHealthy,
           incumbentStillEligible: stillEligible,
+          trace: decision?.trace ?? null,
+          savingsPerTurn,
+          rewarmCost,
         };
       } catch (e) {
         console.warn("[router] routing:choose failed, using incumbent:", e?.message ?? e);
@@ -1075,6 +1105,8 @@ export function buildHandlers({
           changed: false,
           incumbentHealthy: true,
           incumbentStillEligible: true,
+          savingsPerTurn: null,
+          rewarmCost: null,
         };
       }
     },

--- a/src/server/usage.mjs
+++ b/src/server/usage.mjs
@@ -421,13 +421,19 @@ let activePoller = null;
 
 /**
  * @param {{ publish: (evt: object) => void }} bus
- * @param {{ intervalMs?: number }} [opts]
+ * @param {{ intervalMs?: number, pacing?: object }} [opts]
+ *   `pacing` is the optimizer pacing state (src/server/optimizer/pacing.mjs),
+ *   observed from the SAME tap as recordWindowObservations — no second poller,
+ *   no adapter change.
  * @returns {{ stop: () => void }}
  */
-export function startUsagePoller(bus, { intervalMs = POLL_MS } = {}) {
+export function startUsagePoller(bus, { intervalMs = POLL_MS, pacing = null } = {}) {
   const poller = createUsagePoller({
     publish: (evt) => bus.publish(evt),
-    observe: recordWindowObservations,
+    observe: (results) => {
+      recordWindowObservations(results);
+      pacing?.observe?.(results);
+    },
   });
   activePoller = poller;
   const p = startPoller(() => poller.tick(), { intervalMs, label: "usage" });

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -111,6 +111,15 @@ type RoutingChooseDecision = {
   // gate (autoEligibility).
   incumbentHealthy: boolean;
   incumbentStillEligible: boolean;
+  // Optimizer P2.3 (BET-1345): the server-priced numbers for the rewarm
+  // hysteresis. `savingsPerTurn` is the winner's assessed $ saving over the
+  // incumbent (null when the incumbent didn't survive routing — the switch was
+  // forced anyway); `rewarmCost` is the $ to re-warm the winner's cache prefix
+  // (null when the write rate is unknown). `trace.target.eco` drives the
+  // Auto-row "Eco" label.
+  savingsPerTurn: number | null;
+  rewarmCost: number | null;
+  trace: { target?: { eco?: number } } | null;
 };
 // BET-1249: a provider-agnostic catalogue entry as served by
 // `opencode:model-catalog` (models.dev view). Consumed by the renderer's
@@ -451,6 +460,9 @@ export interface Api {
     contextTokens?: number;
     needs?: { tools?: boolean; image?: boolean; pdf?: boolean };
     incumbent: PromptModel | null;
+    // Optimizer P2.3 (BET-1345): the cached prefix size the renderer already
+    // holds (latestTokensRef.cache.read), so the BOX can price the rewarm cost.
+    cachedPrefixTokens?: number;
   }): Promise<RoutingChooseDecision>;
   // BET-1244: the Accounts "Try again" action — clears the out-of-credit
   // evidence-only flag for a provider, delegated to server-side provider

--- a/src/shared/marginalCost.d.mts
+++ b/src/shared/marginalCost.d.mts
@@ -34,6 +34,15 @@ export interface MarginalCostResult {
   reason: string;
 }
 
+/** Optimizer P2.3 (BET-1345): the pacing shadow price, additive on the
+ *  subscription pace curve. Absent on a credit account and anywhere the deficit
+ *  queue does not exist. */
+export interface ShadowPriceInput {
+  lambda: number;
+  tokensPerPct: number | null;
+  protection?: boolean;
+}
+
 export function depletionFactor(balance: number | undefined): number;
 
 export function marginalCost(input: {
@@ -43,4 +52,7 @@ export function marginalCost(input: {
   mix?: unknown;
   reference?: unknown;
   replacementCost?: number;
+  expectedTurnTokens?: number;
+  isLowStakes?: boolean;
+  shadowPrice?: ShadowPriceInput;
 }): MarginalCostResult;

--- a/src/shared/marginalCost.mjs
+++ b/src/shared/marginalCost.mjs
@@ -11,6 +11,7 @@
 // it now, which is about consumed-vs-elapsed, not pct alone).
 
 import { blendedPrice } from "./blendedPrice.mjs";
+import { PROTECTION_LAMBDA_MULTIPLIER } from "./quotaPressure.mjs";
 
 // --- Asymmetry: subscription < credit at equal scarcity ---------------------
 // A subscription's unused quota expires worthless; unused credit carries over
@@ -141,10 +142,21 @@ function subscriptionWindowCost(win, rate, nowMs) {
  * @param {object} [input.mix]          token mix for blendedPrice
  * @param {object} [input.reference]    reference price for the implausible-zero rule
  * @param {number} [input.replacementCost]  $ of the cheapest acceptable alternative
+ * @param {number} [input.expectedTurnTokens]  expected tokens in THIS turn (the
+ *   routing-decision input) — only the subscription branch consumes it, to size
+ *   the pacing pressure
+ * @param {boolean} [input.isLowStakes]  true for general/explore turns (the
+ *   protection multiplier applies only to these)
+ * @param {object} [input.shadowPrice]  the pacing controller's shadow price:
+ *   { lambda, tokensPerPct, protection } — ADDITIVE on top of the pace curve in
+ *   the subscription branch only. Absent / zero-lambda / null-tokensPerPct /
+ *   non-finite non-positive expectedTurnTokens → SKIPPED, cost + basis unchanged
+ *   (the on-or-under-pace regime stays byte-identical to today; the two terms
+ *   only coexist over pace).
  * @returns {{ cost: number, exhausted: boolean, basis: string, reason: string }}
  */
 export function marginalCost(input = {}) {
-  const { model, account, nowMs = 0, mix, reference, replacementCost } = input || {};
+  const { model, account, nowMs = 0, mix, reference, replacementCost, expectedTurnTokens, isLowStakes = false, shadowPrice } = input || {};
 
   // --- Exhausted first -------------------------------------------------------
   const windows = Array.isArray(account?.windows) ? account.windows : [];
@@ -208,11 +220,35 @@ export function marginalCost(input = {}) {
         bestBasis = c.basis;
       }
     }
+    // The pacing shadow price, ADDITIVE on top of the pace curve (Optimizer
+    // P2.3, BET-1345). `max(0, Q_w)` is zero in the on/under-pace regime, so
+    // today's arithmetic — including the under-pace discount that drives work
+    // onto a subscription you already paid for — is preserved byte-for-byte
+    // there. The pressure is skipped entirely (cost + basis unchanged) when any
+    // of its inputs is unusable: a missing shadowPrice, lambda <= 0, a null
+    // tokensPerPct, or a non-finite non-positive expectedTurnTokens. CREDIT
+    // accounts get NO shadow price — a credit balance has no reset window, so
+    // there is no deficit queue for it.
+    let cost = dollar(best);
+    let basis = bestBasis;
+    const sp = shadowPrice;
+    const tokensPerPctValid = sp && isNum(sp.tokensPerPct) && sp.tokensPerPct > 0;
+    const lambdaValid = sp && isNum(sp.lambda) && sp.lambda > 0;
+    const turnValid = isNum(expectedTurnTokens) && expectedTurnTokens > 0;
+    if (lambdaValid && tokensPerPctValid && turnValid) {
+      const protectionMult =
+        sp.protection === true && isLowStakes === true ? PROTECTION_LAMBDA_MULTIPLIER : 1;
+      const pressure = sp.lambda * (expectedTurnTokens / sp.tokensPerPct) * rate * protectionMult;
+      cost = dollar(best) + pressure;
+      basis = "subscription-pace+pressure";
+    }
     return {
-      cost: dollar(best),
+      cost,
       exhausted: false,
-      basis: bestBasis,
-      reason: `subscription priced by pace at exchange rate ${source}`,
+      basis,
+      reason:
+        `subscription priced by pace at exchange rate ${source}` +
+        (basis === "subscription-pace+pressure" ? " + pacing pressure" : ""),
     };
   }
 

--- a/src/shared/marginalCost.test.ts
+++ b/src/shared/marginalCost.test.ts
@@ -195,3 +195,76 @@ describe("marginalCost — exhausted first", () => {
     expect(res.cost).toBeGreaterThanOrEqual(0);
   });
 });
+
+// --- Optimizer P2.3: the pacing shadow price (BET-1345) --------------------
+// The on-pace subscription window used throughout: consumed 0.6 / elapsed 0.6,
+// pace 1 → cost is exactly the exchange rate (15), far from reset (damp 1).
+const PACE_SUB = () => ({
+  model: MODEL,
+  nowMs: 0,
+  replacementCost: EXCHANGE,
+  account: sub(w(60, -1.5 * R, R)),
+});
+
+const SHADOW = { lambda: 1, tokensPerPct: 1000, protection: false };
+
+describe("marginalCost — pacing shadow price (regression pins)", () => {
+  it("absent shadowPrice → byte-identical cost + basis to today", () => {
+    const baseline = marginalCost(PACE_SUB());
+    const res = marginalCost({ ...PACE_SUB(), shadowPrice: undefined });
+    expect(res.cost).toBe(baseline.cost);
+    expect(res.basis).toBe(baseline.basis);
+    expect(res.basis).toBe("subscription-pace");
+  });
+
+  it("lambda: 0 → identical (on/under-pace regime is byte-identical)", () => {
+    const baseline = marginalCost(PACE_SUB());
+    const res = marginalCost({ ...PACE_SUB(), expectedTurnTokens: 20_000, isLowStakes: true, shadowPrice: { ...SHADOW, lambda: 0 } });
+    expect(res.cost).toBe(baseline.cost);
+    expect(res.basis).toBe(baseline.basis);
+  });
+
+  it("tokensPerPct: null → identical (no measured conversion → no pressure)", () => {
+    const baseline = marginalCost(PACE_SUB());
+    const res = marginalCost({ ...PACE_SUB(), expectedTurnTokens: 20_000, isLowStakes: true, shadowPrice: { ...SHADOW, tokensPerPct: null } });
+    expect(res.cost).toBe(baseline.cost);
+    expect(res.basis).toBe(baseline.basis);
+  });
+
+  it("expectedTurnTokens absent / non-positive → identical", () => {
+    const baseline = marginalCost(PACE_SUB());
+    const absent = marginalCost({ ...PACE_SUB(), isLowStakes: true, shadowPrice: SHADOW });
+    const zero = marginalCost({ ...PACE_SUB(), expectedTurnTokens: 0, isLowStakes: true, shadowPrice: SHADOW });
+    expect(absent.cost).toBe(baseline.cost);
+    expect(absent.basis).toBe(baseline.basis);
+    expect(zero.cost).toBe(baseline.cost);
+  });
+
+  it("a real shadow price raises cost and flips basis", () => {
+    const baseline = marginalCost(PACE_SUB());
+    const res = marginalCost({ ...PACE_SUB(), expectedTurnTokens: 20_000, isLowStakes: false, shadowPrice: SHADOW });
+    // pressure = 1 * (20000/1000) * 15 * 1 = 300 on top of the pace anchor 15.
+    expect(res.cost).toBeGreaterThan(baseline.cost);
+    expect(res.cost).toBeCloseTo(EXCHANGE + 300, 6);
+    expect(res.basis).toBe("subscription-pace+pressure");
+  });
+
+  it("the protection multiplier applies only when isLowStakes", () => {
+    const low = marginalCost({ ...PACE_SUB(), expectedTurnTokens: 20_000, isLowStakes: true, shadowPrice: { ...SHADOW, protection: true } });
+    const high = marginalCost({ ...PACE_SUB(), expectedTurnTokens: 20_000, isLowStakes: false, shadowPrice: { ...SHADOW, protection: true } });
+    const base = EXCHANGE + 1 * (20_000 / 1000) * EXCHANGE; // no multiplier
+    expect(high.cost).toBeCloseTo(base, 6);
+    expect(low.cost).toBeCloseTo(EXCHANGE + 1 * (20_000 / 1000) * EXCHANGE * 3, 6);
+    expect(low.cost).toBeGreaterThan(high.cost);
+    expect(high.basis).toBe("subscription-pace+pressure");
+    expect(low.basis).toBe("subscription-pace+pressure");
+  });
+
+  it("credit account gets NO shadow price — depletionFactor remains its only scarcity signal", () => {
+    const baseline = marginalCost({ model: MODEL, nowMs: 0, account: credit(10) });
+    const res = marginalCost({ model: MODEL, nowMs: 0, account: credit(10), expectedTurnTokens: 20_000, isLowStakes: true, shadowPrice: SHADOW });
+    expect(res.cost).toBe(baseline.cost);
+    expect(res.basis).toBe(baseline.basis);
+    expect(res.basis).toBe("credit-depletion");
+  });
+});

--- a/src/shared/modelRouter.d.mts
+++ b/src/shared/modelRouter.d.mts
@@ -54,6 +54,17 @@ export interface RoutingServices {
   mixDefault?: { input?: number; output?: number; cacheRead?: number; cacheWrite?: number };
   /** Keyed by model id — the catalogue's typical input/output rate. */
   referenceByModel?: Record<string, { input?: number; output?: number }>;
+  /** Optimizer P2.3 (BET-1345) — keyed by providerID. The pacing shadow price
+   *  per provider, folded into marginalCost's subscription branch. Absent →
+   *  route exactly as today. */
+  pressure?: Record<
+    string,
+    { lambda: number; tokensPerPct: number | null; deficit: number; ecoLevel: number; protection: boolean }
+  >;
+  /** Optimizer P2.3 (BET-1345) — the max eco level across providers (0-3).
+   *  >= 2 moves the effective preset to "economy" (target tier only, never the
+   *  quality floor). Absent → the configured preset is used verbatim. */
+  ecoLevel?: number;
 }
 
 export interface ChooseInput {
@@ -85,7 +96,7 @@ export interface RoutingTrace {
   considered: number;
   dropped: { stage: "eligible" | "capable"; reason: string; n: number }[];
   intent: { contextTokens: number; needs: { tools: boolean; image: boolean; pdf: boolean } };
-  target: { tier: string; floorTier: string; widened: boolean };
+  target: { tier: string; floorTier: string; widened: boolean; eco?: number };
   winner: RoutingSignals | null;
 }
 
@@ -94,6 +105,14 @@ export interface ChooseResult {
   reason: string;
   alternatives: Model[];
   changed: boolean;
+  /** Optimizer P2.3 (BET-1345) — the assessed-cost accessor for the wiring
+   *  (savingsPerTurn / rewarmCost) without a second assess() call. Present on
+   *  the win-and-switch path; absent elsewhere. */
+  costs?: {
+    winner: number;
+    incumbent: number | null;
+    winnerCacheWritePrice: number | null;
+  };
   trace: RoutingTrace;
 }
 

--- a/src/shared/modelRouter.mjs
+++ b/src/shared/modelRouter.mjs
@@ -79,8 +79,10 @@ function capabilityDrop(m, { contextTokens, needs, health }) {
 }
 
 // Assess one endpoint once — Hard Stage 1 (eligibility), marginal cost and
-// reliability — everything the hard and soft stages read.
-function assess(candidate, { nowMs, replacementCost }, services) {
+// reliability — everything the hard and soft stages read. The shadow price is
+// folded in HERE (the full `services` bag is visible), never inside the
+// comparator, which only sees the reduced {preset, telemetry, health} object.
+function assess(candidate, { nowMs, replacementCost, expectedTurnTokens, isLowStakes }, services) {
   const key = endpointKey(candidate);
   const dec = services.declared?.[key] ?? null;
   const identity = resolveIdentity(candidate, dec, services.catalogMatcher);
@@ -102,7 +104,20 @@ function assess(candidate, { nowMs, replacementCost }, services) {
     declared: dec,
     providerClass: services.providerClass?.[candidate.providerID] ?? "supported",
   });
-  const mc = marginalCost({ model: m, account: services.accounts?.[candidate.providerID], nowMs, mix: perMix, reference: ref, replacementCost });
+  const mc = marginalCost({
+    model: m,
+    account: services.accounts?.[candidate.providerID],
+    nowMs,
+    mix: perMix,
+    reference: ref,
+    replacementCost,
+    // Optimizer P2.3 (BET-1345): the pacing shadow price for THIS provider,
+    // additive on top of the subscription pace curve. Absent → marginalCost
+    // prices exactly as today (the whole on/under-pace regime is preserved).
+    expectedTurnTokens,
+    isLowStakes,
+    shadowPrice: services.pressure?.[candidate.providerID],
+  });
   // The raw mix/reference flags blendedPrice already computed with the SAME
   // inputs marginalCost handed it — reported verbatim, not recomputed. This is
   // what makes a silently-defaulted mix / absent catalogue visible (BET-1265).
@@ -188,6 +203,17 @@ function computeReplacementCost(catalog, services) {
 const num0 = (v) => (isNum(v) ? v : 0);
 const numInf = (v) => (isNum(v) ? v : Infinity);
 const telemetryOf = (a, services) => services.telemetry?.[a.key] ?? {};
+
+// The winner's cache-WRITE price per token, taken from the SAME cost rates
+// blendedPrice reads (a missing cacheWrite bills at the input rate — BET-1269 5a
+// semantics). Returns null when neither rate is a finite number (price unknown →
+// the rewarm cost is unknown → the rewarm hysteresis term is skipped).
+function cacheWritePriceOf(model) {
+  const cost = model && typeof model.cost === "object" ? model.cost : null;
+  if (!cost) return null;
+  if (isNum(cost.cacheWrite)) return cost.cacheWrite;
+  return isNum(cost.input) ? cost.input : null;
+}
 
 // The winner's inspectable signals, read off the assessed entry — every value
 // was already computed during assess(); nothing new is derived here.
@@ -402,6 +428,14 @@ export function chooseModel(input = {}) {
   // The subscription exchange rate anchors to the cheapest non-subscription
   // endpoint's blended price — computed once, before the per-candidate loop.
   const replacementCost = computeReplacementCost(catalog, services);
+  // Optimizer P2.3 (BET-1345): the pacing shadow price is sized by the turn's
+  // expected tokens and stakes. `expectedTurnTokens` is the real conversation
+  // size when it is a finite number, else omitted → no pressure. A "low-stakes"
+  // turn (general/explore) is the one the newsvendor protection multiplier can
+  // inflate — build/plan work keeps its quality floor regardless of pressure.
+  const expectedTurnTokens =
+    isNum(intent?.contextTokens) && intent.contextTokens > 0 ? intent.contextTokens : undefined;
+  const isLowStakes = agent === "general" || agent === "explore";
   const addDrop = (stage, reason) => {
     const existing = drops.find((d) => d.stage === stage && d.reason === reason);
     if (existing) existing.n += 1;
@@ -409,7 +443,7 @@ export function chooseModel(input = {}) {
   };
   for (const c of Array.isArray(catalog) ? catalog : []) {
     considered += 1;
-    const a = assess(c, { nowMs, replacementCost }, services);
+    const a = assess(c, { nowMs, replacementCost, expectedTurnTokens, isLowStakes }, services);
     const cap = capabilityDrop(a.effective ?? a.candidate, hardCtx);
     if ((a.exhausted && !cap) || cap || !a.eligible) {
       const label = bindLabel(a, cap);
@@ -422,13 +456,23 @@ export function chooseModel(input = {}) {
     survivors.push(a);
   }
 
-  const targetRaw = policy?.perAgent?.[agent] ?? AGENT_TIER?.[policy?.preset]?.[agent] ?? "balanced";
+  // Eco (Optimizer P2.3): `policy.preset` stays whatever config holds
+  // ("balanced" — the preset key is retained + pinned, never removed). The
+  // EFFECTIVE preset is "economy" only while the box is under eco pressure
+  // (services.ecoLevel >= 2), which moves the TARGET tier (and stage3Order's
+  // flattening) down for cheap endpoints — but it NEVER relaxes AGENT_FLOOR_SCORE
+  // / meetsFloor: build and plan keep their quality floor no matter how much
+  // pressure the box is under. Eco moves the target, never the floor.
+  const ecoLevel = services.ecoLevel ?? 0;
+  const effectivePreset = ecoLevel >= 2 ? "economy" : policy?.preset;
+  const targetRaw = policy?.perAgent?.[agent] ?? AGENT_TIER?.[effectivePreset]?.[agent] ?? "balanced";
   const floorScore = AGENT_FLOOR_SCORE[agent] ?? 0;
   const targetRank = Math.max(tierRank(targetRaw), tierRank(tierForScore(floorScore)));
   const targetTrace = {
     tier: TIER_BY_RANK[targetRank],
     floorTier: tierForScore(floorScore),
     widened: false,
+    eco: ecoLevel,
   };
 
   if (survivors.length === 0) {
@@ -441,7 +485,7 @@ export function chooseModel(input = {}) {
     };
   }
 
-  const explored = stage3Order(survivors, { preset: policy?.preset, telemetry: services.telemetry, health: services.health });
+  const explored = stage3Order(survivors, { preset: effectivePreset, telemetry: services.telemetry, health: services.health });
   const band = selectBand(explored, targetRank, agent);
   if (band.length === 0) {
     return {
@@ -453,13 +497,26 @@ export function chooseModel(input = {}) {
     };
   }
 
-  const winner = band[0].candidate;
-  const winnerKey = band[0].key;
+  const winnerEntry = band[0];
+  const winner = winnerEntry.candidate;
+  const winnerKey = winnerEntry.key;
+  // Optimizer P2.3 (BET-1345): a minimal COST accessor so the wiring can
+  // report savingsPerTurn / rewarmCost WITHOUT re-running assess(). `incumbent`
+  // is the catalogIncumbent projection; when it survived routing it has an
+  // assessed cost here, else null (shouldSwitch will have forced the switch).
+  const incumbentEntry = incumbent
+    ? (survivors.find((a) => endpointKey(a.candidate) === endpointKey(incumbent)) ?? null)
+    : null;
   return {
     model: winner,
-    reason: explain({ agent, tierName: TIER_BY_RANK[tierRank(band[0].tier)], preset: policy?.preset, winner, cost: band[0].marginalCost }),
+    reason: explain({ agent, tierName: TIER_BY_RANK[tierRank(band[0].tier)], preset: effectivePreset, winner, cost: winnerEntry.marginalCost }),
     alternatives: band.slice(1, 4).map((a) => a.candidate),
     changed: !incumbent || endpointKey(incumbent) !== winnerKey,
+    costs: {
+      winner: winnerEntry.marginalCost,
+      incumbent: incumbentEntry ? incumbentEntry.marginalCost : null,
+      winnerCacheWritePrice: cacheWritePriceOf(winnerEntry.effective ?? winnerEntry.candidate),
+    },
     trace: {
       considered,
       dropped: drops,

--- a/src/shared/modelRouter.test.ts
+++ b/src/shared/modelRouter.test.ts
@@ -3,6 +3,7 @@ import { chooseModel, incumbentStillEligible, describeDecision, AGENT_TIER, type
 import { endpointKey } from "./endpointKey.mjs";
 import { tierRank } from "./modelGuide.mjs";
 import { AGENT_FLOOR_SCORE } from "./modelQuality.mjs";
+import { RESET_RAMP_MS } from "./marginalCost.mjs";
 // Per standing rule 9, candidates below are built with the REAL normaliser,
 // not a hand-written fixture — a fixture that disagreed with production is how
 // these defects survived a green suite. The services context is likewise built
@@ -1022,5 +1023,84 @@ describe("describeDecision", () => {
       trace: { considered: 1, dropped: [], intent: { needs: { tools: true } }, winner: { cost: {} } },
     };
     expect(describeDecision(decision, { surface: "sub", agent: "explore" })).toMatch(/^\[router\] sub\/explore /);
+  });
+});
+
+// --- Optimizer P2.3: pressure + eco (BET-1345) ------------------------------
+// The R constant matches marginalCost's RESET_RAMP_MS so an on-pace window
+// prices at exactly the exchange/overage rate.
+const R = RESET_RAMP_MS;
+
+// An on-pace subscription account at a published overage price: cost = rate.
+function subAccount(overagePrice: number): Record<string, unknown> {
+  return {
+    kind: "subscription",
+    windows: [{ kind: "session", pct: 60, startedAt: -1.5 * R, resetsAt: R }],
+    overagePrice,
+  };
+}
+
+describe("modelRouter — pacing pressure (shadow price)", () => {
+  // Both endpoints are the same model on two subscription providers; the
+  // within-model contest is decided purely by marginal cost, so a shadow price
+  // on A deterministically flips the winner to B.
+  const a = () => endpoint("m", { providerID: "a", cost: { input: 1, output: 1, cacheRead: 1, cacheWrite: 1 } });
+  const b = () => endpoint("m", { providerID: "b", cost: { input: 10, output: 10, cacheRead: 10, cacheWrite: 10 } });
+  const POLICY = { preset: "balanced" };
+  const services = (extra: Record<string, unknown> = {}) => ({ accounts: { a: subAccount(1), b: subAccount(105) }, ...extra });
+
+  it("pressure absent → routing is byte-identical to today (regression pin)", () => {
+    const catalog = [a(), b()];
+    const base = route({ catalog, intent: { contextTokens: 20_000 }, policy: POLICY, services: services() });
+    // eco defaults to 0 → the configured preset is used verbatim, no flattening.
+    expect(base.trace.target.eco).toBe(0);
+    expect(base.trace.winner!.cost.basis).not.toContain("pressure");
+    expect(base.model?.providerID).toBe("a");
+    // A shadowPrice marginalCost skips (lambda 0 / null tokensPerPct) is identical.
+    const inert = route({
+      catalog,
+      intent: { contextTokens: 20_000 },
+      policy: POLICY,
+      services: services({ pressure: { a: { lambda: 0, tokensPerPct: null, deficit: 0, ecoLevel: 0, protection: false } } }),
+    });
+    expect(inert.model?.providerID).toBe("a");
+    expect(inert.trace.winner!.cost.basis).toBe(base.trace.winner!.cost.basis);
+  });
+
+  it("pressure on provider A flips an endpoint on provider B to win where A won before", () => {
+    const catalog = [a(), b()];
+    const base = route({ catalog, intent: { contextTokens: 20_000 }, policy: POLICY, services: services() });
+    expect(base.model?.providerID).toBe("a");
+    const pressured = route({
+      catalog,
+      intent: { contextTokens: 20_000 },
+      policy: POLICY,
+      services: services({ pressure: { a: { lambda: 1, tokensPerPct: 100, deficit: 25, ecoLevel: 1, protection: false } } }),
+    });
+    // pressure on a = 1*(20000/100)*1 = 200 → a's cost 201 > b's 105.
+    expect(pressured.model?.providerID).toBe("b");
+  });
+});
+
+describe("modelRouter — eco level moves the target, never the floor", () => {
+  it("ecoLevel >= 2 flattens the model partition even while preset is 'balanced'", () => {
+    const strong = endpoint("strong", { tier: "balanced", score: 0.6, providerID: "a", cost: { input: 100, output: 100, cacheRead: 50, cacheWrite: 50 } });
+    const weak = endpoint("weak", { tier: "balanced", score: 0.45, providerID: "b", cost: { input: 1, output: 1, cacheRead: 0.5, cacheWrite: 0.5 } });
+    // Without eco, "balanced" keeps the partition: strong wins.
+    const baseline = route({ catalog: [strong, weak], policy: { preset: "balanced" } });
+    expect(baseline.model?.id).toBe("strong");
+    // At eco level 3 the effective preset becomes economy → cheap weak wins.
+    const res = route({ catalog: [strong, weak], policy: { preset: "balanced" }, services: { ecoLevel: 3 } });
+    expect(res.model?.id).toBe("weak");
+    expect(res.reason.toLowerCase()).toContain("economy");
+  });
+
+  it("meetsFloor still rejects a below-floor model for build at eco level 3", () => {
+    // build's floor is >= balanced (0.4); a fast (0.25) model never passes it.
+    const fast = endpoint("below-floor", { tier: "fast", providerID: "a" });
+    const res = route({ catalog: [fast], intent: { agent: "build" }, services: { ecoLevel: 3 } });
+    // Eco relaxed the TARGET tier (economy/build → balanced) but the floor held:
+    // the only candidate is below the floor, so no model is offered.
+    expect(res.model).toBeNull();
   });
 });

--- a/src/shared/quotaPressure.d.mts
+++ b/src/shared/quotaPressure.d.mts
@@ -1,0 +1,40 @@
+// quotaPressure.mjs — pure deficit-queue / shadow-price / eco math (Optimizer
+// P2.3, BET-1345). Typed for the renderer/TS consumer; the implementation is
+// the shared .mjs.
+
+export const OPTIMIZER_LYAPUNOV_V: number;
+export const PROTECTION_V_LOW: number;
+export const PROTECTION_V_HIGH: number;
+export const PROTECTION_QUANTILE: number;
+export const PROTECTION_LAMBDA_MULTIPLIER: number;
+export const MIN_TOKENS_PER_PCT_SAMPLE: number;
+export const ECO_THRESHOLDS: number[];
+
+export interface SeedDeficitInput {
+  pct?: number;
+  startedAt?: number;
+  resetsAt?: number;
+  now?: number;
+}
+export function seedDeficit(input?: SeedDeficitInput): number;
+
+export interface AdvanceDeficitInput {
+  prev?: number;
+  pct?: number;
+  prevPct?: number;
+  resetsAt?: number;
+  now?: number;
+  prevNow?: number;
+}
+export function advanceDeficit(input?: AdvanceDeficitInput): number;
+
+export function shadowPrice(deficit: number): number;
+export function ecoLevel(maxDeficit: number): 0 | 1 | 2 | 3;
+export function quantile(sorted: number[], q: number): number | null;
+
+export interface ProtectionActiveInput {
+  rates?: number[];
+  hoursUntilReset?: number;
+  remainingPct?: number;
+}
+export function protectionActive(input?: ProtectionActiveInput): boolean;

--- a/src/shared/quotaPressure.mjs
+++ b/src/shared/quotaPressure.mjs
@@ -1,0 +1,133 @@
+// quotaPressure.mjs — the pure deficit-queue / shadow-price / eco math behind
+// the optimizer's pacing controller (Optimizer P2.3, BET-1345).
+//
+// PURE: no node:* imports, no Date.now(), no I/O — everything arrives as an
+// argument. This is the shared "src/shared" half of the pacing controller;
+// the stateful observation/persistence half lives in
+// src/server/optimizer/pacing.mjs.
+//
+// MODEL — a deficit queue per quota window, tracked in PCT-POINTS (absolute
+// quota is not derivable: UsageWindow.limit is optional and absent for the
+// claude adapter, plan totals are unpublished and vary by tier). Q_w grows
+// while a window burns above pace (the drift-plus-penalty step in
+// advanceDeficit), is clamped to [0,100], and is closed-form-seeded on a
+// cold start / reset (seedDeficit) so a box that restarts at 90% through a
+// window does not believe Q = 0.
+//
+// The shadow price lambda = max(0, Q_w)/V is ADDITIVE on top of the existing
+// pace curve (marginalCost.mjs). `max(0, Q_w)` is zero while a window is on or
+// under pace, so today's arithmetic is preserved byte-for-byte in that whole
+// regime — the two terms only ever coexist over pace, where the deficit queue
+// is meant to be the controller.
+
+export const OPTIMIZER_LYAPUNOV_V = 25; // pct-points of deficit that make lambda = 1
+export const PROTECTION_V_LOW = 0.35; // relative value of a general/explore turn
+export const PROTECTION_V_HIGH = 1.0; // relative value of a build/plan turn
+export const PROTECTION_QUANTILE = 1 - PROTECTION_V_LOW / PROTECTION_V_HIGH; // 0.65
+export const PROTECTION_LAMBDA_MULTIPLIER = 3;
+export const MIN_TOKENS_PER_PCT_SAMPLE = 5; // pct-points of movement before tokensPerPct is trusted
+export const ECO_THRESHOLDS = [10, 25, 40]; // deficit pct-points -> eco level 1/2/3
+
+const isNum = (v) => typeof v === "number" && Number.isFinite(v);
+
+/**
+ * PURE. Percentile of an ascending-sorted array at fraction `q` in [0,1]
+ * (linear-approach index, matching the ledger's percentile helper). Returns
+ * null for an empty array — callers gate on the sample count.
+ */
+export function quantile(sorted, q) {
+  if (!Array.isArray(sorted) || sorted.length === 0) return null;
+  const p = Math.min(1, Math.max(0, q));
+  const idx = Math.min(sorted.length - 1, Math.floor((sorted.length - 1) * p));
+  return sorted[idx];
+}
+
+/**
+ * PURE. The cold-start deficit: `max(0, pct - 100 * elapsed / span)`, the
+ * closed form of the queue integrated at a constant drain rate. `elapsed` is
+ * the fraction of the window already gone at `now`. Returns 0 when
+ * `startedAt`/`resetsAt` are unusable (no window start → cannot compute
+ * elapsed — never guess).
+ *
+ * @returns {number}
+ */
+export function seedDeficit({ pct, startedAt, resetsAt, now } = {}) {
+  if (!isNum(startedAt) || !isNum(resetsAt) || !isNum(now)) return 0;
+  const span = resetsAt - startedAt;
+  if (!(span > 0)) return 0;
+  const elapsed = Math.max(0, Math.min(1, (now - startedAt) / span));
+  return Math.max(0, (isNum(pct) ? pct : 0) - 100 * elapsed);
+}
+
+/**
+ * PURE. The accumulator step, faithful to the drift-plus-penalty form:
+ *   Q += (pct - prevPct) - rate * dt
+ * where `rate = (100 - prevPct) / max(1, resetsAt - prevNow)` per ms and
+ * `dt = now - prevNow`. The second term drains the queue at the window's
+ * average burn-to-full rate, so a window that stays exactly on pace neither
+ * over- nor under-accumulates. Result clamped to [0, 100].
+ *
+ * A window RESET is detected by the CALLER (`pct < prevPct - 10` — the same
+ * boundary rule forecast.mjs uses); on reset the accumulator is discarded and
+ * the caller re-seeds (seedDeficit). This only advances a live window.
+ *
+ * @param {object} args { prev, pct, prevPct, resetsAt, now, prevNow }
+ * @returns {number}
+ */
+export function advanceDeficit({ prev, pct, prevPct, resetsAt, now, prevNow } = {}) {
+  if (!isNum(resetsAt) || !isNum(now) || !isNum(prevNow)) return isNum(prev) ? prev : 0;
+  const span = Math.max(1, resetsAt - prevNow);
+  const rate = (100 - (isNum(prevPct) ? prevPct : 0)) / span;
+  const dt = now - prevNow;
+  const next = (isNum(prev) ? prev : 0) + ((isNum(pct) ? pct : 0) - (isNum(prevPct) ? prevPct : 0)) - rate * dt;
+  return Math.min(100, Math.max(0, next));
+}
+
+/**
+ * PURE. The shadow price lambda for a deficit. `max(0, deficit) / V`,
+ * dimensionless — it multiplies a dollar figure downstream. Zero at or below
+ * pace (deficit <= 0), preserving today's cost in that regime.
+ *
+ * @returns {number}
+ */
+export function shadowPrice(deficit) {
+  return Math.max(0, isNum(deficit) ? deficit : 0) / OPTIMIZER_LYAPUNOV_V;
+}
+
+/**
+ * PURE. Eco level from the max deficit across a provider's windows: 0 below
+ * 10, 1 below 25, 2 below 40, else 3. Monotonic non-decreasing — a test
+ * asserts that over a swept range.
+ *
+ * @returns {0|1|2|3}
+ */
+export function ecoLevel(maxDeficit) {
+  const d = isNum(maxDeficit) ? maxDeficit : 0;
+  if (d < ECO_THRESHOLDS[0]) return 0;
+  if (d < ECO_THRESHOLDS[1]) return 1;
+  if (d < ECO_THRESHOLDS[2]) return 2;
+  return 3;
+}
+
+/**
+ * PURE. The newsvendor protection level: is the remaining budget likely to run
+ * out before reset, given the MEASURED per-hour rate distribution? False with
+ * fewer than 8 rate samples (the same confidence gate forecastAtReset uses).
+ * Else true when:
+ *   remainingPct <= clamp(quantile(rates, PROTECTION_QUANTILE) * hoursUntilReset, 0, 100)
+ * i.e. the remaining budget is within the burn the (1 - v_low/v_high)-quantile
+ * rate is expected to consume before reset. `rates` is a per-hour pct-points
+ * sample array (ascending not required — sorted here).
+ *
+ * @returns {boolean}
+ */
+export function protectionActive({ rates, hoursUntilReset, remainingPct } = {}) {
+  if (!Array.isArray(rates) || rates.length < 8) return false;
+  if (!isNum(hoursUntilReset) || !isNum(remainingPct)) return false;
+  const sorted = [...rates].map(Number).filter(isNum).sort((a, b) => a - b);
+  if (sorted.length < 8) return false;
+  const q = quantile(sorted, PROTECTION_QUANTILE);
+  if (q == null) return false;
+  const budget = Math.min(100, Math.max(0, q * hoursUntilReset));
+  return remainingPct <= budget;
+}

--- a/src/shared/quotaPressure.test.ts
+++ b/src/shared/quotaPressure.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect } from "vitest";
+import {
+  seedDeficit,
+  advanceDeficit,
+  shadowPrice,
+  ecoLevel,
+  protectionActive,
+  quantile,
+  OPTIMIZER_LYAPUNOV_V,
+  PROTECTION_QUANTILE,
+  PROTECTION_LAMBDA_MULTIPLIER,
+  MIN_TOKENS_PER_PCT_SAMPLE,
+  ECO_THRESHOLDS,
+} from "./quotaPressure.mjs";
+
+describe("seedDeficit — closed form at elapsed fractions", () => {
+  // A 100-hour window from t=0 to t=100h.
+  const SPAN = 100 * 60 * 60 * 1000;
+  const startedAt = 0;
+  const resetsAt = SPAN;
+
+  it("0% elapsed, any pct -> deficit is that pct (nothing drained yet)", () => {
+    // elapsed 0 → pct - 0 = pct.
+    expect(seedDeficit({ pct: 30, startedAt, resetsAt, now: 0 })).toBeCloseTo(30, 6);
+    expect(seedDeficit({ pct: 0, startedAt, resetsAt, now: 0 })).toBeCloseTo(0, 6);
+  });
+
+  it("50% elapsed -> pct - 50, clamped at 0", () => {
+    const now = SPAN / 2;
+    expect(seedDeficit({ pct: 80, startedAt, resetsAt, now })).toBeCloseTo(30, 6); // 80 - 50
+    expect(seedDeficit({ pct: 40, startedAt, resetsAt, now })).toBeCloseTo(0, 6); // 40 - 50 → 0
+  });
+
+  it("100% elapsed -> pct - 100, clamped at 0", () => {
+    const now = SPAN;
+    expect(seedDeficit({ pct: 90, startedAt, resetsAt, now })).toBeCloseTo(0, 6); // 90 - 100 → 0
+    expect(seedDeficit({ pct: 100, startedAt, resetsAt, now })).toBeCloseTo(0, 6); // exactly full → 0
+  });
+
+  it("unusable timestamps -> 0 (never guess a start time)", () => {
+    expect(seedDeficit({ pct: 50, startedAt: undefined, resetsAt, now: 1 })).toBe(0);
+    expect(seedDeficit({ pct: 50, startedAt, resetsAt: undefined, now: 1 })).toBe(0);
+    expect(seedDeficit({ pct: 50, startedAt, resetsAt, now: undefined })).toBe(0);
+    expect(seedDeficit({})).toBe(0);
+  });
+});
+
+describe("advanceDeficit — the accumulator step", () => {
+  it("accumulates over pace -> Q grows", () => {
+    // Window resets 1000ms after prevNow. rate = (100-50)/1000 = 0.05/ms.
+    // Over a 500ms step the drain is 25 pct-points; pct jumps 50→80 (delta 30).
+    const Q = advanceDeficit({
+      prev: 0,
+      pct: 80,
+      prevPct: 50,
+      resetsAt: 1000 + 0, // prevNow=0 → resets in 1000ms
+      now: 500,
+      prevNow: 0,
+    });
+    expect(Q).toBeCloseTo(30 - 25, 6); // 5
+  });
+
+  it("under pace -> clamped at 0 (the discount regime never goes negative)", () => {
+    // Same window; pct jumps 50→60 (delta 10) vs drain 25 → -15, clamped 0.
+    const Q = advanceDeficit({
+      prev: 0,
+      pct: 60,
+      prevPct: 50,
+      resetsAt: 1000,
+      now: 500,
+      prevNow: 0,
+    });
+    expect(Q).toBe(0);
+  });
+
+  it("on pace (pct growth == drain) keeps Q constant", () => {
+    // rate=(100-50)/1000=0.05/ms; over 500ms drain=25. pct 50→75 (delta 25).
+    const Q = advanceDeficit({
+      prev: 10,
+      pct: 75,
+      prevPct: 50,
+      resetsAt: 1000,
+      now: 500,
+      prevNow: 0,
+    });
+    expect(Q).toBeCloseTo(10, 6);
+  });
+
+  it("clamps to [0, 100]", () => {
+    const high = advanceDeficit({
+      prev: 95,
+      pct: 100,
+      prevPct: 0,
+      resetsAt: 1e9,
+      now: 1,
+      prevNow: 0,
+    });
+    expect(high).toBe(100);
+    const low = advanceDeficit({ prev: 5, pct: 10, prevPct: 90, resetsAt: 10, now: 9, prevNow: 0 });
+    expect(low).toBe(0);
+  });
+});
+
+describe("shadowPrice", () => {
+  it("zero at and below pace (deficit <= 0)", () => {
+    expect(shadowPrice(0)).toBe(0);
+    expect(shadowPrice(-5)).toBe(0);
+  });
+
+  it("= deficit / V above pace", () => {
+    expect(shadowPrice(25)).toBeCloseTo(1, 6); // V=25 makes lambda 1 at 25 pct-points
+    expect(shadowPrice(12.5)).toBeCloseTo(0.5, 6);
+    expect(shadowPrice(50)).toBeCloseTo(2, 6);
+  });
+});
+
+describe("ecoLevel — boundaries and monotonicity", () => {
+  it("boundaries at exactly 10, 25, 40", () => {
+    expect(ecoLevel(9)).toBe(0);
+    expect(ecoLevel(10)).toBe(1);
+    expect(ecoLevel(24)).toBe(1);
+    expect(ecoLevel(25)).toBe(2);
+    expect(ecoLevel(39)).toBe(2);
+    expect(ecoLevel(40)).toBe(3);
+    expect(ecoLevel(100)).toBe(3);
+  });
+
+  it("monotonic non-decreasing over a swept range", () => {
+    let prev = -1;
+    for (let d = 0; d <= 120; d += 0.5) {
+      const lvl = ecoLevel(d);
+      expect(lvl).toBeGreaterThanOrEqual(prev);
+      prev = lvl;
+    }
+  });
+});
+
+describe("protectionActive — the newsvendor protection level", () => {
+  // 8+ rates gives the confidence the quantile needs.
+  const rates = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
+
+  it("false with fewer than 8 rate samples", () => {
+    expect(protectionActive({ rates: rates.slice(0, 7), hoursUntilReset: 10, remainingPct: 5 })).toBe(false);
+    expect(protectionActive({ rates: [], hoursUntilReset: 10, remainingPct: 5 })).toBe(false);
+  });
+
+  it("true/false around the 0.65 quantile", () => {
+    // sorted rates [1..10]; q=0.65 → idx=floor(9*0.65)=floor(5.85)=5 → value 6.
+    // budget = 6 * hoursUntilReset. With hoursUntilReset=2, budget=12.
+    // remainingPct 12 → true (<=); remainingPct 13 → false.
+    const hours = 2;
+    expect(protectionActive({ rates, hoursUntilReset: hours, remainingPct: 12 })).toBe(true);
+    expect(protectionActive({ rates, hoursUntilReset: hours, remainingPct: 13 })).toBe(false);
+  });
+
+  it("true when there is essentially no budget left at all", () => {
+    expect(protectionActive({ rates, hoursUntilReset: 5, remainingPct: 0 })).toBe(true);
+  });
+});
+
+describe("exports sanity", () => {
+  it("PROTECTION_QUANTILE = 1 - v_low/v_high", () => {
+    expect(PROTECTION_QUANTILE).toBeCloseTo(0.65, 6);
+    expect(PROTECTION_LAMBDA_MULTIPLIER).toBe(3);
+    expect(MIN_TOKENS_PER_PCT_SAMPLE).toBe(5);
+    expect(OPTIMIZER_LYAPUNOV_V).toBe(25);
+    expect(ECO_THRESHOLDS).toEqual([10, 25, 40]);
+  });
+
+  it("quantile returns the element at the linear-approach index", () => {
+    expect(quantile([1, 2, 3, 4], 0)).toBe(1);
+    expect(quantile([1, 2, 3, 4], 1)).toBe(4);
+    expect(quantile([1, 2, 3, 4], 0.5)).toBe(Math.round((4 - 1) * 0.5) === 1 ? 2 : 2); // idx floor(3*.5)=1
+    expect(quantile([], 0.5)).toBe(null);
+  });
+});

--- a/src/shared/routingBoundary.d.mts
+++ b/src/shared/routingBoundary.d.mts
@@ -6,6 +6,10 @@ export const BOUNDARY: {
   USER: string;
 };
 
+export const ROUTING_REWARM_BETA: number;
+export const ROUTING_REWARM_HORIZON_TURNS: number;
+export const CACHE_WRITE_MULTIPLIER: number;
+
 /**
  * A routed endpoint as it crosses the RPC boundary: the RPC/deliver shape uses
  * `modelID`, the router's internal catalogue shape uses `id`. `endpointKey`
@@ -54,6 +58,12 @@ export interface ShouldSwitchInput {
   incumbentStillCapable: boolean;
   incumbentHealthy: boolean;
   topN?: number;
+  // Optimizer P2.3 (BET-1345): the rewarm hysteresis. Server-priced $ values;
+  // when either is absent, or `freeSwitch` is true (post-compaction / dead
+  // cache), the rewarm term is skipped and today's contention answer stands.
+  savingsPerTurn?: number;
+  rewarmCost?: number;
+  freeSwitch?: boolean;
 }
 
 export interface ShouldSwitchResult {

--- a/src/shared/routingBoundary.mjs
+++ b/src/shared/routingBoundary.mjs
@@ -31,6 +31,16 @@ import { endpointKey } from "./endpointKey.mjs";
 // declared modalities = allow, never "supports nothing" (BET-1267 3e).
 import { acceptsModality } from "./modelGuide.mjs";
 
+// Optimizer P2.3 (BET-1345): the rewarm hysteresis term. Switching model
+// mid-conversation discards the prompt cache and re-bills the whole prefix, so
+// a switch that contention alone would allow may not be worth it if the winner's
+// savings over the next few turns do not pay for re-warming the winner's cache
+// prefix. `savingsPerTurn * HORIZON_TURNS <= BETA * rewarmCost` → the savings
+// won't recover the rewarm cost within the horizon → DON'T switch.
+export const ROUTING_REWARM_BETA = 1.0;
+export const ROUTING_REWARM_HORIZON_TURNS = 10;
+export const CACHE_WRITE_MULTIPLIER = 1.25;
+
 /**
  * Does this turn cross a decision point?
  *
@@ -159,6 +169,12 @@ function incumbentIndex(incumbent, ranked) {
  * @param {boolean}     input.incumbentStillCapable   does it still fit the turn
  * @param {boolean}     input.incumbentHealthy        is its provider available
  * @param {number}      [input.topN]             contention window (default 3)
+ * @param {number}      [input.savingsPerTurn]   $ the winner saves per turn over
+ *   the incumbent (server-priced; null when the incumbent didn't survive routing)
+ * @param {number}      [input.rewarmCost]       $ to re-warm the winner's cache
+ *   prefix (server-priced; null when the write rate is unknown)
+ * @param {boolean}     [input.freeSwitch]       true at post-compaction / dead
+ *   cache — a free moment with no prefix to re-warm, so no rewarm term applies
  * @returns {{ switch: boolean, why: string }}
  */
 export function shouldSwitch(input = {}) {
@@ -169,6 +185,9 @@ export function shouldSwitch(input = {}) {
     incumbentStillCapable = true,
     incumbentHealthy = true,
     topN = 3,
+    savingsPerTurn,
+    rewarmCost,
+    freeSwitch,
   } = input;
 
   if (incumbentStillEligible === false) {
@@ -182,7 +201,24 @@ export function shouldSwitch(input = {}) {
   }
 
   const pos = incumbentIndex(incumbent, ranked);
-  if (pos === -1 || pos >= topN) {
+  const droppedOut = pos === -1 || pos >= topN;
+  if (droppedOut) {
+    // The rewarm term can ONLY PREVENT a switch that contention alone would
+    // have allowed; it can never force one. `freeSwitch` (post-compaction /
+    // dead-cache) is a free moment with no prefix to re-warm → keep today's
+    // switch. Either price absent → today's behaviour.
+    const pricesKnown =
+      typeof savingsPerTurn === "number" &&
+      Number.isFinite(savingsPerTurn) &&
+      typeof rewarmCost === "number" &&
+      Number.isFinite(rewarmCost);
+    if (
+      freeSwitch !== true &&
+      pricesKnown &&
+      savingsPerTurn * ROUTING_REWARM_HORIZON_TURNS <= ROUTING_REWARM_BETA * rewarmCost
+    ) {
+      return { switch: false, why: "rewarm-not-worth-it" };
+    }
     return { switch: true, why: "incumbent-dropped-out" };
   }
   return { switch: false, why: "incumbent-retained" };

--- a/src/shared/routingBoundary.test.ts
+++ b/src/shared/routingBoundary.test.ts
@@ -351,3 +351,68 @@ describe("boundaryPhrase", () => {
     expect(boundaryPhrase("nope")).toBe("");
   });
 });
+
+// --- Optimizer P2.3: the rewarm hysteresis term (BET-1345) ------------------
+describe("shouldSwitch — rewarm hysteresis", () => {
+  // The incumbent is at index 3 (>= topN 3) → dropped out, so the contention
+  // answer would be "switch"; the rewarm term may then prevent it.
+  const base = {
+    incumbent: ep("anthropic", "a"),
+    ranked: [ep("openai", "b"), ep("deepseek", "c"), ep("groq", "d"), ep("anthropic", "a")],
+    incumbentStillEligible: true,
+    incumbentStillCapable: true,
+    incumbentHealthy: true,
+  };
+
+  it("all four forced branches still fire even with a huge rewarmCost", () => {
+    expect(shouldSwitch({ ...base, incumbentStillEligible: false, savingsPerTurn: 0, rewarmCost: 1e9 })).toEqual({
+      switch: true,
+      why: "incumbent-ineligible",
+    });
+    expect(shouldSwitch({ ...base, incumbentStillCapable: false, savingsPerTurn: 0, rewarmCost: 1e9 })).toEqual({
+      switch: true,
+      why: "incumbent-incapable",
+    });
+    expect(shouldSwitch({ ...base, incumbentHealthy: false, savingsPerTurn: 0, rewarmCost: 1e9 })).toEqual({
+      switch: true,
+      why: "incumbent-unhealthy",
+    });
+  });
+
+  it("freeSwitch:true bypasses the rewarm term (post-compaction is a free moment)", () => {
+    expect(shouldSwitch({ ...base, freeSwitch: true, savingsPerTurn: 0, rewarmCost: 1e9 })).toEqual({
+      switch: true,
+      why: "incumbent-dropped-out",
+    });
+  });
+
+  it("savings under the bar -> rewarm-not-worth-it (switch prevented)", () => {
+    // 0.001 * 10 = 0.01 <= 1 * 1 → the savings never recover the rewarm cost.
+    expect(shouldSwitch({ ...base, savingsPerTurn: 0.001, rewarmCost: 1 })).toEqual({
+      switch: false,
+      why: "rewarm-not-worth-it",
+    });
+  });
+
+  it("savings over the bar -> switches (dropped-out)", () => {
+    // 1 * 10 = 10 > 1 * 1 → worth it.
+    expect(shouldSwitch({ ...base, savingsPerTurn: 1, rewarmCost: 1 })).toEqual({
+      switch: true,
+      why: "incumbent-dropped-out",
+    });
+  });
+
+  it("either input absent -> today's answer (dropped-out)", () => {
+    expect(shouldSwitch({ ...base, rewarmCost: 1 })).toEqual({ switch: true, why: "incumbent-dropped-out" });
+    expect(shouldSwitch({ ...base, savingsPerTurn: 0.001 })).toEqual({ switch: true, why: "incumbent-dropped-out" });
+    expect(shouldSwitch({ ...base })).toEqual({ switch: true, why: "incumbent-dropped-out" });
+  });
+
+  it("the rewarm term never forces a switch: an incumbent still in top-N is retained", () => {
+    const kept = { ...base, ranked: [ep("anthropic", "a"), ep("openai", "b"), ep("deepseek", "c")] };
+    expect(shouldSwitch({ ...kept, savingsPerTurn: 100, rewarmCost: 1 })).toEqual({
+      switch: false,
+      why: "incumbent-retained",
+    });
+  });
+});


### PR DESCRIPTION
**Key:** BET-1345 — Optimizer P2.3: pacing controller (deficit queue, shadow price, rewarm hysteresis, eco level)

Implements the pacing controller stage of the optimizer "Act" epic:
- New pure `src/shared/quotaPressure.mjs` — the deficit-queue / shadow-price / eco / protection math + tests.
- New `src/server/optimizer/pacing.mjs` — stateful observation + persistence (`optimizer-pacing.json`), injected I/O, measured tokens-per-pct (fail-open).
- `marginalCost` — additive `shadowPrice` on the subscription pace curve; skipped when absent / lambda≤0 / null tokensPerPct / non-positive expectedTurnTokens (on/under-pace regime byte-identical).
- `modelRouter` — pressure folded in `assess()` (never the comparator); `expectedTurnTokens`/`isLowStakes`; eco moves the TARGET tier (effective preset becomes "economy" at eco level ≥2), never `meetsFloor`; a `costs` accessor for the wiring.
- `routingBoundary` — the rewarm term in `shouldSwitch` (only ever prevents a switch; freeSwitch bypasses).
- `routingServices` — `pressure` + `ecoLevel`, each independently guarded, both gated on `optimizerEnabled === true` and nothing else.
- `rpc routing:choose` — accepts `cachedPrefixTokens`, returns server-priced `savingsPerTurn`/`rewarmCost` + `trace.target.eco`.
- Renderer — passes the cached prefix, threads rewarm args + `freeSwitch` into `shouldSwitch`, and the Auto-row label shows "Eco" when the decision reports eco ≥ 1.

Hygiene:
- `cmpWithinModel` untouched; pressure folded in `assess()` where the full services bag is visible.
- No second usage poller — pacing observes the SAME `recordWindowObservations` tap.
- `optimizerEnabled` gates `pressure`/`ecoLevel` in `buildRoutingServices` only; does not appear in `routingActive`, and `modelRouting.preset` keeps its `"balanced"` default.
- Switch-off decision is identical to a no-pressure-services decision (tested).

**Base:** `origin/main @ 2c423ce3`

**Verification results:**
- PR branch (`multica/BET-1345-pacing-controller` @ `99b1faad`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `2815` pass / `0` fail / `0` skip. Failures: none. log sha256: `bda1fca424d8a3dfe49c8c11c302f7b287f1b913b5895aad97876041aa82e12a`
- Base (`main @ 2c423ce3`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`. log sha256: `fb21cfe4600e6679910cfa7b23c01494b3f1f3683ba9e720dfe1eeb3fb802f5d`
- **Conclusion:** `0` new failures on the PR branch; `2815` pass. Main was green with fewer tests (no pacing/quota tests yet).

Notes / scope:
- The subagent path (`delegate` startJob) does not wire the pacing reader, so subagent spawns route with absent pressure → "route exactly as today". The issue scopes server pricing to `routing:choose` and explicitly allows absent pressure; flagging as a deliberate scoping, not a gap.
- New state file `optimizer-pacing.json` goes through `statePath()` (sandbox-friendly).
