### PR TITLE
feat(server): additive token-turn counterfactual buckets, hourly retention, model attribution (BET-1368)

### DIFF
--- a/src/server/modelLedger.mjs
+++ b/src/server/modelLedger.mjs
@@ -17,6 +17,7 @@
 
 import { getDb } from "./opencodeDb.mjs";
 import { aggregateReliability } from "../shared/toolReliability.mjs";
+import { dayKey, recentBucketKeys } from "../shared/timeBuckets.mjs";
 
 // Turns longer than this are excluded from TIMING only (still counted for
 // cost) — the spec cap is 600s of wall-clock.
@@ -187,14 +188,9 @@ function byCostDesc(a, b) {
 }
 
 // Local-calendar day key "YYYY-MM-DD" for a timestamp. Rows are bucketed into
-// the user's local day, matching how the dashboard graph is read.
-function dayKey(ms) {
-  const d = new Date(num(ms));
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
-}
+// the user's local day, matching how the dashboard graph is read. Shared:
+// `dayKey` / `recentBucketKeys` come from src/shared/timeBuckets.mjs — the
+// same single definition the optimizer counterfactual store uses.
 
 /**
  * PURE. Per-session spend over `rows` (flat ledger rows from
@@ -235,10 +231,7 @@ export function aggregateDailySeries(rows, days = 30, now = Date.now()) {
     byDay.set(key, (byDay.get(key) || 0) + tokensSent(r));
   }
   const out = [];
-  for (let i = n - 1; i >= 0; i--) {
-    const d = new Date(num(now));
-    d.setDate(d.getDate() - i);
-    const key = dayKey(d.getTime());
+  for (const key of recentBucketKeys("day", n, now)) {
     out.push({ day: key, tokensSent: byDay.get(key) || 0 });
   }
   return out;

--- a/src/server/optimizer/counterfactual.mjs
+++ b/src/server/optimizer/counterfactual.mjs
@@ -1,5 +1,5 @@
 // optimizer/counterfactual.mjs — the OBSERVE-ONLY masking counterfactual store
-// (Optimizer P1.3, BET-1335).
+// (Optimizer P1.3, BET-1335; additive token-turn buckets BET-1368).
 //
 // What the manta-optimizer opencode plugin reports (POST
 // /api/optimizer/counterfactual) is not spend — it is the "what manta WOULD
@@ -9,16 +9,22 @@
 // reports so the dashboard's "raw vs optimized" graph has a real second line
 // before any actuation exists.
 //
-// Semantics (a report REPLACES, never increments): each session keeps only its
-// LATEST report's values, because each report is the full would-mask for that
-// session's current history. `days` stores, per local day, the sum over
-// sessions of each session's latest maskedTokens as of that day's last report.
+// Semantics (BET-1368): a report is ADDITIVE token-turns. A tool output masked
+// at turn 5 stays out of the prompt for turns 6, 7, 8…; every one of those
+// turns you avoid paying to send it again. Each plugin report is exactly one
+// turn's worth of that, so each report is added into its bucket (keyed off the
+// report's own ts, not the clock). `days`/`hours` store, per local day/hour,
+// the summed maskedTokens token-turns (plus the applied/rewarm subsets and the
+// per-model split). The `sessions` map keeps its REPLACE semantics (each
+// report replaces the session's latest values) because it backs `bySession` /
+// savedPct, not the dollar figure.
 //
 // Split strictly into pure/store (createCounterfactualStore — injected I/O)
-// and a PURE validator + summaryFields. No real state dir is touched unless
-// index.mjs wires a load/save; tests inject in-memory load/save.
+// and PURE validators + bucketSeries/summaryFields. No real state dir is
+// touched unless index.mjs wires a load/save; tests inject in-memory load/save.
 
 import { statePath } from "../../shared/paths.mjs";
+import { dayKey, hourKey, bucketKeyToMs, recentBucketKeys } from "../../shared/timeBuckets.mjs";
 
 // Persistence file for the store (wired by index.mjs via the shared
 // jsonStore atomic writer — see the hygiene note there). New store, new file:
@@ -27,27 +33,65 @@ export const COUNTERFACTUAL_PATH = statePath("optimizer-counterfactual.json");
 
 export const MAX_SESSIONS = 500;
 export const RETAIN_DAYS = 90;
+export const RETAIN_HOURS = 72;
 export const SUMMARY_DAYS = 30;
+export const STATE_VERSION = 2;
+
+const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
 
 function num(v) {
   return typeof v === "number" && Number.isFinite(v) ? v : 0;
 }
 
-// Local-calendar day key "YYYY-MM-DD", matching how the dashboard graph is read.
-function dayKey(ms) {
-  const d = new Date(num(ms));
-  const y = d.getFullYear();
-  const m = String(d.getMonth() + 1).padStart(2, "0");
-  const day = String(d.getDate()).padStart(2, "0");
-  return `${y}-${m}-${day}`;
+// A report timestamp in the future, or older than the day retention, is
+// clamped to `now` so a delayed/garbage ts can't create an unbounded bucket or
+// a runaway future entry.
+function clampTs(ts, now) {
+  const t = num(ts);
+  const n = num(now);
+  if (t > n) return n;
+  if (n - t > RETAIN_DAYS * DAY_MS) return n;
+  return t;
 }
 
-const DAY_MS = 86_400_000;
+// "providerID/modelID" when BOTH are non-empty strings, else the literal
+// "unknown" — the store keys on what the report carries, never fabrication.
+function modelKey(report) {
+  const p = report.providerID;
+  const m = report.modelID;
+  return typeof p === "string" && p.length > 0 && typeof m === "string" && m.length > 0
+    ? `${p}/${m}`
+    : "unknown";
+}
 
+// v2 buckets are ADDITIVE token-turns. Adds one report into the bucket at
+// `key` (creating an empty bucket on first report). Defensive about a partial
+// or legacy bucket shape that lacks some of the v2 fields — each accumulates
+// from 0.
+function addToBucket(bucketMap, key, report) {
+  const b = bucketMap[key] ?? {};
+  b.maskedTokens = (b.maskedTokens ?? 0) + num(report.maskedTokens);
+  b.appliedTokens = (b.appliedTokens ?? 0) + (report.applied === true ? num(report.maskedTokens) : 0);
+  b.rewarmTokens = (b.rewarmTokens ?? 0) + num(report.rewarmTokens);
+  b.reports = (b.reports ?? 0) + 1;
+  if (!b.byModel || typeof b.byModel !== "object") b.byModel = {};
+  const mk = modelKey(report);
+  b.byModel[mk] = (b.byModel[mk] ?? 0) + num(report.maskedTokens);
+  bucketMap[key] = b;
+}
+
+// v2 normalize. Buckets became additive token-turns in BET-1368, so the OLD
+// snapshot-semantics buckets are dropped (summing two meanings is worse than a
+// gap) while the sessions map is kept (its replace semantics are unchanged).
+// `version` is always persisted.
 function normalizeState(raw) {
   const s = raw && typeof raw === "object" ? raw : {};
+  const isV2 = s.version === STATE_VERSION;
   return {
-    days: s.days && typeof s.days === "object" ? s.days : {},
+    version: STATE_VERSION,
+    days: isV2 && s.days && typeof s.days === "object" ? s.days : {},
+    hours: isV2 && s.hours && typeof s.hours === "object" ? s.hours : {},
     sessions: s.sessions && typeof s.sessions === "object" ? s.sessions : {},
   };
 }
@@ -61,6 +105,12 @@ function normalizeState(raw) {
  *   applied — optional boolean (BET-1344: whether the mutation was performed)
  *   mode — optional "observe" | "act" (BET-1344). Both are OPTIONAL so a
  *     not-yet-updated observe-only plugin still validates.
+ *   providerID / modelID — optional; non-empty strings ≤128 chars when present
+ *     (BET-1368: model attribution).
+ *   rewarmTokens — optional; finite number ≥ 0 when present (BET-1368: cache
+ *     re-warm cost caused).
+ *   All BET-1368 fields are OPTIONAL and the store must behave correctly with
+ *     all three absent — that is the normal case until the plugin propagates.
  */
 export function validateCounterfactualReport(report) {
   const r = report ?? {};
@@ -77,22 +127,25 @@ export function validateCounterfactualReport(report) {
   }
   if (r.applied !== undefined && typeof r.applied !== "boolean") return "applied";
   if (r.mode !== undefined && r.mode !== "observe" && r.mode !== "act") return "mode";
-  return null;
-}
-
-// Recompute a day's entry: the sum of maskedTokens (and count of sessions)
-// over all sessions whose latest report falls on that local day.
-function computeDay(sessions, day) {
-  let maskedTokens = 0;
-  let reports = 0;
-  for (const sd of Object.values(sessions)) {
-    if (!sd || typeof sd.lastTs !== "number") continue;
-    if (dayKey(sd.lastTs) === day) {
-      maskedTokens += num(sd.maskedTokens);
-      reports++;
-    }
+  if (
+    r.providerID !== undefined &&
+    (typeof r.providerID !== "string" || r.providerID.length === 0 || r.providerID.length > 128)
+  ) {
+    return "providerID";
   }
-  return { maskedTokens, reports };
+  if (
+    r.modelID !== undefined &&
+    (typeof r.modelID !== "string" || r.modelID.length === 0 || r.modelID.length > 128)
+  ) {
+    return "modelID";
+  }
+  if (
+    r.rewarmTokens !== undefined &&
+    (typeof r.rewarmTokens !== "number" || !Number.isFinite(r.rewarmTokens) || r.rewarmTokens < 0)
+  ) {
+    return "rewarmTokens";
+  }
+  return null;
 }
 
 // Evict sessions beyond MAX_SESSIONS, oldest `lastTs` first.
@@ -120,16 +173,17 @@ function capSessions(sessions) {
 
 /**
  * The counterfactual store. Injected I/O: `load()` returns the persisted
- * `{days, sessions}` (or {}), `save(state)` persists it atomically, `now` is
- * the clock (number or zero-arg fn, for tests). Pure logic — no fs access
- * unless the injected load/save touch it.
+ * `{version, days, hours, sessions}` (or {}), `save(state)` persists it
+ * atomically, `now` is the clock (number or zero-arg fn, for tests). Pure
+ * logic — no fs access unless the injected load/save touch it.
  *
  * Returns { record, snapshot }:
- *   record({sessionID, maskedTokens, maskedParts, ts}) → {ok, error?}. Validates;
- *   replaces the session's latest report; prunes old day entries; caps sessions
- *   at MAX_SESSIONS; recomputes today's day entry; persists; {ok:true}.
- *   snapshot() → the current state ({days, sessions}), loading from load() on
- *   first access. Backs summaryFields().
+ *   record({sessionID, maskedTokens, maskedParts, ts, ...}) → {ok, error?}.
+ *   Validates; ADDITIVELY writes the report's token-turns into its day and
+ *   hour buckets (keyed off report.ts, clamped); replaces the session's
+ *   latest values; prunes old day/hour buckets; caps sessions; persists.
+ *   snapshot() → the current state ({version, days, hours, sessions}),
+ *   loading from load() on first access. Backs bucketSeries / summaryFields.
  */
 export function createCounterfactualStore({ load, save, now }) {
   let state = null;
@@ -144,14 +198,17 @@ export function createCounterfactualStore({ load, save, now }) {
     const err = validateCounterfactualReport(report);
     if (err) return { ok: false, error: err };
     const s = await ensureLoaded();
-    const t = nowMs();
-    const today = dayKey(t);
-    // REPLACE the session's counterfactual (each report is the full would-mask
-    // for that session's current history, not an increment).
+    // Bucketing keys off the report's own timestamp (clamped to now when in
+    // the future or beyond day retention) — NOT the injected clock — so a
+    // delayed report lands in the bucket its turn actually belonged to.
+    const ts = clampTs(report.ts, nowMs());
+    // REPLACE the session's latest counterfactual (each report is the full
+    // would-mask for that session's current history; the sessions map backs
+    // bySession / savedPct, whose replace semantics are correct for that use).
     const session = {
       maskedTokens: num(report.maskedTokens),
       maskedParts: num(report.maskedParts),
-      lastTs: num(report.ts),
+      lastTs: ts,
     };
     // BET-1344: keep the actuation telemetry when supplied (both optional, so
     // an observe-only plugin's report still merges cleanly).
@@ -159,15 +216,20 @@ export function createCounterfactualStore({ load, save, now }) {
     if (report.mode !== undefined) session.mode = report.mode;
     s.sessions[report.sessionID] = session;
     capSessions(s.sessions);
-    // Retention: drop day entries older than RETAIN_DAYS (ISO keys compare
-    // lexicographically).
-    const cutoff = dayKey(t - RETAIN_DAYS * DAY_MS);
+    // Add the report into its buckets (both sizes, one write path).
+    addToBucket(s.days, dayKey(ts), report);
+    addToBucket(s.hours, hourKey(ts), report);
+    // Retention: drop entries older than RETAIN_DAYS / RETAIN_HOURS (keys
+    // compare lexicographically). RETAIN_HOURS = 72 is a hard bound of 72 keys;
+    // this file is rewritten atomically on every report, so it must not grow.
+    const dayCutoff = dayKey(ts - RETAIN_DAYS * DAY_MS);
     for (const k of Object.keys(s.days)) {
-      if (k < cutoff) delete s.days[k];
+      if (k < dayCutoff) delete s.days[k];
     }
-    // Day entries are snapshots "as of that day's last report" — only today's
-    // is recomputed.
-    s.days[today] = computeDay(s.sessions, today);
+    const hourCutoff = hourKey(ts - RETAIN_HOURS * HOUR_MS);
+    for (const k of Object.keys(s.hours)) {
+      if (k < hourCutoff) delete s.hours[k];
+    }
     await save(s);
     return { ok: true };
   }
@@ -180,29 +242,48 @@ export function createCounterfactualStore({ load, save, now }) {
 }
 
 /**
+ * PURE(over the store's snapshot). The `count` most recent buckets of size
+ * `bucket` ("day" | "hour"), oldest→newest, ZERO-FILLED where nothing was
+ * reported. Each entry:
+ *   { key, t, maskedTokens, appliedTokens, rewarmTokens, byModel }.
+ * `t` is the epoch ms at the START of the local bucket, from bucketKeyToMs.
+ * The single series-building path — summaryFields is implemented on top of it.
+ */
+export async function bucketSeries(store, { bucket = "day", count, now = Date.now() } = {}) {
+  const s = await store.snapshot();
+  const n = Math.max(1, Math.floor(num(count)) || 1);
+  const t = typeof now === "function" ? num(now()) : num(now ?? Date.now());
+  const map = bucket === "hour" ? s.hours ?? {} : s.days ?? {};
+  return recentBucketKeys(bucket, n, t).map((key) => {
+    const b = map[key];
+    return {
+      key,
+      t: bucketKeyToMs(key),
+      maskedTokens: b ? num(b.maskedTokens) : 0,
+      appliedTokens: b ? num(b.appliedTokens) : 0,
+      rewarmTokens: b ? num(b.rewarmTokens) : 0,
+      byModel: b && b.byModel && typeof b.byModel === "object" ? b.byModel : {},
+    };
+  });
+}
+
+/**
  * PURE(over the store's snapshot). Shape consumed by buildOptimizerSummary:
- *   dailySeries: [{day, maskedTokens}] — SUMMARY_DAYS days, oldest→newest,
- *     ZERO-FILLED for days with no counterfactual report.
+ *   dailySeries: [{day, maskedTokens}] — `days` days, oldest→newest,
+ *     ZERO-FILLED for days with no counterfactual report. Derived by mapping
+ *     bucketSeries({bucket:"day"}).
  *   bySession: {[sessionID]: {maskedTokens}} — each session's latest
  *     maskedTokens. `savedPct` is NOT computed here: it needs tokensSent,
  *     which only summary.mjs has (it computes it against its own bySession).
  */
 export async function summaryFields(store, { days = SUMMARY_DAYS, now = Date.now() } = {}) {
+  const series = await bucketSeries(store, { bucket: "day", count: days, now });
   const s = await store.snapshot();
-  const n = Math.max(1, Math.floor(num(days)) || 1);
   const bySession = {};
   for (const [id, sd] of Object.entries(s.sessions ?? {})) {
     if (sd && typeof sd.maskedTokens === "number") {
       bySession[id] = { maskedTokens: sd.maskedTokens };
     }
   }
-  const t = typeof now === "function" ? num(now()) : num(now ?? Date.now());
-  const dailySeries = [];
-  for (let i = n - 1; i >= 0; i--) {
-    const d = new Date(t);
-    d.setDate(d.getDate() - i);
-    const key = dayKey(d.getTime());
-    dailySeries.push({ day: key, maskedTokens: s.days?.[key]?.maskedTokens ?? 0 });
-  }
-  return { dailySeries, bySession };
+  return { dailySeries: series.map((e) => ({ day: e.key, maskedTokens: e.maskedTokens })), bySession };
 }

--- a/src/server/optimizer/counterfactual.test.mjs
+++ b/src/server/optimizer/counterfactual.test.mjs
@@ -8,15 +8,23 @@ import assert from "node:assert/strict";
 import {
   createCounterfactualStore,
   validateCounterfactualReport,
+  bucketSeries,
   MAX_SESSIONS,
   RETAIN_DAYS,
+  RETAIN_HOURS,
 } from "./counterfactual.mjs";
 
 const DAY_MS = 86_400_000;
+const HOUR_MS = 3_600_000;
 
 function dayKey(ms) {
   const d = new Date(ms);
   return `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+}
+
+function hourKey(ms) {
+  const d = new Date(ms);
+  return `${dayKey(ms)}T${String(d.getHours()).padStart(2, "0")}`;
 }
 
 function makeStore({ initial = {}, now }) {
@@ -65,7 +73,7 @@ test("store.record rejects invalid and leaves state untouched", async () => {
   assert.deepEqual(get(), {}); // no load/normalize, no mutation on an invalid report
 });
 
-test("a report REPLACES the session's counterfactual, and today's day is the sum of sessions whose latest report is today", async () => {
+test("a report REPLACES the session's latest values but ADDS to the day's bucket (token-turns)", async () => {
   const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
   const { store, get } = makeStore({ now: fixed(t) });
   const today = dayKey(t);
@@ -75,9 +83,10 @@ test("a report REPLACES the session's counterfactual, and today's day is the sum
   assert.equal(get().days[today].maskedTokens, 300, "two sessions today sum");
   assert.equal(get().days[today].reports, 2);
 
-  // s1's NEWER report replaces its old 100 → today becomes 200(s1) + 200(s2).
+  // s1's newer report REPLACES its session entry (1000) but ADDS its token-turns
+  // to today's bucket (100 + 1000 from s1, 200 from s2 = 1300).
   await store.record({ sessionID: "s1", maskedTokens: 1000, maskedParts: 4, ts: t });
-  assert.equal(get().days[today].maskedTokens, 1200);
+  assert.equal(get().days[today].maskedTokens, 1300);
   assert.equal(get().sessions.s1.maskedTokens, 1000);
 });
 
@@ -109,10 +118,12 @@ test("retention prunes day entries older than RETAIN_DAYS; recent ones survive",
     get,
   } = makeStore({
     initial: {
+      version: 2,
       days: {
         [oldDay]: { maskedTokens: 999, reports: 1 },
         [recentDay]: { maskedTokens: 7, reports: 1 },
       },
+      hours: {},
       sessions: {},
     },
     now: fixed(now),
@@ -157,15 +168,21 @@ test("summaryFields returns a zero-filled 30d maskedTokens series and per-sessio
   assert.deepEqual(f.bySession, { s1: { maskedTokens: 123 } });
 });
 
-test("record is idempotent per report (same report twice → same state)", async () => {
-  const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
+test("two reports from the SAME session in the same hour SUM (additive token-turns — the BET-1368 regression)", async () => {
+  const t = new Date(2026, 7, 24, 12, 30, 0).getTime(); // ts: same hour
   const { store, get } = makeStore({ now: fixed(t) });
-  const today = dayKey(t);
+  const bucket = hourKey(t);
+
   await store.record({ sessionID: "s1", maskedTokens: 42, maskedParts: 2, ts: t });
-  const first = JSON.parse(JSON.stringify(get()));
-  await store.record({ sessionID: "s1", maskedTokens: 42, maskedParts: 2, ts: t });
-  assert.deepEqual(get(), first);
-  assert.equal(get().days[today].maskedTokens, 42);
+  await store.record({ sessionID: "s1", maskedTokens: 58, maskedParts: 2, ts: t });
+
+  // The old code kept only the latest (58); additive keeps the running total.
+  assert.equal(get().hours[bucket].maskedTokens, 100);
+  assert.equal(get().hours[bucket].reports, 2);
+  // The sessions map still holds the LATEST (replace semantics unchanged).
+  assert.equal(get().sessions.s1.maskedTokens, 58);
+  // It also landed in today's day bucket.
+  assert.equal(get().days[dayKey(t)].maskedTokens, 100);
 });
 
 // ----- BET-1344: applied / mode on the report -----
@@ -240,4 +257,147 @@ test("store.record persists applied/mode on the session entry, and omits them wh
   await store.record({ sessionID: "s2", maskedTokens: 50, maskedParts: 1, ts: t });
   assert.equal(Object.hasOwn(get().sessions.s2, "applied"), false);
   assert.equal(Object.hasOwn(get().sessions.s2, "mode"), false);
+});
+
+// ----- BET-1368: additive token-turn buckets, hourly retention, model attribution -----
+
+test("a bucket is keyed off report.ts, not the injected clock (delayed report lands in yesterday's bucket)", async () => {
+  const todayMs = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const yesterdayMs = todayMs - DAY_MS;
+  const { store, get } = makeStore({ now: fixed(todayMs) });
+
+  // The server clock is TODAY, but the report's ts is YESTERDAY.
+  await store.record({ sessionID: "s1", maskedTokens: 77, maskedParts: 1, ts: yesterdayMs });
+
+  assert.equal(get().days[dayKey(yesterdayMs)].maskedTokens, 77, "goes to yesterday's day bucket");
+  assert.equal(get().days[dayKey(todayMs)], undefined, "NOT today's day bucket");
+  assert.equal(get().hours[hourKey(yesterdayMs)].maskedTokens, 77, "and to yesterday's hour bucket");
+});
+
+test("applied:true contributes to appliedTokens; applied:false/absent does not; maskedTokens counts in both", async () => {
+  const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const { store, get } = makeStore({ now: fixed(t) });
+  const bucket = hourKey(t);
+
+  await store.record({ sessionID: "s1", maskedTokens: 100, maskedParts: 1, ts: t, applied: true });
+  await store.record({ sessionID: "s2", maskedTokens: 50, maskedParts: 1, ts: t, applied: false });
+  await store.record({ sessionID: "s3", maskedTokens: 25, maskedParts: 1, ts: t });
+
+  // maskedTokens sums ALL reports; appliedTokens only the applied:true one.
+  assert.equal(get().hours[bucket].maskedTokens, 175);
+  assert.equal(get().hours[bucket].appliedTokens, 100);
+});
+
+test("rewarmTokens accumulates on a bucket; absent means 0", async () => {
+  const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const { store, get } = makeStore({ now: fixed(t) });
+  const bucket = hourKey(t);
+
+  await store.record({ sessionID: "s1", maskedTokens: 10, maskedParts: 1, ts: t, rewarmTokens: 30 });
+  await store.record({ sessionID: "s2", maskedTokens: 20, maskedParts: 1, ts: t, rewarmTokens: 5 });
+  // No rewarmTokens supplied → 0 contribution.
+  await store.record({ sessionID: "s3", maskedTokens: 40, maskedParts: 1, ts: t });
+
+  assert.equal(get().hours[bucket].rewarmTokens, 35);
+  assert.equal(get().days[dayKey(t)].rewarmTokens, 35);
+});
+
+test("byModel splits maskedTokens on providerID/modelID, 'unknown' when either is missing", async () => {
+  const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const { store, get } = makeStore({ now: fixed(t) });
+  const bucket = hourKey(t);
+
+  await store.record({ sessionID: "s1", maskedTokens: 100, maskedParts: 1, ts: t, providerID: "anthropic", modelID: "claude-sonnet" });
+  await store.record({ sessionID: "s2", maskedTokens: 50, maskedParts: 1, ts: t, providerID: "anthropic", modelID: "claude-sonnet" });
+  await store.record({ sessionID: "s3", maskedTokens: 25, maskedParts: 1, ts: t, providerID: "anthropic" }); // no modelID
+  await store.record({ sessionID: "s4", maskedTokens: 15, maskedParts: 1, ts: t }); // neither
+
+  const b = get().hours[bucket];
+  assert.equal(b.byModel["anthropic/claude-sonnet"], 150, "same model sums");
+  assert.equal(b.byModel["unknown"], 40, "missing either field buckets to 'unknown'");
+});
+
+test("hour pruning keeps at most 72 keys; day pruning keeps 90", async () => {
+  const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const farHour = hourKey(t - (RETAIN_HOURS + 5) * HOUR_MS);
+  const nearHour = hourKey(t - 2 * HOUR_MS);
+  const farDay = dayKey(t - (RETAIN_DAYS + 5) * DAY_MS);
+  const nearDay = dayKey(t - 10 * DAY_MS);
+  const { store, get } = makeStore({
+    initial: {
+      version: 2,
+      days: { [farDay]: { maskedTokens: 9, reports: 1 }, [nearDay]: { maskedTokens: 1, reports: 1 } },
+      hours: { [farHour]: { maskedTokens: 9, reports: 1 }, [nearHour]: { maskedTokens: 1, reports: 1 } },
+      sessions: {},
+    },
+    now: fixed(t),
+  });
+
+  // Burst of reports across 80 hours, then a FINAL report at `t` whose ts anchors
+  // the retention cutoffs at `t` — so the OLD tail is pruned, not the new head.
+  for (let h = 0; h < 80; h++) {
+    await store.record({ sessionID: `s${h}`, maskedTokens: 1, maskedParts: 1, ts: t - h * HOUR_MS });
+  }
+  await store.record({ sessionID: "final", maskedTokens: 1, maskedParts: 1, ts: t });
+
+  // The window anchored at `t` bounds the hourly count to the 72h window (the
+  // boundary slot inclusive — the same lexicographic-comparison retention the
+  // day buckets use, "as today") and the daily count to the 90d window.
+  assert.ok(Object.keys(get().hours).length <= RETAIN_HOURS + 1, "hours bounded by the 72h window");
+  assert.ok(Object.keys(get().days).length <= RETAIN_DAYS + 1, "days bounded by the 90d window");
+  assert.equal(get().hours[farHour], undefined, "beyond-72h hour bucket pruned");
+  assert.equal(get().days[farDay], undefined, "beyond-90d day bucket pruned");
+});
+
+test("a v1 state (no version) loads with days emptied, sessions preserved, persists version 2", async () => {
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const oldDay = dayKey(now - 5 * DAY_MS);
+  let saved = null;
+  const store = createCounterfactualStore({
+    load: async () => ({
+      days: { [oldDay]: { maskedTokens: 999, reports: 1 } }, // snapshot-semantics buckets
+      sessions: { s1: { maskedTokens: 42, maskedParts: 2, lastTs: now } },
+    }),
+    save: async (s) => {
+      saved = s;
+    },
+    now: fixed(now),
+  });
+
+  await store.record({ sessionID: "s2", maskedTokens: 7, maskedParts: 1, ts: now });
+
+  assert.equal(saved.version, 2);
+  assert.equal(saved.days[oldDay], undefined, "old snapshot buckets are dropped");
+  assert.equal(saved.sessions.s1.maskedTokens, 42, "sessions map is preserved");
+  assert.equal(saved.sessions.s2.maskedTokens, 7);
+});
+
+test("bucketSeries zero-fills, is oldest→newest, and its length equals count for both bucket sizes", async () => {
+  const t = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const { store } = makeStore({ now: fixed(t) });
+  // A single report on today, spanning a few buckets.
+  await store.record({ sessionID: "s1", maskedTokens: 123, maskedParts: 1, ts: t, applied: true });
+
+  const days = await bucketSeries(store, { bucket: "day", count: 5, now: fixed(t) });
+  assert.equal(days.length, 5);
+  for (let i = 0; i < days.length - 1; i++) assert.ok(days[i].key < days[i + 1].key, "oldest→newest");
+  const today = dayKey(t);
+  assert.equal(days.find((d) => d.key === today).maskedTokens, 123);
+  assert.ok(days.filter((d) => d.key !== today).every((d) => d.maskedTokens === 0), "zero-filled");
+  assert.ok(days.every((d) => typeof d.t === "number" && Number.isFinite(d.t)), "t is the bucket start ms");
+  assert.equal(days.find((d) => d.key === today).appliedTokens, 123);
+
+  const hours = await bucketSeries(store, { bucket: "hour", count: 3, now: fixed(t) });
+  assert.equal(hours.length, 3);
+  const thisHour = hourKey(t);
+  assert.equal(hours.find((h) => h.key === thisHour).maskedTokens, 123);
+  assert.ok(hours.filter((h) => h.key !== thisHour).every((h) => h.maskedTokens === 0));
+});
+
+test("a report timestamp in the future is clamped to now (no runaway future bucket)", async () => {
+  const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const { store, get } = makeStore({ now: fixed(now) });
+  await store.record({ sessionID: "s1", maskedTokens: 10, maskedParts: 1, ts: now + 365 * DAY_MS });
+  assert.equal(get().days[dayKey(now)].maskedTokens, 10, "forward-dated report lands in today's bucket");
+  assert.equal(get().sessions.s1.lastTs, now, "session lastTs is the clamped time");
 });

--- a/src/shared/timeBuckets.d.mts
+++ b/src/shared/timeBuckets.d.mts
@@ -1,0 +1,20 @@
+// Type declarations for the pure shared timeBuckets.mjs (BET-1368). Mirrors the
+// other shared .mjs modules: shared .mjs consumed from .ts must ship a
+// hand-written .d.mts (the .mjs itself has no bundled types). Pure, no I/O.
+
+/** Local-calendar day key, "YYYY-MM-DD". */
+export function dayKey(ms: number): string;
+/** Local-calendar hour key, "YYYY-MM-DDTHH". */
+export function hourKey(ms: number): string;
+/** Epoch ms at the START of the local day/hour a key names. Unparseable → NaN. */
+export function bucketKeyToMs(key: unknown): number;
+/**
+ * The `count` most recent bucket keys ending at `now`, oldest→newest, walked
+ * with Date arithmetic so a DST transition neither duplicates nor skips a
+ * bucket. `bucket` is "day" (default) or "hour".
+ */
+export function recentBucketKeys(
+  bucket: "day" | "hour",
+  count: number,
+  now: number,
+): string[];

--- a/src/shared/timeBuckets.mjs
+++ b/src/shared/timeBuckets.mjs
@@ -1,0 +1,67 @@
+// shared/timeBuckets.mjs — local-calendar time-bucket keys shared by the
+// optimizer counterfactual store and the model spend ledger (BET-1368).
+//
+// Pure: no imports, no I/O. Buckets are LOCAL-calendar day "YYYY-MM-DD" and
+// hour "YYYY-MM-DDTHH" keys, matching the store and the ledger's existing
+// keys — never UTC, never rolling absolute boundaries. DST-safe:
+// recentBucketKeys walks with Date arithmetic (setDate / setHours) so a
+// transition neither duplicates nor skips a bucket.
+
+function toMs(v) {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+
+/** Local-calendar day key, "YYYY-MM-DD". */
+export function dayKey(ms) {
+  const d = new Date(toMs(ms));
+  const y = d.getFullYear();
+  const m = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${y}-${m}-${day}`;
+}
+
+/** Local-calendar hour key, "YYYY-MM-DDTHH". */
+export function hourKey(ms) {
+  const d = new Date(toMs(ms));
+  return `${dayKey(ms)}T${String(d.getHours()).padStart(2, "0")}`;
+}
+
+/** Epoch ms at the START of the local day/hour a key names. Inverse of the above. */
+export function bucketKeyToMs(key) {
+  if (typeof key !== "string") return NaN;
+  const day = /^(\d{4})-(\d{2})-(\d{2})$/.exec(key);
+  if (day) {
+    const y = Number(day[1]);
+    const m = Number(day[2]);
+    const d = Number(day[3]);
+    return new Date(y, m - 1, d).getTime();
+  }
+  const hour = /^(\d{4})-(\d{2})-(\d{2})T(\d{2})$/.exec(key);
+  if (hour) {
+    const y = Number(hour[1]);
+    const m = Number(hour[2]);
+    const d = Number(hour[3]);
+    const h = Number(hour[4]);
+    return new Date(y, m - 1, d, h).getTime();
+  }
+  return NaN;
+}
+
+/**
+ * The `count` most recent bucket keys ending at `now`, oldest→newest, walked
+ * with Date arithmetic (setDate / setHours) so a DST transition neither
+ * duplicates nor skips a bucket. `bucket` is "day" (default) or "hour".
+ */
+export function recentBucketKeys(bucket, count, now) {
+  const n = Math.max(1, Math.floor(toMs(count)) || 1);
+  const base = toMs(now);
+  const isHour = bucket === "hour";
+  const keys = [];
+  for (let i = n - 1; i >= 0; i--) {
+    const d = new Date(base);
+    if (isHour) d.setHours(d.getHours() - i);
+    else d.setDate(d.getDate() - i);
+    keys.push(isHour ? hourKey(d.getTime()) : dayKey(d.getTime()));
+  }
+  return keys;
+}

--- a/src/shared/timeBuckets.test.ts
+++ b/src/shared/timeBuckets.test.ts
@@ -1,0 +1,102 @@
+import { describe, it, expect } from "vitest";
+import { dayKey, hourKey, bucketKeyToMs, recentBucketKeys } from "./timeBuckets.mjs";
+
+describe("key formats and zero-padding", () => {
+  it("dayKey formats a local calendar day with zero-padded month/day", () => {
+    expect(dayKey(new Date(2026, 0, 5, 12, 0, 0).getTime())).toBe("2026-01-05");
+    expect(dayKey(new Date(2026, 11, 31, 23, 59, 59).getTime())).toBe("2026-12-31");
+    expect(dayKey(new Date(2026, 7, 4, 12, 0, 0).getTime())).toBe("2026-08-04");
+  });
+
+  it("hourKey formats a local calendar hour with zero-padded order", () => {
+    expect(hourKey(new Date(2026, 7, 24, 3, 30, 0).getTime())).toBe("2026-08-24T03");
+    expect(hourKey(new Date(2026, 7, 24, 23, 0, 0).getTime())).toBe("2026-08-24T23");
+    expect(hourKey(new Date(2026, 7, 24, 0, 0, 0).getTime())).toBe("2026-08-24T00");
+  });
+
+  it("hourKey is the dayKey with the hour suffix", () => {
+    const ms = new Date(2026, 7, 24, 15, 0, 0).getTime();
+    expect(hourKey(ms)).toBe(`${dayKey(ms)}T15`);
+  });
+});
+
+describe("bucketKeyToMs — inverse of the key functions", () => {
+  it("round-trips a day key to the start of that local day", () => {
+    const ms = new Date(2026, 7, 24, 12, 0, 0).getTime();
+    const key = dayKey(ms);
+    expect(dayKey(bucketKeyToMs(key))).toBe(key);
+    // The start of the day, not noon.
+    expect(new Date(bucketKeyToMs(key)).getHours()).toBe(0);
+  });
+
+  it("round-trips an hour key to the start of that local hour", () => {
+    const ms = new Date(2026, 7, 24, 15, 45, 0).getTime();
+    const key = hourKey(ms);
+    expect(hourKey(bucketKeyToMs(key))).toBe(key);
+    expect(new Date(bucketKeyToMs(key)).getMinutes()).toBe(0);
+  });
+
+  it("zero-padded round-trips survive normalization (single-digit month/day/hour)", () => {
+    const day = dayKey(new Date(2026, 0, 4, 0, 0, 0).getTime());
+    expect(dayKey(bucketKeyToMs(day))).toBe(day);
+    const hour = hourKey(new Date(2026, 0, 4, 5, 0, 0).getTime());
+    expect(hourKey(bucketKeyToMs(hour))).toBe(hour);
+  });
+
+  it("returns NaN for an unparseable key or a non-string", () => {
+    expect(Number.isNaN(bucketKeyToMs("not-a-key"))).toBe(true);
+    expect(Number.isNaN(bucketKeyToMs("2026-1-5"))).toBe(true); // single-digit parts
+    expect(Number.isNaN(bucketKeyToMs("2026-08-24 12:00"))).toBe(true);
+    expect(Number.isNaN(bucketKeyToMs("2026-08-24T"))).toBe(true);
+    expect(Number.isNaN(bucketKeyToMs(null))).toBe(true);
+    expect(Number.isNaN(bucketKeyToMs(undefined))).toBe(true);
+    expect(Number.isNaN(bucketKeyToMs(42))).toBe(true);
+  });
+});
+
+describe("recentBucketKeys", () => {
+  it("returns `count` keys, oldest→newest, ending at the key of `now`", () => {
+    const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+    const keys = recentBucketKeys("day", 5, now);
+    expect(keys).toHaveLength(5);
+    expect(keys[0]).toBe("2026-08-20");
+    expect(keys[4]).toBe("2026-08-24");
+    for (let i = 0; i < keys.length - 1; i++) expect(keys[i] < keys[i + 1]).toBe(true);
+  });
+
+  it("hour bucket keys step by the hour and end at `now`'s hour", () => {
+    const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+    const keys = recentBucketKeys("hour", 3, now);
+    expect(keys).toEqual(["2026-08-24T10", "2026-08-24T11", "2026-08-24T12"]);
+  });
+
+  it("count 1 returns exactly the key of `now`", () => {
+    const now = new Date(2026, 7, 24, 12, 0, 0).getTime();
+    expect(recentBucketKeys("day", 1, now)).toEqual(["2026-08-24"]);
+    expect(recentBucketKeys("hour", 1, now)).toEqual(["2026-08-24T12"]);
+  });
+
+  it("produces exactly `count` DISTINCT keys across a DST spring-forward", () => {
+    // US DST begins 2026-03-08 02:00 local. A 3-day window crossing it must
+    // yield exactly 3 distinct day keys and exactly 3 distinct hour keys.
+    const after = new Date(2026, 2, 9, 12, 0, 0).getTime();
+    const days = recentBucketKeys("day", 3, after);
+    expect(days).toHaveLength(3);
+    expect(new Set(days).size).toBe(3);
+    const hours = recentBucketKeys("hour", 3, after);
+    expect(hours).toHaveLength(3);
+    expect(new Set(hours).size).toBe(3);
+  });
+
+  it("produces exactly `count` DISTINCT keys across a DST fall-back", () => {
+    // US DST ends 2026-11-01 02:00 local. A 5-day window crossing it must
+    // yield exactly 5 distinct day keys and exactly 5 distinct hour keys.
+    const after = new Date(2026, 10, 2, 12, 0, 0).getTime();
+    const days = recentBucketKeys("day", 5, after);
+    expect(days).toHaveLength(5);
+    expect(new Set(days).size).toBe(5);
+    const hours = recentBucketKeys("hour", 5, after);
+    expect(hours).toHaveLength(5);
+    expect(new Set(hours).size).toBe(5);
+  });
+});


### PR DESCRIPTION
## BET-1368 — Optimizer counterfactual: additive token-turn buckets, hourly retention, model attribution

### What changed

The counterfactual store now stores **additive token-turns** (the quantity that maps to money) instead of per-day snapshots. A bucket accumulates each report's `maskedTokens` at write time — a session no longer contributes its whole growing total once per day; each plugin report is exactly one turn's worth.

**Fix 1 — one time-bucket definition.** New `src/shared/timeBuckets.mjs` (`dayKey`, `hourKey`, `bucketKeyToMs`, `recentBucketKeys`, DST-safe via Date arithmetic). The private `dayKey` copies in `modelLedger.mjs` and `counterfactual.mjs` are deleted and both import the shared one; `aggregateDailySeries` builds its key list with `recentBucketKeys("day", …)`.

**Fix 2 — additive buckets.** `computeDay()` deleted entirely. `record` ADDITIVELY writes the report into its `days` and `hours` buckets, keyed off **`report.ts`** (clamped to now when future / beyond day retention — no more clock-vs-ts mismatch), while the `sessions` map keeps its replace semantics (it backs `bySession`/`savedPct`).

**Fix 3 — validator.** `providerID`/`modelID` (optional, ≤128 non-empty strings) and `rewarmTokens` (optional, finite ≥0) accepted; all optional so a not-yet-updated plugin still validates.

**Fix 4 — one-time reset.** `normalizeState` drops old snapshot buckets when `version !== 2` (summing two meanings is worse than a gap), keeps the `sessions` map, persists `version: 2`. The 30-day counterfactual line / Saved figure will start empty and refill over 30 days.

**Fix 5 — one series path.** `bucketSeries` is the single series-building helper; `summaryFields` is implemented on top of it and keeps its existing return shape. `RETAIN_HOURS = 72` exported.

### Files changed
- `src/shared/timeBuckets.mjs` (new)
- `src/shared/timeBuckets.test.ts` (new)
- `src/shared/timeBuckets.d.mts` (new — required companion: shared `.mjs` modules consumed from `.ts` must ship a hand-written `.d.mts` or `tsc` fails with TS7016; matches every other shared module)
- `src/server/optimizer/counterfactual.mjs`
- `src/server/optimizer/counterfactual.test.mjs`
- `src/server/modelLedger.mjs`

Do not-touch scope respected: renderer, RPC layer, optimizer plugin, `summary.mjs`/`summary.test.mjs` all untouched.

**Base: origin/main @ `33f506d6`**

**Verification results:**
- PR branch (`multica/BET-1368-token-turn-buckets` @ `2d669709`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `2901` pass / `0` fail / `0` skip (+ shared `timeBuckets.test.ts`: 12 vitest tests pass). Failures: none. log sha256: `d0b322184c7adefc4748659383c54b41ad84ecfa02a0efc4810d406d84a4a0c9`
- Base (`main` @ `33f506d6`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `2893` pass / `0` fail / `0` skip. Failures: none. log sha256: `4a52edc98529907f1cfcdd6e804f6576ed579f2e1f25fd43ebff1eb872735b9b`
- **Conclusion:** `0` pre-existing failures, `0` new failures. The PR adds 8 node:test cases + 12 vitest cases.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

Cross-cutting note: the counterfactual store/ledger now share `dayKey`/`recentBucketKeys`; the next issue (hourly bucketing in both) consumes the same helpers directly.
