### PR TITLE
fix(server): bound optimizer:summary memo (build budget + busy_timeout) (BET-1360)

### DIFF
--- a/src/server/opencodeDb.mjs
+++ b/src/server/opencodeDb.mjs
@@ -14,6 +14,12 @@ import { join } from "node:path";
 import { existsSync } from "node:fs";
 
 let dbHandle = null;
+// Test-only: a substitute for the node:sqlite module, so tests can fake a
+// DatabaseSync without ever opening the real opencode.db. Not runtime API.
+let _modOverride = null;
+export function _setSqliteModuleOverride(mod) {
+  _modOverride = mod;
+}
 
 // Resolve opencode's SQLite path. First existing wins; a test/override hook
 // (`MANTA_OPENCODE_DB`) is used as-is. null → the box cannot search.
@@ -39,8 +45,17 @@ export async function getDb() {
   const path = resolveDbPath();
   if (!path) return null;
   try {
-    const { DatabaseSync } = await import("node:sqlite");
-    dbHandle = new DatabaseSync(path, { readOnly: true });
+    const mod = _modOverride ?? (await import("node:sqlite"));
+    dbHandle = new mod.DatabaseSync(path, { readOnly: true });
+    try {
+      // BET-1360: bounded wait for a WAL-checkpoint-locked page, so a reader
+      // that meets a busy handle waits at most 5000ms instead of failing
+      // immediately (SQLite default) or blocking forever.
+      dbHandle.exec("PRAGMA busy_timeout = 5000");
+    } catch (e) {
+      // Non-fatal: a handle without the pragma is still usable.
+      console.warn("[opencodeDb] busy_timeout pragma failed:", e?.message ?? e);
+    }
     return dbHandle;
   } catch (e) {
     console.warn("[opencodeDb] node:sqlite unavailable:", e?.message ?? e);

--- a/src/server/opencodeDb.test.mjs
+++ b/src/server/opencodeDb.test.mjs
@@ -4,7 +4,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { resolveDbPath, getDb, _resetDbHandle } from "./opencodeDb.mjs";
+import { resolveDbPath, getDb, _resetDbHandle, _setSqliteModuleOverride } from "./opencodeDb.mjs";
 
 test("resolveDbPath returns MANTA_OPENCODE_DB verbatim when set", () => {
   const override = "/custom/path/opencode.db";
@@ -35,5 +35,61 @@ test("getDb() returns null (and does not throw) when resolveDbPath yields null",
   } finally {
     delete process.env.XDG_DATA_HOME;
     _resetDbHandle();
+  }
+});
+
+// BET-1360: the shared read-only handle applies a bounded busy_timeout on
+// open. These tests fake node:sqlite so no real opencode.db is ever opened.
+
+function fakeHandle(execImpl) {
+  return {
+    isOpen: true,
+    exec: execImpl,
+  };
+}
+
+test("BET-1360: getDb issues PRAGMA busy_timeout = 5000 exactly once on open", async () => {
+  _resetDbHandle();
+  const execCalls = [];
+  _setSqliteModuleOverride({
+    DatabaseSync: () => fakeHandle((sql) => execCalls.push(sql)),
+  });
+  process.env.MANTA_OPENCODE_DB = "/fake/db/opencode.db";
+  try {
+    const db = await getDb();
+    assert.ok(db, "a handle must be returned on open");
+    assert.deepEqual(execCalls, ["PRAGMA busy_timeout = 5000"]);
+    // Second call hits the cached handle → the pragma is not re-issued.
+    await getDb();
+    assert.equal(execCalls.length, 1, "the pragma runs only on open");
+  } finally {
+    _resetDbHandle();
+    _setSqliteModuleOverride(null);
+    delete process.env.MANTA_OPENCODE_DB;
+  }
+});
+
+test("BET-1360: a failing busy_timeout pragma is non-fatal (handle returned, warns once)", async () => {
+  _resetDbHandle();
+  _setSqliteModuleOverride({
+    DatabaseSync: () => fakeHandle(() => { throw new Error("pragma boom"); }),
+  });
+  process.env.MANTA_OPENCODE_DB = "/fake/db/opencode.db";
+  const warns = [];
+  const origWarn = console.warn;
+  console.warn = (m) => warns.push(String(m));
+  try {
+    const db = await getDb();
+    assert.ok(db, "a failing pragma must still yield a usable handle, not null");
+    assert.equal(warns.length, 1);
+    assert.match(warns[0], /busy_timeout pragma failed/);
+    // Cached handle on the next call → no re-open, no second warn.
+    await getDb();
+    assert.equal(warns.length, 1, "warn only on the (single) open");
+  } finally {
+    console.warn = origWarn;
+    _resetDbHandle();
+    _setSqliteModuleOverride(null);
+    delete process.env.MANTA_OPENCODE_DB;
   }
 });

--- a/src/server/opencodeDb.test.mjs
+++ b/src/server/opencodeDb.test.mjs
@@ -52,7 +52,7 @@ test("BET-1360: getDb issues PRAGMA busy_timeout = 5000 exactly once on open", a
   _resetDbHandle();
   const execCalls = [];
   _setSqliteModuleOverride({
-    DatabaseSync: () => fakeHandle((sql) => execCalls.push(sql)),
+    DatabaseSync: function () { return fakeHandle((sql) => execCalls.push(sql)); },
   });
   process.env.MANTA_OPENCODE_DB = "/fake/db/opencode.db";
   try {
@@ -72,7 +72,7 @@ test("BET-1360: getDb issues PRAGMA busy_timeout = 5000 exactly once on open", a
 test("BET-1360: a failing busy_timeout pragma is non-fatal (handle returned, warns once)", async () => {
   _resetDbHandle();
   _setSqliteModuleOverride({
-    DatabaseSync: () => fakeHandle(() => { throw new Error("pragma boom"); }),
+    DatabaseSync: function () { return fakeHandle(() => { throw new Error("pragma boom"); }); },
   });
   process.env.MANTA_OPENCODE_DB = "/fake/db/opencode.db";
   const warns = [];

--- a/src/server/optimizer/summary.mjs
+++ b/src/server/optimizer/summary.mjs
@@ -25,8 +25,15 @@ import { SUMMARY_ACTIVITY_CAP } from "./activityLog.mjs";
 
 const WINDOW_DAYS = 30;
 const TTL_MS = 60_000;
+// BET-1360: the memo's in-flight build budget. A wedged dependency (a fetch or
+// DB read that never settles) must never block a caller past this, and must
+// never hold the single memo slot forever — callers stop waiting at the budget
+// while the slow build may still finish and populate the cache. Deliberately a
+// source constant, not user-tunable; keep it wide (~16× the observed ~620 ms
+// full build). Do not tighten it to chase measured latency.
+const BUILD_BUDGET_MS = 10_000;
 
-export { WINDOW_DAYS };
+export { WINDOW_DAYS, BUILD_BUDGET_MS };
 
 /**
  * PURE. Build the optimizer summary over the last WINDOW_DAYS of ledger rows
@@ -227,9 +234,12 @@ function num(v) {
 
 // Memo slot — mirrors the routing-services cache shape (single slot, one ledger
 // on the box, keyed on nothing) with an added in-flight guard so concurrent
-// calls share one build instead of stampeding the DB.
+// calls share one build instead of stampeding the DB. BET-1360 bounds that
+// in-flight slot: `building` carries the startedAt so callers never wait past
+// BUILD_BUDGET_MS, and the `building === b` guard stops a stale build's finally
+// from clearing a newer slot (no cross-clearing).
 let cache = null; // { at, value }
-let inflight = null;
+let building = null; // { startedAt, promise } — the in-flight build, if any
 
 /**
  * I/O. Wrapper factory. `getDb` resolves the read-only opencode.db handle
@@ -242,7 +252,7 @@ let inflight = null;
 // Clears the memo + in-flight slot. Test-only: not part of the runtime API.
 export function _resetSummaryMemo() {
   cache = null;
-  inflight = null;
+  building = null;
 }
 
 export function createOptimizerSummary({ getDb, now, counterfactualStore = null, usageSnapshots, usageHistory, readCacheTtl, activityStore = null, pressureWindows, compactionStat, meteredEndpoints }) {
@@ -250,8 +260,10 @@ export function createOptimizerSummary({ getDb, now, counterfactualStore = null,
   return async function optimizerSummary() {
     const t = nowMs();
     if (cache && t - cache.at < TTL_MS) return cache.value;
-    if (inflight) return inflight;
-    inflight = (async () => {
+    if (building) return raceBudget(building, t);
+
+    const b = { startedAt: t, promise: null };
+    b.promise = (async () => {
       const db = await getDb();
       if (!db) return { supported: false };
       try {
@@ -276,8 +288,30 @@ export function createOptimizerSummary({ getDb, now, counterfactualStore = null,
         return { supported: false };
       }
     })().finally(() => {
-      inflight = null;
+      // Only clear the slot if it is still OURS — a stale build must never
+      // clear a newer one (BET-1360: no cross-clearing).
+      if (building === b) building = null;
     });
-    return inflight;
+    building = b;
+    return raceBudget(b, t);
   };
+}
+
+// Share the in-flight build, but never wait past its budget. A build that
+// blows the budget keeps running (it may still populate the cache and clear
+// its own slot); callers just stop waiting on it (BET-1360).
+function raceBudget(b, t) {
+  const remaining = b.startedAt + BUILD_BUDGET_MS - t;
+  if (remaining <= 0) return Promise.resolve({ supported: false });
+  return new Promise((resolve) => {
+    const timer = setTimeout(() => {
+      console.error("[optimizer] summary build exceeded budget; degrading to unsupported");
+      resolve({ supported: false });
+    }, remaining);
+    timer.unref?.();
+    b.promise.then(
+      (v) => { clearTimeout(timer); resolve(v); },
+      () => { clearTimeout(timer); resolve({ supported: false }); },
+    );
+  });
 }

--- a/src/server/optimizer/summary.mjs
+++ b/src/server/optimizer/summary.mjs
@@ -33,7 +33,7 @@ const TTL_MS = 60_000;
 // full build). Do not tighten it to chase measured latency.
 const BUILD_BUDGET_MS = 10_000;
 
-export { WINDOW_DAYS, BUILD_BUDGET_MS };
+export { WINDOW_DAYS, BUILD_BUDGET_MS, TTL_MS };
 
 /**
  * PURE. Build the optimizer summary over the last WINDOW_DAYS of ledger rows

--- a/src/server/optimizer/summary.test.mjs
+++ b/src/server/optimizer/summary.test.mjs
@@ -5,8 +5,16 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildOptimizerSummary, createOptimizerSummary, WINDOW_DAYS, _resetSummaryMemo } from "./summary.mjs";
+import { buildOptimizerSummary, createOptimizerSummary, WINDOW_DAYS, BUILD_BUDGET_MS, _resetSummaryMemo } from "./summary.mjs";
 import { createCounterfactualStore } from "./counterfactual.mjs";
+
+// A promise plus the resolve/reject to settle it on demand — lets tests drive
+// a never-resolving build deterministically without real sleeps (BET-1360).
+function deferred() {
+  let resolve, reject;
+  const promise = new Promise((res, rej) => { resolve = res; reject = rej; });
+  return { promise, resolve, reject };
+}
 
 function row(over = {}) {
   return {
@@ -452,4 +460,131 @@ test("BET-1359: _resetSummaryMemo clears the cache so the next build re-queries"
   const second = await summary();
   assert.equal(prepares, 2, "after reset the next build must re-query");
   assert.notEqual(second, first);
+});
+
+// BET-1360 — bounded build budget. All tests drive time with an injected
+// mutable `now` and inject controllable builds (deferred getDb) so nothing
+// sleeps for real seconds.
+
+test("BET-1360: a wedged build yields {supported:false} within the budget instead of hanging", async () => {
+  _resetSummaryMemo();
+  let t = 1_000_000;
+  const hung = deferred();
+  const summary = createOptimizerSummary({ getDb: () => hung.promise, now: () => t });
+  const first = summary(); // starts an in-flight build at t=1_000_000
+  // Advance the clock past the budget: the caller must resolve, not hang.
+  t = 1_000_000 + BUILD_BUDGET_MS + 1;
+  const result = await withTimeout(summary(), 2000);
+  assert.deepEqual(result, { supported: false });
+  hung.resolve(null); // let the wedged build settle before the test ends
+  await withTimeout(first, 2000);
+});
+
+test("BET-1360: no stampede — concurrent callers never start a second build", async () => {
+  _resetSummaryMemo();
+  let t = 1_000_000;
+  let getDbCalls = 0;
+  const hung = deferred();
+  const summary = createOptimizerSummary({
+    getDb: () => { getDbCalls += 1; return hung.promise; },
+    now: () => t,
+  });
+  const first = summary();
+  t = 1_000_000 + BUILD_BUDGET_MS + 1;
+  const results = await Promise.all(Array.from({ length: 10 }, () => summary()));
+  for (const r of results) assert.deepEqual(r, { supported: false });
+  assert.equal(getDbCalls, 1, "only the first caller may start a build");
+  hung.resolve(null);
+  await withTimeout(first, 2000);
+});
+
+test("BET-1360: self-heal — a build that finishes after the budget still populates the cache", async () => {
+  _resetSummaryMemo();
+  let t = 1_000_000;
+  const nowDate = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const late = deferred();
+  const summary = createOptimizerSummary({
+    getDb: () => late.promise.then(() => ({ prepare() { return { all: () => [row({ startedMs: nowDate }) ] }; }, close() {} })),
+    now: () => t,
+  });
+  const first = summary();
+  t = 1_000_000 + BUILD_BUDGET_MS + 1;
+  const degraded = await withTimeout(summary(), 2000);
+  assert.deepEqual(degraded, { supported: false });
+  // The slow build finally settles — it populates the cache, it is not a trip.
+  late.resolve();
+  await withTimeout(first, 2000);
+  const healed = await summary();
+  assert.equal(healed.supported, true, "a slow build that settles after the budget is not sticky");
+});
+
+test("BET-1360: no cross-clearing — a stale build never clears a newer in-flight slot", async () => {
+  _resetSummaryMemo();
+  let t = 1_000_000;
+  const firstDb = deferred();
+  const secondDb = deferred();
+  let getDbCalls = 0;
+  const summary = createOptimizerSummary({
+    getDb: () => {
+      getDbCalls += 1;
+      return getDbCalls === 1 ? firstDb.promise : secondDb.promise;
+    },
+    now: () => t,
+  });
+  const a = summary(); // build A, in flight
+  assert.equal(getDbCalls, 1);
+  t = 1_000_000 + BUILD_BUDGET_MS + 1;
+  await summary(); // degraded against A; no second build
+  assert.equal(getDbCalls, 1);
+
+  firstDb.resolve({ prepare() { return { all: () => [] }; }, close() {} }); // A settles, clears itself
+  await withTimeout(a, 2000);
+
+  t = 1_000_000 + BUILD_BUDGET_MS + TTL_MS + 1; // past A's TTL → build B
+  const b = summary();
+  assert.equal(getDbCalls, 2, "B must start after A clears and the cache expires");
+  t = t + BUILD_BUDGET_MS + 1;
+  await summary();
+  await summary();
+  assert.equal(getDbCalls, 2, "no third build may be started while B is in flight");
+  secondDb.resolve({ prepare() { return { all: () => [] }; }, close() {} });
+  await withTimeout(b, 2000);
+});
+
+test("BET-1360: fast path unchanged — normal build memoizes for TTL_MS with one query", async () => {
+  _resetSummaryMemo();
+  let t = 1_000_000;
+  let prepares = 0;
+  const nowDate = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const summary = createOptimizerSummary({
+    getDb: async () => ({ prepare() { prepares += 1; return { all: () => [row({ startedMs: nowDate }) ] }; }, close() {} }),
+    now: () => t,
+  });
+  const first = await withTimeout(summary(), 2000);
+  assert.equal(first.supported, true);
+  assert.equal(prepares, 1);
+  t += 1; // still inside TTL
+  const second = await summary();
+  assert.equal(second, first, "within TTL the memoized value is returned");
+  assert.equal(prepares, 1, "one query for two calls within the window");
+});
+
+test("BET-1360: a rejecting build degrades to {supported:false} and never caches an error", async () => {
+  _resetSummaryMemo();
+  let t = 1_000_000;
+  const summary = createOptimizerSummary({
+    getDb: async () => { throw new Error("db open boom"); },
+    now: () => t,
+  });
+  const r1 = await withTimeout(summary(), 2000);
+  assert.deepEqual(r1, { supported: false });
+  t += 1;
+  const r2 = await summary();
+  assert.deepEqual(r2, { supported: false });
+  assert.equal(r2.value, undefined, "an error must never be cached");
+});
+
+test("BET-1360: BUILD_BUDGET_MS is exported so tests reference it, not a magic number", () => {
+  assert.equal(typeof BUILD_BUDGET_MS, "number");
+  assert.ok(BUILD_BUDGET_MS > 0);
 });

--- a/src/server/optimizer/summary.test.mjs
+++ b/src/server/optimizer/summary.test.mjs
@@ -5,7 +5,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { buildOptimizerSummary, createOptimizerSummary, WINDOW_DAYS, BUILD_BUDGET_MS, _resetSummaryMemo } from "./summary.mjs";
+import { buildOptimizerSummary, createOptimizerSummary, WINDOW_DAYS, BUILD_BUDGET_MS, TTL_MS, _resetSummaryMemo } from "./summary.mjs";
 import { createCounterfactualStore } from "./counterfactual.mjs";
 
 // A promise plus the resolve/reject to settle it on demand — lets tests drive

--- a/src/server/routingServices.mjs
+++ b/src/server/routingServices.mjs
@@ -42,6 +42,11 @@ const num = (v) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
 // reliability figure cannot change a decision that matters, so deliberately no
 // invalidation protocol, no bus event, no config knob.
 const ROUTING_LEDGER_TTL_MS = 60_000;
+// Deliberately value-only: this cache memos a SETTLED summary, never an
+// in-flight promise. A hanging endpointSummary blocks that one caller but
+// cannot poison later ones (no shared never-settling slot), so it is immune
+// to the BET-1359/BET-1360 memo-wedge failure mode — it is NOT given a build
+// budget or startedAt. It still inherits the shared opencodeDb busy_timeout.
 let ledgerCache = null; // { sum, at, value } — one slot, TTL-bounded
 
 // Fold the config's per-endpoint user overrides into the `declared` map the


### PR DESCRIPTION
## BET-1360 — bound the optimizer:summary memo (build budget + busy_timeout)

Defence-in-depth for the `optimizer:summary` read model, on top of BET-1359
(merged, PR #1362). Bounds the blast radius of a hung dependency so it can
never wedge Settings a second time.

### Part 1 — busy_timeout on the shared read-only handle
`src/server/opencodeDb.mjs` now issues `PRAGMA busy_timeout = 5000` once on
open. A reader that meets a WAL-checkpoint-locked page waits at most 5s
instead of failing immediately (SQLite default). Pragma failure is
non-fatal (warns, handle still returned) — the existing catch-that-returns-
null is still only for the *open* failing.

### Part 2 — build budget on the summary memo
`src/server/optimizer/summary.mjs`:
- `BUILD_BUDGET_MS = 10_000` (exported).
- The in-flight slot is now `{ startedAt, promise }`; callers share the
  in-flight build but never wait past the budget via `raceBudget`.
  A build that blows the budget keeps running (it may still populate the
  cache and clear its own slot); callers just degrade to
  `{ supported:false }`.
- `building === b` guard prevents a stale build's `.finally()` from clearing
  a newer slot (no cross-clearing).
- The existing build body (`getDb` → `buildOptimizerSummary` →
  `cache = { at, value }` → catch) is moved, not rewritten.

### Part 3 — routing ledger note only
`src/server/routingServices.mjs`: comment-only change recording that the
ledger cache is deliberately value-only (no in-flight slot), which is what
makes it immune to this failure mode; it inherits the busy_timeout.

### Tests
- `src/server/optimizer/summary.test.mjs`: budget trip, no stampede,
  self-heal, no cross-clearing, fast path unchanged, rejection degrades,
  `BUILD_BUDGET_MS` exported.
- `src/server/opencodeDb.test.mjs`: pragma applied exactly once on open;
  pragma failure is non-fatal. Fake `node:sqlite` via a new test-only
  `_setSqliteModuleOverride` — no real `opencode.db` is ever opened.

### Files changed
5 files (2 source, 3 test/comment):
`src/server/opencodeDb.mjs`, `src/server/optimizer/summary.mjs`,
`src/server/optimizer/summary.test.mjs`, `src/server/opencodeDb.test.mjs`,
and a comment-only change in `src/server/routingServices.mjs`.

### Verification results
- PR branch (`multica/BET-1360-bounded-summary-memo` @ `69d566f4`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2889 pass / 0 fail / 0 skip. Failures: none. log sha256: `029441fbad4bfb86f990a83e731573c8caaf9655cf2e63463b6b5431f98b60f6`
- Base (`main` @ `fae3a370`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2880 pass / 0 fail / 0 skip. Failures: none. log sha256: `aca8e9b4136161bc0d965f927d510d23ce8de29e4a98cc1cda68c167fdd16b66`
- **Conclusion:** 0 pre-existing failures, 0 new failures, +9 tests added by
  this PR. (Typecheck logs are byte-identical because the diff touches only
  `.mjs` files.)

### Maintainer step
After merge, a server reload is required to pick up the new source
(`systemctl --user restart opencode-serve`, or however the box reloads the
server) — intentionally NOT run from this branch.

**Base: origin/main @ `fae3a370`**
