### PR TITLE
feat(ios): TTL-bounded age chip + All/Recent filter chips (BET-1349)

### DIFF
--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -77,6 +77,10 @@ final class SessionListStore: ObservableObject {
     /// and that must leave the list fully visible with no counts (a missing job
     /// list is missing decoration, never missing sessions).
     @Published private(set) var delegateJobs: [String: DelegateJob] = [:]
+    /// The box's prompt-cache TTL in milliseconds (`"5m"` → 300_000, `"1h"` →
+    /// 3_600_000, anything else/absent → 300_000). Drives the age chip cutoff
+    /// and the Recent filter (BET-1349).
+    @Published private(set) var cacheTtlMs: Double = SessionCacheTtl.defaultMs
 
     private let api: MantaAPIClient
     private let mutations: SessionListMutationAPI
@@ -100,6 +104,12 @@ final class SessionListStore: ObservableObject {
     /// the foreground/reconnect refresh that raced the launch fetch simply
     /// vanished and the list stayed on whatever the first one returned.
     private var refreshQueued = false
+    /// The set of opencode session ids seen running on the last `$sessionStates`
+    /// tick (BET-1349). Diffed against the current tick so a turn ENDING —
+    /// running→idle — triggers a refresh that re-fetches the authoritative
+    /// `time.updated` for the age chip at the exact moment it becomes eligible.
+    private var previouslyRunning: Set<String> = []
+    private var cancellables: Set<AnyCancellable> = []
 
     init(api: MantaAPIClient = MantaAPIClient.live(), eventStore: MantaEventStore, mutations: SessionListMutationAPI? = nil) {
         self.api = api
@@ -109,6 +119,30 @@ final class SessionListStore: ObservableObject {
         self.eventStore.addRawFrameHandler { [weak self] frame in
             self?.trackProgress(frame: frame)
         }
+        // A turn completing is the moment the age chip becomes eligible
+        // (`!running`), and it is precisely when the cached `lastActivity` is
+        // stale. This sink diffs only a small running-id set — it never calls
+        // `objectWillChange.send()` and never mutates published state, so the
+        // hot per-frame `$sessionStates` stream cannot re-render the whole list.
+        self.eventStore.$sessionStates
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] states in
+                self?.trackRunningTransitions(states)
+            }
+            .store(in: &cancellables)
+    }
+
+    /// The set diff that notices a turn just ended (BET-1349). A running→idle
+    /// edge triggers a coalescing `refresh()` so the list re-fetches the box's
+    /// authoritative `time.updated` rather than stamping the device clock
+    /// (mirrors the "NEVER fabricate the local clock" rule at
+    /// `MantaEventStore.swift:260-272`).
+    private func trackRunningTransitions(_ states: [String: MantaSessionStreamState]) {
+        let runningNow = Set(states.filter { $0.value.running == true }.map(\.key))
+        let stopped = previouslyRunning.subtracting(runningNow)
+        previouslyRunning = runningNow
+        guard !stopped.isEmpty else { return }
+        Task { await refresh() }
     }
 
     /// When this window's running turn started, as reported by the box.
@@ -435,6 +469,11 @@ final class SessionListStore: ObservableObject {
             if case .bool(let h)? = config["hapticsEnabled"] {
                 hapticsEnabled = h
             }
+            if case .string(let ttl)? = config["cacheTtl"] {
+                cacheTtlMs = SessionCacheTtl.ms(for: ttl)
+            } else {
+                cacheTtlMs = SessionCacheTtl.ms(for: nil)
+            }
         }
     }
 
