### PR TITLE
fix(server): break optimizer:summary self-await deadlock (BET-1359)

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -994,11 +994,13 @@ const optimizerActivity = createActivityLog({
 // with no price is skipped). A metered endpoint has no window and never resets,
 // so there is nothing to fill — the row is deliberately role+price, no gauge.
 // [] when the catalog or pricing is unavailable (the section is then absent).
-async function readMeteredEndpoints() {
+async function readMeteredEndpoints({ windows = [], cacheShare = {} } = {}) {
   try {
-    const summary = await optimizerSummary();
-    const subProviders = new Set((summary?.windows ?? []).map((w) => w.provider));
-    const cs = summary?.cacheShare ?? {};
+    // BET-1359: consume the windows/cacheShare the summary already computed,
+    // instead of re-awaiting optimizerSummary() — reading the summary it is a
+    // dependency of was a self-await deadlock.
+    const subProviders = new Set((windows ?? []).map((w) => w.provider));
+    const cs = cacheShare ?? {};
     const denom = (cs.input ?? 0) + (cs.output ?? 0) + (cs.cacheRead ?? 0) + (cs.cacheWrite ?? 0);
     const mix =
       denom > 0

--- a/src/server/optimizer/summary.mjs
+++ b/src/server/optimizer/summary.mjs
@@ -117,6 +117,8 @@ export async function buildOptimizerSummary({
     matched: verification ? verification.matched : null,
   };
 
+  const windows = windowsFor(usageSnapshots(), usageHistory(), nowMs, await pressureWindows());
+
   return {
     supported: true,
     windowDays: WINDOW_DAYS,
@@ -126,10 +128,10 @@ export async function buildOptimizerSummary({
     bySession,
     ttl,
     counterfactual: cf ? { dailySeries: cf.dailySeries, bySession: cf.bySession } : null,
-    windows: windowsFor(usageSnapshots(), usageHistory(), nowMs, await pressureWindows()),
+    windows,
     activity: await activityFor(activityStore),
     compaction: await compactionFor(compactionStat),
-    metered: await meteredFor(meteredEndpoints),
+    metered: await meteredFor(meteredEndpoints, { windows, cacheShare }),
   };
 }
 
@@ -147,11 +149,14 @@ async function compactionFor(compactionStat) {
 }
 
 // The metered-endpoints row, or [] when none are wired (the section is then
-// absent — "never render a control whose backing data isn't there").
-async function meteredFor(meteredEndpoints) {
+// absent — "never render a control whose backing data isn't there"). `ctx`
+// carries the context the summary already computed (`{ windows, cacheShare }`)
+// so the metered-read does NOT re-await the summary it is a dependency of
+// (BET-1359: that re-entry was a self-await deadlock).
+async function meteredFor(meteredEndpoints, ctx) {
   if (typeof meteredEndpoints !== "function") return [];
   try {
-    const m = await meteredEndpoints();
+    const m = await meteredEndpoints(ctx);
     return Array.isArray(m) ? m : [];
   } catch {
     return [];
@@ -234,6 +239,12 @@ let inflight = null;
  * summary then degrades to empty counterfactual). The returned async
  * function memoizes the built summary for TTL_MS with an in-flight guard.
  */
+// Clears the memo + in-flight slot. Test-only: not part of the runtime API.
+export function _resetSummaryMemo() {
+  cache = null;
+  inflight = null;
+}
+
 export function createOptimizerSummary({ getDb, now, counterfactualStore = null, usageSnapshots, usageHistory, readCacheTtl, activityStore = null, pressureWindows, compactionStat, meteredEndpoints }) {
   const nowMs = () => (typeof now === "function" ? num(now()) : num(now ?? Date.now()));
   return async function optimizerSummary() {

--- a/src/server/optimizer/summary.test.mjs
+++ b/src/server/optimizer/summary.test.mjs
@@ -5,7 +5,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildOptimizerSummary, createOptimizerSummary, WINDOW_DAYS } from "./summary.mjs";
+import { buildOptimizerSummary, createOptimizerSummary, WINDOW_DAYS, _resetSummaryMemo } from "./summary.mjs";
 import { createCounterfactualStore } from "./counterfactual.mjs";
 
 function row(over = {}) {
@@ -306,4 +306,150 @@ test("buildOptimizerSummary: activity slice surfaces the store's newest entries,
   const withStore = await buildOptimizerSummary({ fetchRows, now, activityStore });
   assert.equal(withStore.activity.entries.length, 1);
   assert.equal(withStore.activity.entries[0].kind, "tune");
+});
+
+// Races `promise` against a short timer so a deadlock fails the suite instead
+// of hanging CI. BET-1359: the old self-await wiring never settled.
+function withTimeout(promise, ms) {
+  let timer;
+  const timeout = new Promise((_, reject) => {
+    timer = setTimeout(() => reject(new Error(`BET-1359: expected resolution within ${ms}ms, hung`)), ms);
+  });
+  return Promise.race([promise, timeout]).finally(() => clearTimeout(timer));
+}
+
+test("BET-1359: meteredEndpoints that reads its injected ctx resolves (no self-await deadlock)", async () => {
+  _resetSummaryMemo();
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  let received = null;
+  const summary = createOptimizerSummary({
+    getDb: async () => ({ prepare() { return { all: () => [row({ startedMs: now }) ] }; }, close() {} }),
+    now: () => 3_000_000,
+    meteredEndpoints: async (ctx) => {
+      received = ctx;
+      return [{ name: "openai · gpt-4o", role: "pay-per-token endpoint", price: "$5.00 / Mtok blended" }];
+    },
+  });
+
+  const s = await withTimeout(summary(), 2000);
+  assert.equal(s.supported, true);
+  assert.equal(s.metered.length, 1);
+  assert.ok(received, "meteredEndpoints must have been invoked with the context");
+});
+
+test("BET-1359: meteredEndpoints is handed a ctx object, never the summary function", async () => {
+  _resetSummaryMemo();
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  let arg = "unset";
+  const summary = createOptimizerSummary({
+    getDb: async () => ({ prepare() { return { all: () => [row({ startedMs: now }) ] }; }, close() {} }),
+    now: () => 4_000_000,
+    meteredEndpoints: async (ctx) => {
+      arg = ctx;
+      return [];
+    },
+  });
+
+  const s = await summary();
+  assert.equal(s.supported, true);
+  assert.equal(typeof arg, "object");
+  assert.ok(Array.isArray(arg.windows), "ctx must carry a windows array");
+  assert.ok(typeof arg.cacheShare === "object" && arg.cacheShare !== null, "ctx must carry a cacheShare object");
+  assert.notEqual(arg, summary, "meteredEndpoints must never receive the summary function");
+  assert.notEqual(arg, s, "meteredEndpoints must never receive the whole summary");
+});
+
+test("BET-1359: meteredEndpoints receives the SAME windows + cacheShare the summary returns", async () => {
+  _resetSummaryMemo();
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const H = 3_600_000;
+  const snapshots = [
+    {
+      provider: "claude",
+      planLabel: "Max 20x",
+      fetchedAt: now,
+      windows: [{ kind: "session", label: "5h", pct: 30, resetsAt: now + 50 * H }],
+    },
+  ];
+  const rows = [row({ cost: 5, input: 1, cacheRead: 2, cacheWrite: 3, output: 4, startedMs: now })];
+  let ctx = null;
+  const summary = createOptimizerSummary({
+    getDb: async () => ({ prepare() { return { all: () => rows }; }, close() {} }),
+    now: () => now,
+    usageSnapshots: () => snapshots,
+    usageHistory: () => ({}),
+    meteredEndpoints: async (c) => {
+      ctx = c;
+      return [];
+    },
+  });
+
+  const s = await summary();
+  assert.equal(s.supported, true);
+  assert.ok(ctx, "meteredEndpoints must have been invoked");
+  // The context is the very objects the summary returns — plumbing, not a copy.
+  assert.equal(ctx.windows, s.windows);
+  assert.equal(ctx.cacheShare, s.cacheShare);
+  // Sanity: the context genuinely carries the known window + cacheShare.
+  assert.equal(s.windows.length, 1);
+  assert.equal(s.windows[0].provider, "claude");
+  assert.deepEqual(ctx.windows, s.windows);
+  assert.deepEqual(ctx.cacheShare, s.cacheShare);
+});
+
+test("BET-1359: metered row lands in summary.metered", async () => {
+  _resetSummaryMemo();
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const s = await buildOptimizerSummary({
+    fetchRows: async () => [row({ startedMs: now })],
+    now,
+    meteredEndpoints: async () => [{ name: "openai · gpt-4o", role: "pay-per-token endpoint", price: "$5.00 / Mtok blended" }],
+  });
+  assert.equal(s.metered.length, 1);
+  assert.equal(s.metered[0].name, "openai · gpt-4o");
+});
+
+test("BET-1359: metered degradation unchanged (throw / non-array / not-a-function → [])", async () => {
+  _resetSummaryMemo();
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const fetchRows = async () => [row({ startedMs: now })];
+
+  const throwing = await buildOptimizerSummary({
+    fetchRows,
+    now,
+    meteredEndpoints: async () => {
+      throw new Error("boom");
+    },
+  });
+  assert.deepEqual(throwing.metered, []);
+
+  const nonArray = await buildOptimizerSummary({ fetchRows, now, meteredEndpoints: async () => ({ not: "array" }) });
+  assert.deepEqual(nonArray.metered, []);
+
+  const notFn = await buildOptimizerSummary({ fetchRows, now, meteredEndpoints: "not-a-function" });
+  assert.deepEqual(notFn.metered, []);
+});
+
+test("BET-1359: _resetSummaryMemo clears the cache so the next build re-queries", async () => {
+  _resetSummaryMemo();
+  let prepares = 0;
+  const stubDb = {
+    prepare() {
+      prepares += 1;
+      return { all: () => [] };
+    },
+    close() {},
+  };
+  const summary = createOptimizerSummary({ getDb: async () => stubDb, now: () => 9_000_000 });
+
+  const first = await summary();
+  assert.equal(prepares, 1);
+  // Within TTL → memoized, no re-query.
+  await summary();
+  assert.equal(prepares, 1);
+
+  _resetSummaryMemo();
+  const second = await summary();
+  assert.equal(prepares, 2, "after reset the next build must re-query");
+  assert.notEqual(second, first);
 });


### PR DESCRIPTION
Fixes BET-1359 — `optimizer:summary` deadlocks forever because `readMeteredEndpoints` re-awaits the summary it is a dependency of.

## Root cause
`readMeteredEndpoints` (wired as `meteredEndpoints`) opened with `const summary = await optimizerSummary()`. When the summary build's memo missed, it assigned the `inflight` slot, then reached `metered: await meteredFor(meteredEndpoints)`, which re-entered `optimizerSummary()`. That re-entry found `cache` still null and returned the very `inflight` promise that was awaiting it — the build awaited itself, never settled, and `.finally()` never ran, pinning `inflight` for the process lifetime (the "Settings frozen" report). Not intermittent: the optimizer-tuner backstop poller primes it at boot.

## The fix
Break the cycle. `readMeteredEndpoints` only needed `windows` and `cacheShare`, both of which `buildOptimizerSummary` already computed. Changed the `meteredEndpoints` contract from `() => rows` to `({ windows, cacheShare }) => rows`:

- `summary.mjs` — hoist `windows` to a local and pass `{ windows, cacheShare }` through `meteredFor`.
- `index.mjs` — `readMeteredEndpoints` consumes the injected context; the `const summary = await optimizerSummary()` line is deleted. Default params keep it safe if ever called bare. Body from `denom` onward untouched.
- `summary.mjs` — added test-only `_resetSummaryMemo()` (mirrors `_resetDbHandle`).

No re-entrancy flag, no second memo slot, no watchdog — the cycle is gone.

## Tests
Six new node:test cases in `summary.test.mjs`, every one calling `_resetSummaryMemo()` first and the hang-prone one time-bounded (races against a 2s timer so a regression fails the suite rather than hanging CI).

## Maintainer note
Reload the server after merge (`systemctl --user restart opencode-serve`) — intentionally NOT run from this branch.

## Base: origin/main @ `4cebdf38`

**Files changed:** 3 files.
```
 src/server/index.mjs                  |  10 ++-
 src/server/optimizer/summary.mjs      |  21 +++--
 src/server/optimizer/summary.test.mjs | 148 ++++++++++++++++++++++++++++-
```

**Verification results:**
- PR branch (`multica/BET-1359-optimizer-summary-deadlock` @ `7c6763ae`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2880 pass / 0 fail / 0 skip. Failures: none. log sha256: `789031a82dedc54c7fdb9ae43ded74de872744dd5bd323b5f3366b7ba5c0de45`
- Base (`origin/main` @ `4cebdf38`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2874 pass / 0 fail / 0 skip. Failures: none. log sha256: `aa7a33f849bfd472d9cf39c612e229f52b5077c0028db51918452cac87220381`
- **Conclusion:** 0 failures pre-existing, 0 new failures. The +6 tests are the new BET-1359 pins.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
