### PR TITLE
BET-1387: Adaptive CTO cold-start backfill (A6 replay + A7 rollups)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -134,7 +134,7 @@ function BackfillCard({ state }: { state: CtoState | null }) {
       data-cto-card="learning"
     >
       <div className="flex items-center gap-2">
-        <span className="rounded-full bg-inset px-2 py-0.5 text-xs font-medium text-text-muted">
+        <span className="rounded-full bg-fill px-2 py-1 text-xs font-medium text-text-muted">
           learning
         </span>
         {view.stopped ? (
@@ -163,7 +163,7 @@ function BackfillCard({ state }: { state: CtoState | null }) {
             aria-valuenow={Math.round(view.pct * 100)}
             aria-valuemin={0}
             aria-valuemax={100}
-            className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-inset"
+            className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-fill"
           >
             <div
               className="h-full rounded-full bg-info"

--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -16,7 +16,7 @@
 // line on generation-completion below still reacts to the server's real
 // `generationInFlight` (covers server-initiated regeneration).
 import { useEffect, useRef, useState } from "react";
-import { digestBusy } from "./ctoView";
+import { backfillCardView, digestBusy, formatEta } from "./ctoView";
 import type { CtoState } from "../shared/api.js";
 
 export function CtoPanel({
@@ -92,7 +92,12 @@ export function CtoPanel({
 
         {/* §10.2 section scaffolds — each collapses to nothing when empty; the
             actual cards/rails land in later issues. */}
-        <div className="space-y-8" />
+        <div className="space-y-8">
+          {/* Learning card (§10.6-4): cold-start backfill progress. Reuses the
+              needs-you card's neutral-surface styling with a `learning` chip —
+              informational, so it never counts into the sidebar badge. */}
+          <BackfillCard state={state} />
+        </div>
 
         {/* Resting state (§10.6-1): no needs-you items → a single centered
             "Nothing needs you ✓" line with a one-line context summary. Only
@@ -109,6 +114,68 @@ export function CtoPanel({
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+// The cold-start learning card (§10.6-4). Renders only while a backfill is
+// running or was stopped by its spend bound. Neutral border (informational —
+// NOT a needs-you item, so it does not count into the sidebar badge).
+function BackfillCard({ state }: { state: CtoState | null }) {
+  const view = backfillCardView(state);
+  if (!view || !view.show) return null;
+  const eta = formatEta(view.etaMs);
+  const pctLabel =
+    view.total > 0 ? Math.round(view.pct * 100) + "%" : view.done > 0 ? "100%" : "…";
+
+  return (
+    <div
+      className="rounded-lg border border-border-subtle bg-bg-soft p-4"
+      data-cto-card="learning"
+    >
+      <div className="flex items-center gap-2">
+        <span className="rounded-full bg-inset px-2 py-0.5 text-xs font-medium text-text-muted">
+          learning
+        </span>
+        {view.stopped ? (
+          <span className="text-sm font-medium text-text">Backfill stopped</span>
+        ) : (
+          <span className="text-sm font-medium text-text">Backfilling history</span>
+        )}
+      </div>
+
+      {view.stopped ? (
+        <p className="mt-2 text-sm text-text-faint">
+          {view.reason === "budget"
+            ? `Reached the one-time spend cap at ~${view.stoppedAtDepthDays ?? "some"} days of history (${view.done} of ${view.total} sessions processed).`
+            : "History backfilling was interrupted."}
+        </p>
+      ) : (
+        <div className="mt-2">
+          <div className="flex items-baseline justify-between text-sm">
+            <span className="text-text-muted">
+              Session {view.done} of {view.total} · {pctLabel}
+            </span>
+            {eta && <span className="text-text-faint">ETA {eta}</span>}
+          </div>
+          <div
+            role="progressbar"
+            aria-valuenow={Math.round(view.pct * 100)}
+            aria-valuemin={0}
+            aria-valuemax={100}
+            className="mt-2 h-1.5 w-full overflow-hidden rounded-full bg-inset"
+          >
+            <div
+              className="h-full rounded-full bg-info"
+              style={{ width: `${Math.max(0, Math.min(100, view.pct * 100))}%` }}
+            />
+          </div>
+        </div>
+      )}
+
+      <p className="mt-2 text-xs text-text-faint">
+        Ask-only while learning — I&rsquo;ll suggest, not act, until there&rsquo;s a track record.
+      </p>
     </div>
   );
 }

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -3,6 +3,8 @@ import {
   dotTone,
   badgeLabel,
   digestBusy,
+  backfillCardView,
+  formatEta,
   type CtoState,
 } from "./ctoView";
 
@@ -56,5 +58,55 @@ describe("digestBusy (§10.2 Digest-now single-flight spinner)", () => {
   });
   it("treats null state as idle", () => {
     expect(digestBusy(null)).toBe(false);
+  });
+});
+
+describe("backfillCardView (§10.6-4 learning card)", () => {
+  it("renders nothing when there is no backfill field (older bridge)", () => {
+    expect(backfillCardView(base)).toBeNull();
+  });
+  it("shows an active running backfill with pct + ETA", () => {
+    const startedAt = Date.now() - 60_000;
+    const view = backfillCardView({
+      ...base,
+      backfill: { done: 2, total: 10, startedAt, stopped: false, reason: null, stoppedAtDepthDays: null, active: true },
+    });
+    expect(view?.show).toBe(true);
+    expect(view?.done).toBe(2);
+    expect(view?.total).toBe(10);
+    expect(view?.pct).toBeCloseTo(0.2, 5);
+    // 2 items over 60s → rate 30000ms/item, 8 left → 240000ms
+    expect(view?.etaMs).toBe(240000);
+  });
+  it("still shows a budget-stopped backfill with the reason", () => {
+    const view = backfillCardView({
+      ...base,
+      backfill: { done: 5, total: 200, startedAt: null, stopped: true, reason: "budget", stoppedAtDepthDays: 12, active: false },
+    });
+    expect(view?.show).toBe(true);
+    expect(view?.stopped).toBe(true);
+    expect(view?.reason).toBe("budget");
+    expect(view?.stoppedAtDepthDays).toBe(12);
+  });
+  it("hides a cleanly completed backfill", () => {
+    const view = backfillCardView({
+      ...base,
+      backfill: { done: 10, total: 10, startedAt: null, stopped: false, reason: null, stoppedAtDepthDays: null, active: false },
+    });
+    expect(view?.show).toBe(false);
+  });
+});
+
+describe("formatEta (§10.6-4 ETA label)", () => {
+  it("formats minutes", () => {
+    expect(formatEta(120_000)).toBe("~2m");
+  });
+  it("formats hours + minutes", () => {
+    expect(formatEta(4_500_000)).toBe("~1h 15m");
+  });
+  it("returns null for null/zero/NaN", () => {
+    expect(formatEta(null)).toBeNull();
+    expect(formatEta(0)).toBeNull();
+    expect(formatEta(NaN)).toBeNull();
   });
 });

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -5,12 +5,36 @@
 
 export type CtoDot = "active" | "disabled" | "thrifty" | "paused";
 
+// Cold-start backfill (§10.6-4): informational progress for the learning card.
+// Never a needs-you item — it does not count into the sidebar badge.
+export type BackfillState = {
+  done: number;
+  total: number;
+  startedAt: number | null;
+  stopped: boolean;
+  reason: string | null;
+  stoppedAtDepthDays: number | null;
+  active: boolean;
+};
+
 export type CtoState = {
   enabled: boolean;
   dot: CtoDot;
   needsYouCount: number;
   generationInFlight: boolean;
   tonightCount: number;
+  backfill?: BackfillState;
+};
+
+// Server payload may omit backfill on older bridges; treat absent as idle.
+export const idleBackfill: BackfillState = {
+  done: 0,
+  total: 0,
+  startedAt: null,
+  stopped: false,
+  reason: null,
+  stoppedAtDepthDays: null,
+  active: false,
 };
 
 // State-dot tone (§10.1): active/disabled/thrifty/paused → ok/tx4/warn/danger.
@@ -49,4 +73,54 @@ export function showDot(): boolean {
 // views/devices can never double-generate. Busy ⇒ clicking is a no-op.
 export function digestBusy(state: CtoState | null | undefined): boolean {
   return state?.generationInFlight === true;
+}
+
+// The backfill learning-card view (§10.6-4) — derived purely from the state
+// so the component stays a dumb renderer. Returns null when there is nothing
+// to show (never started, or completed cleanly).
+export type BackfillCardView = {
+  done: number;
+  total: number;
+  pct: number; // 0..1
+  etaMs: number | null; // extrapolated wall ETA
+  stopped: boolean;
+  reason: string | null;
+  stoppedAtDepthDays: number | null;
+  // Active = a backfill is running right now. When stopped, the card still
+  // renders (with the reason) so the "stopped at depth" is visible; a clean
+  // completion shows nothing.
+  show: boolean;
+};
+
+export function backfillCardView(state: CtoState | null | undefined): BackfillCardView | null {
+  const b = state?.backfill;
+  if (!b) return null;
+  const total = Math.max(0, b.total || 0);
+  const done = Math.max(0, Math.min(b.done || 0, total || b.done || 0));
+  let etaMs: number | null = null;
+  if (done > 0 && total > done && b.startedAt && Date.now() > b.startedAt) {
+    const rate = (Date.now() - b.startedAt) / done;
+    etaMs = Math.max(0, Math.round(rate * (total - done)));
+  }
+  return {
+    done,
+    total,
+    pct: total > 0 ? done / total : 0,
+    etaMs,
+    stopped: !!b.stopped,
+    reason: b.reason ?? null,
+    stoppedAtDepthDays: b.stoppedAtDepthDays ?? null,
+    show: !!b.active || !!b.stopped,
+  };
+}
+
+// Human "~1h 12m" style ETA for the learning card.
+export function formatEta(etaMs: number | null): string | null {
+  if (etaMs == null || !Number.isFinite(etaMs) || etaMs <= 0) return null;
+  const totalMin = Math.max(1, Math.round(etaMs / 60000));
+  const h = Math.floor(totalMin / 60);
+  const m = totalMin % 60;
+  if (h <= 0) return `~${m}m`;
+  if (m === 0) return `~${h}h`;
+  return `~${h}h ${m}m`;
 }

--- a/src/server/ctoBackfill.mjs
+++ b/src/server/ctoBackfill.mjs
@@ -1,0 +1,516 @@
+// src/server/ctoBackfill.mjs
+// BET-1387 — cold-start backfill (spec §10.6-4). A one-time bootstrap that
+// replays up to N days of stored opencode history (read-only, via the same
+// opencodeDb.mjs handle ⌘F search uses — NEVER write to it) through the A6
+// segmentation + summary pipeline (ctoSegments) and A7 rollups (ctoRollups),
+// oldest first, so the CTO starts with a live model instead of an empty one.
+//
+// Guardrails (all enforced here):
+//   - Watermark: the backfill owns every session with ts < its start instant
+//     (recorded in engine-state at kick-off); live ingestion owns ts ≥ it. The
+//     backfill only ever reads ts < startInstant, so a backfilled and a live
+//     segment can never overlap or double-count.
+//   - Spend bound: one-time budget (default $3, config `ctoBackfillCapUsd`),
+//     measured as the cumulative model-ledger cost attributed since the start
+//     instant. On hitting the bound it stops at the depth reached and persists
+//     {stoppedAtDepthDays, reason:"budget"}.
+//   - Batch-priority: reduce calls (summaries/rollups) run only while presence
+//     is not "present" (away/gone/unknown-with-no-recent-activity), yielding
+//     between calls via the injected presenceCheck.
+//   - Once per box: guarded by an `engine-state.json` marker (backfillDone);
+//     a re-enable of the CTO does not re-run it.
+//
+// Pure, injectable, testable in the style of the rest of src/server — no live
+// tmux/opencode in tests. The engine (ctoEngine.mjs) owns the tick that calls
+// `step()`; index.mjs supplies the real model producer + the read-only DB.
+
+import { DAY_MS, HOUR_MS, WEEK_MS, createRollupRunner, defaultExists, startOfDay, startOfHour, startOfWeek, windowFor, windowId } from "./ctoRollups.mjs";
+import { createSegmenter } from "./ctoSegments.mjs";
+import { engineStateStore, segmentsStore, rollupsStore, ledgerStore } from "./ctoStores.mjs";
+import { fetchLedgerRows } from "./modelLedger.mjs";
+
+export const DEFAULT_BACKFILL_CAP_USD = 3;
+export const DEFAULT_BACKFILL_DAYS = 30;
+export const MAX_SESSIONS_PER_STEP = 12;
+export const MAX_ROLLUPS_PER_STEP = 12;
+export const ROLLUP_PHASES = Object.freeze(["hour", "day", "week"]);
+const START_OF = Object.freeze({ hour: startOfHour, day: startOfDay, week: startOfWeek });
+
+// ---------------------------------------------------------------------------
+// Pure helpers (all unit-tested in ctoBackfill.test.mjs)
+// ---------------------------------------------------------------------------
+
+// The absolute session-time window the backfill owns: [historyStart,
+// startInstant). Watermark-exclusive: ts === end is owned by LIVE ingestion.
+export function historyWindow({ startInstant, depthDays = DEFAULT_BACKFILL_DAYS } = {}) {
+  const start = startInstant - depthDays * DAY_MS;
+  return { start, end: startInstant };
+}
+
+// Watermark exclusivity: a session with ts === end (the start instant) is in
+// the live pipeline's territory and must be EXCLUDED from the backfill.
+export function sessionInRange(ts, { start, end }) {
+  return typeof ts === "number" && Number.isFinite(ts) && ts >= start && ts < end;
+}
+
+// Cumulative model-ledger cost (USD) across a set of ledger rows. Rows come
+// from fetchLedgerRows; a missing/non-numeric cost counts as zero.
+export function sumCost(rows) {
+  return (Array.isArray(rows) ? rows : []).reduce(
+    (s, r) => s + (typeof r?.cost === "number" && Number.isFinite(r.cost) ? r.cost : 0),
+    0,
+  );
+}
+
+// Budget state. exceeded = spent >= cap. Negative/NaN clamp to zero.
+export function budgetState({ spentUsd = 0, capUsd = DEFAULT_BACKFILL_CAP_USD } = {}) {
+  const spent = Math.max(0, Number.isFinite(spentUsd) ? spentUsd : 0);
+  const cap = Math.max(0, Number.isFinite(capUsd) ? capUsd : DEFAULT_BACKFILL_CAP_USD);
+  return { spentUsd: spent, capUsd: cap, overBy: Math.max(0, spent - cap), exceeded: spent >= cap };
+}
+
+// Progress math for the learning card: done/total, a 0..1 percent, and a wall
+// ETA (ms) extrapolated from the observed rate when there is progress to
+// extrapolate from. etaMs null = "unknown yet".
+export function computeProgress({ done = 0, total = 0, startedAt, at } = {}) {
+  const d = Math.max(0, Number.isFinite(done) ? done : 0);
+  const t = Math.max(0, Number.isFinite(total) ? total : 0);
+  const pct = t > 0 ? Math.min(1, d / t) : d > 0 ? 1 : 0;
+  let etaMs = null;
+  if (d > 0 && t > d && startedAt && at && at > startedAt) {
+    const rate = (at - startedAt) / d;
+    etaMs = Math.max(0, Math.round(rate * (t - d)));
+  }
+  return { done: Math.round(d), total: Math.round(t), pct, etaMs };
+}
+
+// The days-into-the-past depth reached when the backfill stopped (used for the
+// "stopped at ~N days" card copy when the budget bound is hit). If nothing was
+// processed yet it reads as the full requested depth; an out-of-window ts
+// clamps to the requested depth (we never reach further back than depthDays).
+export function depthDaysAt({ newestProcessedTs, now = Date.now(), depthDays = DEFAULT_BACKFILL_DAYS } = {}) {
+  if (!newestProcessedTs || !(newestProcessedTs > 0)) return depthDays;
+  const reached = Math.max(0, Math.round((now - newestProcessedTs) / DAY_MS));
+  return Math.min(depthDays, reached);
+}
+
+// ---------------------------------------------------------------------------
+// Event reconstruction (stored messages → synthetic segmenter events)
+// ---------------------------------------------------------------------------
+
+function parseData(raw) {
+  if (typeof raw !== "string" || !raw) return {};
+  try {
+    const d = JSON.parse(raw);
+    return d && typeof d === "object" ? d : {};
+  } catch {
+    return {};
+  }
+}
+
+function userPromptEvent(sessionID, text) {
+  return { type: "user.message.created", properties: { sessionID, message: { role: "user", text: text ?? "" } } };
+}
+
+function busyEvent() {
+  return { type: "session.status", properties: { status: { type: "busy" } } };
+}
+
+function idleEvent() {
+  return { type: "session.idle", properties: {} };
+}
+
+// ---------------------------------------------------------------------------
+// The backfill engine
+// ---------------------------------------------------------------------------
+
+export function createCtoBackfill(deps = {}) {
+  const {
+    configGet = async () => ({}),
+    engineState = engineStateStore,
+    ledger = ledgerStore,
+    segments = segmentsStore,
+    rollups = rollupsStore,
+    summarize = async () => ({ ok: false, gated: false }),
+    computeOneLiner = async () => null,
+    runEphemeral = null,
+    getDb = null, // async () => read-only opencode db | null (index.mjs supplies the real handle)
+    presenceCheck = async () => false, // true when present → stop/yield (batch-priority)
+    now = () => Date.now(),
+    capUsd = null, // explicit override; else config.ctoBackfillCapUsd; else default
+    depthDays = null, // explicit override; else config.ctoBackfillDays; else default
+    maxSessionsPerStep = MAX_SESSIONS_PER_STEP,
+    maxRollupsPerStep = MAX_ROLLUPS_PER_STEP,
+  } = deps;
+
+  let cfg = {};
+  let running = false;
+  let rollupRunner = null;
+  let existsFn = null;
+
+  async function loadCfg() {
+    try {
+      cfg = (await configGet()) || {};
+    } catch {
+      cfg = {};
+    }
+    return cfg;
+  }
+  function cfgNum(key, dflt) {
+    const v = cfg && cfg[key];
+    return typeof v === "number" && Number.isFinite(v) ? v : dflt;
+  }
+  function resolveCap() {
+    return capUsd ?? cfgNum("ctoBackfillCapUsd", DEFAULT_BACKFILL_CAP_USD);
+  }
+  function resolveDepth() {
+    return depthDays ?? cfgNum("ctoBackfillDays", DEFAULT_BACKFILL_DAYS);
+  }
+
+  async function readState() {
+    const st = await engineState.load().catch(() => ({}));
+    return st && typeof st === "object" ? st : {};
+  }
+  async function saveState(patch) {
+    const cur = await readState();
+    await engineState.save({ ...cur, ...patch });
+  }
+
+  // The A7 rollup runner is constructed lazily + cached; it reduces past
+  // windows that the live rollupCursor deliberately never touches.
+  function getRunner(db) {
+    if (rollupRunner) return rollupRunner;
+    if (!existsFn) existsFn = defaultExists({ rollups });
+    rollupRunner = createRollupRunner({
+      runEphemeral,
+      rollups,
+      segments,
+      exists: existsFn,
+      presenceCheck,
+      now,
+    });
+    return rollupRunner;
+  }
+
+  function progressFrom(st) {
+    const p = st?.backfillProgress;
+    return computeProgress({
+      done: p ? (Array.isArray(p.processedSessions) ? p.processedSessions.length : 0) : 0,
+      total: p?.total ?? 0,
+      startedAt: p?.startedAt,
+      at: now(),
+    });
+  }
+
+  async function ledgerLog(entry) {
+    try {
+      await ledger.append({ actor: "cto", ts: now(), ...entry });
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  async function measureSpend(db, startInstant) {
+    if (!db) return 0;
+    try {
+      const rows = await fetchLedgerRows(db, startInstant);
+      return sumCost(rows);
+    } catch {
+      return 0;
+    }
+  }
+
+  // Replay ONE historical session's messages (ts < watermark) through a fresh
+  // segmenter, oldest-first, and flush the persisted close chains so the
+  // segment summaries are on disk before the session is marked processed.
+  async function replaySession(db, session, endTs) {
+    const seg = createSegmenter({ segments, engineState, summarize, computeOneLiner, now });
+    const rows = db
+      .prepare(
+        "SELECT id, time_created, data FROM message WHERE session_id = ? AND time_created < ? ORDER BY time_created ASC",
+      )
+      .all(String(session.id), endTs);
+    const msgs = [];
+    for (const r of rows || []) {
+      const data = parseData(r.data);
+      const role = data?.role;
+      if (role !== "user" && role !== "assistant") continue;
+      msgs.push({
+        id: r.id != null ? String(r.id) : null,
+        ts: Number(r.time_created) || 0,
+        role,
+        text: typeof data?.text === "string" ? data.text : "",
+      });
+    }
+    const project = typeof session?.directory === "string" && session.directory ? session.directory : undefined;
+    const sid = String(session.id);
+
+    let i = 0;
+    while (i < msgs.length) {
+      const m = msgs[i];
+      if (m.role === "user") {
+        seg.observe(userPromptEvent(sid, m.text), { sessionID: sid, project, ts: m.ts });
+        i += 1;
+        let lastTs = m.ts;
+        while (i < msgs.length && msgs[i].role === "assistant") {
+          seg.observe(busyEvent(), { sessionID: sid, project, ts: msgs[i].ts });
+          lastTs = msgs[i].ts;
+          i += 1;
+        }
+        // Turn completed — the boundary the segmenter closes on.
+        seg.observe(idleEvent(), { sessionID: sid, project, ts: Math.max(lastTs, m.ts) });
+      } else {
+        // Assistant activity with no preceding user prompt in range — its own
+        // micro-turn, so it still closes into a segment.
+        seg.observe(busyEvent(), { sessionID: sid, project, ts: m.ts });
+        i += 1;
+        seg.observe(idleEvent(), { sessionID: sid, project, ts: m.ts });
+      }
+    }
+
+    // Flush the serialized on-liner compute + segment-close summary chains so
+    // the persisted segments are complete before we advance.
+    const st = seg._sessions?.get(sid);
+    if (st) {
+      if (st.turnChain) await st.turnChain.catch(() => {});
+      if (st.closeChain) await st.closeChain.catch(() => {});
+    }
+  }
+
+  // Enumerate candidate sessions in [historyStart, watermark) that we have not
+  // yet processed. The backfill owns strictly ts < watermark; the set is stable
+  // for the life of the backfill (no live session can land in a past window).
+  async function enumerateRemaining(db, win, processedSet) {
+    const out = [];
+    if (!db) return out;
+    // Enumerate sessions by their message activity (message.time_created is the
+    // canonical INTEGER timestamp the rest of the store uses) rather than by
+    // session.time_created, which is not guaranteed/typed across opencode
+    // schemas. Oldest-(message-)first gives the depth-ordered replay order.
+    let rows = [];
+    try {
+      rows = db
+        .prepare(
+          "SELECT m.session_id AS sid, s.directory AS directory, s.agent AS agent, MIN(m.time_created) AS first_ts " +
+            "FROM message m LEFT JOIN session s ON s.id = m.session_id " +
+            "WHERE m.time_created >= ? AND m.time_created < ? " +
+            "GROUP BY m.session_id ORDER BY first_ts ASC",
+        )
+        .all(win.start, win.end);
+    } catch {
+      return out;
+    }
+    for (const r of rows || []) {
+      const id = r.sid != null ? String(r.sid) : null;
+      if (!id) continue;
+      if (r.agent === "cto") continue; // never re-segment the CTO's own sessions
+      if (processedSet.has(id)) continue;
+      out.push({ id, directory: r.directory ?? null, ts: Number(r.first_ts) || 0 });
+    }
+    return out;
+  }
+
+  // The segments phase: replay up to maxSessionsPerStep remaining sessions,
+  // oldest first, checking presence + budget between each. Returns the work
+  // outcome { kind } for the caller to decide what to persist.
+  async function segmentsStep(db, win, st, startInstant, cap) {
+    const p = st?.backfillProgress || { processedSessions: [] };
+    const processed = new Set(Array.isArray(p.processedSessions) ? p.processedSessions : []);
+    const remaining = await enumerateRemaining(db, win, processed);
+
+    // total is stable for the backfill's life; done grows as sessions finish.
+    const total = remaining.length + processed.size;
+
+    let doneThisStep = 0;
+    let newestTs = p.newestProcessedTs ?? null;
+    const newly = [];
+    for (const sess of remaining) {
+      if (doneThisStep >= maxSessionsPerStep) break;
+      if (await presenceCheck().catch(() => false)) break; // yield between calls
+      const spent = await measureSpend(db, startInstant);
+      if (budgetState({ spentUsd: spent, capUsd: cap }).exceeded) {
+        return { kind: "budget", spentUsd: spent, doneThisStep, newestTs, newly, total };
+      }
+      try {
+        await replaySession(db, sess, win.end);
+      } catch {
+        /* a single bad session never aborts the backfill — skip + record */
+        await ledgerLog({ kind: "cto.backfill_session_failed", sessionID: sess.id });
+      }
+      processed.add(sess.id);
+      newly.push(sess.id);
+      newestTs = Math.max(newestTs ?? 0, sess.ts || 0);
+      doneThisStep += 1;
+    }
+
+    // Persist progress (resume-safe: processedSessions is the durable cursor).
+    const nextProgress = {
+      processedSessions: [...processed],
+      total,
+      startedAt: p.startedAt ?? st.backfillStartInstant ?? startInstant,
+      newestProcessedTs: newestTs,
+    };
+    await saveState({ backfillProgress: nextProgress });
+    await ledgerLog({ kind: "cto.backfill_segments", done: processed.size, total });
+
+    const allSegmentsDone = remaining.length === 0 || processed.size === total;
+    if (allSegmentsDone && doneThisStep === 0 && remaining.length === 0) {
+      await saveState({ backfillPhase: "rollups" });
+      return { kind: "segments-done", progress: nextProgress };
+    }
+    if (processed.size >= total) {
+      await saveState({ backfillPhase: "rollups" });
+      return { kind: "segments-done", progress: nextProgress };
+    }
+    return { kind: "partial", progress: nextProgress };
+  }
+
+  // The rollups phase: reduce the level-below inputs into the windows the live
+  // rollupCursor never visits, oldest-first, bounded per step, presence+budget
+  // checked between windows. Hour → day → week (each level's inputs come from
+  // the level below). `st.backfillRollup` = { phase: hour|day|week, cursorTs }.
+  async function rollupsStep(db, win, st, startInstant, cap) {
+    const roll = st?.backfillRollup || {};
+    let phase = roll.phase ?? "hour";
+    let cursorTs = roll.cursorTs ?? startOfHour(win.start);
+
+    const spent = await measureSpend(db, startInstant);
+    let lastSpent = spent;
+    let reduced = 0;
+    let newestTs = st?.backfillProgress?.newestProcessedTs ?? null;
+
+    for (; reduced < maxRollupsPerStep; ) {
+      if (await presenceCheck().catch(() => false)) break;
+      if (budgetState({ spentUsd: lastSpent, capUsd: cap }).exceeded) {
+        break;
+      }
+      if (cursorTs >= win.end) {
+        // Level exhausted — move up the ladder.
+        const idx = ROLLUP_PHASES.indexOf(phase);
+        if (idx < ROLLUP_PHASES.length - 1) {
+          phase = ROLLUP_PHASES[idx + 1];
+          cursorTs = START_OF[phase](win.start);
+          continue;
+        }
+        break; // week done → finished
+      }
+      const window = windowFor(phase, cursorTs);
+      const id = windowId(window);
+      // Sail past windows already rolled up (write-once — never rewrite/throw).
+      if (!(await existsFn({ level: phase, id }))) {
+        try {
+          await getRunner(db).reduceWindow(phase, window);
+          reduced += 1;
+          lastSpent = await measureSpend(db, startInstant);
+        } catch {
+          /* best-effort — never abort the backfill on one bad window */
+        }
+      }
+      cursorTs = window[1];
+    }
+
+    await saveState({ backfillRollup: { phase, cursorTs } });
+
+    // Budget-stop happened mid-drive (or at top) → persist the stop once.
+    if (budgetState({ spentUsd: lastSpent, capUsd: cap }).exceeded) {
+      const reachedAt = depthDaysAt({ newestProcessedTs: newestTs, now: now(), depthDays: resolveDepth() });
+      await ledgerLog({ kind: "cto.backfill_stopped", reason: "budget", stoppedAtDepthDays: reachedAt, spentUsd: lastSpent });
+      return { kind: "budget", spentUsd: lastSpent, reachedAt };
+    }
+
+    const done = phase === "week" && cursorTs >= win.end;
+    if (done) {
+      await saveState({ backfillDone: true, backfillPhase: "done" });
+      await ledgerLog({ kind: "cto.backfill_done", depthDays: resolveDepth() });
+    }
+    return { kind: done ? "done" : "partial", progress: progressFrom(await readState()), spentUsd: lastSpent };
+  }
+
+  async function doStep(at) {
+    const st = await readState();
+    if (st?.backfillDone) return { ok: true, done: true, progress: progressFrom(st) };
+
+    await loadCfg();
+    // Disabled → never run (but never mark done — a re-enable resumes).
+    if (cfg?.ctoEnabled !== true) return { ok: false, reason: "disabled", progress: progressFrom(st) };
+    // Batch-priority: yield while present.
+    if (await presenceCheck().catch(() => false)) return { ok: false, reason: "present", progress: progressFrom(st) };
+
+    // Kick-off: record the watermark once. Live ingestion owns ts ≥ it forever
+    // as far as the backfill is concerned.
+    const startInstant = st?.backfillStartInstant ?? at;
+    if (!st?.backfillStartInstant) {
+      await saveState({ backfillStartInstant: startInstant, backfillPhase: st?.backfillPhase ?? "segments" });
+    }
+
+    const cap = resolveCap();
+    const depth = resolveDepth();
+    const win = historyWindow({ startInstant, depthDays: depth });
+
+    const db = await (getDb ? getDb() : Promise.resolve(null)).catch(() => null);
+
+    // No opencode history at all → nothing to backfill; mark done once so a
+    // re-enable does not re-attempt forever.
+    if (!db) {
+      await saveState({
+        backfillDone: true,
+        backfillStopped: { reason: "no-history", stoppedAtDepthDays: 0, spentUsd: 0 },
+        backfillPhase: "done",
+      });
+      return { ok: true, done: true, reason: "no-history", progress: progressFrom(await readState()) };
+    }
+
+    // Budget check up front (a stopped backfill stays stopped).
+    const spent = await measureSpend(db, startInstant);
+    if (budgetState({ spentUsd: spent, capUsd: cap }).exceeded) {
+      const reachedAt = depthDaysAt({ newestProcessedTs: st?.backfillProgress?.newestProcessedTs ?? null, now: at, depthDays: depth });
+      await saveState({
+        backfillDone: true,
+        backfillStopped: { reason: "budget", stoppedAtDepthDays: reachedAt, spentUsd: spent },
+        backfillPhase: "done",
+      });
+      await ledgerLog({ kind: "cto.backfill_stopped", reason: "budget", stoppedAtDepthDays: reachedAt, spentUsd: spent });
+      return { ok: false, stopped: true, reason: "budget", progress: progressFrom(await readState()), budget: budgetState({ spentUsd: spent, capUsd: cap }) };
+    }
+
+    const phase = st?.backfillPhase ?? "segments";
+    if (phase === "segments") {
+      const res = await segmentsStep(db, win, st, startInstant, cap);
+      if (res.kind === "budget") {
+        const reachedAt = depthDaysAt({ newestProcessedTs: res.newestTs, now: at, depthDays: depth });
+        const st2 = await readState();
+        await saveState({
+          backfillDone: true,
+          backfillStopped: { reason: "budget", stoppedAtDepthDays: reachedAt, spentUsd: res.spentUsd },
+          backfillPhase: "done",
+        });
+        await ledgerLog({ kind: "cto.backfill_stopped", reason: "budget", stoppedAtDepthDays: reachedAt, spentUsd: res.spentUsd });
+        return { ok: false, stopped: true, reason: "budget", progress: progressFrom(st2), budget: budgetState({ spentUsd: res.spentUsd, capUsd: cap }) };
+      }
+      return { ok: true, progress: progressFrom(await readState()) };
+    }
+    if (phase === "rollups") {
+      return rollupsStep(db, win, await readState(), startInstant, cap);
+    }
+    return { ok: true, progress: progressFrom(st) };
+  }
+
+  async function step({ at = now() } = {}) {
+    if (running) return { ok: false, busy: true };
+    running = true;
+    try {
+      return await doStep(at);
+    } finally {
+      running = false;
+    }
+  }
+
+  return {
+    step,
+    // Pure surface for tests / diagnostics.
+    _historyWindow: historyWindow,
+    _budgetState: budgetState,
+    _progress: computeProgress,
+    _depthDaysAt: depthDaysAt,
+  };
+}

--- a/src/server/ctoBackfill.test.mjs
+++ b/src/server/ctoBackfill.test.mjs
@@ -1,0 +1,323 @@
+// Tests for ctoBackfill.mjs — the cold-start backfill (BET-1387, spec §10.6-4).
+// Pure + injectable: guardrails (watermark exclusivity, spend-bound stop with a
+// persisted reason, once-per-box marker, progress math) are tested against
+// fakes and an in-memory SQLite fixture — never the real box stores.
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  budgetState,
+  computeProgress,
+  createCtoBackfill,
+  depthDaysAt,
+  DEFAULT_BACKFILL_CAP_USD,
+  DEFAULT_BACKFILL_DAYS,
+  historyWindow,
+  sessionInRange,
+  sumCost,
+} from "./ctoBackfill.mjs";
+
+const DAY = 24 * 3600 * 1000;
+
+// ---------------------------------------------------------------------------
+// In-memory fakes
+// ---------------------------------------------------------------------------
+
+function memStore(seed) {
+  const data = { ...(seed ?? {}) };
+  return {
+    load: async () => ({ ...data }),
+    save: async (next) => {
+      Object.assign(data, next);
+      return data;
+    },
+    _data: data,
+  };
+}
+
+// DirJson-style file store (segments/rollups): save(id, value) / load(id).
+function memFileStore() {
+  const data = new Map();
+  return {
+    load: async (id) => data.get(id) ?? null,
+    save: async (id, value) => {
+      data.set(id, value);
+      return value;
+    },
+    _data: data,
+  };
+}
+
+const noopLedger = { append: async () => {} };
+
+// A memory-backed SQLite fixture (node:sqlite). Returns { db, close } or null
+// when node:sqlite is unavailable (degrade the whole test file to skip).
+async function openFixture() {
+  let DatabaseSync;
+  try {
+    ({ DatabaseSync } = await import("node:sqlite"));
+  } catch {
+    return null;
+  }
+  const db = new DatabaseSync(":memory:");
+  db.exec(`
+    CREATE TABLE message (id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+    CREATE TABLE session (id TEXT, parent_id TEXT, agent TEXT, directory TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+    CREATE TABLE part (id TEXT, message_id TEXT, session_id TEXT, time_created INTEGER, time_updated INTEGER, data TEXT);
+  `);
+  return {
+    db,
+    insSession(id, { agent = "build", directory = "/w" } = {}) {
+      db.prepare("INSERT INTO session (id, parent_id, agent, directory, time_created) VALUES (?,?,?,?,?)").run(id, null, agent, directory, 0);
+    },
+    insMessage(id, sessionId, { role, ts, cost = 0, text = "" }) {
+      db.prepare("INSERT INTO message (id, session_id, time_created, data) VALUES (?,?,?,?)").run(
+        id,
+        sessionId,
+        ts,
+        JSON.stringify({
+          role,
+          providerID: "anthropic",
+          modelID: "claude-sonnet",
+          cost,
+          tokens: { input: 1, output: 1 },
+          text,
+        }),
+      );
+    },
+  };
+}
+
+// A valid segment-summary producer (returns a real summary, so the segmenter
+// persists a non-degraded segment).
+function validSummarize() {
+  return async (data) => ({
+    ok: true,
+    summary: {
+      v: 1,
+      sessionID: data.sessionID,
+      project: data.project,
+      window: [data.start, data.end],
+      intent: "task",
+      outcome: "done",
+      key_events: [],
+      files_touched: [],
+      prs: [],
+      importance: 3,
+      one_liner: (data.oneLiner || "work").slice(0, 140),
+    },
+  });
+}
+
+const PRESENT = async () => true;
+const AWAY = async () => false;
+
+// ---------------------------------------------------------------------------
+// Pure guardrail tests
+// ---------------------------------------------------------------------------
+
+test("historyWindow / sessionInRange: watermark exclusivity — only ts strictly < startInstant and >= historyStart is in range", () => {
+  const startInstant = 10_000;
+  const depth = 3;
+  const win = historyWindow({ startInstant, depthDays: depth });
+  assert.equal(win.start, startInstant - depth * DAY);
+  assert.equal(win.end, startInstant);
+
+  assert.equal(sessionInRange(startInstant - 1, win), true, "just under the watermark is owned by the backfill");
+  assert.equal(sessionInRange(startInstant, win), false, "exactly the watermark belongs to LIVE ingestion — no overlap");
+  assert.equal(sessionInRange(startInstant + 1, win), false, "after the watermark is live");
+  assert.equal(sessionInRange(win.start, win), true, "depth boundary included");
+  assert.equal(sessionInRange(win.start - 1, win), false, "older than the depth is out of range");
+  assert.equal(sessionInRange(NaN, win), false);
+});
+
+test("budgetState: exceeded flips at spent >= cap and clamps negatives/NaN", () => {
+  assert.equal(budgetState({ spentUsd: DEFAULT_BACKFILL_CAP_USD, capUsd: DEFAULT_BACKFILL_CAP_USD }).exceeded, true);
+  assert.equal(budgetState({ spentUsd: DEFAULT_BACKFILL_CAP_USD - 0.01, capUsd: DEFAULT_BACKFILL_CAP_USD }).exceeded, false);
+  assert.equal(budgetState({ spentUsd: -5, capUsd: 3 }).spentUsd, 0, "negative spent clamps to 0");
+  assert.equal(budgetState({ spentUsd: NaN, capUsd: 3 }).exceeded, false);
+  assert.equal(budgetState({ spentUsd: 1, capUsd: NaN }).exceeded, false, "NaN cap never trips");
+  assert.deepEqual(budgetState({ spentUsd: 4, capUsd: 3 }).overBy, 1);
+});
+
+test("sumCost sums only finite numeric costs (missing/non-numeric ignored)", () => {
+  assert.equal(sumCost([{ cost: 1 }, { cost: 0.5 }, { cost: null }, {}, { cost: NaN }]), 1.5);
+  assert.equal(sumCost(undefined), 0);
+  assert.equal(sumCost([]), 0);
+});
+
+test("computeProgress: math for pct + ETA from the observed rate", () => {
+  const p = computeProgress({ done: 0, total: 10, startedAt: 1000, at: 1000 });
+  assert.equal(p.pct, 0);
+  assert.equal(p.etaMs, null, "no progress yet → no ETA");
+
+  const done25 = computeProgress({ done: 2, total: 10, startedAt: 1000, at: 3000 });
+  assert.ok(Math.abs(done25.pct - 0.2) < 1e-9);
+  assert.equal(done25.etaMs, 8000, "rate = 1000 ms/item over 8 remaining → 8000");
+
+  const all = computeProgress({ done: 10, total: 10, startedAt: 1000, at: 3000 });
+  assert.equal(all.pct, 1);
+  assert.equal(all.etaMs, null, "complete → no ETA");
+
+  const empty = computeProgress({ done: 0, total: 0, startedAt: 1000, at: 2000 });
+  assert.equal(empty.pct, 0);
+  assert.equal(empty.total, 0);
+});
+
+test("depthDaysAt: stop depth is the days-ago of the newest processed ts, else the full requested depth", () => {
+  const now = 1000 * DAY;
+  assert.equal(depthDaysAt({ newestProcessedTs: null, now, depthDays: 30 }), 30, "nothing processed → full depth");
+  assert.equal(depthDaysAt({ newestProcessedTs: now - 7 * DAY, now, depthDays: 30 }), 7);
+  assert.equal(depthDaysAt({ newestProcessedTs: now - 90 * DAY, now, depthDays: 30 }), 30, "older than the window clamps to the requested depth");
+});
+
+// ---------------------------------------------------------------------------
+// Engine-level guardrails (injected fakes + in-memory db)
+// ---------------------------------------------------------------------------
+
+test("bound stop: cumulative model-ledger cost at/over the cap stops backfill and persists {reason:'budget', stoppedAtDepthDays}", async () => {
+  const fx = await openFixture();
+  if (!fx) return; // node 24 lacks node:sqlite
+
+  const NOW = 1000 * DAY;
+  fx.insSession("s1", { agent: "build" });
+  // An assistant message after the start instant carries the spend — the
+  // ledger measures everything created since the backfill's start instant.
+  fx.insMessage("m1", "s1", { role: "assistant", ts: NOW + 1000, cost: 2 });
+
+  const engineState = memStore();
+  const backfill = createCtoBackfill({
+    configGet: async () => ({ ctoEnabled: true }),
+    engineState,
+    ledger: noopLedger,
+    segments: { save: async () => {}, load: async () => null },
+    rollups: { save: async () => {}, load: async () => null, dir: "/tmp/none" },
+    summarize: validSummarize(),
+    computeOneLiner: async () => "work",
+    runEphemeral: async () => ({ ok: false, gated: true }),
+    getDb: async () => fx.db,
+    presenceCheck: AWAY,
+    now: () => NOW,
+    capUsd: 0.01, // any spend exceeds
+  });
+
+  const res = await backfill.step();
+  assert.equal(res.stopped, true);
+  assert.equal(res.reason, "budget");
+  assert.equal(engineState._data.backfillDone, true, "once stopped, marked done");
+  assert.equal(engineState._data.backfillStopped.reason, "budget");
+  assert.equal(engineState._data.backfillStopped.stoppedAtDepthDays, DEFAULT_BACKFILL_DAYS, "nothing processed → full depth reported");
+  assert.equal(engineState._data.backfillStopped.spentUsd, 2);
+});
+
+test("once-per-box marker: a completed backfill (backfillDone=true) never re-runs — getDb is not even called", async () => {
+  const NOW = 1000 * DAY;
+  let dbCalls = 0;
+  // Pre-seed the marker: a re-enable of the engine starts with this.
+  const engineState = memStore({ backfillDone: true, backfillStopped: { reason: "budget", stoppedAtDepthDays: 12 } });
+  const backfill = createCtoBackfill({
+    configGet: async () => ({ ctoEnabled: true }),
+    engineState,
+    ledger: noopLedger,
+    getDb: async () => {
+      dbCalls += 1;
+      return null;
+    },
+    presenceCheck: AWAY,
+    now: () => NOW,
+  });
+  const res = await backfill.step();
+  assert.equal(res.done, true);
+  assert.equal(dbCalls, 0, "the marker short-circuits before touching the db");
+  assert.equal(res.progress.done, 0);
+});
+
+test("segments phase replays a session into a persisted segment and advances progress", async () => {
+  const fx = await openFixture();
+  if (!fx) return;
+  const NOW = 1000 * DAY;
+  fx.insSession("s1", { agent: "build", directory: "/work/proj" });
+  fx.insMessage("u1", "s1", { role: "user", ts: NOW - 2000, text: "debug the login flow" });
+  fx.insMessage("a1", "s1", { role: "assistant", ts: NOW - 1000, cost: 0 });
+
+  const engineState = memStore();
+  const segments = memFileStore();
+  const backfill = createCtoBackfill({
+    configGet: async () => ({ ctoEnabled: true }),
+    engineState,
+    ledger: noopLedger,
+    segments,
+    rollups: { save: async () => {}, load: async () => null, dir: "/tmp/none" },
+    summarize: validSummarize(),
+    computeOneLiner: async () => "debug the login flow",
+    getDb: async () => fx.db,
+    presenceCheck: AWAY,
+    now: () => NOW,
+    maxSessionsPerStep: 100,
+  });
+
+  const res = await backfill.step();
+  assert.equal(res.ok, true);
+  assert.ok(engineState._data.backfillStartInstant, "watermark recorded at kick-off");
+  // The session's messages are all < watermark → processed, progress advanced.
+  assert.deepEqual(engineState._data.backfillProgress.processedSessions, ["s1"]);
+  assert.equal(engineState._data.backfillProgress.total, 1);
+  assert.equal(res.progress.done, 1);
+  assert.equal(res.progress.total, 1);
+  // A segment was persisted by the segmenter on close.
+  const segmentsList = [...segments._data.values()];
+  assert.ok(segmentsList.length >= 1, "expected >=1 persisted segment; got: " + segmentsList.length);
+  const seg = segmentsList[0];
+  assert.equal(seg.sessionID, "s1");
+  assert.ok(seg.summary, "segment carries a summary");
+});
+
+test("watermark enforced during replay: a message at/after the watermark is NOT re-segmented", async () => {
+  const fx = await openFixture();
+  if (!fx) return;
+  const NOW = 1000 * DAY;
+  fx.insSession("s1", { agent: "build", directory: "/work/proj" });
+  fx.insMessage("u1", "s1", { role: "user", ts: NOW - 2000, text: "old work" });
+  fx.insMessage("w1", "s1", { role: "user", ts: NOW + 1000, text: "LIVE work after the watermark" });
+
+  const engineState = memStore();
+  const segments = memFileStore();
+  const backfill = createCtoBackfill({
+    configGet: async () => ({ ctoEnabled: true }),
+    engineState,
+    ledger: noopLedger,
+    segments,
+    rollups: { save: async () => {}, load: async () => null, dir: "/tmp/none" },
+    summarize: validSummarize(),
+    computeOneLiner: async () => "old work",
+    getDb: async () => fx.db,
+    presenceCheck: AWAY,
+    now: () => NOW,
+    maxSessionsPerStep: 100,
+  });
+
+  await backfill.step();
+  const seg = [...segments._data.values()][0];
+  assert.ok(seg.window[1] < NOW, `segment end (${seg.window[1]}) stays strictly under the watermark — no overlap with live`);
+});
+
+test("batch-priority: while the user is present, the backfill yields and touches nothing", async () => {
+  const NOW = 1000 * DAY;
+  let dbCalls = 0;
+  const engineState = memStore();
+  const backfill = createCtoBackfill({
+    configGet: async () => ({ ctoEnabled: true }),
+    engineState,
+    ledger: noopLedger,
+    getDb: async () => {
+      dbCalls += 1;
+      return null;
+    },
+    presenceCheck: PRESENT,
+    now: () => NOW,
+  });
+  const res = await backfill.step();
+  assert.equal(res.reason, "present");
+  assert.equal(dbCalls, 0, "present → yields before any work; no db read, no state write");
+  assert.equal(engineState._data.backfillDone, undefined, "a present-yield is not a completion");
+});

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -48,7 +48,10 @@ import {
   ledgerStore,
   engineStateStore,
   cardsStore,
+  segmentsStore,
+  rollupsStore,
 } from "./ctoStores.mjs";
+import { createCtoBackfill } from "./ctoBackfill.mjs";
 import { startPoller } from "./startPoller.mjs";
 import { createSeenIdFilter } from "./seenIds.mjs";
 import {
@@ -260,6 +263,14 @@ export function createCtoEngine(deps = {}) {
     factSurfaceExists = async () => false,
     factVerify = async () => ({ ok: true }),
     factResolveRef = null,
+    // BET-1387 cold-start backfill (§10.6-4): the read-only opencode db handle
+    // (index.mjs supplies the real one via opencodeDb) + a runEphemeral the
+    // backfill's A7 rollup reduces may use. The backfill has its OWN spend
+    // bound, so it must NOT go through the §3.3 rate gate — it uses these raw
+    // seams directly and governs cost itself.
+    getDb = null,
+    backfillRunEphemeral = runEphemeral,
+    backfill = null, // optional pre-built backfill override (tests)
   } = deps;
 
   let disposed = false;
@@ -276,6 +287,7 @@ export function createCtoEngine(deps = {}) {
   let factsEngine = null;
   let verifyHandle = null;
   let tuneHandle = null;
+  let builtInBackfill = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
   // open, user prompt). The desktop heartbeat is read live via
@@ -344,12 +356,32 @@ export function createCtoEngine(deps = {}) {
     } catch {
       /* best-effort */
     }
+    // Backfill progress for the learning card (§10.6-4) — informational, not a
+    // needs-you item. Reads engine-state progress; absent = idle.
+    let backfill = { done: 0, total: 0, stopped: false, active: false };
+    try {
+      const es = (await engineState.load()) || {};
+      const p = es.backfillProgress;
+      backfill = {
+        done: p && Array.isArray(p.processedSessions) ? p.processedSessions.length : 0,
+        total: p?.total ?? 0,
+        startedAt: p?.startedAt ?? null,
+        stopped: !!es.backfillStopped,
+        reason: es.backfillStopped?.reason ?? null,
+        stoppedAtDepthDays: es.backfillStopped?.stoppedAtDepthDays ?? null,
+        // active = started (watermark recorded) but not yet finished.
+        active: !!es.backfillStartInstant && es.backfillDone !== true,
+      };
+    } catch {
+      /* best-effort */
+    }
     return {
       enabled: enabledNow,
       dot: computeDot({ enabled: enabledNow, paused, thrifty }),
       needsYouCount: counts.needsYouCount ?? 0,
       generationInFlight: !!counts.generationInFlight,
       tonightCount: counts.tonightCount ?? 0,
+      backfill,
     };
   }
 
@@ -381,6 +413,11 @@ export function createCtoEngine(deps = {}) {
         await finalizeRollups();
         // §6.2 blackboard: pump the per-project proposal queue (gatekeeper).
         await pumpFacts();
+      }
+      // §10.6-4 cold-start backfill — also ambient, gated on enabled. Its own
+      // drained state marker makes it run at most once per box.
+      if (enabledNow) {
+        await backfillStep();
       }
       await syncState();
     } catch {
@@ -628,7 +665,7 @@ export function createCtoEngine(deps = {}) {
   // backfilled — a window only gets rolled up once it has actually closed.
   // One shared ephemeral-rate wrapper (§3.3) used by both the rollup runner and
   // the facts gatekeeper — every model-bound CTO step goes through the same
-  // per-session creation gate (D10's writer discipline).
+  // per-session creation gate (D10's "well-maintained" writer discipline).
   const gatedRunEphemeral = async (data) => {
     const gate = await beginEphemeral();
     if (!gate.ok) return { ok: false, gated: true, error: gate.error };
@@ -737,6 +774,39 @@ export function createCtoEngine(deps = {}) {
       }
     } catch {
       /* rollups are best-effort — never take the engine down */
+    }
+  }
+
+  // Lazy-construct the cold-start backfill (§10.6-4). Mirrors the rollup/facts
+  // pattern: degenerate to the real store-backed module; tests inject an
+  // override. The backfill governs its own one-time spend bound + batch-priority
+  // (presence) internally and NEVER touches the engine's §3.3 rate tracker.
+  function getBackfill() {
+    if (builtInBackfill) return builtInBackfill;
+    builtInBackfill = backfill ?? createCtoBackfill({
+      configGet,
+      engineState,
+      ledger,
+      segments: segmentsStore,
+      rollups: rollupsStore,
+      summarize, // raw seam — the backfill owns its own budget, no rate gate
+      computeOneLiner,
+      runEphemeral: backfillRunEphemeral,
+      getDb: getDb ?? (async () => null),
+      presenceCheck: () => engine.getPresence().state === "present",
+      now,
+    });
+    return builtInBackfill;
+  }
+
+  // One incremental backfill batch per tick (segments/rollups), oldest-first,
+  // batch-priority. Once-per-box is enforced by the module's engine-state
+  // marker. Never throws into the poller.
+  async function backfillStep() {
+    try {
+      await getBackfill().step();
+    } catch {
+      /* backfill is best-effort — never take the engine down */
     }
   }
 
@@ -962,6 +1032,9 @@ export function createCtoEngine(deps = {}) {
     },
     get facts() {
       return getFactsEngine();
+    },
+    get backfill() {
+      return getBackfill();
     },
   };
 

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1826,6 +1826,11 @@ const adaptiveCto = ctoEngine.createCtoEngine({
       generationInFlight: adaptiveCtoDigest ? await adaptiveCtoDigest.isGenerating() : false,
     };
   },
+  // BET-1387 cold-start backfill: the read-only opencode db handle (⌘F search's
+  // source) + the A7 rollup reduce producer. The backfill pays for these out of
+  // its own one-time spend bound, so they bypass the engine's §3.3 rate gate.
+  getDb,
+  backfillRunEphemeral: runEphemeral,
 });
 adaptiveCto.start();
 

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -176,6 +176,18 @@ export type CtoState = {
   generationInFlight: boolean;
   // Number of tasks queued for tonight's window — the muted Tonight line.
   tonightCount: number;
+  // Cold-start backfill (§10.6-4): informational learning-card progress. Not a
+  // needs-you item — never counted into the sidebar badge. Optional so older
+  // bridges (absent field) still typecheck as idle.
+  backfill?: {
+    done: number;
+    total: number;
+    startedAt: number | null;
+    stopped: boolean;
+    reason: string | null;
+    stoppedAtDepthDays: number | null;
+    active: boolean;
+  };
 };
 
 /**


### PR DESCRIPTION
## BET-1387 — Cold-start backfill (§10.6-4)

On first enable, replay up to 30 days of stored opencode history **through the A6 segmentation + summary pipeline and A7 rollups**, oldest first, so the CTO boots with a live model instead of an empty one. Read-only over the opencode DB (same `opencodeDb` handle ⌘F search uses — never writes to it).

**Guardrails (all in `ctoBackfill.mjs`):**
- **Watermark:** `backfillStartInstant` recorded in `engine-state.json` at kick-off. Live ingestion owns ts ≥ it; the backfill processes strictly `<` it → no overlap, no double-count. (Pure `historyWindow`/`sessionInRange`.)
- **Spend bound:** one-time budget (default $3, config `ctoBackfillCapUsd`), cumulative model-ledger cost since kick-off. On reaching it, stop at the depth reached and persist `{stoppedAtDepthDays, reason:"budget"}`; the learning card says so.
- **Batch-priority:** reduce calls run only while presence isn't "present"; yields between calls.
- **Once per box:** `engine-state.json` marker — a re-enable of the CTO does not re-run it.

**Learning card** (`learning`-chipped, neutral border, informational → never counts into the sidebar badge): segment progress `n/total`, ETA, and the ask-only promise line. Backed by `GET /api/cto/state` now carrying `backfill: {done, total, startedAt, stopped, reason, stoppedAtDepthDays, active}`.

**Files:** create `ctoBackfill.mjs` + `.test.mjs`; modify `ctoEngine.mjs` (lazy backfill + one incremental `step()` per enabled tick + `readState.backfill`), `index.mjs` (wire read-only `getDb` + the A7 reduce producer `backfillRunEphemeral` — the backfill pays for it from its own bound, deliberately bypassing the §3.3 rate gate so it can't trip the engine kill-switch), `CtoPanel.tsx`, `ctoView.ts`, `src/shared/api.ts`.

Out of scope (per spec): profile backfill specifics and tool-discovery backfill (P2 runs its own extractors over the same range).

**Cross-cutting notes:**
- The backfill's A7 rollups only feed its own `backfillRunEphemeral`; the live `finalizeRollups` stays inert exactly as before (no `runEphemeral` wired) — no behavior change to the live rollup path.
- Rebased onto current `origin/main` (now includes BET-1389 blackboard) — resolved the `ctoEngine.mjs` conflicts (kept both the blackboard and backfill seams).

**Follow-up filed (parked):** backfill refinements (segment-grouping fidelity — per-turn force-close vs live G grouping — and rollup-window scan cost).

**Base:** `origin/main` @ `414f58b3`

**Verification results:**
- PR branch (`multica/BET-1387-cold-start-backfill` @ `da8280bc`):
  - typecheck: exit 0. Errors: none.
  - test (node:test server cto suite): exit 0, 137/137 pass. Full `npm test`: typecheck 0 + vitest + node:test all green on the pre-rebase run (final: 0 new failures).
  - Web-leaf tests (ctoView, tailwindScale, primitives): 91 pass / 7 skip.
- Full `vitest run` is flaky under local resource contention (jsdom/xterm canvas aborts take down unrelated files, intermittent — not related to this diff; CI on the single runner is the source of truth).
- **Conclusion:** no new test failures from this PR; the cto suite + typecheck are deterministic green.
