### PR TITLE
BET-1381: hour/day/week rollups (A7)

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -72,6 +72,12 @@ import {
   isAskResolveEvent,
 } from "./ctoCards.mjs";
 import { createSegmenter } from "./ctoSegments.mjs";
+import {
+  createRollupRunner,
+  LEVEL_MS as ROLLUP_LEVEL_MS,
+  ROLLUP_LEVELS,
+  windowFor as rollupWindowFor,
+} from "./ctoRollups.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
@@ -236,6 +242,12 @@ export function createCtoEngine(deps = {}) {
     summarize = async () => ({ ok: false, gated: false }),
     computeOneLiner = async () => null,
     segmenterOverride = null, // optional pre-built segmenter (else one is constructed below)
+    // BET-1381 rollups (§5.3): the `ambient-summarize` reduce producer,
+    // wrapped by the engine in the §3.3 ephemeral rate gate (defaults to a
+    // no-op → the runner persists degraded rollups, no model spend). A caller
+    // may inject a pre-built rollup runner instead.
+    runEphemeral = null,
+    rollups = null, // optional pre-built rollup runner override
   } = deps;
 
   let disposed = false;
@@ -248,6 +260,7 @@ export function createCtoEngine(deps = {}) {
   let reaperHandle = null;
   let refitHandle = null;
   let lastPublishedSerialized = null;
+  let rollupRunner = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
   // open, user prompt). The desktop heartbeat is read live via
@@ -343,10 +356,14 @@ export function createCtoEngine(deps = {}) {
     if (disposed) return;
     heartbeatAt = now();
     try {
-      const { paused } = await gateContext();
+      const { enabled: enabledNow, paused } = await gateContext();
       if (paused) {
         await syncState();
         return;
+      }
+      // §5.3 rollups — ambient background work, gated on enabled like any other.
+      if (enabledNow) {
+        await finalizeRollups();
       }
       await syncState();
     } catch {
@@ -563,6 +580,101 @@ export function createCtoEngine(deps = {}) {
       now,
     });
 
+  // ----- BET-1381 rollups (§5.3) -----
+  // Window-close TIMERS live here on the engine tick. The task list tracked a
+  // per-level cursor (the start of the last FINALIZED window) persisted in
+  // engine-state; each 1-min tick asks "has a window of this level closed since
+  // the cursor?" and hands the due windows to the rollup runner. Defaulting the
+  // cursor to the CURRENT window start on first sight means the past is never
+  // backfilled — a window only gets rolled up once it has actually closed.
+  function getRollupRunner() {
+    if (rollupRunner) return rollupRunner;
+    if (deps.rollups) {
+      rollupRunner = deps.rollups;
+      return rollupRunner;
+    }
+    // No reduce producer wired → rolling up would only write degraded data with
+    // no model spend. Stay inert (and never touch the real stores) until a
+    // runEphemeral is supplied.
+    if (!runEphemeral) return null;
+    const gatedRunEphemeral = async (data) => {
+      const gate = await beginEphemeral();
+      if (!gate.ok) return { ok: false, gated: true, error: gate.error };
+      try {
+        return runEphemeral ? await runEphemeral(data) : { ok: false, gated: true };
+      } finally {
+        gate.release?.();
+      }
+    };
+    rollupRunner = createRollupRunner({
+      runEphemeral: gatedRunEphemeral,
+      presenceCheck: () => engine.getPresence().state === "present",
+      now,
+    });
+    return rollupRunner;
+  }
+
+  // Compute, per level, the windows whose close was discovered since the last
+  // finalized cursor (a window closes once now ≥ its end). Returns { level: [windows] }.
+  async function dueRollupWindows() {
+    let payload;
+    try {
+      payload = await engineState.load();
+    } catch {
+      payload = null;
+    }
+    const cursor = payload?.rollupCursor ?? {};
+    const t = now();
+    const due = {};
+    for (const level of ROLLUP_LEVELS) {
+      const duration = ROLLUP_LEVEL_MS[level];
+      let start = cursor[level] != null ? cursor[level] : rollupWindowFor(level, t)[0];
+      const list = [];
+      let guard = 0;
+      while (start + duration <= t && guard < 2000) {
+        list.push(rollupWindowFor(level, start));
+        start += duration;
+        guard += 1;
+      }
+      due[level] = list;
+    }
+    return due;
+  }
+
+  // Fold any closed windows into rollups (respecting enabled/paused via the
+  // tick's gate, and preempting the batch between calls when the user is
+  // present). Advances the persisted cursor only across windows actually
+  // finalized, so a preempted batch re-runs the remainder next tick. Never
+  // throws into the poller.
+  async function finalizeRollups() {
+    try {
+      const runner = getRollupRunner();
+      if (!runner) return;
+      const due = await dueRollupWindows();
+      const payload = (await engineState.load()) || {};
+      const cursor = { ...(payload.rollupCursor ?? {}) };
+      let changed = false;
+      for (const level of ROLLUP_LEVELS) {
+        const windows = due[level];
+        if (!windows || windows.length === 0) continue;
+        const outcomes = await runner.processDue(windows.map((w) => ({ level, window: w })));
+        if (outcomes && outcomes.length > 0) {
+          const last = outcomes[outcomes.length - 1];
+          const next = last.window[1];
+          if (cursor[level] === undefined || next > cursor[level]) {
+            cursor[level] = next;
+            changed = true;
+          }
+        }
+      }
+      if (changed) {
+        await engineState.save({ ...payload, rollupCursor: cursor });
+      }
+    } catch {
+      /* rollups are best-effort — never take the engine down */
+    }
+  }
+
   // Event ingestion — the ONE thing that keeps running while paused (§10.6-5).
   // Driven from index.mjs's event pump (not a timer); the engine is just
   // another consumer (§4.1). Consumes the opencode stream into normalized
@@ -729,6 +841,9 @@ export function createCtoEngine(deps = {}) {
     },
     get segmenter() {
       return segmenter;
+    },
+    get rollupRunner() {
+      return getRollupRunner();
     },
   };
 

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -614,33 +614,6 @@ export function createCtoEngine(deps = {}) {
     return rollupRunner;
   }
 
-  // Compute, per level, the windows whose close was discovered since the last
-  // finalized cursor (a window closes once now ≥ its end). Returns { level: [windows] }.
-  async function dueRollupWindows() {
-    let payload;
-    try {
-      payload = await engineState.load();
-    } catch {
-      payload = null;
-    }
-    const cursor = payload?.rollupCursor ?? {};
-    const t = now();
-    const due = {};
-    for (const level of ROLLUP_LEVELS) {
-      const duration = ROLLUP_LEVEL_MS[level];
-      let start = cursor[level] != null ? cursor[level] : rollupWindowFor(level, t)[0];
-      const list = [];
-      let guard = 0;
-      while (start + duration <= t && guard < 2000) {
-        list.push(rollupWindowFor(level, start));
-        start += duration;
-        guard += 1;
-      }
-      due[level] = list;
-    }
-    return due;
-  }
-
   // Fold any closed windows into rollups (respecting enabled/paused via the
   // tick's gate, and preempting the batch between calls when the user is
   // present). Advances the persisted cursor only across windows actually
@@ -650,18 +623,32 @@ export function createCtoEngine(deps = {}) {
     try {
       const runner = getRollupRunner();
       if (!runner) return;
-      const due = await dueRollupWindows();
       const payload = (await engineState.load()) || {};
       const cursor = { ...(payload.rollupCursor ?? {}) };
-      let changed = false;
+      const t = now();
+      let cursorInit = false;
       for (const level of ROLLUP_LEVELS) {
-        const windows = due[level];
-        if (!windows || windows.length === 0) continue;
-        const outcomes = await runner.processDue(windows.map((w) => ({ level, window: w })));
+        if (cursor[level] == null) {
+          cursor[level] = rollupWindowFor(level, t)[0];
+          cursorInit = true;
+        }
+      }
+      let changed = cursorInit;
+      for (const level of ROLLUP_LEVELS) {
+        const duration = ROLLUP_LEVEL_MS[level];
+        let start = cursor[level];
+        const list = [];
+        let guard = 0;
+        while (start + duration <= t && guard < 2000) {
+          list.push(rollupWindowFor(level, start));
+          start += duration;
+          guard += 1;
+        }
+        if (list.length === 0) continue;
+        const outcomes = await runner.processDue(list.map((w) => ({ level, window: w })));
         if (outcomes && outcomes.length > 0) {
-          const last = outcomes[outcomes.length - 1];
-          const next = last.window[1];
-          if (cursor[level] === undefined || next > cursor[level]) {
+          const next = outcomes[outcomes.length - 1].window[1];
+          if (next > cursor[level]) {
             cursor[level] = next;
             changed = true;
           }

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -412,30 +412,31 @@ function fakeSegStores() {
   };
 }
 
-test("observeEvent feeds pipeline (user) sessions into the segmenter", async () => {
+// Shared A6 segmenter-wiring setup: fake stores + a real segmenter + an engine
+// wired to it, plus event builders. `owner` optionally sets getSessionInfo so
+// cto-owned sessions exercise the exclusion path.
+function makeSegEngine({ owner } = {}) {
   const stores = fakeSegStores();
-  let t = 0;
   const seg = createSegmenter({
     segments: stores.segments,
     ledger: stores.ledger,
     engineState: { load: async () => ({}), save: async () => {} },
     summarize: async () => ({ ok: false, gated: false }),
     computeOneLiner: async () => null,
-    now: () => t,
+    now: () => 0,
   });
-  const harness = makeHarness({ ctoEnabled: false });
   const engine = createCtoEngine({
     configGet: async () => ({ ctoEnabled: false }),
     ledger: { append: async () => {} },
     engineState: { load: async () => ({ v: 1, pendingBlockers: [] }), save: async () => {} },
     publish: () => {},
-    now: () => t,
+    now: () => 0,
     segmenterOverride: seg,
+    ...(owner ? { getSessionInfo: async () => ({ owner, project: undefined }) } : {}),
   });
-
   const prompt = (text, sid) => ({
     type: "user.message.created",
-    id: `id-${text}-${t}`,
+    id: `id-${text}-0`,
     properties: { sessionID: sid, message: { role: "user", text } },
   });
   const idle = (sid, idSuffix) => ({
@@ -443,7 +444,11 @@ test("observeEvent feeds pipeline (user) sessions into the segmenter", async () 
     id: `idle-${idSuffix}`,
     properties: { sessionID: sid },
   });
+  return { stores, engine, seg, prompt, idle };
+}
 
+test("observeEvent feeds pipeline (user) sessions into the segmenter", async () => {
+  const { stores, engine, seg, prompt, idle } = makeSegEngine();
   engine.observeEvent(prompt("first task", "s-user"));
   engine.observeEvent(idle("s-user", 1));
   await new Promise((r) => setTimeout(r, 10)); // let the async owner-resolve + feed land
@@ -453,31 +458,12 @@ test("observeEvent feeds pipeline (user) sessions into the segmenter", async () 
 });
 
 test("cto-owned sessions are never segmented", async () => {
-  const stores = fakeSegStores();
-  let t = 0;
-  const seg = createSegmenter({
-    segments: stores.segments,
-    ledger: stores.ledger,
-    engineState: { load: async () => ({}), save: async () => {} },
-    summarize: async () => ({ ok: false, gated: false }),
-    computeOneLiner: async () => null,
-    now: () => t,
-  });
-  const engine = createCtoEngine({
-    configGet: async () => ({ ctoEnabled: false }),
-    ledger: { append: async () => {} },
-    engineState: { load: async () => ({ v: 1, pendingBlockers: [] }), save: async () => {} },
-    publish: () => {},
-    now: () => t,
-    segmenterOverride: seg,
-    getSessionInfo: async () => ({ owner: "cto", project: undefined }),
-  });
-  const evt = {
+  const { stores, engine } = makeSegEngine({ owner: "cto" });
+  engine.observeEvent({
     type: "user.message.created",
     id: "cto-evt-1",
     properties: { sessionID: "s-cto", message: { role: "user", text: "x" } },
-  };
-  engine.observeEvent(evt);
+  });
   await new Promise((r) => setTimeout(r, 10));
   assert.equal(stores.map.size, 0, "cto-owned work is excluded from segmentation");
 });
@@ -487,54 +473,60 @@ test("cto-owned sessions are never segmented", async () => {
 // BET-1381 §5.3 rollups — window-close timers + persisted cursor on the tick
 // ---------------------------------------------------------------------------
 
-test("tick folds a closed hour window into the rollup runner and persists the cursor", async () => {
+// A rollup-enabled engine harness with an injected runner that records every
+// window passed to processDue (and a stub which marks it finalized). Shared by
+// the rollup tick tests so the boilerplate lives in one place.
+function makeRollupHarness() {
   const d = windowFor("day", Date.UTC(2026, 0, 15, 12, 0, 0))[0];
-  const processed = [];
+  const received = [];
   const runner = {
     processDue: async (windows) => {
-      processed.push(...windows);
-      // mark every window finalized
+      received.push(...windows);
       return windows.map((w) => ({ saved: true, level: w.level, window: w.window, id: String(w.window[0]) }));
     },
   };
   const h = makeHarness({ ctoEnabled: true, rollups: runner });
-  // Position the clock at the top of an hour; cursor defaults there (nothing due).
   h.clock.ms = windowFor("hour", d)[0];
+  return {
+    h,
+    d,
+    runner,
+    get received() {
+      return received;
+    },
+  };
+}
+
+test("tick folds a closed hour window into the rollup runner and persists the cursor", async () => {
+  const { h, d, received } = makeRollupHarness();
+  // First tick at the top of an hour: cursor persists there; nothing due.
   await h.engine.tick();
-  assert.equal(processed.length, 0, "current (not-yet-closed) window is not due");
+  assert.equal(received.length, 0, "current (not-yet-closed) window is not due");
 
   // Advance 90 minutes → the first hour has closed → exactly one hour is due.
   h.advance(90 * 60_000);
   await h.engine.tick();
-  assert.equal(processed.length, 1);
-  assert.equal(processed[0].level, "hour");
-  assert.equal(processed[0].window[0], windowFor("hour", d)[0]);
+  assert.equal(received.length, 1);
+  assert.equal(received[0].level, "hour");
+  assert.equal(received[0].window[0], windowFor("hour", d)[0]);
 
   // The cursor advanced to the closed hour's end; the next tick yields nothing new.
   assert.equal(h.state.rollupCursor.hour, windowFor("hour", d)[1]);
   await h.engine.tick();
-  assert.equal(processed.length, 1);
+  assert.equal(received.length, 1);
 });
 
 test("rollups do not run while paused", async () => {
-  const d = windowFor("day", Date.UTC(2026, 0, 15, 12, 0, 0))[0];
-  let ran = false;
-  const runner = {
-    processDue: async (windows) => (windows.length ? ((ran = true), windows) : []),
-  };
-  const h = makeHarness({ ctoEnabled: true, rollups: runner });
-  // Tick at the top of the hour so the cursor initializes and persists.
-  h.clock.ms = windowFor("hour", d)[0];
-  await h.engine.tick();
-  // Advance an hour → the first hour has closed → rollups run.
+  const { h, received } = makeRollupHarness();
+  await h.engine.tick(); // cursor initializes + persists
   h.advance(60 * 60_000);
-  await h.engine.tick();
-  assert.equal(ran, true);
+  await h.engine.tick(); // hour closed → rollup runs
+  assert.equal(received.length, 1);
 
-  // Now pause, advance another hour, tick → no rollup runs.
+  // Now paused: advancing another hour does not fold a rollup.
   await h.engine.hardPause({ reason: "test" });
   h.advance(60 * 60_000);
-  ran = false;
+  const before = received.length;
   await h.engine.tick();
-  assert.equal(ran, false);
+  assert.equal(received.length, before);
 });

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -11,12 +11,13 @@ import {
   RATE_LIMITS,
 } from "./ctoEngine.mjs";
 import { createSegmenter } from "./ctoSegments.mjs";
+import { windowFor } from "./ctoRollups.mjs";
 
 // Build a fully-injected engine harness: no real fs, no real stores, a fake
 // clock we can advance. Everything the engine touches goes through these
 // seams, so the tests assert pure behavior. `clock` is shared so the watchdog
 // and the engine observe the same time.
-function makeHarness({ ctoEnabled = false, counts = {} } = {}) {
+function makeHarness({ ctoEnabled = false, counts = {}, rollups } = {}) {
   const clock = { ms: 1_000_000 };
   const now = () => clock.ms;
   const ledgerRows = [];
@@ -25,6 +26,7 @@ function makeHarness({ ctoEnabled = false, counts = {} } = {}) {
   let published = [];
   let currentConfig = { ctoEnabled };
   const cardCalls = [];
+  const state = { v: 1, pendingBlockers: [] };
 
   const engine = createCtoEngine({
     configGet: async () => ({ ...currentConfig }),
@@ -40,11 +42,14 @@ function makeHarness({ ctoEnabled = false, counts = {} } = {}) {
       ingestHealthEscalations: async () => ({}),
     },
     engineState: {
-      load: async () => ({ v: 1, pendingBlockers }),
+      load: async () => ({ ...state }),
       save: async (payload) => {
         pendingBlockers = Array.isArray(payload?.pendingBlockers)
           ? payload.pendingBlockers
           : [];
+        state.pendingBlockers = pendingBlockers;
+        if (payload?.rollupCursor) state.rollupCursor = payload.rollupCursor;
+        if (payload?.segmentGMinutes != null) state.segmentGMinutes = payload.segmentGMinutes;
       },
     },
     killSwitch: {
@@ -64,6 +69,7 @@ function makeHarness({ ctoEnabled = false, counts = {} } = {}) {
       tonightCount: 0,
       ...counts,
     }),
+    ...(rollups ? { rollups } : {}),
   });
 
   return {
@@ -72,6 +78,7 @@ function makeHarness({ ctoEnabled = false, counts = {} } = {}) {
     ledgerRows,
     published,
     cardCalls,
+    state,
     get pendingBlockers() {
       return pendingBlockers;
     },
@@ -475,3 +482,59 @@ test("cto-owned sessions are never segmented", async () => {
   assert.equal(stores.map.size, 0, "cto-owned work is excluded from segmentation");
 });
 
+
+// ---------------------------------------------------------------------------
+// BET-1381 §5.3 rollups — window-close timers + persisted cursor on the tick
+// ---------------------------------------------------------------------------
+
+test("tick folds a closed hour window into the rollup runner and persists the cursor", async () => {
+  const d = windowFor("day", Date.UTC(2026, 0, 15, 12, 0, 0))[0];
+  const processed = [];
+  const runner = {
+    processDue: async (windows) => {
+      processed.push(...windows);
+      // mark every window finalized
+      return windows.map((w) => ({ saved: true, level: w.level, window: w.window, id: String(w.window[0]) }));
+    },
+  };
+  const h = makeHarness({ ctoEnabled: true, rollups: runner });
+  // Position the clock at the top of an hour; cursor defaults there (nothing due).
+  h.clock.ms = windowFor("hour", d)[0];
+  await h.engine.tick();
+  assert.equal(processed.length, 0, "current (not-yet-closed) window is not due");
+
+  // Advance 90 minutes → the first hour has closed → exactly one hour is due.
+  h.advance(90 * 60_000);
+  await h.engine.tick();
+  assert.equal(processed.length, 1);
+  assert.equal(processed[0].level, "hour");
+  assert.equal(processed[0].window[0], windowFor("hour", d)[0]);
+
+  // The cursor advanced to the closed hour's end; the next tick yields nothing new.
+  assert.equal(h.state.rollupCursor.hour, windowFor("hour", d)[1]);
+  await h.engine.tick();
+  assert.equal(processed.length, 1);
+});
+
+test("rollups do not run while paused", async () => {
+  const d = windowFor("day", Date.UTC(2026, 0, 15, 12, 0, 0))[0];
+  let ran = false;
+  const runner = {
+    processDue: async (windows) => (windows.length ? ((ran = true), windows) : []),
+  };
+  const h = makeHarness({ ctoEnabled: true, rollups: runner });
+  // Tick at the top of the hour so the cursor initializes and persists.
+  h.clock.ms = windowFor("hour", d)[0];
+  await h.engine.tick();
+  // Advance an hour → the first hour has closed → rollups run.
+  h.advance(60 * 60_000);
+  await h.engine.tick();
+  assert.equal(ran, true);
+
+  // Now pause, advance another hour, tick → no rollup runs.
+  await h.engine.hardPause({ reason: "test" });
+  h.advance(60 * 60_000);
+  ran = false;
+  await h.engine.tick();
+  assert.equal(ran, false);
+});

--- a/src/server/ctoRollups.mjs
+++ b/src/server/ctoRollups.mjs
@@ -1,0 +1,591 @@
+// src/server/ctoRollups.mjs
+// BET-1381 — hour/day/week rollups (spec §5.3). The P1 read-layer that folds
+// A6's segment summaries up the three-tier hierarchy: Hour ← that hour's
+// segment summaries; Day ← its hours; Week ← its days. Each level reads only
+// the level below.
+//
+// Properties (each honored below and asserted in ctoRollups.test.mjs):
+//   - Each reduce is ONE cheap-model call (the `ambient-summarize` class),
+//     conditioned on the preceding same-level rollup (the running context) so
+//     news is never re-reported.
+//   - A reduce runs when its window closes (hour tick for hours; day/week at
+//     local-midnight ticks — the engine wires those timers). Quiet windows
+//     (zero inputs) write NOTHING.
+//   - Rollups are WRITE-ONCE: a rollup file that already exists is never
+//     rewritten; attempting a write into an existing window is a programming
+//     error and throws.
+//   - Reduce batches are preemptible BETWEEN reduce calls: the session runner
+//     checks presence between calls and stops the batch after the in-flight
+//     call (§5.3 + §3.4 rule 4). Segment-close summaries (the trickle, ctoSegments)
+//     are exempt and never pass through this path.
+//   - Evidence pointers propagate: every rollup bullet keeps refs to the leaf
+//     segment ids it was reduced from (hour refs = segment ids; day/week refs =
+//     the union of the level-below's bullet refs).
+//
+// Pure logic + injected I/O in the style of delegate.mjs / ctoEngine.mjs — no
+// live tmux/opencode/network in tests. All model + store + presence seams are
+// injected (`runEphemeral`, `rollups`, `loadInputs`, `loadPreceding`, `exists`,
+// `presenceCheck`, `factsStore`, `resolveSegment`, `now`).
+//
+// Fact sync (P1, §5.3 "ADD/UPDATE/NOOP"): after each day-level reduce the
+// engine applies a deterministic ADD/UPDATE/NOOP against the project's facts
+// store (§6) DIRECTLY from the rollup — single-writer, the engine itself (§15).
+// This is deliberately isolated in one exported function, `syncFactsFromRollup`,
+// so a later P2 collaborative gatekeeper can delete it cleanly.
+
+import { promises as fsp } from "node:fs";
+import { createHash } from "node:crypto";
+import { rollupsStore, segmentsStore, factsStore, ledgerStore } from "./ctoStores.mjs";
+
+export const ROLLUP_VERSION = 1;
+export const ROLLUP_LEVELS = Object.freeze(["hour", "day", "week"]);
+export const HOUR_MS = 3_600_000;
+export const DAY_MS = 24 * HOUR_MS;
+export const WEEK_MS = 7 * DAY_MS;
+
+export const LEVEL_MS = Object.freeze({ hour: HOUR_MS, day: DAY_MS, week: WEEK_MS });
+
+// The next level up (input relation): hour is the leaf over segments.
+export const NEXT_LEVEL = Object.freeze({ hour: "day", day: "week", week: null });
+
+export function isRollupLevel(level) {
+  return ROLLUP_LEVELS.includes(level);
+}
+
+// ---------------------------------------------------------------------------
+// Window math (local time — day/week rollups close at local midnight)
+// ---------------------------------------------------------------------------
+
+export function startOfHour(ts) {
+  const d = new Date(ts);
+  d.setMinutes(0, 0, 0);
+  return d.getTime();
+}
+
+export function startOfDay(ts) {
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+// Start of the local week (Monday).
+export function startOfWeek(ts) {
+  const d = new Date(startOfDay(ts));
+  const day = d.getDay(); // 0 = Sunday
+  d.setDate(d.getDate() + (day === 0 ? -6 : 1 - day));
+  return d.getTime();
+}
+
+const STARTS = Object.freeze({ hour: startOfHour, day: startOfDay, week: startOfWeek });
+
+export function windowFor(level, ts) {
+  assertLevel(level);
+  const start = STARTS[level](ts);
+  return [start, start + LEVEL_MS[level]];
+}
+
+export function windowId(window) {
+  return String(window[0]);
+}
+
+// The window immediately before `window` at the same level (the running
+// context's predecessor).
+export function previousWindow(window, level) {
+  assertLevel(level);
+  return [window[0] - LEVEL_MS[level], window[0]];
+}
+
+export function assertLevel(level) {
+  if (!isRollupLevel(level)) {
+    throw new Error(`rollups level must be one of ${ROLLUP_LEVELS.join(", ")} (got ${JSON.stringify(level)})`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Reduce input selection — each level reads only the level below.
+// ---------------------------------------------------------------------------
+// An item (a segment summary, an hour rollup, a day rollup) is assigned to the
+// window that CONTAINS the item's own window start (item.window[0] ∈ [ws,we)),
+// which partitions items cleanly across contiguous windows (no double-counting
+// at boundaries). Returns the items sorted by start. Pure — `items` are the
+// already-loaded inputs, each with a `.window` of [start, end].
+
+export function selectReduceInputs(level, window, items) {
+  assertLevel(level);
+  const [ws, we] = window;
+  return (Array.isArray(items) ? items : [])
+    .filter((it) => it && Array.isArray(it.window) && it.window[0] >= ws && it.window[0] < we)
+    .sort((a, b) => a.window[0] - b.window[0]);
+}
+
+// ---------------------------------------------------------------------------
+// Ref propagation — every bullet keeps refs to LEAF segment ids.
+// ---------------------------------------------------------------------------
+// hour inputs are raw segments (their own id is the leaf ref). day/week inputs
+// are rollups whose bullets already carry leaf refs — the rollup-level refs are
+// the union of the level-below's bullet refs.
+
+export function collectRefs(level, inputs) {
+  if (level === "hour") {
+    return Array.from(new Set((inputs || []).map((i) => i && i.id).filter((x) => typeof x === "string"))).sort();
+  }
+  const refs = new Set();
+  for (const input of inputs || []) {
+    for (const b of input?.bullets || []) {
+      if (Array.isArray(b?.refs)) {
+        for (const r of b.refs) if (typeof r === "string") refs.add(r);
+      }
+    }
+  }
+  return Array.from(refs).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Rollup shape + validation
+// ---------------------------------------------------------------------------
+
+export function validateRollup(obj) {
+  if (!obj || typeof obj !== "object") return false;
+  if (obj.v !== ROLLUP_VERSION) return false;
+  if (!isRollupLevel(obj.level)) return false;
+  if (
+    !Array.isArray(obj.window) ||
+    obj.window.length !== 2 ||
+    typeof obj.window[0] !== "number" ||
+    typeof obj.window[1] !== "number" ||
+    !(obj.window[1] - obj.window[0] === LEVEL_MS[obj.level])
+  ) {
+    return false;
+  }
+  if (!Array.isArray(obj.bullets)) return false;
+  return obj.bullets.every(
+    (b) =>
+      b &&
+      typeof b === "object" &&
+      typeof b.text === "string" &&
+      b.text.length > 0 &&
+      (b.refs === undefined || (Array.isArray(b.refs) && b.refs.every((r) => typeof r === "string"))),
+  );
+}
+
+// Tolerant extractor for the model's JSON rollup — take the first `{` .. last
+// `}` (a model may wrap the JSON in prose or fences). Parse-only; schema
+// validation is validateRollup's job.
+export function parseRollupText(text) {
+  if (typeof text !== "string") return null;
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  try {
+    const obj = JSON.parse(text.slice(start, end + 1));
+    return obj && typeof obj === "object" ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+// The reduced context producer. Assembles the reduce's context blocks in
+// priority order under the `ambient-summarize` task class: the instruction
+// (high), the level-below content it must fold (medium, with ids so the model
+// can attach refs), the preceding same-level rollup as running context
+// (medium, so news is never re-reported), and a refs pointer to the leaf
+// segment ids being propagated.
+export function buildReduceContext({ level, window, inputs, refs, preceding } = {}) {
+  const inputLines = (inputs || []).map((it) => {
+    if (level === "hour") {
+      const s = it?.summary || {};
+      return `[${it.id}] ${s.one_liner || s.intent || "segment"}${
+        s.project ? ` (project: ${s.project})` : ""
+      } — window ${it.window ? `${it.window[0]}..${it.window[1]}` : "?"}`;
+    }
+    const bullets = (it?.bullets || []).map((b) => `- ${b.text}`).join("\n");
+    return `[${it.id}] ${bullets || "(no bullets)"}`;
+  });
+
+  const blocks = [];
+  blocks.push({
+    priority: "high",
+    text:
+      `You are the Adaptive CTO's ${level}ly rollup summarizer. Reduce the ` +
+      `${level} window ${window[0]}..${window[1]} below into a compact bulleted ` +
+      `rollup of what got done. Output ONLY JSON of the form ` +
+      `{"bullets":[{"text":"<summary sentence>","refs":["<segmentId>",...]}]}. ` +
+      `Each bullet's refs must reference the leaf segment id(s) it came from. ` +
+      `Report only NEWS not already covered by the running context. Keep bullets ` +
+      `concrete and factual.`,
+  });
+  if (refs && refs.length) {
+    blocks.push({
+      priority: "medium",
+      text: `Leaf segment ids in this ${level}: ${refs.join(", ")}.` +
+        (preceding ? "" : " (no preceding same-level rollup exists)"),
+    });
+  }
+  if (inputLines.length) {
+    blocks.push({
+      priority: "medium",
+      text: `The ${level} below (level-below inputs) to fold in:\n${inputLines.join("\n")}`,
+    });
+  }
+  if (preceding && Array.isArray(preceding.bullets) && preceding.bullets.length) {
+    blocks.push({
+      priority: "medium",
+      text:
+        `Running context — the preceding same-${level} rollup (already reported, do not re-report):\n` +
+        preceding.bullets.map((b) => `- ${b.text}`).join("\n"),
+    });
+  }
+  return blocks;
+}
+
+// The degraded fallback used when the model call is gated/unavailable/failed:
+// one bullet per level-below input, carrying correct leaf refs, so the
+// hierarchy is never silently empty.
+export function degradedRollup({ level, window, inputs, refs } = {}) {
+  let bullets;
+  if (level === "hour") {
+    bullets = (inputs || []).map((it) => {
+      const s = it?.summary || {};
+      return { text: s.one_liner || s.intent || "unspecified work", refs: it.id ? [it.id] : [] };
+    });
+  } else {
+    bullets = [];
+    for (const input of inputs || []) {
+      for (const b of input?.bullets || []) {
+        bullets.push({ text: typeof b?.text === "string" ? b.text : "work", refs: Array.isArray(b.refs) ? b.refs : [] });
+      }
+    }
+    if (!bullets.length) bullets = [{ text: `${level} of ${window[0]}`, refs: refs || [] }];
+  }
+  return { v: ROLLUP_VERSION, level, window, bullets };
+}
+
+// ---------------------------------------------------------------------------
+// Fact sync (P1, isolated — see module header). After a day-level reduce the
+// engine applies ADD/UPDATE/NOOP against each project's facts store, grouped
+// per project by resolving each bullet's refs → segment → project. Deterministic
+// and small; a later P2 collaborative gatekeeper replaces this direct path.
+// ---------------------------------------------------------------------------
+
+export function normalizeStatement(text) {
+  return String(text || "").trim().replace(/\s+/g, " ").toLowerCase();
+}
+
+export function refSignature(refs) {
+  return (Array.isArray(refs) ? [...refs] : []).sort().join("|");
+}
+
+// Deterministic ADD/UPDATE/NOOP decision against an existing fact list.
+//   - NOOP:   an active fact with the same normalized statement already exists.
+//   - UPDATE: an active fact from a prior rollup sync shares the same ref
+//             signature but a different statement — supersede it, add the new.
+//   - ADD:    otherwise (new news).
+// Returns { action, existing? }.
+export function decideFactAction(existing, statement, refs) {
+  const norm = normalizeStatement(statement);
+  const sig = refSignature(refs);
+  if (!norm) return { action: "noop" };
+  for (const f of existing) {
+    if (f?.superseded_by || f?.valid_until) continue; // inactive → can't block
+    if (normalizeStatement(f?.statement) === norm) return { action: "noop", existing: f };
+  }
+  for (const f of existing) {
+    if (f?.superseded_by || f?.valid_until) continue;
+    if (f?.sender?.sessionID === undefined && refSignature(f?.refs) === sig && sig) {
+      return { action: "update", existing: f };
+    }
+  }
+  return { action: "add" };
+}
+
+// The isolated P1 fact-sync entry point. `dayRollup` is a validated day-level
+// rollup; `resolveSegment` maps a segment id to `{ project, ... }` (or null);
+// `factsStore` is the per-project facts store ({load(project), save(project,data)}).
+// Applies ADD/UPDATE/NOOP per project and returns a tally.
+export async function syncFactsFromRollup(dayRollup, { resolveSegment, facts = factsStore, sender = "cto", now = Date.now() } = {}) {
+  if (!dayRollup || dayRollup.level !== "day" || !Array.isArray(dayRollup.bullets)) {
+    return { applied: 0, added: 0, updated: 0, noop: 0 };
+  }
+  const byProject = new Map();
+  for (const b of dayRollup.bullets) {
+    if (!b || typeof b.text !== "string" || !b.text.trim()) continue;
+    const refs = Array.isArray(b.refs) ? b.refs.filter((r) => typeof r === "string") : [];
+    let project = null;
+    for (const ref of refs) {
+      try {
+        const seg = await resolveSegment(ref);
+        if (seg?.project) {
+          project = seg.project;
+          break;
+        }
+      } catch {
+        /* resolve a single ref fails → try the next */
+      }
+    }
+    if (!project) continue; // can't attribute → skip (never fabricate a project)
+    if (!byProject.has(project)) byProject.set(project, []);
+    byProject.get(project).push({ text: b.text, refs });
+  }
+
+  const tally = { applied: 0, added: 0, updated: 0, noop: 0 };
+  for (const [project, bullets] of byProject) {
+    let payload;
+    try {
+      payload = await facts.load(project);
+    } catch {
+      payload = { facts: [] };
+    }
+    const existing = Array.isArray(payload?.facts) ? payload.facts : [];
+    const factsOut = [...existing];
+    const ts = now();
+    for (const b of bullets) {
+      const { action, existing: hit } = decideFactAction(existing, b.text, b.refs);
+      if (action === "noop") {
+        tally.noop += 1;
+        if (hit) {
+          hit.last_accessed = ts;
+          hit.access_count = (hit.access_count || 0) + 1;
+        }
+        continue;
+      }
+      if (action === "update" && hit) {
+        hit.superseded_by = "cto:" + createHash("sha1").update(b.text).digest("hex").slice(0, 12);
+      }
+      const fact = {
+        v: 1,
+        id: "cto:" + createHash("sha1").update(`${project}|${b.text}|${refSignature(b.refs)}`).digest("hex").slice(0, 12),
+        kind: "decision",
+        statement: b.text.slice(0, 200),
+        refs: b.refs,
+        confidence: 0.5,
+        created: ts,
+        last_accessed: ts,
+        access_count: 1,
+        sender,
+      };
+      factsOut.push(fact);
+      tally.applied += 1;
+      if (action === "update") tally.updated += 1;
+      else tally.added += 1;
+    }
+    try {
+      await facts.save(project, { facts: factsOut });
+    } catch {
+      /* facts persistence is best-effort — never throw into the reduce */
+    }
+  }
+  return tally;
+}
+
+// ---------------------------------------------------------------------------
+// Rollup runner — the pending-reduce executor with write-once + preemption.
+// ---------------------------------------------------------------------------
+// The engine owns the window-close TIMERS (§5.3) and hands this runner the
+// concrete windows whose closes it detected via the tick. The runner does the
+// reduces (each one `runEphemeral` call), enforces write-once + quiet-window
+// no-op, and preempts the batch between calls when the user is present.
+//
+// deps:
+//   runEphemeral   — async ({taskClass, context}) => {text} — the ← one reduce
+//                    call, wrapped by the engine in the §3.3 ephemeral rate gate.
+//   rollups        — rollups store {load, save} (default rollupsStore).
+//   segments       — segments store (default segmentsStore), used by default
+//                    loadInputs/loadPreceding for the hour level.
+//   fs             — {readdir, ...} for default dir enumeration (default fsp).
+//   loadInputs     — async ({level, window, now}) => inputs (injectable; default
+//                    enumerates the level-below files from the stores).
+//   loadPreceding  — async ({level, window}) => preceding same-level rollup|null.
+//   exists         — async ({level, id}) => bool — write-once detector. Default
+//                    true iff a stored payload already carries `bullets`.
+//   presenceCheck  — async () => bool — true when the user is present; the batch
+//                    stops after the in-flight reduce call.
+//   facts, resolveSegment — for day-level fact sync (default factsStore + a
+//                    segments-store-backed resolver when `segments` provided).
+//   now            — () => epoch ms.
+//   ledger         — A1 ledger {append} (best-effort).
+
+export async function defaultLoadPreceding({ level, window, rollups } = {}) {
+  try {
+    const p = await rollups.load(level, windowId(previousWindow(window, level)));
+    if (p && typeof p === "object" && "bullets" in p) return p;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function defaultExists({ rollups } = {}) {
+  return async ({ level, id } = {}) => {
+    try {
+      const p = await rollups.load(level, id);
+      return p && typeof p === "object" && "bullets" in p;
+    } catch {
+      return false;
+    }
+  };
+}
+
+// Enumerate the level-below inputs for a window from the real stores.
+export function defaultLoadInputs({ fs = fsp, rollups = rollupsStore, segments = segmentsStore } = {}) {
+  return async ({ level, window } = {}) => {
+    assertLevel(level);
+    const [ws, we] = window;
+    if (level === "hour") {
+      const dir = segments.dir;
+      let names = [];
+      try {
+        names = await fs.readdir(dir);
+      } catch {
+        return [];
+      }
+      const out = [];
+      for (const name of names) {
+        if (!name.endsWith(".json")) continue;
+        const id = name.slice(0, -5);
+        let seg;
+        try {
+          seg = await segments.load(id);
+        } catch {
+          continue;
+        }
+        if (seg && Array.isArray(seg.window) && seg.window[0] >= ws && seg.window[0] < we) {
+          out.push({ id, window: seg.window, ts: seg.ts, summary: seg.summary });
+        }
+      }
+      return out.sort((a, b) => a.window[0] - b.window[0]);
+    }
+    const belowLevel = level === "day" ? "hour" : "day";
+    const dir = rollups.dirFor(belowLevel);
+    let names = [];
+    try {
+      names = await fs.readdir(dir);
+    } catch {
+      return [];
+    }
+    const out = [];
+    for (const name of names) {
+      if (!name.endsWith(".json")) continue;
+      const id = name.slice(0, -5);
+      let r;
+      try {
+        r = await rollups.load(belowLevel, id);
+      } catch {
+        continue;
+      }
+      if (r && Array.isArray(r.window) && r.window[0] >= ws && r.window[0] < we) {
+        out.push({ id, window: r.window, bullets: Array.isArray(r.bullets) ? r.bullets : [] });
+      }
+    }
+    return out.sort((a, b) => a.window[0] - b.window[0]);
+  };
+}
+
+export function createRollupRunner(deps = {}) {
+  const {
+    runEphemeral = async () => ({ ok: false, gated: true }),
+    rollups = rollupsStore,
+    segments = segmentsStore,
+    fs = fsp,
+    loadInputs,
+    loadPreceding,
+    exists,
+    presenceCheck = async () => false,
+    facts = factsStore,
+    resolveSegment,
+    now = () => Date.now(),
+    ledger = ledgerStore,
+  } = deps;
+
+  const loadInputsFn = loadInputs ?? defaultLoadInputs({ fs, rollups, segments });
+  const loadPrecedingFn =
+    loadPreceding ?? (({ level, window }) => defaultLoadPreceding({ level, window, rollups }));
+  const existsFn = exists ?? defaultExists({ rollups });
+
+  const defaultResolveSegment = async (id) => {
+    try {
+      const s = await segments.load(id);
+      return s && s.project ? { project: s.project } : null;
+    } catch {
+      return null;
+    }
+  };
+  const resolveSegmentFn = resolveSegment ?? defaultResolveSegment;
+
+  async function ledgerLog(entry) {
+    try {
+      await ledger.append({ actor: "cto", ts: now(), ...entry });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // Reduce ONE window: choose the level-below inputs, thread the running
+  // context, make ONE cheap-model call (degrading on gated/failure), write the
+  // rollup once, and sync facts after a day-level reduce. Never throws into a
+  // poller; a write-once violation DOES throw (programming error per §5.3).
+  async function reduceWindow(level, window) {
+    assertLevel(level);
+    const id = windowId(window);
+    const inputs = await loadInputsFn({ level, window, now: now() });
+    // Quiet window (zero level-below inputs) → write NOTHING (absence is free).
+    if (!Array.isArray(inputs) || inputs.length === 0) {
+      return { skipped: true, level, window, id };
+    }
+    // Write-once: a rollup that already exists is never rewritten.
+    if (await existsFn({ level, id })) {
+      throw new Error(`rollup ${level}/${id} already exists (write-once — refusing to rewrite)`);
+    }
+    const refs = collectRefs(level, inputs);
+    const preceding = await loadPrecedingFn({ level, window });
+    const context = buildReduceContext({ level, window, inputs, refs, preceding });
+
+    let rollup = null;
+    try {
+      const res = await runEphemeral({ taskClass: "ambient-summarize", context });
+      const parsed = parseRollupText(res?.text);
+      if (res?.ok && parsed && validateRollup({ ...parsed, v: ROLLUP_VERSION, level, window })) {
+        rollup = { ...parsed, v: ROLLUP_VERSION, level, window };
+      }
+    } catch {
+      rollup = null;
+    }
+    if (!rollup) {
+      rollup = degradedRollup({ level, window, inputs, refs });
+      await ledgerLog({ kind: "cto.rollup_degraded", level, id });
+    }
+    await rollups.save(level, id, rollup);
+    await ledgerLog({ kind: "cto.rollup_written", level, id, bullets: rollup.bullets.length });
+
+    let factTally = null;
+    if (level === "day") {
+      factTally = await syncFactsFromRollup(rollup, {
+        resolveSegment: resolveSegmentFn,
+        facts,
+        now,
+      }).catch(() => null);
+      if (factTally) await ledgerLog({ kind: "cto.facts_synced", id, ...factTally });
+    }
+    return { saved: true, level, window, id, factTally };
+  }
+
+  // Run a batch of pending reduces with preemption BETWEEN calls: after each
+  // reduce, if the user is present we stop the batch (§5.3 checkpoint). Also
+  // won't start a further call if present from the start. Returns outcomes.
+  async function processDue(pending) {
+    const outcomes = [];
+    for (const item of pending || []) {
+      if (await presenceCheck()) break;
+      const [level, window] = Array.isArray(item) ? item : [item.level, item.window];
+      outcomes.push(await reduceWindow(level, window));
+    }
+    return outcomes;
+  }
+
+  return {
+    reduceWindow,
+    processDue,
+    // exposed for tests / diagnostics
+    _loadInputs: loadInputsFn,
+    _loadPreceding: loadPrecedingFn,
+  };
+}

--- a/src/server/ctoRollups.test.mjs
+++ b/src/server/ctoRollups.test.mjs
@@ -1,0 +1,385 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createRollupRunner,
+  selectReduceInputs,
+  collectRefs,
+  validateRollup,
+  parseRollupText,
+  buildReduceContext,
+  degradedRollup,
+  windowFor,
+  windowId,
+  previousWindow,
+  syncFactsFromRollup,
+  decideFactAction,
+  normalizeStatement,
+  HOUR_MS,
+  DAY_MS,
+  WEEK_MS,
+  ROLLUP_VERSION,
+} from "./ctoRollups.mjs";
+
+// In-memory rollups store shaped like rollupsStore {load, save}. A written
+// rollup always carries a `bullets` array; the default write-once detector
+// keys off that, mirroring the real store.
+function makeRollupsStore() {
+  const map = new Map();
+  return {
+    map,
+    load: async (level, id) => map.get(`${level}/${id}`) ?? { v: 1 },
+    save: async (level, id, data) => {
+      map.set(`${level}/${id}`, data);
+    },
+  };
+}
+
+function fakeExists(store) {
+  return async ({ level, id } = {}) => {
+    const p = store.map.get(`${level}/${id}`);
+    return !!(p && typeof p === "object" && "bullets" in p);
+  };
+}
+
+function makeFactsStore() {
+  const map = new Map();
+  return {
+    map,
+    load: async (project) => map.get(project) ?? { facts: [] },
+    save: async (project, data) => {
+      map.set(project, data);
+    },
+  };
+}
+
+// A runEphemeral + loadInputs harness that records reduce calls and returns
+// controllable model output. `inputs` may be a function of ({level, window}).
+function makeRunner({ inputs = [], modelText = null, preceding = null, presence = () => false } = {}) {
+  const store = makeRollupsStore();
+  const calls = [];
+  const runner = createRollupRunner({
+    runEphemeral: async (data) => {
+      calls.push({ fn: "runEphemeral", data });
+      return modelText ? { ok: true, text: modelText } : { ok: false, gated: true };
+    },
+    rollups: store,
+    loadInputs: async ({ level, window }) =>
+      typeof inputs === "function" ? inputs({ level, window }) : inputs,
+    loadPreceding: async ({ level, window }) => preceding,
+    exists: fakeExists(store),
+    presenceCheck: presence,
+    facts: makeFactsStore(),
+  });
+  return { runner, store, calls };
+}
+
+// A valid day/second-hour-window timestamp basis (start of a local day).
+function baseDay() {
+  return windowFor("day", Date.UTC(2026, 0, 15, 12, 0, 0))[0];
+}
+
+function seg(id, start, extra = {}) {
+  return { id, window: [start, start + 1], summary: { one_liner: `work in ${id}`, ...extra } };
+}
+
+function hourRollup(id, start, bullets) {
+  return { id, window: [start, start + HOUR_MS], bullets };
+}
+
+// ---------------------------------------------------------------------------
+// Window math + input selection
+// ---------------------------------------------------------------------------
+
+test("windowFor partitions the day into contiguous hour windows", () => {
+  const d = Date.UTC(2026, 0, 15, 12, 30, 0);
+  const w = windowFor("hour", d);
+  assert.equal(w[1] - w[0], HOUR_MS);
+  assert.equal(new Date(w[0]).getUTCMinutes(), 0);
+  const day = windowFor("day", d);
+  assert.equal(day[1] - day[0], DAY_MS);
+  assert.equal(new Date(day[0]).getUTCHours(), 0);
+  const week = windowFor("week", d);
+  assert.equal(week[1] - week[0], WEEK_MS);
+  // Jan 15 2026 is a Thursday → Monday is Jan 12.
+  assert.equal(new Date(week[0]).getUTCDay(), 1);
+  assert.equal(windowId(w), String(w[0]));
+});
+
+test("previousWindow returns the same-level window immediately before", () => {
+  const d = Date.UTC(2026, 0, 15, 12, 30, 0);
+  const w = windowFor("hour", d);
+  const prev = previousWindow(w, "hour");
+  assert.equal(prev[1], w[0]);
+  assert.equal(prev[1] - prev[0], HOUR_MS);
+});
+
+test("selectReduceInputs assigns items to the window containing their start (hour)", () => {
+  const d = baseDay();
+  const w0 = windowFor("hour", d);
+  const w1 = windowFor("hour", d + HOUR_MS);
+  const items = [seg("a", w0[0] + 10000), seg("b", w1[0] + 10000), seg("c", w0[0] + 20000)];
+  const in0 = selectReduceInputs("hour", w0, items);
+  assert.deepEqual(in0.map((i) => i.id).sort(), ["a", "c"]);
+  const in1 = selectReduceInputs("hour", w1, items);
+  assert.deepEqual(in1.map((i) => i.id), ["b"]);
+});
+
+test("selectReduceInputs reads only the level below per level (day/week too)", () => {
+  const d = baseDay();
+  const day = windowFor("day", d);
+  const day1 = windowFor("day", d + DAY_MS);
+  const hours = [hourRollup("h1", day[0], []), hourRollup("h2", day1[0], [])];
+  assert.deepEqual(selectReduceInputs("day", day, hours).map((i) => i.id), ["h1"]);
+  const week = windowFor("week", d);
+  const week1 = windowFor("week", d + WEEK_MS);
+  const days = [hourRollup("d1", week[0], []), hourRollup("d2", week1[0], [])];
+  assert.deepEqual(selectReduceInputs("week", week, days).map((i) => i.id), ["d1"]);
+});
+
+test("selectReduceInputs sorts by window start", () => {
+  const d = baseDay();
+  const w0 = windowFor("hour", d);
+  const items = [seg("late", w0[0] + 50000), seg("early", w0[0] + 100), seg("mid", w0[0] + 20000)];
+  assert.deepEqual(selectReduceInputs("hour", w0, items).map((i) => i.id), ["early", "mid", "late"]);
+});
+
+// ---------------------------------------------------------------------------
+// Ref propagation
+// ---------------------------------------------------------------------------
+
+test("hour refs are leaf segment ids; day/week refs union the level-below bullet refs", () => {
+  const d = baseDay();
+  const h = windowFor("hour", d);
+  const segs = [seg("s1", h[0]), seg("s2", h[0] + 1000)];
+  assert.deepEqual(collectRefs("hour", segs), ["s1", "s2"]);
+  const dayInputs = [
+    { id: "hx", bullets: [{ text: "a", refs: ["s1"] }, { text: "b", refs: ["s1", "s2"] }] },
+    { id: "hy", bullets: [{ text: "c", refs: ["s3"] }] },
+  ];
+  assert.deepEqual(collectRefs("day", dayInputs), ["s1", "s2", "s3"]);
+});
+
+// ---------------------------------------------------------------------------
+// Validation + parsing
+// ---------------------------------------------------------------------------
+
+test("validateRollup accepts a well-formed rollup and rejects malformed ones", () => {
+  const d = baseDay();
+  const w = windowFor("hour", d);
+  const good = { v: ROLLUP_VERSION, level: "hour", window: w, bullets: [{ text: "did a thing", refs: ["s1"] }] };
+  assert.equal(validateRollup(good), true);
+  assert.equal(validateRollup({ ...good, v: 99 }), false);
+  assert.equal(validateRollup({ ...good, level: "week" }), false); // wrong window span for week
+  assert.equal(validateRollup({ ...good, window: [w[0], w[0] + 5000] }), false);
+  assert.equal(validateRollup({ ...good, bullets: [{ text: "" }] }), false);
+  assert.equal(validateRollup({ ...good, bullets: [{ text: "x", refs: ["ok", 5] }] }), false);
+});
+
+test("parseRollupText extracts JSON from wrapped prose", () => {
+  const out = parseRollupText('Here you go:\n{"bullets":[{"text":"a","refs":["s1"]}]}\nthanks');
+  assert.deepEqual(out, { bullets: [{ text: "a", refs: ["s1"] }] });
+  assert.equal(parseRollupText("no json here"), null);
+});
+
+// ---------------------------------------------------------------------------
+// Running-context threading
+// ---------------------------------------------------------------------------
+
+test("reduce threads preceding same-level rollup into the running context", async () => {
+  const d = baseDay();
+  const w = windowFor("hour", d);
+  const prev = { v: ROLLUP_VERSION, level: "hour", window: previousWindow(w, "hour"), bullets: [{ text: "PREVIOUS HOUR WORK", refs: ["s0"] }] };
+  const { runner, calls } = makeRunner({
+    inputs: [seg("s1", w[0])],
+    preceding: prev,
+    modelText: JSON.stringify({ bullets: [{ text: "NEW HOUR WORK", refs: ["s1"] }] }),
+  });
+  const res = await runner.reduceWindow("hour", w);
+  assert.equal(res.saved, true);
+  const ctx = calls[0].data.context;
+  const all = ctx.map((b) => b.text).join("\n");
+  assert.match(all, /PREVIOUS HOUR WORK/); // running context present
+  assert.match(all, /work in s1/); // level-below input present
+  assert.match(all, /s1/); // ref pointer present
+  assert.equal(ctx[0].priority, "high");
+});
+
+// ---------------------------------------------------------------------------
+// Write-once
+// ---------------------------------------------------------------------------
+
+test("a reduce into an existing window throws (write-once)", async () => {
+  const d = baseDay();
+  const w = windowFor("hour", d);
+  const { runner, store } = makeRunner({ inputs: [seg("s1", w[0])] });
+  await runner.reduceWindow("hour", w);
+  await assert.rejects(() => runner.reduceWindow("hour", w), /already exists/);
+  assert.equal([...store.map.keys()].filter((k) => k.startsWith("hour/")).length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// Quiet-window no-op
+// ---------------------------------------------------------------------------
+
+test("a quiet window (zero inputs) writes NOTHING", async () => {
+  const d = baseDay();
+  const w = windowFor("hour", d);
+  const { runner, store } = makeRunner({ inputs: [] });
+  const res = await runner.reduceWindow("hour", w);
+  assert.equal(res.skipped, true);
+  assert.equal(store.map.size, 0);
+  assert.equal([...store.map.keys()].length, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Degraded fallback
+// ---------------------------------------------------------------------------
+
+test("a gated/unavailable model persists a degraded rollup with correct refs", async () => {
+  const d = baseDay();
+  const w = windowFor("hour", d);
+  const { runner, store } = makeRunner({ inputs: [seg("s1", w[0]), seg("s2", w[0] + 1000)] });
+  const res = await runner.reduceWindow("hour", w);
+  assert.equal(res.saved, true);
+  const saved = store.map.get(`hour/${w[0]}`);
+  assert.equal(validateRollup(saved), true);
+  assert.deepEqual(saved.bullets.map((b) => b.refs), [["s1"], ["s2"]]);
+});
+
+test("day reduce from hour rollups: degraded keeps propagated leaf refs", async () => {
+  const d = baseDay();
+  const day = windowFor("day", d);
+  const dayInputs = [
+    { id: "h1", window: [day[0], day[0] + HOUR_MS], bullets: [{ text: "H1", refs: ["s1"] }, { text: "H2", refs: ["s2"] }] },
+  ];
+  const { runner, store } = makeRunner({ inputs: dayInputs });
+  await runner.reduceWindow("day", day);
+  const saved = store.map.get(`day/${day[0]}`);
+  assert.deepEqual(saved.bullets.map((b) => b.refs), [["s1"], ["s2"]]);
+  assert.deepEqual([...new Set(saved.bullets.flatMap((b) => b.refs))].sort(), ["s1", "s2"]);
+});
+
+// ---------------------------------------------------------------------------
+// Preemption
+// ---------------------------------------------------------------------------
+
+test("preemption stops the batch BETWEEN reduce calls, not during a call", async () => {
+  const d = baseDay();
+  const w0 = windowFor("hour", d);
+  const windows = [w0, windowFor("hour", d + HOUR_MS), windowFor("hour", d + 2 * HOUR_MS)];
+  // presence flips to TRUE only after the first reduce has saved a rollup (i.e.
+  // after the in-flight call completes) → the batch must stop between calls.
+  const { runner, store } = makeRunner({
+    inputs: ({ window }) => [seg(`s${window[0]}`, window[0])],
+    presence: () => [...store.map.keys()].length > 0,
+  });
+  const outcomes = await runner.processDue(windows.map((w) => ({ level: "hour", window: w })));
+  assert.equal(outcomes.length, 1); // only the first window was reduced
+  assert.deepEqual(outcomes[0].window, w0);
+  const savedHours = [...store.map.keys()].filter((k) => k.startsWith("hour/"));
+  assert.equal(savedHours.length, 1); // no further rollups written after the stop
+});
+
+test("a present user from the start means the batch does not start", async () => {
+  const d = baseDay();
+  const w = windowFor("hour", d);
+  const { runner, store } = makeRunner({
+    inputs: [seg("s1", w[0])],
+    presence: () => true,
+  });
+  const outcomes = await runner.processDue([{ level: "hour", window: w }]);
+  assert.equal(outcomes.length, 0);
+  assert.equal(store.map.size, 0);
+});
+
+// ---------------------------------------------------------------------------
+// Fact sync (P1, isolated)
+// ---------------------------------------------------------------------------
+
+test("decideFactAction maps NOOP on identical statement, UPDATE on same refs, ADD otherwise", () => {
+  const existing = [
+    { statement: "shipped rollups", refs: ["s1"], sender: "cto" },
+    { statement: "old claim", refs: ["s2", "s3"], sender: "cto" },
+  ];
+  assert.equal(decideFactAction(existing, "SHIPPED ROLLUPS", ["s1"]).action, "noop");
+  assert.equal(decideFactAction(existing, "shipped rollups too", ["s1"]).action, "update");
+  assert.equal(decideFactAction(existing, "brand new news", ["s9"]).action, "add");
+});
+
+test("syncFactsFromRollup groups bullets by project and applies ADD/UPDATE/NOOP", async () => {
+  const day = windowFor("day", baseDay());
+  const facts = makeFactsStore();
+  const segments = new Map([
+    ["s1", { project: "alpha" }],
+    ["s2", { project: "alpha" }],
+    ["s3", { project: "beta" }],
+  ]);
+  const rollup = {
+    v: ROLLUP_VERSION,
+    level: "day",
+    window: day,
+    bullets: [
+      { text: "did A", refs: ["s1"] },
+      { text: "did B", refs: ["s2"] },
+      { text: "did C (beta)", refs: ["s3"] },
+    ],
+  };
+  const t1 = await syncFactsFromRollup(rollup, {
+    resolveSegment: async (id) => segments.get(id) ?? null,
+    facts,
+    now: () => 111,
+  });
+  assert.equal(t1.added, 3);
+  assert.equal(facts.map.get("alpha").facts.length, 2);
+  assert.equal(facts.map.get("beta").facts.length, 1);
+
+  // Re-sync the same rollup → all NOOP (news never re-reported), store unchanged.
+  const t2 = await syncFactsFromRollup(rollup, {
+    resolveSegment: async (id) => segments.get(id) ?? null,
+    facts,
+    now: () => 222,
+  });
+  assert.equal(t2.noop, 3);
+  assert.equal(t2.added, 0);
+  assert.equal(facts.map.get("alpha").facts.length, 2);
+});
+
+test("syncFactsFromRollup skips bullets it cannot attribute to a project", async () => {
+  const day = windowFor("day", baseDay());
+  const facts = makeFactsStore();
+  const t = await syncFactsFromRollup(
+    { v: ROLLUP_VERSION, level: "day", window: day, bullets: [{ text: "orphan", refs: ["missing"] }] },
+    { resolveSegment: async () => null, facts },
+  );
+  assert.equal(t.added, 0);
+  assert.equal(facts.map.size, 0);
+});
+
+// ---------------------------------------------------------------------------
+// buildReduceContext sanity
+// ---------------------------------------------------------------------------
+
+test("buildReduceContext orders high instruction first and includes ref pointer", () => {
+  const d = baseDay();
+  const w = windowFor("hour", d);
+  const blocks = buildReduceContext({
+    level: "hour",
+    window: w,
+    inputs: [seg("s1", w[0])],
+    refs: ["s1"],
+    preceding: null,
+  });
+  assert.equal(blocks[0].priority, "high");
+  assert.match(blocks[0].text, /hourly rollup/);
+  assert.ok(blocks.some((b) => /Leaf segment ids/.test(b.text)));
+});
+
+// ---------------------------------------------------------------------------
+// createRollupRunner exported seams present
+// ---------------------------------------------------------------------------
+
+test("createRollupRunner exposes reduceWindow and processDue", () => {
+  const { runner } = makeRunner();
+  assert.equal(typeof runner.reduceWindow, "function");
+  assert.equal(typeof runner.processDue, "function");
+});


### PR DESCRIPTION
## BET-1381 — Rollups (hour/day/week), spec §5.3 (A7)

Builds on A1 stores + A6 segmentation (both merged).

### What
- **`src/server/ctoRollups.mjs`** — the §5.3 reduce pipeline:
  - **Window math** (local time) — hour/day/week; day/week close at local midnight.
  - **Per-level input selection** — hour ← that hour's segment summaries; day ← its hours; week ← its days; each level reads only the level below, partitioned by the item's own window start (no double-counting at boundaries).
  - **Ref propagation** — every bullet keeps refs to LEAF segment ids (hour = segment ids; day/week = union of the level-below's bullet refs).
  - **Write-once** — an existing rollup is never rewritten; a re-reduce into an existing window throws.
  - **Quiet-window no-op** — zero level-below inputs → writes nothing.
  - **Running context** — each reduce is ONE `ambient-summarize` call conditioned on the preceding same-level rollup, so news is never re-reported.
  - **Preemption** — the batch stops BETWEEN reduce calls when the user is present (the in-flight call is the checkpoint); degraded fallback when the model call is gated/unavailable.
  - **`syncFactsFromRollup`** — the isolated P1 day-level ADD/UPDATE/NOOP against the project facts store (grouped per project by ref→segment→project). One exported function — a later P2 collaborative gatekeeper replaces it.
  - `createRollupRunner(deps)` — injected-I/O factory (stores, `runEphemeral`, presence, now, ledger all seams).
- **`src/server/ctoEngine.mjs`** — window-close timers on the existing 1-min tick: a per-level cursor (last finalized window start) persisted in engine-state; each tick folds the windows that closed since the cursor. Cursor initializes to the current window start on first sight (past never backfilled). Inert until a `runEphemeral` producer is wired (mirrors the segmenter's model seam defaulting to a no-op).

### Verification
- New `src/server/ctoRollups.test.mjs` (20 tests): input selection per level, running-context threading, write-once throw, quiet-window no-op, preemption between-not-during, ref propagation, window math, validation, fact sync ADD/UPDATE/NOOP, degraded fallback — all with injected `runEphemeral`.
- New engine-integration tests in `ctoEngine.test.mjs` (2): closed-hour fold + persisted cursor; paused no-op.
- Deduplicated pre-existing self-clones in `ctoEngine.test.mjs` (flagged by the strict jscpd gate on any changed file).
- `npm run typecheck` clean; `npm test` **3091 pass / 0 fail**; duplication-gate **PASS**.

---
**Base:** `origin/main` @ `d47afebf` (main == origin/main after fetch; diff is exactly the 4 intended files, no phantom deletions).
**Branch:** `multica/BET-1381-rollups` @ `0b53bc92`
