### PR TITLE
feat(server): BET-1388 CTO ambient-spend economics

### DIFF
--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -1,0 +1,275 @@
+// src/server/ctoBudget.mjs
+// BET-1388 — the CTO's ambient-spend economics (spec §10.6-6, §12.1, §12.2,
+// §13.3). Pure logic + injected I/O in the style of ctoRollups.mjs / ctoEngine.mjs:
+// nothing here touches a live box.
+//
+// What lives here:
+//   - Per-day ambient spend accumulation into budget.json (day rolls at local
+//     midnight — same local-midnight clock as the rollups layer, reused below).
+//   - The independent HARD CAP (`ctoAmbientCapUsd`, default $2.50 / day): a
+//     ceiling on ambient spend that the engine consults BEFORE every ambient
+//     model call, at every tier, regardless of the A12 tier dial.
+//   - THRIFTY mode (§10.6-6 / §12.2): a numbered capability-shed ladder the
+//     engine consults before each work type. Shed in order (1) speculative
+//     candidate generation, (2) probe fan-outs, (3) profile extraction, (4)
+//     hourly rollups. Kept to the last token: blocker detection, segment
+//     one-liners, digest-on-open. Rungs 1–3 are the contract future (P2)
+//     features must consult; rung 4 is live now (the engine skips hour
+//     reduces; the day reduce reconstructs missing hours over segments).
+//   - TIER gating (§3.3): `tierAllows(tier, feature)` — the pure contract the
+//     engine (and later P2 features) consult before a gated work type.
+//   - The A2 watchdog's expected-hourly-burn figure, derived from the trailing
+//     7-day ambient spend (replaces the placeholder constant the watchdog
+//     shipped with).
+//
+// Spend is PRICED from the existing model-ledger/catalogue pricing data via
+// blendedPrice (src/shared/blendedPrice.mjs): the model's `cost` rates blended
+// across the cache-heavy default mix, times the token count. An unpriceable
+// model (no cost data) prices at 0 — honest: we cannot charge what we cannot
+// measure.
+
+import { budgetStore } from "./ctoStores.mjs";
+import { startOfDay } from "./ctoRollups.mjs";
+import { blendedPrice } from "../shared/blendedPrice.mjs";
+
+export const DEFAULT_AMBIENT_CAP_USD = 2.5;
+export const BURN_HISTORY_DAYS = 7;
+export const HOUR_MS = 3_600_000;
+
+// A local-midnight day key. Reuses startOfDay from the rollups layer so the
+// budget and the rollups agree on when a "day" starts and rolls.
+export function dayKey(ts) {
+  return String(startOfDay(typeof ts === "number" && Number.isFinite(ts) ? ts : Date.now()));
+}
+
+// Hours elapsed since local midnight for `ts` (used to derive a per-hour burn).
+export function hoursIntoLocalDay(ts) {
+  const t = typeof ts === "number" && Number.isFinite(ts) ? ts : Date.now();
+  const sod = startOfDay(t);
+  return Math.max(0, (t - sod) / HOUR_MS);
+}
+
+function num(v) {
+  return typeof v === "number" && Number.isFinite(v) ? v : 0;
+}
+function dollar(v) {
+  return Math.max(0, num(v));
+}
+
+export function defaultBudgetPayload() {
+  return { days: {} };
+}
+
+// Normalise a stored budget payload defensively (bad/absent → empty).
+export function normalizeBudget(payload) {
+  if (!payload || typeof payload !== "object") return defaultBudgetPayload();
+  const days = payload.days && typeof payload.days === "object" ? payload.days : {};
+  return { ...payload, days };
+}
+
+export function dayBucket(payload, key) {
+  const days = normalizeBudget(payload).days;
+  const b = days[key];
+  return b && typeof b === "object" ? b : { usd: 0, calls: 0 };
+}
+
+export function spendForDay(payload, key) {
+  return dollar(dayBucket(payload, key).usd);
+}
+
+export function todaySpend(payload, now) {
+  return spendForDay(payload, dayKey(now));
+}
+
+// The configured per-day ambient cap; falls back to the default when absent or
+// malformed. `ctoAmbientCapUsd` is the config key (§12.1).
+export function ambientCapUsd(cfg) {
+  const c = cfg && typeof cfg === "object" ? cfg.ctoAmbientCapUsd : undefined;
+  return typeof c === "number" && Number.isFinite(c) && c >= 0 ? c : DEFAULT_AMBIENT_CAP_USD;
+}
+
+// True once today's spend reaches the cap. Boundary: spends == cap counts as a
+// hit (a call about to push us to the cap is blocked, not allowed through).
+export function isAmbientCapHit(payload, now, capUsd) {
+  return todaySpend(payload, now) >= dollar(capUsd);
+}
+
+// Accumulate a spend/call into the current local day's bucket. Pure.
+export function recordSpend(payload, { now, usd, calls = 1 } = {}) {
+  const p = normalizeBudget(payload);
+  const t = typeof now === "number" && Number.isFinite(now) ? now : Date.now();
+  const key = dayKey(t);
+  const prev = dayBucket(p, key);
+  const days = { ...p.days, [key]: { usd: dollar(prev.usd) + dollar(usd), calls: num(prev.calls) + ((calls | 0) || 1) } };
+  return { ...p, days, updatedMs: t };
+}
+
+// True when the budget's most recent record belongs to a day other than the
+// current one — i.e. a local midnight has passed since the last recorded spend.
+// The engine uses this to auto-clear thrifty at the daily reset (§10.6-6).
+export function didDayRoll(payload, now) {
+  const p = normalizeBudget(payload);
+  const t = typeof now === "number" && Number.isFinite(now) ? now : Date.now();
+  if (typeof p.updatedMs !== "number" || !Number.isFinite(p.updatedMs)) return false;
+  return dayKey(p.updatedMs) !== dayKey(t);
+}
+
+// ---------------------------------------------------------------------------
+// Pricing — tokens → USD via the model's own cost data (blendedPrice).
+// ---------------------------------------------------------------------------
+
+/**
+ * The USD cost of a turn: blended price per million tokens × tokens / 1e6.
+ * `model` may carry `cost` (the catalogue-provided rates); the resolved model
+ * is enriched with its cost before it reaches the budget. An unpriceable model
+ * (no cost) prices at 0 via blendedPrice's unknown fallback.
+ */
+export function priceTokens({ model, tokens, mix } = {}) {
+  const perMillion = blendedPrice(model ?? {}, mix).price;
+  return dollar((num(tokens) / 1_000_000) * perMillion);
+}
+
+// ---------------------------------------------------------------------------
+// Expected hourly burn — A2 watchdog figure (§13.3 / BET-1385 placeholder).
+// ---------------------------------------------------------------------------
+
+/**
+ * The expected ambient $/hour, derived from the trailing 7-day ambient spend
+ * (total / (7 × 24)). This is what the A2 watchdog compares the measured
+ * per-hour burn against (>2× → auto-thrifty, >4× → auto-pause).
+ *
+ * Degenerate case: when the trailing 7-day history holds no spend (a fresh
+ * box), we fall back to the cap-equivalent even pace (cap / 24) rather than 0 —
+ * otherwise a box with no history would trip the watchdog instantly on its very
+ * first ambient call.
+ */
+export function expectedHourlyBurnUsd(payload, { now, capUsd } = {}) {
+  const t = typeof now === "number" && Number.isFinite(now) ? now : Date.now();
+  const cap = dollar(capUsd);
+  let total = 0;
+  let sod = startOfDay(t);
+  for (let i = 0; i < BURN_HISTORY_DAYS; i++) {
+    total += spendForDay(payload, String(sod));
+    sod -= 24 * HOUR_MS;
+  }
+  if (!(total > 0)) return cap / 24;
+  return dollar(total) / (BURN_HISTORY_DAYS * 24);
+}
+
+/**
+ * The measured ambient $/hour so far today — the watchdog's `getSpendPerHour`.
+ * Returns 0 before the first hour of the day has elapsed.
+ */
+export function spendPerHourNow(payload, now) {
+  const t = typeof now === "number" && Number.isFinite(now) ? now : Date.now();
+  const h = hoursIntoLocalDay(t);
+  if (h <= 0) return 0;
+  return todaySpend(payload, t) / h;
+}
+
+// ---------------------------------------------------------------------------
+// Thrifty shed ladder (§10.6-6 / §12.2).
+// ---------------------------------------------------------------------------
+
+// The numbered shed order. Rungs 1–3 are the contract future P2 features must
+// consult (they have no implementation yet — the declaration IS the interface);
+// rung 4 is live now.
+export const THRIFTY_SHED_ORDER = Object.freeze([
+  "speculative", // (1) speculative candidate generation
+  "probe", //        (2) probe fan-outs
+  "profile", //      (3) profile extraction passes
+  "hourly_rollups", // (4) hourly rollups (segments still summarized; hours reconstructed)
+]);
+
+// Kept to the last token (never shed by the ladder — they only stop at the
+// absolute hard cap, enforced in the engine's pre-call gate).
+export const THRIFTY_KEEP = Object.freeze([
+  "blocker_detection",
+  "segment_one_liners",
+  "digest_on_open",
+]);
+
+/** True when `workType` is shed while thrifty is on. Kept work returns false. */
+export function isWorkShedInThrifty(workType) {
+  return THRIFTY_SHED_ORDER.includes(workType);
+}
+
+// ---------------------------------------------------------------------------
+// Tier gating (§3.3) — the pure contract features consult before running.
+// ---------------------------------------------------------------------------
+
+// The minimum tier each gated feature requires. Default tier is `low`.
+export const FEATURE_TIERS = Object.freeze({
+  // low tier (default): the steady read-layer + rails the engine runs always.
+  rollups: "low",
+  digest: "low",
+  facts_sync: "low",
+  rails: "low",
+  ledger: "low",
+  // medium tier adds the ambient "think ahead" surface (P2 features must gate
+  // on these; nothing implements them yet).
+  suggestion: "medium",
+  probe: "medium",
+  profile: "medium",
+  // high tier adds the overnight batch.
+  overnight: "high",
+});
+
+export const TIER_ORDER = Object.freeze(["low", "medium", "high"]);
+
+export function normalizeTier(tier) {
+  return TIER_ORDER.includes(tier) ? tier : "low";
+}
+
+/**
+ * Does `tier` allow `feature`? A tier allows every feature whose required tier
+ * is at or below it (low ⊂ medium ⊂ high). Unknown/ungated features return
+ * true (no one is locked out of something not yet gated).
+ */
+export function tierAllows(tier, feature) {
+  const required = FEATURE_TIERS[feature];
+  if (!required) return true;
+  const reqIdx = TIER_ORDER.indexOf(required);
+  const tierIdx = TIER_ORDER.indexOf(normalizeTier(tier));
+  return tierIdx !== -1 && reqIdx !== -1 && tierIdx >= reqIdx;
+}
+
+// ---------------------------------------------------------------------------
+// The I/O accessor the engine consumes (injected store + seams).
+// ---------------------------------------------------------------------------
+
+export function createCtoBudget({ store = budgetStore, price = priceTokens, now = Date.now } = {}) {
+  async function load() {
+    try {
+      return normalizeBudget(await store.load());
+    } catch {
+      return defaultBudgetPayload();
+    }
+  }
+  async function save(payload) {
+    await store.save(normalizeBudget(payload));
+  }
+  async function record({ model, tokens, nowMs } = {}) {
+    const t = typeof nowMs === "number" && Number.isFinite(nowMs) ? nowMs : now();
+    const usd = price({ model, tokens });
+    try {
+      const payload = await load();
+      const next = recordSpend(payload, { now: t, usd, calls: 1 });
+      await save(next);
+      return { usd, dayKey: dayKey(t) };
+    } catch {
+      // Metering is best-effort: a store failure must never break the model
+      // call that produced the spend. The spend is dropped, not fatal.
+      return { usd, dayKey: dayKey(t), ok: false };
+    }
+  }
+  return {
+    record,
+    payload: load,
+    todayUsd: async () => todaySpend(await load(), now()),
+    isCapHit: async (capUsd) => isAmbientCapHit(await load(), now(), capUsd),
+    spendPerHourUsd: async () => spendPerHourNow(await load(), now()),
+    expectedHourlyBurnUsd: async ({ capUsd } = {}) => expectedHourlyBurnUsd(await load(), { now: now(), capUsd }),
+    didDayRoll: async () => didDayRoll(await load(), now()),
+  };
+}

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -1,0 +1,204 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  DEFAULT_AMBIENT_CAP_USD,
+  THRIFTY_SHED_ORDER,
+  THRIFTY_KEEP,
+  createCtoBudget,
+  ambientCapUsd,
+  dayKey,
+  defaultBudgetPayload,
+  didDayRoll,
+  expectedHourlyBurnUsd,
+  hoursIntoLocalDay,
+  isAmbientCapHit,
+  isWorkShedInThrifty,
+  priceTokens,
+  recordSpend,
+  spendForDay,
+  spendPerHourNow,
+  tierAllows,
+  todaySpend,
+} from "./ctoBudget.mjs";
+
+// A fixed "local midnight" baseline for deterministic tests (any epoch ms that
+// is a local midnight is fine; we derive other times from it).
+function dayStart(offsetDays = 0) {
+  const d = new Date(2026, 7, 28, 0, 0, 0, 0); // Aug 28 2026, local midnight
+  d.setDate(d.getDate() + offsetDays);
+  return d.getTime();
+}
+const MIDNIGHT = dayStart(0);
+const NOON = MIDNIGHT + 12 * 3_600_000;
+
+test("cap defaults to $2.50 and honors ctoAmbientCapUsd", () => {
+  assert.equal(ambientCapUsd({}), DEFAULT_AMBIENT_CAP_USD);
+  assert.equal(ambientCapUsd({ ctoAmbientCapUsd: 1.25 }), 1.25);
+  assert.equal(ambientCapUsd({ ctoAmbientCapUsd: 0 }), 0);
+  assert.equal(ambientCapUsd({ ctoAmbientCapUsd: -3 }), DEFAULT_AMBIENT_CAP_USD);
+  assert.equal(ambientCapUsd({ ctoAmbientCapUsd: "x" }), DEFAULT_AMBIENT_CAP_USD);
+});
+
+test("day rolls at local midnight (spend lands in separate day buckets)", () => {
+  const late = MIDNIGHT + 23 * 3_600_000 + 59_999; // 23:59:59.999
+  const fresh = MIDNIGHT + 86_400_000; // next local midnight
+  let p = defaultBudgetPayload();
+  p = recordSpend(p, { now: late, usd: 2.0 });
+  p = recordSpend(p, { now: fresh, usd: 0.5 });
+  assert.equal(todaySpend(p, late), 2.0);
+  assert.equal(todaySpend(p, fresh), 0.5);
+  assert.equal(spendForDay(p, dayKey(fresh)), 0.5);
+  assert.notEqual(dayKey(late), dayKey(fresh));
+});
+
+test("didDayRoll detects that a midnight passed since the last record", () => {
+  let p = defaultBudgetPayload();
+  p = recordSpend(p, { now: MIDNIGHT + 60_000 });
+  assert.equal(didDayRoll(p, MIDNIGHT + 60_000), false);
+  assert.equal(didDayRoll(p, MIDNIGHT + 24 * 3_600_000 + 60_000), true);
+  // No recorded spend at all → no roll signal.
+  assert.equal(didDayRoll(defaultBudgetPayload(), MIDNIGHT + 86_400_000), false);
+});
+
+test("hard cap trips once today's spend reaches the cap (boundary inclusive)", () => {
+  let p = defaultBudgetPayload();
+  assert.equal(isAmbientCapHit(p, NOON, 2.5), false);
+  p = recordSpend(p, { now: NOON, usd: 2.49 });
+  assert.equal(isAmbientCapHit(p, NOON, 2.5), false);
+  p = recordSpend(p, { now: NOON, usd: 0.01 });
+  assert.equal(isAmbientCapHit(p, NOON, 2.5), true);
+  // A new day resets the cap.
+  assert.equal(isAmbientCapHit(p, MIDNIGHT + 86_400_000, 2.5), false);
+});
+
+test("recordSpend accumulates usd and call count per bucket", () => {
+  let p = defaultBudgetPayload();
+  p = recordSpend(p, { now: NOON, usd: 1, calls: 1 });
+  p = recordSpend(p, { now: NOON + 1000, usd: 2, calls: 3 });
+  const b = p.days[dayKey(NOON)];
+  assert.equal(b.usd, 3);
+  assert.equal(b.calls, 4);
+});
+
+test("priceTokens prices via the model cost and a cache-heavy mix", () => {
+  const model = {
+    providerID: "anthropic",
+    id: "claude-3-5-sonnet",
+    cost: { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 },
+  };
+  // ~0.8 cacheRead * 0.3 + 0.08 input * 3 + 0.07 write * 3.75 + 0.05 output * 15
+  // = 0.24 + 0.24 + 0.2625 + 0.75 = 1.4925 $ / 1M tokens.
+  const usd = priceTokens({ model, tokens: 1_000_000 });
+  assert.ok(Math.abs(usd - 1.4925) < 1e-9);
+  // Proportional: 500k tokens ≈ half.
+  assert.ok(Math.abs(priceTokens({ model, tokens: 500_000 }) - usd / 2) < 1e-9);
+  // Free model → 0 regardless of tokens.
+  assert.equal(priceTokens({ model: { cost: { input: 0, output: 0 } }, tokens: 5_000_000 }), 0);
+  // Unknown cost → 0 (cannot price what we cannot measure).
+  assert.equal(priceTokens({ model: { providerID: "x", id: "y" }, tokens: 1_000_000 }), 0);
+});
+
+test("expected hourly burn derives from trailing 7-day spend", () => {
+  // Spend $16.80 over 7 days → 16.80 / 168h = $0.10/h.
+  let p = defaultBudgetPayload();
+  for (let i = 0; i < 7; i++) {
+    p = recordSpend(p, { now: MIDNIGHT + i * 86_400_000 + 1000, usd: 2.4 });
+  }
+  const burn = expectedHourlyBurnUsd(p, { now: MIDNIGHT + 6 * 86_400_000 + 2000, capUsd: 2.5 });
+  assert.ok(Math.abs(burn - 0.1) < 1e-9);
+  // Old spend ages out of the 7-day window: the day-7 bucket alone, /168h.
+  const onlyRecent = defaultBudgetPayload();
+  expectedHourlyBurnUsd;
+  const p2 = recordSpend(defaultBudgetPayload(), { now: MIDNIGHT + 6 * 86_400_000 + 1000, usd: 1.68 });
+  const burn2 = expectedHourlyBurnUsd(p2, { now: MIDNIGHT + 6 * 86_400_000 + 5000, capUsd: 2.5 });
+  assert.ok(Math.abs(burn2 - 1.68 / 168) < 1e-9);
+});
+
+test("empty history falls back to the cap-equivalent pace (never 0)", () => {
+  const burn = expectedHourlyBurnUsd(defaultBudgetPayload(), { now: NOON, capUsd: 2.5 });
+  assert.equal(burn, 2.5 / 24);
+});
+
+test("spendPerHourNow measures today's burn vs hours elapsed", () => {
+  const p = recordSpend(defaultBudgetPayload(), { now: NOON, usd: 1.2 }); // 12h into day
+  assert.ok(Math.abs(spendPerHourNow(p, NOON) - 0.1) < 1e-9);
+  assert.equal(spendPerHourNow(p, MIDNIGHT), 0); // 0 hours elapsed
+});
+
+test("thrifty shed ladder: ordered shed vs the kept-to-last-token set", () => {
+  assert.deepEqual(THRIFTY_SHED_ORDER, ["speculative", "probe", "profile", "hourly_rollups"]);
+  assert.deepEqual(THRIFTY_KEEP, ["blocker_detection", "segment_one_liners", "digest_on_open"]);
+  for (const w of THRIFTY_SHED_ORDER) assert.equal(isWorkShedInThrifty(w), true);
+  for (const w of THRIFTY_KEEP) assert.equal(isWorkShedInThrifty(w), false);
+  assert.equal(isWorkShedInThrifty("nonsense"), false);
+});
+
+test("tierAllows table (low ⊂ medium ⊂ high; default low)", () => {
+  // low tier gates: steady read-layer.
+  assert.equal(tierAllows("low", "rollups"), true);
+  assert.equal(tierAllows("low", "digest"), true);
+  assert.equal(tierAllows("low", "facts_sync"), true);
+  assert.equal(tierAllows("low", "rails"), true);
+  assert.equal(tierAllows("low", "ledger"), true);
+  // low tier is denied the medium/high ambient surface.
+  assert.equal(tierAllows("low", "suggestion"), false);
+  assert.equal(tierAllows("low", "probe"), false);
+  assert.equal(tierAllows("low", "profile"), false);
+  assert.equal(tierAllows("low", "overnight"), false);
+  // medium adds suggestion/probe/profile but not overnight.
+  assert.equal(tierAllows("medium", "suggestion"), true);
+  assert.equal(tierAllows("medium", "probe"), true);
+  assert.equal(tierAllows("medium", "profile"), true);
+  assert.equal(tierAllows("medium", "overnight"), false);
+  // high adds overnight (and everything below).
+  assert.equal(tierAllows("high", "overnight"), true);
+  assert.equal(tierAllows("high", "rollups"), true);
+  // Unknown tier falls back to low; unknown feature is ungated.
+  assert.equal(tierAllows(undefined, "suggestion"), false);
+  assert.equal(tierAllows("bogus", "suggestion"), false);
+  assert.equal(tierAllows("low", "whatever_new"), true);
+});
+
+test("createCtoBudget records into an injected store and reports todayUsd/cap", async () => {
+  let saved = { v: 1, days: {} };
+  const store = {
+    load: async () => saved,
+    save: async (p) => {
+      saved = p;
+    },
+  };
+  const price = ({ tokens }) => tokens / 1_000_000 * 5; // deterministic $5/1M
+  const clock = { ms: NOON };
+  const budget = createCtoBudget({ store, price, now: () => clock.ms });
+
+  assert.equal(await budget.todayUsd(), 0);
+  assert.equal(await budget.isCapHit(2.5), false);
+
+  await budget.record({ model: {}, tokens: 500_000 }); // $2.50
+  assert.equal(await budget.todayUsd(), 2.5);
+  assert.equal(await budget.isCapHit(2.5), true);
+
+  // A spend that crosses the cap is still recorded (it already happened);
+  // the NEXT call gates. 
+  // Expected burn + spend-per-hour derive from the same store. $2.50 today
+  // only (no older history) → $2.50 / 168h; the fresh-box fallback only fires
+  // when there is NO history at all.
+  assert.equal(await budget.expectedHourlyBurnUsd({ capUsd: 2.5 }), 2.5 / 168);
+  assert.ok((await budget.spendPerHourUsd()) > 0);
+});
+
+test("createCtoBudget degrades safely when the store is down", async () => {
+  const store = {
+    load: async () => {
+      throw new Error("boom");
+    },
+    save: async () => {
+      throw new Error("boom");
+    },
+  };
+  const budget = createCtoBudget({ store, now: () => NOON });
+  assert.equal(await budget.todayUsd(), 0);
+  assert.equal(await budget.isCapHit(2.5), false);
+  await budget.record({ model: {}, tokens: 1000 }); // must not throw
+  assert.equal(await budget.expectedHourlyBurnUsd({ capUsd: 2.5 }), 2.5 / 24);
+});

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -88,6 +88,13 @@ import {
 } from "./ctoRollups.mjs";
 import { buildFactProposal, createFactsEngine, VERIFY_CYCLE_MS, senderKey, senderReliability } from "./ctoFacts.mjs";
 import { formatFactsBlock } from "./ctoSessions.mjs";
