### PR TITLE
feat(ios): Quote / Quote in new session on the system prose selection menu (BET-1364)

### DIFF
--- a/mobile/native/MantaUI.xcodeproj/project.pbxproj
+++ b/mobile/native/MantaUI.xcodeproj/project.pbxproj
@@ -12,6 +12,7 @@
 		0488B71F794FC6E64CDC0B23 /* TerminalKeyRow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7D7BC8920829E8847057C8DA /* TerminalKeyRow.swift */; };
 		058E2179669599C216446E7C /* ToolOutputPreviewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DAD2C923C52DE07EB54AB821 /* ToolOutputPreviewTests.swift */; };
 		0DA0C1C92C06A3BED780494E /* UsageMeters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1A81D1BB24FB02E4DFFA04FE /* UsageMeters.swift */; };
+		103C101C1679499BAFA7257B /* TranscriptSelectionMenu.swift in Sources */ = {isa = PBXBuildFile; fileRef = B43DC78B0971B2BF584DEA2C /* TranscriptSelectionMenu.swift */; };
 		12070C130BD9D1CD9EA0603F /* WaveformTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = AEF7554D798247FECA6BFF84 /* WaveformTests.swift */; };
 		12C1D08D7311357D1872FA18 /* ChatJSON.swift in Sources */ = {isa = PBXBuildFile; fileRef = E246039C1A3AA38065BE89B0 /* ChatJSON.swift */; };
 		1888AC1DE5A98EFBE6DDEA51 /* DeprecatedModelOptIns.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6169B72F37CC138729DDD22E /* DeprecatedModelOptIns.swift */; };
@@ -248,6 +249,7 @@
 		AE01D00B6A031E239CC12EAD /* VoiceNoteTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VoiceNoteTests.swift; sourceTree = "<group>"; };
 		AEF7554D798247FECA6BFF84 /* WaveformTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WaveformTests.swift; sourceTree = "<group>"; };
 		B230F69A60CD3DBC416612B0 /* manta-logo.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; path = "manta-logo.png"; sourceTree = "<group>"; };
+		B43DC78B0971B2BF584DEA2C /* TranscriptSelectionMenu.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranscriptSelectionMenu.swift; sourceTree = "<group>"; };
 		B82B782F73475FDD71F6D6B5 /* PolishTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PolishTests.swift; sourceTree = "<group>"; };
 		B928337494F2C80D8ACB126C /* SessionCreateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SessionCreateSheet.swift; sourceTree = "<group>"; };
 		BA460F4E709501AE6C65D08A /* ChatOverflowSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChatOverflowSheet.swift; sourceTree = "<group>"; };
@@ -452,6 +454,7 @@
 				6BDC7F6FA94631DA4C55A948 /* TerminalWebView.swift */,
 				A26BEC5EF47268C8B29239F0 /* TranscriptComponents.swift */,
 				74A048582549409FE0949053 /* TranscriptRow.swift */,
+				B43DC78B0971B2BF584DEA2C /* TranscriptSelectionMenu.swift */,
 				1A81D1BB24FB02E4DFFA04FE /* UsageMeters.swift */,
 				7582E08CBBDCE70E242A6B18 /* UsageSheets.swift */,
 				CAFF319B4F3CD4F13A20A1EB /* UsageStore.swift */,
@@ -773,6 +776,7 @@
 				E096BAD9FD8E87E15481B646 /* Theme.swift in Sources */,
 				95970E5B12500AFD427E23D9 /* TranscriptComponents.swift in Sources */,
 				2F0CAA1B1DC211D065AC4761 /* TranscriptRow.swift in Sources */,
+				103C101C1679499BAFA7257B /* TranscriptSelectionMenu.swift in Sources */,
 				0DA0C1C92C06A3BED780494E /* UsageMeters.swift in Sources */,
 				37B7F5C28332A180E825982C /* UsageSheets.swift in Sources */,
 				1E8A1AB9FB3945E6092CA2E2 /* UsageStore.swift in Sources */,

