### PR TITLE
feat(server): delegate pause/resume, per-actor sweep, boot reconciliation (BET-1401)

### DIFF
--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -71,6 +71,10 @@ export const CAP_ERROR =
   "too many background jobs running (5). Do not retry — either wait for one to finish, or do this work yourself.";
 // `running` jobs older than this → `failed "timed out after 30 minutes"`.
 const RUNNING_TIMEOUT_MS = 30 * 60_000;
+// `paused` jobs are kept this long before the sweeper stops them (spec §11.6
+// "[sweep] paused > 7 days → stopped"). A paused job's worktree persists, so
+// the pause window is generous.
+const PAUSE_KEEP_MS = 7 * 24 * 60 * 60_000;
 // Terminal jobs are retained this long, OR until 50 records, whichever bites
 // first. The window + worktree are NEVER removed by the sweeper — only by an
 // explicit delete.
@@ -166,6 +170,16 @@ export function buildCompletionText(job) {
     lines.push(String(job?.result ?? ""));
   }
   return lines.join("\n");
+}
+
+// Mirrors the renderer's isToolStepBoundary (chatUtils.ts) exactly: a tool
+// part that has reached `completed` or `error`. This is the step boundary at
+// which a `pauseRequested` job's session is safely drain-aborted — the current
+// tool has already finished, so no tool's half-written work is lost (spec
+// §11.6-1: "aborted ... at its next completed-tool-part boundary"). Pure.
+export function isToolStepBoundary(part) {
+  if (!part || typeof part !== "object") return false;
+  return part.type === "tool" && (part.state?.status === "completed" || part.state?.status === "error");
 }
 
 // Derive the job name from the first four whitespace-separated words of the
