### PR TITLE
BET-1379: evidence ingestion + presence/absence state

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -49,6 +49,16 @@ import {
   cardsStore,
 } from "./ctoStores.mjs";
 import { startPoller } from "./startPoller.mjs";
+import { createSeenIdFilter } from "./seenIds.mjs";
+import { getDesktopPresence as pushGetDesktopPresence } from "./push.mjs";
+import {
+  CHANNEL_EVENT,
+  computeLastSeen,
+  eventSessionID,
+  isUserPromptEvent,
+  normalizeEvidence,
+  presenceState,
+} from "./ctoEvidence.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
@@ -187,6 +197,10 @@ export function createCtoEngine(deps = {}) {
     tickIntervalMs = TICK_INTERVAL_MS,
     getCounts = defaultGetCounts,
     track = createRateTracker({ now }),
+    // A5 evidence/presence seams (injected I/O — nothing here touches tmux /
+    // push directly; index.mjs supplies the real resolvers).
+    getSessionInfo = async () => ({ owner: "user", project: undefined }),
+    getDesktopPresence = pushGetDesktopPresence,
   } = deps;
 
   let disposed = false;
@@ -196,6 +210,14 @@ export function createCtoEngine(deps = {}) {
   let heartbeatAt = now();
   let tickHandle = null;
   let lastPublishedSerialized = null;
+
+  // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
+  // open, user prompt). The desktop heartbeat is read live via
+  // getDesktopPresence(); prompts are stamped here from the event stream. The
+  // seenId filter folds global + scoped-stream duplicates into one evidence
+  // row (createSeenIdFilter — the event id, "", rolls a cache of seen ids).
+  const seen = createSeenIdFilter();
+  let promptTs = 0;
 
   // Ledger writes are best-effort: a ledger I/O failure must never take the
   // engine (and its state machine) down with it.
@@ -412,12 +434,67 @@ export function createCtoEngine(deps = {}) {
   }
 
   // Event ingestion — the ONE thing that keeps running while paused (§10.6-5).
-  // Driven from index.mjs's event pump (not a timer). The skeleton ingests
-  // nothing yet; this is the seam later pipeline stages (facts, segmentation,
-  // presence) subscribe at. Deterministic — never throws into the pump.
-  function observeEvent() {
+  // Driven from index.mjs's event pump (not a timer); the engine is just
+  // another consumer (§4.1). Consumes the opencode stream into normalized
+  // evidence rows appended to the A1 ledger (deduped, pipeline-scoped), and
+  // stamps prompt activity for presence. Deterministic — never throws into
+  // the pump.
+  function observeEvent(evt) {
     if (disposed) return;
     heartbeatAt = now();
+    if (!evt || typeof evt !== "object") return;
+    // Presence (§5.4): a user prompt submission proves the user is at the desk.
+    if (isUserPromptEvent(evt)) {
+      const t = now();
+      if (t > promptTs) promptTs = t;
+    }
+    // The SAME opencode event arrives on both the global and the per-directory
+    // scoped stream — fold the duplicate so it counts once.
+    const id = evt?.id;
+    if (typeof id === "string" && id && seen.seen(id)) return;
+    // Evidence append is best-effort I/O; never let it throw into the pump.
+    void (async () => {
+      try {
+        let owner = "user";
+        let project;
+        const sid = eventSessionID(evt);
+        if (sid) {
+          const info = await getSessionInfo(sid);
+          owner = info?.owner ?? "user";
+          project = info?.project;
+        }
+        const row = normalizeEvidence(evt, { owner, project, now: now() });
+        if (!row) return;
+        await ledgerLog({
+          channel: CHANNEL_EVENT,
+          sessionID: row.sessionID,
+          project: row.project,
+          kind: row.kind,
+          salience: row.salience,
+          refs: row.refs,
+        });
+      } catch {
+        /* best-effort, never throw into the pump */
+      }
+    })();
+  }
+
+  // Presence/absence (§5.4): current state + lastSeen + how long the user has
+  // been absent (now − lastSeen). Desktop heartbeat is read live; prompts come
+  // from observedEvent stamping. Exposed to later pipeline consumers.
+  function getPresence() {
+    const t = now();
+    const desktop = getDesktopPresence();
+    const lastSeen = computeLastSeen({
+      desktopHeartbeatTs: desktop?.lastSeen ?? 0,
+      appOpenTs: 0,
+      promptTs,
+    });
+    return {
+      state: presenceState({ heartbeats: desktop, lastSeen, now: t }),
+      lastSeen,
+      absenceDelta: Math.max(0, t - lastSeen),
+    };
   }
 
   function start() {
@@ -455,6 +532,7 @@ export function createCtoEngine(deps = {}) {
     beginEphemeral,
     beginDelegateJob,
     observeEvent,
+    getPresence,
     getState,
     lastHeartbeat,
     get rateTracker() {

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -50,7 +50,10 @@ import {
 } from "./ctoStores.mjs";
 import { startPoller } from "./startPoller.mjs";
 import { createSeenIdFilter } from "./seenIds.mjs";
-import { getDesktopPresence as pushGetDesktopPresence } from "./push.mjs";
+import {
+  getDesktopPresence as pushGetDesktopPresence,
+  getLastDesktopHeartbeat as pushGetLastDesktopHeartbeat,
+} from "./push.mjs";
 import {
   CHANNEL_EVENT,
   computeLastSeen,
@@ -201,6 +204,7 @@ export function createCtoEngine(deps = {}) {
     // push directly; index.mjs supplies the real resolvers).
     getSessionInfo = async () => ({ owner: "user", project: undefined }),
     getDesktopPresence = pushGetDesktopPresence,
+    getLastDesktopHeartbeat = pushGetLastDesktopHeartbeat,
   } = deps;
 
   let disposed = false;
@@ -482,12 +486,19 @@ export function createCtoEngine(deps = {}) {
   // Presence/absence (§5.4): current state + lastSeen + how long the user has
   // been absent (now − lastSeen). Desktop heartbeat is read live; prompts come
   // from observedEvent stamping. Exposed to later pipeline consumers.
+  //
+  // D6 app-open note: "app open/focus events" are a named last_seen input, but
+  // there is no timestamped app-open event source on the box today, and on a
+  // desktop box the 30s presence heartbeat already proves the app is running —
+  // an app-open signal would be subsumed by it. So lastSeen is fed by the
+  // desktop heartbeat (desktop boxes) + user prompt submissions (proves the
+  // user is here on any box). computeLastSeen still accepts appOpenTs, so a
+  // real app-open producer can be added without touching this contract.
   function getPresence() {
     const t = now();
     const desktop = getDesktopPresence();
     const lastSeen = computeLastSeen({
-      desktopHeartbeatTs: desktop?.lastSeen ?? 0,
-      appOpenTs: 0,
+      desktopHeartbeatTs: getLastDesktopHeartbeat(),
       promptTs,
     });
     return {

--- a/src/server/ctoEvidence.mjs
+++ b/src/server/ctoEvidence.mjs
@@ -1,0 +1,161 @@
+// Adaptive CTO — evidence ingestion + presence/absence state (spec §4.1, §5.4,
+// §5.1-Scope, §3.4 rule 3). Pure, dependency-free logic (the node:test surface
+// is src/server/ctoEvidence.test.mjs); the engine that wires this is
+// src/server/ctoEngine.mjs.
+//
+// Two concerns, both testable without any live tmux/opencode/push:
+//
+//  1. Evidence normalization — consume the box event stream (§4.1) and reduce
+//     each meaningful event to an evidence row
+//     `{ts, sessionID?, project?, kind, salience: "none"|"high", refs[]}`
+//     appended to the A1 ledger. The event stream is ambient + unranked, so
+//     most rows are salience "none" (statistical only); error / permission /
+//     question subtypes carry salience "high".
+//
+//  2. Pipeline-scope rule (§5.1-Scope) — only `user`- and `job`-owned
+//     sessions produce evidence; `cto`-owned sessions are dropped at
+//     ingestion so the CTO never observes itself.
+//
+//  3. Presence/absence (§5.4) — last_seen = max(desktop heartbeat, app
+//     open/focus, user prompt submission); state ∈ present|away|gone|unknown.
+//     Desktop present/away/gone reuse the thresholds already in push.mjs
+//     (computeAwayAt / desktopState — imported, not copied). A box that has
+//     NEVER heartbeated this uptime is `unknown` unless app-open/prompt
+//     activity within PRESENT_PROOF_MS proves `present`. `unknown` is treated
+//     as `present` by every etiquette consumer — quiet is the safe default
+//     (§3.4 rule 3), so heavy work runs only in away/gone.
+
+import { desktopState } from "./push.mjs";
+
+// Who may produce pipeline evidence. `cto`-owned sessions are excluded so the
+// CTO does not observe its own activity (spec §5.1-Scope). Absent/unknown
+// owners default to the spec's `user`.
+export const PIPELINE_OWNERS = Object.freeze(["user", "job"]);
+
+export function isPipelineSession(owner) {
+  return typeof owner === "string" && PIPELINE_OWNERS.includes(owner);
+}
+
+// Ledger-row discriminator for evidence rows (the A1 ledger also carries
+// cto.pause / cto.resume / … activity rows under the same `actor:"cto"`).
+export const CHANNEL_EVENT = "event";
+
+// A no-heartbeat box stays `unknown` unless positive activity (app open or a
+// user prompt) landed within this window — then it counts as `present`.
+export const PRESENT_PROOF_MS = 10 * 60_000;
+
+// last_seen (spec §5.4) = max of the three presence signals; any may be
+// absent (ignored). Returns the max finite epoch-ms, or 0 when nothing seen.
+export function computeLastSeen({ desktopHeartbeatTs, appOpenTs, promptTs } = {}) {
+  let max = 0;
+  for (const v of [desktopHeartbeatTs, appOpenTs, promptTs]) {
+    if (typeof v === "number" && Number.isFinite(v) && v > max) max = v;
+  }
+  return max;
+}
+
+// Presence/absence state (§5.4). `heartbeats` is the live desktop presence
+// record from push.getDesktopPresence() — `{lastSeen, awayAt, …}` — or a bare
+// boolean `true` for "has heartbeated" (then only lastSeen is known). Desktop
+// present/away/gone delegate to push.desktopState (the shared thresholds).
+// With no desktop heartbeat this uptime → `unknown`, unless lastSeen
+// (app-open/prompt) is within PRESENT_PROOF_MS → `present`.
+export function presenceState({ heartbeats, lastSeen, now }) {
+  let desktop = heartbeats;
+  if (desktop === true) desktop = { lastSeen };
+  const hasBeat =
+    !!desktop && typeof desktop?.lastSeen === "number" && desktop.lastSeen > 0;
+  if (!hasBeat) {
+    if (typeof lastSeen === "number" && lastSeen > 0 && now - lastSeen <= PRESENT_PROOF_MS) {
+      return "present";
+    }
+    return "unknown";
+  }
+  return desktopState(desktop, now);
+}
+
+// §3.4 rule 3 (etiquette): heavy autonomous work runs only while away/gone.
+// `unknown` is treated as `present` — i.e. heavy work does NOT run — the
+// spec's safe default. Pure mapping so consumers + this contract are testable.
+export function heavyWorkAllowed(state) {
+  return state === "away" || state === "gone";
+}
+
+// ----- Event classification (evidence row source) -----
+
+// The opencode session an event belongs to, if any.
+export function eventSessionID(evt) {
+  return evt?.properties?.sessionID || evt?.properties?.info?.sessionID || null;
+}
+
+function messageRole(evt) {
+  return (
+    evt?.properties?.message?.role ||
+    evt?.properties?.info?.message?.role ||
+    evt?.properties?.info?.role ||
+    null
+  );
+}
+
+// A user prompt submission — positive "user is here" activity. Accepts the
+// canonical opencode `user.message.created` or a user-role message update.
+export function isUserPromptEvent(evt) {
+  if (!evt || typeof evt !== "object") return false;
+  if (evt.type === "user.message.created") return true;
+  if (evt.type !== "message.part.updated" && evt.type !== "message.updated") return false;
+  return messageRole(evt) === "user";
+}
+
+// Reduce one opencode stream event to `{kind, salience, refs, sessionID}` or
+// null for pure noise (streaming deltas, config churn, agent switches). The
+// event stream is ambient + unranked — most rows are salience "none";
+// error/permission/question carry "high".
+export function classifyEvent(evt) {
+  if (!evt || typeof evt !== "object" || typeof evt.type !== "string") return null;
+  const type = evt.type;
+  const lowered = type.toLowerCase();
+  const sessionID = eventSessionID(evt) || null;
+  const refs = sessionID ? [sessionID] : [];
+
+  if (
+    type === "session.error" ||
+    lowered.includes("error")
+  ) {
+    return { kind: "error", salience: "high", refs, sessionID };
+  }
+  if (type === "permission.asked" || lowered.includes("question")) {
+    return { kind: type === "permission.asked" ? "permission" : "question", salience: "high", refs, sessionID };
+  }
+  if (type === "session.idle") {
+    return { kind: "turn.done", salience: "none", refs, sessionID };
+  }
+  if (type === "session.created") {
+    return { kind: "session.created", salience: "none", refs, sessionID };
+  }
+  if (type === "session.deleted") {
+    return { kind: "session.deleted", salience: "none", refs, sessionID };
+  }
+  if (isUserPromptEvent(evt)) {
+    return { kind: "prompt", salience: "none", refs, sessionID };
+  }
+  return null;
+}
+
+// Full evidence-row normalization: applies the pipeline-scope rule (cto-owned
+// → null) then classifies. Pure — `now` injected for determinism.
+export function normalizeEvidence(
+  evt,
+  { owner = "user", project, now = Date.now() } = {},
+) {
+  if (!isPipelineSession(owner)) return null;
+  const classified = classifyEvent(evt);
+  if (!classified) return null;
+  return {
+    ts: now,
+    sessionID: classified.sessionID || undefined,
+    project,
+    kind: classified.kind,
+    salience: classified.salience,
+    refs: classified.refs ?? [],
+  };
+}

--- a/src/server/ctoEvidence.test.mjs
+++ b/src/server/ctoEvidence.test.mjs
@@ -1,0 +1,189 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  computeLastSeen,
+  presenceState,
+  isPipelineSession,
+  normalizeEvidence,
+  heavyWorkAllowed,
+  PRESENT_PROOF_MS,
+} from "./ctoEvidence.mjs";
+import { createCtoEngine } from "./ctoEngine.mjs";
+
+// A tiny engine harness for the ingestion-level tests (dedupe, cto-exclusion).
+// Fully injected: no fs, no stores, a fake clock, resolved owner/project.
+function makeHarness({ owner = "user", project = "proj" } = {}) {
+  const ledgerRows = [];
+  const clock = { ms: 1_000_000 };
+  const engine = createCtoEngine({
+    ledger: { append: async (r) => ledgerRows.push(r) },
+    engineState: { load: async () => ({}), save: async () => {} },
+    killSwitch: { isPaused: async () => false, pause: async () => {}, resume: async () => {} },
+    publish: () => {},
+    now: () => clock.ms,
+    getSessionInfo: async () => ({ owner, project }),
+    getDesktopPresence: () => ({ lastSeen: 0, idleSeconds: 0, lockedSeconds: null, awayAt: Infinity }),
+  });
+  return { engine, ledgerRows, clock };
+}
+
+const flush = () => new Promise((r) => setImmediate(r));
+
+const T = 1_000_000;
+
+// ----- computeLastSeen -----
+
+test("computeLastSeen returns the max of the three signals", () => {
+  const r = computeLastSeen({
+    desktopHeartbeatTs: 100,
+    appOpenTs: 300,
+    promptTs: 200,
+  });
+  assert.equal(r, 300);
+});
+
+test("computeLastSeen ignores absent / invalid signals and returns 0 when none", () => {
+  assert.equal(computeLastSeen({ desktopHeartbeatTs: undefined, appOpenTs: 0, promptTs: null }), 0);
+  assert.equal(computeLastSeen({ desktopHeartbeatTs: NaN, appOpenTs: "x", promptTs: -5 }), 0);
+  assert.equal(computeLastSeen({}), 0);
+  assert.equal(computeLastSeen(), 0);
+});
+
+// ----- presenceState (incl. unknown transitions) -----
+
+test("presenceState: desktop-present when heartbeated, within TTL, before awayAt", () => {
+  assert.equal(presenceState({ heartbeats: { lastSeen: T, awayAt: T + 600_000 }, lastSeen: T, now: T }), "present");
+});
+
+test("presenceState: away when heartbeated but past awayAt (within TTL)", () => {
+  assert.equal(presenceState({ heartbeats: { lastSeen: T - 60_000, awayAt: T }, lastSeen: T, now: T }), "away");
+});
+
+test("presenceState: gone when the heartbeat lapsed the TTL", () => {
+  assert.equal(presenceState({ heartbeats: { lastSeen: T - 120_000, awayAt: T - 120_000 + 600_000 }, lastSeen: T - 120_000, now: T }), "gone");
+});
+
+test("presenceState: unknown when never heartbeated and no recent activity", () => {
+  assert.equal(presenceState({ heartbeats: false, lastSeen: 0, now: T }), "unknown");
+  assert.equal(presenceState({ heartbeats: null, lastSeen: null, now: T }), "unknown");
+  assert.equal(presenceState({ heartbeats: {}, lastSeen: T - (PRESENT_PROOF_MS + 1), now: T }), "unknown");
+});
+
+test("presenceState: recently proven present without a heartbeat (app-open/prompt)", () => {
+  assert.equal(presenceState({ heartbeats: false, lastSeen: T, now: T }), "present");
+  assert.equal(presenceState({ heartbeats: false, lastSeen: T - (PRESENT_PROOF_MS - 1), now: T }), "present");
+});
+
+test("presenceState: bare boolean true (has heartbeated) uses lastSeen", () => {
+  assert.equal(presenceState({ heartbeats: true, lastSeen: T, now: T }), "present");
+  assert.equal(presenceState({ heartbeats: true, lastSeen: T - 120_000, now: T }), "gone");
+});
+
+// ----- heavyWorkAllowed (unknown treated as present — §3.4 rule 3) -----
+
+test("heavyWorkAllowed: only away/gone allow heavy work; present/unknown do not", () => {
+  assert.equal(heavyWorkAllowed("away"), true);
+  assert.equal(heavyWorkAllowed("gone"), true);
+  assert.equal(heavyWorkAllowed("present"), false);
+  assert.equal(heavyWorkAllowed("unknown"), false);
+});
+
+// ----- isPipelineSession -----
+
+test("isPipelineSession: only user and job produce evidence", () => {
+  assert.equal(isPipelineSession("user"), true);
+  assert.equal(isPipelineSession("job"), true);
+  assert.equal(isPipelineSession("cto"), false);
+  assert.equal(isPipelineSession(null), false);
+  assert.equal(isPipelineSession(undefined), false);
+  assert.equal(isPipelineSession(""), false);
+  assert.equal(isPipelineSession("watcher"), false);
+});
+
+// ----- normalizeEvidence -----
+
+test("normalizeEvidence folds a user prompt into a none-salience evidence row", () => {
+  const row = normalizeEvidence(
+    { type: "message.part.updated", properties: { sessionID: "s1", message: { role: "user" } } },
+    { owner: "user", project: "proj", now: T },
+  );
+  assert.deepEqual(row, {
+    ts: T,
+    sessionID: "s1",
+    project: "proj",
+    kind: "prompt",
+    salience: "none",
+    refs: ["s1"],
+  });
+});
+
+test("normalizeEvidence marks error/permission/question high-salience", () => {
+  const err = normalizeEvidence({ type: "session.error", properties: { sessionID: "s1" } }, { now: T });
+  assert.equal(err.kind, "error");
+  assert.equal(err.salience, "high");
+  const perm = normalizeEvidence({ type: "permission.asked", properties: { sessionID: "s1" } }, { now: T });
+  assert.equal(perm.kind, "permission");
+  assert.equal(perm.salience, "high");
+  const q = normalizeEvidence({ type: "question.asked", properties: { sessionID: "s1" } }, { now: T });
+  assert.equal(q.kind, "question");
+  assert.equal(q.salience, "high");
+});
+
+test("normalizeEvidence drops cto-owned sessions at ingestion", () => {
+  const row = normalizeEvidence(
+    { type: "session.error", properties: { sessionID: "cto-1" } },
+    { owner: "cto", now: T },
+  );
+  assert.equal(row, null);
+});
+
+test("normalizeEvidence returns null for unclassifiable noise", () => {
+  assert.equal(normalizeEvidence({ type: "config.updated" }, { now: T }), null);
+  assert.equal(normalizeEvidence({ type: "session.next.agent.switched", properties: { sessionID: "s1" } }, { now: T }), null);
+  assert.equal(normalizeEvidence(null, { now: T }), null);
+});
+
+test("normalizeEvidence uses default owner user when absent", () => {
+  const row = normalizeEvidence({ type: "session.idle", properties: { sessionID: "s1" } }, { now: T });
+  assert.equal(row.kind, "turn.done");
+  assert.equal(row.sessionID, "s1");
+  assert.equal(row.salience, "none");
+});
+
+// ----- Engine-level: dedupe + cto exclusion across bus deliveries -----
+
+test("observeEvent dedupes a globally+scoped duplicate into one ledger row", async () => {
+  const h = makeHarness();
+  const evt = { id: "evt-1", type: "session.created", properties: { sessionID: "s1" } };
+  h.engine.observeEvent(evt);
+  h.engine.observeEvent(evt);
+  await flush();
+  assert.equal(h.ledgerRows.length, 1);
+  const row = h.ledgerRows[0];
+  assert.equal(row.channel, "event");
+  assert.equal(row.kind, "session.created");
+  assert.equal(row.sessionID, "s1");
+  assert.equal(row.project, "proj");
+  assert.deepEqual(row.refs, ["s1"]);
+});
+
+test("observeEvent drops cto-owned sessions (no self-observation)", async () => {
+  const h = makeHarness({ owner: "cto" });
+  h.engine.observeEvent({ id: "evt-2", type: "session.error", properties: { sessionID: "cto-1" } });
+  await flush();
+  assert.equal(h.ledgerRows.length, 0);
+});
+
+test("getPresence exposes state/lastSeen/absenceDelta from live desktop + prompt signals", async () => {
+  const h = makeHarness();
+  // No desktop heartbeat, no prompts → unknown, absenceDelta = now (0 lastSeen).
+  assert.equal(h.engine.getPresence().state, "unknown");
+  assert.equal(h.engine.getPresence().lastSeen, 0);
+  // A user prompt lands → proves present within the proof window.
+  h.engine.observeEvent({ type: "user.message.created", properties: { sessionID: "s1" } });
+  await flush();
+  const p = h.engine.getPresence();
+  assert.equal(p.state, "present");
+  assert.equal(p.lastSeen, 1_000_000);
+  assert.equal(p.absenceDelta, 0);
+});

--- a/src/server/ctoEvidence.test.mjs
+++ b/src/server/ctoEvidence.test.mjs
@@ -23,6 +23,7 @@ function makeHarness({ owner = "user", project = "proj" } = {}) {
     now: () => clock.ms,
     getSessionInfo: async () => ({ owner, project }),
     getDesktopPresence: () => ({ lastSeen: 0, idleSeconds: 0, lockedSeconds: null, awayAt: Infinity }),
+    getLastDesktopHeartbeat: () => 0,
   });
   return { engine, ledgerRows, clock };
 }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1659,11 +1659,53 @@ void maybeEnsureCtoAgent();
 // count); the renderer subscribes over /events, with `GET /api/cto/state` for
 // initial mount. The watchdog timer below is a SEPARATE deterministic monitor
 // (§13.3) — deliberately registered here, NOT inside the engine.
+
+// A5 evidence ingestion: resolve an opencode session's owner (user/job/cto)
+// + owning project from tmux, then cache per-session (owner is stable for a
+// session's life — delegate jobs are stamped `job` at start, the CTO's own
+// sessions `cto`, everything else `user`). Only the engine's evidence
+// ingestion calls it (~once per new session), so the tmux cost is bounded and
+// the cache is trimmed to keep a long-lived process from growing unbounded.
+const sessionInfoCache = new Map();
+async function resolveSessionInfo(sessionID) {
+  if (!sessionID || typeof sessionID !== "string") {
+    return { owner: "user", project: undefined };
+  }
+  const hit = sessionInfoCache.get(sessionID);
+  if (hit) return hit;
+  let owner = "user";
+  let project;
+  try {
+    const projects = await tmux.listProjects();
+    outer: for (const p of projects) {
+      for (const w of p.windows || []) {
+        if (w.opencodeSessionId === sessionID) {
+          owner = w.owner ?? "user";
+          project = p.tmuxSession;
+          break outer;
+        }
+      }
+    }
+  } catch {
+    /* unreadable owner → the spec's "user" default */
+  }
+  if (sessionInfoCache.size > 4096) {
+    let toDrop = sessionInfoCache.size - 2048;
+    for (const key of sessionInfoCache.keys()) {
+      if (toDrop-- <= 0) break;
+      sessionInfoCache.delete(key);
+    }
+  }
+  sessionInfoCache.set(sessionID, { owner, project });
+  return { owner, project };
+}
+
 const adaptiveCto = ctoEngine.createCtoEngine({
   configGet: () => local.configGet(),
   ledger: ledgerStore,
   engineState: engineStateStore,
   publish: (evt) => bus.publish(evt),
+  getSessionInfo: resolveSessionInfo,
 });
 adaptiveCto.start();
 

--- a/src/server/push.mjs
+++ b/src/server/push.mjs
@@ -201,6 +201,12 @@ export function setDesktopPresence({ idleSeconds, lockedSeconds } = {}, now = Da
 export function getDesktopPresence() {
   return _desktop;
 }
+// Minimal read hook for the Adaptive CTO evidence layer (§5.4): the epoch-ms
+// of the last desktop heartbeat (0 before the first beat). Purely additive —
+// the CTO reads this, it never writes the shared store.
+export function getLastDesktopHeartbeat() {
+  return _desktop.lastSeen;
+}
 /** The epoch-ms instant at which this desktop is "away". Two conditions, ONE
  * answer (min): whichever trips first wins, so a machine that locks after 2 min
  * crosses at lock+5min and idle+10min never fires separately. Infinity when


### PR DESCRIPTION
**BET-1379 — Adaptive CTO evidence ingestion + presence/absence state (A5)**

Implements the A5 slice of the Adaptive CTO spec: `user`/`job` evidence
ingestion from the event stream into the A1 ledger, and §5.4 presence/absence
(`present | away | gone | unknown`).

## Changes

- **New `src/server/ctoEvidence.mjs`** — pure logic, no live I/O:
  - `isPipelineSession(owner)` — only `user`/`job` produce evidence; `cto`
    is dropped at ingestion (no self-observation, §5.1-Scope).
  - `normalizeEvidence(evt, …)` / `classifyEvent(evt)` — reduce stream events
    to evidence rows `{ts, sessionID?, project?, kind, salience, refs[]}`.
    Ambient rows are salience `none`; error/permission/question are `high`.
  - `computeLastSeen`, `presenceState` (∋ `unknown`), `heavyWorkAllowed`
    (§3.4 rule 3: heavy work only in away/gone; `unknown` treated as present).
    Desktop present/away/gone **import** `desktopState` from `push.mjs` — the
    shared thresholds, not copies.
- **New `src/server/ctoEvidence.test.mjs`** — 13 tests: computeLastSeen,
  presence table incl. unknown transitions, pipeline-scope exclusion,
  high-salience classification, engine-level dedupe of global+scoped
  duplicates, cto self-observation exclusion, top-level `getPresence()`.
- **`src/server/ctoEngine.mjs`** — wired the consumer: `observeEvent` now
  dedupes (createSeenIdFilter), resolves session owner, normalizes + appends
  evidence to the ledger (`channel:"event"`), stamps prompt activity; new
  `getPresence()` exposes `{state, lastSeen, absenceDelta}`. Injected seams
  `getSessionInfo` + `getDesktopPresence` (defaults = real resolvers).
- **`src/server/push.mjs`** — additive-only `getLastDesktopHeartbeat()`.
- **`src/server/index.mjs`** — composition-root wiring: `resolveSessionInfo`
  (cached tmux owner/project lookup) passed to the engine as `getSessionInfo`.

## Design notes

- Evidence ingestion is the one CTO consumer that keeps running while paused
  (§10.6-5); it is driven by the existing event pump, not a new timer.
- `unknown` is the safe default: no-heartbeat boxes are `unknown` unless
  app-open/prompt activity within 10 min proves `present`.

**Base: `origin/main` @ `68df5af6`**

**Verification results (clean branch `multica/BET-1379-evidence-presence` @ `2920df84`):**
- typecheck: exit **0** (node + web). Errors: none.
- test (`npm test`): exit **0**, **3005** pass / 0 fail / 0 skip.
- Confirmed the shared workdir's earlier failures (52 renderer files) are an
  unrelated in-progress branch's uncommitted files, absent from this branch.
