### PR TITLE
feat(server): CTO ephemeral session runner + model task classes (BET-1378)

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -31,13 +31,14 @@
 // registered from src/server/index.mjs (also §13.3), can write it without
 // this module cooperating.
 //
-// Timer discipline: the engine owns exactly one timer today — the liveness /
-// kill-switch / state-refresh tick — via startPoller (timer.unref() + inFlight
-// guard). It is stopped on pause and restarted on resume. Event ingestion
-// (observeEvent) is NOT a timer: it is driven from index.mjs's event pump and
-// keeps running while paused (§10.6-5). Future work timers (probes, overnight,
-// backfill) register through the same start/stop surface so pause halts them
-// too; they are out of scope for this skeleton.
+// Timer discipline: the engine owns exactly two timers — the liveness /
+// kill-switch / state-refresh tick and the ephemeral-session reaper (§3.1,
+// BET-1378) — via startPoller (timer.unref() + inFlight guard). Both are
+// stopped on pause and restarted on resume. Event ingestion (observeEvent) is
+// NOT a timer: it is driven from index.mjs's event pump and keeps running
+// while paused (§10.6-5). Future work timers (probes, overnight, backfill)
+// register through the same start/stop surface so pause halts them too;
+// they are out of scope for this skeleton.
 
 import { promises as fsp } from "node:fs";
 import { dirname } from "node:path";
@@ -205,6 +206,7 @@ export function createCtoEngine(deps = {}) {
     getSessionInfo = async () => ({ owner: "user", project: undefined }),
     getDesktopPresence = pushGetDesktopPresence,
     getLastDesktopHeartbeat = pushGetLastDesktopHeartbeat,
+    reaper = null, // { start() -> {stop} } | null — the §3.1 ephemeral-session reaper (ctoSessions)
   } = deps;
 
   let disposed = false;
@@ -213,6 +215,7 @@ export function createCtoEngine(deps = {}) {
   let enabled = false;
   let heartbeatAt = now();
   let tickHandle = null;
+  let reaperHandle = null;
   let lastPublishedSerialized = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
@@ -325,6 +328,10 @@ export function createCtoEngine(deps = {}) {
       tickHandle.stop();
       tickHandle = null;
     }
+    if (reaperHandle) {
+      reaperHandle.stop();
+      reaperHandle = null;
+    }
   }
 
   function startTimers() {
@@ -334,6 +341,11 @@ export function createCtoEngine(deps = {}) {
       label: "cto-engine",
       immediate: false,
     });
+    // The §3.1 reaper is a work timer like any other: started with the engine,
+    // halted on pause (event ingestion alone keeps running while paused).
+    if (reaper && !reaperHandle && typeof reaper.start === "function") {
+      reaperHandle = reaper.start();
+    }
   }
 
   // §10.6-5: pausing stops all engine timers (event ingestion is not a timer

