### PR TITLE
BET-1326: iOS widget renderer — live window, WKWebView config, manta-widget:// scheme handler

### DIFF
--- a/generated/swift/Theme.swift
+++ b/generated/swift/Theme.swift
@@ -166,12 +166,14 @@ struct TypeMetrics {
     let listRowMargin: CGFloat
     let listGroupAbove: CGFloat
     let listGroupBelow: CGFloat
+    let inlineMaxW: CGFloat
+    let widgetDormantOpacity: CGFloat
 }
 
 enum Metrics {
     static let spacing = Spacing(sp0: 0, spPx: 1, sp1: 4, sp2: 8, sp3: 12, sp4: 16, sp5: 20, sp6: 24, sp8: 32, sp10: 40, sp12: 48)
     static let radius = Radius(xs: 4, sm: 6, md: 8, lg: 12, xl: 16, full: 999)
-    static let type = TypeMetrics(sans: "Inter Variable, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif", mono: "JetBrains Mono Variable, JetBrains Mono, SF Mono, Menlo, Consolas, monospace", body: 15, small: 13, xs: 12, twoXS: 11, display: 28, confirm: 40, otp: 26, medium: 500, semibold: 600, proseLineHeight: 1.55, uiLineHeight: 1.45, rowName: 15.5, headingTracking: -0.015, rowNameTracking: -0.01, chatTitle: 14.5, chatTitleTracking: -0.01, stepRowY: 7, stepDot: 6, chatHeaderBtn: 38, listRowMinH: 62, listRowRadius: 20, listRowMargin: 2, listGroupAbove: 22, listGroupBelow: 6)
+    static let type = TypeMetrics(sans: "Inter Variable, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif", mono: "JetBrains Mono Variable, JetBrains Mono, SF Mono, Menlo, Consolas, monospace", body: 15, small: 13, xs: 12, twoXS: 11, display: 28, confirm: 40, otp: 26, medium: 500, semibold: 600, proseLineHeight: 1.55, uiLineHeight: 1.45, rowName: 15.5, headingTracking: -0.015, rowNameTracking: -0.01, chatTitle: 14.5, chatTitleTracking: -0.01, stepRowY: 7, stepDot: 6, chatHeaderBtn: 38, listRowMinH: 62, listRowRadius: 20, listRowMargin: 2, listGroupAbove: 22, listGroupBelow: 6, inlineMaxW: 520, widgetDormantOpacity: 0.5)
 }
 
 extension Color {

--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -19,6 +19,7 @@
 		1B9026B4F0286A5186FD5197 /* MantaSettingsModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 39978655A14BFA5D39336286 /* MantaSettingsModels.swift */; };
 		1E8A1AB9FB3945E6092CA2E2 /* UsageStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = CAFF319B4F3CD4F13A20A1EB /* UsageStore.swift */; };
 		1F0E6031C0987AFF27CC3F47 /* SessionListStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 24994B33B60EB6C4C6EF4178 /* SessionListStore.swift */; };
+		210BBD9462DF5C99B4BD97F8 /* WidgetLiveStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7A8EE8EB2470107E084E571D /* WidgetLiveStore.swift */; };
 		239BD2739F1F96A11F033259 /* SessionCreateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */; };
 		261925E9ADC090271FED15DE /* TerminalSessionState.swift in Sources */ = {isa = PBXBuildFile; fileRef = 81FE763828641B50BF496F4D /* TerminalSessionState.swift */; };
 		2727E78CDA096DC415008244 /* manta-logo.png in Resources */ = {isa = PBXBuildFile; fileRef = B230F69A60CD3DBC416612B0 /* manta-logo.png */; };
@@ -41,6 +42,7 @@
 		52C319CA847D3FECBC1297E2 /* VoiceRecordingSurface.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9F06F838B4779D52B29E1173 /* VoiceRecordingSurface.swift */; };
 		578DA0FFC68283A72AF914E8 /* VoiceGesture.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6717B2E85100A1BCAC163A31 /* VoiceGesture.swift */; };
 		5A03FC0627C87718E260CC02 /* MantaActionRPCWireTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9CA2F9C1585492985A5D82ED /* MantaActionRPCWireTests.swift */; };
+		5B584A1635E4508AEF8E909D /* WidgetWebView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 3B9489E214B5D762E1D2F168 /* WidgetWebView.swift */; };
 		5DED49382A895F0EB73EE951 /* MantaStreamModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */; };
 		5E0226E9FAFF3F9CA9F45F8F /* SettingsScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = A1E78B0F5B521937B40937DC /* SettingsScreen.swift */; };
 		5F85B39269B52E1E816CBA1B /* SettingsSchema.swift in Sources */ = {isa = PBXBuildFile; fileRef = 988B5D51F20F0D3BC838E083 /* SettingsSchema.swift */; };
@@ -67,6 +69,7 @@
 		863035B4DE4C873A0BD9D0F5 /* MantaAuthClient.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2F29E8693B4AA4191CF9C556 /* MantaAuthClient.swift */; };
 		868536356F9E71119E51F8B7 /* PlanDerivation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7190EEBC7A7233EE21FE264A /* PlanDerivation.swift */; };
 		8A6656EBBD6AEC1B5CE7D0D6 /* MantaSettingsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 57FFB984A951D5C7BD8D02F9 /* MantaSettingsTests.swift */; };
+		8B3AC7065D52D347B4E6DAF1 /* WidgetModelsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6A7D08B1DEE45FBAB73754A6 /* WidgetModelsTests.swift */; };
 		8C67D893A425A3B5495CB882 /* ComposerTypeahead.swift in Sources */ = {isa = PBXBuildFile; fileRef = ED6ABAA46F1CBD2093D4AC87 /* ComposerTypeahead.swift */; };
 		8C965541FA4ABDFB2A2A319E /* terminal in Resources */ = {isa = PBXBuildFile; fileRef = 0C1EE3F998CADE8487D2555E /* terminal */; };
 		8F61F901888B9FE16EA093B0 /* ChatSessionStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 471BF240012879FDED5689C1 /* ChatSessionStore.swift */; };
@@ -114,6 +117,7 @@
 		E12FC0E7284E2760AD3A6C4C /* ChatScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = 436675A65BF149932C1EADE0 /* ChatScreen.swift */; };
 		E37BCF5DE477D4CAAC0ACCD8 /* MantaContextStripVerifyUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BBC0EC48A556426D44A1A42 /* MantaContextStripVerifyUITests.swift */; };
 		E394FF8B718A3D7871EC749C /* ChatModelCatalog.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4098461F579869804595B0A3 /* ChatModelCatalog.swift */; };
+		E3AD00FD4234C06C5CEB2EC2 /* WidgetModels.swift in Sources */ = {isa = PBXBuildFile; fileRef = AB9395F95D40DA67D14C08F0 /* WidgetModels.swift */; };
 		E631BDFC8B6DF9D3E602DE22 /* PlanDerivationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = BEBD86C54D5730F24D2E956E /* PlanDerivationTests.swift */; };
 		E84EC5ADFC08C40B413BE9F3 /* BranchLabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5AE55697AC4EC2304E05D8A1 /* BranchLabelTests.swift */; };
 		E8B921F11FB02F147C910B32 /* PolishTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B82B782F73475FDD71F6D6B5 /* PolishTests.swift */; };
@@ -125,6 +129,7 @@
 		EE3F3D2D85BC08D58A78A564 /* MantaError.swift in Sources */ = {isa = PBXBuildFile; fileRef = A11BB42810D0F3D3ADD9B557 /* MantaError.swift */; };
 		F30211F79048035CE5520266 /* RunningIndicator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6BA4ADBB2FD5BAC7940D5B69 /* RunningIndicator.swift */; };
 		F84BE156312997C53C3314AF /* MantaDeepLink.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8879A94FE1BE824F438342AD /* MantaDeepLink.swift */; };
+		F9C00B6860D35C356F672690 /* WidgetCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = F0B7EFD678C9522E593243EE /* WidgetCard.swift */; };
 		FF511A296958C8376966852F /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 82EEBB3B72D8F63CF4D8CB7B /* Assets.xcassets */; };
 /* End PBXBuildFile section */
 
