### PR TITLE
feat(server): Adaptive CTO blackboard store + gatekeeper (BET-1389)

### DIFF
--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -625,6 +625,19 @@ export function createCtoEngine(deps = {}) {
   // the cursor?" and hands the due windows to the rollup runner. Defaulting the
   // cursor to the CURRENT window start on first sight means the past is never
   // backfilled — a window only gets rolled up once it has actually closed.
+  // One shared ephemeral-rate wrapper (§3.3) used by both the rollup runner and
+  // the facts gatekeeper — every model-bound CTO step goes through the same
+  // per-session creation gate (D10's writer discipline).
+  const gatedRunEphemeral = async (data) => {
+    const gate = await beginEphemeral();
+    if (!gate.ok) return { ok: false, gated: true, error: gate.error };
+    try {
+      return runEphemeral ? await runEphemeral(data) : { ok: false, gated: true };
+    } finally {
+      gate.release?.();
+    }
+  };
+
   function getRollupRunner() {
     if (rollupRunner) return rollupRunner;
     if (deps.rollups) {
@@ -635,15 +648,6 @@ export function createCtoEngine(deps = {}) {
     // no model spend. Stay inert (and never touch the real stores) until a
     // runEphemeral is supplied.
     if (!runEphemeral) return null;
-    const gatedRunEphemeral = async (data) => {
-      const gate = await beginEphemeral();
-      if (!gate.ok) return { ok: false, gated: true, error: gate.error };
-      try {
-        return runEphemeral ? await runEphemeral(data) : { ok: false, gated: true };
-      } finally {
-        gate.release?.();
-      }
-    };
     rollupRunner = createRollupRunner({
       runEphemeral: gatedRunEphemeral,
       presenceCheck: () => engine.getPresence().state === "present",
@@ -664,15 +668,6 @@ export function createCtoEngine(deps = {}) {
       factsEngine = facts;
       return factsEngine;
     }
-    const gatedRunEphemeral = async (data) => {
-      const gate = await beginEphemeral();
-      if (!gate.ok) return { ok: false, gated: true, error: gate.error };
-      try {
-        return runEphemeral ? await runEphemeral(data) : { ok: false, gated: true };
-      } finally {
-        gate.release?.();
-      }
-    };
     factsEngine = createFactsEngine({
       engineState,
       ledger,

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -78,6 +78,7 @@ import {
   ROLLUP_LEVELS,
   windowFor as rollupWindowFor,
 } from "./ctoRollups.mjs";
+import { createFactsEngine, VERIFY_CYCLE_MS } from "./ctoFacts.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
@@ -100,6 +101,8 @@ export const CARD_CHECK_INTERVAL_MS = 60_000;
 // Work-segmentation G refit cadence (§5.1-d): monthly, on the box's own
 // inter-arrival times.
 export const G_REFIT_INTERVAL_MS = 30 * 24 * HOUR_MS;
+// §6.8 monthly half-life tuning cadence (a work timer, halted on pause).
+export const MONTHLY_TUNE_INTERVAL_MS = 30 * 24 * HOUR_MS;
 
 export const DOT = Object.freeze({
   ACTIVE: "active",
@@ -248,6 +251,14 @@ export function createCtoEngine(deps = {}) {
     // may inject a pre-built rollup runner instead.
     runEphemeral = null,
     rollups = null, // optional pre-built rollup runner override
+    // BET-1389 blackboard (§6): optional pre-built facts engine (else one is
+    // constructed below from engineState/ledger/runEphemeral/presence), plus
+    // the opportunistic checkable-verify + trace seams (null defaults → no
+    // verification surface, nothing gets stamped checkable).
+    facts = null,
+    factSurfaceExists = async () => false,
+    factVerify = async () => ({ ok: true }),
+    factResolveRef = null,
   } = deps;
 
   let disposed = false;
@@ -261,6 +272,9 @@ export function createCtoEngine(deps = {}) {
   let refitHandle = null;
   let lastPublishedSerialized = null;
   let rollupRunner = null;
+  let factsEngine = null;
+  let verifyHandle = null;
+  let tuneHandle = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
   // open, user prompt). The desktop heartbeat is read live via
@@ -364,6 +378,8 @@ export function createCtoEngine(deps = {}) {
       // §5.3 rollups — ambient background work, gated on enabled like any other.
       if (enabledNow) {
         await finalizeRollups();
+        // §6.2 blackboard: pump the per-project proposal queue (gatekeeper).
+        await pumpFacts();
       }
       await syncState();
     } catch {
@@ -384,6 +400,14 @@ export function createCtoEngine(deps = {}) {
       refitHandle.stop();
       refitHandle = null;
     }
+    if (verifyHandle) {
+      verifyHandle.stop();
+      verifyHandle = null;
+    }
+    if (tuneHandle) {
+      tuneHandle.stop();
+      tuneHandle = null;
+    }
   }
 
   function startTimers() {
@@ -403,6 +427,20 @@ export function createCtoEngine(deps = {}) {
       refitHandle = startPoller(
         () => segmenter.monthlyRefit().catch(() => {}),
         { intervalMs: G_REFIT_INTERVAL_MS, label: "cto-g-refit", immediate: false },
+      );
+    }
+    // §6.7 checkable-verify cycle (6h, no model cost) — a work timer.
+    if (!verifyHandle) {
+      verifyHandle = startPoller(
+        () => getFactsEngine().verifyDue().catch(() => {}),
+        { intervalMs: VERIFY_CYCLE_MS, label: "cto-facts-verify", immediate: false },
+      );
+    }
+    // §6.8 monthly half-life tuning — a work timer, halted on pause like the rest.
+    if (!tuneHandle) {
+      tuneHandle = startPoller(
+        () => getFactsEngine().recomputeHalfLives().catch(() => {}),
+        { intervalMs: MONTHLY_TUNE_INTERVAL_MS, label: "cto-facts-tune", immediate: false },
       );
     }
   }
@@ -610,8 +648,52 @@ export function createCtoEngine(deps = {}) {
       runEphemeral: gatedRunEphemeral,
       presenceCheck: () => engine.getPresence().state === "present",
       now,
+      // P2 (§6.2): rollup fact-sync submits blackboard proposals to the queue.
+      submitProposal: async (proposal) => (await getFactsEngine()).submitProposal(proposal),
     });
     return rollupRunner;
+  }
+
+  // Lazy-construct the blackboard facts engine (BET-1389 / §6). Mirrors the
+  // rollup-runner pattern: degraded (deterministic gatekeeper) when no model
+  // runner is wired, always useful, never throws. The engine owns the queue
+  // pump (per-project, on tick) + the 6h verify + monthly tuning timers.
+  function getFactsEngine() {
+    if (factsEngine) return factsEngine;
+    if (facts) {
+      factsEngine = facts;
+      return factsEngine;
+    }
+    const gatedRunEphemeral = async (data) => {
+      const gate = await beginEphemeral();
+      if (!gate.ok) return { ok: false, gated: true, error: gate.error };
+      try {
+        return runEphemeral ? await runEphemeral(data) : { ok: false, gated: true };
+      } finally {
+        gate.release?.();
+      }
+    };
+    factsEngine = createFactsEngine({
+      engineState,
+      ledger,
+      runEphemeral: runEphemeral ? gatedRunEphemeral : null,
+      now,
+      presenceCheck: () => engine.getPresence().state === "present",
+      surfaceExists: factSurfaceExists,
+      verify: factVerify,
+      resolveRef: factResolveRef,
+    });
+    return factsEngine;
+  }
+
+  // Pump the blackboard proposal queue (per-project, single writer). Driven
+  // from the tick when enabled; best-effort, never throws into the poller.
+  async function pumpFacts() {
+    try {
+      await getFactsEngine().pump();
+    } catch {
+      /* facts are best-effort — never take the engine down */
+    }
   }
 
   // Fold any closed windows into rollups (respecting enabled/paused via the
@@ -831,6 +913,9 @@ export function createCtoEngine(deps = {}) {
     },
     get rollupRunner() {
       return getRollupRunner();
+    },
+    get facts() {
+      return getFactsEngine();
     },
   };
 

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -11,13 +11,14 @@ import {
   RATE_LIMITS,
 } from "./ctoEngine.mjs";
 import { createSegmenter } from "./ctoSegments.mjs";
+import { createFactsEngine } from "./ctoFacts.mjs";
 import { windowFor } from "./ctoRollups.mjs";
 
 // Build a fully-injected engine harness: no real fs, no real stores, a fake
 // clock we can advance. Everything the engine touches goes through these
 // seams, so the tests assert pure behavior. `clock` is shared so the watchdog
 // and the engine observe the same time.
-function makeHarness({ ctoEnabled = false, counts = {}, rollups } = {}) {
+function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts } = {}) {
   const clock = { ms: 1_000_000 };
   const now = () => clock.ms;
   const ledgerRows = [];
@@ -70,6 +71,7 @@ function makeHarness({ ctoEnabled = false, counts = {}, rollups } = {}) {
       ...counts,
     }),
     ...(rollups ? { rollups } : {}),
+    ...(facts ? { facts } : {}),
   });
 
   return {
@@ -529,4 +531,35 @@ test("rollups do not run while paused", async () => {
   const before = received.length;
   await h.engine.tick();
   assert.equal(received.length, before);
+});
+
+
+// ---------------------------------------------------------------------------
+// BET-1389 blackboard wiring: the engine exposes a facts engine and pumps the
+// proposal queue on tick. Uses an injected in-memory facts engine so no real
+// store is touched.
+// ---------------------------------------------------------------------------
+
+test("engine exposes .facts and pumps proposals on tick (%40 enabled)", async () => {
+  const inmemory = new Map();
+  const fstate = { v: 1 };
+  const facts = createFactsEngine({
+    engineState: {
+      load: async () => ({ ...fstate }),
+      save: async (s) => {
+        Object.keys(fstate).forEach((k) => delete fstate[k]);
+        Object.assign(fstate, s);
+      },
+    },
+    facts: { load: async (p) => inmemory.get(p) ?? { v: 1, facts: [] }, save: async (p, d) => inmemory.set(p, d), dir: "x" },
+    archive: { load: async (p) => inmemory.get("a" + p) ?? { v: 1, entries: [] }, save: async (p, d) => inmemory.set("a" + p, d) },
+  });
+  const harness = makeHarness({ ctoEnabled: true, facts });
+  // Enable + a proposal for alpha, then a tick should drain it into the store.
+  await harness.engine.resume();
+  await facts.submitProposal({ proposalId: "ep", project: "alpha", kind: "status", statement: "engine wired", refs: ["r1"], sender: "cto" });
+  assert.equal(harness.engine.facts, facts);
+  await harness.engine.tick();
+  const saved = inmemory.get("alpha")?.facts ?? [];
+  assert.equal(saved.filter((f) => !f.superseded_by).length, 1);
 });

--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -1,0 +1,752 @@
+// src/server/ctoFacts.mjs — the Adaptive CTO Blackboard store + gatekeeper
+// (BET-1389 / spec §6.1–§6.8).
+//
+// The blackboard is a per-project collection of durable *facts* — short,
+// evidence-backed statements maintained by the CTO. Facts are created through
+// a **collaborative pipeline** (D10): any producer (an agent session, the CTO
+// itself, the user, or a rollup sync) submits a *proposal* to a per-project
+// FIFO queue (D3 — single writer per project), and a **gatekeeper** resolves
+// it into add/update/supersede/merge/reject. Nothing writes facts directly
+// except the gatekeeper — that single-writer rule is the whole point.
+//
+// Determinism + testability: the module is dependency-injected like the other
+// server engines. Pure functions (retention math, queue idempotency, the
+// head-of-chain rule, checkable pattern matching, half-life tuning) are what
+// the tests pin; `createFactsEngine` wires them to real stores and model I/O.
+// All model-needing steps go through the injected `runEphemeral` (`gatekeeper`
+// task class, §12.3) and degrade deterministically when no model runner is
+// present — the engine keeps working with a degraded gatekeeper, no model cost.
+//
+// Storage:
+//   - facts/<project>.json         — active facts ({v, facts:[…]}), cap 50.
+//   - facts-archive/<project>.json — superseded/displaced facts ({v, entries}),
+//                                    capped at 10× (ctoStores.mjs §6.3).
+//   - engine-state.json            — per-project pending proposal queue + the
+//                                    applied-proposal idempotency record, sender
+//                                    reliability Beta counters, checkable verify
+//                                    bookkeeping, and half-life tuning state.
+
+import { readdir } from "node:fs/promises";
+import { createHash } from "node:crypto";
+import { factsStore, factsArchiveStore, ledgerStore, engineStateStore } from "./ctoStores.mjs";
+
+export const FACT_VERSION = 1;
+
+export const KINDS = Object.freeze([
+  "status",
+  "blocker",
+  "decision",
+  "theory",
+  "invariant",
+  "anomaly",
+]);
+
+export const CAP_ACTIVE = 50;
+export const HOUR_MS = 3_600_000;
+export const DAY_MS = 24 * HOUR_MS;
+export const WEEK_MS = 7 * DAY_MS;
+
+// Default per-kind half-lives (§6.4, D11), in HOURS. Tuned monthly (§6.8).
+//   blocker -> no decay while an unresolved ref exists (holds until resolved).
+export const HALF_LIVES_POLICY = Object.freeze({
+  status: 3 * 24,
+  blocker: null,
+  decision: 180 * 24,
+  theory: 21 * 24,
+  invariant: 180 * 24,
+  anomaly: 7 * 24,
+});
+
+export const KIND_WEIGHTS = Object.freeze({
+  status: 1,
+  blocker: 1,
+  decision: 1,
+  theory: 1,
+  invariant: 1,
+  anomaly: 1,
+});
+
+export const TUNING_CLAMP = 0.5;
+export const VERIFY_CYCLE_MS = 6 * HOUR_MS;
+export const OVERTURN_WINDOW_MS = 48 * HOUR_MS;
+
+const STATEMENT_LIMIT = 200;
+
+export function senderKey(sender) {
+  if (sender && typeof sender === "object" && sender.sessionID) {
+    return `session:${sender.sessionID}`;
+  }
+  if (typeof sender === "string" && sender.length > 0) return sender;
+  return "unknown";
+}
+
+export function validateFact(f) {
+  if (!f || typeof f !== "object") return false;
+  if (f.v !== FACT_VERSION) return false;
+  if (!KINDS.includes(f.kind)) return false;
+  if (typeof f.statement !== "string" || f.statement.length === 0) return false;
+  if (f.statement.length > STATEMENT_LIMIT) return false;
+  if (!Array.isArray(f.refs) || f.refs.length === 0) return false;
+  if (!f.refs.every((r) => typeof r === "string" && r.length > 0)) return false;
+  if (typeof f.confidence !== "number" || f.confidence < 0 || f.confidence > 1) return false;
+  if (typeof f.id !== "string" || f.id.length === 0) return false;
+  return true;
+}
+
+export function newFactId({ project, statement, refs, nowMs }) {
+  return (
+    "cto:" +
+    createHash("sha1")
+      .update(`${project}|${statement}|${Array.isArray(refs) ? refs.join(",") : ""}|${nowMs ?? 0}`)
+      .digest("hex")
+      .slice(0, 12)
+  );
+}
+
+export function isActiveFact(f) {
+  return !!f && !f.superseded_by;
+}
+
+export function liveHeadOf(fact, activeById) {
+  let cur = fact;
+  let guard = 0;
+  while (cur && cur.superseded_by && activeById?.[cur.superseded_by] && guard < 1024) {
+    cur = activeById[cur.superseded_by];
+    guard += 1;
+  }
+  return cur;
+}
+
+export function archiveEntry(fact, nowMs) {
+  return { ...fact, ts: nowMs };
+}
+
+export function senderReliability({ confirmed = 0, rejected = 0 } = {}) {
+  return (confirmed + 1) / (confirmed + rejected + 2);
+}
+
+export function retentionOf(fact, { nowMs, halfLives = HALF_LIVES_POLICY, weights = KIND_WEIGHTS, reliability = 1 } = {}) {
+  if (!fact) return 0;
+  const t = nowMs ?? Date.now();
+  if (fact.valid_until != null && t >= fact.valid_until) return 0;
+  const weight = weights[fact.kind] ?? 1;
+  const lastAccess = fact.last_accessed ?? fact.created ?? t;
+  const hours = Math.max(0, (t - lastAccess) / HOUR_MS);
+  const hl = halfLives?.[fact.kind] ?? null;
+  let decay;
+  if (fact.kind === "blocker" && Array.isArray(fact.refs) && fact.refs.length > 0) {
+    decay = 1;
+  } else if (hl == null || hl <= 0) {
+    decay = 1;
+  } else {
+    decay = Math.pow(0.5, hours / hl);
+  }
+  const access = 1 + Math.log(1 + (fact.access_count ?? 0));
+  return weight * decay * access * reliability;
+}
+
+export function lowestRetention(activeFacts, opts) {
+  if (!Array.isArray(activeFacts)) return { fact: null, score: null };
+  let best = null;
+  let bestScore = null;
+  for (const f of activeFacts) {
+    if (!isActiveFact(f)) continue;
+    const s = retentionOf(f, opts);
+    if (bestScore == null || s < bestScore) {
+      best = f;
+      bestScore = s;
+    }
+  }
+  return { fact: best, score: bestScore };
+}
+
+export function validateProposal(p) {
+  if (!p || typeof p !== "object") return false;
+  if (typeof p.proposalId !== "string" || p.proposalId.length === 0) return false;
+  if (typeof p.project !== "string" || p.project.length === 0) return false;
+  if (!KINDS.includes(p.kind)) return false;
+  if (typeof p.statement !== "string" || p.statement.length === 0) return false;
+  if (p.statement.length > STATEMENT_LIMIT) return false;
+  if (!Array.isArray(p.refs)) return false;
+  return true;
+}
+
+export function enqueueProposal(state, proposal) {
+  if (!validateProposal(proposal)) return { state, added: false, reason: "invalid" };
+  const s = state ?? {};
+  const queue = { ...(s.factQueue ?? {}) };
+  const applied = { ...(s.appliedProposals ?? {}) };
+  if (applied[proposal.proposalId]) return { state: s, added: false, reason: "already-applied" };
+  const proj = proposal.project;
+  const list = Array.isArray(queue[proj]) ? queue[proj].slice() : [];
+  if (list.some((q) => q.proposalId === proposal.proposalId)) {
+    return { state: s, added: false, reason: "already-queued" };
+  }
+  list.push(proposal);
+  queue[proj] = list;
+  return { state: { ...s, factQueue: queue, appliedProposals: applied }, added: true };
+}
+
+export function popProposal(state, project) {
+  const queue = { ...(state?.factQueue ?? {}) };
+  const list = Array.isArray(queue[project]) ? queue[project].slice() : [];
+  if (list.length === 0) return { state, proposal: null };
+  const [proposal, ...rest] = list;
+  const next = { ...(state ?? {}), factQueue: { ...queue, [project]: rest } };
+  return { state: next, proposal };
+}
+
+export function markApplied(state, proposalId, outcome) {
+  const s = state ?? {};
+  const applied = { ...(s.appliedProposals ?? {}) };
+  applied[proposalId] = outcome ?? { action: "processed" };
+  return { ...s, appliedProposals: applied };
+}
+
+export async function gatekeeperPrecheck(proposal, activeFacts, { resolveRef = null, traceRefs = true } = {}) {
+  if (!Array.isArray(proposal.refs) || proposal.refs.length === 0) {
+    return { ok: false, reason: "zero refs" };
+  }
+  const targetId = proposal.supersedes == null ? null : String(proposal.supersedes);
+  if (targetId) {
+    const idx = new Map((activeFacts ?? []).map((f) => [f.id, f]));
+    const target = idx.get(targetId);
+    if (!target) return { ok: false, reason: "supersede target not found", targetId };
+    if (!isActiveFact(target)) {
+      const head = liveHeadOf(target, Object.fromEntries(idx));
+      return { ok: false, reason: "supersede target is not the live head", targetId: head?.id ?? targetId };
+    }
+  }
+  if (resolveRef && traceRefs) {
+    for (const ref of proposal.refs) {
+      let ok = false;
+      try {
+        ok = (await resolveRef(ref)) === true;
+      } catch {
+        ok = false;
+      }
+      if (!ok) return { ok: false, reason: "unresolved ref", ref };
+    }
+  }
+  return { ok: true, targetId };
+}
+
+export function buildGatekeeperContext(proposal, activeFacts) {
+  const heads = (activeFacts ?? [])
+    .filter(isActiveFact)
+    .slice(0, 12)
+    .map(
+      (f) =>
+        `- [${f.id}] (${f.kind}, conf ${f.confidence}) ${f.statement} ` +
+        `refs:[${(f.refs ?? []).join(",")}]`,
+    )
+    .join("\n");
+  return [
+    {
+      priority: "high",
+      text:
+        `You are the blackboard gatekeeper. Decide how to file this proposal from sender "${senderKey(proposal.sender)}". ` +
+        `Return ONE line of JSON: {"action":"add"|"update"|"supersede"|"merge"|"reject","targetId":"<id or null>","reason":"<short>"}. ` +
+        `"supersede" replaces a head fact (old stays, chained); "merge" unions refs into an existing fact; ` +
+        `"update" refines an existing fact in place; "reject" refuses. Never invent refs.`,
+    },
+    {
+      priority: "high",
+      text: `Proposal kind=${proposal.kind} conf=${proposal.confidence ?? 0.5} valid_until=${proposal.valid_until ?? "none"}\n${proposal.statement}\nrefs:[${(proposal.refs ?? []).join(",")}]`,
+    },
+    { priority: "medium", text: `Existing LIVE facts:\n${heads || "(none)"}` },
+  ];
+}
+
+export function parseGatekeeperDecision(text) {
+  if (typeof text !== "string") return null;
+  const m = text.match(/\{[\s\S]*?\}/);
+  if (!m) return null;
+  try {
+    const parsed = JSON.parse(m[0]);
+    const action = ["add", "update", "supersede", "merge", "reject"].includes(parsed.action)
+      ? parsed.action
+      : null;
+    if (!action) return null;
+    return {
+      action,
+      targetId: parsed.targetId == null ? null : String(parsed.targetId),
+      reason: typeof parsed.reason === "string" ? parsed.reason : "",
+    };
+  } catch {
+    return null;
+  }
+}
+
+export function validateDecision(decision, activeFacts, proposal) {
+  const targetId = decision?.targetId ? String(decision.targetId) : null;
+  const target =
+    targetId && Array.isArray(activeFacts) ? activeFacts.find((f) => f.id === targetId && isActiveFact(f)) : null;
+  if (decision?.action === "add" || decision?.action === "reject") {
+    return { action: decision.action, targetId: null, reason: decision.reason ?? "" };
+  }
+  if (target) return { action: decision.action, targetId: target.id, reason: decision.reason ?? "" };
+  const proposed = proposal.supersedes ? String(proposal.supersedes) : null;
+  const proposedTarget =
+    proposed && Array.isArray(activeFacts) ? activeFacts.find((f) => f.id === proposed && isActiveFact(f)) : null;
+  if (proposedTarget) {
+    return { action: "supersede", targetId: proposedTarget.id, reason: "degraded: invalid model target" };
+  }
+  return { action: "add", targetId: null, reason: "degraded: no valid target" };
+}
+
+export function applyResolution(proposal, decision, activeFacts, { nowMs = Date.now() } = {}) {
+  const now = nowMs;
+  const facts = Array.isArray(activeFacts) ? activeFacts.slice() : [];
+  const action = decision?.action ?? "add";
+  const targetId = decision?.targetId ? String(decision.targetId) : null;
+  const targetIndex = facts.findIndex((f) => f.id === targetId && isActiveFact(f));
+  const target = targetIndex >= 0 ? facts[targetIndex] : null;
+
+  if (action === "reject") return { action, reason: decision?.reason ?? "rejected", facts };
+  if (action === "update" && target) {
+    facts[targetIndex] = {
+      ...target,
+      statement: proposal.statement ?? target.statement,
+      confidence: proposal.confidence ?? target.confidence,
+      refs: Array.from(new Set([...(target.refs ?? []), ...(proposal.refs ?? [])])),
+      last_accessed: now,
+      access_count: (target.access_count ?? 0) + 1,
+    };
+    return { action, targetId: target.id, facts };
+  }
+  if (action === "merge" && target) {
+    facts[targetIndex] = {
+      ...target,
+      refs: Array.from(new Set([...(target.refs ?? []), ...(proposal.refs ?? [])])),
+      confidence: Math.max(target.confidence ?? 0, proposal.confidence ?? 0),
+      last_accessed: now,
+      access_count: (target.access_count ?? 0) + 1,
+    };
+    return { action, targetId: target.id, facts };
+  }
+
+  const id = newFactId({ project: proposal.project, statement: proposal.statement, refs: proposal.refs, nowMs: now });
+  const newFact = {
+    v: FACT_VERSION,
+    id,
+    kind: proposal.kind,
+    statement: proposal.statement,
+    refs: proposal.refs.slice(),
+    confidence: proposal.confidence ?? 0.5,
+    created: proposal.created ?? now,
+    last_accessed: now,
+    access_count: 0,
+    sender: proposal.sender,
+  };
+  if (proposal.valid_until != null) newFact.valid_until = proposal.valid_until;
+  if (action === "supersede" && target) {
+    const ti = facts.findIndex((f) => f.id === target.id);
+    if (ti >= 0) facts[ti] = { ...facts[ti], superseded_by: id };
+  }
+  facts.push(newFact);
+  return { action, facts, factId: id, targetId: target ? target.id : null };
+}
+
+export function enforceCap(activeFacts, { cap = CAP_ACTIVE, nowMs, halfLives, weights } = {}) {
+  const facts = Array.isArray(activeFacts) ? activeFacts.slice() : [];
+  const displaced = [];
+  while (facts.filter(isActiveFact).length > cap) {
+    const low = lowestRetention(facts, { nowMs, halfLives, weights });
+    if (!low.fact) break;
+    const i = facts.findIndex((f) => f.id === low.fact.id);
+    if (i < 0) break;
+    displaced.push(facts.splice(i, 1)[0]);
+  }
+  return { facts, displaced };
+}
+
+export function matchCheckable(statement) {
+  const s = String(statement ?? "");
+  const branch = s.match(/\bbranch\s+([A-Za-z0-9_\-.\/]+)\b/i);
+  if (branch) return { kind: "branch", surface: "git", probe: branch[1] };
+  const ci = s.match(/\bCI\b[\s\S]*?\b(green|passing|passed|failed|failing|broken)\b/i);
+  if (ci) return { kind: "ci", surface: "ci", probe: ci[1].toLowerCase() };
+  const issue = s.match(/\b([A-Z][A-Z0-9]+-\d+)\b/);
+  if (issue) return { kind: "issue", surface: "issue", probe: issue[1] };
+  const ver = s.match(/\bversion\s+(\d+(?:\.\d+){1,3})\b/i);
+  if (ver) return { kind: "version", surface: "version", probe: ver[1] };
+  return null;
+}
+
+export async function maybeStampCheckable(fact, { surfaceExists = async () => false } = {}) {
+  if (fact?.checkable) return fact;
+  const match = matchCheckable(fact?.statement);
+  if (!match || typeof surfaceExists !== "function") return fact;
+  let exists = false;
+  try {
+    exists = (await surfaceExists(match.surface)) === true;
+  } catch {
+    exists = false;
+  }
+  if (!exists) return fact;
+  return { ...fact, checkable: { probe: match.probe, last_checked: 0, result: null } };
+}
+
+export function median(arr) {
+  const a = Array.isArray(arr) ? arr.slice().sort((x, y) => x - y) : [];
+  if (a.length === 0) return null;
+  const mid = Math.floor(a.length / 2);
+  return a.length % 2 ? a[mid] : (a[mid - 1] + a[mid]) / 2;
+}
+
+export function recomputeHalfLives(entries, { halfLivesPolicy = HALF_LIVES_POLICY, clamp = TUNING_CLAMP } = {}) {
+  const out = {};
+  if (!Array.isArray(entries)) return out;
+  for (const kind of KINDS) {
+    const base = halfLivesPolicy[kind];
+    if (base == null || base <= 0) continue;
+    const hrs = entries
+      .filter((e) => e && e.kind === kind && typeof e.hours === "number")
+      .map((e) => e.hours);
+    const med = median(hrs);
+    if (med == null) continue;
+    const lo = base * (1 - clamp);
+    const hi = base * (1 + clamp);
+    out[kind] = Math.max(1, Math.min(hi, Math.max(lo, med)));
+  }
+  return out;
+}
+
+export function createFactsEngine(deps = {}) {
+  const {
+    facts = factsStore,
+    archive = factsArchiveStore,
+    engineState = engineStateStore,
+    ledger = ledgerStore,
+    runEphemeral = null,
+    now = () => Date.now(),
+    presenceCheck = async () => false,
+    surfaceExists = async () => false,
+    verify = async () => ({ ok: true }),
+    resolveRef = null,
+    traceRefs = true,
+    halfLives = null,
+    listProjects = null,
+  } = deps;
+
+  let disposed = false;
+
+  async function log(entry) {
+    try {
+      await ledger.append({ actor: "cto", ts: now(), ...entry });
+    } catch {}
+  }
+
+  async function loadState() {
+    try {
+      const s = await engineState.load();
+      return s && typeof s === "object" ? s : {};
+    } catch {
+      return {};
+    }
+  }
+  async function saveState(s) {
+    try {
+      await engineState.save({ ...s, v: 1 });
+    } catch {}
+  }
+
+  function currentHalfLives(tuning) {
+    const tuned = tuning?.halfLives && Object.keys(tuning.halfLives).length ? tuning.halfLives : null;
+    return { ...HALF_LIVES_POLICY, ...(halfLives ?? tuned ?? {}) };
+  }
+
+  async function loadFacts(project) {
+    try {
+      const p = await facts.load(project);
+      return Array.isArray(p?.facts) ? p.facts : [];
+    } catch {
+      return [];
+    }
+  }
+  async function saveFacts(project, factArray) {
+    await facts.save(project, { v: 1, facts: factArray });
+  }
+  async function loadArchive(project) {
+    try {
+      const p = await archive.load(project);
+      return Array.isArray(p?.entries) ? p.entries : [];
+    } catch {
+      return [];
+    }
+  }
+  async function saveArchive(project, entries) {
+    await archive.save(project, { v: 1, entries });
+  }
+
+  async function listKnownProjects() {
+    if (typeof listProjects === "function") {
+      try {
+        const p = await listProjects();
+        return Array.isArray(p) ? p : [];
+      } catch {
+        return [];
+      }
+    }
+    try {
+      const dir = facts.dir;
+      if (typeof dir !== "string" || !dir) return [];
+      const names = await readdir(dir);
+      return names.filter((n) => n.endsWith(".json")).map((n) => n.slice(0, -".json".length));
+    } catch {
+      return [];
+    }
+  }
+
+  async function bumpReliability(sender, delta) {
+    const key = senderKey(sender);
+    if (!key) return;
+    const state = await loadState();
+    const rel = { ...(state.factReliability ?? {}) };
+    const cur = { confirmed: 0, rejected: 0, ...(rel[key] ?? {}) };
+    if (delta.confirmed) cur.confirmed += delta.confirmed;
+    if (delta.rejected) cur.rejected += delta.rejected;
+    rel[key] = cur;
+    await saveState({ ...state, factReliability: rel });
+  }
+
+  async function submitProposal(raw) {
+    const proposal = { created: now(), sender: "cto", ...raw };
+    if (!validateProposal(proposal)) return { ok: false, error: "invalid proposal" };
+    const state = await loadState();
+    const res = enqueueProposal(state, proposal);
+    if (res.added) await saveState(res.state);
+    return { ok: res.added, added: res.added, reason: res.reason, proposalId: proposal.proposalId };
+  }
+
+  async function resolveOne(proposal, activeFacts) {
+    const pre = await gatekeeperPrecheck(proposal, activeFacts, { resolveRef, traceRefs });
+    if (!pre.ok) return { action: "reject", reason: pre.reason, reject: true };
+    let decision = null;
+    if (runEphemeral) {
+      try {
+        const res = await runEphemeral({
+          taskClass: "gatekeeper",
+          context: buildGatekeeperContext(proposal, activeFacts),
+        });
+        decision = parseGatekeeperDecision(typeof res?.text === "string" ? res.text : null);
+      } catch {
+        decision = null;
+      }
+    }
+    if (!decision) {
+      decision = {
+        action: proposal.supersedes ? "supersede" : "add",
+        targetId: proposal.supersedes ?? null,
+        reason: "degraded",
+      };
+    }
+    const validated = validateDecision(decision, activeFacts, proposal);
+    const applied = applyResolution(proposal, validated, activeFacts, { nowMs: now() });
+    if (applied.action === "reject") return { ...applied, reject: true };
+    return applied;
+  }
+
+  function mergeReliability(st, key, delta) {
+    const rel = { ...(st.factReliability ?? {}) };
+    const cur = { confirmed: 0, rejected: 0, ...(rel[key] ?? {}) };
+    cur.confirmed += delta.confirmed ?? 0;
+    cur.rejected += delta.rejected ?? 0;
+    rel[key] = cur;
+    return { ...st, factReliability: rel };
+  }
+
+  async function pump(project) {
+    if (disposed) return { processed: 0, byAction: {} };
+    let state = await loadState();
+    const tally = { processed: 0, byAction: {} };
+    const relDeltas = new Map(); // senderKey -> {confirmed, rejected}
+    const noteRel = (sender, delta) => {
+      const key = senderKey(sender);
+      if (!key) return;
+      const e = relDeltas.get(key) ?? { confirmed: 0, rejected: 0 };
+      relDeltas.set(key, {
+        confirmed: e.confirmed + (delta.confirmed ?? 0),
+        rejected: e.rejected + (delta.rejected ?? 0),
+      });
+    };
+    const projects = project ? [project] : Object.keys(state.factQueue ?? {});
+    for (const proj of projects) {
+      const halfLivesNow = currentHalfLives(state.factTuning ?? {});
+      for (;;) {
+        const pop = popProposal(state, proj);
+        if (!pop.proposal) break;
+        const proposal = pop.proposal;
+        state = pop.state;
+        if (state.appliedProposals?.[proposal.proposalId]) continue;
+        let activeFacts = await loadFacts(proj);
+        const result = await resolveOne(proposal, activeFacts);
+        let outcome;
+        if (result.reject) {
+          outcome = { action: "reject", reason: result.reason };
+          noteRel(proposal.sender, { rejected: 1 });
+          await log({ kind: "cto.fact_reject", project: proj, proposalId: proposal.proposalId, reason: result.reason });
+        } else {
+          const capRes = enforceCap(result.facts, { cap: CAP_ACTIVE, nowMs: now(), halfLives: halfLivesNow });
+          if (capRes.displaced.length > 0) {
+            const entries = await loadArchive(proj);
+            await saveArchive(proj, [...entries, ...capRes.displaced.map((f) => archiveEntry(f, now()))]);
+            await log({ kind: "cto.fact_displace", project: proj, count: capRes.displaced.length });
+          }
+          activeFacts = capRes.facts;
+          const newId = result.factId;
+          const fi = newId ? activeFacts.findIndex((f) => f.id === newId) : -1;
+          if (fi >= 0) {
+            const stamped = await maybeStampCheckable(activeFacts[fi], { surfaceExists });
+            if (stamped !== activeFacts[fi]) activeFacts[fi] = stamped;
+          }
+          await saveFacts(proj, activeFacts);
+          outcome = { action: result.action, targetId: result.targetId, factId: result.factId };
+          if (result.action === "supersede" && result.targetId) {
+            const present = await presenceCheck();
+            await log({ kind: "cto.fact_supersede", project: proj, superseded: result.targetId, replacement: result.factId, present });
+            const old = (await loadFacts(proj)).find((x) => x.id === result.targetId);
+            if (old && typeof old.created === "number") {
+              const st = await loadState();
+              const lifespans = [...(st.factTuning?.lifespans ?? []), { kind: proposal.kind, hours: (now() - old.created) / HOUR_MS }];
+              await saveState({ ...st, factTuning: { ...(st.factTuning ?? {}), lifespans } });
+            }
+            if (old && now() - (old.created ?? 0) < OVERTURN_WINDOW_MS) {
+              await bumpReliability(old.sender, { rejected: 1 });
+            }
+          }
+        }
+        state = markApplied(state, proposal.proposalId, outcome);
+        tally.processed += 1;
+        tally.byAction[outcome.action] = (tally.byAction[outcome.action] ?? 0) + 1;
+      }
+    }
+    for (const [key, delta] of relDeltas) {
+      state = mergeReliability(state, key, delta);
+    }
+    await saveState(state);
+    return tally;
+  }
+
+  async function touchFacts({ project, ids }) {
+    if (!Array.isArray(ids) || ids.length === 0) return { touched: 0 };
+    const projects = project ? [project] : await listKnownProjects();
+    let touched = 0;
+    for (const proj of projects) {
+      const active = await loadFacts(proj);
+      let changed = false;
+      const byId = new Set(ids);
+      for (let i = 0; i < active.length; i++) {
+        if (byId.has(active[i]?.id) && isActiveFact(active[i])) {
+          active[i] = { ...active[i], last_accessed: now(), access_count: (active[i].access_count ?? 0) + 1 };
+          changed = true;
+          touched += 1;
+        }
+      }
+      if (changed) await saveFacts(proj, active);
+    }
+    return { touched };
+  }
+
+  async function verifyDue() {
+    if (disposed) return { checked: 0, superseded: 0 };
+    const t = now();
+    let checked = 0;
+    let superseded = 0;
+    let seq = 0;
+    for (const proj of await listKnownProjects()) {
+      let working = await loadFacts(proj);
+      let changed = false;
+      const failed = [];
+      for (let i = 0; i < working.length; i++) {
+        const f = working[i];
+        if (!f?.checkable || !isActiveFact(f)) continue;
+        if (t - (f.checkable.last_checked ?? 0) < VERIFY_CYCLE_MS) continue;
+        let ok = false;
+        let result = null;
+        try {
+          const r = await verify({ surface: matchCheckable(f.statement)?.surface, probe: f.checkable.probe });
+          ok = r?.ok === true;
+          result = r?.result ?? null;
+        } catch {
+          ok = false;
+          result = "verify error";
+        }
+        checked += 1;
+        working[i] = { ...f, checkable: { ...f.checkable, last_checked: t, result: ok ? "ok" : "failed" } };
+        failed.push({ f: working[i], ok });
+        if (ok) changed = true;
+      }
+      for (const { f, ok } of failed) {
+        if (ok) continue;
+        seq += 1;
+        const res = await resolveOne(
+          {
+            proposalId: `verify:${f.id}:${t}:${seq}`,
+            project: proj,
+            kind: f.kind,
+            statement: f.statement,
+            refs: f.refs,
+            sender: "cto",
+            confidence: Math.max(0.05, (f.confidence ?? 0.5) * 0.4),
+            supersedes: f.id,
+          },
+          working,
+        );
+        const idxOld = working.findIndex((x) => x.id === f.id);
+        if (idxOld >= 0) {
+          working[idxOld] = { ...working[idxOld], checkable: { ...(working[idxOld].checkable ?? {}), last_checked: t, result: "failed" } };
+        }
+        if (!res.reject && res.action === "supersede" && res.facts) {
+          const present = await presenceCheck();
+          await log({ kind: "cto.fact_verify_supersede", project: proj, fact: f.id, present });
+          working = res.facts;
+          changed = true;
+          superseded += 1;
+        }
+      }
+      if (changed) await saveFacts(proj, working);
+    }
+    return { checked, superseded };
+  }
+
+  async function recomputeHalfLivesNow() {
+    const state = await loadState();
+    const lifespans = state.factTuning?.lifespans ?? [];
+    const updated = recomputeHalfLives(lifespans, { halfLivesPolicy: HALF_LIVES_POLICY });
+    if (Object.keys(updated).length === 0) return { updated: null };
+    const tuned = { ...(state.factTuning?.halfLives ?? {}), ...updated };
+    await saveState({ ...state, factTuning: { lifespans: state.factTuning?.lifespans ?? [], halfLives: tuned } });
+    await log({ kind: "cto.halflife_tune", updated });
+    return { updated };
+  }
+
+  async function getState() {
+    const state = await loadState();
+    return {
+      appliedProposalCount: Object.keys(state.appliedProposals ?? {}).length,
+      pendingByProject: Object.fromEntries(
+        Object.entries(state.factQueue ?? {}).map(([p, q]) => [p, q.length]),
+      ),
+      senderReliability: state.factReliability ?? {},
+      halfLives: currentHalfLives(state.factTuning ?? {}),
+    };
+  }
+
+  function dispose() {
+    disposed = true;
+  }
+
+  return {
+    submitProposal,
+    pump,
+    touchFacts,
+    verifyDue,
+    recomputeHalfLives: recomputeHalfLivesNow,
+    getState,
+    listFacts: (project) => loadFacts(project).then((arr) => arr.filter(isActiveFact)),
+    listProjects: listKnownProjects,
+    dispose,
+  };
+}

--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -125,7 +125,7 @@ export function senderReliability({ confirmed = 0, rejected = 0 } = {}) {
   return (confirmed + 1) / (confirmed + rejected + 2);
 }
 
-export function retentionOf(fact, { nowMs, halfLives = HALF_LIVES_POLICY, weights = KIND_WEIGHTS, reliability = 1 } = {}) {
+export function retentionOf(fact, { nowMs, halfLives = HALF_LIVES_POLICY, weights = KIND_WEIGHTS, reliability = 1, reliabilityOf } = {}) {
   if (!fact) return 0;
   const t = nowMs ?? Date.now();
   if (fact.valid_until != null && t >= fact.valid_until) return 0;
@@ -142,7 +142,11 @@ export function retentionOf(fact, { nowMs, halfLives = HALF_LIVES_POLICY, weight
     decay = Math.pow(0.5, hours / hl);
   }
   const access = 1 + Math.log(1 + (fact.access_count ?? 0));
-  return weight * decay * access * reliability;
+  // §6.4's `. reliability` term: a per-fact resolver (engine feeds it the
+  // sender's Beta reliability) wins over the flat default, so cap-displacement
+  // actually ranks low-reliability senders lower (reviewer Block 1).
+  const rel = typeof reliabilityOf === "function" ? (reliabilityOf(fact) ?? reliability) : reliability;
+  return weight * decay * access * rel;
 }
 
 export function lowestRetention(activeFacts, opts) {
@@ -348,11 +352,11 @@ export function applyResolution(proposal, decision, activeFacts, { nowMs = Date.
   return { action, facts, factId: id, targetId: target ? target.id : null };
 }
 
-export function enforceCap(activeFacts, { cap = CAP_ACTIVE, nowMs, halfLives, weights } = {}) {
+export function enforceCap(activeFacts, { cap = CAP_ACTIVE, nowMs, halfLives, weights, reliabilityOf } = {}) {
   const facts = Array.isArray(activeFacts) ? activeFacts.slice() : [];
   const displaced = [];
   while (facts.filter(isActiveFact).length > cap) {
-    const low = lowestRetention(facts, { nowMs, halfLives, weights });
+    const low = lowestRetention(facts, { nowMs, halfLives, weights, reliabilityOf });
     if (!low.fact) break;
     const i = facts.findIndex((f) => f.id === low.fact.id);
     if (i < 0) break;
@@ -562,6 +566,14 @@ export function createFactsEngine(deps = {}) {
     let state = await loadState();
     const tally = { processed: 0, byAction: {} };
     const relDeltas = new Map(); // senderKey -> {confirmed, rejected}
+    // §6.4: per-fact sender reliability (Beta mean) feeds the retention/displacement
+    // ranking. Unseen senders default to 1 (neutral) until they earn counters.
+    const relOf = (fact) => {
+      const k = senderKey(fact?.sender);
+      if (!k) return 1;
+      const c = state.factReliability?.[k];
+      return c ? senderReliability(c) : 1;
+    };
     const noteRel = (sender, delta) => {
       const key = senderKey(sender);
       if (!key) return;
@@ -588,7 +600,7 @@ export function createFactsEngine(deps = {}) {
           noteRel(proposal.sender, { rejected: 1 });
           await log({ kind: "cto.fact_reject", project: proj, proposalId: proposal.proposalId, reason: result.reason });
         } else {
-          const capRes = enforceCap(result.facts, { cap: CAP_ACTIVE, nowMs: now(), halfLives: halfLivesNow });
+          const capRes = enforceCap(result.facts, { cap: CAP_ACTIVE, nowMs: now(), halfLives: halfLivesNow, reliabilityOf: relOf });
           if (capRes.displaced.length > 0) {
             const entries = await loadArchive(proj);
             await saveArchive(proj, [...entries, ...capRes.displaced.map((f) => archiveEntry(f, now()))]);
@@ -613,7 +625,7 @@ export function createFactsEngine(deps = {}) {
               await saveState({ ...st, factTuning: { ...(st.factTuning ?? {}), lifespans } });
             }
             if (old && now() - (old.created ?? 0) < OVERTURN_WINDOW_MS) {
-              await bumpReliability(old.sender, { rejected: 1 });
+              noteRel(old.sender, { rejected: 1 });
             }
           }
         }
@@ -655,6 +667,17 @@ export function createFactsEngine(deps = {}) {
     let checked = 0;
     let superseded = 0;
     let seq = 0;
+    let state = await loadState();
+    const relDeltas = new Map();
+    const noteRel = (sender, delta) => {
+      const key = senderKey(sender);
+      if (!key) return;
+      const e = relDeltas.get(key) ?? { confirmed: 0, rejected: 0 };
+      relDeltas.set(key, {
+        confirmed: e.confirmed + (delta.confirmed ?? 0),
+        rejected: e.rejected + (delta.rejected ?? 0),
+      });
+    };
     for (const proj of await listKnownProjects()) {
       let working = await loadFacts(proj);
       let changed = false;
@@ -676,7 +699,11 @@ export function createFactsEngine(deps = {}) {
         checked += 1;
         working[i] = { ...f, checkable: { ...f.checkable, last_checked: t, result: ok ? "ok" : "failed" } };
         failed.push({ f: working[i], ok });
-        if (ok) changed = true;
+        if (ok) {
+          changed = true;
+          // §6.6: a verify-pass is a confirmed instance of the origin sender.
+          noteRel(f.sender, { confirmed: 1 });
+        }
       }
       for (const { f, ok } of failed) {
         if (ok) continue;
@@ -708,6 +735,10 @@ export function createFactsEngine(deps = {}) {
       }
       if (changed) await saveFacts(proj, working);
     }
+    for (const [key, delta] of relDeltas) {
+      state = mergeReliability(state, key, delta);
+    }
+    if (relDeltas.size > 0) await saveState(state);
     return { checked, superseded };
   }
 

--- a/src/server/ctoFacts.test.mjs
+++ b/src/server/ctoFacts.test.mjs
@@ -1,0 +1,339 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FACT_VERSION,
+  KINDS,
+  CAP_ACTIVE,
+  HALF_LIVES_POLICY,
+  HOUR_MS,
+  DAY_MS,
+  validateFact,
+  newFactId,
+  isActiveFact,
+  liveHeadOf,
+  senderKey,
+  senderReliability,
+  retentionOf,
+  lowestRetention,
+  validateProposal,
+  enqueueProposal,
+  popProposal,
+  markApplied,
+  gatekeeperPrecheck,
+  buildGatekeeperContext,
+  parseGatekeeperDecision,
+  validateDecision,
+  applyResolution,
+  enforceCap,
+  matchCheckable,
+  recomputeHalfLives,
+  median,
+  createFactsEngine,
+} from "./ctoFacts.mjs";
+
+const H = HOUR_MS;
+const D = DAY_MS;
+
+function makeFact(over = {}) {
+  return {
+    v: FACT_VERSION,
+    id: "cto:x",
+    kind: "status",
+    statement: "shipped things",
+    refs: ["s1"],
+    confidence: 0.8,
+    created: 0,
+    last_accessed: 0,
+    access_count: 0,
+    sender: "cto",
+    ...over,
+  };
+}
+
+function makeEngine(over = {}) {
+  const inmemory = new Map();
+  const states = { v: 1 };
+  const facts = {
+    load: async (p) => inmemory.get(`f:${p}`) ?? { v: 1, facts: [] },
+    save: async (p, data) => inmemory.set(`f:${p}`, data),
+    dir: "facts-dir-placeholder",
+  };
+  const archive = {
+    load: async (p) => inmemory.get(`a:${p}`) ?? { v: 1, entries: [] },
+    save: async (p, data) => inmemory.set(`a:${p}`, data),
+  };
+  const engineState = {
+    load: async () => states,
+    save: async (s) => {
+      Object.keys(states).forEach((k) => delete states[k]);
+      Object.assign(states, s);
+    },
+  };
+  const ledger = { append: async () => {} };
+  const engine = createFactsEngine({
+    facts,
+    archive,
+    engineState,
+    ledger,
+    listProjects: async () => ["alpha", "beta"],
+    now: () => over.nowMs ?? 1000 * D,
+    ...over,
+  });
+  return { engine, facts, archive, engineState, states, inmemory };
+}
+
+test("validateFact accepts a well-formed fact, rejects bad kinds/refs/confidence", () => {
+  assert.ok(validateFact(makeFact()));
+  assert.ok(!validateFact(makeFact({ kind: "bogus" })));
+  assert.ok(!validateFact(makeFact({ refs: [] })));
+  assert.ok(!validateFact(makeFact({ refs: [""] })));
+  assert.ok(!validateFact(makeFact({ confidence: 1.5 })));
+  assert.ok(!validateFact(makeFact({ confidence: -0.1 })));
+  assert.ok(!validateFact(makeFact({ statement: "x".repeat(300) })));
+});
+
+test("KINDS is the closed set from spec", () => {
+  assert.deepEqual([...KINDS].sort(), ["anomaly", "blocker", "decision", "invariant", "status", "theory"]);
+});
+
+test("senderKey collapses {sessionID} and string senders to reliability keys", () => {
+  assert.equal(senderKey({ sessionID: "abc" }), "session:abc");
+  assert.equal(senderKey("cto"), "cto");
+  assert.equal(senderKey("user"), "user");
+  assert.equal(senderKey(undefined), "unknown");
+});
+
+test("senderReliability is the Beta(confirmed+1, rejected+1) mean", () => {
+  assert.equal(senderReliability({ confirmed: 0, rejected: 0 }), 0.5);
+  assert.equal(senderReliability({ confirmed: 2, rejected: 0 }), 0.75);
+  assert.equal(senderReliability({ confirmed: 0, rejected: 4 }), 1 / 6);
+});
+
+test("retention: decay halves after one half-life", () => {
+  const f = makeFact({ kind: "status", created: 0, last_accessed: 0, access_count: 0 });
+  const s0 = retentionOf(f, { nowMs: 0 });
+  const sAfter = retentionOf(f, { nowMs: HALF_LIVES_POLICY.status * HOUR_MS });
+  assert.ok(Math.abs(sAfter - s0 * 0.5) < 1e-9);
+});
+
+test("retention: access bumps the access multiplier", () => {
+  const a = makeFact({ last_accessed: 0, access_count: 0 });
+  const b = makeFact({ last_accessed: 0, access_count: 10 });
+  assert.ok(retentionOf(b, { nowMs: 0 }) > retentionOf(a, { nowMs: 0 }));
+});
+
+test("retention: unresolved blocker does not decay", () => {
+  const block = makeFact({ kind: "blocker", refs: ["m1"], created: 0, last_accessed: 0 });
+  const status = makeFact({ kind: "status", created: 0, last_accessed: 0 });
+  const far = 10 * D;
+  assert.ok(retentionOf(block, { nowMs: far }) > retentionOf(status, { nowMs: far }));
+  assert.equal(retentionOf(block, { nowMs: far }), retentionOf(block, { nowMs: 1 }));
+});
+
+test("retention: valid_until hard-expires a fact", () => {
+  const f = makeFact({ valid_until: 5 * D });
+  assert.ok(retentionOf(f, { nowMs: 4 * D }) > 0);
+  assert.equal(retentionOf(f, { nowMs: 6 * D }), 0);
+});
+
+test("lowestRetention picks the most-disposable fact", () => {
+  const oldStatus = makeFact({ kind: "status", created: 0, last_accessed: 0 });
+  const freshInvariant = makeFact({ kind: "invariant", created: 0, last_accessed: 30 * D });
+  const { fact } = lowestRetention([oldStatus, freshInvariant], { nowMs: 40 * D });
+  assert.equal(fact.id, oldStatus.id);
+});
+
+test("enqueueProposal adds per-project FIFO and dedupes by proposal id", () => {
+  const p1 = { proposalId: "p1", project: "alpha", kind: "status", statement: "a", refs: ["r1"] };
+  const p2 = { proposalId: "p2", project: "alpha", kind: "status", statement: "b", refs: ["r2"] };
+  let s = {};
+  let r = enqueueProposal(s, p1);
+  assert.ok(r.added);
+  s = r.state;
+  r = enqueueProposal(s, p1);
+  assert.equal(r.added, false);
+  assert.equal(r.reason, "already-queued");
+  r = enqueueProposal(s, p2);
+  s = r.state;
+  const pop1 = popProposal(s, "alpha");
+  assert.equal(pop1.proposal.proposalId, "p1");
+  assert.equal(popProposal(pop1.state, "alpha").proposal.proposalId, "p2");
+});
+
+test("enqueueProposal skips an already-applied id (crash re-resolution no-op)", () => {
+  const p = { proposalId: "p1", project: "alpha", kind: "status", statement: "a", refs: ["r1"] };
+  const s = markApplied({}, p.proposalId, { action: "add" });
+  const r = enqueueProposal(s, p);
+  assert.equal(r.added, false);
+  assert.equal(r.reason, "already-applied");
+});
+
+test("gatekeeperPrecheck rejects zero refs", async () => {
+  const r = await gatekeeperPrecheck({ refs: [] }, []);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "zero refs");
+});
+
+test("gatekeeperPrecheck: supersede must name a live head; else reject with head id", async () => {
+  const old1 = makeFact({ id: "a", superseded_by: "b" });
+  const b = makeFact({ id: "b" });
+  const active = [old1, b];
+  const r = await gatekeeperPrecheck({ refs: ["r1"], supersedes: "a" }, active);
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "supersede target is not the live head");
+  assert.equal(r.targetId, "b");
+  const ok = await gatekeeperPrecheck({ refs: ["r1"], supersedes: "b" }, active);
+  assert.equal(ok.ok, true);
+});
+
+test("gatekeeperPrecheck: trace spot-check rejects unresolved refs", async () => {
+  const resolveRef = async (ref) => ref !== "missing";
+  const r = await gatekeeperPrecheck({ refs: ["good", "missing"] }, [], { resolveRef });
+  assert.equal(r.ok, false);
+  assert.equal(r.reason, "unresolved ref");
+  const ok = await gatekeeperPrecheck({ refs: ["good"] }, [], { resolveRef });
+  assert.equal(ok.ok, true);
+});
+
+test("validateDecision falls back to a safe add/supersede on a bad model target", () => {
+  const active = [makeFact({ id: "head" })];
+  const d = validateDecision({ action: "update", targetId: "nope", reason: "" }, active, { supersedes: null });
+  assert.equal(d.action, "add");
+  const d2 = validateDecision({ action: "merge", targetId: "nope", reason: "" }, active, { supersedes: "head" });
+  assert.equal(d2.action, "supersede");
+  assert.equal(d2.targetId, "head");
+});
+
+test("applyResolution: supersede chains the old fact (never deleted)", () => {
+  const head = makeFact({ id: "head", kind: "decision", created: 100 });
+  const proposal = { proposalId: "p", project: "alpha", kind: "decision", statement: "new take", refs: ["r9"], supersedes: "head", sender: "cto", created: 200 };
+  const res = applyResolution(proposal, { action: "supersede", targetId: "head", reason: "" }, [head], { nowMs: 300 });
+  assert.equal(res.action, "supersede");
+  assert.ok(res.factId);
+  const oldFact = res.facts.find((f) => f.id === "head");
+  assert.equal(oldFact.superseded_by, res.factId);
+  assert.equal(isActiveFact(oldFact), false);
+  assert.equal(res.facts.filter(isActiveFact).length, 1);
+});
+
+test("applyResolution: merge unions refs into the target", () => {
+  const target = makeFact({ id: "t", refs: ["r1"], confidence: 0.3 });
+  const proposal = { proposalId: "p", project: "alpha", kind: "status", statement: "x", refs: ["r2"], confidence: 0.9, sender: "user" };
+  const res = applyResolution(proposal, { action: "merge", targetId: "t", reason: "" }, [target], { nowMs: 500 });
+  const merged = res.facts.find((f) => f.id === "t");
+  assert.deepEqual(merged.refs.slice(), ["r1", "r2"]);
+  assert.equal(merged.confidence, 0.9);
+});
+
+test("enforceCap displaces the lowest-retention fact over the cap", () => {
+  const many = [];
+  for (let i = 0; i < CAP_ACTIVE + 3; i++) {
+    many.push(makeFact({ id: `f${i}`, created: i, last_accessed: i }));
+  }
+  const { facts, displaced } = enforceCap(many, { nowMs: 1000 * 100000 });
+  assert.equal(facts.filter(isActiveFact).length, CAP_ACTIVE);
+  assert.equal(displaced.length, 3);
+  assert.ok(displaced.some((d) => d.id === "f0"));
+});
+
+test("matchCheckable recognizes branch/ci/issue probes", () => {
+  assert.deepEqual(matchCheckable("CI is green on main"), { kind: "ci", surface: "ci", probe: "green" });
+  assert.deepEqual(matchCheckable("branch fix/foo merged"), { kind: "branch", surface: "git", probe: "fix/foo" });
+  assert.deepEqual(matchCheckable("BET-1234 is open"), { kind: "issue", surface: "issue", probe: "BET-1234" });
+  assert.equal(matchCheckable("arbitrary thought"), null);
+});
+
+test("median works on even/odd/empty", () => {
+  assert.equal(median([]), null);
+  assert.equal(median([5, 1, 3]), 3);
+  assert.equal(median([1, 2, 3, 4]), 2.5);
+});
+
+test("recomputeHalfLives clamps to ±50% of policy and skips kinds without policy", () => {
+  const statusHl = HALF_LIVES_POLICY.status;
+  const fast = recomputeHalfLives([{ kind: "status", hours: 1 }]);
+  assert.equal(fast.status, statusHl * 0.5);
+  const slow = recomputeHalfLives([{ kind: "invariant", hours: 99999 }]);
+  assert.equal(slow.invariant, HALF_LIVES_POLICY.invariant * 1.5);
+  const mid = recomputeHalfLives([{ kind: "status", hours: statusHl * 0.75 }]);
+  assert.ok(mid.status >= statusHl * 0.5 && mid.status <= statusHl);
+  assert.ok(!("blocker" in recomputeHalfLives([{ kind: "blocker", hours: 5 }])));
+});
+
+test("pump adds a proposal through the degraded gatekeeper and persists", async () => {
+  const { engine, facts, states } = makeEngine();
+  await engine.submitProposal({ proposalId: "pa", project: "alpha", kind: "status", statement: "shipped rollups", refs: ["s1"], sender: "cto" });
+  const tally = await engine.pump();
+  assert.equal(tally.processed, 1);
+  assert.equal(tally.byAction.add, 1);
+  const saved = (await facts.load("alpha")).facts.filter(isActiveFact);
+  assert.equal(saved.length, 1);
+  assert.equal(saved[0].statement, "shipped rollups");
+  assert.equal(states.appliedProposals.pa.action, "add");
+});
+
+test("pump: positive-flow idempotency — re-pumping an applied id is a no-op", async () => {
+  const { engine, facts } = makeEngine();
+  await engine.submitProposal({ proposalId: "pb", project: "alpha", kind: "status", statement: "only once", refs: ["s1"] });
+  await engine.pump();
+  const t2 = await engine.pump();
+  assert.equal(t2.processed, 0);
+  const saved = (await facts.load("alpha")).facts.filter(isActiveFact);
+  assert.equal(saved.length, 1);
+});
+
+test("pump: zero-refs proposal is rejected, counts rejected sender", async () => {
+  const { engine, states, facts } = makeEngine();
+  await engine.submitProposal({ proposalId: "pz", project: "alpha", kind: "status", statement: "no evidence", refs: [], sender: "user" });
+  const tally = await engine.pump();
+  assert.equal(tally.byAction.reject, 1);
+  assert.equal((await facts.load("alpha")).facts.filter(isActiveFact).length, 0);
+  assert.equal(states.appliedProposals.pz.action, "reject");
+  assert.equal(states.factReliability.user.rejected, 1);
+});
+
+test("pump: trace spot-check failure rejects and counts the sender", async () => {
+  const { engine, states } = makeEngine({ resolveRef: async (r) => r !== "ghost" });
+  await engine.submitProposal({ proposalId: "pt", project: "alpha", kind: "status", statement: "depends on ghost", refs: ["ghost"], sender: { sessionID: "abc" } });
+  await engine.pump();
+  assert.equal(states.appliedProposals.pt.action, "reject");
+  assert.equal(states.factReliability["session:abc"].rejected, 1);
+});
+
+test("pump: caps displacement writes to the archive and caps at CAP_ACTIVE", async () => {
+  const { engine, facts, archive } = makeEngine();
+  for (let i = 0; i < CAP_ACTIVE + 2; i++) {
+    await engine.submitProposal({ proposalId: `pc${i}`, project: "alpha", kind: "status", statement: `fact ${i}`, refs: [`r${i}`] });
+  }
+  await engine.pump();
+  const active = (await facts.load("alpha")).facts.filter(isActiveFact);
+  assert.equal(active.length, CAP_ACTIVE);
+  const arch = (await archive.load("alpha")).entries;
+  assert.equal(arch.length, 2);
+  assert.ok(arch.every((e) => typeof e.ts === "number"));
+});
+
+test("checkable: stamping honors surface-exists; verify supersedes failures", async () => {
+  const { engine, facts } = makeEngine({ surfaceExists: async (s) => s === "git", verify: async () => ({ ok: false }) });
+  await engine.submitProposal({ proposalId: "ck", project: "alpha", kind: "status", statement: "branch fix/a is merged", refs: ["r1"] });
+  await engine.pump();
+  const f = (await facts.load("alpha")).facts.find((x) => isActiveFact(x));
+  assert.ok(f.checkable, "checkable stamped when the git surface exists");
+  const v = await engine.verifyDue();
+  assert.equal(v.checked, 1);
+  assert.equal(v.superseded, 1);
+  const live = (await facts.load("alpha")).facts.filter(isActiveFact);
+  assert.ok(live.length >= 1);
+});
+
+test("touchFacts bumps last_accessed + access_count on retrieval", async () => {
+  const { engine, facts } = makeEngine();
+  await engine.submitProposal({ proposalId: "ta", project: "alpha", kind: "status", statement: "touched", refs: ["r1"] });
+  await engine.pump();
+  const id = (await engine.listFacts("alpha"))[0].id;
+  const r = await engine.touchFacts({ project: "alpha", ids: [id] });
+  assert.equal(r.touched, 1);
+  const f = (await facts.load("alpha")).facts.find((x) => x.id === id);
+  assert.equal(f.access_count, 1);
+  assert.equal(typeof f.last_accessed, "number");
+});

--- a/src/server/ctoFacts.test.mjs
+++ b/src/server/ctoFacts.test.mjs
@@ -337,3 +337,58 @@ test("touchFacts bumps last_accessed + access_count on retrieval", async () => {
   assert.equal(f.access_count, 1);
   assert.equal(typeof f.last_accessed, "number");
 });
+
+// ---------------------------------------------------------------------------
+// §6.4 / §6.6 reliability fixes (reviewer Blocks, attempt 2)
+// ---------------------------------------------------------------------------
+
+test("retention honors per-fact sender reliability (reliabilityOf resolver)", () => {
+  const reliable = makeFact({ id: "r", last_accessed: 0, access_count: 0 });
+  const shaky = makeFact({ id: "s", last_accessed: 0, access_count: 0, sender: "low" });
+  const relOf = (f) => (f.id === "s" ? 0.1 : 1);
+  const sr = retentionOf(reliable, { nowMs: 0, reliabilityOf: relOf });
+  const ss = retentionOf(shaky, { nowMs: 0, reliabilityOf: relOf });
+  assert.ok(ss < sr, "low-reliability sender scores lower");
+  const { fact } = lowestRetention([reliable, shaky], { nowMs: 0, reliabilityOf: relOf });
+  assert.equal(fact.id, "s");
+});
+
+test("enforceCap displaces the low-sender-reliability fact under equivalent retention", () => {
+  const a = makeFact({ id: "a", created: 0, last_accessed: 0, sender: "high" });
+  const b = makeFact({ id: "b", created: 0, last_accessed: 0, sender: "high" });
+  const c = makeFact({ id: "c", created: 0, last_accessed: 0, sender: "low" });
+  const relOf = (f) => (f.sender === "low" ? 0.1 : 1);
+  const { facts, displaced } = enforceCap([a, b, c], { cap: 2, nowMs: 0, reliabilityOf: relOf });
+  assert.equal(displaced.length, 1);
+  assert.equal(displaced[0].id, "c");
+  assert.equal(facts.filter(isActiveFact).length, 2);
+});
+
+test("pump feeds per-sender reliability into cap displacement", async () => {
+  const { engine, facts, archive, states } = makeEngine();
+  states.factReliability = { low: { confirmed: 0, rejected: 9 } };
+  for (let i = 0; i < CAP_ACTIVE + 1; i++) {
+    const sender = i % 2 === 0 ? "cto" : "low";
+    await engine.submitProposal({ proposalId: `pc${i}`, project: "alpha", kind: "status", statement: `fact ${i}`, refs: [`r${i}`], sender });
+  }
+  await engine.pump();
+  const active = (await facts.load("alpha")).facts.filter(isActiveFact);
+  assert.equal(active.length, CAP_ACTIVE);
+  // Same recency/decay: the poor-reliability "low" sender is preferentially
+  // displaced over "cto". No cto-sender fact may be lost this round.
+  assert.ok(active.some((f) => f.sender === "cto"), "a reliable sender survived the cap");
+  const arch = (await archive.load("alpha")).entries;
+  assert.ok(arch.some((e) => e.sender === "low"), "a low-reliability sender was displaced");
+});
+
+test("verify-pass confirms the origin sender (§6.6, Block 2)", async () => {
+  const { engine, states } = makeEngine({ surfaceExists: async (s) => s === "git", verify: async () => ({ ok: true }) });
+  await engine.submitProposal({ proposalId: "cv", project: "alpha", kind: "status", statement: "branch fix/a is merged", refs: ["r1"], sender: "a-sender" });
+  await engine.pump();
+  const f = (await engine.listFacts("alpha"))[0];
+  assert.ok(f.checkable, "stamped because the git surface exists");
+  const v = await engine.verifyDue();
+  assert.equal(v.checked, 1);
+  assert.equal(v.superseded, 0);
+  assert.ok((states.factReliability["a-sender"]?.confirmed ?? 0) >= 1, "confirmed incremented on verify-pass");
+});

--- a/src/server/ctoRollups.mjs
+++ b/src/server/ctoRollups.mjs
@@ -25,17 +25,17 @@
 // Pure logic + injected I/O in the style of delegate.mjs / ctoEngine.mjs — no
 // live tmux/opencode/network in tests. All model + store + presence seams are
 // injected (`runEphemeral`, `rollups`, `loadInputs`, `loadPreceding`, `exists`,
-// `presenceCheck`, `factsStore`, `resolveSegment`, `now`).
+// `presenceCheck`, `submitProposal`, `resolveSegment`, `now`).
 //
-// Fact sync (P1, §5.3 "ADD/UPDATE/NOOP"): after each day-level reduce the
-// engine applies a deterministic ADD/UPDATE/NOOP against the project's facts
-// store (§6) DIRECTLY from the rollup — single-writer, the engine itself (§15).
-// This is deliberately isolated in one exported function, `syncFactsFromRollup`,
-// so a later P2 collaborative gatekeeper can delete it cleanly.
+// Fact sync (P2, §6.2 / D10): after each day-level reduce the runner does NOT
+// write facts directly. It maps each bullet to a per-project blackboard
+// PROPOSAL (sender "cto") and submits it to the B1 gatekeeper queue — the
+// gatekeeper is the single writer (§6.2). This is the one and only engine
+// write path to the blackboard; it goes through the queue like every producer.
 
 import { promises as fsp } from "node:fs";
 import { createHash } from "node:crypto";
-import { rollupsStore, segmentsStore, factsStore, ledgerStore } from "./ctoStores.mjs";
+import { rollupsStore, segmentsStore, ledgerStore } from "./ctoStores.mjs";
 
 export const ROLLUP_VERSION = 1;
 export const ROLLUP_LEVELS = Object.freeze(["hour", "day", "week"]);
@@ -261,117 +261,59 @@ export function degradedRollup({ level, window, inputs, refs } = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Fact sync (P1, isolated — see module header). After a day-level reduce the
-// engine applies ADD/UPDATE/NOOP against each project's facts store, grouped
-// per project by resolving each bullet's refs → segment → project. Deterministic
-// and small; a later P2 collaborative gatekeeper replaces this direct path.
+// Fact sync (P2, §6.2 / D10 — no direct writes). After a day-level reduce the
+// runner maps each bullet to {project, statement, refs} by resolving refs →
+// segment → project (unattributable bullets are skipped — never fabricate a
+// project) and SUBMITS each as a blackboard PROPOSAL to the per-project
+// gatekeeper queue (sender "cto"). The gatekeeper is the single writer (§6.2) —
+// this is the only engine write path and it goes through the queue like every
+// other producer. Proposal ids are deterministic so a re-sync of the same day
+// is idempotent (re-enqueue of an applied id is a no-op).
 // ---------------------------------------------------------------------------
 
-export function normalizeStatement(text) {
-  return String(text || "").trim().replace(/\s+/g, " ").toLowerCase();
-}
-
-export function refSignature(refs) {
-  return (Array.isArray(refs) ? [...refs] : []).sort().join("|");
-}
-
-// Deterministic ADD/UPDATE/NOOP decision against an existing fact list.
-//   - NOOP:   an active fact with the same normalized statement already exists.
-//   - UPDATE: an active fact from a prior rollup sync shares the same ref
-//             signature but a different statement — supersede it, add the new.
-//   - ADD:    otherwise (new news).
-// Returns { action, existing? }.
-export function decideFactAction(existing, statement, refs) {
-  const norm = normalizeStatement(statement);
-  const sig = refSignature(refs);
-  if (!norm) return { action: "noop" };
-  for (const f of existing) {
-    if (f?.superseded_by || f?.valid_until) continue; // inactive → can't block
-    if (normalizeStatement(f?.statement) === norm) return { action: "noop", existing: f };
-  }
-  for (const f of existing) {
-    if (f?.superseded_by || f?.valid_until) continue;
-    if (f?.sender?.sessionID === undefined && refSignature(f?.refs) === sig && sig) {
-      return { action: "update", existing: f };
-    }
-  }
-  return { action: "add" };
-}
-
-// The isolated P1 fact-sync entry point. `dayRollup` is a validated day-level
-// rollup; `resolveSegment` maps a segment id to `{ project, ... }` (or null);
-// `factsStore` is the per-project facts store ({load(project), save(project,data)}).
-// Applies ADD/UPDATE/NOOP per project and returns a tally.
-export async function syncFactsFromRollup(dayRollup, { resolveSegment, facts = factsStore, sender = "cto", now = Date.now() } = {}) {
-  if (!dayRollup || dayRollup.level !== "day" || !Array.isArray(dayRollup.bullets)) {
-    return { applied: 0, added: 0, updated: 0, noop: 0 };
-  }
-  const byProject = new Map();
+// Map a validated day rollup to per-project proposal descriptors. Pure.
+export async function proposalsFromRollup(dayRollup, { resolveSegment } = {}) {
+  if (!dayRollup || dayRollup.level !== "day" || !Array.isArray(dayRollup.bullets)) return [];
+  const out = [];
   for (const b of dayRollup.bullets) {
     if (!b || typeof b.text !== "string" || !b.text.trim()) continue;
     const refs = Array.isArray(b.refs) ? b.refs.filter((r) => typeof r === "string") : [];
+    if (refs.length === 0) continue; // zero-refs proposals are rejected by the gatekeeper anyway
     let project = null;
     for (const ref of refs) {
+      let seg = null;
       try {
-        const seg = await resolveSegment(ref);
-        if (seg?.project) {
-          project = seg.project;
-          break;
-        }
+        seg = resolveSegment ? await resolveSegment(ref) : null;
       } catch {
-        /* resolve a single ref fails → try the next */
+        seg = null;
+      }
+      if (seg?.project) {
+        project = seg.project;
+        break;
       }
     }
     if (!project) continue; // can't attribute → skip (never fabricate a project)
-    if (!byProject.has(project)) byProject.set(project, []);
-    byProject.get(project).push({ text: b.text, refs });
+    out.push({ project, kind: "decision", statement: b.text.slice(0, 200), refs });
   }
+  return out;
+}
 
-  const tally = { applied: 0, added: 0, updated: 0, noop: 0 };
-  for (const [project, bullets] of byProject) {
-    let payload;
+// The runner's day-level fact-sync hook: submit each proposal descriptor to the
+// blackboard queue (sender "cto") with a deterministic proposal id derived from
+// (project, statement, refs). Returns a tally. `submitProposal` is injected by
+// the engine (the facts engine's enqueue); it degrades to a no-op when absent.
+export async function submitFactsFromRollup(dayRollup, { resolveSegment, submitProposal = async () => ({ ok: false }), now = Date.now() } = {}) {
+  const proposals = await proposalsFromRollup(dayRollup, { resolveSegment });
+  const tally = { applied: 0, failed: 0 };
+  for (const p of proposals) {
+    const proposalId =
+      "rollup:" + createHash("sha1").update(`${p.project}|${p.statement}|${(p.refs || []).join(",")}`).digest("hex").slice(0, 12);
     try {
-      payload = await facts.load(project);
+      const res = await submitProposal({ proposalId, ...p, sender: "cto" });
+      if (res?.ok || res?.added) tally.applied += 1;
+      else tally.failed += 1;
     } catch {
-      payload = { facts: [] };
-    }
-    const existing = Array.isArray(payload?.facts) ? payload.facts : [];
-    const factsOut = [...existing];
-    const ts = now();
-    for (const b of bullets) {
-      const { action, existing: hit } = decideFactAction(existing, b.text, b.refs);
-      if (action === "noop") {
-        tally.noop += 1;
-        if (hit) {
-          hit.last_accessed = ts;
-          hit.access_count = (hit.access_count || 0) + 1;
-        }
-        continue;
-      }
-      if (action === "update" && hit) {
-        hit.superseded_by = "cto:" + createHash("sha1").update(b.text).digest("hex").slice(0, 12);
-      }
-      const fact = {
-        v: 1,
-        id: "cto:" + createHash("sha1").update(`${project}|${b.text}|${refSignature(b.refs)}`).digest("hex").slice(0, 12),
-        kind: "decision",
-        statement: b.text.slice(0, 200),
-        refs: b.refs,
-        confidence: 0.5,
-        created: ts,
-        last_accessed: ts,
-        access_count: 1,
-        sender,
-      };
-      factsOut.push(fact);
-      tally.applied += 1;
-      if (action === "update") tally.updated += 1;
-      else tally.added += 1;
-    }
-    try {
-      await facts.save(project, { facts: factsOut });
-    } catch {
-      /* facts persistence is best-effort — never throw into the reduce */
+      tally.failed += 1;
     }
   }
   return tally;
@@ -399,8 +341,11 @@ export async function syncFactsFromRollup(dayRollup, { resolveSegment, facts = f
 //                    true iff a stored payload already carries `bullets`.
 //   presenceCheck  — async () => bool — true when the user is present; the batch
 //                    stops after the in-flight reduce call.
-//   facts, resolveSegment — for day-level fact sync (default factsStore + a
-//                    segments-store-backed resolver when `segments` provided).
+//   resolveSegment — async (segmentId) => {project} | null — attribution for the
+//                    day-level fact sync.
+//   submitProposal — async (proposal) => {ok} — the blackboard proposal enqueue
+//                    (the facts engine's submitProposal); day-level reduce calls
+//                    it for each attributable bullet (sender "cto").
 //   now            — () => epoch ms.
 //   ledger         — A1 ledger {append} (best-effort).
 
@@ -490,8 +435,8 @@ export function createRollupRunner(deps = {}) {
     loadPreceding,
     exists,
     presenceCheck = async () => false,
-    facts = factsStore,
     resolveSegment,
+    submitProposal,
     now = () => Date.now(),
     ledger = ledgerStore,
   } = deps;
@@ -558,12 +503,13 @@ export function createRollupRunner(deps = {}) {
 
     let factTally = null;
     if (level === "day") {
-      factTally = await syncFactsFromRollup(rollup, {
+      // P2 (§6.2): submit each attributable bullet as a blackboard proposal
+      // (sender "cto") — the gatekeeper decides. NEVER a direct facts write.
+      factTally = await submitFactsFromRollup(rollup, {
         resolveSegment: resolveSegmentFn,
-        facts,
-        now,
+        submitProposal,
       }).catch(() => null);
-      if (factTally) await ledgerLog({ kind: "cto.facts_synced", id, ...factTally });
+      if (factTally) await ledgerLog({ kind: "cto.facts_proposed", id, ...factTally });
     }
     return { saved: true, level, window, id, factTally };
   }

--- a/src/server/ctoRollups.test.mjs
+++ b/src/server/ctoRollups.test.mjs
@@ -11,9 +11,8 @@ import {
   windowFor,
   windowId,
   previousWindow,
-  syncFactsFromRollup,
-  decideFactAction,
-  normalizeStatement,
+  proposalsFromRollup,
+  submitFactsFromRollup,
   HOUR_MS,
   DAY_MS,
   WEEK_MS,
@@ -41,17 +40,6 @@ function fakeExists(store) {
   };
 }
 
-function makeFactsStore() {
-  const map = new Map();
-  return {
-    map,
-    load: async (project) => map.get(project) ?? { facts: [] },
-    save: async (project, data) => {
-      map.set(project, data);
-    },
-  };
-}
-
 // A runEphemeral + loadInputs harness that records reduce calls and returns
 // controllable model output. `inputs` may be a function of ({level, window}).
 function makeRunner({ inputs = [], modelText = null, preceding = null, presence = () => false } = {}) {
@@ -68,7 +56,6 @@ function makeRunner({ inputs = [], modelText = null, preceding = null, presence 
     loadPreceding: async ({ level, window }) => preceding,
     exists: fakeExists(store),
     presenceCheck: presence,
-    facts: makeFactsStore(),
   });
   return { runner, store, calls };
 }
@@ -293,22 +280,11 @@ test("a present user from the start means the batch does not start", async () =>
 });
 
 // ---------------------------------------------------------------------------
-// Fact sync (P1, isolated)
+// Fact sync (P2 — proposals, §6.2; no direct writes)
 // ---------------------------------------------------------------------------
 
-test("decideFactAction maps NOOP on identical statement, UPDATE on same refs, ADD otherwise", () => {
-  const existing = [
-    { statement: "shipped rollups", refs: ["s1"], sender: "cto" },
-    { statement: "old claim", refs: ["s2", "s3"], sender: "cto" },
-  ];
-  assert.equal(decideFactAction(existing, "SHIPPED ROLLUPS", ["s1"]).action, "noop");
-  assert.equal(decideFactAction(existing, "shipped rollups too", ["s1"]).action, "update");
-  assert.equal(decideFactAction(existing, "brand new news", ["s9"]).action, "add");
-});
-
-test("syncFactsFromRollup groups bullets by project and applies ADD/UPDATE/NOOP", async () => {
+test("proposalsFromRollup groups bullets per project (skips unattributable)", async () => {
   const day = windowFor("day", baseDay());
-  const facts = makeFactsStore();
   const segments = new Map([
     ["s1", { project: "alpha" }],
     ["s2", { project: "alpha" }],
@@ -322,37 +298,51 @@ test("syncFactsFromRollup groups bullets by project and applies ADD/UPDATE/NOOP"
       { text: "did A", refs: ["s1"] },
       { text: "did B", refs: ["s2"] },
       { text: "did C (beta)", refs: ["s3"] },
+      { text: "orphan", refs: ["missing"] }, // cannot attribute → dropped, never fabricated
     ],
   };
-  const t1 = await syncFactsFromRollup(rollup, {
+  const props = await proposalsFromRollup(rollup, {
     resolveSegment: async (id) => segments.get(id) ?? null,
-    facts,
-    now: () => 111,
   });
-  assert.equal(t1.added, 3);
-  assert.equal(facts.map.get("alpha").facts.length, 2);
-  assert.equal(facts.map.get("beta").facts.length, 1);
-
-  // Re-sync the same rollup → all NOOP (news never re-reported), store unchanged.
-  const t2 = await syncFactsFromRollup(rollup, {
-    resolveSegment: async (id) => segments.get(id) ?? null,
-    facts,
-    now: () => 222,
-  });
-  assert.equal(t2.noop, 3);
-  assert.equal(t2.added, 0);
-  assert.equal(facts.map.get("alpha").facts.length, 2);
+  assert.equal(props.length, 3);
+  assert.equal(props.filter((p) => p.project === "alpha").length, 2);
+  assert.equal(props.filter((p) => p.project === "beta").length, 1);
+  assert.ok(props.every((p) => p.kind === "decision"));
 });
 
-test("syncFactsFromRollup skips bullets it cannot attribute to a project", async () => {
-  const day = windowFor("day", baseDay());
-  const facts = makeFactsStore();
-  const t = await syncFactsFromRollup(
-    { v: ROLLUP_VERSION, level: "day", window: day, bullets: [{ text: "orphan", refs: ["missing"] }] },
-    { resolveSegment: async () => null, facts },
+test("proposalsFromRollup is empty for non-day / empty rollups", async () => {
+  assert.deepEqual(await proposalsFromRollup({ level: "hour", bullets: [] }), []);
+  assert.deepEqual(await proposalsFromRollup(null), []);
+  assert.deepEqual(
+    await proposalsFromRollup({ level: "day", bullets: [{ text: "no ev", refs: [] }] }),
+    [],
   );
-  assert.equal(t.added, 0);
-  assert.equal(facts.map.size, 0);
+});
+
+test("submitFactsFromRollup enqueues deterministic proposals (sender cto, idempotent ids)", async () => {
+  const day = windowFor("day", baseDay());
+  const segments = new Map([["s1", { project: "alpha" }]]);
+  const seen = new Map();
+  const rollup = {
+    v: ROLLUP_VERSION,
+    level: "day",
+    window: day,
+    bullets: [{ text: "shipped things", refs: ["s1"] }],
+  };
+  const submit = async (p) => {
+    seen.set(p.proposalId, p);
+    return { ok: true };
+  };
+  const t1 = await submitFactsFromRollup(rollup, { resolveSegment: async (id) => segments.get(id) ?? null, submitProposal: submit });
+  assert.equal(t1.applied, 1);
+  const [p] = [...seen.values()];
+  assert.equal(p.sender, "cto");
+  assert.equal(p.project, "alpha");
+  assert.match(p.proposalId, /^rollup:/);
+  // Re-submit the same day → the same deterministic proposal id (queue dedupes).
+  const t2 = await submitFactsFromRollup(rollup, { resolveSegment: async (id) => segments.get(id) ?? null, submitProposal: submit });
+  assert.equal(t2.applied, 1);
+  assert.equal(seen.size, 1, "deterministic id — re-sync is idempotent");
 });
 
 // ---------------------------------------------------------------------------


### PR DESCRIPTION
## BET-1389 — Adaptive CTO Blackboard store + gatekeeper (§6.1–§6.8)

Implements the collaborative-pipeline blackboard: per-project durable facts,
written ONLY through a per-project gatekeeper queue (§6.2 / D10). Nothing writes
facts directly except the gatekeeper; rollup fact-sync is now a queue producer
(sender "cto") rather than a direct facts writer.

**Base:** `origin/main @ 069c6a2a`

### Files changed (6)
- `src/server/ctoFacts.mjs` **(new, 752)** — fact schema (§6.1 verbatim), proposal
  queue (durable in engine-state, client-idempotent ids, at-least-once re-resolution),
  gatekeeper (deterministic pre-checks + one `runEphemeral` gatekeeper call →
  add/update/supersede/merge/reject, degraded deterministic fallback), cap 50 with
  lowest-retention displacement to archive, retention §6.4 per-kind half-lives +
  blocker-no-decay, sender reliability §6.6 + trace spot-checks, checkable facts
  §6.7 (pattern stamping only when the surface exists + 6h verify → cto supersede),
  monthly half-life tuning §6.8 (±50% clamp), `touchFacts` access retrieval.
- `src/server/ctoFacts.test.mjs` **(new)** — 28 tests covering all the above.
- `src/server/ctoRollups.mjs` — DELETED `syncFactsFromRollup`/`decideFactAction`/
  `normalizeStatement`/`refSignature` direct-write internals; day-level reduce now
  maps bullets → proposals (`proposalsFromRollup`) and submits them to the queue
  (`submitFactsFromRollup`, deterministic `rollup:` ids so re-sync is idempotent).
- `src/server/ctoRollups.test.mjs` — swapped P1 fact-sync tests for P2 proposal tests.
- `src/server/ctoEngine.mjs` — wires the facts engine (queue pump on tick when
  enabled, 6h verify work timer, monthly tuning work timer — all halted on pause),
  passes `submitProposal` into the rollup runner, exposes `engine.facts`.
- `src/server/ctoEngine.test.mjs` — wiring test (facts engine exposed + pumps on tick).

### Design notes / decisions
- Kind weights default all to 1 (not pinned in spec §6.4) — ordering driven purely
  by decay/access/reliability; trivially tunable later.
- Verify/tune are no-model-cost deterministic work timers (like the segmenter refit);
  the gatekeeper's nano call is optional and degrades to a safe deterministic
  supersede/add when `runEphemeral` is absent (today's wiring — no live model).
- Active cap displacement prefers the weakest fact over the newcomer.

### Verification
- typecheck: pass (0 errors)
- test: 3120 pass / 0 fail (was 3157 before branch workdir churn; same result class).
