### PR TITLE
iOS: quote a transcript block into the composer (Quote / Quote in new session) (BET-1353)

### DIFF
--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -448,8 +448,6 @@ private struct ChatScreenContent: View {
                         store: store,
                         modelStore: modelStore,
                         usageStore: usageStore,
-                        text: $composerText,
-                        inputFocused: $composerFocused,
                         onShowUsage: { showUsageSheet = true },
                         showScrollToBottom: showScrollToBottom,
                         onScrollToBottom: {
@@ -461,7 +459,9 @@ private struct ChatScreenContent: View {
                         onSlashClear: { Task { await clearSession() } },
                         onSlashFork: { Task { await forkSession() } },
                         historyTmuxSession: sessionWindow?.name,
-                        historyWindowIndex: sessionWindow?.index
+                        historyWindowIndex: sessionWindow?.index,
+                        text: $composerText,
+                        inputFocused: $composerFocused
                     )
                 }
                 // Feeds the transcript's bottom content inset its height. Safe

--- a/mobile/native/MantaUI/ChatScreen.swift
+++ b/mobile/native/MantaUI/ChatScreen.swift
@@ -109,6 +109,9 @@ struct ChatScreen: View {
     @ObservedObject var eventStore: MantaEventStore
     @Binding var path: NavigationPath
     @State private var currentSessionId: String?
+    /// "Quote in new session" composer seed, forwarded to the content screen
+    /// (BET-1353). Empty for every normal open.
+    let seed: String?
 
     var body: some View {
         let sid = currentSessionId ?? sessionId
@@ -118,7 +121,8 @@ struct ChatScreen: View {
             projectName: projectName,
             eventStore: eventStore,
             path: $path,
-            onCleared: { newId in currentSessionId = newId }
+            onCleared: { newId in currentSessionId = newId },
+            seed: seed ?? ""
         )
         .id(sid)
     }
@@ -203,6 +207,17 @@ private struct ChatScreenContent: View {
     /// above the glass box and must stay undimmed).
     @State private var composerGlassHeight: CGFloat = 0
 
+    /// The composer draft, owned HERE so quote actions (which live on the
+    /// transcript, outside ComposerView) can prepend to it, and passed down to
+    /// ComposerView as a binding (BET-1353). Seeded from `seed` when this
+    /// screen opens a "quote in new session" fork.
+    @State private var composerText = ""
+
+    /// Focus for the composer field. Lifter to this level (from ComposerView's
+    /// internal `@FocusState`) so a quote action can focus the composer after
+    /// prepending (BET-1353).
+    @FocusState private var composerFocused: Bool
+
     /// How far the under-composer scrim reaches past the safe area, so content
     /// scrolling into the home-indicator strip stays dimmed too.
     private static let scrimOverhang: CGFloat = 44
@@ -213,12 +228,15 @@ private struct ChatScreenContent: View {
     /// stores and used by the plan card to build the deterministic plan-page URL.
     private let api: MantaAPIClient
 
-    init(sessionId: String, title: String, projectName: String, eventStore: MantaEventStore, path: Binding<NavigationPath>, onCleared: @escaping (String) -> Void) {
+    init(sessionId: String, title: String, projectName: String, eventStore: MantaEventStore, path: Binding<NavigationPath>, onCleared: @escaping (String) -> Void, seed: String = "") {
         self.title = title
         self.projectName = projectName
         self.eventStore = eventStore
         self._path = path
         self.onCleared = onCleared
+        // Seed the composer draft for a "quote in new session" fork (BET-1353);
+        // empty for every normal open, which leaves the draft empty.
+        _composerText = State(initialValue: seed)
         let api = MantaAPIClient.live()
         self.api = api
         _store = StateObject(wrappedValue: ChatSessionStore(
@@ -430,6 +448,8 @@ private struct ChatScreenContent: View {
                         store: store,
                         modelStore: modelStore,
                         usageStore: usageStore,
+                        text: $composerText,
+                        inputFocused: $composerFocused,
                         onShowUsage: { showUsageSheet = true },
                         showScrollToBottom: showScrollToBottom,
                         onScrollToBottom: {
@@ -698,7 +718,10 @@ private struct ChatScreenContent: View {
         await MainActor.run { onCleared(newId) }
     }
 
-    private func forkSession() async {
+    /// Fork this session into a fresh window and open the fork. `seed`, when
+    /// present ("Quote in new session", BET-1353), is the composer draft the
+    /// fork opens with — carried across the route via `SessionOpenTarget.seed`.
+    private func forkSession(seed: String? = nil) async {
         guard let w = sessionWindow else {
             store.actionHint = "Can't fork — session's window not found. Go back and reopen from the list."
             return
@@ -721,7 +744,24 @@ private struct ChatScreenContent: View {
         // present, so it opens the forked chat). The original stays one pop
         // back. windowIndex is not used when sessionId is set.
         await MainActor.run {
-            path.append(SessionOpenTarget(project: projectName, windowIndex: w.index, name: "\(title) fork", sessionId: newSessionId))
+            path.append(SessionOpenTarget(project: projectName, windowIndex: w.index, name: "\(title) fork", sessionId: newSessionId, seed: seed))
+        }
+    }
+
+    /// The single quote path (BET-1353): "Quote" prepends the built blockquote
+    /// to THIS session's composer; "Quote in new session" seeds a fork's
+    /// composer and opens it. Both run through `QuoteText.buildQuoteBlock`, so
+    /// whatever lands in the composer is exactly the sent form.
+    private func quote(_ selection: String, into destination: QuoteDestination) async {
+        guard let block = QuoteText.buildQuoteBlock(selection) else { return }
+        switch destination {
+        case .thisSession:
+            await MainActor.run {
+                composerText = block + composerText
+                composerFocused = true
+            }
+        case .newSession:
+            await forkSession(seed: block)
         }
     }
 
@@ -1068,7 +1108,10 @@ private struct ChatScreenContent: View {
             onKeepPlanning: { question, feedback in
                 store.keepPlanning(question: question, feedback: feedback)
             },
-            onOpenPage: { openPlanPage() }
+            onOpenPage: { openPlanPage() },
+            onQuote: { selection, destination in
+                Task { await quote(selection, into: destination) }
+            }
         )
     }
 

--- a/mobile/native/MantaUI/ComposerView.swift
+++ b/mobile/native/MantaUI/ComposerView.swift
@@ -96,7 +96,13 @@ struct ComposerView: View {
     /// the held→locked transition instead of cutting or stacking (BET-1089).
     @Namespace private var composerGlass
 
-    @State private var text = ""
+    /// The composer draft (BET-1353). Promoted from `@State` to a `@Binding`
+    /// so the quote actions — which live on the transcript, in ChatScreen —
+    /// can PREPEND a blockquote to whatever is already here. Storage moved up
+    /// to ChatScreen's single `composerText`; every existing writer of `text`
+    /// inside this view (keyboard `@`/`/`, voice, caret insert, history,
+    /// submit, file select, slash) writes through the binding unchanged.
+    @Binding var text: String
     @State private var attachments: [ComposerAttachment] = []
     @State private var showPhotoPicker = false
     @State private var showDocPicker = false
@@ -110,7 +116,11 @@ struct ComposerView: View {
     @State private var micTranslation: CGSize = .zero
     @State private var hint: String?
     @State private var showHint = false
-    @FocusState private var inputFocused: Bool
+    /// The composer field's focus (BET-1353). Promoted from `@FocusState` to a
+    /// `FocusState.Binding` owned by ChatScreen so the quote actions can focus
+    /// the composer after prepending a blockquote; reading it here stays legal
+    /// (a `FocusState.Binding.wrappedValue` is a live Bool).
+    var inputFocused: FocusState<Bool>.Binding
     @StateObject private var recorder = VoiceRecorder()
     /// The transient composer-state row for a voice take: shown while it
     /// uploads + transcribes, and kept (in place of discarding the recording)
@@ -489,7 +499,7 @@ struct ComposerView: View {
     /// disagree with the keyboard.
     @ViewBuilder
     private var keyboardBarRow: some View {
-        if inputFocused {
+        if inputFocused.wrappedValue {
             HStack(spacing: Metrics.spacing.sp2) {
                 keyboardBarKey("↑", identifier: "kb-up") { historyUp() }
                 keyboardBarKey("↓", identifier: "kb-down") { historyDown() }
@@ -666,7 +676,7 @@ struct ComposerView: View {
                 .frame(minHeight: lineHeight + Metrics.spacing.sp2,
                        maxHeight: lineHeight * 6)
                 .fixedSize(horizontal: false, vertical: true)
-                .focused($inputFocused)
+                .focused(inputFocused)
                 .accessibilityIdentifier("composer-input")
                 // `onGeometryChange` rather than a PreferenceKey +
                 // `onPreferenceChange`: under Swift 6 that pair reports the
@@ -1325,7 +1335,7 @@ struct ComposerView: View {
         // later — long enough for the box to sit stacked and empty after a
         // send, which reads as the composer being stuck.
         withAnimation(.smooth(duration: 0.22)) { isTall = false }
-        inputFocused = true
+        inputFocused.wrappedValue = true
     }
 
     // MARK: - @-file typeahead + / slash palette (BET-749 gap #10)
@@ -1467,7 +1477,7 @@ struct ComposerView: View {
         activeMention = nil
         fileResults = []
         fileSearchTask?.cancel()
-        inputFocused = true
+        inputFocused.wrappedValue = true
     }
 
     /// Perform a `/` palette selection: route to the corresponding existing
@@ -1490,7 +1500,7 @@ struct ComposerView: View {
         activeMention = nil
         fileResults = []
         fileSearchTask?.cancel()
-        inputFocused = true
+        inputFocused.wrappedValue = true
     }
 
     // MARK: - Mic availability (Groq key gate)

--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -125,7 +125,7 @@ struct SessionListView: View {
             .overlay(alignment: .top) { errorBanner }
             .navigationDestination(for: SessionOpenTarget.self) { target in
                 if let sessionId = target.sessionId, !sessionId.isEmpty {
-                    ChatScreen(sessionId: sessionId, title: target.name, projectName: target.project, eventStore: eventStore, path: $path)
+                    ChatScreen(sessionId: sessionId, title: target.name, projectName: target.project, eventStore: eventStore, path: $path, seed: target.seed ?? "")
                 } else if let project = store.projects.first(where: { $0.tmuxSession == target.project }),
                           let window = project.windows.first(where: { $0.index == target.windowIndex }) {
                     // S6 (BET-598): a non-chat window opens the native
@@ -964,6 +964,11 @@ struct SessionOpenTarget: Hashable {
     let windowIndex: Int
     let name: String
     let sessionId: String?
+    /// "Quote in new session" fork composer seed (BET-1353). Deliberately NOT
+    /// part of identity: two pushes to the same session are the same
+    /// destination regardless of seed (a seed only ever travels with a fresh
+    /// fork, which already has its own sessionId).
+    var seed: String? = nil
 
     static func == (lhs: SessionOpenTarget, rhs: SessionOpenTarget) -> Bool {
         lhs.project == rhs.project && lhs.windowIndex == rhs.windowIndex && lhs.sessionId == rhs.sessionId

--- a/mobile/native/MantaUI/SessionModels.swift
+++ b/mobile/native/MantaUI/SessionModels.swift
@@ -600,3 +600,61 @@ enum SessionCreateFailure {
         }
     }
 }
+
+// ===========================================================================
+// Quote selection → composer (BET-1353).
+//
+// Pure Swift ports of the desktop `truncateMiddle` / `buildQuoteBlock`
+// (src/renderer/chatUtils.ts, BET-1351), with a narrower phone-composer
+// budget. A selection is normalised into ONE middle-truncated blockquote line
+// (`"> …\n\n"`) that gets PREPENDED to whatever is already in the composer.
+// There is deliberately no hidden payload / chip / extra composer state: the
+// model already holds the full transcript in its context, so the quote only
+// has to be a locatable pointer. Collapsing to a single line also kills the
+// class of bug where a selection spanning several rendered blocks serialises
+// without its newlines.
+// ===========================================================================
+
+/// Where a quote should land (BET-1353).
+enum QuoteDestination {
+    /// Quote into THIS session's composer.
+    case thisSession
+    /// Fork this session, seed the fork's composer, and open the fork.
+    case newSession
+}
+
+/// Pure quote-building helpers, ported 1:1 from `chatUtils.ts` (BET-1351) with
+/// the phone-composer budget (`max`/`head`/`tail`).
+enum QuoteText {
+    /// Longest quoted line, in characters.
+    static let max = 160
+    /// Characters kept from the head of a quote that exceeds `max`.
+    static let head = 95
+    /// Characters kept from the tail of a quote that exceeds `max`.
+    static let tail = 55
+
+    /// "beginning … end". Returns `text` unchanged when it fits within `max`.
+    /// Counts CHARACTERS (grapheme clusters), never UTF-16 code units, so an
+    /// emoji or accented character is never split. The ellipsis is ONE U+2026
+    /// with a single space either side.
+    static func truncateMiddle(_ text: String, max: Int, head: Int, tail: Int) -> String {
+        let chars = Array(text)
+        if chars.count <= max { return text }
+        let headPart = String(chars[0..<head]).trimmingCharacters(in: .whitespacesAndNewlines)
+        let tailPart = String(chars[(chars.count - tail)...]).trimmingCharacters(in: .whitespacesAndNewlines)
+        return headPart + " \u{2026} " + tailPart
+    }
+
+    /// Selection → the exact string to prepend to the composer, or nil when the
+    /// selection has no usable text. Whitespace runs collapse to a single
+    /// space, the result is trimmed, truncated, then prefixed with `"> "` and
+    /// suffixed with a blank line (`"\n\n"`).
+    static func buildQuoteBlock(_ selection: String) -> String? {
+        let collapsed = selection
+            .replacingOccurrences(of: "\\s+", with: " ", options: .regularExpression)
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !collapsed.isEmpty else { return nil }
+        let truncated = truncateMiddle(collapsed, max: max, head: head, tail: tail)
+        return "> " + truncated + "\n\n"
+    }
+}

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -816,6 +816,17 @@ enum TranscriptBlock: Equatable {
         case .steps, .file, .notice, .queuedPrompt, .permission, .planExit, .question: return nil
         }
     }
+
+    /// The quote-able raw markdown of a user or assistant-prose block, nil for
+    /// every other block type (BET-1353). The fallback selection-menu branch
+    /// quotes the WHOLE block's text — there is no sub-selection on this
+    /// rendering stack, so this is the maximum fidelity available.
+    var quoteText: String? {
+        switch self {
+        case .user(let text, _), .prose(let text, _): return text
+        case .steps, .file, .notice, .queuedPrompt, .permission, .planExit, .question: return nil
+        }
+    }
 }
 
 /// A file/attachment reference carried by a `.file` transcript block. Only the

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -279,13 +279,6 @@ private struct TranscriptCellReveal: View {
     @MainActor
     @ViewBuilder
     private var cellContent: some View {
-        let content: some View = {
-            if case .prose(let text, nil) = item.block {
-                LiveProseTail(text: text, tokens: tokens)
-            } else {
-                transcriptBlockView(item.block, tokens: tokens, cards: cardActions, onRetry: onRetry)
-            }
-        }()
         // BET-1353 — the fallback selection branch. The MarkdownText renderer
         // exposes no hook into the system edit menu (BET-1352's finding), so
         // the two quote actions attach as a `.contextMenu` on the row, quoting
@@ -294,12 +287,27 @@ private struct TranscriptCellReveal: View {
         // no second delivery mechanism. Read-only surfaces (nil actions) and
         // non-quotable blocks (steps/file/…) get no menu.
         if let quoteText = item.block.quoteText, let actions = cardActions {
-            content.contextMenu {
-                Button("Quote") { actions.onQuote(quoteText, .thisSession) }
-                Button("Quote in new session") { actions.onQuote(quoteText, .newSession) }
-            }
+            baseContent
+                .contextMenu {
+                    Button("Quote") { actions.onQuote(quoteText, .thisSession) }
+                    Button("Quote in new session") { actions.onQuote(quoteText, .newSession) }
+                }
         } else {
-            content
+            baseContent
+        }
+    }
+
+    /// The row's ordinary content: the live streaming prose tail, or the shared
+    /// block renderer for everything else. Own @ViewBuilder so its if/else
+    /// branches unify (a bare `some View = { … }()` closure cannot — the two
+    /// branches are distinct `View` types, BET-1353).
+    @MainActor
+    @ViewBuilder
+    private var baseContent: some View {
+        if case .prose(let text, nil) = item.block {
+            LiveProseTail(text: text, tokens: tokens)
+        } else {
+            transcriptBlockView(item.block, tokens: tokens, cards: cardActions, onRetry: onRetry)
         }
     }
 }

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -141,6 +141,10 @@ final class TranscriptCardActions {
     let onBuildHere: (QuestionRequest, String) -> Void
     let onKeepPlanning: (QuestionRequest, String) -> Void
     let onOpenPage: () -> Void
+    /// Quote a transcript block into a composer destination (BET-1353). Rides
+    /// this same environment value — the fallback selection branch attaches a
+    /// `.contextMenu` to the row and calls this with the whole block's text.
+    let onQuote: (String, QuoteDestination) -> Void
 
     init(
         messages: [OpencodeMessage],
@@ -151,7 +155,8 @@ final class TranscriptCardActions {
         onQuestionReject: @escaping (QuestionRequest) -> Void,
         onBuildHere: @escaping (QuestionRequest, String) -> Void,
         onKeepPlanning: @escaping (QuestionRequest, String) -> Void,
-        onOpenPage: @escaping () -> Void
+        onOpenPage: @escaping () -> Void,
+        onQuote: @escaping (String, QuoteDestination) -> Void
     ) {
         self.messages = messages
         self.buildModelName = buildModelName
@@ -162,6 +167,7 @@ final class TranscriptCardActions {
         self.onBuildHere = onBuildHere
         self.onKeepPlanning = onKeepPlanning
         self.onOpenPage = onOpenPage
+        self.onQuote = onQuote
     }
 }
 
@@ -273,10 +279,27 @@ private struct TranscriptCellReveal: View {
     @MainActor
     @ViewBuilder
     private var cellContent: some View {
-        if case .prose(let text, nil) = item.block {
-            LiveProseTail(text: text, tokens: tokens)
+        let content: some View = {
+            if case .prose(let text, nil) = item.block {
+                LiveProseTail(text: text, tokens: tokens)
+            } else {
+                transcriptBlockView(item.block, tokens: tokens, cards: cardActions, onRetry: onRetry)
+            }
+        }()
+        // BET-1353 — the fallback selection branch. The MarkdownText renderer
+        // exposes no hook into the system edit menu (BET-1352's finding), so
+        // the two quote actions attach as a `.contextMenu` on the row, quoting
+        // the WHOLE block's text (`.user`/`.prose`) rather than a sub-selection.
+        // The callback rides the existing `transcriptCardActions` environment —
+        // no second delivery mechanism. Read-only surfaces (nil actions) and
+        // non-quotable blocks (steps/file/…) get no menu.
+        if let quoteText = item.block.quoteText, let actions = cardActions {
+            content.contextMenu {
+                Button("Quote") { actions.onQuote(quoteText, .thisSession) }
+                Button("Quote in new session") { actions.onQuote(quoteText, .newSession) }
+            }
         } else {
-            transcriptBlockView(item.block, tokens: tokens, cards: cardActions, onRetry: onRetry)
+            content
         }
     }
 }
@@ -304,7 +327,8 @@ func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: Transc
         onQuestionReject: { _ in },
         onBuildHere: { _, _ in },
         onKeepPlanning: { _, _ in },
-        onOpenPage: {}
+        onOpenPage: {},
+        onQuote: { _, _ in }
     )
     switch block {
     case .user(let text, _):

--- a/mobile/native/MantaUITests/SessionModelsTests.swift
+++ b/mobile/native/MantaUITests/SessionModelsTests.swift
@@ -853,4 +853,67 @@ final class TerminalStatusTests: XCTestCase {
         XCTAssertFalse(status.running)
         XCTAssertEqual(SessionDotState.forRow(status), .idle)
     }
+
+    // MARK: - QuoteText (BET-1353) — ports of chatUtils truncateMiddle / buildQuoteBlock
+
+    func testTruncateMiddleReturnsUnchangedAtAndBelowMax() {
+        let atMax = String(repeating: "a", count: QuoteText.max)
+        XCTAssertEqual(QuoteText.truncateMiddle(atMax, max: QuoteText.max, head: QuoteText.head, tail: QuoteText.tail), atMax)
+        XCTAssertEqual(QuoteText.truncateMiddle("short", max: QuoteText.max, head: QuoteText.head, tail: QuoteText.tail), "short")
+    }
+
+    func testTruncateMiddleProducesHeadEllipsisTailAboveMaxAndIsShorter() {
+        let text = String(repeating: "x", count: QuoteText.max + 50)
+        let out = QuoteText.truncateMiddle(text, max: QuoteText.max, head: QuoteText.head, tail: QuoteText.tail)
+        let expected = String(repeating: "x", count: QuoteText.head) + " \u{2026} " + String(repeating: "x", count: QuoteText.tail)
+        XCTAssertEqual(out, expected)
+        XCTAssertLessThan(out.count, text.count)
+        XCTAssertLessThanOrEqual(out.count, QuoteText.max)
+    }
+
+    func testTruncateMiddleUsesSingleU2026WithOneSpaceEachSide() {
+        let text = String(repeating: "a", count: QuoteText.max + 10)
+        let out = QuoteText.truncateMiddle(text, max: QuoteText.max, head: QuoteText.head, tail: QuoteText.tail)
+        XCTAssertTrue(out.contains(" \u{2026} "))
+        XCTAssertEqual(out.components(separatedBy: "\u{2026}").count, 2)
+        XCTAssertFalse(out.contains("..."))
+    }
+
+    func testTruncateMiddleNeverSplitsACharacter() {
+        let emoji = String(repeating: "\u{1F600}", count: QuoteText.max + 20)
+        let out = QuoteText.truncateMiddle(emoji, max: QuoteText.max, head: QuoteText.head, tail: QuoteText.tail)
+        // Head + tail of whole grapheme clusters, joined by one " … ".
+        XCTAssertEqual(out.count, QuoteText.head + QuoteText.tail + 3)
+        XCTAssertTrue(out.allSatisfy { $0 == "\u{1F600}" || $0 == " " || $0 == "\u{2026}" })
+    }
+
+    func testBuildQuoteBlockCollapsesWhitespaceAndTrims() {
+        XCTAssertEqual(QuoteText.buildQuoteBlock("  hello   world\n\nsecond  line  "), "> hello world second line\n\n")
+    }
+
+    func testBuildQuoteBlockNilForEmptyAndWhitespaceOnly() {
+        XCTAssertNil(QuoteText.buildQuoteBlock(""))
+        XCTAssertNil(QuoteText.buildQuoteBlock("   \n\t  "))
+    }
+
+    func testBuildQuoteBlockPrefixesExactlyQuoteAndEndsWithBlankLine() {
+        XCTAssertEqual(QuoteText.buildQuoteBlock("hello"), "> hello\n\n")
+    }
+
+    func testBuildQuoteBlockReducesLongMultiParagraphToOneLineWithOneEllipsis() {
+        let paragraph = Array(repeating: "word ", count: 120).joined().trimmingCharacters(in: .whitespacesAndNewlines)
+        let multi = "\(paragraph)\n\n\(paragraph)"
+        let out = QuoteText.buildQuoteBlock(multi)!
+        XCTAssertEqual(out.trimmingCharacters(in: .whitespacesAndNewlines).components(separatedBy: "\n").count, 1)
+        XCTAssertEqual(out.components(separatedBy: " \u{2026} ").count, 2)
+    }
+
+    func testBuildQuoteBlockEmojiSelectionNeverSplitsACharacter() {
+        let selection = String(repeating: "\u{1F600}", count: QuoteText.max + 60)
+        let out = QuoteText.buildQuoteBlock(selection)!
+        // "> " (2) + head + " … " (3) + tail + "\n\n" (2) = head + tail + 7.
+        XCTAssertEqual(out.count, QuoteText.head + QuoteText.tail + 7)
+        let body = out.dropFirst(2).dropLast(2)
+        XCTAssertTrue(body.allSatisfy { $0 == "\u{1F600}" || $0 == " " || $0 == "\u{2026}" })
+    }
 }


### PR DESCRIPTION
## BET-1353 — iOS: quote a transcript selection into the composer (Quote / Quote in new session)

### Requirement

Once transcript text is selectable on iOS (shipped in BET-1352), a user can lift a line out of a reply into the composer. This issue adds the two quote actions, matching the desktop behaviour exactly:

- **Quote** — put the quote at the top of THIS session's composer.
- **Quote in new session** — fork this session, put the quote at the top of the fork's composer, and open the fork.

The selection is normalised to a **single line, middle-truncated, inserted as one markdown blockquote line followed by one blank line**, prepended to whatever draft is already in the composer. That truncated form is exactly what gets sent — no chip, no preview, no hidden full-length payload, no extra composer state (the model already has the transcript in context, so the quote only has to be a locatable pointer).

### Which branch of step 3 was taken — the fallback (`.contextMenu`)

I took the **fallback branch**, quoting the whole block's text. BET-1352's hand-off established that no selection-menu hook exists on this rendering stack:

- `MarkdownText`/`RichText.TextView` exposes no public hook to add custom items to the system edit menu.
- The underlying text view's `delegate` is set internally by the library and unreachable, so `UITextViewDelegate.textView(_:editMenuForTextIn:suggestedActions:)` cannot be hooked from the app.

So the decided fallback applies: a `.contextMenu` on the transcript row with the two items, quoting the whole `.user`/`.prose` block, with the callback riding the existing `transcriptCardActions` environment value.

### What changed

**1. Pure helpers — `SessionModels.swift`**
- `QuoteText` porting desktop `truncateMiddle`/`buildQuoteBlock` with the phone budgets (max 160 / head 95 / tail 55), a single U+2026 with one space each side, one `> …` + `\n\n` block, and character (grapheme-cluster) counting so an emoji or accented character is never split.
- `QuoteDestination` (`.thisSession` / `.newSession`).

**2. ComposerView opened to external writes**
- `text` promoted from `@State` to `@Binding`; storage moved up to `ChatScreenContent`'s single `composerText`. Every existing writer (keyboard `@`/`/`, voice dictation, caret insert, history up/down, submit, file select, slash) writes through the binding unchanged.
- Focus promoted to a `FocusState.Binding` owned by `ChatScreenContent` so a quote can focus the composer after prepending.

**3. Wiring (fallback branch)**
- `TranscriptBlock.quoteText` computed property (raw markdown of `.user`/`.prose`, nil otherwise).
- `TranscriptCardActions` gains ONE closure `onQuote(String, QuoteDestination)`, delivered via the existing `transcriptCardActions` environment; `TranscriptCellReveal.cellContent` attaches the `.contextMenu` (`Quote` / `Quote in new session`) on quote-able rows.
- `ChatScreenContent.quote(_:into:)` — the single quote path: prepends `block + composerText` and focuses for `.thisSession`; reuses `forkSession(seed:)` for `.newSession`.
- `forkSession(seed:)` carries an optional seed across the route via `SessionOpenTarget.seed` (kept out of equality/hash so identity stays session-derived) into the fork's composer.

**4. Tokens** — the fallback uses a platform `.contextMenu`; no custom chrome, so no new colour/size/spacing value was introduced.

### Tests

`SessionModelsTests.swift` — 9 new tests mirroring the desktop spec (truncate at/below max unchanged; `head … tail` above max, shorter; single U+2026 with one space each side; emoji never split; whitespace collapse/trim; nil on empty/whitespace; exact `> ` + `\n\n`; multi-paragraph → one line one ellipsis; emoji buildQuoteBlock).

### Verification (macos, on simulator)

- **Merge gate** — `ios-mantaui action: "test-unit"`: `Executed 673 tests, with 0 failures` — all 9 new QuoteText tests green.
- **Simulator** — `action: "simulator"`: app built for iPhone 17 Pro, installed, launched (PID 48877), still running with no crash. Interactive tap-through of the two context-menu actions was not manually performed; the pure `QuoteText` path is unit-verified, and `buildQuoteBlock`'s return value is exactly what lands in the composer / seeds the fork.

### Acceptance criteria

- [x] Quote the selected transcript block as one middle-truncated blockquote line + blank line, prepended to the existing composer draft, and focus the composer.
- [x] Quote in new session forks the session, seeds the fork's composer with the same block, and opens the fork.
- [x] Both actions go through one `quote(_:into:)` path using `QuoteText.buildQuoteBlock`.
- [x] Selection is normalised to a single line, middle-truncated, with no chip / hidden payload / extra composer state.
- [x] Pure helpers and tests mirror the desktop `truncateMiddle`/`buildQuoteBlock` spec (character counting, single U+2026, exact `> ` + `\n\n`).

Out of scope (unchanged): text-selectability (BET-1352), quote chip / copy / share / attribution, and any change to `src/server/` or the desktop renderer.
