### PR TITLE
BET-1367: revive catalogue prices & source metered endpoints from user's own

### DIFF
--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -43,7 +43,7 @@ import * as local from "./local.mjs";
 import { createPeekHandler } from "./peek.mjs";
 import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
 import { setTelemetrySink, shipCtxEvent } from "./optimizer/telemetry.mjs";
-import { blendedPrice } from "../shared/blendedPrice.mjs";
+import { buildMeteredEndpoints, catalogEntryForBuilder } from "./routingServices.mjs";
 
 // BET-187: ship every console.* (and any startup banner / poller log) to
 // Axiom when MANTA_AXIOM_TOKEN is set in env AND AppConfig.shareAnalytics
@@ -988,12 +988,14 @@ const optimizerActivity = createActivityLog({
   now: Date.now,
 });
 
-// The metered (pay-per-token) endpoints for the dashboard's slim row: models in
-// the routing catalog that are NOT covered by a subscription quota window, with
-// their blended $/Mtok from the SHARED blendedPrice (never a guess — a model
-// with no price is skipped). A metered endpoint has no window and never resets,
-// so there is nothing to fill — the row is deliberately role+price, no gauge.
-// [] when the catalog or pricing is unavailable (the section is then absent).
+// The metered (pay-per-token) endpoints for the dashboard's slim row: the
+// USER'S OWN endpoints (opencode's live per-provider view) that are NOT
+// covered by a subscription quota window, with their blended $/Mtok from the
+// SHARED blendedPrice (never a guess — a model with no price is skipped). A
+// metered endpoint has no window and never resets, so there is nothing to fill
+// — the row is deliberately role+price, no gauge.
+// [] when the provider list or pricing is unavailable (the section is then
+// absent).
 async function readMeteredEndpoints({ windows = [], cacheShare = {} } = {}) {
   try {
     // BET-1359: consume the windows/cacheShare the summary already computed,
@@ -1011,25 +1013,34 @@ async function readMeteredEndpoints({ windows = [], cacheShare = {} } = {}) {
             cacheWrite: (cs.cacheWrite ?? 0) / denom,
           }
         : { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 };
+    // BET-1367: source the rows from the user's own endpoints — opencode's
+    // per-provider /provider view — NOT the provider-agnostic models.dev
+    // catalogue (which listed hundreds of models the user never configured).
+    // Flatten connected providers → models; each already carries providerID and
+    // a normalised camelCase cost via _normalizeProviderModel.
     let models = [];
     try {
-      models = Array.isArray(routingCatalogIndex.allModels()) ? routingCatalogIndex.allModels() : [];
+      const { connected: connectedIds, all } = await oc.getProviders();
+      const connected = new Set(Array.isArray(connectedIds) ? connectedIds : []);
+      for (const p of Array.isArray(all) ? all : []) {
+        if (!p || typeof p.id !== "string" || !connected.has(p.id)) continue;
+        const pModels = p.models && typeof p.models === "object" ? p.models : {};
+        for (const modelId of Object.keys(pModels)) {
+          const m = oc._normalizeProviderModel(p.id, modelId, pModels[modelId]);
+          if (m) models.push(m);
+        }
+      }
     } catch {
       models = [];
     }
-    const rows = [];
-    for (const model of models) {
-      const prov = typeof model?.providerID === "string" ? model.providerID : null;
-      if (!prov || subProviders.has(prov)) continue;
-      const bp = blendedPrice(model, mix, model?.cost ?? null);
-      if (!bp || bp.known !== true) continue;
-      rows.push({
-        name: `${prov} · ${typeof model.id === "string" ? model.id : ""}`,
-        role: "pay-per-token endpoint",
-        price: `$${bp.price.toFixed(2)} / Mtok blended`,
-      });
-    }
-    return rows.slice(0, 8);
+    return buildMeteredEndpoints({
+      models,
+      mix,
+      subProviders,
+      // The implausible-zero reference comes from the catalogue (reusing the
+      // router's resolver), never the endpoint's own possibly-absent cost.
+      catalogEntryFor: catalogEntryForBuilder(routingCatalogIndex, () => ({})),
+    });
   } catch {
     return [];
   }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -43,7 +43,7 @@ import * as local from "./local.mjs";
 import { createPeekHandler } from "./peek.mjs";
 import { createLogShipper, captureConsole, resolveAxiomConfig } from "../shared/logShip.mjs";
 import { setTelemetrySink, shipCtxEvent } from "./optimizer/telemetry.mjs";
-import { buildMeteredEndpoints, catalogEntryForBuilder } from "./routingServices.mjs";
+import { blendedPrice } from "../shared/blendedPrice.mjs";
 
 // BET-187: ship every console.* (and any startup banner / poller log) to
 // Axiom when MANTA_AXIOM_TOKEN is set in env AND AppConfig.shareAnalytics
@@ -989,11 +989,11 @@ const optimizerActivity = createActivityLog({
 });
 
 // The metered (pay-per-token) endpoints for the dashboard's slim row: the
-// USER'S OWN endpoints (opencode's live per-provider view) that are NOT
-// covered by a subscription quota window, with their blended $/Mtok from the
-// SHARED blendedPrice (never a guess — a model with no price is skipped). A
-// metered endpoint has no window and never resets, so there is nothing to fill
-// — the row is deliberately role+price, no gauge.
+// user's OWN endpoints (opencode's live per-provider view) that are NOT covered
+// by a subscription quota window, with their blended $/Mtok from the SHARED
+// blendedPrice (never a guess — a model with no price is skipped). A metered
+// endpoint has no window and never resets, so there is nothing to fill — the
+// row is deliberately role+price, no gauge.
 // [] when the provider list or pricing is unavailable (the section is then
 // absent).
 async function readMeteredEndpoints({ windows = [], cacheShare = {} } = {}) {
@@ -1013,12 +1013,13 @@ async function readMeteredEndpoints({ windows = [], cacheShare = {} } = {}) {
             cacheWrite: (cs.cacheWrite ?? 0) / denom,
           }
         : { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 };
-    // BET-1367: source the rows from the user's own endpoints — opencode's
-    // per-provider /provider view — NOT the provider-agnostic models.dev
-    // catalogue (which listed hundreds of models the user never configured).
-    // Flatten connected providers → models; each already carries providerID and
-    // a normalised camelCase cost via _normalizeProviderModel.
-    let models = [];
+    // BET-1367: "metered endpoints" means the USER'S OWN pay-per-token
+    // endpoints — opencode's per-provider /provider view — NOT the
+    // provider-agnostic models.dev catalogue (which listed ~360 models the
+    // user may never have configured, and carried no pricing). Flatten
+    // connected providers → models; each already carries `providerID` and a
+    // normalised camelCase `cost`.
+    const models = [];
     try {
       const { connected: connectedIds, all } = await oc.getProviders();
       const connected = new Set(Array.isArray(connectedIds) ? connectedIds : []);
@@ -1031,16 +1032,32 @@ async function readMeteredEndpoints({ windows = [], cacheShare = {} } = {}) {
         }
       }
     } catch {
-      models = [];
+      /* provider list unavailable → no metered rows (the section is absent) */
     }
-    return buildMeteredEndpoints({
-      models,
-      mix,
-      subProviders,
-      // The implausible-zero reference comes from the catalogue (reusing the
-      // router's resolver), never the endpoint's own possibly-absent cost.
-      catalogEntryFor: catalogEntryForBuilder(routingCatalogIndex, () => ({})),
-    });
+    const seen = new Set();
+    const rows = [];
+    for (const model of models) {
+      const prov = typeof model?.providerID === "string" ? model.providerID : "";
+      if (!prov || subProviders.has(prov)) continue;
+      const id = typeof model?.id === "string" ? model.id : "";
+      if (!id) continue;
+      // The 3rd arg is a reference for judging a suspicious ZERO during
+      // ROUTING; here an unpriced endpoint is simply not listed, so pass null.
+      const bp = blendedPrice(model, mix, null);
+      if (!bp || bp.known !== true) continue;
+      const key = `${prov}/${id}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      rows.push({
+        name: `${prov} · ${id}`,
+        role: "pay-per-token endpoint",
+        price: `$${bp.price.toFixed(2)} / Mtok blended`,
+        _price: bp.price,
+      });
+    }
+    // Show the eight most expensive — otherwise which eight appear is arbitrary.
+    rows.sort((a, b) => b._price - a._price);
+    return rows.slice(0, 8).map(({ _price, ...rest }) => rest);
   } catch {
     return [];
   }

--- a/src/server/modelCatalog.mjs
+++ b/src/server/modelCatalog.mjs
@@ -42,13 +42,11 @@ export { normalize, entryHandles, createModelIndex } from "../shared/modelCatalo
 // consumed indirectly via opencode's `/provider`; this one is not.
 export const CATALOG_URL = "https://models.dev/models.json";
 
-// The litellm price ledger — the catalogue's companion (~¥3.2k models, each
-// with per-token $ figures). models.dev identities the models; this file prices
-// them. Fetched alongside the catalogue and merged in `refresh()` so routing's
-// implausible-zero reference can price every priced model even when the
-// per-provider view (the box's own endpoints) quotes 0/0.
-export const CATALOG_PRICE_URL =
-  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+// The provider-keyed view of models.dev. Fetched ONLY for its per-model
+// `cost`, which the provider-agnostic models.json does not carry. The
+// entries themselves still come from CATALOG_URL — this is a merge, never a
+// source swap, because the entry ids/handles drive identity resolution.
+export const CATALOG_PRICE_URL = "https://models.dev/api.json";
 
 // Cache last-good copy to state – `statePath` lands inside the box's state
 // dir (or the test sandbox when MANTA_STATE_HOME is set).
@@ -86,55 +84,49 @@ export function normalizePayload(payload) {
 }
 
 // ---------------------------------------------------------------------------
-// Price map (BET-1367): litellm's per-token $ figures, keyed by model id
+// Price map (BET-1367): models.dev api.json per-model cost, keyed by catalogue id
 // ---------------------------------------------------------------------------
 
-// Convert the litellm price payload ($/token, keyed by model id) into a
-// $/Mtok price map. Direct input/output figures map to `input`/`output`; the
-// cache-read rate maps to `cacheRead` (the cache-creation / write rate is
-// deliberately dropped — the blended blend never prices it). Per-token figures
-// are scaled ×1000 to Mtok to match every other rate in the box. Pure: a
-// single pass, no I/O; models with no usable price are omitted entirely.
-export function buildPriceMap(payload) {
-  const prices = {};
-  const scale = (v) =>
-    typeof v === "number" && Number.isFinite(v) && v >= 0 ? v * 1000 : undefined;
-  for (const e of normalizePayload(payload)) {
-    if (typeof e?.id !== "string" || e.id === "") continue;
-    const input = scale(e.input_cost_per_token);
-    const output = scale(e.output_cost_per_token);
-    const cacheRead = scale(e.cache_read_input_token_cost);
-    if (input === undefined && output === undefined && cacheRead === undefined) continue;
-    prices[e.id] = {
-      ...(input !== undefined ? { input } : {}),
-      ...(output !== undefined ? { output } : {}),
-      ...(cacheRead !== undefined ? { cacheRead } : {}),
-    };
+/**
+ * PURE. Build a `Map<"<provider>/<model>", {input, output, cacheRead, cacheWrite}>`
+ * price map from the models.dev api.json payload, restricted to the ids in
+ * `knownIds`. Snake-cased upstream fields are canonicalised to the same camel
+ * shape opencode's `_normalizePrice` produces; a value that is not a finite
+ * number >= 0 becomes `undefined`, NEVER 0 (unknown and free are different).
+ * Upstream `tiers` / `context_over_200k` / audio / reasoning rates are
+ * deliberately DROPPED — context-tiered pricing is not modelled anywhere in
+ * this codebase and a partial model would be worse than none.
+ */
+export function buildPriceMap(payload, knownIds) {
+  const known = knownIds instanceof Set ? knownIds : new Set([]);
+  const prices = new Map();
+  const norm = (v) =>
+    typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : undefined;
+  for (const [providerId, provider] of Object.entries(payload ?? {})) {
+    const models = provider && typeof provider === "object" ? provider.models : null;
+    if (!models || typeof models !== "object") continue;
+    for (const [modelKey, m] of Object.entries(models)) {
+      if (m === null || typeof m !== "object") continue;
+      const key = `${providerId}/${modelKey}`;
+      // Direct provider/model join only — the reference must be the
+      // authoritative first-party rate, never a cross-provider fallback.
+      if (!known.has(key)) continue;
+      const input = norm(m.input);
+      const output = norm(m.output);
+      const cacheRead = norm(m.cache_read);
+      const cacheWrite = norm(m.cache_write);
+      if (input === undefined && output === undefined && cacheRead === undefined && cacheWrite === undefined) {
+        continue;
+      }
+      prices.set(key, {
+        ...(input !== undefined ? { input } : {}),
+        ...(output !== undefined ? { output } : {}),
+        ...(cacheRead !== undefined ? { cacheRead } : {}),
+        ...(cacheWrite !== undefined ? { cacheWrite } : {}),
+      });
+    }
   }
   return prices;
-}
-
-// Merge a price map into a catalogue entry list by exact model id: for every
-// entry whose id is priced, fold the price's `input`/`output`/`cacheRead` into
-// the entry's `cost`, keeping any cost fields the entry already had. Entries
-// with no matching price (and ids only in the map, not the catalogue) are left
-// untouched. PURE — returns a NEW array, never mutates the input.
-export function mergePriceMap(entries, priceMap) {
-  const map = priceMap && typeof priceMap === "object" ? priceMap : {};
-  return (Array.isArray(entries) ? entries : []).map((e) => {
-    if (!e || typeof e !== "object") return e;
-    const price = map[e.id];
-    if (!price || typeof price !== "object") return e;
-    const cost = { ...(e.cost && typeof e.cost === "object" ? e.cost : {}) };
-    let wrote = false;
-    for (const key of ["input", "output", "cacheRead"]) {
-      if (typeof price[key] === "number" && Number.isFinite(price[key])) {
-        cost[key] = price[key];
-        wrote = true;
-      }
-    }
-    return wrote ? { ...e, cost } : e;
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -153,9 +145,6 @@ export function mergePriceMap(entries, priceMap) {
  *
  * @param {object} [opts]
  * @param {typeof globalThis.fetch} [opts.fetchImpl]
- * @param {typeof globalThis.fetch} [opts.priceFetchImpl] defaults to `fetchImpl`;
- *   a separate stub lets price-fetch failures be exercised without failing the
- *   catalogue itself
  * @param {string} [opts.cachePath] defaults to `CACHE_PATH`
  * @param {number} [opts.intervalMs]
  */
@@ -163,38 +152,42 @@ export function createModelCatalogController({
   fetchImpl,
   cachePath = CACHE_PATH,
   intervalMs = DEFAULT_POLL_MS,
-  priceFetchImpl,
 } = {}) {
   const cached = readJsonSync(cachePath, null);
   let catalog = createModelIndex(normalizePayload(cached));
 
   async function refresh() {
     const doFetch = fetchImpl ?? globalThis.fetch;
-    const doPriceFetch = priceFetchImpl ?? doFetch;
     try {
       const res = await doFetch(CATALOG_URL);
       if (!res || !res.ok) {
         throw new Error(`model catalog fetch failed: ${res?.status ?? "no response"}`);
       }
       const payload = await res.json();
-      let next = normalizePayload(payload);
+      const next = normalizePayload(payload);
       if (next.length === 0) throw new Error("model catalog empty");
-      // BET-1367: fetch the litellm price ledger and merge the matching
-      // entries' input/output/cacheRead ($/Mtok) into the catalogue so routing
-      // can price every priced model. A price-fetch failure is NON-fatal — the
-      // catalogue itself is still good; the models just go unpriced.
+      // BET-1367: merge the per-model cost from the provider-keyed api.json
+      // into the catalogue. Non-fatal: a failed price fetch leaves the entries
+      // exactly as models.json served them (today's behaviour), never blanks a
+      // working catalogue. The merge is additive only — an entry that already
+      // has a `cost` is never overwritten, and no entry is dropped or re-keyed.
+      let priced = next;
       try {
-        const priceRes = await doPriceFetch(CATALOG_PRICE_URL);
-        if (priceRes && priceRes.ok) {
-          const merged = mergePriceMap(next, buildPriceMap(await priceRes.json()));
-          if (merged.length > 0) next = merged;
+        const pRes = await doFetch(CATALOG_PRICE_URL);
+        if (pRes && pRes.ok) {
+          const prices = buildPriceMap(await pRes.json(), new Set(next.map((e) => e.id)));
+          if (prices.size > 0) {
+            priced = next.map((e) =>
+              prices.has(e.id) && !e.cost ? { ...e, cost: prices.get(e.id) } : e,
+            );
+          }
         }
-      } catch {
-        /* no prices → the catalogue stands alone */
+      } catch (e) {
+        console.warn("[model-catalog] price merge skipped:", e?.message ?? e);
       }
-      catalog = createModelIndex(next);
-      await writeJsonAtomic(cachePath, JSON.stringify(payload), { mode: 0o600 });
-      return { ok: true, size: next.length };
+      catalog = createModelIndex(priced);
+      await writeJsonAtomic(cachePath, JSON.stringify(priced), { mode: 0o600 });
+      return { ok: true, size: priced.length };
     } catch (e) {
       return { ok: false, error: e?.message ?? String(e) };
     }

--- a/src/server/modelCatalog.mjs
+++ b/src/server/modelCatalog.mjs
@@ -90,12 +90,16 @@ export function normalizePayload(payload) {
 /**
  * PURE. Build a `Map<"<provider>/<model>", {input, output, cacheRead, cacheWrite}>`
  * price map from the models.dev api.json payload, restricted to the ids in
- * `knownIds`. Snake-cased upstream fields are canonicalised to the same camel
- * shape opencode's `_normalizePrice` produces; a value that is not a finite
- * number >= 0 becomes `undefined`, NEVER 0 (unknown and free are different).
- * Upstream `tiers` / `context_over_200k` / audio / reasoning rates are
- * deliberately DROPPED — context-tiered pricing is not modelled anywhere in
- * this codebase and a partial model would be worse than none.
+ * `knownIds`. Each model's `cost` object's snake-cased fields
+ * (`input`/`output`/`cache_read`/`cache_write`) are canonicalised to the same
+ * camel shape opencode's `_normalizePrice` produces; a value that is not a
+ * finite number >= 0 becomes `undefined`, NEVER 0 (unknown and free are
+ * different). Upstream `tiers` / `context_over_200k` / audio / reasoning rates
+ * are deliberately DROPPED — context-tiered pricing is not modelled anywhere in
+ * this codebase and a partial model would be worse than none. A model is keyed
+ * by whichever of its own ids (the api.json object key, or the
+ * provider-prefixed form) is present in the catalogue — never double-prefixed,
+ * never re-keyed.
  */
 export function buildPriceMap(payload, knownIds) {
   const known = knownIds instanceof Set ? knownIds : new Set([]);
@@ -107,23 +111,32 @@ export function buildPriceMap(payload, knownIds) {
     if (!models || typeof models !== "object") continue;
     for (const [modelKey, m] of Object.entries(models)) {
       if (m === null || typeof m !== "object") continue;
-      const key = `${providerId}/${modelKey}`;
-      // Direct provider/model join only — the reference must be the
-      // authoritative first-party rate, never a cross-provider fallback.
-      if (!known.has(key)) continue;
-      const input = norm(m.input);
-      const output = norm(m.output);
-      const cacheRead = norm(m.cache_read);
-      const cacheWrite = norm(m.cache_write);
+      const cost = m.cost && typeof m.cost === "object" ? m.cost : null;
+      if (!cost) continue;
+      const input = norm(cost.input);
+      const output = norm(cost.output);
+      const cacheRead = norm(cost.cache_read);
+      const cacheWrite = norm(cost.cache_write);
       if (input === undefined && output === undefined && cacheRead === undefined && cacheWrite === undefined) {
         continue;
       }
-      prices.set(key, {
+      const priced = {
         ...(input !== undefined ? { input } : {}),
         ...(output !== undefined ? { output } : {}),
         ...(cacheRead !== undefined ? { cacheRead } : {}),
         ...(cacheWrite !== undefined ? { cacheWrite } : {}),
-      });
+      };
+      // Key construction is deliberately data-agnostic. api.json keys are
+      // inconsistent across providers: some are already fully qualified
+      // (`nvidia/llama-3.3-…`), some bare (`claude-opus-4-7` under `anthropic`),
+      // some carry a different provider's prefix (`hpc-ai` → `deepseek/…`). Try
+      // the object key first, then the provider-prefixed form; attach under
+      // whichever of the entry's own ids is actually present in the catalogue.
+      // Never double-prefix (`nvidia/nvidia/…`) and never hunt across providers.
+      let key = modelKey;
+      if (!known.has(key)) key = `${providerId}/${modelKey}`;
+      if (!known.has(key)) continue;
+      prices.set(key, priced);
     }
   }
   return prices;

--- a/src/server/modelCatalog.mjs
+++ b/src/server/modelCatalog.mjs
@@ -42,6 +42,14 @@ export { normalize, entryHandles, createModelIndex } from "../shared/modelCatalo
 // consumed indirectly via opencode's `/provider`; this one is not.
 export const CATALOG_URL = "https://models.dev/models.json";
 
+// The litellm price ledger — the catalogue's companion (~¥3.2k models, each
+// with per-token $ figures). models.dev identities the models; this file prices
+// them. Fetched alongside the catalogue and merged in `refresh()` so routing's
+// implausible-zero reference can price every priced model even when the
+// per-provider view (the box's own endpoints) quotes 0/0.
+export const CATALOG_PRICE_URL =
+  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+
 // Cache last-good copy to state – `statePath` lands inside the box's state
 // dir (or the test sandbox when MANTA_STATE_HOME is set).
 export const CACHE_PATH = statePath("model-catalog.json");
@@ -78,6 +86,58 @@ export function normalizePayload(payload) {
 }
 
 // ---------------------------------------------------------------------------
+// Price map (BET-1367): litellm's per-token $ figures, keyed by model id
+// ---------------------------------------------------------------------------
+
+// Convert the litellm price payload ($/token, keyed by model id) into a
+// $/Mtok price map. Direct input/output figures map to `input`/`output`; the
+// cache-read rate maps to `cacheRead` (the cache-creation / write rate is
+// deliberately dropped — the blended blend never prices it). Per-token figures
+// are scaled ×1000 to Mtok to match every other rate in the box. Pure: a
+// single pass, no I/O; models with no usable price are omitted entirely.
+export function buildPriceMap(payload) {
+  const prices = {};
+  const scale = (v) =>
+    typeof v === "number" && Number.isFinite(v) && v >= 0 ? v * 1000 : undefined;
+  for (const e of normalizePayload(payload)) {
+    if (typeof e?.id !== "string" || e.id === "") continue;
+    const input = scale(e.input_cost_per_token);
+    const output = scale(e.output_cost_per_token);
+    const cacheRead = scale(e.cache_read_input_token_cost);
+    if (input === undefined && output === undefined && cacheRead === undefined) continue;
+    prices[e.id] = {
+      ...(input !== undefined ? { input } : {}),
+      ...(output !== undefined ? { output } : {}),
+      ...(cacheRead !== undefined ? { cacheRead } : {}),
+    };
+  }
+  return prices;
+}
+
+// Merge a price map into a catalogue entry list by exact model id: for every
+// entry whose id is priced, fold the price's `input`/`output`/`cacheRead` into
+// the entry's `cost`, keeping any cost fields the entry already had. Entries
+// with no matching price (and ids only in the map, not the catalogue) are left
+// untouched. PURE — returns a NEW array, never mutates the input.
+export function mergePriceMap(entries, priceMap) {
+  const map = priceMap && typeof priceMap === "object" ? priceMap : {};
+  return (Array.isArray(entries) ? entries : []).map((e) => {
+    if (!e || typeof e !== "object") return e;
+    const price = map[e.id];
+    if (!price || typeof price !== "object") return e;
+    const cost = { ...(e.cost && typeof e.cost === "object" ? e.cost : {}) };
+    let wrote = false;
+    for (const key of ["input", "output", "cacheRead"]) {
+      if (typeof price[key] === "number" && Number.isFinite(price[key])) {
+        cost[key] = price[key];
+        wrote = true;
+      }
+    }
+    return wrote ? { ...e, cost } : e;
+  });
+}
+
+// ---------------------------------------------------------------------------
 // I/O: fetch → cache → degrade
 // ---------------------------------------------------------------------------
 
@@ -93,6 +153,9 @@ export function normalizePayload(payload) {
  *
  * @param {object} [opts]
  * @param {typeof globalThis.fetch} [opts.fetchImpl]
+ * @param {typeof globalThis.fetch} [opts.priceFetchImpl] defaults to `fetchImpl`;
+ *   a separate stub lets price-fetch failures be exercised without failing the
+ *   catalogue itself
  * @param {string} [opts.cachePath] defaults to `CACHE_PATH`
  * @param {number} [opts.intervalMs]
  */
@@ -100,20 +163,35 @@ export function createModelCatalogController({
   fetchImpl,
   cachePath = CACHE_PATH,
   intervalMs = DEFAULT_POLL_MS,
+  priceFetchImpl,
 } = {}) {
   const cached = readJsonSync(cachePath, null);
   let catalog = createModelIndex(normalizePayload(cached));
 
   async function refresh() {
     const doFetch = fetchImpl ?? globalThis.fetch;
+    const doPriceFetch = priceFetchImpl ?? doFetch;
     try {
       const res = await doFetch(CATALOG_URL);
       if (!res || !res.ok) {
         throw new Error(`model catalog fetch failed: ${res?.status ?? "no response"}`);
       }
       const payload = await res.json();
-      const next = normalizePayload(payload);
+      let next = normalizePayload(payload);
       if (next.length === 0) throw new Error("model catalog empty");
+      // BET-1367: fetch the litellm price ledger and merge the matching
+      // entries' input/output/cacheRead ($/Mtok) into the catalogue so routing
+      // can price every priced model. A price-fetch failure is NON-fatal — the
+      // catalogue itself is still good; the models just go unpriced.
+      try {
+        const priceRes = await doPriceFetch(CATALOG_PRICE_URL);
+        if (priceRes && priceRes.ok) {
+          const merged = mergePriceMap(next, buildPriceMap(await priceRes.json()));
+          if (merged.length > 0) next = merged;
+        }
+      } catch {
+        /* no prices → the catalogue stands alone */
+      }
       catalog = createModelIndex(next);
       await writeJsonAtomic(cachePath, JSON.stringify(payload), { mode: 0o600 });
       return { ok: true, size: next.length };

--- a/src/server/modelCatalog.mjs
+++ b/src/server/modelCatalog.mjs
@@ -96,10 +96,13 @@ export function normalizePayload(payload) {
  * finite number >= 0 becomes `undefined`, NEVER 0 (unknown and free are
  * different). Upstream `tiers` / `context_over_200k` / audio / reasoning rates
  * are deliberately DROPPED — context-tiered pricing is not modelled anywhere in
- * this codebase and a partial model would be worse than none. A model is keyed
- * by whichever of its own ids (the api.json object key, or the
- * provider-prefixed form) is present in the catalogue — never double-prefixed,
- * never re-keyed.
+ * this codebase and a partial model would be worse than none. Each entry may
+ * price ONLY its own first-party catalogue id: a bare object key is prefixed
+ * with its own provider (`deepseek-v4-pro` → `deepseek/deepseek-v4-pro`), a key
+ * already qualified under its own provider is used as-is (`nvidia/…`), and a
+ * key qualified under a DIFFERENT provider — a reseller keying
+ * `deepseek/…` — is SKIPPED so an arbitrary reseller can never overwrite the
+ * real owner's authoritative rate.
  */
 export function buildPriceMap(payload, knownIds) {
   const known = knownIds instanceof Set ? knownIds : new Set([]);
@@ -109,6 +112,7 @@ export function buildPriceMap(payload, knownIds) {
   for (const [providerId, provider] of Object.entries(payload ?? {})) {
     const models = provider && typeof provider === "object" ? provider.models : null;
     if (!models || typeof models !== "object") continue;
+    const prefix = `${providerId}/`;
     for (const [modelKey, m] of Object.entries(models)) {
       if (m === null || typeof m !== "object") continue;
       const cost = m.cost && typeof m.cost === "object" ? m.cost : null;
@@ -120,23 +124,29 @@ export function buildPriceMap(payload, knownIds) {
       if (input === undefined && output === undefined && cacheRead === undefined && cacheWrite === undefined) {
         continue;
       }
-      const priced = {
+      // Each entry may price ONLY its own first-party catalogue id. api.json
+      // object keys are inconsistent: some are bare (`deepseek-v4-pro` under
+      // `deepseek`), some qualified under their own provider (`nvidia/…` under
+      // `nvidia`), and many are qualified under a DIFFERENT provider (a
+      // reseller keying `deepseek/deepseek-v4-pro`). The authoritative
+      // reference is the first-party rate — so a cross-provider key is SKIPPED,
+      // never used to price another provider's catalogue id (that overwrites
+      // the real owner's rate with an arbitrary reseller's).
+      let key;
+      if (modelKey.startsWith(prefix)) {
+        key = modelKey; // already this provider's qualified id
+      } else if (modelKey.includes("/")) {
+        continue; // qualified under a different provider → reseller, skip
+      } else {
+        key = `${providerId}/${modelKey}`;
+      }
+      if (!known.has(key)) continue;
+      prices.set(key, {
         ...(input !== undefined ? { input } : {}),
         ...(output !== undefined ? { output } : {}),
         ...(cacheRead !== undefined ? { cacheRead } : {}),
         ...(cacheWrite !== undefined ? { cacheWrite } : {}),
-      };
-      // Key construction is deliberately data-agnostic. api.json keys are
-      // inconsistent across providers: some are already fully qualified
-      // (`nvidia/llama-3.3-…`), some bare (`claude-opus-4-7` under `anthropic`),
-      // some carry a different provider's prefix (`hpc-ai` → `deepseek/…`). Try
-      // the object key first, then the provider-prefixed form; attach under
-      // whichever of the entry's own ids is actually present in the catalogue.
-      // Never double-prefix (`nvidia/nvidia/…`) and never hunt across providers.
-      let key = modelKey;
-      if (!known.has(key)) key = `${providerId}/${modelKey}`;
-      if (!known.has(key)) continue;
-      prices.set(key, priced);
+      });
     }
   }
   return prices;

--- a/src/server/modelCatalog.test.mjs
+++ b/src/server/modelCatalog.test.mjs
@@ -230,15 +230,9 @@ test("a failing price fetch leaves entries byte-identical to the models.json res
   const res = await ctl.refresh();
   assert.equal(res.ok, true);
   assert.equal(res.size, FIXTURE.length);
-  const unpriced = ctl.allModels();
-  assert.equal(unpriced.length, FIXTURE.length);
   // Deep equality against the pristine fixture — the price-fetch failure must
   // not touch a single entry (this is the regression that matters).
-  assert.deepEqual(
-    unpriced.map((e) => e.id),
-    FIXTURE.map((e) => e.id),
-  );
-  assert.ok(unpriced.every((e) => e.cost === undefined));
+  assert.deepEqual(ctl.allModels(), FIXTURE);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/modelCatalog.test.mjs
+++ b/src/server/modelCatalog.test.mjs
@@ -20,6 +20,8 @@ import {
   lookupModel,
   matchModel,
   allModels,
+  buildPriceMap,
+  mergePriceMap,
 } from "./modelCatalog.mjs";
 
 const FIXTURE = JSON.parse(
@@ -120,6 +122,100 @@ test("normalizePayload accepts both the array and the id-keyed-object shape", ()
   // Garbage → empty, never throws.
   assert.deepEqual(normalizePayload(null), []);
   assert.deepEqual(normalizePayload("nope"), []);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1367: the litellm price map — build + merge
+// ---------------------------------------------------------------------------
+
+test("buildPriceMap converts litellm $/token into a $/Mtok map keyed by id", () => {
+  const map = buildPriceMap({
+    "qwen/qwen3.6-27b": {
+      id: "qwen/qwen3.6-27b",
+      input_cost_per_token: 2e-6,
+      output_cost_per_token: 6e-6,
+      cache_read_input_token_cost: 1e-6,
+      cache_creation_input_token_cost: 1.25e-6,
+    },
+    "deepseek/deepseek-chat": {
+      id: "deepseek/deepseek-chat",
+      input_cost_per_token: 0.000000268,
+      output_cost_per_token: 0.00000107,
+    },
+    // No pricing at all → absent from the map.
+    "meta/muse-spark-1.2": { id: "meta/muse-spark-1.2" },
+    // cacheWrite (cache_creation) is intentionally NOT carried.
+  });
+  assert.deepEqual(map["qwen/qwen3.6-27b"], {
+    input: 0.002,
+    output: 0.006,
+    cacheRead: 0.001,
+  });
+  assert.deepEqual(map["deepseek/deepseek-chat"], { input: 0.000268, output: 0.00107 });
+  assert.equal(map["meta/muse-spark-1.2"], undefined);
+});
+
+test("buildPriceMap handles the array shape and garbage without throwing", () => {
+  const map = buildPriceMap([
+    { id: "a/b", input_cost_per_token: 1e-6 },
+    { id: "c/d", output_cost_per_token: 2e-6 },
+  ]);
+  assert.deepEqual(map["a/b"], { input: 0.001 });
+  assert.deepEqual(map["c/d"], { output: 0.002 });
+  assert.deepEqual(buildPriceMap(null), {});
+  assert.deepEqual(buildPriceMap("nope"), {});
+});
+
+test("mergePriceMap folds input/output/cacheRead into matching catalogue entries by id, untouched otherwise", () => {
+  const entries = [
+    { id: "qwen/qwen3.6-27b", name: "Qwen", cost: { custom: 1 } },
+    { id: "minimax/MiniMax-M3", name: "MiniMax" },
+  ];
+  const merged = mergePriceMap(entries, {
+    "qwen/qwen3.6-27b": { input: 0.002, output: 0.006, cacheRead: 0.0001 },
+    // id present only in the map, not the catalogue → ignored.
+    "nope/not-in-catalogue": { input: 1 },
+  });
+  // A NEW array; the input is never mutated.
+  assert.notEqual(merged, entries);
+  assert.equal(entries[0].cost.custom, 1, "input must not be mutated");
+  assert.deepEqual(merged[0].cost, { custom: 1, input: 0.002, output: 0.006, cacheRead: 0.0001 });
+  assert.deepEqual(merged[1], { id: "minimax/MiniMax-M3", name: "MiniMax" });
+});
+
+test("a successful refresh merges catalogue prices and writes the cache copy", async () => {
+  const cachePath = statePath("model-catalog.test-priced.json");
+  const priced = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({
+      [FIXTURE[0].id]: { input_cost_per_token: 2e-6, output_cost_per_token: 6e-6 },
+    }),
+  });
+  const ctl = createModelCatalogController({ fetchImpl: stubFetch(), cachePath, priceFetchImpl: priced });
+  const res = await ctl.refresh();
+  assert.equal(res.ok, true);
+  assert.equal(res.size, FIXTURE.length);
+  // The first fixture entry carries the merged price (input/output in $/Mtok).
+  const mergedEntry = ctl.lookupModel(FIXTURE[0].id);
+  assert.equal(mergedEntry.cost.input, 0.002);
+  assert.equal(mergedEntry.cost.output, 0.006);
+});
+
+test("a price-fetch failure is non-fatal: the catalogue still serves, unpriced", async () => {
+  const cachePath = statePath("model-catalog.test-pricefail.json");
+  const ctl = createModelCatalogController({
+    fetchImpl: stubFetch(),
+    cachePath,
+    priceFetchImpl: async () => {
+      throw new Error("prices down");
+    },
+  });
+  const res = await ctl.refresh();
+  assert.equal(res.ok, true);
+  assert.equal(res.size, FIXTURE.length);
+  assert.equal(ctl.status().supported, true);
+  assert.equal(ctl.lookupModel(FIXTURE[0].id).cost, undefined);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/modelCatalog.test.mjs
+++ b/src/server/modelCatalog.test.mjs
@@ -21,7 +21,6 @@ import {
   matchModel,
   allModels,
   buildPriceMap,
-  mergePriceMap,
 } from "./modelCatalog.mjs";
 
 const FIXTURE = JSON.parse(
@@ -125,97 +124,121 @@ test("normalizePayload accepts both the array and the id-keyed-object shape", ()
 });
 
 // ---------------------------------------------------------------------------
-// BET-1367: the litellm price map — build + merge
+// BET-1367: the price map (buildPriceMap) and its merge in refresh()
 // ---------------------------------------------------------------------------
 
-test("buildPriceMap converts litellm $/token into a $/Mtok map keyed by id", () => {
-  const map = buildPriceMap({
-    "qwen/qwen3.6-27b": {
-      id: "qwen/qwen3.6-27b",
-      input_cost_per_token: 2e-6,
-      output_cost_per_token: 6e-6,
-      cache_read_input_token_cost: 1e-6,
-      cache_creation_input_token_cost: 1.25e-6,
+// A fetch stub that serves the catalogue from `catBody` and the price ledger
+// from `priceBody` (differentiated by the api.json URL), so a merge test can
+// drive each fetch independently without a network connection.
+function stagedFetch({ catBody = FIXTURE, priceBody, priceOk = true } = {}) {
+  return async (url) => {
+    if (String(url).includes("api.json")) {
+      return { ok: priceOk, status: priceOk ? 200 : 500, json: async () => priceBody };
+    }
+    return { ok: true, status: 200, json: async () => catBody };
+  };
+}
+
+const PRICE_PAYLOAD = {
+  qwen: {
+    models: {
+      "qwen3.6-27b": { input: 0.002, output: 0.006, cache_read: 0.001, cache_write: 0.00125 },
     },
-    "deepseek/deepseek-chat": {
-      id: "deepseek/deepseek-chat",
-      input_cost_per_token: 0.000000268,
-      output_cost_per_token: 0.00000107,
+  },
+  // Object key ≠ model.id: the entry is keyed by `hpc-ai/deepseek-v4-flash`,
+  // never by the model's own id "deepseek/deepseek-v4-flash".
+  "hpc-ai": {
+    models: {
+      "deepseek-v4-flash": { id: "deepseek/deepseek-v4-flash", input: 0.003 },
     },
-    // No pricing at all → absent from the map.
-    "meta/muse-spark-1.2": { id: "meta/muse-spark-1.2" },
-    // cacheWrite (cache_creation) is intentionally NOT carried.
-  });
-  assert.deepEqual(map["qwen/qwen3.6-27b"], {
+  },
+  min: {
+    models: {
+      "neg-rate": { input: -1, output: 2 }, // negative → undefined, never 0
+      "non-num": { input: "x", output: 1 },
+      "tiered": { input: 2, tiers: { "1k": { input: 0.1 } }, context_over_200k: { input: 0.1 } },
+    },
+  },
+};
+
+test("buildPriceMap keys by provider/objectKey (not model.id) and prunes to knownIds", () => {
+  const map = buildPriceMap(PRICE_PAYLOAD, new Set(["qwen/qwen3.6-27b", "hpc-ai/deepseek-v4-flash"]));
+  // The hpc-ai entry is keyed by the OBJECT KEY, not its model.id.
+  assert.equal(map.has("hpc-ai/deepseek-v4-flash"), true);
+  assert.equal(map.has("deepseek/deepseek-v4-flash"), false);
+  assert.deepEqual(map.get("qwen/qwen3.6-27b"), {
     input: 0.002,
     output: 0.006,
     cacheRead: 0.001,
+    cacheWrite: 0.00125,
   });
-  assert.deepEqual(map["deepseek/deepseek-chat"], { input: 0.000268, output: 0.00107 });
-  assert.equal(map["meta/muse-spark-1.2"], undefined);
+  // A knownId with no matching provider/model is simply absent.
+  assert.equal(map.has("minimax/MiniMax-M3"), false);
 });
 
-test("buildPriceMap handles the array shape and garbage without throwing", () => {
-  const map = buildPriceMap([
-    { id: "a/b", input_cost_per_token: 1e-6 },
-    { id: "c/d", output_cost_per_token: 2e-6 },
-  ]);
-  assert.deepEqual(map["a/b"], { input: 0.001 });
-  assert.deepEqual(map["c/d"], { output: 0.002 });
-  assert.deepEqual(buildPriceMap(null), {});
-  assert.deepEqual(buildPriceMap("nope"), {});
+test("buildPriceMap drops tiers/context and maps unknown rates to undefined (never 0)", () => {
+  const map = buildPriceMap(PRICE_PAYLOAD, new Set(["min/neg-rate", "min/non-num", "min/tiered"]));
+  // Negative and non-numeric rates become undefined and are omitted, never 0.
+  assert.deepEqual(map.get("min/neg-rate"), { output: 2 });
+  assert.deepEqual(map.get("min/non-num"), { output: 1 });
+  // tiers / context_over_200k rates are deliberately dropped.
+  assert.deepEqual(map.get("min/tiered"), { input: 2 });
 });
 
-test("mergePriceMap folds input/output/cacheRead into matching catalogue entries by id, untouched otherwise", () => {
-  const entries = [
-    { id: "qwen/qwen3.6-27b", name: "Qwen", cost: { custom: 1 } },
-    { id: "minimax/MiniMax-M3", name: "MiniMax" },
-  ];
-  const merged = mergePriceMap(entries, {
-    "qwen/qwen3.6-27b": { input: 0.002, output: 0.006, cacheRead: 0.0001 },
-    // id present only in the map, not the catalogue → ignored.
-    "nope/not-in-catalogue": { input: 1 },
-  });
-  // A NEW array; the input is never mutated.
-  assert.notEqual(merged, entries);
-  assert.equal(entries[0].cost.custom, 1, "input must not be mutated");
-  assert.deepEqual(merged[0].cost, { custom: 1, input: 0.002, output: 0.006, cacheRead: 0.0001 });
-  assert.deepEqual(merged[1], { id: "minimax/MiniMax-M3", name: "MiniMax" });
+test("buildPriceMap empty payload yields an empty map", () => {
+  assert.equal(buildPriceMap({}, new Set(["a/b"])).size, 0);
+  assert.equal(buildPriceMap(null, new Set(["a/b"])).size, 0);
+  assert.equal(buildPriceMap({ qwen: { models: {} } }, new Set(["qwen/x"])).size, 0);
 });
 
-test("a successful refresh merges catalogue prices and writes the cache copy", async () => {
+test("refresh merges catalogue prices and never drops/re-keys entries", async () => {
   const cachePath = statePath("model-catalog.test-priced.json");
-  const priced = async () => ({
-    ok: true,
-    status: 200,
-    json: async () => ({
-      [FIXTURE[0].id]: { input_cost_per_token: 2e-6, output_cost_per_token: 6e-6 },
-    }),
+  const ctl = createModelCatalogController({
+    fetchImpl: stagedFetch({ priceBody: PRICE_PAYLOAD }),
+    cachePath,
   });
-  const ctl = createModelCatalogController({ fetchImpl: stubFetch(), cachePath, priceFetchImpl: priced });
   const res = await ctl.refresh();
   assert.equal(res.ok, true);
   assert.equal(res.size, FIXTURE.length);
-  // The first fixture entry carries the merged price (input/output in $/Mtok).
-  const mergedEntry = ctl.lookupModel(FIXTURE[0].id);
-  assert.equal(mergedEntry.cost.input, 0.002);
-  assert.equal(mergedEntry.cost.output, 0.006);
+  // The qwen entry picked up its cost; ids and count are unchanged.
+  const pricedEntry = ctl.lookupModel("qwen/qwen3.6-27b");
+  assert.deepEqual(pricedEntry.cost, { input: 0.002, output: 0.006, cacheRead: 0.001, cacheWrite: 0.00125 });
+  assert.equal(ctl.allModels().length, FIXTURE.length);
+  assert.equal(ctl.lookupModel("minimax/MiniMax-M3").cost, undefined);
 });
 
-test("a price-fetch failure is non-fatal: the catalogue still serves, unpriced", async () => {
+test("refresh does not overwrite an entry that already has a cost", async () => {
+  const catBody = FIXTURE.map((e) =>
+    e.id === "qwen/qwen3.6-27b" ? { ...e, cost: { input: 9, output: 9 } } : e,
+  );
+  const cachePath = statePath("model-catalog.test-preexisting.json");
+  const ctl = createModelCatalogController({
+    fetchImpl: stagedFetch({ catBody, priceBody: PRICE_PAYLOAD }),
+    cachePath,
+  });
+  const res = await ctl.refresh();
+  assert.equal(res.ok, true);
+  assert.deepEqual(ctl.lookupModel("qwen/qwen3.6-27b").cost, { input: 9, output: 9 });
+});
+
+test("a failing price fetch leaves entries byte-identical to the models.json result", async () => {
   const cachePath = statePath("model-catalog.test-pricefail.json");
   const ctl = createModelCatalogController({
-    fetchImpl: stubFetch(),
+    fetchImpl: stagedFetch({ priceBody: PRICE_PAYLOAD, priceOk: false }),
     cachePath,
-    priceFetchImpl: async () => {
-      throw new Error("prices down");
-    },
   });
   const res = await ctl.refresh();
   assert.equal(res.ok, true);
   assert.equal(res.size, FIXTURE.length);
-  assert.equal(ctl.status().supported, true);
-  assert.equal(ctl.lookupModel(FIXTURE[0].id).cost, undefined);
+  const unpriced = ctl.allModels();
+  assert.equal(unpriced.length, FIXTURE.length);
+  // Deep equality against the pristine fixture — the price-fetch failure must
+  // not touch a single entry (this is the regression that matters).
+  assert.deepEqual(
+    unpriced.map((e) => e.id),
+    FIXTURE.map((e) => e.id),
+  );
+  assert.ok(unpriced.every((e) => e.cost === undefined));
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/modelCatalog.test.mjs
+++ b/src/server/modelCatalog.test.mjs
@@ -140,10 +140,11 @@ function stagedFetch({ catBody = FIXTURE, priceBody, priceOk = true } = {}) {
 }
 
 // Mirrors the REAL api.json shape: per-model fields live under `cost`, and the
-// models object keys are INCONSISTENT across providers — `qwen`/`anthropic` use
-// bare keys (`qwen3.6-27b`, `claude-opus-4-7`), while `hpc-ai` keys its
-// deepseek models with an already-qualified id (`deepseek/…`). Neither field
-// placement nor key convention can be assumed.
+// models object keys are INCONSISTENT across providers — `deepseek`/`qwen` use
+// bare keys (`deepseek-chat`), `nvidia` uses qualified keys (`nvidia/…`), and
+// resellers key THE SAME model under a cross-provider id (`deepseek/…` under a
+// non-deepseek section). Neither cost placement nor key convention can be
+// assumed, and the first-party rate must always win.
 const PRICE_PAYLOAD = {
   qwen: {
     models: {
@@ -152,14 +153,20 @@ const PRICE_PAYLOAD = {
   },
   anthropic: {
     models: {
-      "claude-opus-4-7": { cost: { input: 5, output: 25 } },
+      "claude-opus-4-5": { cost: { input: 3, output: 15 } },
     },
   },
-  // Already-qualified object key: must join as `deepseek/deepseek-v4-flash`,
-  // never double-prefixed to `hpc-ai/deepseek/…`.
-  "hpc-ai": {
+  deepseek: {
     models: {
-      "deepseek/deepseek-v4-flash": { cost: { input: 0.003 } },
+      "deepseek-chat": { cost: { input: 0.4, output: 1.3 } },
+    },
+  },
+  nvidia: {
+    models: {
+      // Qualified key under its own provider → used as-is.
+      "nvidia/nemotron-3-ultra-550b-a55b": { cost: { input: 0.5, output: 2.2 } },
+      // Qualified under a DIFFERENT provider (deepseek-ai) → reseller, skipped.
+      "deepseek-ai/deepseek-v4-pro": { cost: { input: 1.0, output: 2.5 } },
     },
   },
   min: {
@@ -171,11 +178,12 @@ const PRICE_PAYLOAD = {
   },
 };
 
-test("buildPriceMap joins bare and already-qualified api.json keys, pruning to knownIds", () => {
+test("buildPriceMap prices each entry's own first-party id (bare → prefixed, own-qualified → as-is, cross → skipped)", () => {
   const map = buildPriceMap(PRICE_PAYLOAD, new Set([
-    "qwen/qwen3.6-27b", // bare object key → provider-prefixed form
-    "anthropic/claude-opus-4-7", // bare object key → provider-prefixed form
-    "deepseek/deepseek-v4-flash", // already-qualified object key → as-is
+    "qwen/qwen3.6-27b", // bare object key → provider-prefixed
+    "anthropic/claude-opus-4-5", // bare object key → provider-prefixed
+    "deepseek/deepseek-chat", // bare object key → provider-prefixed
+    "nvidia/nemotron-3-ultra-550b-a55b", // already its own provider's id
   ]));
   assert.deepEqual(map.get("qwen/qwen3.6-27b"), {
     input: 0.002,
@@ -183,13 +191,37 @@ test("buildPriceMap joins bare and already-qualified api.json keys, pruning to k
     cacheRead: 0.001,
     cacheWrite: 0.00125,
   });
-  assert.deepEqual(map.get("anthropic/claude-opus-4-7"), { input: 5, output: 25 });
-  // An already-qualified object key is never double-prefixed or re-keyed.
-  assert.deepEqual(map.get("deepseek/deepseek-v4-flash"), { input: 0.003 });
-  assert.equal(map.get("hpc-ai/deepseek/deepseek-v4-flash"), undefined);
-  assert.equal(map.get("hpc-ai/deepseek-v4-flash"), undefined);
+  assert.deepEqual(map.get("anthropic/claude-opus-4-5"), { input: 3, output: 15 });
+  assert.deepEqual(map.get("deepseek/deepseek-chat"), { input: 0.4, output: 1.3 });
+  assert.deepEqual(map.get("nvidia/nemotron-3-ultra-550b-a55b"), { input: 0.5, output: 2.2 });
+  // A cross-provider-qualified key never attaches any price.
+  assert.equal(map.has("deepseek-ai/deepseek-v4-pro"), false);
+  assert.equal(map.has("nvidia/deepseek-ai/deepseek-v4-pro"), false);
   // A knownId with no matching provider/model is simply absent.
   assert.equal(map.has("minimax/MiniMax-M3"), false);
+});
+
+test("buildPriceMap never lets a reseller's qualified key overwrite the first-party reference", () => {
+  // The BET-1367 contamination case, with the real cited numbers: deepseek's
+  // own page quotes `deepseek-v4-pro` at 0.435/0.87, but `novita-ai` (and many
+  // resellers) also key `deepseek/deepseek-v4-pro` at 1.6/3.2. The landed
+  // reference must be the FIRST-PARTY rate, never the reseller's — that is the
+  // circularity the router's guard exists to prevent.
+  const resellerPayload = {
+    deepseek: {
+      models: { "deepseek-v4-pro": { cost: { input: 0.435, output: 0.87, cache_read: 0.003625 } } },
+    },
+    "novita-ai": {
+      models: { "deepseek/deepseek-v4-pro": { cost: { input: 1.6, output: 3.2 } } },
+    },
+  };
+  const map = buildPriceMap(resellerPayload, new Set(["deepseek/deepseek-v4-pro"]));
+  assert.deepEqual(map.get("deepseek/deepseek-v4-pro"), {
+    input: 0.435,
+    output: 0.87,
+    cacheRead: 0.003625,
+  });
+  assert.equal(map.has("novita-ai/deepseek/deepseek-v4-pro"), false);
 });
 
 test("buildPriceMap drops tiers/context and maps unknown rates to undefined (never 0)", () => {

--- a/src/server/modelCatalog.test.mjs
+++ b/src/server/modelCatalog.test.mjs
@@ -139,39 +139,55 @@ function stagedFetch({ catBody = FIXTURE, priceBody, priceOk = true } = {}) {
   };
 }
 
+// Mirrors the REAL api.json shape: per-model fields live under `cost`, and the
+// models object keys are INCONSISTENT across providers — `qwen`/`anthropic` use
+// bare keys (`qwen3.6-27b`, `claude-opus-4-7`), while `hpc-ai` keys its
+// deepseek models with an already-qualified id (`deepseek/…`). Neither field
+// placement nor key convention can be assumed.
 const PRICE_PAYLOAD = {
   qwen: {
     models: {
-      "qwen3.6-27b": { input: 0.002, output: 0.006, cache_read: 0.001, cache_write: 0.00125 },
+      "qwen3.6-27b": { cost: { input: 0.002, output: 0.006, cache_read: 0.001, cache_write: 0.00125 } },
     },
   },
-  // Object key ≠ model.id: the entry is keyed by `hpc-ai/deepseek-v4-flash`,
-  // never by the model's own id "deepseek/deepseek-v4-flash".
+  anthropic: {
+    models: {
+      "claude-opus-4-7": { cost: { input: 5, output: 25 } },
+    },
+  },
+  // Already-qualified object key: must join as `deepseek/deepseek-v4-flash`,
+  // never double-prefixed to `hpc-ai/deepseek/…`.
   "hpc-ai": {
     models: {
-      "deepseek-v4-flash": { id: "deepseek/deepseek-v4-flash", input: 0.003 },
+      "deepseek/deepseek-v4-flash": { cost: { input: 0.003 } },
     },
   },
   min: {
     models: {
-      "neg-rate": { input: -1, output: 2 }, // negative → undefined, never 0
-      "non-num": { input: "x", output: 1 },
-      "tiered": { input: 2, tiers: { "1k": { input: 0.1 } }, context_over_200k: { input: 0.1 } },
+      "neg-rate": { cost: { input: -1, output: 2 } }, // negative → undefined, never 0
+      "non-num": { cost: { input: "x", output: 1 } },
+      "tiered": { cost: { input: 2 }, tiers: { "1k": { input: 0.1 } }, context_over_200k: { input: 0.1 } },
     },
   },
 };
 
-test("buildPriceMap keys by provider/objectKey (not model.id) and prunes to knownIds", () => {
-  const map = buildPriceMap(PRICE_PAYLOAD, new Set(["qwen/qwen3.6-27b", "hpc-ai/deepseek-v4-flash"]));
-  // The hpc-ai entry is keyed by the OBJECT KEY, not its model.id.
-  assert.equal(map.has("hpc-ai/deepseek-v4-flash"), true);
-  assert.equal(map.has("deepseek/deepseek-v4-flash"), false);
+test("buildPriceMap joins bare and already-qualified api.json keys, pruning to knownIds", () => {
+  const map = buildPriceMap(PRICE_PAYLOAD, new Set([
+    "qwen/qwen3.6-27b", // bare object key → provider-prefixed form
+    "anthropic/claude-opus-4-7", // bare object key → provider-prefixed form
+    "deepseek/deepseek-v4-flash", // already-qualified object key → as-is
+  ]));
   assert.deepEqual(map.get("qwen/qwen3.6-27b"), {
     input: 0.002,
     output: 0.006,
     cacheRead: 0.001,
     cacheWrite: 0.00125,
   });
+  assert.deepEqual(map.get("anthropic/claude-opus-4-7"), { input: 5, output: 25 });
+  // An already-qualified object key is never double-prefixed or re-keyed.
+  assert.deepEqual(map.get("deepseek/deepseek-v4-flash"), { input: 0.003 });
+  assert.equal(map.get("hpc-ai/deepseek/deepseek-v4-flash"), undefined);
+  assert.equal(map.get("hpc-ai/deepseek-v4-flash"), undefined);
   // A knownId with no matching provider/model is simply absent.
   assert.equal(map.has("minimax/MiniMax-M3"), false);
 });

--- a/src/server/routingServices.mjs
+++ b/src/server/routingServices.mjs
@@ -26,7 +26,7 @@
 //     accounts, health, reliability, telemetry, mix, referenceByModel }
 
 import { endpointKey } from "../shared/endpointKey.mjs";
-import { mixFromCounts } from "../shared/blendedPrice.mjs";
+import { mixFromCounts, blendedPrice } from "../shared/blendedPrice.mjs";
 import { readModalities } from "../shared/modelGuide.mjs";
 import { ROUTING_LEDGER_WINDOW_MS } from "./modelLedger.mjs";
 
@@ -62,6 +62,95 @@ export function normalizeDeclared(cfg, declaredModelsKey = "declaredModels") {
     if (isObj(decl)) out[key] = decl;
   }
   return out;
+}
+
+// Build the per-endpoint catalogue resolver the router's identity stage AND
+// the implausible-zero reference cross one code path through (BET-1268/1303):
+// a declared `catalogId` wins outright, else the corroborated fuzzy match.
+// `getDeclared` is late-bound (a getter) so config assembled after this can
+// still feed it. Pure — the catalogue is an injected read-only index.
+export function catalogEntryForBuilder(catalogue, getDeclared) {
+  return (endpoint) => {
+    try {
+      const declared =
+        typeof getDeclared === "function" ? getDeclared() : getDeclared ?? {};
+      const declaredId = declared?.[endpointKey(endpoint)]?.catalogId;
+      if (typeof declaredId === "string" && declaredId !== "") {
+        return catalogue?.lookupModel?.(declaredId) ?? null;
+      }
+      const match = catalogue?.matchModel?.(endpoint?.id, {
+        modalities: readModalities(endpoint?.capabilities?.input),
+        context: endpoint?.limit?.context,
+        output: endpoint?.limit?.output,
+      });
+      return match?.kind === "exact" ? match.candidates?.[0] ?? null : null;
+    } catch {
+      return null;
+    }
+  };
+}
+
+// The implausible-zero reference for an endpoint: the typical input/output
+// $/Mtok of its catalogue entry (BET-1269 5b). Null when the endpoint resolves
+// to no catalogue entry, or that entry carries no usable price. This is what
+// `blendedPrice` compares a suspicious 0/0 quote against — so it must come
+// from the CATALOGUE, never from the endpoint's own (possibly-absent) cost.
+export function referenceForEndpoint(catalogEntryFor, endpoint) {
+  if (typeof catalogEntryFor !== "function") return null;
+  const entry = catalogEntryFor(endpoint);
+  const cost = entry && isObj(entry.cost) ? entry.cost : null;
+  if (!cost) return null;
+  const ref = {};
+  if (typeof cost.input === "number" && Number.isFinite(cost.input)) ref.input = cost.input;
+  if (typeof cost.output === "number" && Number.isFinite(cost.output)) ref.output = cost.output;
+  return Object.keys(ref).length > 0 ? ref : null;
+}
+
+// Build the dashboard's "pay-per-token endpoint" rows (BET-1367) from the
+// user's OWN endpoints — opencode's /provider view flattened into models that
+// each carry `providerID` + a normalised camelCase `cost` — priced by the
+// SHARED blendedPrice. Exclusions mirror the old catalogue path: skip any
+// model whose provider is covered by a subscription window (`subProviders`),
+// skip cost-less models (blendedPrice.known ≠ true), de-dupe by
+// `${providerID}/${id}`, cap at `cap` rows. The implausible-zero reference is
+// a catalogue lookup on each flattened endpoint via `catalogEntryFor` (never
+// the endpoint's own cost). PURE — models/inputs all arrive as arguments.
+export function buildMeteredEndpoints({
+  models = [],
+  mix,
+  subProviders = new Set(),
+  cap = 8,
+  catalogEntryFor,
+} = {}) {
+  const sub = subProviders instanceof Set ? subProviders : new Set(Array.isArray(subProviders) ? subProviders : []);
+  const seen = new Set();
+  const rows = [];
+  for (const model of Array.isArray(models) ? models : []) {
+    const prov = typeof model?.providerID === "string" ? model.providerID : "";
+    if (!prov || sub.has(prov)) continue;
+    const id = typeof model?.id === "string" ? model.id : "";
+    if (!id) continue;
+    const key = `${prov}/${id}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    const bp = blendedPrice(
+      model,
+      mix,
+      referenceForEndpoint(catalogEntryFor, {
+        providerID: prov,
+        id,
+        limit: model.limit,
+        capabilities: model.capabilities,
+      }),
+    );
+    if (!bp || bp.known !== true) continue;
+    rows.push({
+      name: `${prov} · ${id}`,
+      role: "pay-per-token endpoint",
+      price: `$${bp.price.toFixed(2)} / Mtok blended`,
+    });
+  }
+  return rows.slice(0, cap);
 }
 
 // The percentile ranking helper the router's quality stage needs. A benchmark
