### PR TITLE
feat(ios): make transcript text selectable via MarkdownText renderer (BET-1352)

### DIFF
--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -27,6 +27,7 @@ struct UserBand: View {
 
     var body: some View {
         Text(text)
+            .textSelection(.enabled)
             .font(.manta(size: Metrics.type.body, weight: mantaFontWeight(Metrics.type.medium)))
             .foregroundColor(tokens.tx1)
             .lineSpacing(pointsFor(multiplier: 1.5, size: MantaDynamicType.scaled(Metrics.type.body)))
@@ -69,7 +70,7 @@ struct MantaProse: View {
     let tokens: Tokens
 
     var body: some View {
-        MarkdownView(text)
+        MarkdownText(text)
             .font(.manta(size: Metrics.type.body), for: .body)
             .font(.manta(size: Metrics.type.body + 4, weight: .semibold), for: .h1)
             .font(.manta(size: Metrics.type.body + 2, weight: .semibold), for: .h2)
@@ -122,6 +123,7 @@ struct LiveProseTail: View {
 
     var body: some View {
         Text(text)
+            .textSelection(.enabled)
             .font(.system(size: Metrics.type.body))
             .foregroundColor(tokens.tx1)
             .lineSpacing(pointsFor(multiplier: Metrics.type.proseLineHeight, size: Metrics.type.body))
@@ -409,6 +411,7 @@ struct StepRowView: View {
 
             if expanded, let output = step.output {
                 Text(ToolOutputPreview.tail(output))
+                    .textSelection(.enabled)
                     .font(.manta(size: Metrics.type.xs, design: .monospaced))
                     .foregroundColor(tokens.tx3)
                     .fixedSize(horizontal: false, vertical: true)


### PR DESCRIPTION
Opened automatically for `multica/BET-1352-ios-transcript-selection`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1352.