### PR TITLE
Optimizer chart: 24h/7d/30d range selector + optimizer:series windowed read (BET-1369)

### DIFF
--- a/src/renderer/OptimizerCard.test.tsx
+++ b/src/renderer/OptimizerCard.test.tsx
@@ -68,7 +68,10 @@ function seriesFixture(over: Partial<OptimizerSeries> = {}): OptimizerSeries {
 }
 
 // Install both reads with sane defaults; tests override specifics per-case.
-function setApi(overrides: { optimizerSummary?: () => Promise<OptimizerSummary>; optimizerSeries?: (range: OptimizerRange) => Promise<OptimizerSeries> } = {}) {
+function setApi(overrides: {
+  optimizerSummary?: () => Promise<OptimizerSummary>;
+  optimizerSeries?: (range: OptimizerRange) => Promise<OptimizerSeries | { supported: false }>;
+} = {}) {
   return installMockApi({
     optimizerSummary: () => Promise.resolve(summaryFixture()),
     optimizerSeries: (range: OptimizerRange) => Promise.resolve(seriesFixture({ range })),
@@ -168,9 +171,9 @@ describe("OptimizerCard — BET-1369 range selector + windowed stats", () => {
     });
     h = mount(<OptimizerCard />);
     await h.flush();
-    // maskedTotal 1000 → saved = round(1000*3/1e6) = 0; overlay shows the
-    // masked total and the Saved stat reads the same estimate.
-    expect(h.text()).toContain("−1.0k");
+    // maskedTotal 1000 → the chart overlay shows the masked total + the est.
+    // saved figure, and the counterfactual legend line appears.
+    expect(h.text()).toContain("−1k tokens · ≈ $0 est.");
     expect(h.text()).toContain("raw counterfactual");
   });
 

--- a/src/renderer/OptimizerCard.test.tsx
+++ b/src/renderer/OptimizerCard.test.tsx
@@ -1,18 +1,21 @@
 // @vitest-environment jsdom
 //
-// Component tests for the Optimizer P2.5 (BET-1347) legibility surfaces on the
-// Settings → Models optimizer card: the activity feed's empty state, the
-// pressure chips (neutral when there is no signal, never a fabricated pace),
-// and the metered-endpoints row (role + price, deliberately NO gauge).
+// Component tests for the Settings → Models optimizer card (BET-1337 + P2.5
+// BET-1347 + BET-1369). BET-1369 made the consumption chart + the range-scoped
+// stats read from the windowed `optimizer:series` RPC (24h/7d/30d) instead of
+// folding over the summary's fixed 30-day dailySeries, so these tests drive
+// BOTH reads: `optimizerSummary` (the rest of the card) and `optimizerSeries`
+// (the chart + Sent/Saved/Cost-per-turn).
 
 import { describe, it, expect, afterEach, beforeEach } from "vitest";
+import { act } from "react";
 import { mount, installMockApi, resetStore, type Harness } from "./testHarness";
 import { OptimizerCard } from "./OptimizerCard";
-import type { OptimizerSummary } from "../shared/types";
+import type { OptimizerSummary, OptimizerSeries, OptimizerRange } from "../shared/types";
 
 const CD = { cacheRead: 8000, cacheWrite: 1000, input: 1000, output: 500 };
 
-function fixture(over: Partial<OptimizerSummary> = {}): OptimizerSummary {
+function summaryFixture(over: Partial<OptimizerSummary> = {}): OptimizerSummary {
   return {
     supported: true,
     windowDays: 30,
@@ -45,7 +48,44 @@ function fixture(over: Partial<OptimizerSummary> = {}): OptimizerSummary {
   };
 }
 
-describe("OptimizerCard — P2.5 legibility surfaces", () => {
+// A 24h hourly series by default (two points, no counterfactual). `range` is
+// honoured so a "7d" click can produce a day-bucket series.
+function seriesFixture(over: Partial<OptimizerSeries> = {}): OptimizerSeries {
+  return {
+    supported: true,
+    range: "24h",
+    bucket: "hour",
+    startMs: new Date(2026, 7, 23, 14, 0, 0).getTime(),
+    endMs: new Date(2026, 7, 24, 14, 0, 0).getTime(),
+    series: [
+      { t: new Date(2026, 7, 23, 14, 0, 0).getTime(), tokensSent: 10, maskedTokens: 0 },
+      { t: new Date(2026, 7, 23, 15, 0, 0).getTime(), tokensSent: 20, maskedTokens: 0 },
+    ],
+    counterfactualAvailable: false,
+    totals: { turns: 100, cost: 12.34, tokensSent: 30, maskedTokens: 0 },
+    ...over,
+  };
+}
+
+// Install both reads with sane defaults; tests override specifics per-case.
+function setApi(overrides: { optimizerSummary?: () => Promise<OptimizerSummary>; optimizerSeries?: (range: OptimizerRange) => Promise<OptimizerSeries> } = {}) {
+  return installMockApi({
+    optimizerSummary: () => Promise.resolve(summaryFixture()),
+    optimizerSeries: (range: OptimizerRange) => Promise.resolve(seriesFixture({ range })),
+    ...overrides,
+  });
+}
+
+// Find the range selector chip whose label is `label` and click it.
+function clickRange(h: Harness, label: string): void {
+  const btn = [...h.container.querySelectorAll<HTMLButtonElement>("button")].find(
+    (b) => b.textContent?.trim() === label,
+  );
+  if (!btn) throw new Error(`no range chip "${label}" found`);
+  act(() => btn.click());
+}
+
+describe("OptimizerCard — BET-1369 range selector + windowed stats", () => {
   let h: Harness | null = null;
 
   beforeEach(() => {
@@ -57,21 +97,155 @@ describe("OptimizerCard — P2.5 legibility surfaces", () => {
     h = null;
   });
 
+  it("defaults to 24h: asks optimizerSeries for '24h' and shows the 24h Sent label", async () => {
+    const { api } = setApi();
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(api.calls.optimizerSeries?.flat()).toContain("24h");
+    expect(h.text()).toContain("Sent (24h)");
+    expect(h.text()).toContain("24h average");
+  });
+
+  it("clicking the 7d chip asks optimizerSeries for '7d' and relabels Sent", async () => {
+    const { api } = setApi({
+      optimizerSeries: (range) =>
+        Promise.resolve(seriesFixture({ range, bucket: "day", series: [{ t: Date.now(), tokensSent: 5, maskedTokens: 0 }] })),
+    });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    clickRange(h, "7d");
+    await h.flush();
+    const ranges = api.calls.optimizerSeries?.map((a) => a[0]);
+    expect(ranges).toContain("7d");
+    expect(h.text()).toContain("Sent (7d)");
+  });
+
+  it("renders the chip group with all three ranges", async () => {
+    setApi();
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    const chips = [...h.container.querySelectorAll("button")].map((b) => b.textContent?.trim());
+    expect(chips).toContain("24h");
+    expect(chips).toContain("7d");
+    expect(chips).toContain("30d");
+  });
+
+  it("the chart axis ticks come from the windowed series, not the summary's dailySeries", async () => {
+    setApi({
+      optimizerSeries: () =>
+        Promise.resolve(
+          seriesFixture({
+            bucket: "day",
+            range: "7d",
+            series: [
+              { t: new Date(2026, 7, 23, 0, 0, 0).getTime(), tokensSent: 10, maskedTokens: 0 },
+              { t: new Date(2026, 7, 24, 0, 0, 0).getTime(), tokensSent: 20, maskedTokens: 0 },
+            ],
+          }),
+        ),
+    });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    const texts = [...h.container.querySelectorAll("svg.opt-chart text")].map((t) => t.textContent ?? "");
+    // Day-bucket labels via chartAxisTicks over the SERIES t's.
+    expect(texts.some((t) => t.includes("Aug 23"))).toBe(true);
+    expect(texts.some((t) => t.includes("Aug 24"))).toBe(true);
+  });
+
+  it("the Counterfactual stat reads the series maskedTokens and shows the saved overlay", async () => {
+    setApi({
+      optimizerSeries: () =>
+        Promise.resolve(
+          seriesFixture({
+            series: [
+              { t: Date.now(), tokensSent: 1000, maskedTokens: 500 },
+              { t: Date.now(), tokensSent: 1000, maskedTokens: 500 },
+            ],
+            counterfactualAvailable: true,
+            totals: { turns: 10, cost: 2, tokensSent: 2000, maskedTokens: 1000 },
+          }),
+        ),
+    });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    // maskedTotal 1000 → saved = round(1000*3/1e6) = 0; overlay shows the
+    // masked total and the Saved stat reads the same estimate.
+    expect(h.text()).toContain("−1.0k");
+    expect(h.text()).toContain("raw counterfactual");
+  });
+
+  it("Cache-hit and Sessions details still say 30d while Sent and Cost/turn say 24h", async () => {
+    setApi();
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    const text = h.text();
+    expect(text).toContain("Sent (24h)");
+    expect(text).toContain("24h average");
+    // Summary-scoped details unchanged:
+    expect(text).toContain("· 30d");
+    expect(text).toContain("TTL 5m default");
+    // Sessions stat detail reads 30d (no compaction in fixture).
+    expect(h.container.textContent).toContain("30d");
+  });
+
+  it("no counterfactual in a 24h window shows the hourly explanation under the legend", async () => {
+    setApi();
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("Hourly comparison starts collecting today.");
+    expect(h.text()).not.toContain("raw counterfactual");
+  });
+
+  it("no counterfactual in a 7d/30d window shows the no-trimming explanation", async () => {
+    const { api } = setApi({
+      optimizerSeries: (range) => Promise.resolve(seriesFixture({ range, bucket: "day" })),
+    });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    // The fixture's series has maskedTokens 0 → counterfactualAvailable false.
+    // Switch to 7d (day bucket) to see the non-hourly explanation.
+    clickRange(h, "7d");
+    await h.flush();
+    expect(api.calls.optimizerSeries?.map((a) => a[0])).toContain("7d");
+    expect(h.text()).toContain("No trimming recorded in this window.");
+  });
+
+  it("an unsupported series read degrades the chart block only; the rest of the card still renders", async () => {
+    setApi({ optimizerSeries: () => Promise.resolve({ supported: false }) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    const text = h.text();
+    expect(text).toContain("Spend history needs a newer box runtime.");
+    // The summary-driven surfaces still render.
+    expect(text).toContain("Token optimizer");
+    expect(text).toContain("Prompt cache");
+  });
+
+  it("an empty window renders the range-specific no-activity empty state and NO chart", async () => {
+    setApi({
+      optimizerSeries: (range) =>
+        Promise.resolve(seriesFixture({ range, series: [], totals: { turns: 0, cost: 0, tokensSent: 0, maskedTokens: 0 } })),
+    });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("No model activity in the last 24h.");
+    expect(h.container.querySelectorAll("svg.opt-chart").length).toBe(0);
+  });
+
   it("with an empty activity feed renders the documented empty state and NO feed rows", async () => {
-    installMockApi({ optimizerSummary: () => Promise.resolve(fixture({ activity: { entries: [] } })) });
+    setApi({ optimizerSummary: () => Promise.resolve(summaryFixture({ activity: { entries: [] } })) });
     h = mount(<OptimizerCard />);
     await h.flush();
     const text = h.text();
     expect(text).toContain("Nothing changed yet. Manta needs a few days of your usage before it starts tuning anything.");
-    // No feed rows: no headline times, and no feed container content.
     expect(h.container.querySelectorAll(".opt-ev").length).toBe(0);
   });
 
   it("renders feed rows + a rolled-back row stays visually distinct when entries exist", async () => {
-    installMockApi({
+    setApi({
       optimizerSummary: () =>
         Promise.resolve(
-          fixture({
+          summaryFixture({
             activity: {
               entries: [
                 { id: "a", ts: 1_700_000_000_000, kind: "tune", subject: "trim threshold 16 → 12 tool uses", from: 16, to: 12, verdict: "kept", evidence: { turns: 62 } },
@@ -91,24 +265,21 @@ describe("OptimizerCard — P2.5 legibility surfaces", () => {
   });
 
   it("no pressure signal renders the neutral chip and NO warn chip", async () => {
-    // The fixture window has tokensPerPct: null → no signal.
-    installMockApi({ optimizerSummary: () => Promise.resolve(fixture()) });
+    setApi();
     h = mount(<OptimizerCard />);
     await h.flush();
     const text = h.text();
     expect(text).toContain("no pressure signal yet");
-    // The neutral chip is the only chip — no warn chip for an absent signal
-    // (the "ahead of pace" phrase in window copy must not become a chip).
     const chipText = [...h.container.querySelectorAll(".opt-chip")].map((c) => c.textContent ?? "").join(" ");
     expect(chipText).not.toContain("ahead of pace");
     expect(h.container.querySelectorAll(".opt-chip.warn").length).toBe(0);
   });
 
   it("a window ahead of pace (signal present, deficit > 0) renders a warn chip", async () => {
-    const f = fixture();
+    const f = summaryFixture();
     f.windows[0].tokensPerPct = 100;
     f.windows[0].deficit = 23;
-    installMockApi({ optimizerSummary: () => Promise.resolve(f) });
+    setApi({ optimizerSummary: () => Promise.resolve(f) });
     h = mount(<OptimizerCard />);
     await h.flush();
     expect(h.text()).toContain("+23 pts ahead of pace");
@@ -116,30 +287,32 @@ describe("OptimizerCard — P2.5 legibility surfaces", () => {
   });
 
   it("a metered endpoint renders the row with role + price and NO gauge element", async () => {
-    const f = fixture({
-      metered: [
-        { name: "OpenAI · gpt-5.2", role: "fallback when over pace", price: "$2.40 / Mtok blended" },
-        { name: "Groq · llama-4-70b", role: "explore + title work", price: "$0.31 / Mtok blended" },
-      ],
+    setApi({
+      optimizerSummary: () =>
+        Promise.resolve(
+          summaryFixture({
+            metered: [
+              { name: "OpenAI · gpt-5.2", role: "fallback when over pace", price: "$2.40 / Mtok blended" },
+              { name: "Groq · llama-4-70b", role: "explore + title work", price: "$0.31 / Mtok blended" },
+            ],
+          }),
+        ),
     });
-    installMockApi({ optimizerSummary: () => Promise.resolve(f) });
     h = mount(<OptimizerCard />);
     await h.flush();
     const text = h.text();
     expect(text).toContain("Metered endpoints");
     expect(text).toContain("gpt-5.2");
     expect(text).toContain("$2.40 / Mtok blended");
-    // Gauges are only for subscription windows (1 in the fixture) — the
-    // metered row is a slim role+price line with NO gauge.
-    const windowCount = f.windows.length;
+    const windowCount = summaryFixture().windows.length;
     expect(h.container.querySelectorAll(".opt-gauge").length).toBe(windowCount);
   });
 
   it("compaction stat shows 'X of Y in background' when the scheduler reports", async () => {
-    installMockApi({
+    setApi({
       optimizerSummary: () =>
         Promise.resolve(
-          fixture({
+          summaryFixture({
             compaction: { background: 6, total: 7 },
             windows: [{ provider: "claude", planLabel: "Max", windowLabel: "week", kind: "weekly", pct: 10, resetsAt: 0, forecastPct: null, deficit: null, tokensPerPct: null }],
           }),
@@ -148,44 +321,5 @@ describe("OptimizerCard — P2.5 legibility surfaces", () => {
     h = mount(<OptimizerCard />);
     await h.flush();
     expect(h.text()).toContain("6 of 7 in background");
-  });
-
-  it("renders x-axis tick <text> labels for the daily series", async () => {
-    installMockApi({ optimizerSummary: () => Promise.resolve(fixture()) });
-    h = mount(<OptimizerCard />);
-    await h.flush();
-    // The fixture's two-day series → 2 ticks, pinned at index 0 and the last.
-    const texts = [...h.container.querySelectorAll("svg.opt-chart text")].map((t) => t.textContent ?? "");
-    expect(texts).toContain("Aug 1");
-    expect(texts).toContain("Aug 2");
-  });
-
-  it("renders the 'last 30 days' range label in the chart heading row", async () => {
-    installMockApi({ optimizerSummary: () => Promise.resolve(fixture()) });
-    h = mount(<OptimizerCard />);
-    await h.flush();
-    expect(h.text()).toContain("last 30 days");
-  });
-
-  it("with no counterfactual draws NO dashed path and NO 'raw counterfactual' legend text", async () => {
-    // Default fixture has maskedTokens all 0 → masked30d === 0.
-    installMockApi({ optimizerSummary: () => Promise.resolve(fixture()) });
-    h = mount(<OptimizerCard />);
-    await h.flush();
-    expect(h.container.querySelectorAll("svg.opt-chart path[stroke-dasharray]").length).toBe(0);
-    expect(h.text()).not.toContain("raw counterfactual");
-  });
-
-  it("with all-zero activity renders the no-activity empty state and NO chart", async () => {
-    installMockApi({
-      optimizerSummary: () =>
-        Promise.resolve(
-          fixture({ dailySeries: [{ day: "2026-08-01", tokensSent: 0, maskedTokens: 0 }] }),
-        ),
-    });
-    h = mount(<OptimizerCard />);
-    await h.flush();
-    expect(h.text()).toContain("No model activity in the last 30 days.");
-    expect(h.container.querySelectorAll("svg.opt-chart").length).toBe(0);
   });
 });

--- a/src/renderer/OptimizerCard.tsx
+++ b/src/renderer/OptimizerCard.tsx
@@ -25,6 +25,7 @@
 
 import { useEffect, useState } from "react";
 import { Card } from "./Card";
+import { ChipGroup } from "./Chip";
 import { useStore } from "./store";
 import {
   buildCumulativePath,
@@ -35,9 +36,10 @@ import {
   describePressure,
   describeActivityEntry,
 } from "./chatUtils";
-import type { OptimizerSummary } from "../shared/types";
+import type { OptimizerSummary, OptimizerRange, OptimizerSeries } from "../shared/types";
 
 type OptimizerData = OptimizerSummary | { supported: false };
+type OptimizerSeriesData = OptimizerSeries | { supported: false };
 
 const wholePct = (v: number): string => `${Math.round(v)}%`;
 
@@ -75,6 +77,31 @@ function axisTokens(v: number): string {
 // (max) and y=H the bottom (zero), then translated into the SVG.
 const CHART = { left: 50, top: 6, width: 600, height: 200 };
 
+// The range selector's options (BET-1369). Single source of truth beside the
+// label suffix lookup below, so the chip set and the stat labels can't drift.
+const RANGE_OPTIONS: { value: OptimizerRange; label: string }[] = [
+  { value: "24h", label: "24h" },
+  { value: "7d", label: "7d" },
+  { value: "30d", label: "30d" },
+];
+
+// The human suffix used in range-scoped stat labels ("Sent (24h)", "24h average").
+const RANGE_LABEL: Record<OptimizerRange, string> = {
+  "24h": "24h",
+  "7d": "7d",
+  "30d": "30d",
+};
+
+// The muted explanation line under the legend when no counterfactual was
+// recorded in the window (BET-1369). Both states are real and reachable.
+function noCounterfactualText(range: OptimizerRange): string {
+  return range === "24h" ? "Hourly comparison starts collecting today." : "No trimming recorded in this window.";
+}
+
+function emptyWindowText(range: OptimizerRange): string {
+  return `No model activity in the last ${range}.`;
+}
+
 export function OptimizerCard() {
   const optimizerEnabled = useStore((s) => s.optimizerEnabled);
   const [state, setState] = useState<{
@@ -82,6 +109,15 @@ export function OptimizerCard() {
     data: OptimizerData | null;
     fetchError: boolean;
   }>({ loading: true, data: null, fetchError: false });
+  // BET-1369: the window selector + the windowed series read. The summary
+  // drives the rest of the card (cache, sessions, windows, activity); the
+  // chart + the range-scoped stats read exclusively from this series.
+  const [range, setRange] = useState<OptimizerRange>("24h");
+  const [series, setSeries] = useState<{
+    loading: boolean;
+    data: OptimizerSeriesData | null;
+    loadError: boolean;
+  }>({ loading: true, data: null, loadError: false });
 
   useEffect(() => {
     let alive = true;
@@ -97,6 +133,22 @@ export function OptimizerCard() {
       alive = false;
     };
   }, []);
+
+  useEffect(() => {
+    let alive = true;
+    setSeries((s) => ({ ...s, loading: true }));
+    window.api
+      .optimizerSeries(range)
+      .then((r: OptimizerSeriesData) => {
+        if (alive) setSeries({ loading: false, data: r, loadError: false });
+      })
+      .catch(() => {
+        if (alive) setSeries((s) => ({ ...s, loading: false, loadError: true }));
+      });
+    return () => {
+      alive = false;
+    };
+  }, [range]);
 
   const header = (
     <span className="text-micro uppercase text-text-faint">Token optimizer</span>
@@ -131,44 +183,48 @@ export function OptimizerCard() {
   const windows = Array.isArray(d.windows) ? d.windows : [];
   const hasWindows = windows.length > 0;
 
-  // 30-day aggregates over the zero-filled daily series.
-  const sent30d = d.dailySeries.reduce((s, e) => s + (e.tokensSent || 0), 0);
-  const masked30d = d.dailySeries.reduce((s, e) => s + (e.maskedTokens || 0), 0);
-  const raw30d = sent30d + masked30d;
-  const trimmedPct = raw30d > 0 ? (masked30d / raw30d) * 100 : 0;
+  // ---- BET-1369: the WINDOWED series drives the consumption chart and the
+  // range-scoped stats below. The summary drives everything else on the card.
+  // While a range fetch is in flight we keep the previous chart (opacity-60);
+  // if the series read is unsupported/rejected, only the chart block degrades.
+  const seriesUnsupported = series.loadError || (series.data ? !series.data.supported : false);
+  const sd = !seriesUnsupported && series.data && series.data.supported ? (series.data as OptimizerSeries) : null;
+
+  // Range-scoped totals (0 until the series is readable).
+  const sentTotal = sd ? sd.totals.tokensSent : 0;
+  const maskedTotal = sd ? sd.totals.maskedTokens : 0;
+  const rawTotal = sentTotal + maskedTotal;
+  const trimmedPct = rawTotal > 0 ? (maskedTotal / rawTotal) * 100 : 0;
+
+  // Flat $3/Mtok counterfactual saving estimate (refined per-model in phase 2) —
+  // computation unchanged, now scoped to the window.
+  const saved = Math.round((maskedTotal * 3) / 1_000_000);
 
   // Consumption chart series (cumulative), scaled together by the peak.
-  const maxTokens = Math.max(raw30d, 1);
+  const maxTokens = Math.max(rawTotal, 1);
   const sentPath = buildCumulativePath(
-    d.dailySeries.map((e) => e.tokensSent || 0),
+    sd ? sd.series.map((p) => p.tokensSent || 0) : [],
     CHART.width,
     CHART.height,
     maxTokens,
   );
   const rawPath = buildCumulativePath(
-    d.dailySeries.map((e) => (e.tokensSent || 0) + (e.maskedTokens || 0)),
+    sd ? sd.series.map((p) => (p.tokensSent || 0) + (p.maskedTokens || 0)) : [],
     CHART.width,
     CHART.height,
     maxTokens,
   );
 
-  // X-axis ticks for the consumption chart (BET-1366): evenly spaced, at most
-  // 4 for "day", always pinned to index 0 and the last index. An all-zero
-  // series and a bare solid line must not be confused — guards in the JSX
-  // below.
-  const seriesTs = d.dailySeries.map((e) => new Date(`${e.day}T00:00:00`).getTime());
-  const axisTicks = chartAxisTicks(seriesTs, "day");
-  const hasCounterfactual = masked30d > 0;
-  const noActivity = sent30d === 0 && masked30d === 0;
-
-  // Flat $3/Mtok counterfactual saving estimate (refined per-model in phase 2).
-  const saved = Math.round((masked30d * 3) / 1_000_000);
+  // X-axis ticks (BET-1366): bucket-start epoch ms, per the range's bucket.
+  const axisTicks = sd ? chartAxisTicks(sd.series.map((p) => p.t), sd.bucket) : [];
+  const hasCounterfactual = sd ? sd.counterfactualAvailable : false;
+  const noActivity = sd ? sentTotal === 0 && maskedTotal === 0 : false;
 
   const cs = d.cacheShare;
   const hitDenom = cs.cacheRead + cs.cacheWrite + cs.input;
   const cacheHitPct = hitDenom > 0 ? (cs.cacheRead / hitDenom) * 100 : 0;
 
-  const costPerTurn = d.totals.turns > 0 ? `$${(d.totals.cost / d.totals.turns).toFixed(2)}` : "—";
+  const costPerTurn = sd && sd.totals.turns > 0 ? `$${(sd.totals.cost / sd.totals.turns).toFixed(2)}` : "—";
 
   // BET-1347 slices.
   const activity = Array.isArray(d.activity?.entries) ? d.activity.entries : [];
@@ -295,108 +351,121 @@ export function OptimizerCard() {
         </>
       )}
 
-      {/* ── Consumption chart (phase 1, unchanged) ───────────────────────── */}
+      {/* ── Consumption chart + range selector (BET-1369) ────────────────── */}
       <div className="flex items-baseline justify-between gap-3">
         <div className="opt-chart-head">Token consumption — with &amp; without optimization</div>
-        <span className="text-micro text-text-faint">last 30 days</span>
+        <ChipGroup label="Consumption window" value={range} options={RANGE_OPTIONS} onChange={setRange} />
       </div>
-      {noActivity ? (
-        <div className="opt-empty">No model activity in the last 30 days.</div>
+      {seriesUnsupported ? (
+        <div className="text-meta text-text-faint">
+          Spend history needs a newer box runtime.
+        </div>
+      ) : !sd ? (
+        <div className="text-meta text-text-faint">Reading your history…</div>
       ) : (
-        <>
-          <svg
-            className="opt-chart"
-            viewBox={`0 0 ${CHART.left + CHART.width + 6} ${CHART.top + CHART.height + 18}`}
-            role="img"
-            aria-label="Token consumption with and without optimization"
-          >
-            <g transform={`translate(${CHART.left} ${CHART.top})`}>
-              <line x1="0" y1={CHART.height} x2={CHART.width} y2={CHART.height} stroke="var(--border-subtle)" />
-              <line x1="0" y1={CHART.height / 2} x2={CHART.width} y2={CHART.height / 2} stroke="var(--border-subtle)" strokeDasharray="2 5" opacity=".6" />
-              <line x1="0" y1="0" x2={CHART.width} y2="0" stroke="var(--border-subtle)" strokeDasharray="2 5" opacity=".6" />
-              <line x1="0" y1="0" x2="0" y2={CHART.height} stroke="var(--border-subtle)" />
-
-              <text x="-8" y={CHART.height + 12} textAnchor="end" fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">0</text>
-              <text x="-8" y={CHART.height / 2 + 4} textAnchor="end" fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">{axisTokens(maxTokens / 2)}</text>
-              <text x="-8" y="4" textAnchor="end" fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">{axisTokens(maxTokens)}</text>
-
-              {axisTicks.map((t) => {
-                const isFirst = t.index === 0;
-                const isLast = t.index === d.dailySeries.length - 1;
-                const anchor = isFirst ? "start" : isLast ? "end" : "middle";
-                const x = axisTicks.length > 1 ? (t.index / (d.dailySeries.length - 1)) * CHART.width : 0;
-                return (
-                  <text key={t.index} x={x} y={CHART.height + 14} textAnchor={anchor} fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">
-                    {t.label}
-                  </text>
-                );
-              })}
-
-              {hasCounterfactual && <path d={rawPath} fill="none" stroke="var(--tx4)" strokeWidth="2" strokeDasharray="5 4" />}
-              <path d={sentPath} fill="none" stroke="var(--accent)" strokeWidth="2.5" />
-              <path
-                d={`${sentPath} L ${CHART.width} ${CHART.height} L 0 ${CHART.height} Z`}
-                fill="rgb(var(--accent-rgb) / 0.08)"
-                stroke="none"
-              />
-
-              {masked30d > 0 && (
-                <text x={CHART.width} y="24" textAnchor="end" fill="var(--ok)" fontSize="10" fontFamily="var(--font-mono)">
-                  −{formatTokens(masked30d)} · ≈ ${saved} est.
-                </text>
-              )}
-            </g>
-          </svg>
-          <div className="opt-legend">
-            <span className="opt-legend-item">
-              <i style={{ background: "var(--accent)" }} />
-              sent
-            </span>
-            {hasCounterfactual && (
-              <span className="opt-legend-item">
-                <i style={{ background: "var(--tx4)" }} />
-                raw counterfactual — same turns, nothing trimmed (est.)
-              </span>
-            )}
-          </div>
-        </>
-      )}
-
-      <div className="opt-stats">
-        <div className="opt-stat">
-          <div className="opt-stat-l">Sent (30d)</div>
-          <div className="opt-stat-v">{formatTokens(sent30d)}</div>
-          <div className="opt-stat-d">raw {formatTokens(raw30d)}</div>
-        </div>
-        <div className="opt-stat">
-          <div className="opt-stat-l">Saved</div>
-          <div className="opt-stat-v ok">≈ ${saved}</div>
-          <div className="opt-stat-d">est. · counterfactual</div>
-        </div>
-        <div className="opt-stat">
-          <div className="opt-stat-l">Cache hit</div>
-          <div className="opt-stat-v">{wholePct(cacheHitPct)}</div>
-          <div className="opt-stat-d">
-            {d.ttl ? `TTL ${ttlLabel(d.ttl.measuredMs)} ${d.ttl.confidence}` : ""}
-          </div>
-        </div>
-        <div className="opt-stat">
-          <div className="opt-stat-l">Cost / turn</div>
-          <div className="opt-stat-v">{costPerTurn}</div>
-          <div className="opt-stat-d">30d average</div>
-        </div>
-        <div className="opt-stat">
-          <div className="opt-stat-l">Sessions</div>
-          <div className="opt-stat-v">{d.bySession.length}</div>
-          {compaction ? (
-            <div className="opt-stat-d" data-testid="compaction-bg">
-              {compaction.background} of {compaction.total} in background
-            </div>
+        <div className={series.loading ? "opacity-60" : undefined}>
+          {noActivity ? (
+            <div className="opt-empty">{emptyWindowText(range)}</div>
           ) : (
-            <div className="opt-stat-d">30d</div>
+            <>
+              <svg
+                className="opt-chart"
+                viewBox={`0 0 ${CHART.left + CHART.width + 6} ${CHART.top + CHART.height + 18}`}
+                role="img"
+                aria-label="Token consumption with and without optimization"
+              >
+                <g transform={`translate(${CHART.left} ${CHART.top})`}>
+                  <line x1="0" y1={CHART.height} x2={CHART.width} y2={CHART.height} stroke="var(--border-subtle)" />
+                  <line x1="0" y1={CHART.height / 2} x2={CHART.width} y2={CHART.height / 2} stroke="var(--border-subtle)" strokeDasharray="2 5" opacity=".6" />
+                  <line x1="0" y1="0" x2={CHART.width} y2="0" stroke="var(--border-subtle)" strokeDasharray="2 5" opacity=".6" />
+                  <line x1="0" y1="0" x2="0" y2={CHART.height} stroke="var(--border-subtle)" />
+
+                  <text x="-8" y={CHART.height + 12} textAnchor="end" fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">0</text>
+                  <text x="-8" y={CHART.height / 2 + 4} textAnchor="end" fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">{axisTokens(maxTokens / 2)}</text>
+                  <text x="-8" y="4" textAnchor="end" fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">{axisTokens(maxTokens)}</text>
+
+                  {axisTicks.map((t) => {
+                    const isFirst = t.index === 0;
+                    const isLast = t.index === sd.series.length - 1;
+                    const anchor = isFirst ? "start" : isLast ? "end" : "middle";
+                    const x = axisTicks.length > 1 ? (t.index / (sd.series.length - 1)) * CHART.width : 0;
+                    return (
+                      <text key={t.index} x={x} y={CHART.height + 14} textAnchor={anchor} fill="var(--tx4)" fontSize="10" fontFamily="var(--font-mono)">
+                        {t.label}
+                      </text>
+                    );
+                  })}
+
+                  {hasCounterfactual && <path d={rawPath} fill="none" stroke="var(--tx4)" strokeWidth="2" strokeDasharray="5 4" />}
+                  <path d={sentPath} fill="none" stroke="var(--accent)" strokeWidth="2.5" />
+                  <path
+                    d={`${sentPath} L ${CHART.width} ${CHART.height} L 0 ${CHART.height} Z`}
+                    fill="rgb(var(--accent-rgb) / 0.08)"
+                    stroke="none"
+                  />
+
+                  {maskedTotal > 0 && (
+                    <text x={CHART.width} y="24" textAnchor="end" fill="var(--ok)" fontSize="10" fontFamily="var(--font-mono)">
+                      −{formatTokens(maskedTotal)} · ≈ ${saved} est.
+                    </text>
+                  )}
+                </g>
+              </svg>
+              <div className="opt-legend">
+                <span className="opt-legend-item">
+                  <i style={{ background: "var(--accent)" }} />
+                  sent
+                </span>
+                {hasCounterfactual && (
+                  <span className="opt-legend-item">
+                    <i style={{ background: "var(--tx4)" }} />
+                    raw counterfactual — same turns, nothing trimmed (est.)
+                  </span>
+                )}
+                {!hasCounterfactual && (
+                  <span className="text-text-faint">{noCounterfactualText(range)}</span>
+                )}
+              </div>
+            </>
           )}
+
+          <div className="opt-stats">
+            <div className="opt-stat">
+              <div className="opt-stat-l">Sent ({RANGE_LABEL[range]})</div>
+              <div className="opt-stat-v">{formatTokens(sentTotal)}</div>
+              <div className="opt-stat-d">raw {formatTokens(rawTotal)}</div>
+            </div>
+            <div className="opt-stat">
+              <div className="opt-stat-l">Saved</div>
+              <div className="opt-stat-v ok">≈ ${saved}</div>
+              <div className="opt-stat-d">est. · counterfactual</div>
+            </div>
+            <div className="opt-stat">
+              <div className="opt-stat-l">Cache hit</div>
+              <div className="opt-stat-v">{wholePct(cacheHitPct)}</div>
+              <div className="opt-stat-d">
+                {`${d.ttl ? `TTL ${ttlLabel(d.ttl.measuredMs)} ${d.ttl.confidence}` : ""} · 30d`}
+              </div>
+            </div>
+            <div className="opt-stat">
+              <div className="opt-stat-l">Cost / turn</div>
+              <div className="opt-stat-v">{costPerTurn}</div>
+              <div className="opt-stat-d">{RANGE_LABEL[range]} average</div>
+            </div>
+            <div className="opt-stat">
+              <div className="opt-stat-l">Sessions</div>
+              <div className="opt-stat-v">{d.bySession.length}</div>
+              {compaction ? (
+                <div className="opt-stat-d" data-testid="compaction-bg">
+                  {compaction.background} of {compaction.total} in background · 30d
+                </div>
+              ) : (
+                <div className="opt-stat-d">30d</div>
+              )}
+            </div>
+          </div>
         </div>
-      </div>
+      )}
 
       {/* ── Metered endpoints: slim role + crossover price, NO gauge ─────── */}
       {metered.length > 0 && (

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -129,6 +129,7 @@ export const DEMO_UNIMPLEMENTED = [
   "opencodeSetReferences",
   "opencodeSetSubagents",
   "opencodeSyncSubagents",
+  "optimizerSeries",
   "optimizerSummary",
   "peekRemoteFile",
   "pluginsRegistry",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1261,6 +1261,7 @@ export const httpApi: Api = {
   opencodeSearchMessages: (input) => rpc(IPC.opencodeSearchMessages, input),
   ledgerSummary: (opts) => rpc(IPC.ledgerSummary, opts),
   optimizerSummary: () => rpc(IPC.optimizerSummary),
+  optimizerSeries: (range) => rpc(IPC.optimizerSeries, { range }),
 
   // -- slash-command execution --
   opencodeRunCommand: (input) => rpc(IPC.opencodeRunCommand, input),

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -18,6 +18,7 @@ import { synthesizeSpeech } from "../shared/groq.mjs";
 import { WebSocketServer } from "ws";
 import { createCounterfactualStore, validateCounterfactualReport } from "./optimizer/counterfactual.mjs";
 import { createOptimizerSummary } from "./optimizer/summary.mjs";
+import { createOptimizerSeries } from "./optimizer/series.mjs";
 import { createActivityLog } from "./optimizer/activityLog.mjs";
 import { createPacingState } from "./optimizer/pacing.mjs";
 import {
@@ -1096,6 +1097,16 @@ const optimizerSummary = createOptimizerSummary({
   meteredEndpoints: readMeteredEndpoints,
 });
 
+// BET-1369: the windowed `optimizer:series` read model, created ONCE at module
+// scope (like optimizerSummary) so the card's per-range selector shares one
+// 60s memo per range. DIFFERENT read from optimizerSummary on purpose: a 24h
+// window must read one day of ledger rows and must not perturb the shared
+// 30-day `optimizer:summary` memo (four other consumers read that).
+const optimizerSeries = createOptimizerSeries({
+  getDb,
+  counterfactualStore: optimizerCounterfactual,
+});
+
 // ---------------------------------------------------------------------------
 // Optimizer P2.4 (BET-1346) — background compaction scheduler + constraint
 // pinning wiring.
@@ -1449,6 +1460,9 @@ rpcHandlers = buildHandlers({
   // above so the RPC channel and the GET /api/optimizer/policy route share one
   // 60s memo + in-flight guard (no second DB query).
   optimizerSummary,
+  // BET-1369: the single shared windowed `optimizer:series` read model, built
+  // above — per-range 60s memo, shared by the RPC channel (the card's selector).
+  optimizerSeries,
   // BET-1336: quota-window forecast-at-reset read sources for the
   // optimizer:summary `windows` slice — the live polled snapshots + the
   // persisted observation history.

--- a/src/server/modelLedger.mjs
+++ b/src/server/modelLedger.mjs
@@ -17,7 +17,7 @@
 
 import { getDb } from "./opencodeDb.mjs";
 import { aggregateReliability } from "../shared/toolReliability.mjs";
-import { dayKey, recentBucketKeys } from "../shared/timeBuckets.mjs";
+import { dayKey, hourKey, recentBucketKeys } from "../shared/timeBuckets.mjs";
 
 // Turns longer than this are excluded from TIMING only (still counted for
 // cost) — the spec cap is 600s of wall-clock.
@@ -223,16 +223,37 @@ export function aggregateBySession(rows) {
  * calendar day. `days` defaults to 30.
  */
 export function aggregateDailySeries(rows, days = 30, now = Date.now()) {
+  return aggregateSeriesByBucket(rows, "day", days, now).map(({ key, tokensSent }) => ({ day: key, tokensSent }));
+}
+
+/**
+ * PURE. Hourly `tokensSent` series over the last `hours` local-calendar hours
+ * ending at `now`, oldest→newest, ZERO-FILLED. Entry shape { hour, tokensSent }.
+ * Ledger rows already carry a per-message timestamp, so this works
+ * retroactively over all existing history — no migration, no schema change.
+ */
+export function aggregateHourlySeries(rows, hours = 24, now = Date.now()) {
+  return aggregateSeriesByBucket(rows, "hour", hours, now).map(({ key, tokensSent }) => ({ hour: key, tokensSent }));
+}
+
+// PURE core shared by the two named series above: buckets `rows` by local
+// calendar bucket (day/hour via the shared timeBuckets key builders), sums
+// `tokensSent` per bucket, and zero-fills the `count` most recent buckets
+// ending at `now`, oldest→newest. Returns [{ key, tokensSent }]; the two
+// exported wrappers differ only in the key NAME (`day` vs `hour`) and the
+// bucket size — one loop, not two.
+function aggregateSeriesByBucket(rows, bucket, count, now) {
   const list = Array.isArray(rows) ? rows : [];
-  const n = Math.max(1, Math.floor(num(days)) || 1);
-  const byDay = new Map();
+  const n = Math.max(1, Math.floor(num(count)) || 1);
+  const keyOf = bucket === "hour" ? hourKey : dayKey;
+  const byBucket = new Map();
   for (const r of list) {
-    const key = dayKey(r.startedMs);
-    byDay.set(key, (byDay.get(key) || 0) + tokensSent(r));
+    const key = keyOf(r.startedMs);
+    byBucket.set(key, (byBucket.get(key) || 0) + tokensSent(r));
   }
   const out = [];
-  for (const key of recentBucketKeys("day", n, now)) {
-    out.push({ day: key, tokensSent: byDay.get(key) || 0 });
+  for (const key of recentBucketKeys(bucket, n, now)) {
+    out.push({ key, tokensSent: byBucket.get(key) || 0 });
   }
   return out;
 }

--- a/src/server/modelLedger.test.mjs
+++ b/src/server/modelLedger.test.mjs
@@ -4,7 +4,7 @@
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { aggregate, aggregateEndpointStats, aggregateBySession, aggregateDailySeries, endpointSummary, fetchLedgerRows } from "./modelLedger.mjs";
+import { aggregate, aggregateEndpointStats, aggregateBySession, aggregateDailySeries, aggregateHourlySeries, endpointSummary, fetchLedgerRows } from "./modelLedger.mjs";
 import { _resetDbHandle } from "./opencodeDb.mjs";
 
 // Fixture builder. Fill only the fields a test cares about.
@@ -247,6 +247,68 @@ test("aggregateDailySeries tokensSent formula: input=1,cacheRead=2,cacheWrite=3,
   );
   assert.equal(out.length, 1);
   assert.equal(out[0].tokensSent, 10);
+});
+
+// ---- aggregateHourlySeries (BET-1369) ----
+
+test("aggregateHourlySeries zero-fills hours with no rows, oldest→newest", () => {
+  // now = a known local time; put one row on the current hour and one 2h prior.
+  const now = new Date(2026, 7, 24, 14, 30, 0).getTime(); // Aug 24 2026 14:30
+  const twoHoursAgo = new Date(2026, 7, 24, 12, 45, 0).getTime();
+  const out = aggregateHourlySeries(
+    [
+      srow({ startedMs: now, input: 1, cacheRead: 0, cacheWrite: 0, output: 9 }),
+      srow({ startedMs: twoHoursAgo, input: 5, cacheRead: 5, cacheWrite: 5, output: 5 }),
+    ],
+    24,
+    now,
+  );
+  assert.equal(out.length, 24);
+  assert.equal(out[0].hour, "2026-08-23T15"); // oldest bucket is 23h before now
+  assert.equal(out[0].tokensSent, 0); // no row in the oldest hour
+  assert.equal(out[2].hour, "2026-08-23T17");
+  assert.equal(out[2].tokensSent, 0); // no row
+  assert.equal(out[23].hour, "2026-08-24T14"); // newest = the current hour
+  assert.equal(out[23].tokensSent, 10); // 1+9
+  assert.equal(out[21].hour, "2026-08-24T12");
+  assert.equal(out[21].tokensSent, 20); // 5+5+5+5
+  // oldest→newest
+  for (let i = 0; i < out.length - 1; i++) assert.ok(out[i].hour < out[i + 1].hour);
+});
+
+test("aggregateHourlySeries default window is 24 hours", () => {
+  const now = new Date(2026, 0, 5, 9, 0, 0).getTime();
+  const out = aggregateHourlySeries([], 24, now);
+  assert.equal(out.length, 24);
+  assert.equal(out[0].hour, "2026-01-04T10");
+  assert.equal(out[23].hour, "2026-01-05T09");
+});
+
+test("aggregateHourlySeries bucket boundary: a row at a fractional minute lands in its own hour", () => {
+  const now = new Date(2026, 0, 5, 12, 0, 0).getTime();
+  const rowMs = new Date(2026, 0, 5, 10, 59, 0).getTime();
+  const out = aggregateHourlySeries([srow({ startedMs: rowMs, input: 3 })], 24, now);
+  // out[23] is the hour of `now` (12:00) → 11; the row at 10:59 belongs to the
+  // 10:00 hour, which is 2 buckets before 12:00 → out[21].
+  assert.equal(out[23].hour, "2026-01-05T12");
+  assert.equal(out[22].hour, "2026-01-05T11");
+  assert.equal(out[22].tokensSent, 0);
+  assert.equal(out[21].hour, "2026-01-05T10");
+  assert.equal(out[21].tokensSent, 3);
+});
+
+test("aggregateHourlySeries over a DST 'spring forward' day yields exactly 24 buckets", () => {
+  // 2026-03-08 12:00 local (US DST spring-forward, a 23-hour day).
+  // recentBucketKeys walks with setHours, so the 23-hour day neither duplicates
+  // nor skips a bucket — it yields exactly 24 strictly-increasing hour keys.
+  const now = new Date(2026, 2, 8, 12, 0, 0).getTime();
+  const out = aggregateHourlySeries([], 24, now);
+  assert.equal(out.length, 24);
+  // i=0 → the hour of `now`; i=23 → setHours(12-23=-11) wraps to 2026-03-07T13
+  // (23 real hours back across the 23-hour day).
+  assert.equal(out[0].hour, "2026-03-07T13");
+  assert.equal(out[23].hour, "2026-03-08T12");
+  for (let i = 0; i < out.length - 1; i++) assert.ok(out[i].hour < out[i + 1].hour);
 });
 
 // ---- aggregateEndpointStats (per-endpoint reliability/speed/latency/mix) ----

--- a/src/server/optimizer/series.mjs
+++ b/src/server/optimizer/series.mjs
@@ -1,0 +1,171 @@
+// optimizer/series.mjs — the `optimizer:series` windowed consumption read.
+//
+// BET-1369: the optimizer card's consumption chart was hardwired to 30 days
+// via a module constant in summary.mjs, and `optimizer:summary` (the single
+// 60s memo slot SHARED by four consumers besides the card) must NOT be
+// parameterised — its window must not change because somebody clicked a chip
+// in Settings. This module is a separate, NARROWER read: a per-range
+// (24h / 7d / 30d) windowed series of sent-vs-counterfactual tokens, fetched
+// over ONLY the requested window (a 24h view reads one day of rows, not thirty
+// and slice — a cold 30-day ledger read was measured in seconds).
+//
+// Split strictly into pure (`buildOptimizerSeries`) and I/O/memoized
+// (`createOptimizerSeries`), mirroring summary.mjs:
+//   • buildOptimizerSeries — all arithmetic. Pure; `fetchRows` and the
+//     counterfactual store are injected. Exported for tests.
+//   • createOptimizerSeries — resolves the DB via getDb(), memoizes per range
+//     behind a short TTL with an in-flight guard.
+//
+// Degradation mirrors summary.mjs: a null DB yields { supported:false } and
+// never throws; a query error logs once and yields { supported:false }; an
+// error is never cached. Read-only is a hard invariant.
+
+import { aggregate, aggregateDailySeries, aggregateHourlySeries, fetchLedgerRows } from "../modelLedger.mjs";
+import { bucketSeries } from "./counterfactual.mjs";
+import { bucketKeyToMs } from "../../shared/timeBuckets.mjs";
+
+// The supported ranges and their bucketing. Bucket keys zip the sent series
+// (from the ledger) with the counterfactual series (from the store) — both are
+// built from the shared recentBucketKeys, so they align on the same key.
+export const RANGES = Object.freeze({
+  "24h": { bucket: "hour", count: 24 },
+  "7d": { bucket: "day", count: 7 },
+  "30d": { bucket: "day", count: 30 },
+});
+
+const BUCKET_MS = Object.freeze({ hour: 3_600_000, day: 86_400_000 });
+const TTL_MS = 60_000;
+
+export { TTL_MS };
+
+function num(v) {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+
+// Unknown range → fall back to the default 24h. Never throws.
+function normalizeRange(range) {
+  return Object.prototype.hasOwnProperty.call(RANGES, range) ? range : "24h";
+}
+
+/**
+ * PURE. Build the windowed consumption series for a range.
+ *
+ * Reads history scoped to the range — `fetchRows(now - count * bucketMs)` — so
+ * a 24h view reads one day of ledger rows, NOT thirty and slice (the cold
+ * 30-day read was measured in seconds). The sent series comes from the ledger
+ * bucket aggregation; the counterfactual series from `bucketSeries` on the
+ * injected store (a null store yields zeros, never a throw). The two are zipped
+ * on the bucket KEY so they are always the same length and aligned, even when
+ * the two sources have different sparse keys.
+ */
+export async function buildOptimizerSeries({ range, fetchRows, counterfactualStore = null, now = Date.now() }) {
+  const r = normalizeRange(range);
+  const { bucket, count } = RANGES[r];
+  const nowMs = num(now);
+  const bucketMs = BUCKET_MS[bucket];
+
+  const raw = await fetchRows(nowMs - count * bucketMs);
+  const rows = Array.isArray(raw) ? raw : [];
+
+  // Sent series over the window, oldest→newest, per the range's bucket.
+  const sent =
+    bucket === "hour"
+      ? aggregateHourlySeries(rows, count, nowMs)
+      : aggregateDailySeries(rows, count, nowMs);
+
+  // Counterfactual over the same bucket keys. A null store → zeros (a series
+  // of zero maskedTokens), never a throw.
+  const cf = counterfactualStore
+    ? await bucketSeries(counterfactualStore, { bucket, count, now: nowMs })
+    : [];
+  const cfByKey = new Map((Array.isArray(cf) ? cf : []).map((e) => [e.key, num(e.maskedTokens)]));
+
+  // Zip on the bucket key so both series are the same length and aligned.
+  const series = sent.map((e) => {
+    const key = bucket === "hour" ? e.hour : e.day;
+    return {
+      t: bucketKeyToMs(key),
+      tokensSent: num(e.tokensSent),
+      maskedTokens: cfByKey.get(key) ?? 0,
+    };
+  });
+
+  const tokensSent = series.reduce((s, p) => s + p.tokensSent, 0);
+  const maskedTokens = series.reduce((s, p) => s + p.maskedTokens, 0);
+
+  // turns/cost reuse the existing aggregate over exactly the window's rows.
+  const { totals } = aggregate(rows);
+
+  return {
+    supported: true,
+    range: r,
+    bucket,
+    startMs: series.length ? series[0].t : nowMs,
+    endMs: series.length ? series[series.length - 1].t : nowMs,
+    series,
+    counterfactualAvailable: series.some((p) => p.maskedTokens > 0),
+    totals: {
+      turns: totals.turns,
+      cost: totals.cost,
+      tokensSent,
+      maskedTokens,
+    },
+  };
+}
+
+// Memo slots per range — a Map<range, {at, value}> plus a Map<range, promise>
+// in-flight guard, so a 7d call never returns a cached 24h value and concurrent
+// calls for the same range share one build instead of stampeding the DB.
+const memo = new Map();
+const inFlight = new Map();
+
+// Clears the memo + in-flight slots. Test-only: not part of the runtime API.
+export function _resetSeriesMemo() {
+  memo.clear();
+  inFlight.clear();
+}
+
+/**
+ * I/O. Wrapper factory. `getDb` resolves the read-only opencode.db handle
+ * (null → { supported:false }); `counterfactualStore` is the observe-mode store
+ * from counterfactual.mjs (null when not wired); `now` (a number or a zero-arg
+ * fn, for tests) is the clock. The returned async function takes a range and
+ * memoizes the built series per range for TTL_MS with an in-flight guard.
+ */
+export function createOptimizerSeries({ getDb, counterfactualStore = null, now }) {
+  const nowMs = () => (typeof now === "function" ? num(now()) : num(now ?? Date.now()));
+  return function optimizerSeries(range) {
+    const r = normalizeRange(range);
+    const t = nowMs();
+    const hit = memo.get(r);
+    if (hit && t - hit.at < TTL_MS) return Promise.resolve(hit.value);
+
+    const pending = inFlight.get(r);
+    if (pending) return pending;
+
+    const p = (async () => {
+      const db = await getDb();
+      if (!db) return { supported: false };
+      try {
+        const value = await buildOptimizerSeries({
+          range: r,
+          fetchRows: (since) => fetchLedgerRows(db, since),
+          counterfactualStore,
+          now: t,
+        });
+        memo.set(r, { at: t, value });
+        return value;
+      } catch (e) {
+        // Query error: log once, degrade to { supported:false } — never an
+        // exception, and never a cached error (the NEXT call retries).
+        console.error("[optimizer] series build failed:", e?.message ?? e);
+        return { supported: false };
+      } finally {
+        // Only clear OUR slot — a stale build must never clear a newer one.
+        if (inFlight.get(r) === p) inFlight.delete(r);
+      }
+    })();
+    inFlight.set(r, p);
+    return p;
+  };
+}

--- a/src/server/optimizer/series.test.mjs
+++ b/src/server/optimizer/series.test.mjs
@@ -1,0 +1,229 @@
+// optimizer/series.test.mjs — the windowed consumption series read (BET-1369).
+import test from "node:test";
+import assert from "node:assert/strict";
+import {
+  buildOptimizerSeries,
+  createOptimizerSeries,
+  RANGES,
+  _resetSeriesMemo,
+} from "./series.mjs";
+
+// Ledger row fixture — the fields `aggregate` / the series bucket agg read.
+function row(over = {}) {
+  return {
+    providerID: "anthropic",
+    modelID: "claude-sonnet-4-6",
+    agent: "build",
+    parentId: null,
+    directory: "/work/proj",
+    cost: 0,
+    input: 0,
+    output: 0,
+    reasoning: 0,
+    cacheRead: 0,
+    cacheWrite: 0,
+    startedMs: 0,
+    completedMs: 0,
+    ...over,
+  };
+}
+
+// A counterfactual store whose snapshot has a couple of masked days/hours.
+function fakeStore(snapshot) {
+  return { snapshot: async () => snapshot };
+}
+
+test("buildOptimizerSeries: unknown range falls back to 24h / hour bucket", async () => {
+  let since = null;
+  const out = await buildOptimizerSeries({
+    range: "bogus",
+    fetchRows: async (s) => {
+      since = s;
+      return [];
+    },
+    now: new Date(2026, 7, 24, 12, 0, 0).getTime(),
+    counterfactualStore: null,
+  });
+  assert.equal(out.supported, true);
+  assert.equal(out.range, "24h");
+  assert.equal(out.bucket, "hour");
+  assert.equal(out.series.length, 24);
+  // The window reads only the last 24 hours of rows, not 30 days and slice.
+  assert.equal(since, new Date(2026, 7, 23, 12, 0, 0).getTime());
+});
+
+test("buildOptimizerSeries: 30d maps to a 30-point day-bucket series", async () => {
+  const out = await buildOptimizerSeries({
+    range: "30d",
+    fetchRows: async () => [],
+    now: new Date(2026, 7, 24, 12, 0, 0).getTime(),
+    counterfactualStore: null,
+  });
+  assert.equal(out.bucket, "day");
+  assert.equal(out.series.length, 30);
+  assert.equal(out.range, "30d");
+});
+
+test("buildOptimizerSeries: sent series sums each day's tokensSent", async () => {
+  const twoDaysAgo = new Date(2026, 7, 24, 12, 0, 0).getTime() - 2 * 86_400_000;
+  const out = await buildOptimizerSeries({
+    range: "7d",
+    fetchRows: async () => [
+      row({ startedMs: twoDaysAgo, input: 5, cacheRead: 5, cacheWrite: 5, output: 5 }),
+    ],
+    now: new Date(2026, 7, 24, 12, 0, 0).getTime(),
+    counterfactualStore: null,
+  });
+  const matching = out.series.find((p) => p.tokensSent === 20);
+  assert.ok(matching, "the day with the 20-token row is present and summed");
+  // Every other bucket is zero-filled.
+  assert.equal(out.series.reduce((s, p) => s + p.tokensSent, 0), 20);
+});
+
+test("buildOptimizerSeries: zips counterfactual onto the sent series by bucket key", async () => {
+  // dayKey / recentBucketKeys are LOCAL-calendar, so build the store's keys the
+  // same way (a local-date formatter, not toISOString which is UTC).
+  const localDay = (d) =>
+    `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+  const nowMs = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const todayLoc = new Date(2026, 7, 24, 0, 0, 0);
+  const yesterdayLoc = new Date(2026, 7, 23, 0, 0, 0);
+  const store = fakeStore({
+    days: {
+      [localDay(yesterdayLoc)]: { maskedTokens: 400 },
+      // `today` has NO key — a sparse store must not throw, and its bucket
+      // must zip to maskedTokens 0, not shift alignment.
+    },
+  });
+  const out = await buildOptimizerSeries({
+    range: "7d",
+    fetchRows: async () => [row({ startedMs: nowMs, input: 1, output: 9 })],
+    now: nowMs,
+    counterfactualStore: store,
+  });
+  // Same length for both lines (counterfactual is never a different length).
+  assert.equal(out.series.length, 7);
+  const sentTot = out.series.reduce((s, p) => s + p.tokensSent, 0);
+  const maskedTot = out.series.reduce((s, p) => s + p.maskedTokens, 0);
+  assert.equal(sentTot, 10);
+  assert.equal(maskedTot, 400, "only yesterday's masked tokens are counted");
+  assert.equal(out.counterfactualAvailable, true);
+  // The `today` bucket (start of today) zipped with no key → maskedTokens 0.
+  const todayBucket = out.series.find((p) => p.t === todayLoc.getTime());
+  assert.ok(todayBucket, "today's bucket is present");
+  assert.equal(todayBucket.maskedTokens, 0);
+});
+
+test("buildOptimizerSeries: a NULL counterfactual store yields zeros, never a throw", async () => {
+  const out = await buildOptimizerSeries({
+    range: "24h",
+    fetchRows: async () => [],
+    now: new Date(2026, 7, 24, 12, 0, 0).getTime(),
+    counterfactualStore: null,
+  });
+  assert.equal(out.series.reduce((s, p) => s + p.maskedTokens, 0), 0);
+  assert.equal(out.counterfactualAvailable, false);
+});
+
+test("buildOptimizerSeries: totals fold turns/cost from the window's rows", async () => {
+  const nowMs = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const out = await buildOptimizerSeries({
+    range: "24h",
+    fetchRows: async () => [
+      row({ startedMs: nowMs, input: 1, output: 9, cost: 1.0 }),
+      row({ startedMs: nowMs - 3_600_000, input: 2, output: 8, cost: 2.0 }),
+    ],
+    now: nowMs,
+    counterfactualStore: null,
+  });
+  assert.equal(out.totals.turns, 2);
+  assert.equal(out.totals.cost, 3.0);
+  assert.equal(out.totals.tokensSent, 20);
+  assert.equal(out.totals.maskedTokens, 0);
+});
+
+// ---- createOptimizerSeries (memo + in-flight + degradation) ----
+
+test("createOptimizerSeries returns { supported:false } when getDb resolves null", async () => {
+  _resetSeriesMemo();
+  const s = createOptimizerSeries({ getDb: async () => null, now: () => 1_000_000 });
+  assert.deepEqual(await s("24h"), { supported: false });
+});
+
+test("createOptimizerSeries memoizes PER RANGE: a 7d call is a separate slot, not a 24h hit", async () => {
+  _resetSeriesMemo();
+  let prepares = 0;
+  const stubDb = {
+    prepare() {
+      prepares += 1;
+      return { all: () => [] };
+    },
+    close() {},
+  };
+  const getDb = async () => stubDb;
+  const s = createOptimizerSeries({ getDb, now: () => 1_000_000 });
+
+  const a1 = await s("24h");
+  const a2 = await s("24h"); // memo hit
+  assert.equal(a1, a2);
+  assert.equal(prepares, 1, "repeated 24h within TTL hits the same memo slot");
+
+  const b1 = await s("7d"); // different range → different query
+  assert.notEqual(b1, a1);
+  assert.equal(prepares, 2, "7d is a SEPARATE memo slot, not a 24h cache hit");
+});
+
+test("createOptimizerSeries in-flight guard shares one build across concurrent calls", async () => {
+  _resetSeriesMemo();
+  let resolves = 0;
+  let release;
+  const gate = new Promise((r) => (release = r));
+  const stubDb = {
+    prepare() {
+      resolves += 1;
+      return { all: () => [] };
+    },
+    close() {},
+  };
+  const getDb = async () => {
+    await gate;
+    return stubDb;
+  };
+  const s = createOptimizerSeries({ getDb, now: () => 5_000_000 });
+
+  const p1 = s("24h");
+  const p2 = s("24h");
+  release();
+  const [r1, r2] = await Promise.all([p1, p2]);
+  assert.equal(r1, r2);
+  assert.equal(resolves, 1, "concurrent calls for the same range share a single build");
+});
+
+test("_resetSeriesMemo clears both slots so the next build re-queries", async () => {
+  _resetSeriesMemo();
+  let prepares = 0;
+  const stubDb = {
+    prepare() {
+      prepares += 1;
+      return { all: () => [] };
+    },
+    close() {},
+  };
+  const getDb = async () => stubDb;
+  const s = createOptimizerSeries({ getDb, now: () => 1_000_000 });
+
+  await s("24h");
+  await s("24h"); // memo hit
+  assert.equal(prepares, 1);
+  _resetSeriesMemo();
+  await s("24h");
+  assert.equal(prepares, 2, "after _resetSeriesMemo the next call re-queries");
+});
+
+test("RANGES exposes exactly the three documented windows", () => {
+  assert.deepEqual(Object.keys(RANGES).sort(), ["24h", "30d", "7d"]);
+  assert.equal(RANGES["24h"].bucket, "hour");
+  assert.equal(RANGES["7d"].bucket, "day");
+  assert.equal(RANGES["30d"].bucket, "day");
+});

--- a/src/server/rpc.mjs
+++ b/src/server/rpc.mjs
@@ -53,6 +53,7 @@ import { searchMessages } from "./messageSearch.mjs";
 import { ledgerSummary } from "./modelLedger.mjs";
 import { getDb } from "./opencodeDb.mjs";
 import { createOptimizerSummary } from "./optimizer/summary.mjs";
+import { createOptimizerSeries } from "./optimizer/series.mjs";
 import { shipCtxEvent } from "./optimizer/telemetry.mjs";
 import { allModels as catalogAllModels } from "./modelCatalog.mjs";
 import { MIN_CLIENT } from "./version.mjs";
@@ -377,6 +378,9 @@ export function buildHandlers({
   // BET-1343: the shared memoized `optimizer:summary` read model, hoisted to
   // index.mjs. Null when not injected → this builds its own (tests / fallback).
   optimizerSummary = null,
+  // BET-1369: the shared windowed `optimizer:series` read model, hoisted to
+  // index.mjs. Null when not injected → this builds its own (tests / fallback).
+  optimizerSeries = null,
 }) {
   // The sole resolver for project cwd — no longer mirrored to a desktop-main
   // copy (the src/main/index.ts duplicate was retired in the HTTP-only
@@ -440,6 +444,15 @@ export function buildHandlers({
     usageSnapshots,
     usageHistory,
     readCacheTtl: () => providers.readCacheTtl({ listProviders: oc.getProviders }),
+  });
+
+  // BET-1369: the windowed `optimizer:series` read model. Like optimizerSummary,
+  // the production instance is hoisted to index.mjs; when not injected (tests /
+  // other buildHandlers callers) this constructs the same instance here. Each
+  // range has its OWN 60s memo — a 7d call never returns a cached 24h value.
+  const optimizerSeriesFn = optimizerSeries ?? createOptimizerSeries({
+    getDb,
+    counterfactualStore,
   });
 
   return {
@@ -1377,6 +1390,13 @@ export function buildHandlers({
     // 60s TTL with an in-flight guard. Degrades to { supported:false } on a
     // box that hasn't taken the Node 24 runtime yet / has no opencode.db.
     "optimizer:summary": () => optimizerSummaryFn(),
+
+    // BET-1369: the windowed consumption read (optimizer/series.mjs). One
+    // argument: the OPTIONAL range ("24h" | "7d" | "30d"; unknown → 24h). The
+    // window is per-call and does NOT touch the optimizer:summary memo.
+    // Memoized per range behind a 60s TTL. Degrades to { supported:false } on
+    // a box without the Node 24 runtime / opencode.db.
+    "optimizer:series": (opts) => optimizerSeriesFn(opts?.range),
 
     // preload: ipcRenderer.invoke(IPC.opencodeRunCommand, { sessionId, command, arguments, model?, attachments? })
     // → args[0] = that object; opencode.mjs runCommand expects same shape

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -86,6 +86,8 @@ import type {
   TranscriptHit,
   LedgerSummary,
   OptimizerSummary,
+  OptimizerRange,
+  OptimizerSeries,
   AppControlPayload,
   MediaEventPayload,
   WidgetEventPayload,
@@ -757,6 +759,11 @@ export interface Api {
   // (`optimizer:summary` RPC). No arguments. `supported:false` = the box can't
   // read opencode.db (needs the Node 24 runtime).
   optimizerSummary(): Promise<OptimizerSummary | { supported: false }>;
+  // BET-1369: the Optimizer's WINDOWED consumption read (`optimizer:series`
+  // RPC). The window is PER-CALL (24h/7d/30d); `optimizer:summary` remains the
+  // fixed-30-day shared read whose memo must not be perturbed by the card's
+  // selector. `supported:false` = the box can't read opencode.db.
+  optimizerSeries(range: OptimizerRange): Promise<OptimizerSeries | { supported: false }>;
 
   // Slash-command execution.
   opencodeRunCommand(input: {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1477,6 +1477,10 @@ export const IPC = {
   // BET-1333: the Optimizer's memoized read model over the ledger. Returns
   // { supported, ...OptimizerSummary }.
   optimizerSummary: "optimizer:summary",
+  // BET-1369: the Optimizer's WINDOWED consumption read. The window is
+  // PER-CALL (24h/7d/30d) — `optimizer:summary` remains the fixed-30-day
+  // shared read whose memo must not be perturbed by the card's selector.
+  optimizerSeries: "optimizer:series",
   // Slash-command execution: invokes POST /session/{id}/command. Distinct
   // from opencode:prompt — the server treats commands specially (templates,
   // configured agent/model, etc.).
@@ -1951,6 +1955,29 @@ export type OptimizerSummary = {
     role: string;
     price: string;
   }[];
+};
+
+// BET-1369: the window selector on the optimizer card. The window is PER-CALL:
+// `optimizer:series` reads only the requested span — it does NOT parameterise
+// `optimizer:summary` (whose single 60s memo is shared by four consumers
+// besides this card).
+export type OptimizerRange = "24h" | "7d" | "30d";
+
+// BET-1369: the windowed consumption series (`optimizer:series` RPC), matched
+// to optimizer/series.mjs's buildOptimizerSeries return. `series` is zipped on
+// bucket key so the sent/counterfactual lines are always the same length;
+// `t` is the epoch-ms START of each bucket (the renderer never re-parses a
+// date string). `counterfactualAvailable` is true when any bucket has
+// maskedTokens > 0. `supported:false` = the box can't read opencode.db.
+export type OptimizerSeries = {
+  supported: boolean;
+  range: OptimizerRange;
+  bucket: "hour" | "day";
+  startMs: number;
+  endMs: number;
+  series: { t: number; tokensSent: number; maskedTokens: number }[];
+  counterfactualAvailable: boolean;
+  totals: { turns: number; cost: number; tokensSent: number; maskedTokens: number };
 };
 
 // A secret's METADATA — what the UI and `secret_list` see. NEVER carries the

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-22T17:17:23.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-22T16:04:35.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
+    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T17:17:23.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:04:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
Adds a 24h/7d/30d range selector to the optimizer consumption chart, backed by a new **windowed** `optimizer:series` read — `optimizer:summary`'s fixed-30-day shared memo (four consumers) is intentionally untouched.

## What changed

- **Fix 1** (`modelLedger.mjs`): `aggregateHourlySeries` — shared 24h/7d day+hour core `aggregateSeriesByBucket`, with `aggregateDailySeries`/`aggregateHourlySeries` as wrappers (one loop, not two).
- **Fix 2** (`optimizer/series.mjs`, NEW): `RANGES` (`24h`→hour, `7d`/`30d`→day), pure `buildOptimizerSeries` (scoped `fetchRows(since)`, sent from the ledger buckets, counterfactual from `bucketSeries`, zipped on bucket key, `considered` totals, `counterfactualAvailable`, **no** `saved` placeholder field per the hygiene rule), and `createOptimizerSeries` with a **per-range** `Map<range,{at,value}>` + `Map<range,promise>` in-flight guard, 60s TTL, and `_resetSeriesMemo()` — degradation contract copied from `summary.mjs` (null DB → `{supported:false}`, error logged once and never cached).
- **Fix 3** — all six wiring sites: IPC map + `OptimizerRange`/`OptimizerSeries` types (`types.ts`), api method + comment (`api.ts`), `httpApi.ts`, `rpc.mjs` (injected `optimizerSeries` param, defaulting to a locally-constructed instance, channel `"optimizer:series": (opts) => optimizerSeriesFn(opts?.range)`), `index.mjs` (shared instance + buildHandlers).
- **Fix 4** (`OptimizerCard.tsx`): `ChipGroup` replaces the `last 30 days` span (default `24h`); `useEffect` on `[range]` with alive guard; previous chart kept at `opacity-60` during a fetch; `{supported:false}`/reject degrades the chart block only; the card's `dailySeries` fold is fully removed; axis ticks from `chartAxisTicks(series.map(p=>p.t), bucket)`; muted no-counterfactual line per range (`Hourly comparison starts collecting today.` for 24h, `No trimming recorded in this window.` for 7d/30d).
- **Fix 5** (stats row): Sent/Cost-per-turn range-scoped (`Sent (24h)` / `24h average`); Cache-hit + Sessions kept summary-scoped and explicitly labeled `· 30d` / `30d` (added to the compaction branch too); Saved stays the flat estimate over `series.totals.maskedTokens`; label suffix from a single `RANGE_LABEL` lookup. `Saved` computation itself unchanged.

`d.dailySeries` is no longer read by the card; the field stays on `OptimizerSummary` for its other consumers.

> Note: `src/renderer/api/demoCoverage.test.ts` is touched (one line) to register `optimizerSeries` in the demo-transport unimplemented inventory — a required consequence of adding an Api method (the inventory test fails otherwise). Not part of the issue's scope list but necessary for the suite to pass.

**Base: origin/main @ `8c0a7966`**

## Verification results
- PR branch (`multica/BET-1369-range-selector` @ `5fd18f2a`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0. vitest 196/196 files, 3745 pass / 7 skip; node:test 2924 pass / 0 fail. Failures: none. log sha256: `a2bc9ef15661e7efbfab5d273cb6e650a4a0106a6941b4d9e63b7c02a5fdd2da`
- Base (`main` @ `8c0a7966`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0. pass. log sha256: `46c8991a2c820bcf09f392a912394625e8a75344f271082d012268e1d9b8684a`
- **Conclusion:** 0 new failures; identical between branches (typecheck sha matches exactly). New tests added for the hourly bucket agg, the series read (incl. per-range memo + error-not-cached + scoped `since`), and the range selector UI.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
