### PR TITLE
fix(server): harden self-update for low disk, clean ANSI from failure banner

### DIFF
--- a/scripts/lib/release.sh
+++ b/scripts/lib/release.sh
@@ -116,10 +116,31 @@ detect_install_kind() { # $1=has_release_json $2=has_git
 # open binary's inode survives until the process exits) and the caller restarts
 # the server at the end of the update.
 #
+# require_free_space <pkg-dir> <dest-dir>
+#
+# Refuse the payload swap when <dest-dir> cannot hold another copy of the
+# extracted payload. replace_release_payload stages each path as `<rel>.new`
+# BEFORE deleting the old one, so an update transiently needs roughly the
+# payload's size in free space on top of what is already installed. Without
+# this the swap dies halfway through with an ENOSPC from `cp`.
+#
+# Deliberately NON-FATAL when either probe fails (no `du`, no `df`, an unusual
+# mount): a preflight must never become a new way for a healthy update to fail.
+# Both probes are asked for KB so the units already agree.
+require_free_space() {
+  local pkg="$1" dest="$2" need avail
+  need="$(du -sk "$pkg" 2>/dev/null | awk '{print $1}')"
+  avail="$(df -Pk "$dest" 2>/dev/null | awk 'NR==2 {print $4}')"
+  [ -n "$need" ] && [ -n "$avail" ] || return 0
+  case "$need" in *[!0-9]*) return 0 ;; esac
+  case "$avail" in *[!0-9]*) return 0 ;; esac
+  [ "$avail" -ge "$need" ] || die "release payload: not enough disk space at $dest — need $((need / 1024)) MB free, have $((avail / 1024)) MB. Free up space and run the update again."
+}
+
 # node-bin is passed in rather than read from a global so this function has no
 # dependency on the caller's variable names.
 replace_release_payload() {
-  local pkg="$1" dest="$2" node_bin="$3" rel includes
+  local pkg="$1" dest="$2" node_bin="$3" rel includes cp_err mv_err
   # Tells install_prod_deps whether this run already installed a prebuilt,
   # build-time-verified node_modules from the payload. Reset per call so a
   # caller can never inherit a stale "yes" from an earlier invocation.
@@ -127,14 +148,15 @@ replace_release_payload() {
   includes="$("$node_bin" -e 'const i=JSON.parse(require("fs").readFileSync(process.argv[1],"utf8")).includes||[]; process.stdout.write(i.join("\n"))' "$pkg/RELEASE.json")" \
     || die "release payload: cannot read includes from $pkg/RELEASE.json"
   [ -n "$includes" ] || die "release payload: $pkg/RELEASE.json has an empty includes list"
+  require_free_space "$pkg" "$dest"
   for rel in $includes; do
     [ -n "$rel" ] || continue
     [ -e "$pkg/$rel" ] || die "release payload: tarball is missing $rel"
     rm -rf "$dest/$rel.new"
     mkdir -p "$(dirname "$dest/$rel")"
-    cp -R "$pkg/$rel" "$dest/$rel.new" || die "release payload: copy failed for $rel"
+    cp_err="$(cp -R "$pkg/$rel" "$dest/$rel.new" 2>&1)" || die "release payload: copy failed for $rel: $cp_err"
     rm -rf "$dest/$rel"
-    mv "$dest/$rel.new" "$dest/$rel" || die "release payload: swap failed for $rel"
+    mv_err="$(mv "$dest/$rel.new" "$dest/$rel" 2>&1)" || die "release payload: swap failed for $rel: $mv_err"
     [ "$rel" = "node_modules" ] && REPLACED_NODE_MODULES=1
   done
   cp "$pkg/RELEASE.json" "$dest/RELEASE.json"

--- a/scripts/lib/release.test.mjs
+++ b/scripts/lib/release.test.mjs
@@ -379,6 +379,89 @@ test("replace_release_payload: signals when it swapped node_modules from the pay
   rmSync(dest, { recursive: true, force: true });
 });
 
+// A package whose payload owns exactly ONE path: `runtime`. Keeps the low-disk
+// / copy-failure cases deterministic — the first (and only) staged copy is
+// always `runtime`, so assertions on `/copy failed for runtime/` are stable.
+function makeRuntimeOnlyPkg() {
+  const pkg = mkdtempSync(join(tmpdir(), "manta-rel-pkg-"));
+  writeFileSync(
+    join(pkg, "RELEASE.json"),
+    JSON.stringify({ name: "manta", version: "2.0.0", includes: ["runtime"] }),
+  );
+  writeTree(pkg, { "runtime/node/bin/node": "new node binary" });
+  return pkg;
+}
+
+test("replace_release_payload: copy failure carries the underlying reason", () => {
+  // The regression: the swap used to die with only "<rel> copy failed" — the
+  // actionable half ("No space left on device") lived on the cp stderr line
+  // BEFORE the die line, which the caller surfaces last and therefore threw
+  // away. Folding cp_err into the die message fixes diagnosability.
+  const pkg = makeRuntimeOnlyPkg();
+  const dest = makeInstalledDest();
+  writeTree(dest, { "runtime/node/bin/node": "old node binary" });
+  try {
+    const r = sourceAndRun(`
+      cp() { echo "cp: cannot create regular file: No space left on device" >&2; return 1; }
+      replace_release_payload '${pkg}' '${dest}' '${NODE_CMD}'
+    `);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stdout, /copy failed for runtime: /);
+    assert.match(r.stdout, /No space left on device/);
+  } finally {
+    rmSync(pkg, { recursive: true, force: true });
+    rmSync(dest, { recursive: true, force: true });
+  }
+});
+
+test("replace_release_payload: preflight refuses when disk is short, mutating nothing", () => {
+  // available (1000 KB) < needed (500000 KB) → refuse before ANY staged copy.
+  // The "nothing was mutated" half is the point: not a .new dir, not a
+  // touched original.
+  const pkg = makeRuntimeOnlyPkg();
+  const dest = makeInstalledDest();
+  writeTree(dest, { "runtime/node/bin/node": "old node binary" });
+  const before = JSON.stringify(readTree(dest));
+  try {
+    const r = sourceAndRun(`
+      du() { echo "500000 $2"; }
+      df() { printf 'Filesystem 1024-blocks Used Available Capacity Mounted\\n/dev/x 100 100 1000 99%% /\\n'; }
+      replace_release_payload '${pkg}' '${dest}' '${NODE_CMD}'
+    `);
+    assert.notEqual(r.status, 0);
+    assert.match(r.stdout, /not enough disk space/);
+    const after = readTree(dest);
+    assert.equal(JSON.stringify(after), before, "dest must be untouched when refused");
+    for (const rel of allPaths(dest)) {
+      assert.ok(!rel.endsWith(".new"), `staging dir survived: ${rel}`);
+      assert.ok(!rel.includes(".new/"), `staging dir survived: ${rel}`);
+    }
+  } finally {
+    rmSync(pkg, { recursive: true, force: true });
+    rmSync(dest, { recursive: true, force: true });
+  }
+});
+
+test("replace_release_payload: preflight stays out of the way when a probe fails", () => {
+  // du returning 1 (no `du`, unusual mount) must NOT become a new way for a
+  // healthy update to fail: require_free_space is non-fatal and the swap
+  // proceeds exactly as it does today.
+  const pkg = makeRuntimeOnlyPkg();
+  const dest = makeInstalledDest();
+  writeTree(dest, { "runtime/node/bin/node": "old node binary" });
+  try {
+    const r = sourceAndRun(`
+      du() { return 1; }
+      replace_release_payload '${pkg}' '${dest}' '${NODE_CMD}'
+    `);
+    assert.equal(r.status, 0, r.stdout);
+    assert.equal(readTree(dest)["runtime/node/bin/node"], "new node binary");
+  } finally {
+    rmSync(pkg, { recursive: true, force: true });
+    rmSync(dest, { recursive: true, force: true });
+  }
+});
+
 // --- release_is_current: the updater's skip decision ------------------------
 //
 // The regression this pins: the check used to compare `version` only, so a