@@ -176,6 +181,7 @@
 		39978655A14BFA5D39336286 /* MantaSettingsModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsModels.swift; sourceTree = "<group>"; };
 		39B5E0C86E9FA4A10239DBFA /* DeprecatedModelOptInsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedModelOptInsTests.swift; sourceTree = "<group>"; };
 		39FCF0EB1ADCD186680EB69C /* PendingPrompt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PendingPrompt.swift; sourceTree = "<group>"; };
+		3B9489E214B5D762E1D2F168 /* WidgetWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetWebView.swift; sourceTree = "<group>"; };
 		4098461F579869804595B0A3 /* ChatModelCatalog.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModelCatalog.swift; sourceTree = "<group>"; };
 		436675A65BF149932C1EADE0 /* ChatScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatScreen.swift; sourceTree = "<group>"; };
 		4603364B1845FF6C330EB601 /* ChatOverflowCaptureScene.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOverflowCaptureScene.swift; sourceTree = "<group>"; };
@@ -196,6 +202,7 @@
 		6169B72F37CC138729DDD22E /* DeprecatedModelOptIns.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DeprecatedModelOptIns.swift; sourceTree = "<group>"; };
 		6717B2E85100A1BCAC163A31 /* VoiceGesture.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceGesture.swift; sourceTree = "<group>"; };
 		681F342360878481A0D8364F /* MantaOverflowCaptureUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaOverflowCaptureUITests.swift; sourceTree = "<group>"; };
+		6A7D08B1DEE45FBAB73754A6 /* WidgetModelsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetModelsTests.swift; sourceTree = "<group>"; };
 		6BA4ADBB2FD5BAC7940D5B69 /* RunningIndicator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunningIndicator.swift; sourceTree = "<group>"; };
 		6BDC7F6FA94631DA4C55A948 /* TerminalWebView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalWebView.swift; sourceTree = "<group>"; };
 		6E08743A649A206BA91EDD67 /* KeychainCredentialStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeychainCredentialStore.swift; sourceTree = "<group>"; };
@@ -207,6 +214,7 @@
 		7582E08CBBDCE70E242A6B18 /* UsageSheets.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UsageSheets.swift; sourceTree = "<group>"; };
 		772D1B80A35F4493F828ACC2 /* MantaReconnectController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaReconnectController.swift; sourceTree = "<group>"; };
 		799EED7CC4F10C6684A5662C /* Theme.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Theme.swift; sourceTree = "<group>"; };
+		7A8EE8EB2470107E084E571D /* WidgetLiveStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetLiveStore.swift; sourceTree = "<group>"; };
 		7D7BC8920829E8847057C8DA /* TerminalKeyRow.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalKeyRow.swift; sourceTree = "<group>"; };
 		7E94945B8AA543436D5A6202 /* ComposerTypeaheadTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTypeaheadTests.swift; sourceTree = "<group>"; };
 		7F45372304FA61F99907B0A3 /* MantaStreamModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaStreamModels.swift; sourceTree = "<group>"; };
@@ -233,6 +241,7 @@
 		A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptComponents.swift; sourceTree = "<group>"; };
 		A2C97C92B5E1ADA62F799D73 /* ModelPickerSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ModelPickerSheet.swift; sourceTree = "<group>"; };
 		A4E84DF65831DE58599C53BD /* RootView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RootView.swift; sourceTree = "<group>"; };
+		AB9395F95D40DA67D14C08F0 /* WidgetModels.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetModels.swift; sourceTree = "<group>"; };
 		ABB2884AC2B1D0FE1E0DA8EB /* MantaPairingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingTests.swift; sourceTree = "<group>"; };
 		ABF1AB00CC95EA99A4EF537B /* MantaSettingsStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaSettingsStore.swift; sourceTree = "<group>"; };
 		AD55034506C4DF218AD7300E /* MantaPairingDriverUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaPairingDriverUITests.swift; sourceTree = "<group>"; };
@@ -266,6 +275,7 @@
 		ED6ABAA46F1CBD2093D4AC87 /* ComposerTypeahead.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ComposerTypeahead.swift; sourceTree = "<group>"; };
 		EE0504A23AC9360042B3D51B /* ChatStreamMergeTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatStreamMergeTests.swift; sourceTree = "<group>"; };
 		EF45305B46745A80925FC1A4 /* MantaEventStreamTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MantaEventStreamTests.swift; sourceTree = "<group>"; };
+		F0B7EFD678C9522E593243EE /* WidgetCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WidgetCard.swift; sourceTree = "<group>"; };
 		F23DFA2A87BE93D8DF5472DF /* ChatModelPrefs.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatModelPrefs.swift; sourceTree = "<group>"; };
 		F88D3B9B782BF819EEBEBF1D /* TerminalSocket.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TerminalSocket.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
@@ -343,6 +353,7 @@
 				E4A5AE775D3F3D82FC69A54F /* VoiceGestureTests.swift */,
 				AE01D00B6A031E239CC12EAD /* VoiceNoteTests.swift */,
 				AEF7554D798247FECA6BFF84 /* WaveformTests.swift */,
+				6A7D08B1DEE45FBAB73754A6 /* WidgetModelsTests.swift */,
 			);
 			path = MantaUITests;
 			sourceTree = "<group>";
@@ -450,6 +461,10 @@
 				4B4BD7922C8909E3A3961957 /* VoiceRecorder.swift */,
 				9F06F838B4779D52B29E1173 /* VoiceRecordingSurface.swift */,
 				8D7B1F4E5EF7E0ADD2238839 /* Waveform.swift */,
+				F0B7EFD678C9522E593243EE /* WidgetCard.swift */,
+				7A8EE8EB2470107E084E571D /* WidgetLiveStore.swift */,
+				AB9395F95D40DA67D14C08F0 /* WidgetModels.swift */,
+				3B9489E214B5D762E1D2F168 /* WidgetWebView.swift */,
 				6C581AFB55001DF333A22728 /* Resources */,
 			);
 			path = MantaUI;
@@ -689,6 +704,7 @@
 				B7D2A1C0F9EC29C5B0002C8F /* VoiceGestureTests.swift in Sources */,
 				49F13D74AD1B942D3313970B /* VoiceNoteTests.swift in Sources */,
 				12070C130BD9D1CD9EA0603F /* WaveformTests.swift in Sources */,
+				8B3AC7065D52D347B4E6DAF1 /* WidgetModelsTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -766,6 +782,10 @@
 				98A26A0ABAFE54728AE97FEE /* VoiceRecorder.swift in Sources */,
 				52C319CA847D3FECBC1297E2 /* VoiceRecordingSurface.swift in Sources */,
 				75B97ECFE219AB9C7D45EDE3 /* Waveform.swift in Sources */,