@@ -466,5 +505,6 @@ final class SessionListStore: ObservableObject {
         hiddenByProject = [:]
         pinnedWindows = []
         hapticsEnabled = true
+        previouslyRunning = []
     }
 }

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -64,6 +64,9 @@ struct SessionListView: View {
     /// is computed from `now` in the body; without a tick nothing re-renders it
     /// after the initial layout, so ages froze at whatever they showed on load.
     @State private var now = Date()
+    /// The All / Recent filter (BET-1349). Not persisted — resets to All on
+    /// launch.
+    @State private var filter: SessionFilter = .all
 
     var body: some View {
         NavigationStack(path: $path) {
@@ -118,7 +121,7 @@ struct SessionListView: View {
                 }
             }
             .refreshable { await store.refresh() }
-            .safeAreaInset(edge: .bottom) { searchBar }
+            .safeAreaInset(edge: .bottom) { filterAndSearchBar }
             .overlay(alignment: .top) { errorBanner }
             .navigationDestination(for: SessionOpenTarget.self) { target in
                 if let sessionId = target.sessionId, !sessionId.isEmpty {
@@ -274,12 +277,20 @@ struct SessionListView: View {
     }
 
     private var filteredProjects: [MantaProject] {
-        guard !searchText.isEmpty else { return sorted(store.projects) }
+        let searched = searchFiltered(store.projects)
+        let recencyFiltered = applyRecencyFilter(searched)
+        return sorted(recencyFiltered)
+    }
+
+    /// The name search — a project-name match keeps the whole group; matching
+    /// window names only means typing the name of the project you were looking
+    /// at would empty the screen. BET-1349 runs the recency filter AFTER this,
+    /// and still applies it inside a name-matched group (a project match is
+    /// about names, not liveness).
+    private func searchFiltered(_ projects: [MantaProject]) -> [MantaProject] {
+        guard !searchText.isEmpty else { return projects }
         let q = searchText.lowercased()
-        let matched = store.projects.compactMap { p -> MantaProject? in
-            // A project-name match keeps the whole group. Matching window names
-            // only meant typing the name of the project you were looking at
-            // emptied the screen.
+        return projects.compactMap { p -> MantaProject? in
             if p.tmuxSession.lowercased().contains(q) { return p }
             let kept = p.windows.filter { $0.name.lowercased().contains(q) }
             guard !kept.isEmpty else { return nil }
@@ -287,7 +298,22 @@ struct SessionListView: View {
             copy.windows = kept
             return copy
         }
-        return sorted(matched)
+    }
+
+    /// The Recent filter (BET-1349): drop windows that fail the recency
+    /// predicate, and drop a project entirely when it has no surviving windows.
+    /// `.all` is an exact no-op on the input.
+    private func applyRecencyFilter(_ projects: [MantaProject]) -> [MantaProject] {
+        guard filter == .recent else { return projects }
+        return projects.compactMap { p -> MantaProject? in
+            let kept = p.windows.filter {
+                SessionRecency.isRecent(store.rowStatus(for: $0), now: now, ttlMs: store.cacheTtlMs)
+            }
+            guard !kept.isEmpty else { return nil }
+            var copy = p
+            copy.windows = kept
+            return copy
+        }
     }
 
     /// Pinned windows to the top of their project — the ONE place a project's
@@ -397,7 +423,7 @@ struct SessionListView: View {
     }
 
     private func ageText(_ window: MantaWindow, now: Date) -> String? {
-        SessionRowAge.text(for: store.rowStatus(for: window), now: now)
+        SessionRowAge.text(for: store.rowStatus(for: window), now: now, ttlMs: store.cacheTtlMs)
     }
 
     private func subtitle(for window: MantaWindow) -> String {
@@ -560,6 +586,32 @@ struct SessionListView: View {
     // That button now lives in the navigation bar, so the container has a
     // single child and is deleted with it: a container whose whole job is to
     // relate two glass shapes is noise once there is only one.
+    //
+    // The All/Recent filter row (BET-1349) sits DIRECTLY above the search
+    // field inside the same bottom safe-area inset, sharing its horizontal
+    // padding — one thumb-reachable control cluster with no new surface.
+    private var filterAndSearchBar: some View {
+        VStack(spacing: Metrics.spacing.sp2) {
+            filterRow
+            searchBar
+        }
+    }
+
+    private var filterRow: some View {
+        HStack(spacing: Metrics.spacing.sp2) {
+            ModelChip(title: "All", selected: filter == .all, tokens: tokens,
+                      accessibilityIdentifier: "session-filter-all") {
+                filter = .all
+            }
+            ModelChip(title: "Recent", selected: filter == .recent, tokens: tokens,
+                      accessibilityIdentifier: "session-filter-recent") {
+                filter = .recent
+            }
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, Metrics.spacing.sp3)
+    }
+
     private var searchBar: some View {
         HStack(spacing: Metrics.spacing.sp2) {
             Image(systemName: "magnifyingglass")

--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -243,12 +243,50 @@ enum SessionRowSubtitle {
     }
 }
 
+/// The single definition of "recent" (BET-1349) — the age chip and the Recent
+/// filter both read it, so they can never disagree. A row is RECENT when it is
+/// mid-turn, or its last activity is inside the prompt-cache TTL.
+enum SessionRecency {
+    static func isRecent(_ s: SessionRowStatus, now: Date, ttlMs: Double) -> Bool {
+        if s.running { return true }
+        if s.attention { return true }
+        guard let last = s.lastActivity else { return false }
+        return now.timeIntervalSince(last) * 1000 < ttlMs
+    }
+}
+
+/// The All / Recent filter row (BET-1349). Not persisted — resets to `.all` on
+/// launch.
+enum SessionFilter: String {
+    case all
+    case recent
+}
+
+/// Maps the box's `cacheTtl` config string to milliseconds, mirroring the
+/// desktop `selectCacheTtlMs` (src/renderer/chatUtils.ts). Values are `"5m"`
+/// and `"1h"`; anything else — or absent — means `"5m"`.
+enum SessionCacheTtl {
+    static let defaultMs: Double = 300_000
+    static let oneHourMs: Double = 3_600_000
+
+    static func ms(for configValue: String?) -> Double {
+        switch configValue {
+        case "1h": return oneHourMs
+        default: return defaultMs // "5m", anything else, or absent
+        }
+    }
+}
+
 /// The row's trailing age slot (BET-1084): a pure gate mirroring the desktop
 /// sidebar's `useAge` (src/renderer/Sidebar.tsx) — running / attention rows and
-/// unknown-activity rows show no age; their dot is the signal.
+/// unknown-activity rows show no age; their dot is the signal. Past the
+/// prompt-cache TTL the chip also disappears (BET-1349) — there is no hover on
+/// a phone to hide a stale age behind.
 enum SessionRowAge {
-    static func text(for s: SessionRowStatus, now: Date) -> String? {
+    static func text(for s: SessionRowStatus, now: Date, ttlMs: Double) -> String? {
         guard !s.running, !s.attention, let last = s.lastActivity else { return nil }
+        let elapsedMs = now.timeIntervalSince(last) * 1000
+        guard elapsedMs < ttlMs else { return nil }
         return SessionTimerFormat.age(now.timeIntervalSince(last))
     }
 }

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -179,23 +179,86 @@ final class SessionModelsTests: XCTestCase {
     }
 
     func testSessionRowAgeGate() {
+        let ttl = 100_000_000.0 // effectively unbounded — TTL-specific cases live in testSessionRowAgeTTL
         let activity = now.addingTimeInterval(-3600)
         // Running rows show no age even with activity known (the dot is the signal).
         let running = SessionRowStatus(running: true, attention: false, backgroundJobs: 0,
                                        modelLabel: nil, lastActivity: activity)
-        XCTAssertNil(SessionRowAge.text(for: running, now: now))
+        XCTAssertNil(SessionRowAge.text(for: running, now: now, ttlMs: ttl))
         // Attention rows likewise.
         let attention = SessionRowStatus(running: false, attention: true, backgroundJobs: 0,
                                          modelLabel: nil, lastActivity: activity)
-        XCTAssertNil(SessionRowAge.text(for: attention, now: now))
+        XCTAssertNil(SessionRowAge.text(for: attention, now: now, ttlMs: ttl))
         // No known activity → no age.
         let none = SessionRowStatus(running: false, attention: false, backgroundJobs: 0,
                                     modelLabel: nil, lastActivity: nil)
-        XCTAssertNil(SessionRowAge.text(for: none, now: now))
+        XCTAssertNil(SessionRowAge.text(for: none, now: now, ttlMs: ttl))
         // A plain idle row with activity → the formatted age.
         let idle = SessionRowStatus(running: false, attention: false, backgroundJobs: 0,
                                     modelLabel: "opus 4.8", lastActivity: activity)
-        XCTAssertEqual(SessionRowAge.text(for: idle, now: now), "1h")
+        XCTAssertEqual(SessionRowAge.text(for: idle, now: now, ttlMs: ttl), "1h")
+    }
+
+    // MARK: - BET-1349 recency (TTL-bounded age chip + All/Recent filter)
+
+    private func recencyStatus(running: Bool = false, attention: Bool = false, lastActivity: Date? = nil) -> SessionRowStatus {
+        SessionRowStatus(running: running, attention: attention, backgroundJobs: 0,
+                         modelLabel: nil, lastActivity: lastActivity)
+    }
+
+    func testRecencyRunningAlwaysRecent() {
+        // A very old lastActivity must not matter — the dot is the signal.
+        let s = recencyStatus(running: true, lastActivity: now.addingTimeInterval(-86_400))
+        XCTAssertTrue(SessionRecency.isRecent(s, now: now, ttlMs: 300_000))
+    }
+
+    func testRecencyAttentionAlwaysRecent() {
+        let s = recencyStatus(attention: true, lastActivity: now.addingTimeInterval(-86_400))
+        XCTAssertTrue(SessionRecency.isRecent(s, now: now, ttlMs: 300_000))
+    }
+
+    func testRecencyNilActivityNotRecent() {
+        XCTAssertFalse(SessionRecency.isRecent(recencyStatus(), now: now, ttlMs: 300_000))
+    }
+
+    func testRecencyInsideTTL() {
+        let s = recencyStatus(lastActivity: now.addingTimeInterval(-60))
+        XCTAssertTrue(SessionRecency.isRecent(s, now: now, ttlMs: 300_000))
+    }
+
+    func testRecencyExactlyAtTTLNotRecent() {
+        // 300 s inside a 300_000 ms TTL is the boundary — not recent.
+        let s = recencyStatus(lastActivity: now.addingTimeInterval(-300))
+        XCTAssertFalse(SessionRecency.isRecent(s, now: now, ttlMs: 300_000))
+    }
+
+    func testRecencyPastTTLNotRecent() {
+        let s = recencyStatus(lastActivity: now.addingTimeInterval(-3600))
+        XCTAssertFalse(SessionRecency.isRecent(s, now: now, ttlMs: 300_000))
+    }
+
+    func testCacheTtlMapping() {
+        XCTAssertEqual(SessionCacheTtl.ms(for: "5m"), 300_000)
+        XCTAssertEqual(SessionCacheTtl.ms(for: "1h"), 3_600_000)
+        XCTAssertEqual(SessionCacheTtl.ms(for: "garbage"), 300_000)
+        XCTAssertEqual(SessionCacheTtl.ms(for: nil), 300_000)
+    }
+
+    func testSessionRowAgeTTL() {
+        let ttl = 3_600_000.0 // 1h
+        // Inside the TTL → a formatted value.
+        let inside = recencyStatus(lastActivity: now.addingTimeInterval(-60))
+        XCTAssertEqual(SessionRowAge.text(for: inside, now: now, ttlMs: ttl), "1m")
+        // Exactly at the TTL → nil.
+        let at = recencyStatus(lastActivity: now.addingTimeInterval(-3600))
+        XCTAssertNil(SessionRowAge.text(for: at, now: now, ttlMs: ttl))
+        // Past the TTL → nil.
+        let past = recencyStatus(lastActivity: now.addingTimeInterval(-7200))
+        XCTAssertNil(SessionRowAge.text(for: past, now: now, ttlMs: ttl))
+        // Running / attention / nil-activity still nil regardless of TTL.
+        XCTAssertNil(SessionRowAge.text(for: recencyStatus(running: true, lastActivity: now), now: now, ttlMs: ttl))
+        XCTAssertNil(SessionRowAge.text(for: recencyStatus(attention: true, lastActivity: now), now: now, ttlMs: ttl))
+        XCTAssertNil(SessionRowAge.text(for: recencyStatus(), now: now, ttlMs: ttl))
     }
 
     // MARK: - BET-897 idle subtitle (model only)


### PR DESCRIPTION
## BET-1349 — iOS session list: TTL-bounded age chip + All/Recent filter chips

One pure recency predicate now drives BOTH the age chip and the new Recent
filter, so they can never disagree.

### What changed
- **`SessionRecency.isRecent`** — the single definition of "recent": running →
  true, attention → true, nil lastActivity → false, else last activity inside
  the prompt-cache TTL.
- **`SessionRowAge.text`** gains a `ttlMs` param and returns `nil` past the TTL
  (full TTL, not desktop's 90% — no hover on a phone). Row layout unchanged;
  past the TTL the row just shows the chevron like any ageless row.
- **`SessionCacheTtl.ms`** — pure mapping `"5m"`→300_000, `"1h"`→3_600_000,
  unknown/absent→300_000, mirroring desktop `selectCacheTtlMs`.
- **`SessionListStore`** publishes `cacheTtlMs` (read in `loadConfig`) and adds
  a Combine sink on `$sessionStates` that diffs a small running-id set and
  triggers a coalescing `refresh()` on the running→idle edge — so `lastActivity`
  comes from the box's authoritative `time.updated` at the exact moment the age
  chip becomes eligible. The sink never calls `objectWillChange`/mutates
  published state; `previouslyRunning` cleared in `resetForBoxChange()`.
- **`SessionListView`** — an All/Recent `ModelChip` row (reused as-is, no new
  chip type, no new colour/size/spacing tokens) inside the existing bottom
  `safeAreaInset`, directly above the search field, sharing its horizontal
  padding. Filter composes in `filteredProjects` after search, before
  `sorted(_:)`; `.all` is an exact no-op. Empty result reuses `noMatchState`.
  Accessibility ids `session-filter-all` / `session-filter-recent`.

### Verification
- `npm run typecheck`: exit 0 (identical on PR and base — the diff is Swift-only,
  which the JS gates don't compile).
- `npm test`: 2844 pass / 0 fail on both branches.
- **Swift verification is NOT possible on this Linux box** (no Swift toolchain,
  per `mobile/native/AGENTS.md`). It is delegated to `macos`: run the
  `ios-mantaui` plugin `action: "test-unit"` (MantaUITests merge gate) then
  `action: "simulator"` to describe the filter row and confirm Recent hides idle
  sessions. Real output to be pasted, never reported by assumption.

Base: origin/main @ 83ca0e7e