@@ -338,6 +352,8 @@ async function registerJob(
     origin,
     permission,
     link,
+    actor,
+    sweepAllowanceMs,
   },
   deps = {},
 ) {
@@ -432,6 +448,17 @@ async function registerJob(
     // the triggering issue — with no per-feature plumbing. A forge-triggered
     // delegate sets this at dispatch; a user delegate leaves it null.
     link: link ?? null,
+    // Who started the job ("user" default; "cto" for the adaptive-CTO engine).
+    // Persisted so the CTO engine can reason about its own jobs across restarts.
+    actor: actor ?? "user",
+    // Running-sweep allowance (ms) this job gets; absent ⇒ the 30-min default.
+    // The CTO engine passes overnightWindowRemainingMs for its overnight sweep.
+    // Persisted so a resumed or restarted job keeps the same allowance.
+    sweepAllowanceMs: sweepAllowanceMs ?? null,
+    // The permission ruleset the job's session was created with, persisted so a
+    // RESUME (a fresh session in the same worktree) is re-scoped and never
+    // silently falls back to an unscoped session that could prompt the user.
+    permission: permission ?? null,
     status: "running",
     activity: null,
     createdAt: now(),
@@ -832,6 +859,8 @@ export async function startJob(input, deps = {}) {
         origin: "delegate",
         permission: input?.permission,
         link: input?.link,
+        actor: input?.actor,
+        sweepAllowanceMs: input?.sweepAllowanceMs,
       },
       deps,
     );
@@ -1050,6 +1079,24 @@ export async function observeEvent(evt, deps = {}, sawBusy = new Map()) {
     // completed by a stale idle. (Session ids are unique per opencode
     // session, so this is defensive only.)
     return;
+  }
+
+  // Pause (spec §11.6-1): pauseJob set `pauseRequested`; the actual transition
+  // to `paused` happens HERE at the next completed-tool-part boundary — the
+  // current tool has finished, so drain-aborting the session loses no
+  // half-written tool work. The window + worktree + branch are KEPT so
+  // resumeJob can spin up a fresh session in the same worktree later.
+  if (job.pauseRequested) {
+    const boundary =
+      evt.type === "message.part.updated" && isToolStepBoundary(evt?.properties?.part);
+    if (boundary) {
+      await pauseAtBoundary(job, deps);
+      // After the drain-abort the aborting opencode session emits a
+      // MessageAbortedError (ignored) then an idle; by then this job is
+      // `paused`, so those events find no `running` job and are no-ops. Deliberately
+      // do NOT fall through to the completion handlers below.
+      return;
+    }
   }
 
   if (evt.type === "session.error") {
@@ -1412,16 +1459,29 @@ export async function sweepDelegateJobs(deps = {}) {
 
     const transitioned = [];
     for (const job of jobs) {
-      if (
-        job.status === "running" &&
-        job.startedAt != null &&
-        nowMs - job.startedAt > RUNNING_TIMEOUT_MS
-      ) {
-        transitioned.push(job);
+      if (job.status === "running" && job.startedAt != null) {
+        // Per-job running-sweep allowance: default 30 min, or the caller's
+        // sweepAllowanceMs (spec §11.6-4 — CTO overnight jobs pass
+        // overnightWindowRemainingMs). User-started jobs keep the 30-min rule.
+        const allowance = job.sweepAllowanceMs ?? RUNNING_TIMEOUT_MS;
+        if (nowMs - job.startedAt > allowance) {
+          transitioned.push({ job, allowance });
+        }
       }
     }
 
-    if (transitioned.length === 0 && orphaned.length === 0) {
+    // spec §11.6: `paused` jobs older than 7 days → `stopped` (terminal, with
+    // the same keep-on-dirty cleanup). Silent: the job has been idle for a week
+    // and the parent session is likely long gone, so no completion is
+    // delivered — matching how a long-stopped background run fades out.
+    const pausedExpired = [];
+    for (const job of jobs) {
+      if (job.status === "paused" && job.pausedAt != null && nowMs - job.pausedAt > PAUSE_KEEP_MS) {
+        pausedExpired.push(job);
+      }
+    }
+
+    if (transitioned.length === 0 && orphaned.length === 0 && pausedExpired.length === 0) {
       await persistRetention({ load, save }, nowMs);
       return;
     }
@@ -1435,14 +1495,65 @@ export async function sweepDelegateJobs(deps = {}) {
       await stopJob(job.id, { load, save, publish, deliver, abortSession, now, killWindow: deps.killWindow, gitRemoveWorktree: deps.gitRemoveWorktree });
     }
     // Timed-out jobs → failed. Pass the FULL deps so finishJob's terminal
-    // cleanup (killWindow + gitRemoveWorktree) actually runs.
-    for (const job of transitioned) {
-      await finishJob(job, "failed", "timed out after 30 minutes", deps, new Map());
+    // cleanup (killWindow + gitRemoveWorktree) actually runs. The error
+    // reflects the job's own allowance, so the default path stays byte-for-byte
+    // the legacy "timed out after 30 minutes".
+    for (const { job, allowance } of transitioned) {
+      const mins = Math.round(allowance / 60_000);
+      await finishJob(job, "failed", `timed out after ${mins} minutes`, deps, new Map());
+    }
+    // Paused-expired jobs → stopped.
+    for (const job of pausedExpired) {
+      await stopExpiredPausedJob(job, {
+        load, save, publish, now,
+        killWindow: deps.killWindow,
+        gitRemoveWorktree: deps.gitRemoveWorktree,
+      });
     }
     await persistRetention({ load, save }, nowMs);
   } catch (e) {
     console.warn("[delegate] sweep failed:", e?.message ?? e);
   }
+}
+
+/**
+ * Terminal transition for a `paused` job that exceeded PAUSE_KEEP_MS: mark it
+ * `stopped` and run the standard keep-on-dirty terminal cleanup (the dirty
+ * worktree survives; the record is retained via the cleanedUp=false stamp).
+ */
+async function stopExpiredPausedJob(job, deps = {}) {
+  const { load = loadJobs, save = saveJobs, publish, now = () => Date.now(), killWindow, gitRemoveWorktree } = deps;
+  return jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === job.id);
+    if (idx === -1) return;
+    const live = jobs[idx];
+    if (live.status !== "paused") return; // a writer already resumed/stopped it
+    const stopped = {
+      ...live,
+      status: "stopped",
+      error: "paused for over 7 days, stopped",
+      finishedAt: now(),
+    };
+    jobs[idx] = stopped;
+    await save(jobs);
+    publish?.({ kind: "delegate.updated", payload: { id: stopped.id, status: "stopped" } });
+    let cleanedUp = false;
+    try {
+      const res = await cleanupTerminalJob(stopped, { killWindow, gitRemoveWorktree });
+      cleanedUp = !!res.cleanedUp;
+    } catch (e) {
+      console.warn(`[delegate] paused-expiry cleanup failed for ${job.id}:`, e?.message ?? e);
+    }
+    {
+      const jobs2 = await load();
+      const i2 = jobs2.findIndex((j) => j.id === job.id);
+      if (i2 !== -1) {
+        jobs2[i2] = { ...jobs2[i2], cleanedUp };
+        await save(jobs2);
+      }
+    }
+  });
 }
 
 // Retention prune under the jobs-store lock: re-read the store fresh so the
@@ -1635,6 +1746,316 @@ export async function deleteJob(id, deps = {}) {
 }
 
 // ---------------------------------------------------------------------------
+// Pausing, resuming, reconciliation (spec §11.6)
+//
+// `paused` is a distinct, non-terminal state. A paused job keeps its window,
+// worktree and branch; only its opencode child session is aborted. Paused jobs
+// do NOT count against the global running cap (MAX_RUNNING_JOBS counts only
+// `running`), so parking a job frees a slot while keeping its work intact.
+//
+// pause → at the next completed-tool-part boundary, the child session is
+//   drain-aborted (see observeEvent) and the job flips to `paused`.
+// resume → a FRESH opencode session is started in the SAME worktree/branch
+//   (never a new worktree), re-acquiring a cap slot like a fresh start, and
+//   seeded with the original prompt plus git log / git status / last progress.
+// ---------------------------------------------------------------------------
+
+/**
+ * Request a pause. Only flags the job — the actual transition to `paused`
+ * happens in observeEvent at the job's next completed-tool-part boundary, so
+ * an in-flight tool is never interrupted mid-write. Idempotent for a running
+ * job (re-sets the flag).
+ */
+export async function pauseJob(id, deps = {}) {
+  const { load = loadJobs, save = saveJobs, publish } = deps;
+  return jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === id);
+    if (idx === -1) return { ok: false, error: "not found" };
+    const job = jobs[idx];
+    if (job.status !== "running") {
+      return { ok: false, error: "job not running", status: job.status };
+    }
+    const updated = { ...job, pauseRequested: true };
+    jobs[idx] = updated;
+    await save(jobs);
+    // Status stays "running" until pauseAtBoundary flips it to `paused`; the
+    // flag is what observeEvent acts on.
+    publish?.({
+      kind: "delegate.updated",
+      payload: { id: updated.id, status: updated.status, pauseRequested: true },
+    });
+    return { ok: true, job: updated };
+  });
+}
+
+/**
+ * The drain-abort + state flip that completes a pause request, run by
+ * observeEvent at a completed-tool-part boundary. The window + worktree +
+ * branch are deliberately KEPT (resumeJob reuses them).
+ */
+async function pauseAtBoundary(job, deps = {}) {
+  const {
+    load = loadJobs,
+    save = saveJobs,
+    publish,
+    abortSession,
+    now = () => Date.now(),
+  } = deps;
+  if (abortSession && job.childSessionID) {
+    try {
+      await abortSession(job.childSessionID);
+    } catch (e) {
+      console.warn(`[delegate] pause abortSession failed for ${job.id}:`, e?.message ?? e);
+    }
+  }
+  // Under the jobs-store lock: re-read so a concurrent writer that already
+  // resumed/stopped this job is not clobbered.
+  return jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === job.id);
+    if (idx === -1) return { ok: true };
+    const live = jobs[idx];
+    if (live.status !== "running" || !live.pauseRequested) return { ok: true };
+    const paused = { ...live, status: "paused", pauseRequested: false, pausedAt: now() };
+    jobs[idx] = paused;
+    await save(jobs);
+    publish?.({
+      kind: "delegate.updated",
+      payload: { id: paused.id, status: "paused" },
+    });
+    return { ok: true, job: paused };
+  });
+}
+
+/**
+ * @returns {Promise<number>} the box-wide count of currently `running` jobs.
+ * Paused jobs are excluded (they do not consume a cap slot). Exposed for the
+ * CTO engine's own sub-cap accounting, which needs the global running read.
+ */
+export async function runningJobCount(deps = {}) {
+  const { load = loadJobs } = deps;
+  const jobs = await load();
+  return jobs.filter((j) => j.status === "running").length;
+}
+
+/**
+ * Build the opening prompt for a RESUME: the original prompt plus context that
+ * lets a fresh session pick up where the aborted one left off in the SAME
+ * worktree/branch — the last ~20 commits, the porcelain status, and the job's
+ * last progress report (read from the OLD child session, before it is replaced).
+ */
+async function buildResumePrompt(job, deps, childSessionID) {
+  const { gitRun, readProgress } = deps;
+  const blocks = [String(job.prompt ?? "").trim()];
+  if (job.worktree && gitRun) {
+    try {
+      const { stdout } = await gitRun(["-C", job.worktree, "log", "--oneline", "-20"]);
+      // trimEnd (NOT trim): porcelain-style output preserves a meaningful
+      // leading column, and the log is a list we never want right-padded.
+      const log = String(stdout ?? "").trimEnd();
+      blocks.push(`Recent commit history (branch ${job.branch ?? job.worktree}):\n${log || "(no commits yet)"}`);
+    } catch {
+      /* best-effort */
+    }
+    try {
+      const { stdout } = await gitRun(["-C", job.worktree, "status", "--porcelain"]);
+      // trimEnd, not trim: git status --porcelain uses a leading two-column
+      // status (index/worktree) whose first character can be a space — trimming
+      // the head would silently corrupt the per-file status of the first entry.
+      const st = String(stdout ?? "").trimEnd();
+      blocks.push(`Working tree status:\n${st || "(clean)"}`);
+    } catch {
+      /* best-effort */
+    }
+  }
+  if (readProgress && childSessionID) {
+    try {
+      const rec = await readProgress(childSessionID);
+      if (rec) {
+        const bits = [];
+        if (rec.label) bits.push(String(rec.label));
+        if (rec.step != null) {
+          const total = rec.total != null ? ` of ${rec.total}` : "";
+          bits.push(`step ${rec.step}${total}`);
+        }
+        if (rec.state) bits.push(String(rec.state));
+        if (rec.detail) bits.push(String(rec.detail));
+        blocks.push(`Last progress report:\n${bits.length ? bits.join(" — ") : "(none)"}`);
+      }
+    } catch {
+      /* best-effort */
+    }
+  }
+  return blocks.filter((b) => b && b.trim()).join("\n\n---\n\n");
+}
+
+/**
+ * Resume a paused job: start a FRESH opencode session in the SAME worktree +
+ * branch, re-acquiring a cap slot like a fresh start, and deliver the resume
+ * context. If the cap is full the job stays `paused` and the call is retriable
+ * ({ok:false, error:CAP_ERROR, retriable:true}).
+ */
+export async function resumeJob(id, deps = {}) {
+  const {
+    load = loadJobs,
+    save = saveJobs,
+    publish,
+    newWindow,
+    stampOwner,
+    killWindow,
+    listProjects,
+    deliver,
+    now = () => Date.now(),
+  } = deps;
+
+  const reg = await jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    const idx = jobs.findIndex((j) => j.id === id);
+    if (idx === -1) return { ok: false, error: "not found" };
+    const job = jobs[idx];
+    if (job.status !== "paused") {
+      return { ok: false, error: "job not paused", status: job.status };
+    }
+    // Re-acquire a cap slot like a fresh start; `paused` is not counted by the
+    // cap, but the resumed job needs a free slot to run. Cap full → stay
+    // paused and let the caller retry.
+    const running = jobs.filter((j) => j.status === "running").length;
+    if (running >= MAX_RUNNING_JOBS) {
+      return { ok: false, error: CAP_ERROR, retriable: true };
+    }
+
+    const oldChildSessionID = job.childSessionID;
+    const oldWindow = { sessionName: job.tmuxSession, windowIndex: job.windowIndex };
+    let newChildSessionID = null;
+    let newWindowIndex = null;
+    let ownerSession = null;
+    try {
+      const owner = resolveOwner(await listProjects(), job.parentSessionID);
+      if (!owner) throw new Error(`could not resolve the tmux session owning ${job.parentSessionID}`);
+      ownerSession = owner.tmuxSession;
+      const cwd = job.worktree || job.parentDirectory;
+      const created = await newWindow({
+        sessionName: ownerSession,
+        windowName: job.name,
+        cwd: cwd || null,
+        chatMode: true,
+        existingSessionId: undefined,
+        worktreePath: job.worktree,
+        oc: deps.oc,
+        permission: job.permission,
+      });
+      newChildSessionID = created.sessionId ?? null;
+      newWindowIndex = created.windowIndex ?? null;
+    } catch (e) {
+      return { ok: false, error: String(e?.message ?? e) };
+    }
+    if (!newChildSessionID) {
+      return { ok: false, error: "could not create a session to resume into" };
+    }
+
+    // Advisory owner stamp on the fresh window (best-effort, mirrors
+    // registerJob's BET-1377 stamp).
+    if (stampOwner && newWindowIndex != null) {
+      try {
+        await stampOwner(ownerSession, newWindowIndex, "job");
+      } catch {
+        /* best-effort */
+      }
+    }
+    // Best-effort remove the OLD aborted window; the worktree is what persists.
+    if (killWindow && oldWindow.sessionName != null && oldWindow.windowIndex != null) {
+      try {
+        await killWindow(oldWindow);
+      } catch (e) {
+        console.warn(`[delegate] resume killWindow failed for ${id}:`, e?.message ?? e);
+      }
+    }
+
+    const updated = {
+      ...job,
+      status: "running",
+      childSessionID: newChildSessionID,
+      tmuxSession: ownerSession ?? job.tmuxSession,
+      windowIndex: newWindowIndex ?? job.windowIndex,
+      pauseRequested: false,
+      pausedAt: null,
+      // Reset the running-timeout clock: a resumed job re-acquires a cap slot
+      // AND a fresh allowance window "like a fresh start" — otherwise a job
+      // paused for days would trip the running-sweep on its first tick back.
+      startedAt: now(),
+    };
+    jobs[idx] = updated;
+    await save(jobs);
+    publish?.({
+      kind: "delegate.updated",
+      payload: { id: updated.id, status: "running" },
+    });
+    return { ok: true, job: updated, oldChildSessionID };
+  });
+
+  if (!reg.ok) return reg;
+  // Build + deliver the resume prompt to the fresh session. The progress read
+  // targets the OLD (aborted) child session, captured before the record's
+  // childSessionID was overwritten.
+  const resumeText = buildJobPrompt({
+    prompt: await buildResumePrompt(reg.job, deps, reg.oldChildSessionID),
+    worktree: reg.job.worktree,
+    branch: reg.job.branch,
+  });
+  if (deliver) {
+    try {
+      await deliver({ sessionId: reg.job.childSessionID, text: resumeText });
+    } catch (e) {
+      console.warn(`[delegate] resume prompt delivery failed for ${id}:`, e?.message ?? e);
+    }
+  }
+  return { ok: true, job: reg.job };
+}
+
+// ---------------------------------------------------------------------------
+// Restart reconciliation (spec §11.6-5)
+//
+// A job recorded `running` whose child session no longer exists (the box
+// restarted; opencode sessions are not durable across a reboot) is parked as
+// `paused` — its worktree + branch persist, so it can be resumed. This runs
+// once at delegate-engine boot. Exported for the CTO engine (C3) to call too.
+// ---------------------------------------------------------------------------
+
+/**
+ * @returns {Promise<{ok:true, reconciled:number}>} count of jobs flipped
+ * running → paused. Skips reconciliation when `sessionExists` is absent.
+ */
+export async function reconcileJobsOnBoot(deps = {}) {
+  const { load = loadJobs, save = saveJobs, publish, sessionExists, now = () => Date.now() } = deps;
+  if (typeof sessionExists !== "function") return { ok: true, reconciled: 0 };
+  return jobsLock.runExclusive(async () => {
+    const jobs = await load();
+    let reconciled = 0;
+    const next = [];
+    for (const job of jobs) {
+      if (job.status === "running" && job.childSessionID) {
+        let alive = true;
+        try {
+          alive = await sessionExists(job.childSessionID);
+        } catch {
+          alive = true; // transient blip → don't park a healthy job
+        }
+        if (!alive) {
+          next.push({ ...job, status: "paused", pauseRequested: false, pausedAt: now() });
+          publish?.({ kind: "delegate.updated", payload: { id: job.id, status: "paused" } });
+          reconciled += 1;
+          continue;
+        }
+      }
+      next.push(job);
+    }
+    if (reconciled > 0) await save(next);
+    return { ok: true, reconciled };
+  });
+}
+
+// ---------------------------------------------------------------------------
 // Pre-flight approval (BET-418 §A)
 //
 // When trust mode is OFF and the model declared `tools`, the `delegate` call
