### PR TITLE
BET-1414: Now-rail per-session cost field (§10.4)

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -37,6 +37,7 @@ import {
   formatEta,
   showPausedBanner,
   statDisplay,
+  nowCostLabel,
   type BlockerCard,
   type CtoState,
   type CtoHealthStat,
@@ -137,6 +138,7 @@ export function CtoPanel({
   // Store-derived live state for the Now rail + answer-now routing.
   const projects = useStore((s) => s.projects);
   const status = useStore((s) => s.status);
+  const sessionCost = useStore((s) => s.sessionCost);
 
   // §10.3 target resolution: is a card's owning session still present?
   const knownSessions = useMemo(
@@ -192,12 +194,15 @@ export function CtoPanel({
         if (!active) continue;
         const sessionId = w.opencodeSessionId;
         const elapsed = typeof st.lastMessageAt === "number" ? relativeTime(st.lastMessageAt, Date.now()) : null;
+        const cost = sessionId ? nowCostLabel(sessionCost[sessionId]) : null;
         out.push({
           id: sessionId ?? `${p.tmuxSession}-${w.index}`,
           name: w.name,
           state: blocked ? "blocked" : "working",
           step: st.progressLabel ?? null,
-          meta: elapsed ? `${p.tmuxSession} · ${elapsed}` : p.tmuxSession,
+          project: p.tmuxSession,
+          cost,
+          elapsed,
           onClick: () => {
             if (sessionId) onOpenSession(sessionId);
           },

--- a/src/renderer/ctoSections.tsx
+++ b/src/renderer/ctoSections.tsx
@@ -14,6 +14,7 @@ import {
   relativeTime,
   digestExpandable,
   finishedVariant,
+  nowRailMeta,
   type BlockerCard,
   type FinishedVariant,
 } from "./ctoView";
@@ -166,7 +167,9 @@ export type NowCard = {
   name: string;
   state: "working" | "blocked";
   step: string | null;
-  meta: string; // "project · elapsed"
+  project: string;
+  cost: string | null;
+  elapsed: string | null;
   onClick: () => void;
 };
 
@@ -200,7 +203,7 @@ export const NowRail = memo(function NowRail({ cards }: { cards: NowCard[] }) {
             ) : card.step ? (
               <span className="truncate text-xs text-text-muted">{card.step}</span>
             ) : (
-              <span className="truncate text-xs text-text-faint">{card.meta}</span>
+              <span className="truncate text-xs text-text-faint">{nowRailMeta(card.project, card.cost, card.elapsed)}</span>
             )}
           </button>
         ))}

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -14,6 +14,8 @@ import {
   digestExpandable,
   resting,
   stateTone,
+  nowCostLabel,
+  nowRailMeta,
   type CtoState,
   type CtoHealthStat,
 } from "./ctoView";
@@ -307,5 +309,34 @@ describe("stateTone (§10.4 Now blocked chip)", () => {
   });
   it("working → ok", () => {
     expect(stateTone("working")).toBe("ok");
+  });
+});
+
+describe("nowCostLabel (§10.4 Now cost format)", () => {
+  it("formats a positive cost to two decimals", () => {
+    expect(nowCostLabel(1.5)).toBe("$1.50");
+    expect(nowCostLabel(0.42)).toBe("$0.42");
+    expect(nowCostLabel(12)).toBe("$12.00");
+  });
+  it("returns null when absent", () => {
+    expect(nowCostLabel(undefined)).toBeNull();
+    expect(nowCostLabel(null)).toBeNull();
+  });
+  it("returns null for zero or NaN", () => {
+    expect(nowCostLabel(0)).toBeNull();
+    expect(nowCostLabel(Number.NaN)).toBeNull();
+  });
+});
+
+describe("nowRailMeta (§10.4 project · cost · elapsed)", () => {
+  it("places cost between project and elapsed", () => {
+    expect(nowRailMeta("bui", "$1.50", "5m")).toBe("bui · $1.50 · 5m");
+  });
+  it("drops the cost segment when absent (no double separator)", () => {
+    expect(nowRailMeta("bui", null, "5m")).toBe("bui · 5m");
+    expect(nowRailMeta("bui", null, null)).toBe("bui");
+  });
+  it("drops empty-string segments", () => {
+    expect(nowRailMeta("bui", "", "5m")).toBe("bui · 5m");
   });
 });

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -278,3 +278,18 @@ export function resting(
 export function stateTone(state: "working" | "blocked"): "ok" | "warn" {
   return state === "blocked" ? "warn" : "ok";
 }
+
+// Now-rail cost formatting (§10.4). A session's accumulated cost (USD) as a
+// short `$X.XX` label, or null when absent/zero/NaN so the caller can omit the
+// segment entirely (component may also choose how granular to show it).
+export function nowCostLabel(cost: number | null | undefined): string | null {
+  if (typeof cost !== "number" || !Number.isFinite(cost) || cost <= 0) return null;
+  return `$${cost.toFixed(2)}`;
+}
+
+// Now-rail meta composition (§10.4): `project · cost · elapsed`. The cost
+// segment sits between the project name and the elapsed time and is dropped
+// when absent (no `· ·` gap in the line). Pure + deterministic for tests.
+export function nowRailMeta(project: string, cost: string | null, elapsed: string | null): string {
+  return [project, cost, elapsed].filter((s): s is string => Boolean(s && s.length > 0)).join(" · ");
+}

--- a/src/renderer/store.ts
+++ b/src/renderer/store.ts
@@ -460,6 +460,11 @@ type State = {
   seedPrompt: { sid: string; text: string } | null;
   // sessionName -> windowIndex -> status
   status: Record<string, Record<number, WindowStatusUI>>;
+  // opencode sessionId -> accumulated cost (USD), read off the same
+  // `opencodeListSessions` response as the `lastMessageAt` backfill. Feeds the
+  // CTO panel's Now-rail `project · cost · elapsed` line (§10.4). Absent when
+  // the box hasn't reported a cost yet — the renderer omits the segment.
+  sessionCost: Record<string, number | undefined>;
   // Background-delegation jobs keyed by childSessionID (BET-381). Drives the
   // sidebar's per-row activity second line (desktop + mobile). Fed by the
   // single app-level 10s poll — see JobRow comment above.
@@ -832,6 +837,7 @@ export const useStore = create<State>((set, get) => ({
   autoSubmitPrompt: null,
   seedPrompt: null,
   status: {},
+  sessionCost: {},
   jobs: {},
   usage: [],
   usageStopped: [],
@@ -1544,6 +1550,7 @@ export const useStore = create<State>((set, get) => ({
     if (dirs.size === 0) return;
     if (!window.api.opencodeListSessions) return;
     const updatedBySessionId = new Map<string, number>();
+    const costBySessionId = new Map<string, number | undefined>();
     await runWithConcurrency(
       [...dirs],
       OPENCODE_FANOUT_CONCURRENCY,
@@ -1555,13 +1562,16 @@ export const useStore = create<State>((set, get) => ({
             if (typeof updated === "number" && updated > 0) {
               updatedBySessionId.set(s.id, updated);
             }
+            if (typeof s.cost === "number" && Number.isFinite(s.cost)) {
+              costBySessionId.set(s.id, s.cost);
+            }
           }
         } catch {
           // Per-directory failure is non-fatal — best-effort backfill.
         }
       },
     );
-    if (updatedBySessionId.size === 0) return;
+    if (updatedBySessionId.size === 0 && costBySessionId.size === 0) return;
     set((prev) => {
       let changed = false;
       const next: Record<string, Record<number, WindowStatusUI>> = {
@@ -1589,7 +1599,12 @@ export const useStore = create<State>((set, get) => ({
           changed = true;
         }
       }
-      return changed ? { status: next } : prev;
+      const sessionCost = costBySessionId.size
+        ? { ...prev.sessionCost, ...Object.fromEntries(costBySessionId) }
+        : prev.sessionCost;
+      const costChanged = costBySessionId.size > 0;
+      changed = changed || costChanged;
+      return changed ? { status: next, ...(costChanged ? { sessionCost } : {}) } : prev;
     });
   },
 


### PR DESCRIPTION
## What
Adds a per-session cost to the CTO panel's **Now rail**, rendering `project · cost · elapsed` (§10.4).

## Changes
- **`ctoView.ts`** — two pure selectors:
  - `nowCostLabel(cost)` → formats a session USD cost as `.XX`, or `null` when absent/zero/NaN.
  - `nowRailMeta(project, cost, elapsed)` → composes `project · cost · elapsed`, dropping the cost segment when absent (no `· ·` gap).
- **`store.ts`** — new `sessionCost` slice (`sessionId → cost`), fed by reusing the **existing** `opencodeListSessions` fan-out in `backfillLastMessageTimes` (no new endpoint, no extra polling — the box already returns `.cost` on session list items).
- **`ctoSections.tsx`** — `NowCard` now carries `project`/`cost`/`elapsed`; the Now-card component renders cost between project and elapsed via `nowRailMeta`.
- **`CtoPanel.tsx`** — sources cost from `store.sessionCost` per active session and passes it into the card.
- **`ctoView.test.ts`** — pure selector tests for cost formatting + absent segment branches.

## Scope note
Per the issue scope, "do NOT re-litigate the design; follow the spec." The header plan dials are per-provider plan usage (not attributable per-session), so reuse of the existing per-session `opencodeListSessions` read is the seam used — no new server endpoint.

## Verification results
**Files changed:** `5` files. `src/renderer/{CtoPanel.tsx, ctoSections.tsx, ctoView.ts, ctoView.test.ts, store.ts}`

- PR branch (`multica/BET-1414-now-rail-cost` @ `f409685c`):
  - typecheck: exit 0. Errors: none.
  - test: exit 0 — vitest 3829 pass / 0 fail / 7 skip (198 files); server node:test 3255 pass / 0 fail.
- Base (`main` @ `b6b702e5`): changes are renderer-only + additive; full suite green on the PR branch.
- **Conclusion:** 0 new failures.