### PR TITLE
feat(server): stamp @manta-owner on tmux windows (BET-1377)

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -346,6 +346,7 @@ async function registerJob(
     save = saveJobs,
     publish,
     newWindow,
+    stampOwner,
     listProjects,
     gitRemoveWorktree,
     oc,
@@ -387,6 +388,21 @@ async function registerJob(
       }
     }
     return { ok: false, error: String(e?.message ?? e) };
+  }
+
+  // BET-1377: stamp the window's owner as "job" now that it exists, so the
+  // CTO digest (and any other consumer of listProjects) can tell a delegate
+  // job's window apart from a user's window. Mirror of the @manta-session-id
+  // stamp — a separate option (@manta-owner) so the two never collide. This
+  // is advisory metadata: a stamp failure must not fail the job start (absent
+  // option ⇒ "user"), so it is best-effort and never rolled back.
+  if (stampOwner) {
+    try {
+      await stampOwner(tmuxSession, windowIndex, "job");
+    } catch {
+      /* best-effort; the window already exists and the job record below is
+         the source of truth for the job's own lifecycle */
+    }
   }
 
   // Persist the record with status "running", startedAt = now.

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -494,6 +494,43 @@ test("startJob leaves the link null when none is provided", async () => {
   assert.equal(job.link, null);
 });
 
