### PR TITLE
BET-1417: health-card reserveFractile row stays honest for windowless (reserve-disabled) providers

### DIFF
--- a/src/server/ctoHealth.mjs
+++ b/src/server/ctoHealth.mjs
@@ -217,8 +217,19 @@ export async function computeHealthStats({
   // 7. Reserve fractile (§11.3) — the current per-provider fractile, for the
   //    Tonight's-budget reserve line (§10.5-3). The fractile *history* is
   //    ledgered (§14.5); this row is the live value for the gauge.
-  const withFractile = quotaRows.find((q) => typeof q?.fractile === "number");
-  const fractileLabel = withFractile != null ? `P${Math.round(withFractile.fractile * 100)}` : null;
+  //    Windowless providers disable the reserve (§11.2) yet still persist
+  //    their P95-init `fractile` on the quota row (BET-1400's windowless
+  //    row), so the row must never present that init value as a live reserve:
+  //    prefer reserve-enabled (windowed) rows, and when only a windowless row
+  //    exists, surface the mode in the value instead of a bare fractile.
+  const withFractile =
+    quotaRows.find((q) => q?.mode !== "windowless" && typeof q?.fractile === "number") ??
+    quotaRows.find((q) => q?.mode === "windowless" && typeof q?.fractile === "number");
+  const reserveDisabled = withFractile?.mode === "windowless";
+  const fractileLabel =
+    withFractile != null
+      ? `P${Math.round(withFractile.fractile * 100)}${reserveDisabled ? " (windowless — reserve off)" : ""}`
+      : null;
   stats.push({
     id: "reserveFractile",
     label: "Reserve fractile",

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -222,7 +222,7 @@ test("BET-1417: windowless-first box labels the mode — never a bare fractile f
     }),
   });
   const r = stats.find((s) => s.id === "reserveFractile");
-  assert.equal(r.value, "P95 · claude (windowless — reserve off)");
+  assert.equal(r.value, "P95 (windowless — reserve off) · claude");
 });
 
 test("BET-1417: a windowless row never shadows a reserve-enabled provider's fractile", async () => {

--- a/src/server/ctoHealth.test.mjs
+++ b/src/server/ctoHealth.test.mjs
@@ -210,3 +210,46 @@ test("BET-1400: reserve fractile row surfaces the primary quota fractile", async
   const r = stats.find((s) => s.id === "reserveFractile");
   assert.equal(r.value, "P99 · claude");
 });
+
+test("BET-1417: windowless-first box labels the mode — never a bare fractile for a reserve-disabled provider", async () => {
+  // BET-1400's windowless quota row persists the P95-init fractile with
+  // reserve disabled (§11.2); the row must surface the mode, not imply a
+  // reserve exists at that fractile.
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    budgetRead: async () => ({
+      quota: { claude: { provider: "claude", mode: "windowless", reserve: 0, fractile: 0.95 } },
+    }),
+  });
+  const r = stats.find((s) => s.id === "reserveFractile");
+  assert.equal(r.value, "P95 · claude (windowless — reserve off)");
+});
+
+test("BET-1417: a windowless row never shadows a reserve-enabled provider's fractile", async () => {
+  // Mixed box: the windowless provider is iterated first, but the live
+  // reserve fractile belongs to the windowed one.
+  const { stats } = await computeHealthStats({
+    now: () => NOW,
+    budgetRead: async () => ({
+      quota: {
+        gpt: { provider: "gpt", mode: "windowless", reserve: 0, fractile: 0.95 },
+        claude: { provider: "claude", mode: "forecast", fractile: 0.99 },
+      },
+    }),
+  });
+  const r = stats.find((s) => s.id === "reserveFractile");
+  assert.equal(r.value, "P99 · claude");
+});
+
+test("BET-1417: windowed row behavior unchanged (mode not surfaced in the value)", async () => {
+  for (const mode of ["forecast", "fallback", null, undefined]) {
+    const { stats } = await computeHealthStats({
+      now: () => NOW,
+      budgetRead: async () => ({
+        quota: { claude: { provider: "claude", mode, fractile: 0.9 } },
+      }),
+    });
+    const r = stats.find((s) => s.id === "reserveFractile");
+    assert.equal(r.value, "P90 · claude");
+  }
+});


### PR DESCRIPTION
Post-merge nit from the cycle-2 review of BET-1400 (non-blocking): the health card's `reserveFractile` row could show a bare "Reserve fractile: P95" for a provider with **no reserve**. Since BET-1400's windowless fix, windowless quota rows persist the P95-init `fractile` with `reserve: 0` — and the row picked the first quota row with a numeric fractile regardless of mode (§11.2: reserve is disabled on the windowless path).

## Fix

`src/server/ctoHealth.mjs` (reserveFractile row, ~line 217):

- The row now **prefers reserve-enabled (windowed) quota rows** — any row whose `mode !== "windowless"` (`forecast` / `fallback` / legacy `null`) — so on a mixed box a windowless provider never shadows a live reserve fractile.
- When **only** a windowless row exists (windowless-first box), the mode is surfaced in the value instead of a bare fractile: `P95 (windowless — reserve off) · claude` — the reviewer's suggested labeling form.
- Windowed-box behavior is byte-identical to before (no suffix, same selection).

Duplicate-site check: `fractile` has no other display consumer in `src/renderer/`/`src/shared/` — this row is the single source of that label.

Base: origin/main @ 757a399b

## Verification results

- PR branch (`multica/BET-1417-reserve-fractile-honesty` @ `54a6c2fd`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3366` pass / `0` fail / `0` skip. Failures: none. log sha256: `15c92fe61e158bd4bfaa61a9bc1c7e03127665805d29118d152e6fa18099867e`
- Base (`main` @ `757a399b`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, `3363` pass / `0` fail / `0` skip. Failures: none. log sha256: `3c48ea020c4b7c16228d25d503e62f4201ee9dc6eb79162c9eb31aa124946847`
- **Conclusion:** 0 new failures, 0 pre-existing failures; the 3-test delta is the new BET-1417 coverage (windowless-first labeling, windowless-never-shadows-windowed, windowed-unchanged).

## Tests added (`src/server/ctoHealth.test.mjs`)

- Windowless-first box: the row labels the mode — never a bare fractile for a reserve-disabled provider.
- Mixed box: a windowless row (iterated first) never shadows a reserve-enabled provider's live fractile.
- Windowed box: value unchanged across `mode: forecast | fallback | null | undefined`.

## Self-check

```
CRITERION 1: row cannot imply a reserve exists for a windowless provider → 9/10 → bare fractile impossible: windowed rows preferred, windowless-only surfaces "(windowless — reserve off)"; pinned by tests
CRITERION 2: windowed box behavior unchanged → 10/10 → selection path untouched for non-windowless modes; pinned by 4-mode test loop + original BET-1400 test untouched
CRITERION 3: typecheck && test pass → 10/10 → exit 0 / 3366 pass on PR branch; base green too
CRITERION 4: branch + PR titled with key + reassign reviewer → 10/10 → this PR; reassign follows this comment
```

No actionable follow-ups surfaced (two-line label fix; forecast/reserve math untouched per scope).
