### PR TITLE
BET-1358: Optimizer perf: push role filter + json_extract projection into fetchLedgerRows SQL

### DIFF
--- a/src/server/modelLedger.mjs
+++ b/src/server/modelLedger.mjs
@@ -292,33 +292,64 @@ function tokensSent(row) {
 
 /**
  * I/O. The ONE ledger row query. Extracts the flat ledger row shape (the
- * `aggregate`/aggregate* fold inputs) from assistant messages over `sinceMs`,
- * via the shared SQL in `assistantRows`. Both `ledgerSummary` and the
- * optimizer summary consume this — a single query path, no duplicated SQL.
- * Returns the parsed, role-filtered flat rows. Never throws on a malformed
- * row (those are skipped); query/parse scaffolding lives in the callers.
+ * `aggregate`/aggregate* fold inputs) from assistant messages over `sinceMs`.
+ * Projected query: the role filter + JSON parsing run in SQLite via
+ * `json_extract`, so the SELECT streams only the fields the flat shape needs
+ * instead of the full `data` blob (which kept `assistantRows`'s parse+filter
+ * at ~3 s on a cold 30-day read). Returns the role-filtered flat rows, mapped
+ * into the exact same shape the old JS-parse path produced (same field names,
+ * same typing) so `aggregate`, `aggregateBySession`, `aggregateDailySeries`,
+ * `measureEffectiveTtl` and the routing fold consume them unchanged.
+ *
+ * `assistantRows` is deliberately NOT used here (it stays for
+ * `aggregateEndpointStats`, which needs the raw `data` blob + the `part` join
+ * for tool reliability). Degradation matches the old path: a row whose `data`
+ * is malformed JSON or lacks `role === "assistant"` is skipped silently. The
+ * `json_valid(m.data)` guard filters malformed rows out BEFORE `json_extract`
+ * runs (json_extract throws on invalid JSON rather than returning NULL, so the
+ * guard is what keeps a single bad row from failing the whole query); rows
+ * that are valid JSON but not an assistant message are excluded by the
+ * `= 'assistant'` predicate. Never throws. Query/parse scaffolding lives in
+ * the callers.
  */
 export async function fetchLedgerRows(db, sinceMs) {
   const since = num(sinceMs);
+  const sql = `
+    SELECT m.id AS msg_id,
+           s.id AS session_id,
+           s.parent_id AS parent_id, s.agent AS agent, s.directory AS directory,
+           json_extract(m.data,'$.providerID')           AS providerID,
+           json_extract(m.data,'$.modelID')              AS modelID,
+           json_extract(m.data,'$.cost')                 AS cost,
+           json_extract(m.data,'$.tokens.input')         AS input,
+           json_extract(m.data,'$.tokens.output')        AS output,
+           json_extract(m.data,'$.tokens.reasoning')     AS reasoning,
+           json_extract(m.data,'$.tokens.cache.read')    AS cacheRead,
+           json_extract(m.data,'$.tokens.cache.write')   AS cacheWrite,
+           json_extract(m.data,'$.time.created')         AS startedMs,
+           json_extract(m.data,'$.time.completed')       AS completedMs
+    FROM message m JOIN session s ON s.id = m.session_id
+    WHERE m.time_created >= ?
+      AND json_valid(m.data) = 1
+      AND json_extract(m.data,'$.role') = 'assistant'`;
+  const stmt = db.prepare(sql);
   const rows = [];
-  for (const { data, sessionId, parentId, agent, directory } of await assistantRows(db, since)) {
-    const tokens = data.tokens ?? {};
-    const cache = tokens.cache ?? {};
+  for (const row of stmt.all(since)) {
     rows.push({
-      providerID: data.providerID ?? null,
-      modelID: data.modelID ?? null,
-      sessionID: sessionId,
-      agent,
-      parentId,
-      directory,
-      cost: data.cost,
-      input: tokens.input,
-      output: tokens.output,
-      reasoning: tokens.reasoning,
-      cacheRead: cache.read,
-      cacheWrite: cache.write,
-      startedMs: data.time?.created,
-      completedMs: data.time?.completed,
+      providerID: row.providerID ?? null,
+      modelID: row.modelID ?? null,
+      sessionID: row.session_id != null ? String(row.session_id) : null,
+      agent: row.agent ?? null,
+      parentId: row.parent_id != null ? String(row.parent_id) : null,
+      directory: row.directory ?? null,
+      cost: row.cost,
+      input: row.input,
+      output: row.output,
+      reasoning: row.reasoning,
+      cacheRead: row.cacheRead,
+      cacheWrite: row.cacheWrite,
+      startedMs: row.startedMs,
+      completedMs: row.completedMs,
     });
   }
   return rows;

--- a/src/server/modelLedger.test.mjs
+++ b/src/server/modelLedger.test.mjs
@@ -4,7 +4,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { aggregate, aggregateEndpointStats, aggregateBySession, aggregateDailySeries, endpointSummary } from "./modelLedger.mjs";
+import { aggregate, aggregateEndpointStats, aggregateBySession, aggregateDailySeries, endpointSummary, fetchLedgerRows } from "./modelLedger.mjs";
 import { _resetDbHandle } from "./opencodeDb.mjs";
 
 // Fixture builder. Fill only the fields a test cares about.
@@ -380,6 +380,165 @@ test("endpointSummary reads tool calls from the part table so reliability is mea
       if (prev === undefined) delete process.env.MANTA_OPENCODE_DB;
       else process.env.MANTA_OPENCODE_DB = prev;
       _resetDbHandle();
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+// ---- fetchLedgerRows projected-query parity (BET-1358) ----
+//
+// fetchLedgerRows was optimized from "stream full `data` blobs + JSON.parse +
+// role-filter in JS" to a SQL json_extract projection. These DB-backed tests
+// prove the projected rows are the exact same flat SHAPE the old JS-parse path
+// produced (deep-compare on well-formed rows) and that aggregate() totals are
+// byte-identical even with absent/null cost+token fields and missing time —
+// while a non-assistant (and a malformed-JSON) message stays excluded.
+//
+// Reference: the pre-BET-1358 fetchLedgerRows (assistantRows + JSON.parse +
+// role filter + JS shape mapping). Mirrors the removed implementation so the
+// new SQL projection can be compared against "what it used to produce".
+async function legacyFetchLedgerRows(db, sinceMs) {
+  const sql = `
+    SELECT m.id AS msg_id, m.data AS msg_data,
+           s.id AS session_id, s.parent_id AS parent_id,
+           s.agent AS agent, s.directory AS directory
+    FROM message m JOIN session s ON s.id = m.session_id
+    WHERE m.time_created >= ?`;
+  const stmt = db.prepare(sql);
+  const out = [];
+  for (const row of stmt.all(sinceMs)) {
+    let data;
+    try {
+      data = JSON.parse(row.msg_data);
+    } catch {
+      continue;
+    }
+    if (!data || typeof data !== "object" || data.role !== "assistant") continue;
+    const tokens = data.tokens ?? {};
+    const cache = tokens.cache ?? {};
+    out.push({
+      providerID: data.providerID ?? null,
+      modelID: data.modelID ?? null,
+      sessionID: row.session_id != null ? String(row.session_id) : null,
+      agent: row.agent ?? null,
+      parentId: row.parent_id != null ? String(row.parent_id) : null,
+      directory: row.directory ?? null,
+      cost: data.cost,
+      input: tokens.input,
+      output: tokens.output,
+      reasoning: tokens.reasoning,
+      cacheRead: cache.read,
+      cacheWrite: cache.write,
+      startedMs: data.time?.created,
+      completedMs: data.time?.completed,
+    });
+  }
+  return out;
+}
+
+// Open an opencode-shaped read-only DB seeded from raw message `data` strings
+// (so a test can plant genuinely malformed JSON, not just JSON-encoded values).
+function openLedgerFixture(DatabaseSync, dbPath, messages, sessions) {
+  const seed = new DatabaseSync(dbPath);
+  seed.exec(`
+    CREATE TABLE message (id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+    CREATE TABLE session (id TEXT, parent_id TEXT, agent TEXT, directory TEXT);
+  `);
+  const insSess = seed.prepare("INSERT INTO session (id, parent_id, agent, directory) VALUES (?,?,?,?)");
+  for (const s of sessions) insSess.run(s.id, s.parentId ?? null, s.agent ?? null, s.directory ?? null);
+  const insMsg = seed.prepare("INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES (?,?,?,?,?)");
+  for (const m of messages) insMsg.run(m.id, m.sessionId, m.ts, m.ts, m.data);
+  seed.close();
+  return new DatabaseSync(dbPath, { readOnly: true });
+}
+
+test("fetchLedgerRows projected query deep-compares to the legacy JS-parse shape on well-formed rows (BET-1358)", async (t) => {
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import("node:sqlite"));
+  } catch {
+    t.skip("node:sqlite unavailable on this runtime");
+    return;
+  }
+  const { mkdtempSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const dir = mkdtempSync(join(tmpdir(), "manta-ledger-shape-"));
+  const now = Date.now();
+  const messages = [
+    { id: "a1", sessionId: "s1", ts: now - 5000, data: JSON.stringify({ role: "assistant", providerID: "anthropic", modelID: "claude-sonnet", cost: 0.05, tokens: { input: 100, output: 50, reasoning: 10, cache: { read: 200, write: 300 } }, time: { created: now - 4000, completed: now - 3900 } }) },
+    { id: "a2", sessionId: "s2", ts: now - 3000, data: JSON.stringify({ role: "assistant", providerID: "openai", modelID: "gpt-4o", cost: 0.2, tokens: { input: 500, output: 100, reasoning: 0, cache: { read: 0, write: 0 } }, time: { created: now - 2000, completed: now - 1800 } }) },
+    { id: "u1", sessionId: "s1", ts: now - 2000, data: JSON.stringify({ role: "user", content: "hi" }) },
+    { id: "bad", sessionId: "s1", ts: now - 1000, data: "{not json" },
+  ];
+  const sessions = [
+    { id: "s1", parentId: null, agent: "build", directory: "/w1" },
+    { id: "s2", parentId: "child-of-s1", agent: "build", directory: "/w2" },
+  ];
+  try {
+    const db = openLedgerFixture(DatabaseSync, join(dir, "opencode.db"), messages, sessions);
+    try {
+      const projected = await fetchLedgerRows(db, now - 60_000);
+      const legacy = await legacyFetchLedgerRows(db, now - 60_000);
+      assert.deepEqual(projected, legacy);
+      assert.equal(projected.length, 2);
+    } finally {
+      db.close();
+    }
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+test("fetchLedgerRows: absent/null cost+token fields aggregate to 0 exactly as today; non-assistant and malformed rows excluded (BET-1358)", async (t) => {
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import("node:sqlite"));
+  } catch {
+    t.skip("node:sqlite unavailable on this runtime");
+    return;
+  }
+  const { mkdtempSync, rmSync } = await import("node:fs");
+  const { tmpdir } = await import("node:os");
+  const { join } = await import("node:path");
+  const dir = mkdtempSync(join(tmpdir(), "manta-ledger-mixed-"));
+  const now = Date.now();
+  const messages = [
+    // Full row: only this one carries cost and cache.
+    { id: "a1", sessionId: "s1", ts: now - 5000, data: JSON.stringify({ role: "assistant", providerID: "anthropic", modelID: "claude-sonnet", cost: 0.5, tokens: { input: 100, output: 50, reasoning: 10, cache: { read: 200, write: 300 } }, time: { created: now - 4000, completed: now - 3900 } }) },
+    // No cost, no tokens, only a start time (no completion).
+    { id: "a2", sessionId: "s2", ts: now - 4000, data: JSON.stringify({ role: "assistant", providerID: "openai", modelID: "gpt-4o", time: { created: now - 3000 } }) },
+    // No cache object, explicit null cost.
+    { id: "a3", sessionId: "s2", ts: now - 3000, data: JSON.stringify({ role: "assistant", providerID: "anthropic", modelID: "claude-haiku", cost: null, tokens: { input: 7, output: 8 } }) },
+    // Non-assistant message in the window — must be excluded.
+    { id: "u1", sessionId: "s1", ts: now - 2000, data: JSON.stringify({ role: "user", content: "hello" }) },
+    // Malformed JSON — must be skipped, never throw.
+    { id: "bad", sessionId: "s1", ts: now - 1000, data: "{not json" },
+  ];
+  const sessions = [
+    { id: "s1", parentId: null, agent: "build", directory: "/w1" },
+    { id: "s2", parentId: null, agent: "build", directory: "/w2" },
+  ];
+  try {
+    const db = openLedgerFixture(DatabaseSync, join(dir, "opencode.db"), messages, sessions);
+    try {
+      const projected = await fetchLedgerRows(db, now - 60_000);
+      const legacy = await legacyFetchLedgerRows(db, now - 60_000);
+      assert.equal(projected.length, 3);
+      assert.equal(legacy.length, 3);
+      // Both implementations must fold to byte-identical aggregate totals
+      // (absent/null cost+token leaves become 0 via num(), as they always did).
+      assert.deepEqual(aggregate(projected), aggregate(legacy));
+      const totals = aggregate(projected).totals;
+      assert.equal(totals.turns, 3);
+      assert.equal(totals.cost, 0.5);
+      assert.equal(totals.input, 107); // 100 + 0 + 7
+      assert.equal(totals.output, 58); // 50 + 0 + 8
+      assert.equal(totals.cacheRead, 200);
+      assert.equal(totals.cacheWrite, 300);
+    } finally {
+      db.close();
     }
   } finally {
     rmSync(dir, { recursive: true, force: true });


### PR DESCRIPTION
## Summary

Optimizes the cold `optimizer:summary` / routing `ledgerSummary` read. Rewrote
`fetchLedgerRows` (src/server/modelLedger.mjs) from `assistantRows` (stream
full `data` blob → JSON.parse every message in JS → role-filter in a loop;
~3s on a cold 30-day read) to a single SQL `json_extract` projection that moves
the role filter + JSON parse into SQLite and streams only the flat ledger
fields. Output rows are key-for-key identical to the old JS-parse shape.

`assistantRows`, `collectToolParts`, `aggregate`, `aggregateEndpointStats`,
`ledgerSummary` are **untouched** — `assistantRows` stays for
`aggregateEndpointStats` (needs the raw `data` blob + `part` join for tool
reliability). Diff is confined to `src/server/modelLedger.mjs` +
`src/server/modelLedger.test.mjs`.

Two deliberate additions to the issue's verbatim SQL, both **required by the
issue's own acceptance criteria** (not free design choices):

- **`s.id AS session_id`** — the flat shape's `sessionID` field is consumed by
  `aggregateBySession`/the optimizer summary. The verbatim SQL omitted it,
  which would have dropped `sessionID` from every row and broken the
  "key-for-key identical output" requirement.
- **`AND json_valid(m.data) = 1`** — `json_extract` **throws** (does not return
  NULL) on malformed JSON, so without the guard a single bad row would fail the
  whole query and collapse the summary to `supported:false`. The guard
  pre-filters malformed rows so the old skip-the-row degradation is preserved
  (`json_extract` only ever runs on valid JSON). Verified against node:sqlite.

Degradation: malformed-JSON rows and non-assistant rows are excluded silently,
never throwing — same as the old path. Absent/null cost+token leaves fold to 0
via `num()`, identical to today. No schema change, no new deps, no state files.

## Performance gate

The structural change (project off the full blob, zero JS JSON.parse/filter)
is what the issue's own ~3s timing attributes the cost to. I could not measure
the cold path on this run box (no reference `opencode.db` here — the issue
says to trust the reference box's measured facts); the gate is for the
reference box to confirm `< ~1s`. Not committing a benchmark per the issue.

## Verification results

**Files changed:** `2` files. `src/server/modelLedger.mjs`, `src/server/modelLedger.test.mjs`

**Verification results:**
- PR branch (`multica/BET-1358-optimizer-prefetch-ledger` @ `be961245`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, **2874 pass / 0 fail / 0 skip**. Failures: none. log sha256: `cd09bc42b112403fd6c8b80d22d9f1d0e6917cc4a97326ca56413c01904486fe`
- Base (`main` @ `a18851a9`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, **2872 pass / 0 fail / 0 skip**. Failures: none. log sha256: `add0137f340b5de7d19e3bb49adf098dbdcdc7e5b5417b2267142e2df3d16023`
- **Conclusion:** 0 failures total. The PR adds 2 tests (2874 vs 2872) — the two new `fetchLedgerRows` parity tests; both pass. 0 new failures, 0 resolved, 0 pre-existing.

New tests:
- `fetchLedgerRows projected query deep-compares to the legacy JS-parse shape on well-formed rows` — seeds a fixture DB, runs the new projected query and a local legacy reference, `deepEqual` on the resulting arrays + asserts the user/malformed rows are excluded.
- `fetchLedgerRows: absent/null cost+token fields aggregate to 0 exactly as today; non-assistant and malformed rows excluded` — mixed fixture (multi-session, some rows without cost/tokens/time), asserts `aggregate(projected) deepEqual aggregate(legacy)` (byte-identical totals) plus exact totals and turn exclusion.

Both are DB-backed via `node:sqlite` (temp dir + read-only handle), `MANTA_STATE_HOME` sandboxed — no real box state written.

**Base: origin/main @ a18851a9**

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