+import {
+  ambientCapUsd as budgetAmbientCapUsd,
+  createCtoBudget,
+  dayKey as budgetDayKey,
+  isWorkShedInThrifty,
+  tierAllows as budgetTierAllows,
+} from "./ctoBudget.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
@@ -302,10 +309,18 @@ export function createCtoEngine(deps = {}) {
     // the shared `verdicts.json` store). The verdict engine + facts sink are
     // constructed below from it.
     verdicts = verdictsStore,
+    // BET-1388 economics (§10.6-6/§12.1/§12.2/§13.3): the ambient-spend budget
+    // accessor (defaults to the real budget.json store via createCtoBudget).
+    // beginEphemeral consults it for the independent HARD CAP before every
+    // ambient model call; reportAmbientSpend records each run's spend and flips
+    // thrifty when the cap is crossed. `tier` is the A12 dial (default low).
+    budget = createCtoBudget(),
+    tierGet = async () => "low",
   } = deps;
 
   let disposed = false;
   let thrifty = false;
+  let thriftyAtDay = null; // local-day key thrifty was set on (BET-1388 auto-clear)
   let selfPaused = false;
   let enabled = false;
   let heartbeatAt = now();
@@ -445,6 +460,8 @@ export function createCtoEngine(deps = {}) {
         await syncState();
         return;
       }