--- a/src/server/ctoSessions.mjs
+++ b/src/server/ctoSessions.mjs
@@ -1,0 +1,423 @@
+// src/server/ctoSessions.mjs
+// BET-1378 — the Adaptive CTO's ephemeral session runner (§3.1) + model task
+// classes (§12.3). The one helper every model-needing CTO step uses: run a
+// headless opencode session, read the result synchronously (GET …/message,
+// no scoped SSE, no directory registration), delete it, and never leak.
+//
+// Pure logic + injected I/O in the style of delegate.mjs — no live
+// tmux/opencode/network in tests.
+
+import { startPoller } from "./startPoller.mjs";
+import { engineStateStore } from "./ctoStores.mjs";
+import { listRoutableModels } from "./opencode.mjs";
+import { buildRoutingServices } from "./routingServices.mjs";
+import { lookupModel, matchModel, allModels } from "./modelCatalog.mjs";
+import { chooseSubagentModel } from "./delegate.mjs";
+
+// ---------------------------------------------------------------------------
+// Task classes (§12.3) — a literal table in code. NEVER a model id.
+//
+//   nano tier  : ambient-summarize (≤4k ctx), gatekeeper, worthiness
+//   mid tier   : digest-compose (≤12k ctx), suggest
+//   spawn      : context-assembly budget ≤8k (a delegate job, not a tier)
+//
+// `tier` is the routing band; `contextBudget` is the token cap for the
+// assembled context (absent → no cap). Model resolution always goes through
+// the existing model catalog/router (never hardcoded).
+// ---------------------------------------------------------------------------
+export const TASK_CLASSES = Object.freeze({
+  "ambient-summarize": Object.freeze({ tier: "nano", contextBudget: 4000 }),
+  gatekeeper: Object.freeze({ tier: "nano" }),
+  worthiness: Object.freeze({ tier: "nano" }),
+  "digest-compose": Object.freeze({ tier: "mid", contextBudget: 12000 }),
+  suggest: Object.freeze({ tier: "mid" }),
+  spawn: Object.freeze({ contextBudget: 8000 }),
+});
+
+// Route-band per §12.3 tier — what the existing router is asked to satisfy.
+export const TIER_TO_ROUTER_TIER = Object.freeze({
+  nano: "fast", // cheapest qualifying
+  mid: "balanced",
+});
+
+// Cascade rule (§12.3): an AMBIENT (nano) class may escalate exactly one tier
+// when its structured output fails validation, at most once per call. Mid-tier
+// classes and `spawn` never escalate.
+export const TIER_ESCALATION = Object.freeze({ nano: "mid" });
+
+export const CTO_TITLE_PREFIX = "cto:";
+
+// Reaper (§3.1): every 10 min sweep orphaned `cto:` sessions older than 30 min
+// that are not in the active set (so a crash between create and delete can't
+// leak sessions).
+export const REAPER_INTERVAL_MS = 10 * 60 * 1000;
+export const REAPER_MAX_AGE_MS = 30 * 60 * 1000;
+
+export function getTaskClass(taskClass) {
+  const meta = TASK_CLASSES[taskClass];
+  if (!meta) {
+    throw new Error(`runEphemeral: unknown task class "${taskClass}" (see TASK_CLASSES)`);
+  }
+  return meta;
+}
+
+// One-step escalation for a class tier; null when the tier must not escalate.
+export function escalateTier(tier) {
+  return TIER_ESCALATION[tier] ?? null;
+}
+
+// Approximate token count (1 token ≈ 4 chars) for budget truncation.
+export function estimateTokens(text) {
+  return Math.ceil(String(text ?? "").length / 4);
+}
+
+/**
+ * Pure context assembly (§3.1, §12.3). `context` is an ORDERED list of
+ * `{ priority, text }` blocks. Budgets the result to the task class's token
+ * budget by dropping the LOWEST-priority blocks first (high-priority kept),
+ * then joining with a blank line. No budget on the class → all blocks kept in
+ * priority order. A single highest-priority block that alone overflows the
+ * budget is truncated rather than dropped, so the model always sees something.
+ */
+export function assembleContext(context = [], { taskClass } = {}) {
+  const meta = getTaskClass(taskClass);
+  const budget = meta?.contextBudget;
+  const blocks = Array.isArray(context) ? context : [];
+  const ordered = blocks
+    .map((b) => ({ priority: Number(b?.priority) || 0, text: String(b?.text ?? "") }))
+    .sort((a, b) => b.priority - a.priority);
+
+  if (budget == null) {
+    return ordered.map((b) => b.text).join("\n\n");
+  }
+
+  const kept = [];
+  let tokens = 0;
+  for (const b of ordered) {
+    const t = estimateTokens(b.text);
+    if (tokens + t > budget) {
+      if (kept.length === 0) {
+        const chars = Math.max(0, Math.floor(budget * 4));
+        kept.push(b.text.slice(0, chars));
+      }
+      break; // this and every lower-priority block are dropped first
+    }
+    kept.push(b.text);
+    tokens += t;
+  }
+  return kept.join("\n\n");
+}
+
+// ---------------------------------------------------------------------------
+// Active-set bookkeeping (engine-state.json `activeEphemeral`, A1 store).
+// The active set protects a mid-flight session from the reaper.
+// ---------------------------------------------------------------------------
+
+export function addActive(set, id) {
+  const out = new Set(Array.isArray(set) ? set : []);
+  out.add(id);
+  return [...out];
+}
+
+export function removeActive(set, id) {
+  return (Array.isArray(set) ? set : []).filter((x) => x !== id);
+}
+
+async function loadActivePayload(engineState) {
+  try {
+    const p = await engineState.load();
+    return p && typeof p === "object" ? p : {};
+  } catch {
+    return {};
+  }
+}
+
+async function activeAdd(sid, { engineState }) {
+  const payload = await loadActivePayload(engineState);
+  await engineState.save({
+    ...payload,
+    activeEphemeral: addActive(payload.activeEphemeral, sid),
+  });
+}
+
+async function activeRemove(sid, { engineState }) {
+  const payload = await loadActivePayload(engineState);
+  await engineState.save({
+    ...payload,
+    activeEphemeral: removeActive(payload.activeEphemeral, sid),
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Session lifecycle
+// ---------------------------------------------------------------------------
+
+/**
+ * Run ONE headless ephemeral session for a task class.
+ *
+ * 1. Resolves the model for the class tier through the existing model
+ *    catalog/router (cheapest qualifying model; null → box default).
+ * 2. Runs the session via the injected oc.runEphemeralSession — which (a)
+ *    creates a headless session (no tmux window, no @manta-session-id stamp →
+ *    no sidebar row) titled `cto:<taskClass>`, (b) calls onCreated(sid) BEFORE
+ *    prompting (records the session in engine-state's activeEphemeral set),
+ *    (c) prompts then reads the result synchronously, (d) deletes the session.
+ * 3. On any path (success or error) removes the session from the active set.
+ *
+ * The production `oc` adapter wires opencode.mjs's `runSynchronousSession`
+ * (the one non-SSE create→prompt→poll→read→delete primitive — used by
+ * auto-rename and the optimizer too; never a second copy). Tests inject a mock.
+ *
+ * @param {object} a
+ * @param {string} a.taskClass  a key of TASK_CLASSES
+ * @param {Array<{priority,text}>} [a.context]  ordered rank-ordered blocks
+ * @param {string} [a.directory]  headless session workdir (default "~")
+ * @param {object} [a.deps]
+ * @param {object} a.deps.oc  { runEphemeralSession(opts) -> {text, sid} }
+ * @param {object} [a.deps.engineState]  { load, save } (default engineStateStore)
+ * @param {Function} [a.deps.resolveModel]  async ({taskClass,tier,meta,configGet}) -> model|null
+ * @param {Function} [a.deps.configGet]  async () -> AppConfig (for model routing)
+ * @param {Function} [a.deps.validate]  async (result) => bool — structured-output check; triggers the cascade
+ * @returns {Promise<{text:string, taskClass:string, tier:string}>}
+ */
+export async function runEphemeral({ taskClass, context = [], directory = "~", deps = {} } = {}) {
+  const meta = getTaskClass(taskClass);
+
+  let tier = meta.tier;
+  let escalated = false;
+  for (let attempt = 0; attempt <= 1; attempt++) {
+    const out = await runOnce({ taskClass, meta, tier, context, directory, deps });
+    const valid = typeof deps.validate === "function" ? await deps.validate(out) : true;
+    if (valid) return out;
+    const next = escalateTier(meta.tier); // nano -> mid; others null
+    if (next && next !== tier && !escalated) {
+      escalated = true;
+      tier = next;
+      continue; // cascade exactly one tier, at most once per call
+    }
+    return out;
+  }
+  // unreachable: the loop runs at most twice
+  throw new Error(`runEphemeral: cascade exceeded maximum attempts for "${taskClass}"`);
+}
+
+async function runOnce({ taskClass, meta, tier, context, directory, deps }) {
+  const {
+    oc,
+    engineState = engineStateStore,
+    resolveModel = defaultResolveModel,
+    configGet,
+  } = deps;
+  if (!oc || typeof oc.runEphemeralSession !== "function") {
+    throw new Error("runEphemeral requires deps.oc with runEphemeralSession()");
+  }
+  const model = typeof resolveModel === "function"
+    ? await resolveModel({ taskClass, tier, meta, configGet })
+    : null;
+  const instruction = assembleContext(context, { taskClass });
+
+  let sid = null;
+  try {
+    const res = await oc.runEphemeralSession({
+      directory,
+      title: `${CTO_TITLE_PREFIX}${taskClass}`,
+      instruction,
+      model,
+      onCreated: async (s) => {
+        sid = s;
+        await activeAdd(s, { engineState });
+      },
+    });
+    return { text: res?.text ?? "", taskClass, tier, sid: res?.sid ?? sid };
+  } finally {
+    // Remove from the active set even when the run errored (finally).
+    if (sid) {
+      try {
+        await activeRemove(sid, { engineState });
+      } catch {
+        /* a failed removal must not mask the run's own result/error */
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Model resolution (productions default — the existing catalog/router path).
+// ---------------------------------------------------------------------------
+
+/**
+ * Default model resolver: pick the CHEAPEST model satisfying the class tier
+ * through the existing router. Reuses the same inputs delegate.mjs builds
+ * (routable catalogue + RoutingServices), but FORCES the §12.3 tier via a
+ * per-agent routing directive, so an ambient (nano) or digest/suggest (mid)
+ * step is never up-routed by the user's own modelRouting and never hardcodes a
+ * model id. Returns the structured {providerID, modelID} (or null → box
+ * default, which chooseSubagentModel returns when nothing survives).
+ */
+export async function defaultResolveModel({ taskClass, tier, meta, configGet }) {
+  const nowMs = Date.now();
+  let cfg = {};
+  if (typeof configGet === "function") {
+    try {
+      cfg = (await configGet()) ?? {};
+    } catch {
+      cfg = {};
+    }
+  }
+  const policy = (cfg && cfg.modelRouting) || {};
+  const agent = `cto:${taskClass}`;
+  // Force the class tier; never let the user's own perAgent/preset override it.
+  const forcedPolicy = {
+    ...policy,
+    perAgent: { ...(policy.perAgent ?? {}), [agent]: TIER_TO_ROUTER_TIER[tier] },
+  };
+
+  let catalog = [];
+  try {
+    catalog = (await listRoutableModels("sub", cfg)) ?? [];
+  } catch {
+    catalog = [];
+  }
+
+  let services = null;
+  try {
+    services = await buildRoutingServices(cfg, {
+      catalogIndex: { lookupModel, matchModel, allModels },
+      endpoints: catalog,
+      snapshots: [],
+      providerHealthState: null,
+      endpointSummary: null,
+      pacing: null,
+    }, nowMs);
+  } catch {
+    services = null; // degraded → router routes on absent context (box default)
+  }
+
+  try {
+    return chooseSubagentModel({
+      incumbent: null,
+      catalog,
+      policy: forcedPolicy,
+      agent,
+      nowMs,
+      contextTokens: meta?.contextBudget ?? undefined,
+      services,
+    });
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reaper (§3.1): sweep orphaned `cto:` sessions every 10 min.
+// ---------------------------------------------------------------------------
+
+/**
+ * The age of a session (epoch ms created), for reaping. Unknown → null (the
+ * reaper never reaps a session it cannot date — safe default).
+ */
+export function sessionCreatedMs(session) {
+  const t = session?.time;
+  if (t && typeof t === "object") {
+    if (typeof t.created === "number") return t.created;
+    if (typeof t.updated === "number") return t.updated;
+  }
+  if (typeof session?.time === "number") return session.time;
+  if (typeof session?.created === "number") return session.created;
+  return null;
+}
+
+/**
+ * Pure reaper selection: sessions with the `cto:` title prefix that are older
+ * than `maxAgeMs` and NOT in the active set. Returns the session ids to delete.
+ */
+export function selectReapCandidates({
+  sessions = [],
+  activeSet = [],
+  nowMs = Date.now(),
+  maxAgeMs = REAPER_MAX_AGE_MS,
+  prefix = CTO_TITLE_PREFIX,
+} = {}) {
+  const active = new Set(Array.isArray(activeSet) ? activeSet : []);
+  const cut = nowMs - maxAgeMs;
+  const doomed = [];
+  for (const s of Array.isArray(sessions) ? sessions : []) {
+    const id = s?.id;
+    if (!id) continue;
+    const title = typeof s?.title === "string" ? s.title : "";
+    if (!title.startsWith(prefix)) continue;
+    if (active.has(id)) continue;
+    const ts = sessionCreatedMs(s);
+    if (ts == null || ts >= cut) continue; // recent, or undatable → not an orphan
+    doomed.push(id);
+  }
+  return doomed;
+}
+
+/**
+ * The reaper, as a poller. `listSessions` + `deleteSession` default to the
+ * injected `oc`; construction is injected I/O only. `tick()` sweeps once;
+ * `start()` runs it on the 10-min cadence via the shared startPoller (inFlight
+ * guard + timer.unref()). First tick is NOT immediate — nothing to sweep at
+ * boot that isn't already handled, and the interval is the contract.
+ */
+export function createEphemeralReaper({
+  oc,
+  engineState = engineStateStore,
+  listSessions,
+  deleteSession,
+  now = () => Date.now(),
+  poller = startPoller,
+  intervalMs = REAPER_INTERVAL_MS,
+  maxAgeMs = REAPER_MAX_AGE_MS,
+  prefix = CTO_TITLE_PREFIX,
+} = {}) {
+  const list = listSessions ?? oc?.listSessions;
+  const del = deleteSession ?? oc?.deleteSession;
+  if (typeof list !== "function" || typeof del !== "function") {
+    throw new Error("createEphemeralReaper requires listSessions + deleteSession (or an oc client)");
+  }
+
+  async function tick() {
+    let sessions = [];
+    let active = new Set();
+    try {
+      sessions = (await list()) ?? [];
+    } catch {
+      sessions = [];
+    }
+    try {
+      const payload = await engineState.load();
+      active = new Set(Array.isArray(payload?.activeEphemeral) ? payload.activeEphemeral : []);
+    } catch {
+      active = new Set();
+    }
+    const doomed = selectReapCandidates({
+      sessions,
+      activeSet: [...active],
+      nowMs: now(),
+      maxAgeMs,
+      prefix,
+    });
+    for (const id of doomed) {
+      try {
+        await del(id);
+      } catch {
+        /* a failed delete is retried next sweep */
+      }
+    }
+    return doomed;
+  }
+
+  return {
+    tick,
+    start() {
+      return poller(tick, { intervalMs, label: "ctoEphemeralReaper", immediate: false });
+    },
+  };
+}
+
+/** Convenience: build + start the reaper; returns the poller handle ({ stop }). */
+export function startEphemeralReaper(deps) {
+  return createEphemeralReaper(deps).start();
+}

--- a/src/server/ctoSessions.test.mjs
+++ b/src/server/ctoSessions.test.mjs
@@ -1,0 +1,344 @@
+// src/server/ctoSessions.test.mjs — BET-1378 ephemeral session runner (§3.1),
+// task classes + cascade (§12.3), context budgets, active-set, reaper. Pure
+// logic only — injected oc/engineState, no live tmux/opencode/network.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  TASK_CLASSES,
+  TIER_TO_ROUTER_TIER,
+  getTaskClass,
+  escalateTier,
+  estimateTokens,
+  assembleContext,
+  addActive,
+  removeActive,
+  sessionCreatedMs,
+  selectReapCandidates,
+  createEphemeralReaper,
+  runEphemeral,
+} from "./ctoSessions.mjs";
+
+function fakeEngineState(initial = {}) {
+  let payload = { ...initial };
+  return {
+    async load() {
+      return payload;
+    },
+    async save(p) {
+      payload = p;
+    },
+    peek() {
+      return payload;
+    },
+  };
+}
+
+// The resolveModel is injected in unit tests; modelID carries the ROUTER tier
+// so the cascade's escalation is observable without touching the real router.
+function tierModelResolver() {
+  return async ({ tier }) => ({ providerID: "p", modelID: TIER_TO_ROUTER_TIER[tier] ?? tier });
+}
+
+// ---------------------------------------------------------------------------
+// Task classes (§12.3)
+// ---------------------------------------------------------------------------
+
+test("getTaskClass returns the literal §12.3 table (tier + budget)", () => {
+  assert.equal(getTaskClass("ambient-summarize").tier, "nano");
+  assert.equal(getTaskClass("ambient-summarize").contextBudget, 4000);
+  assert.equal(getTaskClass("gatekeeper").tier, "nano");
+  assert.equal(getTaskClass("worthiness").tier, "nano");
+  assert.equal(getTaskClass("digest-compose").tier, "mid");
+  assert.equal(getTaskClass("digest-compose").contextBudget, 12000);
+  assert.equal(getTaskClass("suggest").tier, "mid");
+  assert.equal(getTaskClass("spawn").contextBudget, 8000);
+});
+
+test("getTaskClass rejects an unknown class", () => {
+  assert.throws(() => getTaskClass("nope"), /unknown task class/);
+});
+
+test("escalation: only ambient (nano) classes escalate exactly one tier", () => {
+  assert.equal(escalateTier("nano"), "mid");
+  assert.equal(escalateTier("mid"), null);
+});
+
+test("router-tier mapping never hardcodes a model", () => {
+  assert.equal(TIER_TO_ROUTER_TIER.nano, "fast");
+  assert.equal(TIER_TO_ROUTER_TIER.mid, "balanced");
+});
+
+// ---------------------------------------------------------------------------
+// Context budgets (§12.3) — pure truncation
+// ---------------------------------------------------------------------------
+
+test("assembleContext drops the LOWEST-priority blocks first", () => {
+  const high = { priority: 3, text: "high " + "h".repeat(200) };
+  const mid = { priority: 2, text: "mid " + "m".repeat(200) };
+  const low = { priority: 1, text: "low " + "l".repeat(40000) }; // huge, lowest priority
+  const out = assembleContext([high, mid, low], { taskClass: "ambient-summarize" });
+  assert.ok(out.includes("high"));
+  assert.ok(out.includes("mid"));
+  assert.ok(!out.includes("low"), "lowest-priority block is dropped first");
+});
+
+test("assembleContext truncates a lone over-budget highest block rather than drop it", () => {
+  const big = "x".repeat(100000); // way over ambient-summarize's 4k-token budget
+  const out = assembleContext([{ priority: 3, text: big }], {
+    taskClass: "ambient-summarize",
+  });
+  assert.ok(out.length > 0, "a lone over-budget block is truncated, never dropped");
+  assert.ok(out.length <= 4000 * 4, "truncated to the class budget (1 token ≈ 4 chars)");
+});
+
+test("assembleContext keeps blocks in priority order when all fit", () => {
+  const a = { priority: 1, text: "a" };
+  const b = { priority: 5, text: "b" };
+  const out = assembleContext([a, b], { taskClass: "spawn" });
+  // spawn has an 8k budget — both tiny blocks fit; b (higher priority) is first
+  assert.equal(out, "b\n\na");
+});
+
+test("estimateTokens is 4 chars per token", () => {
+  assert.equal(estimateTokens("1234"), 1);
+  assert.equal(estimateTokens("12345678"), 2);
+  assert.equal(estimateTokens(""), 0);
+});
+
+// ---------------------------------------------------------------------------
+// Active-set bookkeeping
+// ---------------------------------------------------------------------------
+
+test("addActive/removeActive dedupe and delete", () => {
+  let set = addActive([], "s1");
+  set = addActive(set, "s1");
+  assert.deepEqual(set, ["s1"]);
+  set = addActive(set, "s2");
+  assert.deepEqual(set, ["s1", "s2"]);
+  assert.deepEqual(removeActive(set, "s1"), ["s2"]);
+  assert.deepEqual(removeActive(set, "s3"), ["s1", "s2"]);
+});
+
+// ---------------------------------------------------------------------------
+// runEphemeral — lifecycle + cascade
+// ---------------------------------------------------------------------------
+
+test("runEphemeral records the session in the active set BEFORE prompting, then removes it", async () => {
+  let activeDuringPrompt = null;
+  const engineState = fakeEngineState();
+  const oc = {
+    async runEphemeralSession({ onCreated }) {
+      await onCreated("sid-1");
+      activeDuringPrompt = [...engineState.peek().activeEphemeral];
+      return { text: "reply", sid: "sid-1" };
+    },
+  };
+  const out = await runEphemeral({
+    taskClass: "gatekeeper",
+    context: [{ priority: 1, text: "hi" }],
+    deps: { oc, engineState, resolveModel: async () => null },
+  });
+  assert.equal(out.text, "reply");
+  assert.deepEqual(activeDuringPrompt, ["sid-1"], "recorded BEFORE prompting");
+  assert.deepEqual(
+    engineState.peek().activeEphemeral ?? [],
+    [],
+    "removed from the active set after the run",
+  );
+});
+
+test("runEphemeral removes the active-set entry on error (finally)", async () => {
+  const engineState = fakeEngineState();
+  const oc = {
+    async runEphemeralSession({ onCreated }) {
+      await onCreated("sid-err");
+      throw new Error("boom");
+    },
+  };
+  await assert.rejects(
+    () =>
+      runEphemeral({
+        taskClass: "worthiness",
+        context: [],
+        deps: { oc, engineState, resolveModel: async () => null },
+      }),
+    /boom/,
+  );
+  assert.deepEqual(
+    engineState.peek().activeEphemeral ?? [],
+    [],
+    "active-set entry removed even though the session run errored",
+  );
+});
+
+test("cascade fires ONCE and ONLY on validation failure, escalating nano→mid", async () => {
+  const engineState = fakeEngineState();
+  const calls = [];
+  const oc = {
+    async runEphemeralSession({ model, onCreated }) {
+      calls.push(model?.modelID);
+      await onCreated(`sid-${calls.length}`);
+      return { text: `reply-${calls.length}`, sid: `sid-${calls.length}` };
+    },
+  };
+  let validateCalls = 0;
+  const validate = async () => {
+    validateCalls += 1;
+    return validateCalls >= 2; // first attempt fails → cascade once
+  };
+  const modelFor = tierModelResolver();
+  const out = await runEphemeral({
+    taskClass: "ambient-summarize",
+    context: [],
+    deps: {
+      oc,
+      engineState,
+      resolveModel: modelFor,
+      validate,
+    },
+  });
+  assert.equal(calls.length, 2, "exactly one escalation");
+  assert.equal(calls[0], "fast", "first attempt on nano → cheapest fast");
+  assert.equal(calls[1], "balanced", "escalated one tier to mid → balanced");
+  assert.equal(out.text, "reply-2");
+  assert.equal(out.tier, "mid");
+});
+
+test("cascade does NOT fire a third attempt when validation keeps failing (at most once)", async () => {
+  const engineState = fakeEngineState();
+  const calls = [];
+  const oc = {
+    async runEphemeralSession({ onCreated }) {
+      calls.push(true);
+      await onCreated(`sid-${calls.length}`);
+      return { text: "x", sid: `sid-${calls.length}` };
+    },
+  };
+  const out = await runEphemeral({
+    taskClass: "ambient-summarize",
+    context: [],
+    deps: { oc, engineState, resolveModel: async () => null, validate: async () => false },
+  });
+  assert.equal(calls.length, 2, "two attempts at most");
+  assert.equal(out.text, "x", "returns the last (still low-confidence) result");
+});
+
+test("cascade does NOT fire when validation passes on the first attempt", async () => {
+  const engineState = fakeEngineState();
+  const calls = [];
+  const oc = {
+    async runEphemeralSession({ onCreated }) {
+      calls.push(true);
+      await onCreated("sid-1");
+      return { text: "fresh", sid: "sid-1" };
+    },
+  };
+  const out = await runEphemeral({
+    taskClass: "worthiness",
+    context: [],
+    deps: { oc, engineState, resolveModel: async () => null, validate: async () => true },
+  });
+  assert.equal(calls.length, 1);
+  assert.equal(out.text, "fresh");
+});
+
+test("cascade does NOT escalate a mid-tier class on validation failure", async () => {
+  const engineState = fakeEngineState();
+  const calls = [];
+  const oc = {
+    async runEphemeralSession({ onCreated }) {
+      calls.push(true);
+      await onCreated("sid-1");
+      return { text: "x", sid: "sid-1" };
+    },
+  };
+  const modelFor = tierModelResolver();
+  const out = await runEphemeral({
+    taskClass: "digest-compose", // mid tier — no escalation allowed
+    context: [],
+    deps: { oc, engineState, resolveModel: modelFor, validate: async () => false },
+  });
+  assert.equal(calls.length, 1, "mid tier never cascades");
+  assert.equal(out.tier, "mid");
+});
+
+test("runEphemeral throws when no oc client is injected", async () => {
+  await assert.rejects(
+    () => runEphemeral({ taskClass: "suggest", context: [], deps: {} }),
+    /requires deps\.oc/,
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Reaper (§3.1)
+// ---------------------------------------------------------------------------
+
+test("sessionCreatedMs reads opencode session time", () => {
+  assert.equal(sessionCreatedMs({ time: { created: 123 } }), 123);
+  assert.equal(sessionCreatedMs({ time: { updated: 456 } }), 456);
+  assert.equal(sessionCreatedMs({ time: 789 }), 789);
+  assert.equal(sessionCreatedMs({ created: 1000 }), 1000);
+  assert.equal(sessionCreatedMs({}), null);
+});
+
+test("selectReapCandidates: age + active-set + prefix", () => {
+  const nowMs = 1_000_000_000_000;
+  const old = nowMs - 40 * 60 * 1000; // 40 min
+  const sessions = [
+    { id: "a", title: "cto:gatekeeper", time: { created: old } },
+    { id: "b", title: "cto:worthiness", time: { created: old } }, // in active
+    { id: "c", title: "cto:suggest", time: { created: nowMs - 5 * 60 * 1000 } }, // recent
+    { id: "d", title: "not-cto", time: { created: old } }, // wrong prefix
+    { id: "e", title: "cto:spawn" }, // undatable
+  ];
+  const doomed = selectReapCandidates({
+    sessions,
+    activeSet: ["b"],
+    nowMs,
+    maxAgeMs: 30 * 60 * 1000,
+    prefix: "cto:",
+  });
+  assert.deepEqual(doomed, ["a"]);
+});
+
+test("reaper tick lists, selects and deletes only orphans", async () => {
+  const nowMs = 1_000_000_000_000;
+  const old = nowMs - 40 * 60 * 1000;
+  const deleted = [];
+  const engineState = fakeEngineState({ activeEphemeral: ["active-session"] });
+  const reaper = createEphemeralReaper({
+    listSessions: async () => [
+      { id: "orphan", title: "cto:gatekeeper", time: { created: old } },
+      { id: "active-session", title: "cto:worthiness", time: { created: old } },
+      { id: "fresh", title: "cto:suggest", time: { created: nowMs - 5 * 60 * 1000 } },
+    ],
+    deleteSession: async (id) => {
+      deleted.push(id);
+    },
+    engineState,
+    now: () => nowMs,
+  });
+  const doomed = await reaper.tick();
+  assert.deepEqual(doomed, ["orphan"]);
+  assert.deepEqual(deleted, ["orphan"]);
+});
+
+test("reaper tolerates list/delete/state failures without throwing", async () => {
+  const reaper = createEphemeralReaper({
+    listSessions: async () => {
+      throw new Error("list failed");
+    },
+    deleteSession: async () => {
+      throw new Error("delete failed");
+    },
+    engineState: fakeEngineState(),
+    now: () => Date.now(),
+  });
+  const doomed = await reaper.tick(); // must not throw
+  assert.deepEqual(doomed, []);
+});
+
+test("createEphemeralReaper requires listSessions + deleteSession", () => {
+  assert.throws(() => createEphemeralReaper(), /requires listSessions/);
+});

--- a/src/server/opencode.mjs
+++ b/src/server/opencode.mjs
@@ -942,26 +942,48 @@ export function generateSessionTitle({ directory, instruction }) {
 }
 
 /**
- * The THROWAWAY-SESSION cheap-agent call: create a hidden session in
- * `directory`, prompt it on a cheap agent (default `title`) with an
- * `instruction`, poll for the assistant reply for up to ~30s, then delete the
- * session. Returns the RAW assistant text; "" on any failure/timeout so the
- * caller can skip rather than error.
+ * The THROWAWAY-SESSION synchronous mechanism: create a hidden session in
+ * `directory`, prompt it (optionally on a given agent with a routed model)
+ * with an `instruction`, poll the assistant reply from the raw message list
+ * for up to ~`maxAttempts * pollIntervalMs`, then delete the session — all
+ * WITHOUT subscribing to a scoped SSE stream and WITHOUT registering the
+ * session directory (avoids the documented scoped-stream trap in the CTO
+ * spec §3.1). Returns `{ text, sid }`; `text` is "" on any failure/timeout so
+ * a caller can skip rather than error.
  *
- * This is the ONE such mechanism — auto-rename (BET-1018) and the optimizer's
- * constraint extraction (BET-1346) both use it; a second copy must not be
- * built. NOTE: do NOT add structured output (a JSON schema format) to the
- * prompt_async body — it is ACCEPTED by opencode but makes its reader reject
- * the whole session's message list with a permanent HTTP 400.
+ * The ONE non-SSE create→prompt→poll→read→delete primitive — auto-rename
+ * (BET-1018), the optimizer's constraint extraction (BET-1346) and the
+ * Adaptive CTO's ephemeral sessions (BET-1378) all go through it; a second
+ * copy must not be built. NOTE: do NOT add structured output (a JSON schema
+ * format) to the prompt_async body — it is ACCEPTED by opencode but makes its
+ * reader reject the whole session's message list with a permanent HTTP 400.
+ *
+ * `onCreated(sid)` (optional) is awaited right AFTER create and BEFORE the
+ * prompt is sent, so a caller that must track the session while it runs (the
+ * CTO's `activeEphemeral` set, BET-1378) can record it before the model
+ * starts, and clean it up in its own finally around this call.
  *
  * @param {object} a
  * @param {string} a.directory  absolute session directory
  * @param {string} a.instruction  the prompt text
  * @param {string} [a.agent]  agent to run on (default "title" — the cheap model)
+ * @param {object} [a.model]  structured { providerID, modelID, variant? } to pin (null/absent → box default)
  * @param {string} [a.title]  creation title tag for the hidden session
- * @returns {Promise<string>}
+ * @param {number} [a.pollIntervalMs]  ms between message-list polls (default 1000)
+ * @param {number} [a.maxAttempts]  max polls before giving up (default 30)
+ * @param {Function} [a.onCreated]  async (sid) => {} — called after create, before prompt
+ * @returns {Promise<{text: string, sid: string|null}>}
  */
-export async function runThrowawayAgent({ directory, instruction, agent = "title", title = "manta-throwaway" }) {
+export async function runSynchronousSession({
+  directory,
+  instruction,
+  agent = "title",
+  model,
+  title = "manta-throwaway",
+  pollIntervalMs = 1000,
+  maxAttempts = 30,
+  onCreated,
+}) {
   const absDir = expandTilde(directory);
 
   let sid = null;
@@ -976,11 +998,22 @@ export async function runThrowawayAgent({ directory, instruction, agent = "title
     );
     if (!createRes.ok) {
       await discardBody(createRes);
-      return "";
+      return { text: "", sid: null };
     }
     sid = (await createRes.json()).id;
+    if (typeof onCreated === "function") {
+      try {
+        await onCreated(sid);
+      } catch {
+        /* a failed tracker must not block the run (BET-1378 active set is best-effort) */
+      }
+    }
 
     const promptBody = { parts: [{ type: "text", text: instruction }], agent };
+    if (model && model.providerID && model.modelID) {
+      promptBody.model = { providerID: model.providerID, modelID: model.modelID };
+      if (model.variant) promptBody.variant = model.variant;
+    }
     const promptRes = await ocFetch(
       apiUrl(
         `/session/${encodeURIComponent(sid)}/prompt_async?directory=${encodeURIComponent(absDir)}`,
@@ -993,12 +1026,12 @@ export async function runThrowawayAgent({ directory, instruction, agent = "title
     );
     if (!promptRes.ok) {
       await discardBody(promptRes);
-      return "";
+      return { text: "", sid };
     }
 
     const msgUrl = apiUrl(`/session/${encodeURIComponent(sid)}/message`);
-    for (let i = 0; i < 30; i++) {
-      await new Promise((r) => setTimeout(r, 1000));
+    for (let i = 0; i < maxAttempts; i++) {
+      await new Promise((r) => setTimeout(r, pollIntervalMs));
       const r = await ocFetch(msgUrl);
       if (!r.ok) {
         await discardBody(r);
@@ -1006,11 +1039,11 @@ export async function runThrowawayAgent({ directory, instruction, agent = "title
       }
       const msgs = await r.json();
       const text = extractAssistantText(msgs);
-      if (text) return text;
+      if (text) return { text, sid };
     }
-    return "";
+    return { text: "", sid };
   } catch {
-    return "";
+    return { text: "", sid };
   } finally {
     if (sid) {
       try {
@@ -1020,6 +1053,24 @@ export async function runThrowawayAgent({ directory, instruction, agent = "title
       }
     }
   }
+}
+
+/**
+ * The THROWAWAY-SESSION cheap-agent call: run runSynchronousSession on a cheap
+ * agent (default `title`), returning the RAW assistant text; "" on any
+ * failure/timeout so the caller can skip rather than error. Thin wrapper over
+ * runSynchronousSession — the single source of truth for this mechanism.
+ *
+ * @param {object} a
+ * @param {string} a.directory  absolute session directory
+ * @param {string} a.instruction  the prompt text
+ * @param {string} [a.agent]  agent to run on (default "title" — the cheap model)
+ * @param {string} [a.title]  creation title tag for the hidden session
+ * @returns {Promise<string>}
+ */
+export async function runThrowawayAgent({ directory, instruction, agent = "title", title = "manta-throwaway" }) {
+  const { text } = await runSynchronousSession({ directory, instruction, agent, title });
+  return text;
 }
 
 function extractAssistantText(msgs) {


### PR DESCRIPTION
## What

The Adaptive CTO's **ephemeral session runner + model task classes** (BET-1378, spec §3.1 + §12.3) — the one helper every model-needing CTO step uses: run a headless opencode session, read the result synchronously, delete it, never leak.

`src/server/ctoSessions.mjs` (new):
- **`runEphemeral({ taskClass, context, deps })`** — headless `cto:<taskClass>` session (no tmux window, no `@manta-session-id` stamp → no sidebar row); records the session id in engine-state's `activeEphemeral` set **before** prompting; reads the result **synchronously** via `GET …/message` (no scoped SSE, no directory/stream registration); deletes the session and removes the active-set entry in a `finally` (error path included).
- **Task classes (§12.3 literal table)**: `ambient-summarize` (≤4k), `gatekeeper`, `worthiness` (nano); `digest-compose` (≤12k), `suggest` (mid); `spawn` (context ≤8k). Model resolution reuses the existing catalog/router (`modelCatalog.mjs` / `routingServices.mjs` + `chooseSubagentModel`) — cheapest model satisfying the class tier, never a hardcoded id.
- **Cascade rule**: ambient (nano) classes escalate exactly one tier (nano→mid) when `validate` fails, at most once per call. Tested.
- **Context budgets**: `assembleContext` truncates the ordered `{priority, text}` block list to the class budget, dropping lowest-priority blocks first.
- **Reaper (§3.1)**: every 10 min, sweeps `cto:` sessions >30 min old not in the active set; shared `startPoller` shape (inFlight guard, `timer.unref()`).

`src/server/opencode.mjs` (justified modification): extracted the non-SSE throwaway mechanism into exported **`runSynchronousSession`** (create→prompt→poll→read→delete, optional `onCreated`/`model`), and made `runThrowawayAgent` a thin wrapper over it. Required so the ephemeral runner reuses the ONE existing throwaway-session primitive instead of building a second copy (per that function's own "a second copy must not be built" note and the anti-spaghetti contract). `@manta-session-id` stamping was never part of this path — the headless `POST /session` with `{title}` is byte-identical to the exported `createSession` without a permission ruleset.

`src/server/ctoEngine.mjs`: registered the reaper in the engine timer surface so it starts/restarts with the engine and halts on pause (the "pause stops all timers" invariant). **Rebased onto fresh `origin/main` (`267777bd`, incl. the BET-1379 merge) and conflict resolved — keeps both the §3.1 reaper registration (BET-1378) and the A5 evidence/presence seams (BET-1379) in `ctoEngine.mjs`.**

## Tests

`src/server/ctoSessions.test.mjs` (21 tests): reaper selection (age + active-set + prefix, injected lists), reaper tick, cascade fires once and only on validation failure (incl. not firing on pass / not on mid-tier / at-most-once), budget truncation order, active-set add/remove including the error path.

## Files changed

`4 files`
- `src/server/ctoSessions.mjs` (new)
- `src/server/ctoSessions.test.mjs` (new)
- `src/server/opencode.mjs`
- `src/server/ctoEngine.mjs`

## Verification results (after rebase onto `main` @ `267777bd`)

- PR branch (`multica/BET-1378-cto-ephemeral-sessions` @ `05e66ed8`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0, **3026** pass / **0** fail / 0 skip.
- Base (`main` @ `267777bd`): reviewed/CI-gated via the merge; the branch now applies cleanly (`mergeable: MERGEABLE`).
- **Conclusion:** 0 new failures; the only conflict (`ctoEngine.mjs`) resolved, keeping both BET-1378's reaper wire and BET-1379's evidence/presence seams.

## Base

`Base: origin/main @ 267777bd` (rebase; previously `68df5af6`)