+				F9C00B6860D35C356F672690 /* WidgetCard.swift in Sources */,
+				210BBD9462DF5C99B4BD97F8 /* WidgetLiveStore.swift in Sources */,
+				E3AD00FD4234C06C5CEB2EC2 /* WidgetModels.swift in Sources */,
+				5B584A1635E4508AEF8E909D /* WidgetWebView.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -846,7 +866,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.19;
+				MARKETING_VERSION = 1.0.22;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;
@@ -953,7 +973,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.0.19;
+				MARKETING_VERSION = 1.0.22;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_BUNDLE_IDENTIFIER = com.antoinedc.mantaui;
 				PRODUCT_NAME = MantaUI;

--- a/mobile/native/MantaUI/ChatModels.swift
+++ b/mobile/native/MantaUI/ChatModels.swift
@@ -261,7 +261,18 @@ enum ChatTranscriptMapper {
     }
 
     static func blocks(from messages: [OpencodeMessage], voiceNotes: [VoiceNote]) -> [TranscriptBlock] {
+        blocks(from: messages, voiceNotes: voiceNotes, widgets: [])
+    }
+
+    /// Map the canonical transcript onto blocks, then merge the two
+    /// side-channel collections the box announces on the bus — voice notes
+    /// (BET-1029) and widgets (BET-1326). Both arrive out-of-band and are
+    /// claimed onto the message that produced them, so a widget renders as a
+    /// `.file` attachment right where its turn landed without inventing any
+    /// new row identity.
+    static func blocks(from messages: [OpencodeMessage], voiceNotes: [VoiceNote], widgets: [WidgetRef]) -> [TranscriptBlock] {
         let voiceMap = buildVoiceNoteMap(messages: messages, notes: voiceNotes)
+        let widgetMap = buildWidgetMap(widgets)
         var blocks: [TranscriptBlock] = []
         var pending: [StepGroupRow] = []
 
@@ -280,6 +291,7 @@ enum ChatTranscriptMapper {
                     if let note = voiceMap[msg.info.id] {
                         blocks.append(.file(TranscriptAttachment(kind: .voiceNote(note))))
                     }
+                    appendWidgets(widgetMap[msg.info.id], into: &blocks)
                 }
             case "assistant":
                 // An assistant message still streaming (time.completed == nil)
@@ -293,12 +305,35 @@ enum ChatTranscriptMapper {
                     process(part, index: index, at: at, pending: &pending, blocks: &blocks)
                 }
                 flush(&pending, into: &blocks)
+                // A turn's widgets follow its steps/prose: the model rendered
+                // them as part of that assistant message.
+                appendWidgets(widgetMap[msg.info.id], into: &blocks)
             default:
                 break
             }
         }
         flush(&pending, into: &blocks)
         return blocks
+    }
+
+    /// messageId → widgets claimed onto that message. A widget whose message is
+    /// outside the loaded window (or missing) is dropped, exactly like a voice
+    /// note that matches nothing — it carries no id-based claim of its own.
+    static func buildWidgetMap(_ widgets: [WidgetRef]) -> [String: [WidgetRef]] {
+        var map: [String: [WidgetRef]] = [:]
+        for w in widgets {
+            if let mid = w.messageId, !mid.isEmpty {
+                map[mid, default: []].append(w)
+            }
+        }
+        return map
+    }
+
+    private static func appendWidgets(_ widgets: [WidgetRef]?, into blocks: inout [TranscriptBlock]) {
+        guard let widgets, !widgets.isEmpty else { return }
+        for w in widgets {
+            blocks.append(.file(TranscriptAttachment(kind: .widget(w))))
+        }
     }
 
     /// Append the still-running LIVE tools AND live subagents (streamed mid-turn

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -224,7 +224,8 @@ private struct ChatScreenContent: View {
         _store = StateObject(wrappedValue: ChatSessionStore(
             sessionId: sessionId,
             eventStore: eventStore,
-            api: api
+            api: api,
+            widgetLiveStore: WidgetLiveStore.shared
         ))
         _modelStore = StateObject(wrappedValue: ChatModelStore(sessionId: sessionId, api: api))
         _settingsStore = StateObject(wrappedValue: MantaSettingsStore())
@@ -769,6 +770,9 @@ private struct ChatScreenContent: View {
         // Deliver the blocking-card actions to the transcript cells via the
         // SwiftUI environment (BET-1214). The subagent drill-in keeps `nil`.
         .environment(\.transcriptCardActions, cardActions)
+        // Deliver the box-wide widget live store to widget cards so liveness
+        // can ride on the store rather than the cell (BET-1326).
+        .environment(\.widgetLiveStore, WidgetLiveStore.shared)
     }
     /// How far above the bottom the user must scroll for the down-arrow to
     /// appear. Same magnitude MessagingUI uses internally for its own "near

--- a/mobile/native/MantaUI/ChatSessionStore.swift
+++ b/mobile/native/MantaUI/ChatSessionStore.swift
@@ -144,6 +144,11 @@ final class ChatSessionStore: ObservableObject {
     /// `buildVoiceNoteMap`, so a dictated note renders its player bubble in the
     /// transcript under the message it became (BET-1029).
     @Published private(set) var voiceNotes: [VoiceNote] = []
+    /// The widget refs announced on the bus for THIS session, merged into the
+    /// transcript as `.file(.widget(...))` attachments (BET-1326). Mirrors the
+    /// voice-notes side channel: refs come out-of-band, claimed onto the
+    /// message that produced each widget.
+    @Published private(set) var widgets: [WidgetRef] = []
     /// The LAST fetched raw transcript (`opencode:messages`), kept alongside the
     /// rendered `transcript` blocks so the plan card can run its exact
     /// derivation (`isPlanExitQuestion` / `extractPlanData` need the raw tool
@@ -219,6 +224,10 @@ final class ChatSessionStore: ObservableObject {
 
     private let api: MantaAPIClient
     private let eventStore: MantaEventStore
+    /// The box-wide live store this session's widgets are read from (nil on a
+    /// read-only surface, where no widget is ever live). Kept so the session
+    /// can sink on its own widget announcements (BET-1326).
+    private let widgetLiveStore: WidgetLiveStore?
     private var cancellables: Set<AnyCancellable> = []
     private var runningSince: Date?
     /// Stable id for the streaming `.prose` tail, fixed for the life of one
@@ -311,11 +320,13 @@ final class ChatSessionStore: ObservableObject {
         sessionId: String,
         eventStore: MantaEventStore,
         api: MantaAPIClient,
+        widgetLiveStore: WidgetLiveStore? = nil,
         isReadOnly: Bool = false
     ) {
         self.sessionId = sessionId
         self.eventStore = eventStore
         self.api = api
+        self.widgetLiveStore = widgetLiveStore
         self.isReadOnly = isReadOnly
 
         // Per-session subscription (BET-672): sink on THIS session's state
@@ -344,6 +355,18 @@ final class ChatSessionStore: ObservableObject {
             .removeDuplicates()
             .sink { [weak self] d in self?.degraded = d }
             .store(in: &cancellables)
+
+        // A new widget announced for this session (route through the box-wide
+        // store) re-merges the transcript. The store's `$widgets` replays its
+        // current value on subscribe, so an open session picks up widgets that
+        // arrived before it was created.
+        if let widgetLiveStore {
+            widgetLiveStore.$widgets
+                .receive(on: DispatchQueue.main)
+                .removeDuplicates()
+                .sink { [weak self] _ in self?.refreshWidgets() }
+                .store(in: &cancellables)
+        }
     }
 
     // MARK: - Lifecycle
@@ -805,7 +828,7 @@ final class ChatSessionStore: ObservableObject {
                     // (self.messages), not the shadowed local.
                     self.messages = loaded
                     voiceNoteMap = ChatTranscriptMapper.buildVoiceNoteMap(messages: loaded, notes: voiceNotes)
-                    transcript = ChatTranscriptMapper.blocks(from: loaded, voiceNotes: voiceNotes)
+                    transcript = ChatTranscriptMapper.blocks(from: loaded, voiceNotes: voiceNotes, widgets: widgets)
                     // The transcript now carries these messages, so any live
                     // copy of them is a duplicate — retire it BEFORE rebuilding
                     // or the finished answer renders twice, once from each
@@ -852,7 +875,7 @@ final class ChatSessionStore: ObservableObject {
     func refreshVoiceNotes() async {
         let notes = (try? await api.voiceNotes(sessionId: sessionId)) ?? []
         await MainActor.run {
-            let remapped = ChatTranscriptMapper.blocks(from: messages, voiceNotes: notes)
+            let remapped = ChatTranscriptMapper.blocks(from: messages, voiceNotes: notes, widgets: widgets)
             voiceNotes = notes
             voiceNoteMap = ChatTranscriptMapper.buildVoiceNoteMap(messages: messages, notes: notes)
             // Defensive, mirrors BET-1125's fetch guard: never let a voice-notes
@@ -867,6 +890,22 @@ final class ChatSessionStore: ObservableObject {
             }
             rebuildBlocks()
         }
+    }
+
+    // MARK: - Widgets (BET-1326)
+
+    /// Fold the box-wide store's announced widgets for THIS session into the
+    /// transcript as `.file(.widget(...))` blocks. Called when the store's
+    /// widgets change; the same no-blank-clobber guard as voice notes.
+    func refreshWidgets() {
+        let sessionWidgets = widgetLiveStore?.widgets.values.filter { $0.sessionId == sessionId } ?? []
+        guard sessionWidgets != widgets else { return }
+        widgets = sessionWidgets
+        let remapped = ChatTranscriptMapper.blocks(from: messages, voiceNotes: voiceNotes, widgets: widgets)
+        if !(remapped.isEmpty && !transcript.isEmpty) {
+            transcript = remapped
+        }
+        rebuildBlocks()
     }
 
     // MARK: - Answers (wire from the phone, S1a)

--- a/mobile/native/MantaUI/MantaUIApp.swift
+++ b/mobile/native/MantaUI/MantaUIApp.swift
@@ -30,6 +30,9 @@ struct MantaUIApp: App {
         let event = MantaEventStore()
         _store = StateObject(wrappedValue: event)
         _sessionStore = StateObject(wrappedValue: SessionListStore(eventStore: event))
+        // The box-wide widget live store consumes `kind: "widget"` frames off
+        // the same /events stream (registered once, idempotently).
+        WidgetLiveStore.shared.bind(eventStore: event)
     }
 
     var body: some Scene {

--- a/mobile/native/MantaUI/TerminalWebView.swift
+++ b/mobile/native/MantaUI/TerminalWebView.swift
@@ -548,12 +548,6 @@ extension TerminalContainerController: WKScriptMessageHandler, WKNavigationDeleg
         webViewDidFinish(webView)
     }
 
-    func webView(_ webView: WKWebView, createWebViewWith configuration: WKWebViewConfiguration,
-                 for navigationAction: WKNavigationAction, windowFeatures: WKWindowFeatures) -> WKWebView? {
-        if let url = navigationAction.request.url { UIApplication.shared.open(url) }
-        return nil
-    }
-
     func gestureRecognizer(_ gestureRecognizer: UIGestureRecognizer,
                            shouldRecognizeSimultaneouslyWith otherGestureRecognizer: UIGestureRecognizer) -> Bool {
         true

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -816,12 +816,18 @@ enum TranscriptBlock: Equatable {
 }
 
 /// A file/attachment reference carried by a `.file` transcript block. Only the
-/// `.voiceNote` flavour renders today; image and generic-file rendering are
-/// deliberately not implemented yet (BET-1029) — a file part that is not a
-/// voice note renders nothing, exactly as it did before.
+/// `.voiceNote` and `.widget` flavours render today; image and generic-file
+/// rendering are deliberately not implemented yet (BET-1029) — a file part
+/// that is not one of those renders nothing, exactly as it did before.
 struct TranscriptAttachment: Equatable {
     enum Kinds: Equatable {
         case voiceNote(VoiceNote)
+        /// A referenced, rendered-inline widget (BET-1326). A widget is an
+        /// artifact referenced by the transcript, which is exactly what `.file`
+        /// means — deliberately NOT a new `TranscriptBlock` case (a new case
+        /// would fork the row-identity logic). Its `WidgetRef.id` is the
+        /// deterministic row identity.
+        case widget(WidgetRef)
     }
     let kind: Kinds
 }

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -75,6 +75,10 @@ extension TranscriptBlock {
 private func attachmentIdentity(_ attachment: TranscriptAttachment) -> String {
     switch attachment.kind {
     case .voiceNote(let note): return "voice:\(note.id)"
+    // The widget's OWN id from the bus event — the deterministic, reproducible
+    // row identity (never an index, never a render-time UUID). A refetch of the
+    // same window re-derives the same id, so TiledView updates the row in place.
+    case .widget(let ref): return "widget:\(ref.id)"
     }
 }
 
@@ -388,9 +392,13 @@ func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: Transc
     }
 }
 
-/// Render a `.file` attachment block. ONLY the voice-note flavour renders — an
-/// image or generic-file part is deliberately NOT implemented yet (BET-1029);
-/// it would return nothing here, exactly as it did before this case existed.
+/// Render a `.file` attachment block. ONLY the voice-note and widget flavours
+/// render — an image or generic-file part is deliberately NOT implemented yet
+/// (BET-1029); it would return nothing here, exactly as it did before this
+/// case existed. The widget store comes through the SwiftUI environment (a
+/// `@MainActor` reference type, like `transcriptCardActions`), so a read-only
+/// surface (subagent drill-in, capture fixture) leaves it unset and a widget
+/// renders its inert placeholder with no live wiring.
 @ViewBuilder
 private func attachmentView(_ attachment: TranscriptAttachment, tokens: Tokens) -> some View {
     switch attachment.kind {
@@ -398,6 +406,10 @@ private func attachmentView(_ attachment: TranscriptAttachment, tokens: Tokens) 
         VoiceNotePlayerRow(note: note, tokens: tokens)
             .padding(.horizontal, Metrics.spacing.sp3)
             .padding(.bottom, Metrics.spacing.sp4)
+    case .widget(let ref):
+        WidgetCardView(ref: ref, tokens: tokens)
+            .padding(.horizontal, Metrics.spacing.sp3)
+            .padding(.bottom, Metrics.spacing.sp3)
     }
 }
 

--- a/mobile/native/MantaUI/WidgetCard.swift
+++ b/mobile/native/MantaUI/WidgetCard.swift
@@ -1,0 +1,433 @@
+import SwiftUI
+import UIKit
+
+// ===========================================================================
+// WidgetCard.swift — the inline widget card (`.mk-ios-live` conformance).
+//
+// A widget card is NOT a new component: it is the existing ToolCard shell
+// (a header ribbon + an OutputWell-style body) — exactly how the desktop's
+// MediaBody/WidgetBody render. The only genuinely new things here are what
+// goes inside the well (a WKWebView instead of an <img>) and the four
+// lifecycle states the meta slot names: live / snapshot / placeholder /
+// stopped. Naming the state in the meta slot is required — without it a
+// dimmed bitmap of a chart and a working chart look identical and people tap
+// a picture expecting it to respond.
+//
+// Every state occupies the IDENTICAL reserved box (size from the declared
+// width/height/aspectRatio — never measured from content), so nothing reflows
+// when a widget activates, dies or restores.
+//
+// The card reads liveness from the box-wide `WidgetLiveStore` via the SwiftUI
+// environment. A read-only surface (subagent drill-in, capture fixture) leaves
+// the store unset and renders the inert placeholder.
+// ===========================================================================
+
+/// The four lifecycle states, named in the card's meta slot.
+enum WidgetState: Equatable {
+    case live
+    case snapshot
+    case placeholder
+    case stopped
+
+    var label: String {
+        switch self {
+        case .live: return "live"
+        case .snapshot: return "snapshot"
+        case .placeholder: return "placeholder"
+        case .stopped: return "stopped"
+        }
+    }
+}
+
+/// The environment-provided entry point. Wires the live store when present,
+/// else falls back to the inert placeholder (no live wiring, no webview).
+struct WidgetCardView: View {
+    @Environment(\.widgetLiveStore) private var liveStore
+    let ref: WidgetRef
+    let tokens: Tokens
+
+    var body: some View {
+        if let liveStore {
+            LiveWidgetCard(store: liveStore, ref: ref, tokens: tokens)
+        } else {
+            InertWidgetCard(ref: ref, tokens: tokens)
+        }
+    }
+}
+
+/// The live, store-wired card. Holds the tap / expand behaviour and the expand
+/// sheet; reports on-screen edges to the store so the live window's
+/// screen-protection rule holds.
+@MainActor
+struct LiveWidgetCard: View {
+    @ObservedObject var store: WidgetLiveStore
+    let ref: WidgetRef
+    let tokens: Tokens
+    @State private var showSheet = false
+
+    private var state: WidgetState {
+        // Stopped first (the process is gone — never present a dead chart as
+        // live), then live, then the captured snapshot, then placeholder.
+        if store.isStopped(ref.id) { return .stopped }
+        if store.isLive(ref.id) { return .live }
+        if store.snapshot(for: ref.id) != nil { return .snapshot }
+        return .placeholder
+    }
+
+    var body: some View {
+        WidgetCardChrome(
+            ref: ref,
+            tokens: tokens,
+            state: state,
+            onActivate: {
+                store.clearStopped(ref.id)
+                store.activate(ref.id)
+            },
+            onExpand: {
+                // The sheet is the only place a widget takes full interaction;
+                // presenting it activates the widget like any other tap (it
+                // counts against the live cap).
+                store.activate(ref.id)
+                showSheet = true
+            },
+            content: {
+                switch state {
+                case .live:
+                    WidgetLiveWebView(ref: ref, liveStore: store, onReady: { _ in })
+                case .snapshot:
+                    WidgetDormantSurface(
+                        ref: ref, tokens: tokens, state: .snapshot,
+                        snapshot: store.snapshot(for: ref.id),
+                        onActivate: { store.activate(ref.id) }
+                    )
+                case .placeholder:
+                    WidgetDormantSurface(
+                        ref: ref, tokens: tokens, state: .placeholder,
+                        snapshot: nil,
+                        onActivate: { store.activate(ref.id) }
+                    )
+                case .stopped:
+                    WidgetDormantSurface(
+                        ref: ref, tokens: tokens, state: .stopped,
+                        snapshot: nil,
+                        onActivate: {
+                            store.clearStopped(ref.id)
+                            store.activate(ref.id)
+                        }
+                    )
+                }
+            }
+        )
+        .onAppear { store.setOnScreen(ref.id, true) }
+        .onDisappear { store.setOnScreen(ref.id, false) }
+        .sheet(isPresented: $showSheet) {
+            WidgetExpandSheet(ref: ref, tokens: tokens, liveStore: store)
+        }
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("widget-card")
+    }
+}
+
+/// A read-only surface's widget card: the same shell, forever in the
+/// placeholder state with no live wiring and no actions.
+struct InertWidgetCard: View {
+    let ref: WidgetRef
+    let tokens: Tokens
+
+    var body: some View {
+        WidgetCardChrome(
+            ref: ref,
+            tokens: tokens,
+            state: .placeholder,
+            onActivate: {},
+            onExpand: {},
+            content: {
+                WidgetDormantSurface(
+                    ref: ref, tokens: tokens, state: .placeholder,
+                    snapshot: nil, onActivate: {}
+                )
+            }
+        )
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("widget-card")
+    }
+}
+
+// MARK: - The chrome (header + body)
+
+/// The ToolCard-style shell: header ribbon (status dot, name, arg, state meta,
+/// iOS-only expand button) above the reserved body box. `maxWidth` capped at
+/// the `--inline-max-w` token so the widget's reading width matches every other
+/// inline embed.
+struct WidgetCardChrome<Body: View>: View {
+    let ref: WidgetRef
+    let tokens: Tokens
+    let state: WidgetState
+    let onActivate: () -> Void
+    let onExpand: () -> Void
+    @ViewBuilder var content: () -> Body
+
+    var body: some View {
+        VStack(spacing: 0) {
+            header
+            bodyContent
+        }
+        .background(tokens.panel)
+        .clipShape(RoundedRectangle(cornerRadius: Metrics.radius.md))
+        .overlay(
+            RoundedRectangle(cornerRadius: Metrics.radius.md)
+                .stroke(tokens.borderSubtle, lineWidth: 1)
+        )
+        .frame(maxWidth: Metrics.type.inlineMaxW)
+    }
+
+    private var bodyContent: some View {
+        content()
+            .frame(maxWidth: .infinity)
+            .background(tokens.inset)
+            .overlay(alignment: .top) {
+                Rectangle().fill(tokens.borderSubtle).frame(height: 1)
+            }
+    }
+
+    private var header: some View {
+        HStack(spacing: Metrics.spacing.sp2) {
+            Circle()
+                .fill(dotColor)
+                .frame(width: Metrics.type.stepDot, height: Metrics.type.stepDot)
+            Text("Widget")
+                .font(.manta(size: Metrics.type.small, weight: .semibold))
+                .foregroundColor(tokens.tx1)
+            Text(ref.title ?? "Widget")
+                .font(.manta(size: Metrics.type.twoXS))
+                .foregroundColor(tokens.tx3)
+                .lineLimit(1)
+                .truncationMode(.tail)
+                .frame(maxWidth: .infinity, alignment: .leading)
+            // The meta slot names the state — required, not cosmetic.
+            Text(state.label)
+                .font(.manta(size: Metrics.type.twoXS))
+                .foregroundColor(tokens.tx4)
+            // iOS-only expand affordance (desktop widgets have no sheet).
+            Button(action: onExpand) {
+                Image(systemName: "arrow.up.left.and.arrow.down.right")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(tokens.tx3)
+            }
+            .buttonStyle(.plain)
+            .accessibilityLabel("Expand widget")
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp2)
+    }
+
+    private var dotColor: Color {
+        switch state {
+        case .live: return tokens.accent
+        case .stopped: return tokens.danger
+        case .snapshot, .placeholder: return tokens.tx4
+        }
+    }
+}
+
+// MARK: - Reserved box + dormant states
+
+/// The reserved box: identical size for every state, so nothing reflows. The
+/// width caps at `--inline-max-w`; the height comes from the widget's declared
+/// width/height/aspectRatio (or a fixed default), never from rendered content.
+struct WidgetBox<Content: View>: View {
+    let ref: WidgetRef
+    @ViewBuilder var content: () -> Content
+
+    var body: some View {
+        content()
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .frame(maxWidth: Metrics.type.inlineMaxW)
+            .modifier(WidgetBoxSizeModifier(ref: ref))
+    }
+}
+
+/// Applies the declared-size height (or aspectRatio) to the box.
+private struct WidgetBoxSizeModifier: ViewModifier {
+    let ref: WidgetRef
+
+    func body(content: Content) -> some View {
+        if let h = ref.height, h > 0 {
+            content.frame(height: h)
+        } else if let ratio = ref.aspectRatio, ratio > 0 {
+            content.aspectRatio(ratio, contentMode: .fit)
+        } else if let w = ref.width, w > 0 {
+            content.frame(height: w)
+        } else {
+            content.frame(height: WidgetMetrics.defaultHeight)
+        }
+    }
+}
+
+/// A dormant state (placeholder / snapshot / stopped) filling the reserved box,
+/// with its "tap to [activate|load|reload]" chip centered.
+struct WidgetDormantSurface: View {
+    let ref: WidgetRef
+    let tokens: Tokens
+    let state: WidgetState
+    let snapshot: UIImage?
+    let onActivate: () -> Void
+
+    var body: some View {
+        WidgetBox(ref: ref) { bodyContent }
+            .contentShape(Rectangle())
+            .onTapGesture { onActivate() }
+            .accessibilityLabel(accessibilityLabel)
+    }
+
+    @ViewBuilder
+    private var bodyContent: some View {
+        ZStack {
+            switch state {
+            case .snapshot:
+                if let snapshot {
+                    // The captured bitmap, dimmed by the shared dormant-opacity
+                    // token (both clients dim identically) + desaturated.
+                    Image(uiImage: snapshot)
+                        .resizable()
+                        .scaledToFill()
+                        .opacity(Metrics.type.widgetDormantOpacity)
+                        .saturation(0.6)
+                        .clipped()
+                } else {
+                    placeholderContent
+                }
+            case .placeholder:
+                placeholderContent
+            case .stopped:
+                stoppedContent
+            case .live:
+                EmptyView()
+            }
+        }
+        .overlay { chip }
+        .clipped()
+    }
+
+    private var placeholderContent: some View {
+        GeometryReader { geo in
+            VStack(alignment: .leading, spacing: Metrics.spacing.sp2) {
+                skeletonBar(fraction: 0.42, width: geo.size.width)
+                skeletonBar(fraction: 0.78, width: geo.size.width)
+                skeletonBar(fraction: 0.61, width: geo.size.width)
+            }
+            .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .center)
+        }
+    }
+
+    private var stoppedContent: some View {
+        VStack(spacing: Metrics.spacing.sp2) {
+            Image(systemName: "exclamationmark.triangle.fill")
+                .font(.system(size: 16, weight: .medium))
+                .foregroundColor(tokens.warn)
+            Text("Widget stopped while the app was in the background.")
+                .font(.manta(size: Metrics.type.xs))
+                .foregroundColor(tokens.tx3)
+                .multilineTextAlignment(.center)
+        }
+        .padding(.horizontal, Metrics.spacing.sp3)
+    }
+
+    private func skeletonBar(fraction: CGFloat, width: CGFloat) -> some View {
+        RoundedRectangle(cornerRadius: Metrics.radius.full)
+            .fill(tokens.fillActive)
+            .frame(width: max(width * fraction, 20), height: Metrics.spacing.sp2)
+    }
+
+    @ViewBuilder
+    private var chip: some View {
+        if !chipText.isEmpty {
+            WidgetChip(text: chipText, tokens: tokens)
+        }
+    }
+
+    private var chipText: String {
+        switch state {
+        case .placeholder: return "Tap to load"
+        case .snapshot: return "Tap to activate"
+        case .stopped: return "Tap to reload"
+        case .live: return ""
+        }
+    }
+
+    private var accessibilityLabel: String {
+        "Widget, \(state.label)"
+    }
+}
+
+/// The pill that names the tap affordance on a dormant widget.
+struct WidgetChip: View {
+    let text: String
+    let tokens: Tokens
+
+    var body: some View {
+        HStack(spacing: Metrics.spacing.sp1) {
+            Image(systemName: "play.fill")
+                .font(.system(size: 9))
+            Text(text)
+                .font(.manta(size: Metrics.type.xs, weight: .medium))
+        }
+        .foregroundColor(tokens.tx1)
+        .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.vertical, Metrics.spacing.sp1)
+        .background(tokens.panel)
+        .clipShape(Capsule())
+        .overlay(Capsule().stroke(tokens.borderStrong, lineWidth: 1))
+        .shadow(color: Color.black.opacity(0.25), radius: Metrics.spacing.sp2)
+        .allowsHitTesting(false)
+    }
+}
+
+// MARK: - Expand sheet (.mk-ios-sheet)
+
+/// The full-screen sheet — the ONLY place a widget scrolls or takes real
+/// interaction. It counts against the live cap like any other live widget (the
+/// presenting card activates it). Its webview re-uses the same hardened
+/// configuration but with scrolling enabled and it occupies the whole sheet,
+/// not a fixed declared-size frame.
+struct WidgetExpandSheet: View {
+    let ref: WidgetRef
+    let tokens: Tokens
+    @ObservedObject var liveStore: WidgetLiveStore
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        VStack(spacing: 0) {
+            HStack(spacing: Metrics.spacing.sp2) {
+                Text(ref.title ?? "Widget")
+                    .font(.manta(size: Metrics.type.small, weight: .semibold))
+                    .foregroundColor(tokens.tx1)
+                    .lineLimit(1)
+                Spacer(minLength: 0)
+                Button { dismiss() } label: {
+                    Image(systemName: "xmark")
+                        .font(.system(size: 13, weight: .semibold))
+                        .foregroundColor(tokens.tx3)
+                        .frame(width: 28, height: 28)
+                        .background(tokens.fill, in: Circle())
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Close widget")
+            }
+            .padding(.horizontal, Metrics.spacing.sp4)
+            .padding(.vertical, Metrics.spacing.sp3)
+
+            WidgetExpandWebView(ref: ref, liveStore: liveStore)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(tokens.inset)
+
+            Text("sandboxed · no network · scrollable here")
+                .font(.manta(size: Metrics.type.twoXS))
+                .foregroundColor(tokens.tx4)
+                .padding(.vertical, Metrics.spacing.sp4)
+        }
+        .background(tokens.panel.ignoresSafeArea())
+        .accessibilityElement(children: .contain)
+        .accessibilityIdentifier("widget-sheet")
+    }
+}

--- a/mobile/native/MantaUI/WidgetLiveStore.swift
+++ b/mobile/native/MantaUI/WidgetLiveStore.swift
@@ -1,0 +1,181 @@
+import Foundation
+import Combine
+import UIKit
+import SwiftUI
+
+// ===========================================================================
+// WidgetLiveStore.swift — the box-wide owner of widget liveness.
+//
+// Liveness is a property of the WIDGET IN THIS STORE, not of the transcript
+// cell: the transcript recycles cells as you scroll, so if liveness rode on
+// cell lifecycle a widget would flicker in and out based on scroll position
+// and rows would stop being reproducible from the block alone. Every live-set
+// mutation funnels through the pure `WidgetLiveWindow.resolve` decision maker;
+// this store owns the state and observes the singleton bus + memory warnings.
+//
+// The cap is BOX-WIDE (across sessions and the expand sheet), so there is one
+// shared instance (`WidgetLiveStore.shared`) wired at the app root to the
+// `/events` stream. Fresh instances exist only in tests.
+// ===========================================================================
+
+@MainActor
+final class WidgetLiveStore: ObservableObject {
+    /// The app-wide instance, box-wide by construction. Registered with the
+    /// `/events` stream once at the app root (see `bind`).
+    static let shared = WidgetLiveStore()
+
+    /// Every widget announced this app run, keyed by its bus id. A card reads
+    /// its ref (url, dimensions, title) from here; the ChatSessionStore reads
+    /// its session's widgets to merge them into the transcript.
+    @Published private(set) var widgets: [String: WidgetRef] = [:]
+    /// The ordered live set (oldest first, newest last) — what's actually
+    /// running a web content process. At most `WidgetLiveWindow.maxLive` unless
+    /// the screen-protection rule holds more.
+    @Published private(set) var liveIDs: [String] = []
+    /// Bitmaps captured when a widget went dormant, keyed by id. Used to render
+    /// the dimmed `snapshot` state; absent → the card falls back to `placeholder`.
+    @Published private(set) var snapshots: [String: UIImage] = [:]
+    /// Widgets whose web content process was terminated (backgrounding, memory
+    /// pressure) — they render the labelled `stopped` state, never a blank box.
+    @Published private(set) var stoppedIDs: Set<String> = []
+
+    /// Widgets currently on screen (their cards reported via `setOnScreen`).
+    /// Rule 2 of the live window: nothing ever goes dead while it is on screen.
+    private var onScreen: Set<String> = []
+    private var boundEventStore = false
+
+    init() {
+        // Rule 4: drop to zero live on a memory warning. Selector-based (not a
+        // token) so `deinit` can remove the observer without touching a
+        // non-Sendable stored value (Swift 6 forbids that in a nonisolated
+        // deinit).
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleMemoryWarningNotification),
+            name: UIApplication.didReceiveMemoryWarningNotification,
+            object: nil
+        )
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
+    }
+
+    @objc private func handleMemoryWarningNotification() {
+        handleMemoryWarning()
+    }
+
+    /// Register this store as a consumer of `kind: "widget"` frames on the
+    /// `/events` stream. Idempotent — safe to call repeatedly (it binds once).
+    func bind(eventStore: MantaEventStore) {
+        guard !boundEventStore else { return }
+        boundEventStore = true
+        eventStore.addRawFrameHandler { [weak self] frame in
+            self?.handleFrame(frame)
+        }
+    }
+
+    /// Route a raw `/events` frame into this store if it is a widget frame.
+    func handleFrame(_ frame: MantaStreamFrame) {
+        guard frame.kind == "widget" else { return }
+        if let payload = try? frame.decodedPayload(WidgetPayload.self) {
+            handleShow(payload)
+        }
+    }
+
+    // MARK: - Live-set mutations (all through WidgetLiveWindow.resolve)
+
+    /// A widget was announced on the bus. Record its ref and grant it liveness
+    /// (rule 2/3), then enforce the cap (rule 1).
+    func handleShow(_ payload: WidgetPayload) {
+        guard payload.action == "show" || payload.action.isEmpty,
+              let id = payload.id, !id.isEmpty else { return }
+        let ref = WidgetRef(
+            id: id,
+            url: payload.url,
+            title: payload.title,
+            width: payload.width,
+            height: payload.height,
+            aspectRatio: payload.aspectRatio,
+            sessionId: payload.sessionId,
+            messageId: payload.messageId
+        )
+        widgets[id] = ref
+        stoppedIDs.remove(id)
+        liveIDs = WidgetLiveWindow.resolve(existing: liveIDs, arriving: id, onScreen: onScreen)
+    }
+
+    /// A tap promoted a dormant widget into the live set (taps count against
+    /// the cap like any other activation). No-op for an unknown / already-live
+    /// widget.
+    func activate(_ id: String) {
+        guard widgets[id] != nil, !liveIDs.contains(id) else { return }
+        stoppedIDs.remove(id)
+        liveIDs = WidgetLiveWindow.resolve(existing: liveIDs, arriving: id, onScreen: onScreen)
+    }
+
+    /// Report a widget's on-screen / off-screen edge from its card. Called on
+    /// the card's `onAppear`/`onDisappear`; re-resolves the live set so a
+    /// widget that scrolled fully off-screen AND is out of the newest-2 is
+    /// evicted, while an on-screen one is never torn out.
+    func setOnScreen(_ id: String, _ visible: Bool) {
+        if visible {
+            onScreen.insert(id)
+        } else {
+            onScreen.remove(id)
+        }
+        liveIDs = WidgetLiveWindow.resolve(existing: liveIDs, arriving: nil, onScreen: onScreen)
+    }
+
+    /// Store a dormant widget's captured bitmap for the `snapshot` state.
+    func captureSnapshot(id: String, image: UIImage) {
+        snapshots[id] = image
+    }
+
+    /// A widget's web content process was terminated → the `stopped` state,
+    /// and it leaves the live set (nothing blank renders in its place).
+    func markStopped(_ id: String) {
+        if liveIDs.contains(id) {
+            liveIDs = WidgetLiveWindow.resolve(
+                existing: liveIDs.filter { $0 != id },
+                arriving: nil,
+                onScreen: onScreen
+            )
+        }
+        stoppedIDs.insert(id)
+    }
+
+    /// A user tapped to reload a `stopped` widget: clear the stopped marker so
+    /// a fresh (recreated) webview can load and go live again.
+    func clearStopped(_ id: String) {
+        stoppedIDs.remove(id)
+    }
+
+    /// Rule 4: the live set goes to zero on a memory warning.
+    func handleMemoryWarning() {
+        liveIDs = []
+    }
+
+    // MARK: - Reads
+
+    func ref(for id: String) -> WidgetRef? { widgets[id] }
+    func isLive(_ id: String) -> Bool { liveIDs.contains(id) }
+    func snapshot(for id: String) -> UIImage? { snapshots[id] }
+    func isStopped(_ id: String) -> Bool { stoppedIDs.contains(id) }
+}
+
+// MARK: - Environment wiring
+
+/// The box-wide live store, injected into transcript cells via the SwiftUI
+/// environment (the same delivery as `transcriptCardActions`). `nil` on
+/// read-only surfaces where widgets render inert with no live wiring.
+private struct WidgetLiveStoreKey: EnvironmentKey {
+    static let defaultValue: WidgetLiveStore? = nil
+}
+
+extension EnvironmentValues {
+    var widgetLiveStore: WidgetLiveStore? {
+        get { self[WidgetLiveStoreKey.self] }
+        set { self[WidgetLiveStoreKey.self] = newValue }
+    }
+}

--- a/mobile/native/MantaUI/WidgetModels.swift
+++ b/mobile/native/MantaUI/WidgetModels.swift
@@ -1,0 +1,127 @@
+import Foundation
+
+// ===========================================================================
+// WidgetModels.swift — inline-widget models + pure live-window logic.
+//
+// A widget is a model-authored, sandboxed HTML document announced to the
+// clients on the `/events` bus as ONE kind (`widget`) with an `action`
+// discriminator (only `show` today), carrying the served URL plus the same
+// reserved-box dimension fields the media kind uses. The box spine
+// (src/server/widgets.mjs) is the single source of the payload shape; this
+// file holds the device-side mirror and the pure rules the live window is
+// built on.
+//
+// ROW IDENTITY: a widget's stable identity is its `id` from the bus event —
+// never an index and never a UUID minted at render time. Liveness is a
+// property of the widget in a `@MainActor` store (WidgetLiveStore), NOT of the
+// transcript cell, so a cell that scrolls away and back does not flicker a
+// widget in and out of the live set. This file only contains the value-type
+// decision maker; the store owns the state.
+// ===========================================================================
+
+/// The wallet-card reference carried by a `.file` transcript block's `.widget`
+/// attachment kind. Equatable + Sendable so it flows through the pure block
+/// mapping unchanged, and its `id` is the deterministic row identity.
+struct WidgetRef: Equatable, Identifiable, Sendable {
+    let id: String
+    /// The served `https://<box>/widgets/<id>` URL. Could be nil on a partial
+    /// frame; the live webview then falls back to the `manta-widget://<id>`
+    /// URL derived from the id alone.
+    let url: String?
+    let title: String?
+    /// Reserved-box dimensions taken from the bus payload. `width`/`height` in
+    /// points, `aspectRatio` unitless. Height is never measured from content.
+    let width: Double?
+    let height: Double?
+    let aspectRatio: Double?
+    let sessionId: String?
+    let messageId: String?
+
+    init(id: String, url: String?, title: String?, width: Double?, height: Double?,
+         aspectRatio: Double?, sessionId: String?, messageId: String?) {
+        self.id = id
+        self.url = url
+        self.title = title
+        self.width = width
+        self.height = height
+        self.aspectRatio = aspectRatio
+        self.sessionId = sessionId
+        self.messageId = messageId
+    }
+}
+
+/// The wire payload of a `kind: "widget"` frame, mirroring exactly what
+/// src/server/widgets.mjs publishes (id, url, title, width, height,
+/// aspectRatio, sessionId, messageId — lowercase `d` routing fields, the
+/// BET-1328 shared contract). Optional fields tolerate a partial frame.
+struct WidgetPayload: Codable, Equatable, Sendable {
+    var action: String
+    var id: String?
+    var url: String?
+    var title: String?
+    var width: Double?
+    var height: Double?
+    var aspectRatio: Double?
+    var sessionId: String?
+    var messageId: String?
+}
+
+// MARK: - The live window (pure)
+
+/// The pure eviction decision for the widget live set.
+///
+/// All four rules of the design (see the issue) are test cases here:
+///   1. Cap: at most `maxLive` widgets are live, box-wide, including tap-
+///      activated ones.
+///   2. Grant, don't recompute: a widget goes live on arrival and keeps it
+///      until it is BOTH off-screen AND out of the newest-2. Nothing ever goes
+///      dead while it is on screen.
+///   3. A session open (a single `arriving` id) activates only the newest —
+///      one web content process on open.
+///   4. A memory warning drops the whole set to zero — that is a store action
+///      (the store clears `live` out-of-band), not this function.
+///
+/// `existing` (ordered, oldest first) and `onScreen` are pure inputs; the
+/// function neither stores nor derives liveness from the cell. The single
+/// entry point the store funnels every mutation through, so the cap and the
+/// screen protection cannot be bypassed by a call site.
+enum WidgetLiveWindow {
+    static let maxLive = 2
+
+    static func resolve(existing: [String], arriving: String?, onScreen: Set<String>) -> [String] {
+        var live = existing
+        // Rule 2 + 3 grant: a single arriving widget goes live (the newest).
+        if let arriving, !arriving.isEmpty, !live.contains(arriving) {
+            live.append(arriving)
+        }
+        // Rule 1 builds the cap out of rule 2's eviction test: keep the newest
+        // `maxLive` (they are live because they are new), plus anything on
+        // screen (rule 2's "never torn out from under a finger" — the only
+        // thing that may hold the set above the cap). Evict the rest, oldest
+        // first, preserving arrival order.
+        let newestLive = Set(live.suffix(maxLive))
+        return live.filter { newestLive.contains($0) || onScreen.contains($0) }
+    }
+}
+
+// MARK: - Reserved box (pure)
+
+/// The canonical display height of a widget's reserved box, derived from the
+/// _declared_ width/height/aspectRatio in the bus payload — never from
+/// measured content, and never via a resize message. Every state (live,
+/// snapshot, placeholder, stopped) occupies this SAME box so nothing reflows
+/// when a widget activates, dies or restores. `availableWidth` is the row
+/// width before the `maxWidth` cap (the `--inline-max-w` token) is applied.
+enum WidgetMetrics {
+    /// A pragmatic floor/fallback when a widget declares none of the height
+    /// dimensions (keeps a placeholder from collapsing to a hairline).
+    static let defaultHeight: CGFloat = 120
+
+    static func height(ref: WidgetRef, availableWidth: CGFloat, maxWidth: CGFloat) -> CGFloat {
+        let width = min(max(availableWidth, 0), maxWidth)
+        if let h = ref.height, h > 0 { return h }
+        if let ratio = ref.aspectRatio, ratio > 0 { return width / ratio }
+        if let w = ref.width, w > 0 { return w }
+        return defaultHeight
+    }
+}

--- a/mobile/native/MantaUI/WidgetWebView.swift
+++ b/mobile/native/MantaUI/WidgetWebView.swift
@@ -49,21 +49,26 @@ final class WidgetSchemeHandler: NSObject, WKURLSchemeHandler {
 
     func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
         let box = WidgetSchemeTaskBox(urlSchemeTask)
-        let requestURL = urlSchemeTask.request.url
-            ?? URL(string: "manta-widget://\(webView.tag)")!
-        guard let id = urlSchemeTask.request.url?.host, !id.isEmpty,
-              let server = serverURL,
+        guard let server = serverURL,
+              let requestURL = urlSchemeTask.request.url,
+              let id = requestURL.host, !id.isEmpty,
               let target = Self.widgetURL(server: server, id: id) else {
-            deliver(
-                .failure(MantaError.transport("bad widget request")),
-                url: requestURL,
-                box: box
-            )
+            fail(urlSchemeTask, box: box)
             return
         }
         Task { @MainActor in
             let result = await Self.fetch(target)
             self.deliver(result, url: requestURL, box: box)
+        }
+    }
+
+    /// Fail a malformed scheme request without fabricating a URL (the request
+    /// against the __box__ is what needs the real id; a bad one just errors).
+    private func fail(_ task: WKURLSchemeTask, box: WidgetSchemeTaskBox) {
+        if let url = task.request.url {
+            deliver(.failure(MantaError.transport("bad widget request")), url: url, box: box)
+        } else {
+            box.task.didFailWithError(self.boxed(MantaError.transport("bad widget request")))
         }
     }
 
@@ -144,7 +149,7 @@ final class WidgetWebViewController: UIViewController {
     /// content process dies. Nil on read-only surfaces where nothing should
     /// mutate shared live state.
     let liveStore: WidgetLiveStore?
-    private(set) var webView: WKWebView!
+    private(set) var webView: WKWebView?
     /// Inline (transcript) webviews disable their own scrolling so they never
     /// fight the transcript's pan; the expand sheet is the one place a widget
     /// scrolls, and re-creates its controller with `scrollEnabled = true`.
@@ -184,7 +189,7 @@ final class WidgetWebViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         if let url = URL(string: "manta-widget://\(ref.id)") {
-            webView.load(URLRequest(url: url))
+            webView?.load(URLRequest(url: url))
         }
     }
 

--- a/mobile/native/MantaUI/WidgetWebView.swift
+++ b/mobile/native/MantaUI/WidgetWebView.swift
@@ -1,0 +1,320 @@
+import SwiftUI
+import WebKit
+import UIKit
+
+// ===========================================================================
+// WidgetWebView.swift — the widget webview + its hardened configuration.
+//
+// The app's ONLY other WKWebView (`TerminalWebView`) is a TRUSTED-content
+// webview and is deliberately NOT a template here: a widget is UNTRUSTED,
+// model-authored HTML, so its webview gets its own configuration with no
+// script-message handlers, a navigation policy gate, an assigned UI delegate,
+// a non-persistent data store and no access to the terminal's shared store.
+//
+// The widget loads from `manta-widget://<id>` via a WKURLSchemeHandler — NOT
+// `loadHTMLString` (which would not carry the response's CSP header) and NOT
+// `loadFileURL` (a file:// origin would grant local read access). The scheme
+// handler fetches the widget's bytes from the box's auth-exempt
+// `GET /widgets/<id>` and returns them as an HTTPURLResponse carrying the
+// box's Content-Security-Policy header through unchanged — the SAME policy
+// that applies on the desktop client.
+//
+// The box token never goes near this webview: no URL query, no header. A
+// widget's own scripts can read `document.location`; nothing authenticating
+// the user is ever placed where they could reach it.
+// ===========================================================================
+
+/// WKURLSchemeTask is a main-thread-bound class that the compiler does not
+/// treat as Sendable. The URLSession fetch completes off-main, so this thin
+/// box lets the task cross to the fetch's completion handler. It wraps a
+/// main-thread-only object and is touched ONLY on the main actor (every
+/// mutating call lands inside a `MainActor.run`), so the `@unchecked
+/// Sendable` claim is sound.
+private final class WidgetSchemeTaskBox: @unchecked Sendable {
+    let task: WKURLSchemeTask
+    init(_ task: WKURLSchemeTask) { self.task = task }
+}
+
+/// Serves `manta-widget://<id>` by fetching `GET <server>/widgets/<id>`
+/// (auth-exempt by design — an iframe/webview cannot send an Authorization
+/// header, and the id is 256 bits of unguessable entropy) and replaying the
+/// bytes with the box's CSP header preserved.
+@MainActor
+final class WidgetSchemeHandler: NSObject, WKURLSchemeHandler {
+    let serverURL: URL?
+
+    init(serverURL: URL?) {
+        self.serverURL = serverURL
+    }
+
+    func webView(_ webView: WKWebView, start urlSchemeTask: WKURLSchemeTask) {
+        let box = WidgetSchemeTaskBox(urlSchemeTask)
+        let requestURL = urlSchemeTask.request.url
+            ?? URL(string: "manta-widget://\(webView.tag)")!
+        guard let id = urlSchemeTask.request.url?.host, !id.isEmpty,
+              let server = serverURL,
+              let target = Self.widgetURL(server: server, id: id) else {
+            deliver(
+                .failure(MantaError.transport("bad widget request")),
+                url: requestURL,
+                box: box
+            )
+            return
+        }
+        Task { @MainActor in
+            let result = await Self.fetch(target)
+            self.deliver(result, url: requestURL, box: box)
+        }
+    }
+
+    func webView(_ webView: WKWebView, stop urlSchemeTask: WKURLSchemeTask) {
+        // A one-shot fetch; there is nothing to cancel on stop.
+    }
+
+    /// The auth-exempt box URL for a widget id, used both to fetch the HTML
+    /// and (as a fallback when the payload carried no `url`) as the served URL.
+    static func widgetURL(server: URL?, id: String) -> URL? {
+        guard let server else { return nil }
+        var comps = URLComponents(url: server, resolvingAgainstBaseURL: false)
+        comps?.path = "/widgets/\(id)"
+        comps?.query = nil
+        return comps?.url
+    }
+
+    private static func fetch(_ url: URL) async -> Result<(Data, Int, String?), Error> {
+        var request = URLRequest(url: url)
+        request.timeoutInterval = 20
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            let http = response as? HTTPURLResponse
+            let csp = http?.value(forHTTPHeaderField: "Content-Security-Policy")
+            return .success((data, http?.statusCode ?? 200, csp))
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    /// Replay the fetch onto the scheme task on the main actor. The CSP header
+    /// from the box passes through UNCHANGED — that is what applies the same
+    /// sandbox policy on both clients.
+    private func deliver(_ result: Result<(Data, Int, String?), Error>, url: URL, box: WidgetSchemeTaskBox) {
+        switch result {
+        case .failure(let error):
+            box.task.didFailWithError(self.boxed(error))
+        case .success(let (data, statusCode, csp)):
+            var headers: [String: String] = [:]
+            headers["Content-Type"] = "text/html; charset=utf-8"
+            if let csp, !csp.isEmpty {
+                headers["Content-Security-Policy"] = csp
+            }
+            guard let response = HTTPURLResponse(
+                url: url,
+                statusCode: statusCode,
+                httpVersion: nil,
+                headerFields: headers
+            ) else {
+                box.task.didFailWithError(self.boxed(MantaError.transport("widget response")))
+                return
+            }
+            box.task.didReceive(response)
+            box.task.didReceive(data)
+            box.task.didFinish()
+        }
+    }
+
+    private func boxed(_ error: Error) -> NSError {
+        if case MantaError.server(let message) = error {
+            return NSError(domain: "manta.widget", code: 1, userInfo: [NSLocalizedDescriptionKey: message])
+        }
+        return error as NSError
+    }
+}
+
+// MARK: - The widget host controller
+
+/// Owns a single widget WKWebView with the hardened, untrusted-content
+/// configuration. Lifecycle: created when the widget goes live, loaded from
+/// `manta-widget://<id>`, and (for the inline card) reports process-termination
+/// back to the live store so the card can fall back to the labelled `stopped`
+/// state instead of a blank white rectangle.
+@MainActor
+final class WidgetWebViewController: UIViewController {
+    let ref: WidgetRef
+    /// The box-wide live store, used to mark the widget `stopped` when the web
+    /// content process dies. Nil on read-only surfaces where nothing should
+    /// mutate shared live state.
+    let liveStore: WidgetLiveStore?
+    private(set) var webView: WKWebView!
+    /// Inline (transcript) webviews disable their own scrolling so they never
+    /// fight the transcript's pan; the expand sheet is the one place a widget
+    /// scrolls, and re-creates its controller with `scrollEnabled = true`.
+    private let scrollEnabled: Bool
+
+    init(ref: WidgetRef, liveStore: WidgetLiveStore?, scrollEnabled: Bool = false) {
+        self.ref = ref
+        self.liveStore = liveStore
+        self.scrollEnabled = scrollEnabled
+        super.init(nibName: nil, bundle: nil)
+    }
+
+    required init?(coder: NSCoder) { fatalError("not used") }
+
+    override func loadView() {
+        let config = WKWebViewConfiguration()
+        // Never the default persistent store, never shared with the terminal.
+        config.websiteDataStore = .nonPersistent()
+        config.setURLSchemeHandler(
+            WidgetSchemeHandler(serverURL: KeychainCredentialStore.shared.serverURL),
+            forURLScheme: "manta-widget"
+        )
+        // Deliberately NO WKUserContentController: every script-message handler
+        // is a hole in the boundary, and this design needs none (height comes
+        // from the declared dimensions, not from JS).
+
+        let webView = WKWebView(frame: .zero, configuration: config)
+        webView.navigationDelegate = self
+        webView.uiDelegate = self
+        webView.scrollView.isScrollEnabled = scrollEnabled
+        webView.isOpaque = false
+        webView.backgroundColor = .clear
+        self.webView = webView
+        view = webView
+    }
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        if let url = URL(string: "manta-widget://\(ref.id)") {
+            webView.load(URLRequest(url: url))
+        }
+    }
+
+    override func viewDidDisappear(_ animated: Bool) {
+        super.viewDidDisappear(animated)
+        // The widget is going dormant (evicted / scrolled out). Capture its
+        // rendered bitmap at this moment so the card can show the labelled
+        // `snapshot` state instead of leaving a live webview around. Inline
+        // webviews only — the expand sheet's full-screen copy must not
+        // overwrite the inline snapshot when it dismisses.
+        guard !scrollEnabled else { return }
+        captureSnapshot { [weak self] image in
+            self?.liveStore?.captureSnapshot(id: self?.ref.id ?? "", image: image)
+        }
+    }
+
+    /// Capture the webview's rendered bitmap (dormancy). Best-effort: if the
+    /// capture fails or the process already died, the caller falls back to the
+    /// placeholder state (the documented behaviour).
+    func captureSnapshot(_ completion: @escaping (UIImage) -> Void) {
+        webView?.takeSnapshot(with: nil) { image, _ in
+            if let image { completion(image) }
+        }
+    }
+}
+
+// MARK: - Navigation policy gate
+
+extension WidgetWebViewController: WKNavigationDelegate {
+    func webView(
+        _ webView: WKWebView,
+        decidePolicyFor navigationAction: WKNavigationAction,
+        decisionHandler: @escaping (WKNavigationActionPolicy) -> Void
+    ) {
+        // Allow only the initial `manta-widget://` load; `.cancel` every
+        // subsequent navigation so the widget can never replace itself (or
+        // navigate the frame) with a page of its choosing.
+        if navigationAction.request.url?.scheme == "manta-widget",
+           navigationAction.navigationType == .other {
+            decisionHandler(.allow)
+        } else {
+            decisionHandler(.cancel)
+        }
+    }
+
+    func webViewWebContentProcessDidTerminate(_ webView: WKWebView) {
+        // The DEFAULT failure is a blank white rectangle (the most common way
+        // embedded webviews look broken). Fall back to the labelled `stopped`
+        // state instead — never leave a blank box on screen.
+        liveStore?.markStopped(ref.id)
+    }
+}
+
+// MARK: - UI delegate (deny modal chrome + window.open)
+
+extension WidgetWebViewController: WKUIDelegate {
+    func webView(
+        _ webView: WKWebView,
+        createWebViewWith configuration: WKWebViewConfiguration,
+        for navigationAction: WKNavigationAction,
+        windowFeatures: WKWindowFeatures
+    ) -> WKWebView? {
+        nil // deny window.open
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptAlertPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable () -> Void
+    ) {
+        completionHandler() // dismiss / no-op — no native-looking modal
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptConfirmPanelWithMessage message: String,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable (Bool) -> Void
+    ) {
+        completionHandler(false)
+    }
+
+    func webView(
+        _ webView: WKWebView,
+        runJavaScriptTextInputPanelWithPrompt prompt: String,
+        defaultText: String?,
+        initiatedByFrame frame: WKFrameInfo,
+        completionHandler: @escaping @MainActor @Sendable (String?) -> Void
+    ) {
+        completionHandler(nil)
+    }
+}
+
+// MARK: - SwiftUI representable
+
+/// Hosts an inline (live) widget webview. `onReady` hands back the underlying
+/// controller so the card can capture a snapshot at the moment of eviction.
+struct WidgetLiveWebView: UIViewControllerRepresentable {
+    let ref: WidgetRef
+    let liveStore: WidgetLiveStore?
+    let onReady: (WidgetWebViewController) -> Void
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onReady: onReady)
+    }
+
+    func makeUIViewController(context: Context) -> WidgetWebViewController {
+        let controller = WidgetWebViewController(ref: ref, liveStore: liveStore)
+        context.coordinator.onReady(controller)
+        return controller
+    }
+
+    func updateUIViewController(_ uiViewController: WidgetWebViewController, context: Context) {}
+
+    final class Coordinator {
+        let onReady: (WidgetWebViewController) -> Void
+        init(onReady: @escaping (WidgetWebViewController) -> Void) { self.onReady = onReady }
+    }
+}
+
+/// The expand-sheet webview — the ONE place a widget scrolls. Same hardened
+/// configuration, but with scrolling enabled and sized to fill the sheet.
+struct WidgetExpandWebView: UIViewControllerRepresentable {
+    let ref: WidgetRef
+    let liveStore: WidgetLiveStore?
+
+    func makeUIViewController(context: Context) -> WidgetWebViewController {
+        WidgetWebViewController(ref: ref, liveStore: liveStore, scrollEnabled: true)
+    }
+
+    func updateUIViewController(_ uiViewController: WidgetWebViewController, context: Context) {}
+}

--- a/mobile/native/MantaUITests/WidgetModelsTests.swift
+++ b/mobile/native/MantaUITests/WidgetModelsTests.swift
@@ -1,0 +1,189 @@
+import XCTest
+@testable import MantaUI
+
+// BET-1326 — the pure widget logic: the live-window eviction decision, the
+// reserved-box sizing, and the side-channel merge of widget refs into the
+// transcript. Pure/derivable logic only, per the repo convention (no UI, no
+// webview here — those live in MantaUI but are not unit-tested through).
+
+final class WidgetLiveWindowTests: XCTestCase {
+
+    // MARK: - Rule 1: cap at 2 (absolute, incl. tap-activated)
+
+    func testCapAtTwoWhenNothingOnScreen() {
+        var live = WidgetLiveWindow.resolve(existing: [], arriving: "a", onScreen: [])
+        XCTAssertEqual(live, ["a"])
+        live = WidgetLiveWindow.resolve(existing: live, arriving: "b", onScreen: [])
+        XCTAssertEqual(live, ["a", "b"])
+        // A third arrival evicts the OLDEST (a), keeping only the newest-2.
+        live = WidgetLiveWindow.resolve(existing: live, arriving: "c", onScreen: [])
+        XCTAssertEqual(live, ["b", "c"])
+        XCTAssertEqual(live.count, WidgetLiveWindow.maxLive)
+    }
+
+    /// A tap-activated widget counts against the cap exactly like an arrival.
+    func testTapActivationCountsAgainstCap() {
+        // Two live already (nothing on screen). Tapping a third promotes it and
+        // evicts the oldest.
+        let live = WidgetLiveWindow.resolve(existing: ["a", "b"], arriving: "c", onScreen: [])
+        XCTAssertEqual(live, ["b", "c"])
+    }
+
+    // MARK: - Rule 2: grant, don't recompute — nothing goes dead on screen
+
+    /// An on-screen widget that is out of the newest-2 STAYS live; only when it
+    /// also scrolls off-screen is it evicted.
+    func testOnScreenWidgetOutOfNewestTwoStaysLive() {
+        // Three were live at some point (a matured out of newest-2 but a third
+        // came in), yet `a` is still on screen → keep it.
+        let live = WidgetLiveWindow.resolve(existing: ["a", "b", "c"], arriving: nil, onScreen: ["a"])
+        XCTAssertEqual(live, ["a", "b", "c"])
+    }
+
+    /// The very moment the on-screen widget ALSO scrolls off, it is (finally)
+    /// evicted: eviction requires BOTH off-screen AND out of the newest-2.
+    func testOffScreenOutOfNewestTwoIsEvicted() {
+        let live = WidgetLiveWindow.resolve(existing: ["a", "b", "c"], arriving: nil, onScreen: [])
+        XCTAssertEqual(live, ["b", "c"])
+        XCTAssertFalse(live.contains("a"))
+    }
+
+    /// Re-resolving with the same inputs is a no-op — the window never flaps a
+    /// live widget in and out on a scroll by itself.
+    func testResolveIsStableUnderRepeatedCalls() {
+        let a = WidgetLiveWindow.resolve(existing: ["a", "b"], arriving: nil, onScreen: ["a"])
+        let b = WidgetLiveWindow.resolve(existing: ["a", "b"], arriving: nil, onScreen: ["a"])
+        XCTAssertEqual(a, b)
+    }
+
+    /// The screen-protection rule is the ONLY thing that may hold the set above
+    /// the cap (three widgets genuinely on screen: all three stay live, nothing
+    /// is torn out from under the finger).
+    func testScreenProtectionMayHoldAboveCap() {
+        let live = WidgetLiveWindow.resolve(existing: ["a", "b", "c"], arriving: nil, onScreen: ["a", "b", "c"])
+        XCTAssertEqual(live, ["a", "b", "c"])
+    }
+
+    // MARK: - Rule 3: session open activates only the newest
+
+    /// Opening a session with several dormant (on-screen, not live) widgets
+    /// activates ONLY the single arriving (newest) widget — one web content
+    /// process on open, not everything in the viewport.
+    func testSessionOpenActivatesOnlyNewest() {
+        let live = WidgetLiveWindow.resolve(existing: [], arriving: "newest", onScreen: ["old1", "old2"])
+        XCTAssertEqual(live, ["newest"])
+    }
+
+    // MARK: - Re-arrival / dedup / guards
+
+    func testReannouncingAlreadyLiveWidgetIsNoOp() {
+        let live = WidgetLiveWindow.resolve(existing: ["a"], arriving: "a", onScreen: [])
+        XCTAssertEqual(live, ["a"])
+    }
+
+    func testEmptyArrivingIsIgnored() {
+        let live = WidgetLiveWindow.resolve(existing: ["a"], arriving: "", onScreen: [])
+        XCTAssertEqual(live, ["a"])
+    }
+}
+
+final class WidgetMetricsTests: XCTestCase {
+
+    private func ref(height: Double? = nil, width: Double? = nil, ratio: Double? = nil) -> WidgetRef {
+        WidgetRef(id: "w", url: nil, title: nil, width: width, height: height,
+                  aspectRatio: ratio, sessionId: "s", messageId: "m")
+    }
+
+    func testDeclaredHeightWins() {
+        XCTAssertEqual(WidgetMetrics.height(ref: ref(height: 196, width: 300, ratio: 2), availableWidth: 320, maxWidth: 520), 196)
+    }
+
+    func testAspectRatioDerivesHeightFromWidth() {
+        XCTAssertEqual(WidgetMetrics.height(ref: ref(ratio: 2), availableWidth: 400, maxWidth: 520), 200)
+    }
+
+    func testWidthCappedBeforeAspectDerivation() {
+        XCTAssertEqual(WidgetMetrics.height(ref: ref(ratio: 2), availableWidth: 800, maxWidth: 520), 260)
+    }
+
+    func testDeclaredWidthFallsBackToSquare() {
+        XCTAssertEqual(WidgetMetrics.height(ref: ref(width: 300), availableWidth: 320, maxWidth: 520), 300)
+    }
+
+    func testNoDimensionsFallsBackToDefault() {
+        XCTAssertEqual(WidgetMetrics.height(ref: ref(), availableWidth: 320, maxWidth: 520), WidgetMetrics.defaultHeight)
+    }
+
+    func testNegativeAvailableWidthClamps() {
+        XCTAssertEqual(WidgetMetrics.height(ref: ref(ratio: 2), availableWidth: -10, maxWidth: 520), 0)
+    }
+}
+
+// MARK: - Side-channel merge into the transcript
+
+final class WidgetMapperMergeTests: XCTestCase {
+
+    private func textPart(_ id: String, _ messageID: String, _ text: String) -> OpencodePart {
+        OpencodePart(type: "text", id: id, messageID: messageID, text: text)
+    }
+
+    private func message(id: String, role: String, parts: [OpencodePart], completed: Bool = true) -> OpencodeMessage {
+        OpencodeMessage(
+            info: OpencodeMessageInfo(
+                id: id,
+                sessionID: "ses",
+                role: OpencodeRole(rawValue: role),
+                time: OpencodeTime(created: 0, completed: completed ? 1 : nil),
+                modelID: nil,
+                providerID: nil
+            ),
+            parts: parts
+        )
+    }
+
+    private func widget(id: String, messageId: String) -> WidgetRef {
+        WidgetRef(id: id, url: nil, title: "Revenue by quarter", width: 520, height: 196,
+                  aspectRatio: nil, sessionId: "ses", messageId: messageId)
+    }
+
+    /// A widget claimed onto its assistant message renders as a `.file(.widget)`
+    /// block right after that message's prose.
+    func testWidgetAttachesToItsAssistantMessage() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [textPart("p1", "m1", "Here's the chart.")])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs, voiceNotes: [], widgets: [widget(id: "w1", messageId: "m1")])
+        XCTAssertEqual(blocks.count, 2)
+        guard case .file(let attachment) = blocks[1], case .widget(let ref) = attachment.kind else {
+            return XCTFail("expected a .widget attachment block, got \(blocks[1])")
+        }
+        XCTAssertEqual(ref.id, "w1")
+    }
+
+    /// A widget whose message is outside the loaded window is dropped (it has
+    /// no claim of its own) — matching the voice-note behaviour.
+    func testWidgetForOutsideWindowIsDropped() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [textPart("p1", "m1", "Hello")])]
+        let blocks = ChatTranscriptMapper.blocks(from: msgs, voiceNotes: [], widgets: [widget(id: "w9", messageId: "absent-msg")])
+        XCTAssertEqual(blocks.count, 1) // only the prose
+    }
+
+    /// The no-side-channel call keeps working unchanged.
+    func testNoWidgetsIsSameAsEmptyCollection() {
+        let msgs = [message(id: "m1", role: "assistant", parts: [textPart("p1", "m1", "Hello")])]
+        XCTAssertEqual(
+            ChatTranscriptMapper.blocks(from: msgs),
+            ChatTranscriptMapper.blocks(from: msgs, voiceNotes: [], widgets: [])
+        )
+    }
+
+    /// buildWidgetMap groups widgets by message id.
+    func testBuildWidgetMapGroupsByMessageId() {
+        let map = ChatTranscriptMapper.buildWidgetMap([
+            widget(id: "w1", messageId: "m1"),
+            widget(id: "w2", messageId: "m1"),
+            widget(id: "w3", messageId: "m2"),
+        ])
+        XCTAssertEqual(map["m1"]?.count, 2)
+        XCTAssertEqual(map["m2"]?.count, 1)
+        XCTAssertEqual(map["absent"], nil)
+    }
+}

--- a/scripts/gen-swift-tokens.mjs
+++ b/scripts/gen-swift-tokens.mjs
@@ -108,6 +108,10 @@ const LAYOUT_MAP = {
   listRowMinH: "list-row-min-h", listRowRadius: "list-row-radius",
   listRowMargin: "list-row-margin",
   listGroupAbove: "list-group-above", listGroupBelow: "list-group-below",
+  // Inline embed width cap + dormant opacity (widgets epic). Cross-consumer:
+  // the reading-width cap bounds inline media/widgets; the opacity dims a
+  // dormant widget's captured snapshot on BOTH clients identically.
+  inlineMaxW: "inline-max-w", widgetDormantOpacity: "widget-dormant-opacity",
 };
 
 // CSS allows a leading-dot decimal (".035"); Swift requires a leading zero

--- a/scripts/gen-swift-tokens.test.mjs
+++ b/scripts/gen-swift-tokens.test.mjs
@@ -43,6 +43,10 @@ const ROOT_VARIABLES = [
   // test fixture.
   ["font-size-chat-title", "14.5px"], ["tracking-chat-title", "-0.01"],
   ["chat-header-btn", "38px"],
+  // Inline embed + widget tokens (widgets epic, BET-1326) — must track
+  // gen-swift-tokens.mjs LAYOUT_MAP so the widened generator's lookups resolve
+  // in the test fixture.
+  ["inline-max-w", "520px"], ["widget-dormant-opacity", "0.5"],
 ];
 
 function cssFor(prefix) {


### PR DESCRIPTION
Opened automatically for `agent/macos/8d81400db791`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1326.