### PR TITLE
feat(server): work segmentation, segment summaries, and turn completion (BET-1380)

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -59,6 +59,7 @@ import {
   CHANNEL_EVENT,
   computeLastSeen,
   eventSessionID,
+  isPipelineSession,
   isUserPromptEvent,
   normalizeEvidence,
   presenceState,
@@ -70,6 +71,7 @@ import {
   createCtoCards,
   isAskResolveEvent,
 } from "./ctoCards.mjs";
+import { createSegmenter } from "./ctoSegments.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
@@ -89,6 +91,9 @@ export const TICK_INTERVAL_MS = 60_000;
 // escalations once a minute and promotes any ask past BLOCKER_AFTER_MS into a
 // blocker card. The card threshold itself (10 min) lives in ctoCards.mjs.
 export const CARD_CHECK_INTERVAL_MS = 60_000;
+// Work-segmentation G refit cadence (§5.1-d): monthly, on the box's own
+// inter-arrival times.
+export const G_REFIT_INTERVAL_MS = 30 * 24 * HOUR_MS;
 
 export const DOT = Object.freeze({
   ACTIVE: "active",
@@ -224,6 +229,13 @@ export function createCtoEngine(deps = {}) {
     getDesktopPresence = pushGetDesktopPresence,
     getLastDesktopHeartbeat = pushGetLastDesktopHeartbeat,
     reaper = null, // { start() -> {stop} } | null — the §3.1 ephemeral-session reaper (ctoSessions)
+    // A6 segmentation seams (§5.1/§5.2): the model-backed summary producers
+    // (wired to runEphemeral in index.mjs; defaults degrade to a truncated
+    // prompt). The engine wraps them in the §3.3 ephemeral rate gate so a
+    // summary call is a normal rate-limited session creation.
+    summarize = async () => ({ ok: false, gated: false }),
+    computeOneLiner = async () => null,
+    segmenterOverride = null, // optional pre-built segmenter (else one is constructed below)
   } = deps;
 
   let disposed = false;
@@ -234,6 +246,7 @@ export function createCtoEngine(deps = {}) {
   let tickHandle = null;
   let cardTickHandle = null;
   let reaperHandle = null;
+  let refitHandle = null;
   let lastPublishedSerialized = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
@@ -350,6 +363,10 @@ export function createCtoEngine(deps = {}) {
       reaperHandle.stop();
       reaperHandle = null;
     }
+    if (refitHandle) {
+      refitHandle.stop();
+      refitHandle = null;
+    }
   }
 
   function startTimers() {
@@ -363,6 +380,13 @@ export function createCtoEngine(deps = {}) {
     // halted on pause (event ingestion alone keeps running while paused).
     if (reaper && !reaperHandle && typeof reaper.start === "function") {
       reaperHandle = reaper.start();
+    }
+    // §5.1-d monthly G refit — a work timer, halted on pause like the rest.
+    if (segmenter && !refitHandle) {
+      refitHandle = startPoller(
+        () => segmenter.monthlyRefit().catch(() => {}),
+        { intervalMs: G_REFIT_INTERVAL_MS, label: "cto-g-refit", immediate: false },
+      );
     }
   }
 
@@ -508,6 +532,37 @@ export function createCtoEngine(deps = {}) {
     return { ok: true, release };
   }
 
+  // ----- A6 work segmentation (§5.1/§5.2) -----
+  // The segmenter's model-backed seams are wrapped in the §3.3 ephemeral rate
+  // gate so each segment summary / one-liner is a normal rate-limited session
+  // creation — disabled/paused/at-cap → gated → the segmenter persists a
+  // degraded summary with no model spend.
+  const gatedSummarize = async (data) => {
+    const gate = await beginEphemeral();
+    if (!gate.ok) return { ok: false, gated: true, error: gate.error };
+    try {
+      return await summarize(data);
+    } finally {
+      gate.release?.();
+    }
+  };
+  const gatedOneLiner = async (data) => {
+    const gate = await beginEphemeral();
+    if (!gate.ok) return null;
+    try {
+      return await computeOneLiner(data);
+    } finally {
+      gate.release?.();
+    }
+  };
+  const segmenter =
+    segmenterOverride ??
+    createSegmenter({
+      summarize: gatedSummarize,
+      computeOneLiner: gatedOneLiner,
+      now,
+    });
+
   // Event ingestion — the ONE thing that keeps running while paused (§10.6-5).
   // Driven from index.mjs's event pump (not a timer); the engine is just
   // another consumer (§4.1). Consumes the opencode stream into normalized
@@ -537,6 +592,16 @@ export function createCtoEngine(deps = {}) {
           const info = await getSessionInfo(sid);
           owner = info?.owner ?? "user";
           project = info?.project;
+        }
+        // A6 segmentation — feed pipeline (user|job) sessions into the
+        // segmenter's online state machine. Never throws into the pump;
+        // G refit / summaries happen on their own async paths.
+        if (segmenter && sid && isPipelineSession(owner)) {
+          try {
+            segmenter.observe(evt, { sessionID: sid, project, ts: now() });
+          } catch {
+            /* best-effort — segmentation must never break ingestion */
+          }
         }
         const row = normalizeEvidence(evt, { owner, project, now: now() });
         if (!row) return;
@@ -617,6 +682,10 @@ export function createCtoEngine(deps = {}) {
 
   function start() {
     if (disposed) throw new Error("cto engine already disposed");
+    // Load the persisted segmentation G (minutes) from engine-state (§5.1-d).
+    if (segmenter && typeof segmenter.boot === "function") {
+      void segmenter.boot().catch(() => {});
+    }
     startTimers();
     startCardTimer();
     // Publish the initial state once (fire-and-forget) so a subscriber that
@@ -657,6 +726,9 @@ export function createCtoEngine(deps = {}) {
     lastHeartbeat,
     get rateTracker() {
       return track;
+    },
+    get segmenter() {
+      return segmenter;
     },
   };
 

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -10,6 +10,7 @@ import {
   HOUR_MS,
   RATE_LIMITS,
 } from "./ctoEngine.mjs";
+import { createSegmenter } from "./ctoSegments.mjs";
 
 // Build a fully-injected engine harness: no real fs, no real stores, a fake
 // clock we can advance. Everything the engine touches goes through these
@@ -379,4 +380,98 @@ test("defaultGetCounts counts open cards from the real cards store", async () =>
     generationInFlight: false,
     tonightCount: 0,
   });
+// ---------------------------------------------------------------------------
 });
+// A6 segmentation wiring (observeEvent → segmenter) (§5.1)
+// ---------------------------------------------------------------------------
+
+function fakeSegStores() {
+  const map = new Map();
+  const ledger = [];
+  return {
+    map,
+    segments: {
+      name: "segments",
+      pathFor: (id) => id,
+      async load(id) {
+        return map.get(id) ?? { v: 1 };
+      },
+      async save(id, data) {
+        map.set(id, data);
+      },
+    },
+    ledger: { append: async (r) => ledger.push(r) },
+    peekLedger: () => ledger,
+  };
+}
+
+test("observeEvent feeds pipeline (user) sessions into the segmenter", async () => {
+  const stores = fakeSegStores();
+  let t = 0;
+  const seg = createSegmenter({
+    segments: stores.segments,
+    ledger: stores.ledger,
+    engineState: { load: async () => ({}), save: async () => {} },
+    summarize: async () => ({ ok: false, gated: false }),
+    computeOneLiner: async () => null,
+    now: () => t,
+  });
+  const harness = makeHarness({ ctoEnabled: false });
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: false }),
+    ledger: { append: async () => {} },
+    engineState: { load: async () => ({ v: 1, pendingBlockers: [] }), save: async () => {} },
+    publish: () => {},
+    now: () => t,
+    segmenterOverride: seg,
+  });
+
+  const prompt = (text, sid) => ({
+    type: "user.message.created",
+    id: `id-${text}-${t}`,
+    properties: { sessionID: sid, message: { role: "user", text } },
+  });
+  const idle = (sid, idSuffix) => ({
+    type: "session.idle",
+    id: `idle-${idSuffix}`,
+    properties: { sessionID: sid },
+  });
+
+  engine.observeEvent(prompt("first task", "s-user"));
+  engine.observeEvent(idle("s-user", 1));
+  await new Promise((r) => setTimeout(r, 10)); // let the async owner-resolve + feed land
+  const st = seg._sessions.get("s-user");
+  await st?.closeChain;
+  assert.equal(stores.map.size, 1, "a pipeline session's work is segmented");
+});
+
+test("cto-owned sessions are never segmented", async () => {
+  const stores = fakeSegStores();
+  let t = 0;
+  const seg = createSegmenter({
+    segments: stores.segments,
+    ledger: stores.ledger,
+    engineState: { load: async () => ({}), save: async () => {} },
+    summarize: async () => ({ ok: false, gated: false }),
+    computeOneLiner: async () => null,
+    now: () => t,
+  });
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: false }),
+    ledger: { append: async () => {} },
+    engineState: { load: async () => ({ v: 1, pendingBlockers: [] }), save: async () => {} },
+    publish: () => {},
+    now: () => t,
+    segmenterOverride: seg,
+    getSessionInfo: async () => ({ owner: "cto", project: undefined }),
+  });
+  const evt = {
+    type: "user.message.created",
+    id: "cto-evt-1",
+    properties: { sessionID: "s-cto", message: { role: "user", text: "x" } },
+  };
+  engine.observeEvent(evt);
+  await new Promise((r) => setTimeout(r, 10));
+  assert.equal(stores.map.size, 0, "cto-owned work is excluded from segmentation");
+});
+

