### PR TITLE
BET-1418: fix flaky ctoView ETA test (freeze clock)

### DIFF
--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   dotTone,
   badgeLabel,
@@ -133,17 +133,25 @@ describe("backfillCardView (§10.6-4 learning card)", () => {
     expect(backfillCardView(base)).toBeNull();
   });
   it("shows an active running backfill with pct + ETA", () => {
-    const startedAt = Date.now() - 60_000;
-    const view = backfillCardView({
-      ...base,
-      backfill: { done: 2, total: 10, startedAt, stopped: false, reason: null, stoppedAtDepthDays: null, active: true },
-    });
-    expect(view?.show).toBe(true);
-    expect(view?.done).toBe(2);
-    expect(view?.total).toBe(10);
-    expect(view?.pct).toBeCloseTo(0.2, 5);
-    // 2 items over 60s → rate 30000ms/item, 8 left → 240000ms
-    expect(view?.etaMs).toBe(240000);
+    // BET-1418: backfillCardView reads Date.now() twice (guard + elapsed), the
+    // test reads it once for startedAt — a real ms tick between reads shifted
+    // the exact ETA assertion. Freeze the clock so every read sees one instant.
+    vi.useFakeTimers();
+    try {
+      const startedAt = Date.now() - 60_000;
+      const view = backfillCardView({
+        ...base,
+        backfill: { done: 2, total: 10, startedAt, stopped: false, reason: null, stoppedAtDepthDays: null, active: true },
+      });
+      expect(view?.show).toBe(true);
+      expect(view?.done).toBe(2);
+      expect(view?.total).toBe(10);
+      expect(view?.pct).toBeCloseTo(0.2, 5);
+      // 2 items over exactly 60s → rate 30000ms/item, 8 left → exactly 240000ms
+      expect(view?.etaMs).toBe(240000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
   it("still shows a budget-stopped backfill with the reason", () => {
     const view = backfillCardView({


### PR DESCRIPTION
## BET-1418 — Flaky test: ctoView ETA assertions race `Date.now`

**Files changed:** 1. `src/renderer/ctoView.test.ts` (test-only; no production code touched)

### Root cause

`backfillCardView` (`src/renderer/ctoView.ts:137-138`) reads `Date.now()` twice (eligibility guard + elapsed computation), while the test read it once to seed `startedAt = Date.now() - 60_000`. A real millisecond tick landing between the test's read and the code's reads made elapsed 60001+ ms, so `rate × (total − done)` came out 240004… and the exact `expect(view?.etaMs).toBe(240000)` failed intermittently — even in isolation.

### Fix

`vi.useFakeTimers()` inside the one racy test (established repo pattern, e.g. `messageFlash.test.ts`), so the test's seed and both of the component's reads see the same frozen instant; exact `240000` assertion retained. `vi.useRealTimers()` in a `finally` restores the clock. No production change — the component's double `Date.now()` read is fine in production (it only makes the ETA off by ~1ms).

**Base: origin/main @ 887d370c**

**Verification results:**
- PR branch (`multica/BET-1418-flaky-eta-test` @ `2c7665f0`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, vitest 3838 pass / 0 fail / 7 skip (198 files); node:test 3405 pass / 0 fail. **5× consecutive full-suite runs, all green** (+10× single-file runs of `ctoView.test.ts`). log sha256: `03d36e3d0a67003472f0165dc6e50c823408d782687db3015fd2b180430072fb`
- Base (`main` @ `887d370c`):
  - typecheck: exit `0`. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit `0`, vitest 3838 pass / 0 fail / 7 skip; node:test 3405 pass / 0 fail. log sha256: `617e87a7d7343a6c713e51b5b1a509dfd398692dad227639d85519805096ce09`
- **Conclusion:** 0 new failures, 0 pre-existing failures, 0 resolved (both branches fully green — this PR removes a *latent* intermittent failure mode, not a currently-red test).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` (+ `/tmp/test-pr-{2..5}.log` for the repeat runs) for reviewer spot-check.

Follow-ups: none surfaced — single-test fix, no adjacent racy `Date.now` assertions found (`grep` over `src/renderer/*.test.ts`: every other `Date.now()`-sensitive test already uses fake timers or an injected `now`).