--- a/src/server/opencodeAdmin.mjs
+++ b/src/server/opencodeAdmin.mjs
@@ -177,6 +177,17 @@ export function parseProgressLine(line) {
   return { step, total, label: m[3].trim() };
 }
 
+// Strip SGR colour codes and a leading status glyph from a self-update log
+// line. The shell helpers in scripts/self-update.sh colour their output and
+// prefix a glyph; both are noise once the text is interpolated into the UI
+// banner, where "Update failed: ✗ …" reads as a doubled error.
+function cleanLogLine(line) {
+  return line
+    .replace(/\x1b\[[0-9;]*m/g, "")
+    .replace(/^[✗✓!▸]\s*/, "")
+    .trim();
+}
+
 // Last non-empty line of the self-update log, or a fallback derived from the
 // error/exit that triggered the failure report. Never throws.
 function lastLogLine(logPath, err) {
@@ -184,7 +195,7 @@ function lastLogLine(logPath, err) {
   try {
     const lines = readFileSync(logPath, "utf8")
       .split(/\r?\n/)
-      .map((l) => l.trim())
+      .map(cleanLogLine)
       .filter((l) => l.length > 0);
     return lines.length > 0 ? lines[lines.length - 1] : fallback;
   } catch {

--- a/src/server/opencodeAdmin.test.mjs
+++ b/src/server/opencodeAdmin.test.mjs
@@ -130,7 +130,38 @@ describe("runServerSelfUpdate", () => {
       timeoutMs: 500,
     });
     assert.equal(result.ok, false);
-    assert.equal(result.error, "✗ self-update: manifest fetch failed: https://mantaui.com/releases/");
+    assert.equal(result.error, "self-update: manifest fetch failed: https://mantaui.com/releases/");
+  });
+
+  it("strips SGR colour codes and the leading status glyph from the last log line", async () => {
+    // The self-update shell helpers colour their output and prefix a glyph;
+    // lastLogLine is the one point every consumer of the banner flows through.
+    // A coloured+glyph failure line must reach the banner clean: no escape
+    // bytes, no leading ✗ (which would read as a doubled error under
+    // "Update failed: …").
+    const logPath = statePath("self-update.log");
+    mkdirSync(dirname(logPath), { recursive: true });
+    writeFileSync(
+      logPath,
+      "\u001b[31m✗ release payload: copy failed for runtime: cp: No space left on device\u001b[0m\n",
+    );
+
+    const child = new EventEmitter();
+    child.pid = 4242;
+    child.unref = () => {};
+    const spawn = () => {
+      setImmediate(() => setTimeout(() => child.emit("exit", 1), 0));
+      return child;
+    };
+    const result = await runServerSelfUpdate("/abs/scripts/self-update.sh", spawn, {
+      timeoutMs: 500,
+    });
+    assert.equal(result.ok, false);
+    assert.ok(!/\u001b/.test(result.error), "no escape bytes may reach the banner");
+    assert.equal(
+      result.error,
+      "release payload: copy failed for runtime: cp: No space left on device",
+    );
   });
 
   it("resolves ok:true when the child exits zero fast", async () => {


### PR DESCRIPTION
Harden the packaged self-update for low-disk boxes and clean up the
failure banner.

## Changes

1. **Low-disk preflight** (`require_free_space` in `scripts/lib/release.sh`):
   `replace_release_payload` stages each payload path as `<rel>.new`
   *before* deleting the old one, so an update transiently needs roughly
   the payload's size in free space on top of what is installed. On a tight
   disk the `cp` dies with a bare ENOSPC and the box is left half-swapped.
   The new preflight refuses the whole swap up front (non-fatal when either
   probe fails — no `du`/`df`/unusual mount must not become a new way a
   healthy update fails).

2. **Diagnosable copy/swap failures**: the `cp`/`mv` dies now fold the
   underlying reason into the message instead of "copy failed for <rel>",
   so "No space left on device" actually reaches the operator.

3. **Clean ANSI from the failure banner** (`lastLogLine` in
   `src/server/opencodeAdmin.mjs`): strip SGR colour codes + the leading
   status glyph from the log line the UI surfaces, so a coloured "✗ …"
   line doesn't render as a doubled error under "Update failed: …".

## Verification (red/green)

- 2 new `release.test.mjs` cases (copy-failure reason, low-disk refusal)
  **fail** on the pre-change `release.sh` and **pass** after; the
  probe-failure case passes both (non-regression guard).
- 1 `opencodeAdmin.test.mjs` case (ANSI+glyph stripping) plus the
  existing last-log-line companion test **fail** without the
  `opencodeAdmin.mjs` change and **pass** after.

**Files changed:** `4` files `scripts/lib/release.sh`,
`scripts/lib/release.test.mjs`, `src/server/opencodeAdmin.mjs`,
`src/server/opencodeAdmin.test.mjs`

**Verification results:**
- PR branch (`multica/BET-1365-selupdate-disk-ansi` @ `09a42334`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2893 pass / 0 fail / 0 skip. Failures: none. log sha256: `d9568a6e0bbe0bd782f509e253d8d51a18423729e5dca7874b3fd4ef7545d7d5`
- Base (`main` @ `0fc76285`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2893 pass / 0 fail / 0 skip. Failures: none. log sha256: `f7cd6094df23ca4e809244b93b7527f8577377deee9bf62482aef72a0d88e002`
- **Conclusion:** 0 failures on either branch; test output differs only in
  run timestamps. No new failures introduced.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`,
`/tmp/test-pr.log`, `/tmp/test-main.log`.

Base: origin/main @ `0fc76285`.
