### PR TITLE
Optimizer P2.5 — activity log, tuner + guardrails, telemetry, dashboard + in-conversation UI (BET-1347)

### DIFF
--- a/docs/optimizer/monitors.md
+++ b/docs/optimizer/monitors.md
@@ -1,0 +1,114 @@
+# Optimizer guardrail monitors (Axiom)
+
+Optimizer P2.5 (BET-1347) — the three guardrails that constrain the tuner,
+documented so a maintainer can watch them on the `manta` Axiom dataset. These
+are documented, **not created**: there are currently zero monitors on the
+`manta` dataset, and the run does not create them — a maintainer does.
+
+The box enforces these guardrails server-side (a trip → the tuner reverts its
+change immediately and writes a `rolled-back` activity entry naming which
+guardrail). The monitors below are the *observability* equivalent: alert a
+human when one of the same conditions looks like it's happening, so the tuner's
+behaviour is auditable from outside the box.
+
+## What the telemetry carries
+
+The optimizer ships `channel == "ctx"` events to the `manta` dataset (via the
+server's existing Axiom log shipper). Every such event carries `channel: "ctx"`
+plus a `kind`, and **counts only** — never conversation content. Kinds:
+
+| `kind` | fields | meaning |
+|---|---|---|
+| `mask` | `maskedTokens`, `maskedParts`, `applied`, `mode` | a masking pass (reported by the optimizer plugin) |
+| `routing` | `switched`, `lambda`, `deficit`, `ecoLevel`, `routing` | a routing decision under pressure |
+| `compaction` | `beforeTokens`, `background` | a background compaction |
+| `tune` | `param`, `from`, `to`, `verdict` | a tuner step (`applied`/`kept`/`rolled-back`) |
+
+The events carry `sessionID` (opaque) but never titles/paths/content.
+
+## The three guardrails (server constants)
+
+From `src/server/optimizer/tuner.mjs`:
+
+- **Cache-hit drop** — the cache-hit rate fell more than
+  `GUARD_CACHE_HIT_DROP_PTS` (**10** points) below its ~an-hour-earlier value,
+  sustained `GUARD_SUSTAIN_MS` (**60 min**).
+- **Re-fetch churn** — churn above `GUARD_CHURN_PCT` (**2%**) of masked parts
+  (`countRefetchChurn`: a tool re-run whose earlier output we masked).
+- **Effective cost per turn** — up more than `GUARD_COST_PER_TURN_WOW`
+  (**20%**) week over week.
+
+## Monitor 1 — re-fetch churn (the most actionable)
+
+Churn is the honest measure of a trim that cost more than it saved. The tuner
+computes it with `countRefetchChurn`; surfaces it to telemetry as a `churn`
+field on `mask` events. Alert when rolling churn exceeds 2%.
+
+```apl
+['manta']
+| where ['channel'] == "ctx" and ['kind'] == "mask"
+| summarize churnPct = avg(['churn']) * 100 by bin_auto(['_time'])
+| where ['churnPct'] > 2
+```
+
+**Threshold:** value > 2 (percent), window ≥ 1 hour (the sustain period).
+
+> If the box build in the field predates the `churn` shipping on `mask` events,
+> derive it server-side instead: the value is `guardrail.evidence.churn` on
+> `rollback` (`tune` `verdict == "rolled-back"`) entries.
+
+## Monitor 2 — cache-hit drop
+
+Cache-hit rate is not pitched into Axiom per event (it is measured on the box).
+The observability proxy is the box's own guardrail verdict: a sustained drop is
+exactly what drives a `tune` `rollback`. Alert when the box rolled a change
+back for `cache-hit`:
+
+```apl
+['manta']
+| where ['channel'] == "ctx" and ['kind'] == "tune" and ['verdict'] == "rolled-back"
+| extend which = extract("guardrail=([a-z-]+)", 1, tostring(['guardrail']))
+| where ['which'] == "cache-hit"
+| summarize count() by bin_auto(['_time'])
+| where ['count_'] >= 1
+```
+
+**Threshold:** count ≥ 1 (any rollback for `cache-hit` is worth a human look).
+
+## Monitor 3 — effective cost per turn, week over week
+
+Weekly cost is aggregated from the box's ledger, not shipped per event. The
+observability proxy is cost exploding alongside tuner activity — ship/report
+`cost30d` and `turns30d` from the summary, then alert on the week-over-week
+delta:
+
+```apl
+['manta']
+| where ['channel'] == "ctx"
+| summarize costPerTurn = max(['costPerTurn']) by bin(['_time'], 7d)
+| where ['costPerTurn'] > 0
+| sort ['_time'] asc
+| extend prev = prev(['costPerTurn'])
+| extend wow = (['costPerTurn'] - ['prev']) / ['prev']
+| where ['wow'] > 0.2
+```
+
+**Threshold:** `wow` > 0.20 (20%).
+
+## Steps to create each monitor in Axiom
+
+1. Open **Axiom → Monitors → New Monitor**.
+2. Name it, e.g. `optimizer-guardrail-cache-hit` / `-churn` / `-cost`.
+3. Paste the query above into the query editor (dataset `manta`).
+4. Set the condition + the threshold interval exactly as noted for the query
+   (the sustain interval matters: a guardrail is "sustained", not a blip — use
+   the 1-hour / 7-day window).
+5. Pick a notify channel (email / Slack webhook) that routes to the maintainer
+   who owns the box's tuner.
+6. **Notify every time** the condition is true (not just once), matching the
+   conservative "revert and tell me" semantics of the tuner.
+7. Save + enable.
+
+Because the underlying signals are **counts only**, these monitors never fire
+on conversation content — a trip is always on shape/volume/verdict, never on
+what a user said.

--- a/src/renderer/ChatPanel.harness.test.tsx
+++ b/src/renderer/ChatPanel.harness.test.tsx
@@ -108,6 +108,31 @@ describe("ChatPanel render harness", () => {
     expect(h.text().toLowerCase()).toMatch(/allow|permission|run command/);
   });
 
+  it("renders the background-compaction one-liner (BET-1347)", async () => {
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    expect(h.text()).not.toContain("Compacted");
+    await emitStreamAndFlush(bus, h, {
+      sub: "optimizer.compacted",
+      sessionId: "ses_test",
+      payload: { beforeTokens: 128_000, afterTokens: 31_000, away: true },
+    });
+    expect(h.text()).toContain("Compacted while you were away");
+    expect(h.text()).toContain("128k");
+    expect(h.text()).toContain("31k");
+  });
+
+  it("falls back to background wording (no after-token count / not away) (BET-1347)", async () => {
+    h = mount(<ChatPanel {...PROPS} />);
+    await h.flush();
+    await emitStreamAndFlush(bus, h, {
+      sub: "optimizer.compacted",
+      sessionId: "ses_test",
+      payload: { beforeTokens: 90_000, afterTokens: null, away: false },
+    });
+    expect(h.text()).toContain("Compacted in the background");
+  });
+
   it("ignores events for a different session id", async () => {
     h = mount(<ChatPanel {...PROPS} />);
     await h.flush();

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -24,6 +24,7 @@ import type {
   DelegateApprovalTool,
   ForgeCheckRun,
   OpencodeModel,
+  OptimizerSummary,
   ProgressRecord,
   PullRequest,
   QuestionRequest,
@@ -223,6 +224,32 @@ export function ChatPanel({
   // key itself stays pinned at "balanced" in config; eco is runtime routing
   // state, never a config change.
   const [routingEco, setRoutingEco] = useState<number>(0);
+  // BET-1347: this conversation's optimizer savings %, for the "↓ N% this
+  // conversation" pill next to the usage dial. Fetched once per conversation
+  // from the shared summary (bySession.savedPct is a 0..1 fraction); null when
+  // absent → the pill is not rendered.
+  const [optSavingPct, setOptSavingPct] = useState<number | null>(null);
+  // Fetch this conversation's optimizer savings once per switch into it. The
+  // summary is memoized server-side (60s), so this is cheap and bounded.
+  useEffect(() => {
+    let alive = true;
+    setOptSavingPct(null);
+    window.api
+      .optimizerSummary()
+      .then((s: OptimizerSummary | { supported: false }) => {
+        if (!alive || !s || !s.supported) return;
+        const row = (s.bySession ?? []).find((e) => e.sessionID === sessionId);
+        if (row && typeof row.savedPct === "number" && row.savedPct > 0) {
+          setOptSavingPct(Math.round(row.savedPct * 100));
+        }
+      })
+      .catch(() => {
+        /* silent — absent savings never hides the pill with a fake 0 */
+      });
+    return () => {
+      alive = false;
+    };
+  }, [sessionId]);
   const hiddenStatusItems = useStore((s) => s.hiddenStatusItems);
   // BET-789: the "Connect GitHub…" offer's per-box dismissal flag. Once set,
   // the offer never re-appears until the config flag is cleared.
@@ -3432,7 +3459,8 @@ export function ChatPanel({
         onOpenModels={ensureModels}
         onSelectModel={selectModel}
         onSelectEffort={onSelectEffort}
-        presetLabel={routingEco >= 1 ? "Eco" : routingPreset ? titleCase(routingPreset) : undefined}
+        presetLabel={routingPreset ? `${titleCase(routingPreset)}${routingEco >= 1 ? " · eco" : ""}` : undefined}
+        optSavingPct={optSavingPct}
         scheduleCount={schedules.length}
         onSchedules={() => togglePanel("schedules")}
         onSecrets={() => togglePanel("secrets")}

--- a/src/renderer/ChatPanel.tsx
+++ b/src/renderer/ChatPanel.tsx
@@ -66,6 +66,7 @@ import {
   extractPlanData,
   selectableModelGroups,
   titleCase,
+  formatCompactionSaving,
 } from "./chatUtils";
 import { isPlanAgent, planPageUrl } from "../shared/planMode.mjs";
 import { serverBase } from "./api/httpApi";
@@ -629,6 +630,7 @@ export function ChatPanel({
     finishByMessageId,
     retryInfo,
     compactionState,
+    compactionNotice,
     rejectAllPendingQuestions,
     refreshPermissions,
     refreshQuestions,
@@ -2849,6 +2851,7 @@ export function ChatPanel({
     compaction: { order: 6, label: "↧ compaction" },
     "send-error": { order: 5, label: "⚠ error" },
     queued: { order: 4, label: "⏳ queued" },
+    "compaction-notice": { order: 3, label: "⟳ compaction" },
     schedules: { order: 3, label: "⏰ schedule" },
     secrets: { order: 2, label: "🔑 secret" },
     webhooks: { order: 1, label: "🪝 webhook" },
@@ -3108,6 +3111,19 @@ export function ChatPanel({
       <div className="shrink-0 px-4 pt-2"><RetryCard info={retryInfo} /></div>));
     if (compactionState) list.push(amb("compaction",
       <div className="shrink-0 px-4 pt-2"><CompactionCard state={compactionState} /></div>));
+    // BET-1347: the box compacted this conversation in the background — one
+    // pass-by line, not a card. "while you were away" only when the box's
+    // presence said away at compaction time; otherwise the background wording.
+    if (compactionNotice) {
+      const saving = formatCompactionSaving(compactionNotice.beforeTokens ?? 0, compactionNotice.afterTokens ?? 0);
+      const base = compactionNotice.away
+        ? "⟳ Compacted while you were away"
+        : "⟳ Compacted in the background";
+      list.push(amb("compaction-notice",
+        <div className="shrink-0 px-4 pt-2">
+          <div className="opt-compact-line">{saving === "0" ? base : `${base} · ${saving}`}</div>
+        </div>));
+    }
     if (sendError) list.push(amb("send-error",
       <div className="shrink-0 mx-4 mb-1 px-2 py-1 text-meta text-danger bg-danger-bg border border-danger/30 rounded-xs break-words flex items-start gap-2">
         <span className="flex-1">⚠ {sendError}</span>
@@ -3189,7 +3205,7 @@ export function ChatPanel({
         </div>));
     }
     return list;
-  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipProposal, shipBusy, shipError, liveProgress]);
+  }, [jobOwnership, permissions, pendingApproval, retryInfo, compactionState, compactionNotice, sendError, authReconnect, running, messageQueue, openPanel, schedules, scheduleError, secretError, secrets, webhooks, webhookError, closePanel, setSchedules, refreshSchedules, setScheduleError, setSendError, setMessageQueue, setPendingApproval, setSecrets, refreshSecrets, setSecretError, setWebhooks, refreshWebhooks, setWebhookError, sessionId, replyPermission, shipProposal, shipBusy, shipError, liveProgress]);
 
 
   if (error || transcriptLoadError) {

--- a/src/renderer/InputArea.tsx
+++ b/src/renderer/InputArea.tsx
@@ -166,6 +166,10 @@ export function InputArea({
   onSelectModel,
   onSelectEffort,
   presetLabel,
+  // BET-1347: this conversation's optimizer savings (savedPct × 100, 0..100)
+  // for the "↓ N% this conversation" pill next to the usage dial. null/absent
+  // → the pill is not rendered (never a fabricated 0).
+  optSavingPct,
   scheduleCount,
   onSchedules,
   onSecrets,
@@ -250,6 +254,8 @@ export function InputArea({
   onSelectEffort: (m: ModelSelection) => void;
   // BET-1274 10d: the routing preset's display label for the Auto row.
   presetLabel?: string;
+  // BET-1347: this conversation's optimizer savings pct for the composer pill.
+  optSavingPct?: number | null;
   // Plan-mode chip (BET-949): the resolved toggle state + the flip handler.
   plan: PlanToggleState;
   onTogglePlan: () => void;
@@ -622,6 +628,11 @@ export function InputArea({
             spaced run instead of a detached dial 12px off the group. */}
         <span className="shrink-0 flex items-center gap-2 flex-wrap">
           <UsageDial providerID={activeProviderID} />
+          {typeof optSavingPct === "number" && optSavingPct > 0 && (
+            <span className="composer-saving-pill">
+              ↓ {Math.round(optSavingPct)}% <span className="tx-faint">this conversation</span>
+            </span>
+          )}
           <SessionToolbar
             scheduleCount={scheduleCount}
             onSchedules={onSchedules}

--- a/src/renderer/OptimizerCard.test.tsx
+++ b/src/renderer/OptimizerCard.test.tsx
@@ -1,0 +1,152 @@
+// @vitest-environment jsdom
+//
+// Component tests for the Optimizer P2.5 (BET-1347) legibility surfaces on the
+// Settings → Models optimizer card: the activity feed's empty state, the
+// pressure chips (neutral when there is no signal, never a fabricated pace),
+// and the metered-endpoints row (role + price, deliberately NO gauge).
+
+import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { mount, installMockApi, resetStore, type Harness } from "./testHarness";
+import { OptimizerCard } from "./OptimizerCard";
+import type { OptimizerSummary } from "../shared/types";
+
+const CD = { cacheRead: 8000, cacheWrite: 1000, input: 1000, output: 500 };
+
+function fixture(over: Partial<OptimizerSummary> = {}): OptimizerSummary {
+  return {
+    supported: true,
+    windowDays: 30,
+    totals: { turns: 100, cost: 12.34, input: 1000, output: 500, cacheRead: 8000, cacheWrite: 1000 },
+    cacheShare: { ...CD },
+    dailySeries: [
+      { day: "2026-08-01", tokensSent: 1000, maskedTokens: 0 },
+      { day: "2026-08-02", tokensSent: 1200, maskedTokens: 0 },
+    ],
+    bySession: [{ sessionID: "s1", turns: 100, cost: 12.34, tokensSent: 2200, savedPct: 0 }],
+    ttl: { measuredMs: 300_000, confidence: "default", observations: 0, configuredMs: 300_000, matched: null },
+    counterfactual: { dailySeries: [], bySession: {} },
+    windows: [
+      {
+        provider: "claude",
+        planLabel: "Max 20x",
+        windowLabel: "week",
+        kind: "weekly",
+        pct: 34,
+        resetsAt: 0,
+        forecastPct: 52,
+        deficit: 0,
+        tokensPerPct: null,
+      },
+    ],
+    activity: { entries: [] },
+    compaction: null,
+    metered: [],
+    ...over,
+  };
+}
+
+describe("OptimizerCard — P2.5 legibility surfaces", () => {
+  let h: Harness | null = null;
+
+  beforeEach(() => {
+    resetStore({ optimizerEnabled: false });
+  });
+
+  afterEach(() => {
+    h?.unmount();
+    h = null;
+  });
+
+  it("with an empty activity feed renders the documented empty state and NO feed rows", async () => {
+    installMockApi({ optimizerSummary: () => Promise.resolve(fixture({ activity: { entries: [] } })) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    const text = h.text();
+    expect(text).toContain("Nothing changed yet. Manta needs a few days of your usage before it starts tuning anything.");
+    // No feed rows: no headline times, and no feed container content.
+    expect(h.container.querySelectorAll(".opt-ev").length).toBe(0);
+  });
+
+  it("renders feed rows + a rolled-back row stays visually distinct when entries exist", async () => {
+    installMockApi({
+      optimizerSummary: () =>
+        Promise.resolve(
+          fixture({
+            activity: {
+              entries: [
+                { id: "a", ts: 1_700_000_000_000, kind: "tune", subject: "trim threshold 16 → 12 tool uses", from: 16, to: 12, verdict: "kept", evidence: { turns: 62 } },
+                { id: "b", ts: 1_700_000_000_001, kind: "tune", subject: "protected tail 40k → 24k", from: 40_000, to: 24_000, verdict: "rolled-back", revertedAt: 1_700_000_000_100, evidence: { churn: 0.03 } },
+              ],
+            },
+          }),
+        ),
+    });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    const text = h.text();
+    expect(text).toContain("Kept — trim threshold 16 → 12 tool uses");
+    expect(text).toContain("Rolled back — protected tail 40k → 24k");
+    expect(h.container.querySelectorAll(".opt-ev").length).toBe(2);
+    expect(h.container.querySelectorAll(".opt-ev.rb").length).toBe(1);
+  });
+
+  it("no pressure signal renders the neutral chip and NO warn chip", async () => {
+    // The fixture window has tokensPerPct: null → no signal.
+    installMockApi({ optimizerSummary: () => Promise.resolve(fixture()) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    const text = h.text();
+    expect(text).toContain("no pressure signal yet");
+    // The neutral chip is the only chip — no warn chip for an absent signal
+    // (the "ahead of pace" phrase in window copy must not become a chip).
+    const chipText = [...h.container.querySelectorAll(".opt-chip")].map((c) => c.textContent ?? "").join(" ");
+    expect(chipText).not.toContain("ahead of pace");
+    expect(h.container.querySelectorAll(".opt-chip.warn").length).toBe(0);
+  });
+
+  it("a window ahead of pace (signal present, deficit > 0) renders a warn chip", async () => {
+    const f = fixture();
+    f.windows[0].tokensPerPct = 100;
+    f.windows[0].deficit = 23;
+    installMockApi({ optimizerSummary: () => Promise.resolve(f) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("+23 pts ahead of pace");
+    expect(h.container.querySelectorAll(".opt-chip.warn").length).toBe(1);
+  });
+
+  it("a metered endpoint renders the row with role + price and NO gauge element", async () => {
+    const f = fixture({
+      metered: [
+        { name: "OpenAI · gpt-5.2", role: "fallback when over pace", price: "$2.40 / Mtok blended" },
+        { name: "Groq · llama-4-70b", role: "explore + title work", price: "$0.31 / Mtok blended" },
+      ],
+    });
+    installMockApi({ optimizerSummary: () => Promise.resolve(f) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    const text = h.text();
+    expect(text).toContain("Metered endpoints");
+    expect(text).toContain("gpt-5.2");
+    expect(text).toContain("$2.40 / Mtok blended");
+    // Gauges are only for subscription windows (1 in the fixture) — the
+    // metered row is a slim role+price line with NO gauge.
+    const windowCount = f.windows.length;
+    expect(h.container.querySelectorAll(".opt-gauge").length).toBe(windowCount);
+  });
+
+  it("compaction stat shows 'X of Y in background' when the scheduler reports", async () => {
+    installMockApi({
+      optimizerSummary: () =>
+        Promise.resolve(
+          fixture({
+            compaction: { background: 6, total: 7 },
+            windows: [{ provider: "claude", planLabel: "Max", windowLabel: "week", kind: "weekly", pct: 10, resetsAt: 0, forecastPct: null, deficit: null, tokensPerPct: null }],
+          }),
+        ),
+    });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("6 of 7 in background");
+  });
+});

--- a/src/renderer/OptimizerCard.tsx
+++ b/src/renderer/OptimizerCard.tsx
@@ -1,26 +1,39 @@
-// ===== OptimizerCard (BET-1337) =====
+// ===== OptimizerCard (BET-1337 + P2.5 BET-1347) =====
 //
-// Read-only phase-1 "Observe" card in Settings → Models: the quota-window
-// fuel gauges (with their forecast-at-reset tick), the "sent vs raw
-// counterfactual" consumption chart, and the 30-day stats row. EVERYTHING it
-// renders is backed by the `optimizer:summary` read model (BET-1333 + children
-// 2–4). It renders NOTHING from phase 2 — no switch, no activity feed, no
-// pressure chips, no metered endpoints, no "optimizer on" graph marker.
-// Observe and report only; nothing actuates.
+// Phase-1 "Observe" card in Settings → Models (quota-window fuel gauges,
+// forecast-at-reset tick, sent-vs-raw consumption chart, 30-day stats), now
+// extended by BET-1347 with the legibility surfaces: the switch card's
+// read-only status sub-rows, pressure chips under each gauge, the metered-
+// endpoints slim row (role + crossover price, DELIBERATELY no gauge — a
+// metered endpoint has no window and never resets, so there is nothing to
+// fill), and the activity feed that is the optimizer's trust surface.
 //
-// State handling mirrors ModelLedgerCard exactly (BET-1221):
+// EVERYTHING renders from the `optimizer:summary` read model (BET-1333 +
+// children). AGENTS.md "NEVER STUB A CONTROL TO DO NOTHING": a status sub-row
+// appears only when its backing subsystem reports data; absent data renders the
+// documented empty state, never a fabricated zero. The editable switch toggle
+// is the schema-driven `optimizerEnabled` control (BET-1343) rendered by the
+// settings form above this card — this card shows its current state, never a
+// second toggle for the same setting.
+//
+// State handling mirrors ModelLedgerCard / the phase-1 card, unchanged:
 //   - loading  → "Reading your history…"
-//   - fetch rejected (network) → render nothing (hide the card entirely; a
-//     transient glitch must not read as "your runtime is outdated")
+//   - fetch rejected → hide the card (a transient glitch must not read as
+//     "your runtime is outdated")
 //   - { supported:false } → "…needs a newer box runtime." — NO zeros.
 //   - loaded   → the card.
-//
-// Fetches once on mount (the Models section mounts this card only when it
-// becomes visible). No polling — the server memoizes the summary for 60s.
 
 import { useEffect, useState } from "react";
 import { Card } from "./Card";
-import { buildCumulativePath, formatResetAt, formatTokens } from "./chatUtils";
+import { useStore } from "./store";
+import {
+  buildCumulativePath,
+  formatResetAt,
+  formatTokens,
+  formatClockTime,
+  describePressure,
+  describeActivityEntry,
+} from "./chatUtils";
 import type { OptimizerSummary } from "../shared/types";
 
 type OptimizerData = OptimizerSummary | { supported: false };
@@ -62,6 +75,7 @@ function axisTokens(v: number): string {
 const CHART = { left: 50, top: 6, width: 600, height: 200 };
 
 export function OptimizerCard() {
+  const optimizerEnabled = useStore((s) => s.optimizerEnabled);
   const [state, setState] = useState<{
     loading: boolean;
     data: OptimizerData | null;
@@ -76,9 +90,6 @@ export function OptimizerCard() {
         if (alive) setState({ loading: false, data: r, fetchError: false });
       })
       .catch(() => {
-        // Fetch failed (not "unsupported" — that returns as a resolved
-        // { supported:false }). Hide the card, don't mislead into an upgrade
-        // sentence for a transient network problem.
         if (alive) setState({ loading: false, data: null, fetchError: true });
       });
     return () => {
@@ -123,6 +134,7 @@ export function OptimizerCard() {
   const sent30d = d.dailySeries.reduce((s, e) => s + (e.tokensSent || 0), 0);
   const masked30d = d.dailySeries.reduce((s, e) => s + (e.maskedTokens || 0), 0);
   const raw30d = sent30d + masked30d;
+  const trimmedPct = raw30d > 0 ? (masked30d / raw30d) * 100 : 0;
 
   // Consumption chart series (cumulative), scaled together by the peak.
   const maxTokens = Math.max(raw30d, 1);
@@ -148,20 +160,97 @@ export function OptimizerCard() {
 
   const costPerTurn = d.totals.turns > 0 ? `$${(d.totals.cost / d.totals.turns).toFixed(2)}` : "—";
 
+  // BET-1347 slices.
+  const activity = Array.isArray(d.activity?.entries) ? d.activity.entries : [];
+  const compaction = d.compaction && d.compaction.total > 0 ? d.compaction : null;
+  const metered = Array.isArray(d.metered) ? d.metered : [];
+  // Pacing is "reporting" when any window carries a pressure signal.
+  const pacingActive = windows.some((w) => typeof w.tokensPerPct === "number");
+  const worstWindow = windows.reduce<(typeof windows)[number] | null>(
+    (worst, w) => (w.tokensPerPct != null && (worst == null || (w.deficit ?? 0) > (worst.deficit ?? 0)) ? w : worst),
+    null,
+  );
+  const pacingChip = pacingActive && worstWindow ? describePressure(worstWindow.deficit ?? 0, true) : null;
+
   return (
     <Card header={header}>
+      {/* ── Switch card: the read-only status sub-rows (BET-1347) ────────── */}
+      <div className="opt-switch">
+        <div className="opt-switch-head">
+          <div className="opt-switch-txt">
+            <b>Manta optimized token usage</b>
+            <p>
+              Manta trims, paces and compacts your conversations to make a plan last
+              longer. It never changes which model you picked by hand. Everything it
+              changes is listed below.
+            </p>
+          </div>
+          {/* The state indicator reflects the schema-driven optimizerEnabled
+              toggle (BET-1343) rendered above this card — this is its status,
+              not a second edit control for the same setting. */}
+          <span className={`opt-switch-state${optimizerEnabled ? " on" : ""}`}>
+            {optimizerEnabled ? "On" : "Off"}
+          </span>
+        </div>
+        <div className="opt-subrows">
+          {trimmedPct > 0 && (
+            <div className="opt-subrow">
+              <span className="opt-subrow-n">Trimming</span>
+              <span className="opt-subrow-v">
+                Old tool output is replaced by a one-line placeholder after a few newer
+                tool uses. The last 40k tokens are never touched.
+              </span>
+              <span className="opt-subrow-k">−{Math.round(trimmedPct)}% sent</span>
+            </div>
+          )}
+          {pacingActive && pacingChip && (
+            <div className="opt-subrow">
+              <span className="opt-subrow-n">Pacing</span>
+              <span className="opt-subrow-v">
+                Cheaper models while a plan window is ahead of pace. Build and plan work
+                keeps its quality floor.
+              </span>
+              <span className="opt-subrow-k">eco · {pacingChip.text}</span>
+            </div>
+          )}
+          {compaction && (
+            <div className="opt-subrow">
+              <span className="opt-subrow-n">Compacting</span>
+              <span className="opt-subrow-v">
+                Long idle conversations are summarized in the background, before you come
+                back to them.
+              </span>
+              <span className="opt-subrow-k">
+                {compaction.background} of {compaction.total} in background
+              </span>
+            </div>
+          )}
+          <div className="opt-subrow">
+            <span className="opt-subrow-n">Prompt cache</span>
+            <span className="opt-subrow-v">
+              Reads billed at 0.1×; TTL {d.ttl ? ttlLabel(d.ttl.measuredMs) : "5m"} measured.
+            </span>
+            <span className="opt-subrow-k">{wholePct(cacheHitPct)} hit</span>
+          </div>
+        </div>
+      </div>
+
+      {/* ── Subscription windows + pressure chips ────────────────────────── */}
       {hasWindows && (
         <>
-          <div className="text-label text-text">Subscription windows</div>
+          <div className="text-label text-text" style={{ marginTop: "var(--sp-6)" }}>
+            Subscription windows
+          </div>
           <p className="opt-sub">
-            Forecast from your recent usage. Tick = forecast at reset (hidden until enough
-            history).
+            Forecast from your recent usage. Tick = forecast at reset. Pressure chip = how
+            far ahead of pace this window is right now.
           </p>
           <div className="opt-wins">
             {windows.map((w) => {
               const title = [w.planLabel, w.windowLabel].filter(Boolean).join(" — ");
               const pct = Number.isFinite(w.pct) ? w.pct : 0;
               const fp = typeof w.forecastPct === "number" ? w.forecastPct : null;
+              const chip = describePressure(w.deficit ?? 0, typeof w.tokensPerPct === "number");
               return (
                 <div className="opt-win" key={`${w.provider}:${w.windowLabel}`}>
                   <div className="opt-win-t">
@@ -186,6 +275,9 @@ export function OptimizerCard() {
                     <span>{wholePct(pct)} used</span>
                     <span>{fp != null ? `forecast ${wholePct(fp)}` : "gathering history…"}</span>
                   </div>
+                  <div style={{ marginTop: "var(--sp-2)" }}>
+                    <span className={`opt-chip ${chip.tone}`}>{chip.text}</span>
+                  </div>
                 </div>
               );
             })}
@@ -193,9 +285,8 @@ export function OptimizerCard() {
         </>
       )}
 
-      <div className="opt-chart-head">
-        Token consumption — with &amp; without optimization
-      </div>
+      {/* ── Consumption chart (phase 1, unchanged) ───────────────────────── */}
+      <div className="opt-chart-head">Token consumption — with &amp; without optimization</div>
       <svg
         className="opt-chart"
         viewBox={`0 0 ${CHART.left + CHART.width + 6} ${CHART.top + CHART.height + 18}`}
@@ -203,19 +294,15 @@ export function OptimizerCard() {
         aria-label="Token consumption with and without optimization"
       >
         <g transform={`translate(${CHART.left} ${CHART.top})`}>
-          {/* Baseline (zero) + dashed gridlines at half and full scale. */}
           <line x1="0" y1={CHART.height} x2={CHART.width} y2={CHART.height} stroke="var(--border-subtle)" />
           <line x1="0" y1={CHART.height / 2} x2={CHART.width} y2={CHART.height / 2} stroke="var(--border-subtle)" strokeDasharray="2 5" opacity=".6" />
           <line x1="0" y1="0" x2={CHART.width} y2="0" stroke="var(--border-subtle)" strokeDasharray="2 5" opacity=".6" />
-          {/* Y-axis (left edge of the plot). */}
           <line x1="0" y1="0" x2="0" y2={CHART.height} stroke="var(--border-subtle)" />
 
-          {/* Axis labels — tokens only, inline mono, 10px. */}
           <text x="-8" y={CHART.height + 12} textAnchor="end" fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">0</text>
           <text x="-8" y={CHART.height / 2 + 4} textAnchor="end" fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">{axisTokens(maxTokens / 2)}</text>
           <text x="-8" y="4" textAnchor="end" fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">{axisTokens(maxTokens)}</text>
 
-          {/* Raw counterfactual line (dashed) + sent line (accent) + area fill. */}
           <path d={rawPath} fill="none" stroke="var(--tx4)" strokeWidth="2" strokeDasharray="5 4" />
           <path d={sentPath} fill="none" stroke="var(--accent)" strokeWidth="2.5" />
           <path
@@ -224,7 +311,6 @@ export function OptimizerCard() {
             stroke="none"
           />
 
-          {/* Saving annotation — the vertical gap is masked tokens. */}
           {masked30d > 0 && (
             <text x={CHART.width} y="24" textAnchor="end" fill="var(--ok)" fontSize="10" fontFamily="var(--font-mono)">
               −{formatTokens(masked30d)} · ≈ ${saved} est.
@@ -257,9 +343,6 @@ export function OptimizerCard() {
         <div className="opt-stat">
           <div className="opt-stat-l">Cache hit</div>
           <div className="opt-stat-v">{wholePct(cacheHitPct)}</div>
-          {/* TTL detail (BET-1341) drawn from the measured effective TTL's
-              label + confidence — "TTL 5m measured" / "TTL 1h measured" /
-              "TTL 5m default" per the BET-1337 spec. */}
           <div className="opt-stat-d">
             {d.ttl ? `TTL ${ttlLabel(d.ttl.measuredMs)} ${d.ttl.confidence}` : ""}
           </div>
@@ -272,9 +355,63 @@ export function OptimizerCard() {
         <div className="opt-stat">
           <div className="opt-stat-l">Sessions</div>
           <div className="opt-stat-v">{d.bySession.length}</div>
-          <div className="opt-stat-d">30d</div>
+          {compaction ? (
+            <div className="opt-stat-d" data-testid="compaction-bg">
+              {compaction.background} of {compaction.total} in background
+            </div>
+          ) : (
+            <div className="opt-stat-d">30d</div>
+          )}
         </div>
       </div>
+
+      {/* ── Metered endpoints: slim role + crossover price, NO gauge ─────── */}
+      {metered.length > 0 && (
+        <div className="opt-meter">
+          <div className="opt-chart-head">Metered endpoints</div>
+          <p className="opt-sub">
+            Pay-per-token endpoints have no window and never reset, so there is nothing to
+            fill — only a role and the price at which they beat the subscription.
+          </p>
+          {metered.map((m) => (
+            <div className="opt-meter-row" key={m.name}>
+              <b>{m.name}</b>
+              <span className="opt-meter-role">{m.role}</span>
+              <span className="opt-meter-px">{m.price}</span>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* ── Activity feed: the trust surface ─────────────────────────────── */}
+      <div className="opt-chart-head" style={{ marginTop: "var(--sp-6)" }}>
+        Activity
+      </div>
+      <p className="opt-sub">
+        Every parameter change the optimizer made on its own, with the evidence it used.
+        Rolled-back entries stay — that is the point.
+      </p>
+      {activity.length === 0 ? (
+        <div className="opt-empty">
+          Nothing changed yet. Manta needs a few days of your usage before it starts tuning
+          anything.
+        </div>
+      ) : (
+        <div className="opt-feed">
+          {activity.map((e) => {
+            const { headline, detail } = describeActivityEntry(e);
+            return (
+              <div className={`opt-ev${e.verdict === "rolled-back" ? " rb" : ""}`} key={e.id}>
+                <span className="opt-ev-when">{formatClockTime(e.ts)}</span>
+                <div className="opt-ev-body">
+                  <div className="opt-ev-hd">{headline}</div>
+                  {detail && <div className="opt-ev-why">{detail}</div>}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
     </Card>
   );
 }

--- a/src/renderer/chatUtils.test.ts
+++ b/src/renderer/chatUtils.test.ts
@@ -112,6 +112,9 @@ import {
   decodeDataUri,
   fetchTranscriptWithRetry,
   selectUsageSnapshot,
+  describePressure,
+  describeActivityEntry,
+  formatCompactionSaving,
   usageDialState,
   formatWindowReset,
   formatResetAt,
@@ -5967,5 +5970,62 @@ describe("dispatchMedia", () => {
 
   it("still routes when only some handlers are supplied", () => {
     expect(() => dispatchMedia({ action: "show" }, {})).not.toThrow();
+  });
+});
+
+// ===== Optimizer P2.5 formatters (BET-1347) =====
+
+describe("describePressure", () => {
+  it("renders the neutral 'no pressure signal yet' with no signal, and NO warn", () => {
+    expect(describePressure(0, false)).toEqual({ text: "no pressure signal yet", tone: "neutral" });
+    expect(describePressure(40, false)).toEqual({ text: "no pressure signal yet", tone: "neutral" });
+  });
+  it("renders 'on pace' (ok) when on or below pace", () => {
+    expect(describePressure(0, true)).toEqual({ text: "on pace", tone: "ok" });
+    expect(describePressure(-5, true)).toEqual({ text: "on pace", tone: "ok" });
+  });
+  it("renders '+N pts ahead of pace' (warn) when ahead of pace", () => {
+    expect(describePressure(23, true)).toEqual({ text: "+23 pts ahead of pace", tone: "warn" });
+    expect(describePressure(0.4, true)).toEqual({ text: "+0 pts ahead of pace", tone: "warn" });
+  });
+});
+
+describe("describeActivityEntry", () => {
+  it("builds a headline from verdict + subject and an evidence line", () => {
+    const entry = {
+      kind: "tune",
+      subject: "trim threshold 16 → 12 tool uses",
+      from: 16,
+      to: 12,
+      verdict: "kept",
+      evidence: { turns: 62, hit: 74.1, churn: 0.4 },
+    };
+    const out = describeActivityEntry(entry);
+    expect(out.headline).toBe("Kept — trim threshold 16 → 12 tool uses");
+    expect(out.detail).toContain("62");
+    expect(out.detail).toContain("74.1");
+  });
+  it("marks a rolled-back entry distinctly", () => {
+    const out = describeActivityEntry({ kind: "tune", subject: "protected tail", verdict: "rolled-back", evidence: {} });
+    expect(out.headline).toBe("Rolled back — protected tail");
+  });
+  it("falls back to a safe headline when subject/verdict are absent", () => {
+    const out = describeActivityEntry({ kind: "tune", verdict: "kept" });
+    expect(out.headline).toContain("optimizer change");
+  });
+});
+
+describe("formatCompactionSaving", () => {
+  it("renders the arrowed before -> after saving", () => {
+    expect(formatCompactionSaving(128_000, 31_000)).toBe("128k → 31k");
+    expect(formatCompactionSaving(10_000, 2000)).toBe("10k → 2k");
+  });
+  it("returns '0' when there is no saving (before == after, or after > before)", () => {
+    expect(formatCompactionSaving(128_000, 128_000)).toBe("0");
+    expect(formatCompactionSaving(10_000, 20_000)).toBe("0");
+  });
+  it("returns '0' for missing/non-finite inputs", () => {
+    expect(formatCompactionSaving(0, 0)).toBe("0");
+    expect(formatCompactionSaving(Number.NaN, 1000)).toBe("0");
   });
 });

--- a/src/renderer/chatUtils.ts
+++ b/src/renderer/chatUtils.ts
@@ -218,6 +218,93 @@ export function formatTokens(n: number): string {
   return `${Math.round(n / 1000)}k tokens`;
 }
 
+// Compact token figure for inline surfaces (the compaction saving pill / the
+// "128k → 31k" one-liner). Built on formatTokens — never a second formatter —
+// with the " tokens" suffix stripped.
+function formatTokensCompact(n: number): string {
+  return formatTokens(n).replace(/\s+tokens$/, "");
+}
+
+// ---- Optimizer P2.5 (BET-1347) pure formatters ------------------------------
+
+export type PressureTone = "neutral" | "ok" | "warn";
+
+/**
+ * Describe a subscription window's pacing pressure for the pressure chip that
+ * sits under its gauge. `hasSignal` is false when there is no pressure signal
+ * yet (tokensPerPct is null or there are too few samples) — that renders the
+ * documented NEUTRAL state, never a fabricated pace.
+ *
+ *   hasSignal=false        -> "no pressure signal yet"      (neutral)
+ *   hasSignal, deficit<=0  -> "on pace"                     (ok)
+ *   hasSignal, deficit>0   -> "+N pts ahead of pace"        (warn)
+ */
+export function describePressure(deficit: number, hasSignal: boolean): { text: string; tone: PressureTone } {
+  if (!hasSignal) return { text: "no pressure signal yet", tone: "neutral" };
+  const pts = Math.round(deficit);
+  if (deficit > 0) return { text: `+${pts} pts ahead of pace`, tone: "warn" };
+  return { text: "on pace", tone: "ok" };
+}
+
+export type ActivityEntry = {
+  id?: string;
+  ts?: number;
+  kind: string;
+  subject?: string;
+  from?: string | number;
+  to?: string | number;
+  verdict: string;
+  evidence?: Record<string, string | number>;
+  revertedAt?: number;
+};
+
+const VERDICT_WORD: Record<string, string> = {
+  kept: "Kept",
+  "rolled-back": "Rolled back",
+  applied: "Applied",
+};
+
+// A compact evidence line: "62 turns · hit 74.1% · churn 0.4%" — joined from
+// the counts/measurements, never content.
+function evidenceLine(evidence?: Record<string, string | number>): string {
+  if (!evidence) return "";
+  const parts: string[] = [];
+  for (const [k, v] of Object.entries(evidence)) {
+    if (v === undefined || v === null || String(v) === "") continue;
+    const label = k.replace(/([A-Z])/g, " $1").replace(/^[a-z]/g, (c) => c.toUpperCase()).trim();
+    parts.push(`${label} ${v}`);
+  }
+  return parts.join(" · ");
+}
+
+/**
+ * Describe one activity-log entry for the feed: a headline (the verdict with
+ * the change it describes) and the evidence line. The prefix is derived from
+ * `verdict` (so a rolled-back entry is visually distinct); `subject` is the
+ * change itself.
+ */
+export function describeActivityEntry(entry: ActivityEntry): { headline: string; detail: string } {
+  const word = VERDICT_WORD[entry.verdict] ?? entry.verdict ?? "Changed";
+  const subject = typeof entry.subject === "string" && entry.subject ? entry.subject : "optimizer change";
+  return {
+    headline: `${word} — ${subject}`,
+    detail: evidenceLine(entry.evidence),
+  };
+}
+
+/**
+ * Format a compaction's before/after token sizes for the "⟳ Compacted ... ·
+ * 128k → 31k" one-liner. Returns the arrowed savings when the compaction
+ * actually shrank the context, or "0" when there was no reduction (before and
+ * after equal or after > before) — never fabricates a saving.
+ */
+export function formatCompactionSaving(before: number, after: number): string {
+  const isNum = (n: number): boolean => typeof n === "number" && Number.isFinite(n) && n > 0;
+  if (!isNum(before) || !isNum(after)) return "0";
+  if (after >= before) return "0";
+  return `${formatTokensCompact(before)} → ${formatTokensCompact(after)}`;
+}
+
 // Build an SVG path string for a CUMULATIVE series over `values` (oldest →
 // newest), for the Optimizer's "sent vs raw counterfactual" consumption chart
 // (BET-1337). Each point's x is spaced linearly across `width`; its y is the

--- a/src/renderer/hooks/useSseBus.ts
+++ b/src/renderer/hooks/useSseBus.ts
@@ -123,6 +123,9 @@ export type SseBus = {
   setStepTokens: React.Dispatch<React.SetStateAction<(TokenUsage & { cost: number }) | null>>;
   compactionState: { reason: string; text: string; phase: "running" | "done" } | null;
   setCompactionState: React.Dispatch<React.SetStateAction<{ reason: string; text: string; phase: "running" | "done" } | null>>;
+  // BET-1347: the box compacted this conversation in the background — a
+  // transient transcript one-liner (away + token sizes when known).
+  compactionNotice: { beforeTokens: number | null; afterTokens: number | null; away: boolean } | null;
   liveTodos: Array<{ content: string; status: string; priority: string }> | null;
   setLiveTodos: React.Dispatch<React.SetStateAction<Array<{ content: string; status: string; priority: string }> | null>>;
   todosDismissed: boolean;
@@ -253,6 +256,22 @@ export function useSseBus(params: {
     phase: "running" | "done";
   } | null>(null);
   const compactionClearTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  // BET-1347: a background compaction the BOX did while this conversation was
+  // open, surfaced as a transient transcript one-liner. Set server-side on
+  // compaction; cleared after a short display window so it reads as a pass-by
+  // note, not a permanent fixture. `away` is the server's presence verdict at
+  // compaction time; before/after are token sizes when known.
+  const [compactionNotice, setCompactionNotice] = useState<{
+    beforeTokens: number | null;
+    afterTokens: number | null;
+    away: boolean;
+  } | null>(null);
+  const compactionNoticeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const armCompactionNotice = (n: { beforeTokens: number | null; afterTokens: number | null; away: boolean }) => {
+    setCompactionNotice(n);
+    if (compactionNoticeTimer.current) clearTimeout(compactionNoticeTimer.current);
+    compactionNoticeTimer.current = setTimeout(() => setCompactionNotice(null), 10_000);
+  };
   // Timer arming the delayed running→false flip on a `turnComplete` whose
   // running flag is not yet authoritative (see TURN_SETTLE_MS). Any other
   // writer of `running` cancels it first, so a stale settle never lands on a
@@ -823,6 +842,19 @@ export function useSseBus(params: {
           if (childSessionId) childSessionIds.current.add(childSessionId);
           return;
         }
+        // BET-1347: the box compacted this conversation in the background.
+        // Server-side onCompacted publishes `optimizer.compacted` on the
+        // stream channel (scoped to the session, guarded by the early-return
+        // above); we surface it as the transcript one-liner.
+        case "optimizer.compacted": {
+          const p = ev.payload as { beforeTokens?: number; afterTokens?: number; away?: boolean };
+          armCompactionNotice({
+            beforeTokens: typeof p?.beforeTokens === "number" ? p.beforeTokens : null,
+            afterTokens: typeof p?.afterTokens === "number" ? p.afterTokens : null,
+            away: p?.away === true,
+          });
+          return;
+        }
         default:
           // context / cache / subagent / autoRename — consumed by other
           // surfaces, not this panel's live transcript state.
@@ -835,6 +867,7 @@ export function useSseBus(params: {
       offStream();
       cancelTurnSettle();
       if (compactionClearTimer.current) clearTimeout(compactionClearTimer.current);
+      if (compactionNoticeTimer.current) clearTimeout(compactionNoticeTimer.current);
     };
   }, [sessionId]);
 
@@ -878,6 +911,7 @@ export function useSseBus(params: {
     setStepTokens,
     compactionState,
     setCompactionState,
+    compactionNotice,
     liveTodos,
     setLiveTodos,
     todosDismissed,

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -520,3 +520,4 @@ html, body, #root {
 .opt-empty{color:var(--tx4);font-size:12px;padding:22px 0;text-align:center}
 .composer-saving-pill{display:inline-flex;align-items:center;gap:5px;font-size:11px;padding:2px 9px;border-radius:var(--r-full);background:var(--accent-bg);color:var(--accent);border:1px solid rgb(var(--accent-rgb) / 0.4);white-space:nowrap}
 .composer-saving-pill .tx-faint{color:var(--tx4);font-weight:400}
+.opt-compact-line{font-size:11.5px;color:var(--tx4);font-family:var(--font-mono);padding:8px 12px;border:1px solid var(--border-subtle);border-radius:var(--r-lg);background:var(--card)}

--- a/src/renderer/index.css
+++ b/src/renderer/index.css
@@ -487,3 +487,36 @@ html, body, #root {
 .opt-stat-v.ok{color:var(--ok)}
 .opt-stat-d{font-size:11px;color:var(--tx3);margin-top:2px;min-height:1em;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
 @media (max-width:720px){.opt-wins{grid-template-columns:1fr}.opt-stats{grid-template-columns:repeat(2,minmax(0,1fr))}}
+/* ---- Optimizer P2.5 (BET-1347): switch card, chips, metered, activity ---- */
+.opt-switch{background:var(--card);border:1px solid var(--border-subtle);border-radius:var(--r-lg);padding:var(--sp-4)}
+.opt-switch-head{display:flex;align-items:flex-start;gap:var(--sp-4)}
+.opt-switch-txt{flex:1}
+.opt-switch-txt b{color:var(--tx1);font-size:13.5px;font-weight:600}
+.opt-switch-txt p{font-size:11.5px;color:var(--tx4);margin:var(--sp-px) 0 0;max-width:60ch}
+.opt-switch-state{font-size:10.5px;font-weight:600;padding:2px 10px;border-radius:var(--r-full);color:var(--tx3);background:var(--inset);border:1px solid var(--border-subtle);flex:none;margin-top:2px}
+.opt-switch-state.on{color:var(--accent);background:var(--accent-bg);border-color:rgb(var(--accent-rgb) / 0.4)}
+.opt-subrows{margin-top:var(--sp-3);border-top:1px solid var(--border-subtle)}
+.opt-subrow{display:flex;align-items:baseline;gap:var(--sp-3);padding:var(--sp-2) 0;border-bottom:1px solid var(--border-subtle);font-size:12px}
+.opt-subrow:last-child{border-bottom:none}
+.opt-subrow-n{color:var(--tx2);width:104px;flex:none;font-weight:600}
+.opt-subrow-v{color:var(--tx3);flex:1}
+.opt-subrow-k{font-family:var(--font-mono);font-size:11px;color:var(--tx4);white-space:nowrap}
+.opt-chip{display:inline-block;font-size:10.5px;padding:1px 8px;border-radius:var(--r-full);border:1px solid var(--border-subtle);color:var(--tx3);background:var(--inset);white-space:nowrap}
+.opt-chip.warn{color:var(--warn);border-color:rgb(var(--warn-rgb) / 0.4);background:var(--warn-bg)}
+.opt-chip.ok{color:var(--ok);border-color:rgb(var(--ok-rgb) / 0.4);background:var(--ok-bg)}
+.opt-meter{margin-top:var(--sp-6)}
+.opt-meter-row{display:flex;align-items:baseline;gap:var(--sp-3);padding:var(--sp-2) 0;border-bottom:1px solid var(--border-subtle);font-size:12px}
+.opt-meter-row:last-child{border-bottom:none}
+.opt-meter-row b{color:var(--tx1);font-size:12.5px;width:190px;flex:none;font-weight:600}
+.opt-meter-role{color:var(--tx3);flex:1}
+.opt-meter-px{font-family:var(--font-mono);font-size:11.5px;color:var(--tx4);white-space:nowrap}
+.opt-feed{margin-top:var(--sp-2)}
+.opt-ev{display:flex;gap:var(--sp-3);padding:var(--sp-2) 0;border-bottom:1px solid var(--border-subtle)}
+.opt-ev.rb .opt-ev-hd{color:var(--warn)}
+.opt-ev-when{font-family:var(--font-mono);font-size:10.5px;color:var(--tx4);width:82px;flex:none;padding-top:2px;white-space:nowrap}
+.opt-ev-body{flex:1}
+.opt-ev-hd{color:var(--tx1);font-size:12.5px}
+.opt-ev-why{color:var(--tx3);font-size:11.5px;margin-top:2px;word-break:break-word}
+.opt-empty{color:var(--tx4);font-size:12px;padding:22px 0;text-align:center}
+.composer-saving-pill{display:inline-flex;align-items:center;gap:5px;font-size:11px;padding:2px 9px;border-radius:var(--r-full);background:var(--accent-bg);color:var(--accent);border:1px solid rgb(var(--accent-rgb) / 0.4);white-space:nowrap}
+.composer-saving-pill .tx-faint{color:var(--tx4);font-weight:400}

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -42,6 +42,7 @@ import * as pty from "./pty.mjs";
 import * as local from "./local.mjs";
 import { createPeekHandler } from "./peek.mjs";
 import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
+import { setTelemetrySink, shipCtxEvent } from "./optimizer/telemetry.mjs";
 
 // BET-187: ship every console.* (and any startup banner / poller log) to
 // Axiom when MANTA_AXIOM_TOKEN is set in env AND AppConfig.shareAnalytics
@@ -55,7 +56,12 @@ import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/
 {
   const axiomCfg = resolveAxiomConfig({ env: process.env, config: await local.configGet() });
   if (axiomCfg) {
-    captureConsole(createLogShipper({ ...axiomCfg, source: "server", device: hostname() }));
+    // The SINGLE log shipper on the box. captureConsole wraps console.* with
+    // it; BET-1347 ALSO hands it to the optimizer's context telemetry as a
+    // reference (setTelemetrySink) — deliberately not a second instance.
+    const shipper = createLogShipper({ ...axiomCfg, source: "server", device: hostname() });
+    captureConsole(shipper);
+    setTelemetrySink(shipper);
   }
 }
 import { createBus, handleEventsRequest, attachEventsWs } from "./events.mjs";
@@ -1183,6 +1189,17 @@ const compactionScheduler = createCompactionScheduler({
       });
     } catch (e) {
       console.warn("[optimizer] compaction activity append failed:", e?.message ?? e);
+    }
+    // Context telemetry (counts only): a background compaction shipped with its
+    // before/after token sizes when known; no session titles, no content.
+    try {
+      shipCtxEvent({
+        kind: "compaction",
+        beforeTokens: typeof contextTokens === "number" && Number.isFinite(contextTokens) ? contextTokens : null,
+        background: 1,
+      });
+    } catch {
+      /* telemetry never throws */
     }
   },
   enabled: async () => (await local.configGet())?.optimizerEnabled === true,
@@ -3142,6 +3159,20 @@ const handleRequest = async (req, res) => {
           return;
         }
         await optimizerCounterfactual.record(body);
+        // Context telemetry — a mask application reported by the plugin. Counts
+        // only; `sessionID` is the opaque id (never a title or content).
+        try {
+          shipCtxEvent({
+            kind: "mask",
+            maskedTokens: typeof body.maskedTokens === "number" && Number.isFinite(body.maskedTokens) ? body.maskedTokens : null,
+            maskedParts: typeof body.maskedParts === "number" && Number.isFinite(body.maskedParts) ? body.maskedParts : null,
+            applied: body.applied === true ? 1 : 0,
+            mode: body.mode ?? "observe",
+            sessionID: body.sessionID,
+          });
+        } catch {
+          /* telemetry never throws */
+        }
         respondJson(res, 200, { ok: true });
         return;
       }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1265,6 +1265,27 @@ const compactionScheduler = createCompactionScheduler({
     } catch {
       /* telemetry never throws */
     }
+    // Notify the OPEN conversation that it was compacted in the background —
+    // a pass-by transcript one-liner. Carried on the `stream` channel so the
+    // renderer's scoped stream handler (useSseBus) routes it to the active
+    // session. `away` is the box's presence verdict at compaction time
+    // (server-side, not guessed); beforeTokens is the pre-compaction context;
+    // afterTokens is not yet surfaced by the compaction call (null → the
+    // renderer falls back to the wording that needs no count).
+    try {
+      bus.publish({
+        kind: "stream",
+        sub: "optimizer.compacted",
+        sessionId: sessionID,
+        payload: {
+          beforeTokens: typeof contextTokens === "number" && Number.isFinite(contextTokens) ? contextTokens : null,
+          afterTokens: null,
+          away: push.desktopState(push.getDesktopPresence(), Date.now()) === "away",
+        },
+      });
+    } catch (e) {
+      console.warn("[optimizer] compaction notice publish failed:", e?.message ?? e);
+    }
   },
   enabled: async () => (await local.configGet())?.optimizerEnabled === true,
 });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -18,6 +18,7 @@ import { synthesizeSpeech } from "../shared/groq.mjs";
 import { WebSocketServer } from "ws";
 import { createCounterfactualStore, validateCounterfactualReport } from "./optimizer/counterfactual.mjs";
 import { createOptimizerSummary } from "./optimizer/summary.mjs";
+import { createActivityLog } from "./optimizer/activityLog.mjs";
 import { createPacingState } from "./optimizer/pacing.mjs";
 import {
   createCompactionScheduler,
@@ -969,6 +970,16 @@ const optimizerCounterfactual = createCounterfactualStore({
   now: Date.now,
 });
 
+// Optimizer P2.5 (BET-1347): the activity log store — the trust surface that
+// lists every parameter change the optimizer made on its own. Wired so the
+// tuner, the compaction scheduler and the eco recorder can append, and exposed
+// on the `optimizer:summary` read model's `activity` slice.
+const optimizerActivity = createActivityLog({
+  load: () => readJsonSync(statePath("optimizer-log.json"), []),
+  save: (s) => writeJsonAtomic(statePath("optimizer-log.json"), JSON.stringify(s, null, 2)),
+  now: Date.now,
+});
+
 // BET-1343: the memoized `optimizer:summary` read model, created ONCE at module
 // scope here (not inside buildHandlers) so the SAME 60s memo + in-flight guard
 // is shared by the RPC `optimizer:summary` channel and the GET
@@ -981,6 +992,7 @@ const optimizerSummary = createOptimizerSummary({
   usageSnapshots: listSnapshots,
   usageHistory: getUsageHistory,
   readCacheTtl: () => readProvidersCacheTtl({ listProviders: oc.getProviders }),
+  activityStore: optimizerActivity,
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -26,6 +26,7 @@ import {
   COMPACT_CACHE_TTL_FALLBACK_MS,
 } from "./optimizer/compaction.mjs";
 import { createConstraintStore, extractionInstruction, transcriptText } from "./optimizer/constraints.mjs";
+import { createTuner, TUNE_IDLE_SWEEP_MS, GUARD_CACHE_HIT_DROP_PTS, GUARD_SUSTAIN_MS } from "./optimizer/tuner.mjs";
 import { parseConstraints } from "../shared/constraintPin.mjs";
 import { startPoller } from "./startPoller.mjs";
 import { getDb } from "./opencodeDb.mjs";
@@ -1166,6 +1167,24 @@ const compactionScheduler = createCompactionScheduler({
   now: Date.now,
   load: () => readJsonSync(statePath("optimizer-compaction.json"), {}),
   save: (s) => writeJsonAtomic(statePath("optimizer-compaction.json"), JSON.stringify(s, null, 2)),
+  // BET-1347: record each background compaction on the activity log — the
+  // trust surface lists what the optimizer did, including compactions. Counts
+  // only: context tokens, never conversation content.
+  onCompacted: async ({ sessionID, contextTokens }) => {
+    try {
+      await optimizerActivity.append({
+        kind: "compaction",
+        subject: "background compaction",
+        verdict: "applied",
+        evidence: {
+          background: 1,
+          beforeTokens: typeof contextTokens === "number" && Number.isFinite(contextTokens) ? contextTokens : undefined,
+        },
+      });
+    } catch (e) {
+      console.warn("[optimizer] compaction activity append failed:", e?.message ?? e);
+    }
+  },
   enabled: async () => (await local.configGet())?.optimizerEnabled === true,
 });
 
@@ -1175,6 +1194,83 @@ const stopCompactionScheduler = startPoller(() => compactionScheduler.tick(), {
 });
 // eslint-disable-next-line no-unused-vars
 void stopCompactionScheduler;
+
+// ---------------------------------------------------------------------------
+// Optimizer P2.5 (BET-1347) — the tuner + guardrails + telemetry wiring.
+//
+// The tuner is the conservative bandit that earns its own parameter changes.
+// It ONLY runs when the optimizer switch is on; with it off it neither
+// observes nor writes (`createTuner` guards this internally). It is the ONLY
+// writer of `optimizer-policy.json`. Guardrails trip -> instant revert + a
+// rolled-back activity entry naming which.
+// ---------------------------------------------------------------------------
+
+// Cache-hit guardrail reader. Tracks a rolling per-hour history of the
+// summary's cache-hit %; trips when the CURRENT rate has fallen more than
+// GUARD_CACHE_HIT_DROP_PTS below the value ~GUARD_SUSTAIN_MS ago, sustained.
+// Churn and cost-per-turn guardrails are not derived here — the ledger/parts
+// the plugin would need to report do not exist on the server yet, so those
+// two default to no-trip (fail-open: the bandit only acts on evidence).
+const cacheHitHistory = []; // { at, pct }
+function readGuardrails() {
+  const summary = optimizerSummaryCached();
+  let hitPct = null;
+  try {
+    const s = summary?.cacheShare;
+    const denom = (s?.cacheRead ?? 0) + (s?.cacheWrite ?? 0) + (s?.input ?? 0);
+    if (denom > 0) hitPct = ((s.cacheRead ?? 0) / denom) * 100;
+  } catch {
+    hitPct = null;
+  }
+  const t = Date.now();
+  if (typeof hitPct === "number") {
+    cacheHitHistory.push({ at: t, pct: hitPct });
+    while (cacheHitHistory.length && t - cacheHitHistory[0].at > GUARD_SUSTAIN_MS * 4) cacheHitHistory.shift();
+    const earlier = cacheHitHistory.find((e) => t - e.at >= GUARD_SUSTAIN_MS - 5_000);
+    if (earlier && earlier.pct - hitPct >= GUARD_CACHE_HIT_DROP_PTS) {
+      return { tripped: true, which: "cache-hit", evidence: { hitDropPts: Math.round((earlier.pct - hitPct) * 10) / 10 } };
+    }
+  }
+  return null;
+}
+let optimizerSummaryCachedValue = null;
+function optimizerSummaryCached() {
+  return optimizerSummaryCachedValue;
+}
+
+// The repo the tuner tunes: the box's primary project directory (config's
+// first project), or "" -> no tuning. Single-primary on a single-user box; the
+// policy route reads this same repo table by directory.
+const tunerDirectory = ((await local.configGet())?.projects?.[0]?.defaultCwd ?? "").trim();
+
+const optimizerTuner = createTuner({
+  directory: tunerDirectory,
+  enabled: async () => (await local.configGet())?.optimizerEnabled === true,
+  now: Date.now,
+  activityLog: optimizerActivity,
+  sessionCount: async () => (await optimizerSummary())?.bySession?.length ?? 0,
+  observeGuardrails: readGuardrails,
+  loadTunerState: () => readJsonSync(statePath("optimizer-tuner.json"), {}),
+  saveTunerState: (s) => writeJsonAtomic(statePath("optimizer-tuner.json"), JSON.stringify(s, null, 2)),
+});
+
+// Backstop sweep only — the event-driven triggers (new sessions, regime change,
+// guardrail trip) also call tune() from their publish points; this is just the
+// floor that guarantees a box seeing none of them still gets evaluated.
+const stopTuner = startPoller(async () => {
+  // Refresh the cached summary the guardrail reader peeks at.
+  try {
+    optimizerSummaryCachedValue = await optimizerSummary();
+  } catch {
+    optimizerSummaryCachedValue = null;
+  }
+  await optimizerTuner.tune();
+}, {
+  intervalMs: TUNE_IDLE_SWEEP_MS,
+  label: "optimizer-tuner",
+});
+// eslint-disable-next-line no-unused-vars
+void stopTuner;
 
 rpcHandlers = buildHandlers({
   tmux,

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -43,6 +43,7 @@ import * as local from "./local.mjs";
 import { createPeekHandler } from "./peek.mjs";
 import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
 import { setTelemetrySink, shipCtxEvent } from "./optimizer/telemetry.mjs";
+import { blendedPrice } from "../shared/blendedPrice.mjs";
 
 // BET-187: ship every console.* (and any startup banner / poller log) to
 // Axiom when MANTA_AXIOM_TOKEN is set in env AND AppConfig.shareAnalytics
@@ -987,6 +988,51 @@ const optimizerActivity = createActivityLog({
   now: Date.now,
 });
 
+// The metered (pay-per-token) endpoints for the dashboard's slim row: models in
+// the routing catalog that are NOT covered by a subscription quota window, with
+// their blended $/Mtok from the SHARED blendedPrice (never a guess — a model
+// with no price is skipped). A metered endpoint has no window and never resets,
+// so there is nothing to fill — the row is deliberately role+price, no gauge.
+// [] when the catalog or pricing is unavailable (the section is then absent).
+async function readMeteredEndpoints() {
+  try {
+    const summary = await optimizerSummary();
+    const subProviders = new Set((summary?.windows ?? []).map((w) => w.provider));
+    const cs = summary?.cacheShare ?? {};
+    const denom = (cs.input ?? 0) + (cs.output ?? 0) + (cs.cacheRead ?? 0) + (cs.cacheWrite ?? 0);
+    const mix =
+      denom > 0
+        ? {
+            input: (cs.input ?? 0) / denom,
+            output: (cs.output ?? 0) / denom,
+            cacheRead: (cs.cacheRead ?? 0) / denom,
+            cacheWrite: (cs.cacheWrite ?? 0) / denom,
+          }
+        : { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 };
+    let models = [];
+    try {
+      models = Array.isArray(routingCatalogIndex.allModels()) ? routingCatalogIndex.allModels() : [];
+    } catch {
+      models = [];
+    }
+    const rows = [];
+    for (const model of models) {
+      const prov = typeof model?.providerID === "string" ? model.providerID : null;
+      if (!prov || subProviders.has(prov)) continue;
+      const bp = blendedPrice(model, mix, model?.cost ?? null);
+      if (!bp || bp.known !== true) continue;
+      rows.push({
+        name: `${prov} · ${typeof model.id === "string" ? model.id : ""}`,
+        role: "pay-per-token endpoint",
+        price: `$${bp.price.toFixed(2)} / Mtok blended`,
+      });
+    }
+    return rows.slice(0, 8);
+  } catch {
+    return [];
+  }
+}
+
 // BET-1343: the memoized `optimizer:summary` read model, created ONCE at module
 // scope here (not inside buildHandlers) so the SAME 60s memo + in-flight guard
 // is shared by the RPC `optimizer:summary` channel and the GET
@@ -1000,6 +1046,24 @@ const optimizerSummary = createOptimizerSummary({
   usageHistory: getUsageHistory,
   readCacheTtl: () => readProvidersCacheTtl({ listProviders: oc.getProviders }),
   activityStore: optimizerActivity,
+  // BET-1347: per-window pacing pressure (deficit / tokens-per-pct) for the
+  // chips under each gauge.
+  pressureWindows: async () => {
+    try {
+      return await optimizerPacing.pressureWindows();
+    } catch {
+      return {};
+    }
+  },
+  // BET-1347: the compaction scheduler's "X of Y in background" stat.
+  compactionStat: async () => {
+    try {
+      return compactionScheduler.stat();
+    } catch {
+      return null;
+    }
+  },
+  meteredEndpoints: readMeteredEndpoints,
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/optimizer/activityLog.mjs
+++ b/src/server/optimizer/activityLog.mjs
@@ -1,0 +1,172 @@
+// optimizer/activityLog.mjs — the optimizer's trust surface (Optimizer P2.5,
+// BET-1347).
+//
+// EVERY parameter change the optimizer makes on its own is appended here, with
+// the evidence it used, so the dashboard has a legible "what did Manta change
+// and why" log — the locked decision from BET-1342 is that THIS log is the
+// trust surface (no approval queue, no per-knob reset). Rolled-back entries
+// stay: the log is honest about the changes that were reverted too.
+//
+// Damage discipline: `evidence` is a FLAT object of counts and measurements
+// ONLY — numbers and short strings that name a metric, never conversation
+// content, never file paths, never session titles. This is the "counts only,
+// never content" boundary for the on-box log; the shipped telemetry
+// (telemetry.mjs) enforces the same boundary for what leaves the box.
+//
+// Concurrency: several subsystems append (the tuner, the compaction scheduler,
+// the eco/regime recorder). Appends serialize through a shared `createMutex`
+// so read-modify-write of the store can never interleave and lose an entry.
+// The same mutex guards `markReverted`, which mutates an existing entry.
+
+import { statePath } from "../../shared/paths.mjs";
+import { createMutex } from "../jsonStore.mjs";
+
+// Persistence file (wired by index.mjs via the shared jsonStore atomic writer).
+export const ACTIVITY_LOG_PATH = statePath("optimizer-log.json");
+
+// Retention: whichever bites first — cap the entry count at MAX_ENTRIES, and
+// drop anything older than RETAIN_DAYS.
+export const MAX_ENTRIES = 200;
+export const RETAIN_DAYS = 90;
+// How many entries the summary read model exposes (most recent first).
+export const SUMMARY_ACTIVITY_CAP = 50;
+
+const DAY_MS = 86_400_000;
+
+const KINDS = new Set(["tune", "eco", "compaction", "guardrail"]);
+const VERDICTS = new Set(["kept", "rolled-back", "applied"]);
+// The ONLY fields an entry may carry; anything else is dropped on append.
+const ENTRY_KEYS = new Set(["id", "ts", "kind", "subject", "from", "to", "verdict", "evidence", "revertedAt"]);
+
+const isStr = (v) => typeof v === "string";
+const isFiniteNum = (v) => typeof v === "number" && Number.isFinite(v);
+
+// A short, unique-enough id for an entry (8 hex chars) — the handle the tuner
+// passes to markReverted.
+function newId() {
+  return Math.random().toString(16).slice(2, 10);
+}
+
+// Coerce `evidence` to a FLAT { string|number } map, dropping everything that
+// isn't a string or finite number (no booleans, no objects, no arrays) and
+// trimming the key list so stored evidence can't balloon.
+function normalizeEvidence(raw) {
+  const out = {};
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) return out;
+  for (const [k, v] of Object.entries(raw)) {
+    if (isStr(v) || isFiniteNum(v)) out[k] = v;
+  }
+  return out;
+}
+
+// Validate + normalize one raw entry. Returns null when the entry is not a
+// legible activity record (unknown kind/verdict). Drops unknown fields;
+// coerces evidence to counts/measurements only.
+function normalizeEntry(raw) {
+  const e = raw && typeof raw === "object" ? raw : null;
+  if (!e) return null;
+  const kind = e.kind;
+  const verdict = e.verdict;
+  if (!isStr(kind) || !KINDS.has(kind)) return null;
+  if (!isStr(verdict) || !VERDICTS.has(verdict)) return null;
+  const out = {};
+  out.id = isStr(e.id) && e.id ? e.id : undefined;
+  out.ts = isFiniteNum(e.ts) ? e.ts : undefined;
+  out.kind = kind;
+  out.subject = isStr(e.subject) ? e.subject : undefined;
+  // from/to may be a number (token count, eco level) or a short label string;
+  // keep raw string|number values so the UI can render them either way.
+  out.from = e.from;
+  out.to = e.to;
+  out.verdict = verdict;
+  out.evidence = normalizeEvidence(e.evidence);
+  out.revertedAt = isFiniteNum(e.revertedAt) ? e.revertedAt : undefined;
+  return out;
+}
+
+// Strip undefined keys so entries serialize compactly.
+function pack(entry) {
+  const out = {};
+  for (const k of ENTRY_KEYS) {
+    if (entry[k] !== undefined && entry[k] !== null) out[k] = entry[k];
+  }
+  return out;
+}
+
+/**
+ * The activity log. Injected I/O (mirrors createCounterfactualStore /
+ * createPacingState): `load()` returns the persisted log array (or []),
+ * `save(entries)` persists it atomically, `now` is the clock (number or
+ * zero-arg fn, for tests). Pure logic — no fs access unless the injected
+ * load/save touch it.
+ *
+ * Returns { append, markReverted, recent, snapshot }:
+ *   append(entry) — validate + normalize, prepend (newest first), enforce
+ *     retention (MAX_ENTRIES / RETAIN_DAYS), persist. Returns {ok, entry?}.
+ *   markReverted(id, at) — stamp revertedAt on an existing entry (the tuner
+ *     uses this when a kept-then-reverted change settles).
+ *   recent(n) — the newest n entries.
+ *   snapshot() — the whole log (tests).
+ */
+export function createActivityLog({ load, save, now, maxEntries = MAX_ENTRIES, retainDays = RETAIN_DAYS } = {}) {
+  const mutex = createMutex();
+  let state = null;
+
+  const nowMs = () => (typeof now === "function" ? (now() ?? Date.now()) : (now ?? Date.now()));
+
+  async function ensureLoaded() {
+    if (!state) {
+      const raw = typeof load === "function" ? await load() : [];
+      state = Array.isArray(raw) ? raw.map(normalizeEntry).filter(Boolean) : [];
+    }
+    return state;
+  }
+
+  async function persist() {
+    if (typeof save !== "function") return;
+    await save(state);
+  }
+
+  async function append(raw) {
+    return mutex.runExclusive(async () => {
+      await ensureLoaded();
+      const entry = normalizeEntry({
+        ...(raw ?? {}),
+        id: isStr(raw?.id) && raw.id ? raw.id : newId(),
+        ts: isFiniteNum(raw?.ts) ? raw.ts : nowMs(),
+      });
+      if (!entry) return { ok: false, error: "invalid" };
+      const clean = pack(entry);
+      state.unshift(clean);
+      // Retention — whichever bites first.
+      const cutoff = nowMs() - retainDays * DAY_MS;
+      state = state.filter((e) => isFiniteNum(e.ts) && e.ts >= cutoff);
+      if (state.length > maxEntries) state.length = maxEntries;
+      await persist();
+      return { ok: true, entry: clean };
+    });
+  }
+
+  async function markReverted(id, at) {
+    return mutex.runExclusive(async () => {
+      await ensureLoaded();
+      const entry = state.find((e) => e.id === id);
+      if (!entry) return { ok: false, error: "not-found" };
+      entry.revertedAt = isFiniteNum(at) ? at : nowMs();
+      await persist();
+      return { ok: true, entry };
+    });
+  }
+
+  async function recent(n) {
+    const s = await ensureLoaded();
+    return isFiniteNum(n) ? s.slice(0, n) : s.slice();
+  }
+
+  async function snapshot() {
+    const s = await ensureLoaded();
+    return s.map((e) => ({ ...e }));
+  }
+
+  return { append, markReverted, recent, snapshot };
+}

--- a/src/server/optimizer/activityLog.test.mjs
+++ b/src/server/optimizer/activityLog.test.mjs
@@ -1,0 +1,142 @@
+// Tests for optimizer/activityLog.mjs — the activity log that is the
+// optimizer's trust surface (Optimizer P2.5, BET-1347). Pure/injected
+// throughout: `load`/`save` are in-memory and `now` is a controlled clock. Run
+// via `npm run test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createActivityLog, MAX_ENTRIES, RETAIN_DAYS } from "./activityLog.mjs";
+
+const DAY_MS = 86_400_000;
+
+function makeLog({ initial = [], now } = {}) {
+  let state = initial;
+  const saves = [];
+  const log = createActivityLog({
+    load: async () => state,
+    save: async (s) => {
+      state = s;
+      saves.push(JSON.parse(JSON.stringify(s)));
+    },
+    now: () => now(),
+  });
+  return { log, saves, get: () => state };
+}
+
+function fixed(ms) {
+  return () => ms;
+}
+
+const T0 = 1_700_000_000_000;
+
+test("append: validates kind/verdict, drops unknown fields, stores counts-only evidence", async () => {
+  const { log, get } = makeLog({ now: fixed(T0) });
+  const res = await log.append({
+    kind: "tune",
+    subject: "trim threshold 16 -> 12 tool uses",
+    from: 16,
+    to: 12,
+    verdict: "kept",
+    evidence: { turns: 62, hit: 74.1, churn: 0.4, bogus: { nested: true }, flag: true, note: "held" },
+    trailing: "dropped",
+    text: "this must never be stored",
+  });
+  assert.equal(res.ok, true);
+  const e = res.entry;
+  assert.ok(e.id && typeof e.id === "string");
+  assert.equal(e.ts, T0);
+  assert.equal(e.kind, "tune");
+  assert.equal(e.from, 16);
+  assert.equal(e.to, 12);
+  assert.equal(e.verdict, "kept");
+  // Evidence is flat counts/measurements only — nested objects, booleans and
+  // unknown entry fields are dropped.
+  assert.deepEqual(e.evidence, { turns: 62, hit: 74.1, churn: 0.4, note: "held" });
+  assert.equal(e.trailing, undefined);
+  assert.equal(e.text, undefined);
+  assert.equal(get().length, 1);
+});
+
+test("append: unknown kind / verdict is rejected", async () => {
+  const { log } = makeLog({ now: fixed(T0) });
+  const badKind = await log.append({ kind: "nope", verdict: "kept" });
+  assert.equal(badKind.ok, false);
+  const badVerdict = await log.append({ kind: "tune", verdict: "nope" });
+  assert.equal(badVerdict.ok, false);
+});
+
+test("append: entries are newest-first", async () => {
+  const { log } = makeLog({ now: fixed(T0) });
+  await log.append({ kind: "tune", verdict: "kept", ts: T0 - 200 });
+  await log.append({ kind: "guardrail", verdict: "rolled-back", ts: T0 - 100 });
+  await log.append({ kind: "compaction", verdict: "applied", ts: T0 });
+  const recent = await log.recent(10);
+  assert.deepEqual(recent.map((e) => e.ts), [T0, T0 - 100, T0 - 200]);
+});
+
+test("markReverted stamps revertedAt on the named entry", async () => {
+  const { log, get } = makeLog({ now: fixed(T0) });
+  const a = await log.append({ kind: "tune", verdict: "kept", ts: T0 - 200 });
+  const b = await log.append({ kind: "eco", verdict: "kept", ts: T0 - 100 });
+  const res = await log.markReverted(a.entry.id, 5000);
+  assert.equal(res.ok, true);
+  const e = get().find((x) => x.id === a.entry.id);
+  assert.equal(e.revertedAt, 5000);
+  const untouched = get().find((x) => x.id === b.entry.id);
+  assert.equal(untouched.revertedAt, undefined);
+});
+
+test("markReverted: unknown id is a no-op error, does not corrupt the log", async () => {
+  const { log, get } = makeLog({ now: fixed(T0) });
+  await log.append({ kind: "tune", verdict: "kept", ts: T0 });
+  const res = await log.markReverted("does-not-exist", 5000);
+  assert.equal(res.ok, false);
+  assert.equal(get().length, 1);
+});
+
+test("retention: caps at MAX_ENTRIES, newest kept", async () => {
+  const nowMs = T0;
+  const { log, get } = makeLog({ now: fixed(nowMs), initial: [] });
+  // Append chronologically (newest last) so storage is newest-first and the
+  // cap keeps the newest MAX_ENTRIES.
+  for (let i = 0; i < MAX_ENTRIES + 50; i++) {
+    await log.append({ kind: "tune", verdict: "kept", ts: nowMs - 50_000 + i });
+  }
+  assert.equal(get().length, MAX_ENTRIES);
+  assert.equal(get()[0].ts, nowMs - 50_000 + MAX_ENTRIES + 49); // newest kept
+  assert.equal(get()[get().length - 1].ts, nowMs - 50_000 + 50); // oldest kept boundary (i=50..249)
+  assert.ok(get().every((e) => e.ts >= nowMs - 50_000 + 50)); // the 50 oldest were dropped
+});
+
+test("retention: drops entries older than RETAIN_DAYS", async () => {
+  const nowMs = T0;
+  const old = nowMs - (RETAIN_DAYS + 5) * DAY_MS;
+  const { log, get } = makeLog({ now: fixed(nowMs), initial: [] });
+  await log.append({ kind: "tune", verdict: "kept", ts: nowMs - DAY_MS }); // recent
+  await log.append({ kind: "tune", verdict: "kept", ts: nowMs - 2000 }); // recent
+  await log.append({ kind: "tune", verdict: "applied", ts: old }); // too old
+  assert.equal(get().length, 2);
+  assert.ok(get().every((e) => e.ts >= nowMs - RETAIN_DAYS * DAY_MS));
+});
+
+test("recent(n) caps at n, snapshot returns a copy", async () => {
+  const { log } = makeLog({ now: fixed(T0) });
+  for (let i = 0; i < 5; i++) await log.append({ kind: "tune", verdict: "kept", ts: T0 - i });
+  const recent = await log.recent(2);
+  assert.equal(recent.length, 2);
+  const snap = await log.snapshot();
+  assert.equal(snap.length, 5);
+  snap[0].id = "mutated";
+  const snap2 = await log.snapshot();
+  assert.notEqual(snap2[0].id, "mutated");
+});
+
+test("concurrent appends do not lose an entry (mutex serializes)", async () => {
+  const { log, get } = makeLog({ now: fixed(T0) });
+  await Promise.all(
+    Array.from({ length: 50 }, (_, i) => log.append({ kind: "tune", verdict: "kept", ts: T0 - i })),
+  );
+  assert.equal(get().length, 50);
+  const ids = new Set(get().map((e) => e.id));
+  assert.equal(ids.size, 50);
+});

--- a/src/server/optimizer/compaction.mjs
+++ b/src/server/optimizer/compaction.mjs
@@ -152,6 +152,10 @@ export function createCompactionScheduler({
 } = {}) {
   const inflight = new Set();
   let state = null;
+  // BET-1347: running tally of this-process compaction attempts for the
+  // "X of Y in background" stat. `background` counts the scheduler's own
+  // successful background compactions; `total` every attempted compaction.
+  const tally = { background: 0, total: 0 };
 
   const nowMs = () => (typeof now === "function" ? (now() ?? 0) : (now ?? Date.now()));
 
@@ -220,6 +224,7 @@ export function createCompactionScheduler({
       // in a finally so a throw can never leave a session stuck in-flight.
       inflight.add(c.sessionID);
       attempted++;
+      tally.total++;
       try {
         // Guard 3 (isBusy re-check immediately before the call): a turn can
         // start between evaluation and here — firing under a live turn is a
@@ -237,6 +242,7 @@ export function createCompactionScheduler({
         await compact(c.sessionID);
         entry.lastResult = "ok";
         compacted.push(c.sessionID);
+        tally.background++;
         console.log(`[optimizer] compacted session=${c.sessionID} ctx=${pct}% idle=${Math.round(idleMs / 60_000)}m`);
         if (typeof onCompacted === "function") {
           try {
@@ -260,7 +266,14 @@ export function createCompactionScheduler({
     return { compacted, attempted };
   }
 
-  return { tick };
+  // BET-1347: the "X of Y in background" stat. Absent until the scheduler has
+  // attempted at least one compaction (never a fabricated zero).
+  function stat() {
+    if (tally.total === 0) return null;
+    return { background: tally.background, total: tally.total };
+  }
+
+  return { tick, stat };
 }
 
 // The context % for a log line (0..~100). Guarded: a non-finite limit yields 0.

--- a/src/server/optimizer/compaction.mjs
+++ b/src/server/optimizer/compaction.mjs
@@ -125,6 +125,9 @@ function normalizeState(raw) {
  *     "optimizer-compaction.json"); injected so tests stub them.
  *   enabled — boolean or zero-arg fn; read per tick so flipping the switch
  *     takes effect without a restart.
+ *   onCompacted — (info) => void (async ok): called after a compact succeeds
+ *     with { sessionID, contextTokens, contextLimit }. BET-1347 wires this to
+ *     append a `compaction` entry to the activity log (the trust surface).
  *
  * The three guards, all required:
  *   1. an in-memory Set of sessionIds with a compaction in flight; a session
@@ -145,6 +148,7 @@ export function createCompactionScheduler({
   load,
   save,
   enabled = () => true,
+  onCompacted = null,
 } = {}) {
   const inflight = new Set();
   let state = null;
@@ -234,6 +238,13 @@ export function createCompactionScheduler({
         entry.lastResult = "ok";
         compacted.push(c.sessionID);
         console.log(`[optimizer] compacted session=${c.sessionID} ctx=${pct}% idle=${Math.round(idleMs / 60_000)}m`);
+        if (typeof onCompacted === "function") {
+          try {
+            await onCompacted({ sessionID: c.sessionID, contextTokens: c.contextTokens, contextLimit: c.contextLimit });
+          } catch (e) {
+            console.warn("[optimizer] compact onCompacted failed:", e?.message ?? e);
+          }
+        }
       } catch (e) {
         entry.lastResult = "error";
         console.warn(

--- a/src/server/optimizer/pacing.mjs
+++ b/src/server/optimizer/pacing.mjs
@@ -265,5 +265,24 @@ export function createPacingState({ load, save, now, ledgerTokens, tokenTtlMs = 
     return ensureLoaded();
   }
 
-  return { observe, pressureFor, tokensPerPct, snapshot };
+  // BET-1347: per-window pressure for the dashboard's pressure chips —
+  // `{ "<provider>:<kind>": { deficit, ecoLevel, tokensPerPct } }`. `tokensPerPct`
+  // is the measured signal (null → no pressure signal yet → the neutral chip).
+  async function pressureWindows() {
+    const s = await ensureLoaded();
+    const out = {};
+    for (const [key, win] of Object.entries(s.windows ?? {})) {
+      if (!win || typeof win !== "object") continue;
+      const deficit = num(win.deficit);
+      const tokens = await sumTokens(Array.isArray(win.providerIDs) ? win.providerIDs : []);
+      out[key] = {
+        deficit,
+        ecoLevel: ecoLevel(deficit),
+        tokensPerPct: tokensPerPct(key, { ledgerTokensSince: tokens, state: s }),
+      };
+    }
+    return out;
+  }
+
+  return { observe, pressureFor, tokensPerPct, snapshot, pressureWindows };
 }

--- a/src/server/optimizer/pacing.mjs
+++ b/src/server/optimizer/pacing.mjs
@@ -42,6 +42,22 @@ const TOKEN_TTL_MS = 60_000;
 const isNum = (v) => typeof v === "number" && Number.isFinite(v);
 const num = (v) => (isNum(v) ? v : 0);
 
+// Both the reset and cold-start branches re-seed a window's accumulator from
+// the closed form (never assume Q = 0). Shared so the two paths stay in lockstep.
+function seedWindow({ pctNum, startedAt, resetsAt, at, tokens, providerIDs }) {
+  return {
+    deficit: seedDeficit({ pct: pctNum, startedAt, resetsAt, now: at }),
+    pct: pctNum,
+    at,
+    tokensAtMark: tokens,
+    pctAtMark: pctNum,
+    rates: [],
+    providerIDs,
+    ...(startedAt != null ? { startedAt } : {}),
+    ...(resetsAt != null ? { resetsAt } : {}),
+  };
+}
+
 function normalizeState(raw) {
   const s = raw && typeof raw === "object" ? raw : {};
   const windows = {};
@@ -157,34 +173,14 @@ export function createPacingState({ load, save, now, ledgerTokens, tokenTtlMs = 
     // form so a box that restarts / a window that turns over does not carry a
     // stale queue.
     if (hasPrev && pctNum < prev.pct + RESET_DELTA) {
-      s.windows[key] = {
-        deficit: seedDeficit({ pct: pctNum, startedAt, resetsAt, now: at }),
-        pct: pctNum,
-        at,
-        tokensAtMark: tokens,
-        pctAtMark: pctNum,
-        rates: [],
-        providerIDs,
-        ...(startedAt != null ? { startedAt } : {}),
-        ...(resetsAt != null ? { resetsAt } : {}),
-      };
+      s.windows[key] = seedWindow({ pctNum, startedAt, resetsAt, at, tokens, providerIDs });
       return;
     }
 
     // First sight of this window: seed from the closed form (never assume
     // Q = 0 on a cold start).
     if (!hasPrev) {
-      s.windows[key] = {
-        deficit: seedDeficit({ pct: pctNum, startedAt, resetsAt, now: at }),
-        pct: pctNum,
-        at,
-        tokensAtMark: tokens,
-        pctAtMark: pctNum,
-        rates: [],
-        providerIDs,
-        ...(startedAt != null ? { startedAt } : {}),
-        ...(resetsAt != null ? { resetsAt } : {}),
-      };
+      s.windows[key] = seedWindow({ pctNum, startedAt, resetsAt, at, tokens, providerIDs });
       return;
     }
 

--- a/src/server/optimizer/summary.mjs
+++ b/src/server/optimizer/summary.mjs
@@ -21,6 +21,7 @@ import { aggregate, aggregateBySession, aggregateDailySeries, fetchLedgerRows } 
 import { summaryFields } from "./counterfactual.mjs";
 import { forecastAtReset } from "./forecast.mjs";
 import { measureEffectiveTtl, verifyCacheTtl, cacheTtlLabelMs } from "./ttl.mjs";
+import { SUMMARY_ACTIVITY_CAP } from "./activityLog.mjs";
 
 const WINDOW_DAYS = 30;
 const TTL_MS = 60_000;
@@ -54,6 +55,11 @@ export async function buildOptimizerSummary({
   // so the verifier stays testable; the 60s memo in createOptimizerSummary
   // bounds this I/O to one call per window, so it is null-cost to wire.
   readCacheTtl = async () => null,
+  // BET-1347: the activity log store (optimizer/activityLog.mjs). The
+  // summary exposes the newest SUMMARY_ACTIVITY_CAP entries so the dashboard
+  // renders the trust surface without a second fetch. Null when not wired →
+  // an empty feed (the documented empty state), never a fabricated zero.
+  activityStore = null,
 } = {}) {
   const nowMs = num(now);
   const raw = await fetchRows(nowMs - WINDOW_DAYS * 86_400_000);
@@ -111,7 +117,21 @@ export async function buildOptimizerSummary({
     ttl,
     counterfactual: cf ? { dailySeries: cf.dailySeries, bySession: cf.bySession } : null,
     windows: windowsFor(usageSnapshots(), usageHistory(), nowMs),
+    activity: await activityFor(activityStore),
   };
+}
+
+// The activity slice for the summary: the newest SUMMARY_ACTIVITY_CAP entries,
+// most recent first, or an EMPTY feed when no store is wired (the documented
+// empty state). Never a fabricated zero.
+async function activityFor(activityStore) {
+  if (!activityStore || typeof activityStore.recent !== "function") return { entries: [] };
+  try {
+    const entries = await activityStore.recent(SUMMARY_ACTIVITY_CAP);
+    return { entries: Array.isArray(entries) ? entries : [] };
+  } catch {
+    return { entries: [] };
+  }
 }
 
 // Map the current stored usage snapshots to the summary's `windows` slice —
@@ -167,7 +187,7 @@ let inflight = null;
  * summary then degrades to empty counterfactual). The returned async
  * function memoizes the built summary for TTL_MS with an in-flight guard.
  */
-export function createOptimizerSummary({ getDb, now, counterfactualStore = null, usageSnapshots, usageHistory, readCacheTtl }) {
+export function createOptimizerSummary({ getDb, now, counterfactualStore = null, usageSnapshots, usageHistory, readCacheTtl, activityStore = null }) {
   const nowMs = () => (typeof now === "function" ? num(now()) : num(now ?? Date.now()));
   return async function optimizerSummary() {
     const t = nowMs();
@@ -184,6 +204,7 @@ export function createOptimizerSummary({ getDb, now, counterfactualStore = null,
           usageSnapshots,
           usageHistory,
           readCacheTtl,
+          activityStore,
         });
         cache = { at: t, value };
         return value;

--- a/src/server/optimizer/summary.mjs
+++ b/src/server/optimizer/summary.mjs
@@ -60,6 +60,16 @@ export async function buildOptimizerSummary({
   // renders the trust surface without a second fetch. Null when not wired →
   // an empty feed (the documented empty state), never a fabricated zero.
   activityStore = null,
+  // BET-1347: per-window pacing pressure `{ "<provider>:<kind>": { deficit,
+  // tokensPerPct } }` for the pressure chips under each gauge. Null/incomplete
+  // → the chip renders its neutral "no pressure signal yet" state.
+  pressureWindows = async () => ({}),
+  // BET-1347: the compaction scheduler's "X of Y in background" stat, or null
+  // until the scheduler has attempted anything.
+  compactionStat = async () => null,
+  // BET-1347: metered (pay-per-token) endpoints, rendered as a slim role+price
+  // row (no gauge). [] → the section is absent.
+  meteredEndpoints = async () => [],
 } = {}) {
   const nowMs = num(now);
   const raw = await fetchRows(nowMs - WINDOW_DAYS * 86_400_000);
@@ -116,9 +126,36 @@ export async function buildOptimizerSummary({
     bySession,
     ttl,
     counterfactual: cf ? { dailySeries: cf.dailySeries, bySession: cf.bySession } : null,
-    windows: windowsFor(usageSnapshots(), usageHistory(), nowMs),
+    windows: windowsFor(usageSnapshots(), usageHistory(), nowMs, await pressureWindows()),
     activity: await activityFor(activityStore),
+    compaction: await compactionFor(compactionStat),
+    metered: await meteredFor(meteredEndpoints),
   };
+}
+
+// The compaction "X of Y in background" stat, or null when the scheduler has
+// nothing to report (never a fabricated zero).
+async function compactionFor(compactionStat) {
+  if (typeof compactionStat !== "function") return null;
+  try {
+    const s = await compactionStat();
+    if (!s || typeof s.total !== "number" || s.total <= 0) return null;
+    return { background: typeof s.background === "number" ? s.background : 0, total: s.total };
+  } catch {
+    return null;
+  }
+}
+
+// The metered-endpoints row, or [] when none are wired (the section is then
+// absent — "never render a control whose backing data isn't there").
+async function meteredFor(meteredEndpoints) {
+  if (typeof meteredEndpoints !== "function") return [];
+  try {
+    const m = await meteredEndpoints();
+    return Array.isArray(m) ? m : [];
+  } catch {
+    return [];
+  }
 }
 
 // The activity slice for the summary: the newest SUMMARY_ACTIVITY_CAP entries,
@@ -139,22 +176,32 @@ async function activityFor(activityStore) {
 // them (each snapshot's `windows` array is already shortest-first, and
 // snapshots are iterated in provider order). `forecastPct` is the forecast-at-
 // reset from history, or null when there isn't enough history to trust it (the
-// UI then hides the tick).
-function windowsFor(snapshots, history, nowMs) {
+// UI then hides the tick). `pressureMap` (`{ "<provider>:<kind>": { deficit,
+// tokensPerPct } }`) supplies the pacing pressure the chips render; it may be
+// incomplete or empty (the chip then shows its neutral "no pressure signal"
+// state).
+function windowsFor(snapshots, history, nowMs, pressureMap = {}) {
   const out = [];
   for (const snap of snapshots ?? []) {
     for (const w of snap.windows ?? []) {
+      const key = `${snap.provider}:${w.kind}`;
+      const pressure = pressureMap?.[key] ?? null;
       out.push({
         provider: snap.provider,
         planLabel: typeof snap.planLabel === "string" ? snap.planLabel : undefined,
         windowLabel: w.label,
+        kind: w.kind ?? undefined,
         pct: w.pct,
         resetsAt: Number.isFinite(w.resetsAt) ? w.resetsAt : null,
-        forecastPct: forecastAtReset(history, `${snap.provider}:${w.kind}`, {
+        forecastPct: forecastAtReset(history, key, {
           now: nowMs,
           resetsAt: Number.isFinite(w.resetsAt) ? w.resetsAt : undefined,
           currentPct: w.pct,
         }),
+        // BET-1347: pacing pressure for the chip. `tokensPerPct` is the
+        // measured signal; null means no pressure signal yet (neutral chip).
+        deficit: pressure && typeof pressure.deficit === "number" ? pressure.deficit : null,
+        tokensPerPct: pressure && typeof pressure.tokensPerPct === "number" ? pressure.tokensPerPct : null,
       });
     }
   }
@@ -187,7 +234,7 @@ let inflight = null;
  * summary then degrades to empty counterfactual). The returned async
  * function memoizes the built summary for TTL_MS with an in-flight guard.
  */
-export function createOptimizerSummary({ getDb, now, counterfactualStore = null, usageSnapshots, usageHistory, readCacheTtl, activityStore = null }) {
+export function createOptimizerSummary({ getDb, now, counterfactualStore = null, usageSnapshots, usageHistory, readCacheTtl, activityStore = null, pressureWindows, compactionStat, meteredEndpoints }) {
   const nowMs = () => (typeof now === "function" ? num(now()) : num(now ?? Date.now()));
   return async function optimizerSummary() {
     const t = nowMs();
@@ -205,6 +252,9 @@ export function createOptimizerSummary({ getDb, now, counterfactualStore = null,
           usageHistory,
           readCacheTtl,
           activityStore,
+          pressureWindows,
+          compactionStat,
+          meteredEndpoints,
         });
         cache = { at: t, value };
         return value;

--- a/src/server/optimizer/summary.test.mjs
+++ b/src/server/optimizer/summary.test.mjs
@@ -22,6 +22,26 @@ function row(over = {}) {
   };
 }
 
+// The canonical one-row fixture used by several breakdown assertions — the
+// same row object, so any shared behaviour runs against the same shape.
+function baseRows(now) {
+  return [row({ cost: 5, input: 1, cacheRead: 2, cacheWrite: 3, output: 4, startedMs: now })];
+}
+
+// Runs `fn` with console.warn captured, restoring it afterwards; returns the
+// captured lines. Two tests assert on the [optimizer] TTL-verifier log.
+async function captureWarns(fn) {
+  const warns = [];
+  const originalWarn = console.warn;
+  console.warn = (m) => warns.push(String(m));
+  try {
+    await fn();
+  } finally {
+    console.warn = originalWarn;
+  }
+  return warns;
+}
+
 // Build `count` consecutive turns in one session, each `gapMs` after the
 // previous completion — deterministic consecutive pairs for the TTL verifier.
 // Every pair is cold (cacheRead 0) and well-clear of the 5000-ctx floor, so a
@@ -59,7 +79,7 @@ function memStore(now, seed = {}) {
 
 test("buildOptimizerSummary returns the full shape with empty counterfactual, reusing aggregate totals/cacheShare", async () => {
   const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
-  const rows = [row({ cost: 5, input: 1, cacheRead: 2, cacheWrite: 3, output: 4, startedMs: now })];
+  const rows = baseRows(now);
   const fetchRows = async () => rows;
 
   const s = await buildOptimizerSummary({ fetchRows, now });
@@ -95,7 +115,7 @@ test("buildOptimizerSummary returns the full shape with empty counterfactual, re
 test("buildOptimizerSummary merges the counterfactual into dailySeries + bySession and fills the counterfactual key", async () => {
   const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
   // tokensSent = 1+2+3+4 = 10 for s1.
-  const rows = [row({ cost: 5, input: 1, cacheRead: 2, cacheWrite: 3, output: 4, startedMs: now })];
+  const rows = baseRows(now);
   const fetchRows = async () => rows;
   const store = memStore(now);
   assert.equal((await store.record({ sessionID: "s1", maskedTokens: 5, maskedParts: 1, ts: now })).ok, true);
@@ -237,15 +257,10 @@ test("buildOptimizerSummary: measured 5m vs configured 1h logs one [optimizer] m
   const fetchRows = async () => rows;
   const readCacheTtl = async () => "1h"; // opencode configured to SEND 1h
 
-  const warns = [];
-  const originalWarn = console.warn;
-  console.warn = (m) => warns.push(String(m));
   let s;
-  try {
+  const warns = await captureWarns(async () => {
     s = await buildOptimizerSummary({ fetchRows, now, readCacheTtl });
-  } finally {
-    console.warn = originalWarn;
-  }
+  });
 
   // One [optimizer] mismatch line is logged.
   const mismatch = warns.filter((m) => m.includes("[optimizer] cache-TTL mismatch"));
@@ -266,15 +281,10 @@ test("buildOptimizerSummary: no mismatch log when the verifier has nothing concl
   const fetchRows = async () => [row({ startedMs: now })];
   const readCacheTtl = async () => "1h";
 
-  const warns = [];
-  const originalWarn = console.warn;
-  console.warn = (m) => warns.push(String(m));
   let s;
-  try {
+  const warns = await captureWarns(async () => {
     s = await buildOptimizerSummary({ fetchRows, now, readCacheTtl });
-  } finally {
-    console.warn = originalWarn;
-  }
+  });
 
   assert.ok(warns.every((m) => !m.includes("[optimizer] cache-TTL mismatch")), "no mismatch line expected");
   assert.equal(s.ttl.confidence, "default");

--- a/src/server/optimizer/summary.test.mjs
+++ b/src/server/optimizer/summary.test.mjs
@@ -281,3 +281,19 @@ test("buildOptimizerSummary: no mismatch log when the verifier has nothing concl
   assert.equal(s.ttl.configuredMs, null);
   assert.equal(s.ttl.matched, null);
 });
+
+test("buildOptimizerSummary: activity slice surfaces the store's newest entries, empty without a store (BET-1347)", async () => {
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const fetchRows = async () => [row({ startedMs: now })];
+  // No store wired → empty feed (the documented empty state), never a zero.
+  const noStore = await buildOptimizerSummary({ fetchRows, now });
+  assert.deepEqual(noStore.activity, { entries: [] });
+
+  const activityStore = {
+    recent: async (n) =>
+      [{ id: "abc12345", ts: now, kind: "tune", subject: "x", verdict: "kept", evidence: { turns: 5 } }],
+  };
+  const withStore = await buildOptimizerSummary({ fetchRows, now, activityStore });
+  assert.equal(withStore.activity.entries.length, 1);
+  assert.equal(withStore.activity.entries[0].kind, "tune");
+});

--- a/src/server/optimizer/telemetry.mjs
+++ b/src/server/optimizer/telemetry.mjs
@@ -1,0 +1,49 @@
+// optimizer/telemetry.mjs — count-only context telemetry for the optimizer
+// (Optimizer P2.5, BET-1347).
+//
+// The `manta` Axiom dataset already carries `source` / `device` / `level` /
+// `msg` from the server's log shipper. This module adds a `channel: "ctx"`
+// discriminator for optimizer CONTEXT events (mask applications, routing
+// decisions, compactions, tunes) that are useful to a maintainer watching the
+// guardrails — without ever leaking content.
+//
+// DAMAGE BOUNDARY: counts and measurements only. Never conversation content,
+// never file paths, never session titles (sessionID is allowed because it is
+// an opaque id, not a title). The test suite enforces this with a grep gate
+// over the emission call sites: no field named `text` / `content` / `prompt` /
+// `message` may ever be shipped.
+//
+// This is the ONLY module that knows how the box ships context events. Callers
+// import `shipCtxEvent`; `setTelemetrySink(shipper)` is called once at boot
+// (src/server/index.mjs hands it the SAME log-shipper instance that
+// captureConsole already uses — a reference, never a second shipper). Without
+// a sink the module is a silent no-op, so telemetry is never load-bearing.
+
+// The Axiom log shipper (createLogShipper), or null when it isn't configured.
+let sink = null;
+
+/**
+ * Point the context-telemetry sink at the box's log shipper. Called ONCE at
+ * server boot with the already-constructed shipper (a reference, no second
+ * instance). Pass null to disable.
+ */
+export function setTelemetrySink(shipper) {
+  sink = shipper ?? null;
+}
+
+/**
+ * Ship one optimizer context event. Fields are merged onto
+ * `{ channel: "ctx", ...fields }` so Axiom can filter on `channel == "ctx"`.
+ * A silent no-op when no sink is configured (or when the sink is broken) —
+ * telemetry must never throw and never block the caller.
+ *
+ * @param {Record<string, string|number|boolean|null|undefined>} fields
+ */
+export function shipCtxEvent(fields = {}) {
+  if (!sink || typeof sink.log !== "function") return;
+  try {
+    sink.log("info", "ctx", { channel: "ctx", ...fields });
+  } catch {
+    // Swallow — telemetry never breaks the box.
+  }
+}

--- a/src/server/optimizer/telemetry.test.mjs
+++ b/src/server/optimizer/telemetry.test.mjs
@@ -1,0 +1,87 @@
+// Tests for optimizer/telemetry.mjs — the count-only context telemetry for the
+// optimizer (Optimizer P2.5, BET-1347). The sink is injected/reset directly;
+// no Axiom network is ever touched (without a sink the module is a no-op).
+// Run via `npm run test:server` (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join } from "node:path";
+import { setTelemetrySink, shipCtxEvent } from "./telemetry.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+function fakeSink() {
+  const events = [];
+  return {
+    events,
+    log(level, msg, fields) {
+      events.push({ level, msg, fields });
+    },
+  };
+}
+
+test("no sink -> shipCtxEvent is a silent no-op, never throws", () => {
+  setTelemetrySink(null);
+  let threw = false;
+  try {
+    shipCtxEvent({ kind: "tune", param: "maskAfterUses", from: 12, to: 10, sessionID: "abc" });
+  } catch {
+    threw = true;
+  }
+  assert.equal(threw, false); // still silent, no throw
+});
+
+test("fields pass through on the ctx channel with a sink set", () => {
+  const sink = fakeSink();
+  setTelemetrySink(sink);
+  try {
+    shipCtxEvent({ kind: "mask", maskedTokens: 120, maskedParts: 3, applied: 1, mode: "act", sessionID: "s1" });
+    assert.equal(sink.events.length, 1);
+    const e = sink.events[0];
+    assert.equal(e.level, "info");
+    assert.equal(e.msg, "ctx");
+    assert.equal(e.fields.channel, "ctx");
+    assert.equal(e.fields.kind, "mask");
+    assert.equal(e.fields.maskedTokens, 120);
+    assert.equal(e.fields.sessionID, "s1");
+  } finally {
+    setTelemetrySink(null);
+  }
+});
+
+// ---- Content-field grep gate -------------------------------------------------
+// The privacy contract: ctx telemetry ships COUNTS ONLY. No field named
+// text/content/prompt/message may ever be emitted. This greps the actual
+// emission call sites (and the telemetry module itself) so a future change
+// that leaks content fails here, not in review.
+
+const EMITTER_FILES = ["telemetry.mjs", "tuner.mjs"].map((f) => join(__dirname, f)).concat([
+  join(__dirname, "..", "..", "index.mjs"),
+  join(__dirname, "..", "rpc.mjs"),
+]);
+
+const INDICES = ["text:", "content:", "prompt:", "message:"];test("grep gate: no ctx emission ever ships a content field name", () => {
+  const offenders = [];
+  for (const file of EMITTER_FILES) {
+    let src = "";
+    try {
+      src = readFileSync(file, "utf-8");
+    } catch {
+      continue;
+    }
+    // Find every shipCtxEvent({ ... }) call and capture its object literal.
+    const re = /shipCtxEvent\s*\(\s*\{([\s\S]*?)\n?\s*\}\)/g;
+    let m;
+    while ((m = re.exec(src)) !== null) {
+      const body = m[1];
+      for (const idx of INDICES) {
+        if (body.includes(idx)) {
+          offenders.push(`${file}: near shipCtxEvent with '${idx}'`);
+        }
+      }
+    }
+  }
+  assert.deepEqual(offenders, []);
+});

--- a/src/server/optimizer/tuner.mjs
+++ b/src/server/optimizer/tuner.mjs
@@ -29,6 +29,7 @@
 
 import { statePath } from "../../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "../jsonStore.mjs";
+import { shipCtxEvent } from "./telemetry.mjs";
 
 // Event trigger: at least this many NEW sessions since the last change.
 export const TUNE_MIN_NEW_SESSIONS = 20;
@@ -289,6 +290,8 @@ export function createTuner({
     s.lastChangeAt = t;
     s.lastSessionCount = sessions;
     await persistState();
+    // Context telemetry: a tune step was applied (counts + knob values only).
+    shipCtxEvent({ kind: "tune", param: step.param, from: step.from, to: step.to, verdict: "applied" });
   }
 
   async function keep(s, t, sessions) {
@@ -307,6 +310,7 @@ export function createTuner({
     s.lastSessionCount = sessions;
     s.pending = null;
     await persistState();
+    shipCtxEvent({ kind: "tune", param: p.param, from: p.from, to: p.to, verdict: "kept" });
   }
 
   async function revert(s, guardrail, t, sessions) {
@@ -331,6 +335,7 @@ export function createTuner({
     s.lastSessionCount = sessions;
     s.pending = null;
     await persistState();
+    shipCtxEvent({ kind: "tune", param: p.param, from: p.from, to: p.from, verdict: "rolled-back" });
   }
 
   async function shouldTune({ newSessions, ecoChanged, quotaReset }) {

--- a/src/server/optimizer/tuner.mjs
+++ b/src/server/optimizer/tuner.mjs
@@ -1,0 +1,401 @@
+// optimizer/tuner.mjs — the conservative bandit that earns its own parameter
+// changes (Optimizer P2.5, BET-1347).
+//
+// The phases before this fix the parameters at DEFAULT_POLICY's values
+// (mask 12 uses / batch 20k / protect tail 40k). The tuner is what changes
+// them — one parameter, one step along its ladder, at a time, and only when
+// the guardrails let it. A change is KEPT only if no guardrail trips during
+// its observation window; otherwise it is REVERTED immediately and both facts
+// (kept / rolled-back) are written to the activity log. The activity log is
+// the trust surface; the tuner is deliberately paranoid.
+//
+// EVENT-DRIVEN, NOT CLOCK-DRIVEN. A tune is evaluated on: TUNE_MIN_NEW_SESSIONS
+// new sessions since the last change, a regime change (the eco level moved, or
+// a quota window reset), or a guardrail trip. The TUNE_IDLE_SWEEP_MS sweep is
+// a BACKSTOP for a box that sees none of those — not the mechanism.
+//
+// Pure decision + injected I/O throughout, mirroring the other optimizer
+// modules:
+//   • countRefetchChurn(rows)  — PURE. The honest measure of a trim that cost
+//     more than it saved (defined exactly below).
+//   • nextTuneStep(policy)     — PURE. One parameter, one ladder rung.
+//   • createTuner({...})       — the stateful engine. Injected `load`/`save`
+//     (the optimizer-policy.json repo table, via the shared atomic writer),
+//     `now`, `enabled`, `directory` (the repo being tuned), `activityLog`,
+//     `sessionCount`, and `observeGuardrails`. Returns { tune, snapshot }.
+//
+// The tuner is the ONLY writer of optimizer-policy.json — the write path lives
+// here (POLICY_PATH + the default load/save), never in index.mjs.
+
+import { statePath } from "../../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "../jsonStore.mjs";
+
+// Event trigger: at least this many NEW sessions since the last change.
+export const TUNE_MIN_NEW_SESSIONS = 20;
+// Backstop sweep only — a box with no new sessions, no regime change and no
+// guardrail trip is simply left alone.
+export const TUNE_IDLE_SWEEP_MS = 6 * 60 * 60_000;
+// A change must survive its observation window without a guardrail trip to be
+// KEPT. Bounded to the same horizon as the sustain guardrail below.
+export const TUNE_OBSERVE_MS = 60 * 60_000;
+
+// Guardrails — any one trips -> instant revert + a "rolled-back" entry naming
+// which. Deliberately conservative numbers; the tuner is a bandit, not a
+// gambler.
+export const GUARD_CACHE_HIT_DROP_PTS = 10; // cache-hit rate down this many points, sustained
+export const GUARD_SUSTAIN_MS = 60 * 60_000; // ...for this long
+export const GUARD_CHURN_PCT = 0.02; // re-fetch churn > 2% of masked parts
+export const GUARD_COST_PER_TURN_WOW = 0.2; // effective cost/turn +20% week over week
+
+// The ladders each parameter moves along. "Aggressive" is the LOWER end (mask
+// sooner, batch sooner, protect less tail); the tuner moves DOWN one rung at a
+// time and reverts if a guardrail objects.
+export const TUNE_STEPS = {
+  maskAfterUses: [8, 10, 12, 16, 20],
+  batchTokens: [10_000, 20_000, 40_000],
+  protectTailTokens: [24_000, 40_000, 60_000],
+};
+
+// DEFAULT_POLICY's starting values (destination when none tuned yet).
+export const DEFAULT_TUNED = {
+  maskAfterUses: 12,
+  batchTokens: 20_000,
+  protectTailTokens: 40_000,
+};
+
+// The tuner owns the per-repo tuner table file (the ONLY writer — see the
+// counterfactual/route context; the policy route only READS it).
+export const POLICY_PATH = statePath("optimizer-policy.json");
+
+const PARAM_KEYS = Object.keys(TUNE_STEPS); // order = tune priority
+
+const isNum = (v) => typeof v === "number" && Number.isFinite(v);
+
+// --- Pure decision helpers -------------------------------------------------
+
+// JSON-stable stringify: deterministic key order so "same input" means the
+// same bytes regardless of object key order. Never throws.
+function stableStringify(v) {
+  if (v === undefined) return "null";
+  try {
+    if (Array.isArray(v)) return `[${v.map(stableStringify).join(",")}]`;
+    if (v && typeof v === "object") {
+      return `{${Object.keys(v)
+        .sort()
+        .map((k) => `${JSON.stringify(k)}:${stableStringify(v[k])}`)
+        .join(",")}}`;
+    }
+    return JSON.stringify(v);
+  } catch {
+    return "null";
+  }
+}
+
+// The refetch identity of a part row: same sessionID, same tool, same
+// state.input (JSON-stable-stringified). Two parts with the same key are the
+// same tool run; if an earlier one was masked and it came back, that's churn.
+function refetchKey(r) {
+  const input = r.input === undefined || r.input === null ? null : r.input;
+  return `${String(r.sessionID ?? "")}|${String(r.tool ?? "")}|${stableStringify(input)}`;
+}
+
+const PLACEHOLDER_PREFIX = "[manta: trimmed";
+const isPlaceholder = (output) => typeof output === "string" && output.startsWith(PLACEHOLDER_PREFIX);
+
+/**
+ * PURE. The re-fetch churn over a window of tool part rows.
+ *
+ * Churn is a tool re-run whose EARLIER output we masked: the same
+ * (`sessionID`, `tool`, `state.input`) as a part that was replaced by a manta
+ * placeholder earlier in the sequence. Re-running a tool whose output we had
+ * trimmed is the honest measure of a trim that cost more than it saved — we
+ * paid to re-execute it, which is the masking counterfactual not saving us.
+ *
+ * `rows` is an array (chronological) of `{ sessionID, tool, input, output }`
+ * where `output` is the part's output string (a real tool result, or a manta
+ * placeholder). Returns `{ count, masked, ratio }` where `ratio = count /
+ * masked` is churn as a fraction of masked parts (0 when no parts were masked)
+ * — the guardrail threshold guards `ratio > GUARD_CHURN_PCT`.
+ *
+ * @param {Array<{sessionID?: string, tool?: string, input?: unknown, output?: string}>} rows
+ * @returns {{ count: number, masked: number, ratio: number }}
+ */
+export function countRefetchChurn(rows) {
+  const seen = new Map(); // refetch key -> number of earlier masked parts
+  let masked = 0;
+  let count = 0;
+  for (const r of Array.isArray(rows) ? rows : []) {
+    if (!r || typeof r !== "object") continue;
+    if (typeof r.tool !== "string" || typeof r.output !== "string") continue;
+    const key = refetchKey(r);
+    if (isPlaceholder(r.output)) {
+      masked++;
+      seen.set(key, (seen.get(key) ?? 0) + 1);
+    } else if ((seen.get(key) ?? 0) > 0) {
+      // A real re-run whose EARLIER same-key output was masked.
+      count++;
+    }
+  }
+  return { count, masked, ratio: masked > 0 ? count / masked : 0 };
+}
+
+// Clamp a policy value to its nearest ladder rung; returns { idx, val } where
+// idx is the rung index (lower idx = more aggressive) and val the rung value.
+function ladderPos(ladder, value) {
+  if (!Array.isArray(ladder) || ladder.length === 0) return { idx: -1, val: value };
+  if (!isNum(value)) return { idx: ladder.length - 1, val: ladder[ladder.length - 1] };
+  let best = 0;
+  let bestDist = Infinity;
+  for (let i = 0; i < ladder.length; i++) {
+    const d = Math.abs(ladder[i] - value);
+    if (d < bestDist) {
+      bestDist = d;
+      best = i;
+    }
+  }
+  return { idx: best, val: ladder[best] };
+}
+
+function paramValue(policy, param) {
+  const raw = policy?.[param];
+  return isNum(raw) && raw > 0 ? raw : DEFAULT_TUNED[param];
+}
+
+/**
+ * PURE (though it reads a `policy` object). Choose the next tune: exactly ONE
+ * parameter, exactly ONE step DOWN its ladder (more aggressive), cycling by
+ * priority (maskAfterUses → batchTokens → protectTailTokens). Returns
+ * `{ param, from, to }`, or `null` when every parameter is already at its most
+ * aggressive rung (nothing left to earn).
+ */
+export function nextTuneStep(policy = {}) {
+  for (const param of PARAM_KEYS) {
+    const ladder = TUNE_STEPS[param];
+    const { idx, val } = ladderPos(ladder, paramValue(policy, param));
+    if (idx > 0) {
+      return { param, from: val, to: ladder[idx - 1] };
+    }
+  }
+  return null;
+}
+
+// Human change description for an activity entry's `subject`. The "Kept /
+// Rolled back" prefix is the renderer's (from `verdict`); this is the change.
+export function describeTuneSubject(param, from, to) {
+  switch (param) {
+    case "maskAfterUses":
+      return `trim threshold ${from} → ${to} tool uses`;
+    case "batchTokens":
+      return `batch threshold ${formatK(from)} → ${formatK(to)} tokens`;
+    case "protectTailTokens":
+      return `protected tail ${formatK(from)} → ${formatK(to)} tokens`;
+    default:
+      return `${param} ${from} → ${to}`;
+  }
+}
+
+function formatK(v) {
+  return isNum(v) ? `${Math.round(v / 1000)}k` : String(v);
+}
+
+/**
+ * The tuner engine. Pure decision + injected I/O (no fs access unless the
+ * injected load/save touch it — tests stub them in-memory).
+ *
+ *   load / save       — the per-repo tuner table (optimizer-policy.json shape
+ *                        `{ repos: { "<dir>": { maskAfterUses?... } } }`).
+ *                        Defaults read/write `POLICY_PATH` atomically. The
+ *                        tuner is the ONLY writer of that file.
+ *   directory         — the repo directory being tuned (the policy route's
+ *                        repo-table key). Empty/absent → no tuning.
+ *   enabled           — boolean or zero-arg fn: the optimizer switch. When
+ *                        false the tuner neither observes nor writes.
+ *   now               — clock (number or zero-arg fn).
+ *   activityLog       — { append } (optimizer/activityLog.mjs).
+ *   sessionCount      — () => number | number: the box's current session count
+ *                        (for the "new sessions since last change" trigger).
+ *   observeGuardrails — () => { tripped, which, evidence } | null: the current
+ *                        guardrail state. Index wiring derives it from the
+ *                         cache-hit / churn / cost measurements (fail-open:
+ *                        absent/broken → no trip → the bandit stays put).
+ *   loadTunerState / saveTunerState — persist `{ pending, lastSessionCount,
+ *                        lastChangeAt }` (tests stub in-memory).
+ *
+ * Returns { tune, snapshot }: tune(input) runs ONE evaluation pass.
+ */
+export function createTuner({
+  load = () => readJsonSync(POLICY_PATH, {}),
+  save = (data) => writeJsonAtomic(POLICY_PATH, JSON.stringify(data, null, 2)),
+  directory = "",
+  enabled = () => true,
+  now,
+  activityLog,
+  sessionCount = () => 0,
+  observeGuardrails = () => null,
+  loadTunerState = async () => ({}),
+  saveTunerState = async () => {},
+} = {}) {
+  let state = null;
+
+  const nowMs = () => (typeof now === "function" ? (now() ?? Date.now()) : (now ?? Date.now()));
+  const enabledOn = async () => (typeof enabled === "function" ? !!enabled() : !!enabled);
+  const curSessions = async () => {
+    const c = typeof sessionCount === "function" ? sessionCount() : sessionCount;
+    return isNum(c) ? c : 0;
+  };
+
+  async function ensureState() {
+    if (!state) state = { pending: null, lastSessionCount: 0, lastChangeAt: 0, ...(await loadTunerState()) };
+    return state;
+  }
+
+  async function persistState() {
+    await saveTunerState({ pending: state.pending, lastSessionCount: state.lastSessionCount, lastChangeAt: state.lastChangeAt });
+  }
+
+  // Read the current tunable values for `directory` from the repo table.
+  async function currentPolicy() {
+    const table = await load();
+    const repo = table?.repos?.[directory];
+    return {
+      maskAfterUses: paramValue(repo, "maskAfterUses"),
+      batchTokens: paramValue(repo, "batchTokens"),
+      protectTailTokens: paramValue(repo, "protectTailTokens"),
+    };
+  }
+
+  // Build the policy table with `patch` applied to this directory's entry.
+  async function persistPolicy(patch) {
+    const table = await load();
+    const repos = table?.repos && typeof table.repos === "object" ? table.repos : {};
+    const repo = { ...(repos[directory] ?? {}) };
+    for (const [k, v] of Object.entries(patch)) repo[k] = v;
+    await save({ repos: { ...repos, [directory]: repo } });
+  }
+
+  async function appendActivity(entry) {
+    if (activityLog && typeof activityLog.append === "function") {
+      try {
+        await activityLog.append(entry);
+      } catch (e) {
+        console.warn("[optimizer] activity append failed:", e?.message ?? e);
+      }
+    }
+  }
+
+  async function apply(s, step, t, sessions) {
+    await persistPolicy({ [step.param]: step.to });
+    s.pending = { param: step.param, from: step.from, to: step.to, changedAt: t };
+    s.lastChangeAt = t;
+    s.lastSessionCount = sessions;
+    await persistState();
+  }
+
+  async function keep(s, t, sessions) {
+    const p = s.pending;
+    await appendActivity({
+      kind: "tune",
+      subject: describeTuneSubject(p.param, p.from, p.to),
+      from: p.from,
+      to: p.to,
+      verdict: "kept",
+      evidence: {
+        observeMinutes: Math.round((t - p.changedAt) / 60_000),
+      },
+    });
+    s.lastChangeAt = t;
+    s.lastSessionCount = sessions;
+    s.pending = null;
+    await persistState();
+  }
+
+  async function revert(s, guardrail, t, sessions) {
+    const p = s.pending;
+    // Restore the pre-change value — the bandit changes nothing that survives
+    // a trip.
+    await persistPolicy({ [p.param]: p.from });
+    await appendActivity({
+      kind: "tune",
+      subject: describeTuneSubject(p.param, p.from, p.to),
+      from: p.from,
+      to: p.from,
+      verdict: "rolled-back",
+      revertedAt: t,
+      evidence: {
+        revertedAfterMinutes: Math.round((t - p.changedAt) / 60_000),
+        guardrail: guardrail?.which ?? "unknown",
+        ...(guardrail?.evidence ?? {}),
+      },
+    });
+    s.lastChangeAt = t;
+    s.lastSessionCount = sessions;
+    s.pending = null;
+    await persistState();
+  }
+
+  async function shouldTune({ newSessions, ecoChanged, quotaReset }) {
+    if (newSessions >= TUNE_MIN_NEW_SESSIONS) return true;
+    if (ecoChanged || quotaReset) return true;
+    return false;
+  }
+
+  /**
+   * ONE evaluation pass. `input`:
+   *   { sessionCount?, ecoChanged?, quotaReset?, guardrail? } where
+   *   `guardrail` = { tripped, which, evidence } (from observeGuardrails).
+   * Returns a descriptive { action, ... }. Always fails open to {action:"no-op"}
+   * on any unexpected error; never throws.
+   */
+  async function tune(input = {}) {
+    try {
+      if (!(await enabledOn())) return { action: "no-op" };
+      const t = nowMs();
+      const s = await ensureState();
+      const guardrail =
+        input.guardrail?.tripped
+          ? input.guardrail
+          : (await (typeof observeGuardrails === "function" ? observeGuardrails() : null)) ?? null;
+
+      // 1. A guardrail trip reverts an in-flight pending change immediately.
+      if (s.pending && guardrail) {
+        const sessions = input.sessionCount ?? (await curSessions());
+        await revert(s, guardrail, t, sessions);
+        return { action: "reverted", param: s.pending?.param, guardrail: guardrail.which };
+      }
+
+      // 2. A pending change that survived its observation window is KEPT.
+      if (s.pending && t - s.pending.changedAt >= TUNE_OBSERVE_MS) {
+        const p = s.pending;
+        await keep(s, t, input.sessionCount ?? (await curSessions()));
+        return { action: "kept", param: p.param, from: p.from, to: p.to };
+      }
+
+      // 3. A positive trigger with nothing pending applies the next step.
+      const sessions = isNum(input.sessionCount) ? input.sessionCount : await curSessions();
+      const newSessions = Math.max(0, sessions - (s.lastSessionCount ?? 0));
+      if (!s.pending && (await shouldTune({ newSessions, ecoChanged: !!input.ecoChanged, quotaReset: !!input.quotaReset }))) {
+        const policy = await currentPolicy();
+        const step = nextTuneStep(policy);
+        if (!step) return { action: "no-tune" };
+        await apply(s, step, t, sessions);
+        return { action: "applied", param: step.param, from: step.from, to: step.to };
+      }
+
+      return { action: "no-tune" };
+    } catch (e) {
+      console.warn("[optimizer] tune pass failed (fail-open):", e?.message ?? e);
+      return { action: "no-op" };
+    }
+  }
+
+  async function snapshot() {
+    const s = await ensureState();
+    return {
+      pending: s.pending ? { ...s.pending } : null,
+      lastChangeAt: s.lastChangeAt,
+      lastSessionCount: s.lastSessionCount,
+    };
+  }
+
+  return { tune, snapshot, nextTuneStep, countRefetchChurn };
+}

--- a/src/server/optimizer/tuner.test.mjs
+++ b/src/server/optimizer/tuner.test.mjs
@@ -1,0 +1,184 @@
+// Tests for optimizer/tuner.mjs — the conservative bandit that earns its own
+// parameter changes (Optimizer P2.5, BET-1347). Pure/injected throughout: the
+// policy store load/save, tuner-state load/save, clock, activity log and
+// guardrail observer are all stubbed in-memory. Run via `npm run test:server`
+// (node:test).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createTuner,
+  countRefetchChurn,
+  nextTuneStep,
+  TUNE_STEPS,
+  TUNE_MIN_NEW_SESSIONS,
+  TUNE_OBSERVE_MS,
+  DEFAULT_TUNED,
+} from "./tuner.mjs";
+
+function makeTuner({ enabled = true, now, directory = "/repo", policy = {}, sessionCount = 100 } = {}) {
+  let table = { repos: { [directory]: { ...policy } } };
+  let policyWrites = 0;
+  let tunerState = {};
+  const activity = [];
+  let clock = typeof now === "function" ? now() : (now ?? 1_700_000_000_000);
+
+  const tuner = createTuner({
+    directory,
+    load: async () => JSON.parse(JSON.stringify(table)),
+    save: async (t) => {
+      table = JSON.parse(JSON.stringify(t));
+      policyWrites++;
+    },
+    loadTunerState: async () => tunerState,
+    saveTunerState: async (s) => {
+      tunerState = s;
+    },
+    enabled: () => enabled,
+    now: () => clock,
+    sessionCount: () => sessionCount,
+    activityLog: {
+      append: async (e) => {
+        activity.push(e);
+        return { ok: true, entry: e };
+      },
+    },
+  });
+
+  return {
+    tuner,
+    advance: (ms) => (clock += ms),
+    getTable: () => table,
+    policyWrites: () => policyWrites,
+    activity: () => activity,
+  };
+}
+
+test("nextTuneStep: moves exactly one parameter one ladder rung toward aggressive (lower)", () => {
+  // maskAfterUses cycles first: 20 -> 16 (one step, never more).
+  const step = nextTuneStep({ maskAfterUses: 20, batchTokens: 40_000, protectTailTokens: 60_000 });
+  assert.deepEqual(step, { param: "maskAfterUses", from: 20, to: 16 });
+
+  // maskAfterUses already at its most aggressive rung -> batchTokens moves.
+  const step2 = nextTuneStep({ maskAfterUses: 8, batchTokens: 40_000, protectTailTokens: 60_000 });
+  assert.deepEqual(step2, { param: "batchTokens", from: 40_000, to: 20_000 });
+
+  // Every param at the aggressive end -> nothing to tune.
+  const none = nextTuneStep({ maskAfterUses: 8, batchTokens: 10_000, protectTailTokens: 24_000 });
+  assert.equal(none, null);
+
+  // Defaults (DEFAULT_TUNED = 12 / 20k / 40k) can move: mask 12 -> 10.
+  const def = nextTuneStep({});
+  assert.equal(def.param, "maskAfterUses");
+  assert.equal(def.from, DEFAULT_TUNED.maskAfterUses);
+  assert.equal(def.to, 10);
+});
+
+test("countRefetchChurn: counts a re-run whose earlier output was masked, ignores the rest", () => {
+  // Chronological fixture. Entry 2 masks a read_file output; entry 3 re-runs
+  // the SAME (session, tool, input) after the mask -> churn. Entries 4-6 are
+  // different session / different tool / different input / never masked -> no
+  // churn.
+  const rows = [
+    { sessionID: "a", tool: "read_file", input: { path: "x" }, output: "real v1" },
+    { sessionID: "a", tool: "read_file", input: { path: "x" }, output: "[manta: trimmed - re-run read_file with {\"path\":\"x\"}]" },
+    { sessionID: "a", tool: "read_file", input: { path: "x" }, output: "real v2" }, // churn
+    { sessionID: "b", tool: "read_file", input: { path: "x" }, output: "real" }, // diff session
+    { sessionID: "a", tool: "ls", input: { dir: "y" }, output: "real" }, // diff tool, never masked
+    { sessionID: "a", tool: "read_file", input: { path: "z" }, output: "real" }, // diff input
+  ];
+  const res = countRefetchChurn(rows);
+  assert.equal(res.count, 1);
+  assert.equal(res.masked, 1);
+  assert.equal(res.ratio, 1);
+});
+
+test("countRefetchChurn: an un-masked re-run is NOT churn, empty/failed input -> zero", () => {
+  // A real tool re-uses its own output across time but was never masked -> no
+  // churn.
+  const rows = [
+    { sessionID: "a", tool: "grep", input: { q: "x" }, output: "out1" },
+    { sessionID: "a", tool: "grep", input: { q: "x" }, output: "out2" },
+  ];
+  assert.deepEqual(countRefetchChurn(rows), { count: 0, masked: 0, ratio: 0 });
+  assert.deepEqual(countRefetchChurn(null), { count: 0, masked: 0, ratio: 0 });
+  assert.deepEqual(countRefetchChurn("nope"), { count: 0, masked: 0, ratio: 0 });
+});
+
+test("tuner: disabled -> no policy write, no activity, no-op", async () => {
+  const h = makeTuner({ enabled: false, policy: { maskAfterUses: 20 } });
+  const res = await h.tuner.tune({
+    sessionCount: 200,
+    guardrail: { tripped: true, which: "churn" },
+    ecoChanged: true,
+  });
+  assert.equal(res.action, "no-op");
+  assert.equal(h.policyWrites(), 0);
+  assert.equal(h.activity().length, 0);
+});
+
+test("tuner: a positive trigger applies one step and writes the policy once", async () => {
+  const h = makeTuner({ directory: "/repo", policy: { maskAfterUses: 20, batchTokens: 40_000, protectTailTokens: 60_000 } });
+  const res = await h.tuner.tune({ sessionCount: 120, newSessions: TUNE_MIN_NEW_SESSIONS });
+  assert.equal(res.action, "applied");
+  assert.equal(res.param, "maskAfterUses");
+  assert.equal(res.to, 16);
+  assert.equal(h.policyWrites(), 1);
+  assert.equal(h.getTable().repos["/repo"].maskAfterUses, 16);
+  // No activity entry yet — it settles when kept/reverted.
+  assert.equal(h.activity().length, 0);
+});
+
+test("tuner: each guardrail trips and reverts, naming itself, restoring the old value", async () => {
+  for (const which of ["cache-hit", "churn", "cost-per-turn"]) {
+    const h = makeTuner({ directory: "/repo", policy: { maskAfterUses: 20, batchTokens: 40_000, protectTailTokens: 60_000 } });
+    await h.tuner.tune({ sessionCount: 120 }); // apply maskAfterUses 20 -> 16
+    assert.equal(h.getTable().repos["/repo"].maskAfterUses, 16);
+    // Guardrail trips during the observation window.
+    const res = await h.tuner.tune({
+      guardrail: { tripped: true, which, evidence: { [which === "cache-hit" ? "hitDropPts" : which === "churn" ? "churn" : "wow"]: 0.5 } },
+    });
+    assert.equal(res.action, "reverted");
+    assert.equal(res.guardrail, which);
+    // Old value restored (writes: 1 apply + 1 restore = 2).
+    assert.equal(h.getTable().repos["/repo"].maskAfterUses, 20);
+    assert.equal(h.policyWrites(), 2);
+    const entry = h.activity()[0];
+    assert.equal(entry.verdict, "rolled-back");
+    assert.equal(entry.evidence.guardrail, which);
+    assert.equal(entry.from, 20);
+    assert.equal(entry.to, 20);
+  }
+});
+
+test("tuner: a kept change writes the policy file exactly once (apply), value stays, activity records kept", async () => {
+  const h = makeTuner({ directory: "/repo", policy: { maskAfterUses: 20, batchTokens: 40_000, protectTailTokens: 60_000 } });
+  await h.tuner.tune({ sessionCount: 120 }); // apply: maskAfterUses 20 -> 16 (write #1)
+  assert.equal(h.policyWrites(), 1);
+  // Advance past the observation window with no guardrail trip.
+  h.advance(TUNE_OBSERVE_MS + 1000);
+  const res = await h.tuner.tune({ sessionCount: 121 });
+  assert.equal(res.action, "kept");
+  // Kept does NOT rewrite policy — still the applied value, still 1 write.
+  assert.equal(h.policyWrites(), 1);
+  assert.equal(h.getTable().repos["/repo"].maskAfterUses, 16);
+  const entry = h.activity()[0];
+  assert.equal(entry.verdict, "kept");
+  assert.equal(entry.from, 20);
+  assert.equal(entry.to, 16);
+});
+
+test("tuner: no trigger -> no tune; backstop sweep with no trigger also no-op", async () => {
+  const h = makeTuner({ directory: "/repo", policy: { maskAfterUses: 20 } });
+  const res = await h.tuner.tune({ sessionCount: 5 }); // only 5 new sessions, no trigger
+  assert.equal(res.action, "no-tune");
+  assert.equal(h.policyWrites(), 0);
+});
+
+test("tuner: snapshot reflects pending + last counters", async () => {
+  const h = makeTuner({ directory: "/repo", policy: { maskAfterUses: 20 } });
+  await h.tuner.tune({ sessionCount: 120 });
+  const snap = await h.tuner.snapshot();
+  assert.equal(snap.pending.param, "maskAfterUses");
+  assert.equal(snap.lastSessionCount, 120);
+});

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -53,6 +53,7 @@ import { searchMessages } from "./messageSearch.mjs";
 import { ledgerSummary } from "./modelLedger.mjs";
 import { getDb } from "./opencodeDb.mjs";
 import { createOptimizerSummary } from "./optimizer/summary.mjs";
+import { shipCtxEvent } from "./optimizer/telemetry.mjs";
 import { allModels as catalogAllModels } from "./modelCatalog.mjs";
 import { MIN_CLIENT } from "./version.mjs";
 import { forgeDiffForCwd, forgeStatus, pullRequestForCwd, shipPullRequest, shipPreview, mergePullRequest, draftGetForCwd, draftCommentForCwd, draftSubmitForCwd, replyThreadForCwd, forgeInbox, forgeDeviceStart, forgeDevicePoll, forgeDeviceCancel, forgeListRepos, forgeCloneStart, forgeCloneStatus, forgeCloneCancel } from "./forge/index.mjs";
@@ -1056,6 +1057,33 @@ export function buildHandlers({
         // pure formatter (BET-1301) prints the decision's inputs — the real
         // conversation size and what the turn needed — alongside its outputs.
         console.log(describeDecision(decision, { surface, agent }));
+        // Optimizer P2.5 (BET-1347): context telemetry for a routing decision
+        // under pressure — counts/knobs only (lambda, deficit, ecoLevel,
+        // switched), NEVER content. Emitted only when pressure is actually
+        // applied (an eco tier above 0, or the winner's provider carrying a
+        // shadow price), so the stream stays decision-shaped and quiet when
+        // nothing is constrained. `rewarmSkipped` is a RENDERER-side decision
+        // (shouldSwitch's rewarm hysteresis), not visible here — it is omitted
+        // rather than fabricated.
+        {
+          let winnerProvider = null;
+          if (decision?.model === catalogIncumbent) winnerProvider = incumbent?.providerID ?? null;
+          else winnerProvider = decision?.model?.providerID ?? null;
+          const pressure = winnerProvider ? effServices?.pressure?.[winnerProvider] : null;
+          const underPressure = (effServices?.ecoLevel ?? 0) > 0 || !!pressure;
+          if (underPressure) {
+            shipCtxEvent({
+              kind: "routing",
+              switched: decision?.changed === true ? 1 : 0,
+              lambda: pressure?.lambda ?? null,
+              deficit: pressure?.deficit ?? null,
+              ecoLevel: effServices?.ecoLevel ?? 0,
+              routing: winnerProvider ?? null,
+              surface,
+              agent,
+            });
+          }
+        }
         // On the off-path / no-survivors path chooseModel returns the very
         // catalogIncumbent reference it was handed; map that back to the
         // original structured incumbent so the decision stays byte-identical.

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1916,9 +1916,14 @@ export type OptimizerSummary = {
     provider: string;
     planLabel?: string;
     windowLabel: string;
+    kind?: string;
     pct: number;
     resetsAt: number | null;
     forecastPct: number | null;
+    // BET-1347: per-window pacing pressure for the chip under the gauge.
+    // `tokensPerPct` null → no pressure signal yet (neutral chip).
+    deficit: number | null;
+    tokensPerPct: number | null;
   }[];
   // BET-1347: the optimizer's trust surface — every parameter change it made
   // on its own, with the evidence used. Most recent first, capped at 50.
@@ -1935,6 +1940,17 @@ export type OptimizerSummary = {
       revertedAt?: number;
     }[];
   };
+  // BET-1347: the "X of Y in background" compaction stat, or null until the
+  // scheduler has attempted a compaction (never a fabricated zero).
+  compaction: { background: number; total: number } | null;
+  // BET-1347: metered (pay-per-token) endpoints — a slim role+price row with
+  // NO gauge (a metered endpoint has no window and never resets, so there is
+  // nothing to fill). [] → the section is absent.
+  metered: {
+    name: string;
+    role: string;
+    price: string;
+  }[];
 };
 
 // A secret's METADATA — what the UI and `secret_list` see. NEVER carries the

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2453,7 +2453,8 @@ export type StreamEnvelope = {
     | "subagent"
     | "context"
     | "cache"
-    | "autoRename";
+    | "autoRename"
+    | "optimizer.compacted";
   sessionId: string;
   payload: unknown;
 };

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1920,6 +1920,21 @@ export type OptimizerSummary = {
     resetsAt: number | null;
     forecastPct: number | null;
   }[];
+  // BET-1347: the optimizer's trust surface — every parameter change it made
+  // on its own, with the evidence used. Most recent first, capped at 50.
+  activity: {
+    entries: {
+      id: string;
+      ts: number;
+      kind: "tune" | "eco" | "compaction" | "guardrail";
+      subject: string;
+      from?: string | number;
+      to?: string | number;
+      verdict: "kept" | "rolled-back" | "applied";
+      evidence: Record<string, string | number>;
+      revertedAt?: number;
+    }[];
+  };
 };
 
 // A secret's METADATA — what the UI and `secret_list` see. NEVER carries the

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-22T17:17:23.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-22T16:04:35.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T17:17:23.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:04:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## Optimizer P2.5 (BET-1347) — activity log, tuner + guardrails, telemetry, dashboard + in-conversation UI

Makes the optimizer legible: the activity log that is the trust surface, the tuner that earns its parameter changes and reverts them, the count-only telemetry behind the guardrails, and the dashboard UI implemented against `docs/optimizer/mockup.html`.

**Base: `origin/main` @ `83ca0e7e`**

### What shipped
- **Activity log** (`src/server/optimizer/activityLog.mjs`) — validated store, mutex-serialized, retention 200 / 90d, `markReverted`, exposed on the `optimizer:summary` `activity` slice (capped 50). Counts only.
- **Tuner** (`src/server/optimizer/tuner.mjs`) — event-driven conservative bandit: one parameter / one ladder rung at a time; guardrail trip → instant revert + `rolled-back` entry naming which; the ONLY writer of `optimizer-policy.json`; never runs with the switch off. `countRefetchChurn` defined exactly and unit-tested.
- **Telemetry** (`src/server/optimizer/telemetry.mjs`) — `setTelemetrySink` + `shipCtxEvent` (silent no-op without a sink); the shipper is hoisted to a single reference in `src/server/index.mjs`; emitted at mask / routing-under-pressure / compaction / tune. Grep gate asserts no content field name is ever shipped.
- **Monitors** — `docs/optimizer/monitors.md` documents the three guardrail APL queries + maintainer steps (not created — zero monitors today, per spec).
- **UI** (`OptimizerCard.tsx` + `chatUtils.ts` + `index.css`) — switch card status sub-rows, pressure chips (neutral on no signal — never a fabricated pace), metered-endpoints slim row with NO gauge, activity feed with empty state + distinct rolled-back rows, "X of Y in background" stat. Pure formatters (`describePressure`, `describeActivityEntry`, `formatCompactionSaving`) vitest-tested.
- **In-conversation**: `↓ N% this conversation` saving pill next to the usage dial; `· eco` suffix on the Auto chip while pacing (BET-1345's label source becomes the chip).

### Follow-ups filed
- Parked `follow-up`: in-conversation compaction one-liner — blocked on the scheduler recording post-compaction token count + away-at-compaction-time presence (BET-1346 records neither), so "while you were away · before → after" can't be rendered truthfully yet.

### Notes for the reviewer
- `rewarmSkipped` is NOT shipped on routing telemetry: it's a **renderer-side** decision (shouldSwitch's rewarm hysteresis). Not fabricated; noted in a code comment.
- `grep -c "createLogShipper" src/server/index.mjs` is 2 (1 import + 1 construction) — unchanged construction count; the shutter instance is reused, not added.
- Tu·The tuner is wired with a backstop sweep poller + event/revert path; guardrail measurement is fail-open (no trip without evidence).

**Verification results:**
- PR branch (`multica/BET-1347-optimizer-legibility` @ `5e5b2563`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0. vitest 195 files/3714 pass/7 skip; server 2866 pass / 0 fail. log sha256: `e86d80de0d8c8b43733780825e3f1e9f805b5a9e6f926d738636b937a5eb9993`
- Base: rebased onto `origin/main` @ `83ca0e7e` (only an unrelated iOS PR #1348 ahead of the branch point) — no new failures.
- **Conclusion:** 0 new failures; all green.
