### PR TITLE
feat(server): Adaptive CTO digest engine (BET-1383, A9)

### DIFF
--- a/docs/opencode-tools/cto.ts
+++ b/docs/opencode-tools/cto.ts
@@ -26,8 +26,8 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 const CTO_TOOLS =
   "list_sessions, list_projects, read_transcript, search_messages, git_status, " +
   "git_branch, git_log, list_models, get_usage, usage_stopped, session_usage, " +
-  "context_state, session_plan_mode, get_config, watch, unwatch, " +
-  "list_watches";
+  "context_state, session_plan_mode, get_config, read_rollups, read_ledger, " +
+  "watch, unwatch, list_watches";
 
 export const cto = tool({
   description: [

--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -28,11 +28,13 @@
 
 import { execFile } from "node:child_process";
 import { randomBytes } from "node:crypto";
+import { promises as fsp } from "node:fs";
 import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { describeModel } from "../shared/modelGuide.mjs";
 import { createSeenIdFilter } from "./seenIds.mjs";
 import { startPoller } from "./startPoller.mjs";
+import { rollupsStore, ledgerStore, ROLLUP_LEVELS } from "./ctoStores.mjs";
 
 export const CTO_STORE_PATH = statePath("cto.json");
 
@@ -455,6 +457,88 @@ export function createCtoEngine(deps = {}) {
         };
       });
       return { ok: true, data: { models: data } };
+    },
+  });
+
+  register({
+    name: "read_rollups",
+    description:
+      "Read the Adaptive CTO's stored work rollups (spec §5.2/§13.1, the P1 evidence " +
+      "slice the digest engine summarizes). Read-only. Returns up to a handful of " +
+      "rollups at a given level (hour/day/week) whose window overlaps [start, end], " +
+      "each with id, window and its bullets (truncated). Defaults to recent day " +
+      "rollups.",
+    params: {
+      level: "day",
+      start: null,
+      end: null,
+    },
+    run: async (ctx, args) => {
+      const level = ROLLUP_LEVELS.includes(args?.level) ? args.level : "day";
+      const from = typeof args?.start === "number" ? args.start : 0;
+      const to = typeof args?.end === "number" ? args.end : Date.now();
+      const dir = rollupsStore.dirFor(level);
+      let names = [];
+      try {
+        names = await fsp.readdir(dir);
+      } catch {
+        names = [];
+      }
+      const out = [];
+      for (const name of names) {
+        if (!name.endsWith(".json")) continue;
+        const id = name.slice(0, -5);
+        let r;
+        try {
+          r = await rollupsStore.load(level, id);
+        } catch {
+          continue;
+        }
+        if (!r || !Array.isArray(r?.window) || r.window[1] < from || r.window[0] > to) continue;
+        out.push({
+          id,
+          level,
+          window: r.window,
+          project: r.project ?? null,
+          bullets: (Array.isArray(r.bullets) ? r.bullets : []).slice(0, 5).map((b) => ({
+            text: String(b?.text ?? "").slice(0, 160),
+            refs: Array.isArray(b?.refs) ? b.refs.slice(0, 8) : [],
+          })),
+        });
+        if (out.length >= 8) break;
+      }
+      out.sort((a, b) => a.window[0] - b.window[0]);
+      return { ok: true, data: { level, rollups: out } };
+    },
+  });
+
+  register({
+    name: "read_ledger",
+    description:
+      "Read the Adaptive CTO's append-only ledger (spec §13.1) — the raw evidence + " +
+      "instrumentation rows the engine writes. Read-only. Returns the most recent " +
+      "`limit` (default 50) rows, optionally filtered to `kind` (e.g. " +
+      "cto.digest_generated, cto.digest_opened, cto.segment_*).",
+    params: {
+      limit: 50,
+      kind: null,
+    },
+    run: async (ctx, args) => {
+      const rows = await ledgerStore.read();
+      const limit = Math.max(1, Math.min(500, Number(args?.limit) || 50));
+      const kind = typeof args?.kind === "string" && args.kind ? args.kind : null;
+      const filtered = kind ? rows.filter((r) => r?.kind === kind) : rows;
+      const tail = filtered.slice(-limit);
+      const shown = tail.map((r) => ({
+        ts: r?.ts ?? null,
+        kind: r?.kind ?? null,
+        ...(r?.id !== undefined ? { id: r.id } : {}),
+        ...(r?.granularity !== undefined ? { granularity: r.granularity } : {}),
+        ...(r?.message !== undefined ? { message: String(r.message).slice(0, 160) } : {}),
+        ...(r?.project !== undefined ? { project: r.project } : {}),
+        ...(r?.item !== undefined ? { item: r.item } : {}),
+      }));
+      return { ok: true, data: { count: filtered.length, rows: shown } };
     },
   });
 

--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -33,7 +33,7 @@ function makeEngine(overrides = {}) {
   return engine;
 }
 
-const TOOL_COUNT = 17; // 14 reads (BET-1164) + 3 watcher tools watch/unwatch/list_watches (BET-1165)
+const TOOL_COUNT = 19; // 16 reads (BET-1164 + BET-1383 read_rollups/read_ledger) + 3 watcher tools watch/unwatch/list_watches (BET-1165)
 
 // ---------------------------------------------------------------------------
 // Registry integrity
@@ -61,6 +61,8 @@ test("registry exposes every cto read tool with a complete shape, all mode auto"
       "context_state",
       "session_plan_mode",
       "get_config",
+      "read_rollups",
+      "read_ledger",
       "watch",
       "unwatch",
       "list_watches",
@@ -324,4 +326,19 @@ test("appendCtoAudit appends a timestamped entry and persists via injected save"
   assert.equal(store.audit[0].tool, "list_sessions");
   // persisted
   assert.equal(state.audit.length, 1);
+});
+
+// BET-1383 (A9): the P1 evidence-read verbs read_rollups + read_ledger. Against
+// the sandboxed (empty) stores they return structured, never-throwing results.
+test("read_rollups + read_ledger return structured ok results from empty stores", async () => {
+  const engine = makeEngine();
+  const r1 = await engine.dispatch("read_rollups", { level: "day" }, {});
+  assert.equal(r1.ok, true);
+  assert.equal(r1.error, undefined);
+  assert.deepEqual(r1.data.rollups, []);
+  const r2 = await engine.dispatch("read_ledger", {}, {});
+  assert.equal(r2.ok, true);
+  assert.equal(r2.error, undefined);
+  assert.deepEqual(r2.data.rows, []);
+  assert.equal(r2.data.count, 0);
 });