--- a/src/server/ctoSegments.mjs
+++ b/src/server/ctoSegments.mjs
@@ -1,0 +1,644 @@
+// src/server/ctoSegments.mjs
+// BET-1380 — work segmentation, segment summaries, and turn completion (spec
+// §5.1, §5.2). The read-layer that turns the ambient opencode event stream
+// (A5 evidence) into work episodes ("segments"), bounded by idle events and by
+// a per-box recency threshold G that is refit monthly from the box's own
+// inter-arrival times.
+//
+// Pure logic + injected I/O in the style of delegate.mjs / ctoEngine.mjs —
+// no live tmux/opencode/network in tests. The model-backed summarization and
+// one-liner seams (`summarize`, `computeOneLiner`) are injected; ctoEngine.mjs
+// wraps them with the §3.3 ephemeral-session rate gate and wires them to the
+// real runner (ctoSessions.runEphemeral) from src/server/index.mjs.
+//
+// Segmentation rules (§5.1):
+//   - A segment is a contiguous run of meaningful activity on one pipeline
+//     session (owner user|job — never cto's own sessions).
+//   - A segment closes when the inter-event gap exceeds G **or** on
+//     `session.idle`. Closing by a gap starts the next segment at the event
+//     that triggered the close; closing by idle leaves the session open until
+//     the next activity opens a fresh segment.
+//   - Turn completion is the session's FIRST `session.idle` after a seen busy —
+//     the same sawBusy-then-idle shape delegate.mjs's observeEvent uses. An
+//     idle caused by a MessageAbortedError (user abort or the queued-drain
+//     abort, detected exactly the way push.mjs's classifier does — by error
+//     name) is NOT a turn completion.
+//   - At turn completion a one-liner is computed and cached (the Just-finished
+//     rail, a later issue, reads it from cache); segment close REUSES the
+//     cached one-liner instead of recomputing (§5.2).
+//   - On close, ONE `ambient-summarize` call produces the §5.2 schema. If the
+//     model output fails schema validation the runner's cascade retries once;
+//     on final failure a degraded summary is stored and the failure recorded.
+//   - Segments persist 30d in the segments area of the rollups store (A1),
+//     swept by ctoStores.sweepSegments.
+
+import { engineStateStore, segmentsStore, ledgerStore } from "./ctoStores.mjs";
+import { isUserPromptEvent } from "./ctoEvidence.mjs";
+
+export const DEFAULT_G_MINUTES = 45;
+export const G_MIN = 20;
+export const G_MAX = 90;
+export const MINUTE_MS = 60_000;
+export const ONE_LINER_MAX = 140;
+export const MIN_GAP_SAMPLES = 8; // below this a refit reuses the current G
+export const MAX_SEGMENT_EVENTS = 32; // cap per-segment context kept in memory
+export const SEGMENT_SUMMARY_VERSION = 1;
+
+export const OUTCOMES = Object.freeze(["done", "failed", "blocked", "in-progress"]);
+
+export function minutesToMs(mins) {
+  return Math.round(mins * MINUTE_MS);
+}
+
+function clamp(v, lo, hi) {
+  return Math.min(hi, Math.max(lo, v));
+}
+
+// ---------------------------------------------------------------------------
+// Event interpretation
+// ---------------------------------------------------------------------------
+
+function evtName(evt) {
+  return evt?.properties?.error?.name || evt?.properties?.info?.error?.name || null;
+}
+
+function statusType(evt) {
+  return (
+    evt?.properties?.status?.type ||
+    evt?.properties?.info?.status?.type ||
+    evt?.properties?.status ||
+    null
+  );
+}
+
+// A `session.status` busy/retry — the turn-start signal for sawBusy.
+export function isBusyEvent(evt) {
+  if (!evt || typeof evt !== "object" || evt.type !== "session.status") return false;
+  const s = statusType(evt);
+  return s === "busy" || s === "retry";
+}
+
+// An idle signal — either the canonical `session.idle` or a `session.status`
+// with type idle. Both can fire for one logical idle; the sawBusy reset below
+// makes the pair idempotent.
+export function isIdleEvent(evt) {
+  if (!evt || typeof evt !== "object" || typeof evt.type !== "string") return false;
+  if (evt.type === "session.idle") return true;
+  if (evt.type === "session.status") return statusType(evt) === "idle";
+  return false;
+}
+
+// MessageAbortedError — the abort marker, detected by error name the way
+// push.mjs's classifier detects it. An idle following one is NOT a turn
+// completion.
+export function isAbortEvent(evt) {
+  return evt?.type === "session.error" && evtName(evt) === "MessageAbortedError";
+}
+
+// Best-effort user prompt text (for degraded summaries / one-line fallback).
+export function userPromptText(evt) {
+  if (!evt || typeof evt !== "object") return "";
+  const p = evt.properties || {};
+  const info = p.info || {};
+  const msg = p.message || info.message || info;
+  const candidate =
+    (typeof msg === "object" ? msg?.text : msg) ||
+    info?.text ||
+    p?.text ||
+    "";
+  return typeof candidate === "string" ? candidate.trim() : "";
+}
+
+// Reduce one event to its segmentation significance. Returns one of
+// "busy" | "idle" | "abort" | "prompt" | "touch" | null (null = noise, i.e.
+// streaming deltas / config churn — the same events normalizeEvidence drops).
+export function segmentEventKind(evt) {
+  if (!evt || typeof evt !== "object" || typeof evt.type !== "string") return null;
+  const type = evt.type;
+  if (type === "session.error") {
+    return isAbortEvent(evt) ? "abort" : "touch";
+  }
+  if (type === "session.idle") return "idle";
+  if (type === "session.status") {
+    const s = statusType(evt);
+    if (s === "busy" || s === "retry") return "busy";
+    if (s === "idle") return "idle";
+    return null;
+  }
+  if (isUserPromptEvent(evt)) return "prompt";
+  if (type === "session.created" || type === "session.deleted") return "touch";
+  return null; // noise
+}
+
+// Pure turn-completion predicate: an idle, not caused by an abort, after a
+// seen busy. `sessionState` = { sawBusy, abort } maintained by the segmenter.
+export function isTurnCompletion(evt, sessionState) {
+  if (!isIdleEvent(evt)) return false;
+  if (!sessionState) return false;
+  if (sessionState.abort) return false; // idle caused by MessageAbortedError
+  return sessionState.sawBusy === true;
+}
+
+export function truncatePrompt(text, max = ONE_LINER_MAX) {
+  const s = String(text ?? "").trim();
+  if (s.length <= max) return s;
+  return s.slice(0, max);
+}
+
+// Tolerant extractor for the model's JSON segment summary — a model may wrap
+// the JSON in code fences or prose; we take the first `{` .. last `}`.
+// Parse-only: schema validation is validateSegmentSummary's job.
+export function parseSegmentSummaryText(text) {
+  if (typeof text !== "string") return null;
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  try {
+    const obj = JSON.parse(text.slice(start, end + 1));
+    return obj && typeof obj === "object" ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+// The one-liner is plain text (not JSON); test it against the ≤140 constraint.
+export function validOneLiner(text) {
+  const t = typeof text === "string" ? text.trim() : "";
+  return t.length > 0 && t.length <= ONE_LINER_MAX ? t : null;
+}
+
+// ---------------------------------------------------------------------------
+// §5.2 segment-summary schema validation + degraded fallback
+// ---------------------------------------------------------------------------
+
+export function validateSegmentSummary(obj) {
+  if (!obj || typeof obj !== "object") return false;
+  if (obj.v !== SEGMENT_SUMMARY_VERSION) return false;
+  if (typeof obj.sessionID !== "string" || !obj.sessionID) return false;
+  if (obj.project !== undefined && typeof obj.project !== "string") return false;
+  if (
+    !Array.isArray(obj.window) ||
+    obj.window.length !== 2 ||
+    typeof obj.window[0] !== "number" ||
+    typeof obj.window[1] !== "number" ||
+    !(obj.window[0] <= obj.window[1])
+  ) {
+    return false;
+  }
+  if (typeof obj.intent !== "string") return false;
+  if (!OUTCOMES.includes(obj.outcome)) return false;
+  if (
+    !Array.isArray(obj.key_events) ||
+    obj.key_events.length > 5 ||
+    obj.key_events.some(
+      (e) =>
+        !e ||
+        typeof e !== "object" ||
+        typeof e.t !== "number" ||
+        typeof e.text !== "string",
+    )
+  ) {
+    return false;
+  }
+  if (
+    !Array.isArray(obj.files_touched) ||
+    obj.files_touched.some((f) => typeof f !== "string")
+  ) {
+    return false;
+  }
+  if (!Array.isArray(obj.prs) || obj.prs.some((p) => typeof p !== "string")) {
+    return false;
+  }
+  if (
+    typeof obj.importance !== "number" ||
+    !Number.isInteger(obj.importance) ||
+    obj.importance < 1 ||
+    obj.importance > 10
+  ) {
+    return false;
+  }
+  if (typeof obj.one_liner !== "string" || obj.one_liner.length > ONE_LINER_MAX) {
+    return false;
+  }
+  return true;
+}
+
+export function degradedSegmentSummary({ sessionID, project, start, end, lastUserPrompt } = {}) {
+  return {
+    v: SEGMENT_SUMMARY_VERSION,
+    sessionID,
+    project,
+    window: [start, end],
+    intent: truncatePrompt(lastUserPrompt) || "in-progress",
+    outcome: "in-progress",
+    key_events: [],
+    files_touched: [],
+    prs: [],
+    importance: 1,
+    one_liner: truncatePrompt(lastUserPrompt),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// G refit — 2-component Gaussian mixture on log inter-arrival times (§5.1-d)
+// ---------------------------------------------------------------------------
+
+function gaussianDens(x, mu, s) {
+  if (!(s > 0)) return Number.EPSILON;
+  const z = (x - mu) / s;
+  return Math.exp(-0.5 * z * z) / (Math.sqrt(2 * Math.PI) * s);
+}
+
+export function emGaussianMixture(
+  xs,
+  { iterations = 50 } = {},
+) {
+  const n = xs.length;
+  if (n < MIN_GAP_SAMPLES) return null;
+  const sorted = [...xs].sort((a, b) => a - b);
+  const mean = sorted.reduce((s, v) => s + v, 0) / n;
+  const variance = sorted.reduce((s, v) => s + (v - mean) * (v - mean), 0) / n;
+  let mu1 = mean - 1;
+  let mu2 = mean + 1;
+  let s1 = Math.max(Math.sqrt(variance), 1e-3);
+  let s2 = s1;
+  let w1 = 0.5;
+  let w2 = 0.5;
+  for (let it = 0; it < iterations; it++) {
+    let n1 = 0;
+    let n2 = 0;
+    let t1 = 0;
+    let t2 = 0;
+    let q1 = 0;
+    let q2 = 0;
+    for (const x of xs) {
+      const d1 = w1 * gaussianDens(x, mu1, s1);
+      const d2 = w2 * gaussianDens(x, mu2, s2);
+      const den = d1 + d2;
+      const r1 = den > 0 ? d1 / den : it % 2 === 0 ? 1 : 0;
+      const r2 = 1 - r1;
+      n1 += r1;
+      n2 += r2;
+      t1 += r1 * x;
+      t2 += r2 * x;
+      q1 += r1 * x * x;
+      q2 += r2 * x * x;
+    }
+    if (n1 < 1 || n2 < 1) return null; // collapsed to one cluster
+    w1 = n1 / n;
+    w2 = n2 / n;
+    mu1 = t1 / n1;
+    mu2 = t2 / n2;
+    s1 = Math.sqrt(Math.max(q1 / n1 - mu1 * mu1, 1e-6));
+    s2 = Math.sqrt(Math.max(q2 / n2 - mu2 * mu2, 1e-6));
+  }
+  return { w1, mu1, s1, w2, mu2, s2 };
+}
+
+// The crossing point(s) where w1·N1(x) = w2·N2(x) — the log-space quadratic.
+export function mixtureCrossings({ w1, mu1, s1, w2, mu2, s2 }) {
+  if (!(s1 > 0) || !(s2 > 0)) return null;
+  const A = 1 / (2 * s1 * s1);
+  const B = 1 / (2 * s2 * s2);
+  const a2 = B - A;
+  const b2 = 2 * (A * mu1 - B * mu2);
+  const c2 = B * mu2 * mu2 - A * mu1 * mu1 + Math.log(w1 / s1) - Math.log(w2 / s2);
+  if (Math.abs(a2) < 1e-12) {
+    // equal variances — the crossing is linear
+    if (Math.abs(b2) < 1e-12) return null;
+    return [-c2 / b2];
+  }
+  const disc = b2 * b2 - 4 * a2 * c2;
+  if (disc < 0) return null;
+  const sq = Math.sqrt(disc);
+  return [(-b2 + sq) / (2 * a2), (-b2 - sq) / (2 * a2)];
+}
+
+// The mixture valley (log-ms): the crossing between the two component means
+// where the combined density is lowest. Returns null when there is no clean
+// between-means crossing.
+export function mixtureValley(components) {
+  if (!components) return null;
+  const { w1, mu1, s1, w2, mu2, s2 } = components;
+  const cross = mixtureCrossings(components);
+  if (!cross) return null;
+  const lo = Math.min(mu1, mu2);
+  const hi = Math.max(mu1, mu2);
+  const density = (x) => w1 * gaussianDens(x, mu1, s1) + w2 * gaussianDens(x, mu2, s2);
+  let best = null;
+  let bestVal = Infinity;
+  const candidates = [...cross, (lo + hi) / 2];
+  for (const x of candidates) {
+    if (x < lo || x > hi) continue;
+    const v = density(x);
+    if (v < bestVal) {
+      bestVal = v;
+      best = x;
+    }
+  }
+  return best;
+}
+
+// Refit G from `logGapSamples` (log of inter-arrival milliseconds). Returns
+// { gMinutes, components?, reused } — `reused:true` when the sample is too
+// small or degenerate, keeping the current G.
+export function refitG(logGapSamples, { currentGMinutes = DEFAULT_G_MINUTES, gMin = G_MIN, gMax = G_MAX } = {}) {
+  if (!Array.isArray(logGapSamples) || logGapSamples.length < MIN_GAP_SAMPLES) {
+    return { gMinutes: currentGMinutes, reused: true };
+  }
+  const components = emGaussianMixture(logGapSamples);
+  if (!components) return { gMinutes: currentGMinutes, reused: true };
+  const valley = mixtureValley(components);
+  if (valley == null) return { gMinutes: currentGMinutes, reused: true };
+  const minutes = Math.exp(valley) / MINUTE_MS;
+  return { gMinutes: clamp(minutes, gMin, gMax), components, reused: false };
+}
+
+// ---------------------------------------------------------------------------
+// The segmenter — per-session online segmentation over the evidence stream
+// ---------------------------------------------------------------------------
+
+// memory-safe rollup of a session's open segment + idle/busy bookkeeping.
+function newSessionState(sessionID, project) {
+  return {
+    sessionID,
+    project,
+    sawBusy: false,
+    abort: false,
+    lastActivityTs: null,
+    lastUserPrompt: "",
+    segment: null,
+    turnChain: Promise.resolve(), // serialized one-liner computes (turn completion)
+    closeChain: Promise.resolve(), // serialized segment-close summaries
+  };
+}
+
+function newSegment(st, ts, evt) {
+  return {
+    id: `${st.sessionID}-${ts}`,
+    sessionID: st.sessionID,
+    project: st.project,
+    start: ts,
+    lastTs: ts,
+    lastUserPrompt: st.lastUserPrompt,
+    events: [segEventRow(evt, ts)],
+  };
+}
+
+function segEventRow(evt, ts) {
+  const kind = segmentEventKind(evt);
+  return {
+    t: ts,
+    kind: kind === "touch" ? "activity" : kind,
+    refs: [evt?.properties?.sessionID].filter(Boolean),
+  };
+}
+
+// Load the stored G (minutes) from engine-state, or the default.
+async function loadStoredG(engineState) {
+  try {
+    const p = await engineState.load();
+    if (p && typeof p === "object" && typeof p.segmentGMinutes === "number") {
+      return p.segmentGMinutes;
+    }
+  } catch {
+    /* unreadable → default */
+  }
+  return DEFAULT_G_MINUTES;
+}
+
+/**
+ * Create the segmenter. Deps:
+ *   segments        — A1 segments store { pathFor, load, save } (default segmentsStore)
+ *   ledger          — A1 ledger { append } (default ledgerStore)
+ *   engineState     — { load, save } for persisted G (default engineStateStore)
+ *   summarize       — async (data) => { ok, summary?, gated? } — the §5.2 summary producer
+ *   computeOneLiner — async (data) => string|null — the one-line producer
+ *   now             — () => epoch ms (default Date.now)
+ *   initialGMinutes — number (default DEFAULT_G_MINUTES; overridden by stored G on boot)
+ */
+export function createSegmenter(deps = {}) {
+  const {
+    segments = segmentsStore,
+    ledger = ledgerStore,
+    engineState = engineStateStore,
+    summarize = async () => ({ ok: false, gated: false }),
+    computeOneLiner = async () => null,
+    now = () => Date.now(),
+    initialGMinutes = DEFAULT_G_MINUTES,
+  } = deps;
+
+  let gMinutes = initialGMinutes;
+  let booted = false;
+  const sessions = new Map(); // sessionID -> sessionState
+  const oneLiners = new Map(); // sessionID -> { oneLiner, ts }
+  let gapSamples = []; // global inter-arrival gaps (ms) since the last refit
+
+  async function boot() {
+    if (booted) return;
+    booted = true;
+    gMinutes = await loadStoredG(engineState);
+    return { gMinutes };
+  }
+
+  async function persistG(nextMinutes) {
+    try {
+      const p = await engineState.load();
+      await engineState.save({ ...p, segmentGMinutes: nextMinutes });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  async function ledgerLog(entry) {
+    try {
+      await ledger.append({ actor: "cto", ts: now(), ...entry });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // A segment closed → one summarize call, then persist (valid summary or
+  // degraded), reusing the session's cached one-liner. Never throws. Awaits
+  // any pending one-liner compute (turn completion) so close reuses the cached
+  // value rather than racing it.
+  async function doClose(seg, st) {
+    if (st?.turnChain) {
+      try {
+        await st.turnChain;
+      } catch {
+        /* one-liner compute is best-effort */
+      }
+    }
+    const cached = oneLiners.get(seg.sessionID)?.oneLiner;
+    const data = {
+      sessionID: seg.sessionID,
+      project: seg.project,
+      start: seg.start,
+      end: seg.end,
+      events: seg.events,
+      lastUserPrompt: truncatePrompt(seg.lastUserPrompt),
+      oneLiner: cached ?? truncatePrompt(seg.lastUserPrompt),
+    };
+    let summary;
+    let failed = false;
+    try {
+      const res = await summarize(data);
+      if (res?.ok && validateSegmentSummary(res.summary)) {
+        summary = res.summary;
+        // Reuse the cached one-liner at close (§5.2) instead of recomputing.
+        if (cached) summary.one_liner = truncatePrompt(cached);
+        // Anchor the persisted window to the actual observed bounds.
+        summary.window = [seg.start, seg.end];
+        summary.sessionID = seg.sessionID;
+      } else if (!res?.gated) {
+        // A real (non-gated) validation failure — record + degrade.
+        summary = degradedSegmentSummary(data);
+        failed = true;
+      } else {
+        // Gated (disabled/paused/rate-limited): expected, persist degraded.
+        summary = degradedSegmentSummary(data);
+      }
+    } catch {
+      summary = degradedSegmentSummary(data);
+      failed = true;
+    }
+    if (failed) {
+      await ledgerLog({ kind: "cto.segment_summary_failed", sessionID: seg.sessionID, project: seg.project });
+    }
+    try {
+      await segments.save(seg.id, {
+        v: SEGMENT_SUMMARY_VERSION,
+        id: seg.id,
+        sessionID: seg.sessionID,
+        project: seg.project,
+        window: summary.window,
+        ts: seg.end,
+        summary,
+      });
+    } catch {
+      /* persistence is best-effort */
+    }
+    return summary;
+  }
+
+  function closeSegment(st, endTs) {
+    const seg = st.segment;
+    if (!seg) return;
+    st.segment = null;
+    seg.end = endTs;
+    // Serialize closes per session so summaries for one session stay ordered.
+    st.closeChain = (st.closeChain ?? Promise.resolve()).then(() => doClose(seg, st)).catch(() => {});
+  }
+
+  // Turn completion: compute + cache the one-liner; a failed/absent model
+  // call degrades to the truncated last user prompt. Never throws.
+  async function computeAndCacheOneLiner(st) {
+    const data = {
+      sessionID: st.sessionID,
+      project: st.project,
+      events: st.segment ? st.segment.events : [],
+      lastUserPrompt: truncatePrompt(st.lastUserPrompt),
+    };
+    let oneLiner = null;
+    try {
+      oneLiner = await computeOneLiner(data);
+    } catch {
+      oneLiner = null;
+    }
+    const cached = truncatePrompt(oneLiner) || truncatePrompt(st.lastUserPrompt);
+    oneLiners.set(st.sessionID, { oneLiner: cached, ts: now() });
+  }
+
+  // "inter-event gap exceeds G" close on a busy/prompt/touch event.
+  function touchActivity(st, ts, evt) {
+    if (st.lastActivityTs != null) gapSamples.push(ts - st.lastActivityTs);
+    st.lastActivityTs = ts;
+    if (st.segment && ts - st.segment.lastTs > minutesToMs(gMinutes)) {
+      closeSegment(st, st.segment.lastTs);
+    }
+    if (!st.segment) {
+      st.segment = newSegment(st, ts, evt);
+    } else {
+      st.segment.lastTs = ts;
+      if (st.segment.events.length < MAX_SEGMENT_EVENTS) st.segment.events.push(segEventRow(evt, ts));
+    }
+  }
+
+  function observe(evt, { sessionID, project, ts = now() } = {}) {
+    if (!sessionID || typeof sessionID !== "string") return;
+    const kind = segmentEventKind(evt);
+    if (!kind) return; // noise — not activity, no boundary
+    let st = sessions.get(sessionID);
+    if (!st) {
+      st = newSessionState(sessionID, project);
+      sessions.set(sessionID, st);
+    }
+    if (project != null) st.project = project;
+
+    if (kind === "abort") {
+      st.abort = true;
+      return;
+    }
+    if (kind === "idle") {
+      if (isTurnCompletion(evt, st)) {
+        st.turnChain = (st.turnChain ?? Promise.resolve()).then(() => computeAndCacheOneLiner(st)).catch(() => {});
+      }
+      st.sawBusy = false;
+      st.abort = false;
+      closeSegment(st, ts);
+      return;
+    }
+    if (kind === "busy") st.sawBusy = true;
+    if (kind === "prompt") {
+      const text = userPromptText(evt);
+      if (text) {
+        st.lastUserPrompt = text;
+        if (st.segment) st.segment.lastUserPrompt = text;
+      }
+    }
+    touchActivity(st, ts, evt);
+  }
+
+  // Monthly G refit (§5.1-d): fit on the box's own inter-arrival times, persist
+  // the new G, and reset the sample window.
+  async function monthlyRefit() {
+    if (gapSamples.length < MIN_GAP_SAMPLES) {
+      return { gMinutes, reused: true, samples: gapSamples.length };
+    }
+    const logs = gapSamples.map((x) => Math.log(Math.max(x, 1)));
+    const out = refitG(logs, { currentGMinutes: gMinutes });
+    if (!out.reused) {
+      gMinutes = out.gMinutes;
+      await persistG(gMinutes);
+    }
+    gapSamples = [];
+    return { gMinutes, reused: out.reused };
+  }
+
+  function getOneLiner(sessionID) {
+    return oneLiners.get(sessionID)?.oneLiner ?? null;
+  }
+
+  function getGMinutes() {
+    return gMinutes;
+  }
+
+  return {
+    observe,
+    monthlyRefit,
+    boot,
+    getGMinutes,
+    getOneLiner,
+    get gapSampleCount() {
+      return gapSamples.length;
+    },
+    get openSegmentCount() {
+      return sessions.size;
+    },
+    // exposed for tests / diagnostics
+    _sessions: sessions,
+    _gapSamples: gapSamples,
+    _oneLiners: oneLiners,
+  };
+}

--- a/src/server/ctoSegments.test.mjs
+++ b/src/server/ctoSegments.test.mjs
@@ -1,0 +1,520 @@
+// src/server/ctoSegments.test.mjs — BET-1380 work segmentation (§5.1), segment
+// summaries (§5.2), turn completion, and the G refit. Pure logic only —
+// injected stores/seams/now, no live tmux/opencode/network.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_G_MINUTES,
+  G_MIN,
+  G_MAX,
+  MINUTE_MS,
+  segmentEventKind,
+  isIdleEvent,
+  isBusyEvent,
+  isAbortEvent,
+  isTurnCompletion,
+  userPromptText,
+  truncatePrompt,
+  validOneLiner,
+  parseSegmentSummaryText,
+  validateSegmentSummary,
+  degradedSegmentSummary,
+  refitG,
+  emGaussianMixture,
+  createSegmenter,
+} from "./ctoSegments.mjs";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const idle = (sid = "s1") => ({ type: "session.idle", properties: { sessionID: sid } });
+const status = (s, sid = "s1") => ({
+  type: "session.status",
+  properties: { sessionID: sid, status: { type: s } },
+});
+const busy = (sid = "s1") => status("busy", sid);
+const prompt = (text = "do the thing", sid = "s1") => ({
+  type: "user.message.created",
+  properties: { sessionID: sid, message: { role: "user", text } },
+});
+const abort = (sid = "s1") => ({
+  type: "session.error",
+  properties: { sessionID: sid, error: { name: "MessageAbortedError" } },
+});
+const otherError = (sid = "s1") => ({
+  type: "session.error",
+  properties: { sessionID: sid, error: { name: "SomeOtherError" } },
+});
+const noise = (sid = "s1") => ({
+  type: "message.part.delta",
+  properties: { sessionID: sid },
+});
+
+function fakeStores() {
+  const segments = new Map();
+  const ledger = [];
+  return {
+    segmentsStore: {
+      name: "segments",
+      pathFor: (id) => id,
+      async load(id) {
+        return segments.get(id) ?? { v: 1 };
+      },
+      async save(id, data) {
+        segments.set(id, data);
+      },
+      peek() {
+        return segments;
+      },
+    },
+    ledgerStore: {
+      async append(row) {
+        ledger.push(row);
+      },
+      peek() {
+        return ledger;
+      },
+    },
+    engineState: {
+      payload: {},
+      async load() {
+        return this.payload;
+      },
+      async save(p) {
+        this.payload = p;
+      },
+      peek() {
+        return this.payload;
+      },
+    },
+  };
+}
+
+function validSummary(over = {}) {
+  return {
+    v: 1,
+    sessionID: "s1",
+    project: "p1",
+    window: [1000, 2000],
+    intent: "fixed login",
+    outcome: "done",
+    key_events: [{ t: 1000, text: "submitted prompt", refs: ["s1"] }],
+    files_touched: ["src/login.ts"],
+    prs: [],
+    importance: 5,
+    one_liner: "Fixed the login redirect",
+    ...over,
+  };
+}
+
+// A controllable clock + segmenter wired to fake stores.
+function makeSeg({ g = DEFAULT_G_MINUTES, summarize, computeOneLiner, stores = fakeStores() } = {}) {
+  let t = 0;
+  const now = () => t;
+  const seg = createSegmenter({
+    segments: stores.segmentsStore,
+    ledger: stores.ledgerStore,
+    engineState: stores.engineState,
+    summarize: summarize ?? (async () => ({ ok: false, gated: false })),
+    computeOneLiner: computeOneLiner ?? (async () => null),
+    now,
+    initialGMinutes: g,
+  });
+  return {
+    seg,
+    stores,
+    set(tv) {
+      t = tv;
+    },
+    now: () => t,
+  };
+}
+
+async function flushClose(seg, sid = "s1") {
+  const st = seg._sessions.get(sid);
+  if (st?.closeChain) await st.closeChain;
+}
+async function flushTurns(seg, sid = "s1") {
+  const st = seg._sessions.get(sid);
+  if (st?.turnChain) await st.turnChain;
+}
+
+// ---------------------------------------------------------------------------
+// Event interpretation
+// ---------------------------------------------------------------------------
+
+test("segmentEventKind classifies busy/idle/abort/prompt/touch and drops noise", () => {
+  assert.equal(segmentEventKind(busy()), "busy");
+  assert.equal(segmentEventKind(idle()), "idle");
+  assert.equal(segmentEventKind(status("idle")), "idle");
+  assert.equal(segmentEventKind(abort()), "abort");
+  assert.equal(segmentEventKind(otherError()), "touch");
+  assert.equal(segmentEventKind(prompt()), "prompt");
+  assert.equal(segmentEventKind({ type: "session.created", properties: {} }), "touch");
+  assert.equal(segmentEventKind(noise()), null);
+  assert.equal(segmentEventKind(null), null);
+  assert.equal(segmentEventKind({ type: "message.part.updated", properties: { message: { role: "assistant" } } }), null);
+});
+
+test("isIdleEvent / isBusyEvent / isAbortEvent accept both shapes", () => {
+  assert.ok(isIdleEvent(idle()));
+  assert.ok(isIdleEvent(status("idle")));
+  assert.ok(!isIdleEvent(status("busy")));
+  assert.ok(isBusyEvent(busy()));
+  assert.ok(isBusyEvent(status("retry")));
+  assert.ok(!isBusyEvent(idle()));
+  assert.ok(isAbortEvent(abort()));
+  assert.ok(!isAbortEvent(otherError()));
+  assert.ok(!isAbortEvent(idle()));
+});
+
+test("userPromptText extracts the prompt body best-effort", () => {
+  assert.equal(userPromptText(prompt("hello")), "hello");
+  assert.equal(userPromptText({ type: "user.message.created", properties: { info: { message: { text: "from info" } } } }), "from info");
+  assert.equal(userPromptText({ type: "user.message.created", properties: {} }), "");
+});
+
+// ---------------------------------------------------------------------------
+// Turn completion (§5.1-c)
+// ---------------------------------------------------------------------------
+
+test("turn completion: idle after a seen busy (and a prompt touch)", () => {
+  const h = makeSeg();
+  h.set(0);
+  h.seg.observe(busy("a"), { sessionID: "a", project: "p", ts: h.now() });
+  const st = h.seg._sessions.get("a");
+  assert.ok(isTurnCompletion(idle("a"), st));
+  st.sawBusy = false;
+  assert.ok(!isTurnCompletion(idle("a"), st));
+});
+
+test("turn completion: idle without busy is NOT a completion", () => {
+  const h = makeSeg();
+  const st = { sawBusy: false, abort: false };
+  assert.ok(!isTurnCompletion(idle(), st));
+  assert.ok(!isTurnCompletion(status("idle"), { sawBusy: false }));
+});
+
+test("turn completion: an idle caused by MessageAbortedError is NOT a completion", () => {
+  const st = { sawBusy: true, abort: true };
+  assert.ok(!isTurnCompletion(idle(), st));
+  // a non-idle event is never a completion even with busy
+  assert.ok(!isTurnCompletion(prompt(), { sawBusy: true, abort: false }));
+});
+
+test("user abort (queued-drain) never caches a one-liner or flags a completion", async () => {
+  const calls = [];
+  const h = makeSeg({ computeOneLiner: async () => { calls.push(1); return "nope"; } });
+  h.set(0);
+  h.seg.observe(busy(), { sessionID: "s1", project: "p", ts: h.now() }); // busy
+  h.set(1000);
+  h.seg.observe(abort(), { sessionID: "s1", ts: h.now() }); // abort
+  h.set(2000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() }); // idle after abort
+  await flushTurns(h.seg);
+  assert.equal(calls.length, 0, "abort idle must not run a one-liner compute");
+  assert.equal(h.seg.getOneLiner("s1"), null);
+});
+
+// ---------------------------------------------------------------------------
+// Segmentation: gap close, idle close (§5.1-a,b)
+// ---------------------------------------------------------------------------
+
+test("events closer than G stay in one segment; idle closes it", async () => {
+  const calls = [];
+  const h = makeSeg({
+    g: 1, // G = 1 minute
+    summarize: async (data) => { calls.push(data); return { ok: true, summary: validSummary({ window: data.start ? [0, 0] : [0, 0] }) }; },
+  });
+  h.set(0);
+  h.seg.observe(prompt("a"), { sessionID: "s1", project: "p", ts: h.now() });
+  h.set(30_000);
+  h.seg.observe(prompt("b"), { sessionID: "s1", ts: h.now() }); // within G
+  h.set(60_000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() }); // idle closes
+  await flushClose(h.seg);
+  assert.equal(h.stores.segmentsStore.peek().size, 1, "one segment persisted");
+  const file = [...h.stores.segmentsStore.peek().values()][0];
+  assert.equal(file.summary.outcome, "done");
+  assert.equal(file.ts, 60_000);
+  assert.deepEqual(file.window, [0, 60_000]);
+  assert.equal(calls.length, 1, "one summarize call on close");
+});
+
+test("an inter-event gap exceeding G closes the segment and opens a new one", async () => {
+  const h = makeSeg({
+    g: 1, // G = 60000 ms
+    summarize: async () => ({ ok: true, summary: validSummary() }),
+  });
+  h.set(0);
+  h.seg.observe(prompt("a"), { sessionID: "s1", project: "p", ts: h.now() });
+  h.set(30_000);
+  h.seg.observe(prompt("b"), { sessionID: "s1", ts: h.now() }); // gap 30s < G
+  h.set(200_000);
+  h.seg.observe(prompt("c"), { sessionID: "s1", ts: h.now() }); // gap 170s > G → closes seg1, opens seg2
+  h.set(250_000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() }); // idle closes seg2
+  await flushClose(h.seg);
+  const files = [...h.stores.segmentsStore.peek().values()];
+  assert.equal(files.length, 2, "two segments");
+  const segs = files.map((f) => f.window).sort((a, b) => a[0] - b[0]);
+  assert.deepEqual(segs[0], [0, 30_000], "seg1 ends at last activity before the gap");
+  assert.deepEqual(segs[1], [200_000, 250_000], "seg2 opens at the gap-triggering event");
+});
+
+test("idle leaves the session windowed; the next activity starts a fresh segment", async () => {
+  const h = makeSeg({
+    g: 10,
+    summarize: async () => ({ ok: true, summary: validSummary() }),
+  });
+  h.set(0);
+  h.seg.observe(prompt("a"), { sessionID: "s1", project: "p", ts: h.now() });
+  h.set(1000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() }); // closes seg1
+  await flushClose(h.seg);
+  h.set(5000);
+  // next activity (well within G of nothing open) opens a fresh segment
+  h.seg.observe(prompt("b"), { sessionID: "s1", ts: h.now() });
+  h.set(6000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
+  await flushClose(h.seg);
+  const files = [...h.stores.segmentsStore.peek().values()].map((f) => f.window).sort((a, b) => a[0] - b[0]);
+  assert.deepEqual(files, [[0, 1000], [5000, 6000]]);
+});
+
+test("the deltas that flooded during a turn are noise and do not extend the segment", () => {
+  const h = makeSeg({ g: 1 });
+  h.set(0);
+  h.seg.observe(prompt("a"), { sessionID: "s1", ts: h.now() });
+  h.set(1000);
+  h.seg.observe(noise(), { sessionID: "s1", ts: h.now() }); // deltas ignored
+  h.set(2000);
+  h.seg.observe(noise(), { sessionID: "s1", ts: h.now() });
+  const st = h.seg._sessions.get("s1");
+  assert.equal(st.segment.events.length, 1, "only the prompt is a segment event");
+  assert.equal(st.segment.lastTs, 0, "lastTs unchanged by noise");
+});
+
+// ---------------------------------------------------------------------------
+// One-liner: computed at turn completion, cached, reused at close (§5.2)
+// ---------------------------------------------------------------------------
+
+test("one-liner computed at turn completion is cached and reused at segment close", async () => {
+  const oneLinerSeen = [];
+  const summarizeData = [];
+  const h = makeSeg({
+    computeOneLiner: async () => { oneLinerSeen.push(1); return "Fixed the login redirect"; },
+    summarize: async (data) => {
+      summarizeData.push(data);
+      return { ok: true, summary: validSummary({ one_liner: "model would say something else" }) };
+    },
+  });
+  h.set(0);
+  h.seg.observe(prompt("a"), { sessionID: "s1", project: "p", ts: h.now() });
+  h.set(1000);
+  h.seg.observe(busy(), { sessionID: "s1", ts: h.now() });
+  h.set(2000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() }); // turn completion → one-liner
+  await flushTurns(h.seg);
+  await flushClose(h.seg);
+  assert.equal(oneLinerSeen.length, 1, "one-liner computed exactly once, at turn completion");
+  assert.equal(h.seg.getOneLiner("s1"), "Fixed the login redirect", "cached");
+  assert.equal(summarizeData[0].oneLiner, "Fixed the login redirect", "close feeds the cached one-liner");
+  const file = [...h.stores.segmentsStore.peek().values()][0];
+  assert.equal(file.summary.one_liner, "Fixed the login redirect", "persisted summary reuses the cache, not a recompute");
+});
+
+test("a failed/absent one-liner degrades to the truncated last user prompt", async () => {
+  const h = makeSeg({ computeOneLiner: async () => null });
+  h.set(0);
+  h.seg.observe(prompt("do the thing now"), { sessionID: "s1", ts: h.now() });
+  h.set(1000);
+  h.seg.observe(busy(), { sessionID: "s1", ts: h.now() });
+  h.set(2000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
+  await flushTurns(h.seg);
+  assert.equal(h.seg.getOneLiner("s1"), "do the thing now", "fallback is the truncated prompt");
+});
+
+// ---------------------------------------------------------------------------
+// Summary failure handling (§5.2)
+// ---------------------------------------------------------------------------
+
+test("a non-gated validation failure persists a degraded summary and records the failure", async () => {
+  const h = makeSeg({ summarize: async () => ({ ok: false, gated: false }) });
+  h.set(0);
+  h.seg.observe(prompt("fix the bug please"), { sessionID: "s1", project: "p", ts: h.now() });
+  h.set(1000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
+  await flushClose(h.seg);
+  const file = [...h.stores.segmentsStore.peek().values()][0];
+  assert.equal(file.summary.outcome, "in-progress");
+  assert.equal(file.summary.one_liner, "fix the bug please");
+  assert.ok(
+    h.stores.ledgerStore.peek().some((r) => r.kind === "cto.segment_summary_failed"),
+    "failure recorded in the ledger",
+  );
+});
+
+test("a gated summary (disabled/paused) degrades without recording a failure", async () => {
+  const h = makeSeg({ summarize: async () => ({ ok: false, gated: true }) });
+  h.set(0);
+  h.seg.observe(prompt("work"), { sessionID: "s1", ts: h.now() });
+  h.set(1000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
+  await flushClose(h.seg);
+  const file = [...h.stores.segmentsStore.peek().values()][0];
+  assert.equal(file.summary.outcome, "in-progress");
+  assert.ok(
+    !h.stores.ledgerStore.peek().some((r) => r.kind === "cto.segment_summary_failed"),
+    "gating is expected, not a failure",
+  );
+});
+
+// ---------------------------------------------------------------------------
+// Schema validation (§5.2)
+// ---------------------------------------------------------------------------
+
+test("validateSegmentSummary accepts a well-formed summary and rejects bad ones", () => {
+  assert.ok(validateSegmentSummary(validSummary()));
+  assert.ok(!validateSegmentSummary(validSummary({ outcome: "nope" })));
+  assert.ok(!validateSegmentSummary(validSummary({ v: 2 })));
+  assert.ok(!validateSegmentSummary(validSummary({ importance: 11 })));
+  assert.ok(!validateSegmentSummary(validSummary({ one_liner: "x".repeat(141) })));
+  assert.ok(!validateSegmentSummary(validSummary({ window: [2000, 1000] })));
+  assert.ok(!validateSegmentSummary(validSummary({ key_events: [{ t: 1, text: "a" }, { t: 2 }, { t: 3 }, { t: 4 }, { t: 5 }, { t: 6 }] })));
+  assert.ok(!validateSegmentSummary(null));
+});
+
+test("parseSegmentSummaryText extracts JSON from fenced/prose model output", () => {
+  const obj = parseSegmentSummaryText('Here you go:\n```json\n{"v":1,"sessionID":"s1"}\n```');
+  assert.equal(obj.sessionID, "s1");
+  assert.equal(parseSegmentSummaryText("no json here"), null);
+  assert.equal(parseSegmentSummaryText('{"broken"'), null);
+  assert.equal(parseSegmentSummaryText(null), null);
+});
+
+test("validOneLiner enforces the <=140 char bound and non-emptiness", () => {
+  assert.equal(validOneLiner("short"), "short");
+  assert.equal(validOneLiner("x".repeat(140)), "x".repeat(140));
+  assert.equal(validOneLiner("x".repeat(141)), null);
+  assert.equal(validOneLiner("   "), null);
+  assert.equal(validOneLiner(null), null);
+});
+
+test("degradedSegmentSummary carries outcome in-progress and a truncated one-liner", () => {
+  const d = degradedSegmentSummary({ start: 0, end: 1000, lastUserPrompt: "y".repeat(200) });
+  assert.equal(d.outcome, "in-progress");
+  assert.equal(d.one_liner.length, 140);
+  assert.deepEqual(d.window, [0, 1000]);
+});
+
+// ---------------------------------------------------------------------------
+// G refit math (§5.1-d)
+// ---------------------------------------------------------------------------
+
+let rngSeed = 987654321;
+function rng() {
+  rngSeed = (rngSeed * 1664525 + 1013904223) >>> 0;
+  return rngSeed / 4294967296;
+}
+function gauss() {
+  let u = 0;
+  let v = 0;
+  while (u === 0) u = rng();
+  while (v === 0) v = rng();
+  return Math.sqrt(-2 * Math.log(u)) * Math.cos(2 * Math.PI * v);
+}
+function cluster(logMean, logSd, n) {
+  const out = [];
+  for (let i = 0; i < n; i++) out.push(logMean + gauss() * logSd);
+  return out;
+}
+
+test("refitG finds the valley between two inter-arrival clusters, within [20,90] min", () => {
+  const mid = (Math.log(30 * MINUTE_MS) + Math.log(60 * MINUTE_MS)) / 2; // ~42.6 min in log-ms
+  const logs = [...cluster(Math.log(30 * MINUTE_MS), 0.05, 150), ...cluster(Math.log(60 * MINUTE_MS), 0.05, 150)];
+  const out = refitG(logs, { currentGMinutes: DEFAULT_G_MINUTES });
+  assert.equal(out.reused, false);
+  assert.ok(out.gMinutes >= G_MIN && out.gMinutes <= G_MAX, `gMinutes ${out.gMinutes} within clamp`);
+  const expected = Math.exp(mid) / MINUTE_MS;
+  assert.ok(Math.abs(out.gMinutes - expected) < 5, `gMinutes ${out.gMinutes} near expected ${expected}`);
+});
+
+test("refitG clamps to G_MIN when the natural valley is below 20 minutes", () => {
+  const logs = [...cluster(Math.log(2 * MINUTE_MS), 0.05, 150), ...cluster(Math.log(5 * MINUTE_MS), 0.05, 150)];
+  const out = refitG(logs);
+  assert.equal(out.reused, false);
+  assert.equal(out.gMinutes, G_MIN);
+});
+
+test("refitG clamps to G_MAX when the natural valley is above 90 minutes", () => {
+  const logs = [...cluster(Math.log(200 * MINUTE_MS), 0.05, 150), ...cluster(Math.log(400 * MINUTE_MS), 0.05, 150)];
+  const out = refitG(logs);
+  assert.equal(out.reused, false);
+  assert.equal(out.gMinutes, G_MAX);
+});
+
+test("refitG reuses the current G on degenerate / insufficient samples", () => {
+  assert.equal(refitG([]).reused, true);
+  assert.equal(refitG([Math.log(1000), Math.log(1001)]).reused, true); // < 8 samples
+  // single cluster — no between-means valley
+  const logs = Array.from({ length: 40 }, () => Math.log(60 * MINUTE_MS + (rng() * 2 - 1)));
+  assert.equal(refitG(logs, { currentGMinutes: 60 }).reused, true);
+  assert.equal(refitG(logs, { currentGMinutes: 60 }).gMinutes, 60);
+});
+
+// ---------------------------------------------------------------------------
+// Monthly refit wiring + persistence
+// ---------------------------------------------------------------------------
+
+test("monthlyRefit fits on accumulated gaps, persists G, and resets the window", async () => {
+  const stores = fakeStores();
+  const h = makeSeg({ stores, g: DEFAULT_G_MINUTES });
+  // Feed prompts whose inter-arrival gaps alternate between two rhythms so the
+  // mixture fit has two distinct clusters (and persists a refit, not default).
+  const start = 1_000_000;
+  let t = start;
+  for (let i = 1; i < 40; i++) {
+    t = i % 2 === 0 ? t + 120_000 : t + 3_600_000; // 2-min vs 60-min gaps
+    h.set(t);
+    h.seg.observe(prompt(`p${i}`), { sessionID: "s1", ts: h.now() });
+  }
+  assert.ok(h.seg.gapSampleCount > 0, "gap samples collected");
+  const out = await h.seg.monthlyRefit();
+  assert.equal(out.reused, false, "a two-cluster fit is reusable");
+  assert.ok(out.gMinutes >= G_MIN && out.gMinutes <= G_MAX);
+  assert.equal(typeof stores.engineState.peek().segmentGMinutes, "number", "G persisted to engine-state");
+  assert.equal(h.seg.gapSampleCount, 0, "sample window reset after refit");
+});
+
+test("boot loads a stored G from engine-state", async () => {
+  const stores = fakeStores();
+  stores.engineState.payload = { segmentGMinutes: 33 };
+  const h = makeSeg({ stores });
+  await h.seg.boot();
+  assert.equal(h.seg.getGMinutes(), 33);
+  // and a fresh boot without a stored value falls back to the default
+  const stores2 = fakeStores();
+  const h2 = makeSeg({ stores: stores2 });
+  await h2.seg.boot();
+  assert.equal(h2.seg.getGMinutes(), DEFAULT_G_MINUTES);
+});
+
+// ---------------------------------------------------------------------------
+// Engine-exposure sanity
+// ---------------------------------------------------------------------------
+
+test("createSegmenter exposes diagnostics without leaking internals into the API surface", () => {
+  const h = makeSeg();
+  h.set(0);
+  h.seg.observe(prompt("a"), { sessionID: "s1", ts: h.now() });
+  assert.equal(h.seg.openSegmentCount, 1);
+  h.set(1000);
+  h.seg.observe(idle(), { sessionID: "s1", ts: h.now() });
+  assert.equal(h.seg.openSegmentCount, 1); // session retained (closed) for bookkeeping
+  assert.equal(typeof h.seg.monthlyRefit, "function");
+  assert.equal(typeof h.seg.boot, "function");
+});

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -184,6 +184,9 @@ function createDirJsonStore(name, dirPart) {
 export const factsStore = createDirJsonStore("facts", "facts");
 export const factsArchiveStore = createDirJsonStore("facts-archive", "facts-archive");
 export const digestsStore = createDirJsonStore("digests", "digests");
+// Segments store — the read-layer work episodes (spec §5.1), one JSON file per
+// segment, swept 30d by sweepSegments(). Owned by the segmentation issue (A6).
+export const segmentsStore = createDirJsonStore("segments", "segments");
 
 // ---------------------------------------------------------------------------
 // Rollups: `rollups/<hour|day|week>/<id>.json` — one JSON file per rollup.


### PR DESCRIPTION
A6 — work segmentation, segment summaries, and turn completion (BET-1380)

Implements spec §5.1 (segmentation + G refit + turn completion) and §5.2
(segment summaries) as a pure, injected-I/O module wired into the CTO engine.
Builds on the merged BET-1378 (ephemeral runner / `ambient-summarize`) and
BET-1379 (A5 evidence normalization).

## What's in this PR

- **`src/server/ctoSegments.mjs` (new)** — pure segmentation logic:
  - Online per-session state machine: a segment closes when the inter-event
    gap exceeds G or on `session.idle`; a gap close opens the next segment at
    the gap-triggering event, an idle close leaves the session windowed until
    the next activity (§5.1-a/b).
  - **Turn completion** = the session's first `session.idle` after a seen
    busy — the sawBusy-then-idle shape delegate.mjs uses. An idle caused by a
    `MessageAbortedError` (user abort **and** the queued-drain abort, detected
    by error name the way push.mjs's classifier does) is NOT a completion
    (§5.1-c). Streaming deltas are noise and never advance the segment.
  - **G refit** (§5.1-d): 2-component Gaussian-mixture EM on the box's own log
    inter-arrival times, valley between component means, clamped to [20,90]
    minutes, persisted to `engine-state.json#segmentGMinutes`; a monthly timer
    in the engine refits + resets the window (rebased cleanly onto BET-1382).
  - **§5.2 summary on close**: one `ambient-summarize` call validated against
    the schema; on a real (non-gated) validation failure the runner's cascade
    retried it and this module persists a **degraded summary** (outcome
    `in-progress`, one_liner = truncated last user prompt) and records
    `cto.segment_summary_failed`. Gated (disabled/paused/at-cap) → degraded
    with **no** failure record.
  - **One-liner at turn completion** is cached; segment close reuses the
    cached value instead of recomputing (§5.2).
  - Segments persist via a new `segmentsStore` (the segments area of the A1
    rollups store, `~/.manta/cto/segments/`) — swept 30d by the existing
    `sweepSegments`.
- **`src/server/ctoEngine.mjs`** — wires the segmenter into A5 evidence:
  `observerEvent` feeds pipeline (user|job) sessions into the segmenter
  (cto-owned excluded); the model seams are wrapped in the engine's §3.3
  ephemeral rate gate (disabled/paused → gated → degraded, no spend); monthly
  G-refit work timer registered with the other work timers (halted on pause).
- **`src/server/ctoStores.mjs`** — `segmentsStore` accessor (segments area of
  the rollups store).
- **Tests**: `ctoSegments.test.mjs` (26) + 2 engine wiring tests (rebase kept
  BET-1382's card tests intact).

## Anti-spaghetti notes

- No new call sites duplicated — the model seam is injected and defaulted to
  degrade; it is the runner's job (BET-1378) to cascade on failure.
- The offline/degraded path is a first-class, tested outcome, not an error
  swallow.

## Deferred / follow-ups

- Wiring the real `runEphemeral`-backed `summarize`/`computeOneLiner` (and the
  §3.1 reaper) into `src/server/index.mjs` is split out — **`index.mjs` does
  not parse on `main` right now** (pre-existing module-scope `let ctoEngine`
  shadows `import * as ctoEngine`, line ~1612, unrelated to this PR), so
  nothing in it can load until that's fixed. Filed as **BET-1408**; the engine
  seam is ready for it.

## Verification results

**Files changed:** 5 files. 1335 insertions.

- PR branch (`multica/BET-1380-segmentation` @ `2b54523b`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d…8fce`
  - test: exit `0`, `3069` pass / `0` fail / `0` skip. log sha256: `3a280951…e38f`
- Base (`main` @ `5441b5f9`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d…8fce`
  - test: exit `0`, `3041` pass / `0` fail / `0` skip. log sha256: `4bb8b68c…e836`
- **Conclusion:** `0` new failures, `28` new tests added by this PR.

**Base: origin/main @ `5441b5f9`** (rebased after BET-1382 landed to keep it fresh)

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log`.
