### PR TITLE
feat(server): adaptive CTO engine skeleton (BET-1376)

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1,0 +1,521 @@
+// The Adaptive CTO engine skeleton (BET-1376 / spec §3, §10.1, §10.6, §13.3).
+//
+// The CTO is NOT a long-running agent (spec §3.1): it is deterministic server
+// code — schedulers, stores, queues, scoring, thresholds, budget math — in the
+// same dependency-injected style as delegate.mjs. This module is that engine's
+// P1 skeleton: it owns the engine's timer discipline, the state surface the
+// `/api/cto/state` route + `{kind:"ctoState"}` bus event serve (§10.1), the
+// kill switch + health state machine (§10.6), the rate limits (§3.3), and
+// records every mutating act in the A1 activity ledger. The pipeline pipelines
+// (facts, presence, digest, overnight, reaper) land in later issues against
+// this shell.
+//
+// Determinism + testability: every I/O seam (config, ledger, engine-state,
+// kill switch, clock, counts) is injected with a real default, exactly like
+// the other server engines. Nothing here touches tmux/opencode directly.
+//
+// State machine (§10.6): dot ∈ {active, disabled, thrifty, paused}.
+//   - disabled – config `ctoEnabled` is false (the default). No work.
+//   - paused   – the kill-switch flag file is present, or a rate-limit trip
+//     self-paused the engine (§10.6-5). All work timers stop; event ingestion
+//     keeps running. Resume() (a user action) is the only way out.
+//   - thrifty  – the cap/window is tight; set by the watchdog (>2× expected
+//     hourly burn, §13.3) or a cap hit. Quiet warn chip; auto-clears later.
+//   - active   – enabled, not paused, not thrifty.
+//
+// Kill switch (§13.3): engine-EXTERNAL. A flag file whose path lives on the
+// box (`statePath("cto","paused")` via A1 ctoPath). It is checked at every
+// engine tick and before every job/session start; pause()/resume() write and
+// remove it. Because it is a flag file (not a bit in this process's memory) a
+// wedged engine still stops — the watchdog, which is a SEPARATE timer
+// registered from src/server/index.mjs (also §13.3), can write it without
+// this module cooperating.
+//
+// Timer discipline: the engine owns exactly one timer today — the liveness /
+// kill-switch / state-refresh tick — via startPoller (timer.unref() + inFlight
+// guard). It is stopped on pause and restarted on resume. Event ingestion
+// (observeEvent) is NOT a timer: it is driven from index.mjs's event pump and
+// keeps running while paused (§10.6-5). Future work timers (probes, overnight,
+// backfill) register through the same start/stop surface so pause halts them
+// too; they are out of scope for this skeleton.
+
+import { promises as fsp } from "node:fs";
+import { dirname } from "node:path";
+import { randomBytes } from "node:crypto";
+import {
+  ctoPath,
+  ledgerStore,
+  engineStateStore,
+  cardsStore,
+} from "./ctoStores.mjs";
+import { startPoller } from "./startPoller.mjs";
+
+// Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
+export const ACTOR = "cto";
+
+// Rate limits (spec §3.3): exceed any one and the engine pauses itself and
+// raises a health warning (§10.6-7).
+export const RATE_LIMITS = Object.freeze({
+  sessionCreationsPerHour: 30,
+  concurrentEphemeral: 5,
+  concurrentDelegate: 2, // inside delegate's global cap of 5
+});
+
+export const HOUR_MS = 3_600_000;
+export const TICK_INTERVAL_MS = 60_000;
+
+export const DOT = Object.freeze({
+  ACTIVE: "active",
+  DISABLED: "disabled",
+  THRIFTY: "thrifty",
+  PAUSED: "paused",
+});
+
+function nextId() {
+  return randomBytes(4).toString("hex");
+}
+
+// ---------------------------------------------------------------------------
+// Kill switch — a flag file, engine-external (§13.3)
+// ---------------------------------------------------------------------------
+
+export function createKillSwitch({ path = ctoPath("paused"), fs = fsp } = {}) {
+  async function isPaused() {
+    try {
+      await fs.access(path);
+      return true;
+    } catch {
+      return false;
+    }
+  }
+  async function pause() {
+    await fs.mkdir(dirname(path), { recursive: true });
+    await fs.writeFile(path, String(Date.now()), { mode: 0o600 });
+  }
+  async function resume() {
+    await fs.rm(path, { force: true });
+  }
+  return { isPaused, pause, resume };
+}
+
+// ---------------------------------------------------------------------------
+// Rate tracker (spec §3.3)
+// ---------------------------------------------------------------------------
+
+export function createRateTracker({ now = () => Date.now() } = {}) {
+  const sessionCreations = [];
+  let ephemeral = 0;
+  let delegate = 0;
+
+  function pruneWindow(windowMs) {
+    const cutoff = now() - windowMs;
+    while (sessionCreations.length > 0 && sessionCreations[0] < cutoff) {
+      sessionCreations.shift();
+    }
+  }
+
+  return {
+    sessionCreationsPerHour() {
+      pruneWindow(HOUR_MS);
+      return sessionCreations.length;
+    },
+    recordSessionCreation(ts = now()) {
+      sessionCreations.push(ts);
+    },
+    get ephemeral() {
+      return ephemeral;
+    },
+    beginEphemeral() {
+      ephemeral += 1;
+      return () => {
+        ephemeral = Math.max(0, ephemeral - 1);
+      };
+    },
+    get delegate() {
+      return delegate;
+    },
+    beginDelegate() {
+      delegate += 1;
+      return () => {
+        delegate = Math.max(0, delegate - 1);
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// State dot (spec §10.6)
+// ---------------------------------------------------------------------------
+
+export function computeDot({ enabled, paused, thrifty }) {
+  if (!enabled) return DOT.DISABLED;
+  if (paused) return DOT.PAUSED;
+  if (thrifty) return DOT.THRIFTY;
+  return DOT.ACTIVE;
+}
+
+// Default counts producer: needs-you count from the A1 cards store, digest /
+// tonight counts not populated until later pipeline issues. Defensive — a
+// malformed or missing store yields zeros, never a throw.
+export async function defaultGetCounts() {
+  let needsYouCount = 0;
+  try {
+    const cards = await cardsStore.load();
+    const arr = Array.isArray(cards?.cards) ? cards.cards : [];
+    needsYouCount = arr.filter(
+      (c) => c && c.needsYou === true && c.resolved !== true,
+    ).length;
+  } catch {
+    needsYouCount = 0;
+  }
+  return { needsYouCount, generationInFlight: false, tonightCount: 0 };
+}
+
+// ---------------------------------------------------------------------------
+// The engine
+// ---------------------------------------------------------------------------
+
+export function createCtoEngine(deps = {}) {
+  const {
+    configGet = async () => ({}), // → { ctoEnabled?: boolean }
+    ledger = ledgerStore, // A1 ledger writer { append }
+    engineState = engineStateStore, // { load, save } (engine-state.json)
+    killSwitch = createKillSwitch(),
+    publish = () => {}, // (evt: {kind:"ctoState", payload}) => void
+    now = () => Date.now(),
+    rates: rateLimits = RATE_LIMITS,
+    tickIntervalMs = TICK_INTERVAL_MS,
+    getCounts = defaultGetCounts,
+    track = createRateTracker({ now }),
+  } = deps;
+
+  let disposed = false;
+  let thrifty = false;
+  let selfPaused = false;
+  let enabled = false;
+  let heartbeatAt = now();
+  let tickHandle = null;
+  let lastPublishedSerialized = null;
+
+  // Ledger writes are best-effort: a ledger I/O failure must never take the
+  // engine (and its state machine) down with it.
+  async function ledgerLog(entry) {
+    try {
+      await ledger.append({ actor: ACTOR, ts: now(), ...entry });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // Load + append a pending blocker-card request (health escalation, §10.6-7)
+  // into engine-state.json. Best-effort — the health record never throws.
+  async function recordBlocker(source, reason) {
+    try {
+      const payload = await engineState.load();
+      const pending = Array.isArray(payload?.pendingBlockers)
+        ? payload.pendingBlockers
+        : [];
+      pending.push({
+        id: nextId(),
+        kind: "blocker",
+        source,
+        reason,
+        ts: now(),
+        resolved: false,
+      });
+      await engineState.save({ ...payload, pendingBlockers: pending });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // Re-read the live signals the state dot depends on (kill-switch flag is the
+  // costly one, so only gates/sync pay it). Returns the fresh context.
+  async function gateContext() {
+    let enabledNow = false;
+    try {
+      enabledNow = (await configGet())?.ctoEnabled === true;
+    } catch {
+      enabledNow = enabled;
+    }
+    enabled = enabledNow;
+    let paused = selfPaused;
+    try {
+      paused = paused || (await killSwitch.isPaused());
+    } catch {
+      /* flag read failure → treat as not paused */
+    }
+    return { enabled: enabledNow, paused };
+  }
+
+  async function readState() {
+    const { enabled: enabledNow, paused } = await gateContext();
+    let counts = { needsYouCount: 0, generationInFlight: false, tonightCount: 0 };
+    try {
+      counts = (await getCounts()) ?? counts;
+    } catch {
+      /* best-effort */
+    }
+    return {
+      enabled: enabledNow,
+      dot: computeDot({ enabled: enabledNow, paused, thrifty }),
+      needsYouCount: counts.needsYouCount ?? 0,
+      generationInFlight: !!counts.generationInFlight,
+      tonightCount: counts.tonightCount ?? 0,
+    };
+  }
+
+  // Publish {kind:"ctoState"} ONLY when something changed (no spam, §10.1).
+  async function syncState() {
+    const state = await readState();
+    const serialized = JSON.stringify(state);
+    if (serialized !== lastPublishedSerialized) {
+      lastPublishedSerialized = serialized;
+      publish({ kind: "ctoState", payload: state });
+    }
+    return state;
+  }
+
+  // The engine's single lifecycle tick (startPoller: unref + inFlight).
+  // Kill switch is honored at every tick (§13.3): if the flag is present the
+  // engine reflects paused and does no work.
+  async function tick() {
+    if (disposed) return;
+    heartbeatAt = now();
+    try {
+      const { paused } = await gateContext();
+      if (paused) {
+        await syncState();
+        return;
+      }
+      await syncState();
+    } catch {
+      /* never throw into the poller */
+    }
+  }
+
+  function stopTimers() {
+    if (tickHandle) {
+      tickHandle.stop();
+      tickHandle = null;
+    }
+  }
+
+  function startTimers() {
+    if (tickHandle || disposed) return;
+    tickHandle = startPoller(tick, {
+      intervalMs: tickIntervalMs,
+      label: "cto-engine",
+      immediate: false,
+    });
+  }
+
+  // §10.6-5: pausing stops all engine timers (event ingestion is not a timer
+  // and is unaffected). The kill-switch flag is the persisted, external mark.
+  async function pause({ reason = "manual", source = "engine" } = {}) {
+    await killSwitch.pause();
+    stopTimers();
+    selfPaused = false; // the flag is now authoritative
+    await ledgerLog({ kind: "cto.pause", reason, source });
+    await syncState();
+    return { ok: true };
+  }
+
+  async function resume({ reason = "manual" } = {}) {
+    await killSwitch.resume();
+    selfPaused = false;
+    startTimers();
+    await ledgerLog({ kind: "cto.resume", reason });
+    await syncState();
+    return { ok: true };
+  }
+
+  // Watchdog escalation (>4× expected hourly burn, §13.3): writes the kill
+  // switch flag AND records a blocker-card request in engine-state.json.
+  async function hardPause({ reason = "watchdog", source = "watchdog" } = {}) {
+    await killSwitch.pause();
+    stopTimers();
+    selfPaused = false;
+    await recordBlocker(source, reason);
+    await ledgerLog({ kind: "cto.hard_pause", reason, source });
+    await syncState();
+    return { ok: true };
+  }
+
+  // Watchdog / cap-hit signal (>2× expected hourly burn, §13.3; §10.6-6).
+  async function setThrifty(value, { reason = "", source = "watchdog" } = {}) {
+    const next = !!value;
+    const changed = next !== thrifty;
+    thrifty = next;
+    if (changed) {
+      await ledgerLog({
+        kind: next ? "cto.thrifty_on" : "cto.thrifty_off",
+        reason,
+        source,
+      });
+    }
+    await syncState();
+    return { ok: true, changed };
+  }
+
+  // Exceeding a rate limit pauses the engine + raises a health warning (§3.3
+  // / §10.6-7).
+  async function exceedRateLimit(limitId) {
+    selfPaused = true;
+    await ledgerLog({ kind: "cto.ratelimit_trip", reason: limitId, source: "engine" });
+    await recordBlocker("rate_limit", limitId);
+    await syncState();
+  }
+
+  // ----- Session / job creation gates (§3.3) -----
+  // Each checks the kill switch at START (the second place the flag is
+  // honored, §13.3) plus the relevant rate limit. Later pipeline issues call
+  // these before creating a session / starting a delegate job; the skeleton
+  // ships the guards + the pause-on-trip behavior.
+
+  async function checkCanCreateSession() {
+    const { enabled: enabledNow, paused } = await gateContext();
+    if (!enabledNow) return { ok: false, error: "cto_disabled" };
+    if (paused) return { ok: false, error: "cto_paused" };
+    if (track.sessionCreationsPerHour() >= rateLimits.sessionCreationsPerHour) {
+      await exceedRateLimit("sessionCreationsPerHour");
+      return { ok: false, error: "rate_limit:sessionCreationsPerHour" };
+    }
+    return { ok: true };
+  }
+
+  async function beginEphemeral() {
+    const { enabled: enabledNow, paused } = await gateContext();
+    if (!enabledNow) return { ok: false, error: "cto_disabled" };
+    if (paused) return { ok: false, error: "cto_paused" };
+    if (track.ephemeral >= rateLimits.concurrentEphemeral) {
+      await exceedRateLimit("concurrentEphemeral");
+      return { ok: false, error: "rate_limit:concurrentEphemeral" };
+    }
+    track.recordSessionCreation();
+    const release = track.beginEphemeral();
+    await ledgerLog({ kind: "cto.ephemeral_begin" });
+    return { ok: true, release };
+  }
+
+  async function beginDelegateJob() {
+    const { enabled: enabledNow, paused } = await gateContext();
+    if (!enabledNow) return { ok: false, error: "cto_disabled" };
+    if (paused) return { ok: false, error: "cto_paused" };
+    if (track.delegate >= rateLimits.concurrentDelegate) {
+      await exceedRateLimit("concurrentDelegate");
+      return { ok: false, error: "rate_limit:concurrentDelegate" };
+    }
+    const release = track.beginDelegate();
+    await ledgerLog({ kind: "cto.delegate_begin" });
+    return { ok: true, release };
+  }
+
+  // Event ingestion — the ONE thing that keeps running while paused (§10.6-5).
+  // Driven from index.mjs's event pump (not a timer). The skeleton ingests
+  // nothing yet; this is the seam later pipeline stages (facts, segmentation,
+  // presence) subscribe at. Deterministic — never throws into the pump.
+  function observeEvent() {
+    if (disposed) return;
+    heartbeatAt = now();
+  }
+
+  function start() {
+    if (disposed) throw new Error("cto engine already disposed");
+    startTimers();
+    // Publish the initial state once (fire-and-forget) so a subscriber that
+    // mounts before the first tick still sees a ctoState event.
+    void syncState().catch(() => {});
+    return engine;
+  }
+
+  function dispose() {
+    disposed = true;
+    stopTimers();
+  }
+
+  async function getState() {
+    return syncState();
+  }
+
+  function lastHeartbeat() {
+    return heartbeatAt;
+  }
+
+  const engine = {
+    actor: ACTOR,
+    start,
+    dispose,
+    tick, // exposed for tests + explicit syncs
+    pause,
+    resume,
+    hardPause,
+    setThrifty,
+    checkCanCreateSession,
+    beginEphemeral,
+    beginDelegateJob,
+    observeEvent,
+    getState,
+    lastHeartbeat,
+    get rateTracker() {
+      return track;
+    },
+  };
+
+  return engine;
+}
+
+// ---------------------------------------------------------------------------
+// Watchdog (§13.3) — a SEPARATE, deterministic monitor. Its timer is owned by
+// src/server/index.mjs (deliberately NOT inside the engine); the logic lives
+// here so it is a pure, injectable, testable unit. Checks engine liveness +
+// ambient spend rate: > 2× expected hourly burn → auto-thrifty + health
+// warning; > 4× → auto-pause + blocker card.
+// ---------------------------------------------------------------------------
+
+export function createWatchdog(deps = {}) {
+  const {
+    engine,
+    getSpendPerHour = async () => 0, // measured ambient burn since the reset
+    expectedHourlyBurn = async () => 0, // the budget's expected burning rate
+    livenessMs = 2 * TICK_INTERVAL_MS,
+    now = () => Date.now(),
+    ledger = ledgerStore,
+  } = deps;
+
+  async function ledgerLog(entry) {
+    try {
+      await ledger.append({ actor: ACTOR, ts: now(), ...entry });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  async function tick() {
+    const burn = await getSpendPerHour();
+    const expected = await expectedHourlyBurn();
+    if (burn > 4 * expected) {
+      await engine.hardPause({
+        reason: `ambient spend ${burn} > 4x expected ${expected}`,
+        source: "watchdog",
+      });
+      return;
+    }
+    if (burn > 2 * expected) {
+      await engine.setThrifty(true, {
+        reason: `ambient spend ${burn} > 2x expected ${expected}`,
+        source: "watchdog",
+      });
+      return;
+    }
+    const age = now() - (typeof engine.lastHeartbeat === "function" ? engine.lastHeartbeat() : 0);
+    if (age > livenessMs) {
+      await ledgerLog({
+        kind: "cto.watchdog_stale",
+        reason: `engine heartbeat stale ${age}ms > ${livenessMs}`,
+      });
+    }
+  }
+
+  return { tick };
+}

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -1,0 +1,305 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createCtoEngine,
+  createWatchdog,
+  createRateTracker,
+  createKillSwitch,
+  computeDot,
+  DOT,
+  HOUR_MS,
+  RATE_LIMITS,
+} from "./ctoEngine.mjs";
+
+// Build a fully-injected engine harness: no real fs, no real stores, a fake
+// clock we can advance. Everything the engine touches goes through these
+// seams, so the tests assert pure behavior. `clock` is shared so the watchdog
+// and the engine observe the same time.
+function makeHarness({ ctoEnabled = false, counts = {} } = {}) {
+  const clock = { ms: 1_000_000 };
+  const now = () => clock.ms;
+  const ledgerRows = [];
+  let pendingBlockers = [];
+  let killSwitchPaused = false;
+  let published = [];
+  let currentConfig = { ctoEnabled };
+
+  const engine = createCtoEngine({
+    configGet: async () => ({ ...currentConfig }),
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    engineState: {
+      load: async () => ({ v: 1, pendingBlockers }),
+      save: async (payload) => {
+        pendingBlockers = Array.isArray(payload?.pendingBlockers)
+          ? payload.pendingBlockers
+          : [];
+      },
+    },
+    killSwitch: {
+      isPaused: async () => killSwitchPaused,
+      pause: async () => {
+        killSwitchPaused = true;
+      },
+      resume: async () => {
+        killSwitchPaused = false;
+      },
+    },
+    publish: (evt) => published.push(evt),
+    now,
+    getCounts: async () => ({
+      needsYouCount: 0,
+      generationInFlight: false,
+      tonightCount: 0,
+      ...counts,
+    }),
+  });
+
+  return {
+    engine,
+    clock,
+    ledgerRows,
+    published,
+    get pendingBlockers() {
+      return pendingBlockers;
+    },
+    get killSwitchPaused() {
+      return killSwitchPaused;
+    },
+    set killSwitchPaused(v) {
+      killSwitchPaused = v;
+    },
+    setEnabled(v) {
+      currentConfig.ctoEnabled = v;
+    },
+    advance(ms) {
+      clock.ms += ms;
+    },
+  };
+}
+
+// A watchdog deps object for tests: throttle spend/expected/now over the same
+// harness clock so spend thresholds + liveness are deterministic.
+function makeWatchdog(harness, { spend = 0, expected = 0, livenessMs = 120_000 } = {}) {
+  return createWatchdog({
+    engine: harness.engine,
+    getSpendPerHour: async () => spend,
+    expectedHourlyBurn: async () => expected,
+    livenessMs,
+    now: () => harness.clock.ms,
+    ledger: { append: async (row) => harness.ledgerRows.push(row) },
+  });
+}
+
+test("disabled by default when ctoEnabled is false (config default)", async () => {
+  const h = makeHarness({ ctoEnabled: false });
+  const s = await h.engine.getState();
+  assert.equal(s.enabled, false);
+  assert.equal(s.dot, DOT.DISABLED);
+  assert.equal(s.needsYouCount, 0);
+  assert.equal(s.generationInFlight, false);
+  assert.equal(s.tonightCount, 0);
+});
+
+test("active when enabled, and reflects counts from getCounts", async () => {
+  const h = makeHarness({
+    ctoEnabled: true,
+    counts: { needsYouCount: 3, generationInFlight: true, tonightCount: 2 },
+  });
+  const s = await h.engine.getState();
+  assert.equal(s.enabled, true);
+  assert.equal(s.dot, DOT.ACTIVE);
+  assert.equal(s.needsYouCount, 3);
+  assert.equal(s.generationInFlight, true);
+  assert.equal(s.tonightCount, 2);
+});
+
+test("ctoState fires only on change (no spam)", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  assert.equal(h.published.length, 0);
+  await h.engine.getState();
+  assert.equal(h.published.length, 1);
+  assert.equal(h.published[0].kind, "ctoState");
+  // same state again → no re-publish
+  await h.engine.getState();
+  assert.equal(h.published.length, 1);
+  // state change → re-publish
+  h.setEnabled(false);
+  await h.engine.getState();
+  assert.equal(h.published.length, 2);
+});
+
+test("kill-switch flag is honored at every tick", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  // externally-written flag → the next tick reflects paused and does no work
+  h.killSwitchPaused = true;
+  await h.engine.tick();
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  // clearing the flag externally → tick returns to active
+  h.killSwitchPaused = false;
+  await h.engine.tick();
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+});
+
+test("kill-switch flag is honored before job/session start", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  assert.deepEqual(await h.engine.checkCanCreateSession(), { ok: true });
+  h.killSwitchPaused = true;
+  assert.deepEqual(await h.engine.checkCanCreateSession(), {
+    ok: false,
+    error: "cto_paused",
+  });
+  assert.deepEqual(await h.engine.beginEphemeral(), {
+    ok: false,
+    error: "cto_paused",
+  });
+  assert.deepEqual(await h.engine.beginDelegateJob(), {
+    ok: false,
+    error: "cto_paused",
+  });
+});
+
+test("disabled engine refuses to start sessions", async () => {
+  const h = makeHarness({ ctoEnabled: false });
+  assert.deepEqual(await h.engine.checkCanCreateSession(), {
+    ok: false,
+    error: "cto_disabled",
+  });
+});
+
+test("session-creations-per-hour limit trips to paused + health escalation", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  for (let i = 0; i < RATE_LIMITS.sessionCreationsPerHour; i++) {
+    h.engine.rateTracker.recordSessionCreation();
+  }
+  const gate = await h.engine.checkCanCreateSession();
+  assert.equal(gate.ok, false);
+  assert.equal(gate.error, "rate_limit:sessionCreationsPerHour");
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  const trip = h.ledgerRows.find((r) => r.kind === "cto.ratelimit_trip");
+  assert.ok(trip, "rate-limit trip ledgered");
+  assert.equal(trip.reason, "sessionCreationsPerHour");
+  assert.equal(trip.actor, "cto");
+  assert.equal(h.pendingBlockers.length, 1);
+  assert.equal(h.pendingBlockers[0].source, "rate_limit");
+});
+
+test("concurrent ephemeral cap trips to paused", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  for (let i = 0; i < RATE_LIMITS.concurrentEphemeral; i++) {
+    assert.equal((await h.engine.beginEphemeral()).ok, true);
+  }
+  const sixth = await h.engine.beginEphemeral();
+  assert.equal(sixth.ok, false);
+  assert.equal(sixth.error, "rate_limit:concurrentEphemeral");
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+});
+
+test("concurrent delegate cap trips to paused", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  for (let i = 0; i < RATE_LIMITS.concurrentDelegate; i++) {
+    assert.equal((await h.engine.beginDelegateJob()).ok, true);
+  }
+  const third = await h.engine.beginDelegateJob();
+  assert.equal(third.ok, false);
+  assert.equal(third.error, "rate_limit:concurrentDelegate");
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+});
+
+test("releasing an ephemeral/delegate slot frees the cap", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  const a = await h.engine.beginEphemeral();
+  assert.equal(a.ok, true);
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  a.release();
+  // release then begin again at the cap → ok
+  const b = await h.engine.beginEphemeral();
+  assert.equal(b.ok, true);
+  b.release();
+});
+
+test("pause() and resume() flip the flag, stop/restart state, and ledger", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+
+  await h.engine.pause({ reason: "manual" });
+  assert.equal(h.killSwitchPaused, true);
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  assert.ok(h.ledgerRows.find((r) => r.kind === "cto.pause"));
+
+  await h.engine.resume({ reason: "manual" });
+  assert.equal(h.killSwitchPaused, false);
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  assert.ok(h.ledgerRows.find((r) => r.kind === "cto.resume"));
+});
+
+test("computeDot maps the four states", () => {
+  assert.equal(computeDot({ enabled: true, paused: false, thrifty: false }), "active");
+  assert.equal(computeDot({ enabled: false, paused: false, thrifty: false }), "disabled");
+  assert.equal(computeDot({ enabled: true, paused: true, thrifty: false }), "paused");
+  assert.equal(computeDot({ enabled: true, paused: false, thrifty: true }), "thrifty");
+});
+
+test("watchdog: > 2x expected burn → auto-thrifty", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  const w = makeWatchdog(h, { spend: 3, expected: 1 });
+  await w.tick();
+  assert.equal((await h.engine.getState()).dot, DOT.THRIFTY);
+  assert.ok(h.ledgerRows.find((r) => r.kind === "cto.thrifty_on"));
+});
+
+test("watchdog: > 4x expected burn → auto-pause + blocker card", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  const w = makeWatchdog(h, { spend: 5, expected: 1 });
+  await w.tick();
+  assert.equal(h.killSwitchPaused, true);
+  assert.equal((await h.engine.getState()).dot, DOT.PAUSED);
+  assert.ok(h.ledgerRows.find((r) => r.kind === "cto.hard_pause"));
+  assert.equal(h.pendingBlockers.length, 1);
+  assert.equal(h.pendingBlockers[0].kind, "blocker");
+  assert.equal(h.pendingBlockers[0].source, "watchdog");
+});
+
+test("watchdog: safe defaults (0 spend / 0 expected) never pause or thrift", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  const w = makeWatchdog(h, { spend: 0, expected: 0 });
+  await w.tick();
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  assert.equal(h.killSwitchPaused, false);
+  assert.ok(!h.ledgerRows.some((r) => r.kind.startsWith("cto.thrifty")));
+  assert.ok(!h.ledgerRows.some((r) => r.kind === "cto.hard_pause"));
+});
+
+test("watchdog: stale engine heartbeat is flagged, state untouched", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  const w = makeWatchdog(h, { spend: 0, expected: 0, livenessMs: 120_000 });
+  // move the clock far past the engine's last heartbeat (no tick/event yet)
+  h.advance(10 * 60_000);
+  await w.tick();
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  assert.ok(h.ledgerRows.find((r) => r.kind === "cto.watchdog_stale"));
+});
+
+test("rate tracker slides the hourly window", async () => {
+  const clock = { ms: 5_000 };
+  const now = () => clock.ms;
+  const t = createRateTracker({ now });
+  t.recordSessionCreation();
+  assert.equal(t.sessionCreationsPerHour(), 1);
+  clock.ms += HOUR_MS + 1;
+  assert.equal(t.sessionCreationsPerHour(), 0);
+  assert.equal(t.ephemeral, 0);
+  assert.equal(t.delegate, 0);
+});
+
+test("createKillSwitch uses a real flag file (sandboxed state home)", async () => {
+  // The engine never hardcodes the path; the default kill switch resolves it
+  // through A1's ctoPath → statePath, so under the test sandbox it lands in
+  // the ephemeral state dir, never production data.
+  const ks = createKillSwitch();
+  assert.equal(await ks.isPaused(), false);
+  await ks.pause();
+  assert.equal(await ks.isPaused(), true);
+  await ks.resume();
+  assert.equal(await ks.isPaused(), false);
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -136,6 +136,8 @@ import {
 import { endpointSummary as routingEndpointSummary, providerTokenTotals, ROUTING_LEDGER_WINDOW_MS, fetchLedgerRows } from "./modelLedger.mjs";
 import * as appControl from "./appControl.mjs";
 import * as cto from "./cto.mjs";
+import * as ctoEngine from "./ctoEngine.mjs";
+import { ledgerStore, engineStateStore } from "./ctoStores.mjs";
 import { searchMessages } from "./messageSearch.mjs";
 import {
   dispatch as mediaDispatch,
@@ -1648,6 +1650,39 @@ async function maybeEnsureCtoAgent() {
 }
 void maybeEnsureCtoAgent();
 
+// ----- Adaptive CTO engine (BET-1376) -----
+// The background engine (spec §3, §10.1, §13.3). Created + started ALWAYS so
+// `/api/cto/state` answers and the sidebar dot reflects config live; actual
+// work is gated INSIDE the engine on the top-level `ctoEnabled` config field
+// (default false). It publishes `{kind:"ctoState"}` on the shared bus on every
+// state change (needs-you count, status dot, generation-in-flight, tonight
+// count); the renderer subscribes over /events, with `GET /api/cto/state` for
+// initial mount. The watchdog timer below is a SEPARATE deterministic monitor
+// (§13.3) — deliberately registered here, NOT inside the engine.
+const adaptiveCto = ctoEngine.createCtoEngine({
+  configGet: () => local.configGet(),
+  ledger: ledgerStore,
+  engineState: engineStateStore,
+  publish: (evt) => bus.publish(evt),
+});
+adaptiveCto.start();
+
+// Watchdog (§13.3): checks engine liveness + ambient spend rate; > 2× expected
+// hourly burn → auto-thrifty, > 4× → auto-pause + blocker card. Spend is not
+// measured yet (the budget reading lands with a later pipeline issue), so the
+// defaults are 0/0 → never trips and never pauses; the pure logic is wired so
+// a real spend source simply slots in.
+const adaptiveCtoWatchdog = ctoEngine.createWatchdog({
+  engine: adaptiveCto,
+  getSpendPerHour: async () => 0,
+  expectedHourlyBurn: async () => 0,
+});
+const stopAdaptiveCtoWatchdog = startPoller(adaptiveCtoWatchdog.tick, {
+  intervalMs: ctoEngine.TICK_INTERVAL_MS,
+  label: "cto-watchdog",
+});
+void stopAdaptiveCtoWatchdog;
+
 // On-call CTO inbound funnel (Issue 2): the single place a CTO-bound event
 // enters the box. Producers (the send_to_cto tool, the watcher poller, a
 // scheduled prompt targeting the CTO, a webhook routed to the CTO) all call
@@ -1861,6 +1896,13 @@ const stopOpencodePump = oc.subscribeEvents((evt) => {
     delegateEngine.observeEvent(evt);
   } catch (e) {
     console.warn("[delegate] observeEvent failed:", e?.message ?? e);
+  }
+  // Adaptive CTO engine (BET-1376): event ingestion. The one CTO consumer that
+  // keeps running while paused (§10.6-5). Never throws into the pump.
+  try {
+    adaptiveCto.observeEvent(evt);
+  } catch (e) {
+    console.warn("[cto-engine] observeEvent failed:", e?.message ?? e);
   }
   try {
     usageStopEngine.observeEvent(evt);
@@ -3555,6 +3597,24 @@ const handleRequest = async (req, res) => {
       respondJson(res, 405, { error: "method not allowed" });
     } catch (e) {
       // Errors return a message the model can act on, never a bare 500.
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Adaptive CTO (BET-1376) ----------
+  // GET /api/cto/state → {enabled, dot, needsYouCount, generationInFlight, tonightCount}
+  // The renderer's initial-mount read (§10.1); live updates ride the
+  // `{kind:"ctoState"}` bus event over /events. Behind the /api/* Bearer gate.
+  if (path === "/api/cto/state") {
+    try {
+      if (req.method === "GET") {
+        const state = await adaptiveCto.getState();
+        respondJson(res, 200, state);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
       respondJson(res, 500, { error: String(e?.message ?? e) });
     }
     return;

--- a/src/server/local.mjs
+++ b/src/server/local.mjs
@@ -81,6 +81,11 @@ const DEFAULT_CONFIG = {
   modelRouting: {
     preset: "balanced",
   },
+  // Adaptive CTO (BET-1376). Top-level master switch for the background
+  // engine; DISTINCT from the nested on-call CTO `cto.enabled` above (that
+  // gates the voice call window / read belt). Default false until the system
+  // ships. With it off the engine reports `disabled` and starts no work.
+  ctoEnabled: false,
 };
 
 let _config = null;

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -294,6 +294,12 @@ export type AppConfig = {
     // Whether the call window listens continuously (Issue 3). Default false.
     alwaysListening?: boolean;
   };
+  // ----- Adaptive CTO (BET-1376) -----
+  // Top-level master switch for the background engine. DISTINCT from the
+  // nested on-call CTO `cto.enabled` above (that gates the voice call window /
+  // read belt). Default false until the system is shipped. With it OFF the
+  // engine reports `disabled` and starts no work.
+  ctoEnabled?: boolean;
   // ----- Manta Optimizer (BET-1342 / Phase 2) -----
   // Master switch for the optimizer. DEFAULT FALSE. Opt-in: with it OFF the
   // optimizer changes nothing. It does NOT gate Automatic Manta Routing —


### PR DESCRIPTION
# CTO engine skeleton (BET-1376)

Deterministic engine process-side frame for the Adaptive CTO: lifecycle,
safety rails, and the one state surface the UI consumes. No pipeline logic
yet (explicitly out of scope).

## What this adds

- `src/server/ctoEngine.mjs` — `createCtoEngine(deps)` factory in the
  `delegate.mjs` dependency-injected style. All I/O injected; timers run
  through the shared `startPoller` (timer.unref() + inFlight guard).
  - Actor identity: every mutating act writes an A1 ledger row stamped
    `actor: "cto"`.
  - Rate limits (§3.3): ≤30 session creations/hour, ≤5 concurrent ephemeral,
    ≤2 concurrent CTO delegate jobs, tracked engine-side; exceeding any one
    pauses the engine + records a health-escalation blocker row.
  - Kill switch (§13.3): engine-external flag file at
    `statePath("cto","paused")`, checked at every tick and before every
    job/session start; `pause()`/`resume()` write/remove it; paused stops the
    engine's timer, event ingestion (a pump call, not a timer) keeps running
    (§10.6-5).
  - `createWatchdog` — pure, injectable watchdog logic (spend thresholds +
    liveness), registered as a **separate** timer from `index.mjs` (§13.3):
    >2× expected hourly burn → thrifty; >4× → kill-switch flag + blocker-card
    request in `engine-state.json`.
  - `createKillSwitch`, `createRateTracker`, `computeDot` exported separately
    for the tests.
- `src/server/ctoEngine.test.mjs` — 18 node:test cases (injected I/O only).

## Wiring in `src/server/index.mjs`

- Engine created + started always (self-gates on config); publishes
  `{kind:"ctoState"}` on the shared bus on every state change.
- `GET /api/cto/state` (behind the existing `/api/*` bearer gate) →
  `{enabled, dot, needsYouCount, generationInFlight, tonightCount}`.
- `adaptiveCto.observeEvent(evt)` fed from the same event pump as the other
  engines.
- New config field `ctoEnabled` (default false) added to
  `src/server/local.mjs` DEFAULT_CONFIG + `src/shared/types.ts` AppConfig,
  read via the existing `configGet()`. No `rpc.mjs` channel added — the
  generic `configUpdate` already covers new fields (per the issue).

## Verification results

**Files changed:** 5. `src/server/ctoEngine.mjs`, `src/server/ctoEngine.test.mjs`, `src/server/index.mjs`, `src/server/local.mjs`, `src/shared/types.ts`

- PR branch (`multica/BET-1376-cto-engine-skeleton` @ `4bbda0e0`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2987 pass / 0 fail / 0 skip. log sha256: `a0e717917de6e0a91fe48745e80e497be916645daa1ff04f454c1c54f7622de5`
- Base (`main` @ `6807e6bb`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 2969 pass / 0 fail / 0 skip. log sha256: `4dc7094ee265b7413f9410ccd1f6d003a1a1722e6b9b5d2f84e8f21483a65619`
- **Conclusion:** 0 new failures are caused by this PR; 18 new tests pass;
  0 pre-existing failures were resolved.

**Base: `origin/main` @ `6807e6bb`**

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.

## Follow-ups

- Parked: watchdog spend source is stubbed to 0/0 in `index.mjs` (deliberate —
  the budget reading lands with a later pipeline issue; 0/0 is a safe no-op).
  Filed: `01a04586-695f-78a3-b517-df86607f4704` (labeled follow-up).
