### PR TITLE
feat(server): cto_fact tool + facts spawn-context seed (BET-1390)

### DIFF
--- a/docs/opencode-tools/AGENTS.md
+++ b/docs/opencode-tools/AGENTS.md
@@ -504,6 +504,31 @@ never a symlink: `cp <repo>/docs/opencode-tools/cto.ts
 then `systemctl --user restart
 opencode-serve`. The engine lives in `src/server/cto.mjs` (see there).
 
+## manta cto_fact — Adaptive CTO blackboard (BET-1390)
+
+You have a `cto_fact` tool (global opencode custom tool) that proposes a
+short, evidence-backed *fact* about a project onto the Adaptive CTO blackboard
+(spec §6.2). Facts are the CTO's durable cross-session memory — they are
+surfaced later to new sessions and delegate jobs as §6.9 spawn-context, so
+recording a root cause, a settled decision, or a blocker you hit makes it
+survive your session ending. Install/update is a COPY, never a symlink:
+`cp <repo>/docs/opencode-tools/cto-fact.ts ~/.config/opencode/tools/cto-fact.ts`
+and `cp <repo>/docs/opencode-tools/manta-auth.ts
+~/.config/opencode/tools/manta-auth.ts` (the shared `./manta-auth` import),
+then `systemctl --user restart opencode-serve`.
+
+Reach for `cto_fact` when a concrete fact about the project is worth
+preserving: the current state of a subsystem, a blocker with its cause, a
+decision and why, a theory to track, something that must not regress, or an
+anomaly you saw. Use concise kinds (`status` / `blocker` / `decision` /
+`theory` / `invariant` / `anomaly`). **Every proposal requires at least one
+`refs` evidence pointer** (a message id, commit sha, file path, or issue key) —
+a proposal with no refs is rejected, so attach evidence to your claim.
+`supersedes` lets you state that a new fact revises an earlier one; keep
+statements ≤ 200 characters. It is a thin registrar: the server owns the
+durable queue and the gatekeeper, and returns the gatekeeper verdict (or a
+"queued" note when the judge is still deciding — it resolves regardless).
+
 ## manta on-call CTO inbound — `send_to_cto` + watchers (BET-1165)
 
 Two companion capabilities to the `cto` read belt, both global opencode tools.

--- a/docs/opencode-tools/cto-fact.ts
+++ b/docs/opencode-tools/cto-fact.ts
@@ -1,0 +1,118 @@
+// `cto_fact` tool — global opencode custom tool (Adaptive CTO, BET-1390 / §6.2).
+//
+// Lets any agent session propose a *fact* onto the Adaptive CTO blackboard: a
+// short, evidence-backed statement about a project (a status, blocker,
+// decision, theory, invariant, or anomaly). Facts are the CTO's durable,
+// cross-session memory — surfaced later to new sessions and delegate jobs via
+// §6.9 spawn-context seeding.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/cto-fact.ts ~/.config/opencode/tools/cto-fact.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+//
+// This tool is a THIN registrar (see docs/opencode-tools/AGENTS.md). It
+// validates the proposal and POSTs it to manta-server (127.0.0.1:8787, same
+// box — no SSH hop), which owns the durable queue and the gatekeeper
+// (src/server/ctoFacts.mjs). execute() returns promptly with the gatekeeper
+// verdict when it resolves fast, or a "queued" note if resolution is still
+// pending (the server's durable queue resolves it regardless).
+//
+// Refs rule: every proposal needs at least one `refs` evidence pointer (a
+// message id, commit sha, file path, issue key). A proposal submitted with no
+// refs is rejected client-side here, with a nudge to attach evidence.
+
+import { tool } from "@opencode-ai/plugin";
+import { authHeaders } from "./manta-auth";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+export const cto_fact = tool({
+  description: [
+    "Propose a fact onto the Adaptive CTO blackboard: a short, evidence-backed",
+    "statement about a project (status, blocker, decision, theory, invariant,",
+    "or anomaly). Facts become durable cross-session memory for the CTO and are",
+    "surfaced to future sessions as context. Use it to record something you",
+    "learned or settled (a root cause, a decision, a blocker you hit) so it is",
+    "not lost when your session ends. Every proposal needs at least one `refs`",
+    "evidence pointer (message id, commit sha, file path, issue key) — proposals",
+    "without evidence are rejected.",
+  ].join(" "),
+  args: {
+    project: z
+      .string()
+      .describe(
+        "The project this fact is about (the session id or its name) — required.",
+      ),
+    kind: z
+      .enum(["status", "blocker", "decision", "theory", "invariant", "anomaly"])
+      .describe(
+        "What kind of fact this is: status (current state), blocker (something blocking progress), " +
+          "decision (a settled choice), theory (an unconfirmed hypothesis), invariant (something that must hold), " +
+          "anomaly (unexpected behavior).",
+      ),
+    statement: z
+      .string()
+      .describe("The fact itself — a short, concrete, evidence-backed statement (≤ 200 chars)."),
+    refs: z
+      .array(z.string())
+      .optional()
+      .describe(
+        "Evidence pointers for the claim — message ids, commit shas, file paths, issue keys. " +
+          "At least one is required; a proposal with no refs is rejected and you must attach evidence.",
+      ),
+    valid_until: z
+      .string()
+      .optional()
+      .describe("Optional ISO 8601 expiry; after this time the fact is dropped."),
+    supersedes: z
+      .string()
+      .optional()
+      .describe("Optional id of a prior fact that this statement revises or replaces."),
+  },
+  async execute(args, context) {
+    const refs = Array.isArray(args.refs) ? args.refs : [];
+    if (refs.length === 0) {
+      return (
+        "Rejected: a fact proposal requires at least one `refs` entry (an evidence pointer such as " +
+        "a message id, commit sha, or file path). Attach evidence to your claim and retry."
+      );
+    }
+    const result = await call("POST", "/api/cto/facts", {
+      project: args.project,
+      kind: args.kind,
+      statement: args.statement,
+      refs,
+      ...(args.valid_until ? { valid_until: args.valid_until } : {}),
+      ...(args.supersedes ? { supersedes: args.supersedes } : {}),
+      sessionID: context.sessionID,
+    });
+    if (result.queued) {
+      return `Fact proposal queued for gatekeeper review (proposal ${result.proposalId}). It will be resolved shortly.`;
+    }
+    const action = result?.outcome?.action ?? "submitted";
+    const reason = result?.outcome?.reason ? ` — ${result.outcome.reason}` : "";
+    return `Fact proposal resolved: ${action}${reason} (proposal ${result.proposalId}).`;
+  },
+});

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -78,7 +78,8 @@ import {
   ROLLUP_LEVELS,
   windowFor as rollupWindowFor,
 } from "./ctoRollups.mjs";
-import { createFactsEngine, VERIFY_CYCLE_MS } from "./ctoFacts.mjs";
+import { buildFactProposal, createFactsEngine, VERIFY_CYCLE_MS } from "./ctoFacts.mjs";
+import { formatFactsBlock } from "./ctoSessions.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
@@ -884,6 +885,51 @@ export function createCtoEngine(deps = {}) {
     return heartbeatAt;
   }
 
+  // cto_fact route handler (BET-1390 / §6.2): turn tool input into a
+  // validated proposal, enqueue it on the blackboard's single-writer queue,
+  // then await the gatekeeper's resolution for up to 10s so the caller gets
+  // the verdict when it resolves fast. If resolution is still pending we
+  // return `queued:true` — the durable queue + the tick's pump guarantee the
+  // proposal is still resolved (nothing is lost by returning early).
+  async function proposeFact(input = {}) {
+    const built = buildFactProposal(input);
+    if (built.error) return { ok: false, error: built.error };
+    const fe = getFactsEngine();
+    const id = built.proposal.proposalId;
+    const submitted = await fe.submitProposal(built.proposal);
+    if (!submitted.ok) {
+      // Not newly added: either already applied (idempotent re-delivery) or
+      // still queued from a prior enqueue. Report the known outcome when there
+      // is one.
+      const existing = await fe.proposalOutcome(id);
+      if (existing) return { ok: true, proposalId: id, applied: false, outcome: existing };
+      return { ok: true, proposalId: id, applied: false, queued: true };
+    }
+    await Promise.race([
+      fe.pump(built.proposal.project).catch(() => {}),
+      new Promise((r) => setTimeout(r, 10000)),
+    ]);
+    const outcome = await fe.proposalOutcome(id);
+    if (!outcome) return { ok: true, proposalId: id, applied: true, queued: true };
+    return { ok: true, proposalId: id, applied: true, outcome };
+  }
+
+  // Spawn-context facts seed for a project (§6.9): pull the top-K facts by
+  // retention, format them into a context block, and record the access so the
+  // retention clock reflects "this fact was actually surfaced". Returns null
+  // when there is nothing to seed (callers omit the block entirely).
+  async function factsContextBlock(project, { cap = 15, nowMs } = {}) {
+    if (!project || !getFactsEngine()) return null;
+    const fe = getFactsEngine();
+    return buildFactsContext({
+      project,
+      cap,
+      nowMs,
+      getTopFacts: (p, k) => fe.topFacts(p, { k, nowMs }),
+      touchFacts: (opts) => fe.touchFacts(opts),
+    });
+  }
+
   const engine = {
     actor: ACTOR,
     start,
@@ -900,6 +946,8 @@ export function createCtoEngine(deps = {}) {
     getPresence,
     getState,
     lastHeartbeat,
+    proposeFact,
+    factsContextBlock,
     get rateTracker() {
       return track;
     },
@@ -918,6 +966,23 @@ export function createCtoEngine(deps = {}) {
   };
 
   return engine;
+}
+
+// ---------------------------------------------------------------------------
+// Spawn-context facts seed (BET-1390 / §6.9) — pure orchestration over
+// injected providers so it is testable without a live facts engine. Pulls
+// top-K facts for a project, formats them into a `{priority,text}` context
+// block, and records a retention touch on exactly the facts that were
+// surfaced. Returns null when there is nothing to seed.
+// ---------------------------------------------------------------------------
+export async function buildFactsContext({ project, cap = 15, nowMs, getTopFacts, touchFacts } = {}) {
+  if (!project || typeof getTopFacts !== "function" || typeof touchFacts !== "function") return null;
+  const facts = await getTopFacts(project, cap);
+  const block = formatFactsBlock(facts, { cap, nowMs });
+  if (!block) return null;
+  const ids = (Array.isArray(facts) ? facts : []).slice(0, cap).map((f) => f?.id).filter(Boolean);
+  if (ids.length > 0) await touchFacts({ project, ids });
+  return block;
 }
 
 // ---------------------------------------------------------------------------

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -565,6 +565,60 @@ test("engine exposes .facts and pumps proposals on tick (%40 enabled)", async ()
   assert.equal(saved.filter((f) => !f.superseded_by).length, 1);
 });
 
+test("proposeFact enqueues, resolves via the gatekeeper, and reports the verdict", async () => {
+  const inmemory = new Map();
+  const fstate = { v: 1 };
+  const facts = createFactsEngine({
+    engineState: {
+      load: async () => ({ ...fstate }),
+      save: async (s) => {
+        Object.keys(fstate).forEach((k) => delete fstate[k]);
+        Object.assign(fstate, s);
+      },
+    },
+    facts: { load: async (p) => inmemory.get(p) ?? { v: 1, facts: [] }, save: async (p, d) => inmemory.set(p, d), dir: "x" },
+    archive: { load: async (p) => inmemory.get("a" + p) ?? { v: 1, entries: [] }, save: async (p, d) => inmemory.set("a" + p, d) },
+  });
+  const harness = makeHarness({ ctoEnabled: true, facts });
+  await harness.engine.resume();
+
+  // zero-ref is rejected with the attach-evidence message, never enqueued
+  const rejected = await harness.engine.proposeFact({
+    project: "alpha",
+    kind: "status",
+    statement: "no evidence",
+    refs: [],
+    sessionID: "ses_1",
+  });
+  assert.equal(rejected.ok, false);
+  assert.match(rejected.error ?? "", /attach evidence/i);
+
+  // a valid proposal resolves (degraded gatekeeper → add) with an idempotent id
+  const first = await harness.engine.proposeFact({
+    project: "alpha",
+    kind: "decision",
+    statement: "moved to postgres",
+    refs: ["m1"],
+    sessionID: "ses_1",
+  });
+  assert.equal(first.ok, true);
+  assert.equal(first.applied, true);
+  assert.equal(first.outcome.action, "add");
+  assert.ok(first.proposalId && first.proposalId.startsWith("cto:"));
+
+  // same-content re-submission is idempotent: same proposalId, not re-applied
+  const again = await harness.engine.proposeFact({
+    project: "alpha",
+    kind: "decision",
+    statement: "moved to postgres",
+    refs: ["m1"],
+    sessionID: "ses_1",
+  });
+  assert.equal(again.proposalId, first.proposalId);
+  assert.equal(again.applied, false, "idempotent — an already-applied proposal is not applied twice");
+  assert.equal(again.outcome.action, "add");
+});
+
 // ---------------------------------------------------------------------------
 // buildFactsContext (BET-1390 / §6.9) — spawn-context facts seed
 // ---------------------------------------------------------------------------

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -9,6 +9,7 @@ import {
   DOT,
   HOUR_MS,
   RATE_LIMITS,
+  buildFactsContext,
 } from "./ctoEngine.mjs";
 import { createSegmenter } from "./ctoSegments.mjs";
 import { createFactsEngine } from "./ctoFacts.mjs";
@@ -562,4 +563,43 @@ test("engine exposes .facts and pumps proposals on tick (%40 enabled)", async ()
   await harness.engine.tick();
   const saved = inmemory.get("alpha")?.facts ?? [];
   assert.equal(saved.filter((f) => !f.superseded_by).length, 1);
+});
+
+// ---------------------------------------------------------------------------
+// buildFactsContext (BET-1390 / §6.9) — spawn-context facts seed
+// ---------------------------------------------------------------------------
+
+test("buildFactsContext returns null without project or providers", async () => {
+  assert.equal(await buildFactsContext({}), null);
+  assert.equal(await buildFactsContext({ project: "alpha" }), null);
+  assert.equal(
+    await buildFactsContext({ project: "alpha", getTopFacts: async () => [], touchFacts: async () => ({}) }),
+    null,
+  );
+});
+
+test("buildFactsContext formats the block, caps at K, and touches only surfaced facts", async () => {
+  const nowMs = 5000 * 3600_000;
+  const many = Array.from({ length: 20 }, (_, i) => ({
+    id: `cto:${i}`,
+    kind: "status",
+    statement: `fact ${i}`,
+    created: nowMs - 3600_000,
+    retention: 20 - i,
+  }));
+  const touched = [];
+  const block = await buildFactsContext({
+    project: "alpha",
+    cap: 15,
+    nowMs,
+    getTopFacts: async (project, k) => many, // provider is sloppy: returns more than K
+    touchFacts: async ({ project, ids }) => touched.push({ project, ids }),
+  });
+  assert.ok(block);
+  assert.equal(block.priority, 60);
+  const lines = block.text.split("\n").filter((l) => l.startsWith("- ["));
+  assert.equal(lines.length, 15, "block is capped at K even when the provider over-returns");
+  assert.ok(touched.length === 1 && touched[0].project === "alpha");
+  assert.equal(touched[0].ids.length, 15, "touch records exactly the surfaced facts");
+  assert.ok(touched[0].ids.includes("cto:0") && touched[0].ids.includes("cto:14"), "touches the highest-retention facts");
 });

--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -175,6 +175,61 @@ export function validateProposal(p) {
   return true;
 }
 
+// Build a validated proposal from the `cto_fact` tool's raw input (§6.2).
+// The registrar-side contract, kept pure and testable:
+//   - zero `refs` is rejected here (the client tool also checks, but the
+//     server is the backstop) with a message telling the agent to attach
+//     evidence;
+//   - a proposalId is DERIVED deterministically from (project, kind,
+//     statement, refs, sessionID) when the client didn't supply one, which is
+//     what makes the at-least-once queue idempotent: re-delivering the same
+//     proposal from the same session collapses to one application;
+//   - the sender defaults to {sessionID} so the blackboard can track
+//     per-sender reliability (§6.4) instead of lumping every tool call under
+//     "cto".
+export function buildFactProposal(input = {}) {
+  const refs = Array.isArray(input.refs) ? input.refs : [];
+  if (refs.length === 0) {
+    return {
+      error:
+        "Rejected: a fact proposal requires at least one `refs` entry (an evidence pointer such as a message id, commit sha, or file path). Attach evidence to your claim and retry.",
+    };
+  }
+  const project = typeof input.project === "string" ? input.project.trim() : "";
+  if (!project) return { error: "Rejected: `project` is required." };
+  if (!KINDS.includes(input.kind)) {
+    return { error: `Rejected: \`kind\` must be one of ${KINDS.join(", ")}.` };
+  }
+  const statement = typeof input.statement === "string" ? input.statement.trim() : "";
+  if (!statement) return { error: "Rejected: `statement` is required." };
+  if (statement.length > STATEMENT_LIMIT) {
+    return { error: `Rejected: \`statement\` must be ≤ ${STATEMENT_LIMIT} characters.` };
+  }
+  const sessionID = typeof input.sessionID === "string" ? input.sessionID : "";
+  const proposalId =
+    (typeof input.proposalId === "string" && input.proposalId.length > 0
+      ? input.proposalId
+      : "cto:" +
+        createHash("sha1")
+          .update([project, input.kind, statement, ...refs, sessionID].join("|"))
+          .digest("hex")
+          .slice(0, 16));
+  const sender = input.sender ?? (sessionID ? { sessionID } : "cto");
+  const proposal = {
+    proposalId,
+    project,
+    kind: input.kind,
+    statement,
+    refs,
+    sender,
+  };
+  if (typeof input.confidence === "number") proposal.confidence = input.confidence;
+  if (typeof input.valid_until === "string" && input.valid_until.length > 0) proposal.valid_until = input.valid_until;
+  if (typeof input.supersedes === "string" && input.supersedes.length > 0) proposal.supersedes = input.supersedes;
+  if (!validateProposal(proposal)) return { error: "Rejected: invalid proposal." };
+  return { proposal };
+}
+
 export function enqueueProposal(state, proposal) {
   if (!validateProposal(proposal)) return { state, added: false, reason: "invalid" };
   const s = state ?? {};
@@ -765,6 +820,38 @@ export function createFactsEngine(deps = {}) {
     };
   }
 
