### PR TITLE
feat(server): BET-1400 quota forecast + reserve (HW seasonal reserve, spendable, ctoNightCapUsd, health rows, quota RPC)

### DIFF
--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -28,11 +28,60 @@
 // model (no cost data) prices at 0 — honest: we cannot charge what we cannot
 // measure.
 
+// ---------------------------------------------------------------------------
+// Reserve & spendable (§11.2, §11.3) — BET-1400
+// ---------------------------------------------------------------------------
+//
+// The overnight CTO reserves a slice of each WINDOWED provider's plan window
+// against the user's own near-term demand, so overnight autonomy never starves
+// the user's interactive work. Everything here lives in FRACTION-OF-WINDOW
+// space (Option A — see ctoForecast.mjs for the units decision):
+//
+//   reserve   = newsvendor fractile of next-day forecast demand (fraction),
+//               or the §11.3 pre-forecast fallback max(observed daily max,
+//               60% of window) under 14 days of history.
+//   spendable = remaining − reserve, floored at 0.  (created/spendable)
+//
+// The fractile initializes at P95 and NOTCHES across the ladder
+// [P90, P95, P99]: up (≤ P99) on each user cap-hit; down (≥ P90) after 30
+// clean days. Notching is active only once ≥ 14 days of history exist — the
+// pre-forecast fallback is not a fractile and never notches.
+//
+// Clean-day / cap-hit definitions (BET-1400 blocker resolution): a cap-hit =
+// the user's plan window is exhausted (an adapter reports a window at/over
+// its limit, `pct >= 100`); a clean day = no cap-hit AND no forecast-exceeding
+// spend that day. Both are recorded as §14.5 ledger rows by the accessor.
+//
+// WINDOWLESS / NO-ADAPTER (§11.2): the reserve math is disabled (there is
+// nothing to reserve) and overnight spend is bounded by an absolute $ budget,
+// `ctoNightCapUsd` (user-set in Behavior, default $5/night). The forecaster
+// still runs to feed the Health card, but produces no reserve.
+
 import { budgetStore } from "./ctoStores.mjs";
 import { startOfDay } from "./ctoRollups.mjs";
 import { blendedPrice } from "../shared/blendedPrice.mjs";
+import {
+  forecastNextDayFraction,
+  forecastMape,
+  trailingDailySeries,
+  dailyUsageFractions,
+} from "./ctoForecast.mjs";
 
+export const DEFAULT_NIGHT_CAP_USD = 5;
 export const DEFAULT_AMBIENT_CAP_USD = 2.5;
+
+// The fractile notch ladder — P95 init, P99 ceiling, P90 floor (§11.3).
+export const FRACTILE_LADDER = Object.freeze([0.9, 0.95, 0.99]);
+export const FRACTILE_INIT = 0.95;
+// ≥ this many days of history activates notching (the pre-forecast fallback —
+// which is not a fractile — never notches).
+export const RESERVE_ACTIVATE_DAYS = 14;
+// This many consecutive clean days lower the fractile one notch (§11.3).
+export const RESERVE_CLEAN_DAYS = 30;
+// The §11.3 fallback floor: 60% of the window.
+export const RESERVE_FALLBACK_FLOOR = 0.6;
+// Rolling look-back for the daily series — 8 weeks.
+export const RESERVE_FORECAST_DAYS = 56;
 export const BURN_HISTORY_DAYS = 7;
 export const HOUR_MS = 3_600_000;
 
@@ -234,20 +283,173 @@ export function tierAllows(tier, feature) {
   return tierIdx !== -1 && reqIdx !== -1 && tierIdx >= reqIdx;
 }
 
