### PR TITLE
feat(server): wire optimizer pacing pressure into subagent routing (BET-1354)

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -665,9 +665,9 @@ export function chooseSubagentModel({
  *        PR, `{issue?, pr?}` shape) a forge-triggered delegate carries so the
  *        progress sink addresses the linked issue/PR. Stored on the job record.
  * @param {object} deps injected I/O (load/save/publish/deliver/listProjects/
- *        newWindow/gitAddWorktree/gitRun/oc listMessages/listModels/now;
- *        routingServices/catalogIndex/providerHealthState/endpointSummary for
- *        the router; chooseSubagentModel only as a test seam)
+  *        newWindow/gitAddWorktree/gitRun/oc listMessages/listModels/now;
+  *        routingServices/catalogIndex/providerHealthState/endpointSummary/pacing
+  *        for the router; chooseSubagentModel only as a test seam)
  */
 export async function startJob(input, deps = {}) {
   const { deliver, listModels, configGet = async () => ({}), listSnapshots = () => [] } = deps;
@@ -861,6 +861,7 @@ export async function startJob(input, deps = {}) {
           snapshots: quota,
           providerHealthState: deps.providerHealthState,
           endpointSummary: deps.endpointSummary,
+          pacing: deps.pacing,
         }, nowMs);
       } catch (e) {
         console.error(`[router] routing services degraded, routing on absent context: ${e?.message ?? e}`);

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -747,6 +747,62 @@ test("startJob routes to the non-deranked sibling when an endpoint is reliabilit
   assert.deepEqual(h.delivered[0].model, { providerID: "openai", modelID: "claude-sonnet-4" });
 });
 