+// BET-1377: @manta-owner. startJob stamps the created window's owner as "job"
+// (absent ⇒ "user"), so listProjects can tell a delegate job's window from a
+// user's window for the CTO digest. Best-effort — a stamp failure must not
+// fail the job start.
+test("startJob stamps the new window's owner as job (BET-1377)", async () => {
+  const h = harness([]);
+  h.deps.gitAddWorktree = async () => { throw new Error("not a git repository"); };
+  const parentWin = { index: 1, name: "p", opencodeSessionId: "parent", paneCurrentPath: "/repo" };
+  h.deps.listProjects = async () => [{ tmuxSession: "s", windows: [parentWin] }];
+  h.deps.newWindow = async () => ({ sessionId: "child_owner", windowIndex: 4 });
+  const stamps = [];
+  h.deps.stampOwner = async (sessionName, windowIndex, owner) => {
+    stamps.push({ sessionName, windowIndex, owner });
+  };
+  const res = await startJob(
+    { prompt: "delegate work", parentSessionID: "parent", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.deepEqual(stamps, [{ sessionName: "s", windowIndex: 4, owner: "job" }]);
+});
+
+test("startJob still succeeds when the owner stamp fails (best-effort)", async () => {
+  const h = harness([]);
+  h.deps.gitAddWorktree = async () => { throw new Error("not a git repository"); };
+  const parentWin = { index: 1, name: "p", opencodeSessionId: "parent", paneCurrentPath: "/repo" };
+  h.deps.listProjects = async () => [{ tmuxSession: "s", windows: [parentWin] }];
+  h.deps.newWindow = async () => ({ sessionId: "child_owner_fail", windowIndex: 2 });
+  h.deps.stampOwner = async () => { throw new Error("tmux exploded"); };
+  const res = await startJob(
+    { prompt: "delegate work", parentSessionID: "parent", parentDirectory: "/repo" },
+    h.deps,
+  );
+  assert.equal(res.ok, true);
+  assert.ok(h.jobs.some((j) => j.childSessionID === "child_owner_fail"), "job persisted");
+});
+
 // ----------------------------------------------------------------------------
 // BET-947 — startJob model threading (structured, free text, no-match, none)
 // ----------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -638,6 +638,9 @@ const delegateEngine = createDelegateEngine({
   listProjects: () => tmux.listProjects(),
   newWindow: (input) => tmux.newWindow(input),
   killWindow: (input) => tmux.killWindow(input),
+  // BET-1377: stamp the job's window owner as "job" (see tmux.stampOwner).
+  stampOwner: (sessionName, windowIndex, owner) =>
+    tmux.stampOwner(sessionName, windowIndex, owner),
   gitAddWorktree: (input) => local.gitAddWorktree(input),
   gitRemoveWorktree: (input) => local.gitRemoveWorktree(input),
   gitRun: (args) => tmux.run("git", args),

--- a/src/server/tmux.mjs
+++ b/src/server/tmux.mjs
@@ -272,7 +272,7 @@ export function parseSessions(sessStdout, winStdout, owned = new Set()) {
   // Phase 2: join windows into their session. Skip orphan window lines.
   for (const line of winStdout.split("\n").filter(Boolean)) {
     const parts = line.split(FS);
-    const [session, index, wname, active, pane, sidRaw, wtRaw] = parts;
+    const [session, index, wname, active, pane, sidRaw, wtRaw, ownerRaw] = parts;
     if (!sessions.has(session)) continue; // defensive: orphan
     sessions.get(session).windows.push({
       index: Number(index), name: wname,
@@ -282,12 +282,26 @@ export function parseSessions(sessStdout, winStdout, owned = new Set()) {
       // absolute path is stamped on `@manta-worktree-path`. Empty/null = not
       // a worktree window — clean-on-close must skip it.
       worktreePath: wtRaw ? wtRaw : null,
+      // @manta-owner — who owns this window: "user", "cto" or "job". Absent
+      // (nothing stamped it) or unrecognized ⇒ "user"; never backfilled. Only
+      // delegate.mjs stamps "job" today; nothing stamps "cto" yet.
+      owner: resolveOwner(ownerRaw),
     });
   }
   return Array.from(sessions.values()).map((s) => ({
     ...s,
     defaultCwd: s.windows[0]?.paneCurrentPath ?? "~",
   }));
+}
+
+// Resolve a window's `@manta-owner` stamp to a canonical owner value. The
+// option is absent until something explicitly stamps it (delegate.mjs stamps
+// "job"; nothing stamps "cto" yet), so empty / unrecognized values fall back
+// to "user" rather than erroring or backfilling the option. Pure + exported
+// for tests.
+export function resolveOwner(raw) {
+  const v = typeof raw === "string" ? raw.trim() : "";
+  return v === "cto" || v === "job" ? v : "user";
 }
 
 // True iff a tmux invocation failed because there is genuinely no tmux server
@@ -331,7 +345,7 @@ async function tmuxListOutput(args) {
 
 export async function listProjects(installHome = INSTALL_HOME) {
   const sessFmt = `#{session_name}${FS}#{?session_attached,1,0}`;
-  const winFmt = `#{session_name}${FS}#{window_index}${FS}#{window_name}${FS}#{?window_active,1,0}${FS}#{pane_current_path}${FS}#{@manta-session-id}${FS}#{@manta-worktree-path}`;
+  const winFmt = `#{session_name}${FS}#{window_index}${FS}#{window_name}${FS}#{?window_active,1,0}${FS}#{pane_current_path}${FS}#{@manta-session-id}${FS}#{@manta-worktree-path}${FS}#{@manta-owner}`;
   const sess = { stdout: await tmuxListOutput(["list-sessions", "-F", sessFmt]) };
   const wins = { stdout: await tmuxListOutput(["list-windows", "-a", "-F", winFmt]) };
   // BET-348: build the owned set from the cache (hydrated on first call),
@@ -642,6 +656,22 @@ export async function restampSessionId(sessionName, windowIndex, sessionId) {
  */
 export async function stampWorktreePath(sessionName, windowIndex, path) {
   await setWindowOption(sessionName, windowIndex, "@manta-worktree-path", path);
+}
+
+/**
+ * Stamp (or update) the @manta-owner user-option on a tmux window — which
+ * actor owns the window: "user", "cto" or "job". Mirrors the
+ * restampSessionId pattern with its own option name so the stamps never
+ * collide. Absent option ⇒ "user" (see resolveOwner); nothing backfills it.
+ * delegate.mjs stamps "job" on the windows it creates; nothing stamps "cto"
+ * yet, so "cto" is reserved for future use.
+ *
+ * @param {string} sessionName
+ * @param {number} windowIndex
+ * @param {"user"|"cto"|"job"} owner
+ */
+export async function stampOwner(sessionName, windowIndex, owner) {
+  await setWindowOption(sessionName, windowIndex, "@manta-owner", owner);
 }
 
 /**

--- a/src/server/tmux.test.mjs
+++ b/src/server/tmux.test.mjs
@@ -22,6 +22,8 @@ import {
   listProjects,
   setWindowOption,
   getWindowOption,
+  stampOwner,
+  resolveOwner,
   findWindowForCwd,
   killSession,
   renameSession,
@@ -710,6 +712,34 @@ test("parseSessions stamps mantaOwned from the provided owned set", () => {
   assert.equal(byName.gamma, true, "gamma is owned");
 });
 
+// BET-1377: @manta-owner — absent ⇒ "user", never backfilled; resolved owner
+test("parseSessions resolves @manta-owner with a user default", () => {
+  const sess = "Capo\t1";
+  // 8 columns now: session, index, name, active, pane, @manta-session-id,
+  // @manta-worktree-path, @manta-owner
+  const wins =
+    "Capo\t1\tmain\t0\t/home/dev/projects/capo\t\t\t\n" +      // absent owner -> user
+    "Capo\t2\tjob\t0\t/home/dev/projects/capo\tses_job\t\tjob\n" + // delegate job
+    "Capo\t3\tcto\t0\t/home/dev/projects/capo\tses_cto\t\tcto\n" + // reserved cto
+    "Capo\t4\tweird\t0\t/home/dev/projects/capo\t\t\tgarbage";     // unrecognized -> user
+  const out = parseSessions(sess, wins);
+  const cap = out.find((p) => p.tmuxSession === "Capo");
+  assert.equal(cap.windows.find((w) => w.index === 1).owner, "user");
+  assert.equal(cap.windows.find((w) => w.index === 2).owner, "job");
+  assert.equal(cap.windows.find((w) => w.index === 3).owner, "cto");
+  assert.equal(cap.windows.find((w) => w.index === 4).owner, "user");
+});
+
+test("resolveOwner defaults to user for absent, empty and unrecognized values", () => {
+  assert.equal(resolveOwner(undefined), "user");
+  assert.equal(resolveOwner(""), "user");
+  assert.equal(resolveOwner("  "), "user");
+  assert.equal(resolveOwner("User"), "user"); // case-sensitive
+  assert.equal(resolveOwner("user"), "user");
+  assert.equal(resolveOwner("job"), "job");
+  assert.equal(resolveOwner("cto"), "cto");
+});
+
 test("parseSessions defaults mantaOwned to false when no owned set is passed", () => {
   // Existing callers + tests that pass 2 args must keep working — and
   // the new field must default to false so the renderer treats unknown
@@ -916,6 +946,24 @@ test("setWindowOption issues the single set-window-option command", async () => 
   assert.ok(cmd, "set-window-option issued");
   assert.deepEqual(cmd.args, [
     "set-window-option", "-t", "proj:2", "@manta-forge-issue", "github.com/acme/widget#412",
+  ]);
+});
+
+test("stampOwner issues the single set-window-option command for @manta-owner", async () => {
+  const cmds = [];
+  _setRun(async (cmd, args) => {
+    cmds.push({ cmd, args });
+    return { stdout: "", stderr: "" };
+  });
+  try {
+    await stampOwner("proj", 3, "job");
+  } finally {
+    _setRun(null);
+  }
+  const cmd = cmds.find((c) => c.args.includes("set-window-option"));
+  assert.ok(cmd, "set-window-option issued");
+  assert.deepEqual(cmd.args, [
+    "set-window-option", "-t", "proj:3", "@manta-owner", "job",
   ]);
 });
 


### PR DESCRIPTION
## BET-1377 — `@manta-owner`: session owner tagging on tmux windows

New `@manta-owner` tmux user-option tagging who owns each window:
`user | cto | job`. This is the first slice of the absence-aware CTO digest —
the digest needs to tell a delegate job's window apart from a user's window.

**Files changed:** 5. `src/server/tmux.mjs`, `src/server/delegate.mjs`,
`src/server/index.mjs`, `src/server/tmux.test.mjs`,
`src/server/delegate.test.mjs`.

### What lands
- `tmux.stampOwner(sessionName, windowIndex, owner)` — a
  `restampSessionId`-style set-window-option helper writing `@manta-owner`,
  through the existing single `setWindowOption` write path (no second
  wrapper added).
- `resolveOwner(raw)` — mirrors the `@manta-session-id` read mechanics:
  absent / empty / unrecognized ⇒ `"user"`, never backfilled. `"cto"` and
  `"job"` pass through verbatim.
- `listProjects()` window objects gain `owner` (`"user" | "cto" | "job"`),
  resolved from `@manta-owner` with the `"user"` default — read via the
  `winFmt` column, joined in `parseSessions`.
- `delegate.mjs` `registerJob` stamps `owner: "job"` on the window at the
  point the job's window is created — the same creation point `@manta-session-id`
  is stamped. Best-effort (a stamp failure must not fail the job start;
  absent ⇒ `"user"`), wired through `index.mjs` as a `stampOwner` dep
  mirroring `newWindow`.
- Nothing stamps `"cto"` yet — `"cto"` is reserved for the future CTO
  session.

### Anti-spaghetti
- Reused the existing canonical `setWindowOption` write path rather than a
  new wrapper.
- `stampOwner` mirrors `restampSessionId`/`stampWorktreePath` exactly
  (separate option name so stamps can't collide) — same shape, no
  duplication.
- Backfill was deliberately NOT done: the issue says absent ⇒ `"user"` and
  "do NOT backfill". `resolveOwner` treats absence as `"user"` at read time
  but never writes the option.

**Follow-ups:** none — this is the full, self-contained slice specified by
the issue. The `cto` stamp and client (mobile/renderer) consumption of
`owner` are explicitly out of scope until the CTO session exists.

**Base:** `origin/main` @ `78de7453`

### Verification results
- **PR branch** (`multica/BET-1377-owner-tag` @ `HEAD`):
  - typecheck: exit 0, errors none. log sha256 `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2929 pass / 0 fail / 0 skip. log sha256 `2164b4589dc212ef852497468e50ee7d7c198304a09cf803a2038c12f2e36626`
- **Base** (`main` @ `78de7453`):
  - typecheck: exit 0, errors none. log sha256 `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2924 pass / 0 fail / 0 skip. log sha256 `e7ec99080fea612e78775e7e8a9f9baabd3b402a82d131a52d859b5d2814103c`
- **Conclusion:** 0 failures on both branches; PR adds 5 tests (all pass).
  No regressions.
