### PR TITLE
chore(release): bump iOS marketing version to 1.0.23

### DIFF
--- a/mobile/native/project.yml
+++ b/mobile/native/project.yml
@@ -95,7 +95,7 @@ targets:
         INFOPLIST_KEY_UILaunchScreen_Generation: YES
         INFOPLIST_KEY_UISupportedInterfaceOrientations: "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight"
         TARGETED_DEVICE_FAMILY: "1,2"
-        MARKETING_VERSION: "1.0.22"
+        MARKETING_VERSION: "1.0.23"
         CURRENT_PROJECT_VERSION: "1"
         CODE_SIGN_STYLE: Automatic
         SWIFT_EMIT_LOC_STRINGS: YES


### PR DESCRIPTION
Bump MARKETING_VERSION to 1.0.23 so the iOS TestFlight release picks up the latest main (includes the private-server pairing transport fix, PR #1377). On merge the `ios-release-tag` workflow auto-tags `ios-v1.0.23` and triggers Codemagic → TestFlight.