### PR TITLE
iOS session list: move All/Recent filter into opaque strip under nav bar (BET-1361)

### DIFF
--- a/mobile/native/MantaUI/SessionListView.swift
+++ b/mobile/native/MantaUI/SessionListView.swift
@@ -95,8 +95,6 @@ struct SessionListView: View {
             }
             .navigationTitle("Sessions")
             .navigationBarTitleDisplayMode(.inline)
-            .toolbarBackgroundVisibility(.visible, for: .navigationBar)
-            .toolbarBackground(tokens.canvas, for: .navigationBar)
             .mantaNavigationBarBackground(tokens)
             .toolbar {
                 ToolbarItem(placement: .topBarLeading) {
@@ -121,7 +119,8 @@ struct SessionListView: View {
                 }
             }
             .refreshable { await store.refresh() }
-            .safeAreaInset(edge: .bottom) { filterAndSearchBar }
+            .safeAreaInset(edge: .bottom) { searchBar }
+            .safeAreaInset(edge: .top) { filterRow }
             .overlay(alignment: .top) { errorBanner }
             .navigationDestination(for: SessionOpenTarget.self) { target in
                 if let sessionId = target.sessionId, !sessionId.isEmpty {
@@ -587,16 +586,9 @@ struct SessionListView: View {
     // single child and is deleted with it: a container whose whole job is to
     // relate two glass shapes is noise once there is only one.
     //
-    // The All/Recent filter row (BET-1349) sits DIRECTLY above the search
-    // field inside the same bottom safe-area inset, sharing its horizontal
-    // padding — one thumb-reachable control cluster with no new surface.
-    private var filterAndSearchBar: some View {
-        VStack(spacing: Metrics.spacing.sp2) {
-            filterRow
-            searchBar
-        }
-    }
-
+    // The All/Recent filter (BET-1349) lives in a pinned strip under the nav
+    // bar (see `filterRow`), not floating over the list — so rows scroll past
+    // it without colliding, and the unselected chip keeps a real pill.
     private var filterRow: some View {
         HStack(spacing: Metrics.spacing.sp2) {
             ModelChip(title: "All", selected: filter == .all, tokens: tokens,
@@ -608,8 +600,15 @@ struct SessionListView: View {
                 filter = .recent
             }
         }
-        .frame(maxWidth: .infinity, alignment: .leading)
+        // Pinned top strip. The `tokens.canvas` background is what stops list
+        // rows scrolling behind the chips from showing through — do not remove
+        // it as redundant paint; without it the strip is transparent. Pad, then
+        // expand, then paint, so the background covers the padding.
         .padding(.horizontal, Metrics.spacing.sp3)
+        .padding(.top, Metrics.spacing.sp1)
+        .padding(.bottom, Metrics.spacing.sp2)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(tokens.canvas)
     }
 
     private var searchBar: some View {


### PR DESCRIPTION
## BET-1361 — iOS session list: All/Recent filter into an opaque strip under the nav bar

Moves the All/Recent filter chips out of the bottom safe-area cluster (where
list rows scrolled through them, unreadable — BET-1349's bug) into a pinned
opaque strip directly under the navigation bar.

**Files changed:** `1` file. `mobile/native/MantaUI/SessionListView.swift` (13 insertions, 14 deletions — net smaller than main).

What changed (exactly per the decision, no re-opened placement):
- Deleted the `filterAndSearchBar` wrapper; bottom inset is back to `searchBar` alone (searchBar itself untouched).
- Re-homed `filterRow` into `.safeAreaInset(edge: .top)`, painted `tokens.canvas` with pad→expand→paint modifier order, doc comment explaining why the background must stay.
- Deleted the two hand-written duplicate toolbar modifiers; `.mantaNavigationBarBackground(tokens)` now sole owner (verified the helper applies exactly those two).
- Updated the stale searchBar comment paragraph.

No `ModelChip` / model picker change, no new filters, no ScrollView, no new token/metric values, no filter persistence, nothing under `src/`.

**Base: origin/main @ `c86ff04d`** (branched fresh; diff is only the one intended file).

## Verification
- iOS unit gate `ios-mantaui test-unit` on this branch: **UNIT: PASS** — `Executed 692 tests, with 0 failures (0 unexpected)`.
- Real visual check: app built from this branch, paired the simulator against the live box, captured the populated session list. Confirmed (vision-verified): All/Recent chips sit in an opaque strip directly under the nav bar, strip reads as one continuous surface with the nav bar (no seam), no list rows show through behind the chips, floating search bar remains at the bottom.
- Step 4 (tap Recent → confirm filter empties list and strip stays reachable): not executed — no existing tooling drives a tap on the filter chip. The strip is unconditional by construction (same-view top inset as the search bar), and `SessionRecency` filtering is already unit-tested and untouched here.
