### PR TITLE
BET-1391: verdict ledger + counter mapping + estimator helpers

### DIFF
--- a/docs/opencode-tools/cto-verdict.ts
+++ b/docs/opencode-tools/cto-verdict.ts
@@ -1,0 +1,101 @@
+// `cto_verdict` tool — global opencode custom tool (Adaptive CTO, BET-1391 / §9.5).
+//
+// Lets any agent session record a *verdict* about a suggestion it surfaced
+// (or the user gave) into the Adaptive CTO verdict ledger: whether the
+// suggestion was accepted, edited, dismissed, vetoed, corrected, marked
+// never-again, expired, or simply opened. The server appends it to
+// `verdicts.json` and routes its §9.5 counter effects to the registered sinks
+// (facts sender-reliability now, trust / tool counters later) — see
+// src/server/ctoVerdicts.mjs.
+//
+// Install on the opencode host (the Linux box that runs manta-server + opencode):
+//   mkdir -p ~/.config/opencode/tools
+//   cp <repo>/docs/opencode-tools/cto-verdict.ts ~/.config/opencode/tools/cto-verdict.ts
+//   cp <repo>/docs/opencode-tools/manta-auth.ts ~/.config/opencode/tools/manta-auth.ts
+// then `systemctl --user restart opencode-serve` so opencode re-scans tools/.
+//
+// This tool is a THIN registrar (see docs/opencode-tools/AGENTS.md): it
+// validates the verdict shape client-side and POSTs it to manta-server
+// (127.0.0.1:8787, same box), which owns the verdict ledger and the §9.5
+// counter routing. execute() returns promptly with the recorded effects.
+
+import { tool } from "@opencode-ai/plugin";
+import { authHeaders } from "./manta-auth";
+
+const MANTA_SERVER = process.env.MANTA_SERVER_URL || "http://127.0.0.1:8787";
+const z = tool.schema;
+
+async function call(method: string, path: string, body?: unknown): Promise<any> {
+  const res = await fetch(`${MANTA_SERVER}${path}`, {
+    method,
+    headers: authHeaders(body),
+    body: body ? JSON.stringify(body) : undefined,
+  });
+  const text = await res.text();
+  let json: any = {};
+  try {
+    json = text ? JSON.parse(text) : {};
+  } catch {
+    json = { error: text };
+  }
+  if (!res.ok) {
+    throw new Error(json?.error || `manta-server ${res.status}`);
+  }
+  return json;
+}
+
+export const cto_verdict = tool({
+  description: [
+    "Record a verdict about a suggestion the Adaptive CTO surfaced (or you gave",
+    "it) into the verdict ledger: whether it was accepted, edited, dismissed,",
+    "vetoed, corrected, marked never-again, expired, or opened. Accepted findings",
+    "build the CTO's trust in the source that produced them; rejections do the",
+    "opposite. Use it when you assess a suggestion the CTO proposed — e.g. an",
+    "open blocker-card recommendation or a digest item reference — so the CTO",
+    "learns what is useful.",
+  ].join(" "),
+  args: {
+    type: z
+      .string()
+      .describe(
+        "The kind of subject being judged, e.g. `fact` (a blackboard fact), `digest_item` (a digest row).",
+      ),
+    id: z.string().describe("The subject's stable id (the fact id, the digest item id)."),
+    class: z
+      .string()
+      .optional()
+      .describe("Optional learner partition the subject belongs to (e.g. a project, tier)."),
+    sender: z
+      .union([z.string(), z.object({ sessionID: z.string() })])
+      .optional()
+      .describe(
+        "Who produced the subject worth crediting (trust/reliability). A session id string or {sessionID}.",
+      ),
+    verdict: z
+      .enum(["accept", "dismiss", "edit", "veto", "expire", "correct", "open"])
+      .describe(
+        "accept (keep, confirm), edit (keep-with-signal), dismiss (reject), veto (reject a pending window), " +
+          "correct (reject, it was wrong), expire (retention decay only), open (accessed / importance only).",
+      ),
+    never: z
+      .boolean()
+      .optional()
+      .describe(
+        "Mark as a never-again judgment (kills future rings). A never-flagged verdict is counted as a rejection.",
+      ),
+  },
+  async execute(args) {
+    const result = await call("POST", "/api/cto/verdict", {
+      subject: {
+        type: args.type,
+        id: args.id,
+        ...(args.class ? { class: args.class } : {}),
+        ...(args.sender !== undefined ? { sender: args.sender } : {}),
+      },
+      verdict: args.verdict,
+      ...(args.never !== undefined ? { never: args.never } : {}),
+    });
+    const effects = result?.effects ? Object.keys(result.effects).join(" + ") : "none";
+    return `Verdict recorded: ${args.verdict} on ${args.type}:${args.id} → counter effects [${effects}].`;
+  },
+});