+      // §10.6-6 BET-1388: thrifty auto-clears at the daily budget reset.
+      await maybeClearThrifty();
       // §5.3 rollups — ambient background work, gated on enabled like any other.
       if (enabledNow) {
         await finalizeRollups();
@@ -609,6 +626,7 @@ export function createCtoEngine(deps = {}) {
     const next = !!value;
     const changed = next !== thrifty;
     thrifty = next;
+    thriftyAtDay = next ? budgetDayKey(now()) : thriftyAtDay;
     if (changed) {
       await ledgerLog({
         kind: next ? "cto.thrifty_on" : "cto.thrifty_off",
@@ -618,6 +636,41 @@ export function createCtoEngine(deps = {}) {
     }
     await syncState();
     return { ok: true, changed };
+  }
+
+  // BET-1388 (§10.6-6/§12.1): record an ambient model call's spend into budget
+  // (wired as runEphemeral's reportCost seam), and flip thrifty if the record
+  // crosses today's cap — shedding starts even if no further call is blocked.
+  // Metering is best-effort: a budget failure never breaks the run.
+  async function reportAmbientSpend({ model, tokens } = {}) {
+    try {
+      await budget.record({ model, tokens, nowMs: now() });
+    } catch {
+      /* best-effort */
+    }
+    let cap = budgetAmbientCapUsd({});
+    try {
+      cap = budgetAmbientCapUsd((await configGet()) ?? {});
+    } catch {
+      /* keep default */
+    }
+    try {
+      if (await budget.isCapHit(cap)) {
+        await setThrifty(true, { reason: "cap_hit", source: "cap" });
+      }
+    } catch {
+      /* best-effort */
+    }
+    return { ok: true };
+  }
+
+  // BET-1388 (§10.6-6): auto-clear thrifty once a local midnight passes since
+  // it was set (the daily budget reset). Runs from the tick.
+  async function maybeClearThrifty() {
+    if (!thrifty || !thriftyAtDay) return;
+    if (budgetDayKey(now()) !== thriftyAtDay) {
+      await setThrifty(false, { reason: "daily_reset", source: "engine" });
+    }
   }
 
   // Exceeding a rate limit pauses the engine + raises a health warning (§3.3
@@ -650,6 +703,27 @@ export function createCtoEngine(deps = {}) {
     const { enabled: enabledNow, paused } = await gateContext();
     if (!enabledNow) return { ok: false, error: "cto_disabled" };
     if (paused) return { ok: false, error: "cto_paused" };
+    // BET-1388 (§12.1): the independent HARD CAP — checked before EVERY ambient
+    // model call, at every tier, regardless of the tier dial. Once today's
+    // ambient spend reaches the cap, no new ambient session is created (even
+    // the "kept to the last token" work stops at the cap). A cap hit also flips
+    // the engine thrifty (§10.6-6). A budget read failure never opens an
+    // unchecked writer — we default to the configured cap and treat a failed
+    // read as non-hit (the run proceeds; the meter stays best-effort).
+    let cap = budgetAmbientCapUsd({});
+    try {
+      cap = budgetAmbientCapUsd((await configGet()) ?? {});
+    } catch {
+      /* keep default */
+    }
+    try {
+      if (await budget.isCapHit(cap)) {
+        await setThrifty(true, { reason: "cap_hit", source: "cap" });
+        return { ok: false, error: "cto_cap_hit" };
+      }
+    } catch {
+      /* a failed cap read must not block ambient work */
+    }
     if (track.ephemeral >= rateLimits.concurrentEphemeral) {
       await exceedRateLimit("concurrentEphemeral");
       return { ok: false, error: "rate_limit:concurrentEphemeral" };
@@ -721,7 +795,16 @@ export function createCtoEngine(deps = {}) {
     const gate = await beginEphemeral();
     if (!gate.ok) return { ok: false, gated: true, error: gate.error };
     try {
-      return runEphemeral ? await runEphemeral(data) : { ok: false, gated: true };
+      // BET-1388: the engine-wrapped ambient model calls report their spend to
+      // the budget via reportAmbientSpend. The rollup runner / facts engine
+      // call runEphemeral without their own deps, so the reportCost seam is
+      // injected here.
+      return runEphemeral
+        ? await runEphemeral({
+            ...data,
+            deps: { ...(data?.deps || {}), reportCost: reportAmbientSpend },
+          })
+        : { ok: false, gated: true };
     } finally {
       gate.release?.();
     }
@@ -840,6 +923,8 @@ export function createCtoEngine(deps = {}) {
         }
       }
       let changed = cursorInit;
+      // BET-1388 §12.2 rung 4: shed hourly rollups while thrifty (§10.6-6).
+      const shedHourly = thrifty;
       for (const level of ROLLUP_LEVELS) {
         const duration = ROLLUP_LEVEL_MS[level];
         let start = cursor[level];
@@ -851,6 +936,14 @@ export function createCtoEngine(deps = {}) {
           guard += 1;
         }
         if (list.length === 0) continue;
+        if (shedHourly && level === "hour") {
+          // No hour reduces while thrifty; advance the cursor across the closed
+          // windows so they are never re-attempted later. The next DAY reduce
+          // reconstructs the missing hours from segments (ctoRollups).
+          cursor[level] = list[list.length - 1].window[1];
+          changed = true;
+          continue;
+        }
         const outcomes = await runner.processDue(list.map((w) => ({ level, window: w })));
         if (outcomes && outcomes.length > 0) {
           const next = outcomes[outcomes.length - 1].window[1];
@@ -1193,6 +1286,10 @@ export function createCtoEngine(deps = {}) {
     checkCanCreateSession,
     beginEphemeral,
     beginDelegateJob,
+    reportAmbientSpend,
+    // BET-1388 tier gating (§3.3): pure consult; reads the A12 dial via the
+    // injected tierGet (default low). Exposed so P2 features gate on it.
+    tierAllowsFeature: async (feature) => budgetTierAllows(await tierGet(), feature),
     observeEvent,
     drainInbox,
     getPresence,

--- a/src/server/ctoEngine.test.mjs
+++ b/src/server/ctoEngine.test.mjs
@@ -12,6 +12,7 @@ import {
   buildFactsContext,
 } from "./ctoEngine.mjs";
 import { createSegmenter } from "./ctoSegments.mjs";
+import { startOfDay } from "./ctoRollups.mjs";
 import { createFactsEngine } from "./ctoFacts.mjs";
 import { windowFor } from "./ctoRollups.mjs";
 
@@ -29,6 +30,7 @@ function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts } = {}) {
   let currentConfig = { ctoEnabled };
   const cardCalls = [];
   const state = { v: 1, pendingBlockers: [] };
+  const budgetCfg = { budgetIsHit: false, tier: "low" };
 
   const engine = createCtoEngine({
     configGet: async () => ({ ...currentConfig }),
@@ -71,6 +73,13 @@ function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts } = {}) {
       tonightCount: 0,
       ...counts,
     }),
+    // BET-1388: hermetic budget for all engine tests (never touches the real
+    // budget.json). Cap tests override `budgetCfg.budget`.
+    budget: {
+      isCapHit: async () => budgetCfg.budgetIsHit,
+      record: async () => ({ usd: 0, dayKey: "0" }),
+    },
+    tierGet: async () => budgetCfg.tier,
     ...(rollups ? { rollups } : {}),
     ...(facts ? { facts } : {}),
   });
@@ -82,6 +91,7 @@ function makeHarness({ ctoEnabled = false, counts = {}, rollups, facts } = {}) {
     published,
     cardCalls,
     state,
+    budgetCfg,
     get pendingBlockers() {
       return pendingBlockers;
     },
@@ -261,6 +271,79 @@ test("computeDot maps the four states", () => {
   assert.equal(computeDot({ enabled: false, paused: false, thrifty: false }), "disabled");
   assert.equal(computeDot({ enabled: true, paused: true, thrifty: false }), "paused");
   assert.equal(computeDot({ enabled: true, paused: false, thrifty: true }), "thrifty");
+});
+
+test("BET-1388: hard cap blocks beginEphemeral (cap hit → cto_cap_hit + thrifty)", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  assert.equal((await h.engine.beginEphemeral()).ok, true);
+  h.budgetCfg.budgetIsHit = true;
+  const gate = await h.engine.beginEphemeral();
+  assert.equal(gate.ok, false);
+  assert.equal(gate.error, "cto_cap_hit");
+  // cap-hit flips thrifty (§10.6-6)
+  assert.equal((await h.engine.getState()).dot, DOT.THRIFTY);
+  assert.ok(h.ledgerRows.find((r) => r.kind === "cto.thrifty_on" && r.source === "cap"));
+});
+
+test("BET-1388: reportAmbientSpend records spend and flips thrifty on cap", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  await h.engine.reportAmbientSpend({ model: {}, tokens: 1000 });
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  h.budgetCfg.budgetIsHit = true;
+  await h.engine.reportAmbientSpend({ model: {}, tokens: 1000 });
+  assert.equal((await h.engine.getState()).dot, DOT.THRIFTY);
+});
+
+test("BET-1388: thrifty auto-clears at the daily reset", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  const sod = startOfDay(h.clock.ms);
+  h.clock.ms = sod + 60_000; // just past local midnight
+  await h.engine.setThrifty(true, { reason: "cap_hit", source: "cap" });
+  assert.equal((await h.engine.getState()).dot, DOT.THRIFTY);
+  // advance into the next local day, then tick → thrifty cleared
+  h.clock.ms = sod + 86_400_000 + 60_000;
+  await h.engine.tick();
+  assert.equal((await h.engine.getState()).dot, DOT.ACTIVE);
+  assert.ok(h.ledgerRows.find((r) => r.kind === "cto.thrifty_off" && r.reason === "daily_reset"));
+});
+
+test("BET-1388: tierAllowsFeature reads the A12 dial and gates features", async () => {
+  const h = makeHarness({ ctoEnabled: true });
+  // default low tier
+  assert.equal(await h.engine.tierAllowsFeature("rollups"), true);
+  assert.equal(await h.engine.tierAllowsFeature("suggestion"), false);
+  assert.equal(await h.engine.tierAllowsFeature("overnight"), false);
+  h.budgetCfg.tier = "high";
+  assert.equal(await h.engine.tierAllowsFeature("overnight"), true);
+  assert.equal(await h.engine.tierAllowsFeature("probe"), true);
+});
+
+test("BET-1388: thrifty sheds hourly rollups (§12.2 rung 4) — no hour reduces", async () => {
+  const levelsCalled = [];
+  const rollups = {
+    processDue: async (items) => {
+      for (const it of items || []) levelsCalled.push(it.level);
+      return (items || []).map((it) => ({ level: it.level, window: it.window, saved: true }));
+    },
+  };
+
+  const h = makeHarness({ ctoEnabled: true, rollups });
+  // First tick: initialize the rollup cursor.
+  await h.engine.tick();
+  levelsCalled.length = 0;
+
+  // Normal mode: 3 closed hours → hour reduces run.
+  h.advance(3 * HOUR_MS);
+  await h.engine.tick();
+  assert.ok(levelsCalled.includes("hour"), "hour reduces run when not thrifty");
+
+  // Thrifty mode: the same 3 closed hours are shed (no hour reduces), cursor
+  // advances past them so they are never re-attempted.
+  levelsCalled.length = 0;
+  h.advance(3 * HOUR_MS);
+  await h.engine.setThrifty(true, { reason: "cap_hit", source: "cap" });
+  await h.engine.tick();
+  assert.ok(!levelsCalled.includes("hour"), "hour reduces shed while thrifty");
 });
 
 test("watchdog: > 2x expected burn → auto-thrifty", async () => {

--- a/src/server/ctoRollups.mjs
+++ b/src/server/ctoRollups.mjs
@@ -260,6 +260,22 @@ export function degradedRollup({ level, window, inputs, refs } = {}) {
   return { v: ROLLUP_VERSION, level, window, bullets };
 }
 
+// BET-1388 (§12.2 rung 4): reconstruct ONE absent hour rollup from its segment
+// summaries (one bullet per segment, each carrying the leaf segment id). The
+// day reduce uses this to fold hours that were shed while the CTO was thrifty
+// — segments are still summarized (that work is "kept to the last token"), so
+// a missing hour is never silent at the day level. Mirrors degradedRollup's
+// hour branch. Returns `null` when the hour has nothing to fold.
+export function reconstructHour({ window, segments = [] } = {}) {
+  const segs = Array.isArray(segments) ? segments : [];
+  if (!segs.length) return null;
+  const bullets = segs.map((it) => {
+    const s = it?.summary || {};
+    return { text: s.one_liner || s.intent || "unspecified work", refs: it.id ? [it.id] : [] };
+  });
+  return { id: String(window && window[0] != null ? window[0] : ""), window, bullets };
+}
+
 // ---------------------------------------------------------------------------
 // Fact sync (P2, §6.2 / D10 — no direct writes). After a day-level reduce the
 // runner maps each bullet to {project, statement, refs} by resolving refs →
@@ -405,9 +421,10 @@ export function defaultLoadInputs({ fs = fsp, rollups = rollupsStore, segments =
     try {
       names = await fs.readdir(dir);
     } catch {
-      return [];
+      names = [];
     }
-    const out = [];
+    // Existing level-below rollups within this window (write-once artifacts).
+    const byStart = new Map();
     for (const name of names) {
       if (!name.endsWith(".json")) continue;
       const id = name.slice(0, -5);
@@ -418,8 +435,52 @@ export function defaultLoadInputs({ fs = fsp, rollups = rollupsStore, segments =
         continue;
       }
       if (r && Array.isArray(r.window) && r.window[0] >= ws && r.window[0] < we) {
-        out.push({ id, window: r.window, bullets: Array.isArray(r.bullets) ? r.bullets : [] });
+        byStart.set(r.window[0], {
+          id,
+          window: r.window,
+          bullets: Array.isArray(r.bullets) ? r.bullets : [],
+        });
       }
+    }
+    // BET-1388 (§12.2 rung 4) — hour-gap reconstruction. When the CTO is
+    // thrifty, hourly rollups are shed (no hour reduce runs); the DAY reduce
+    // must still be able to fold those hours. Segments are still summarized
+    // ("kept to the last token"), so for every hour that has segments but no
+    // hour rollup we synthesize a reconstructed hour from its segment summaries.
+    let out = Array.from(byStart.values());
+    if (level === "day") {
+      const segsDir = segments.dir;
+      const byHour = new Map();
+      let segNames = [];
+      try {
+        segNames = await fs.readdir(segsDir);
+      } catch {
+        segNames = [];
+      }
+      for (const name of segNames) {
+        if (!name.endsWith(".json")) continue;
+        const id = name.slice(0, -5);
+        let sg;
+        try {
+          sg = await segments.load(id);
+        } catch {
+          continue;
+        }
+        if (sg && Array.isArray(sg.window) && sg.window[0] >= ws && sg.window[0] < we) {
+          const hourStart = startOfHour(sg.window[0]);
+          if (!byHour.has(hourStart)) byHour.set(hourStart, []);
+          byHour.get(hourStart).push({ id, window: sg.window, ts: sg.ts, summary: sg.summary });
+        }
+      }
+      const covered = new Set(out.map((o) => o.window && o.window[0]));
+      const reconstructed = [];
+      for (let hourStart = ws; hourStart < we; hourStart += HOUR_MS) {
+        if (covered.has(hourStart)) continue;
+        const segs = (byHour.get(hourStart) || []).sort((a, b) => a.window[0] - b.window[0]);
+        const recon = reconstructHour({ window: [hourStart, hourStart + HOUR_MS], segments: segs });
+        if (recon) reconstructed.push(recon);
+      }
+      out = out.concat(reconstructed);
     }
     return out.sort((a, b) => a.window[0] - b.window[0]);
   };

--- a/src/server/ctoRollups.test.mjs
+++ b/src/server/ctoRollups.test.mjs
@@ -13,6 +13,9 @@ import {
   previousWindow,
   proposalsFromRollup,
   submitFactsFromRollup,
+  reconstructHour,
+  defaultLoadInputs,
+  startOfHour,
   HOUR_MS,
   DAY_MS,
   WEEK_MS,
@@ -244,6 +247,76 @@ test("day reduce from hour rollups: degraded keeps propagated leaf refs", async 
   const saved = store.map.get(`day/${day[0]}`);
   assert.deepEqual(saved.bullets.map((b) => b.refs), [["s1"], ["s2"]]);
   assert.deepEqual([...new Set(saved.bullets.flatMap((b) => b.refs))].sort(), ["s1", "s2"]);
+});
+
+test("reconstructHour folds a shed hour's segments into bullets with leaf refs", () => {
+  const window = [startOfHour(Date.now()), startOfHour(Date.now()) + HOUR_MS];
+  const recon = reconstructHour({
+    window,
+    segments: [
+      { id: "s1", summary: { one_liner: "wired auth" } },
+      { id: "s2", summary: { intent: "refactor" } },
+      { id: "s3", summary: {} },
+    ],
+  });
+  assert.equal(recon.id, String(window[0]));
+  assert.deepEqual(recon.window, window);
+  assert.deepEqual(recon.bullets, [
+    { text: "wired auth", refs: ["s1"] },
+    { text: "refactor", refs: ["s2"] },
+    { text: "unspecified work", refs: ["s3"] },
+  ]);
+});
+
+test("reconstructHour returns null when the hour has no segments", () => {
+  assert.equal(reconstructHour({ window: [0, HOUR_MS], segments: [] }), null);
+});
+
+test("defaultLoadInputs day: reconstructs missing hours from segments (thrifty gap)", async () => {
+  // A fake fs over a rollups/hour dir + a segments dir.
+  const rollupFiles = ["hExisting.json"];
+  const segFiles = ["s1.json", "s2.json", "s3.json"];
+  const dayStart = new Date(2026, 7, 28, 0, 0, 0, 0).getTime();
+  const h = (i) => dayStart + i * HOUR_MS; // hour i start
+  const rollups = {
+    dirFor: () => "rollups/hour",
+    load: async (level, id) => {
+      if (id === "hExisting")
+        return { v: 1, level: "hour", window: [h(0), h(1)], bullets: [{ text: "H0", refs: ["s0"] }] };
+      return { v: 1 };
+    },
+  };
+  const segments = {
+    dir: "segments",
+    load: async (id) => {
+      const map = {
+        s1: { v: 1, window: [h(1), h(1) + HOUR_MS], ts: h(1), summary: { one_liner: "A" } },
+        s2: { v: 1, window: [h(1), h(1) + HOUR_MS], ts: h(1) + 1, summary: { one_liner: "B" } },
+        s3: { v: 1, window: [h(2), h(2) + HOUR_MS], ts: h(2), summary: { intent: "C" } },
+      };
+      return map[id] ?? { v: 1 };
+    },
+  };
+  const fs = {
+    readdir: async (dir) => (dir === "rollups/hour" ? rollupFiles : dir === "segments" ? segFiles : []),
+  };
+  const loadInputs = defaultLoadInputs({ fs, rollups, segments });
+  const day = windowFor("day", dayStart);
+  const items = await loadInputs({ level: "day", window: day });
+
+  // h0: existing hour rollup; h1 + h2 reconstructed from segments; h3.. empty.
+  const byStart = new Map(items.map((it) => [it.window[0], it]));
+  assert.equal(byStart.get(h(0)).id, "hExisting");
+  assert.equal(byStart.get(h(0)).bullets[0].text, "H0");
+  // h1 reconstructed from two segments (leaf refs s1, s2)
+  const h1 = byStart.get(h(1));
+  assert.equal(h1.id, String(h(1)));
+  assert.deepEqual(h1.bullets.map((b) => b.refs), [["s1"], ["s2"]]);
+  assert.deepEqual(h1.bullets.map((b) => b.text), ["A", "B"]);
+  // h2 reconstructed from one segment
+  assert.deepEqual(byStart.get(h(2)).bullets.map((b) => b.text), ["C"]);
+  // items sorted by start
+  assert.deepEqual(items.map((it) => it.window[0]), [h(0), h(1), h(2)]);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/ctoSessions.mjs
+++ b/src/server/ctoSessions.mjs
@@ -209,6 +209,8 @@ async function activeRemove(sid, { engineState }) {
  * @param {Function} [a.deps.resolveModel]  async ({taskClass,tier,meta,configGet}) -> model|null
  * @param {Function} [a.deps.configGet]  async () -> AppConfig (for model routing)
  * @param {Function} [a.deps.validate]  async (result) => bool — structured-output check; triggers the cascade
+ * @param {Function} [a.deps.reportCost]  async ({taskClass,tier,model,tokens}) => void — BET-1388 metering
+ *   hook; every run reports its estimated token cost (default no-op). The engine wires it to the budget.
  * @returns {Promise<{text:string, taskClass:string, tier:string}>}
  */
 export async function runEphemeral({ taskClass, context = [], directory = "~", deps = {} } = {}) {
@@ -238,6 +240,7 @@ async function runOnce({ taskClass, meta, tier, context, directory, deps }) {
     engineState = engineStateStore,
     resolveModel = defaultResolveModel,
     configGet,
+    reportCost = async () => {},
   } = deps;
   if (!oc || typeof oc.runEphemeralSession !== "function") {
     throw new Error("runEphemeral requires deps.oc with runEphemeralSession()");
@@ -259,6 +262,19 @@ async function runOnce({ taskClass, meta, tier, context, directory, deps }) {
         await activeAdd(s, { engineState });
       },
     });
+    // BET-1388 (§12.1): every ambient model call reports its token cost into
+    // budget.json. Best-effort — a metering failure must never mask the run.
+    // The engine wires this to the budget's record(); the default is a no-op.
+    try {
+      await reportCost({
+        taskClass,
+        tier,
+        model,
+        tokens: estimateTokens(instruction) + estimateTokens(res?.text ?? ""),
+      });
+    } catch {
+      /* metering is best-effort */
+    }
     return { text: res?.text ?? "", taskClass, tier, sid: res?.sid ?? sid };
   } finally {
     // Remove from the active set even when the run errored (finally).
@@ -325,7 +341,7 @@ export async function defaultResolveModel({ taskClass, tier, meta, configGet }) 
   }
 
   try {
-    return chooseSubagentModel({
+    const chosen = chooseSubagentModel({
       incumbent: null,
       catalog,
       policy: forcedPolicy,
@@ -334,6 +350,17 @@ export async function defaultResolveModel({ taskClass, tier, meta, configGet }) 
       contextTokens: meta?.contextBudget ?? undefined,
       services,
     });
+    // BET-1388 (§12.1 / §13.3): attach the catalogue's pricing data (`cost`) to
+    // the resolved model so the budget can price the turn. chooseSubagentModel
+    // returns a provider/model id only; the run does not need cost, but the
+    // spend meter prices on it. Unknown → the model is unpriceable (prices 0).
+    if (chosen && chosen.providerID && chosen.modelID) {
+      const priced = catalog.find(
+        (x) => x && x.providerID === chosen.providerID && x.id === chosen.modelID,
+      );
+      if (priced && priced.cost) return { ...chosen, cost: priced.cost };
+    }
+    return chosen;
   } catch {
     return null;
   }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -137,6 +137,7 @@ import { endpointSummary as routingEndpointSummary, providerTokenTotals, ROUTING
 import * as appControl from "./appControl.mjs";
 import * as cto from "./cto.mjs";
 import * as ctoEngine from "./ctoEngine.mjs";
+import * as ctoBudget from "./ctoBudget.mjs";
 import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore } from "./ctoStores.mjs";
 import { computeHealthStats } from "./ctoHealth.mjs";
 import { runEphemeral, createEphemeralReaper } from "./ctoSessions.mjs";
@@ -1773,6 +1774,9 @@ async function segmentSummarize(data = {}) {
         oc: { runEphemeralSession: oc.runSynchronousSession },
         configGet: () => local.configGet(),
         validate,
+        // BET-1388: segments are summarized (kept to the last token) but still
+        // consume budget — report their spend so the ambient cap counts them.
+        reportCost: (c) => adaptiveCto?.reportAmbientSpend?.(c),
       },
     });
     const summary = parseSegmentSummaryText(res?.text);
@@ -1808,6 +1812,7 @@ async function segmentOneLiner(data = {}) {
         oc: { runEphemeralSession: oc.runSynchronousSession },
         configGet: () => local.configGet(),
         validate: async (out) => validOneLiner(out?.text) !== null,
+        reportCost: (c) => adaptiveCto?.reportAmbientSpend?.(c),
       },
     });
     return validOneLiner(res?.text);
@@ -1842,6 +1847,15 @@ const adaptiveCto = ctoEngine.createCtoEngine({
       generationInFlight: adaptiveCtoDigest ? await adaptiveCtoDigest.isGenerating() : false,
     };
   },
+  // BET-1388 tier gating (§3.3): the A12 dial writes `ctoTier` to config
+  // (default low). tierAllowsFeature consults it.
+  tierGet: async () => {
+    try {
+      return (await local.configGet())?.ctoTier ?? "low";
+    } catch {
+      return "low";
+    }
+  },
   // BET-1387 cold-start backfill: the read-only opencode db handle (⌘F search's
   // source) + the A7 rollup reduce producer. The backfill pays for these out of
   // its own one-time spend bound, so they bypass the engine's §3.3 rate gate.
@@ -1870,6 +1884,9 @@ let adaptiveCtoDigest = null;
           ...(opts?.deps || {}),
           oc: { runEphemeralSession: oc.runSynchronousSession },
           configGet: () => local.configGet(),
+          // BET-1388: the digest is kept to the last token but still consumes
+          // budget — report its spend to the ambient cap.
+          reportCost: (c) => adaptiveCto.reportAmbientSpend(c),
         },
       });
     } finally {
@@ -1923,14 +1940,24 @@ let adaptiveCtoDigest = null;
 }
 
 // Watchdog (§13.3): checks engine liveness + ambient spend rate; > 2× expected
-// hourly burn → auto-thrifty, > 4× → auto-pause + blocker card. Spend is not
-// measured yet (the budget reading lands with a later pipeline issue), so the
-// defaults are 0/0 → never trips and never pauses; the pure logic is wired so
-// a real spend source simply slots in.
+// hourly burn → auto-thrifty, > 4× → auto-pause + blocker card. The expected
+// hourly burn derives from the trailing 7-day ambient spend (BET-1388 —
+// replaces the placeholder 0/0 that could never trip), and the measured
+// per-hour burn is today's budget spend / hours elapsed. Both read the real
+// budget.json store via ctoBudget.
+const adaptiveCtoBudget = ctoBudget.createCtoBudget();
 const adaptiveCtoWatchdog = ctoEngine.createWatchdog({
   engine: adaptiveCto,
-  getSpendPerHour: async () => 0,
-  expectedHourlyBurn: async () => 0,
+  getSpendPerHour: async () => adaptiveCtoBudget.spendPerHourUsd(),
+  expectedHourlyBurn: async () => {
+    let cap = ctoBudget.DEFAULT_AMBIENT_CAP_USD;
+    try {
+      cap = ctoBudget.ambientCapUsd(await local.configGet());
+    } catch {
+      /* keep default */
+    }
+    return adaptiveCtoBudget.expectedHourlyBurnUsd({ capUsd: cap });
+  },
 });
 const stopAdaptiveCtoWatchdog = startPoller(adaptiveCtoWatchdog.tick, {
   intervalMs: ctoEngine.TICK_INTERVAL_MS,


### PR DESCRIPTION
## BET-1388 — CTO ambient-spend economics (§10.6-6, §12.1, §12.2, §13.3)

Implements the CTO's ambient-spend economics: a per-day spend budget, an
independent hard cap, thrifty-mode shedding, tier gating, and the watchdog's
expected-hourly-burn figure.

**Files changed:** 8 files.

```
 src/server/ctoBudget.mjs       | 275 +++++++++++++++++++++++++++++++++++++++++
 src/server/ctoBudget.test.mjs  | 204 ++++++++++++++++++++++++++++++
 src/server/ctoEngine.mjs       |  99 ++++++++++++++-
 src/server/ctoEngine.test.mjs  |  83 +++++++++++++
 src/server/ctoRollups.mjs      |  67 +++++++++-
 src/server/ctoRollups.test.mjs |  73 +++++++++++
 src/server/ctoSessions.mjs     |  29 ++++-
 src/server/index.mjs           |  39 +++++-
 8 files changed, 858 insertions(+), 11 deletions(-)
```

### What ships

- **`ctoBudget.mjs` (new, pure + injected I/O)** — per-day ambient spend
  accumulation into `budget.json` (day rolls at local midnight on the same
  clock as the rollups layer). Exports pure `dayKey` / `recordSpend` /
  `todaySpend` / `isAmbientCapHit` / `expectedHourlyBurnUsd` /
  `spendPerHourNow`, the thrifty shed ladder (`THRIFTY_SHED_ORDER` /
  `isWorkShedInThrifty`), the tier table (`FEATURE_TIERS` / `tierAllows`),
  and `priceTokens` (blendedPrice over the model's own `cost`), plus a
  `createCtoBudget({store, price, now})` accessor.
- **Hard cap (§12.1)** — `beginEphemeral` now checks `ctoAmbientCapUsd`
  (default **$2.50/day**) before **every** ambient model call, at every
  tier, independent of the dial. At cap → `{error:"cto_cap_hit"}` and the
  engine flips thrifty. A failed cap read never opens an unchecked writer
  and never blocks ambient work.
- **Thrifty (§10.6-6 / §12.2)** — the numbered shed ladder the engine
  consults before each work type: shed (1) speculative, (2) probe,
  (3) profile (declared contract for P2 features; nothing implements them
  yet), (4) hourly rollups. Kept to the last token: blocker detection,
  segment one-liners, digest-on-open. **Rung 4 is live now**: while thrifty,
  `finalizeRollups` skips hour reduces (cursor advances so shed windows are
  never re-attempted). **Hour-gap reconstruction is implemented now** in
  `ctoRollups.mjs` — the day reduce folds missing hours from segment
  summaries (`reconstructHour`), since segments are still summarized.
  Thrifty auto-clears at the daily budget reset (tracked via `thriftyAtDay`).
- **Tier gating (§3.3)** — `tierAllows(tier, feature)`: Low → rollups /
  digest / facts-sync / rails / ledger; Medium → + suggestion / probe /
  profile; High → + overnight. Default Low (A12 dial writes `ctoTier`, wired
  via `tierGet`). Exposed as `engine.tierAllowsFeature`.
- **Cost reporting hook (`ctoSessions.mjs`)** — `runEphemeral` accepts a
  `deps.reportCost({taskClass, tier, model, tokens})` seam; every ambient
  call reports its estimated token cost (default no-op). The engine / index
  wire it to `reportAmbientSpend` → `budget.record`, which prices via the
  model's pricing data and flips thrifty on cap. `defaultResolveModel` now
  attaches the catalogue `cost` so pricing is non-zero for priced models.
- **Watchdog burn (§13.3)** — `expectedHourlyBurn` now derives from the
  trailing 7-day ambient spend (pure, with a cap-equivalent fallback when
  there is no history so a fresh box isn't falsely tripped); `getSpendPerHour`
  is today's spend ÷ hours elapsed. **The placeholder `0/0` that could never
  trip is deleted.**

### Behavioral notes / decisions

- **Backfill is not metered** against the ambient cap: it "pays for these out
  of its own one-time spend bound" per the existing design, so its
  `runEphemeral` calls keep the default no-op reportCost. Only ambient work
  (segment summarize/one-liner, digest, engine-wrapped rollups/facts) reports
  to the budget.
- A spend that drives today's total to the cap is recorded (it already
  happened); the **next** call gates. `reportAmbientSpend` also flips thrifty
  the moment the cap is crossed.
- An unpriceable model (no `cost`) prices at 0 — we cannot charge what we
  cannot measure.

### Verification results

- PR branch (`multica/BET-1388-cto-economics` @ `85cd51b5`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, vitest 3823 pass / 7 skip / 0 fail; node 3285 pass / 0 fail / 77 suites. log sha256: `327146ca6cd8d9938969cbeb26c9c650277f2b60d695ea9c2159434f8113d1be`
- Base (`main` @ `c33af9b9`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, vitest 3823 pass / 7 skip / 0 fail; node 3264 pass / 0 fail / 77 suites. log sha256: `3f6bacc3ee54e29a3ce8748346b65de5fbf8df7a0579b5ee77ad1cf0c74e1eb1`
- **Conclusion:** 0 new failures. The node-test delta (3285 vs 3264) is the 21 tests this PR adds (ctoBudget, ctoEngine, ctoRollups). The typecheck log is byte-identical across branches.

**Base: origin/main @ `c33af9b9`**