+function clamp01(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : 0;
+}
+
+/** The configured nightly $ bound for windowless/no-adapter overnight work
+ *  (config `ctoNightCapUsd`, default $5/night, §11.2). */
+export function nightCapUsd(cfg) {
+  const c = cfg && typeof cfg === "object" ? cfg.ctoNightCapUsd : undefined;
+  return typeof c === "number" && Number.isFinite(c) && c >= 0 ? c : DEFAULT_NIGHT_CAP_USD;
+}
+
+/** A fresh per-provider reserve-quota state row (stored under `budget.quota`). */
+export function defaultQuotaState(provider = null) {
+  return {
+    provider,
+    fractile: FRACTILE_INIT,
+    activated: false,
+    cleanDays: 0,
+    mode: null,
+    reserve: 0,
+    spendable: 0,
+    maxObserved: 0,
+    historyDays: 0,
+    remainingFrac: 0,
+    mape14: null,
+    updatedMs: null,
+  };
+}
+
+/** Normalise a stored budget payload defensively, preserving the `quota` bag. */
+export function normalizeQuota(payload) {
+  const p = normalizeBudget(payload);
+  const quota = p.quota && typeof p.quota === "object" ? p.quota : {};
+  return { ...p, quota };
+}
+
+/** Move a fractile one ladder notch up (+1) or down (−1), clamped to the
+ *  ladder [P90, P95, P99]. Unknown current values normalise to the P95 init
+ *  before stepping. */
+export function notchFractile(current, direction) {
+  let idx = FRACTILE_LADDER.indexOf(current);
+  if (idx === -1) idx = FRACTILE_LADDER.indexOf(FRACTILE_INIT);
+  const target = Math.max(0, Math.min(FRACTILE_LADDER.length - 1, idx + (direction > 0 ? 1 : direction < 0 ? -1 : 0)));
+  return FRACTILE_LADDER[target];
+}
+
+/**
+ * Fold cap-hit / clean-day signals into a quota state (pure). Notching is only
+ * applied once `activated` (≥ 14 days of history — the caller decides, since
+ * only it knows the history length):
+ *   - each cap-hit raises the fractile one notch (already clamped to ≤ P99),
+ *   - `RESERVE_CLEAN_DAYS` accumulated clean days lower it one notch, then
+ *     reset the clean streak (a clean day = no cap-hit AND no
+ *     forecast-exceeding spend).
+ * Returns a new state; the input is never mutated.
+ */
+export function foldQuotaState(state, { capHits = 0, earnedCleanDays = 0, activated = false } = {}) {
+  const s = state && typeof state === "object" ? { ...state } : defaultQuotaState(null);
+  let fractile = s.fractile ?? FRACTILE_INIT;
+  let cleanDays = s.cleanDays ?? 0;
+  if (activated) {
+    cleanDays = Math.max(0, cleanDays) + Math.max(0, Number.isFinite(Number(earnedCleanDays)) ? earnedCleanDays | 0 : 0);
+    const hits = Math.max(0, Number(Number(capHits) | 0));
+    for (let i = 0; i < hits; i++) fractile = notchFractile(fractile, +1);
+    if (cleanDays >= RESERVE_CLEAN_DAYS) {
+      fractile = notchFractile(fractile, -1);
+      cleanDays = 0;
+    }
+  }
+  return { ...s, fractile, cleanDays, activated: !!activated };
+}
+
+/**
+ * The §11.3 reserve + spendable for one provider's plan window (pure). `series`
+ * is the contiguous trailing daily fraction series (oldest→newest, from the
+ * forecast module); `forecast` is a `({series, fractile}) => {mode, value}`
+ * function (default: the HW/quantile forecast — injectable for tests). Below
+ * the 14-day activation gate (or when the forecaster has insufficient data) it
+ * returns the pre-forecast fallback `max(observed daily max, 60% of window)`
+ * at the P95 init fractile — which never notches.
+ */
+export function planReserve({
+  state = defaultQuotaState(),
+  series,
+  remainingPct,
+  forecast = ({ fractile } = {}) => forecastNextDayFraction({ series, fractile }),
+  fallbackFloor = RESERVE_FALLBACK_FLOOR,
+} = {}) {
+  const vals = Array.isArray(series) ? series.filter(Number.isFinite) : [];
+  const maxObserved = vals.length ? Math.max(0, ...vals) : 0;
+  const historyDays = vals.filter((v) => v > 0).length;
+  const activated = !!state?.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
+  const fractile = activated ? (state?.fractile ?? FRACTILE_INIT) : FRACTILE_INIT;
+
+  let mode;
+  let reserve;
+  let point = null;
+  let sigma = null;
+  if (!activated) {
+    mode = "fallback";
+    reserve = Math.max(maxObserved, fallbackFloor);
+  } else {
+    const fc = forecast({ series, fractile }) ?? { mode: "fallback", value: null };
+    if (fc?.mode === "forecast" && typeof fc.value === "number") {
+      mode = "forecast";
+      reserve = fc.value;
+      point = fc.point ?? null;
+      sigma = fc.sigma ?? null;
+    } else {
+      mode = "fallback";
+      reserve = Math.max(maxObserved, fallbackFloor);
+    }
+  }
+  reserve = clamp01(reserve);
+  const remainingFrac = clamp01((Number(remainingPct) || 0) / 100);
+  const spendableFrac = Math.max(0, remainingFrac - reserve);
+  return {
+    mode,
+    activated,
+    fractile,
+    reserve,
+    maxObserved,
+    historyDays,
+    remainingFrac,
+    spendableFrac,
+    point,
+    sigma,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The I/O accessor the engine consumes (injected store + seams).
 // ---------------------------------------------------------------------------
 // The I/O accessor the engine consumes (injected store + seams).
 // ---------------------------------------------------------------------------
 
-export function createCtoBudget({ store = budgetStore, price = priceTokens, now = Date.now } = {}) {
+export function createCtoBudget({
+  store = budgetStore,
+  price = priceTokens,
+  now = Date.now,
+  // BET-1400 seams (all injectable for sandboxed tests; index.mjs wires the
+  // real usage-history + §14.5 ledger):
+  history = async () => ({}), // () => { "<provider>:<kind>": [{ts,pct}] }
+  historyKey = (provider, kind) => `${provider}:${kind}`,
+  buildSeries = (obs, t) => trailingDailySeries(dailyUsageFractions(obs), { now: t, days: RESERVE_FORECAST_DAYS }),
+  forecast = ({ series, fractile }) => forecastNextDayFraction({ series, fractile }),
+  mapeFn = forecastMape,
+  cfg = () => ({}), // () => config object (ctoNightCapUsd read here)
+  ledger = null, // optional { append(row) } — the §14.5 activity ledger
+} = {}) {
   async function load() {
     try {
-      return normalizeBudget(await store.load());
+      return normalizeQuota(await store.load());
     } catch {
-      return defaultBudgetPayload();
+      return normalizeQuota(defaultBudgetPayload());
     }
   }
   async function save(payload) {
-    await store.save(normalizeBudget(payload));
+    await store.save(normalizeQuota(payload));
+  }
+  async function ledgerAppend(row) {
+    try {
+      if (ledger && typeof ledger.append === "function") await ledger.append(row);
+    } catch {
+      /* ledger is best-effort — never fail quota evaluation on a ledger write */
+    }
   }
   async function record({ model, tokens, nowMs } = {}) {
     const t = typeof nowMs === "number" && Number.isFinite(nowMs) ? nowMs : now();
@@ -263,6 +465,95 @@ export function createCtoBudget({ store = budgetStore, price = priceTokens, now 
       return { usd, dayKey: dayKey(t), ok: false };
     }
   }
+
+  /**
+   * Re-evaluate one provider's reserve + spendable (§11.3): read the provider's
+   * pct observation history, fold cap-hit/clean-day signals into its quota
+   * state, compute the reserve at the active fractile (or the pre-forecast
+   * fallback), persist the quota row + the §14.5 forecast cache, and return the
+   * plan. This is the function C3's overnight scheduler calls on its 30-min
+   * re-evaluation; the Health card reads the persisted `budget.quota`.
+   *
+   * `windowed: false` (a windowless provider or one with no adapter, §11.2)
+   * disables the reserve: it returns `{windowed:false, mode:'windowless',
+   * spendable:null, reserve:0, nightCapUsd}` and bounds overnight spend by the
+   * absolute `ctoNightCapUsd` budget instead.
+   */
+  async function computeSpendable({
+    provider,
+    remainingPct,
+    windowKind = "session",
+    windowed = true,
+    capHitsSince = 0,
+    earnedCleanDays = 0,
+  } = {}) {
+    const t = typeof now === "function" ? now() : typeof now === "number" ? now : Date.now();
+    if (!windowed) {
+      let conf = {};
+      try {
+        conf = (await cfg()) ?? {};
+      } catch {
+        conf = {};
+      }
+      if (!conf || typeof conf !== "object") conf = {};
+      return {
+        provider,
+        windowed: false,
+        mode: "windowless",
+        reserve: 0,
+        spendable: null,
+        remainingFrac: null,
+        historyDays: 0,
+        nightCapUsd: nightCapUsd(conf),
+      };
+    }
+    const hist = (await history().catch(() => ({}))) ?? {};
+    const obs = hist[historyKey(provider, windowKind)] ?? [];
+    const { series, historyDays, maxObserved } = buildSeries(obs, t);
+
+    const payload = await load();
+    const prev = payload.quota?.[provider] ?? defaultQuotaState(provider);
+    const activated = !!prev.activated || historyDays >= RESERVE_ACTIVATE_DAYS;
+    const folded = foldQuotaState(prev, { capHits: capHitsSince, earnedCleanDays, activated });
+    const plan = planReserve({ state: folded, series, remainingPct, forecast });
+    const quota = {
+      ...folded,
+      provider,
+      mode: plan.mode,
+      reserve: plan.reserve,
+      spendable: plan.spendableFrac,
+      maxObserved: plan.maxObserved,
+      historyDays: plan.historyDays,
+      remainingFrac: plan.remainingFrac,
+      mape14: mapeFn({ series, tailDays: 14 }),
+      updatedMs: t,
+    };
+    const nextPayload = { ...payload, quota: { ...payload.quota, [provider]: quota } };
+    try {
+      await save(nextPayload);
+    } catch {
+      /* quota persistence is best-effort */
+    }
+    // §14.5 ledger rows: a fractile notch and a spendable-reserve line.
+    if (folded.fractile !== (prev.fractile ?? FRACTILE_INIT)) {
+      await ledgerAppend({ kind: "cto.reserve.fractile", ts: t, provider, from: prev.fractile ?? FRACTILE_INIT, to: folded.fractile });
+    }
+    await ledgerAppend({ kind: "cto.reserve", ts: t, provider, reserve: plan.reserve, spendable: plan.spendableFrac, fractile: plan.fractile, mode: plan.mode });
+    return { provider, windowed: true, ...plan, mape14: quota.mape14 };
+  }
+
+  /**
+   * Record a user cap-hit (the provider's plan window exhausted, `pct >= 100`)
+   * as a §14.5 ledger row. Does not itself notch — the next evaluate folds the
+   * cap-hit into the quota state. Purely a recording seam for the poller/engine
+   * that observes the exhaustion.
+   */
+  async function recordCapHit({ provider, tsMs, pct } = {}) {
+    const t = typeof tsMs === "number" && Number.isFinite(tsMs) ? tsMs : (typeof now === "function" ? now() : Date.now());
+    await ledgerAppend({ kind: "cto.cap_hit", ts: t, provider, pct });
+    return { ok: true };
+  }
+
   return {
     record,
     payload: load,
@@ -271,5 +562,7 @@ export function createCtoBudget({ store = budgetStore, price = priceTokens, now 
     spendPerHourUsd: async () => spendPerHourNow(await load(), now()),
     expectedHourlyBurnUsd: async ({ capUsd } = {}) => expectedHourlyBurnUsd(await load(), { now: now(), capUsd }),
     didDayRoll: async () => didDayRoll(await load(), now()),
+    computeSpendable,
+    recordCapHit,
   };
 }

--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -417,8 +417,6 @@ export function planReserve({
 // ---------------------------------------------------------------------------
 // The I/O accessor the engine consumes (injected store + seams).
 // ---------------------------------------------------------------------------
-// The I/O accessor the engine consumes (injected store + seams).
-// ---------------------------------------------------------------------------
 
 export function createCtoBudget({
   store = budgetStore,
@@ -475,9 +473,12 @@ export function createCtoBudget({
    * re-evaluation; the Health card reads the persisted `budget.quota`.
    *
    * `windowed: false` (a windowless provider or one with no adapter, §11.2)
-   * disables the reserve: it returns `{windowed:false, mode:'windowless',
-   * spendable:null, reserve:0, nightCapUsd}` and bounds overnight spend by the
-   * absolute `ctoNightCapUsd` budget instead.
+   * disables the reserve — it returns the same key set as the windowed plan
+   * (`spendableFrac: null`, `reserve: 0`, `mode: 'windowless'`, plus
+   * `nightCapUsd`) and bounds overnight spend by the absolute
+   * `ctoNightCapUsd` budget instead. The forecaster still runs (§11.2): the
+   * pct series is built, `mape14` computed (null without usable history) and
+   * persisted in the quota row for the Health card.
    */
   async function computeSpendable({
     provider,
@@ -496,14 +497,49 @@ export function createCtoBudget({
         conf = {};
       }
       if (!conf || typeof conf !== "object") conf = {};
+      // §11.2: reserve disabled, but the forecaster still runs to feed the
+      // Health card — build the same pct-history series the windowed path
+      // uses and persist a quota row carrying `mape14` (reserve stays 0;
+      // overnight spend is bounded by the absolute `ctoNightCapUsd` instead).
+      const hist = (await history().catch(() => ({}))) ?? {};
+      const obs = hist[historyKey(provider, windowKind)] ?? [];
+      const { series, historyDays, maxObserved } = buildSeries(obs, t);
+      const mape14 = mapeFn({ series, tailDays: 14 });
+      const payload = await load();
+      const quota = {
+        ...defaultQuotaState(provider),
+        mode: "windowless",
+        reserve: 0,
+        spendable: null,
+        maxObserved,
+        historyDays,
+        remainingFrac: null,
+        mape14,
+        updatedMs: t,
+      };
+      const nextPayload = { ...payload, quota: { ...payload.quota, [provider]: quota } };
+      try {
+        await save(nextPayload);
+      } catch {
+        /* quota persistence is best-effort */
+      }
+      await ledgerAppend({ kind: "cto.reserve", ts: t, provider, reserve: 0, spendable: null, fractile: quota.fractile, mode: "windowless" });
+      // Same key set as the windowed plan below — C3's re-evaluation seam
+      // consumes both modes uniformly (null where the concept doesn't apply).
       return {
         provider,
         windowed: false,
         mode: "windowless",
+        activated: false,
+        fractile: quota.fractile,
         reserve: 0,
-        spendable: null,
+        maxObserved,
+        historyDays,
         remainingFrac: null,
-        historyDays: 0,
+        spendableFrac: null,
+        point: null,
+        sigma: null,
+        mape14,
         nightCapUsd: nightCapUsd(conf),
       };
     }

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -2,17 +2,24 @@ import { test } from "node:test";
 import assert from "node:assert/strict";
 import {
   DEFAULT_AMBIENT_CAP_USD,
+  DEFAULT_NIGHT_CAP_USD,
+  FRACTILE_INIT,
   THRIFTY_SHED_ORDER,
   THRIFTY_KEEP,
   createCtoBudget,
   ambientCapUsd,
   dayKey,
   defaultBudgetPayload,
+  defaultQuotaState,
   didDayRoll,
   expectedHourlyBurnUsd,
+  foldQuotaState,
   hoursIntoLocalDay,
   isAmbientCapHit,
   isWorkShedInThrifty,
+  nightCapUsd,
+  notchFractile,
+  planReserve,
   priceTokens,
   recordSpend,
   spendForDay,
@@ -201,4 +208,157 @@ test("createCtoBudget degrades safely when the store is down", async () => {
   assert.equal(await budget.isCapHit(2.5), false);
   await budget.record({ model: {}, tokens: 1000 }); // must not throw
   assert.equal(await budget.expectedHourlyBurnUsd({ capUsd: 2.5 }), 2.5 / 24);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1400 — reserve & spendable (§11.2, §11.3)
+// ---------------------------------------------------------------------------
+
+test("nightCapUsd defaults to $5 and honors ctoNightCapUsd", () => {
+  assert.equal(nightCapUsd({}), DEFAULT_NIGHT_CAP_USD);
+  assert.equal(nightCapUsd({ ctoNightCapUsd: 3 }), 3);
+  assert.equal(nightCapUsd({ ctoNightCapUsd: 0 }), 0);
+  assert.equal(nightCapUsd({ ctoNightCapUsd: -1 }), DEFAULT_NIGHT_CAP_USD);
+});
+
+test("notchFractile walks the [P90,P95,P99] ladder and clamps", () => {
+  assert.equal(notchFractile(0.95, +1), 0.99);
+  assert.equal(notchFractile(0.99, +1), 0.99); // max P99
+  assert.equal(notchFractile(0.95, -1), 0.9);
+  assert.equal(notchFractile(0.9, -1), 0.9); // min P90
+  assert.equal(notchFractile(999, +1), 0.99); // unknown normalises from P95 init
+});
+
+test("foldQuotaState: no notching before activation (>= 14 days)", () => {
+  const s = foldQuotaState(defaultQuotaState(), { capHits: 5, earnedCleanDays: 60, activated: false });
+  assert.equal(s.fractile, FRACTILE_INIT);
+  assert.equal(s.cleanDays, 0);
+  assert.equal(s.activated, false);
+});
+
+test("foldQuotaState: cap-hits raise the fractile one notch (max P99)", () => {
+  const s = foldQuotaState(defaultQuotaState(), { capHits: 1, activated: true });
+  assert.equal(s.fractile, 0.99);
+  // a second hit stays clamped at P99
+  const s2 = foldQuotaState(defaultQuotaState(), { capHits: 2, activated: true });
+  assert.equal(s2.fractile, 0.99);
+  // from P90 a single hit climbs one rung
+  const s3 = foldQuotaState({ ...defaultQuotaState(), fractile: 0.9 }, { capHits: 1, activated: true });
+  assert.equal(s3.fractile, 0.95);
+});
+
+test("foldQuotaState: 30 clean days lower the fractile one notch (min P90)", () => {
+  const s = foldQuotaState(defaultQuotaState(), { earnedCleanDays: 30, activated: true });
+  assert.equal(s.fractile, 0.9);
+  assert.equal(s.cleanDays, 0); // streak reset after the notch
+  // 60 clean days still notch only once per fold
+  const s2 = foldQuotaState(defaultQuotaState(), { earnedCleanDays: 60, activated: true });
+  assert.equal(s2.fractile, 0.9);
+  // from 0.99 one clean month steps down to 0.95
+  const s3 = foldQuotaState({ ...defaultQuotaState(), fractile: 0.99 }, { earnedCleanDays: 30, activated: true });
+  assert.equal(s3.fractile, 0.95);
+});
+
+test("planReserve: pre-forecast fallback below 14 days uses max(observed, 60% window)", () => {
+  const plan = planReserve({ state: defaultQuotaState(), series: [0.1, 0.1, 0.1], remainingPct: 50 });
+  assert.equal(plan.mode, "fallback");
+  assert.equal(plan.activated, false);
+  assert.equal(plan.fractile, FRACTILE_INIT);
+  assert.equal(plan.reserve, 0.6); // max(0.1, 0.6)
+  assert.equal(plan.spendableFrac, 0); // remaining(0.5) < reserve(0.6) → floored at 0
+});
+
+test("planReserve: forecast mode above the gate; spendable = remaining − reserve", () => {
+  const series = Array(14).fill(0.1);
+  const plan = planReserve({
+    state: defaultQuotaState(),
+    series,
+    remainingPct: 90,
+    forecast: () => ({ mode: "forecast", value: 0.3, point: 0.25, sigma: 0.05 }),
+  });
+  assert.equal(plan.mode, "forecast");
+  assert.equal(plan.activated, true);
+  assert.ok(Math.abs(plan.reserve - 0.3) < 1e-9);
+  assert.ok(Math.abs(plan.spendableFrac - 0.6) < 1e-9);
+});
+
+test("planReserve: spendable floored at 0 when remaining < reserve", () => {
+  const plan = planReserve({
+    state: { ...defaultQuotaState(), activated: true },
+    series: Array(14).fill(0.1),
+    remainingPct: 20,
+    forecast: () => ({ mode: "forecast", value: 0.3 }),
+  });
+  assert.equal(plan.spendableFrac, 0);
+});
+
+test("planReserve: forecast that returns fallback still degrades to the fallback", () => {
+  const plan = planReserve({
+    state: { ...defaultQuotaState(), activated: true },
+    series: Array(14).fill(0.1),
+    remainingPct: 80,
+    forecast: () => ({ mode: "fallback", value: null }),
+  });
+  assert.equal(plan.mode, "fallback");
+  assert.equal(plan.reserve, 0.6);
+});
+
+test("computeSpendable: windowless/no-adapter routes to the $ bound (no reserve)", async () => {
+  const budget = createCtoBudget({ store: { load: async () => ({}), save: async () => {} }, cfg: () => ({ ctoNightCapUsd: 3 }) });
+  const plan = await budget.computeSpendable({ provider: "someone", windowed: false });
+  assert.equal(plan.mode, "windowless");
+  assert.equal(plan.windowed, false);
+  assert.equal(plan.spendable, null);
+  assert.equal(plan.reserve, 0);
+  assert.equal(plan.nightCapUsd, 3);
+});
+
+test("computeSpendable: windowed persists quota + attaches §14.5 ledger rows", async () => {
+  let saved = null;
+  const ledgerRows = [];
+  const store = {
+    load: async () => ({}),
+    save: async (p) => {
+      saved = p;
+    },
+  };
+  const budget = createCtoBudget({
+    store,
+    now: () => NOON,
+    history: async () => ({ "claude:session": [{ ts: NOON, pct: 10 }] }),
+    buildSeries: (obs, t) => ({ series: Array(14).fill(0.1), historyDays: 14, maxObserved: 0.1 }),
+    forecast: () => ({ mode: "forecast", value: 0.25, point: 0.2, sigma: 0.05 }),
+    mapeFn: () => 5,
+    ledger: { append: (r) => ledgerRows.push(r) },
+  });
+  const plan = await budget.computeSpendable({ provider: "claude", remainingPct: 80, windowed: true, capHitsSince: 1 });
+  assert.equal(plan.windowed, true);
+  assert.equal(plan.reserve, 0.25);
+  assert.ok(Math.abs(plan.spendableFrac - 0.55) < 1e-9); // 0.8 − 0.25
+  assert.equal(plan.fractile, 0.99); // capHitsSince 1 notched up
+  assert.equal(plan.mape14, 5);
+  // persisted quota row reflects the plan
+  assert.equal(saved.quota.claude.reserve, 0.25);
+  assert.equal(saved.quota.claude.activated, true);
+  // fractile change + reserve line both ledgered
+  const kinds = ledgerRows.map((r) => r.kind);
+  assert.ok(kinds.includes("cto.reserve.fractile"));
+  assert.ok(kinds.includes("cto.reserve"));
+  const fracRow = ledgerRows.find((r) => r.kind === "cto.reserve.fractile");
+  assert.equal(fracRow.from, 0.95);
+  assert.equal(fracRow.to, 0.99);
+});
+
+test("recordCapHit writes a cto.cap_hit ledger row", async () => {
+  const ledgerRows = [];
+  const budget = createCtoBudget({
+    store: { load: async () => ({}), save: async () => {} },
+    now: () => NOON,
+    ledger: { append: (r) => ledgerRows.push(r) },
+  });
+  await budget.recordCapHit({ provider: "claude", pct: 100 });
+  assert.equal(ledgerRows.length, 1);
+  assert.equal(ledgerRows[0].kind, "cto.cap_hit");
+  assert.equal(ledgerRows[0].provider, "claude");
+  assert.equal(ledgerRows[0].pct, 100);
 });

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -115,7 +115,6 @@ test("expected hourly burn derives from trailing 7-day spend", () => {
   assert.ok(Math.abs(burn - 0.1) < 1e-9);
   // Old spend ages out of the 7-day window: the day-7 bucket alone, /168h.
   const onlyRecent = defaultBudgetPayload();
-  expectedHourlyBurnUsd;
   const p2 = recordSpend(defaultBudgetPayload(), { now: MIDNIGHT + 6 * 86_400_000 + 1000, usd: 1.68 });
   const burn2 = expectedHourlyBurnUsd(p2, { now: MIDNIGHT + 6 * 86_400_000 + 5000, capUsd: 2.5 });
   assert.ok(Math.abs(burn2 - 1.68 / 168) < 1e-9);
@@ -303,14 +302,58 @@ test("planReserve: forecast that returns fallback still degrades to the fallback
   assert.equal(plan.reserve, 0.6);
 });
 
-test("computeSpendable: windowless/no-adapter routes to the $ bound (no reserve)", async () => {
-  const budget = createCtoBudget({ store: { load: async () => ({}), save: async () => {} }, cfg: () => ({ ctoNightCapUsd: 3 }) });
+test("computeSpendable: windowless/no-adapter routes to the $ bound (no reserve, no history → no MAPE)", async () => {
+  let saved = null;
+  const ledgerRows = [];
+  const budget = createCtoBudget({
+    store: { load: async () => ({}), save: async (p) => (saved = p) },
+    cfg: () => ({ ctoNightCapUsd: 3 }),
+    ledger: { append: (r) => ledgerRows.push(r) },
+  });
   const plan = await budget.computeSpendable({ provider: "someone", windowed: false });
   assert.equal(plan.mode, "windowless");
   assert.equal(plan.windowed, false);
-  assert.equal(plan.spendable, null);
+  assert.equal(plan.spendableFrac, null);
   assert.equal(plan.reserve, 0);
   assert.equal(plan.nightCapUsd, 3);
+  // no usable history → the forecaster yields no MAPE, but the key set still
+  // matches the windowed plan (uniform seam for C3)
+  assert.equal(plan.mape14, null);
+  assert.equal(plan.historyDays, 0);
+  assert.equal(plan.maxObserved, 0);
+  assert.equal(plan.remainingFrac, null);
+  // a quota row is still persisted (mode windowless, reserve 0)
+  assert.equal(saved.quota.someone.mode, "windowless");
+  assert.equal(saved.quota.someone.reserve, 0);
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.reserve" && r.mode === "windowless"));
+});
+
+test("computeSpendable: windowless still computes the forecast for the health card (§11.2)", async () => {
+  let saved = null;
+  const ledgerRows = [];
+  const budget = createCtoBudget({
+    store: { load: async () => ({}), save: async (p) => (saved = p) },
+    now: () => NOON,
+    history: async () => ({ "kimi:session": [{ ts: NOON, pct: 10 }] }),
+    buildSeries: () => ({ series: Array(14).fill(0.1), historyDays: 14, maxObserved: 0.1 }),
+    mapeFn: () => 7.5,
+    ledger: { append: (r) => ledgerRows.push(r) },
+    cfg: () => ({ ctoNightCapUsd: 3 }),
+  });
+  const plan = await budget.computeSpendable({ provider: "kimi", windowed: false });
+  assert.equal(plan.windowed, false);
+  assert.equal(plan.mode, "windowless");
+  assert.equal(plan.reserve, 0);
+  assert.equal(plan.spendableFrac, null);
+  assert.equal(plan.mape14, 7.5); // the forecaster ran — the health card is fed
+  assert.equal(plan.historyDays, 14);
+  assert.ok(Math.abs(plan.maxObserved - 0.1) < 1e-9);
+  assert.equal(plan.nightCapUsd, 3);
+  // the persisted row carries the MAPE and no reserve
+  assert.equal(saved.quota.kimi.mape14, 7.5);
+  assert.equal(saved.quota.kimi.reserve, 0);
+  assert.equal(saved.quota.kimi.mode, "windowless");
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.reserve" && r.mode === "windowless"));
 });
 
 test("computeSpendable: windowed persists quota + attaches §14.5 ledger rows", async () => {

--- a/src/server/ctoForecast.mjs
+++ b/src/server/ctoForecast.mjs
@@ -1,0 +1,288 @@
+// src/server/ctoForecast.mjs
+// BET-1400 — the CTO's usage forecasting math (spec §11.2, §11.3, §14.5).
+// Pure: no I/O, no imports from the live box. All inputs are injected.
+//
+// WHAT LIVES HERE (per the issue's "Files": ctoForecast.mjs = pure math +
+// injected history):
+//   - dailyUsageFractions      pct observations -> per-day usage as a fraction
+//                              of the plan window (Option A, §11.3 — see below).
+//   - holtWinters              additive Holt-Winters with damped trend and
+//                              weekly seasonality (m=7) over a daily series.
+//   - sampleStd / mape         residual scatter + forecast accuracy (§14.5).
+//   - quantileForecast         newsvendor fractile from residual sigma.
+//   - forecastNextDayFraction  the small exported "reserve" math: hand a
+//                              trailing daily series + a fractile, get the
+//                              next-day point/quantile forecast or the
+//                              pre-forecast fallback.
+//   - trailingDailySeries      builds the contiguous rolling-8-week daily
+//                              series a forecast consumes, from observations.
+//
+// RESERVE UNITS (the BET-1400 blocker, resolved to Option A): reserve and
+// spendable live in FRACTION-OF-WINDOW space, and the demand series comes from
+// the box's existing per-provider pct observation history
+// (`usage.mjs` → `statePath("usage-history.json")`, BET-1336), NOT from the
+// model ledger. The windowed adapters (claude/codex/kimi) only report a
+// fraction of the plan window (claude/codex: pct only; kimi: used/limit request
+// counts) — they expose no window capacity in token/$ units, so a reserve
+// expressed in ledger units could never be compared to `remaining`. Working in
+// fraction-of-window space makes every formula in §11.3 coherent
+// (`reserve = max(observed daily max, 60% of window)` meaningful, `remaining −
+// reserve` comparable) with zero invented capacity. The pct history *is* a
+// usage history, so this does not stretch §11.3's "usage ledger".
+//
+// CLEAN-DAY / CAP-HIT DEFINITIONS (also resolved by the BET-1400 blocker): a
+// cap-hit = the user's provider plan window is exhausted (an adapter snapshot
+// reports a window at/over its limit, `pct >= 100`). A clean day = no cap-hit
+// AND no forecast-exceeding spend that day. Both are recorded as §14.5 ledger
+// rows and consumed by the notch state machine in ctoBudget.mjs.
+
+import { dayKey } from "../shared/timeBuckets.mjs";
+
+// Standard normal Z for the newsvendor fractiles §11.3 names. The fractile
+// ladder is P90 / P95 / P99; the Z values let `quantileForecast` translate
+// residual sigma into the forecast at a given fractile.
+export const QUANTILE_Z = Object.freeze({
+  0.9: 1.2815515655446004,
+  0.95: 1.6448536269514722,
+  0.99: 2.3263478740408408,
+});
+
+/** Rolling look-back for the daily series — 8 weeks (56 days), per §11.3. */
+export const FORECAST_LOOKBACK_DAYS = 56;
+
+function clamp01(v) {
+  const n = Number(v);
+  return Number.isFinite(n) ? Math.max(0, Math.min(1, n)) : 0;
+}
+
+/** Sample standard deviation; 0 for < 2 samples. */
+export function sampleStd(values) {
+  if (!Array.isArray(values) || values.length < 2) return 0;
+  const xs = values.filter(Number.isFinite);
+  if (xs.length < 2) return 0;
+  const mean = xs.reduce((a, b) => a + b, 0) / xs.length;
+  const ss = xs.reduce((a, b) => a + (b - mean) * (b - mean), 0);
+  return Math.sqrt(ss / (xs.length - 1));
+}
+
+/** Mean absolute percentage error (×100, i.e. "%"). null for < 2 non-zero
+ *  actuals — a MAPE with one or zero samples is noise, not signal (§10.5 never
+ *  shows noise). Zero actuals are skipped (division undefined). */
+export function mape(actual, forecast) {
+  if (!Array.isArray(actual) || !Array.isArray(forecast)) return null;
+  let sum = 0;
+  let n = 0;
+  const len = Math.min(actual.length, forecast.length);
+  for (let i = 0; i < len; i++) {
+    const a = actual[i];
+    const f = forecast[i];
+    if (!Number.isFinite(a) || !Number.isFinite(f) || a === 0) continue;
+    sum += Math.abs((a - f) / a);
+    n += 1;
+  }
+  return n >= 2 ? (sum / n) * 100 : null;
+}
+
+/**
+ * Daily usage (fraction of the window) from raw pct observations (BET-1336
+ * history rows: `[{ts, pct}]`, any order). `pct` is 0-100; a day's usage is the
+ * shared fraction of the window consumed that day, attributed to the local day
+ * of each observation:
+ *
+ *   usage += max(0, pct[t] − pct[t−1]) / 100     (per observation, same window)
+ *
+ * A positive delta accumulates consumption within one window cycle; a window
+ * RESET shows as a pct DROP, whose negative delta contributes 0 (a reset never
+ * "frees" usage), and the fresh cycle then accumulates from its lower baseline —
+ * so a mid-day reset correctly keeps BOTH the old cycle's consumption and the
+ * new cycle's, and the day total never exceeds 1.0. This is the Option-A
+ * "pct delta across a local day within one window cycle".
+ * @param {Array<{ts:number, pct:number}>} observations
+ * @returns {Array<{day:string, usage:number}>} oldest→newest, one per day that
+ *          consumed anything.
+ */
+export function dailyUsageFractions(observations) {
+  const obs = (Array.isArray(observations) ? observations : [])
+    .filter((o) => o && typeof o.ts === "number" && Number.isFinite(o.ts) && Number.isFinite(o.pct))
+    .sort((a, b) => a.ts - b.ts);
+  const byDay = new Map();
+  let prev = null;
+  for (const cur of obs) {
+    const day = dayKey(cur.ts);
+    const delta = prev == null ? 0 : (cur.pct - prev.pct) / 100;
+    if (delta > 0) {
+      byDay.set(day, clamp01((byDay.get(day) ?? 0) + delta));
+    }
+    prev = cur;
+  }
+  return [...byDay.entries()]
+    .map(([day, usage]) => ({ day, usage }))
+    .sort((a, b) => (a.day < b.day ? -1 : a.day > b.day ? 1 : 0));
+}
+
+/**
+ * Build the contiguous, oldest→newest trailing daily series a forecast consumes
+ * over the last `days` completed local days (today is partial — excluded, since
+ * we forecast from *completed* days). Days with no data are 0 (no usage then).
+ * Also returns `historyDays` (distinct days with usage > 0) — the §11.3
+ * activation gate ("≥ 14 days") — and `maxObserved` (the §11.3 fallback's
+ * "observed daily max").
+ * @param {Array<{day:string, usage:number}>} daily  from dailyUsageFractions
+ * @param {{now:number, days?:number}} [opts]
+ */
+export function trailingDailySeries(daily, { now, days = FORECAST_LOOKBACK_DAYS } = {}) {
+  const t = typeof now === "number" && Number.isFinite(now) ? now : Date.now();
+  const count = Math.max(1, Math.floor(days) || 1);
+  const map = new Map((Array.isArray(daily) ? daily : []).map((d) => [d.day, d.usage]));
+  const series = [];
+  const todayKey = dayKey(t);
+  for (let i = count - 1; i >= 0; i--) {
+    const d = new Date(t);
+    d.setDate(d.getDate() - (i + 1));
+    const k = dayKey(d.getTime());
+    series.push(clamp01(map.get(k) ?? 0));
+  }
+  let historyDays = 0;
+  let maxObserved = 0;
+  for (const v of series) {
+    if (v > 0) historyDays += 1;
+    if (v > maxObserved) maxObserved = v;
+  }
+  return { series, historyDays, maxObserved };
+}
+
+/**
+ * Additive Holt-Winters with damped trend and weekly seasonality (m=7), the
+ * three §-standard recursions run directly:
+ *
+ *   Forecast next:   F_{t+1} = L_t + φ·b_t + S_{t−m+1}          (position t mod m)
+ *   Level:           L_t = α(y_t − S_{t−m}) + (1−α)(L_{t−1} + φ·b_{t−1})
+ *   Trend:           b_t = β(L_t − L_{t−1}) + (1−β)·φ·b_{t−1}
+ *   Seasonal:        S_t = γ(y_t − L_t) + (1−γ)·S_{t−m}
+ *
+ * with φ the trend damper (0.9 default). Initialization uses two full seasons:
+ * level = mean of the first season, trend = (2nd-season mean − 1st-season mean)/
+ * m, and each seasonal index = the mean of (y − that week's mean) over the
+ * weeks available (a detrended additive seasonal). Requires ≥ 2m samples;
+ * otherwise returns `{ok:false, reason:"insufficient"}` and the caller uses the
+ * §11.3 pre-forecast fallback (not enough history forecloses a seasonal fit).
+ *
+ * `sigma` is the sample std of the in-sample one-step residuals from the second
+ * season onward (the first season absorbs the init transient — its residuals
+ * are noise, not signal).
+ *
+ * @param {{series:number[], m?:number, alpha?:number, beta?:number,
+ *          gamma?:number, phi?:number}} opts
+ */
+export function holtWinters({ series, m = 7, alpha = 0.1, beta = 0.05, gamma = 0.2, phi = 0.9 }) {
+  const y = Array.isArray(series) ? series : [];
+  const n = y.length;
+  if (n < 2 * m) return { ok: false, reason: "insufficient", n };
+  if (!y.every((v) => Number.isFinite(v))) return { ok: false, reason: "non-finite", n };
+  const period = Math.max(1, Math.floor(m));
+  const a = Math.max(0, Math.min(1, alpha));
+  const be = Math.max(0, Math.min(1, beta));
+  const g = Math.max(0, Math.min(1, gamma));
+  const p = Math.max(0, Math.min(1, phi));
+
+  const meanRange = (lo, hi) => {
+    let s = 0;
+    for (let i = lo; i < hi; i++) s += y[i];
+    return s / (hi - lo);
+  };
+  const weeks = Math.max(1, Math.floor(n / period));
+  const weekBase = [];
+  for (let w = 0; w < weeks; w++) weekBase.push(meanRange(w * period, Math.min(w * period + period, n)));
+  const baseLevel = meanRange(0, period);
+  const initTrend = (meanRange(period, Math.min(2 * period, n)) - baseLevel) / period;
+  const S = new Array(period).fill(0);
+  for (let j = 0; j < period; j++) {
+    let s = 0;
+    let c = 0;
+    for (let w = 0; w < weeks; w++) {
+      const idx = w * period + j;
+      if (idx < n) {
+        s += y[idx] - weekBase[w];
+        c += 1;
+      }
+    }
+    S[j] = c ? s / c : 0;
+  }
+
+  let Lprev = baseLevel;
+  let bprev = initTrend;
+  const fitted = new Array(n).fill(NaN);
+  const residuals = new Array(n).fill(NaN);
+  for (let t = 0; t < n; t++) {
+    const pos = ((t % period) + period) % period;
+    const yhat = Lprev + p * bprev + S[pos];
+    fitted[t] = yhat;
+    const res = y[t] - yhat;
+    residuals[t] = res;
+    const Lt = a * (y[t] - S[pos]) + (1 - a) * (Lprev + p * bprev);
+    const bt = be * (Lt - Lprev) + (1 - be) * p * bprev;
+    S[pos] = g * (y[t] - Lt) + (1 - g) * S[pos];
+    Lprev = Lt;
+    bprev = bt;
+  }
+  const sigma = sampleStd(residuals.slice(period));
+  const posNext = ((n % period) + period) % period;
+  const forecast = Lprev + p * bprev + S[posNext];
+  return {
+    ok: true,
+    n,
+    level: Lprev,
+    trend: bprev,
+    seasonal: S,
+    fitted,
+    residuals,
+    sigma,
+    forecast,
+  };
+}
+
+/**
+ * Newsvendor quantile from a point forecast + residual sigma: `point + z_p·σ`.
+ * Z defaults to P95 when `p` is not on the ladder.
+ */
+export function quantileForecast(point, sigma, p = 0.95) {
+  const z = QUANTILE_Z[p];
+  const s = Number.isFinite(sigma) ? sigma : 0;
+  return (Number.isFinite(point) ? point : 0) + (z !== undefined ? z * s : 0);
+}
+
+/**
+ * The §11.3 reserve for one provider, given a contiguous trailing daily
+ * fraction series and the active fractile. Below the HW minimum (2 seasons) it
+ * returns the pre-forecast fallback — `{mode:'fallback', value:null}` — and the
+ * caller applies `reserve = max(observed daily max, 60% of window)` (§11.3;
+ * the fallback is not a fractile and never notches). Otherwise it returns the
+ * fractile quantile of next-day demand in fraction-of-window units.
+ *
+ * @param {{series:number[], fractile?:number, m?:number, params?:object}} opts
+ */
+export function forecastNextDayFraction({ series, fractile = 0.95, m = 7, params } = {}) {
+  const out = holtWinters({ series, m, ...(params ?? {}) });
+  if (!out.ok) {
+    return { mode: "fallback", reason: out.reason, value: null, fractile, n: out.n };
+  }
+  const value = clamp01(quantileForecast(out.forecast, out.sigma, fractile));
+  return { mode: "forecast", value, fractile, point: out.forecast, sigma: out.sigma, n: out.n };
+}
+
+/** MAPE (%) of the HW fit over the trailing `tailDays` of a daily series —
+ *  the §14.5 "forecast accuracy (MAPE 14d)" figure. null when insufficient. */
+export function forecastMape({ series, m = 7, params, tailDays = 14 } = {}) {
+  const out = holtWinters({ series, m, ...(params ?? {}) });
+  if (!out.ok) return null;
+  const n = out.n;
+  const from = Math.max(0, n - Math.max(1, Math.floor(tailDays) || 1));
+  const act = [];
+  const f = [];
+  for (let i = from; i < n; i++) {
+    if (!Number.isFinite(out.fitted[i])) continue;
+    act.push(series[i]);
+    f.push(out.fitted[i]);
+  }
+  return mape(act, f);
+}

--- a/src/server/ctoForecast.test.mjs
+++ b/src/server/ctoForecast.test.mjs
@@ -1,0 +1,142 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  FORECAST_LOOKBACK_DAYS,
+  QUANTILE_Z,
+  dailyUsageFractions,
+  forecastMape,
+  forecastNextDayFraction,
+  holtWinters,
+  mape,
+  quantileForecast,
+  sampleStd,
+  trailingDailySeries,
+} from "./ctoForecast.mjs";
+import { dayKey } from "../shared/timeBuckets.mjs";
+
+// A deterministic local-midnight baseline for series/day tests.
+function dayStart(offsetDays = 0) {
+  const d = new Date(2026, 7, 28, 0, 0, 0, 0);
+  d.setDate(d.getDate() + offsetDays);
+  return d.getTime();
+}
+const D0 = dayStart(0);
+const D1 = dayStart(1);
+
+test("sampleStd: known sample std (2.138) and guards", () => {
+  assert.ok(Math.abs(sampleStd([2, 4, 4, 4, 5, 5, 7, 9]) - 2.138) < 0.001);
+  assert.equal(sampleStd([]), 0);
+  assert.equal(sampleStd([5]), 0);
+});
+
+test("mape: percent error over non-zero actuals; null when < 2 usable", () => {
+  assert.ok(Math.abs(mape([100, 200], [110, 180]) - 10) < 1e-9);
+  assert.equal(mape([100], [110]), null);
+  assert.equal(mape([0, 0], [0, 0]), null);
+  assert.equal(mape([1], [2]), null);
+});
+
+test("quantileForecast: point + z_p * sigma at the §11.3 fractiles", () => {
+  assert.ok(Math.abs(quantileForecast(10, 2, 0.95) - (10 + QUANTILE_Z[0.95] * 2)) < 1e-9);
+  assert.ok(Math.abs(quantileForecast(10, 2, 0.9) - (10 + QUANTILE_Z[0.9] * 2)) < 1e-9);
+  assert.ok(Math.abs(quantileForecast(10, 2, 0.99) - (10 + QUANTILE_Z[0.99] * 2)) < 1e-9);
+  assert.equal(quantileForecast(10, undefined, 0.95), 10);
+});
+
+test("dailyUsageFractions: window reset + cross-day attribution (hand fixture)", () => {
+  // Same local day, window resets mid-day: usage = old-cycle share + new-cycle share.
+  const obs = [
+    { ts: D0 + 10, pct: 20 },
+    { ts: D0 + 12, pct: 45 }, // +0.25
+    { ts: D0 + 14, pct: 5 }, // reset: -0.40 -> 0
+    { ts: D0 + 16, pct: 30 }, // +0.25
+  ];
+  const days = dailyUsageFractions(obs);
+  assert.equal(days.length, 1);
+  assert.equal(days[0].day, dayKey(D0));
+  assert.ok(Math.abs(days[0].usage - 0.5) < 1e-9);
+
+  // Cross-midnight: a delta between a late obs on D0 and an early obs on D1 is
+  // attributed to D1 (the day of the later observation).
+  const cross = dailyUsageFractions([
+    { ts: D0 + 23 * 3_600_000, pct: 40 },
+    { ts: D1 + 3_600_000, pct: 52 },
+  ]);
+  assert.equal(cross.length, 1);
+  assert.equal(cross[0].day, dayKey(D1));
+  assert.ok(Math.abs(cross[0].usage - 0.12) < 1e-9);
+});
+
+test("dailyUsageFractions: day total accumulates correctly (hand values)", () => {
+  // 10 -> 95 = +0.85; 95 -> 100 = +0.05; total 0.90 (no clamp needed).
+  const d = dailyUsageFractions([
+    { ts: D0 + 1, pct: 10 },
+    { ts: D0 + 2, pct: 95 },
+    { ts: D0 + 3, pct: 100 },
+  ]);
+  assert.equal(d[0].day, dayKey(D0));
+  assert.ok(Math.abs(d[0].usage - 0.9) < 1e-9);
+});
+
+test("trailingDailySeries: contiguous lookback excludes today, zero-fills", () => {
+  const daily = [{ day: dayKey(D0), usage: 0.4 }];
+  const { series, historyDays, maxObserved } = trailingDailySeries(daily, { now: D1, days: 4 });
+  // 4 trailing days ending at the day before D1: D0 and the 3 days before it.
+  assert.equal(series.length, 4);
+  assert.ok(Math.abs(series[3] - 0.4) < 1e-9); // D0 is the most recent trailing day
+  assert.equal(historyDays, 1);
+  assert.ok(Math.abs(maxObserved - 0.4) < 1e-9);
+  series.slice(0, 3).forEach((v) => assert.equal(v, 0)); // earlier days zero-filled
+});
+
+test("trailingDailySeries: default lookback is 8 weeks", () => {
+  const { series } = trailingDailySeries([], { now: D0 });
+  assert.equal(series.length, FORECAST_LOOKBACK_DAYS);
+});
+
+test("holtWinters: constant series fits exactly (hand fixture, m=2)", () => {
+  const out = holtWinters({ series: [0.1, 0.1, 0.1, 0.1], m: 2, alpha: 0.1, beta: 0.05, gamma: 0.2, phi: 0.9 });
+  assert.equal(out.ok, true);
+  out.fitted.forEach((f) => assert.ok(Math.abs(f - 0.1) < 1e-12));
+  assert.equal(out.sigma, 0);
+  assert.ok(Math.abs(out.forecast - 0.1) < 1e-12);
+});
+
+test("holtWinters: damped-trend ramp matches hand-computed first steps", () => {
+  // series [0.1,0.1,0.2,0.2], m=2: initLevel=0.1, initTrend=0.05,
+  // seasonal=[0,0]. Step t=0 uses S[0]=0:
+  //   yhat0 = 0.1 + 0.9*0.05 = 0.145
+  //   L0    = 0.1*(0.1) + 0.9*(0.1+0.9*0.05) = 0.01 + 0.9*0.145 = 0.1405
+  //   b0    = 0.05*(0.1405-0.1) + 0.95*0.9*0.05 = 0.002025 + 0.04275 = 0.044775
+  //   S0    = 0.2*(0.1-0.1405) + 0.8*0 = -0.0081
+  // Full pass ends (hand-computed through t=3) at final level ≈ 0.238247 —
+  // the code matches the recursion through all four points.
+  const out = holtWinters({ series: [0.1, 0.1, 0.2, 0.2], m: 2, alpha: 0.1, beta: 0.05, gamma: 0.2, phi: 0.9 });
+  assert.equal(out.ok, true);
+  assert.ok(Math.abs(out.fitted[0] - 0.145) < 1e-9);
+  assert.ok(Math.abs(out.fitted[1] - 0.1807975) < 1e-6, `fitted1 ${out.fitted[1]}`);
+  assert.ok(Math.abs(out.level - 0.23824735998443758) < 1e-6, `level ${out.level}`);
+  assert.ok(Math.abs(out.seasonal[0] - -0.008193944025000014) < 1e-6, `seasonal0 ${out.seasonal[0]}`);
+});
+
+test("holtWinters: requires two full seasons (activation gate plumbing)", () => {
+  assert.equal(holtWinters({ series: [0.1, 0.1, 0.1], m: 2 }).ok, false);
+  assert.equal(holtWinters({ series: [0.1, 0.1, 0.1, 0.1], m: 2 }).ok, true);
+});
+
+test("forecastNextDayFraction: fallback below 2 seasons, forecast above", () => {
+  const fb = forecastNextDayFraction({ series: [0.1, 0.1, 0.1], m: 2, fractile: 0.95 });
+  assert.equal(fb.mode, "fallback");
+  assert.equal(fb.value, null);
+
+  const fc = forecastNextDayFraction({ series: [0.1, 0.1, 0.1, 0.1], m: 2, fractile: 0.95 });
+  assert.equal(fc.mode, "forecast");
+  assert.ok(Math.abs(fc.value - 0.1) < 1e-9);
+  assert.equal(fc.fractile, 0.95);
+});
+
+test("forecastMape: null below two seasons, number above with scatter", () => {
+  assert.equal(forecastMape({ series: [0.1, 0.1, 0.1], m: 2 }), null);
+  // Constant series fits exactly -> 0% MAPE.
+  assert.equal(forecastMape({ series: [0.1, 0.1, 0.1, 0.1], m: 2 }), 0);
+});

--- a/src/server/ctoHealth.mjs
+++ b/src/server/ctoHealth.mjs
@@ -24,6 +24,9 @@ export const HEALTH_STAT_MIN = Object.freeze({
   digestOpens: 7,
   pipelineLag: 7,
   suggestionAcceptance: 10,
+  forecastAccuracy: 1,
+  capHitsCaused: 1,
+  reserveFractile: 1,
 });
 
 function medianOf(values) {
@@ -177,6 +180,51 @@ export async function computeHealthStats({
       decided >= HEALTH_STAT_MIN.suggestionAcceptance
         ? `${Math.round(acceptRate * 100)}% accepted`
         : null,
+  });
+
+  // 5. Forecast accuracy (MAPE 14d, §14.5) — the best available cached
+  //    per-provider 14-day MAPE from the budget's quota/forecast cache
+  //    (BET-1400 recomputes each provider's MAPE on every quota evaluation).
+  //    The first quota row carrying a numeric MAPE speaks for the box.
+  let quota = null;
+  try {
+    quota = (await budgetRead())?.quota ?? null;
+  } catch {
+    quota = null;
+  }
+  const quotaRows = quota && typeof quota === "object" ? Object.values(quota) : [];
+  const withMape = quotaRows.find((q) => typeof q?.mape14 === "number" && Number.isFinite(q.mape14));
+  stats.push({
+    id: "forecastAccuracy",
+    label: "Forecast accuracy · MAPE 14d",
+    min: HEALTH_STAT_MIN.forecastAccuracy,
+    n: withMape ? 1 : 0,
+    value: withMape ? `${withMape.mape14.toFixed(1)}%` : null,
+  });
+
+  // 6. Cap-hits caused (30d, §14.5) — count of `cto.cap_hit` §14.5 ledger rows
+  //    (the user's plan window exhausted) in the last 30 days.
+  const capCutoff = t - 30 * DAY_MS;
+  const capHits = rows.filter((r) => r?.kind === "cto.cap_hit" && typeof r?.ts === "number" && r.ts >= capCutoff).length;
+  stats.push({
+    id: "capHitsCaused",
+    label: "Cap-hits caused · 30d",
+    min: HEALTH_STAT_MIN.capHitsCaused,
+    n: capHits,
+    value: capHits >= HEALTH_STAT_MIN.capHitsCaused ? `${capHits} window(s) hit` : null,
+  });
+
+  // 7. Reserve fractile (§11.3) — the current per-provider fractile, for the
+  //    Tonight's-budget reserve line (§10.5-3). The fractile *history* is
+  //    ledgered (§14.5); this row is the live value for the gauge.
+  const withFractile = quotaRows.find((q) => typeof q?.fractile === "number");
+  const fractileLabel = withFractile != null ? `P${Math.round(withFractile.fractile * 100)}` : null;
+  stats.push({
+    id: "reserveFractile",
+    label: "Reserve fractile",
+    min: HEALTH_STAT_MIN.reserveFractile,
+    n: withFractile ? 1 : 0,
+    value: withFractile && fractileLabel ? `${fractileLabel} · ${withFractile.provider ?? "provider"}` : null,
   });
 
   return { stats, generatedAt: t };

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -178,3 +178,35 @@ test("suggestion acceptance: verdicts older than 30d are excluded", async () => 
   const s = stats.find((x) => x.id === "suggestionAcceptance");
   assert.equal(s.n, 10);
 });
+
+test("BET-1400: forecast accuracy row reflects the cached quota MAPE", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    budgetRead: async () => ({ quota: { claude: { provider: "claude", mape14: 12.4, fractile: 0.95 } } }),
+  });
+  const f = stats.find((s) => s.id === "forecastAccuracy");
+  assert.equal(f.value, "12.4%");
+  assert.equal(f.n, 1);
+  // no quota row with a numeric MAPE -> collecting
+  const { stats: empty } = await computeHealthStats({ now: () => NOW, budgetRead: async () => ({ quota: {} }) });
+  assert.equal(empty.find((s) => s.id === "forecastAccuracy").n, 0);
+});
+
+test("BET-1400: cap-hits-caused counts §14.5 rows in the last 30 days only", async () => {
+  const capAt = (offsetDays) => ({ kind: "cto.cap_hit", ts: NOW - offsetDays * DAY });
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    ledgerRead: async () => [capAt(1), capAt(5), capAt(45)],
+  });
+  const c = stats.find((s) => s.id === "capHitsCaused");
+  assert.equal(c.value, "2 window(s) hit"); // 45 days ago excluded
+});
+
+test("BET-1400: reserve fractile row surfaces the primary quota fractile", async () => {
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    budgetRead: async () => ({ quota: { claude: { provider: "claude", fractile: 0.99 } } }),
+  });
+  const r = stats.find((s) => s.id === "reserveFractile");
+  assert.equal(r.value, "P99 · claude");
+});

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1519,8 +1519,13 @@ rpcHandlers = buildHandlers({
   // BET-1400: quota forecast + reserve - drive a per-provider re-evaluation
   // (C3's 30-min overnight re-eval calls `quota:evaluate`; the health card
   // reads the persisted budget.quota via `quota:read`), and record a user
-  // cap-hit (sect11.3) through `quota:capHit`.
-  "quota:evaluate": (input) => adaptiveCtoBudget.computeSpendable(input ?? {}),
+  // cap-hit (sect11.3) through `quota:capHit`. A missing provider errors
+  // before any state is touched (an absent input would otherwise persist a
+  // `quota.undefined` row).
+  "quota:evaluate": (input) => {
+    if (typeof input?.provider !== "string" || !input.provider.trim()) throw new Error("quota:evaluate requires a provider");
+    return adaptiveCtoBudget.computeSpendable(input);
+  },
   "quota:capHit": (input) => adaptiveCtoBudget.recordCapHit(input ?? {}),
   "quota:read": () => adaptiveCtoBudget.payload(),
   // BET-790: renderer read channel for a session's progress record (the

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1516,6 +1516,13 @@ rpcHandlers = buildHandlers({
   // persisted observation history.
   usageSnapshots: listSnapshots,
   usageHistory: getUsageHistory,
+  // BET-1400: quota forecast + reserve - drive a per-provider re-evaluation
+  // (C3's 30-min overnight re-eval calls `quota:evaluate`; the health card
+  // reads the persisted budget.quota via `quota:read`), and record a user
+  // cap-hit (sect11.3) through `quota:capHit`.
+  "quota:evaluate": (input) => adaptiveCtoBudget.computeSpendable(input ?? {}),
+  "quota:capHit": (input) => adaptiveCtoBudget.recordCapHit(input ?? {}),
+  "quota:read": () => adaptiveCtoBudget.payload(),
   // BET-790: renderer read channel for a session's progress record (the
   // server store from src/server/progress.mjs). The write side is the AI's
   // progress_report tool → POST /api/progress.
@@ -2031,7 +2038,22 @@ const SUGGEST_INTERVAL_MS = 30 * 60_000;
 // replaces the placeholder 0/0 that could never trip), and the measured
 // per-hour burn is today's budget spend / hours elapsed. Both read the real
 // budget.json store via ctoBudget.
-const adaptiveCtoBudget = ctoBudget.createCtoBudget();
+const adaptiveCtoBudget = ctoBudget.createCtoBudget({
+  // BET-1400: the reserve/forecast runs over the poller's pct observation
+  // history (BET-1336), records cap-hits + fractile notches to the sect14.5
+  // ledger, and reads the user's config (ctoNightCapUsd) for the windowless
+  // bound. getUsageHistory returns { "<provider>:<window.kind>": [{ts,pct}] }.
+  history: getUsageHistory,
+  historyKey: (provider, kind = "session") => `${provider}:${kind}`,
+  ledger: ledgerStore,
+  cfg: async () => {
+    try {
+      return await local.configGet();
+    } catch {
+      return {};
+    }
+  },
+});
 const adaptiveCtoWatchdog = ctoEngine.createWatchdog({
   engine: adaptiveCto,
   getSpendPerHour: async () => adaptiveCtoBudget.spendPerHourUsd(),

--- a/src/server/usageAdapters/claude.mjs
+++ b/src/server/usageAdapters/claude.mjs
@@ -45,6 +45,9 @@ function extraFor(pool, label) {
 export const claudeAdapter = {
   id: "claude",
   providerIDs: ["anthropic"],
+  // BET-1400 (§11.2): has plan windows (5h session + 7d weekly) — the reserve
+  // math applies and spendable is measured in fraction-of-window units.
+  windowed: true,
 
   async detect({ readCredentials = defaultReadCredentials } = {}) {
     const creds = await readCredentials();

--- a/src/server/usageAdapters/codex.mjs
+++ b/src/server/usageAdapters/codex.mjs
@@ -47,6 +47,8 @@ function resolveResetsAt(win, nowMs) {
 export const codexAdapter = {
   id: "codex",
   providerIDs: ["openai"],
+  // BET-1400 (§11.2): has plan windows (session + weekly) — reserve applies.
+  windowed: true,
 
   async detect({ readToken = defaultReadToken } = {}) {
     const token = await readToken();

--- a/src/server/usageAdapters/kimi.mjs
+++ b/src/server/usageAdapters/kimi.mjs
@@ -64,6 +64,8 @@ function windowFromDetail(detail, kind, label) {
 export const kimiAdapter = {
   id: "kimi",
   providerIDs: [PROVIDER_ID],
+  // BET-1400 (§11.2): has plan windows (5h session + weekly) — reserve applies.
+  windowed: true,
 
   async detect({ readKey = defaultReadKey } = {}) {
     const key = await readKey();


### PR DESCRIPTION
## BET-1400 — Quota forecasting & reserve (Usage forecast + spend governor)

Implements spec §11.2/§11.3 and §14.5: the overnight CTO's quota reserve and
spendable governor, so overnight autonomy never starves the user's interactive
provider windows.

**New file — `src/server/ctoForecast.mjs`** (pure math + injected history):
- Additive Holt-Winters with damped trend and weekly seasonality (m=7) over a
  rolling 8-week daily series; the three §-standard recursions are implemented
  directly with the formulas in the code comments.
- Daily usage as a fraction of the plan window, derived from the poller's pct
  observation history (BET-1336) — **Option A** from the BET-1400 blocker:
  reserve/spendable live in fraction-of-window space (the windowed adapters
  expose no capacity in token/$ units, so a ledger-unit reserve could never be
  compared to `remaining`). The pct history *is* a usage history.
- Quantile forecast (`point + z_p·σ`) at the §11.3 newsvendor fractiles
  (P90/P95/P99), pre-forecast fallback below two seasons, and MAPE for health.

**`src/server/ctoBudget.mjs`** — reserve + spendable (§11.3):
- Fractile notch state machine: P95 init, up (≤ P99) per user cap-hit, down
  (≥ P90) after 30 clean days, active only once ≥ 14 days of history.
- Pre-forecast fallback `max(observed daily max, 60% of window)`.
- `spendable = remaining − reserve`, floored at 0.
- **Windowless / no-adapter**: reserve disabled; overnight bound = absolute
  `ctoNightCapUsd` (config, default $5/night).
- Budget store gains `budget.quota`; §14.5 ledger rows (`cto.reserve`,
  `cto.reserve.fractile`, `cto.cap_hit`).
- `computeSpendable(now)` + `recordCapHit` accessors (C3's 30-min re-eval).

**Usage adapters** (claude/codex/kimi): additive `windowed: true` capability
flag.

**`src/server/ctoHealth.mjs`** — Health card gains forecast accuracy (MAPE 14d),
cap-hits-caused (30d), and reserve-fractile rows.

**`src/server/index.mjs`** — wires the real usage-history + §14.5 ledger +
config into the budget accessor; adds `quota:evaluate` / `quota:capHit` /
`quota:read` RPC channels.

### Tests
`ctoForecast.test.mjs` (HW recursions vs hand-computed fixtures, quantiles,
daily series, MAPE, fallback gate), `ctoBudget.test.mjs` (notch state machine
incl. activation gate, clean-day/cap-hit transitions, spendable floor,
windowless routing, ledger rows), `ctoHealth.test.mjs` (new rows).

### Verification
- PR branch (`multica/BET-1400-usage-forecast` @ `8aab6936`):
  - typecheck: exit 0. Errors: none. log sha256 `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, **3323 pass / 0 fail / 0 skip**. Failures: none. log sha256 `2835df510aacaeeaae41425ac124d56b507d6961e4214f45f6959d8adde2e190`
- Base: `origin/main` @ `482a7755`
- **Conclusion:** 0 new failures, 0 pre-existing on this branch's slice.

### Note (branch collision)
The original `multica/BET-1400-forecast-reserve` branch was concurrently
co-opted by a BET-1398 watcher-supersession run (same shared workdir), which
force-pushed its watcher work over mine and squatted PR #1401. This PR is cut
from a clean, distinct branch (`multica/BET-1400-usage-forecast`) whose diff vs
`origin/main` is exactly the 10 BET-1400 files above. The squatted
`multica/BET-1400-forecast-reserve` / PR #1401 should be abandoned.
