### PR TITLE
BET-1402: Overnight scheduler CORE — window state machine + portfolio scoring (server-only)

### DIFF
--- a/src/server/ctoOvernight.mjs
+++ b/src/server/ctoOvernight.mjs
@@ -1,0 +1,763 @@
+// src/server/ctoOvernight.mjs
+// BET-1402 — the overnight scheduler CORE (spec §11.1, §11.4, §11.5, §11.6):
+// the window state machine, the portfolio scorer, and the execution-contract
+// helpers. Pure logic with injected I/O throughout — no live tmux/opencode/
+// network here. `createOvernightScheduler` is the thin I/O accessor (injected
+// store + ledger + budget seam) BET-1419 wires into the engine; every decision
+// it makes is one of the exported pure functions, so all of it is testable.
+//
+// Split of the original BET-1402: veto card, tonight UI, engine wiring,
+// settings and data-gate flips live in BET-1419. This module must not touch
+// ctoEngine.mjs, ctoCards.mjs, ctoSuggest.mjs, httpApi or any UI surface.
+
+import { betaMean, thompsonDraw, effectsForVerdict } from "./ctoVerdicts.mjs";
+import { createMutex, readJsonSync, writeJsonAtomic } from "./jsonStore.mjs";
+import { statePath } from "../shared/paths.mjs";
+
+// ---------------------------------------------------------------------------
+// Constants (spec-cited, injectable where the spec leaves the number open)
+// ---------------------------------------------------------------------------
+
+export const HOUR_MS = 3_600_000;
+export const DAY_MS = 86_400_000;
+
+// §11.1: on boxes with no desktop client, the absence signal is ≥ 60 min of
+// zero user-originated events inside the trough.
+export const ABSENCE_SILENCE_MIN_MS = 60 * 60_000;
+
+// §11.1: the veto-window card announces the open 30 min ahead — the countdown
+// the veto verb (BET-1419) arms and this module carries/abandons.
+export const VETO_COUNTDOWN_LEAD_MS = 30 * 60_000;
+
+// A countdown that elapsed while the box was down is abandoned (§11.6 last
+// bullet): never executed late. The grace window only covers scheduler-tick
+// jitter (the due moment passed but a normal tick is about to evaluate it);
+// past the grace, elapsed = abandoned.
+export const COUNTDOWN_ABANDON_GRACE_MS = 15 * 60_000;
+
+// §11.4 lattice — coarse on purpose, model-scored.
+export const VALUE_LATTICE = Object.freeze([3, 2, 1, 0.5, 0.25]);
+export const CONFIDENCE_LATTICE = Object.freeze([1.0, 0.8, 0.5]);
+
+// §11.4: hygiene floor — maintenance is guaranteed 20% of the night's budget
+// when any maintenance candidate exists.
+export const HYGIENE_FLOOR_SHARE = 0.2;
+
+// §11.4: λ = shadow price, 0 when spendable is fat, rising as it thins. The
+// fat threshold and ceiling are our calibration (spec names the shape, not
+// the constants): λ = 0 at spendable ≥ 50% of the window, rising linearly to
+// LAMBDA_MAX as spendable → 0 (so near dawn the cheap jobs win).
+export const SPENDABLE_FAT_FRAC = 0.5;
+export const LAMBDA_MAX = 10;
+
+// Per-category staleness τ for Decay (§11.4 "per-category τ"). Defaults are
+// our calibration: explicit tonight-intent decays slowest, hygiene fastest
+// (it recurs). Injectable per call.
+export const DEFAULT_TAU_MS = Object.freeze({
+  "queue-tonight": 7 * DAY_MS,
+  suggestion: 3 * DAY_MS,
+  "data-source": 7 * DAY_MS,
+  maintenance: 1 * DAY_MS,
+  watcher: 3 * DAY_MS,
+});
+
+// §11.4 "rising urgency (untouched-project pressure)": a candidate touching a
+// project untouched this many days gets an urgency boost in Decay.
+export const RISING_URGENCY_DAYS = 7;
+export const RISING_URGENCY_FACTOR = 1.5;
+
+// §11.5: unreviewed drafts expire after 7 days with an `expire` verdict.
+export const DRAFT_EXPIRY_MS = 7 * DAY_MS;
+
+// Candidate classes (§11.4 first paragraph).
+export const CANDIDATE_CATEGORIES = Object.freeze([
+  "queue-tonight", // accepted decision-card options marked "tonight"
+  "suggestion", // below act thresholds but scoring high on value
+  "data-source", // data-source analyses (§7.6)
+  "maintenance", // hygiene class: dep advisories, CI red
+  "watcher", // watcher-driven investigations
+]);
+
+// Default predicted cost (fraction-of-window units) when a candidate carries
+// no cost estimate — keeps unknown-cost maintenance candidates scoreable
+// instead of silently dropped (graceful-empty rule, §11.4).
+export const DEFAULT_PREDICTED_COST = 1;
+
+export const OVERNIGHT_LEDGER_SOURCE = "overnight";
+export const OVERNIGHT_STATE_FILENAME = "overnight.json";
+
+// ---------------------------------------------------------------------------
+// Small shared helpers
+// ---------------------------------------------------------------------------
+
+function clamp01(v) {
+  return Math.min(1, Math.max(0, v));
+}
+
+function finiteOrNull(v) {
+  return typeof v === "number" && Number.isFinite(v) ? v : null;
+}
+
+function ledgerRow(kind, ts, extra = {}) {
+  return { actor: "cto", kind, source: OVERNIGHT_LEDGER_SOURCE, ts, ...extra };
+}
+
+// Nearest lattice value; non-finite input snaps to nothing (caller drops the
+// candidate — graceful degradation, never a crash on bad model output).
+export function snapToLattice(v, lattice) {
+  if (typeof v !== "number" || !Number.isFinite(v)) return null;
+  let best = null;
+  let bestDist = Infinity;
+  for (const l of lattice) {
+    const d = Math.abs(v - l);
+    if (d < bestDist) {
+      best = l;
+      bestDist = d;
+    }
+  }
+  return best;
+}
+
+// ---------------------------------------------------------------------------
+// §11.1 — the window state machine (pure; I/O injected by the caller)
+// ---------------------------------------------------------------------------
+
+// Coerce an unknown persisted window payload into the canonical shape. Never
+// throws: a corrupt/foreign store yields a closed window (the quiet default).
+export function normalizeWindow(prev) {
+  const w = prev && typeof prev === "object" ? prev : {};
+  const state = w.state === "open" ? "open" : "closed";
+  const countdown =
+    w.countdown && typeof w.countdown === "object" && finiteOrNull(w.countdown.dueMs) !== null
+      ? { dueMs: w.countdown.dueMs, announcedMs: finiteOrNull(w.countdown.announcedMs) ?? w.countdown.dueMs }
+      : null;
+  return {
+    state,
+    openedMs: finiteOrNull(w.openedMs),
+    closedMs: finiteOrNull(w.closedMs),
+    closeReason: typeof w.closeReason === "string" ? w.closeReason : null,
+    openedBy: typeof w.openedBy === "string" ? w.openedBy : null,
+    // true when the window opened while the user was demonstrably present
+    // (run-now override) — such a window closes on the next user event, not
+    // on the presence flag (which was already "present" at open).
+    openedDuringPresence: w.openedDuringPresence === true,
+    // Manual pin (input consent): when set, this exact order governs the
+    // window's plan for its whole life — exempt from re-scoring.
+    pinnedOrder: Array.isArray(w.pinnedOrder) ? w.pinnedOrder.filter((x) => typeof x === "string") : null,
+    countdown,
+    lastEvaluatedMs: finiteOrNull(w.lastEvaluatedMs),
+  };
+}
+
+export function defaultWindow() {
+  return normalizeWindow(null);
+}
+
+// Is `ts` inside the trough [startMs, endMs)? A missing/invalid trough means
+// "no trough known" — the window can still be run-now'd, never auto-opened.
+export function troughContains(ts, trough) {
+  if (!trough) return false;
+  const start = finiteOrNull(trough.startMs);
+  const end = finiteOrNull(trough.endMs);
+  if (start === null || end === null || end <= start) return false;
+  return ts >= start && ts < end;
+}
+
+/**
+ * The positive absence signal (§11.1). Returns the signal kind or `null`.
+ * - presence `gone` (desktop-confirmed) → "presence-gone"
+ * - no-desktop boxes: ≥ 60 min of zero user-originated events *inside the
+ *   trough* — the silent stretch is measured from the later of the last user
+ *   event and the trough start, so pre-trough quiet does not count; with no
+ *   trough known the silence cannot be verified as trough-internal → null.
+ * Prolonged signal *absence* alone never opens the window: on a desktop box
+ * with presence unknown/present this returns null.
+ */
+export function absenceSignal({ now, presence, hasDesktop, lastUserEventMs, trough }) {
+  if (presence === "gone") return "presence-gone";
+  if (hasDesktop) return null; // desktop boxes rely on presence only
+  if (!troughContains(now, trough)) return null;
+  const last = finiteOrNull(lastUserEventMs);
+  if (last === null) return null; // no event data at all is signal *absence*
+  const effectiveLast = Math.max(last, trough.startMs);
+  return now - effectiveLast >= ABSENCE_SILENCE_MIN_MS ? "event-silence" : null;
+}
+
+/**
+ * The pure transition step for one scheduler tick.
+ *
+ * `prev`  — the persisted window state (normalizeWindow shape).
+ * `input` — { now, trough?, presence, hasDesktop, lastUserEventMs, runNow?,
+ *            candidateCount }
+ *
+ * Returns `{ window, ledgerRows }`. Ledger rows are §14-shaped entries the
+ * caller appends best-effort (kind `cto.overnight.*`).
+ *
+ * Transitions:
+ * - closed → open when (a) `runNow` consent is set (the override; the verb
+ *   that sets it ships in BET-1419), or (b) inside the trough AND a positive
+ *   absence signal AND candidates exist. Zero candidates → no window
+ *   (§11.4 graceful-empty: "a night with zero candidates opens no window").
+ *   A pending veto countdown is executed (cleared) by the very open it was
+ *   counting down to.
+ * - open → closed at trough end or on user return, whichever first. User
+ *   return = a user-originated event newer than the open, or the presence
+ *   flag flipping present for a window that opened during absence.
+ * - elapsed-but-never-evaluated veto countdowns (box was down) are abandoned
+ *   + ledgered past the grace window — never executed late (§11.6).
+ */
+export function evaluateWindow(prev, input) {
+  const now = finiteOrNull(input?.now) ?? Date.now();
+  const w = normalizeWindow(prev);
+  const rows = [];
+  const trough = input?.trough ?? null;
+  const presence = input?.presence ?? null;
+  const candidateCount = Number.isFinite(input?.candidateCount) ? input.candidateCount : null;
+
+  // --- countdown bookkeeping (a window-independent veto artifact) -----------
+  let countdown = w.countdown;
+  if (countdown && now >= countdown.dueMs) {
+    const canOpenNow = troughContains(now, trough) && !!absenceSignal({ now, presence, hasDesktop: input?.hasDesktop, lastUserEventMs: input?.lastUserEventMs, trough });
+    if (canOpenNow || (w.state === "open" && now - w.openedMs < COUNTDOWN_ABANDON_GRACE_MS)) {
+      // The moment it was counting down to has arrived (or the window already
+      // opened on its own signal) — the countdown is fulfilled, not abandoned.
+      countdown = null;
+    } else if (now - countdown.dueMs > COUNTDOWN_ABANDON_GRACE_MS) {
+      // Elapsed unmet (box was down / signal never materialized) → abandoned,
+      // never executed late (§11.6 last bullet).
+      rows.push(
+        ledgerRow("cto.overnight.countdown-abandoned", now, {
+          reason: "veto countdown elapsed without its window opening; never run retroactively",
+          dueMs: countdown.dueMs,
+        }),
+      );
+      countdown = null;
+    }
+    // else: within grace — leave pending for the next tick.
+  }
+
+  // --- close checks (an open window closes before anything else reopens) ---
+  if (w.state === "open") {
+    const freshUserEvent =
+      finiteOrNull(input?.lastUserEventMs) !== null && input.lastUserEventMs > w.openedMs;
+    const presenceReturn = presence === "present" && !w.openedDuringPresence;
+    if (troughContains(w.openedMs, trough) && now >= trough.endMs) {
+      rows.push(ledgerRow("cto.overnight.close", now, { reason: "trough-end", openedMs: w.openedMs }));
+      return {
+        window: normalizeWindow({ ...w, state: "closed", closedMs: now, closeReason: "trough-end", countdown }),
+        ledgerRows: rows,
+      };
+    }
+    if (freshUserEvent || presenceReturn) {
+      const reason = freshUserEvent ? "user-event" : "user-return";
+      rows.push(ledgerRow("cto.overnight.close", now, { reason, openedMs: w.openedMs }));
+      return {
+        window: normalizeWindow({ ...w, state: "closed", closedMs: now, closeReason: reason, countdown }),
+        ledgerRows: rows,
+      };
+    }
+    // Still open — nothing to do this tick.
+    return { window: normalizeWindow({ ...w, countdown, lastEvaluatedMs: now }), ledgerRows: rows };
+  }
+
+  // --- open checks ----------------------------------------------------------
+  const runNow = input?.runNow === true;
+  const signal = absenceSignal({ now, presence, hasDesktop: input?.hasDesktop, lastUserEventMs: input?.lastUserEventMs, trough });
+  const inTrough = troughContains(now, trough);
+  const zeroCandidates = candidateCount === 0;
+
+  if (zeroCandidates) {
+    // §11.4: a night with zero candidates opens no window at all — not even
+    // on run-now (there is nothing to run).
+    if (inTrough && (signal || runNow)) {
+      rows.push(ledgerRow("cto.overnight.no-candidates", now, { reason: "zero candidates; no window" }));
+    }
+    return { window: normalizeWindow({ ...w, countdown, lastEvaluatedMs: now }), ledgerRows: rows };
+  }
+
+  const mayOpen = runNow || (inTrough && signal !== null);
+  if (!mayOpen) {
+    return { window: normalizeWindow({ ...w, countdown, lastEvaluatedMs: now }), ledgerRows: rows };
+  }
+
+  const openedDuringPresence = presence === "present";
+  rows.push(
+    ledgerRow("cto.overnight.open", now, {
+      reason: runNow && !inTrough ? "run-now" : signal ?? "run-now",
+      openedBy: runNow ? "run-now" : signal,
+    }),
+  );
+  return {
+    window: normalizeWindow({
+      ...w,
+      state: "open",
+      openedMs: now,
+      closedMs: null,
+      closeReason: null,
+      openedBy: runNow ? "run-now" : signal,
+      openedDuringPresence,
+      countdown: null, // an open fulfills any pending countdown
+      lastEvaluatedMs: now,
+    }),
+    ledgerRows: rows,
+  };
+}
+
+/**
+ * Arm the veto countdown (the 30-min pre-open announcement, §11.1 / §10.3).
+ * The verb that *calls* this ships in BET-1419; the machine carries the state
+ * and abandons it if it elapses unmet. Returns the next window state.
+ */
+export function scheduleCountdown(prev, { now, dueMs } = {}) {
+  const w = normalizeWindow(prev);
+  const due = finiteOrNull(dueMs);
+  if (due === null) return w;
+  return normalizeWindow({
+    ...w,
+    countdown: { dueMs: due, announcedMs: finiteOrNull(now) ?? due - VETO_COUNTDOWN_LEAD_MS },
+  });
+}
+
+/**
+ * §11.6 restart recovery (the pure part; job-state reconciliation against the
+ * delegate store is BET-1419). On boot: re-derive the window from trough +
+ * presence; an open window whose trough fully elapsed during downtime is
+ * closed and *skipped* (no-catch-up — never run retroactively); an open
+ * window still inside its trough survives but demands a fresh spendable
+ * computation before any new start; elapsed veto countdowns are abandoned.
+ */
+export function reconcileOnRestart(prev, input) {
+  const now = finiteOrNull(input?.now) ?? Date.now();
+  const w = normalizeWindow(prev);
+  const rows = [];
+  const trough = input?.trough ?? null;
+
+  let window = w;
+  let recomputeSpendable = false;
+
+  if (w.countdown && now >= w.countdown.dueMs + COUNTDOWN_ABANDON_GRACE_MS) {
+    rows.push(
+      ledgerRow("cto.overnight.countdown-abandoned", now, {
+        reason: "veto countdown elapsed while the box was down; never executed late",
+        dueMs: w.countdown.dueMs,
+      }),
+    );
+    window = normalizeWindow({ ...window, countdown: null });
+  }
+
+  if (w.state === "open") {
+    const inTrough = troughContains(w.openedMs, trough);
+    if (inTrough && now >= trough.endMs) {
+      // The window's whole life is behind us: skipped, never caught up.
+      rows.push(
+        ledgerRow("cto.overnight.close", now, { reason: "trough-end", openedMs: w.openedMs, note: "restart reconcile" }),
+      );
+      rows.push(
+        ledgerRow("cto.overnight.no-catch-up", now, {
+          reason: "window missed entirely while the box was down; skipped, never run retroactively",
+        }),
+      );
+      window = normalizeWindow({ ...window, state: "closed", closedMs: now, closeReason: "trough-end" });
+    } else {
+      // Still inside its trough: re-derived, kept — but the reserve math must
+      // run again before anything new starts (§11.6 "re-runs the reserve
+      // computation before starting anything new").
+      recomputeSpendable = true;
+      rows.push(
+        ledgerRow("cto.overnight.restart", now, { reason: "window re-derived after restart; spendable recompute required" }),
+      );
+    }
+  }
+
+  return { window, ledgerRows: rows, recomputeSpendable };
+}
+
+// ---------------------------------------------------------------------------
+// §11.4 — the portfolio scorer
+// ---------------------------------------------------------------------------
+
+/**
+ * λ from the spendable ratio (§11.4): 0 when spendable is fat (≥ half the
+ * window), rising linearly to LAMBDA_MAX as spendable → 0. A windowless
+ * plan (`spendableFrac: null`, §11.2) has no fractional reserve — λ = 0 and
+ * the absolute $ night cap governs instead. An unreadable budget also yields
+ * 0: a budget read failure must never block the night (graceful).
+ */
+export function lambdaFromSpendable(spendable) {
+  const s = finiteOrNull(spendable?.spendableFrac);
+  if (s === null) return 0; // windowless / unknown → no shadow price
+  const frac = clamp01(s);
+  if (frac >= SPENDABLE_FAT_FRAC) return 0;
+  return LAMBDA_MAX * ((SPENDABLE_FAT_FRAC - frac) / SPENDABLE_FAT_FRAC);
+}
+
+/**
+ * Decay(t) (§11.4): staleness exp(-age/τ) with a per-category τ, times the
+ * rising-urgency boost for candidates on an untouched project. Missing age
+ * data decays to 1 (no staleness evidence is not staleness).
+ */
+export function decayFactor(candidate, { now, tauMs } = {}) {
+  const tau = finiteOrNull(tauMs) ?? (DEFAULT_TAU_MS[candidate?.category] ?? 3 * DAY_MS);
+  const touched = finiteOrNull(candidate?.lastTouchedMs);
+  let decay = touched === null ? 1 : Math.exp(-Math.max(0, now - touched) / Math.max(1, tau));
+  const untouchedDays = finiteOrNull(candidate?.untouchedProjectDays);
+  if (untouchedDays !== null && untouchedDays >= RISING_URGENCY_DAYS) decay *= RISING_URGENCY_FACTOR;
+  return decay;
+}
+
+/**
+ * Thompson-blend multiplier for one category (§11.4: "Category Value·
+ * Confidence is blended with Thompson-sampled acceptance posteriors — two
+ * counters per category, from verdicts"). `counters` maps category →
+ * { alpha, beta } (successes/rejections); no data draws the flat 0.5 prior
+ * via thompsonDraw(0,0).
+ */
+export function thompsonMultiplier(counters, category, rng = Math.random) {
+  const c = counters && typeof counters === "object" ? counters[category] : null;
+  const alpha = finiteOrNull(c?.alpha) ?? 0;
+  const beta = finiteOrNull(c?.beta) ?? 0;
+  return thompsonDraw(alpha, beta, rng);
+}
+
+/**
+ * Fold one verdict's effects into a category's acceptance counters (immutable
+ * copy). Success effects (accept/edit) bump alpha; rejection effects
+ * (dismiss/veto/correct, plus the `never` flag) bump beta — via the shared
+ * `effectsForVerdict` table so the portfolio can never disagree with the
+ * verdict ledger's semantics. BET-1419 calls this from the queue-tonight
+ * verdict sink.
+ */
+export function foldVerdictIntoCounters(counters, { category, verdict, never } = {}) {
+  const base = counters && typeof counters === "object" ? counters : {};
+  const cur = base[category] && typeof base[category] === "object" ? base[category] : {};
+  const effects = effectsForVerdict(verdict, never);
+  return {
+    ...base,
+    [category]: {
+      alpha: (finiteOrNull(cur.alpha) ?? 0) + (effects.success ? 1 : 0),
+      beta: (finiteOrNull(cur.beta) ?? 0) + (effects.rejection ? 1 : 0),
+    },
+  };
+}
+
+/**
+ * Score the candidate portfolio (§11.4, formula verbatim):
+ *
+ *   Score = p_use · Value · Confidence · Decay(t) / (λ · PredictedCost)
+ *
+ * with Value·Confidence snapped to the coarse lattices and blended with the
+ * Thompson-sampled acceptance posterior of the candidate's category. λ comes
+ * from the spendable ratio. Candidates with unscoreable Value/Confidence are
+ * dropped (graceful); a missing cost falls back to DEFAULT_PREDICTED_COST;
+ * λ = 0 (fat budget) removes the cost penalty entirely (divide-by-zero is
+ * the mathematical λ→∞-affordability limit, resolved as `score = numerator`).
+ *
+ * Returns the ranked list (score desc) annotated with every factor. Never
+ * throws on garbage input; `[]` in → `[]` out.
+ */
+export function scoreCandidates(candidates, { now, spendable, counters, rng, tauMs } = {}) {
+  const t = finiteOrNull(now) ?? Date.now();
+  const lambda = lambdaFromSpendable(spendable ?? {});
+  const list = Array.isArray(candidates) ? candidates : [];
+  const scored = [];
+  for (const c of list) {
+    if (!c || typeof c !== "object" || typeof c.id !== "string" || c.id.length === 0) continue;
+    const value = snapToLattice(c.value, VALUE_LATTICE);
+    const confidence = snapToLattice(c.confidence, CONFIDENCE_LATTICE);
+    if (value === null || confidence === null) continue; // unscoreable → drop
+    const category = CANDIDATE_CATEGORIES.includes(c.category) ? c.category : "suggestion";
+    const pUse = clamp01(finiteOrNull(c.pUse) ?? 1);
+    const costRaw = finiteOrNull(c.predictedCost);
+    const predictedCost = costRaw !== null && costRaw > 0 ? costRaw : DEFAULT_PREDICTED_COST;
+    const decay = decayFactor({ ...c, category }, { now: t, tauMs });
+    const thompson = thompsonMultiplier(counters, category, rng);
+    const numerator = pUse * value * confidence * decay * thompson;
+    const denom = lambda * predictedCost;
+    const score = denom > 0 ? numerator / denom : numerator;
+    scored.push({
+      ...c,
+      category,
+      value,
+      confidence,
+      pUse,
+      predictedCost,
+      decay,
+      thompson,
+      lambda,
+      score,
+    });
+  }
+  scored.sort((a, b) => b.score - a.score);
+  return scored;
+}
+
+/**
+ * Select tonight's plan from the ranked list (§11.4 + §11.3 budget cut).
+ * Applies the hygiene floor: when any maintenance candidate exists, 20% of
+ * the night's budget is reserved for the maintenance class — non-maintenance
+ * jobs may not consume it while a maintenance candidate remains unselected.
+ * Every class degrades to empty gracefully: empty in → empty out.
+ *
+ * `budgetFrac` is the night's budget in predictedCost units (the spendable
+ * fraction of the plan window; the accessor passes it from ctoBudget).
+ * `pinnedOrder` (manual pin, input consent) overrides ranking entirely: the
+ * pinned candidate order governs selection and is exempt from re-scoring.
+ */
+export function selectPortfolio(ranked, { budgetFrac = 1, pinnedOrder = null } = {}) {
+  const list = Array.isArray(ranked) ? ranked : [];
+  const budget = Math.max(0, finiteOrNull(budgetFrac) ?? 1);
+  const byId = new Map(list.map((c) => [c.id, c]));
+
+  let ordered;
+  if (Array.isArray(pinnedOrder) && pinnedOrder.length > 0) {
+    // Pinned order governs; unknown ids are skipped, un-pinned candidates
+    // never jump ahead of the pin (the pin is the window's contract).
+    ordered = pinnedOrder.map((id) => byId.get(id)).filter(Boolean);
+  } else {
+    ordered = [...list];
+  }
+
+  const hasMaintenance = list.some((c) => c.category === "maintenance");
+  const floorFrac = hasMaintenance ? HYGIENE_FLOOR_SHARE * budget : 0;
+  let spendable = budget;
+  let generalBudget = budget - floorFrac;
+
+  const selected = [];
+  let maintenanceSelectedFrac = 0;
+  for (const c of ordered) {
+    const cost = Math.max(0, finiteOrNull(c.predictedCost) ?? DEFAULT_PREDICTED_COST);
+    const isMaintenance = c.category === "maintenance";
+    if (isMaintenance) {
+      if (cost > spendable) continue;
+      spendable -= cost;
+      maintenanceSelectedFrac += cost;
+      selected.push(c);
+    } else {
+      // Non-maintenance jobs stop at the hygiene-floor line while any
+      // maintenance candidate is still waiting for its reserved slice.
+      const maintenanceStillWaiting = list.some(
+        (m) => m.category === "maintenance" && !selected.includes(m),
+      );
+      const limit = maintenanceStillWaiting ? generalBudget : budget;
+      if (cost > limit || cost > spendable) continue;
+      spendable -= cost;
+      generalBudget -= cost;
+      selected.push(c);
+    }
+  }
+
+  return {
+    selected,
+    reservedMaintenanceFrac: maintenanceSelectedFrac,
+    floorFrac,
+    hasMaintenance,
+    budgetFrac: budget,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// §11.5 — execution-contract helpers (exported for BET-1419 to call)
+// ---------------------------------------------------------------------------
+
+/**
+ * Machine gates before surfacing (§11.5): the gate set is read from project
+ * config (`gates: { typecheck, tests, lint }` — truthy entry = defined gate).
+ * An **empty gate set passes with a `no-gates` note** carried on the artifact,
+ * the Just-finished card and the digest item — review expectations are
+ * calibrated, never silently absent.
+ */
+export function evaluateGates(projectConfig) {
+  const gates = projectConfig?.gates && typeof projectConfig.gates === "object" ? projectConfig.gates : {};
+  const defined = Object.keys(gates).filter((k) => gates[k]);
+  if (defined.length === 0) {
+    return { pass: true, gates: [], note: "no-gates" };
+  }
+  return { pass: true, gates: defined, note: null };
+}
+
+/**
+ * Overnight delegate jobs require a git project (§11.5: worktrees are git).
+ * Non-git projects are read/digest-only surfaces: they never receive
+ * file-editing jobs, but read-only work is fine.
+ */
+export function gitOnlyJobRule(project, { fileEditing = true } = {}) {
+  const isGit = project?.git === true;
+  if (!fileEditing) return { allowed: true, reason: null };
+  if (!isGit) return { allowed: false, reason: "non-git" };
+  return { allowed: true, reason: null };
+}
+
+/**
+ * §11.2 routing: batch-flagged request-shaped tasks route to a provider's
+ * batch pool where the adapter reports one (cheaper, non-competing); agentic
+ * tasks always draw on the interactive pool. `providers` maps provider id →
+ * adapter capabilities ({ batchPool: boolean }); a provider with no adapter
+ * entry is treated as interactive-only and never blocks the path.
+ */
+export function routeRequestShaped(candidate, providers = {}) {
+  const provider = typeof candidate?.provider === "string" && candidate.provider ? candidate.provider : null;
+  if (!provider) return { provider: null, pool: "interactive", reason: "no provider" };
+  const caps = providers && typeof providers === "object" ? providers[provider] : null;
+  const batchPool = caps?.batchPool === true;
+  if (candidate?.requestShaped === true && batchPool) {
+    return { provider, pool: "batch", reason: null };
+  }
+  return { provider, pool: "interactive", reason: candidate?.requestShaped === true ? "no batch pool" : "agentic" };
+}
+
+/**
+ * §11.5 draft expiry: unreviewed drafts close after 7 days with an `expire`
+ * verdict and a one-line digest note. Returns the expired drafts (each with
+ * its verdict row) and the survivors. Never throws; garbage entries are kept
+ * untouched rather than expired on a guessed age.
+ */
+export function expireDrafts(drafts, now) {
+  const t = finiteOrNull(now) ?? Date.now();
+  const list = Array.isArray(drafts) ? drafts : [];
+  const expired = [];
+  const keep = [];
+  for (const d of list) {
+    const created = finiteOrNull(d?.createdMs);
+    const reviewed = d?.reviewed === true;
+    const unreviewed = !reviewed && d?.reviewedAtMs == null;
+    if (d && typeof d === "object" && typeof d.id === "string" && created !== null && unreviewed && t - created >= DRAFT_EXPIRY_MS) {
+      expired.push({
+        draft: d,
+        verdict: "expire",
+        digestNote: `Draft “${d.title ?? d.id}” expired unreviewed after 7 days.`,
+      });
+    } else {
+      keep.push(d);
+    }
+  }
+  return { expired, keep };
+}
+
+/**
+ * §11.6 preempt-on-return (the pure decision; the bus wiring is BET-1419):
+ * when presence flips present while an absence-opened window holds, the
+ * running overnight jobs pause (at their next tool-call boundary) and the
+ * window closes. A window opened during presence (run-now while the user is
+ * there) is not preempted by the presence flag alone — its user-event close
+ * rule governs.
+ */
+export function preemptOnReturn({ presence, window, runningJobs = [] } = {}) {
+  const w = normalizeWindow(window);
+  if (presence !== "present" || w.state !== "open" || w.openedDuringPresence) {
+    return { shouldPause: false, pauseJobs: [], closeWindow: false };
+  }
+  return {
+    shouldPause: true,
+    pauseJobs: (Array.isArray(runningJobs) ? runningJobs : []).filter((j) => typeof j === "string"),
+    closeWindow: true,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// The I/O accessor (injected store + ledger + budget; BET-1419 wires it)
+// ---------------------------------------------------------------------------
+
+// Default store: the shared atomic jsonStore pattern at the sandboxed state
+// path (statePath — never a bare homedir join; the test-sandbox rule).
+function defaultOvernightStore() {
+  const path = statePath("cto", OVERNIGHT_STATE_FILENAME);
+  const mutex = createMutex();
+  const fallback = { v: 1, window: null };
+  return {
+    path,
+    load: async () => {
+      const raw = readJsonSync(path, fallback);
+      return raw && typeof raw === "object" ? raw : fallback;
+    },
+    save: (data) =>
+      mutex.runExclusive(() => writeJsonAtomic(path, JSON.stringify(data ?? fallback, null, 2), { mode: 0o600 })),
+  };
+}
+
+/**
+ * The overnight scheduler accessor. All decision logic lives in the exported
+ * pure functions above; this factory only injects I/O:
+ * - `store`  — { load, save } for the window state (default: jsonStore at
+ *              statePath("cto/overnight.json"))
+ * - `now`    — clock seam
+ * - `budget` — async () => ({ spendableFrac, remainingFrac } | null), fed
+ *              from ctoBudget's computeSpendable by BET-1419; a throw is
+ *              swallowed (budget read failure must never block the night)
+ * - `ledger` — optional { append(row) } for the §14.5 activity ledger
+ */
+export function createOvernightScheduler({ store = defaultOvernightStore(), now = Date.now, budget = async () => null, ledger = null } = {}) {
+  async function ledgerAppend(rows) {
+    for (const row of rows ?? []) {
+      try {
+        if (ledger && typeof ledger.append === "function") await ledger.append(row);
+      } catch {
+        /* ledger is best-effort — never fail a tick on a ledger write */
+      }
+    }
+  }
+
+  async function readSpendable() {
+    try {
+      return (await budget()) ?? {};
+    } catch {
+      return {}; // graceful: unreadable budget → λ = 0 (fat default)
+    }
+  }
+
+  return {
+    /**
+     * One scheduler tick. `input`: { trough?, presence, hasDesktop,
+     * lastUserEventMs, runNow?, candidates? }. Persists the window state,
+     * appends ledger rows best-effort, and — whenever the window is open and
+     * candidates are supplied — scores the portfolio and selects tonight's
+     * plan under the current spendable. Returns { window, plan, ledgerRows }.
+     */
+    async tick(input = {}) {
+      const t = typeof now === "function" ? now() : now;
+      const payload = await store.load().catch(() => ({ v: 1, window: null }));
+      const prevWindow = payload?.window ?? null;
+      const candidates = Array.isArray(input.candidates) ? input.candidates : [];
+
+      const { window, ledgerRows } = evaluateWindow(prevWindow, {
+        ...input,
+        now: t,
+        candidateCount: candidates.length,
+      });
+
+      let plan = null;
+      if (window.state === "open" && candidates.length > 0) {
+        const spendable = await readSpendable();
+        const ranked = scoreCandidates(candidates, { now: t, spendable, counters: payload?.counters, rng: Math.random });
+        // The spendable fraction of the plan window IS the night's budget in
+        // predictedCost units (both are fraction-of-window space, §11.3).
+        const budgetFrac = finiteOrNull(spendable.spendableFrac) ?? 1;
+        plan = selectPortfolio(ranked, { budgetFrac, pinnedOrder: window.pinnedOrder });
+      }
+
+      await store.save({ ...payload, window }).catch(() => {});
+      await ledgerAppend(ledgerRows);
+      return { window, plan, ledgerRows };
+    },
+
+    /**
+     * §11.6 restart recovery: re-derive the window, abandon elapsed veto
+     * countdowns, skip fully-missed windows, and flag whether the spendable
+     * must be recomputed before any new start. Persists + ledgers.
+     */
+    async reconcile(input = {}) {
+      const t = typeof now === "function" ? now() : now;
+      const payload = await store.load().catch(() => ({ v: 1, window: null }));
+      const { window, ledgerRows, recomputeSpendable } = reconcileOnRestart(payload?.window ?? null, {
+        ...input,
+        now: t,
+      });
+      await store.save({ ...payload, window }).catch(() => {});
+      await ledgerAppend(ledgerRows);
+      return { window, recomputeSpendable, ledgerRows };
+    },
+  };
+}
+
+// Re-exported for BET-1419's convenience (and so tests assert the exact
+// helper identities the engine will consume).
+export { betaMean, thompsonDraw, statePath };

--- a/src/server/ctoOvernight.test.mjs
+++ b/src/server/ctoOvernight.test.mjs
@@ -1,0 +1,463 @@
+// src/server/ctoOvernight.test.mjs
+// BET-1402 — pure-logic tests for the overnight scheduler CORE (node:test,
+// injected I/O only — no live tmux/opencode/network).
+
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  ABSENCE_SILENCE_MIN_MS,
+  CANDIDATE_CATEGORIES,
+  CONFIDENCE_LATTICE,
+  COUNTDOWN_ABANDON_GRACE_MS,
+  DEFAULT_PREDICTED_COST,
+  HYGIENE_FLOOR_SHARE,
+  VALUE_LATTICE,
+  absenceSignal,
+  createOvernightScheduler,
+  decayFactor,
+  evaluateGates,
+  evaluateWindow,
+  expireDrafts,
+  foldVerdictIntoCounters,
+  gitOnlyJobRule,
+  lambdaFromSpendable,
+  normalizeWindow,
+  preemptOnReturn,
+  reconcileOnRestart,
+  routeRequestShaped,
+  scheduleCountdown,
+  scoreCandidates,
+  selectPortfolio,
+  snapToLattice,
+  thompsonMultiplier,
+} from "./ctoOvernight.mjs";
+
+const H = 3_600_000;
+const T0 = 1_800_000_000_000; // arbitrary fixed epoch
+const TROUGH = { startMs: T0, endMs: T0 + 6 * H };
+
+function tickInput(over = {}) {
+  return {
+    now: T0 + H,
+    trough: TROUGH,
+    presence: "gone",
+    hasDesktop: true,
+    lastUserEventMs: T0 - H,
+    candidateCount: 3,
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// §11.1 — window state machine
+// ---------------------------------------------------------------------------
+
+test("window opens on presence-gone inside the trough", () => {
+  const { window, ledgerRows } = evaluateWindow(null, tickInput());
+  assert.equal(window.state, "open");
+  assert.equal(window.openedBy, "presence-gone");
+  assert.equal(window.openedMs, T0 + H);
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.open"));
+});
+
+test("window opens on ≥60 min of zero user events inside the trough (no-desktop box)", () => {
+  const { window } = evaluateWindow(
+    null,
+    tickInput({ presence: null, hasDesktop: false, now: T0 + ABSENCE_SILENCE_MIN_MS + 1, lastUserEventMs: T0 - 5 * 60_000 }),
+  );
+  assert.equal(window.state, "open");
+  assert.equal(window.openedBy, "event-silence");
+});
+
+test("pre-trough quiet does not count toward the 60-min silence (signal must be inside the trough)", () => {
+  // Last user event 2h before the trough; only 30 min of trough-internal silence.
+  const { window } = evaluateWindow(null, tickInput({ presence: null, hasDesktop: false, now: T0 + 30 * 60_000, lastUserEventMs: T0 - 2 * H }));
+  assert.equal(window.state, "closed");
+});
+
+test("sub-60-min silence never opens (no-desktop box)", () => {
+  const { window } = evaluateWindow(
+    null,
+    tickInput({ presence: null, hasDesktop: false, now: T0 + 59 * 60_000, lastUserEventMs: T0 }),
+  );
+  assert.equal(window.state, "closed");
+});
+
+test("prolonged signal ABSENCE alone never opens (desktop box, presence unknown/present)", () => {
+  for (const presence of [null, "present"]) {
+    const { window } = evaluateWindow(null, tickInput({ presence, lastUserEventMs: T0 - 48 * H }));
+    assert.equal(window.state, "closed", `presence=${presence}`);
+    assert.equal(absenceSignal({ now: T0 + H, presence, hasDesktop: true, lastUserEventMs: T0 - 48 * H }), null);
+  }
+});
+
+test("window closes at trough end", () => {
+  const { window } = evaluateWindow(null, tickInput({ now: T0 + H }));
+  const { window: closed, ledgerRows } = evaluateWindow(window, tickInput({ now: TROUGH.endMs }));
+  assert.equal(closed.state, "closed");
+  assert.equal(closed.closeReason, "trough-end");
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.close" && r.reason === "trough-end"));
+});
+
+test("window closes on user return (presence flip)", () => {
+  const { window } = evaluateWindow(null, tickInput({ now: T0 + H }));
+  const { window: closed, ledgerRows } = evaluateWindow(window, tickInput({ now: T0 + 2 * H, presence: "present" }));
+  assert.equal(closed.state, "closed");
+  assert.equal(closed.closeReason, "user-return");
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.close" && r.reason === "user-return"));
+});
+
+test("window closes on a fresh user-originated event after open", () => {
+  const { window } = evaluateWindow(null, tickInput({ now: T0 + H }));
+  const { window: closed } = evaluateWindow(window, tickInput({ now: T0 + 90 * 60_000, lastUserEventMs: T0 + 80 * 60_000 }));
+  assert.equal(closed.state, "closed");
+  assert.equal(closed.closeReason, "user-event");
+});
+
+test("run-now override opens immediately, even outside the trough", () => {
+  const { window, ledgerRows } = evaluateWindow(null, tickInput({ now: T0 - 3 * H, trough: null, runNow: true }));
+  assert.equal(window.state, "open");
+  assert.equal(window.openedBy, "run-now");
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.open"));
+});
+
+test("a run-now window opened while the user is present is NOT closed by presence alone — the next user event closes it", () => {
+  const { window } = evaluateWindow(null, tickInput({ presence: "present", runNow: true }));
+  assert.equal(window.openedDuringPresence, true);
+  const stillOpen = evaluateWindow(window, tickInput({ presence: "present", runNow: true, now: T0 + 2 * H }));
+  assert.equal(stillOpen.window.state, "open");
+  const closed = evaluateWindow(window, tickInput({ presence: "present", runNow: true, now: T0 + 2 * H, lastUserEventMs: T0 + 2 * H }));
+  assert.equal(closed.window.state, "closed");
+  assert.equal(closed.window.closeReason, "user-event");
+});
+
+test("zero candidates → no window at all (§11.4 graceful-empty), even on run-now", () => {
+  for (const runNow of [false, true]) {
+    const { window, ledgerRows } = evaluateWindow(null, tickInput({ candidateCount: 0, runNow }));
+    assert.equal(window.state, "closed", `runNow=${runNow}`);
+    assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.no-candidates"), `runNow=${runNow}`);
+  }
+});
+
+test("a fulfilled veto countdown is cleared by the open it announced", () => {
+  const due = T0 + 30 * 60_000;
+  let window = scheduleCountdown(null, { now: T0, dueMs: due });
+  assert.equal(window.countdown.dueMs, due);
+  const { window: opened } = evaluateWindow(window, tickInput({ now: due + 60_000 }));
+  assert.equal(opened.state, "open");
+  assert.equal(opened.countdown, null);
+});
+
+test("a veto countdown elapsed unmet past the grace window is abandoned + ledgered, never executed late", () => {
+  const due = T0 + 30 * 60_000;
+  const window = scheduleCountdown(null, { now: T0, dueMs: due });
+  // Due passed, but the box was down: no trough membership now (or no signal).
+  const { window: after, ledgerRows } = evaluateWindow(window, tickInput({ now: due + COUNTDOWN_ABANDON_GRACE_MS + 60_000, trough: null }));
+  assert.equal(after.state, "closed");
+  assert.equal(after.countdown, null);
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.countdown-abandoned"));
+});
+
+test("restart mid-window: window re-derived and kept, spendable recompute required", () => {
+  const { window } = evaluateWindow(null, tickInput({ now: T0 + H }));
+  const { window: after, recomputeSpendable, ledgerRows } = reconcileOnRestart(window, { now: T0 + 2 * H, trough: TROUGH });
+  assert.equal(after.state, "open");
+  assert.equal(after.openedMs, T0 + H);
+  assert.equal(recomputeSpendable, true);
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.restart"));
+});
+
+test("restart with the window's trough fully elapsed: skipped, never run retroactively (no-catch-up)", () => {
+  const { window } = evaluateWindow(null, tickInput({ now: T0 + H }));
+  const { window: after, recomputeSpendable, ledgerRows } = reconcileOnRestart(window, { now: TROUGH.endMs + 3 * H, trough: TROUGH });
+  assert.equal(after.state, "closed");
+  assert.equal(recomputeSpendable, false);
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.close" && r.reason === "trough-end"));
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.no-catch-up"));
+});
+
+test("restart with an elapsed pending veto countdown abandons it", () => {
+  const due = T0 + 30 * 60_000;
+  const window = scheduleCountdown(null, { now: T0, dueMs: due });
+  const { window: after, ledgerRows } = reconcileOnRestart(window, { now: due + 2 * H, trough: TROUGH });
+  assert.equal(after.countdown, null);
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.countdown-abandoned"));
+});
+
+test("normalizeWindow never throws on garbage and degrades to a closed window", () => {
+  for (const garbage of [null, undefined, 42, "x", { state: "bogus" }, { state: "open" }]) {
+    const w = normalizeWindow(garbage);
+    assert.equal(w.state, garbage?.state === "open" ? "open" : "closed");
+    assert.equal(Array.isArray(w.pinnedOrder) || w.pinnedOrder === null, true);
+  }
+});
+
+// ---------------------------------------------------------------------------
+// §11.4 — portfolio scorer
+// ---------------------------------------------------------------------------
+
+const FAT = { spendableFrac: 0.8, remainingFrac: 0.9 };
+const THIN = { spendableFrac: 0.25, remainingFrac: 0.4 };
+
+function candidate(over = {}) {
+  return {
+    id: over.id ?? "c1",
+    category: "suggestion",
+    value: 2,
+    confidence: 1.0,
+    pUse: 1,
+    predictedCost: 2,
+    lastTouchedMs: T0 + H, // fresh → decay 1
+    ...over,
+  };
+}
+
+test("Score = p_use · Value · Confidence · Decay / (λ·PredictedCost), formula verbatim (fat budget → λ=0, no counters → θ=0.5)", () => {
+  const [scored] = scoreCandidates([candidate()], { now: T0 + H, spendable: FAT });
+  // λ=0 → denominator resolved to 1; numerator = 1·2·1·1·0.5
+  assert.equal(scored.lambda, 0);
+  assert.equal(scored.thompson, 0.5);
+  assert.ok(Math.abs(scored.score - 1) < 1e-12);
+});
+
+test("Thompson blend uses the category's acceptance posterior (all-success → 1, all-rejection → 0)", () => {
+  const c = [candidate()];
+  const yes = scoreCandidates(c, { now: T0 + H, spendable: FAT, counters: { suggestion: { alpha: 4, beta: 0 } } });
+  const no = scoreCandidates(c, { now: T0 + H, spendable: FAT, counters: { suggestion: { alpha: 0, beta: 4 } } });
+  assert.equal(yes[0].thompson, 1);
+  assert.equal(no[0].thompson, 0);
+  assert.ok(yes[0].score > no[0].score);
+});
+
+test("Value and Confidence snap to the coarse lattices; unscoreable candidates are dropped", () => {
+  assert.deepEqual(snapToLattice(2.4, VALUE_LATTICE), 2);
+  assert.deepEqual(snapToLattice(0.9, VALUE_LATTICE), 1);
+  assert.deepEqual(snapToLattice(0.75, CONFIDENCE_LATTICE), 0.8);
+  assert.equal(snapToLattice("high", VALUE_LATTICE), null);
+  const scored = scoreCandidates([candidate({ id: "good", value: 2.4, confidence: 0.75 }), candidate({ id: "bad", value: "huge" })], {
+    now: T0 + H,
+    spendable: FAT,
+  });
+  assert.deepEqual(scored.map((c) => c.id), ["good"]);
+  assert.equal(scored[0].value, 2);
+  assert.equal(scored[0].confidence, 0.8);
+});
+
+test("missing/invalid predictedCost falls back to the default (unknown-cost maintenance stays scoreable)", () => {
+  const [scored] = scoreCandidates([candidate({ category: "maintenance", predictedCost: null })], { now: T0 + H, spendable: THIN });
+  assert.equal(scored.predictedCost, DEFAULT_PREDICTED_COST);
+});
+
+test("λ rises as spendable thins; a thin budget makes the cheap job win near dawn", () => {
+  assert.equal(lambdaFromSpendable({ spendableFrac: 0.5 }), 0);
+  assert.equal(lambdaFromSpendable({ spendableFrac: 0.25 }), 5);
+  assert.equal(lambdaFromSpendable({ spendableFrac: 0 }), 10);
+  assert.equal(lambdaFromSpendable({ spendableFrac: null }), 0); // windowless → no shadow price
+  assert.equal(lambdaFromSpendable({}), 0); // unreadable budget → graceful fat default
+
+  const expensive = candidate({ id: "expensive", value: 3, confidence: 1.0, predictedCost: 8 });
+  const cheap = candidate({ id: "cheap", value: 1, confidence: 1.0, predictedCost: 1 });
+  const fat = scoreCandidates([expensive, cheap], { now: T0 + H, spendable: FAT });
+  assert.deepEqual(fat.map((c) => c.id), ["expensive", "cheap"]); // one expensive high-value job wins early
+  const thin = scoreCandidates([expensive, cheap], { now: T0 + H, spendable: THIN });
+  assert.deepEqual(thin.map((c) => c.id), ["cheap", "expensive"]); // cheap jobs win near dawn
+});
+
+test("Decay: staleness per-category τ, rising-urgency boost for untouched projects", () => {
+  const stale = candidate({ lastTouchedMs: T0 + H - 4 * 24 * H }); // 4 days old
+  const freshTau = decayFactor(stale, { now: T0 + H }); // suggestion τ = 3d
+  assert.ok(freshTau < 1 && freshTau > 0);
+  const urgent = decayFactor({ ...stale, untouchedProjectDays: 9 }, { now: T0 + H });
+  assert.ok(Math.abs(urgent - freshTau * 1.5) < 1e-12);
+  const noAge = decayFactor(candidate({ lastTouchedMs: null }), { now: T0 + H });
+  assert.equal(noAge, 1); // no staleness evidence is not staleness
+});
+
+test("hygiene floor: maintenance is guaranteed 20% of the night's budget when maintenance candidates exist", () => {
+  const ranked = [
+    candidate({ id: "g1", predictedCost: 0.5 }),
+    candidate({ id: "g2", predictedCost: 0.5 }),
+    candidate({ id: "m1", category: "maintenance", predictedCost: 0.2, value: 0.25 }),
+  ];
+  const plan = selectPortfolio(ranked, { budgetFrac: 1 });
+  assert.equal(plan.hasMaintenance, true);
+  assert.equal(plan.floorFrac, HYGIENE_FLOOR_SHARE);
+  const ids = plan.selected.map((c) => c.id);
+  assert.ok(ids.includes("m1"), "the maintenance candidate is selected despite the low score");
+  assert.ok(!ids.includes("g2"), "a general job is shed to honor the floor");
+  assert.ok(plan.reservedMaintenanceFrac > 0);
+});
+
+test("hygiene floor applies only when maintenance candidates exist", () => {
+  const plan = selectPortfolio([candidate({ predictedCost: 0.6 }), candidate({ id: "c2", predictedCost: 0.4 })], { budgetFrac: 1 });
+  assert.equal(plan.hasMaintenance, false);
+  assert.equal(plan.floorFrac, 0);
+  assert.equal(plan.selected.length, 2);
+});
+
+test("graceful-empty everywhere: empty classes allocate nothing; empty in → empty out", () => {
+  assert.deepEqual(scoreCandidates([], { now: T0 + H, spendable: FAT }), []);
+  const plan = selectPortfolio([], { budgetFrac: 1 });
+  assert.deepEqual(plan.selected, []);
+  assert.equal(plan.hasMaintenance, false);
+});
+
+test("a manual pinnedOrder pins that order for the window, exempt from re-scoring", () => {
+  const ranked = [candidate({ id: "a" }), candidate({ id: "b", value: 3 }), candidate({ id: "c", value: 0.5 })];
+  const plan = selectPortfolio(ranked, { budgetFrac: 10, pinnedOrder: ["c", "a", "b"] });
+  assert.deepEqual(plan.selected.map((x) => x.id), ["c", "a", "b"]);
+  // The pin survives re-scoring with different inputs (the window machine
+  // carries pinnedOrder; selectPortfolio keeps honoring it).
+  const rescored = scoreCandidates(ranked, { now: T0 + 2 * H, spendable: THIN, counters: { suggestion: { alpha: 9, beta: 0 } } });
+  const plan2 = selectPortfolio(rescored, { budgetFrac: 10, pinnedOrder: ["c", "a", "b"] });
+  assert.deepEqual(plan2.selected.map((x) => x.id), ["c", "a", "b"]);
+});
+
+test("the window state carries the pin across ticks", () => {
+  const { window } = evaluateWindow(null, tickInput());
+  const pinned = normalizeWindow({ ...window, pinnedOrder: ["c", "a"] });
+  assert.deepEqual(pinned.pinnedOrder, ["c", "a"]);
+});
+
+test("candidate categories are the spec's five classes; unknown categories fall back to suggestion", () => {
+  assert.deepEqual([...CANDIDATE_CATEGORIES], ["queue-tonight", "suggestion", "data-source", "maintenance", "watcher"]);
+  const [s] = scoreCandidates([candidate({ category: "mystery" })], { now: T0 + H, spendable: FAT });
+  assert.equal(s.category, "suggestion");
+});
+
+test("foldVerdictIntoCounters feeds the two counters per category from verdicts", () => {
+  let counters = {};
+  counters = foldVerdictIntoCounters(counters, { category: "queue-tonight", verdict: "accept" });
+  counters = foldVerdictIntoCounters(counters, { category: "queue-tonight", verdict: "edit" });
+  counters = foldVerdictIntoCounters(counters, { category: "queue-tonight", verdict: "veto" });
+  counters = foldVerdictIntoCounters(counters, { category: "queue-tonight", verdict: "open", never: true });
+  assert.deepEqual(counters["queue-tonight"], { alpha: 2, beta: 2 });
+  // thompsonMultiplier consumes the same shape.
+  assert.equal(thompsonMultiplier({ queueTonightX: { alpha: 1, beta: 0 } }, "nope"), 0.5);
+});
+
+// ---------------------------------------------------------------------------
+// §11.5 — execution-contract helpers
+// ---------------------------------------------------------------------------
+
+test("empty gate set passes with a `no-gates` note; defined gates list their names", () => {
+  const empty = evaluateGates({});
+  assert.deepEqual(empty, { pass: true, gates: [], note: "no-gates" });
+  const none = evaluateGates(null);
+  assert.equal(none.note, "no-gates");
+  const full = evaluateGates({ gates: { typecheck: "npm run typecheck", tests: "npm test", lint: null } });
+  assert.deepEqual(full, { pass: true, gates: ["typecheck", "tests"], note: null });
+});
+
+test("git-only rule: non-git projects never receive file-editing jobs; read-only work is fine", () => {
+  assert.deepEqual(gitOnlyJobRule({ git: false }, { fileEditing: true }), { allowed: false, reason: "non-git" });
+  assert.deepEqual(gitOnlyJobRule({}, { fileEditing: true }), { allowed: false, reason: "non-git" });
+  assert.deepEqual(gitOnlyJobRule({ git: false }, { fileEditing: false }), { allowed: true, reason: null });
+  assert.deepEqual(gitOnlyJobRule({ git: true }, { fileEditing: true }), { allowed: true, reason: null });
+});
+
+test("batch-flagged request-shaped tasks route to a batch pool only where the adapter reports one", () => {
+  const providers = { anthropic: { batchPool: true }, groq: {} };
+  assert.deepEqual(routeRequestShaped({ provider: "anthropic", requestShaped: true }, providers), { provider: "anthropic", pool: "batch", reason: null });
+  assert.deepEqual(routeRequestShaped({ provider: "groq", requestShaped: true }, providers).pool, "interactive");
+  assert.deepEqual(routeRequestShaped({ provider: "anthropic", requestShaped: false }, providers).pool, "interactive");
+  assert.deepEqual(routeRequestShaped({ provider: "unknown", requestShaped: true }, providers).pool, "interactive");
+  assert.equal(routeRequestShaped({}, providers).provider, null);
+});
+
+test("draft expiry: unreviewed 7d → closed with an `expire` verdict + one-line digest note", () => {
+  const old = { id: "d1", title: "old draft", createdMs: T0 - 7 * 24 * H };
+  const fresh = { id: "d2", createdMs: T0 - 6 * 24 * H };
+  const reviewed = { id: "d3", createdMs: T0 - 30 * 24 * H, reviewed: true };
+  const { expired, keep } = expireDrafts([old, fresh, reviewed, null], T0);
+  assert.equal(expired.length, 1);
+  assert.equal(expired[0].draft.id, "d1");
+  assert.equal(expired[0].verdict, "expire");
+  assert.match(expired[0].digestNote, /old draft/);
+  assert.deepEqual(keep.map((d) => d?.id ?? null), ["d2", "d3", null]);
+});
+
+test("preempt-on-return: present flip → pause list + window close; run-now-during-presence windows are exempt", () => {
+  const { window } = evaluateWindow(null, tickInput({ now: T0 + H }));
+  const decision = preemptOnReturn({ presence: "present", window, runningJobs: ["j1", "j2", 7] });
+  assert.equal(decision.shouldPause, true);
+  assert.equal(decision.closeWindow, true);
+  assert.deepEqual(decision.pauseJobs, ["j1", "j2"]);
+
+  const runNowOpen = evaluateWindow(null, tickInput({ presence: "present", runNow: true })).window;
+  const exempt = preemptOnReturn({ presence: "present", window: runNowOpen, runningJobs: ["j1"] });
+  assert.equal(exempt.shouldPause, false);
+
+  const closedWindow = normalizeWindow({ ...window, state: "closed" });
+  assert.equal(preemptOnReturn({ presence: "present", window: closedWindow }).shouldPause, false);
+  assert.equal(preemptOnReturn({ presence: "gone", window }).shouldPause, false);
+});
+
+// ---------------------------------------------------------------------------
+// The accessor (injected I/O, end-to-end pure-logic glue)
+// ---------------------------------------------------------------------------
+
+function memoryScheduler(over = {}) {
+  let saved = { v: 1, window: null };
+  const ledgerRows = [];
+  const scheduler = createOvernightScheduler({
+    store: {
+      load: async () => saved,
+      save: async (d) => {
+        saved = d;
+      },
+    },
+    now: () => T0 + H,
+    budget: over.budget ?? (async () => FAT),
+    ledger: { append: async (row) => ledgerRows.push(row) },
+    ...over,
+  });
+  return { scheduler, saved: () => saved, ledgerRows };
+}
+
+test("tick: opens on the absence signal, scores + selects the plan under the live spendable, persists", async () => {
+  const { scheduler, saved, ledgerRows } = memoryScheduler();
+  const out = await scheduler.tick(tickInput({ candidates: [candidate({ id: "a", predictedCost: 0.5 }), candidate({ id: "b", predictedCost: 0.3 })] }));
+  assert.equal(out.window.state, "open");
+  assert.deepEqual(out.plan.selected.map((c) => c.id), ["a", "b"]);
+  assert.equal(out.plan.budgetFrac, FAT.spendableFrac);
+  assert.equal(saved().window.state, "open");
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.open"));
+
+  // The user returns → the next tick closes the window (and the plan is gone).
+  const closed = await scheduler.tick(tickInput({ now: T0 + 2 * H, presence: "present", candidates: [] }));
+  assert.equal(closed.window.state, "closed");
+  assert.equal(closed.plan, null);
+});
+
+test("tick with an unreadable budget still plans (graceful λ=0 fat default)", async () => {
+  const { scheduler } = memoryScheduler({ budget: async () => { throw new Error("budget down"); } });
+  const out = await scheduler.tick(tickInput({ candidates: [candidate({ predictedCost: 0.5 })] }));
+  assert.equal(out.window.state, "open");
+  assert.equal(out.plan.selected.length, 1);
+  assert.equal(out.plan.selected[0].lambda, 0);
+});
+
+test("reconcile persists the re-derived window and reports the spendable recompute", async () => {
+  const { scheduler, saved } = memoryScheduler();
+  await scheduler.tick(tickInput({ candidates: [candidate()] }));
+  const out = await scheduler.reconcile({ now: T0 + 2 * H, trough: TROUGH });
+  assert.equal(out.window.state, "open");
+  assert.equal(out.recomputeSpendable, true);
+  assert.equal(saved().window.state, "open");
+});
+
+test("every pure entry point survives garbage input (graceful, never throws)", () => {
+  assert.doesNotThrow(() => evaluateWindow(undefined, undefined));
+  assert.doesNotThrow(() => scoreCandidates(undefined, undefined));
+  assert.doesNotThrow(() => selectPortfolio(undefined, undefined));
+  assert.doesNotThrow(() => expireDrafts(undefined, undefined));
+  assert.doesNotThrow(() => reconcileOnRestart(null, null));
+  assert.doesNotThrow(() => lambdaFromSpendable(null));
+  assert.doesNotThrow(() => betaMeanGuards());
+  function betaMeanGuards() {
+    // imported indirectly through the module — presence checked via thompson path
+    thompsonMultiplier(null, null, () => 0.5);
+  }
+});


### PR DESCRIPTION
## Summary

Overnight scheduler CORE (server-only) — the pure-logic half of the overnight scheduler, split from the original BET-1402 scope (wiring/UI deferred to BET-1419). Two new files, nothing else touched:

- `src/server/ctoOvernight.mjs` — window state machine (opens on positive absence signal — presence `gone`, or ≥60 min zero user events inside the trough on no-desktop boxes; closes on trough end / user return; run-now override; restart reconciliation with spendable recompute; missed-veto-countdown abandonment; no-catch-up per §11.6), portfolio scorer (§11.4 formula verbatim: `p_use·Value·Confidence·Decay / (λ·PredictedCost)`, coarse lattices, λ from spendable ratio, 20% hygiene floor when maintenance candidates exist, Thompson blend via `ctoVerdicts` helpers with `queue-tonight`-verdict-fed counters, graceful-empty, zero candidates → no window, `pinnedOrder` exemption), and execution-contract helpers (gate evaluation with empty-set = pass + `no-gates`, git-only job rule, request-shaped routing by adapter capability, 7d draft expiry with `expire` verdict, preempt-on-return decision).
- `src/server/ctoOvernight.test.mjs` — 39 pure-logic tests (injected I/O only, no live tmux/opencode/network).

Reuses `thompsonDraw`/`betaMean` from `ctoVerdicts.mjs`, the atomic jsonStore pattern, and `statePath()` from `src/shared/paths.mjs` per the issue's ground rules.

## Verification results

- **Files changed:** 2. `src/server/ctoOvernight.mjs` (+763), `src/server/ctoOvernight.test.mjs` (+463)
- **Base:** `origin/main @ 75256335`
- PR branch (`multica/BET-1402-overnight-core` @ `862bfa58`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3405 pass / 0 fail / 0 skip. Failures: none. log sha256: `3dc2ba6c1aa5125e2f7ace8faed9842279195cf99e29a6d9fe21f1ae1c67ee38`
- Base (`main` @ `75256335`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3366 pass / 0 fail / 0 skip. Failures: none. log sha256: `b68519d1f38fc7d23494a5d21ae173100fcaf6ce8ede00e7549b95e2d1b8e45e`
- **Conclusion:** 0 pre-existing failures, 0 new failures; the +39 tests vs base are the new `ctoOvernight` suite.

## Out of scope (tracked in BET-1419)

Engine wiring, veto card variant, tonight UI, settings + data-gate flips, delegate `startJob` invocation, veto-window verb endpoints.
