### PR TITLE
BET-1363: refactor(mobile-ios): remove whole-row quote context menu, restore native text selection

### DIFF
--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -816,17 +816,6 @@ enum TranscriptBlock: Equatable {
         case .steps, .file, .notice, .queuedPrompt, .permission, .planExit, .question: return nil
         }
     }
-
-    /// The quote-able raw markdown of a user or assistant-prose block, nil for
-    /// every other block type (BET-1353). The fallback selection-menu branch
-    /// quotes the WHOLE block's text — there is no sub-selection on this
-    /// rendering stack, so this is the maximum fidelity available.
-    var quoteText: String? {
-        switch self {
-        case .user(let text, _), .prose(let text, _): return text
-        case .steps, .file, .notice, .queuedPrompt, .permission, .planExit, .question: return nil
-        }
-    }
 }
 
 /// A file/attachment reference carried by a `.file` transcript block. Only the

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -145,9 +145,7 @@ final class TranscriptCardActions {
     let onBuildHere: (QuestionRequest, String) -> Void
     let onKeepPlanning: (QuestionRequest, String) -> Void
     let onOpenPage: () -> Void
-    /// Quote a transcript block into a composer destination (BET-1353). Rides
-    /// this same environment value — the fallback selection branch attaches a
-    /// `.contextMenu` to the row and calls this with the whole block's text.
+    /// Invoked from the system text-selection edit menu with the user's SELECTED text, not a whole block (BET-1364).
     let onQuote: (String, QuoteDestination) -> Void
 
     init(
@@ -283,31 +281,6 @@ private struct TranscriptCellReveal: View {
     @MainActor
     @ViewBuilder
     private var cellContent: some View {
-        // BET-1353 — the fallback selection branch. The MarkdownText renderer
-        // exposes no hook into the system edit menu (BET-1352's finding), so
-        // the two quote actions attach as a `.contextMenu` on the row, quoting
-        // the WHOLE block's text (`.user`/`.prose`) rather than a sub-selection.
-        // The callback rides the existing `transcriptCardActions` environment —
-        // no second delivery mechanism. Read-only surfaces (nil actions) and
-        // non-quotable blocks (steps/file/…) get no menu.
-        if let quoteText = item.block.quoteText, let actions = cardActions {
-            baseContent
-                .contextMenu {
-                    Button("Quote") { actions.onQuote(quoteText, .thisSession) }
-                    Button("Quote in new session") { actions.onQuote(quoteText, .newSession) }
-                }
-        } else {
-            baseContent
-        }
-    }
-
-    /// The row's ordinary content: the live streaming prose tail, or the shared
-    /// block renderer for everything else. Own @ViewBuilder so its if/else
-    /// branches unify (a bare `some View = { … }()` closure cannot — the two
-    /// branches are distinct `View` types, BET-1353).
-    @MainActor
-    @ViewBuilder
-    private var baseContent: some View {
         if case .prose(let text, nil) = item.block {
             LiveProseTail(text: text, tokens: tokens)
         } else {


### PR DESCRIPTION
## Summary

Removal-only change (BET-1363). Deletes the whole-row SwiftUI `.contextMenu` quote action attached to every transcript row, which was lifting+highlighting the entire message on long-press and competing with (and defeating) the native text selection BET-1352 enabled.

**Net diff: ** `-38` lines (2 files, 1 insertion for the updated doc comment, 39 deletions). Nothing added.

### Changes
1. `mobile/native/MantaUI/TranscriptRow.swift`
   - Removed the `.contextMenu` wrapper branch in `TranscriptCellReveal.cellContent` (the BET-1353 fallback that quoted the WHOLE block via `quoteText`).
   - Collapsed the now-dead two-property split (`cellContent` wrapping `baseContent`) back into a single `cellContent` whose body is exactly what `baseContent` held.
   - Updated `TranscriptCardActions.onQuote`'s doc comment: it is now invoked from the system text-selection edit menu with the user's SELECTED text, with BET-1364 named as the follow-up that re-attaches the quote actions.
2. `mobile/native/MantaUI/TranscriptComponents.swift`
   - Deleted `TranscriptBlock.quoteText` + its doc comment. Confirmed via repo-wide search that nothing else referenced it.

### Kept deliberately (churn avoidance — BET-1364 re-attaches these)
`TranscriptCardActions.onQuote` + its init param + the inert `onQuote: { _, _ in }` default; `ChatScreen.quote(_:into:)` / `forkSession(seed:)` / `composerText` / `composerFocused`; `SessionOpenTarget.seed`; the `ComposerView` `text`/`inputFocused` bindings; `QuoteDestination`/`QuoteText` in `SessionModels.swift` and their tests.

### Out of scope (per issue)
No menu item added; `MantaProse`/`UserBand`/`LiveProseTail`/step rows untouched; MessagingUI & MarkdownView untouched; composer untouched; desktop renderer untouched.

## Behavior after this change
- Long-press assistant prose → native SwiftUI text selection (word + grab handles, stock Copy/Look Up/Translate/Share menu).
- Long-press a user message → SwiftUI's selection menu.
- No Quote item (correct for this issue; BET-1364 adds it).
- No whole row lifts/highlights.

## Verification
- **iOS unit suite: PASS** — `ios-mantaui` `action: test-unit` on `multica/BET-1363-ios-remove-quote-contextmenu` @ `a18a2bc4`: **Executed 692 tests, 0 failures** (includes the mandated-green `QuoteText` `SessionModelsTests`).
- **Simulator gesture observation (issue step 2/3): NOT yet completed.** The `manta-sim-drive pair` run stalled at the live-box pairing step and the Mac desktop executor was lost (30-min timeout — laptop asleep). Also, the available simulator tooling has no long-press / drag-selection-handle gesture driver. This is a required answer for BET-1364 and is being handled via Mac-side handoff.

**Base:** `origin/main` @ `99e61dba`
