### PR TITLE
iOS session list: symmetric group-header spacing (BET-1362)

### DIFF
--- a/generated/swift/Theme.swift
+++ b/generated/swift/Theme.swift
@@ -173,7 +173,7 @@ struct TypeMetrics {
 enum Metrics {
     static let spacing = Spacing(sp0: 0, spPx: 1, sp1: 4, sp2: 8, sp3: 12, sp4: 16, sp5: 20, sp6: 24, sp8: 32, sp10: 40, sp12: 48)
     static let radius = Radius(xs: 4, sm: 6, md: 8, lg: 12, xl: 16, full: 999)
-    static let type = TypeMetrics(sans: "Inter Variable, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif", mono: "JetBrains Mono Variable, JetBrains Mono, SF Mono, Menlo, Consolas, monospace", body: 15, small: 13, xs: 12, twoXS: 11, display: 28, confirm: 40, otp: 26, medium: 500, semibold: 600, proseLineHeight: 1.55, uiLineHeight: 1.45, rowName: 15.5, headingTracking: -0.015, rowNameTracking: -0.01, chatTitle: 14.5, chatTitleTracking: -0.01, stepRowY: 7, stepDot: 6, chatHeaderBtn: 38, listRowMinH: 62, listRowRadius: 20, listRowMargin: 2, listGroupAbove: 22, listGroupBelow: 6, inlineMaxW: 520, widgetDormantOpacity: 0.5)
+    static let type = TypeMetrics(sans: "Inter Variable, Inter, system-ui, -apple-system, Segoe UI, Roboto, sans-serif", mono: "JetBrains Mono Variable, JetBrains Mono, SF Mono, Menlo, Consolas, monospace", body: 15, small: 13, xs: 12, twoXS: 11, display: 28, confirm: 40, otp: 26, medium: 500, semibold: 600, proseLineHeight: 1.55, uiLineHeight: 1.45, rowName: 15.5, headingTracking: -0.015, rowNameTracking: -0.01, chatTitle: 14.5, chatTitleTracking: -0.01, stepRowY: 7, stepDot: 6, chatHeaderBtn: 38, listRowMinH: 62, listRowRadius: 20, listRowMargin: 2, listGroupAbove: 6, listGroupBelow: 6, inlineMaxW: 520, widgetDormantOpacity: 0.5)
 }
 
 extension Color {

--- a/src/renderer/tokens.css
+++ b/src/renderer/tokens.css
@@ -142,7 +142,7 @@
   --list-row-min-h: 62px;
   --list-row-radius: 20px;
   --list-row-margin: 2px;
-  --list-group-above: 22px;
+  --list-group-above: 6px;
   --list-group-below: 6px;
   --font-size-row-name: 15.5px;
   --tracking-list-heading: -0.015;


### PR DESCRIPTION
Opened automatically for `multica/BET-1362-ios-group-header-spacing`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1362.