--- a/mobile/native/MantaUI/TranscriptComponents.swift
+++ b/mobile/native/MantaUI/TranscriptComponents.swift
@@ -68,6 +68,16 @@ struct UserBand: View {
 struct MantaProse: View {
     let text: String
     let tokens: Tokens
+    /// Quote callback for the system text-selection menu (BET-1364). Nil on
+    /// read-only surfaces (subagent drill-in, capture fixture) which have no
+    /// composer to quote into — they keep the stock selection menu.
+    let onQuote: ((String, QuoteDestination) -> Void)?
+
+    init(text: String, tokens: Tokens, onQuote: ((String, QuoteDestination) -> Void)? = nil) {
+        self.text = text
+        self.tokens = tokens
+        self.onQuote = onQuote
+    }
 
     var body: some View {
         MarkdownText(text)
@@ -102,6 +112,15 @@ struct MantaProse: View {
             .padding(.bottom, Metrics.spacing.sp3)
             .accessibilityElement(children: .contain)
             .accessibilityIdentifier("assistant-prose")
+            // The quote-menu attachment (BET-1364): a zero-size background probe
+            // that finds the library's `UITextView` and installs the forwarding
+            // edit-menu delegate. `onQuote` nil on read-only surfaces → nothing
+            // attached, stock menu stays.
+            .background {
+                if let onQuote {
+                    TranscriptEditMenuAttachment(onQuote: onQuote)
+                }
+            }
     }
 }
 

--- a/mobile/native/MantaUI/TranscriptRow.swift
+++ b/mobile/native/MantaUI/TranscriptRow.swift
@@ -320,7 +320,10 @@ func transcriptBlockView(_ block: TranscriptBlock, tokens: Tokens, cards: Transc
         UserBand(text: text, tokens: tokens)
             .padding(.bottom, Metrics.spacing.sp4)
     case .prose(let text, _):
-        MantaProse(text: text, tokens: tokens)
+        // `cards?.onQuote` (not the inert fallback `actions`): read-only
+        // surfaces (`cards == nil`) attach nothing and keep the stock selection
+        // menu — they have no composer to quote into (BET-1364).
+        MantaProse(text: text, tokens: tokens, onQuote: cards?.onQuote)
     case .file(let attachment):
         // The voice-note player sits directly under the user band it belongs
         // to: 12px horizontal, 14px below. Image and generic-file rendering are

--- a/mobile/native/MantaUI/TranscriptSelectionMenu.swift
+++ b/mobile/native/MantaUI/TranscriptSelectionMenu.swift
@@ -1,0 +1,178 @@
+import SwiftUI
+import UIKit
+
+// ===========================================================================
+// Quote on the SYSTEM text-selection menu (BET-1364).
+//
+// Assistant prose renders through `MantaProse` → `MarkdownText` (the
+// MarkdownView package), which drops a plain `UITextView` (owned by the
+// transitive RichText package) into the cell. iOS lets an app add items to a
+// text-selection menu ONLY through that text view's `UITextViewDelegate`, and
+// MarkdownView exposes no hook — its coordinator wires nothing to the
+// edit-menu callback.
+//
+// This file installs our OWN forwarding delegate on that `UITextView` at
+// runtime: every message is forwarded to whatever delegate was already there
+// (so the library keeps working) and exactly one method is implemented on top
+// — `textView(_:editMenuForTextInRanges:suggestedActions:)` — to append the
+// two quote actions.
+//
+// Scope (deliberate): assistant prose (`MantaProse`) ONLY. User bands, the
+// live streaming tail and step-row tool output are plain SwiftUI `Text` with
+// no UIKit text view to hook, and stay on the stock menu.
+// ===========================================================================
+
+/// The edit-menu forwarding delegate installed on the assistant prose text
+/// view. `@MainActor`: `UITextViewDelegate` is main-actor isolated in the iOS
+/// 26 SDK.
+@MainActor
+final class TranscriptEditMenuDelegate: NSObject, UITextViewDelegate {
+    private weak var wrapped: (any UITextViewDelegate)?
+    private let onQuote: (String, QuoteDestination) -> Void
+
+    init(wrapping wrapped: (any UITextViewDelegate)?, onQuote: @escaping (String, QuoteDestination) -> Void) {
+        self.wrapped = wrapped
+        self.onQuote = onQuote
+        super.init()
+    }
+
+    /// Obj-C message forwarding so the library's own delegate keeps receiving
+    /// everything it did before this delegate was interposed.
+    override func responds(to aSelector: Selector!) -> Bool {
+        super.responds(to: aSelector) || (wrapped?.responds(to: aSelector) ?? false)
+    }
+
+    override func forwardingTarget(for aSelector: Selector!) -> Any? {
+        wrapped
+    }
+
+    /// The ONE method this delegate implements itself: adds `Quote` and
+    /// `Quote in new session` to the selection menu, appended AFTER the system
+    /// suggested actions.
+    func textView(_ textView: UITextView,
+                  editMenuForTextInRanges ranges: [NSValue],
+                  suggestedActions: [UIMenuElement]) -> UIMenu? {
+        let selection = ranges
+            .compactMap { Range($0.rangeValue, in: textView.text) }
+            .map { String(textView.text[$0]) }
+            .joined(separator: " ")
+
+        // Empty / whitespace-only selection → show the default system menu.
+        guard QuoteText.buildQuoteBlock(selection) != nil else { return nil }
+
+        let quoteAction = UIAction(title: "Quote") { [onQuote] _ in
+            onQuote(selection, .thisSession)
+        }
+        let quoteNewSessionAction = UIAction(title: "Quote in new session") { [onQuote] _ in
+            onQuote(selection, .newSession)
+        }
+
+        // The RAW selection, not a built block — `ChatScreen.quote(_:into:)`
+        // already runs it through `QuoteText.buildQuoteBlock`.
+        return UIMenu(children: suggestedActions + [quoteAction, quoteNewSessionAction])
+    }
+}
+
+/// A zero-size, non-interactive probe placed as the `.background` of the prose
+/// view. Its only job is to find the rendered `UITextView` and install the
+/// forwarding delegate.
+struct TranscriptEditMenuAttachment: UIViewRepresentable {
+    let onQuote: (String, QuoteDestination) -> Void
+
+    @MainActor
+    final class Coordinator {
+        /// Strong reference to the installed delegate (`UITextView.delegate` is
+        /// `weak`, so without this the delegate deallocates immediately and the
+        /// menu silently never appears).
+        private var delegate: TranscriptEditMenuDelegate?
+        private let onQuote: (String, QuoteDestination) -> Void
+
+        init(onQuote: @escaping (String, QuoteDestination) -> Void) {
+            self.onQuote = onQuote
+        }
+
+        func attach(in probe: ProbeView?) {
+            guard let probe, let textView = Self.firstTextView(from: probe) else { return }
+            // Idempotent: leave an already-installed delegate alone.
+            guard !(textView.delegate is TranscriptEditMenuDelegate) else { return }
+            let delegate = TranscriptEditMenuDelegate(wrapping: textView.delegate, onQuote: onQuote)
+            textView.delegate = delegate
+            self.delegate = delegate
+        }
+
+        /// Search: starting at the probe, walk up at most 8 superviews; at each
+        /// node breadth-first search its subtree for the first `UITextView`;
+        /// stop at the first one found. If none is found, do nothing silently.
+        private static func firstTextView(from start: UIView) -> UITextView? {
+            var node: UIView? = start
+            var steps = 0
+            while let current = node, steps <= 8 {
+                if let textView = bfsFirstTextView(in: current) {
+                    return textView
+                }
+                node = current.superview
+                steps += 1
+            }
+            return nil
+        }
+
+        private static func bfsFirstTextView(in root: UIView) -> UITextView? {
+            var queue: [UIView] = [root]
+            var index = 0
+            while index < queue.count {
+                let node = queue[index]
+                index += 1
+                if let textView = node as? UITextView {
+                    return textView
+                }
+                queue.append(contentsOf: node.subviews)
+            }
+            return nil
+        }
+    }
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onQuote: onQuote)
+    }
+
+    func makeUIView(context: Context) -> ProbeView {
+        let probe = ProbeView()
+        probe.onProbe = { [weak coordinator = context.coordinator, weak probe] in
+            coordinator?.attach(in: probe)
+        }
+        return probe
+    }
+
+    func updateUIView(_ uiView: ProbeView, context: Context) {}
+
+    /// The attachment must never affect row height.
+    func sizeThatFits(_ proposal: ProposedViewSize, uiView: ProbeView, context: Context) -> CGSize? {
+        .zero
+    }
+
+    /// The zero-size, non-interactive probe view.
+    final class ProbeView: UIView {
+        var onProbe: (() -> Void)?
+
+        override init(frame: CGRect) {
+            super.init(frame: frame)
+            isUserInteractionEnabled = false
+            backgroundColor = .clear
+        }
+
+        @available(*, unavailable)
+        required init?(coder: NSCoder) {
+            fatalError("init(coder:) has not been implemented")
+        }
+
+        override func didMoveToWindow() {
+            super.didMoveToWindow()
+            onProbe?()
+        }
+
+        override func layoutSubviews() {
+            super.layoutSubviews()
+            onProbe?()
+        }
+    }
+}

--- a/mobile/native/MantaUI/TranscriptSelectionMenu.swift
+++ b/mobile/native/MantaUI/TranscriptSelectionMenu.swift
@@ -13,9 +13,8 @@ import UIKit
 //
 // This file installs our OWN forwarding delegate on that `UITextView` at
 // runtime: every message is forwarded to whatever delegate was already there
-// (so the library keeps working) and exactly one method is implemented on top
-// — `textView(_:editMenuForTextInRanges:suggestedActions:)` — to append the
-// two quote actions.
+// (so the library keeps working) and the edit-menu methods are implemented on
+// top to append the two quote actions.
 //
 // Scope (deliberate): assistant prose (`MantaProse`) ONLY. User bands, the
 // live streaming tail and step-row tool output are plain SwiftUI `Text` with
@@ -46,9 +45,9 @@ final class TranscriptEditMenuDelegate: NSObject, UITextViewDelegate {
         wrapped
     }
 
-    /// The ONE method this delegate implements itself: adds `Quote` and
-    /// `Quote in new session` to the selection menu, appended AFTER the system
-    /// suggested actions.
+    /// The multiple-ranges edit-menu variant (iOS 26). UIKit prefers this when
+    /// the delegate implements it and only falls back to the single-range
+    /// variant when it does not, so this is the primary path.
     func textView(_ textView: UITextView,
                   editMenuForTextInRanges ranges: [NSValue],
                   suggestedActions: [UIMenuElement]) -> UIMenu? {
@@ -56,8 +55,22 @@ final class TranscriptEditMenuDelegate: NSObject, UITextViewDelegate {
             .compactMap { Range($0.rangeValue, in: textView.text) }
             .map { String(textView.text[$0]) }
             .joined(separator: " ")
+        return editMenu(for: selection, suggestedActions: suggestedActions)
+    }
 
-        // Empty / whitespace-only selection → show the default system menu.
+    /// The single-range edit-menu variant (16.0+). Implemented alongside the
+    /// ranges variant so the two items appear regardless of which selector
+    /// UIKit dispatches on a given OS/selection mode.
+    func textView(_ textView: UITextView,
+                  editMenuForTextIn range: NSRange,
+                  suggestedActions: [UIMenuElement]) -> UIMenu? {
+        guard let swiftRange = Range(range, in: textView.text) else { return nil }
+        return editMenu(for: String(textView.text[swiftRange]), suggestedActions: suggestedActions)
+    }
+
+    private func editMenu(for selection: String, suggestedActions: [UIMenuElement]) -> UIMenu? {
+        // Empty / whitespace-only selection → show the default system menu
+        // (returning nil; an empty UIMenu would suppress the menu entirely).
         guard QuoteText.buildQuoteBlock(selection) != nil else { return nil }
 
         let quoteAction = UIAction(title: "Quote") { [onQuote] _ in
@@ -86,23 +99,71 @@ struct TranscriptEditMenuAttachment: UIViewRepresentable {
         /// menu silently never appears).
         private var delegate: TranscriptEditMenuDelegate?
         private let onQuote: (String, QuoteDestination) -> Void
+        private weak var probe: ProbeView?
+        private var firstAttempt: Date?
+        private let maxTriesMilliseconds: TimeInterval = 5_000
 
         init(onQuote: @escaping (String, QuoteDestination) -> Void) {
             self.onQuote = onQuote
         }
 
         func attach(in probe: ProbeView?) {
-            guard let probe, let textView = Self.firstTextView(from: probe) else { return }
+            self.probe = probe
+            let now = Date()
+            if firstAttempt == nil { firstAttempt = now }
+            tryAttach()
+        }
+
+        /// One install attempt. Idempotent (an already-installed delegate is
+        /// left alone). If no text view is found yet — RichText lays its text
+        /// view into the hierarchy asynchronously after the probe's own
+        /// `didMoveToWindow`/`layoutSubviews` fire — schedules a bounded retry;
+        /// the probe's subsequent layout passes also re-invoke `attach`.
+        private func tryAttach() {
+            guard let probe, let textView = Self.firstTextView(from: probe) else {
+                scheduleRetryIfNeeded()
+                return
+            }
             // Idempotent: leave an already-installed delegate alone.
             guard !(textView.delegate is TranscriptEditMenuDelegate) else { return }
-            let delegate = TranscriptEditMenuDelegate(wrapping: textView.delegate, onQuote: onQuote)
+            let original = textView.delegate
+            let delegate = TranscriptEditMenuDelegate(wrapping: original, onQuote: onQuote)
             textView.delegate = delegate
             self.delegate = delegate
+            // Single line of runtime evidence: which text view we attached to,
+            // so a sighted/on-device check can confirm it is the assistant-prose
+            // text view (and that we wrapped RichText's own delegate).
+            NSLog("[BET1364] attached edit-menu delegate to \(type(of: textView)) frame=\(textView.frame) wrapped=\(String(describing: type(of: original)))")
+        }
+
+        /// Bounded retry backstop for the async text-view appear: retry with a
+        /// short backoff while the probe is still in a window and within a
+        /// generous time budget, stopping as soon as the delegate is attached.
+        /// Not a polling loop — finite (time-bounded), and each pass returns
+        /// immediately once attached.
+        private func scheduleRetryIfNeeded() {
+            guard let probe, probe.window != nil else { return }
+            guard let firstAttempt else { return }
+            let elapsed = Date().timeIntervalSince(firstAttempt) * 1_000
+            guard elapsed < maxTriesMilliseconds else { return }
+            let delay = min(pow(1.3, CGFloat(retryStep())), 0.5)
+            Task { @MainActor [weak self] in
+                try? await Task.sleep(nanoseconds: UInt64(delay * 1_000_000_000))
+                self?.tryAttach()
+            }
+        }
+
+        private var retryStepValue = 0
+        private func retryStep() -> Int {
+            retryStepValue += 1
+            return retryStepValue
         }
 
         /// Search: starting at the probe, walk up at most 8 superviews; at each
         /// node breadth-first search its subtree for the first `UITextView`;
-        /// stop at the first one found. If none is found, do nothing silently.
+        /// stop at the first one found. If none is found, do nothing silently —
+        /// the stock menu still works and a missing quote item is not worth a
+        /// crash or log spam.
         private static func firstTextView(from start: UIView) -> UITextView? {
             var node: UIView? = start
             var steps = 0

--- a/mobile/native/MantaUI/TranscriptSelectionMenu.swift
+++ b/mobile/native/MantaUI/TranscriptSelectionMenu.swift
@@ -37,10 +37,12 @@ final class TranscriptEditMenuDelegate: NSObject, UITextViewDelegate {
 
     /// Obj-C message forwarding so the library's own delegate keeps receiving
     /// everything it did before this delegate was interposed.
+    // swiftlint:disable:next implicitly_unwrapped_optional
     override func responds(to aSelector: Selector!) -> Bool {
         super.responds(to: aSelector) || (wrapped?.responds(to: aSelector) ?? false)
     }
 
+    // swiftlint:disable:next implicitly_unwrapped_optional
     override func forwardingTarget(for aSelector: Selector!) -> Any? {
         wrapped
     }


### PR DESCRIPTION
Opened automatically for `multica/BET-1364-ios-transcript-quote-menu`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1364.