### PR TITLE
feat(server): BET-1400 usage forecast math (HW damped-trend + seasonal, quantile reserve)

### DIFF
--- a/src/server/cto.mjs
+++ b/src/server/cto.mjs
@@ -33,7 +33,6 @@ import { statePath } from "../shared/paths.mjs";
 import { readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
 import { describeModel } from "../shared/modelGuide.mjs";
 import { createSeenIdFilter } from "./seenIds.mjs";
-import { startPoller } from "./startPoller.mjs";
 import {
   rollupsStore,
   ledgerStore,
@@ -43,6 +42,7 @@ import {
   inboxExpiresAt,
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
+import { makeWatcher as buildWatcher, validatePredicate } from "./ctoWatchers.mjs";
 
 export const CTO_STORE_PATH = statePath("cto.json");
 
@@ -126,12 +126,10 @@ export function createCtoEngine(deps = {}) {
     gitBranch = remoteGitBranch,
     gitLog = remoteGitLog,
     isPlanAgent = (name) => name === "plan" || name === "manta-plan",
-    loadWatches = async () => Array.isArray(loadCtoStore()?.watches) ? loadCtoStore().watches : [],
-    saveWatches = async (watches) => {
-      const store = loadCtoStore();
-      store.watches = Array.isArray(watches) ? watches : [];
-      await saveCtoStore(store);
-    },
+    // BET-1398 standing-query watchers (supersedes the cto.json poller). Empty
+    // default keeps the read gateway resolving standalone; index.mjs wires this
+    // to the adaptive engine's event-driven `watchers`.
+    watchers = null,
     loadInbox = async () => inboxStore.load(),
     saveInbox = async (data) => inboxStore.save(data),
     now = () => Date.now(),
@@ -147,6 +145,31 @@ export function createCtoEngine(deps = {}) {
       run: def.run,
     });
   };
+
+  // BET-1398: resolve the standing-query watcher registry. The adaptive
+  // engine's persistent, event-driven engine is preferred; standalone, fall
+  // back to a self-contained in-memory registry so the read gateway keeps
+  // resolving (e.g. in isolation tests).
+  let memWatcherStore = null;
+  function resolveWatchers() {
+    if (watchers) return watchers;
+    if (!memWatcherStore) memWatcherStore = [];
+    return {
+      register: async (input) => {
+        const built = buildWatcher({ ...input, now });
+        if (!built.ok) return { ok: false, error: built.error };
+        memWatcherStore.push(built.watch);
+        return { ok: true, data: { watch: built.watch } };
+      },
+      unregister: async (id) => {
+        const i = memWatcherStore.findIndex((w) => w && w.id === id);
+        if (i === -1) return { ok: true, data: { removed: false } };
+        memWatcherStore.splice(i, 1);
+        return { ok: true, data: { removed: true } };
+      },
+      list: async () => memWatcherStore,
+    };
+  }
 
   // Best-effort branch resolver: one git call per distinct directory, cached.
   // Shared by list_sessions / list_projects so the per-project git state is
@@ -716,46 +739,52 @@ export function createCtoEngine(deps = {}) {
   });
 
   // -------------------------------------------------------------------------
-  // Watchers (Issue 2) — watch / unwatch / list_watches
+  // Watchers (BET-1398) — watch / unwatch / list_watches
   // -------------------------------------------------------------------------
-  // A watch registers a recurring probe against a SURFACE (schedule,
-  // delegate, session…). The watcher poller (createWatcherPoller below) runs
-  // each active watch's query against the surface's existing read and, when
-  // its condition matches AND its seenId is new, calls cto.inbound with that
-  // surface. `watch` is a CONFIRM-mode tool: registering a repeat probe is a
-  // side effect, so it needs the user's go-ahead (see the gate dispatch below).
+  // A watch registers a STANDING QUERY evaluated over the CTO's evidence
+  // stream (spec §4.3/§13.4): an event-driven predicate, not a surface poll.
+  // `watch` takes a predicate `{kind, params}` — kind ∈ {event-pattern,
+  // rate-threshold, usage-burn} — via flat args below. `watch` is a
+  // CONFIRM-mode tool: registering a recurring probe is a side effect, so it
+  // needs the user's go-ahead (see the gate dispatch below).
   register({
     name: "watch",
     description:
-      "Register a watcher that probes a surface and surfaces a notification when its " +
-      "condition matches. `surface` is one of: schedule, " +
-      "delegate, or session. `query` names what to read on that surface (for schedule, " +
-      "e.g. the job id or 'read from the board'); `condition` is a natural-language " +
-      "phrase describing the trigger (e.g. 'a P0 opens'). The watcher poller runs it " +
-      "periodically via the surface's existing read. NOTE: this is a confirm-mode " +
-      "action — it registers a recurring probe, so it needs your go-ahead before it takes " +
-      "effect.",
+      "Register a standing-query watcher evaluated over the CTO's evidence stream. " +
+      "The wire runs the three predicate kinds (closed set): event-pattern (a regex " +
+      "matched against evidence text/kind), rate-threshold (count of matching events " +
+      "in a window >= threshold), or usage-burn (ambient spend pace vs the daily cap " +
+      "fraction). A matching evidence event becomes a high-salience watcher hit that " +
+      "feeds the suggestion engine. NOTE: this is a confirm-mode action — it registers " +
+      "a recurring probe, so it needs your go-ahead before it takes effect.",
     params: {
-      surface: { type: "string", description: "The surface to watch: schedule, delegate, or session." },
-      query: { type: "string", description: "What to query on that surface (informational)." },
-      condition: { type: "string", description: "Natural-language condition for when to trigger." },
+      kind: {
+        type: "string",
+        description: "Predicate kind: event-pattern | rate-threshold | usage-burn.",
+      },
+      pattern: { type: "string", description: "Regex (event-pattern, or a rate-threshold filter)." },
+      eventKind: { type: "string", description: "Limit matches to this evidence kind (optional)." },
+      threshold: { type: "number", description: "Count to trigger (rate-threshold)." },
+      windowMs: { type: "number", description: "Window ms (rate-threshold / usage-burn)." },
+      capFraction: { type: "number", description: "Daily-cap fraction (usage-burn)." },
     },
     mode: "confirm",
     run: async (ctx, args) => {
-      const surface = String(args?.surface ?? "").trim();
-      if (!surface) return { ok: false, error: "surface is required (schedule, delegate, session)" };
-      const watch = {
-        id: randomBytes(4).toString("hex"),
-        surface,
-        query: String(args?.query ?? "").trim(),
-        condition: String(args?.condition ?? "").trim(),
-        active: true,
-        lastFiredAt: null,
-        createdAt: now(),
+      const predicate = {
+        kind: String(args?.kind ?? "").trim(),
+        params: {
+          ...(args?.pattern != null ? { pattern: String(args.pattern) } : {}),
+          ...(args?.eventKind != null ? { eventKind: String(args.eventKind) } : {}),
+          ...(args?.threshold != null ? { threshold: args.threshold } : {}),
+          ...(args?.windowMs != null ? { windowMs: args.windowMs } : {}),
+          ...(args?.capFraction != null ? { capFraction: args.capFraction } : {}),
+        },
       };
-      const watches = await loadWatches();
-      await saveWatches([...watches, watch]);
-      return { ok: true, data: { watch } };
+      const v = validatePredicate(predicate);
+      if (!v.ok) return { ok: false, error: v.error };
+      const res = await resolveWatchers().register({ predicate, source: "user" });
+      if (!res.ok) return { ok: false, error: res.error };
+      return { ok: true, data: { watch: res.data.watch } };
     },
   });
 
@@ -766,20 +795,21 @@ export function createCtoEngine(deps = {}) {
     params: { id: { type: "string", description: "The watcher id to remove." } },
     run: async (ctx, args) => {
       const id = String(args?.id ?? "");
-      const watches = await loadWatches();
-      const next = (watches ?? []).filter((w) => w?.id !== id);
-      if (next.length === (watches ?? []).length) return { ok: true, data: { removed: false } };
-      await saveWatches(next);
-      return { ok: true, data: { removed: true } };
+      const res = await resolveWatchers().unregister(id);
+      if (!res.ok) return { ok: false, error: res.error };
+      return { ok: true, data: { removed: res.data.removed } };
     },
   });
 
   register({
     name: "list_watches",
-    description: "List every registered watcher: id, surface, query, condition, active," +
-      " and when it last fired. Read-only.",
+    description: "List every registered watcher: id, predicate kind, pattern signature," +
+      " source, created, lastHit and hit count. Read-only.",
     params: {},
-    run: async () => ({ ok: true, data: { watches: await loadWatches() } }),
+    run: async () => {
+      const watchList = await resolveWatchers().list();
+      return { ok: true, data: { watches: Array.isArray(watchList) ? watchList : [] } };
+    },
   });
 
   register({
@@ -1114,83 +1144,11 @@ export function coalesceInboxEntry(existing, incoming, ts) {
 }
 
 // ---------------------------------------------------------------------------
-// Watcher poller (Issue 2) — createWatcherPoller
-// ---------------------------------------------------------------------------
-// For each ACTIVE watch it runs the surface's existing read, computes a stable
-// seenId, and when the seenId is new AND the condition matches it calls the
-// inbound funnel with that surface. In-flight-guarded + timer.unref(), mirroring
-// the schedule/delegate pollers. The read + the seenId + the condition matcher
-// are all injected so the tick is unit-testable with no live engines.
-//
-// A watch whose surface read fails is skipped (logged, never wedges the loop);
-// a watch is only re-armed once its seenId moves, so a constantly-matching
-// read doesn't re-fire every tick.
-export function createWatcherPoller({
-  loadWatches,
-  saveWatches,
-  readSurface,
-  seenFilter = createSeenIdFilter(),
-  sendToInbound,
-  conditionMatches = defaultConditionMatches,
-  computeSeenId = defaultComputeSurfaceSeenId,
-  messageFor = defaultWatchMessage,
-  now = () => Date.now(),
-} = {}) {
-  let inFlight = false;
-
-  async function tick() {
-    if (inFlight) return;
-    inFlight = true;
-    try {
-      const watches = await loadWatches();
-      let mutated = false;
-      const snapshot = Array.isArray(watches) ? watches : [];
-      for (const watch of snapshot) {
-        if (!watch || watch.active === false || watch.disabled) continue;
-        if (!watch.surface) continue;
-        let read;
-        try {
-          read = await readSurface(watch.surface, watch.query);
-        } catch (e) {
-          console.warn(`[cto] watch ${watch.id} surface "${watch.surface}" read failed:`, e?.message ?? e);
-          continue;
-        }
-        const seenId = computeSeenId(read);
-        if (seenFilter.seen(seenId)) continue; // no new content since last tick
-        if (!conditionMatches(watch.condition, read)) continue; // not a trigger
-        await sendToInbound({ surface: watch.surface, payload: { message: messageFor(watch, read) }, seenId });
-        watch.lastFiredAt = now();
-        mutated = true;
-      }
-      if (mutated) await saveWatches(snapshot);
-    } catch (e) {
-      console.warn("[cto] watcher tick failed:", e?.message ?? e);
-    } finally {
-      inFlight = false;
-    }
-  }
-
-  return {
-    tick,
-    start: ({ intervalMs = 15_000 } = {}) => startPoller(tick, { intervalMs, label: "cto-watcher", immediate: true }),
-  };
-}
-
-// Build the notification message for a fired watch. Falls back to a clear
-// "condition matched on <surface>" line when the read carries no snippet.
-export function defaultWatchMessage(watch, read) {
-  const condition =
-    typeof watch?.condition === "string" && watch.condition ? ` (${watch.condition})` : "";
-  const snippet = firstSnippet(read?.data ?? read);
-  const base = `CTO watch on ${watch?.surface ?? "?"}${condition} matched`;
-  return snippet ? `${base}: ${snippet}` : base;
-}
-
 // ---------------------------------------------------------------------------
 // Pure helpers (injectable wires, unit-tested)
 // ---------------------------------------------------------------------------
 
-// Stable short hash of a string (used for confirm ids and surface seen ids).
+// Stable short hash of a string (used for confirm ids).
 export function stableHash(str) {
   let h = 2166136261;
   const s = String(str ?? "");
@@ -1223,56 +1181,4 @@ export function buildPreview(def, args) {
   return header.join(" ");
 }
 
-const CONDITION_STOPWORDS = new Set([
-  "a", "an", "the", "of", "to", "in", "on", "for", "and", "or", "with",
-  "when", "if", "is", "are", "was", "were", "new", "opens", "open", "appears",
-  "shows", "changes", "has", "have", "any", "that", "this", "there", "it",
-]);
 
-// Keywords of a natural-language condition (lowercased tokens minus stopwords) —
-// the deterministic v1 condition evaluator. Issue 3 may replace this with an
-// LLM/narration judgement; until then a keyword hit is the honest seam.
-export function conditionKeywords(condition) {
-  if (typeof condition !== "string") return [];
-  return condition
-    .toLowerCase()
-    .split(/[^a-z0-9]+/)
-    .filter((t) => t.length > 0 && !CONDITION_STOPWORDS.has(t));
-}
-
-// Default condition evaluator: matches when any keyword from the condition is
-// present in the serialized read, or when the condition is empty/no keywords
-// (treat any new content as a trigger). Lowercased case-insensitive match.
-export function defaultConditionMatches(condition, read) {
-  const keywords = conditionKeywords(condition);
-  if (keywords.length === 0) return true;
-  const haystack = JSON.stringify(read ?? {}).toLowerCase();
-  return keywords.some((k) => haystack.includes(k));
-}
-
-// A stable seenId for a surface read. Prefers an explicit `seenId` on the read
-// (readers may stamp one, e.g. the newest issue id), else hashes a stable
-// serialization of the whole read. Two identical reads hash identically, so
-// the poller does not re-fire until content actually changes.
-export function defaultComputeSurfaceSeenId(read) {
-  if (read && typeof read === "object" && typeof read.seenId === "string" && read.seenId) {
-    return read.seenId;
-  }
-  return stableHash(JSON.stringify(read ?? {}));
-}
-
-// First short text snippet from a read for the watch notification message.
-function firstSnippet(data) {
-  if (!data) return null;
-  if (typeof data === "string") return data.slice(0, 140);
-  const issues = Array.isArray(data?.issues) ? data.issues : null;
-  if (issues) {
-    const first = issues.find((i) => i && (i.identifier || i.title));
-    if (first) {
-      const label = [first.identifier, first.status, first.title].filter(Boolean).join(" · ");
-      return label.slice(0, 140);
-    }
-  }
-  const text = JSON.stringify(data);
-  return text && text !== "{}" && text !== "[]" ? text.slice(0, 140) : null;
-}

--- a/src/server/cto.test.mjs
+++ b/src/server/cto.test.mjs
@@ -128,28 +128,35 @@ test("a confirm tool still returns needConfirmation (does NOT act)", async () =>
   const engine = makeEngine();
   const gate = () => "confirm";
   // `watch` is the one confirm-mode tool. A confirm gate on it pauses.
-  const result = await engine.dispatch("watch", { surface: "schedule" }, { gate });
+  const result = await engine.dispatch("watch", { kind: "event-pattern", pattern: "P0" }, { gate });
   assert.equal(result.ok, true);
   assert.equal(result.needConfirmation, true);
   assert.equal(typeof result.preview, "string");
 });
 
 test("a confirm tool pauses by default (no gate) and trustedActions bypasses it", async () => {
-  const saved = [];
+  const registered = [];
   const engine = makeEngine({
-    loadWatches: async () => [],
-    saveWatches: async (w) => saved.push(w),
+    watchers: {
+      register: async (input) => {
+        registered.push(input);
+        return { ok: true, data: { watch: { id: "w1", ...input, created: 1 } } };
+      },
+      unregister: async () => ({ ok: true, data: { removed: true } }),
+      list: async () => registered,
+    },
   });
   // Default (DEFAULT_GATE = allow) still pauses a confirm tool — mode is what
   // decides, not the gate.
-  const paused = await engine.dispatch("watch", { surface: "schedule" }, {});
+  const paused = await engine.dispatch("watch", { kind: "event-pattern", pattern: "P0" }, {});
   assert.equal(paused.ok, true);
   assert.equal(paused.needConfirmation, true);
+  assert.equal(registered.length, 0, "paused confirm tool did not register");
   // trustedActions bypasses the pause for a confirm tool.
-  const run = await engine.dispatch("watch", { surface: "schedule" }, { trustedActions: ["watch"] });
+  const run = await engine.dispatch("watch", { kind: "event-pattern", pattern: "P0" }, { trustedActions: ["watch"] });
   assert.equal(run.ok, true);
   assert.equal(run.needConfirmation, undefined);
-  assert.ok(saved.length > 0, "trusted confirm tool actually ran (watcher saved)");
+  assert.ok(registered.length > 0, "trusted confirm tool actually ran (watcher registered)");
 });
 
 test("default gate returns allow for every tool (Issue 1 ships auto)", async () => {

--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -489,6 +489,13 @@ export function createCtoBudget({
   } = {}) {
     const t = typeof now === "function" ? now() : typeof now === "number" ? now : Date.now();
     if (!windowed) {
+      let conf = {};
+      try {
+        conf = (await cfg()) ?? {};
+      } catch {
+        conf = {};
+      }
+      if (!conf || typeof conf !== "object") conf = {};
       return {
         provider,
         windowed: false,
@@ -497,7 +504,7 @@ export function createCtoBudget({
         spendable: null,
         remainingFrac: null,
         historyDays: 0,
-        nightCapUsd: nightCapUsd(cfg() ?? {}),
+        nightCapUsd: nightCapUsd(conf),
       };
     }
     const hist = (await history().catch(() => ({}))) ?? {};

--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -28,11 +28,60 @@
 // model (no cost data) prices at 0 — honest: we cannot charge what we cannot
 // measure.
 
+// ---------------------------------------------------------------------------
+// Reserve & spendable (§11.2, §11.3) — BET-1400
+// ---------------------------------------------------------------------------
+//
+// The overnight CTO reserves a slice of each WINDOWED provider's plan window
+// against the user's own near-term demand, so overnight autonomy never starves
+// the user's interactive work. Everything here lives in FRACTION-OF-WINDOW
+// space (Option A — see ctoForecast.mjs for the units decision):
+//
+//   reserve   = newsvendor fractile of next-day forecast demand (fraction),
+//               or the §11.3 pre-forecast fallback max(observed daily max,
+//               60% of window) under 14 days of history.
+//   spendable = remaining − reserve, floored at 0.  (created/spendable)
+//
+// The fractile initializes at P95 and NOTCHES across the ladder
+// [P90, P95, P99]: up (≤ P99) on each user cap-hit; down (≥ P90) after 30
+// clean days. Notching is active only once ≥ 14 days of history exist — the
+// pre-forecast fallback is not a fractile and never notches.
+//
+// Clean-day / cap-hit definitions (BET-1400 blocker resolution): a cap-hit =
+// the user's plan window is exhausted (an adapter reports a window at/over
+// its limit, `pct >= 100`); a clean day = no cap-hit AND no forecast-exceeding
+// spend that day. Both are recorded as §14.5 ledger rows by the accessor.
+//
+// WINDOWLESS / NO-ADAPTER (§11.2): the reserve math is disabled (there is
+// nothing to reserve) and overnight spend is bounded by an absolute $ budget,
+// `ctoNightCapUsd` (user-set in Behavior, default $5/night). The forecaster
+// still runs to feed the Health card, but produces no reserve.
+
 import { budgetStore } from "./ctoStores.mjs";
 import { startOfDay } from "./ctoRollups.mjs";
 import { blendedPrice } from "../shared/blendedPrice.mjs";
+import {
+  forecastNextDayFraction,
+  forecastMape,
+  trailingDailySeries,
+  dailyUsageFractions,
+} from "./ctoForecast.mjs";
 
+export const DEFAULT_NIGHT_CAP_USD = 5;
 export const DEFAULT_AMBIENT_CAP_USD = 2.5;
+
+// The fractile notch ladder — P95 init, P99 ceiling, P90 floor (§11.3).
+export const FRACTILE_LADDER = Object.freeze([0.9, 0.95, 0.99]);
+export const FRACTILE_INIT = 0.95;
+// ≥ this many days of history activates notching (the pre-forecast fallback —
+// which is not a fractile — never notches).
+export const RESERVE_ACTIVATE_DAYS = 14;
+// This many consecutive clean days lower the fractile one notch (§11.3).
+export const RESERVE_CLEAN_DAYS = 30;
+// The §11.3 fallback floor: 60% of the window.
+export const RESERVE_FALLBACK_FLOOR = 0.6;
+// Rolling look-back for the daily series — 8 weeks.
+export const RESERVE_FORECAST_DAYS = 56;
 export const BURN_HISTORY_DAYS = 7;
 export const HOUR_MS = 3_600_000;
 
@@ -234,20 +283,173 @@ export function tierAllows(tier, feature) {
   return tierIdx !== -1 && reqIdx !== -1 && tierIdx >= reqIdx;
 }
 
+function clamp01(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : 0;
+}
+
+/** The configured nightly $ bound for windowless/no-adapter overnight work
+ *  (config `ctoNightCapUsd`, default $5/night, §11.2). */
+export function nightCapUsd(cfg) {
+  const c = cfg && typeof cfg === "object" ? cfg.ctoNightCapUsd : undefined;
+  return typeof c === "number" && Number.isFinite(c) && c >= 0 ? c : DEFAULT_NIGHT_CAP_USD;
+}
+
+/** A fresh per-provider reserve-quota state row (stored under `budget.quota`). */
+export function defaultQuotaState(provider = null) {
+  return {
+    provider,
+    fractile: FRACTILE_INIT,
+    activated: false,
+    cleanDays: 0,
+    mode: null,
+    reserve: 0,
+    spendable: 0,
+    maxObserved: 0,
+    historyDays: 0,
+    remainingFrac: 0,
+    mape14: null,
+    updatedMs: null,
+  };
+}
+
+/** Normalise a stored budget payload defensively, preserving the `quota` bag. */
+export function normalizeQuota(payload) {
+  const p = normalizeBudget(payload);
+  const quota = p.quota && typeof p.quota === "object" ? p.quota : {};
+  return { ...p, quota };
+}
+
+/** Move a fractile one ladder notch up (+1) or down (−1), clamped to the
+ *  ladder [P90, P95, P99]. Unknown current values normalise to the P95 init
+ *  before stepping. */
+export function notchFractile(current, direction) {
+  let idx = FRACTILE_LADDER.indexOf(current);
+  if (idx === -1) idx = FRACTILE_LADDER.indexOf(FRACTILE_INIT);
+  const target = Math.max(0, Math.min(FRACTILE_LADDER.length - 1, idx + (direction > 0 ? 1 : direction < 0 ? -1 : 0)));
+  return FRACTILE_LADDER[target];
+}
+
+/**
+ * Fold cap-hit / clean-day signals into a quota state (pure). Notching is only
+ * applied once `activated` (≥ 14 days of history — the caller decides, since
+ * only it knows the history length):
+ *   - each cap-hit raises the fractile one notch (already clamped to ≤ P99),
+ *   - `RESERVE_CLEAN_DAYS` accumulated clean days lower it one notch, then
+ *     reset the clean streak (a clean day = no cap-hit AND no
+ *     forecast-exceeding spend).
+ * Returns a new state; the input is never mutated.
+ */
+export function foldQuotaState(state, { capHits = 0, earnedCleanDays = 0, activated = false } = {}) {
+  const s = state && typeof state === "object" ? { ...state } : defaultQuotaState(null);
+  let fractile = s.fractile ?? FRACTILE_INIT;
+  let cleanDays = s.cleanDays ?? 0;
+  if (activated) {
+    cleanDays = Math.max(0, cleanDays) + Math.max(0, Number.isFinite(Number(earnedCleanDays)) ? earnedCleanDays | 0 : 0);
+    const hits = Math.max(0, Number(Number(capHits) | 0));
+    for (let i = 0; i < hits; i++) fractile = notchFractile(fractile, +1);
+    if (cleanDays >= RESERVE_CLEAN_DAYS) {
+      fractile = notchFractile(fractile, -1);
+      cleanDays = 0;
+    }
+  }
+  return { ...s, fractile, cleanDays, activated: !!activated };
+}
+
+/**
+ * The §11.3 reserve + spendable for one provider's plan window (pure). `series`
+ * is the contiguous trailing daily fraction series (oldest→newest, from the
+ * forecast module); `forecast` is a `({series, fractile}) => {mode, value}`
+ * function (default: the HW/quantile forecast — injectable for tests). Below
+ * the 14-day activation gate (or when the forecaster has insufficient data) it
+ * returns the pre-forecast fallback `max(observed daily max, 60% of window)`
+ * at the P95 init fractile — which never notches.
+ */
+export function planReserve({
+  state = defaultQuotaState(),
+  series,
+  remainingPct,
+  forecast = ({ fractile } = {}) => forecastNextDayFraction({ series, fractile }),
+  fallbackFloor = RESERVE_FALLBACK_FLOOR,
+} = {}) {
+  const vals = Array.isArray(series) ? series.filter(Number.isFinite) : [];
+  const maxObserved = vals.length ? Math.max(0, ...vals) : 0;
+  const historyDays = vals.filter((v) => v > 0).length;
+  const activated = !!state?.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
+  const fractile = activated ? (state?.fractile ?? FRACTILE_INIT) : FRACTILE_INIT;
+
+  let mode;
+  let reserve;
+  let point = null;
+  let sigma = null;
+  if (!activated) {
+    mode = "fallback";
+    reserve = Math.max(maxObserved, fallbackFloor);
+  } else {
+    const fc = forecast({ series, fractile }) ?? { mode: "fallback", value: null };
+    if (fc?.mode === "forecast" && typeof fc.value === "number") {
+      mode = "forecast";
+      reserve = fc.value;
+      point = fc.point ?? null;
+      sigma = fc.sigma ?? null;
+    } else {
+      mode = "fallback";
+      reserve = Math.max(maxObserved, fallbackFloor);
+    }
+  }
+  reserve = clamp01(reserve);
+  const remainingFrac = clamp01((Number(remainingPct) || 0) / 100);
+  const spendableFrac = Math.max(0, remainingFrac - reserve);
+  return {
+    mode,
+    activated,
+    fractile,
+    reserve,
+    maxObserved,
+    historyDays,
+    remainingFrac,
+    spendableFrac,
+    point,
+    sigma,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The I/O accessor the engine consumes (injected store + seams).
 // ---------------------------------------------------------------------------
 // The I/O accessor the engine consumes (injected store + seams).
 // ---------------------------------------------------------------------------
 
-export function createCtoBudget({ store = budgetStore, price = priceTokens, now = Date.now } = {}) {
+export function createCtoBudget({
+  store = budgetStore,
+  price = priceTokens,
+  now = Date.now,
+  // BET-1400 seams (all injectable for sandboxed tests; index.mjs wires the
+  // real usage-history + §14.5 ledger):
+  history = async () => ({}), // () => { "<provider>:<kind>": [{ts,pct}] }
+  historyKey = (provider, kind) => `${provider}:${kind}`,
+  buildSeries = (obs, t) => trailingDailySeries(dailyUsageFractions(obs), { now: t, days: RESERVE_FORECAST_DAYS }),
+  forecast = ({ series, fractile }) => forecastNextDayFraction({ series, fractile }),
+  mapeFn = forecastMape,
+  cfg = () => ({}), // () => config object (ctoNightCapUsd read here)
+  ledger = null, // optional { append(row) } — the §14.5 activity ledger
+} = {}) {
   async function load() {
     try {
-      return normalizeBudget(await store.load());
+      return normalizeQuota(await store.load());
     } catch {
-      return defaultBudgetPayload();
+      return normalizeQuota(defaultBudgetPayload());
     }
   }
   async function save(payload) {
-    await store.save(normalizeBudget(payload));
+    await store.save(normalizeQuota(payload));
+  }
+  async function ledgerAppend(row) {
+    try {
+      if (ledger && typeof ledger.append === "function") await ledger.append(row);
+    } catch {
+      /* ledger is best-effort — never fail quota evaluation on a ledger write */
+    }
   }
   async function record({ model, tokens, nowMs } = {}) {
     const t = typeof nowMs === "number" && Number.isFinite(nowMs) ? nowMs : now();
@@ -263,6 +465,88 @@ export function createCtoBudget({ store = budgetStore, price = priceTokens, now 
       return { usd, dayKey: dayKey(t), ok: false };
     }
   }
+
+  /**
+   * Re-evaluate one provider's reserve + spendable (§11.3): read the provider's
+   * pct observation history, fold cap-hit/clean-day signals into its quota
+   * state, compute the reserve at the active fractile (or the pre-forecast
+   * fallback), persist the quota row + the §14.5 forecast cache, and return the
+   * plan. This is the function C3's overnight scheduler calls on its 30-min
+   * re-evaluation; the Health card reads the persisted `budget.quota`.
+   *
+   * `windowed: false` (a windowless provider or one with no adapter, §11.2)
+   * disables the reserve: it returns `{windowed:false, mode:'windowless',
+   * spendable:null, reserve:0, nightCapUsd}` and bounds overnight spend by the
+   * absolute `ctoNightCapUsd` budget instead.
+   */
+  async function computeSpendable({
+    provider,
+    remainingPct,
+    windowKind = "session",
+    windowed = true,
+    capHitsSince = 0,
+    earnedCleanDays = 0,
+  } = {}) {
+    const t = typeof now === "function" ? now() : typeof now === "number" ? now : Date.now();
+    if (!windowed) {
+      return {
+        provider,
+        windowed: false,
+        mode: "windowless",
+        reserve: 0,
+        spendable: null,
+        remainingFrac: null,
+        historyDays: 0,
+        nightCapUsd: nightCapUsd(cfg() ?? {}),
+      };
+    }
+    const hist = (await history().catch(() => ({}))) ?? {};
+    const obs = hist[historyKey(provider, windowKind)] ?? [];
+    const { series, historyDays, maxObserved } = buildSeries(obs, t);
+
+    const payload = await load();
+    const prev = payload.quota?.[provider] ?? defaultQuotaState(provider);
+    const activated = !!prev.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
+    const folded = foldQuotaState(prev, { capHits: capHitsSince, earnedCleanDays, activated });
+    const plan = planReserve({ state: folded, series, remainingPct, forecast });
+    const quota = {
+      ...folded,
+      provider,
+      mode: plan.mode,
+      reserve: plan.reserve,
+      spendable: plan.spendableFrac,
+      maxObserved: plan.maxObserved,
+      historyDays: plan.historyDays,
+      remainingFrac: plan.remainingFrac,
+      mape14: mapeFn({ series, tailDays: 14 }),
+      updatedMs: t,
+    };
+    const nextPayload = { ...payload, quota: { ...payload.quota, [provider]: quota } };
+    try {
+      await save(nextPayload);
+    } catch {
+      /* quota persistence is best-effort */
+    }
+    // §14.5 ledger rows: a fractile notch and a spendable-reserve line.
+    if (folded.fractile !== (prev.fractile ?? FRACTILE_INIT)) {
+      await ledgerAppend({ kind: "cto.reserve.fractile", ts: t, provider, from: prev.fractile ?? FRACTILE_INIT, to: folded.fractile });
+    }
+    await ledgerAppend({ kind: "cto.reserve", ts: t, provider, reserve: plan.reserve, spendable: plan.spendableFrac, fractile: plan.fractile, mode: plan.mode });
+    return { provider, windowed: true, ...plan, mape14: quota.mape14 };
+  }
+
+  /**
+   * Record a user cap-hit (the provider's plan window exhausted, `pct >= 100`)
+   * as a §14.5 ledger row. Does not itself notch — the next evaluate folds the
+   * cap-hit into the quota state. Purely a recording seam for the poller/engine
+   * that observes the exhaustion.
+   */
+  async function recordCapHit({ provider, tsMs, pct } = {}) {
+    const t = typeof tsMs === "number" && Number.isFinite(tsMs) ? tsMs : (typeof now === "function" ? now() : Date.now());
+    await ledgerAppend({ kind: "cto.cap_hit", ts: t, provider, pct });
+    return { ok: true };
+  }
+
   return {
     record,
     payload: load,
@@ -271,5 +555,7 @@ export function createCtoBudget({ store = budgetStore, price = priceTokens, now 
     spendPerHourUsd: async () => spendPerHourNow(await load(), now()),
     expectedHourlyBurnUsd: async ({ capUsd } = {}) => expectedHourlyBurnUsd(await load(), { now: now(), capUsd }),
     didDayRoll: async () => didDayRoll(await load(), now()),
+    computeSpendable,
+    recordCapHit,
   };
 }

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -2,17 +2,24 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   DEFAULT_AMBIENT_CAP_USD,
+  DEFAULT_NIGHT_CAP_USD,
+  FRACTILE_INIT,
   THRIFTY_SHED_ORDER,
   THRIFTY_KEEP,
   createCtoBudget,
   ambientCapUsd,
   dayKey,
   defaultBudgetPayload,
+  defaultQuotaState,
   didDayRoll,
   expectedHourlyBurnUsd,
+  foldQuotaState,
   hoursIntoLocalDay,
   isAmbientCapHit,
   isWorkShedInThrifty,
+  nightCapUsd,
+  notchFractile,
+  planReserve,
   priceTokens,
   recordSpend,
   spendForDay,
@@ -201,4 +208,157 @@ test("createCtoBudget degrades safely when the store is down", async () => {
   assert.equal(await budget.isCapHit(2.5), false);
   await budget.record({ model: {}, tokens: 1000 }); // must not throw
   assert.equal(await budget.expectedHourlyBurnUsd({ capUsd: 2.5 }), 2.5 / 24);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1400 — reserve & spendable (§11.2, §11.3)
+// ---------------------------------------------------------------------------
+
+test("nightCapUsd defaults to $5 and honors ctoNightCapUsd", () => {
+  assert.equal(nightCapUsd({}), DEFAULT_NIGHT_CAP_USD);
+  assert.equal(nightCapUsd({ ctoNightCapUsd: 3 }), 3);
+  assert.equal(nightCapUsd({ ctoNightCapUsd: 0 }), 0);
+  assert.equal(nightCapUsd({ ctoNightCapUsd: -1 }), DEFAULT_NIGHT_CAP_USD);
+});
+
+test("notchFractile walks the [P90,P95,P99] ladder and clamps", () => {
+  assert.equal(notchFractile(0.95, +1), 0.99);
+  assert.equal(notchFractile(0.99, +1), 0.99); // max P99
+  assert.equal(notchFractile(0.95, -1), 0.9);
+  assert.equal(notchFractile(0.9, -1), 0.9); // min P90
+  assert.equal(notchFractile(999, +1), 0.99); // unknown normalises from P95 init
+});
+
+test("foldQuotaState: no notching before activation (>= 14 days)", () => {
+  const s = foldQuotaState(defaultQuotaState(), { capHits: 5, earnedCleanDays: 60, activated: false });
+  assert.equal(s.fractile, FRACTILE_INIT);
+  assert.equal(s.cleanDays, 0);
+  assert.equal(s.activated, false);
+});
+
+test("foldQuotaState: cap-hits raise the fractile one notch (max P99)", () => {
+  const s = foldQuotaState(defaultQuotaState(), { capHits: 1, activated: true });
+  assert.equal(s.fractile, 0.99);
+  // a second hit stays clamped at P99
+  const s2 = foldQuotaState(defaultQuotaState(), { capHits: 2, activated: true });
+  assert.equal(s2.fractile, 0.99);
+  // from P90 a single hit climbs one rung
+  const s3 = foldQuotaState({ ...defaultQuotaState(), fractile: 0.9 }, { capHits: 1, activated: true });
+  assert.equal(s3.fractile, 0.95);
+});
+
+test("foldQuotaState: 30 clean days lower the fractile one notch (min P90)", () => {
+  const s = foldQuotaState(defaultQuotaState(), { earnedCleanDays: 30, activated: true });
+  assert.equal(s.fractile, 0.9);
+  assert.equal(s.cleanDays, 0); // streak reset after the notch
+  // 60 clean days still notch only once per fold
+  const s2 = foldQuotaState(defaultQuotaState(), { earnedCleanDays: 60, activated: true });
+  assert.equal(s2.fractile, 0.9);
+  // from 0.99 one clean month steps down to 0.95
+  const s3 = foldQuotaState({ ...defaultQuotaState(), fractile: 0.99 }, { earnedCleanDays: 30, activated: true });
+  assert.equal(s3.fractile, 0.95);
+});
+
+test("planReserve: pre-forecast fallback below 14 days uses max(observed, 60% window)", () => {
+  const plan = planReserve({ state: defaultQuotaState(), series: [0.1, 0.1, 0.1], remainingPct: 50 });
+  assert.equal(plan.mode, "fallback");
+  assert.equal(plan.activated, false);
+  assert.equal(plan.fractile, FRACTILE_INIT);
+  assert.equal(plan.reserve, 0.6); // max(0.1, 0.6)
+  assert.equal(plan.spendableFrac, 0); // remaining(0.5) < reserve(0.6) → floored at 0
+});
+
+test("planReserve: forecast mode above the gate; spendable = remaining − reserve", () => {
+  const series = Array(14).fill(0.1);
+  const plan = planReserve({
+    state: defaultQuotaState(),
+    series,
+    remainingPct: 90,
+    forecast: () => ({ mode: "forecast", value: 0.3, point: 0.25, sigma: 0.05 }),
+  });
+  assert.equal(plan.mode, "forecast");
+  assert.equal(plan.activated, true);
+  assert.ok(Math.abs(plan.reserve - 0.3) < 1e-9);
+  assert.ok(Math.abs(plan.spendableFrac - 0.6) < 1e-9);
+});
+
+test("planReserve: spendable floored at 0 when remaining < reserve", () => {
+  const plan = planReserve({
+    state: { ...defaultQuotaState(), activated: true },
+    series: Array(14).fill(0.1),
+    remainingPct: 20,
+    forecast: () => ({ mode: "forecast", value: 0.3 }),
+  });
+  assert.equal(plan.spendableFrac, 0);
+});
+
+test("planReserve: forecast that returns fallback still degrades to the fallback", () => {
+  const plan = planReserve({
+    state: { ...defaultQuotaState(), activated: true },
+    series: Array(14).fill(0.1),
+    remainingPct: 80,
+    forecast: () => ({ mode: "fallback", value: null }),
+  });
+  assert.equal(plan.mode, "fallback");
+  assert.equal(plan.reserve, 0.6);
+});
+
+test("computeSpendable: windowless/no-adapter routes to the $ bound (no reserve)", async () => {
+  const budget = createCtoBudget({ store: { load: async () => ({}), save: async () => {} }, cfg: () => ({ ctoNightCapUsd: 3 }) });
+  const plan = await budget.computeSpendable({ provider: "someone", windowed: false });
+  assert.equal(plan.mode, "windowless");
+  assert.equal(plan.windowed, false);
+  assert.equal(plan.spendable, null);
+  assert.equal(plan.reserve, 0);
+  assert.equal(plan.nightCapUsd, 3);
+});
+
+test("computeSpendable: windowed persists quota + attaches §14.5 ledger rows", async () => {
+  let saved = null;
+  const ledgerRows = [];
+  const store = {
+    load: async () => ({}),
+    save: async (p) => {
+      saved = p;
+    },
+  };
+  const budget = createCtoBudget({
+    store,
+    now: () => NOON,
+    history: async () => ({ "claude:session": [{ ts: NOON, pct: 10 }] }),
+    buildSeries: (obs, t) => ({ series: Array(14).fill(0.1), historyDays: 14, maxObserved: 0.1 }),
+    forecast: () => ({ mode: "forecast", value: 0.25, point: 0.2, sigma: 0.05 }),
+    mapeFn: () => 5,
+    ledger: { append: (r) => ledgerRows.push(r) },
+  });
+  const plan = await budget.computeSpendable({ provider: "claude", remainingPct: 80, windowed: true, capHitsSince: 1 });
+  assert.equal(plan.windowed, true);
+  assert.equal(plan.reserve, 0.25);
+  assert.ok(Math.abs(plan.spendableFrac - 0.55) < 1e-9); // 0.8 − 0.25
+  assert.equal(plan.fractile, 0.99); // capHitsSince 1 notched up
+  assert.equal(plan.mape14, 5);
+  // persisted quota row reflects the plan
+  assert.equal(saved.quota.claude.reserve, 0.25);
+  assert.equal(saved.quota.claude.activated, true);
+  // fractile change + reserve line both ledgered
+  const kinds = ledgerRows.map((r) => r.kind);
+  assert.ok(kinds.includes("cto.reserve.fractile"));
+  assert.ok(kinds.includes("cto.reserve"));
+  const fracRow = ledgerRows.find((r) => r.kind === "cto.reserve.fractile");
+  assert.equal(fracRow.from, 0.95);
+  assert.equal(fracRow.to, 0.99);
+});
+
+test("recordCapHit writes a cto.cap_hit ledger row", async () => {
+  const ledgerRows = [];
+  const budget = createCtoBudget({
+    store: { load: async () => ({}), save: async () => {} },
+    now: () => NOON,
+    ledger: { append: (r) => ledgerRows.push(r) },
+  });
+  await budget.recordCapHit({ provider: "claude", pct: 100 });
+  assert.equal(ledgerRows.length, 1);
+  assert.equal(ledgerRows[0].kind, "cto.cap_hit");
+  assert.equal(ledgerRows[0].provider, "claude");
+  assert.equal(ledgerRows[0].pct, 100);
 });

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -52,6 +52,7 @@ import {
   rollupsStore,
   inboxStore,
   verdictsStore,
+  watchersStore,
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
 import { createVerdictEngine } from "./ctoVerdicts.mjs";
@@ -96,6 +97,9 @@ import {
   isWorkShedInThrifty,
   tierAllows as budgetTierAllows,
 } from "./ctoBudget.mjs";
+// BET-1398 standing-query watchers (§4.3/§13.4): the event-driven watcher
+// engine hosted by the adaptive engine. Supersedes the old cto.json poller.
+import { createStandingQueryEngine } from "./ctoWatchers.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
@@ -317,6 +321,13 @@ export function createCtoEngine(deps = {}) {
     // thrifty when the cap is crossed. `tier` is the A12 dial (default low).
     budget = createCtoBudget(),
     tierGet = async () => "low",
+    // BET-1398 standing-query watchers (§4.3/§13.4): optional pre-built
+    // watcher engine (else one is constructed below from watchersStore/ledger/
+    // engineState/budget). `legacyWatchesLoader` is the one-time source for
+    // migrating the superseded cto.json poller watches (index.mjs wires the
+    // real loader; default none → no migration).
+    watchers = null,
+    legacyWatchesLoader = async () => [],
   } = deps;
 
   let disposed = false;
@@ -339,6 +350,7 @@ export function createCtoEngine(deps = {}) {
   let builtInBackfill = null;
   let profileDecayHandle = null;
   let verdictsEngine = null;
+  let watcherEngine = null;
 
   // A5 presence inputs (spec §5.4): lastSeen = max(desktop heartbeat, app
   // open, user prompt). The desktop heartbeat is read live via
@@ -469,6 +481,9 @@ export function createCtoEngine(deps = {}) {
         await finalizeRollups();
         // §6.2 blackboard: pump the per-project proposal queue (gatekeeper).
         await pumpFacts();
+        // §4.3/§13.4 standing-query watchers: windowed kinds + retirement, and
+        // auto-created watchers after a new day rollup lands.
+        await watcherTick();
       }
       // §10.6-4 cold-start backfill — also ambient, gated on enabled. Its own
       // drained state marker makes it run at most once per box.
@@ -892,6 +907,87 @@ export function createCtoEngine(deps = {}) {
     return verdictsEngine;
   }
 
+  // BET-1398 standing-query watchers (§4.3/§13.4): lazy single instance over
+  // the shared watchers store. Injected seams for usage-burn evaluation read
+  // today's ambient spend pace and the daily cap from the budget engine — the
+  // same sources the §13.3 watchdog consults — so a `usage-burn` watcher fires
+  // when the ambient burn is running hot relative to the cap fraction.
+  function getWatchers() {
+    if (watcherEngine) return watcherEngine;
+    watcherEngine = watchers ?? createStandingQueryEngine({
+      store: watchersStore,
+      ledger,
+      engineState,
+      now,
+      publish,
+      getSpendInWindow: async (windowMs) => {
+        const perHour =
+          budget && typeof budget.spendPerHourUsd === "function" ? await budget.spendPerHourUsd() : 0;
+        return perHour * (windowMs / HOUR_MS);
+      },
+      getCapUsd: async () => {
+        let cap = budgetAmbientCapUsd({});
+        try {
+          cap = budgetAmbientCapUsd((await configGet()) ?? {});
+        } catch {
+          /* keep default */
+        }
+        return cap;
+      },
+    });
+    return watcherEngine;
+  }
+
+  // Load the last `windowDays` (default 7, §13.4) day rollups so the watcher
+  // auto-creator can scan them for recurring themes. Reverse-chron, already
+  // oldest-first — the themes extractor filters by window start itself.
+  async function loadRecentDayRollups(windowDays = 7) {
+    const since = now() - windowDays * 24 * HOUR_MS;
+    let names = [];
+    try {
+      names = await fsp.readdir(rollupsStore.dirFor("day"));
+    } catch {
+      return [];
+    }
+    const out = [];
+    for (const name of names) {
+      if (!name.endsWith(".json")) continue;
+      let r;
+      try {
+        r = await rollupsStore.load("day", name.slice(0, -5));
+      } catch {
+        continue;
+      }
+      if (r && Array.isArray(r?.window) && typeof r.window[0] === "number" && r.window[0] >= since) {
+        out.push(r);
+      }
+    }
+    out.sort((a, b) => a.window[0] - b.window[0]);
+    return out;
+  }
+
+  // Watcher run growth per tick (enabled-gated, §13.4): evaluate the windowed
+  // kinds (usage-burn) + retirement, and after a new day rollup has landed run
+  // the auto-creation scan once per day (guarded by a day marker so it doesn't
+  // re-run every tick). Best-effort — never throws into the poller.
+  async function watcherTick() {
+    try {
+      await getWatchers().runTick();
+      const es = (await engineState.load()) ?? {};
+      const lastAutoDay = es?.watchers?.lastAutoDay ?? null;
+      const todayKey = budgetDayKey(now());
+      if (lastAutoDay === todayKey) return;
+      const dayRollups = await loadRecentDayRollups();
+      const result = await getWatchers().autoCreate(dayRollups);
+      await engineState.save({ ...es, watchers: { ...(es?.watchers || {}), lastAutoDay: todayKey } });
+      if (result.added.length > 0) {
+        await ledgerLog({ kind: "watcher.auto_created", count: result.added.length, signatures: result.added.map((a) => a.patternSignature) });
+      }
+    } catch {
+      /* watchers are best-effort — never take the engine down */
+    }
+  }
+
   // The facts sink (BET-1391 / §9.5): map verdict acceptance/rejection effects
   // on fact subjects back onto the fact sender's reliability counters — success
   // → confirmed, rejection → rejected. `open`/`expire` (importance/retention
@@ -1124,7 +1220,15 @@ export function createCtoEngine(deps = {}) {
           kind: row.kind,
           salience: row.salience,
           refs: row.refs,
+          ...(row.text ? { text: row.text } : {}),
         });
+        // §4.3/§13.4 standing-query watchers: evaluate the standing queries
+        // against this evidence event. Event-driven (NOT a poll loop); a match
+        // becomes a high-salience `watcher.hit` evidence event + B4 source.
+        // Fire-and-forget — a watcher must never break ingestion into the pump.
+        void getWatchers()
+          .evaluateEvent(row)
+          .catch(() => {});
       } catch {
         /* best-effort, never throw into the pump */
       }
@@ -1200,6 +1304,19 @@ export function createCtoEngine(deps = {}) {
     }
     // Load the persisted profile (§8.1) — deterministic, lazy, best-effort.
     void getProfile().init().catch(() => {});
+    // BET-1398: one-time migration of the superseded cto.json watcher poller's
+    // watches into the standing-query engine (idempotent — a marker in
+    // engine-state.json makes a re-deploy a no-op). Best-effort.
+    if (typeof legacyWatchesLoader === "function") {
+      void (async () => {
+        try {
+          const legacy = await legacyWatchesLoader();
+          await getWatchers().migrateLegacy(Array.isArray(legacy) ? legacy : []);
+        } catch {
+          /* best-effort */
+        }
+      })();
+    }
     startTimers();
     startCardTimer();
     // Publish the initial state once (fire-and-forget) so a subscriber that
@@ -1344,6 +1461,12 @@ export function createCtoEngine(deps = {}) {
     },
     get journal() {
       return getJournal();
+    },
+    // BET-1398 standing-query watchers: expose the engine's register/unregister/
+    // list so the on-call CTO read gateway re-points its watch/unwatch/
+    // list_watches verbs here (same confirm-mode contract for `watch`).
+    get watchers() {
+      return getWatchers();
     },
     get cards() {
       return cards;

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -53,6 +53,7 @@ import {
   inboxStore,
   verdictsStore,
   watchersStore,
+  factsArchiveStore,
   purgeExpiredInbox,
 } from "./ctoStores.mjs";
 import { createVerdictEngine } from "./ctoVerdicts.mjs";
@@ -99,7 +100,7 @@ import {
 } from "./ctoBudget.mjs";
 // BET-1398 standing-query watchers (§4.3/§13.4): the event-driven watcher
 // engine hosted by the adaptive engine. Supersedes the old cto.json poller.
-import { createStandingQueryEngine } from "./ctoWatchers.mjs";
+import { createStandingQueryEngine, extractSignifiers, patternSignatureFor } from "./ctoWatchers.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
@@ -966,13 +967,46 @@ export function createCtoEngine(deps = {}) {
     return out;
   }
 
+  // §13.4 "or the underlying fact archived": collect the normalized patterns of
+  // superseded/archived facts so a watcher whose theme is archived retires.
+  // Best-effort — an unreadable archive yields no signatures.
+  async function archivedWatcherSignatures() {
+    const out = new Set();
+    try {
+      const dir = factsArchiveStore.dir;
+      let names = [];
+      if (typeof dir === "string" && dir) {
+        names = (await fsp.readdir(dir).catch(() => [])) ?? [];
+      }
+      for (const name of names) {
+        const project = String(name).endsWith(".json") ? String(name).slice(0, -5) : String(name);
+        let p;
+        try {
+          p = await factsArchiveStore.load(project);
+        } catch {
+          continue;
+        }
+        for (const f of Array.isArray(p?.entries) ? p.entries : []) {
+          for (const sig of extractSignifiers(f?.statement)) {
+            const norm = patternSignatureFor(sig);
+            if (norm) out.add(norm);
+          }
+        }
+      }
+    } catch {
+      /* best-effort */
+    }
+    return [...out];
+  }
+
   // Watcher run growth per tick (enabled-gated, §13.4): evaluate the windowed
   // kinds (usage-burn) + retirement, and after a new day rollup has landed run
   // the auto-creation scan once per day (guarded by a day marker so it doesn't
   // re-run every tick). Best-effort — never throws into the poller.
   async function watcherTick() {
     try {
-      await getWatchers().runTick();
+      const archivedSig = await archivedWatcherSignatures();
+      await getWatchers().runTick({ archivedSignatures: archivedSig });
       const es = (await engineState.load()) ?? {};
       const lastAutoDay = es?.watchers?.lastAutoDay ?? null;
       const todayKey = budgetDayKey(now());

--- a/src/server/ctoEvidence.mjs
+++ b/src/server/ctoEvidence.mjs
@@ -141,6 +141,32 @@ export function classifyEvent(evt) {
   return null;
 }
 
+// Best-effort free-text hint for an evidence row (BET-1398). The A5 stream is
+// primarily structured (`kind`), but the standing-query engine's
+// `event-pattern` predicate matches "evidence text" too — pull a snippet from
+// the raw event when it has one (error messages, permission texts, part text).
+// Never fabricates; returns undefined when the event carries no readable text.
+export function evidenceText(evt) {
+  if (!evt || typeof evt !== "object") return undefined;
+  for (const key of ["message", "error", "title", "text"]) {
+    const v = evt[key];
+    if (typeof v === "string" && v.trim()) return v.slice(0, 512);
+  }
+  const props = evt.properties;
+  if (props && typeof props === "object") {
+    for (const key of ["message", "error", "level", "title", "text"]) {
+      const v = props[key];
+      if (typeof v === "string" && v.trim()) return v.slice(0, 512);
+      if (v && typeof v === "object" && typeof v.message === "string" && v.message.trim()) {
+        return v.message.slice(0, 512);
+      }
+    }
+  }
+  const text = evt.text;
+  if (typeof text === "string" && text.trim()) return text.slice(0, 512);
+  return undefined;
+}
+
 // Full evidence-row normalization: applies the pipeline-scope rule (cto-owned
 // → null) then classifies. Pure — `now` injected for determinism.
 export function normalizeEvidence(
@@ -157,5 +183,6 @@ export function normalizeEvidence(
     kind: classified.kind,
     salience: classified.salience,
     refs: classified.refs ?? [],
+    text: evidenceText(evt),
   };
 }

--- a/src/server/ctoEvidence.mjs
+++ b/src/server/ctoEvidence.mjs
@@ -176,6 +176,7 @@ export function normalizeEvidence(
   if (!isPipelineSession(owner)) return null;
   const classified = classifyEvent(evt);
   if (!classified) return null;
+  const text = evidenceText(evt);
   return {
     ts: now,
     sessionID: classified.sessionID || undefined,
@@ -183,6 +184,9 @@ export function normalizeEvidence(
     kind: classified.kind,
     salience: classified.salience,
     refs: classified.refs ?? [],
-    text: evidenceText(evt),
+    // Best-effort free-text hint (BET-1398) for latent watcher matching.
+    // Omitted when the event carries no readable text so existing rows stay
+    // shape-identical.
+    ...(text ? { text } : {}),
   };
 }

--- a/src/server/ctoForecast.mjs
+++ b/src/server/ctoForecast.mjs
@@ -1,0 +1,288 @@
+// src/server/ctoForecast.mjs
+// BET-1400 — the CTO's usage forecasting math (spec §11.2, §11.3, §14.5).
+// Pure: no I/O, no imports from the live box. All inputs are injected.
+//
+// WHAT LIVES HERE (per the issue's "Files": ctoForecast.mjs = pure math +
+// injected history):
+//   - dailyUsageFractions      pct observations -> per-day usage as a fraction
+//                              of the plan window (Option A, §11.3 — see below).
+//   - holtWinters              additive Holt-Winters with damped trend and
+//                              weekly seasonality (m=7) over a daily series.
+//   - sampleStd / mape         residual scatter + forecast accuracy (§14.5).
+//   - quantileForecast         newsvendor fractile from residual sigma.
+//   - forecastNextDayFraction  the small exported "reserve" math: hand a
+//                              trailing daily series + a fractile, get the
+//                              next-day point/quantile forecast or the
+//                              pre-forecast fallback.
+//   - trailingDailySeries      builds the contiguous rolling-8-week daily
+//                              series a forecast consumes, from observations.
+//
+// RESERVE UNITS (the BET-1400 blocker, resolved to Option A): reserve and
+// spendable live in FRACTION-OF-WINDOW space, and the demand series comes from
+// the box's existing per-provider pct observation history
+// (`usage.mjs` → `statePath("usage-history.json")`, BET-1336), NOT from the
+// model ledger. The windowed adapters (claude/codex/kimi) only report a
+// fraction of the plan window (claude/codex: pct only; kimi: used/limit request
+// counts) — they expose no window capacity in token/$ units, so a reserve
+// expressed in ledger units could never be compared to `remaining`. Working in
+// fraction-of-window space makes every formula in §11.3 coherent
+// (`reserve = max(observed daily max, 60% of window)` meaningful, `remaining −
+// reserve` comparable) with zero invented capacity. The pct history *is* a
+// usage history, so this does not stretch §11.3's "usage ledger".
+//
+// CLEAN-DAY / CAP-HIT DEFINITIONS (also resolved by the BET-1400 blocker): a
+// cap-hit = the user's provider plan window is exhausted (an adapter snapshot
+// reports a window at/over its limit, `pct >= 100`). A clean day = no cap-hit
+// AND no forecast-exceeding spend that day. Both are recorded as §14.5 ledger
+// rows and consumed by the notch state machine in ctoBudget.mjs.
+
+import { dayKey } from "../shared/timeBuckets.mjs";
+
+// Standard normal Z for the newsvendor fractiles §11.3 names. The fractile
+// ladder is P90 / P95 / P99; the Z values let `quantileForecast` translate
+// residual sigma into the forecast at a given fractile.
+export const QUANTILE_Z = Object.freeze({
+  0.9: 1.2815515655446004,
+  0.95: 1.6448536269514722,
+  0.99: 2.3263478740408408,
+});
+
+/** Rolling look-back for the daily series — 8 weeks (56 days), per §11.3. */
+export const FORECAST_LOOKBACK_DAYS = 56;
+
+function clamp01(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : 0;
+}
+
+/** Sample standard deviation; 0 for < 2 samples. */
+export function sampleStd(values) {
+  if (!Array.isArray(values) || values.length < 2) return 0;
+  const xs = values.filter(Number.isFinite);
+  if (xs.length < 2) return 0;
+  const mean = xs.reduce((a, b) => a + b, 0) / xs.length;
+  const ss = xs.reduce((a, b) => a + (b - mean) * (b - mean), 0);
+  return Math.sqrt(ss / (xs.length - 1));
+}
+
+/** Mean absolute percentage error (×100, i.e. "%"). null for < 2 non-zero
+ *  actuals — a MAPE with one or zero samples is noise, not signal (§10.5 never
+ *  shows noise). Zero actuals are skipped (division undefined). */
+export function mape(actual, forecast) {
+  if (!Array.isArray(actual) || !Array.isArray(forecast)) return null;
+  let sum = 0;
+  let n = 0;
+  const len = Math.min(actual.length, forecast.length);
+  for (let i = 0; i < len; i++) {
+    const a = actual[i];
+    const f = forecast[i];
+    if (!Number.isFinite(a) || !Number.isFinite(f) || a === 0) continue;
+    sum += Math.abs((a - f) / a);
+    n += 1;
+  }
+  return n >= 2 ? (sum / n) * 100 : null;
+}
+
+/**
+ * Daily usage (fraction of the window) from raw pct observations (BET-1336
+ * history rows: `[{ts, pct}]`, any order). `pct` is 0-100; a day's usage is the
+ * shared fraction of the window consumed that day, attributed to the local day
+ * of each observation:
+ *
+ *   usage += max(0, pct[t] − pct[t−1]) / 100     (per observation, same window)
+ *
+ * A positive delta accumulates consumption within one window cycle; a window
+ * RESET shows as a pct DROP, whose negative delta contributes 0 (a reset never
+ * "frees" usage), and the fresh cycle then accumulates from its lower baseline —
+ * so a mid-day reset correctly keeps BOTH the old cycle's consumption and the
+ * new cycle's, and the day total never exceeds 1.0. This is the Option-A
+ * "pct delta across a local day within one window cycle".
+ * @param {Array<{ts:number, pct:number}>} observations
+ * @returns {Array<{day:string, usage:number}>} oldest→newest, one per day that
+ *          consumed anything.
+ */
+export function dailyUsageFractions(observations) {
+  const obs = (Array.isArray(observations) ? observations : [])
+    .filter((o) => o && typeof o.ts === "number" && Number.isFinite(o.ts) && Number.isFinite(o.pct))
+    .sort((a, b) => a.ts - b.ts);
+  const byDay = new Map();
+  let prev = null;
+  for (const cur of obs) {
+    const day = dayKey(cur.ts);
+    const delta = prev == null ? 0 : (cur.pct - prev.pct) / 100;
+    if (delta > 0) {
+      byDay.set(day, clamp01((byDay.get(day) ?? 0) + delta));
+    }
+    prev = cur;
+  }
+  return [...byDay.entries()]
+    .map(([day, usage]) => ({ day, usage }))
+    .sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0));
+}
+
+/**
+ * Build the contiguous, oldest→newest trailing daily series a forecast consumes
+ * over the last `days` completed local days (today is partial — excluded, since
+ * we forecast from *completed* days). Days with no data are 0 (no usage then).
+ * Also returns `historyDays` (distinct days with usage > 0) — the §11.3
+ * activation gate ("≥ 14 days") — and `maxObserved` (the §11.3 fallback's
+ * "observed daily max").
+ * @param {Array<{day:string, usage:number}>} daily  from dailyUsageFractions
+ * @param {{now:number, days?:number}} [opts]
+ */
+export function trailingDailySeries(daily, { now, days = FORECAST_LOOKBACK_DAYS } = {}) {
+  const t = typeof now === "number" && Number.isFinite(now) ? now : Date.now();
+  const count = Math.max(1, Math.floor(days) || 1);
+  const map = new Map((Array.isArray(daily) ? daily : []).map((d) => [d.day, d.usage]));
+  const series = [];
+  const todayKey = dayKey(t);
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(t);
+    d.setDate(d.getDate() - (i + 1));
+    const k = dayKey(d.getTime());
+    series.push(clamp01(map.get(k) ?? 0));
+  }
+  let historyDays = 0;
+  let maxObserved = 0;
+  for (const v of series) {
+    if (v > 0) historyDays += 1;
+    if (v > maxObserved) maxObserved = v;
+  }
+  return { series, historyDays, maxObserved };
+}
+
+/**
+ * Additive Holt-Winters with damped trend and weekly seasonality (m=7), the
+ * three §-standard recursions run directly:
+ *
+ *   Forecast next:   F_{t+1} = L_t + φ·b_t + S_{t−m+1}          (position t mod m)
+ *   Level:           L_t = α(y_t − S_{t−m}) + (1−α)(L_{t−1} + φ·b_{t−1})
+ *   Trend:           b_t = β(L_t − L_{t−1}) + (1−β)·φ·b_{t−1}
+ *   Seasonal:        S_t = γ(y_t − L_t) + (1−γ)·S_{t−m}
+ *
+ * with φ the trend damper (0.9 default). Initialization uses two full seasons:
+ * level = mean of the first season, trend = (2nd-season mean − 1st-season mean)/
+ * m, and each seasonal index = the mean of (y − that week's mean) over the
+ * weeks available (a detrended additive seasonal). Requires ≥ 2m samples;
+ * otherwise returns `{ok:false, reason:"insufficient"}` and the caller uses the
+ * §11.3 pre-forecast fallback (not enough history forecloses a seasonal fit).
+ *
+ * `sigma` is the sample std of the in-sample one-step residuals from the second
+ * season onward (the first season absorbs the init transient — its residuals
+ * are noise, not signal).
+ *
+ * @param {{series:number[], m?:number, alpha?:number, beta?:number,
+ *          gamma?:number, phi?:number}} opts
+ */
+export function holtWinters({ series, m = 7, alpha = 0.1, beta = 0.05, gamma = 0.2, phi = 0.9 }) {
+  const y = Array.isArray(series) ? series : [];
+  const n = y.length;
+  if (n < 2 * m) return { ok: false, reason: "insufficient", n };
+  if (!y.every((v) => Number.isFinite(v))) return { ok: false, reason: "non-finite", n };
+  const period = Math.max(1, Math.floor(m));
+  const a = Math.max(0, Math.min(1, alpha));
+  const be = Math.max(0, Math.min(1, beta));
+  const g = Math.max(0, Math.min(1, gamma));
+  const p = Math.max(0, Math.min(1, phi));
+
+  const meanRange = (lo, hi) => {
+    let s = 0;
+    for (let i = lo; i < hi; i++) s += y[i];
+    return s / (hi - lo);
+  };
+  const weeks = Math.max(1, Math.floor(n / period));
+  const weekBase = [];
+  for (let w = 0; w < weeks; w++) weekBase.push(meanRange(w * period, Math.min(w * period + period, n)));
+  const baseLevel = meanRange(0, period);
+  const initTrend = (meanRange(period, Math.min(2 * period, n)) - baseLevel) / period;
+  const S = new Array(period).fill(0);
+  for (let j = 0; j < period; j++) {
+    let s = 0;
+    let c = 0;
+    for (let w = 0; w < weeks; w++) {
+      const idx = w * period + j;
+      if (idx < n) {
+        s += y[idx] - weekBase[w];
+        c += 1;
+      }
+    }
+    S[j] = c ? s / c : 0;
+  }
+
+  let Lprev = baseLevel;
+  let bprev = initTrend;
+  const fitted = new Array(n).fill(NaN);
+  const residuals = new Array(n).fill(NaN);
+  for (let t = 0; t < n; t++) {
+    const pos = ((t % period) + period) % period;
+    const yhat = Lprev + p * bprev + S[pos];
+    fitted[t] = yhat;
+    const res = y[t] - yhat;
+    residuals[t] = res;
+    const Lt = a * (y[t] - S[pos]) + (1 - a) * (Lprev + p * bprev);
+    const bt = be * (Lt - Lprev) + (1 - be) * p * bprev;
+    S[pos] = g * (y[t] - Lt) + (1 - g) * S[pos];
+    Lprev = Lt;
+    bprev = bt;
+  }
+  const sigma = sampleStd(residuals.slice(period));
+  const posNext = ((n % period) + period) % period;
+  const forecast = Lprev + p * bprev + S[posNext];
+  return {
+    ok: true,
+    n,
+    level: Lprev,
+    trend: bprev,
+    seasonal: S,
+    fitted,
+    residuals,
+    sigma,
+    forecast,
+  };
+}
+
+/**
+ * Newsvendor quantile from a point forecast + residual sigma: `point + z_p·σ`.
+ * Z defaults to P95 when `p` is not on the ladder.
+ */
+export function quantileForecast(point, sigma, p = 0.95) {
+  const z = QUANTILE_Z[p];
+  const s = Number.isFinite(sigma) ? sigma : 0;
+  return (Number.isFinite(point) ? point : 0) + (z !== undefined ? z * s : 0);
+}
+
+/**
+ * The §11.3 reserve for one provider, given a contiguous trailing daily
+ * fraction series and the active fractile. Below the HW minimum (2 seasons) it
+ * returns the pre-forecast fallback — `{mode:'fallback', value:null}` — and the
+ * caller applies `reserve = max(observed daily max, 60% of window)` (§11.3;
+ * the fallback is not a fractile and never notches). Otherwise it returns the
+ * fractile quantile of next-day demand in fraction-of-window units.
+ *
+ * @param {{series:number[], fractile?:number, m?:number, params?:object}} opts
+ */
+export function forecastNextDayFraction({ series, fractile = 0.95, m = 7, params } = {}) {
+  const out = holtWinters({ series, m, ...(params ?? {}) });
+  if (!out.ok) {
+    return { mode: "fallback", reason: out.reason, value: null, fractile, n: out.n };
+  }
+  const value = clamp01(quantileForecast(out.forecast, out.sigma, fractile));
+  return { mode: "forecast", value, fractile, point: out.forecast, sigma: out.sigma, n: out.n };
+}
+
+/** MAPE (%) of the HW fit over the trailing `tailDays` of a daily series —
+ *  the §14.5 "forecast accuracy (MAPE 14d)" figure. null when insufficient. */
+export function forecastMape({ series, m = 7, params, tailDays = 14 } = {}) {
+  const out = holtWinters({ series, m, ...(params ?? {}) });
+  if (!out.ok) return null;
+  const n = out.n;
+  const from = Math.max(0, n - Math.max(1, Math.floor(tailDays) || 1));
+  const act = [];
+  const f = [];
+  for (let i = from; i < n; i++) {
+    if (!Number.isFinite(out.fitted[i])) continue;
+    act.push(series[i]);
+    f.push(out.fitted[i]);
+  }
+  return mape(act, f);
+}

--- a/src/server/ctoForecast.test.mjs
+++ b/src/server/ctoForecast.test.mjs
@@ -1,0 +1,142 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FORECAST_LOOKBACK_DAYS,
+  QUANTILE_Z,
+  dailyUsageFractions,
+  forecastMape,
+  forecastNextDayFraction,
+  holtWinters,
+  mape,
+  quantileForecast,
+  sampleStd,
+  trailingDailySeries,
+} from "./ctoForecast.mjs";
+import { dayKey } from "../shared/timeBuckets.mjs";
+
+// A deterministic local-midnight baseline for series/day tests.
+function dayStart(offsetDays = 0) {
+  const d = new Date(2026, 7, 28, 0, 0, 0, 0);
+  d.setDate(d.getDate() + offsetDays);
+  return d.getTime();
+}
+const D0 = dayStart(0);
+const D1 = dayStart(1);
+
+test("sampleStd: known sample std (2.138) and guards", () => {
+  assert.ok(Math.abs(sampleStd([2, 4, 4, 4, 5, 5, 7, 9]) - 2.138) < 0.001);
+  assert.equal(sampleStd([]), 0);
+  assert.equal(sampleStd([5]), 0);
+});
+
+test("mape: percent error over non-zero actuals; null when < 2 usable", () => {
+  assert.ok(Math.abs(mape([100, 200], [110, 180]) - 10) < 1e-9);
+  assert.equal(mape([100], [110]), null);
+  assert.equal(mape([0, 0], [0, 0]), null);
+  assert.equal(mape([1], [2]), null);
+});
+
+test("quantileForecast: point + z_p * sigma at the §11.3 fractiles", () => {
+  assert.ok(Math.abs(quantileForecast(10, 2, 0.95) - (10 + QUANTILE_Z[0.95] * 2)) < 1e-9);
+  assert.ok(Math.abs(quantileForecast(10, 2, 0.9) - (10 + QUANTILE_Z[0.9] * 2)) < 1e-9);
+  assert.ok(Math.abs(quantileForecast(10, 2, 0.99) - (10 + QUANTILE_Z[0.99] * 2)) < 1e-9);
+  assert.equal(quantileForecast(10, undefined, 0.95), 10);
+});
+
+test("dailyUsageFractions: window reset + cross-day attribution (hand fixture)", () => {
+  // Same local day, window resets mid-day: usage = old-cycle share + new-cycle share.
+  const obs = [
+    { ts: D0 + 10, pct: 20 },
+    { ts: D0 + 12, pct: 45 }, // +0.25
+    { ts: D0 + 14, pct: 5 }, // reset: -0.40 -> 0
+    { ts: D0 + 16, pct: 30 }, // +0.25
+  ];
+  const days = dailyUsageFractions(obs);
+  assert.equal(days.length, 1);
+  assert.equal(days[0].day, dayKey(D0));
+  assert.ok(Math.abs(days[0].usage - 0.5) < 1e-9);
+
+  // Cross-midnight: a delta between a late obs on D0 and an early obs on D1 is
+  // attributed to D1 (the day of the later observation).
+  const cross = dailyUsageFractions([
+    { ts: D0 + 23 * 3_600_000, pct: 40 },
+    { ts: D1 + 3_600_000, pct: 52 },
+  ]);
+  assert.equal(cross.length, 1);
+  assert.equal(cross[0].day, dayKey(D1));
+  assert.ok(Math.abs(cross[0].usage - 0.12) < 1e-9);
+});
+
+test("dailyUsageFractions: day total accumulates correctly (hand values)", () => {
+  // 10 -> 95 = +0.85; 95 -> 100 = +0.05; total 0.90 (no clamp needed).
+  const d = dailyUsageFractions([
+    { ts: D0 + 1, pct: 10 },
+    { ts: D0 + 2, pct: 95 },
+    { ts: D0 + 3, pct: 100 },
+  ]);
+  assert.equal(d[0].day, dayKey(D0));
+  assert.ok(Math.abs(d[0].usage - 0.9) < 1e-9);
+});
+
+test("trailingDailySeries: contiguous lookback excludes today, zero-fills", () => {
+  const daily = [{ day: dayKey(D0), usage: 0.4 }];
+  const { series, historyDays, maxObserved } = trailingDailySeries(daily, { now: D1, days: 4 });
+  // 4 trailing days ending at the day before D1: D0 and the 3 days before it.
+  assert.equal(series.length, 4);
+  assert.ok(Math.abs(series[3] - 0.4) < 1e-9); // D0 is the most recent trailing day
+  assert.equal(historyDays, 1);
+  assert.ok(Math.abs(maxObserved - 0.4) < 1e-9);
+  series.slice(0, 3).forEach((v) => assert.equal(v, 0)); // earlier days zero-filled
+});
+
+test("trailingDailySeries: default lookback is 8 weeks", () => {
+  const { series } = trailingDailySeries([], { now: D0 });
+  assert.equal(series.length, FORECAST_LOOKBACK_DAYS);
+});
+
+test("holtWinters: constant series fits exactly (hand fixture, m=2)", () => {
+  const out = holtWinters({ series: [0.1, 0.1, 0.1, 0.1], m: 2, alpha: 0.1, beta: 0.05, gamma: 0.2, phi: 0.9 });
+  assert.equal(out.ok, true);
+  out.fitted.forEach((f) => assert.ok(Math.abs(f - 0.1) < 1e-12));
+  assert.equal(out.sigma, 0);
+  assert.ok(Math.abs(out.forecast - 0.1) < 1e-12);
+});
+
+test("holtWinters: damped-trend ramp matches hand-computed first steps", () => {
+  // series [0.1,0.1,0.2,0.2], m=2: initLevel=0.1, initTrend=0.05,
+  // seasonal=[0,0]. Step t=0 uses S[0]=0:
+  //   yhat0 = 0.1 + 0.9*0.05 = 0.145
+  //   L0    = 0.1*(0.1) + 0.9*(0.1+0.9*0.05) = 0.01 + 0.9*0.145 = 0.1405
+  //   b0    = 0.05*(0.1405-0.1) + 0.95*0.9*0.05 = 0.002025 + 0.04275 = 0.044775
+  //   S0    = 0.2*(0.1-0.1405) + 0.8*0 = -0.0081
+  // Full pass ends (hand-computed through t=3) at final level ≈ 0.238247 —
+  // the code matches the recursion through all four points.
+  const out = holtWinters({ series: [0.1, 0.1, 0.2, 0.2], m: 2, alpha: 0.1, beta: 0.05, gamma: 0.2, phi: 0.9 });
+  assert.equal(out.ok, true);
+  assert.ok(Math.abs(out.fitted[0] - 0.145) < 1e-9);
+  assert.ok(Math.abs(out.fitted[1] - 0.1807975) < 1e-6, `fitted1 ${out.fitted[1]}`);
+  assert.ok(Math.abs(out.level - 0.23824735998443758) < 1e-6, `level ${out.level}`);
+  assert.ok(Math.abs(out.seasonal[0] - -0.008193944025000014) < 1e-6, `seasonal0 ${out.seasonal[0]}`);
+});
+
+test("holtWinters: requires two full seasons (activation gate plumbing)", () => {
+  assert.equal(holtWinters({ series: [0.1, 0.1, 0.1], m: 2 }).ok, false);
+  assert.equal(holtWinters({ series: [0.1, 0.1, 0.1, 0.1], m: 2 }).ok, true);
+});
+
+test("forecastNextDayFraction: fallback below 2 seasons, forecast above", () => {
+  const fb = forecastNextDayFraction({ series: [0.1, 0.1, 0.1], m: 2, fractile: 0.95 });
+  assert.equal(fb.mode, "fallback");
+  assert.equal(fb.value, null);
+
+  const fc = forecastNextDayFraction({ series: [0.1, 0.1, 0.1, 0.1], m: 2, fractile: 0.95 });
+  assert.equal(fc.mode, "forecast");
+  assert.ok(Math.abs(fc.value - 0.1) < 1e-9);
+  assert.equal(fc.fractile, 0.95);
+});
+
+test("forecastMape: null below two seasons, number above with scatter", () => {
+  assert.equal(forecastMape({ series: [0.1, 0.1, 0.1], m: 2 }), null);
+  // Constant series fits exactly -> 0% MAPE.
+  assert.equal(forecastMape({ series: [0.1, 0.1, 0.1, 0.1], m: 2 }), 0);
+});

--- a/src/server/ctoHealth.mjs
+++ b/src/server/ctoHealth.mjs
@@ -24,6 +24,9 @@ export const HEALTH_STAT_MIN = Object.freeze({
   digestOpens: 7,
   pipelineLag: 7,
   suggestionAcceptance: 10,
+  forecastAccuracy: 1,
+  capHitsCaused: 1,
+  reserveFractile: 1,
 });
 
 function medianOf(values) {
@@ -177,6 +180,51 @@ export async function computeHealthStats({
       decided >= HEALTH_STAT_MIN.suggestionAcceptance
         ? `${Math.round(acceptRate * 100)}% accepted`
         : null,
+  });
+
+  // 5. Forecast accuracy (MAPE 14d, §14.5) — the best available cached
+  //    per-provider 14-day MAPE from the budget's quota/forecast cache
+  //    (BET-1400 recomputes each provider's MAPE on every quota evaluation).
+  //    The first quota row carrying a numeric MAPE speaks for the box.
+  let quota = null;
+  try {
+    quota = (await budgetRead())?.quota ?? null;
+  } catch {
+    quota = null;
+  }
+  const quotaRows = quota && typeof quota === "object" ? Object.values(quota) : [];
+  const withMape = quotaRows.find((q) => typeof q?.mape14 === "number" && Number.isFinite(q.mape14));
+  stats.push({
+    id: "forecastAccuracy",
+    label: "Forecast accuracy · MAPE 14d",
+    min: HEALTH_STAT_MIN.forecastAccuracy,
+    n: withMape ? 1 : 0,
+    value: withMape ? `${withMape.mape14.toFixed(1)}%` : null,
+  });
+
+  // 6. Cap-hits caused (30d, §14.5) — count of `cto.cap_hit` §14.5 ledger rows
+  //    (the user's plan window exhausted) in the last 30 days.
+  const capCutoff = t - 30 * DAY_MS;
+  const capHits = rows.filter((r) => r?.kind === "cto.cap_hit" && typeof r?.ts === "number" && r.ts >= capCutoff).length;
+  stats.push({
+    id: "capHitsCaused",
+    label: "Cap-hits caused · 30d",
+    min: HEALTH_STAT_MIN.capHitsCaused,
+    n: capHits,
+    value: capHits >= HEALTH_STAT_MIN.capHitsCaused ? `${capHits} window(s) hit` : null,
+  });
+
+  // 7. Reserve fractile (§11.3) — the current per-provider fractile, for the
+  //    Tonight's-budget reserve line (§10.5-3). The fractile *history* is
+  //    ledgered (§14.5); this row is the live value for the gauge.
+  const withFractile = quotaRows.find((q) => typeof q?.fractile === "number");
+  const fractileLabel = withFractile != null ? `P${Math.round(withFractile.fractile * 100)}` : null;
+  stats.push({
+    id: "reserveFractile",
+    label: "Reserve fractile",
+    min: HEALTH_STAT_MIN.reserveFractile,
+    n: withFractile ? 1 : 0,
+    value: withFractile && fractileLabel ? `${fractileLabel} · ${withFractile.provider ?? "provider"}` : null,
   });
 
   return { stats, generatedAt: t };

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -178,3 +178,35 @@ test("suggestion acceptance: verdicts older than 30d are excluded", async () => 
   const s = stats.find((x) => x.id === "suggestionAcceptance");
   assert.equal(s.n, 10);
 });
+
+test("BET-1400: forecast accuracy row reflects the cached quota MAPE", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    budgetRead: async () => ({ quota: { claude: { provider: "claude", mape14: 12.4, fractile: 0.95 } } }),
+  });
+  const f = stats.find((s) => s.id === "forecastAccuracy");
+  assert.equal(f.value, "12.4%");
+  assert.equal(f.n, 1);
+  // no quota row with a numeric MAPE -> collecting
+  const { stats: empty } = await computeHealthStats({ now: () => NOW, budgetRead: async () => ({ quota: {} }) });
+  assert.equal(empty.find((s) => s.id === "forecastAccuracy").n, 0);
+});
+
+test("BET-1400: cap-hits-caused counts §14.5 rows in the last 30 days only", async () => {
+  const capAt = (offsetDays) => ({ kind: "cto.cap_hit", ts: NOW - offsetDays * DAY });
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    ledgerRead: async () => [capAt(1), capAt(5), capAt(45)],
+  });
+  const c = stats.find((s) => s.id === "capHitsCaused");
+  assert.equal(c.value, "2 window(s) hit"); // 45 days ago excluded
+});
+
+test("BET-1400: reserve fractile row surfaces the primary quota fractile", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    budgetRead: async () => ({ quota: { claude: { provider: "claude", fractile: 0.99 } } }),
+  });
+  const r = stats.find((s) => s.id === "reserveFractile");
+  assert.equal(r.value, "P99 · claude");
+});

--- a/src/server/ctoInbound.test.mjs
+++ b/src/server/ctoInbound.test.mjs
@@ -178,15 +178,39 @@ function makeEngine(overrides = {}) {
 // Gate that reports confirm only for `watch` (the confirm-mode tool).
 const gate = (name) => (name === "watch" ? "confirm" : "allow");
 
+// BET-1398: the read gateway's watch verbs proxy to the standing-query engine
+// registry via the injected `watchers` seam. A small in-memory fake stands in
+// for the adaptive engine's persistent registry in these gate tests.
+function makeWatcherSeam(store) {
+  return {
+    register: async (input) => {
+      const watch = {
+        id: "w" + (store.length + 1),
+        ...input,
+        created: 1,
+        lastHit: null,
+        hits: 0,
+        retired: false,
+      };
+      store.push(watch);
+      return { ok: true, data: { watch } };
+    },
+    unregister: async (id) => {
+      const i = store.findIndex((w) => w.id === id);
+      if (i === -1) return { ok: true, data: { removed: false } };
+      store.splice(i, 1);
+      return { ok: true, data: { removed: true } };
+    },
+    list: async () => store,
+  };
+}
+
+const WATCH_ARGS = { kind: "event-pattern", pattern: "P0" };
+
 test("untrusted confirm-mode tool returns needConfirmation + preview and does NOT act", async () => {
   const watchers = [];
-  const engine = makeEngine({
-    loadWatches: async () => watchers,
-    saveWatches: async (w) => {
-      watchers.splice(0, watchers.length, ...w);
-    },
-  });
-  const res = await engine.dispatch("watch", { surface: "multica", query: "q", condition: "a P0 opens" }, { gate });
+  const engine = makeEngine({ watchers: makeWatcherSeam(watchers) });
+  const res = await engine.dispatch("watch", WATCH_ARGS, { gate });
   assert.equal(res.ok, true);
   assert.equal(res.needConfirmation, true);
   assert.equal(res.tool, "watch");
@@ -197,55 +221,34 @@ test("untrusted confirm-mode tool returns needConfirmation + preview and does NO
 
 test("a trusted action in trustedActions runs without confirmation", async () => {
   const watchers = [];
-  const engine = makeEngine({
-    loadWatches: async () => watchers,
-    saveWatches: async (w) => {
-      watchers.splice(0, watchers.length, ...w);
-    },
-  });
-  const res = await engine.dispatch(
-    "watch",
-    { surface: "multica", query: "q", condition: "a P0 opens" },
-    { gate, trustedActions: ["watch"] },
-  );
+  const engine = makeEngine({ watchers: makeWatcherSeam(watchers) });
+  const res = await engine.dispatch("watch", WATCH_ARGS, { gate, trustedActions: ["watch"] });
   assert.equal(res.ok, true);
   assert.equal(res.needConfirmation, undefined);
   assert.equal(watchers.length, 1);
-  assert.equal(watchers[0].surface, "multica");
+  assert.equal(watchers[0].predicate.kind, "event-pattern");
 });
 
 test("text loop: approveConfirm(id) then re-dispatch of the same tool+args runs it", async () => {
   const watchers = [];
-  const engine = makeEngine({
-    loadWatches: async () => watchers,
-    saveWatches: async (w) => {
-      watchers.splice(0, watchers.length, ...w);
-    },
-  });
-  const args = { surface: "multica", query: "q", condition: "a P0 opens" };
-  const first = await engine.dispatch("watch", args, { gate });
+  const engine = makeEngine({ watchers: makeWatcherSeam(watchers) });
+  const first = await engine.dispatch("watch", WATCH_ARGS, { gate });
   assert.equal(first.needConfirmation, true);
   assert.equal(watchers.length, 0);
   // user says "go ahead"
   assert.equal(engine.approveConfirm(first.id), true);
-  const second = await engine.dispatch("watch", args, { gate });
+  const second = await engine.dispatch("watch", WATCH_ARGS, { gate });
   assert.equal(second.needConfirmation, undefined);
   assert.equal(watchers.length, 1);
 });
 
 test("text loop: rejectConfirm(id) aborts and the tool stays blocked until approved again", async () => {
   const watchers = [];
-  const engine = makeEngine({
-    loadWatches: async () => watchers,
-    saveWatches: async (w) => {
-      watchers.splice(0, watchers.length, ...w);
-    },
-  });
-  const args = { surface: "multica", query: "q", condition: "a P0 opens" };
-  const first = await engine.dispatch("watch", args, { gate });
+  const engine = makeEngine({ watchers: makeWatcherSeam(watchers) });
+  const first = await engine.dispatch("watch", WATCH_ARGS, { gate });
   // user says "no"
   assert.equal(engine.rejectConfirm(first.id), true);
-  const second = await engine.dispatch("watch", args, { gate });
+  const second = await engine.dispatch("watch", WATCH_ARGS, { gate });
   assert.equal(second.needConfirmation, true); // still blocked
   assert.equal(watchers.length, 0);
 });
@@ -256,19 +259,15 @@ test("text loop: rejectConfirm(id) aborts and the tool stays blocked until appro
 
 test("watch registry CRUD through the engine (watch / list_watches / unwatch)", async () => {
   const watchers = [];
-  const engine = makeEngine({
-    loadWatches: async () => watchers,
-    saveWatches: async (w) => {
-      watchers.splice(0, watchers.length, ...w);
-    },
-  });
+  const engine = makeEngine({ watchers: makeWatcherSeam(watchers) });
   const gated = { gate, trustedActions: ["watch"] };
-  const added = await engine.dispatch("watch", { surface: "multica", query: "q", condition: "a P0 opens" }, gated);
+  const added = await engine.dispatch("watch", WATCH_ARGS, gated);
   assert.equal(added.ok, true);
   const id = added.data.watch.id;
   assert.equal(watchers.length, 1);
-  assert.equal(watchers[0].active, true);
-  assert.equal(watchers[0].lastFiredAt, null);
+  assert.equal(watchers[0].predicate.kind, "event-pattern");
+  assert.equal(watchers[0].hits, 0);
+  assert.equal(watchers[0].lastHit, null);
 
   const list = await engine.dispatch("list_watches", {});
   assert.equal(list.data.watches.length, 1);

--- a/src/server/ctoInbound.test.mjs
+++ b/src/server/ctoInbound.test.mjs
@@ -1,11 +1,13 @@
 // ctoInbound.test.mjs — On-call CTO inbound feed (BET-1165, issue 2/3).
 // Pure logic + injected I/O, no live tmux / opencode / multica / push:
 //   - inbound routing (live flag off → park; live on → inject; dedupe via seenId)
-//   - watcher tick with injected reads (fires on new + matching, no re-fire)
 //   - watch registry CRUD (engine confirm-gated, cto.json atomic store round-trip)
 //   - gate: confirm → allow via trustedActions; untrusted → needConfirmation;
 //     text-loop approve / reject re-dispatch
-//   - pure helpers (conditionKeywords / defaultConditionMatches / seenId / preview)
+//   - pure helpers (seenId / preview)
+//
+// The old watcher poller tests were removed in BET-1398 — the poller is
+// superseded by the event-driven standing-query engine (ctoWatchers.mjs).
 
 import { test } from "node:test";
 import assert from "node:assert/strict";
@@ -14,13 +16,9 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 import {
   createCtoInbound,
-  createWatcherPoller,
   createCtoEngine,
   loadCtoStore,
   saveCtoStore,
-  conditionKeywords,
-  defaultConditionMatches,
-  defaultComputeSurfaceSeenId,
   computeConfirmId,
   buildPreview,
   stableHash,
@@ -323,105 +321,8 @@ test("read_inbox returns the inbox (filterable) without marking read or writing"
 });
 
 // ---------------------------------------------------------------------------
-// Watcher poller with injected reads
-// ---------------------------------------------------------------------------
-
-test("watcher tick fires inbound when condition matches and seenId is new; no re-fire on the same read", async () => {
-  const readOnce = { ok: true, data: { issues: [{ identifier: "BET-1", status: "critical", title: "P0 outage" }] } };
-  const fired = [];
-  const poller = createWatcherPoller({
-    loadWatches: async () => [
-      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null },
-    ],
-    saveWatches: async () => {},
-    readSurface: async () => readOnce,
-    sendToInbound: async (input) => fired.push(input),
-  });
-  await poller.tick();
-  assert.equal(fired.length, 1);
-  assert.equal(fired[0].surface, "multica");
-  assert.equal(typeof fired[0].seenId, "string");
-  assert.ok(fired[0].payload.message.includes("P0"), "message carries the matching snippet");
-  // Same (unchanged) read on the next tick → seenId unchanged → no re-fire.
-  await poller.tick();
-  assert.equal(fired.length, 1);
-});
-
-test("watcher tick respects an inactive/disabled watch", async () => {
-  const fired = [];
-  const poller = createWatcherPoller({
-    loadWatches: async () => [
-      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: false, lastFiredAt: null },
-    ],
-    saveWatches: async () => {},
-    readSurface: async () => ({ ok: true, data: { issues: [{ identifier: "BET-1", status: "critical", title: "P0 outage" }] } }),
-    sendToInbound: async (input) => fired.push(input),
-  });
-  await poller.tick();
-  assert.equal(fired.length, 0);
-});
-
-test("watcher tick does not fire when the condition does not match", async () => {
-  const fired = [];
-  // read has no P0 and no keyword from the condition ("P0")
-  const poller = createWatcherPoller({
-    loadWatches: async () => [
-      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null },
-    ],
-    saveWatches: async () => {},
-    readSurface: async () => ({ ok: true, data: { issues: [{ identifier: "BET-2", status: "todo", title: "chore" }] } }),
-    sendToInbound: async (input) => fired.push(input),
-  });
-  await poller.tick();
-  assert.equal(fired.length, 0);
-});
-
-test("watcher tick survives a failed surface read (skips the watch, keeps going)", async () => {
-  const fired = [];
-  let calls = 0;
-  const poller = createWatcherPoller({
-    loadWatches: async () => [
-      { id: "w1", surface: "multica", query: "q", condition: "a P0 opens", active: true, lastFiredAt: null },
-      { id: "w2", surface: "multica", query: "q2", condition: "a P0 opens", active: true, lastFiredAt: null },
-    ],
-    saveWatches: async () => {},
-    readSurface: async () => {
-      calls += 1;
-      if (calls === 1) throw new Error("surface down");
-      return { ok: true, data: { issues: [{ identifier: "BET-1", status: "critical", title: "P0 outage" }] } };
-    },
-    sendToInbound: async (input) => fired.push(input),
-  });
-  await poller.tick();
-  // w1's read threw (skipped, no throw out of the tick); w2's read succeeded.
-  assert.equal(fired.length, 1);
-});
-
-// ---------------------------------------------------------------------------
 // Pure helpers
 // ---------------------------------------------------------------------------
-
-test("conditionKeywords strips stopwords and normalizes case", () => {
-  assert.deepEqual(conditionKeywords("a P0 opens"), ["p0"]);
-  assert.deepEqual(conditionKeywords("deploy failed"), ["deploy", "failed"]);
-  assert.deepEqual(conditionKeywords(""), []);
-});
-
-test("defaultConditionMatches is a keyword hit (case-insensitive) or true on empty condition", () => {
-  const read = { data: { issues: [{ identifier: "BET-1", title: "P0 Outage" }] } };
-  assert.equal(defaultConditionMatches("a P0 opens", read), true);
-  assert.equal(defaultConditionMatches("deploy failed", read), false);
-  assert.equal(defaultConditionMatches("", read), true);
-});
-
-test("defaultComputeSurfaceSeenId is stable for identical reads, differs for changed ones", () => {
-  const readA = { data: { issues: [{ identifier: "BET-1" }] } };
-  const readB = { data: { issues: [{ identifier: "BET-1" }, { identifier: "BET-2" }] } };
-  assert.equal(defaultComputeSurfaceSeenId(readA), defaultComputeSurfaceSeenId(readA));
-  assert.notEqual(defaultComputeSurfaceSeenId(readA), defaultComputeSurfaceSeenId(readB));
-  // An explicit seenId on the read always wins.
-  assert.equal(defaultComputeSurfaceSeenId({ seenId: "abc" }), "abc");
-});
 
 test("computeConfirmId is deterministic per (tool, args) and buildPreview summarizes", () => {
   assert.equal(computeConfirmId("watch", { surface: "multica" }), computeConfirmId("watch", { surface: "multica" }));

--- a/src/server/ctoStores.mjs
+++ b/src/server/ctoStores.mjs
@@ -146,6 +146,10 @@ export const toolRegistryStore = createCtoJsonStore("tool-registry", ctoPath("to
 export const toolUsageStore = createCtoJsonStore("tool-usage", ctoPath("tool-usage.json"));
 export const verdictsStore = createCtoJsonStore("verdicts", ctoPath("verdicts.json"));
 export const budgetStore = createCtoJsonStore("budget", ctoPath("budget.json"));
+// BET-1398 standing-query watchers (supersedes the cto.json watcher poller).
+// Payload shape: `{ watchers: [{ id, patternSignature, predicate, source,
+// created, lastHit, hits, retired? }] }`. Owned by ctoWatchers.mjs.
+export const watchersStore = createCtoJsonStore("watchers", ctoPath("watchers.json"));
 export const engineStateStore = createCtoJsonStore("engine-state", ctoPath("engine-state.json"));
 
 // ---------------------------------------------------------------------------

--- a/src/server/ctoSuggest.mjs
+++ b/src/server/ctoSuggest.mjs
@@ -39,6 +39,7 @@ import {
   digestsStore,
   factsStore,
 } from "./ctoStores.mjs";
+import { collectWatcherHitsFromLedger } from "./ctoWatchers.mjs";
 
 export const SUGGEST_VERSION = 1;
 
@@ -53,7 +54,10 @@ export const ACTION_TYPES = Object.freeze([
 
 // Steep-decay source kinds that earn the `notify` (informational router call)
 // variant alongside the decision card. Deterministic rule, not a learned flag.
-export const NOTIFY_RECURRENCE_KINDS = Object.freeze(["failure-recurrence"]);
+// BET-1398: a watcher whose predicate was rate-threshold carries sourceKind
+// `watcher-hit-rate` and earns the notify variant (a burst-trip is a steep
+// signal); a plain `watcher-hit` (event-pattern / usage-burn) does not.
+export const NOTIFY_RECURRENCE_KINDS = Object.freeze(["failure-recurrence", "watcher-hit-rate"]);
 
 // §9.2 class priors — the per-class `p(want | class)` used in worthiness
 // calibration. Flat defaults; callers may override per class via config.
@@ -199,8 +203,8 @@ export function normalizeCandidates(parsed, findingId) {
 }
 
 // ---------------------------------------------------------------------------
-// P2 findings sources — digest-detected recurrences + fact anomalies.
-// (Watcher hits arrive in a later issue.)
+// P2 findings sources — digest-detected recurrences + fact anomalies
+// + watcher hits (BET-1398).
 // ---------------------------------------------------------------------------
 
 // A failure-tier digest item that recurs across digests is a high-salience
@@ -258,6 +262,10 @@ export function collectFindings(digests = [], facts = [], opts = {}) {
   return [
     ...collectFailuresFromDigests(digests, opts),
     ...collectAnomaliesFromFacts(facts, opts),
+    // BET-1398 watcher hits as a candidate source: high-salience `watcher.hit`
+    // evidence rows. `sourceKind` is `watcher-hit`, or `watcher-hit-rate` for a
+    // rate-threshold watcher (which earns the steep-decay notify variant).
+    ...collectWatcherHitsFromLedger(opts?.ledgerRows),
   ];
 }
 
@@ -420,6 +428,16 @@ export function createCtoSuggest(deps = {}) {
     }
   }
 
+  // BET-1398: the raw A1 ledger rows so the watcher-hit candidate source can
+  // be collected from them. Best-effort — an unreadable ledger yields [].
+  async function loadLedgerRows() {
+    try {
+      return (await ledger.read()) ?? [];
+    } catch {
+      return [];
+    }
+  }
+
   async function loadFacts() {
     const out = [];
     try {
@@ -560,8 +578,8 @@ export function createCtoSuggest(deps = {}) {
     const cfg = await configGet();
     const tier = String(cfg?.ctoTier ?? "low").toLowerCase();
     const coldStart = (await countVerdicts()) < VERDICT_MIN;
-    const [digestsArr, factsArr] = await Promise.all([loadDigests(), loadFacts()]);
-    const findings = collectFindings(digestsArr, factsArr, { nowMs });
+    const [digestsArr, factsArr, ledgerRows] = await Promise.all([loadDigests(), loadFacts(), loadLedgerRows()]);
+    const findings = collectFindings(digestsArr, factsArr, { nowMs, ledgerRows });
     let surfaced = 0;
     let silent = 0;
     for (const f of findings) {

--- a/src/server/ctoWatchers.mjs
+++ b/src/server/ctoWatchers.mjs
@@ -226,7 +226,12 @@ export function upsertWatchers(watchers, candidates, { now = Date.now() } = {}) 
   const updated = [];
   for (const cand of Array.isArray(candidates) ? candidates : []) {
     if (!cand || !cand.patternSignature) continue;
-    const built = makeWatcher({ predicate: cand.predicate, source: cand.source || "auto", now });
+    const built = makeWatcher({
+      predicate: cand.predicate,
+      source: cand.source || "auto",
+      patternSignature: cand.patternSignature,
+      now,
+    });
     if (!built.ok) continue;
     const idx = next.findIndex((w) => w && w.patternSignature === cand.patternSignature);
     if (idx === -1) {
@@ -244,22 +249,28 @@ export function upsertWatchers(watchers, candidates, { now = Date.now() } = {}) 
 }
 
 // Retire watchers that have gone quiet (no hit for `inactiveAfterMs`) or whose
-// patternSignature is in the archived set. Best-effort per watcher — a bad
-// record is skipped, never thrown.
+// patternSignature is in the archived set. A retired watcher is flagged
+// `retired: true` and kept (so an auto-created theme that resurfaces on a later
+// day rollup re-arms in place — see upsertWatchers) but is skipped by evidence
+// evaluation. Best-effort per watcher — a bad record is skipped, never thrown.
+// Retired watchers are also passed back in `retired` for logging.
 export function retireWatchers(watchers, { nowMs = Date.now(), inactiveAfterMs = RETIRE_AFTER_MS, archivedSignatures = [] } = {}) {
   const archived = new Set(Array.isArray(archivedSignatures) ? archivedSignatures : []);
   const next = [];
   const retired = [];
   for (const w of Array.isArray(watchers) ? watchers : []) {
-    if (!w || w.retired) {
-      if (w) next.push(w);
+    if (!w) continue;
+    if (w.retired) {
+      next.push(w);
       continue;
     }
-    const quiet = nowMs - (typeof w.lastHit === "number" && w.lastHit > 0 ? w.lastHit : w.created ?? 0) >= inactiveAfterMs;
+    const last = typeof w.lastHit === "number" && w.lastHit > 0 ? w.lastHit : w.created ?? 0;
+    const quiet = nowMs - last >= inactiveAfterMs;
     const archivedAway = w.patternSignature != null && archived.has(w.patternSignature);
     if (quiet || archivedAway) {
+      next.push({ ...w, retired: true, retiredAt: nowMs, retiredReason: archivedAway ? "archived" : "inactive" });
       retired.push({ id: w.id, patternSignature: w.patternSignature, reason: archivedAway ? "archived" : "inactive" });
-      continue; // retired watchers are dropped (they can be re-armed by upsert)
+      continue;
     }
     next.push(w);
   }
@@ -280,7 +291,7 @@ function significantKeywords(text) {
   const words = text
     .toLowerCase()
     .split(/[^a-z0-9]+/)
-    .filter((w) => w.length >= 4 && !STOP.get(w));
+    .filter((w) => w.length >= 4 && !STOP.has(w));
   return [...new Set(words)];
 }
 
@@ -371,7 +382,10 @@ export function extractRecurringThemes(dayRollups, { minOccurrences = AUTO_MIN_O
   }
   const candidates = [];
   for (const [norm, info] of count) {
-    if (info.bullets.size < minOccurrences) continue; // >=2 bullets (distinct days) share the theme
+    // `occurrences` == number of distinct bullets that contain the signifier
+    // (extractSignifiers dedupes per bullet), so >= minOccurrences means at
+    // least that many rollup bullets in the last 7 days feature the pattern.
+    if (info.occurrences < minOccurrences) continue;
     candidates.push({
       patternSignature: norm,
       predicate: { kind: EVENT_PATTERN, params: { pattern: escapeRegex(norm), fields: "both" } },
@@ -390,7 +404,7 @@ export function extractRecurringThemes(dayRollups, { minOccurrences = AUTO_MIN_O
 // The high-salience evidence payload appended to the A1 ledger for a hit. The
 // predicate-kind drives the B4 sourceKind: a rate-threshold watch that trips
 // earns the steep-decay notify rule (`watcher-hit-rate`).
-export function watcherHitPayload(watch, event = {}, { now = Date.now() } = {}) {
+export function watcherHitPayload(watch, event = {}, { now = Date.now } = {}) {
   const pk = watch?.predicate?.kind;
   return {
     kind: WATCHER_HIT_KIND,

--- a/src/server/ctoWatchers.mjs
+++ b/src/server/ctoWatchers.mjs
@@ -1,0 +1,675 @@
+// Watcher supersession + auto-created watchers (BET-1398 / spec §4.3, §13.4).
+//
+// The OLD watcher poller (BET-1165) ran a poll loop: every minute it swept the
+// registered watches, ran each watch's query against a surface read, and only
+// surfaced a notification when a NLP condition matched AND the surface's
+// seenId moved. Its watches lived in cto.json (loadWatches/saveWatches) and
+// only understood the on/off presence of a surface — never the actual work
+// evidence flowing through the CTO.
+//
+// This module supersedes that with a STANDING-QUERY engine evaluated over the
+// A5 evidence stream — event-driven, NOT a poll loop. A watcher is
+//
+//     { id, patternSignature,
+//       predicate: { kind, params },
+//       source, created, lastHit, hits, retired?, legacy? }
+//
+// evaluated against each evidence event (and, for the windowed kinds, each
+// engine tick). Exactly three predicate kinds exist (closed set, §13.4):
+//
+//   - event-pattern : regex over evidence text/kind. Per-event.
+//   - rate-threshold: count of matching events in a window >= threshold.
+//   - usage-burn    : ambient spend pace vs the daily cap fraction.
+//
+// Every predicate kind is validated up front (validatePredicate); a watcher
+// register with an unknown kind is rejected loudly. There is no fourth kind —
+// new kinds are a spec change, not this module growing ad hoc.
+//
+// Watcher HITS are themselves high-salience evidence events (kind
+// `watcher.hit`, salience `high`) appended to the A1 ledger, and they feed the
+// B4 suggestion engine as a candidate source (`sourceKind: "watcher-hit"`, or
+// `"watcher-hit-rate"` when the predicate was `rate-threshold`, which earns the
+// steep-decay notify rule). This module is pure + injected-I/O in the same DI
+// style as the rest of src/server — nothing here touches tmux/opencode.
+//
+// Auto-created watchers: after each day rollup, recurring themes (>=2
+// occurrences of a matchable pattern across the last 7 days of rollup bullets)
+// are upserted by patternSignature — never duplicated. Retirement: 30 days
+// without a hit, or when the underlying fact/pattern is archived.
+
+import { randomBytes } from "node:crypto";
+
+// Closed set of predicate kinds (spec §13.4). Adding a kind is a spec change.
+export const PREDICATE_KINDS = Object.freeze(["event-pattern", "rate-threshold", "usage-burn"]);
+
+export const EVENT_PATTERN = "event-pattern";
+export const RATE_THRESHOLD = "rate-threshold";
+export const USAGE_BURN = "usage-burn";
+
+// The watcher-hit ledger kind + its evidence salience.
+export const WATCHER_HIT_KIND = "watcher.hit";
+export const WATCHER_HIT_SALIENCE = "high";
+export const WATCHER_CHANNEL = "watcher";
+
+// Auto-created watcher tuning (§13.4).
+export const AUTO_MIN_OCCURRENCES = 2; // >=2 occurrences of a pattern
+export const AUTO_WINDOW_DAYS = 7; // across the last 7 days of rollup bullets
+// Retirement: 30 days without a hit.
+export const RETIRE_AFTER_MS = 30 * 24 * 60 * 60 * 1000;
+
+// engine-state.json marker that legacy watches were migrated (idempotent).
+export const WATCHER_MIGRATION_KEY = "watchers";
+
+const HOUR_MS = 3_600_000;
+const DAY_MS = 24 * HOUR_MS;
+
+function nextId() {
+  return randomBytes(4).toString("hex");
+}
+
+function escapeRegex(s) {
+  return String(s).replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+function safeRegex(pattern) {
+  try {
+    return pattern == null ? null : new RegExp(String(pattern));
+  } catch {
+    return null;
+  }
+}
+
+// Normalize a theme string into a stable pattern signature (lowercased,
+// punctuation collapsed). Used to key auto-created watchers so the same theme
+// is never duplicated.
+export function patternSignatureFor(theme) {
+  return String(theme ?? "")
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, "_")
+    .replace(/^_+|_+$/g, "")
+    .slice(0, 120);
+}
+
+// ---------------------------------------------------------------------------
+// Predicate validation (closed set)
+// ---------------------------------------------------------------------------
+
+export function validatePredicate(pred) {
+  if (!pred || typeof pred !== "object") {
+    return { ok: false, error: "predicate is required" };
+  }
+  const kind = pred.kind;
+  if (!PREDICATE_KINDS.includes(kind)) {
+    return {
+      ok: false,
+      error: `unknown predicate kind "${kind}" (allowed: ${PREDICATE_KINDS.join(", ")})`,
+    };
+  }
+  const params = pred.params ?? {};
+  if (kind === EVENT_PATTERN) {
+    const pattern = params.pattern;
+    if (typeof pattern !== "string" || pattern.trim() === "") {
+      return { ok: false, error: "event-pattern requires params.pattern (a regex string)" };
+    }
+    if (safeRegex(pattern) == null) {
+      return { ok: false, error: `event-pattern regex is invalid: ${pattern}` };
+    }
+    return { ok: true };
+  }
+  if (kind === RATE_THRESHOLD) {
+    const threshold = params.threshold;
+    const windowMs = params.windowMs;
+    if (!Number.isInteger(threshold) || threshold < 1) {
+      return { ok: false, error: "rate-threshold requires params.threshold (integer >= 1)" };
+    }
+    if (!Number.isFinite(windowMs) || windowMs <= 0) {
+      return { ok: false, error: "rate-threshold requires params.windowMs (> 0)" };
+    }
+    if (params.pattern != null && params.pattern !== "" && safeRegex(params.pattern) == null) {
+      return { ok: false, error: `rate-threshold filter regex is invalid: ${params.pattern}` };
+    }
+    return { ok: true };
+  }
+  if (kind === USAGE_BURN) {
+    const windowMs = params.windowMs;
+    const capFraction = params.capFraction;
+    if (!Number.isFinite(windowMs) || windowMs <= 0) {
+      return { ok: false, error: "usage-burn requires params.windowMs (> 0)" };
+    }
+    if (!Number.isFinite(capFraction) || capFraction <= 0 || capFraction > 1) {
+      return { ok: false, error: "usage-burn requires params.capFraction in (0, 1]" };
+    }
+    return { ok: true };
+  }
+  return { ok: false, error: `unknown predicate kind "${kind}"` };
+}
+
+// ---------------------------------------------------------------------------
+// Pure predicate evaluation
+// ---------------------------------------------------------------------------
+
+// event-pattern: regex over evidence text/kind. Default fields = both. Returns
+// true when the (cached) regex matches the event's text or kind.
+export function eventPatternMatches(pred, event = {}) {
+  const params = pred?.params ?? {};
+  const re = safeRegex(params.pattern);
+  if (re == null) return false;
+  const fields = params.fields ?? "both";
+  const text = typeof event?.text === "string" ? event.text : "";
+  const kind = typeof event?.kind === "string" ? event.kind : "";
+  if (fields === "text" && text) return re.test(text);
+  if (fields === "kind" && kind) return re.test(kind);
+  re.lastIndex = 0;
+  if (fields !== "kind" && text && re.test(text)) return true;
+  re.lastIndex = 0;
+  if (fields !== "text" && kind && re.test(kind)) return true;
+  return false;
+}
+
+// rate-threshold event filter: does a single evidence event count toward the
+// threshold? Honors optional params.pattern / params.eventKind filters.
+export function rateEventCounts(pred, event = {}) {
+  const params = pred?.params ?? {};
+  let matched = true;
+  if (params.eventKind != null && params.eventKind !== "") {
+    matched = matched && event?.kind === params.eventKind;
+  }
+  if (matched && params.pattern != null && params.pattern !== "") {
+    matched = matched && eventPatternMatches({ params: { ...params, fields: params.fields ?? "both" } }, event);
+  }
+  return matched;
+}
+
+// usage-burn: hit when the ambient spend over `windowMs` is at least
+// `capFraction` of the proportional share of the daily cap for that window.
+export function usageBurnHit(pred, { spend, capUsd } = {}) {
+  const params = pred?.params ?? {};
+  const capShare = (capUsd ?? 0) * (params.windowMs / DAY_MS);
+  if (!(capShare > 0)) return false;
+  return (spend ?? 0) >= params.capFraction * capShare;
+}
+
+// ---------------------------------------------------------------------------
+// Watcher construction + upsert + retirement
+// ---------------------------------------------------------------------------
+
+// Build a watcher record. `patternSignature` is derived when omitted (from the
+// predicate). `validate` option (default true) rejects unknown predicate kinds.
+export function makeWatcher({ predicate, source = "user", patternSignature, now = Date.now(), id, validate = true } = {}) {
+  if (validate) {
+    const v = validatePredicate(predicate);
+    if (!v.ok) return { ok: false, error: v.error };
+  }
+  const sig =
+    patternSignature || patternSignatureFor(`${predicate?.kind || ""} ${JSON.stringify(predicate?.params ?? {})}`);
+  return {
+    ok: true,
+    watch: {
+      id: id || nextId(),
+      patternSignature: sig,
+      predicate,
+      source,
+      created: now(),
+      lastHit: null,
+      hits: 0,
+      retired: false,
+    },
+  };
+}
+
+// Upsert a set of candidate watchers keyed by patternSignature — auto-created
+// themes never duplicate. Existing watchers matching a signature are left
+// untouched (their hit/lastHit history is kept). Returns {next, added, updated}.
+export function upsertWatchers(watchers, candidates, { now = Date.now() } = {}) {
+  const next = Array.isArray(watchers) ? [...watchers] : [];
+  const added = [];
+  const updated = [];
+  for (const cand of Array.isArray(candidates) ? candidates : []) {
+    if (!cand || !cand.patternSignature) continue;
+    const built = makeWatcher({ predicate: cand.predicate, source: cand.source || "auto", now });
+    if (!built.ok) continue;
+    const idx = next.findIndex((w) => w && w.patternSignature === cand.patternSignature);
+    if (idx === -1) {
+      next.push(built.watch);
+      added.push({ patternSignature: cand.patternSignature, id: built.watch.id });
+    } else if (next[idx].retired) {
+      // Re-armed: an archived theme resurfacing re-activates its watcher.
+      next[idx] = { ...next[idx], retired: false, predicate: built.watch.predicate, source: built.watch.source };
+      updated.push({ patternSignature: cand.patternSignature, id: next[idx].id, rearmed: true });
+    } else {
+      updated.push({ patternSignature: cand.patternSignature, id: next[idx].id, rearmed: false });
+    }
+  }
+  return { next, added, updated };
+}
+
+// Retire watchers that have gone quiet (no hit for `inactiveAfterMs`) or whose
+// patternSignature is in the archived set. Best-effort per watcher — a bad
+// record is skipped, never thrown.
+export function retireWatchers(watchers, { nowMs = Date.now(), inactiveAfterMs = RETIRE_AFTER_MS, archivedSignatures = [] } = {}) {
+  const archived = new Set(Array.isArray(archivedSignatures) ? archivedSignatures : []);
+  const next = [];
+  const retired = [];
+  for (const w of Array.isArray(watchers) ? watchers : []) {
+    if (!w || w.retired) {
+      if (w) next.push(w);
+      continue;
+    }
+    const quiet = nowMs - (typeof w.lastHit === "number" && w.lastHit > 0 ? w.lastHit : w.created ?? 0) >= inactiveAfterMs;
+    const archivedAway = w.patternSignature != null && archived.has(w.patternSignature);
+    if (quiet || archivedAway) {
+      retired.push({ id: w.id, patternSignature: w.patternSignature, reason: archivedAway ? "archived" : "inactive" });
+      continue; // retired watchers are dropped (they can be re-armed by upsert)
+    }
+    next.push(w);
+  }
+  return { next, retired };
+}
+
+// ---------------------------------------------------------------------------
+// Migration from the legacy poller store (cto.json) — idempotent
+// ---------------------------------------------------------------------------
+
+// Convert one legacy watch (from the old cto.json watcher store) into a
+// standing-query watcher. Natural-language conditions become an alternation of
+// their significant keywords (regex-escaped) so a migrated watcher still fires
+// on future evidence mentioning those words. A legacy watch that yields no
+// meaningful keyword is dropped (never a never-matching dead watcher).
+function significantKeywords(text) {
+  if (typeof text !== "string") return [];
+  const words = text
+    .toLowerCase()
+    .split(/[^a-z0-9]+/)
+    .filter((w) => w.length >= 4 && !STOP.get(w));
+  return [...new Set(words)];
+}
+
+const STOP = new Set(
+  "about above after again against all also and any are because been before being below between both but can did does doing down during each few for from further had has have having here how if in into is it its itself just more most much must my no nor not now of off on once only or other our own same should so some such than that the their them then there these they this those through too under until up very was were what when where which while who why will with would you your".split(
+    " ",
+  ),
+);
+
+export function migrateLegacyWatches(legacyWatches, { now = Date.now() } = {}) {
+  const out = [];
+  for (const w of Array.isArray(legacyWatches) ? legacyWatches : []) {
+    if (!w || w.active === false) continue;
+    const words = significantKeywords(w.condition);
+    if (words.length === 0) continue; // nothing matchable — skip the dead watcher
+    const pattern = words.map(escapeRegex).join("|");
+    const pred = { kind: EVENT_PATTERN, params: { pattern } };
+    const sig = patternSignatureFor(`${w.query || ""} ${w.condition || ""}`);
+    out.push({
+      id: typeof w.id === "string" && w.id ? w.id : nextId(),
+      patternSignature: sig,
+      predicate: pred,
+      source: "migrated-legacy",
+      legacy: {
+        surface: typeof w.surface === "string" ? w.surface : undefined,
+        query: typeof w.query === "string" ? w.query : undefined,
+        condition: typeof w.condition === "string" ? w.condition : undefined,
+      },
+      created: typeof w.createdAt === "number" ? w.createdAt : now(),
+      lastHit: typeof w.lastFiredAt === "number" ? w.lastFiredAt : null,
+      hits: 0,
+      retired: false,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Auto-created watchers from day-rollup bullets
+// ---------------------------------------------------------------------------
+
+// Extract candidate "matchable patterns" (normalized failure/tool/test
+// identifiers) from a rollup bullet's text. Deterministic heuristics: issue
+// keys, file refs, function calls, PascalCase identifiers, bracketed ids.
+export function extractSignifiers(text) {
+  if (typeof text !== "string") return [];
+  const out = new Set();
+  // Issue keys: BET-123, MUL-45, ...
+  for (const m of text.matchAll(/\b[A-Z]{2,}-\d+\b/g)) out.add(m[0]);
+  // File refs: path/name.ext (mjs/js/ts/tsx/py/go/rs/sh/json/yaml...).
+  for (const m of text.matchAll(/\b[\w./-]+\.(?:mjs|js|ts|tsx|py|go|rs|sh|jsonc?|ya?ml|sql)\b/g))
+    out.add(m[0]);
+  // Function calls: foo(), pkg.foo(), foo.bar()
+  for (const m of text.matchAll(/\b[\w$.]+\(\)/g)) out.add(m[0]);
+  // Bracket ids: [something] where something looks like an identifier.
+  for (const m of text.matchAll(/\[([A-Za-z0-9_-]{4,})\]/g)) out.add(m[1]);
+  // PascalCase identifiers (classes / tool names), len >= 5.
+  for (const m of text.matchAll(/\b[A-Z][a-zA-Z0-9]{4,}\b/g)) out.add(m[0]);
+  const trimmed = [];
+  for (const s of out) {
+    const t = s.trim();
+    if (patternSignatureFor(t).length >= 3) trimmed.push(t);
+  }
+  return [...new Set(trimmed)];
+}
+
+// Reduce day rollups to recurring-theme watcher candidates. Counts each
+// extracted signifier across the given day-rollup bullets; a signifier present
+// in >= `minOccurrences` distinct bullets becomes an event-pattern candidate.
+export function extractRecurringThemes(dayRollups, { minOccurrences = AUTO_MIN_OCCURRENCES, now = Date.now(), windowDays = AUTO_WINDOW_DAYS } = {}) {
+  const since = now() - windowDays * DAY_MS;
+  const count = new Map(); // normalized signifier -> { occurrences, bullets:Set }
+  for (const rp of Array.isArray(dayRollups) ? dayRollups : []) {
+    if (!rp || rp.level !== "day" || typeof rp.window?.[0] !== "number") continue;
+    if (rp.window[0] < since) continue; // only the last 7 days
+    for (const b of Array.isArray(rp.bullets) ? rp.bullets : []) {
+      const sigs = extractSignifiers(b?.text);
+      for (const sig of sigs) {
+        const norm = patternSignatureFor(sig);
+        if (!norm) continue;
+        const cur = count.get(norm) || { occurrences: 0, bullets: new Set(), matched: sig };
+        cur.occurrences += 1;
+        cur.bullets.add(rp.window[0]);
+        cur.matched = sig;
+        count.set(norm, cur);
+      }
+    }
+  }
+  const candidates = [];
+  for (const [norm, info] of count) {
+    if (info.bullets.size < minOccurrences) continue; // >=2 bullets (distinct days) share the theme
+    candidates.push({
+      patternSignature: norm,
+      predicate: { kind: EVENT_PATTERN, params: { pattern: escapeRegex(norm), fields: "both" } },
+      source: "auto",
+    });
+  }
+  // Deterministic order (upsert is order-independent, but stable tests).
+  candidates.sort((a, b) => a.patternSignature.localeCompare(b.patternSignature));
+  return candidates;
+}
+
+// ---------------------------------------------------------------------------
+// Watcher-hit evidence + B4 candidate source
+// ---------------------------------------------------------------------------
+
+// The high-salience evidence payload appended to the A1 ledger for a hit. The
+// predicate-kind drives the B4 sourceKind: a rate-threshold watch that trips
+// earns the steep-decay notify rule (`watcher-hit-rate`).
+export function watcherHitPayload(watch, event = {}, { now = Date.now() } = {}) {
+  const pk = watch?.predicate?.kind;
+  return {
+    kind: WATCHER_HIT_KIND,
+    salience: WATCHER_HIT_SALIENCE,
+    watcherId: watch?.id,
+    predicateKind: pk,
+    patternSignature: watch?.patternSignature,
+    sourceKind: pk === RATE_THRESHOLD ? "watcher-hit-rate" : "watcher-hit",
+    text:
+      typeof event?.text === "string" && event.text.trim()
+        ? event.text.slice(0, 512)
+        : `Watcher ${watch?.id} matched`,
+    refs: Array.isArray(event?.refs) ? event.refs : [],
+    ts: now(),
+  };
+}
+
+// Convert `watcher.hit` ledger rows into B4 findings for the suggestion
+// engine. Stable keying per watcherId so repeated hits for the same watcher
+// upsert one card (auto-created watchers never spam).
+export function collectWatcherHitsFromLedger(rows) {
+  const out = [];
+  for (const r of Array.isArray(rows) ? rows : []) {
+    if (!r || r.kind !== WATCHER_HIT_KIND) continue;
+    if (r.salience !== WATCHER_HIT_SALIENCE) continue;
+    const pk = r.predicateKind;
+    out.push({
+      id: `wh:${r.watcherId || "watcher"}`,
+      sourceKind: pk === RATE_THRESHOLD ? "watcher-hit-rate" : "watcher-hit",
+      text:
+        typeof r.text === "string" && r.text.trim()
+          ? r.text
+          : `Watcher ${r.watcherId || "?"} for ${r.patternSignature || "?"} triggered`,
+      refs: Array.isArray(r.refs) ? r.refs : [],
+      ts: typeof r.ts === "number" ? r.ts : 0,
+      watcherId: r.watcherId,
+      patternSignature: r.patternSignature,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// The standing-query engine (event-driven, injected I/O)
+// ---------------------------------------------------------------------------
+
+// The stateful engine. deps:
+//   store          – { load, save } returning/accepting `{ watchers: [] }`
+//   ledger         – { append } (A1 evidence ledger)
+//   engineState    – { load, save } for the migration marker
+//   now            – () => ms timestamp
+//   publish        – (evt) => void (optional watcher-hit bus event)
+//   getSpendInWindow – async (windowMs) => USD spent over the window (usage-burn)
+//   getCapUsd      – async () => daily ambient cap USD (usage-burn)
+//
+// In-memory, per-watcher window accumulation for rate-threshold (a rolling
+// list of matching event timestamps); window state is deliberately ephemeral —
+// a rate-threshold watcher recounts from the fresh stream after a restart.
+export function createStandingQueryEngine(deps = {}) {
+  const {
+    store,
+    ledger,
+    engineState,
+    now = () => Date.now(),
+    publish = () => {},
+    getSpendInWindow = async () => 0,
+    getCapUsd = async () => 0,
+  } = deps;
+
+  // watcherId -> array of matching event timestamps (rate-threshold window).
+  const windowHits = new Map();
+  // watcherId -> last usage-burn hit ts (so burn doesn't re-fire every tick).
+  const lastBurnHit = new Map();
+
+  async function loadAll() {
+    try {
+      const payload = await store.load();
+      return Array.isArray(payload?.watchers) ? payload.watchers : [];
+    } catch {
+      return [];
+    }
+  }
+
+  async function saveAll(watchers) {
+    await store.save({ watchers: Array.isArray(watchers) ? watchers : [] });
+  }
+
+  async function hit(watch, event = {}) {
+    const payload = watcherHitPayload(watch, event, { now });
+    try {
+      await ledger.append({ channel: WATCHER_CHANNEL, actor: "cto", ts: now(), ...payload });
+    } catch {
+      /* best-effort */
+    }
+    // Persist the watcher's moved hit accounting.
+    try {
+      const all = await loadAll();
+      const idx = all.findIndex((w) => w && w.id === watch.id);
+      if (idx !== -1) {
+        all[idx] = {
+          ...all[idx],
+          lastHit: now(),
+          hits: (typeof all[idx].hits === "number" ? all[idx].hits : 0) + 1,
+        };
+        await saveAll(all);
+      }
+    } catch {
+      /* best-effort */
+    }
+    try {
+      publish({ kind: "watcher.hit", payload });
+    } catch {
+      /* best-effort */
+    }
+    return payload;
+  }
+
+  async function evaluateEvent(event = {}) {
+    let all;
+    try {
+      all = await loadAll();
+    } catch {
+      return;
+    }
+    const t = now();
+    for (const w of all) {
+      if (!w || w.retired) continue;
+      const pk = w.predicate?.kind;
+      try {
+        if (pk === EVENT_PATTERN) {
+          if (eventPatternMatches(w.predicate, event)) await hit(w, event);
+        } else if (pk === RATE_THRESHOLD) {
+          if (rateEventCounts(w.predicate, event)) {
+            const list = windowHits.get(w.id) || [];
+            list.push(t);
+            const cutoff = t - (w.predicate.params?.windowMs ?? 0);
+            while (list.length && list[0] < cutoff) list.shift();
+            windowHits.set(w.id, list);
+            if (list.length >= (w.predicate.params?.threshold ?? Infinity)) {
+              windowHits.delete(w.id); // reset so it needs a fresh burst
+              await hit(w, event);
+            }
+          }
+        }
+        // usage-burn is evaluated on the tick, not per-event.
+      } catch {
+        /* one bad watcher never breaks ingestion */
+      }
+    }
+  }
+
+  // Evaluates windowed kinds (usage-burn) + retirement, driven from the engine
+  // tick (a work timer — already gated by pause).
+  async function runTick() {
+    let all;
+    try {
+      all = await loadAll();
+    } catch {
+      return;
+    }
+    const t = now();
+    let changed = false;
+    for (const w of all) {
+      if (!w || w.retired) continue;
+      const pk = w.predicate?.kind;
+      if (pk !== USAGE_BURN) continue;
+      const windowMs = w.predicate?.params?.windowMs ?? 0;
+      const last = lastBurnHit.get(w.id) || 0;
+      if (t - last < windowMs) continue; // fire at most once per window
+      try {
+        const [spend, capUsd] = await Promise.all([getSpendInWindow(windowMs), getCapUsd()]);
+        if (usageBurnHit(w.predicate, { spend, capUsd })) {
+          lastBurnHit.set(w.id, t);
+          await hit(w, {});
+          changed = true;
+        }
+      } catch {
+        /* best-effort */
+      }
+    }
+    // Retirement is cheap to run here too (once per tick).
+    try {
+      const { next, retired } = retireWatchers(all, { nowMs: t });
+      if (retired.length > 0) {
+        await saveAll(next);
+      }
+    } catch {
+      /* best-effort */
+    }
+    return changed;
+  }
+
+  async function register(input = {}) {
+    const built = makeWatcher({ ...input, now });
+    if (!built.ok) return { ok: false, error: built.error };
+    const all = await loadAll();
+    // A watcher with the same patternSignature is added alongside (user
+    // registration is distinct from auto-upsert) but the same id is not.
+    if (all.some((w) => w && w.id === built.watch.id)) {
+      return { ok: false, error: `watcher id already exists: ${built.watch.id}` };
+    }
+    await saveAll([...all, built.watch]);
+    return { ok: true, data: { watch: built.watch } };
+  }
+
+  async function unregister(id) {
+    if (!id || typeof id !== "string") return { ok: true, data: { removed: false } };
+    const all = await loadAll();
+    const next = all.filter((w) => w && w.id !== id);
+    if (next.length === all.length) return { ok: true, data: { removed: false } };
+    await saveAll(next);
+    windowHits.delete(id);
+    lastBurnHit.delete(id);
+    return { ok: true, data: { removed: true } };
+  }
+
+  async function list() {
+    return (await loadAll()).map((w) => ({
+      id: w.id,
+      patternSignature: w.patternSignature,
+      predicate: w.predicate,
+      source: w.source,
+      created: w.created,
+      lastHit: w.lastHit,
+      hits: w.hits,
+      retired: w.retired === true,
+      legacy: w.legacy,
+    }));
+  }
+
+  // Auto-create watchers from the last N days of day rollups. Idempotent by
+  // patternSignature (upsert never duplicates).
+  async function autoCreate(dayRollups) {
+    const candidates = extractRecurringThemes(dayRollups, { now });
+    if (candidates.length === 0) return { added: [], updated: [] };
+    const all = await loadAll();
+    const { next, added, updated } = upsertWatchers(all, candidates, { now });
+    if (added.length > 0 || updated.some((u) => u.rearmed)) await saveAll(next);
+    return { added, updated };
+  }
+
+  // One-time migration of legacy cto.json watches, guarded by a marker in
+  // engine-state.json. Re-invoking after a successful migration is a no-op.
+  async function migrateLegacy(legacyWatches = []) {
+    let meta = {};
+    try {
+      meta = (await engineState.load()) ?? {};
+    } catch {
+      meta = {};
+    }
+    if (meta?.[WATCHER_MIGRATION_KEY]?.migrated === true) {
+      return { migrated: false, count: 0 };
+    }
+    const converted = migrateLegacyWatches(legacyWatches, { now });
+    if (converted.length > 0) {
+      const all = await loadAll();
+      const existingIds = new Set(all.map((w) => w?.id));
+      const fresh = converted.filter((c) => !existingIds.has(c.id));
+      await saveAll([...all, ...fresh]);
+    }
+    try {
+      await engineState.save({
+        ...meta,
+        [WATCHER_MIGRATION_KEY]: { ...(meta?.[WATCHER_MIGRATION_KEY] || {}), migrated: true, at: now() },
+      });
+    } catch {
+      /* best-effort */
+    }
+    return { migrated: true, count: converted.length };
+  }
+
+  return {
+    list,
+    register,
+    unregister,
+    evaluateEvent,
+    runTick,
+    autoCreate,
+    migrateLegacy,
+    hitsFromLedger: collectWatcherHitsFromLedger,
+  };
+}

--- a/src/server/ctoWatchers.mjs
+++ b/src/server/ctoWatchers.mjs
@@ -557,8 +557,10 @@ export function createStandingQueryEngine(deps = {}) {
   }
 
   // Evaluates windowed kinds (usage-burn) + retirement, driven from the engine
-  // tick (a work timer — already gated by pause).
-  async function runTick() {
+  // tick (a work timer — already gated by pause). `archivedSignatures` (the
+  // normalized patterns of newly-archived underlying facts) retires matching
+  // watchers (§13.4 "or the underlying fact archived").
+  async function runTick({ archivedSignatures = [] } = {}) {
     let all;
     try {
       all = await loadAll();
@@ -587,7 +589,7 @@ export function createStandingQueryEngine(deps = {}) {
     }
     // Retirement is cheap to run here too (once per tick).
     try {
-      const { next, retired } = retireWatchers(all, { nowMs: t });
+      const { next, retired } = retireWatchers(all, { nowMs: t, archivedSignatures });
       if (retired.length > 0) {
         await saveAll(next);
       }

--- a/src/server/ctoWatchers.test.mjs
+++ b/src/server/ctoWatchers.test.mjs
@@ -159,7 +159,7 @@ test("event-pattern watcher hit becomes a high-salience evidence event", async (
   const hits = deps.ledgerRows.filter((r) => r.kind === "watcher.hit");
   assert.equal(hits.length, 1);
   assert.equal(hits[0].salience, "high");
-  assert.equal(hits[0].refs, "a,b", "refs carried through");
+  assert.deepEqual(hits[0].refs, ["a", "b"], "refs carried through");
 });
 
 // ---------------------------------------------------------------------------
@@ -175,26 +175,35 @@ test("upsertWatchers keys by patternSignature — never duplicates, re-arms a re
   const second = upsertWatchers(next, [{ patternSignature: "bet_123", predicate: { kind: EVENT_PATTERN, params: { pattern: "BET-123" } }, source: "auto" }], { now: () => t });
   assert.equal(second.added.length, 0);
   assert.equal(second.next.length, 1);
-  // retirement then resurface re-arms
-  const { next: retiredNext } = retireWatchers(second.next, { nowMs: t + 100_000_000 });
-  assert.equal(retiredNext.length, 0);
+  // retirement then resurface re-arms in place (retired watcher kept, flagged)
+  const { next: retiredNext } = retireWatchers(second.next, { nowMs: 1 + 31 * 24 * 3_600_000 });
+  assert.equal(retiredNext.length, 1);
+  assert.equal(retiredNext[0].retired, true);
   const rearm = upsertWatchers(retiredNext, [{ patternSignature: "bet_123", predicate: { kind: EVENT_PATTERN, params: { pattern: "BET-123" } }, source: "auto" }], { now: () => t + 1 });
   assert.equal(rearm.updated[0].rearmed, true);
   assert.equal(rearm.next[0].retired, false);
 });
 
 test("retireWatchers retires inactive watchers and archived signatures", () => {
-  const nowMs = 1_000_000;
+  const nowMs = 3_000_000_000_000;
+  const DAY = 86_400_000;
   const list = [
-    { id: "w1", patternSignature: "s1", created: nowMs - 10, lastHit: nowMs - 100_000_000, retired: false }, // inactive
+    { id: "w1", patternSignature: "s1", created: nowMs - 60 * DAY, lastHit: nowMs - 40 * DAY, retired: false }, // inactive (40d)
     { id: "w2", patternSignature: "s2", created: nowMs - 10, lastHit: nowMs - 5, retired: false }, // active
     { id: "w3", patternSignature: "s3", created: nowMs, lastHit: null, retired: false }, // archived signature
   ];
   const { next, retired } = retireWatchers(list, { nowMs, archivedSignatures: ["s3"] });
-  const ids = next.map((w) => w.id).sort();
-  assert.deepEqual(ids, ["w2"]);
+  // w2 stays active; w1/w3 stay present but flagged retired.
+  assert.deepEqual(next.map((w) => w.id).sort(), ["w1", "w2", "w3"]);
+  assert.deepEqual(
+    next
+      .filter((w) => !w.retired)
+      .map((w) => w.id),
+    ["w2"],
+  );
   assert.deepEqual(retired.map((r) => r.id).sort(), ["w1", "w3"]);
   assert.equal(retired.find((r) => r.id === "w3").reason, "archived");
+  assert.equal(next.find((w) => w.id === "w1").retired, true);
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/ctoWatchers.test.mjs
+++ b/src/server/ctoWatchers.test.mjs
@@ -1,0 +1,306 @@
+// ctoWatchers.test.mjs — standing-query watcher engine (BET-1398 / §4.3, §13.4).
+// Pure logic + injected I/O (fake store/ledger/engineState), no live services:
+//   - predicate validation (closed set of 3 kinds; unknown/bad params rejected)
+//   - event-pattern matching over evidence text/kind
+//   - rate-threshold window counting fires at threshold, then resets
+//   - usage-burn fires when burst spend vs cap fraction (once per window)
+//   - upsert keying (auto-created watchers never duplicate; re-arm on resurface)
+//   - retirement (30d inactive, or the underlying signature archived)
+//   - migration idempotency (run twice = once, marker-guarded)
+//   - auto-creation from day-rollup bullets (>=2 distinct days, 7-day window)
+//   - hit → B4 candidate-source wiring (sourceKind, incl. watcher-hit-rate)
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  PREDICATE_KINDS,
+  EVENT_PATTERN,
+  RATE_THRESHOLD,
+  USAGE_BURN,
+  validatePredicate,
+  eventPatternMatches,
+  rateEventCounts,
+  usageBurnHit,
+  makeWatcher,
+  patternSignatureFor,
+  upsertWatchers,
+  retireWatchers,
+  migrateLegacyWatches,
+  extractSignifiers,
+  extractRecurringThemes,
+  watcherHitPayload,
+  collectWatcherHitsFromLedger,
+  createStandingQueryEngine,
+} from "./ctoWatchers.mjs";
+import { NOTIFY_RECURRENCE_KINDS, collectFindings } from "./ctoSuggest.mjs";
+
+function makeEngineDeps(overrides = {}) {
+  const state = { watchers: [] };
+  const ledgerRows = [];
+  const es = {};
+  return {
+    store: {
+      load: async () => state,
+      save: async (p) => {
+        state.watchers = p.watchers;
+      },
+    },
+    ledger: {
+      append: async (row) => ledgerRows.push(row),
+    },
+    engineState: {
+      load: async () => es,
+      save: async (p) => {
+        Object.assign(es, p);
+      },
+    },
+    now: () => 1_000_000,
+    publish: () => {},
+    getSpendInWindow: async () => 0,
+    getCapUsd: async () => 100,
+    ledgerRows,
+    es,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Predicate validation (closed set)
+// ---------------------------------------------------------------------------
+
+test("PREDICATE_KINDS is exactly the closed set of three", () => {
+  assert.deepEqual([...PREDICATE_KINDS].sort(), ["event-pattern", "rate-threshold", "usage-burn"]);
+});
+
+test("validatePredicate accepts the three valid kinds with required params", () => {
+  assert.equal(validatePredicate({ kind: EVENT_PATTERN, params: { pattern: "P0" } }).ok, true);
+  assert.equal(validatePredicate({ kind: RATE_THRESHOLD, params: { threshold: 3, windowMs: 6000 } }).ok, true);
+  assert.equal(validatePredicate({ kind: USAGE_BURN, params: { windowMs: 6000, capFraction: 0.5 } }).ok, true);
+});
+
+test("validatePredicate rejects unknown kinds and bad params", () => {
+  assert.equal(validatePredicate({ kind: "pager" }).ok, false);
+  assert.equal(validatePredicate(null).ok, false);
+  assert.equal(validatePredicate({ kind: EVENT_PATTERN, params: {} }).ok, false);
+  assert.equal(validatePredicate({ kind: EVENT_PATTERN, params: { pattern: "[" } }).ok, false);
+  assert.equal(validatePredicate({ kind: RATE_THRESHOLD, params: { threshold: 0, windowMs: 1 } }).ok, false);
+  assert.equal(validatePredicate({ kind: USAGE_BURN, params: { windowMs: 1, capFraction: 2 } }).ok, false);
+});
+
+// ---------------------------------------------------------------------------
+// event-pattern
+// ---------------------------------------------------------------------------
+
+test("eventPatternMatches matches against evidence text and kind", () => {
+  const ep = { kind: EVENT_PATTERN, params: { pattern: "P0|cli" } };
+  assert.equal(eventPatternMatches(ep, { text: "a P0 opens", kind: "error" }), true);
+  assert.equal(eventPatternMatches(ep, { text: "nothing here", kind: "prompt" }), false);
+  assert.equal(eventPatternMatches({ kind: EVENT_PATTERN, params: { pattern: "cli", fields: "kind" } }, { text: "foo cli", kind: "tool.cli" }), true);
+  assert.equal(eventPatternMatches({ kind: EVENT_PATTERN, params: { pattern: "cli", fields: "text" } }, { text: "foo cli", kind: "tool.cli" }), true);
+});
+
+// ---------------------------------------------------------------------------
+// Standing-query engine — rate-threshold + usage-burn + hits
+// ---------------------------------------------------------------------------
+
+test("rate-threshold watcher fires when the count in the window reaches threshold, then resets", async () => {
+  const deps = makeEngineDeps();
+  const eng = createStandingQueryEngine(deps);
+  await eng.register({ predicate: { kind: RATE_THRESHOLD, params: { threshold: 3, windowMs: 6000 } } });
+  // three matching events within the window trip the hit
+  await eng.evaluateEvent({ text: "click", kind: "error" });
+  await eng.evaluateEvent({ text: "click", kind: "error" });
+  await eng.evaluateEvent({ text: "click", kind: "error" });
+  const hits = deps.ledgerRows.filter((r) => r.kind === "watcher.hit");
+  assert.equal(hits.length, 1);
+  // window restarted — needs a fresh burst of 3 before firing again
+  await eng.evaluateEvent({ text: "click", kind: "error" });
+  await eng.evaluateEvent({ text: "click", kind: "error" });
+  assert.equal(deps.ledgerRows.filter((r) => r.kind === "watcher.hit").length, 1);
+});
+
+test("rate-threshold honors an eventKind filter (other kinds don't count)", async () => {
+  const deps = makeEngineDeps();
+  const eng = createStandingQueryEngine(deps);
+  await eng.register({ predicate: { kind: RATE_THRESHOLD, params: { threshold: 2, windowMs: 6000, eventKind: "error" } } });
+  await eng.evaluateEvent({ text: "boom", kind: "prompt" });
+  await eng.evaluateEvent({ text: "boom", kind: "prompt" });
+  assert.equal(deps.ledgerRows.filter((r) => r.kind === "watcher.hit").length, 0);
+});
+
+test("usage-burn fires when burst spend is at/above the cap fraction (once per window)", async () => {
+  const deps = makeEngineDeps({
+    getSpendInWindow: async () => 60, // windowMs 6000 of a day = huge share
+    getCapUsd: async () => 100,
+  });
+  const eng = createStandingQueryEngine(deps);
+  await eng.register({ predicate: { kind: USAGE_BURN, params: { windowMs: 6000, capFraction: 0.5 } } });
+  // 60 >= 0.5 * (100 * 6000 / 86400000)=0.0035 → true
+  await eng.runTick();
+  assert.equal(deps.ledgerRows.filter((r) => r.kind === "watcher.hit").length, 1);
+});
+
+test("usage-burn does not fire when spend is below the cap share", async () => {
+  const deps = makeEngineDeps({
+    getSpendInWindow: async () => 0,
+    getCapUsd: async () => 100,
+  });
+  const eng = createStandingQueryEngine(deps);
+  await eng.register({ predicate: { kind: USAGE_BURN, params: { windowMs: 6000, capFraction: 0.5 } } });
+  await eng.runTick();
+  assert.equal(deps.ledgerRows.filter((r) => r.kind === "watcher.hit").length, 0);
+});
+
+test("event-pattern watcher hit becomes a high-salience evidence event", async () => {
+  const deps = makeEngineDeps();
+  const eng = createStandingQueryEngine(deps);
+  await eng.register({ predicate: { kind: EVENT_PATTERN, params: { pattern: "refactor" } } });
+  await eng.evaluateEvent({ text: "time to refactor the store", kind: "tool", refs: ["a", "b"] });
+  const hits = deps.ledgerRows.filter((r) => r.kind === "watcher.hit");
+  assert.equal(hits.length, 1);
+  assert.equal(hits[0].salience, "high");
+  assert.equal(hits[0].refs, "a,b", "refs carried through");
+});
+
+// ---------------------------------------------------------------------------
+// Upsert (auto-created watchers never duplicate) + retirement
+// ---------------------------------------------------------------------------
+
+test("upsertWatchers keys by patternSignature — never duplicates, re-arms a retired one", () => {
+  const t = 1;
+  let { next, added } = upsertWatchers([], [{ patternSignature: "bet_123", predicate: { kind: EVENT_PATTERN, params: { pattern: "BET-123" } }, source: "auto" }], { now: () => t });
+  assert.equal(added.length, 1);
+  assert.equal(next.length, 1);
+  // same signature again → no new watcher
+  const second = upsertWatchers(next, [{ patternSignature: "bet_123", predicate: { kind: EVENT_PATTERN, params: { pattern: "BET-123" } }, source: "auto" }], { now: () => t });
+  assert.equal(second.added.length, 0);
+  assert.equal(second.next.length, 1);
+  // retirement then resurface re-arms
+  const { next: retiredNext } = retireWatchers(second.next, { nowMs: t + 100_000_000 });
+  assert.equal(retiredNext.length, 0);
+  const rearm = upsertWatchers(retiredNext, [{ patternSignature: "bet_123", predicate: { kind: EVENT_PATTERN, params: { pattern: "BET-123" } }, source: "auto" }], { now: () => t + 1 });
+  assert.equal(rearm.updated[0].rearmed, true);
+  assert.equal(rearm.next[0].retired, false);
+});
+
+test("retireWatchers retires inactive watchers and archived signatures", () => {
+  const nowMs = 1_000_000;
+  const list = [
+    { id: "w1", patternSignature: "s1", created: nowMs - 10, lastHit: nowMs - 100_000_000, retired: false }, // inactive
+    { id: "w2", patternSignature: "s2", created: nowMs - 10, lastHit: nowMs - 5, retired: false }, // active
+    { id: "w3", patternSignature: "s3", created: nowMs, lastHit: null, retired: false }, // archived signature
+  ];
+  const { next, retired } = retireWatchers(list, { nowMs, archivedSignatures: ["s3"] });
+  const ids = next.map((w) => w.id).sort();
+  assert.deepEqual(ids, ["w2"]);
+  assert.deepEqual(retired.map((r) => r.id).sort(), ["w1", "w3"]);
+  assert.equal(retired.find((r) => r.id === "w3").reason, "archived");
+});
+
+// ---------------------------------------------------------------------------
+// Auto-creation from day rollups
+// ---------------------------------------------------------------------------
+
+test("extractRecurringThemes picks patterns appearing in >=2 distinct day bullets within 7 days", () => {
+  const nowMs = 1_000_000;
+  const day = nowMs - 86_400_000;
+  const dayRollups = [
+    { level: "day", window: [day, day + 86_400_000], bullets: [{ text: "BET-123 still failing in deploy" }] },
+    { level: "day", window: [day, day + 86_400_000], bullets: [{ text: "BET-123 reappears; CLI broke" }] },
+    { level: "day", window: [day, day + 86_400_000], bullets: [{ text: "random unrelated work" }] },
+  ];
+  const themes = extractRecurringThemes(dayRollups, { now: () => nowMs, minOccurrences: 2 });
+  const sigs = themes.map((t) => t.patternSignature);
+  assert.ok(sigs.includes("bet_123"), "BET-123 recurs in 2 bullets");
+  assert.ok(!sigs.includes("cli"), "single-occurrence "); // cli appears in one bullet only
+});
+
+test("engine.autoCreate upserts recurring themes by patternSignature", async () => {
+  const deps = makeEngineDeps();
+  const eng = createStandingQueryEngine(deps);
+  const day = 1_000_000 - 86_400_000;
+  const rollups = [
+    { level: "day", window: [day, day + 86_400_000], bullets: [{ text: "deploy failed on BET-99" }] },
+    { level: "day", window: [day, day + 86_400_000], bullets: [{ text: "BET-99 flaky again" }] },
+  ];
+  const first = await eng.autoCreate(rollups);
+  assert.ok(first.added.some((a) => a.patternSignature === "bet_99"));
+  const second = await eng.autoCreate(rollups);
+  assert.equal(second.added.length, 0, "second pass never dups");
+});
+
+// ---------------------------------------------------------------------------
+// Migration idempotency
+// ---------------------------------------------------------------------------
+
+test("migrateLegacy converts cto.json watches once and is a no-op on re-run", async () => {
+  const deps = makeEngineDeps();
+  const eng = createStandingQueryEngine(deps);
+  const legacy = [
+    { id: "w1", surface: "schedule", query: "read board", condition: "a P0 opens", active: true, createdAt: 10 },
+    { id: "w2", surface: "delegate", query: "q", condition: "deploy failed", active: true, createdAt: 11 },
+    { id: "w3", surface: "session", query: "q", condition: "a P0 opens", active: false, createdAt: 12 }, // inactive → skipped
+  ];
+  const firstRun = await eng.migrateLegacy(legacy);
+  assert.equal(firstRun.migrated, true);
+  assert.equal(firstRun.count, 2);
+  assert.equal((await eng.list()).length, 2);
+  // re-run is a no-op (marker in engine-state)
+  const secondRun = await eng.migrateLegacy(legacy);
+  assert.equal(secondRun.migrated, false);
+  assert.equal(secondRun.count, 0);
+  assert.equal((await eng.list()).length, 2);
+});
+
+test("migrateLegacyWatches is pure and skips un-matchable conditions", () => {
+  const converted = migrateLegacyWatches(
+    [
+      { id: "a", surface: "schedule", query: "q", condition: "deploy failed", active: true, createdAt: 1 },
+      { id: "b", surface: "session", condition: "the", active: true, createdAt: 2 }, // stopwords only → dropped
+    ],
+    { now: () => 5 },
+  );
+  assert.equal(converted.length, 1);
+  assert.equal(converted[0].id, "a");
+  assert.equal(converted[0].predicate.kind, EVENT_PATTERN);
+  assert.equal(converted[0].legacy.surface, "schedule");
+});
+
+// ---------------------------------------------------------------------------
+// Watcher hits → B4 candidate source
+// ---------------------------------------------------------------------------
+
+test("watcherHitPayload carries predicate-kind → sourceKind mapping", () => {
+  const ep = makeWatcher({ predicate: { kind: EVENT_PATTERN, params: { pattern: "x" } }, now: () => 1 }).watch;
+  const rt = makeWatcher({ predicate: { kind: RATE_THRESHOLD, params: { threshold: 2, windowMs: 5 } }, now: () => 1 }).watch;
+  assert.equal(watcherHitPayload(ep, {}).sourceKind, "watcher-hit");
+  assert.equal(watcherHitPayload(rt, {}).sourceKind, "watcher-hit-rate");
+});
+
+test("collectWatcherHitsFromLedger produces B4 findings (rate-threshold → watcher-hit-rate)", () => {
+  const rows = [
+    { kind: "watcher.hit", salience: "high", watcherId: "w1", predicateKind: RATE_THRESHOLD, text: "burst of failures", ts: 1 },
+    { kind: "watcher.hit", salience: "high", watcherId: "w2", predicateKind: EVENT_PATTERN, text: "theme", ts: 2 },
+    { kind: "other", salience: "high", watcherId: "w3", text: "nope" },
+  ];
+  const findings = collectWatcherHitsFromLedger(rows);
+  assert.equal(findings.length, 2);
+  assert.deepEqual(findings.map((f) => f.sourceKind).sort(), ["watcher-hit", "watcher-hit-rate"]);
+  assert.deepEqual(findings.map((f) => f.id).sort(), ["wh:w1", "wh:w2"]);
+});
+
+test("the steep-decay notify rule set gained watcher-hit-rate", () => {
+  assert.ok(NOTIFY_RECURRENCE_KINDS.includes("watcher-hit-rate"));
+  assert.ok(NOTIFY_RECURRENCE_KINDS.includes("failure-recurrence"));
+});
+
+test("collectFindings wires watcher hits into the candidate source input set", () => {
+  const ledgerRows = [
+    { kind: "watcher.hit", salience: "high", watcherId: "w1", predicateKind: EVENT_PATTERN, text: "theme match", ts: 1 },
+  ];
+  const findings = collectFindings([], [], { ledgerRows });
+  assert.ok(findings.some((f) => f.sourceKind === "watcher-hit" && f.text.includes("theme match")));
+  // without ledger rows no watcher findings
+  const none = collectFindings([], [], {});
+  assert.equal(none.some((f) => f.sourceKind === "watcher-hit"), false);
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1623,7 +1623,7 @@ void ensureMantaPlanAgent().catch((e) => console.error("[manta-plan] ensure fail
 let adaptiveCtoInstance = null;
 function getCtoEngine() {
   if (!adaptiveCtoInstance) {
-    adaptiveCtoInstance = cto.createCtoEngine({
+    const engine = cto.createCtoEngine({
       listProjects: () => tmux.listProjects(),
       listSessions: (dir) => oc.listSessions(dir),
       listMessages: (sid, opts) => oc.listMessages(sid, opts),
@@ -1633,7 +1633,17 @@ function getCtoEngine() {
       listStopped,
       searchMessages,
       configGet: () => local.configGet(),
+      // BET-1398: the read gateway's watch/unwatch/list_watches verbs re-point
+      // to the adaptive engine's standing-query watchers (persistent,
+      // event-driven over the evidence stream). `adaptiveCto` is created
+      // later in module scope; these closures only run at dispatch time.
+      watchers: {
+        register: (input) => adaptiveCto.watchers.register(input),
+        unregister: (id) => adaptiveCto.watchers.unregister(id),
+        list: () => adaptiveCto.watchers.list(),
+      },
     });
+    adaptiveCtoInstance = engine;
   }
   return adaptiveCtoInstance;
 }
@@ -1864,6 +1874,10 @@ const adaptiveCto = ctoEngine.createCtoEngine({
   getDb,
   backfillRunEphemeral: runEphemeral,
   cardFireNotify: (args) => push.fireNotify(args),
+  // BET-1398: one-time migration of the superseded cto.json watcher poller's
+  // watches into the standing-query engine (idempotent, marker-guarded).
+  legacyWatchesLoader: async () =>
+    Array.isArray(cto.loadCtoStore()?.watches) ? cto.loadCtoStore().watches : [],
 });
 adaptiveCto.start();
 
@@ -2096,36 +2110,10 @@ function setCallActive(active, engine) {
 // callWs.mjs where it is unit-testable.
 const callRegistry = createCallRegistry();
 
-// Which read a watcher's surface maps to. NATIVE surfaces (schedule, delegate)
-// go through the box's own stores. `session` needs no poller read — session
-// events arrive directly via send_to_cto.
-async function ctoSurfaceRead(surface, query) {
-  switch (surface) {
-    case "schedule":
-      return { ok: true, data: { jobs: await listJobs() } };
-    case "delegate":
-      return { ok: true, data: { jobs: await loadDelegateJobs() } };
-    case "session":
-    default:
-      return { ok: true, data: {} };
-  }
-}
-
-// Watcher poller (Issue 2): probes each active watch against its surface's
-// existing read and routes a matching + unseen event into the inbound funnel.
-// In-flight-guarded + timer.unref(), mirroring the schedule/delegate pollers.
-const watcherPoller = cto.createWatcherPoller({
-  loadWatches: async () => Array.isArray(cto.loadCtoStore()?.watches) ? cto.loadCtoStore().watches : [],
-  saveWatches: async (watches) => {
-    const store = cto.loadCtoStore();
-    store.watches = Array.isArray(watches) ? watches : [];
-    await cto.saveCtoStore(store);
-  },
-  readSurface: ctoSurfaceRead,
-  sendToInbound: (input) => ctoInbound.inbound(input),
-});
-// eslint-disable-next-line no-unused-vars
-const stopWatcherPoller = watcherPoller.start({ intervalMs: 15_000 });
+// BET-1398: the old surface-probing watcher poller is removed — watchers are
+// now the standing-query engine evaluated over the CTO's evidence stream (see
+// ctoWatchers.mjs / the adaptive engine's `watchers`). `send_to_cto` notes
+// still flow through createCtoInbound().inbound directly.
 
 // Sweep expired artifact-mailbox files (TTL past) every 5 min — non-destructive
 // otherwise: downloads do not delete, the sweep is what reclaims disk.

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1516,6 +1516,13 @@ rpcHandlers = buildHandlers({
   // persisted observation history.
   usageSnapshots: listSnapshots,
   usageHistory: getUsageHistory,
+  // BET-1400: quota forecast + reserve — drive a per-provider re-evaluation
+  // (C3's 30-min overnight re-eval calls `quota:evaluate`; the health card
+  // reads the persisted budget.quota via `quota:read`), and record a user
+  // cap-hit (§11.3) through `quota:capHit`.
+  "quota:evaluate": (input) => adaptiveCtoBudget.computeSpendable(input ?? {}),
+  "quota:capHit": (input) => adaptiveCtoBudget.recordCapHit(input ?? {}),
+  "quota:read": () => adaptiveCtoBudget.payload(),
   // BET-790: renderer read channel for a session's progress record (the
   // server store from src/server/progress.mjs). The write side is the AI's
   // progress_report tool → POST /api/progress.
@@ -2045,7 +2052,22 @@ const SUGGEST_INTERVAL_MS = 30 * 60_000;
 // replaces the placeholder 0/0 that could never trip), and the measured
 // per-hour burn is today's budget spend / hours elapsed. Both read the real
 // budget.json store via ctoBudget.
-const adaptiveCtoBudget = ctoBudget.createCtoBudget();
+const adaptiveCtoBudget = ctoBudget.createCtoBudget({
+  // BET-1400: the reserve/forecast runs over the poller's pct observation
+  // history (BET-1336), records cap-hits + fractile notches to the §14.5
+  // ledger, and reads the user's config (ctoNightCapUsd) for the windowless
+  // bound. getUsageHistory returns { "<provider>:<window.kind>": [{ts,pct}] }.
+  history: getUsageHistory,
+  historyKey: (provider, kind = "session") => `${provider}:${kind}`,
+  ledger: ledgerStore,
+  cfg: async () => {
+    try {
+      return await local.configGet();
+    } catch {
+      return {};
+    }
+  },
+});
 const adaptiveCtoWatchdog = ctoEngine.createWatchdog({
   engine: adaptiveCto,
   getSpendPerHour: async () => adaptiveCtoBudget.spendPerHourUsd(),

--- a/src/server/usageAdapters/claude.mjs
+++ b/src/server/usageAdapters/claude.mjs
@@ -45,6 +45,9 @@ function extraFor(pool, label) {
 export const claudeAdapter = {
   id: "claude",
   providerIDs: ["anthropic"],
+  // BET-1400 (§11.2): has plan windows (5h session + 7d weekly) — the reserve
+  // math applies and spendable is measured in fraction-of-window units.
+  windowed: true,
 
   async detect({ readCredentials = defaultReadCredentials } = {}) {
     const creds = await readCredentials();

--- a/src/server/usageAdapters/codex.mjs
+++ b/src/server/usageAdapters/codex.mjs
@@ -47,6 +47,8 @@ function resolveResetsAt(win, nowMs) {
 export const codexAdapter = {
   id: "codex",
   providerIDs: ["openai"],
+  // BET-1400 (§11.2): has plan windows (session + weekly) — reserve applies.
+  windowed: true,
 
   async detect({ readToken = defaultReadToken } = {}) {
     const token = await readToken();

--- a/src/server/usageAdapters/kimi.mjs
+++ b/src/server/usageAdapters/kimi.mjs
@@ -64,6 +64,8 @@ function windowFromDetail(detail, kind, label) {
 export const kimiAdapter = {
   id: "kimi",
   providerIDs: [PROVIDER_ID],
+  // BET-1400 (§11.2): has plan windows (5h session + weekly) — reserve applies.
+  windowed: true,
 
   async detect({ readKey = defaultReadKey } = {}) {
     const key = await readKey();


### PR DESCRIPTION
Opened automatically for `multica/BET-1400-forecast-reserve`, which was pushed without a pull request.

Some agents push a branch but never open a PR — the `macos` worker is
forbidden from opening one, and any run can die between its push and its
hand-off. Either way the work is stranded on the remote and invisible to
review. This sweep carries it into a reviewable PR instead.

The commits are the agent's own and have not been modified.

Relates to BET-1400.