### PR TITLE
feat(server): CTO stores + schema-version harness (BET-1375)

### DIFF
--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -1,0 +1,502 @@
+// ctoStores.mjs — the durable storage layer for the Adaptive CTO (BET-1375).
+//
+// Everything nests under `~/.manta/cto/` and resolves through `statePath()`,
+// so the test-sandbox rule (AGENTS.md / paths.mjs) covers every store — a
+// forgotten injection writes into the throwaway MANTA_STATE_HOME, never the
+// live box. Spec: docs/adaptive-cto-spec.md §13.1 (stores), §13.2 (schema
+// versioning), §6.3 (archive cap), §3.2 (journal store lives in this layer).
+//
+// One accessor per store, all sharing three conventions:
+//   - JSON stores write atomically via the shared jsonStore pattern (temp
+//     file + rename), mode 0600.
+//   - Every JSON payload carries `v` (current = CURRENT_VERSION); loads run
+//     the store's payload through migrateStore() (§13.2). A payload with a
+//     `v` NEWER than the supported version throws loudly naming the store —
+//     never silently truncates. A payload with no `v` is treated as v1.
+//   - Retention is a set of PURE functions (tested boundary-exact) wired to
+//     I/O by `createCtoStoreSweep` / `startCtoStoreSweeper`, which copy the
+//     inFlight-guard + timer.unref() shape from servePage.mjs.
+//
+// DELIBERATELY NOT in scope: engine timers, any consumer of these stores,
+// probe YAML validation, any UI, and wiring into index.mjs. Leaf payload
+// shapes (what lives inside inbox/facts/cards/...) are refined by the engine
+// issues that consume them; this layer only fixes the durability contract.
+
+import { readFileSync, existsSync, readdirSync } from "node:fs";
+import { readFile, writeFile, appendFile, mkdir, rm, readdir } from "node:fs/promises";
+import { dirname, join } from "node:path";
+import { parse as parseYaml, stringify as stringifyYaml } from "yaml";
+import { statePath } from "../shared/paths.mjs";
+import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { startPoller } from "./startPoller.mjs";
+
+const MODE = 0o600;
+const DAY_MS = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// Path root — every store hangs off `~/.manta/cto/` via statePath().
+// ---------------------------------------------------------------------------
+
+export function ctoPath(...parts) {
+  return statePath("cto", ...parts);
+}
+
+// ---------------------------------------------------------------------------
+// Schema versioning (§13.2)
+// ---------------------------------------------------------------------------
+
+export const CURRENT_VERSION = 1;
+
+// Forward-migration table: `{ [fromVersion]: (payload) => payload }`. Migrates
+// a payload one version at a time from its stored `v` up to CURRENT_VERSION.
+// Empty today (v1 is the first schema); later schema bumps register a step
+// here plus a unit test. The harness is what this issue ships.
+export const MIGRATIONS = Object.freeze({});
+
+/**
+ * Validate + forward-migrate a store payload. Returns the (possibly migrated)
+ * payload. Throws naming the store (per §13.2) when:
+ *   - `v` is newer than CURRENT_VERSION (never silently truncate), or
+ *   - `v` is present but not a positive integer, or
+ *   - a migration step is missing for a stored version.
+ * A payload with no `v` is treated as v1.
+ */
+export function migrateStore(name, data) {
+  if (data === null || data === undefined) return data;
+  const rawV = data && typeof data === "object" && "v" in data ? data.v : 1;
+  if (typeof rawV !== "number" || !Number.isInteger(rawV) || rawV < 1) {
+    throw new Error(
+      `store "${name}" has invalid schema version ${JSON.stringify(data.v)} (expected a positive integer)`,
+    );
+  }
+  if (rawV > CURRENT_VERSION) {
+    throw new Error(
+      `store "${name}" has schema version ${rawV}, which is newer than the supported version ` +
+        `${CURRENT_VERSION} — refusing to read (never silently truncate)`,
+    );
+  }
+  let migrated = data;
+  for (let v = rawV; v < CURRENT_VERSION; v++) {
+    const step = MIGRATIONS[v];
+    if (!step) {
+      throw new Error(`store "${name}": no migration path from schema version ${v}`);
+    }
+    migrated = step(migrated);
+  }
+  return migrated;
+}
+
+// ---------------------------------------------------------------------------
+// Small shared helpers
+// ---------------------------------------------------------------------------
+
+async function readJson(path, fallback) {
+  try {
+    return JSON.parse(await readFile(path, "utf-8"));
+  } catch {
+    return fallback;
+  }
+}
+
+function defaultPayload() {
+  return { v: CURRENT_VERSION };
+}
+
+// Blocks path traversal through user-supplied store ids (project, tool,
+// rollup/digest id). Rollups validate `level` separately against the closed set.
+function assertSafeName(value, label) {
+  if (typeof value !== "string" || value.length === 0) {
+    throw new Error(`${label} must be a non-empty string`);
+  }
+  if (/[/\\]/.test(value) || value === "." || value === "..") {
+    throw new Error(`${label} "${value}" is not allowed in a store path`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Single-file JSON stores (atomic jsonStore writes, mode 0600)
+// ---------------------------------------------------------------------------
+
+function createCtoJsonStore(name, path) {
+  return {
+    name,
+    path,
+    migrate: (data) => migrateStore(name, data),
+    loadSync: () => {
+      const raw = readJsonSync(path, null);
+      return raw === null ? defaultPayload() : migrateStore(name, raw);
+    },
+    load: async () => {
+      const raw = await readJson(path, null);
+      return raw === null ? defaultPayload() : migrateStore(name, raw);
+    },
+    save: async (data) => {
+      await writeJsonAtomic(path, JSON.stringify({ ...data, v: CURRENT_VERSION }, null, 2), {
+        mode: MODE,
+      });
+    },
+  };
+}
+
+export const inboxStore = createCtoJsonStore("inbox", ctoPath("inbox.json"));
+export const cardsStore = createCtoJsonStore("cards", ctoPath("cards.json"));
+export const profileStore = createCtoJsonStore("profile", ctoPath("profile.json"));
+export const journalStore = createCtoJsonStore("journal", ctoPath("journal.json"));
+export const toolRegistryStore = createCtoJsonStore("tool-registry", ctoPath("tool-registry.json"));
+export const toolUsageStore = createCtoJsonStore("tool-usage", ctoPath("tool-usage.json"));
+export const verdictsStore = createCtoJsonStore("verdicts", ctoPath("verdicts.json"));
+export const budgetStore = createCtoJsonStore("budget", ctoPath("budget.json"));
+export const engineStateStore = createCtoJsonStore("engine-state", ctoPath("engine-state.json"));
+
+// ---------------------------------------------------------------------------
+// Single-level directory JSON stores: one file per id, e.g. `facts/<project>.json`
+// ---------------------------------------------------------------------------
+
+function createDirJsonStore(name, dirPart) {
+  const filePath = (id) => ctoPath(dirPart, `${id}.json`);
+  return {
+    name,
+    dir: ctoPath(dirPart),
+    pathFor: (id) => {
+      assertSafeName(id, name);
+      return filePath(id);
+    },
+    migrate: (data) => migrateStore(name, data),
+    loadSync: (id) => {
+      assertSafeName(id, name);
+      const raw = readJsonSync(filePath(id), null);
+      return raw === null ? defaultPayload() : migrateStore(name, raw);
+    },
+    load: async (id) => {
+      assertSafeName(id, name);
+      const raw = await readJson(filePath(id), null);
+      return raw === null ? defaultPayload() : migrateStore(name, raw);
+    },
+    save: async (id, data) => {
+      assertSafeName(id, name);
+      await writeJsonAtomic(filePath(id), JSON.stringify({ ...data, v: CURRENT_VERSION }, null, 2), {
+        mode: MODE,
+      });
+    },
+  };
+}
+
+export const factsStore = createDirJsonStore("facts", "facts");
+export const factsArchiveStore = createDirJsonStore("facts-archive", "facts-archive");
+export const digestsStore = createDirJsonStore("digests", "digests");
+
+// ---------------------------------------------------------------------------
+// Rollups: `rollups/<hour|day|week>/<id>.json` — one JSON file per rollup.
+// ---------------------------------------------------------------------------
+
+export const ROLLUP_LEVELS = Object.freeze(["hour", "day", "week"]);
+
+export const rollupsStore = {
+  name: "rollups",
+  dir: ctoPath("rollups"),
+  dirFor: (level) => {
+    assertRollupLevel(level);
+    return ctoPath("rollups", level);
+  },
+  pathFor: (level, id) => {
+    assertRollupLevel(level);
+    assertSafeName(id, "rollups");
+    return ctoPath("rollups", level, `${id}.json`);
+  },
+  migrate: (data) => migrateStore("rollups", data),
+  load: async (level, id) => {
+    assertRollupLevel(level);
+    assertSafeName(id, "rollups");
+    const raw = await readJson(ctoPath("rollups", level, `${id}.json`), null);
+    return raw === null ? defaultPayload() : migrateStore("rollups", raw);
+  },
+  save: async (level, id, data) => {
+    assertRollupLevel(level);
+    assertSafeName(id, "rollups");
+    await writeJsonAtomic(
+      ctoPath("rollups", level, `${id}.json`),
+      JSON.stringify({ ...data, v: CURRENT_VERSION }, null, 2),
+      { mode: MODE },
+    );
+  },
+};
+
+function assertRollupLevel(level) {
+  if (!ROLLUP_LEVELS.includes(level)) {
+    throw new Error(`rollups level must be one of ${ROLLUP_LEVELS.join(", ")} (got ${JSON.stringify(level)})`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Ledger: `ledger.jsonl` — append-only, one JSON object per line, fsync not
+// required. Each row carries a `ts` (epoch ms, stamped at append if absent);
+// the reader parses rows and returns those within a time range.
+// ---------------------------------------------------------------------------
+
+export function createLedgerStore({ path = ctoPath("ledger.jsonl"), now = () => Date.now() } = {}) {
+  async function append(entry) {
+    if (entry === null || typeof entry !== "object") {
+      throw new Error("ledger entries must be objects");
+    }
+    const row = { ...entry, ts: entry.ts != null ? entry.ts : now() };
+    await mkdir(dirname(path), { recursive: true });
+    await appendFile(path, JSON.stringify(row) + "\n", { mode: MODE });
+  }
+
+  async function read({ from, to, timeField = "ts" } = {}) {
+    let text;
+    try {
+      text = await readFile(path, "utf-8");
+    } catch {
+      return [];
+    }
+    const rows = [];
+    for (const line of text.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed) continue;
+      try {
+        const row = JSON.parse(trimmed);
+        if (from !== undefined || to !== undefined) {
+          const t = row?.[timeField];
+          if (from !== undefined && (typeof t !== "number" || t < from)) continue;
+          if (to !== undefined && (typeof t !== "number" || t > to)) continue;
+        }
+        rows.push(row);
+      } catch {
+        // Skip malformed lines — the ledger is best-effort.
+      }
+    }
+    return rows;
+  }
+
+  // Rewrites the whole file (used by the retention sweep to drop expired rows).
+  async function rewrite(rows) {
+    const text = rows.map((r) => JSON.stringify(r)).join("\n") + (rows.length ? "\n" : "");
+    await mkdir(dirname(path), { recursive: true });
+    await writeFile(path, text, { mode: MODE });
+  }
+
+  return { name: "ledger", path, append, read, rewrite };
+}
+
+export const ledgerStore = createLedgerStore();
+
+// ---------------------------------------------------------------------------
+// Probes: `probes/<tool>.yaml` — YAML helpers (parse/stringify only; probe
+// validation is a later issue). Reuses the `yaml` package parsing like
+// src/shared/pluginManifest.mjs.
+// ---------------------------------------------------------------------------
+
+export const probesStore = {
+  name: "probes",
+  dir: ctoPath("probes"),
+  pathFor: (tool) => {
+    assertSafeName(tool, "probes");
+    return ctoPath("probes", `${tool}.yaml`);
+  },
+  loadSync: (tool) => {
+    assertSafeName(tool, "probes");
+    try {
+      const parsed = parseYaml(readFileSync(ctoPath("probes", `${tool}.yaml`), "utf-8"));
+      return parsed ?? {};
+    } catch {
+      return {};
+    }
+  },
+  load: async (tool) => {
+    assertSafeName(tool, "probes");
+    try {
+      const parsed = parseYaml(await readFile(ctoPath("probes", `${tool}.yaml`), "utf-8"));
+      return parsed ?? {};
+    } catch {
+      return {};
+    }
+  },
+  save: async (tool, data) => {
+    assertSafeName(tool, "probes");
+    await mkdir(ctoPath("probes"), { recursive: true });
+    await writeFile(ctoPath("probes", `${tool}.yaml`), stringifyYaml(data ?? {}), { mode: MODE });
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Retention (spec §13.1)
+// ---------------------------------------------------------------------------
+
+export const RETENTION_MS = Object.freeze({
+  ledger: 180 * DAY_MS,
+  verdicts: 180 * DAY_MS,
+  "rollups/hour": 14 * DAY_MS,
+  "rollups/day": 120 * DAY_MS,
+  "rollups/week": 2 * 365 * DAY_MS,
+  segments: 30 * DAY_MS,
+});
+
+// facts-archive caps at 10× the 50-fact active cap, oldest dropped (§6.3).
+export const ARCHIVE_CAP = 10 * 50;
+// digests keeps the last 30 generated digests (spec §5.5).
+export const DIGESTS_KEEP = 30;
+
+// True when `ts` (epoch ms) falls outside the [nowMs - retentionMs, nowMs]
+// window — i.e. the entry/file is due for removal. Boundary-exact: an entry
+// exactly at the cutoff is kept.
+export function isExpired(ts, { nowMs, retentionMs }) {
+  return typeof ts === "number" && ts < nowMs - retentionMs;
+}
+
+// Pure filter: split `rows` into `keep` (within retention) and `dropped`.
+export function expireRows(rows, { nowMs, retentionMs, timeField = "ts" } = {}) {
+  const keep = [];
+  const dropped = [];
+  for (const row of rows) {
+    if (isExpired(row?.[timeField], { nowMs, retentionMs })) dropped.push(row);
+    else keep.push(row);
+  }
+  return { keep, dropped };
+}
+
+// Archive cap: keep the `cap` most recent entries (by `timeField`), dropping
+// the oldest. Order-preserving within the kept set (stable).
+export function capArchive(entries, { cap = ARCHIVE_CAP, timeField = "ts" } = {}) {
+  if (entries.length <= cap) return entries;
+  const indexed = entries.map((entry, i) => ({ entry, i }));
+  indexed.sort(
+    (a, b) => (a.entry?.[timeField] ?? 0) - (b.entry?.[timeField] ?? 0) || a.i - b.i,
+  );
+  return indexed
+    .slice(entries.length - cap)
+    .sort((a, b) => a.i - b.i)
+    .map((x) => x.entry);
+}
+
+// ---------------------------------------------------------------------------
+// Sweep wiring (copies the createCleanupSweep shape from servePage.mjs).
+// I/O is the real fs but every path resolves under ctoPath() → the sandbox in
+// tests, so running the sweep in a test never touches a live box.
+// ---------------------------------------------------------------------------
+
+const SWEEP_INTERVAL_MS = 5 * 60 * 1000;
+
+async function listJsonFiles(dir) {
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return [];
+  }
+  return entries
+    .filter((e) => e.isFile() && e.name.endsWith(".json"))
+    .map((e) => e.name);
+}
+
+async function fileTimestamp(filePath) {
+  const raw = await readJson(filePath, null);
+  return raw && typeof raw.ts === "number" ? raw.ts : undefined;
+}
+
+async function sweepLedger(nowMs) {
+  const rows = await ledgerStore.read();
+  if (rows.length === 0) return;
+  const { keep } = expireRows(rows, { nowMs, retentionMs: RETENTION_MS.ledger });
+  if (keep.length !== rows.length) await ledgerStore.rewrite(keep);
+}
+
+async function sweepVerdicts(nowMs) {
+  const payload = await verdictsStore.load();
+  const entries = Array.isArray(payload?.entries) ? payload.entries : [];
+  if (entries.length === 0) return;
+  const { keep } = expireRows(entries, { nowMs, retentionMs: RETENTION_MS.verdicts });
+  if (keep.length !== entries.length) await verdictsStore.save({ ...payload, entries: keep });
+}
+
+async function sweepDirByFileTime(dir, nowMs, retentionMs) {
+  const files = await listJsonFiles(dir);
+  for (const name of files) {
+    const filePath = join(dir, name);
+    const ts = await fileTimestamp(filePath);
+    if (ts !== undefined && isExpired(ts, { nowMs, retentionMs })) {
+      await rm(filePath, { force: true });
+    }
+  }
+}
+
+async function sweepRollups(nowMs) {
+  for (const level of ROLLUP_LEVELS) {
+    await sweepDirByFileTime(
+      ctoPath("rollups", level),
+      nowMs,
+      RETENTION_MS[`rollups/${level}`],
+    );
+  }
+}
+
+// The segments store is owned by the segmentation issue (A6); the sweep rule
+// ships here per §13.1 ("segments 30d"). No directory yet → no-op.
+async function sweepSegments(nowMs) {
+  await sweepDirByFileTime(ctoPath("segments"), nowMs, RETENTION_MS.segments);
+}
+
+async function sweepDigests() {
+  const dir = ctoPath("digests");
+  const files = await listJsonFiles(dir);
+  if (files.length <= DIGESTS_KEEP) return;
+  const timed = [];
+  for (const name of files) {
+    timed.push({ name, ts: (await fileTimestamp(join(dir, name))) ?? 0 });
+  }
+  timed.sort((a, b) => b.ts - a.ts || a.name.localeCompare(b.name));
+  for (const { name } of timed.slice(DIGESTS_KEEP)) {
+    await rm(join(dir, name), { force: true });
+  }
+}
+
+async function sweepArchiveCaps() {
+  const dir = ctoPath("facts-archive");
+  const files = await listJsonFiles(dir);
+  for (const name of files) {
+    const filePath = join(dir, name);
+    const payload = await readJson(filePath, null);
+    if (!payload) continue;
+    const entries = Array.isArray(payload?.entries) ? payload.entries : [];
+    if (entries.length <= ARCHIVE_CAP) continue;
+    await writeJsonAtomic(
+      filePath,
+      JSON.stringify({ ...payload, entries: capArchive(entries, { cap: ARCHIVE_CAP }) }, null, 2),
+      { mode: MODE },
+    );
+  }
+}
+
+/** Run every retention rule once. Pure-ish: resolves real paths (sandboxed in
+ * tests). Exported for direct invocation in tests. */
+export async function sweepAllStores({ nowMs = Date.now() } = {}) {
+  await Promise.all([
+    sweepLedger(nowMs),
+    sweepVerdicts(nowMs),
+    sweepRollups(nowMs),
+    sweepSegments(nowMs),
+    sweepDigests(),
+    sweepArchiveCaps(),
+  ]);
+}
+
+export function createCtoStoreSweep({ now = () => Date.now() } = {}) {
+  let inFlight = false;
+
+  async function sweep() {
+    if (inFlight) return;
+    inFlight = true;
+    try {
+      await sweepAllStores({ nowMs: now() });
+    } finally {
+      inFlight = false;
+    }
+  }
+
+  return { sweep };
+}
+
+export function startCtoStoreSweeper({ intervalMs = SWEEP_INTERVAL_MS, ...opts } = {}) {
+  const { sweep } = createCtoStoreSweep(opts);
+  return startPoller(sweep, { intervalMs, label: "cto-stores" });
+}

--- a/src/server/ctoStores.test.mjs
+++ b/src/server/ctoStores.test.mjs
@@ -1,0 +1,255 @@
+// ctoStores.test.mjs — BET-1375 stores + schema-version harness.
+//
+// Pure logic (migration harness, retention sweep math) + a wiring canary that
+// asserts every store resolves under the MANTA_STATE_HOME sandbox. No live
+// tmux/opencode/network; the only I/O is real fs against grand the sandboxed
+// cto root (every path goes through ctoPath() → statePath()).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { homedir } from "node:os";
+import { sep } from "node:path";
+import {
+  CURRENT_VERSION,
+  migrateStore,
+  RETENTION_MS,
+  ARCHIVE_CAP,
+  DIGESTS_KEEP,
+  isExpired,
+  expireRows,
+  capArchive,
+  ctoPath,
+  verdictsStore,
+  ledgerStore,
+  factsArchiveStore,
+  digestsStore,
+  rollupsStore,
+  probesStore,
+  sweepAllStores,
+} from "./ctoStores.mjs";
+
+const NOW_MS = 1_000_000_000_000;
+const DAY = 86_400_000;
+
+// ---------------------------------------------------------------------------
+// Schema versioning (§13.2)
+// ---------------------------------------------------------------------------
+
+test("migrateStore: a v1 payload loads clean and unchanged", () => {
+  const payload = { v: 1, entries: [{ ts: 1 }] };
+  const out = migrateStore("cards", payload);
+  assert.deepEqual(out, payload);
+});
+
+test("migrateStore: a payload with no v is treated as v1", () => {
+  const noV = { entries: [{ ts: 1 }] };
+  const out = migrateStore("journal", noV);
+  assert.deepEqual(out, noV);
+});
+
+test("migrateStore: v is the current version on defaults", () => {
+  assert.equal(CURRENT_VERSION, 1);
+});
+
+test("migrateStore: a future v throws naming the store (never truncates)", () => {
+  assert.throws(() => migrateStore("inbox", { v: 2, entries: [] }), /"inbox".*2/);
+  assert.throws(() => migrateStore("verdicts", { v: 99 }), /"verdicts"/);
+});
+
+test("migrateStore: an invalid v throws naming the store", () => {
+  assert.throws(() => migrateStore("budget", { v: 0 }), /"budget"/);
+  assert.throws(() => migrateStore("budget", { v: -1 }), /"budget"/);
+  assert.throws(() => migrateStore("budget", { v: 1.5 }), /"budget"/);
+});
+
+// ---------------------------------------------------------------------------
+// Retention sweep math (§13.1) — boundary-exact
+// ---------------------------------------------------------------------------
+
+test("isExpired is boundary-exact at the retention cutoff", () => {
+  const retentionMs = 180 * DAY;
+  const cutoff = NOW_MS - retentionMs;
+  // Exactly at the cutoff is kept (not expired).
+  assert.equal(isExpired(cutoff, { nowMs: NOW_MS, retentionMs }), false);
+  // Just before the cutoff is expired.
+  assert.equal(isExpired(cutoff - 1, { nowMs: NOW_MS, retentionMs }), true);
+  // Well inside the window is kept.
+  assert.equal(isExpired(NOW_MS, { nowMs: NOW_MS, retentionMs }), false);
+  assert.equal(isExpired(NOW_MS - retentionMs + 1, { nowMs: NOW_MS, retentionMs }), false);
+});
+
+test("expireRows splits keep vs dropped on the time field", () => {
+  const retentionMs = 180 * DAY;
+  const cutoff = NOW_MS - retentionMs;
+  const rows = [
+    { id: "old", ts: cutoff - 1 }, // expired
+    { id: "at-cutoff", ts: cutoff }, // kept (boundary)
+    { id: "fresh", ts: NOW_MS }, // kept
+    { id: "no-ts", note: "x" }, // kept (unknown time -> never expire)
+  ];
+  const { keep, dropped } = expireRows(rows, { nowMs: NOW_MS, retentionMs });
+  assert.deepEqual(
+    dropped.map((r) => r.id),
+    ["old"],
+  );
+  assert.deepEqual(
+    keep.map((r) => r.id),
+    ["at-cutoff", "fresh", "no-ts"],
+  );
+});
+
+test("expireRows honor a custom time field", () => {
+  const retentionMs = 30 * DAY;
+  const cutoff = NOW_MS - retentionMs;
+  const rows = [
+    { id: "old", created: cutoff - 1 },
+    { id: "fresh", created: NOW_MS },
+  ];
+  const { keep } = expireRows(rows, { nowMs: NOW_MS, retentionMs, timeField: "created" });
+  assert.deepEqual(
+    keep.map((r) => r.id),
+    ["fresh"],
+  );
+});
+
+test("retention constants match the spec table", () => {
+  assert.equal(RETENTION_MS.ledger, 180 * DAY);
+  assert.equal(RETENTION_MS.verdicts, 180 * DAY);
+  assert.equal(RETENTION_MS["rollups/hour"], 14 * DAY);
+  assert.equal(RETENTION_MS["rollups/day"], 120 * DAY);
+  assert.equal(RETENTION_MS["rollups/week"], 2 * 365 * DAY);
+  assert.equal(RETENTION_MS.segments, 30 * DAY);
+});
+
+test("rollups/week retention is two years", () => {
+  const retentionMs = RETENTION_MS["rollups/week"];
+  assert.equal(retentionMs, 2 * 365 * DAY);
+  const cutoff = NOW_MS - retentionMs;
+  assert.equal(isExpired(cutoff, { nowMs: NOW_MS, retentionMs }), false);
+  assert.equal(isExpired(cutoff - 1, { nowMs: NOW_MS, retentionMs }), true);
+});
+
+test("archive cap: oldest dropped, cap retained, order preserved within the kept set", () => {
+  const cap = 3;
+  const entries = [
+    { id: "a", ts: 100 },
+    { id: "b", ts: 200 },
+    { id: "c", ts: 300 },
+    { id: "d", ts: 400 },
+    { id: "e", ts: 500 },
+  ];
+  const kept = capArchive(entries, { cap });
+  assert.deepEqual(
+    kept.map((e) => e.id),
+    ["c", "d", "e"],
+  ); // oldest two dropped, target order preserved
+});
+
+test("archive cap: no-op when at or under the cap", () => {
+  const entries = [
+    { id: "a", ts: 1 },
+    { id: "b", ts: 2 },
+  ];
+  assert.deepEqual(capArchive(entries, { cap: 2 }), entries);
+});
+
+test("archive cap defaults to 10x the 50-fact active cap (500)", () => {
+  assert.equal(ARCHIVE_CAP, 10 * 50);
+  const many = Array.from({ length: 520 }, (_, i) => ({ id: i, ts: i }));
+  const kept = capArchive(many);
+  assert.equal(kept.length, 500);
+  // The 20 oldest (ts 0..19) were dropped.
+  assert.equal(kept[0].ts, 20);
+  assert.equal(kept[kept.length - 1].ts, 519);
+});
+
+test("digests keep count is 30", () => {
+  assert.equal(DIGESTS_KEEP, 30);
+});
+
+// ---------------------------------------------------------------------------
+// Sandbox canary — every store root must honor MANTA_STATE_HOME
+// ---------------------------------------------------------------------------
+
+test("the cto store root resolves inside the sandbox, not the live box", () => {
+  const sandbox = process.env.MANTA_STATE_HOME;
+  assert.ok(sandbox && sandbox.trim() !== "", "MANTA_STATE_HOME unset — run via `npm test`");
+  assert.ok(
+    ctoPath("inbox.json").startsWith(sandbox + sep),
+    `inbox store resolved to ${ctoPath("inbox.json")}, outside the sandbox ${sandbox}`,
+  );
+  assert.ok(!ctoPath("inbox.json").startsWith(homedir() + sep + ".manta"));
+  assert.ok(ctoPath("facts", "proj.json").startsWith(sandbox + sep));
+  assert.ok(verdictsStore.path.startsWith(sandbox + sep));
+  assert.ok(ledgerStore.path.startsWith(sandbox + sep));
+});
+
+// ---------------------------------------------------------------------------
+// Wiring — accessors read/write through the sandbox, versioned
+// ---------------------------------------------------------------------------
+
+test("verdicts store round-trips a versioned payload through the sandbox", async () => {
+  await verdictsStore.save({ entries: [{ ts: 1, verdict: "accept" }] });
+  const loaded = await verdictsStore.load();
+  assert.equal(loaded.v, CURRENT_VERSION);
+  assert.equal(loaded.entries[0].verdict, "accept");
+});
+
+test("dir stores reject path-traversal ids", () => {
+  assert.throws(() => factsArchiveStore.pathFor("../evil"), /facts-archive/);
+  assert.throws(() => digestsStore.pathFor("a/b"), /digests/);
+  assert.throws(() => rollupsStore.pathFor("week", "a/../b"), /rollups/);
+  assert.throws(() => rollupsStore.dirFor("year"), /rollups level/);
+  assert.throws(() => probesStore.pathFor("../../x"), /probes/);
+});
+
+test("probes store round-trips YAML through the sandbox", async () => {
+  await probesStore.save("http-check", { name: "Http", timeout: "10s", steps: [] });
+  const loaded = await probesStore.load("http-check");
+  assert.equal(loaded.name, "Http");
+  assert.equal(loaded.timeout, "10s");
+  assert.deepEqual(loaded.steps, []);
+});
+
+// ---------------------------------------------------------------------------
+// Sweep wiring (sandboxed fs)
+// ---------------------------------------------------------------------------
+
+test("sweepAllStores trims the ledger and caps the archive (integration)", async () => {
+  const nowMs = NOW_MS;
+  const cutoff = nowMs - RETENTION_MS.ledger;
+
+  // Seed a ledger with an expired row and a fresh row.
+  await ledgerStore.append({ kind: "old", ts: cutoff - 1 });
+  await ledgerStore.append({ kind: "fresh", ts: nowMs });
+
+  // Seed an archive over the cap.
+  const many = Array.from({ length: ARCHIVE_CAP + 10 }, (_, i) => ({ id: i, ts: i }));
+  await factsArchiveStore.save("proj", { entries: many });
+
+  // Seed an expired rollup file and an in-window one.
+  const staleRollup = rollupsStore.pathFor("hour", "stale");
+  await rollupsStore.save("hour", "stale", { ts: nowMs - RETENTION_MS["rollups/hour"] - 1 });
+  const freshRollup = rollupsStore.pathFor("hour", "fresh");
+  await rollupsStore.save("hour", "fresh", { ts: nowMs });
+
+  const { existsSync } = await import("node:fs");
+  assert.ok(existsSync(staleRollup), "stale rollup should exist before the sweep");
+
+  await sweepAllStores({ nowMs });
+
+  // Ledger: expired row gone.
+  const rows = await ledgerStore.read();
+  assert.deepEqual(rows.map((r) => r.kind), ["fresh"]);
+
+  // Archive: capped at ARCHIVE_CAP.
+  const archived = await factsArchiveStore.load("proj");
+  assert.equal(archived.entries.length, ARCHIVE_CAP);
+
+  // Rollup: expired file removed, fresh kept.
+  assert.equal(existsSync(staleRollup), false);
+  assert.equal(existsSync(freshRollup), true);
+
+  const { rm } = await import("node:fs/promises");
+  await rm(freshRollup);
+});


### PR DESCRIPTION
## BET-1375 — CTO stores + schema-version harness

Durable storage layer every other Adaptive CTO issue builds on. Nothing user-visible. Implements `docs/adaptive-cto-spec.md` §13.1 (stores), §13.2 (schema versioning), §6.3 (archive cap), §3.2 (journal store lives in this layer).

Base: `origin/main @ 07eef463`

### What ships

`src/server/ctoStores.mjs` — one accessor per store, all rooted at `~/.manta/cto/` via `statePath("cto", …)` (test-sandbox rule covers every store):

- **Single-file JSON stores** (atomic jsonStore writes, mode 0600): `inbox`, `cards`, `profile`, `journal`, `tool-registry`, `tool-usage`, `verdicts`, `budget`, `engine-state`.
- **Per-project JSON stores**: `facts/<project>.json`, `facts-archive/<project>.json`.
- **Directory JSON stores**: `rollups/<hour|day|week>/<id>.json` (levels validated against a closed set) and `digests/<id>.json`, one file per rollup/digest.
- **`ledger.jsonl`**: append-only writer (`ts` stamped at append), reader that returns parsed rows for a time range, plus a `rewrite` for the retention trim.
- **`probes/<tool>.yaml`**: YAML parse/stringify via the same `yaml` package `pluginManifest.mjs` uses — parse only, no probe validation (a later issue).
- **`migrateStore(name, data)`**: pure forward-migration table (empty today, v1 is the first schema). Payload with `v` newer than `CURRENT_VERSION` throws naming the store — never silently truncates. No `v` = v1.
- **Retention**: pure functions `isExpired` / `expireRows` / `capArchive` (boundary-exact), wired by `createCtoStoreSweep` (inFlight guard, the `servePage.mjs createCleanupSweep` shape) + `startCtoStoreSweeper` (`startPoller` → `timer.unref()`). Rules: ledger + verdicts 180d; rollups hours 14d / days 120d / weeks 2y; segments 30d (dir owned by the segmentation issue A6 — no dir yet = no-op); facts-archive capped at 10×50 = 500 entries/project, oldest dropped.

`index.mjs` is untouched (wiring is the engine-skeleton issue). Out-of-scope respected: no engine timers started (sweeper only exported, never invoked), no consumers, no probe validation, no UI.

### Design notes

- Leaf payload shapes are deliberately minimal (`{ v, entries: [] }` for the list-like stores). The engine issues define what lives inside; this layer only fixes the durability/versioning contract.
- Consistency: `ts` (epoch ms) is the canonical time field across stores — normative for verdicts (§9.5) and tool-usage (§7.1), so the sweeps default to it (overridable per rule).
- One small scope call: the issue's retention list omits digests, but spec §5.5 is normative that "the last 30 generated digests persist" — I added a `DIGESTS_KEEP = 30` rule so the digests store can't grow unbounded. Flagging rather than silently skipping.

**Files changed:** 2 (both new)
- `src/server/ctoStores.mjs` (+502)
- `src/server/ctoStores.test.mjs` (+255)

**Verification results:**
- PR branch (`multica/BET-1375-cto-stores` @ `37285dc0`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2969 pass / 0 fail / 0 skip. Failures: none. log sha256: `afa7d4b1399cda424c66957c0754c61e156e5a3d61cfb0da8bf3a5d8093f0039`
- Base (`main` @ `07eef463`): not re-run — branch only adds two new files, nothing touches existing code, full suite green.
- **Conclusion:** 0 new failures. Added tests: migration harness (v1 clean / no-v = v1 / future-v throws naming store), sweep math boundary-exact, sandbox canary (`stateSandbox.test.mjs` shape), plus sandboxed wiring round-trips.

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/test-pr.log`.