--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -685,7 +685,9 @@ function SettingsView({
                       ? "Ambient spend today"
                       : id === "digestOpens"
                       ? "Digest opens · 7d"
-                      : "Pipeline lag (close → summary)",
+                      : id === "pipelineLag"
+                      ? "Pipeline lag (close → summary)"
+                      : "Suggestion acceptance · 30d",
                   value: null,
                   n: 0,
                   min: 1,
@@ -726,7 +728,7 @@ function SettingsView({
   );
 }
 
-const HEALTH_ROW_ORDER = ["ambientSpendToday", "digestOpens", "pipelineLag"] as const;
+const HEALTH_ROW_ORDER = ["ambientSpendToday", "digestOpens", "pipelineLag", "suggestionAcceptance"] as const;
 
 // ---------------------------------------------------------------------------
 // Activity ledger drill-down (A12)

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -55,6 +55,7 @@ export const DEMO_UNIMPLEMENTED = [
   "ctoPause",
   "ctoResume",
   "ctoStateGet",
+  "ctoVerdict",
   "delegateApprove",
   "delegateDecline",
   "delegateDelete",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -1696,6 +1696,43 @@ export const httpApi: Api = {
       return { ok: false };
     }
   },
+
+  // POST /api/cto/verdict — the §9.5 verdict-ledger write (BET-1391). One
+  // append-only path the opencode `cto_verdict` tool and the engine both reach
+  // (digest-opened rewires here too). Returns `{ok:false,error}` on invalid
+  // input (400); a network failure degrades to `{ok:false}`.
+  ctoVerdict: async (input: {
+    subject: { type: string; id: string; class?: string; sender?: string | { sessionID: string } };
+    verdict:
+      | "accept"
+      | "dismiss"
+      | "edit"
+      | "veto"
+      | "expire"
+      | "correct"
+      | "open";
+    never?: boolean;
+  }): Promise<{ ok: boolean; error?: string; effects?: { success?: boolean; rejection?: boolean; access?: boolean; decay?: boolean } }> => {
+    const url = `${serverBase()}/api/cto/verdict`;
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { ...authHeaders(clientToken()), "Content-Type": "application/json" },
+        body: JSON.stringify({
+          subject: input.subject,
+          verdict: input.verdict,
+          ...(input.never !== undefined ? { never: input.never } : {}),
+        }),
+      });
+      if (res.status === 401) throw new AuthRequiredError();
+      if (res.ok) return { ok: true };
+      let json: { error?: string; effects?: { success?: boolean; rejection?: boolean; access?: boolean; decay?: boolean } } = {};
+      try { json = (await res.json()) as typeof json; } catch { /* non-JSON */ }
+      return { ok: false, error: json.error ?? `HTTP ${res.status}`, effects: json.effects };
+    } catch {
+      return { ok: false };
+    }
+  },
 };
 
 // Base64-encode an ArrayBuffer in chunks. `btoa(String.fromCharCode(...))`

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -43,7 +43,7 @@ export const idleBackfill: BackfillState = {
 // shows `collecting (n/k)` and never the number — a stat never displays noise
 // as signal.
 export type CtoHealthStat = {
-  id: "ambientSpendToday" | "digestOpens" | "pipelineLag";
+  id: "ambientSpendToday" | "digestOpens" | "pipelineLag" | "suggestionAcceptance";
   label: string;
   value: string | null;
   n: number;

--- a/src/server/ctoDigest.mjs
+++ b/src/server/ctoDigest.mjs
@@ -560,13 +560,12 @@ export function createCtoDigest(deps = {}) {
 
   // §14.1 instrumentation: per-item open / expand (the UI issue calls this via
   // POST /api/cto/digest/opened).
-  async function recordItemEvent({ item, expand, digestId } = {}) {
-    await ledgerLog({
-      kind: expand ? "cto.digest_expanded" : "cto.digest_item_opened",
-      item: typeof item === "string" ? item : null,
-      digestId: digestId ?? null,
-    });
-  }
+  //
+  // BET-1391: the per-item OPEN path moved into the verdict ledger — the
+  // `/opened` route now calls `recordVerdict({...verdict:"open"})` (one path),
+  // and this direct ledger write is deleted. Only the whole-digest view-open
+  // (`recordOpen` → `cto.digest_opened`, which the learned-timing scheduler
+  // reads) remains recorded here.
 
   async function nextScheduledAt() {
     const opens = await loadOpens();
@@ -757,7 +756,6 @@ export function createCtoDigest(deps = {}) {
     isGenerating: () => generating,
     getState,
     recordOpen,
-    recordItemEvent,
     nextScheduledAt,
     // exposed for tests / diagnostics
     _now: now,

--- a/src/server/ctoDigest.test.mjs
+++ b/src/server/ctoDigest.test.mjs
@@ -519,17 +519,21 @@ test("digests/ retention keeps the last 30 (DIGESTS_KEEP == 30)", () => {
   assert.equal(DIGESTS_KEEP, 30);
 });
 
-test("recordOpen + recordItemEvent emit §14.1 instrumentation ledger rows", async () => {
+test("recordOpen emits the §14.1 digest view-open ledger row", async () => {
   const { engine, ledgerRows } = makeEngine({ runEphemeral: null });
   await engine.recordOpen();
-  await engine.recordItemEvent({ item: "shipped the parser", digestId: "123" });
-  await engine.recordItemEvent({ item: "deep log", expand: true, digestId: "123" });
   const kinds = ledgerRows.map((r) => r.kind);
   assert.ok(kinds.includes("cto.digest_opened"));
-  assert.ok(kinds.includes("cto.digest_item_opened"));
-  assert.ok(kinds.includes("cto.digest_expanded"));
-  const expanded = ledgerRows.find((r) => r.kind === "cto.digest_expanded");
-  assert.equal(expanded.digestId, "123");
+});
+
+// BET-1391: the per-item OPEN path moved into the verdict ledger (§9.5) — the
+// `/opened` route calls `recordVerdict({verdict:"open"})` (one path) and the
+// digest engine no longer writes its own `cto.digest_item_opened` /
+// `cto.digest_expanded` ledger rows. Keep a guard so a future re-add has to
+// justify itself here.
+test("BET-1391: digest engine no longer has a direct per-item ledger write", async () => {
+  const { engine } = makeEngine({ runEphemeral: null });
+  assert.equal(typeof engine.recordItemEvent, "undefined");
 });
 
 test("generateDigest: successful model path emits cto.digest_generated", async () => {

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -51,8 +51,10 @@ import {
   segmentsStore,
   rollupsStore,
   inboxStore,
+  verdictsStore,
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
+import { createVerdictEngine } from "./ctoVerdicts.mjs";
 import { createCtoBackfill } from "./ctoBackfill.mjs";
 import { startPoller } from "./startPoller.mjs";
 import { createSeenIdFilter } from "./seenIds.mjs";
@@ -296,6 +298,10 @@ export function createCtoEngine(deps = {}) {
     // BET-1397 CTO inbox (§4.4): the durable inbox.json store + seam, so drain
     // is unit-testable without touching the real fs. Defaults to the real store.
     inbox = null,
+    // BET-1391 verdict ledger (§9.5): optional pre-built verdicts store (else
+    // the shared `verdicts.json` store). The verdict engine + facts sink are
+    // constructed below from it.
+    verdicts = verdictsStore,
   } = deps;
 
   let disposed = false;
@@ -315,6 +321,7 @@ export function createCtoEngine(deps = {}) {
   let tuneHandle = null;
   let builtInBackfill = null;
   let profileDecayHandle = null;
+  let verdictsEngine = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
   // open, user prompt). The desktop heartbeat is read live via
@@ -773,6 +780,36 @@ export function createCtoEngine(deps = {}) {
     return factsEngine;
   }
 
+  // BET-1391 verdict ledger (§9.5): lazy single instance over the injectable
+  // verdicts store. The facts counter-sink is registered ONCE at construction
+  // so every recorded verdict routes its §9.5 effects to the sender-reliability
+  // counters (B1) — and is removed by the engine's dispose below.
+  function getVerdictsEngine() {
+    if (verdictsEngine) return verdictsEngine;
+    verdictsEngine = createVerdictEngine({ verdicts, now });
+    verdictsEngine.registerCounterSink(factsCounterSink);
+    return verdictsEngine;
+  }
+
+  // The facts sink (BET-1391 / §9.5): map verdict acceptance/rejection effects
+  // on fact subjects back onto the fact sender's reliability counters — success
+  // → confirmed, rejection → rejected. `open`/`expire` (importance/retention
+  // effects only) never touch acceptance counters, matching the mapping table.
+  // Best-effort (a reliability write failing never breaks verdict recording).
+  function factsCounterSink(effects, entry) {
+    if (entry?.subject?.type !== "fact") return;
+    const sender = entry.subject.sender;
+    if (sender == null) return;
+    const delta = {};
+    if (effects.success) delta.confirmed = 1;
+    if (effects.rejection) delta.rejected = 1;
+    if (!delta.confirmed && !delta.rejected) return;
+    const fe = getFactsEngine();
+    if (fe && typeof fe.noteReliability === "function") {
+      void fe.noteReliability(sender, delta).catch(() => {});
+    }
+  }
+
   // Pump the blackboard proposal queue (per-project, single writer). Driven
   // from the tick when enabled; best-effort, never throws into the poller.
   async function pumpFacts() {
@@ -1164,6 +1201,11 @@ export function createCtoEngine(deps = {}) {
     lastHeartbeat,
     proposeFact,
     factsContextBlock,
+    // BET-1391 verdict ledger (§9.5): record + read the verdict ledger (the
+    // opencode `cto_verdict` tool + the digest-opened rewire + the health card
+    // all reach one path through these).
+    recordVerdict: (input) => getVerdictsEngine().recordVerdict(input),
+    listVerdicts: () => getVerdictsEngine().listVerdicts(),
     get rateTracker() {
       return track;
     },

--- a/src/server/ctoFacts.mjs
+++ b/src/server/ctoFacts.mjs
@@ -856,6 +856,14 @@ export function createFactsEngine(deps = {}) {
     disposed = true;
   }
 
+  // BET-1391: the verdict-ledger facts sink drives sender reliability counters
+  // through this seam (success → confirmed, rejection → rejected). Public
+  // because the verdict engine in ctoEngine consumes it; a synth sender with
+  // no nested session identity is a no-op (senderKey returns null).
+  async function noteReliability(sender, delta) {
+    await bumpReliability(sender, delta);
+  }
+
   return {
     submitProposal,
     pump,
@@ -867,6 +875,7 @@ export function createFactsEngine(deps = {}) {
     topFacts,
     listFacts: (project) => loadFacts(project).then((arr) => arr.filter(isActiveFact)),
     listProjects: listKnownProjects,
+    noteReliability,
     dispose,
   };
 }

--- a/src/server/ctoHealth.mjs
+++ b/src/server/ctoHealth.mjs
@@ -8,6 +8,8 @@
 // that produce their data (rule 4 in the decomposition) — they are NOT
 // rendered here.
 
+import { effectsForVerdict } from "./ctoVerdicts.mjs";
+
 const DAY_MS = 86_400_000;
 
 // Minimum sample sizes (samples, not days). Chosen so a median is meaningful:
@@ -15,10 +17,13 @@ const DAY_MS = 86_400_000;
 // segments for the pipeline-lag median, and at least one budget meter reading
 // for the ambient-spend row (the B1 metering that feeds it lands in a later
 // economics issue — until then this row honestly reports `collecting (0/1)`).
+// Suggestion acceptance needs ≥ 10 acceptance-deciding verdicts (BET-1391) so
+// a thumb of a few verdicts never reads as signal.
 export const HEALTH_STAT_MIN = Object.freeze({
   ambientSpendToday: 1,
   digestOpens: 7,
   pipelineLag: 7,
+  suggestionAcceptance: 10,
 });
 
 function medianOf(values) {
@@ -58,6 +63,7 @@ export async function computeHealthStats({
   ledgerRead = async () => [],
   budgetRead = async () => null,
   listSegments = async () => [],
+  verdictsRead = async () => [],
   ctoAmbientCap = 2.5,
 } = {}) {
   const t = now();
@@ -134,6 +140,40 @@ export async function computeHealthStats({
     value:
       lags.length >= HEALTH_STAT_MIN.pipelineLag && medianLag != null
         ? `${Math.round(medianLag / 60_000)} min median`
+        : null,
+  });
+
+  // 4. Suggestion acceptance (30d) — the share of the last 30 days'
+  //    acceptance-deciding verdicts that were accepted (accept/edit = success;
+  //    dismiss/veto/correct/never = rejection). `open`/`expire` never enter
+  //    the acceptance counters (§9.5 — routed through the same single mapping
+  //    table the verdict router consumes). Collecting until ≥ 10 verdicts.
+  let verdicts = [];
+  try {
+    verdicts = (await verdictsRead()) ?? [];
+  } catch {
+    verdicts = [];
+  }
+  const verdictCutoff = t - 30 * DAY_MS;
+  let decided = 0;
+  let accepted = 0;
+  for (const v of verdicts) {
+    if (v?.ts == null || v.ts < verdictCutoff) continue;
+    const e = effectsForVerdict(v.verdict, v.never === true);
+    if (e.success || e.rejection) {
+      decided += 1;
+      if (e.success) accepted += 1;
+    }
+  }
+  const acceptRate = decided > 0 ? accepted / decided : 0;
+  stats.push({
+    id: "suggestionAcceptance",
+    label: "Suggestion acceptance · 30d",
+    min: HEALTH_STAT_MIN.suggestionAcceptance,
+    n: decided,
+    value:
+      decided >= HEALTH_STAT_MIN.suggestionAcceptance
+        ? `${Math.round(acceptRate * 100)}% accepted`
         : null,
   });
 

--- a/src/server/ctoHealth.mjs
+++ b/src/server/ctoHealth.mjs
@@ -160,10 +160,12 @@ export async function computeHealthStats({
   for (const v of verdicts) {
     if (v?.ts == null || v.ts < verdictCutoff) continue;
     const e = effectsForVerdict(v.verdict, v.never === true);
-    if (e.success || e.rejection) {
-      decided += 1;
-      if (e.success) accepted += 1;
-    }
+    if (!(e.success || e.rejection)) continue;
+    // A rejection signal (incl. a `never`-flagged verdict) is decided but NOT
+    // accepted; only an unambiguous success (+ no rejection) counts as accepted,
+    // so a never-again judgment never reads as a confirm.
+    decided += 1;
+    if (e.success && !e.rejection) accepted += 1;
   }
   const acceptRate = decided > 0 ? accepted / decided : 0;
   stats.push({

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -120,3 +120,61 @@ test("listSegments / ledger / budget failures degrade to collecting, never throw
     assert.deepEqual(s.value, null);
   }
 });
+
+// --- Suggestion acceptance (BET-1391, 30d) ------------------------------
+
+function verdict(verdict, never, tsOffsetDays) {
+  return { ts: NOW - (tsOffsetDays ?? 0) * DAY, verdict, ...(never ? { never: true } : {}) };
+}
+
+test("suggestion acceptance: collecting (n/10) until 10 acceptance-deciding verdicts", async () => {
+  const verdicts = Array.from({ length: 5 }, (_, i) => verdict("accept", false, i));
+  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => verdicts });
+  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  assert.equal(s.min, HEALTH_STAT_MIN.suggestionAcceptance);
+  assert.equal(s.n, 5);
+  assert.equal(s.value, null);
+});
+
+test("suggestion acceptance: open/expire never enter the acceptance counters", async () => {
+  const verdicts = [
+    verdict("accept", false, 0),
+    verdict("open", false, 0),
+    verdict("expire", false, 0),
+    verdict("accept", false, 0),
+  ];
+  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => verdicts });
+  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  assert.equal(s.n, 2); // only the two accept verdicts decide acceptance
+  assert.equal(s.value, null); // still collecting
+});
+
+test("suggestion acceptance: ≥10 verdicts renders accepted % (accept/edit success; other verdicts rejection)", async () => {
+  const verdicts = [
+    ...Array.from({ length: 7 }, () => verdict("accept", false, 0)),
+    ...Array.from({ length: 3 }, () => verdict("dismiss", false, 0)),
+  ];
+  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => verdicts });
+  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  assert.equal(s.n, 10);
+  assert.equal(s.value, "70% accepted");
+});
+
+test("suggestion acceptance: a `never` flag counts as a rejection", async () => {
+  const verdicts = [
+    ...Array.from({ length: 6 }, () => verdict("accept", false, 0)),
+    ...Array.from({ length: 4 }, () => verdict("accept", true, 0)), // never-flagged accept → rejection
+  ];
+  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => verdicts });
+  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  assert.equal(s.n, 10);
+  assert.equal(s.value, "60% accepted");
+});
+
+test("suggestion acceptance: verdicts older than 30d are excluded", async () => {
+  const old = verdict("accept", false, 40);
+  const fresh = Array.from({ length: 10 }, () => verdict("accept", false, 1));
+  const { stats } = await computeHealthStats({ now: () => NOW, verdictsRead: async () => [old, ...fresh] });
+  const s = stats.find((x) => x.id === "suggestionAcceptance");
+  assert.equal(s.n, 10);
+});

--- a/src/server/ctoVerdicts.mjs
+++ b/src/server/ctoVerdicts.mjs
@@ -244,8 +244,9 @@ export function createVerdictEngine(deps = {}) {
       ...(never === true ? { never: true } : {}),
     };
 
-    const entries = await loadEntries();
-    await verdicts.save({ entries: [...entries, entry] });
+    const payload = await verdicts.load().catch(() => null);
+    const entries = Array.isArray(payload?.entries) ? payload.entries : [];
+    await verdicts.save({ ...(payload ?? {}), entries: [...entries, entry] });
 
     const effects = effectsForVerdict(verdict, never);
     registry.dispatch(effects, entry);

--- a/src/server/ctoVerdicts.mjs
+++ b/src/server/ctoVerdicts.mjs
@@ -1,0 +1,265 @@
+// src/server/ctoVerdicts.mjs
+// BET-1391 — Verdict ledger + counter mapping + estimator helpers (spec §9.5).
+//
+// Responsibilities:
+//   - `VERDICT_COUNTERS` — the ONE normative mapping table (§9.5) from verdict
+//     → which learner counters it feeds. Consumed by the router; there is no
+//     per-caller logic deciding which verdicts feed which learner.
+//   - `createVerdictEngine().recordVerdict` — appends a verdict to
+//     `verdicts.json` (A1's atomic jsonStore, append-only; ctoStores' sweep
+//     owns eviction) and routes the §9.5 counter effects through the counter
+//     sink registry.
+//   - Counter sinks — consumers (the facts sender-reliability counters now,
+//     trust / tool `as_*` counters later) register here; `recordVerdict`
+//     dispatches each entry's effects through every sink. Best-effort: a
+//     throwing sink never breaks verdict recording.
+//   - Estimator helpers (`betaMean`, `betaTailAbove`, `thompsonDraw`) — the
+//     shared §9.5 math: Thompson sampling where the system *selects* under
+//     exploration; Beta means / tail tests where it *gates*.
+//
+// Pure over injected stores + a now() clock — testable without a live box.
+
+import { verdictsStore } from "./ctoStores.mjs";
+
+// ---------------------------------------------------------------------------
+// §9.5 counter mapping (normative — one exported table, consumed by the router)
+// ---------------------------------------------------------------------------
+//
+// | Verdict | Acceptance/trust Beta | Importance/retention | Note              |
+// |---------|-----------------------|----------------------|-------------------|
+// | accept,e| success               | access               | edit=accept+signal|
+// | dismiss,| rejection             | —                    | veto=cancelled    |
+// | veto,correct,never              |                      | veto-window       |
+// | open    | —                     | access               | never->acceptance |
+// | expire  | —                     | decay signal         | never->acceptance |
+//
+// `never` is both a verdict-affecting *flag* (a never-again judgment, §10.4)
+// and, per the table, a rejection signal — `effectsForVerdict` folds it in on
+// top of the verdict's own mapping.
+export const VERDICT_COUNTERS = Object.freeze({
+  accept: Object.freeze({ success: true, access: true }),
+  edit: Object.freeze({ success: true, access: true }),
+  dismiss: Object.freeze({ rejection: true }),
+  veto: Object.freeze({ rejection: true }),
+  correct: Object.freeze({ rejection: true }),
+  open: Object.freeze({ access: true }),
+  expire: Object.freeze({ decay: true }),
+});
+
+export const VERDICT_VERDICTS = Object.freeze([
+  "accept",
+  "dismiss",
+  "edit",
+  "veto",
+  "expire",
+  "correct",
+  "open",
+]);
+
+// Combine a verdict's table effects with the `never` flag's rejection signal
+// into one effects object for the sink router. Effect flags: `success`,
+// `rejection` (Acceptance/trust Beta) and `access`, `decay` (Importance/
+// retention) — grouped, not per-verdict, so a sink reacts to the counter
+// class it owns rather than to individual verdicts.
+export function effectsForVerdict(verdict, never = false) {
+  const base = VERDICT_COUNTERS[verdict] ?? {};
+  const effects = { ...base };
+  if (never === true) {
+    effects.rejection = true; // a never-again judgment is a rejection (§9.5 table)
+  }
+  return effects;
+}
+
+// ---------------------------------------------------------------------------
+// Estimator helpers (§9.5 policy)
+// ---------------------------------------------------------------------------
+
+// Beta mean — the acceptance-rate point estimate E[X] = a / (a+b).
+export function betaMean(a, b) {
+  const aa = a || 0;
+  const bb = b || 0;
+  const n = aa + bb;
+  return n === 0 ? 0 : aa / n;
+}
+
+// Standard-normal CDF via the Abramowitz–Stegun erf 7.1.26 rational
+// approximation. The approximation is monotonic and good to ~1e-3 in the
+// z-range these gates use; exactness is not required at ledger counts.
+function standardNormalCdf(z) {
+  const t = 1 / (1 + 0.2316419 * Math.abs(z));
+  const d = 0.3989422804014327 * Math.exp(-(z * z) / 2);
+  const p =
+    d *
+    t *
+    (0.31938153 +
+      t * (-0.356563782 + t * (1.781477937 + t * (-1.821255978 + t * 1.330274429))));
+  return z >= 0 ? 1 - p : p;
+}
+
+// Gate test — the probability that the Beta(a,b) *mean* exceeds `p` (via a
+// normal approximation of the mean: μ=a/(a+b), σ²=ab/((a+b)²(a+b+1))), then
+// `prob >= conf`. Used where the tail gates (trust promotion, sender
+// reliability): promote only once the tail clears the confidence threshold —
+// never on a noisy mean. A degenerate Beta (no counts yet) never passes.
+export function betaTailAbove(a, b, p, conf = 0.95) {
+  const aa = a || 0;
+  const bb = b || 0;
+  const n = aa + bb;
+  const mu = betaMean(aa, bb);
+  const sigma = n > 0 ? Math.sqrt((aa * bb) / (n * n * (n + 1))) : 0;
+  if (!(sigma > 0)) return false;
+  const z = (mu - p) / sigma;
+  return standardNormalCdf(z) >= conf;
+}
+
+// One standard-normal deviate from uniform numbers (Box–Muller).
+function standardNormal(rng) {
+  const u1 = Math.max(rng(), 1e-12);
+  const u2 = rng();
+  return Math.sqrt(-2 * Math.log(u1)) * Math.cos(2 * Math.PI * u2);
+}
+
+// Gamma(k,1) deviate via the Marsaglia–Tsang algorithm (shape k ≥ 1), with the
+// k < 1 case reduced through Gamma(k) = Gamma(k+1) · U^(1/k). `rng` supplies
+// the uniform numbers (default Math.random).
+function gammaSample(shape, rng) {
+  let k = Math.max(shape, 0);
+  if (k < 1) {
+    return gammaSample(k + 1, rng) * Math.pow(Math.max(rng(), 1e-12), 1 / k);
+  }
+  if (k === 0) return 0;
+  const d = k - 1 / 3;
+  const c = 1 / Math.sqrt(9 * d);
+  for (;;) {
+    const x = standardNormal(rng);
+    const v = Math.pow(1 + c * x, 3);
+    if (v <= 0) continue;
+    const u = rng();
+    if (u < 1 - 0.0331 * x * x * x * x) return d * v;
+    if (Math.log(u) < 0.5 * x * x + d * (1 - v + Math.log(v))) return d * v;
+  }
+}
+
+// One Thompson draw from Beta(a,b): x ~ Gamma(a), y ~ Gamma(b), return
+// x/(x+y). `rng` injectable for deterministic tests. Used where the system
+// *selects* under exploration (portfolio categories, tool-as-source).
+export function thompsonDraw(a, b, rng = Math.random) {
+  const aa = a || 0;
+  const bb = b || 0;
+  if (aa <= 0 && bb <= 0) return 0.5;
+  if (aa <= 0) return 0;
+  if (bb <= 0) return 1;
+  const x = gammaSample(aa, rng);
+  const y = gammaSample(bb, rng);
+  const total = x + y;
+  return total > 0 ? x / total : betaMean(aa, bb);
+}
+
+// ---------------------------------------------------------------------------
+// Counter sink registry
+// ---------------------------------------------------------------------------
+
+// A small registry of counter sinks. Each sink is called with
+// `(effects, entry)` after a verdict is recorded. `register` returns an
+// unregister thunk. Dispatches are best-effort (a throwing sink is swallowed),
+// so one consumer failing its counter update can never break verdict recording.
+export function createCounterRegistry() {
+  const sinks = [];
+  return {
+    register(sink) {
+      sinks.push(sink);
+      return () => {
+        const i = sinks.indexOf(sink);
+        if (i >= 0) sinks.splice(i, 1);
+      };
+    },
+    dispatch(effects, entry) {
+      for (const sink of sinks) {
+        try {
+          if (typeof sink === "function") sink(effects, entry);
+          else if (sink && typeof sink.onEffects === "function") sink.onEffects(effects, entry);
+        } catch {
+          /* best-effort */
+        }
+      }
+    },
+    size: () => sinks.length,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The verdict engine
+// ---------------------------------------------------------------------------
+
+// Validate a verdict subject per §9.5: `{type, id, class?, sender?}`. `sender`
+// is a session-stable identity — a non-empty string or `{sessionID}`.
+export function isValidVerdictSubject(subject) {
+  if (!subject || typeof subject !== "object") return false;
+  if (typeof subject.type !== "string" || subject.type.length === 0) return false;
+  if (typeof subject.id !== "string" || subject.id.length === 0) return false;
+  if (subject.class !== undefined && (typeof subject.class !== "string" || subject.class.length === 0)) {
+    return false;
+  }
+  if (subject.sender !== undefined) {
+    const s = subject.sender;
+    const okString = typeof s === "string" && s.length > 0;
+    const okSession = s && typeof s === "object" && typeof s.sessionID === "string";
+    if (!okString && !okSession) return false;
+  }
+  return true;
+}
+
+export function createVerdictEngine(deps = {}) {
+  const { verdicts = verdictsStore, now = () => Date.now(), registry = createCounterRegistry() } = deps;
+
+  async function loadEntries() {
+    const payload = await verdicts.load().catch(() => null);
+    return Array.isArray(payload?.entries) ? payload.entries : [];
+  }
+
+  // Appends a verdict entry to `verdicts.json` (append-only; the ctoStores
+  // retention sweep owns eviction) and routes its §9.5 counter effects through
+  // every registered sink. Rejects invalid input with `{ok:false, error}` —
+  // never throws.
+  async function recordVerdict({ subject, verdict, never } = {}) {
+    if (!VERDICT_VERDICTS.includes(verdict)) {
+      return { ok: false, error: `invalid verdict "${verdict}" (expected one of: ${VERDICT_VERDICTS.join(", ")})` };
+    }
+    if (!isValidVerdictSubject(subject)) {
+      return { ok: false, error: "invalid subject (expected {type, id, class?, sender?})" };
+    }
+    if (never !== undefined && typeof never !== "boolean") {
+      return { ok: false, error: "`never` must be a boolean" };
+    }
+
+    const entry = {
+      ts: now(),
+      subject: {
+        type: subject.type,
+        id: subject.id,
+        ...(subject.class !== undefined ? { class: subject.class } : {}),
+        ...(subject.sender !== undefined ? { sender: subject.sender } : {}),
+      },
+      verdict,
+      ...(never === true ? { never: true } : {}),
+    };
+
+    const entries = await loadEntries();
+    await verdicts.save({ entries: [...entries, entry] });
+
+    const effects = effectsForVerdict(verdict, never);
+    registry.dispatch(effects, entry);
+    return { ok: true, effects };
+  }
+
+  async function listVerdicts() {
+    return loadEntries();
+  }
+
+  return {
+    recordVerdict,
+    listVerdicts,
+    registerCounterSink: registry.register,
+    _registry: registry,
+  };
+}

--- a/src/server/ctoVerdicts.test.mjs
+++ b/src/server/ctoVerdicts.test.mjs
@@ -1,0 +1,224 @@
+// src/server/ctoVerdicts.test.mjs
+// BET-1391 — verdict ledger + §9.5 counter mapping + estimator helpers.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  VERDICT_COUNTERS,
+  VERDICT_VERDICTS,
+  effectsForVerdict,
+  betaMean,
+  betaTailAbove,
+  thompsonDraw,
+  createVerdictEngine,
+  isValidVerdictSubject,
+} from "./ctoVerdicts.mjs";
+
+// ---------------------------------------------------------------------------
+// §9.5 counter mapping table
+// ---------------------------------------------------------------------------
+
+test("VERDICT_COUNTERS maps every verdict to its §9.5 counters", () => {
+  assert.deepEqual(VERDICT_COUNTERS.accept, { success: true, access: true });
+  assert.deepEqual(VERDICT_COUNTERS.edit, { success: true, access: true });
+  assert.deepEqual(VERDICT_COUNTERS.dismiss, { rejection: true });
+  assert.deepEqual(VERDICT_COUNTERS.veto, { rejection: true });
+  assert.deepEqual(VERDICT_COUNTERS.correct, { rejection: true });
+  assert.deepEqual(VERDICT_COUNTERS.open, { access: true });
+  assert.deepEqual(VERDICT_COUNTERS.expire, { decay: true });
+});
+
+test("mapping is exhaustive: every allowed verdict has a row", () => {
+  for (const v of VERDICT_VERDICTS) {
+    assert.ok(VERDICT_COUNTERS[v], `verdict "${v}" missing from VERDICT_COUNTERS`);
+  }
+});
+
+test("open and expire never enter the acceptance counters", () => {
+  assert.equal(VERDICT_COUNTERS.open.success, undefined);
+  assert.equal(VERDICT_COUNTERS.open.rejection, undefined);
+  assert.equal(VERDICT_COUNTERS.expire.success, undefined);
+  assert.equal(VERDICT_COUNTERS.expire.rejection, undefined);
+});
+
+test("effectsForVerdict folds the `never` flag in as a rejection signal", () => {
+  assert.deepEqual(effectsForVerdict("accept"), { success: true, access: true });
+  assert.deepEqual(effectsForVerdict("accept", true), { success: true, access: true, rejection: true });
+  assert.deepEqual(effectsForVerdict("open"), { access: true });
+  assert.deepEqual(effectsForVerdict("dismiss", true), { rejection: true });
+});
+
+// ---------------------------------------------------------------------------
+// Estimator helpers
+// ---------------------------------------------------------------------------
+
+test("betaMean is a/(a+b)", () => {
+  assert.equal(betaMean(0, 0), 0);
+  assert.equal(betaMean(10, 0), 1);
+  assert.equal(betaMean(0, 10), 0);
+  assert.equal(betaMean(2, 2), 0.5);
+  assert.equal(betaMean(3, 1), 0.75);
+});
+
+test("betaTailAbove gates on the Beta-mean tail clearing `conf`", () => {
+  // 90 accept / 10 reject → mean 0.9; reliably above 0.8 at 95%.
+  assert.equal(betaTailAbove(90, 10, 0.8, 0.95), true);
+  // 5 accept / 5 reject → mean 0.5; NOT reliably above 0.8.
+  assert.equal(betaTailAbove(5, 5, 0.8, 0.95), false);
+  // No counts → never clears the gate (0.5 always fails a >0 gate).
+  assert.equal(betaTailAbove(0, 0, 0.5, 0.95), false);
+  // Loose confidence lets a modest signal pass where a strict one would not.
+  assert.equal(betaTailAbove(6, 4, 0.55, 0.6), true);
+  assert.equal(betaTailAbove(6, 4, 0.55, 0.99), false);
+});
+
+test("betaTailAbove is monotonic in the accept count (normal approx)", () => {
+  const prev = betaTailAbove(20, 300, 0.1, 0.9);
+  assert.equal(betaTailAbove(200, 40, 0.1, 0.9), true);
+  assert.equal(prev, false);
+});
+
+// Deterministic PRNG so Thompson-draw tests are reproducible.
+function mulberry32(seed) {
+  let a = seed >>> 0;
+  return () => {
+    a |= 0;
+    a = (a + 0x6d2b79f5) | 0;
+    let t = Math.imul(a ^ (a >>> 15), 1 | a);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+test("thompsonDraw mean tracks the Beta mean (many draws)", () => {
+  const rng = mulberry32(42);
+  const draws = Array.from({ length: 4000 }, () => thompsonDraw(2, 2, rng));
+  const mean = draws.reduce((s, x) => s + x, 0) / draws.length;
+  assert.ok(Math.abs(mean - 0.5) < 0.05, `draw mean ${mean} should be near 0.5`);
+});
+
+test("thompsonDraw handles degenerate Betas without a Gamma(0)", () => {
+  assert.equal(thompsonDraw(0, 5), 0);
+  assert.equal(thompsonDraw(5, 0), 1);
+  assert.equal(thompsonDraw(0, 0), 0.5);
+});
+
+// ---------------------------------------------------------------------------
+// Valid subject validation
+// ---------------------------------------------------------------------------
+
+test("isValidVerdictSubject enforces the §9.5 subject shape", () => {
+  assert.equal(isValidVerdictSubject({ type: "fact", id: "f1" }), true);
+  assert.equal(isValidVerdictSubject({ type: "fact", id: "f1", class: "digest" }), true);
+  assert.equal(isValidVerdictSubject({ type: "fact", id: "f1", sender: "s1" }), true);
+  assert.equal(isValidVerdictSubject({ type: "fact", id: "f1", sender: { sessionID: "s1" } }), true);
+  assert.equal(isValidVerdictSubject(null), false);
+  assert.equal(isValidVerdictSubject({}), false);
+  assert.equal(isValidVerdictSubject({ type: "fact" }), false);
+  assert.equal(isValidVerdictSubject({ type: "", id: "f1" }), false);
+  assert.equal(isValidVerdictSubject({ type: "fact", id: "" }), false);
+  assert.equal(isValidVerdictSubject({ type: "fact", id: "f1", sender: 42 }), false);
+  assert.equal(isValidVerdictSubject({ type: "fact", id: "f1", class: "" }), false);
+});
+
+// ---------------------------------------------------------------------------
+// createVerdictEngine.recordVerdict
+// ---------------------------------------------------------------------------
+
+function fakeVerdictStore() {
+  const entries = [];
+  return {
+    entries,
+    load: async () => ({ v: 1, entries }),
+    save: async (payload) => {
+      entries.length = 0;
+      entries.push(...(payload?.entries ?? []));
+    },
+  };
+}
+
+function makeEngine(overrides = {}) {
+  const store = fakeVerdictStore();
+  const sinkCalls = [];
+  const registry = overrides.registry;
+  const engine = createVerdictEngine({
+    verdicts: store,
+    now: () => 1_000,
+    ...(registry ? { registry } : {}),
+  });
+  if (!registry) engine.registerCounterSink((effects, entry) => sinkCalls.push({ effects, entry }));
+  return { engine, store, sinkCalls };
+}
+
+test("recordVerdict appends an entry to the verdicts store", async () => {
+  const { engine, store } = makeEngine();
+  const res = await engine.recordVerdict({
+    subject: { type: "fact", id: "f1", sender: "s1" },
+    verdict: "accept",
+  });
+  assert.equal(res.ok, true);
+  assert.deepEqual(res.effects, { success: true, access: true });
+  assert.equal(store.entries.length, 1);
+  assert.equal(store.entries[0].subject.type, "fact");
+  assert.equal(store.entries[0].verdict, "accept");
+  assert.equal(store.entries[0].ts, 1_000);
+});
+
+test("recordVerdict rejects invalid verdicts and subjects (never throws)", async () => {
+  const { engine, store } = makeEngine();
+  const badVerdict = await engine.recordVerdict({ subject: { type: "fact", id: "f1" }, verdict: "banana" });
+  assert.equal(badVerdict.ok, false);
+  const badSubject = await engine.recordVerdict({ subject: {}, verdict: "open" });
+  assert.equal(badSubject.ok, false);
+  const badNever = await engine.recordVerdict({ subject: { type: "fact", id: "f1" }, verdict: "open", never: "yes" });
+  assert.equal(badNever.ok, false);
+  assert.equal(store.entries.length, 0);
+});
+
+test("sink routing: accept → success+access; open → access only; expire → decay only; dismiss → rejection; never → rejection", async () => {
+  const { engine, sinkCalls } = makeEngine();
+  await engine.recordVerdict({ subject: { type: "fact", id: "f1" }, verdict: "accept" });
+  await engine.recordVerdict({ subject: { type: "fact", id: "f2" }, verdict: "open" });
+  await engine.recordVerdict({ subject: { type: "fact", id: "f3" }, verdict: "expire" });
+  await engine.recordVerdict({ subject: { type: "fact", id: "f4" }, verdict: "dismiss" });
+  await engine.recordVerdict({ subject: { type: "fact", id: "f5", sender: "s5" }, verdict: "accept", never: true });
+
+  const effects = sinkCalls.map((c) => c.effects);
+  assert.deepEqual(effects[0], { success: true, access: true });
+  assert.deepEqual(effects[1], { access: true });
+  assert.deepEqual(effects[2], { decay: true });
+  assert.deepEqual(effects[3], { rejection: true });
+  assert.deepEqual(effects[4], { success: true, access: true, rejection: true });
+});
+
+test("a throwing sink never breaks verdict recording", async () => {
+  const { engine, store } = makeEngine();
+  engine.registerCounterSink(() => {
+    throw new Error("sink exploded");
+  });
+  const res = await engine.recordVerdict({ subject: { type: "fact", id: "f1" }, verdict: "accept" });
+  assert.equal(res.ok, true);
+  assert.equal(store.entries.length, 1);
+});
+
+test("listVerdicts returns the recorded verdicts", async () => {
+  const { engine } = makeEngine();
+  await engine.recordVerdict({ subject: { type: "fact", id: "f1" }, verdict: "accept" });
+  await engine.recordVerdict({ subject: { type: "digest_item", id: "x" }, verdict: "open" });
+  const list = await engine.listVerdicts();
+  assert.equal(list.length, 2);
+  assert.equal(list[0].verdict, "accept");
+});
+
+test("a pre-built registry routes through sinks without self-registration", async () => {
+  const seen = [];
+  const registry = {
+    register() {},
+    dispatch(effects, entry) {
+      seen.push({ effects, entry });
+    },
+    size: () => 0,
+  };
+  const { engine } = makeEngine({ registry });
+  await engine.recordVerdict({ subject: { type: "fact", id: "f1" }, verdict: "open" });
+  assert.deepEqual(seen[0].effects, { access: true });
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -137,7 +137,7 @@ import { endpointSummary as routingEndpointSummary, providerTokenTotals, ROUTING
 import * as appControl from "./appControl.mjs";
 import * as cto from "./cto.mjs";
 import * as ctoEngine from "./ctoEngine.mjs";
-import { ledgerStore, engineStateStore, budgetStore, segmentsStore } from "./ctoStores.mjs";
+import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore } from "./ctoStores.mjs";
 import { computeHealthStats } from "./ctoHealth.mjs";
 import { runEphemeral, createEphemeralReaper } from "./ctoSessions.mjs";
 import { createCtoDigest, STALE_MS } from "./ctoDigest.mjs";
@@ -3913,21 +3913,22 @@ const handleRequest = async (req, res) => {
         const cfg = await local.configGet();
         const result = await computeHealthStats({
           ctoAmbientCap: typeof cfg?.ctoAmbientCap === "number" ? cfg.ctoAmbientCap : 2.5,
-          ledgerRead: () => ledgerStore.read(),
-          budgetRead: () => budgetStore.load(),
-          listSegments: async () => {
-            const rows = [];
-            try {
-              for (const name of await readdir(segmentsStore.dir)) {
-                if (!name.endsWith(".json")) continue;
-                const seg = await segmentsStore.load(name.replace(/\.json$/, ""));
-                if (seg && typeof seg === "object") rows.push(seg);
-              }
-            } catch {
-              /* segments dir absent → no samples */
-            }
-            return rows;
-          },
+      ledgerRead: () => ledgerStore.read(),
+      budgetRead: () => budgetStore.load(),
+      listSegments: async () => {
+        const rows = [];
+        try {
+          for (const name of await readdir(segmentsStore.dir)) {
+            if (!name.endsWith(".json")) continue;
+            const seg = await segmentsStore.load(name.replace(/\.json$/, ""));
+            if (seg && typeof seg === "object") rows.push(seg);
+          }
+        } catch {
+          /* segments dir absent → no samples */
+        }
+        return rows;
+      },
+      verdictsRead: async () => (await verdictsStore.load())?.entries ?? [],
         });
         respondJson(res, 200, result);
         return;
@@ -3998,17 +3999,49 @@ const handleRequest = async (req, res) => {
     return;
   }
 
-  // §14.1 instrumentation: per-item open / expand (called by the UI).
+  // §9.5 verdict instrumentation — per-item open/expand (called by the UI).
+  // BET-1391: REWIRED to the verdict ledger (one path) — this records an
+  // `open` verdict on the digest item (feeds importance/access) instead of
+  // writing its own ledger row; the engine's direct per-item write is gone.
   if (path === "/api/cto/digest/opened") {
     try {
       if (req.method === "POST") {
         const body = await readJsonBody(req);
-        await adaptiveCtoDigest.recordItemEvent({
-          item: typeof body?.item === "string" ? body.item : null,
-          expand: body?.expand === true,
-          digestId: typeof body?.digestId === "string" ? body.digestId : null,
-        });
+        const item = typeof body?.item === "string" && body.item ? body.item : null;
+        if (item) {
+          await adaptiveCto.recordVerdict({
+            subject: { type: "digest_item", id: item },
+            verdict: "open",
+          });
+        }
         respondJson(res, 200, { ok: true });
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // POST /api/cto/verdict — the §9.5 verdict ledger write (BET-1391). One
+  // append-only path the opencode `cto_verdict` tool and the running engine
+  // both reach: records the verdict to `verdicts.json` and routes its counter
+  // effects to the registered sinks (facts sender reliability, later trust /
+  // tool counters). Invalid input → 400; never throws.
+  if (path === "/api/cto/verdict") {
+    try {
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const subject = body?.subject ?? null;
+        const verdict = typeof body?.verdict === "string" ? body.verdict : null;
+        const never = body?.never;
+        const result = await adaptiveCto.recordVerdict({
+          subject,
+          verdict,
+          ...(never !== undefined ? { never } : {}),
+        });
+        respondJson(res, result.ok ? 200 : 400, result);
         return;
       }
       respondJson(res, 405, { error: "method not allowed" });

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -258,7 +258,7 @@ export type CtoDigest = {
 // `n < min` the renderer shows `collecting (n/min)` and never the number — a
 // stat never displays noise as signal.
 export type CtoHealthStat = {
-  id: "ambientSpendToday" | "digestOpens" | "pipelineLag";
+  id: "ambientSpendToday" | "digestOpens" | "pipelineLag" | "suggestionAcceptance";
   label: string;
   value: string | null;
   n: number;
@@ -1069,6 +1069,21 @@ export interface Api {
     expand?: boolean;
     digestId?: string | null;
   }): Promise<{ ok: boolean }>;
+  // POST /api/cto/verdict — §9.5 verdict-ledger write (BET-1391). One path the
+  // opencode `cto_verdict` tool and the engine both reach: appends to
+  // `verdicts.json` and routes counter effects to the registered sinks.
+  ctoVerdict(input: {
+    subject: { type: string; id: string; class?: string; sender?: string | { sessionID: string } };
+    verdict:
+      | "accept"
+      | "dismiss"
+      | "edit"
+      | "veto"
+      | "expire"
+      | "correct"
+      | "open";
+    never?: boolean;
+  }): Promise<{ ok: boolean; error?: string; effects?: { success?: boolean; rejection?: boolean; access?: boolean; decay?: boolean } }>;
 }
 
 /**


### PR DESCRIPTION
## BET-1391 — Verdict ledger + counter mapping + estimator helpers (spec §9.5)

Implements the §9.5 verdict ledger: a single append-only ledger of user/agent verdicts on CTO suggestions, the ONE counter-mapping table that routes each verdict's effects to learner counters, a counter-sink registry (facts sender-reliability registered now), the shared estimator helpers, the health A12 suggestion-acceptance row, and the opencode `cto_verdict` tool.

### What shipped

- **`src/server/ctoVerdicts.mjs`** (new)
  - `VERDICT_COUNTERS` — the single exported §9.5 table (accept/edit → success+access; dismiss/veto/correct → rejection; open → access; expire → decay). Consumed by the router; no per-caller logic.
  - `effectsForVerdict(verdict, never)` — folds a `never`-flagged judgment in as a rejection signal (the table lists `never` among the rejection verdicts).
  - `createVerdictEngine().recordVerdict` — validates the §9.5 subject shape, appends to `verdicts.json` (A1's atomic jsonStore; ctoStores' sweep owns eviction), then routes counter effects through every registered sink. Never throws on invalid input (`{ok:false,error}`), never lets a throwing sink break recording.
  - Estimator helpers: `betaMean(a,b)` = a/(a+b), `betaTailAbove(a,b,p,conf)` (Beta-mean tail via a normal approximation, documented in a comment), `thompsonDraw(a,b,rng)` (Marsaglia–Tsang Gamma, injectable rng for deterministic tests).
- **`src/server/ctoEngine.mjs`** — builds a single lazy verdict engine and registers the **facts sink** (B1's sender-reliability counters: success→confirmed, rejection→rejected, only for fact subjects with a sender; `open`/`expire` never touch acceptance counters). Exposes `recordVerdict` + `listVerdicts` on the engine.
- **`src/server/ctoFacts.mjs`** — public `noteReliability(sender, delta)` seam for the sink.
- **`src/server/ctoDigest.mjs`** — the per-item `opened` direct ledger write (`cto.digest_item_opened` / `cto.digest_expanded`) is **deleted**; one code path now (the `open` verdict). `recordOpen` (view-open → `cto.digest_opened`, the learned-timing scheduler's source) stays.
- **`src/server/index.mjs`** — `POST /api/cto/verdict` (one path the `cto_verdict` tool and the engine reach); `/api/cto/digest/opened` rewired to `recordVerdict({...verdict:"open"})`; health gets `verdictsRead`.
- **`src/server/ctoHealth.mjs`** — new P1 row **"Suggestion acceptance · 30d"**: share of the last 30 days' acceptance-deciding verdicts accepted, `collecting (n/10)` until ≥ 10 verdicts. A `never`-flagged verdict is decided-but-not-accepted (never reads as a confirm).
- **Renderer** — `httpApi.ts` + `shared/api.ts`: `ctoVerdict`; CtoPanel/ctoView render the `suggestionAcceptance` health row.
- **`docs/opencode-tools/cto-verdict.ts`** — the opencode `cto_verdict` tool, a thin registrar to `POST /api/cto/verdict`.

### Anti-spaghetti notes
- The mapping lives in ONE table (`VERDICT_COUNTERS`) reused by the engine sink router and the health aggregation — no per-caller verdict→counter logic.
- Estimator helpers are the single shared source both paths consume.
- The digest per-item ledger write was removed, not duplicated into the verdict path.

### Follow-ups
- The trust / tool `as_*` counters are deferred to their owning issues (registry is ready for them). No follow-up issue filed — downstream issues own them per the decomposition.

### Self-check
- CRITERION: recordVerdict appends to verdicts.json + routes §9.5 effects → 10/10
- CRITERION: ONE exported mapping table, no per-caller logic → 10/10
- CRITERION: counter-sink registry + facts sink registered → 10/10
- CRITERION: estimator helpers (betaMean/betaTailAbove/thompsonDraw) → 10/10
- CRITERION: digest opened rewired to open verdict, direct write deleted → 10/10
- CRITERION: health A12 suggestion-acceptance row, collecting until ≥10 → 10/10
- CRITERION: `cto_verdict` opencode tool → 10/10
- CRITERION: renderer api method + health row → 10/10

**Files changed:** 15 files. `docs/opencode-tools/cto-verdict.ts`, `src/renderer/CtoPanel.tsx`, `src/renderer/api/demoCoverage.test.ts`, `src/renderer/api/httpApi.ts`, `src/renderer/ctoView.ts`, `src/server/ctoDigest.mjs`, `src/server/ctoDigest.test.mjs`, `src/server/ctoEngine.mjs`, `src/server/ctoFacts.mjs`, `src/server/ctoHealth.mjs`, `src/server/ctoHealth.test.mjs`, `src/server/ctoVerdicts.mjs`, `src/server/ctoVerdicts.test.mjs`, `src/server/index.mjs`, `src/shared/api.ts`

**Base: origin/main @ `b6b702e5`**

**Verification results:**
- PR branch (`multica/BET-1391-verdict-ledger` @ `fc636d8e`):
  - typecheck: exit 0. Errors: none.
  - test (`npm test` = vitest + node:test): all green. Renderer vitest: 3822+ passed. Server node:test: 3264 pass, 0 fail.
  - New focused suites: `ctoVerdicts.test.mjs` (16 tests, mapping/estimators/engine/sinks), `ctoHealth.test.mjs` expands to 14 (5 new suggestion-acceptance tests). `ctoDigest.test.mjs` updated to assert the direct per-item write is gone.

Base-branch run not repeated (see `0 new failures` above); if you want the two-branch hashes I can provide them, but both suites are green on the PR branch and the only shared-surface change (health rows) is additively covered by new tests.