+  // Top-K active facts for a project ranked by retention (§6.4) — the
+  // ordering the spawn-context seed uses (BET-1390 / §6.9). The same
+  // reliability-aware ranking as pump's displacement, so the facts that
+  // survive the cap are the ones surfaced to new sessions.
+  async function topFacts(project, { k = 15, nowMs } = {}) {
+    if (!project || project.length === 0) return [];
+    const t = nowMs ?? now();
+    const active = await loadFacts(project);
+    const state = await loadState();
+    const halfLives = currentHalfLives(state.factTuning ?? {});
+    const relOf = (fact) => {
+      const key = senderKey(fact?.sender);
+      if (!key) return 1;
+      const c = state.factReliability?.[key];
+      return c ? senderReliability(c) : 1;
+    };
+    return active
+      .map((fact) => ({ fact, retention: retentionOf(fact, { nowMs: t, halfLives, weights: KIND_WEIGHTS, reliabilityOf: relOf }) }))
+      .sort((a, b) => b.retention - a.retention)
+      .slice(0, k)
+      .map((x) => x.fact);
+  }
+
+  // Read the applied outcome for a proposalId from the durable idempotency
+  // record — lets the `cto_fact` route report the gatekeeper verdict (or
+  // "queued"/already-applied) instead of just "submitted".
+  async function proposalOutcome(proposalId) {
+    if (!proposalId) return null;
+    const s = await loadState();
+    return s.appliedProposals?.[proposalId] ?? null;
+  }
+
   function dispose() {
     disposed = true;
   }
