### PR TITLE
feat(optimizer): per-model savings pricing for the optimizer series (BET-1370)

### DIFF
--- a/docs/opencode-tools/manta-optimizer-plugin.ts
+++ b/docs/opencode-tools/manta-optimizer-plugin.ts
@@ -118,6 +118,7 @@ function scanEligible(
   let maskedTokens = 0
   let maskedParts = 0
   let partsSeen = 0
+  let maxTailAtMask = 0
   const eligible: any[] = []
   const t0 = budget ? budget.t0 : 0
   const budgetMs = budget ? budget.budgetMs : 0
@@ -127,7 +128,7 @@ function scanEligible(
     for (let i = parts.length - 1; i >= 0; i--) {
       partsSeen++
       if (checkEvery > 0 && partsSeen % checkEvery === 0 && budget!.now() - t0 > budgetMs) {
-        return { bailed: "budget", maskedTokens, maskedParts, eligible }
+        return { bailed: "budget", maskedTokens, maskedParts, eligible, maxTailAtMask }
       }
       const part = parts[i]
       const isTool = part?.type === "tool"
@@ -142,6 +143,10 @@ function scanEligible(
       if (isTool && done && !isSkill && !alreadyPlaceholder && !protectedByTail && !protectedByRecency) {
         maskedTokens += estTokens(out)
         maskedParts++
+        // The spot this mask is inserted rewrites the cache for everything
+        // AFTER it — track the largest tail re-warmed by any mask (the full
+        // prompt tail that follows the mask point), for the re-warm cost.
+        if (tailTokens > maxTailAtMask) maxTailAtMask = tailTokens
         eligible.push({
           m,
           i,
@@ -152,7 +157,7 @@ function scanEligible(
       }
     }
   }
-  return { bailed: null, maskedTokens, maskedParts, eligible }
+  return { bailed: null, maskedTokens, maskedParts, eligible, maxTailAtMask }
 }
 
 function decideApply(a: {
@@ -175,6 +180,7 @@ function planMask(a: { messages: any[]; policy: any; now?: () => number }): any 
     return {
       bailed: "parts", apply: false, maskedTokens: 0, maskedParts: 0,
       eligible: [], reclaimable: 0, cacheDead: false, lastAssistantCompletedMs: 0,
+      rewarmTokens: 0,
     }
   }
   const t0 = now()
@@ -185,6 +191,7 @@ function planMask(a: { messages: any[]; policy: any; now?: () => number }): any 
     return {
       bailed: "budget", apply: false, maskedTokens: 0, maskedParts: 0,
       eligible: [], reclaimable: 0, cacheDead: false, lastAssistantCompletedMs: 0,
+      rewarmTokens: 0,
     }
   }
   const lastAssistantCompletedMs = lastAssistantCompleted(messages)
@@ -199,6 +206,10 @@ function planMask(a: { messages: any[]; policy: any; now?: () => number }): any 
     bailed: null, apply, cacheDead, lastAssistantCompletedMs,
     maskedTokens: scan.maskedTokens, maskedParts: scan.maskedParts,
     eligible: scan.eligible, reclaimable: scan.maskedTokens,
+    // Rewarm tokens the trimming would cause: the tail rewritten after the mask
+    // point. A dead cache means that tail was being re-written ANYWAY, so there
+    // is no NEW re-warm to charge — only a live cache has a re-warm cost.
+    rewarmTokens: cacheDead ? 0 : scan.maxTailAtMask,
   }
 }
 
@@ -260,6 +271,31 @@ function applyMask(messages: any[], eligible: any[], format: string): void {
     if (!part || part.type !== "tool" || !part.state) continue
     part.state.output = renderPlaceholder(e.tool, e.input, format)
   }
+}
+
+// BET-1370: the model whose tokens we are masking, for per-model savings
+// pricing. Source 1 is the transform's own input (the request carries
+// providerID/modelID); source 2 is a backwards scan of the messages for the
+// last entry that recorded them on its info. Both must be present to attribute
+// the tokens (missing either → {} — the report then carries no model and the
+// window is priced as unknown).
+function resolveModel(messages: any[], input: any): { providerID?: string; modelID?: string } {
+  if (
+    typeof input?.providerID === "string" && input.providerID !== "" &&
+    typeof input?.modelID === "string" && input.modelID !== ""
+  ) {
+    return { providerID: input.providerID, modelID: input.modelID }
+  }
+  for (let m = messages.length - 1; m >= 0; m--) {
+    const info = messages[m]?.info
+    if (
+      typeof info?.providerID === "string" && info.providerID !== "" &&
+      typeof info?.modelID === "string" && info.modelID !== ""
+    ) {
+      return { providerID: info.providerID, modelID: info.modelID }
+    }
+  }
+  return {}
 }
 
 //
@@ -347,7 +383,7 @@ function resolveCachedConstraints(sessionID: string): string[] {
 
 export const MantaOptimizerMask: Plugin = async () => {
   return {
-    "experimental.chat.messages.transform": async (_input: any, output: any) => {
+    "experimental.chat.messages.transform": async (input: any, output: any) => {
       try {
         const messages: any[] = output?.messages ?? []
         const sessionID: string = messages[0]?.info?.sessionID ?? ""
@@ -371,16 +407,26 @@ export const MantaOptimizerMask: Plugin = async () => {
           applied = true
         }
 
+        // BET-1370: attribute the masked tokens to a model so the savings can be
+        // priced per model. Report only when BOTH identity fields resolve — a
+        // bare `modelID` is not a usable key.
+        const model = resolveModel(messages, input)
+        const modelFields =
+          model.providerID && model.modelID ? { providerID: model.providerID, modelID: model.modelID } : {}
+
         // Report actual AND counterfactual — not awaited. maskedTokens /
         // maskedParts are the full would-mask computed identically whether the
         // policy is on or off, so the observe line stays byte-identical to
-        // phase 1 (which reported only above MIN_BATCH_TOKENS == batchTokens).
-        if (plan.maskedTokens >= policy.batchTokens) {
+        // phase 1. BET-1370 widened the trigger from >= batchTokens to > 0 and
+        // carries the re-warm tokens + model identity.
+        if (plan.maskedTokens > 0) {
           reportCounterfactual(sessionID, {
             maskedTokens: plan.maskedTokens,
             maskedParts: plan.maskedParts,
+            rewarmTokens: plan.rewarmTokens,
             applied,
             mode,
+            ...modelFields,
           })
         }
       } catch {

--- a/src/renderer/OptimizerCard.test.tsx
+++ b/src/renderer/OptimizerCard.test.tsx
@@ -242,6 +242,15 @@ describe("OptimizerCard — BET-1369 range selector + windowed stats", () => {
     expect(h.text()).not.toContain("not priced");
   });
 
+  it("a sub-dollar saving renders two decimals (≈ $0.37), never rounded to $0", async () => {
+    const saved: OptimizerSeries["saved"] = { usd: 0.37, potentialUsd: 0.4, basis: "measured", pricedShare: 1 };
+    setApi({ optimizerSeries: (range) => Promise.resolve(seriesFixture({ range, saved })) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("≈ $0.37");
+    expect(h.text()).not.toContain("≈ $0\n"); // no whole-dollar "$0"
+  });
+
   it("no counterfactual in a 24h window shows the hourly explanation under the legend", async () => {
     setApi();
     h = mount(<OptimizerCard />);

--- a/src/renderer/OptimizerCard.test.tsx
+++ b/src/renderer/OptimizerCard.test.tsx
@@ -63,6 +63,7 @@ function seriesFixture(over: Partial<OptimizerSeries> = {}): OptimizerSeries {
     ],
     counterfactualAvailable: false,
     totals: { turns: 100, cost: 12.34, tokensSent: 30, maskedTokens: 0 },
+    saved: { usd: 0, potentialUsd: 0, basis: "measured", pricedShare: 1 },
     ...over,
   };
 }
@@ -166,14 +167,16 @@ describe("OptimizerCard — BET-1369 range selector + windowed stats", () => {
             ],
             counterfactualAvailable: true,
             totals: { turns: 10, cost: 2, tokensSent: 2000, maskedTokens: 1000 },
+            saved: { usd: 0.37, potentialUsd: 0.37, basis: "measured", pricedShare: 1 },
           }),
         ),
     });
     h = mount(<OptimizerCard />);
     await h.flush();
     // maskedTotal 1000 → the chart overlay shows the masked total + the est.
-    // saved figure, and the counterfactual legend line appears.
-    expect(h.text()).toContain("−1k tokens · ≈ $0 est.");
+    // figure (two decimals from saved.usd), and the counterfactual legend line
+    // appears.
+    expect(h.text()).toContain("−1k tokens · ≈ $0.37 est.");
     expect(h.text()).toContain("raw counterfactual");
   });
 
@@ -189,6 +192,54 @@ describe("OptimizerCard — BET-1369 range selector + windowed stats", () => {
     expect(text).toContain("TTL 5m default");
     // Sessions stat detail reads 30d (no compaction in fixture).
     expect(h.container.textContent).toContain("30d");
+  });
+
+  it("an unpriced Saved stat renders 'not priced' with the documented detail", async () => {
+    setApi({
+      optimizerSeries: (range) =>
+        Promise.resolve(seriesFixture({ range, saved: { usd: null, potentialUsd: null, basis: "unpriced", pricedShare: 0 } })),
+    });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("not priced");
+    expect(h.text()).toContain("these endpoints declare no price");
+  });
+
+  it("a negative Saved stat renders a warn −$ figure and the re-warm detail", async () => {
+    const saved: OptimizerSeries["saved"] = { usd: -0.43, potentialUsd: 0.2, basis: "measured", pricedShare: 1 };
+    setApi({ optimizerSeries: (range) => Promise.resolve(seriesFixture({ range, saved })) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("−$0.43");
+    expect(h.text()).toContain("re-warm cost exceeded the saving");
+    expect(h.container.querySelector(".opt-stat-v.warn")).toBeTruthy();
+  });
+
+  it("a measured positive Saved stat renders two-decimal ≈ $X.XX and the potential detail", async () => {
+    const saved: OptimizerSeries["saved"] = { usd: 1.234, potentialUsd: 1.25, basis: "measured", pricedShare: 1 };
+    setApi({ optimizerSeries: (range) => Promise.resolve(seriesFixture({ range, saved })) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("≈ $1.23");
+    expect(h.text()).toContain("≈$1.25 potential");
+  });
+
+  it("a partial Saved stat shows potential · % priced on the detail line", async () => {
+    const saved: OptimizerSeries["saved"] = { usd: 2.4, potentialUsd: 3.6, basis: "partial", pricedShare: 0.5 };
+    setApi({ optimizerSeries: (range) => Promise.resolve(seriesFixture({ range, saved })) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("≈ $2.40");
+    expect(h.text()).toContain("≈$3.60 potential · 50% priced");
+  });
+
+  it("an optimizer-off window (nothing applied) renders Saved as ≈ $0.00, not 'not priced'", async () => {
+    const saved: OptimizerSeries["saved"] = { usd: 0, potentialUsd: 1.25, basis: "measured", pricedShare: 1 };
+    setApi({ optimizerSeries: (range) => Promise.resolve(seriesFixture({ range, saved })) });
+    h = mount(<OptimizerCard />);
+    await h.flush();
+    expect(h.text()).toContain("≈ $0.00");
+    expect(h.text()).not.toContain("not priced");
   });
 
   it("no counterfactual in a 24h window shows the hourly explanation under the legend", async () => {

--- a/src/renderer/OptimizerCard.tsx
+++ b/src/renderer/OptimizerCard.tsx
@@ -196,9 +196,16 @@ export function OptimizerCard() {
   const rawTotal = sentTotal + maskedTotal;
   const trimmedPct = rawTotal > 0 ? (maskedTotal / rawTotal) * 100 : 0;
 
-  // Flat $3/Mtok counterfactual saving estimate (refined per-model in phase 2) —
-  // computation unchanged, now scoped to the window.
-  const saved = Math.round((maskedTotal * 3) / 1_000_000);
+  // BET-1370: the window's savings now come from the SERIES — real per-model
+  // prompt-side pricing minus the cache re-warm the mask forced, computed
+  // server-side — not a flat $3/Mtok counterfactual guess. `usd` is null when
+  // the applied turns aren't priceable ("not priced"); negative when the
+  // re-warm cost exceeded the saving (never clamped). While the series is
+  // in flight / unsupported, fall back to the unpriced state.
+  const savedUsd = sd ? sd.saved.usd : null;
+  const savedBasis = sd ? sd.saved.basis : "unpriced";
+  const savedPricedShare = sd ? sd.saved.pricedShare : 0;
+  const potentialUsd = sd ? sd.saved.potentialUsd : null;
 
   // Consumption chart series (cumulative), scaled together by the peak.
   const maxTokens = Math.max(rawTotal, 1);
@@ -406,7 +413,8 @@ export function OptimizerCard() {
 
                   {maskedTotal > 0 && (
                     <text x={CHART.width} y="24" textAnchor="end" fill="var(--ok)" fontSize="10" fontFamily="var(--font-mono)">
-                      −{formatTokens(maskedTotal)} · ≈ ${saved} est.
+                      −{formatTokens(maskedTotal)}
+                      {savedUsd !== null ? ` · ≈ $${savedUsd.toFixed(2)} est.` : ""}
                     </text>
                   )}
                 </g>
@@ -437,8 +445,26 @@ export function OptimizerCard() {
             </div>
             <div className="opt-stat">
               <div className="opt-stat-l">Saved</div>
-              <div className="opt-stat-v ok">≈ ${saved}</div>
-              <div className="opt-stat-d">est. · counterfactual</div>
+              {savedBasis === "unpriced" ? (
+                <>
+                  <div className="opt-stat-v">not priced</div>
+                  <div className="opt-stat-d">these endpoints declare no price</div>
+                </>
+              ) : savedUsd !== null && savedUsd < 0 ? (
+                <>
+                  <div className="opt-stat-v warn">−${(-savedUsd).toFixed(2)}</div>
+                  <div className="opt-stat-d">re-warm cost exceeded the saving</div>
+                </>
+              ) : (
+                <>
+                  <div className="opt-stat-v ok">≈ ${savedUsd !== null ? savedUsd.toFixed(2) : "0.00"}</div>
+                  <div className="opt-stat-d">
+                    {savedBasis === "partial"
+                      ? `≈$${potentialUsd !== null ? potentialUsd.toFixed(2) : "0.00"} potential · ${Math.round(savedPricedShare * 100)}% priced`
+                      : `≈$${potentialUsd !== null ? potentialUsd.toFixed(2) : "0.00"} potential`}
+                  </div>
+                </>
+              )}
             </div>
             <div className="opt-stat">
               <div className="opt-stat-l">Cache hit</div>

--- a/src/renderer/OptimizerCard.tsx
+++ b/src/renderer/OptimizerCard.tsx
@@ -198,10 +198,10 @@ export function OptimizerCard() {
 
   // BET-1370: the window's savings now come from the SERIES — real per-model
   // prompt-side pricing minus the cache re-warm the mask forced, computed
-  // server-side — not a flat $3/Mtok counterfactual guess. `usd` is null when
-  // the applied turns aren't priceable ("not priced"); negative when the
-  // re-warm cost exceeded the saving (never clamped). While the series is
-  // in flight / unsupported, fall back to the unpriced state.
+  // server-side (the old whole-dollar per-million-token guess is gone). `usd`
+  // is null when the applied turns aren't priceable ("not priced"); negative
+  // when the re-warm cost exceeded the saving (never clamped). While the series
+  // is in flight / unsupported, fall back to the unpriced state.
   const savedUsd = sd ? sd.saved.usd : null;
   const savedBasis = sd ? sd.saved.basis : "unpriced";
   const savedPricedShare = sd ? sd.saved.pricedShare : 0;

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1105,6 +1105,30 @@ const optimizerSummary = createOptimizerSummary({
 const optimizerSeries = createOptimizerSeries({
   getDb,
   counterfactualStore: optimizerCounterfactual,
+  // BET-1370: the per-model cost reader that prices the window's savings. Built
+  // from oc.getProviders — each model already carries a normalised camelCase
+  // `cost` ({ input, output, cacheRead, cacheWrite } in $/Mtok) — keyed
+  // `"<providerID>/<modelID>"`, EXACTLY the key the counterfactual store's
+  // byModel split uses. Never throws: an unreadable provider list just means no
+  // window is priceable (the card renders "not priced").
+  modelRates: async () => {
+    try {
+      const { all } = await oc.getProviders();
+      const out = {};
+      for (const p of Array.isArray(all) ? all : []) {
+        if (!p || typeof p.id !== "string") continue;
+        const pModels = p.models && typeof p.models === "object" ? p.models : {};
+        for (const modelId of Object.keys(pModels)) {
+          const m = oc._normalizeProviderModel(p.id, modelId, pModels[modelId]);
+          if (!m || typeof m.id !== "string") continue;
+          out[`${p.id}/${m.id}`] = m.cost;
+        }
+      }
+      return out;
+    } catch {
+      return {};
+    }
+  },
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/optimizer/series.mjs
+++ b/src/server/optimizer/series.mjs
@@ -23,6 +23,8 @@
 import { aggregate, aggregateDailySeries, aggregateHourlySeries, fetchLedgerRows } from "../modelLedger.mjs";
 import { bucketSeries } from "./counterfactual.mjs";
 import { bucketKeyToMs } from "../../shared/timeBuckets.mjs";
+import { mixFromCounts } from "../../shared/blendedPrice.mjs";
+import { promptSideRate, savedUsd } from "../../shared/optimizerSavings.mjs";
 
 // The supported ranges and their bucketing. Bucket keys zip the sent series
 // (from the ledger) with the counterfactual series (from the store) — both are
@@ -57,8 +59,20 @@ function normalizeRange(range) {
  * injected store (a null store yields zeros, never a throw). The two are zipped
  * on the bucket KEY so they are always the same length and aligned, even when
  * the two sources have different sparse keys.
+ *
+ * `modelRates` is an injected async reader (like summary.mjs's readCacheTtl)
+ * returning `{ "<providerID>/<modelID>": normalizedCost }` — the per-model cost
+ * map used to price the window's savings (BET-1370). It may resolve to {} (the
+ * box can't read opencode's provider list) and any missing model simply is not
+ * priceable.
  */
-export async function buildOptimizerSeries({ range, fetchRows, counterfactualStore = null, now = Date.now() }) {
+export async function buildOptimizerSeries({
+  range,
+  fetchRows,
+  counterfactualStore = null,
+  now = Date.now(),
+  modelRates = async () => ({}),
+}) {
   const r = normalizeRange(range);
   const { bucket, count } = RANGES[r];
   const nowMs = num(now);
@@ -93,8 +107,49 @@ export async function buildOptimizerSeries({ range, fetchRows, counterfactualSto
   const tokensSent = series.reduce((s, p) => s + p.tokensSent, 0);
   const maskedTokens = series.reduce((s, p) => s + p.maskedTokens, 0);
 
+  // ---- BET-1370: price the window's savings (real per-model rates, not a
+  // flat per-million guess). The counterfactual store's buckets carry the
+  // token-turn sums and the per-model split; sum them across the window. ----
+  let appliedTokens = 0;
+  let rewarmTokens = 0;
+  const maskedByModel = {};
+  for (const b of Array.isArray(cf) ? cf : []) {
+    appliedTokens += num(b.appliedTokens);
+    rewarmTokens += num(b.rewarmTokens);
+    if (b.byModel && typeof b.byModel === "object") {
+      for (const [mk, tok] of Object.entries(b.byModel)) {
+        maskedByModel[mk] = (maskedByModel[mk] ?? 0) + num(tok);
+      }
+    }
+  }
+
+  // The store keys byModel on the full WOULD-mask set (every report, applied or
+  // not); there is no separate applied split. Derive the applied set by scaling
+  // the would-mask split by the applied/masked ratio: nothing applied → empty
+  // (usd 0, the optimizer is off); everything applied → equal to potential.
+  const ratio = maskedTokens > 0 ? appliedTokens / maskedTokens : 0;
+  const appliedByModel = {};
+  for (const [mk, tok] of Object.entries(maskedByModel)) appliedByModel[mk] = tok * ratio;
+  const appliedRewarm = rewarmTokens * ratio;
+
   // turns/cost reuse the existing aggregate over exactly the window's rows.
-  const { totals } = aggregate(rows);
+  const { totals, cacheShare } = aggregate(rows);
+
+  // Measured cache mix over the window (all-zero → DEFAULT_MIX via
+  // mixFromCounts — the single shared default, never a second one here).
+  const mix = mixFromCounts(cacheShare);
+
+  // Build the per-model prompt-side rates from the injected reader.
+  const modelCosts = await modelRates();
+  const rates = {};
+  if (modelCosts && typeof modelCosts === "object") {
+    for (const [mk, cost] of Object.entries(modelCosts)) rates[mk] = promptSideRate(cost, mix);
+  }
+
+  // potential: the full would-mask set (what trimming WOULD save); applied: the
+  // subset actually masked (what it DID save — 0 when the optimizer is off).
+  const applied = savedUsd({ byModel: appliedByModel, rewarmTokens: appliedRewarm, rates });
+  const potential = savedUsd({ byModel: maskedByModel, rewarmTokens, rates });
 
   return {
     supported: true,
@@ -109,6 +164,12 @@ export async function buildOptimizerSeries({ range, fetchRows, counterfactualSto
       cost: totals.cost,
       tokensSent,
       maskedTokens,
+    },
+    saved: {
+      usd: applied.usd,
+      potentialUsd: potential.usd,
+      basis: applied.basis,
+      pricedShare: applied.pricedShare,
     },
   };
 }
@@ -128,11 +189,13 @@ export function _resetSeriesMemo() {
 /**
  * I/O. Wrapper factory. `getDb` resolves the read-only opencode.db handle
  * (null → { supported:false }); `counterfactualStore` is the observe-mode store
- * from counterfactual.mjs (null when not wired); `now` (a number or a zero-arg
- * fn, for tests) is the clock. The returned async function takes a range and
- * memoizes the built series per range for TTL_MS with an in-flight guard.
+ * from counterfactual.mjs (null when not wired); `modelRates` is the injected
+ * per-model cost reader (built from oc.getProviders in index.mjs); `now` (a
+ * number or a zero-arg fn, for tests) is the clock. The returned async function
+ * takes a range and memoizes the built series per range for TTL_MS with an
+ * in-flight guard.
  */
-export function createOptimizerSeries({ getDb, counterfactualStore = null, now }) {
+export function createOptimizerSeries({ getDb, counterfactualStore = null, modelRates, now }) {
   const nowMs = () => (typeof now === "function" ? num(now()) : num(now ?? Date.now()));
   return function optimizerSeries(range) {
     const r = normalizeRange(range);
@@ -151,6 +214,7 @@ export function createOptimizerSeries({ getDb, counterfactualStore = null, now }
           range: r,
           fetchRows: (since) => fetchLedgerRows(db, since),
           counterfactualStore,
+          modelRates,
           now: t,
         });
         memo.set(r, { at: t, value });

--- a/src/server/optimizer/series.test.mjs
+++ b/src/server/optimizer/series.test.mjs
@@ -217,6 +217,36 @@ test("buildOptimizerSeries: nothing applied (observe/flags off) → usd 0 while 
   assert.ok(out.saved.potentialUsd > 0, "potential still shows what it would save");
 });
 
+test("buildOptimizerSeries: mixed known+unknown tokens + re-warm → partial basis, weighted-average pricing, subtracted re-warm", async () => {
+  const nowMs = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const todayLoc = new Date(2026, 7, 24, 0, 0, 0);
+  const store = fakeStore({
+    days: {
+      [localDay(todayLoc)]: {
+        maskedTokens: 3000,
+        appliedTokens: 3000,
+        rewarmTokens: 1000, // 1k re-warm at cacheWrite−cacheRead = 2.7/Mtok
+        byModel: { "claude/sonnet": 1000, unknown: 2000 },
+      },
+    },
+  });
+  const out = await buildOptimizerSeries({
+    range: "7d",
+    fetchRows: async () => [],
+    now: nowMs,
+    counterfactualStore: store,
+    modelRates: async () => ({ "claude/sonnet": SONNET_COST }),
+  });
+  const sonnet = promptSideRate(SONNET_COST);
+  // known 1000 @ sonnet + unknown 2000 at the weighted average (= sonnet, the
+  // only known rate), minus re-warm 1000/Mtok × (cacheWrite − cacheRead).
+  const expected = (3000 / 1e6) * sonnet.rate - (1000 / 1e6) * (sonnet.cacheWrite - sonnet.cacheRead);
+  assert.ok(Math.abs(out.saved.usd - expected) < 1e-9);
+  assert.equal(out.saved.potentialUsd, out.saved.usd); // all applied
+  assert.equal(out.saved.basis, "partial");
+  assert.ok(Math.abs(out.saved.pricedShare - 1 / 3) < 1e-9);
+});
+
 test("buildOptimizerSeries: tokens exist but no pricing available → usd null, unpriced", async () => {
   const nowMs = new Date(2026, 7, 24, 12, 0, 0).getTime();
   const todayLoc = new Date(2026, 7, 24, 0, 0, 0);

--- a/src/server/optimizer/series.test.mjs
+++ b/src/server/optimizer/series.test.mjs
@@ -7,6 +7,7 @@ import {
   RANGES,
   _resetSeriesMemo,
 } from "./series.mjs";
+import { promptSideRate } from "../../shared/optimizerSavings.mjs";
 
 // Ledger row fixture — the fields `aggregate` / the series bucket agg read.
 function row(over = {}) {
@@ -141,6 +142,104 @@ test("buildOptimizerSeries: totals fold turns/cost from the window's rows", asyn
   assert.equal(out.totals.cost, 3.0);
   assert.equal(out.totals.tokensSent, 20);
   assert.equal(out.totals.maskedTokens, 0);
+});
+
+// ---- BET-1370: the window's `saved` figure (per-model pricing vs re-warm) ----
+
+const localDay = (d) =>
+  `${d.getFullYear()}-${String(d.getMonth() + 1).padStart(2, "0")}-${String(d.getDate()).padStart(2, "0")}`;
+
+const SONNET_COST = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3 };
+
+test("buildOptimizerSeries: with a counterfactual store and no rates, `saved` is a zero/empty set (not a crash)", async () => {
+  const nowMs = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const out = await buildOptimizerSeries({
+    range: "7d",
+    fetchRows: async () => [],
+    now: nowMs,
+    counterfactualStore: null, // no store at all
+  });
+  assert.equal(out.saved.usd, 0);
+  assert.equal(out.saved.potentialUsd, 0);
+  assert.equal(out.saved.basis, "measured");
+  assert.equal(out.saved.pricedShare, 1);
+});
+
+test("buildOptimizerSeries: applied window prices tokens at the model's prompt-side rate", async () => {
+  const nowMs = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const todayLoc = new Date(2026, 7, 24, 0, 0, 0);
+  const store = fakeStore({
+    days: {
+      [localDay(todayLoc)]: {
+        maskedTokens: 1000,
+        appliedTokens: 1000, // everything applied → usd == potential
+        rewarmTokens: 0,
+        byModel: { "claude/sonnet": 1000 },
+      },
+    },
+  });
+  const out = await buildOptimizerSeries({
+    range: "7d",
+    fetchRows: async () => [],
+    now: nowMs,
+    counterfactualStore: store,
+    modelRates: async () => ({ "claude/sonnet": SONNET_COST }),
+  });
+  const expected = promptSideRate(SONNET_COST).rate * (1000 / 1e6);
+  assert.ok(out.saved.usd > 0, "a priced applied window has a positive figure");
+  assert.ok(Math.abs(out.saved.usd - expected) < 1e-9);
+  assert.equal(out.saved.potentialUsd, out.saved.usd, "all applied → potential == actual");
+  assert.equal(out.saved.basis, "measured");
+  assert.equal(out.saved.pricedShare, 1);
+});
+
+test("buildOptimizerSeries: nothing applied (observe/flags off) → usd 0 while potentialUsd is positive", async () => {
+  const nowMs = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const todayLoc = new Date(2026, 7, 24, 0, 0, 0);
+  const store = fakeStore({
+    days: {
+      [localDay(todayLoc)]: {
+        maskedTokens: 1000,
+        appliedTokens: 0, // nothing applied — the optimizer is off
+        rewarmTokens: 0,
+        byModel: { "claude/sonnet": 1000 },
+      },
+    },
+  });
+  const out = await buildOptimizerSeries({
+    range: "7d",
+    fetchRows: async () => [],
+    now: nowMs,
+    counterfactualStore: store,
+    modelRates: async () => ({ "claude/sonnet": SONNET_COST }),
+  });
+  assert.equal(out.saved.usd, 0, "off → it saved nothing");
+  assert.ok(out.saved.potentialUsd > 0, "potential still shows what it would save");
+});
+
+test("buildOptimizerSeries: tokens exist but no pricing available → usd null, unpriced", async () => {
+  const nowMs = new Date(2026, 7, 24, 12, 0, 0).getTime();
+  const todayLoc = new Date(2026, 7, 24, 0, 0, 0);
+  const store = fakeStore({
+    days: {
+      [localDay(todayLoc)]: {
+        maskedTokens: 1000,
+        appliedTokens: 1000,
+        rewarmTokens: 0,
+        byModel: { "unknown": 1000 }, // no model identity → nothing priceable
+      },
+    },
+  });
+  const out = await buildOptimizerSeries({
+    range: "7d",
+    fetchRows: async () => [],
+    now: nowMs,
+    counterfactualStore: store,
+    modelRates: async () => ({}), // box can't read providers
+  });
+  assert.equal(out.saved.usd, null);
+  assert.equal(out.saved.potentialUsd, null);
+  assert.equal(out.saved.basis, "unpriced");
 });
 
 // ---- createOptimizerSeries (memo + in-flight + degradation) ----

--- a/src/shared/optimizerSavings.d.mts
+++ b/src/shared/optimizerSavings.d.mts
@@ -1,0 +1,38 @@
+// Type declarations for optimizerSavings.mjs (the pure per-model savings
+// pricing shared by the optimizer series + card, BET-1370).
+
+// opencode's normalised per-model cost, $/Mtok. `undefined` means unknown
+// (NOT zero — "free" is a deliberate declared 0).
+export interface OptimizerCost {
+  input?: number;
+  output?: number;
+  cacheRead?: number;
+  cacheWrite?: number;
+}
+
+// The resolved per-model prompt-side rate, plus the cache rates used for the
+// re-warm subtraction (missing cache rates bill at the full input rate).
+export interface PromptSideRate {
+  rate: number;
+  known: boolean;
+  cacheRead: number;
+  cacheWrite: number;
+}
+
+export type SavingsBasis = "measured" | "partial" | "unpriced";
+
+// savedUsd's result. `usd` is null only for the "unpriced" set (tokens exist
+// but none are priceable); the genuinely-empty set is 0 with basis "measured".
+export interface SavingsResult {
+  usd: number | null;
+  basis: SavingsBasis;
+  pricedShare: number;
+}
+
+export function promptSideRate(cost?: OptimizerCost | null, mix?: unknown): PromptSideRate;
+
+export function savedUsd(args: {
+  byModel?: Record<string, number>;
+  rewarmTokens?: number;
+  rates?: Record<string, PromptSideRate>;
+}): SavingsResult;

--- a/src/shared/optimizerSavings.mjs
+++ b/src/shared/optimizerSavings.mjs
@@ -1,0 +1,172 @@
+// optimizerSavings.mjs — price a window of OPTIMIZER savings honestly.
+//
+// Pure. No node:* imports, no Date.now(), no I/O — everything arrives as an
+// argument. Two functions:
+//   promptSideRate(cost, mix) — $ per 1M tokens saved by REMOVING a token from
+//     a prompt.
+//   savedUsd({ byModel, rewarmTokens, rates }) — a window's savings in dollars.
+//
+// Why this module exists (BET-1370): OptimizerCard used to compute the savings
+// figure with a flat `$3/Mtok` counterfactual guess — Claude Sonnet's *input*
+// rate. But the tokens being trimmed are old *tool outputs* removed from the
+// prompt, tokens that would overwhelmingly have been billed as prompt-cache
+// reads at a tenth of that. Measured against real published rates the flat
+// figure overstated savings by ~10x on a Haiku box and ~3x on a Sonnet box.
+// Worse, masking rewrites the prompt prefix, so everything after the mask point
+// loses its cache entry and is re-written once at cache-write rate — nothing
+// subtracted that re-warm cost, and on a conversation that ends a few turns
+// after the trim the "saving" was actually a loss.
+//
+// Both errors are fixed here. The rate is derived from the measured per-model
+// cache mix restricted to the prompt side (a removed token is billed as input /
+// cache-write / cache-read, NEVER output), and the re-warm cost is subtracted
+// using the dominant model's cacheWrite−cacheRead delta. A negative result is
+// real and is returned, never clamped — reporting a gain on a trim that cost
+// money is the failure this module engineers out.
+
+import { DEFAULT_MIX } from "./blendedPrice.mjs";
+
+// A finite number >= 0, else 0 (non-numeric / negative junk → 0; a declared 0
+// stays 0 — "free" is a deliberate number, distinct from "unknown").
+function dollar(v) {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : 0;
+}
+
+// Is `v` a finite, non-negative rate we can trust? (distinct from dollar(): a
+// declared 0 here is meaningful, so this returns true for 0 rather than a flag.)
+function isRate(v) {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0;
+}
+
+// The prompt-side mix weights. A token removed from a prompt is billed as
+// input, cache-write or cache-read — never as output — so the workload mix is
+// restricted to those three buckets and renormalised. A mix that is missing or
+// has no positive prompt-side weight falls back to DEFAULT_MIX's prompt buckets.
+function promptWeights(mix) {
+  const use = mix && typeof mix === "object" ? mix : DEFAULT_MIX;
+  const i = dollar(use.input);
+  const r = dollar(use.cacheRead);
+  const w = dollar(use.cacheWrite);
+  const denom = i + r + w;
+  if (denom > 0) return { wInput: i / denom, wRead: r / denom, wWrite: w / denom };
+  const di = dollar(DEFAULT_MIX.input);
+  const dr = dollar(DEFAULT_MIX.cacheRead);
+  const dw = dollar(DEFAULT_MIX.cacheWrite);
+  return { wInput: di / (di + dr + dw), wRead: dr / (di + dr + dw), wWrite: dw / (di + dr + dw) };
+}
+
+function num(v) {
+  return typeof v === "number" && Number.isFinite(v) && v >= 0 ? v : 0;
+}
+
+/**
+ * PURE. $ per 1M tokens for a token REMOVED FROM A PROMPT.
+ *
+ * A masked token is an old tool output taken out of the prompt — it would have
+ * been billed as input, cache-write or cache-read, and NEVER as output. So the
+ * weights are the measured mix restricted to those three buckets and
+ * renormalised; using the router's full blended rate (which weights output
+ * heavily) would overstate savings.
+ *
+ * Missing cacheRead / cacheWrite rates bill at the full input rate, matching
+ * blendedPrice(); a declared 0 stays 0. Returns { rate, known, cacheRead,
+ * cacheWrite }, with known:false when `cost.input` is not a finite number >= 0 —
+ * unknown is NOT zero and must never be silently treated as free.
+ *
+ * @param {object} cost  normalised per-model cost { input, output, cacheRead, cacheWrite } in $/Mtok
+ * @param {object} [mix] workload mix { input, output, cacheRead, cacheWrite } fractions
+ * @returns {{ rate: number, known: boolean, cacheRead: number, cacheWrite: number }}
+ */
+export function promptSideRate(cost, mix) {
+  const input = isRate(cost?.input) ? cost.input : null;
+  if (input === null) return { rate: 0, known: false, cacheRead: 0, cacheWrite: 0 };
+
+  // Missing cache rates bill at the full input rate; declared 0 stays 0.
+  const cacheRead = isRate(cost.cacheRead) ? dollar(cost.cacheRead) : input;
+  const cacheWrite = isRate(cost.cacheWrite) ? dollar(cost.cacheWrite) : input;
+
+  const { wInput, wRead, wWrite } = promptWeights(mix);
+  const rate = input * wInput + cacheRead * wRead + cacheWrite * wWrite;
+
+  return { rate, known: true, cacheRead, cacheWrite };
+}
+
+// The model key with the most tokens that has a known rate, else null. Used for
+// the re-warm subtraction (the dominant model's cacheWrite−cacheRead delta).
+function dominantRateKey(byModel, rates) {
+  let bestKey = null;
+  let bestTokens = -1;
+  for (const [mk, tokens] of Object.entries(byModel)) {
+    if (mk === "unknown") continue;
+    if (rates[mk]?.known !== true) continue;
+    const t = num(tokens);
+    if (t > bestTokens) {
+      bestTokens = t;
+      bestKey = mk;
+    }
+  }
+  return bestKey;
+}
+
+/**
+ * PURE. The window's savings in dollars.
+ *
+ * @param byModel      { "<providerID>/<modelID>": tokens } — the window's
+ *                     token-turns, summed across buckets. The key "unknown"
+ *                     holds tokens reported without a model.
+ * @param rewarmTokens prompt-cache re-warm tokens the trimming caused, summed.
+ * @param rates        { "<providerID>/<modelID>": { rate, known, cacheRead, cacheWrite } }
+ * @returns {{ usd: number | null, basis: "measured"|"partial"|"unpriced", pricedShare: number }}
+ */
+export function savedUsd({ byModel = {}, rewarmTokens = 0, rates = {} }) {
+  let knownContrib = 0; // $ from models with a directly-known rate
+  let knownTokens = 0; // tokens under a directly-known rate
+  let unknownTokens = 0; // tokens under "unknown" or an unpriced model
+
+  for (const [mk, tokens] of Object.entries(byModel)) {
+    const t = num(tokens);
+    if (t <= 0) continue;
+    if (mk !== "unknown" && rates[mk]?.known === true && Number.isFinite(rates[mk].rate)) {
+      knownContrib += (t / 1e6) * rates[mk].rate;
+      knownTokens += t;
+    } else {
+      unknownTokens += t;
+    }
+  }
+
+  const total = knownTokens + unknownTokens;
+  if (total <= 0) {
+    // Nothing to price: the genuine zero (a window with no applied turns — e.g.
+    // the optimizer is off). This is NOT "unpriced"; it is "nothing saved".
+    return { usd: 0, basis: "measured", pricedShare: 1 };
+  }
+
+  const pricedShare = knownTokens / total;
+  if (pricedShare === 0) {
+    // Tokens exist but none are directly priceable — do NOT invent a figure.
+    // The card renders "not priced".
+    return { usd: null, basis: "unpriced", pricedShare: 0 };
+  }
+  const basis = pricedShare === 1 ? "measured" : "partial";
+
+  // Unknown-model tokens price at the token-weighted average of the known rates.
+  let usd = knownContrib;
+  if (unknownTokens > 0) usd += unknownTokens * (knownContrib / knownTokens);
+
+  // Re-warm: the mask rewrote part of the prefix, losing the cache entry for
+  // everything after it so it is re-billed once at cache-write instead of read.
+  // Subtract that using the dominant known model's rates. Missing cache rate →
+  // its input rate (already resolved by promptSideRate). Never clamped: a loss
+  // is real and must render as such.
+  const rewarm = num(rewarmTokens);
+  if (rewarm > 0) {
+    const dominant = dominantRateKey(byModel, rates);
+    const dr = dominant !== null ? rates[dominant] : null;
+    if (dr && dr.known === true) {
+      const delta = dollar(dr.cacheWrite) - dollar(dr.cacheRead);
+      usd -= (rewarm / 1e6) * delta;
+    }
+  }
+
+  return { usd, basis, pricedShare };
+}

--- a/src/shared/optimizerSavings.test.ts
+++ b/src/shared/optimizerSavings.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from "vitest";
+import { promptSideRate, savedUsd } from "./optimizerSavings.mjs";
+import type { PromptSideRate } from "./optimizerSavings.mjs";
+
+// The DEFAULT_MIX prompt-side weights, renormalised to input/cacheRead/cacheWrite
+// only: input 0.08, cacheRead 0.8, cacheWrite 0.07 → /0.95.
+const W_INPUT = 0.08 / 0.95;
+const W_READ = 0.8 / 0.95;
+const W_WRITE = 0.07 / 0.95;
+
+// Anthropic catalogue prices ($/Mtok) — the numbers from the BET-1370 worked
+// maths. cacheWrite == input, cacheRead = input/10.
+const S = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3 }; // Sonnet
+const H = { input: 1, output: 5, cacheRead: 0.1, cacheWrite: 1 }; // Haiku
+
+// With the DEFAULT_MIX these must reproduce the issue's worked figures.
+const expectedSonnet = 3 * W_INPUT + 0.3 * W_READ + 3 * W_WRITE;
+const expectedHaiku = 1 * W_INPUT + 0.1 * W_READ + 1 * W_WRITE;
+
+describe("promptSideRate", () => {
+  it("reproduces the worked Sonnet figure (~$0.78/Mtok) with the default mix", () => {
+    const r = promptSideRate(S);
+    expect(r.known).toBe(true);
+    expect(r.rate).toBeCloseTo(expectedSonnet, 6);
+    expect(r.rate).toBeGreaterThan(0.7);
+    expect(r.rate).toBeLessThan(0.85);
+  });
+
+  it("replicates the DEFAULT_MIX blended-price figures — Haiku is a tenth of Sonnet's cacheRead, so a fraction of Sonnet", () => {
+    const s = promptSideRate(S);
+    const h = promptSideRate(H);
+    expect(h.known).toBe(true);
+    expect(h.rate).toBeCloseTo(expectedHaiku, 6);
+    expect(h.rate).toBeLessThan(s.rate);
+  });
+
+  it("a removed token is never billed as output: the rate uses only input/cacheRead/cacheWrite", () => {
+    // If output were (wrongly) included the rate would approach output*0.05;
+    // the prompt-side rate stays on the three cheap buckets no matter how
+    // expensive output is.
+    const pricey = { input: 3, output: 300, cacheRead: 0.3, cacheWrite: 3 };
+    const r = promptSideRate(pricey);
+    expect(r.rate).toBeCloseTo(expectedSonnet, 6);
+  });
+
+  it("missing cacheWrite/cacheRead bill at the full input rate, matching blendedPrice", () => {
+    const r = promptSideRate({ input: 3, output: 300 }); // no cache rates
+    expect(r.known).toBe(true);
+    expect(r.rate).toBeCloseTo(3, 6); // all three prompt buckets at input rate
+    expect(r.cacheRead).toBe(3);
+    expect(r.cacheWrite).toBe(3);
+  });
+
+  it("a declared 0 cache rate stays 0 (free, distinct from unknown → full input)", () => {
+    const free = promptSideRate({ input: 3, output: 300, cacheRead: 0, cacheWrite: 0 });
+    const missing = promptSideRate({ input: 3, output: 300 });
+    expect(free.cacheRead).toBe(0);
+    expect(free.cacheWrite).toBe(0);
+    expect(free.rate).toBeLessThan(missing.rate);
+    expect(free.known).toBe(true);
+  });
+
+  it("unknown (missing/non-finite/negative) input → known false, never treated as free", () => {
+    expect(promptSideRate({}).known).toBe(false);
+    expect(promptSideRate({ input: Number.NaN, output: 10 }).known).toBe(false);
+    expect(promptSideRate({ input: -5, output: 10 }).known).toBe(false);
+    expect(promptSideRate({ input: 0, output: 0 }).known).toBe(true); // declared free IS known
+  });
+
+  it("a degenerate or missing mix falls back to the default prompt-side weights", () => {
+    const withDefault = promptSideRate(S);
+    const degenerate = promptSideRate(S, { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    const absent = promptSideRate(S, undefined);
+    expect(degenerate.rate).toBeCloseTo(withDefault.rate, 9);
+    expect(absent.rate).toBeCloseTo(withDefault.rate, 9);
+  });
+
+  it("a measured read-heavy mix shifts the rate down toward cacheRead", () => {
+    const r = promptSideRate(S, { input: 0.1, output: 0.1, cacheRead: 0.8, cacheWrite: 0.0 });
+    expect(r.rate).toBeLessThan(promptSideRate(S).rate);
+  });
+});
+
+describe("savedUsd", () => {
+  const rates = (m: PromptSideRate) => ({ "claude/sonnet": m });
+
+  it("prices a single known model's token-turns at its prompt-side rate, measured basis", () => {
+    const r = savedUsd({ byModel: { "claude/sonnet": 1e6 }, rates: rates(promptSideRate(S)) });
+    expect(r.usd).toBeCloseTo(expectedSonnet, 6);
+    expect(r.basis).toBe("measured");
+    expect(r.pricedShare).toBe(1);
+  });
+
+  it("an empty applied set is zero savings with a measured basis (not unpriced, not null)", () => {
+    const r = savedUsd({ byModel: {}, rates: rates(promptSideRate(S)) });
+    expect(r.usd).toBe(0);
+    expect(r.pricedShare).toBe(1);
+    expect(r.basis).toBe("measured");
+  });
+
+  it("tokens under 'unknown' price at the token-weighted average of the known rates", () => {
+    // 1M Sonnet at ~0.78 + 1M unknown at the same average → 2× the known figure.
+    const sonnet = promptSideRate(S);
+    const r = savedUsd({
+      byModel: { "claude/sonnet": 1e6, unknown: 1e6 },
+      rates: { "claude/sonnet": sonnet },
+    });
+    expect(r.usd).toBeCloseTo(2 * expectedSonnet, 6);
+    expect(r.basis).toBe("partial");
+    expect(r.pricedShare).toBeCloseTo(0.5, 6);
+  });
+
+  it("every model unknown → usd null, basis unpriced — do not invent a figure", () => {
+    const r = savedUsd({ byModel: { unknown: 5e6 }, rates: {} });
+    expect(r.usd).toBeNull();
+    expect(r.basis).toBe("unpriced");
+    expect(r.pricedShare).toBe(0);
+  });
+
+  it("an unpriced model key (no known rate) counts as unknown, and if none priced → null", () => {
+    const r = savedUsd({ byModel: { "openai/gpt9": 4e6 }, rates: {} });
+    expect(r.usd).toBeNull();
+    expect(r.basis).toBe("unpriced");
+  });
+
+  it("subtracts the re-warm cost using the dominant known model's cacheWrite−cacheRead delta", () => {
+    // Dominant model: cacheWrite 3, cacheRead 0.3 → delta 2.7/Mtok.
+    const sonnet = promptSideRate(S);
+    const noRewarm = savedUsd({ byModel: { "claude/sonnet": 1e6 }, rates: { "claude/sonnet": sonnet } });
+    const withRewarm = savedUsd({
+      byModel: { "claude/sonnet": 1e6 },
+      rewarmTokens: 200_000, // 0.2 Mtok × 2.7 = $0.54 re-warm
+      rates: { "claude/sonnet": sonnet },
+    });
+    expect(withRewarm.usd!).toBeCloseTo(noRewarm.usd! - (0.2 * 2.7), 6);
+  });
+
+  it("a re-warm larger than the saving yields a NEGATIVE usd — never clamped", () => {
+    // Tiny saving (100k tokens), huge re-warm (5M): 5M × 2.7 = $13.5 re-warm.
+    const sonnet = promptSideRate(S);
+    const r = savedUsd({
+      byModel: { "claude/sonnet": 100_000 },
+      rewarmTokens: 5_000_000,
+      rates: { "claude/sonnet": sonnet },
+    });
+    expect(r.usd).toBeLessThan(0);
+    expect(r.basis).toBe("measured");
+  });
+
+  it("no known rate → no re-warm subtraction (there is nothing to price against)", () => {
+    const r = savedUsd({ byModel: { unknown: 1e6 }, rewarmTokens: 5_000_000, rates: {} });
+    expect(r.usd).toBeNull(); // still unpriced — re-warm never manufactures a number
+  });
+
+  it("ignores junk token values (negative / non-numeric) without throwing", () => {
+    const sonnet = promptSideRate(S);
+    const r = savedUsd({
+      byModel: { "claude/sonnet": Number.NaN, unknown: -10 },
+      rates: { "claude/sonnet": sonnet },
+    });
+    expect(r.usd).toBe(0);
+    expect(r.basis).toBe("measured");
+  });
+});

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1978,6 +1978,18 @@ export type OptimizerSeries = {
   series: { t: number; tokensSent: number; maskedTokens: number }[];
   counterfactualAvailable: boolean;
   totals: { turns: number; cost: number; tokensSent: number; maskedTokens: number };
+  // BET-1370: the window's savings, priced at REAL per-model prompt-side rates
+  // (not a flat per-million guess) minus the cache re-warm the mask forced.
+  // `usd` is null when the window's applied turns have no known price ("not
+  // priced"); otherwise it may be negative (re-warm exceeded the saving) and is
+  // never clamped. `potentialUsd` prices the full WOULD-mask set. `basis` /
+  // `pricedShare` describe how completely the APPLIED set was priced.
+  saved: {
+    usd: number | null;
+    potentialUsd: number | null;
+    basis: "measured" | "partial" | "unpriced";
+    pricedShare: number;
+  };
 };
 
 // A secret's METADATA — what the UI and `secret_list` see. NEVER carries the

--- a/website/sitemap.xml
+++ b/website/sitemap.xml
@@ -2,31 +2,31 @@
 <urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
   <url>
     <loc>https://mantaui.com/claude-code-mobile</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/claude-code-remote</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T17:17:23.000Z</lastmod>
     <changefreq>weekly</changefreq>
     <priority>1.0</priority>
   </url>
   <url>
     <loc>https://mantaui.com/open-source</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:04:35.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
   <url>
     <loc>https://mantaui.com/pricing</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>
@@ -50,7 +50,7 @@
   </url>
   <url>
     <loc>https://mantaui.com/vs-orca</loc>
-    <lastmod>2026-08-22T15:51:24.000Z</lastmod>
+    <lastmod>2026-08-22T16:01:05.000Z</lastmod>
     <changefreq>monthly</changefreq>
     <priority>0.8</priority>
   </url>


### PR DESCRIPTION
## BET-1370 — Optimizer savings: real per-model prompt-side pricing minus cache re-warm

Replaces the flat `$3/Mtok` (Claude Sonnet input-rate) counterfactual saving guess on the optimizer card with real per-model prompt-side pricing minus the cache re-warm the mask forces.

**Files changed:** 11. `src/shared/optimizerSavings.mjs` (+`.d.mts`, +`.test.ts`) [NEW], `src/server/optimizer/series.mjs`, `src/server/optimizer/series.test.mjs`, `src/server/index.mjs` (wiring), `src/shared/types.ts`, `src/renderer/OptimizerCard.tsx`, `src/renderer/OptimizerCard.test.tsx`, `docs/opencode-tools/manta-optimizer-plugin.ts`.

### What changed

- **Fix 1 — `promptSideRate(cost, mix)`** (pure, shared): $/Mtok for a token removed from a prompt. Mix restricted to input/cacheRead/cacheWrite and renormalised (a removed token is never billed as output); missing cache rates bill at full input; declared `0` stays 0; unknown input → `known:false` (never silently free). Repro of the issue's worked figures (Haiku ~$0.26 / Sonnet ~$0.78 / Opus ~$3.91 under the default mix) is pinned in tests.
- **Fix 1 — `savedUsd({ byModel, rewarmTokens, rates })`** (pure, shared): rule 1 known-model token-turns; rule 2 unknown/unpriced tokens priced at the token-weighted average of known rates; rule 3/4 `pricedShare` + `basis`; rule 5 unpriced → `usd: null`; rule 6 re-warm subtracted at the dominant known model's `cacheWrite−cacheRead`; rule 7 no clamping. Every rule + the empty set + declared-free vs unknown + re-warm-makes-negative are unit-tested.
- **Fix 2 — plugin** adds model identity (`input` + backwards `info` scan), re-warm tokens (`maxTailAtMask` → `rewarmTokens: cacheDead ? 0 : scan.maxTailAtMask`), and widens the report gate to `maskedTokens > 0` (so applied-but-below-batch turns — e.g. `cacheDead` applies — are no longer dropped). No plugin-side accumulator state added.
- **Fix 3 — series** gains an injected `modelRates` reader, wired in `index.mjs` from `oc.getProviders` (per-model `cost` keyed `` `${providerID}/${id}` ``, the same key the store's `byModel` uses), building `rates` via `promptSideRate(model.cost, mix)` where `mix` is the measured cache mix (`aggregate(rows).cacheShare` → `mixFromCounts`, falling back to the one shared `DEFAULT_MIX`). Response gains `saved: { usd, potentialUsd, basis, pricedShare }`: `usd` over `appliedTokens`, `potentialUsd` over `maskedTokens` — always both, no branch on the switch.
- **Fix 4 — card** deletes the flat constant (grep-clean in the renderer) and renders `series.saved`: unpriced → "not priced"; negative → `−$X.XX` warn; else `≈ $X.XX` ok; partial detail `≈$Y potential · N% priced`, measured `≈$Y potential`. Two decimals (sub-$1 renders cents, never rounded to `$0`). The inline SVG `−Ntok · ≈ $X est.` uses `saved.usd`, token-only when null.

### Verification results

- PR branch (`multica/BET-1370-optimizer-savings` @ `6a4de6a1`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d…`
  - vitest (renderer/shared): `3768` passed / `7` skipped. Failures: none.
  - node:test (server/shared/scripts): exit `0`, `2929` pass / `0` fail. Failures: none. log sha256: `9c0dfd8c…`
- Base (`origin/main` @ `78de7453`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d…`
  - vitest: `3745` passed / `7` skipped. Failures: none.
  - node:test: exit `0`, `2924` pass / `0` fail. Failures: none. log sha256: `ae12947f…`
- **Conclusion:** `0` failures pre-existing (identical between branches), `0` new failures. This PR adds `+23` vitest tests (17 `optimizerSavings` unit tests covering every pricing rule, 6 new card render-state tests) and `+5` node:test series-integration tests.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

**Base: origin/main @ `78de7453`**

### Manual propagation note — plugin

This is a **manual propagation**: `cp docs/opencode-tools/manta-optimizer-plugin.ts ~/.config/opencode/plugins/manta-optimizer.ts` plus the `manta-auth.ts` helper, then `systemctl --user restart opencode-serve`. Boxes will report without the new `providerID`/`modelID`/`rewarmTokens` fields until then, which the server handles (they default to "unknown" → not directly priceable).

### Known residual (as scoped by the issue — not fixed here)

Context-tiered pricing is deliberately not modelled (opencode's `_normalizePrice` drops `tiers`/`context_over_200K`, as does the catalogue merge). Impact: 0% on standard-context models, up to ~15% understatement on boxes that routinely run above a tier threshold. Left alone per the issue — a half-modelled tier is worse than none.

### Note on the empty-applied case

`savedUsd` returns `usd: 0` with `basis: "measured"` for an empty token set (nothing applied — the optimizer is off), not `usd: null`. This is forced by the issue's own required behaviour — "`usd` is 0 while `potentialUsd` is positive when nothing was applied" and "with it off, usd is 0" — which cannot coexist with "unpriced → null" for the empty set. `null` is reserved for the genuinely unpriced state (tokens exist but none are priceable), rendering "not priced" on the card.
