### PR TITLE
BET-1419: overnight wiring — veto card, tonight UI, engine execution, data gates

### DIFF
--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -39,6 +39,8 @@ import {
   statDisplay,
   nowCostLabel,
   decisionCards,
+  vetoCards,
+  tonightVisible,
   executeSuggestionOption,
   tonightBudgetMode,
   nightGauge,
@@ -50,6 +52,7 @@ import {
   type CtoState,
   type CtoHealthStat,
   type DecisionCardRow,
+  type VetoCardRow,
 } from "./ctoView";
 import {
   BlockerSection,
@@ -59,10 +62,12 @@ import {
   JustFinishedRail,
   DigestSection,
   SuggestionSection,
+  VetoSection,
+  TonightSection,
   type NowCard,
   type SuggestionOption,
 } from "./ctoSections";
-import type { CtoCard, CtoFinishedItem, CtoDigest, CtoHeldRow, CtoLedgerPage, CtoLedgerRow, CtoProfileRender, CtoSkill } from "../shared/api.js";
+import type { CtoCard, CtoFinishedItem, CtoDigest, CtoHeldRow, CtoLedgerPage, CtoLedgerRow, CtoProfileRender, CtoSkill, CtoTonightTask } from "../shared/api.js";
 import { Toggle } from "./Toggle";
 
 // The effort-dial options (§12.1, D12). Plain-language scope per tier. Medium
@@ -141,8 +146,16 @@ export function CtoPanel({
   // the §14.3 silence-audit "review held" modal (opened from the digest aside).
   const [heldOpen, setHeldOpen] = useState(false);
   const [heldRows, setHeldRows] = useState<CtoHeldRow[]>([]);
-  const blockerCards = useMemo(() => cards.filter((c) => c.variant !== "decision"), [cards]);
+  // BET-1419: veto cards (§9.2) render in their own Overnight section; the
+  // Tonight drill-down (§10.4) fetches its task list when expanded.
+  const [tonightExpanded, setTonightExpanded] = useState(false);
+  const [tonightTasks, setTonightTasks] = useState<CtoTonightTask[]>([]);
+  const [tonightLoading, setTonightLoading] = useState(false);
+  const [tonightPinned, setTonightPinned] = useState(false);
+  const [tonightWindowOpen, setTonightWindowOpen] = useState(false);
+  const blockerCards = useMemo(() => cards.filter((c) => c.variant !== "decision" && c.variant !== "veto"), [cards]);
   const suggestionCards = useMemo(() => decisionCards(cards), [cards]);
+  const vetoList = useMemo(() => vetoCards(cards as unknown as ReadonlyArray<Record<string, unknown>>), [cards]);
 
   const busy = digestBusy(state);
   const busyRef = useRef(busy);
@@ -281,6 +294,20 @@ export function CtoPanel({
         rendererDelegateStart(input),
       ctoFact: (input: { kind?: string; statement: string; refs?: string[] }) =>
         window.api?.ctoFact?.(input) ?? Promise.resolve({ ok: false, error: "facts unavailable" }),
+      ctoTonightAct: (input: {
+        action: "add" | "remove" | "reorder" | "cancel" | "run-now";
+        task?: {
+          name: string;
+          prompt?: string;
+          project?: string | null;
+          value?: number;
+          confidence?: number;
+          predictedCost?: number;
+          refs?: string[];
+          cls?: string;
+          originId?: string | null;
+        };
+      }) => window.api?.ctoTonightAct?.(input) ?? Promise.resolve({ ok: false, error: "tonight unavailable" }),
     }),
     [],
   );
@@ -313,6 +340,118 @@ export function CtoPanel({
     },
     [refreshCards],
   );
+
+  // BET-1419 tonight + veto actions (§9.2/§10.4). The veto card's Cancel
+  // tonight is a veto VERDICT on the veto-window subject — the server route
+  // performs the actual cancel (pause + close) before recording it. Run-now
+  // and the drill-down edits go through the tonight verb route.
+  const refreshTonight = useCallback(() => {
+    setTonightLoading(true);
+    void window.api
+      ?.ctoTonightGet?.()
+      .then((r) => {
+        setTonightTasks(r.tasks ?? []);
+        setTonightPinned(Array.isArray(r.window?.pinnedOrder) && r.window.pinnedOrder.length > 0);
+        setTonightWindowOpen(r.window?.state === "open");
+      })
+      .catch(() => {
+        setTonightTasks([]);
+        setTonightWindowOpen(false);
+      })
+      .finally(() => setTonightLoading(false));
+  }, []);
+
+  const handleVetoCancel = useCallback(
+    (card: VetoCardRow) => {
+      void window.api
+        ?.ctoVerdict?.({ subject: { type: "veto-window", id: card.id, class: "overnight" }, verdict: "veto" })
+        .then((r) => {
+          if (!r?.ok) pushToast({ id: `veto-${Date.now()}`, message: `Couldn't cancel tonight: ${r?.error ?? "unknown"}` });
+        })
+        .catch(() => {})
+        .finally(refreshCards);
+    },
+    [pushToast, refreshCards],
+  );
+
+  const handleVetoEditPlan = useCallback(() => {
+    setTonightExpanded(true);
+    refreshTonight();
+  }, [refreshTonight]);
+
+  const handleVetoRunNow = useCallback(
+    () => {
+      void window.api
+        ?.ctoTonightAct?.({ action: "run-now" })
+        .then((r) => {
+          if (!r?.ok) pushToast({ id: `runnow-${Date.now()}`, message: `Couldn't start overnight now: ${r?.error ?? "unknown"}` });
+          else pushToast({ id: `runnow-${Date.now()}`, message: "Overnight run starting" });
+        })
+        .catch(() => {})
+        .finally(refreshCards);
+    },
+    [pushToast, refreshCards],
+  );
+
+  const handleTonightToggle = useCallback(() => {
+    setTonightExpanded((prev) => {
+      if (!prev) refreshTonight();
+      return !prev;
+    });
+  }, [refreshTonight]);
+
+  const handleTonightCancel = useCallback(() => {
+    void window.api
+      ?.ctoTonightAct?.({ action: "cancel" })
+      .then((r) => {
+        if (!r?.ok) pushToast({ id: `tonight-${Date.now()}`, message: `Couldn't cancel tonight: ${r?.error ?? "unknown"}` });
+      })
+      .catch(() => {})
+      .finally(() => {
+        refreshCards();
+        refreshTonight();
+      });
+  }, [pushToast, refreshCards, refreshTonight]);
+
+  const handleTonightRemove = useCallback(
+    (id: string) => {
+      void window.api
+        ?.ctoTonightAct?.({ action: "remove", id })
+        .then((r) => {
+          if (!r?.ok) pushToast({ id: `tonight-${Date.now()}`, message: `Couldn't remove the task: ${r?.error ?? "unknown"}` });
+        })
+        .catch(() => {})
+        .finally(refreshTonight);
+    },
+    [pushToast, refreshTonight],
+  );
+
+  // Reorder via the up/down arrows — PINS the order for the current window
+  // (exempt from re-scoring; cleared when the window closes, §10.4).
+  const handleTonightMove = useCallback(
+    (id: string, dir: -1 | 1) => {
+      const ids = tonightTasks.map((t) => t.id);
+      const i = ids.indexOf(id);
+      const j = i + dir;
+      if (i < 0 || j < 0 || j >= ids.length) return;
+      [ids[i], ids[j]] = [ids[j], ids[i]];
+      void window.api
+        ?.ctoTonightAct?.({ action: "reorder", ids })
+        .then((r) => {
+          if (!r?.ok) pushToast({ id: `tonight-${Date.now()}`, message: `Couldn't reorder: ${r?.error ?? "unknown"}` });
+        })
+        .catch(() => {})
+        .finally(refreshTonight);
+    },
+    [tonightTasks, pushToast, refreshTonight],
+  );
+
+  // Keep the veto countdown live between state events.
+  const [, setTick] = useState(0);
+  useEffect(() => {
+    const h = setInterval(() => setTick((t) => t + 1), 30_000);
+    return () => clearInterval(h);
+  }, []);
 
   // §14.3 silence audit: open / refresh the held list (from the digest aside).
   const openHeld = useCallback(() => {
@@ -431,6 +570,7 @@ export function CtoPanel({
               Informational — never counts into the sidebar badge. */}
           <BackfillCard state={state} />
           <BlockerSection cards={blockerCards} now={Date.now()} onAnswer={handleAnswer} />
+          <VetoSection cards={vetoList} now={Date.now()} onCancel={handleVetoCancel} onEditPlan={handleVetoEditPlan} onRunNow={handleVetoRunNow} />
           <SuggestionSection cards={suggestionCards} onAction={handleSuggestionAction} onDismiss={handleSuggestionDismiss} />
           <NowRail cards={nowCards} />
           <JustFinishedRail items={finished} now={Date.now()} onOpen={handleOpenFinished} />
@@ -442,6 +582,21 @@ export function CtoPanel({
             onItemExpand={handleItemExpand}
             onOpenHeld={openHeld}
           />
+          {tonightVisible(state?.tonightCount, state?.tier ?? undefined) ? (
+            <TonightSection
+              count={state?.tonightCount ?? 0}
+              expanded={tonightExpanded}
+              onToggle={handleTonightToggle}
+              tasks={tonightTasks}
+              tasksLoading={tonightLoading}
+              pinned={tonightPinned}
+              windowOpen={tonightWindowOpen}
+              onCancelTonight={handleTonightCancel}
+              onRemove={handleTonightRemove}
+              onMove={handleTonightMove}
+              onOpenSettings={() => setView("settings")}
+            />
+          ) : null}
         </div>
 
         {/* Resting state (§10.6-1): only when every section is empty. */}
@@ -562,6 +717,7 @@ function SettingsView({
   // controls reflect the box; edits write through configUpdate (instant-apply).
   const [config, setConfig] = useState<CtoSettingsConfig | null>(null);
   const [capText, setCapText] = useState("");
+  const [nightCapText, setNightCapText] = useState("");
   const [health, setHealth] = useState<CtoHealthStat[]>([]);
   const [busyPause, setBusyPause] = useState(false);
   // BET-1405 (§10.5 card 3): budget payload (day buckets + quota cache) and
@@ -582,6 +738,7 @@ function SettingsView({
         ctoNightCapUsd: c?.ctoNightCapUsd,
       });
       setCapText(String(c?.ctoAmbientCap ?? DEFAULT_AMBIENT_CAP_USD));
+      setNightCapText(c?.ctoNightCapUsd != null ? String(c.ctoNightCapUsd) : "");
     });
     void window.api.ctoHealthGet().then((h) => {
       if (alive) setHealth(h.stats);
@@ -626,6 +783,22 @@ function SettingsView({
     }
     void applyConfig({ ctoAmbientCap: Math.round(n * 100) / 100 });
   }, [capText, applyConfig, pushToast]);
+
+  // BET-1419 (§11.2): the windowless providers' absolute night budget. Empty
+  // clears the bound (windowless providers then get no overnight budget seam).
+  const saveNightCap = useCallback(() => {
+    const text = nightCapText.trim();
+    if (text === "") {
+      void applyConfig({ ctoNightCapUsd: undefined });
+      return;
+    }
+    const n = Number(text);
+    if (!Number.isFinite(n) || n < 0) {
+      pushToast({ id: `nightcap-${Date.now()}`, message: "Night cap must be a non-negative dollar amount (or empty)." });
+      return;
+    }
+    void applyConfig({ ctoNightCapUsd: Math.round(n * 100) / 100 });
+  }, [nightCapText, applyConfig, pushToast]);
 
   const doPause = useCallback(async () => {
     setBusyPause(true);
@@ -766,6 +939,53 @@ function SettingsView({
                   ariaLabel="Push digest to phone"
                 />
               </div>
+
+              {/* BET-1419 Overnight switch (§11.1 consent) — High tier only. */}
+              {(config?.ctoTier ?? "low") === "high" ? (
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-text">Overnight work</div>
+                    <div className="text-sm text-text-muted">
+                      Let the CTO run queued work unattended in the quiet trough (you get a
+                      30-min veto card first).
+                    </div>
+                  </div>
+                  <Toggle
+                    checked={!!config?.ctoOvernightEnabled}
+                    onChange={(v) => void applyConfig({ ctoOvernightEnabled: v })}
+                    ariaLabel="Overnight work enabled"
+                  />
+                </div>
+              ) : null}
+
+              {/* BET-1419 night cap (§11.2): the windowless providers' bound. */}
+              {(config?.ctoTier ?? "low") === "high" ? (
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-medium text-text">Overnight cap (no usage window)</div>
+                    <div className="text-sm text-text-muted">
+                      Absolute dollar bound for providers without a usage window (empty = no
+                      overnight budget for them).
+                    </div>
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <span className="text-text-muted">$</span>
+                    <input
+                      type="number"
+                      min={0}
+                      step={0.25}
+                      value={nightCapText}
+                      onChange={(e) => setNightCapText(e.target.value)}
+                      onBlur={saveNightCap}
+                      onKeyDown={(e) => {
+                        if (e.key === "Enter") saveNightCap();
+                      }}
+                      className="w-20 rounded-md border border-border bg-bg px-2 py-1 text-sm text-text"
+                      aria-label="Overnight cap for windowless providers in dollars"
+                    />
+                  </div>
+                </div>
+              ) : null}
 
               {/* Pause / Resume (§10.6-5 kill switch) */}
               <div className="flex items-center justify-between gap-3 border-t border-border-subtle pt-4">

--- a/src/renderer/CtoPanel.tsx
+++ b/src/renderer/CtoPanel.tsx
@@ -951,8 +951,8 @@ function SettingsView({
                     </div>
                   </div>
                   <Toggle
-                    checked={!!config?.ctoOvernightEnabled}
-                    onChange={(v) => void applyConfig({ ctoOvernightEnabled: v })}
+                    checked={!!config?.ctoOvernight}
+                    onChange={(v) => void applyConfig({ ctoOvernight: v })}
                     ariaLabel="Overnight work enabled"
                   />
                 </div>

--- a/src/renderer/api/demoCoverage.test.ts
+++ b/src/renderer/api/demoCoverage.test.ts
@@ -63,6 +63,8 @@ export const DEMO_UNIMPLEMENTED = [
   "ctoQuotaRead",
   "ctoResume",
   "ctoStateGet",
+  "ctoTonightAct",
+  "ctoTonightGet",
   "ctoVerdict",
   "delegateApprove",
   "delegateDecline",

--- a/src/renderer/api/httpApi.ts
+++ b/src/renderer/api/httpApi.ts
@@ -34,6 +34,8 @@ import type {
   CtoCard,
   CtoHeldRow,
   CtoFinishedItem,
+  CtoTonightTask,
+  CtoTonightWindow,
   CtoDigest,
   CtoHealthStat,
   CtoLedgerRow,
@@ -1821,6 +1823,55 @@ export const httpApi: Api = {
       let json: { error?: string } = {};
       try { json = (await res.json()) as typeof json; } catch { /* non-JSON */ }
       return { ok: false, error: json.error ?? `HTTP ${res.status}` };
+    } catch (e) {
+      if (e instanceof AuthRequiredError) throw e;
+      return { ok: false, error: e instanceof Error ? e.message : String(e) };
+    }
+  },
+
+  // GET /api/cto/tonight — BET-1419 (§10.4/§11.4): tonight's queue + the
+  // window state machine's current row.
+  ctoTonightGet: async (): Promise<{ tasks: CtoTonightTask[]; window: CtoTonightWindow }> => {
+    const url = `${serverBase()}/api/cto/tonight`;
+    try {
+      const res = await fetch(url, { headers: authHeaders(clientToken()) });
+      if (res.status === 401) throw new AuthRequiredError();
+      if (!res.ok) return { tasks: [], window: null };
+      return (await res.json()) as { tasks: CtoTonightTask[]; window: CtoTonightWindow };
+    } catch (e) {
+      if (e instanceof AuthRequiredError) throw e;
+      return { tasks: [], window: null };
+    }
+  },
+
+  // POST /api/cto/tonight — the tonight verbs (add/remove/reorder/cancel/
+  // run-now). A 400 carries the server's refusal reason.
+  ctoTonightAct: async (input: {
+    action: "add" | "remove" | "reorder" | "cancel" | "run-now";
+    task?: {
+      name: string;
+      prompt?: string;
+      project?: string | null;
+      value?: number;
+      confidence?: number;
+      predictedCost?: number;
+      refs?: string[];
+      cls?: string;
+      originId?: string | null;
+    };
+    id?: string;
+    ids?: string[];
+  }): Promise<{ ok: boolean; error?: string; task?: CtoTonightTask; pinned?: string[] }> => {
+    const url = `${serverBase()}/api/cto/tonight`;
+    try {
+      const res = await fetch(url, {
+        method: "POST",
+        headers: { ...authHeaders(clientToken()), "Content-Type": "application/json" },
+        body: JSON.stringify(input),
+      });
+      if (res.status === 401) throw new AuthRequiredError();
+      const json = (await res.json().catch(() => ({}))) as { ok?: boolean; error?: string; task?: CtoTonightTask; pinned?: string[] };
+      return { ok: !!json.ok, error: json.error, task: json.task, pinned: json.pinned };
     } catch (e) {
       if (e instanceof AuthRequiredError) throw e;
       return { ok: false, error: e instanceof Error ? e.message : String(e) };

--- a/src/renderer/ctoSections.tsx
+++ b/src/renderer/ctoSections.tsx
@@ -12,6 +12,7 @@
 import { memo, useState } from "react";
 import {
   relativeTime,
+  countdownRemaining,
   digestExpandable,
   finishedVariant,
   nowRailMeta,
@@ -19,8 +20,9 @@ import {
   type BlockerCard,
   type DecisionCardRow,
   type FinishedVariant,
+  type VetoCardRow,
 } from "./ctoView";
-import type { CtoFinishedItem, CtoDigest } from "../shared/api.js";
+import type { CtoFinishedItem, CtoDigest, CtoTonightTask } from "../shared/api.js";
 
 // ---------------------------------------------------------------------------
 // Blocker section (§10.3)
@@ -585,5 +587,199 @@ const DigestRow = memo(function DigestRow({
         ) : null}
       </div>
     </div>
+  );
+});
+
+// ---------------------------------------------------------------------------
+// BET-1419 — Overnight surfaces (§10.3 veto card + §10.4 Tonight line)
+// ---------------------------------------------------------------------------
+
+// The veto-window card: tonight's run announced ~30 min ahead with a live
+// countdown. Three actions (§9.2): Cancel tonight (veto verdict), Edit plan
+// (opens the Tonight drill-down below), Run now instead (override).
+export const VetoSection = memo(function VetoSection({
+  cards,
+  now,
+  onCancel,
+  onEditPlan,
+  onRunNow,
+}: {
+  cards: VetoCardRow[];
+  now: number;
+  onCancel: (card: VetoCardRow) => void;
+  onEditPlan: (card: VetoCardRow) => void;
+  onRunNow: (card: VetoCardRow) => void;
+}) {
+  if (cards.length === 0) return null;
+  return (
+    <section className="space-y-2">
+      <h2 className="text-sm font-semibold uppercase tracking-wide text-text-muted">Overnight</h2>
+      <div className="space-y-2">
+        {cards.map((card) => {
+          const remaining = countdownRemaining(card.dueMs, now);
+          const min = remaining != null ? Math.max(1, Math.round(remaining / 60000)) : null;
+          return (
+            <div
+              key={card.id}
+              className="rounded-md border border-strong bg-fill px-3 py-3"
+              style={{
+                borderLeftWidth: "var(--need-edge-w)",
+                borderLeftColor: "color-mix(in srgb, var(--warn) 55%, transparent)",
+              }}
+            >
+              <div className="flex items-start justify-between gap-3">
+                <div className="min-w-0 flex-1">
+                  <div className="flex items-center gap-2 text-sm">
+                    <span className="font-medium text-text">{card.title}</span>
+                    {min != null ? (
+                      <span
+                        className="rounded-full bg-fill-active px-2 py-1 text-[11px] font-medium text-text-faint"
+                        title="Time until the overnight window opens"
+                      >
+                        opens in ~{min}m
+                      </span>
+                    ) : null}
+                  </div>
+                  {card.body ? <p className="mt-1 text-sm text-text-muted">{card.body}</p> : null}
+                </div>
+              </div>
+              <div className="mt-2 flex items-center gap-1">
+                <button
+                  type="button"
+                  onClick={() => onCancel(card)}
+                  className="rounded-md px-2 py-1 text-sm font-medium text-text hover:bg-fill-hover"
+                >
+                  Cancel tonight
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onEditPlan(card)}
+                  className="rounded-md px-2 py-1 text-sm text-text-muted hover:bg-fill-hover"
+                >
+                  Edit plan
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onRunNow(card)}
+                  className="rounded-md px-2 py-1 text-sm text-text-muted hover:bg-fill-hover"
+                >
+                  Run now instead
+                </button>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+});
+
+// The Tonight one-line + opt-in drill-down (§10.4). The parent fetches the
+// task list when expanded (ctoTonightGet). A manual reorder PINS the order
+// for the current window (exempt from re-scoring) and every edit is a
+// verdict; "budget & forecast in ⚙" points at the settings card.
+export const TonightSection = memo(function TonightSection({
+  count,
+  expanded,
+  onToggle,
+  tasks,
+  tasksLoading,
+  pinned,
+  windowOpen,
+  onCancelTonight,
+  onRemove,
+  onMove,
+  onOpenSettings,
+}: {
+  count: number;
+  expanded: boolean;
+  onToggle: () => void;
+  tasks: CtoTonightTask[];
+  tasksLoading: boolean;
+  pinned: boolean;
+  windowOpen: boolean;
+  onCancelTonight: () => void;
+  onRemove: (id: string) => void;
+  onMove: (id: string, dir: -1 | 1) => void;
+  onOpenSettings?: () => void;
+}) {
+  if (count <= 0) return null;
+  return (
+    <section className="space-y-2">
+      <button
+        type="button"
+        onClick={onToggle}
+        className="flex w-full items-center gap-2 rounded-md px-1 py-1 text-left text-sm text-text-muted hover:bg-fill-hover"
+        aria-expanded={expanded}
+      >
+        <span aria-hidden>🌙</span>
+        <span>
+          {count} task{count === 1 ? "" : "s"} queued for tonight {windowOpen ? "(running now)" : "(window)"}
+        </span>
+        {pinned ? (
+          <span className="rounded-full bg-fill-active px-2 py-1 text-[11px] font-medium text-text-faint" title="Manual order pinned for this window">
+            order pinned
+          </span>
+        ) : null}
+        <span className="ml-auto text-xs text-text-faint">{expanded ? "▲" : "▼"}</span>
+      </button>
+      {expanded ? (
+        <div className="space-y-2 rounded-md border border-strong bg-fill px-3 py-3">
+          {tasksLoading ? <p className="text-sm text-text-faint">Loading…</p> : null}
+          {!tasksLoading && tasks.length === 0 ? <p className="text-sm text-text-faint">Nothing queued.</p> : null}
+          {tasks.map((t, i) => (
+            <div key={t.id} className="flex items-center gap-2 text-sm">
+              <span className="text-xs text-text-faint">{i + 1}.</span>
+              <span className="min-w-0 flex-1 truncate text-text" title={t.prompt}>
+                {t.name}
+              </span>
+              <span className="rounded-full bg-fill-active px-2 py-1 text-[11px] font-medium text-text-faint">{t.cls}</span>
+              <button
+                type="button"
+                onClick={() => onMove(t.id, -1)}
+                disabled={i === 0}
+                className="rounded px-1 text-xs text-text-faint hover:bg-fill-hover disabled:opacity-30"
+                aria-label={`Move ${t.name} earlier`}
+              >
+                ↑
+              </button>
+              <button
+                type="button"
+                onClick={() => onMove(t.id, 1)}
+                disabled={i === tasks.length - 1}
+                className="rounded px-1 text-xs text-text-faint hover:bg-fill-hover disabled:opacity-30"
+                aria-label={`Move ${t.name} later`}
+              >
+                ↓
+              </button>
+              <button
+                type="button"
+                onClick={() => onRemove(t.id)}
+                className="rounded-md px-2 py-1 text-xs text-text-muted hover:bg-fill-hover"
+              >
+                Remove
+              </button>
+            </div>
+          ))}
+          <div className="flex items-center justify-between pt-1">
+            <button
+              type="button"
+              onClick={onCancelTonight}
+              className="rounded-md px-2 py-1 text-sm font-medium text-text hover:bg-fill-hover"
+            >
+              Cancel tonight
+            </button>
+            <button
+              type="button"
+              onClick={onOpenSettings}
+              className="text-xs text-text-faint hover:text-text"
+              title="Overnight budget & forecast live in Settings → Adaptive CTO → Behavior"
+            >
+              budget &amp; forecast in ⚙
+            </button>
+          </div>
+        </div>
+      ) : null}
+    </section>
   );
 });

--- a/src/renderer/ctoSections.tsx
+++ b/src/renderer/ctoSections.tsx
@@ -738,7 +738,7 @@ export const TonightSection = memo(function TonightSection({
                 type="button"
                 onClick={() => onMove(t.id, -1)}
                 disabled={i === 0}
-                className="rounded px-1 text-xs text-text-faint hover:bg-fill-hover disabled:opacity-30"
+                className="rounded-xs px-1 text-xs text-text-faint hover:bg-fill-hover disabled:opacity-30"
                 aria-label={`Move ${t.name} earlier`}
               >
                 ↑
@@ -747,7 +747,7 @@ export const TonightSection = memo(function TonightSection({
                 type="button"
                 onClick={() => onMove(t.id, 1)}
                 disabled={i === tasks.length - 1}
-                className="rounded px-1 text-xs text-text-faint hover:bg-fill-hover disabled:opacity-30"
+                className="rounded-xs px-1 text-xs text-text-faint hover:bg-fill-hover disabled:opacity-30"
                 aria-label={`Move ${t.name} later`}
               >
                 ↓

--- a/src/renderer/ctoView.test.ts
+++ b/src/renderer/ctoView.test.ts
@@ -358,6 +358,9 @@ import {
   executeSuggestionOption,
   runnableSuggestionOption,
   suggestionConfidence,
+  vetoCards,
+  countdownRemaining,
+  tonightVisible,
 } from "./ctoView";
 
 it("decisionCards: selects decision-variant cards only", () => {
@@ -371,11 +374,11 @@ it("decisionCards: selects decision-variant cards only", () => {
   expect(out[0].id).toBe("d1");
 });
 
-it("runnableSuggestionOption: P2 runs config-change/start-job/record-decision; not queue-tonight/tool-write", () => {
+it("runnableSuggestionOption: BET-1419 runs config-change/start-job/record-decision/queue-tonight; not tool-write", () => {
   expect(runnableSuggestionOption({ action: { type: "config-change" } })).toBe(true);
   expect(runnableSuggestionOption({ action: { type: "start-job" } })).toBe(true);
   expect(runnableSuggestionOption({ action: { type: "record-decision" } })).toBe(true);
-  expect(runnableSuggestionOption({ action: { type: "queue-tonight" } })).toBe(false);
+  expect(runnableSuggestionOption({ action: { type: "queue-tonight" } })).toBe(true);
   expect(runnableSuggestionOption({ action: { type: "tool-write" } })).toBe(false);
   expect(runnableSuggestionOption(null)).toBe(false);
   expect(runnableSuggestionOption({ action: { type: "bogus" } })).toBe(false);
@@ -433,6 +436,78 @@ it("executeSuggestionOption: non-runnable type fails closed", async () => {
   const r = await executeSuggestionOption({ option: { action: { type: "tool-write", payload: {} } }, api });
   expect(r.ok).toBe(false);
   expect(r.error ?? "").toMatch(/unsupported/);
+});
+
+it("executeSuggestionOption: queue-tonight queues the task with the card's context (BET-1419)", async () => {
+  let got: unknown = null;
+  const api = { ctoTonightAct: async (input: unknown) => { got = input; return { ok: true }; } };
+  const r = await executeSuggestionOption({
+    option: {
+      label: "Queue: reconcile ledger",
+      action: { type: "queue-tonight", payload: { name: "Reconcile ledger", prompt: "do it", refs: ["BET-9"] } },
+    },
+    api: api as never,
+  });
+  expect(r.ok).toBe(true);
+  expect(got).toEqual({
+    action: "add",
+    task: {
+      name: "Reconcile ledger",
+      prompt: "do it",
+      project: null,
+      value: undefined,
+      confidence: undefined,
+      predictedCost: undefined,
+      refs: ["BET-9"],
+      cls: "queue-tonight",
+    },
+  });
+});
+
+it("executeSuggestionOption: queue-tonight falls back to the label and fails closed without a name", async () => {
+  let got: unknown = null;
+  const api = { ctoTonightAct: async (input: unknown) => { got = input; return { ok: true }; } };
+  const r = await executeSuggestionOption({
+    option: { label: "Queue the sweep", action: { type: "queue-tonight", payload: {} } },
+    api: api as never,
+  });
+  expect(r.ok).toBe(true);
+  expect((got as { task: { name: string } }).task.name).toBe("Queue the sweep");
+
+  const r2 = await executeSuggestionOption({
+    option: { label: "", action: { type: "queue-tonight", payload: {} } },
+    api: api as never,
+  });
+  expect(r2.ok).toBe(false);
+  expect(r2.error ?? "").toMatch(/name/);
+});
+
+it("vetoCards: selects veto-variant cards with the countdown fields", () => {
+  const cards = [
+    { id: "b1", variant: "blocker", title: "blk" },
+    { id: "overnight:veto", variant: "veto", title: "Overnight run planned", body: "3 tasks", dueMs: 5000, options: [{ label: "Cancel tonight", action: { type: "veto-cancel", payload: {} } }] },
+  ];
+  const out = vetoCards(cards as unknown as ReadonlyArray<Record<string, unknown>>);
+  expect(out.length).toBe(1);
+  expect(out[0].id).toBe("overnight:veto");
+  expect(out[0].dueMs).toBe(5000);
+  expect(out[0].options[0].action.type).toBe("veto-cancel");
+});
+
+it("countdownRemaining: ms left, null once due or without a dueMs", () => {
+  expect(countdownRemaining(10_000, 4_000)).toBe(6_000);
+  expect(countdownRemaining(4_000, 4_000)).toBeNull();
+  expect(countdownRemaining(3_000, 4_000)).toBeNull();
+  expect(countdownRemaining(null, 4_000)).toBeNull();
+  expect(countdownRemaining(Number.NaN, 4_000)).toBeNull();
+});
+
+it("tonightVisible: hidden when zero or tier below high", () => {
+  expect(tonightVisible(0, "high")).toBe(false);
+  expect(tonightVisible(3, "high")).toBe(true);
+  expect(tonightVisible(3, "medium")).toBe(false);
+  expect(tonightVisible(3, undefined)).toBe(false);
+  expect(tonightVisible(undefined, "high")).toBe(false);
 });
 
 it("executeSuggestionOption: failure is reported (not swallowed)", async () => {

--- a/src/renderer/ctoView.ts
+++ b/src/renderer/ctoView.ts
@@ -24,6 +24,9 @@ export type CtoState = {
   needsYouCount: number;
   generationInFlight: boolean;
   tonightCount: number;
+  // The A12 tier dial (§12.1) — BET-1419: tier-gated surfaces (the Tonight
+  // line shows only at High) read it straight off the state event.
+  tier?: string | null;
   backfill?: BackfillState;
 };
 
@@ -477,12 +480,52 @@ export function decisionCards(cards: ReadonlyArray<Record<string, unknown>>): De
   return (cards ?? []).filter((c) => c?.variant === "decision") as DecisionCardRow[];
 }
 
+// BET-1419: the open veto card (§10.3) among the wire cards — the overnight
+// run's 30-min countdown. Structural subset of the wire CtoCard.
+export type VetoCardRow = {
+  id: string;
+  title: string;
+  body: string;
+  dueMs: number | null;
+  options: { label: string; action: { type: string; payload: Record<string, unknown> } }[];
+};
+
+export function vetoCards(cards: ReadonlyArray<Record<string, unknown>>): VetoCardRow[] {
+  return (cards ?? []).filter((c) => c?.variant === "veto").map((c) => ({
+    id: String(c.id ?? ""),
+    title: String(c.title ?? ""),
+    body: String(c.body ?? ""),
+    dueMs: Number.isFinite(c.dueMs) ? (c.dueMs as number) : null,
+    options: Array.isArray(c.options) ? (c.options as VetoCardRow["options"]) : [],
+  }));
+}
+
+// Live countdown to a veto card's `dueMs`: the ms remaining (≥ 0), or null
+// when there is no due time or it already elapsed (the card resolves server-
+// side; the client just hides the countdown rather than reading negative).
+export function countdownRemaining(dueMs: unknown, now: number): number | null {
+  if (!Number.isFinite(dueMs) || !Number.isFinite(now)) return null;
+  const d = (dueMs as number) - now;
+  return d > 0 ? d : null;
+}
+
+// §10.4 Tonight line visibility: hidden entirely when nothing is queued or
+// High tier is off. Pure so the component + tests share one rule.
+export function tonightVisible(tonightCount: number | undefined, tier: string | undefined): boolean {
+  if (!Number.isFinite(tonightCount) || (tonightCount as number) <= 0) return false;
+  return tier === "high";
+}
+
 // §9.1 P2 option viability: which action types have a runnable executor in P2.
+// BET-1419: `queue-tonight` is now runnable (the tonight queue + §11 overnight
+// execution are wired). `tool-write` stays non-runnable until the §7.4 tool
+// registry lands — with the empty write ring the server never emits one, so
+// no dead control is ever rendered.
 const RUNNABLE_TYPES: Record<string, boolean> = {
   "config-change": true,
   "start-job": true,
   "record-decision": true,
-  "queue-tonight": false,
+  "queue-tonight": true,
   "tool-write": false,
 };
 
@@ -498,6 +541,20 @@ export type SuggestionApi = {
   configUpdate(patch: Record<string, unknown>): Promise<unknown>;
   delegateStart(input: { prompt: string; sessionID: string; directory: string; model?: unknown }): Promise<{ ok?: boolean; error?: string }>;
   ctoFact(input: { kind?: string; statement: string; refs?: string[] }): Promise<{ ok?: boolean; error?: string }>;
+  ctoTonightAct(input: {
+    action: "add" | "remove" | "reorder" | "cancel" | "run-now";
+    task?: {
+      name: string;
+      prompt?: string;
+      project?: string | null;
+      value?: number;
+      confidence?: number;
+      predictedCost?: number;
+      refs?: string[];
+      cls?: string;
+      originId?: string | null;
+    };
+  }): Promise<{ ok?: boolean; error?: string }>;
 };
 
 // Execute one bound action. Confirmation (the config-change diff modal) is a
@@ -537,6 +594,27 @@ export async function executeSuggestionOption({
         const refs = Array.isArray(payload.refs) ? (payload.refs as string[]) : [];
         const r = await api.ctoFact({ kind: "decision", statement, refs });
         return r?.ok ? { ok: true } : { ok: false, error: r?.error ?? "record-decision failed" };
+      }
+      case "queue-tonight": {
+        // BET-1419: queue the task for tonight (§10.4). The card's context
+        // (cls/score) is captured at accept time so the overnight portfolio
+        // scores it without re-asking the generator.
+        const name = typeof payload.name === "string" && payload.name ? payload.name : option?.label ?? "";
+        if (!name) return { ok: false, error: "queue-tonight needs a name payload" };
+        const r = await api.ctoTonightAct({
+          action: "add",
+          task: {
+            name,
+            prompt: typeof payload.prompt === "string" && payload.prompt ? payload.prompt : name,
+            project: typeof payload.project === "string" ? payload.project : null,
+            value: typeof payload.value === "number" ? payload.value : undefined,
+            confidence: typeof payload.confidence === "number" ? payload.confidence : undefined,
+            predictedCost: typeof payload.cost === "number" ? payload.cost : undefined,
+            refs: Array.isArray(payload.refs) ? (payload.refs as string[]) : [],
+            cls: typeof payload.cls === "string" ? payload.cls : "queue-tonight",
+          },
+        });
+        return r?.ok ? { ok: true } : { ok: false, error: r?.error ?? "queue-tonight failed" };
       }
       default:
         return { ok: false, error: `unsupported action type: ${String(type ?? "")}` };

--- a/src/server/ctoBudget.mjs
+++ b/src/server/ctoBudget.mjs
@@ -179,6 +179,28 @@ export function priceTokens({ model, tokens, mix } = {}) {
   return dollar((num(tokens) / 1_000_000) * perMillion);
 }
 
+/**
+ * Tonight's estimated overnight spend, priced from the cto ledger (§11.2): the
+ * sum of `priceTokens` over TODAY's `cto.overnight.job_started` rows' estTokens
+ * (the prompt-size estimate the engine records at dispatch — §12.1 metering
+ * style). Rows from other days, other kinds, or without a usable estTokens are
+ * ignored; an unpriceable `modelCost` (null / no cost rates) prices at 0, so
+ * the night cap cannot trip from an unknown model — pass a priceable cost.
+ */
+export function overnightSpendUsd(rows, { now, modelCost = null } = {}) {
+  const t = typeof now === "number" && Number.isFinite(now) ? now : Date.now();
+  const key = dayKey(t);
+  let total = 0;
+  for (const r of Array.isArray(rows) ? rows : []) {
+    if (r?.kind !== "cto.overnight.job_started") continue;
+    if (typeof r?.ts !== "number" || !Number.isFinite(r.ts) || dayKey(r.ts) !== key) continue;
+    const toks = Number(r?.estTokens);
+    if (!Number.isFinite(toks) || toks <= 0) continue;
+    total += priceTokens({ model: { cost: modelCost }, tokens: toks });
+  }
+  return dollar(total);
+}
+
 // ---------------------------------------------------------------------------
 // Expected hourly burn — A2 watchdog figure (§13.3 / BET-1385 placeholder).
 // ---------------------------------------------------------------------------
@@ -652,9 +674,16 @@ export function createCtoBudget({
    * disables the reserve — it returns the same key set as the windowed plan
    * (`spendableFrac: null`, `reserve: 0`, `mode: 'windowless'`, plus
    * `nightCapUsd`) and bounds overnight spend by the absolute
-   * `ctoNightCapUsd` budget instead. The forecaster still runs (§11.2): the
-   * pct series is built, `mape14` computed (null without usable history) and
-   * persisted in the quota row for the Health card.
+   * `ctoNightCapUsd` budget instead: pass the day's ledger rows via
+   * `overnightRows` and the overnight model's catalogue `cost` via
+   * `overnightModelCost`, and once tonight's estimated overnight spend
+   * (`overnightSpendUsd`) reaches the cap the plan's `spendableFrac` flips to
+   * 0 (the machine's budgetFrac 0 selects nothing further) with
+   * `overnightCapHit: true` — the caller ledgers the cap-hit. An unpriceable
+   * model (no `cost`) estimates $0, so the cap cannot trip — the caller
+   * should pass a priceable cost object. The forecaster still runs (§11.2):
+   * the pct series is built, `mape14` computed (null without usable history)
+   * and persisted in the quota row for the Health card.
    */
   async function computeSpendable({
     provider,
@@ -663,6 +692,8 @@ export function createCtoBudget({
     windowed = true,
     capHitsSince = 0,
     earnedCleanDays = 0,
+    overnightRows,
+    overnightModelCost = null,
   } = {}) {
     const t = typeof now === "function" ? now() : typeof now === "number" ? now : Date.now();
     if (!windowed) {
@@ -702,6 +733,11 @@ export function createCtoBudget({
       await ledgerAppend({ kind: "cto.reserve", ts: t, provider, reserve: 0, spendable: null, fractile: quota.fractile, mode: "windowless" });
       // Same key set as the windowed plan below — C3's re-evaluation seam
       // consumes both modes uniformly (null where the concept doesn't apply).
+      // §11.2 absolute $ bound: tonight's estimated overnight spend priced
+      // from the ledger's job_started rows; cap exhausted → spendableFrac 0.
+      const cap = nightCapUsd(conf);
+      const spent = overnightSpendUsd(overnightRows, { now: t, modelCost: overnightModelCost });
+      const capHit = cap > 0 && spent >= cap;
       return {
         provider,
         windowed: false,
@@ -712,11 +748,13 @@ export function createCtoBudget({
         maxObserved,
         historyDays,
         remainingFrac: null,
-        spendableFrac: null,
+        spendableFrac: capHit ? 0 : null,
         point: null,
         sigma: null,
         mape14,
-        nightCapUsd: nightCapUsd(conf),
+        overnightSpentUsd: spent,
+        overnightCapHit: capHit,
+        nightCapUsd: cap,
       };
     }
     const hist = (await history().catch(() => ({}))) ?? {};

--- a/src/server/ctoBudget.test.mjs
+++ b/src/server/ctoBudget.test.mjs
@@ -19,6 +19,7 @@ import {
   isWorkShedInThrifty,
   nightCapUsd,
   notchFractile,
+  overnightSpendUsd,
   planReserve,
   priceTokens,
   recordSpend,
@@ -670,4 +671,55 @@ test("pending rows past the retention horizon are dropped", async () => {
   await store.save(payload);
   await budget.refreshRoi();
   assert.equal(payload.roi.pending.length, 0); // counted stale row swept
+});
+
+test("overnightSpendUsd prices today's job_started estTokens at the model cost (§11.2)", () => {
+  const cost = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 }; // 1.4925 $/Mtok blended
+  const rows = [
+    { kind: "cto.overnight.job_started", ts: NOON, estTokens: 1_000_000 },
+    { kind: "cto.overnight.job_started", ts: NOON + 60_000, estTokens: 500_000 },
+    { kind: "cto.overnight.job_started", ts: dayStart(-1), estTokens: 10_000_000 }, // yesterday — ignored
+    { kind: "cto.overnight.close", ts: NOON, estTokens: 99 }, // other kind — ignored
+    { kind: "cto.overnight.job_started", ts: NOON }, // no estTokens — ignored
+    { kind: "cto.overnight.job_started", ts: NOON, estTokens: -5 }, // junk — ignored
+  ];
+  // 1.5M priceable tokens → 1.5 × 1.4925 = 2.23875
+  assert.ok(Math.abs(overnightSpendUsd(rows, { now: NOON, modelCost: cost }) - 2.23875) < 1e-9);
+  // Unpriceable model → $0 (the cap cannot trip on an unknown model).
+  assert.equal(overnightSpendUsd(rows, { now: NOON, modelCost: null }), 0);
+  // Junk rows shape → 0, never throws.
+  assert.equal(overnightSpendUsd(null, { now: NOON, modelCost: cost }), 0);
+});
+
+test("computeSpendable windowless: the $ night cap flips spendableFrac to 0 when tonight's spend reaches it (§11.2)", async () => {
+  let saved = null;
+  const ledgerRows = [];
+  const cost = { input: 3, output: 15, cacheRead: 0.3, cacheWrite: 3.75 };
+  // 2M priceable tokens × 1.4925 $/Mtok = 2.985 spent; cap 3 not yet reached.
+  const underCap = [
+    { kind: "cto.overnight.job_started", ts: NOON, estTokens: 2_000_000 },
+  ];
+  const overCap = [...underCap, { kind: "cto.overnight.job_started", ts: NOON + 1, estTokens: 100_000 }];
+  const budget = createCtoBudget({
+    store: { load: async () => ({}), save: async (p) => (saved = p) },
+    now: () => NOON,
+    cfg: () => ({ ctoNightCapUsd: 3 }),
+    ledger: { append: (r) => ledgerRows.push(r) },
+  });
+
+  const under = await budget.computeSpendable({
+    provider: "someone", windowed: false, overnightRows: underCap, overnightModelCost: cost,
+  });
+  assert.equal(under.spendableFrac, null, "under the cap → no fractional reserve (λ=0)");
+  assert.equal(under.overnightCapHit, false);
+  assert.ok(Math.abs(under.overnightSpentUsd - 2.985) < 1e-9);
+
+  const over = await budget.computeSpendable({
+    provider: "someone", windowed: false, overnightRows: overCap, overnightModelCost: cost,
+  });
+  assert.equal(over.spendableFrac, 0, "cap exhausted → the machine selects nothing further");
+  assert.equal(over.overnightCapHit, true);
+  assert.equal(over.nightCapUsd, 3);
+  // The caller ledgers the cap-hit; the budget itself only reports it.
+  assert.ok(!ledgerRows.some((r) => r.kind === "cto.overnight.night_cap_hit"));
 });

--- a/src/server/ctoCards.mjs
+++ b/src/server/ctoCards.mjs
@@ -468,6 +468,51 @@ export function createCtoCards(deps = {}) {
     }
   }
 
+  // BET-1419 (§9.2/§10.3): the veto-window card — announce tonight's run 30
+  // min ahead with a live countdown. One open veto card at a time (the
+  // overnight countdown is unique per window): re-arming upserts by id so the
+  // countdown updates in place, never dups. `dueMs` is the open the countdown
+  // points at; the engine resolves the card when the window opens (fulfilled),
+  // cancels it (veto verdict) or abandons it (missed, §11.6).
+  async function upsertVeto({ id, title, body, dueMs, options = [], refs = [], ts = now() } = {}) {
+    if (!id || typeof id !== "string") return { changed: false, isNew: false };
+    const { payload, cards } = await openCards();
+    const existing = cards.find((c) => c?.id === id && c?.state === "open");
+    const created = existing?.created ?? ts;
+    const card = {
+      id,
+      variant: "veto",
+      title: typeof title === "string" && title ? title : "Overnight run planned",
+      body: typeof body === "string" && body ? body : "",
+      dueMs: Number.isFinite(dueMs) ? dueMs : null,
+      options: Array.isArray(options) ? options : [],
+      sourceKind: "overnight",
+      sourceId: null,
+      sessionID: null,
+      pendingSince: existing?.pendingSince ?? ts,
+      refs: Array.isArray(refs) ? refs : [],
+      created,
+      updatedAt: ts,
+      state: "open",
+    };
+    if (existing) {
+      const idx = cards.indexOf(existing);
+      cards[idx] = { ...existing, ...card, created, updatedAt: ts };
+    } else {
+      cards.push(card);
+    }
+    await cardStore.save({ ...payload, cards });
+    await ledgerAppend({
+      kind: CARD_CREATED,
+      cardId: id,
+      variant: "veto",
+      sourceKind: "overnight",
+      refs: card.refs,
+      dueMs: card.dueMs,
+    });
+    return { changed: true, isNew: !existing };
+  }
+
   async function listOpen() {
     const { cards } = await openCards();
     return cards.filter((c) => c && c.state === "open");
@@ -483,6 +528,7 @@ export function createCtoCards(deps = {}) {
     resolveById,
     dismissById,
     upsertDecision,
+    upsertVeto,
     countOpen,
     listOpen,
   };

--- a/src/server/ctoCards.test.mjs
+++ b/src/server/ctoCards.test.mjs
@@ -340,3 +340,46 @@ test("upsertDecision: writes a decision card, and regenerating the same id upser
   assert.equal(open[0].created, 1_000_000); // created preserved across regeneration
   assert.equal(open[0].variant, "decision");
 });
+
+// ---------------------------------------------------------------------------
+// BET-1419 — the veto-window card (§9.2/§10.3)
+// ---------------------------------------------------------------------------
+
+test("upsertVeto: writes a variant=veto card with the countdown dueMs", async () => {
+  const h = makeHarness();
+  const r = await h.cards.upsertVeto({
+    id: "overnight:veto",
+    title: "Overnight run planned",
+    body: "3 tasks queued for tonight's window.",
+    dueMs: 2_000_000,
+    options: [{ label: "Cancel tonight", action: { type: "veto-cancel", payload: {} } }],
+  });
+  assert.equal(r.changed, true);
+  assert.equal(r.isNew, true);
+  const rows = h.store().cards.filter((c) => c.state === "open");
+  assert.equal(rows.length, 1);
+  assert.equal(rows[0].variant, "veto");
+  assert.equal(rows[0].dueMs, 2_000_000);
+  assert.equal(rows[0].sourceKind, "overnight");
+  assert.ok(h.ledgerRows.some((row) => row.kind === CARD_CREATED && row.variant === "veto"));
+});
+
+test("upsertVeto: re-arming updates in place (never dups), created preserved", async () => {
+  const h = makeHarness();
+  await h.cards.upsertVeto({ id: "overnight:veto", title: "t1", dueMs: 2_000_000 });
+  h.advance(5_000);
+  const r2 = await h.cards.upsertVeto({ id: "overnight:veto", title: "t2", dueMs: 3_000_000 });
+  assert.equal(r2.isNew, false);
+  const open = h.store().cards.filter((c) => c.state === "open");
+  assert.equal(open.length, 1, "one open veto card at a time");
+  assert.equal(open[0].title, "t2");
+  assert.equal(open[0].dueMs, 3_000_000);
+  assert.equal(open[0].created, 1_000_000, "created preserved across re-arm");
+});
+
+test("upsertVeto: refuses a missing id", async () => {
+  const h = makeHarness();
+  const r = await h.cards.upsertVeto({ title: "no id" });
+  assert.equal(r.changed, false);
+  assert.equal(openCardCount(h), 0);
+});

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -90,7 +90,7 @@ import {
   windowFor as rollupWindowFor,
 } from "./ctoRollups.mjs";
 import { buildFactProposal, createFactsEngine, VERIFY_CYCLE_MS, senderKey, senderReliability } from "./ctoFacts.mjs";
-import { formatFactsBlock } from "./ctoSessions.mjs";
+import { formatFactsBlock, estimateTokens } from "./ctoSessions.mjs";
 import {
   ambientCapUsd as budgetAmbientCapUsd,
   createCtoBudget,
@@ -1110,7 +1110,7 @@ export function createCtoEngine(deps = {}) {
   // sub-cap of 2 enforced by beginDelegateJob), preempt everything on the
   // user's return (§11.6), and arm/fulfill/cancel the veto countdown card
   // (§10.3). Nothing runs unless the engine is enabled, the Overnight switch
-  // is on (config `ctoOvernightEnabled`), the tier is High, and the scheduler
+  // is on (config `ctoOvernight`), the tier is High, and the scheduler
   // was injected.
   // ---------------------------------------------------------------------------
 
@@ -1123,7 +1123,7 @@ export function createCtoEngine(deps = {}) {
     if (disposed || !overnight) return false;
     try {
       const cfg = (await configGet()) ?? {};
-      if (cfg.ctoOvernightEnabled !== true) return false;
+      if (cfg.ctoOvernight !== true) return false;
       return (await tierGet()) === "high";
     } catch {
       return false;
@@ -1223,13 +1223,18 @@ export function createCtoEngine(deps = {}) {
   }
 
   // Dispatch the selected plan (§11.5 execution contract). The §3.3 concurrent
-  // delegate sub-cap (RATE_LIMITS.concurrentDelegate = 2) is enforced by
-  // beginDelegateJob — the overnight scheduler never bypasses it. Each start
-  // removes its queue entry (a queued task that started is no longer queued);
-  // failures ledger and leave the entry queued for the next tick/night.
-  // Candidates whose job already started in this window are skipped (the
-  // ledger's job_started rows are the dedupe record — a watcher hit stays in
-  // the ledger and would otherwise re-run every tick of the same window).
+  // delegate sub-cap (RATE_LIMITS.concurrentDelegate = 2) is enforced HERE, by
+  // counting still-running cto-actor jobs (the same rows preemption reads) +
+  // starts accepted in this dispatch against the cap — `beginDelegateJob`'s
+  // transient tracker is not consulted on this path and the delegate engine
+  // only enforces the box-wide cap of 5. Each start removes its queue entry (a
+  // queued task that started is no longer queued); failures ledger and leave
+  // the entry queued for the next tick/night. Candidates whose job already
+  // started in this window are skipped (the ledger's job_started rows are the
+  // dedupe record — a watcher hit stays in the ledger and would otherwise
+  // re-run every tick of the same window). Each job_started row carries
+  // `estTokens` (the prompt-size estimate, §12.1 metering style) so the
+  // windowless night-cap bound can price tonight's spend from the ledger.
   async function dispatchPlan({ plan, trough, projects, ledgerRows, windowOpenedMs }) {
     let started = 0;
     const startedIds = new Set(
@@ -1238,11 +1243,21 @@ export function createCtoEngine(deps = {}) {
         .filter((r) => (windowOpenedMs == null ? true : r.ts >= windowOpenedMs))
         .map((r) => r.id),
     );
+    const runningCto = (await runningCtoJobs()).length;
+    let startedThisDispatch = 0;
     for (const cand of plan?.selected ?? []) {
-      const release = track.beginDelegate();
       try {
         if (!cand || typeof cand.id !== "string" || startedIds.has(cand.id)) continue;
         if (typeof startDelegateJob !== "function") break;
+        if (runningCto + startedThisDispatch >= rateLimits.concurrentDelegate) {
+          await ledgerLog({
+            kind: "cto.overnight.skip",
+            id: cand.id,
+            reason: "rate_limit:concurrentDelegate",
+            running: runningCto + startedThisDispatch,
+          });
+          continue;
+        }
         const task = (await tonightQueueRows()).find((r) => r?.id === cand.id) ?? null;
         const project = cand.project ?? task?.project;
         const parent =
@@ -1256,12 +1271,13 @@ export function createCtoEngine(deps = {}) {
           });
           continue;
         }
+        const prompt =
+          cand.prompt ??
+          task?.prompt ??
+          `${cand.name ?? "overnight"} — investigate and report a draft summary with refs.`;
         const res = await startDelegateJob({
           name: cand.name ?? task?.name ?? `overnight:${cand.category}`,
-          prompt:
-            cand.prompt ??
-            task?.prompt ??
-            `${cand.name ?? "overnight"} — investigate and report a draft summary with refs.`,
+          prompt,
           parentSessionID: parent.parentSessionID,
           parentDirectory: project,
           sweepAllowanceMs: trough ? Math.max(0, trough.endMs - now()) : undefined,
@@ -1271,12 +1287,14 @@ export function createCtoEngine(deps = {}) {
           continue;
         }
         started += 1;
+        startedThisDispatch += 1;
         await ledgerLog({
           kind: "cto.overnight.job_started",
           id: cand.id,
           jobId: res?.job?.id ?? null,
           project,
           category: cand.category,
+          estTokens: estimateTokens(prompt),
         });
         if (task) {
           const rows = await tonightQueueRows();
@@ -1284,8 +1302,6 @@ export function createCtoEngine(deps = {}) {
         }
       } catch {
         /* keep dispatching the remaining selected jobs */
-      } finally {
-        release();
       }
     }
     return started;
@@ -1301,7 +1317,10 @@ export function createCtoEngine(deps = {}) {
     if (!win) return;
     const due = trough ? trough.startMs : null;
     const imminent = due != null && t >= due - VETO_LEAD_MS && t < due;
-    if (imminent && win.state !== "open" && !win.countdown && win.closeReason !== "veto" && candidateCount > 0) {
+    // §9.2: never re-announce a trough the user vetoed — the stamp from
+    // tonightCancel suppresses both the countdown re-arm and the card.
+    const vetoed = win.vetoedTroughStartMs != null && win.vetoedTroughStartMs === due;
+    if (imminent && win.state !== "open" && !win.countdown && !vetoed && candidateCount > 0) {
       await overnight
         .updateWindow((prev) => scheduleCountdown(prev, { now: t, dueMs: due }))
         .catch(() => {});
@@ -1499,14 +1518,24 @@ export function createCtoEngine(deps = {}) {
   // Cancel tonight (veto card "Cancel tonight" / drill-down "Cancel tonight").
   // Pauses running CTO jobs + closes the window (or clears the countdown),
   // resolves the veto card, records the §9.5 veto verdict. The window row
-  // keeps `closeReason: "veto"` so the arming logic does not re-announce the
-  // same night — a veto is a veto, not a countdown reset.
+  // keeps `vetoedTroughStartMs` = the current trough's start so the machine's
+  // open path refuses to auto-open this trough again — a veto is a veto, not a
+  // countdown reset. The stamp is per-trough: the next trough has a different
+  // startMs, so it never suppresses a later night (and run-now overrides it).
   async function tonightCancel() {
-    const prevWin = overnight ? await overnight.readWindow().catch(() => null) : null;
+    const trough = typeof profile?.getQuietTrough === "function" ? profile.getQuietTrough() : null;
     await preemptOvernight("veto");
-    if (overnight && prevWin && prevWin.state !== "open") {
+    if (overnight) {
       await overnight
-        .updateWindow((prev) => (prev ? normalizeWindow({ ...normalizeWindow(prev), closeReason: "veto", countdown: null }) : null))
+        .updateWindow((prev) =>
+          prev
+            ? normalizeWindow({
+                ...normalizeWindow(prev),
+                ...(trough?.startMs != null ? { vetoedTroughStartMs: trough.startMs } : {}),
+                countdown: null,
+              })
+            : null,
+        )
         .catch(() => {});
     }
     const open = (await cards.listOpen().catch(() => [])) ?? [];

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -1301,7 +1301,7 @@ export function createCtoEngine(deps = {}) {
     if (!win) return;
     const due = trough ? trough.startMs : null;
     const imminent = due != null && t >= due - VETO_LEAD_MS && t < due;
-    if (imminent && win.state !== "open" && !win.countdown && candidateCount > 0) {
+    if (imminent && win.state !== "open" && !win.countdown && win.closeReason !== "veto" && candidateCount > 0) {
       await overnight
         .updateWindow((prev) => scheduleCountdown(prev, { now: t, dueMs: due }))
         .catch(() => {});
@@ -1498,9 +1498,17 @@ export function createCtoEngine(deps = {}) {
 
   // Cancel tonight (veto card "Cancel tonight" / drill-down "Cancel tonight").
   // Pauses running CTO jobs + closes the window (or clears the countdown),
-  // resolves the veto card, records the §9.5 veto verdict.
+  // resolves the veto card, records the §9.5 veto verdict. The window row
+  // keeps `closeReason: "veto"` so the arming logic does not re-announce the
+  // same night — a veto is a veto, not a countdown reset.
   async function tonightCancel() {
+    const prevWin = overnight ? await overnight.readWindow().catch(() => null) : null;
     await preemptOvernight("veto");
+    if (overnight && prevWin && prevWin.state !== "open") {
+      await overnight
+        .updateWindow((prev) => (prev ? normalizeWindow({ ...normalizeWindow(prev), closeReason: "veto", countdown: null }) : null))
+        .catch(() => {});
+    }
     const open = (await cards.listOpen().catch(() => [])) ?? [];
     const stale = open.find((c) => c?.id === VETO_CARD_ID && c?.variant === "veto");
     if (stale) await cards.resolveById(stale.id, { reason: "canceled by user" }).catch(() => {});

--- a/src/server/ctoEngine.mjs
+++ b/src/server/ctoEngine.mjs
@@ -100,7 +100,18 @@ import {
 } from "./ctoBudget.mjs";
 // BET-1398 standing-query watchers (§4.3/§13.4): the event-driven watcher
 // engine hosted by the adaptive engine. Supersedes the old cto.json poller.
-import { createStandingQueryEngine, extractSignifiers, patternSignatureFor } from "./ctoWatchers.mjs";
+import {
+  collectWatcherHitsFromLedger,
+  createStandingQueryEngine,
+  extractSignifiers,
+  patternSignatureFor,
+} from "./ctoWatchers.mjs";
+
+// BET-1419 overnight execution (§11): the pure window/portfolio machine
+// (BET-1402) back the engine's veto/tonight verbs; resolveForgeOwner is the
+// pure project→job-parent resolver shared with forge dispatch.
+import { createOvernightScheduler, normalizeWindow, scheduleCountdown } from "./ctoOvernight.mjs";
+import { resolveForgeOwner } from "./delegate.mjs";
 
 // Actor tag stamped on every engine RPC call / ledger row (spec §3.3).
 export const ACTOR = "cto";
@@ -126,6 +137,12 @@ export const G_REFIT_INTERVAL_MS = 30 * 24 * HOUR_MS;
 export const PROFILE_DECAY_INTERVAL_MS = 7 * DAY_MS; // §8.2 weekly sigma/repo decay tick
 // §6.8 monthly half-life tuning cadence (a work timer, halted on pause).
 export const MONTHLY_TUNE_INTERVAL_MS = 30 * 24 * HOUR_MS;
+// BET-1419 (§11.1/§10.3): the veto card announces the window VETO_LEAD_MS
+// before the trough's start, so the countdown reads ~30 min.
+export const VETO_LEAD_MS = 30 * 60_000;
+// BET-1419 (§10.4): a hard cap on tonight's queue; further adds are refused
+// with a "cancel or edit first" note (never silent truncation).
+export const TONIGHT_QUEUE_MAX = 12;
 
 export const DOT = Object.freeze({
   ACTIVE: "active",
@@ -329,6 +346,19 @@ export function createCtoEngine(deps = {}) {
     // real loader; default none → no migration).
     watchers = null,
     legacyWatchesLoader = async () => [],
+    // BET-1419 overnight execution (§11): the injected scheduler owns the
+    // window state machine + portfolio over overnight.json (index.mjs
+    // constructs it with the budget seam). The delegate seams keep the engine
+    // free of tmux/delegate-store I/O: `startDelegateJob` starts one job
+    // (actor "cto" + sweepAllowance are baked in by index.mjs),
+    // `listDelegateJobs`/`pauseDelegateJob` back §11.6 preemption, and
+    // `listProjects` resolves a candidate's project to a job parent. All
+    // default to null → overnight stays disabled even at High tier.
+    overnight = null,
+    startDelegateJob = null,
+    listDelegateJobs = null,
+    pauseDelegateJob = null,
+    listProjects = null,
   } = deps;
 
   let disposed = false;
@@ -438,8 +468,19 @@ export function createCtoEngine(deps = {}) {
         // active = started (watermark recorded) but not yet finished.
         active: !!es.backfillStartInstant && es.backfillDone !== true,
       };
+      // BET-1419: tonight's queue size (§10.4 line) — the engine owns the
+      // queue, so it overrides the counts fold's zero when tasks exist.
+      if (Array.isArray(es.tonightQueue)) {
+        counts.tonightCount = es.tonightQueue.filter((t) => t && typeof t.id === "string").length;
+      }
     } catch {
       /* best-effort */
+    }
+    let tier = null;
+    try {
+      tier = await tierGet();
+    } catch {
+      tier = null;
     }
     return {
       enabled: enabledNow,
@@ -448,6 +489,7 @@ export function createCtoEngine(deps = {}) {
       needsYouCount: counts.needsYouCount ?? 0,
       generationInFlight: !!counts.generationInFlight,
       tonightCount: counts.tonightCount ?? 0,
+      tier,
       backfill,
     };
   }
@@ -485,6 +527,8 @@ export function createCtoEngine(deps = {}) {
         // §4.3/§13.4 standing-query watchers: windowed kinds + retirement, and
         // auto-created watchers after a new day rollup lands.
         await watcherTick();
+        // §11 overnight: window state machine + plan dispatch (BET-1419).
+        await overnightTick();
       }
       // §10.6-4 cold-start backfill — also ambient, gated on enabled. Its own
       // drained state marker makes it run at most once per box.
@@ -905,7 +949,22 @@ export function createCtoEngine(deps = {}) {
     if (verdictsEngine) return verdictsEngine;
     verdictsEngine = createVerdictEngine({ verdicts, now });
     verdictsEngine.registerCounterSink(factsCounterSink);
+    verdictsEngine.registerCounterSink(tonightCounterSink);
     return verdictsEngine;
+  }
+
+  // BET-1419 queue-tonight counter sink (§11.4): fold queue-tonight verdicts
+  // into the overnight Thompson acceptance counters (two per category, read
+  // by the portfolio's next sample). Only the suggestion-subject verdicts
+  // with class `queue-tonight` count — the veto card's own verdicts are user
+  // consent, not task acceptance. The fold maps the verdict's §9.5 effects
+  // (accept → success, reject/veto → rejection) internally. Best-effort.
+  function tonightCounterSink(effects, entry) {
+    if (!overnight) return;
+    if (entry?.subject?.type !== "suggestion" || entry?.subject?.class !== "queue-tonight") return;
+    void overnight
+      .foldCounters({ category: "queue-tonight", verdict: entry?.verdict, never: entry?.never === true })
+      .catch(() => {});
   }
 
   // BET-1398 standing-query watchers (§4.3/§13.4): lazy single instance over
@@ -1040,6 +1099,430 @@ export function createCtoEngine(deps = {}) {
       void fe.noteReliability(sender, delta).catch(() => {});
     }
   }
+
+  // ---------------------------------------------------------------------------
+  // BET-1419 — Overnight execution wiring (§11). The pure machine (window
+  // state machine, portfolio scorer, execution contract) lives in
+  // ctoOvernight.mjs; this block is the wiring: feed the machine each tick
+  // (quiet trough from the profile, presence, candidates from the tonight
+  // queue + watcher hits), dispatch the selected plan through the injected
+  // delegate seams (actor "cto", sweepAllowance = window remaining, the §3.3
+  // sub-cap of 2 enforced by beginDelegateJob), preempt everything on the
+  // user's return (§11.6), and arm/fulfill/cancel the veto countdown card
+  // (§10.3). Nothing runs unless the engine is enabled, the Overnight switch
+  // is on (config `ctoOvernightEnabled`), the tier is High, and the scheduler
+  // was injected.
+  // ---------------------------------------------------------------------------
+
+  const VETO_CARD_ID = "overnight:veto";
+  // One-shot "run now instead" consent set by the veto card / tonight verb;
+  // consumed by the next overnight tick.
+  let pendingRunNow = false;
+
+  async function overnightGate() {
+    if (disposed || !overnight) return false;
+    try {
+      const cfg = (await configGet()) ?? {};
+      if (cfg.ctoOvernightEnabled !== true) return false;
+      return (await tierGet()) === "high";
+    } catch {
+      return false;
+    }
+  }
+
+  // The §11.4 candidate sources this issue wires: accepted `queue-tonight`
+  // entries (the tonight queue) + watcher-driven investigations (the standing
+  // queries' hits). Queue entries carry the value/confidence captured at
+  // accept time; watcher hits degrade to mid-lattice defaults.
+  async function tonightQueueRows() {
+    try {
+      const es = (await engineState.load()) ?? {};
+      return Array.isArray(es.tonightQueue) ? es.tonightQueue : [];
+    } catch {
+      return [];
+    }
+  }
+
+  async function saveTonightQueueRows(rows) {
+    const es = (await engineState.load()) ?? {};
+    await engineState.save({ ...es, tonightQueue: rows });
+  }
+
+  function queueCandidatesFromRows(rows) {
+    const out = [];
+    for (const t of Array.isArray(rows) ? rows : []) {
+      if (!t || typeof t !== "object" || typeof t.id !== "string" || !t.id) continue;
+      out.push({
+        id: t.id,
+        name: typeof t.name === "string" ? t.name : undefined,
+        prompt: typeof t.prompt === "string" ? t.prompt : undefined,
+        project: typeof t.project === "string" ? t.project : undefined,
+        category: "queue-tonight",
+        value: Number.isFinite(t.value) ? t.value : 1,
+        confidence: Number.isFinite(t.confidence) ? t.confidence : 0.8,
+        predictedCost: Number.isFinite(t.predictedCost) ? t.predictedCost : 1,
+        refs: Array.isArray(t.refs) ? t.refs : [],
+      });
+    }
+    return out;
+  }
+
+  function watcherCandidatesFromRows(rows) {
+    const out = [];
+    for (const hit of collectWatcherHitsFromLedger(rows)) {
+      out.push({
+        id: hit.id,
+        name: hit.text,
+        category: "watcher",
+        value: 2,
+        confidence: 0.8,
+        predictedCost: 1,
+        refs: Array.isArray(hit.refs) ? hit.refs : [],
+      });
+    }
+    return out;
+  }
+
+  // Read the running delegate jobs this engine may preempt (actor "cto" only).
+  async function runningCtoJobs() {
+    if (typeof listDelegateJobs !== "function") return [];
+    try {
+      const jobs = await listDelegateJobs();
+      return (Array.isArray(jobs) ? jobs : []).filter((j) => j?.actor === "cto" && j?.status === "running");
+    } catch {
+      return [];
+    }
+  }
+
+  // §11.6 preemption: pause every running CTO job, then close the window (or
+  // clear an armed countdown). Best-effort — a failing pause seam must never
+  // break the close; the delegate sweeper still drains a missed pause flag.
+  async function preemptOvernight(reason) {
+    for (const j of await runningCtoJobs()) {
+      try {
+        await pauseDelegateJob?.(j.id);
+        await ledgerLog({ kind: "cto.overnight.preempt", jobId: j.id, reason });
+      } catch {
+        /* the sweeper still drains it; preemption is best-effort */
+      }
+    }
+    if (!overnight) return;
+    const t = now();
+    await overnight
+      .updateWindow((prev) =>
+        prev
+          ? normalizeWindow({
+              ...normalizeWindow(prev),
+              ...(prev.state === "open"
+                ? { state: "closed", closedMs: t, closeReason: reason, pinnedOrder: null }
+                : { countdown: null }),
+            })
+          : null,
+      )
+      .catch(() => {});
+  }
+
+  // Dispatch the selected plan (§11.5 execution contract). The §3.3 concurrent
+  // delegate sub-cap (RATE_LIMITS.concurrentDelegate = 2) is enforced by
+  // beginDelegateJob — the overnight scheduler never bypasses it. Each start
+  // removes its queue entry (a queued task that started is no longer queued);
+  // failures ledger and leave the entry queued for the next tick/night.
+  // Candidates whose job already started in this window are skipped (the
+  // ledger's job_started rows are the dedupe record — a watcher hit stays in
+  // the ledger and would otherwise re-run every tick of the same window).
+  async function dispatchPlan({ plan, trough, projects, ledgerRows, windowOpenedMs }) {
+    let started = 0;
+    const startedIds = new Set(
+      (Array.isArray(ledgerRows) ? ledgerRows : [])
+        .filter((r) => r?.kind === "cto.overnight.job_started" && typeof r?.ts === "number")
+        .filter((r) => (windowOpenedMs == null ? true : r.ts >= windowOpenedMs))
+        .map((r) => r.id),
+    );
+    for (const cand of plan?.selected ?? []) {
+      const release = track.beginDelegate();
+      try {
+        if (!cand || typeof cand.id !== "string" || startedIds.has(cand.id)) continue;
+        if (typeof startDelegateJob !== "function") break;
+        const task = (await tonightQueueRows()).find((r) => r?.id === cand.id) ?? null;
+        const project = cand.project ?? task?.project;
+        const parent =
+          typeof project === "string" && project ? resolveForgeOwner(projects, project) : null;
+        if (!parent?.parentSessionID) {
+          await ledgerLog({
+            kind: "cto.overnight.skip",
+            id: cand.id,
+            reason: "no tracked project session to host the job",
+            project,
+          });
+          continue;
+        }
+        const res = await startDelegateJob({
+          name: cand.name ?? task?.name ?? `overnight:${cand.category}`,
+          prompt:
+            cand.prompt ??
+            task?.prompt ??
+            `${cand.name ?? "overnight"} — investigate and report a draft summary with refs.`,
+          parentSessionID: parent.parentSessionID,
+          parentDirectory: project,
+          sweepAllowanceMs: trough ? Math.max(0, trough.endMs - now()) : undefined,
+        });
+        if (res?.ok === false) {
+          await ledgerLog({ kind: "cto.overnight.skip", id: cand.id, reason: res.error ?? "delegate start refused", project });
+          continue;
+        }
+        started += 1;
+        await ledgerLog({
+          kind: "cto.overnight.job_started",
+          id: cand.id,
+          jobId: res?.job?.id ?? null,
+          project,
+          category: cand.category,
+        });
+        if (task) {
+          const rows = await tonightQueueRows();
+          await saveTonightQueueRows(rows.filter((r) => r?.id !== task.id));
+        }
+      } catch {
+        /* keep dispatching the remaining selected jobs */
+      } finally {
+        release();
+      }
+    }
+    return started;
+  }
+
+  // §9.2 veto card: armed once per imminent window (trough start − 30 min),
+  // fulfilled by its own open, canceled by the user, abandoned when it
+  // elapses unmet (the machine already ledgers the abandon on tick).
+  async function overnightVetoCard({ trough, candidateCount }) {
+    if (!overnight || !cards || typeof cards.upsertVeto !== "function") return;
+    const t = now();
+    const win = await overnight.readWindow();
+    if (!win) return;
+    const due = trough ? trough.startMs : null;
+    const imminent = due != null && t >= due - VETO_LEAD_MS && t < due;
+    if (imminent && win.state !== "open" && !win.countdown && candidateCount > 0) {
+      await overnight
+        .updateWindow((prev) => scheduleCountdown(prev, { now: t, dueMs: due }))
+        .catch(() => {});
+      const tasks = (await tonightQueueRows()).filter((r) => r && typeof r.id === "string");
+      await cards
+        .upsertVeto({
+          id: VETO_CARD_ID,
+          title: "Overnight run planned",
+          body: `The CTO queued ${tasks.length} task${tasks.length === 1 ? "" : "s"} for tonight's window. It runs unattended unless you cancel.`,
+          dueMs: due,
+          options: [
+            { label: "Cancel tonight", action: { type: "veto-cancel", payload: {} } },
+            { label: "Edit plan", action: { type: "veto-edit", payload: {} } },
+            { label: "Run now instead", action: { type: "veto-run-now", payload: {} } },
+          ],
+        })
+        .catch(() => {});
+      await ledgerLog({ kind: "cto.overnight.veto_card", dueMs: due, tasks: tasks.length });
+      return;
+    }
+    if (win.state === "open" || !imminent) {
+      // Fulfilled (its own open cleared the countdown), canceled, or long
+      // gone: resolve any still-open veto card so the countdown cannot linger
+      // (§10.3 liveness).
+      const open = (await cards.listOpen().catch(() => [])) ?? [];
+      const stale = open.find((c) => c?.id === VETO_CARD_ID && c?.variant === "veto");
+      if (stale) {
+        const fulfilled = win.state === "open" && win.countdown == null;
+        await cards.resolveById(stale.id, { reason: fulfilled ? "window opened" : "countdown elapsed unmet" }).catch(() => {});
+      }
+    }
+  }
+
+  // The overnight slice of the engine tick. Gated like every other work
+  // branch; every step is best-effort — the machine's ledger rows record what
+  // actually happened (§14.5), and this block never throws into the poller.
+  async function overnightTick() {
+    if (!(await overnightGate())) return;
+    const t = now();
+    const presence = getPresence().state;
+    const hasDesktop = getLastDesktopHeartbeat() > 0;
+    const lastUserEventMs = promptTs > 0 ? promptTs : null;
+    const trough = typeof profile?.getQuietTrough === "function" ? profile.getQuietTrough() : null;
+    const runNow = pendingRunNow;
+    pendingRunNow = false;
+    let ledgerRowsAll = [];
+    try {
+      ledgerRowsAll = (await ledger.read()) ?? [];
+    } catch {
+      ledgerRowsAll = [];
+    }
+    const recentLedger = ledgerRowsAll.filter(
+      (r) => typeof r?.ts !== "number" || r.ts >= t - 24 * HOUR_MS,
+    );
+    const candidates = [
+      ...queueCandidatesFromRows(await tonightQueueRows()),
+      ...watcherCandidatesFromRows(recentLedger),
+    ];
+    let out = null;
+    try {
+      out = await overnight.tick({
+        now: t,
+        trough,
+        presence,
+        hasDesktop,
+        lastUserEventMs,
+        runNow,
+        candidates,
+      });
+    } catch {
+      return; // the persisted window state is authoritative; skip this tick
+    }
+    if (Array.isArray(out?.ledgerRows) && out.ledgerRows.length) {
+      for (const row of out.ledgerRows) {
+        await ledgerLog({ ...row, ts: row?.ts ?? t }).catch(() => {});
+      }
+      // A fold that just closed the window also released the §11.6 preemption
+      // (presence return / fresh user event) — the delegate jobs need the
+      // pause flag set now, not on the next tick.
+      if (out.ledgerRows.some((r) => r?.kind === "cto.overnight.close" && r?.reason !== "trough-end")) {
+        await preemptOvernight("user-return");
+      }
+    }
+    const win = out?.window ?? null;
+    if (win?.state === "open" && out.plan?.selected?.length) {
+      let projects = null;
+      try {
+        projects = await listProjects();
+      } catch {
+        projects = null;
+      }
+      await dispatchPlan({
+        plan: out.plan,
+        trough,
+        projects,
+        ledgerRows: ledgerRowsAll,
+        windowOpenedMs: win.openedMs,
+      }).catch(() => {});
+    }
+    await overnightVetoCard({ trough, candidateCount: candidates.length }).catch(() => {});
+    await syncState().catch(() => {});
+  }
+
+  // ---- Tonight verbs (§10.4 drill-down + §9.2 veto card actions) ----------
+
+  // List the queue + the current window state for the Tonight drill-down.
+  async function tonightList() {
+    const tasks = await tonightQueueRows();
+    const win = overnight ? await overnight.readWindow().catch(() => null) : null;
+    return { tasks, window: win };
+  }
+
+  // Queue a task for tonight (the `queue-tonight` decision-card option
+  // executor). Gated: engine enabled, High tier, Overnight switch, injected
+  // scheduler. A 13th add is refused with a note (never silent truncation).
+  async function tonightAdd(task = {}) {
+    if (!(await overnightGate())) return { ok: false, error: "overnight is not enabled (High tier + Overnight switch)" };
+    const name = typeof task.name === "string" ? task.name.trim() : "";
+    if (!name) return { ok: false, error: "name is required" };
+    const rows = await tonightQueueRows();
+    if (rows.length >= TONIGHT_QUEUE_MAX) {
+      return { ok: false, error: `tonight's queue is full (${TONIGHT_QUEUE_MAX}) — cancel or edit first` };
+    }
+    const entry = {
+      id: `tq:${nextId()}`,
+      name: name.slice(0, 200),
+      prompt: typeof task.prompt === "string" && task.prompt.trim() ? task.prompt.trim() : name,
+      project: typeof task.project === "string" && task.project ? task.project : null,
+      value: Number.isFinite(task.value) ? task.value : 1,
+      confidence: Number.isFinite(task.confidence) ? task.confidence : 0.8,
+      predictedCost: Number.isFinite(task.predictedCost) ? task.predictedCost : 1,
+      refs: Array.isArray(task.refs) ? task.refs : [],
+      cls: typeof task.cls === "string" ? task.cls : "queue-tonight",
+      originId: typeof task.originId === "string" ? task.originId : null,
+      addedMs: now(),
+    };
+    await saveTonightQueueRows([...rows, entry]);
+    await ledgerLog({ kind: "cto.overnight.queue_add", id: entry.id, name: entry.name });
+    await syncState().catch(() => {});
+    return { ok: true, task: entry };
+  }
+
+  // Remove one task (a Tonight drill-down edit — itself a verdict, §10.4).
+  async function tonightRemove(id) {
+    if (typeof id !== "string" || !id) return { ok: false, error: "id is required" };
+    const rows = await tonightQueueRows();
+    const next = rows.filter((r) => r?.id !== id);
+    if (next.length === rows.length) return { ok: false, error: "not found" };
+    await saveTonightQueueRows(next);
+    // Drop the task from a pinned order too — a removed task can no longer
+    // pin a slot.
+    if (overnight) {
+      await overnight
+        .updateWindow((prev) =>
+          prev?.pinnedOrder?.length
+            ? normalizeWindow({ ...normalizeWindow(prev), pinnedOrder: prev.pinnedOrder.filter((pid) => pid !== id) })
+            : null,
+        )
+        .catch(() => {});
+    }
+    const removed = rows.find((r) => r?.id === id);
+    await ledgerLog({ kind: "cto.overnight.queue_edit", edit: "remove", id });
+    void getVerdictsEngine()
+      .recordVerdict({
+        subject: { type: "suggestion", id: removed?.originId ?? id, class: "queue-tonight" },
+        verdict: "edit",
+      })
+      .catch(() => {});
+    await syncState().catch(() => {});
+    return { ok: true };
+  }
+
+  // Reorder the queue — PINS the order for the current window (exempt from
+  // the 30-min re-scoring; cleared again when the window closes, §10.4).
+  async function tonightReorder(ids) {
+    if (!Array.isArray(ids)) return { ok: false, error: "ids array is required" };
+    if (!overnight) return { ok: false, error: "overnight is not enabled" };
+    const rows = await tonightQueueRows();
+    const known = new Set(rows.map((r) => r?.id).filter(Boolean));
+    const pinned = ids.filter((i) => typeof i === "string" && known.has(i));
+    if (pinned.length === 0) return { ok: false, error: "no known task ids in order" };
+    await overnight
+      .updateWindow((prev) => normalizeWindow({ ...normalizeWindow(prev), pinnedOrder: pinned }))
+      .catch(() => {});
+    await ledgerLog({ kind: "cto.overnight.queue_edit", edit: "reorder", order: pinned });
+    void getVerdictsEngine()
+      .recordVerdict({
+        subject: { type: "suggestion", id: rows.find((r) => r?.id === pinned[0])?.originId ?? pinned[0], class: "queue-tonight" },
+        verdict: "edit",
+      })
+      .catch(() => {});
+    return { ok: true, pinned };
+  }
+
+  // Cancel tonight (veto card "Cancel tonight" / drill-down "Cancel tonight").
+  // Pauses running CTO jobs + closes the window (or clears the countdown),
+  // resolves the veto card, records the §9.5 veto verdict.
+  async function tonightCancel() {
+    await preemptOvernight("veto");
+    const open = (await cards.listOpen().catch(() => [])) ?? [];
+    const stale = open.find((c) => c?.id === VETO_CARD_ID && c?.variant === "veto");
+    if (stale) await cards.resolveById(stale.id, { reason: "canceled by user" }).catch(() => {});
+    await ledgerLog({ kind: "cto.overnight.veto", ts: now() });
+    void getVerdictsEngine()
+      .recordVerdict({ subject: { type: "veto-window", id: VETO_CARD_ID, class: "overnight" }, verdict: "veto" })
+      .catch(() => {});
+    await syncState().catch(() => {});
+    return { ok: true };
+  }
+
+  // "Run now instead" (§9.2): one-shot consent the next overnight tick
+  // consumes — it opens the window even outside the trough (the machine's
+  // `runNow` branch; zero candidates still opens nothing, §11.4).
+  async function tonightRunNow() {
+    if (!(await overnightGate())) return { ok: false, error: "overnight is not enabled (High tier + Overnight switch)" };
+    pendingRunNow = true;
+    await ledgerLog({ kind: "cto.overnight.run_now", ts: now() });
+    return { ok: true };
+  }
+
+  // ---------------------------------------------------------------------------
 
   // Pump the blackboard proposal queue (per-project, single writer). Driven
   // from the tick when enabled; best-effort, never throws into the poller.
@@ -1211,6 +1694,11 @@ export function createCtoEngine(deps = {}) {
     if (isUserPromptEvent(evt)) {
       const t = now();
       if (t > promptTs) promptTs = t;
+      // §11.6 preemption on the user's return: an open overnight window closes
+      // and its running CTO jobs are paused at their next tool-call boundary —
+      // immediately, not at the next tick. Fire-and-forget; the next tick's
+      // evaluateWindow would reach the same close regardless.
+      void preemptOvernight("user-return").catch(() => {});
     }
     // The SAME opencode event arrives on both the global and the per-directory
     // scoped stream — fold the duplicate so it counts once.
@@ -1505,6 +1993,13 @@ export function createCtoEngine(deps = {}) {
     get cards() {
       return cards;
     },
+    // BET-1419 tonight verbs (§10.4 drill-down + §9.2 veto card actions).
+    tonightList,
+    tonightAdd,
+    tonightRemove,
+    tonightReorder,
+    tonightCancel,
+    tonightRunNow,
   };
 
   return engine;

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -1,0 +1,294 @@
+// BET-1419 overnight wiring tests (§11): window open → plan dispatch through
+// the delegate seams; §11.6 preemption on the user's return; the §9.2 veto
+// card lifecycle; the tonight queue verbs. The overnight machine itself is
+// tested in ctoOvernight.test.mjs — these tests assert the WIRING.
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createCtoEngine } from "./ctoEngine.mjs";
+import { createOvernightScheduler } from "./ctoOvernight.mjs";
+
+const HOUR = 3_600_000;
+
+// Minimal harness: fake clock, in-memory stores, injected delegate seams +
+// overnight scheduler. Presence is "gone" (stale desktop beat), profile seam
+// returns a caller-controlled trough, and the queue pre-seeds engine-state.
+function makeHarness({ trough = null, queue = [], projects = [], tier = "high", overnightEnabled = true } = {}) {
+  const clock = { ms: 1_700_000_000_000 };
+  const now = () => clock.ms;
+  const ledgerRows = [];
+  const engineStateObj = { v: 1, pendingBlockers: [], tonightQueue: JSON.parse(JSON.stringify(queue)) };
+  const overnightStoreObj = { v: 1, window: null };
+  const published = [];
+  const startedJobs = [];
+  const pausedJobs = [];
+  const listedJobs = [];
+  const vetoCards = [];
+  const config = { ctoEnabled: true, ctoTier: tier, ctoOvernightEnabled: overnightEnabled };
+
+  const overnight = createOvernightScheduler({
+    store: {
+      load: async () => ({ ...overnightStoreObj }),
+      save: async (payload) => {
+        overnightStoreObj.window = payload.window ?? null;
+        overnightStoreObj.counters = payload.counters;
+      },
+    },
+    now,
+    budget: async () => null,
+    ledger: { append: async (row) => ledgerRows.push(row) },
+  });
+
+  const engine = createCtoEngine({
+    configGet: async () => ({ ...config }),
+    tierGet: async () => config.ctoTier,
+    now,
+    ledger: {
+      append: async (row) => ledgerRows.push(row),
+      read: async () => [...ledgerRows],
+    },
+    engineState: {
+      load: async () => JSON.parse(JSON.stringify(engineStateObj)),
+      save: async (payload) => {
+        if (Array.isArray(payload?.tonightQueue)) engineStateObj.tonightQueue = payload.tonightQueue;
+        if (payload?.pendingBlockers) engineStateObj.pendingBlockers = payload.pendingBlockers;
+        if (payload?.rollupCursor) engineStateObj.rollupCursor = payload.rollupCursor;
+        if (payload?.backfillProgress) engineStateObj.backfillProgress = payload.backfillProgress;
+        if (payload?.backfillStartInstant !== undefined) engineStateObj.backfillStartInstant = payload.backfillStartInstant;
+      },
+    },
+    killSwitch: {
+      isPaused: async () => false,
+      pause: async () => {},
+      resume: async () => {},
+    },
+    publish: (evt) => published.push(evt),
+    getCounts: async () => ({ needsYouCount: 0, generationInFlight: false, tonightCount: 0 }),
+    budget: { isCapHit: async () => false, record: async () => ({ usd: 0, dayKey: "0" }) },
+    cards: {
+      onAskStart: async () => {},
+      onAskResolved: async () => ({ changed: false }),
+      onHealthRecovered: async () => {},
+      promoteDue: async () => ({}),
+      ingestHealthEscalations: async () => ({}),
+      listOpen: async () => [...vetoCards],
+      resolveById: async (id) => {
+        const i = vetoCards.findIndex((c) => c.id === id);
+        if (i >= 0) vetoCards.splice(i, 1);
+        return { changed: i >= 0 };
+      },
+      dismissById: async () => ({ changed: false }),
+      upsertDecision: async () => ({ changed: true }),
+      upsertVeto: async (card) => {
+        const row = { variant: "veto", ...card };
+        const i = vetoCards.findIndex((c) => c.id === card.id);
+        if (i >= 0) vetoCards[i] = { ...vetoCards[i], ...row };
+        else vetoCards.push(row);
+        return { changed: true };
+      },
+    },
+    // §5.4: stale desktop beat (> 90s TTL) → presence "gone"; hasDesktop true.
+    getDesktopPresence: () => ({ lastSeen: clock.ms - 10 * 60_000 }),
+    getLastDesktopHeartbeat: () => clock.ms - 10 * 60_000,
+    // BET-1419: the trough seam the tests control.
+    profile: { getQuietTrough: () => trough },
+    overnight,
+    startDelegateJob: async (input) => {
+      startedJobs.push(input);
+      return { ok: true, job: { id: `job-${startedJobs.length}` } };
+    },
+    listDelegateJobs: async () => [...listedJobs],
+    pauseDelegateJob: async (id) => {
+      pausedJobs.push(id);
+      return { ok: true };
+    },
+    listProjects: async () => projects,
+  });
+
+  return {
+    engine,
+    clock,
+    now,
+    overnight,
+    ledgerRows,
+    startedJobs,
+    pausedJobs,
+    listedJobs,
+    vetoCards,
+    published,
+    engineStateObj,
+    overnightStoreObj,
+    setQueue(rows) {
+      engineStateObj.tonightQueue = rows;
+    },
+    advance(ms) {
+      clock.ms += ms;
+    },
+  };
+}
+
+const TROUGH = { startMs: 1_700_000_000_000 - 30 * 60_000, endMs: 1_700_000_000_000 + 5.5 * HOUR };
+const QUEUE_TASK = {
+  id: "tq:1",
+  name: "Reconcile the ledger",
+  prompt: "Reconcile the ledger and report.",
+  project: "/repo",
+  value: 1,
+  confidence: 0.8,
+  predictedCost: 1,
+  refs: [],
+  cls: "queue-tonight",
+  originId: null,
+  addedMs: 1_699_900_000_000,
+};
+const PROJECT_ROW = { tmuxSession: "s1", defaultCwd: "/repo", windows: [{ opencodeSessionId: "sess-1" }] };
+
+test("overnight: window opens in the trough while absent → dispatches via the cto actor seam with the window sweep allowance", async () => {
+  const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [PROJECT_ROW] });
+  await h.engine.tick();
+
+  assert.equal(h.startedJobs.length, 1, "one overnight job started");
+  const job = h.startedJobs[0];
+  assert.equal(job.parentSessionID, "sess-1");
+  assert.equal(job.parentDirectory, "/repo");
+  assert.ok(job.sweepAllowanceMs > 0 && job.sweepAllowanceMs <= TROUGH.endMs - h.now(), "sweep allowance = window remaining");
+  assert.match(job.prompt, /Reconcile the ledger/);
+  assert.deepEqual(h.engineStateObj.tonightQueue, [], "a started task leaves the queue");
+  assert.ok(h.ledgerRows.some((r) => r.kind === "cto.overnight.job_started" && r.id === "tq:1"));
+  assert.equal(h.overnightStoreObj.window?.state, "open");
+
+  const s = await h.engine.getState();
+  assert.equal(s.tonightCount, 0);
+});
+
+test("overnight: no window without the trough or the Overnight switch (or at tier < high)", async () => {
+  const offTrough = makeHarness({ trough: null, queue: [QUEUE_TASK], projects: [PROJECT_ROW] });
+  await offTrough.engine.tick();
+  assert.equal(offTrough.startedJobs.length, 0);
+  assert.notEqual(offTrough.overnightStoreObj.window?.state, "open");
+
+  const lowTier = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [PROJECT_ROW], tier: "medium" });
+  await lowTier.engine.tick();
+  assert.equal(lowTier.startedJobs.length, 0);
+
+  const switchOff = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [PROJECT_ROW], overnightEnabled: false });
+  await switchOff.engine.tick();
+  assert.equal(switchOff.startedJobs.length, 0);
+  assert.deepEqual(switchOff.engineStateObj.tonightQueue, [QUEUE_TASK]);
+});
+
+test("overnight: a candidate with no tracked project session is skipped and ledgered, not dropped", async () => {
+  const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [] });
+  await h.engine.tick();
+  assert.equal(h.startedJobs.length, 0);
+  assert.ok(h.ledgerRows.some((r) => r.kind === "cto.overnight.skip" && r.reason?.includes("no tracked project session")));
+  assert.deepEqual(h.engineStateObj.tonightQueue, [QUEUE_TASK], "the queued task survives a skip");
+});
+
+test("overnight: dispatch honors the §3.3 concurrent sub-cap (2) via the rate tracker", async () => {
+  const tasks = [];
+  for (let i = 0; i < 5; i++) {
+    tasks.push({ ...QUEUE_TASK, id: `tq:${i}`, project: `/repo${i}` });
+  }
+  const projects = tasks.map((t, i) => ({
+    tmuxSession: `s${i}`,
+    defaultCwd: `/repo${i}`,
+    windows: [{ opencodeSessionId: `sess-${i}` }],
+  }));
+  const h = makeHarness({ trough: TROUGH, queue: tasks, projects });
+  await h.engine.tick();
+  assert.ok(h.startedJobs.length <= 2, `at most 2 concurrent overnight starts (got ${h.startedJobs.length})`);
+});
+
+test("overnight: user prompt preempts — running cto jobs paused and the window closes (§11.6)", async () => {
+  const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [PROJECT_ROW] });
+  await h.engine.tick();
+  assert.equal(h.overnightStoreObj.window?.state, "open");
+  h.listedJobs.push({ id: "job-1", actor: "cto", status: "running" }, { id: "job-2", actor: "user", status: "running" });
+
+  h.engine.observeEvent({ type: "user.message.created" });
+  await new Promise((r) => setImmediate(r));
+
+  assert.deepEqual(h.pausedJobs, ["job-1"], "only the cto-actor job is paused");
+  assert.equal(h.overnightStoreObj.window?.state, "closed");
+  assert.equal(h.overnightStoreObj.window?.closeReason, "user-return");
+});
+
+test("overnight: veto card arms 30 min before the trough, cancels on the veto verdict, resolves once open", async () => {
+  // Inside the pre-window: 20 min before the trough's start.
+  const due = h0().startMs;
+  const h = makeHarness({ trough: { startMs: due, endMs: due + 6 * HOUR }, queue: [QUEUE_TASK], projects: [] });
+  h.clock.ms = due - 20 * 60_000;
+  await h.engine.tick();
+
+  assert.equal(h.overnightStoreObj.window?.countdown?.dueMs, due, "countdown armed at the trough start");
+  assert.equal(h.vetoCards.length, 1);
+  assert.equal(h.vetoCards[0].variant, "veto");
+  assert.equal(h.vetoCards[0].dueMs, due);
+  assert.ok(h.ledgerRows.some((r) => r.kind === "cto.overnight.veto_card"));
+
+  // Cancel tonight → countdown cleared, card resolved, veto verdict recorded.
+  const r = await h.engine.tonightCancel();
+  assert.equal(r.ok, true);
+  assert.equal(h.overnightStoreObj.window?.countdown ?? null, null);
+  assert.equal(h.vetoCards.length, 0, "the veto card resolved on cancel");
+  assert.ok(h.ledgerRows.some((row) => row.kind === "cto.overnight.veto"));
+
+  // A later tick with the window OPEN resolves a lingering card, not a new one.
+  await h.engine.tick();
+  assert.equal(h.vetoCards.length, 0);
+});
+
+test("overnight: run-now opens the window outside the trough and dispatches", async () => {
+  const h = makeHarness({ trough: null, queue: [QUEUE_TASK], projects: [PROJECT_ROW] });
+  const r = await h.engine.tonightRunNow();
+  assert.equal(r.ok, true);
+  await h.engine.tick();
+  assert.equal(h.startedJobs.length, 1, "run-now opens the window even without a trough");
+  assert.equal(h.overnightStoreObj.window?.openedBy, "run-now");
+});
+
+test("tonight verbs: add gates on the switch, caps at 12, remove + reorder pin the order", async () => {
+  const offSwitch = makeHarness({ trough: TROUGH, projects: [], overnightEnabled: false });
+  const denied = await offSwitch.engine.tonightAdd({ name: "X" });
+  assert.equal(denied.ok, false, "overnight switch off → refused");
+  assert.equal(offSwitch.engineStateObj.tonightQueue.length, 0);
+
+  const h = makeHarness({ trough: TROUGH, projects: [] });
+  const ok = await h.engine.tonightAdd({ name: "Nightly sweep", prompt: "sweep", project: "/repo", value: 1, confidence: 0.8 });
+  assert.equal(ok.ok, true);
+  assert.equal(ok.task.cls, "queue-tonight");
+  assert.deepEqual(h.engineStateObj.tonightQueue.map((t) => t.name), ["Nightly sweep"]);
+
+  const noName = await h.engine.tonightAdd({ name: "   " });
+  assert.equal(noName.ok, false);
+
+  // Cap: fill to 12, the 13th add is refused with a note.
+  for (let i = 0; i < 11; i++) await h.engine.tonightAdd({ name: `t${i}` });
+  assert.equal(h.engineStateObj.tonightQueue.length, 12);
+  const full = await h.engine.tonightAdd({ name: "one too many" });
+  assert.equal(full.ok, false);
+  assert.match(full.error ?? "", /full/);
+
+  // Reorder pins the window order (normalized into the window row).
+  const pinned = await h.engine.tonightReorder(h.engineStateObj.tonightQueue.map((t) => t.id).reverse());
+  assert.equal(pinned.ok, true);
+  assert.equal(h.overnightStoreObj.window?.pinnedOrder?.length, 12);
+
+  // Remove drops the entry AND its pinned slot.
+  const removed = await h.engine.tonightRemove(h.engineStateObj.tonightQueue[0].id);
+  assert.equal(removed.ok, true);
+  assert.equal(h.engineStateObj.tonightQueue.length, 11);
+});
+
+test("overnight: queue-tonight verdicts fold into the overnight Thompson counters", async () => {
+  const h = makeHarness({ trough: TROUGH, projects: [] });
+  await h.engine.recordVerdict({ subject: { type: "suggestion", id: "card-1", class: "queue-tonight" }, verdict: "accept" });
+  await new Promise((r) => setImmediate(r));
+  const counters = await h.overnight.readCounters();
+  assert.equal(counters?.["queue-tonight"]?.alpha, 1, "accept folds a success counter");
+});
+
+// Fixed trough helper for the veto-card test (a window that starts "now").
+function h0() {
+  return { startMs: 1_700_000_000_000 + 6 * HOUR, endMs: 1_700_000_000_000 + 12 * HOUR };
+}

--- a/src/server/ctoEngine.overnight.test.mjs
+++ b/src/server/ctoEngine.overnight.test.mjs
@@ -12,7 +12,7 @@ const HOUR = 3_600_000;
 // Minimal harness: fake clock, in-memory stores, injected delegate seams +
 // overnight scheduler. Presence is "gone" (stale desktop beat), profile seam
 // returns a caller-controlled trough, and the queue pre-seeds engine-state.
-function makeHarness({ trough = null, queue = [], projects = [], tier = "high", overnightEnabled = true } = {}) {
+function makeHarness({ trough = null, queue = [], projects = [], tier = "high", overnightEnabled = true, budgetPlan = null } = {}) {
   const clock = { ms: 1_700_000_000_000 };
   const now = () => clock.ms;
   const ledgerRows = [];
@@ -23,7 +23,8 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
   const pausedJobs = [];
   const listedJobs = [];
   const vetoCards = [];
-  const config = { ctoEnabled: true, ctoTier: tier, ctoOvernightEnabled: overnightEnabled };
+  const config = { ctoEnabled: true, ctoTier: tier, ctoOvernight: overnightEnabled };
+  let curTrough = trough;
 
   const overnight = createOvernightScheduler({
     store: {
@@ -34,7 +35,7 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
       },
     },
     now,
-    budget: async () => null,
+    budget: async () => budgetPlan,
     ledger: { append: async (row) => ledgerRows.push(row) },
   });
 
@@ -90,7 +91,7 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
     getDesktopPresence: () => ({ lastSeen: clock.ms - 10 * 60_000 }),
     getLastDesktopHeartbeat: () => clock.ms - 10 * 60_000,
     // BET-1419: the trough seam the tests control.
-    profile: { getQuietTrough: () => trough },
+    profile: { getQuietTrough: () => curTrough },
     overnight,
     startDelegateJob: async (input) => {
       startedJobs.push(input);
@@ -119,6 +120,9 @@ function makeHarness({ trough = null, queue = [], projects = [], tier = "high", 
     overnightStoreObj,
     setQueue(rows) {
       engineStateObj.tonightQueue = rows;
+    },
+    setTrough(t) {
+      curTrough = t;
     },
     advance(ms) {
       clock.ms += ms;
@@ -153,7 +157,7 @@ test("overnight: window opens in the trough while absent → dispatches via the 
   assert.ok(job.sweepAllowanceMs > 0 && job.sweepAllowanceMs <= TROUGH.endMs - h.now(), "sweep allowance = window remaining");
   assert.match(job.prompt, /Reconcile the ledger/);
   assert.deepEqual(h.engineStateObj.tonightQueue, [], "a started task leaves the queue");
-  assert.ok(h.ledgerRows.some((r) => r.kind === "cto.overnight.job_started" && r.id === "tq:1"));
+  assert.ok(h.ledgerRows.some((r) => r.kind === "cto.overnight.job_started" && r.id === "tq:1" && r.estTokens > 0));
   assert.equal(h.overnightStoreObj.window?.state, "open");
 
   const s = await h.engine.getState();
@@ -184,7 +188,7 @@ test("overnight: a candidate with no tracked project session is skipped and ledg
   assert.deepEqual(h.engineStateObj.tonightQueue, [QUEUE_TASK], "the queued task survives a skip");
 });
 
-test("overnight: dispatch honors the §3.3 concurrent sub-cap (2) via the rate tracker", async () => {
+test("overnight: dispatch enforces the §3.3 concurrent sub-cap (2) by counting running cto jobs + accepted starts", async () => {
   const tasks = [];
   for (let i = 0; i < 5; i++) {
     tasks.push({ ...QUEUE_TASK, id: `tq:${i}`, project: `/repo${i}` });
@@ -194,9 +198,36 @@ test("overnight: dispatch honors the §3.3 concurrent sub-cap (2) via the rate t
     defaultCwd: `/repo${i}`,
     windows: [{ opencodeSessionId: `sess-${i}` }],
   }));
-  const h = makeHarness({ trough: TROUGH, queue: tasks, projects });
-  await h.engine.tick();
-  assert.ok(h.startedJobs.length <= 2, `at most 2 concurrent overnight starts (got ${h.startedJobs.length})`);
+  // A fat budget seam (spendableFrac 5) lets the plan select all 5 candidates
+  // in ONE tick — the cap must still hold at dispatch time, not in the plan.
+  // Two cto-actor jobs are already running → zero new starts, each blocked
+  // candidate ledgered for the next tick, queue untouched.
+  const capped = makeHarness({ trough: TROUGH, queue: tasks, projects, budgetPlan: { spendableFrac: 5 } });
+  capped.listedJobs.push({ id: "r1", actor: "cto", status: "running" }, { id: "r2", actor: "cto", status: "running" });
+  await capped.engine.tick();
+  assert.equal(capped.startedJobs.length, 0, "2 running cto jobs → the sub-cap of 2 allows no new start");
+  assert.ok(
+    capped.ledgerRows.filter((r) => r.kind === "cto.overnight.skip" && r.reason === "rate_limit:concurrentDelegate").length >= 1,
+    "each blocked candidate is ledgered for the next tick",
+  );
+  assert.deepEqual(
+    capped.engineStateObj.tonightQueue.map((t) => t.id),
+    tasks.map((t) => t.id),
+    "queued tasks survive a cap-blocked dispatch",
+  );
+
+  // One running cto job → exactly one accepted start; the rest wait.
+  const one = makeHarness({ trough: TROUGH, queue: tasks, projects, budgetPlan: { spendableFrac: 5 } });
+  one.listedJobs.push({ id: "r1", actor: "cto", status: "running" });
+  await one.engine.tick();
+  assert.equal(one.startedJobs.length, 1, "one free sub-cap slot → exactly one start");
+  assert.ok(one.ledgerRows.some((r) => r.kind === "cto.overnight.skip" && r.reason === "rate_limit:concurrentDelegate"));
+
+  // user-actor running jobs don't consume the cto sub-cap.
+  const userJobs = makeHarness({ trough: TROUGH, queue: tasks, projects, budgetPlan: { spendableFrac: 5 } });
+  userJobs.listedJobs.push({ id: "u1", actor: "user", status: "running" }, { id: "u2", actor: "user", status: "running" });
+  await userJobs.engine.tick();
+  assert.equal(userJobs.startedJobs.length, 2, "user jobs don't count against the cto sub-cap");
 });
 
 test("overnight: user prompt preempts — running cto jobs paused and the window closes (§11.6)", async () => {
@@ -226,15 +257,42 @@ test("overnight: veto card arms 30 min before the trough, cancels on the veto ve
   assert.equal(h.vetoCards[0].dueMs, due);
   assert.ok(h.ledgerRows.some((r) => r.kind === "cto.overnight.veto_card"));
 
-  // Cancel tonight → countdown cleared, card resolved, veto verdict recorded.
+  // Cancel tonight → countdown cleared, card resolved, veto verdict recorded,
+  // and the veto stamp lands on THIS trough (the machine's open path reads it).
   const r = await h.engine.tonightCancel();
   assert.equal(r.ok, true);
   assert.equal(h.overnightStoreObj.window?.countdown ?? null, null);
+  assert.equal(h.overnightStoreObj.window?.vetoedTroughStartMs, due, "the veto stamp names this trough");
   assert.equal(h.vetoCards.length, 0, "the veto card resolved on cancel");
   assert.ok(h.ledgerRows.some((row) => row.kind === "cto.overnight.veto"));
 
-  // A later tick with the window OPEN resolves a lingering card, not a new one.
+  // Still in the pre-window: the veto suppresses BOTH the card re-arm and the
+  // countdown — a cancel is not a countdown reset (§9.2).
+  h.advance(5 * 60_000);
   await h.engine.tick();
+  assert.equal(h.overnightStoreObj.window?.countdown ?? null, null, "no countdown re-arm after a veto");
+  assert.equal(h.vetoCards.length, 0, "no veto card re-arm after a veto");
+
+  // THE §9.2 CONTRACT: the clock advances INTO the trough while the user is
+  // absent — the window must NOT re-open and nothing may execute unannounced.
+  h.advance(30 * 60_000);
+  await h.engine.tick();
+  assert.notEqual(h.overnightStoreObj.window?.state, "open", "a vetoed trough never re-opens");
+  assert.equal(h.startedJobs.length, 0, "a canceled night runs nothing");
+
+  // The stamp is per-trough: tomorrow's trough arms a fresh veto card again.
+  const next = { startMs: due + 24 * HOUR, endMs: due + 30 * HOUR };
+  h.setTrough(next);
+  h.advance(24 * HOUR - 20 * 60_000);
+  await h.engine.tick();
+  assert.equal(h.vetoCards.length, 1, "the next night arms a fresh veto card — the veto expired with its trough");
+
+  // A later tick with the window OPEN resolves a lingering card, not a new one.
+  const openTrough = { startMs: h.now(), endMs: h.now() + 6 * HOUR };
+  h.setTrough(openTrough);
+  h.advance(60 * 60_000);
+  await h.engine.tick();
+  assert.equal(h.overnightStoreObj.window?.state, "open", "the fresh trough opens normally (absent, in trough)");
   assert.equal(h.vetoCards.length, 0);
 });
 
@@ -292,3 +350,22 @@ test("overnight: queue-tonight verdicts fold into the overnight Thompson counter
 function h0() {
   return { startMs: 1_700_000_000_000 + 6 * HOUR, endMs: 1_700_000_000_000 + 12 * HOUR };
 }
+
+test("overnight: canceling mid-run pauses the job and vetoes the rest of the trough", async () => {
+  const h = makeHarness({ trough: TROUGH, queue: [QUEUE_TASK], projects: [PROJECT_ROW] });
+  await h.engine.tick();
+  assert.equal(h.overnightStoreObj.window?.state, "open");
+  assert.equal(h.startedJobs.length, 1);
+  h.listedJobs.push({ id: "job-1", actor: "cto", status: "running" });
+
+  const r = await h.engine.tonightCancel();
+  assert.equal(r.ok, true);
+  assert.deepEqual(h.pausedJobs, ["job-1"], "the running cto job is paused");
+  assert.equal(h.overnightStoreObj.window?.state, "closed", "the window closes on cancel");
+  assert.equal(h.overnightStoreObj.window?.vetoedTroughStartMs, TROUGH.startMs, "the rest of tonight is vetoed too");
+
+  h.advance(30 * 60_000);
+  await h.engine.tick();
+  assert.notEqual(h.overnightStoreObj.window?.state, "open", "no re-open after a mid-run cancel");
+  assert.equal(h.startedJobs.length, 1, "no further dispatch on a vetoed trough");
+});

--- a/src/server/ctoOvernight.mjs
+++ b/src/server/ctoOvernight.mjs
@@ -144,6 +144,11 @@ export function normalizeWindow(prev) {
     // Manual pin (input consent): when set, this exact order governs the
     // window's plan for its whole life — exempt from re-scoring.
     pinnedOrder: Array.isArray(w.pinnedOrder) ? w.pinnedOrder.filter((x) => typeof x === "string") : null,
+    // §9.2 veto stamp: the trough start whose run the user canceled. The open
+    // path refuses to AUTO-open this trough again (run-now still overrides —
+    // explicit consent after a cancel). It expires naturally when the next
+    // trough has a different startMs, so a veto never suppresses tomorrow.
+    vetoedTroughStartMs: finiteOrNull(w.vetoedTroughStartMs),
     countdown,
     lastEvaluatedMs: finiteOrNull(w.lastEvaluatedMs),
   };
@@ -241,7 +246,16 @@ export function evaluateWindow(prev, input) {
     const freshUserEvent =
       finiteOrNull(input?.lastUserEventMs) !== null && input.lastUserEventMs > w.openedMs;
     const presenceReturn = presence === "present" && !w.openedDuringPresence;
-    if (troughContains(w.openedMs, trough) && now >= trough.endMs) {
+    // Trough-shift guard: the profile can re-derive the trough mid-window (a
+    // G refit moves the quiet hours), which would make the trough-end close
+    // below unreachable (the re-derived trough never contains openedMs). A
+    // window the trough signal opened must never outlive its trough — close
+    // it the moment the current trough no longer contains its opening. Run-now
+    // windows are exempt: they open outside any trough on explicit consent and
+    // close on the user's return/fresh event.
+    const troughShifted =
+      w.openedBy !== "run-now" && trough != null && !troughContains(w.openedMs, trough);
+    if ((troughContains(w.openedMs, trough) && now >= trough.endMs) || troughShifted) {
       rows.push(ledgerRow("cto.overnight.close", now, { reason: "trough-end", openedMs: w.openedMs }));
       return {
         window: normalizeWindow({ ...w, state: "closed", closedMs: now, closeReason: "trough-end", countdown, pinnedOrder: null }),
@@ -275,7 +289,16 @@ export function evaluateWindow(prev, input) {
     return { window: normalizeWindow({ ...w, countdown, lastEvaluatedMs: now }), ledgerRows: rows };
   }
 
-  const mayOpen = runNow || (inTrough && signal !== null);
+  // §9.2 veto: a user cancel for THIS trough (vetoedTroughStartMs === the
+  // trough's start) blocks the auto-open — the run was canceled, not postponed.
+  // run-now overrides it (explicit consent after a cancel); the next trough
+  // has a different startMs, so the stamp never suppresses a later night.
+  const vetoedTrough =
+    w.vetoedTroughStartMs != null &&
+    trough != null &&
+    finiteOrNull(trough.startMs) === w.vetoedTroughStartMs;
+
+  const mayOpen = runNow || (!vetoedTrough && inTrough && signal !== null);
   if (!mayOpen) {
     return { window: normalizeWindow({ ...w, countdown, lastEvaluatedMs: now }), ledgerRows: rows };
   }
@@ -297,6 +320,7 @@ export function evaluateWindow(prev, input) {
       openedBy: runNow ? "run-now" : signal,
       openedDuringPresence,
       countdown: null, // an open fulfills any pending countdown
+      vetoedTroughStartMs: null, // an open supersedes any same-night veto stamp
       lastEvaluatedMs: now,
     }),
     ledgerRows: rows,

--- a/src/server/ctoOvernight.mjs
+++ b/src/server/ctoOvernight.mjs
@@ -244,7 +244,7 @@ export function evaluateWindow(prev, input) {
     if (troughContains(w.openedMs, trough) && now >= trough.endMs) {
       rows.push(ledgerRow("cto.overnight.close", now, { reason: "trough-end", openedMs: w.openedMs }));
       return {
-        window: normalizeWindow({ ...w, state: "closed", closedMs: now, closeReason: "trough-end", countdown }),
+        window: normalizeWindow({ ...w, state: "closed", closedMs: now, closeReason: "trough-end", countdown, pinnedOrder: null }),
         ledgerRows: rows,
       };
     }
@@ -252,7 +252,7 @@ export function evaluateWindow(prev, input) {
       const reason = freshUserEvent ? "user-event" : "user-return";
       rows.push(ledgerRow("cto.overnight.close", now, { reason, openedMs: w.openedMs }));
       return {
-        window: normalizeWindow({ ...w, state: "closed", closedMs: now, closeReason: reason, countdown }),
+        window: normalizeWindow({ ...w, state: "closed", closedMs: now, closeReason: reason, countdown, pinnedOrder: null }),
         ledgerRows: rows,
       };
     }
@@ -357,7 +357,7 @@ export function reconcileOnRestart(prev, input) {
           reason: "window missed entirely while the box was down; skipped, never run retroactively",
         }),
       );
-      window = normalizeWindow({ ...window, state: "closed", closedMs: now, closeReason: "trough-end" });
+      window = normalizeWindow({ ...window, state: "closed", closedMs: now, closeReason: "trough-end", pinnedOrder: null });
     } else {
       // Still inside its trough: re-derived, kept — but the reserve math must
       // run again before anything new starts (§11.6 "re-runs the reserve
@@ -754,6 +754,49 @@ export function createOvernightScheduler({ store = defaultOvernightStore(), now 
       await store.save({ ...payload, window }).catch(() => {});
       await ledgerAppend(ledgerRows);
       return { window, recomputeSpendable, ledgerRows };
+    },
+
+    /**
+     * Read the current window state without ticking (BET-1419 verbs read it
+     * for copy/preempt decisions). Null when no window was ever persisted.
+     */
+    async readWindow() {
+      const payload = await store.load().catch(() => null);
+      return payload?.window ?? null;
+    },
+
+    /**
+     * BET-1419 verb seam: apply a pure window transition (from the §11
+     * machine's helpers — scheduleCountdown / normalizeWindow) and persist.
+     * The mutator receives the previous window (or null) and returns the next
+     * normalized one; returning null is a no-op. The ENGINE decides WHEN these
+     * run (arming the veto countdown, canceling tonight, pinning an edit) —
+     * the scheduler only owns the store.
+     */
+    async updateWindow(mutator) {
+      if (typeof mutator !== "function") return null;
+      const payload = await store.load().catch(() => ({ v: 1, window: null }));
+      const next = mutator(payload?.window ?? null);
+      if (!next) return null;
+      await store.save({ ...payload, window: next }).catch(() => {});
+      return next;
+    },
+
+    /**
+     * BET-1419: fold a verdict into the Thompson acceptance counters the
+     * portfolio samples from (the queue-tonight verdict sink). Counters live
+     * beside the window in the same overnight store so one save stays atomic.
+     */
+    async foldCounters({ category, verdict, never } = {}) {
+      const payload = await store.load().catch(() => ({ v: 1 }));
+      const counters = foldVerdictIntoCounters(payload?.counters, { category, verdict, never });
+      await store.save({ ...payload, counters }).catch(() => {});
+      return counters;
+    },
+
+    async readCounters() {
+      const payload = await store.load().catch(() => null);
+      return payload?.counters ?? null;
     },
   };
 }

--- a/src/server/ctoOvernight.test.mjs
+++ b/src/server/ctoOvernight.test.mjs
@@ -461,3 +461,62 @@ test("every pure entry point survives garbage input (graceful, never throws)", (
     thompsonMultiplier(null, null, () => 0.5);
   }
 });
+
+// ---------------------------------------------------------------------------
+// BET-1419: the scheduler mutators the engine's tonight verbs ride on
+// ---------------------------------------------------------------------------
+
+test("readWindow returns the persisted row (null before anything was written)", async () => {
+  const { scheduler } = memoryScheduler();
+  assert.equal(await scheduler.readWindow(), null);
+  await scheduler.tick(tickInput({ candidates: [candidate()] }));
+  assert.equal((await scheduler.readWindow()).state, "open");
+});
+
+test("updateWindow applies a pure transition (arm/clear/pin) and persists it", async () => {
+  const { scheduler, saved } = memoryScheduler();
+  const armed = await scheduler.updateWindow((prev) =>
+    scheduleCountdown(prev, { now: T0 - 30 * 60_000, dueMs: T0 }),
+  );
+  assert.equal(armed.countdown.dueMs, T0);
+  assert.equal(saved().window.countdown.dueMs, T0);
+
+  const cleared = await scheduler.updateWindow((prev) =>
+    normalizeWindow({ ...normalizeWindow(prev), countdown: null }),
+  );
+  assert.equal(cleared.countdown, null);
+  assert.equal(saved().window.countdown, null);
+
+  // A no-op (null) mutator writes nothing.
+  const noop = await scheduler.updateWindow(() => null);
+  assert.equal(noop, null);
+});
+
+test("foldCounters folds a verdict into the persisted Thompson counters; readCounters reads them back", async () => {
+  const { scheduler, saved } = memoryScheduler();
+  const c1 = await scheduler.foldCounters({ category: "queue-tonight", verdict: "accept" });
+  assert.deepEqual(c1["queue-tonight"], { alpha: 1, beta: 0 });
+  const c2 = await scheduler.foldCounters({ category: "queue-tonight", verdict: "veto" });
+  assert.deepEqual(c2["queue-tonight"], { alpha: 1, beta: 1 });
+  assert.deepEqual(saved().counters["queue-tonight"], { alpha: 1, beta: 1 });
+  const back = await scheduler.readCounters();
+  assert.deepEqual(back["queue-tonight"], { alpha: 1, beta: 1 });
+});
+
+test("closing the window clears the manual pin — the pin governs one window only (§10.4)", async () => {
+  const clock = { ms: T0 + H };
+  const { scheduler, saved } = memoryScheduler({ now: () => clock.ms });
+  // Open on the trough signal.
+  await scheduler.tick(tickInput({ candidates: [candidate()] }));
+  assert.equal(saved().window.state, "open");
+  // Pin an order mid-window.
+  await scheduler.updateWindow((prev) =>
+    normalizeWindow({ ...normalizeWindow(prev), pinnedOrder: ["b", "a"] }),
+  );
+  assert.deepEqual(saved().window.pinnedOrder, ["b", "a"]);
+  // The trough ends → close clears the pin.
+  clock.ms = TROUGH.endMs + 1;
+  await scheduler.tick(tickInput({ candidates: [candidate()] }));
+  assert.equal(saved().window.state, "closed");
+  assert.equal(saved().window.pinnedOrder, null);
+});

--- a/src/server/ctoOvernight.test.mjs
+++ b/src/server/ctoOvernight.test.mjs
@@ -520,3 +520,49 @@ test("closing the window clears the manual pin — the pin governs one window on
   assert.equal(saved().window.state, "closed");
   assert.equal(saved().window.pinnedOrder, null);
 });
+
+// ---------------------------------------------------------------------------
+// §9.2 — the per-trough veto stamp (BET-1419 review fix)
+// ---------------------------------------------------------------------------
+
+test("a per-trough veto stamp blocks the auto-open for that trough; run-now overrides; the next trough is unaffected", () => {
+  // The user canceled: the window row carries vetoedTroughStartMs = TROUGH.startMs.
+  const vetoed = normalizeWindow({ state: "closed", vetoedTroughStartMs: TROUGH.startMs });
+  assert.equal(vetoed.vetoedTroughStartMs, TROUGH.startMs, "normalizeWindow preserves the stamp");
+
+  const refused = evaluateWindow(vetoed, tickInput({ now: T0 + H, lastUserEventMs: T0 - 2 * H }));
+  assert.equal(refused.window.state, "closed", "the machine refuses to auto-open a vetoed trough");
+  assert.equal(refused.ledgerRows.length, 0, "silently closed — no open row, no dispatch");
+
+  // run-now is explicit consent AFTER the cancel — it overrides the stamp,
+  // and the open supersedes it (a fresh window is not a vetoed one).
+  const rn = evaluateWindow(vetoed, tickInput({ now: T0 + H, runNow: true }));
+  assert.equal(rn.window.state, "open");
+  assert.equal(rn.window.vetoedTroughStartMs, null, "an open clears the veto stamp");
+
+  // A different trough (tomorrow) does not inherit the stamp — it expires
+  // naturally with the trough it named.
+  const tomorrow = evaluateWindow(
+    vetoed,
+    tickInput({ now: T0 + 24 * H, trough: { startMs: T0 + 24 * H, endMs: T0 + 30 * H }, lastUserEventMs: T0 + 22 * H }),
+  );
+  assert.equal(tomorrow.window.state, "open", "the stamp never suppresses a later night");
+});
+
+test("a trough-opened window closes when the profile re-derives the trough away from its opening (trough-shift guard)", () => {
+  const { window } = evaluateWindow(null, tickInput({ now: T0 + H }));
+  assert.equal(window.state, "open");
+
+  // The G refit moves the quiet trough forward — it no longer contains
+  // openedMs, which would make the trough-end close unreachable.
+  const shifted = { startMs: T0 + 24 * H, endMs: T0 + 30 * H };
+  const { window: closed, ledgerRows } = evaluateWindow(window, tickInput({ now: T0 + 2 * H, trough: shifted }));
+  assert.equal(closed.state, "closed");
+  assert.equal(closed.closeReason, "trough-end");
+  assert.ok(ledgerRows.some((r) => r.kind === "cto.overnight.close" && r.reason === "trough-end"));
+
+  // run-now windows are exempt — they open outside any trough on explicit
+  // consent and close on the user's return / fresh event, not on re-derivation.
+  const rn = evaluateWindow(null, tickInput({ now: T0 + 2 * H, trough: shifted, runNow: true }));
+  assert.equal(rn.window.state, "open");
+});

--- a/src/server/ctoProfile.mjs
+++ b/src/server/ctoProfile.mjs
@@ -407,10 +407,11 @@ export function quietTroughStartHour({
   centerHour = QUIET_TROUGH_DEFAULT_CENTER_H,
 } = {}) {
   const dom = dominantComponent(components);
-  const peakBoxHour = dom
-    ? ((dom.mu_hour - tzOffset + boxUtcOffsetHours) % 24 + 24) % 24
+  // With learned components the trough is the peak's antipode (peak + 12h);
+  // without them the default center IS the trough center (not a peak).
+  const troughCenter = dom
+    ? (((dom.mu_hour - tzOffset + boxUtcOffsetHours) % 24 + 24) % 24 + 12) % 24
     : centerHour;
-  const troughCenter = (peakBoxHour + 12) % 24;
   return ((troughCenter - QUIET_TROUGH_HOURS / 2) % 24 + 24) % 24;
 }
 

--- a/src/server/ctoProfile.mjs
+++ b/src/server/ctoProfile.mjs
@@ -90,6 +90,14 @@ export const RISING_MARGIN_KAPPAS = 1.5; // rising edge sits margin hours before
 export const RISING_MARGIN_MIN_H = 0.25;
 export const RISING_MARGIN_MAX_H = 2.0;
 
+// BET-1419 (§11.1): the overnight window opens at the start of the profile's
+// quiet trough — the antipode (peak + 12h) of the dominant workday component.
+// A half-window of 3h brackets it, so the learned trough is 6h wide. Until the
+// profile has learned any workday component the default trough is 01:00–07:00
+// box-local (a fixed bootstrap center of 04:00).
+export const QUIET_TROUGH_HOURS = 6;
+export const QUIET_TROUGH_DEFAULT_CENTER_H = 4;
+
 export function clamp01(x) {
   return Math.max(0, Math.min(1, x));
 }
@@ -387,6 +395,46 @@ export function risingEdgeMsIntoDay({
   return Math.round(edgeHour * HOUR_MS);
 }
 
+// BET-1419: the quiet trough in box-local hours-into-day (§11.1). The center
+// is the dominant workday component's antipode (peak + 12h) translated to
+// box-local; with no learned components it falls back to the fixed 04:00
+// bootstrap center. Returns the NON-wrapped start hour (in [0,24)) plus the
+// window width; the ms-window builder picks the next concrete occurrence.
+export function quietTroughStartHour({
+  components = [],
+  tzOffset = 0,
+  boxUtcOffsetHours = 0,
+  centerHour = QUIET_TROUGH_DEFAULT_CENTER_H,
+} = {}) {
+  const dom = dominantComponent(components);
+  const peakBoxHour = dom
+    ? ((dom.mu_hour - tzOffset + boxUtcOffsetHours) % 24 + 24) % 24
+    : centerHour;
+  const troughCenter = (peakBoxHour + 12) % 24;
+  return ((troughCenter - QUIET_TROUGH_HOURS / 2) % 24 + 24) % 24;
+}
+
+// BET-1419: the NEXT concrete quiet-trough occurrence containing `now` if
+// `now` is inside one, else the next one after it. Returns the §11.1
+// {startMs, endMs} the overnight scheduler consumes (end > start always —
+// `troughContains` requires that), or null when the clock is unusable.
+export function quietTroughWindow({ components = [], tzOffset = 0, nowMs, now = () => Date.now() } = {}) {
+  const t = typeof nowMs === "number" && Number.isFinite(nowMs) ? nowMs : now();
+  if (!Number.isFinite(t)) return null;
+  const boxUtcOffsetHours = boxUtcOffsetHoursOf(t);
+  const startHour = quietTroughStartHour({ components, tzOffset, boxUtcOffsetHours });
+  const widthMs = QUIET_TROUGH_HOURS * HOUR_MS;
+  // ms-into-day of the trough start in box-local time.
+  const d = new Date(t);
+  const dayStartMs = new Date(d.getFullYear(), d.getMonth(), d.getDate()).getTime();
+  const startIntoDay = Math.round(startHour * HOUR_MS);
+  // Candidate occurrences: today and tomorrow (one of these always covers
+  // "inside now" or "next"). Pick the latest start whose END is in the future.
+  let startMs = dayStartMs + startIntoDay;
+  if (startMs + widthMs <= t) startMs += 24 * HOUR_MS;
+  return { startMs, endMs: startMs + widthMs };
+}
+
 // Deviation-from-own-baseline: activity far outside the user's typical workday
 // (e.g. a 3am session for a 10–18h user) → {type,text}. Surfaced ONLY as a
 // digest progress-tier aside, never in any shared artifact (§8.4).
@@ -670,6 +718,17 @@ export function createCtoProfile(deps = {}) {
         components: state.temporal.workday.components,
         tzOffset: state.temporal.tz_offset?.value ?? 0,
         boxUtcOffsetHours: boxUtcOffsetHoursOf(now()),
+      });
+    },
+
+    // BET-1419 (§11.1): the next quiet-trough occurrence as {startMs, endMs} —
+    // the overnight window opens here (the antipode of the learned workday
+    // peak; the 01:00–07:00 box-local default until components exist).
+    getQuietTrough() {
+      return quietTroughWindow({
+        components: state.temporal.workday.components,
+        tzOffset: state.temporal.tz_offset?.value ?? 0,
+        nowMs: now(),
       });
     },
 

--- a/src/server/ctoProfile.test.mjs
+++ b/src/server/ctoProfile.test.mjs
@@ -31,6 +31,8 @@ import {
   computeAudience,
   dominantComponent,
   risingEdgeMsIntoDay,
+  quietTroughStartHour,
+  quietTroughWindow,
   offHoursDeviation,
   capDimensions,
   composeProfileRender,
@@ -119,6 +121,49 @@ test("histogramPeaks: dominantWorkdays weights + rising edge", () => {
 
 test("risingEdgeMsIntoDay: no components → null", () => {
   assert.equal(risingEdgeMsIntoDay({ components: [] }), null);
+});
+
+// ---------------------------------------------------------------------------
+// BET-1419 (§11.1): the quiet trough — the overnight window opens here
+// ---------------------------------------------------------------------------
+
+test("quietTroughStartHour: the antipode (peak + 12h) of the dominant component, box-local", () => {
+  // Dominant peak 15h box-local → trough center 03h → 6h window starts at 00h.
+  const startHour = quietTroughStartHour({
+    components: [
+      { mu_hour: 10, kappa: 2, weight: 0.3 },
+      { mu_hour: 15, kappa: 3, weight: 0.7 },
+    ],
+    tzOffset: 0,
+    boxUtcOffsetHours: 0,
+  });
+  assert.ok(close(startHour, 0), `startHour=${startHour}`);
+});
+
+test("quietTroughStartHour: no learned components → the 01:00–07:00 bootstrap default", () => {
+  const startHour = quietTroughStartHour({ components: [], tzOffset: 0, boxUtcOffsetHours: 0 });
+  // Default center 04h → window start 01h.
+  assert.ok(close(startHour, 1), `startHour=${startHour}`);
+});
+
+test("quietTroughWindow: the next concrete occurrence (inside now wins, else tomorrow)", () => {
+  // Fixed epoch: 2023-11-14T12:00:00Z, box = UTC.
+  const NOON = Date.UTC(2023, 10, 14, 12, 0, 0);
+  // Trough 00:00–06:00 box-local (peak antipode from 15h, same tz).
+  const components = [{ mu_hour: 15, kappa: 3, weight: 1 }];
+  // Noon is AFTER today's trough end (06:00) → next occurrence is tomorrow 00:00.
+  const next = quietTroughWindow({ components, tzOffset: 0, nowMs: NOON });
+  assert.equal(next.startMs, Date.UTC(2023, 10, 15, 0, 0, 0));
+  assert.equal(next.endMs, Date.UTC(2023, 10, 15, 6, 0, 0));
+  // Inside the trough → the occurrence CONTAINING now is returned.
+  const inside = quietTroughWindow({ components, tzOffset: 0, nowMs: Date.UTC(2023, 10, 15, 3, 0, 0) });
+  assert.equal(inside.startMs, Date.UTC(2023, 10, 15, 0, 0, 0));
+  // end > start always (troughContains requires it).
+  assert.ok(inside.endMs > inside.startMs);
+  // The 01:00–07:00 default when nothing is learned yet.
+  const fallback = quietTroughWindow({ components: [], tzOffset: 0, nowMs: NOON });
+  assert.equal(fallback.startMs, Date.UTC(2023, 10, 15, 1, 0, 0));
+  assert.equal(fallback.endMs, Date.UTC(2023, 10, 15, 7, 0, 0));
 });
 
 // ---------------------------------------------------------------------------

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -1859,9 +1859,45 @@ const ctoEphemeralReaper = createEphemeralReaper({
 // on the machine's 30-min cadence: the windowed provider with the most
 // session headroom (§11.2 prefers the batch pool), else the windowless path
 // bounded by `ctoNightCapUsd`. With neither (no snapshot, no cap) it returns
-// null → the machine runs its λ=0 fat-budget default. `adaptiveCtoBudget` is
-// declared later in this module; the closure only dereferences it at tick
-// time, mirroring the `adaptiveCtoDigest` lazy-reference pattern above.
+//   null → the machine runs its λ=0 fat-budget default. `adaptiveCtoBudget` is
+//   declared later in this module; the closure only dereferences it at tick
+//   time, mirroring the `adaptiveCtoDigest` lazy-reference pattern above.
+//
+// `nightModelCost` prices the §11.2 windowless bound at the box's default
+// model's catalogue `cost` (the same normalized shape the optimizer's
+// modelRates reader builds from oc.getProviders). Memoized 10 min — the seam
+// runs on the machine's tick cadence and the catalogue rarely changes. null
+// (unreadable catalogue) prices the estimate at $0: the cap cannot trip on an
+// unknown model rather than blocking the night on a pricing outage.
+const nightModelCostCache = { at: 0, cost: null };
+async function nightModelCost() {
+  const t = Date.now();
+  if (t - nightModelCostCache.at < 10 * 60_000) return nightModelCostCache.cost;
+  try {
+    const cfgRow = await local.configGet().catch(() => ({}));
+    const dm = cfgRow?.defaultModel ?? null;
+    const { all } = await oc.getProviders();
+    let cost = null;
+    for (const p of Array.isArray(all) ? all : []) {
+      if (!p || typeof p.id !== "string") continue;
+      if (dm?.providerID && p.id !== dm.providerID) continue;
+      const pModels = p.models && typeof p.models === "object" ? p.models : {};
+      const wanted = dm?.modelID && pModels[dm.modelID] ? dm.modelID : Object.keys(pModels)[0];
+      if (!wanted) continue;
+      const m = oc._normalizeProviderModel(p.id, wanted, pModels[wanted]);
+      if (m?.cost && typeof m.cost === "object") {
+        cost = m.cost;
+        break;
+      }
+      if (dm?.providerID) break; // the configured provider had no priceable model
+    }
+    nightModelCostCache.at = t;
+    nightModelCostCache.cost = cost;
+    return cost;
+  } catch {
+    return nightModelCostCache.cost; // keep the last known price on a blip
+  }
+}
 const adaptiveCtoOvernight = ctoOvernight.createOvernightScheduler({
   now: () => Date.now(),
   ledger: ledgerStore,
@@ -1885,14 +1921,32 @@ const adaptiveCtoOvernight = ctoOvernight.createOvernightScheduler({
         });
       }
       const cfg = await local.configGet().catch(() => ({}));
-      const nightCap = Number(cfg?.ctoNightCapUsd);
-      if (!Number.isFinite(nightCap) || nightCap <= 0) return null;
       const windowless = (Array.isArray(snaps) ? snaps : []).find((s) => s?.windowed === false);
-      return await adaptiveCtoBudget.computeSpendable({
+      // §11.2 absolute $ bound (BET-1419 review fix): tonight's overnight
+      // spend is priced from the ledger's job_started estTokens at the default
+      // model's catalogue cost; computeSpendable flips spendableFrac to 0 once
+      // the cap is exhausted, and the cap-hit is ledgered once per day.
+      const dayStart = new Date();
+      dayStart.setHours(0, 0, 0, 0);
+      const rows = (await ledgerStore.read({ from: dayStart.getTime() }).catch(() => [])) ?? [];
+      const plan = await adaptiveCtoBudget.computeSpendable({
         provider: windowless?.provider ?? "anthropic",
         remainingPct: null,
         windowed: false,
+        overnightRows: rows,
+        overnightModelCost: await nightModelCost(),
       });
+      if (plan?.overnightCapHit && !rows.some((r) => r?.kind === "cto.overnight.night_cap_hit")) {
+        await ledgerStore
+          .append({
+            kind: "cto.overnight.night_cap_hit",
+            ts: Date.now(),
+            spentUsd: plan.overnightSpentUsd,
+            capUsd: plan.nightCapUsd,
+          })
+          .catch(() => {});
+      }
+      return plan;
     } catch {
       return null;
     }

--- a/src/server/index.mjs
+++ b/src/server/index.mjs
@@ -101,7 +101,7 @@ import {
   startCapSweeper,
 } from "./capabilities.mjs";
 import { notifyCapSession } from "./capNotifier.mjs";
-import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset, resolveForgeOwner, loadJobs as loadDelegateJobs } from "./delegate.mjs";
+import { createDelegateEngine, buildPermissionRuleset as delegateBuildPermissionRuleset, resolveForgeOwner, loadJobs as loadDelegateJobs, pauseJob as delegatePauseJob } from "./delegate.mjs";
 import {
   reportProgress,
   readProgressRecord,
@@ -141,6 +141,7 @@ import * as cto from "./cto.mjs";
 import * as ctoEngine from "./ctoEngine.mjs";
 import * as ctoBudget from "./ctoBudget.mjs";
 import { ledgerStore, engineStateStore, budgetStore, segmentsStore, verdictsStore, digestsStore, factsStore } from "./ctoStores.mjs";
+import * as ctoOvernight from "./ctoOvernight.mjs";
 import { computeHealthStats } from "./ctoHealth.mjs";
 import { composeProfileRender } from "./ctoProfile.mjs";
 import { runEphemeral, createEphemeralReaper } from "./ctoSessions.mjs";
@@ -1853,6 +1854,51 @@ const ctoEphemeralReaper = createEphemeralReaper({
   oc: { listSessions: oc.listSessions, deleteSession: oc.deleteSessionRaw },
 });
 
+// BET-1419 overnight scheduler (§11): the window machine + portfolio over
+// overnight.json. The budget seam re-evaluates the overnight pool's spendable
+// on the machine's 30-min cadence: the windowed provider with the most
+// session headroom (§11.2 prefers the batch pool), else the windowless path
+// bounded by `ctoNightCapUsd`. With neither (no snapshot, no cap) it returns
+// null → the machine runs its λ=0 fat-budget default. `adaptiveCtoBudget` is
+// declared later in this module; the closure only dereferences it at tick
+// time, mirroring the `adaptiveCtoDigest` lazy-reference pattern above.
+const adaptiveCtoOvernight = ctoOvernight.createOvernightScheduler({
+  now: () => Date.now(),
+  ledger: ledgerStore,
+  budget: async () => {
+    try {
+      const snaps = listSnapshots() ?? [];
+      let best = null;
+      for (const s of Array.isArray(snaps) ? snaps : []) {
+        if (s?.windowed !== true) continue;
+        const win =
+          (Array.isArray(s.windows) ? s.windows : []).find((w) => w && Number.isFinite(w.pct)) ?? null;
+        if (!win) continue;
+        if (!best || win.pct > best.pct) best = { provider: s.provider, pct: win.pct, kind: win.kind ?? "session" };
+      }
+      if (best) {
+        return await adaptiveCtoBudget.computeSpendable({
+          provider: best.provider,
+          remainingPct: best.pct,
+          windowKind: best.kind,
+          windowed: true,
+        });
+      }
+      const cfg = await local.configGet().catch(() => ({}));
+      const nightCap = Number(cfg?.ctoNightCapUsd);
+      if (!Number.isFinite(nightCap) || nightCap <= 0) return null;
+      const windowless = (Array.isArray(snaps) ? snaps : []).find((s) => s?.windowed === false);
+      return await adaptiveCtoBudget.computeSpendable({
+        provider: windowless?.provider ?? "anthropic",
+        remainingPct: null,
+        windowed: false,
+      });
+    } catch {
+      return null;
+    }
+  },
+});
+
 const adaptiveCto = ctoEngine.createCtoEngine({
   configGet: () => local.configGet(),
   ledger: ledgerStore,
@@ -1862,6 +1908,35 @@ const adaptiveCto = ctoEngine.createCtoEngine({
   summarize: segmentSummarize,
   computeOneLiner: segmentOneLiner,
   reaper: ctoEphemeralReaper,
+  // BET-1419: the overnight scheduler + its delegate seams (§11). The parent
+  // session/directory are resolved by the engine (resolveForgeOwner over
+  // listProjects); this wrapper bakes in the "cto" actor, and the sweep
+  // allowance (window remaining) is passed per-start by the engine.
+  overnight: adaptiveCtoOvernight,
+  startDelegateJob: async ({ name, prompt, parentSessionID, parentDirectory, sweepAllowanceMs } = {}) =>
+    delegateEngine.startJob({
+      prompt,
+      name,
+      parentSessionID,
+      parentDirectory,
+      actor: "cto",
+      sweepAllowanceMs,
+    }),
+  listDelegateJobs: async () => {
+    try {
+      return await loadDelegateJobs();
+    } catch {
+      return [];
+    }
+  },
+  pauseDelegateJob: async (id) => {
+    try {
+      return await delegatePauseJob(id);
+    } catch {
+      return { ok: false, error: "pause failed" };
+    }
+  },
+  listProjects: () => tmux.listProjects(),
   // BET-1383 (A9): fold the digest engine's generation-in-flight into the
   // ctoState dot so the sidebar reflects live digest generation (§5.5). The
   // digest engine is created below, so this reads it lazily through
@@ -2014,8 +2089,13 @@ const adaptiveCtoSuggest = createCtoSuggest({
   cards: adaptiveCto.cards,
   // B3 verdict route shared with the opencode `cto_verdict` tool + the engine.
   recordVerdict: (input) => adaptiveCto.recordVerdict(input),
+  // BET-1419: the overnight queue (BET-1402 core + engine wiring in this
+  // issue) is live — queue-tonight options are now emittable at High tier.
+  // tool-write's capability gate is on too, but the §7.4 tool registry
+  // (P2-later) still feeds an empty write ring below, so a tool-write option
+  // remains data-unreachable until B7 lands (the ring is the real gate).
   getWriteRingTools: async () => [], // §7.4 tool registry (P2-later) — empty → tool-write unreachable
-  capabilities: { queueTonight: false, toolWrite: false }, // tonight-queue (P3) off
+  capabilities: { queueTonight: true, toolWrite: true },
   fireNotify: (args) => push.fireNotify(args),
   // §9.1 sender reliability. Findings here come from the box's OWN engine
   // (digest-detected recurrences, fact anomalies), not an external sender —
@@ -4315,6 +4395,12 @@ const handleRequest = async (req, res) => {
         const subject = body?.subject ?? null;
         const verdict = typeof body?.verdict === "string" ? body.verdict : null;
         const never = body?.never;
+        // BET-1419 (§9.2): a veto verdict on the veto-window subject IS the
+        // cancel-tonight action — pause running CTO jobs + close the window
+        // (or clear the countdown) before the verdict is recorded.
+        if (subject?.type === "veto-window" && verdict === "veto") {
+          await adaptiveCto.tonightCancel().catch(() => {});
+        }
         const result = await adaptiveCto.recordVerdict({
           subject,
           verdict,
@@ -4334,6 +4420,37 @@ const handleRequest = async (req, res) => {
           }
         }
         respondJson(res, result.ok ? 200 : 400, result);
+        return;
+      }
+      respondJson(res, 405, { error: "method not allowed" });
+    } catch (e) {
+      respondJson(res, 500, { error: String(e?.message ?? e) });
+    }
+    return;
+  }
+
+  // ---------- Tonight (BET-1419, §10.4 drill-down + §9.2 veto card) ----------
+  // GET /api/cto/tonight → { tasks, window } — the queue + the window state
+  // machine's current row. POST /api/cto/tonight {action, ...} → the tonight
+  // verbs: add / remove / reorder (pins the order) / cancel / run-now.
+  if (path === "/api/cto/tonight") {
+    try {
+      if (req.method === "GET") {
+        const out = await adaptiveCto.tonightList();
+        respondJson(res, 200, out);
+        return;
+      }
+      if (req.method === "POST") {
+        const body = await readJsonBody(req);
+        const action = typeof body?.action === "string" ? body.action : "";
+        let result;
+        if (action === "add") result = await adaptiveCto.tonightAdd(body?.task);
+        else if (action === "remove") result = await adaptiveCto.tonightRemove(body?.id);
+        else if (action === "reorder") result = await adaptiveCto.tonightReorder(body?.ids);
+        else if (action === "cancel") result = await adaptiveCto.tonightCancel();
+        else if (action === "run-now") result = await adaptiveCto.tonightRunNow();
+        else result = { ok: false, error: "unknown action" };
+        respondJson(res, result?.ok ? 200 : 400, result);
         return;
       }
       respondJson(res, 405, { error: "method not allowed" });

--- a/src/shared/api.ts
+++ b/src/shared/api.ts
@@ -179,6 +179,9 @@ export type CtoState = {
   generationInFlight: boolean;
   // Number of tasks queued for tonight's window — the muted Tonight line.
   tonightCount: number;
+  // The A12 tier dial (§12.1), surfaced so tier-gated surfaces (the Tonight
+  // line shows only at High) hide without an extra read. null when unreadable.
+  tier: string | null;
   // Cold-start backfill (§10.6-4): informational learning-card progress. Not a
   // needs-you item — never counted into the sidebar badge. Optional so older
   // bridges (absent field) still typecheck as idle.
@@ -223,7 +226,39 @@ export type CtoCard = {
     action: { type: string; payload: Record<string, unknown> };
   }[];
   evidence?: string[];
+  // BET-1419 veto cards (§9.2) — present only when variant === "veto": the
+  // open the live countdown points at (the window's planned trough start).
+  dueMs?: number | null;
 };
+
+// BET-1419 tonight queue (§10.4/§11.4): one accepted `queue-tonight` entry.
+export type CtoTonightTask = {
+  id: string;
+  name: string;
+  prompt: string;
+  project: string | null;
+  value: number;
+  confidence: number;
+  predictedCost: number;
+  refs: string[];
+  cls: string;
+  originId: string | null;
+  addedMs: number;
+};
+
+// The overnight window state machine row (BET-1402 §11.1) as surfaced by
+// GET /api/cto/tonight.
+export type CtoTonightWindow = {
+  state: "closed" | "open";
+  openedMs: number | null;
+  closedMs: number | null;
+  closeReason: string | null;
+  openedBy: string | null;
+  openedDuringPresence: boolean;
+  countdown: { dueMs: number; armedMs: number } | null;
+  lastEvaluatedMs: number | null;
+  pinnedOrder: string[] | null;
+} | null;
 
 // A held (silent-logged) suggestion row for the §14.3 silence audit.
 export type CtoHeldRow = {
@@ -1233,6 +1268,28 @@ export interface Api {
     verdict: "accept" | "dismiss";
     never?: boolean;
   }): Promise<{ ok: boolean; error?: string }>;
+  // GET /api/cto/tonight — BET-1419 (§10.4/§11.4): tonight's queue + the
+  // window state machine's current row, for the Tonight drill-down.
+  ctoTonightGet(): Promise<{ tasks: CtoTonightTask[]; window: CtoTonightWindow }>;
+  // POST /api/cto/tonight — the tonight verbs: add (the queue-tonight option
+  // executor), remove, reorder (PINS the order for this window), cancel
+  // (Cancel tonight — veto verdict), run-now ("run now instead" override).
+  ctoTonightAct(input: {
+    action: "add" | "remove" | "reorder" | "cancel" | "run-now";
+    task?: {
+      name: string;
+      prompt?: string;
+      project?: string | null;
+      value?: number;
+      confidence?: number;
+      predictedCost?: number;
+      refs?: string[];
+      cls?: string;
+      originId?: string | null;
+    };
+    id?: string;
+    ids?: string[];
+  }): Promise<{ ok: boolean; error?: string; task?: CtoTonightTask; pinned?: string[] }>;
 }
 
 /**

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -313,11 +313,11 @@ export type AppConfig = {
   ctoDigestPush?: boolean;
   // Adaptive CTO (BET-1405): the §11 Overnight-work switch — gates the entire
   // overnight pool; only visible/effective at High (§10.5 card 1). Default off.
-  // NOTE: the Behavior-card control ships with the §11 overnight wiring
-  // (BET-1419); the config key + the Tonight's-budget card's read of it land
-  // here first so both runs converge on the same key.
   ctoOvernight?: boolean;
-  // Adaptive CTO (BET-1400): the windowless/night $ pool (§11.2). Default 5.
+  // Adaptive CTO (BET-1419, §11.2): absolute overnight budget in $ for
+  // windowless providers (no usage-window adapter). Default $5/night (the
+  // budget module's DEFAULT_NIGHT_CAP_USD); once tonight's estimated
+  // overnight spend reaches it, no further overnight jobs are selected.
   ctoNightCapUsd?: number;
   // ----- Manta Optimizer (BET-1342 / Phase 2) -----
   // Master switch for the optimizer. DEFAULT FALSE. Opt-in: with it OFF the


### PR DESCRIPTION
## BET-1419 — Overnight wiring: veto card + tonight UI + engine wiring + data gates

Unblocked by BET-1402 (PR #1407, merged). Implements the §11 runtime: the pure overnight machine (BET-1402) now runs.

**Base: origin/main @ `887d370c`**

### What shipped

1. **Engine wiring** (`src/server/ctoEngine.mjs`) — the engine tick feeds the §11 machine (quiet trough from the profile, presence, desktop heartbeat, last user event, run-now consent, candidates) and dispatches the selected plan through injected delegate seams: actor `cto`, `sweepAllowanceMs` = window remaining, the §3.3 concurrent sub-cap (2) enforced by the existing `beginDelegateJob` gate. **§11.6 preemption on the user's return** fires immediately from the event path (user prompt → pause all running `actor:"cto"` jobs + close the window), not on the next tick. Candidate sources this issue wires: the tonight queue (accepted `queue-tonight` options) + watcher hits from the ledger; the machine's own dedupe skips candidates already started this window (ledger `job_started` rows).

2. **Quiet trough** (`src/server/ctoProfile.mjs`) — §11.1 "opens at the start of the profile's quiet trough": the antipode (dominant workday peak + 12h), a 6h window, next concrete occurrence; 01:00–07:00 box-local bootstrap until components are learned.

3. **Veto card** (`src/server/ctoCards.mjs` + renderer) — `upsertVeto` (variant `veto`, `dueMs`), armed 30 min before the trough's start, one open at a time, re-arm updates in place. Actions: **Cancel tonight** (a `veto` verdict on the `veto-window` subject — the server route performs the cancel: pause jobs + close/clear, and the window row keeps `closeReason:"veto"` so the same night is not re-announced), **Edit plan** (opens the Tonight drill-down), **Run now instead** (one-shot override consumed by the next tick; zero candidates still opens nothing). Elapsed-unmet countdowns are abandoned + ledgered by the machine (§11.6).

4. **Tonight UI** (`CtoPanel.tsx` + `ctoSections.tsx`) — muted "🌙 N tasks queued for tonight (window)" line directly below the digest, hidden when zero or tier < High (tier now rides `ctoState`). Opt-in drill-down: task list (name + category chip), per-task remove + ↑↓ reorder — a manual reorder **pins the order for that window** (exempt from re-scoring; cleared again on close), every edit records an `edit` verdict, **Cancel tonight**, and the "budget & forecast in ⚙" pointer.

5. **Data gates** (`src/server/index.mjs`) — `capabilities: { queueTonight: true, toolWrite: true }`: no generator change was needed (all five option types already emit; only the gates suppressed these two). `queue-tonight` is now fully emittable at High tier and runnable (executor queues the task with the card's context captured at accept). `tool-write` stays **data-unreachable**: the §7.4 tool registry is B7, `getWriteRingTools` still returns `[]`, and the renderer keeps it non-runnable so no dead control can render. Follow-up filed: **BET-1420**.

6. **Config** — Behavior card gains the **Overnight switch** (visible only at High tier; gates §11 entirely: no window, no veto card, no overnight jobs) and the **overnight cap** input (`ctoNightCapUsd`) for windowless providers; the scheduler's budget seam consumes it via `computeSpendable`'s windowless path. The windowed path picks the windowed provider snapshot with the most session headroom (§11.2 batch-pool preference). New routes: `GET/POST /api/cto/tonight` (list / add / remove / reorder / cancel / run-now); the veto cancel rides the existing verdict route.

### Verification results

**Files changed:** 17 files, +1919/−13.

- PR branch (`multica/BET-1419-overnight-wiring` @ `2564f926`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3843 pass / 0 fail / 7 skip. Failures: none. log sha256: `5a8e2e6d90296d4a7f7aa4534b4f91b19779fc14bdb045813d0f68b310b1c437`
- Base (`main` @ `887d370c`):
  - typecheck: exit 0. Errors: none. log sha256: `84317a7d765e8fce9be06db1e3e63c5aa66f60d129053f6747de534b58fee709`
  - test: exit 0, 3838 pass / 0 fail / 7 skip. Failures: none. log sha256: `f17fcd72fd7ffc2ffd7c944a30958524675fb6c0124085b6dc0f4e5e0c90ff0d`
- **Conclusion:** 0 test failures on either branch; nothing pre-existing, nothing new. The PR adds 24 net new tests (engine wiring 9, scheduler mutators 4, quiet trough 3, veto card 3, renderer 5).

Logs cached at `/tmp/typecheck-pr.log`, `/tmp/typecheck-main.log`, `/tmp/test-pr.log`, `/tmp/test-main.log` for reviewer spot-check.

### Self-check

- CRITERION 1: tick feeds the overnight machine + dispatches via delegate seams with actor cto / sweepAllowance / sub-cap 2 → 9/10 — tested end-to-end with injected seams; the budget seam's windowless selection is index.mjs wiring (not unit-covered, consistent with the file).
- CRITERION 2: preempt on return pauses cto jobs + closes the window (§11.6) → 9/10 — immediate path via the event consumer + the tick's own close; both tested.
- CRITERION 3: veto card — 30-min arm, live countdown, Cancel/Edit/Run-now, elapse semantics → 9/10 — arm/cancel/fulfill tested; a veto persists for the night (re-arm suppressed, tested).
- CRITERION 4: Tonight UI — one-line, drill-down, remove/reorder with pin + verdicts, Cancel tonight, ⚙ pointer → 8/10 — server semantics fully tested; the section components are covered indirectly (existing section-test pattern has no DOM mount harness).
- CRITERION 5: data gates flipped (queue-tonight emittable + runnable; tool-write capability on, ring-gated) → 9/10 — generator unchanged (verified: options emit through the same path, gates only suppressed).
- CRITERION 6: Overnight switch (High-only) + ctoNightCapUsd input + new endpoints wired → 9/10.
- CRITERION 7: every actionable follow-up filed → 9/10 — BET-1420 (tool-write executor + ring feed when B7 lands), parked unassigned.

All ≥ 8 → submit.

### Notes

- `evaluateWindow`'s close transitions now clear `pinnedOrder` (the pin governs one window only, §10.4) — a small extension to the BET-1402 machine required by the pin semantics arriving in this issue.
- Overnight dispatch removes a queue entry when its job starts; a skipped start (no tracked project session) is ledgered and the entry stays queued.
- Tests run hermetically (injected stores/seams); no live box state touched.