@@ -776,6 +863,8 @@ export function createFactsEngine(deps = {}) {
     verifyDue,
     recomputeHalfLives: recomputeHalfLivesNow,
     getState,
+    proposalOutcome,
+    topFacts,
     listFacts: (project) => loadFacts(project).then((arr) => arr.filter(isActiveFact)),
     listProjects: listKnownProjects,
     dispose,

--- a/src/server/ctoFacts.test.mjs
+++ b/src/server/ctoFacts.test.mjs
@@ -16,6 +16,7 @@ import {
   retentionOf,
   lowestRetention,
   validateProposal,
+  buildFactProposal,
   enqueueProposal,
   popProposal,
   markApplied,
@@ -107,6 +108,105 @@ test("senderReliability is the Beta(confirmed+1, rejected+1) mean", () => {
   assert.equal(senderReliability({ confirmed: 0, rejected: 0 }), 0.5);
   assert.equal(senderReliability({ confirmed: 2, rejected: 0 }), 0.75);
   assert.equal(senderReliability({ confirmed: 0, rejected: 4 }), 1 / 6);
+});
+
+test("buildFactProposal shapes the registrar payload (project/kind/statement/refs/sender)", () => {
+  const { proposal } = buildFactProposal({
+    project: "alpha",
+    kind: "blocker",
+    statement: "build is red after the deploy",
+    refs: ["m1", "a1b2c3"],
+    valid_until: "2026-12-01T00:00:00Z",
+    supersedes: "cto:abc",
+    sessionID: "ses_1",
+  });
+  assert.ok(proposal);
+  assert.equal(proposal.project, "alpha");
+  assert.equal(proposal.kind, "blocker");
+  assert.equal(proposal.statement, "build is red after the deploy");
+  assert.deepEqual(proposal.refs, ["m1", "a1b2c3"]);
+  assert.equal(proposal.valid_until, "2026-12-01T00:00:00Z");
+  assert.equal(proposal.supersedes, "cto:abc");
+  assert.deepEqual(proposal.sender, { sessionID: "ses_1" });
+  // it produces a proposalId you can enqueue
+  assert.ok(typeof proposal.proposalId === "string" && proposal.proposalId.startsWith("cto:"));
+});
+
+test("buildFactProposal derives an idempotent proposalId from content + session", () => {
+  const base = { project: "alpha", kind: "status", statement: "api is healthy", refs: ["m9"], sessionID: "s1" };
+  const a = buildFactProposal(base).proposal.proposalId;
+  const b = buildFactProposal(base).proposal.proposalId;
+  assert.equal(a, b);
+  // changing evidence or session changes the id, so genuine updates are distinct
+  assert.notEqual(a, buildFactProposal({ ...base, refs: ["m10"] }).proposal.proposalId);
+  assert.notEqual(a, buildFactProposal({ ...base, sessionID: "s2" }).proposal.proposalId);
+});
+
+test("buildFactProposal rejects zero refs with an attach-evidence message", () => {
+  const res = buildFactProposal({ project: "alpha", kind: "status", statement: "x", refs: [], sessionID: "s1" });
+  assert.ok(!res.proposal);
+  assert.match(res.error ?? "", /attach evidence/i);
+  assert.match(res.error ?? "", /refs/i);
+});
+
+test("buildFactProposal trims statement, rejects empty/missing project, bad kind, over-limit", () => {
+  assert.ok(buildFactProposal({ kind: "status", statement: "x", refs: ["r"], sessionID: "s" }).error);
+  assert.match(
+    buildFactProposal({ project: "alpha", kind: "bogus", statement: "x", refs: ["r"] }).error ?? "",
+    /kind/,
+  );
+  assert.ok(buildFactProposal({ project: "alpha", kind: "status", statement: "  ", refs: ["r"] }).error);
+  assert.ok(
+    buildFactProposal({ project: "alpha", kind: "status", statement: "x".repeat(300), refs: ["r"] }).error,
+  );
+  // valid stays valid, statement trimmed
+  assert.equal(
+    buildFactProposal({ project: "alpha", kind: "status", statement: "  ok  ", refs: ["r"] }).proposal.statement,
+    "ok",
+  );
+});
+
+test("buildFactProposal defaults sender to cto when no sessionID is supplied", () => {
+  const { proposal } = buildFactProposal({ project: "alpha", kind: "status", statement: "ok", refs: ["r"] });
+  assert.equal(proposal.sender, "cto");
+});
+
+test("topFacts ranks active facts by retention and applies the K cap", async () => {
+  const { engine, facts } = makeEngine({ nowMs: 5 * D });
+  const fresh = makeFact({
+    id: "cto:fresh",
+    kind: "decision",
+    statement: "we moved to postgres",
+    refs: ["m2"],
+    created: 4.9 * D,
+    last_accessed: 4.9 * D,
+    access_count: 3,
+    sender: "cto",
+  });
+  const stale = makeFact({
+    id: "cto:stale",
+    kind: "decision",
+    statement: "old call path",
+    refs: ["m1"],
+    created: 0,
+    last_accessed: 0,
+    access_count: 0,
+    sender: "cto",
+  });
+  await facts.save("alpha", { v: 1, facts: [stale, fresh] });
+
+  const top1 = await engine.topFacts("alpha", { k: 1, nowMs: 5 * D });
+  assert.equal(top1.length, 1);
+  assert.equal(top1[0].id, "cto:fresh");
+
+  const topAll = await engine.topFacts("alpha", { k: 10, nowMs: 5 * D });
+  assert.deepEqual(
+    topAll.map((f) => f.id),
+    ["cto:fresh", "cto:stale"],
+  );
+
+  assert.deepEqual(await engine.topFacts("", { k: 10 }), []);
+  assert.deepEqual(await engine.topFacts("nope", { k: 10 }), []);
 });
 
 test("retention: decay halves after one half-life", () => {

--- a/src/server/ctoSessions.mjs
+++ b/src/server/ctoSessions.mjs
@@ -108,6 +108,37 @@ export function assembleContext(context = [], { taskClass } = {}) {
   return kept.join("\n\n");
 }
 
+// Human-readable age label for a fact, used in the spawn-context seed.
+export function factAgeLabel(created, nowMs = Date.now()) {
+  const ms = Math.max(0, (nowMs ?? Date.now()) - Number(created) || 0);
+  const hours = Math.floor(ms / 3_600_000);
+  if (hours < 24) return `${hours}h`;
+  const days = Math.floor(hours / 24);
+  if (days < 30) return `${days}d`;
+  const months = Math.floor(days / 30);
+  if (months < 12) return `${months}mo`;
+  return `${Math.floor(months / 12)}y`;
+}
+
+// Pure formatter for the spawn-context facts block (BET-1390 / §6.9). Takes
+// the top-K facts already ranked by retention and renders a single
+// `{ priority, text }` context block: one `- [kind] statement (age)` line per
+// fact under a short header. Returns `null` when there is nothing to seed, so
+// callers can omit the block entirely. `cap` is a defensive upper bound — the
+// caller's top-K provider is expected to rank, this still slices.
+export function formatFactsBlock(facts = [], { cap = 15, nowMs = Date.now() } = {}) {
+  const ranked = (Array.isArray(facts) ? facts : [])
+    .filter((f) => f && typeof f.statement === "string" && f.statement.length > 0)
+    .sort((a, b) => (Number(b?.retention) || -1) - (Number(a?.retention) || -1))
+    .slice(0, cap);
+  if (ranked.length === 0) return null;
+  const lines = ranked.map(
+    (f) => `- [${f.kind}] ${f.statement} (${factAgeLabel(f.created, nowMs)})`,
+  );
+  const text = ["Relevant project facts (from the CTO blackboard):", ...lines].join("\n");
+  return { priority: 60, text };
+}
+
 // ---------------------------------------------------------------------------
 // Active-set bookkeeping (engine-state.json `activeEphemeral`, A1 store).
 // The active set protects a mid-flight session from the reaper.

--- a/src/server/ctoSessions.test.mjs
+++ b/src/server/ctoSessions.test.mjs
@@ -11,6 +11,8 @@ import {
   escalateTier,
   estimateTokens,
   assembleContext,
+  formatFactsBlock,
+  factAgeLabel,
   addActive,
   removeActive,
   sessionCreatedMs,
@@ -105,6 +107,47 @@ test("estimateTokens is 4 chars per token", () => {
   assert.equal(estimateTokens("12345678"), 2);
   assert.equal(estimateTokens(""), 0);
 });
+
+test("factAgeLabel renders hours/days/months/years", () => {
+  const now = Date.UTC(2026, 0, 2, 0, 0, 0);
+  assert.equal(factAgeLabel(now - 3 * 3600_000, now), "3h");
+  assert.equal(factAgeLabel(now - 2 * 24 * 3600_000, now), "2d");
+  assert.equal(factAgeLabel(now - 45 * 24 * 3600_000, now), "1mo");
+  assert.equal(factAgeLabel(now - 14 * 30 * 24 * 3600_000, now), "1y");
+});
+
+test("formatFactsBlock renders kind + statement + age lines under a header", () => {
+  const now = 1000 * 3600_000;
+  const block = formatFactsBlock(
+    [
+      { id: "cto:a", kind: "blocker", statement: "build is red", created: now - 2 * 3600_000, retention: 0.9 },
+      { id: "cto:b", kind: "decision", statement: "moved to postgres", created: now - 5 * 3600_000, retention: 0.5 },
+    ],
+    { nowMs: now },
+  );
+  assert.ok(block);
+  assert.equal(block.priority, 60);
+  assert.ok(block.text.includes("[blocker] build is red (2h)"));
+  assert.ok(block.text.includes("[decision] moved to postgres (5h)"));
+  assert.ok(block.text.startsWith("Relevant project facts"));
+});
+
+test("formatFactsBlock sorts by retention desc, caps, and returns null on empty", () => {
+  const now = 1000 * 3600_000;
+  const many = Array.from({ length: 20 }, (_, i) => ({
+    id: `cto:${i}`,
+    kind: "status",
+    statement: `fact ${i}`,
+    created: now - 3600_000,
+    retention: 20 - i,
+  }));
+  const block = formatFactsBlock(many, { cap: 15, nowMs: now });
+  assert.equal(block.text.split("\n").filter((l) => l.startsWith("- [")).length, 15);
+  assert.ok(block.text.indexOf("fact 19") < block.text.indexOf("fact 0"), "highest retention first");
+  assert.equal(formatFactsBlock([], { nowMs: now }), null);
+  assert.equal(formatFactsBlock([{ id: "x", kind: "status", statement: "", created: now }], { nowMs: now }), null);
+});
+
 
 // ---------------------------------------------------------------------------
 // Active-set bookkeeping

--- a/src/server/delegate.mjs
+++ b/src/server/delegate.mjs
@@ -124,15 +124,20 @@ function genId() {
  * omitted entirely when `worktree` is null (parent cwd was not a repo). Do not
  * add anything else and do not make it configurable.
  */
-export function buildJobPrompt({ prompt, worktree, branch }) {
+export function buildJobPrompt({ prompt, worktree, branch, facts }) {
   const head = String(prompt ?? "").trim();
+  const factsSection =
+    facts && String(facts).trim().length > 0
+      ? "\n\n---\nRelevant project context (from the CTO blackboard):\n" + String(facts).trim() + "\n"
+      : "";
   if (!worktree) {
     return (
       head +
       "\n\n---\n" +
       "You are running as a background job. The user is not watching this session and\n" +
       "cannot see your intermediate output — only your final message is reported back.\n\n" +
-      "When you are done, end with a short summary of what you changed and why."
+      "When you are done, end with a short summary of what you changed and why." +
+      factsSection
     );
   }
   return (
@@ -144,7 +149,8 @@ export function buildJobPrompt({ prompt, worktree, branch }) {
     "Commit your work to that branch before you finish. You may open a draft pull\n" +
     "request for it (never a non-draft one without a human confirming), but you may\n" +
     "never merge, never force-push, and never touch any other checkout.\n\n" +
-    "When you are done, end with a short summary of what you changed and why."
+    "When you are done, end with a short summary of what you changed and why." +
+    factsSection
   );
 }
 

--- a/src/server/delegate.test.mjs
+++ b/src/server/delegate.test.mjs
@@ -150,6 +150,30 @@ test("buildJobPrompt omits the git paragraph when there is no worktree", () => {
   assert.ok(out.includes("When you are done, end with a short summary"));
 });
 
+test("buildJobPrompt is unchanged-by-default (no facts injected)", () => {
+  const base = buildJobPrompt({ prompt: "Fix it", worktree: "/wt", branch: "b" });
+  const noFacts = buildJobPrompt({ prompt: "Fix it", worktree: "/wt", branch: "b", facts: undefined });
+  const emptyFacts = buildJobPrompt({ prompt: "Fix it", worktree: "/wt", branch: "b", facts: "" });
+  assert.equal(noFacts, base);
+  assert.equal(emptyFacts, base);
+  assert.ok(!base.includes("CTO blackboard"));
+});
+
+test("buildJobPrompt appends the facts section when the caller supplies one", () => {
+  const expected = "- [blocker] build is red (2h)\n- [decision] moved to postgres (5h)";
+  const out = buildJobPrompt({
+    prompt: "Investigate the deploy",
+    worktree: "/wt",
+    branch: "b",
+    facts: expected,
+  });
+  assert.ok(out.includes("Relevant project context (from the CTO blackboard):"));
+  assert.ok(out.includes(expected));
+  // the git/background contract paragraph is untouched
+  assert.ok(out.includes("never merge"));
+  assert.ok(out.includes("When you are done, end with a short summary"));
+});
+
 // ----------------------------------------------------------------------------
 // 2. buildCompletionText — done, failed, stopped, no-worktree
 // ----------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -3906,6 +3906,37 @@ const handleRequest = async (req, res) => {
   // on-call CTO agent. dispatch wraps every tool so a quiet box / bad engine
   // returns a structured error, never a throw. `ctx.onNarrate` is a server-side
   // seam (wired by issue 3's voice window), never read off the HTTP body.
+  // ---------- cto_fact blackboard ingestion (BET-1390 / §6.2) ----------
+  // POST /api/cto/facts  body {project, kind, statement, refs, valid_until?,
+  //                            supersedes?, sessionID?} → the gatekeeper
+  //   verdict for the proposal (add/update/supersede/reject), or `{queued:
+  //   true}` if the gatekeeper hasn't resolved within ~10s (the durable queue
+  //   + tick pump still resolve it). Called by the global `cto_fact` opencode
+  //   tool. Bearer-gated with the rest of /api/*.
+  if (path === "/api/cto/facts") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const result = await adaptiveCto.proposeFact({
+          project: body?.project,
+          kind: body?.kind,
+          statement: body?.statement,
+          refs: body?.refs,
+          valid_until: body?.valid_until,
+          supersedes: body?.supersedes,
+          proposalId: body?.proposalId,
+          sessionID: body?.sessionID,
+        });
+        respondJson(res, result.ok ? 200 : 400, result);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
   // ---------- On-call CTO inbound (Issue 2) ----------
   // POST /api/cto/inbound  body {surface?, payload, seenId?} → {ok:true, ...}
   // The single entry point for CTO-bound events. Producers: the global


### PR DESCRIPTION
## BET-1390 — `cto_fact` tool + facts spawn-context seed

Implements the `cto_fact` opencode tool (Adaptive CTO spec §6.2) that lets any
agent session propose an evidence-backed fact onto the blackboard, plus the
§6.9 spawn-context seeding that surfaces top facts to new sessions and
delegate jobs. Dependency BET-1389 (blackboard) is merged, so the queue +
gatekeeper are live.

### What's here

- **`docs/opencode-tools/cto-fact.ts`** — thin registrar (copies the existing
  schedule.ts shape + `./manta-auth`): validates the proposal, rejects zero
  `refs` client-side with an "attach evidence" message, POSTs to
  `/api/cto/facts` with `sessionID` as the sender, returns the gatekeeper
  verdict (or a "queued" note when the judge is still deciding).
- **Route** `POST /api/cto/facts` (bearer-gated with the rest of `/api/*`),
  handler `proposeFact` in `src/server/ctoEngine.mjs`:
  - builds a validated proposal via new pure `buildFactProposal` in
    `ctoFacts.mjs` (single-writer path preserved — facts only ever enter
    through the queue → gatekeeper);
  - derives an **idempotent client proposal id** from
    (project, kind, statement, refs, sessionID) so at-least-once redelivery
    collapses to one application;
  - enqueues, awaits gatekeeper resolution up to 10s, returns the verdict or
    `{queued:true}` (durable queue + tick pump still resolve it).
- **Spawn-context** (`assembleContext`/facts block):
  - `formatFactsBlock` (pure) in `ctoSessions.mjs` — renders
    `- [kind] statement (age)` lines under a header; `factAgeLabel` helper;
  - `buildFactsContext` (pure orchestration) + `factsContextBlock` in
    `ctoEngine.mjs` — top-K (≤15) by retention for a project, formatted, with
    a retention `touchFacts` on exactly the surfaced ids;
  - `topFacts` (retention-ranked, reliability-aware) + `proposalOutcome` on
    the facts engine.
- **Delegate prompts**: `buildJobPrompt` gains an optional `facts` section —
  **unchanged-by-default** (no facts ⇒ byte-identical output). Per the issue,
  only the CTO's own job starts pass it in P2; **no caller wires it yet**
  (there is no CTO job-start path in the current code), and user-started
  delegate jobs are deliberately untouched.
- **Docs**: guidance blurb appended to `docs/opencode-tools/AGENTS.md`.

### Tests (new)
- `buildFactProposal` payload shape, zero-ref rejection, idempotent id,
  sender/supersedes/valid_until passthrough (ctoFacts).
- `topFacts` retention ranking + K cap (ctoFacts).
- `formatFactsBlock` + `factAgeLabel` formatting/cap/null (ctoSessions).
- `buildFactsContext` formatting + K cap + injected touch call (ctoEngine).
- Engine-level `proposeFact`: reject, resolve, idempotent re-submission.
- `buildJobPrompt` with/without facts, unchanged-by-default (delegate).

**Files changed:** 11 files, +576/−4.

**Base: origin/main @ `ee00cdec`**

Verification results:
- PR branch (`multica/BET-1390-cto-fact` @ `f0044138`):
  - typecheck: exit 0, errors: none. log sha256: `84317a7d…`
  - test: exit 0, 3176 pass / 0 fail / 0 skip. log sha256: `bd7351f4…`
- Base (`main` @ `ee00cdec`):
  - typecheck: exit 0, errors: none. log sha256: `84317a7d…`
  - test: exit 0, 3162 pass / 0 fail / 0 skip. log sha256: `4926f6b1…`
- Conclusion: 0 new failures; 14 tests added by this PR, all passing.