@@ -1763,6 +2184,10 @@ export function createDelegateEngine(deps) {
     startJobWithApproval,
     stopJob: (id) => stopJob(id, deps),
     deleteJob: (id) => deleteJob(id, deps),
+    pauseJob: (id) => pauseJob(id, deps),
+    resumeJob: (id) => resumeJob(id, deps),
+    runningJobCount: () => runningJobCount(deps),
+    reconcileJobsOnBoot: () => reconcileJobsOnBoot(deps),
     observeEvent: (evt) => {
       const sid = evt?.properties?.sessionID;
       if (typeof sid !== "string" || !sid) {

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -23,6 +23,11 @@ import {
   tickActivity,
   chooseSubagentModel,
   resolveNamedModel,
+  pauseJob,
+  resumeJob,
+  runningJobCount,
+  reconcileJobsOnBoot,
+  isToolStepBoundary,
 } from "./delegate.mjs";
 import { familyKey } from "../shared/modelGuide.mjs";
 // Per standing rule 9: a routing test may not hand-write a candidate literal.
@@ -2122,4 +2127,222 @@ test("finishJob clears the child's progress record (BET-790)", async () => {
   h.deps.clearProgress = async (sid) => { cleared.push(sid); return { ok: true, deleted: true }; };
   await finishJob(h.jobs[0], "done", null, h.deps, new Map());
   assert.deepEqual(cleared, ["child1"]);
+});
+
+// ----------------------------------------------------------------------------
+// 11. Pause / resume / reconciliation (spec §11.6)
+// ----------------------------------------------------------------------------
+
+test("isToolStepBoundary: true only for tool parts at completed/error", () => {
+  assert.equal(isToolStepBoundary({ type: "tool", state: { status: "completed" } }), true);
+  assert.equal(isToolStepBoundary({ type: "tool", state: { status: "error" } }), true);
+  assert.equal(isToolStepBoundary({ type: "tool", state: { status: "running" } }), false);
+  assert.equal(isToolStepBoundary({ type: "tool", state: { status: "pending" } }), false);
+  assert.equal(isToolStepBoundary({ type: "text", state: { status: "completed" } }), false);
+  assert.equal(isToolStepBoundary({ type: "reasoning", state: { status: "completed" } }), false);
+  assert.equal(isToolStepBoundary(null), false);
+});
+
+test("pauseJob flags a running job but leaves status running (transition at boundary)", async () => {
+  const h = harness([runningObserverJob()]);
+  const res = await pauseJob("j1", h.deps);
+  assert.equal(res.ok, true);
+  assert.equal(h.jobs[0].status, "running");
+  assert.equal(h.jobs[0].pauseRequested, true);
+  const evt = h.published.find((e) => e.kind === "delegate.updated");
+  assert.equal(evt.payload.pauseRequested, true);
+});
+
+test("pauseJob refuses a non-running or missing job", async () => {
+  const h = harness([{ ...runningObserverJob(), id: "done-job", status: "done" }]);
+  const notRunning = await pauseJob("done-job", h.deps);
+  assert.equal(notRunning.ok, false);
+  assert.equal(notRunning.status, "done");
+  assert.equal((await pauseJob("nope", h.deps)).ok, false);
+});
+
+test("pauseJob then a completed-tool-part boundary aborts + pauses, worktree kept", async () => {
+  const h = harness([{
+    ...runningObserverJob(), id: "p1", worktree: "/repo/wt-p", branch: "fix-p",
+  }]);
+  const aborted = [];
+  h.deps.abortSession = async (sid) => { aborted.push(sid); };
+  const sawBusy = new Map();
+  await pauseJob("p1", h.deps);
+  await observeEvent({
+    type: "message.part.updated",
+    properties: { sessionID: "child", part: { type: "tool", state: { status: "completed" } } },
+  }, h.deps, sawBusy);
+  assert.deepEqual(aborted, ["child"]);
+  assert.equal(h.jobs[0].status, "paused");
+  assert.equal(h.jobs[0].pauseRequested, false);
+  assert.equal(h.jobs[0].pausedAt, 1_700_000_000_000);
+  // worktree + branch kept for a later resume
+  assert.equal(h.jobs[0].worktree, "/repo/wt-p");
+  assert.equal(h.jobs[0].branch, "fix-p");
+});
+
+test("a non-boundary tool part does NOT pause a pauseRequested job", async () => {
+  const h = harness([{ ...runningObserverJob(), id: "p2", pauseRequested: true }]);
+  h.deps.abortSession = async () => {};
+  const sawBusy = new Map();
+  await observeEvent({
+    type: "message.part.updated",
+    properties: { sessionID: "child", part: { type: "tool", state: { status: "running" } } },
+  }, h.deps, sawBusy);
+  assert.equal(h.jobs[0].status, "running");
+  assert.equal(h.jobs[0].pauseRequested, true);
+});
+
+test("paused jobs do not count against the running cap (runningJobCount)", async () => {
+  const h = harness([
+    { ...runningObserverJob(), id: "a" },
+    { ...runningObserverJob(), id: "b" },
+    { ...runningObserverJob(), id: "p", status: "paused", pausedAt: 1 },
+  ]);
+  assert.equal(await runningJobCount(h.deps), 2);
+});
+
+test("resumeJob at cap: stays paused, returns retriable CAP_ERROR", async () => {
+  const running = Array.from({ length: MAX_RUNNING_JOBS }, (_, i) =>
+    ({ ...runningObserverJob(), id: `r${i}` }));
+  const paused = {
+    ...runningObserverJob(), id: "paused1", status: "paused", pausedAt: 1,
+    worktree: "/wt", branch: "b",
+  };
+  const h = harness([...running, paused]);
+  h.deps.listProjects = async () => [];
+  const res = await resumeJob("paused1", h.deps);
+  assert.equal(res.ok, false);
+  assert.equal(res.retriable, true);
+  assert.equal(res.error, CAP_ERROR);
+  assert.equal(h.jobs.find((j) => j.id === "paused1").status, "paused");
+});
+
+test("resumeJob refuses to resume a non-paused job", async () => {
+  const h = harness([{ ...runningObserverJob(), id: "running1" }]);
+  const res = await resumeJob("running1", h.deps);
+  assert.equal(res.ok, false);
+  assert.equal(res.error, "job not paused");
+});
+
+test("resumeJob starts a fresh session in the SAME worktree with resume context", async () => {
+  const job = {
+    ...runningObserverJob(), id: "paused1", status: "paused", pausedAt: 1,
+    worktree: "/repo/wt-r", branch: "fix-r", parentSessionID: "parent",
+  };
+  const h = harness([job]);
+  const parentWin = { index: 1, opencodeSessionId: "parent" };
+  h.deps.listProjects = async () => [{ tmuxSession: "s", windows: [parentWin] }];
+  const newWindows = [];
+  h.deps.newWindow = async (input) => {
+    newWindows.push(input);
+    return { sessionId: "child-resumed", windowIndex: 9 };
+  };
+  const killed = [];
+  h.deps.killWindow = async (input) => { killed.push(input); };
+  const stamps = [];
+  h.deps.stampOwner = async (s, i, o) => { stamps.push({ s, i, o }); };
+  h.deps.readProgress = async () => ({ label: "wiring the handler", step: 3, total: 5 });
+  h.deps.gitRun = async (args) => {
+    if (args.includes("log")) return { stdout: "abc123 fix thing\n" };
+    if (args.includes("status")) return { stdout: " M src/x.js\n" };
+    return { stdout: "" };
+  };
+
+  const res = await resumeJob("paused1", h.deps);
+  assert.equal(res.ok, true);
+  assert.equal(res.job.status, "running");
+  assert.equal(res.job.childSessionID, "child-resumed");
+  assert.equal(res.job.windowIndex, 9);
+  assert.equal(res.job.pauseRequested, false);
+  assert.equal(res.job.pausedAt, null);
+  // fresh startedAt resets the running-timeout window ("like a fresh start")
+  assert.equal(res.job.startedAt, 1_700_000_000_000);
+
+  // SAME worktree reused (no new gitAddWorktree), old window killed, owner stamped
+  assert.equal(newWindows[0].cwd, "/repo/wt-r");
+  assert.equal(newWindows[0].worktreePath, "/repo/wt-r");
+  assert.equal(newWindows[0].existingSessionId, undefined);
+  assert.deepEqual(killed, [{ sessionName: "s", windowIndex: 1 }]);
+  assert.deepEqual(stamps, [{ s: "s", i: 9, o: "job" }]);
+
+  // delivered resume context: original prompt + git log + status + progress
+  assert.equal(h.delivered.length, 1);
+  assert.equal(h.delivered[0].sessionId, "child-resumed");
+  assert.match(h.delivered[0].text, /^p/); // original prompt leads
+  assert.ok(h.delivered[0].text.includes("abc123 fix thing"));
+  assert.ok(h.delivered[0].text.includes(" M src/x.js"));
+  assert.ok(h.delivered[0].text.includes("step 3 of 5"));
+});
+
+test("sweeper uses the job's sweepAllowanceMs (CTO overnight), not the 30-min default", async () => {
+  const started = 1_700_000_000_000;
+  const h = harness([{
+    ...runningObserverJob(), id: "cto", startedAt: started, actor: "cto",
+    sweepAllowanceMs: 24 * 60 * 60_000,
+  }], started + 31 * 60_000);
+  h.deps.gitRun = async () => ({ stdout: "" });
+  await sweepDelegateJobs(h.deps);
+  assert.equal(h.jobs[0].status, "running");
+  assert.equal(h.delivered.length, 0);
+});
+
+test("sweeper fails a job past its sweepAllowanceMs with an allowance-accurate message", async () => {
+  const started = 1_700_000_000_000;
+  const h = harness([{
+    ...runningObserverJob(), id: "cto2", startedAt: started, actor: "cto",
+    sweepAllowanceMs: 5 * 60_000,
+  }], started + 10 * 60_000);
+  h.deps.gitRun = async () => ({ stdout: "" });
+  await sweepDelegateJobs(h.deps);
+  assert.equal(h.jobs[0].status, "failed");
+  assert.equal(h.jobs[0].error, "timed out after 5 minutes");
+});
+
+test("sweeper stops a paused job older than 7 days", async () => {
+  const pausedAt = 1_700_000_000_000;
+  const h = harness([{
+    ...runningObserverJob(), id: "oldpaused", status: "paused", pausedAt,
+    worktree: "/wt-old", branch: "b", tmuxSession: "s", windowIndex: 3,
+  }], pausedAt + 7 * 24 * 60 * 60_000 + 1);
+  h.deps.gitRemoveWorktree = async () => ({ removed: true });
+  await sweepDelegateJobs(h.deps);
+  const j = h.jobs[0];
+  assert.equal(j.status, "stopped");
+  assert.equal(j.error, "paused for over 7 days, stopped");
+  assert.equal(j.cleanedUp, true);
+});
+
+test("sweeper leaves a young paused job paused", async () => {
+  const pausedAt = 1_700_000_000_000;
+  const h = harness([{ ...runningObserverJob(), id: "youngpa", status: "paused", pausedAt }],
+    pausedAt + 60_000);
+  await sweepDelegateJobs(h.deps);
+  assert.equal(h.jobs[0].status, "paused");
+});
+
+test("reconcileJobsOnBoot parks a running job whose session is gone as paused", async () => {
+  const h = harness([{ ...runningObserverJob(), id: "gone", childSessionID: "dead" }]);
+  h.deps.sessionExists = async (sid) => sid !== "dead";
+  const res = await reconcileJobsOnBoot(h.deps);
+  assert.equal(res.reconciled, 1);
+  assert.equal(h.jobs[0].status, "paused");
+  assert.equal(h.jobs[0].pausedAt, 1_700_000_000_000);
+  assert.equal(h.jobs[0].worktree, null); // non-worktree job still parks
+});
+
+test("reconcileJobsOnBoot leaves a live running job untouched", async () => {
+  const h = harness([{ ...runningObserverJob(), id: "alive", childSessionID: "child" }]);
+  h.deps.sessionExists = async () => true;
+  const res = await reconcileJobsOnBoot(h.deps);
+  assert.equal(res.reconciled, 0);
+  assert.equal(h.jobs[0].status, "running");
+});
+
+test("reconcileJobsOnBoot is a no-op without a sessionExists dep", async () => {
+  const h = harness([{ ...runningObserverJob(), id: "x" }]);
+  const res = await reconcileJobsOnBoot(h.deps);
+  assert.equal(res.reconciled, 0);
+  assert.equal(h.jobs[0].status, "running");
 });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -682,6 +682,14 @@ const delegateEngine = createDelegateEngine({
   readProgress: (sid) => readProgressRecord(sid),
   clearProgress: (sid) => clearProgress(sid),
 });
+// Restart reconciliation (spec §11.6-5): a job recorded `running` whose opencode
+// child session did not survive the box restart is parked as `paused` (its
+// worktree + branch persist, so it can be resumed). Best-effort, non-blocking;
+// a healthy box reconciles nothing. The CTO engine also calls this on its own
+// boot (C3).
+delegateEngine.reconcileJobsOnBoot().catch((e) =>
+  console.warn("[delegate] boot reconciliation failed:", e?.message ?? e),
+);
 // eslint-disable-next-line no-unused-vars
 const { stop: stopDelegateSweeper } = delegateEngine.startSweeper();
 // eslint-disable-next-line no-unused-vars


### PR DESCRIPTION
Implements delegate-engine **pause / resume / sweep / boot-reconciliation** per `docs/adaptive-cto-spec.md` §11.6 (decomposition C2).

## What changed

**`src/server/delegate.mjs`**
- New `paused` (non-terminal) status.
- `pauseJob(id)` — sets a `pauseRequested` flag; the actual drain-abort + `running → paused` transition happens in `observeEvent` at the job's next **completed-tool-part boundary** (`isToolStepBoundary`, mirrors the renderer). Window + worktree + branch are kept.
- `resumeJob(id)` — starts a **fresh session in the SAME worktree/branch** (never a new worktree), re-acquiring a cap slot like a fresh start; cap full → stays `paused`, returns `{retriable:true, error:CAP_ERROR}`. Resets `startedAt` so a resumed job gets a fresh running-sweep window. Best-effort: re-stamps the window owner, kills the old dead window, re-applies the job's persisted permission ruleset (so the resumed session never falls back to an unscoped session that could prompt the user). Delivers resume context = original prompt + `git log --oneline -20` + `git status --porcelain` + last progress report.
- `runningJobCount(deps)` — exposed running-count read for the CTO engine's own sub-cap (paused excluded; paused does NOT count against `MAX_RUNNING_JOBS`).
- `reconcileJobsOnBoot(deps)` — a `running` job whose child session no longer exists is parked `paused` (worktree persists). Exported; called at engine boot (see index.mjs) and available to the CTO engine (C3).
- `startJob` now accepts optional `{actor, sweepAllowanceMs}` (additive; existing callers unchanged). Both persisted so resume/restart keep them.
- Sweeper: running-timeout now honors the job's own `sweepAllowanceMs` (default stays 30 min → byte-identical "timed out after 30 minutes" for user jobs; a custom allowance yields an allowance-accurate message). New `paused > PAUSE_KEEP_MS (7 days) → stopped` (terminal, keep-on-dirty cleanup).
- New helper `isToolStepBoundary(part)` exported for tests.

**`src/server/index.mjs`**
- Calls `delegateEngine.reconcileJobsOnBoot()` once at engine boot (best-effort, non-blocking).

**`src/server/delegate.test.mjs`**
- 16 new tests covering: `isToolStepBoundary`, pause flag, pause refusal, pause-at-boundary (abort ordering + worktree kept), non-boundary no-op, cap excludes paused, resume cap-full retriable, resume non-paused refusal, resume same-worktree + resume-context assembly, sweepAllowanceMs honored, allowance-accurate failure, paused-7d → stopped, young-paused kept, boot reconciliation (gone/live/absent-dep).

## Out of scope (unchanged)
Overnight scheduler (C3), veto windows, any UI/REST surface. Completion/`observeEvent` machinery unchanged beyond the pause boundary check.

## Files changed
`src/server/delegate.mjs`, `src/server/delegate.test.mjs`, `src/server/index.mjs` (boot reconcile call only).

**Base: origin/main @ `ed973dd0`**

**Verification results:**
- PR branch (`multica/BET-1401-delegate-pause-resume` @ `10226485`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `2950` pass / `0` fail / `0` skip. Failures: none. log sha256: `5efd3176cbf3429e3ca74d76bf076c80b1aa18fb9f36d1ccf9c2b695dcdd733b`
- Base (`main` @ `ed973dd0`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `2934` pass / `0` fail / `0` skip. Failures: none. log sha256: `20ff2e1eacc3fcf186303140e2e705ddc79c148263ae65f0bd50c0c16e9d5e86`
- **Conclusion:** `0` test failures on both branches; this PR adds `16` tests (all passing), `0` new failures.
