### PR TITLE
docs(spec): BET-1416 record Option-A reserve units in §11.3 (fraction-of-window, pct history, cap-hit/clean-day definitions)

### DIFF
--- a/docs/adaptive-cto-spec.md
+++ b/docs/adaptive-cto-spec.md
@@ -968,17 +968,31 @@ overnight path and never bypasses its $ bound.
 
 ### 11.3 Reserve
 
-Forecast tomorrow's own demand per provider: Holt-Winters (damped trend,
-weekly seasonality) over a rolling 8 weeks of the box's usage ledger; under
-14 days of history, fall back to `reserve = max(observed daily max, 60% of
-window)`. Reserve = P95 of forecast demand (newsvendor fractile with
-C_u ≫ C_o). `spendable = remaining − reserve`, floored at 0. Every user
-cap-hit event raises the fractile one notch (max P99); 30 clean days lower it
-one notch (min P90). The fractile initializes at P95; notch adaptation begins
-only once the forecaster is active (≥ 14 days) — the pre-forecast fallback is
-not a fractile and does not notch. Re-evaluated every 30 min during the
-window; a shrinking spendable stops task starts and preempts at boundaries if
-already negative.
+Reserve and spendable are **fractions of the plan window**, not token or $
+amounts: the windowed adapters report `remaining` only as a fraction of the
+window and expose no window capacity in ledger units, so the reserve lives in
+that same fractional space — otherwise `remaining − reserve` compares
+incomparable units. Forecast tomorrow's own demand per provider: Holt-Winters
+(damped trend, weekly seasonality) over a rolling 8 weeks of the daily demand
+series derived from the per-provider **usage-observation history** (the pct
+observations the usage poller persists): a day's demand is the pct delta
+accumulated across that local day within one window cycle — a positive pct
+delta is consumption, a window reset shows as a pct drop and contributes 0.
+Under 14 days of history, fall back to `reserve = max(observed daily max,
+60% of window)` — both terms in the same fraction-of-window space. Reserve =
+P95 of forecast demand (newsvendor fractile with C_u ≫ C_o).
+`spendable = remaining − reserve`, floored at 0.
+
+Two event definitions feed the notch state machine, both ledgered per §14.5:
+a **cap-hit** = the provider's plan window exhausted — an adapter snapshot
+reporting the window at/over its limit (pct ≥ 100); a **clean day** = a day
+with no cap-hit and no forecast-exceeding spend. Every user cap-hit event
+raises the fractile one notch (max P99); 30 clean days lower it one notch
+(min P90). The fractile initializes at P95; notch adaptation begins only once
+the forecaster is active (≥ 14 days) — the pre-forecast fallback is not a
+fractile and does not notch. Re-evaluated every 30 min during the window; a
+shrinking spendable stops task starts and preempts at boundaries if already
+negative.
 
 ### 11.4 Task portfolio
 


### PR DESCRIPTION
**Base: origin/main @ `482a7755`**

Docs-only amendment of `docs/adaptive-cto-spec.md` §11.3 recording the BET-1400 blocker resolution (Option A):

- Reserve/spendable are **fractions of the plan window**, not token/$ amounts — normative, with the comparability rationale (`remaining` is itself fractional; windowed adapters expose no window capacity in ledger units).
- The demand series is the daily pct-delta derived from the per-provider **usage-observation history** (pct observations persisted by the usage poller) — the §11.3 "usage ledger" source reference is gone.
- The pre-forecast fallback `max(observed daily max, 60% of window)` is stated to live in the same fraction-of-window space.
- Event definitions recorded as normative text: **cap-hit** = provider plan window exhausted (adapter snapshot pct ≥ 100); **clean day** = a day with no cap-hit and no forecast-exceeding spend. Both ledgered per §14.5.

Scope: §11.3 only. §11.2 (no-adapter absolute-$ path) and the C3 scheduler issues are untouched per the issue's out-of-scope list. No code changes; single hunk inside §11.3 (lines ~969–1001).

Note: BET-1400's PR (#1403) is still open; this cannot collide — its file list contains no docs, this PR contains no code.

**Files changed:** `1` file — `docs/adaptive-cto-spec.md` (+25/−11)

**Verification results:**
- PR branch (`multica/BET-1416-spec-113-reserve-units` @ `5e8efb73`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3323` pass / `0` fail / `0` skip. Failures: none. log sha256: `333536176741cabcf67ddca34da8160ab5f371514eb2c8ad2e6dff327bd2993c`
- Base (`main` @ `482a7755`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3323` pass / `0` fail / `0` skip. Failures: none. log sha256: `b61b47b3845791275bc0cac3b10f069248d7fff9b9deeacbcf007cfc561368e8`
- **Conclusion:** 0 new failures, 0 pre-existing — identical suites both branches (docs-only diff).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

Follow-ups filed: none (no actionable gaps found — the shipped BET-1400 code comments already cite this decision; the spec is now its normative home).
