### PR TITLE
iOS session list: terminal windows show poller running status (BET-1350)

### DIFF
--- a/mobile/native/MantaUI/SessionListStore.swift
+++ b/mobile/native/MantaUI/SessionListStore.swift
@@ -109,6 +109,13 @@ final class SessionListStore: ObservableObject {
     /// running→idle — triggers a refresh that re-fetches the authoritative
     /// `time.updated` for the age chip at the exact moment it becomes eligible.
     private var previouslyRunning: Set<String> = []
+    /// `tmuxSession#windowIndex` -> live tmux-poller status for TERMINAL
+    /// windows (BET-1350). Chat-mode windows are NOT in here: their status
+    /// comes from the interpreted stream, and the box's pane scrape cannot see
+    /// them anyway (a chat window's pane runs `sleep infinity`, so
+    /// capture-pane returns blank). Read by `rowStatus` for terminal windows
+    /// only; one source per window type, no merging.
+    private(set) var terminalStatus: [String: WindowPollStatus] = [:]
     private var cancellables: Set<AnyCancellable> = []
 
     init(api: MantaAPIClient = MantaAPIClient.live(), eventStore: MantaEventStore, mutations: SessionListMutationAPI? = nil) {
@@ -118,6 +125,7 @@ final class SessionListStore: ObservableObject {
         self.loadConfig()
         self.eventStore.addRawFrameHandler { [weak self] frame in
             self?.trackProgress(frame: frame)
+            self?.trackStatus(frame: frame)
         }
         // A turn completing is the moment the age chip becomes eligible
         // (`!running`), and it is precisely when the cached `lastActivity` is
@@ -287,10 +295,22 @@ final class SessionListStore: ObservableObject {
     /// presentation decided in SessionModels.
     func rowStatus(for window: MantaWindow) -> SessionRowStatus {
         let sid = window.opencodeSessionId ?? ""
+        let isTerminal = window.opencodeSessionId == nil
         let stream = eventStore.sessionStates[sid]
-        let running = stream?.running == true
+        var running = stream?.running == true
         let attention = !(stream?.questions?.questions.isEmpty ?? true)
             || !(stream?.permissions?.permissions.isEmpty ?? true)
+        if isTerminal,
+           let project = projects.first(where: { $0.windows.contains(window) }),
+           let polled = terminalStatus[Self.terminalKey(project: project.tmuxSession, windowIndex: window.index)] {
+            // A terminal window's running status comes ONLY from the box's
+            // tmux poller (BET-1350). The interpreted stream cannot see it (a
+            // terminal pane runs claude's TUI, not an opencode session), so the
+            // poller is this window type's single source — deliberately no
+            // fallback to the stream. Chat windows are untouched (the branch is
+            // terminal-only; one source per window type, no merging).
+            running = polled.running
+        }
         return SessionRowStatus(
             running: running,
             attention: attention,
@@ -298,7 +318,7 @@ final class SessionListStore: ObservableObject {
             modelLabel: sessionMeta[sid]?.modelLabel,
             progressLabel: progressBySession[sid],
             lastActivity: sessionMeta[sid]?.lastActivity,
-            isTerminal: window.opencodeSessionId == nil
+            isTerminal: isTerminal
         )
     }
 
@@ -333,6 +353,52 @@ final class SessionListStore: ObservableObject {
     private func workingProgressLabel(sessionID: String) async -> String? {
         guard let record = try? await api.progressGet(sessionID: sessionID) else { return nil }
         return record.workingLabel
+    }
+
+    // MARK: - Terminal-window status (BET-1350)
+
+    /// The `tmuxSession#windowIndex` composite key for terminal-window poller
+    /// status. REUSES the existing id shape — `SessionRowEntry.id` is the
+    /// `"\(project)#\(windowIndex)"` composite already used for a row's
+    /// `project#window` identity (`SessionListView.swift`); this is the SAME
+    /// composite, not a third id format. `SessionPinID.window` (a `/`
+    /// separator, pin identity) is a different shape and is deliberately not
+    /// used here.
+    static func terminalKey(project: String, windowIndex: Int) -> String {
+        "\(project)#\(windowIndex)"
+    }
+
+    /// The wire shape of one `kind: "status"` payload entry. The payload is a
+    /// JSON ARRAY of these (per `src/server/status.mjs`), e.g.
+    /// `[{"session":"proj","windowIndex":2,"running":true,"subagents":0}]`.
+    private struct TerminalStatusFrame: Decodable {
+        var session: String
+        var windowIndex: Int
+        var running: Bool
+        var subagents: Int
+    }
+
+    /// Consume `kind: "status"` frames (the box's 2s tmux activity poller,
+    /// `src/server/status.mjs`) for TERMINAL windows. Each batch REPLACES the
+    /// entries for the windows it names; a window absent from a batch keeps
+    /// its previous value (the batch is per-tick and complete for live
+    /// windows; a vanished window is cleaned up by the next `refresh()`
+    /// dropping the row). Publishes only on an actual change so a 2s tick
+    /// cannot re-render the whole list unconditionally (the guard that
+    /// `applyJobs` / `trackRunningTransitions` already follow).
+    private func trackStatus(frame: MantaStreamFrame) {
+        guard frame.kind == "status",
+              let entries = try? frame.decodedPayload([TerminalStatusFrame].self),
+              !entries.isEmpty else { return }
+        var next = terminalStatus
+        for e in entries {
+            next[Self.terminalKey(project: e.session, windowIndex: e.windowIndex)] =
+                WindowPollStatus(running: e.running, subagents: e.subagents)
+        }
+        if next != terminalStatus {
+            terminalStatus = next
+            objectWillChange.send()
+        }
     }
 
     // MARK: - Pin (§7.2 swipe-right)
@@ -506,5 +572,6 @@ final class SessionListStore: ObservableObject {
         pinnedWindows = []
         hapticsEnabled = true
         previouslyRunning = []
+        terminalStatus = [:]
     }
 }

--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -210,6 +210,16 @@ struct SessionRowStatus: Equatable, Sendable {
     var isTerminal: Bool = false
 }
 
+/// Per-window live status for a TERMINAL window, as reported by the box's
+/// tmux activity poller (`src/server/status.mjs`) on `kind: "status"` frames
+/// (BET-1350). Chat-mode windows never populate this — their status comes
+/// from the interpreted stream, and the pane scrape can't see them anyway
+/// (a chat window's pane runs `sleep infinity`, so capture-pane is blank).
+struct WindowPollStatus: Equatable, Sendable {
+    var running: Bool
+    var subagents: Int
+}
+
 enum SessionRowSubtitle {
     /// §7.1a subtitle table — precedence: background jobs, then the working
     /// progress label, then running, then blocked, then (idle) model. The

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -747,3 +747,110 @@ final class SessionListJobToleranceTests: XCTestCase {
         XCTAssertNil(store.loadError)
     }
 }
+
+// MARK: - BET-1350 terminal-window running status (tmux poller frames)
+
+@MainActor
+final class TerminalStatusTests: XCTestCase {
+
+    /// Minimal injectable stream so `kind: "status"` frames can be pushed
+    /// straight through the store's raw-frame path — no live socket (mirrors
+    /// the suite's other `MantaEventStreamControl` fakes).
+    @MainActor
+    private final class Stream: MantaEventStreamControl {
+        var onState: ((MantaConnectionState) -> Void)?
+        var onMessage: ((String) -> Void)?
+        var onReconnect: (() -> Void)?
+        var onConfigError: ((Error) -> Void)?
+        var hasConnectedOnce = false
+        var currentState: MantaConnectionState = .idle
+        func ensure() {}
+        func markReconnectAndEnsure() {}
+        func retryNow() {}
+        func forceReconnect() {}
+        func close(reason: String) {}
+        func inject(_ text: String) { onMessage?(text) }
+    }
+
+    private func makeStore() -> (store: SessionListStore, stream: Stream) {
+        let stream = Stream()
+        let eventStore = MantaEventStore(stream: stream, tokenProvider: { nil }, serverProvider: { nil })
+        let store = SessionListStore(
+            api: MantaAPIClient(serverURL: URL(string: "https://127.0.0.1:1")!),
+            eventStore: eventStore
+        )
+        return (store, stream)
+    }
+
+    private func project(_ session: String, _ window: MantaWindow) -> MantaProject {
+        MantaProject(tmuxSession: session, defaultCwd: "/tmp", windows: [window], attached: false, mantaOwned: nil)
+    }
+
+    private func terminalWindow(_ index: Int) -> MantaWindow {
+        MantaWindow(index: index, name: "dev", active: false, paneCurrentPath: "/x", opencodeSessionId: nil, worktreePath: nil)
+    }
+
+    private func chatWindow(_ index: Int, sid: String) -> MantaWindow {
+        MantaWindow(index: index, name: "chat", active: false, paneCurrentPath: "/x", opencodeSessionId: sid, worktreePath: nil)
+    }
+
+    private func statusFrame(session: String, windowIndex: Int, running: Bool) -> String {
+        #"{"kind":"status","payload":[{"session":"\#(session)","windowIndex":\#(windowIndex),"running":\#(running),"subagents":0}]}"#
+    }
+
+    func testStatusFrameDecodesToSingleEntryKeyedProjectHashWindow() {
+        let (store, stream) = makeStore()
+
+        stream.inject(#"{"kind":"status","payload":[{"session":"proj","windowIndex":2,"running":true,"subagents":0}]}"#)
+
+        XCTAssertEqual(store.terminalStatus.count, 1)
+        XCTAssertEqual(Set(store.terminalStatus.keys), ["proj#2"])
+        XCTAssertEqual(store.terminalStatus["proj#2"]?.running, true)
+        XCTAssertEqual(store.terminalStatus["proj#2"]?.subagents, 0)
+    }
+
+    func testTerminalRowWithRunningPollerEntryIsRunningWithRunningDotAndSubtitle() {
+        let (store, stream) = makeStore()
+        let w = terminalWindow(2)
+        store.applyProjects([project("proj", w)])
+
+        stream.inject(statusFrame(session: "proj", windowIndex: 2, running: true))
+
+        let status = store.rowStatus(for: w)
+        XCTAssertTrue(status.isTerminal)
+        XCTAssertTrue(status.running)
+        XCTAssertEqual(SessionDotState.forRow(status), .running)
+        // A running terminal row falls into the running subtitle branch and
+        // reads "running" (no model label, so not the "running · model" variant).
+        XCTAssertEqual(SessionRowSubtitle.text(for: status), "running")
+    }
+
+    func testChatWindowUnaffectedByPollerEntryNamingItsWindowIndex() {
+        let (store, stream) = makeStore()
+        let w = chatWindow(2, sid: "ses-1")
+        store.applyProjects([project("proj", w)])
+
+        // The poller names this chat window's index — it must be ignored; the
+        // window's status still comes from the stream (no entry → idle).
+        stream.inject(statusFrame(session: "proj", windowIndex: 2, running: true))
+
+        let status = store.rowStatus(for: w)
+        XCTAssertFalse(status.isTerminal)
+        XCTAssertFalse(status.running)
+        XCTAssertEqual(SessionDotState.forRow(status), .idle)
+    }
+
+    func testLaterBatchReportingWindowIdleFlipsTerminalRowBack() {
+        let (store, stream) = makeStore()
+        let w = terminalWindow(2)
+        store.applyProjects([project("proj", w)])
+
+        stream.inject(statusFrame(session: "proj", windowIndex: 2, running: true))
+        XCTAssertTrue(store.rowStatus(for: w).running)
+
+        stream.inject(statusFrame(session: "proj", windowIndex: 2, running: false))
+        let status = store.rowStatus(for: w)
+        XCTAssertFalse(status.running)
+        XCTAssertEqual(SessionDotState.forRow(status), .idle)
+    }
+}


### PR DESCRIPTION
Opened automatically for `multica/BET-1350-ios-terminal-status`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1350.