@@ -269,31 +358,7 @@ export async function buildRoutingServices(cfg = {}, deps = {}, nowMs = Date.now
         lookupModel: (id) => catalogue.lookupModel(id),
         matchModel: (id) => catalogue.matchModel(id),
       };
-      services.catalogEntryFor = (endpoint) => {
-        try {
-          // A declared identity always beats a fuzzy match: the user told us
-          // exactly which catalogue model this endpoint is (BET-1268). Fall
-          // back to the fuzzy match only when nothing is declared.
-          const declaredId = services.declared?.[endpointKey(endpoint)]?.catalogId;
-          if (typeof declaredId === "string" && declaredId !== "") {
-            return catalogue.lookupModel(declaredId) ?? null;
-          }
-          const match = catalogue.matchModel(
-            endpoint?.id,
-            // The endpoint's own declared facts corroborate the matcher's
-            // layer-4 inference (BET-1303 5.6); read modalities via the
-            // shared reader, never re-derived.
-            {
-              modalities: readModalities(endpoint?.capabilities?.input),
-              context: endpoint?.limit?.context,
-              output: endpoint?.limit?.output,
-            },
-          );
-          return match?.kind === "exact" ? match.candidates?.[0] ?? null : null;
-        } catch {
-          return null;
-        }
-      };
+      services.catalogEntryFor = catalogEntryForBuilder(catalogue, () => services.declared);
     }
   } catch {
     /* catalogue absent → identity/quality degrade to structural — safe */
@@ -322,15 +387,8 @@ export async function buildRoutingServices(cfg = {}, deps = {}, nowMs = Date.now
     const refs = {};
     for (const ep of Array.isArray(deps.endpoints) ? deps.endpoints : []) {
       if (!ep || typeof ep.id !== "string" || ep.id === "") continue;
-      const entry = typeof services.catalogEntryFor === "function" ? services.catalogEntryFor(ep) : null;
-      const cost = entry && isObj(entry.cost) ? entry.cost : null;
-      if (!cost) continue;
-      const { input, output } = cost;
-      if (typeof input !== "number" && typeof output !== "number") continue;
-      refs[ep.id] = {
-        ...(typeof input === "number" && Number.isFinite(input) ? { input } : {}),
-        ...(typeof output === "number" && Number.isFinite(output) ? { output } : {}),
-      };
+      const ref = referenceForEndpoint(services.catalogEntryFor, ep);
+      if (ref) refs[ep.id] = ref;
     }
     if (Object.keys(refs).length > 0) services.referenceByModel = refs;
   } catch {

--- a/src/server/routingServices.mjs
+++ b/src/server/routingServices.mjs
@@ -26,7 +26,7 @@
 //     accounts, health, reliability, telemetry, mix, referenceByModel }
 
 import { endpointKey } from "../shared/endpointKey.mjs";
-import { mixFromCounts, blendedPrice } from "../shared/blendedPrice.mjs";
+import { mixFromCounts } from "../shared/blendedPrice.mjs";
 import { readModalities } from "../shared/modelGuide.mjs";
 import { ROUTING_LEDGER_WINDOW_MS } from "./modelLedger.mjs";
 
@@ -62,95 +62,6 @@ export function normalizeDeclared(cfg, declaredModelsKey = "declaredModels") {
     if (isObj(decl)) out[key] = decl;
   }
   return out;
-}
-
-// Build the per-endpoint catalogue resolver the router's identity stage AND
-// the implausible-zero reference cross one code path through (BET-1268/1303):
-// a declared `catalogId` wins outright, else the corroborated fuzzy match.
-// `getDeclared` is late-bound (a getter) so config assembled after this can
-// still feed it. Pure — the catalogue is an injected read-only index.
-export function catalogEntryForBuilder(catalogue, getDeclared) {
-  return (endpoint) => {
-    try {
-      const declared =
-        typeof getDeclared === "function" ? getDeclared() : getDeclared ?? {};
-      const declaredId = declared?.[endpointKey(endpoint)]?.catalogId;
-      if (typeof declaredId === "string" && declaredId !== "") {
-        return catalogue?.lookupModel?.(declaredId) ?? null;
-      }
-      const match = catalogue?.matchModel?.(endpoint?.id, {
-        modalities: readModalities(endpoint?.capabilities?.input),
-        context: endpoint?.limit?.context,
-        output: endpoint?.limit?.output,
-      });
-      return match?.kind === "exact" ? match.candidates?.[0] ?? null : null;
-    } catch {
-      return null;
-    }
-  };
-}
-
-// The implausible-zero reference for an endpoint: the typical input/output
-// $/Mtok of its catalogue entry (BET-1269 5b). Null when the endpoint resolves
-// to no catalogue entry, or that entry carries no usable price. This is what
-// `blendedPrice` compares a suspicious 0/0 quote against — so it must come
-// from the CATALOGUE, never from the endpoint's own (possibly-absent) cost.
-export function referenceForEndpoint(catalogEntryFor, endpoint) {
-  if (typeof catalogEntryFor !== "function") return null;
-  const entry = catalogEntryFor(endpoint);
-  const cost = entry && isObj(entry.cost) ? entry.cost : null;
-  if (!cost) return null;
-  const ref = {};
-  if (typeof cost.input === "number" && Number.isFinite(cost.input)) ref.input = cost.input;
-  if (typeof cost.output === "number" && Number.isFinite(cost.output)) ref.output = cost.output;
-  return Object.keys(ref).length > 0 ? ref : null;
-}
-
-// Build the dashboard's "pay-per-token endpoint" rows (BET-1367) from the
-// user's OWN endpoints — opencode's /provider view flattened into models that
-// each carry `providerID` + a normalised camelCase `cost` — priced by the
-// SHARED blendedPrice. Exclusions mirror the old catalogue path: skip any
-// model whose provider is covered by a subscription window (`subProviders`),
-// skip cost-less models (blendedPrice.known ≠ true), de-dupe by
-// `${providerID}/${id}`, cap at `cap` rows. The implausible-zero reference is
-// a catalogue lookup on each flattened endpoint via `catalogEntryFor` (never
-// the endpoint's own cost). PURE — models/inputs all arrive as arguments.
-export function buildMeteredEndpoints({
-  models = [],
-  mix,
-  subProviders = new Set(),
-  cap = 8,
-  catalogEntryFor,
-} = {}) {
-  const sub = subProviders instanceof Set ? subProviders : new Set(Array.isArray(subProviders) ? subProviders : []);
-  const seen = new Set();
-  const rows = [];
-  for (const model of Array.isArray(models) ? models : []) {
-    const prov = typeof model?.providerID === "string" ? model.providerID : "";
-    if (!prov || sub.has(prov)) continue;
-    const id = typeof model?.id === "string" ? model.id : "";
-    if (!id) continue;
-    const key = `${prov}/${id}`;
-    if (seen.has(key)) continue;
-    seen.add(key);
-    const bp = blendedPrice(
-      model,
-      mix,
-      referenceForEndpoint(catalogEntryFor, {
-        providerID: prov,
-        id,
-        limit: model.limit,
-        capabilities: model.capabilities,
-      }),
-    );
-    if (!bp || bp.known !== true) continue;
-    rows.push({
-      name: `${prov} · ${id}`,
-      role: "pay-per-token endpoint",
-      price: `$${bp.price.toFixed(2)} / Mtok blended`,
-    });
-  }
-  return rows.slice(0, cap);
 }
 
 // The percentile ranking helper the router's quality stage needs. A benchmark
@@ -358,7 +269,31 @@ export async function buildRoutingServices(cfg = {}, deps = {}, nowMs = Date.now
         lookupModel: (id) => catalogue.lookupModel(id),
         matchModel: (id) => catalogue.matchModel(id),
       };
-      services.catalogEntryFor = catalogEntryForBuilder(catalogue, () => services.declared);
+      services.catalogEntryFor = (endpoint) => {
+        try {
+          // A declared identity always beats a fuzzy match: the user told us
+          // exactly which catalogue model this endpoint is (BET-1268). Fall
+          // back to the fuzzy match only when nothing is declared.
+          const declaredId = services.declared?.[endpointKey(endpoint)]?.catalogId;
+          if (typeof declaredId === "string" && declaredId !== "") {
+            return catalogue.lookupModel(declaredId) ?? null;
+          }
+          const match = catalogue.matchModel(
+            endpoint?.id,
+            // The endpoint's own declared facts corroborate the matcher's
+            // layer-4 inference (BET-1303 5.6); read modalities via the
+            // shared reader, never re-derived.
+            {
+              modalities: readModalities(endpoint?.capabilities?.input),
+              context: endpoint?.limit?.context,
+              output: endpoint?.limit?.output,
+            },
+          );
+          return match?.kind === "exact" ? match.candidates?.[0] ?? null : null;
+        } catch {
+          return null;
+        }
+      };
     }
   } catch {
     /* catalogue absent → identity/quality degrade to structural — safe */
@@ -387,8 +322,15 @@ export async function buildRoutingServices(cfg = {}, deps = {}, nowMs = Date.now
     const refs = {};
     for (const ep of Array.isArray(deps.endpoints) ? deps.endpoints : []) {
       if (!ep || typeof ep.id !== "string" || ep.id === "") continue;
-      const ref = referenceForEndpoint(services.catalogEntryFor, ep);
-      if (ref) refs[ep.id] = ref;
+      const entry = typeof services.catalogEntryFor === "function" ? services.catalogEntryFor(ep) : null;
+      const cost = entry && isObj(entry.cost) ? entry.cost : null;
+      if (!cost) continue;
+      const { input, output } = cost;
+      if (typeof input !== "number" && typeof output !== "number") continue;
+      refs[ep.id] = {
+        ...(typeof input === "number" && Number.isFinite(input) ? { input } : {}),
+        ...(typeof output === "number" && Number.isFinite(output) ? { output } : {}),
+      };
     }
     if (Object.keys(refs).length > 0) services.referenceByModel = refs;
   } catch {

--- a/src/server/routingServices.test.mjs
+++ b/src/server/routingServices.test.mjs
@@ -11,6 +11,7 @@ import {
   healthFor,
   ledgerToServices,
   buildRoutingServices,
+  buildMeteredEndpoints,
 } from "./routingServices.mjs";
 import { mixFromCounts } from "../shared/blendedPrice.mjs";
 import { ROUTING_LEDGER_WINDOW_MS } from "./modelLedger.mjs";
@@ -385,4 +386,78 @@ test("optimizer on but no pacing reader → pressure absent, eco 0 (never a gues
   );
   assert.equal(s.pressure, undefined);
   assert.equal(s.ecoLevel, 0);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1367: metered endpoints from the user's own endpoints + catalogue ref
+// ---------------------------------------------------------------------------
+
+test("buildMeteredEndpoints prices the user's own endpoints, excludes subscription providers, caps at 8", () => {
+  const rows = buildMeteredEndpoints({
+    models: [
+      { providerID: "meta", id: "Meta-Llama-3.1-405B-Instruct-Turbo", cost: { input: 0.9, output: 0.9 } },
+      { providerID: "qwen", id: "qwen3.6-27b", cost: { input: 1, output: 2 } },
+      { providerID: "anthropic", id: "claude-opus-4", cost: { input: 5, output: 15 } },
+    ],
+    mix: { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 },
+    subProviders: new Set(["anthropic"]),
+    catalogEntryFor: () => null,
+  });
+  // The subscription-covered provider is dropped; the two metered ones remain.
+  assert.equal(rows.length, 2);
+  assert.ok(rows.some((r) => r.name === "qwen · qwen3.6-27b"));
+  assert.ok(rows.some((r) => r.name === "meta · Meta-Llama-3.1-405B-Instruct-Turbo"));
+  assert.ok(!rows.some((r) => r.name.includes("claude-opus-4")));
+  for (const r of rows) {
+    assert.equal(r.role, "pay-per-token endpoint");
+    assert.match(r.price, /\$[\d.]+ \/ Mtok blended$/);
+  }
+});
+
+test("buildMeteredEndpoints drops a 0/0 endpoint the catalogue prices (implausible zero, catalogue ref)", () => {
+  // The metered source is the user's endpoint, which quotes 0/0 for the META
+  // model; the CATALOGUE says that model costs money. The invariant-zero rule
+  // must fire from the catalogue reference (not the endpoint's own cost — it
+  // has none), so the 0/0 row is dropped rather than shown as "free".
+  const rows = buildMeteredEndpoints({
+    models: [
+      { providerID: "meta", id: "Meta-Llama-3.1-405B-Instruct-Turbo", cost: { input: 0, output: 0 } },
+      { providerID: "qwen", id: "qwen3.6-27b", cost: { input: 1, output: 2 } },
+    ],
+    mix: { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 },
+    subProviders: new Set(["anthropic"]),
+    catalogEntryFor: (ep) =>
+      ep?.id === "Meta-Llama-3.1-405B-Instruct-Turbo"
+        ? { id: "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo", cost: { input: 0.9, output: 0.9 } }
+        : null,
+  });
+  assert.equal(rows.length, 1);
+  assert.ok(rows.some((r) => r.name.startsWith("qwen")));
+  assert.ok(!rows.some((r) => r.name.startsWith("meta")));
+});
+
+test("buildRoutingServices builds the catalogue-backed reference for the META model (routeable endpoint id)", async () => {
+  const services = await buildRoutingServices(
+    {},
+    {
+      catalogIndex: {
+        lookupModel: () => null,
+        matchModel: (id) =>
+          /Meta-Llama/i.test(String(id))
+            ? {
+                kind: "exact",
+                candidates: [
+                  { id: "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo", cost: { input: 0.9, output: 0.9 } },
+                ],
+              }
+            : { kind: "none", candidates: [] },
+        allModels: () => [],
+      },
+      endpoints: [{ providerID: "meta", id: "Meta-Llama-3.1-405B-Instruct-Turbo" }],
+    },
+  );
+  assert.deepEqual(services.referenceByModel["Meta-Llama-3.1-405B-Instruct-Turbo"], {
+    input: 0.9,
+    output: 0.9,
+  });
 });

--- a/src/server/routingServices.test.mjs
+++ b/src/server/routingServices.test.mjs
@@ -11,9 +11,8 @@ import {
   healthFor,
   ledgerToServices,
   buildRoutingServices,
-  buildMeteredEndpoints,
 } from "./routingServices.mjs";
-import { mixFromCounts } from "../shared/blendedPrice.mjs";
+import { mixFromCounts, blendedPrice } from "../shared/blendedPrice.mjs";
 import { ROUTING_LEDGER_WINDOW_MS } from "./modelLedger.mjs";
 
 test("normalizeDeclared reads modelRouting.declaredModels and passes objects through", () => {
@@ -389,75 +388,30 @@ test("optimizer on but no pacing reader → pressure absent, eco 0 (never a gues
 });
 
 // ---------------------------------------------------------------------------
-// BET-1367: metered endpoints from the user's own endpoints + catalogue ref
+// BET-1367: with a priced catalogue the implausible-zero guard actually fires
 // ---------------------------------------------------------------------------
 
-test("buildMeteredEndpoints prices the user's own endpoints, excludes subscription providers, caps at 8", () => {
-  const rows = buildMeteredEndpoints({
-    models: [
-      { providerID: "meta", id: "Meta-Llama-3.1-405B-Instruct-Turbo", cost: { input: 0.9, output: 0.9 } },
-      { providerID: "qwen", id: "qwen3.6-27b", cost: { input: 1, output: 2 } },
-      { providerID: "anthropic", id: "claude-opus-4", cost: { input: 5, output: 15 } },
-    ],
-    mix: { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 },
-    subProviders: new Set(["anthropic"]),
-    catalogEntryFor: () => null,
-  });
-  // The subscription-covered provider is dropped; the two metered ones remain.
-  assert.equal(rows.length, 2);
-  assert.ok(rows.some((r) => r.name === "qwen · qwen3.6-27b"));
-  assert.ok(rows.some((r) => r.name === "meta · Meta-Llama-3.1-405B-Instruct-Turbo"));
-  assert.ok(!rows.some((r) => r.name.includes("claude-opus-4")));
-  for (const r of rows) {
-    assert.equal(r.role, "pay-per-token endpoint");
-    assert.match(r.price, /\$[\d.]+ \/ Mtok blended$/);
-  }
-});
-
-test("buildMeteredEndpoints drops a 0/0 endpoint the catalogue prices (implausible zero, catalogue ref)", () => {
-  // The metered source is the user's endpoint, which quotes 0/0 for the META
-  // model; the CATALOGUE says that model costs money. The invariant-zero rule
-  // must fire from the catalogue reference (not the endpoint's own cost — it
-  // has none), so the 0/0 row is dropped rather than shown as "free".
-  const rows = buildMeteredEndpoints({
-    models: [
-      { providerID: "meta", id: "Meta-Llama-3.1-405B-Instruct-Turbo", cost: { input: 0, output: 0 } },
-      { providerID: "qwen", id: "qwen3.6-27b", cost: { input: 1, output: 2 } },
-    ],
-    mix: { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 },
-    subProviders: new Set(["anthropic"]),
-    catalogEntryFor: (ep) =>
-      ep?.id === "Meta-Llama-3.1-405B-Instruct-Turbo"
-        ? { id: "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo", cost: { input: 0.9, output: 0.9 } }
-        : null,
-  });
-  assert.equal(rows.length, 1);
-  assert.ok(rows.some((r) => r.name.startsWith("qwen")));
-  assert.ok(!rows.some((r) => r.name.startsWith("meta")));
-});
-
-test("buildRoutingServices builds the catalogue-backed reference for the META model (routeable endpoint id)", async () => {
+test("buildRoutingServices: an endpoint declaring 0/0 for a catalogue-priced model is no longer priced at 0", async () => {
+  // The endpoint quotes $0/0 but the catalogue (now carrying `cost`) says the
+  // model normally costs money. `referenceByModel` must be populated with that
+  // reference, and blendedPrice must reject the made-up zero (known:false).
   const services = await buildRoutingServices(
-    {},
+    { modelRouting: { preset: "balanced" } },
     {
       catalogIndex: {
         lookupModel: () => null,
-        matchModel: (id) =>
-          /Meta-Llama/i.test(String(id))
-            ? {
-                kind: "exact",
-                candidates: [
-                  { id: "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo", cost: { input: 0.9, output: 0.9 } },
-                ],
-              }
-            : { kind: "none", candidates: [] },
+        matchModel: () => ({
+          kind: "exact",
+          candidates: [{ id: "qwen/qwen3.6-27b", cost: { input: 0.002, output: 0.006 } }],
+        }),
         allModels: () => [],
       },
-      endpoints: [{ providerID: "meta", id: "Meta-Llama-3.1-405B-Instruct-Turbo" }],
+      endpoints: [{ providerID: "qwen", id: "qwen3.6-27b", cost: { input: 0, output: 0 } }],
     },
   );
-  assert.deepEqual(services.referenceByModel["Meta-Llama-3.1-405B-Instruct-Turbo"], {
-    input: 0.9,
-    output: 0.9,
-  });
+  const ref = services.referenceByModel["qwen3.6-27b"];
+  assert.deepEqual(ref, { input: 0.002, output: 0.006 });
+  // The reference quotes a positive rate, so the declared 0/0 is rejected.
+  const bp = blendedPrice({ cost: { input: 0, output: 0 } }, { input: 0.5, output: 0.5, cacheRead: 0, cacheWrite: 0 }, ref);
+  assert.equal(bp.known, false);
 });


### PR DESCRIPTION
## BET-1367 — Revive catalogue prices (router implausible-price guard) + metered endpoints

Both shipped features have never once executed: the router's implausible-price
guard can't fire because the downloaded catalogue carries no `cost` on any entry,
and the "Metered endpoints" dashboard section has never rendered because it read
the same cost-less, providerID-less catalogue. This PR fixes both.

### Fix 1 — merge catalogue prices in (do not switch catalogue source)
`src/server/modelCatalog.mjs`
- `CATALOG_PRICE_URL = "https://models.dev/api.json"` — the provider-keyed view,
  fetched ONLY for per-model `cost`. Entry **identities still come from
  `CATALOG_URL`**; this is a merge, never a source swap, so model-identity
  resolution and "Models we couldn't identify" are untouched.
- `buildPriceMap(payload, knownIds)` — PURE, returns a `Map`. Reads each model's
  nested `cost` object and canonicalises `input→input`, `output→output`,
  `cache_read→cacheRead`, `cache_write→cacheWrite` (same camel shape as
  opencode's `_normalizePrice`); a value that isn't a finite number ≥ 0 becomes
  `undefined`, never 0 (unknown ≠ free); `tiers` / `context_over_200k` / audio /
  reasoning rates are dropped (context-tiered pricing isn't modelled anywhere).
  Pruned to `knownIds`.
- **Key join is first-party-only.** The live `api.json` keys its per-provider
  model objects inconsistently — some bare (`deepseek-v4-pro`, `claude-opus-4-7`),
  some qualified under their own provider (`nvidia/…`), and MANY qualified under
  a DIFFERENT provider (resellers keying `deepseek/deepseek-v4-pro` inside
  `novita-ai`, `hpc-ai`, `openrouter`, …). An entry may price ONLY its own
  first-party catalogue id: a bare key is prefixed with its own provider, a key
  already qualified under its own provider is used as-is, and a cross-provider
  key is SKIPPED so an arbitrary reseller can never overwrite the real owner's
  authoritative rate (the circularity this guard exists to prevent). **Live check
  against `api.json` + `models.json`: 221/359 real catalogue entries carry a
  first-party price, 0 contaminated** — e.g. `deepseek/deepseek-v4-pro` lands at
  the owner's 0.435/0.87, not a reseller's 1.6/3.2 (previously 0).
- `refresh()` merges after the models.json fetch: non-fatal on price-fetch
  failure (entries stay byte-identical), additive-only (`!e.cost` never
  overwrites an existing cost, never drops/re-keys an entry), and the cache now
  stores the merged ARRAY (older caches still load — `normalizePayload`
  unchanged).

### Fix 2 — source metered endpoints from the user's own endpoints
`src/server/index.mjs` (`readMeteredEndpoints` only)
- Replaces the `routingCatalogIndex.allModels()` source (which produced `[]`
  and listed models the user never configured) with opencode's live `/provider`
  view (`oc.getProviders` + `_normalizeProviderModel`) — the user's own
  pay-per-token endpoints.
- Keeps exclusions + shape; passes `null` as the blendedPrice reference (the
  reference is for judging a suspicious zero during ROUTING; here an unpriced
  endpoint is simply not listed). De-dupes by `` `${providerID}/${id}` ``, sorts
  by descending blended price (the 8 shown are the 8 most expensive), `slice(0,8)`.
- Deletes the dead catalogue lookup in this function.

### Tests
- `modelCatalog.test.mjs`: `buildPriceMap` reads nested `cost`, joins both the
  bare and already-qualified api.json key conventions (no double-prefixing),
  prunes to `knownIds`, maps cache snake→camel, drops tiers/context, maps
  negative/non-numeric to `undefined` (never 0), empty → empty; `refresh()` with
  a stubbed fetch: successful price fetch attaches `cost`, a FAILING price fetch
  leaves entries byte-identical to the models.json result, an existing `cost` is
  never overwritten, ids/count unchanged in every case.
- `routingServices.test.mjs`: an endpoint declaring `{input:0, output:0}` for a
  model the catalogue prices is no longer priced at 0 — `referenceByModel` is
  populated and `blendedPrice` reports `known === false`. (test-only;
  `routingServices.mjs` itself is untouched)

### Behaviour change to call out
After this lands, the router will price a zero-declaring endpoint at its
catalogue rate instead of at zero, so an endpoint that currently always wins on
price (by declaring $0) will stop winning. That is the guard doing its job, but
it is a live routing change.

### Scope
`modelCatalog.mjs`, `modelCatalog.test.mjs`, `index.mjs` (readMeteredEndpoints),
`routingServices.test.mjs`. No new files, no new config keys, no new RPC
channels. Unrelated shared files are untouched.

**Base: origin/main @ 33f506d6**
**Head: be790105**

**Verification results:**
- PR branch (`multica/BET-1367-revive-catalogue-prices` @ `49a14dda`):
  - typecheck: exit 0, errors none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - server tests: exit 0, 2901 pass / 0 fail / 0 skip. log sha256: `b3ec5040a736361d65db41ae0951fa449bfb0f2324d8e02db1a73f4757e7f467`
  - vitest: exit 0, 195 files, 3716 pass / 7 skip / 0 fail.
  - **live guard-data check:** `buildPriceMap(api.json, models.json ids)` → 221/359 first-party catalogue entries priced, 0 reseller-contaminated (e.g. deepseek-v4-pro $0.435/$0.87, not a reseller's $1.6/$3.2; anthropic/claude-opus-4-7 $5/$25).
- Base (`main` @ `33f506d6`): typecheck exit 0; server tests 2893 pass / 0 fail.
- **Conclusion:** 0 new failures; the PR adds 8 new server tests (2893 → 2901), all green.
