### PR TITLE
feat(cto): inbox supersession for send_to_cto (BET-1397)

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -533,11 +533,22 @@ durable queue and the gatekeeper, and returns the gatekeeper verdict (or a
 
 Two companion capabilities to the `cto` read belt, both global opencode tools.
 
-- **`send_to_cto(message, opts?)`** (global tool, `docs/opencode-tools/send-to-cto.ts`):
-  report a note up to the CTO from ANY session. With no live call it is surfaced
-  to the user as a notification; once the call-window feature ships it is injected
-  into the CTO conversation as a turn. Use it to flag something the CTO should know
-  (a new P0, a blocker, a call-back request). Thin registrar → `POST /api/cto/inbound`.
+- **`send_to_cto({kind?, message, refs?, tag?, title?})`** (global tool,
+  `docs/opencode-tools/send-to-cto.ts`): report a note to the CTO inbox from
+  ANY session (spec §4.4). One verb, one routing rule: a bare `{message}` maps
+  to `kind: "blocker"` and fires the immediate blocking-tier notification (the
+  same router a waiting-question uses); every other kind (`fyi`/`finding`/
+  `handoff`/`anomaly`) is SILENT — it lands in the durable
+  `~/.manta/cto/inbox.json` store unread and surfaces only via `read_inbox`
+  (or the engine drain). Dedupe: notes sharing a `tag` coalesce into one entry
+  (refs union, timestamp refreshed). Give each note context and passing `refs`
+  so the CTO can jump to it. This supersedes all earlier send_to_cto spellings.
+  Thin registrar → `POST /api/cto/inbound`.
+- **`read_inbox({kind?, read?, tag?})`** (via the `cto` tool,
+  `docs/opencode-tools/cto.ts`): read the CTO inbox — the queue of notes any
+  session sent via send_to_cto — optionally filtered. READ-ONLY: it never
+  marks notes read (the engine drain does, at rollup-close breakpoints) and
+  never writes.
 - **`watch(surface, condition)`** + `unwatch` / `list_watches` (via the `cto` tool,
   `docs/opencode-tools/cto.ts`): register a recurring probe against a surface
   (`schedule`, `delegate`, ...). The box runs the watch's condition

--- a/docs/opencode-tools/cto.ts
+++ b/docs/opencode-tools/cto.ts
@@ -26,14 +26,20 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 const CTO_TOOLS =
   "list_sessions, list_projects, read_transcript, search_messages, git_status, " +
   "git_branch, git_log, list_models, get_usage, usage_stopped, session_usage, " +
+<<<<<<< HEAD
   "context_state, session_plan_mode, get_config, read_rollups, read_ledger, " +
   "watch, unwatch, list_watches";
+=======
+  "context_state, session_plan_mode, get_config, read_inbox, watch, unwatch, " +
+  "list_watches";
+>>>>>>> 49a8ab9d (feat(cto): inbox supersession for send_to_cto (BET-1397))
 
 export const cto = tool({
   description: [
     "Deterministic on-call CTO tools: inspect what's running on this box,",
     "read chat transcripts, search messages, git state, models, plan usage,",
-    "stopped conversations, per-session cost/context/plan-mode, and config. Reads",
+    "stopped conversations, per-session cost/context/plan-mode, config, and the",
+    "CTO inbox (read_inbox — the notes any session sent via send_to_cto). Reads",
     "never mutate anything. The watch/unwatch/list_watches",
     "tools register watchers (watch is a confirm-mode action).",
     `Pick \`tool\` from: ${CTO_TOOLS}.`,

--- a/docs/opencode-tools/cto.ts
+++ b/docs/opencode-tools/cto.ts
@@ -26,13 +26,8 @@ const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
 const CTO_TOOLS =
   "list_sessions, list_projects, read_transcript, search_messages, git_status, " +
   "git_branch, git_log, list_models, get_usage, usage_stopped, session_usage, " +
-<<<<<<< HEAD
-  "context_state, session_plan_mode, get_config, read_rollups, read_ledger, " +
-  "watch, unwatch, list_watches";
-=======
-  "context_state, session_plan_mode, get_config, read_inbox, watch, unwatch, " +
+  "context_state, session_plan_mode, get_config, read_rollups, read_ledger, read_inbox, watch, unwatch, " +
   "list_watches";
->>>>>>> 49a8ab9d (feat(cto): inbox supersession for send_to_cto (BET-1397))
 
 export const cto = tool({
   description: [

--- a/docs/opencode-tools/send-to-cto.ts
+++ b/docs/opencode-tools/send-to-cto.ts
@@ -11,14 +11,17 @@
 // registers.
 //
 // PURPOSE: let ANY session report something to the on-call CTO. This is a THIN
-// registrar: `execute` POSTs `{surface:"session", sessionID, message, ...opts}`
-// to manta-server's /api/cto/inbound (same box, no SSH hop) and returns
-// immediately. manta-server owns the routing (dedupe + live-vs-parked), NOT
-// this tool. See src/server/cto.mjs (createCtoInbound).
+// registrar: `execute` POSTs `{surface:"session", sessionID, kind?, message,
+// refs?, tag?, title?}` to manta-server's /api/cto/inbound (same box, no SSH
+// hop) and returns immediately. manta-server owns the routing (dedupe +
+// live-vs-parked + the inbox store, spec §4.4), NOT this tool. See
+// src/server/cto.mjs (createCtoInbound).
 //
-// When no "call is live" flag is set (this issue), the message routes to the
-// PARKED path and the user gets a push/notify. Once Issue 3 flips the live
-// flag, the message is injected into the CTO session as a turn instead.
+// BET-1397 supersession: the note lands in the durable CTR inbox (sender
+// identity, dedupe by tag, kind, TTL); a bare {message} maps to `blocker`.
+// Only `blocker` kinds fire the immediate blocking-tier notification. When no
+// "call is live" flag is set (this issue), the note persists to the inbox and
+// the CTO reads it via the `read_inbox` verb.
 
 import { tool } from "@opencode-ai/plugin";
 import { boxToken, authHeaders } from "./manta-auth";
@@ -55,43 +58,57 @@ async function call(method: string, path: string, body?: unknown): Promise<any> 
 
 export const send_to_cto = tool({
   description: [
-    "Send a message to the on-call CTO. Any session can call this: it reports a",
-    "note up to the CTO, who has a read-only tool belt over what's running, the",
-    "Multica board, usage, and more. The message is surfaced to the user: when",
-    "the CTO call is not live it arrives as a push/notify; once the call-window",
-    "feature ships it is injected into the CTO conversation as a turn. Use this",
-    "to flag something the CTO should know (a new P0, a blocker, a request to",
-    "call you back). It returns immediately — the box owns routing.",
+    "Report a note to the on-call CTO. Any session can call this: it appends a",
+    "note to the durable CTO inbox (the CTO reads it via the read_inbox verb).",
+    "One verb, one routing rule: a bare {message} is treated as a blocker and",
+    "fires the immediate blocking-tier notification the same way a question",
+    "waiting does; a non-blocker kind is silent — it sits in the inbox until the",
+    "CTO drains it. You should give the message some context (what happened, why",
+    "it matters), and pass refs (a new P0 issue, a blocker, a failing check) so",
+    "the CTO can jump to it. This supersedes every earlier send_to_cto spelling.",
   ].join(" "),
   args: {
     message: z
       .string()
-      .describe("What to report to the CTO. Be concrete: the fact, not the process."),
-    title: z
+      .describe("What to report. Be concrete: the fact, the impact, what the CTO should know."),
+    kind: z
+      .enum(["fyi", "finding", "blocker", "handoff", "anomaly"])
+      .optional()
+      .describe(
+        "The note's kind. Default (and bare {message}) is `blocker`, which is the only " +
+          "kind that fires the immediate blocking-tier notification. fyi/finding/handoff/" +
+          "anomaly are silent — they land in the inbox unread and surface via read_inbox.",
+      ),
+    refs: z
+      .array(z.string())
+      .optional()
+      .describe("Optional refs for the note — issue/PR keys, check names, surface ids — so the CTO can jump to them."),
+    tag: z
       .string()
       .optional()
       .describe(
-        "Optional short title for the surfaced notification. Defaults to the sender's " +
-          "session label.",
+        "Optional dedupe tag: two notes with the same tag coalesce into one inbox entry " +
+          "(refs union, timestamp refreshed, count bumped) instead of creating a duplicate.",
       ),
-    urgent: z
-      .boolean()
+    title: z
+      .string()
       .optional()
-      .describe(
-        "If true, deliver to every device immediately (blocking tier). Use sparingly — " +
-          "only for something the CTO must see right now.",
-      ),
+      .describe("Optional short title for the surfaced notification. Defaults to the sender's session label."),
   },
   async execute(args, context) {
     const result = await call("POST", "/api/cto/inbound", {
       surface: "session",
       sessionID: context.sessionID,
+      kind: args.kind,
       message: args.message,
+      refs: args.refs,
+      tag: args.tag,
       title: args.title,
-      urgent: !!args.urgent,
     });
-    return result.parked
-      ? "Reported to the CTO (no live call — surfaced as a notification)."
-      : "Reported to the CTO.";
+    const blocker = result.parked && args.kind !== "fyi" && args.kind !== "finding" &&
+      args.kind !== "handoff" && args.kind !== "anomaly" && (args.kind === "blocker" || !args.kind);
+    return blocker
+      ? "Flagged to the CTO as a blocker (immediate notification + inbox note)."
+      : "Reported to the CTO inbox (silent — surfaces via read_inbox).";
   },
 });

--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -34,7 +34,15 @@ import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { describeModel } from "../shared/modelGuide.mjs";
 import { createSeenIdFilter } from "./seenIds.mjs";
 import { startPoller } from "./startPoller.mjs";
-import { rollupsStore, ledgerStore, ROLLUP_LEVELS } from "./ctoStores.mjs";
+import {
+  rollupsStore,
+  ledgerStore,
+  ROLLUP_LEVELS,
+  inboxStore,
+  INBOX_KINDS,
+  inboxExpiresAt,
+  purgeExpiredInbox,
+} from "./ctoStores.mjs";
 
 export const CTO_STORE_PATH = statePath("cto.json");
 
@@ -124,6 +132,8 @@ export function createCtoEngine(deps = {}) {
       store.watches = Array.isArray(watches) ? watches : [];
       await saveCtoStore(store);
     },
+    loadInbox = async () => inboxStore.load(),
+    saveInbox = async (data) => inboxStore.save(data),
     now = () => Date.now(),
   } = deps;
 
@@ -772,6 +782,42 @@ export function createCtoEngine(deps = {}) {
     run: async () => ({ ok: true, data: { watches: await loadWatches() } }),
   });
 
+  register({
+    name: "read_inbox",
+    description: "Read the on-call CTO inbox (spec §4.4) — the durable queue of notes any " +
+      "session sent via send_to_cto. Returns each note's kind (fyi|finding|blocker|" +
+      "handoff|anomaly), message, tag, refs, sender, ts, read state, and count. " +
+      "READ-ONLY: it does not mark notes read (the engine drain does at breakpoints) " +
+      "and it never writes. Optionally filter by kind, read state, or tag. " +
+      "An expired note is absent from the view.",
+    params: {
+      kind: { type: "string", description: "Only notes of this kind (fyi|finding|blocker|handoff|anomaly)." },
+      read: { type: "boolean", description: "Only notes with this read state (true/false)." },
+      tag: { type: "string", description: "Only notes carrying this dedupe tag." },
+    },
+    run: async (ctx, args) => {
+      let data;
+      try {
+        data = await loadInbox();
+      } catch {
+        data = {};
+      }
+      let entries = Array.isArray(data?.entries) ? data.entries : [];
+      const { keep } = purgeExpiredInbox(entries, { nowMs: now() });
+      entries = keep;
+      if (args && typeof args.kind === "string" && args.kind) {
+        entries = entries.filter((e) => e?.kind === args.kind);
+      }
+      if (args && typeof args.read === "boolean") {
+        entries = entries.filter((e) => e?.read === args.read);
+      }
+      if (args && typeof args.tag === "string" && args.tag) {
+        entries = entries.filter((e) => e?.tag === args.tag);
+      }
+      return { ok: true, data: { entries } };
+    },
+  });
+
   // -------------------------------------------------------------------------
   // Dispatch
   // -------------------------------------------------------------------------
@@ -936,21 +982,26 @@ async function remoteGitLog(cwd, { n = 10, oneline = true } = {}) {
 }
 
 // ---------------------------------------------------------------------------
-// Inbound funnel (Issue 2) — createCtoInbound
+// Inbound funnel (superseded by BET-1397) — createCtoInbound
 // ---------------------------------------------------------------------------
 // The single place a CTO-bound event enters the box. Producers (the
 // send_to_cto tool, the watcher poller, a scheduled prompt, a webhook) all
 // call `inbound({ surface, payload, seenId })`. Live vs parked is decided by
 // the server-side "call active" flag (Issue 3 sets it; this issue it is
 // always false, so every event takes the parked route). Parked events are
-// de-duped by seenId and surfaced through the EXISTING notification router
-// (push.mjs fireNotify) — no second notify path.
+// de-duped by seenId, persisted to the inbox.json store (spec §4.4), and only
+// a `blocker` kind additionally enters the A8 card path (which fires the ONE
+// blocking-tier notification through the existing router). The old direct
+// blanket-notify branch is deleted — non-blocker notes are silent.
 export function createCtoInbound({
   seenFilter = createSeenIdFilter(),
   isCallActive = () => false,
   ctoSessionID = null,
-  fireNotify = async () => {},
   sendPrompt = async () => {},
+  loadInbox = async () => inboxStore.load(),
+  saveInbox = async (data) => inboxStore.save(data),
+  registerBlocker = async () => {},
+  now = () => Date.now(),
 } = {}) {
   async function inbound({ surface = "session", payload = {}, seenId } = {}) {
     // De-dupe: an event whose seenId was already handled is a re-delivery
@@ -969,23 +1020,97 @@ export function createCtoInbound({
       }
       return { ok: true, live: true };
     }
-    // PARKED route: surface via the existing notification router.
+    // PARKED route: write the inbox store. A bare {message} maps to the
+    // `blocker` default (§4.4) — the current urgent semantics preserved.
+    const kind = normalizeInboxKind(payload?.kind);
     const message = typeof payload?.message === "string" ? payload.message.trim() : "";
-    if (message) {
+    if (!message) {
+      // Nothing meaningful to persist — resolve without writing or notifying.
+      return { ok: true, parked: true, dropped: true };
+    }
+    const ts = now();
+    const tag = typeof payload?.tag === "string" && payload.tag ? payload.tag : null;
+    const sender = {
+      sessionID: typeof payload?.sessionID === "string" && payload.sessionID ? payload.sessionID : null,
+      name: typeof payload?.senderName === "string" && payload.senderName ? payload.senderName : null,
+    };
+    const entry = {
+      id: tag ? stableHash(`tag:${tag}`) : stableHash(randomBytes(16).toString("hex")),
+      kind,
+      message,
+      refs: Array.isArray(payload?.refs) ? payload.refs.filter((r) => typeof r === "string") : [],
+      tag,
+      sender,
+      title: typeof payload?.title === "string" && payload.title ? payload.title : undefined,
+      ts,
+      read: false,
+      count: 1,
+      expires: inboxExpiresAt(kind, ts, { now }),
+    };
+
+    // Load (silently dropping expired), dedupe by tag (coalesce) else append.
+    let data;
+    try {
+      data = await loadInbox();
+    } catch {
+      data = {};
+    }
+    let entries = Array.isArray(data?.entries) ? data.entries : [];
+    const { keep } = purgeExpiredInbox(entries, { nowMs: ts });
+    entries = keep;
+    let coalesced = false;
+    if (tag) {
+      const idx = entries.findIndex((e) => e?.tag === tag);
+      if (idx >= 0) {
+        entries[idx] = coalesceInboxEntry(entries[idx], entry, ts);
+        coalesced = true;
+      } else {
+        entries.push(entry);
+      }
+    } else {
+      entries.push(entry);
+    }
+    const effective = coalesced ? entries.find((e) => e?.tag === tag) : entry;
+    try {
+      await saveInbox({ ...data, entries });
+    } catch (e) {
+      console.warn("[cto] inbox save failed:", e?.message ?? e);
+    }
+
+    // blocker → the A8 card path (source 3), which fires the single
+    // blocking-tier notification through the existing router. Other kinds are
+    // silent — they surface later only via read_inbox / the engine drain.
+    if (kind === "blocker") {
       try {
-        await fireNotify({
-          message,
-          title: typeof payload?.title === "string" && payload.title ? payload.title : undefined,
-          urgent: !!payload?.urgent,
-          sessionID: typeof payload?.sessionID === "string" ? payload.sessionID : undefined,
-        });
+        await registerBlocker(effective);
       } catch (e) {
-        console.warn("[cto] inbound notify failed:", e?.message ?? e);
+        console.warn("[cto] inbox blocker card failed:", e?.message ?? e);
       }
     }
-    return { ok: true, parked: true };
+    return { ok: true, parked: true, kind, tag, coalesced, entryId: effective.id };
   }
   return { inbound };
+}
+
+// Map a supplied kind to a valid inbox kind; anything unrecognised (or a bare
+// {message}) is the `blocker` default — the prior urgent semantics, preserved.
+export function normalizeInboxKind(kind) {
+  return typeof kind === "string" && INBOX_KINDS.includes(kind) ? kind : "blocker";
+}
+
+// Coalesce a re-tagged note into its existing entry (spec §4.4): refs union,
+// timestamp refreshed, count incremented; the merged note is unread until
+// drained.
+export function coalesceInboxEntry(existing, incoming, ts) {
+  const refs = Array.from(new Set([...(existing?.refs ?? []), ...(incoming?.refs ?? [])]));
+  return {
+    ...existing,
+    ...incoming,
+    refs,
+    ts,
+    count: (typeof existing?.count === "number" ? existing.count : 1) + 1,
+    read: false,
+  };
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -33,7 +33,7 @@ function makeEngine(overrides = {}) {
   return engine;
 }
 
-const TOOL_COUNT = 19; // 16 reads (BET-1164 + BET-1383 read_rollups/read_ledger) + 3 watcher tools watch/unwatch/list_watches (BET-1165)
+const TOOL_COUNT = 20; // 16 reads (BET-1164 + BET-1383 read_rollups/read_ledger) + read_inbox (BET-1397) + 3 watcher tools (BET-1165)
 
 // ---------------------------------------------------------------------------
 // Registry integrity
@@ -63,6 +63,7 @@ test("registry exposes every cto read tool with a complete shape, all mode auto"
       "get_config",
       "read_rollups",
       "read_ledger",
+      "read_inbox",
       "watch",
       "unwatch",
       "list_watches",

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -63,6 +63,11 @@ export const CARD_DISMISSED = "card.dismissed";
 // Blocker source discriminator for health/watchdog escalations (distinct from
 // the question|permission worker-ask source kinds).
 export const HEALTH_SOURCE_KIND = "health";
+// Source (3): an inbox note of kind `blocker` sent via send_to_cto (BET-1397 /
+// spec §4.4). It becomes an A8 blocker-card source — the blocking-tier
+// notification fires IMMEDIATELY through the existing router (the same one
+// source 1 relies on), and the card appears at > 10 min via promoteDue.
+export const INBOX_SOURCE_KIND = "inbox";
 
 // Stable, collision-resistant card id. Re-detection of the same (sourceKind,
 // sourceId) yields the same id → upsert in place, never a duplicate.
@@ -119,12 +124,14 @@ export function askResolveInfo(evt) {
 export function blockerTitle(kind) {
   if (kind === "permission") return "Permission needed";
   if (kind === "question") return "Question waiting";
+  if (kind === "inbox") return "Blocker flagged for CTO";
   return "Health check";
 }
 
 export function blockerBody(kind, text) {
   if (kind === "permission") return text || "Claude needs permission to run a tool.";
   if (kind === "question") return text || "Claude is waiting on an answer.";
+  if (kind === "inbox") return text || "A session flagged a blocker for the CTO.";
   return text || "The CTO paused itself — review the health state.";
 }
 
@@ -147,6 +154,10 @@ export function createCtoCards(deps = {}) {
     cardStore = cardsStore,
     engineState = engineStateStore,
     ledger = ledgerStore,
+    // Source (3) router (BET-1397): the existing blocking-tier notification
+    // router (push.mjs fireNotify). Only `onInboxBlocker` uses it — worker-ask
+    // and health cards keep the "no notification path" invariant.
+    fireNotify = async () => {},
     now = () => Date.now(),
   } = deps;
 
@@ -154,6 +165,41 @@ export function createCtoCards(deps = {}) {
   // body, askedAt }. Kept in memory (derived from the live event stream); once
   // promoted, the card itself is durable in cards.json.
   const pendingAsks = new Map();
+
+  // Source (3): a `blocker` inbox note (BET-1397 / spec §4.4). This is the ONE
+  // notification path for inbox notes: fires the blocking-tier notify through
+  // the injected router exactly once, and registers a pending blocker so the
+  // card timer (promoteDue) promotes it at > 10 min like any ask. Read-only on
+  // the inbox itself — the inbound funnel already persisted the entry.
+  async function onInboxBlocker({ message, title, refs = [], tag, sessionID, ts = now() } = {}) {
+    const text = typeof message === "string" ? message.trim() : "";
+    if (!text) return { changed: false, notified: false };
+    // Blocking-tier notification — exactly one, via the shared router.
+    try {
+      await fireNotify({
+        message: text,
+        title: typeof title === "string" && title ? title : undefined,
+        urgent: true,
+        sessionID: typeof sessionID === "string" ? sessionID : undefined,
+      });
+    } catch (e) {
+      console.warn("[cto] inbox blocker notify failed:", e?.message ?? e);
+    }
+    // Register a pending blocker so the card appears at > 10 min. Key by the
+    // sending session when known, else by a stable hash of the tag/message;
+    // the card id stays stable across re-reports of the same note (upsert).
+    const sourceId = stableCardId(INBOX_SOURCE_KIND, tag || text);
+    const key = typeof sessionID === "string" && sessionID ? sessionID : sourceId;
+    pendingAsks.set(key, {
+      sourceKind: INBOX_SOURCE_KIND,
+      sourceId,
+      sessionID: typeof sessionID === "string" ? sessionID : undefined,
+      body: text,
+      refs: Array.isArray(refs) ? refs : [],
+      askedAt: ts,
+    });
+    return { changed: true, notified: true };
+  }
 
   async function ledgerAppend(entry) {
     try {
@@ -291,7 +337,7 @@ export function createCtoCards(deps = {}) {
         sessionID: ask.sessionID,
         title: blockerTitle(ask.sourceKind),
         body: blockerBody(ask.sourceKind, ask.body),
-        refs: ask.sessionID ? [ask.sessionID] : [],
+        refs: Array.isArray(ask.refs) && ask.refs.length ? ask.refs : ask.sessionID ? [ask.sessionID] : [],
         ts: nowMs,
         pendingSince: ask.askedAt,
       });
@@ -381,6 +427,7 @@ export function createCtoCards(deps = {}) {
   return {
     onAskStart,
     onAskResolved,
+    onInboxBlocker,
     promoteDue,
     ingestHealthEscalations,
     onHealthRecovered,

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -245,3 +245,47 @@ test("countOpen reflects only open cards", async () => {
   await h.cards.onAskResolved({ sessionID: "sC" });
   assert.equal(await h.cards.countOpen(), 0);
 });
+
+test("BET-1397 source 3: an inbox blocker fires the blocking-tier notify exactly once and promotes a card", async () => {
+  const clock = { ms: 1_000_000 };
+  let cardPayload = { v: 1, cards: [] };
+  const ledgerRows = [];
+  const notified = [];
+  const cards = createCtoCards({
+    cardStore: {
+      load: async () => cardPayload,
+      save: async (p) => {
+        cardPayload = p;
+      },
+    },
+    engineState: { load: async () => ({ v: 1 }), save: async () => {} },
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    fireNotify: async (a) => notified.push(a),
+    now: () => clock.ms,
+  });
+
+  const r = await cards.onInboxBlocker({
+    message: "build is red",
+    title: "CI broken",
+    refs: ["BET-777"],
+    tag: "ci",
+    sessionID: "ses-9",
+    ts: clock.ms,
+  });
+  assert.equal(r.notified, true);
+  // Exactly ONE notification, blocking tier, via the shared router.
+  assert.equal(notified.length, 1);
+  assert.equal(notified[0].message, "build is red");
+  assert.equal(notified[0].title, "CI broken");
+  assert.equal(notified[0].urgent, true);
+  assert.equal(notified[0].sessionID, "ses-9");
+
+  // The inbox blocker becomes a card at > 10 min like any ask.
+  clock.ms += BLOCKER_AFTER_MS;
+  const p = await cards.promoteDue();
+  assert.equal(p.changed, true);
+  const open = cardPayload.cards.filter((c) => c.state === "open");
+  assert.equal(open.length, 1);
+  assert.equal(open[0].sourceKind, "inbox");
+  assert.deepEqual(open[0].refs, ["BET-777"]);
+});

--- a/src/server/ctoDigest.mjs
+++ b/src/server/ctoDigest.mjs
@@ -490,6 +490,7 @@ export function createCtoDigest(deps = {}) {
     getEnabled = async () => false, // top-level ctoEnabled gate for the scheduler
     digestPushEnabled = async () => false, // §10.5 toggle (ships A12) — off by default
     pushDigest = async () => {}, // informational notification honoring router deferral
+    drain = async () => {}, // BET-1397: call engine.drainInbox() so unread inbox notes become evidence before composing
     intervalMs = SCHEDULER_INTERVAL_MS,
     fs = fsp,
   } = deps;
@@ -585,6 +586,9 @@ export function createCtoDigest(deps = {}) {
   async function doGenerate({ reason = "manual", presenceOf } = {}) {
     const t = now();
     if (!presenceOf) return null;
+    // BET-1397 digest-generation breakpoint: fold unread inbox notes into
+    // evidence before composing (best-effort — never blocks the digest).
+    await safe(drain);
     const gMinutes = (await safe(getGMinutes)) ?? DEFAULT_G_MINUTES;
     const lastSeen = typeof presenceOf.lastSeen === "number" ? presenceOf.lastSeen : t;
     const delta = typeof presenceOf.absenceDelta === "number" ? presenceOf.absenceDelta : Math.max(0, t - lastSeen);

--- a/src/server/ctoDigest.test.mjs
+++ b/src/server/ctoDigest.test.mjs
@@ -542,3 +542,11 @@ test("generateDigest: successful model path emits cto.digest_generated", async (
   assert.equal(generated.reason, "manual");
   assert.equal(generated.items, 1);
 });
+
+test("BET-1397: digest generation drains the CTO inbox before composing", async () => {
+  let drained = 0;
+  const model = async () => ({ text: JSON.stringify({ items: [{ tier: "progress", text: "shipped", refs: [] }] }) });
+  const { engine } = makeEngine({ runEphemeral: model, drain: async () => { drained += 1; } });
+  await engine.generateDigest({ reason: "scheduled" });
+  assert.equal(drained, 1);
+});

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -904,8 +904,6 @@ export function createCtoEngine(deps = {}) {
       return { drained: 0 };
     }
   }
-    }
-  }
 
   // Event ingestion — the ONE thing that keeps running while paused (§10.6-5).
   // Driven from index.mjs's event pump (not a timer); the engine is just

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -50,6 +50,8 @@ import {
   cardsStore,
   segmentsStore,
   rollupsStore,
+  inboxStore,
+  purgeExpiredInbox,
 } from "./ctoStores.mjs";
 import { createCtoBackfill } from "./ctoBackfill.mjs";
 import { startPoller } from "./startPoller.mjs";
@@ -82,7 +84,7 @@ import {
   ROLLUP_LEVELS,
   windowFor as rollupWindowFor,
 } from "./ctoRollups.mjs";
-import { buildFactProposal, createFactsEngine, VERIFY_CYCLE_MS } from "./ctoFacts.mjs";
+import { buildFactProposal, createFactsEngine, VERIFY_CYCLE_MS, senderKey, senderReliability } from "./ctoFacts.mjs";
 import { formatFactsBlock } from "./ctoSessions.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
@@ -237,7 +239,11 @@ export function createCtoEngine(deps = {}) {
     // BET-1382 needs-you card machinery (blocker cards). Defaults to the real
     // stores; tests inject a fake. Cards are about the user's own blockers,
     // not autonomous CTO work, so this is wired regardless of enabled state.
-    cards = createCtoCards({}),
+    // BET-1397: the internal cards manager gets the blocking-tier router
+    // (`cardFireNotify`) so an inbox `blocker` note (source 3) fires the one
+    // notification on the live box.
+    cardFireNotify = async () => {},
+    cards = createCtoCards({ fireNotify: cardFireNotify }),
     // A5 evidence/presence seams (injected I/O — nothing here touches tmux /
     // push directly; index.mjs supplies the real resolvers).
     getSessionInfo = async () => ({ owner: "user", project: undefined }),
@@ -276,6 +282,9 @@ export function createCtoEngine(deps = {}) {
     // §8 profile (BET-1393): optional pre-built profile engine (else one is
     // constructed from the shared profileStore — deterministic, never throws).
     profile = null,
+    // BET-1397 CTO inbox (§4.4): the durable inbox.json store + seam, so drain
+    // is unit-testable without touching the real fs. Defaults to the real store.
+    inbox = null,
   } = deps;
 
   let disposed = false;
@@ -803,6 +812,9 @@ export function createCtoEngine(deps = {}) {
       if (changed) {
         await engineState.save({ ...payload, rollupCursor: cursor });
       }
+      // BET-1397 breakpoint drain (rollup close): fold unread inbox notes into
+      // evidence. Best-effort — never blocks or breaks the rollup fold.
+      await drainInbox();
     } catch {
       /* rollups are best-effort — never take the engine down */
     }
@@ -838,6 +850,60 @@ export function createCtoEngine(deps = {}) {
       await getBackfill().step();
     } catch {
       /* backfill is best-effort — never take the engine down */
+    }
+  }
+
+  // BET-1397 inbox drain (§4.4): at breakpoints (rollup close; digest /
+  // overnight planning land with later issues and hook the same method) every
+  // UNREAD inbox note becomes a high-salience evidence event on the A1 ledger,
+  // weighted by the B1 sender-reliability (Beta mean) of the sending session,
+  // and is then marked read. Inbox content rides as untrusted data — it is
+  // written verbatim to the ledger, never treated as instructions. Silent:
+  // expired entries are dropped (`purgeExpiredInbox`) with no trace.
+  async function drainInbox() {
+    try {
+      const store = inbox ?? inboxStore;
+      const payload = await store.load();
+      const entries = Array.isArray(payload?.entries) ? payload.entries : [];
+      if (entries.length === 0) return { drained: 0 };
+      const { keep } = purgeExpiredInbox(entries, { nowMs: now() });
+      const unread = keep.filter((e) => !e?.read);
+      if (unread.length === 0) {
+        if (keep.length !== entries.length) await store.save({ ...payload, entries: keep });
+        return { drained: 0 };
+      }
+      // Per-sender reliability (Beta mean, §6.4 / B1); unseen senders default
+      // to neutral (1).
+      let rel = {};
+      try {
+        rel = (await getFactsEngine().getState())?.senderReliability ?? {};
+      } catch {
+        rel = {};
+      }
+      const next = keep.map((e) => {
+        if (e?.read) return e;
+        const weight = senderReliability(rel[senderKey(e?.sender)] ?? {});
+        const refs = Array.isArray(e?.refs) ? e.refs.slice() : [];
+        if (e?.sender?.sessionID) refs.push(e.sender.sessionID);
+        void ledgerLog({
+          channel: CHANNEL_EVENT,
+          sessionID: e?.sender?.sessionID ?? undefined,
+          kind: `inbox.${e?.kind ?? "note"}`,
+          salience: "high",
+          senderReliability: weight,
+          refs,
+          message: e?.message,
+          tag: e?.tag,
+        });
+        return { ...e, read: true };
+      });
+      await store.save({ ...payload, entries: next });
+      return { drained: unread.length };
+    } catch {
+      /* inbox drain is best-effort — never takes the engine down */
+      return { drained: 0 };
+    }
+  }
     }
   }
 
@@ -1054,6 +1120,7 @@ export function createCtoEngine(deps = {}) {
     beginEphemeral,
     beginDelegateJob,
     observeEvent,
+    drainInbox,
     getPresence,
     getState,
     lastHeartbeat,
@@ -1079,6 +1146,9 @@ export function createCtoEngine(deps = {}) {
     },
     get profile() {
       return getProfile();
+    },
+    get cards() {
+      return cards;
     },
   };
 

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -657,3 +657,63 @@ test("buildFactsContext formats the block, caps at K, and touches only surfaced 
   assert.equal(touched[0].ids.length, 15, "touch records exactly the surfaced facts");
   assert.ok(touched[0].ids.includes("cto:0") && touched[0].ids.includes("cto:14"), "touches the highest-retention facts");
 });
+
+// ---------------------------------------------------------------------------
+// BET-1397 inbox drain (unread notes → evidence, marked read, B1-weighted)
+// ---------------------------------------------------------------------------
+
+test("drainInbox folds unread notes into high-salience B1-weighted evidence and marks them read", async () => {
+  const clock = { ms: 1_000_000 };
+  const ledgerRows = [];
+  const state = { v: 1, entries: [] };
+  const store = {
+    load: async () => state,
+    save: async (s) => {
+      state.entries = s?.entries ?? [];
+    },
+  };
+  // Low-reliability sender (0 confirmed / 5 rejected → Beta mean 1/7) and a
+  // neutral one (0/0 → 1/2). Keys match `senderKey` (session:<id>) so the
+  // drain's reliability lookup resolves them.
+  const rel = {
+    "session:low-ses": { confirmed: 0, rejected: 5 },
+    "session:neutral-ses": { confirmed: 0, rejected: 0 },
+  };
+  const facts = { getState: async () => ({ senderReliability: rel }) };
+  state.entries = [
+    { id: "a", kind: "finding", message: "flaky", refs: ["BET-1"], sender: { sessionID: "low-ses" }, tag: null, read: false, count: 1, expires: clock.ms + 1000 },
+    { id: "b", kind: "fyi", message: "heads up", refs: [], sender: { sessionID: "neutral-ses" }, tag: null, read: false, count: 1, expires: clock.ms + 1000 },
+    { id: "c", kind: "blocker", message: "already seen", refs: [], sender: null, tag: null, read: true, count: 1, expires: clock.ms + 1000 },
+  ];
+
+  const engine = createCtoEngine({
+    configGet: async () => ({ ctoEnabled: true }),
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    engineState: { load: async () => ({ v: 1, entries: [] }), save: async () => {} },
+    cards: {},
+    inbox: store,
+    facts,
+    now: () => clock.ms,
+    publish: () => {},
+  });
+
+  const r = await engine.drainInbox();
+  assert.equal(r.drained, 2); // a + b drained; c was already read
+
+  // Both unread entries marked read in the persisted store.
+  assert.equal(state.entries.find((e) => e.id === "a").read, true);
+  assert.equal(state.entries.find((e) => e.id === "b").read, true);
+
+  // High-salience inbox.* evidence rows emitted with B1 weights applied.
+  const rows = ledgerRows.filter((row) => String(row.kind).startsWith("inbox."));
+  assert.equal(rows.length, 2);
+  const rowA = rows.find((row) => row.message === "flaky");
+  assert.equal(rowA.kind, "inbox.finding");
+  assert.equal(rowA.salience, "high");
+  assert.ok(Math.abs(rowA.senderReliability - 1 / 7) < 1e-9, "low-reliability sender weighted");
+  assert.deepEqual(rowA.refs, ["BET-1", "low-ses"]); // note refs + sender sessionID
+  const rowB = rows.find((row) => row.message === "heads up");
+  assert.ok(Math.abs(rowB.senderReliability - 1 / 2) < 1e-9, "neutral sender weighted 1/2");
+  // No evidence for the already-read entry.
+  assert.ok(!rows.some((row) => row.message === "already seen"));
+});

--- a/src/server/ctoInbound.test.mjs
+++ b/src/server/ctoInbound.test.mjs
@@ -27,31 +27,90 @@ import {
 } from "./cto.mjs";
 
 // ---------------------------------------------------------------------------
-// Inbound routing + dedupe
+// Inbound routing + dedupe (BET-1397: parked notes persist to the inbox store;
+// only a `blocker` kind enters the A8 card path via registerBlocker)
 // ---------------------------------------------------------------------------
 
-test("inbound parks when the call flag is off and surfaces via fireNotify", async () => {
-  const notified = [];
-  const inbound = createCtoInbound({ fireNotify: async (a) => notified.push(a) });
-  const res = await inbound.inbound({ surface: "session", payload: { message: "hey", urgent: true } });
+function memInbox() {
+  const state = { v: 1, entries: [] };
+  return {
+    load: async () => state,
+    save: async (s) => {
+      state.entries = s?.entries ?? [];
+    },
+    entries: () => state.entries,
+  };
+}
+
+test("inbound parks a bare {message} as a blocker: persisted to the inbox + routed to the blocker card (one path)", async () => {
+  const inbox = memInbox();
+  const blockers = [];
+  const inbound = createCtoInbound({
+    loadInbox: inbox.load,
+    saveInbox: inbox.save,
+    registerBlocker: async (e) => blockers.push(e),
+  });
+  const res = await inbound.inbound({ surface: "session", payload: { message: "hey", sessionID: "ses-1" } });
   assert.equal(res.ok, true);
   assert.equal(res.parked, true);
-  assert.equal(res.live, undefined);
-  assert.equal(notified.length, 1);
-  assert.equal(notified[0].message, "hey");
-  assert.equal(notified[0].urgent, true);
+  assert.equal(res.kind, "blocker"); // bare {message} → blocker default
+  assert.equal(inbox.entries().length, 1);
+  assert.equal(inbox.entries()[0].kind, "blocker");
+  assert.equal(blockers.length, 1);
+  assert.equal(blockers[0].message, "hey");
 });
 
-test("inbound drops a re-delivered event with an already-seen seenId (dedupe)", async () => {
-  const notified = [];
-  const inbound = createCtoInbound({ fireNotify: async (a) => notified.push(a) });
+test("inbound persists a non-blocker kind silently (no card, no notify)", async () => {
+  const inbox = memInbox();
+  let blockers = 0;
+  const inbound = createCtoInbound({
+    loadInbox: inbox.load,
+    saveInbox: inbox.save,
+    registerBlocker: async () => {
+      blockers += 1;
+    },
+  });
+  const res = await inbound.inbound({ surface: "session", payload: { kind: "fyi", message: "heads up" } });
+  assert.equal(res.parked, true);
+  assert.equal(res.kind, "fyi");
+  assert.equal(inbox.entries().length, 1);
+  assert.equal(inbox.entries()[0].kind, "fyi");
+  assert.equal(blockers, 0);
+});
+
+test("inbound dedupes a re-delivered event with an already-seen seenId; no-seenId never swallows", async () => {
+  const inbox = memInbox();
+  const inbound = createCtoInbound({
+    loadInbox: inbox.load,
+    saveInbox: inbox.save,
+  });
   await inbound.inbound({ surface: "session", payload: { message: "a" }, seenId: "evt-1" });
   const second = await inbound.inbound({ surface: "session", payload: { message: "b" }, seenId: "evt-1" });
   assert.equal(second.deduped, true);
-  assert.equal(notified.length, 1); // only the first surfaced
-  // An event with no seenId is never swallowed.
+  assert.equal(inbox.entries().length, 1); // only the first persisted
   await inbound.inbound({ surface: "session", payload: { message: "c" } });
-  assert.equal(notified.length, 2);
+  assert.equal(inbox.entries().length, 2);
+});
+
+test("inbound coalesces notes sharing a tag into one entry (refs union, count bumped)", async () => {
+  const inbox = memInbox();
+  const inbound = createCtoInbound({
+    loadInbox: inbox.load,
+    saveInbox: inbox.save,
+  });
+  await inbound.inbound({
+    surface: "session",
+    payload: { kind: "finding", message: "deploy flaky", tag: "deploy", refs: ["BET-1"], sessionID: "s1" },
+  });
+  const res = await inbound.inbound({
+    surface: "session",
+    payload: { kind: "finding", message: "deploy flaky again", tag: "deploy", refs: ["BET-2", "BET-1"], sessionID: "s2" },
+  });
+  assert.equal(res.coalesced, true);
+  const entries = inbox.entries();
+  assert.equal(entries.length, 1);
+  assert.equal(entries[0].count, 2);
+  assert.deepEqual(entries[0].refs, ["BET-1", "BET-2"]);
 });
 
 test("inbound live route injects into the CTO session when the flag is on (stub seam)", async () => {
@@ -60,7 +119,6 @@ test("inbound live route injects into the CTO session when the flag is on (stub 
     isCallActive: () => true,
     ctoSessionID: "cto-ses",
     sendPrompt: async (a) => sent.push(a),
-    fireNotify: async () => {},
   });
   const res = await inbound.inbound({ surface: "session", payload: { message: "live" } });
   assert.equal(res.live, true);
@@ -69,13 +127,31 @@ test("inbound live route injects into the CTO session when the flag is on (stub 
   assert.equal(sent[0].text, "live");
 });
 
-test("inbound with no message and no live call surfaces nothing but resolves ok", async () => {
-  const notified = [];
-  const inbound = createCtoInbound({ fireNotify: async (a) => notified.push(a) });
+test("inbound with no message and no live call writes nothing but resolves ok", async () => {
+  const inbox = memInbox();
+  const inbound = createCtoInbound({ loadInbox: inbox.load, saveInbox: inbox.save });
   const res = await inbound.inbound({ surface: "multica", payload: {} });
   assert.equal(res.ok, true);
   assert.equal(res.parked, true);
-  assert.equal(notified.length, 0);
+  assert.equal(res.dropped, true);
+  assert.equal(inbox.entries().length, 0);
+});
+
+test("normalizeInboxKind maps unknown/bare to blocker; coalesceInboxEntry unions refs + bumps count", async () => {
+  const { normalizeInboxKind, coalesceInboxEntry } = await import("./cto.mjs");
+  assert.equal(normalizeInboxKind("finding"), "finding");
+  assert.equal(normalizeInboxKind("blocker"), "blocker");
+  assert.equal(normalizeInboxKind(undefined), "blocker");
+  assert.equal(normalizeInboxKind("weird"), "blocker");
+  const merged = coalesceInboxEntry(
+    { refs: ["a"], count: 1, message: "x", read: true },
+    { refs: ["b", "a"], message: "y" },
+    100,
+  );
+  assert.deepEqual(merged.refs, ["a", "b"]);
+  assert.equal(merged.count, 2);
+  assert.equal(merged.ts, 100);
+  assert.equal(merged.read, false);
 });
 
 // ---------------------------------------------------------------------------
@@ -217,6 +293,33 @@ test("cto.json store load/save round-trips watches atomically", async () => {
   const reloaded = loadCtoStore(path);
   assert.equal(reloaded.watches.length, 1);
   assert.equal(reloaded.watches[0].surface, "multica");
+});
+
+test("read_inbox returns the inbox (filterable) without marking read or writing", async () => {
+  const state = {
+    v: 1,
+    entries: [
+      { id: "a", kind: "fyi", message: "heads up", tag: null, read: false, ts: 1, count: 1, expires: 500 },
+      { id: "b", kind: "blocker", message: "stop", tag: "t", read: true, ts: 2, count: 1, expires: 500 },
+      { id: "c", kind: "fyi", message: "expired", read: false, ts: 0, count: 1, expires: 10 },
+    ],
+  };
+  const engine = makeEngine({
+    loadInbox: async () => state,
+    now: () => 100,
+  });
+  const all = await engine.dispatch("read_inbox", {});
+  assert.equal(all.ok, true);
+  // The expired note (expires 10 < now 100) is absent from the view.
+  assert.deepEqual(all.data.entries.map((e) => e.id).sort(), ["a", "b"]);
+  // Filter by kind.
+  const fyi = await engine.dispatch("read_inbox", { kind: "fyi" });
+  assert.deepEqual(fyi.data.entries.map((e) => e.id), ["a"]);
+  // Filter by read state.
+  const unread = await engine.dispatch("read_inbox", { read: false });
+  assert.deepEqual(unread.data.entries.map((e) => e.id), ["a"]);
+  // READ-ONLY: the store was not written (entries untouched, ids keep read=false).
+  assert.equal(state.entries.find((e) => e.id === "a").read, false);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -373,6 +373,50 @@ export function capArchive(entries, { cap = ARCHIVE_CAP, timeField = "ts" } = {}
 }
 
 // ---------------------------------------------------------------------------
+// CTO inbox TTL (BET-1397 / spec §4.4). The `inbox.json` store carries one
+// entry per inbound note; unread entries expire SILENTLY once past their TTL
+// (never surfaced to the user — the inbox is a queue, not a notification
+// system). `fyi` notes are ephemeral (48h); every other kind (and the bare
+// `blocker` default) keeps a week.
+// ---------------------------------------------------------------------------
+
+export const INBOX_KINDS = Object.freeze(["fyi", "finding", "blocker", "handoff", "anomaly"]);
+export const INBOX_TTL_MS = Object.freeze({
+  fyi: 2 * DAY_MS,
+  blocker: 7 * DAY_MS,
+  finding: 7 * DAY_MS,
+  handoff: 7 * DAY_MS,
+  anomaly: 7 * DAY_MS,
+});
+
+// The TTL for an inbox kind (defaults to the 7d general case for unknown).
+export function inboxExpiresAt(kind, ts, { now = () => Date.now() } = {}) {
+  const t = typeof ts === "number" && Number.isFinite(ts) ? ts : now();
+  return t + (INBOX_TTL_MS[kind] ?? INBOX_TTL_MS.blocker);
+}
+
+// Pure filter: drop inbox entries whose `expires` (epoch ms) is past `nowMs`.
+// Silent by design (§4.4) — expiry produces nothing, no notification.
+export function purgeExpiredInbox(entries, { nowMs = Date.now(), expiresField = "expires" } = {}) {
+  const keep = [];
+  const dropped = [];
+  for (const e of entries) {
+    const expires = e?.[expiresField];
+    if (typeof expires === "number" && expires <= nowMs) dropped.push(e);
+    else keep.push(e);
+  }
+  return { keep, dropped };
+}
+
+export async function sweepInbox(nowMs = Date.now()) {
+  const payload = await inboxStore.load();
+  const entries = Array.isArray(payload?.entries) ? payload.entries : [];
+  if (entries.length === 0) return;
+  const { keep } = purgeExpiredInbox(entries, { nowMs });
+  if (keep.length !== entries.length) await inboxStore.save({ ...payload, entries: keep });
+}
+
+// ---------------------------------------------------------------------------
 // Sweep wiring (copies the createCleanupSweep shape from servePage.mjs).
 // I/O is the real fs but every path resolves under ctoPath() → the sandbox in
 // tests, so running the sweep in a test never touches a live box.
@@ -480,6 +524,7 @@ export async function sweepAllStores({ nowMs = Date.now() } = {}) {
     sweepSegments(nowMs),
     sweepDigests(),
     sweepArchiveCaps(),
+    sweepInbox(nowMs),
   ]);
 }
 

--- a/src/server/ctoStores.test.mjs
+++ b/src/server/ctoStores.test.mjs
@@ -26,6 +26,10 @@ import {
   rollupsStore,
   probesStore,
   sweepAllStores,
+  INBOX_KINDS,
+  INBOX_TTL_MS,
+  inboxExpiresAt,
+  purgeExpiredInbox,
 } from "./ctoStores.mjs";
 
 const NOW_MS = 1_000_000_000_000;
@@ -252,4 +256,28 @@ test("sweepAllStores trims the ledger and caps the archive (integration)", async
 
   const { rm } = await import("node:fs/promises");
   await rm(freshRollup);
+});
+
+test("inboxExpiresAt: fyi is 48h, every other kind (and unknown) is 7 days", () => {
+  // TTL map is closed over every declared kind.
+  for (const k of INBOX_KINDS) assert.ok(INBOX_TTL_MS[k] !== undefined, `TTL set for ${k}`);
+  assert.equal(inboxExpiresAt("fyi", 1000) - 1000, 2 * DAY);
+  assert.equal(inboxExpiresAt("blocker", 1000) - 1000, 7 * DAY);
+  assert.equal(inboxExpiresAt("finding", 1000) - 1000, 7 * DAY);
+  assert.equal(inboxExpiresAt("handoff", 1000) - 1000, 7 * DAY);
+  assert.equal(inboxExpiresAt("anomaly", 1000) - 1000, 7 * DAY);
+  assert.equal(inboxExpiresAt("weird", 1000) - 1000, 7 * DAY); // unknown → 7d general case
+});
+
+test("purgeExpiredInbox drops only expired entries, silently (no trace)", () => {
+  const nowMs = 1000;
+  const entries = [
+    { id: "a", expires: 500 }, // expired
+    { id: "b", expires: 1000 }, // boundary (<= now) → expired
+    { id: "c", expires: 1500 }, // keep
+    { id: "d" }, // no expires → keep
+  ];
+  const { keep, dropped } = purgeExpiredInbox(entries, { nowMs });
+  assert.deepEqual(keep.map((e) => e.id), ["c", "d"]);
+  assert.deepEqual(dropped.map((e) => e.id), ["a", "b"]);
 });

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1878,6 +1878,9 @@ let adaptiveCtoDigest = null;
   adaptiveCtoDigest = createCtoDigest({
     publish: (evt) => bus.publish(evt),
     runEphemeral: gatedDigestCompose,
+    // BET-1397: the digest-generation breakpoint drains the CTO inbox — unread
+    // notes become evidence folded into the composed digest, then marked read.
+    drain: () => adaptiveCto.drainInbox(),
     presence: { get: () => adaptiveCto.getPresence() },
     getGMinutes: async () => adaptiveCto.segmenter?.getGMinutes?.() ?? null,
     listOpenCards: async () => (await adaptiveCto.cards?.listOpen?.()) ?? [],

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1846,6 +1846,7 @@ const adaptiveCto = ctoEngine.createCtoEngine({
   // its own one-time spend bound, so they bypass the engine's §3.3 rate gate.
   getDb,
   backfillRunEphemeral: runEphemeral,
+  cardFireNotify: (args) => push.fireNotify(args),
 });
 adaptiveCto.start();
 
@@ -1942,7 +1943,11 @@ void stopAdaptiveCtoWatchdog;
 const ctoInbound = cto.createCtoInbound({
   isCallActive: () => callActive,
   ctoSessionID: null, // issue 3 wires the live route below via the active call engine
-  fireNotify: (args) => push.fireNotify(args),
+  // BET-1397: a `blocker` inbox note enters the A8 blocker-card path (source
+  // 3), which fires the single blocking-tier notification through the existing
+  // router and promotes a card at > 10 min. The old direct blanket-notify
+  // branch is gone — non-blocker notes are silent in the inbox.
+  registerBlocker: (entry) => adaptiveCto.cards.onInboxBlocker(entry),
   sendPrompt: async ({ text }) => {
     // LIVE route (issue 3): while a call is open, inject the inbound event as
     // a turn into the active Realtime session so the CTO speaks it. Parked
@@ -3974,10 +3979,23 @@ const handleRequest = async (req, res) => {
     try {
       if (req.method === "POST") {
         const body = await readJsonBody(req);
+        // The send_to_cto tool posts kind/message/refs/tag/title/urgent/sessionID
+        // at the TOP level (many also carry a nested `payload`); merge both so
+        // the inbox sees the note either way.
         const result = await ctoInbound.inbound({
           surface: body?.surface,
-          payload: body?.payload ?? {},
           seenId: body?.seenId,
+          payload: {
+            ...(body?.payload ?? {}),
+            kind: body?.kind,
+            message: body?.message,
+            refs: body?.refs,
+            tag: body?.tag,
+            title: body?.title,
+            urgent: body?.urgent,
+            sessionID: body?.sessionID,
+            senderName: body?.senderName,
+          },
         });
         respondJson(res, result.ok ? 200 : 400, result);
         return;


### PR DESCRIPTION
## BET-1397 — Inbox supersession for `send_to_cto`

Implements the CTO **inbox** (spec §4.4): the durable queue of notes any session
sends via `send_to_cto`, with kinds, tag-dedupe, TTLs, read/unread, a one-path
blocker notification, and an engine drain that folds unread notes into
evidence at breakpoints.

### What changed

- **`docs/opencode-tools/send-to-cto.ts`** — schema extended to
  `{kind?, message, refs?, tag?, title?}` with `kind ∈ fyi|finding|blocker|handoff|anomaly`.
  A bare `{message}` maps to `blocker` (the old urgent semantics, preserved).
  Only `blocker` fires the immediate blocking-tier notification; the other
  kinds are silent. Description updated per §4.4 (supersedes earlier spellings).
- **`src/server/cto.mjs`** — `createCtoInbound` parked route rewritten to
  persist to the `inbox.json` store (path from the existing `inboxStore`):
  kind defaulting, **tag dedupe / refs-union coalescing**, `read:false`,
  per-kind `expires`. The **old blanket `fireNotify` branch is deleted**. A
  `blocker` kind delegates to an injected `registerBlocker` (the A8 card
  path). Added pure helpers `normalizeInboxKind` / `coalesceInboxEntry`, and
  the **`read_inbox`** read-belt verb (READ-ONLY; filters by kind/read/tag;
  purges expired notes from the view).
- **`src/server/ctoCards.mjs`** — **source 3** `onInboxBlocker`: fires the
  blocking-tier notification **exactly once** through the injected router
  (same one source 1 relies on) and registers a pending blocker card promoted
  at > 10 min. `blockerTitle`/`blockerBody` handle the `inbox` kind. The
  worker-ask and health paths keep their no-notification invariant.
- **`src/server/ctoStores.mjs`** — inbox TTL constants (`fyi` 48h, others 7d),
  `inboxExpiresAt`, pure `purgeExpiredInbox` (silent expiry), and `sweepInbox`
  wired into `sweepAllStores`.
- **`src/server/ctoEngine.mjs`** — `drainInbox()`: at the **rollup-close**
  breakpoint, every unread note becomes a high-salience `inbox.<kind>` evidence
  row weighted by the **B1 sender-reliability** (Beta mean) of the sending
  session, then marked read. Nested/over the `inbox` seam for tests. Engine
  exposes `drainInbox` and `cards`.
- **`src/server/index.mjs`** — `/api/cto/inbound` merges top-level tool fields
  into the payload; wires `registerBlocker → adaptiveCto.cards.onInboxBlocker`
  and `cardFireNotify → push.fireNotify`.
- **`docs/opencode-tools/cto.ts`** + **`docs/opencode-tools/AGENTS.md`** — the
  `read_inbox` verb listed; guidance updated for the inbox semantics.
- **Tests** — inbound kind mapping incl. bare-`{message}` compat, tag
  coalescing, silent non-blocker kinds, inbox persistence; `read_inbox`
  filtering without writing; cards source-3 fires exactly one notification +
  promotes a card; inbox TTL/expiry; engine drain marks read + emits
  reliability-weighted evidence; registry tool-count updated for `read_inbox`.

### Verification results

**Files changed:** 10 files. `cto.mjs`, `ctoCards.mjs`, `ctoEngine.mjs`,
`ctoStores.mjs`, `index.mjs`, `send-to-cto.ts`, `cto.ts`, `AGENTS.md`,
`ctoInbound.test.mjs`, `cto.test.mjs`.

- PR branch (`multica/BET-1397-inbox-supersession` @ `a64299c4`, based on `main` @ `ee00cdec`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3166 pass / 0 fail / 0 skip. Failures: none. log sha256: `b16726c6bff66a3fb6e514b2cdbea37d0f02249524869d0e5b1bf4b04c15b433`
- Base (`main` @ `ee00cdec`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 0 failures (dir). log sha256: `4926f6b1495c55a5b227c82983e26e3acfebb1aee00fec29c5a40650c812879e`
- **Conclusion:** 0 new failures. The PR branch adds its own tests (all pass);
  every pre-existing suite stays green.

**Base:** `origin/main @ ee00cdec`

### Notes for the reviewer

- This repo's workdir is shared and actively churned by other in-flight CTO
  branches, so the branch was verified in an isolated clone of
  `origin/multica/BET-1397-inbox-supersession` and rebased onto current
  `origin/main` (the digest-engine `read_rollups`/`read_ledger` merge) before
  this PR.
- The engine drain currently hooks the **rollup-close** breakpoint. Hooking it
  at the digest-generation breakpoint is filed as a follow-up (the digest
  composition path landed separately in BET-1383).

Follow-up filed: BET-1413 (→ manta-pm) — hook `drainInbox` at the
digest-generation / overnight breakpoint, so overnight summaries include inbox
notes.