+// BET-1354 — the pacing reader passed via `deps.pacing` reaches
+// buildRoutingServices and actually influences the subagent decision: with the
+// optimizer switch on, an ecoLevel >= 2 forces the effective preset to economy,
+// moving the build agent's TARGET tier from deep (opus-4) down to balanced
+// (sonnet-4) — the floor, which eco may move the target toward but never below.
+// Without a pacing reader (or with the switch off) the subagent routes exactly
+// as today. This is the subagent side of the main-panel routing:choose pacing
+// wiring (BET-1345).
+test("startJob applies optimizer pacing pressure to the subagent decision (BET-1354)", async () => {
+  const liveReaders = () => {
+    const h = startHarness("child_pacing");
+    h.deps.configGet = async () => ({ modelRouting: { preset: "balanced" }, optimizerEnabled: true });
+    h.deps.listSnapshots = () => [];
+    const models = [
+      normalize("anthropic", "claude-opus-4", rawProviderModel({ id: "claude-opus-4", cost: { input: 15, output: 75, cache: { read: 1.5, write: 22.5 } }, capabilities: { reasoning: true, toolcall: true } })),
+      normalize("anthropic", "claude-sonnet-4", rawProviderModel({ id: "claude-sonnet-4", cost: { input: 3, output: 15, cache: { read: 0.3, write: 4.5 } }, capabilities: { reasoning: true, toolcall: true } })),
+      normalize("anthropic", "claude-haiku-4", rawProviderModel({ id: "claude-haiku-4", cost: { input: 1, output: 5, cache: { read: 0.1, write: 1.5 } }, capabilities: { toolcall: true } })),
+    ];
+    h.deps.listModels = async () => models;
+    const cat = (id) => ({ id, family: familyKey(id) });
+    h.deps.catalogIndex = {
+      lookupModel: (id) => cat(id),
+      matchModel: (id) => ({ kind: "exact", candidates: [cat(id)] }),
+      allModels: () => [],
+    };
+    h.deps.providerHealthState = () => "ok";
+    h.deps.endpointSummary = async () => ({ supported: true, endpoints: {} });
+    return h;
+  };
+
+  // No pacing reader: optimizer is on but pressure is absent -> eco 0 -> the
+  // balanced preset stands, build targets "deep" -> opus-4 wins.
+  const noPacing = liveReaders();
+  const balanced = await startJob(
+    { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo", subagent_type: "build" },
+    noPacing.deps,
+  );
+  assert.equal(balanced.ok, true);
+  assert.deepEqual(noPacing.delivered[0].model, { providerID: "anthropic", modelID: "claude-opus-4" });
+
+  // With pacing pressure at ecoLevel 2 the effective preset becomes economy ->
+  // build targets "balanced" (its floor) -> sonnet-4 wins. This proves
+  // deps.pacing reached the router and moved the decision, not just that the
+  // builder was called.
+  const withPacing = liveReaders();
+  withPacing.deps.pacing = {
+    pressureFor: async () => ({ lambda: 1, tokensPerPct: 100, deficit: 30, ecoLevel: 2, protection: false }),
+  };
+  const eco = await startJob(
+    { prompt: "do it", parentSessionID: "parent", parentDirectory: "/repo", subagent_type: "build" },
+    withPacing.deps,
+  );
+  assert.equal(eco.ok, true);
+  assert.deepEqual(withPacing.delivered[0].model, { providerID: "anthropic", modelID: "claude-sonnet-4" });
+});
+
 test("startJob ignores the stale modelRouter key and delivers the incumbent (BET-1227)", async () => {
   const h = startHarness("child_stale_key");
   // The wrong, never-written key must NOT activate routing — a preset under

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -640,6 +640,12 @@ const delegateEngine = createDelegateEngine({
   catalogIndex: routingCatalogIndex,
   providerHealthState: (providerID) => providerHealth.state(providerID),
   endpointSummary: routingEndpointSummary,
+  // Optimizer P2.3 (BET-1345): pass the pacing state through to startJob's
+  // buildRoutingServices so the subagent model router sees the pacing shadow
+  // price when the optimizer switch is on. Null/absent → pressure absent → the
+  // subagent spawn routes exactly as today (behavior-neutral until the switch is
+  // on, mirroring the main-panel routing:choose wiring in rpc.mjs).
+  pacing: optimizerPacing,
   abortSession: (sid) => oc.abortSession(sid),
   // BET-418 §B: detect a running job whose parent opencode session is gone so
   // the sweeper can stop + clean it up (nobody left to report to).


### PR DESCRIPTION
## Summary

Wires the optimizer pacing reader (`src/server/optimizer/pacing.mjs`, `createPacingState`) into the **subagent spawn** routing path in `src/server/delegate.mjs` (`startJob` → `buildRoutingServices`).

Previously only the main-panel `routing:choose` handler (via `src/server/rpc.mjs` → `buildRoutingServices`) injected `deps.pacing`, so subagent model selection routed with absent pressure. This adds the same wiring to the delegate path:

- `src/server/index.mjs`: pass `pacing: optimizerPacing` into the `delegateEngine` deps (alongside `catalogIndex`/`providerHealthState`/`endpointSummary`).
- `src/server/delegate.mjs`: add `pacing: deps.pacing` to the `buildRoutingServices(cfg, {...})` call in `startJob`.

Behavior-neutral while `optimizerEnabled` is false — the gating in `routingServices.mjs` already short-circuits (pressure/eco absent → route exactly as today). This was deliberately excluded from BET-1345 as a scope boundary.

## Tests

Added `startJob applies optimizer pacing pressure to the subagent decision (BET-1354)` in `src/server/delegate.test.mjs`: with the optimizer switch on and a pacing reader at `ecoLevel >= 2`, the effective preset flips to economy and the build agent's target tier drops deep→balanced (winner opus-4 → sonnet-4). Without a pacing reader the subagent routes exactly as today. This locks the passthrough end-to-end through `startJob`.

**Files changed:** 3 files.

```
src/server/delegate.mjs      |  7 +++---
src/server/delegate.test.mjs | 56 ++++++++++++++++++++++++++++++++++++++++++++
src/server/index.mjs         |  6 +++++
```

**Verification results** (PR branch `multica/BET-1354-pacing-subagent` @ `65054707`):
- typecheck: exit 0. Errors: none.
- test: exit 0, 2838 pass / 0 fail / 0 skip. Failures: none.
- Conclusion: 0 new failures, 0 pre-existing — behavior-neutral change (subagent routing consumes pacing only when the optimizer switch is on).

**Base: origin/main @ `0c335763`**
