### PR TITLE
feat(optimizer): surface post-compaction afterTokens in the background-compaction one-liner (BET-1356)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1232,6 +1232,12 @@ const compactionScheduler = createCompactionScheduler({
   compact: async (sessionID) => {
     await extractAndStoreConstraints(sessionID);
     await oc.compactSession(sessionID);
+    // BET-1356: surface the post-compaction context so the one-liner can show
+    // "before → after". opencode's compact endpoint returns no token count, so
+    // we measure the retained history's size from the session messages
+    // post-compaction (null when unreadable → renderer uses the no-count
+    // wording).
+    return await oc.measureSessionContextTokens(sessionID);
   },
   isBusy: (sid) => promptDelivery.isBusy(sid),
   now: Date.now,
@@ -1240,7 +1246,9 @@ const compactionScheduler = createCompactionScheduler({
   // BET-1347: record each background compaction on the activity log — the
   // trust surface lists what the optimizer did, including compactions. Counts
   // only: context tokens, never conversation content.
-  onCompacted: async ({ sessionID, contextTokens }) => {
+  onCompacted: async ({ sessionID, contextTokens, afterTokens }) => {
+    const before = typeof contextTokens === "number" && Number.isFinite(contextTokens) ? contextTokens : undefined;
+    const after = typeof afterTokens === "number" && Number.isFinite(afterTokens) ? afterTokens : undefined;
     try {
       await optimizerActivity.append({
         kind: "compaction",
@@ -1248,7 +1256,8 @@ const compactionScheduler = createCompactionScheduler({
         verdict: "applied",
         evidence: {
           background: 1,
-          beforeTokens: typeof contextTokens === "number" && Number.isFinite(contextTokens) ? contextTokens : undefined,
+          beforeTokens: before,
+          afterTokens: after,
         },
       });
     } catch (e) {
@@ -1259,7 +1268,8 @@ const compactionScheduler = createCompactionScheduler({
     try {
       shipCtxEvent({
         kind: "compaction",
-        beforeTokens: typeof contextTokens === "number" && Number.isFinite(contextTokens) ? contextTokens : null,
+        beforeTokens: before ?? null,
+        afterTokens: after ?? null,
         background: 1,
       });
     } catch {
@@ -1269,18 +1279,21 @@ const compactionScheduler = createCompactionScheduler({
     // a pass-by transcript one-liner. Carried on the `stream` channel so the
     // renderer's scoped stream handler (useSseBus) routes it to the active
     // session. `away` is the box's presence verdict at compaction time
-    // (server-side, not guessed); beforeTokens is the pre-compaction context;
-    // afterTokens is not yet surfaced by the compaction call (null → the
-    // renderer falls back to the wording that needs no count).
+    // (server-side, not guessed) — the "while you were away" wording holds when
+    // presence was away OR gone (BET-1356), never for a present user. before/
+    // afterTokens are the context sizes when known (nulls → the renderer falls
+    // back to the wording that needs no count).
     try {
+      const presence = push.desktopState(push.getDesktopPresence(), Date.now());
+      const away = presence === "away" || presence === "gone";
       bus.publish({
         kind: "stream",
         sub: "optimizer.compacted",
         sessionId: sessionID,
         payload: {
-          beforeTokens: typeof contextTokens === "number" && Number.isFinite(contextTokens) ? contextTokens : null,
-          afterTokens: null,
-          away: push.desktopState(push.getDesktopPresence(), Date.now()) === "away",
+          beforeTokens: before ?? null,
+          afterTokens: after ?? null,
+          away,
         },
       });
     } catch (e) {

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -863,13 +863,16 @@ export async function compactSession(sessionId) {
  * Sums the characters of every text-bearing STRING value in the messages
  * (part text, tool inputs/outputs, etc.) and applies a 4 chars/token heuristic
  * — matching how opencode estimates context for its own compaction retention
- * (Token.estimate over the serialized messages). Numbers (token counts, ids,
- * timestamps) and structural keys are not content and are skipped, so the
- * compaction summary's large `tokens.input` never inflates the "after" figure.
- * Input-robust: any shape degrades to a sane number, never throws.
+ * (Token.estimate over the serialized messages). Structural keys (type/role/id/
+ * status/index/timestamps) are not content and are skipped, so they add no
+ * per-message noise, and the compaction summary's large `tokens.input` (a
+ * number) never inflates the "after" figure. Input-robust: any shape degrades
+ * to a sane number, never throws.
  * @param {unknown[]} [messages] opencode SessionV1.WithParts list
  * @returns {number} estimated context tokens (0 for empty/missing)
  */
+const NON_CONTENT_KEYS = new Set(["type", "role", "id", "status", "index"]);
+
 export function estimateMessageListTokens(messages) {
   if (!Array.isArray(messages)) return 0;
   const acc = { chars: 0 };
@@ -879,13 +882,22 @@ export function estimateMessageListTokens(messages) {
   return Math.ceil(acc.chars / 4);
 }
 
+function isNonContentKey(key) {
+  if (NON_CONTENT_KEYS.has(key)) return true;
+  const lower = String(key).toLowerCase();
+  return lower === "id" || lower.endsWith("id") || lower === "created" || lower === "completed" || lower === "started";
+}
+
 function collectTextChars(node, acc) {
   if (Array.isArray(node)) {
     for (const v of node) collectTextChars(v, acc);
     return;
   }
   if (node && typeof node === "object") {
-    for (const v of Object.values(node)) collectTextChars(v, acc);
+    for (const [key, v] of Object.entries(node)) {
+      if (isNonContentKey(key)) continue;
+      collectTextChars(v, acc);
+    }
     return;
   }
   if (typeof node === "string" && node.length > 0) {

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -848,6 +848,64 @@ export async function compactSession(sessionId) {
   }
 }
 
+// BET-1356: the background-compaction one-liner's "before → after" figure.
+// opencode's compact/summarize endpoint returns no token count (its success
+// body is just `true`), so the post-compaction context (`afterTokens`) has to
+// be measured from the retained history. `estimateMessageListTokens` is the
+// PURE estimate (chars of every text-bearing value ÷ 4, the same ~4
+// chars/token heuristic opencode's own compaction retention uses);
+// `measureSessionContextTokens` is the I/O wrapper that fetches the session's
+// messages post-compaction and hands them to it. Degrades to null so the
+// renderer falls back to the no-count wording rather than a wrong number.
+
+/**
+ * PURE. Estimate a session's context-token footprint from its message list.
+ * Sums the characters of every text-bearing STRING value in the messages
+ * (part text, tool inputs/outputs, etc.) and applies a 4 chars/token heuristic
+ * — matching how opencode estimates context for its own compaction retention
+ * (Token.estimate over the serialized messages). Numbers (token counts, ids,
+ * timestamps) and structural keys are not content and are skipped, so the
+ * compaction summary's large `tokens.input` never inflates the "after" figure.
+ * Input-robust: any shape degrades to a sane number, never throws.
+ * @param {unknown[]} [messages] opencode SessionV1.WithParts list
+ * @returns {number} estimated context tokens (0 for empty/missing)
+ */
+export function estimateMessageListTokens(messages) {
+  if (!Array.isArray(messages)) return 0;
+  const acc = { chars: 0 };
+  for (const m of messages) {
+    if (m && typeof m === "object") collectTextChars(m, acc);
+  }
+  return Math.ceil(acc.chars / 4);
+}
+
+function collectTextChars(node, acc) {
+  if (Array.isArray(node)) {
+    for (const v of node) collectTextChars(v, acc);
+    return;
+  }
+  if (node && typeof node === "object") {
+    for (const v of Object.values(node)) collectTextChars(v, acc);
+    return;
+  }
+  if (typeof node === "string" && node.length > 0) {
+    acc.chars += node.length;
+  }
+}
+
+/** I/O. Measure a session's current (post-compaction) context tokens, best
+ *  effort — returns null when the session can't be read so callers fall back
+ *  to the no-count wording. @param {string} sessionId @returns {Promise<number|null>}
+ */
+export async function measureSessionContextTokens(sessionId) {
+  try {
+    const messages = await listMessages(sessionId);
+    return estimateMessageListTokens(messages);
+  } catch {
+    return null;
+  }
+}
+
 /** Delete a session and its messages on the opencode server.
  *  Named deleteSessionRaw to distinguish from any local session cleanup.
  *  @param {string} sessionId

--- a/src/server/opencode.test.mjs
+++ b/src/server/opencode.test.mjs
@@ -39,6 +39,7 @@ import {
   getProviders,
   getDefaultModel,
   generateSessionTitle,
+  estimateMessageListTokens,
   listModels,
   listRoutableModels,
   _normalizeProviderModel,
@@ -2613,4 +2614,41 @@ test("completeProviderOauth includes code in the body when passed a real code (o
       assert.deepEqual(captured.body, { method: 1, code: "ABCD-1234" });
     },
   );
+});
+
+// BET-1356: post-compaction context estimate for the one-liner's "before →
+// after" figure. Pure over the message list; numbers/structural keys are not
+// content and never inflate the estimate.
+test("estimateMessageListTokens: 0 for empty/missing input", () => {
+  assert.equal(estimateMessageListTokens(undefined), 0);
+  assert.equal(estimateMessageListTokens(null), 0);
+  assert.equal(estimateMessageListTokens([]), 0);
+});
+
+test("estimateMessageListTokens: sums part text with ~4 chars/token", () => {
+  const messages = [
+    {
+      info: { role: "assistant", id: "m1", tokens: { input: 128_000, cache: { write: 0 } } },
+      parts: [
+        { type: "text", text: "this is a summary of the whole conversation" },
+        { type: "tool", state: { title: "Bash", output: "hello world one two" } },
+      ],
+    },
+    {
+      info: { role: "user", id: "m2" },
+      parts: [{ type: "text", text: "short user reply" }],
+    },
+  ];
+  // chars of all string values ÷ 4, ceil
+  const chars = "this is a summary of the whole conversation".length
+    + "Bash".length
+    + "hello world one two".length
+    + "short user reply".length;
+  assert.equal(estimateMessageListTokens(messages), Math.ceil(chars / 4));
+  // Asserts the big numeric token count does NOT inflate the estimate.
+  assert.ok(estimateMessageListTokens(messages) < 128_000);
+});
+
+test("estimateMessageListTokens: a single empty text message yields 0 not a tiny-to-inflate artifact", () => {
+  assert.equal(estimateMessageListTokens([{ info: { role: "user" }, parts: [{ type: "text", text: "" }] }]), 0);
 });

--- a/src/server/optimizer/compaction.mjs
+++ b/src/server/optimizer/compaction.mjs
@@ -117,6 +117,9 @@ function normalizeState(raw) {
  *     activity fallback) + the firehose-stamped lastActivityAt map, and the
  *     shared optimizer summary for the effective cache TTL.
  *   compact(sessionId) — async — the already-wired oc.compactSession call.
+ *     May return the post-compaction token count (`afterTokens`) so the
+ *     one-liner can show "before → after"; undefined/null is fine (→ no count).
+ *     BET-1356 wires the production `compact` to measure the retained history.
  *   isBusy(sessionId) — the shared promptDelivery busy gate (grep-verified:
  *     INJECTED here, never re-implemented).
  *   now — number or zero-arg fn (the clock).
@@ -125,9 +128,12 @@ function normalizeState(raw) {
  *     "optimizer-compaction.json"); injected so tests stub them.
  *   enabled — boolean or zero-arg fn; read per tick so flipping the switch
  *     takes effect without a restart.
- *   onCompacted — (info) => void (async ok): called after a compact succeeds
- *     with { sessionID, contextTokens, contextLimit }. BET-1347 wires this to
- *     append a `compaction` entry to the activity log (the trust surface).
+ *  onCompacted — (info) => void (async ok): called after a compact succeeds
+ *     with { sessionID, contextTokens, afterTokens, contextLimit }. BET-1347
+ *     wires this to append a `compaction` entry to the activity log (the trust
+ *     surface). BET-1356 adds `afterTokens`: the post-compaction context the
+ *     injected `compact` returned (null when unknown), so the one-liner can
+ *     show the before → after figure.
  *
  * The three guards, all required:
  *   1. an in-memory Set of sessionIds with a compaction in flight; a session
@@ -239,14 +245,22 @@ export function createCompactionScheduler({
         console.log(
           `[optimizer] precompact session=${c.sessionID} ctx=${pct}% idle=${Math.round(idleMs / 60_000)}m`,
         );
-        await compact(c.sessionID);
+        // BET-1356: capture the post-compaction context the injected `compact`
+        // returns (null/undefined when unknown) so onCompacted can surface the
+        // one-liner's "before → after" figure.
+        const afterTokens = await compact(c.sessionID);
         entry.lastResult = "ok";
         compacted.push(c.sessionID);
         tally.background++;
         console.log(`[optimizer] compacted session=${c.sessionID} ctx=${pct}% idle=${Math.round(idleMs / 60_000)}m`);
         if (typeof onCompacted === "function") {
           try {
-            await onCompacted({ sessionID: c.sessionID, contextTokens: c.contextTokens, contextLimit: c.contextLimit });
+            await onCompacted({
+              sessionID: c.sessionID,
+              contextTokens: c.contextTokens,
+              afterTokens: typeof afterTokens === "number" && Number.isFinite(afterTokens) && afterTokens > 0 ? afterTokens : null,
+              contextLimit: c.contextLimit,
+            });
           } catch (e) {
             console.warn("[optimizer] compact onCompacted failed:", e?.message ?? e);
           }

--- a/src/server/optimizer/compaction.test.mjs
+++ b/src/server/optimizer/compaction.test.mjs
@@ -204,3 +204,56 @@ test("scheduler: the in-flight set blocks a re-entrant tick", async () => {
   await Promise.all([t1, t2]);
   assert.deepEqual(calls, ["compact"], "the same in-flight session must not be compacted twice");
 });
+
+// BET-1356: the injected `compact` may return the post-compaction token count,
+// and the scheduler must flow it through to onCompacted (and pass null when it
+// returns nothing, so callers fall back to the no-count wording).
+test("scheduler: forwards compact's post-compaction token count to onCompacted", async () => {
+  let notified = null;
+  const scheduler = createCompactionScheduler({
+    listCandidates: async () => [candidate("s1")],
+    compact: async () => 31_000,
+    isBusy: () => false,
+    now: () => NOW,
+    load: async () => ({ sessions: {} }),
+    save: async () => {},
+    enabled: () => true,
+    onCompacted: async (info) => { notified = info; },
+  });
+  await scheduler.tick();
+  assert.equal(notified.sessionID, "s1");
+  assert.equal(notified.contextTokens, 90_000, "before stays contextTokens");
+  assert.equal(notified.afterTokens, 31_000, "after is compact's return value");
+});
+
+test("scheduler: onCompacted gets afterTokens null when compact returns nothing", async () => {
+  let notified = null;
+  const scheduler = createCompactionScheduler({
+    listCandidates: async () => [candidate("s1")],
+    compact: async () => undefined, // legacy/no-measure stub
+    isBusy: () => false,
+    now: () => NOW,
+    load: async () => ({ sessions: {} }),
+    save: async () => {},
+    enabled: () => true,
+    onCompacted: async (info) => { notified = info; },
+  });
+  await scheduler.tick();
+  assert.equal(notified.afterTokens, null, "unknown after → null (renderer falls back)");
+});
+
+test("scheduler: non-finite/zero compact return is coerced to null", async () => {
+  let notified = null;
+  const scheduler = createCompactionScheduler({
+    listCandidates: async () => [candidate("s1")],
+    compact: async () => Number.NaN,
+    isBusy: () => false,
+    now: () => NOW,
+    load: async () => ({ sessions: {} }),
+    save: async () => {},
+    enabled: () => true,
+    onCompacted: async (info) => { notified = info; },
+  });
+  await scheduler.tick();
+  assert.equal(notified.afterTokens, null);
+});

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-22T17:17:23.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-22T16:04:35.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T17:17:23.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:04:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
**BET-1356** — Optimizer P2.5 follow-up: surface `afterTokens` (post-compaction token count) so the background-compaction one-liner can show the exact `128k → 31k` before→after figure.

**Files changed:** 5. `[src/server/index.mjs, src/server/opencode.mjs, src/server/opencode.test.mjs, src/server/optimizer/compaction.mjs, src/server/optimizer/compaction.test.mjs]`

**What/why**

OpenCode's compact/summarize endpoint returns no token count (its success body is just `true`), so `afterTokens` has to be *measured* from the compaction path rather than read off the response. This PR:

1. **`afterTokens` flows end-to-end.** The injected scheduler `compact` now returns the post-compaction context; the scheduler hands it to `onCompacted` as `afterTokens`; `index.mjs` carries it into the `optimizer.compacted` stream notice, the optimizer activity-log entry, and the context telemetry. When the count is unknown (measure fails, legacy stub), it stays `null` and the renderer falls back to the no-count wording — it never fabricates a saving.
   - Measurement: `oc.measureSessionContextTokens(sessionId)` fetches the session's post-compaction messages and `estimateMessageListTokens` (pure, tested) estimates the retained history's context from the text-bearing content (~4 chars/token, the same heuristic opencode's own compaction retention uses). Structural keys (`type`/`role`/`id`/timestamps) and the compaction summary's large numeric `tokens.input` are deliberately excluded so they never inflate the "after" figure.
2. **`while you were away` covers away *or* gone.** The presence predicate was `desktopState(...) === "away"`, missing the `"gone"` (desktop not running / no heartbeat in TTL) path. Now `"away" || "gone"`.
3. Renderer side already renders the exact `before · before→after` figure when `afterTokens` is present and falls back otherwise (`formatCompactionSaving`, harness-tested in BET-1347) — no change needed there; it now receives a real count.

**Verification results:**
- PR branch (`multica/BET-1356-compaction-one-liner-after-tokens` @ `3a1e8d13`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2872 pass / 0 fail / 0 skip. Failures: none. log sha256: `bad9e0b1bb795dd139b56a2d237c137e093037c513c07d6b873b9e9119ad2369`
- Base (`main` @ `deaa9450`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2866 pass / 0 fail / 0 skip. Failures: none. log sha256: `b806b90084fbc507802e61103e847268cdf5c760ed0d733feb52e9c729e93a52`
- **Conclusion:** 0 new failures; +6 tests (test count 2866 → 2872). Typecheck logs identical between branches.

**Base: `origin/main` @ `deaa9450`**

**Follow-ups filed:** `Parked: BET-1357` for the before/after token-unit reconciliation (see below) — linked by key in the completion comment.