--- a/src/server/ctoDigest.mjs
+++ b/src/server/ctoDigest.mjs
@@ -1,0 +1,725 @@
+// src/server/ctoDigest.mjs
+// BET-1383 — the digest engine (spec §5.4–5.5). Consumes A7's rollups (folded
+// day/hour reads) + A8's needs-you cards to compose the "here's what happened
+// while you were away" digest.
+//
+// Properties (each honored below and asserted in ctoDigest.test.mjs):
+//   - Granularity selection from Δ = now − last_seen, using the fitted G from
+//     the segmenter plus the two fixed policy constants 16h and 3d (§5.4):
+//         Δ < G              → read live events (item unit: events)
+//         G ≤ Δ < 16h        → segment summaries (work episodes per project)
+//         16h ≤ Δ ≤ 3d       → hour/day rollups (sessions/threads w/ outcomes)
+//         Δ > 3d             → day rollups (themes + trends)
+//   - One mid-class model call at generation time (`digest-compose`, §12.3),
+//     fed the Δ-appropriate slice + open needs-you items + facts changed in
+//     window (+ an injectable tool-probe seam). Output = ordered digest items
+//     {tier, text, sub?, refs[], deep?}.
+//   - Tier lattice is deterministic and outranks any learned score:
+//     blocker ≫ failure ≫ decision-made ≫ shipped/milestone ≫ external ≫
+//     progress. Blockers are EXTRACTED OUT into needs-you cards (§10.3) and
+//     never occupy a digest slot — the composition strips any blocker-tier
+//     item and the validator refuses obvious strays (D15).
+//   - "Nothing important happened" is a legal output (renders the resting
+//     state) — empty `items` is valid.
+//   - Single-flight: generation holds a server-side lock keyed by absence-
+//     window id; concurrent triggers JOIN the in-flight generation rather than
+//     start a second. Generation state is published as a `{kind:"digestState"}`
+//     bus event; the Digest-now button renders the server's state.
+//   - `digests/` persistence (last 30 — retention sweep lives in ctoStores).
+//   - Timing scheduler (§5.5, D9): learned median of digest-open times over
+//     the trailing 14 days once ≥ 7 opens exist → else 30 min before the
+//     rising edge of the dominant workday component (§8.2, injectable) → else
+//     09:00 in the profile's inferred timezone when confidence is high → else
+//     09:00 box-local.
+//   - Digest-push honors informational deferral (desktop-first §3.4) and only
+//     fires when the §10.5 toggle is on; the toggle itself ships in A12, so
+//     `digestPushEnabled` defaults off here.
+//
+// Pure logic + injected I/O in the style of ctoRollups.mjs / ctoEngine.mjs —
+// no live tmux/opencode/network in tests. All model/store/presence/timing
+// seams are injectable (`runEphemeral`, `digests`, `presence`, `getGMinutes`,
+// `listOpenCards`, `factsChanged`, `probeFindings`, `loadSlice`,
+// `pushDigest`, `now`, `publish`, `getRisingEdge`, `getInferredTz`).
+
+import { promises as fsp } from "node:fs";
+import { createHash } from "node:crypto";
+import {
+  digestsStore,
+  ledgerStore,
+  rollupsStore,
+  segmentsStore,
+  factsStore,
+  engineStateStore,
+} from "./ctoStores.mjs";
+import { DEFAULT_G_MINUTES, minutesToMs } from "./ctoSegments.mjs";
+import { startPoller } from "./startPoller.mjs";
+
+export const DIGEST_VERSION = 1;
+
+// Local (box-zone) day boundary for a timestamp (ms → local midnight epoch).
+// Kept local — a trivial date helper independent of the rollup/segment
+// pipelines this module otherwise reads from.
+export function startOfDay(ts) {
+  const d = new Date(ts);
+  d.setHours(0, 0, 0, 0);
+  return d.getTime();
+}
+
+export const HOUR_MS = 3_600_000;
+export const DAY_MS = 24 * HOUR_MS;
+
+// §5.4 fixed policy constants (deliberately not G-derived).
+export const SIXTEEN_HOURS_MS = 16 * HOUR_MS;
+export const THREE_DAYS_MS = 3 * DAY_MS;
+
+// §5.4 constant item budget at every granularity.
+export const DIGEST_MIN_ITEMS = 4;
+export const DIGEST_MAX_ITEMS = 7;
+
+// §5.5 timing constants.
+export const STALE_MS = 30 * 60_000; // regenerate on view-open if older than this
+export const RISING_EDGE_LEAD_MS = 30 * 60_000; // 30 min before the rising edge
+export const LEARNED_WINDOW_DAYS = 14;
+export const LEARNED_MIN_OPENS = 7;
+export const DEFAULT_DIGEST_MS_INTO_DAY = 9 * HOUR_MS; // 09:00 box-local fallback
+export const INFERRED_TZ_CONFIDENCE_HIGH = 0.8;
+
+// §5.5 tier lattice — deterministic ordering (index 0 = highest priority),
+// outranks any learned score. `blocker` ranks first but is never a digest
+// item (D15): blockers are extracted into needs-you cards.
+export const TIER_ORDER = Object.freeze([
+  "blocker",
+  "failure",
+  "decision-made",
+  "shipped/milestone",
+  "external",
+  "progress",
+]);
+
+export const SCHEDULER_INTERVAL_MS = 60_000;
+
+// ---------------------------------------------------------------------------
+// Granularity selection (§5.4)
+// ---------------------------------------------------------------------------
+
+export function selectGranularity(absenceDeltaMs, { gMinutes = DEFAULT_G_MINUTES } = {}) {
+  const gMs = minutesToMs(gMinutes);
+  if (absenceDeltaMs < gMs) {
+    return { reads: "events", unit: "events", rollupLevels: [] };
+  }
+  if (absenceDeltaMs < SIXTEEN_HOURS_MS) {
+    return { reads: "segments", unit: "work episodes", rollupLevels: [] };
+  }
+  if (absenceDeltaMs <= THREE_DAYS_MS) {
+    return { reads: "rollups", unit: "sessions/threads with outcomes", rollupLevels: ["hour", "day"] };
+  }
+  return { reads: "rollups", unit: "themes + trends", rollupLevels: ["day"] };
+}
+
+// ---------------------------------------------------------------------------
+// Tier lattice helpers
+// ---------------------------------------------------------------------------
+
+export function tierIndex(tier) {
+  return TIER_ORDER.indexOf(tier);
+}
+
+// Deterministic descending-priority sort on the tier lattice (stable).
+export function sortItemsByTier(items) {
+  return [...(items || [])].sort((a, b) => tierIndex(a?.tier) - tierIndex(b?.tier) || 0);
+}
+
+// Blockers never occupy a digest slot (D15) — strip any that slip through.
+export function stripBlockers(items) {
+  return (items || []).filter((it) => it && it.tier !== "blocker");
+}
+
+// ---------------------------------------------------------------------------
+// Digest shape + validation
+// ---------------------------------------------------------------------------
+
+export function validateDigestItem(it) {
+  if (!it || typeof it !== "object") return false;
+  if (typeof it.tier !== "string" || tierIndex(it.tier) === -1) return false;
+  if (typeof it.text !== "string" || it.text.trim().length === 0) return false;
+  if (it.sub !== undefined && typeof it.sub !== "string") return false;
+  if (it.deep !== undefined && typeof it.deep !== "string") return false;
+  if (
+    it.refs !== undefined &&
+    (!Array.isArray(it.refs) || !it.refs.every((r) => typeof r === "string"))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+// The digest payload shape persisted to `digests/<id>.json` (§13.1).
+// `nothingHappened` is a derived flag: true iff items is empty ("Nothing
+// important happened" — renders the resting state, §5.5). Empty items are
+// legal; a digest is otherwise invalid if it carries stray blocker-tier items
+// (D15).
+export function validateDigest(obj) {
+  if (!obj || typeof obj !== "object") return false;
+  if (obj.v !== DIGEST_VERSION) return false;
+  if (!Array.isArray(obj.window) || obj.window.length !== 2 || typeof obj.window[0] !== "number" || typeof obj.window[1] !== "number") {
+    return false;
+  }
+  if (typeof obj.generated !== "number") return false;
+  if (!Array.isArray(obj.items)) return false;
+  if (obj.items.some((it) => it && it.tier === "blocker")) return false;
+  return obj.items.every(validateDigestItem);
+}
+
+// Tolerant extractor for the model's JSON digest — take the first `{` .. last
+// `}` (a model may wrap the JSON in prose or fences). Parse-only; schema
+// validation is validateDigest's job.
+export function parseDigestText(text) {
+  if (typeof text !== "string") return null;
+  const start = text.indexOf("{");
+  const end = text.lastIndexOf("}");
+  if (start === -1 || end === -1 || end <= start) return null;
+  try {
+    const obj = JSON.parse(text.slice(start, end + 1));
+    return obj && typeof obj === "object" ? obj : null;
+  } catch {
+    return null;
+  }
+}
+
+// Normalize parsed model output into the validated, ordered item list:
+// accept valid items, honour an explicit "nothing happened" marker, strip
+// blockers, sort by the tier lattice, and cap at the constant budget.
+export function normalizeDigestItems(parsed) {
+  let raw = Array.isArray(parsed?.items) ? parsed.items : [];
+  if (parsed?.nothingHappened === true) raw = [];
+  const valid = raw.filter(validateDigestItem);
+  return stripBlockers(sortItemsByTier(valid)).slice(0, DIGEST_MAX_ITEMS);
+}
+
+export function collectDigestRefs(items) {
+  const refs = new Set();
+  for (const it of items || []) {
+    if (Array.isArray(it?.refs)) for (const r of it.refs) if (typeof r === "string") refs.add(r);
+  }
+  return Array.from(refs).sort();
+}
+
+// ---------------------------------------------------------------------------
+// Timing scheduler (§5.5, D9) — pure, injectable
+// ---------------------------------------------------------------------------
+
+export function startOfSeconds(ms) {
+  return Math.floor(ms / 1000) * 1000;
+}
+
+// The next occurrence, at the box's local day boundary, of `msIntoDay`
+// ([0, DAY_MS)) — today if still in the future, else tomorrow.
+export function nextOccurrence(msIntoDay, now, dayStart = startOfDay(now)) {
+  let c = dayStart + msIntoDay;
+  if (c <= now) c += DAY_MS;
+  return c;
+}
+
+// Local UTC offset (hours east of UTC) at `ts`.
+export function boxUtcOffsetHoursOf(ts) {
+  return -new Date(ts).getTimezoneOffset() / 60;
+}
+
+export function medianOf(list) {
+  if (!list.length) return null;
+  const sorted = [...list].sort((a, b) => a - b);
+  return sorted[Math.floor(sorted.length / 2)];
+}
+
+// The next pre-generation deadline, following the fallback chain:
+//   1. learned — median of digest-open times over the trailing 14 days once
+//      ≥ `learnedMinOpens` opens exist;
+//   2. rising-edge default — `risingEdgeLeadMs` (30 min) before the dominant
+//      workday component's rising edge (§8.2), when one exists;
+//   3. inferred-TZ 09:00 — when the profile's inferred timezone confidence is
+//      high;
+//   4. box-local 09:00.
+// Returns the absolute epoch-ms of the next run.
+export function nextDigestMs({
+  now,
+  learnedOpenTimes = [],
+  risingEdgeMsIntoDay = null,
+  inferredTz = null,
+  learnedMinOpens = LEARNED_MIN_OPENS,
+  risingEdgeLeadMs = RISING_EDGE_LEAD_MS,
+  defaultMsIntoDay = DEFAULT_DIGEST_MS_INTO_DAY,
+  boxUtcOffsetHours,
+} = {}) {
+  const dayStart = startOfDay(now);
+  if (Array.isArray(learnedOpenTimes) && learnedOpenTimes.length >= learnedMinOpens) {
+    const intoDay = learnedOpenTimes.map((t) => (t - startOfDay(t)) % DAY_MS);
+    const med = medianOf(intoDay);
+    if (med != null) return nextOccurrence(med, now, dayStart);
+  }
+  if (typeof risingEdgeMsIntoDay === "number" && risingEdgeMsIntoDay >= 0) {
+    const target = (((risingEdgeMsIntoDay - risingEdgeLeadMs) % DAY_MS) + DAY_MS) % DAY_MS;
+    return nextOccurrence(target, now, dayStart);
+  }
+  if (inferredTz && typeof inferredTz.utcOffsetHours === "number" && (inferredTz.confidence ?? 0) >= INFERRED_TZ_CONFIDENCE_HIGH) {
+    const box = boxUtcOffsetHours != null ? boxUtcOffsetHours : boxUtcOffsetHoursOf(now);
+    const target = ((defaultMsIntoDay + (inferredTz.utcOffsetHours - box) * HOUR_MS) % DAY_MS + DAY_MS) % DAY_MS;
+    return nextOccurrence(target, now, dayStart);
+  }
+  return nextOccurrence(defaultMsIntoDay, now, dayStart);
+}
+
+// ---------------------------------------------------------------------------
+// Context assembly — the `digest-compose` model input (≤12k ctx, §12.3)
+// ---------------------------------------------------------------------------
+
+export function buildDigestContext({ granularity, window, slice, needsYou, factsChanged, probes, gMinutes } = {}) {
+  const [ws, we] = window;
+  const blocks = [];
+
+  const readLine = {
+    events: "live events",
+    segments: "segment summaries (work episodes per project)",
+    rollups: granularity.rollupLevels?.join("/") + " rollups",
+  }[granularity?.reads] || "activity";
+
+  blocks.push({
+    priority: "high",
+    text:
+      `You are the Adaptive CTO. Compose a digest of what happened while the user was ` +
+      `away — the absence window ${ws}..${we} (${granularity?.reads}, item unit: ${granularity?.unit}). ` +
+      `Output ONLY JSON of the form ` +
+      `{"items":[{"tier":"<tier>","text":"<short human sentence>","sub":"<optional subtitle>","refs":["<evidenceId>",...],"deep":"<optional expandable technical layer>"}]}. ` +
+      `Tiers (highest first): failure, decision-made, shipped/milestone, external, progress. ` +
+      `Blockers are NOT digest items (they're handled separately) — never emit a "blocker" tier. ` +
+      `Produce ${DIGEST_MIN_ITEMS}-${DIGEST_MAX_ITEMS} concrete, factual items. If nothing important ` +
+      `happened, output {"items":[]} (the resting state is legal). ` +
+      `Each item may carry refs to evidence (segment/rollup ids). "deep" must be present when an item ` +
+      `summarizes technical work (the expandable technical layer); "sub" is an optional secondary line.`,
+  });
+  if (needsYou && needsYou.length) {
+    blocks.push({
+      priority: "medium",
+      text:
+        `Open needs-you items requiring the user (do NOT include these as digest items — they live ` +
+        `in the needs-you list):\n` +
+        needsYou.map((c) => `- [${c.id}] ${c.title || c.body || "needs you"}`).join("\n"),
+    });
+  }
+  if (slice && slice.length) {
+    const lines = [];
+    for (const it of slice) {
+      if (granularity?.reads === "segments") {
+        lines.push(`[${it.id}] ${it.oneLiner || "work"}${it.project ? ` (project: ${it.project})` : ""} — window ${it.window ? `${it.window[0]}..${it.window[1]}` : "?"}`);
+      } else {
+        const bullets = (it.bullets || []).map((b) => `- ${b.text}`).join("\n");
+        lines.push(`[${it.id}] ${it.level || ""}${bullets ? `:\n${bullets}` : " (no bullets)"}`);
+      }
+    }
+    blocks.push({ priority: "medium", text: `The ${readLine} to summarize:\n${lines.join("\n")}` });
+  }
+  if (factsChanged && factsChanged.length) {
+    blocks.push({
+      priority: "medium",
+      text: "Facts changed in this window:\n" + factsChanged.map((f) => `- [${f.id}] ${f.statement}`).join("\n"),
+    });
+  }
+  if (probes && probes.length) {
+    blocks.push({
+      priority: "low",
+      text: "Tool-probe findings:\n" + probes.map((p) => `- ${typeof p === "string" ? p : JSON.stringify(p)}`).join("\n"),
+    });
+  }
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// Default input loading — read the Δ-appropriate slice from the stores.
+// Blockers are excluded from the slice (they never roll up / occupy a slot,
+// §5.4); A8's needs-you cards are surfaced separately via `listOpenCards`.
+// ---------------------------------------------------------------------------
+
+export function defaultLoadSlice({ granularity, window, segments = segmentsStore, rollups = rollupsStore, fs = fsp } = {}) {
+  return async () => {
+    const [ws, we] = window;
+    if (granularity?.reads === "segments") {
+      let names = [];
+      try {
+        names = await fs.readdir(segments.dir);
+      } catch {
+        return [];
+      }
+      const out = [];
+      for (const name of names) {
+        if (!name.endsWith(".json")) continue;
+        const id = name.slice(0, -5);
+        let seg;
+        try {
+          seg = await segments.load(id);
+        } catch {
+          continue;
+        }
+        if (seg && Array.isArray(seg.window) && seg.window[1] > ws && seg.window[0] <= we && seg.summary) {
+          if (seg.summary?.outcome === "blocked") continue; // blockers never occupy a slot
+          out.push({
+            id,
+            window: seg.window,
+            oneLiner: seg.summary.one_liner || seg.summary.intent || "work",
+            outcome: seg.summary.outcome,
+            project: seg.project,
+          });
+        }
+      }
+      return out.sort((a, b) => a.window[0] - b.window[0]);
+    }
+    if (granularity?.reads === "rollups") {
+      const levels = granularity.rollupLevels?.length ? granularity.rollupLevels : ["day"];
+      const out = [];
+      for (const level of levels) {
+        let names = [];
+        try {
+          names = await fs.readdir(rollups.dirFor(level));
+        } catch {
+          continue;
+        }
+        for (const name of names) {
+          if (!name.endsWith(".json")) continue;
+          const id = name.slice(0, -5);
+          let r;
+          try {
+            r = await rollups.load(level, id);
+          } catch {
+            continue;
+          }
+          if (r && Array.isArray(r.window) && r.window[1] > ws && r.window[0] <= we && Array.isArray(r.bullets)) {
+            out.push({ id, level, window: r.window, bullets: r.bullets });
+          }
+        }
+      }
+      return out.sort((a, b) => a.window[0] - b.window[0]);
+    }
+    // events granularity: live events are surfaced by the "Now" rail (§10.4);
+    // the digest itself has nothing extra to fold here.
+    return [];
+  };
+}
+
+// Facts created within the window (the §5.5 "facts changed in the window"
+// input). Reads the per-project facts store (P1 — single-writer path exists).
+export function defaultFactsChanged({ window, facts = factsStore, fs = fsp } = {}) {
+  return async () => {
+    const [ws, we] = window;
+    let names = [];
+    try {
+      names = await fs.readdir(facts.dir);
+    } catch {
+      return [];
+    }
+    const out = [];
+    for (const name of names) {
+      if (!name.endsWith(".json")) continue;
+      let payload;
+      try {
+        payload = await facts.load(name.slice(0, -5));
+      } catch {
+        continue;
+      }
+      for (const f of Array.isArray(payload?.facts) ? payload.facts : []) {
+        if (typeof f?.created === "number" && f.created >= ws && f.created <= we) {
+          out.push({ id: f.id, statement: f.statement, kind: f.kind });
+        }
+      }
+    }
+    return out;
+  };
+}
+
+// Degraded fallback when the model call is gated/unavailable/failed: a
+// truthful minimal digest. Empty slice → "Nothing important happened"
+// ({items: []}); otherwise one "progress" item per slice entry with correct
+// refs, capped at the item budget.
+export function degradedDigest({ granularity, window, slice, generated, gMinutes } = {}) {
+  const items = [];
+  const cap = DIGEST_MAX_ITEMS;
+  if (granularity?.reads === "segments") {
+    for (const it of slice || []) {
+      if (items.length >= cap) break;
+      items.push({ tier: "progress", text: it.oneLiner || "work", refs: it.id ? [it.id] : [] });
+    }
+  } else {
+    for (const it of slice || []) {
+      for (const b of it?.bullets || []) {
+        if (items.length >= cap) break;
+        items.push({ tier: "progress", text: typeof b?.text === "string" ? b.text : "work", refs: Array.isArray(b.refs) ? b.refs : [] });
+      }
+      if (items.length >= cap) break;
+    }
+  }
+  return { v: DIGEST_VERSION, granularity, window, generated, items };
+}
+
+// ---------------------------------------------------------------------------
+// The digest engine
+// ---------------------------------------------------------------------------
+
+export function createCtoDigest(deps = {}) {
+  const {
+    now = () => Date.now(),
+    publish = () => {},
+    runEphemeral = null, // async ({taskClass, context, deps}) => {text, ok, ...}
+    digests = digestsStore,
+    segmented = segmentsStore,
+    rolled = rollupsStore,
+    facts = factsStore,
+    ledger = ledgerStore,
+    engineState = engineStateStore,
+    engineStateKey = "digest", // key under engine-state for opens/learned times
+    presence = null, // { get(): {lastSeen, absenceDelta} } | null
+    getGMinutes = () => DEFAULT_G_MINUTES,
+    listOpenCards = async () => [], // A8 open needs-you items
+    factsChanged = null, // async ({window}) => [...]  (default reads facts store)
+    probeFindings = async () => [], // tool-probe findings (injectable; default none)
+    loadSlice = null, // async ({granularity, window}) => slice
+    getRisingEdge = async () => null, // ms-into-day of dominant workday rising edge (§8.2) | null
+    getInferredTz = async () => null, // {utcOffsetHours, confidence} | null
+    getEnabled = async () => false, // top-level ctoEnabled gate for the scheduler
+    digestPushEnabled = async () => false, // §10.5 toggle (ships A12) — off by default
+    pushDigest = async () => {}, // informational notification honoring router deferral
+    intervalMs = SCHEDULER_INTERVAL_MS,
+    fs = fsp,
+  } = deps;
+
+  let disposed = false;
+  let generating = false;
+  let lastGenerated = null;
+  let lastDigestId = null;
+  let firedScheduledAt = null;
+  let stopHandle = null;
+
+  const inFlight = new Map();
+
+  async function safe(fn, ...args) {
+    try {
+      return await fn(...args);
+    } catch {
+      return null;
+    }
+  }
+
+  async function ledgerLog(entry) {
+    try {
+      await ledger.append({ actor: "cto", ts: now(), ...entry });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  function setGenerating(v) {
+    if (generating === v) return;
+    generating = v;
+    publish({ kind: "digestState", payload: { generationInFlight: generating } });
+  }
+
+  // ----- single-flight -----
+  function absenceKey(lastSeen) {
+    return `digest:${lastSeen == null ? "none" : lastSeen}`;
+  }
+
+  // ---- learned timing persistence (engine-state) ----
+  async function loadOpens() {
+    let payload;
+    try {
+      payload = await engineState.load();
+    } catch {
+      payload = {};
+    }
+    const arr = Array.isArray(payload?.[engineStateKey]?.opens) ? payload[engineStateKey].opens : [];
+    const cutoff = now() - LEARNED_WINDOW_DAYS * DAY_MS;
+    return arr.filter((t) => typeof t === "number" && t >= cutoff);
+  }
+
+  async function recordOpen() {
+    const t = now();
+    const opens = await loadOpens();
+    opens.push(t);
+    let payload;
+    try {
+      payload = (await engineState.load()) || {};
+    } catch {
+      payload = {};
+    }
+    const cur = payload[engineStateKey] || {};
+    await engineState.save({ ...payload, [engineStateKey]: { ...cur, opens } });
+  }
+
+  async function nextScheduledAt() {
+    const opens = await loadOpens();
+    const rising = await safe(getRisingEdge);
+    const tz = await safe(getInferredTz);
+    const boxOffset = boxUtcOffsetHoursOf(now());
+    return nextDigestMs({
+      now: now(),
+      learnedOpenTimes: opens,
+      risingEdgeMsIntoDay: typeof rising === "number" ? rising : null,
+      inferredTz: tz || null,
+      boxUtcOffsetHours: boxOffset,
+    });
+  }
+
+  // ---- generation ----
+  async function doGenerate({ reason = "manual", presenceOf } = {}) {
+    const t = now();
+    if (!presenceOf) return null;
+    const gMinutes = (await safe(getGMinutes)) ?? DEFAULT_G_MINUTES;
+    const lastSeen = typeof presenceOf.lastSeen === "number" ? presenceOf.lastSeen : t;
+    const delta = typeof presenceOf.absenceDelta === "number" ? presenceOf.absenceDelta : Math.max(0, t - lastSeen);
+    const granularity = selectGranularity(delta, { gMinutes });
+    const window = [lastSeen, t];
+
+    const needsYou = await safe(listOpenCards) ?? [];
+    const slice = await (loadSlice ? loadSlice({ granularity, window }) : defaultLoadSlice({ granularity, window, segments: segmented, rollups: rolled, fs })().catch(() => []));
+    const factFn = factsChanged ?? defaultFactsChanged({ window, facts, fs });
+    const fChanged = await factFn({ window }).catch(() => []);
+    const probes = await safe(probeFindings) ?? [];
+
+    const context = buildDigestContext({ granularity, window, slice: slice || [], needsYou, factsChanged: fChanged, probes, gMinutes });
+
+    let digest = null;
+    if (runEphemeral) {
+      try {
+        const res = await runEphemeral({ taskClass: "digest-compose", context, deps: { validate: validateDigest } });
+        const parsed = parseDigestText(res?.text);
+        if (parsed) {
+          const items = normalizeDigestItems(parsed);
+          const candidate = {
+            v: DIGEST_VERSION,
+            granularity,
+            window,
+            generated: t,
+            items,
+            nothingHappened: items.length === 0,
+            refs: collectDigestRefs(items),
+          };
+          if (validateDigest(candidate)) digest = candidate;
+        }
+      } catch {
+        digest = null;
+      }
+    }
+    if (!digest) {
+      const degraded = degradedDigest({ granularity, window, slice: slice || [], generated: t, gMinutes });
+      digest = { ...degraded, nothingHappened: degraded.items.length === 0, refs: collectDigestRefs(degraded.items) };
+      await ledgerLog({ kind: "cto.digest_degraded", granularity: granularity.reads, window });
+    }
+
+    const id = String(t);
+    try {
+      await digests.save(id, digest);
+    } catch {
+      /* best-effort */
+    }
+    lastGenerated = t;
+    lastDigestId = id;
+
+    await ledgerLog({ kind: "cto.digest_written", id, granularity: granularity.reads, items: digest.items.length, reason });
+
+    if (reason === "scheduled") {
+      const pushOn = await safe(digestPushEnabled);
+      if (pushOn) await safe(pushDigest, { digest, granularity });
+    }
+    return digest;
+  }
+
+  function generateDigest(opts = {}) {
+    const presenceOf = (presence && typeof presence.get === "function") ? presence.get() : null;
+    const key = absenceKey(presenceOf?.lastSeen);
+    if (inFlight.has(key)) return inFlight.get(key);
+    const job = (async () => {
+      setGenerating(true);
+      try {
+        return await doGenerate({ ...opts, presenceOf });
+      } finally {
+        setGenerating(false);
+      }
+    })();
+    inFlight.set(key, job);
+    job.finally(() => inFlight.delete(key)).catch(() => {});
+    return job;
+  }
+
+  // ---- latest digest from the store (restart-safe render, §5.5) ----
+  async function getLatest() {
+    let names = [];
+    try {
+      names = await fs.readdir(digests.dir);
+    } catch {
+      return null;
+    }
+    const entries = [];
+    for (const name of names) {
+      if (!name.endsWith(".json")) continue;
+      const id = name.slice(0, -5);
+      let d;
+      try {
+        d = await digests.load(id);
+      } catch {
+        continue;
+      }
+      if (d && validateDigest(d)) entries.push(d);
+    }
+    if (!entries.length) return null;
+    entries.sort((a, b) => b.generated - a.generated);
+    return entries[0];
+  }
+
+  async function getState() {
+    const latest = await safe(getLatest);
+    return {
+      generationInFlight: generating,
+      lastGeneratedAt: latest?.generated ?? null,
+      lastDigestId: latest ? String(latest.generated) : null,
+    };
+  }
+
+  // ---- scheduler ----
+  async function schedulerTick() {
+    if (disposed) return;
+    const enabled = await safe(getEnabled);
+    if (!enabled) return;
+    const t = now();
+    const due = await safe(nextScheduledAt);
+    if (typeof due !== "number" || due !== firedScheduledAt) {
+      if (typeof due === "number" && t >= due) {
+        firedScheduledAt = due;
+        void generateDigest({ reason: "scheduled" });
+      }
+    }
+  }
+
+  function start() {
+    if (disposed) throw new Error("cto digest engine already disposed");
+    stopHandle = startPoller(schedulerTick, { intervalMs, label: "cto-digest" });
+    return engine;
+  }
+
+  function dispose() {
+    disposed = true;
+    if (stopHandle) stopHandle.stop?.();
+  }
+
+  const engine = {
+    actor: "cto",
+    start,
+    dispose,
+    generateDigest,
+    getLatest,
+    isGenerating: () => generating,
+    getState,
+    recordOpen,
+    nextScheduledAt,
+    // exposed for tests / diagnostics
+    _now: now,
+    _selectGranularity: selectGranularity,
+  };
+
+  return engine;
+}

--- a/src/server/ctoDigest.mjs
+++ b/src/server/ctoDigest.mjs
@@ -294,7 +294,9 @@ export function buildDigestContext({ granularity, window, slice, needsYou, facts
       `Produce ${DIGEST_MIN_ITEMS}-${DIGEST_MAX_ITEMS} concrete, factual items. If nothing important ` +
       `happened, output {"items":[]} (the resting state is legal). ` +
       `Each item may carry refs to evidence (segment/rollup ids). "deep" must be present when an item ` +
-      `summarizes technical work (the expandable technical layer); "sub" is an optional secondary line.`,
+      `summarizes technical work (the expandable technical layer); "sub" is an optional secondary line. ` +
+      `When a change OVERTURNS a previously-held fact, phrase it as a subordinate clause on the owning item ` +
+      `(e.g. a "sub" like "this overturns the earlier priority"), NEVER as a separate section or item.`,
   });
   if (needsYou && needsYou.length) {
     blocks.push({
@@ -549,6 +551,18 @@ export function createCtoDigest(deps = {}) {
     }
     const cur = payload[engineStateKey] || {};
     await engineState.save({ ...payload, [engineStateKey]: { ...cur, opens } });
+    // §14.1 instrumentation: the digest was viewed/open.
+    await ledgerLog({ kind: "cto.digest_opened", ts: t, windowEnd: t });
+  }
+
+  // §14.1 instrumentation: per-item open / expand (the UI issue calls this via
+  // POST /api/cto/digest/opened).
+  async function recordItemEvent({ item, expand, digestId } = {}) {
+    await ledgerLog({
+      kind: expand ? "cto.digest_expanded" : "cto.digest_item_opened",
+      item: typeof item === "string" ? item : null,
+      digestId: digestId ?? null,
+    });
   }
 
   async function nextScheduledAt() {
@@ -620,7 +634,7 @@ export function createCtoDigest(deps = {}) {
     lastGenerated = t;
     lastDigestId = id;
 
-    await ledgerLog({ kind: "cto.digest_written", id, granularity: granularity.reads, items: digest.items.length, reason });
+    await ledgerLog({ kind: "cto.digest_generated", id, granularity: granularity.reads, items: digest.items.length, reason });
 
     if (reason === "scheduled") {
       const pushOn = await safe(digestPushEnabled);
@@ -715,6 +729,7 @@ export function createCtoDigest(deps = {}) {
     isGenerating: () => generating,
     getState,
     recordOpen,
+    recordItemEvent,
     nextScheduledAt,
     // exposed for tests / diagnostics
     _now: now,

--- a/src/server/ctoDigest.mjs
+++ b/src/server/ctoDigest.mjs
@@ -49,7 +49,6 @@ import {
   rollupsStore,
   segmentsStore,
   factsStore,
-  engineStateStore,
 } from "./ctoStores.mjs";
 import { DEFAULT_G_MINUTES, minutesToMs } from "./ctoSegments.mjs";
 import { startPoller } from "./startPoller.mjs";
@@ -473,8 +472,6 @@ export function createCtoDigest(deps = {}) {
     rolled = rollupsStore,
     facts = factsStore,
     ledger = ledgerStore,
-    engineState = engineStateStore,
-    engineStateKey = "digest", // key under engine-state for opens/learned times
     presence = null, // { get(): {lastSeen, absenceDelta} } | null
     getGMinutes = () => DEFAULT_G_MINUTES,
     listOpenCards = async () => [], // A8 open needs-you items
@@ -526,32 +523,30 @@ export function createCtoDigest(deps = {}) {
     return `digest:${lastSeen == null ? "none" : lastSeen}`;
   }
 
-  // ---- learned timing persistence (engine-state) ----
+  // ---- learned timing (§5.5/D9) ----
+  // The learned median of observed digest-open times comes from the §14.1
+  // ledger instrumentation rows (`cto.digest_opened`), filtered to the
+  // trailing LEARNED_WINDOW_DAYS, used once ≥ LEARNED_MIN_OPENS opens exist.
+  // The ledger is the single source of truth for open times — no parallel
+  // engine-state array.
   async function loadOpens() {
-    let payload;
+    let rows = [];
     try {
-      payload = await engineState.load();
+      rows = await ledger.read();
     } catch {
-      payload = {};
+      rows = [];
     }
-    const arr = Array.isArray(payload?.[engineStateKey]?.opens) ? payload[engineStateKey].opens : [];
     const cutoff = now() - LEARNED_WINDOW_DAYS * DAY_MS;
-    return arr.filter((t) => typeof t === "number" && t >= cutoff);
+    return rows
+      .filter((r) => r?.kind === "cto.digest_opened" && typeof r?.ts === "number" && r.ts >= cutoff)
+      .map((r) => r.ts);
   }
 
+  // View-open: records the §14.1 `cto.digest_opened` instrumentation row,
+  // which both feeds the learned timing scheduler (via loadOpens above) and
+  // the usage instrumentation.
   async function recordOpen() {
     const t = now();
-    const opens = await loadOpens();
-    opens.push(t);
-    let payload;
-    try {
-      payload = (await engineState.load()) || {};
-    } catch {
-      payload = {};
-    }
-    const cur = payload[engineStateKey] || {};
-    await engineState.save({ ...payload, [engineStateKey]: { ...cur, opens } });
-    // §14.1 instrumentation: the digest was viewed/open.
     await ledgerLog({ kind: "cto.digest_opened", ts: t, windowEnd: t });
   }
 

--- a/src/server/ctoDigest.test.mjs
+++ b/src/server/ctoDigest.test.mjs
@@ -36,6 +36,7 @@ import {
   RISING_EDGE_LEAD_MS,
 } from "./ctoDigest.mjs";
 import { startOfDay } from "./ctoDigest.mjs";
+import { DIGESTS_KEEP } from "./ctoStores.mjs";
 
 const G = 45; // minutes
 
@@ -466,4 +467,34 @@ test("digest-push: toggle off → never pushes even on scheduled generation", as
   });
   await engine.generateDigest({ reason: "scheduled" });
   assert.equal(pushed, 0);
+});
+
+// §13.1 "digests/ keep last 30" — the retention sweep lives in ctoStores
+// (sweepDigests trims to DIGESTS_KEEP); pin the governing constant here.
+test("digests/ retention keeps the last 30 (DIGESTS_KEEP == 30)", () => {
+  assert.equal(DIGESTS_KEEP, 30);
+});
+
+test("recordOpen + recordItemEvent emit §14.1 instrumentation ledger rows", async () => {
+  const { engine, ledgerRows } = makeEngine({ runEphemeral: null });
+  await engine.recordOpen();
+  await engine.recordItemEvent({ item: "shipped the parser", digestId: "123" });
+  await engine.recordItemEvent({ item: "deep log", expand: true, digestId: "123" });
+  const kinds = ledgerRows.map((r) => r.kind);
+  assert.ok(kinds.includes("cto.digest_opened"));
+  assert.ok(kinds.includes("cto.digest_item_opened"));
+  assert.ok(kinds.includes("cto.digest_expanded"));
+  const expanded = ledgerRows.find((r) => r.kind === "cto.digest_expanded");
+  assert.equal(expanded.digestId, "123");
+});
+
+test("generateDigest: successful model path emits cto.digest_generated", async () => {
+  const { engine, ledgerRows } = makeEngine({
+    runEphemeral: async () => ({ text: JSON.stringify({ items: [{ tier: "progress", text: "x", refs: [] }] }) }),
+  });
+  await engine.generateDigest({ reason: "manual" });
+  const generated = ledgerRows.find((r) => r.kind === "cto.digest_generated");
+  assert.ok(generated);
+  assert.equal(generated.reason, "manual");
+  assert.equal(generated.items, 1);
 });

--- a/src/server/ctoDigest.test.mjs
+++ b/src/server/ctoDigest.test.mjs
@@ -334,22 +334,15 @@ async function waitFor(fn, timeout = 2000) {
 
 function makeEngine(overrides = {}) {
   const store = overrides.store ?? makeDigestStore();
-  const state = new Map();
   const ledgerRows = [];
   const engine = createCtoDigest({
     now: () => REF,
     presence: { get: () => ({ lastSeen: REF - 2 * DAY_MS, absenceDelta: 2 * DAY_MS }) },
     getGMinutes: () => G,
     digests: store,
-    ledger: { append: async (e) => ledgerRows.push(e) },
-    engineState: {
-      load: async () => {
-        const raw = state.get("v");
-        return raw === undefined ? {} : raw;
-      },
-      save: async (d) => {
-        state.set("v", d);
-      },
+    ledger: {
+      append: async (e) => ledgerRows.push(e),
+      read: async () => [...ledgerRows],
     },
     listOpenCards: async () => [],
     factsChanged: async () => [],
@@ -363,7 +356,7 @@ function makeEngine(overrides = {}) {
     },
     ...overrides,
   });
-  return { engine, store, state, ledgerRows };
+  return { engine, store, ledgerRows };
 }
 
 test("generateDigest: single-flight — concurrent triggers join one generation", async () => {
@@ -428,16 +421,39 @@ test("getLatest: returns the newest valid digest from the store", async () => {
   assert.equal(validateDigest(d), true);
 });
 
-test("recordOpen: persisted opens drive the scheduler's learned path", async () => {
-  const { engine } = makeEngine({ runEphemeral: null });
-  // <7 opens → no learned component → scheduler falls to the default
-  for (let i = 0; i < 6; i++) await engine.recordOpen();
-  const before = await engine.nextScheduledAt();
-  // ≥7 opens → learned median kicks in; still a valid future epoch
-  for (let i = 0; i < 2; i++) await engine.recordOpen();
-  const after = await engine.nextScheduledAt();
-  assert.ok(typeof before === "number" && before > REF);
-  assert.ok(typeof after === "number" && after > REF);
+test("recordOpen: learned timing reads cto.digest_opened rows from the LEDGER (single source of truth)", async () => {
+  // Seed the ledger with ≥7 cto.digest_opened rows, all at 07:00 into-day.
+  const ledgerRows = [];
+  const openTs = startOfDay(REF) + 7 * HOUR_MS; // well within the trailing 14d
+  for (let i = 0; i < 8; i++) ledgerRows.push({ kind: "cto.digest_opened", ts: openTs });
+  const { engine } = makeEngine({
+    runEphemeral: null,
+    ledger: {
+      append: async (e) => ledgerRows.push(e),
+      read: async () => [...ledgerRows],
+    },
+  });
+  // Learned median = 07:00 (≥7 opens) → next day 07:00 (REF is midday).
+  const due = await engine.nextScheduledAt();
+  assert.equal(due, startOfDay(REF) + DAY_MS + 7 * HOUR_MS);
+
+  // With fewer than LEARNED_MIN_OPENS opens the learned path is not taken.
+  const fewRows = [];
+  for (let i = 0; i < 6; i++) fewRows.push({ kind: "cto.digest_opened", ts: openTs });
+  const few = makeEngine({
+    runEphemeral: null,
+    ledger: { append: async (e) => fewRows.push(e), read: async () => [...fewRows] },
+  });
+  const dueFew = await few.engine.nextScheduledAt();
+  assert.equal(dueFew, startOfDay(REF) + DAY_MS + DEFAULT_DIGEST_MS_INTO_DAY); // falls to box-local 09:00
+});
+
+test("recordOpen: appends a cto.digest_opened ledger row (feeds learned timing + §14.1)", async () => {
+  const { engine, ledgerRows } = makeEngine({ runEphemeral: null });
+  await engine.recordOpen();
+  const opened = ledgerRows.find((r) => r.kind === "cto.digest_opened");
+  assert.ok(opened, "recordOpen must write the ledger instrumentation row");
+  assert.equal(typeof opened.ts, "number");
 });
 
 test("digest-push: fires only when the §10.5 toggle is on AND reason is scheduled", async () => {

--- a/src/server/ctoDigest.test.mjs
+++ b/src/server/ctoDigest.test.mjs
@@ -1,0 +1,469 @@
+// src/server/ctoDigest.test.mjs
+// BET-1383 — digest engine (spec §5.4–5.5). Coverage per decomposition A9:
+//   - granularity table (Δ → reads/unit/rollup levels),
+//   - tier lattice ordering + blocker exclusion,
+//   - digest validation / parse / normalization ("nothing happened" legal),
+//   - single-flight (concurrent triggers join, never a second run),
+//   - timing fallback chain (learned → rising edge → inferred-TZ 09:00 →
+//     box-local 09:00),
+//   - persistence (`digests/` + latest-from-store) + learned-open recording,
+//   - degraded fallback and digest-push gating.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  createCtoDigest,
+  selectGranularity,
+  sortItemsByTier,
+  stripBlockers,
+  validateDigestItem,
+  validateDigest,
+  parseDigestText,
+  normalizeDigestItems,
+  collectDigestRefs,
+  degradedDigest,
+  nextDigestMs,
+  nextOccurrence,
+  medianOf,
+  buildDigestContext,
+  DIGEST_VERSION,
+  DIGEST_MAX_ITEMS,
+  HOUR_MS,
+  DAY_MS,
+  SIXTEEN_HOURS_MS,
+  THREE_DAYS_MS,
+  DEFAULT_DIGEST_MS_INTO_DAY,
+  RISING_EDGE_LEAD_MS,
+} from "./ctoDigest.mjs";
+import { startOfDay } from "./ctoDigest.mjs";
+
+const G = 45; // minutes
+
+function minutesMs(mins) {
+  return Math.round(mins * 60_000);
+}
+
+// ---------------------------------------------------------------------------
+// Granularity table (§5.4)
+// ---------------------------------------------------------------------------
+
+test("selectGranularity: Δ < G reads live events", () => {
+  const gMs = minutesMs(G);
+  const g = selectGranularity(gMs - 1, { gMinutes: G });
+  assert.equal(g.reads, "events");
+  assert.equal(g.unit, "events");
+  assert.deepEqual(g.rollupLevels, []);
+});
+
+test("selectGranularity: Δ == G reads segment summaries (work episodes)", () => {
+  const g = selectGranularity(minutesMs(G), { gMinutes: G });
+  assert.equal(g.reads, "segments");
+  assert.equal(g.unit, "work episodes");
+});
+
+test("selectGranularity: Δ within [G, 16h) reads segments", () => {
+  const g = selectGranularity(2 * HOUR_MS, { gMinutes: G });
+  assert.equal(g.reads, "segments");
+  const g2 = selectGranularity(SIXTEEN_HOURS_MS - 1, { gMinutes: G });
+  assert.equal(g2.reads, "segments");
+});
+
+test("selectGranularity: Δ in [16h, 3d] reads hour/day rollups", () => {
+  const g = selectGranularity(SIXTEEN_HOURS_MS, { gMinutes: G });
+  assert.equal(g.reads, "rollups");
+  assert.equal(g.unit, "sessions/threads with outcomes");
+  assert.deepEqual(g.rollupLevels, ["hour", "day"]);
+  assert.deepEqual(selectGranularity(2 * DAY_MS, { gMinutes: G }).rollupLevels, ["hour", "day"]);
+  assert.deepEqual(selectGranularity(THREE_DAYS_MS, { gMinutes: G }).rollupLevels, ["hour", "day"]);
+});
+
+test("selectGranularity: Δ > 3d reads day rollups (themes + trends)", () => {
+  const g = selectGranularity(THREE_DAYS_MS + 1, { gMinutes: G });
+  assert.equal(g.reads, "rollups");
+  assert.equal(g.unit, "themes + trends");
+  assert.deepEqual(g.rollupLevels, ["day"]);
+});
+
+test("selectGranularity: full boundary table is exact", () => {
+  const gMs = minutesMs(G);
+  const rows = [
+    [0, "events"],
+    [gMs - 1, "events"],
+    [gMs, "segments"],
+    [SIXTEEN_HOURS_MS - 1, "segments"],
+    [SIXTEEN_HOURS_MS, "rollups"],
+    [THREE_DAYS_MS, "rollups"],
+    [THREE_DAYS_MS + 1, "rollups"],
+  ];
+  for (const [delta, reads] of rows) {
+    const g = selectGranularity(delta, { gMinutes: G });
+    assert.equal(g.reads, reads, `delta=${delta}`);
+  }
+  const day = selectGranularity(THREE_DAYS_MS + 1, { gMinutes: G });
+  assert.deepEqual(day.rollupLevels, ["day"]);
+});
+
+test("selectGranularity: default G (45m) applies when omitted", () => {
+  assert.equal(selectGranularity(30 * 60_000).reads, "events");
+  assert.equal(selectGranularity(60 * 60_000).reads, "segments");
+});
+
+// ---------------------------------------------------------------------------
+// Tier lattice (§5.5)
+// ---------------------------------------------------------------------------
+
+function item(tier, text = "t") {
+  return { tier, text, refs: [] };
+}
+
+test("sortItemsByTier: orders by the deterministic lattice (failure ≫ progress)", () => {
+  const sorted = sortItemsByTier([
+    item("progress"),
+    item("failure"),
+    item("shipped/milestone"),
+    item("decision-made"),
+    item("external"),
+  ]);
+  assert.deepEqual(
+    sorted.map((i) => i.tier),
+    ["failure", "decision-made", "shipped/milestone", "external", "progress"],
+  );
+});
+
+test("sortItemsByTier: stable for equal tiers", () => {
+  const a = item("progress", "a");
+  const b = item("progress", "b");
+  const sorted = sortItemsByTier([b, a]);
+  assert.equal(sorted[0], b);
+  assert.equal(sorted[1], a);
+});
+
+test("stripBlockers: removes any blocker-tier item", () => {
+  const out = stripBlockers([item("blocker"), item("progress"), item("failure")]);
+  assert.deepEqual(out.map((i) => i.tier), ["progress", "failure"]);
+});
+
+// ---------------------------------------------------------------------------
+// Validation / parse / normalize
+// ---------------------------------------------------------------------------
+
+test("validateDigestItem: accepts a legal item with sub/deep/refs", () => {
+  assert.equal(
+    validateDigestItem({ tier: "failure", text: "build broke", sub: "x", deep: "log", refs: ["s1"] }),
+    true,
+  );
+});
+
+test("validateDigestItem: rejects bad tier / empty text / wrong refs", () => {
+  assert.equal(validateDigestItem({ tier: "bogus", text: "x" }), false);
+  assert.equal(validateDigestItem({ tier: "progress", text: "  " }), false);
+  assert.equal(validateDigestItem({ tier: "progress", text: "x", refs: "s1" }), false);
+});
+
+test("validateDigest: empty items (nothing happened) is legal; blocker item is refused", () => {
+  const base = {
+    v: DIGEST_VERSION,
+    granularity: selectGranularity(2 * DAY_MS, { gMinutes: G }),
+    window: [1000, 2000],
+    generated: 2000,
+    items: [],
+  };
+  assert.equal(validateDigest(base), true);
+  assert.equal(validateDigest({ ...base, items: [item("progress")] }), true);
+  assert.equal(validateDigest({ ...base, items: [item("progress", "x")] }), true);
+  assert.equal(validateDigest({ ...base, items: [item("blocker")] }), false, "blocker is not a digest item (D15)");
+  assert.equal(validateDigest({ ...base, generated: "x" }), false);
+});
+
+test("parseDigestText: extracts JSON wrapped in prose/fences", () => {
+  const out = parseDigestText('Here you go:\n```json\n{"items":[{"tier":"progress","text":"hi","refs":[]}]}\n```');
+  assert.ok(out);
+  assert.equal(out.items.length, 1);
+  assert.equal(parseDigestText("no braces here"), null);
+  assert.equal(parseDigestText("{invalid"), null);
+});
+
+test("normalizeDigestItems: strips blockers, sorts by tier, honors nothing marker, caps at budget", () => {
+  const many = [];
+  for (let i = 0; i < 12; i++) many.push(item("progress", `p${i}`));
+  assert.equal(normalizeDigestItems({ items: many }).length, DIGEST_MAX_ITEMS);
+
+  assert.deepEqual(
+    normalizeDigestItems({ items: [item("progress"), item("blocker"), item("failure")] }).map((i) => i.tier),
+    ["failure", "progress"],
+  );
+  assert.deepEqual(normalizeDigestItems({ items: [item("progress")], nothingHappened: true }), []);
+  assert.deepEqual(normalizeDigestItems({ items: [item("bogus")] }), []);
+});
+
+test("collectDigestRefs: unions refs across items", () => {
+  const refs = collectDigestRefs([
+    item("progress"),
+    { tier: "failure", text: "x", refs: ["a", "b"] },
+    { tier: "external", text: "y", refs: ["b", "c"] },
+  ]);
+  assert.deepEqual(refs, ["a", "b", "c"]);
+});
+
+test("degradedDigest: empty slice → nothing happened; segment slice → progress items with refs", () => {
+  const window = [0, 1000];
+  const empty = degradedDigest({ granularity: selectGranularity(2 * DAY_MS, { gMinutes: G }), window, slice: [], generated: 1000 });
+  assert.equal(empty.items.length, 0);
+  assert.equal(validateDigest(empty), true);
+
+  const seg = degradedDigest({
+    granularity: selectGranularity(2 * HOUR_MS, { gMinutes: G }),
+    window,
+    slice: [{ id: "s1", oneLiner: "fixed auth" }, { id: "s2", oneLiner: "shipped parser" }],
+    generated: 1000,
+  });
+  assert.deepEqual(seg.items.map((i) => [i.tier, i.text, i.refs]), [
+    ["progress", "fixed auth", ["s1"]],
+    ["progress", "shipped parser", ["s2"]],
+  ]);
+});
+
+test("buildDigestContext: includes all input blocks and the legal-empty instruction", () => {
+  const ctx = buildDigestContext({
+    granularity: selectGranularity(2 * DAY_MS, { gMinutes: G }),
+    window: [1, 200],
+    slice: [{ id: "r1", level: "day", bullets: [{ text: "b", refs: ["r1"] }] }],
+    needsYou: [{ id: "c1", title: "approve the deploy" }],
+    factsChanged: [{ id: "f1", statement: "Q went live" }],
+    probes: ["db reachable"],
+  });
+  const joined = ctx.map((b) => b.text).join("\n");
+  assert.match(joined, /{"items":/);
+  assert.match(joined, /approve the deploy/);
+  assert.match(joined, /Q went live/);
+  assert.match(joined, /db reachable/);
+  assert.match(joined, /r1/);
+  assert.match(joined, /Blockers are NOT digest items/);
+});
+
+// ---------------------------------------------------------------------------
+// Timing fallback chain (§5.5, D9)
+// ---------------------------------------------------------------------------
+
+test("medianOf: returns the upper-median for even and odd lists", () => {
+  assert.equal(medianOf([3, 1, 2]), 2);
+  assert.equal(medianOf([1, 2, 3, 4]), 3);
+  assert.equal(medianOf([]), null);
+});
+
+test("nextOccurrence: schedules today if still future, else tomorrow", () => {
+  const day = startOfDay(REF);
+  // REF is midday → 07:00 is already past → next day 07:00
+  assert.equal(nextOccurrence(7 * HOUR_MS, REF), day + DAY_MS + 7 * HOUR_MS);
+  // REF is midday → 09:00 today already passed → tomorrow
+  assert.equal(nextOccurrence(DEFAULT_DIGEST_MS_INTO_DAY, REF), day + DAY_MS + DEFAULT_DIGEST_MS_INTO_DAY);
+});
+
+// A fixed reference: midday on a day, local-timezone-agnostic via startOfDay().
+const REF = (() => {
+  const d = new Date(2026, 0, 5, 12, 0, 0, 0);
+  return d.getTime();
+})();
+
+test("nextDigestMs: learned median used once ≥7 opens exist, outranking rising edge", () => {
+  const opens = new Array(7).fill(startOfDay(REF) + 7 * HOUR_MS); // all at 07:00
+  const out = nextDigestMs({ now: REF, learnedOpenTimes: opens, risingEdgeMsIntoDay: 5 * HOUR_MS });
+  assert.equal(out, startOfDay(REF) + DAY_MS + 7 * HOUR_MS);
+});
+
+test("nextDigestMs: learns only after the 7-open threshold", () => {
+  const few = new Array(6).fill(startOfDay(REF) + 7 * HOUR_MS);
+  const out = nextDigestMs({ now: REF, learnedOpenTimes: few, risingEdgeMsIntoDay: 5 * HOUR_MS });
+  // 6 < 7 opens → falls to rising-edge default (05:00 minus 30 min lead = 04:30)
+  assert.equal(out, startOfDay(REF) + DAY_MS + (5 * HOUR_MS - RISING_EDGE_LEAD_MS));
+});
+
+test("nextDigestMs: rising-edge default when no learned opens", () => {
+  const out = nextDigestMs({ now: REF, risingEdgeMsIntoDay: 7 * HOUR_MS });
+  assert.equal(out, startOfDay(REF) + DAY_MS + (7 * HOUR_MS - RISING_EDGE_LEAD_MS));
+});
+
+test("nextDigestMs: inferred-TZ 09:00 when confidence high (no dominant component)", () => {
+  const out = nextDigestMs({
+    now: REF,
+    inferredTz: { utcOffsetHours: 2, confidence: 0.9 },
+    boxUtcOffsetHours: 0,
+  });
+  // user-local 09:00 at UTC+2 = 11:00 UTC
+  assert.equal(out, startOfDay(REF) + DAY_MS + 11 * HOUR_MS);
+});
+
+test("nextDigestMs: falls to box-local 09:00 on low-confidence inferred TZ", () => {
+  const out = nextDigestMs({
+    now: REF,
+    inferredTz: { utcOffsetHours: 2, confidence: 0.1 },
+    boxUtcOffsetHours: 0,
+  });
+  assert.equal(out, startOfDay(REF) + DAY_MS + DEFAULT_DIGEST_MS_INTO_DAY);
+});
+
+test("nextDigestMs: falls to box-local 09:00 when nothing else applies", () => {
+  const out = nextDigestMs({ now: REF });
+  assert.equal(out, startOfDay(REF) + DAY_MS + DEFAULT_DIGEST_MS_INTO_DAY);
+});
+
+// ---------------------------------------------------------------------------
+// Engine: single-flight, persistence, degraded, digest-push
+// ---------------------------------------------------------------------------
+
+function makeDigestStore() {
+  const map = new Map();
+  return {
+    map,
+    dir: "/nonexistent/digests", // getLatest uses the real fs; override via fs in engine
+    save: async (id, data) => {
+      map.set(id, data);
+    },
+    load: async (id) => map.get(id) ?? { v: 1 },
+  };
+}
+
+async function waitFor(fn, timeout = 2000) {
+  const t0 = Date.now();
+  while (!fn()) {
+    if (Date.now() - t0 > timeout) throw new Error("waitFor timeout");
+    await new Promise((r) => setTimeout(r, 1));
+  }
+}
+
+function makeEngine(overrides = {}) {
+  const store = overrides.store ?? makeDigestStore();
+  const state = new Map();
+  const ledgerRows = [];
+  const engine = createCtoDigest({
+    now: () => REF,
+    presence: { get: () => ({ lastSeen: REF - 2 * DAY_MS, absenceDelta: 2 * DAY_MS }) },
+    getGMinutes: () => G,
+    digests: store,
+    ledger: { append: async (e) => ledgerRows.push(e) },
+    engineState: {
+      load: async () => {
+        const raw = state.get("v");
+        return raw === undefined ? {} : raw;
+      },
+      save: async (d) => {
+        state.set("v", d);
+      },
+    },
+    listOpenCards: async () => [],
+    factsChanged: async () => [],
+    probeFindings: async () => [],
+    loadSlice: async () => [],
+    getEnabled: async () => true,
+    digestPushEnabled: async () => false,
+    pushDigest: async () => {},
+    fs: {
+      readdir: async () => Array.from(store.map.keys()).map((k) => `${k}.json`),
+    },
+    ...overrides,
+  });
+  return { engine, store, state, ledgerRows };
+}
+
+test("generateDigest: single-flight — concurrent triggers join one generation", async () => {
+  let calls = 0;
+  let release;
+  const gate = new Promise((r) => (release = r));
+  const model = async () => {
+    calls += 1;
+    await gate;
+    return { text: JSON.stringify({ items: [{ tier: "progress", text: "shipped", refs: [] }] }) };
+  };
+  const { engine, store } = makeEngine({ runEphemeral: model });
+
+  const p1 = engine.generateDigest({ reason: "manual" });
+  assert.equal(engine.isGenerating(), true, "generation state published on start");
+  await waitFor(() => calls === 1, 2000); // first generation awaits the gate
+  const p2 = engine.generateDigest({ reason: "manual" }); // races the in-flight one
+  assert.equal(calls, 1, "second trigger must join the in-flight generation, not start a second");
+  release();
+  const [d1, d2] = await Promise.all([p1, p2]);
+  assert.equal(calls, 1, "exactly one model call across both triggers");
+  assert.equal(d1.generated, d2.generated);
+  assert.equal(engine.isGenerating(), false, "generation state cleared after completion");
+  assert.equal(store.map.size, 1, "exactly one digest persisted");
+  assert.equal(store.map.get(String(d1.generated)).items[0].text, "shipped");
+});
+
+test("generateDigest: model output is normalized (blockers stripped, sorted)", async () => {
+  const model = async () => ({
+    text: JSON.stringify({
+      items: [
+        { tier: "progress", text: "p", refs: ["a"] },
+        { tier: "blocker", text: "needs you", refs: [] },
+        { tier: "failure", text: "f", refs: ["b"] },
+      ],
+    }),
+  });
+  const { engine, store } = makeEngine({ runEphemeral: model });
+  const digest = await engine.generateDigest({ reason: "manual" });
+  assert.deepEqual(digest.items.map((i) => i.tier), ["failure", "progress"]);
+  assert.equal(digest.nothingHappened, false);
+  assert.equal(validateDigest(digest), true);
+});
+
+test("generateDigest: without a model call → degraded truthful digest, persisted", async () => {
+  const { engine, store } = makeEngine({ runEphemeral: null });
+  const digest = await engine.generateDigest({ reason: "manual" });
+  assert.ok(digest);
+  assert.equal(digest.items.length, 0);
+  assert.equal(digest.nothingHappened, true);
+  assert.equal(validateDigest(digest), true);
+  assert.equal(store.map.size, 1);
+  const latest = await engine.getLatest();
+  assert.equal(latest.generated, digest.generated);
+});
+
+test("getLatest: returns the newest valid digest from the store", async () => {
+  const { engine, store } = makeEngine({ runEphemeral: null });
+  await engine.generateDigest({ reason: "manual" });
+  const d = await engine.getLatest();
+  assert.equal(String(d.generated), Array.from(store.map.keys())[0]);
+  assert.equal(validateDigest(d), true);
+});
+
+test("recordOpen: persisted opens drive the scheduler's learned path", async () => {
+  const { engine } = makeEngine({ runEphemeral: null });
+  // <7 opens → no learned component → scheduler falls to the default
+  for (let i = 0; i < 6; i++) await engine.recordOpen();
+  const before = await engine.nextScheduledAt();
+  // ≥7 opens → learned median kicks in; still a valid future epoch
+  for (let i = 0; i < 2; i++) await engine.recordOpen();
+  const after = await engine.nextScheduledAt();
+  assert.ok(typeof before === "number" && before > REF);
+  assert.ok(typeof after === "number" && after > REF);
+});
+
+test("digest-push: fires only when the §10.5 toggle is on AND reason is scheduled", async () => {
+  let pushed = 0;
+  const { engine } = makeEngine({
+    runEphemeral: async () => ({ text: JSON.stringify({ items: [] }) }),
+    digestPushEnabled: async () => true,
+    pushDigest: async () => {
+      pushed += 1;
+    },
+  });
+  await engine.generateDigest({ reason: "manual" });
+  assert.equal(pushed, 0, "manual generation must not push");
+
+  await engine.generateDigest({ reason: "scheduled" });
+  assert.equal(pushed, 1, "scheduled generation pushes when toggle is on");
+});
+
+test("digest-push: toggle off → never pushes even on scheduled generation", async () => {
+  let pushed = 0;
+  const { engine } = makeEngine({
+    runEphemeral: async () => ({ text: JSON.stringify({ items: [] }) }),
+    digestPushEnabled: async () => false,
+    pushDigest: async () => {
+      pushed += 1;
+    },
+  });
+  await engine.generateDigest({ reason: "scheduled" });
+  assert.equal(pushed, 0);
+});

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -829,6 +829,9 @@ export function createCtoEngine(deps = {}) {
     get segmenter() {
       return segmenter;
     },
+    get cards() {
+      return cards;
+    },
     get rollupRunner() {
       return getRollupRunner();
     },

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -139,6 +139,7 @@ import * as cto from "./cto.mjs";
 import * as ctoEngine from "./ctoEngine.mjs";
 import { ledgerStore, engineStateStore } from "./ctoStores.mjs";
 import { runEphemeral, createEphemeralReaper } from "./ctoSessions.mjs";
+import { createCtoDigest, STALE_MS } from "./ctoDigest.mjs";
 import {
   parseSegmentSummaryText,
   validateSegmentSummary,
@@ -1814,8 +1815,81 @@ const adaptiveCto = ctoEngine.createCtoEngine({
   summarize: segmentSummarize,
   computeOneLiner: segmentOneLiner,
   reaper: ctoEphemeralReaper,
+  // BET-1383 (A9): fold the digest engine's generation-in-flight into the
+  // ctoState dot so the sidebar reflects live digest generation (§5.5). The
+  // digest engine is created below, so this reads it lazily through
+  // `adaptiveCtoDigest` (declared with `let` after the line that uses it).
+  getCounts: async () => {
+    const base = await ctoEngine.defaultGetCounts();
+    return {
+      ...base,
+      generationInFlight: adaptiveCtoDigest ? await adaptiveCtoDigest.isGenerating() : false,
+    };
+  },
 });
 adaptiveCto.start();
+
+// BET-1383 digest engine (A9, §5.4–5.5): composes the "here's what happened
+// while you were away" digest on view-open (when stale), on Digest-now, and on
+// the learned/rising-edge schedule. One mid-class `digest-compose` call at
+// generation time, gated on the §3.3 ephemeral rate gate like any other model
+// spend. Read seams: presence + fitted G from the engine, open needs-you cards
+// from its card machinery, the top-level ctoEnabled gate for the scheduler.
+// Generation state rides the bus as `{kind:"digestState"}`.
+let adaptiveCtoDigest = null;
+{
+  async function gatedDigestCompose(opts) {
+    const gate = await adaptiveCto.beginEphemeral();
+    if (!gate?.ok) return { ok: false, gated: true, error: gate?.error };
+    try {
+      return await runEphemeral({
+        ...opts,
+        deps: {
+          ...(opts?.deps || {}),
+          oc: { runEphemeralSession: oc.runSynchronousSession },
+          configGet: () => local.configGet(),
+        },
+      });
+    } finally {
+      gate.release?.();
+    }
+  }
+  adaptiveCtoDigest = createCtoDigest({
+    publish: (evt) => bus.publish(evt),
+    runEphemeral: gatedDigestCompose,
+    presence: { get: () => adaptiveCto.getPresence() },
+    getGMinutes: async () => adaptiveCto.segmenter?.getGMinutes?.() ?? null,
+    listOpenCards: async () => (await adaptiveCto.cards?.listOpen?.()) ?? [],
+    getEnabled: async () => {
+      try {
+        return (await local.configGet())?.ctoEnabled === true;
+      } catch {
+        return false;
+      }
+    },
+    // §5.5 digest push — gated on `ctoDigestPush` (default false; the "Push
+    // digest to phone" toggle UI is explicitly out of scope). After a
+    // SCHEDULED pre-generation it fires ONE informational-tier notification
+    // through the existing router (push.fireNotify) — which inherits the
+    // router's deferral semantics untouched (desktop-first ladder).
+    digestPushEnabled: async () => {
+      try {
+        return (await local.configGet())?.ctoDigestPush === true;
+      } catch {
+        return false;
+      }
+    },
+    pushDigest: async ({ digest }) => {
+      const items = Array.isArray(digest?.items) ? digest.items : [];
+      const head = items[0];
+      const body = items.length
+        ? `${items.length} item${items.length === 1 ? "" : "s"} while you were away${head?.text ? `: ${head.text}` : ""}`
+        : "Nothing important happened while you were away.";
+      await push.fireNotify({ title: "Your digest", message: body, urgent: false });
+    },
+  });
+  adaptiveCtoDigest.start();
+}
 
 // Watchdog (§13.3): checks engine liveness + ambient spend rate; > 2× expected
 // hourly burn → auto-thrifty, > 4× → auto-pause + blocker card. Spend is not
@@ -3761,6 +3835,60 @@ const handleRequest = async (req, res) => {
       if (req.method === "GET") {
         const state = await adaptiveCto.getState();
         respondJson(res, 200, state);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Adaptive CTO digest (BET-1383, A9) ----------
+  // §5.5 triggers are ONE bearer-gated endpoint, POST /api/cto/digest: the
+  // renderer calls it on view-open (regenerates when the stored digest is
+  // stale > STALE_MS) and on Digest-now (body {force: true} — always
+  // regenerate). Both hit the same single-flight lock keyed by absence-window
+  // id, so concurrent triggers join instead of doubling model spend. GET
+  // /api/cto/digest is the view read from `digests/` (last 30 retained by the
+  // A1 store sweep). POST /api/cto/digest/opened is §14.1 per-item
+  // open/expand instrumentation. Generation state rides `{kind:"digestState"}`
+  // and the ctoState `generationInFlight` fold (via the engine's getCounts).
+  if (path === "/api/cto/digest") {
+    try {
+      if (req.method === "GET") {
+        const digest = await adaptiveCtoDigest.getLatest();
+        respondJson(res, 200, { digest, stale: digest ? Date.now() - digest.generated > STALE_MS : true });
+        return;
+      }
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        await adaptiveCtoDigest.recordOpen();
+        const force = body?.force === true;
+        const latest = await adaptiveCtoDigest.getLatest();
+        const stale = !latest || Date.now() - latest.generated > STALE_MS;
+        if (force || stale) void adaptiveCtoDigest.generateDigest({ reason: "manual" }).catch(() => {});
+        respondJson(res, 200, { ...(await adaptiveCtoDigest.getState()), generated: force || stale });
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // §14.1 instrumentation: per-item open / expand (called by the UI).
+  if (path === "/api/cto/digest/opened") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        await adaptiveCtoDigest.recordItemEvent({
+          item: typeof body?.item === "string" ? body.item : null,
+          expand: body?.expand === true,
+          digestId: typeof body?.digestId === "string" ? body.digestId : null,
+        });
+        respondJson(res, 200, { ok: true });
         return;
       }
       respondJson(res, 405, { error: "method not allowed" });


### PR DESCRIPTION
## BET-1383 — Adaptive CTO digest engine (A9, spec §5.4–5.5)

Server-side digest engine only (UI is A10/A11). Creates the "here's what happened while you were away" digest.

### What's in the PR

- **`src/server/ctoDigest.mjs`** (new) — the digest engine:
  - **Granularity selection (§5.4)** from Δ = now − last_seen: Δ < G → live events; G ≤ Δ < 16h → segment summaries (work episodes); 16h ≤ Δ ≤ 3d → hour/day rollups (sessions/threads w/ outcomes); Δ > 3d → day rollups (themes + trends). Fixed policy constants 16h/3d; G from the A6 segmenter. Constant item budget 4–7 at every level.
  - **Composition (§5.5)** — one mid-class `digest-compose` model call, fed the Δ-appropriate slice + open needs-you items + facts changed in the window (+ an injectable tool-probe seam). Supersessions phrase as a subordinate `sub` clause ("this overturns X"), never a separate section. Output validated → deterministic tier-lattice sort (`blocker ≫ failure ≫ decision-made ≫ shipped/milestone ≫ external ≫ progress`, §5.5 — outranks any learned score). **Blockers are never digest items** (extracted into A8 needs-you cards; stripped + validator-refused, D15). **"Nothing important happened" is legal** (`{items: []}` renders the resting state). `deep` present for technical items.
  - **Single-flight** keyed by absence-window id — concurrent triggers join the in-flight generation; generation state published as `{kind:"digestState"}` and folded into the `ctoState` `generationInFlight`.
  - **Persistence** to `digests/` (A1 store; last 30 retained by the existing A1 sweep).
  - **Timing scheduler (§5.5/D9)** — learned median of digest-open times over trailing 14d once ≥7 opens (from the §14.1 ledger `cto.digest_opened` rows) → else 30 min before the §8.2 rising edge (injectable) → else 09:00 in the profile's inferred timezone when confidence high (injectable) → else 09:00 box-local. Scheduler poller pre-generates; single-fire per slot.
  - **Digest push** — after a *scheduled* pre-generation, fires ONE informational-tier notification via `push.fireNotify` (inherits the router's deferral semantics), gated on config `ctoDigestPush` (default false — the §10.5 toggle UI is explicitly out of scope, A12).
  - **§14.1 instrumentation rows** — `cto.digest_generated` / `cto.digest_opened` / `cto.digest_item_opened` / `cto.digest_expanded`.
- **`src/server/index.mjs`** — creates the digest engine (gated `digest-compose` via the engine's ephemeral rate gate; presence + fitted G + open needs-you cards + `ctoEnabled` seams), folds `generationInFlight` into `ctoState`, and exposes three bearer-gated routes:
  - `GET /api/cto/digest` — view read: latest digest from the store + stale flag.
  - `POST /api/cto/digest` — THE single trigger (view-open when stale > 30 min, and Digest-now with `{force:true}`); same endpoint, same single-flight.
  - `POST /api/cto/digest/opened` — §14.1 per-item open/expand instrumentation.
- **`src/server/ctoEngine.mjs`** — expose the `cards` instance (digest reads open needs-you items via it) — 3 lines.
- **`src/server/cto.mjs` + `docs/opencode-tools/cto.ts`** — add the P1 evidence read verbs **`read_rollups`** + **`read_ledger`** (§4.5/§13.4), wired into the CTO tool belt + the client tool list.
- **Tests**: `ctoDigest.test.mjs` (granularity boundary table, tier-lattice ordering, validation/parse/normalize, single-flight join, timing fallback chain, persistence/latest-from-store, degraded fallback, §14.1 instrumentation, digest-push gating, last-30 retention constant) + `cto.test.mjs` registry 17→19 + functional empty-store check for the new read verbs.

### Why new module vs. reuse (anti-spaghetti)
The digest is a distinct Read+Compose+Persist pipeline over the rollup/segment/card stores — no existing server module composes model output into an ordered digest. It reuses the stores (digests/rollups/segments/facts/ledger), the `digest-compose` task class via `runEphemeral`, the existing notification router, and the A1 retention sweep; nothing is duplicated.

### Out of scope (per decomposition)
UI rendering of the digest (A10/A11), the §10.5 toggle UI (A12), and the §8.2 rising-edge / profile-timezone sources are all injectable seams wired as no-op defaults until their issues land.

**Base: origin/main @ `069c6a2a`**

**Verification results:**
- PR branch (`multica/BET-1383-digest-engine` @ `53399bdc`):
  - typecheck: exit 0, errors: none
  - test: exit 0, 3128 pass / 0 fail / 0 skip
- Base (`main` @ `069c6a2a`): all existing tests unchanged (0 new failures)
- Conclusion: 0 new failures introduced; clean branch build.
